### PR TITLE
Bind presets to agents

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"flag"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/preset"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
@@ -60,6 +62,7 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 	runtimeName := fs.String("runtime", "", "agent runtime: codex, claude, or shell")
 	session := fs.String("session", "", "runtime session reference, last, or shell command")
 	role := fs.String("role", "", "agent role")
+	presetID := fs.String("preset", "", "agent prompt preset")
 	policy := fs.String("policy", "auto", "autonomy policy")
 	var repos repeatedFlag
 	var capabilities repeatedFlag
@@ -94,13 +97,19 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 	if len(normalizedRepos) > 0 {
 		repoScope = normalizedRepos[0]
 	}
+	resolvedRole, resolvedCapabilities, err := resolvePresetDefaults(*presetID, *role, capabilities)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid preset: %v\n", err)
+		return 2
+	}
 	agent := runtime.Agent{
 		Name:           name,
-		Role:           *role,
+		Role:           resolvedRole,
 		Runtime:        *runtimeName,
 		RuntimeRef:     *session,
 		RepoScope:      repoScope,
-		Capabilities:   capabilities,
+		PresetID:       strings.TrimSpace(*presetID),
+		Capabilities:   resolvedCapabilities,
 		AutonomyPolicy: *policy,
 		HealthStatus:   "unknown",
 	}
@@ -109,12 +118,24 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	if err := withStore(*home, func(store *db.Store) error {
+		if agent.PresetID != "" {
+			if _, err := store.GetPreset(context.Background(), agent.PresetID); err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return fmt.Errorf("preset %s is not installed; run gitmoot preset update %s", agent.PresetID, agent.PresetID)
+				}
+				return err
+			}
+		}
 		if err := store.UpsertAgent(context.Background(), dbAgent(agent)); err != nil {
 			return err
 		}
 		return store.ReplaceAgentRepos(context.Background(), agent.Name, normalizedRepos)
 	}); err != nil {
-		fmt.Fprintf(stderr, "subscribe agent: %v\n", err)
+		if strings.HasPrefix(err.Error(), "preset ") {
+			fmt.Fprintf(stderr, "%v\n", err)
+		} else {
+			fmt.Fprintf(stderr, "subscribe agent: %v\n", err)
+		}
 		return 1
 	}
 	if len(normalizedRepos) == 0 {
@@ -123,6 +144,49 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "subscribed %s (%s) for %s\n", agent.Name, agent.Runtime, strings.Join(normalizedRepos, ","))
 	}
 	return 0
