### PR TITLE
test: cover local agent ask dispatch

### DIFF
--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -255,16 +255,28 @@ it on a real PR.
    /tmp/gitmoot-current daemon status --home "$GITMOOT_SMOKE_HOME"
    ```
 
-4. Open a disposable PR, then comment:
+4. Ask the planner directly through the local agent path.
+
+   ```sh
+   /tmp/gitmoot-current agent ask planner-smoke \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --repo owner/project \
+     "Write a task-by-task implementation plan for this feature, then create the goal file prompt."
+   /tmp/gitmoot-current job list --home "$GITMOOT_SMOKE_HOME" --repo owner/project
+   /tmp/gitmoot-current job show <local-ask-job-id> --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+5. Open a disposable PR, then comment:
 
    ```text
    /gitmoot planner-smoke ask Write a task-by-task implementation plan for this feature, then create the goal file prompt.
    ```
 
-5. Verify the queued job and PR result.
+6. Verify the queued PR job and PR result.
 
    ```sh
    /tmp/gitmoot-current job list --home "$GITMOOT_SMOKE_HOME" --repo owner/project
+   /tmp/gitmoot-current job show <pr-ask-job-id> --home "$GITMOOT_SMOKE_HOME"
    /tmp/gitmoot-current events --home "$GITMOOT_SMOKE_HOME" --repo owner/project
    gh pr view <number> --repo owner/project --comments
    ```
@@ -275,11 +287,15 @@ Expected signals:
 - `preset show` displays `default role: planner`, `default capabilities: ask`,
   and `mutation: true`.
 - `agent doctor planner-smoke` succeeds.
+- `agent ask planner-smoke` prints `state: succeeded`, `agent: planner-smoke`,
+  `action: ask`, and a planner summary.
+- `job show <local-ask-job-id>` includes `"sender": "local"`, the cached
+  `gitmoot-plan-and-goal` preset metadata, and the planner result.
 - The PR result comment includes `Preset: gitmoot-plan-and-goal`.
 - The planner returns a structured plan and, when requested, a
   `GOAL-<short-slug>.md` path plus `/goal GOAL-<short-slug>.md`.
 
-6. Stop the isolated daemon.
+7. Stop the isolated daemon.
 
    ```sh
    /tmp/gitmoot-current daemon stop --home "$GITMOOT_SMOKE_HOME"

--- a/internal/pluginpack/pluginpack_test.go
+++ b/internal/pluginpack/pluginpack_test.go
@@ -107,6 +107,9 @@ func TestBuildUsesEmbeddedSkillByDefault(t *testing.T) {
 		t.Fatalf("Build() error = %v", err)
 	}
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "SKILL.md"), "Gitmoot Agent Skill")
+	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "SKILL.md"), "gitmoot agent ask <agent>")
+	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "CLI.md"), "gitmoot agent ask planner --repo owner/repo")
+	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "WORKFLOWS.md"), "separate skill-only planning path")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "GOAL_TEMPLATE.md"), "codex exec review is clean; ready for manual /review.")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "RESULT_CONTRACT.md"), "gitmoot_result")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "presets", "gitmoot-plan-and-goal.md"), "Gitmoot Plan And Goal Writer")

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -75,6 +75,48 @@ func TestCanonicalSkillDocumentsResultAndRereadGuidance(t *testing.T) {
 	}
 }
 
+func TestCanonicalSkillDocumentsLocalAgentAsk(t *testing.T) {
+	text := readRepoFile(t, "skills", "gitmoot", "SKILL.md")
+	cli := readRepoFile(t, "skills", "gitmoot", "references", "CLI.md")
+	workflows := readRepoFile(t, "skills", "gitmoot", "references", "WORKFLOWS.md")
+	for _, check := range []struct {
+		name string
+		text string
+		want []string
+	}{
+		{
+			name: "skill",
+			text: text,
+			want: []string{
+				"gitmoot agent ask <agent>",
+				"The plugin is only the runtime discovery surface",
+			},
+		},
+		{
+			name: "cli",
+			text: cli,
+			want: []string{
+				"gitmoot agent ask planner --repo owner/repo",
+				"replace `gitmoot agent ask`",
+			},
+		},
+		{
+			name: "workflows",
+			text: workflows,
+			want: []string{
+				"gitmoot agent ask planner --repo owner/repo",
+				"separate skill-only planning path",
+			},
+		},
+	} {
+		for _, want := range check.want {
+			if !strings.Contains(check.text, want) {
+				t.Fatalf("%s missing %q", check.name, want)
+			}
+		}
+	}
+}
+
 func TestRootSkillCompatibilityEntrypoint(t *testing.T) {
 	text := readRepoFile(t, "SKILL.md")
 	frontmatter := parseFrontmatter(t, text)
@@ -104,6 +146,7 @@ func TestRootSkillCompatibilityEntrypoint(t *testing.T) {
 		"gitmoot.io/SKILL.md",
 		"gitmoot_result",
 		"branch locks",
+		"gitmoot agent ask <agent>",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("root SKILL.md missing compatibility content %q", want)


### PR DESCRIPTION
WHAT:
- Added final package/skill test coverage and smoke-test documentation for the local `gitmoot agent ask` path.

WHY:
- The plugin-guided planner workflow needs durable coverage so generated plugin packages keep the local ask guidance, and beta smoke docs show how to validate planner setup through both local ask and PR-comment ask.

CHANGES:
- Added canonical skill assertions for local `agent ask` guidance across `SKILL.md`, `CLI.md`, and `WORKFLOWS.md`.
- Added plugin packaging assertions that generated packages include local ask guidance in embedded skill docs.
- Extended the planner preset smoke test with a direct `gitmoot agent ask` step, job listing, and job inspection before the PR-comment ask path.

RESULTS:
- `git diff --check`
- `/root/temp/ts/tool/go test ./internal/skill ./internal/pluginpack`
- `/root/temp/ts/tool/go test ./...`
- `codex exec review --uncommitted` final raw output:

```text
The changes are limited to smoke-test documentation and assertions that the canonical/embedded skill docs mention the local agent ask path. I did not find any discrete correctness issue in the modified lines.
The changes are limited to smoke-test documentation and assertions that the canonical/embedded skill docs mention the local agent ask path. I did not find any discrete correctness issue in the modified lines.
```

RISK:
- No skipped local checks. The smoke addition is documented rather than executed against a live Codex session in this PR.
