### PR TITLE
feat: add job recovery commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ gitmoot agent remove <name>
 gitmoot status
 gitmoot goal import --file <path>
 gitmoot task run <id> --repo owner/repo --owner <agent>
+gitmoot job list|show|events|run|retry|cancel
 ```
 
 ## Documentation

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -20,6 +20,10 @@ gitmoot agent list
 gitmoot agent doctor <name>
 gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
+gitmoot job list
+gitmoot job show <job-id>
+gitmoot job retry <job-id>
+gitmoot job cancel <job-id>
 gitmoot status --repo owner/repo
 gitmoot daemon start --repo owner/repo --poll 30s
 ```
@@ -96,6 +100,8 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    ```text
    /gitmoot audit review focus on correctness and missed edge cases
    /gitmoot lead implement fix the review findings without broad refactors
+   /gitmoot retry <job-id>
+   /gitmoot cancel <job-id>
    ```
 
    Implement jobs require the agent to hold the branch lock. Review and ask jobs

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -785,21 +785,35 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 		poller := defaultRegisteredRepoPoller(store, workers, dryRun, stdout)
 		worker := defaultJobWorker(store, stdout)
 		worker.CommenterFactory = worker.defaultCommenter
+		checkoutLocks := &repoCheckoutLocks{}
+		poller.CheckoutLocks = checkoutLocks
+		var workerErr <-chan error
+		if !dryRun {
+			if err := recoverCancelledRunningJobsForEnabledRepos(ctx, store, stdout); err != nil {
+				return err
+			}
+			workerErr = startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
+				return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, stdout, now, checkoutLocks)
+			})
+		}
 		for {
+			if err := receiveSupervisorWorkerError(workerErr); err != nil {
+				return err
+			}
 			wait, err := pollRegisteredReposWithPoller(ctx, poller, schedule, time.Now().UTC(), poll)
 			if err != nil {
 				return err
-			}
-			if !dryRun {
-				if err := runEnabledRepoWorkerTicks(ctx, store, worker, workers, stdout, time.Now().UTC()); err != nil {
-					return err
-				}
 			}
 			timer := time.NewTimer(wait)
 			select {
 			case <-ctx.Done():
 				timer.Stop()
 				return ctx.Err()
+			case err := <-workerErr:
+				timer.Stop()
+				if err != nil {
+					return err
+				}
 			case <-timer.C:
 			}
 		}
@@ -810,28 +824,98 @@ func runSingleRepoSupervisor(ctx context.Context, d daemon.Daemon, store *db.Sto
 	if err := recoverRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName()); err != nil {
 		return err
 	}
+	if err := recoverCancelledRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName()); err != nil {
+		return err
+	}
 	interval := d.PollInterval
 	if interval <= 0 {
 		interval = 30 * time.Second
 	}
 	worker := defaultJobWorker(store, stdout)
 	worker.CommenterFactory = worker.defaultCommenter
+	var checkoutLock sync.Mutex
+	workerErr := startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
+		checkoutLock.Lock()
+		defer checkoutLock.Unlock()
+		return runDaemonWorkerTick(ctx, store, worker, workers, false, d.Repo.FullName(), stdout, now)
+	})
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		_ = d.PollOnce(ctx)
-		if err := runDaemonWorkerTick(ctx, store, worker, workers, false, d.Repo.FullName(), stdout, time.Now().UTC()); err != nil {
+		if err := receiveSupervisorWorkerError(workerErr); err != nil {
 			return err
+		}
+		if checkoutLock.TryLock() {
+			_ = d.PollOnce(ctx)
+			checkoutLock.Unlock()
+		} else {
+			_ = d.PollRecoveryCommandsOnce(ctx)
 		}
 		timer := time.NewTimer(interval)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
 			return ctx.Err()
+		case err := <-workerErr:
+			timer.Stop()
+			if err != nil {
+				return err
+			}
 		case <-timer.C:
 		}
 	}
