### PR TITLE
Add plugin build and doctor commands

### DIFF
--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -1,0 +1,393 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/pluginpack"
+	"github.com/jerryfane/gitmoot/skills"
+)
+
+var pluginLookPath = exec.LookPath
+
+type pluginCheck struct {
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	Detail   string `json:"detail"`
+	Required bool   `json:"required"`
+}
+
+type pluginDoctorRuntime struct {
+	Runtime string        `json:"runtime"`
+	Path    string        `json:"path"`
+	Healthy bool          `json:"healthy"`
+	Checks  []pluginCheck `json:"checks"`
+}
+
+type pluginDoctorOutput struct {
+	Home     string                `json:"home"`
+	Runtimes []pluginDoctorRuntime `json:"runtimes"`
+}
+
+func runPlugin(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPluginUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "build":
+		return runPluginBuild(args[1:], stdout, stderr)
+	case "path":
+		return runPluginPath(args[1:], stdout, stderr)
+	case "doctor":
+		return runPluginDoctor(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown plugin command %q\n\n", args[0])
+		printPluginUsage(stderr)
+		return 2
+	}
+}
+
+func printPluginUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot plugin build codex|claude")
+	fmt.Fprintln(w, "  gitmoot plugin path codex|claude")
+	fmt.Fprintln(w, "  gitmoot plugin doctor [codex|claude]")
+}
+
+func runPluginBuild(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("plugin build", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	outDir := fs.String("out", "", "package output directory")
+	force := fs.Bool("force", false, "replace an existing generated package")
+	provider, ok, help := parsePluginProviderArg(args, fs, stderr, "plugin build")
+	if help {
+		return 0
+	}
+	if !ok {
+		return 2
+	}
+
+	homePath := ""
+	if *outDir == "" {
+		paths, err := pathsFromFlag(*home)
+		if err != nil {
+			fmt.Fprintf(stderr, "plugin build: %v\n", err)
+			return 1
+		}
+		homePath = paths.Home
+	}
+	result, err := pluginpack.Build(pluginpack.BuildOptions{
+		Provider: provider,
+		Home:     homePath,
+		OutDir:   *outDir,
+		Force:    *force,
+		Info:     buildinfo.Current(),
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "plugin build: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "%s", result.Path)
+	return 0
+}
+
+func runPluginPath(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("plugin path", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	provider, ok, help := parsePluginProviderArg(args, fs, stderr, "plugin path")
+	if help {
+		return 0
+	}
+	if !ok {
+		return 2
+	}
+
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "plugin path: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "%s", pluginpack.DefaultPackageDir(paths.Home, provider))
+	return 0
+}
+
+func runPluginDoctor(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("plugin doctor", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "print doctor output as JSON")
+	selected, explicitRuntime, help, ok := parsePluginDoctorArgs(args, fs, stderr)
+	if help {
+		return 0
+	}
+	if !ok {
+		return 2
+	}
+
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "plugin doctor: %v\n", err)
+		return 1
+	}
+	providers := []pluginpack.Provider{pluginpack.ProviderCodex, pluginpack.ProviderClaude}
+	if explicitRuntime {
+		providers = []pluginpack.Provider{selected}
+	}
+
+	output := pluginDoctorOutput{Home: paths.Home}
+	for _, provider := range providers {
+		output.Runtimes = append(output.Runtimes, doctorRuntime(paths.Home, provider, explicitRuntime))
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "write plugin doctor json: %v\n", err)
+			return 1
+		}
+	} else {
+		printPluginDoctor(stdout, output)
+	}
+
+	if explicitRuntime {
+		if len(output.Runtimes) == 1 && !output.Runtimes[0].Healthy {
+			fmt.Fprintf(stderr, "plugin doctor: %s runtime is unhealthy\n", output.Runtimes[0].Runtime)
+			return 1
+		}
+		return 0
+	}
+	for _, runtime := range output.Runtimes {
+		if runtime.Healthy {
+			return 0
+		}
+	}
+	fmt.Fprintln(stderr, "plugin doctor: no supported plugin runtime is healthy")
+	return 1
+}
+
+func parsePluginProviderArg(args []string, fs *flag.FlagSet, stderr io.Writer, commandName string) (pluginpack.Provider, bool, bool) {
+	if len(args) == 0 {
+		fmt.Fprintf(stderr, "%s requires codex|claude\n", commandName)
+		return "", false, false
+	}
+	if args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		return "", false, true
+	}
+	provider, err := pluginpack.ParseProvider(args[0])
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", commandName, err)
+		return "", false, false
+	}
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return provider, false, true
+		}
+		return "", false, false
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "%s does not accept extra positional arguments\n", commandName)
+		return "", false, false
+	}
+	return provider, true, false
+}
+
+func parsePluginDoctorArgs(args []string, fs *flag.FlagSet, stderr io.Writer) (pluginpack.Provider, bool, bool, bool) {
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		provider, err := pluginpack.ParseProvider(args[0])
+		if err != nil {
+			fmt.Fprintf(stderr, "plugin doctor: %v\n", err)
+			return "", false, false, false
+		}
+		if err := fs.Parse(args[1:]); err != nil {
+			if errors.Is(err, flag.ErrHelp) {
+				return "", false, true, false
+			}
+			return "", false, false, false
+		}
+		if fs.NArg() != 0 {
+			fmt.Fprintln(stderr, "plugin doctor does not accept extra positional arguments")
+			return "", false, false, false
+		}
+		return provider, true, false, true
+	}
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return "", false, true, false
+		}
+		return "", false, false, false
+	}
+	if fs.NArg() > 1 {
+		fmt.Fprintln(stderr, "plugin doctor accepts at most one runtime")
+		return "", false, false, false
+	}
+	if fs.NArg() == 0 {
+		return "", false, false, true
+	}
+	provider, err := pluginpack.ParseProvider(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(stderr, "plugin doctor: %v\n", err)
+		return "", false, false, false
+	}
+	return provider, true, false, true
+}
+
+func doctorRuntime(home string, provider pluginpack.Provider, explicitRuntime bool) pluginDoctorRuntime {
+	packagePath := pluginpack.DefaultPackageDir(home, provider)
+	runtime := pluginDoctorRuntime{
+		Runtime: string(provider),
+		Path:    packagePath,
+	}
+
+	runtime.Checks = append(runtime.Checks, checkHome(home))
+	runtime.Checks = append(runtime.Checks, checkCanonicalSkill())
+	runtime.Checks = append(runtime.Checks, checkPackage(packagePath))
+	runtime.Checks = append(runtime.Checks, checkManifest(packagePath, provider))
+	runtime.Checks = append(runtime.Checks, checkCopiedSkill(packagePath))
+	runtime.Checks = append(runtime.Checks, checkMarketplacePath(home, provider))
+	runtime.Checks = append(runtime.Checks, checkRuntimeCLI(provider, explicitRuntime))
+	runtime.Checks = append(runtime.Checks, checkValidationCommand(provider, explicitRuntime))
+	runtime.Healthy = runtimeChecksHealthy(runtime.Checks)
+	return runtime
+}
+
+func checkHome(home string) pluginCheck {
+	if home == "" {
+		return failCheck("home", "Gitmoot home is empty", true)
+	}
+	return okCheck("home", home, true)
+}
+
+func checkCanonicalSkill() pluginCheck {
+	info, err := fs.Stat(skills.FS, "gitmoot/SKILL.md")
+	if err != nil {
+		return failCheck("canonical-skill", err.Error(), true)
+	}
+	if info.IsDir() {
+		return failCheck("canonical-skill", "embedded SKILL.md is a directory", true)
+	}
+	return okCheck("canonical-skill", "embedded skills/gitmoot/SKILL.md is available", true)
+}
+
+func checkPackage(packagePath string) pluginCheck {
+	info, err := os.Stat(packagePath)
+	if err != nil {
+		return failCheck("package", packagePath, true)
+	}
+	if !info.IsDir() {
+		return failCheck("package", packagePath+" is not a directory", true)
+	}
+	return okCheck("package", packagePath, true)
+}
+
+func checkManifest(packagePath string, provider pluginpack.Provider) pluginCheck {
+	manifest := pluginpack.ManifestPath(packagePath, provider)
+	content, err := os.ReadFile(manifest)
+	if err != nil {
+		return failCheck("manifest", manifest, true)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(content, &decoded); err != nil {
+		return failCheck("manifest", manifest+": "+err.Error(), true)
+	}
+	return okCheck("manifest", manifest, true)
+}
+
+func checkCopiedSkill(packagePath string) pluginCheck {
+	path := filepath.Join(packagePath, "skills", pluginpack.PluginName, "SKILL.md")
+	info, err := os.Stat(path)
+	if err != nil {
+		return failCheck("copied-skill", path, true)
+	}
+	if info.IsDir() {
+		return failCheck("copied-skill", path+" is a directory", true)
+	}
+	return okCheck("copied-skill", path, true)
+}
+
+func checkMarketplacePath(home string, provider pluginpack.Provider) pluginCheck {
+	return okCheck("marketplace-path", pluginpack.DefaultMarketplaceDir(home, provider), false)
+}
+
+func checkRuntimeCLI(provider pluginpack.Provider, explicitRuntime bool) pluginCheck {
+	binary := string(provider)
+	path, err := pluginLookPath(binary)
+	if err != nil {
+		required := explicitRuntime
+		if required {
+			return failCheck("runtime-cli", binary+" was not found on PATH", true)
+		}
+		return warnCheck("runtime-cli", binary+" was not found on PATH", false)
+	}
+	return okCheck("runtime-cli", path, true)
+}
+
+func checkValidationCommand(provider pluginpack.Provider, explicitRuntime bool) pluginCheck {
+	switch provider {
+	case pluginpack.ProviderClaude:
+		if _, err := pluginLookPath("claude"); err != nil {
+			return missingCheck("validation-command", "claude plugin validate requires claude on PATH", explicitRuntime)
+		}
+		return okCheck("validation-command", "claude plugin validate", true)
+	case pluginpack.ProviderCodex:
+		return warnCheck("validation-command", "codex plugin validation command is not exposed by the installed CLI", false)
+	default:
+		return failCheck("validation-command", "unknown runtime", true)
+	}
+}
+
+func missingCheck(name, detail string, required bool) pluginCheck {
+	if required {
+		return failCheck(name, detail, true)
+	}
+	return warnCheck(name, detail, false)
+}
+
+func okCheck(name, detail string, required bool) pluginCheck {
+	return pluginCheck{Name: name, Status: "ok", Detail: detail, Required: required}
+}
+
+func warnCheck(name, detail string, required bool) pluginCheck {
+	return pluginCheck{Name: name, Status: "warn", Detail: detail, Required: required}
+}
+
+func failCheck(name, detail string, required bool) pluginCheck {
+	return pluginCheck{Name: name, Status: "fail", Detail: detail, Required: required}
+}
+
+func runtimeChecksHealthy(checks []pluginCheck) bool {
+	for _, check := range checks {
+		if check.Status == "fail" {
+			return false
+		}
+		if check.Name == "runtime-cli" && check.Status != "ok" {
+			return false
+		}
+	}
+	return true
+}
+
+func printPluginDoctor(w io.Writer, output pluginDoctorOutput) {
+	writeLine(w, "home: %s", output.Home)
+	for _, runtime := range output.Runtimes {
+		status := "ok"
+		if !runtime.Healthy {
+			status = "fail"
+		}
+		writeLine(w, "%s: %s", runtime.Runtime, status)
+		for _, check := range runtime.Checks {
+			writeLine(w, "  %-18s %-5s %s", check.Name, check.Status, check.Detail)
+		}
+	}
+}

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/pluginpack"
+)
+
+func TestRunPluginPathPrintsPackagePath(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+
+	code := Run([]string{"plugin", "path", "codex", "--home", home}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin path exit code = %d, stderr=%s", code, stderr.String())
+	}
+	want := filepath.Join(home, ".gitmoot", "plugins", "build", "codex", "gitmoot") + "\n"
+	if stdout.String() != want {
+		t.Fatalf("plugin path stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestRunPluginBuildPrintsPackagePath(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+
+	code := Run([]string{"plugin", "build", "claude", "--home", home}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin build exit code = %d, stderr=%s", code, stderr.String())
+	}
+	packagePath := strings.TrimSpace(stdout.String())
+	if packagePath != filepath.Join(home, ".gitmoot", "plugins", "build", "claude", "gitmoot") {
+		t.Fatalf("unexpected package path %q", packagePath)
+	}
+	for _, path := range []string{
+		filepath.Join(packagePath, ".claude-plugin", "plugin.json"),
+		filepath.Join(packagePath, "skills", "gitmoot", "SKILL.md"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected generated file %s: %v", path, err)
+		}
+	}
+}
+
+func TestRunPluginBuildExplicitOutDoesNotNeedHome(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	out := filepath.Join(t.TempDir(), "plugin")
+
+	code := Run([]string{"plugin", "build", "codex", "--out", out}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin build --out exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != out {
+		t.Fatalf("plugin build --out stdout = %q, want %q", stdout.String(), out)
+	}
+	if _, err := os.Stat(filepath.Join(out, ".codex-plugin", "plugin.json")); err != nil {
+		t.Fatalf("codex manifest missing: %v", err)
+	}
+}
+
+func TestRunPluginBuildRejectsBadRuntime(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"plugin", "build", "nope"}, &stdout, &stderr)
+
+	if code != 2 {
+		t.Fatalf("bad runtime exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), `unknown plugin runtime "nope"`) {
+		t.Fatalf("stderr missing bad runtime:\n%s", stderr.String())
+	}
+}
+
+func TestRunPluginBuildHelpBeforeRuntime(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"plugin", "build", "--help"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin build --help exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "-force") || !strings.Contains(stderr.String(), "-home") {
+		t.Fatalf("plugin build --help missing flag help:\n%s", stderr.String())
+	}
+}
+
+func TestRunPluginPathHelpBeforeRuntime(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"plugin", "path", "--help"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin path --help exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "-home") {
+		t.Fatalf("plugin path --help missing flag help:\n%s", stderr.String())
+	}
+}
+
+func TestRunPluginDoctorJSON(t *testing.T) {
+	home := t.TempDir()
+	build := pluginpack.BuildOptions{
+		Provider: pluginpack.ProviderCodex,
+		Home:     filepath.Join(home, ".gitmoot"),
+	}
+	if _, err := pluginpack.Build(build); err != nil {
+		t.Fatalf("build package: %v", err)
+	}
+	restore := stubPluginLookPath(map[string]string{"codex": "/tmp/bin/codex"})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "doctor", "codex", "--home", home, "--json"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin doctor exit code = %d, stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	var output pluginDoctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("doctor JSON did not parse: %v\n%s", err, stdout.String())
+	}
+	if output.Home != filepath.Join(home, ".gitmoot") {
+		t.Fatalf("doctor home = %q", output.Home)
+	}
+	if len(output.Runtimes) != 1 || output.Runtimes[0].Runtime != "codex" {
+		t.Fatalf("unexpected runtimes: %+v", output.Runtimes)
+	}
+	if !output.Runtimes[0].Healthy {
+		t.Fatalf("codex runtime should be healthy: %+v", output.Runtimes[0])
+	}
+	assertDoctorCheck(t, output.Runtimes[0].Checks, "manifest", "ok")
+	assertDoctorCheck(t, output.Runtimes[0].Checks, "copied-skill", "ok")
+	assertDoctorCheck(t, output.Runtimes[0].Checks, "marketplace-path", "ok")
+	assertDoctorCheck(t, output.Runtimes[0].Checks, "runtime-cli", "ok")
+	assertDoctorCheck(t, output.Runtimes[0].Checks, "validation-command", "warn")
+}
+
+func TestRunPluginDoctorFailsExplicitUnhealthyRuntime(t *testing.T) {
+	restore := stubPluginLookPath(map[string]string{})
+	defer restore()
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+
+	code := Run([]string{"plugin", "doctor", "claude", "--home", home}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("plugin doctor exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "claude runtime is unhealthy") {
+		t.Fatalf("stderr missing unhealthy runtime:\n%s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "manifest") || !strings.Contains(stdout.String(), "fail") {
+		t.Fatalf("stdout missing failed checks:\n%s", stdout.String())
+	}
+}
+
+func TestRunPluginDoctorAllRuntimesAllowsMissingRuntimeWarnings(t *testing.T) {
+	home := t.TempDir()
+	if _, err := pluginpack.Build(pluginpack.BuildOptions{
+		Provider: pluginpack.ProviderCodex,
+		Home:     filepath.Join(home, ".gitmoot"),
+	}); err != nil {
+		t.Fatalf("build codex package: %v", err)
+	}
+	restore := stubPluginLookPath(map[string]string{"codex": "/tmp/bin/codex"})
+	defer restore()
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"plugin", "doctor", "--home", home}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin doctor exit code = %d, stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "codex: ok") {
+		t.Fatalf("stdout missing healthy codex:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "claude: fail") {
+		t.Fatalf("stdout missing unhealthy claude report:\n%s", stdout.String())
+	}
+}
+
+func stubPluginLookPath(paths map[string]string) func() {
+	original := pluginLookPath
+	pluginLookPath = func(file string) (string, error) {
+		if path, ok := paths[file]; ok {
+			return path, nil
+		}
+		return "", errors.New("not found")
+	}
+	return func() {
+		pluginLookPath = original
+	}
+}
+
+func assertDoctorCheck(t *testing.T, checks []pluginCheck, name string, status string) {
+	t.Helper()
+	for _, check := range checks {
+		if check.Name == name {
+			if check.Status != status {
+				t.Fatalf("%s status = %q, want %q; checks=%+v", name, check.Status, status, checks)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing check %q in %+v", name, checks)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,6 +30,7 @@ var rootCommands = []command{
 	{name: "daemon", summary: "run the local PR watcher", run: runDaemon},
 	{name: "agent", summary: "manage registered agents", run: runAgent},
 	{name: "preset", summary: "manage agent prompt presets", run: runPreset},
+	{name: "plugin", summary: "build and inspect Gitmoot agent plugins", run: runPlugin},
 	{name: "events", summary: "show local repo events", run: runEvents},
 	{name: "status", summary: "show local workflow status", run: runStatus},
 	{name: "goal", summary: "import or inspect goals", run: runGoal},

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -53,7 +53,7 @@ func TestRunInitCreatesState(t *testing.T) {
 }
 
 func TestRunSubcommandHelpSucceeds(t *testing.T) {
-	for _, command := range []string{"init", "doctor", "version", "config", "update", "setup", "repo", "preset", "events", "job", "lock"} {
+	for _, command := range []string{"init", "doctor", "version", "config", "update", "setup", "repo", "preset", "plugin", "events", "job", "lock"} {
 		t.Run(command, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 

--- a/internal/pluginpack/pluginpack.go
+++ b/internal/pluginpack/pluginpack.go
@@ -66,6 +66,21 @@ func DefaultPackageDir(home string, provider Provider) string {
 	return filepath.Join(home, "plugins", "build", string(provider), PluginName)
 }
 
+func DefaultMarketplaceDir(home string, provider Provider) string {
+	return filepath.Join(home, "plugins", "marketplaces", string(provider))
+}
+
+func ManifestPath(root string, provider Provider) string {
+	switch provider {
+	case ProviderCodex:
+		return filepath.Join(root, ".codex-plugin", "plugin.json")
+	case ProviderClaude:
+		return filepath.Join(root, ".claude-plugin", "plugin.json")
+	default:
+		return filepath.Join(root, "plugin.json")
+	}
+}
+
 func Build(opts BuildOptions) (BuildResult, error) {
 	provider, err := validateProvider(opts.Provider)
 	if err != nil {
@@ -80,11 +95,15 @@ func Build(opts BuildOptions) (BuildResult, error) {
 	}
 
 	outDir := strings.TrimSpace(opts.OutDir)
+	defaultOutDir := ""
+	if strings.TrimSpace(opts.Home) != "" {
+		defaultOutDir = filepath.Clean(DefaultPackageDir(opts.Home, provider))
+	}
 	if outDir == "" {
-		if strings.TrimSpace(opts.Home) == "" {
+		if defaultOutDir == "" {
 			return BuildResult{}, errors.New("home is required when out dir is omitted")
 		}
-		outDir = DefaultPackageDir(opts.Home, provider)
+		outDir = defaultOutDir
 	}
 	outDir = filepath.Clean(outDir)
 	if exists, err := pathExists(outDir); err != nil {
@@ -92,6 +111,9 @@ func Build(opts BuildOptions) (BuildResult, error) {
 	} else if exists {
 		if !opts.Force {
 			return BuildResult{}, fmt.Errorf("%s already exists; pass --force to replace it", outDir)
+		}
+		if outDir != defaultOutDir && !isGeneratedPackageDir(outDir, provider) {
+			return BuildResult{}, fmt.Errorf("%s does not look like a generated %s plugin package; refusing forced replacement", outDir, provider)
 		}
 		if err := os.RemoveAll(outDir); err != nil {
 			return BuildResult{}, fmt.Errorf("remove existing package: %w", err)
@@ -106,7 +128,7 @@ func Build(opts BuildOptions) (BuildResult, error) {
 		return BuildResult{}, err
 	}
 
-	manifestPath := manifestPath(outDir, provider)
+	manifestPath := ManifestPath(outDir, provider)
 	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
 		return BuildResult{}, fmt.Errorf("create manifest dir: %w", err)
 	}
@@ -193,17 +215,6 @@ func copyDir(source fs.FS, sourceRoot, targetRoot string) error {
 		perm := info.Mode().Perm() | 0o600
 		return os.WriteFile(target, content, perm)
 	})
-}
-
-func manifestPath(root string, provider Provider) string {
-	switch provider {
-	case ProviderCodex:
-		return filepath.Join(root, ".codex-plugin", "plugin.json")
-	case ProviderClaude:
-		return filepath.Join(root, ".claude-plugin", "plugin.json")
-	default:
-		return filepath.Join(root, "plugin.json")
-	}
 }
 
 func manifest(provider Provider, info buildinfo.Info) (any, error) {
@@ -329,4 +340,22 @@ func pathExists(path string) (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+func isGeneratedPackageDir(path string, provider Provider) bool {
+	manifestBytes, err := os.ReadFile(ManifestPath(path, provider))
+	if err != nil {
+		return false
+	}
+	var manifest struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return false
+	}
+	if manifest.Name != PluginName {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(path, "skills", PluginName, "SKILL.md"))
+	return err == nil && !info.IsDir()
 }

--- a/internal/pluginpack/pluginpack_test.go
+++ b/internal/pluginpack/pluginpack_test.go
@@ -134,8 +134,12 @@ func TestBuildRefusesOverwriteWithoutForce(t *testing.T) {
 
 func TestBuildForceReplacesExistingPackage(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "gitmoot")
-	if err := os.MkdirAll(out, 0o755); err != nil {
-		t.Fatal(err)
+	if _, err := Build(BuildOptions{
+		Provider: ProviderCodex,
+		OutDir:   out,
+		SourceFS: validSkillFS(),
+	}); err != nil {
+		t.Fatalf("initial Build() error = %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(out, "stale.txt"), []byte("stale"), 0o644); err != nil {
 		t.Fatal(err)
@@ -154,6 +158,27 @@ func TestBuildForceReplacesExistingPackage(t *testing.T) {
 		t.Fatalf("stale file still exists after force rebuild: %v", err)
 	}
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "SKILL.md"), "Gitmoot")
+}
+
+func TestBuildForceRefusesArbitraryExplicitOutput(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "not-a-plugin")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(out, "important.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Build(BuildOptions{
+		Provider: ProviderCodex,
+		OutDir:   out,
+		Force:    true,
+		SourceFS: validSkillFS(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "refusing forced replacement") {
+		t.Fatalf("Build() error = %v, want refusing forced replacement", err)
+	}
+	assertFileContains(t, filepath.Join(out, "important.txt"), "keep")
 }
 
 func TestBuildValidatesSkillSource(t *testing.T) {


### PR DESCRIPTION
WHAT: Add `gitmoot plugin` build, path, and doctor CLI commands.

WHY: Gitmoot needs a user-facing command surface for rendering Codex/Claude plugin packages and diagnosing whether generated packages and local runtimes are usable before adding install helpers.

CHANGES:
- Added root `plugin` command dispatch.
- Added `gitmoot plugin build codex|claude` with `--home`, `--out`, and `--force`.
- Added `gitmoot plugin path codex|claude` for script-friendly default package paths.
- Added `gitmoot plugin doctor [codex|claude]` with readable output and `--json`.
- Added doctor checks for home, canonical skill, package, manifest JSON, copied skill, marketplace path, runtime CLI, and validation command availability.
- Exported package/marketplace path helpers from `pluginpack` and added a forced-rebuild guard so `--force --out` refuses arbitrary non-plugin directories.
- Added focused CLI and package-builder tests for command output, help handling, bad runtimes, JSON doctor output, explicit `--out`, all-runtime warnings, and forced output safety.

RESULTS:
- `git diff --check` passed.
- `go test ./internal/cli ./internal/pluginpack` could not run: `go: download go1.26 for linux/amd64: toolchain not available`.
- `GOTOOLCHAIN=local go test ./internal/cli ./internal/pluginpack` could not run: `go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local)`.
- `codex exec review --uncommitted` final raw output:

```text
No actionable correctness issues were found in the current staged, unstaged, or untracked changes. Go tests could not be run because the sandbox could not write the downloaded Go 1.26 toolchain lockfile.
No actionable correctness issues were found in the current staged, unstaged, or untracked changes. Go tests could not be run because the sandbox could not write the downloaded Go 1.26 toolchain lockfile.
```

RISK:
- Focused Go tests are written but not executable on this host until a Go 1.26 toolchain is available.
- `plugin install` is intentionally not implemented in this task; it remains the next goal task.