### PR TITLE
feat: add github client integration

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,13 +1,501 @@
 package github
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
 
 type Client interface {
 	Ping(ctx context.Context) error
+	ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error)
+	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
+	ListIssueComments(ctx context.Context, repo Repository, issueNumber int64) ([]IssueComment, error)
+	PostIssueComment(ctx context.Context, repo Repository, issueNumber int64, body string) (IssueComment, error)
+	MergePullRequest(ctx context.Context, input MergePullRequestInput) (MergeResult, error)
+	GetCombinedStatus(ctx context.Context, repo Repository, ref string) (CombinedStatus, error)
+	ListPullRequestChecks(ctx context.Context, repo Repository, number int64) ([]PullRequestCheck, error)
+	CreateCommitStatus(ctx context.Context, input CommitStatusInput) (CommitStatus, error)
+	ListPullRequestFiles(ctx context.Context, repo Repository, number int64) ([]PullRequestFile, error)
+	ListPullRequestCommits(ctx context.Context, repo Repository, number int64) ([]PullRequestCommit, error)
+}
+
+type Repository struct {
+	Owner string
+	Name  string
+}
+
+func (r Repository) FullName() string {
+	if r.Owner == "" || r.Name == "" {
+		return ""
+	}
+	return r.Owner + "/" + r.Name
+}
+
+type PullRequest struct {
+	Number    int64  `json:"number"`
+	Title     string `json:"title"`
+	State     string `json:"state"`
+	URL       string `json:"html_url"`
+	HeadRef   string
+	BaseRef   string
+	HeadSHA   string
+	Mergeable *bool `json:"mergeable"`
+}
+
+func (p *PullRequest) UnmarshalJSON(data []byte) error {
+	type wire struct {
+		Number    int64  `json:"number"`
+		Title     string `json:"title"`
+		State     string `json:"state"`
+		URL       string `json:"html_url"`
+		Mergeable *bool  `json:"mergeable"`
+		Head      struct {
+			Ref string `json:"ref"`
+			SHA string `json:"sha"`
+		} `json:"head"`
+		Base struct {
+			Ref string `json:"ref"`
+		} `json:"base"`
+	}
+	var decoded wire
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	p.Number = decoded.Number
+	p.Title = decoded.Title
+	p.State = decoded.State
+	p.URL = decoded.URL
+	p.Mergeable = decoded.Mergeable
+	p.HeadRef = decoded.Head.Ref
+	p.HeadSHA = decoded.Head.SHA
+	p.BaseRef = decoded.Base.Ref
+	return nil
+}
+
+type IssueComment struct {
+	ID        int64  `json:"id"`
+	Body      string `json:"body"`
+	URL       string `json:"html_url"`
+	Author    string
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+func (c *IssueComment) UnmarshalJSON(data []byte) error {
+	type wire struct {
+		ID        int64  `json:"id"`
+		Body      string `json:"body"`
+		URL       string `json:"html_url"`
+		CreatedAt string `json:"created_at"`
+		UpdatedAt string `json:"updated_at"`
+		User      struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	var decoded wire
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	c.ID = decoded.ID
+	c.Body = decoded.Body
+	c.URL = decoded.URL
+	c.Author = decoded.User.Login
+	c.CreatedAt = decoded.CreatedAt
+	c.UpdatedAt = decoded.UpdatedAt
+	return nil
+}
+
+type CreatePullRequestInput struct {
+	Repo  Repository
+	Title string
+	Body  string
+	Head  string
+	Base  string
+	Draft bool
+}
+
+type MergePullRequestInput struct {
+	Repo            Repository
+	Number          int64
+	Method          string
+	Subject         string
+	Body            string
+	MatchHeadCommit string
+	DeleteBranch    bool
+}
+
+type MergeResult struct {
+	SHA     string `json:"sha"`
+	Merged  bool   `json:"merged"`
+	Message string `json:"message"`
+}
+
+type CombinedStatus struct {
+	State    string         `json:"state"`
+	Statuses []CommitStatus `json:"statuses"`
+}
+
+type CommitStatusInput struct {
+	Repo        Repository
+	SHA         string
+	State       string
+	Context     string
+	Description string
+	TargetURL   string
+}
+
+type CommitStatus struct {
+	ID          int64  `json:"id"`
+	State       string `json:"state"`
+	Context     string `json:"context"`
+	Description string `json:"description"`
+	TargetURL   string `json:"target_url"`
+	URL         string `json:"url"`
+}
+
+type PullRequestCheck struct {
+	Name        string `json:"name"`
+	State       string `json:"state"`
+	Bucket      string `json:"bucket"`
+	Link        string `json:"link"`
+	Workflow    string `json:"workflow"`
+	CompletedAt string `json:"completedAt"`
+}
+
+type PullRequestFile struct {
+	Filename string `json:"filename"`
+	Status   string `json:"status"`
+	SHA      string `json:"sha"`
+	Patch    string `json:"patch"`
+}
+
+type PullRequestCommit struct {
+	SHA string `json:"sha"`
+}
+
+type GhClient struct {
+	Runner     subprocess.Runner
+	Dir        string
+	Sleep      func(context.Context, time.Duration) error
+	MaxRetries int
+
+	mutateMu sync.Mutex
+}
+
+func NewClient(dir string) *GhClient {
+	return &GhClient{Dir: dir}
+}
+
+func (c *GhClient) Ping(ctx context.Context) error {
+	_, err := c.run(ctx, false, "repo", "view", "--json", "nameWithOwner")
+	return err
+}
+
+func (c *GhClient) ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error) {
+	if state == "" {
+		state = "open"
+	}
+	return apiPaginatedJSON[PullRequest](ctx, c, "-X", "GET", endpoint(repo, "pulls"), "-f", "state="+state)
+}
+
+func (c *GhClient) CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error) {
+	args := []string{"pr", "create", "--repo", input.Repo.FullName(), "--title", input.Title, "--body", input.Body, "--head", input.Head, "--base", input.Base}
+	if input.Draft {
+		args = append(args, "--draft")
+	}
+	result, err := c.run(ctx, true, args...)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	ref, err := ParsePullRequestURL(firstLine(result.Stdout))
+	if err != nil {
+		return PullRequest{}, err
+	}
+	pr, err := c.getPullRequest(ctx, input.Repo, int64(ref.Number))
+	if err != nil {
+		return PullRequest{}, err
+	}
+	return pr, nil
+}
+
+func (c *GhClient) ListIssueComments(ctx context.Context, repo Repository, issueNumber int64) ([]IssueComment, error) {
+	comments, err := apiPaginatedJSON[IssueComment](ctx, c, endpoint(repo, "issues", issueNumber, "comments"))
+	return dedupeComments(comments), err
+}
+
+func (c *GhClient) PostIssueComment(ctx context.Context, repo Repository, issueNumber int64, body string) (IssueComment, error) {
+	var comment IssueComment
+	err := c.apiJSON(ctx, true, &comment, endpoint(repo, "issues", issueNumber, "comments"), "-f", "body="+body)
+	return comment, err
+}
+
+func (c *GhClient) MergePullRequest(ctx context.Context, input MergePullRequestInput) (MergeResult, error) {
+	method := input.Method
+	if method == "" {
+		method = "squash"
+	}
+	args := []string{"pr", "merge", strconv.FormatInt(input.Number, 10), "--repo", input.Repo.FullName()}
+	switch method {
+	case "merge":
+		args = append(args, "--merge")
+	case "rebase":
+		args = append(args, "--rebase")
+	case "squash":
+		args = append(args, "--squash")
+	default:
+		return MergeResult{}, fmt.Errorf("unsupported merge method: %s", method)
+	}
+	if input.Subject != "" {
+		args = append(args, "--subject", input.Subject)
+	}
+	if input.Body != "" {
+		args = append(args, "--body", input.Body)
+	}
+	if input.MatchHeadCommit != "" {
+		args = append(args, "--match-head-commit", input.MatchHeadCommit)
+	}
+	if input.DeleteBranch {
+		args = append(args, "--delete-branch")
+	}
+	if _, err := c.run(ctx, true, args...); err != nil {
+		return MergeResult{}, err
+	}
+	return MergeResult{Merged: true}, nil
+}
+
+func (c *GhClient) GetCombinedStatus(ctx context.Context, repo Repository, ref string) (CombinedStatus, error) {
+	var status CombinedStatus
+	err := c.apiJSON(ctx, false, &status, endpoint(repo, "commits", ref, "status"))
+	return status, err
+}
+
+func (c *GhClient) ListPullRequestChecks(ctx context.Context, repo Repository, number int64) ([]PullRequestCheck, error) {
+	result, err := c.run(ctx, false,
+		"pr", "checks", strconv.FormatInt(number, 10),
+		"--repo", repo.FullName(),
+		"--json", "name,state,bucket,link,workflow,completedAt",
+	)
+	if err != nil && strings.TrimSpace(result.Stdout) == "" {
+		if isNoChecks(result) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var checks []PullRequestCheck
+	if decodeErr := json.Unmarshal([]byte(result.Stdout), &checks); decodeErr != nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("decode gh pr checks response: %w", decodeErr)
+	}
+	return checks, nil
+}
+
+func (c *GhClient) CreateCommitStatus(ctx context.Context, input CommitStatusInput) (CommitStatus, error) {
+	var status CommitStatus
+	args := []string{
+		endpoint(input.Repo, "statuses", input.SHA),
+		"-f", "state=" + input.State,
+		"-f", "context=" + input.Context,
+	}
+	if input.Description != "" {
+		args = append(args, "-f", "description="+input.Description)
+	}
+	if input.TargetURL != "" {
+		args = append(args, "-f", "target_url="+input.TargetURL)
+	}
+	err := c.apiJSON(ctx, true, &status, args...)
+	return status, err
+}
+
+func (c *GhClient) ListPullRequestFiles(ctx context.Context, repo Repository, number int64) ([]PullRequestFile, error) {
+	return apiPaginatedJSON[PullRequestFile](ctx, c, endpoint(repo, "pulls", number, "files"))
+}
+
+func (c *GhClient) ListPullRequestCommits(ctx context.Context, repo Repository, number int64) ([]PullRequestCommit, error) {
+	return apiPaginatedJSON[PullRequestCommit](ctx, c, endpoint(repo, "pulls", number, "commits"))
+}
+
+func (c *GhClient) getPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error) {
+	var pr PullRequest
+	err := c.apiJSON(ctx, false, &pr, endpoint(repo, "pulls", number))
+	return pr, err
+}
+
+func (c *GhClient) apiJSON(ctx context.Context, mutate bool, output any, args ...string) error {
+	result, err := c.run(ctx, mutate, append([]string{"api"}, args...)...)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), output); err != nil {
+		return fmt.Errorf("decode gh api response: %w", err)
+	}
+	return nil
+}
+
+func apiPaginatedJSON[T any](ctx context.Context, c *GhClient, args ...string) ([]T, error) {
+	result, err := c.run(ctx, false, append([]string{"api", "--paginate", "--slurp"}, args...)...)
+	if err != nil {
+		return nil, err
+	}
+	var pages [][]T
+	if err := json.Unmarshal([]byte(result.Stdout), &pages); err != nil {
+		return nil, fmt.Errorf("decode paginated gh api response: %w", err)
+	}
+	var values []T
+	for _, page := range pages {
+		values = append(values, page...)
+	}
+	return values, nil
+}
+
+func (c *GhClient) run(ctx context.Context, mutate bool, args ...string) (subprocess.Result, error) {
+	if mutate {
+		c.mutateMu.Lock()
+		defer c.mutateMu.Unlock()
+	}
+
+	runner := c.Runner
+	if runner == nil {
+		runner = subprocess.ExecRunner{}
+	}
+	retries := c.MaxRetries
+	if retries == 0 {
+		retries = 2
+	}
+	var result subprocess.Result
+	var err error
+	for attempt := 0; attempt <= retries; attempt++ {
+		result, err = runner.Run(ctx, c.Dir, "gh", args...)
+		if err == nil || !isRateLimit(result) || attempt == retries {
+			break
+		}
+		if sleepErr := c.sleep(ctx, time.Duration(attempt+1)*time.Second); sleepErr != nil {
+			return result, sleepErr
+		}
+	}
+	if err != nil {
+		return result, commandError(result, err)
+	}
+	return result, nil
+}
+
+func (c *GhClient) sleep(ctx context.Context, d time.Duration) error {
+	if c.Sleep != nil {
+		return c.Sleep(ctx, d)
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func commandError(result subprocess.Result, err error) error {
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	if detail == "" {
+		return err
+	}
+	return fmt.Errorf("%s: %w", detail, err)
+}
+
+func isRateLimit(result subprocess.Result) bool {
+	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	return strings.Contains(text, "rate limit") || strings.Contains(text, "retry-after") || strings.Contains(text, "http 429")
+}
+
+func isNoChecks(result subprocess.Result) bool {
+	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	return strings.Contains(text, "no checks reported")
+}
+
+func endpoint(repo Repository, parts ...any) string {
+	values := []string{"repos", repo.Owner, repo.Name}
+	for _, part := range parts {
+		values = append(values, fmt.Sprint(part))
+	}
+	return strings.Join(values, "/")
+}
+
+func dedupeComments(comments []IssueComment) []IssueComment {
+	seen := make(map[int64]struct{}, len(comments))
+	unique := make([]IssueComment, 0, len(comments))
+	for _, comment := range comments {
+		if _, ok := seen[comment.ID]; ok {
+			continue
+		}
+		seen[comment.ID] = struct{}{}
+		unique = append(unique, comment)
+	}
+	return unique
+}
+
+func firstLine(value string) string {
+	for _, line := range strings.Split(value, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
 }
 
 type NoopClient struct{}
 
 func (NoopClient) Ping(context.Context) error {
 	return nil
+}
+
+func (NoopClient) ListPullRequests(context.Context, Repository, string) ([]PullRequest, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (NoopClient) CreatePullRequest(context.Context, CreatePullRequestInput) (PullRequest, error) {
+	return PullRequest{}, errors.ErrUnsupported
+}
+
+func (NoopClient) ListIssueComments(context.Context, Repository, int64) ([]IssueComment, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (NoopClient) PostIssueComment(context.Context, Repository, int64, string) (IssueComment, error) {
+	return IssueComment{}, errors.ErrUnsupported
+}
+
+func (NoopClient) MergePullRequest(context.Context, MergePullRequestInput) (MergeResult, error) {
+	return MergeResult{}, errors.ErrUnsupported
+}
+
+func (NoopClient) GetCombinedStatus(context.Context, Repository, string) (CombinedStatus, error) {
+	return CombinedStatus{}, errors.ErrUnsupported
+}
+
+func (NoopClient) ListPullRequestChecks(context.Context, Repository, int64) ([]PullRequestCheck, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (NoopClient) CreateCommitStatus(context.Context, CommitStatusInput) (CommitStatus, error) {
+	return CommitStatus{}, errors.ErrUnsupported
+}
+
+func (NoopClient) ListPullRequestFiles(context.Context, Repository, int64) ([]PullRequestFile, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (NoopClient) ListPullRequestCommits(context.Context, Repository, int64) ([]PullRequestCommit, error) {
+	return nil, errors.ErrUnsupported
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,304 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+func TestListIssueCommentsDedupesByID(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `[
+				[
+					{"id": 11, "body": "first", "html_url": "https://example.com/1", "user": {"login": "alice"}},
+					{"id": 11, "body": "duplicate", "html_url": "https://example.com/1", "user": {"login": "alice"}}
+				],
+				[
+					{"id": 12, "body": "second", "html_url": "https://example.com/2", "user": {"login": "bob"}}
+				]
+			]`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	comments, err := client.ListIssueComments(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, 2)
+
+	if err != nil {
+		t.Fatalf("ListIssueComments returned error: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("comments length = %d, want 2", len(comments))
+	}
+	if comments[0].Body != "first" || comments[1].Author != "bob" {
+		t.Fatalf("comments were not decoded in first-seen order: %+v", comments)
+	}
+	runner.wantArgs(t, 0, "api", "--paginate", "--slurp", "repos/jerryfane/gitmoot/issues/2/comments")
+}
+
+func TestPostIssueCommentUsesIssueCommentsEndpoint(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"id": 21, "body": "done", "html_url": "https://github.com/jerryfane/gitmoot/pull/2#issuecomment-21", "user": {"login": "gitmoot"}}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	comment, err := client.PostIssueComment(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, 2, "done")
+
+	if err != nil {
+		t.Fatalf("PostIssueComment returned error: %v", err)
+	}
+	if comment.ID != 21 || comment.Body != "done" {
+		t.Fatalf("comment = %+v", comment)
+	}
+	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/issues/2/comments", "-f", "body=done")
+}
+
+func TestCreateCommitStatusUsesStatusesEndpoint(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"id": 31, "state": "success", "context": "gitmoot/task", "description": "ok", "target_url": "https://example.com"}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	status, err := client.CreateCommitStatus(context.Background(), CommitStatusInput{
+		Repo:        Repository{Owner: "jerryfane", Name: "gitmoot"},
+		SHA:         "abc123",
+		State:       "success",
+		Context:     "gitmoot/task",
+		Description: "ok",
+		TargetURL:   "https://example.com",
+	})
+
+	if err != nil {
+		t.Fatalf("CreateCommitStatus returned error: %v", err)
+	}
+	if status.ID != 31 || status.State != "success" {
+		t.Fatalf("status = %+v", status)
+	}
+	runner.wantArgs(t, 0,
+		"api",
+		"repos/jerryfane/gitmoot/statuses/abc123",
+		"-f", "state=success",
+		"-f", "context=gitmoot/task",
+		"-f", "description=ok",
+		"-f", "target_url=https://example.com",
+	)
+}
+
+func TestListPullRequestChecksUsesGhChecksOutput(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `[
+				{"name": "test", "state": "SUCCESS", "bucket": "pass", "link": "https://example.com/check", "workflow": "ci"},
+				{"name": "lint", "state": "PENDING", "bucket": "pending", "workflow": "ci"}
+			]`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	checks, err := client.ListPullRequestChecks(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, 2)
+
+	if err != nil {
+		t.Fatalf("ListPullRequestChecks returned error: %v", err)
+	}
+	if len(checks) != 2 || checks[0].Bucket != "pass" || checks[1].Bucket != "pending" {
+		t.Fatalf("checks = %+v", checks)
+	}
+	runner.wantArgs(t, 0,
+		"pr", "checks", "2",
+		"--repo", "jerryfane/gitmoot",
+		"--json", "name,state,bucket,link,workflow,completedAt",
+	)
+}
+
+func TestListPullRequestChecksAcceptsPendingExitWithJSON(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `[{"name": "test", "state": "PENDING", "bucket": "pending"}]`,
+		}},
+		errs: []error{errors.New("exit status 8")},
+	}
+	client := GhClient{Runner: runner}
+
+	checks, err := client.ListPullRequestChecks(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, 2)
+
+	if err != nil {
+		t.Fatalf("ListPullRequestChecks returned error: %v", err)
+	}
+	if len(checks) != 1 || checks[0].Bucket != "pending" {
+		t.Fatalf("checks = %+v", checks)
+	}
+}
+
+func TestListPullRequestChecksTreatsNoChecksAsEmpty(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stderr: "no checks reported on the 'task' branch",
+		}},
+		errs: []error{errors.New("exit status 1")},
+	}
+	client := GhClient{Runner: runner}
+
+	checks, err := client.ListPullRequestChecks(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, 2)
+
+	if err != nil {
+		t.Fatalf("ListPullRequestChecks returned error: %v", err)
+	}
+	if len(checks) != 0 {
+		t.Fatalf("checks = %+v, want empty", checks)
+	}
+}
+
+func TestMergePullRequestUsesSafeHeadMatch(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "merged"}}}
+	client := GhClient{Runner: runner}
+
+	result, err := client.MergePullRequest(context.Background(), MergePullRequestInput{
+		Repo:            Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Number:          2,
+		Method:          "squash",
+		Subject:         "feat: task",
+		MatchHeadCommit: "abc123",
+		DeleteBranch:    true,
+	})
+
+	if err != nil {
+		t.Fatalf("MergePullRequest returned error: %v", err)
+	}
+	if !result.Merged {
+		t.Fatalf("merge result = %+v", result)
+	}
+	runner.wantArgs(t, 0,
+		"pr", "merge", "2",
+		"--repo", "jerryfane/gitmoot",
+		"--squash",
+		"--subject", "feat: task",
+		"--match-head-commit", "abc123",
+		"--delete-branch",
+	)
+}
+
+func TestRateLimitBackoffRetries(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stderr: "HTTP 429: secondary rate limit"},
+			{Stdout: `{"id": 42, "state": "pending", "context": "gitmoot/task"}`},
+		},
+		errs: []error{errors.New("exit 1"), nil},
+	}
+	var sleeps []time.Duration
+	client := GhClient{
+		Runner: runner,
+		Sleep: func(_ context.Context, d time.Duration) error {
+			sleeps = append(sleeps, d)
+			return nil
+		},
+		MaxRetries: 1,
+	}
+
+	status, err := client.CreateCommitStatus(context.Background(), CommitStatusInput{
+		Repo:    Repository{Owner: "jerryfane", Name: "gitmoot"},
+		SHA:     "abc123",
+		State:   "pending",
+		Context: "gitmoot/task",
+	})
+
+	if err != nil {
+		t.Fatalf("CreateCommitStatus returned error: %v", err)
+	}
+	if status.ID != 42 {
+		t.Fatalf("status = %+v", status)
+	}
+	if !reflect.DeepEqual(sleeps, []time.Duration{time.Second}) {
+		t.Fatalf("sleeps = %v, want [1s]", sleeps)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("runner calls = %d, want 2", len(runner.calls))
+	}
+}
+
+func TestCreatePullRequestFetchesCreatedPR(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stdout: "https://github.com/jerryfane/gitmoot/pull/7\n"},
+			{Stdout: `{"number": 7, "title": "Task 7", "state": "open", "html_url": "https://github.com/jerryfane/gitmoot/pull/7", "head": {"ref": "task-7", "sha": "abc123"}, "base": {"ref": "main"}}`},
+		},
+	}
+	client := GhClient{Runner: runner}
+
+	pr, err := client.CreatePullRequest(context.Background(), CreatePullRequestInput{
+		Repo:  Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Title: "Task 7",
+		Body:  "body",
+		Head:  "task-7",
+		Base:  "main",
+	})
+
+	if err != nil {
+		t.Fatalf("CreatePullRequest returned error: %v", err)
+	}
+	if pr.Number != 7 || pr.HeadSHA != "abc123" {
+		t.Fatalf("pr = %+v", pr)
+	}
+	runner.wantArgs(t, 0,
+		"pr", "create",
+		"--repo", "jerryfane/gitmoot",
+		"--title", "Task 7",
+		"--body", "body",
+		"--head", "task-7",
+		"--base", "main",
+	)
+	runner.wantArgs(t, 1, "api", "repos/jerryfane/gitmoot/pulls/7")
+}
+
+type fakeRunner struct {
+	results []subprocess.Result
+	errs    []error
+	calls   [][]string
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	call := append([]string{command}, args...)
+	f.calls = append(f.calls, call)
+	index := len(f.calls) - 1
+	if command != "gh" {
+		return subprocess.Result{}, errors.New("unexpected command: " + command)
+	}
+	result := subprocess.Result{Command: command, Args: args}
+	if index < len(f.results) {
+		result = f.results[index]
+		result.Command = command
+		result.Args = args
+	}
+	var err error
+	if index < len(f.errs) {
+		err = f.errs[index]
+	}
+	return result, err
+}
+
+func (f *fakeRunner) LookPath(file string) (string, error) {
+	if file != "gh" {
+		return "", errors.New("not found")
+	}
+	return "/usr/bin/gh", nil
+}
+
+func (f *fakeRunner) wantArgs(t *testing.T, index int, want ...string) {
+	t.Helper()
+	if index >= len(f.calls) {
+		t.Fatalf("missing call %d; calls=%v", index, f.calls)
+	}
+	got := f.calls[index]
+	if !reflect.DeepEqual(got, append([]string{"gh"}, want...)) {
+		t.Fatalf("call %d = %s\nwant %s", index, strings.Join(got, " "), strings.Join(append([]string{"gh"}, want...), " "))
+	}
+}


