### PR TITLE
Document agent start workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ gitmoot daemon run [--repo owner/repo] [--poll 30s]
 gitmoot daemon stop|restart|status|logs
 gitmoot preset list
 gitmoot preset show|update|diff thermo-nuclear-code-quality-review
+gitmoot agent start <name> --runtime codex|claude --repo owner/repo [--path .] [--preset <preset-id>] [--start-daemon]
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
-gitmoot agent subscribe thermo-review --runtime codex --session <session-id-or-last> --repo owner/repo --preset thermo-nuclear-code-quality-review
+gitmoot agent start thermo-review --runtime codex --repo owner/repo --preset thermo-nuclear-code-quality-review
 gitmoot agent allow|deny|repos
 gitmoot agent list
 gitmoot agent doctor <name>
@@ -63,13 +64,17 @@ queued job so retries remain reproducible.
 
 ```sh
 gitmoot preset update thermo-nuclear-code-quality-review
-gitmoot agent subscribe thermo-review \
+gitmoot agent start thermo-review \
   --runtime codex \
-  --session <session-id-or-last> \
   --repo owner/repo \
-  --preset thermo-nuclear-code-quality-review
+  --preset thermo-nuclear-code-quality-review \
+  --start-daemon
 gitmoot agent doctor thermo-review
 ```
+
+Use `agent start` for a new Gitmoot-managed Codex or Claude session. Use
+`agent subscribe` when the runtime session already exists, or for shell command
+adapters.
 
 Ask it to review from a PR comment:
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -10,6 +10,7 @@ An adapter implements `runtime.Adapter`:
 ```go
 type Adapter interface {
     Name() string
+    Start(ctx context.Context, request StartRequest) (StartResult, error)
     Validate(ctx context.Context, agent Agent) error
     Deliver(ctx context.Context, agent Agent, job Job) (Result, error)
     Health(ctx context.Context, agent Agent) error
@@ -19,7 +20,10 @@ type Adapter interface {
 
 Responsibilities:
 
-- `Name` returns the runtime key used by `gitmoot agent subscribe`.
+- `Name` returns the runtime key used by `gitmoot agent start` and
+  `gitmoot agent subscribe`.
+- `Start` creates a new runtime session for `gitmoot agent start` and returns
+  the runtime reference Gitmoot should store.
 - `Validate` checks the agent record without doing unnecessary work.
 - `Deliver` resumes or invokes the runtime with the rendered job prompt and
   returns raw output.
@@ -50,6 +54,40 @@ type Agent struct {
 `PresetID` is Gitmoot-owned metadata. Adapters do not fetch or interpret preset
 content; Gitmoot snapshots cached preset instructions into the rendered prompt
 before delivery.
+
+## Session Startup
+
+`gitmoot agent start` uses the adapter `Start` method to create a new session
+without leaving an interactive terminal open. The startup prompt tells the
+runtime to initialize only, make no file edits, and reply with a short readiness
+acknowledgment.
+
+Codex startup runs in the repo checkout path:
+
+```sh
+codex exec --json -- '<startup-prompt>'
+```
+
+The adapter parses JSONL stdout and stores the first
+`thread.started.thread_id`. Future jobs resume that session with:
+
+```sh
+codex exec resume <session-id> -- '<job-prompt>'
+```
+
+Claude startup generates a UUID before invocation, then runs:
+
+```sh
+claude --session-id <uuid> -p --output-format json -- '<startup-prompt>'
+```
+
+The UUID is stored only after the command succeeds. Future jobs use the Claude
+adapter's resume path. This depends on the installed Claude Code CLI supporting
+the documented `--session-id`, `-p`, `--output-format json`, and `--resume`
+contract.
+
+Shell adapters do not support `agent start`; register shell commands with
+`agent subscribe`.
 
 ## Job Input
 
@@ -84,9 +122,11 @@ output must be preserved for parsing and diagnostics.
 2. Implement an adapter type in `internal/runtime`.
 3. Register it in `runtime.Factory.Adapter`.
 4. Extend `ValidateAgent` only for runtime-specific reference rules.
-5. Add tests for validation, command arguments, error handling, health checks,
-   and capability reporting.
-6. Add or update docs for the runtime-specific `--session` value.
+5. Implement startup semantics or return a clear unsupported error from
+   `Start`.
+6. Add tests for startup command arguments, validation, delivery command
+   arguments, error handling, health checks, and capability reporting.
+7. Add or update docs for the runtime-specific `--session` and startup values.
 
 Keep runtime-specific command names, flags, JSON modes, session lookup, and
 fallback behavior inside the adapter package. Do not leak Codex or Claude
@@ -105,9 +145,8 @@ gitmoot preset update thermo-nuclear-code-quality-review
 After it is cached, bind it to a normal runtime-backed agent:
 
 ```sh
