### PR TITLE
chore: bootstrap gitmoot go project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Gitmoot
+
+Gitmoot is a local-first multi-agent orchestration tool for GitHub pull request
+workflows. It coordinates persistent AI agent sessions running on a user's
+machine and uses GitHub PRs as the public audit trail.
+
+V1 is intentionally local-only:
+
+```text
+GitHub PR comments/state
+  -> local gitmoot daemon
+  -> local SQLite state machine and job mailbox
+  -> registered runtime adapter
+  -> Codex, Claude Code, or another agent runtime
+  -> GitHub PR comments, statuses, branches, PRs, and merges
+```
+
+The core primitive is a runtime-neutral Gitmoot agent, not a Codex-specific
+session. Codex and Claude Code are adapters behind the same internal runtime
+contract.
+
+## Planned Commands
+
+```text
+gitmoot init
+gitmoot doctor
+gitmoot daemon start
+gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id>
+gitmoot agent list
+gitmoot status
+gitmoot goal import --file <path>
+gitmoot task run <id>
+```
+
+## Development
+
+```sh
+go test ./...
+go vet ./...
+```

--- a/cmd/gitmoot/main.go
+++ b/cmd/gitmoot/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/jerryfane/gitmoot/internal/cli"
+)
+
+func main() {
+	os.Exit(cli.Run(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jerryfane/gitmoot
+
+go 1.26

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type command struct {
+	name        string
+	summary     string
+	description string
+	run         func(args []string, stdout, stderr io.Writer) int
+}
+
+var rootCommands = []command{
+	{name: "init", summary: "initialize local Gitmoot state", run: notImplemented("init")},
+	{name: "doctor", summary: "check local Gitmoot prerequisites", run: notImplemented("doctor")},
+	{name: "daemon", summary: "run the local PR watcher", run: notImplemented("daemon")},
+	{name: "agent", summary: "manage registered agents", run: notImplemented("agent")},
+	{name: "status", summary: "show local workflow status", run: notImplemented("status")},
+	{name: "goal", summary: "import or inspect goals", run: notImplemented("goal")},
+	{name: "task", summary: "run or inspect tasks", run: notImplemented("task")},
+}
+
+func Run(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
+		printUsage(stdout)
+		return 0
+	}
+
+	name := args[0]
+	for _, cmd := range rootCommands {
+		if cmd.name == name {
+			return cmd.run(args[1:], stdout, stderr)
+		}
+	}
+
+	fmt.Fprintf(stderr, "unknown command %q\n\n", name)
+	printUsage(stderr)
+	return 2
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, "gitmoot coordinates local AI agent sessions through GitHub PRs.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot <command> [flags]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Commands:")
+	for _, cmd := range rootCommands {
+		fmt.Fprintf(w, "  %-8s %s\n", cmd.name, cmd.summary)
+	}
+}
+
+func notImplemented(name string) func(args []string, stdout, stderr io.Writer) int {
+	return func(args []string, stdout, stderr io.Writer) int {
+		if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
+			fmt.Fprintf(stdout, "Usage:\n  gitmoot %s [flags]\n", name)
+			return 0
+		}
+		fmt.Fprintf(stderr, "gitmoot %s is not implemented yet\n", name)
+		if len(args) > 0 {
+			fmt.Fprintf(stderr, "received args: %s\n", strings.Join(args, " "))
+		}
+		return 1
+	}
+}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunPrintsUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	code := Run(nil, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("Run(nil) exit code = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "gitmoot <command>") {
+		t.Fatalf("usage output missing command help:\n%s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunRejectsUnknownCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"nope"}, &stdout, &stderr)
+
+	if code != 2 {
+		t.Fatalf("unknown command exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), `unknown command "nope"`) {
+		t.Fatalf("stderr missing unknown command message:\n%s", stderr.String())
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	DirName    = ".gitmoot"
+	ConfigName = "config.toml"
+	DBName     = "gitmoot.db"
+	LogsDir    = "logs"
+	WorkDir    = "workspaces"
+)
+
+type Paths struct {
+	Home       string
+	ConfigFile string
+	Database   string
+	Logs       string
+	Workspaces string
+}
+
+func DefaultPaths() (Paths, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return Paths{}, err
+	}
+	return PathsForHome(home), nil
+}
+
+func PathsForHome(home string) Paths {
+	root := filepath.Join(home, DirName)
+	return Paths{
+		Home:       root,
+		ConfigFile: filepath.Join(root, ConfigName),
+		Database:   filepath.Join(root, DBName),
+		Logs:       filepath.Join(root, LogsDir),
+		Workspaces: filepath.Join(root, WorkDir),
+	}
+}

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPathsForHome(t *testing.T) {
+	paths := PathsForHome("/tmp/example")
+
+	if paths.ConfigFile != filepath.Join("/tmp/example", ".gitmoot", "config.toml") {
+		t.Fatalf("ConfigFile = %q", paths.ConfigFile)
+	}
+	if paths.Database != filepath.Join("/tmp/example", ".gitmoot", "gitmoot.db") {
+		t.Fatalf("Database = %q", paths.Database)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,0 +1,10 @@
+package daemon
+
+import "context"
+
+type Daemon struct{}
+
+func (Daemon) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1,0 +1,18 @@
+package db
+
+import "context"
+
+type Store interface {
+	Close() error
+	Ping(ctx context.Context) error
+}
+
+type NoopStore struct{}
+
+func (NoopStore) Close() error {
+	return nil
+}
+
+func (NoopStore) Ping(context.Context) error {
+	return nil
+}

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -1,0 +1,37 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Repo struct {
+	Owner string
+	Name  string
+}
+
+func (r Repo) String() string {
+	if r.Owner == "" || r.Name == "" {
+		return ""
+	}
+	return r.Owner + "/" + r.Name
+}
+
+func ParseGitHubRemote(remote string) (Repo, error) {
+	path := strings.TrimSpace(remote)
+	switch {
+	case strings.HasPrefix(path, "https://github.com/"):
+		path = strings.TrimPrefix(path, "https://github.com/")
+	case strings.HasPrefix(path, "git@github.com:"):
+		path = strings.TrimPrefix(path, "git@github.com:")
+	default:
+		return Repo{}, fmt.Errorf("unsupported GitHub remote: %s", remote)
+	}
+
+	path = strings.TrimSuffix(strings.Trim(path, "/"), ".git")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return Repo{}, fmt.Errorf("unsupported GitHub remote: %s", remote)
+	}
+	return Repo{Owner: parts[0], Name: parts[1]}, nil
+}

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -1,0 +1,28 @@
+package git
+
+import "testing"
+
+func TestParseGitHubRemote(t *testing.T) {
+	tests := []struct {
+		name   string
+		remote string
+		want   string
+	}{
+		{name: "https without suffix", remote: "https://github.com/jerryfane/gitmoot", want: "jerryfane/gitmoot"},
+		{name: "https with suffix", remote: "https://github.com/jerryfane/gitmoot.git", want: "jerryfane/gitmoot"},
+		{name: "ssh", remote: "git@github.com:jerryfane/gitmoot.git", want: "jerryfane/gitmoot"},
+		{name: "dotted repo", remote: "https://github.com/jerryfane/foo.bar.git", want: "jerryfane/foo.bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, err := ParseGitHubRemote(tt.remote)
+			if err != nil {
+				t.Fatalf("ParseGitHubRemote returned error: %v", err)
+			}
+			if repo.String() != tt.want {
+				t.Fatalf("repo = %q, want %q", repo.String(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,0 +1,13 @@
+package github
+
+import "context"
+
+type Client interface {
+	Ping(ctx context.Context) error
+}
+
+type NoopClient struct{}
+
+func (NoopClient) Ping(context.Context) error {
+	return nil
+}

--- a/internal/github/prurl.go
+++ b/internal/github/prurl.go
@@ -1,0 +1,42 @@
+package github
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type PullRequestRef struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+func (r PullRequestRef) Repository() string {
+	if r.Owner == "" || r.Repo == "" {
+		return ""
+	}
+	return r.Owner + "/" + r.Repo
+}
+
+func ParsePullRequestURL(raw string) (PullRequestRef, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return PullRequestRef{}, err
+	}
+	if parsed.Host != "github.com" {
+		return PullRequestRef{}, fmt.Errorf("unsupported PR host: %s", parsed.Host)
+	}
+
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 4 || parts[2] != "pull" {
+		return PullRequestRef{}, fmt.Errorf("unsupported PR path: %s", parsed.Path)
+	}
+
+	number, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return PullRequestRef{}, fmt.Errorf("invalid PR number %q: %w", parts[3], err)
+	}
+	return PullRequestRef{Owner: parts[0], Repo: parts[1], Number: number}, nil
+}

--- a/internal/github/prurl_test.go
+++ b/internal/github/prurl_test.go
@@ -1,0 +1,16 @@
+package github
+
+import "testing"
+
+func TestParsePullRequestURL(t *testing.T) {
+	ref, err := ParsePullRequestURL("https://github.com/jerryfane/gitmoot/pull/12")
+	if err != nil {
+		t.Fatalf("ParsePullRequestURL returned error: %v", err)
+	}
+	if ref.Repository() != "jerryfane/gitmoot" {
+		t.Fatalf("repository = %q", ref.Repository())
+	}
+	if ref.Number != 12 {
+		t.Fatalf("number = %d, want 12", ref.Number)
+	}
+}

--- a/internal/jsonutil/json.go
+++ b/internal/jsonutil/json.go
@@ -1,0 +1,17 @@
+package jsonutil
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func Pretty(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/jsonutil/json_test.go
+++ b/internal/jsonutil/json_test.go
@@ -1,0 +1,16 @@
+package jsonutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrettyDoesNotEscapeHTML(t *testing.T) {
+	got, err := Pretty(map[string]string{"comment": "/gitmoot audit <review>"})
+	if err != nil {
+		t.Fatalf("Pretty returned error: %v", err)
+	}
+	if strings.Contains(string(got), "\\u003c") {
+		t.Fatalf("Pretty escaped HTML characters:\n%s", string(got))
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,10 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+)
+
+func New(level slog.Level) *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+}

--- a/internal/pathutil/path.go
+++ b/internal/pathutil/path.go
@@ -1,0 +1,16 @@
+package pathutil
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func CleanExpandHome(path, home string) string {
+	if path == "~" {
+		return home
+	}
+	if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	}
+	return filepath.Clean(path)
+}

--- a/internal/pathutil/path_test.go
+++ b/internal/pathutil/path_test.go
@@ -1,0 +1,11 @@
+package pathutil
+
+import "testing"
+
+func TestCleanExpandHome(t *testing.T) {
+	got := CleanExpandHome("~/repo/../gitmoot", "/Users/example")
+	want := "/Users/example/gitmoot"
+	if got != want {
+		t.Fatalf("CleanExpandHome = %q, want %q", got, want)
+	}
+}

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -1,0 +1,10 @@
+package prompts
+
+type JobPrompt struct {
+	Repo        string
+	Branch      string
+	PullRequest int
+	Task        string
+	Action      string
+	Constraints []string
+}

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -1,0 +1,35 @@
+package runtime
+
+import "context"
+
+type Agent struct {
+	Name         string
+	Role         string
+	Runtime      string
+	RuntimeRef   string
+	RepoScope    string
+	Capabilities []string
+}
+
+type Job struct {
+	ID          string
+	AgentName   string
+	Action      string
+	Prompt      string
+	Repository  string
+	PullRequest int
+}
+
+type Result struct {
+	Decision string
+	Summary  string
+	Raw      string
+}
+
+type Adapter interface {
+	Name() string
+	Validate(ctx context.Context, agent Agent) error
+	Deliver(ctx context.Context, agent Agent, job Job) (Result, error)
+	Health(ctx context.Context, agent Agent) error
+	Capabilities(ctx context.Context) ([]string, error)
+}

--- a/internal/subprocess/runner.go
+++ b/internal/subprocess/runner.go
@@ -1,0 +1,31 @@
+package subprocess
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+)
+
+type Result struct {
+	Command string
+	Args    []string
+	Stdout  string
+	Stderr  string
+}
+
+func Run(ctx context.Context, dir string, command string, args ...string) (Result, error) {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Dir = dir
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	return Result{
+		Command: command,
+		Args:    args,
+		Stdout:  stdout.String(),
+		Stderr:  stderr.String(),
+	}, err
+}

--- a/internal/subprocess/runner_test.go
+++ b/internal/subprocess/runner_test.go
@@ -1,0 +1,22 @@
+package subprocess
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunCapturesStdout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command differs on windows")
+	}
+
+	result, err := Run(context.Background(), "", "sh", "-c", "printf gitmoot")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if strings.TrimSpace(result.Stdout) != "gitmoot" {
+		t.Fatalf("stdout = %q", result.Stdout)
+	}
+}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -1,0 +1,14 @@
+package workflow
+
+type TaskState string
+
+const (
+	TaskPlanned TaskState = "planned"
+)
+
+type Task struct {
+	ID     string
+	Title  string
+	State  TaskState
+	Branch string
+}


### PR DESCRIPTION
WHAT: Bootstrapped the Gitmoot Go project structure for the local-first multi-agent PR orchestrator.

WHY: Task 1 requires a clean, testable foundation before implementing config, storage, GitHub integration, runtime adapters, and the daemon.

CHANGES:
- Added a Go module and `cmd/gitmoot` binary entrypoint.
- Added the initial CLI command tree with planned Gitmoot commands.
- Added internal package boundaries for config, DB, daemon, Git, GitHub, JSON helpers, logging, path helpers, prompts, runtime adapters, subprocess execution, and workflow types.
- Added reusable helpers for subprocess execution, JSON formatting, path expansion, GitHub remote parsing, and PR URL parsing.
- Added baseline tests and README documentation for the local-only V1 architecture.
- Fixed the initial review finding by supporting dotted GitHub repository names in remote parsing.

RESULTS:
- `go test ./...` passed.
- `go vet ./...` passed.
- `gofmt` check passed.
- `git diff --cached --check` passed before commit.
- `codex exec review --uncommitted` passed after one review-fix loop.

Raw final `codex exec review --uncommitted` output:

```text
The bootstrap changes compile and the included tests pass. I did not find any discrete correctness, security, performance, or maintainability issue that should block this patch.
The bootstrap changes compile and the included tests pass. I did not find any discrete correctness, security, performance, or maintainability issue that should block this patch.
```

RISK:
- No CI is configured yet, so validation is local-only for this task.
- CLI subcommands are intentionally placeholders in Task 1; implementation begins in later tasks.
