### PR TITLE
feat: add job mailbox and agent result contract

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -270,9 +270,138 @@ func (s *Store) CreateJob(ctx context.Context, job Job) error {
 	return err
 }
 
+func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, updated_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`, job.ID, job.Agent, job.Type, job.State, job.Payload); err != nil {
+		return err
+	}
+	if event.JobID == "" {
+		event.JobID = job.ID
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload FROM jobs WHERE id = ?`, id)
+	var job Job
+	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload); err != nil {
+		return Job{}, err
+	}
+	return job, nil
+}
+
+func (s *Store) UpdateJobState(ctx context.Context, id string, state string) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE jobs SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, state, id)
+	if err != nil {
+		return err
+	}
+	return requireAffected(result, "job", id)
+}
+
+func (s *Store) TransitionJobState(ctx context.Context, id string, from string, to string) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `UPDATE jobs SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`, to, id, from)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
+}
+
+func (s *Store) TransitionJobStateWithEvent(ctx context.Context, id string, from string, to string, event JobEvent) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	result, err := tx.ExecContext(ctx, `UPDATE jobs SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`, to, id, from)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		return false, tx.Commit()
+	}
+	if event.JobID == "" {
+		event.JobID = id
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
+		return false, err
+	}
+	return true, tx.Commit()
+}
+
+func (s *Store) TransitionJobStatePayloadWithEvent(ctx context.Context, id string, from string, to string, payload string, event JobEvent) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	result, err := tx.ExecContext(ctx, `UPDATE jobs SET state = ?, payload = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`, to, payload, id, from)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		return false, tx.Commit()
+	}
+	if event.JobID == "" {
+		event.JobID = id
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
+		return false, err
+	}
+	return true, tx.Commit()
+}
+
+func (s *Store) UpdateJobPayload(ctx context.Context, id string, payload string) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE jobs SET payload = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, payload, id)
+	if err != nil {
+		return err
+	}
+	return requireAffected(result, "job", id)
+}
+
 func (s *Store) AddJobEvent(ctx context.Context, event JobEvent) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message)
 	return err
