### PR TITLE
feat: add daemon job workers

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/db"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -190,13 +192,13 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 			},
 		}
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
-		return (daemon.Daemon{
+		return runSingleRepoSupervisor(ctx, daemon.Daemon{
 			Repo:         repo,
 			PollInterval: *poll,
 			Store:        store,
 			GitHub:       gh,
 			Workflow:     &engine,
-		}).Run(ctx)
+		}, store, *workers, stdout)
 	})
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return 0
@@ -781,10 +783,16 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			ErrorStreak: map[string]int{},
 		}
 		poller := defaultRegisteredRepoPoller(store, workers, dryRun, stdout)
+		worker := defaultJobWorker(store, stdout)
 		for {
 			wait, err := pollRegisteredReposWithPoller(ctx, poller, schedule, time.Now().UTC(), poll)
 			if err != nil {
 				return err
+			}
+			if !dryRun {
+				if err := runEnabledRepoWorkerTicks(ctx, store, worker, workers, stdout, time.Now().UTC()); err != nil {
+					return err
+				}
 			}
 			timer := time.NewTimer(wait)
 			select {
@@ -795,6 +803,33 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			}
 		}
 	})
+}
+
+func runSingleRepoSupervisor(ctx context.Context, d daemon.Daemon, store *db.Store, workers int, stdout io.Writer) error {
+	if err := recoverRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName()); err != nil {
+		return err
+	}
+	interval := d.PollInterval
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	worker := defaultJobWorker(store, stdout)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_ = d.PollOnce(ctx)
+		if err := runDaemonWorkerTick(ctx, store, worker, workers, false, d.Repo.FullName(), stdout, time.Now().UTC()); err != nil {
+			return err
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
 }
 
 func pollRegisteredRepos(ctx context.Context, store *db.Store, workers int, dryRun bool, stdout io.Writer, nextPoll map[string]time.Time, now time.Time, fallbackPoll time.Duration) (time.Duration, error) {
@@ -833,15 +868,8 @@ func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdo
 		Stdout:       stdout,
 		GitHubClient: func(checkout string) github.Client { return github.NewClient(checkout) },
 		WorkflowFactory: func(store *db.Store, gh github.Client, checkout string) *workflow.Engine {
-			return &workflow.Engine{
-				Store: store,
-				MergeGate: workflow.PolicyMergeGate{
-					Store:        store,
-					GitHub:       gh,
-					Git:          gitutil.Client{Dir: checkout},
-					DeleteBranch: true,
-				},
-			}
+			engine := daemonWorkflowEngine(store, gh, checkout)
+			return &engine
 		},
 	}
 }
@@ -962,6 +990,529 @@ func shorterWait(current time.Duration, candidate time.Duration, set *bool) time
 		return candidate
 	}
 	return current
