### PR TITLE
feat: add task branches pr bodies and locks

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -179,7 +179,7 @@ func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullR
 		title:  pull.Title,
 		branch: pull.HeadRef,
 	}
-	if task, err := d.lookupPullRequestTask(ctx, pull.HeadRef); err == nil {
+	if task, err := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef); err == nil {
 		ref.id = task.ID
 		ref.goalID = task.GoalID
 		ref.title = task.Title
@@ -207,15 +207,22 @@ func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullR
 	})
 }
 
-func (d Daemon) lookupPullRequestTask(ctx context.Context, branch string) (db.Task, error) {
-	task, err := d.Store.GetTaskByBranch(ctx, branch)
+func (d Daemon) lookupPullRequestTask(ctx context.Context, repoFullName string, branch string) (db.Task, error) {
+	task, err := d.Store.GetTaskByRepoBranch(ctx, repoFullName, branch)
 	if err == nil {
 		return task, nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return db.Task{}, err
 	}
-	return d.Store.GetTask(ctx, branch)
+	task, err = d.Store.GetTask(ctx, branch)
+	if err != nil {
+		return db.Task{}, err
+	}
+	if task.RepoFullName != "" && task.RepoFullName != repoFullName {
+		return db.Task{}, sql.ErrNoRows
+	}
+	return task, nil
 }
 
 func (d Daemon) workflowReviewers(ctx context.Context) ([]string, error) {
@@ -289,7 +296,20 @@ func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comm
 	if !hasCapability(agent.Capabilities, command.Action) {
 		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot agent `%s` does not advertise `%s` capability.", agent.Name, command.Action))
 	}
+	if command.Action == "implement" {
+		allowed, err := d.agentOwnsBranchLock(ctx, agent.Name, pull.HeadRef)
+		if err != nil {
+			return err
+		}
+		if !allowed {
+			return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot agent `%s` cannot implement on `%s` without holding the branch lock.", agent.Name, pull.HeadRef))
+		}
+	}
 
+	ref, err := d.commentTaskRef(ctx, pull, comment)
+	if err != nil {
+		return err
+	}
 	job, created, err := d.enqueueJob(ctx, workflow.JobRequest{
 		ID:           jobID(d.Repo, pull.Number, comment.ID, sequence, command.Agent, command.Action),
 		Agent:        agent.Name,
@@ -297,8 +317,9 @@ func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comm
 		Repo:         d.Repo.FullName(),
 		Branch:       pull.HeadRef,
 		PullRequest:  int(pull.Number),
-		TaskID:       fmt.Sprintf("pr-%d-comment-%d", pull.Number, comment.ID),
-		TaskTitle:    pull.Title,
+		GoalID:       ref.goalID,
+		TaskID:       ref.id,
+		TaskTitle:    ref.title,
 		Sender:       comment.Author,
 		Instructions: command.Instructions,
 		Constraints: []string{
@@ -320,6 +341,39 @@ func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comm
 		}
 	}
 	return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot queued `%s` job `%s` for `%s`.", command.Action, job.ID, agent.Name))
+}
+
+func (d Daemon) commentTaskRef(ctx context.Context, pull github.PullRequest, comment github.IssueComment) (workflowTaskRef, error) {
+	ref := workflowTaskRef{
+		id:     fmt.Sprintf("pr-%d-comment-%d", pull.Number, comment.ID),
+		title:  pull.Title,
+		branch: pull.HeadRef,
+	}
+	task, err := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ref, nil
+		}
+		return workflowTaskRef{}, err
+	}
+	ref.id = task.ID
+	ref.goalID = task.GoalID
+	ref.title = task.Title
+	if task.Branch != "" {
+		ref.branch = task.Branch
+	}
+	return ref, nil
+}
+
+func (d Daemon) agentOwnsBranchLock(ctx context.Context, agentName string, branch string) (bool, error) {
+	lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), branch)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return lock.Owner == agentName, nil
 }
 
 func (d Daemon) authorizeCommenter(ctx context.Context, author string) (bool, error) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -677,6 +677,89 @@ func TestPollOnceAcknowledgesMissingCapabilityWithoutJob(t *testing.T) {
 	}
 }
 
