### PR TITLE
fix: serialize runtime session delivery

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -68,6 +68,23 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
+	releaseLock, acquired, lockKey, err := acquireRuntimeSessionLock(ctx, store, job.ID, runtimeAgent(agent), time.Now().UTC(), daemonRunningJobStaleAfter)
+	if err != nil {
+		return localAgentJobOutput{}, err
+	}
+	if !acquired {
+		message := fmt.Sprintf("runtime session %s is busy; synchronous ask was not run", lockKey)
+		_, _ = store.TransitionJobStateWithEvent(ctx, job.ID, string(workflow.JobQueued), string(workflow.JobCancelled), db.JobEvent{
+			JobID:   job.ID,
+			Kind:    string(workflow.JobCancelled),
+			Message: message,
+		})
+		_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: message})
+		return localAgentJobOutput{}, fmt.Errorf("runtime session %s is busy; queued job %s was not run", lockKey, job.ID)
+	}
+	defer func() {
+		_ = releaseLock(context.Background())
+	}()
 	if _, err := (workflow.Mailbox{Store: store}).Run(ctx, job.ID, runtimeAgent(agent), adapter); err != nil {
 		return localAgentJobOutput{}, err
 	}

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -11,10 +11,12 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
 func TestRunAgentSubscribeListRemove(t *testing.T) {
@@ -593,6 +595,74 @@ func TestRunAgentAskValidatesInputAndAccess(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), `agent "outsider" is not allowed on "owner/repo"`) {
 		t.Fatalf("disallowed repo stderr = %q", stderr.String())
+	}
+}
+
+func TestRunAgentAskCancelsQueuedJobWhenRuntimeSessionBusy(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "subscribe", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440041",
+		"--role", "planner",
+		"--repo", "owner/repo",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("subscribe planner exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	if acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey: "runtime:codex:550e8400-e29b-41d4-a716-446655440041",
+		OwnerJobID:  "other-job",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	store.Close()
+
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"agent", "ask", "planner", "Write a plan", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("busy ask exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "runtime session runtime:codex:550e8400-e29b-41d4-a716-446655440041 is busy") {
+		t.Fatalf("busy ask stderr = %q", stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runtime calls = %+v, want none", runner.calls)
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("jobs = %+v, want one cancelled job", jobs)
+	}
+	if jobs[0].State != string(workflow.JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", jobs[0].State)
+	}
+	events, err := store.ListJobEvents(context.Background(), jobs[0].ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !hasCLIJobEvent(events, string(workflow.JobCancelled)) || !hasCLIJobEvent(events, "runtime_lock_wait") {
+		t.Fatalf("events = %+v, want cancellation and runtime_lock_wait", events)
 	}
 }
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -789,6 +789,9 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 		poller.CheckoutLocks = checkoutLocks
 		var workerErr <-chan error
 		if !dryRun {
+			if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, time.Now().UTC()); err != nil {
+				return err
+			}
 			if err := recoverCancelledRunningJobsForEnabledRepos(ctx, store, stdout); err != nil {
 				return err
 			}
@@ -821,6 +824,9 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 }
 
 func runSingleRepoSupervisor(ctx context.Context, d daemon.Daemon, store *db.Store, workers int, stdout io.Writer) error {
+	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, time.Now().UTC()); err != nil {
+		return err
+	}
 	if err := recoverRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName()); err != nil {
 		return err
 	}
@@ -1106,6 +1112,8 @@ const daemonRunningJobStaleAfter = 30 * time.Minute
 const daemonJobCancelPollInterval = 250 * time.Millisecond
 const daemonWorkerLoopInterval = 1 * time.Second
 
+var errRuntimeSessionBusy = errors.New("runtime session is busy")
+
 func defaultJobWorker(store *db.Store, stdout io.Writer) jobWorker {
 	worker := jobWorker{Store: store, Stdout: stdout}
 	worker.AdapterFactory = worker.defaultAdapter
@@ -1116,6 +1124,17 @@ func defaultJobWorker(store *db.Store, stdout io.Writer) jobWorker {
 
 func recoverRunningJobs(ctx context.Context, store *db.Store, stdout io.Writer) error {
 	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, time.Now().UTC().Add(-daemonRunningJobStaleAfter), "")
+}
+
+func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time) error {
+	deleted, err := store.DeleteExpiredResourceLocks(ctx, now)
+	if err != nil {
+		return err
+	}
+	if deleted > 0 {
+		writeLine(stdout, "recovered %d expired runtime session locks", deleted)
+	}
+	return nil
 }
 
 func recoverRunningJobsBefore(ctx context.Context, store *db.Store, stdout io.Writer, before time.Time) error {
@@ -1220,6 +1239,9 @@ func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker,
 	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now.Add(-daemonRunningJobStaleAfter), repoFilter); err != nil {
 		return err
 	}
+	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, now); err != nil {
+		return err
+	}
 	if err := retryPendingJobAdvancements(ctx, worker, repoFilter); err != nil {
 		return err
 	}
