### PR TITLE
feat: add autonomous workflow engine

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
 func runDaemon(args []string, stdout, stderr io.Writer) int {
@@ -64,12 +65,14 @@ func runDaemonStart(args []string, stdout, stderr io.Writer) int {
 	defer stop()
 
 	err = withStore(*home, func(store *db.Store) error {
+		engine := workflow.Engine{Store: store}
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
 		return (daemon.Daemon{
 			Repo:         repo,
 			PollInterval: *poll,
 			Store:        store,
 			GitHub:       github.NewClient("."),
+			Workflow:     &engine,
 		}).Run(ctx)
 	})
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -22,6 +23,7 @@ type Daemon struct {
 	PollInterval time.Duration
 	Store        *db.Store
 	GitHub       github.Client
+	Workflow     *workflow.Engine
 	Sleep        func(context.Context, time.Duration) error
 }
 
@@ -53,13 +55,28 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 		return err
 	}
 
+	var firstErr error
 	pulls, err := d.GitHub.ListPullRequests(ctx, d.Repo, "open")
 	if err != nil {
 		return err
 	}
 	for _, pull := range pulls {
-		if err := d.recordPullRequest(ctx, pull); err != nil {
+		changed, err := d.pullRequestChanged(ctx, pull)
+		if err != nil {
 			return err
+		}
+		if changed {
+			if err := d.handlePullRequestWorkflow(ctx, pull); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				changed = false
+			}
+		}
+		if changed {
+			if err := d.recordPullRequest(ctx, pull); err != nil {
+				return err
+			}
 		}
 		comments, err := d.GitHub.ListIssueComments(ctx, d.Repo, pull.Number)
 		if err != nil {
@@ -71,7 +88,7 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 			}
 		}
 	}
