### PR TITLE
docs: route plugin planner workflow through agent ask

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ gitmoot goal template
 gitmoot goal import --file <path> [--repo owner/repo]
 gitmoot agent start <name> --runtime codex|claude --repo owner/repo [--path .] [--preset <preset-id>] [--start-daemon]
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
+gitmoot agent ask <name> "message" [--repo owner/repo] [--json]
 gitmoot agent start planner --runtime codex --repo owner/repo --preset gitmoot-plan-and-goal
 gitmoot agent start thermo-review --runtime codex --repo owner/repo --preset thermo-nuclear-code-quality-review
 gitmoot agent allow|deny|repos
@@ -102,6 +103,13 @@ Ask it from a PR comment:
 
 ```text
 /gitmoot planner ask Write a task-by-task implementation plan for this feature, then create the goal file prompt.
+```
+
+Ask it directly from a local Codex or Claude chat by having the runtime call the
+Gitmoot CLI:
+
+```sh
+gitmoot agent ask planner --repo owner/repo "Write a task-by-task implementation plan for this feature, then create the goal file prompt."
 ```
 
 ## Thermo Review Preset

--- a/SKILL.md
+++ b/SKILL.md
@@ -76,6 +76,7 @@ gitmoot daemon status
 gitmoot plugin doctor
 gitmoot agent list
 gitmoot agent doctor <agent>
+gitmoot agent ask <agent> --repo owner/repo "question or instructions"
 gitmoot job list --repo owner/repo
 gitmoot job show <job-id>
 gitmoot job events <job-id>
@@ -85,6 +86,11 @@ gitmoot lock show owner/repo <branch>
 
 Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`
 only when the user explicitly wants a foreground process.
+
+Use `gitmoot agent ask` when the user wants to invoke a registered Gitmoot
+agent from the current local chat. This is the same agent registry and runtime
+adapter path used by PR-comment ask jobs; the plugin only helps the runtime
+discover this skill and does not replace the `gitmoot` CLI.
 
 ## PR Comment Commands
 

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -22,6 +22,7 @@ gitmoot preset add frontend-reviewer --file agents/frontend-reviewer.md
 gitmoot preset update thermo-nuclear-code-quality-review
 gitmoot agent start <name> --runtime codex|claude --repo owner/repo --path . --preset thermo-nuclear-code-quality-review --start-daemon
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
+gitmoot agent ask <name> "message" --repo owner/repo
 gitmoot agent start thermo-review --runtime codex --repo owner/repo --preset thermo-nuclear-code-quality-review
 gitmoot agent allow <name> --repo owner/repo
 gitmoot agent repos <name>
@@ -59,6 +60,10 @@ gitmoot plugin doctor
 The plugins are guidance and discovery surfaces. They do not replace
 `gitmoot daemon start`, agent registration, GitHub CLI authentication, or the
 local SQLite workflow state.
+
+If a Codex or Claude chat wants to invoke a registered Gitmoot agent directly,
+it should run `gitmoot agent ask <agent> --repo owner/repo "..."`. That uses the
+same local agent registry and runtime adapter path as PR-comment ask jobs.
 
 ## End-To-End Demo Path
 
@@ -228,6 +233,14 @@ local SQLite workflow state.
    Implement jobs require the agent to hold the branch lock. Review and ask jobs
    are routed through the runtime adapter and must return the `gitmoot_result`
    JSON contract.
+
+   For a local chat ask that should not go through a PR comment, call the same
+   registered agent directly:
+
+   ```sh
+   gitmoot agent ask planner --repo owner/project "Write a task-by-task implementation plan and goal file prompt."
+   gitmoot job show <job-id>
+   ```
 
    Stale branch locks can be inspected and released locally:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -91,6 +91,22 @@ The agent should read the bundled skill, verify `gitmoot version`, check
 `gh auth status` before PR workflows, and use read-only Gitmoot status commands
 before mutating daemon, agent, job, or lock state.
 
+When you want the current Codex chat to invoke a registered Gitmoot agent, route
+that request through the CLI:
+
+```text
+$gitmoot:gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+```
+
+Without the chat command bridge, ask Codex to run the same shell command:
+
+```sh
+gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+```
+
+This keeps local chat asks on the same Gitmoot agent registry, repo access,
+runtime adapter, cached preset, and job history path as PR-comment ask jobs.
+
 ## Use From Claude Code
 
 After installing the Claude plugin, ask Claude Code to use the Gitmoot skill for
@@ -103,6 +119,15 @@ Use the Gitmoot skill. Check gitmoot status for this repo.
 Claude should use the bundled Gitmoot skill content as guidance, then call the
 local `gitmoot` CLI only when the user asks for setup, status, agent
 coordination, or PR-comment workflow help.
+
+For a registered-agent ask from Claude Code, use the same CLI command:
+
+```sh
+gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+```
+
+The plugin is discovery and guidance. The `gitmoot` CLI is still the execution
+path.
 
 ## Troubleshooting
 

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -30,10 +30,16 @@ agents, custom prompt agents, job status, or branch lock inspection.
 
 Use `gitmoot status --repo owner/repo` for repo status, `gitmoot daemon status`
 for daemon state, `gitmoot agent list` for registered agents, and
+`gitmoot agent ask <agent> --repo owner/repo "..."` to invoke a registered
+Gitmoot agent from the current local chat. Use
 `gitmoot job list --repo owner/repo` for queued or recent jobs. Use
 `gitmoot plugin doctor` when checking whether Codex or Claude Code can discover
 Gitmoot through an installed runtime plugin. Use `gitmoot goal template` when
 writing a standard task-by-task goal file.
+
+The plugin is only the runtime discovery surface for this skill. Local agent
+invocation still goes through the `gitmoot` CLI and the same registered agent,
+repo access, runtime adapter, and job history model used by PR-comment jobs.
 
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -92,6 +92,18 @@ gitmoot agent repos reviewer
 gitmoot agent doctor reviewer
 ```
 
