### PR TITLE
feat: add merge gate

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -65,13 +66,26 @@ func runDaemonStart(args []string, stdout, stderr io.Writer) int {
 	defer stop()
 
 	err = withStore(*home, func(store *db.Store) error {
-		engine := workflow.Engine{Store: store}
+		checkout, err := resolveDaemonCheckout(ctx, repo, gitutil.Client{Dir: "."})
+		if err != nil {
+			return err
+		}
+		gh := github.NewClient(checkout)
+		engine := workflow.Engine{
+			Store: store,
+			MergeGate: workflow.PolicyMergeGate{
+				Store:        store,
+				GitHub:       gh,
+				Git:          gitutil.Client{Dir: checkout},
+				DeleteBranch: true,
+			},
+		}
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
 		return (daemon.Daemon{
 			Repo:         repo,
 			PollInterval: *poll,
 			Store:        store,
-			GitHub:       github.NewClient("."),
+			GitHub:       gh,
 			Workflow:     &engine,
 		}).Run(ctx)
 	})
@@ -83,4 +97,23 @@ func runDaemonStart(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+func resolveDaemonCheckout(ctx context.Context, repo github.Repository, client gitutil.Client) (string, error) {
+	root, err := client.Root(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve daemon checkout: %w", err)
+	}
+	remote, err := client.OriginRemote(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve daemon checkout remote: %w", err)
+	}
+	remoteRepo, err := gitutil.ParseGitHubRemote(remote)
+	if err != nil {
+		return "", err
+	}
+	if remoteRepo.String() != repo.FullName() {
+		return "", fmt.Errorf("current checkout origin is %s, not %s", remoteRepo.String(), repo.FullName())
+	}
+	return root, nil
 }

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -2,8 +2,15 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"reflect"
 	"strings"
 	"testing"
+
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
 func TestRunDaemonUsageAndValidation(t *testing.T) {
@@ -34,5 +41,73 @@ func TestRunDaemonUsageAndValidation(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "poll interval must be positive") {
 		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestResolveDaemonCheckoutRequiresMatchingOrigin(t *testing.T) {
+	runner := &daemonGitRunner{results: []subprocess.Result{
+		{Stdout: "/repo/gitmoot\n"},
+		{Stdout: "https://github.com/jerryfane/gitmoot.git\n"},
+	}}
+
+	root, err := resolveDaemonCheckout(context.Background(), github.Repository{Owner: "jerryfane", Name: "gitmoot"}, gitutil.Client{Runner: runner, Dir: "."})
+
+	if err != nil {
+		t.Fatalf("resolveDaemonCheckout returned error: %v", err)
+	}
+	if root != "/repo/gitmoot" {
+		t.Fatalf("root = %q, want /repo/gitmoot", root)
+	}
+	runner.wantArgs(t, 0, "git", "rev-parse", "--show-toplevel")
+	runner.wantArgs(t, 1, "git", "remote", "get-url", "origin")
+}
+
+func TestResolveDaemonCheckoutRejectsWrongOrigin(t *testing.T) {
+	runner := &daemonGitRunner{results: []subprocess.Result{
+		{Stdout: "/repo/other\n"},
+		{Stdout: "https://github.com/jerryfane/other.git\n"},
+	}}
+
+	_, err := resolveDaemonCheckout(context.Background(), github.Repository{Owner: "jerryfane", Name: "gitmoot"}, gitutil.Client{Runner: runner, Dir: "."})
+
+	if err == nil || !strings.Contains(err.Error(), "not jerryfane/gitmoot") {
+		t.Fatalf("error = %v, want wrong-origin error", err)
+	}
+}
+
+type daemonGitRunner struct {
+	results []subprocess.Result
+	errs    []error
+	calls   [][]string
+}
+
+func (f *daemonGitRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	call := append([]string{command}, args...)
+	f.calls = append(f.calls, call)
+	index := len(f.calls) - 1
+	result := subprocess.Result{Command: command, Args: args}
+	if index < len(f.results) {
+		result = f.results[index]
+		result.Command = command
+		result.Args = args
+	}
+	var err error
+	if index < len(f.errs) {
+		err = f.errs[index]
+	}
+	return result, err
+}
+
+func (f *daemonGitRunner) LookPath(string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (f *daemonGitRunner) wantArgs(t *testing.T, index int, want ...string) {
+	t.Helper()
+	if index >= len(f.calls) {
+		t.Fatalf("missing call %d; calls=%v", index, f.calls)
+	}
+	if !reflect.DeepEqual(f.calls[index], want) {
+		t.Fatalf("call %d = %v, want %v", index, f.calls[index], want)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -60,7 +60,9 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	openBranches := map[string]struct{}{}
 	for _, pull := range pulls {
+		openBranches[pull.HeadRef] = struct{}{}
 		changed, err := d.pullRequestChanged(ctx, pull)
 		if err != nil {
 			return err
@@ -71,11 +73,29 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 					firstErr = err
 				}
 				changed = false
+			} else {
+				merged, err := d.pullRequestStoredMerged(ctx, pull)
+				if err != nil {
+					return err
+				}
+				if merged {
+					changed = false
+				}
 			}
 		}
 		if changed {
 			if err := d.recordPullRequest(ctx, pull); err != nil {
 				return err
+			}
+		} else {
+			retry, err := d.pullRequestReadyToMerge(ctx, pull)
+			if err != nil {
+				return err
+			}
+			if retry {
+				if err := d.handleReadyToMergeWorkflow(ctx, pull); err != nil && firstErr == nil {
+					firstErr = err
+				}
 			}
 		}
 		comments, err := d.GitHub.ListIssueComments(ctx, d.Repo, pull.Number)
@@ -87,6 +107,9 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 				return err
 			}
 		}
+	}
+	if err := d.retryClosedReadyToMerge(ctx, openBranches); err != nil && firstErr == nil {
+		firstErr = err
 	}
 	return firstErr
 }
@@ -108,17 +131,14 @@ func (d Daemon) pullRequestChanged(ctx context.Context, pull github.PullRequest)
 	previous, err := d.Store.GetPullRequest(ctx, d.Repo.FullName(), pull.Number)
 	switch {
 	case err == nil:
-		if strings.TrimSpace(previous.HeadSHA) == "" {
-			routed, err := d.pullRequestWorkflowRouted(ctx, pull)
-			if err != nil {
-				return false, err
-			}
-			if routed {
-				return false, d.recordPullRequest(ctx, pull)
-			}
+		if previous.HeadSHA != pull.HeadSHA {
 			return true, nil
 		}
-		return previous.HeadSHA != pull.HeadSHA, nil
+		routing, err := d.pullRequestWorkflowRouting(ctx, pull)
+		if err != nil {
+			return false, err
+		}
+		return routing.stale, nil
 	case errors.Is(err, sql.ErrNoRows):
 		return true, nil
 	default:
@@ -126,18 +146,23 @@ func (d Daemon) pullRequestChanged(ctx context.Context, pull github.PullRequest)
 	}
 }
 
-func (d Daemon) pullRequestWorkflowRouted(ctx context.Context, pull github.PullRequest) (bool, error) {
+type pullRequestRouting struct {
+	stale bool
+}
+
+func (d Daemon) pullRequestWorkflowRouting(ctx context.Context, pull github.PullRequest) (pullRequestRouting, error) {
 	jobs, err := d.Store.ListJobs(ctx)
 	if err != nil {
-		return false, err
+		return pullRequestRouting{}, err
 	}
+	routing := pullRequestRouting{}
 	for _, job := range jobs {
 		if job.Type != "review" {
 			continue
 		}
 		var payload workflow.JobPayload
 		if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
-			return false, fmt.Errorf("parse job payload %q: %w", job.ID, err)
+			return pullRequestRouting{}, fmt.Errorf("parse job payload %q: %w", job.ID, err)
 		}
 		if payload.Repo == d.Repo.FullName() &&
 			payload.PullRequest == int(pull.Number) &&
@@ -145,10 +170,13 @@ func (d Daemon) pullRequestWorkflowRouted(ctx context.Context, pull github.PullR
 			strings.TrimSpace(payload.LeadAgent) != "" &&
 			strings.TrimSpace(payload.ReviewRound) != "" &&
 			len(payload.Reviewers) > 0 {
-			return true, nil
+			if strings.TrimSpace(payload.HeadSHA) == pull.HeadSHA {
+				return pullRequestRouting{}, nil
+			}
+			routing.stale = true
 		}
 	}
-	return false, nil
+	return routing, nil
 }
 
 func (d Daemon) recordPullRequest(ctx context.Context, pull github.PullRequest) error {
@@ -161,6 +189,17 @@ func (d Daemon) recordPullRequest(ctx context.Context, pull github.PullRequest) 
 		HeadSHA:      pull.HeadSHA,
 		State:        pull.State,
 	})
+}
+
+func (d Daemon) pullRequestStoredMerged(ctx context.Context, pull github.PullRequest) (bool, error) {
+	stored, err := d.Store.GetPullRequest(ctx, d.Repo.FullName(), pull.Number)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.TrimSpace(stored.State) == "merged", nil
 }
 
 func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullRequest) error {
@@ -205,6 +244,105 @@ func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullR
 		Sender:            "github",
 		RequiredReviewers: reviewers,
 	})
