### PR TITLE
feat: add lock management

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ gitmoot status
 gitmoot goal import --file <path>
 gitmoot task run <id> --repo owner/repo --owner <agent>
 gitmoot job list|show|events|run|retry|cancel
+gitmoot lock list|show|release
 ```
 
 ## Documentation

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -108,6 +108,14 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    are routed through the runtime adapter and must return the `gitmoot_result`
    JSON contract.
 
+   Stale branch locks can be inspected and released locally:
+
+   ```sh
+   gitmoot lock list --repo owner/project
+   gitmoot lock show owner/project <branch>
+   gitmoot lock release owner/project <branch> --owner <agent>
+   ```
+
 8. Let the PR converge.
 
    Agents review, request fixes, and rerun work through comments and job output.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -123,11 +123,24 @@ Checks:
 
 ```sh
 gitmoot agent list
+gitmoot lock list --repo owner/repo
+gitmoot lock show owner/repo <branch>
 ```
 
-Current V1 does not expose a lock-management CLI. Inspect local state only if
-you understand the schema and have backed up the database. The safer path is to
-finish or merge the owning task so the merge gate releases the lock.
+The safest path is still to finish or merge the owning task so the merge gate
+releases the lock and records the release event. If the task is abandoned, use
+an exact-owner release:
+
+```sh
+gitmoot lock release owner/repo <branch> --owner <agent>
+```
+
+Use `--force` only when the stored owner is stale or the owning session is no
+longer recoverable:
+
+```sh
+gitmoot lock release owner/repo <branch> --force
+```
 
 ## Malformed Agent Output
 

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -1,0 +1,227 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/daemon"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func runLock(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printLockUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "list":
+		return runLockList(args[1:], stdout, stderr)
+	case "show":
+		return runLockShow(args[1:], stdout, stderr)
+	case "release":
+		return runLockRelease(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown lock command %q\n\n", args[0])
+		printLockUsage(stderr)
+		return 2
+	}
+}
+
+func printLockUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot lock list [--repo owner/repo]")
+	fmt.Fprintln(w, "  gitmoot lock show owner/repo <branch>")
+	fmt.Fprintln(w, "  gitmoot lock release owner/repo <branch> --owner <agent>")
+	fmt.Fprintln(w, "  gitmoot lock release owner/repo <branch> --force")
+}
+
+func runLockList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("lock list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repoFlag := fs.String("repo", "", "repo scope as owner/repo")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "lock list does not accept positional arguments")
+		return 2
+	}
+	repoFullName, ok := normalizeOptionalRepoFlag(*repoFlag, stderr)
+	if !ok {
+		return 2
+	}
+	var locks []db.BranchLock
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		locks, err = store.ListBranchLocks(context.Background(), repoFullName)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "lock list: %v\n", err)
+		return 1
+	}
+	for _, lock := range locks {
+		fmt.Fprintf(stdout, "%s\t%s\t%s\n", lock.RepoFullName, lock.Branch, lock.Owner)
+	}
+	return 0
+}
+
+func runLockShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("lock show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repoFullName, branch, ok := parseLockTarget(fs, args, stderr, "lock show")
+	if !ok {
+		return parseLockTargetExitCode(args)
+	}
+	var lock db.BranchLock
+	var events []db.BranchLockEvent
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		lock, err = store.GetBranchLock(context.Background(), repoFullName, branch)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("lock %s %q not found", repoFullName, branch)
+		}
+		if err != nil {
+			return err
+		}
+		events, err = store.ListBranchLockEvents(context.Background(), repoFullName, branch)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "lock show: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "repo: %s\n", lock.RepoFullName)
+	fmt.Fprintf(stdout, "branch: %s\n", lock.Branch)
+	fmt.Fprintf(stdout, "owner: %s\n", lock.Owner)
+	for _, event := range events {
+		fmt.Fprintf(stdout, "event: %s\t%s\t%s\n", event.Kind, event.Owner, event.Message)
+	}
+	return 0
+}
+
+func runLockRelease(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("lock release", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	owner := fs.String("owner", "", "agent that owns the lock")
+	force := fs.Bool("force", false, "release the lock regardless of owner")
+	repoFullName, branch, ok := parseLockTarget(fs, args, stderr, "lock release")
+	if !ok {
+		return parseLockTargetExitCode(args)
+	}
+	if *force && strings.TrimSpace(*owner) != "" {
+		fmt.Fprintln(stderr, "lock release accepts either --owner or --force, not both")
+		return 2
+	}
+	if !*force && strings.TrimSpace(*owner) == "" {
+		fmt.Fprintln(stderr, "lock release requires --owner unless --force is passed")
+		return 2
+	}
+	var releasedLock db.BranchLock
+	if err := withStore(*home, func(store *db.Store) error {
+		event := db.BranchLockEvent{Kind: "released", Message: "released by gitmoot lock release"}
+		if *force {
+			event.Kind = "force_released"
+			event.Message = "force released by gitmoot lock release"
+			lock, released, err := store.ForceReleaseLockWithEvent(context.Background(), repoFullName, branch, event)
+			if err != nil {
+				return err
+			}
+			if !released {
+				return fmt.Errorf("lock %s %q not found", repoFullName, branch)
+			}
+			releasedLock = lock
+			return nil
+		}
+
+		lock, err := store.GetBranchLock(context.Background(), repoFullName, branch)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("lock %s %q not found", repoFullName, branch)
+		}
+		if err != nil {
+			return err
+		}
+		if lock.Owner != *owner {
+			return fmt.Errorf("lock %s %q is owned by %s, not %s", repoFullName, branch, lock.Owner, *owner)
+		}
+		released, err := store.ReleaseLockWithEvent(context.Background(), lock, event)
+		if err != nil {
+			return err
+		}
+		if !released {
+			return fmt.Errorf("lock %s %q was not released", repoFullName, branch)
+		}
+		releasedLock = lock
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "lock release: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "released lock %s %s owned by %s\n", releasedLock.RepoFullName, releasedLock.Branch, releasedLock.Owner)
+	return 0
+}
+
+func parseLockTarget(fs *flag.FlagSet, args []string, stderr io.Writer, command string) (string, string, bool) {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintf(stderr, "%s requires owner/repo and branch\n", command)
+			return "", "", false
+		}
+		return "", "", false
+	}
+	if len(args) < 2 {
+		fmt.Fprintf(stderr, "%s requires owner/repo and branch\n", command)
+		return "", "", false
+	}
+	repoFullName, ok := normalizeRepoArg(args[0], stderr)
+	if !ok {
+		return "", "", false
+	}
+	branch := strings.TrimSpace(args[1])
+	if branch == "" {
+		fmt.Fprintf(stderr, "%s requires branch\n", command)
+		return "", "", false
+	}
+	if err := fs.Parse(args[2:]); err != nil {
+		return "", "", false
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "%s requires owner/repo and branch\n", command)
+		return "", "", false
+	}
+	return repoFullName, branch, true
+}
+
+func parseLockTargetExitCode(args []string) int {
+	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
+		return 0
+	}
+	return 2
+}
+
+func normalizeOptionalRepoFlag(value string, stderr io.Writer) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", true
+	}
+	return normalizeRepoArg(value, stderr)
+}
+
+func normalizeRepoArg(value string, stderr io.Writer) (string, bool) {
+	repo, err := daemon.ParseRepository(value)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+		return "", false
+	}
+	return repo.FullName(), true
+}

--- a/internal/cli/lock_test.go
+++ b/internal/cli/lock_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestRunLockListShowRelease(t *testing.T) {
+	home := t.TempDir()
+	store := openCLILockStore(t, home)
+	defer store.Close()
+	acquireCLILock(t, store, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-9", Owner: "lead"})
+	acquireCLILock(t, store, db.BranchLock{RepoFullName: "owner/other", Branch: "task-1", Owner: "audit"})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"lock", "list", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("lock list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "owner/repo\ttask-9\tlead") || strings.Contains(stdout.String(), "owner/other") {
+		t.Fatalf("lock list output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"lock", "show", "owner/repo", "task-9", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("lock show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"repo: owner/repo", "branch: task-9", "owner: lead"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("lock show missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"lock", "release", "owner/repo", "task-9", "--home", home, "--owner", "lead"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("lock release exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "released lock owner/repo task-9 owned by lead") {
+		t.Fatalf("lock release output = %q", stdout.String())
+	}
+	events, err := store.ListBranchLockEvents(context.Background(), "owner/repo", "task-9")
+	if err != nil {
+		t.Fatalf("ListBranchLockEvents returned error: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "released" || events[0].Owner != "lead" {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestRunLockReleaseRequiresOwnerUnlessForced(t *testing.T) {
+	home := t.TempDir()
+	store := openCLILockStore(t, home)
+	defer store.Close()
+	acquireCLILock(t, store, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-9", Owner: "lead"})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"lock", "release", "owner/repo", "task-9", "--home", home, "--owner", "other"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("wrong owner exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "owned by lead, not other") {
+		t.Fatalf("wrong owner stderr = %q", stderr.String())
+	}
+	if _, err := store.GetBranchLock(context.Background(), "owner/repo", "task-9"); err != nil {
+		t.Fatalf("lock should still exist after wrong owner: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"lock", "release", "owner/repo", "task-9", "--home", home}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("missing owner exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"lock", "release", "owner/repo", "task-9", "--home", home, "--force"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("force release exit code = %d, stderr=%s", code, stderr.String())
+	}
+	events, err := store.ListBranchLockEvents(context.Background(), "owner/repo", "task-9")
+	if err != nil {
+		t.Fatalf("ListBranchLockEvents returned error: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "force_released" || events[0].Owner != "lead" {
+		t.Fatalf("force events = %+v", events)
+	}
+}
+
+func openCLILockStore(t *testing.T, home string) *db.Store {
+	t.Helper()
+	return openCLIJobStore(t, home)
+}
+
+func acquireCLILock(t *testing.T, store *db.Store, lock db.BranchLock) {
+	t.Helper()
+	acquired, err := store.AcquireLock(context.Background(), lock)
+	if err != nil {
+		t.Fatalf("AcquireLock returned error: %v", err)
+	}
+	if !acquired {
+		t.Fatalf("AcquireLock did not acquire %+v", lock)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,6 +30,7 @@ var rootCommands = []command{
 	{name: "goal", summary: "import or inspect goals", run: runGoal},
 	{name: "task", summary: "run or inspect tasks", run: runTask},
 	{name: "job", summary: "inspect and recover jobs", run: runJob},
+	{name: "lock", summary: "inspect and release branch locks", run: runLock},
 }
 
 func Run(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -53,7 +53,7 @@ func TestRunInitCreatesState(t *testing.T) {
 }
 
 func TestRunSubcommandHelpSucceeds(t *testing.T) {
-	for _, command := range []string{"init", "doctor", "version", "repo", "job"} {
+	for _, command := range []string{"init", "doctor", "version", "repo", "job", "lock"} {
 		t.Run(command, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -95,6 +96,14 @@ type BranchLock struct {
 	RepoFullName string
 	Branch       string
 	Owner        string
+}
+
+type BranchLockEvent struct {
+	RepoFullName string
+	Branch       string
+	Owner        string
+	Kind         string
+	Message      string
 }
 
 type MergeGate struct {
@@ -942,6 +951,31 @@ func (s *Store) GetBranchLock(ctx context.Context, repoFullName string, branch s
 	return lock, nil
 }
 
+func (s *Store) ListBranchLocks(ctx context.Context, repoFullName string) ([]BranchLock, error) {
+	query := `SELECT repo_full_name, branch, owner FROM branch_locks`
+	args := []any{}
+	if strings.TrimSpace(repoFullName) != "" {
+		query += ` WHERE repo_full_name = ?`
+		args = append(args, repoFullName)
+	}
+	query += ` ORDER BY repo_full_name, branch`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var locks []BranchLock
+	for rows.Next() {
+		var lock BranchLock
+		if err := rows.Scan(&lock.RepoFullName, &lock.Branch, &lock.Owner); err != nil {
+			return nil, err
+		}
+		locks = append(locks, lock)
+	}
+	return locks, rows.Err()
+}
+
 func (s *Store) ReleaseLock(ctx context.Context, lock BranchLock) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM branch_locks WHERE repo_full_name = ? AND branch = ? AND owner = ?`, lock.RepoFullName, lock.Branch, lock.Owner)
 	if err != nil {
@@ -952,6 +986,110 @@ func (s *Store) ReleaseLock(ctx context.Context, lock BranchLock) (bool, error) 
 		return false, err
 	}
 	return affected == 1, nil
