### PR TITLE
docs: describe custom prompt agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ gitmoot daemon start [--repo owner/repo] [--poll 30s]
 gitmoot daemon run [--repo owner/repo] [--poll 30s]
 gitmoot daemon stop|restart|status|logs
 gitmoot preset list
-gitmoot preset show|update|diff thermo-nuclear-code-quality-review
+gitmoot preset add <preset-id> --file ./agents/<preset-id>.md
+gitmoot preset show|update|diff <preset-id>
 gitmoot agent start <name> --runtime codex|claude --repo owner/repo [--path .] [--preset <preset-id>] [--start-daemon]
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
 gitmoot agent start thermo-review --runtime codex --repo owner/repo --preset thermo-nuclear-code-quality-review
@@ -87,6 +88,33 @@ Check upstream changes before refreshing the cached preset:
 ```sh
 gitmoot preset diff thermo-nuclear-code-quality-review
 gitmoot preset update thermo-nuclear-code-quality-review
+```
+
+## Custom Prompt Presets
+
+Custom presets let you keep a local prompt file and bind its snapshotted
+instructions to any Gitmoot agent.
+
+```sh
+mkdir -p agents
+printf '%s\n' 'Review frontend changes for correctness and responsive behavior.' > agents/frontend-reviewer.md
+gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
+gitmoot agent start frontend-reviewer \
+  --runtime codex \
+  --repo owner/repo \
+  --preset frontend-reviewer \
+  --role reviewer \
+  --capability ask \
+  --capability review
+```
+
+Gitmoot copies the file content into local SQLite when you run `preset add` or
+`preset update`. Jobs use that cached snapshot. After editing the prompt file,
+run:
+
+```sh
+gitmoot preset diff frontend-reviewer
+gitmoot preset update frontend-reviewer
 ```
 
 ## Documentation

--- a/SKILL.md
+++ b/SKILL.md
@@ -88,6 +88,35 @@ gitmoot preset diff thermo-nuclear-code-quality-review
 gitmoot preset update thermo-nuclear-code-quality-review
 ```
 
+## Custom Prompt Presets
+
+Users can install local prompt files as custom presets. Gitmoot snapshots the
+file content into local SQLite at add/update time; queued jobs use that cached
+snapshot, not the live file.
+
+```sh
+gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
+gitmoot agent start frontend-reviewer \
+  --runtime codex \
+  --repo owner/repo \
+  --preset frontend-reviewer \
+  --role reviewer \
+  --capability ask \
+  --capability review
+```
+
+Use `agent start` to create a new Codex or Claude runtime session. Use
+`agent subscribe` when the runtime session already exists. Custom presets do
+not provide default role or capabilities for subscribed agents, so pass
+`--role` and one or more `--capability` flags.
+
+After editing a local prompt file, refresh the cached snapshot explicitly:
+
+```sh
+gitmoot preset diff frontend-reviewer
+gitmoot preset update frontend-reviewer
+```
+
 ## Required Result Contract
 
 Every agent job must return a `gitmoot_result` JSON object. Keep it concise and

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -135,8 +135,11 @@ assumptions into workflow, daemon, GitHub, database, or merge-gate code.
 ## Presets
 
 Presets are prompt/profile bundles layered above runtimes. They are not runtime
-adapters and should not create adapter-specific behavior. The built-in
-`thermo-nuclear-code-quality-review` preset is fetched explicitly with:
+adapters and should not create adapter-specific behavior. Gitmoot snapshots
+cached preset content into startup and job prompts before invoking an adapter.
+
+The built-in `thermo-nuclear-code-quality-review` preset is fetched explicitly
+with:
 
 ```sh
 gitmoot preset update thermo-nuclear-code-quality-review
@@ -153,6 +156,18 @@ gitmoot agent start thermo-review \
 
 The thermo preset is non-mutating. It supplies reviewer defaults and allows
 `ask,review`, but it cannot grant `implement`.
+
+Local custom presets are installed from files:
+
+```sh
+gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
+```
+
+They store `local@file:<absolute-path>` metadata and a `sha256:<hash>` resolved
+identifier. Adapters should not read those files or decide how presets behave;
+workflow code passes only the rendered prompt. After a prompt file changes, the
+user must run `gitmoot preset update <custom-id>` before new jobs use the new
+content.
 
 ## Shell Adapter
 

