### PR TITLE
fix: resolve codex sessions from shell snapshots

### DIFF
--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -103,6 +103,7 @@ type CodexSessionResolver interface {
 
 type CodexSessionIndex struct {
 	Path string
+	Home string
 }
 
 type CodexAdapter struct {
@@ -163,6 +164,9 @@ func (a CodexAdapter) verifySession(ctx context.Context, agent Agent) error {
 		return fmt.Errorf("verify codex session: %w", err)
 	}
 	if !exists {
+		if isUUID(agent.RuntimeRef) {
+			return nil
+		}
 		return fmt.Errorf("codex session %q was not found", agent.RuntimeRef)
 	}
 	return nil
@@ -339,10 +343,37 @@ func isUUID(value string) bool {
 }
 
 func (r CodexSessionIndex) Exists(ctx context.Context, ref string) (bool, error) {
-	path, err := r.path()
+	locations, err := r.locations()
 	if err != nil {
 		return false, err
 	}
+	for _, location := range locations {
+		found, err := codexSessionIndexContains(ctx, location.IndexPath, ref)
+		if err != nil {
+			return false, err
+		}
+		if found {
+			return true, nil
+		}
+		if isUUID(ref) {
+			found, err = codexShellSnapshotsContain(ctx, location.SnapshotsDir, ref)
+			if err != nil {
+				return false, err
+			}
+			if found {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+type codexSessionLocation struct {
+	IndexPath    string
+	SnapshotsDir string
+}
+
+func codexSessionIndexContains(ctx context.Context, path string, ref string) (bool, error) {
 	file, err := os.Open(path)
 	if os.IsNotExist(err) {
 		return false, nil
@@ -351,7 +382,6 @@ func (r CodexSessionIndex) Exists(ctx context.Context, ref string) (bool, error)
 		return false, err
 	}
 	defer file.Close()
-
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
@@ -374,17 +404,75 @@ func (r CodexSessionIndex) Exists(ctx context.Context, ref string) (bool, error)
 	return false, nil
 }
 
-func (r CodexSessionIndex) path() (string, error) {
-	if r.Path != "" {
-		return r.Path, nil
+func codexShellSnapshotsContain(ctx context.Context, dir string, ref string) (bool, error) {
+	pattern := filepath.Join(dir, ref+".*.sh")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return false, err
 	}
-	home := strings.TrimSpace(os.Getenv("CODEX_HOME"))
-	if home == "" {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	return len(matches) > 0, nil
+}
+
+func (r CodexSessionIndex) locations() ([]codexSessionLocation, error) {
+	if r.Path != "" {
+		return []codexSessionLocation{codexLocationForIndex(r.Path)}, nil
+	}
+	homes := []string{}
+	if home := strings.TrimSpace(r.Home); home != "" {
+		return []codexSessionLocation{codexLocationForHome(home)}, nil
+	}
+	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
+		homes = append(homes, home)
+	}
+	userHome, err := os.UserHomeDir()
+	if err != nil && len(homes) == 0 {
+		return nil, err
+	}
+	if err == nil {
+		homes = append(homes, filepath.Join(userHome, ".codex"))
+	}
+	locations := make([]codexSessionLocation, 0, len(homes))
+	seen := map[string]bool{}
+	for _, home := range homes {
+		home = filepath.Clean(home)
+		if seen[home] {
+			continue
+		}
+		seen[home] = true
+		locations = append(locations, codexLocationForHome(home))
+	}
+	return locations, nil
+}
+
+func (r CodexSessionIndex) path() (string, error) {
+	locations, err := r.locations()
+	if err != nil {
+		return "", err
+	}
+	if len(locations) == 0 {
 		userHome, err := os.UserHomeDir()
 		if err != nil {
 			return "", err
 		}
-		home = filepath.Join(userHome, ".codex")
+		return filepath.Join(userHome, ".codex", "session_index.jsonl"), nil
 	}
-	return filepath.Join(home, "session_index.jsonl"), nil
+	return locations[0].IndexPath, nil
+}
+
+func codexLocationForIndex(path string) codexSessionLocation {
+	home := filepath.Dir(path)
+	return codexSessionLocation{
+		IndexPath:    path,
+		SnapshotsDir: filepath.Join(home, "shell_snapshots"),
+	}
+}
+
+func codexLocationForHome(home string) codexSessionLocation {
+	return codexSessionLocation{
+		IndexPath:    filepath.Join(home, "session_index.jsonl"),
+		SnapshotsDir: filepath.Join(home, "shell_snapshots"),
+	}
 }

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -104,6 +104,17 @@ func TestCodexDeliverRejectsMissingNamedSession(t *testing.T) {
 	}
 }
 
+func TestCodexDeliverAllowsMissingUUIDSessionToReachCodex(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "done"}}}
+	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{}}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", "review")
+}
+
 func TestCodexHealthUsesRegisteredSession(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "OK"}}}
 	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{exists: true}}
