### PR TITLE
feat: add multi-repo agent access

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
@@ -27,6 +28,12 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 		return runAgentRemove(args[1:], stdout, stderr)
 	case "doctor":
 		return runAgentDoctor(args[1:], stdout, stderr)
+	case "allow":
+		return runAgentAllow(args[1:], stdout, stderr)
+	case "deny":
+		return runAgentDeny(args[1:], stdout, stderr)
+	case "repos":
+		return runAgentRepos(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown agent command %q\n\n", args[0])
 		printAgentUsage(stderr)
@@ -36,8 +43,11 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 
 func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>")
+	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> [--repo owner/repo...] --capability <capability>")
 	fmt.Fprintln(w, "    Codex sessions may use a UUID, thread name, or last. Claude sessions may use a UUID or last. Shell sessions are commands.")
+	fmt.Fprintln(w, "  gitmoot agent allow <name> --repo owner/repo")
+	fmt.Fprintln(w, "  gitmoot agent deny <name> --repo owner/repo")
+	fmt.Fprintln(w, "  gitmoot agent repos <name>")
 	fmt.Fprintln(w, "  gitmoot agent list")
 	fmt.Fprintln(w, "  gitmoot agent remove <name>")
 	fmt.Fprintln(w, "  gitmoot agent doctor <name>")
@@ -50,9 +60,10 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 	runtimeName := fs.String("runtime", "", "agent runtime: codex, claude, or shell")
 	session := fs.String("session", "", "runtime session reference, last, or shell command")
 	role := fs.String("role", "", "agent role")
-	repo := fs.String("repo", "", "repo scope as owner/repo")
 	policy := fs.String("policy", "auto", "autonomy policy")
+	var repos repeatedFlag
 	var capabilities repeatedFlag
+	fs.Var(&repos, "repo", "allowed repo as owner/repo, repeatable")
 	fs.Var(&capabilities, "capability", "agent capability, repeatable")
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		fs.Usage()
@@ -74,12 +85,21 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
+	normalizedRepos, err := normalizeRepoFlags(repos)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+		return 2
+	}
+	repoScope := ""
+	if len(normalizedRepos) > 0 {
+		repoScope = normalizedRepos[0]
+	}
 	agent := runtime.Agent{
 		Name:           name,
 		Role:           *role,
 		Runtime:        *runtimeName,
 		RuntimeRef:     *session,
-		RepoScope:      *repo,
+		RepoScope:      repoScope,
 		Capabilities:   capabilities,
 		AutonomyPolicy: *policy,
 		HealthStatus:   "unknown",
@@ -89,12 +109,19 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	if err := withStore(*home, func(store *db.Store) error {
-		return store.UpsertAgent(context.Background(), dbAgent(agent))
+		if err := store.UpsertAgent(context.Background(), dbAgent(agent)); err != nil {
+			return err
+		}
+		return store.ReplaceAgentRepos(context.Background(), agent.Name, normalizedRepos)
 	}); err != nil {
 		fmt.Fprintf(stderr, "subscribe agent: %v\n", err)
 		return 1
 	}
-	fmt.Fprintf(stdout, "subscribed %s (%s) for %s\n", agent.Name, agent.Runtime, agent.RepoScope)
+	if len(normalizedRepos) == 0 {
+		fmt.Fprintf(stdout, "subscribed %s (%s) with no repo access\n", agent.Name, agent.Runtime)
+	} else {
+		fmt.Fprintf(stdout, "subscribed %s (%s) for %s\n", agent.Name, agent.Runtime, strings.Join(normalizedRepos, ","))
+	}
 	return 0
 }
 
