### PR TITLE
feat: add attributed job result comments

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -784,6 +784,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 		}
 		poller := defaultRegisteredRepoPoller(store, workers, dryRun, stdout)
 		worker := defaultJobWorker(store, stdout)
+		worker.CommenterFactory = worker.defaultCommenter
 		for {
 			wait, err := pollRegisteredReposWithPoller(ctx, poller, schedule, time.Now().UTC(), poll)
 			if err != nil {
@@ -814,6 +815,7 @@ func runSingleRepoSupervisor(ctx context.Context, d daemon.Daemon, store *db.Sto
 		interval = 30 * time.Second
 	}
 	worker := defaultJobWorker(store, stdout)
+	worker.CommenterFactory = worker.defaultCommenter
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -998,6 +1000,7 @@ type jobWorker struct {
 	AdapterFactory    func(runtime.Agent, string) (workflow.DeliveryAdapter, error)
 	CheckoutValidator func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error)
 	WorkflowFactory   func(string) workflow.Engine
+	CommenterFactory  func(string) github.Client
 }
 
 const daemonRunningJobStaleAfter = 30 * time.Minute
@@ -1083,6 +1086,9 @@ func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker,
 	if err := retryPendingJobAdvancements(ctx, worker, repoFilter); err != nil {
 		return err
 	}
+	if err := retryPendingJobComments(ctx, worker, repoFilter); err != nil {
+		return err
+	}
 	return runQueuedJobsForRepo(ctx, worker, workers, repoFilter)
 }
 
@@ -1103,6 +1109,42 @@ func runEnabledRepoWorkerTicks(ctx context.Context, store *db.Store, worker jobW
 }
 
 func jobStateCanRetryAdvancement(state string) bool {
+	switch state {
+	case string(workflow.JobSucceeded), string(workflow.JobFailed), string(workflow.JobBlocked):
+		return true
+	default:
+		return false
+	}
+}
+
+func retryPendingJobComments(ctx context.Context, worker jobWorker, repoFilter string) error {
+	jobs, err := worker.Store.ListJobs(ctx)
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		if !jobStateCanRetryComment(job.State) || !queuedJobMatchesRepo(job, repoFilter) {
+			continue
+		}
+		needsRetry, err := worker.jobNeedsCommentRetry(ctx, job.ID)
+		if err != nil {
+			return err
+		}
+		if !needsRetry {
+			continue
+		}
+		agent := runtime.Agent{Name: job.Agent}
+		if dbAgent, err := worker.Store.GetAgent(ctx, job.Agent); err == nil {
+			agent = runtimeAgent(dbAgent)
+		}
+		if err := worker.postJobResultComment(ctx, job.ID, agent, "", nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func jobStateCanRetryComment(state string) bool {
 	switch state {
 	case string(workflow.JobSucceeded), string(workflow.JobFailed), string(workflow.JobBlocked):
 		return true
@@ -1188,16 +1230,28 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	}
 	dbAgent, err := w.Store.GetAgent(ctx, job.Agent)
 	if err != nil {
-		return w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err)
+		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, runtime.Agent{Name: job.Agent}, "", err)
+		return nil
 	}
 	agent := runtimeAgent(dbAgent)
 	checkout, err := w.CheckoutValidator(ctx, job, payload, agent)
 	if err != nil {
-		return w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err)
+		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, "", err)
+		return nil
 	}
 	adapter, err := w.AdapterFactory(agent, checkout)
 	if err != nil {
-		return w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err)
+		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
+		return nil
 	}
 	writeLine(w.Stdout, "running job %s for %s in %s", job.ID, agent.Name, payload.Repo)
 	engine := w.WorkflowFactory(checkout)
@@ -1206,9 +1260,11 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		if markErr := w.handleRunJobError(ctx, job.ID, err); markErr != nil {
 			return markErr
 		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 		writeLine(w.Stdout, "job %s failed: %v", job.ID, err)
 		return nil
 	}