+}
+
+func (s *Store) ListJobEvents(ctx context.Context, jobID string) ([]JobEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT job_id, kind, message FROM job_events WHERE job_id = ? ORDER BY id`, jobID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var events []JobEvent
+	for rows.Next() {
+		var event JobEvent
+		if err := rows.Scan(&event.JobID, &event.Kind, &event.Message); err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
 }
 
 func (s *Store) AcquireLock(ctx context.Context, lock BranchLock) (bool, error) {
@@ -328,6 +457,17 @@ func scanAgent(scanner agentScanner) (Agent, error) {
 		return Agent{}, err
 	}
 	return agent, nil
+}
+
+func requireAffected(result sql.Result, subject string, id string) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return fmt.Errorf("%s %q not found", subject, id)
+	}
+	return nil
 }
 
 var migrations = []string{

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -96,8 +96,83 @@ func TestRepositoryMethods(t *testing.T) {
 	if err := store.CreateJob(ctx, Job{ID: "job-1", Agent: "audit", Type: "review", State: "queued"}); err != nil {
 		t.Fatalf("CreateJob returned error: %v", err)
 	}
+	job, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != "queued" {
+		t.Fatalf("job state = %q, want queued", job.State)
+	}
+	if err := store.UpdateJobState(ctx, "job-1", "running"); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	transitioned, err := store.TransitionJobState(ctx, "job-1", "queued", "running")
+	if err != nil {
+		t.Fatalf("TransitionJobState stale returned error: %v", err)
+	}
+	if transitioned {
+		t.Fatal("TransitionJobState unexpectedly changed a non-matching state")
+	}
+	transitioned, err = store.TransitionJobState(ctx, "job-1", "running", "succeeded")
+	if err != nil {
+		t.Fatalf("TransitionJobState returned error: %v", err)
+	}
+	if !transitioned {
+		t.Fatal("TransitionJobState did not change matching state")
+	}
+	if err := store.CreateJob(ctx, Job{ID: "job-2", Agent: "audit", Type: "review", State: "queued"}); err != nil {
+		t.Fatalf("second CreateJob returned error: %v", err)
+	}
+	transitioned, err = store.TransitionJobStateWithEvent(ctx, "job-2", "queued", "running", JobEvent{Kind: "running", Message: "started"})
+	if err != nil {
+		t.Fatalf("TransitionJobStateWithEvent returned error: %v", err)
+	}
+	if !transitioned {
+		t.Fatal("TransitionJobStateWithEvent did not change matching state")
+	}
+	jobEvents, err := store.ListJobEvents(ctx, "job-2")
+	if err != nil {
+		t.Fatalf("ListJobEvents for job-2 returned error: %v", err)
+	}
+	if len(jobEvents) != 1 || jobEvents[0].Kind != "running" {
+		t.Fatalf("job-2 events = %+v", jobEvents)
+	}
+	if err := store.CreateJobWithEvent(ctx, Job{ID: "job-3", Agent: "audit", Type: "review", State: "queued"}, JobEvent{Kind: "queued", Message: "created"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	jobEvents, err = store.ListJobEvents(ctx, "job-3")
+	if err != nil {
+		t.Fatalf("ListJobEvents for job-3 returned error: %v", err)
+	}
+	if len(jobEvents) != 1 || jobEvents[0].Kind != "queued" {
+		t.Fatalf("job-3 events = %+v", jobEvents)
+	}
+	transitioned, err = store.TransitionJobStatePayloadWithEvent(ctx, "job-3", "queued", "succeeded", `{"result":{"summary":"ok"}}`, JobEvent{Kind: "succeeded", Message: "done"})
+	if err != nil {
+		t.Fatalf("TransitionJobStatePayloadWithEvent returned error: %v", err)
+	}
+	if !transitioned {
+		t.Fatal("TransitionJobStatePayloadWithEvent did not change matching state")
+	}
+	job, err = store.GetJob(ctx, "job-3")
+	if err != nil {
+		t.Fatalf("GetJob for job-3 returned error: %v", err)
+	}
+	if job.State != "succeeded" || job.Payload != `{"result":{"summary":"ok"}}` {
+		t.Fatalf("job-3 = %+v", job)
+	}
+	if err := store.UpdateJobPayload(ctx, "job-1", `{"raw_outputs":["ok"]}`); err != nil {
+		t.Fatalf("UpdateJobPayload returned error: %v", err)
+	}
 	if err := store.AddJobEvent(ctx, JobEvent{JobID: "job-1", Kind: "queued", Message: "created"}); err != nil {
 		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "queued" {
+		t.Fatalf("events = %+v", events)
 	}
 	acquired, err := store.AcquireLock(ctx, BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task", Owner: "lead"})
 	if err != nil {

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -1,10 +1,83 @@
 package prompts
 
+import (
+	"fmt"
+	"strings"
+)
+
 type JobPrompt struct {
-	Repo        string
-	Branch      string
-	PullRequest int
-	Task        string
-	Action      string
-	Constraints []string
+	Repo         string
+	Branch       string
+	PullRequest  int
+	Task         string
+	Sender       string
+	Action       string
+	Instructions string
+	Constraints  []string
+}
+
+func RenderJob(prompt JobPrompt) string {
+	var builder strings.Builder
+	builder.WriteString("Gitmoot job\n\n")
+	writeField(&builder, "Repo", prompt.Repo)
+	writeField(&builder, "Branch", prompt.Branch)
+	if prompt.PullRequest > 0 {
+		writeField(&builder, "Pull request", fmt.Sprintf("#%d", prompt.PullRequest))
+	}
+	writeField(&builder, "Task", prompt.Task)
+	writeField(&builder, "Sender", prompt.Sender)
+	writeField(&builder, "Requested action", prompt.Action)
+	writeField(&builder, "Instructions", prompt.Instructions)
+
+	if len(prompt.Constraints) > 0 {
+		builder.WriteString("\nConstraints:\n")
+		for _, constraint := range prompt.Constraints {
+			constraint = strings.TrimSpace(constraint)
+			if constraint != "" {
+				builder.WriteString("- ")
+				builder.WriteString(constraint)
+				builder.WriteByte('\n')
+			}
+		}
+	}
+
+	builder.WriteString("\nRequired output:\n")
+	builder.WriteString("Return exactly one JSON object containing a top-level gitmoot_result field.\n")
+	builder.WriteString("Use this shape:\n")
+	builder.WriteString(`{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`)
+	builder.WriteByte('\n')
+	return builder.String()
+}
+
+func RenderRepairPrompt(rawOutput string, parseError error) string {
+	var builder strings.Builder
+	builder.WriteString("Your previous response did not contain a valid gitmoot_result JSON object.\n")
+	if parseError != nil {
+		writeField(&builder, "Parse error", parseError.Error())
+	}
+	builder.WriteString("\nReturn only one JSON object in this exact shape:\n")
+	builder.WriteString(`{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`)
+	builder.WriteString("\n\nPrevious raw output:\n")
+	builder.WriteString(trimRawOutput(rawOutput, 12000))
+	builder.WriteByte('\n')
+	return builder.String()
+}
+
+func writeField(builder *strings.Builder, label string, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	builder.WriteString(label)
+	builder.WriteString(": ")
+	builder.WriteString(value)
+	builder.WriteByte('\n')
+}
+
+func trimRawOutput(output string, limit int) string {
+	output = strings.TrimSpace(output)
+	if len(output) <= limit {
+		return output
+	}
+	return output[:limit] + "\n[truncated]"
 }

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -1,0 +1,51 @@
+package prompts
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRenderJobIncludesContextAndContract(t *testing.T) {
+	prompt := RenderJob(JobPrompt{
+		Repo:         "jerryfane/gitmoot",
+		Branch:       "task-005",
+		PullRequest:  5,
+		Task:         "task-5: Job Mailbox",
+		Sender:       "octocat",
+		Action:       "review",
+		Instructions: "focus on state transitions",
+		Constraints:  []string{"Preserve existing behavior", "", "Return JSON"},
+	})
+
+	for _, want := range []string{
+		"Repo: jerryfane/gitmoot",
+		"Branch: task-005",
+		"Pull request: #5",
+		"Task: task-5: Job Mailbox",
+		"Sender: octocat",
+		"Requested action: review",
+		"- Preserve existing behavior",
+		"gitmoot_result",
+		`"decision":"approved|changes_requested|blocked|implemented|failed"`,
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestRenderRepairPromptIncludesErrorAndRawOutput(t *testing.T) {
+	prompt := RenderRepairPrompt("not json", errors.New("missing gitmoot_result"))
+
+	for _, want := range []string{
+		"did not contain a valid gitmoot_result",
+		"Parse error: missing gitmoot_result",
+		"Return only one JSON object",
+		"not json",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("repair prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -1,0 +1,335 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/prompts"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+type Mailbox struct {
+	Store *db.Store
+}
+
+type JobRequest struct {
+	ID           string
+	Agent        string
+	Action       string
+	Repo         string
+	Branch       string
+	PullRequest  int
+	TaskID       string
+	TaskTitle    string
+	Sender       string
+	Instructions string
+	Constraints  []string
+}
+
+type JobPayload struct {
+	Repo         string       `json:"repo"`
+	Branch       string       `json:"branch"`
+	PullRequest  int          `json:"pull_request"`
+	TaskID       string       `json:"task_id"`
+	TaskTitle    string       `json:"task_title"`
+	Sender       string       `json:"sender"`
+	Instructions string       `json:"instructions"`
+	Constraints  []string     `json:"constraints"`
+	RawOutputs   []string     `json:"raw_outputs,omitempty"`
+	Result       *AgentResult `json:"result,omitempty"`
+}
+
+type DeliveryAdapter interface {
+	Deliver(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error)
+}
+
+func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error) {
+	if m.Store == nil {
+		return db.Job{}, errors.New("mailbox store is required")
+	}
+	if err := validateJobRequest(request); err != nil {
+		return db.Job{}, err
+	}
+
+	payload, err := marshalPayload(JobPayload{
+		Repo:         request.Repo,
+		Branch:       request.Branch,
+		PullRequest:  request.PullRequest,
+		TaskID:       request.TaskID,
+		TaskTitle:    request.TaskTitle,
+		Sender:       request.Sender,
+		Instructions: request.Instructions,
+		Constraints:  compactStrings(request.Constraints),
+	})
+	if err != nil {
+		return db.Job{}, err
+	}
+
+	job := db.Job{
+		ID:      request.ID,
+		Agent:   request.Agent,
+		Type:    request.Action,
+		State:   string(JobQueued),
+		Payload: payload,
+	}
+	if err := m.Store.CreateJobWithEvent(ctx, job, db.JobEvent{JobID: job.ID, Kind: string(JobQueued), Message: "job queued"}); err != nil {
+		return db.Job{}, err
+	}
+	return job, nil
+}
+
+func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, adapter DeliveryAdapter) (AgentResult, error) {
+	if m.Store == nil {
+		return AgentResult{}, errors.New("mailbox store is required")
+	}
+	if adapter == nil {
+		return AgentResult{}, errors.New("delivery adapter is required")
+	}
+
+	job, err := m.Store.GetJob(ctx, jobID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return AgentResult{}, fmt.Errorf("job %q not found", jobID)
+		}
+		return AgentResult{}, err
+	}
+	if job.Agent != agent.Name {
+		return AgentResult{}, fmt.Errorf("job %q is assigned to %q, not %q", job.ID, job.Agent, agent.Name)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		return AgentResult{}, err
+	}
+
+	if err := m.claim(ctx, job); err != nil {
+		return AgentResult{}, err
+	}
+
+	prompt := prompts.RenderJob(payload.prompt(job.Type))
+	firstRaw, firstErr := m.deliver(ctx, adapter, agent, job, payload, prompt)
+	if firstErr != nil {
+		_ = m.fail(ctx, job.ID, fmt.Sprintf("delivery failed: %v", firstErr))
+		return AgentResult{}, firstErr
+	}
+	payload.RawOutputs = append(payload.RawOutputs, firstRaw)
+
+	result, parseErr := ExtractAgentResult(firstRaw)
+	if parseErr != nil {
+		if err := m.savePayload(ctx, job.ID, payload); err != nil {
+			return AgentResult{}, err
+		}
+		if err := m.addEvent(ctx, job.ID, "malformed_output", parseErr.Error()); err != nil {
+			return AgentResult{}, err
+		}
+		if err := m.ensureRunning(ctx, job.ID); err != nil {
+			return AgentResult{}, err
+		}
+		if err := m.addEvent(ctx, job.ID, "repair_retry", "retrying once with repair prompt"); err != nil {
+			return AgentResult{}, err
+		}
+
+		repairPrompt := prompts.RenderRepairPrompt(firstRaw, parseErr)
+		secondRaw, secondErr := m.deliver(ctx, adapter, agent, job, payload, repairPrompt)
+		if secondErr != nil {
+			_ = m.fail(ctx, job.ID, fmt.Sprintf("repair delivery failed: %v", secondErr))
+			return AgentResult{}, secondErr
+		}
+		payload.RawOutputs = append(payload.RawOutputs, secondRaw)
+		result, parseErr = ExtractAgentResult(secondRaw)
+		if parseErr != nil {
+			if err := m.savePayload(ctx, job.ID, payload); err != nil {
+				return AgentResult{}, err
+			}
+			_ = m.fail(ctx, job.ID, fmt.Sprintf("repair output malformed: %v", parseErr))
+			return AgentResult{}, parseErr
+		}
+	}
+
+	if err := m.ensureRunning(ctx, job.ID); err != nil {
+		return AgentResult{}, err
+	}
+	payload.Result = &result
+	state := stateForDecision(result.Decision)
+	if err := m.finishWithPayload(ctx, job.ID, state, fmt.Sprintf("job %s", state), payload); err != nil {
+		return AgentResult{}, err
+	}
+	return result, nil
+}
+
+func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent runtime.Agent, job db.Job, payload JobPayload, prompt string) (string, error) {
+	result, err := adapter.Deliver(ctx, agent, runtime.Job{
+		ID:          job.ID,
+		AgentName:   agent.Name,
+		Action:      job.Type,
+		Prompt:      prompt,
+		Repository:  payload.Repo,
+		PullRequest: payload.PullRequest,
+	})
+	if strings.TrimSpace(result.Summary) != "" {
+		return result.Summary, err
+	}
+	return result.Raw, err
+}
+
+func (m Mailbox) finish(ctx context.Context, jobID string, state JobState, message string) error {
+	transitioned, err := m.Store.TransitionJobStateWithEvent(ctx, jobID, string(JobRunning), string(state), db.JobEvent{
+		JobID:   jobID,
+		Kind:    string(state),
+		Message: message,
+	})
+	if err != nil {
+		return err
+	}
+	if !transitioned {
+		latest, getErr := m.Store.GetJob(ctx, jobID)
+		if getErr != nil {
+			return getErr
+		}
+		return fmt.Errorf("job %q is %s, not running", jobID, latest.State)
+	}
+	return nil
+}
+
+func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobState, message string, payload JobPayload) error {
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		return err
+	}
+	transitioned, err := m.Store.TransitionJobStatePayloadWithEvent(ctx, jobID, string(JobRunning), string(state), encoded, db.JobEvent{
+		JobID:   jobID,
+		Kind:    string(state),
+		Message: message,
+	})
+	if err != nil {
+		return err
+	}
+	if !transitioned {
+		latest, getErr := m.Store.GetJob(ctx, jobID)
+		if getErr != nil {
+			return getErr
+		}
+		return fmt.Errorf("job %q is %s, not running", jobID, latest.State)
+	}
+	return nil
+}
+
+func (m Mailbox) ensureRunning(ctx context.Context, jobID string) error {
+	latest, err := m.Store.GetJob(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if latest.State != string(JobRunning) {
+		return fmt.Errorf("job %q is %s, not running", jobID, latest.State)
+	}
+	return nil
+}
+
+func (m Mailbox) claim(ctx context.Context, job db.Job) error {
+	if job.State != string(JobQueued) {
+		return fmt.Errorf("job %q is %s, not queued", job.ID, job.State)
+	}
+	claimed, err := m.Store.TransitionJobStateWithEvent(ctx, job.ID, string(JobQueued), string(JobRunning), db.JobEvent{
+		JobID:   job.ID,
+		Kind:    string(JobRunning),
+		Message: "job started",
+	})
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		latest, getErr := m.Store.GetJob(ctx, job.ID)
+		if getErr != nil {
+			return getErr
+		}
+		return fmt.Errorf("job %q is %s, not queued", job.ID, latest.State)
+	}
+	return nil
+}
+
+func (m Mailbox) fail(ctx context.Context, jobID string, message string) error {
+	return m.finish(ctx, jobID, JobFailed, message)
+}
+
+func (m Mailbox) addEvent(ctx context.Context, jobID string, kind string, message string) error {
+	return m.Store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: kind, Message: message})
+}
+
+func (m Mailbox) savePayload(ctx context.Context, jobID string, payload JobPayload) error {
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		return err
+	}
+	return m.Store.UpdateJobPayload(ctx, jobID, encoded)
+}
+
+func (p JobPayload) prompt(action string) prompts.JobPrompt {
+	return prompts.JobPrompt{
+		Repo:         p.Repo,
+		Branch:       p.Branch,
+		PullRequest:  p.PullRequest,
+		Task:         taskLabel(p.TaskID, p.TaskTitle),
+		Sender:       p.Sender,
+		Action:       action,
+		Instructions: p.Instructions,
+		Constraints:  p.Constraints,
+	}
+}
+
+func validateJobRequest(request JobRequest) error {
+	switch {
+	case strings.TrimSpace(request.ID) == "":
+		return errors.New("job id is required")
+	case strings.TrimSpace(request.Agent) == "":
+		return errors.New("job agent is required")
+	case strings.TrimSpace(request.Action) == "":
+		return errors.New("job action is required")
+	case strings.TrimSpace(request.Repo) == "":
+		return errors.New("job repo is required")
+	}
+	return nil
+}
+
+func marshalPayload(payload JobPayload) (string, error) {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func unmarshalPayload(value string) (JobPayload, error) {
+	var payload JobPayload
+	if err := json.Unmarshal([]byte(value), &payload); err != nil {
+		return JobPayload{}, fmt.Errorf("parse job payload: %w", err)
+	}
+	return payload, nil
+}
+
+func taskLabel(id string, title string) string {
+	id = strings.TrimSpace(id)
+	title = strings.TrimSpace(title)
+	switch {
+	case id == "":
+		return title
+	case title == "":
+		return id
+	default:
+		return id + ": " + title
+	}
+}
+
+func compactStrings(values []string) []string {
+	compacted := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			compacted = append(compacted, value)
+		}
+	}
+	return compacted
+}

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -1,0 +1,317 @@
+package workflow
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+func TestMailboxEnqueueCreatesQueuedJobAndEvent(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+
+	job, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:          "job-1",
+		Agent:       "audit",
+		Action:      "review",
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-005",
+		PullRequest: 5,
+		TaskID:      "task-5",
+		TaskTitle:   "Job Mailbox",
+		Sender:      "octocat",
+		Constraints: []string{"  preserve behavior  ", ""},
+	})
+
+	if err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if job.State != string(JobQueued) {
+		t.Fatalf("state = %q, want queued", job.State)
+	}
+	stored, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.Payload == "" || !strings.Contains(stored.Payload, `"repo":"jerryfane/gitmoot"`) {
+		t.Fatalf("payload = %q", stored.Payload)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "queued" {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestMailboxRunStoresResultAndSucceeds(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["mailbox"],"tests_run":["go test ./..."],"needs":[],"next_agents":[]}}`,
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "implement", Repo: "jerryfane/gitmoot", Branch: "task-005", PullRequest: 5}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	result, err := mailbox.Run(ctx, "job-1", agent, adapter)
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Decision != "implemented" {
+		t.Fatalf("decision = %q", result.Decision)
+	}
+	stored, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(JobSucceeded) {
+		t.Fatalf("state = %q, want succeeded", stored.State)
+	}
+	if !strings.Contains(stored.Payload, `"result"`) || !strings.Contains(stored.Payload, `"raw_outputs"`) {
+		t.Fatalf("payload = %q", stored.Payload)
+	}
+	if len(adapter.prompts) != 1 || !strings.Contains(adapter.prompts[0], "Required output") {
+		t.Fatalf("prompts = %+v", adapter.prompts)
+	}
+}
+
+func TestMailboxRunUsesAdapterSummaryWhenAvailable(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ClaudeRuntime, RuntimeRef: runtime.LastRef, RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{
+		outputs: []string{`{"result":"wrapped by runtime"}`},
+		summaries: []string{
+			`{"gitmoot_result":{"decision":"approved","summary":"parsed from summary","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		},
+	}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	result, err := mailbox.Run(ctx, "job-1", agent, adapter)
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Summary != "parsed from summary" {
+		t.Fatalf("summary = %q", result.Summary)
+	}
+	if len(adapter.prompts) != 1 {
+		t.Fatalf("deliveries = %d, want 1", len(adapter.prompts))
+	}
+}
+
+func TestMailboxRunRetriesMalformedOutputOnce(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		"review complete, no json",
+		`{"gitmoot_result":{"decision":"approved","summary":"clean after repair","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	result, err := mailbox.Run(ctx, "job-1", agent, adapter)
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Summary != "clean after repair" {
+		t.Fatalf("summary = %q", result.Summary)
+	}
+	if len(adapter.prompts) != 2 {
+		t.Fatalf("deliveries = %d, want 2", len(adapter.prompts))
+	}
+	if !strings.Contains(adapter.prompts[1], "Previous raw output") {
+		t.Fatalf("repair prompt = %s", adapter.prompts[1])
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !hasEvent(events, "malformed_output") || !hasEvent(events, "repair_retry") {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestMailboxRunMarksBlockedDecision(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"blocked","summary":"needs credentials","findings":[],"changes_made":[],"tests_run":[],"needs":["GITHUB_TOKEN"],"next_agents":[]}}`,
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	stored, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(JobBlocked) {
+		t.Fatalf("state = %q, want blocked", stored.State)
+	}
+}
+
+func TestMailboxRunRejectsNonQueuedJob(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"should not run","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if err := store.UpdateJobState(ctx, "job-1", string(JobCancelled)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err == nil {
+		t.Fatal("Run accepted a non-queued job")
+	}
+	if len(adapter.prompts) != 0 {
+		t.Fatalf("adapter was called for non-queued job: %+v", adapter.prompts)
+	}
+	stored, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(JobCancelled) {
+		t.Fatalf("state = %q, want cancelled", stored.State)
+	}
+	if strings.Contains(stored.Payload, `"result"`) {
+		t.Fatalf("cancelled job stored final result payload: %s", stored.Payload)
+	}
+}
+
+func TestMailboxRunPreservesCancellationDuringDelivery(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{
+		outputs: []string{
+			`{"gitmoot_result":{"decision":"approved","summary":"completed after cancellation","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		},
+		onDeliver: func() {
+			if err := store.UpdateJobState(ctx, "job-1", string(JobCancelled)); err != nil {
+				t.Fatalf("UpdateJobState returned error: %v", err)
+			}
+		},
+	}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err == nil {
+		t.Fatal("Run completed a job cancelled during delivery")
+	}
+	stored, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(JobCancelled) {
+		t.Fatalf("state = %q, want cancelled", stored.State)
+	}
+}
+
+func TestMailboxRunSkipsRepairAfterCancellation(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{
+		outputs: []string{"malformed"},
+		onDeliver: func() {
+			if err := store.UpdateJobState(ctx, "job-1", string(JobCancelled)); err != nil {
+				t.Fatalf("UpdateJobState returned error: %v", err)
+			}
+		},
+	}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err == nil {
+		t.Fatal("Run repaired a job cancelled after malformed output")
+	}
+	if len(adapter.prompts) != 1 {
+		t.Fatalf("deliveries = %d, want 1", len(adapter.prompts))
+	}
+	stored, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(JobCancelled) {
+		t.Fatalf("state = %q, want cancelled", stored.State)
+	}
+}
+
+func openTestStore(t *testing.T) *db.Store {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	return store
+}
+
+func hasEvent(events []db.JobEvent, kind string) bool {
+	for _, event := range events {
+		if event.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+type fakeDelivery struct {
+	outputs   []string
+	summaries []string
+	prompts   []string
+	onDeliver func()
+}
+
+func (f *fakeDelivery) Deliver(_ context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	f.prompts = append(f.prompts, job.Prompt)
+	if f.onDeliver != nil {
+		f.onDeliver()
+	}
+	index := len(f.prompts) - 1
+	result := runtime.Result{}
+	if index >= len(f.outputs) {
+		return result, nil
+	}
+	result.Raw = f.outputs[index]
+	if index < len(f.summaries) {
+		result.Summary = f.summaries[index]
+	}
+	return result, nil
+}

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -1,0 +1,153 @@
+package workflow
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const resultKey = `"gitmoot_result"`
+
+type AgentResult struct {
+	Decision    string            `json:"decision"`
+	Summary     string            `json:"summary"`
+	Findings    []json.RawMessage `json:"findings"`
+	ChangesMade []string          `json:"changes_made"`
+	TestsRun    []string          `json:"tests_run"`
+	Needs       []string          `json:"needs"`
+	NextAgents  []string          `json:"next_agents"`
+}
+
+func ExtractAgentResult(output string) (AgentResult, error) {
+	var validationErr error
+	for _, candidate := range jsonObjectCandidates(output) {
+		var envelope map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(candidate), &envelope); err != nil {
+			continue
+		}
+		raw, ok := envelope["gitmoot_result"]
+		if !ok {
+			continue
+		}
+		var result AgentResult
+		if err := json.Unmarshal(raw, &result); err != nil {
+			if validationErr == nil {
+				validationErr = err
+			}
+			continue
+		}
+		if err := validateAgentResult(result); err != nil {
+			if validationErr == nil {
+				validationErr = err
+			}
+			continue
+		}
+		normalizeAgentResult(&result)
+		return result, nil
+	}
+	if validationErr != nil {
+		return AgentResult{}, validationErr
+	}
+	return AgentResult{}, errors.New("missing valid gitmoot_result JSON object")
+}
+
+func validateAgentResult(result AgentResult) error {
+	switch result.Decision {
+	case "approved", "changes_requested", "blocked", "implemented", "failed":
+	default:
+		return fmt.Errorf("unsupported gitmoot_result decision %q", result.Decision)
+	}
+	if strings.TrimSpace(result.Summary) == "" {
+		return errors.New("gitmoot_result summary is required")
+	}
+	return nil
+}
+
+func normalizeAgentResult(result *AgentResult) {
+	if result.Findings == nil {
+		result.Findings = []json.RawMessage{}
+	}
+	if result.ChangesMade == nil {
+		result.ChangesMade = []string{}
+	}
+	if result.TestsRun == nil {
+		result.TestsRun = []string{}
+	}
+	if result.Needs == nil {
+		result.Needs = []string{}
+	}
+	if result.NextAgents == nil {
+		result.NextAgents = []string{}
+	}
+}
+
+func stateForDecision(decision string) JobState {
+	switch decision {
+	case "blocked":
+		return JobBlocked
+	case "failed":
+		return JobFailed
+	default:
+		return JobSucceeded
+	}
+}
+
+func jsonObjectCandidates(output string) []string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil
+	}
+
+	candidates := make([]string, 0, 2)
+	if strings.HasPrefix(output, "{") && strings.Contains(output, resultKey) {
+		candidates = append(candidates, output)
+	}
+
+	for start := 0; start < len(output); start++ {
+		if output[start] != '{' {
+			continue
+		}
+		if candidate, ok := balancedJSONObject(output[start:]); ok && strings.Contains(candidate, resultKey) {
+			candidates = append(candidates, candidate)
+		}
+	}
+	return candidates
+}
+
+func balancedJSONObject(input string) (string, bool) {
+	depth := 0
+	inString := false
+	escaped := false
+
+	for index := 0; index < len(input); index++ {
+		char := input[index]
+		if inString {
+			switch {
+			case escaped:
+				escaped = false
+			case char == '\\':
+				escaped = true
+			case char == '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch char {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return input[:index+1], true
+			}
+			if depth < 0 {
+				return "", false
+			}
+		}
+	}
+	return "", false
+}

--- a/internal/workflow/result_test.go
+++ b/internal/workflow/result_test.go
@@ -1,0 +1,62 @@
+package workflow
+
+import "testing"
+
+func TestExtractAgentResultFromFencedOutput(t *testing.T) {
+	output := "done\n```json\n" +
+		`{"gitmoot_result":{"decision":"approved","summary":"looks good","findings":[],"changes_made":[],"tests_run":["go test ./..."],"needs":[],"next_agents":[]}}` +
+		"\n```"
+
+	result, err := ExtractAgentResult(output)
+
+	if err != nil {
+		t.Fatalf("ExtractAgentResult returned error: %v", err)
+	}
+	if result.Decision != "approved" || result.Summary != "looks good" {
+		t.Fatalf("result = %+v", result)
+	}
+	if len(result.TestsRun) != 1 || result.TestsRun[0] != "go test ./..." {
+		t.Fatalf("tests_run = %+v", result.TestsRun)
+	}
+}
+
+func TestExtractAgentResultRejectsMalformedOutput(t *testing.T) {
+	if _, err := ExtractAgentResult("plain text without contract"); err == nil {
+		t.Fatal("ExtractAgentResult accepted output without gitmoot_result")
+	}
+}
+
+func TestExtractAgentResultNormalizesMissingArrays(t *testing.T) {
+	output := `{"gitmoot_result":{"decision":"approved","summary":"minimal"}}`
+
+	result, err := ExtractAgentResult(output)
+
+	if err != nil {
+		t.Fatalf("ExtractAgentResult returned error: %v", err)
+	}
+	if result.Findings == nil || result.ChangesMade == nil || result.TestsRun == nil || result.Needs == nil || result.NextAgents == nil {
+		t.Fatalf("result arrays were not normalized: %+v", result)
+	}
+}
+
+func TestExtractAgentResultSkipsDecoyJSONCandidate(t *testing.T) {
+	output := `{"note":"mentions gitmoot_result but is not the envelope"}` + "\n" +
+		`{"gitmoot_result":{"decision":"approved","summary":"real result","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`
+
+	result, err := ExtractAgentResult(output)
+
+	if err != nil {
+		t.Fatalf("ExtractAgentResult returned error: %v", err)
+	}
+	if result.Summary != "real result" {
+		t.Fatalf("summary = %q", result.Summary)
+	}
+}
+
+func TestExtractAgentResultRejectsUnsupportedDecision(t *testing.T) {
+	output := `{"gitmoot_result":{"decision":"maybe","summary":"unclear","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`
+
+	if _, err := ExtractAgentResult(output); err == nil {
+		t.Fatal("ExtractAgentResult accepted unsupported decision")
+	}
+}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -6,6 +6,17 @@ const (
 	TaskPlanned TaskState = "planned"
 )
 
+type JobState string
+
+const (
+	JobQueued    JobState = "queued"
+	JobRunning   JobState = "running"
+	JobBlocked   JobState = "blocked"
+	JobFailed    JobState = "failed"
+	JobSucceeded JobState = "succeeded"
+	JobCancelled JobState = "cancelled"
+)
+
 type Task struct {
 	ID     string
 	Title  string


### PR DESCRIPTION
WHAT: Added the local job mailbox and normalized agent prompt/result contract.

WHY: Gitmoot needs a local queue that can persist jobs, deliver structured prompts through runtime adapters, parse agent results consistently, and preserve a reliable SQLite state machine before the PR-comment daemon starts dispatching work.

CHANGES:
- Added typed job states for queued, running, blocked, failed, succeeded, and cancelled jobs.
- Added DB helpers for job lookup, payload updates, event listing, and atomic job/event state transitions.
- Added structured job and repair prompt rendering with the required `gitmoot_result` output shape.
- Added result extraction for `gitmoot_result` JSON blocks, including fenced/mixed output handling and normalized array fields.
- Added a workflow mailbox that enqueues jobs, atomically claims queued jobs, delivers prompts, retries malformed output once, stores raw output, and completes only from running state.
- Added cancellation/race-oriented tests so cancelled jobs are not re-run, repaired, or completed after cancellation.

RESULTS:
- `go test ./internal/workflow ./internal/prompts ./internal/db`
- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/workflow`
- `git diff --cached --check && git diff --check`
- `codex exec review --uncommitted` final raw output:

```text
No correctness issues were found in the staged changes, and the relevant test and vet checks pass.
No correctness issues were found in the staged changes, and the relevant test and vet checks pass.
```

RISK:
- No GitHub Actions CI is currently configured for this repository, so local checks are the gating evidence.
- Task 5 intentionally stops at the local mailbox and contract layer; daemon polling and PR comment dispatch are Task 6.