+}
+
+func startSupervisorWorkerLoop(ctx context.Context, interval time.Duration, run func(time.Time) error) <-chan error {
+	errCh := make(chan error, 1)
+	if interval <= 0 {
+		interval = daemonWorkerLoopInterval
+	}
+	go func() {
+		defer close(errCh)
+		for {
+			if err := ctx.Err(); err != nil {
+				return
+			}
+			if err := run(time.Now().UTC()); err != nil {
+				errCh <- err
+				return
+			}
+			timer := time.NewTimer(interval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+	}()
+	return errCh
+}
+
+func receiveSupervisorWorkerError(errCh <-chan error) error {
+	if errCh == nil {
+		return nil
+	}
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return nil
+	}
+}
+
+type repoCheckoutLocks struct {
+	locks sync.Map
+}
+
+func (l *repoCheckoutLocks) For(repo string) *sync.Mutex {
+	if l == nil {
+		return nil
+	}
+	value, _ := l.locks.LoadOrStore(repo, &sync.Mutex{})
+	return value.(*sync.Mutex)
 }
 
 func pollRegisteredRepos(ctx context.Context, store *db.Store, workers int, dryRun bool, stdout io.Writer, nextPoll map[string]time.Time, now time.Time, fallbackPoll time.Duration) (time.Duration, error) {
@@ -858,6 +942,8 @@ type registeredRepoPoller struct {
 	Workers         int
 	DryRun          bool
 	Stdout          io.Writer
+	RecoveryOnly    bool
+	CheckoutLocks   *repoCheckoutLocks
 	GitHubClient    func(checkout string) github.Client
 	WorkflowFactory func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
 }
@@ -940,12 +1026,25 @@ func (p registeredRepoPoller) pollRepo(ctx context.Context, repoRecord db.Repo, 
 	}
 	gh := p.GitHubClient(repoRecord.CheckoutPath)
 	engine := p.WorkflowFactory(store, gh, repoRecord.CheckoutPath)
-	err = (daemon.Daemon{
+	recoveryOnly := p.RecoveryOnly
+	if lock := p.CheckoutLocks.For(repoRecord.FullName()); lock != nil {
+		if lock.TryLock() {
+			defer lock.Unlock()
+		} else {
+			recoveryOnly = true
+		}
+	}
+	d := daemon.Daemon{
 		Repo:     repo,
 		Store:    store,
 		GitHub:   gh,
 		Workflow: engine,
-	}).PollOnce(ctx)
+	}
+	if recoveryOnly {
+		err = d.PollRecoveryCommandsOnce(ctx)
+	} else {
+		err = d.PollOnce(ctx)
+	}
 	lastError := ""
 	if err != nil {
 		lastError = err.Error()
@@ -1004,6 +1103,8 @@ type jobWorker struct {
 }
 
 const daemonRunningJobStaleAfter = 30 * time.Minute
+const daemonJobCancelPollInterval = 250 * time.Millisecond
+const daemonWorkerLoopInterval = 1 * time.Second
 
 func defaultJobWorker(store *db.Store, stdout io.Writer) jobWorker {
 	worker := jobWorker{Store: store, Stdout: stdout}
@@ -1023,6 +1124,42 @@ func recoverRunningJobsBefore(ctx context.Context, store *db.Store, stdout io.Wr
 
 func recoverRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.Writer, repoFilter string) error {
 	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, time.Now().UTC().Add(-daemonRunningJobStaleAfter), repoFilter)
+}
+
+func recoverCancelledRunningJobsForEnabledRepos(ctx context.Context, store *db.Store, stdout io.Writer) error {
+	repos, err := store.ListRepos(ctx)
+	if err != nil {
+		return err
+	}
+	for _, repo := range repos {
+		if !repo.Enabled {
+			continue
+		}
+		if err := recoverCancelledRunningJobsForRepo(ctx, store, stdout, repo.FullName()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func recoverCancelledRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.Writer, repoFilter string) error {
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		if job.State != string(workflow.JobCancelled) || !queuedJobMatchesRepo(job, repoFilter) {
+			continue
+		}
+		settled, err := workflow.SettleCancelledRunningJob(ctx, store, job.ID, "cancelled job recovered after daemon restart")
+		if err != nil {
+			return err
+		}
+		if settled {
+			writeLine(stdout, "settled cancelled running job %s", job.ID)
+		}
+	}
+	return nil
 }
 
 func recoverRunningJobsBeforeForRepo(ctx context.Context, store *db.Store, stdout io.Writer, before time.Time, repoFilter string) error {
@@ -1093,6 +1230,10 @@ func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker,
 }
 
 func runEnabledRepoWorkerTicks(ctx context.Context, store *db.Store, worker jobWorker, workers int, stdout io.Writer, now time.Time) error {
+	return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, stdout, now, nil)
+}
+
+func runEnabledRepoWorkerTicksWithLocks(ctx context.Context, store *db.Store, worker jobWorker, workers int, stdout io.Writer, now time.Time, locks *repoCheckoutLocks) error {
 	repos, err := store.ListRepos(ctx)
 	if err != nil {
 		return err
@@ -1101,8 +1242,18 @@ func runEnabledRepoWorkerTicks(ctx context.Context, store *db.Store, worker jobW
 		if !repo.Enabled {
 			continue
 		}
+		lock := locks.For(repo.FullName())
+		if lock != nil {
+			lock.Lock()
+		}
 		if err := runDaemonWorkerTick(ctx, store, worker, workers, false, repo.FullName(), stdout, now); err != nil {
+			if lock != nil {
+				lock.Unlock()
+			}
 			return err
+		}
+		if lock != nil {
+			lock.Unlock()
 		}
 	}
 	return nil
@@ -1255,7 +1406,9 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	}
 	writeLine(w.Stdout, "running job %s for %s in %s", job.ID, agent.Name, payload.Repo)
 	engine := w.WorkflowFactory(checkout)
-	_, err = engine.RunJob(ctx, job.ID, agent, adapter)
+	runCtx, stopRun := w.runningJobContext(ctx, job.ID)
+	defer stopRun()
+	_, err = engine.RunJob(runCtx, job.ID, agent, adapter)
 	if err != nil {
 		if markErr := w.handleRunJobError(ctx, job.ID, err); markErr != nil {
 			return markErr
@@ -1269,6 +1422,32 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	return nil
 }
 
+func (w jobWorker) runningJobContext(ctx context.Context, jobID string) (context.Context, func()) {
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(daemonJobCancelPollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+			case <-ticker.C:
+				job, err := w.Store.GetJob(ctx, jobID)
+				if err == nil && job.State == string(workflow.JobCancelled) {
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+	return runCtx, func() {
+		cancel()
+		<-done
+	}
+}
+
 func (w jobWorker) jobNeedsAdvanceRetry(ctx context.Context, jobID string) (bool, error) {
 	events, err := w.Store.ListJobEvents(ctx, jobID)
 	if err != nil {
@@ -1280,6 +1459,8 @@ func (w jobWorker) jobNeedsAdvanceRetry(ctx context.Context, jobID string) (bool
 		case "advance_started", "advance_retry":
 			needsRetry = true
 		case "advance_completed", "advance_retried", "advance_blocked", "advance_retry_skipped":
+			needsRetry = false
+		case "retry_queued":
 			needsRetry = false
 		}
 	}
@@ -1540,7 +1721,8 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause er
 		return w.finishQueuedJob(ctx, jobID, state, cause)
 	}
 	if latest.State == string(workflow.JobCancelled) {
-		return nil
+		_, err := workflow.SettleCancelledRunningJob(ctx, w.Store, latest.ID, "cancelled job worker settled")
+		return err
 	}
 	payload, payloadErr := daemonJobPayload(latest)
 	if payloadErr == nil && payload.Result != nil {
@@ -1617,12 +1799,16 @@ func (w jobWorker) jobResultCommentPosted(ctx context.Context, jobID string) (bo
 	if err != nil {
 		return false, err
 	}
+	posted := false
 	for _, event := range events {
-		if event.Kind == "comment_posted" {
-			return true, nil
+		switch event.Kind {
+		case "retry_queued":
+			posted = false
+		case "comment_posted":
+			posted = true
 		}
 	}
-	return false, nil
+	return posted, nil
 }
 
 func (w jobWorker) jobNeedsCommentRetry(ctx context.Context, jobID string) (bool, error) {
@@ -1636,6 +1822,8 @@ func (w jobWorker) jobNeedsCommentRetry(ctx context.Context, jobID string) (bool
 		case "comment_post_failed":
 			needsRetry = true
 		case "comment_posted":
+			needsRetry = false
+		case "retry_queued":
 			needsRetry = false
 		}
 	}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -830,6 +830,56 @@ func TestRetryPendingJobCommentsPreservesStoredFailureDiagnostic(t *testing.T) {
 	}
 }
 
+func TestRunQueuedJobsPostsCommentAfterRetryDespitePriorComment(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	payload := workflow.JobPayload{Repo: "owner/repo", Branch: "main", PullRequest: 7}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-comment-after-retry", Agent: "audit", Type: "ask", State: string(workflow.JobFailed), Payload: string(encoded)}, db.JobEvent{
+		JobID:   "job-comment-after-retry",
+		Kind:    string(workflow.JobFailed),
+		Message: "job failed",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-comment-after-retry", Kind: "comment_posted", Message: "old result comment"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+	if _, err := workflow.RetryJob(ctx, store, "job-comment-after-retry"); err != nil {
+		t.Fatalf("RetryJob returned error: %v", err)
+	}
+	comments := &cliPollFakeGitHub{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return &cliWorkerFakeAdapter{
+			output: `{"gitmoot_result":{"decision":"approved","summary":"retried","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		}, nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if len(comments.posted) != 1 {
+		t.Fatalf("posted comments = %+v, want retried result comment", comments.posted)
+	}
+	if !strings.Contains(comments.posted[0].body, "**Summary:** retried") {
+		t.Fatalf("retried comment body = %s", comments.posted[0].body)
+	}
+}
+
 func TestRunQueuedJobsDrainsBeyondWorkerLimit(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -1083,8 +1133,8 @@ func TestRunQueuedJobsPreservesCancellationRace(t *testing.T) {
 	adapter := &cliWorkerFakeAdapter{
 		output: `{"gitmoot_result":{"decision":"approved","summary":"late","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
 		onDeliver: func() {
-			if err := store.UpdateJobState(ctx, "job-cancel", string(workflow.JobCancelled)); err != nil {
-				t.Fatalf("UpdateJobState returned error: %v", err)
+			if _, err := workflow.CancelJob(ctx, store, "job-cancel"); err != nil {
+				t.Fatalf("CancelJob returned error: %v", err)
 			}
 		},
 	}
@@ -1113,6 +1163,58 @@ func TestRunQueuedJobsPreservesCancellationRace(t *testing.T) {
 	}
 	if len(comments.posted) != 0 {
 		t.Fatalf("posted comments = %+v, want no comment for cancelled job", comments.posted)
+	}
+	events, err := store.ListJobEvents(ctx, "job-cancel")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "cancel_settled") {
+		t.Fatalf("events = %+v, want cancel_settled", events)
+	}
+}
+
+func TestRunQueuedJobsCancelsActiveDeliveryContext(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-active-cancel", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	adapter := &cliWorkerFakeAdapter{
+		waitForContextCancel: true,
+		onDeliver: func() {
+			if _, err := workflow.CancelJob(ctx, store, "job-active-cancel"); err != nil {
+				t.Fatalf("CancelJob returned error: %v", err)
+			}
+		},
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if !adapter.observedContextCancel() {
+		t.Fatal("adapter did not observe context cancellation")
+	}
+	job, err := store.GetJob(ctx, "job-active-cancel")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+	events, err := store.ListJobEvents(ctx, "job-active-cancel")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "cancel_settled") {
+		t.Fatalf("events = %+v, want cancel_settled", events)
 	}
 }
 
@@ -1595,6 +1697,32 @@ func TestRetryPendingJobAdvancementsAdvancesFailedStoredResult(t *testing.T) {
 	}
 }
 
+func TestJobNeedsAdvanceRetryResetsAfterJobRetry(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-retry-reset", Agent: "audit", Type: "ask", State: string(workflow.JobFailed), Payload: `{"repo":"owner/repo"}`}, db.JobEvent{
+		JobID:   "job-retry-reset",
+		Kind:    string(workflow.JobFailed),
+		Message: "failed",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-retry-reset", Kind: "advance_retry", Message: "old advance retry"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+	if _, err := workflow.RetryJob(ctx, store, "job-retry-reset"); err != nil {
+		t.Fatalf("RetryJob returned error: %v", err)
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	needsRetry, err := worker.jobNeedsAdvanceRetry(ctx, "job-retry-reset")
+	if err != nil {
+		t.Fatalf("jobNeedsAdvanceRetry returned error: %v", err)
+	}
+	if needsRetry {
+		t.Fatal("jobNeedsAdvanceRetry returned true after retry_queued reset")
+	}
+}
+
 func TestRetryPendingJobAdvancementsRefreshesImplementedHeadBeforePreflight(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -1786,6 +1914,67 @@ func TestRecoverRunningJobsKeepsRecentRunningJobsOnStartup(t *testing.T) {
 	}
 }
 
+func TestRecoverCancelledRunningJobsSettlesAbandonedCancellation(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-cancelled", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if err := store.UpdateJobState(ctx, "job-cancelled", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	if _, err := workflow.CancelJob(ctx, store, "job-cancelled"); err != nil {
+		t.Fatalf("CancelJob returned error: %v", err)
+	}
+
+	if err := recoverCancelledRunningJobsForRepo(ctx, store, io.Discard, "owner/repo"); err != nil {
+		t.Fatalf("recoverCancelledRunningJobsForRepo returned error: %v", err)
+	}
+
+	events, err := store.ListJobEvents(ctx, "job-cancelled")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "cancel_settled") {
+		t.Fatalf("events = %+v, want cancel_settled", events)
+	}
+	if _, err := workflow.RetryJob(ctx, store, "job-cancelled"); err != nil {
+		t.Fatalf("RetryJob after cancelled recovery returned error: %v", err)
+	}
+}
+
+func TestRecoverCancelledRunningJobsForRepoSkipsOtherRepos(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 1})
+	for _, id := range []string{"job-a", "job-b"} {
+		if err := store.UpdateJobState(ctx, id, string(workflow.JobRunning)); err != nil {
+			t.Fatalf("UpdateJobState(%s) returned error: %v", id, err)
+		}
+		if _, err := workflow.CancelJob(ctx, store, id); err != nil {
+			t.Fatalf("CancelJob(%s) returned error: %v", id, err)
+		}
+	}
+
+	if err := recoverCancelledRunningJobsForRepo(ctx, store, io.Discard, "owner/repo-a"); err != nil {
+		t.Fatalf("recoverCancelledRunningJobsForRepo returned error: %v", err)
+	}
+
+	eventsA, err := store.ListJobEvents(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("ListJobEvents job-a returned error: %v", err)
+	}
+	eventsB, err := store.ListJobEvents(ctx, "job-b")
+	if err != nil {
+		t.Fatalf("ListJobEvents job-b returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(eventsA, "cancel_settled") {
+		t.Fatalf("eventsA = %+v, want cancel_settled", eventsA)
+	}
+	if daemonWorkerHasEvent(eventsB, "cancel_settled") {
+		t.Fatalf("eventsB = %+v, want no cancel_settled", eventsB)
+	}
+}
+
 func TestDaemonWorkerTickRechecksStaleRunningJobs(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -1962,23 +2151,39 @@ func (f *cliPollFakeGitHub) GetUserPermission(context.Context, github.Repository
 }
 
 type cliWorkerFakeAdapter struct {
-	mu        sync.Mutex
-	output    string
-	calls     int
-	delivered []string
-	onDeliver func()
+	mu                   sync.Mutex
+	output               string
+	calls                int
+	delivered            []string
+	onDeliver            func()
+	waitForContextCancel bool
+	contextCancelled     bool
 }
 
-func (f *cliWorkerFakeAdapter) Deliver(_ context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
+func (f *cliWorkerFakeAdapter) Deliver(ctx context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
 	f.mu.Lock()
 	f.calls++
 	f.delivered = append(f.delivered, job.ID)
 	onDeliver := f.onDeliver
+	waitForContextCancel := f.waitForContextCancel
 	f.mu.Unlock()
 	if onDeliver != nil {
 		onDeliver()
 	}
+	if waitForContextCancel {
+		<-ctx.Done()
+		f.mu.Lock()
+		f.contextCancelled = true
+		f.mu.Unlock()
+		return runtime.Result{}, ctx.Err()
+	}
 	return runtime.Result{Raw: f.output}, nil
+}
+
+func (f *cliWorkerFakeAdapter) observedContextCancel() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.contextCancelled
 }
 
 type cliWorkerFakeMergeGate struct {

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -1,0 +1,288 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func runJob(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printJobUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "list":
+		return runJobList(args[1:], stdout, stderr)
+	case "show":
+		return runJobShow(args[1:], stdout, stderr)
+	case "events":
+		return runJobEvents(args[1:], stdout, stderr)
+	case "run":
+		return runJobRun(args[1:], stdout, stderr)
+	case "retry":
+		return runJobRetry(args[1:], stdout, stderr)
+	case "cancel":
+		return runJobCancel(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown job command %q\n\n", args[0])
+		printJobUsage(stderr)
+		return 2
+	}
+}
+
+func printJobUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot job list [--repo owner/repo] [--state state]")
+	fmt.Fprintln(w, "  gitmoot job show <id>")
+	fmt.Fprintln(w, "  gitmoot job events <id>")
+	fmt.Fprintln(w, "  gitmoot job run <id>")
+	fmt.Fprintln(w, "  gitmoot job retry <id>")
+	fmt.Fprintln(w, "  gitmoot job cancel <id>")
+}
+
+func runJobList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repo := fs.String("repo", "", "repo scope as owner/repo")
+	state := fs.String("state", "", "job state filter")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "job list does not accept positional arguments")
+		return 2
+	}
+	var jobs []db.Job
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		jobs, err = store.ListJobs(context.Background())
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "job list: %v\n", err)
+		return 1
+	}
+	for _, job := range filterJobs(jobs, *repo, *state) {
+		payload, _ := daemonJobPayload(job)
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t#%d\n", job.ID, job.State, job.Type, job.Agent, payload.Repo, payload.PullRequest)
+	}
+	return 0
+}
+
+func runJobShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jobID, ok := parseSingleJobID(fs, args, stderr, "job show")
+	if !ok {
+		return parseSingleJobIDExitCode(args)
+	}
+	job, payload, err := loadJobWithPayload(*home, jobID)
+	if err != nil {
+		fmt.Fprintf(stderr, "job show: %v\n", err)
+		return 1
+	}
+	printJob(stdout, job, payload)
+	return 0
+}
+
+func runJobEvents(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job events", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jobID, ok := parseSingleJobID(fs, args, stderr, "job events")
+	if !ok {
+		return parseSingleJobIDExitCode(args)
+	}
+	var events []db.JobEvent
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		if _, err = store.GetJob(context.Background(), jobID); err != nil {
+			return err
+		}
+		events, err = store.ListJobEvents(context.Background(), jobID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "job events: %v\n", err)
+		return 1
+	}
+	for _, event := range events {
+		fmt.Fprintf(stdout, "%s\t%s\n", event.Kind, event.Message)
+	}
+	return 0
+}
+
+func runJobRun(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job run", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jobID, ok := parseSingleJobID(fs, args, stderr, "job run")
+	if !ok {
+		return parseSingleJobIDExitCode(args)
+	}
+	var latest db.Job
+	if err := withStore(*home, func(store *db.Store) error {
+		job, err := store.GetJob(context.Background(), jobID)
+		if err != nil {
+			return err
+		}
+		if job.State != string(workflow.JobQueued) {
+			return fmt.Errorf("job %s is %s; run requires queued", job.ID, job.State)
+		}
+		worker := defaultJobWorker(store, stdout)
+		worker.CommenterFactory = worker.defaultCommenter
+		if err := worker.run(context.Background(), job); err != nil {
+			return err
+		}
+		latest, err = store.GetJob(context.Background(), jobID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "job run: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "ran job %s: %s\n", latest.ID, latest.State)
+	return 0
+}
+
+func runJobRetry(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job retry", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jobID, ok := parseSingleJobID(fs, args, stderr, "job retry")
+	if !ok {
+		return parseSingleJobIDExitCode(args)
+	}
+	var job db.Job
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		job, err = workflow.RetryJob(context.Background(), store, jobID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "job retry: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "queued retry for job %s\n", job.ID)
+	return 0
+}
+
+func runJobCancel(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job cancel", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jobID, ok := parseSingleJobID(fs, args, stderr, "job cancel")
+	if !ok {
+		return parseSingleJobIDExitCode(args)
+	}
+	var job db.Job
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		job, err = workflow.CancelJob(context.Background(), store, jobID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "job cancel: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "cancelled job %s\n", job.ID)
+	return 0
+}
+
+func parseSingleJobID(fs *flag.FlagSet, args []string, stderr io.Writer, command string) (string, bool) {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintf(stderr, "%s requires exactly one id\n", command)
+			return "", false
+		}
+		return "", false
+	}
+	jobID := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		return "", false
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "%s requires exactly one id\n", command)
+		return "", false
+	}
+	return jobID, true
+}
+
+func parseSingleJobIDExitCode(args []string) int {
+	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
+		return 0
+	}
+	return 2
+}
+
+func filterJobs(jobs []db.Job, repoFilter string, stateFilter string) []db.Job {
+	repoFilter = strings.TrimSpace(repoFilter)
+	stateFilter = strings.TrimSpace(stateFilter)
+	filtered := make([]db.Job, 0, len(jobs))
+	for _, job := range jobs {
+		if stateFilter != "" && job.State != stateFilter {
+			continue
+		}
+		if repoFilter != "" {
+			payload, err := daemonJobPayload(job)
+			if err != nil || payload.Repo != repoFilter {
+				continue
+			}
+		}
+		filtered = append(filtered, job)
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].ID < filtered[j].ID
+	})
+	return filtered
+}
+
+func loadJobWithPayload(home string, jobID string) (db.Job, workflow.JobPayload, error) {
+	var job db.Job
+	var payload workflow.JobPayload
+	err := withStore(home, func(store *db.Store) error {
+		var err error
+		job, err = store.GetJob(context.Background(), jobID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("job %q not found", jobID)
+			}
+			return err
+		}
+		payload, err = daemonJobPayload(job)
+		return err
+	})
+	return job, payload, err
+}
+
+func printJob(stdout io.Writer, job db.Job, payload workflow.JobPayload) {
+	fmt.Fprintf(stdout, "id: %s\n", job.ID)
+	fmt.Fprintf(stdout, "state: %s\n", job.State)
+	fmt.Fprintf(stdout, "type: %s\n", job.Type)
+	fmt.Fprintf(stdout, "agent: %s\n", job.Agent)
+	fmt.Fprintf(stdout, "repo: %s\n", payload.Repo)
+	fmt.Fprintf(stdout, "branch: %s\n", payload.Branch)
+	fmt.Fprintf(stdout, "pull_request: %d\n", payload.PullRequest)
+	if payload.Result != nil {
+		fmt.Fprintf(stdout, "decision: %s\n", payload.Result.Decision)
+		fmt.Fprintf(stdout, "summary: %s\n", payload.Result.Summary)
+	}
+	if len(payload.RawOutputs) > 0 {
+		fmt.Fprintf(stdout, "raw_outputs: %d retained locally\n", len(payload.RawOutputs))
+	}
+	encoded, err := json.MarshalIndent(payload, "", "  ")
+	if err == nil {
+		fmt.Fprintf(stdout, "payload: %s\n", string(encoded))
+	}
+}

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func TestRunJobListShowEventsRetryCancel(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedCLIJob(t, store, db.Job{
+		ID:      "job-failed",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobFailed),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", PullRequest: 7, RawOutputs: []string{"raw"}}),
+	}, "failed")
+	seedCLIJob(t, store, db.Job{
+		ID:      "job-queued",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobQueued),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", PullRequest: 7}),
+	}, "queued")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "list", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "job-failed") || !strings.Contains(stdout.String(), "job-queued") {
+		t.Fatalf("job list output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "show", "job-failed", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"id: job-failed", "state: failed", "repo: owner/repo", "raw_outputs: 1 retained locally"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("job show missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "events", "job-failed", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job events exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "failed\tfailed") {
+		t.Fatalf("job events output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "retry", "job-failed", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job retry exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "queued retry for job job-failed") {
+		t.Fatalf("job retry output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "cancel", "job-queued", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job cancel exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "cancelled job job-queued") {
+		t.Fatalf("job cancel output = %q", stdout.String())
+	}
+}
+
+func TestRunJobRunUsesDaemonWorkerInternals(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "branch", "-m", "main")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", "shell", `printf '%s\n' '{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}'`, []string{"ask"}, "owner/repo")
+	seedCLIJob(t, store, db.Job{
+		ID:      "job-run",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobQueued),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", PullRequest: 0}),
+	}, "queued")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "run", "job-run", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job run exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "ran job job-run: succeeded") {
+		t.Fatalf("job run output = %q", stdout.String())
+	}
+	job, err := store.GetJob(context.Background(), "job-run")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) || !strings.Contains(job.Payload, `"summary":"done"`) {
+		t.Fatalf("job after run = %+v", job)
+	}
+}
+
+func openCLIJobStore(t *testing.T, home string) *db.Store {
+	t.Helper()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	return store
+}
+
+func seedCLIJob(t *testing.T, store *db.Store, job db.Job, message string) {
+	t.Helper()
+	if err := store.CreateJobWithEvent(context.Background(), job, db.JobEvent{Kind: job.State, Message: message}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+}
+
+func mustJobPayload(t *testing.T, payload workflow.JobPayload) string {
+	t.Helper()
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	return string(encoded)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,6 +29,7 @@ var rootCommands = []command{
 	{name: "status", summary: "show local workflow status", run: runStatus},
 	{name: "goal", summary: "import or inspect goals", run: runGoal},
 	{name: "task", summary: "run or inspect tasks", run: runTask},
+	{name: "job", summary: "inspect and recover jobs", run: runJob},
 }
 
 func Run(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -53,7 +53,7 @@ func TestRunInitCreatesState(t *testing.T) {
 }
 
 func TestRunSubcommandHelpSucceeds(t *testing.T) {
-	for _, command := range []string{"init", "doctor", "version", "repo"} {
+	for _, command := range []string{"init", "doctor", "version", "repo", "job"} {
 		t.Run(command, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 

--- a/internal/daemon/command.go
+++ b/internal/daemon/command.go
@@ -8,6 +8,7 @@ import (
 type Command struct {
 	Action       string
 	Agent        string
+	JobID        string
 	Instructions string
 }
 
@@ -34,6 +35,11 @@ func ParseCommand(line string) (Command, bool) {
 	switch fields[1] {
 	case "status", "merge":
 		return Command{Action: fields[1], Instructions: trailing(fields, 2)}, true
+	case "retry", "cancel":
+		if len(fields) < 3 {
+			return Command{}, false
+		}
+		return Command{Action: fields[1], JobID: fields[2], Instructions: trailing(fields, 3)}, true
 	case "ask":
 		if len(fields) < 3 {
 			return Command{}, false
@@ -49,11 +55,14 @@ func ParseCommand(line string) (Command, bool) {
 
 func (c Command) Validate() error {
 	switch c.Action {
-	case "review", "implement", "ask", "status", "merge":
+	case "review", "implement", "ask", "status", "merge", "retry", "cancel":
 	default:
 		return fmt.Errorf("unsupported command action %q", c.Action)
 	}
-	if c.Action != "status" && c.Action != "merge" && c.Agent == "" {
+	if (c.Action == "retry" || c.Action == "cancel") && c.JobID == "" {
+		return fmt.Errorf("command %q requires a job id", c.Action)
+	}
+	if c.Action != "status" && c.Action != "merge" && c.Action != "retry" && c.Action != "cancel" && c.Agent == "" {
 		return fmt.Errorf("command %q requires an agent", c.Action)
 	}
 	return nil

--- a/internal/daemon/command_test.go
+++ b/internal/daemon/command_test.go
@@ -40,6 +40,23 @@ func TestParseCommandsOnlyReturnsGitmootLines(t *testing.T) {
 	}
 }
 
+func TestParseJobRecoveryCommands(t *testing.T) {
+	command, ok := ParseCommand("/gitmoot retry job-123")
+	if !ok {
+		t.Fatal("ParseCommand did not parse retry command")
+	}
+	if command.Action != "retry" || command.JobID != "job-123" {
+		t.Fatalf("retry command = %+v", command)
+	}
+	command, ok = ParseCommand("/gitmoot cancel job-456")
+	if !ok {
+		t.Fatal("ParseCommand did not parse cancel command")
+	}
+	if command.Action != "cancel" || command.JobID != "job-456" {
+		t.Fatalf("cancel command = %+v", command)
+	}
+}
+
 func TestValidateRejectsUnsupportedCommand(t *testing.T) {
 	if err := (Command{Action: "deploy", Agent: "audit"}).Validate(); err == nil {
 		t.Fatal("Validate accepted unsupported action")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -114,6 +114,28 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 	return firstErr
 }
 
+func (d Daemon) PollRecoveryCommandsOnce(ctx context.Context) error {
+	if err := d.validate(); err != nil {
+		return err
+	}
+	pulls, err := d.GitHub.ListPullRequests(ctx, d.Repo, "open")
+	if err != nil {
+		return err
+	}
+	for _, pull := range pulls {
+		comments, err := d.GitHub.ListIssueComments(ctx, d.Repo, pull.Number)
+		if err != nil {
+			return err
+		}
+		for _, comment := range comments {
+			if err := d.handleRecoveryComment(ctx, pull, comment); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (d Daemon) validate() error {
 	if d.Store == nil {
 		return errors.New("daemon store is required")
@@ -417,6 +439,48 @@ func (d Daemon) handleComment(ctx context.Context, pull github.PullRequest, comm
 	return d.markCommentSeen(ctx, pull, comment)
 }
 
+func (d Daemon) handleRecoveryComment(ctx context.Context, pull github.PullRequest, comment github.IssueComment) error {
+	commands := ParseCommands(comment.Body)
+	if len(commands) == 0 || !onlyJobRecoveryCommands(commands) {
+		return nil
+	}
+
+	seen, err := d.Store.HasCommentSeen(ctx, d.Repo.FullName(), comment.ID)
+	if err != nil {
+		return err
+	}
+	if seen {
+		return nil
+	}
+
+	authorized, err := d.authorizeCommenter(ctx, comment.Author)
+	if err != nil {
+		return err
+	}
+	if !authorized {
+		if err := d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot ignored comment %d from `%s`: `/gitmoot` commands require write, maintain, or admin repository permission.", comment.ID, comment.Author)); err != nil {
+			return err
+		}
+		return d.markCommentSeen(ctx, pull, comment)
+	}
+
+	for sequence, command := range commands {
+		if err := d.handleCommand(ctx, pull, comment, sequence, command); err != nil {
+			return err
+		}
+	}
+	return d.markCommentSeen(ctx, pull, comment)
+}
+
+func onlyJobRecoveryCommands(commands []Command) bool {
+	for _, command := range commands {
+		if command.Action != "retry" && command.Action != "cancel" {
+			return false
+		}
+	}
+	return true
+}
+
 func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comment github.IssueComment, sequence int, command Command) error {
 	if err := command.Validate(); err != nil {
 		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not route comment %d: %v.", comment.ID, err))
@@ -426,6 +490,10 @@ func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comm
 		return d.handleStatusCommand(ctx, pull, comment)
 	case "merge":
 		return d.handleMergeCommand(ctx, pull, comment)
+	case "retry":
+		return d.handleRetryCommand(ctx, pull, command)
+	case "cancel":
+		return d.handleCancelCommand(ctx, pull, command)
 	}
 
 	agent, err := d.Store.GetAgent(ctx, command.Agent)
@@ -491,6 +559,46 @@ func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comm
 		}
 	}
 	return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot queued `%s` job `%s` for `%s`.", command.Action, job.ID, agent.Name))
+}
+
+func (d Daemon) handleRetryCommand(ctx context.Context, pull github.PullRequest, command Command) error {
+	if err := d.validateJobCommandScope(ctx, pull, command.JobID); err != nil {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not retry job `%s`: %v.", command.JobID, err))
+	}
+	job, err := workflow.RetryJob(ctx, d.Store, command.JobID)
+	if err != nil {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not retry job `%s`: %v.", command.JobID, err))
+	}
+	return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot queued retry for job `%s`.", job.ID))
+}
+
+func (d Daemon) handleCancelCommand(ctx context.Context, pull github.PullRequest, command Command) error {
+	if err := d.validateJobCommandScope(ctx, pull, command.JobID); err != nil {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not cancel job `%s`: %v.", command.JobID, err))
+	}
+	job, err := workflow.CancelJob(ctx, d.Store, command.JobID)
+	if err != nil {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not cancel job `%s`: %v.", command.JobID, err))
+	}
+	return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot cancelled job `%s`.", job.ID))
+}
+
+func (d Daemon) validateJobCommandScope(ctx context.Context, pull github.PullRequest, jobID string) error {
+	job, err := d.Store.GetJob(ctx, jobID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("job not found")
+		}
+		return err
+	}
+	payload, err := workflowPayload(job)
+	if err != nil {
+		return err
+	}
+	if payload.Repo != d.Repo.FullName() || int64(payload.PullRequest) != pull.Number {
+		return fmt.Errorf("job belongs to %s PR #%d", payload.Repo, payload.PullRequest)
+	}
+	return nil
 }
 
 func (d Daemon) handleStatusCommand(ctx context.Context, pull github.PullRequest, comment github.IssueComment) error {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1110,6 +1110,244 @@ func TestPollOnceReportsStatusCommand(t *testing.T) {
 	}
 }
 
+func TestPollOnceRetriesJobFromComment(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-10",
+		PullRequest: 10,
+		TaskID:      "task-010",
+		RawOutputs:  []string{"raw"},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-retry", Agent: "audit", Type: "review", State: string(workflow.JobFailed), Payload: string(payload)}, db.JobEvent{
+		Kind:    string(workflow.JobFailed),
+		Message: "failed",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main", HeadSHA: "abc123"}},
+		comments: map[int64][]github.IssueComment{
+			10: {{ID: 920, Body: "/gitmoot retry job-retry", Author: "dana"}},
+		},
+	}
+
+	err = (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-retry")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) || !strings.Contains(job.Payload, `"raw_outputs":["raw"]`) {
+		t.Fatalf("job after retry = %+v", job)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "queued retry for job `job-retry`") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+}
+
+func TestPollOnceCancelsJobFromComment(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-10",
+		PullRequest: 10,
+		TaskID:      "task-010",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-cancel", Agent: "audit", Type: "review", State: string(workflow.JobRunning), Payload: string(payload)}, db.JobEvent{
+		Kind:    string(workflow.JobRunning),
+		Message: "running",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main", HeadSHA: "abc123"}},
+		comments: map[int64][]github.IssueComment{
+			10: {{ID: 921, Body: "/gitmoot cancel job-cancel", Author: "dana"}},
+		},
+	}
+
+	err = (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-cancel")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "cancelled job `job-cancel`") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+}
+
+func TestPollRecoveryCommandsOnceOnlyHandlesJobRecovery(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-10",
+		PullRequest: 10,
+		TaskID:      "task-010",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-cancel", Agent: "audit", Type: "review", State: string(workflow.JobRunning), Payload: string(payload)}, db.JobEvent{
+		Kind:    string(workflow.JobRunning),
+		Message: "running",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main", HeadSHA: "abc123"}},
+		comments: map[int64][]github.IssueComment{
+			10: {
+				{ID: 921, Body: "/gitmoot cancel job-cancel", Author: "dana"},
+				{ID: 922, Body: "/gitmoot audit review later", Author: "dana"},
+			},
+		},
+	}
+
+	err = (Daemon{Repo: repo, Store: store, GitHub: client}).PollRecoveryCommandsOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollRecoveryCommandsOnce returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-cancel")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "cancelled job `job-cancel`") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("jobs = %+v, want only recovery target", jobs)
+	}
+}
+
+func TestPollOnceDoesNotRetryRunningJobCancelledInSameComment(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-10",
+		PullRequest: 10,
+		TaskID:      "task-010",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-cancel-retry", Agent: "audit", Type: "review", State: string(workflow.JobRunning), Payload: string(payload)}, db.JobEvent{
+		Kind:    string(workflow.JobRunning),
+		Message: "running",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main", HeadSHA: "abc123"}},
+		comments: map[int64][]github.IssueComment{
+			10: {{ID: 923, Body: "/gitmoot cancel job-cancel-retry\n/gitmoot retry job-cancel-retry", Author: "dana"}},
+		},
+	}
+
+	err = (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-cancel-retry")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+	if len(client.posted) != 2 || !strings.Contains(client.posted[1].body, "wait for the active worker to settle") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+}
+
+func TestPollOnceRejectsJobRecoveryForDifferentPullRequest(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-11",
+		PullRequest: 11,
+		TaskID:      "task-011",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-other", Agent: "audit", Type: "review", State: string(workflow.JobFailed), Payload: string(payload)}, db.JobEvent{
+		Kind:    string(workflow.JobFailed),
+		Message: "failed",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main", HeadSHA: "abc123"}},
+		comments: map[int64][]github.IssueComment{
+			10: {{ID: 922, Body: "/gitmoot retry job-other", Author: "dana"}},
+		},
+	}
+
+	err = (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx)
+
+	if err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-other")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "belongs to jerryfane/gitmoot PR #11") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
+	}
+}
+
 func TestPollOnceReportsStatusCommandCountsUnregisteredPRJobs(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -1,0 +1,129 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error) {
+	if store == nil {
+		return db.Job{}, fmt.Errorf("store is required")
+	}
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		return db.Job{}, err
+	}
+	switch job.State {
+	case string(JobFailed), string(JobBlocked), string(JobCancelled):
+	default:
+		return db.Job{}, fmt.Errorf("job %s is %s; retry requires failed, blocked, or cancelled", job.ID, job.State)
+	}
+	if job.State == string(JobCancelled) {
+		fromRunning, err := latestCancellationWasFromRunning(ctx, store, job.ID)
+		if err != nil {
+			return db.Job{}, err
+		}
+		if fromRunning {
+			return db.Job{}, fmt.Errorf("job %s was cancelled while running; wait for the active worker to settle before retrying", job.ID)
+		}
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		return db.Job{}, err
+	}
+	payload.Result = nil
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		return db.Job{}, err
+	}
+	transitioned, err := store.TransitionJobStatePayloadWithEvent(ctx, job.ID, job.State, string(JobQueued), encoded, db.JobEvent{
+		JobID:   job.ID,
+		Kind:    "retry_queued",
+		Message: fmt.Sprintf("retry requested from %s", job.State),
+	})
+	if err != nil {
+		return db.Job{}, err
+	}
+	if !transitioned {
+		latest, getErr := store.GetJob(ctx, job.ID)
+		if getErr != nil {
+			return db.Job{}, getErr
+		}
+		return db.Job{}, fmt.Errorf("job %s is %s; retry requires failed, blocked, or cancelled", latest.ID, latest.State)
+	}
+	return store.GetJob(ctx, job.ID)
+}
+
+func latestCancellationWasFromRunning(ctx context.Context, store *db.Store, jobID string) (bool, error) {
+	events, err := store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+	for i := len(events) - 1; i >= 0; i-- {
+		event := events[i]
+		if event.Kind == "cancel_settled" {
+			return false, nil
+		}
+		if event.Kind == string(JobCancelled) {
+			return event.Message == "cancel requested from running", nil
+		}
+	}
+	return false, nil
+}
+
+func SettleCancelledRunningJob(ctx context.Context, store *db.Store, jobID string, message string) (bool, error) {
+	if store == nil {
+		return false, fmt.Errorf("store is required")
+	}
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+	if job.State != string(JobCancelled) {
+		return false, nil
+	}
+	fromRunning, err := latestCancellationWasFromRunning(ctx, store, job.ID)
+	if err != nil {
+		return false, err
+	}
+	if !fromRunning {
+		return false, nil
+	}
+	if message == "" {
+		message = "cancelled job worker settled"
+	}
+	return true, store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "cancel_settled", Message: message})
+}
+
+func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error) {
+	if store == nil {
+		return db.Job{}, fmt.Errorf("store is required")
+	}
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		return db.Job{}, err
+	}
+	switch job.State {
+	case string(JobQueued), string(JobRunning):
+	default:
+		return db.Job{}, fmt.Errorf("job %s is %s; cancel requires queued or running", job.ID, job.State)
+	}
+	transitioned, err := store.TransitionJobStateWithEvent(ctx, job.ID, job.State, string(JobCancelled), db.JobEvent{
+		JobID:   job.ID,
+		Kind:    string(JobCancelled),
+		Message: fmt.Sprintf("cancel requested from %s", job.State),
+	})
+	if err != nil {
+		return db.Job{}, err
+	}
+	if !transitioned {
+		latest, getErr := store.GetJob(ctx, job.ID)
+		if getErr != nil {
+			return db.Job{}, getErr
+		}
+		return db.Job{}, fmt.Errorf("job %s is %s; cancel requires queued or running", latest.ID, latest.State)
+	}
+	return store.GetJob(ctx, job.ID)
+}

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -1,0 +1,126 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestRetryJobRequeuesTerminalJobAndPreservesPayload(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	payload := `{"repo":"owner/repo","raw_outputs":["raw"],"result":{"decision":"approved","summary":"stale"}}`
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "ask", State: string(JobFailed), Payload: payload}, db.JobEvent{
+		Kind:    string(JobFailed),
+		Message: "failed",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	job, err := RetryJob(ctx, store, "job-1")
+	if err != nil {
+		t.Fatalf("RetryJob returned error: %v", err)
+	}
+
+	if job.State != string(JobQueued) {
+		t.Fatalf("job after retry = %+v", job)
+	}
+	storedPayload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if storedPayload.Result != nil || len(storedPayload.RawOutputs) != 1 || storedPayload.RawOutputs[0] != "raw" {
+		t.Fatalf("payload after retry = %+v, want stale result cleared and raw output preserved", storedPayload)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if len(events) != 2 || events[1].Kind != "retry_queued" || !strings.Contains(events[1].Message, "failed") {
+		t.Fatalf("events = %+v, want retry event preserving prior events", events)
+	}
+}
+
+func TestRetryJobRejectsNonTerminalJob(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "ask", State: string(JobQueued)}, db.JobEvent{Kind: string(JobQueued), Message: "queued"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if _, err := RetryJob(ctx, store, "job-1"); err == nil {
+		t.Fatal("RetryJob accepted queued job")
+	}
+}
+
+func TestRetryJobAllowsQueuedCancellationButRejectsRunningCancellation(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	for _, jobID := range []string{"queued-cancel", "running-cancel"} {
+		if err := store.CreateJobWithEvent(ctx, db.Job{ID: jobID, Agent: "audit", Type: "ask", State: string(JobCancelled), Payload: `{"repo":"owner/repo"}`}, db.JobEvent{
+			Kind:    string(JobCancelled),
+			Message: "cancel requested from " + strings.TrimSuffix(jobID, "-cancel"),
+		}); err != nil {
+			t.Fatalf("CreateJobWithEvent %s returned error: %v", jobID, err)
+		}
+	}
+	if _, err := RetryJob(ctx, store, "queued-cancel"); err != nil {
+		t.Fatalf("RetryJob rejected queued cancellation: %v", err)
+	}
+	if _, err := RetryJob(ctx, store, "running-cancel"); err == nil {
+		t.Fatal("RetryJob accepted running cancellation")
+	}
+}
+
+func TestRetryJobAllowsRunningCancellationAfterWorkerSettles(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "ask", State: string(JobCancelled), Payload: `{"repo":"owner/repo"}`}, db.JobEvent{
+		Kind:    string(JobCancelled),
+		Message: "cancel requested from running",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-1", Kind: "cancel_settled", Message: "cancelled job worker settled"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+	if _, err := RetryJob(ctx, store, "job-1"); err != nil {
+		t.Fatalf("RetryJob rejected settled running cancellation: %v", err)
+	}
+}
+
+func TestCancelJobCancelsQueuedOrRunningJob(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "ask", State: string(JobRunning)}, db.JobEvent{Kind: string(JobRunning), Message: "running"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	job, err := CancelJob(ctx, store, "job-1")
+	if err != nil {
+		t.Fatalf("CancelJob returned error: %v", err)
+	}
+
+	if job.State != string(JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if len(events) != 2 || events[1].Kind != string(JobCancelled) {
+		t.Fatalf("events = %+v, want cancellation event", events)
+	}
+}
+
+func TestCancelJobRejectsTerminalJob(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "ask", State: string(JobSucceeded)}, db.JobEvent{Kind: string(JobSucceeded), Message: "succeeded"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if _, err := CancelJob(ctx, store, "job-1"); err == nil {
+		t.Fatal("CancelJob accepted succeeded job")
+	}
+}


### PR DESCRIPTION
WHAT: Added job inspection and recovery commands for queued Gitmoot jobs.

WHY: Operators and agents need a direct way to inspect, rerun, retry, and cancel jobs from the local CLI and from PR comments without manually editing the database.

CHANGES:
- Added `gitmoot job list/show/events/run/retry/cancel`.
- Added `/gitmoot retry <job-id>` and `/gitmoot cancel <job-id>` PR command handling.
- Added workflow-level retry/cancel helpers that preserve job events and raw outputs while clearing stale result state on retry.
- Added worker cancellation support so running runtime deliveries observe cancellation requests.
- Added daemon recovery-only polling while checkout locks are held, plus restart recovery for cancelled running jobs.
- Documented the new commands in README and local workflow docs.

RESULTS:
- `git diff --check` passed.
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli ./internal/daemon ./internal/workflow` passed.
- `GOTOOLCHAIN=go1.26.0 go test ./...` passed.
- `GOTOOLCHAIN=go1.26.0 go vet ./...` passed.
- `codex exec review --uncommitted` final raw output:

```text
codex
I did not identify any discrete correctness issues in the current staged, unstaged, or untracked changes. I could not run the Go test suite because the sandbox cannot download the configured Go 1.26 toolchain.
```

RISK: The Codex review sandbox could not download Go 1.26, so test execution evidence comes from the explicit local `GOTOOLCHAIN=go1.26.0` runs above.