+	_ = w.postJobResultComment(ctx, job.ID, agent, checkout, nil)
 	writeLine(w.Stdout, "job %s completed", job.ID)
 	return nil
 }
@@ -1309,6 +1365,10 @@ func (w jobWorker) defaultAdapter(agent runtime.Agent, checkout string) (workflo
 
 func (w jobWorker) defaultWorkflow(checkout string) workflow.Engine {
 	return daemonWorkflowEngine(w.Store, github.NewClient(checkout), checkout)
+}
+
+func (w jobWorker) defaultCommenter(_ string) github.Client {
+	return github.NewClient("")
 }
 
 func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string) workflow.Engine {
@@ -1505,6 +1565,117 @@ func (w jobWorker) recordPostDeliveryWorkflowError(ctx context.Context, job db.J
 		Kind:    "advance_retry",
 		Message: "post-delivery workflow error; advancement will retry from stored result: " + cause.Error(),
 	})
+}
+
+func (w jobWorker) postJobResultComment(ctx context.Context, jobID string, agent runtime.Agent, _ string, cause error) error {
+	job, payload, err := daemonWorkerJobPayload(ctx, w.Store, jobID)
+	if err != nil {
+		return err
+	}
+	if job.State == string(workflow.JobCancelled) {
+		return nil
+	}
+	if payload.PullRequest <= 0 || strings.TrimSpace(payload.Repo) == "" {
+		return nil
+	}
+	if w.CommenterFactory == nil {
+		return nil
+	}
+	posted, err := w.jobResultCommentPosted(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if posted {
+		return nil
+	}
+	repo, err := daemon.ParseRepository(payload.Repo)
+	if err != nil {
+		return err
+	}
+	diagnostic := jobResultDiagnostic(cause)
+	if diagnostic == "" && payload.Result == nil {
+		diagnostic = w.storedJobFailureDiagnostic(ctx, job)
+	}
+	body := workflow.RenderJobResultComment(workflow.JobResultComment{
+		AgentName:  firstNonEmpty(agent.Name, job.Agent),
+		Runtime:    agent.Runtime,
+		JobID:      job.ID,
+		JobState:   job.State,
+		Payload:    payload,
+		Result:     payload.Result,
+		Diagnostic: diagnostic,
+	})
+	if _, err := w.CommenterFactory("").PostIssueComment(ctx, repo, int64(payload.PullRequest), body); err != nil {
+		_ = w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "comment_post_failed", Message: err.Error()})
+		return nil
+	}
+	return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "comment_posted", Message: "posted attributed PR result comment"})
+}
+
+func (w jobWorker) jobResultCommentPosted(ctx context.Context, jobID string) (bool, error) {
+	events, err := w.Store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+	for _, event := range events {
+		if event.Kind == "comment_posted" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (w jobWorker) jobNeedsCommentRetry(ctx context.Context, jobID string) (bool, error) {
+	events, err := w.Store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+	needsRetry := false
+	for _, event := range events {
+		switch event.Kind {
+		case "comment_post_failed":
+			needsRetry = true
+		case "comment_posted":
+			needsRetry = false
+		}
+	}
+	return needsRetry, nil
+}
+
+func (w jobWorker) storedJobFailureDiagnostic(ctx context.Context, job db.Job) string {
+	if job.State != string(workflow.JobFailed) && job.State != string(workflow.JobBlocked) {
+		return ""
+	}
+	events, err := w.Store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		return ""
+	}
+	for i := len(events) - 1; i >= 0; i-- {
+		event := events[i]
+		if event.Kind == job.State && strings.TrimSpace(event.Message) != "" {
+			return event.Message
+		}
+	}
+	return ""
+}
+
+func daemonWorkerJobPayload(ctx context.Context, store *db.Store, jobID string) (db.Job, workflow.JobPayload, error) {
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		return db.Job{}, workflow.JobPayload{}, err
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return db.Job{}, workflow.JobPayload{}, err
+	}
+	return job, payload, nil
+}
+
+func jobResultDiagnostic(cause error) string {
+	if cause == nil {
+		return ""
+	}
+	return cause.Error()
 }
 
 func daemonJobPayload(job db.Job) (workflow.JobPayload, error) {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -611,6 +611,225 @@ func TestRunQueuedJobsUsesMailboxRepairForMalformedOutput(t *testing.T) {
 	}
 }
 
