### PR TITLE
Document thermo preset workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ gitmoot update [--restart-daemon]
 gitmoot daemon start [--repo owner/repo] [--poll 30s]
 gitmoot daemon run [--repo owner/repo] [--poll 30s]
 gitmoot daemon stop|restart|status|logs
+gitmoot preset list
+gitmoot preset show|update|diff thermo-nuclear-code-quality-review
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
+gitmoot agent subscribe thermo-review --runtime codex --session <session-id-or-last> --repo owner/repo --preset thermo-nuclear-code-quality-review
 gitmoot agent allow|deny|repos
 gitmoot agent list
 gitmoot agent doctor <name>
@@ -50,6 +53,36 @@ gitmoot lock list|show|release
 
 Agents should read [SKILL.md](SKILL.md) for the Gitmoot job contract, branch
 lock expectations, and safe behavior rules.
+
+## Thermo Review Preset
+
+Gitmoot includes one built-in preset agent profile,
+`thermo-nuclear-code-quality-review`, for strict review-only work. Preset
+content is fetched explicitly and cached locally, then snapshotted into each
+queued job so retries remain reproducible.
+
+```sh
+gitmoot preset update thermo-nuclear-code-quality-review
+gitmoot agent subscribe thermo-review \
+  --runtime codex \
+  --session <session-id-or-last> \
+  --repo owner/repo \
+  --preset thermo-nuclear-code-quality-review
+gitmoot agent doctor thermo-review
+```
+
+Ask it to review from a PR comment:
+
+```text
+/gitmoot thermo-review review
+```
+
+Check upstream changes before refreshing the cached preset:
+
+```sh
+gitmoot preset diff thermo-nuclear-code-quality-review
+gitmoot preset update thermo-nuclear-code-quality-review
+```
 
 ## Documentation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -59,6 +59,35 @@ Common PR commands:
 When unsure which agents or commands are available, ask for `/gitmoot help` or
 run local status commands before acting.
 