-gitmoot agent subscribe thermo-review \
+gitmoot agent start thermo-review \
   --runtime codex \
-  --session <session-id-or-last> \
   --repo owner/repo \
   --preset thermo-nuclear-code-quality-review
 ```

--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -80,19 +80,29 @@ Goal: PR comment -> queued review job -> Codex resume with cached thermo preset
 instructions -> attributed PR result comment. Run this with a Gitmoot build that
 includes `gitmoot preset` commands.
 
-1. Cache the preset and subscribe a Codex review agent.
+1. Cache the preset and start a Gitmoot-managed Codex review agent.
 
    ```sh
    gitmoot preset update thermo-nuclear-code-quality-review
-   gitmoot agent subscribe thermo-review \
+   gitmoot agent start thermo-review \
      --runtime codex \
-     --session <session-id-or-last> \
      --repo owner/project \
+     --path . \
      --preset thermo-nuclear-code-quality-review
    gitmoot agent doctor thermo-review
    ```
 
-2. Start the daemon for the test repo.
+   Gitmoot prints the created session id. To inspect that Codex thread later:
+
+   ```sh
+   codex resume <session-id>
+   ```
+
+   If you prefer registering an already-open Codex session, use
+   `gitmoot agent subscribe ... --session <session-id-or-last>` instead.
+
+2. Start the daemon for the test repo, or pass `--start-daemon` to
+   `agent start`.
 
    ```sh
    gitmoot daemon start --repo owner/project --poll 10s
@@ -130,6 +140,67 @@ Expected signals:
    ```sh
    gitmoot preset diff thermo-nuclear-code-quality-review
    gitmoot preset update thermo-nuclear-code-quality-review
+   ```
+
+## Agent Start Smoke Test
+
+Goal: prove `gitmoot agent start` can create a Codex session, store the session
+reference, start the daemon, and route a PR comment job through that new
+session.
+
+1. Build a local test binary and use an isolated Gitmoot home.
+
+   ```sh
+   GOTOOLCHAIN=go1.26.0 go build -o /tmp/gitmoot-current ./cmd/gitmoot
+   export GITMOOT_SMOKE_HOME=/tmp/gitmoot-agent-start-smoke
+   rm -rf "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current init --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+2. From the test repo checkout, cache the preset and start the agent.
+
+   ```sh
+   cd /path/to/project
+   /tmp/gitmoot-current preset update --home "$GITMOOT_SMOKE_HOME" thermo-nuclear-code-quality-review
+   /tmp/gitmoot-current agent start thermo-start-smoke \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --runtime codex \
+     --repo owner/project \
+     --path . \
+     --preset thermo-nuclear-code-quality-review \
+     --start-daemon
+   /tmp/gitmoot-current agent list --home "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current daemon status --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+3. Open a disposable PR, then comment:
+
+   ```text
+   /gitmoot thermo-start-smoke review
+   ```
+
+4. Verify the job and PR comments.
+
+   ```sh
+   /tmp/gitmoot-current job list --home "$GITMOOT_SMOKE_HOME" --repo owner/project
+   /tmp/gitmoot-current events --home "$GITMOOT_SMOKE_HOME" --repo owner/project
+   gh pr view <number> --repo owner/project --comments
+   ```
+
+Expected signals:
+
+- `agent list` shows `thermo-start-smoke` with a generated Codex session id.
+- The PR receives a queued-job acknowledgement.
+- The job succeeds and the result comment includes agent, runtime, preset, and
+  job metadata.
+- `codex resume <session-id>` opens the created session if manual inspection is
+  needed.
+
+5. Stop the isolated daemon.
+
+   ```sh
+   /tmp/gitmoot-current daemon stop --home "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current daemon status --home "$GITMOOT_SMOKE_HOME"
    ```
 
 ## Two-Repo Smoke Test

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -16,8 +16,9 @@ gitmoot setup --repo owner/repo --path . --agent lead --runtime codex --session 
 gitmoot doctor --repo .
 gitmoot preset list
 gitmoot preset update thermo-nuclear-code-quality-review
+gitmoot agent start <name> --runtime codex|claude --repo owner/repo --path . --preset thermo-nuclear-code-quality-review --start-daemon
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
-gitmoot agent subscribe thermo-review --runtime codex --session <session-id-or-last> --repo owner/repo --preset thermo-nuclear-code-quality-review
+gitmoot agent start thermo-review --runtime codex --repo owner/repo --preset thermo-nuclear-code-quality-review
 gitmoot agent allow <name> --repo owner/repo
 gitmoot agent repos <name>
 gitmoot agent list