+}
+
+func (d Daemon) pullRequestReadyToMerge(ctx context.Context, pull github.PullRequest) (bool, error) {
+	task, err := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return task.State == string(workflow.TaskReadyToMerge), nil
+}
+
+func (d Daemon) handleReadyToMergeWorkflow(ctx context.Context, pull github.PullRequest) error {
+	if d.Workflow == nil {
+		return nil
+	}
+	task, err := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
+	if err != nil {
+		return err
+	}
+	lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	leadAgent := strings.TrimSpace(lock.Owner)
+	if leadAgent == "" {
+		leadAgent = "github"
+	}
+	branch := task.Branch
+	if branch == "" {
+		branch = pull.HeadRef
+	}
+	return d.Workflow.HandlePullRequestReadyToMerge(ctx, workflow.PullRequestEvent{
+		Repo:        d.Repo.FullName(),
+		Branch:      branch,
+		PullRequest: int(pull.Number),
+		HeadSHA:     pull.HeadSHA,
+		GoalID:      task.GoalID,
+		TaskID:      task.ID,
+		TaskTitle:   task.Title,
+		LeadAgent:   leadAgent,
+		Sender:      "github",
+	})
+}
+
+func (d Daemon) retryClosedReadyToMerge(ctx context.Context, openBranches map[string]struct{}) error {
+	tasks, err := d.Store.ListTasksByRepoState(ctx, d.Repo.FullName(), string(workflow.TaskReadyToMerge))
+	if err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		return nil
+	}
+	type readyPullRequest struct {
+		number  int64
+		headSHA string
+	}
+	readyBranches := map[string]readyPullRequest{}
+	for _, task := range tasks {
+		if task.Branch == "" {
+			continue
+		}
+		if _, open := openBranches[task.Branch]; open {
+			continue
+		}
+		stored, err := d.Store.GetPullRequestByRepoBranch(ctx, d.Repo.FullName(), task.Branch)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return err
+		}
+		readyBranches[task.Branch] = readyPullRequest{number: stored.Number, headSHA: stored.HeadSHA}
+	}
+	if len(readyBranches) == 0 {
+		return nil
+	}
+	closed, err := d.GitHub.ListPullRequests(ctx, d.Repo, "closed")
+	if err != nil {
+		return err
+	}
+	for _, pull := range closed {
+		ready, ok := readyBranches[pull.HeadRef]
+		if !ok {
+			continue
+		}
+		if pull.Number != ready.number {
+			continue
+		}
+		if ready.headSHA != "" && pull.HeadSHA != ready.headSHA {
+			continue
+		}
+		if err := d.handleReadyToMergeWorkflow(ctx, pull); err != nil {
+			return err
+		}
+		delete(readyBranches, pull.HeadRef)
+	}
+	return nil
 }
 
 func (d Daemon) lookupPullRequestTask(ctx context.Context, repoFullName string, branch string) (db.Task, error) {
@@ -317,6 +455,7 @@ func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comm
 		Repo:         d.Repo.FullName(),
 		Branch:       pull.HeadRef,
 		PullRequest:  int(pull.Number),
+		HeadSHA:      pull.HeadSHA,
 		GoalID:       ref.goalID,
 		TaskID:       ref.id,
 		TaskTitle:    ref.title,

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -271,10 +271,11 @@ func TestPollOnceRecordsAlreadyRoutedPullRequestWithoutDuplicateReviewRound(t *t
 	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
 		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
 	}
-	payload, err := json.Marshal(workflow.JobPayload{
+	stalePayload, err := json.Marshal(workflow.JobPayload{
 		Repo:        repo.FullName(),
 		Branch:      "task-7",
 		PullRequest: 7,
+		HeadSHA:     "old123",
 		TaskID:      "task-7",
 		LeadAgent:   "lead",
 		Reviewers:   []string{"audit"},
@@ -288,7 +289,29 @@ func TestPollOnceRecordsAlreadyRoutedPullRequestWithoutDuplicateReviewRound(t *t
 		Agent:   "audit",
 		Type:    "review",
 		State:   string(workflow.JobQueued),
-		Payload: string(payload),
+		Payload: string(stalePayload),
+	}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "old routed review"}); err != nil {
+		t.Fatalf("CreateJobWithEvent stale returned error: %v", err)
+	}
+	currentPayload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-7",
+		PullRequest: 7,
+		HeadSHA:     "abc123",
+		TaskID:      "task-7",
+		LeadAgent:   "lead",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-2",
+	})
+	if err != nil {
+		t.Fatalf("Marshal current returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID:      "review-audit-task-7-review-2",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(workflow.JobQueued),
+		Payload: string(currentPayload),
 	}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "already routed by engine"}); err != nil {
 		t.Fatalf("CreateJobWithEvent returned error: %v", err)
 	}
