### PR TITLE
Add agent start command

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -16,12 +16,18 @@ import (
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
+var newRuntimeFactory = func() runtime.Factory {
+	return runtime.Factory{}
+}
+
 func runAgent(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		printAgentUsage(stdout)
 		return 0
 	}
 	switch args[0] {
+	case "start":
+		return runAgentStart(args[1:], stdout, stderr)
 	case "subscribe":
 		return runAgentSubscribe(args[1:], stdout, stderr)
 	case "list":
@@ -45,6 +51,7 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 
 func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot agent start <name> --runtime codex|claude --repo owner/repo [--path .] [--preset <preset-id>] [--start-daemon]")
 	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> [--repo owner/repo...] --capability <capability>")
 	fmt.Fprintln(w, "    Codex sessions may use a UUID, thread name, or last. Claude sessions may use a UUID or last. Shell sessions are commands.")
 	fmt.Fprintln(w, "  gitmoot agent allow <name> --repo owner/repo")
@@ -53,6 +60,153 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent list")
 	fmt.Fprintln(w, "  gitmoot agent remove <name>")
 	fmt.Fprintln(w, "  gitmoot agent doctor <name>")
+}
+
+func runAgentStart(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent start", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	runtimeName := fs.String("runtime", "", "agent runtime: codex or claude")
+	repoFlag := fs.String("repo", "", "allowed repo as owner/repo")
+	path := fs.String("path", ".", "local checkout path")
+	role := fs.String("role", "", "agent role")
+	presetID := fs.String("preset", "", "agent prompt preset")
+	policy := fs.String("policy", "auto", "autonomy policy")
+	updatePreset := fs.Bool("update-preset", false, "install or refresh the preset before starting")
+	startDaemon := fs.Bool("start-daemon", false, "start the background daemon after setup")
+	var capabilities repeatedFlag
+	fs.Var(&capabilities, "capability", "agent capability, repeatable")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent start requires exactly one name")
+			return 2
+		}
+		return 0
+	}
+	name := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent start requires exactly one name")
+		return 2
+	}
+	if strings.TrimSpace(*runtimeName) == "" {
+		fmt.Fprintln(stderr, "agent start requires --runtime")
+		return 2
+	}
+	if strings.TrimSpace(*repoFlag) == "" {
+		fmt.Fprintln(stderr, "agent start requires --repo")
+		return 2
+	}
+	if *updatePreset && strings.TrimSpace(*presetID) == "" {
+		fmt.Fprintln(stderr, "agent start --update-preset requires --preset")
+		return 2
+	}
+	repo, err := daemon.ParseRepository(*repoFlag)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+		return 2
+	}
+	record, err := repoRecordFromPath(context.Background(), repo, *path)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent start: %v\n", err)
+		return 1
+	}
+	resolvedRole, resolvedCapabilities, err := resolveAgentDefaults(*presetID, *role, capabilities, "agent", []string{"ask", "review", "implement"})
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid preset: %v\n", err)
+		return 2
+	}
+	agent := runtime.Agent{
+		Name:           name,
+		Role:           resolvedRole,
+		Runtime:        strings.TrimSpace(*runtimeName),
+		RepoScope:      repo.FullName(),
+		PresetID:       strings.TrimSpace(*presetID),
+		Capabilities:   resolvedCapabilities,
+		AutonomyPolicy: *policy,
+		HealthStatus:   "unknown",
+	}
+	if err := runtime.ValidateStartRequest(runtime.StartRequest{Agent: agent, Prompt: "preflight"}); err != nil {
+		fmt.Fprintf(stderr, "invalid agent: %v\n", err)
+		return 2
+	}
+	if agent.Runtime == runtime.ShellRuntime {
+		fmt.Fprintln(stderr, "start runtime: shell runtime does not support agent start; use gitmoot agent subscribe --runtime shell --session <command>")
+		return 1
+	}
+	var cachedPreset db.Preset
+	if err := withStore(*home, func(store *db.Store) error {
+		if _, err := store.GetAgent(context.Background(), agent.Name); err == nil {
+			return fmt.Errorf("agent %s already exists", agent.Name)
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if agent.PresetID == "" {
+			return nil
+		}
+		if *updatePreset {
+			updated, err := preset.Update(context.Background(), store, newPresetFetcher(), agent.PresetID)
+			if err != nil {
+				return err
+			}
+			cachedPreset = updated
+			return nil
+		}
+		installed, err := loadInstalledPreset(context.Background(), store, agent.PresetID)
+		if err != nil {
+			return err
+		}
+		cachedPreset = installed
+		return nil
+	}); err != nil {
+		if strings.HasPrefix(err.Error(), "preset ") {
+			fmt.Fprintf(stderr, "%v\n", err)
+		} else {
+			fmt.Fprintf(stderr, "agent start: %v\n", err)
+		}
+		return 1
+	}
+	prompt := agentStartupPrompt(agent, cachedPreset)
+	adapter, err := runtimeStartAdapter(newRuntimeFactory(), agent.Runtime, record.CheckoutPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "load adapter: %v\n", err)
+		return 1
+	}
+	started, err := adapter.Start(context.Background(), runtime.StartRequest{Agent: agent, Prompt: prompt})
+	if err != nil {
+		fmt.Fprintf(stderr, "start runtime: %v\n", err)
+		return 1
+	}
+	agent.RuntimeRef = strings.TrimSpace(started.RuntimeRef)
+	if err := runtime.ValidateAgent(agent); err != nil {
+		fmt.Fprintf(stderr, "invalid started agent: %v\n", err)
+		return 1
+	}
+	if err := withStore(*home, func(store *db.Store) error {
+		if err := store.UpsertRepo(context.Background(), record); err != nil {
+			return err
+		}
+		return persistAgentSubscription(context.Background(), store, agent, []string{repo.FullName()})
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent start: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "started %s (%s) for %s", agent.Name, agent.Runtime, repo.FullName())
+	writeLine(stdout, "session: %s", agent.RuntimeRef)
+	writeLine(stdout, "invoke: /gitmoot %s review", agent.Name)
+	if *startDaemon {
+		writeLine(stdout, "step: start background daemon")
+		return runDaemonStartWithWorkDir([]string{"--home", *home, "--repo", repo.FullName()}, record.CheckoutPath, stdout, stderr)
+	}
+	writeLine(stdout, "next: cd %s", shellArg(record.CheckoutPath))
+	writeLine(stdout, "next: %s", daemonStartHint(*home, repo.FullName()))
+	return 0
 }
 
 func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
