### PR TITLE
feat: add goal status task cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,10 @@ gitmoot agent doctor <name>
 gitmoot agent remove <name>
 ```
 
-The goal and task commands are planned but not implemented in this checkout:
-
 ```text
 gitmoot status
 gitmoot goal import --file <path>
-gitmoot task run <id>
+gitmoot task run <id> --repo owner/repo --owner <agent>
 ```
 
 ## Documentation

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -9,7 +9,8 @@ statuses, and merges only after the merge gate passes.
 ## What Exists Today
 
 The current CLI supports local state initialization, prerequisite checks, agent
-registration, agent health checks, and the daemon:
+registration, agent health checks, plan import, task branch startup, status,
+and the daemon:
 
 ```sh
 gitmoot init
@@ -17,14 +18,14 @@ gitmoot doctor --repo .
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
 gitmoot agent list
 gitmoot agent doctor <name>
+gitmoot goal import --file GOAL.md --repo owner/repo
+gitmoot task run task-001 --repo owner/repo --owner lead --base main
+gitmoot status --repo owner/repo
 gitmoot daemon start --repo owner/repo --poll 30s
 ```
 
-Goal import, task run, and status commands are planned surfaces. Until those
-commands are implemented, a realistic demo imports the plan by keeping it in the
-repository, opening task PRs manually or through an agent session, and letting
-the daemon coordinate comments, reviews, retries, and merge gates for the PRs it
-can observe.
+Goal import turns Markdown headings shaped like `### Task N: Title` into local
+planned tasks. `task run` starts one task branch and records its branch lock.
 
 ## End-To-End Demo Path
 
@@ -38,18 +39,14 @@ can observe.
    gh auth status
    ```
 
-2. Write the plan in the repository.
+2. Write and import the plan.
 
    Keep the implementation plan in a tracked file such as `GOAL.md`. The future
    command shape is:
 
    ```sh
