### PR TITLE
docs: package Gitmoot as an Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ gitmoot job list|show|events|run|retry|cancel
 gitmoot lock list|show|release
 ```
 
-Agents should read [SKILL.md](SKILL.md) for the Gitmoot job contract, branch
-lock expectations, and safe behavior rules.
+Agents should read the canonical Agent Skills package at
+[skills/gitmoot/SKILL.md](skills/gitmoot/SKILL.md) for the Gitmoot job contract,
+branch lock expectations, and safe behavior rules. The root [SKILL.md](SKILL.md)
+remains as a raw compatibility entrypoint for agents and `gitmoot.io/SKILL.md`.
 
 ## Thermo Review Preset
 
@@ -119,6 +121,7 @@ gitmoot preset update frontend-reviewer
 
 ## Documentation
 
+- [Agent Skills package](skills/gitmoot/SKILL.md)
 - [Local workflow walkthrough](docs/local-workflow.md)
 - [Beta smoke tests](docs/beta-smoke-tests.md)
 - [Runtime adapter authoring](docs/adapters.md)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: gitmoot
 description: Use Gitmoot for local-first multi-agent coordination through GitHub PR comments, repo-scoped agent subscriptions, daemon checks, jobs, branch locks, presets, custom prompt agents, and Codex or Claude Code runtime workflows.
+version: 0.1.0
 license: MIT
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
 metadata:
   gitmoot-version: "0.1.0"
   source: "jerryfane/gitmoot"
+  openclaw:
+    requires:
+      bins:
+        - gitmoot
+        - git
+        - gh
+    envVars:
+      - name: GH_TOKEN
+        required: false
+        description: Optional GitHub token used by gh when GitHub CLI is not already authenticated.
 ---
 
 # Gitmoot Agent Skill

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 
 This root `SKILL.md` is kept as a raw compatibility entrypoint for agents and
 `gitmoot.io/SKILL.md`. The canonical Agent Skills package lives at
-`skills/gitmoot/`.
+`skills/gitmoot/`, with deeper reference files under `skills/gitmoot/references/`.
 
 Gitmoot is a local-first coordinator for AI agents working through GitHub pull
 requests. Use this skill when the user wants PR-comment agent workflows,
@@ -30,24 +30,111 @@ inspection.
    unless the user asks or the current task clearly requires it.
 5. Prefer read-only status commands before mutating Gitmoot state.
 
-## Common Commands
+## Install And Update
 
-Use `gitmoot status --repo owner/repo` for repo status, `gitmoot daemon status`
-for daemon state, `gitmoot agent list` for registered agents, and
-`gitmoot job list --repo owner/repo` for queued or recent jobs.
+If `gitmoot` is not installed, install the latest beta:
 
-For complete command examples, read
-`skills/gitmoot/references/CLI.md`. For end-to-end workflows, read
-`skills/gitmoot/references/WORKFLOWS.md`.
+```sh
+curl -fsSL https://gitmoot.io/install.sh | sh
+```
+
+Verify the install and GitHub access before using Gitmoot:
+
+```sh
+gitmoot version
+gitmoot update --check
+gh auth status
+```
+
+## Common Local Commands
+
+```sh
+gitmoot status --repo owner/repo
+gitmoot events --repo owner/repo
+gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon status
+gitmoot agent list
+gitmoot agent doctor <agent>
+gitmoot job list --repo owner/repo
+gitmoot job show <job-id>
+gitmoot job events <job-id>
+gitmoot lock list --repo owner/repo
+gitmoot lock show owner/repo <branch>
+```
+
+Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`
+only when the user explicitly wants a foreground process.
+
+## PR Comment Commands
+
+Use GitHub PR comments as the public audit trail:
+
+```text
+/gitmoot help
+/gitmoot status
+/gitmoot <agent> review [instructions]
+/gitmoot <agent> implement [instructions]
+/gitmoot ask <agent> [question]
+/gitmoot retry <job-id>
+/gitmoot cancel <job-id>
+/gitmoot merge
+```
+
+## Preset Agents
+
+Install or refresh the built-in thermo review preset:
+
+```sh
+gitmoot preset update thermo-nuclear-code-quality-review
+gitmoot agent start thermo-review \
+  --runtime codex \
+  --repo owner/repo \
+  --preset thermo-nuclear-code-quality-review \
+  --start-daemon
+```
+
+Create a local custom prompt preset:
+
+```sh
+gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
+gitmoot agent start frontend-reviewer \
+  --runtime codex \
+  --repo owner/repo \
+  --preset frontend-reviewer \
+  --role reviewer \
+  --capability ask \
+  --capability review
+```
+
+After editing a local prompt file, refresh Gitmoot's cached snapshot explicitly:
+
+```sh
+gitmoot preset diff frontend-reviewer
+gitmoot preset update frontend-reviewer
+```
 
 ## Agent Job Contract
 
 Every Gitmoot job should return a concise and truthful `gitmoot_result` JSON