+func TestRunQueuedJobsPostsAttributedResultComment(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-comment", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 7})
+	comments := &cliPollFakeGitHub{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return &cliWorkerFakeAdapter{
+			output: `{"gitmoot_result":{"decision":"approved","summary":"done with token=ghp_abcdefghijklmnopqrstuvwxyz123456","findings":[{"severity":"low","body":"ok"}],"changes_made":["commented"],"tests_run":["go test ./..."],"needs":["none"],"next_agents":["lead"]}}`,
+		}, nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if len(comments.posted) != 1 {
+		t.Fatalf("posted comments = %+v, want 1", comments.posted)
+	}
+	body := comments.posted[0].body
+	for _, want := range []string{
+		"> Agent: `audit`",
+		"> Runtime: `shell`",
+		"> Job: `job-comment`",
+		"**Decision:** `approved`",
+		"**Summary:** done with token=[REDACTED]",
+		"**Findings**",
+		"**Changes Made**",
+		"**Tests Run**",
+		"**Needs**",
+		"**Next Agents**",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("comment body missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "ghp_abcdefghijklmnopqrstuvwxyz123456") {
+		t.Fatalf("comment leaked token:\n%s", body)
+	}
+	events, err := store.ListJobEvents(ctx, "job-comment")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "comment_posted") {
+		t.Fatalf("events = %+v, want comment_posted", events)
+	}
+}
+
+func TestRunQueuedJobsPostsMalformedOutputDiagnosticComment(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-malformed", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 7})
+	comments := &cliPollFakeGitHub{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return &cliWorkerFakeAdapter{output: "not valid json with token=ghp_abcdefghijklmnopqrstuvwxyz123456"}, nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if len(comments.posted) != 1 {
+		t.Fatalf("posted comments = %+v, want 1", comments.posted)
+	}
+	body := comments.posted[0].body
+	if !strings.Contains(body, "> Agent: `audit`") || !strings.Contains(body, "**Decision:** `failed`") || !strings.Contains(body, "**Diagnostics:**") {
+		t.Fatalf("comment body missing failure diagnostics:\n%s", body)
+	}
+	if strings.Contains(body, "not valid json") || strings.Contains(body, "ghp_abcdefghijklmnopqrstuvwxyz123456") {
+		t.Fatalf("comment leaked raw output:\n%s", body)
+	}
+	if !strings.Contains(body, "Raw runtime output was retained in local Gitmoot state") {
+		t.Fatalf("comment did not mention local raw output retention:\n%s", body)
+	}
+}
+
+func TestRunQueuedJobsPostsCheckoutDiagnosticWithoutCheckoutCwd(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", "/missing/gitmoot-checkout")
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-checkout-comment", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 7})
+	comments := &cliPollFakeGitHub{}
+	commenterDir := "unset"
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return "", errors.New("checkout path is missing")
+	}
+	worker.CommenterFactory = func(dir string) github.Client {
+		commenterDir = dir
+		return comments
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if commenterDir != "" {
+		t.Fatalf("commenter dir = %q, want empty cwd for PR comment posting", commenterDir)
+	}
+	if len(comments.posted) != 1 {
+		t.Fatalf("posted comments = %+v, want checkout diagnostic comment", comments.posted)
+	}
+	body := comments.posted[0].body
+	if !strings.Contains(body, "**Diagnostics:** checkout path is missing") {
+		t.Fatalf("comment body lost checkout diagnostic:\n%s", body)
+	}
+}
+
+func TestDaemonWorkerTickRetriesFailedResultCommentPost(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-comment-retry", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 7})
+	comments := &cliPollFakeGitHub{postErr: errors.New("temporary github error")}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return &cliWorkerFakeAdapter{
+			output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		}, nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	if len(comments.posted) != 0 {
+		t.Fatalf("posted comments = %+v, want failed post only", comments.posted)
+	}
+	events, err := store.ListJobEvents(ctx, "job-comment-retry")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "comment_post_failed") {
+		t.Fatalf("events = %+v, want comment_post_failed", events)
+	}
+
+	comments.postErr = nil
+	if err := retryPendingJobComments(ctx, worker, "owner/repo"); err != nil {
+		t.Fatalf("retryPendingJobComments returned error: %v", err)
+	}
+	if len(comments.posted) != 1 {
+		t.Fatalf("posted comments = %+v, want retry post", comments.posted)
+	}
+	events, err = store.ListJobEvents(ctx, "job-comment-retry")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "comment_posted") {
+		t.Fatalf("events = %+v, want comment_posted", events)
+	}
+}
+
+func TestRetryPendingJobCommentsPreservesStoredFailureDiagnostic(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	payload := workflow.JobPayload{Repo: "owner/repo", Branch: "main", PullRequest: 7}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-comment-diagnostic-retry", Agent: "audit", Type: "ask", State: string(workflow.JobFailed), Payload: string(encoded)}, db.JobEvent{
+		JobID:   "job-comment-diagnostic-retry",
+		Kind:    string(workflow.JobFailed),
+		Message: "checkout validation failed",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-comment-diagnostic-retry", Kind: "comment_post_failed", Message: "temporary github error"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+	comments := &cliPollFakeGitHub{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
+	}
+
+	if err := retryPendingJobComments(ctx, worker, "owner/repo"); err != nil {
+		t.Fatalf("retryPendingJobComments returned error: %v", err)
+	}
+
+	if len(comments.posted) != 1 {
+		t.Fatalf("posted comments = %+v, want retry post", comments.posted)
+	}
+	body := comments.posted[0].body
+	if !strings.Contains(body, "**Diagnostics:** checkout validation failed") {
+		t.Fatalf("comment body lost stored failure diagnostic:\n%s", body)
+	}
+}
+
 func TestRunQueuedJobsDrainsBeyondWorkerLimit(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -869,12 +1088,16 @@ func TestRunQueuedJobsPreservesCancellationRace(t *testing.T) {
 			}
 		},
 	}