+Ask a registered agent from the current local chat:
+
+```sh
+gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --json "Return the plan status."
+```
+
+This uses the same agent registry, repo access grants, cached preset snapshot,
+runtime adapter, and local job history as PR-comment ask jobs. The runtime
+plugin helps Codex or Claude Code discover Gitmoot guidance, but it does not
+replace `gitmoot agent ask`.
+
 ## Presets
 
 Install or refresh the built-in thermo review preset:

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -90,11 +90,17 @@ Ask from a PR comment:
 /gitmoot planner ask Write a task-by-task implementation plan for this feature, then create the goal file prompt.
 ```
 
-Ask directly from a Codex plugin session:
+Ask directly from a local Codex or Claude Code chat by having the runtime call
+the Gitmoot CLI:
 
-```text
-$gitmoot:gitmoot Use the planner workflow to create a plan and goal file for this feature: ...
+```sh
+gitmoot agent ask planner --repo owner/repo "Write a task-by-task implementation plan for this feature, then create the goal file prompt."
 ```
+
+If the Codex plugin exposes a Gitmoot command bridge in chat, the equivalent
+form is `$gitmoot:gitmoot agent ask planner --repo owner/repo "..."`. The
+important part is that the request goes through `gitmoot agent ask`, not a
+separate skill-only planning path.
 
 If the planner writes a goal file and the user wants Gitmoot to track it, import
 it explicitly:


### PR DESCRIPTION
WHAT:
- Updated README, root skill, canonical skill, plugin docs, local workflow docs, and skill references to route local plugin/chat planner use through `gitmoot agent ask`.

WHY:
- The previous wording could imply a separate skill-only planner path. Gitmoot should expose one clear model: plugins provide runtime guidance, while registered agents are invoked through the Gitmoot CLI or PR comments.

CHANGES:
- Documented `gitmoot agent ask <agent> ...` in the command surface and skill references.
- Clarified that plugins are discovery/guidance surfaces, not the execution path.
- Added Codex and Claude examples for asking a registered planner agent from local chat.
- Updated workflow docs to distinguish local chat ask from PR-comment ask while keeping both on the same agent registry/runtime/job path.

RESULTS:
- `git diff --check`
- `/root/temp/ts/tool/go test ./internal/skill ./internal/pluginpack`
- `/root/temp/ts/tool/go test ./...`
- `codex exec review --uncommitted` final raw output:

```text
The changes are documentation-only and align with the existing `gitmoot agent ask` CLI behavior. I did not identify any discrete correctness issues in the modified docs.
The changes are documentation-only and align with the existing `gitmoot agent ask` CLI behavior. I did not identify any discrete correctness issues in the modified docs.
```

RISK:
- No skipped checks. Documentation-only change.
