### PR TITLE
docs: add planner preset smoke workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ gitmoot daemon stop|restart|status|logs
 gitmoot preset list
 gitmoot preset add <preset-id> --file ./agents/<preset-id>.md
 gitmoot preset show|update|diff <preset-id>
+gitmoot goal template
+gitmoot goal import --file <path> [--repo owner/repo]
 gitmoot agent start <name> --runtime codex|claude --repo owner/repo [--path .] [--preset <preset-id>] [--start-daemon]
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
+gitmoot agent start planner --runtime codex --repo owner/repo --preset gitmoot-plan-and-goal
 gitmoot agent start thermo-review --runtime codex --repo owner/repo --preset thermo-nuclear-code-quality-review
 gitmoot agent allow|deny|repos
 gitmoot agent list
@@ -51,7 +54,6 @@ gitmoot agent remove <name>
 ```text
 gitmoot status
 gitmoot events --repo owner/repo
-gitmoot goal import --file <path>
 gitmoot task run <id> --repo owner/repo --owner <agent>
 gitmoot job list|show|events|run|retry|cancel
 gitmoot lock list|show|release
@@ -78,6 +80,29 @@ The plugins do not run a hosted service or replace the Gitmoot daemon. They
 install the local skill package and point agents back to the `gitmoot` CLI for
 repo setup, daemon status, jobs, locks, and PR-comment workflows. See
 [docs/plugins.md](docs/plugins.md) for install details and troubleshooting.
+
+## Planner Preset
+
+Gitmoot includes `gitmoot-plan-and-goal` for structured implementation planning
+and standard goal-file writing. It uses the canonical goal template from
+`gitmoot goal template`, then writes plan tasks as `### Task N: ...` headings so
+`gitmoot goal import` can track them.
+
+```sh
+gitmoot preset update gitmoot-plan-and-goal
+gitmoot agent start planner \
+  --runtime codex \
+  --repo owner/repo \
+  --path . \
+  --preset gitmoot-plan-and-goal \
+  --start-daemon
+```
+
+Ask it from a PR comment:
+
+```text
+/gitmoot planner ask Write a task-by-task implementation plan for this feature, then create the goal file prompt.
+```
 
 ## Thermo Review Preset
 

--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -216,6 +216,76 @@ Expected signals:
    gitmoot preset update thermo-nuclear-code-quality-review
    ```
 
+## Planner Preset Smoke Test
+
+Goal: canonical goal template -> cached planner preset -> Gitmoot-managed Codex
+planner agent. This verifies the planning workflow is discoverable before using
+it on a real PR.
+
+1. Build a local test binary and use an isolated Gitmoot home.
+
+   ```sh
+   GOTOOLCHAIN=go1.26.0 go build -o /tmp/gitmoot-current ./cmd/gitmoot
+   export GITMOOT_SMOKE_HOME=/tmp/gitmoot-planner-preset-smoke
+   rm -rf "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current init --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+2. Confirm the canonical template and planner preset are available.
+
+   ```sh
+   /tmp/gitmoot-current goal template | grep "codex exec review is clean; ready for manual /review."
+   /tmp/gitmoot-current preset list --home "$GITMOOT_SMOKE_HOME" | grep gitmoot-plan-and-goal
+   /tmp/gitmoot-current preset update --home "$GITMOOT_SMOKE_HOME" gitmoot-plan-and-goal
+   /tmp/gitmoot-current preset show --home "$GITMOOT_SMOKE_HOME" gitmoot-plan-and-goal
+   ```
+
+3. From the test repo checkout, start the planner agent.
+
+   ```sh
+   cd /path/to/project
+   /tmp/gitmoot-current agent start planner-smoke \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --runtime codex \
+     --repo owner/project \
+     --path . \
+     --preset gitmoot-plan-and-goal \
+     --start-daemon
+   /tmp/gitmoot-current agent doctor planner-smoke --home "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current daemon status --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+4. Open a disposable PR, then comment:
+
+   ```text
+   /gitmoot planner-smoke ask Write a task-by-task implementation plan for this feature, then create the goal file prompt.
+   ```
+
+5. Verify the queued job and PR result.
+
+   ```sh
+   /tmp/gitmoot-current job list --home "$GITMOOT_SMOKE_HOME" --repo owner/project
+   /tmp/gitmoot-current events --home "$GITMOOT_SMOKE_HOME" --repo owner/project
+   gh pr view <number> --repo owner/project --comments
+   ```
+
+Expected signals:
+
+- `goal template` prints the canonical PR-per-task prompt.
+- `preset show` displays `default role: planner`, `default capabilities: ask`,
+  and `mutation: true`.
+- `agent doctor planner-smoke` succeeds.
+- The PR result comment includes `Preset: gitmoot-plan-and-goal`.
+- The planner returns a structured plan and, when requested, a
+  `GOAL-<short-slug>.md` path plus `/goal GOAL-<short-slug>.md`.
+
+6. Stop the isolated daemon.
+
+   ```sh
+   /tmp/gitmoot-current daemon stop --home "$GITMOOT_SMOKE_HOME"
+   /tmp/gitmoot-current daemon status --home "$GITMOOT_SMOKE_HOME"
+   ```
+
 ## Agent Start Smoke Test
 
 Goal: prove `gitmoot agent start` can create a Codex session, store the session


### PR DESCRIPTION
WHAT: Added user-facing planner preset docs to README and beta smoke tests.

WHY: The new planner preset needs a visible quickstart and release-smoke path before beta use.

CHANGES:
- Added `gitmoot goal template` and planner preset commands to README command surface.
- Added a README planner preset section with startup and PR-comment examples.
- Added a planner preset smoke test covering the canonical goal template, preset cache, agent startup, daemon status, and expected PR result metadata.

RESULTS:
- /root/temp/ts/tool/go test ./internal/skill ./internal/pluginpack
- /root/temp/ts/tool/go test ./...
- /root/temp/ts/tool/go vet ./...
- git diff --check
- /root/temp/ts/tool/go run ./cmd/gitmoot goal template | grep "codex exec review is clean; ready for manual /review."
- /root/temp/ts/tool/go run ./cmd/gitmoot preset list --home /tmp/gitmoot-task4-planner-smoke | grep gitmoot-plan-and-goal
- codex exec review --uncommitted

Final codex exec review --uncommitted output:
```
The changes are documentation-only and the added commands/expected signals align with the current CLI behavior. No discrete actionable correctness issues were found.
The changes are documentation-only and the added commands/expected signals align with the current CLI behavior. No discrete actionable correctness issues were found.
```

RISK: No skipped checks. Residual risk is that the full live PR-comment planner smoke depends on an installed authenticated Codex runtime and a disposable PR.