@@ -60,38 +61,64 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    gitmoot goal import --file GOAL.md --repo owner/project
    ```
 
-3. Start persistent agent sessions on the same machine.
+3. Initialize Gitmoot state and start Gitmoot-managed agents.
 
-   For Codex, start a normal session and note its session id or thread name.
-   Using `last` works for quick demos, but explicit ids are safer because the
-   newest session can change.
-
-   For Claude Code, start the session and note its UUID. Claude sessions may use
-   a UUID or `last`.
-
-4. Initialize Gitmoot state and subscribe the agents.
+   `agent start` creates a new runtime session, stores the returned session
+   reference, grants the repo, and can start the background daemon. For Codex it
+   runs `codex exec --json -- <startup-prompt>` and records the emitted
+   `thread.started.thread_id`. For Claude Code it creates a session id and uses
+   the installed Claude CLI's non-interactive print mode.
 
    ```sh
-   gitmoot setup --repo owner/project --path . --agent lead --runtime codex --session <codex-session-id> --role lead
+   gitmoot init
    gitmoot doctor --repo .
-   gitmoot agent subscribe audit --runtime claude --session <claude-session-id> --role reviewer --repo owner/project --capability review --capability ask
+   gitmoot agent start lead \
+     --runtime codex \
+     --repo owner/project \
+     --path . \
+     --role lead \
+     --capability ask \
+     --capability review \
+     --capability implement
    gitmoot agent list
    gitmoot agent doctor lead
-   gitmoot agent doctor audit
    ```
 
-   To add the built-in strict review preset, fetch and cache it explicitly,
-   then subscribe a Codex-backed review agent. `--preset` supplies the default
-   reviewer role and `ask,review` capabilities when those flags are omitted.
+   To add the built-in strict review preset, fetch and cache it explicitly.
+   `--preset` supplies the default reviewer role and `ask,review` capabilities
+   when those flags are omitted.
 
    ```sh
    gitmoot preset update thermo-nuclear-code-quality-review
-   gitmoot agent subscribe thermo-review \
+   gitmoot agent start thermo-review \
      --runtime codex \
-     --session <session-id-or-last> \
      --repo owner/project \
      --preset thermo-nuclear-code-quality-review
    gitmoot agent doctor thermo-review
+   ```
+
+   If the preset is not cached yet, `agent start --preset ...` fails with the
+   same explicit `gitmoot preset update <preset>` guidance as `agent subscribe`.
+   Add `--update-preset` when you want startup to refresh the cached preset
+   before creating the runtime session.
+
+   After startup, open a created Codex session later with the session id printed
+   by Gitmoot:
+
+   ```sh
+   codex resume <session-id>
+   ```
+
+4. Subscribe existing sessions or shell adapters when needed.
+
+   Use `agent subscribe` when a Codex or Claude session already exists, or when
+   registering a shell command adapter. Using `last` works for quick demos, but
+   explicit ids are safer because the newest session can change.
+
+   ```sh
+   gitmoot agent subscribe audit --runtime claude --session <claude-session-id> --role reviewer --repo owner/project --capability review --capability ask
+   gitmoot agent subscribe shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"ok\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell\"],\"needs\":[],\"next_agents\":[]}}'" --role reviewer --repo owner/project --capability ask
+   gitmoot agent list
    ```
 
    Preset updates are explicit and auditable. Diff upstream content before
@@ -116,8 +143,10 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    ```
 
    The daemon validates that the current checkout's `origin` remote matches
-   `--repo`. Use `gitmoot daemon start` without `--repo` after registering all
-   intended repos if one daemon should supervise the whole Gitmoot home.
+   `--repo`. `agent start --start-daemon` runs this same background start path
+   for the selected checkout. Use `gitmoot daemon start` without `--repo` after
+   registering all intended repos if one daemon should supervise the whole
+   Gitmoot home.
 
 6. Start and open the first task PR.
 


### PR DESCRIPTION
WHAT:
Document the new `gitmoot agent start` workflow and clarify when to use it versus `agent subscribe`.

WHY:
The CLI can now create runtime sessions directly, so the docs should guide new users toward the simpler Gitmoot-managed startup path while keeping existing-session registration documented.

CHANGES:
- Updated README command surface and thermo preset example to use `agent start`.
- Updated local workflow docs with `agent start`, preset update/start, daemon behavior, `codex resume <session-id>`, and subscribe guidance for existing sessions/shell adapters.
- Updated adapter docs with the `Start` contract, Codex startup/resume behavior, Claude startup expectations, and shell unsupported behavior.
- Added a Codex `agent start` smoke section to beta smoke tests.

RESULTS:
- Docs reviewed by inspection.
- `git diff --check` passed.
- `codex exec review --uncommitted` final raw output:

```text
The current changes are documentation-only and align with the implemented agent start CLI/runtime behavior. I did not find any actionable correctness issues in the modified files.
The current changes are documentation-only and align with the implemented agent start CLI/runtime behavior. I did not find any actionable correctness issues in the modified files.
```

RISK:
- Documentation-only change. Live validation is covered by the next smoke task.
