### PR TITLE
docs: document gitmoot plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ gitmoot config path|show
 gitmoot version [--json]
 gitmoot update --check
 gitmoot update [--restart-daemon]
+gitmoot plugin build codex|claude
+gitmoot plugin install codex|claude
+gitmoot plugin doctor [codex|claude]
+gitmoot plugin path codex|claude
 gitmoot daemon start [--repo owner/repo] [--poll 30s]
 gitmoot daemon run [--repo owner/repo] [--poll 30s]
 gitmoot daemon stop|restart|status|logs
@@ -57,6 +61,23 @@ Agents should read the canonical Agent Skills package at
 [skills/gitmoot/SKILL.md](skills/gitmoot/SKILL.md) for the Gitmoot job contract,
 branch lock expectations, and safe behavior rules. The root [SKILL.md](SKILL.md)
 remains as a raw compatibility entrypoint for agents and `gitmoot.io/SKILL.md`.
+
+## Runtime Plugins
+
+Gitmoot can package the canonical Agent Skill for Codex and Claude Code so the
+runtime can discover Gitmoot guidance from its plugin system.
+
+```sh
+curl -fsSL https://gitmoot.io/install.sh | sh
+gitmoot plugin install codex
+gitmoot plugin install claude
+gitmoot plugin doctor
+```
+
+The plugins do not run a hosted service or replace the Gitmoot daemon. They
+install the local skill package and point agents back to the `gitmoot` CLI for
+repo setup, daemon status, jobs, locks, and PR-comment workflows. See
+[docs/plugins.md](docs/plugins.md) for install details and troubleshooting.
 
 ## Thermo Review Preset
 
@@ -122,6 +143,7 @@ gitmoot preset update frontend-reviewer
 ## Documentation
 
 - [Agent Skills package](skills/gitmoot/SKILL.md)
+- [Codex and Claude plugins](docs/plugins.md)
 - [Local workflow walkthrough](docs/local-workflow.md)
 - [Beta smoke tests](docs/beta-smoke-tests.md)
 - [Runtime adapter authoring](docs/adapters.md)

--- a/SKILL.md
+++ b/SKILL.md
@@ -57,6 +57,15 @@ gitmoot update --check
 gh auth status
 ```
 
+Install runtime plugin guidance when the user wants Codex or Claude Code to
+discover Gitmoot from its plugin system:
+
+```sh
+gitmoot plugin install codex
+gitmoot plugin install claude
+gitmoot plugin doctor
+```
+
 ## Common Local Commands
 
 ```sh
@@ -64,6 +73,7 @@ gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
 gitmoot daemon start --repo owner/repo --poll 30s
 gitmoot daemon status
+gitmoot plugin doctor
 gitmoot agent list
 gitmoot agent doctor <agent>
 gitmoot job list --repo owner/repo

--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -17,6 +17,74 @@ gitmoot doctor --repo .
 Use a test repository or a disposable branch. Keep generated logs, cloned
 helper repos, session archives, and large outputs untracked.
 
+## Plugin Package Smoke Test
+
+Goal: prove Gitmoot can build runtime plugin packages, register local
+marketplaces in isolated homes, and diagnose the generated packages without
+writing into the real user runtime state.
+
+1. Build a local test binary and use an isolated Gitmoot home.
+
+   ```sh
+   GOTOOLCHAIN=go1.26.0 go build -o /tmp/gitmoot-current ./cmd/gitmoot
+   export GITMOOT_SMOKE_HOME=/tmp/gitmoot-plugin-smoke
+   export GITMOOT_RUNTIME_HOME=/tmp/gitmoot-plugin-runtime-smoke
+   rm -rf "$GITMOOT_SMOKE_HOME"
+   rm -rf "$GITMOOT_RUNTIME_HOME"
+   mkdir -p "$GITMOOT_RUNTIME_HOME"
+   /tmp/gitmoot-current init --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+2. Build both plugin packages.
+
+   ```sh
+   /tmp/gitmoot-current plugin build codex --home "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current plugin build claude --home "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current plugin path codex --home "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current plugin path claude --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+3. Diagnose the built packages.
+
+   ```sh
+   /tmp/gitmoot-current plugin doctor --home "$GITMOOT_SMOKE_HOME" || true
+   /tmp/gitmoot-current plugin doctor codex --home "$GITMOOT_SMOKE_HOME" || true
+   /tmp/gitmoot-current plugin doctor claude --home "$GITMOOT_SMOKE_HOME" || true
+   ```
+
+   Missing runtime CLIs are valid in this smoke path. Continue when doctor
+   reports `runtime-cli` failures for missing `codex` or `claude`.
+
+4. Install with an isolated runtime home.
+
+   ```sh
+   HOME="$GITMOOT_RUNTIME_HOME" /tmp/gitmoot-current plugin install codex --home "$GITMOOT_SMOKE_HOME" --force
+   HOME="$GITMOOT_RUNTIME_HOME" /tmp/gitmoot-current plugin install claude --home "$GITMOOT_SMOKE_HOME" --scope user --force
+   ```
+
+   If `codex` or `claude` is not installed, the command should keep generated
+   files and print manual install commands instead of failing after partial
+   destructive work.
+
+5. Validate diagnostics again after install.
+
+   ```sh
+   /tmp/gitmoot-current plugin doctor --home "$GITMOOT_SMOKE_HOME" || true
+   /tmp/gitmoot-current plugin doctor codex --home "$GITMOOT_SMOKE_HOME" || true
+   /tmp/gitmoot-current plugin doctor claude --home "$GITMOOT_SMOKE_HOME" || true
+   ```
+
+Expected signals:
+
+- `plugin path codex` and `plugin path claude` point under
+  `$GITMOOT_SMOKE_HOME/.gitmoot/plugins/build`.
+- Each generated package contains `skills/gitmoot/SKILL.md`.
+- Doctor reports readable manifests and copied skill files.
+- Runtime marketplace or install state is written under `$GITMOOT_RUNTIME_HOME`,
+  not the real user home.
+- Missing runtime CLIs are reported as diagnostics with next steps, not as
+  corrupt generated packages.
+
 ## One-Repo Smoke Test
 
 Goal: PR comment -> queued ask job -> adapter result -> attributed PR comment

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -14,6 +14,9 @@ registration, plan import, task branch startup, status, recovery, and updates:
 ```sh
 gitmoot setup --repo owner/repo --path . --agent lead --runtime codex --session <session-ref> --role lead
 gitmoot doctor --repo .
+gitmoot plugin install codex
+gitmoot plugin install claude
+gitmoot plugin doctor
 gitmoot preset list
 gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
 gitmoot preset update thermo-nuclear-code-quality-review
@@ -40,6 +43,22 @@ gitmoot daemon status
 
 Goal import turns Markdown headings shaped like `### Task N: Title` into local
 planned tasks. `task run` starts one task branch and records its branch lock.
