### PR TITLE
feat: add repo registry

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -66,10 +66,15 @@ func runDaemonStart(args []string, stdout, stderr io.Writer) int {
 	defer stop()
 
 	err = withStore(*home, func(store *db.Store) error {
-		checkout, err := resolveDaemonCheckout(ctx, repo, gitutil.Client{Dir: "."})
+		repoRecord, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: "."})
 		if err != nil {
 			return err
 		}
+		repoRecord.PollInterval = poll.String()
+		if err := store.UpsertRepo(ctx, repoRecord); err != nil {
+			return err
+		}
+		checkout := repoRecord.CheckoutPath
 		gh := github.NewClient(checkout)
 		engine := workflow.Engine{
 			Store: store,
@@ -100,20 +105,38 @@ func runDaemonStart(args []string, stdout, stderr io.Writer) int {
 }
 
 func resolveDaemonCheckout(ctx context.Context, repo github.Repository, client gitutil.Client) (string, error) {
-	root, err := client.Root(ctx)
-	if err != nil {
-		return "", fmt.Errorf("resolve daemon checkout: %w", err)
-	}
-	remote, err := client.OriginRemote(ctx)
-	if err != nil {
-		return "", fmt.Errorf("resolve daemon checkout remote: %w", err)
-	}
-	remoteRepo, err := gitutil.ParseGitHubRemote(remote)
+	record, err := repoRecordForCheckout(ctx, repo, client)
 	if err != nil {
 		return "", err
 	}
-	if remoteRepo.String() != repo.FullName() {
-		return "", fmt.Errorf("current checkout origin is %s, not %s", remoteRepo.String(), repo.FullName())
+	return record.CheckoutPath, nil
+}
+
+func repoRecordForCheckout(ctx context.Context, repo github.Repository, client gitutil.Client) (db.Repo, error) {
+	root, err := client.Root(ctx)
+	if err != nil {
+		return db.Repo{}, fmt.Errorf("resolve repo checkout: %w", err)
 	}
-	return root, nil
+	remote, err := client.OriginRemote(ctx)
+	if err != nil {
+		return db.Repo{}, fmt.Errorf("resolve repo checkout remote: %w", err)
+	}
+	remoteRepo, err := gitutil.ParseGitHubRemote(remote)
+	if err != nil {
+		return db.Repo{}, err
+	}
+	if remoteRepo.String() != repo.FullName() {
+		return db.Repo{}, fmt.Errorf("current checkout origin is %s, not %s", remoteRepo.String(), repo.FullName())
+	}
+	defaultBranch := ""
+	if branch, err := client.CurrentBranch(ctx); err == nil {
+		defaultBranch = branch
+	}
+	return db.Repo{
+		Owner:         repo.Owner,
+		Name:          repo.Name,
+		DefaultBranch: defaultBranch,
+		RemoteURL:     remote,
+		CheckoutPath:  root,
+	}, nil
 }

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -1,0 +1,252 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/daemon"
+	"github.com/jerryfane/gitmoot/internal/db"
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/pathutil"
+)
+
+func runRepo(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printRepoUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "add":
+		return runRepoAdd(args[1:], stdout, stderr)
+	case "list":
+		return runRepoList(args[1:], stdout, stderr)
+	case "remove":
+		return runRepoRemove(args[1:], stdout, stderr)
+	case "doctor":
+		return runRepoDoctor(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown repo command %q\n\n", args[0])
+		printRepoUsage(stderr)
+		return 2
+	}
+}
+
+func printRepoUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot repo add owner/repo --path <path> [--poll 30s]")
+	fmt.Fprintln(w, "  gitmoot repo list")
+	fmt.Fprintln(w, "  gitmoot repo remove owner/repo")
+	fmt.Fprintln(w, "  gitmoot repo doctor owner/repo")
+}
+
+func runRepoAdd(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("repo add", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	path := fs.String("path", ".", "local checkout path")
+	poll := fs.Duration("poll", 30*time.Second, "poll interval")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "repo add requires owner/repo")
+			return 2
+		}
+		return 0
+	}
+	repoArg := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "repo add requires exactly one owner/repo")
+		return 2
+	}
+	if *poll <= 0 {
+		fmt.Fprintln(stderr, "poll interval must be positive")
+		return 2
+	}
+	repo, err := daemon.ParseRepository(repoArg)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+		return 2
+	}
+	record, err := repoRecordFromPath(context.Background(), repo, *path)
+	if err != nil {
+		fmt.Fprintf(stderr, "repo add: %v\n", err)
+		return 1
+	}
+	record.PollInterval = poll.String()
+	if err := withStore(*home, func(store *db.Store) error {
+		return store.UpsertRepo(context.Background(), record)
+	}); err != nil {
+		fmt.Fprintf(stderr, "repo add: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "registered %s at %s", record.FullName(), record.CheckoutPath)
+	return 0
+}
+
+func runRepoList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("repo list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "repo list does not accept positional arguments")
+		return 2
+	}
+	var repos []db.Repo
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		repos, err = store.ListRepos(context.Background())
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "repo list: %v\n", err)
+		return 1
+	}
+	for _, repo := range repos {
+		enabled := "disabled"
+		if repo.Enabled {
+			enabled = "enabled"
+		}
+		writeLine(stdout, "%-24s %-8s %-8s %s", repo.FullName(), enabled, repo.PollInterval, repo.CheckoutPath)
+	}
+	return 0
+}
+
+func runRepoRemove(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("repo remove", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "repo remove requires owner/repo")
+			return 2
+		}
+		return 0
+	}
+	repoArg := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "repo remove requires exactly one owner/repo")
+		return 2
+	}
+	repo, err := daemon.ParseRepository(repoArg)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+		return 2
+	}
+	var removed bool
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		removed, err = store.RemoveRepo(context.Background(), repo.FullName())
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "repo remove: %v\n", err)
+		return 1
+	}
+	if !removed {
+		fmt.Fprintf(stderr, "repo %q not found\n", repo.FullName())
+		return 1
+	}
+	writeLine(stdout, "removed %s", repo.FullName())
+	return 0
+}
+
+func runRepoDoctor(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("repo doctor", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "repo doctor requires owner/repo")
+			return 2
+		}
+		return 0
+	}
+	repoArg := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "repo doctor requires exactly one owner/repo")
+		return 2
+	}
+	repo, err := daemon.ParseRepository(repoArg)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+		return 2
+	}
+	var record db.Repo
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		record, err = store.GetRepo(context.Background(), repo.FullName())
+		return err
+	}); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			fmt.Fprintf(stderr, "repo %q not found\n", repo.FullName())
+			return 1
+		}
+		fmt.Fprintf(stderr, "repo doctor: %v\n", err)
+		return 1
+	}
+	validated, err := repoRecordFromPath(context.Background(), repo, record.CheckoutPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "repo doctor: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "repo: %s ok", repo.FullName())
+	writeLine(stdout, "path: %s", validated.CheckoutPath)
+	writeLine(stdout, "remote: %s", validated.RemoteURL)
+	if validated.DefaultBranch != "" {
+		writeLine(stdout, "branch: %s", validated.DefaultBranch)
+	}
+	return 0
+}
+
+func repoRecordFromPath(ctx context.Context, repo github.Repository, path string) (db.Repo, error) {
+	checkout, err := cleanCheckoutPath(path)
+	if err != nil {
+		return db.Repo{}, err
+	}
+	return repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: checkout})
+}
+
+func cleanCheckoutPath(path string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	cleaned := pathutil.CleanExpandHome(path, home)
+	absolute, err := filepath.Abs(cleaned)
+	if err != nil {
+		return "", err
+	}
+	return absolute, nil
+}

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRepoAddListDoctorRemove(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/jerryfane/gitmoot.git")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"repo", "add", "jerryfane/gitmoot", "--home", home, "--path", repoDir, "--poll", "45s"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("repo add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "registered jerryfane/gitmoot") {
+		t.Fatalf("repo add output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"repo", "list", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("repo list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"jerryfane/gitmoot", "enabled", "45s", filepath.Clean(repoDir)} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("repo list missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"repo", "doctor", "jerryfane/gitmoot", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("repo doctor exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"repo: jerryfane/gitmoot ok", "remote: https://github.com/jerryfane/gitmoot.git", "branch: main"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("repo doctor missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"repo", "remove", "jerryfane/gitmoot", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("repo remove exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "removed jerryfane/gitmoot") {
+		t.Fatalf("repo remove output = %q", stdout.String())
+	}
+}
+
+func TestRunRepoAddRejectsWrongOrigin(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/jerryfane/other.git")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"repo", "add", "jerryfane/gitmoot", "--home", home, "--path", repoDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("repo add exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not jerryfane/gitmoot") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,6 +23,7 @@ var rootCommands = []command{
 	{name: "init", summary: "initialize local Gitmoot state", run: runInit},
 	{name: "doctor", summary: "check local Gitmoot prerequisites", run: runDoctor},
 	{name: "version", summary: "show Gitmoot version and build metadata", run: runVersion},
+	{name: "repo", summary: "manage watched repositories", run: runRepo},
 	{name: "daemon", summary: "run the local PR watcher", run: runDaemon},
 	{name: "agent", summary: "manage registered agents", run: runAgent},
 	{name: "status", summary: "show local workflow status", run: runStatus},

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -53,7 +53,7 @@ func TestRunInitCreatesState(t *testing.T) {
 }
 
 func TestRunSubcommandHelpSucceeds(t *testing.T) {
-	for _, command := range []string{"init", "doctor", "version"} {
+	for _, command := range []string{"init", "doctor", "version", "repo"} {
 		t.Run(command, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -226,10 +226,14 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fmt.Errorf("invalid repo: %w", err)
 		}
-		checkout, err := resolveDaemonCheckout(context.Background(), repo, gitutil.Client{Dir: "."})
+		repoRecord, err := repoRecordForCheckout(context.Background(), repo, gitutil.Client{Dir: "."})
 		if err != nil {
 			return err
 		}
+		if err := store.UpsertRepo(context.Background(), repoRecord); err != nil {
+			return err
+		}
+		checkout := repoRecord.CheckoutPath
 		requestBranch := firstNonEmpty(*branch, task.Branch, task.ID)
 		engine := workflow.Engine{Store: store}
 		started, err = engine.StartTaskBranch(context.Background(), workflow.TaskBranchRequest{

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -337,6 +337,44 @@ func TestRunTaskRunRejectsWrongCheckout(t *testing.T) {
 	}
 }
 
+func TestRunTaskRunRegistersCurrentRepo(t *testing.T) {
+	home := t.TempDir()
+	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: Bootstrap\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", home, "--file", goalPath, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/jerryfane/gitmoot.git")
+	withWorkingDirectory(t, repoDir)
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"task", "run", "task-001", "--home", home, "--repo", "jerryfane/gitmoot", "--owner", "lead"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("task run exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	repo, err := store.GetRepo(context.Background(), "jerryfane/gitmoot")
+	if err != nil {
+		t.Fatalf("GetRepo returned error: %v", err)
+	}
+	if repo.CheckoutPath != repoDir || repo.RemoteURL != "https://github.com/jerryfane/gitmoot.git" {
+		t.Fatalf("repo = %+v", repo)
+	}
+}
+
 func TestTaskBranchNameFallsBackToTaskID(t *testing.T) {
 	if got := taskBranchName("task-001", "!!!"); got != "task-001" {
 		t.Fatalf("taskBranchName returned %q, want task-001", got)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -20,6 +20,11 @@ type Repo struct {
 	Name          string
 	DefaultBranch string
 	RemoteURL     string
+	CheckoutPath  string
+	Enabled       bool
+	PollInterval  string
+	LastPollAt    string
+	LastError     string
 }
 
 type Agent struct {
@@ -167,14 +172,94 @@ func (s *Store) applyMigration(ctx context.Context, version int, migration strin
 
 func (s *Store) UpsertRepo(ctx context.Context, repo Repo) error {
 	fullName := repo.Owner + "/" + repo.Name
-	_, err := s.db.ExecContext(ctx, `INSERT INTO repos(owner, name, full_name, default_branch, remote_url, updated_at)
-		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	updatePollInterval := repo.PollInterval
+	insertPollInterval := repo.PollInterval
+	if strings.TrimSpace(insertPollInterval) == "" {
+		insertPollInterval = "30s"
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO repos(owner, name, full_name, default_branch, remote_url, checkout_path, enabled, poll_interval, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, 1, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(full_name) DO UPDATE SET
-			default_branch = excluded.default_branch,
-			remote_url = excluded.remote_url,
+			default_branch = CASE WHEN excluded.default_branch <> '' THEN excluded.default_branch ELSE repos.default_branch END,
+			remote_url = CASE WHEN excluded.remote_url <> '' THEN excluded.remote_url ELSE repos.remote_url END,
+			checkout_path = CASE WHEN excluded.checkout_path <> '' THEN excluded.checkout_path ELSE repos.checkout_path END,
+			poll_interval = CASE WHEN ? <> '' THEN excluded.poll_interval ELSE repos.poll_interval END,
 			updated_at = CURRENT_TIMESTAMP`,
-		repo.Owner, repo.Name, fullName, repo.DefaultBranch, repo.RemoteURL)
+		repo.Owner, repo.Name, fullName, repo.DefaultBranch, repo.RemoteURL, repo.CheckoutPath, insertPollInterval, updatePollInterval)
 	return err
+}
+
+func (s *Store) GetRepo(ctx context.Context, fullName string) (Repo, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT owner, name, default_branch, remote_url, checkout_path, enabled, poll_interval, last_poll_at, last_error
+		FROM repos WHERE full_name = ?`, fullName)
+	return scanRepo(row)
+}
+
+func (s *Store) ListRepos(ctx context.Context) ([]Repo, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT owner, name, default_branch, remote_url, checkout_path, enabled, poll_interval, last_poll_at, last_error
+		FROM repos ORDER BY full_name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	repos := []Repo{}
+	for rows.Next() {
+		repo, err := scanRepo(rows)
+		if err != nil {
+			return nil, err
+		}
+		repos = append(repos, repo)
+	}
+	return repos, rows.Err()
+}
+
+func (s *Store) SetRepoEnabled(ctx context.Context, fullName string, enabled bool) error {
+	value := 0
+	if enabled {
+		value = 1
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE repos SET enabled = ?, updated_at = CURRENT_TIMESTAMP WHERE full_name = ?`, value, fullName)
+	if err != nil {
+		return err
+	}
+	return requireAffected(result, "repo", fullName)
+}
+
+func (s *Store) UpdateRepoPollResult(ctx context.Context, fullName string, lastPollAt string, lastError string) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE repos SET last_poll_at = ?, last_error = ?, updated_at = CURRENT_TIMESTAMP WHERE full_name = ?`, lastPollAt, lastError, fullName)
+	if err != nil {
+		return err
+	}
+	return requireAffected(result, "repo", fullName)
+}
+
+func (s *Store) RemoveRepo(ctx context.Context, fullName string) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM repos WHERE full_name = ?`, fullName)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+func scanRepo(row interface{ Scan(dest ...any) error }) (Repo, error) {
+	var repo Repo
+	var enabled int
+	if err := row.Scan(&repo.Owner, &repo.Name, &repo.DefaultBranch, &repo.RemoteURL, &repo.CheckoutPath, &enabled, &repo.PollInterval, &repo.LastPollAt, &repo.LastError); err != nil {
+		return Repo{}, err
+	}
+	repo.Enabled = enabled != 0
+	return repo, nil
+}
+
+func (r Repo) FullName() string {
+	if r.Owner == "" || r.Name == "" {
+		return ""
+	}
+	return r.Owner + "/" + r.Name
 }
 
 func (s *Store) UpsertAgent(ctx context.Context, agent Agent) error {
@@ -893,5 +978,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_repo_branch_unique ON tasks(repo_ful
 	`,
 	`
 ALTER TABLE pull_requests ADD COLUMN merge_commit_sha TEXT NOT NULL DEFAULT '';
+	`,
+	`
+ALTER TABLE repos ADD COLUMN checkout_path TEXT NOT NULL DEFAULT '';
+ALTER TABLE repos ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE repos ADD COLUMN poll_interval TEXT NOT NULL DEFAULT '30s';
+ALTER TABLE repos ADD COLUMN last_poll_at TEXT NOT NULL DEFAULT '';
+ALTER TABLE repos ADD COLUMN last_error TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -49,8 +49,58 @@ func TestRepositoryMethods(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.UpsertRepo(ctx, Repo{Owner: "jerryfane", Name: "gitmoot", DefaultBranch: "main"}); err != nil {
+	if err := store.UpsertRepo(ctx, Repo{Owner: "jerryfane", Name: "gitmoot", DefaultBranch: "main", RemoteURL: "https://github.com/jerryfane/gitmoot.git", CheckoutPath: "/repo/gitmoot"}); err != nil {
 		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	repo, err := store.GetRepo(ctx, "jerryfane/gitmoot")
+	if err != nil {
+		t.Fatalf("GetRepo returned error: %v", err)
+	}
+	if repo.FullName() != "jerryfane/gitmoot" || repo.DefaultBranch != "main" || repo.RemoteURL == "" || repo.CheckoutPath != "/repo/gitmoot" || !repo.Enabled || repo.PollInterval != "30s" {
+		t.Fatalf("repo = %+v", repo)
+	}
+	if err := store.UpsertRepo(ctx, Repo{Owner: "jerryfane", Name: "gitmoot", PollInterval: "1m"}); err != nil {
+		t.Fatalf("second UpsertRepo returned error: %v", err)
+	}
+	repo, err = store.GetRepo(ctx, "jerryfane/gitmoot")
+	if err != nil {
+		t.Fatalf("GetRepo after update returned error: %v", err)
+	}
+	if repo.DefaultBranch != "main" || repo.RemoteURL == "" || repo.CheckoutPath != "/repo/gitmoot" || repo.PollInterval != "1m" {
+		t.Fatalf("updated repo lost existing fields: %+v", repo)
+	}
+	if err := store.UpsertRepo(ctx, Repo{Owner: "jerryfane", Name: "gitmoot", RemoteURL: "git@github.com:jerryfane/gitmoot.git"}); err != nil {
+		t.Fatalf("auto UpsertRepo returned error: %v", err)
+	}
+	repo, err = store.GetRepo(ctx, "jerryfane/gitmoot")
+	if err != nil {
+		t.Fatalf("GetRepo after auto update returned error: %v", err)
+	}
+	if repo.RemoteURL != "git@github.com:jerryfane/gitmoot.git" || repo.PollInterval != "1m" {
+		t.Fatalf("auto update did not preserve configured poll interval: %+v", repo)
+	}
+	if err := store.SetRepoEnabled(ctx, "jerryfane/gitmoot", false); err != nil {
+		t.Fatalf("SetRepoEnabled returned error: %v", err)
+	}
+	if err := store.UpdateRepoPollResult(ctx, "jerryfane/gitmoot", "2026-05-21T12:00:00Z", "rate limited"); err != nil {
+		t.Fatalf("UpdateRepoPollResult returned error: %v", err)
+	}
+	repos, err := store.ListRepos(ctx)
+	if err != nil {
+		t.Fatalf("ListRepos returned error: %v", err)
+	}
+	if len(repos) != 1 || repos[0].Enabled || repos[0].LastPollAt == "" || repos[0].LastError != "rate limited" {
+		t.Fatalf("repos = %+v", repos)
+	}
+	removed, err := store.RemoveRepo(ctx, "jerryfane/gitmoot")
+	if err != nil {
+		t.Fatalf("RemoveRepo returned error: %v", err)
+	}
+	if !removed {
+		t.Fatal("RemoveRepo did not remove repo")
+	}
+	if err := store.UpsertRepo(ctx, repo); err != nil {
+		t.Fatalf("restore UpsertRepo returned error: %v", err)
 	}
 	if err := store.UpsertAgent(ctx, Agent{Name: "audit", Role: "reviewer", Runtime: "codex", RuntimeRef: "session", RepoScope: "jerryfane/gitmoot", Capabilities: []string{"review"}, AutonomyPolicy: "auto", HealthStatus: "ok"}); err != nil {
 		t.Fatalf("UpsertAgent returned error: %v", err)
@@ -269,7 +319,7 @@ func TestRepositoryMethods(t *testing.T) {
 	if err := store.UpsertMergeGate(ctx, MergeGate{RepoFullName: "jerryfane/gitmoot", PullRequest: 1, State: "pending", Reason: "waiting"}); err != nil {
 		t.Fatalf("UpsertMergeGate returned error: %v", err)
 	}
-	removed, err := store.RemoveAgent(ctx, "audit")
+	removed, err = store.RemoveAgent(ctx, "audit")
 	if err != nil {
 		t.Fatalf("RemoveAgent returned error: %v", err)
 	}


### PR DESCRIPTION
WHAT:
- Adds first-class local repository registration and storage metadata for checkout path, enabled state, poll interval, last poll timestamp, and last error.

WHY:
- Multi-repo Gitmoot needs durable local repo records so one daemon can safely know which checkouts to watch and validate.

CHANGES:
- Added repo store methods for get/list/upsert/enable-disable/poll-result/remove.
- Added `gitmoot repo add/list/remove/doctor` with checkout root and origin validation.
- Auto-upserts repo records from existing `daemon start --repo` and `task run --repo` flows after validating the current checkout.
- Added focused CLI, DB, and task-run registration tests, including a regression test that auto-upsert preserves custom poll intervals.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/cli`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/daemon ./internal/workflow ./internal/git ./internal/doctor ./internal/cli`
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `GOTOOLCHAIN=go1.26.0 go vet ./...`
- `git diff --check`
- `git diff --cached --check`
- Direct smoke: `go run ./cmd/gitmoot repo add/list/doctor` against a temporary Git checkout for `jerryfane/gitmoot`.
- `codex exec review --uncommitted` final raw output:

```text
No actionable correctness issues were found in the staged, unstaged, or untracked changes. Tests could not be executed here because the repo requires Go 1.26 and the sandbox cannot download the toolchain.
No actionable correctness issues were found in the staged, unstaged, or untracked changes. Tests could not be executed here because the repo requires Go 1.26 and the sandbox cannot download the toolchain.
```

RISK:
- Review sandbox could not run tests with local Go 1.22.2, so tests were run outside the review sandbox with `GOTOOLCHAIN=go1.26.0`.