### PR DESCRIPTION
WHAT:
- Added the internal GitHub client layer for Gitmoot.

WHY:
- Later daemon, workflow, and merge-gate tasks need one typed integration boundary for GitHub PRs, comments, statuses, checks, files, commits, PR creation, and PR merging.

CHANGES:
- Replaced the placeholder GitHub client with a `GhClient` backed by `gh`/`gh api`.
- Added typed models for repositories, pull requests, issue comments, commit statuses, PR checks, PR files, and PR commits.
- Added list/create/merge/status/check/file/commit methods behind the `Client` interface.
- Added paginated API decoding with `gh api --paginate --slurp` and comment dedupe by GitHub comment id.
- Added serialized mutation execution and basic rate-limit retry/backoff.
- Added `gh pr checks --json` support for GitHub Actions/check-run state without using the GitHub Checks API directly.
- Treated `gh pr checks` no-CI output as an empty check set so merge-gate code can record no CI explicitly later.
- Added fake-runner tests for comment listing/posting, status creation, PR checks, PR merge, rate-limit retry, no-CI handling, and PR creation URL parsing/fetching.

RESULTS:
- Verified GitHub contracts against official GitHub REST docs for issue comments, pull requests, and commit statuses, plus local `gh api --help`, `gh pr merge --help`, and `gh pr checks --help`.
- `go test ./...` passed.
- `go vet ./...` passed.
- `test -z "$(gofmt -l $(rg --files -g '*.go'))"` passed.
- `git diff --cached --check` passed before commit.
- Safe direct GitHub smoke tests passed:
  - `gh api repos/{owner}/{repo}/issues/2/comments --jq 'length'` returned `0`.
  - `gh api repos/{owner}/{repo}/commits/<head>/status --jq '.state'` returned `pending`.
  - `gh api --paginate --slurp -X GET repos/{owner}/{repo}/pulls -f state=closed` returned valid output.
  - `gh pr checks 2 --repo jerryfane/gitmoot --json name,state,bucket,link,workflow,completedAt || true` returned `no checks reported on the 'task-002-config-doctor-store' branch`, matching the no-CI empty-check behavior covered by tests.
- Final `codex exec review --uncommitted` output:
  ```text
  The staged GitHub client implementation and tests appear consistent with the existing codebase, and `go test ./...` passes. I did not find a discrete correctness issue that should block the patch.
  ```

RISK:
- Mutating GitHub smoke calls for posting comments and creating statuses were not run against the real repo to avoid adding noisy PR comments/statuses. Those paths are covered with fake-runner tests.
- No repository CI is configured yet; checks were run locally.