@@ -1322,14 +1344,19 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 		queued := make([]db.Job, 0, limit)
 		remaining := make([]db.Job, 0, len(pending))
 		selectedCheckouts := map[string]bool{}
+		selectedRuntimeResources := map[string]bool{}
 		for _, job := range pending {
 			checkoutKey := queuedJobCheckoutKey(job)
-			if len(queued) == limit || selectedCheckouts[checkoutKey] {
+			runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
+			if len(queued) == limit || selectedCheckouts[checkoutKey] || (runtimeKey != "" && selectedRuntimeResources[runtimeKey]) {
 				remaining = append(remaining, job)
 				continue
 			}
 			queued = append(queued, job)
 			selectedCheckouts[checkoutKey] = true
+			if runtimeKey != "" {
+				selectedRuntimeResources[runtimeKey] = true
+			}
 		}
 		if len(queued) == 0 {
 			return nil
@@ -1349,7 +1376,7 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 		wg.Wait()
 		close(errs)
 		for err := range errs {
-			if err != nil {
+			if err != nil && !errors.Is(err, errRuntimeSessionBusy) {
 				return err
 			}
 		}
@@ -1372,6 +1399,21 @@ func queuedJobCheckoutKey(job db.Job) string {
 		return "job:" + job.ID
 	}
 	return "repo:" + payload.Repo
+}
+
+func queuedJobRuntimeResourceKey(ctx context.Context, store *db.Store, job db.Job) string {
+	if store == nil {
+		return ""
+	}
+	agent, err := store.GetAgent(ctx, job.Agent)
+	if err != nil {
+		return ""
+	}
+	key, ok := runtimeSessionResourceKey(runtimeAgent(agent))
+	if !ok {
+		return ""
+	}
+	return key
 }
 
 func (w jobWorker) run(ctx context.Context, job db.Job) error {
@@ -1404,6 +1446,27 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 		return nil
 	}
+	releaseLock, acquired, lockKey, err := acquireRuntimeSessionLock(ctx, w.Store, job.ID, agent, time.Now().UTC(), daemonRunningJobStaleAfter)
+	if err != nil {
+		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
+		return nil
+	}
+	if !acquired {
+		message := fmt.Sprintf("runtime session %s is busy", lockKey)
+		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: message}); eventErr != nil {
+			return eventErr
+		}
+		writeLine(w.Stdout, "job %s waiting: %s", job.ID, message)
+		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, message)
+	}
+	defer func() {
+		if err := releaseLock(context.Background()); err != nil {
+			writeLine(w.Stdout, "job %s runtime lock release failed: %v", job.ID, err)
+		}
+	}()
 	writeLine(w.Stdout, "running job %s for %s in %s", job.ID, agent.Name, payload.Repo)
 	engine := w.WorkflowFactory(checkout)
 	runCtx, stopRun := w.runningJobContext(ctx, job.ID)

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1069,7 +1070,7 @@ func TestRunQueuedJobsSerializesSameRepoCheckout(t *testing.T) {
 				maxActive = active
 			}
 			mu.Unlock()
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 			mu.Lock()
 			active--
 			mu.Unlock()
@@ -1092,6 +1093,150 @@ func TestRunQueuedJobsSerializesSameRepoCheckout(t *testing.T) {
 	}
 	if adapter.calls != 2 {
 		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+}
