### PR TITLE
feat: add version and update commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ gitmoot init
 gitmoot setup --repo owner/repo --path . --agent <name> --runtime codex|claude|shell --session <ref>
 gitmoot doctor --repo .
 gitmoot config path|show
+gitmoot version [--json]
+gitmoot update --check
+gitmoot update [--restart-daemon]
 gitmoot daemon start --repo owner/repo --poll 30s
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
 gitmoot agent list

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -25,6 +25,8 @@ gitmoot job show <job-id>
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>
 gitmoot status --repo owner/repo
+gitmoot version --json
+gitmoot update --check
 gitmoot daemon start --repo owner/repo --poll 30s
 ```
 
@@ -72,6 +74,13 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    gitmoot agent list
    gitmoot agent doctor lead
    gitmoot agent doctor audit
+   ```
+
+   To inspect the installed Gitmoot build or check for a beta release:
+
+   ```sh
+   gitmoot version
+   gitmoot update --check
    ```
 
 5. Start the daemon from the repository checkout.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,6 +24,7 @@ var rootCommands = []command{
 	{name: "doctor", summary: "check local Gitmoot prerequisites", run: runDoctor},
 	{name: "version", summary: "show Gitmoot version and build metadata", run: runVersion},
 	{name: "config", summary: "show local Gitmoot config paths", run: runConfig},
+	{name: "update", summary: "check for and apply Gitmoot releases", run: runUpdate},
 	{name: "setup", summary: "register a repo and initial agent", run: runSetup},
 	{name: "repo", summary: "manage watched repositories", run: runRepo},
 	{name: "daemon", summary: "run the local PR watcher", run: runDaemon},

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -53,7 +53,7 @@ func TestRunInitCreatesState(t *testing.T) {
 }
 
 func TestRunSubcommandHelpSucceeds(t *testing.T) {
-	for _, command := range []string{"init", "doctor", "version", "config", "setup", "repo", "events", "job", "lock"} {
+	for _, command := range []string{"init", "doctor", "version", "config", "update", "setup", "repo", "events", "job", "lock"} {
 		t.Run(command, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/update"
+)
+
+func runUpdate(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	checkOnly := fs.Bool("check", false, "check for the latest GitHub release without updating")
+	restartDaemon := fs.Bool("restart-daemon", false, "restart the daemon after a successful update")
+	repo := fs.String("repo", update.DefaultRepo, "GitHub repository to check for releases")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "update does not accept positional arguments")
+		return 2
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(stderr, "resolve executable: %v\n", err)
+		return 1
+	}
+	result, err := update.Check(context.Background(), update.GhReleaseClient{}, *repo, buildinfo.Current(), "", "", executable)
+	if err != nil {
+		fmt.Fprintf(stderr, "update check: %v\n", err)
+		return 1
+	}
+	printUpdateCheck(stdout, result)
+	if *checkOnly || result.UpToDate {
+		return 0
+	}
+
+	applied, err := update.Apply(context.Background(), nil, *repo, result, executable)
+	if err != nil {
+		fmt.Fprintf(stderr, "update: %v\n", err)
+		return 1
+	}
+	if !applied.Applied {
+		writeLine(stdout, "auto-update unavailable: %s", applied.Reason)
+		printManualCommands(stdout, result.ManualCommands)
+		if *restartDaemon {
+			writeLine(stdout, "daemon restart skipped: update was not applied")
+		}
+		return 0
+	}
+	writeLine(stdout, "updated gitmoot to %s", result.LatestVersion)
+	if !*restartDaemon {
+		return 0
+	}
+	return runDaemonRestartFromExecutable(executable, *home, stdout, stderr)
+}
+
+func printUpdateCheck(w io.Writer, result update.CheckResult) {
+	writeLine(w, "current: %s", result.CurrentVersion)
+	writeLine(w, "latest: %s", result.LatestVersion)
+	if result.ReleaseURL != "" {
+		writeLine(w, "release: %s", result.ReleaseURL)
+	}
+	if result.UpToDate {
+		writeLine(w, "status: up to date")
+		return
+	}
+	if result.NoRelease {
+		writeLine(w, "status: no release found")
+		return
+	}
+	writeLine(w, "status: update available")
+	if result.Asset != nil {
+		writeLine(w, "asset: %s", result.Asset.Name)
+	} else {
+		writeLine(w, "asset: no exact asset for this platform")
+	}
+}
+
+func printManualCommands(w io.Writer, commands []string) {
+	if len(commands) == 0 {
+		return
+	}
+	writeLine(w, "manual update commands:")
+	for _, command := range commands {
+		writeLine(w, "  %s", command)
+	}
+}
+
+func runDaemonRestartFromExecutable(executable string, home string, stdout, stderr io.Writer) int {
+	args := []string{"daemon", "restart"}
+	if home != "" {
+		args = append(args, "--home", home)
+	}
+	cmd := exec.CommandContext(context.Background(), executable, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(stderr, "daemon restart: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,345 @@
+package update
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+const DefaultRepo = "jerryfane/gitmoot"
+
+var ErrNoRelease = errors.New("no GitHub release found")
+
+type ReleaseClient interface {
+	LatestRelease(ctx context.Context, repo string) (Release, error)
+}
+
+type Release struct {
+	TagName    string  `json:"tag_name"`
+	Name       string  `json:"name"`
+	URL        string  `json:"html_url"`
+	Draft      bool    `json:"draft"`
+	Prerelease bool    `json:"prerelease"`
+	Assets     []Asset `json:"assets"`
+}
+
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Digest             string `json:"digest"`
+	Size               int64  `json:"size"`
+}
+
+type GhReleaseClient struct {
+	Runner subprocess.Runner
+	Dir    string
+}
+
+func (c GhReleaseClient) LatestRelease(ctx context.Context, repo string) (Release, error) {
+	runner := c.Runner
+	if runner == nil {
+		runner = subprocess.ExecRunner{}
+	}
+	result, err := runner.Run(ctx, c.Dir, "gh", "api", "repos/"+repo+"/releases?per_page=20")
+	if err != nil {
+		if isNotFound(result) {
+			return Release{}, ErrNoRelease
+		}
+		return Release{}, commandError(result, err)
+	}
+	var releases []Release
+	if err := json.Unmarshal([]byte(result.Stdout), &releases); err != nil {
+		return Release{}, fmt.Errorf("decode releases: %w", err)
+	}
+	for _, release := range releases {
+		if !release.Draft {
+			return release, nil
+		}
+	}
+	return Release{}, ErrNoRelease
+}
+
+type CheckResult struct {
+	CurrentVersion string
+	LatestVersion  string
+	ReleaseURL     string
+	UpToDate       bool
+	NoRelease      bool
+	Asset          *Asset
+	ManualCommands []string
+}
+
+func Check(ctx context.Context, client ReleaseClient, repo string, current buildinfo.Info, goos string, goarch string, executable string) (CheckResult, error) {
+	if strings.TrimSpace(repo) == "" {
+		repo = DefaultRepo
+	}
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	if goarch == "" {
+		goarch = runtime.GOARCH
+	}
+	release, err := client.LatestRelease(ctx, repo)
+	if errors.Is(err, ErrNoRelease) {
+		return CheckResult{
+			CurrentVersion: current.Version,
+			LatestVersion:  "none",
+			NoRelease:      true,
+			ManualCommands: []string{"gh release view --repo " + shellQuote(repo)},
+		}, nil
+	}
+	if err != nil {
+		return CheckResult{}, err
+	}
+	asset := matchingAsset(release.Assets, goos, goarch)
+	result := CheckResult{
+		CurrentVersion: current.Version,
+		LatestVersion:  release.TagName,
+		ReleaseURL:     release.URL,
+		Asset:          asset,
+		UpToDate:       sameVersion(current.Version, release.TagName),
+	}
+	result.ManualCommands = ManualCommands(repo, release.TagName, asset, executable)
+	return result, nil
+}
+
+type ApplyResult struct {
+	Applied bool
+	Reason  string
+}
+
+func Apply(ctx context.Context, runner subprocess.Runner, repo string, check CheckResult, executable string) (ApplyResult, error) {
+	if runner == nil {
+		runner = subprocess.ExecRunner{}
+	}
+	reason := unsafeReason(check, executable)
+	if reason != "" {
+		return ApplyResult{Reason: reason}, nil
+	}
+	tmpDir, err := os.MkdirTemp("", "gitmoot-update-*")
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	target := filepath.Join(tmpDir, "gitmoot")
+	_, err = runner.Run(ctx, "", "gh", "release", "download", check.LatestVersion, "--repo", repo, "--pattern", check.Asset.Name, "--output", target)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	if err := verifyDigest(target, check.Asset.Digest); err != nil {
+		return ApplyResult{}, err
+	}
+	if err := os.Chmod(target, 0o755); err != nil {
+		return ApplyResult{}, err
+	}
+	if err := replaceExecutable(target, executable); err != nil {
+		return ApplyResult{}, err
+	}
+	return ApplyResult{Applied: true}, nil
+}
+
+func ManualCommands(repo string, tag string, asset *Asset, executable string) []string {
+	if asset == nil {
+		return []string{
+			"gh release view " + shellQuote(tag) + " --repo " + shellQuote(repo),
+			"gh release download " + shellQuote(tag) + " --repo " + shellQuote(repo) + " --dir /tmp/gitmoot-update",
+		}
+	}
+	downloadPath := "/tmp/gitmoot-update/" + asset.Name
+	return []string{
+		"mkdir -p /tmp/gitmoot-update",
+		"gh release download " + shellQuote(tag) + " --repo " + shellQuote(repo) + " --pattern " + shellQuote(asset.Name) + " --output " + shellQuote(downloadPath),
+		"install -m 0755 " + shellQuote(downloadPath) + " " + shellExecutable(executable),
+	}
+}
+
+func matchingAsset(assets []Asset, goos string, goarch string) *Asset {
+	candidates := map[string]struct{}{}
+	for _, name := range assetCandidates(goos, goarch) {
+		candidates[name] = struct{}{}
+	}
+	for i := range assets {
+		if _, ok := candidates[assets[i].Name]; ok {
+			return &assets[i]
+		}
+	}
+	return nil
+}
+
+func assetCandidates(goos string, goarch string) []string {
+	names := []string{
+		"gitmoot_" + goos + "_" + goarch,
+		"gitmoot-" + goos + "-" + goarch,
+	}
+	if goos == "windows" {
+		names = append(names, "gitmoot_"+goos+"_"+goarch+".exe", "gitmoot-"+goos+"-"+goarch+".exe")
+	}
+	return names
+}
+
+func sameVersion(current string, latest string) bool {
+	current = strings.TrimPrefix(strings.TrimSpace(current), "v")
+	latest = strings.TrimPrefix(strings.TrimSpace(latest), "v")
+	return current != "" && latest != "" && current == latest
+}
+
+func unsafeReason(check CheckResult, executable string) string {
+	switch {
+	case check.NoRelease:
+		return "no GitHub release found"
+	case check.UpToDate:
+		return "already up to date"
+	case check.CurrentVersion == "" || check.CurrentVersion == "dev" || check.CurrentVersion == "unknown":
+		return "development builds are not auto-updated"
+	case check.Asset == nil:
+		return "no exact binary asset matched this platform"
+	case !strings.HasPrefix(check.Asset.Digest, "sha256:"):
+		return "release asset is missing a sha256 digest"
+	case runtime.GOOS == "windows":
+		return "in-place replacement is not supported on Windows"
+	case strings.TrimSpace(executable) == "":
+		return "could not resolve the current executable path"
+	}
+	if !filepath.IsAbs(executable) {
+		return "current executable path is not absolute"
+	}
+	info, err := os.Lstat(executable)
+	if err != nil {
+		return "current executable cannot be inspected: " + err.Error()
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "current executable is a symlink"
+	}
+	if !info.Mode().IsRegular() {
+		return "current executable is not a regular file"
+	}
+	if err := canWriteDir(filepath.Dir(executable)); err != nil {
+		return "install directory is not writable: " + err.Error()
+	}
+	return ""
+}
+
+func canWriteDir(dir string) error {
+	file, err := os.CreateTemp(dir, ".gitmoot-update-check-*")
+	if err != nil {
+		return err
+	}
+	name := file.Name()
+	closeErr := file.Close()
+	removeErr := os.Remove(name)
+	if closeErr != nil {
+		return closeErr
+	}
+	return removeErr
+}
+
+func verifyDigest(path string, digest string) error {
+	if !strings.HasPrefix(digest, "sha256:") {
+		return errors.New("asset digest must use sha256")
+	}
+	want := strings.TrimPrefix(digest, "sha256:")
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return err
+	}
+	got := hex.EncodeToString(hash.Sum(nil))
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("sha256 mismatch: got %s want %s", got, want)
+	}
+	return nil
+}
+
+func replaceExecutable(source string, target string) error {
+	dir := filepath.Dir(target)
+	tmp, err := os.CreateTemp(dir, ".gitmoot-new-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	input, err := os.Open(source)
+	if err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := io.Copy(tmp, input); err != nil {
+		_ = input.Close()
+		_ = tmp.Close()
+		return err
+	}
+	if err := input.Close(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o755); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	backup := target + ".old"
+	_ = os.Remove(backup)
+	if err := os.Rename(target, backup); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, target); err != nil {
+		_ = os.Rename(backup, target)
+		return err
+	}
+	return os.Remove(backup)
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if strings.IndexFunc(value, func(r rune) bool {
+		return !(r == '/' || r == '.' || r == '-' || r == '_' || r == ':' || r == '@' || r == '+' || r == '=' || r >= '0' && r <= '9' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z')
+	}) == -1 {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func shellExecutable(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "$(command -v gitmoot)"
+	}
+	return shellQuote(value)
+}
+
+func commandError(result subprocess.Result, err error) error {
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	if detail == "" {
+		return err
+	}
+	return fmt.Errorf("%s: %w", detail, err)
+}
+
+func isNotFound(result subprocess.Result) bool {
+	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	return strings.Contains(text, "http 404") || strings.Contains(text, "not found")
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,197 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+func TestGhReleaseClientQueriesLatestRelease(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{
+		Stdout: `[
+			{"tag_name":"v0.1.0-beta.1","html_url":"https://github.com/jerryfane/gitmoot/releases/tag/v0.1.0-beta.1","prerelease":true,"assets":[{"name":"gitmoot_linux_amd64","browser_download_url":"https://example.com/gitmoot","digest":"sha256:abc","size":12}]}
+		]`,
+	}}}
+	client := GhReleaseClient{Runner: runner}
+
+	release, err := client.LatestRelease(context.Background(), DefaultRepo)
+
+	if err != nil {
+		t.Fatalf("LatestRelease returned error: %v", err)
+	}
+	if release.TagName != "v0.1.0-beta.1" || len(release.Assets) != 1 {
+		t.Fatalf("release = %+v", release)
+	}
+	runner.wantArgs(t, 0, "gh", "api", "repos/jerryfane/gitmoot/releases?per_page=20")
+}
+
+func TestGhReleaseClientMapsLatestReleaseNotFound(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "HTTP 404: Not Found"}},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	client := GhReleaseClient{Runner: runner}
+
+	_, err := client.LatestRelease(context.Background(), DefaultRepo)
+
+	if !errors.Is(err, ErrNoRelease) {
+		t.Fatalf("error = %v, want ErrNoRelease", err)
+	}
+}
+
+func TestCheckReportsMissingRelease(t *testing.T) {
+	client := fakeReleaseClient{err: ErrNoRelease}
+
+	result, err := Check(context.Background(), client, DefaultRepo, buildinfo.Info{Version: "dev"}, "linux", "amd64", "")
+
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !result.NoRelease || result.LatestVersion != "none" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestCheckFindsPlatformAssetAndManualCommands(t *testing.T) {
+	client := fakeReleaseClient{release: Release{
+		TagName: "v0.1.0-beta.1",
+		URL:     "https://github.com/jerryfane/gitmoot/releases/tag/v0.1.0-beta.1",
+		Assets:  []Asset{{Name: "gitmoot_linux_amd64", Digest: "sha256:abc"}},
+	}}
+
+	result, err := Check(context.Background(), client, DefaultRepo, buildinfo.Info{Version: "v0.1.0-beta.0"}, "linux", "amd64", "/usr/local/bin/gitmoot")
+
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if result.UpToDate {
+		t.Fatal("result was up to date")
+	}
+	if result.Asset == nil || result.Asset.Name != "gitmoot_linux_amd64" {
+		t.Fatalf("asset = %+v", result.Asset)
+	}
+	want := "gh release download v0.1.0-beta.1 --repo jerryfane/gitmoot --pattern gitmoot_linux_amd64 --output /tmp/gitmoot-update/gitmoot_linux_amd64"
+	if !contains(result.ManualCommands, want) {
+		t.Fatalf("manual commands = %+v, missing %q", result.ManualCommands, want)
+	}
+}
+
+func TestManualCommandsKeepExecutableFallbackUsable(t *testing.T) {
+	commands := ManualCommands(DefaultRepo, "v0.1.0-beta.1", &Asset{Name: "gitmoot_linux_amd64"}, "")
+
+	want := "install -m 0755 /tmp/gitmoot-update/gitmoot_linux_amd64 $(command -v gitmoot)"
+	if !contains(commands, want) {
+		t.Fatalf("manual commands = %+v, missing %q", commands, want)
+	}
+}
+
+func TestCheckMarksSameVersionUpToDate(t *testing.T) {
+	client := fakeReleaseClient{release: Release{TagName: "v0.1.0-beta.1"}}
+
+	result, err := Check(context.Background(), client, DefaultRepo, buildinfo.Info{Version: "0.1.0-beta.1"}, "linux", "amd64", "")
+
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !result.UpToDate {
+		t.Fatalf("result was not up to date: %+v", result)
+	}
+}
+
+func TestApplyRefusesUnsafeDevelopmentBuild(t *testing.T) {
+	result := CheckResult{
+		CurrentVersion: "dev",
+		LatestVersion:  "v0.1.0-beta.1",
+		Asset:          &Asset{Name: "gitmoot_linux_amd64", Digest: "sha256:abc"},
+	}
+	runner := &fakeRunner{}
+
+	applied, err := Apply(context.Background(), runner, DefaultRepo, result, "/usr/local/bin/gitmoot")
+
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if applied.Applied || !strings.Contains(applied.Reason, "development builds") {
+		t.Fatalf("applied = %+v", applied)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %+v, want none", runner.calls)
+	}
+}
+
+func TestApplyRefusesMissingDigest(t *testing.T) {
+	result := CheckResult{
+		CurrentVersion: "v0.1.0-beta.0",
+		LatestVersion:  "v0.1.0-beta.1",
+		Asset:          &Asset{Name: "gitmoot_linux_amd64"},
+	}
+
+	applied, err := Apply(context.Background(), &fakeRunner{}, DefaultRepo, result, "/usr/local/bin/gitmoot")
+
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if applied.Applied || !strings.Contains(applied.Reason, "sha256") {
+		t.Fatalf("applied = %+v", applied)
+	}
+}
+
+type fakeReleaseClient struct {
+	release Release
+	err     error
+}
+
+func (f fakeReleaseClient) LatestRelease(context.Context, string) (Release, error) {
+	return f.release, f.err
+}
+
+type fakeRunner struct {
+	results []subprocess.Result
+	errs    []error
+	calls   [][]string
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	call := append([]string{command}, args...)
+	f.calls = append(f.calls, call)
+	index := len(f.calls) - 1
+	result := subprocess.Result{Command: command, Args: args}
+	if index < len(f.results) {
+		result = f.results[index]
+		result.Command = command
+		result.Args = args
+	}
+	var err error
+	if index < len(f.errs) {
+		err = f.errs[index]
+	}
+	return result, err
+}
+
+func (f *fakeRunner) LookPath(string) (string, error) {
+	return "", errors.New("not found")
+}
+
+func (f *fakeRunner) wantArgs(t *testing.T, index int, want ...string) {
+	t.Helper()
+	if index >= len(f.calls) {
+		t.Fatalf("missing call %d; calls=%v", index, f.calls)
+	}
+	if !reflect.DeepEqual(f.calls[index], want) {
+		t.Fatalf("call %d = %s\nwant %s", index, strings.Join(f.calls[index], " "), strings.Join(want, " "))
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
WHAT:
Added Gitmoot update support alongside the existing version command surface.

WHY:
Beta users need a local way to inspect their installed build, check for GitHub release updates, and update conservatively without requiring a hosted service.

CHANGES:
- Added `gitmoot update --check`, `gitmoot update`, and `gitmoot update --restart-daemon`.
- Added an `internal/update` package for GitHub release lookup, platform asset matching, digest verification, safe executable replacement, and manual fallback commands.
- Release lookup lists GitHub releases so beta prereleases are visible, while draft releases are skipped.
- Auto-update only proceeds for non-development builds with an exact platform asset, sha256 digest, regular executable path, and writable install directory.
- Manual update commands are printed whenever auto-update is not provably safe.
- `--restart-daemon` restarts through the installed binary path after replacement instead of rediscovering the executable from the old process.
- Documented `version` and `update` in README/local workflow docs.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./internal/update`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli ./internal/update`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli`
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `GOTOOLCHAIN=go1.26.0 go vet ./...`
- `GOTOOLCHAIN=go1.26.0 go run ./cmd/gitmoot version`
- `GOTOOLCHAIN=go1.26.0 go run ./cmd/gitmoot update --check` returned `latest: none` because this repo has no release yet.
- `git diff --check`
- `git diff --cached --check`
- `codex exec review --uncommitted` final raw output:

```text
No discrete correctness issues were found in the staged, unstaged, or untracked changes. Tests could not be run in this sandbox because the required Go 1.26 toolchain could not be downloaded.
No discrete correctness issues were found in the staged, unstaged, or untracked changes. Tests could not be run in this sandbox because the required Go 1.26 toolchain could not be downloaded.
```

RISK:
- The review tool could not run tests in its sandbox due Go 1.26 toolchain download limits. Explicit local Go 1.26 test, vet, version, and update-check commands passed.
- No release exists yet, so live `update --check` verifies the no-release path rather than downloading an asset.