-object. Use `blocked` when work cannot continue without human input or external
-state, and `failed` when an attempted action errored.
+object:
 
-For the required result shape and decision meanings, read
-`skills/gitmoot/references/RESULT_CONTRACT.md`.
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved|changes_requested|blocked|implemented|failed",
+    "summary": "Brief outcome.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "next_agents": []
+  }
+}
+```
+
+Use `blocked` when work cannot continue without human input or external state.
+Use `failed` when the attempted action errored. Do not report tests, changes, or
+approvals that were not actually verified.
 
 ## Safety Rules
 
@@ -56,7 +143,13 @@ scoped to the target repo. Do not commit generated data, caches, logs, secrets,
 session archives, cloned helper repos, or large outputs unless explicitly
 requested. Respect Gitmoot branch locks for implementation jobs.
 
-For detailed safety and lock rules, read `skills/gitmoot/references/SAFETY.md`.
+Implementation jobs must not edit or push an implementation branch unless
+Gitmoot assigned the job and the branch lock is held by the assigned agent.
+Review and ask jobs should inspect and report without mutating branches unless
+the task explicitly instructs otherwise.
+
+Redact secrets from GitHub comments, job summaries, raw examples, and copied
+command output.
 
 ## When Unsure
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,175 +1,64 @@
 ---
-name: gitmoot-agent
-description: Use Gitmoot to coordinate local AI agent sessions through GitHub pull requests, including PR commands, repo access, branch locks, job results, and safe agent behavior.
-version: 0.1.0
+name: gitmoot
+description: Use Gitmoot for local-first multi-agent coordination through GitHub PR comments, repo-scoped agent subscriptions, daemon checks, jobs, branch locks, presets, custom prompt agents, and Codex or Claude Code runtime workflows.
+license: MIT
+compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
 metadata:
-  openclaw:
-    requires:
-      bins:
-        - gitmoot
-        - git
-        - gh
-    envVars:
-      - name: GH_TOKEN
-        required: false
-        description: Optional GitHub token used by gh when GitHub CLI is not already authenticated.
+  gitmoot-version: "0.1.0"
+  source: "jerryfane/gitmoot"
 ---
 
 # Gitmoot Agent Skill
 
+This root `SKILL.md` is kept as a raw compatibility entrypoint for agents and
+`gitmoot.io/SKILL.md`. The canonical Agent Skills package lives at
+`skills/gitmoot/`.
+
 Gitmoot is a local-first coordinator for AI agents working through GitHub pull
-requests. A local `gitmoot daemon` watches PR comments, routes jobs to allowed
-agents, records job state in local SQLite, and posts attributed results back to
-the PR.
+requests. Use this skill when the user wants PR-comment agent workflows,
+repo-scoped agent subscriptions, background daemon checks, Codex or Claude Code
+agent startup, preset agents, custom prompt agents, job status, or branch lock
+inspection.
 
-## Install Gitmoot
+## Before Acting
 
-If `gitmoot` is not installed, install the latest beta:
+1. Check whether `gitmoot` is installed with `gitmoot version`.
+2. Confirm GitHub CLI access with `gh auth status` before using PR workflows.
+3. Detect or ask for the target repo before starting daemons, subscribing agents,
+   or routing jobs.
+4. Do not start daemons, create agents, update presets, or change subscriptions
+   unless the user asks or the current task clearly requires it.
+5. Prefer read-only status commands before mutating Gitmoot state.
 
-```sh
-curl -fsSL https://gitmoot.io/install.sh | sh
-```
+## Common Commands
 
-Verify the install and GitHub access before using Gitmoot:
+Use `gitmoot status --repo owner/repo` for repo status, `gitmoot daemon status`
+for daemon state, `gitmoot agent list` for registered agents, and
+`gitmoot job list --repo owner/repo` for queued or recent jobs.
 
-```sh
-gitmoot version
-gitmoot update --check
-gh auth status
-```
+For complete command examples, read
+`skills/gitmoot/references/CLI.md`. For end-to-end workflows, read
+`skills/gitmoot/references/WORKFLOWS.md`.
 
-## Core Workflow
+## Agent Job Contract
 
-Use GitHub PR comments as the public audit trail. Local Gitmoot state is the
-workflow source of truth.
+Every Gitmoot job should return a concise and truthful `gitmoot_result` JSON
+object. Use `blocked` when work cannot continue without human input or external
+state, and `failed` when an attempted action errored.
 
-Common PR commands:
+For the required result shape and decision meanings, read
+`skills/gitmoot/references/RESULT_CONTRACT.md`.
 
-```text
-/gitmoot help
-/gitmoot status
-/gitmoot <agent> review [instructions]
-/gitmoot <agent> implement [instructions]
-/gitmoot ask <agent> [question]
-/gitmoot retry <job-id>
-/gitmoot cancel <job-id>
-/gitmoot merge
-```
+## Safety Rules
 
-When unsure which agents or commands are available, ask for `/gitmoot help` or
-run local status commands before acting.
+Preserve existing behavior unless the job explicitly changes it. Keep work
+scoped to the target repo. Do not commit generated data, caches, logs, secrets,
+session archives, cloned helper repos, or large outputs unless explicitly
+requested. Respect Gitmoot branch locks for implementation jobs.
 
-## Thermo Review Preset
+For detailed safety and lock rules, read `skills/gitmoot/references/SAFETY.md`.
 
-Gitmoot can register the built-in `thermo-nuclear-code-quality-review` preset
-as a strict review-only agent. Preset content is updated explicitly and cached
-locally; queued jobs keep the preset snapshot they were created with.
+## When Unsure
 
-```sh
-gitmoot preset update thermo-nuclear-code-quality-review
-gitmoot agent subscribe thermo-review \
-  --runtime codex \
-  --session <session-id-or-last> \
-  --repo owner/repo \
-  --preset thermo-nuclear-code-quality-review
-gitmoot agent doctor thermo-review
-```
-
-Use it from a PR comment:
-
-```text
-/gitmoot thermo-review review
-```
-
-Check upstream changes before refreshing the cached preset:
-
-```sh
-gitmoot preset diff thermo-nuclear-code-quality-review
-gitmoot preset update thermo-nuclear-code-quality-review
-```
-
-## Custom Prompt Presets
-
-Users can install local prompt files as custom presets. Gitmoot snapshots the
-file content into local SQLite at add/update time; queued jobs use that cached
-snapshot, not the live file.
-
-```sh
-gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
-gitmoot agent start frontend-reviewer \
-  --runtime codex \
-  --repo owner/repo \
-  --preset frontend-reviewer \
-  --role reviewer \
-  --capability ask \
-  --capability review
-```
-
-Use `agent start` to create a new Codex or Claude runtime session. Use
-`agent subscribe` when the runtime session already exists. Custom presets do
-not provide default role or capabilities for subscribed agents, so pass
-`--role` and one or more `--capability` flags.
-
-After editing a local prompt file, refresh the cached snapshot explicitly:
-
-```sh
-gitmoot preset diff frontend-reviewer
-gitmoot preset update frontend-reviewer
-```
-
-## Required Result Contract
-
-Every agent job must return a `gitmoot_result` JSON object. Keep it concise and
-truthful.
-
-```json
-{
-  "gitmoot_result": {
-    "decision": "approved|changes_requested|blocked|implemented|failed",
-    "summary": "Brief outcome.",
-    "findings": [],
-    "changes_made": [],
-    "tests_run": [],
-    "needs": [],
-    "next_agents": []
-  }
-}
-```
-
-Use `blocked` when work cannot continue without human input or external state.
-Use `failed` when the attempted action errored. Do not report tests or changes
-that were not actually run or made.
-
-## Repo Access And Locks
-
-Agents are global identities with explicit per-repo access. A PR's repository is
-the routing context for `/gitmoot <agent> ...`.
-
-Implementation jobs must respect branch locks. Do not edit or push an
-implementation branch unless Gitmoot assigned the job and the branch lock is
-held by the assigned agent. Review and ask jobs should inspect and report
-without mutating the branch unless the task explicitly instructs otherwise.
-
-Useful local commands:
-
-```sh
-gitmoot status --repo owner/repo
-gitmoot events --repo owner/repo
-gitmoot job list --repo owner/repo
-gitmoot job show <job-id>
-gitmoot job events <job-id>
-gitmoot lock list --repo owner/repo
-gitmoot lock show owner/repo <branch>
-```
-
-## Safe Agent Behavior
-
-- Preserve existing behavior unless the job explicitly changes it.
-- Keep changes scoped to the job and the target repo.
-- Do not commit generated data, caches, logs, secrets, session archives, cloned
-  helper repos, or large outputs unless explicitly requested.
-- Verify external APIs, CLIs, env vars, generated scripts, and service launchers
-  with local commands or official docs before editing.
-- Redact secrets from summaries, comments, and raw examples.
-- If a Gitmoot instruction is unclear, reread this `SKILL.md`, then inspect
-  `/gitmoot help`, `gitmoot status`, and relevant job events.
+Reread this `SKILL.md`, then inspect `/gitmoot help`, `gitmoot status`, and the
+relevant job events before acting.

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -80,10 +80,23 @@ func TestRootSkillCompatibilityEntrypoint(t *testing.T) {
 	for _, want := range []string{
 		"name: gitmoot",
 		"description: Use Gitmoot",
+		"version: 0.1.0",
+		"openclaw:",
+		"requires:",
+		"bins:",
+		"- gitmoot",
+		"- git",
+		"- gh",
+		"envVars:",
+		"- name: GH_TOKEN",
+		"required: false",
 	} {
 		if !strings.Contains(frontmatter, want) {
 			t.Fatalf("root SKILL.md frontmatter missing %q:\n%s", want, frontmatter)
 		}
+	}
+	if strings.Contains(frontmatter, "requires:\n      env:") || strings.Contains(frontmatter, "requires.env") {
+		t.Fatalf("optional GH_TOKEN must not be declared as required env:\n%s", frontmatter)
 	}
 	for _, want := range []string{
 		"skills/gitmoot/",

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -7,12 +7,108 @@ import (
 	"testing"
 )
 
-func TestRootSkillFrontmatter(t *testing.T) {
-	contents, err := os.ReadFile(filepath.Join("..", "..", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read SKILL.md: %v", err)
+func TestCanonicalSkillFrontmatter(t *testing.T) {
+	text := readRepoFile(t, "skills", "gitmoot", "SKILL.md")
+	frontmatter := parseFrontmatter(t, text)
+
+	for _, want := range []string{
+		"name: gitmoot",
+		"description: Use Gitmoot",
+		"license: MIT",
+		"compatibility:",
+		"metadata:",
+		"gitmoot-version:",
+	} {
+		if !strings.Contains(frontmatter, want) {
+			t.Fatalf("frontmatter missing %q:\n%s", want, frontmatter)
+		}
 	}
-	text := string(contents)
+
+	for _, want := range []string{
+		"GitHub PR comments",
+		"agent subscriptions",
+		"daemon checks",
+		"jobs",
+		"branch locks",
+		"presets",
+		"custom prompt agents",
+		"Codex",
+		"Claude Code",
+	} {
+		if !strings.Contains(frontmatter, want) {
+			t.Fatalf("description missing trigger term %q:\n%s", want, frontmatter)
+		}
+	}
+}
+
+func TestCanonicalSkillReferencesExist(t *testing.T) {
+	text := readRepoFile(t, "skills", "gitmoot", "SKILL.md")
+	for _, ref := range []string{
+		"references/CLI.md",
+		"references/WORKFLOWS.md",
+		"references/RESULT_CONTRACT.md",
+		"references/SAFETY.md",
+	} {
+		if !strings.Contains(text, ref) {
+			t.Fatalf("canonical SKILL.md missing reference %q", ref)
+		}
+		path := filepath.Join(append([]string{"..", "..", "skills", "gitmoot"}, strings.Split(ref, "/")...)...)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("referenced file %s missing: %v", ref, err)
+		}
+	}
+}
+
+func TestCanonicalSkillDocumentsResultAndRereadGuidance(t *testing.T) {
+	text := readRepoFile(t, "skills", "gitmoot", "SKILL.md")
+	for _, want := range []string{
+		"gitmoot_result",
+		"blocked",
+		"failed",
+		"branch locks",
+		"Reread this `SKILL.md`",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("canonical SKILL.md missing %q", want)
+		}
+	}
+}
+
+func TestRootSkillCompatibilityEntrypoint(t *testing.T) {
+	text := readRepoFile(t, "SKILL.md")
+	frontmatter := parseFrontmatter(t, text)
+	for _, want := range []string{
+		"name: gitmoot",
+		"description: Use Gitmoot",
+	} {
+		if !strings.Contains(frontmatter, want) {
+			t.Fatalf("root SKILL.md frontmatter missing %q:\n%s", want, frontmatter)
+		}
+	}
+	for _, want := range []string{
+		"skills/gitmoot/",
+		"gitmoot.io/SKILL.md",
+		"gitmoot_result",
+		"branch locks",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("root SKILL.md missing compatibility content %q", want)
+		}
+	}
+}
+
+func readRepoFile(t *testing.T, parts ...string) string {
+	t.Helper()
+	path := filepath.Join(append([]string{"..", ".."}, parts...)...)
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", filepath.Join(parts...), err)
+	}
+	return string(contents)
+}
+
+func parseFrontmatter(t *testing.T, text string) string {
+	t.Helper()
 	if !strings.HasPrefix(text, "---\n") {
 		t.Fatal("SKILL.md missing YAML frontmatter opener")
 	}
@@ -20,45 +116,5 @@ func TestRootSkillFrontmatter(t *testing.T) {
 	if len(parts) != 3 {
 		t.Fatal("SKILL.md missing YAML frontmatter closer")
 	}
-	frontmatter := parts[1]
-	for _, want := range []string{
-		"name: gitmoot-agent",
-		"description: Use Gitmoot",
-		"version: 0.1.0",
-		"metadata:",
-		"openclaw:",
-		"requires:",
-		"bins:",
-		"- gitmoot",
-		"- git",
-		"- gh",
-		"envVars:",
-		"- name: GH_TOKEN",
-		"required: false",
-	} {
-		if !strings.Contains(frontmatter, want) {
-			t.Fatalf("frontmatter missing %q:\n%s", want, frontmatter)
-		}
-	}
-	if strings.Contains(frontmatter, "requires:\n      env:") || strings.Contains(frontmatter, "requires.env") {
-		t.Fatalf("optional GH_TOKEN must not be declared as required env:\n%s", frontmatter)
-	}
-}
-
-func TestRootSkillDocumentsGitmootResultAndRereadGuidance(t *testing.T) {
-	contents, err := os.ReadFile(filepath.Join("..", "..", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read SKILL.md: %v", err)
-	}
-	text := string(contents)
-	for _, want := range []string{
-		"gitmoot_result",
-		"approved|changes_requested|blocked|implemented|failed",
-		"branch locks",
-		"reread this `SKILL.md`",
-	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("SKILL.md missing %q", want)
-		}
-	}
+	return parts[1]
 }

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: gitmoot
+description: Use Gitmoot for local-first multi-agent coordination through GitHub PR comments, repo-scoped agent subscriptions, daemon checks, jobs, branch locks, presets, custom prompt agents, and Codex or Claude Code runtime workflows.
+license: MIT
+compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
+metadata:
+  gitmoot-version: "0.1.0"
+  source: "jerryfane/gitmoot"
+---
+
+# Gitmoot Agent Skill
+
+Gitmoot is a local-first coordinator for AI agents working through GitHub pull
+requests. Use this skill when the user wants PR-comment agent workflows,
+repo-scoped agent subscriptions, background daemon checks, Codex or Claude Code
+agent startup, preset agents, custom prompt agents, job status, or branch lock
+inspection.
+
+## Before Acting
+
+1. Check whether `gitmoot` is installed with `gitmoot version`.
+2. Confirm GitHub CLI access with `gh auth status` before using PR workflows.
+3. Detect or ask for the target repo before starting daemons, subscribing agents,
+   or routing jobs.
+4. Do not start daemons, create agents, update presets, or change subscriptions
+   unless the user asks or the current task clearly requires it.
+5. Prefer read-only status commands before mutating Gitmoot state.
+
+## Common Commands
+
+Use `gitmoot status --repo owner/repo` for repo status, `gitmoot daemon status`
+for daemon state, `gitmoot agent list` for registered agents, and
+`gitmoot job list --repo owner/repo` for queued or recent jobs.
+
+For complete command examples, read [CLI.md](references/CLI.md).
+For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).
+
+## Agent Job Contract
+
+Every Gitmoot job should return a concise and truthful `gitmoot_result` JSON
+object. Use `blocked` when work cannot continue without human input or external
+state, and `failed` when an attempted action errored.
+
+For the required result shape and decision meanings, read
+[RESULT_CONTRACT.md](references/RESULT_CONTRACT.md).
+
+## Safety Rules
+
+Preserve existing behavior unless the job explicitly changes it. Keep work
+scoped to the target repo. Do not commit generated data, caches, logs, secrets,
+session archives, cloned helper repos, or large outputs unless explicitly
+requested. Respect Gitmoot branch locks for implementation jobs.
+
+For detailed safety and lock rules, read [SAFETY.md](references/SAFETY.md).
+
+## When Unsure
+
+Reread this `SKILL.md`, then inspect `/gitmoot help`, `gitmoot status`, and the
+relevant job events before acting.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1,0 +1,128 @@
+# Gitmoot CLI Reference
+
+Use these commands from an agent session only when the user asks for Gitmoot
+setup, status, agent coordination, or PR-comment workflow help.
+
+## Install And Update
+
+```sh
+curl -fsSL https://gitmoot.io/install.sh | sh
+gitmoot version
+gitmoot update --check
+gitmoot update --restart-daemon
+```
+
+Verify GitHub access before PR workflows:
+
+```sh
+gh auth status
+```
+
+## Repo And Daemon Status
+
+```sh
+gitmoot status --repo owner/repo
+gitmoot events --repo owner/repo
+gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon status
+gitmoot daemon logs
+gitmoot daemon stop
+```
+
+Use `daemon start` for the background daemon. Use `daemon run` only when the
+user explicitly wants a foreground process.
+
+## Agent Setup
+
+Start a new runtime session managed by Gitmoot:
+
+```sh
+gitmoot agent start reviewer \
+  --runtime codex \
+  --repo owner/repo \
+  --path . \
+  --role reviewer \
+  --capability ask \
+  --capability review \
+  --start-daemon
+```
+
+Subscribe an existing runtime session:
+
+```sh
+gitmoot agent subscribe reviewer \
+  --runtime codex \
+  --session <session-id-or-last> \
+  --repo owner/repo \
+  --role reviewer \
+  --capability ask \
+  --capability review
+```
+
+Inspect agents:
+
+```sh
+gitmoot agent list
+gitmoot agent repos reviewer
+gitmoot agent doctor reviewer
+```
+
+## Presets
+
+Install or refresh the built-in thermo review preset:
+
+```sh
+gitmoot preset update thermo-nuclear-code-quality-review
+gitmoot agent start thermo-review \
+  --runtime codex \
+  --repo owner/repo \
+  --preset thermo-nuclear-code-quality-review \
+  --start-daemon
+```
+
+Create a local custom prompt preset:
+
+```sh
+gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
+gitmoot agent start frontend-reviewer \
+  --runtime codex \
+  --repo owner/repo \
+  --preset frontend-reviewer \
+  --role reviewer \
+  --capability ask \
+  --capability review
+```
+
+After editing a local prompt file, refresh Gitmoot's cached snapshot:
+
+```sh
+gitmoot preset diff frontend-reviewer
+gitmoot preset update frontend-reviewer
+```
+
+## PR Comments
+
+Use GitHub PR comments as the public audit trail:
+
+```text
+/gitmoot help
+/gitmoot status
+/gitmoot <agent> review [instructions]
+/gitmoot <agent> implement [instructions]
+/gitmoot ask <agent> [question]
+/gitmoot retry <job-id>
+/gitmoot cancel <job-id>
+/gitmoot merge
+```
+
+## Jobs And Locks
+
+```sh
+gitmoot job list --repo owner/repo
+gitmoot job show <job-id>
+gitmoot job events <job-id>
+gitmoot job retry <job-id>
+gitmoot job cancel <job-id>
+gitmoot lock list --repo owner/repo
+gitmoot lock show owner/repo <branch>
+```

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -1,0 +1,35 @@
+# Gitmoot Result Contract
+
+Every agent job must return a `gitmoot_result` JSON object. Keep it concise,
+truthful, and tied to work that actually happened.
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved|changes_requested|blocked|implemented|failed",
+    "summary": "Brief outcome.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "next_agents": []
+  }
+}
+```
+
+## Decisions
+
+- `approved`: review found no blocking issues.
+- `changes_requested`: review found issues that should be fixed before merge.
+- `blocked`: work cannot continue without human input or an external state change.
+- `implemented`: the requested implementation work was completed.
+- `failed`: the attempted action errored or could not complete.
+
+## Reporting Rules
+
+- Do not claim tests were run unless they were actually run.
+- Do not claim files were changed unless they were actually changed.
+- Use `needs` for missing credentials, unclear scope, unavailable tools, failing
+  external services, or required human decisions.
+- Use `next_agents` only when another named Gitmoot agent should be invoked.
+- Redact secrets from summaries, findings, raw command output, and examples.

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -1,0 +1,44 @@
+# Gitmoot Safety Reference
+
+## Repo Scope
+
+A PR repository is the routing context for `/gitmoot <agent> ...`. Always confirm
+or pass `--repo owner/repo` when the user works across multiple repositories.
+
+## Branch Locks
+
+Implementation jobs must respect Gitmoot branch locks. Do not edit or push an
+implementation branch unless Gitmoot assigned the job and the branch lock is held
+by the assigned agent.
+
+Review and ask jobs should inspect and report without mutating branches unless
+the task explicitly instructs otherwise.
+
+Useful commands:
+
+```sh
+gitmoot lock list --repo owner/repo
+gitmoot lock show owner/repo <branch>
+```
+
+## Files And Secrets
+
+Do not commit generated data, caches, logs, build outputs, session archives,
+cloned helper repos, secrets, credentials, or large artifacts unless the user or
+plan explicitly says they are intended tracked fixtures or release assets.
+
+Redact secrets from GitHub comments, job summaries, raw examples, and copied
+command output.
+
+## External Contracts
+
+If the work depends on external APIs, CLIs, env vars, generated scripts, service
+launchers, installers, deployment behavior, or third-party libraries, verify the
+real contract with local commands and/or official documentation before editing.
+
+## When To Stop
+
+Stop and report `blocked` when the target repo is unclear, GitHub auth is
+missing, the daemon cannot access the repo, branch lock ownership is wrong, or
+continuing would require credentials or destructive operations the user did not
+approve.

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1,0 +1,83 @@
+# Gitmoot Workflows
+
+## First Repo Setup
+
+1. Confirm the repo identity and GitHub auth.
+2. Start the daemon for the repo.
+3. Start or subscribe at least one agent.
+4. Verify the agent is healthy before asking PR comments to route jobs.
+
+```sh
+gh repo view --json nameWithOwner
+gh auth status
+gitmoot daemon start --repo owner/repo
+gitmoot agent start reviewer --runtime codex --repo owner/repo --role reviewer --capability ask --capability review --start-daemon
+gitmoot agent doctor reviewer
+```
+
+## Review Agent From A PR Comment
+
+1. Register a reviewer agent for the target repo.
+2. Ensure the daemon watches the same repo.
+3. Comment on the PR.
+4. Inspect job status if no result appears.
+
+```text
+/gitmoot reviewer review
+```
+
+```sh
+gitmoot job list --repo owner/repo
+gitmoot job show <job-id>
+gitmoot job events <job-id>
+```
+
+## Built-In Thermo Review Agent
+
+Use the thermo preset for strict review-only work. It should not implement code
+or request implementation capability.
+
+```sh
+gitmoot preset update thermo-nuclear-code-quality-review
+gitmoot agent start thermo-review --runtime codex --repo owner/repo --preset thermo-nuclear-code-quality-review --start-daemon
+```
+
+PR comment:
+
+```text
+/gitmoot thermo-review review
+```
+
+## Custom Prompt Agent
+
+Use custom prompt presets for project-specific reviewers or helpers.
+
+```sh
+mkdir -p agents
+printf '%s\n' 'Review frontend changes for correctness and responsive behavior.' > agents/frontend-reviewer.md
+gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
+gitmoot agent start frontend-reviewer \
+  --runtime codex \
+  --repo owner/repo \
+  --preset frontend-reviewer \
+  --role reviewer \
+  --capability ask \
+  --capability review
+```
+
+Custom preset content is snapshotted into local Gitmoot state. After editing the
+source prompt file, run `gitmoot preset diff <id>` and `gitmoot preset update
+<id>` before expecting new jobs to use the changed prompt.
+
+## Multi-Repo Work
+
+Agents are global identities with explicit per-repo access. When working across
+multiple repos, always pass `--repo owner/repo` to status, daemon, job, and event
+commands so jobs are routed in the correct repository context.
+
+```sh
+gitmoot agent allow reviewer --repo owner/project-a
+gitmoot agent allow reviewer --repo owner/project-b
+gitmoot status --repo owner/project-a
+gitmoot status --repo owner/project-b
+```


