### PR TITLE
Task 6: Daemon and PR comment routing

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/daemon"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+func runDaemon(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printDaemonUsage(stdout)
+		return 0
+	}
+	if args[0] != "start" {
+		fmt.Fprintf(stderr, "unknown daemon command %q\n\n", args[0])
+		printDaemonUsage(stderr)
+		return 2
+	}
+	return runDaemonStart(args[1:], stdout, stderr)
+}
+
+func printDaemonUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot daemon start --repo owner/repo --poll 30s")
+}
+
+func runDaemonStart(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("daemon start", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repoFlag := fs.String("repo", "", "GitHub repository as owner/repo")
+	poll := fs.Duration("poll", 30*time.Second, "poll interval")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "daemon start does not accept positional arguments")
+		return 2
+	}
+	repo, err := daemon.ParseRepository(*repoFlag)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+		return 2
+	}
+	if *poll <= 0 {
+		fmt.Fprintln(stderr, "poll interval must be positive")
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	err = withStore(*home, func(store *db.Store) error {
+		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
+		return (daemon.Daemon{
+			Repo:         repo,
+			PollInterval: *poll,
+			Store:        store,
+			GitHub:       github.NewClient("."),
+		}).Run(ctx)
+	})
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return 0
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "daemon start: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunDaemonUsageAndValidation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"daemon", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("daemon help exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "gitmoot daemon start") {
+		t.Fatalf("daemon help output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"daemon", "start", "--repo", "not-a-repo"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("daemon start invalid repo exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "invalid repo") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"daemon", "start", "--repo", "jerryfane/gitmoot", "--poll", "0s"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("daemon start invalid poll exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "poll interval must be positive") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,7 +23,7 @@ type command struct {
 var rootCommands = []command{
 	{name: "init", summary: "initialize local Gitmoot state", run: runInit},
 	{name: "doctor", summary: "check local Gitmoot prerequisites", run: runDoctor},
-	{name: "daemon", summary: "run the local PR watcher", run: notImplemented("daemon")},
+	{name: "daemon", summary: "run the local PR watcher", run: runDaemon},
 	{name: "agent", summary: "manage registered agents", run: runAgent},
 	{name: "status", summary: "show local workflow status", run: notImplemented("status")},
 	{name: "goal", summary: "import or inspect goals", run: notImplemented("goal")},

--- a/internal/daemon/command.go
+++ b/internal/daemon/command.go
@@ -1,0 +1,71 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Command struct {
+	Action       string
+	Agent        string
+	Instructions string
+}
+
+func ParseCommands(body string) []Command {
+	var commands []Command
+	for _, line := range strings.Split(body, "\n") {
+		command, ok := ParseCommand(line)
+		if ok {
+			commands = append(commands, command)
+		}
+	}
+	return commands
+}
+
+func ParseCommand(line string) (Command, bool) {
+	fields := strings.Fields(strings.TrimSpace(line))
+	if len(fields) == 0 || fields[0] != "/gitmoot" {
+		return Command{}, false
+	}
+	if len(fields) == 1 {
+		return Command{}, false
+	}
+
+	switch fields[1] {
+	case "status", "merge":
+		return Command{Action: fields[1], Instructions: trailing(fields, 2)}, true
+	case "ask":
+		if len(fields) < 3 {
+			return Command{}, false
+		}
+		return Command{Action: "ask", Agent: cleanAgent(fields[2]), Instructions: trailing(fields, 3)}, true
+	default:
+		if len(fields) < 3 {
+			return Command{}, false
+		}
+		return Command{Action: fields[2], Agent: cleanAgent(fields[1]), Instructions: trailing(fields, 3)}, true
+	}
+}
+
+func (c Command) Validate() error {
+	switch c.Action {
+	case "review", "implement", "ask", "status", "merge":
+	default:
+		return fmt.Errorf("unsupported command action %q", c.Action)
+	}
+	if c.Action != "status" && c.Action != "merge" && c.Agent == "" {
+		return fmt.Errorf("command %q requires an agent", c.Action)
+	}
+	return nil
+}
+
+func cleanAgent(agent string) string {
+	return strings.TrimPrefix(strings.TrimSpace(agent), "@")
+}
+
+func trailing(fields []string, start int) string {
+	if len(fields) <= start {
+		return ""
+	}
+	return strings.Join(fields[start:], " ")
+}

--- a/internal/daemon/command_test.go
+++ b/internal/daemon/command_test.go
@@ -1,0 +1,47 @@
+package daemon
+
+import "testing"
+
+func TestParseCommandAgentFirstActions(t *testing.T) {
+	command, ok := ParseCommand("/gitmoot audit review check the branch")
+	if !ok {
+		t.Fatal("ParseCommand did not parse review command")
+	}
+	if command.Agent != "audit" || command.Action != "review" || command.Instructions != "check the branch" {
+		t.Fatalf("command = %+v", command)
+	}
+
+	command, ok = ParseCommand("/gitmoot @builder implement fix tests")
+	if !ok {
+		t.Fatal("ParseCommand did not parse implement command")
+	}
+	if command.Agent != "builder" || command.Action != "implement" || command.Instructions != "fix tests" {
+		t.Fatalf("command = %+v", command)
+	}
+}
+
+func TestParseCommandAskAgentShape(t *testing.T) {
+	command, ok := ParseCommand("/gitmoot ask reviewer what failed?")
+	if !ok {
+		t.Fatal("ParseCommand did not parse ask command")
+	}
+	if command.Agent != "reviewer" || command.Action != "ask" || command.Instructions != "what failed?" {
+		t.Fatalf("command = %+v", command)
+	}
+}
+
+func TestParseCommandsOnlyReturnsGitmootLines(t *testing.T) {
+	commands := ParseCommands("hello\n/gitmoot status\n/gitmoot merge when ready\nthanks")
+	if len(commands) != 2 {
+		t.Fatalf("commands length = %d, want 2", len(commands))
+	}
+	if commands[0].Action != "status" || commands[1].Action != "merge" || commands[1].Instructions != "when ready" {
+		t.Fatalf("commands = %+v", commands)
+	}
+}
+
+func TestValidateRejectsUnsupportedCommand(t *testing.T) {
+	if err := (Command{Action: "deploy", Agent: "audit"}).Validate(); err == nil {
+		t.Fatal("Validate accepted unsupported action")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,10 +1,280 @@
 package daemon
 
-import "context"
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"strconv"
+	"strings"
+	"time"
 
-type Daemon struct{}
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
 
-func (Daemon) Run(ctx context.Context) error {
-	<-ctx.Done()
-	return ctx.Err()
+const defaultPollInterval = 30 * time.Second
+
+type Daemon struct {
+	Repo         github.Repository
+	PollInterval time.Duration
+	Store        *db.Store
+	GitHub       github.Client
+	Sleep        func(context.Context, time.Duration) error
+}
+
+func (d Daemon) Run(ctx context.Context) error {
+	interval := d.PollInterval
+	if interval == 0 {
+		interval = defaultPollInterval
+	}
+	if interval < 0 {
+		return fmt.Errorf("poll interval must be positive")
+	}
+	if err := d.validate(); err != nil {
+		return err
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_ = d.PollOnce(ctx)
+		if err := d.sleep(ctx, interval); err != nil {
+			return err
+		}
+	}
+}
+
+func (d Daemon) PollOnce(ctx context.Context) error {
+	if err := d.validate(); err != nil {
+		return err
+	}
+
+	pulls, err := d.GitHub.ListPullRequests(ctx, d.Repo, "open")
+	if err != nil {
+		return err
+	}
+	for _, pull := range pulls {
+		if err := d.recordPullRequest(ctx, pull); err != nil {
+			return err
+		}
+		comments, err := d.GitHub.ListIssueComments(ctx, d.Repo, pull.Number)
+		if err != nil {
+			return err
+		}
+		for _, comment := range comments {
+			if err := d.handleComment(ctx, pull, comment); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (d Daemon) validate() error {
+	if d.Store == nil {
+		return errors.New("daemon store is required")
+	}
+	if d.GitHub == nil {
+		return errors.New("daemon github client is required")
+	}
+	if d.Repo.FullName() == "" {
+		return errors.New("daemon repo is required")
+	}
+	return nil
+}
+
+func (d Daemon) recordPullRequest(ctx context.Context, pull github.PullRequest) error {
+	return d.Store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: d.Repo.FullName(),
+		Number:       pull.Number,
+		URL:          pull.URL,
+		HeadBranch:   pull.HeadRef,
+		BaseBranch:   pull.BaseRef,
+		State:        pull.State,
+	})
+}
+
+func (d Daemon) handleComment(ctx context.Context, pull github.PullRequest, comment github.IssueComment) error {
+	commands := ParseCommands(comment.Body)
+	if len(commands) == 0 {
+		return nil
+	}
+
+	seen, err := d.Store.HasCommentSeen(ctx, d.Repo.FullName(), comment.ID)
+	if err != nil {
+		return err
+	}
+	if seen {
+		return nil
+	}
+
+	authorized, err := d.authorizeCommenter(ctx, comment.Author)
+	if err != nil {
+		return err
+	}
+	if !authorized {
+		if err := d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot ignored comment %d from `%s`: `/gitmoot` commands require write, maintain, or admin repository permission.", comment.ID, comment.Author)); err != nil {
+			return err
+		}
+		return d.markCommentSeen(ctx, pull, comment)
+	}
+
+	for sequence, command := range commands {
+		if err := d.handleCommand(ctx, pull, comment, sequence, command); err != nil {
+			return err
+		}
+	}
+	return d.markCommentSeen(ctx, pull, comment)
+}
+
+func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comment github.IssueComment, sequence int, command Command) error {
+	if err := command.Validate(); err != nil {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not route comment %d: %v.", comment.ID, err))
+	}
+	if command.Action == "status" || command.Action == "merge" {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot recognized `/gitmoot %s`, but that command is not implemented in this task yet.", command.Action))
+	}
+
+	agent, err := d.Store.GetAgent(ctx, command.Agent)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not find subscribed agent `%s` for this repository.", command.Agent))
+		}
+		return err
+	}
+	if agent.RepoScope != d.Repo.FullName() {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot agent `%s` is subscribed for `%s`, not `%s`.", agent.Name, agent.RepoScope, d.Repo.FullName()))
+	}
+	if !hasCapability(agent.Capabilities, command.Action) {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot agent `%s` does not advertise `%s` capability.", agent.Name, command.Action))
+	}
+
+	job, created, err := d.enqueueJob(ctx, workflow.JobRequest{
+		ID:           jobID(d.Repo, pull.Number, comment.ID, sequence, command.Agent, command.Action),
+		Agent:        agent.Name,
+		Action:       command.Action,
+		Repo:         d.Repo.FullName(),
+		Branch:       pull.HeadRef,
+		PullRequest:  int(pull.Number),
+		TaskID:       fmt.Sprintf("pr-%d-comment-%d", pull.Number, comment.ID),
+		TaskTitle:    pull.Title,
+		Sender:       comment.Author,
+		Instructions: command.Instructions,
+		Constraints: []string{
+			"Respond using the gitmoot_result JSON contract.",
+			"Keep the work scoped to the pull request and requested action.",
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	if created {
+		if err := d.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "routed",
+			Message: fmt.Sprintf("routed from PR #%d comment %d by %s", pull.Number, comment.ID, comment.Author),
+		}); err != nil {
+			return err
+		}
+	}
+	return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot queued `%s` job `%s` for `%s`.", command.Action, job.ID, agent.Name))
+}
+
+func (d Daemon) authorizeCommenter(ctx context.Context, author string) (bool, error) {
+	if strings.TrimSpace(author) == "" {
+		return false, nil
+	}
+	permission, err := d.GitHub.GetUserPermission(ctx, d.Repo, author)
+	if err != nil {
+		return false, err
+	}
+	return hasWritePermission(permission.Permission), nil
+}
+
+func hasWritePermission(permission string) bool {
+	switch permission {
+	case "admin", "maintain", "write":
+		return true
+	default:
+		return false
+	}
+}
+
+func (d Daemon) enqueueJob(ctx context.Context, request workflow.JobRequest) (db.Job, bool, error) {
+	existing, err := d.Store.GetJob(ctx, request.ID)
+	if err == nil {
+		return existing, false, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return db.Job{}, false, err
+	}
+	job, err := (workflow.Mailbox{Store: d.Store}).Enqueue(ctx, request)
+	return job, true, err
+}
+
+func (d Daemon) markCommentSeen(ctx context.Context, pull github.PullRequest, comment github.IssueComment) error {
+	_, err := d.Store.MarkCommentSeenIfNew(ctx, db.Comment{
+		RepoFullName: d.Repo.FullName(),
+		CommentID:    comment.ID,
+		PullRequest:  pull.Number,
+		Body:         comment.Body,
+	})
+	return err
+}
+
+func (d Daemon) ack(ctx context.Context, issueNumber int64, body string) error {
+	_, err := d.GitHub.PostIssueComment(ctx, d.Repo, issueNumber, body)
+	return err
+}
+
+func (d Daemon) sleep(ctx context.Context, duration time.Duration) error {
+	if d.Sleep != nil {
+		return d.Sleep(ctx, duration)
+	}
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func hasCapability(capabilities []string, target string) bool {
+	for _, capability := range capabilities {
+		if capability == target {
+			return true
+		}
+	}
+	return false
+}
+
+func jobID(repo github.Repository, pullNumber, commentID int64, sequence int, agent, action string) string {
+	hash := fnv.New64a()
+	_, _ = hash.Write([]byte(repo.FullName()))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(strconv.FormatInt(pullNumber, 10)))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(strconv.FormatInt(commentID, 10)))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(strconv.Itoa(sequence)))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(agent))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(action))
+	return "pr-comment-" + strconv.FormatUint(hash.Sum64(), 36)
+}
+
+func ParseRepository(value string) (github.Repository, error) {
+	parts := strings.Split(strings.TrimSpace(value), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return github.Repository{}, fmt.Errorf("repo must be owner/repo")
+	}
+	return github.Repository{Owner: parts[0], Name: parts[1]}, nil
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,0 +1,461 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func TestPollOnceCreatesJobAndAcknowledgement(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{
+			7: {{ID: 101, Body: "/gitmoot audit review focus on tests", Author: "alice"}},
+		},
+	}
+
+	err := (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 1 {
+		t.Fatalf("posted acknowledgements = %+v, want 1", client.posted)
+	}
+	if !strings.Contains(client.posted[0].body, "queued `review` job") || !strings.Contains(client.posted[0].body, "`audit`") {
+		t.Fatalf("ack body = %q", client.posted[0].body)
+	}
+
+	jobID := jobID(repo, 7, 101, 0, "audit", "review")
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.Agent != "audit" || job.Type != "review" || job.State != string(workflow.JobQueued) {
+		t.Fatalf("job = %+v", job)
+	}
+	var payload workflow.JobPayload
+	if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Repo != repo.FullName() || payload.Branch != "task-7" || payload.PullRequest != 7 || payload.Sender != "alice" || payload.Instructions != "focus on tests" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	events, err := store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if len(events) != 2 || events[0].Kind != string(workflow.JobQueued) || events[1].Kind != "routed" {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestPollOnceDedupesSeenComments(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 3, Title: "Task 3", State: "open", HeadRef: "task-3", BaseRef: "main"}},
+		comments: map[int64][]github.IssueComment{
+			3: {{ID: 202, Body: "/gitmoot audit review", Author: "bob"}},
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("first PollOnce returned error: %v", err)
+	}
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("second PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 1 {
+		t.Fatalf("posted acknowledgements = %+v, want one after duplicate poll", client.posted)
+	}
+}
+
+func TestPollOnceQueuesRepeatedCommandsInOneComment(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 6, Title: "Task 6", State: "open", HeadRef: "task-6", BaseRef: "main"}},
+		comments: map[int64][]github.IssueComment{
+			6: {{ID: 505, Body: "/gitmoot audit review first\n/gitmoot audit review second", Author: "erin"}},
+		},
+	}
+
+	err := (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 2 {
+		t.Fatalf("posted acknowledgements = %+v, want 2", client.posted)
+	}
+	for sequence := 0; sequence < 2; sequence++ {
+		if _, err := store.GetJob(ctx, jobID(repo, 6, 505, sequence, "audit", "review")); err != nil {
+			t.Fatalf("GetJob for sequence %d returned error: %v", sequence, err)
+		}
+	}
+}
+
+func TestPollOnceAcknowledgesUnknownAgentWithoutJob(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 4, Title: "Task 4", State: "open", HeadRef: "task-4", BaseRef: "main"}},
+		comments: map[int64][]github.IssueComment{
+			4: {{ID: 303, Body: "/gitmoot missing review", Author: "carol"}},
+		},
+	}
+
+	err := (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "could not find subscribed agent `missing`") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+	if _, err := store.GetJob(ctx, jobID(repo, 4, 303, 0, "missing", "review")); err == nil {
+		t.Fatal("unknown agent created a job")
+	}
+}
+
+func TestPollOnceRejectsUnauthorizedCommenter(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		permissions: map[string]string{"mallory": "read"},
+		pulls:       []github.PullRequest{{Number: 8, Title: "Task 8", State: "open", HeadRef: "task-8", BaseRef: "main"}},
+		comments: map[int64][]github.IssueComment{
+			8: {{ID: 606, Body: "/gitmoot audit review", Author: "mallory"}},
+		},
+	}
+
+	err := (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "ignored comment 606") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+	if _, err := store.GetJob(ctx, jobID(repo, 8, 606, 0, "audit", "review")); err == nil {
+		t.Fatal("unauthorized commenter created a job")
+	}
+	seen, err := store.HasCommentSeen(ctx, repo.FullName(), 606)
+	if err != nil {
+		t.Fatalf("HasCommentSeen returned error: %v", err)
+	}
+	if !seen {
+		t.Fatal("unauthorized command was not marked seen after acknowledgement")
+	}
+}
+
+func TestPollOnceAcknowledgesMissingCapabilityWithoutJob(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "builder",
+		Role:           "builder",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 5, Title: "Task 5", State: "open", HeadRef: "task-5", BaseRef: "main"}},
+		comments: map[int64][]github.IssueComment{
+			5: {{ID: 404, Body: "/gitmoot builder review", Author: "dana"}},
+		},
+	}
+
+	err := (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "does not advertise `review` capability") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+}
+
+func TestPollOnceRetriesUnseenCommentAfterAckFailure(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		postErrs: []error{errors.New("temporary ack failure")},
+		pulls:    []github.PullRequest{{Number: 9, Title: "Task 9", State: "open", HeadRef: "task-9", BaseRef: "main"}},
+		comments: map[int64][]github.IssueComment{
+			9: {{ID: 707, Body: "/gitmoot audit review", Author: "frank"}},
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client}
+
+	if err := daemon.PollOnce(ctx); err == nil {
+		t.Fatal("first PollOnce succeeded despite acknowledgement failure")
+	}
+	seen, err := store.HasCommentSeen(ctx, repo.FullName(), 707)
+	if err != nil {
+		t.Fatalf("HasCommentSeen returned error: %v", err)
+	}
+	if seen {
+		t.Fatal("comment was marked seen before acknowledgement succeeded")
+	}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("second PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 2 {
+		t.Fatalf("posted acknowledgements = %+v, want 2 attempts", client.posted)
+	}
+	events, err := store.ListJobEvents(ctx, jobID(repo, 9, 707, 0, "audit", "review"))
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %+v, want original queue+routed only", events)
+	}
+}
+
+func TestRunReturnsOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := testStore(t)
+	client := &fakeGitHub{}
+	daemon := Daemon{
+		Repo:         github.Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Store:        store,
+		GitHub:       client,
+		PollInterval: time.Hour,
+		Sleep: func(ctx context.Context, _ time.Duration) error {
+			cancel()
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	err := daemon.Run(ctx)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context.Canceled", err)
+	}
+	if client.listPullRequestsCalls != 1 {
+		t.Fatalf("ListPullRequests calls = %d, want 1", client.listPullRequestsCalls)
+	}
+}
+
+func TestRunContinuesAfterPollError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := testStore(t)
+	client := &fakeGitHub{listPullRequestsErrs: []error{errors.New("rate limited"), nil}}
+	var sleeps int
+	daemon := Daemon{
+		Repo:         github.Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Store:        store,
+		GitHub:       client,
+		PollInterval: time.Second,
+		Sleep: func(ctx context.Context, _ time.Duration) error {
+			sleeps++
+			if sleeps == 1 {
+				return nil
+			}
+			cancel()
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	err := daemon.Run(ctx)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context.Canceled", err)
+	}
+	if client.listPullRequestsCalls != 2 {
+		t.Fatalf("ListPullRequests calls = %d, want 2", client.listPullRequestsCalls)
+	}
+}
+
+func testStore(t *testing.T) *db.Store {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	return store
+}
+
+type fakeGitHub struct {
+	pulls                 []github.PullRequest
+	comments              map[int64][]github.IssueComment
+	posted                []postedComment
+	permissions           map[string]string
+	postErrs              []error
+	listPullRequestsCalls int
+	listPullRequestsErrs  []error
+}
+
+type postedComment struct {
+	issueNumber int64
+	body        string
+}
+
+func (f *fakeGitHub) Ping(context.Context) error {
+	return nil
+}
+
+func (f *fakeGitHub) ListPullRequests(context.Context, github.Repository, string) ([]github.PullRequest, error) {
+	f.listPullRequestsCalls++
+	if len(f.listPullRequestsErrs) > 0 {
+		err := f.listPullRequestsErrs[0]
+		f.listPullRequestsErrs = f.listPullRequestsErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return append([]github.PullRequest(nil), f.pulls...), nil
+}
+
+func (f *fakeGitHub) CreatePullRequest(context.Context, github.CreatePullRequestInput) (github.PullRequest, error) {
+	return github.PullRequest{}, errors.New("not implemented")
+}
+
+func (f *fakeGitHub) ListIssueComments(_ context.Context, _ github.Repository, issueNumber int64) ([]github.IssueComment, error) {
+	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
+}
+
+func (f *fakeGitHub) PostIssueComment(_ context.Context, _ github.Repository, issueNumber int64, body string) (github.IssueComment, error) {
+	f.posted = append(f.posted, postedComment{issueNumber: issueNumber, body: body})
+	if len(f.postErrs) > 0 {
+		err := f.postErrs[0]
+		f.postErrs = f.postErrs[1:]
+		if err != nil {
+			return github.IssueComment{}, err
+		}
+	}
+	return github.IssueComment{ID: int64(len(f.posted)), Body: body}, nil
+}
+
+func (f *fakeGitHub) GetUserPermission(_ context.Context, _ github.Repository, username string) (github.UserPermission, error) {
+	permission := "write"
+	if f.permissions != nil {
+		permission = f.permissions[username]
+	}
+	return github.UserPermission{Permission: permission, RoleName: permission}, nil
+}
+
+func (f *fakeGitHub) MergePullRequest(context.Context, github.MergePullRequestInput) (github.MergeResult, error) {
+	return github.MergeResult{}, errors.New("not implemented")
+}
+
+func (f *fakeGitHub) GetCombinedStatus(context.Context, github.Repository, string) (github.CombinedStatus, error) {
+	return github.CombinedStatus{}, errors.New("not implemented")
+}
+
+func (f *fakeGitHub) ListPullRequestChecks(context.Context, github.Repository, int64) ([]github.PullRequestCheck, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeGitHub) CreateCommitStatus(context.Context, github.CommitStatusInput) (github.CommitStatus, error) {
+	return github.CommitStatus{}, errors.New("not implemented")
+}
+
+func (f *fakeGitHub) ListPullRequestFiles(context.Context, github.Repository, int64) ([]github.PullRequestFile, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeGitHub) ListPullRequestCommits(context.Context, github.Repository, int64) ([]github.PullRequestCommit, error) {
+	return nil, errors.New("not implemented")
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -264,6 +264,25 @@ func (s *Store) MarkCommentSeen(ctx context.Context, comment Comment) error {
 	return err
 }
 
+func (s *Store) HasCommentSeen(ctx context.Context, repoFullName string, commentID int64) (bool, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM seen_comments WHERE repo_full_name = ? AND comment_id = ?`, repoFullName, commentID).Scan(&count)
+	return count > 0, err
+}
+
+func (s *Store) MarkCommentSeenIfNew(ctx context.Context, comment Comment) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO seen_comments(repo_full_name, comment_id, pull_request, body)
+		VALUES (?, ?, ?, ?)`, comment.RepoFullName, comment.CommentID, comment.PullRequest, comment.Body)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
+}
+
 func (s *Store) CreateJob(ctx context.Context, job Job) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, updated_at)
 		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`, job.ID, job.Agent, job.Type, job.State, job.Payload)

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -93,6 +93,27 @@ func TestRepositoryMethods(t *testing.T) {
 	if err := store.MarkCommentSeen(ctx, Comment{RepoFullName: "jerryfane/gitmoot", CommentID: 100, PullRequest: 1, Body: "/gitmoot audit review"}); err != nil {
 		t.Fatalf("MarkCommentSeen returned error: %v", err)
 	}
+	seen, err := store.HasCommentSeen(ctx, "jerryfane/gitmoot", 100)
+	if err != nil {
+		t.Fatalf("HasCommentSeen returned error: %v", err)
+	}
+	if !seen {
+		t.Fatal("HasCommentSeen did not find marked comment")
+	}
+	isNew, err := store.MarkCommentSeenIfNew(ctx, Comment{RepoFullName: "jerryfane/gitmoot", CommentID: 101, PullRequest: 1, Body: "/gitmoot audit review again"})
+	if err != nil {
+		t.Fatalf("MarkCommentSeenIfNew returned error: %v", err)
+	}
+	if !isNew {
+		t.Fatal("MarkCommentSeenIfNew did not report new comment")
+	}
+	isNew, err = store.MarkCommentSeenIfNew(ctx, Comment{RepoFullName: "jerryfane/gitmoot", CommentID: 101, PullRequest: 1, Body: "/gitmoot audit review again"})
+	if err != nil {
+		t.Fatalf("duplicate MarkCommentSeenIfNew returned error: %v", err)
+	}
+	if isNew {
+		t.Fatal("MarkCommentSeenIfNew reported duplicate comment as new")
+	}
 	if err := store.CreateJob(ctx, Job{ID: "job-1", Agent: "audit", Type: "review", State: "queued"}); err != nil {
 		t.Fatalf("CreateJob returned error: %v", err)
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -19,6 +19,7 @@ type Client interface {
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
 	ListIssueComments(ctx context.Context, repo Repository, issueNumber int64) ([]IssueComment, error)
 	PostIssueComment(ctx context.Context, repo Repository, issueNumber int64, body string) (IssueComment, error)
+	GetUserPermission(ctx context.Context, repo Repository, username string) (UserPermission, error)
 	MergePullRequest(ctx context.Context, input MergePullRequestInput) (MergeResult, error)
 	GetCombinedStatus(ctx context.Context, repo Repository, ref string) (CombinedStatus, error)
 	ListPullRequestChecks(ctx context.Context, repo Repository, number int64) ([]PullRequestCheck, error)
@@ -87,6 +88,11 @@ type IssueComment struct {
 	Author    string
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
+}
+
+type UserPermission struct {
+	Permission string `json:"permission"`
+	RoleName   string `json:"role_name"`
 }
 
 func (c *IssueComment) UnmarshalJSON(data []byte) error {
@@ -235,6 +241,21 @@ func (c *GhClient) PostIssueComment(ctx context.Context, repo Repository, issueN
 	var comment IssueComment
 	err := c.apiJSON(ctx, true, &comment, endpoint(repo, "issues", issueNumber, "comments"), "-f", "body="+body)
 	return comment, err
+}
+
+func (c *GhClient) GetUserPermission(ctx context.Context, repo Repository, username string) (UserPermission, error) {
+	var permission UserPermission
+	result, err := c.run(ctx, false, "api", endpoint(repo, "collaborators", username, "permission"))
+	if err != nil {
+		if isNotFound(result) {
+			return UserPermission{Permission: "none"}, nil
+		}
+		return UserPermission{}, err
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &permission); err != nil {
+		return UserPermission{}, fmt.Errorf("decode gh api response: %w", err)
+	}
+	return permission, nil
 }
 
 func (c *GhClient) MergePullRequest(ctx context.Context, input MergePullRequestInput) (MergeResult, error) {
@@ -418,6 +439,11 @@ func isRateLimit(result subprocess.Result) bool {
 	return strings.Contains(text, "rate limit") || strings.Contains(text, "retry-after") || strings.Contains(text, "http 429")
 }
 
+func isNotFound(result subprocess.Result) bool {
+	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	return strings.Contains(text, "http 404") || strings.Contains(text, "not found")
+}
+
 func isNoChecks(result subprocess.Result) bool {
 	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
 	return strings.Contains(text, "no checks reported")
@@ -474,6 +500,10 @@ func (NoopClient) ListIssueComments(context.Context, Repository, int64) ([]Issue
 
 func (NoopClient) PostIssueComment(context.Context, Repository, int64, string) (IssueComment, error) {
 	return IssueComment{}, errors.ErrUnsupported
+}
+
+func (NoopClient) GetUserPermission(context.Context, Repository, string) (UserPermission, error) {
+	return UserPermission{}, errors.ErrUnsupported
 }
 
 func (NoopClient) MergePullRequest(context.Context, MergePullRequestInput) (MergeResult, error) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -60,6 +60,42 @@ func TestPostIssueCommentUsesIssueCommentsEndpoint(t *testing.T) {
 	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/issues/2/comments", "-f", "body=done")
 }
 
+func TestGetUserPermissionUsesCollaboratorPermissionEndpoint(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"permission": "write", "role_name": "write"}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	permission, err := client.GetUserPermission(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, "alice")
+
+	if err != nil {
+		t.Fatalf("GetUserPermission returned error: %v", err)
+	}
+	if permission.Permission != "write" || permission.RoleName != "write" {
+		t.Fatalf("permission = %+v", permission)
+	}
+	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/collaborators/alice/permission")
+}
+
+func TestGetUserPermissionMapsNotFoundToNone(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "HTTP 404: Not Found"}},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	client := GhClient{Runner: runner}
+
+	permission, err := client.GetUserPermission(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, "mallory")
+
+	if err != nil {
+		t.Fatalf("GetUserPermission returned error: %v", err)
+	}
+	if permission.Permission != "none" {
+		t.Fatalf("permission = %+v, want none", permission)
+	}
+}
+
 func TestCreateCommitStatusUsesStatusesEndpoint(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{


### PR DESCRIPTION
WHAT:
- Added `gitmoot daemon start --repo owner/repo --poll 30s`.
- Added PR comment polling, `/gitmoot` command parsing, agent routing, acknowledgement comments, and SQLite dedupe/state tracking.

WHY:
- Task 6 needs the local daemon to watch GitHub PR comments and turn valid tagged agent commands into queued Gitmoot jobs.

CHANGES:
- Wired the daemon CLI command and signal-aware long-running loop.
- Added daemon command parsing for `review`, `implement`, `ask`, `status`, and `merge` forms.
- Added GitHub collaborator permission checks before routing commands.
- Added idempotent comment processing so transient acknowledgement failures retry without duplicate job events.
- Added SQLite helpers for comment seen checks and insert-if-new behavior.
- Added GitHub client support for repository user permission lookup.
- Added fake GitHub tests for polling, dedupe, command parsing, unknown agents, authorization, acknowledgement comments, job creation, and shutdown behavior.

RESULTS:
- `go test ./internal/daemon ./internal/github ./internal/db ./internal/cli`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:
```text
No discrete correctness issues were found in the current staged, unstaged, or untracked changes. The daemon routing, parsing, GitHub permission checks, persistence additions, and tests appear consistent, and `go test ./...` plus `go vet ./...` pass.
No discrete correctness issues were found in the current staged, unstaged, or untracked changes. The daemon routing, parsing, GitHub permission checks, persistence additions, and tests appear consistent, and `go test ./...` plus `go vet ./...` pass.
```

RISK:
- No skipped required checks.
- `/gitmoot status` and `/gitmoot merge` are parsed and acknowledged but their full behavior is deferred to later tasks.