+}
+
+type jobWorker struct {
+	Store             *db.Store
+	Stdout            io.Writer
+	AdapterFactory    func(runtime.Agent, string) (workflow.DeliveryAdapter, error)
+	CheckoutValidator func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error)
+	WorkflowFactory   func(string) workflow.Engine
+}
+
+const daemonRunningJobStaleAfter = 30 * time.Minute
+
+func defaultJobWorker(store *db.Store, stdout io.Writer) jobWorker {
+	worker := jobWorker{Store: store, Stdout: stdout}
+	worker.AdapterFactory = worker.defaultAdapter
+	worker.CheckoutValidator = worker.defaultCheckout
+	worker.WorkflowFactory = worker.defaultWorkflow
+	return worker
+}
+
+func recoverRunningJobs(ctx context.Context, store *db.Store, stdout io.Writer) error {
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, time.Now().UTC().Add(-daemonRunningJobStaleAfter), "")
+}
+
+func recoverRunningJobsBefore(ctx context.Context, store *db.Store, stdout io.Writer, before time.Time) error {
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, before, "")
+}
+
+func recoverRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.Writer, repoFilter string) error {
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, time.Now().UTC().Add(-daemonRunningJobStaleAfter), repoFilter)
+}
+
+func recoverRunningJobsBeforeForRepo(ctx context.Context, store *db.Store, stdout io.Writer, before time.Time, repoFilter string) error {
+	jobs, err := store.ListRunningJobsUpdatedBefore(ctx, before)
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		if !queuedJobMatchesRepo(job, repoFilter) {
+			continue
+		}
+		recovered, err := store.TransitionJobStateWithEvent(ctx, job.ID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
+			JobID:   job.ID,
+			Kind:    string(workflow.JobQueued),
+			Message: "recovered stale running job on daemon startup",
+		})
+		if err != nil {
+			return err
+		}
+		if recovered {
+			writeLine(stdout, "requeued stale running job %s", job.ID)
+		}
+	}
+	return nil
+}
+
+func runQueuedJobs(ctx context.Context, worker jobWorker, limit int) error {
+	return runQueuedJobsForRepo(ctx, worker, limit, "")
+}
+
+func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilter string) error {
+	jobs, err := worker.Store.ListJobs(ctx)
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		if !jobStateCanRetryAdvancement(job.State) || !queuedJobMatchesRepo(job, repoFilter) {
+			continue
+		}
+		needsRetry, err := worker.jobNeedsAdvanceRetry(ctx, job.ID)
+		if err != nil {
+			return err
+		}
+		if !needsRetry {
+			continue
+		}
+		if err := worker.advanceJob(ctx, job); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker, workers int, dryRun bool, repoFilter string, stdout io.Writer, now time.Time) error {
+	if dryRun {
+		return nil
+	}
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now.Add(-daemonRunningJobStaleAfter), repoFilter); err != nil {
+		return err
+	}
+	if err := retryPendingJobAdvancements(ctx, worker, repoFilter); err != nil {
+		return err
+	}
+	return runQueuedJobsForRepo(ctx, worker, workers, repoFilter)
+}
+
+func runEnabledRepoWorkerTicks(ctx context.Context, store *db.Store, worker jobWorker, workers int, stdout io.Writer, now time.Time) error {
+	repos, err := store.ListRepos(ctx)
+	if err != nil {
+		return err
+	}
+	for _, repo := range repos {
+		if !repo.Enabled {
+			continue
+		}
+		if err := runDaemonWorkerTick(ctx, store, worker, workers, false, repo.FullName(), stdout, now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func jobStateCanRetryAdvancement(state string) bool {
+	switch state {
+	case string(workflow.JobSucceeded), string(workflow.JobFailed), string(workflow.JobBlocked):
+		return true
+	default:
+		return false
+	}
+}
+
+func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repoFilter string) error {
+	if limit <= 0 {
+		return nil
+	}
+	jobs, err := worker.Store.ListQueuedJobs(ctx)
+	if err != nil {
+		return err
+	}
+	pending := make([]db.Job, 0, len(jobs))
+	for _, job := range jobs {
+		if queuedJobMatchesRepo(job, repoFilter) {
+			pending = append(pending, job)
+		}
+	}
+	for len(pending) > 0 {
+		queued := make([]db.Job, 0, limit)
+		remaining := make([]db.Job, 0, len(pending))
+		selectedCheckouts := map[string]bool{}
+		for _, job := range pending {
+			checkoutKey := queuedJobCheckoutKey(job)
+			if len(queued) == limit || selectedCheckouts[checkoutKey] {
+				remaining = append(remaining, job)
+				continue
+			}
+			queued = append(queued, job)
+			selectedCheckouts[checkoutKey] = true
+		}
+		if len(queued) == 0 {
+			return nil
+		}
+		pending = remaining
+
+		errs := make(chan error, len(queued))
+		var wg sync.WaitGroup
+		for _, job := range queued {
+			job := job
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				errs <- worker.run(ctx, job)
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func queuedJobMatchesRepo(job db.Job, repoFilter string) bool {
+	repoFilter = strings.TrimSpace(repoFilter)
+	if repoFilter == "" {
+		return true
+	}
+	payload, err := daemonJobPayload(job)
+	return err == nil && payload.Repo == repoFilter
+}
+
+func queuedJobCheckoutKey(job db.Job) string {
+	payload, err := daemonJobPayload(job)
+	if err != nil || strings.TrimSpace(payload.Repo) == "" {
+		return "job:" + job.ID
+	}
+	return "repo:" + payload.Repo
+}
+
+func (w jobWorker) run(ctx context.Context, job db.Job) error {
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err)
+	}
+	dbAgent, err := w.Store.GetAgent(ctx, job.Agent)
+	if err != nil {
+		return w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err)
+	}
+	agent := runtimeAgent(dbAgent)
+	checkout, err := w.CheckoutValidator(ctx, job, payload, agent)
+	if err != nil {
+		return w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err)
+	}
+	adapter, err := w.AdapterFactory(agent, checkout)
+	if err != nil {
+		return w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err)
+	}
+	writeLine(w.Stdout, "running job %s for %s in %s", job.ID, agent.Name, payload.Repo)
+	engine := w.WorkflowFactory(checkout)
+	_, err = engine.RunJob(ctx, job.ID, agent, adapter)
+	if err != nil {
+		if markErr := w.handleRunJobError(ctx, job.ID, err); markErr != nil {
+			return markErr
+		}
+		writeLine(w.Stdout, "job %s failed: %v", job.ID, err)
+		return nil
+	}
+	writeLine(w.Stdout, "job %s completed", job.ID)
+	return nil
+}
+
+func (w jobWorker) jobNeedsAdvanceRetry(ctx context.Context, jobID string) (bool, error) {
+	events, err := w.Store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+	needsRetry := false
+	for _, event := range events {
+		switch event.Kind {
+		case "advance_started", "advance_retry":
+			needsRetry = true
+		case "advance_completed", "advance_retried", "advance_blocked", "advance_retry_skipped":
+			needsRetry = false
+		}
+	}
+	return needsRetry, nil
+}
+
+func (w jobWorker) advanceJob(ctx context.Context, job db.Job) error {
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retry_skipped", Message: err.Error()})
+	}
+	dbAgent, err := w.Store.GetAgent(ctx, job.Agent)
+	if err != nil {
+		return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retry_skipped", Message: err.Error()})
+	}
+	agent := runtimeAgent(dbAgent)
+	if refreshed, ok, err := w.refreshImplementedPayloadForRetry(ctx, job, payload); err != nil {
+		return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retry", Message: "post-delivery workflow retry refresh failed: " + err.Error()})
+	} else if ok {
+		payload = refreshed
+	}
+	checkout, err := w.CheckoutValidator(ctx, job, payload, agent)
+	if err != nil {
+		return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retry", Message: "post-delivery workflow retry preflight failed: " + err.Error()})
+	}
+	engine := w.WorkflowFactory(checkout)
+	if err := engine.AdvanceJob(ctx, job.ID); err != nil {
+		var blocked workflow.BlockedError
+		if errors.As(err, &blocked) {
+			return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_blocked", Message: err.Error()})
+		}
+		return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retry", Message: "post-delivery workflow retry failed: " + err.Error()})
+	}
+	writeLine(w.Stdout, "job %s advancement retried", job.ID)
+	return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retried", Message: "post-delivery workflow retry completed"})
+}
+
+func (w jobWorker) refreshImplementedPayloadForRetry(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, bool, error) {
+	if job.Type != "implement" || payload.Result == nil || payload.Result.Decision != "implemented" {
+		return payload, false, nil
+	}
+	repoRecord, err := w.Store.GetRepo(ctx, payload.Repo)
+	if err != nil {
+		return workflow.JobPayload{}, false, err
+	}
+	checkout := strings.TrimSpace(repoRecord.CheckoutPath)
+	if checkout == "" {
+		return workflow.JobPayload{}, false, fmt.Errorf("repo %s has no checkout path", payload.Repo)
+	}
+	repo, err := daemon.ParseRepository(payload.Repo)
+	if err != nil {
+		return workflow.JobPayload{}, false, err
+	}
+	if err := preflightDaemonRepoCheckout(ctx, repo, checkout); err != nil {
+		return workflow.JobPayload{}, false, err
+	}
+	payload, err = refreshDaemonJobPayload(ctx, w.Store, checkout, job, payload)
+	if err != nil {
+		return workflow.JobPayload{}, false, err
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return workflow.JobPayload{}, false, err
+	}
+	if err := w.Store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+		return workflow.JobPayload{}, false, err
+	}
+	return payload, true, nil
+}
+
+func (w jobWorker) defaultAdapter(agent runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
+	switch agent.Runtime {
+	case runtime.CodexRuntime:
+		return runtime.CodexAdapter{Dir: checkout}, nil
+	case runtime.ClaudeRuntime:
+		return runtime.ClaudeAdapter{Dir: checkout}, nil
+	case runtime.ShellRuntime:
+		return runtime.ShellAdapter{Dir: checkout}, nil
+	default:
+		return nil, fmt.Errorf("unsupported runtime: %s", agent.Runtime)
+	}
+}
+
+func (w jobWorker) defaultWorkflow(checkout string) workflow.Engine {
+	return daemonWorkflowEngine(w.Store, github.NewClient(checkout), checkout)
+}
+
+func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string) workflow.Engine {
+	return workflow.Engine{
+		Store: store,
+		MergeGate: workflow.PolicyMergeGate{
+			Store:        store,
+			GitHub:       gh,
+			Git:          gitutil.Client{Dir: checkout},
+			DeleteBranch: true,
+		},
+		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
+			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
+		},
+	}
+}
+
+func refreshDaemonJobPayload(ctx context.Context, store *db.Store, checkout string, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
+	if job.Type != "implement" || payload.Result == nil || payload.Result.Decision != "implemented" {
+		return payload, nil
+	}
+	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		return workflow.JobPayload{}, err
+	}
+	payload.HeadSHA = head
+	if len(payload.Reviewers) == 0 {
+		reviewers, err := daemonReviewers(ctx, store, payload.Repo)
+		if err != nil {
+			return workflow.JobPayload{}, err
+		}
+		payload.Reviewers = reviewers
+	}
+	return payload, nil
+}
+
+func daemonReviewers(ctx context.Context, store *db.Store, repo string) ([]string, error) {
+	agents, err := store.ListAgents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	reviewers := []string{}
+	for _, agent := range agents {
+		allowed, err := store.AgentCanAccessRepo(ctx, agent.Name, repo)
+		if err != nil {
+			return nil, err
+		}
+		if allowed && agentHasCapability(agent.Capabilities, "review") {
+			reviewers = append(reviewers, agent.Name)
+		}
+	}
+	return reviewers, nil
+}
+
+func agentHasCapability(capabilities []string, target string) bool {
+	for _, capability := range capabilities {
+		if capability == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload workflow.JobPayload, agent runtime.Agent) (string, error) {
+	repoRecord, err := w.Store.GetRepo(ctx, payload.Repo)
+	if err != nil {
+		return "", err
+	}
+	checkout := strings.TrimSpace(repoRecord.CheckoutPath)
+	if checkout == "" {
+		return "", fmt.Errorf("repo %s has no checkout path", payload.Repo)
+	}
+	repo, err := daemon.ParseRepository(payload.Repo)
+	if err != nil {
+		return "", err
+	}
+	if err := preflightDaemonRepoCheckout(ctx, repo, checkout); err != nil {
+		return "", err
+	}
+	switch job.Type {
+	case "implement":
+		if err := w.validateTargetCheckout(ctx, payload, checkout); err != nil {
+			return "", err
+		}
+		if err := w.validateImplementationLock(ctx, payload, agent); err != nil {
+			return "", err
+		}
+	case "review":
+		if err := w.validateTargetCheckout(ctx, payload, checkout); err != nil {
+			return "", err
+		}
+	case "ask":
+		if payload.PullRequest > 0 {
+			if err := w.validateTargetCheckout(ctx, payload, checkout); err != nil {
+				return "", err
+			}
+		}
+	}
+	return checkout, nil
+}
+
+func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.JobPayload, checkout string) error {
+	git := gitutil.Client{Dir: checkout}
+	branch, err := git.CurrentBranch(ctx)
+	if err != nil {
+		return err
+	}
+	if branch != payload.Branch {
+		return fmt.Errorf("checkout branch is %s, not job branch %s", branch, payload.Branch)
+	}
+	clean, err := git.WorktreeClean(ctx)
+	if err != nil {
+		return err
+	}
+	if !clean {
+		return fmt.Errorf("checkout %s has uncommitted changes", checkout)
+	}
+	expectedHead := strings.TrimSpace(payload.HeadSHA)
+	if expectedHead == "" {
+		return fmt.Errorf("job for %s has no head SHA", payload.Branch)
+	}
+	head, err := git.HeadSHA(ctx)
+	if err != nil {
+		return err
+	}
+	if head != expectedHead {
+		return fmt.Errorf("checkout head is %s, not job head %s", head, expectedHead)
+	}
+	return nil
+}
+
+func (w jobWorker) validateImplementationLock(ctx context.Context, payload workflow.JobPayload, agent runtime.Agent) error {
+	lock, err := w.Store.GetBranchLock(ctx, payload.Repo, payload.Branch)
+	if err != nil {
+		return err
+	}
+	if lock.Owner != agent.Name {
+		return fmt.Errorf("branch %s is locked by %s, not %s", payload.Branch, lock.Owner, agent.Name)
+	}
+	return nil
+}
+
+func (w jobWorker) finishQueuedJob(ctx context.Context, jobID string, state workflow.JobState, cause error) error {
+	transitioned, err := w.Store.TransitionJobStateWithEvent(ctx, jobID, string(workflow.JobQueued), string(state), db.JobEvent{
+		JobID:   jobID,
+		Kind:    string(state),
+		Message: cause.Error(),
+	})
+	if err != nil {
+		return err
+	}
+	if transitioned {
+		writeLine(w.Stdout, "job %s %s: %v", jobID, state, cause)
+	}
+	return nil
+}
+
+func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause error) error {
+	latest, err := w.Store.GetJob(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if latest.State == string(workflow.JobQueued) {
+		state := workflow.JobFailed
+		var blocked workflow.BlockedError
+		if errors.As(cause, &blocked) {
+			state = workflow.JobBlocked
+		}
+		return w.finishQueuedJob(ctx, jobID, state, cause)
+	}
+	if latest.State == string(workflow.JobCancelled) {
+		return nil
+	}
+	payload, payloadErr := daemonJobPayload(latest)
+	if payloadErr == nil && payload.Result != nil {
+		var blocked workflow.BlockedError
+		if errors.As(cause, &blocked) {
+			return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: latest.ID, Kind: "advance_blocked", Message: cause.Error()})
+		}
+		if err := w.recordPostDeliveryWorkflowError(ctx, latest, cause); err != nil {
+			return err
+		}
+		return nil
+	}
+	if latest.State == string(workflow.JobFailed) || latest.State == string(workflow.JobBlocked) {
+		return nil
+	}
+	return cause
+}
+
+func (w jobWorker) recordPostDeliveryWorkflowError(ctx context.Context, job db.Job, cause error) error {
+	return w.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   job.ID,
+		Kind:    "advance_retry",
+		Message: "post-delivery workflow error; advancement will retry from stored result: " + cause.Error(),
+	})
+}
+
+func daemonJobPayload(job db.Job) (workflow.JobPayload, error) {
+	var payload workflow.JobPayload
+	if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
+		return workflow.JobPayload{}, fmt.Errorf("parse job payload %q: %w", job.ID, err)
+	}
+	return payload, nil
 }
 
 func resolveDaemonCheckout(ctx context.Context, repo github.Repository, client gitutil.Client) (string, error) {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -11,13 +11,16 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -526,6 +529,1091 @@ func TestPollRegisteredReposBacksOffFailedRepoWithoutStoppingOthers(t *testing.T
 	}
 }
 
