### PR TITLE
Support older gh checks output

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -340,6 +340,9 @@ func (c *GhClient) ListPullRequestChecks(ctx context.Context, repo Repository, n
 		"--repo", repo.FullName(),
 		"--json", "name,state,bucket,link,workflow,completedAt",
 	)
+	if err != nil && isUnsupportedJSONFlag(result) {
+		return c.listPullRequestChecksViaView(ctx, repo, number)
+	}
 	if err != nil && strings.TrimSpace(result.Stdout) == "" {
 		if isNoChecks(result) {
 			return nil, nil
@@ -354,6 +357,81 @@ func (c *GhClient) ListPullRequestChecks(ctx context.Context, repo Repository, n
 		return nil, fmt.Errorf("decode gh pr checks response: %w", decodeErr)
 	}
 	return checks, nil
+}
+
+func (c *GhClient) listPullRequestChecksViaView(ctx context.Context, repo Repository, number int64) ([]PullRequestCheck, error) {
+	result, err := c.run(ctx, false,
+		"pr", "view", strconv.FormatInt(number, 10),
+		"--repo", repo.FullName(),
+		"--json", "statusCheckRollup",
+	)
+	if err != nil {
+		return nil, err
+	}
+	var response struct {
+		StatusCheckRollup []statusCheckRollupItem `json:"statusCheckRollup"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &response); err != nil {
+		return nil, fmt.Errorf("decode gh pr view statusCheckRollup response: %w", err)
+	}
+	checks := make([]PullRequestCheck, 0, len(response.StatusCheckRollup))
+	for _, item := range response.StatusCheckRollup {
+		checks = append(checks, item.pullRequestCheck())
+	}
+	return checks, nil
+}
+
+type statusCheckRollupItem struct {
+	Name         string `json:"name"`
+	Context      string `json:"context"`
+	State        string `json:"state"`
+	Status       string `json:"status"`
+	Conclusion   string `json:"conclusion"`
+	DetailsURL   string `json:"detailsUrl"`
+	TargetURL    string `json:"targetUrl"`
+	WorkflowName string `json:"workflowName"`
+}
+
+func (i statusCheckRollupItem) pullRequestCheck() PullRequestCheck {
+	state := firstNonEmpty(i.State, i.Conclusion, i.Status)
+	return PullRequestCheck{
+		Name:     firstNonEmpty(i.Name, i.Context),
+		State:    state,
+		Bucket:   checkBucket(i),
+		Link:     firstNonEmpty(i.DetailsURL, i.TargetURL),
+		Workflow: i.WorkflowName,
+	}
+}
+
+func checkBucket(item statusCheckRollupItem) string {
+	state := strings.ToLower(strings.TrimSpace(item.State))
+	if state != "" {
+		switch state {
+		case "success":
+			return "pass"
+		case "expected", "pending":
+			return "pending"
+		case "failure", "error":
+			return "fail"
+		}
+	}
+	status := strings.ToLower(strings.TrimSpace(item.Status))
+	if status != "" && status != "completed" {
+		return "pending"
+	}
+	switch strings.ToLower(strings.TrimSpace(item.Conclusion)) {
+	case "success", "neutral":
+		return "pass"
+	case "skipped":
+		return "skipping"
+	case "failure", "cancelled", "timed_out", "action_required":
+		return "fail"
+	case "":
+		if status == "completed" {
+			return "pass"
+		}
+	}
+	return ""
 }
 
 func (c *GhClient) CreateCommitStatus(ctx context.Context, input CommitStatusInput) (CommitStatus, error) {
@@ -496,6 +574,11 @@ func isNoChecks(result subprocess.Result) bool {
 	return strings.Contains(text, "no checks reported")
 }
 
+func isUnsupportedJSONFlag(result subprocess.Result) bool {
+	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	return strings.Contains(text, "unknown flag: --json") || strings.Contains(text, "unknown shorthand flag") && strings.Contains(text, "json")
+}
+
 func endpoint(repo Repository, parts ...any) string {
 	values := []string{"repos", repo.Owner, repo.Name}
 	for _, part := range parts {
@@ -522,6 +605,16 @@ func firstLine(value string) string {
 		line = strings.TrimSpace(line)
 		if line != "" {
 			return line
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
 		}
 	}
 	return ""

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -229,6 +229,47 @@ func TestListPullRequestChecksTreatsNoChecksAsEmpty(t *testing.T) {
 	}
 }
 
+func TestListPullRequestChecksFallsBackToStatusCheckRollup(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stderr: "unknown flag: --json"},
+			{Stdout: `{"statusCheckRollup":[
+				{"name":"test","status":"COMPLETED","conclusion":"SUCCESS","detailsUrl":"https://example.com/check","workflowName":"ci"},
+				{"name":"lint","status":"IN_PROGRESS","workflowName":"ci"},
+				{"context":"legacy","state":"FAILURE","targetUrl":"https://example.com/status"},
+				{"context":"required","state":"EXPECTED"}
+			]}`},
+		},
+		errs: []error{errors.New("exit status 1"), nil},
+	}
+	client := GhClient{Runner: runner}
+
+	checks, err := client.ListPullRequestChecks(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, 2)
+
+	if err != nil {
+		t.Fatalf("ListPullRequestChecks returned error: %v", err)
+	}
+	if len(checks) != 4 {
+		t.Fatalf("checks = %+v, want 4", checks)
+	}
+	if checks[0].Bucket != "pass" || checks[1].Bucket != "pending" || checks[2].Bucket != "fail" || checks[3].Bucket != "pending" {
+		t.Fatalf("checks = %+v", checks)
+	}
+	if checks[2].Name != "legacy" || checks[2].Link != "https://example.com/status" {
+		t.Fatalf("legacy status check = %+v", checks[2])
+	}
+	runner.wantArgs(t, 0,
+		"pr", "checks", "2",
+		"--repo", "jerryfane/gitmoot",
+		"--json", "name,state,bucket,link,workflow,completedAt",
+	)
+	runner.wantArgs(t, 1,
+		"pr", "view", "2",
+		"--repo", "jerryfane/gitmoot",
+		"--json", "statusCheckRollup",
+	)
+}
+
 func TestMergePullRequestUsesSafeHeadMatch(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{
 		{Stdout: "merged"},


### PR DESCRIPTION
WHAT: Added a fallback for GitHub CLI versions where `gh pr checks --json` is not supported.

WHY: The live thermo preset smoke exposed that this host's `gh` accepts `gh pr view --json statusCheckRollup` but rejects `gh pr checks --json`, which caused Gitmoot to post the `unknown flag: --json` diagnostic after otherwise successful review jobs.

CHANGES:
- Detect unsupported `--json` errors from `gh pr checks`.
- Fall back to `gh pr view --json statusCheckRollup`.
- Convert check runs and legacy status contexts into Gitmoot's existing check bucket model.
- Treat `EXPECTED` legacy status contexts as pending, not failed.
- Added focused coverage for the fallback path.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./internal/github ./internal/workflow ./internal/daemon`
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `GOTOOLCHAIN=go1.26.0 go vet ./...`
- `git diff --check`
- `codex exec review --uncommitted` final output:

```text
No correctness issues were found in the current changes. The fallback path preserves existing behavior for supported gh versions while adding a reasonable statusCheckRollup conversion for older gh versions.
No correctness issues were found in the current changes. The fallback path preserves existing behavior for supported gh versions while adding a reasonable statusCheckRollup conversion for older gh versions.
```

RISK: The fallback maps the fields exposed by `gh pr view --json statusCheckRollup` on this host. It preserves the existing `gh pr checks --json` path for newer GitHub CLI versions.