+}
+
+func resolvePresetDefaults(presetID string, role string, capabilities []string) (string, []string, error) {
+	presetID = strings.TrimSpace(presetID)
+	role = strings.TrimSpace(role)
+	resolvedCapabilities := compactValues(capabilities)
+	if presetID == "" {
+		return role, resolvedCapabilities, nil
+	}
+	definition, ok := preset.Lookup(presetID)
+	if !ok {
+		return "", nil, fmt.Errorf("unknown preset %q", presetID)
+	}
+	if role == "" {
+		role = definition.DefaultRole
+	}
+	if len(resolvedCapabilities) == 0 {
+		resolvedCapabilities = append([]string{}, definition.DefaultCapabilities...)
+	}
+	if !definition.Mutation && containsValue(resolvedCapabilities, "implement") {
+		return "", nil, fmt.Errorf("preset %s does not allow implement capability", definition.ID)
+	}
+	return role, resolvedCapabilities, nil
+}
+
+func compactValues(values []string) []string {
+	compacted := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			compacted = append(compacted, value)
+		}
+	}
+	return compacted
+}
+
+func containsValue(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func runAgentList(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -138,6 +138,121 @@ func TestRunAgentAccessCommands(t *testing.T) {
 	}
 }
 
+func TestRunAgentSubscribeAppliesInstalledPresetDefaults(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"init", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("init exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.UpsertPreset(context.Background(), db.Preset{
+		ID:             "thermo-nuclear-code-quality-review",
+		Name:           "Thermo-Nuclear Code Quality Review",
+		SourceRepo:     "cursor/plugins",
+		SourceRef:      "main",
+		SourcePath:     "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+		ResolvedCommit: "abc123",
+		Content:        "Review deeply.",
+	}); err != nil {
+		t.Fatalf("UpsertPreset returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{
+		"agent", "subscribe", "thermo-review",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--repo", "jerryfane/gitmoot",
+		"--preset", "thermo-nuclear-code-quality-review",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store, err = db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "thermo-review")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.Role != "reviewer" || agent.PresetID != "thermo-nuclear-code-quality-review" || strings.Join(agent.Capabilities, ",") != "ask,review" {
+		t.Fatalf("agent = %+v", agent)
+	}
+}
+
+func TestRunAgentSubscribeRejectsMissingPresetAndImplementCapability(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "subscribe", "thermo-review",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--repo", "jerryfane/gitmoot",
+		"--preset", "thermo-nuclear-code-quality-review",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("missing preset exit code = %d, want 1", code)
+	}
+	want := "preset thermo-nuclear-code-quality-review is not installed; run gitmoot preset update thermo-nuclear-code-quality-review"
+	if strings.TrimSpace(stderr.String()) != want {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"init", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("init exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.UpsertPreset(context.Background(), db.Preset{
+		ID:             "thermo-nuclear-code-quality-review",
+		Name:           "Thermo-Nuclear Code Quality Review",
+		SourceRepo:     "cursor/plugins",
+		SourceRef:      "main",
+		SourcePath:     "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+		ResolvedCommit: "abc123",
+		Content:        "Review deeply.",
+	}); err != nil {
+		t.Fatalf("UpsertPreset returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "subscribe", "thermo-review",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--repo", "jerryfane/gitmoot",
+		"--preset", "thermo-nuclear-code-quality-review",
+		"--capability", "implement",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("implement capability exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "does not allow implement capability") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
 func TestRunAgentSubscribeValidatesInput(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{"agent", "subscribe", "bad name", "--runtime", "codex", "--session", "s", "--role", "reviewer", "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -18,12 +18,24 @@ func TestPollOnceCreatesJobAndAcknowledgement(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
 	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertPreset(ctx, db.Preset{
+		ID:             "thermo-nuclear-code-quality-review",
+		Name:           "Thermo-Nuclear Code Quality Review",
+		SourceRepo:     "cursor/plugins",
+		SourceRef:      "main",
+		SourcePath:     "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+		ResolvedCommit: "abc123",
+		Content:        "Review deeply.",
+	}); err != nil {
+		t.Fatalf("UpsertPreset returned error: %v", err)
+	}
 	if err := store.UpsertAgent(ctx, db.Agent{
 		Name:           "audit",
 		Role:           "reviewer",
 		Runtime:        "codex",
 		RuntimeRef:     "last",
 		RepoScope:      repo.FullName(),
+		PresetID:       "thermo-nuclear-code-quality-review",
 		Capabilities:   []string{"review"},
 		AutonomyPolicy: "auto",
 		HealthStatus:   "ok",
@@ -71,6 +83,9 @@ func TestPollOnceCreatesJobAndAcknowledgement(t *testing.T) {
 	}
 	if payload.Repo != repo.FullName() || payload.Branch != "task-7" || payload.PullRequest != 7 || payload.Sender != "alice" || payload.Instructions != "focus on tests" {
 		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.PresetID != "thermo-nuclear-code-quality-review" || payload.PresetResolvedCommit != "abc123" || payload.PresetContent != "Review deeply." {
+		t.Fatalf("payload preset snapshot = %+v", payload)
 	}
 	events, err := store.ListJobEvents(ctx, jobID)
 	if err != nil {

--- a/internal/workflow/job_comment.go
+++ b/internal/workflow/job_comment.go
@@ -28,6 +28,11 @@ func RenderJobResultComment(comment JobResultComment) string {
 	builder.WriteString("> Runtime: `")
 	builder.WriteString(markdownInline(comment.Runtime))
 	builder.WriteString("`\n")
+	if strings.TrimSpace(comment.Payload.PresetID) != "" {
+		builder.WriteString("> Preset: `")
+		builder.WriteString(markdownInline(comment.Payload.PresetID))
+		builder.WriteString("`\n")
+	}
 	builder.WriteString("> Job: `")
 	builder.WriteString(markdownInline(comment.JobID))
 	builder.WriteString("`\n\n")

--- a/internal/workflow/job_comment_test.go
+++ b/internal/workflow/job_comment_test.go
@@ -12,6 +12,7 @@ func TestRenderJobResultCommentIncludesAttributionAndResult(t *testing.T) {
 		Runtime:   "codex",
 		JobID:     "job-123",
 		JobState:  string(JobSucceeded),
+		Payload:   JobPayload{PresetID: "thermo-nuclear-code-quality-review"},
 		Result: &AgentResult{
 			Decision:    "changes_requested",
 			Summary:     "fix the edge case",
@@ -26,6 +27,7 @@ func TestRenderJobResultCommentIncludesAttributionAndResult(t *testing.T) {
 	for _, want := range []string{
 		"> Agent: `audit`",
 		"> Runtime: `codex`",
+		"> Preset: `thermo-nuclear-code-quality-review`",
 		"> Job: `job-123`",
 		"**Decision:** `changes_requested`",
 		"**Summary:** fix the edge case",

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -11,7 +11,7 @@ import (
 func TestRetryJobRequeuesTerminalJobAndPreservesPayload(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	payload := `{"repo":"owner/repo","raw_outputs":["raw"],"result":{"decision":"approved","summary":"stale"}}`
+	payload := `{"repo":"owner/repo","preset_id":"thermo","preset_resolved_commit":"abc123","preset_content":"Review deeply.","raw_outputs":["raw"],"result":{"decision":"approved","summary":"stale"}}`
 	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "ask", State: string(JobFailed), Payload: payload}, db.JobEvent{
 		Kind:    string(JobFailed),
 		Message: "failed",
@@ -31,7 +31,8 @@ func TestRetryJobRequeuesTerminalJobAndPreservesPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unmarshalPayload returned error: %v", err)
 	}
-	if storedPayload.Result != nil || len(storedPayload.RawOutputs) != 1 || storedPayload.RawOutputs[0] != "raw" {
+	if storedPayload.Result != nil || len(storedPayload.RawOutputs) != 1 || storedPayload.RawOutputs[0] != "raw" ||
+		storedPayload.PresetID != "thermo" || storedPayload.PresetResolvedCommit != "abc123" || storedPayload.PresetContent != "Review deeply." {
 		t.Fatalf("payload after retry = %+v, want stale result cleared and raw output preserved", storedPayload)
 	}
 	events, err := store.ListJobEvents(ctx, "job-1")


### PR DESCRIPTION
WHAT: Bound installed prompt presets to agent subscriptions and job result attribution.

WHY: Preset-backed review agents need stable defaults, permission boundaries, cached preset snapshots in queued work, and visible attribution when jobs report back to PRs.

CHANGES:
- Added `--preset` to `gitmoot agent subscribe`.
- Applied thermo preset defaults for role and capabilities when omitted.
- Rejected `implement` capability for the non-mutating thermo review preset.
- Failed subscription with the required install hint when a preset is not cached locally.
- Added preset attribution to rendered job result comments.
- Covered subscription defaults, missing preset handling, implement rejection, daemon job snapshotting, result comments, and retry snapshot preservation.

RESULTS:
- `gofmt -w internal/cli/agent.go internal/cli/agent_test.go internal/daemon/daemon_test.go internal/workflow/job_comment.go internal/workflow/job_comment_test.go internal/workflow/job_recovery_test.go`
- `git diff --check`
- `go test ./internal/cli ./internal/daemon ./internal/workflow` failed before tests ran: `go: download go1.26 for linux/amd64: toolchain not available`
- `GOTOOLCHAIN=local go test ./internal/cli ./internal/daemon ./internal/workflow` failed before tests ran: `go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local)`
- `codex exec review --uncommitted` final output:

```text
No actionable correctness issues were found in the current changes. I could not run the test suite because the sandbox cannot download the required Go 1.26 toolchain, but the diff itself appears internally consistent.
No actionable correctness issues were found in the current changes. I could not run the test suite because the sandbox cannot download the required Go 1.26 toolchain, but the diff itself appears internally consistent.
```

RISK: Go tests could not execute in this environment because the configured Go 1.26 toolchain is unavailable and the installed local Go version is 1.22.2.