+func TestRunQueuedJobsExecutesShellAdapterSuccess(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, `printf '%s\n' '{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}'`, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-success", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-success")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) || !strings.Contains(job.Payload, `"summary":"done"`) {
+		t.Fatalf("job after worker = %+v", job)
+	}
+}
+
+func TestRunQueuedJobsMarksShellAdapterFailure(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "exit 7", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-fail", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-fail")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+}
+
+func TestRunQueuedJobsUsesMailboxRepairForMalformedOutput(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, `if printf '%s' "$1" | grep -q 'Previous raw output'; then printf '%s\n' '{"gitmoot_result":{"decision":"approved","summary":"repaired","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}'; else printf '%s\n' 'not json'; fi`, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-repair", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-repair")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) || !strings.Contains(job.Payload, `"summary":"repaired"`) {
+		t.Fatalf("job after repair = %+v", job)
+	}
+	events, err := store.ListJobEvents(ctx, "job-repair")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "malformed_output") || !daemonWorkerHasEvent(events, "repair_retry") {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestRunQueuedJobsDrainsBeyondWorkerLimit(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	for _, id := range []string{"job-1", "job-2", "job-3"} {
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	}
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 2); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if adapter.calls != 3 {
+		t.Fatalf("adapter calls = %d, want 3", adapter.calls)
+	}
+	for _, id := range []string{"job-1", "job-2", "job-3"} {
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob(%s) returned error: %v", id, err)
+		}
+		if job.State != string(workflow.JobSucceeded) {
+			t.Fatalf("%s state = %q, want succeeded", id, job.State)
+		}
+	}
+}
+
+func TestRunQueuedJobsDefersJobsEnqueuedByCurrentSnapshot(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:          "job-implement",
+		Agent:       "lead",
+		Action:      "implement",
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 1,
+		TaskID:      "task-1",
+		TaskTitle:   "Task 1",
+		LeadAgent:   "lead",
+		HeadSHA:     strings.Repeat("a", 40),
+	})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"implemented","summary":"opened","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, RequiredReviewers: []string{"reviewer"}}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 2); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want only initial implementation job", adapter.calls)
+	}
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Agent != "reviewer" || jobs[0].Type != "review" {
+		t.Fatalf("queued jobs = %+v, want deferred reviewer job", jobs)
+	}
+}
+
+func TestRunQueuedJobsRefreshesImplementedHeadBeforeReviewDispatch(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "branch", "-m", "task-1")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	oldHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:          "job-implement",
+		Agent:       "lead",
+		Action:      "implement",
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 1,
+		TaskID:      "task-1",
+		TaskTitle:   "Task 1",
+		LeadAgent:   "lead",
+		HeadSHA:     oldHead,
+	})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"implemented","summary":"opened","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		onDeliver: func() {
+			if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("implemented\n"), 0o644); err != nil {
+				t.Fatalf("WriteFile returned error: %v", err)
+			}
+			runGit(t, checkout, "add", "README.md")
+			runGit(t, checkout, "commit", "-m", "implement")
+		},
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(checkout string) workflow.Engine {
+		return daemonWorkflowEngine(store, github.NoopClient{}, checkout)
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	newHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	if newHead == oldHead {
+		t.Fatal("new HEAD did not change")
+	}
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Agent != "reviewer" || jobs[0].Type != "review" {
+		t.Fatalf("queued jobs = %+v, want reviewer job", jobs)
+	}
+	payload, err := daemonJobPayload(jobs[0])
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if payload.HeadSHA != newHead {
+		t.Fatalf("review payload head = %q, want %q", payload.HeadSHA, newHead)
+	}
+}
+
+func TestRunQueuedJobsSerializesSameRepoCheckout(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	for _, id := range []string{"job-a", "job-b"} {
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	}
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		onDeliver: func() {
+			mu.Lock()
+			active++
+			if active > maxActive {
+				maxActive = active
+			}
+			mu.Unlock()
+			time.Sleep(10 * time.Millisecond)
+			mu.Lock()
+			active--
+			mu.Unlock()
+		},
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 2); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if maxActive != 1 {
+		t.Fatalf("max concurrent same-repo deliveries = %d, want 1", maxActive)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+}
+
+func TestRunQueuedJobsPreservesCreationOrderForSameRepo(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	for _, id := range []string{"job-z", "job-a"} {
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	}
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	want := []string{"job-z", "job-a"}
+	if !reflect.DeepEqual(adapter.delivered, want) {
+		t.Fatalf("delivered jobs = %v, want %v", adapter.delivered, want)
+	}
+}
+
+func TestRunQueuedJobsPreservesCancellationRace(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-cancel", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"late","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		onDeliver: func() {
+			if err := store.UpdateJobState(ctx, "job-cancel", string(workflow.JobCancelled)); err != nil {
+				t.Fatalf("UpdateJobState returned error: %v", err)
+			}
+		},
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-cancel")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+}
+
+func TestRunQueuedJobsUsesConfiguredMergeGate(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:          "job-review",
+		Agent:       "reviewer",
+		Action:      "review",
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 1,
+		TaskID:      "task-1",
+	})
+	gate := &cliWorkerFakeMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true}}
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, MergeGate: gate}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if gate.calls != 1 {
+		t.Fatalf("merge gate calls = %d, want 1", gate.calls)
+	}
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskMerged) {
+		t.Fatalf("task state = %q, want merged", task.State)
+	}
+}
+
+func TestRunQueuedJobsFailsImplementWithoutBranchLockBeforeDelivery(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "branch", "-m", "task-1")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-implement", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 1, TaskID: "task-1"})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want preflight to stop delivery", adapter.calls)
+	}
+	job, err := store.GetJob(ctx, "job-implement")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+}
+
+func TestRunQueuedJobsFailsReviewOnWrongCheckoutBranchBeforeDelivery(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("test\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "branch", "-m", "main")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-review", Agent: "reviewer", Action: "review", Repo: "owner/repo", Branch: "task-1", PullRequest: 1, HeadSHA: head})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want preflight to stop delivery", adapter.calls)
+	}
+	job, err := store.GetJob(ctx, "job-review")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+}
+
+func TestRunQueuedJobsFailsReviewOnWrongCheckoutHeadBeforeDelivery(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("test\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "branch", "-m", "task-1")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-review", Agent: "reviewer", Action: "review", Repo: "owner/repo", Branch: "task-1", PullRequest: 1, HeadSHA: strings.Repeat("0", 40)})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want preflight to stop delivery", adapter.calls)
+	}
+	job, err := store.GetJob(ctx, "job-review")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+}
+
+func TestRunQueuedJobsFailsPRScopedAskOnWrongCheckoutHeadBeforeDelivery(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("test\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "branch", "-m", "task-1")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-ask", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "task-1", PullRequest: 1, HeadSHA: strings.Repeat("0", 40)})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want preflight to stop delivery", adapter.calls)
+	}
+	job, err := store.GetJob(ctx, "job-ask")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+}
+
+func TestRunQueuedJobsForRepoSkipsOtherRepos(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo-a")
+	if err := store.AllowAgentRepo(ctx, "audit", "owner/repo-b"); err != nil {
+		t.Fatalf("AllowAgentRepo returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobsForRepo(ctx, worker, 2, "owner/repo-a"); err != nil {
+		t.Fatalf("runQueuedJobsForRepo returned error: %v", err)
+	}
+
+	jobA, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob job-a returned error: %v", err)
+	}
+	jobB, err := store.GetJob(ctx, "job-b")
+	if err != nil {
+		t.Fatalf("GetJob job-b returned error: %v", err)
+	}
+	if jobA.State != string(workflow.JobSucceeded) {
+		t.Fatalf("job-a state = %q, want succeeded", jobA.State)
+	}
+	if jobB.State != string(workflow.JobQueued) {
+		t.Fatalf("job-b state = %q, want queued", jobB.State)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+}
+
+func TestRunEnabledRepoWorkerTicksSkipsDisabledRepos(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/enabled", t.TempDir())
+	seedDaemonWorkerRepo(t, store, "owner/disabled", t.TempDir())
+	if err := store.SetRepoEnabled(ctx, "owner/disabled", false); err != nil {
+		t.Fatalf("SetRepoEnabled returned error: %v", err)
+	}
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/enabled")
+	if err := store.AllowAgentRepo(ctx, "audit", "owner/disabled"); err != nil {
+		t.Fatalf("AllowAgentRepo returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-enabled", Agent: "audit", Action: "ask", Repo: "owner/enabled", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-disabled", Agent: "audit", Action: "ask", Repo: "owner/disabled", Branch: "main", PullRequest: 2})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runEnabledRepoWorkerTicks(ctx, store, worker, 2, io.Discard, time.Now().UTC()); err != nil {
+		t.Fatalf("runEnabledRepoWorkerTicks returned error: %v", err)
+	}
+
+	enabledJob, err := store.GetJob(ctx, "job-enabled")
+	if err != nil {
+		t.Fatalf("GetJob job-enabled returned error: %v", err)
+	}
+	disabledJob, err := store.GetJob(ctx, "job-disabled")
+	if err != nil {
+		t.Fatalf("GetJob job-disabled returned error: %v", err)
+	}
+	if enabledJob.State != string(workflow.JobSucceeded) {
+		t.Fatalf("enabled job state = %q, want succeeded", enabledJob.State)
+	}
+	if disabledJob.State != string(workflow.JobQueued) {
+		t.Fatalf("disabled job state = %q, want queued", disabledJob.State)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+}
+
+func TestRunQueuedJobsRecordsPostDeliveryWorkflowErrorForRetry(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:          "job-review",
+		Agent:       "reviewer",
+		Action:      "review",
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 1,
+		TaskID:      "task-1",
+		HeadSHA:     strings.Repeat("a", 40),
+	})
+	gate := &cliWorkerFakeMergeGate{err: errors.New("github unavailable")}
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, MergeGate: gate}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	job, getErr := store.GetJob(ctx, "job-review")
+	if getErr != nil {
+		t.Fatalf("GetJob returned error: %v", getErr)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded result preserved", job.State)
+	}
+	events, err := store.ListJobEvents(ctx, "job-review")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "advance_retry") {
+		t.Fatalf("events = %+v, want advance retry event", events)
+	}
+	gate.err = nil
+	gate.decision = workflow.MergeDecision{Ready: true}
+	if err := retryPendingJobAdvancements(ctx, worker, ""); err != nil {
+		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want no redelivery during advance retry", adapter.calls)
+	}
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskReadyToMerge) {
+		t.Fatalf("task state = %q, want ready_to_merge", task.State)
+	}
+	events, err = store.ListJobEvents(ctx, "job-review")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "advance_retried") {
+		t.Fatalf("events = %+v, want advance retried event", events)
+	}
+}
+
+func TestRetryPendingJobAdvancementsRecoversStartedAdvancement(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	payload := workflow.JobPayload{
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 1,
+		TaskID:      "task-1",
+		Result:      &workflow.AgentResult{Decision: "approved", Summary: "approved"},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-review", Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded), Payload: string(encoded)}, db.JobEvent{
+		JobID:   "job-review",
+		Kind:    string(workflow.JobSucceeded),
+		Message: "job succeeded",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-review", Kind: "advance_started", Message: "workflow advancement started"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+	gate := &cliWorkerFakeMergeGate{decision: workflow.MergeDecision{Ready: true}}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, MergeGate: gate}
+	}
+
+	if err := retryPendingJobAdvancements(ctx, worker, ""); err != nil {
+		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
+	}
+
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskReadyToMerge) {
+		t.Fatalf("task state = %q, want ready_to_merge", task.State)
+	}
+	events, err := store.ListJobEvents(ctx, "job-review")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "advance_retried") {
+		t.Fatalf("events = %+v, want advance retried event", events)
+	}
+}
+
+func TestRetryPendingJobAdvancementsAdvancesFailedStoredResult(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	payload := workflow.JobPayload{
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 1,
+		TaskID:      "task-1",
+		Result:      &workflow.AgentResult{Decision: "failed", Summary: "tests failed"},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-review", Agent: "reviewer", Type: "review", State: string(workflow.JobFailed), Payload: string(encoded)}, db.JobEvent{
+		JobID:   "job-review",
+		Kind:    string(workflow.JobFailed),
+		Message: "job failed",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-review", Kind: "advance_retry", Message: "transient workflow failure"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store}
+	}
+
+	if err := retryPendingJobAdvancements(ctx, worker, ""); err != nil {
+		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
+	}
+
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task state = %q, want blocked", task.State)
+	}
+	events, err := store.ListJobEvents(ctx, "job-review")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "advance_blocked") {
+		t.Fatalf("events = %+v, want advance blocked event", events)
+	}
+}
+
+func TestRetryPendingJobAdvancementsRefreshesImplementedHeadBeforePreflight(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "branch", "-m", "task-1")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	oldHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("implemented\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "implement")
+	newHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	payload := workflow.JobPayload{
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 1,
+		HeadSHA:     oldHead,
+		TaskID:      "task-1",
+		TaskTitle:   "Task 1",
+		LeadAgent:   "lead",
+		Result:      &workflow.AgentResult{Decision: "implemented", Summary: "done"},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-implement", Agent: "lead", Type: "implement", State: string(workflow.JobSucceeded), Payload: string(encoded)}, db.JobEvent{
+		JobID:   "job-implement",
+		Kind:    string(workflow.JobSucceeded),
+		Message: "job succeeded",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-implement", Kind: "advance_retry", Message: "transient refresh failure"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.WorkflowFactory = func(checkout string) workflow.Engine {
+		return daemonWorkflowEngine(store, github.NoopClient{}, checkout)
+	}
+
+	if err := retryPendingJobAdvancements(ctx, worker, ""); err != nil {
+		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
+	}
+
+	implementJob, err := store.GetJob(ctx, "job-implement")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	implementPayload, err := daemonJobPayload(implementJob)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if implementPayload.HeadSHA != newHead {
+		t.Fatalf("implement payload head = %q, want %q", implementPayload.HeadSHA, newHead)
+	}
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Agent != "reviewer" || jobs[0].Type != "review" {
+		t.Fatalf("queued jobs = %+v, want reviewer job", jobs)
+	}
+	reviewPayload, err := daemonJobPayload(jobs[0])
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if reviewPayload.HeadSHA != newHead {
+		t.Fatalf("review payload head = %q, want %q", reviewPayload.HeadSHA, newHead)
+	}
+}
+
+func TestRunQueuedJobsSwallowsPostDeliveryBlockedWorkflow(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:          "job-review",
+		Agent:       "reviewer",
+		Action:      "review",
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 1,
+		TaskID:      "task-1",
+		HeadSHA:     strings.Repeat("a", 40),
+	})
+	gate := &cliWorkerFakeMergeGate{decision: workflow.MergeDecision{Ready: false, Reason: "ci pending"}}
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, MergeGate: gate}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-review")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded result preserved", job.State)
+	}
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task state = %q, want blocked", task.State)
+	}
+}
+
+func TestRecoverRunningJobsRequeuesStaleRunningJobs(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-running", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if err := store.UpdateJobState(ctx, "job-running", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+
+	if err := recoverRunningJobsBefore(ctx, store, io.Discard, time.Now().UTC().Add(time.Second)); err != nil {
+		t.Fatalf("recoverRunningJobsBefore returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-running")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued", job.State)
+	}
+	events, err := store.ListJobEvents(ctx, "job-running")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, string(workflow.JobQueued)) {
+		t.Fatalf("events = %+v, want queued recovery event", events)
+	}
+}
+
+func TestRecoverRunningJobsKeepsRecentRunningJobsOnStartup(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-running", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if err := store.UpdateJobState(ctx, "job-running", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+
+	if err := recoverRunningJobs(ctx, store, io.Discard); err != nil {
+		t.Fatalf("recoverRunningJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-running")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("job state = %q, want running", job.State)
+	}
+}
+
+func TestDaemonWorkerTickRechecksStaleRunningJobs(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-running", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if err := store.UpdateJobState(ctx, "job-running", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	now := time.Now().UTC().Add(daemonRunningJobStaleAfter + time.Second)
+
+	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "", io.Discard, now); err != nil {
+		t.Fatalf("runDaemonWorkerTick returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-running")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued", job.State)
+	}
+}
+
+func TestRecoverRunningJobsForRepoSkipsOtherRepos(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 1})
+	for _, id := range []string{"job-a", "job-b"} {
+		if err := store.UpdateJobState(ctx, id, string(workflow.JobRunning)); err != nil {
+			t.Fatalf("UpdateJobState(%s) returned error: %v", id, err)
+		}
+	}
+
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, io.Discard, time.Now().UTC().Add(time.Second), "owner/repo-a"); err != nil {
+		t.Fatalf("recoverRunningJobsBeforeForRepo returned error: %v", err)
+	}
+
+	jobA, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob job-a returned error: %v", err)
+	}
+	jobB, err := store.GetJob(ctx, "job-b")
+	if err != nil {
+		t.Fatalf("GetJob job-b returned error: %v", err)
+	}
+	if jobA.State != string(workflow.JobQueued) {
+		t.Fatalf("job-a state = %q, want queued", jobA.State)
+	}
+	if jobB.State != string(workflow.JobRunning) {
+		t.Fatalf("job-b state = %q, want running", jobB.State)
+	}
+}
+
 func TestDaemonLogsEmptyWhenMissing(t *testing.T) {
 	home := t.TempDir()
 	var stdout, stderr bytes.Buffer
@@ -641,4 +1729,99 @@ func (f *cliPollFakeGitHub) PostIssueComment(_ context.Context, _ github.Reposit
 
 func (f *cliPollFakeGitHub) GetUserPermission(context.Context, github.Repository, string) (github.UserPermission, error) {
 	return github.UserPermission{Permission: "write", RoleName: "write"}, nil
+}
+
+type cliWorkerFakeAdapter struct {
+	mu        sync.Mutex
+	output    string
+	calls     int
+	delivered []string
+	onDeliver func()
+}
+
+func (f *cliWorkerFakeAdapter) Deliver(_ context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	f.mu.Lock()
+	f.calls++
+	f.delivered = append(f.delivered, job.ID)
+	onDeliver := f.onDeliver
+	f.mu.Unlock()
+	if onDeliver != nil {
+		onDeliver()
+	}
+	return runtime.Result{Raw: f.output}, nil
+}
+
+type cliWorkerFakeMergeGate struct {
+	calls    int
+	decision workflow.MergeDecision
+	err      error
+}
+
+func (f *cliWorkerFakeMergeGate) Evaluate(context.Context, workflow.MergeRequest) (workflow.MergeDecision, error) {
+	f.calls++
+	if f.err != nil {
+		return workflow.MergeDecision{}, f.err
+	}
+	return f.decision, nil
+}
+
+func daemonWorkerStore(t *testing.T) *db.Store {
+	t.Helper()
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	return store
+}
+
+func seedDaemonWorkerRepo(t *testing.T, store *db.Store, fullName string, checkout string) {
+	t.Helper()
+	repo, err := daemon.ParseRepository(fullName)
+	if err != nil {
+		t.Fatalf("ParseRepository returned error: %v", err)
+	}
+	if err := store.UpsertRepo(context.Background(), db.Repo{Owner: repo.Owner, Name: repo.Name, CheckoutPath: checkout, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+}
+
+func seedDaemonWorkerAgent(t *testing.T, store *db.Store, name string, runtimeName string, runtimeRef string, capabilities []string, repo string) {
+	t.Helper()
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:           name,
+		Role:           "worker",
+		Runtime:        runtimeName,
+		RuntimeRef:     runtimeRef,
+		RepoScope:      repo,
+		Capabilities:   capabilities,
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+}
+
+func enqueueDaemonWorkerJob(t *testing.T, store *db.Store, request workflow.JobRequest) {
+	t.Helper()
+	if _, err := (workflow.Mailbox{Store: store}).Enqueue(context.Background(), request); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+}
+
+func daemonWorkerHasEvent(events []db.JobEvent, kind string) bool {
+	for _, event := range events {
+		if event.Kind == kind {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -118,6 +118,8 @@ func Open(path string) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 
 	store := &Store{db: db}
 	if err := store.Migrate(context.Background()); err != nil {
@@ -750,6 +752,44 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 	return jobs, rows.Err()
 }
 
+func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload
+		FROM jobs WHERE state = ? ORDER BY created_at, rowid`, "queued")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobs []Job
+	for rows.Next() {
+		var job Job
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload); err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
+func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Time) ([]Job, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload
+		FROM jobs WHERE state = ? AND updated_at < ? ORDER BY id`, "running", before.UTC().Format("2006-01-02 15:04:05"))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobs []Job
+	for rows.Next() {
+		var job Job
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload); err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
 func (s *Store) UpdateJobState(ctx context.Context, id string, state string) error {
 	result, err := s.db.ExecContext(ctx, `UPDATE jobs SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, state, id)
 	if err != nil {
@@ -797,7 +837,7 @@ func (s *Store) TransitionJobStateWithEvent(ctx context.Context, id string, from
 	return true, tx.Commit()
 }
 
-func (s *Store) TransitionJobStatePayloadWithEvent(ctx context.Context, id string, from string, to string, payload string, event JobEvent) (bool, error) {
+func (s *Store) TransitionJobStatePayloadWithEvent(ctx context.Context, id string, from string, to string, payload string, event JobEvent, extraEvents ...JobEvent) (bool, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return false, err
@@ -820,6 +860,14 @@ func (s *Store) TransitionJobStatePayloadWithEvent(ctx context.Context, id strin
 	}
 	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
 		return false, err
+	}
+	for _, extra := range extraEvents {
+		if extra.JobID == "" {
+			extra.JobID = id
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, extra.JobID, extra.Kind, extra.Message); err != nil {
+			return false, err
+		}
 	}
 	return true, tx.Commit()
 }

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -81,6 +81,18 @@ func (c Client) WorktreeClean(ctx context.Context) (bool, error) {
 	return strings.TrimSpace(result.Stdout) == "", nil
 }
 
+func (c Client) HeadSHA(ctx context.Context) (string, error) {
+	result, err := c.run(ctx, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	sha := strings.TrimSpace(result.Stdout)
+	if sha == "" {
+		return "", errors.New("git HEAD SHA is empty")
+	}
+	return sha, nil
+}
+
 func (c Client) UpdateBase(ctx context.Context, remote string, branch string) error {
 	if strings.TrimSpace(remote) == "" {
 		remote = "origin"

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -76,6 +76,18 @@ func TestClientRejectsUnsafeBranchNames(t *testing.T) {
 	}
 }
 
+func TestClientHeadSHA(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "abc123\n"}}}
+	sha, err := (Client{Runner: runner, Dir: "/repo"}).HeadSHA(context.Background())
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	if sha != "abc123" {
+		t.Fatalf("sha = %q, want abc123", sha)
+	}
+	runner.wantArgs(t, 0, "git", "rev-parse", "HEAD")
+}
+
 func TestClientCreateBranchSmoke(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not installed")

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -18,6 +18,7 @@ type Engine struct {
 	RequiredReviewers []string
 	MergeGate         MergeGate
 	JobID             func(JobRequest) string
+	PayloadRefresher  func(context.Context, db.Job, JobPayload) (JobPayload, error)
 }
 
 type PullRequestEvent struct {
@@ -190,10 +191,34 @@ func (e Engine) RunJob(ctx context.Context, jobID string, agent runtime.Agent, a
 	if err != nil {
 		return result, err
 	}
+	if e.PayloadRefresher != nil {
+		if err := e.refreshJobPayload(ctx, jobID); err != nil {
+			return result, err
+		}
+	}
 	if err := e.AdvanceJob(ctx, jobID); err != nil {
 		return result, err
 	}
+	if err := e.Store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: "advance_completed", Message: "workflow advancement completed"}); err != nil {
+		return result, err
+	}
 	return result, nil
+}
+
+func (e Engine) refreshJobPayload(ctx context.Context, jobID string) error {
+	job, payload, err := e.jobPayload(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	payload, err = e.PayloadRefresher(ctx, job, payload)
+	if err != nil {
+		return err
+	}
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		return err
+	}
+	return e.Store.UpdateJobPayload(ctx, jobID, encoded)
 }
 
 func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
@@ -220,6 +245,15 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 	}
 	if payload.Result.Decision == "blocked" || payload.Result.Decision == "failed" {
 		return e.block(ctx, ref, payload.Result.Summary)
+	}
+	if job.Type == "review" && payload.Result.Decision == "approved" {
+		done, err := e.reviewApprovalAlreadyAdvanced(ctx, ref)
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
 	}
 	if err := e.dispatchNextAgents(ctx, payload, *payload.Result, ref); err != nil {
 		return err
@@ -529,7 +563,63 @@ func (e Engine) enqueue(ctx context.Context, request JobRequest) error {
 		request.ID = e.jobID(request)
 	}
 	_, err := (Mailbox{Store: e.Store}).Enqueue(ctx, request)
+	if err == nil {
+		return nil
+	}
+	matches, matchErr := e.existingJobMatchesRequest(ctx, request)
+	if matchErr != nil {
+		return err
+	}
+	if matches {
+		return nil
+	}
 	return err
+}
+
+func (e Engine) existingJobMatchesRequest(ctx context.Context, request JobRequest) (bool, error) {
+	job, err := e.Store.GetJob(ctx, request.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	if job.Agent != request.Agent || job.Type != request.Action {
+		return false, nil
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		return false, err
+	}
+	return payloadMatchesRequest(payload, request), nil
+}
+
+func payloadMatchesRequest(payload JobPayload, request JobRequest) bool {
+	return payload.Repo == request.Repo &&
+		payload.Branch == request.Branch &&
+		payload.PullRequest == request.PullRequest &&
+		payload.HeadSHA == request.HeadSHA &&
+		payload.GoalID == request.GoalID &&
+		payload.TaskID == request.TaskID &&
+		payload.TaskTitle == request.TaskTitle &&
+		payload.LeadAgent == request.LeadAgent &&
+		payload.ReviewRound == request.ReviewRound &&
+		payload.Sender == request.Sender &&
+		payload.Instructions == request.Instructions &&
+		equalStrings(payload.Reviewers, compactStrings(request.Reviewers)) &&
+		equalStrings(payload.Constraints, compactStrings(request.Constraints))
+}
+
+func equalStrings(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (e Engine) ensureAgentAllowed(ctx context.Context, request JobRequest, ref taskRef) error {
@@ -648,6 +738,7 @@ func (e Engine) nextReviewRound(ctx context.Context, event PullRequestEvent) (st
 	}
 	current := JobPayload{Repo: event.Repo, PullRequest: event.PullRequest, TaskID: event.TaskID}
 	rounds := map[string]bool{}
+	existingHeadRound := ""
 	for _, job := range jobs {
 		if job.Type != "review" {
 			continue
@@ -663,9 +754,29 @@ func (e Engine) nextReviewRound(ctx context.Context, event PullRequestEvent) (st
 		if round == "" {
 			round = job.ID
 		}
+		if payload.HeadSHA != "" && payload.HeadSHA == event.HeadSHA {
+			existingHeadRound = round
+		}
 		rounds[round] = true
 	}
+	if existingHeadRound != "" {
+		return existingHeadRound, nil
+	}
 	return "review-" + strconv.Itoa(len(rounds)+1), nil
+}
+
+func (e Engine) reviewApprovalAlreadyAdvanced(ctx context.Context, ref taskRef) (bool, error) {
+	if strings.TrimSpace(ref.ID) == "" {
+		return false, nil
+	}
+	task, err := e.Store.GetTask(ctx, ref.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return task.State == string(TaskReadyToMerge) || task.State == string(TaskMerged), nil
 }
 
 func (e Engine) block(ctx context.Context, ref taskRef, reason string) error {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -344,6 +344,48 @@ func TestEngineAdvanceReviewChangesRequestedDispatchesFix(t *testing.T) {
 	}
 }
 
+func TestEngineAdvanceReviewChangesRequestedReplayIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "changes_requested", Summary: "fix edge case"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("first AdvanceJob returned error: %v", err)
+	}
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("second AdvanceJob returned error: %v", err)
+	}
+
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	implementJobs := 0
+	for _, job := range jobs {
+		if job.ID == "implement-lead-task-7" {
+			implementJobs++
+		}
+	}
+	if implementJobs != 1 {
+		t.Fatalf("implement job count = %d, want 1", implementJobs)
+	}
+	assertTaskState(t, store, "task-7", TaskChangesRequested)
+}
+
 func TestEngineAdvanceReviewChangesRequestedUsesBranchLockLead(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -219,6 +219,10 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 		JobID:   jobID,
 		Kind:    string(state),
 		Message: message,
+	}, db.JobEvent{
+		JobID:   jobID,
+		Kind:    "advance_started",
+		Message: "workflow advancement started",
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
WHAT:
- Added daemon worker execution for queued Gitmoot jobs, including runtime adapter delivery, checkout validation, retry handling, and workflow advancement.

WHY:
- PR comments could queue jobs, but the daemon did not yet consume those jobs and resume subscribed agents automatically.

CHANGES:
- Added queued/running job listing and stale running-job recovery.
- Added worker ticks for single-repo and registered multi-repo daemon modes, skipping disabled repos.
- Added runtime adapter dispatch for Codex, Claude, and shell agents.
- Added checkout preflight validation for repo, branch, clean worktree, head SHA, and implement branch locks.
- Added post-delivery advancement retry handling without redelivering jobs.
- Added payload head refresh for implemented jobs and required reviewer population from subscribed review agents.
- Made workflow replay paths idempotent for deterministic job IDs, repeated implemented results, and review approval advancement.
- Added focused tests for worker execution, repo filtering, stale recovery, retry behavior, checkout safety, and workflow idempotency.

RESULTS:
- gofmt
- git diff --check
- GOTOOLCHAIN=go1.26.0 go test ./internal/cli ./internal/db ./internal/git ./internal/workflow
- GOTOOLCHAIN=go1.26.0 go test ./...
- GOTOOLCHAIN=go1.26.0 go vet ./...
- codex exec review --uncommitted:

```
No discrete correctness issues were found in the reviewed staged, unstaged, and untracked changes. I could not run the full test suite because the Go 1.26 toolchain download is blocked by the environment, so this verdict is based on static review.
```

RISK:
- Codex review could not run tests inside its own sandbox, but the local full Go test suite and vet passed with GOTOOLCHAIN=go1.26.0.