-	return nil
+	return firstErr
 }
 
 func (d Daemon) validate() error {
@@ -87,6 +104,53 @@ func (d Daemon) validate() error {
 	return nil
 }
 
+func (d Daemon) pullRequestChanged(ctx context.Context, pull github.PullRequest) (bool, error) {
+	previous, err := d.Store.GetPullRequest(ctx, d.Repo.FullName(), pull.Number)
+	switch {
+	case err == nil:
+		if strings.TrimSpace(previous.HeadSHA) == "" {
+			routed, err := d.pullRequestWorkflowRouted(ctx, pull)
+			if err != nil {
+				return false, err
+			}
+			if routed {
+				return false, d.recordPullRequest(ctx, pull)
+			}
+			return true, nil
+		}
+		return previous.HeadSHA != pull.HeadSHA, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return true, nil
+	default:
+		return false, err
+	}
+}
+
+func (d Daemon) pullRequestWorkflowRouted(ctx context.Context, pull github.PullRequest) (bool, error) {
+	jobs, err := d.Store.ListJobs(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		var payload workflow.JobPayload
+		if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
+			return false, fmt.Errorf("parse job payload %q: %w", job.ID, err)
+		}
+		if payload.Repo == d.Repo.FullName() &&
+			payload.PullRequest == int(pull.Number) &&
+			payload.Branch == pull.HeadRef &&
+			strings.TrimSpace(payload.LeadAgent) != "" &&
+			strings.TrimSpace(payload.ReviewRound) != "" &&
+			len(payload.Reviewers) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (d Daemon) recordPullRequest(ctx context.Context, pull github.PullRequest) error {
 	return d.Store.UpsertPullRequest(ctx, db.PullRequest{
 		RepoFullName: d.Repo.FullName(),
@@ -94,8 +158,81 @@ func (d Daemon) recordPullRequest(ctx context.Context, pull github.PullRequest) 
 		URL:          pull.URL,
 		HeadBranch:   pull.HeadRef,
 		BaseBranch:   pull.BaseRef,
+		HeadSHA:      pull.HeadSHA,
 		State:        pull.State,
 	})
+}
+
+func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullRequest) error {
+	if d.Workflow == nil {
+		return nil
+	}
+	lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+	ref := workflowTaskRef{
+		id:     pull.HeadRef,
+		title:  pull.Title,
+		branch: pull.HeadRef,
+	}
+	if task, err := d.lookupPullRequestTask(ctx, pull.HeadRef); err == nil {
+		ref.id = task.ID
+		ref.goalID = task.GoalID
+		ref.title = task.Title
+		if task.Branch != "" {
+			ref.branch = task.Branch
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	reviewers, err := d.workflowReviewers(ctx)
+	if err != nil {
+		return err
+	}
+	return d.Workflow.HandlePullRequestOpened(ctx, workflow.PullRequestEvent{
+		Repo:              d.Repo.FullName(),
+		Branch:            ref.branch,
+		PullRequest:       int(pull.Number),
+		HeadSHA:           pull.HeadSHA,
+		GoalID:            ref.goalID,
+		TaskID:            ref.id,
+		TaskTitle:         ref.title,
+		LeadAgent:         lock.Owner,
+		Sender:            "github",
+		RequiredReviewers: reviewers,
+	})
+}
+
+func (d Daemon) lookupPullRequestTask(ctx context.Context, branch string) (db.Task, error) {
+	task, err := d.Store.GetTaskByBranch(ctx, branch)
+	if err == nil {
+		return task, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return db.Task{}, err
+	}
+	return d.Store.GetTask(ctx, branch)
+}
+
+func (d Daemon) workflowReviewers(ctx context.Context) ([]string, error) {
+	if d.Workflow != nil && len(d.Workflow.RequiredReviewers) > 0 {
+		return append([]string{}, d.Workflow.RequiredReviewers...), nil
+	}
+	agents, err := d.Store.ListAgents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	reviewers := []string{}
+	for _, agent := range agents {
+		if agent.RepoScope == d.Repo.FullName() && hasCapability(agent.Capabilities, "review") {
+			reviewers = append(reviewers, agent.Name)
+		}
+	}
+	return reviewers, nil
 }
 
 func (d Daemon) handleComment(ctx context.Context, pull github.PullRequest, comment github.IssueComment) error {
@@ -244,6 +381,13 @@ func (d Daemon) sleep(ctx context.Context, duration time.Duration) error {
 	case <-timer.C:
 		return nil
 	}
+}
+
+type workflowTaskRef struct {
+	id     string
+	goalID string
+	title  string
+	branch string
 }
 
 func hasCapability(capabilities []string, target string) bool {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -81,6 +81,428 @@ func TestPollOnceCreatesJobAndAcknowledgement(t *testing.T) {
 	}
 }
 
+func TestPollOnceRoutesPullRequestUpdatesToWorkflow(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Role:           "lead",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-007", GoalID: "goal-1", Title: "Task 7", State: string(workflow.TaskPlanned), Branch: "task-7"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	engine := workflow.Engine{
+		Store: store,
+		JobID: func(request workflow.JobRequest) string {
+			parts := []string{request.Action, request.Agent, request.TaskID}
+			if request.ReviewRound != "" {
+				parts = append(parts, request.ReviewRound)
+			}
+			return strings.Join(parts, "-")
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("first PollOnce returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "review-audit-task-007-review-1"); err != nil {
+		t.Fatalf("GetJob first review round returned error: %v", err)
+	}
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("second PollOnce returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "review-audit-task-007-review-2"); err == nil {
+		t.Fatal("unchanged pull request head created a second review round")
+	}
+
+	client.pulls[0].HeadSHA = "def456"
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("third PollOnce returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "review-audit-task-007-review-2"); err != nil {
+		t.Fatalf("GetJob second review round returned error: %v", err)
+	}
+}
+
+func TestPollOnceRetriesPullRequestWorkflowAfterRoutingFailure(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Role:           "lead",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{
+			7: {{ID: 707, Body: "/gitmoot lead implement handle manual fallback", Author: "alice"}},
+		},
+	}
+	engine := workflow.Engine{
+		Store:             store,
+		RequiredReviewers: []string{"audit"},
+		JobID: func(request workflow.JobRequest) string {
+			parts := []string{request.Action, request.Agent, request.TaskID}
+			if request.ReviewRound != "" {
+				parts = append(parts, request.ReviewRound)
+			}
+			return strings.Join(parts, "-")
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err == nil {
+		t.Fatal("PollOnce succeeded despite missing required reviewer")
+	}
+	if _, err := store.GetPullRequest(ctx, repo.FullName(), 7); err == nil {
+		t.Fatal("pull request head was recorded before workflow routing succeeded")
+	}
+	if _, err := store.GetJob(ctx, jobID(repo, 7, 707, 0, "lead", "implement")); err != nil {
+		t.Fatalf("manual comment job was not routed after workflow failure: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("retry PollOnce returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "review-audit-task-7-review-1"); err != nil {
+		t.Fatalf("GetJob retry review round returned error: %v", err)
+	}
+	if pr, err := store.GetPullRequest(ctx, repo.FullName(), 7); err != nil || pr.HeadSHA != "abc123" {
+		t.Fatalf("stored pull request after retry = %+v err=%v", pr, err)
+	}
+}
+
+func TestPollOnceRecordsAlreadyRoutedPullRequestWithoutDuplicateReviewRound(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Role:           "lead",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		LeadAgent:   "lead",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-1",
+	})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID:      "review-audit-task-7-review-1",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(workflow.JobQueued),
+		Payload: string(payload),
+	}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "already routed by engine"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       7,
+		HeadBranch:   "task-7",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	engine := workflow.Engine{
+		Store: store,
+		JobID: func(request workflow.JobRequest) string {
+			parts := []string{request.Action, request.Agent, request.TaskID}
+			if request.ReviewRound != "" {
+				parts = append(parts, request.ReviewRound)
+			}
+			return strings.Join(parts, "-")
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "review-audit-task-7-review-2"); err == nil {
+		t.Fatal("already routed pull request created a duplicate review round")
+	}
+	if pr, err := store.GetPullRequest(ctx, repo.FullName(), 7); err != nil || pr.HeadSHA != "abc123" {
+		t.Fatalf("stored pull request = %+v err=%v", pr, err)
+	}
+}
+
+func TestPollOnceRoutesPullRequestWithEmptyStoredHeadSHA(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Role:           "lead",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       7,
+		HeadBranch:   "task-7",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	engine := workflow.Engine{
+		Store: store,
+		JobID: func(request workflow.JobRequest) string {
+			parts := []string{request.Action, request.Agent, request.TaskID}
+			if request.ReviewRound != "" {
+				parts = append(parts, request.ReviewRound)
+			}
+			return strings.Join(parts, "-")
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "review-audit-task-7-review-1"); err != nil {
+		t.Fatalf("GetJob review round returned error: %v", err)
+	}
+	if pr, err := store.GetPullRequest(ctx, repo.FullName(), 7); err != nil || pr.HeadSHA != "abc123" {
+		t.Fatalf("stored pull request = %+v err=%v", pr, err)
+	}
+}
+
+func TestPollOnceDoesNotTreatManualReviewJobAsWorkflowRoute(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Role:           "lead",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	manualPayload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Task 7",
+		Sender:      "alice",
+	})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID:      "manual-review-job",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(workflow.JobQueued),
+		Payload: string(manualPayload),
+	}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "manual review"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       7,
+		HeadBranch:   "task-7",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	engine := workflow.Engine{
+		Store: store,
+		JobID: func(request workflow.JobRequest) string {
+			parts := []string{request.Action, request.Agent, request.TaskID}
+			if request.ReviewRound != "" {
+				parts = append(parts, request.ReviewRound)
+			}
+			return strings.Join(parts, "-")
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "review-audit-task-7-review-2"); err != nil {
+		t.Fatalf("GetJob workflow review round returned error: %v", err)
+	}
+	if pr, err := store.GetPullRequest(ctx, repo.FullName(), 7); err != nil || pr.HeadSHA != "abc123" {
+		t.Fatalf("stored pull request = %+v err=%v", pr, err)
+	}
+}
+
 func TestPollOnceDedupesSeenComments(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -54,6 +54,7 @@ type PullRequest struct {
 	URL          string
 	HeadBranch   string
 	BaseBranch   string
+	HeadSHA      string
 	State        string
 }
 
@@ -245,17 +246,47 @@ func (s *Store) UpsertTask(ctx context.Context, task Task) error {
 	return err
 }
 
+func (s *Store) GetTask(ctx context.Context, id string) (Task, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, goal_id, title, state, branch FROM tasks WHERE id = ?`, id)
+	var task Task
+	if err := row.Scan(&task.ID, &task.GoalID, &task.Title, &task.State, &task.Branch); err != nil {
+		return Task{}, err
+	}
+	return task, nil
+}
+
+func (s *Store) GetTaskByBranch(ctx context.Context, branch string) (Task, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, goal_id, title, state, branch
+		FROM tasks WHERE branch = ? ORDER BY updated_at DESC, id LIMIT 1`, branch)
+	var task Task
+	if err := row.Scan(&task.ID, &task.GoalID, &task.Title, &task.State, &task.Branch); err != nil {
+		return Task{}, err
+	}
+	return task, nil
+}
+
 func (s *Store) UpsertPullRequest(ctx context.Context, pr PullRequest) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO pull_requests(repo_full_name, number, url, head_branch, base_branch, state, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO pull_requests(repo_full_name, number, url, head_branch, base_branch, head_sha, state, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(repo_full_name, number) DO UPDATE SET
 			url = excluded.url,
 			head_branch = excluded.head_branch,
 			base_branch = excluded.base_branch,
+			head_sha = excluded.head_sha,
 			state = excluded.state,
 			updated_at = CURRENT_TIMESTAMP`,
-		pr.RepoFullName, pr.Number, pr.URL, pr.HeadBranch, pr.BaseBranch, pr.State)
+		pr.RepoFullName, pr.Number, pr.URL, pr.HeadBranch, pr.BaseBranch, pr.HeadSHA, pr.State)
 	return err
+}
+
+func (s *Store) GetPullRequest(ctx context.Context, repoFullName string, number int64) (PullRequest, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, number, url, head_branch, base_branch, head_sha, state
+		FROM pull_requests WHERE repo_full_name = ? AND number = ?`, repoFullName, number)
+	var pr PullRequest
+	if err := row.Scan(&pr.RepoFullName, &pr.Number, &pr.URL, &pr.HeadBranch, &pr.BaseBranch, &pr.HeadSHA, &pr.State); err != nil {
+		return PullRequest{}, err
+	}
+	return pr, nil
 }
 
 func (s *Store) MarkCommentSeen(ctx context.Context, comment Comment) error {
@@ -316,6 +347,24 @@ func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
 		return Job{}, err
 	}
 	return job, nil
+}
+
+func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload FROM jobs ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobs []Job
+	for rows.Next() {
+		var job Job
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload); err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
 }
 
 func (s *Store) UpdateJobState(ctx context.Context, id string, state string) error {
@@ -440,6 +489,15 @@ func (s *Store) AcquireLock(ctx context.Context, lock BranchLock) (bool, error) 
 		return false, err
 	}
 	return owner == lock.Owner, nil
+}
+
+func (s *Store) GetBranchLock(ctx context.Context, repoFullName string, branch string) (BranchLock, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, branch, owner FROM branch_locks WHERE repo_full_name = ? AND branch = ?`, repoFullName, branch)
+	var lock BranchLock
+	if err := row.Scan(&lock.RepoFullName, &lock.Branch, &lock.Owner); err != nil {
+		return BranchLock{}, err
+	}
+	return lock, nil
 }
 
 func (s *Store) UpsertMergeGate(ctx context.Context, gate MergeGate) error {
@@ -596,5 +654,8 @@ CREATE TABLE merge_gates (
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	UNIQUE(repo_full_name, pull_request)
 );
+`,
+	`
+ALTER TABLE pull_requests ADD COLUMN head_sha TEXT NOT NULL DEFAULT '';
 `,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -80,15 +80,22 @@ func TestRepositoryMethods(t *testing.T) {
 	if err := store.UpsertTask(ctx, Task{ID: "task-1", GoalID: "goal-2", Title: "Bootstrap", State: "planned"}); err != nil {
 		t.Fatalf("second UpsertTask returned error: %v", err)
 	}
-	var goalID string
-	if err := store.db.QueryRowContext(ctx, `SELECT goal_id FROM tasks WHERE id = ?`, "task-1").Scan(&goalID); err != nil {
-		t.Fatalf("query task goal_id: %v", err)
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
 	}
-	if goalID != "goal-2" {
-		t.Fatalf("goal_id = %q, want goal-2", goalID)
+	if task.GoalID != "goal-2" {
+		t.Fatalf("task goal_id = %q, want goal-2", task.GoalID)
 	}
-	if err := store.UpsertPullRequest(ctx, PullRequest{RepoFullName: "jerryfane/gitmoot", Number: 1, URL: "https://github.com/jerryfane/gitmoot/pull/1", HeadBranch: "task", BaseBranch: "main", State: "open"}); err != nil {
+	if err := store.UpsertPullRequest(ctx, PullRequest{RepoFullName: "jerryfane/gitmoot", Number: 1, URL: "https://github.com/jerryfane/gitmoot/pull/1", HeadBranch: "task", BaseBranch: "main", HeadSHA: "abc123", State: "open"}); err != nil {
 		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	pr, err := store.GetPullRequest(ctx, "jerryfane/gitmoot", 1)
+	if err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+	if pr.HeadSHA != "abc123" {
+		t.Fatalf("pull request head sha = %q, want abc123", pr.HeadSHA)
 	}
 	if err := store.MarkCommentSeen(ctx, Comment{RepoFullName: "jerryfane/gitmoot", CommentID: 100, PullRequest: 1, Body: "/gitmoot audit review"}); err != nil {
 		t.Fatalf("MarkCommentSeen returned error: %v", err)
@@ -123,6 +130,13 @@ func TestRepositoryMethods(t *testing.T) {
 	}
 	if job.State != "queued" {
 		t.Fatalf("job state = %q, want queued", job.State)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ID != "job-1" {
+		t.Fatalf("jobs = %+v", jobs)
 	}
 	if err := store.UpdateJobState(ctx, "job-1", "running"); err != nil {
 		t.Fatalf("UpdateJobState returned error: %v", err)
@@ -208,6 +222,13 @@ func TestRepositoryMethods(t *testing.T) {
 	}
 	if !acquired {
 		t.Fatal("same-owner AcquireLock did not return acquired")
+	}
+	lock, err := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.Owner != "lead" {
+		t.Fatalf("lock owner = %q, want lead", lock.Owner)
 	}
 	acquired, err = store.AcquireLock(ctx, BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task", Owner: "other"})
 	if err != nil {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1,0 +1,688 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"strconv"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+type Engine struct {
+	Store             *db.Store
+	RequiredReviewers []string
+	MergeGate         MergeGate
+	JobID             func(JobRequest) string
+}
+
+type PullRequestEvent struct {
+	Repo              string
+	Branch            string
+	PullRequest       int
+	HeadSHA           string
+	GoalID            string
+	TaskID            string
+	TaskTitle         string
+	LeadAgent         string
+	Sender            string
+	RequiredReviewers []string
+}
+
+type MergeRequest struct {
+	Repo        string
+	Branch      string
+	PullRequest int
+	TaskID      string
+	Reviewer    string
+}
+
+type MergeDecision struct {
+	Ready  bool
+	Reason string
+}
+
+type MergeGate interface {
+	Evaluate(ctx context.Context, request MergeRequest) (MergeDecision, error)
+}
+
+type BlockedError struct {
+	Reason string
+}
+
+func (e BlockedError) Error() string {
+	return "workflow blocked: " + e.Reason
+}
+
+func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEvent) error {
+	if err := e.validate(); err != nil {
+		return err
+	}
+	if err := validatePullRequestEvent(event); err != nil {
+		return err
+	}
+	ref := taskRefFromPullRequest(event)
+	if err := e.setTaskState(ctx, ref, TaskPullRequestOpen); err != nil {
+		return err
+	}
+	if err := e.ensureAgentAllowed(ctx, JobRequest{
+		Agent:  event.LeadAgent,
+		Action: "implement",
+		Repo:   event.Repo,
+		Branch: event.Branch,
+	}, ref); err != nil {
+		return err
+	}
+	reviewers := compactStrings(append([]string{}, event.RequiredReviewers...))
+	if len(reviewers) == 0 {
+		reviewers = compactStrings(append([]string{}, e.RequiredReviewers...))
+	}
+	if len(reviewers) == 0 {
+		if err := e.runMergeGate(ctx, "", JobPayload{
+			Repo:        event.Repo,
+			Branch:      event.Branch,
+			PullRequest: event.PullRequest,
+			GoalID:      event.GoalID,
+			TaskID:      event.TaskID,
+			TaskTitle:   event.TaskTitle,
+			LeadAgent:   event.LeadAgent,
+		}, ref); err != nil {
+			return err
+		}
+		return e.recordPullRequestBaseline(ctx, event)
+	}
+	reviewRound, err := e.nextReviewRound(ctx, event)
+	if err != nil {
+		return err
+	}
+	requests := make([]JobRequest, 0, len(reviewers))
+	for _, reviewer := range reviewers {
+		request := JobRequest{
+			Agent:       reviewer,
+			Action:      "review",
+			Repo:        event.Repo,
+			Branch:      event.Branch,
+			PullRequest: event.PullRequest,
+			GoalID:      event.GoalID,
+			TaskID:      event.TaskID,
+			TaskTitle:   event.TaskTitle,
+			LeadAgent:   event.LeadAgent,
+			Reviewers:   reviewers,
+			ReviewRound: reviewRound,
+			Sender:      event.Sender,
+			Instructions: fmt.Sprintf(
+				"Review pull request #%d for task %s.",
+				event.PullRequest,
+				taskLabel(event.TaskID, event.TaskTitle),
+			),
+		}
+		requests = append(requests, request)
+	}
+	for _, request := range requests {
+		if err := e.ensureAgentAllowed(ctx, request, ref); err != nil {
+			return err
+		}
+	}
+	for _, request := range requests {
+		if err := e.enqueue(ctx, request); err != nil {
+			return err
+		}
+	}
+	if err := e.setTaskState(ctx, ref, TaskReviewing); err != nil {
+		return err
+	}
+	return e.recordPullRequestBaseline(ctx, event)
+}
+
+func (e Engine) RunJob(ctx context.Context, jobID string, agent runtime.Agent, adapter DeliveryAdapter) (AgentResult, error) {
+	if err := e.validate(); err != nil {
+		return AgentResult{}, err
+	}
+	job, payload, err := e.jobPayload(ctx, jobID)
+	if err != nil {
+		return AgentResult{}, err
+	}
+	if err := e.ensureAgentAllowed(ctx, JobRequest{
+		Agent:  job.Agent,
+		Action: job.Type,
+		Repo:   payload.Repo,
+		Branch: payload.Branch,
+	}, taskRefFromPayload(payload)); err != nil {
+		return AgentResult{}, err
+	}
+	result, err := (Mailbox{Store: e.Store}).Run(ctx, jobID, agent, adapter)
+	if err != nil {
+		return result, err
+	}
+	if err := e.AdvanceJob(ctx, jobID); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
+	if err := e.validate(); err != nil {
+		return err
+	}
+	job, payload, err := e.jobPayload(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if payload.Result == nil {
+		return fmt.Errorf("job %q has no agent result", jobID)
+	}
+	ref := taskRefFromPayload(payload)
+
+	if job.Type == "review" {
+		latest, err := e.latestReviewRound(ctx, payload)
+		if err != nil {
+			return err
+		}
+		if latest != "" && strings.TrimSpace(payload.ReviewRound) != latest {
+			return nil
+		}
+	}
+	if payload.Result.Decision == "blocked" || payload.Result.Decision == "failed" {
+		return e.block(ctx, ref, payload.Result.Summary)
+	}
+	if err := e.dispatchNextAgents(ctx, payload, *payload.Result, ref); err != nil {
+		return err
+	}
+
+	switch job.Type {
+	case "implement":
+		if payload.Result.Decision != "implemented" {
+			return nil
+		}
+		leadAgent := strings.TrimSpace(payload.LeadAgent)
+		if leadAgent == "" {
+			leadAgent = job.Agent
+		}
+		event := PullRequestEvent{
+			Repo:              payload.Repo,
+			Branch:            payload.Branch,
+			PullRequest:       payload.PullRequest,
+			GoalID:            payload.GoalID,
+			TaskID:            payload.TaskID,
+			TaskTitle:         payload.TaskTitle,
+			LeadAgent:         leadAgent,
+			Sender:            job.Agent,
+			RequiredReviewers: e.requiredReviewers(payload),
+		}
+		return e.HandlePullRequestOpened(ctx, event)
+	case "review":
+		switch payload.Result.Decision {
+		case "changes_requested":
+			if err := e.setTaskState(ctx, ref, TaskChangesRequested); err != nil {
+				return err
+			}
+			return e.dispatchFix(ctx, job.Agent, payload, *payload.Result, ref)
+		case "approved":
+			ready, err := e.allRequiredReviewersApproved(ctx, job.Agent, payload)
+			if err != nil {
+				return err
+			}
+			if !ready {
+				return e.setReviewingIfNotChangesRequested(ctx, ref)
+			}
+			return e.runMergeGate(ctx, job.Agent, payload, ref)
+		}
+	}
+	return nil
+}
+
+func (e Engine) jobPayload(ctx context.Context, jobID string) (db.Job, JobPayload, error) {
+	job, err := e.Store.GetJob(ctx, jobID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return db.Job{}, JobPayload{}, fmt.Errorf("job %q not found", jobID)
+		}
+		return db.Job{}, JobPayload{}, err
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		return db.Job{}, JobPayload{}, err
+	}
+	return job, payload, nil
+}
+
+func (e Engine) validate() error {
+	if e.Store == nil {
+		return errors.New("workflow engine store is required")
+	}
+	return nil
+}
+
+func validatePullRequestEvent(event PullRequestEvent) error {
+	switch {
+	case strings.TrimSpace(event.Repo) == "":
+		return errors.New("pull request repo is required")
+	case strings.TrimSpace(event.Branch) == "":
+		return errors.New("pull request branch is required")
+	case event.PullRequest <= 0:
+		return errors.New("pull request number is required")
+	case strings.TrimSpace(event.TaskID) == "":
+		return errors.New("pull request task id is required")
+	case strings.TrimSpace(event.LeadAgent) == "":
+		return errors.New("pull request lead agent is required")
+	}
+	return nil
+}
+
+func (e Engine) dispatchFix(ctx context.Context, reviewer string, payload JobPayload, result AgentResult, ref taskRef) error {
+	leadAgent, err := e.leadAgent(ctx, payload)
+	if err != nil {
+		return err
+	}
+	request := JobRequest{
+		Agent:       leadAgent,
+		Action:      "implement",
+		Repo:        payload.Repo,
+		Branch:      payload.Branch,
+		PullRequest: payload.PullRequest,
+		GoalID:      payload.GoalID,
+		TaskID:      payload.TaskID,
+		TaskTitle:   payload.TaskTitle,
+		LeadAgent:   leadAgent,
+		Reviewers:   e.requiredReviewers(payload),
+		ReviewRound: payload.ReviewRound,
+		Sender:      reviewer,
+		Instructions: fmt.Sprintf(
+			"Address requested changes from %s: %s",
+			reviewer,
+			result.Summary,
+		),
+	}
+	return e.dispatch(ctx, request, ref)
+}
+
+func (e Engine) leadAgent(ctx context.Context, payload JobPayload) (string, error) {
+	leadAgent := strings.TrimSpace(payload.LeadAgent)
+	if leadAgent != "" {
+		return leadAgent, nil
+	}
+	lock, err := e.Store.GetBranchLock(ctx, payload.Repo, payload.Branch)
+	if err == nil {
+		return lock.Owner, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", errors.New("lead agent is required")
+	}
+	return "", err
+}
+
+func (e Engine) dispatchNextAgents(ctx context.Context, payload JobPayload, result AgentResult, ref taskRef) error {
+	requests := []JobRequest{}
+	for _, agent := range compactStrings(result.NextAgents) {
+		request := JobRequest{
+			Agent:        agent,
+			Action:       "ask",
+			Repo:         payload.Repo,
+			Branch:       payload.Branch,
+			PullRequest:  payload.PullRequest,
+			GoalID:       payload.GoalID,
+			TaskID:       payload.TaskID,
+			TaskTitle:    payload.TaskTitle,
+			LeadAgent:    payload.LeadAgent,
+			Reviewers:    e.requiredReviewers(payload),
+			ReviewRound:  payload.ReviewRound,
+			Sender:       payload.Sender,
+			Instructions: "Another agent requested your input: " + result.Summary,
+		}
+		requests = append(requests, request)
+	}
+	for _, request := range requests {
+		if err := e.ensureAgentAllowed(ctx, request, ref); err != nil {
+			return err
+		}
+	}
+	for _, request := range requests {
+		if err := e.enqueue(ctx, request); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e Engine) allRequiredReviewersApproved(ctx context.Context, currentReviewer string, payload JobPayload) (bool, error) {
+	required := e.requiredReviewers(payload)
+	if len(required) == 0 {
+		return true, nil
+	}
+
+	approved := map[string]bool{}
+	if currentReviewer != "" {
+		approved[currentReviewer] = true
+	}
+
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		jobPayload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return false, err
+		}
+		if !sameTask(payload, jobPayload) || !sameReviewRound(payload, jobPayload) || jobPayload.Result == nil {
+			continue
+		}
+		if jobPayload.Result.Decision == "approved" {
+			approved[job.Agent] = true
+		}
+	}
+
+	for _, reviewer := range required {
+		if !approved[reviewer] {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (e Engine) setReviewingIfNotChangesRequested(ctx context.Context, ref taskRef) error {
+	if strings.TrimSpace(ref.ID) == "" {
+		return nil
+	}
+	task, err := e.Store.GetTask(ctx, ref.ID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	if err == nil && task.State == string(TaskChangesRequested) {
+		return nil
+	}
+	return e.setTaskState(ctx, ref, TaskReviewing)
+}
+
+func (e Engine) latestReviewRound(ctx context.Context, current JobPayload) (string, error) {
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return "", err
+	}
+	latestRound := ""
+	latestNumber := 0
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return "", err
+		}
+		if !sameTask(current, payload) {
+			continue
+		}
+		round := strings.TrimSpace(payload.ReviewRound)
+		if round == "" {
+			continue
+		}
+		number, ok := reviewRoundNumber(round)
+		if ok && number > latestNumber {
+			latestRound = round
+			latestNumber = number
+			continue
+		}
+		if !ok && latestNumber == 0 && round > latestRound {
+			latestRound = round
+		}
+	}
+	return latestRound, nil
+}
+
+func reviewRoundNumber(round string) (int, bool) {
+	value, ok := strings.CutPrefix(round, "review-")
+	if !ok {
+		return 0, false
+	}
+	number, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, false
+	}
+	return number, true
+}
+
+func (e Engine) requiredReviewers(payload JobPayload) []string {
+	reviewers := compactStrings(append([]string{}, payload.Reviewers...))
+	if len(reviewers) == 0 {
+		reviewers = compactStrings(append([]string{}, e.RequiredReviewers...))
+	}
+	return reviewers
+}
+
+func sameTask(left JobPayload, right JobPayload) bool {
+	if left.Repo != "" && right.Repo != "" && left.Repo != right.Repo {
+		return false
+	}
+	if left.PullRequest > 0 && right.PullRequest > 0 && left.PullRequest != right.PullRequest {
+		return false
+	}
+	if left.TaskID != "" || right.TaskID != "" {
+		return left.TaskID != "" && left.TaskID == right.TaskID
+	}
+	return left.Repo == right.Repo && left.PullRequest == right.PullRequest
+}
+
+func sameReviewRound(left JobPayload, right JobPayload) bool {
+	leftRound := strings.TrimSpace(left.ReviewRound)
+	rightRound := strings.TrimSpace(right.ReviewRound)
+	if leftRound == "" {
+		return rightRound == ""
+	}
+	return leftRound == rightRound
+}
+
+func (e Engine) dispatch(ctx context.Context, request JobRequest, ref taskRef) error {
+	if request.ID == "" {
+		request.ID = e.jobID(request)
+	}
+	if err := e.ensureAgentAllowed(ctx, request, ref); err != nil {
+		return err
+	}
+	return e.enqueue(ctx, request)
+}
+
+func (e Engine) enqueue(ctx context.Context, request JobRequest) error {
+	if request.ID == "" {
+		request.ID = e.jobID(request)
+	}
+	_, err := (Mailbox{Store: e.Store}).Enqueue(ctx, request)
+	return err
+}
+
+func (e Engine) ensureAgentAllowed(ctx context.Context, request JobRequest, ref taskRef) error {
+	agent, err := e.Store.GetAgent(ctx, request.Agent)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return e.block(ctx, ref, fmt.Sprintf("agent %q is not subscribed", request.Agent))
+		}
+		return err
+	}
+	if agent.RepoScope != request.Repo {
+		return e.block(ctx, ref, fmt.Sprintf("agent %q is scoped to %q, not %q", agent.Name, agent.RepoScope, request.Repo))
+	}
+	if !contains(agent.Capabilities, request.Action) {
+		return e.block(ctx, ref, fmt.Sprintf("agent %q lacks %q capability", agent.Name, request.Action))
+	}
+	if request.Action == "implement" {
+		if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, request.Agent, ref); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e Engine) ensureBranchLock(ctx context.Context, repo string, branch string, owner string, ref taskRef) error {
+	if strings.TrimSpace(branch) == "" {
+		return e.block(ctx, ref, "branch lock rejected action: branch is required")
+	}
+	acquired, err := e.Store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo, Branch: branch, Owner: owner})
+	if err != nil {
+		return err
+	}
+	if !acquired {
+		return e.block(ctx, ref, fmt.Sprintf("branch lock rejected action for %s", branch))
+	}
+	return nil
+}
+
+func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPayload, ref taskRef) error {
+	if e.MergeGate == nil {
+		return e.setTaskState(ctx, ref, TaskReadyToMerge)
+	}
+	decision, err := e.MergeGate.Evaluate(ctx, MergeRequest{
+		Repo:        payload.Repo,
+		Branch:      payload.Branch,
+		PullRequest: payload.PullRequest,
+		TaskID:      payload.TaskID,
+		Reviewer:    reviewer,
+	})
+	if err != nil {
+		return err
+	}
+	if !decision.Ready {
+		reason := strings.TrimSpace(decision.Reason)
+		if reason == "" {
+			reason = "merge gate rejected action"
+		}
+		return e.block(ctx, ref, reason)
+	}
+	return e.setTaskState(ctx, ref, TaskReadyToMerge)
+}
+
+func (e Engine) recordPullRequestBaseline(ctx context.Context, event PullRequestEvent) error {
+	if event.PullRequest <= 0 {
+		return nil
+	}
+	return e.Store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: event.Repo,
+		Number:       int64(event.PullRequest),
+		HeadBranch:   event.Branch,
+		HeadSHA:      event.HeadSHA,
+		State:        "open",
+	})
+}
+
+func (e Engine) nextReviewRound(ctx context.Context, event PullRequestEvent) (string, error) {
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return "", err
+	}
+	current := JobPayload{Repo: event.Repo, PullRequest: event.PullRequest, TaskID: event.TaskID}
+	rounds := map[string]bool{}
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return "", err
+		}
+		if !sameTask(current, payload) {
+			continue
+		}
+		round := strings.TrimSpace(payload.ReviewRound)
+		if round == "" {
+			round = job.ID
+		}
+		rounds[round] = true
+	}
+	return "review-" + strconv.Itoa(len(rounds)+1), nil
+}
+
+func (e Engine) block(ctx context.Context, ref taskRef, reason string) error {
+	if err := e.setTaskState(ctx, ref, TaskBlocked); err != nil {
+		return err
+	}
+	return BlockedError{Reason: reason}
+}
+
+func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) error {
+	if strings.TrimSpace(ref.ID) == "" {
+		return nil
+	}
+	task := db.Task{
+		ID:     ref.ID,
+		GoalID: ref.GoalID,
+		Title:  ref.Title,
+		State:  string(state),
+		Branch: ref.Branch,
+	}
+	existing, err := e.Store.GetTask(ctx, ref.ID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	if err == nil {
+		if task.GoalID == "" {
+			task.GoalID = existing.GoalID
+		}
+		if task.Title == "" {
+			task.Title = existing.Title
+		}
+		if task.Branch == "" {
+			task.Branch = existing.Branch
+		}
+	}
+	return e.Store.UpsertTask(ctx, task)
+}
+
+func (e Engine) jobID(request JobRequest) string {
+	if e.JobID != nil {
+		return e.JobID(request)
+	}
+	hash := fnv.New64a()
+	for _, value := range []string{
+		request.Repo,
+		request.Branch,
+		strconv.Itoa(request.PullRequest),
+		request.TaskID,
+		request.Agent,
+		request.Action,
+		request.ReviewRound,
+		request.Instructions,
+	} {
+		_, _ = hash.Write([]byte(value))
+		_, _ = hash.Write([]byte{0})
+	}
+	return "workflow-" + strconv.FormatUint(hash.Sum64(), 36)
+}
+
+type taskRef struct {
+	ID     string
+	GoalID string
+	Title  string
+	Branch string
+}
+
+func taskRefFromPullRequest(event PullRequestEvent) taskRef {
+	return taskRef{
+		ID:     event.TaskID,
+		GoalID: event.GoalID,
+		Title:  event.TaskTitle,
+		Branch: event.Branch,
+	}
+}
+
+func taskRefFromPayload(payload JobPayload) taskRef {
+	return taskRef{
+		ID:     payload.TaskID,
+		GoalID: payload.GoalID,
+		Title:  payload.TaskTitle,
+		Branch: payload.Branch,
+	}
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1,0 +1,1055 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+func TestEngineHandlePullRequestOpenedDispatchesReviewers(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:              "jerryfane/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		GoalID:            "goal-1",
+		TaskID:            "task-7",
+		TaskTitle:         "Workflow Engine",
+		LeadAgent:         "lead",
+		Sender:            "lead",
+		RequiredReviewers: []string{"audit"},
+	})
+
+	if err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+	job := mustJob(t, store, "review-audit-task-7-review-1")
+	if job.Agent != "audit" || job.Type != "review" || job.State != string(JobQueued) {
+		t.Fatalf("review job = %+v", job)
+	}
+	if !strings.Contains(job.Payload, `"lead_agent":"lead"`) {
+		t.Fatalf("payload missing lead agent: %s", job.Payload)
+	}
+	pr, err := store.GetPullRequest(ctx, "jerryfane/gitmoot", 7)
+	if err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+	if pr.HeadBranch != "task-7" || pr.HeadSHA != "" {
+		t.Fatalf("pull request baseline = %+v", pr)
+	}
+}
+
+func TestEngineHandlePullRequestOpenedBlocksOnBranchLock(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-7", Owner: "other"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	engine := testEngine(store)
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+	})
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "branch lock") {
+		t.Fatalf("error = %v, want branch lock BlockedError", err)
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+}
+
+func TestEngineHandlePullRequestOpenedBlocksWhenLeadLacksCapability(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+	})
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "lacks") {
+		t.Fatalf("error = %v, want capability BlockedError", err)
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+}
+
+func TestEngineHandlePullRequestOpenedRunsMergeGateWithoutReviewers(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Reason: "ci is pending"}}
+	engine.MergeGate = gate
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+	})
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || blocked.Reason != "ci is pending" {
+		t.Fatalf("error = %v, want merge gate BlockedError", err)
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+	if len(gate.requests) != 1 || gate.requests[0].Reviewer != "" || gate.requests[0].PullRequest != 7 {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestEngineAdvanceImplementDispatchesReviewers(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RequiredReviewers = []string{"audit"}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-job",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		GoalID:      "goal-1",
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "implemented", Summary: "opened PR"},
+	})
+
+	err := engine.AdvanceJob(ctx, "implement-job")
+
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+	mustJob(t, store, "review-audit-task-7-review-1")
+}
+
+func TestEngineAdvanceImplementDefaultsLeadAgent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RequiredReviewers = []string{"audit"}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-job",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Result:      &AgentResult{Decision: "implemented", Summary: "opened PR"},
+	})
+
+	err := engine.AdvanceJob(ctx, "implement-job")
+
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+	mustJob(t, store, "review-audit-task-7-review-1")
+}
+
+func TestEngineRunJobAdvancesCompletedResult(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RequiredReviewers = []string{"audit"}
+	agent := runtime.Agent{Name: "lead", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "lead"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"implemented","summary":"opened PR","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:          "implement-job",
+		Agent:       "lead",
+		Action:      "implement",
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	result, err := engine.RunJob(ctx, "implement-job", agent, adapter)
+
+	if err != nil {
+		t.Fatalf("RunJob returned error: %v", err)
+	}
+	if result.Decision != "implemented" {
+		t.Fatalf("result = %+v", result)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+	mustJob(t, store, "review-audit-task-7-review-1")
+}
+
+func TestEngineRunJobPreflightsPolicyBeforeDelivery(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-7", Owner: "other"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	engine := testEngine(store)
+	agent := runtime.Agent{Name: "lead", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "lead"}
+	delivered := false
+	adapter := &fakeDelivery{
+		outputs: []string{
+			`{"gitmoot_result":{"decision":"implemented","summary":"opened PR","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		},
+		onDeliver: func() {
+			delivered = true
+		},
+	}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:          "implement-job",
+		Agent:       "lead",
+		Action:      "implement",
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	_, err := engine.RunJob(ctx, "implement-job", agent, adapter)
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "branch lock") {
+		t.Fatalf("error = %v, want branch lock BlockedError", err)
+	}
+	if delivered {
+		t.Fatal("adapter delivered job before branch-lock preflight")
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+}
+
+func TestEngineAdvanceReviewChangesRequestedDispatchesFix(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "changes_requested", Summary: "fix edge case"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-job")
+
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskChangesRequested)
+	job := mustJob(t, store, "implement-lead-task-7")
+	if !strings.Contains(job.Payload, "fix edge case") {
+		t.Fatalf("fix job payload = %s", job.Payload)
+	}
+}
+
+func TestEngineAdvanceReviewChangesRequestedUsesBranchLockLead(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "manual-review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Result:      &AgentResult{Decision: "changes_requested", Summary: "fix manual review"},
+	})
+
+	err := engine.AdvanceJob(ctx, "manual-review-job")
+
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskChangesRequested)
+	job := mustJob(t, store, "implement-lead-task-7")
+	if !strings.Contains(job.Payload, "fix manual review") {
+		t.Fatalf("fix job payload = %s", job.Payload)
+	}
+}
+
+func TestEngineAdvanceReviewApprovalRunsMergeGate(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-job")
+
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+	if len(gate.requests) != 1 || gate.requests[0].Reviewer != "audit" || gate.requests[0].PullRequest != 7 {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestEngineAdvanceReviewApprovalWaitsForAllRequiredReviewers(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+	reviewers := []string{"audit", "security"}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "audit-review",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   reviewers,
+		Result:      &AgentResult{Decision: "approved", Summary: "audit ready"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "audit-review"); err != nil {
+		t.Fatalf("first AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate ran before all approvals: %+v", gate.requests)
+	}
+
+	insertCompletedJob(t, store, db.Job{
+		ID:    "security-review",
+		Agent: "security",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   reviewers,
+		Result:      &AgentResult{Decision: "approved", Summary: "security ready"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "security-review"); err != nil {
+		t.Fatalf("second AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+	if len(gate.requests) != 1 || gate.requests[0].Reviewer != "security" {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestEngineAdvanceReviewApprovalPreservesChangesRequested(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+	reviewers := []string{"audit", "security"}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "audit-review",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Reviewers:   reviewers,
+		Result:      &AgentResult{Decision: "changes_requested", Summary: "fix edge case"},
+	})
+	if err := engine.AdvanceJob(ctx, "audit-review"); err != nil {
+		t.Fatalf("changes requested AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskChangesRequested)
+
+	insertCompletedJob(t, store, db.Job{
+		ID:    "security-review",
+		Agent: "security",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Reviewers:   reviewers,
+		Result:      &AgentResult{Decision: "approved", Summary: "security ready"},
+	})
+	if err := engine.AdvanceJob(ctx, "security-review"); err != nil {
+		t.Fatalf("approval AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskChangesRequested)
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate ran despite requested changes: %+v", gate.requests)
+	}
+}
+
+func TestEngineHandlePullRequestOpenedCreatesNewReviewRoundForUpdates(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	event := PullRequestEvent{
+		Repo:              "jerryfane/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		TaskID:            "task-7",
+		TaskTitle:         "Workflow Engine",
+		LeadAgent:         "lead",
+		RequiredReviewers: []string{"audit"},
+	}
+
+	if err := engine.HandlePullRequestOpened(ctx, event); err != nil {
+		t.Fatalf("first HandlePullRequestOpened returned error: %v", err)
+	}
+	if err := engine.HandlePullRequestOpened(ctx, event); err != nil {
+		t.Fatalf("second HandlePullRequestOpened returned error: %v", err)
+	}
+
+	mustJob(t, store, "review-audit-task-7-review-1")
+	mustJob(t, store, "review-audit-task-7-review-2")
+}
+
+func TestEngineHandlePullRequestOpenedPreflightsReviewersBeforeEnqueue(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:              "jerryfane/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		TaskID:            "task-7",
+		TaskTitle:         "Workflow Engine",
+		LeadAgent:         "lead",
+		RequiredReviewers: []string{"audit", "missing"},
+	})
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "not subscribed") {
+		t.Fatalf("error = %v, want missing reviewer BlockedError", err)
+	}
+	jobs, listErr := store.ListJobs(ctx)
+	if listErr != nil {
+		t.Fatalf("ListJobs returned error: %v", listErr)
+	}
+	for _, job := range jobs {
+		if job.Type == "review" {
+			t.Fatalf("review job was enqueued before reviewer preflight completed: %+v", job)
+		}
+	}
+}
+
+func TestEngineAdvanceReviewApprovalIgnoresEarlierReviewRounds(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+	reviewers := []string{"audit", "security"}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "audit-review-round-1",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   reviewers,
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "old approval"},
+	})
+	insertCompletedJob(t, store, db.Job{
+		ID:    "security-review-round-2",
+		Agent: "security",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   reviewers,
+		ReviewRound: "review-2",
+		Result:      &AgentResult{Decision: "approved", Summary: "security ready"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "security-review-round-2"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate ran with stale approval: %+v", gate.requests)
+	}
+
+	insertCompletedJob(t, store, db.Job{
+		ID:    "audit-review-round-2",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   reviewers,
+		ReviewRound: "review-2",
+		Result:      &AgentResult{Decision: "approved", Summary: "audit ready"},
+	})
+	if err := engine.AdvanceJob(ctx, "audit-review-round-2"); err != nil {
+		t.Fatalf("second AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+	if len(gate.requests) != 1 || gate.requests[0].Reviewer != "audit" {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestEngineAdvanceReviewApprovalIgnoresStaleRoundWhenNewerRoundExists(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:     "task-7",
+		GoalID: "goal-1",
+		Title:  "Workflow Engine",
+		State:  string(TaskReviewing),
+		Branch: "task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "audit-review-round-1",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "old approval"},
+	})
+	encoded, err := marshalPayload(JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-2",
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID:      "audit-review-round-2",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(JobQueued),
+		Payload: encoded,
+	}, db.JobEvent{Kind: string(JobQueued), Message: "newer round queued"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	if err := engine.AdvanceJob(ctx, "audit-review-round-1"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate ran with stale approval: %+v", gate.requests)
+	}
+}
+
+func TestEngineAdvanceStaleReviewDoesNotDispatchNextAgents(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	seedAgent(t, store, "planner", []string{"ask"}, "jerryfane/gitmoot")
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:     "task-7",
+		GoalID: "goal-1",
+		Title:  "Workflow Engine",
+		State:  string(TaskReviewing),
+		Branch: "task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "audit-review-round-1",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "old approval", NextAgents: []string{"planner"}},
+	})
+	encoded, err := marshalPayload(JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-2",
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID:      "audit-review-round-2",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(JobQueued),
+		Payload: encoded,
+	}, db.JobEvent{Kind: string(JobQueued), Message: "newer round queued"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	if err := engine.AdvanceJob(ctx, "audit-review-round-1"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "ask" {
+			t.Fatalf("stale review dispatched next-agent job: %+v", job)
+		}
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+}
+
+func TestEngineAdvanceStaleReviewDoesNotRegressReadyState(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+	insertCompletedJob(t, store, db.Job{
+		ID:    "audit-review-round-1",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "old approval"},
+	})
+	insertCompletedJob(t, store, db.Job{
+		ID:    "audit-review-round-2",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-2",
+		Result:      &AgentResult{Decision: "approved", Summary: "new approval"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "audit-review-round-2"); err != nil {
+		t.Fatalf("newer AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+	if err := engine.AdvanceJob(ctx, "audit-review-round-1"); err != nil {
+		t.Fatalf("stale AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+}
+
+func TestEngineAdvanceReviewApprovalIgnoresOtherRepoTaskID(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+	reviewers := []string{"audit", "security"}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "other-repo-audit-review",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "other/repo",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   reviewers,
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "other repo ready"},
+	})
+	insertCompletedJob(t, store, db.Job{
+		ID:    "security-review",
+		Agent: "security",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   reviewers,
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "security ready"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "security-review"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate ran with other repo approval: %+v", gate.requests)
+	}
+}
+
+func TestEngineAdvanceReviewApprovalBlocksOnMergeGateRejection(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Reason: "checks are pending"}}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-job")
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || blocked.Reason != "checks are pending" {
+		t.Fatalf("error = %v, want merge gate BlockedError", err)
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+}
+
+func TestEngineAdvanceBlocksOnAgentBlockedResult(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-7",
+		TaskID:    "task-7",
+		TaskTitle: "Workflow Engine",
+		Result:    &AgentResult{Decision: "blocked", Summary: "needs credentials"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-job")
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || blocked.Reason != "needs credentials" {
+		t.Fatalf("error = %v, want agent BlockedError", err)
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+}
+
+func TestEngineAdvanceDispatchesNextAgents(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "planner", []string{"ask"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-7",
+		TaskID:    "task-7",
+		TaskTitle: "Workflow Engine",
+		Result:    &AgentResult{Decision: "approved", Summary: "ask planner", NextAgents: []string{"planner"}},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-job")
+
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	mustJob(t, store, "ask-planner-task-7")
+}
+
+func TestEngineAdvanceBlocksWhenNextAgentScopeRejected(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "planner", []string{"ask"}, "other/repo")
+	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-7",
+		TaskID:    "task-7",
+		TaskTitle: "Workflow Engine",
+		Result:    &AgentResult{Decision: "approved", Summary: "ask planner", NextAgents: []string{"planner"}},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-job")
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "scoped") {
+		t.Fatalf("error = %v, want scope BlockedError", err)
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+}
+
+func TestEngineAdvancePreflightsNextAgentsBeforeEnqueue(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "planner", []string{"ask"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-7",
+		TaskID:    "task-7",
+		TaskTitle: "Workflow Engine",
+		Result:    &AgentResult{Decision: "approved", Summary: "ask planner", NextAgents: []string{"planner", "missing"}},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-job")
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "not subscribed") {
+		t.Fatalf("error = %v, want missing next-agent BlockedError", err)
+	}
+	jobs, listErr := store.ListJobs(ctx)
+	if listErr != nil {
+		t.Fatalf("ListJobs returned error: %v", listErr)
+	}
+	for _, job := range jobs {
+		if job.Type == "ask" {
+			t.Fatalf("ask job was enqueued before next-agent preflight completed: %+v", job)
+		}
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+}
+
+func TestEngineSetTaskStatePreservesExistingMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:     "task-7",
+		GoalID: "goal-1",
+		Title:  "Workflow Engine",
+		State:  string(TaskPlanned),
+		Branch: "task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	engine := testEngine(store)
+
+	if err := engine.setTaskState(ctx, taskRef{ID: "task-7"}, TaskReviewing); err != nil {
+		t.Fatalf("setTaskState returned error: %v", err)
+	}
+
+	task, err := store.GetTask(ctx, "task-7")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.GoalID != "goal-1" || task.Title != "Workflow Engine" || task.Branch != "task-7" || task.State != string(TaskReviewing) {
+		t.Fatalf("task metadata was not preserved: %+v", task)
+	}
+}
+
+func openEngineStore(t *testing.T) *db.Store {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	return store
+}
+
+func testEngine(store *db.Store) Engine {
+	return Engine{
+		Store: store,
+		JobID: func(request JobRequest) string {
+			parts := []string{request.Action, request.Agent, request.TaskID}
+			if request.ReviewRound != "" {
+				parts = append(parts, request.ReviewRound)
+			}
+			return strings.Join(parts, "-")
+		},
+	}
+}
+
+func seedAgent(t *testing.T, store *db.Store, name string, capabilities []string, repo string) {
+	t.Helper()
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:           name,
+		Role:           "agent",
+		Runtime:        runtime.ShellRuntime,
+		RuntimeRef:     "printf ok",
+		RepoScope:      repo,
+		Capabilities:   capabilities,
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+}
+
+func insertCompletedJob(t *testing.T, store *db.Store, job db.Job, payload JobPayload) {
+	t.Helper()
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	job.State = string(JobSucceeded)
+	job.Payload = encoded
+	if err := store.CreateJobWithEvent(context.Background(), job, db.JobEvent{Kind: string(JobSucceeded), Message: "done"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+}
+
+func assertTaskState(t *testing.T, store *db.Store, taskID string, want TaskState) {
+	t.Helper()
+	task, err := store.GetTask(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(want) {
+		t.Fatalf("task state = %q, want %q", task.State, want)
+	}
+}
+
+func mustJob(t *testing.T, store *db.Store, jobID string) db.Job {
+	t.Helper()
+	job, err := store.GetJob(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s) returned error: %v", jobID, err)
+	}
+	return job
+}
+
+type fakeMergeGate struct {
+	decision MergeDecision
+	requests []MergeRequest
+}
+
+func (f *fakeMergeGate) Evaluate(_ context.Context, request MergeRequest) (MergeDecision, error) {
+	f.requests = append(f.requests, request)
+	return f.decision, nil
+}

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -24,8 +24,12 @@ type JobRequest struct {
 	Repo         string
 	Branch       string
 	PullRequest  int
+	GoalID       string
 	TaskID       string
 	TaskTitle    string
+	LeadAgent    string
+	Reviewers    []string
+	ReviewRound  string
 	Sender       string
 	Instructions string
 	Constraints  []string
@@ -35,8 +39,12 @@ type JobPayload struct {
 	Repo         string       `json:"repo"`
 	Branch       string       `json:"branch"`
 	PullRequest  int          `json:"pull_request"`
+	GoalID       string       `json:"goal_id,omitempty"`
 	TaskID       string       `json:"task_id"`
 	TaskTitle    string       `json:"task_title"`
+	LeadAgent    string       `json:"lead_agent,omitempty"`
+	Reviewers    []string     `json:"reviewers,omitempty"`
+	ReviewRound  string       `json:"review_round,omitempty"`
 	Sender       string       `json:"sender"`
 	Instructions string       `json:"instructions"`
 	Constraints  []string     `json:"constraints"`
@@ -60,8 +68,12 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		Repo:         request.Repo,
 		Branch:       request.Branch,
 		PullRequest:  request.PullRequest,
+		GoalID:       request.GoalID,
 		TaskID:       request.TaskID,
 		TaskTitle:    request.TaskTitle,
+		LeadAgent:    request.LeadAgent,
+		Reviewers:    compactStrings(request.Reviewers),
+		ReviewRound:  request.ReviewRound,
 		Sender:       request.Sender,
 		Instructions: request.Instructions,
 		Constraints:  compactStrings(request.Constraints),

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -3,7 +3,14 @@ package workflow
 type TaskState string
 
 const (
-	TaskPlanned TaskState = "planned"
+	TaskPlanned          TaskState = "planned"
+	TaskImplementing     TaskState = "implementing"
+	TaskPullRequestOpen  TaskState = "pr_open"
+	TaskReviewing        TaskState = "reviewing"
+	TaskChangesRequested TaskState = "changes_requested"
+	TaskReadyToMerge     TaskState = "ready_to_merge"
+	TaskMerged           TaskState = "merged"
+	TaskBlocked          TaskState = "blocked"
 )
 
 type JobState string


### PR DESCRIPTION
WHAT:
Add the autonomous workflow engine for Task 7.

WHY:
Gitmoot needs local, runtime-neutral automation that advances task PRs from PR-opened or PR-updated events into review jobs, fix jobs, next-agent jobs, and merge-gate-ready states without requiring manual PR comment routing for every step.

CHANGES:
- Added `internal/workflow/engine.go` with task state transitions, reviewer dispatch, fix routing, next-agent dispatch, branch-lock/capability/scope enforcement, merge-gate hooks, and stale review-round protection.
- Extended workflow job payloads with goal, lead, reviewer, and review-round metadata.
- Added task states for implementing, PR open, reviewing, changes requested, ready to merge, merged, and blocked.
- Added store helpers for task lookup, PR lookup with `head_sha`, job listing, branch-lock lookup, and a migration for PR head SHA tracking.
- Wired `gitmoot daemon start` to create a workflow engine and route PR head changes through it.
- Kept existing PR comment routing active even when workflow routing fails, with retry behavior for failed PR workflow routing.
- Added daemon and workflow tests for PR update routing, empty/legacy PR baselines, manual review jobs, branch locks, review rounds, stale reviews, next-agent preflight, merge-gate decisions, and metadata preservation.

RESULTS:
- `go test ./internal/workflow ./internal/daemon ./internal/db ./internal/cli`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:
```text
The changed and untracked files compile and the workflow/daemon behavior covered by the new tests is consistent with the stated task scope. I did not find a discrete regression that should block this patch.
The changed and untracked files compile and the workflow/daemon behavior covered by the new tests is consistent with the stated task scope. I did not find a discrete regression that should block this patch.
```

RISK:
- Merge-gate execution is intentionally an interface hook in this task. The concrete policy and GitHub merge implementation are planned for Task 9.
- No skipped local checks.