### PR DESCRIPTION
WHAT
- Adds a spec-aligned canonical Agent Skills package at `skills/gitmoot/`.
- Keeps root `SKILL.md` as a standalone raw compatibility entrypoint for existing agents and `gitmoot.io/SKILL.md` usage.

WHY
- Gitmoot agent instructions should have one canonical package that Codex, Claude Code, future plugins, and raw web links can reuse without duplicating slightly different guidance.

CHANGES
- Adds `skills/gitmoot/SKILL.md` with `name: gitmoot`, description trigger terms, compatibility metadata, and concise activation guidance.
- Splits detailed guidance into `references/CLI.md`, `WORKFLOWS.md`, `RESULT_CONTRACT.md`, and `SAFETY.md`.
- Keeps root `SKILL.md` useful as a single raw file by including install, common command, PR comment, preset, result contract, safety guidance, and OpenClaw compatibility metadata inline.
- Updates `README.md` to point agents to the canonical skill package while preserving root `SKILL.md` compatibility.
- Updates `internal/skill/skill_test.go` to validate the canonical package, required references, and root compatibility entrypoint.

RESULTS
- `git diff --check` passed.
- `codex exec review --uncommitted` is clean; ready for manual /review.
- Manual review found and fixed one compatibility issue: root `SKILL.md` was too pointer-like for `gitmoot.io/SKILL.md` raw consumers, so it is now standalone again.
- Codex review found and fixed one compatibility issue: root `SKILL.md` needed to preserve OpenClaw `version`, required binary metadata, and optional `GH_TOKEN` metadata.

RISK
- `go test ./...` and `go vet ./...` could not run on this host because `go.mod` requires Go 1.26, the installed local Go is 1.22.2, and the Go 1.26 toolchain download is unavailable here.
- `skills-ref validate ./skills/gitmoot` was not run because the validator is not installed in this environment.