@@ -241,6 +252,67 @@ func TestCodexSessionIndexFindsIDAndThreadName(t *testing.T) {
 		if !exists {
 			t.Fatalf("Exists(%q) = false, want true", ref)
 		}
+	}
+}
+
+func TestCodexSessionIndexFindsIDFromShellSnapshot(t *testing.T) {
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, "session_index.jsonl"), nil, 0o600); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	snapshots := filepath.Join(home, "shell_snapshots")
+	if err := os.MkdirAll(snapshots, 0o700); err != nil {
+		t.Fatalf("mkdir snapshots: %v", err)
+	}
+	sessionID := "550e8400-e29b-41d4-a716-446655440003"
+	snapshot := filepath.Join(snapshots, sessionID+".1779518064381155930.sh")
+	if err := os.WriteFile(snapshot, []byte("# snapshot\n"), 0o600); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	exists, err := (CodexSessionIndex{Home: home}).Exists(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("Exists returned error: %v", err)
+	}
+	if !exists {
+		t.Fatal("Exists returned false for shell snapshot session")
+	}
+}
+
+func TestCodexSessionIndexUsesCodexHomeBeforeDefaultHome(t *testing.T) {
+	codexHome := t.TempDir()
+	sessionID := "550e8400-e29b-41d4-a716-446655440004"
+	content := `{"id":"` + sessionID + `","thread_name":"codex-home-thread","updated_at":"2026-05-20T00:00:00Z"}` + "\n"
+	if err := os.WriteFile(filepath.Join(codexHome, "session_index.jsonl"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	t.Setenv("CODEX_HOME", codexHome)
+
+	exists, err := (CodexSessionIndex{}).Exists(context.Background(), "codex-home-thread")
+	if err != nil {
+		t.Fatalf("Exists returned error: %v", err)
+	}
+	if !exists {
+		t.Fatal("Exists returned false for CODEX_HOME thread")
+	}
+}
+
+func TestCodexSessionIndexDoesNotMatchThreadNameFromSnapshot(t *testing.T) {
+	home := t.TempDir()
+	snapshots := filepath.Join(home, "shell_snapshots")
+	if err := os.MkdirAll(snapshots, 0o700); err != nil {
+		t.Fatalf("mkdir snapshots: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snapshots, "review-thread.1779518064381155930.sh"), []byte("# snapshot\n"), 0o600); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	exists, err := (CodexSessionIndex{Home: home}).Exists(context.Background(), "review-thread")
+	if err != nil {
+		t.Fatalf("Exists returned error: %v", err)
+	}
+	if exists {
+		t.Fatal("Exists returned true for non-UUID snapshot thread name")
 	}
 }
 


### PR DESCRIPTION
WHAT:
Fix Codex explicit-session resolution so Gitmoot accepts sessions visible through shell snapshots and does not reject valid UUID refs solely because session_index.jsonl is stale.

WHY:
Codex sessions can exist in ~/.codex/shell_snapshots even when ~/.codex/session_index.jsonl is stale. Gitmoot was rejecting those agents before codex exec resume could verify them.

CHANGES:
- Added Codex session location resolution for explicit Path, explicit Home, CODEX_HOME, and default ~/.codex.
- Added shell snapshot lookup for UUID session ids only.
- Kept thread-name lookup restricted to session_index.jsonl.
- Allowed syntactically valid UUID refs to reach codex exec resume when local lookup is missing.
- Added focused runtime tests for snapshot lookup, CODEX_HOME lookup, missing UUID passthrough, and non-UUID snapshot isolation.

RESULTS:
- codex exec resume --help passed.
- gofmt -w internal/runtime/adapter.go internal/runtime/adapter_test.go ran.
- git diff --check passed.
- codex exec review --uncommitted final output:

No discrete correctness issues were found in the reviewed changes. The runtime tests could not be executed in this sandbox because Go attempted to download the configured toolchain into a read-only cache, but the diff itself appears consistent with the stated resolver behavior.
No discrete correctness issues were found in the reviewed changes. The runtime tests could not be executed in this sandbox because Go attempted to download the configured toolchain into a read-only cache, but the diff itself appears consistent with the stated resolver behavior.

- go test ./internal/runtime was attempted but blocked: go: downloading go1.26 (linux/amd64) then go: download go1.26 for linux/amd64: toolchain not available.
- GOTOOLCHAIN=local go test ./internal/runtime was attempted but blocked: go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local).

RISK:
Local Go tests could not be executed in this environment because the installed Go is 1.22.2 and the repo requires Go 1.26; CI or a host with Go 1.26 should run the runtime tests before merge if required.