### PR TITLE
feat: add local custom preset prompts

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -151,7 +151,7 @@ func runAgentStart(args []string, stdout, stderr io.Writer) int {
 			return nil
 		}
 		if *updatePreset {
-			updated, err := preset.Update(context.Background(), store, newPresetFetcher(), agent.PresetID)
+			updated, err := updatePresetByID(context.Background(), store, agent.PresetID)
 			if err != nil {
 				return err
 			}
@@ -251,6 +251,22 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 	if len(normalizedRepos) > 0 {
 		repoScope = normalizedRepos[0]
 	}
+	trimmedPresetID := strings.TrimSpace(*presetID)
+	if trimmedPresetID != "" {
+		if _, ok := preset.Lookup(trimmedPresetID); !ok {
+			if err := withStore(*home, func(store *db.Store) error {
+				_, err := loadInstalledPreset(context.Background(), store, trimmedPresetID)
+				return err
+			}); err != nil {
+				if strings.HasPrefix(err.Error(), "preset ") {
+					fmt.Fprintf(stderr, "%v\n", err)
+				} else {
+					fmt.Fprintf(stderr, "subscribe agent: %v\n", err)
+				}
+				return 1
+			}
+		}
+	}
 	resolvedRole, resolvedCapabilities, err := resolvePresetDefaults(*presetID, *role, capabilities)
 	if err != nil {
 		fmt.Fprintf(stderr, "invalid preset: %v\n", err)
@@ -313,7 +329,22 @@ func resolveAgentDefaults(presetID string, role string, capabilities []string, f
 	}
 	definition, ok := preset.Lookup(presetID)
 	if !ok {
-		return "", nil, fmt.Errorf("unknown preset %q", presetID)
+		if err := preset.ValidateID(presetID); err != nil {
+			return "", nil, err
+		}
+		if role == "" {
+			if fallbackRole == "" {
+				return "", nil, fmt.Errorf("preset %s does not define a default role; pass --role", presetID)
+			}
+			role = fallbackRole
+		}
+		if len(resolvedCapabilities) == 0 {
+			if len(fallbackCapabilities) == 0 {
+				return "", nil, fmt.Errorf("preset %s does not define default capabilities; pass --capability", presetID)
+			}
+			resolvedCapabilities = append([]string{}, fallbackCapabilities...)
+		}
+		return role, resolvedCapabilities, nil
 	}
 	if role == "" {
 		role = definition.DefaultRole
@@ -330,6 +361,9 @@ func resolveAgentDefaults(presetID string, role string, capabilities []string, f
 func loadInstalledPreset(ctx context.Context, store *db.Store, presetID string) (db.Preset, error) {
 	cached, err := store.GetPreset(ctx, presetID)
 	if errors.Is(err, sql.ErrNoRows) {
+		if _, ok := preset.Lookup(presetID); !ok {
+			return db.Preset{}, fmt.Errorf("preset %s is not installed; run gitmoot preset add %s --file <path>", presetID, presetID)
+		}
 		return db.Preset{}, fmt.Errorf("preset %s is not installed; run gitmoot preset update %s", presetID, presetID)
 	}
 	return cached, err

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -239,6 +240,52 @@ func TestRunAgentStartAppliesInstalledPresetDefaults(t *testing.T) {
 	}
 }
 
+func TestRunAgentStartUsesInstalledCustomPreset(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	promptPath := filepath.Join(t.TempDir(), "frontend.md")
+	if err := os.WriteFile(promptPath, []byte("Review frontend behavior.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"preset", "add", "frontend-reviewer", "--home", home, "--file", promptPath}, &stdout, &stderr); code != 0 {
+		t.Fatalf("preset add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	runner := &agentStartRunner{results: []subprocess.Result{{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440022"}` + "\n"}}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{
+		"agent", "start", "frontend-reviewer",
+		"--home", home,
+		"--runtime", "codex",
+		"--repo", "owner/repo",
+		"--path", repoDir,
+		"--preset", "frontend-reviewer",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "frontend-reviewer")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.Role != "agent" || agent.PresetID != "frontend-reviewer" || strings.Join(agent.Capabilities, ",") != "ask,review,implement" {
+		t.Fatalf("agent = %+v", agent)
+	}
+	prompt := runner.calls[0].args[len(runner.calls[0].args)-1]
+	if !strings.Contains(prompt, "Preset: frontend-reviewer @ sha256:") || !strings.Contains(prompt, "Review frontend behavior.") {
+		t.Fatalf("startup prompt missing custom preset content:\n%s", prompt)
+	}
+}
+
 func TestRunAgentStartRejectsMissingPresetBeforeRuntime(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()
@@ -261,6 +308,36 @@ func TestRunAgentStartRejectsMissingPresetBeforeRuntime(t *testing.T) {
 		t.Fatalf("start exit code = %d, want 1", code)
 	}
 	want := "preset thermo-nuclear-code-quality-review is not installed; run gitmoot preset update thermo-nuclear-code-quality-review"
+	if strings.TrimSpace(stderr.String()) != want {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runtime was started before preset validation: %+v", runner.calls)
+	}
+}
+
+func TestRunAgentStartRejectsMissingCustomPresetBeforeRuntime(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "start", "frontend-reviewer",
+		"--home", home,
+		"--runtime", "codex",
+		"--repo", "owner/repo",
+		"--path", repoDir,
+		"--preset", "frontend-reviewer",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("start exit code = %d, want 1", code)
+	}
+	want := "preset frontend-reviewer is not installed; run gitmoot preset add frontend-reviewer --file <path>"
 	if strings.TrimSpace(stderr.String()) != want {
 		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
 	}
@@ -416,10 +493,85 @@ func TestRunAgentSubscribeAppliesInstalledPresetDefaults(t *testing.T) {
 	}
 }
 
+func TestRunAgentSubscribeUsesInstalledCustomPreset(t *testing.T) {
+	home := t.TempDir()
+	promptPath := filepath.Join(t.TempDir(), "frontend.md")
+	if err := os.WriteFile(promptPath, []byte("Review frontend behavior.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"preset", "add", "frontend-reviewer", "--home", home, "--file", promptPath}, &stdout, &stderr); code != 0 {
+		t.Fatalf("preset add exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{
+		"agent", "subscribe", "frontend-reviewer",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--repo", "jerryfane/gitmoot",
+		"--preset", "frontend-reviewer",
+		"--role", "reviewer",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("subscribe without capabilities exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "does not define default capabilities") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "subscribe", "frontend-reviewer",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--repo", "jerryfane/gitmoot",
+		"--preset", "frontend-reviewer",
+		"--role", "reviewer",
+		"--capability", "ask",
+		"--capability", "review",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "frontend-reviewer")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.Role != "reviewer" || agent.PresetID != "frontend-reviewer" || strings.Join(agent.Capabilities, ",") != "ask,review" {
+		t.Fatalf("agent = %+v", agent)
+	}
+}
+
 func TestRunAgentSubscribeRejectsMissingPresetAndImplementCapability(t *testing.T) {
 	home := t.TempDir()
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{
+		"agent", "subscribe", "frontend-reviewer",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--repo", "jerryfane/gitmoot",
+		"--preset", "frontend-reviewer",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("missing custom preset exit code = %d, want 1", code)
+	}
+	want := "preset frontend-reviewer is not installed; run gitmoot preset add frontend-reviewer --file <path>"
+	if strings.TrimSpace(stderr.String()) != want {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
 		"agent", "subscribe", "thermo-review",
 		"--home", home,
 		"--runtime", "codex",
@@ -430,7 +582,7 @@ func TestRunAgentSubscribeRejectsMissingPresetAndImplementCapability(t *testing.
 	if code != 1 {
 		t.Fatalf("missing preset exit code = %d, want 1", code)
 	}
-	want := "preset thermo-nuclear-code-quality-review is not installed; run gitmoot preset update thermo-nuclear-code-quality-review"
+	want = "preset thermo-nuclear-code-quality-review is not installed; run gitmoot preset update thermo-nuclear-code-quality-review"
 	if strings.TrimSpace(stderr.String()) != want {
 		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
 	}

--- a/internal/cli/preset.go
+++ b/internal/cli/preset.go
@@ -23,6 +23,8 @@ func runPreset(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 	switch args[0] {
+	case "add":
+		return runPresetAdd(args[1:], stdout, stderr)
 	case "list":
 		return runPresetList(args[1:], stdout, stderr)
 	case "show":
@@ -40,10 +42,57 @@ func runPreset(args []string, stdout, stderr io.Writer) int {
 
 func printPresetUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot preset add <preset-id> --file ./agents/<preset-id>.md [--name <name>] [--description <text>]")
 	fmt.Fprintln(w, "  gitmoot preset list")
 	fmt.Fprintln(w, "  gitmoot preset show thermo-nuclear-code-quality-review")
 	fmt.Fprintln(w, "  gitmoot preset update thermo-nuclear-code-quality-review")
 	fmt.Fprintln(w, "  gitmoot preset diff thermo-nuclear-code-quality-review")
+}
+
+func runPresetAdd(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("preset add", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	file := fs.String("file", "", "local prompt file to install")
+	name := fs.String("name", "", "preset display name")
+	description := fs.String("description", "", "preset description")
+	id, flagArgs := leadingID(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if id == "" {
+		if fs.NArg() == 1 {
+			id = fs.Arg(0)
+		} else {
+			fmt.Fprintln(stderr, "preset add requires exactly one preset id")
+			return 2
+		}
+	} else if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "preset add requires exactly one preset id")
+		return 2
+	}
+	if strings.TrimSpace(*file) == "" {
+		fmt.Fprintln(stderr, "preset add requires --file")
+		return 2
+	}
+	return withStoreExit(*home, stderr, "add preset", func(store *db.Store) error {
+		added, err := preset.AddLocal(context.Background(), store, id, *file, *name, *description)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "added %s at %s\n", added.ID, added.ResolvedCommit)
+		return nil
+	})
+}
+
+func leadingID(args []string) (string, []string) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return "", args
+	}
+	return args[0], args[1:]
 }
 
 func runPresetList(args []string, stdout, stderr io.Writer) int {
@@ -61,16 +110,24 @@ func runPresetList(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	return withStoreExit(*home, stderr, "list presets", func(store *db.Store) error {
-		installed, err := installedPresets(context.Background(), store)
+		cachedPresets, err := store.ListPresets(context.Background())
 		if err != nil {
 			return err
 		}
+		installed := installedPresetMap(cachedPresets)
 		for _, definition := range preset.Builtins() {
 			status := "available"
 			if installedPreset, ok := installed[definition.ID]; ok {
 				status = "installed@" + shortCommit(installedPreset.ResolvedCommit)
 			}
 			fmt.Fprintf(stdout, "%-36s %-18s %s\n", definition.ID, status, definition.SourceRepo+"/"+definition.SourcePath)
+		}
+		for _, cached := range cachedPresets {
+			if _, ok := preset.Lookup(cached.ID); ok {
+				continue
+			}
+			status := "installed@" + shortCommit(cached.ResolvedCommit)
+			fmt.Fprintf(stdout, "%-36s %-18s %s:%s\n", cached.ID, status, cached.SourceRepo, cached.SourcePath)
 		}
 		return nil
 	})
@@ -90,29 +147,32 @@ func runPresetShow(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "preset show requires exactly one preset id")
 		return 2
 	}
-	definition, ok := preset.Lookup(fs.Arg(0))
-	if !ok {
-		fmt.Fprintf(stderr, "unknown preset %q\n", fs.Arg(0))
-		return 2
-	}
+	id := fs.Arg(0)
 	return withStoreExit(*home, stderr, "show preset", func(store *db.Store) error {
-		cached, err := store.GetPreset(context.Background(), definition.ID)
-		installed := true
-		if errors.Is(err, sql.ErrNoRows) {
-			installed = false
-		} else if err != nil {
-			return err
-		}
-		writePresetDefinition(stdout, definition)
-		if !installed {
-			fmt.Fprintln(stdout, "installed: no")
+		if definition, ok := preset.Lookup(id); ok {
+			cached, err := store.GetPreset(context.Background(), definition.ID)
+			installed := true
+			if errors.Is(err, sql.ErrNoRows) {
+				installed = false
+			} else if err != nil {
+				return err
+			}
+			writePresetDefinition(stdout, definition)
+			if !installed {
+				fmt.Fprintln(stdout, "installed: no")
+				return nil
+			}
+			writeInstalledPreset(stdout, cached)
 			return nil
 		}
-		fmt.Fprintln(stdout, "installed: yes")
-		fmt.Fprintf(stdout, "resolved commit: %s\n", cached.ResolvedCommit)
-		fmt.Fprintf(stdout, "updated: %s\n", cached.UpdatedAt)
-		fmt.Fprintln(stdout, "content:")
-		fmt.Fprintln(stdout, strings.TrimRight(cached.Content, "\n"))
+		cached, err := store.GetPreset(context.Background(), id)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("unknown preset %q", id)
+		}
+		if err != nil {
+			return err
+		}
+		writeCustomPreset(stdout, cached)
 		return nil
 	})
 }
@@ -132,12 +192,8 @@ func runPresetUpdate(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	id := fs.Arg(0)
-	if _, ok := preset.Lookup(id); !ok {
-		fmt.Fprintf(stderr, "unknown preset %q\n", id)
-		return 2
-	}
 	return withStoreExit(*home, stderr, "update preset", func(store *db.Store) error {
-		updated, err := preset.Update(context.Background(), store, newPresetFetcher(), id)
+		updated, err := updatePresetByID(context.Background(), store, id)
 		if err != nil {
 			return err
 		}
@@ -160,18 +216,31 @@ func runPresetDiff(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "preset diff requires exactly one preset id")
 		return 2
 	}
-	definition, ok := preset.Lookup(fs.Arg(0))
-	if !ok {
-		fmt.Fprintf(stderr, "unknown preset %q\n", fs.Arg(0))
-		return 2
-	}
+	id := fs.Arg(0)
 	return withStoreExit(*home, stderr, "diff preset", func(store *db.Store) error {
-		cached, err := store.GetPreset(context.Background(), definition.ID)
+		cached, err := store.GetPreset(context.Background(), id)
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("preset %s is not installed; run gitmoot preset update %s", definition.ID, definition.ID)
+			if _, ok := preset.Lookup(id); ok {
+				return fmt.Errorf("preset %s is not installed; run gitmoot preset update %s", id, id)
+			}
+			return fmt.Errorf("unknown preset %q", id)
 		}
 		if err != nil {
 			return err
+		}
+		if preset.IsLocal(cached) {
+			file, hash, err := preset.ReadLocalForDiff(cached.SourcePath)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, "cached:   %s\n", cached.ResolvedCommit)
+			fmt.Fprintf(stdout, "upstream: %s\n", hash)
+			fmt.Fprint(stdout, preset.DiffExact(cached.Content, file.Content))
+			return nil
+		}
+		definition, ok := preset.Lookup(id)
+		if !ok {
+			return fmt.Errorf("preset %s is not a local custom preset and has no built-in source", id)
 		}
 		fetcher := newPresetFetcher()
 		resolvedCommit, err := fetcher.ResolveRef(context.Background(), definition.SourceRepo, definition.SourceRef)
@@ -189,16 +258,29 @@ func runPresetDiff(args []string, stdout, stderr io.Writer) int {
 	})
 }
 
-func installedPresets(ctx context.Context, store *db.Store) (map[string]db.Preset, error) {
-	presets, err := store.ListPresets(ctx)
-	if err != nil {
-		return nil, err
+func updatePresetByID(ctx context.Context, store *db.Store, id string) (db.Preset, error) {
+	if _, ok := preset.Lookup(id); ok {
+		return preset.Update(ctx, store, newPresetFetcher(), id)
 	}
+	cached, err := store.GetPreset(ctx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.Preset{}, fmt.Errorf("unknown preset %q; run gitmoot preset add %s --file <path>", id, id)
+	}
+	if err != nil {
+		return db.Preset{}, err
+	}
+	if !preset.IsLocal(cached) {
+		return db.Preset{}, fmt.Errorf("preset %s is not a local custom preset and has no built-in source", id)
+	}
+	return preset.UpdateLocal(ctx, store, cached)
+}
+
+func installedPresetMap(presets []db.Preset) map[string]db.Preset {
 	installed := make(map[string]db.Preset, len(presets))
 	for _, cached := range presets {
 		installed[cached.ID] = cached
 	}
-	return installed, nil
+	return installed
 }
 
 func writePresetDefinition(w io.Writer, definition preset.Definition) {
@@ -209,6 +291,25 @@ func writePresetDefinition(w io.Writer, definition preset.Definition) {
 	fmt.Fprintf(w, "default role: %s\n", definition.DefaultRole)
 	fmt.Fprintf(w, "default capabilities: %s\n", strings.Join(definition.DefaultCapabilities, ","))
 	fmt.Fprintf(w, "mutation: %t\n", definition.Mutation)
+}
+
+func writeCustomPreset(w io.Writer, cached db.Preset) {
+	fmt.Fprintf(w, "id: %s\n", cached.ID)
+	fmt.Fprintf(w, "name: %s\n", cached.Name)
+	fmt.Fprintf(w, "description: %s\n", cached.Description)
+	fmt.Fprintf(w, "source: %s@%s:%s\n", cached.SourceRepo, cached.SourceRef, cached.SourcePath)
+	fmt.Fprintln(w, "default role: ")
+	fmt.Fprintln(w, "default capabilities: ")
+	fmt.Fprintln(w, "mutation: false")
+	writeInstalledPreset(w, cached)
+}
+
+func writeInstalledPreset(w io.Writer, cached db.Preset) {
+	fmt.Fprintln(w, "installed: yes")
+	fmt.Fprintf(w, "resolved commit: %s\n", cached.ResolvedCommit)
+	fmt.Fprintf(w, "updated: %s\n", cached.UpdatedAt)
+	fmt.Fprintln(w, "content:")
+	fmt.Fprintln(w, strings.TrimRight(cached.Content, "\n"))
 }
 
 func shortCommit(commit string) string {

--- a/internal/cli/preset_test.go
+++ b/internal/cli/preset_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -92,6 +94,176 @@ func TestPresetListShowsAvailableBuiltin(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "thermo-nuclear-code-quality-review") || !strings.Contains(stdout.String(), "available") {
 		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func TestPresetAddInstallsLocalCustomPreset(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	promptPath := filepath.Join(t.TempDir(), "frontend.md")
+	if err := os.WriteFile(promptPath, []byte("Review frontend changes.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	code := Run([]string{
+		"preset", "add", "frontend-reviewer",
+		"--home", home,
+		"--file", promptPath,
+		"--name", "Frontend Reviewer",
+		"--description", "Reviews UI.",
+	}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("preset add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "added frontend-reviewer at sha256:") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"preset", "show", "--home", home, "frontend-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("preset show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"name: Frontend Reviewer", "description: Reviews UI.", "source: local@file:", "installed: yes", "Review frontend changes."} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("show output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestPresetAddRejectsInvalidLocalFiles(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	dir := t.TempDir()
+	emptyPath := filepath.Join(dir, "empty.md")
+	if err := os.WriteFile(emptyPath, []byte("\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	cases := [][]string{
+		{"preset", "add", "--home", home, "frontend-reviewer"},
+		{"preset", "add", "--home", home, "--file", filepath.Join(dir, "missing.md"), "frontend-reviewer"},
+		{"preset", "add", "--home", home, "--file", dir, "frontend-reviewer"},
+		{"preset", "add", "--home", home, "--file", emptyPath, "frontend-reviewer"},
+		{"preset", "add", "--home", home, "--file", emptyPath, "Bad"},
+	}
+	for _, args := range cases {
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run(args, &stdout, &stderr); code == 0 {
+			t.Fatalf("Run(%v) exit code = 0, stdout=%s stderr=%s", args, stdout.String(), stderr.String())
+		}
+	}
+}
+
+func TestPresetListShowsInstalledCustomPreset(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	promptPath := filepath.Join(t.TempDir(), "frontend.md")
+	if err := os.WriteFile(promptPath, []byte("Review frontend changes.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	apiPromptPath := filepath.Join(t.TempDir(), "api.md")
+	if err := os.WriteFile(apiPromptPath, []byte("Review API changes.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if code := Run([]string{"preset", "add", "--home", home, "--file", promptPath, "frontend-reviewer"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("preset add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"preset", "add", "--home", home, "--file", apiPromptPath, "api-reviewer"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("preset add exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"preset", "list", "--home", home}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("preset list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"thermo-nuclear-code-quality-review", "api-reviewer", "frontend-reviewer", "installed@sha256:"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("list output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.Index(stdout.String(), "api-reviewer") > strings.Index(stdout.String(), "frontend-reviewer") {
+		t.Fatalf("custom presets are not sorted:\n%s", stdout.String())
+	}
+}
+
+func TestPresetUpdateAndDiffLocalCustomPreset(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	promptPath := filepath.Join(t.TempDir(), "frontend.md")
+	if err := os.WriteFile(promptPath, []byte("Old prompt.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if code := Run([]string{"preset", "add", "--home", home, "--file", promptPath, "frontend-reviewer"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("preset add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if err := os.WriteFile(promptPath, []byte("New prompt.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"preset", "diff", "--home", home, "frontend-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("preset diff exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"cached:   sha256:", "upstream: sha256:", "-Old prompt.", "+New prompt."} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("diff output missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"preset", "show", "--home", home, "frontend-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("preset show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Old prompt.") || strings.Contains(stdout.String(), "New prompt.") {
+		t.Fatalf("diff mutated cached preset:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"preset", "update", "--home", home, "frontend-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("preset update exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "updated frontend-reviewer at sha256:") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func TestPresetDiffReportsExactTrailingNewlineChanges(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	promptPath := filepath.Join(t.TempDir(), "frontend.md")
+	if err := os.WriteFile(promptPath, []byte("Prompt.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if code := Run([]string{"preset", "add", "frontend-reviewer", "--home", home, "--file", promptPath}, &stdout, &stderr); code != 0 {
+		t.Fatalf("preset add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if err := os.WriteFile(promptPath, []byte("Prompt.\n\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"preset", "diff", "--home", home, "frontend-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("preset diff exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "preset content is up to date") || !strings.Contains(stdout.String(), "+++ upstream") {
+		t.Fatalf("diff did not report exact newline change:\n%s", stdout.String())
 	}
 }
 

--- a/internal/preset/preset.go
+++ b/internal/preset/preset.go
@@ -2,11 +2,16 @@ package preset
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -14,6 +19,11 @@ import (
 )
 
 const ThermoNuclearCodeQualityReviewID = "thermo-nuclear-code-quality-review"
+const LocalSourceRepo = "local"
+const LocalSourceRef = "file"
+const DefaultLocalDescription = "Local custom prompt preset."
+
+var idPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$`)
 
 type Definition struct {
 	ID                  string
@@ -64,6 +74,96 @@ func Lookup(id string) (Definition, bool) {
 		}
 	}
 	return Definition{}, false
+}
+
+func ValidateID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("preset id is required")
+	}
+	if !idPattern.MatchString(id) {
+		return fmt.Errorf("invalid preset id %q; use lowercase letters, numbers, and single dashes", id)
+	}
+	return nil
+}
+
+func AddLocal(ctx context.Context, store *db.Store, id string, path string, name string, description string) (db.Preset, error) {
+	if store == nil {
+		return db.Preset{}, errors.New("preset store is required")
+	}
+	id = strings.TrimSpace(id)
+	if err := ValidateID(id); err != nil {
+		return db.Preset{}, err
+	}
+	if _, ok := Lookup(id); ok {
+		return db.Preset{}, fmt.Errorf("preset %s is built in and cannot be replaced with a local preset", id)
+	}
+	local, err := readLocal(path)
+	if err != nil {
+		return db.Preset{}, err
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = id
+	}
+	description = strings.TrimSpace(description)
+	if description == "" {
+		description = DefaultLocalDescription
+	}
+	preset := db.Preset{
+		ID:             id,
+		Name:           name,
+		Description:    description,
+		SourceRepo:     LocalSourceRepo,
+		SourceRef:      LocalSourceRef,
+		SourcePath:     local.Path,
+		ResolvedCommit: HashContent(local.Content),
+		Content:        local.Content,
+	}
+	if err := store.UpsertPreset(ctx, preset); err != nil {
+		return db.Preset{}, err
+	}
+	return store.GetPreset(ctx, preset.ID)
+}
+
+func UpdateLocal(ctx context.Context, store *db.Store, cached db.Preset) (db.Preset, error) {
+	if store == nil {
+		return db.Preset{}, errors.New("preset store is required")
+	}
+	if !IsLocal(cached) {
+		return db.Preset{}, fmt.Errorf("preset %s is not a local custom preset", cached.ID)
+	}
+	local, err := readLocal(cached.SourcePath)
+	if err != nil {
+		return db.Preset{}, err
+	}
+	updated := cached
+	updated.SourceRepo = LocalSourceRepo
+	updated.SourceRef = LocalSourceRef
+	updated.SourcePath = local.Path
+	updated.ResolvedCommit = HashContent(local.Content)
+	updated.Content = local.Content
+	if err := store.UpsertPreset(ctx, updated); err != nil {
+		return db.Preset{}, err
+	}
+	return store.GetPreset(ctx, updated.ID)
+}
+
+func ReadLocalForDiff(path string) (File, string, error) {
+	local, err := readLocal(path)
+	if err != nil {
+		return File{}, "", err
+	}
+	return File{Content: local.Content}, HashContent(local.Content), nil
+}
+
+func IsLocal(preset db.Preset) bool {
+	return preset.SourceRepo == LocalSourceRepo && preset.SourceRef == LocalSourceRef
+}
+
+func HashContent(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func Update(ctx context.Context, store *db.Store, fetcher Fetcher, id string) (db.Preset, error) {
@@ -175,9 +275,50 @@ func stripBase64Whitespace(value string) string {
 	return replacer.Replace(value)
 }
 
+type localFile struct {
+	Path    string
+	Content string
+}
+
+func readLocal(path string) (localFile, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return localFile{}, errors.New("preset file is required")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return localFile{}, fmt.Errorf("resolve preset file path: %w", err)
+	}
+	abs = filepath.Clean(abs)
+	info, err := os.Stat(abs)
+	if err != nil {
+		return localFile{}, fmt.Errorf("read preset file %s: %w", abs, err)
+	}
+	if info.IsDir() {
+		return localFile{}, fmt.Errorf("preset file %s is a directory", abs)
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return localFile{}, fmt.Errorf("read preset file %s: %w", abs, err)
+	}
+	content := string(data)
+	if strings.TrimSpace(content) == "" {
+		return localFile{}, fmt.Errorf("preset file %s is empty", abs)
+	}
+	return localFile{Path: abs, Content: content}, nil
+}
+
 func Diff(local string, upstream string) string {
 	local = strings.TrimRight(local, "\n")
 	upstream = strings.TrimRight(upstream, "\n")
+	return diffLines(local, upstream)
+}
+
+func DiffExact(local string, upstream string) string {
+	return diffLines(local, upstream)
+}
+
+func diffLines(local string, upstream string) string {
 	if local == upstream {
 		return "preset content is up to date\n"
 	}

--- a/internal/preset/preset_test.go
+++ b/internal/preset/preset_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
@@ -57,6 +60,120 @@ func TestDiffReportsChangedContent(t *testing.T) {
 		if !strings.Contains(diff, want) {
 			t.Fatalf("diff missing %q:\n%s", want, diff)
 		}
+	}
+}
+
+func TestDiffExactReportsTrailingNewlineChange(t *testing.T) {
+	diff := DiffExact("same\n", "same\n\n")
+	if strings.Contains(diff, "up to date") || !strings.Contains(diff, "+++ upstream") {
+		t.Fatalf("diff = %s", diff)
+	}
+}
+
+func TestValidateID(t *testing.T) {
+	for _, id := range []string{"frontend-reviewer", "reviewer2", "a"} {
+		if err := ValidateID(id); err != nil {
+			t.Fatalf("ValidateID(%q) returned error: %v", id, err)
+		}
+	}
+	for _, id := range []string{"", "Frontend", "-bad", "bad-", "bad--id", "bad_id", "bad.id"} {
+		if err := ValidateID(id); err == nil {
+			t.Fatalf("ValidateID(%q) returned nil", id)
+		}
+	}
+}
+
+func TestAddLocalInstallsCustomPreset(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	promptPath := filepath.Join(t.TempDir(), "reviewer.md")
+	if err := os.WriteFile(promptPath, []byte("Review UI changes.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	added, err := AddLocal(ctx, store, "frontend-reviewer", promptPath, "", "")
+	if err != nil {
+		t.Fatalf("AddLocal returned error: %v", err)
+	}
+
+	if added.ID != "frontend-reviewer" || added.Name != "frontend-reviewer" || added.Description != DefaultLocalDescription {
+		t.Fatalf("added preset metadata = %+v", added)
+	}
+	if added.SourceRepo != LocalSourceRepo || added.SourceRef != LocalSourceRef || !filepath.IsAbs(added.SourcePath) {
+		t.Fatalf("added preset source = %+v", added)
+	}
+	if added.ResolvedCommit != HashContent("Review UI changes.\n") || added.Content != "Review UI changes.\n" {
+		t.Fatalf("added preset content = %+v", added)
+	}
+}
+
+func TestAddLocalRejectsInvalidInputs(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	dir := t.TempDir()
+	emptyPath := filepath.Join(dir, "empty.md")
+	if err := os.WriteFile(emptyPath, []byte(" \n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	validPath := filepath.Join(dir, "valid.md")
+	if err := os.WriteFile(validPath, []byte("Prompt."), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	cases := []struct {
+		id   string
+		path string
+	}{
+		{id: "Bad", path: validPath},
+		{id: ThermoNuclearCodeQualityReviewID, path: validPath},
+		{id: "missing", path: filepath.Join(dir, "missing.md")},
+		{id: "directory", path: dir},
+		{id: "empty", path: emptyPath},
+	}
+	for _, tc := range cases {
+		if _, err := AddLocal(ctx, store, tc.id, tc.path, "", ""); err == nil {
+			t.Fatalf("AddLocal(%q, %q) returned nil", tc.id, tc.path)
+		}
+	}
+}
+
+func TestUpdateLocalRefreshesFromStoredPath(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	promptPath := filepath.Join(t.TempDir(), "reviewer.md")
+	if err := os.WriteFile(promptPath, []byte("Old prompt.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	added, err := AddLocal(ctx, store, "frontend-reviewer", promptPath, "Frontend Reviewer", "Reviews UI.")
+	if err != nil {
+		t.Fatalf("AddLocal returned error: %v", err)
+	}
+	if err := os.WriteFile(promptPath, []byte("New prompt.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	updated, err := UpdateLocal(ctx, store, added)
+	if err != nil {
+		t.Fatalf("UpdateLocal returned error: %v", err)
+	}
+
+	if updated.Name != "Frontend Reviewer" || updated.Description != "Reviews UI." {
+		t.Fatalf("UpdateLocal changed metadata: %+v", updated)
+	}
+	if updated.Content != "New prompt.\n" || updated.ResolvedCommit != HashContent("New prompt.\n") {
+		t.Fatalf("UpdateLocal content = %+v", updated)
 	}
 }
 


### PR DESCRIPTION
WHAT:
- Added local custom prompt presets through `gitmoot preset add <id> --file <path>`.
- Integrated installed custom presets with agent start/subscribe and preset list/show/update/diff.

WHY:
- Users need reusable local prompt files for Gitmoot-managed agents without relying on runtime-specific slash commands or live prompt files during job delivery.

CHANGES:
- Added local preset validation, exact content snapshotting, sha256 resolved identifiers, local update, and exact diff support.
- Added preset CLI support for custom add/list/show/update/diff while preserving the built-in thermo preset flow.
- Updated agent defaults and installed-preset validation so custom presets work for `agent start` and require explicit role/capabilities for `agent subscribe`.
- Added focused CLI and preset package tests for happy paths, invalid files, missing preset guidance, deterministic listing, exact local diffs, and startup prompt snapshots.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `git diff --check`
- `codex exec review --uncommitted` raw output:

```text
codex
I did not identify any discrete, actionable correctness issues in the current staged, unstaged, or untracked changes.
I did not identify any discrete, actionable correctness issues in the current staged, unstaged, or untracked changes.
```

RISK:
- Plain local `go test` is not usable on this host because the repo requires Go 1.26; checks used `GOTOOLCHAIN=go1.26.0`.
- Custom presets intentionally do not define default subscribe role/capabilities in v1.