+
+## Runtime Plugin Setup
+
+Install the Codex or Claude plugin when you want the runtime to discover
+Gitmoot's Agent Skill through its plugin system:
+
+```sh
+curl -fsSL https://gitmoot.io/install.sh | sh
+gitmoot plugin install codex
+gitmoot plugin install claude
+gitmoot plugin doctor
+```
+
+The plugins are guidance and discovery surfaces. They do not replace
+`gitmoot daemon start`, agent registration, GitHub CLI authentication, or the
+local SQLite workflow state.
 
 ## End-To-End Demo Path
 
@@ -73,6 +92,8 @@ planned tasks. `task run` starts one task branch and records its branch lock.
    ```sh
    gitmoot init
    gitmoot doctor --repo .
+   gitmoot plugin install codex
+   gitmoot plugin doctor codex
    gitmoot agent start lead \
      --runtime codex \
      --repo owner/project \

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,140 @@
+# Codex And Claude Plugins
+
+Gitmoot plugins package the canonical Gitmoot Agent Skill for Codex and Claude
+Code. They make the runtime aware of Gitmoot commands, safety rules, and
+workflow expectations without changing Gitmoot's local-first architecture.
+
+The Gitmoot CLI remains the engine. The daemon still polls GitHub pull
+requests, local SQLite remains the workflow source of truth, and PR comments
+remain the public audit trail.
+
+## What Plugins Do
+
+- Install Gitmoot's agent skill into a local runtime plugin package.
+- Register a local marketplace named `gitmoot-local`.
+- Help Codex or Claude discover Gitmoot workflow instructions.
+- Point agents to the `gitmoot` CLI for status, jobs, locks, and daemon
+  management.
+
+## What Plugins Do Not Do
+
+- They do not start a hosted service, webhook receiver, or cloud runner.
+- They do not replace `gitmoot daemon start`.
+- They do not install Codex, Claude Code, Git, or GitHub CLI.
+- They do not silently subscribe agents or mutate repository state.
+
+## Install Gitmoot
+
+```sh
+curl -fsSL https://gitmoot.io/install.sh | sh
+gitmoot version
+gh auth status
+```
+
+## Install The Codex Plugin
+
+```sh
+gitmoot plugin install codex
+gitmoot plugin doctor codex
+```
+
+`plugin install codex` builds the Codex package under Gitmoot home, writes a
+local Codex marketplace manifest, runs `codex plugin marketplace add`, and runs
+`codex plugin add gitmoot@gitmoot-local` when the `codex` CLI is available.
+
+Use `gitmoot plugin path codex` to print the generated package path.
+
+## Install The Claude Plugin
+
+```sh
+gitmoot plugin install claude
+gitmoot plugin doctor claude
+```
+
+`plugin install claude` builds the Claude package under Gitmoot home, validates
+the package when the `claude` CLI is available, registers the local marketplace,
+refreshes any existing installed copy, and installs
+`gitmoot@gitmoot-local`.
+
+Claude supports installation scopes:
+
+```sh
+gitmoot plugin install claude --scope user
+gitmoot plugin install claude --scope project
+gitmoot plugin install claude --scope local
+```
+
+Use `gitmoot plugin path claude` to print the generated package path.
+
+## Verify
+
+```sh
+gitmoot plugin doctor
+gitmoot plugin doctor codex
+gitmoot plugin doctor claude
+```
+
+Doctor checks the canonical skill, generated package, manifest JSON, copied
+skill, marketplace path, runtime CLI availability, and runtime validation where
+supported.
+
+## Use From Codex
+
+After installing the Codex plugin, ask Codex to use the Gitmoot skill when the
+task involves local PR-comment agent coordination:
+
+```text
+Use the Gitmoot skill. Check gitmoot status for this repo.
+```
+
+The agent should read the bundled skill, verify `gitmoot version`, check
+`gh auth status` before PR workflows, and use read-only Gitmoot status commands
+before mutating daemon, agent, job, or lock state.
+
+## Use From Claude Code
+
+After installing the Claude plugin, ask Claude Code to use the Gitmoot skill for
+the current workflow:
+
+```text
+Use the Gitmoot skill. Check gitmoot status for this repo.
+```
+
+Claude should use the bundled Gitmoot skill content as guidance, then call the
+local `gitmoot` CLI only when the user asks for setup, status, agent
+coordination, or PR-comment workflow help.
+
+## Troubleshooting
+
+If the runtime CLI is missing, `gitmoot plugin install` keeps generated files
+and prints manual install commands. Install the missing runtime, then rerun:
+
+```sh
+gitmoot plugin install codex
+gitmoot plugin install claude
+```
+
+If a package looks stale, rebuild and reinstall:
+
+```sh
+gitmoot plugin install codex --force
+gitmoot plugin install claude --force
+```
+
+If Claude validation fails, inspect the generated package and rerun validation
+directly:
+
+```sh
+claude plugin validate "$(gitmoot plugin path claude)"
+```
+
+If Codex or Claude does not show the plugin after install, run:
+
+```sh
+gitmoot plugin doctor
+gitmoot plugin path codex
+gitmoot plugin path claude
+```
+
+Then confirm the runtime uses the same home directory as the shell where
+`gitmoot plugin install` ran.

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -30,7 +30,9 @@ inspection.
 
 Use `gitmoot status --repo owner/repo` for repo status, `gitmoot daemon status`
 for daemon state, `gitmoot agent list` for registered agents, and
-`gitmoot job list --repo owner/repo` for queued or recent jobs.
+`gitmoot job list --repo owner/repo` for queued or recent jobs. Use
+`gitmoot plugin doctor` when checking whether Codex or Claude Code can discover
+Gitmoot through an installed runtime plugin.
 
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -18,6 +18,31 @@ Verify GitHub access before PR workflows:
 gh auth status
 ```
 