@@ -109,16 +136,126 @@ func runAgentList(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	var agents []db.Agent
+	agentRepos := map[string][]string{}
 	if err := withStore(*home, func(store *db.Store) error {
 		var err error
 		agents, err = store.ListAgents(context.Background())
-		return err
+		if err != nil {
+			return err
+		}
+		for _, agent := range agents {
+			repos, err := store.ListAgentRepos(context.Background(), agent.Name)
+			if err != nil {
+				return err
+			}
+			agentRepos[agent.Name] = repos
+		}
+		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "list agents: %v\n", err)
 		return 1
 	}
 	for _, agent := range agents {
-		fmt.Fprintf(stdout, "%-16s %-8s %-12s %-20s %s\n", agent.Name, agent.Runtime, agent.Role, agent.RepoScope, strings.Join(agent.Capabilities, ","))
+		fmt.Fprintf(stdout, "%-16s %-8s %-12s %-20s %s\n", agent.Name, agent.Runtime, agent.Role, strings.Join(agentRepos[agent.Name], ","), strings.Join(agent.Capabilities, ","))
+	}
+	return 0
+}
+
+func runAgentAllow(args []string, stdout, stderr io.Writer) int {
+	return runAgentAccessChange("allow", args, stdout, stderr)
+}
+
+func runAgentDeny(args []string, stdout, stderr io.Writer) int {
+	return runAgentAccessChange("deny", args, stdout, stderr)
+}
+
+func runAgentAccessChange(action string, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent "+action, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repoFlag := fs.String("repo", "", "repo scope as owner/repo")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintf(stderr, "agent %s requires exactly one name\n", action)
+			return 2
+		}
+		return 0
+	}
+	name := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "agent %s requires exactly one name\n", action)
+		return 2
+	}
+	repo, err := normalizeRepoFlag(*repoFlag)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+		return 2
+	}
+	if err := withStore(*home, func(store *db.Store) error {
+		if _, err := store.GetAgent(context.Background(), name); err != nil {
+			return err
+		}
+		if action == "allow" {
+			return store.AllowAgentRepo(context.Background(), name, repo)
+		}
+		_, err := store.DenyAgentRepo(context.Background(), name, repo)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent %s: %v\n", action, err)
+		return 1
+	}
+	if action == "allow" {
+		fmt.Fprintf(stdout, "allowed %s on %s\n", name, repo)
+	} else {
+		fmt.Fprintf(stdout, "denied %s on %s\n", name, repo)
+	}
+	return 0
+}
+
+func runAgentRepos(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent repos", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent repos requires exactly one name")
+			return 2
+		}
+		return 0
+	}
+	name := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent repos requires exactly one name")
+		return 2
+	}
+	var repos []string
+	if err := withStore(*home, func(store *db.Store) error {
+		if _, err := store.GetAgent(context.Background(), name); err != nil {
+			return err
+		}
+		var err error
+		repos, err = store.ListAgentRepos(context.Background(), name)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent repos: %v\n", err)
+		return 1
+	}
+	for _, repo := range repos {
+		writeLine(stdout, "%s", repo)
 	}
 	return 0
 }
@@ -270,6 +407,30 @@ func runtimeAgent(agent db.Agent) runtime.Agent {
 		AutonomyPolicy: agent.AutonomyPolicy,
 		HealthStatus:   agent.HealthStatus,
 	}
+}
+
+func normalizeRepoFlags(values []string) ([]string, error) {
+	repos := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, value := range values {
+		repo, err := normalizeRepoFlag(value)
+		if err != nil {
+			return nil, err
+		}
+		if !seen[repo] {
+			repos = append(repos, repo)
+			seen[repo] = true
+		}
+	}
+	return repos, nil
+}
+
+func normalizeRepoFlag(value string) (string, error) {
+	repo, err := daemon.ParseRepository(value)
+	if err != nil {
+		return "", err
+	}
+	return repo.FullName(), nil
 }
 
 type repeatedFlag []string

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -21,6 +21,7 @@ func TestRunAgentSubscribeListRemove(t *testing.T) {
 		"--session", "550e8400-e29b-41d4-a716-446655440001",
 		"--role", "reviewer",
 		"--repo", "jerryfane/gitmoot",
+		"--repo", "jerryfane/other",
 		"--capability", "review",
 		"--capability", "ask",
 	}, &stdout, &stderr)