+}
+
+func (s *Store) ReleaseLockWithEvent(ctx context.Context, lock BranchLock, event BranchLockEvent) (bool, error) {
+	return s.releaseLockWithEvent(ctx, lock, false, event)
+}
+
+func (s *Store) ForceReleaseLockWithEvent(ctx context.Context, repoFullName string, branch string, event BranchLockEvent) (BranchLock, bool, error) {
+	lock, err := s.GetBranchLock(ctx, repoFullName, branch)
+	if errors.Is(err, sql.ErrNoRows) {
+		return BranchLock{}, false, nil
+	}
+	if err != nil {
+		return BranchLock{}, false, err
+	}
+	released, err := s.releaseLockWithEvent(ctx, lock, true, event)
+	if err != nil {
+		return BranchLock{}, false, err
+	}
+	if !released {
+		return BranchLock{}, false, nil
+	}
+	return lock, true, nil
+}
+
+func (s *Store) releaseLockWithEvent(ctx context.Context, lock BranchLock, force bool, event BranchLockEvent) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	current := lock
+	if force || strings.TrimSpace(current.Owner) == "" {
+		row := tx.QueryRowContext(ctx, `SELECT repo_full_name, branch, owner FROM branch_locks WHERE repo_full_name = ? AND branch = ?`, lock.RepoFullName, lock.Branch)
+		if err := row.Scan(&current.RepoFullName, &current.Branch, &current.Owner); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return false, tx.Commit()
+			}
+			return false, err
+		}
+	}
+
+	query := `DELETE FROM branch_locks WHERE repo_full_name = ? AND branch = ? AND owner = ?`
+	args := []any{current.RepoFullName, current.Branch, current.Owner}
+	if force {
+		query = `DELETE FROM branch_locks WHERE repo_full_name = ? AND branch = ?`
+		args = []any{current.RepoFullName, current.Branch}
+	}
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		return false, tx.Commit()
+	}
+
+	event.RepoFullName = current.RepoFullName
+	event.Branch = current.Branch
+	event.Owner = current.Owner
+	if strings.TrimSpace(event.Kind) == "" {
+		event.Kind = "released"
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO lock_events(repo_full_name, branch, owner, kind, message)
+		VALUES (?, ?, ?, ?, ?)`, event.RepoFullName, event.Branch, event.Owner, event.Kind, event.Message); err != nil {
+		return false, err
+	}
+	return true, tx.Commit()
+}
+
+func (s *Store) ListBranchLockEvents(ctx context.Context, repoFullName string, branch string) ([]BranchLockEvent, error) {
+	query := `SELECT repo_full_name, branch, owner, kind, message FROM lock_events`
+	args := []any{}
+	conditions := []string{}
+	if strings.TrimSpace(repoFullName) != "" {
+		conditions = append(conditions, "repo_full_name = ?")
+		args = append(args, repoFullName)
+	}
+	if strings.TrimSpace(branch) != "" {
+		conditions = append(conditions, "branch = ?")
+		args = append(args, branch)
+	}
+	if len(conditions) > 0 {
+		query += ` WHERE ` + strings.Join(conditions, ` AND `)
+	}
+	query += ` ORDER BY rowid`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var events []BranchLockEvent
+	for rows.Next() {
+		var event BranchLockEvent
+		if err := rows.Scan(&event.RepoFullName, &event.Branch, &event.Owner, &event.Kind, &event.Message); err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
 }
 
 func (s *Store) UpsertMergeGate(ctx context.Context, gate MergeGate) error {
@@ -1160,5 +1298,16 @@ CREATE TABLE agent_repos (
 
 INSERT OR IGNORE INTO agent_repos(agent_name, repo_full_name)
 SELECT name, repo_scope FROM agents WHERE repo_scope <> '';
+	`,
+	`
+CREATE TABLE IF NOT EXISTS lock_events (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	repo_full_name TEXT NOT NULL,
+	branch TEXT NOT NULL,
+	owner TEXT NOT NULL,
+	kind TEXT NOT NULL,
+	message TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -25,6 +26,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"jobs",
 		"job_events",
 		"branch_locks",
+		"lock_events",
 		"merge_gates",
 		"agent_repos",
 	} {
@@ -357,12 +359,29 @@ func TestRepositoryMethods(t *testing.T) {
 	if released {
 		t.Fatal("wrong-owner ReleaseLock released lock")
 	}
-	released, err = store.ReleaseLock(ctx, BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task", Owner: "lead"})
+	released, err = store.ReleaseLockWithEvent(ctx, BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task", Owner: "lead"}, BranchLockEvent{Kind: "released", Message: "done"})
 	if err != nil {
-		t.Fatalf("ReleaseLock returned error: %v", err)
+		t.Fatalf("ReleaseLockWithEvent returned error: %v", err)
 	}
 	if !released {
 		t.Fatal("ReleaseLock did not release owned lock")
+	}
+	lockEvents, err := store.ListBranchLockEvents(ctx, "jerryfane/gitmoot", "task")
+	if err != nil {
+		t.Fatalf("ListBranchLockEvents returned error: %v", err)
+	}
+	if len(lockEvents) != 1 || lockEvents[0].Kind != "released" || lockEvents[0].Owner != "lead" {
+		t.Fatalf("lock events = %+v", lockEvents)
+	}
+	if acquired, err := store.AcquireLock(ctx, BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-force", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("force lock AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	releasedLock, released, err := store.ForceReleaseLockWithEvent(ctx, "jerryfane/gitmoot", "task-force", BranchLockEvent{Kind: "force_released", Message: "stale"})
+	if err != nil {
+		t.Fatalf("ForceReleaseLockWithEvent returned error: %v", err)
+	}
+	if !released || releasedLock.Owner != "lead" {
+		t.Fatalf("force release returned lock=%+v released=%v", releasedLock, released)
 	}
 	if err := store.UpsertMergeGate(ctx, MergeGate{RepoFullName: "jerryfane/gitmoot", PullRequest: 1, State: "pending", Reason: "waiting"}); err != nil {
 		t.Fatalf("UpsertMergeGate returned error: %v", err)
@@ -399,7 +418,14 @@ func TestMigrateCopiesAgentRepoScopeToAgentRepos(t *testing.T) {
 	store := &Store{db: raw}
 	defer store.Close()
 
-	for version, migration := range migrations[:len(migrations)-1] {
+	agentReposMigration := len(migrations) - 1
+	for i, migration := range migrations {
+		if strings.Contains(migration, "CREATE TABLE agent_repos") {
+			agentReposMigration = i
+			break
+		}
+	}
+	for version, migration := range migrations[:agentReposMigration] {
 		if err := store.applyMigration(ctx, version+1, migration); err != nil {
 			t.Fatalf("applyMigration(%d) returned error: %v", version+1, err)
 		}

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -139,7 +139,7 @@ func (g PolicyMergeGate) finishMerged(ctx context.Context, request MergeRequest,
 	postMergeWarnings := []string{}
 	lock, err := g.Store.GetBranchLock(ctx, request.Repo, pr.HeadRef)
 	if err == nil {
-		if _, err := g.Store.ReleaseLock(ctx, lock); err != nil {
+		if _, err := g.Store.ReleaseLockWithEvent(ctx, lock, db.BranchLockEvent{Kind: "released", Message: "released after pull request merge"}); err != nil {
 			postMergeWarnings = append(postMergeWarnings, "release branch lock: "+err.Error())
 		}
 	} else if !errors.Is(err, sql.ErrNoRows) {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -67,6 +67,13 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 	if _, err := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-9"); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("branch lock after merge error = %v, want sql.ErrNoRows", err)
 	}
+	lockEvents, err := store.ListBranchLockEvents(ctx, "jerryfane/gitmoot", "task-9")
+	if err != nil {
+		t.Fatalf("ListBranchLockEvents returned error: %v", err)
+	}
+	if len(lockEvents) != 1 || lockEvents[0].Kind != "released" || lockEvents[0].Owner != "lead" {
+		t.Fatalf("lock events = %+v", lockEvents)
+	}
 	pr, err := store.GetPullRequest(ctx, "jerryfane/gitmoot", 9)
 	if err != nil {
 		t.Fatalf("GetPullRequest returned error: %v", err)


### PR DESCRIPTION
WHAT: Added branch-lock inspection and recovery support.

WHY: Operators need a safe way to inspect and release stale branch locks in multi-repo workflows without direct database edits.

CHANGES:
- Added `gitmoot lock list/show/release`.
- Added exact-owner release and explicit `--force` release behavior.
- Added lock release events through a new `lock_events` table.
- Updated merge-gate lock release to record a release event after successful merge.
- Updated local workflow and troubleshooting docs with lock recovery commands.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/cli ./internal/workflow` passed.
- `git diff --check` passed.
- `GOTOOLCHAIN=go1.26.0 go test ./...` passed.
- `GOTOOLCHAIN=go1.26.0 go vet ./...` passed.
- `codex exec review --uncommitted` final raw output:

```text
codex
No discrete correctness issues were identified in the changed or untracked files. The new lock CLI and lock event persistence appear consistent with the existing store and merge-gate flows.
No discrete correctness issues were identified in the changed or untracked files. The new lock CLI and lock event persistence appear consistent with the existing store and merge-gate flows.
```

RISK: No known skipped checks. The review sandbox could not use local Go 1.22 for `GOTOOLCHAIN=local`, but explicit Go 1.26 test/vet commands passed.