### PR TITLE
docs: document gitmoot local workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,31 @@ The core primitive is a runtime-neutral Gitmoot agent, not a Codex-specific
 session. Codex and Claude Code are adapters behind the same internal runtime
 contract.
 
-## Planned Commands
+## Current Command Surface
 
 ```text
 gitmoot init
-gitmoot doctor
-gitmoot daemon start
-gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id>
+gitmoot doctor --repo .
+gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
 gitmoot agent list
+gitmoot agent doctor <name>
+gitmoot agent remove <name>
+```
+
+The goal and task commands are planned but not implemented in this checkout:
+
+```text
 gitmoot status
 gitmoot goal import --file <path>
 gitmoot task run <id>
 ```
+
+## Documentation
+
+- [Local workflow walkthrough](docs/local-workflow.md)
+- [Runtime adapter authoring](docs/adapters.md)
+- [Troubleshooting](docs/troubleshooting.md)
 
 ## Development
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,0 +1,104 @@
+# Runtime Adapter Authoring
+
+Gitmoot treats Codex, Claude Code, and shell commands as runtime adapters behind
+one interface. Workflow, daemon, and GitHub code should stay runtime-neutral.
+
+## Adapter Contract
+
+An adapter implements `runtime.Adapter`:
+
+```go
+type Adapter interface {
+    Name() string
+    Validate(ctx context.Context, agent Agent) error
+    Deliver(ctx context.Context, agent Agent, job Job) (Result, error)
+    Health(ctx context.Context, agent Agent) error
+    Capabilities(ctx context.Context) ([]string, error)
+}
+```
+
+Responsibilities:
+
+- `Name` returns the runtime key used by `gitmoot agent subscribe`.
+- `Validate` checks the agent record without doing unnecessary work.
+- `Deliver` resumes or invokes the runtime with the rendered job prompt and
+  returns raw output.
+- `Health` performs a small operational check that proves the runtime can accept
+  a job.
+- `Capabilities` advertises actions such as `review`, `implement`, and `ask`.
+
+## Agent Record
+
+Adapters receive a normalized `runtime.Agent`:
+
+```go
+type Agent struct {
+    Name           string
+    Role           string
+    Runtime        string
+    RuntimeRef     string
+    RepoScope      string
+    Capabilities   []string
+    AutonomyPolicy string
+    HealthStatus   string
+}
+```
+
+`RuntimeRef` is runtime-specific. Codex accepts a session UUID, thread name, or
+`last`. Claude accepts a UUID or `last`. Shell uses the configured command.
+
+## Job Input
+
+Gitmoot sends adapters a `runtime.Job`:
+
+```go
+type Job struct {
+    ID          string
+    AgentName   string
+    Action      string
+    Prompt      string
+    Repository  string
+    PullRequest int
+}
+```
+
+The prompt already includes repo, branch, PR number, task label, sender,
+requested action, constraints, and the required `gitmoot_result` JSON shape.
+Adapters should pass the prompt through without rewriting workflow semantics.
+
+## Result Handling
+
+`Deliver` should return raw runtime output. Gitmoot parses the
+`gitmoot_result` object after delivery. If the runtime returns structured JSON
+with a nested text result, the adapter may also fill `Result.Summary`, but raw
+output must be preserved for parsing and diagnostics.
+
+## Adding A Runtime
+
+1. Add a runtime constant in `internal/runtime/adapter.go`.
+2. Implement an adapter type in `internal/runtime`.
+3. Register it in `runtime.Factory.Adapter`.
+4. Extend `ValidateAgent` only for runtime-specific reference rules.
+5. Add tests for validation, command arguments, error handling, health checks,
+   and capability reporting.
+6. Add or update docs for the runtime-specific `--session` value.
+
+Keep runtime-specific command names, flags, JSON modes, session lookup, and
+fallback behavior inside the adapter package. Do not leak Codex or Claude
+assumptions into workflow, daemon, GitHub, database, or merge-gate code.
+
+## Shell Adapter
+
+The shell adapter is useful for experiments and contract tests. It invokes:
+
+```sh
+sh -c '<configured command>' gitmoot '<job prompt>'
+```
+
+Health checks invoke:
+
+```sh
+sh -c '<configured command>' gitmoot-health 'Gitmoot health check. Reply OK only.'
+```
+
+The command must print a valid `gitmoot_result` object for normal jobs.

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -1,0 +1,150 @@
+# Local Workflow
+
+Gitmoot V1 runs on one machine. The GitHub repository is the visible audit
+trail, while local SQLite state is the workflow source of truth. The local
+daemon polls GitHub PRs and comments, routes jobs to registered agents, resumes
+their runtime sessions through adapters, records job output, updates PR
+statuses, and merges only after the merge gate passes.
+
+## What Exists Today
+
+The current CLI supports local state initialization, prerequisite checks, agent
+registration, agent health checks, and the daemon:
+
+```sh
+gitmoot init
+gitmoot doctor --repo .
+gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
+gitmoot agent list
+gitmoot agent doctor <name>
+gitmoot daemon start --repo owner/repo --poll 30s
+```
+
+Goal import, task run, and status commands are planned surfaces. Until those
+commands are implemented, a realistic demo imports the plan by keeping it in the
+repository, opening task PRs manually or through an agent session, and letting
+the daemon coordinate comments, reviews, retries, and merge gates for the PRs it
+can observe.
+
+## End-To-End Demo Path
+
+1. Create or choose the project repository.
+
+   ```sh
+   git clone git@github.com:owner/project.git
+   cd project
+   git status --short
+   git remote -v
+   gh auth status
+   ```
+
+2. Write the plan in the repository.
+
+   Keep the implementation plan in a tracked file such as `GOAL.md`. The future
+   command shape is:
+
+   ```sh
+   gitmoot goal import --file GOAL.md
+   ```
+
+   In this checkout that command is not implemented yet, so the first agent
+   should read the plan file directly and open the task PRs using the normal
+   task-by-task workflow.
+
+3. Start persistent agent sessions on the same machine.
+
+   For Codex, start a normal session and note its session id or thread name.
+   Using `last` works for quick demos, but explicit ids are safer because the
+   newest session can change.
+
+   For Claude Code, start the session and note its UUID. Claude sessions may use
+   a UUID or `last`.
+
+4. Initialize Gitmoot state and subscribe the agents.
+
+   ```sh
+   gitmoot init
+   gitmoot doctor --repo .
+   gitmoot agent subscribe lead --runtime codex --session <codex-session-id> --role lead --repo owner/project --capability implement --capability review --capability ask
+   gitmoot agent subscribe audit --runtime claude --session <claude-session-id> --role reviewer --repo owner/project --capability review --capability ask
+   gitmoot agent list
+   gitmoot agent doctor lead
+   gitmoot agent doctor audit
+   ```
+
+5. Start the daemon from the repository checkout.
+
+   ```sh
+   gitmoot daemon start --repo owner/project --poll 30s
+   ```
+
+   The daemon validates that the current checkout's `origin` remote matches
+   `--repo`. Keep it running while the workflow is active.
+
+6. Open the first task PR.
+
+   The lead agent or the human creates the task branch, implements the task,
+   pushes it, and opens a PR. The PR comments become the public audit trail.
+   The local Gitmoot database tracks the task, jobs, branch locks, PR head SHA,
+   and merge gate state.
+
+7. Route other agents through PR comments.
+
+   A repository writer can ask a subscribed agent to work from a PR comment:
+
+   ```text
+   /gitmoot audit review focus on correctness and missed edge cases
+   /gitmoot lead implement fix the review findings without broad refactors
+   ```
+
+   Implement jobs require the agent to hold the branch lock. Review and ask jobs
+   are routed through the runtime adapter and must return the `gitmoot_result`
+   JSON contract.
+
+8. Let the PR converge.
+
+   Agents review, request fixes, and rerun work through comments and job output.
+   When required reviews are approved and the branch is ready, the merge gate
+   checks the current PR head, local worktree cleanliness, branch freshness,
+   Gitmoot statuses, external CI if present, and mergeability.
+
+9. Merge and continue.
+
+   By default Gitmoot merges with a squash merge guarded by the current head SHA.
+   After merge it records the merged commit, releases the branch lock, updates
+   the local base branch, and can enqueue the next task once that queueing
+   surface is wired in.
+
+## Local-Only Limits
+
+- The machine running `gitmoot daemon start` must stay online.
+- Polling is the V1 mechanism; there is no webhook receiver yet.
+- GitHub Checks are best implemented later through GitHub App mode. V1 uses
+  commit statuses and `gh pr checks`.
+- Use explicit session ids for long workflows. `last` is convenient but can
+  point at the wrong session after a new Codex or Claude session starts.
+- GitHub comments are the public audit trail, not canonical state. Local SQLite
+  remains the workflow source of truth.
+- There is no hosted dashboard, cloud runner, billing, or remote control plane
+  in V1.
+
+## Agent Output Contract
+
+Agents must return exactly one JSON object containing `gitmoot_result`:
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "ready",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "next_agents": []
+  }
+}
+```
+
+Valid decisions are `approved`, `changes_requested`, `blocked`, `implemented`,
+and `failed`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,196 @@
+# Troubleshooting
+
+Use `gitmoot doctor --repo .` first. It checks local prerequisites from the
+repository checkout.
+
+## `gh`
+
+Symptoms:
+
+- `gh auth status` fails.
+- PR comments, PR reads, status creation, or merges fail.
+- The daemon reports GitHub API or permission errors.
+
+Checks:
+
+```sh
+gh auth status
+gh repo view owner/repo --json nameWithOwner
+gh pr list --repo owner/repo --state open
+```
+
+Fixes:
+
+- Authenticate `gh` for the account that can read and write the repository.
+- Confirm the `--repo owner/repo` value matches the checkout remote.
+- Retry after GitHub rate limits clear.
+
+## Codex
+
+Symptoms:
+
+- `gitmoot agent doctor <name>` cannot validate a Codex agent.
+- A job cannot resume the intended session.
+- A `last` reference resumes the wrong session.
+
+Checks:
+
+```sh
+codex exec resume --help
+gitmoot agent list
+gitmoot agent doctor <name>
+```
+
+Fixes:
+
+- Prefer an explicit Codex session UUID or thread name over `last`.
+- Confirm `CODEX_HOME` if sessions are stored outside `~/.codex`.
+- Re-subscribe the agent with the correct session reference.
+
+## Claude Code
+
+Symptoms:
+
+- Claude jobs fail to resume.
+- JSON output mode is unsupported by the installed Claude CLI.
+- `last` points at an unexpected session.
+
+Checks:
+
+```sh
+claude --help
+gitmoot agent doctor <name>
+```
+
+Fixes:
+
+- Use a Claude session UUID for long workflows.
+- Upgrade Claude Code if JSON output mode is needed.
+- If JSON mode is unsupported, the adapter falls back to plain output, but the
+  output still must contain the `gitmoot_result` object.
+
+## Repo Remotes
+
+Symptoms:
+
+- `gitmoot daemon start` reports that the checkout origin is not the requested
+  repo.
+- The daemon reads the wrong repository's PRs.
+
+Checks:
+
+```sh
+git rev-parse --show-toplevel
+git remote get-url origin
+gitmoot daemon start --repo owner/repo --poll 30s
+```
+
+Fixes:
+
+- Start the daemon from the intended checkout.
+- Correct the `origin` remote or pass the matching `--repo`.
+- Avoid running one daemon from a parent folder that contains multiple repos.
+
+## Permissions
+
+Symptoms:
+
+- `/gitmoot ...` comments are ignored.
+- A commenter cannot route jobs.
+- Merge attempts fail.
+
+Checks:
+
+```sh
+gh api repos/owner/repo/collaborators/<user>/permission
+gh pr view <number> --repo owner/repo --json reviewDecision,mergeable
+```
+
+Fixes:
+
+- Comment routing requires write, maintain, or admin permission.
+- Merge requires the authenticated `gh` user to have repository merge rights.
+- Required reviews and branch protection still apply.
+
+## Stale Locks
+
+Symptoms:
+
+- Implement jobs are rejected because another agent owns the branch lock.
+- A branch remains locked after a failed or interrupted run.
+
+Checks:
+
+```sh
+gitmoot agent list
+```
+
+Current V1 does not expose a lock-management CLI. Inspect local state only if
+you understand the schema and have backed up the database. The safer path is to
+finish or merge the owning task so the merge gate releases the lock.
+
+## Malformed Agent Output
+
+Symptoms:
+
+- A job fails because output is missing `gitmoot_result`.
+- The repair prompt keeps asking for JSON.
+
+Required shape:
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "ready",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "next_agents": []
+  }
+}
+```
+
+Fixes:
+
+- Return exactly one JSON object.
+- Use one of the supported decisions: `approved`, `changes_requested`,
+  `blocked`, `implemented`, or `failed`.
+- Keep `summary` non-empty.
+
+## Rate Limits
+
+Symptoms:
+
+- GitHub API calls fail with 429, `retry-after`, or rate-limit messages.
+- Polling works briefly and then stalls.
+
+Fixes:
+
+- Increase `--poll`, for example `--poll 60s`.
+- Reduce the number of active PRs watched by one daemon.
+- Wait for the GitHub rate-limit window to reset.
+
+## Merge Gate
+
+Symptoms:
+
+- The PR remains `ready_to_merge`.
+- `gitmoot/merge-gate` is pending or failing.
+- The daemon retries a queued merge.
+
+Checks:
+
+```sh
+gh pr checks <number> --repo owner/repo
+gh pr view <number> --repo owner/repo --json mergeable,statusCheckRollup,reviewDecision
+git status --short
+```
+
+Fixes:
+
+- Clean the local worktree before the daemon attempts the merge.
+- Update the PR branch if it is behind or diverged from base.
+- Fix failing external CI or Gitmoot statuses.
+- Rerun reviews after the PR head SHA changes.


