### PR TITLE
feat: add agent registry and runtime adapters

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1,0 +1,284 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+func runAgent(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printAgentUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "subscribe":
+		return runAgentSubscribe(args[1:], stdout, stderr)
+	case "list":
+		return runAgentList(args[1:], stdout, stderr)
+	case "remove":
+		return runAgentRemove(args[1:], stdout, stderr)
+	case "doctor":
+		return runAgentDoctor(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown agent command %q\n\n", args[0])
+		printAgentUsage(stderr)
+		return 2
+	}
+}
+
+func printAgentUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>")
+	fmt.Fprintln(w, "    Codex sessions may use a UUID, thread name, or last. Claude sessions may use a UUID or last. Shell sessions are commands.")
+	fmt.Fprintln(w, "  gitmoot agent list")
+	fmt.Fprintln(w, "  gitmoot agent remove <name>")
+	fmt.Fprintln(w, "  gitmoot agent doctor <name>")
+}
+
+func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent subscribe", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	runtimeName := fs.String("runtime", "", "agent runtime: codex, claude, or shell")
+	session := fs.String("session", "", "runtime session reference, last, or shell command")
+	role := fs.String("role", "", "agent role")
+	repo := fs.String("repo", "", "repo scope as owner/repo")
+	policy := fs.String("policy", "auto", "autonomy policy")
+	var capabilities repeatedFlag
+	fs.Var(&capabilities, "capability", "agent capability, repeatable")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent subscribe requires exactly one name")
+			return 2
+		}
+		return 0
+	}
+	name := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent subscribe requires exactly one name")
+		return 2
+	}
+
+	agent := runtime.Agent{
+		Name:           name,
+		Role:           *role,
+		Runtime:        *runtimeName,
+		RuntimeRef:     *session,
+		RepoScope:      *repo,
+		Capabilities:   capabilities,
+		AutonomyPolicy: *policy,
+		HealthStatus:   "unknown",
+	}
+	if err := runtime.ValidateAgent(agent); err != nil {
+		fmt.Fprintf(stderr, "invalid agent: %v\n", err)
+		return 2
+	}
+	if err := withStore(*home, func(store *db.Store) error {
+		return store.UpsertAgent(context.Background(), dbAgent(agent))
+	}); err != nil {
+		fmt.Fprintf(stderr, "subscribe agent: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "subscribed %s (%s) for %s\n", agent.Name, agent.Runtime, agent.RepoScope)
+	return 0
+}
+
+func runAgentList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	var agents []db.Agent
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		agents, err = store.ListAgents(context.Background())
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "list agents: %v\n", err)
+		return 1
+	}
+	for _, agent := range agents {
+		fmt.Fprintf(stdout, "%-16s %-8s %-12s %-20s %s\n", agent.Name, agent.Runtime, agent.Role, agent.RepoScope, strings.Join(agent.Capabilities, ","))
+	}
+	return 0
+}
+
+func runAgentRemove(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent remove", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent remove requires exactly one name")
+			return 2
+		}
+		return 0
+	}
+	name := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent remove requires exactly one name")
+		return 2
+	}
+	var removed bool
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		removed, err = store.RemoveAgent(context.Background(), name)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "remove agent: %v\n", err)
+		return 1
+	}
+	if !removed {
+		fmt.Fprintf(stderr, "agent %q not found\n", name)
+		return 1
+	}
+	fmt.Fprintf(stdout, "removed %s\n", name)
+	return 0
+}
+
+func runAgentDoctor(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent doctor", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent doctor requires exactly one name")
+			return 2
+		}
+		return 0
+	}
+	name := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent doctor requires exactly one name")
+		return 2
+	}
+	var agent db.Agent
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		agent, err = store.GetAgent(context.Background(), name)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "load agent: %v\n", err)
+		return 1
+	}
+	rtAgent := runtimeAgent(agent)
+	adapter, err := (runtime.Factory{}).Adapter(rtAgent.Runtime)
+	if err != nil {
+		fmt.Fprintf(stderr, "load adapter: %v\n", err)
+		return 1
+	}
+	if err := adapter.Validate(context.Background(), rtAgent); err != nil {
+		_ = persistAgentHealth(*home, name, "failed")
+		fmt.Fprintf(stderr, "invalid agent: %v\n", err)
+		return 1
+	}
+	if err := adapter.Health(context.Background(), rtAgent); err != nil {
+		_ = persistAgentHealth(*home, name, "failed")
+		fmt.Fprintf(stderr, "agent %s health failed: %v\n", rtAgent.Name, err)
+		return 1
+	}
+	if err := persistAgentHealth(*home, name, "ok"); err != nil {
+		fmt.Fprintf(stderr, "update agent health: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "agent %s ok\n", rtAgent.Name)
+	return 0
+}
+
+func persistAgentHealth(home, name, status string) error {
+	return withStore(home, func(store *db.Store) error {
+		agent, err := store.GetAgent(context.Background(), name)
+		if err != nil {
+			return err
+		}
+		agent.HealthStatus = status
+		return store.UpsertAgent(context.Background(), agent)
+	})
+}
+
+func withStore(home string, fn func(*db.Store) error) error {
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return err
+	}
+	if err := config.Initialize(paths); err != nil {
+		return err
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	return fn(store)
+}
+
+func dbAgent(agent runtime.Agent) db.Agent {
+	return db.Agent{
+		Name:           agent.Name,
+		Role:           agent.Role,
+		Runtime:        agent.Runtime,
+		RuntimeRef:     agent.RuntimeRef,
+		RepoScope:      agent.RepoScope,
+		Capabilities:   agent.Capabilities,
+		AutonomyPolicy: agent.AutonomyPolicy,
+		HealthStatus:   agent.HealthStatus,
+	}
+}
+
+func runtimeAgent(agent db.Agent) runtime.Agent {
+	return runtime.Agent{
+		Name:           agent.Name,
+		Role:           agent.Role,
+		Runtime:        agent.Runtime,
+		RuntimeRef:     agent.RuntimeRef,
+		RepoScope:      agent.RepoScope,
+		Capabilities:   agent.Capabilities,
+		AutonomyPolicy: agent.AutonomyPolicy,
+		HealthStatus:   agent.HealthStatus,
+	}
+}
+
+type repeatedFlag []string
+
+func (f *repeatedFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *repeatedFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestRunAgentSubscribeListRemove(t *testing.T) {
+	home := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "subscribe", "audit",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "review",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "list", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "audit") || !strings.Contains(output, "review,ask") {
+		t.Fatalf("list output = %q", output)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "remove", "audit", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("remove exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "list", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("second list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "audit") {
+		t.Fatalf("agent was not removed: %q", stdout.String())
+	}
+}
+
+func TestRunAgentSubscribeValidatesInput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "subscribe", "bad name", "--runtime", "codex", "--session", "s", "--role", "reviewer", "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "invalid agent") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+
+}
+
+func TestRunAgentDoctorPersistsHealth(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{
+		"agent", "subscribe", "shell",
+		"--home", home,
+		"--runtime", "shell",
+		"--session", "printf ok",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "doctor", "shell", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doctor exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "shell")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.HealthStatus != "ok" {
+		t.Fatalf("health status = %q, want ok", agent.HealthStatus)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,7 +24,7 @@ var rootCommands = []command{
 	{name: "init", summary: "initialize local Gitmoot state", run: runInit},
 	{name: "doctor", summary: "check local Gitmoot prerequisites", run: runDoctor},
 	{name: "daemon", summary: "run the local PR watcher", run: notImplemented("daemon")},
-	{name: "agent", summary: "manage registered agents", run: notImplemented("agent")},
+	{name: "agent", summary: "manage registered agents", run: runAgent},
 	{name: "status", summary: "show local workflow status", run: notImplemented("status")},
 	{name: "goal", summary: "import or inspect goals", run: notImplemented("goal")},
 	{name: "task", summary: "run or inspect tasks", run: notImplemented("task")},

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -190,6 +190,43 @@ func (s *Store) UpsertAgent(ctx context.Context, agent Agent) error {
 	return err
 }
 
+func (s *Store) GetAgent(ctx context.Context, name string) (Agent, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, capabilities_json, autonomy_policy, health_status
+		FROM agents WHERE name = ?`, name)
+	return scanAgent(row)
+}
+
+func (s *Store) ListAgents(ctx context.Context) ([]Agent, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, capabilities_json, autonomy_policy, health_status
+		FROM agents ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var agents []Agent
+	for rows.Next() {
+		agent, err := scanAgent(rows)
+		if err != nil {
+			return nil, err
+		}
+		agents = append(agents, agent)
+	}
+	return agents, rows.Err()
+}
+
+func (s *Store) RemoveAgent(ctx context.Context, name string) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM agents WHERE name = ?`, name)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
 func (s *Store) InsertGoal(ctx context.Context, goal Goal) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO goals(id, title, source, status) VALUES (?, ?, ?, ?)`, goal.ID, goal.Title, goal.Source, goal.Status)
 	return err
@@ -275,6 +312,22 @@ func (s *Store) HasTable(ctx context.Context, name string) (bool, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, name).Scan(&count)
 	return count == 1, err
+}
+
+type agentScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAgent(scanner agentScanner) (Agent, error) {
+	var agent Agent
+	var capabilities string
+	if err := scanner.Scan(&agent.Name, &agent.Role, &agent.Runtime, &agent.RuntimeRef, &agent.RepoScope, &capabilities, &agent.AutonomyPolicy, &agent.HealthStatus); err != nil {
+		return Agent{}, err
+	}
+	if err := json.Unmarshal([]byte(capabilities), &agent.Capabilities); err != nil {
+		return Agent{}, err
+	}
+	return agent, nil
 }
 
 var migrations = []string{

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -54,6 +54,20 @@ func TestRepositoryMethods(t *testing.T) {
 	if err := store.UpsertAgent(ctx, Agent{Name: "audit", Role: "reviewer", Runtime: "codex", RuntimeRef: "session", RepoScope: "jerryfane/gitmoot", Capabilities: []string{"review"}, AutonomyPolicy: "auto", HealthStatus: "ok"}); err != nil {
 		t.Fatalf("UpsertAgent returned error: %v", err)
 	}
+	agent, err := store.GetAgent(ctx, "audit")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.Name != "audit" || agent.Capabilities[0] != "review" {
+		t.Fatalf("agent = %+v", agent)
+	}
+	agents, err := store.ListAgents(ctx)
+	if err != nil {
+		t.Fatalf("ListAgents returned error: %v", err)
+	}
+	if len(agents) != 1 || agents[0].Name != "audit" {
+		t.Fatalf("agents = %+v", agents)
+	}
 	if err := store.InsertGoal(ctx, Goal{ID: "goal-1", Title: "Build Gitmoot", Source: "GOAL.md", Status: "planned"}); err != nil {
 		t.Fatalf("InsertGoal returned error: %v", err)
 	}
@@ -108,5 +122,19 @@ func TestRepositoryMethods(t *testing.T) {
 	}
 	if err := store.UpsertMergeGate(ctx, MergeGate{RepoFullName: "jerryfane/gitmoot", PullRequest: 1, State: "pending", Reason: "waiting"}); err != nil {
 		t.Fatalf("UpsertMergeGate returned error: %v", err)
+	}
+	removed, err := store.RemoveAgent(ctx, "audit")
+	if err != nil {
+		t.Fatalf("RemoveAgent returned error: %v", err)
+	}
+	if !removed {
+		t.Fatal("RemoveAgent did not remove existing agent")
+	}
+	removed, err = store.RemoveAgent(ctx, "audit")
+	if err != nil {
+		t.Fatalf("second RemoveAgent returned error: %v", err)
+	}
+	if removed {
+		t.Fatal("second RemoveAgent removed missing agent")
 	}
 }

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -1,14 +1,36 @@
 package runtime
 
-import "context"
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+const (
+	CodexRuntime  = "codex"
+	ClaudeRuntime = "claude"
+	ShellRuntime  = "shell"
+	LastRef       = "last"
+
+	healthPrompt = "Gitmoot health check. Reply OK only."
+)
 
 type Agent struct {
-	Name         string
-	Role         string
-	Runtime      string
-	RuntimeRef   string
-	RepoScope    string
-	Capabilities []string
+	Name           string
+	Role           string
+	Runtime        string
+	RuntimeRef     string
+	RepoScope      string
+	Capabilities   []string
+	AutonomyPolicy string
+	HealthStatus   string
 }
 
 type Job struct {
@@ -32,4 +54,339 @@ type Adapter interface {
 	Deliver(ctx context.Context, agent Agent, job Job) (Result, error)
 	Health(ctx context.Context, agent Agent) error
 	Capabilities(ctx context.Context) ([]string, error)
+}
+
+type Factory struct {
+	Runner subprocess.Runner
+}
+
+func (f Factory) Adapter(name string) (Adapter, error) {
+	switch name {
+	case CodexRuntime:
+		return CodexAdapter{Runner: f.Runner}, nil
+	case ClaudeRuntime:
+		return ClaudeAdapter{Runner: f.Runner}, nil
+	case ShellRuntime:
+		return ShellAdapter{Runner: f.Runner}, nil
+	default:
+		return nil, fmt.Errorf("unsupported runtime: %s", name)
+	}
+}
+
+func ValidateAgent(agent Agent) error {
+	switch {
+	case strings.TrimSpace(agent.Name) == "":
+		return errors.New("agent name is required")
+	case strings.ContainsAny(agent.Name, " \t\n/"):
+		return fmt.Errorf("agent name %q cannot contain whitespace or slash", agent.Name)
+	case strings.TrimSpace(agent.Role) == "":
+		return errors.New("agent role is required")
+	case strings.TrimSpace(agent.Runtime) == "":
+		return errors.New("agent runtime is required")
+	case strings.TrimSpace(agent.RuntimeRef) == "":
+		return errors.New("agent runtime reference is required")
+	case strings.TrimSpace(agent.RepoScope) == "":
+		return errors.New("agent repo scope is required")
+	case !validRepoScope(agent.RepoScope):
+		return fmt.Errorf("agent repo scope %q must be owner/repo", agent.RepoScope)
+	}
+	if _, err := (Factory{}).Adapter(agent.Runtime); err != nil {
+		return err
+	}
+	if agent.Runtime == ClaudeRuntime && agent.RuntimeRef != LastRef && !isUUID(agent.RuntimeRef) {
+		return fmt.Errorf("claude runtime reference %q must be a UUID or last", agent.RuntimeRef)
+	}
+	return nil
+}
+
+type CodexSessionResolver interface {
+	Exists(ctx context.Context, ref string) (bool, error)
+}
+
+type CodexSessionIndex struct {
+	Path string
+}
+
+type CodexAdapter struct {
+	Runner          subprocess.Runner
+	Dir             string
+	SessionResolver CodexSessionResolver
+}
+
+func (a CodexAdapter) Name() string { return CodexRuntime }
+
+func (a CodexAdapter) Validate(_ context.Context, agent Agent) error {
+	return validateRuntime(agent, a.Name())
+}
+
+func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, error) {
+	if err := a.Validate(ctx, agent); err != nil {
+		return Result{}, err
+	}
+	if err := a.verifySession(ctx, agent); err != nil {
+		return Result{}, err
+	}
+	args := []string{"exec", "resume"}
+	if agent.RuntimeRef == "last" {
+		args = append(args, "--last")
+	} else {
+		args = append(args, agent.RuntimeRef)
+	}
+	args = append(args, "--", job.Prompt)
+	result, err := a.runner().Run(ctx, a.Dir, "codex", args...)
+	if err != nil {
+		return Result{Raw: result.Stdout + result.Stderr}, commandError(result, err)
+	}
+	return Result{Raw: result.Stdout}, nil
+}
+
+func (a CodexAdapter) Health(ctx context.Context, agent Agent) error {
+	_, err := a.Deliver(ctx, agent, Job{Prompt: healthPrompt})
+	return err
+}
+
+func (a CodexAdapter) Capabilities(context.Context) ([]string, error) {
+	return []string{"review", "implement", "ask"}, nil
+}
+
+func (a CodexAdapter) runner() subprocess.Runner {
+	if a.Runner != nil {
+		return a.Runner
+	}
+	return subprocess.ExecRunner{}
+}
+
+func (a CodexAdapter) verifySession(ctx context.Context, agent Agent) error {
+	if agent.RuntimeRef == "last" {
+		return nil
+	}
+	exists, err := a.sessionResolver().Exists(ctx, agent.RuntimeRef)
+	if err != nil {
+		return fmt.Errorf("verify codex session: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("codex session %q was not found", agent.RuntimeRef)
+	}
+	return nil
+}
+
+func (a CodexAdapter) sessionResolver() CodexSessionResolver {
+	if a.SessionResolver != nil {
+		return a.SessionResolver
+	}
+	return CodexSessionIndex{}
+}
+
+type ClaudeAdapter struct {
+	Runner subprocess.Runner
+	Dir    string
+}
+
+func (a ClaudeAdapter) Name() string { return ClaudeRuntime }
+
+func (a ClaudeAdapter) Validate(_ context.Context, agent Agent) error {
+	return validateRuntime(agent, a.Name())
+}
+
+func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, error) {
+	if err := a.Validate(ctx, agent); err != nil {
+		return Result{}, err
+	}
+	args := claudeArgs(agent, job.Prompt, true)
+	result, err := a.runner().Run(ctx, a.Dir, "claude", args...)
+	if err != nil && isClaudeJSONUnsupported(result) {
+		result, err = a.runner().Run(ctx, a.Dir, "claude", claudeArgs(agent, job.Prompt, false)...)
+	}
+	if err != nil {
+		return Result{Raw: result.Stdout + result.Stderr}, commandError(result, err)
+	}
+	parsed := Result{Raw: result.Stdout}
+	var payload struct {
+		Result string `json:"result"`
+	}
+	if json.Unmarshal([]byte(result.Stdout), &payload) == nil && payload.Result != "" {
+		parsed.Summary = payload.Result
+	} else {
+		parsed.Summary = strings.TrimSpace(result.Stdout)
+	}
+	return parsed, nil
+}
+
+func (a ClaudeAdapter) Health(ctx context.Context, agent Agent) error {
+	if err := a.Validate(ctx, agent); err != nil {
+		return err
+	}
+	_, err := a.Deliver(ctx, agent, Job{Prompt: healthPrompt})
+	return err
+}
+
+func (a ClaudeAdapter) Capabilities(context.Context) ([]string, error) {
+	return []string{"review", "implement", "ask"}, nil
+}
+
+func (a ClaudeAdapter) runner() subprocess.Runner {
+	if a.Runner != nil {
+		return a.Runner
+	}
+	return subprocess.ExecRunner{}
+}
+
+type ShellAdapter struct {
+	Runner subprocess.Runner
+	Dir    string
+}
+
+func (a ShellAdapter) Name() string { return ShellRuntime }
+
+func (a ShellAdapter) Validate(_ context.Context, agent Agent) error {
+	return validateRuntime(agent, a.Name())
+}
+
+func (a ShellAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, error) {
+	if err := a.Validate(ctx, agent); err != nil {
+		return Result{}, err
+	}
+	result, err := a.runner().Run(ctx, a.Dir, "sh", "-c", agent.RuntimeRef, "gitmoot", job.Prompt)
+	if err != nil {
+		return Result{Raw: result.Stdout + result.Stderr}, commandError(result, err)
+	}
+	return Result{Raw: result.Stdout, Summary: strings.TrimSpace(result.Stdout)}, nil
+}
+
+func (a ShellAdapter) Health(ctx context.Context, agent Agent) error {
+	if err := a.Validate(ctx, agent); err != nil {
+		return err
+	}
+	result, err := a.runner().Run(ctx, a.Dir, "sh", "-c", agent.RuntimeRef, "gitmoot-health", healthPrompt)
+	if err != nil {
+		return commandError(result, err)
+	}
+	return nil
+}
+
+func (a ShellAdapter) Capabilities(context.Context) ([]string, error) {
+	return []string{"review", "implement", "ask"}, nil
+}
+
+func (a ShellAdapter) runner() subprocess.Runner {
+	if a.Runner != nil {
+		return a.Runner
+	}
+	return subprocess.ExecRunner{}
+}
+
+func commandError(result subprocess.Result, err error) error {
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	if detail == "" {
+		return err
+	}
+	return fmt.Errorf("%s: %w", detail, err)
+}
+
+func claudeArgs(agent Agent, prompt string, jsonOutput bool) []string {
+	args := []string{}
+	if agent.RuntimeRef == "last" {
+		args = append(args, "--continue")
+	} else {
+		args = append(args, "--resume", agent.RuntimeRef)
+	}
+	args = append(args, "-p")
+	if jsonOutput {
+		args = append(args, "--output-format", "json")
+	}
+	return append(args, "--", prompt)
+}
+
+func isClaudeJSONUnsupported(result subprocess.Result) bool {
+	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	return strings.Contains(text, "output-format") &&
+		(strings.Contains(text, "unknown") || strings.Contains(text, "unsupported") || strings.Contains(text, "invalid"))
+}
+
+func validateRuntime(agent Agent, runtimeName string) error {
+	if err := ValidateAgent(agent); err != nil {
+		return err
+	}
+	if agent.Runtime != runtimeName {
+		return fmt.Errorf("agent runtime %q does not match adapter %q", agent.Runtime, runtimeName)
+	}
+	return nil
+}
+
+func validRepoScope(scope string) bool {
+	parts := strings.Split(scope, "/")
+	return len(parts) == 2 && strings.TrimSpace(parts[0]) != "" && strings.TrimSpace(parts[1]) != ""
+}
+
+func isUUID(value string) bool {
+	if len(value) != 36 {
+		return false
+	}
+	for index, char := range value {
+		switch index {
+		case 8, 13, 18, 23:
+			if char != '-' {
+				return false
+			}
+		default:
+			if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (r CodexSessionIndex) Exists(ctx context.Context, ref string) (bool, error) {
+	path, err := r.path()
+	if err != nil {
+		return false, err
+	}
+	file, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		var entry struct {
+			ID         string `json:"id"`
+			ThreadName string `json:"thread_name"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			return false, fmt.Errorf("parse codex session index: %w", err)
+		}
+		if entry.ID == ref || entry.ThreadName == ref {
+			return true, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func (r CodexSessionIndex) path() (string, error) {
+	if r.Path != "" {
+		return r.Path, nil
+	}
+	home := strings.TrimSpace(os.Getenv("CODEX_HOME"))
+	if home == "" {
+		userHome, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		home = filepath.Join(userHome, ".codex")
+	}
+	return filepath.Join(home, "session_index.jsonl"), nil
 }

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -1,0 +1,289 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+func TestValidateAgent(t *testing.T) {
+	agent := Agent{Name: "audit", Role: "reviewer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440000", RepoScope: "jerryfane/gitmoot"}
+	if err := ValidateAgent(agent); err != nil {
+		t.Fatalf("ValidateAgent returned error: %v", err)
+	}
+
+	agent.Runtime = "unknown"
+	if err := ValidateAgent(agent); err == nil {
+		t.Fatal("ValidateAgent accepted unsupported runtime")
+	}
+
+	agent = Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "session-name", RepoScope: "jerryfane/gitmoot"}
+	if err := ValidateAgent(agent); err != nil {
+		t.Fatalf("ValidateAgent rejected Codex runtime name: %v", err)
+	}
+
+	agent = Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "session-name", RepoScope: "jerryfane/gitmoot"}
+	if err := ValidateAgent(agent); err == nil {
+		t.Fatal("ValidateAgent accepted non-UUID Claude runtime ref")
+	}
+
+	for _, scope := range []string{"owner/", "/repo", "owner/repo/extra"} {
+		agent := Agent{Name: "audit", Role: "reviewer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440000", RepoScope: scope}
+		if err := ValidateAgent(agent); err == nil {
+			t.Fatalf("ValidateAgent accepted malformed repo scope %q", scope)
+		}
+	}
+}
+
+func TestAdapterValidateRejectsRuntimeMismatch(t *testing.T) {
+	agent := Agent{Name: "audit", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440000", RepoScope: "jerryfane/gitmoot"}
+	if err := (CodexAdapter{}).Validate(context.Background(), agent); err == nil {
+		t.Fatal("CodexAdapter accepted a Claude agent")
+	}
+}
+
+func TestCodexDeliverCommand(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "done"}}}
+	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{exists: true}}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review this"})
+
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Raw != "done" {
+		t.Fatalf("raw = %q", result.Raw)
+	}
+	runner.want(t, 0, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
+}
+
+func TestCodexDeliverLastSessionCommand(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "done"}}}
+	adapter := CodexAdapter{Runner: runner}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: LastRef, RepoScope: "jerryfane/gitmoot"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "continue"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "resume", "--last", "--", "continue")
+}
+
+func TestCodexDeliverVerifiesNamedSession(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "done"}}}
+	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{exists: true}}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "review-thread", RepoScope: "jerryfane/gitmoot"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "resume", "review-thread", "--", "review")
+}
+
+func TestCodexDeliverRejectsMissingNamedSession(t *testing.T) {
+	runner := &fakeRunner{}
+	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{}}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "missing-thread", RepoScope: "jerryfane/gitmoot"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err == nil {
+		t.Fatal("Deliver accepted missing codex session")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner was called before session verification: %v", runner.calls)
+	}
+}
+
+func TestCodexHealthUsesRegisteredSession(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "OK"}}}
+	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{exists: true}}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot"}
+
+	if err := adapter.Health(context.Background(), agent); err != nil {
+		t.Fatalf("Health returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", healthPrompt)
+}
+
+func TestCodexHealthRejectsBrokenSession(t *testing.T) {
+	runner := &fakeRunner{errs: []error{errors.New("exit 1")}}
+	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{exists: true}}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot"}
+
+	if err := adapter.Health(context.Background(), agent); err == nil {
+		t.Fatal("Health accepted broken codex session")
+	}
+	runner.want(t, 0, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", healthPrompt)
+}
+
+func TestClaudeDeliverCommand(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"done"}`}}}
+	adapter := ClaudeAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "done" {
+		t.Fatalf("summary = %q", result.Summary)
+	}
+	runner.want(t, 0, "claude", "--resume", "550e8400-e29b-41d4-a716-446655440002", "-p", "--output-format", "json", "--", "review")
+}
+
+func TestClaudeDeliverLastSessionCommand(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"done"}`}}}
+	adapter := ClaudeAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: LastRef, RepoScope: "jerryfane/gitmoot"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "claude", "--continue", "-p", "--output-format", "json", "--", "review")
+}
+
+func TestClaudeDeliverFallsBackToText(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stderr: "unknown option '--output-format'"},
+			{Stdout: "plain response\n"},
+		},
+		errs: []error{errors.New("exit 1"), nil},
+	}
+	adapter := ClaudeAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "plain response" {
+		t.Fatalf("summary = %q", result.Summary)
+	}
+	runner.want(t, 0, "claude", "--resume", "550e8400-e29b-41d4-a716-446655440002", "-p", "--output-format", "json", "--", "review")
+	runner.want(t, 1, "claude", "--resume", "550e8400-e29b-41d4-a716-446655440002", "-p", "--", "review")
+}
+
+func TestClaudeHealthUsesRegisteredSession(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"OK"}`}}}
+	adapter := ClaudeAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	if err := adapter.Health(context.Background(), agent); err != nil {
+		t.Fatalf("Health returned error: %v", err)
+	}
+	runner.want(t, 0, "claude", "--resume", "550e8400-e29b-41d4-a716-446655440002", "-p", "--output-format", "json", "--", healthPrompt)
+}
+
+func TestClaudeHealthRejectsBrokenSession(t *testing.T) {
+	runner := &fakeRunner{errs: []error{errors.New("exit 1")}}
+	adapter := ClaudeAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	if err := adapter.Health(context.Background(), agent); err == nil {
+		t.Fatal("Health accepted broken claude session")
+	}
+	runner.want(t, 0, "claude", "--resume", "550e8400-e29b-41d4-a716-446655440002", "-p", "--output-format", "json", "--", healthPrompt)
+}
+
+func TestShellDeliverCommand(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "ok\n"}}}
+	adapter := ShellAdapter{Runner: runner}
+	agent := Agent{Name: "custom", Role: "reviewer", Runtime: ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "hello"})
+
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "ok" {
+		t.Fatalf("summary = %q", result.Summary)
+	}
+	runner.want(t, 0, "sh", "-c", "printf ok", "gitmoot", "hello")
+}
+
+func TestShellHealthRunsProbe(t *testing.T) {
+	runner := &fakeRunner{errs: []error{errors.New("exit 1")}}
+	adapter := ShellAdapter{Runner: runner}
+	agent := Agent{Name: "custom", Role: "reviewer", Runtime: ShellRuntime, RuntimeRef: "exit 1", RepoScope: "jerryfane/gitmoot"}
+
+	if err := adapter.Health(context.Background(), agent); err == nil {
+		t.Fatal("Health accepted failing shell command")
+	}
+	runner.want(t, 0, "sh", "-c", "exit 1", "gitmoot-health", healthPrompt)
+}
+
+func TestCodexSessionIndexFindsIDAndThreadName(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session_index.jsonl")
+	content := `{"id":"550e8400-e29b-41d4-a716-446655440001","thread_name":"review-thread","updated_at":"2026-05-20T00:00:00Z"}` + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	index := CodexSessionIndex{Path: path}
+
+	for _, ref := range []string{"550e8400-e29b-41d4-a716-446655440001", "review-thread"} {
+		exists, err := index.Exists(context.Background(), ref)
+		if err != nil {
+			t.Fatalf("Exists returned error for %q: %v", ref, err)
+		}
+		if !exists {
+			t.Fatalf("Exists(%q) = false, want true", ref)
+		}
+	}
+}
+
+type staticCodexSessions struct {
+	exists bool
+	err    error
+}
+
+func (s staticCodexSessions) Exists(context.Context, string) (bool, error) {
+	return s.exists, s.err
+}
+
+type fakeRunner struct {
+	results []subprocess.Result
+	errs    []error
+	calls   [][]string
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	call := append([]string{command}, args...)
+	f.calls = append(f.calls, call)
+	index := len(f.calls) - 1
+	result := subprocess.Result{Command: command, Args: args}
+	if index < len(f.results) {
+		result = f.results[index]
+		result.Command = command
+		result.Args = args
+	}
+	var err error
+	if index < len(f.errs) {
+		err = f.errs[index]
+	}
+	return result, err
+}
+
+func (f *fakeRunner) LookPath(file string) (string, error) {
+	if file == "" {
+		return "", errors.New("empty file")
+	}
+	return "/usr/bin/" + file, nil
+}
+
+func (f *fakeRunner) want(t *testing.T, index int, want ...string) {
+	t.Helper()
+	if index >= len(f.calls) {
+		t.Fatalf("missing call %d; calls=%v", index, f.calls)
+	}
+	if !reflect.DeepEqual(f.calls[index], want) {
+		t.Fatalf("call %d = %s\nwant %s", index, strings.Join(f.calls[index], " "), strings.Join(want, " "))
+	}
+}


### PR DESCRIPTION
WHAT: Added the local agent registry CLI and runtime adapter layer for Codex, Claude, and shell-backed Gitmoot agents.

WHY: Gitmoot needs a machine-local abstraction that can register listening agents, validate their runtime identity, and deliver PR-comment tasks through the correct agent infrastructure without coupling the rest of the service to a specific CLI.

CHANGES:
- Added `gitmoot agent subscribe/list/remove/doctor` commands with persistent SQLite-backed agent registration.
- Added agent store helpers for lookup, listing, removal, and health metadata updates.
- Added runtime adapter selection plus Codex, Claude, and shell adapters.
- Added Codex session-index validation for explicit session IDs/thread names while preserving runtime-relative `last` semantics.
- Added Claude resume/continue command execution with JSON output parsing and text fallback.
- Added focused CLI, store, and runtime adapter tests.

RESULTS:
- `go test ./...`
- `go vet ./...`
- `gofmt` on touched Go files
- `git diff --cached --check && git diff --check`
- `codex exec resume --help`
- `HOME=$(mktemp -d) claude --help`
- Shell agent subscribe/doctor smoke test
- Codex `last` persistence smoke test
- `codex exec review --uncommitted` final raw output:

```text
The staged changes implement the agent CLI, store helpers, and runtime adapters coherently, and the repository test suite passes. I did not find a discrete correctness issue that should block the patch.
The staged changes implement the agent CLI, store helpers, and runtime adapters coherently, and the repository test suite passes. I did not find a discrete correctness issue that should block the patch.
```

RISK:
- No GitHub Actions CI is currently configured for this repository, so local checks are the gating evidence.
- Direct `claude --help` inside the review sandbox hit an EPERM reading `/Users/jerryfane/.claude.json`; the CLI contract was verified with a temporary HOME.
- `last` remains intentionally runtime-relative and moving, matching Codex/Claude CLI behavior. Explicit Codex IDs/thread names are checked against the local session index before delivery/health.