+
+func TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo-a")
+	if err := store.AllowAgentRepo(ctx, "audit", "owner/repo-b"); err != nil {
+		t.Fatalf("AllowAgentRepo returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2})
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		onDeliver: func() {
+			mu.Lock()
+			active++
+			if active > maxActive {
+				maxActive = active
+			}
+			mu.Unlock()
+			time.Sleep(10 * time.Millisecond)
+			mu.Lock()
+			active--
+			mu.Unlock()
+		},
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 2); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if maxActive != 1 {
+		t.Fatalf("max concurrent same-runtime deliveries = %d, want 1", maxActive)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+}
+
+func TestRunQueuedJobsAllowsDifferentRuntimeSessionsAcrossRepos(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit-a", runtime.CodexRuntime, "session-a", []string{"ask"}, "owner/repo-a")
+	seedDaemonWorkerAgent(t, store, "audit-b", runtime.CodexRuntime, "session-b", []string{"ask"}, "owner/repo-b")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit-a", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit-b", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2})
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		onDeliver: func() {
+			mu.Lock()
+			active++
+			if active > maxActive {
+				maxActive = active
+			}
+			mu.Unlock()
+			time.Sleep(100 * time.Millisecond)
+			mu.Lock()
+			active--
+			mu.Unlock()
+		},
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 2); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if maxActive != 2 {
+		t.Fatalf("max concurrent different-runtime deliveries = %d, want 2", maxActive)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+}
+
+func TestRunQueuedJobsLeavesBusyRuntimeSessionQueued(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: "runtime:codex:session-1",
+		OwnerJobID:  "other-job",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued", job.State)
+	}
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want 0", adapter.calls)
+	}
+	events, err := store.ListJobEvents(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "runtime_lock_wait") {
+		t.Fatalf("events = %+v, want runtime_lock_wait", events)
 	}
 }
 