@@ -119,17 +273,11 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 	}
 	if err := withStore(*home, func(store *db.Store) error {
 		if agent.PresetID != "" {
-			if _, err := store.GetPreset(context.Background(), agent.PresetID); err != nil {
-				if errors.Is(err, sql.ErrNoRows) {
-					return fmt.Errorf("preset %s is not installed; run gitmoot preset update %s", agent.PresetID, agent.PresetID)
-				}
+			if _, err := loadInstalledPreset(context.Background(), store, agent.PresetID); err != nil {
 				return err
 			}
 		}
-		if err := store.UpsertAgent(context.Background(), dbAgent(agent)); err != nil {
-			return err
-		}
-		return store.ReplaceAgentRepos(context.Background(), agent.Name, normalizedRepos)
+		return persistAgentSubscription(context.Background(), store, agent, normalizedRepos)
 	}); err != nil {
 		if strings.HasPrefix(err.Error(), "preset ") {
 			fmt.Fprintf(stderr, "%v\n", err)
@@ -147,10 +295,20 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 }
 
 func resolvePresetDefaults(presetID string, role string, capabilities []string) (string, []string, error) {
+	return resolveAgentDefaults(presetID, role, capabilities, "", nil)
+}
+
+func resolveAgentDefaults(presetID string, role string, capabilities []string, fallbackRole string, fallbackCapabilities []string) (string, []string, error) {
 	presetID = strings.TrimSpace(presetID)
 	role = strings.TrimSpace(role)
 	resolvedCapabilities := compactValues(capabilities)
 	if presetID == "" {
+		if role == "" {
+			role = fallbackRole
+		}
+		if len(resolvedCapabilities) == 0 {
+			resolvedCapabilities = append([]string{}, fallbackCapabilities...)
+		}
 		return role, resolvedCapabilities, nil
 	}
 	definition, ok := preset.Lookup(presetID)
@@ -167,6 +325,84 @@ func resolvePresetDefaults(presetID string, role string, capabilities []string) 
 		return "", nil, fmt.Errorf("preset %s does not allow implement capability", definition.ID)
 	}
 	return role, resolvedCapabilities, nil
+}
+
+func loadInstalledPreset(ctx context.Context, store *db.Store, presetID string) (db.Preset, error) {
+	cached, err := store.GetPreset(ctx, presetID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.Preset{}, fmt.Errorf("preset %s is not installed; run gitmoot preset update %s", presetID, presetID)
+	}
+	return cached, err
+}
+
+func persistAgentSubscription(ctx context.Context, store *db.Store, agent runtime.Agent, repos []string) error {
+	if err := store.UpsertAgent(ctx, dbAgent(agent)); err != nil {
+		return err
+	}
+	return store.ReplaceAgentRepos(ctx, agent.Name, repos)
+}
+
+func agentStartupPrompt(agent runtime.Agent, cachedPreset db.Preset) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "You are a Gitmoot-managed agent named %s.\n", agent.Name)
+	fmt.Fprintf(&builder, "Runtime: %s\n", agent.Runtime)
+	fmt.Fprintf(&builder, "Allowed repo: %s\n", agent.RepoScope)
+	fmt.Fprintf(&builder, "Role: %s\n", agent.Role)
+	fmt.Fprintf(&builder, "Capabilities: %s\n", strings.Join(agent.Capabilities, ","))
+	if agent.PresetID != "" {
+		fmt.Fprintf(&builder, "Preset: %s", agent.PresetID)
+		if cachedPreset.ResolvedCommit != "" {
+			fmt.Fprintf(&builder, " @ %s", cachedPreset.ResolvedCommit)
+		}
+		builder.WriteString("\n\nPreset instructions:\n")
+		builder.WriteString(strings.TrimRight(cachedPreset.Content, "\n"))
+		builder.WriteString("\n\n")
+	}
+	builder.WriteString("Initialize this session for future Gitmoot jobs. Do not edit files, run long tasks, create commits, or open pull requests now. Reply with a short readiness acknowledgment only.")
+	return builder.String()
+}
+
+func runtimeStartAdapter(factory runtime.Factory, runtimeName string, checkout string) (runtime.Adapter, error) {
+	switch runtimeName {
+	case runtime.CodexRuntime:
+		return runtime.CodexAdapter{Runner: factory.Runner, Dir: checkout}, nil
+	case runtime.ClaudeRuntime:
+		return runtime.ClaudeAdapter{Runner: factory.Runner, Dir: checkout}, nil
+	case runtime.ShellRuntime:
+		return runtime.ShellAdapter{Runner: factory.Runner, Dir: checkout}, nil
+	default:
+		return nil, fmt.Errorf("unsupported runtime: %s", runtimeName)
+	}
+}
+
+func daemonStartHint(home string, repo string) string {
+	args := []string{"gitmoot", "daemon", "start"}
+	if strings.TrimSpace(home) != "" {
+		args = append(args, "--home", home)
+	}
+	args = append(args, "--repo", repo)
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellArg(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellArg(value string) string {
+	if value == "" {
+		return "''"
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		switch r {
+		case '_', '-', '.', '/', ':', '@', '%', '+', '=', ',':
+			continue
+		}
+		return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+	}
+	return value
 }
 
 func compactValues(values []string) []string {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -3,11 +3,16 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"errors"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
 func TestRunAgentSubscribeListRemove(t *testing.T) {
@@ -135,6 +140,226 @@ func TestRunAgentAccessCommands(t *testing.T) {
 	}
 	if strings.TrimSpace(stdout.String()) != "" {
 		t.Fatalf("repos after deny output = %q", stdout.String())
+	}
+}
+
+func TestRunAgentStartCreatesCodexSessionAndStoresAgent(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runner := &agentStartRunner{results: []subprocess.Result{{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440011"}` + "\n"}}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "start", "lead",
+		"--home", home,
+		"--runtime", "codex",
+		"--repo", "owner/repo",
+		"--path", repoDir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("start exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"started lead (codex) for owner/repo",
+		"session: 550e8400-e29b-41d4-a716-446655440011",
+		"invoke: /gitmoot lead review",
+		"next: cd " + repoDir,
+		"next: gitmoot daemon start --home " + home + " --repo owner/repo",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("start output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	runner.want(t, 0, repoDir, "codex", "exec", "--json", "--")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "lead")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.Runtime != "codex" || agent.RuntimeRef != "550e8400-e29b-41d4-a716-446655440011" || agent.Role != "agent" || strings.Join(agent.Capabilities, ",") != "ask,review,implement" {
+		t.Fatalf("agent = %+v", agent)
+	}
+	if _, err := store.GetRepo(context.Background(), "owner/repo"); err != nil {
+		t.Fatalf("GetRepo returned error: %v", err)
+	}
+	allowed, err := store.AgentCanAccessRepo(context.Background(), "lead", "owner/repo")
+	if err != nil {
+		t.Fatalf("AgentCanAccessRepo returned error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("agent start did not allow lead on owner/repo")
+	}
+	if !strings.Contains(runner.calls[0].args[len(runner.calls[0].args)-1], "You are a Gitmoot-managed agent named lead.") {
+		t.Fatalf("startup prompt = %q", runner.calls[0].args[len(runner.calls[0].args)-1])
+	}
+}
+
+func TestRunAgentStartAppliesInstalledPresetDefaults(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	seedThermoPreset(t, home)
+	runner := &agentStartRunner{results: []subprocess.Result{{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440012"}` + "\n"}}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "start", "thermo-review",
+		"--home", home,
+		"--runtime", "codex",
+		"--repo", "owner/repo",
+		"--path", repoDir,
+		"--preset", "thermo-nuclear-code-quality-review",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "thermo-review")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.Role != "reviewer" || agent.PresetID != "thermo-nuclear-code-quality-review" || strings.Join(agent.Capabilities, ",") != "ask,review" {
+		t.Fatalf("agent = %+v", agent)
+	}
+	prompt := runner.calls[0].args[len(runner.calls[0].args)-1]
+	if !strings.Contains(prompt, "Preset: thermo-nuclear-code-quality-review @ abc123") || !strings.Contains(prompt, "Review deeply.") {
+		t.Fatalf("startup prompt missing preset content:\n%s", prompt)
+	}
+}
+
+func TestRunAgentStartRejectsMissingPresetBeforeRuntime(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "start", "thermo-review",
+		"--home", home,
+		"--runtime", "codex",
+		"--repo", "owner/repo",
+		"--path", repoDir,
+		"--preset", "thermo-nuclear-code-quality-review",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("start exit code = %d, want 1", code)
+	}
+	want := "preset thermo-nuclear-code-quality-review is not installed; run gitmoot preset update thermo-nuclear-code-quality-review"
+	if strings.TrimSpace(stderr.String()) != want {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runtime was started before preset validation: %+v", runner.calls)
+	}
+}
+
+func TestRunAgentStartRejectsExistingAgentBeforeRuntime(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"agent", "subscribe", "lead", "--home", home, "--runtime", "codex", "--session", "last", "--role", "lead", "--repo", "owner/repo", "--capability", "ask"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"agent", "start", "lead", "--home", home, "--runtime", "codex", "--repo", "owner/repo", "--path", repoDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("start exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "agent lead already exists") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runtime was started before existing-agent validation: %+v", runner.calls)
+	}
+}
+
+func TestRunAgentStartUpdatePresetInstallsBeforeStart(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	restoreFetcher := replacePresetFetcher(fakePresetFetcher{content: "Updated review instructions."})
+	defer restoreFetcher()
+	runner := &agentStartRunner{results: []subprocess.Result{{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440013"}` + "\n"}}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "start", "thermo-review",
+		"--home", home,
+		"--runtime", "codex",
+		"--repo", "owner/repo",
+		"--path", repoDir,
+		"--preset", "thermo-nuclear-code-quality-review",
+		"--update-preset",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("start exit code = %d, stderr=%s", code, stderr.String())
+	}
+	prompt := runner.calls[0].args[len(runner.calls[0].args)-1]
+	if !strings.Contains(prompt, "Updated review instructions.") {
+		t.Fatalf("startup prompt missing updated preset:\n%s", prompt)
+	}
+}
+
+func TestRunAgentStartRejectsShellRuntimeBeforePresetUpdate(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	restoreFetcher := replacePresetFetcher(fakePresetFetcher{content: "should not fetch"})
+	defer restoreFetcher()
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "start", "shell-agent",
+		"--home", home,
+		"--runtime", "shell",
+		"--repo", "owner/repo",
+		"--path", repoDir,
+		"--preset", "thermo-nuclear-code-quality-review",
+		"--update-preset",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("start exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "shell runtime does not support agent start") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runtime was started for shell agent: %+v", runner.calls)
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if _, err := store.GetPreset(context.Background(), "thermo-nuclear-code-quality-review"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("preset lookup error = %v, want sql.ErrNoRows", err)
 	}
 }
 
@@ -300,5 +525,91 @@ func TestRunAgentDoctorPersistsHealth(t *testing.T) {
 	}
 	if agent.HealthStatus != "ok" {
 		t.Fatalf("health status = %q, want ok", agent.HealthStatus)
+	}
+}
+
+func seedThermoPreset(t *testing.T, home string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"init", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("init exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertPreset(context.Background(), db.Preset{
+		ID:             "thermo-nuclear-code-quality-review",
+		Name:           "Thermo-Nuclear Code Quality Review",
+		SourceRepo:     "cursor/plugins",
+		SourceRef:      "main",
+		SourcePath:     "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+		ResolvedCommit: "abc123",
+		Content:        "Review deeply.",
+	}); err != nil {
+		t.Fatalf("UpsertPreset returned error: %v", err)
+	}
+}
+
+func replaceRuntimeFactory(factory runtime.Factory) func() {
+	previous := newRuntimeFactory
+	newRuntimeFactory = func() runtime.Factory {
+		return factory
+	}
+	return func() {
+		newRuntimeFactory = previous
+	}
+}
+
+type agentStartRunner struct {
+	results []subprocess.Result
+	errs    []error
+	calls   []agentStartCall
+}
+
+type agentStartCall struct {
+	dir     string
+	command string
+	args    []string
+}
+
+func (r *agentStartRunner) Run(_ context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
+	r.calls = append(r.calls, agentStartCall{dir: dir, command: command, args: append([]string{}, args...)})
+	index := len(r.calls) - 1
+	result := subprocess.Result{Command: command, Args: args}
+	if index < len(r.results) {
+		result = r.results[index]
+		result.Command = command
+		result.Args = args
+	}
+	var err error
+	if index < len(r.errs) {
+		err = r.errs[index]
+	}
+	return result, err
+}
+
+func (r *agentStartRunner) LookPath(file string) (string, error) {
+	if file == "" {
+		return "", errors.New("empty file")
+	}
+	return "/usr/bin/" + file, nil
+}
+
+func (r *agentStartRunner) want(t *testing.T, index int, dir string, command string, wantPrefix ...string) {
+	t.Helper()
+	if index >= len(r.calls) {
+		t.Fatalf("missing call %d; calls=%+v", index, r.calls)
+	}
+	call := r.calls[index]
+	if call.dir != dir {
+		t.Fatalf("call %d dir = %q, want %q", index, call.dir, dir)
+	}
+	if call.command != command {
+		t.Fatalf("call %d command = %q, want %q", index, call.command, command)
+	}
+	if len(call.args) < len(wantPrefix) || !reflect.DeepEqual(call.args[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("call %d args = %s\nwant prefix %s", index, strings.Join(call.args, " "), strings.Join(wantPrefix, " "))
 	}
 }

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -97,6 +97,14 @@ func ValidateAgent(agent Agent) error {
 	return nil
 }
 
+func ValidateStartRequest(request StartRequest) error {
+	adapter, err := (Factory{}).Adapter(request.Agent.Runtime)
+	if err != nil {
+		return err
+	}
+	return validateStartRequest(request.Agent, adapter.Name(), request.Prompt)
+}
+
 func validateStartRequest(agent Agent, runtimeName string, prompt string) error {
 	if err := validateAgentFields(agent, false); err != nil {
 		return err


### PR DESCRIPTION
WHAT:
Add `gitmoot agent start` so Gitmoot can create a new Codex or Claude runtime session, register the returned session reference, and optionally start the daemon.

WHY:
`agent subscribe` only registers an existing session. The new workflow needs Gitmoot to bootstrap a fresh runtime session without keeping an interactive terminal open.

CHANGES:
- Added `agent start` CLI parsing and usage.
- Added startup prompt generation with agent name, runtime, repo, role, capabilities, and optional cached preset instructions.
- Reused preset validation/defaults and agent persistence helpers across start/subscribe.
- Added runtime start request validation for CLI preflight.
- Stored the created runtime reference, repo record, and repo access after successful runtime start.
- Added checkout/home-aware daemon follow-up output and `--start-daemon` integration.
- Added focused CLI tests for default start, preset-backed start, missing preset, existing agent rejection, `--update-preset`, and shell unsupported behavior.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli ./internal/runtime` passed.
- `GOTOOLCHAIN=go1.26.0 go test ./...` passed.
- `git diff --check` passed.
- `codex exec review --uncommitted` final raw output:

```text
I did not find any actionable correctness issues in the current staged/unstaged changes. The new agent start flow appears to validate inputs, avoid starting runtimes before preset/existing-agent checks, and persists the resulting agent/repo subscription as intended.
I did not find any actionable correctness issues in the current staged/unstaged changes. The new agent start flow appears to validate inputs, avoid starting runtimes before preset/existing-agent checks, and persists the resulting agent/repo subscription as intended.
```

RISK:
- `--start-daemon` is covered through existing daemon start code path and will be exercised in the live smoke task.
