### PR TITLE
docs: document beta workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ gitmoot config path|show
 gitmoot version [--json]
 gitmoot update --check
 gitmoot update [--restart-daemon]
-gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon start [--repo owner/repo] [--poll 30s]
+gitmoot daemon run [--repo owner/repo] [--poll 30s]
+gitmoot daemon stop|restart|status|logs
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
+gitmoot agent allow|deny|repos
 gitmoot agent list
 gitmoot agent doctor <name>
 gitmoot agent remove <name>
@@ -45,11 +48,23 @@ gitmoot job list|show|events|run|retry|cancel
 gitmoot lock list|show|release
 ```
 
+Agents should read [SKILL.md](SKILL.md) for the Gitmoot job contract, branch
+lock expectations, and safe behavior rules.
+
 ## Documentation
 
 - [Local workflow walkthrough](docs/local-workflow.md)
+- [Beta smoke tests](docs/beta-smoke-tests.md)
 - [Runtime adapter authoring](docs/adapters.md)
 - [Troubleshooting](docs/troubleshooting.md)
+
+## V1 Limits
+
+- Local-only: no hosted dashboard, GitHub App bot identity, cloud runner, or
+  remote control plane.
+- Polling watches GitHub PRs; there is no webhook receiver in V1.
+- GitHub comments are authored by the authenticated `gh` user. Agent identity
+  appears in the comment body.
 
 ## Development
 

--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -1,0 +1,154 @@
+# Beta Smoke Tests
+
+Use these smoke tests before cutting a beta release. They verify the local V1
+loop without a hosted service or webhook receiver.
+
+## Prerequisites
+
+Run from each repository checkout that will be watched:
+
+```sh
+git status --short
+git remote -v
+gh auth status
+gitmoot doctor --repo .
+```
+
+Use a test repository or a disposable branch. Keep generated logs, cloned
+helper repos, session archives, and large outputs untracked.
+
+## One-Repo Smoke Test
+
+Goal: PR comment -> queued ask job -> adapter result -> attributed PR comment
+-> local job status update. This intentionally uses `ask`, not `review`, so
+the smoke test cannot approve or merge the PR.
+
+1. Register the repo and a shell smoke agent.
+
+   ```sh
+   gitmoot setup --repo owner/project --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"shell ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"next_agents\":[]}}'"
+   gitmoot agent repos shell-smoke
+   ```
+
+2. Start the background daemon.
+
+   ```sh
+   gitmoot daemon start --repo owner/project --poll 30s
+   gitmoot daemon status
+   ```
+
+3. Open a small test PR in `owner/project`, then comment:
+
+   ```text
+   /gitmoot help
+   /gitmoot shell-smoke ask smoke test routing
+   ```
+
+4. Confirm the job was queued and completed.
+
+   ```sh
+   gitmoot job list --repo owner/project
+   gitmoot events --repo owner/project
+   gh pr view <number> --repo owner/project --comments
+   ```
+
+Expected signals:
+
+- The PR receives a Gitmoot queued-job acknowledgement.
+- `gitmoot job list --repo owner/project` shows the job as succeeded.
+- The PR receives a result comment with:
+
+  ```md
+  > Agent: `shell-smoke`
+  > Runtime: `shell`
+  > Job: `...`
+  ```
+
+- `gitmoot events --repo owner/project` shows the queued/running/succeeded
+  job events.
+
+5. Stop the daemon when finished.
+
+   ```sh
+   gitmoot daemon stop
+   gitmoot daemon status
+   ```
+
+## Two-Repo Smoke Test
+
+Goal: one daemon -> two registered repos -> same allowed agent -> ask jobs in
+each repo -> no cross-routing. This intentionally avoids approving reviews.
+
+1. Register both repos with the same agent identity.
+
+   ```sh
+   cd /path/to/project-a
+   gitmoot setup --repo owner/project-a --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"repo ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"next_agents\":[]}}'"
+
+   cd /path/to/project-b
+   gitmoot setup --repo owner/project-b --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"repo ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"next_agents\":[]}}'"
+
+   gitmoot agent repos shell-smoke
+   ```
+
+2. Start one daemon for all enabled repos.
+
+   ```sh
+   gitmoot daemon start
+   gitmoot daemon status
+   gitmoot status
+   ```
+
+3. Open one test PR in each repo. Comment in each PR:
+
+   ```text
+   /gitmoot shell-smoke ask repo routing smoke
+   ```
+
+4. Verify each repo saw only its own job.
+
+   ```sh
+   gitmoot job list --repo owner/project-a
+   gitmoot job list --repo owner/project-b
+   gitmoot events --repo owner/project-a
+   gitmoot events --repo owner/project-b
+   gh pr view <project-a-pr> --repo owner/project-a --comments
+   gh pr view <project-b-pr> --repo owner/project-b --comments
+   ```
+
+Expected signals:
+
+- Each PR receives exactly the acknowledgement and result for its own comment.
+- `gitmoot job list --repo owner/project-a` does not show project B jobs.
+- `gitmoot job list --repo owner/project-b` does not show project A jobs.
+- The same agent name is allowed on both repos:
+
+  ```sh
+  gitmoot agent repos shell-smoke
+  ```
+
+## Recovery Checks
+
+Run these against one smoke job if you need to verify recovery UX:
+
+```sh
+gitmoot job show <job-id>
+gitmoot job events <job-id>
+gitmoot job retry <job-id>
+gitmoot job cancel <job-id>
+gitmoot lock list --repo owner/project
+gitmoot lock show owner/project <branch>
+```
+
+Only retry failed, blocked, or cancelled jobs. Only cancel queued or running
+jobs. Use `gitmoot lock release owner/project <branch> --owner <agent>` for an
+exact-owner stale lock; use `--force` only when the stored owner is stale.
+
+## Known V1 Limits
+
+- Local-only: the machine running the daemon must stay online.
+- Polling watches GitHub; there is no webhook receiver.
+- GitHub comments are authored by the authenticated `gh` user, not a bot.
+- Agent identity is shown in the comment body.
+- There is no hosted dashboard, GitHub App bot identity, cloud runner, billing,
+  or remote control plane.

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -8,14 +8,15 @@ statuses, and merges only after the merge gate passes.
 
 ## What Exists Today
 
-The current CLI supports local state initialization, prerequisite checks, agent
-registration, agent health checks, plan import, task branch startup, status,
-and the daemon:
+The current CLI supports local setup, multi-repo daemon management, agent
+registration, plan import, task branch startup, status, recovery, and updates:
 
 ```sh