--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -203,6 +203,106 @@ Expected signals:
    /tmp/gitmoot-current daemon status --home "$GITMOOT_SMOKE_HOME"
    ```
 
+## Custom Prompt Preset Smoke Test
+
+Goal: local prompt file -> cached custom preset -> preset-backed Codex agent ->
+queued PR comment job with custom preset metadata.
+
+Prerequisites: a safe test repository, authenticated `gh`, installed Codex, and
+a Gitmoot build that includes `preset add`.
+
+1. Build a local test binary and use an isolated Gitmoot home.
+
+   ```sh
+   GOTOOLCHAIN=go1.26.0 go build -o /tmp/gitmoot-current ./cmd/gitmoot
+   export GITMOOT_SMOKE_HOME=/tmp/gitmoot-custom-preset-smoke
+   rm -rf "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current init --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+2. From the test repo checkout, create and install a local prompt preset.
+
+   ```sh
+   cd /path/to/project
+   mkdir -p agents
+   printf '%s\n' 'Review only correctness, regressions, and missing tests.' > agents/local-reviewer.md
+   /tmp/gitmoot-current preset add local-reviewer \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --file agents/local-reviewer.md \
+     --name "Local Reviewer"
+   /tmp/gitmoot-current preset show --home "$GITMOOT_SMOKE_HOME" local-reviewer
+   ```
+
+3. Start or subscribe a Codex test agent with the custom preset.
+
+   ```sh
+   /tmp/gitmoot-current agent start local-reviewer \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --runtime codex \
+     --repo owner/project \
+     --path . \
+     --preset local-reviewer \
+     --role reviewer \
+     --capability ask \
+     --capability review \
+     --start-daemon
+   /tmp/gitmoot-current agent doctor local-reviewer --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+   To register an existing session instead, use:
+
+   ```sh
+   /tmp/gitmoot-current agent subscribe local-reviewer \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --runtime codex \
+     --session <session-id-or-last> \
+     --repo owner/project \
+     --preset local-reviewer \
+     --role reviewer \
+     --capability ask \
+     --capability review
+   /tmp/gitmoot-current daemon start \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --repo owner/project \
+     --poll 10s
+   ```
+
+4. Open a disposable PR, then comment:
+
+   ```text
+   /gitmoot local-reviewer review
+   ```
+
+5. Verify the job and metadata.
+
+   ```sh
+   /tmp/gitmoot-current job list --home "$GITMOOT_SMOKE_HOME" --repo owner/project
+   /tmp/gitmoot-current job show <job-id> --home "$GITMOOT_SMOKE_HOME"
+   gh pr view <number> --repo owner/project --comments
+   ```
+
+Expected signals:
+
+- `preset show` displays `source: local@file:` and `resolved commit: sha256:...`.
+- The PR receives a queued-job acknowledgement for `local-reviewer`.
+- The result comment includes `Agent`, `Runtime`, `Preset`, and `Job` metadata.
+- `job show <job-id>` includes the custom preset id and `sha256:` content hash.
+
+6. Edit and refresh the prompt only through explicit preset commands.
+
+   ```sh
+   printf '%s\n' 'Review correctness, regressions, missing tests, and edge cases.' > agents/local-reviewer.md
+   /tmp/gitmoot-current preset diff --home "$GITMOOT_SMOKE_HOME" local-reviewer
+   /tmp/gitmoot-current preset update --home "$GITMOOT_SMOKE_HOME" local-reviewer
+   ```
+
+7. Stop the isolated daemon.
+
+   ```sh
+   /tmp/gitmoot-current daemon stop --home "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current daemon status --home "$GITMOOT_SMOKE_HOME"
+   ```
+
 ## Two-Repo Smoke Test
 
 Goal: one daemon -> two registered repos -> same allowed agent -> ask jobs in

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -15,6 +15,7 @@ registration, plan import, task branch startup, status, recovery, and updates:
 gitmoot setup --repo owner/repo --path . --agent lead --runtime codex --session <session-ref> --role lead
 gitmoot doctor --repo .
 gitmoot preset list
+gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
 gitmoot preset update thermo-nuclear-code-quality-review
 gitmoot agent start <name> --runtime codex|claude --repo owner/repo --path . --preset thermo-nuclear-code-quality-review --start-daemon
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
@@ -102,6 +103,36 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    Add `--update-preset` when you want startup to refresh the cached preset
    before creating the runtime session.
 
+   Custom prompt presets are local files snapshotted into Gitmoot state. Use
+   them when you want a repo- or team-specific agent profile without changing
+   Codex, Claude, or repository agent files.
+
+   ```sh
+   mkdir -p agents
+   printf '%s\n' 'Review frontend changes for correctness and responsive behavior.' > agents/frontend-reviewer.md
+   gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
+   gitmoot agent start frontend-reviewer \
+     --runtime codex \
+     --repo owner/project \
+     --path . \
+     --preset frontend-reviewer \
+     --role reviewer \
+     --capability ask \
+     --capability review
+   ```
+
+   Built-in presets can define default roles and capabilities. Custom presets
+   do not in V1, so pass the role and capabilities you want. `agent start`
+   still keeps the normal fallback defaults if omitted, while
+   `agent subscribe --preset <custom-id>` requires explicit values.
+
+   After editing a custom prompt file, refresh the cached snapshot explicitly:
+
+   ```sh
+   gitmoot preset diff frontend-reviewer
+   gitmoot preset update frontend-reviewer
+   ```
+
    After startup, open a created Codex session later with the session id printed
    by Gitmoot:
 
@@ -122,7 +153,8 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    ```
 
    Preset updates are explicit and auditable. Diff upstream content before
