### PR TITLE
feat: add thermo preset management

### DIFF
--- a/internal/cli/preset.go
+++ b/internal/cli/preset.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/preset"
+)
+
+var newPresetFetcher = func() preset.Fetcher {
+	return preset.GHFetcher{}
+}
+
+func runPreset(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPresetUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "list":
+		return runPresetList(args[1:], stdout, stderr)
+	case "show":
+		return runPresetShow(args[1:], stdout, stderr)
+	case "update":
+		return runPresetUpdate(args[1:], stdout, stderr)
+	case "diff":
+		return runPresetDiff(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown preset command %q\n\n", args[0])
+		printPresetUsage(stderr)
+		return 2
+	}
+}
+
+func printPresetUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot preset list")
+	fmt.Fprintln(w, "  gitmoot preset show thermo-nuclear-code-quality-review")
+	fmt.Fprintln(w, "  gitmoot preset update thermo-nuclear-code-quality-review")
+	fmt.Fprintln(w, "  gitmoot preset diff thermo-nuclear-code-quality-review")
+}
+
+func runPresetList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("preset list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "preset list does not accept positional arguments")
+		return 2
+	}
+	return withStoreExit(*home, stderr, "list presets", func(store *db.Store) error {
+		installed, err := installedPresets(context.Background(), store)
+		if err != nil {
+			return err
+		}
+		for _, definition := range preset.Builtins() {
+			status := "available"
+			if installedPreset, ok := installed[definition.ID]; ok {
+				status = "installed@" + shortCommit(installedPreset.ResolvedCommit)
+			}
+			fmt.Fprintf(stdout, "%-36s %-18s %s\n", definition.ID, status, definition.SourceRepo+"/"+definition.SourcePath)
+		}
+		return nil
+	})
+}
+
+func runPresetShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("preset show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "preset show requires exactly one preset id")
+		return 2
+	}
+	definition, ok := preset.Lookup(fs.Arg(0))
+	if !ok {
+		fmt.Fprintf(stderr, "unknown preset %q\n", fs.Arg(0))
+		return 2
+	}
+	return withStoreExit(*home, stderr, "show preset", func(store *db.Store) error {
+		cached, err := store.GetPreset(context.Background(), definition.ID)
+		installed := true
+		if errors.Is(err, sql.ErrNoRows) {
+			installed = false
+		} else if err != nil {
+			return err
+		}
+		writePresetDefinition(stdout, definition)
+		if !installed {
+			fmt.Fprintln(stdout, "installed: no")
+			return nil
+		}
+		fmt.Fprintln(stdout, "installed: yes")
+		fmt.Fprintf(stdout, "resolved commit: %s\n", cached.ResolvedCommit)
+		fmt.Fprintf(stdout, "updated: %s\n", cached.UpdatedAt)
+		fmt.Fprintln(stdout, "content:")
+		fmt.Fprintln(stdout, strings.TrimRight(cached.Content, "\n"))
+		return nil
+	})
+}
+
+func runPresetUpdate(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("preset update", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "preset update requires exactly one preset id")
+		return 2
+	}
+	id := fs.Arg(0)
+	if _, ok := preset.Lookup(id); !ok {
+		fmt.Fprintf(stderr, "unknown preset %q\n", id)
+		return 2
+	}
+	return withStoreExit(*home, stderr, "update preset", func(store *db.Store) error {
+		updated, err := preset.Update(context.Background(), store, newPresetFetcher(), id)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "updated %s at %s\n", updated.ID, updated.ResolvedCommit)
+		return nil
+	})
+}
+
+func runPresetDiff(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("preset diff", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "preset diff requires exactly one preset id")
+		return 2
+	}
+	definition, ok := preset.Lookup(fs.Arg(0))
+	if !ok {
+		fmt.Fprintf(stderr, "unknown preset %q\n", fs.Arg(0))
+		return 2
+	}
+	return withStoreExit(*home, stderr, "diff preset", func(store *db.Store) error {
+		cached, err := store.GetPreset(context.Background(), definition.ID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("preset %s is not installed; run gitmoot preset update %s", definition.ID, definition.ID)
+		}
+		if err != nil {
+			return err
+		}
+		fetcher := newPresetFetcher()
+		resolvedCommit, err := fetcher.ResolveRef(context.Background(), definition.SourceRepo, definition.SourceRef)
+		if err != nil {
+			return err
+		}
+		upstream, err := fetcher.FetchFile(context.Background(), definition.SourceRepo, resolvedCommit, definition.SourcePath)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "cached:   %s\n", cached.ResolvedCommit)
+		fmt.Fprintf(stdout, "upstream: %s\n", resolvedCommit)
+		fmt.Fprint(stdout, preset.Diff(cached.Content, upstream.Content))
+		return nil
+	})
+}
+
+func installedPresets(ctx context.Context, store *db.Store) (map[string]db.Preset, error) {
+	presets, err := store.ListPresets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	installed := make(map[string]db.Preset, len(presets))
+	for _, cached := range presets {
+		installed[cached.ID] = cached
+	}
+	return installed, nil
+}
+
+func writePresetDefinition(w io.Writer, definition preset.Definition) {
+	fmt.Fprintf(w, "id: %s\n", definition.ID)
+	fmt.Fprintf(w, "name: %s\n", definition.Name)
+	fmt.Fprintf(w, "description: %s\n", definition.Description)
+	fmt.Fprintf(w, "source: %s@%s:%s\n", definition.SourceRepo, definition.SourceRef, definition.SourcePath)
+	fmt.Fprintf(w, "default role: %s\n", definition.DefaultRole)
+	fmt.Fprintf(w, "default capabilities: %s\n", strings.Join(definition.DefaultCapabilities, ","))
+	fmt.Fprintf(w, "mutation: %t\n", definition.Mutation)
+}
+
+func shortCommit(commit string) string {
+	commit = strings.TrimSpace(commit)
+	if len(commit) <= 12 {
+		return commit
+	}
+	return commit[:12]
+}
+
+func withStoreExit(home string, stderr io.Writer, label string, fn func(*db.Store) error) int {
+	if err := withStore(home, fn); err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", label, err)
+		return 1
+	}
+	return 0
+}