-   gitmoot goal import --file GOAL.md
+   gitmoot goal import --file GOAL.md --repo owner/project
    ```
-
-   In this checkout that command is not implemented yet, so the first agent
-   should read the plan file directly and open the task PRs using the normal
-   task-by-task workflow.
 
 3. Start persistent agent sessions on the same machine.
 
@@ -81,7 +78,11 @@ can observe.
    The daemon validates that the current checkout's `origin` remote matches
    `--repo`. Keep it running while the workflow is active.
 
-6. Open the first task PR.
+6. Start and open the first task PR.
+
+   ```sh
+   gitmoot task run task-001 --repo owner/project --owner lead --base main
+   ```
 
    The lead agent or the human creates the task branch, implements the task,
    pushes it, and opens a PR. The PR comments become the public audit trail.
@@ -112,8 +113,8 @@ can observe.
 
    By default Gitmoot merges with a squash merge guarded by the current head SHA.
    After merge it records the merged commit, releases the branch lock, updates
-   the local base branch, and can enqueue the next task once that queueing
-   surface is wired in.
+   the local base branch, and can enqueue the next task once the task queueing
+   policy selects it.
 
 ## Local-Only Limits
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -25,9 +24,9 @@ var rootCommands = []command{
 	{name: "doctor", summary: "check local Gitmoot prerequisites", run: runDoctor},
 	{name: "daemon", summary: "run the local PR watcher", run: runDaemon},
 	{name: "agent", summary: "manage registered agents", run: runAgent},
-	{name: "status", summary: "show local workflow status", run: notImplemented("status")},
-	{name: "goal", summary: "import or inspect goals", run: notImplemented("goal")},
-	{name: "task", summary: "run or inspect tasks", run: notImplemented("task")},
+	{name: "status", summary: "show local workflow status", run: runStatus},
+	{name: "goal", summary: "import or inspect goals", run: runGoal},
+	{name: "task", summary: "run or inspect tasks", run: runTask},
 }
 
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -130,18 +129,4 @@ func pathsFromFlag(home string) (config.Paths, error) {
 		return config.PathsForHome(home), nil
 	}
 	return config.DefaultPaths()
-}
-
-func notImplemented(name string) func(args []string, stdout, stderr io.Writer) int {
-	return func(args []string, stdout, stderr io.Writer) int {
-		if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
-			fmt.Fprintf(stdout, "Usage:\n  gitmoot %s [flags]\n", name)
-			return 0
-		}
-		fmt.Fprintf(stderr, "gitmoot %s is not implemented yet\n", name)
-		if len(args) > 0 {
-			fmt.Fprintf(stderr, "received args: %s\n", strings.Join(args, " "))
-		}
-		return 1
-	}
 }

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -1,0 +1,389 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/jerryfane/gitmoot/internal/daemon"
+	"github.com/jerryfane/gitmoot/internal/db"
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+var taskHeadingPattern = regexp.MustCompile(`^### Task ([0-9]+):\s*(.+)$`)
+
+type importedGoal struct {
+	Goal  db.Goal
+	Tasks []db.Task
+}
+
+func runStatus(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repo := fs.String("repo", "", "filter pull requests by owner/repo")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "status does not accept positional arguments")
+		return 2
+	}
+
+	var agents []db.Agent
+	var goals []db.Goal
+	var tasks []db.Task
+	var prs []db.PullRequest
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		if agents, err = store.ListAgents(context.Background()); err != nil {
+			return err
+		}
+		if goals, err = store.ListGoals(context.Background()); err != nil {
+			return err
+		}
+		if strings.TrimSpace(*repo) == "" {
+			if tasks, err = store.ListTasks(context.Background()); err != nil {
+				return err
+			}
+		} else {
+			if tasks, err = store.ListTasksByRepo(context.Background(), *repo); err != nil {
+				return err
+			}
+		}
+		prs, err = store.ListPullRequests(context.Background(), *repo)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "status: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "agents: %d\n", len(agents))
+	fmt.Fprintf(stdout, "goals: %d\n", len(goals))
+	fmt.Fprintf(stdout, "tasks: %d\n", len(tasks))
+	counts := taskStateCounts(tasks)
+	states := make([]string, 0, len(counts))
+	for state := range counts {
+		states = append(states, state)
+	}
+	sort.Strings(states)
+	for _, state := range states {
+		fmt.Fprintf(stdout, "  %s: %d\n", state, counts[state])
+	}
+	fmt.Fprintf(stdout, "pull_requests: %d\n", len(prs))
+	return 0
+}
+
+func runGoal(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printGoalUsage(stdout)
+		return 0
+	}
+	if args[0] != "import" {
+		fmt.Fprintf(stderr, "unknown goal command %q\n\n", args[0])
+		printGoalUsage(stderr)
+		return 2
+	}
+	return runGoalImport(args[1:], stdout, stderr)
+}
+
+func printGoalUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot goal import --file <path> [--repo owner/repo]")
+}
+
+func runGoalImport(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("goal import", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	file := fs.String("file", "", "goal markdown file to import")
+	repo := fs.String("repo", "", "repo scope as owner/repo")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "goal import does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*file) == "" {
+		fmt.Fprintln(stderr, "goal import requires --file")
+		return 2
+	}
+	repoScope := strings.TrimSpace(*repo)
+	if repoScope != "" {
+		parsedRepo, err := daemon.ParseRepository(repoScope)
+		if err != nil {
+			fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+			return 2
+		}
+		repoScope = parsedRepo.FullName()
+	}
+	imported, err := parseGoalFile(*file, repoScope)
+	if err != nil {
+		fmt.Fprintf(stderr, "parse goal: %v\n", err)
+		return 1
+	}
+	if err := withStore(*home, func(store *db.Store) error {
+		if err := validateImportConflicts(context.Background(), store, imported.Tasks); err != nil {
+			return err
+		}
+		return store.UpsertGoalWithTasks(context.Background(), imported.Goal, imported.Tasks)
+	}); err != nil {
+		fmt.Fprintf(stderr, "import goal: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "imported goal %s with %d tasks\n", imported.Goal.ID, len(imported.Tasks))
+	return 0
+}
+
+func runTask(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printTaskUsage(stdout)
+		return 0
+	}
+	if args[0] != "run" {
+		fmt.Fprintf(stderr, "unknown task command %q\n\n", args[0])
+		printTaskUsage(stderr)
+		return 2
+	}
+	return runTaskRun(args[1:], stdout, stderr)
+}
+
+func printTaskUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot task run <id> --repo owner/repo --owner <agent> [--branch <branch>] [--base <branch>]")
+}
+
+func runTaskRun(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("task run", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repo := fs.String("repo", "", "repo scope as owner/repo")
+	owner := fs.String("owner", "", "agent that will hold the branch lock")
+	branch := fs.String("branch", "", "task branch name")
+	base := fs.String("base", "", "base branch for git switch -c")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "task run requires exactly one id")
+			return 2
+		}
+		return 0
+	}
+	taskID := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "task run requires exactly one id")
+		return 2
+	}
+	if strings.TrimSpace(*owner) == "" {
+		fmt.Fprintln(stderr, "task run requires --owner")
+		return 2
+	}
+
+	var started db.Task
+	if err := withStore(*home, func(store *db.Store) error {
+		task, err := store.GetTask(context.Background(), taskID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("task %q not found", taskID)
+			}
+			return err
+		}
+		requestRepo := firstNonEmpty(*repo, task.RepoFullName)
+		if strings.TrimSpace(requestRepo) == "" {
+			return errors.New("task run requires --repo when task has no repo")
+		}
+		if strings.TrimSpace(*repo) != "" && strings.TrimSpace(task.RepoFullName) != "" && *repo != task.RepoFullName {
+			return fmt.Errorf("task %s belongs to repo %s, not %s", task.ID, task.RepoFullName, *repo)
+		}
+		repo, err := daemon.ParseRepository(requestRepo)
+		if err != nil {
+			return fmt.Errorf("invalid repo: %w", err)
+		}
+		checkout, err := resolveDaemonCheckout(context.Background(), repo, gitutil.Client{Dir: "."})
+		if err != nil {
+			return err
+		}
+		requestBranch := firstNonEmpty(*branch, task.Branch, task.ID)
+		engine := workflow.Engine{Store: store}
+		started, err = engine.StartTaskBranch(context.Background(), workflow.TaskBranchRequest{
+			Repo:       requestRepo,
+			GoalID:     task.GoalID,
+			TaskID:     task.ID,
+			TaskTitle:  task.Title,
+			Branch:     requestBranch,
+			BaseBranch: *base,
+			Owner:      *owner,
+		}, gitutil.Client{Dir: checkout})
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "run task: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "started %s on %s\n", started.ID, started.Branch)
+	return 0
+}
+
+func parseGoalFile(path string, repo string) (importedGoal, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return importedGoal{}, err
+	}
+	defer file.Close()
+	title := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	goalID := slug(title)
+	if goalID == "" {
+		goalID = "goal-" + shortHash(path)
+	}
+	scanner := bufio.NewScanner(file)
+	tasks := []db.Task{}
+	seenTaskIDs := map[string]bool{}
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "# ") && title == strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)) {
+			if heading := strings.TrimSpace(strings.TrimPrefix(line, "# ")); heading != "" {
+				title = heading
+			}
+		}
+		matches := taskHeadingPattern.FindStringSubmatch(line)
+		if len(matches) != 3 {
+			continue
+		}
+		number, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return importedGoal{}, err
+		}
+		taskTitle := strings.TrimSpace(matches[2])
+		taskID := fmt.Sprintf("task-%03d", number)
+		if seenTaskIDs[taskID] {
+			return importedGoal{}, fmt.Errorf("duplicate task heading %s", taskID)
+		}
+		seenTaskIDs[taskID] = true
+		tasks = append(tasks, db.Task{
+			ID:           taskID,
+			RepoFullName: strings.TrimSpace(repo),
+			GoalID:       goalID,
+			Title:        taskTitle,
+			State:        string(workflow.TaskPlanned),
+			Branch:       taskBranchName(taskID, taskTitle),
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return importedGoal{}, err
+	}
+	if len(tasks) == 0 {
+		return importedGoal{}, errors.New("goal file contains no task headings")
+	}
+	return importedGoal{
+		Goal: db.Goal{
+			ID:     goalID,
+			Title:  title,
+			Source: path,
+			Status: "planned",
+		},
+		Tasks: tasks,
+	}, nil
+}
+
+func validateImportConflicts(ctx context.Context, store *db.Store, tasks []db.Task) error {
+	for _, task := range tasks {
+		existing, err := store.GetTask(ctx, task.ID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return err
+		}
+		if taskImportConflict(existing, task) {
+			return fmt.Errorf("task %s already exists for goal %q repo %q; choose a different task number or remove the existing task before importing", task.ID, existing.GoalID, existing.RepoFullName)
+		}
+	}
+	return nil
+}
+
+func taskImportConflict(existing db.Task, imported db.Task) bool {
+	if existing.GoalID != imported.GoalID {
+		return true
+	}
+	existingRepo := strings.TrimSpace(existing.RepoFullName)
+	importedRepo := strings.TrimSpace(imported.RepoFullName)
+	return existingRepo != "" && importedRepo != "" && existingRepo != importedRepo
+}
+
+func taskStateCounts(tasks []db.Task) map[string]int {
+	counts := map[string]int{}
+	for _, task := range tasks {
+		state := strings.TrimSpace(task.State)
+		if state == "" {
+			state = "unknown"
+		}
+		counts[state]++
+	}
+	return counts
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func slug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	lastDash := false
+	for _, char := range value {
+		if unicode.IsLetter(char) || unicode.IsDigit(char) {
+			builder.WriteRune(char)
+			lastDash = false
+			continue
+		}
+		if !lastDash && builder.Len() > 0 {
+			builder.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func taskBranchName(taskID string, title string) string {
+	titleSlug := slug(title)
+	if titleSlug == "" {
+		return taskID
+	}
+	return taskID + "-" + titleSlug
+}
+
+func shortHash(value string) string {
+	sum := sha1.Sum([]byte(value))
+	return hex.EncodeToString(sum[:])[:8]
+}

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -1,0 +1,377 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestRunGoalImportAndStatus(t *testing.T) {
+	home := t.TempDir()
+	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+	writeFile(t, goalPath, `# Build Gitmoot
+
+### Task 1: Bootstrap Runtime
+
+Set up the runtime adapter.
+
+### Task 10: Docs & Status
+
+Document the workflow.
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", home, "--file", goalPath, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "imported goal goal with 2 tasks") {
+		t.Fatalf("goal import output = %q", stdout.String())
+	}
+
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	goals, err := store.ListGoals(context.Background())
+	if err != nil {
+		t.Fatalf("ListGoals returned error: %v", err)
+	}
+	if len(goals) != 1 {
+		t.Fatalf("goals len = %d, want 1", len(goals))
+	}
+	if goals[0].ID != "goal" || goals[0].Title != "Build Gitmoot" || goals[0].Status != "planned" {
+		t.Fatalf("goal = %+v", goals[0])
+	}
+
+	task, err := store.GetTask(context.Background(), "task-001")
+	if err != nil {
+		t.Fatalf("GetTask task-001 returned error: %v", err)
+	}
+	if task.RepoFullName != "jerryfane/gitmoot" || task.GoalID != "goal" || task.Branch != "task-001-bootstrap-runtime" {
+		t.Fatalf("task-001 = %+v", task)
+	}
+	if err := store.UpsertTask(context.Background(), db.Task{
+		ID:           "other-task",
+		RepoFullName: "jerryfane/other",
+		GoalID:       "other",
+		Title:        "Other",
+		State:        "blocked",
+		Branch:       "other-task",
+	}); err != nil {
+		t.Fatalf("UpsertTask other repo returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"status", "--home", home, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("status exit code = %d, stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{"agents: 0", "goals: 1", "tasks: 2", "  planned: 2", "pull_requests: 0"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("status output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "blocked") {
+		t.Fatalf("status output included another repo task:\n%s", output)
+	}
+}
+
+func TestRunGoalImportValidatesInput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", t.TempDir()}, &stdout, &stderr)
+
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "goal import requires --file") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunStatusIncludesUnscopedImportedTasks(t *testing.T) {
+	home := t.TempDir()
+	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: Bootstrap\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", home, "--file", goalPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"status", "--home", home, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("status exit code = %d, stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{"tasks: 1", "  planned: 1"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("status output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestRunGoalImportRejectsInvalidRepo(t *testing.T) {
+	home := t.TempDir()
+	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: Bootstrap\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", home, "--file", goalPath, "--repo", "gitmoot"}, &stdout, &stderr)
+
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "invalid repo") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(home, ".gitmoot", "gitmoot.db")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("database stat error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestRunGoalImportRejectsTaskIDConflict(t *testing.T) {
+	home := t.TempDir()
+	firstGoal := filepath.Join(t.TempDir(), "first.md")
+	writeFile(t, firstGoal, "# First\n\n### Task 1: Bootstrap\n")
+	secondGoal := filepath.Join(t.TempDir(), "second.md")
+	writeFile(t, secondGoal, "# Second\n\n### Task 1: Other Bootstrap\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", home, "--file", firstGoal, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("first import exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"goal", "import", "--home", home, "--file", secondGoal, "--repo", "jerryfane/other"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("second import exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "task task-001 already exists") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunGoalImportPreservesExistingTaskProgress(t *testing.T) {
+	home := t.TempDir()
+	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: Bootstrap\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", home, "--file", goalPath, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("first import exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.UpsertTask(context.Background(), db.Task{
+		ID:           "task-001",
+		RepoFullName: "jerryfane/gitmoot",
+		GoalID:       "goal",
+		Title:        "Bootstrap",
+		State:        "implementing",
+		Branch:       "custom-branch",
+	}); err != nil {
+		t.Fatalf("UpsertTask progress returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: Bootstrap Updated\n")
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"goal", "import", "--home", home, "--file", goalPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("second import exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store, err = db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer store.Close()
+	task, err := store.GetTask(context.Background(), "task-001")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.RepoFullName != "jerryfane/gitmoot" || task.Title != "Bootstrap Updated" || task.State != "implementing" || task.Branch != "custom-branch" {
+		t.Fatalf("task after reimport = %+v", task)
+	}
+}
+
+func TestRunGoalImportRollsBackOnTaskFailure(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"init", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("init exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.UpsertTask(context.Background(), db.Task{
+		ID:           "task-existing",
+		RepoFullName: "jerryfane/gitmoot",
+		GoalID:       "existing",
+		Title:        "Existing",
+		State:        "planned",
+		Branch:       "task-002-conflict",
+	}); err != nil {
+		t.Fatalf("UpsertTask existing returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: First\n\n### Task 2: Conflict\n")
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"goal", "import", "--home", home, "--file", goalPath, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("import exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+
+	store, err = db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer store.Close()
+	if _, err := store.GetTask(context.Background(), "task-001"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("task-001 error = %v, want sql.ErrNoRows", err)
+	}
+	goals, err := store.ListGoals(context.Background())
+	if err != nil {
+		t.Fatalf("ListGoals returned error: %v", err)
+	}
+	if len(goals) != 0 {
+		t.Fatalf("goals after failed import = %+v, want none", goals)
+	}
+}
+
+func TestRunTaskRunValidatesInput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"task", "run", "task-001", "--home", t.TempDir()}, &stdout, &stderr)
+
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "task run requires --owner") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunTaskRunRejectsRepoMismatch(t *testing.T) {
+	home := t.TempDir()
+	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: Bootstrap\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", home, "--file", goalPath, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/jerryfane/other.git")
+	withWorkingDirectory(t, repoDir)
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"task", "run", "task-001", "--home", home, "--repo", "jerryfane/other", "--owner", "lead"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("task run exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "belongs to repo jerryfane/gitmoot") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunTaskRunRejectsWrongCheckout(t *testing.T) {
+	home := t.TempDir()
+	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: Bootstrap\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", home, "--file", goalPath, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/jerryfane/other.git")
+	withWorkingDirectory(t, repoDir)
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"task", "run", "task-001", "--home", home, "--repo", "jerryfane/gitmoot", "--owner", "lead"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("task run exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not jerryfane/gitmoot") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestTaskBranchNameFallsBackToTaskID(t *testing.T) {
+	if got := taskBranchName("task-001", "!!!"); got != "task-001" {
+		t.Fatalf("taskBranchName returned %q, want task-001", got)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(output))
+	}
+}
+
+func withWorkingDirectory(t *testing.T, dir string) {
+	t.Helper()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Fatalf("restore working directory: %v", err)
+		}
+	})
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -417,8 +417,11 @@ func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comm
 	if err := command.Validate(); err != nil {
 		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not route comment %d: %v.", comment.ID, err))
 	}
-	if command.Action == "status" || command.Action == "merge" {
-		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot recognized `/gitmoot %s`, but that command is not implemented in this task yet.", command.Action))
+	switch command.Action {
+	case "status":
+		return d.handleStatusCommand(ctx, pull, comment)
+	case "merge":
+		return d.handleMergeCommand(ctx, pull, comment)
 	}
 
 	agent, err := d.Store.GetAgent(ctx, command.Agent)
@@ -480,6 +483,163 @@ func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comm
 		}
 	}
 	return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot queued `%s` job `%s` for `%s`.", command.Action, job.ID, agent.Name))
+}
+
+func (d Daemon) handleStatusCommand(ctx context.Context, pull github.PullRequest, comment github.IssueComment) error {
+	ref, err := d.commentTaskRef(ctx, pull, comment)
+	if err != nil {
+		return err
+	}
+	statusTaskID := ""
+	lines := []string{fmt.Sprintf("Gitmoot status for PR #%d:", pull.Number)}
+	if task, err := d.Store.GetTask(ctx, ref.id); err == nil {
+		statusTaskID = task.ID
+		lines = append(lines, fmt.Sprintf("- task: `%s` `%s`", task.ID, task.State))
+		if strings.TrimSpace(task.Branch) != "" {
+			lines = append(lines, fmt.Sprintf("- branch: `%s`", task.Branch))
+		}
+	} else if errors.Is(err, sql.ErrNoRows) {
+		lines = append(lines, fmt.Sprintf("- task: `%s` not registered", ref.id))
+	} else {
+		return err
+	}
+	if strings.TrimSpace(pull.HeadSHA) != "" {
+		lines = append(lines, fmt.Sprintf("- head: `%s`", pull.HeadSHA))
+	}
+	if lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef); err == nil {
+		lines = append(lines, fmt.Sprintf("- branch_lock: `%s`", lock.Owner))
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	counts, err := d.jobStateCounts(ctx, pull, statusTaskID)
+	if err != nil {
+		return err
+	}
+	lines = append(lines, "- jobs: "+formatJobCounts(counts))
+	if gate, err := d.Store.GetMergeGate(ctx, d.Repo.FullName(), pull.Number); err == nil {
+		lines = append(lines, fmt.Sprintf("- merge_gate: `%s` %s", gate.State, strings.TrimSpace(gate.Reason)))
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	return d.ack(ctx, pull.Number, strings.Join(lines, "\n"))
+}
+
+func (d Daemon) handleMergeCommand(ctx context.Context, pull github.PullRequest, comment github.IssueComment) error {
+	if d.Workflow == nil {
+		return d.ack(ctx, pull.Number, "Gitmoot cannot merge this PR because the workflow engine is not configured.")
+	}
+	task, err := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot cannot merge PR #%d because branch `%s` is not registered as a task.", pull.Number, pull.HeadRef))
+		}
+		return err
+	}
+	if task.State == string(workflow.TaskMerged) {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot merged PR #%d.", pull.Number))
+	}
+	if task.State != string(workflow.TaskReadyToMerge) {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot cannot merge PR #%d because task `%s` is `%s`, not `%s`.", pull.Number, task.ID, task.State, workflow.TaskReadyToMerge))
+	}
+	leadAgent := "github"
+	if lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef); err == nil && strings.TrimSpace(lock.Owner) != "" {
+		leadAgent = lock.Owner
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	reviewers, err := d.workflowReviewers(ctx)
+	if err != nil {
+		return err
+	}
+	err = d.Workflow.HandlePullRequestReadyToMerge(ctx, workflow.PullRequestEvent{
+		Repo:              d.Repo.FullName(),
+		Branch:            firstNonEmpty(task.Branch, pull.HeadRef),
+		PullRequest:       int(pull.Number),
+		HeadSHA:           pull.HeadSHA,
+		GoalID:            task.GoalID,
+		TaskID:            task.ID,
+		TaskTitle:         task.Title,
+		LeadAgent:         leadAgent,
+		Sender:            comment.Author,
+		RequiredReviewers: reviewers,
+	})
+	if err != nil {
+		var blocked workflow.BlockedError
+		if errors.As(err, &blocked) {
+			return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot merge is blocked: %s.", blocked.Reason))
+		}
+		return err
+	}
+	task, err = d.Store.GetTask(ctx, task.ID)
+	if err != nil {
+		return err
+	}
+	if task.State == string(workflow.TaskMerged) {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot merged PR #%d.", pull.Number))
+	}
+	return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot merge gate ran; task `%s` is `%s`.", task.ID, task.State))
+}
+
+func (d Daemon) jobStateCounts(ctx context.Context, pull github.PullRequest, taskID string) (map[string]int, error) {
+	jobs, err := d.Store.ListJobs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	counts := map[string]int{}
+	for _, job := range jobs {
+		payload, err := workflowPayload(job)
+		if err != nil {
+			return nil, err
+		}
+		if payload.Repo != d.Repo.FullName() || payload.PullRequest != int(pull.Number) {
+			continue
+		}
+		if strings.TrimSpace(taskID) != "" && strings.TrimSpace(payload.TaskID) != "" && payload.TaskID != taskID {
+			continue
+		}
+		state := strings.TrimSpace(job.State)
+		if state == "" {
+			state = "unknown"
+		}
+		counts[state]++
+	}
+	return counts, nil
+}
+
+func workflowPayload(job db.Job) (workflow.JobPayload, error) {
+	var payload workflow.JobPayload
+	if strings.TrimSpace(job.Payload) == "" {
+		return payload, nil
+	}
+	if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
+		return workflow.JobPayload{}, fmt.Errorf("parse job payload %q: %w", job.ID, err)
+	}
+	return payload, nil
+}
+
+func formatJobCounts(counts map[string]int) string {
+	states := []string{
+		string(workflow.JobQueued),
+		string(workflow.JobRunning),
+		string(workflow.JobSucceeded),
+		string(workflow.JobFailed),
+		string(workflow.JobBlocked),
+		string(workflow.JobCancelled),
+	}
+	parts := make([]string, 0, len(states))
+	for _, state := range states {
+		parts = append(parts, fmt.Sprintf("%s=%d", state, counts[state]))
+	}
+	return strings.Join(parts, " ")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (d Daemon) commentTaskRef(ctx context.Context, pull github.PullRequest, comment github.IssueComment) (workflowTaskRef, error) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1011,6 +1011,210 @@ func TestPollOnceRejectsImplementWithoutBranchLock(t *testing.T) {
 	}
 }
 
+func TestPollOnceReportsStatusCommand(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-010",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1",
+		Title:        "Task 10",
+		State:        string(workflow.TaskReviewing),
+		Branch:       "task-10",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-10", Owner: "builder"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-10",
+		PullRequest: 10,
+		TaskID:      "task-010",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "review", State: string(workflow.JobQueued), Payload: string(payload)}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	if err := store.UpsertMergeGate(ctx, db.MergeGate{RepoFullName: repo.FullName(), PullRequest: 10, State: "pending", Reason: "ci pending"}); err != nil {
+		t.Fatalf("UpsertMergeGate returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main", HeadSHA: "abc123"}},
+		comments: map[int64][]github.IssueComment{
+			10: {{ID: 909, Body: "/gitmoot status", Author: "dana"}},
+		},
+	}
+
+	err = (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 1 {
+		t.Fatalf("posted acknowledgements = %+v, want 1", client.posted)
+	}
+	body := client.posted[0].body
+	for _, want := range []string{"Gitmoot status for PR #10", "task: `task-010` `reviewing`", "branch_lock: `builder`", "queued=1", "merge_gate: `pending` ci pending"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("status body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestPollOnceReportsStatusCommandCountsUnregisteredPRJobs(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-10",
+		PullRequest: 10,
+		TaskID:      "pr-10-comment-111",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "review", State: string(workflow.JobQueued), Payload: string(payload)}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main", HeadSHA: "abc123"}},
+		comments: map[int64][]github.IssueComment{
+			10: {{ID: 909, Body: "/gitmoot status", Author: "dana"}},
+		},
+	}
+
+	err = (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 1 {
+		t.Fatalf("posted acknowledgements = %+v, want 1", client.posted)
+	}
+	body := client.posted[0].body
+	for _, want := range []string{"task: `pr-10-comment-909` not registered", "queued=1"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("status body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestPollOnceMergeCommandRunsMergeGate(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-010",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1",
+		Title:        "Task 10",
+		State:        string(workflow.TaskReadyToMerge),
+		Branch:       "task-10",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-10", Owner: "builder"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       10,
+		HeadBranch:   "task-10",
+		BaseBranch:   "main",
+		HeadSHA:      "abc123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	client := &fakeGitHub{}
+	err := (Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}).handleMergeCommand(
+		ctx,
+		github.PullRequest{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main", HeadSHA: "abc123"},
+		github.IssueComment{ID: 910, Body: "/gitmoot merge", Author: "dana"},
+	)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(gate.requests) != 1 {
+		t.Fatalf("merge gate requests = %+v, want 1", gate.requests)
+	}
+	request := gate.requests[0]
+	if request.Repo != repo.FullName() || request.Branch != "task-10" || request.PullRequest != 10 || request.TaskID != "task-010" {
+		t.Fatalf("merge request = %+v", request)
+	}
+	if request.ReviewOptional {
+		t.Fatalf("merge request ReviewOptional = true, want false when repo review agents are configured")
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "Gitmoot merged PR #10") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+	task, err := store.GetTask(ctx, "task-010")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskMerged) {
+		t.Fatalf("task state = %q, want merged", task.State)
+	}
+}
+
+func TestPollOnceMergeCommandRequiresReadyTask(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-010",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1",
+		Title:        "Task 10",
+		State:        string(workflow.TaskReviewing),
+		Branch:       "task-10",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-10", Owner: "builder"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	client := &fakeGitHub{}
+	err := (Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}).handleMergeCommand(
+		ctx,
+		github.PullRequest{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main", HeadSHA: "abc123"},
+		github.IssueComment{ID: 911, Body: "/gitmoot merge", Author: "dana"},
+	)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate requests = %+v, want none", gate.requests)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "not `ready_to_merge`") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+}
+
 func TestPollOnceQueuesImplementWithBranchLock(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -99,6 +99,10 @@ type Pinger interface {
 	Ping(ctx context.Context) error
 }
 
+type sqlExecer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
 func Open(path string) (*Store, error) {
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -235,8 +239,45 @@ func (s *Store) InsertGoal(ctx context.Context, goal Goal) error {
 	return err
 }
 
+func (s *Store) UpsertGoal(ctx context.Context, goal Goal) error {
+	return upsertGoal(ctx, s.db, goal)
+}
+
+func upsertGoal(ctx context.Context, execer sqlExecer, goal Goal) error {
+	_, err := execer.ExecContext(ctx, `INSERT INTO goals(id, title, source, status, updated_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			title = excluded.title,
+			source = excluded.source,
+			status = excluded.status,
+			updated_at = CURRENT_TIMESTAMP`,
+		goal.ID, goal.Title, goal.Source, goal.Status)
+	return err
+}
+
+func (s *Store) ListGoals(ctx context.Context) ([]Goal, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, title, source, status FROM goals ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	goals := []Goal{}
+	for rows.Next() {
+		var goal Goal
+		if err := rows.Scan(&goal.ID, &goal.Title, &goal.Source, &goal.Status); err != nil {
+			return nil, err
+		}
+		goals = append(goals, goal)
+	}
+	return goals, rows.Err()
+}
+
 func (s *Store) UpsertTask(ctx context.Context, task Task) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, updated_at)
+	return upsertTask(ctx, s.db, task)
+}
+
+func upsertTask(ctx context.Context, execer sqlExecer, task Task) error {
+	_, err := execer.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			repo_full_name = excluded.repo_full_name,
@@ -244,6 +285,41 @@ func (s *Store) UpsertTask(ctx context.Context, task Task) error {
 			title = excluded.title,
 			state = excluded.state,
 			branch = excluded.branch,
+			updated_at = CURRENT_TIMESTAMP`,
+		task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch)
+	return err
+}
+
+func (s *Store) UpsertGoalWithTasks(ctx context.Context, goal Goal, tasks []Task) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if err := upsertGoal(ctx, tx, goal); err != nil {
+		return err
+	}
+	for _, task := range tasks {
+		if err := upsertImportedTask(ctx, tx, task); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func upsertImportedTask(ctx context.Context, execer sqlExecer, task Task) error {
+	_, err := execer.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+			ON CONFLICT(id) DO UPDATE SET
+				repo_full_name = CASE
+					WHEN excluded.repo_full_name <> '' THEN excluded.repo_full_name
+					ELSE tasks.repo_full_name
+				END,
+				goal_id = excluded.goal_id,
+				title = excluded.title,
+				state = tasks.state,
+			branch = tasks.branch,
 			updated_at = CURRENT_TIMESTAMP`,
 		task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch)
 	return err
@@ -271,6 +347,43 @@ func (s *Store) GetTaskByRepoBranch(ctx context.Context, repoFullName string, br
 		ORDER BY CASE WHEN repo_full_name = ? THEN 0 ELSE 1 END, updated_at DESC, id
 		LIMIT 1`, branch, repoFullName, repoFullName)
 	return scanTask(row)
+}
+
+func (s *Store) ListTasks(ctx context.Context) ([]Task, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch FROM tasks ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	tasks := []Task{}
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+	return tasks, rows.Err()
+}
+
+func (s *Store) ListTasksByRepo(ctx context.Context, repoFullName string) ([]Task, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch
+		FROM tasks
+		WHERE repo_full_name = ? OR repo_full_name = ''
+		ORDER BY CASE WHEN repo_full_name = ? THEN 0 ELSE 1 END, id`, repoFullName, repoFullName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	tasks := []Task{}
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+	return tasks, rows.Err()
 }
 
 func (s *Store) ListTasksByRepoState(ctx context.Context, repoFullName string, state string) ([]Task, error) {
@@ -334,6 +447,30 @@ func (s *Store) GetPullRequestByRepoBranch(ctx context.Context, repoFullName str
 		return PullRequest{}, err
 	}
 	return pr, nil
+}
+
+func (s *Store) ListPullRequests(ctx context.Context, repoFullName string) ([]PullRequest, error) {
+	query := `SELECT repo_full_name, number, url, head_branch, base_branch, head_sha, merge_commit_sha, state FROM pull_requests`
+	args := []any{}
+	if strings.TrimSpace(repoFullName) != "" {
+		query += ` WHERE repo_full_name = ?`
+		args = append(args, repoFullName)
+	}
+	query += ` ORDER BY repo_full_name, number`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	prs := []PullRequest{}
+	for rows.Next() {
+		var pr PullRequest
+		if err := rows.Scan(&pr.RepoFullName, &pr.Number, &pr.URL, &pr.HeadBranch, &pr.BaseBranch, &pr.HeadSHA, &pr.MergeCommitSHA, &pr.State); err != nil {
+			return nil, err
+		}
+		prs = append(prs, pr)
+	}
+	return prs, rows.Err()
 }
 
 func (s *Store) MarkCommentSeen(ctx context.Context, comment Comment) error {
@@ -579,6 +716,17 @@ func (s *Store) UpsertMergeGate(ctx context.Context, gate MergeGate) error {
 			updated_at = CURRENT_TIMESTAMP`,
 		gate.RepoFullName, gate.PullRequest, gate.State, gate.Reason)
 	return err
+}
+
+func (s *Store) GetMergeGate(ctx context.Context, repoFullName string, pullRequest int64) (MergeGate, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, pull_request, state, reason
+		FROM merge_gates WHERE repo_full_name = ? AND pull_request = ?`,
+		repoFullName, pullRequest)
+	var gate MergeGate
+	if err := row.Scan(&gate.RepoFullName, &gate.PullRequest, &gate.State, &gate.Reason); err != nil {
+		return MergeGate{}, err
+	}
+	return gate, nil
 }
 
 func (s *Store) HasTable(ctx context.Context, name string) (bool, error) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -165,6 +165,7 @@ func (e Engine) HandlePullRequestReadyToMerge(ctx context.Context, event PullReq
 		TaskID:      event.TaskID,
 		TaskTitle:   event.TaskTitle,
 		LeadAgent:   event.LeadAgent,
+		Reviewers:   compactStrings(append([]string{}, event.RequiredReviewers...)),
 	}, ref)
 	return err
 }


### PR DESCRIPTION
WHAT: Added the missing local workflow command surfaces for status reporting, goal import, task branch start, and PR status/merge commands.

WHY: The goal audit found the planned Gitmoot workflow still needed usable CLI and PR command entry points before the implementation goal could be considered complete.

CHANGES:
- Added `gitmoot status`, `gitmoot goal import --file <path> [--repo owner/repo]`, and `gitmoot task run <id> --repo owner/repo --owner <agent>`.
- Added transactional goal/task imports that preserve task progress and repo scope on re-import.
- Added repo-aware status queries, unscoped planned task visibility, PR status comments, and guarded `/gitmoot merge` handling.
- Propagated required reviewers into ready-to-merge handling so merge gates keep review requirements intact.
- Updated README and local workflow docs from planned surfaces to implemented commands.

RESULTS:
- `go test ./internal/cli ./internal/db ./internal/daemon`
- `go test ./internal/daemon ./internal/workflow ./internal/cli`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `codex exec review --uncommitted` final raw output:

```text
No actionable correctness issues were found in the current staged, unstaged, or untracked changes. The new CLI, daemon, store, and workflow additions build and the test suite passes.
No actionable correctness issues were found in the current staged, unstaged, or untracked changes. The new CLI, daemon, store, and workflow additions build and the test suite passes.
```

RISK: No skipped checks. Residual risk is limited to real-world GitHub polling/merge behavior beyond the fake clients and local smoke paths covered here.
