### PR TITLE
docs: document planner preset workflow

### DIFF
--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitmoot
-description: Use Gitmoot for local-first multi-agent coordination through GitHub PR comments, repo-scoped agent subscriptions, daemon checks, jobs, branch locks, presets, custom prompt agents, and Codex or Claude Code runtime workflows.
+description: Use Gitmoot for local-first multi-agent coordination through GitHub PR comments, structured implementation plans, standard goal files, repo-scoped agent subscriptions, daemon checks, jobs, branch locks, presets, custom prompt agents, and Codex or Claude Code runtime workflows.
 license: MIT
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
 metadata:
@@ -13,8 +13,8 @@ metadata:
 Gitmoot is a local-first coordinator for AI agents working through GitHub pull
 requests. Use this skill when the user wants PR-comment agent workflows,
 repo-scoped agent subscriptions, background daemon checks, Codex or Claude Code
-agent startup, preset agents, custom prompt agents, job status, or branch lock
-inspection.
+agent startup, structured implementation plans, standard goal files, preset
+agents, custom prompt agents, job status, or branch lock inspection.
 
 ## Before Acting
 
@@ -32,10 +32,14 @@ Use `gitmoot status --repo owner/repo` for repo status, `gitmoot daemon status`
 for daemon state, `gitmoot agent list` for registered agents, and
 `gitmoot job list --repo owner/repo` for queued or recent jobs. Use
 `gitmoot plugin doctor` when checking whether Codex or Claude Code can discover
-Gitmoot through an installed runtime plugin.
+Gitmoot through an installed runtime plugin. Use `gitmoot goal template` when
+writing a standard task-by-task goal file.
 
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).
+For the canonical goal prompt template, read
+[GOAL_TEMPLATE.md](references/GOAL_TEMPLATE.md) only when the user asks for a
+goal file.
 
 ## Agent Job Contract
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -105,6 +105,18 @@ gitmoot agent start thermo-review \
   --start-daemon
 ```
 
+Install or refresh the built-in planner preset:
+
+```sh
+gitmoot preset update gitmoot-plan-and-goal
+gitmoot agent start planner \
+  --runtime codex \
+  --repo owner/repo \
+  --path . \
+  --preset gitmoot-plan-and-goal \
+  --start-daemon
+```
+
 Create a local custom prompt preset:
 
 ```sh
@@ -123,6 +135,20 @@ After editing a local prompt file, refresh Gitmoot's cached snapshot:
 ```sh
 gitmoot preset diff frontend-reviewer
 gitmoot preset update frontend-reviewer
+```
+
+## Goals
+
+Print the standard Gitmoot goal prompt template:
+
+```sh
+gitmoot goal template
+```
+
+Import a goal file into local Gitmoot state:
+
+```sh
+gitmoot goal import --file GOAL-feature.md --repo owner/repo
 ```
 
 ## PR Comments

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -69,6 +69,40 @@ Custom preset content is snapshotted into local Gitmoot state. After editing the
 source prompt file, run `gitmoot preset diff <id>` and `gitmoot preset update
 <id>` before expecting new jobs to use the changed prompt.
 
+## Planner And Goal File Agent
+
+Use the planner preset when the user wants a structured implementation plan or a
+standard Gitmoot goal file.
+
+```sh
+gitmoot preset update gitmoot-plan-and-goal
+gitmoot agent start planner \
+  --runtime codex \
+  --repo owner/repo \
+  --path . \
+  --preset gitmoot-plan-and-goal \
+  --start-daemon
+```
+
+Ask from a PR comment:
+
+```text
+/gitmoot planner ask Write a task-by-task implementation plan for this feature, then create the goal file prompt.
+```
+
+Ask directly from a Codex plugin session:
+
+```text
+$gitmoot:gitmoot Use the planner workflow to create a plan and goal file for this feature: ...
+```
+
+If the planner writes a goal file and the user wants Gitmoot to track it, import
+it explicitly:
+
+```sh
+gitmoot goal import --file GOAL-feature.md --repo owner/repo
+```
+
 ## Multi-Repo Work
 
 Agents are global identities with explicit per-repo access. When working across


### PR DESCRIPTION
WHAT: Documented the planner preset in the Gitmoot skill package.

WHY: Agents and users need discoverable instructions for using the built-in planner preset and canonical goal template.

CHANGES:
- Added planner preset startup examples to the skill CLI reference.
- Added a planner-and-goal-file workflow to the skill workflow reference.
- Updated the Gitmoot skill entrypoint to mention structured plans, standard goal files, and the canonical goal template.

RESULTS:
- /root/temp/ts/tool/go test ./internal/skill ./internal/pluginpack
- /root/temp/ts/tool/go run ./cmd/gitmoot plugin build codex --home /tmp/gitmoot-task3-plugin-smoke --force
- test -f /tmp/gitmoot-task3-plugin-smoke/.gitmoot/plugins/build/codex/gitmoot/skills/gitmoot/references/GOAL_TEMPLATE.md
- test -f /tmp/gitmoot-task3-plugin-smoke/.gitmoot/plugins/build/codex/gitmoot/skills/gitmoot/presets/gitmoot-plan-and-goal.md
- /root/temp/ts/tool/go test ./...
- /root/temp/ts/tool/go vet ./...
- git diff --check
- codex exec review --uncommitted

Final codex exec review --uncommitted output:
```
The changes are documentation-only and align with existing CLI commands and files present in the repository. I did not find any discrete correctness issue that would break the documented workflows.
The changes are documentation-only and align with existing CLI commands and files present in the repository. I did not find any discrete correctness issue that would break the documented workflows.
```

RISK: No skipped checks. Residual risk is limited to documentation clarity.