+## Runtime Plugins
+
+Install Gitmoot's Agent Skill into Codex or Claude Code when the user wants the
+runtime to discover Gitmoot workflow guidance from its plugin system:
+
+```sh
+gitmoot plugin install codex
+gitmoot plugin install claude
+gitmoot plugin doctor
+```
+
+Inspect or build packages without installing:
+
+```sh
+gitmoot plugin build codex
+gitmoot plugin build claude
+gitmoot plugin path codex
+gitmoot plugin path claude
+gitmoot plugin doctor codex
+gitmoot plugin doctor claude
+```
+
+Claude scopes are supported with `--scope user|project|local`. Codex ignores
+`--scope` because the current Codex plugin install command does not use it.
+
 ## Repo And Daemon Status
 
 ```sh


### PR DESCRIPTION
## WHAT
Documents the Gitmoot Codex and Claude plugin install flow and updates agent-facing skill references.

## WHY
The new plugin build/install commands need clear human and agent guidance, including isolated smoke-test instructions and troubleshooting.

## CHANGES
- Added the plugin command surface to `README.md`.
- Added `docs/plugins.md` covering plugin purpose, install, verification, usage, and troubleshooting.
- Updated `docs/local-workflow.md` with plugin setup in the local workflow.
- Added plugin package smoke-test steps to `docs/beta-smoke-tests.md` with isolated Gitmoot and runtime homes.
- Updated the root `SKILL.md`, canonical skill summary, and `skills/gitmoot/references/CLI.md` with plugin guidance.

## RESULTS
- `git diff --check`
- Verified documented plugin commands against `internal/cli/plugin.go`, `internal/plugininstall`, and `internal/pluginpack`.
- `go test ./internal/cli ./internal/plugininstall ./internal/pluginpack` blocked: `go: download go1.26 for linux/amd64: toolchain not available`
- `GOTOOLCHAIN=local go test ./internal/cli ./internal/plugininstall ./internal/pluginpack` blocked: `go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local)`

## REVIEW
```text
The changes are documentation and skill updates describing the existing plugin CLI surface. I did not find any discrete inaccuracies or regressions that would break the documented workflows.
The changes are documentation and skill updates describing the existing plugin CLI surface. I did not find any discrete inaccuracies or regressions that would break the documented workflows.
```

## RISK
Go unit tests could not run on this host because the required Go 1.26 toolchain is unavailable. This task is docs-only; command text was checked against the implemented CLI surface.