### PR TITLE
feat: add planner preset agent

### DIFF
--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -286,6 +286,80 @@ func TestRunAgentStartUsesInstalledCustomPreset(t *testing.T) {
 	}
 }
 
+func TestRunAgentStartAppliesPlannerPresetDefaults(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	seedPlannerPreset(t, home)
+	runner := &agentStartRunner{results: []subprocess.Result{{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440032"}` + "\n"}}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "start", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--repo", "owner/repo",
+		"--path", repoDir,
+		"--preset", "gitmoot-plan-and-goal",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.Role != "planner" || agent.PresetID != "gitmoot-plan-and-goal" || strings.Join(agent.Capabilities, ",") != "ask" {
+		t.Fatalf("agent = %+v", agent)
+	}
+	prompt := runner.calls[0].args[len(runner.calls[0].args)-1]
+	if !strings.Contains(prompt, "Preset: gitmoot-plan-and-goal @ def456") || !strings.Contains(prompt, "Plan and write goals.") {
+		t.Fatalf("startup prompt missing planner preset content:\n%s", prompt)
+	}
+}
+
+func TestRunAgentStartAllowsImplementForPlannerPreset(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	seedPlannerPreset(t, home)
+	runner := &agentStartRunner{results: []subprocess.Result{{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440033"}` + "\n"}}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "start", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--repo", "owner/repo",
+		"--path", repoDir,
+		"--preset", "gitmoot-plan-and-goal",
+		"--capability", "ask",
+		"--capability", "implement",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if strings.Join(agent.Capabilities, ",") != "ask,implement" {
+		t.Fatalf("capabilities = %+v", agent.Capabilities)
+	}
+}
+
 func TestRunAgentStartRejectsMissingPresetBeforeRuntime(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()
@@ -699,6 +773,30 @@ func seedThermoPreset(t *testing.T, home string) {
 		SourcePath:     "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
 		ResolvedCommit: "abc123",
 		Content:        "Review deeply.",
+	}); err != nil {
+		t.Fatalf("UpsertPreset returned error: %v", err)
+	}
+}
+
+func seedPlannerPreset(t *testing.T, home string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"init", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("init exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertPreset(context.Background(), db.Preset{
+		ID:             "gitmoot-plan-and-goal",
+		Name:           "Gitmoot Plan and Goal Writer",
+		SourceRepo:     "jerryfane/gitmoot",
+		SourceRef:      "main",
+		SourcePath:     "skills/gitmoot/presets/gitmoot-plan-and-goal.md",
+		ResolvedCommit: "def456",
+		Content:        "Plan and write goals.",
 	}); err != nil {
 		t.Fatalf("UpsertPreset returned error: %v", err)
 	}

--- a/internal/cli/preset_test.go
+++ b/internal/cli/preset_test.go
@@ -92,7 +92,7 @@ func TestPresetListShowsAvailableBuiltin(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("preset list exit code = %d, stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "thermo-nuclear-code-quality-review") || !strings.Contains(stdout.String(), "available") {
+	if !strings.Contains(stdout.String(), "thermo-nuclear-code-quality-review") || !strings.Contains(stdout.String(), "gitmoot-plan-and-goal") || !strings.Contains(stdout.String(), "available") {
 		t.Fatalf("stdout = %s", stdout.String())
 	}
 }

--- a/internal/preset/preset.go
+++ b/internal/preset/preset.go
@@ -19,6 +19,7 @@ import (
 )
 
 const ThermoNuclearCodeQualityReviewID = "thermo-nuclear-code-quality-review"
+const GitmootPlanAndGoalID = "gitmoot-plan-and-goal"
 const LocalSourceRepo = "local"
 const LocalSourceRef = "file"
 const DefaultLocalDescription = "Local custom prompt preset."
@@ -57,6 +58,17 @@ var builtins = []Definition{
 		SourceRepo:          "cursor/plugins",
 		SourceRef:           "main",
 		SourcePath:          "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+	},
+	{
+		ID:                  GitmootPlanAndGoalID,
+		Name:                "Gitmoot Plan and Goal Writer",
+		Description:         "Structured planning and standard goal-file preset for Gitmoot workflows.",
+		DefaultRole:         "planner",
+		DefaultCapabilities: []string{"ask"},
+		Mutation:            true,
+		SourceRepo:          "jerryfane/gitmoot",
+		SourceRef:           "main",
+		SourcePath:          "skills/gitmoot/presets/gitmoot-plan-and-goal.md",
 	},
 }
 

--- a/internal/preset/preset_test.go
+++ b/internal/preset/preset_test.go
@@ -14,17 +14,46 @@ import (
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
-func TestBuiltinsIncludesOnlyThermoPreset(t *testing.T) {
+func TestBuiltinsIncludesPlannerAndThermoPresets(t *testing.T) {
 	definitions := Builtins()
-	if len(definitions) != 1 {
-		t.Fatalf("builtin count = %d, want 1", len(definitions))
+	if len(definitions) != 2 {
+		t.Fatalf("builtin count = %d, want 2", len(definitions))
 	}
-	definition := definitions[0]
-	if definition.ID != ThermoNuclearCodeQualityReviewID || definition.Mutation {
-		t.Fatalf("definition = %+v", definition)
+	thermo, ok := Lookup(ThermoNuclearCodeQualityReviewID)
+	if !ok {
+		t.Fatal("thermo preset missing")
 	}
-	if !reflect.DeepEqual(definition.DefaultCapabilities, []string{"ask", "review"}) {
-		t.Fatalf("capabilities = %+v", definition.DefaultCapabilities)
+	if thermo.Mutation || !reflect.DeepEqual(thermo.DefaultCapabilities, []string{"ask", "review"}) {
+		t.Fatalf("thermo definition = %+v", thermo)
+	}
+	planner, ok := Lookup(GitmootPlanAndGoalID)
+	if !ok {
+		t.Fatal("planner preset missing")
+	}
+	if !planner.Mutation || planner.DefaultRole != "planner" || !reflect.DeepEqual(planner.DefaultCapabilities, []string{"ask"}) {
+		t.Fatalf("planner definition = %+v", planner)
+	}
+	if planner.SourceRepo != "jerryfane/gitmoot" || planner.SourcePath != "skills/gitmoot/presets/gitmoot-plan-and-goal.md" {
+		t.Fatalf("planner source = %+v", planner)
+	}
+}
+
+func TestUpdatePlannerPreset(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	updated, err := Update(ctx, store, fakeFetcher{commit: "def456", content: "Plan carefully."}, GitmootPlanAndGoalID)
+	if err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+	if updated.ID != GitmootPlanAndGoalID || updated.ResolvedCommit != "def456" || updated.Content != "Plan carefully." {
+		t.Fatalf("updated planner preset = %+v", updated)
+	}
+	if updated.SourceRepo != "jerryfane/gitmoot" || updated.SourcePath != "skills/gitmoot/presets/gitmoot-plan-and-goal.md" {
+		t.Fatalf("updated source = %+v", updated)
 	}
 }
 
@@ -201,4 +230,17 @@ func (f *fakeRunner) Run(_ context.Context, _ string, command string, args ...st
 
 func (f *fakeRunner) LookPath(file string) (string, error) {
 	return file, nil
+}
+
+type fakeFetcher struct {
+	commit  string
+	content string
+}
+
+func (f fakeFetcher) ResolveRef(context.Context, string, string) (string, error) {
+	return f.commit, nil
+}
+
+func (f fakeFetcher) FetchFile(context.Context, string, string, string) (File, error) {
+	return File{Content: f.content}, nil
 }

--- a/skills/gitmoot/presets/gitmoot-plan-and-goal.md
+++ b/skills/gitmoot/presets/gitmoot-plan-and-goal.md
@@ -1,0 +1,49 @@
+# Gitmoot Plan And Goal Writer
+
+You are a Gitmoot planner agent. Your job is to turn feature requests into
+clean implementation plans and, when asked, write a standard Gitmoot goal file.
+
+## Planning Workflow
+
+1. Inspect the current repo state and relevant existing patterns before writing
+   the plan.
+2. Use web search when the request depends on current external APIs, CLI
+   contracts, docs, standards, package behavior, deployment behavior, or
+   best-practice claims. Prefer official or primary sources.
+3. Ask clarifying questions only for high-impact product decisions that cannot
+   be discovered from the repo or official sources.
+4. Write a decision-complete plan that another engineer or agent can implement
+   without guessing.
+5. Split the plan into tasks. Each task should have a clear scope, PR boundary,
+   acceptance criteria, tests/checks, and suggested commit message.
+6. Keep the plan clean and organized. Preserve existing behavior unless the
+   requested feature explicitly changes it. Avoid broad rewrites.
+7. Avoid code duplication. When repeated logic appears, call out the helper or
+   abstraction that should be reused or extracted.
+
+## Goal File Workflow
+
+When asked to write the goal file:
+
+1. Read the canonical standard template with:
+
+   ```sh
+   gitmoot goal template
+   ```
+
+2. Create a goal file named `GOAL-<short-slug>.md`.
+3. Fill the template with the approved plan.
+4. Ensure each implementation task uses a heading in this exact form:
+
+   ```markdown
+   ### Task N: Task Title
+   ```
+
+5. Return the exact prompt the user should run:
+
+   ```text
+   /goal GOAL-<short-slug>.md
+   ```
+
+Do not implement the planned feature unless the user explicitly asks after the
+plan and goal file are complete.


### PR DESCRIPTION
WHAT: Added the built-in `gitmoot-plan-and-goal` planner preset agent.

WHY: Gitmoot needs a reusable preset for converting feature requests into structured implementation plans and standard goal files without adding a new runtime or MCP layer.

CHANGES:
- Added `GitmootPlanAndGoalID` and a built-in preset definition with role `planner`, default capability `ask`, and mutating capability support.
- Added `skills/gitmoot/presets/gitmoot-plan-and-goal.md` with planner and goal-file workflow instructions.
- Added preset update and lookup tests for the planner preset.
- Added CLI tests covering planner default role/capabilities and explicit `implement` capability allowance.

RESULTS:
- `/root/temp/ts/tool/go test ./internal/preset ./internal/cli`
- `/root/temp/ts/tool/go test ./...`
- `/root/temp/ts/tool/go vet ./...`
- `git diff --check`
- `/root/temp/ts/tool/go run ./cmd/gitmoot preset list --home /tmp/gitmoot-planner-task2-smoke`
- `/root/temp/ts/tool/go run ./cmd/gitmoot preset show --home /tmp/gitmoot-planner-task2-smoke gitmoot-plan-and-goal`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:

```text
No actionable correctness issues were found in the current staged, unstaged, or untracked changes. I could not run the Go test suite because the sandbox cannot download the required Go 1.26 toolchain.
No actionable correctness issues were found in the current staged, unstaged, or untracked changes. I could not run the Go test suite because the sandbox cannot download the required Go 1.26 toolchain.
```

RISK: Live `gitmoot preset update gitmoot-plan-and-goal` resolves from `main`, so it is expected to work only after this PR is merged. The update path is covered with a fake fetcher before merge.