+## Thermo Review Preset
+
+Gitmoot can register the built-in `thermo-nuclear-code-quality-review` preset
+as a strict review-only agent. Preset content is updated explicitly and cached
+locally; queued jobs keep the preset snapshot they were created with.
+
+```sh
+gitmoot preset update thermo-nuclear-code-quality-review
+gitmoot agent subscribe thermo-review \
+  --runtime codex \
+  --session <session-id-or-last> \
+  --repo owner/repo \
+  --preset thermo-nuclear-code-quality-review
+gitmoot agent doctor thermo-review
+```
+
+Use it from a PR comment:
+
+```text
+/gitmoot thermo-review review
+```
+
+Check upstream changes before refreshing the cached preset:
+
+```sh
+gitmoot preset diff thermo-nuclear-code-quality-review
+gitmoot preset update thermo-nuclear-code-quality-review
+```
+
 ## Required Result Contract
 
 Every agent job must return a `gitmoot_result` JSON object. Keep it concise and

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -38,6 +38,7 @@ type Agent struct {
     Runtime        string
     RuntimeRef     string
     RepoScope      string
+    PresetID       string
     Capabilities   []string
     AutonomyPolicy string
     HealthStatus   string
@@ -46,6 +47,9 @@ type Agent struct {
 
 `RuntimeRef` is runtime-specific. Codex accepts a session UUID, thread name, or
 `last`. Claude accepts a UUID or `last`. Shell uses the configured command.
+`PresetID` is Gitmoot-owned metadata. Adapters do not fetch or interpret preset
+content; Gitmoot snapshots cached preset instructions into the rendered prompt
+before delivery.
 
 ## Job Input
 
@@ -63,8 +67,9 @@ type Job struct {
 ```
 
 The prompt already includes repo, branch, PR number, task label, sender,
-requested action, constraints, and the required `gitmoot_result` JSON shape.
-Adapters should pass the prompt through without rewriting workflow semantics.
+requested action, cached preset instructions when present, constraints, and the
+required `gitmoot_result` JSON shape. Adapters should pass the prompt through
+without rewriting workflow semantics.
 
 ## Result Handling
 
@@ -86,6 +91,29 @@ output must be preserved for parsing and diagnostics.
 Keep runtime-specific command names, flags, JSON modes, session lookup, and
 fallback behavior inside the adapter package. Do not leak Codex or Claude
 assumptions into workflow, daemon, GitHub, database, or merge-gate code.
+
+## Presets
+
+Presets are prompt/profile bundles layered above runtimes. They are not runtime
+adapters and should not create adapter-specific behavior. The built-in
+`thermo-nuclear-code-quality-review` preset is fetched explicitly with:
+
+```sh
+gitmoot preset update thermo-nuclear-code-quality-review
+```
+
+After it is cached, bind it to a normal runtime-backed agent:
+
+```sh
+gitmoot agent subscribe thermo-review \
+  --runtime codex \
+  --session <session-id-or-last> \
+  --repo owner/repo \
+  --preset thermo-nuclear-code-quality-review
+```
+
+The thermo preset is non-mutating. It supplies reviewer defaults and allows
+`ask,review`, but it cannot grant `implement`.
 
 ## Shell Adapter
 

--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -74,6 +74,64 @@ Expected signals:
    gitmoot daemon status
    ```
 
+## Thermo Preset Smoke Test
+
+Goal: PR comment -> queued review job -> Codex resume with cached thermo preset
+instructions -> attributed PR result comment. Run this with a Gitmoot build that
+includes `gitmoot preset` commands.
+
+1. Cache the preset and subscribe a Codex review agent.
+
+   ```sh
+   gitmoot preset update thermo-nuclear-code-quality-review
+   gitmoot agent subscribe thermo-review \
+     --runtime codex \
+     --session <session-id-or-last> \
+     --repo owner/project \
+     --preset thermo-nuclear-code-quality-review
+   gitmoot agent doctor thermo-review
+   ```
+
+2. Start the daemon for the test repo.
+
+   ```sh
+   gitmoot daemon start --repo owner/project --poll 10s
+   gitmoot daemon status
+   ```
+
+3. Open a disposable PR, then comment:
+
+   ```text
+   /gitmoot thermo-review review
+   ```
+
+4. Verify the queued job and PR result.
+
+   ```sh
+   gitmoot job list --repo owner/project
+   gh pr view <number> --repo owner/project --comments
+   ```
+
+Expected signals:
+
+- The PR receives a queued-job acknowledgement for `thermo-review`.
+- `gitmoot job list --repo owner/project` shows the review job.
+- The result comment includes preset attribution:
+
+  ```md
+  > Agent: `thermo-review`
+  > Runtime: `codex`
+  > Preset: `thermo-nuclear-code-quality-review`
+  > Job: `...`
+  ```
+
+5. Check or refresh the cached preset only through explicit commands.
+
+   ```sh
+   gitmoot preset diff thermo-nuclear-code-quality-review
+   gitmoot preset update thermo-nuclear-code-quality-review
+   ```
+
 ## Two-Repo Smoke Test
 
 Goal: one daemon -> two registered repos -> same allowed agent -> ask jobs in

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -14,7 +14,10 @@ registration, plan import, task branch startup, status, recovery, and updates:
 ```sh
 gitmoot setup --repo owner/repo --path . --agent lead --runtime codex --session <session-ref> --role lead
 gitmoot doctor --repo .
+gitmoot preset list
+gitmoot preset update thermo-nuclear-code-quality-review
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
+gitmoot agent subscribe thermo-review --runtime codex --session <session-id-or-last> --repo owner/repo --preset thermo-nuclear-code-quality-review
 gitmoot agent allow <name> --repo owner/repo
 gitmoot agent repos <name>
 gitmoot agent list
@@ -77,6 +80,28 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    gitmoot agent doctor audit
    ```
 
+   To add the built-in strict review preset, fetch and cache it explicitly,
+   then subscribe a Codex-backed review agent. `--preset` supplies the default
+   reviewer role and `ask,review` capabilities when those flags are omitted.
+
+   ```sh
+   gitmoot preset update thermo-nuclear-code-quality-review
+   gitmoot agent subscribe thermo-review \
+     --runtime codex \
+     --session <session-id-or-last> \
+     --repo owner/project \
+     --preset thermo-nuclear-code-quality-review
+   gitmoot agent doctor thermo-review
+   ```
+
+   Preset updates are explicit and auditable. Diff upstream content before
+   refreshing the local cached copy:
+
+   ```sh
+   gitmoot preset diff thermo-nuclear-code-quality-review
+   gitmoot preset update thermo-nuclear-code-quality-review
+   ```
+
    To inspect the installed Gitmoot build or check for a beta release:
 
    ```sh
@@ -112,6 +137,7 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    ```text
    /gitmoot help
    /gitmoot audit review focus on correctness and missed edge cases
+   /gitmoot thermo-review review
    /gitmoot lead implement fix the review findings without broad refactors
    /gitmoot retry <job-id>
    /gitmoot cancel <job-id>
@@ -160,6 +186,8 @@ planned tasks. `task run` starts one task branch and records its branch lock.
   in V1.
 - GitHub comments are authored by the authenticated user. Agent attribution is
   written in the comment body.
+- Preset content is not fetched at job runtime. Run `gitmoot preset update`
+  intentionally when you want to refresh a cached preset.
 
 ## Multi-Repo Supervision
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,6 +47,49 @@ Fixes:
 - Confirm `CODEX_HOME` if sessions are stored outside `~/.codex`.
 - Re-subscribe the agent with the correct session reference.
 
+## Presets
+
+Symptoms:
+
+- `gitmoot agent subscribe ... --preset thermo-nuclear-code-quality-review`
+  fails with an install hint.
+- A preset-backed job does not include the expected review instructions.
+- You want to know whether the cached preset differs from upstream.
+
+Checks:
+
+```sh
+gitmoot preset list
+gitmoot preset show thermo-nuclear-code-quality-review
+gitmoot preset diff thermo-nuclear-code-quality-review
+gitmoot agent list
+```
+
+Fixes:
+
+- Install or refresh the preset explicitly:
+
+  ```sh
+  gitmoot preset update thermo-nuclear-code-quality-review
+  ```
+
+- Re-subscribe the agent after the preset is installed:
+
+  ```sh
+  gitmoot agent subscribe thermo-review \
+    --runtime codex \
+    --session <session-id-or-last> \
+    --repo owner/repo \
+    --preset thermo-nuclear-code-quality-review
+  gitmoot agent doctor thermo-review
+  ```
+
+- Preset content is snapshotted when a job is queued. Retry an existing job to
+  reuse its original snapshot; comment again after `preset update` to queue a
+  job with refreshed content.
+- The thermo preset is review-only. Remove `--capability implement` and route
+  implementation work to a separate implementation-capable agent.
+
 ## Claude Code
 
 Symptoms:


### PR DESCRIPTION
WHAT: Documented the thermo preset workflow across user, agent, adapter, smoke-test, and troubleshooting docs.

WHY: Users and agents need clear commands for explicit preset updates, preset-backed agent subscription, PR routing, and result attribution before cutting the next beta.

CHANGES:
- Added README command-surface and quick-start coverage for `thermo-nuclear-code-quality-review`.
- Added local workflow guidance for explicit Codex session ids, `last`, preset update/diff, preset-backed subscription, and `/gitmoot thermo-review review`.
- Added a thermo preset smoke-test section with expected queued/result comments and preset attribution.
- Updated adapter docs to clarify that presets are runtime-neutral prompt/profile metadata, not runtime adapters.
- Added troubleshooting guidance for missing cached presets, stale snapshots, and review-only capability boundaries.
- Updated `SKILL.md` so agents can reread the thermo preset setup and PR command.

RESULTS:
- `git diff --check`
- `go test ./...` failed before tests ran: `go: download go1.26 for linux/amd64: toolchain not available`
- `go vet ./...` failed before packages loaded: `go: download go1.26 for linux/amd64: toolchain not available`
- Manual smoke attempt with installed `gitmoot v0.1.0-beta.1` stopped because that release predates the new command: `unknown command "preset"`
- `codex exec review --uncommitted` final output:

```text
The documentation-only changes are consistent with the implemented preset CLI, agent defaults, preset snapshotting, and result-comment attribution behavior. I did not find any actionable correctness issues in the modified files.
The documentation-only changes are consistent with the implemented preset CLI, agent defaults, preset snapshotting, and result-comment attribution behavior. I did not find any actionable correctness issues in the modified files.
```

RISK: The full live thermo preset smoke could not be completed on this host until a Gitmoot binary containing PRs #27-#30 and this docs PR is built or released. The local Go command cannot build/test this repo because it attempts to download Go 1.26 and reports that the toolchain is unavailable.