### PR DESCRIPTION
WHAT:
Documents Gitmoot's local workflow, runtime adapter contract, and troubleshooting paths.

WHY:
Task 10 requires a realistic end-to-end local demo path and user-facing docs for V1's local-only architecture, future runtime adapters, and common operational failures.

CHANGES:
- Expanded README with the current implemented command surface and documentation links.
- Added a local workflow walkthrough covering agent sessions, agent subscription, daemon startup, PR comment routing, merge gates, and local-only limits.
- Added runtime adapter authoring docs for future adapters and shell adapter behavior.
- Added troubleshooting docs for gh, Codex, Claude, repo remotes, permissions, stale locks, malformed output, rate limits, and merge gates.

RESULTS:
- docs link/path sanity check: verified docs/local-workflow.md, docs/adapters.md, docs/troubleshooting.md exist.
- command examples manually reviewed against actual CLI names with rg over README.md and docs/.
- go test ./...
- go vet ./...
- git diff --check
- codex exec review --uncommitted

RISK:
No skipped checks. The walkthrough clearly labels goal/task/status commands as planned but not implemented in this checkout.

TASK:
task-010

AGENTS:
- codex

RAW FINAL REVIEW OUTPUT:
````
codex
The changes are documentation-focused and align with the currently implemented CLI surface and runtime adapter contracts. I did not identify any discrete issue that would break existing behavior or materially mislead users.
The changes are documentation-focused and align with the currently implemented CLI surface and runtime adapter contracts. I did not identify any discrete issue that would break existing behavior or materially mislead users.
````
