### PR TITLE
test: cover planner preset skill packaging

### DIFF
--- a/internal/pluginpack/pluginpack_test.go
+++ b/internal/pluginpack/pluginpack_test.go
@@ -107,7 +107,9 @@ func TestBuildUsesEmbeddedSkillByDefault(t *testing.T) {
 		t.Fatalf("Build() error = %v", err)
 	}
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "SKILL.md"), "Gitmoot Agent Skill")
+	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "GOAL_TEMPLATE.md"), "codex exec review is clean; ready for manual /review.")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "RESULT_CONTRACT.md"), "gitmoot_result")
+	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "presets", "gitmoot-plan-and-goal.md"), "Gitmoot Plan And Goal Writer")
 }
 
 func TestBuildRefusesOverwriteWithoutForce(t *testing.T) {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -46,6 +46,7 @@ func TestCanonicalSkillReferencesExist(t *testing.T) {
 	for _, ref := range []string{
 		"references/CLI.md",
 		"references/WORKFLOWS.md",
+		"references/GOAL_TEMPLATE.md",
 		"references/RESULT_CONTRACT.md",
 		"references/SAFETY.md",
 	} {


### PR DESCRIPTION
WHAT: Added coverage for planner preset skill packaging.

WHY: The planner workflow depends on the canonical goal template and planner preset prompt being present in the skill package and generated runtime plugin packages.

CHANGES:
- Extended the canonical skill reference test to require `references/GOAL_TEMPLATE.md`.
- Extended the embedded plugin package test to assert generated packages include `references/GOAL_TEMPLATE.md` and `presets/gitmoot-plan-and-goal.md`.

RESULTS:
- /root/temp/ts/tool/go test ./internal/cli ./internal/preset ./internal/skill ./internal/pluginpack
- /root/temp/ts/tool/go test ./...
- /root/temp/ts/tool/go vet ./...
- git diff --check
- /root/temp/ts/tool/go run ./cmd/gitmoot plugin build codex --home /tmp/gitmoot-task5-plugin-smoke --force
- test -f /tmp/gitmoot-task5-plugin-smoke/.gitmoot/plugins/build/codex/gitmoot/skills/gitmoot/references/GOAL_TEMPLATE.md
- test -f /tmp/gitmoot-task5-plugin-smoke/.gitmoot/plugins/build/codex/gitmoot/skills/gitmoot/presets/gitmoot-plan-and-goal.md
- codex exec review --uncommitted

Final codex exec review --uncommitted output:
```
The changes only add coverage for files and content that are present in the current skill package. I did not identify any actionable correctness issues; local test execution was blocked because Go attempted to download the 1.26 toolchain into a read-only module cache.
The changes only add coverage for files and content that are present in the current skill package. I did not identify any actionable correctness issues; local test execution was blocked because Go attempted to download the 1.26 toolchain into a read-only module cache.
```

RISK: No skipped local checks. Review sandbox could not run Go tests because it attempted to download Go 1.26 into a read-only module cache; local tests passed with /root/temp/ts/tool/go.