-gitmoot init
+gitmoot setup --repo owner/repo --path . --agent lead --runtime codex --session <session-ref> --role lead
 gitmoot doctor --repo .
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
+gitmoot agent allow <name> --repo owner/repo
+gitmoot agent repos <name>
 gitmoot agent list
 gitmoot agent doctor <name>
 gitmoot goal import --file GOAL.md --repo owner/repo
@@ -28,6 +29,8 @@ gitmoot status --repo owner/repo
 gitmoot version --json
 gitmoot update --check
 gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon start
+gitmoot daemon status
 ```
 
 Goal import turns Markdown headings shaped like `### Task N: Title` into local
@@ -66,10 +69,8 @@ planned tasks. `task run` starts one task branch and records its branch lock.
 4. Initialize Gitmoot state and subscribe the agents.
 
    ```sh
-   gitmoot setup --repo owner/project --path . --agent lead --runtime codex --session <codex-session-id>
-   gitmoot init
+   gitmoot setup --repo owner/project --path . --agent lead --runtime codex --session <codex-session-id> --role lead
    gitmoot doctor --repo .
-   gitmoot agent subscribe lead --runtime codex --session <codex-session-id> --role lead --repo owner/project --capability implement --capability review --capability ask
    gitmoot agent subscribe audit --runtime claude --session <claude-session-id> --role reviewer --repo owner/project --capability review --capability ask
    gitmoot agent list
    gitmoot agent doctor lead
@@ -90,7 +91,8 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    ```
 
    The daemon validates that the current checkout's `origin` remote matches
-   `--repo`. Keep it running while the workflow is active.
+   `--repo`. Use `gitmoot daemon start` without `--repo` after registering all
+   intended repos if one daemon should supervise the whole Gitmoot home.
 
 6. Start and open the first task PR.
 
@@ -122,6 +124,9 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    Stale branch locks can be inspected and released locally:
 
    ```sh
+   gitmoot job list --repo owner/project
+   gitmoot job show <job-id>
+   gitmoot job events <job-id>
    gitmoot lock list --repo owner/project
    gitmoot lock show owner/project <branch>
    gitmoot lock release owner/project <branch> --owner <agent>
@@ -153,6 +158,37 @@ planned tasks. `task run` starts one task branch and records its branch lock.
   remains the workflow source of truth.
 - There is no hosted dashboard, cloud runner, billing, or remote control plane
   in V1.
+- GitHub comments are authored by the authenticated user. Agent attribution is
+  written in the comment body.
+
+## Multi-Repo Supervision
+
+One daemon can supervise multiple enabled repos for the same Gitmoot home.
+Register each checkout explicitly and grant agents repo access explicitly:
+
+```sh
+cd /path/to/project-a
+gitmoot setup --repo owner/project-a --path . --agent lead --runtime codex --session <session-ref> --role lead
+
+cd /path/to/project-b
+gitmoot setup --repo owner/project-b --path . --agent lead --runtime codex --session <same-session-or-explicit-ref> --role lead
+
+gitmoot agent repos lead
+gitmoot daemon start
+gitmoot status
+```
+
+The PR repository supplies routing context. `/gitmoot lead review` in
+`owner/project-a` queues work for `owner/project-a`; the same command in
+`owner/project-b` queues work for `owner/project-b` if `lead` is allowed there.
+
+## Skill Usage
+
+Agents should read the root [`SKILL.md`](../SKILL.md) before working through
+Gitmoot. The skill documents PR commands, the required `gitmoot_result` JSON
+contract, branch lock rules, repo access, and safe agent behavior. If an agent
+is unsure how Gitmoot expects it to behave, it should reread `SKILL.md`, then
+inspect `/gitmoot help`, `gitmoot status`, and relevant job events.
 
 ## Agent Output Contract
 


### PR DESCRIPTION
WHAT: Documented the beta local workflow, multi-repo daemon operation, worker execution, recovery commands, update/version commands, and agent skill usage.

WHY: The beta needs clear operator docs for one-machine multi-repo Gitmoot workflows before release.

CHANGES:
- Expanded README command surface, documentation links, skill reference, and V1 limits.
- Updated docs/local-workflow.md for setup, multi-repo daemon management, job/lock recovery, update/version, and skill usage.
- Added docs/beta-smoke-tests.md with one-repo and two-repo live smoke-test guides that use non-merge ask jobs.

RESULTS:
- GOTOOLCHAIN=go1.26.0 go test ./...: passed
- GOTOOLCHAIN=go1.26.0 go vet ./...: passed
- git diff --check: passed
- Docs command snippets inspected against current CLI help and implementation.
- codex exec review --uncommitted final raw output:

```text
The changes are documentation-only and align with the current CLI command surface and behavior. I did not identify any actionable correctness issues introduced by the modified or untracked files.
```

RISK:
- Smoke tests are documented but not executed against live GitHub in this task.
