### PR TITLE
chore: prepare v0.1.0-beta.1

### DIFF
--- a/docs/release-notes/v0.1.0-beta.1.md
+++ b/docs/release-notes/v0.1.0-beta.1.md
@@ -1,0 +1,38 @@
+# Gitmoot v0.1.0-beta.1
+
+Gitmoot v0.1.0-beta.1 is the first local-first beta for coordinating AI agent
+sessions through GitHub pull requests.
+
+## Features
+
+- Local SQLite workflow state for repos, agents, goals, tasks, jobs, PRs, and
+  branch locks.
+- Runtime-neutral agent registry with Codex, Claude Code, and shell adapters.
+- Multi-repo daemon mode for watching all enabled repositories from one
+  Gitmoot home.
+- Repo-scoped agent access so one global agent identity can work across
+  multiple allowed repos without cross-routing.
+- PR comment commands for help, status, agent ask/review/implement jobs, merge
+  requests, retries, and cancellation.
+- Background daemon management with start, run, stop, restart, status, and logs.
+- Worker loop that executes queued jobs, records raw output locally, advances
+  workflow state, and posts attributed PR result comments.
+- Branch lock commands for inspecting and releasing stale implementation locks.
+- Job recovery commands for listing, showing, retrying, cancelling, and
+  inspecting job events.
+- Version and update commands backed by GitHub Releases, with conservative
+  manual fallback commands when self-update is not safe.
+- Agent-facing `SKILL.md` covering Gitmoot commands, output contracts, and safe
+  behavior rules.
+- Live smoke-test documentation for one-repo and two-repo local workflows.
+
+## Known V1 Limits
+
+- Gitmoot runs locally; the daemon host must stay online.
+- GitHub is polled; there is no webhook receiver in this beta.
+- PR comments are authored by the authenticated GitHub user, with agent
+  attribution in the comment body.
+- There is no hosted dashboard, GitHub App bot identity, cloud runner, billing,
+  or remote control plane.
+- GitHub Checks are not used in V1; Gitmoot uses PR comments and commit
+  statuses where appropriate.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"strconv"
 	"strings"