-   refreshing the local cached copy:
+   refreshing the local cached copy. For custom presets, `diff` compares the
+   cached content with the stored local file path.
 
    ```sh
    gitmoot preset diff thermo-nuclear-code-quality-review

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,6 +53,9 @@ Symptoms:
 
 - `gitmoot agent subscribe ... --preset thermo-nuclear-code-quality-review`
   fails with an install hint.
+- `gitmoot agent start ... --preset <custom-id>` fails with a `preset add`
+  hint.
+- A custom prompt edit is not reflected in new jobs.
 - A preset-backed job does not include the expected review instructions.
 - You want to know whether the cached preset differs from upstream.
 
@@ -61,7 +64,9 @@ Checks:
 ```sh
 gitmoot preset list
 gitmoot preset show thermo-nuclear-code-quality-review
+gitmoot preset show <custom-id>
 gitmoot preset diff thermo-nuclear-code-quality-review
+gitmoot preset diff <custom-id>
 gitmoot agent list
 ```
 
@@ -71,6 +76,13 @@ Fixes:
 
   ```sh
   gitmoot preset update thermo-nuclear-code-quality-review
+  ```
+
+  For a custom local prompt file:
+
+  ```sh
+  gitmoot preset add <custom-id> --file agents/<custom-id>.md
+  gitmoot preset update <custom-id>
   ```
 
 - Re-subscribe the agent after the preset is installed:
@@ -87,6 +99,9 @@ Fixes:
 - Preset content is snapshotted when a job is queued. Retry an existing job to
   reuse its original snapshot; comment again after `preset update` to queue a
   job with refreshed content.
+- Custom preset files are not read at job runtime. Run
+  `gitmoot preset diff <custom-id>` and `gitmoot preset update <custom-id>`
+  after editing the file.
 - The thermo preset is review-only. Remove `--capability implement` and route
   implementation work to a separate implementation-capable agent.
 


### PR DESCRIPTION
WHAT:
- Documented local custom prompt presets in README, SKILL.md, workflow docs, adapter docs, smoke tests, and troubleshooting.

WHY:
- Users and agents need a concise path for creating prompt files, installing them as presets, starting/subscribing agents, and refreshing cached snapshots after edits.

CHANGES:
- Added copyable `preset add` and custom agent examples.
- Clarified built-in presets vs local custom presets, `agent start` vs `agent subscribe`, and snapshot/update behavior.
- Added a custom prompt preset smoke test, including the subscribe path daemon start.
- Added troubleshooting guidance for missing custom presets and stale prompt snapshots.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `GOTOOLCHAIN=go1.26.0 go vet ./...`
- `git diff --check`
- Local smoke subset: built `/tmp/gitmoot-current-custom-preset-docs`, installed/showed/diffed/updated a custom preset in an isolated home, and subscribed a preset-backed shell agent.
- `codex exec review --uncommitted` raw output after fixes:

```text
codex
The changes are documentation-only and accurately describe the existing custom preset behavior and CLI command shapes. I did not find any discrete correctness issues introduced by the patch.
The changes are documentation-only and accurately describe the existing custom preset behavior and CLI command shapes. I did not find any discrete correctness issues introduced by the patch.
```

RISK:
- Did not run the live Codex + disposable PR portion of the smoke test in this task; that requires an explicit safe PR target and runtime invocation. The local custom-preset registration/update path was smoke-tested.