+func TestPollOnceRejectsImplementWithoutBranchLock(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "builder",
+		Role:           "builder",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main"}},
+		comments: map[int64][]github.IssueComment{
+			10: {{ID: 808, Body: "/gitmoot builder implement", Author: "dana"}},
+		},
+	}
+
+	err := (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "without holding the branch lock") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+	if _, err := store.GetJob(ctx, jobID(repo, 10, 808, 0, "builder", "implement")); err == nil {
+		t.Fatal("implement job was created without a branch lock")
+	}
+}
+
+func TestPollOnceQueuesImplementWithBranchLock(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "builder",
+		Role:           "builder",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-10", Owner: "builder"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-010", GoalID: "goal-1", Title: "Task 10", State: string(workflow.TaskImplementing), Branch: "task-10"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main"}},
+		comments: map[int64][]github.IssueComment{
+			10: {{ID: 808, Body: "/gitmoot builder implement", Author: "dana"}},
+		},
+	}
+
+	err := (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, jobID(repo, 10, 808, 0, "builder", "implement"))
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	var payload workflow.JobPayload
+	if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
+		t.Fatalf("Unmarshal payload returned error: %v", err)
+	}
+	if payload.TaskID != "task-010" || payload.GoalID != "goal-1" {
+		t.Fatalf("payload task context = task %q goal %q, want existing branch task context", payload.TaskID, payload.GoalID)
+	}
+}
+
 func TestPollOnceRetriesUnseenCommentAfterAckFailure(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -41,11 +41,12 @@ type Goal struct {
 }
 
 type Task struct {
-	ID     string
-	GoalID string
-	Title  string
-	State  string
-	Branch string
+	ID           string
+	RepoFullName string
+	GoalID       string
+	Title        string
+	State        string
+	Branch       string
 }
 
 type PullRequest struct {
@@ -234,32 +235,46 @@ func (s *Store) InsertGoal(ctx context.Context, goal Goal) error {
 }
 
 func (s *Store) UpsertTask(ctx context.Context, task Task) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO tasks(id, goal_id, title, state, branch, updated_at)
-		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
+			repo_full_name = excluded.repo_full_name,
 			goal_id = excluded.goal_id,
 			title = excluded.title,
 			state = excluded.state,
 			branch = excluded.branch,
 			updated_at = CURRENT_TIMESTAMP`,
-		task.ID, task.GoalID, task.Title, task.State, task.Branch)
+		task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch)
 	return err
 }
 
 func (s *Store) GetTask(ctx context.Context, id string) (Task, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, goal_id, title, state, branch FROM tasks WHERE id = ?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch FROM tasks WHERE id = ?`, id)
 	var task Task
-	if err := row.Scan(&task.ID, &task.GoalID, &task.Title, &task.State, &task.Branch); err != nil {
+	if err := row.Scan(&task.ID, &task.RepoFullName, &task.GoalID, &task.Title, &task.State, &task.Branch); err != nil {
 		return Task{}, err
 	}
 	return task, nil
 }
 
 func (s *Store) GetTaskByBranch(ctx context.Context, branch string) (Task, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, goal_id, title, state, branch
+	row := s.db.QueryRowContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch
 		FROM tasks WHERE branch = ? ORDER BY updated_at DESC, id LIMIT 1`, branch)
+	return scanTask(row)
+}
+
+func (s *Store) GetTaskByRepoBranch(ctx context.Context, repoFullName string, branch string) (Task, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch
+		FROM tasks
+		WHERE branch = ? AND (repo_full_name = ? OR repo_full_name = '')
+		ORDER BY CASE WHEN repo_full_name = ? THEN 0 ELSE 1 END, updated_at DESC, id
+		LIMIT 1`, branch, repoFullName, repoFullName)
+	return scanTask(row)
+}
+
+func scanTask(row interface{ Scan(dest ...any) error }) (Task, error) {
 	var task Task
-	if err := row.Scan(&task.ID, &task.GoalID, &task.Title, &task.State, &task.Branch); err != nil {
+	if err := row.Scan(&task.ID, &task.RepoFullName, &task.GoalID, &task.Title, &task.State, &task.Branch); err != nil {
 		return Task{}, err
 	}
 	return task, nil
@@ -473,14 +488,12 @@ func (s *Store) ListJobEvents(ctx context.Context, jobID string) ([]JobEvent, er
 }
 
 func (s *Store) AcquireLock(ctx context.Context, lock BranchLock) (bool, error) {
-	result, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO branch_locks(repo_full_name, branch, owner, updated_at)
-		VALUES (?, ?, ?, CURRENT_TIMESTAMP)`, lock.RepoFullName, lock.Branch, lock.Owner)
+	created, err := s.CreateLock(ctx, lock)
 	if err != nil {
 		return false, err
 	}
-	affected, err := result.RowsAffected()
-	if err != nil || affected == 1 {
-		return affected == 1, err
+	if created {
+		return true, nil
 	}
 
 	var owner string
@@ -491,6 +504,19 @@ func (s *Store) AcquireLock(ctx context.Context, lock BranchLock) (bool, error) 
 	return owner == lock.Owner, nil
 }
 
+func (s *Store) CreateLock(ctx context.Context, lock BranchLock) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO branch_locks(repo_full_name, branch, owner, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP)`, lock.RepoFullName, lock.Branch, lock.Owner)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
+}
+
 func (s *Store) GetBranchLock(ctx context.Context, repoFullName string, branch string) (BranchLock, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, branch, owner FROM branch_locks WHERE repo_full_name = ? AND branch = ?`, repoFullName, branch)
 	var lock BranchLock
@@ -498,6 +524,18 @@ func (s *Store) GetBranchLock(ctx context.Context, repoFullName string, branch s
 		return BranchLock{}, err
 	}
 	return lock, nil
+}
+
+func (s *Store) ReleaseLock(ctx context.Context, lock BranchLock) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM branch_locks WHERE repo_full_name = ? AND branch = ? AND owner = ?`, lock.RepoFullName, lock.Branch, lock.Owner)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
 }
 
 func (s *Store) UpsertMergeGate(ctx context.Context, gate MergeGate) error {
@@ -657,5 +695,20 @@ CREATE TABLE merge_gates (
 `,
 	`
 ALTER TABLE pull_requests ADD COLUMN head_sha TEXT NOT NULL DEFAULT '';
-`,
+	`,
+	`
+ALTER TABLE tasks ADD COLUMN repo_full_name TEXT NOT NULL DEFAULT '';
+
+WITH ranked_tasks AS (
+	SELECT rowid AS task_rowid,
+		ROW_NUMBER() OVER (PARTITION BY repo_full_name, branch ORDER BY updated_at DESC, id) AS branch_rank
+	FROM tasks
+	WHERE branch <> ''
+)
+UPDATE tasks
+SET branch = ''
+WHERE rowid IN (SELECT task_rowid FROM ranked_tasks WHERE branch_rank > 1);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_repo_branch_unique ON tasks(repo_full_name, branch) WHERE branch <> '';
+	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 )
@@ -230,12 +231,33 @@ func TestRepositoryMethods(t *testing.T) {
 	if lock.Owner != "lead" {
 		t.Fatalf("lock owner = %q, want lead", lock.Owner)
 	}
+	created, err := store.CreateLock(ctx, BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task", Owner: "lead"})
+	if err != nil {
+		t.Fatalf("CreateLock existing returned error: %v", err)
+	}
+	if created {
+		t.Fatal("CreateLock reported existing lock as newly created")
+	}
 	acquired, err = store.AcquireLock(ctx, BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task", Owner: "other"})
 	if err != nil {
 		t.Fatalf("second AcquireLock returned error: %v", err)
 	}
 	if acquired {
 		t.Fatal("second AcquireLock unexpectedly acquired lock")
+	}
+	released, err := store.ReleaseLock(ctx, BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task", Owner: "other"})
+	if err != nil {
+		t.Fatalf("wrong-owner ReleaseLock returned error: %v", err)
+	}
+	if released {
+		t.Fatal("wrong-owner ReleaseLock released lock")
+	}
+	released, err = store.ReleaseLock(ctx, BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task", Owner: "lead"})
+	if err != nil {
+		t.Fatalf("ReleaseLock returned error: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseLock did not release owned lock")
 	}
 	if err := store.UpsertMergeGate(ctx, MergeGate{RepoFullName: "jerryfane/gitmoot", PullRequest: 1, State: "pending", Reason: "waiting"}); err != nil {
 		t.Fatalf("UpsertMergeGate returned error: %v", err)
@@ -253,5 +275,104 @@ func TestRepositoryMethods(t *testing.T) {
 	}
 	if removed {
 		t.Fatal("second RemoveAgent removed missing agent")
+	}
+}
+
+func TestTasksRequireUniqueNonEmptyBranches(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.UpsertTask(ctx, Task{ID: "task-1", GoalID: "goal-1", Title: "First", State: "planned", Branch: "task-branch"}); err != nil {
+		t.Fatalf("UpsertTask first returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, Task{ID: "task-2", GoalID: "goal-1", Title: "Second", State: "planned", Branch: "task-branch"}); err == nil {
+		t.Fatal("UpsertTask allowed two tasks to share one branch")
+	}
+	if err := store.UpsertTask(ctx, Task{ID: "task-empty-1", GoalID: "goal-1", Title: "Empty 1", State: "planned"}); err != nil {
+		t.Fatalf("UpsertTask empty first returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, Task{ID: "task-empty-2", GoalID: "goal-1", Title: "Empty 2", State: "planned"}); err != nil {
+		t.Fatalf("UpsertTask empty second returned error: %v", err)
+	}
+}
+
+func TestTasksAllowSameBranchAcrossRepos(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	first := Task{ID: "task-1", RepoFullName: "jerryfane/gitmoot", GoalID: "goal-1", Title: "First", State: "planned", Branch: "task-branch"}
+	second := Task{ID: "task-2", RepoFullName: "jerryfane/other", GoalID: "goal-1", Title: "Second", State: "planned", Branch: "task-branch"}
+	if err := store.UpsertTask(ctx, first); err != nil {
+		t.Fatalf("UpsertTask first returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, second); err != nil {
+		t.Fatalf("UpsertTask second repo returned error: %v", err)
+	}
+	got, err := store.GetTaskByRepoBranch(ctx, "jerryfane/other", "task-branch")
+	if err != nil {
+		t.Fatalf("GetTaskByRepoBranch returned error: %v", err)
+	}
+	if got.ID != "task-2" {
+		t.Fatalf("repo scoped task = %q, want task-2", got.ID)
+	}
+}
+
+func TestMigrationDeduplicatesExistingTaskBranches(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open returned error: %v", err)
+	}
+	if _, err := raw.ExecContext(ctx, `CREATE TABLE schema_migrations (
+		version INTEGER PRIMARY KEY,
+		applied_at TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("create schema_migrations returned error: %v", err)
+	}
+	for version, migration := range migrations[:2] {
+		if _, err := raw.ExecContext(ctx, migration); err != nil {
+			t.Fatalf("apply seed migration %d returned error: %v", version+1, err)
+		}
+		if _, err := raw.ExecContext(ctx, `INSERT INTO schema_migrations(version, applied_at) VALUES (?, 'test')`, version+1); err != nil {
+			t.Fatalf("record seed migration %d returned error: %v", version+1, err)
+		}
+	}
+	if _, err := raw.ExecContext(ctx, `INSERT INTO tasks(id, goal_id, title, state, branch, updated_at) VALUES
+		('task-old', 'goal-1', 'Old', 'planned', 'task-branch', '2026-01-01T00:00:00Z'),
+		('task-new', 'goal-1', 'New', 'planned', 'task-branch', '2026-01-02T00:00:00Z')`); err != nil {
+		t.Fatalf("insert duplicate tasks returned error: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw Close returned error: %v", err)
+	}
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	kept, err := store.GetTaskByBranch(ctx, "task-branch")
+	if err != nil {
+		t.Fatalf("GetTaskByBranch returned error: %v", err)
+	}
+	if kept.ID != "task-new" {
+		t.Fatalf("kept task = %q, want latest task-new", kept.ID)
+	}
+	old, err := store.GetTask(ctx, "task-old")
+	if err != nil {
+		t.Fatalf("GetTask old returned error: %v", err)
+	}
+	if old.Branch != "" {
+		t.Fatalf("duplicate task branch = %q, want cleared", old.Branch)
 	}
 }

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -1,0 +1,89 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+type Client struct {
+	Runner subprocess.Runner
+	Dir    string
+}
+
+func (c Client) CreateBranch(ctx context.Context, branch string, base string) error {
+	if err := validateBranch(branch); err != nil {
+		return err
+	}
+	args := []string{"switch", "-c", branch}
+	if strings.TrimSpace(base) != "" {
+		args = append(args, base)
+	}
+	_, err := c.run(ctx, args...)
+	return err
+}
+
+func (c Client) CurrentBranch(ctx context.Context) (string, error) {
+	result, err := c.run(ctx, "branch", "--show-current")
+	if err != nil {
+		return "", err
+	}
+	branch := strings.TrimSpace(result.Stdout)
+	if branch == "" {
+		return "", errors.New("current git branch is empty")
+	}
+	return branch, nil
+}
+
+func (c Client) PushBranch(ctx context.Context, remote string, branch string) error {
+	if strings.TrimSpace(remote) == "" {
+		remote = "origin"
+	}
+	if err := validateBranch(branch); err != nil {
+		return err
+	}
+	_, err := c.run(ctx, "push", "-u", remote, branch)
+	return err
+}
+
+func (c Client) run(ctx context.Context, args ...string) (subprocess.Result, error) {
+	runner := c.Runner
+	if runner == nil {
+		runner = subprocess.ExecRunner{}
+	}
+	result, err := runner.Run(ctx, c.Dir, "git", args...)
+	if err != nil {
+		return result, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return result, nil
+}
+
+func validateBranch(branch string) error {
+	trimmed := strings.TrimSpace(branch)
+	switch {
+	case trimmed == "":
+		return errors.New("branch is required")
+	case trimmed != branch:
+		return fmt.Errorf("branch %q must not contain leading or trailing whitespace", branch)
+	case strings.HasPrefix(branch, "-"):
+		return fmt.Errorf("branch %q must not start with '-'", branch)
+	case strings.ContainsAny(branch, " \t\r\n"):
+		return fmt.Errorf("branch %q must not contain whitespace", branch)
+	case strings.ContainsAny(branch, ":~^?*[\\"):
+		return fmt.Errorf("branch %q contains invalid git ref characters", branch)
+	case strings.Contains(branch, ".."):
+		return fmt.Errorf("branch %q must not contain '..'", branch)
+	case strings.Contains(branch, "@{"):
+		return fmt.Errorf("branch %q must not contain '@{'", branch)
+	case strings.Contains(branch, "//"):
+		return fmt.Errorf("branch %q must not contain '//'", branch)
+	case strings.HasPrefix(branch, "/") || strings.HasSuffix(branch, "/"):
+		return fmt.Errorf("branch %q must not start or end with '/'", branch)
+	case strings.HasSuffix(branch, ".lock"):
+		return fmt.Errorf("branch %q must not end with .lock", branch)
+	}
+	return nil
+}

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -1,0 +1,121 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+func TestClientUsesSharedSubprocessRunner(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{}, {Stdout: "task-1\n"}}}
+	client := Client{Runner: runner, Dir: "/repo"}
+
+	if err := client.CreateBranch(context.Background(), "task-1", "main"); err != nil {
+		t.Fatalf("CreateBranch returned error: %v", err)
+	}
+	branch, err := client.CurrentBranch(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentBranch returned error: %v", err)
+	}
+	if branch != "task-1" {
+		t.Fatalf("branch = %q, want task-1", branch)
+	}
+	if err := client.PushBranch(context.Background(), "origin", "task-1"); err != nil {
+		t.Fatalf("PushBranch returned error: %v", err)
+	}
+
+	runner.wantArgs(t, 0, "git", "switch", "-c", "task-1", "main")
+	runner.wantArgs(t, 1, "git", "branch", "--show-current")
+	runner.wantArgs(t, 2, "git", "push", "-u", "origin", "task-1")
+}
+
+func TestClientRejectsUnsafeBranchNames(t *testing.T) {
+	for _, branch := range []string{"", " task", "task ", "-bad", "bad branch", "bad..branch", "bad.lock", "HEAD:main", "bad~branch", "bad^branch", "bad?branch", "bad[branch", "bad\\branch", "bad@{branch", "/bad", "bad/", "bad//branch"} {
+		t.Run(branch, func(t *testing.T) {
+			if err := (Client{}).CreateBranch(context.Background(), branch, "main"); err == nil {
+				t.Fatal("CreateBranch accepted unsafe branch")
+			}
+		})
+	}
+}
+
+func TestClientCreateBranchSmoke(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, dir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# smoke\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "init")
+
+	client := Client{Dir: dir}
+	if err := client.CreateBranch(context.Background(), "task-branch", "main"); err != nil {
+		t.Fatalf("CreateBranch returned error: %v", err)
+	}
+	branch, err := client.CurrentBranch(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentBranch returned error: %v", err)
+	}
+	if branch != "task-branch" {
+		t.Fatalf("branch = %q, want task-branch", branch)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+type fakeRunner struct {
+	results []subprocess.Result
+	errs    []error
+	calls   [][]string
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	call := append([]string{command}, args...)
+	f.calls = append(f.calls, call)
+	index := len(f.calls) - 1
+	result := subprocess.Result{Command: command, Args: args}
+	if index < len(f.results) {
+		result = f.results[index]
+		result.Command = command
+		result.Args = args
+	}
+	var err error
+	if index < len(f.errs) {
+		err = f.errs[index]
+	}
+	return result, err
+}
+
+func (f *fakeRunner) LookPath(string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (f *fakeRunner) wantArgs(t *testing.T, index int, want ...string) {
+	t.Helper()
+	if index >= len(f.calls) {
+		t.Fatalf("missing call %d; calls=%v", index, f.calls)
+	}
+	if !reflect.DeepEqual(f.calls[index], want) {
+		t.Fatalf("call %d = %v, want %v", index, f.calls[index], want)
+	}
+}

--- a/internal/workflow/branch.go
+++ b/internal/workflow/branch.go
@@ -1,0 +1,110 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+type BranchCreator interface {
+	CreateBranch(ctx context.Context, branch string, base string) error
+}
+
+type TaskBranchRequest struct {
+	Repo       string
+	GoalID     string
+	TaskID     string
+	TaskTitle  string
+	Branch     string
+	BaseBranch string
+	Owner      string
+}
+
+func (e Engine) StartTaskBranch(ctx context.Context, request TaskBranchRequest, brancher BranchCreator) (db.Task, error) {
+	if err := e.validate(); err != nil {
+		return db.Task{}, err
+	}
+	if brancher == nil {
+		return db.Task{}, errors.New("branch creator is required")
+	}
+	if err := validateTaskBranchRequest(request); err != nil {
+		return db.Task{}, err
+	}
+	existing, err := e.Store.GetTaskByRepoBranch(ctx, request.Repo, request.Branch)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return db.Task{}, err
+	}
+	if err == nil && existing.ID != request.TaskID {
+		return db.Task{}, errors.New("task branch is already assigned to another task")
+	}
+	lock := db.BranchLock{RepoFullName: request.Repo, Branch: request.Branch, Owner: request.Owner}
+	createdLock, err := e.Store.CreateLock(ctx, lock)
+	if err != nil {
+		return db.Task{}, err
+	}
+	if !createdLock {
+		existingLock, err := e.Store.GetBranchLock(ctx, request.Repo, request.Branch)
+		if err != nil {
+			return db.Task{}, err
+		}
+		if existingLock.Owner != request.Owner {
+			return db.Task{}, BlockedError{Reason: "branch lock rejected action for " + request.Branch}
+		}
+	}
+
+	if err := brancher.CreateBranch(ctx, request.Branch, request.BaseBranch); err != nil {
+		if createdLock {
+			_, _ = e.Store.ReleaseLock(ctx, lock)
+		}
+		return db.Task{}, err
+	}
+	taskGoalID := request.GoalID
+	taskTitle := request.TaskTitle
+	existingTask, err := e.Store.GetTask(ctx, request.TaskID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if createdLock {
+			_, _ = e.Store.ReleaseLock(ctx, lock)
+		}
+		return db.Task{}, err
+	}
+	if err == nil {
+		if taskGoalID == "" {
+			taskGoalID = existingTask.GoalID
+		}
+		if taskTitle == "" {
+			taskTitle = existingTask.Title
+		}
+	}
+	task := db.Task{
+		ID:           request.TaskID,
+		RepoFullName: request.Repo,
+		GoalID:       taskGoalID,
+		Title:        taskTitle,
+		State:        string(TaskImplementing),
+		Branch:       request.Branch,
+	}
+	if err := e.Store.UpsertTask(ctx, task); err != nil {
+		if createdLock {
+			_, _ = e.Store.ReleaseLock(ctx, lock)
+		}
+		return db.Task{}, err
+	}
+	return task, nil
+}
+
+func validateTaskBranchRequest(request TaskBranchRequest) error {
+	switch {
+	case strings.TrimSpace(request.Repo) == "":
+		return errors.New("task branch repo is required")
+	case strings.TrimSpace(request.TaskID) == "":
+		return errors.New("task branch task id is required")
+	case strings.TrimSpace(request.Branch) == "":
+		return errors.New("task branch name is required")
+	case strings.TrimSpace(request.Owner) == "":
+		return errors.New("task branch owner is required")
+	}
+	return nil
+}

--- a/internal/workflow/branch_test.go
+++ b/internal/workflow/branch_test.go
@@ -1,0 +1,208 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestEngineStartTaskBranchCreatesBranchAndLock(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	brancher := &fakeBranchCreator{}
+
+	task, err := engine.StartTaskBranch(ctx, TaskBranchRequest{
+		Repo:       "jerryfane/gitmoot",
+		GoalID:     "goal-1",
+		TaskID:     "task-8",
+		TaskTitle:  "Branch Rules",
+		Branch:     "task-8",
+		BaseBranch: "main",
+		Owner:      "lead",
+	}, brancher)
+
+	if err != nil {
+		t.Fatalf("StartTaskBranch returned error: %v", err)
+	}
+	if task.ID != "task-8" || task.Branch != "task-8" || task.State != string(TaskImplementing) {
+		t.Fatalf("task = %+v", task)
+	}
+	lock, err := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-8")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.Owner != "lead" {
+		t.Fatalf("lock owner = %q, want lead", lock.Owner)
+	}
+	if len(brancher.calls) != 1 || brancher.calls[0].branch != "task-8" || brancher.calls[0].base != "main" {
+		t.Fatalf("branch calls = %+v", brancher.calls)
+	}
+}
+
+func TestEngineStartTaskBranchReleasesLockOnBranchCreateFailure(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	brancher := &fakeBranchCreator{err: errors.New("git failed")}
+
+	_, err := engine.StartTaskBranch(ctx, TaskBranchRequest{
+		Repo:   "jerryfane/gitmoot",
+		TaskID: "task-8",
+		Branch: "task-8",
+		Owner:  "lead",
+	}, brancher)
+
+	if err == nil {
+		t.Fatal("StartTaskBranch succeeded despite branch failure")
+	}
+	if _, lockErr := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-8"); !errors.Is(lockErr, sql.ErrNoRows) {
+		t.Fatalf("lock after failure error = %v, want sql.ErrNoRows", lockErr)
+	}
+}
+
+func TestEngineStartTaskBranchPreservesExistingTaskMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-8",
+		RepoFullName: "jerryfane/gitmoot",
+		GoalID:       "goal-1",
+		Title:        "Branch Rules",
+		State:        string(TaskPlanned),
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	engine := testEngine(store)
+
+	task, err := engine.StartTaskBranch(ctx, TaskBranchRequest{
+		Repo:   "jerryfane/gitmoot",
+		TaskID: "task-8",
+		Branch: "task-8",
+		Owner:  "lead",
+	}, &fakeBranchCreator{})
+
+	if err != nil {
+		t.Fatalf("StartTaskBranch returned error: %v", err)
+	}
+	if task.GoalID != "goal-1" || task.Title != "Branch Rules" {
+		t.Fatalf("task metadata = goal %q title %q", task.GoalID, task.Title)
+	}
+}
+
+func TestEngineStartTaskBranchPreservesExistingSameOwnerLockOnFailure(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-8", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	brancher := &fakeBranchCreator{err: errors.New("git failed")}
+
+	_, err := engine.StartTaskBranch(ctx, TaskBranchRequest{
+		Repo:   "jerryfane/gitmoot",
+		TaskID: "task-8",
+		Branch: "task-8",
+		Owner:  "lead",
+	}, brancher)
+
+	if err == nil {
+		t.Fatal("StartTaskBranch succeeded despite branch failure")
+	}
+	lock, lockErr := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-8")
+	if lockErr != nil {
+		t.Fatalf("GetBranchLock returned error: %v", lockErr)
+	}
+	if lock.Owner != "lead" {
+		t.Fatalf("lock owner = %q, want lead", lock.Owner)
+	}
+}
+
+func TestEngineStartTaskBranchBlocksWhenBranchLocked(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-8", Owner: "other"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+
+	_, err := engine.StartTaskBranch(ctx, TaskBranchRequest{
+		Repo:   "jerryfane/gitmoot",
+		TaskID: "task-8",
+		Branch: "task-8",
+		Owner:  "lead",
+	}, &fakeBranchCreator{})
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("error = %v, want BlockedError", err)
+	}
+}
+
+func TestEngineStartTaskBranchRejectsBranchAssignedToOtherTask(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-existing", GoalID: "goal-1", Title: "Existing", State: string(TaskPlanned), Branch: "task-8"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	brancher := &fakeBranchCreator{}
+
+	_, err := engine.StartTaskBranch(ctx, TaskBranchRequest{
+		Repo:   "jerryfane/gitmoot",
+		TaskID: "task-8",
+		Branch: "task-8",
+		Owner:  "lead",
+	}, brancher)
+
+	if err == nil || !strings.Contains(err.Error(), "another task") {
+		t.Fatalf("error = %v, want branch assignment error", err)
+	}
+	if len(brancher.calls) != 0 {
+		t.Fatalf("branch was created despite assignment conflict: %+v", brancher.calls)
+	}
+}
+
+func TestEngineStartTaskBranchAllowsSameBranchInAnotherRepo(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-existing", RepoFullName: "jerryfane/other", GoalID: "goal-1", Title: "Existing", State: string(TaskPlanned), Branch: "task-8"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	engine := testEngine(store)
+	brancher := &fakeBranchCreator{}
+
+	task, err := engine.StartTaskBranch(ctx, TaskBranchRequest{
+		Repo:      "jerryfane/gitmoot",
+		GoalID:    "goal-1",
+		TaskID:    "task-8",
+		TaskTitle: "Task 8",
+		Branch:    "task-8",
+		Owner:     "lead",
+	}, brancher)
+	if err != nil {
+		t.Fatalf("StartTaskBranch returned error: %v", err)
+	}
+	if task.RepoFullName != "jerryfane/gitmoot" {
+		t.Fatalf("task repo = %q, want jerryfane/gitmoot", task.RepoFullName)
+	}
+}
+
+type fakeBranchCreator struct {
+	err   error
+	calls []branchCall
+}
+
+type branchCall struct {
+	branch string
+	base   string
+}
+
+func (f *fakeBranchCreator) CreateBranch(_ context.Context, branch string, base string) error {
+	f.calls = append(f.calls, branchCall{branch: branch, base: base})
+	return f.err
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -608,11 +608,12 @@ func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) 
 		return nil
 	}
 	task := db.Task{
-		ID:     ref.ID,
-		GoalID: ref.GoalID,
-		Title:  ref.Title,
-		State:  string(state),
-		Branch: ref.Branch,
+		ID:           ref.ID,
+		RepoFullName: ref.Repo,
+		GoalID:       ref.GoalID,
+		Title:        ref.Title,
+		State:        string(state),
+		Branch:       ref.Branch,
 	}
 	existing, err := e.Store.GetTask(ctx, ref.ID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -621,6 +622,9 @@ func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) 
 	if err == nil {
 		if task.GoalID == "" {
 			task.GoalID = existing.GoalID
+		}
+		if task.RepoFullName == "" {
+			task.RepoFullName = existing.RepoFullName
 		}
 		if task.Title == "" {
 			task.Title = existing.Title
@@ -655,6 +659,7 @@ func (e Engine) jobID(request JobRequest) string {
 
 type taskRef struct {
 	ID     string
+	Repo   string
 	GoalID string
 	Title  string
 	Branch string
@@ -663,6 +668,7 @@ type taskRef struct {
 func taskRefFromPullRequest(event PullRequestEvent) taskRef {
 	return taskRef{
 		ID:     event.TaskID,
+		Repo:   event.Repo,
 		GoalID: event.GoalID,
 		Title:  event.TaskTitle,
 		Branch: event.Branch,
@@ -672,6 +678,7 @@ func taskRefFromPullRequest(event PullRequestEvent) taskRef {
 func taskRefFromPayload(payload JobPayload) taskRef {
 	return taskRef{
 		ID:     payload.TaskID,
+		Repo:   payload.Repo,
 		GoalID: payload.GoalID,
 		Title:  payload.TaskTitle,
 		Branch: payload.Branch,

--- a/internal/workflow/pr_body.go
+++ b/internal/workflow/pr_body.go
@@ -1,0 +1,94 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type PullRequestBody struct {
+	TaskID          string
+	AgentNames      []string
+	What            string
+	Why             string
+	Changes         []string
+	Results         []string
+	Risk            string
+	RawReviewOutput string
+}
+
+func RenderPullRequestBody(body PullRequestBody) (string, error) {
+	if strings.TrimSpace(body.TaskID) == "" {
+		return "", errors.New("task id is required")
+	}
+	if strings.TrimSpace(body.RawReviewOutput) == "" {
+		return "", errors.New("raw final review output is required")
+	}
+	var builder strings.Builder
+	writeSection(&builder, "WHAT", requiredText(body.What, "No summary provided."))
+	writeSection(&builder, "WHY", requiredText(body.Why, "No rationale provided."))
+	writeListSection(&builder, "CHANGES", body.Changes)
+	writeListSection(&builder, "RESULTS", body.Results)
+	writeSection(&builder, "RISK", requiredText(body.Risk, "No residual risk reported."))
+	writeSection(&builder, "TASK", strings.TrimSpace(body.TaskID))
+	writeListSection(&builder, "AGENTS", body.AgentNames)
+	fence := rawOutputFence(body.RawReviewOutput)
+	builder.WriteString("RAW FINAL REVIEW OUTPUT:\n")
+	builder.WriteString(fence)
+	builder.WriteString("text\n")
+	builder.WriteString(body.RawReviewOutput)
+	if !strings.HasSuffix(body.RawReviewOutput, "\n") {
+		builder.WriteString("\n")
+	}
+	builder.WriteString(fence)
+	builder.WriteString("\n")
+	return builder.String(), nil
+}
+
+func writeSection(builder *strings.Builder, title string, value string) {
+	builder.WriteString(title)
+	builder.WriteString(":\n")
+	builder.WriteString(value)
+	builder.WriteString("\n\n")
+}
+
+func writeListSection(builder *strings.Builder, title string, values []string) {
+	builder.WriteString(title)
+	builder.WriteString(":\n")
+	values = compactStrings(values)
+	if len(values) == 0 {
+		builder.WriteString("- None reported.\n\n")
+		return
+	}
+	for _, value := range values {
+		fmt.Fprintf(builder, "- %s\n", value)
+	}
+	builder.WriteString("\n")
+}
+
+func requiredText(value string, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func rawOutputFence(value string) string {
+	longest := 0
+	current := 0
+	for _, char := range value {
+		if char == '`' {
+			current++
+			if current > longest {
+				longest = current
+			}
+			continue
+		}
+		current = 0
+	}
+	if longest < 3 {
+		longest = 3
+	}
+	return strings.Repeat("`", longest+1)
+}

--- a/internal/workflow/pr_body_test.go
+++ b/internal/workflow/pr_body_test.go
@@ -1,0 +1,71 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderPullRequestBodyIncludesRequiredSections(t *testing.T) {
+	body, err := RenderPullRequestBody(PullRequestBody{
+		TaskID:          "task-8",
+		AgentNames:      []string{"lead", "audit"},
+		What:            "Add branch rules.",
+		Why:             "Keep task work isolated.",
+		Changes:         []string{"Added lock release.", "Rendered PR body."},
+		Results:         []string{"go test ./..."},
+		Risk:            "No skipped checks.",
+		RawReviewOutput: "codex exec review is clean",
+	})
+	if err != nil {
+		t.Fatalf("RenderPullRequestBody returned error: %v", err)
+	}
+	for _, section := range []string{"WHAT:", "WHY:", "CHANGES:", "RESULTS:", "RISK:", "TASK:", "AGENTS:", "RAW FINAL REVIEW OUTPUT:"} {
+		if !strings.Contains(body, section) {
+			t.Fatalf("body missing section %s:\n%s", section, body)
+		}
+	}
+	for _, value := range []string{"task-8", "lead", "audit", "codex exec review is clean"} {
+		if !strings.Contains(body, value) {
+			t.Fatalf("body missing %q:\n%s", value, body)
+		}
+	}
+}
+
+func TestRenderPullRequestBodyRequiresTaskAndReviewOutput(t *testing.T) {
+	if _, err := RenderPullRequestBody(PullRequestBody{RawReviewOutput: "ok"}); err == nil {
+		t.Fatal("RenderPullRequestBody accepted empty task id")
+	}
+	if _, err := RenderPullRequestBody(PullRequestBody{TaskID: "task-8"}); err == nil {
+		t.Fatal("RenderPullRequestBody accepted empty raw review output")
+	}
+}
+
+func TestRenderPullRequestBodyPreservesRawReviewOutput(t *testing.T) {
+	raw := "\n codex exec review is clean \n\n"
+	body, err := RenderPullRequestBody(PullRequestBody{
+		TaskID:          "task-8",
+		RawReviewOutput: raw,
+	})
+	if err != nil {
+		t.Fatalf("RenderPullRequestBody returned error: %v", err)
+	}
+	want := "````text\n" + raw + "````\n"
+	if !strings.Contains(body, want) {
+		t.Fatalf("raw review output was not preserved:\n%s", body)
+	}
+}
+
+func TestRenderPullRequestBodyUsesSafeRawOutputFence(t *testing.T) {
+	raw := "review output\n```text\ninside\n```\n"
+	body, err := RenderPullRequestBody(PullRequestBody{
+		TaskID:          "task-8",
+		RawReviewOutput: raw,
+	})
+	if err != nil {
+		t.Fatalf("RenderPullRequestBody returned error: %v", err)
+	}
+	want := "````text\n" + raw + "````\n"
+	if !strings.Contains(body, want) {
+		t.Fatalf("raw review output fence was not safe:\n%s", body)
+	}
+}


### PR DESCRIPTION
WHAT:
Adds Task 8 branch ownership, writer locks, PR body rendering, and shared Git branch helpers.

WHY:
Task work needs one branch per task, a single implementer writer lock per branch, reviewer read/comment-only behavior by default, and auditable PR bodies.

CHANGES:
- Added repo-scoped task branch storage and uniqueness with migration dedupe for old duplicate branches.
- Added lock create/release helpers and branch startup rollback that only releases locks created by the current call.
- Added shared Git client helpers for branch create/current/push with safe branch-name validation and a temp-repo smoke test.
- Added structured PR body rendering with task id, agent names, risk/results sections, and raw review output preserved behind a safe Markdown fence.
- Enforced branch-lock ownership before comment-routed implement jobs and reused existing branch task/goal context for routed PR jobs.

RESULTS:
- go test ./internal/workflow ./internal/db ./internal/git ./internal/daemon
- go test ./...
- go vet ./...
- git diff --check
- codex exec review --uncommitted

RISK:
No skipped checks. Existing duplicate task branches are migrated by clearing duplicate branch assignments except the latest task per repo/branch.

TASK:
task-008

AGENTS:
- codex

RAW FINAL REVIEW OUTPUT:
````
No discrete correctness issues were found in the staged, unstaged, or untracked changes. The affected packages also pass `go test ./...` and `go vet ./...`.
````