@@ -35,8 +36,34 @@ func TestRunAgentSubscribeListRemove(t *testing.T) {
 		t.Fatalf("list exit code = %d, stderr=%s", code, stderr.String())
 	}
 	output := stdout.String()
-	if !strings.Contains(output, "audit") || !strings.Contains(output, "review,ask") {
+	if !strings.Contains(output, "audit") || !strings.Contains(output, "jerryfane/gitmoot,jerryfane/other") || !strings.Contains(output, "review,ask") {
 		t.Fatalf("list output = %q", output)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "subscribe", "audit",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "review",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("resubscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "list", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("list after resubscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+	output = stdout.String()
+	if !strings.Contains(output, "jerryfane/gitmoot") || strings.Contains(output, "jerryfane/other") {
+		t.Fatalf("list after resubscribe output = %q", output)
 	}
 
 	stdout.Reset()
@@ -54,6 +81,60 @@ func TestRunAgentSubscribeListRemove(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "audit") {
 		t.Fatalf("agent was not removed: %q", stdout.String())
+	}
+}
+
+func TestRunAgentAccessCommands(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{
+		"agent", "subscribe", "audit",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--role", "reviewer",
+		"--capability", "review",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "allow", "audit", "--home", home, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("allow exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "allowed audit on jerryfane/gitmoot") {
+		t.Fatalf("allow output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "repos", "audit", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("repos exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "jerryfane/gitmoot" {
+		t.Fatalf("repos output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "deny", "audit", "--home", home, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("deny exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "repos", "audit", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("repos after deny exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("repos after deny output = %q", stdout.String())
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -373,7 +373,11 @@ func (d Daemon) workflowReviewers(ctx context.Context) ([]string, error) {
 	}
 	reviewers := []string{}
 	for _, agent := range agents {
-		if agent.RepoScope == d.Repo.FullName() && hasCapability(agent.Capabilities, "review") {
+		allowed, err := d.Store.AgentCanAccessRepo(ctx, agent.Name, d.Repo.FullName())
+		if err != nil {
+			return nil, err
+		}
+		if allowed && hasCapability(agent.Capabilities, "review") {
 			reviewers = append(reviewers, agent.Name)
 		}
 	}
@@ -431,8 +435,12 @@ func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comm
 		}
 		return err
 	}
-	if agent.RepoScope != d.Repo.FullName() {
-		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot agent `%s` is subscribed for `%s`, not `%s`.", agent.Name, agent.RepoScope, d.Repo.FullName()))
+	allowed, err := d.Store.AgentCanAccessRepo(ctx, agent.Name, d.Repo.FullName())
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot agent `%s` is not allowed on `%s`.", agent.Name, d.Repo.FullName()))
 	}
 	if !hasCapability(agent.Capabilities, command.Action) {
 		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot agent `%s` does not advertise `%s` capability.", agent.Name, command.Action))

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -81,6 +81,50 @@ func TestPollOnceCreatesJobAndAcknowledgement(t *testing.T) {
 	}
 }
 
+func TestPollOnceAcknowledgesAgentWithoutRepoAccess(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{
+			7: {{ID: 101, Body: "/gitmoot audit review focus on tests", Author: "alice"}},
+		},
+	}
+
+	err := (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "not allowed") {
+		t.Fatalf("posted acknowledgements = %+v, want not-allowed ack", client.posted)
+	}
+	jobID := jobID(repo, 7, 101, 0, "audit", "review")
+	if _, err := store.GetJob(ctx, jobID); err == nil {
+		t.Fatal("job was queued for agent without repo access")
+	}
+}
+
 func TestPollOnceRoutesPullRequestUpdatesToWorkflow(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -38,6 +38,11 @@ type Agent struct {
 	HealthStatus   string
 }
 
+type AgentRepo struct {
+	AgentName    string
+	RepoFullName string
+}
+
 type Goal struct {
 	ID     string
 	Title  string
@@ -267,19 +272,32 @@ func (s *Store) UpsertAgent(ctx context.Context, agent Agent) error {
 	if err != nil {
 		return err
 	}
-	_, err = s.db.ExecContext(ctx, `INSERT INTO agents(name, role, runtime, runtime_ref, repo_scope, capabilities_json, autonomy_policy, health_status, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-		ON CONFLICT(name) DO UPDATE SET
-			role = excluded.role,
-			runtime = excluded.runtime,
-			runtime_ref = excluded.runtime_ref,
-			repo_scope = excluded.repo_scope,
-			capabilities_json = excluded.capabilities_json,
-			autonomy_policy = excluded.autonomy_policy,
-			health_status = excluded.health_status,
-			updated_at = CURRENT_TIMESTAMP`,
-		agent.Name, agent.Role, agent.Runtime, agent.RuntimeRef, agent.RepoScope, string(capabilities), agent.AutonomyPolicy, agent.HealthStatus)
-	return err
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `INSERT INTO agents(name, role, runtime, runtime_ref, repo_scope, capabilities_json, autonomy_policy, health_status, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+			ON CONFLICT(name) DO UPDATE SET
+				role = excluded.role,
+				runtime = excluded.runtime,
+				runtime_ref = excluded.runtime_ref,
+				repo_scope = excluded.repo_scope,
+				capabilities_json = excluded.capabilities_json,
+				autonomy_policy = excluded.autonomy_policy,
+				health_status = excluded.health_status,
+				updated_at = CURRENT_TIMESTAMP`,
+		agent.Name, agent.Role, agent.Runtime, agent.RuntimeRef, agent.RepoScope, string(capabilities), agent.AutonomyPolicy, agent.HealthStatus); err != nil {
+		return err
+	}
+	if strings.TrimSpace(agent.RepoScope) != "" {
+		if _, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO agent_repos(agent_name, repo_full_name, updated_at)
+			VALUES (?, ?, CURRENT_TIMESTAMP)`, agent.Name, agent.RepoScope); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 func (s *Store) GetAgent(ctx context.Context, name string) (Agent, error) {
@@ -308,7 +326,15 @@ func (s *Store) ListAgents(ctx context.Context) ([]Agent, error) {
 }
 
 func (s *Store) RemoveAgent(ctx context.Context, name string) (bool, error) {
-	result, err := s.db.ExecContext(ctx, `DELETE FROM agents WHERE name = ?`, name)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM agent_repos WHERE agent_name = ?`, name); err != nil {
+		return false, err
+	}
+	result, err := tx.ExecContext(ctx, `DELETE FROM agents WHERE name = ?`, name)
 	if err != nil {
 		return false, err
 	}
@@ -316,7 +342,95 @@ func (s *Store) RemoveAgent(ctx context.Context, name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return affected > 0, nil
+	return affected > 0, tx.Commit()
+}
+
+func (s *Store) AllowAgentRepo(ctx context.Context, agentName string, repoFullName string) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE agents
+		SET repo_scope = CASE WHEN repo_scope = '' THEN ? ELSE repo_scope END,
+			updated_at = CURRENT_TIMESTAMP
+		WHERE name = ?`, repoFullName, agentName)
+	if err != nil {
+		return err
+	}
+	if err := requireAffected(result, "agent", agentName); err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT OR IGNORE INTO agent_repos(agent_name, repo_full_name, updated_at)
+		VALUES (?, ?, CURRENT_TIMESTAMP)`, agentName, repoFullName)
+	return err
+}
+
+func (s *Store) DenyAgentRepo(ctx context.Context, agentName string, repoFullName string) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+	result, err := tx.ExecContext(ctx, `DELETE FROM agent_repos WHERE agent_name = ? AND repo_full_name = ?`, agentName, repoFullName)
+	if err != nil {
+		return false, err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE agents SET repo_scope = '', updated_at = CURRENT_TIMESTAMP WHERE name = ? AND repo_scope = ?`, agentName, repoFullName); err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, tx.Commit()
+}
+
+func (s *Store) ReplaceAgentRepos(ctx context.Context, agentName string, repoFullNames []string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	repoScope := ""
+	if len(repoFullNames) > 0 {
+		repoScope = repoFullNames[0]
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE agents SET repo_scope = ?, updated_at = CURRENT_TIMESTAMP WHERE name = ?`, repoScope, agentName)
+	if err != nil {
+		return err
+	}
+	if err := requireAffected(result, "agent", agentName); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM agent_repos WHERE agent_name = ?`, agentName); err != nil {
+		return err
+	}
+	for _, repo := range repoFullNames {
+		if _, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO agent_repos(agent_name, repo_full_name, updated_at)
+			VALUES (?, ?, CURRENT_TIMESTAMP)`, agentName, repo); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *Store) ListAgentRepos(ctx context.Context, agentName string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT repo_full_name FROM agent_repos WHERE agent_name = ? ORDER BY repo_full_name`, agentName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	repos := []string{}
+	for rows.Next() {
+		var repo string
+		if err := rows.Scan(&repo); err != nil {
+			return nil, err
+		}
+		repos = append(repos, repo)
+	}
+	return repos, rows.Err()
+}
+
+func (s *Store) AgentCanAccessRepo(ctx context.Context, agentName string, repoFullName string) (bool, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_repos WHERE agent_name = ? AND repo_full_name = ?`, agentName, repoFullName).Scan(&count)
+	return count > 0, err
 }
 
 func (s *Store) InsertGoal(ctx context.Context, goal Goal) error {
@@ -985,5 +1099,18 @@ ALTER TABLE repos ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1;
 ALTER TABLE repos ADD COLUMN poll_interval TEXT NOT NULL DEFAULT '30s';
 ALTER TABLE repos ADD COLUMN last_poll_at TEXT NOT NULL DEFAULT '';
 ALTER TABLE repos ADD COLUMN last_error TEXT NOT NULL DEFAULT '';
+	`,
+	`
+CREATE TABLE agent_repos (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	agent_name TEXT NOT NULL,
+	repo_full_name TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	UNIQUE(agent_name, repo_full_name)
+);
+
+INSERT OR IGNORE INTO agent_repos(agent_name, repo_full_name)
+SELECT name, repo_scope FROM agents WHERE repo_scope <> '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -26,6 +26,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"job_events",
 		"branch_locks",
 		"merge_gates",
+		"agent_repos",
 	} {
 		ok, err := store.HasTable(ctx, table)
 		if err != nil {
@@ -104,6 +105,53 @@ func TestRepositoryMethods(t *testing.T) {
 	}
 	if err := store.UpsertAgent(ctx, Agent{Name: "audit", Role: "reviewer", Runtime: "codex", RuntimeRef: "session", RepoScope: "jerryfane/gitmoot", Capabilities: []string{"review"}, AutonomyPolicy: "auto", HealthStatus: "ok"}); err != nil {
 		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	allowed, err := store.AgentCanAccessRepo(ctx, "audit", "jerryfane/gitmoot")
+	if err != nil {
+		t.Fatalf("AgentCanAccessRepo returned error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("agent repo scope was not added as allowed repo")
+	}
+	if err := store.AllowAgentRepo(ctx, "audit", "jerryfane/other"); err != nil {
+		t.Fatalf("AllowAgentRepo returned error: %v", err)
+	}
+	agentRepos, err := store.ListAgentRepos(ctx, "audit")
+	if err != nil {
+		t.Fatalf("ListAgentRepos returned error: %v", err)
+	}
+	if len(agentRepos) != 2 || agentRepos[0] != "jerryfane/gitmoot" || agentRepos[1] != "jerryfane/other" {
+		t.Fatalf("agent repos = %+v", agentRepos)
+	}
+	denied, err := store.DenyAgentRepo(ctx, "audit", "jerryfane/other")
+	if err != nil {
+		t.Fatalf("DenyAgentRepo returned error: %v", err)
+	}
+	if !denied {
+		t.Fatal("DenyAgentRepo did not remove access")
+	}
+	if err := store.ReplaceAgentRepos(ctx, "audit", []string{"jerryfane/second", "jerryfane/third"}); err != nil {
+		t.Fatalf("ReplaceAgentRepos returned error: %v", err)
+	}
+	agentRepos, err = store.ListAgentRepos(ctx, "audit")
+	if err != nil {
+		t.Fatalf("ListAgentRepos after replace returned error: %v", err)
+	}
+	if len(agentRepos) != 2 || agentRepos[0] != "jerryfane/second" || agentRepos[1] != "jerryfane/third" {
+		t.Fatalf("agent repos after replace = %+v", agentRepos)
+	}
+	if err := store.ReplaceAgentRepos(ctx, "audit", nil); err != nil {
+		t.Fatalf("empty ReplaceAgentRepos returned error: %v", err)
+	}
+	allowed, err = store.AgentCanAccessRepo(ctx, "audit", "jerryfane/second")
+	if err != nil {
+		t.Fatalf("AgentCanAccessRepo after empty replace returned error: %v", err)
+	}
+	if allowed {
+		t.Fatal("empty ReplaceAgentRepos left stale access")
+	}
+	if err := store.AllowAgentRepo(ctx, "audit", "jerryfane/gitmoot"); err != nil {
+		t.Fatalf("restore AllowAgentRepo returned error: %v", err)
 	}
 	agent, err := store.GetAgent(ctx, "audit")
 	if err != nil {
@@ -326,12 +374,52 @@ func TestRepositoryMethods(t *testing.T) {
 	if !removed {
 		t.Fatal("RemoveAgent did not remove existing agent")
 	}
+	agentRepos, err = store.ListAgentRepos(ctx, "audit")
+	if err != nil {
+		t.Fatalf("ListAgentRepos after RemoveAgent returned error: %v", err)
+	}
+	if len(agentRepos) != 0 {
+		t.Fatalf("agent repos after RemoveAgent = %+v", agentRepos)
+	}
 	removed, err = store.RemoveAgent(ctx, "audit")
 	if err != nil {
 		t.Fatalf("second RemoveAgent returned error: %v", err)
 	}
 	if removed {
 		t.Fatal("second RemoveAgent removed missing agent")
+	}
+}
+
+func TestMigrateCopiesAgentRepoScopeToAgentRepos(t *testing.T) {
+	ctx := context.Background()
+	raw, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("sql.Open returned error: %v", err)
+	}
+	store := &Store{db: raw}
+	defer store.Close()
+
+	for version, migration := range migrations[:len(migrations)-1] {
+		if err := store.applyMigration(ctx, version+1, migration); err != nil {
+			t.Fatalf("applyMigration(%d) returned error: %v", version+1, err)
+		}
+	}
+	if _, err := raw.ExecContext(ctx, `INSERT INTO agents(name, role, runtime, runtime_ref, repo_scope, capabilities_json, autonomy_policy, health_status)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "audit", "reviewer", "codex", "last", "jerryfane/gitmoot", `["review"]`, "auto", "ok"); err != nil {
+		t.Fatalf("insert legacy agent returned error: %v", err)
+	}
+	if _, err := store.ListAgentRepos(ctx, "audit"); err == nil {
+		t.Fatal("ListAgentRepos succeeded before agent_repos migration")
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	repos, err := store.ListAgentRepos(ctx, "audit")
+	if err != nil {
+		t.Fatalf("ListAgentRepos returned error: %v", err)
+	}
+	if len(repos) != 1 || repos[0] != "jerryfane/gitmoot" {
+		t.Fatalf("repos = %+v", repos)
 	}
 }
 

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -85,9 +85,7 @@ func ValidateAgent(agent Agent) error {
 		return errors.New("agent runtime is required")
 	case strings.TrimSpace(agent.RuntimeRef) == "":
 		return errors.New("agent runtime reference is required")
-	case strings.TrimSpace(agent.RepoScope) == "":
-		return errors.New("agent repo scope is required")
-	case !validRepoScope(agent.RepoScope):
+	case strings.TrimSpace(agent.RepoScope) != "" && !validRepoScope(agent.RepoScope):
 		return fmt.Errorf("agent repo scope %q must be owner/repo", agent.RepoScope)
 	}
 	if _, err := (Factory{}).Adapter(agent.Runtime); err != nil {

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -17,6 +17,11 @@ func TestValidateAgent(t *testing.T) {
 	if err := ValidateAgent(agent); err != nil {
 		t.Fatalf("ValidateAgent returned error: %v", err)
 	}
+	agent.RepoScope = ""
+	if err := ValidateAgent(agent); err != nil {
+		t.Fatalf("ValidateAgent rejected global agent without repo scope: %v", err)
+	}
+	agent.RepoScope = "jerryfane/gitmoot"
 
 	agent.Runtime = "unknown"
 	if err := ValidateAgent(agent); err == nil {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -540,8 +540,12 @@ func (e Engine) ensureAgentAllowed(ctx context.Context, request JobRequest, ref 
 		}
 		return err
 	}
-	if agent.RepoScope != request.Repo {
-		return e.block(ctx, ref, fmt.Sprintf("agent %q is scoped to %q, not %q", agent.Name, agent.RepoScope, request.Repo))
+	allowed, err := e.Store.AgentCanAccessRepo(ctx, agent.Name, request.Repo)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return e.block(ctx, ref, fmt.Sprintf("agent %q is not allowed on %q", agent.Name, request.Repo))
 	}
 	if !contains(agent.Capabilities, request.Action) {
 		return e.block(ctx, ref, fmt.Sprintf("agent %q lacks %q capability", agent.Name, request.Action))

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -947,7 +947,7 @@ func TestEngineAdvanceBlocksWhenNextAgentScopeRejected(t *testing.T) {
 	err := engine.AdvanceJob(ctx, "review-job")
 
 	var blocked BlockedError
-	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "scoped") {
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "not allowed") {
 		t.Fatalf("error = %v, want scope BlockedError", err)
 	}
 	assertTaskState(t, store, "task-7", TaskBlocked)


### PR DESCRIPTION
WHAT:
- Adds global agents with explicit many-to-many repository access.

WHY:
- Gitmoot agents need to operate across multiple repositories without global name conflicts or single-repo `repo_scope` limitations.

CHANGES:
- Added `agent_repos` migration and store helpers for allow, deny, replace, list, and authorization checks.
- Migrates legacy `repo_scope` into `agent_repos`.
- Added `gitmoot agent allow`, `agent deny`, and `agent repos`.
- Updated `agent subscribe` to accept repeated `--repo` flags and replace configured repo grants on re-subscribe.
- Updated daemon routing and workflow authorization to use explicit repo access.
- Relaxed runtime validation so agents may subscribe globally with no repo grants yet.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/cli ./internal/daemon ./internal/workflow ./internal/runtime`
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `GOTOOLCHAIN=go1.26.0 go vet ./...`
- `git diff --check`
- `git diff --cached --check`
- `codex exec review --uncommitted` final raw output:

```text
I did not identify any discrete correctness issues in the changed access-control flow. The new agent_repos migration, CLI commands, and daemon/workflow authorization checks appear consistent with the multi-repo agent access behavior.
I did not identify any discrete correctness issues in the changed access-control flow. The new agent_repos migration, CLI commands, and daemon/workflow authorization checks appear consistent with the multi-repo agent access behavior.
```

RISK:
- Review sandbox could not run tests with local Go 1.22.2, so tests were run outside the review sandbox with `GOTOOLCHAIN=go1.26.0`.