--- a/internal/cli/preset_test.go
+++ b/internal/cli/preset_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/preset"
+)
+
+func TestPresetUpdateInstallsThermoPreset(t *testing.T) {
+	restore := replacePresetFetcher(fakePresetFetcher{
+		commit:  "abc123",
+		content: "Review deeply.",
+	})
+	defer restore()
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+
+	code := Run([]string{"preset", "update", "--home", home, "thermo-nuclear-code-quality-review"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("preset update exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "updated thermo-nuclear-code-quality-review at abc123") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"preset", "show", "--home", home, "thermo-nuclear-code-quality-review"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("preset show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"installed: yes", "resolved commit: abc123", "Review deeply."} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("show output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestPresetDiffDoesNotMutateCachedPreset(t *testing.T) {
+	restore := replacePresetFetcher(fakePresetFetcher{
+		commit:  "abc123",
+		content: "old body",
+	})
+	defer restore()
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	if code := Run([]string{"preset", "update", "--home", home, "thermo-nuclear-code-quality-review"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("preset update exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	restore()
+	restore = replacePresetFetcher(fakePresetFetcher{
+		commit:  "def456",
+		content: "new body",
+	})
+	defer restore()
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"preset", "diff", "--home", home, "thermo-nuclear-code-quality-review"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("preset diff exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"cached:   abc123", "upstream: def456", "-old body", "+new body"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("diff output missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"preset", "show", "--home", home, "thermo-nuclear-code-quality-review"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("preset show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "resolved commit: abc123") || strings.Contains(stdout.String(), "def456") {
+		t.Fatalf("diff mutated cached preset:\n%s", stdout.String())
+	}
+}
+
+func TestPresetListShowsAvailableBuiltin(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"preset", "list", "--home", t.TempDir()}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("preset list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "thermo-nuclear-code-quality-review") || !strings.Contains(stdout.String(), "available") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func replacePresetFetcher(fetcher preset.Fetcher) func() {
+	previous := newPresetFetcher
+	newPresetFetcher = func() preset.Fetcher {
+		return fetcher
+	}
+	return func() {
+		newPresetFetcher = previous
+	}
+}
+
+type fakePresetFetcher struct {
+	commit  string
+	content string
+}
+
+func (f fakePresetFetcher) ResolveRef(context.Context, string, string) (string, error) {
+	return f.commit, nil
+}
+
+func (f fakePresetFetcher) FetchFile(context.Context, string, string, string) (preset.File, error) {
+	return preset.File{Content: f.content}, nil
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,6 +29,7 @@ var rootCommands = []command{
 	{name: "repo", summary: "manage watched repositories", run: runRepo},
 	{name: "daemon", summary: "run the local PR watcher", run: runDaemon},
 	{name: "agent", summary: "manage registered agents", run: runAgent},
+	{name: "preset", summary: "manage agent prompt presets", run: runPreset},
 	{name: "events", summary: "show local repo events", run: runEvents},
 	{name: "status", summary: "show local workflow status", run: runStatus},
 	{name: "goal", summary: "import or inspect goals", run: runGoal},

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -53,7 +53,7 @@ func TestRunInitCreatesState(t *testing.T) {
 }
 
 func TestRunSubcommandHelpSucceeds(t *testing.T) {
-	for _, command := range []string{"init", "doctor", "version", "config", "update", "setup", "repo", "events", "job", "lock"} {
+	for _, command := range []string{"init", "doctor", "version", "config", "update", "setup", "repo", "preset", "events", "job", "lock"} {
 		t.Run(command, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 

--- a/internal/preset/preset.go
+++ b/internal/preset/preset.go
@@ -1,0 +1,228 @@
+package preset
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+const ThermoNuclearCodeQualityReviewID = "thermo-nuclear-code-quality-review"
+
+type Definition struct {
+	ID                  string
+	Name                string
+	Description         string
+	DefaultRole         string
+	DefaultCapabilities []string
+	Mutation            bool
+	SourceRepo          string
+	SourceRef           string
+	SourcePath          string
+}
+
+type File struct {
+	Content string
+}
+
+type Fetcher interface {
+	ResolveRef(ctx context.Context, repo string, ref string) (string, error)
+	FetchFile(ctx context.Context, repo string, ref string, path string) (File, error)
+}
+
+var builtins = []Definition{
+	{
+		ID:                  ThermoNuclearCodeQualityReviewID,
+		Name:                "Thermo-Nuclear Code Quality Review",
+		Description:         "Strict review-only preset sourced from Cursor Team Kit.",
+		DefaultRole:         "reviewer",
+		DefaultCapabilities: []string{"ask", "review"},
+		Mutation:            false,
+		SourceRepo:          "cursor/plugins",
+		SourceRef:           "main",
+		SourcePath:          "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+	},
+}
+
+func Builtins() []Definition {
+	definitions := make([]Definition, len(builtins))
+	copy(definitions, builtins)
+	return definitions
+}
+
+func Lookup(id string) (Definition, bool) {
+	id = strings.TrimSpace(id)
+	for _, definition := range builtins {
+		if definition.ID == id {
+			return definition, true
+		}
+	}
+	return Definition{}, false
+}
+
+func Update(ctx context.Context, store *db.Store, fetcher Fetcher, id string) (db.Preset, error) {
+	if store == nil {
+		return db.Preset{}, errors.New("preset store is required")
+	}
+	if fetcher == nil {
+		return db.Preset{}, errors.New("preset fetcher is required")
+	}
+	definition, ok := Lookup(id)
+	if !ok {
+		return db.Preset{}, fmt.Errorf("unknown preset %q", id)
+	}
+	resolvedCommit, err := fetcher.ResolveRef(ctx, definition.SourceRepo, definition.SourceRef)
+	if err != nil {
+		return db.Preset{}, err
+	}
+	file, err := fetcher.FetchFile(ctx, definition.SourceRepo, resolvedCommit, definition.SourcePath)
+	if err != nil {
+		return db.Preset{}, err
+	}
+	preset := db.Preset{
+		ID:             definition.ID,
+		Name:           definition.Name,
+		Description:    definition.Description,
+		SourceRepo:     definition.SourceRepo,
+		SourceRef:      definition.SourceRef,
+		SourcePath:     definition.SourcePath,
+		ResolvedCommit: resolvedCommit,
+		Content:        file.Content,
+	}
+	if err := store.UpsertPreset(ctx, preset); err != nil {
+		return db.Preset{}, err
+	}
+	return store.GetPreset(ctx, preset.ID)
+}
+
+type GHFetcher struct {
+	Runner subprocess.Runner
+	Dir    string
+}
+
+func (f GHFetcher) ResolveRef(ctx context.Context, repo string, ref string) (string, error) {
+	repo = strings.TrimSpace(repo)
+	ref = strings.TrimPrefix(strings.TrimSpace(ref), "refs/heads/")
+	if repo == "" || ref == "" {
+		return "", errors.New("repo and ref are required")
+	}
+	result, err := f.run(ctx, "api", "repos/"+repo+"/git/ref/heads/"+url.PathEscape(ref), "--jq", ".object.sha")
+	if err != nil {
+		return "", err
+	}
+	sha := strings.TrimSpace(result.Stdout)
+	if sha == "" {
+		return "", errors.New("github ref response did not include a commit sha")
+	}
+	return sha, nil
+}
+
+func (f GHFetcher) FetchFile(ctx context.Context, repo string, ref string, path string) (File, error) {
+	repo = strings.TrimSpace(repo)
+	ref = strings.TrimSpace(ref)
+	path = strings.TrimLeft(strings.TrimSpace(path), "/")
+	if repo == "" || ref == "" || path == "" {
+		return File{}, errors.New("repo, ref, and path are required")
+	}
+	result, err := f.run(ctx, "api", "-X", "GET", "repos/"+repo+"/contents/"+path, "-f", "ref="+ref)
+	if err != nil {
+		return File{}, err
+	}
+	var response struct {
+		Encoding string `json:"encoding"`
+		Content  string `json:"content"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &response); err != nil {
+		return File{}, fmt.Errorf("decode github contents response: %w", err)
+	}
+	if response.Encoding != "base64" {
+		return File{}, fmt.Errorf("unsupported github contents encoding %q", response.Encoding)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(stripBase64Whitespace(response.Content))
+	if err != nil {
+		return File{}, fmt.Errorf("decode github contents: %w", err)
+	}
+	return File{Content: string(decoded)}, nil
+}
+
+func (f GHFetcher) run(ctx context.Context, args ...string) (subprocess.Result, error) {
+	runner := f.Runner
+	if runner == nil {
+		runner = subprocess.ExecRunner{}
+	}
+	result, err := runner.Run(ctx, f.Dir, "gh", args...)
+	if err != nil {
+		detail := strings.TrimSpace(result.Stderr)
+		if detail == "" {
+			detail = strings.TrimSpace(result.Stdout)
+		}
+		if detail == "" {
+			return result, err
+		}
+		return result, fmt.Errorf("%s: %w", detail, err)
+	}
+	return result, nil
+}
+
+func stripBase64Whitespace(value string) string {
+	replacer := strings.NewReplacer("\n", "", "\r", "", "\t", "", " ", "")
+	return replacer.Replace(value)
+}
+
+func Diff(local string, upstream string) string {
+	local = strings.TrimRight(local, "\n")
+	upstream = strings.TrimRight(upstream, "\n")
+	if local == upstream {
+		return "preset content is up to date\n"
+	}
+	localLines := strings.Split(local, "\n")
+	upstreamLines := strings.Split(upstream, "\n")
+	prefix := commonPrefix(localLines, upstreamLines)
+	suffix := commonSuffix(localLines[prefix:], upstreamLines[prefix:])
+	var builder strings.Builder
+	builder.WriteString("--- cached\n")
+	builder.WriteString("+++ upstream\n")
+	for _, line := range localLines[prefix : len(localLines)-suffix] {
+		builder.WriteString("-")
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+	}
+	for _, line := range upstreamLines[prefix : len(upstreamLines)-suffix] {
+		builder.WriteString("+")
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+	}
+	return builder.String()
+}
+
+func commonPrefix(left []string, right []string) int {
+	limit := len(left)
+	if len(right) < limit {
+		limit = len(right)
+	}
+	for index := 0; index < limit; index++ {
+		if left[index] != right[index] {
+			return index
+		}
+	}
+	return limit
+}
+
+func commonSuffix(left []string, right []string) int {
+	limit := len(left)
+	if len(right) < limit {
+		limit = len(right)
+	}
+	for index := 0; index < limit; index++ {
+		if left[len(left)-1-index] != right[len(right)-1-index] {
+			return index
+		}
+	}
+	return limit
+}

--- a/internal/preset/preset_test.go
+++ b/internal/preset/preset_test.go
@@ -1,0 +1,87 @@
+package preset
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+func TestBuiltinsIncludesOnlyThermoPreset(t *testing.T) {
+	definitions := Builtins()
+	if len(definitions) != 1 {
+		t.Fatalf("builtin count = %d, want 1", len(definitions))
+	}
+	definition := definitions[0]
+	if definition.ID != ThermoNuclearCodeQualityReviewID || definition.Mutation {
+		t.Fatalf("definition = %+v", definition)
+	}
+	if !reflect.DeepEqual(definition.DefaultCapabilities, []string{"ask", "review"}) {
+		t.Fatalf("capabilities = %+v", definition.DefaultCapabilities)
+	}
+}
+
+func TestGHFetcherUsesGitHubAPIAndDecodesContent(t *testing.T) {
+	runner := &fakeRunner{}
+	fetcher := GHFetcher{Runner: runner}
+
+	sha, err := fetcher.ResolveRef(context.Background(), "cursor/plugins", "main")
+	if err != nil {
+		t.Fatalf("ResolveRef returned error: %v", err)
+	}
+	if sha != "abc123" {
+		t.Fatalf("sha = %q, want abc123", sha)
+	}
+	file, err := fetcher.FetchFile(context.Background(), "cursor/plugins", sha, "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md")
+	if err != nil {
+		t.Fatalf("FetchFile returned error: %v", err)
+	}
+	if file.Content != "preset body" {
+		t.Fatalf("content = %q", file.Content)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls = %+v", runner.calls)
+	}
+	if !strings.Contains(strings.Join(runner.calls[1].args, " "), "-X GET repos/cursor/plugins/contents/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md -f ref=abc123") {
+		t.Fatalf("fetch args = %+v", runner.calls[1].args)
+	}
+}
+
+func TestDiffReportsChangedContent(t *testing.T) {
+	diff := Diff("same\nold\nend\n", "same\nnew\nend\n")
+	for _, want := range []string{"--- cached", "+++ upstream", "-old", "+new"} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("diff missing %q:\n%s", want, diff)
+		}
+	}
+}
+
+type fakeRunner struct {
+	calls []fakeCall
+}
+
+type fakeCall struct {
+	command string
+	args    []string
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	f.calls = append(f.calls, fakeCall{command: command, args: append([]string{}, args...)})
+	joined := strings.Join(args, " ")
+	switch {
+	case strings.Contains(joined, "/git/ref/heads/main"):
+		return subprocess.Result{Command: command, Args: args, Stdout: "abc123\n"}, nil
+	case strings.Contains(joined, "/contents/"):
+		return subprocess.Result{Command: command, Args: args, Stdout: `{"encoding":"base64","content":"` + base64.StdEncoding.EncodeToString([]byte("preset body")) + `"}`}, nil
+	default:
+		return subprocess.Result{Command: command, Args: args, Stderr: "unexpected call"}, errors.New("unexpected call")
+	}
+}
+
+func (f *fakeRunner) LookPath(file string) (string, error) {
+	return file, nil
+}


### PR DESCRIPTION
WHAT:
Add the user-facing preset command group and the single built-in thermo-nuclear-code-quality-review preset registry entry.

WHY:
Gitmoot needs explicit, auditable preset updates instead of fetching mutable upstream prompt content during job delivery.

CHANGES:
- Added gitmoot preset list/show/update/diff.
- Added the thermo-nuclear-code-quality-review builtin with reviewer defaults, ask/review capabilities, mutation=false, and Cursor Team Kit source metadata.
- Added a preset package with a testable GitHub API fetcher using gh api.
- Resolve cursor/plugins main to an exact commit before fetching and storing preset content.
- Added local diff rendering without mutating cached preset content.
- Added CLI and fetcher tests using fake boundaries.

RESULTS:
- gofmt ran on touched Go files.
- git diff --check passed.
- GitHub API contract check passed:
  - gh api -X GET repos/cursor/plugins/contents/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md -f ref=main returned encoding=base64, size=12437.
  - gh api repos/cursor/plugins/git/ref/heads/main returned refs/heads/main at 3347cbab5b54136f6fba0994c3a01a56f7fb7fca.
- codex exec review --uncommitted final output:

No actionable correctness issues were found in the current changes. Test execution could not be completed because the Go 1.26 toolchain download is blocked by the read-only module cache in this environment.
No actionable correctness issues were found in the current changes. Test execution could not be completed because the Go 1.26 toolchain download is blocked by the read-only module cache in this environment.

- go test ./internal/cli ./internal/db ./internal/preset was attempted but blocked: go: downloading go1.26 (linux/amd64) then go: download go1.26 for linux/amd64: toolchain not available.
- GOTOOLCHAIN=local go test ./internal/cli ./internal/db ./internal/preset was attempted but blocked: go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local).

RISK:
Local Go tests could not be executed in this environment because the installed Go is 1.22.2 and the repo requires Go 1.26; CI or a host with Go 1.26 should run the focused packages before merge if required.