@@ -1215,6 +1360,40 @@ func TestRunQueuedJobsCancelsActiveDeliveryContext(t *testing.T) {
 	}
 	if !daemonWorkerHasEvent(events, "cancel_settled") {
 		t.Fatalf("events = %+v, want cancel_settled", events)
+	}
+}
+
+func TestRunQueuedJobsReleasesRuntimeSessionLockAfterCancellation(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-cancel", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-active-cancel", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	adapter := &cliWorkerFakeAdapter{
+		waitForContextCancel: true,
+		onDeliver: func() {
+			if _, err := workflow.CancelJob(ctx, store, "job-active-cancel"); err != nil {
+				t.Fatalf("CancelJob returned error: %v", err)
+			}
+		},
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if !adapter.observedContextCancel() {
+		t.Fatal("adapter did not observe context cancellation")
+	}
+	if _, err := store.GetResourceLock(ctx, "runtime:codex:session-cancel"); err == nil || err != sql.ErrNoRows {
+		t.Fatalf("runtime lock after cancellation error = %v, want no rows", err)
 	}
 }
 

--- a/internal/cli/runtime_lock.go
+++ b/internal/cli/runtime_lock.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+func acquireRuntimeSessionLock(ctx context.Context, store *db.Store, jobID string, agent runtime.Agent, now time.Time, ttl time.Duration) (func(context.Context) error, bool, string, error) {
+	key, ok := runtimeSessionResourceKey(agent)
+	if !ok {
+		return func(context.Context) error { return nil }, true, "", nil
+	}
+	if ttl <= 0 {
+		return nil, false, key, fmt.Errorf("runtime lock ttl must be positive")
+	}
+	ownerToken, err := newRuntimeLockOwnerToken()
+	if err != nil {
+		return nil, false, key, err
+	}
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  jobID,
+		OwnerToken:  ownerToken,
+		ExpiresAt:   now.UTC().Add(ttl).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil || !acquired {
+		return func(context.Context) error { return nil }, acquired, key, err
+	}
+	return func(releaseCtx context.Context) error {
+		_, err := store.ReleaseResourceLock(releaseCtx, key, jobID, ownerToken)
+		return err
+	}, true, key, nil
+}
+
+func runtimeSessionResourceKey(agent runtime.Agent) (string, bool) {
+	runtimeName := strings.TrimSpace(agent.Runtime)
+	runtimeRef := strings.TrimSpace(agent.RuntimeRef)
+	switch runtimeName {
+	case runtime.CodexRuntime, runtime.ClaudeRuntime:
+	default:
+		return "", false
+	}
+	if runtimeRef == "" {
+		return "", false
+	}
+	return "runtime:" + runtimeName + ":" + runtimeRef, true
+}
+
+func newRuntimeLockOwnerToken() (string, error) {
+	var bytes [16]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return "", fmt.Errorf("generate runtime lock owner token: %w", err)
+	}
+	return hex.EncodeToString(bytes[:]), nil
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -120,6 +120,15 @@ type BranchLockEvent struct {
 	Message      string
 }
 
+type ResourceLock struct {
+	ResourceKey string
+	OwnerJobID  string
+	OwnerToken  string
+	AcquiredAt  string
+	UpdatedAt   string
+	ExpiresAt   string
+}
+
 type MergeGate struct {
 	RepoFullName string
 	PullRequest  int64
@@ -967,6 +976,100 @@ func (s *Store) ListJobEvents(ctx context.Context, jobID string) ([]JobEvent, er
 	return events, rows.Err()
 }
 
+func (s *Store) AcquireResourceLock(ctx context.Context, lock ResourceLock, now time.Time) (bool, error) {
+	resourceKey := strings.TrimSpace(lock.ResourceKey)
+	ownerJobID := strings.TrimSpace(lock.OwnerJobID)
+	ownerToken := strings.TrimSpace(lock.OwnerToken)
+	if resourceKey == "" {
+		return false, errors.New("resource lock key is required")
+	}
+	if ownerJobID == "" {
+		return false, errors.New("resource lock owner job id is required")
+	}
+	if ownerToken == "" {
+		return false, errors.New("resource lock owner token is required")
+	}
+	expiresAt := strings.TrimSpace(lock.ExpiresAt)
+	if expiresAt == "" {
+		return false, errors.New("resource lock expiry is required")
+	}
+	parsedExpiresAt, err := time.Parse(time.RFC3339Nano, expiresAt)
+	if err != nil {
+		return false, fmt.Errorf("resource lock expiry must be RFC3339: %w", err)
+	}
+	expiresAt = formatResourceLockTime(parsedExpiresAt)
+	nowText := formatResourceLockTime(now)
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM resource_locks
+		WHERE resource_key = ?
+			AND expires_at <= ?
+			AND NOT EXISTS (
+				SELECT 1 FROM jobs
+				WHERE jobs.id = resource_locks.owner_job_id
+					AND jobs.state = 'running'
+			)`, resourceKey, nowText); err != nil {
+		return false, err
+	}
+	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO resource_locks(resource_key, owner_job_id, owner_token, acquired_at, updated_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?)`, resourceKey, ownerJobID, ownerToken, nowText, nowText, expiresAt)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 1 {
+		return true, tx.Commit()
+	}
+	return false, tx.Commit()
+}
+
+func (s *Store) GetResourceLock(ctx context.Context, resourceKey string) (ResourceLock, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT resource_key, owner_job_id, owner_token, acquired_at, updated_at, expires_at FROM resource_locks WHERE resource_key = ?`, resourceKey)
+	var lock ResourceLock
+	if err := row.Scan(&lock.ResourceKey, &lock.OwnerJobID, &lock.OwnerToken, &lock.AcquiredAt, &lock.UpdatedAt, &lock.ExpiresAt); err != nil {
+		return ResourceLock{}, err
+	}
+	return lock, nil
+}
+
+func (s *Store) ReleaseResourceLock(ctx context.Context, resourceKey string, ownerJobID string, ownerToken string) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks WHERE resource_key = ? AND owner_job_id = ? AND owner_token = ?`, resourceKey, ownerJobID, ownerToken)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
+}
+
+func (s *Store) DeleteExpiredResourceLocks(ctx context.Context, now time.Time) (int64, error) {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks
+		WHERE expires_at <= ?
+			AND NOT EXISTS (
+				SELECT 1 FROM jobs
+				WHERE jobs.id = resource_locks.owner_job_id
+					AND jobs.state = 'running'
+			)`, formatResourceLockTime(now))
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+func formatResourceLockTime(value time.Time) string {
+	return value.UTC().Format("2006-01-02T15:04:05.000000000Z")
+}
+
 func (s *Store) AcquireLock(ctx context.Context, lock BranchLock) (bool, error) {
 	created, err := s.CreateLock(ctx, lock)
 	if err != nil {
@@ -1392,5 +1495,17 @@ CREATE TABLE presets (
 );
 
 ALTER TABLE agents ADD COLUMN preset_id TEXT NOT NULL DEFAULT '';
+	`,
+	`
+CREATE TABLE resource_locks (
+	resource_key TEXT PRIMARY KEY,
+	owner_job_id TEXT NOT NULL,
+	acquired_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	expires_at TEXT NOT NULL
+);
+	`,
+	`
+ALTER TABLE resource_locks ADD COLUMN owner_token TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestOpenMigratesSchema(t *testing.T) {
@@ -27,6 +28,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"job_events",
 		"branch_locks",
 		"lock_events",
+		"resource_locks",
 		"merge_gates",
 		"agent_repos",
 		"presets",
@@ -42,6 +44,184 @@ func TestOpenMigratesSchema(t *testing.T) {
 
 	if err := store.Migrate(ctx); err != nil {
 		t.Fatalf("second Migrate returned error: %v", err)
+	}
+}
+
+func TestResourceLockMethods(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	lock := ResourceLock{
+		ResourceKey: "runtime:codex:session-a",
+		OwnerJobID:  "job-a",
+		OwnerToken:  "token-a",
+		ExpiresAt:   now.Add(time.Minute).Format(time.RFC3339Nano),
+	}
+	acquired, err := store.AcquireResourceLock(ctx, lock, now)
+	if err != nil {
+		t.Fatalf("AcquireResourceLock returned error: %v", err)
+	}
+	if !acquired {
+		t.Fatal("first AcquireResourceLock did not acquire")
+	}
+	acquired, err = store.AcquireResourceLock(ctx, ResourceLock{
+		ResourceKey: lock.ResourceKey,
+		OwnerJobID:  "job-b",
+		OwnerToken:  "token-b",
+		ExpiresAt:   now.Add(time.Minute).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		t.Fatalf("conflicting AcquireResourceLock returned error: %v", err)
+	}
+	if acquired {
+		t.Fatal("conflicting AcquireResourceLock acquired busy resource")
+	}
+	acquired, err = store.AcquireResourceLock(ctx, ResourceLock{
+		ResourceKey: lock.ResourceKey,
+		OwnerJobID:  "job-a",
+		OwnerToken:  "token-c",
+		ExpiresAt:   now.Add(time.Minute).Format(time.RFC3339Nano),
+	}, now.Add(10*time.Second))
+	if err != nil {
+		t.Fatalf("same-job duplicate AcquireResourceLock returned error: %v", err)
+	}
+	if acquired {
+		t.Fatal("same-job duplicate AcquireResourceLock acquired busy resource")
+	}
+	stored, err := store.GetResourceLock(ctx, lock.ResourceKey)
+	if err != nil {
+		t.Fatalf("GetResourceLock returned error: %v", err)
+	}
+	if stored.OwnerJobID != "job-a" || stored.OwnerToken != "token-a" || stored.AcquiredAt == "" || stored.UpdatedAt == "" || stored.ExpiresAt == "" {
+		t.Fatalf("resource lock = %+v", stored)
+	}
+	if stored.ExpiresAt != formatResourceLockTime(now.Add(time.Minute)) {
+		t.Fatalf("resource lock expiry = %q, want fixed-width timestamp", stored.ExpiresAt)
+	}
+	released, err := store.ReleaseResourceLock(ctx, lock.ResourceKey, "job-b", "token-a")
+	if err != nil {
+		t.Fatalf("wrong-owner ReleaseResourceLock returned error: %v", err)
+	}
+	if released {
+		t.Fatal("wrong owner released resource lock")
+	}
+	released, err = store.ReleaseResourceLock(ctx, lock.ResourceKey, "job-a", "token-c")
+	if err != nil {
+		t.Fatalf("wrong-token ReleaseResourceLock returned error: %v", err)
+	}
+	if released {
+		t.Fatal("wrong token released resource lock")
+	}
+	released, err = store.ReleaseResourceLock(ctx, lock.ResourceKey, "job-a", "token-a")
+	if err != nil {
+		t.Fatalf("ReleaseResourceLock returned error: %v", err)
+	}
+	if !released {
+		t.Fatal("ReleaseResourceLock did not release")
+	}
+	if _, err := store.GetResourceLock(ctx, lock.ResourceKey); err == nil || err != sql.ErrNoRows {
+		t.Fatalf("GetResourceLock after release error = %v, want no rows", err)
+	}
+}
+
+func TestResourceLockRecoversExpiredLock(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	if acquired, err := store.AcquireResourceLock(ctx, ResourceLock{
+		ResourceKey: "runtime:codex:session-a",
+		OwnerJobID:  "job-a",
+		OwnerToken:  "token-a",
+		ExpiresAt:   now.Add(time.Minute).Format(time.RFC3339Nano),
+	}, now); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	acquired, err := store.AcquireResourceLock(ctx, ResourceLock{
+		ResourceKey: "runtime:codex:session-a",
+		OwnerJobID:  "job-b",
+		OwnerToken:  "token-b",
+		ExpiresAt:   now.Add(3 * time.Minute).Format(time.RFC3339Nano),
+	}, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("expired AcquireResourceLock returned error: %v", err)
+	}
+	if !acquired {
+		t.Fatal("expired AcquireResourceLock did not acquire")
+	}
+	stored, err := store.GetResourceLock(ctx, "runtime:codex:session-a")
+	if err != nil {
+		t.Fatalf("GetResourceLock returned error: %v", err)
+	}
+	if stored.OwnerJobID != "job-b" {
+		t.Fatalf("resource lock owner = %q, want job-b", stored.OwnerJobID)
+	}
+	deleted, err := store.DeleteExpiredResourceLocks(ctx, now.Add(4*time.Minute))
+	if err != nil {
+		t.Fatalf("DeleteExpiredResourceLocks returned error: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expired locks deleted = %d, want 1", deleted)
+	}
+}
+
+func TestResourceLockDoesNotRecoverExpiredRunningOwner(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	if err := store.CreateJob(ctx, Job{ID: "job-a", Agent: "audit", Type: "ask", State: "running", Payload: `{"repo":"owner/repo"}`}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	if acquired, err := store.AcquireResourceLock(ctx, ResourceLock{
+		ResourceKey: "runtime:codex:session-a",
+		OwnerJobID:  "job-a",
+		OwnerToken:  "token-a",
+		ExpiresAt:   now.Add(time.Minute).Format(time.RFC3339Nano),
+	}, now); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	acquired, err := store.AcquireResourceLock(ctx, ResourceLock{
+		ResourceKey: "runtime:codex:session-a",
+		OwnerJobID:  "job-b",
+		OwnerToken:  "token-b",
+		ExpiresAt:   now.Add(3 * time.Minute).Format(time.RFC3339Nano),
+	}, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("expired running-owner AcquireResourceLock returned error: %v", err)
+	}
+	if acquired {
+		t.Fatal("expired running-owner AcquireResourceLock acquired active resource")
+	}
+	deleted, err := store.DeleteExpiredResourceLocks(ctx, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("DeleteExpiredResourceLocks returned error: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("expired running-owner locks deleted = %d, want 0", deleted)
+	}
+	if err := store.UpdateJobState(ctx, "job-a", "queued"); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	deleted, err = store.DeleteExpiredResourceLocks(ctx, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("DeleteExpiredResourceLocks after requeue returned error: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expired non-running-owner locks deleted = %d, want 1", deleted)
 	}
 }
 

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, PR comments, daemon jobs, branch locks, presets, custom prompt agents, and Codex or Claude Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, jobs, branch locks, presets, custom prompt agents, and Codex or Claude Code runtime workflows.
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
 metadata:


### PR DESCRIPTION
WHAT:
- Adds a database-backed runtime session lock so Codex/Claude runtime sessions only receive one active job at a time.
- Applies the same lock path to daemon workers, direct `gitmoot job run`, and synchronous local `gitmoot agent ask`.

WHY:
- The agent execution UX plan requires safe on-demand agent execution without concurrent deliveries racing through the same runtime session.

CHANGES:
- Added `resource_locks` store helpers and migrations with per-run owner tokens and fixed-width timestamp expiry comparisons.
- Added shared runtime lock helper for Codex/Claude runtime refs.
- Prevented daemon worker batches from selecting multiple jobs for the same runtime session.
- Kept busy daemon jobs queued with a `runtime_lock_wait` event; direct `job run` now exits non-zero on a busy runtime.
- Cancelled synchronous local ask jobs when the target runtime session is already busy.
- Added focused DB/CLI coverage for lock acquisition, expiry recovery, busy sessions, cancellation, and same/different runtime concurrency.
- Updated the Gitmoot skill description to satisfy the existing skill metadata trigger checks.

RESULTS:
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/db`
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/cli`
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./...`
- `git diff --check`
- `git diff --cached --check`

Final `codex exec review --uncommitted` raw output:
```
I did not find any discrete correctness issues in the changed code. Test execution was blocked by the sandboxed toolchain cache being read-only, but the diff itself appears internally consistent.
I did not find any discrete correctness issues in the changed code. Test execution was blocked by the sandboxed toolchain cache being read-only, but the diff itself appears internally consistent.
```

RISK:
- The default `go` wrapper tried to fetch Go 1.26 and failed in this environment, so tests were run with the already cached Go 1.26.2 toolchain path above.
- Review could not execute tests inside its sandbox for the same toolchain-cache reason, but local focused and full suites passed.