@@ -398,19 +399,30 @@ func (c *GhClient) apiJSON(ctx context.Context, mutate bool, output any, args ..
 }
 
 func apiPaginatedJSON[T any](ctx context.Context, c *GhClient, args ...string) ([]T, error) {
-	result, err := c.run(ctx, false, append([]string{"api", "--paginate", "--slurp"}, args...)...)
+	result, err := c.run(ctx, false, append([]string{"api", "--paginate"}, args...)...)
 	if err != nil {
 		return nil, err
 	}
-	var pages [][]T
-	if err := json.Unmarshal([]byte(result.Stdout), &pages); err != nil {
+	values, err := decodePaginatedJSON[T](result.Stdout)
+	if err != nil {
 		return nil, fmt.Errorf("decode paginated gh api response: %w", err)
 	}
+	return values, nil
+}
+
+func decodePaginatedJSON[T any](output string) ([]T, error) {
+	decoder := json.NewDecoder(strings.NewReader(output))
 	var values []T
-	for _, page := range pages {
+	for {
+		var page []T
+		if err := decoder.Decode(&page); err != nil {
+			if errors.Is(err, io.EOF) {
+				return values, nil
+			}
+			return nil, err
+		}
 		values = append(values, page...)
 	}
-	return values, nil
 }
 
 func (c *GhClient) run(ctx context.Context, mutate bool, args ...string) (subprocess.Result, error) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -15,13 +15,11 @@ func TestListIssueCommentsDedupesByID(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{
 			Stdout: `[
-				[
-					{"id": 11, "body": "first", "html_url": "https://example.com/1", "user": {"login": "alice"}},
-					{"id": 11, "body": "duplicate", "html_url": "https://example.com/1", "user": {"login": "alice"}}
-				],
-				[
-					{"id": 12, "body": "second", "html_url": "https://example.com/2", "user": {"login": "bob"}}
-				]
+				{"id": 11, "body": "first", "html_url": "https://example.com/1", "user": {"login": "alice"}},
+				{"id": 11, "body": "duplicate", "html_url": "https://example.com/1", "user": {"login": "alice"}}
+			]
+			[
+				{"id": 12, "body": "second", "html_url": "https://example.com/2", "user": {"login": "bob"}}
 			]`,
 		}},
 	}
@@ -38,7 +36,7 @@ func TestListIssueCommentsDedupesByID(t *testing.T) {
 	if comments[0].Body != "first" || comments[1].Author != "bob" {
 		t.Fatalf("comments were not decoded in first-seen order: %+v", comments)
 	}
-	runner.wantArgs(t, 0, "api", "--paginate", "--slurp", "repos/jerryfane/gitmoot/issues/2/comments")
+	runner.wantArgs(t, 0, "api", "--paginate", "repos/jerryfane/gitmoot/issues/2/comments")
 }
 
 func TestPostIssueCommentUsesIssueCommentsEndpoint(t *testing.T) {


### PR DESCRIPTION
WHAT: Prepared v0.1.0-beta.1 release notes and fixed the GitHub CLI pagination path required by live daemon polling.

WHY: The first beta release requires successful live one-repo and two-repo smoke tests. The smoke exposed that this machine's GitHub CLI supports `gh api --paginate` but not `--slurp`, so paginated API decoding needed to match the installed CLI contract.

CHANGES:
- Added docs/release-notes/v0.1.0-beta.1.md with beta features and known V1 limits.
- Changed GitHub paginated API calls from `gh api --paginate --slurp` to `gh api --paginate`.
- Added decoding for concatenated paginated JSON arrays emitted by `gh api --paginate`.
- Updated the pagination unit test to cover multi-page concatenated arrays.

RESULTS:
- GOTOOLCHAIN=go1.26.0 go test ./internal/github: passed
- GOTOOLCHAIN=go1.26.0 go test ./...: passed
- GOTOOLCHAIN=go1.26.0 go vet ./...: passed
- git diff --check: passed
- Generated/tracked-file audit: no `repos/`, SQLite DBs, logs, session archives, secrets, tokens, or `/tmp` smoke outputs are tracked.
- GitHub CLI contract check: `gh version` is 2.45.0 and `gh api --help` documents `--paginate` but not `--slurp`.
- Live one-repo smoke:
  - Disposable PR: https://github.com/jerryfane/gitmoot/pull/25, now closed and branch deleted.
  - Commands included: `gitmoot setup --home /tmp/gitmoot-beta-smoke/home --repo jerryfane/gitmoot --path . --agent shell-smoke --runtime shell --session <shell gitmoot_result command>`, `gitmoot daemon start --home /tmp/gitmoot-beta-smoke/home --repo jerryfane/gitmoot --poll 2s`, and PR comment `/gitmoot ask shell-smoke one repo smoke checkout-correct beta-20260521191115`.
  - Result: `gitmoot job list --repo jerryfane/gitmoot` showed `pr-comment-17s7tenufa50v succeeded ask shell-smoke jerryfane/gitmoot #25`; PR comment https://github.com/jerryfane/gitmoot/pull/25#issuecomment-4511968662 contained the attributed `shell-smoke` result block.
- Live two-repo smoke:
  - Disposable PRs: https://github.com/jerryfane/gitmoot/pull/25 and https://github.com/jerryfane/codex-session-sync/pull/1, now closed and branches deleted.
  - Commands included registering both repos in one Gitmoot home, `gitmoot daemon start --home /tmp/gitmoot-beta-smoke/home --poll 2s`, PR comment `/gitmoot ask shell-smoke two repo gitmoot smoke beta-20260521191115`, and PR comment `/gitmoot ask shell-smoke two repo sync smoke beta-20260521191115`.
  - Result: `gitmoot status` showed `repos: 2`, `agents: 1`, `jobs: 5`, all succeeded. Repo-filtered job lists showed Gitmoot jobs only under `jerryfane/gitmoot` and sync job `pr-comment-3nd4qznoqaa1r succeeded ask shell-smoke jerryfane/codex-session-sync #1` only under `jerryfane/codex-session-sync`.
  - Attributed result comments posted at https://github.com/jerryfane/gitmoot/pull/25#issuecomment-4511980613 and https://github.com/jerryfane/codex-session-sync/pull/1#issuecomment-4511980214.
- codex exec review --uncommitted final raw output:

```text
The paginated GitHub API decoding change matches the non-slurped `gh api --paginate` output format for the array endpoints used here, and the updated test covers multi-page concatenated JSON arrays. The untracked release note is documentation-only and does not introduce a correctness issue.
```

RISK:
- Smoke PRs were intentionally disposable and are now closed.
- Release tag and GitHub release will be created only after this PR merges, from the merged main commit.