+	comments := &cliPollFakeGitHub{}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		return t.TempDir(), nil
 	}
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
 		return adapter, nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
 	}
 
 	if err := runQueuedJobs(ctx, worker, 1); err != nil {
@@ -887,6 +1110,9 @@ func TestRunQueuedJobsPreservesCancellationRace(t *testing.T) {
 	}
 	if job.State != string(workflow.JobCancelled) {
 		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+	if len(comments.posted) != 0 {
+		t.Fatalf("posted comments = %+v, want no comment for cancelled job", comments.posted)
 	}
 }
 
@@ -1701,6 +1927,7 @@ type cliPollFakeGitHub struct {
 	pulls                 []github.PullRequest
 	comments              map[int64][]github.IssueComment
 	listErr               error
+	postErr               error
 	listPullRequestsCalls int
 	posted                []cliPollPostedComment
 }
@@ -1723,6 +1950,9 @@ func (f *cliPollFakeGitHub) ListIssueComments(_ context.Context, _ github.Reposi
 }
 
 func (f *cliPollFakeGitHub) PostIssueComment(_ context.Context, _ github.Repository, issueNumber int64, body string) (github.IssueComment, error) {
+	if f.postErr != nil {
+		return github.IssueComment{}, f.postErr
+	}
 	f.posted = append(f.posted, cliPollPostedComment{issueNumber: issueNumber, body: body})
 	return github.IssueComment{ID: int64(len(f.posted)), Body: body}, nil
 }

--- a/internal/workflow/job_comment.go
+++ b/internal/workflow/job_comment.go
@@ -1,0 +1,193 @@
+package workflow
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+const maxCommentFieldRunes = 2000
+const maxCommentBodyRunes = 60000
+
+type JobResultComment struct {
+	AgentName  string
+	Runtime    string
+	JobID      string
+	JobState   string
+	Payload    JobPayload
+	Result     *AgentResult
+	Diagnostic string
+}
+
+func RenderJobResultComment(comment JobResultComment) string {
+	var builder strings.Builder
+	builder.WriteString("> Agent: `")
+	builder.WriteString(markdownInline(comment.AgentName))
+	builder.WriteString("`\n")
+	builder.WriteString("> Runtime: `")
+	builder.WriteString(markdownInline(comment.Runtime))
+	builder.WriteString("`\n")
+	builder.WriteString("> Job: `")
+	builder.WriteString(markdownInline(comment.JobID))
+	builder.WriteString("`\n\n")
+
+	decision := strings.TrimSpace(comment.JobState)
+	summary := strings.TrimSpace(comment.Diagnostic)
+	if comment.Result != nil {
+		decision = strings.TrimSpace(comment.Result.Decision)
+		summary = strings.TrimSpace(comment.Result.Summary)
+	}
+	if decision == "" {
+		decision = "unknown"
+	}
+	if summary == "" {
+		summary = "No summary provided."
+	}
+	writeScalar(&builder, "Decision", "`"+markdownInline(decision)+"`")
+	writeScalar(&builder, "Summary", limitCommentText(summary))
+
+	if comment.Result != nil {
+		writeFindings(&builder, comment.Result.Findings)
+		writeList(&builder, "Changes Made", comment.Result.ChangesMade)
+		writeList(&builder, "Tests Run", comment.Result.TestsRun)
+		writeList(&builder, "Needs", comment.Result.Needs)
+		writeList(&builder, "Next Agents", comment.Result.NextAgents)
+	}
+	if strings.TrimSpace(comment.Diagnostic) != "" && (comment.Result == nil || strings.TrimSpace(comment.Diagnostic) != strings.TrimSpace(comment.Result.Summary)) {
+		writeScalar(&builder, "Diagnostics", limitCommentText(comment.Diagnostic))
+	}
+	if len(comment.Payload.RawOutputs) > 0 {
+		builder.WriteString("\nRaw runtime output was retained in local Gitmoot state and is not posted here.\n")
+	}
+	return limitCommentBody(builder.String())
+}
+
+func writeScalar(builder *strings.Builder, label string, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	builder.WriteString("**")
+	builder.WriteString(label)
+	builder.WriteString(":** ")
+	builder.WriteString(value)
+	builder.WriteString("\n")
+}
+
+func writeFindings(builder *strings.Builder, findings []json.RawMessage) {
+	if len(findings) == 0 {
+		return
+	}
+	builder.WriteString("\n**Findings**\n")
+	for _, finding := range findings {
+		text := formatFinding(finding)
+		if text == "" {
+			continue
+		}
+		builder.WriteString("- ")
+		builder.WriteString(limitCommentText(text))
+		builder.WriteByte('\n')
+	}
+}
+
+func writeList(builder *strings.Builder, title string, values []string) {
+	items := compactStrings(values)
+	if len(items) == 0 {
+		return
+	}
+	builder.WriteString("\n**")
+	builder.WriteString(title)
+	builder.WriteString("**\n")
+	for _, item := range items {
+		builder.WriteString("- ")
+		builder.WriteString(limitCommentText(item))
+		builder.WriteByte('\n')
+	}
+}
+
+func formatFinding(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err == nil {
+		return compact.String()
+	}
+	return string(raw)
+}
+
+func limitCommentText(value string) string {
+	value = RedactCommentText(value)
+	value = strings.TrimSpace(value)
+	runes := []rune(value)
+	if len(runes) <= maxCommentFieldRunes {
+		return neutralizeGitmootCommandLines(value)
+	}
+	return neutralizeGitmootCommandLines(completeTrailingRedactionMarker(string(runes[:maxCommentFieldRunes]))) + "\n[truncated]"
+}
+
+func limitCommentBody(value string) string {
+	value = neutralizeGitmootCommandLines(RedactCommentText(strings.TrimSpace(value)))
+	runes := []rune(value)
+	if len(runes) <= maxCommentBodyRunes {
+		return value + "\n"
+	}
+	const suffix = "\n\n[comment truncated; full result is retained in local Gitmoot state]\n"
+	limit := maxCommentBodyRunes - len([]rune(suffix))
+	if limit < 0 {
+		limit = 0
+	}
+	return neutralizeGitmootCommandLines(completeTrailingRedactionMarker(string(runes[:limit]))) + suffix
+}
+
+func markdownInline(value string) string {
+	return strings.ReplaceAll(strings.TrimSpace(value), "`", "'")
+}
+
+func completeTrailingRedactionMarker(value string) string {
+	const marker = "[REDACTED]"
+	for i := 1; i < len(marker); i++ {
+		if strings.HasSuffix(value, marker[:i]) {
+			return strings.TrimSuffix(value, marker[:i]) + marker
+		}
+	}
+	return value
+}
+
+func neutralizeGitmootCommandLines(value string) string {
+	lines := strings.Split(value, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "/gitmoot") {
+			lines[i] = strings.TrimSuffix(line, trimmed) + `\/gitmoot` + strings.TrimPrefix(trimmed, "/gitmoot")
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+var commentRedactors = []struct {
+	pattern *regexp.Regexp
+	replace string
+}{
+	{regexp.MustCompile(`(?i)github_pat_[A-Za-z0-9_]{20,}`), "[REDACTED]"},
+	{regexp.MustCompile(`(?i)gh[opsur]_[A-Za-z0-9_]{20,}`), "[REDACTED]"},
+	{regexp.MustCompile(`(?i)sk-[A-Za-z0-9_-]{20,}`), "[REDACTED]"},
+	{regexp.MustCompile(`(?i)(aws_access_key_id\s*[:=]\s*)[A-Z0-9]{16,}`), "${1}[REDACTED]"},
+	{regexp.MustCompile(`(?i)("(?:aws_)?secret_access_key"\s*:\s*)(?:"[^"]*"|'[^']*'|[^\s,;}]+)`), `${1}"[REDACTED]"`},
+	{regexp.MustCompile(`(?i)((?:aws_)?secret_access_key\s*[:=]\s*)(?:"[^"]+"|'[^']+'|[^\s,;]+)`), "${1}[REDACTED]"},
+	{regexp.MustCompile(`(?i)("(?:api[_-]?key|token|secret|password)"\s*:\s*)(?:"[^"]*"|'[^']*'|[^\s,;}]+)`), `${1}"[REDACTED]"`},
+	{regexp.MustCompile(`(?i)((?:api[_-]?key|token|secret|password)\s*[:=]\s*)(?:"[^"]+"|'[^']+'|[^\s,;]+)`), "${1}[REDACTED]"},
+}
+
+func RedactCommentText(value string) string {
+	for _, redactor := range commentRedactors {
+		value = redactor.pattern.ReplaceAllString(value, redactor.replace)
+	}
+	return value
+}

--- a/internal/workflow/job_comment_test.go
+++ b/internal/workflow/job_comment_test.go
@@ -1,0 +1,159 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRenderJobResultCommentIncludesAttributionAndResult(t *testing.T) {
+	body := RenderJobResultComment(JobResultComment{
+		AgentName: "audit",
+		Runtime:   "codex",
+		JobID:     "job-123",
+		JobState:  string(JobSucceeded),
+		Result: &AgentResult{
+			Decision:    "changes_requested",
+			Summary:     "fix the edge case",
+			Findings:    []json.RawMessage{json.RawMessage(`{"severity":"high","body":"bad branch"}`)},
+			ChangesMade: []string{"reviewed workflow"},
+			TestsRun:    []string{"go test ./..."},
+			Needs:       []string{"rerun review"},
+			NextAgents:  []string{"lead"},
+		},
+	})
+
+	for _, want := range []string{
+		"> Agent: `audit`",
+		"> Runtime: `codex`",
+		"> Job: `job-123`",
+		"**Decision:** `changes_requested`",
+		"**Summary:** fix the edge case",
+		"**Findings**",
+		`{"severity":"high","body":"bad branch"}`,
+		"**Changes Made**",
+		"**Tests Run**",
+		"**Needs**",
+		"**Next Agents**",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("comment body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestRenderJobResultCommentRedactsSecretsAndOmitsRawOutput(t *testing.T) {
+	body := RenderJobResultComment(JobResultComment{
+		AgentName:  "audit",
+		Runtime:    "shell",
+		JobID:      "job-secret",
+		JobState:   string(JobFailed),
+		Diagnostic: "delivery failed with token=ghp_abcdefghijklmnopqrstuvwxyz123456 password=secret-value AWS_SECRET_ACCESS_KEY=env-aws-secret",
+		Result: &AgentResult{
+			Decision: "failed",
+			Summary:  "failed",
+			Findings: []json.RawMessage{json.RawMessage(`{"token":"plain-secret-value","password":"another-secret-value","aws_secret_access_key":"json-aws-secret"}`)},
+		},
+		Payload: JobPayload{
+			RawOutputs: []string{"raw token ghp_abcdefghijklmnopqrstuvwxyz123456"},
+		},
+	})
+
+	if strings.Contains(body, "ghp_abcdefghijklmnopqrstuvwxyz123456") ||
+		strings.Contains(body, "secret-value") ||
+		strings.Contains(body, "plain-secret-value") ||
+		strings.Contains(body, "another-secret-value") ||
+		strings.Contains(body, "json-aws-secret") ||
+		strings.Contains(body, "env-aws-secret") {
+		t.Fatalf("comment leaked secret:\n%s", body)
+	}
+	if !strings.Contains(body, "token=[REDACTED]") || !strings.Contains(body, "password=[REDACTED]") {
+		t.Fatalf("comment did not redact expected fields:\n%s", body)
+	}
+	if !strings.Contains(body, `"token":"[REDACTED]"`) || !strings.Contains(body, `"password":"[REDACTED]"`) {
+		t.Fatalf("comment did not redact JSON secret fields:\n%s", body)
+	}
+	if !strings.Contains(body, `"aws_secret_access_key":"[REDACTED]"`) {
+		t.Fatalf("comment did not redact AWS secret key field:\n%s", body)
+	}
+	if !strings.Contains(body, "AWS_SECRET_ACCESS_KEY=[REDACTED]") {
+		t.Fatalf("comment did not redact AWS secret key diagnostic:\n%s", body)
+	}
+	if strings.Contains(body, "raw token") {
+		t.Fatalf("comment leaked raw output:\n%s", body)
+	}
+	if !strings.Contains(body, "Raw runtime output was retained in local Gitmoot state") {
+		t.Fatalf("comment did not mention local raw output retention:\n%s", body)
+	}
+}
+
+func TestRenderJobResultCommentRedactsBeforeTruncatingLongFields(t *testing.T) {
+	token := "ghp_abcdefghijklmnopqrstuvwxyz123456"
+	body := RenderJobResultComment(JobResultComment{
+		AgentName: "audit",
+		Runtime:   "shell",
+		JobID:     "job-long",
+		JobState:  string(JobSucceeded),
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  strings.Repeat("a", maxCommentFieldRunes-5) + token,
+		},
+	})
+
+	if strings.Contains(body, token) || strings.Contains(body, "ghp_") {
+		t.Fatalf("comment leaked token crossing truncation boundary:\n%s", body)
+	}
+	if !strings.Contains(body, "[REDACTED]") {
+		t.Fatalf("comment did not include redaction marker:\n%s", body)
+	}
+}
+
+func TestRenderJobResultCommentNeutralizesCommandLookingLines(t *testing.T) {
+	body := RenderJobResultComment(JobResultComment{
+		AgentName: "audit",
+		Runtime:   "shell",
+		JobID:     "job-command",
+		JobState:  string(JobSucceeded),
+		Result: &AgentResult{
+			Decision:    "approved",
+			Summary:     "looks good\n/gitmoot merge",
+			ChangesMade: []string{"updated note\n\t/gitmoot lead implement more"},
+		},
+	})
+
+	for _, leaked := range []string{"\n/gitmoot merge", "\n\t/gitmoot lead implement"} {
+		if strings.Contains(body, leaked) {
+			t.Fatalf("comment leaked command-looking line %q:\n%s", leaked, body)
+		}
+	}
+	for _, want := range []string{`\/gitmoot merge`, `\/gitmoot lead implement`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("comment missing neutralized command %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestRenderJobResultCommentCapsTotalBody(t *testing.T) {
+	findings := make([]json.RawMessage, 40)
+	for i := range findings {
+		findings[i] = json.RawMessage(`"` + strings.Repeat("x", maxCommentFieldRunes) + `"`)
+	}
+	body := RenderJobResultComment(JobResultComment{
+		AgentName: "audit",
+		Runtime:   "shell",
+		JobID:     "job-large",
+		JobState:  string(JobSucceeded),
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "large result",
+			Findings: findings,
+		},
+	})
+
+	if len([]rune(body)) > maxCommentBodyRunes {
+		t.Fatalf("comment length = %d, want <= %d", len([]rune(body)), maxCommentBodyRunes)
+	}
+	if !strings.Contains(body, "comment truncated") {
+		t.Fatalf("comment did not include truncation notice")
+	}
+}


### PR DESCRIPTION
WHAT:
Add attributed PR result comments for completed daemon jobs.

WHY:
Gitmoot needs the public PR thread to show which local agent handled a job, what the runtime decided, and what diagnostics are available without exposing raw runtime output or secrets.

CHANGES:
- Added a shared workflow job-result comment formatter with agent/runtime/job attribution.
- Included decision, summary, findings, changes made, tests run, needs, next agents, diagnostics, and raw-output retention notices.
- Added redaction for common GitHub/OpenAI/API/password/AWS secret patterns before posting comments.
- Neutralized `/gitmoot`-looking lines from agent output before publishing to PR comments.
- Added daemon comment posting after job success/failure plus retry of failed comment posts.
- Preserved failure diagnostics across comment-post retries and skipped comments for cancelled jobs.
- Posted PR comments through `gh api` without depending on a potentially broken repo checkout cwd.

RESULTS:
- `gofmt -w internal/cli/daemon.go internal/cli/daemon_test.go internal/workflow/job_comment.go internal/workflow/job_comment_test.go`
- `git diff --check`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli ./internal/workflow`
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `GOTOOLCHAIN=go1.26.0 go vet ./...`
- `codex exec review --uncommitted`

Final `codex exec review --uncommitted` output:
```text
I did not identify any discrete correctness issues in the staged, unstaged, or untracked changes. I was unable to run the full test suite because the required Go 1.26 toolchain download is blocked in this environment.
```

RISK:
- `codex exec review` could not run its own test pass due to Go 1.26 toolchain availability in its sandbox, but the full suite and vet passed locally with `GOTOOLCHAIN=go1.26.0`.
