### PR TITLE
docs: add gitmoot agent skill

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: gitmoot-agent
+description: Use Gitmoot to coordinate local AI agent sessions through GitHub pull requests, including PR commands, repo access, branch locks, job results, and safe agent behavior.
+version: 0.1.0
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - gitmoot
+        - git
+        - gh
+    envVars:
+      - name: GH_TOKEN
+        required: false
+        description: Optional GitHub token used by gh when GitHub CLI is not already authenticated.
+---
+
+# Gitmoot Agent Skill
+
+Gitmoot is a local-first coordinator for AI agents working through GitHub pull
+requests. A local `gitmoot daemon` watches PR comments, routes jobs to allowed
+agents, records job state in local SQLite, and posts attributed results back to
+the PR.
+
+## Core Workflow
+
+Use GitHub PR comments as the public audit trail. Local Gitmoot state is the
+workflow source of truth.
+
+Common PR commands:
+
+```text
+/gitmoot help
+/gitmoot status
+/gitmoot <agent> review [instructions]
+/gitmoot <agent> implement [instructions]
+/gitmoot ask <agent> [question]
+/gitmoot retry <job-id>
+/gitmoot cancel <job-id>
+/gitmoot merge
+```
+
+When unsure which agents or commands are available, ask for `/gitmoot help` or
+run local status commands before acting.
+
+## Required Result Contract
+
+Every agent job must return a `gitmoot_result` JSON object. Keep it concise and
+truthful.
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved|changes_requested|blocked|implemented|failed",
+    "summary": "Brief outcome.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "next_agents": []
+  }
+}
+```
+
+Use `blocked` when work cannot continue without human input or external state.
+Use `failed` when the attempted action errored. Do not report tests or changes
+that were not actually run or made.
+
+## Repo Access And Locks
+
+Agents are global identities with explicit per-repo access. A PR's repository is
+the routing context for `/gitmoot <agent> ...`.
+
+Implementation jobs must respect branch locks. Do not edit or push an
+implementation branch unless Gitmoot assigned the job and the branch lock is
+held by the assigned agent. Review and ask jobs should inspect and report
+without mutating the branch unless the task explicitly instructs otherwise.
+
+Useful local commands:
+
+```sh
+gitmoot status --repo owner/repo
+gitmoot events --repo owner/repo
+gitmoot job list --repo owner/repo
+gitmoot job show <job-id>
+gitmoot job events <job-id>
+gitmoot lock list --repo owner/repo
+gitmoot lock show owner/repo <branch>
+```
+
+## Safe Agent Behavior
+
+- Preserve existing behavior unless the job explicitly changes it.
+- Keep changes scoped to the job and the target repo.
+- Do not commit generated data, caches, logs, secrets, session archives, cloned
+  helper repos, or large outputs unless explicitly requested.
+- Verify external APIs, CLIs, env vars, generated scripts, and service launchers
+  with local commands or official docs before editing.
+- Redact secrets from summaries, comments, and raw examples.
+- If a Gitmoot instruction is unclear, reread this `SKILL.md`, then inspect
+  `/gitmoot help`, `gitmoot status`, and relevant job events.

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,0 +1,64 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRootSkillFrontmatter(t *testing.T) {
+	contents, err := os.ReadFile(filepath.Join("..", "..", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	text := string(contents)
+	if !strings.HasPrefix(text, "---\n") {
+		t.Fatal("SKILL.md missing YAML frontmatter opener")
+	}
+	parts := strings.SplitN(text, "---\n", 3)
+	if len(parts) != 3 {
+		t.Fatal("SKILL.md missing YAML frontmatter closer")
+	}
+	frontmatter := parts[1]
+	for _, want := range []string{
+		"name: gitmoot-agent",
+		"description: Use Gitmoot",
+		"version: 0.1.0",
+		"metadata:",
+		"openclaw:",
+		"requires:",
+		"bins:",
+		"- gitmoot",
+		"- git",
+		"- gh",
+		"envVars:",
+		"- name: GH_TOKEN",
+		"required: false",
+	} {
+		if !strings.Contains(frontmatter, want) {
+			t.Fatalf("frontmatter missing %q:\n%s", want, frontmatter)
+		}
+	}
+	if strings.Contains(frontmatter, "requires:\n      env:") || strings.Contains(frontmatter, "requires.env") {
+		t.Fatalf("optional GH_TOKEN must not be declared as required env:\n%s", frontmatter)
+	}
+}
+
+func TestRootSkillDocumentsGitmootResultAndRereadGuidance(t *testing.T) {
+	contents, err := os.ReadFile(filepath.Join("..", "..", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	text := string(contents)
+	for _, want := range []string{
+		"gitmoot_result",
+		"approved|changes_requested|blocked|implemented|failed",
+		"branch locks",
+		"reread this `SKILL.md`",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("SKILL.md missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
WHAT:
Added root `SKILL.md` documentation for agents using Gitmoot.

WHY:
Agents need a compact, rereadable contract for how Gitmoot expects PR-command work, repo access, branch locks, and job results to behave.

CHANGES:
- Added OpenClaw-compatible `SKILL.md` frontmatter with `name`, `description`, `version`, `metadata.openclaw.requires.bins`, and optional `GH_TOKEN` env var metadata.
- Documented Gitmoot's PR comment workflow, required `gitmoot_result` JSON contract, repo access, branch-lock expectations, debug/status commands, and safe agent behavior.
- Added lightweight tests that validate the root skill frontmatter and core body requirements.

RESULTS:
- Verified OpenClaw skill format from official docs before editing.
- `GOTOOLCHAIN=go1.26.0 go test ./internal/skill`
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `GOTOOLCHAIN=go1.26.0 go vet ./...`
- `git diff --check`
- `git diff --cached --check`
- `codex exec review --uncommitted` final raw output:

```text
The untracked changes add the requested root SKILL.md and lightweight validation tests. I did not find any discrete correctness issues in the changed files.
The untracked changes add the requested root SKILL.md and lightweight validation tests. I did not find any discrete correctness issues in the changed files.
```

RISK:
- Docs-only behavior change plus lightweight validation. No runtime behavior changed.
