### PR TITLE
test: add plugin smoke coverage

### DIFF
--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -23,6 +23,12 @@ Goal: prove Gitmoot can build runtime plugin packages, register local
 marketplaces in isolated homes, and diagnose the generated packages without
 writing into the real user runtime state.
 
+For the scripted version, run:
+
+```sh
+GO_BIN=/path/to/go1.26 scripts/plugin-smoke.sh
+```
+
 1. Build a local test binary and use an isolated Gitmoot home.
 
    ```sh

--- a/scripts/plugin-smoke.sh
+++ b/scripts/plugin-smoke.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GO_BIN="${GO_BIN:-go}"
+CREATED_WORK_DIR=""
+if [[ -n "${GITMOOT_PLUGIN_SMOKE_DIR:-}" ]]; then
+  WORK_DIR="$GITMOOT_PLUGIN_SMOKE_DIR"
+else
+  WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/gitmoot-plugin-smoke.XXXXXX")"
+  CREATED_WORK_DIR=1
+fi
+KEEP_WORK_DIR="${GITMOOT_PLUGIN_SMOKE_KEEP:-}"
+
+cleanup() {
+  if [[ -n "$CREATED_WORK_DIR" && -z "$KEEP_WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$WORK_DIR"
+
+BIN="${GITMOOT_BIN:-$WORK_DIR/gitmoot}"
+SMOKE_USER_HOME="$WORK_DIR/user-home"
+RUNTIME_HOME="$WORK_DIR/runtime-home"
+CODEX_OUT="$WORK_DIR/codex-plugin"
+CLAUDE_OUT="$WORK_DIR/claude-plugin"
+
+rm -rf "$SMOKE_USER_HOME" "$RUNTIME_HOME" "$CODEX_OUT" "$CLAUDE_OUT"
+mkdir -p "$SMOKE_USER_HOME" "$RUNTIME_HOME"
+
+if [[ -z "${GITMOOT_BIN:-}" ]]; then
+  (cd "$ROOT_DIR" && "$GO_BIN" build -o "$BIN" ./cmd/gitmoot)
+fi
+
+"$BIN" init --home "$SMOKE_USER_HOME"
+"$BIN" plugin build codex --out "$CODEX_OUT"
+"$BIN" plugin build claude --out "$CLAUDE_OUT"
+
+HAS_CLAUDE=""
+HAS_CODEX=""
+if command -v claude >/dev/null 2>&1; then
+  HAS_CLAUDE=1
+  claude plugin validate "$CLAUDE_OUT"
+else
+  echo "skip: claude CLI not found; package validation skipped"
+fi
+
+if command -v codex >/dev/null 2>&1; then
+  HAS_CODEX=1
+  HOME="$RUNTIME_HOME" codex plugin marketplace list >/dev/null
+  HOME="$RUNTIME_HOME" codex plugin list >/dev/null
+else
+  echo "skip: codex CLI not found; non-mutating codex plugin checks skipped"
+fi
+
+"$BIN" plugin build codex --home "$SMOKE_USER_HOME"
+"$BIN" plugin build claude --home "$SMOKE_USER_HOME"
+
+if command -v codex >/dev/null 2>&1; then
+  "$BIN" plugin doctor codex --home "$SMOKE_USER_HOME"
+else
+  "$BIN" plugin doctor codex --home "$SMOKE_USER_HOME" || true
+fi
+
+if command -v claude >/dev/null 2>&1; then
+  "$BIN" plugin doctor claude --home "$SMOKE_USER_HOME"
+else
+  "$BIN" plugin doctor claude --home "$SMOKE_USER_HOME" || true
+fi
+
+HOME="$RUNTIME_HOME" "$BIN" plugin install codex --home "$SMOKE_USER_HOME" --force
+HOME="$RUNTIME_HOME" "$BIN" plugin install claude --home "$SMOKE_USER_HOME" --scope user --force
+if [[ -n "$HAS_CODEX$HAS_CLAUDE" ]]; then
+  "$BIN" plugin doctor --home "$SMOKE_USER_HOME"
+else
+  "$BIN" plugin doctor --home "$SMOKE_USER_HOME" || true
+fi
+
+test -f "$SMOKE_USER_HOME/.gitmoot/plugins/build/codex/gitmoot/skills/gitmoot/SKILL.md"
+test -f "$SMOKE_USER_HOME/.gitmoot/plugins/build/claude/gitmoot/skills/gitmoot/SKILL.md"
+if [[ -n "$HAS_CODEX" ]]; then
+  test -f "$RUNTIME_HOME/.codex/config.toml"
+fi
+if [[ -n "$HAS_CLAUDE" ]]; then
+  test -f "$RUNTIME_HOME/.claude/plugins/installed_plugins.json"
+fi
+
+echo "plugin smoke passed"
+echo "work dir: $WORK_DIR"


### PR DESCRIPTION
## WHAT
Adds a repeatable plugin smoke-test helper and links it from the beta smoke-test docs.

## WHY
The plugin build/install flow needs an easy release-readiness check that exercises generated Codex and Claude packages without mutating real user runtime state.

## CHANGES
- Added `scripts/plugin-smoke.sh` to build Gitmoot, generate Codex and Claude plugin packages, validate Claude packages when available, run non-mutating Codex plugin checks, install into isolated runtime homes, and verify generated skill files.
- Added support for `GO_BIN`, `GITMOOT_BIN`, `GITMOOT_PLUGIN_SMOKE_DIR`, and `GITMOOT_PLUGIN_SMOKE_KEEP` so the smoke can run with local toolchain constraints.
- Updated `docs/beta-smoke-tests.md` with the scripted smoke command.

## RESULTS
- `bash -n scripts/plugin-smoke.sh`
- `git diff --check`
- `/root/temp/ts/tool/go test ./internal/cli ./internal/plugininstall ./internal/pluginpack`
- `/root/temp/ts/tool/go test ./...`
- `/root/temp/ts/tool/go vet ./...`
- `/root/temp/ts/tool/go build -o /tmp/gitmoot-plugin-smoke-current ./cmd/gitmoot`
- `GO_BIN=/root/temp/ts/tool/go scripts/plugin-smoke.sh`
- `PATH=<temp-bin-without-codex-or-claude> GITMOOT_BIN=/tmp/gitmoot-plugin-smoke-current /bin/bash scripts/plugin-smoke.sh`
- Manual isolated smoke also covered `claude plugin validate`, `codex plugin marketplace list`, `codex plugin list`, `gitmoot plugin doctor`, `gitmoot plugin doctor codex`, `gitmoot plugin doctor claude`, `gitmoot plugin install codex`, and `gitmoot plugin install claude --scope user` with temporary homes.

System `go` remains unusable here: `go: download go1.26 for linux/amd64: toolchain not available`. The checks above used `/root/temp/ts/tool/go` (`go1.26.2`).

## REVIEW
```text
I found no actionable correctness issues in the current staged, unstaged, or untracked changes.
I found no actionable correctness issues in the current staged, unstaged, or untracked changes.
```

## RISK
The smoke helper mutates only temporary Gitmoot and runtime homes by default. It preserves a caller-provided `GITMOOT_PLUGIN_SMOKE_DIR` and only deletes its own generated temp directory unless `GITMOOT_PLUGIN_SMOKE_KEEP` is set.