### PR TITLE
feat: add local agent ask dispatch

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -3,17 +3,22 @@ package cli
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/preset"
 	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
 var newRuntimeFactory = func() runtime.Factory {
@@ -28,6 +33,8 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "start":
 		return runAgentStart(args[1:], stdout, stderr)
+	case "ask":
+		return runAgentAsk(args[1:], stdout, stderr)
 	case "subscribe":
 		return runAgentSubscribe(args[1:], stdout, stderr)
 	case "list":
@@ -52,6 +59,7 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot agent start <name> --runtime codex|claude --repo owner/repo [--path .] [--preset <preset-id>] [--start-daemon]")
+	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> [--repo owner/repo...] --capability <capability>")
 	fmt.Fprintln(w, "    Codex sessions may use a UUID, thread name, or last. Claude sessions may use a UUID or last. Shell sessions are commands.")
 	fmt.Fprintln(w, "  gitmoot agent allow <name> --repo owner/repo")
@@ -60,6 +68,270 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent list")
 	fmt.Fprintln(w, "  gitmoot agent remove <name>")
 	fmt.Fprintln(w, "  gitmoot agent doctor <name>")
+}
+
+type agentAskOptions struct {
+	home       string
+	repo       string
+	jsonOutput bool
+	agent      string
+	message    string
+}
+
+type agentAskOutput struct {
+	JobID          string                `json:"job_id"`
+	State          string                `json:"state"`
+	Repo           string                `json:"repo"`
+	Agent          string                `json:"agent"`
+	Action         string                `json:"action"`
+	Result         *workflow.AgentResult `json:"result,omitempty"`
+	RawOutputCount int                   `json:"raw_output_count"`
+}
+
+func runAgentAsk(args []string, stdout, stderr io.Writer) int {
+	options, ok := parseAgentAskOptions(args, stderr)
+	if !ok {
+		if containsHelpFlag(args) {
+			return 0
+		}
+		return 2
+	}
+	var output agentAskOutput
+	if err := withStore(options.home, func(store *db.Store) error {
+		ctx := context.Background()
+		repo, record, err := resolveAgentAskRepo(ctx, store, options.repo)
+		if err != nil {
+			return err
+		}
+		if err := store.UpsertRepo(ctx, record); err != nil {
+			return err
+		}
+		agent, err := store.GetAgent(ctx, options.agent)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("agent %q not found", options.agent)
+			}
+			return err
+		}
+		if err := ensureAgentAskAccess(ctx, store, agent, repo.FullName()); err != nil {
+			return err
+		}
+		adapter, err := runtimeStartAdapter(newRuntimeFactory(), agent.Runtime, record.CheckoutPath)
+		if err != nil {
+			return err
+		}
+		job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+			ID:           localAskJobID(agent.Name),
+			Agent:        agent.Name,
+			Action:       "ask",
+			Repo:         repo.FullName(),
+			Branch:       record.DefaultBranch,
+			Sender:       "local",
+			Instructions: options.message,
+		})
+		if err != nil {
+			return err
+		}
+		if _, err := (workflow.Mailbox{Store: store}).Run(ctx, job.ID, runtimeAgent(agent), adapter); err != nil {
+			return err
+		}
+		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_completed", Message: "workflow advancement completed"}); err != nil {
+			return err
+		}
+		latest, err := store.GetJob(ctx, job.ID)
+		if err != nil {
+			return err
+		}
+		payload, err := daemonJobPayload(latest)
+		if err != nil {
+			return err
+		}
+		output = agentAskOutput{
+			JobID:          latest.ID,
+			State:          latest.State,
+			Repo:           payload.Repo,
+			Agent:          latest.Agent,
+			Action:         latest.Type,
+			Result:         payload.Result,
+			RawOutputCount: len(payload.RawOutputs),
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent ask: %v\n", err)
+		return 1
+	}
+	if options.jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "agent ask: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printAgentAskOutput(stdout, output)
+	return 0
+}
+
+func parseAgentAskOptions(args []string, stderr io.Writer) (agentAskOptions, bool) {
+	if len(args) == 0 || containsHelpFlag(args) {
+		printAgentAskUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent ask requires exactly one agent and one message")
+		}
+		return agentAskOptions{}, false
+	}
+	options := agentAskOptions{}
+	positionals := []string{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "--json":
+			options.jsonOutput = true
+		case arg == "--repo" || arg == "--home":
+			if index+1 >= len(args) {
+				fmt.Fprintf(stderr, "agent ask requires a value for %s\n", arg)
+				return agentAskOptions{}, false
+			}
+			index++
+			if arg == "--repo" {
+				options.repo = args[index]
+			} else {
+				options.home = args[index]
+			}
+		case strings.HasPrefix(arg, "--repo="):
+			options.repo = strings.TrimPrefix(arg, "--repo=")
+		case strings.HasPrefix(arg, "--home="):
+			options.home = strings.TrimPrefix(arg, "--home=")
+		case strings.HasPrefix(arg, "-") && len(positionals) >= 2:
+			fmt.Fprintf(stderr, "unknown agent ask flag %q\n", arg)
+			return agentAskOptions{}, false
+		default:
+			positionals = append(positionals, arg)
+		}
+	}
+	if len(positionals) != 2 {
+		fmt.Fprintln(stderr, "agent ask requires exactly one agent and one message")
+		return agentAskOptions{}, false
+	}
+	options.agent = strings.TrimSpace(positionals[0])
+	options.message = strings.TrimSpace(positionals[1])
+	if options.agent == "" || options.message == "" {
+		fmt.Fprintln(stderr, "agent ask requires exactly one agent and one message")
+		return agentAskOptions{}, false
+	}
+	return options, true
+}
+
+func containsHelpFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+func printAgentAskUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--home path] [--json]")
+}
+
+func resolveAgentAskRepo(ctx context.Context, store *db.Store, repoFlag string) (github.Repository, db.Repo, error) {
+	repo, err := agentAskTargetRepo(ctx, repoFlag)
+	if err != nil {
+		return github.Repository{}, db.Repo{}, err
+	}
+	if strings.TrimSpace(repoFlag) == "" {
+		record, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: "."})
+		if err != nil {
+			return github.Repository{}, db.Repo{}, err
+		}
+		return repo, record, nil
+	}
+	if existing, err := store.GetRepo(ctx, repo.FullName()); err == nil && strings.TrimSpace(existing.CheckoutPath) != "" {
+		record, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: existing.CheckoutPath})
+		if err != nil {
+			return github.Repository{}, db.Repo{}, err
+		}
+		record.PollInterval = existing.PollInterval
+		return repo, record, nil
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return github.Repository{}, db.Repo{}, err
+	}
+	record, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: "."})
+	if err != nil {
+		return github.Repository{}, db.Repo{}, err
+	}
+	return repo, record, nil
+}
+
+func agentAskTargetRepo(ctx context.Context, repoFlag string) (github.Repository, error) {
+	if strings.TrimSpace(repoFlag) != "" {
+		return daemon.ParseRepository(repoFlag)
+	}
+	remote, err := (gitutil.Client{Dir: "."}).OriginRemote(ctx)
+	if err != nil {
+		return github.Repository{}, fmt.Errorf("infer repo from current checkout: %w", err)
+	}
+	parsed, err := gitutil.ParseGitHubRemote(remote)
+	if err != nil {
+		return github.Repository{}, err
+	}
+	return github.Repository{Owner: parsed.Owner, Name: parsed.Name}, nil
+}
+
+func ensureAgentAskAccess(ctx context.Context, store *db.Store, agent db.Agent, repo string) error {
+	allowed, err := store.AgentCanAccessRepo(ctx, agent.Name, repo)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return fmt.Errorf("agent %q is not allowed on %q", agent.Name, repo)
+	}
+	if !agentHasCapability(agent.Capabilities, "ask") {
+		return fmt.Errorf("agent %q lacks ask capability", agent.Name)
+	}
+	return nil
+}
+
+func localAskJobID(agent string) string {
+	return fmt.Sprintf("local-ask-%s-%x", agent, time.Now().UTC().UnixNano())
+}
+
+func printAgentAskOutput(stdout io.Writer, output agentAskOutput) {
+	writeLine(stdout, "job: %s", output.JobID)
+	writeLine(stdout, "state: %s", output.State)
+	writeLine(stdout, "repo: %s", output.Repo)
+	writeLine(stdout, "agent: %s", output.Agent)
+	writeLine(stdout, "action: %s", output.Action)
+	if output.Result == nil {
+		return
+	}
+	writeLine(stdout, "decision: %s", output.Result.Decision)
+	writeLine(stdout, "summary: %s", output.Result.Summary)
+	printRawMessages(stdout, "findings", output.Result.Findings)
+	printStringList(stdout, "needs", output.Result.Needs)
+	printStringList(stdout, "tests_run", output.Result.TestsRun)
+	printStringList(stdout, "next_agents", output.Result.NextAgents)
+}
+
+func printRawMessages(stdout io.Writer, label string, values []json.RawMessage) {
+	if len(values) == 0 {
+		return
+	}
+	writeLine(stdout, "%s:", label)
+	for _, value := range values {
+		writeLine(stdout, "- %s", strings.TrimSpace(string(value)))
+	}
+}
+
+func printStringList(stdout io.Writer, label string, values []string) {
+	if len(values) == 0 {
+		return
+	}
+	writeLine(stdout, "%s:", label)
+	for _, value := range values {
+		writeLine(stdout, "- %s", value)
+	}
 }
 
 func runAgentStart(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -358,6 +359,250 @@ func TestRunAgentStartAllowsImplementForPlannerPreset(t *testing.T) {
 	if strings.Join(agent.Capabilities, ",") != "ask,implement" {
 		t.Fatalf("capabilities = %+v", agent.Capabilities)
 	}
+}
+
+func TestRunAgentAskDispatchesAndStoresResult(t *testing.T) {
+	home := t.TempDir()
+	otherHome := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+	seedPlannerPreset(t, home)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "subscribe", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440021",
+		"--repo", "owner/repo",
+		"--preset", "gitmoot-plan-and-goal",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"agent", "ask", "planner", "use the isolated state", "--home", otherHome, "--repo", "owner/repo"}, &stdout, &stderr); code != 1 {
+		t.Fatalf("ask with other home exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), `agent "planner" not found`) {
+		t.Fatalf("ask with other home stderr = %q", stderr.String())
+	}
+
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"gitmoot_result":{"decision":"approved","summary":"plan ready","findings":[{"title":"clear"}],"changes_made":[],"tests_run":["go test ./internal/cli"],"needs":["ship it"],"next_agents":["thermo-review"]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"approved","summary":"json ready","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"agent", "ask", "planner", "Write a plan", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("ask exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"job: local-ask-planner-",
+		"state: succeeded",
+		"repo: owner/repo",
+		"agent: planner",
+		"action: ask",
+		"decision: approved",
+		"summary: plan ready",
+		"findings:",
+		`- {"title":"clear"}`,
+		"needs:",
+		"- ship it",
+		"tests_run:",
+		"- go test ./internal/cli",
+		"next_agents:",
+		"- thermo-review",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("ask output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	runner.want(t, 0, repoDir, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440021", "--")
+	if !strings.Contains(runner.calls[0].args[len(runner.calls[0].args)-1], "Write a plan") {
+		t.Fatalf("ask prompt missing message:\n%s", runner.calls[0].args[len(runner.calls[0].args)-1])
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("jobs = %+v, want one job", jobs)
+	}
+	payload, err := daemonJobPayload(jobs[0])
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if payload.PresetID != "gitmoot-plan-and-goal" || payload.PresetResolvedCommit != "def456" || !strings.Contains(payload.PresetContent, "Plan and write goals.") {
+		t.Fatalf("payload preset snapshot = %+v", payload)
+	}
+	if payload.PullRequest != 0 || payload.Sender != "local" || payload.Instructions != "Write a plan" {
+		t.Fatalf("payload local ask fields = %+v", payload)
+	}
+	if payload.Result == nil || payload.Result.Summary != "plan ready" || len(payload.RawOutputs) != 1 {
+		t.Fatalf("payload result = %+v", payload)
+	}
+	events, err := store.ListJobEvents(context.Background(), jobs[0].ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !hasCLIJobEvent(events, "advance_completed") {
+		t.Fatalf("events = %+v, want advance_completed", events)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "list", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), jobs[0].ID+"\tsucceeded\task\tplanner\towner/repo\t#0") {
+		t.Fatalf("job list output = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "show", jobs[0].ID, "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{`"preset_id": "gitmoot-plan-and-goal"`, "decision: approved", "summary: plan ready"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("job show output missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	otherStore := openCLIJobStore(t, otherHome)
+	defer otherStore.Close()
+	otherJobs, err := otherStore.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("other ListJobs returned error: %v", err)
+	}
+	if len(otherJobs) != 0 {
+		t.Fatalf("other home jobs = %+v, want none", otherJobs)
+	}
+
+	runGit(t, repoDir, "switch", "-c", "feature/local-ask")
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "planner", "- Write JSON", "--home", home, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("ask --json exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "gitmoot_result") {
+		t.Fatalf("json output leaked raw runtime output:\n%s", stdout.String())
+	}
+	var decoded agentAskOutput
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("json output did not decode: %v\n%s", err, stdout.String())
+	}
+	if decoded.State != "succeeded" || decoded.Repo != "owner/repo" || decoded.Result == nil || decoded.Result.Summary != "json ready" || decoded.RawOutputCount != 1 {
+		t.Fatalf("decoded output = %+v", decoded)
+	}
+	jsonJob, err := store.GetJob(context.Background(), decoded.JobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s) returned error: %v", decoded.JobID, err)
+	}
+	jsonPayload, err := daemonJobPayload(jsonJob)
+	if err != nil {
+		t.Fatalf("json daemonJobPayload returned error: %v", err)
+	}
+	if jsonPayload.Branch != "feature/local-ask" || jsonPayload.Instructions != "- Write JSON" {
+		t.Fatalf("json ask payload = %+v", jsonPayload)
+	}
+}
+
+func TestRunAgentAskValidatesInputAndAccess(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "ask", "planner", "--home", home}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("missing message exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "agent ask requires exactly one agent and one message") {
+		t.Fatalf("missing message stderr = %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "missing", "hello", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("missing agent exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), `agent "missing" not found`) {
+		t.Fatalf("missing agent stderr = %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"agent", "subscribe", "reviewer",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440031",
+		"--role", "reviewer",
+		"--repo", "owner/repo",
+		"--capability", "review",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("subscribe reviewer exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "reviewer", "hello", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("missing ask capability exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), `agent "reviewer" lacks ask capability`) {
+		t.Fatalf("missing ask capability stderr = %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"agent", "subscribe", "outsider",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440032",
+		"--role", "planner",
+		"--repo", "owner/other",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("subscribe outsider exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "outsider", "hello", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("disallowed repo exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), `agent "outsider" is not allowed on "owner/repo"`) {
+		t.Fatalf("disallowed repo stderr = %q", stderr.String())
+	}
+}
+
+func hasCLIJobEvent(events []db.JobEvent, kind string) bool {
+	for _, event := range events {
+		if event.Kind == kind {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRunAgentStartRejectsMissingPresetBeforeRuntime(t *testing.T) {


### PR DESCRIPTION
WHAT:
- Added `gitmoot agent ask <name> "message"` for local, synchronous dispatch to a registered Gitmoot agent.

WHY:
- The plugin/current-chat workflow needs a real Gitmoot agent path instead of a separate skill-only planner path, so users can ask any registered agent from the CLI and keep the result in Gitmoot job history.

CHANGES:
- Added the `agent ask` route and usage text.
- Added local repo resolution from `--repo` or the current checkout, including branch refresh for registered checkouts.
- Validates agent existence, repo access, and `ask` capability before dispatch.
- Enqueues and runs a local `ask` job through the registered runtime adapter.
- Prints concise text output or structured `--json` output without leaking raw runtime output.
- Added tests for `--home` isolation, dispatch arguments, preset snapshot storage, job list/show visibility, JSON output, branch refresh, dash-prefixed messages, missing agents, missing capability, and disallowed repos.

RESULTS:
- `git diff --check`
- `/root/temp/ts/tool/go test ./internal/cli ./internal/workflow ./internal/runtime`
- `/root/temp/ts/tool/go test ./...`
- `codex exec review --uncommitted` final raw output:

```text
I found no discrete correctness issues in the current changes. I could not run the Go tests because the required Go 1.26 toolchain download is blocked by the sandbox's read-only module cache.
I found no discrete correctness issues in the current changes. I could not run the Go tests because the required Go 1.26 toolchain download is blocked by the sandbox's read-only module cache.
```

RISK:
- No skipped local checks. The review tool could not run tests through the system Go path, but the same tests passed through the repo's Go 1.26 toolchain path.
- `agent ask` does not post PR comments; it is local CLI dispatch only.
- Follow-up `gitmoot agent review` and `gitmoot agent implement` commands are tracked in #50.
