### PR TITLE
feat: add plugin install helper

### DIFF
--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -13,11 +14,14 @@ import (
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/plugininstall"
 	"github.com/jerryfane/gitmoot/internal/pluginpack"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 	"github.com/jerryfane/gitmoot/skills"
 )
 
 var pluginLookPath = exec.LookPath
+var pluginInstallRunner subprocess.Runner = subprocess.ExecRunner{}
 
 type pluginCheck struct {
 	Name     string `json:"name"`
@@ -50,6 +54,8 @@ func runPlugin(args []string, stdout, stderr io.Writer) int {
 		return runPluginPath(args[1:], stdout, stderr)
 	case "doctor":
 		return runPluginDoctor(args[1:], stdout, stderr)
+	case "install":
+		return runPluginInstall(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown plugin command %q\n\n", args[0])
 		printPluginUsage(stderr)
@@ -60,8 +66,76 @@ func runPlugin(args []string, stdout, stderr io.Writer) int {
 func printPluginUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot plugin build codex|claude")
+	fmt.Fprintln(w, "  gitmoot plugin install codex|claude")
 	fmt.Fprintln(w, "  gitmoot plugin path codex|claude")
 	fmt.Fprintln(w, "  gitmoot plugin doctor [codex|claude]")
+}
+
+func runPluginInstall(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("plugin install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	scope := fs.String("scope", "user", "Claude plugin scope: user, project, or local")
+	force := fs.Bool("force", false, "replace existing generated plugin package")
+	explicitScope := hasFlag(args, "scope")
+	provider, ok, help := parsePluginProviderArg(args, fs, stderr, "plugin install")
+	if help {
+		return 0
+	}
+	if !ok {
+		return 2
+	}
+
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "plugin install: %v\n", err)
+		return 1
+	}
+	result, err := plugininstall.Install(context.Background(), plugininstall.Options{
+		Provider: provider,
+		Home:     paths.Home,
+		Scope:    *scope,
+		Force:    *force,
+		Info:     buildinfo.Current(),
+		Runner:   pluginInstallRunner,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "plugin install: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "package: %s", result.PackagePath)
+	writeLine(stdout, "marketplace: %s", result.MarketplaceRoot)
+	if provider == pluginpack.ProviderCodex && explicitScope {
+		writeLine(stdout, "scope: ignored for codex")
+	}
+	if result.RuntimeMissing {
+		writeLine(stdout, "%s CLI was not found; generated files are ready.", provider)
+		printPluginManualCommands(stdout, result.ManualCommands)
+		return 0
+	}
+	writeLine(stdout, "installed %s plugin", provider)
+	return 0
+}
+
+func hasFlag(args []string, name string) bool {
+	short := "-" + name
+	long := "--" + name
+	for _, arg := range args {
+		if arg == short || arg == long || strings.HasPrefix(arg, short+"=") || strings.HasPrefix(arg, long+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func printPluginManualCommands(w io.Writer, commands []string) {
+	if len(commands) == 0 {
+		return
+	}
+	writeLine(w, "manual install commands:")
+	for _, command := range commands {
+		writeLine(w, "  %s", command)
+	}
 }
 
 func runPluginBuild(args []string, stdout, stderr io.Writer) int {

--- a/internal/plugininstall/install.go
+++ b/internal/plugininstall/install.go
@@ -1,0 +1,359 @@
+package plugininstall
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/pluginpack"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+const (
+	defaultScope             = "user"
+	marketplacePluginRelPath = "./plugins/" + pluginpack.PluginName
+)
+
+type Options struct {
+	Provider pluginpack.Provider
+	Home     string
+	Scope    string
+	Force    bool
+	Info     buildinfo.Info
+	Runner   subprocess.Runner
+}
+
+type Result struct {
+	Provider            pluginpack.Provider
+	PackagePath         string
+	MarketplaceRoot     string
+	MarketplaceManifest string
+	Installed           bool
+	RuntimeMissing      bool
+	ManualCommands      []string
+	Commands            []string
+}
+
+func Install(ctx context.Context, opts Options) (Result, error) {
+	provider, err := pluginpack.ParseProvider(string(opts.Provider))
+	if err != nil {
+		return Result{}, err
+	}
+	if opts.Home == "" {
+		return Result{}, errors.New("home is required")
+	}
+	scope := opts.Scope
+	if scope == "" {
+		scope = defaultScope
+	}
+	if provider == pluginpack.ProviderClaude && !validClaudeScope(scope) {
+		return Result{}, fmt.Errorf("unknown claude plugin scope %q", scope)
+	}
+	runner := opts.Runner
+	if runner == nil {
+		runner = subprocess.ExecRunner{}
+	}
+
+	marketplaceRoot := pluginpack.DefaultMarketplaceDir(opts.Home, provider)
+	packagePath := pluginpack.DefaultPackageDir(opts.Home, provider)
+	marketplacePackagePath := filepath.Join(marketplaceRoot, "plugins", pluginpack.PluginName)
+	build, err := buildPackage(provider, opts.Home, packagePath, opts.Force, opts.Info)
+	if err != nil {
+		return Result{}, err
+	}
+	if _, err := buildPackage(provider, opts.Home, marketplacePackagePath, opts.Force, opts.Info); err != nil {
+		return Result{}, err
+	}
+
+	result := Result{
+		Provider:            provider,
+		PackagePath:         build.Path,
+		MarketplaceRoot:     marketplaceRoot,
+		MarketplaceManifest: marketplaceManifestPath(opts.Home, provider),
+	}
+	if err := writeMarketplace(result.MarketplaceRoot, provider); err != nil {
+		return Result{}, err
+	}
+
+	binary := string(provider)
+	if _, err := runner.LookPath(binary); err != nil {
+		result.RuntimeMissing = true
+		result.ManualCommands = manualCommands(provider, result.MarketplaceRoot, result.PackagePath, scope)
+		return result, nil
+	}
+
+	switch provider {
+	case pluginpack.ProviderCodex:
+		if err := runCommand(ctx, runner, &result, "codex", "plugin", "marketplace", "add", result.MarketplaceRoot); err != nil {
+			return result, err
+		}
+		if err := runCommand(ctx, runner, &result, "codex", "plugin", "add", pluginpack.PluginName+"@"+pluginpack.MarketplaceName); err != nil {
+			return result, err
+		}
+	case pluginpack.ProviderClaude:
+		if err := runCommand(ctx, runner, &result, "claude", "plugin", "validate", build.Path); err != nil {
+			return result, err
+		}
+		if err := runCommand(ctx, runner, &result, "claude", "plugin", "marketplace", "add", result.MarketplaceRoot, "--scope", scope); err != nil {
+			return result, err
+		}
+		if err := runOptionalClaudeUninstall(ctx, runner, &result, pluginpack.PluginName+"@"+pluginpack.MarketplaceName, scope); err != nil {
+			return result, err
+		}
+		if err := runCommand(ctx, runner, &result, "claude", "plugin", "install", pluginpack.PluginName+"@"+pluginpack.MarketplaceName, "--scope", scope); err != nil {
+			return result, err
+		}
+	}
+	result.Installed = true
+	return result, nil
+}
+
+func buildPackage(provider pluginpack.Provider, home string, outDir string, force bool, info buildinfo.Info) (pluginpack.BuildResult, error) {
+	buildForce := force
+	if !buildForce {
+		if exists, err := pathExists(outDir); err != nil {
+			return pluginpack.BuildResult{}, err
+		} else if exists && pluginpack.IsGeneratedPackageDir(outDir, provider) {
+			buildForce = true
+		}
+	}
+	return pluginpack.Build(pluginpack.BuildOptions{
+		Provider: provider,
+		Home:     home,
+		OutDir:   outDir,
+		Force:    buildForce,
+		Info:     info,
+	})
+}
+
+func validClaudeScope(scope string) bool {
+	switch scope {
+	case "user", "project", "local":
+		return true
+	default:
+		return false
+	}
+}
+
+func runCommand(ctx context.Context, runner subprocess.Runner, result *Result, command string, args ...string) error {
+	result.Commands = append(result.Commands, command+" "+joinArgs(args))
+	run, err := runner.Run(ctx, "", command, args...)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w\nstdout: %s\nstderr: %s", command, joinArgs(args), err, run.Stdout, run.Stderr)
+	}
+	return nil
+}
+
+func runOptionalClaudeUninstall(ctx context.Context, runner subprocess.Runner, result *Result, selector string, scope string) error {
+	args := []string{"plugin", "uninstall", selector, "--scope", scope, "--keep-data"}
+	result.Commands = append(result.Commands, "claude "+joinArgs(args))
+	run, err := runner.Run(ctx, "", "claude", args...)
+	if err == nil {
+		return nil
+	}
+	output := run.Stdout + "\n" + run.Stderr
+	if strings.Contains(output, "not found in installed plugins") {
+		return nil
+	}
+	return fmt.Errorf("claude %s: %w\nstdout: %s\nstderr: %s", joinArgs(args), err, run.Stdout, run.Stderr)
+}
+
+func marketplaceManifestPath(home string, provider pluginpack.Provider) string {
+	root := pluginpack.DefaultMarketplaceDir(home, provider)
+	switch provider {
+	case pluginpack.ProviderCodex:
+		return filepath.Join(root, ".agents", "plugins", "marketplace.json")
+	case pluginpack.ProviderClaude:
+		return filepath.Join(root, ".claude-plugin", "marketplace.json")
+	default:
+		return filepath.Join(root, "marketplace.json")
+	}
+}
+
+func writeMarketplace(root string, provider pluginpack.Provider) error {
+	path := filepath.Join(root, "marketplace.json")
+	switch provider {
+	case pluginpack.ProviderCodex:
+		path = filepath.Join(root, ".agents", "plugins", "marketplace.json")
+	case pluginpack.ProviderClaude:
+		path = filepath.Join(root, ".claude-plugin", "marketplace.json")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create marketplace dir: %w", err)
+	}
+	payload := marketplacePayload(provider)
+	content, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal marketplace: %w", err)
+	}
+	content = append(content, '\n')
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		return fmt.Errorf("write marketplace: %w", err)
+	}
+	return nil
+}
+
+func marketplacePayload(provider pluginpack.Provider) any {
+	switch provider {
+	case pluginpack.ProviderCodex:
+		return codexMarketplace{
+			Name: pluginpack.MarketplaceName,
+			Interface: marketplaceInterface{
+				DisplayName: "Gitmoot Local",
+			},
+			Plugins: []codexMarketplacePlugin{{
+				Name: pluginpack.PluginName,
+				Source: codexSource{
+					Source: "local",
+					Path:   marketplacePluginRelPath,
+				},
+				Policy: codexPolicy{
+					Installation:   "AVAILABLE",
+					Authentication: "ON_INSTALL",
+				},
+				Category: "Productivity",
+			}},
+		}
+	case pluginpack.ProviderClaude:
+		return claudeMarketplace{
+			Schema:      "https://anthropic.com/claude-code/marketplace.schema.json",
+			Name:        pluginpack.MarketplaceName,
+			Description: "Local Gitmoot plugin marketplace.",
+			Owner:       claudeOwner{Name: "Gitmoot"},
+			Plugins: []claudeMarketplacePlugin{{
+				Name:        pluginpack.PluginName,
+				Description: pluginpack.Description,
+				Author:      claudeOwner{Name: "Gitmoot"},
+				Category:    "productivity",
+				Source:      marketplacePluginRelPath,
+				Homepage:    pluginpack.HomepageURL,
+			}},
+		}
+	default:
+		return map[string]any{"name": pluginpack.MarketplaceName}
+	}
+}
+
+type marketplaceInterface struct {
+	DisplayName string `json:"displayName"`
+}
+
+type codexMarketplace struct {
+	Name      string                   `json:"name"`
+	Interface marketplaceInterface     `json:"interface"`
+	Plugins   []codexMarketplacePlugin `json:"plugins"`
+}
+
+type codexMarketplacePlugin struct {
+	Name     string      `json:"name"`
+	Source   codexSource `json:"source"`
+	Policy   codexPolicy `json:"policy"`
+	Category string      `json:"category"`
+}
+
+type codexSource struct {
+	Source string `json:"source"`
+	Path   string `json:"path"`
+}
+
+type codexPolicy struct {
+	Installation   string `json:"installation"`
+	Authentication string `json:"authentication"`
+}
+
+type claudeMarketplace struct {
+	Schema      string                    `json:"$schema"`
+	Name        string                    `json:"name"`
+	Description string                    `json:"description"`
+	Owner       claudeOwner               `json:"owner"`
+	Plugins     []claudeMarketplacePlugin `json:"plugins"`
+}
+
+type claudeOwner struct {
+	Name string `json:"name"`
+}
+
+type claudeMarketplacePlugin struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	Author      claudeOwner `json:"author"`
+	Category    string      `json:"category"`
+	Source      string      `json:"source"`
+	Homepage    string      `json:"homepage"`
+}
+
+func manualCommands(provider pluginpack.Provider, marketplaceRoot string, packagePath string, scope string) []string {
+	switch provider {
+	case pluginpack.ProviderCodex:
+		return []string{
+			"codex plugin marketplace add " + shellQuote(marketplaceRoot),
+			"codex plugin add " + pluginpack.PluginName + "@" + pluginpack.MarketplaceName,
+		}
+	case pluginpack.ProviderClaude:
+		return []string{
+			"claude plugin validate " + shellQuote(packagePath),
+			"claude plugin marketplace add " + shellQuote(marketplaceRoot) + " --scope " + scope,
+			"claude plugin uninstall " + pluginpack.PluginName + "@" + pluginpack.MarketplaceName + " --scope " + scope + " --keep-data 2>/dev/null || true",
+			"claude plugin install " + pluginpack.PluginName + "@" + pluginpack.MarketplaceName + " --scope " + scope,
+		}
+	default:
+		return nil
+	}
+}
+
+func joinArgs(args []string) string {
+	out := ""
+	for i, arg := range args {
+		if i > 0 {
+			out += " "
+		}
+		out += arg
+	}
+	return out
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	for _, r := range value {
+		if !isShellSafe(r) {
+			return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+		}
+	}
+	return value
+}
+
+func isShellSafe(r rune) bool {
+	if r >= 'a' && r <= 'z' {
+		return true
+	}
+	if r >= 'A' && r <= 'Z' {
+		return true
+	}
+	if r >= '0' && r <= '9' {
+		return true
+	}
+	switch r {
+	case '/', '.', '_', '-', '+', '=', ':', ',', '@', '%':
+		return true
+	default:
+		return false
+	}
+}
+
+func pathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}

--- a/internal/plugininstall/install_test.go
+++ b/internal/plugininstall/install_test.go
@@ -1,0 +1,265 @@
+package plugininstall
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/pluginpack"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+func TestInstallCodexCommandOrder(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".gitmoot")
+	runner := &fakeRunner{paths: map[string]string{"codex": "/bin/codex"}}
+
+	result, err := Install(context.Background(), Options{
+		Provider: pluginpack.ProviderCodex,
+		Home:     home,
+		Runner:   runner,
+	})
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if !result.Installed || result.RuntimeMissing {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	wantCalls := []fakeCall{
+		{command: "codex", args: []string{"plugin", "marketplace", "add", pluginpack.DefaultMarketplaceDir(home, pluginpack.ProviderCodex)}},
+		{command: "codex", args: []string{"plugin", "add", "gitmoot@gitmoot-local"}},
+	}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("calls = %+v, want %+v", runner.calls, wantCalls)
+	}
+	wantPackagePath := pluginpack.DefaultPackageDir(home, pluginpack.ProviderCodex)
+	if result.PackagePath != wantPackagePath {
+		t.Fatalf("PackagePath = %q, want %q", result.PackagePath, wantPackagePath)
+	}
+	if _, err := os.Stat(filepath.Join(result.MarketplaceRoot, "plugins", pluginpack.PluginName, ".codex-plugin", "plugin.json")); err != nil {
+		t.Fatalf("expected marketplace package copy: %v", err)
+	}
+	assertCodexMarketplace(t, result.MarketplaceManifest)
+}
+
+func TestInstallClaudeCommandOrder(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".gitmoot")
+	runner := &fakeRunner{paths: map[string]string{"claude": "/bin/claude"}}
+
+	result, err := Install(context.Background(), Options{
+		Provider: pluginpack.ProviderClaude,
+		Home:     home,
+		Scope:    "project",
+		Runner:   runner,
+	})
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	want := []fakeCall{
+		{command: "claude", args: []string{"plugin", "validate", result.PackagePath}},
+		{command: "claude", args: []string{"plugin", "marketplace", "add", result.MarketplaceRoot, "--scope", "project"}},
+		{command: "claude", args: []string{"plugin", "uninstall", "gitmoot@gitmoot-local", "--scope", "project", "--keep-data"}},
+		{command: "claude", args: []string{"plugin", "install", "gitmoot@gitmoot-local", "--scope", "project"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %+v, want %+v", runner.calls, want)
+	}
+	wantPackagePath := pluginpack.DefaultPackageDir(home, pluginpack.ProviderClaude)
+	if result.PackagePath != wantPackagePath {
+		t.Fatalf("PackagePath = %q, want %q", result.PackagePath, wantPackagePath)
+	}
+	if _, err := os.Stat(filepath.Join(result.MarketplaceRoot, "plugins", pluginpack.PluginName, ".claude-plugin", "plugin.json")); err != nil {
+		t.Fatalf("expected marketplace package copy: %v", err)
+	}
+	assertClaudeMarketplace(t, result.MarketplaceManifest)
+}
+
+func TestInstallClaudeIgnoresMissingPriorInstall(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".gitmoot")
+	runner := &fakeRunner{
+		paths:                 map[string]string{"claude": "/bin/claude"},
+		failUninstallNotFound: true,
+	}
+
+	result, err := Install(context.Background(), Options{
+		Provider: pluginpack.ProviderClaude,
+		Home:     home,
+		Runner:   runner,
+	})
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if !result.Installed {
+		t.Fatalf("expected installed result: %+v", result)
+	}
+}
+
+func TestInstallMissingRuntimeKeepsGeneratedFiles(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".gitmoot")
+	result, err := Install(context.Background(), Options{
+		Provider: pluginpack.ProviderCodex,
+		Home:     home,
+		Runner:   &fakeRunner{},
+	})
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if !result.RuntimeMissing || result.Installed {
+		t.Fatalf("unexpected missing runtime result: %+v", result)
+	}
+	for _, path := range []string{
+		filepath.Join(result.PackagePath, ".codex-plugin", "plugin.json"),
+		result.MarketplaceManifest,
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected generated file %s: %v", path, err)
+		}
+	}
+	if len(result.ManualCommands) != 2 {
+		t.Fatalf("manual commands = %+v", result.ManualCommands)
+	}
+}
+
+func TestInstallMarketplaceIsIdempotent(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".gitmoot")
+	runner := &fakeRunner{paths: map[string]string{"codex": "/bin/codex"}}
+	if _, err := Install(context.Background(), Options{
+		Provider: pluginpack.ProviderCodex,
+		Home:     home,
+		Runner:   runner,
+	}); err != nil {
+		t.Fatalf("first Install() error = %v", err)
+	}
+	result, err := Install(context.Background(), Options{
+		Provider: pluginpack.ProviderCodex,
+		Home:     home,
+		Runner:   runner,
+	})
+	if err != nil {
+		t.Fatalf("second Install() error = %v", err)
+	}
+	assertCodexMarketplace(t, result.MarketplaceManifest)
+}
+
+func TestInstallRefusesExistingNonGeneratedPackageWithoutForce(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".gitmoot")
+	packagePath := pluginpack.DefaultPackageDir(home, pluginpack.ProviderCodex)
+	if err := os.MkdirAll(packagePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packagePath, "keep.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Install(context.Background(), Options{
+		Provider: pluginpack.ProviderCodex,
+		Home:     home,
+		Runner:   &fakeRunner{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("Install() error = %v, want already exists", err)
+	}
+	if _, err := os.Stat(filepath.Join(packagePath, "keep.txt")); err != nil {
+		t.Fatalf("existing file was removed: %v", err)
+	}
+}
+
+func TestMissingRuntimeManualCommandsUseShellSafeQuotes(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "gitmoot '$HOME';next")
+	result, err := Install(context.Background(), Options{
+		Provider: pluginpack.ProviderClaude,
+		Home:     home,
+		Runner:   &fakeRunner{},
+	})
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if len(result.ManualCommands) != 4 {
+		t.Fatalf("manual commands = %+v", result.ManualCommands)
+	}
+	for _, command := range result.ManualCommands[:2] {
+		if !strings.Contains(command, "$HOME") || !strings.Contains(command, "'\"'\"'") {
+			t.Fatalf("manual command is not shell-safe: %s", command)
+		}
+	}
+}
+
+type fakeRunner struct {
+	paths                 map[string]string
+	calls                 []fakeCall
+	failUninstallNotFound bool
+}
+
+type fakeCall struct {
+	command string
+	args    []string
+}
+
+func (r *fakeRunner) LookPath(file string) (string, error) {
+	if path, ok := r.paths[file]; ok {
+		return path, nil
+	}
+	return "", errors.New("not found")
+}
+
+func (r *fakeRunner) Run(ctx context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
+	r.calls = append(r.calls, fakeCall{command: command, args: append([]string(nil), args...)})
+	if r.failUninstallNotFound && command == "claude" && len(args) >= 2 && args[0] == "plugin" && args[1] == "uninstall" {
+		return subprocess.Result{Command: command, Args: args, Stderr: `Plugin "gitmoot@gitmoot-local" not found in installed plugins`}, errors.New("exit status 1")
+	}
+	return subprocess.Result{Command: command, Args: args}, nil
+}
+
+func assertCodexMarketplace(t *testing.T, path string) {
+	t.Helper()
+	var payload struct {
+		Name    string `json:"name"`
+		Plugins []struct {
+			Name   string `json:"name"`
+			Source struct {
+				Source string `json:"source"`
+				Path   string `json:"path"`
+			} `json:"source"`
+		} `json:"plugins"`
+	}
+	readJSONFile(t, path, &payload)
+	if payload.Name != pluginpack.MarketplaceName || len(payload.Plugins) != 1 {
+		t.Fatalf("unexpected codex marketplace: %+v", payload)
+	}
+	if payload.Plugins[0].Name != pluginpack.PluginName || payload.Plugins[0].Source.Path != marketplacePluginRelPath {
+		t.Fatalf("unexpected codex plugin entry: %+v", payload.Plugins[0])
+	}
+}
+
+func assertClaudeMarketplace(t *testing.T, path string) {
+	t.Helper()
+	var payload struct {
+		Name    string `json:"name"`
+		Plugins []struct {
+			Name   string `json:"name"`
+			Source string `json:"source"`
+		} `json:"plugins"`
+	}
+	readJSONFile(t, path, &payload)
+	if payload.Name != pluginpack.MarketplaceName || len(payload.Plugins) != 1 {
+		t.Fatalf("unexpected claude marketplace: %+v", payload)
+	}
+	if payload.Plugins[0].Name != pluginpack.PluginName || payload.Plugins[0].Source != marketplacePluginRelPath {
+		t.Fatalf("unexpected claude plugin entry: %+v", payload.Plugins[0])
+	}
+}
+
+func readJSONFile(t *testing.T, path string, out any) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(content, out); err != nil {
+		t.Fatalf("unmarshal %s: %v\n%s", path, err, content)
+	}
+}

