### PR TITLE
feat: add background agent asks

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -54,7 +54,7 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot agent start <name> --runtime codex|claude --repo owner/repo [--path .] [--preset <preset-id>] [--start-daemon]")
-	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> [--repo owner/repo...] --capability <capability>")
 	fmt.Fprintln(w, "    Codex sessions may use a UUID, thread name, or last. Claude sessions may use a UUID or last. Shell sessions are commands.")
 	fmt.Fprintln(w, "  gitmoot agent allow <name> --repo owner/repo")
@@ -69,6 +69,7 @@ type agentAskOptions struct {
 	home       string
 	repo       string
 	jsonOutput bool
+	background bool
 	agent      string
 	message    string
 }
@@ -89,11 +90,21 @@ func runAgentAsk(args []string, stdout, stderr io.Writer) int {
 			Agent:        options.agent,
 			Action:       "ask",
 			Instructions: options.message,
+			Background:   options.background,
 		})
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "agent ask: %v\n", err)
 		return 1
+	}
+	if options.background {
+		output.WatchCommand = jobWatchCommand(output.JobID, options.home)
+		running, err := daemonIsRunning(options.home)
+		if err != nil {
+			fmt.Fprintf(stderr, "agent ask: %v\n", err)
+			return 1
+		}
+		output.DaemonRunning = running
 	}
 	if options.jsonOutput {
 		if err := writeJSON(stdout, output); err != nil {
@@ -103,6 +114,11 @@ func runAgentAsk(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 	printLocalAgentJobOutput(stdout, output)
+	if options.background && !output.DaemonRunning {
+		writeLine(stdout, "queued: daemon is not running")
+		writeLine(stdout, "process: %s", daemonStartHint(options.home, output.Repo))
+		writeLine(stdout, "or: %s", jobRunCommand(output.JobID, options.home))
+	}
 	return 0
 }
 
@@ -119,6 +135,8 @@ func parseAgentAskOptions(args []string, stderr io.Writer) (agentAskOptions, boo
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
 		switch {
+		case arg == "--background":
+			options.background = true
 		case arg == "--json":
 			options.jsonOutput = true
 		case arg == "--repo" || arg == "--home":
@@ -167,7 +185,40 @@ func containsHelpFlag(args []string) bool {
 
 func printAgentAskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--home path] [--json]")
+}
+
+func daemonIsRunning(home string) (bool, error) {
+	paths, err := initializedPaths(home)
+	if err != nil {
+		return false, err
+	}
+	pid, _, err := currentDaemonPID(daemonProcessState(paths))
+	return pid > 0, err
+}
+
+func jobWatchCommand(jobID string, home string) string {
+	args := []string{"gitmoot", "job", "watch", jobID}
+	if strings.TrimSpace(home) != "" {
+		args = append(args, "--home", home)
+	}
+	return shellArgs(args)
+}
+
+func jobRunCommand(jobID string, home string) string {
+	args := []string{"gitmoot", "job", "run", jobID}
+	if strings.TrimSpace(home) != "" {
+		args = append(args, "--home", home)
+	}
+	return shellArgs(args)
+}
+
+func shellArgs(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellArg(arg))
+	}
+	return strings.Join(quoted, " ")
 }
 
 func runAgentStart(args []string, stdout, stderr io.Writer) int {
@@ -523,11 +574,7 @@ func daemonStartHint(home string, repo string) string {
 		args = append(args, "--home", home)
 	}
 	args = append(args, "--repo", repo)
-	quoted := make([]string, 0, len(args))
-	for _, arg := range args {
-		quoted = append(quoted, shellArg(arg))
-	}
-	return strings.Join(quoted, " ")
+	return shellArgs(args)
 }
 
 func shellArg(value string) string {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -22,6 +22,7 @@ type localAgentDispatchRequest struct {
 	Agent        string
 	Action       string
 	Instructions string
+	Background   bool
 }
 
 type localAgentJobOutput struct {
@@ -32,6 +33,8 @@ type localAgentJobOutput struct {
 	Action         string                `json:"action"`
 	Result         *workflow.AgentResult `json:"result,omitempty"`
 	RawOutputCount int                   `json:"raw_output_count"`
+	WatchCommand   string                `json:"watch_command,omitempty"`
+	DaemonRunning  bool                  `json:"daemon_running,omitempty"`
 }
 
 func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAgentDispatchRequest) (localAgentJobOutput, error) {
@@ -52,10 +55,6 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err := ensureLocalAgentAccess(ctx, store, agent, repo.FullName(), request.Action); err != nil {
 		return localAgentJobOutput{}, err
 	}
-	adapter, err := runtimeStartAdapter(newRuntimeFactory(), agent.Runtime, record.CheckoutPath)
-	if err != nil {
-		return localAgentJobOutput{}, err
-	}
 	job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
 		ID:           localAgentJobID(request.Action, agent.Name),
 		Agent:        agent.Name,
@@ -65,6 +64,20 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		Sender:       "local",
 		Instructions: request.Instructions,
 	})
+	if err != nil {
+		return localAgentJobOutput{}, err
+	}
+	if request.Background {
+		return localAgentJobOutput{
+			JobID:          job.ID,
+			State:          job.State,
+			Repo:           repo.FullName(),
+			Agent:          job.Agent,
+			Action:         job.Type,
+			RawOutputCount: 0,
+		}, nil
+	}
+	adapter, err := runtimeStartAdapter(newRuntimeFactory(), agent.Runtime, record.CheckoutPath)
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
@@ -178,6 +191,9 @@ func printLocalAgentJobOutput(stdout io.Writer, output localAgentJobOutput) {
 	writeLine(stdout, "repo: %s", output.Repo)
 	writeLine(stdout, "agent: %s", output.Agent)
 	writeLine(stdout, "action: %s", output.Action)
+	if output.WatchCommand != "" {
+		writeLine(stdout, "next: %s", output.WatchCommand)
+	}
 	if output.Result == nil {
 		return
 	}

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -524,6 +524,108 @@ func TestRunAgentAskDispatchesAndStoresResult(t *testing.T) {
 	}
 }
 
+func TestRunAgentAskBackgroundQueuesWithoutRuntimeDelivery(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "subscribe", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440022",
+		"--role", "planner",
+		"--repo", "owner/repo",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"agent", "ask", "planner", "Write a plan", "--home", home, "--repo", "owner/repo", "--background"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("background ask exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"job: local-ask-planner-",
+		"state: queued",
+		"repo: owner/repo",
+		"agent: planner",
+		"action: ask",
+		"next: gitmoot job watch local-ask-planner-",
+		"queued: daemon is not running",
+		"process: gitmoot daemon start",
+		"or: gitmoot job run local-ask-planner-",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("background ask output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runtime calls = %+v, want none", runner.calls)
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].State != string(workflow.JobQueued) {
+		t.Fatalf("jobs = %+v, want one queued job", jobs)
+	}
+	payload, err := daemonJobPayload(jobs[0])
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if payload.Instructions != "Write a plan" || payload.Result != nil || len(payload.RawOutputs) != 0 {
+		t.Fatalf("background payload = %+v", payload)
+	}
+}
+
+func TestRunAgentAskBackgroundJSON(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "subscribe", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440023",
+		"--role", "planner",
+		"--repo", "owner/repo",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"agent", "ask", "planner", "Write JSON", "--home", home, "--repo", "owner/repo", "--background", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("background ask --json exit code = %d, stderr=%s", code, stderr.String())
+	}
+	var decoded localAgentJobOutput
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("json output did not decode: %v\n%s", err, stdout.String())
+	}
+	if decoded.State != string(workflow.JobQueued) || decoded.Repo != "owner/repo" || decoded.Result != nil || decoded.WatchCommand == "" || decoded.DaemonRunning {
+		t.Fatalf("decoded background output = %+v", decoded)
+	}
+}
+
 func TestRunAgentAskValidatesInputAndAccess(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/workflow"
@@ -27,6 +28,8 @@ func runJob(args []string, stdout, stderr io.Writer) int {
 		return runJobShow(args[1:], stdout, stderr)
 	case "events":
 		return runJobEvents(args[1:], stdout, stderr)
+	case "watch":
+		return runJobWatch(args[1:], stdout, stderr)
 	case "run":
 		return runJobRun(args[1:], stdout, stderr)
 	case "retry":
@@ -45,6 +48,7 @@ func printJobUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot job list [--repo owner/repo] [--state state]")
 	fmt.Fprintln(w, "  gitmoot job show <id>")
 	fmt.Fprintln(w, "  gitmoot job events <id>")
+	fmt.Fprintln(w, "  gitmoot job watch <id> [--poll 1s] [--json]")
 	fmt.Fprintln(w, "  gitmoot job run <id>")
 	fmt.Fprintln(w, "  gitmoot job retry <id>")
 	fmt.Fprintln(w, "  gitmoot job cancel <id>")
@@ -122,6 +126,68 @@ func runJobEvents(args []string, stdout, stderr io.Writer) int {
 	for _, event := range events {
 		fmt.Fprintf(stdout, "%s\t%s\n", event.Kind, event.Message)
 	}
+	return 0
+}
+
+type jobWatchOutput struct {
+	Job    db.Job        `json:"job"`
+	Events []db.JobEvent `json:"events"`
+}
+
+func runJobWatch(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job watch", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	poll := fs.Duration("poll", time.Second, "poll interval")
+	jsonOutput := fs.Bool("json", false, "print final job and events as JSON")
+	jobID, ok := parseSingleJobID(fs, args, stderr, "job watch")
+	if !ok {
+		return parseSingleJobIDExitCode(args)
+	}
+	if *poll <= 0 {
+		fmt.Fprintln(stderr, "job watch poll interval must be positive")
+		return 2
+	}
+	var output jobWatchOutput
+	if err := withStore(*home, func(store *db.Store) error {
+		nextEvent := 0
+		for {
+			job, err := store.GetJob(context.Background(), jobID)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return fmt.Errorf("job %q not found", jobID)
+				}
+				return err
+			}
+			events, err := store.ListJobEvents(context.Background(), jobID)
+			if err != nil {
+				return err
+			}
+			if !*jsonOutput {
+				for nextEvent < len(events) {
+					event := events[nextEvent]
+					fmt.Fprintf(stdout, "%s\t%s\n", event.Kind, event.Message)
+					nextEvent++
+				}
+			}
+			if jobStateIsTerminal(job.State) {
+				output = jobWatchOutput{Job: job, Events: events}
+				return nil
+			}
+			time.Sleep(*poll)
+		}
+	}); err != nil {
+		fmt.Fprintf(stderr, "job watch: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "job watch: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	fmt.Fprintf(stdout, "state: %s\n", output.Job.State)
 	return 0
 }
 
@@ -224,6 +290,15 @@ func parseSingleJobIDExitCode(args []string) int {
 		return 0
 	}
 	return 2
+}
+
+func jobStateIsTerminal(state string) bool {
+	switch state {
+	case string(workflow.JobSucceeded), string(workflow.JobFailed), string(workflow.JobBlocked), string(workflow.JobCancelled):
+		return true
+	default:
+		return false
+	}
 }
 
 func filterJobs(jobs []db.Job, repoFilter string, stateFilter string) []db.Job {

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -83,6 +83,59 @@ func TestRunJobListShowEventsRetryCancel(t *testing.T) {
 	}
 }
 
+func TestRunJobWatchPrintsEventsUntilTerminal(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedCLIJob(t, store, db.Job{
+		ID:      "job-watch",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobSucceeded),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main"}),
+	}, "succeeded")
+	if err := store.AddJobEvent(context.Background(), db.JobEvent{JobID: "job-watch", Kind: "advance_completed", Message: "done"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "watch", "job-watch", "--home", home, "--poll", "1ms"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job watch exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"succeeded\tsucceeded", "advance_completed\tdone", "state: succeeded"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("job watch output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestRunJobWatchJSON(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedCLIJob(t, store, db.Job{
+		ID:      "job-watch-json",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobFailed),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main"}),
+	}, "failed")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "watch", "job-watch-json", "--home", home, "--json", "--poll", "1ms"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job watch --json exit code = %d, stderr=%s", code, stderr.String())
+	}
+	var decoded jobWatchOutput
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("json output did not decode: %v\n%s", err, stdout.String())
+	}
+	if decoded.Job.ID != "job-watch-json" || decoded.Job.State != string(workflow.JobFailed) || len(decoded.Events) != 1 || decoded.Events[0].Kind != string(workflow.JobFailed) {
+		t.Fatalf("decoded watch output = %+v", decoded)
+	}
+}
+
 func TestRunJobRunUsesDaemonWorkerInternals(t *testing.T) {
 	home := t.TempDir()
 	store := openCLIJobStore(t, home)


### PR DESCRIPTION
WHAT:
- Adds `gitmoot agent ask --background` to queue local ask jobs without invoking the runtime immediately.
- Adds `gitmoot job watch` to follow job events until a terminal state.

WHY:
- Long-running local asks need a non-blocking path with a clear follow-up command while keeping synchronous ask behavior intact.

CHANGES:
- Added `--background` parsing and output for `agent ask`, including daemon-stopped hints and watch/run commands.
- Kept synchronous `agent ask` on the existing runtime-locked delivery path.
- Added `job watch <id>` with polling, terminal-state exit, and JSON output.
- Kept local background jobs as PR-less jobs, so they do not post GitHub comments unless they originated from PR workflow data.
- Added CLI tests for background ask, JSON output, daemon-stopped messaging, and job watch output.

RESULTS:
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/cli`
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./...`
- `git diff --check`
- `git diff --cached --check`

Final `codex exec review --uncommitted` raw output:
```
No actionable correctness issues were found in the current changes. I could not run the Go tests because the toolchain download target is read-only in this environment, so the verdict is based on code review only.
No actionable correctness issues were found in the current changes. I could not run the Go tests because the toolchain download target is read-only in this environment, so the verdict is based on code review only.
```

RISK:
- The default `go` wrapper still cannot download Go 1.26 in this environment, so tests were run with the cached Go 1.26.2 binary path above.
- Reviewer test execution was blocked by its sandbox/toolchain cache, but local focused and full suites passed.