@@ -296,6 +319,7 @@ func TestPollOnceRecordsAlreadyRoutedPullRequestWithoutDuplicateReviewRound(t *t
 		RepoFullName: repo.FullName(),
 		Number:       7,
 		HeadBranch:   "task-7",
+		HeadSHA:      "abc123",
 		State:        "open",
 	}); err != nil {
 		t.Fatalf("UpsertPullRequest returned error: %v", err)
@@ -327,11 +351,285 @@ func TestPollOnceRecordsAlreadyRoutedPullRequestWithoutDuplicateReviewRound(t *t
 	if err := daemon.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce returned error: %v", err)
 	}
-	if _, err := store.GetJob(ctx, "review-audit-task-7-review-2"); err == nil {
+	if _, err := store.GetJob(ctx, "review-audit-task-7-review-3"); err == nil {
 		t.Fatal("already routed pull request created a duplicate review round")
 	}
 	if pr, err := store.GetPullRequest(ctx, repo.FullName(), 7); err != nil || pr.HeadSHA != "abc123" {
 		t.Fatalf("stored pull request = %+v err=%v", pr, err)
+	}
+}
+
+func TestPollOnceReroutesLegacyReviewWithoutHeadSHA(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Role:           "lead",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		LeadAgent:   "lead",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-1",
+	})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID:      "review-audit-task-7-review-1",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(workflow.JobQueued),
+		Payload: string(payload),
+	}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "legacy review"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       7,
+		HeadBranch:   "task-7",
+		HeadSHA:      "abc123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	engine := workflow.Engine{
+		Store: store,
+		JobID: func(request workflow.JobRequest) string {
+			parts := []string{request.Action, request.Agent, request.TaskID}
+			if request.ReviewRound != "" {
+				parts = append(parts, request.ReviewRound)
+			}
+			return strings.Join(parts, "-")
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "review-audit-task-7-review-2")
+	if err != nil {
+		t.Fatalf("GetJob rerouted review returned error: %v", err)
+	}
+	if !strings.Contains(job.Payload, `"head_sha":"abc123"`) {
+		t.Fatalf("rerouted job payload missing head sha: %s", job.Payload)
+	}
+}
+
+func TestPollOnceRetriesReadyToMergePullRequestWithoutHeadChange(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-7",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1",
+		Title:        "Task 7",
+		State:        string(workflow.TaskReadyToMerge),
+		Branch:       "task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       7,
+		URL:          "https://github.com/jerryfane/gitmoot/pull/7",
+		HeadBranch:   "task-7",
+		BaseBranch:   "main",
+		HeadSHA:      "abc123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 || gate.requests[0].HeadSHA != "abc123" {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestPollOnceRetriesClosedReadyToMergePullRequest(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-7",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1",
+		Title:        "Task 7",
+		State:        string(workflow.TaskReadyToMerge),
+		Branch:       "task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       7,
+		URL:          "https://github.com/jerryfane/gitmoot/pull/7",
+		HeadBranch:   "task-7",
+		BaseBranch:   "main",
+		HeadSHA:      "abc123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pullsByState: map[string][]github.PullRequest{
+			"open": {},
+			"closed": {{
+				Number:  6,
+				Title:   "Task 7 old",
+				State:   "closed",
+				Merged:  true,
+				URL:     "https://github.com/jerryfane/gitmoot/pull/6",
+				HeadRef: "task-7",
+				BaseRef: "main",
+				HeadSHA: "old123",
+			}, {
+				Number:  7,
+				Title:   "Task 7",
+				State:   "closed",
+				Merged:  true,
+				URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+				HeadRef: "task-7",
+				BaseRef: "main",
+				HeadSHA: "abc123",
+			}},
+		},
+		comments: map[int64][]github.IssueComment{},
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 || gate.requests[0].HeadSHA != "abc123" {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestPollOnceDoesNotOverwriteNoReviewerAutoMerge(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Role:           "lead",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	gate := &fakeWorkflowMergeGate{
+		decision: workflow.MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"},
+		onEvaluate: func(request workflow.MergeRequest) {
+			if err := store.UpsertPullRequest(ctx, db.PullRequest{
+				RepoFullName:   request.Repo,
+				Number:         int64(request.PullRequest),
+				URL:            "https://github.com/jerryfane/gitmoot/pull/7",
+				HeadBranch:     request.Branch,
+				BaseBranch:     "main",
+				HeadSHA:        request.HeadSHA,
+				MergeCommitSHA: "merge123",
+				State:          "merged",
+			}); err != nil {
+				t.Fatalf("UpsertPullRequest returned error: %v", err)
+			}
+		},
+	}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	pr, err := store.GetPullRequest(ctx, repo.FullName(), 7)
+	if err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+	if pr.State != "merged" || pr.MergeCommitSHA != "merge123" {
+		t.Fatalf("stored pull request = %+v", pr)
 	}
 }
 
@@ -884,6 +1182,7 @@ func testStore(t *testing.T) *db.Store {
 
 type fakeGitHub struct {
 	pulls                 []github.PullRequest
+	pullsByState          map[string][]github.PullRequest
 	comments              map[int64][]github.IssueComment
 	posted                []postedComment
 	permissions           map[string]string
@@ -901,7 +1200,7 @@ func (f *fakeGitHub) Ping(context.Context) error {
 	return nil
 }
 
-func (f *fakeGitHub) ListPullRequests(context.Context, github.Repository, string) ([]github.PullRequest, error) {
+func (f *fakeGitHub) ListPullRequests(_ context.Context, _ github.Repository, state string) ([]github.PullRequest, error) {
 	f.listPullRequestsCalls++
 	if len(f.listPullRequestsErrs) > 0 {
 		err := f.listPullRequestsErrs[0]
@@ -909,6 +1208,9 @@ func (f *fakeGitHub) ListPullRequests(context.Context, github.Repository, string
 		if err != nil {
 			return nil, err
 		}
+	}
+	if f.pullsByState != nil {
+		return append([]github.PullRequest(nil), f.pullsByState[state]...), nil
 	}
 	return append([]github.PullRequest(nil), f.pulls...), nil
 }
@@ -945,8 +1247,16 @@ func (f *fakeGitHub) MergePullRequest(context.Context, github.MergePullRequestIn
 	return github.MergeResult{}, errors.New("not implemented")
 }
 
+func (f *fakeGitHub) GetPullRequest(context.Context, github.Repository, int64) (github.PullRequest, error) {
+	return github.PullRequest{}, errors.New("not implemented")
+}
+
 func (f *fakeGitHub) GetCombinedStatus(context.Context, github.Repository, string) (github.CombinedStatus, error) {
 	return github.CombinedStatus{}, errors.New("not implemented")
+}
+
+func (f *fakeGitHub) CompareCommits(context.Context, github.Repository, string, string) (github.CompareResult, error) {
+	return github.CompareResult{}, errors.New("not implemented")
 }
 
 func (f *fakeGitHub) ListPullRequestChecks(context.Context, github.Repository, int64) ([]github.PullRequestCheck, error) {
@@ -963,4 +1273,18 @@ func (f *fakeGitHub) ListPullRequestFiles(context.Context, github.Repository, in
 
 func (f *fakeGitHub) ListPullRequestCommits(context.Context, github.Repository, int64) ([]github.PullRequestCommit, error) {
 	return nil, errors.New("not implemented")
+}
+
+type fakeWorkflowMergeGate struct {
+	decision   workflow.MergeDecision
+	onEvaluate func(workflow.MergeRequest)
+	requests   []workflow.MergeRequest
+}
+
+func (f *fakeWorkflowMergeGate) Evaluate(_ context.Context, request workflow.MergeRequest) (workflow.MergeDecision, error) {
+	f.requests = append(f.requests, request)
+	if f.onEvaluate != nil {
+		f.onEvaluate(request)
+	}
+	return f.decision, nil
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -50,13 +50,14 @@ type Task struct {
 }
 
 type PullRequest struct {
-	RepoFullName string
-	Number       int64
-	URL          string
-	HeadBranch   string
-	BaseBranch   string
-	HeadSHA      string
-	State        string
+	RepoFullName   string
+	Number         int64
+	URL            string
+	HeadBranch     string
+	BaseBranch     string
+	HeadSHA        string
+	MergeCommitSHA string
+	State          string
 }
 
 type Comment struct {
@@ -272,6 +273,26 @@ func (s *Store) GetTaskByRepoBranch(ctx context.Context, repoFullName string, br
 	return scanTask(row)
 }
 
+func (s *Store) ListTasksByRepoState(ctx context.Context, repoFullName string, state string) ([]Task, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch
+		FROM tasks
+		WHERE repo_full_name = ? AND state = ?
+		ORDER BY id`, repoFullName, state)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	tasks := []Task{}
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+	return tasks, rows.Err()
+}
+
 func scanTask(row interface{ Scan(dest ...any) error }) (Task, error) {
 	var task Task
 	if err := row.Scan(&task.ID, &task.RepoFullName, &task.GoalID, &task.Title, &task.State, &task.Branch); err != nil {
@@ -281,24 +302,35 @@ func scanTask(row interface{ Scan(dest ...any) error }) (Task, error) {
 }
 
 func (s *Store) UpsertPullRequest(ctx context.Context, pr PullRequest) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO pull_requests(repo_full_name, number, url, head_branch, base_branch, head_sha, state, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO pull_requests(repo_full_name, number, url, head_branch, base_branch, head_sha, merge_commit_sha, state, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(repo_full_name, number) DO UPDATE SET
 			url = excluded.url,
 			head_branch = excluded.head_branch,
 			base_branch = excluded.base_branch,
 			head_sha = excluded.head_sha,
+			merge_commit_sha = excluded.merge_commit_sha,
 			state = excluded.state,
 			updated_at = CURRENT_TIMESTAMP`,
-		pr.RepoFullName, pr.Number, pr.URL, pr.HeadBranch, pr.BaseBranch, pr.HeadSHA, pr.State)
+		pr.RepoFullName, pr.Number, pr.URL, pr.HeadBranch, pr.BaseBranch, pr.HeadSHA, pr.MergeCommitSHA, pr.State)
 	return err
 }
 
 func (s *Store) GetPullRequest(ctx context.Context, repoFullName string, number int64) (PullRequest, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, number, url, head_branch, base_branch, head_sha, state
+	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, number, url, head_branch, base_branch, head_sha, merge_commit_sha, state
 		FROM pull_requests WHERE repo_full_name = ? AND number = ?`, repoFullName, number)
 	var pr PullRequest
-	if err := row.Scan(&pr.RepoFullName, &pr.Number, &pr.URL, &pr.HeadBranch, &pr.BaseBranch, &pr.HeadSHA, &pr.State); err != nil {
+	if err := row.Scan(&pr.RepoFullName, &pr.Number, &pr.URL, &pr.HeadBranch, &pr.BaseBranch, &pr.HeadSHA, &pr.MergeCommitSHA, &pr.State); err != nil {
+		return PullRequest{}, err
+	}
+	return pr, nil
+}
+
+func (s *Store) GetPullRequestByRepoBranch(ctx context.Context, repoFullName string, branch string) (PullRequest, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, number, url, head_branch, base_branch, head_sha, merge_commit_sha, state
+		FROM pull_requests WHERE repo_full_name = ? AND head_branch = ? ORDER BY number DESC LIMIT 1`, repoFullName, branch)
+	var pr PullRequest
+	if err := row.Scan(&pr.RepoFullName, &pr.Number, &pr.URL, &pr.HeadBranch, &pr.BaseBranch, &pr.HeadSHA, &pr.MergeCommitSHA, &pr.State); err != nil {
 		return PullRequest{}, err
 	}
 	return pr, nil
@@ -710,5 +742,8 @@ SET branch = ''
 WHERE rowid IN (SELECT task_rowid FROM ranked_tasks WHERE branch_rank > 1);
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_repo_branch_unique ON tasks(repo_full_name, branch) WHERE branch <> '';
+	`,
+	`
+ALTER TABLE pull_requests ADD COLUMN merge_commit_sha TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -98,6 +98,13 @@ func TestRepositoryMethods(t *testing.T) {
 	if pr.HeadSHA != "abc123" {
 		t.Fatalf("pull request head sha = %q, want abc123", pr.HeadSHA)
 	}
+	byBranch, err := store.GetPullRequestByRepoBranch(ctx, "jerryfane/gitmoot", "task")
+	if err != nil {
+		t.Fatalf("GetPullRequestByRepoBranch returned error: %v", err)
+	}
+	if byBranch.Number != 1 || byBranch.HeadSHA != "abc123" {
+		t.Fatalf("pull request by branch = %+v", byBranch)
+	}
 	if err := store.MarkCommentSeen(ctx, Comment{RepoFullName: "jerryfane/gitmoot", CommentID: 100, PullRequest: 1, Body: "/gitmoot audit review"}); err != nil {
 		t.Fatalf("MarkCommentSeen returned error: %v", err)
 	}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -49,6 +49,55 @@ func (c Client) PushBranch(ctx context.Context, remote string, branch string) er
 	return err
 }
 
+func (c Client) Root(ctx context.Context) (string, error) {
+	result, err := c.run(ctx, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", err
+	}
+	root := strings.TrimSpace(result.Stdout)
+	if root == "" {
+		return "", errors.New("git root is empty")
+	}
+	return root, nil
+}
+
+func (c Client) OriginRemote(ctx context.Context) (string, error) {
+	result, err := c.run(ctx, "remote", "get-url", "origin")
+	if err != nil {
+		return "", err
+	}
+	remote := strings.TrimSpace(result.Stdout)
+	if remote == "" {
+		return "", errors.New("origin remote is empty")
+	}
+	return remote, nil
+}
+
+func (c Client) WorktreeClean(ctx context.Context) (bool, error) {
+	result, err := c.run(ctx, "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(result.Stdout) == "", nil
+}
+
+func (c Client) UpdateBase(ctx context.Context, remote string, branch string) error {
+	if strings.TrimSpace(remote) == "" {
+		remote = "origin"
+	}
+	if err := validateBranch(branch); err != nil {
+		return err
+	}
+	if _, err := c.run(ctx, "fetch", remote, branch); err != nil {
+		return err
+	}
+	if _, err := c.run(ctx, "switch", branch); err != nil {
+		return err
+	}
+	_, err := c.run(ctx, "pull", "--ff-only", remote, branch)
+	return err
+}
+
 func (c Client) run(ctx context.Context, args ...string) (subprocess.Result, error) {
 	runner := c.Runner
 	if runner == nil {

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestClientUsesSharedSubprocessRunner(t *testing.T) {
-	runner := &fakeRunner{results: []subprocess.Result{{}, {Stdout: "task-1\n"}}}
+	runner := &fakeRunner{results: []subprocess.Result{{}, {Stdout: "task-1\n"}, {}, {Stdout: "/repo\n"}, {Stdout: "https://github.com/jerryfane/gitmoot.git\n"}, {}, {}, {}}}
 	client := Client{Runner: runner, Dir: "/repo"}
 
 	if err := client.CreateBranch(context.Background(), "task-1", "main"); err != nil {
@@ -30,10 +30,40 @@ func TestClientUsesSharedSubprocessRunner(t *testing.T) {
 	if err := client.PushBranch(context.Background(), "origin", "task-1"); err != nil {
 		t.Fatalf("PushBranch returned error: %v", err)
 	}
+	root, err := client.Root(context.Background())
+	if err != nil {
+		t.Fatalf("Root returned error: %v", err)
+	}
+	if root != "/repo" {
+		t.Fatalf("root = %q, want /repo", root)
+	}
+	remote, err := client.OriginRemote(context.Background())
+	if err != nil {
+		t.Fatalf("OriginRemote returned error: %v", err)
+	}
+	if remote != "https://github.com/jerryfane/gitmoot.git" {
+		t.Fatalf("remote = %q", remote)
+	}
+	clean, err := client.WorktreeClean(context.Background())
+	if err != nil {
+		t.Fatalf("WorktreeClean returned error: %v", err)
+	}
+	if !clean {
+		t.Fatal("WorktreeClean reported dirty worktree")
+	}
+	if err := client.UpdateBase(context.Background(), "origin", "main"); err != nil {
+		t.Fatalf("UpdateBase returned error: %v", err)
+	}
 
 	runner.wantArgs(t, 0, "git", "switch", "-c", "task-1", "main")
 	runner.wantArgs(t, 1, "git", "branch", "--show-current")
 	runner.wantArgs(t, 2, "git", "push", "-u", "origin", "task-1")
+	runner.wantArgs(t, 3, "git", "rev-parse", "--show-toplevel")
+	runner.wantArgs(t, 4, "git", "remote", "get-url", "origin")
+	runner.wantArgs(t, 5, "git", "status", "--porcelain")
+	runner.wantArgs(t, 6, "git", "fetch", "origin", "main")
+	runner.wantArgs(t, 7, "git", "switch", "main")
+	runner.wantArgs(t, 8, "git", "pull", "--ff-only", "origin", "main")
 }
 
 func TestClientRejectsUnsafeBranchNames(t *testing.T) {
@@ -70,6 +100,40 @@ func TestClientCreateBranchSmoke(t *testing.T) {
 	}
 	if branch != "task-branch" {
 		t.Fatalf("branch = %q, want task-branch", branch)
+	}
+}
+
+func TestClientWorktreeCleanSmoke(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, dir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# smoke\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "init")
+
+	client := Client{Dir: dir}
+	clean, err := client.WorktreeClean(context.Background())
+	if err != nil {
+		t.Fatalf("WorktreeClean returned error: %v", err)
+	}
+	if !clean {
+		t.Fatal("new repository should be clean")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile dirty returned error: %v", err)
+	}
+	clean, err = client.WorktreeClean(context.Background())
+	if err != nil {
+		t.Fatalf("dirty WorktreeClean returned error: %v", err)
+	}
+	if clean {
+		t.Fatal("WorktreeClean did not report untracked file")
 	}
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -16,12 +17,14 @@ import (
 type Client interface {
 	Ping(ctx context.Context) error
 	ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error)
+	GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
 	ListIssueComments(ctx context.Context, repo Repository, issueNumber int64) ([]IssueComment, error)
 	PostIssueComment(ctx context.Context, repo Repository, issueNumber int64, body string) (IssueComment, error)
 	GetUserPermission(ctx context.Context, repo Repository, username string) (UserPermission, error)
 	MergePullRequest(ctx context.Context, input MergePullRequestInput) (MergeResult, error)
 	GetCombinedStatus(ctx context.Context, repo Repository, ref string) (CombinedStatus, error)
+	CompareCommits(ctx context.Context, repo Repository, base string, head string) (CompareResult, error)
 	ListPullRequestChecks(ctx context.Context, repo Repository, number int64) ([]PullRequestCheck, error)
 	CreateCommitStatus(ctx context.Context, input CommitStatusInput) (CommitStatus, error)
 	ListPullRequestFiles(ctx context.Context, repo Repository, number int64) ([]PullRequestFile, error)
@@ -45,9 +48,12 @@ type PullRequest struct {
 	Title     string `json:"title"`
 	State     string `json:"state"`
 	URL       string `json:"html_url"`
+	Merged    bool   `json:"merged"`
 	HeadRef   string
 	BaseRef   string
+	BaseSHA   string
 	HeadSHA   string
+	MergeSHA  string
 	Mergeable *bool `json:"mergeable"`
 }
 
@@ -57,13 +63,16 @@ func (p *PullRequest) UnmarshalJSON(data []byte) error {
 		Title     string `json:"title"`
 		State     string `json:"state"`
 		URL       string `json:"html_url"`
+		Merged    bool   `json:"merged"`
 		Mergeable *bool  `json:"mergeable"`
+		MergeSHA  string `json:"merge_commit_sha"`
 		Head      struct {
 			Ref string `json:"ref"`
 			SHA string `json:"sha"`
 		} `json:"head"`
 		Base struct {
 			Ref string `json:"ref"`
+			SHA string `json:"sha"`
 		} `json:"base"`
 	}
 	var decoded wire
@@ -74,10 +83,13 @@ func (p *PullRequest) UnmarshalJSON(data []byte) error {
 	p.Title = decoded.Title
 	p.State = decoded.State
 	p.URL = decoded.URL
+	p.Merged = decoded.Merged
 	p.Mergeable = decoded.Mergeable
 	p.HeadRef = decoded.Head.Ref
 	p.HeadSHA = decoded.Head.SHA
+	p.MergeSHA = decoded.MergeSHA
 	p.BaseRef = decoded.Base.Ref
+	p.BaseSHA = decoded.Base.SHA
 	return nil
 }
 
@@ -149,6 +161,12 @@ type CombinedStatus struct {
 	Statuses []CommitStatus `json:"statuses"`
 }
 
+type CompareResult struct {
+	Status   string `json:"status"`
+	AheadBy  int    `json:"ahead_by"`
+	BehindBy int    `json:"behind_by"`
+}
+
 type CommitStatusInput struct {
 	Repo        Repository
 	SHA         string
@@ -210,6 +228,10 @@ func (c *GhClient) ListPullRequests(ctx context.Context, repo Repository, state 
 		state = "open"
 	}
 	return apiPaginatedJSON[PullRequest](ctx, c, "-X", "GET", endpoint(repo, "pulls"), "-f", "state="+state)
+}
+
+func (c *GhClient) GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error) {
+	return c.getPullRequest(ctx, repo, number)
 }
 
 func (c *GhClient) CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error) {
@@ -289,13 +311,26 @@ func (c *GhClient) MergePullRequest(ctx context.Context, input MergePullRequestI
 	if _, err := c.run(ctx, true, args...); err != nil {
 		return MergeResult{}, err
 	}
-	return MergeResult{Merged: true}, nil
+	pr, err := c.getPullRequest(ctx, input.Repo, input.Number)
+	if err != nil {
+		return MergeResult{}, fmt.Errorf("fetch merged pull request: %w", err)
+	}
+	if !pr.Merged && strings.TrimSpace(pr.State) != "merged" {
+		return MergeResult{Message: fmt.Sprintf("pull request merge is pending; current state is %q", pr.State)}, nil
+	}
+	return MergeResult{SHA: pr.MergeSHA, Merged: true}, nil
 }
 
 func (c *GhClient) GetCombinedStatus(ctx context.Context, repo Repository, ref string) (CombinedStatus, error) {
 	var status CombinedStatus
 	err := c.apiJSON(ctx, false, &status, endpoint(repo, "commits", ref, "status"))
 	return status, err
+}
+
+func (c *GhClient) CompareCommits(ctx context.Context, repo Repository, base string, head string) (CompareResult, error) {
+	var result CompareResult
+	err := c.apiJSON(ctx, false, &result, endpoint(repo, "compare", url.PathEscape(base+"..."+head)))
+	return result, err
 }
 
 func (c *GhClient) ListPullRequestChecks(ctx context.Context, repo Repository, number int64) ([]PullRequestCheck, error) {
@@ -490,6 +525,10 @@ func (NoopClient) ListPullRequests(context.Context, Repository, string) ([]PullR
 	return nil, errors.ErrUnsupported
 }
 
+func (NoopClient) GetPullRequest(context.Context, Repository, int64) (PullRequest, error) {
+	return PullRequest{}, errors.ErrUnsupported
+}
+
 func (NoopClient) CreatePullRequest(context.Context, CreatePullRequestInput) (PullRequest, error) {
 	return PullRequest{}, errors.ErrUnsupported
 }
@@ -512,6 +551,10 @@ func (NoopClient) MergePullRequest(context.Context, MergePullRequestInput) (Merg
 
 func (NoopClient) GetCombinedStatus(context.Context, Repository, string) (CombinedStatus, error) {
 	return CombinedStatus{}, errors.ErrUnsupported
+}
+
+func (NoopClient) CompareCommits(context.Context, Repository, string, string) (CompareResult, error) {
+	return CompareResult{}, errors.ErrUnsupported
 }
 
 func (NoopClient) ListPullRequestChecks(context.Context, Repository, int64) ([]PullRequestCheck, error) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -129,6 +129,44 @@ func TestCreateCommitStatusUsesStatusesEndpoint(t *testing.T) {
 	)
 }
 
+func TestGetPullRequestDecodesBaseSHA(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"number": 2, "title": "Task", "state": "open", "html_url": "https://github.com/jerryfane/gitmoot/pull/2", "head": {"ref": "task", "sha": "head123"}, "base": {"ref": "main", "sha": "base123"}}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	pr, err := client.GetPullRequest(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, 2)
+
+	if err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+	if pr.HeadSHA != "head123" || pr.BaseSHA != "base123" {
+		t.Fatalf("pull request = %+v", pr)
+	}
+	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/pulls/2")
+}
+
+func TestCompareCommitsUsesEscapedCompareEndpoint(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"status": "ahead", "ahead_by": 3, "behind_by": 0}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	compare, err := client.CompareCommits(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, "release/1.0", "head123")
+
+	if err != nil {
+		t.Fatalf("CompareCommits returned error: %v", err)
+	}
+	if compare.Status != "ahead" || compare.AheadBy != 3 || compare.BehindBy != 0 {
+		t.Fatalf("compare = %+v", compare)
+	}
+	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/compare/release%2F1.0...head123")
+}
+
 func TestListPullRequestChecksUsesGhChecksOutput(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{
@@ -194,7 +232,10 @@ func TestListPullRequestChecksTreatsNoChecksAsEmpty(t *testing.T) {
 }
 
 func TestMergePullRequestUsesSafeHeadMatch(t *testing.T) {
-	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "merged"}}}
+	runner := &fakeRunner{results: []subprocess.Result{
+		{Stdout: "merged"},
+		{Stdout: `{"number": 2, "title": "Task", "state": "closed", "merged": true, "html_url": "https://github.com/jerryfane/gitmoot/pull/2", "merge_commit_sha": "merge123", "head": {"ref": "task", "sha": "abc123"}, "base": {"ref": "main"}}`},
+	}}
 	client := GhClient{Runner: runner}
 
 	result, err := client.MergePullRequest(context.Background(), MergePullRequestInput{
@@ -209,7 +250,7 @@ func TestMergePullRequestUsesSafeHeadMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MergePullRequest returned error: %v", err)
 	}
-	if !result.Merged {
+	if !result.Merged || result.SHA != "merge123" {
 		t.Fatalf("merge result = %+v", result)
 	}
 	runner.wantArgs(t, 0,
@@ -220,6 +261,49 @@ func TestMergePullRequestUsesSafeHeadMatch(t *testing.T) {
 		"--match-head-commit", "abc123",
 		"--delete-branch",
 	)
+	runner.wantArgs(t, 1, "api", "repos/jerryfane/gitmoot/pulls/2")
+}
+
+func TestMergePullRequestRequiresConfirmedMergedState(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stdout: "merged"},
+			{Stderr: "HTTP 502"},
+		},
+		errs: []error{nil, errors.New("exit status 1")},
+	}
+	client := GhClient{Runner: runner}
+
+	result, err := client.MergePullRequest(context.Background(), MergePullRequestInput{
+		Repo:            Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Number:          2,
+		MatchHeadCommit: "abc123",
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "fetch merged pull request") {
+		t.Fatalf("error = %v, want fetch confirmation error; result=%+v", err, result)
+	}
+}
+
+func TestMergePullRequestReportsQueuedMergeAsPending(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{
+		{Stdout: "queued"},
+		{Stdout: `{"number": 2, "title": "Task", "state": "open", "html_url": "https://github.com/jerryfane/gitmoot/pull/2", "merge_commit_sha": "synthetic", "head": {"ref": "task", "sha": "abc123"}, "base": {"ref": "main"}}`},
+	}}
+	client := GhClient{Runner: runner}
+
+	result, err := client.MergePullRequest(context.Background(), MergePullRequestInput{
+		Repo:            Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Number:          2,
+		MatchHeadCommit: "abc123",
+	})
+
+	if err != nil {
+		t.Fatalf("MergePullRequest returned error: %v", err)
+	}
+	if result.Merged || !strings.Contains(result.Message, "pending") {
+		t.Fatalf("merge result = %+v", result)
+	}
 }
 
 func TestRateLimitBackoffRetries(t *testing.T) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -34,16 +34,20 @@ type PullRequestEvent struct {
 }
 
 type MergeRequest struct {
-	Repo        string
-	Branch      string
-	PullRequest int
-	TaskID      string
-	Reviewer    string
+	Repo           string
+	Branch         string
+	PullRequest    int
+	HeadSHA        string
+	TaskID         string
+	Reviewer       string
+	ReviewOptional bool
 }
 
 type MergeDecision struct {
-	Ready  bool
-	Reason string
+	Ready          bool
+	Merged         bool
+	MergeCommitSHA string
+	Reason         string
 }
 
 type MergeGate interface {
@@ -82,16 +86,21 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 		reviewers = compactStrings(append([]string{}, e.RequiredReviewers...))
 	}
 	if len(reviewers) == 0 {
-		if err := e.runMergeGate(ctx, "", JobPayload{
+		decision, err := e.runMergeGate(ctx, "", JobPayload{
 			Repo:        event.Repo,
 			Branch:      event.Branch,
 			PullRequest: event.PullRequest,
+			HeadSHA:     event.HeadSHA,
 			GoalID:      event.GoalID,
 			TaskID:      event.TaskID,
 			TaskTitle:   event.TaskTitle,
 			LeadAgent:   event.LeadAgent,
-		}, ref); err != nil {
+		}, ref)
+		if err != nil {
 			return err
+		}
+		if decision.Merged {
+			return nil
 		}
 		return e.recordPullRequestBaseline(ctx, event)
 	}
@@ -107,6 +116,7 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 			Repo:        event.Repo,
 			Branch:      event.Branch,
 			PullRequest: event.PullRequest,
+			HeadSHA:     event.HeadSHA,
 			GoalID:      event.GoalID,
 			TaskID:      event.TaskID,
 			TaskTitle:   event.TaskTitle,
@@ -136,6 +146,27 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 		return err
 	}
 	return e.recordPullRequestBaseline(ctx, event)
+}
+
+func (e Engine) HandlePullRequestReadyToMerge(ctx context.Context, event PullRequestEvent) error {
+	if err := e.validate(); err != nil {
+		return err
+	}
+	if err := validatePullRequestEvent(event); err != nil {
+		return err
+	}
+	ref := taskRefFromPullRequest(event)
+	_, err := e.runMergeGate(ctx, "", JobPayload{
+		Repo:        event.Repo,
+		Branch:      event.Branch,
+		PullRequest: event.PullRequest,
+		HeadSHA:     event.HeadSHA,
+		GoalID:      event.GoalID,
+		TaskID:      event.TaskID,
+		TaskTitle:   event.TaskTitle,
+		LeadAgent:   event.LeadAgent,
+	}, ref)
+	return err
 }
 
 func (e Engine) RunJob(ctx context.Context, jobID string, agent runtime.Agent, adapter DeliveryAdapter) (AgentResult, error) {
@@ -206,6 +237,7 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			Repo:              payload.Repo,
 			Branch:            payload.Branch,
 			PullRequest:       payload.PullRequest,
+			HeadSHA:           payload.HeadSHA,
 			GoalID:            payload.GoalID,
 			TaskID:            payload.TaskID,
 			TaskTitle:         payload.TaskTitle,
@@ -229,7 +261,8 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			if !ready {
 				return e.setReviewingIfNotChangesRequested(ctx, ref)
 			}
-			return e.runMergeGate(ctx, job.Agent, payload, ref)
+			_, err = e.runMergeGate(ctx, job.Agent, payload, ref)
+			return err
 		}
 	}
 	return nil
@@ -284,6 +317,7 @@ func (e Engine) dispatchFix(ctx context.Context, reviewer string, payload JobPay
 		Repo:        payload.Repo,
 		Branch:      payload.Branch,
 		PullRequest: payload.PullRequest,
+		HeadSHA:     payload.HeadSHA,
 		GoalID:      payload.GoalID,
 		TaskID:      payload.TaskID,
 		TaskTitle:   payload.TaskTitle,
@@ -324,6 +358,7 @@ func (e Engine) dispatchNextAgents(ctx context.Context, payload JobPayload, resu
 			Repo:         payload.Repo,
 			Branch:       payload.Branch,
 			PullRequest:  payload.PullRequest,
+			HeadSHA:      payload.HeadSHA,
 			GoalID:       payload.GoalID,
 			TaskID:       payload.TaskID,
 			TaskTitle:    payload.TaskTitle,
@@ -532,28 +567,60 @@ func (e Engine) ensureBranchLock(ctx context.Context, repo string, branch string
 	return nil
 }
 
-func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPayload, ref taskRef) error {
+func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPayload, ref taskRef) (MergeDecision, error) {
 	if e.MergeGate == nil {
-		return e.setTaskState(ctx, ref, TaskReadyToMerge)
+		return MergeDecision{Ready: true}, e.setTaskState(ctx, ref, TaskReadyToMerge)
+	}
+	reviewRequired, err := e.mergeGateReviewRequired(ctx, payload)
+	if err != nil {
+		return MergeDecision{}, err
 	}
 	decision, err := e.MergeGate.Evaluate(ctx, MergeRequest{
-		Repo:        payload.Repo,
-		Branch:      payload.Branch,
-		PullRequest: payload.PullRequest,
-		TaskID:      payload.TaskID,
-		Reviewer:    reviewer,
+		Repo:           payload.Repo,
+		Branch:         payload.Branch,
+		PullRequest:    payload.PullRequest,
+		HeadSHA:        payload.HeadSHA,
+		TaskID:         payload.TaskID,
+		Reviewer:       reviewer,
+		ReviewOptional: !reviewRequired,
 	})
 	if err != nil {
-		return err
+		return MergeDecision{}, err
 	}
 	if !decision.Ready {
 		reason := strings.TrimSpace(decision.Reason)
 		if reason == "" {
 			reason = "merge gate rejected action"
 		}
-		return e.block(ctx, ref, reason)
+		return decision, e.block(ctx, ref, reason)
 	}
-	return e.setTaskState(ctx, ref, TaskReadyToMerge)
+	if decision.Merged {
+		return decision, e.setTaskState(ctx, ref, TaskMerged)
+	}
+	return decision, e.setTaskState(ctx, ref, TaskReadyToMerge)
+}
+
+func (e Engine) mergeGateReviewRequired(ctx context.Context, payload JobPayload) (bool, error) {
+	if len(e.requiredReviewers(payload)) > 0 {
+		return true, nil
+	}
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		jobPayload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return false, err
+		}
+		if sameTask(payload, jobPayload) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (e Engine) recordPullRequestBaseline(ctx context.Context, event PullRequestEvent) error {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -119,8 +119,55 @@ func TestEngineHandlePullRequestOpenedRunsMergeGateWithoutReviewers(t *testing.T
 		t.Fatalf("error = %v, want merge gate BlockedError", err)
 	}
 	assertTaskState(t, store, "task-7", TaskBlocked)
-	if len(gate.requests) != 1 || gate.requests[0].Reviewer != "" || gate.requests[0].PullRequest != 7 {
+	if len(gate.requests) != 1 || gate.requests[0].Reviewer != "" || gate.requests[0].PullRequest != 7 || !gate.requests[0].ReviewOptional {
 		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestEngineHandlePullRequestOpenedDoesNotOverwriteNoReviewerMerge(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	gate := &fakeMergeGate{
+		decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"},
+		onEvaluate: func(request MergeRequest) {
+			if err := store.UpsertPullRequest(ctx, db.PullRequest{
+				RepoFullName:   request.Repo,
+				Number:         int64(request.PullRequest),
+				URL:            "https://github.com/jerryfane/gitmoot/pull/7",
+				HeadBranch:     request.Branch,
+				BaseBranch:     "main",
+				HeadSHA:        request.HeadSHA,
+				MergeCommitSHA: "merge123",
+				State:          "merged",
+			}); err != nil {
+				t.Fatalf("UpsertPullRequest returned error: %v", err)
+			}
+		},
+	}
+	engine.MergeGate = gate
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		HeadSHA:     "head123",
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+	})
+
+	if err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+	pr, err := store.GetPullRequest(ctx, "jerryfane/gitmoot", 7)
+	if err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+	if pr.State != "merged" || pr.MergeCommitSHA != "merge123" {
+		t.Fatalf("stored pull request = %+v", pr)
 	}
 }
 
@@ -355,7 +402,7 @@ func TestEngineAdvanceReviewApprovalRunsMergeGate(t *testing.T) {
 		t.Fatalf("AdvanceJob returned error: %v", err)
 	}
 	assertTaskState(t, store, "task-7", TaskReadyToMerge)
-	if len(gate.requests) != 1 || gate.requests[0].Reviewer != "audit" || gate.requests[0].PullRequest != 7 {
+	if len(gate.requests) != 1 || gate.requests[0].Reviewer != "audit" || gate.requests[0].PullRequest != 7 || gate.requests[0].ReviewOptional {
 		t.Fatalf("merge gate requests = %+v", gate.requests)
 	}
 }
@@ -1045,11 +1092,15 @@ func mustJob(t *testing.T, store *db.Store, jobID string) db.Job {
 }
 
 type fakeMergeGate struct {
-	decision MergeDecision
-	requests []MergeRequest
+	decision   MergeDecision
+	onEvaluate func(MergeRequest)
+	requests   []MergeRequest
 }
 
 func (f *fakeMergeGate) Evaluate(_ context.Context, request MergeRequest) (MergeDecision, error) {
 	f.requests = append(f.requests, request)
+	if f.onEvaluate != nil {
+		f.onEvaluate(request)
+	}
 	return f.decision, nil
 }

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -24,6 +24,7 @@ type JobRequest struct {
 	Repo         string
 	Branch       string
 	PullRequest  int
+	HeadSHA      string
 	GoalID       string
 	TaskID       string
 	TaskTitle    string
@@ -39,6 +40,7 @@ type JobPayload struct {
 	Repo         string       `json:"repo"`
 	Branch       string       `json:"branch"`
 	PullRequest  int          `json:"pull_request"`
+	HeadSHA      string       `json:"head_sha,omitempty"`
 	GoalID       string       `json:"goal_id,omitempty"`
 	TaskID       string       `json:"task_id"`
 	TaskTitle    string       `json:"task_title"`
@@ -68,6 +70,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		Repo:         request.Repo,
 		Branch:       request.Branch,
 		PullRequest:  request.PullRequest,
+		HeadSHA:      request.HeadSHA,
 		GoalID:       request.GoalID,
 		TaskID:       request.TaskID,
 		TaskTitle:    request.TaskTitle,

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1,0 +1,487 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+const (
+	gitmootMergeGateContext         = "gitmoot/merge-gate"
+	gitmootNoCIContext              = "gitmoot/ci"
+	commitStatusDescriptionMaxRunes = 140
+)
+
+type MergeGateGitHub interface {
+	GetPullRequest(ctx context.Context, repo github.Repository, number int64) (github.PullRequest, error)
+	GetCombinedStatus(ctx context.Context, repo github.Repository, ref string) (github.CombinedStatus, error)
+	CompareCommits(ctx context.Context, repo github.Repository, base string, head string) (github.CompareResult, error)
+	ListPullRequestChecks(ctx context.Context, repo github.Repository, number int64) ([]github.PullRequestCheck, error)
+	CreateCommitStatus(ctx context.Context, input github.CommitStatusInput) (github.CommitStatus, error)
+	MergePullRequest(ctx context.Context, input github.MergePullRequestInput) (github.MergeResult, error)
+}
+
+type MergeGateGit interface {
+	WorktreeClean(ctx context.Context) (bool, error)
+	UpdateBase(ctx context.Context, remote string, branch string) error
+}
+
+type NextTaskEnqueuer interface {
+	EnqueueNextTask(ctx context.Context, completedTaskID string) error
+}
+
+type PolicyMergeGate struct {
+	Store        *db.Store
+	GitHub       MergeGateGitHub
+	Git          MergeGateGit
+	NextTasks    NextTaskEnqueuer
+	DeleteBranch bool
+	MergeMethod  string
+}
+
+func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (MergeDecision, error) {
+	if err := g.validate(); err != nil {
+		return MergeDecision{}, err
+	}
+	repo, err := parseRepoFullName(request.Repo)
+	if err != nil {
+		return MergeDecision{}, err
+	}
+	if request.PullRequest <= 0 {
+		return MergeDecision{}, errors.New("merge gate pull request number is required")
+	}
+	pr, err := g.GitHub.GetPullRequest(ctx, repo, int64(request.PullRequest))
+	if err != nil {
+		return MergeDecision{}, err
+	}
+	headSHA := strings.TrimSpace(pr.HeadSHA)
+	if headSHA == "" {
+		return g.block(ctx, request, "", "pull request head SHA is missing")
+	}
+	if pullRequestMerged(pr) {
+		return g.finishMerged(ctx, request, pr, strings.TrimSpace(pr.MergeSHA))
+	}
+	if strings.TrimSpace(pr.State) == "closed" {
+		return g.block(ctx, request, headSHA, "pull request is closed without being merged")
+	}
+	if g.Git != nil {
+		clean, err := g.Git.WorktreeClean(ctx)
+		if err != nil {
+			return MergeDecision{}, err
+		}
+		if !clean {
+			return g.block(ctx, request, headSHA, "local worktree is not clean")
+		}
+	}
+	if pr.Mergeable != nil && !*pr.Mergeable {
+		return g.block(ctx, request, headSHA, "pull request is not mergeable; rebase or update the branch")
+	}
+	if err := g.ensureBranchFresh(ctx, repo, pr, headSHA); err != nil {
+		return g.block(ctx, request, headSHA, err.Error())
+	}
+	if !request.ReviewOptional {
+		if err := g.ensureFinalReviewCaptured(ctx, request, headSHA); err != nil {
+			return g.block(ctx, request, headSHA, err.Error())
+		}
+	}
+	if err := g.ensureStatuses(ctx, repo, int64(request.PullRequest), headSHA); err != nil {
+		var pending mergePending
+		if errors.As(err, &pending) {
+			return g.pending(ctx, request, headSHA, pending.reason)
+		}
+		var blocked mergeBlocked
+		if errors.As(err, &blocked) {
+			return g.block(ctx, request, headSHA, blocked.reason)
+		}
+		return MergeDecision{}, err
+	}
+
+	if _, err := g.GitHub.CreateCommitStatus(ctx, github.CommitStatusInput{
+		Repo:        repo,
+		SHA:         headSHA,
+		State:       "success",
+		Context:     gitmootMergeGateContext,
+		Description: "Gitmoot merge gate passed",
+	}); err != nil {
+		return MergeDecision{}, err
+	}
+	result, err := g.GitHub.MergePullRequest(ctx, github.MergePullRequestInput{
+		Repo:            repo,
+		Number:          int64(request.PullRequest),
+		Method:          mergeMethod(g.MergeMethod),
+		Subject:         mergeSubject(request),
+		Body:            "Merged by Gitmoot after policy gate passed.",
+		MatchHeadCommit: headSHA,
+		DeleteBranch:    g.DeleteBranch,
+	})
+	if err != nil {
+		return MergeDecision{}, err
+	}
+	if !result.Merged {
+		reason := strings.TrimSpace(result.Message)
+		if reason == "" {
+			reason = "pull request merge is pending"
+		}
+		return g.pending(ctx, request, headSHA, reason)
+	}
+	return g.finishMerged(ctx, request, pr, strings.TrimSpace(result.SHA))
+}
+
+func (g PolicyMergeGate) finishMerged(ctx context.Context, request MergeRequest, pr github.PullRequest, mergeSHA string) (MergeDecision, error) {
+	if err := g.recordMerged(ctx, request, pr, mergeSHA); err != nil {
+		return MergeDecision{}, err
+	}
+	postMergeWarnings := []string{}
+	lock, err := g.Store.GetBranchLock(ctx, request.Repo, pr.HeadRef)
+	if err == nil {
+		if _, err := g.Store.ReleaseLock(ctx, lock); err != nil {
+			postMergeWarnings = append(postMergeWarnings, "release branch lock: "+err.Error())
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		postMergeWarnings = append(postMergeWarnings, "load branch lock: "+err.Error())
+	}
+	if g.Git != nil && strings.TrimSpace(pr.BaseRef) != "" {
+		if err := g.Git.UpdateBase(ctx, "origin", pr.BaseRef); err != nil {
+			postMergeWarnings = append(postMergeWarnings, "update base: "+err.Error())
+		}
+	}
+	if g.NextTasks != nil {
+		if err := g.NextTasks.EnqueueNextTask(ctx, request.TaskID); err != nil {
+			postMergeWarnings = append(postMergeWarnings, "enqueue next task: "+err.Error())
+		}
+	}
+	reason := "merged"
+	if len(postMergeWarnings) > 0 {
+		reason = "merged with post-merge warnings: " + strings.Join(postMergeWarnings, "; ")
+		_ = g.Store.UpsertMergeGate(ctx, db.MergeGate{RepoFullName: request.Repo, PullRequest: int64(request.PullRequest), State: "merged", Reason: reason})
+	}
+	return MergeDecision{Ready: true, Merged: true, MergeCommitSHA: mergeSHA, Reason: reason}, nil
+}
+
+func (g PolicyMergeGate) validate() error {
+	if g.Store == nil {
+		return errors.New("merge gate store is required")
+	}
+	if g.GitHub == nil {
+		return errors.New("merge gate github client is required")
+	}
+	return nil
+}
+
+func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request MergeRequest, headSHA string) error {
+	jobs, err := g.Store.ListJobs(ctx)
+	if err != nil {
+		return err
+	}
+	current := JobPayload{Repo: request.Repo, PullRequest: request.PullRequest, TaskID: request.TaskID}
+	latest := ""
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return err
+		}
+		if !sameTask(current, payload) {
+			continue
+		}
+		round := strings.TrimSpace(payload.ReviewRound)
+		if round == "" {
+			round = job.ID
+		}
+		if latest == "" || reviewRoundAfter(round, latest) {
+			latest = round
+		}
+	}
+	if latest == "" {
+		return errors.New("final agent review is not captured")
+	}
+	approved := false
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return err
+		}
+		round := strings.TrimSpace(payload.ReviewRound)
+		if round == "" {
+			round = job.ID
+		}
+		if !sameTask(current, payload) || round != latest || payload.Result == nil {
+			continue
+		}
+		if err := g.ensureReviewMatchesHead(payload, headSHA, job.Agent); err != nil {
+			return err
+		}
+		switch payload.Result.Decision {
+		case "approved":
+			approved = true
+		case "changes_requested", "blocked", "failed":
+			return fmt.Errorf("latest review round has blocking result from %s", job.Agent)
+		}
+	}
+	if !approved {
+		return errors.New("required reviewer approval is missing")
+	}
+	return nil
+}
+
+func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repository, pr github.PullRequest, headSHA string) error {
+	base := strings.TrimSpace(pr.BaseRef)
+	if base == "" {
+		base = strings.TrimSpace(pr.BaseSHA)
+	}
+	if base == "" {
+		return errors.New("pull request base ref is missing")
+	}
+	compare, err := g.GitHub.CompareCommits(ctx, repo, base, headSHA)
+	if err != nil {
+		return err
+	}
+	status := strings.ToLower(strings.TrimSpace(compare.Status))
+	if compare.BehindBy > 0 || status == "behind" || status == "diverged" {
+		return fmt.Errorf("pull request branch is behind base %s; update the branch before merging", base)
+	}
+	if status != "" && status != "ahead" && status != "identical" {
+		return fmt.Errorf("pull request branch freshness is unknown: compare status %q", compare.Status)
+	}
+	return nil
+}
+
+func (g PolicyMergeGate) ensureReviewMatchesHead(payload JobPayload, headSHA string, agent string) error {
+	reviewHead := strings.TrimSpace(payload.HeadSHA)
+	if reviewHead == headSHA {
+		return nil
+	}
+	if reviewHead != "" {
+		return fmt.Errorf("latest review from %s is for a different head SHA", agent)
+	}
+	return fmt.Errorf("latest review from %s does not record a head SHA; rerun review", agent)
+}
+
+func (g PolicyMergeGate) ensureStatuses(ctx context.Context, repo github.Repository, pullRequest int64, headSHA string) error {
+	status, err := g.GitHub.GetCombinedStatus(ctx, repo, headSHA)
+	if err != nil {
+		return err
+	}
+	externalStatusCount := 0
+	for _, item := range status.Statuses {
+		if strings.HasPrefix(item.Context, "gitmoot/") {
+			if item.Context == gitmootMergeGateContext {
+				continue
+			}
+			if statusPending(item.State) {
+				return mergePending{reason: fmt.Sprintf("gitmoot status %q is pending", item.Context)}
+			}
+			if item.State != "success" {
+				return mergeBlocked{reason: fmt.Sprintf("gitmoot status %q is %s", item.Context, item.State)}
+			}
+			continue
+		}
+		externalStatusCount++
+		if statusPending(item.State) {
+			return mergePending{reason: "external commit status " + item.Context + " is pending"}
+		}
+		if item.State != "success" {
+			return mergeBlocked{reason: "external commit status " + item.Context + " is not successful"}
+		}
+	}
+
+	checks, err := g.GitHub.ListPullRequestChecks(ctx, repo, pullRequest)
+	if err != nil {
+		return err
+	}
+	externalCheckCount := 0
+	for _, check := range checks {
+		name := strings.TrimSpace(check.Name)
+		if name == gitmootMergeGateContext {
+			continue
+		}
+		externalCheckCount++
+		if checkPending(check) {
+			if name == "" {
+				name = "unnamed check"
+			}
+			return mergePending{reason: fmt.Sprintf("external CI check %q is pending", name)}
+		}
+		if !checkPassed(check) {
+			if name == "" {
+				name = "unnamed check"
+			}
+			return mergeBlocked{reason: fmt.Sprintf("external CI check %q is not successful", name)}
+		}
+	}
+	if externalCheckCount == 0 && externalStatusCount == 0 {
+		_, err := g.GitHub.CreateCommitStatus(ctx, github.CommitStatusInput{
+			Repo:        repo,
+			SHA:         headSHA,
+			State:       "success",
+			Context:     gitmootNoCIContext,
+			Description: "No external CI reported",
+		})
+		return err
+	}
+	return nil
+}
+
+func reviewRoundAfter(left string, right string) bool {
+	leftNumber, leftOK := reviewRoundNumber(left)
+	rightNumber, rightOK := reviewRoundNumber(right)
+	if leftOK && rightOK {
+		return leftNumber > rightNumber
+	}
+	if leftOK != rightOK {
+		return leftOK
+	}
+	return left > right
+}
+
+func (g PolicyMergeGate) block(ctx context.Context, request MergeRequest, sha string, reason string) (MergeDecision, error) {
+	if err := g.Store.UpsertMergeGate(ctx, db.MergeGate{RepoFullName: request.Repo, PullRequest: int64(request.PullRequest), State: "blocked", Reason: reason}); err != nil {
+		return MergeDecision{}, err
+	}
+	if sha != "" {
+		repo, err := parseRepoFullName(request.Repo)
+		if err != nil {
+			return MergeDecision{}, err
+		}
+		if _, err := g.GitHub.CreateCommitStatus(ctx, github.CommitStatusInput{
+			Repo:        repo,
+			SHA:         sha,
+			State:       "failure",
+			Context:     gitmootMergeGateContext,
+			Description: commitStatusDescription(reason),
+		}); err != nil {
+			return MergeDecision{}, err
+		}
+	}
+	return MergeDecision{Reason: reason}, nil
+}
+
+func (g PolicyMergeGate) pending(ctx context.Context, request MergeRequest, sha string, reason string) (MergeDecision, error) {
+	if err := g.Store.UpsertMergeGate(ctx, db.MergeGate{RepoFullName: request.Repo, PullRequest: int64(request.PullRequest), State: "pending", Reason: reason}); err != nil {
+		return MergeDecision{}, err
+	}
+	if sha != "" {
+		repo, err := parseRepoFullName(request.Repo)
+		if err != nil {
+			return MergeDecision{}, err
+		}
+		if _, err := g.GitHub.CreateCommitStatus(ctx, github.CommitStatusInput{
+			Repo:        repo,
+			SHA:         sha,
+			State:       "pending",
+			Context:     gitmootMergeGateContext,
+			Description: commitStatusDescription(reason),
+		}); err != nil {
+			return MergeDecision{}, err
+		}
+	}
+	return MergeDecision{Ready: true, Reason: reason}, nil
+}
+
+func commitStatusDescription(description string) string {
+	runes := []rune(description)
+	if len(runes) <= commitStatusDescriptionMaxRunes {
+		return description
+	}
+	return string(runes[:commitStatusDescriptionMaxRunes-3]) + "..."
+}
+
+func (g PolicyMergeGate) recordMerged(ctx context.Context, request MergeRequest, pr github.PullRequest, mergeSHA string) error {
+	if err := g.Store.UpsertMergeGate(ctx, db.MergeGate{RepoFullName: request.Repo, PullRequest: int64(request.PullRequest), State: "merged", Reason: mergeSHA}); err != nil {
+		return err
+	}
+	return g.Store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName:   request.Repo,
+		Number:         int64(request.PullRequest),
+		URL:            pr.URL,
+		HeadBranch:     pr.HeadRef,
+		BaseBranch:     pr.BaseRef,
+		HeadSHA:        pr.HeadSHA,
+		MergeCommitSHA: mergeSHA,
+		State:          "merged",
+	})
+}
+
+type mergeBlocked struct {
+	reason string
+}
+
+type mergePending struct {
+	reason string
+}
+
+func (e mergeBlocked) Error() string {
+	return e.reason
+}
+
+func (e mergePending) Error() string {
+	return e.reason
+}
+
+func statusPending(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "pending", "queued", "in_progress", "waiting", "requested":
+		return true
+	default:
+		return false
+	}
+}
+
+func checkPending(check github.PullRequestCheck) bool {
+	bucket := strings.ToLower(strings.TrimSpace(check.Bucket))
+	if bucket != "" {
+		return bucket == "pending"
+	}
+	switch strings.ToLower(strings.TrimSpace(check.State)) {
+	case "pending", "queued", "in_progress", "waiting", "requested":
+		return true
+	default:
+		return false
+	}
+}
+
+func checkPassed(check github.PullRequestCheck) bool {
+	bucket := strings.ToLower(strings.TrimSpace(check.Bucket))
+	if bucket != "" {
+		return bucket == "pass" || bucket == "skipping"
+	}
+	state := strings.ToLower(strings.TrimSpace(check.State))
+	return state == "success" || state == "skipped" || state == "neutral"
+}
+
+func pullRequestMerged(pr github.PullRequest) bool {
+	return pr.Merged || strings.TrimSpace(pr.State) == "merged"
+}
+
+func mergeMethod(method string) string {
+	method = strings.TrimSpace(method)
+	if method == "" {
+		return "squash"
+	}
+	return method
+}
+
+func mergeSubject(request MergeRequest) string {
+	if strings.TrimSpace(request.TaskID) == "" {
+		return "Gitmoot merge"
+	}
+	return "Gitmoot merge " + strings.TrimSpace(request.TaskID)
+}
+
+func parseRepoFullName(value string) (github.Repository, error) {
+	owner, name, ok := strings.Cut(strings.TrimSpace(value), "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return github.Repository{}, fmt.Errorf("invalid repo %q", value)
+	}
+	return github.Repository{Owner: owner, Name: name}, nil
+}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -1,0 +1,640 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number:    9,
+			Title:     "Task 9",
+			State:     "open",
+			URL:       "https://github.com/jerryfane/gitmoot/pull/9",
+			HeadRef:   "task-9",
+			BaseRef:   "main",
+			HeadSHA:   "head123",
+			Mergeable: &mergeable,
+		},
+		status: github.CombinedStatus{
+			State: "success",
+			Statuses: []github.CommitStatus{
+				{Context: gitmootMergeGateContext, State: "failure"},
+			},
+		},
+		checks:      []github.PullRequestCheck{{Name: gitmootMergeGateContext, Bucket: "fail", State: "FAILURE"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	git := &fakeMergeGateGit{clean: true}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: git, DeleteBranch: true}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9", Reviewer: "audit"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged || decision.MergeCommitSHA != "merge123" {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(gh.merges) != 1 || gh.merges[0].Method != "squash" || gh.merges[0].MatchHeadCommit != "head123" || !gh.merges[0].DeleteBranch {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+	if !hasStatus(gh.statuses, gitmootNoCIContext, "success") || !hasStatus(gh.statuses, gitmootMergeGateContext, "success") {
+		t.Fatalf("statuses = %+v", gh.statuses)
+	}
+	if _, err := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-9"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("branch lock after merge error = %v, want sql.ErrNoRows", err)
+	}
+	pr, err := store.GetPullRequest(ctx, "jerryfane/gitmoot", 9)
+	if err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+	if pr.State != "merged" || pr.MergeCommitSHA != "merge123" {
+		t.Fatalf("stored pull request = %+v", pr)
+	}
+	if len(git.updated) != 1 || git.updated[0] != "origin/main" {
+		t.Fatalf("updated base calls = %+v", git.updated)
+	}
+}
+
+func TestPolicyMergeGateDoesNotRecordPreMergeSyntheticSHA(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number:    9,
+			State:     "open",
+			URL:       "https://github.com/jerryfane/gitmoot/pull/9",
+			HeadRef:   "task-9",
+			BaseRef:   "main",
+			HeadSHA:   "head123",
+			MergeSHA:  "synthetic-premerge-sha",
+			Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9", Reviewer: "audit"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged || decision.MergeCommitSHA != "" {
+		t.Fatalf("decision = %+v", decision)
+	}
+	pr, err := store.GetPullRequest(ctx, "jerryfane/gitmoot", 9)
+	if err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+	if pr.MergeCommitSHA != "" {
+		t.Fatalf("stored pull request merge SHA = %q, want empty", pr.MergeCommitSHA)
+	}
+}
+
+func TestPolicyMergeGateBlocksDirtyWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	gh := &fakeMergeGateGitHub{pr: github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123"}}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: false}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready || !strings.Contains(decision.Reason, "worktree") {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+}
+
+func TestPolicyMergeGateBlocksFailedExternalCI(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status: github.CombinedStatus{
+			State: "success",
+			Statuses: []github.CommitStatus{
+				{Context: "gitmoot/review", State: "success"},
+			},
+		},
+		checks: []github.PullRequestCheck{{Name: "ci", Bucket: "fail", State: "COMPLETED"}},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready || !strings.Contains(decision.Reason, "external CI") {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+}
+
+func TestPolicyMergeGateTruncatesLongStatusDescriptions(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:     github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status: github.CombinedStatus{State: "success"},
+		checks: []github.PullRequestCheck{{
+			Name:   "ci-" + strings.Repeat("very-long-check-name-", 12),
+			Bucket: "fail",
+			State:  "COMPLETED",
+		}},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(gh.statuses) != 1 {
+		t.Fatalf("statuses = %+v", gh.statuses)
+	}
+	if got := len([]rune(gh.statuses[0].Description)); got > 140 {
+		t.Fatalf("status description length = %d, want <= 140: %q", got, gh.statuses[0].Description)
+	}
+}
+
+func TestPolicyMergeGateAllowsSkippedExternalCI(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		checks:      []github.PullRequestCheck{{Name: "conditional", Bucket: "skipping", State: "SKIPPED"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func TestPolicyMergeGateBlocksStaleBranch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:      github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:  github.CombinedStatus{State: "success"},
+		compare: github.CompareResult{Status: "behind", BehindBy: 1},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready || !strings.Contains(decision.Reason, "behind base") {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+	if !hasStatus(gh.statuses, gitmootMergeGateContext, "failure") {
+		t.Fatalf("statuses = %+v", gh.statuses)
+	}
+}
+
+func TestPolicyMergeGateKeepsPendingCIReadyToRetry(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:     github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status: github.CombinedStatus{State: "success"},
+		checks: []github.PullRequestCheck{{Name: "ci", Bucket: "pending", State: "IN_PROGRESS"}},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Ready || decision.Merged || !strings.Contains(decision.Reason, "pending") {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+	if !hasStatus(gh.statuses, gitmootMergeGateContext, "pending") {
+		t.Fatalf("statuses = %+v", gh.statuses)
+	}
+}
+
+func TestPolicyMergeGateKeepsQueuedMergePending(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Message: "pull request merge is pending"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Ready || decision.Merged || !strings.Contains(decision.Reason, "pending") {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if _, err := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-9"); err != nil {
+		t.Fatalf("branch lock after queued merge error = %v", err)
+	}
+	if _, err := store.GetPullRequest(ctx, "jerryfane/gitmoot", 9); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetPullRequest after queued merge error = %v, want sql.ErrNoRows", err)
+	}
+	if !hasStatus(gh.statuses, gitmootMergeGateContext, "pending") {
+		t.Fatalf("statuses = %+v", gh.statuses)
+	}
+}
+
+func TestPolicyMergeGateAllowsReviewOptionalPullRequest(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9", ReviewOptional: true})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(gh.merges) != 1 {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+}
+
+func TestPolicyMergeGateRecordsAlreadyMergedPullRequest(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number:   9,
+			State:    "closed",
+			Merged:   true,
+			URL:      "https://github.com/jerryfane/gitmoot/pull/9",
+			HeadRef:  "task-9",
+			BaseRef:  "main",
+			HeadSHA:  "head123",
+			MergeSHA: "merge123",
+		},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: false}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged || decision.MergeCommitSHA != "merge123" {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+	if _, err := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-9"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("branch lock after merge error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestPolicyMergeGateBlocksClosedUnmergedPullRequest(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number:  9,
+			State:   "closed",
+			Merged:  false,
+			HeadRef: "task-9",
+			BaseRef: "main",
+			HeadSHA: "head123",
+		},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready || !strings.Contains(decision.Reason, "closed") {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+	if !hasStatus(gh.statuses, gitmootMergeGateContext, "failure") {
+		t.Fatalf("statuses = %+v", gh.statuses)
+	}
+}
+
+func TestPolicyMergeGateUsesLatestNumericReviewRound(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-nine", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "old123",
+		TaskID:      "task-9",
+		ReviewRound: "review-9",
+		Result:      &AgentResult{Decision: "changes_requested", Summary: "old change"},
+	})
+	insertCompletedJob(t, store, db.Job{ID: "review-ten", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-10",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func TestPolicyMergeGateBlocksReviewForStaleHead(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "old123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:     github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status: github.CombinedStatus{State: "success"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready || !strings.Contains(decision.Reason, "different head SHA") {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func TestPolicyMergeGateBlocksLegacyReviewWithoutHeadSHA(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "jerryfane/gitmoot",
+		Number:       9,
+		URL:          "https://github.com/jerryfane/gitmoot/pull/9",
+		HeadBranch:   "task-9",
+		BaseBranch:   "main",
+		HeadSHA:      "head123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready || !strings.Contains(decision.Reason, "does not record a head SHA") {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func TestPolicyMergeGateBlocksMissingFinalReview(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:     github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status: github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "gitmoot/review", State: "success"}}},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready || !strings.Contains(decision.Reason, "review") {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+type fakeMergeGateGitHub struct {
+	pr          github.PullRequest
+	status      github.CombinedStatus
+	compare     github.CompareResult
+	checks      []github.PullRequestCheck
+	mergeResult github.MergeResult
+	statuses    []github.CommitStatusInput
+	merges      []github.MergePullRequestInput
+}
+
+func (f *fakeMergeGateGitHub) GetPullRequest(context.Context, github.Repository, int64) (github.PullRequest, error) {
+	return f.pr, nil
+}
+
+func (f *fakeMergeGateGitHub) GetCombinedStatus(context.Context, github.Repository, string) (github.CombinedStatus, error) {
+	return f.status, nil
+}
+
+func (f *fakeMergeGateGitHub) CompareCommits(context.Context, github.Repository, string, string) (github.CompareResult, error) {
+	if f.compare.Status == "" && f.compare.AheadBy == 0 && f.compare.BehindBy == 0 {
+		return github.CompareResult{Status: "ahead", AheadBy: 1}, nil
+	}
+	return f.compare, nil
+}
+
+func (f *fakeMergeGateGitHub) ListPullRequestChecks(context.Context, github.Repository, int64) ([]github.PullRequestCheck, error) {
+	return f.checks, nil
+}
+
+func (f *fakeMergeGateGitHub) CreateCommitStatus(_ context.Context, input github.CommitStatusInput) (github.CommitStatus, error) {
+	f.statuses = append(f.statuses, input)
+	return github.CommitStatus{State: input.State, Context: input.Context}, nil
+}
+
+func (f *fakeMergeGateGitHub) MergePullRequest(_ context.Context, input github.MergePullRequestInput) (github.MergeResult, error) {
+	f.merges = append(f.merges, input)
+	return f.mergeResult, nil
+}
+
+type fakeMergeGateGit struct {
+	clean   bool
+	updated []string
+}
+
+func (f *fakeMergeGateGit) WorktreeClean(context.Context) (bool, error) {
+	return f.clean, nil
+}
+
+func (f *fakeMergeGateGit) UpdateBase(_ context.Context, remote string, branch string) error {
+	f.updated = append(f.updated, remote+"/"+branch)
+	return nil
+}
+
+func hasStatus(statuses []github.CommitStatusInput, context string, state string) bool {
+	for _, status := range statuses {
+		if status.Context == context && status.State == state {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
WHAT:
Adds the Task 9 merge policy gate and wires it into the daemon workflow.

WHY:
Gitmoot needs automated merges to be guarded by local cleanliness, current-head review approval, branch freshness, Gitmoot statuses, external CI, and safe GitHub merge semantics.

CHANGES:
- Added a workflow PolicyMergeGate that checks current PR head SHA, latest review approval when reviews are required, local worktree state, target checkout identity, branch freshness, Gitmoot statuses, external CI, and mergeability before merging.
- Added no-CI status reporting, stale/self merge-gate status handling, skipped/neutral check handling, numeric review-round ordering, stale-head and legacy-head review blocking, pending-CI retry state, and closed-PR retry handling for merge queues.
- Added merge execution through gh pr merge with match-head-commit and post-merge confirmation before recording merged state.
- Added local Git helpers for checkout root/origin validation, clean worktree detection, and base-branch fast-forward updates.
- Propagated PR head SHA through job payloads so final reviews are tied to the exact head commit being merged.
- Wired the policy gate into daemon startup and extended GitHub client merge/fetch/compare behavior.

RESULTS:
- go test ./internal/workflow ./internal/github ./internal/git ./internal/db ./internal/cli ./internal/daemon
- go test ./internal/daemon ./internal/workflow ./internal/db
- go test ./...
- go vet ./...
- git diff --check
- codex exec review --uncommitted

RISK:
No skipped checks. If gh pr merge succeeds but GitHub cannot be re-read afterward, Gitmoot now returns an error instead of recording an unconfirmed merge.

TASK:
task-009

AGENTS:
- codex

RAW FINAL REVIEW OUTPUT:
````
codex
I reviewed the staged, unstaged, and untracked changes and did not find any discrete, actionable correctness issues. The full test suite also passes with `go test ./...`.
I reviewed the staged, unstaged, and untracked changes and did not find any discrete, actionable correctness issues. The full test suite also passes with `go test ./...`.
````