--- a/internal/pluginpack/pluginpack.go
+++ b/internal/pluginpack/pluginpack.go
@@ -81,6 +81,10 @@ func ManifestPath(root string, provider Provider) string {
 	}
 }
 
+func IsGeneratedPackageDir(path string, provider Provider) bool {
+	return isGeneratedPackageDir(path, provider)
+}
+
 func Build(opts BuildOptions) (BuildResult, error) {
 	provider, err := validateProvider(opts.Provider)
 	if err != nil {


### PR DESCRIPTION
## WHAT
Adds `gitmoot plugin install codex|claude` and reusable install logic for local runtime plugin marketplaces.

## WHY
Users need a one-command way to build, register, and install Gitmoot plugins into Codex and Claude Code without hand-editing runtime config.

## CHANGES
- Added `internal/plugininstall` to build primary plugin packages plus marketplace-local packages.
- Wrote Codex and Claude marketplace manifests with runtime-compatible relative `./plugins/gitmoot` sources.
- Added Codex marketplace/install command execution and Claude validate/marketplace/uninstall/install refresh flow.
- Added missing-runtime manual next steps with shell-safe path quoting.
- Exported `pluginpack.IsGeneratedPackageDir` so install can preserve idempotency without overwriting non-generated directories.
- Added fake-runner tests for command order, missing runtimes, idempotency, safe overwrite behavior, safe quoting, and missing prior Claude installs.

## RESULTS
- `gofmt -d internal/cli/plugin.go internal/pluginpack/pluginpack.go internal/plugininstall/install.go internal/plugininstall/install_test.go`
- `git diff --check`
- `go test ./internal/cli ./internal/plugininstall ./internal/pluginpack` blocked: `go: download go1.26 for linux/amd64: toolchain not available`
- `GOTOOLCHAIN=local go test ./internal/cli ./internal/plugininstall ./internal/pluginpack` blocked: `go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local)`
- Manual Codex temp marketplace add/list/install check passed with relative source.
- Manual Claude temp marketplace validate/add/uninstall/install check passed with relative source.

## REVIEW
```text
I did not identify any discrete correctness issues in the staged, unstaged, or untracked changes. The new install flow appears consistent with the existing plugin packaging code and local Codex/Claude marketplace command contracts.
I did not identify any discrete correctness issues in the staged, unstaged, or untracked changes. The new install flow appears consistent with the existing plugin packaging code and local Codex/Claude marketplace command contracts.
```

## RISK
Go unit tests could not run on this host because the required Go 1.26 toolchain is unavailable. Runtime CLI contracts were smoke-checked locally with temporary homes and marketplaces.