### PR TITLE
feat: add background agent types

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -7,7 +7,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
@@ -30,6 +32,10 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 		return runAgentStart(args[1:], stdout, stderr)
 	case "ask":
 		return runAgentAsk(args[1:], stdout, stderr)
+	case "type":
+		return runAgentType(args[1:], stdout, stderr)
+	case "gc":
+		return runAgentGC(args[1:], stdout, stderr)
 	case "subscribe":
 		return runAgentSubscribe(args[1:], stdout, stderr)
 	case "list":
@@ -55,6 +61,8 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot agent start <name> --runtime codex|claude --repo owner/repo [--path .] [--preset <preset-id>] [--start-daemon]")
 	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot agent type list|show|set ...")
+	fmt.Fprintln(w, "  gitmoot agent gc")
 	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> [--repo owner/repo...] --capability <capability>")
 	fmt.Fprintln(w, "    Codex sessions may use a UUID, thread name, or last. Claude sessions may use a UUID or last. Shell sessions are commands.")
 	fmt.Fprintln(w, "  gitmoot agent allow <name> --repo owner/repo")
@@ -70,6 +78,7 @@ type agentAskOptions struct {
 	repo       string
 	jsonOutput bool
 	background bool
+	typeName   string
 	agent      string
 	message    string
 }
@@ -91,6 +100,8 @@ func runAgentAsk(args []string, stdout, stderr io.Writer) int {
 			Action:       "ask",
 			Instructions: options.message,
 			Background:   options.background,
+			Type:         options.typeName,
+			Home:         options.home,
 		})
 		return err
 	}); err != nil {
@@ -137,6 +148,13 @@ func parseAgentAskOptions(args []string, stderr io.Writer) (agentAskOptions, boo
 		switch {
 		case arg == "--background":
 			options.background = true
+		case arg == "--type":
+			if index+1 >= len(args) {
+				fmt.Fprintln(stderr, "agent ask requires a value for --type")
+				return agentAskOptions{}, false
+			}
+			index++
+			options.typeName = args[index]
 		case arg == "--json":
 			options.jsonOutput = true
 		case arg == "--repo" || arg == "--home":
@@ -154,6 +172,8 @@ func parseAgentAskOptions(args []string, stderr io.Writer) (agentAskOptions, boo
 			options.repo = strings.TrimPrefix(arg, "--repo=")
 		case strings.HasPrefix(arg, "--home="):
 			options.home = strings.TrimPrefix(arg, "--home=")
+		case strings.HasPrefix(arg, "--type="):
+			options.typeName = strings.TrimPrefix(arg, "--type=")
 		case strings.HasPrefix(arg, "-") && len(positionals) >= 2:
 			fmt.Fprintf(stderr, "unknown agent ask flag %q\n", arg)
 			return agentAskOptions{}, false
@@ -185,7 +205,7 @@ func containsHelpFlag(args []string) bool {
 
 func printAgentAskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--type type] [--home path] [--json]")
 }
 
 func daemonIsRunning(home string) (bool, error) {
@@ -219,6 +239,290 @@ func shellArgs(args []string) string {
 		quoted = append(quoted, shellArg(arg))
 	}
 	return strings.Join(quoted, " ")
+}
+
+func runAgentType(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printAgentTypeUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "list":
+		return runAgentTypeList(args[1:], stdout, stderr)
+	case "show":
+		return runAgentTypeShow(args[1:], stdout, stderr)
+	case "set":
+		return runAgentTypeSet(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown agent type command %q\n\n", args[0])
+		printAgentTypeUsage(stderr)
+		return 2
+	}
+}
+
+func printAgentTypeUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot agent type list")
+	fmt.Fprintln(w, "  gitmoot agent type show <type>")
+	fmt.Fprintln(w, "  gitmoot agent type set <type> --runtime codex|claude --preset <preset-id> --max-background 2 --idle-timeout 20m")
+}
+
+func runAgentTypeList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent type list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent type list does not accept positional arguments")
+		return 2
+	}
+	types, err := loadAgentTypeConfig(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent type list: %v\n", err)
+		return 1
+	}
+	names := make([]string, 0, len(types))
+	for name := range types {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		entry := types[name]
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%d\n", entry.Name, entry.Runtime, entry.Preset, entry.MaxBackground)
+	}
+	return 0
+}
+
+func runAgentTypeShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent type show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent type show requires exactly one type")
+			return 2
+		}
+		return 0
+	}
+	name := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent type show requires exactly one type")
+		return 2
+	}
+	types, err := loadAgentTypeConfig(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent type show: %v\n", err)
+		return 1
+	}
+	entry, ok := types[strings.TrimSpace(name)]
+	if !ok {
+		fmt.Fprintf(stderr, "agent type %q not found\n", name)
+		return 1
+	}
+	printAgentType(stdout, entry)
+	return 0
+}
+
+func runAgentTypeSet(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent type set", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	runtimeName := fs.String("runtime", "", "agent runtime: codex or claude")
+	presetID := fs.String("preset", "", "agent prompt preset")
+	role := fs.String("role", "", "agent role")
+	maxBackground := fs.Int("max-background", -1, "maximum managed background instances")
+	idleTimeout := fs.String("idle-timeout", "", "managed instance idle timeout")
+	jobTimeout := fs.String("job-timeout", "", "managed job timeout")
+	var capabilities repeatedFlag
+	fs.Var(&capabilities, "capability", "agent capability, repeatable")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent type set requires exactly one type")
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent type set requires exactly one type")
+		return 2
+	}
+	if !validAgentTypeName(name) {
+		fmt.Fprintf(stderr, "invalid agent type %q\n", name)
+		return 2
+	}
+	paths, types, err := loadAgentTypeConfigWithPaths(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent type set: %v\n", err)
+		return 1
+	}
+	entry := types[name]
+	entry.Name = name
+	if strings.TrimSpace(*runtimeName) != "" {
+		entry.Runtime = strings.TrimSpace(*runtimeName)
+	}
+	if strings.TrimSpace(entry.Runtime) == "" {
+		fmt.Fprintln(stderr, "agent type set requires --runtime for new types")
+		return 2
+	}
+	if _, err := (runtime.Factory{}).Adapter(entry.Runtime); err != nil {
+		fmt.Fprintf(stderr, "invalid runtime: %v\n", err)
+		return 2
+	}
+	if entry.Runtime == runtime.ShellRuntime {
+		fmt.Fprintln(stderr, "invalid runtime: managed agent types support codex or claude")
+		return 2
+	}
+	if strings.TrimSpace(*presetID) != "" {
+		entry.Preset = strings.TrimSpace(*presetID)
+	}
+	if strings.TrimSpace(*role) != "" {
+		entry.Role = strings.TrimSpace(*role)
+	}
+	if *maxBackground == 0 || *maxBackground < -1 {
+		fmt.Fprintln(stderr, "max background must be positive")
+		return 2
+	}
+	if *maxBackground > 0 {
+		entry.MaxBackground = *maxBackground
+	}
+	if strings.TrimSpace(*idleTimeout) != "" {
+		parsed, err := time.ParseDuration(*idleTimeout)
+		if err != nil {
+			fmt.Fprintf(stderr, "invalid idle timeout: %v\n", err)
+			return 2
+		}
+		if parsed <= 0 {
+			fmt.Fprintln(stderr, "idle timeout must be positive")
+			return 2
+		}
+		entry.IdleTimeout = strings.TrimSpace(*idleTimeout)
+	}
+	if strings.TrimSpace(*jobTimeout) != "" {
+		parsed, err := time.ParseDuration(*jobTimeout)
+		if err != nil {
+			fmt.Fprintf(stderr, "invalid job timeout: %v\n", err)
+			return 2
+		}
+		if parsed <= 0 {
+			fmt.Fprintln(stderr, "job timeout must be positive")
+			return 2
+		}
+		entry.JobTimeout = strings.TrimSpace(*jobTimeout)
+	}
+	if len(capabilities) > 0 {
+		entry.Capabilities = compactValues(capabilities)
+	}
+	resolvedRole, resolvedCapabilities, err := resolveAgentDefaults(entry.Preset, entry.Role, entry.Capabilities, name, []string{"ask"})
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid preset: %v\n", err)
+		return 2
+	}
+	entry.Role = resolvedRole
+	entry.Capabilities = resolvedCapabilities
+	if entry.Preset != "" {
+		if err := withStore(*home, func(store *db.Store) error {
+			_, err := loadInstalledPreset(context.Background(), store, entry.Preset)
+			return err
+		}); err != nil {
+			fmt.Fprintf(stderr, "%v\n", err)
+			return 1
+		}
+	}
+	if err := config.SaveAgentType(paths, entry); err != nil {
+		fmt.Fprintf(stderr, "agent type set: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "configured agent type %s", name)
+	return 0
+}
+
+func validAgentTypeName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, char := range name {
+		switch {
+		case char >= 'a' && char <= 'z':
+		case char >= 'A' && char <= 'Z':
+		case char >= '0' && char <= '9':
+		case char == '-' || char == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func runAgentGC(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent gc", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent gc does not accept positional arguments")
+		return 2
+	}
+	var deleted int64
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		deleted, err = store.DeleteExpiredAgentInstances(context.Background(), time.Now().UTC())
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent gc: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "removed %d expired agent instances", deleted)
+	return 0
+}
+
+func loadAgentTypeConfig(home string) (map[string]config.AgentType, error) {
+	_, types, err := loadAgentTypeConfigWithPaths(home)
+	return types, err
+}
+
+func loadAgentTypeConfigWithPaths(home string) (config.Paths, map[string]config.AgentType, error) {
+	paths, err := initializedPaths(home)
+	if err != nil {
+		return config.Paths{}, nil, err
+	}
+	types, err := config.LoadAgentTypes(paths)
+	return paths, types, err
+}
+
+func printAgentType(stdout io.Writer, entry config.AgentType) {
+	writeLine(stdout, "name: %s", entry.Name)
+	writeLine(stdout, "runtime: %s", entry.Runtime)
+	writeLine(stdout, "preset: %s", entry.Preset)
+	writeLine(stdout, "role: %s", entry.Role)
+	writeLine(stdout, "capabilities: %s", strings.Join(entry.Capabilities, ","))
+	writeLine(stdout, "max_background: %d", entry.MaxBackground)
+	writeLine(stdout, "idle_timeout: %s", entry.IdleTimeout)
+	writeLine(stdout, "job_timeout: %s", entry.JobTimeout)
 }
 
 func runAgentStart(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -23,6 +25,8 @@ type localAgentDispatchRequest struct {
 	Action       string
 	Instructions string
 	Background   bool
+	Type         string
+	Home         string
 }
 
 type localAgentJobOutput struct {
@@ -45,13 +49,13 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err := store.UpsertRepo(ctx, record); err != nil {
 		return localAgentJobOutput{}, err
 	}
-	agent, err := store.GetAgent(ctx, request.Agent)
+	agent, releaseAgentReservation, err := resolveLocalDispatchAgent(ctx, store, request, repo.FullName(), record)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return localAgentJobOutput{}, fmt.Errorf("agent %q not found", request.Agent)
-		}
 		return localAgentJobOutput{}, err
 	}
+	defer func() {
+		_ = releaseAgentReservation(context.Background())
+	}()
 	if err := ensureLocalAgentAccess(ctx, store, agent, repo.FullName(), request.Action); err != nil {
 		return localAgentJobOutput{}, err
 	}
@@ -121,6 +125,179 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		Result:         payload.Result,
 		RawOutputCount: len(payload.RawOutputs),
 	}, nil
+}
+
+func resolveLocalDispatchAgent(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string, record db.Repo) (db.Agent, func(context.Context) error, error) {
+	forceType := strings.TrimSpace(request.Type)
+	if forceType == "" {
+		agent, err := store.GetAgent(ctx, request.Agent)
+		if err == nil {
+			return agent, noopAgentReservationRelease, nil
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return db.Agent{}, noopAgentReservationRelease, err
+		}
+	}
+	if !request.Background {
+		return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("agent %q not found", request.Agent)
+	}
+	typeName := firstNonEmpty(forceType, request.Agent)
+	return ensureManagedAgentInstance(ctx, store, request.Home, typeName, repo, record)
+}
+
+func noopAgentReservationRelease(context.Context) error {
+	return nil
+}
+
+func ensureManagedAgentInstance(ctx context.Context, store *db.Store, home string, typeName string, repo string, record db.Repo) (db.Agent, func(context.Context) error, error) {
+	types, err := loadAgentTypeConfig(home)
+	if err != nil {
+		return db.Agent{}, noopAgentReservationRelease, err
+	}
+	agentType, ok := types[typeName]
+	if !ok {
+		return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("agent %q not found", typeName)
+	}
+	idleTimeout, err := time.ParseDuration(agentType.IdleTimeout)
+	if err != nil {
+		return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("agent type %s idle_timeout: %w", typeName, err)
+	}
+	now := time.Now().UTC()
+	releaseTypeLock, acquiredTypeLock, typeLockKey, err := acquireManagedAgentTypeLock(ctx, store, typeName, now, daemonRunningJobStaleAfter)
+	if err != nil {
+		return db.Agent{}, noopAgentReservationRelease, err
+	}
+	if !acquiredTypeLock {
+		return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("managed agent type %s is busy reserving %s", typeName, typeLockKey)
+	}
+	releaseOnError := true
+	defer func() {
+		if releaseOnError {
+			_ = releaseTypeLock(context.Background())
+		}
+	}()
+	if instance, ok, err := store.FindReusableAgentInstance(ctx, typeName, repo, now); err != nil {
+		return db.Agent{}, noopAgentReservationRelease, err
+	} else if ok {
+		if err := store.TouchAgentInstance(ctx, instance.Name, now, idleTimeout); err != nil {
+			return db.Agent{}, noopAgentReservationRelease, err
+		}
+		agent, err := store.GetAgent(ctx, instance.Name)
+		if err != nil {
+			return db.Agent{}, noopAgentReservationRelease, err
+		}
+		releaseOnError = false
+		return agent, releaseTypeLock, nil
+	}
+	count, err := store.CountActiveAgentInstances(ctx, typeName, now)
+	if err != nil {
+		return db.Agent{}, noopAgentReservationRelease, err
+	}
+	if count >= agentType.MaxBackground {
+		instance, ok, err := store.FindActiveAgentInstance(ctx, typeName, repo, now)
+		if err != nil {
+			return db.Agent{}, noopAgentReservationRelease, err
+		}
+		if ok {
+			agent, err := store.GetAgent(ctx, instance.Name)
+			if err != nil {
+				return db.Agent{}, noopAgentReservationRelease, err
+			}
+			releaseOnError = false
+			return agent, releaseTypeLock, nil
+		}
+		return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("managed agent type %s reached max_background but no active instance is available", typeName)
+	}
+	instanceAgent := runtimeAgentFromType(agentType, repo, managedAgentInstanceName(typeName))
+	var cachedPreset db.Preset
+	if instanceAgent.PresetID != "" {
+		var err error
+		cachedPreset, err = store.GetPreset(ctx, instanceAgent.PresetID)
+		if err != nil {
+			return db.Agent{}, noopAgentReservationRelease, err
+		}
+	}
+	adapter, err := runtimeStartAdapter(newRuntimeFactory(), instanceAgent.Runtime, record.CheckoutPath)
+	if err != nil {
+		return db.Agent{}, noopAgentReservationRelease, err
+	}
+	started, err := adapter.Start(ctx, runtime.StartRequest{Agent: instanceAgent, Prompt: agentStartupPrompt(instanceAgent, cachedPreset)})
+	if err != nil {
+		return db.Agent{}, noopAgentReservationRelease, err
+	}
+	instanceAgent.RuntimeRef = strings.TrimSpace(started.RuntimeRef)
+	if err := runtime.ValidateAgent(instanceAgent); err != nil {
+		return db.Agent{}, noopAgentReservationRelease, err
+	}
+	instance := db.AgentInstance{
+		Name:         instanceAgent.Name,
+		Type:         agentType.Name,
+		Runtime:      instanceAgent.Runtime,
+		RuntimeRef:   instanceAgent.RuntimeRef,
+		RepoFullName: repo,
+		Role:         instanceAgent.Role,
+		PresetID:     instanceAgent.PresetID,
+		Capabilities: instanceAgent.Capabilities,
+		State:        "idle",
+		CreatedAt:    formatManagedAgentTime(now),
+		LastUsedAt:   formatManagedAgentTime(now),
+		ExpiresAt:    formatManagedAgentTime(now.Add(idleTimeout)),
+	}
+	if err := store.UpsertAgentInstance(ctx, instance); err != nil {
+		return db.Agent{}, noopAgentReservationRelease, err
+	}
+	agent, err := store.GetAgent(ctx, instance.Name)
+	if err != nil {
+		return db.Agent{}, noopAgentReservationRelease, err
+	}
+	releaseOnError = false
+	return agent, releaseTypeLock, nil
+}
+
+func acquireManagedAgentTypeLock(ctx context.Context, store *db.Store, typeName string, now time.Time, ttl time.Duration) (func(context.Context) error, bool, string, error) {
+	if ttl <= 0 {
+		return nil, false, "", fmt.Errorf("managed agent type lock ttl must be positive")
+	}
+	key := "agent-type:" + typeName
+	ownerToken, err := newRuntimeLockOwnerToken()
+	if err != nil {
+		return nil, false, key, err
+	}
+	owner := "agent-type:" + typeName
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  owner,
+		OwnerToken:  ownerToken,
+		ExpiresAt:   now.UTC().Add(ttl).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil || !acquired {
+		return func(context.Context) error { return nil }, acquired, key, err
+	}
+	return func(releaseCtx context.Context) error {
+		_, err := store.ReleaseResourceLock(releaseCtx, key, owner, ownerToken)
+		return err
+	}, true, key, nil
+}
+
+func runtimeAgentFromType(agentType config.AgentType, repo string, name string) runtime.Agent {
+	return runtime.Agent{
+		Name:           name,
+		Role:           agentType.Role,
+		Runtime:        agentType.Runtime,
+		RepoScope:      repo,
+		PresetID:       agentType.Preset,
+		Capabilities:   agentType.Capabilities,
+		AutonomyPolicy: "auto",
+		HealthStatus:   "idle",
+	}
+}
+
+func managedAgentInstanceName(typeName string) string {
+	return fmt.Sprintf("%s-bg-%x", typeName, time.Now().UTC().UnixNano())
+}
+
+func formatManagedAgentTime(value time.Time) string {
+	return value.UTC().Format("2006-01-02T15:04:05.000000000Z")
 }
 
 func resolveLocalAgentRepo(ctx context.Context, store *db.Store, repoFlag string) (github.Repository, db.Repo, error) {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -626,6 +626,473 @@ func TestRunAgentAskBackgroundJSON(t *testing.T) {
 	}
 }
 
+func TestRunAgentTypeSetListShowAndManagedBackgroundAsk(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "planner",
+		"--max-background", "1",
+		"--idle-timeout", "20m",
+		"--job-timeout", "5m",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "configured agent type planner") {
+		t.Fatalf("agent type set output = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "type", "list", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "planner\tcodex\t\t1") {
+		t.Fatalf("agent type list output = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "type", "show", "planner", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "max_background: 1") || !strings.Contains(stdout.String(), "capabilities: ask") {
+		t.Fatalf("agent type show output = %q", stdout.String())
+	}
+
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440111"}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "planner", "First plan", "--home", home, "--repo", "owner/repo", "--background"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("managed background ask exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "state: queued") {
+		t.Fatalf("managed background ask output = %q", stdout.String())
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runtime start calls = %+v, want one", runner.calls)
+	}
+	runner.want(t, 0, repoDir, "codex", "exec", "--json", "--")
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "planner", "Second plan", "--home", home, "--repo", "owner/repo", "--background"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("second managed background ask exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runtime start calls after reuse = %+v, want one", runner.calls)
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	instances, err := store.ListAgentInstances(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgentInstances returned error: %v", err)
+	}
+	if len(instances) != 1 || instances[0].Type != "planner" || instances[0].RuntimeRef != "550e8400-e29b-41d4-a716-446655440111" {
+		t.Fatalf("instances = %+v", instances)
+	}
+	config, err := (jobWorker{Store: store, ConfigHome: home}).managedJobConfig(context.Background(), instances[0].Name)
+	if err != nil {
+		t.Fatalf("managedJobConfig returned error: %v", err)
+	}
+	if !config.OK || config.JobTimeout != 5*time.Minute || config.IdleTimeout != 20*time.Minute {
+		t.Fatalf("managedJobConfig = %+v; want 5m job and 20m idle", config)
+	}
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 2 || jobs[0].Agent != instances[0].Name || jobs[1].Agent != instances[0].Name {
+		t.Fatalf("jobs = %+v, instance = %+v", jobs, instances[0])
+	}
+}
+
+func TestRunAgentTypeSetRejectsNonStartableRuntime(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{
+		"agent", "type", "set", "shell-planner",
+		"--home", home,
+		"--runtime", "shell",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("agent type set shell exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "managed agent types support codex or claude") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunAgentTypeSetMaxBackgroundCreatesSecondBusyInstance(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--max-background", "2",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440121"}` + "\n"},
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440122"}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	for _, prompt := range []string{"First", "Second"} {
+		stdout.Reset()
+		stderr.Reset()
+		code = Run([]string{"agent", "ask", "planner", prompt, "--home", home, "--repo", "owner/repo", "--background"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("managed background ask %q exit code = %d, stderr=%s", prompt, code, stderr.String())
+		}
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("runtime start calls = %+v, want two", runner.calls)
+	}
+}
+
+func TestRunAgentTypeSetMaxBackgroundCapsAcrossRepos(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	otherRepoDir := t.TempDir()
+	runGit(t, otherRepoDir, "init")
+	runGit(t, otherRepoDir, "branch", "-m", "main")
+	runGit(t, otherRepoDir, "remote", "add", "origin", "https://github.com/owner/other.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"repo", "add", "owner/other", "--home", home, "--path", otherRepoDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("repo add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440123"}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "planner", "First", "--home", home, "--repo", "owner/repo", "--background"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("first managed background ask exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "planner", "Second", "--home", home, "--repo", "owner/other", "--background"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("second repo managed background ask exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "reached max_background") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runtime start calls = %+v, want one", runner.calls)
+	}
+}
+
+func TestRunAgentTypeSetMaxBackgroundUsesOnlyActiveFallback(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	now := time.Now().UTC()
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertAgentInstance(context.Background(), db.AgentInstance{
+		Name:         "planner-bg-expired",
+		Type:         "planner",
+		Runtime:      "codex",
+		RuntimeRef:   "550e8400-e29b-41d4-a716-446655440131",
+		RepoFullName: "owner/repo",
+		Role:         "planner",
+		Capabilities: []string{"ask"},
+		State:        "idle",
+		CreatedAt:    now.Add(-time.Hour).Format(time.RFC3339Nano),
+		LastUsedAt:   now.Add(-time.Hour).Format(time.RFC3339Nano),
+		ExpiresAt:    now.Add(-time.Minute).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("UpsertAgentInstance expired returned error: %v", err)
+	}
+	if err := store.UpsertAgentInstance(context.Background(), db.AgentInstance{
+		Name:         "planner-bg-active",
+		Type:         "planner",
+		Runtime:      "codex",
+		RuntimeRef:   "550e8400-e29b-41d4-a716-446655440132",
+		RepoFullName: "owner/repo",
+		Role:         "planner",
+		Capabilities: []string{"ask"},
+		State:        "idle",
+		CreatedAt:    now.Format(time.RFC3339Nano),
+		LastUsedAt:   now.Format(time.RFC3339Nano),
+		ExpiresAt:    now.Add(time.Hour).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("UpsertAgentInstance active returned error: %v", err)
+	}
+	if err := store.CreateJob(context.Background(), db.Job{ID: "queued-for-active", Agent: "planner-bg-active", Type: "ask", State: "queued", Payload: "{}"}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	store.Close()
+
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "planner", "Third", "--home", home, "--repo", "owner/repo", "--background"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("managed background ask exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runtime start calls = %+v, want none", runner.calls)
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	activeJobs := 0
+	expiredJobs := 0
+	for _, job := range jobs {
+		if job.Agent == "planner-bg-active" {
+			activeJobs++
+		}
+		if job.Agent == "planner-bg-expired" {
+			expiredJobs++
+		}
+	}
+	if len(jobs) != 2 || activeJobs != 2 || expiredJobs != 0 {
+		t.Fatalf("jobs = %+v, want all jobs assigned to active instance", jobs)
+	}
+}
+
+func TestRunAgentTypeSetMaxBackgroundCountsQueuedExpiredInstance(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	now := time.Now().UTC()
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertAgentInstance(context.Background(), db.AgentInstance{
+		Name:         "planner-bg-expired",
+		Type:         "planner",
+		Runtime:      "codex",
+		RuntimeRef:   "550e8400-e29b-41d4-a716-446655440141",
+		RepoFullName: "owner/repo",
+		Role:         "planner",
+		Capabilities: []string{"ask"},
+		State:        "idle",
+		CreatedAt:    now.Add(-time.Hour).Format(time.RFC3339Nano),
+		LastUsedAt:   now.Add(-time.Hour).Format(time.RFC3339Nano),
+		ExpiresAt:    now.Add(-time.Minute).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("UpsertAgentInstance returned error: %v", err)
+	}
+	if err := store.CreateJob(context.Background(), db.Job{ID: "queued-for-expired", Agent: "planner-bg-expired", Type: "ask", State: "queued", Payload: "{}"}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	store.Close()
+
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "planner", "Second", "--home", home, "--repo", "owner/repo", "--background"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("managed background ask exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runtime start calls = %+v, want none", runner.calls)
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	expiredJobs := 0
+	for _, job := range jobs {
+		if job.Agent == "planner-bg-expired" {
+			expiredJobs++
+		}
+	}
+	if len(jobs) != 2 || expiredJobs != 2 {
+		t.Fatalf("jobs = %+v, want queued expired instance to retain max slot", jobs)
+	}
+}
+
+func TestRunAgentTypeSetValidatesPreset(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--preset", "missing-preset",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("agent type set missing preset exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "preset missing-preset is not installed") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunAgentTypeSetRejectsConfigUnsafeName(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{
+		"agent", "type", "set", "bad#name",
+		"--home", home,
+		"--runtime", "codex",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("agent type set unsafe name exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "invalid agent type") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunAgentTypeSetRejectsNonPositiveTimeouts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		flag string
+		want string
+	}{
+		{name: "idle", flag: "--idle-timeout", want: "idle timeout must be positive"},
+		{name: "job", flag: "--job-timeout", want: "job timeout must be positive"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			var stdout, stderr bytes.Buffer
+
+			code := Run([]string{
+				"agent", "type", "set", "planner",
+				"--home", home,
+				"--runtime", "codex",
+				tc.flag, "0s",
+			}, &stdout, &stderr)
+			if code != 2 {
+				t.Fatalf("agent type set exit code = %d, want 2", code)
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestRunAgentGCRemovesExpiredManagedInstances(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	now := time.Now().UTC().Add(-time.Hour)
+	if err := store.UpsertAgentInstance(context.Background(), db.AgentInstance{
+		Name:         "planner-bg-expired",
+		Type:         "planner",
+		Runtime:      "codex",
+		RuntimeRef:   "550e8400-e29b-41d4-a716-446655440112",
+		RepoFullName: "owner/repo",
+		Role:         "planner",
+		Capabilities: []string{"ask"},
+		State:        "idle",
+		CreatedAt:    now.Format(time.RFC3339Nano),
+		LastUsedAt:   now.Format(time.RFC3339Nano),
+		ExpiresAt:    now.Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("UpsertAgentInstance returned error: %v", err)
+	}
+	store.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "gc", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent gc exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "removed 1 expired agent instances") {
+		t.Fatalf("agent gc output = %q", stdout.String())
+	}
+}
+
 func TestRunAgentAskValidatesInputAndAccess(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -192,7 +193,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 			},
 		}
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
-		return runSingleRepoSupervisor(ctx, daemon.Daemon{
+		return runSingleRepoSupervisor(ctx, *home, daemon.Daemon{
 			Repo:         repo,
 			PollInterval: *poll,
 			Store:        store,
@@ -783,7 +784,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			ErrorStreak: map[string]int{},
 		}
 		poller := defaultRegisteredRepoPoller(store, workers, dryRun, stdout)
-		worker := defaultJobWorker(store, stdout)
+		worker := defaultJobWorker(store, stdout, home)
 		worker.CommenterFactory = worker.defaultCommenter
 		checkoutLocks := &repoCheckoutLocks{}
 		poller.CheckoutLocks = checkoutLocks
@@ -823,7 +824,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 	})
 }
 
-func runSingleRepoSupervisor(ctx context.Context, d daemon.Daemon, store *db.Store, workers int, stdout io.Writer) error {
+func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, store *db.Store, workers int, stdout io.Writer) error {
 	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, time.Now().UTC()); err != nil {
 		return err
 	}
@@ -837,7 +838,7 @@ func runSingleRepoSupervisor(ctx context.Context, d daemon.Daemon, store *db.Sto
 	if interval <= 0 {
 		interval = 30 * time.Second
 	}
-	worker := defaultJobWorker(store, stdout)
+	worker := defaultJobWorker(store, stdout, home)
 	worker.CommenterFactory = worker.defaultCommenter
 	var checkoutLock sync.Mutex
 	workerErr := startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
@@ -1102,6 +1103,7 @@ func shorterWait(current time.Duration, candidate time.Duration, set *bool) time
 type jobWorker struct {
 	Store             *db.Store
 	Stdout            io.Writer
+	ConfigHome        string
 	AdapterFactory    func(runtime.Agent, string) (workflow.DeliveryAdapter, error)
 	CheckoutValidator func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error)
 	WorkflowFactory   func(string) workflow.Engine
@@ -1114,8 +1116,12 @@ const daemonWorkerLoopInterval = 1 * time.Second
 
 var errRuntimeSessionBusy = errors.New("runtime session is busy")
 
-func defaultJobWorker(store *db.Store, stdout io.Writer) jobWorker {
-	worker := jobWorker{Store: store, Stdout: stdout}
+func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWorker {
+	configHome := ""
+	if len(home) > 0 {
+		configHome = home[0]
+	}
+	worker := jobWorker{Store: store, Stdout: stdout, ConfigHome: configHome}
 	worker.AdapterFactory = worker.defaultAdapter
 	worker.CheckoutValidator = worker.defaultCheckout
 	worker.WorkflowFactory = worker.defaultWorkflow
@@ -1446,7 +1452,19 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 		return nil
 	}
-	releaseLock, acquired, lockKey, err := acquireRuntimeSessionLock(ctx, w.Store, job.ID, agent, time.Now().UTC(), daemonRunningJobStaleAfter)
+	managed, err := w.managedJobConfig(ctx, agent.Name)
+	if err != nil {
+		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
+		return nil
+	}
+	lockTTL := daemonRunningJobStaleAfter
+	if managed.OK {
+		lockTTL = managed.JobTimeout
+	}
+	releaseLock, acquired, lockKey, err := acquireRuntimeSessionLock(ctx, w.Store, job.ID, agent, time.Now().UTC(), lockTTL)
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
 			return finishErr
@@ -1467,10 +1485,29 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			writeLine(w.Stdout, "job %s runtime lock release failed: %v", job.ID, err)
 		}
 	}()
+	if managed.OK {
+		if err := w.Store.MarkAgentInstanceRunning(ctx, agent.Name, time.Now().UTC(), managed.JobTimeout); err != nil {
+			if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
+				return finishErr
+			}
+			_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
+			return nil
+		}
+		defer func() {
+			if err := w.Store.TouchAgentInstance(context.Background(), agent.Name, time.Now().UTC(), managed.IdleTimeout); err != nil {
+				writeLine(w.Stdout, "job %s managed agent state update failed: %v", job.ID, err)
+			}
+		}()
+	}
 	writeLine(w.Stdout, "running job %s for %s in %s", job.ID, agent.Name, payload.Repo)
 	engine := w.WorkflowFactory(checkout)
 	runCtx, stopRun := w.runningJobContext(ctx, job.ID)
 	defer stopRun()
+	if managed.OK {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(runCtx, managed.JobTimeout)
+		defer cancel()
+	}
 	_, err = engine.RunJob(runCtx, job.ID, agent, adapter)
 	if err != nil {
 		if markErr := w.handleRunJobError(ctx, job.ID, err); markErr != nil {
@@ -1483,6 +1520,45 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	_ = w.postJobResultComment(ctx, job.ID, agent, checkout, nil)
 	writeLine(w.Stdout, "job %s completed", job.ID)
 	return nil
+}
+
+type managedJobRuntimeConfig struct {
+	OK          bool
+	JobTimeout  time.Duration
+	IdleTimeout time.Duration
+}
+
+func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (managedJobRuntimeConfig, error) {
+	instance, err := w.Store.GetAgentInstance(ctx, agentName)
+	if errors.Is(err, sql.ErrNoRows) {
+		return managedJobRuntimeConfig{}, nil
+	}
+	if err != nil {
+		return managedJobRuntimeConfig{}, err
+	}
+	types, err := loadAgentTypeConfig(w.ConfigHome)
+	if err != nil {
+		return managedJobRuntimeConfig{}, err
+	}
+	agentType, ok := types[instance.Type]
+	if !ok {
+		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %q not found for managed instance %s", instance.Type, agentName)
+	}
+	jobTimeout, err := time.ParseDuration(agentType.JobTimeout)
+	if err != nil {
+		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s job_timeout: %w", instance.Type, err)
+	}
+	if jobTimeout <= 0 {
+		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s job_timeout must be positive", instance.Type)
+	}
+	idleTimeout, err := time.ParseDuration(agentType.IdleTimeout)
+	if err != nil {
+		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s idle_timeout: %w", instance.Type, err)
+	}
+	if idleTimeout <= 0 {
+		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s idle_timeout must be positive", instance.Type)
+	}
+	return managedJobRuntimeConfig{OK: true, JobTimeout: jobTimeout, IdleTimeout: idleTimeout}, nil
 }
 
 func (w jobWorker) runningJobContext(ctx context.Context, jobID string) (context.Context, func()) {

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -208,7 +208,7 @@ func runJobRun(args []string, stdout, stderr io.Writer) int {
 		if job.State != string(workflow.JobQueued) {
 			return fmt.Errorf("job %s is %s; run requires queued", job.ID, job.State)
 		}
-		worker := defaultJobWorker(store, stdout)
+		worker := defaultJobWorker(store, stdout, *home)
 		worker.CommenterFactory = worker.defaultCommenter
 		if err := worker.run(context.Background(), job); err != nil {
 			return err

--- a/internal/config/agent_types.go
+++ b/internal/config/agent_types.go
@@ -1,0 +1,255 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type AgentType struct {
+	Name          string
+	Runtime       string
+	Preset        string
+	Role          string
+	Capabilities  []string
+	MaxBackground int
+	IdleTimeout   string
+	JobTimeout    string
+}
+
+func LoadAgentTypes(paths Paths) (map[string]AgentType, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	types := map[string]AgentType{}
+	var current string
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			current = ""
+			if strings.HasPrefix(section, "agents.") {
+				current = strings.TrimSpace(strings.TrimPrefix(section, "agents."))
+				if current != "" {
+					entry := types[current]
+					entry.Name = current
+					types[current] = entry
+				}
+			}
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		entry := types[current]
+		if err := applyAgentTypeField(&entry, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
+			return nil, fmt.Errorf("parse [agents.%s].%s: %w", current, strings.TrimSpace(key), err)
+		}
+		types[current] = entry
+	}
+	for name, entry := range types {
+		entry.Name = name
+		applyAgentTypeDefaults(&entry)
+		types[name] = entry
+	}
+	return types, nil
+}
+
+func SaveAgentType(paths Paths, entry AgentType) error {
+	types, err := LoadAgentTypes(paths)
+	if err != nil {
+		return err
+	}
+	applyAgentTypeDefaults(&entry)
+	types[entry.Name] = entry
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return err
+	}
+	base := removeAgentTypeBlocks(string(content))
+	var builder strings.Builder
+	builder.WriteString(strings.TrimRight(base, "\n"))
+	builder.WriteString("\n")
+	names := make([]string, 0, len(types))
+	for name := range types {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		writeAgentTypeBlock(&builder, types[name])
+	}
+	return os.WriteFile(paths.ConfigFile, []byte(builder.String()), 0o600)
+}
+
+func applyAgentTypeDefaults(entry *AgentType) {
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.Runtime = strings.TrimSpace(entry.Runtime)
+	entry.Preset = strings.TrimSpace(entry.Preset)
+	entry.Role = strings.TrimSpace(entry.Role)
+	if entry.Role == "" {
+		entry.Role = entry.Name
+	}
+	entry.Capabilities = compactConfigStrings(entry.Capabilities)
+	if len(entry.Capabilities) == 0 {
+		entry.Capabilities = []string{"ask"}
+	}
+	if entry.MaxBackground <= 0 {
+		entry.MaxBackground = 1
+	}
+	if strings.TrimSpace(entry.IdleTimeout) == "" {
+		entry.IdleTimeout = "20m"
+	}
+	if strings.TrimSpace(entry.JobTimeout) == "" {
+		entry.JobTimeout = "10m"
+	}
+}
+
+func applyAgentTypeField(entry *AgentType, key string, value string) error {
+	switch key {
+	case "runtime":
+		parsed, err := parseConfigString(value)
+		entry.Runtime = parsed
+		return err
+	case "preset":
+		parsed, err := parseConfigString(value)
+		entry.Preset = parsed
+		return err
+	case "role":
+		parsed, err := parseConfigString(value)
+		entry.Role = parsed
+		return err
+	case "capabilities":
+		parsed, err := parseConfigStringArray(value)
+		entry.Capabilities = parsed
+		return err
+	case "max_background":
+		parsed, err := strconv.Atoi(value)
+		entry.MaxBackground = parsed
+		return err
+	case "idle_timeout":
+		parsed, err := parseConfigString(value)
+		entry.IdleTimeout = parsed
+		return err
+	case "job_timeout":
+		parsed, err := parseConfigString(value)
+		entry.JobTimeout = parsed
+		return err
+	default:
+		return nil
+	}
+}
+
+func stripConfigComment(value string) string {
+	inString := false
+	escaped := false
+	for index, r := range value {
+		switch {
+		case escaped:
+			escaped = false
+		case r == '\\' && inString:
+			escaped = true
+		case r == '"':
+			inString = !inString
+		case r == '#' && !inString:
+			return value[:index]
+		}
+	}
+	return value
+}
+
+func parseConfigString(value string) (string, error) {
+	parsed, err := strconv.Unquote(strings.TrimSpace(value))
+	if err != nil {
+		return "", err
+	}
+	return parsed, nil
+}
+
+func parseConfigStringArray(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
+		return nil, fmt.Errorf("expected string array")
+	}
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "["), "]"))
+	if inner == "" {
+		return nil, nil
+	}
+	parts := strings.Split(inner, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		parsed, err := parseConfigString(part)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, parsed)
+	}
+	return compactConfigStrings(values), nil
+}
+
+func removeAgentTypeBlocks(content string) string {
+	lines := strings.Split(content, "\n")
+	kept := make([]string, 0, len(lines))
+	skip := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")
+			skip = strings.HasPrefix(section, "agents.")
+		}
+		if !skip {
+			kept = append(kept, line)
+		}
+	}
+	return strings.TrimRight(strings.Join(kept, "\n"), "\n") + "\n"
+}
+
+func writeAgentTypeBlock(builder *strings.Builder, entry AgentType) {
+	builder.WriteString("\n[agents.")
+	builder.WriteString(entry.Name)
+	builder.WriteString("]\n")
+	builder.WriteString("runtime = ")
+	builder.WriteString(strconv.Quote(entry.Runtime))
+	builder.WriteString("\n")
+	if entry.Preset != "" {
+		builder.WriteString("preset = ")
+		builder.WriteString(strconv.Quote(entry.Preset))
+		builder.WriteString("\n")
+	}
+	builder.WriteString("role = ")
+	builder.WriteString(strconv.Quote(entry.Role))
+	builder.WriteString("\ncapabilities = [")
+	for index, capability := range entry.Capabilities {
+		if index > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString(strconv.Quote(capability))
+	}
+	builder.WriteString("]\nmax_background = ")
+	builder.WriteString(strconv.Itoa(entry.MaxBackground))
+	builder.WriteString("\nidle_timeout = ")
+	builder.WriteString(strconv.Quote(entry.IdleTimeout))
+	builder.WriteString("\njob_timeout = ")
+	builder.WriteString(strconv.Quote(entry.JobTimeout))
+	builder.WriteString("\n")
+}
+
+func compactConfigStrings(values []string) []string {
+	compacted := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			compacted = append(compacted, value)
+		}
+	}
+	return compacted
+}

--- a/internal/config/agent_types_test.go
+++ b/internal/config/agent_types_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoadAndSaveAgentTypes(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[agents.planner]
+runtime = "codex"
+preset = "gitmoot-plan-lite"
+role = "planner"
+capabilities = ["ask", "review"]
+max_background = 2
+idle_timeout = "15m"
+job_timeout = "5m"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	types, err := LoadAgentTypes(paths)
+	if err != nil {
+		t.Fatalf("LoadAgentTypes returned error: %v", err)
+	}
+	planner := types["planner"]
+	if planner.Runtime != "codex" || planner.Preset != "gitmoot-plan-lite" || planner.Role != "planner" || planner.MaxBackground != 2 || planner.IdleTimeout != "15m" || strings.Join(planner.Capabilities, ",") != "ask,review" {
+		t.Fatalf("planner type = %+v", planner)
+	}
+
+	planner.MaxBackground = 3
+	planner.Capabilities = []string{"ask"}
+	if err := SaveAgentType(paths, planner); err != nil {
+		t.Fatalf("SaveAgentType returned error: %v", err)
+	}
+	updated, err := LoadAgentTypes(paths)
+	if err != nil {
+		t.Fatalf("LoadAgentTypes after save returned error: %v", err)
+	}
+	if updated["planner"].MaxBackground != 3 || strings.Join(updated["planner"].Capabilities, ",") != "ask" {
+		t.Fatalf("updated planner type = %+v", updated["planner"])
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -58,6 +58,21 @@ type AgentRepo struct {
 	RepoFullName string
 }
 
+type AgentInstance struct {
+	Name         string
+	Type         string
+	Runtime      string
+	RuntimeRef   string
+	RepoFullName string
+	Role         string
+	PresetID     string
+	Capabilities []string
+	State        string
+	CreatedAt    string
+	LastUsedAt   string
+	ExpiresAt    string
+}
+
 type Goal struct {
 	ID     string
 	Title  string
@@ -338,7 +353,28 @@ func (s *Store) UpsertAgent(ctx context.Context, agent Agent) error {
 func (s *Store) GetAgent(ctx context.Context, name string) (Agent, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, preset_id, capabilities_json, autonomy_policy, health_status
 		FROM agents WHERE name = ?`, name)
-	return scanAgent(row)
+	agent, err := scanAgent(row)
+	if err == nil {
+		return agent, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return Agent{}, err
+	}
+	instance, err := s.GetAgentInstance(ctx, name)
+	if err != nil {
+		return Agent{}, err
+	}
+	return Agent{
+		Name:           instance.Name,
+		Role:           instance.Role,
+		Runtime:        instance.Runtime,
+		RuntimeRef:     instance.RuntimeRef,
+		RepoScope:      instance.RepoFullName,
+		PresetID:       instance.PresetID,
+		Capabilities:   instance.Capabilities,
+		AutonomyPolicy: "auto",
+		HealthStatus:   instance.State,
+	}, nil
 }
 
 func (s *Store) ListAgents(ctx context.Context) ([]Agent, error) {
@@ -505,7 +541,171 @@ func (s *Store) ListPresets(ctx context.Context) ([]Preset, error) {
 func (s *Store) AgentCanAccessRepo(ctx context.Context, agentName string, repoFullName string) (bool, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_repos WHERE agent_name = ? AND repo_full_name = ?`, agentName, repoFullName).Scan(&count)
+	if err != nil || count > 0 {
+		return count > 0, err
+	}
+	err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_instances WHERE name = ? AND repo_full_name = ?`, agentName, repoFullName).Scan(&count)
 	return count > 0, err
+}
+
+func (s *Store) UpsertAgentInstance(ctx context.Context, instance AgentInstance) error {
+	capabilities, err := json.Marshal(instance.Capabilities)
+	if err != nil {
+		return err
+	}
+	instance.CreatedAt = normalizeStoredTime(instance.CreatedAt)
+	instance.LastUsedAt = normalizeStoredTime(instance.LastUsedAt)
+	instance.ExpiresAt = normalizeStoredTime(instance.ExpiresAt)
+	_, err = s.db.ExecContext(ctx, `INSERT INTO agent_instances(name, type, runtime, runtime_ref, repo_full_name, role, preset_id, capabilities_json, state, created_at, last_used_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(name) DO UPDATE SET
+			type = excluded.type,
+			runtime = excluded.runtime,
+			runtime_ref = excluded.runtime_ref,
+			repo_full_name = excluded.repo_full_name,
+			role = excluded.role,
+			preset_id = excluded.preset_id,
+			capabilities_json = excluded.capabilities_json,
+			state = excluded.state,
+			last_used_at = excluded.last_used_at,
+			expires_at = excluded.expires_at`,
+		instance.Name, instance.Type, instance.Runtime, instance.RuntimeRef, instance.RepoFullName, instance.Role, instance.PresetID, string(capabilities), instance.State, instance.CreatedAt, instance.LastUsedAt, instance.ExpiresAt)
+	return err
+}
+
+func (s *Store) GetAgentInstance(ctx context.Context, name string) (AgentInstance, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, preset_id, capabilities_json, state, created_at, last_used_at, expires_at
+		FROM agent_instances WHERE name = ?`, name)
+	return scanAgentInstance(row)
+}
+
+func (s *Store) FindReusableAgentInstance(ctx context.Context, typ string, repo string, now time.Time) (AgentInstance, bool, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, preset_id, capabilities_json, state, created_at, last_used_at, expires_at
+		FROM agent_instances
+		WHERE type = ? AND repo_full_name = ? AND expires_at > ?
+			AND state = 'idle'
+			AND NOT EXISTS (
+				SELECT 1 FROM jobs
+				WHERE jobs.agent = agent_instances.name
+					AND jobs.state IN ('queued', 'running')
+			)
+		ORDER BY last_used_at DESC, created_at DESC
+		LIMIT 1`, typ, repo, formatResourceLockTime(now))
+	instance, err := scanAgentInstance(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AgentInstance{}, false, nil
+	}
+	if err != nil {
+		return AgentInstance{}, false, err
+	}
+	return instance, true, nil
+}
+
+func (s *Store) CountActiveAgentInstances(ctx context.Context, typ string, now time.Time) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_instances
+		WHERE type = ?
+			AND (
+				expires_at > ?
+				OR EXISTS (
+					SELECT 1 FROM jobs
+					WHERE jobs.agent = agent_instances.name
+						AND jobs.state IN ('queued', 'running')
+				)
+			)`, typ, formatResourceLockTime(now)).Scan(&count)
+	return count, err
+}
+
+func (s *Store) FindActiveAgentInstance(ctx context.Context, typ string, repo string, now time.Time) (AgentInstance, bool, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, preset_id, capabilities_json, state, created_at, last_used_at, expires_at
+		FROM agent_instances
+		WHERE type = ? AND repo_full_name = ?
+			AND (
+				expires_at > ?
+				OR EXISTS (
+					SELECT 1 FROM jobs
+					WHERE jobs.agent = agent_instances.name
+						AND jobs.state IN ('queued', 'running')
+				)
+			)
+		ORDER BY
+			CASE WHEN expires_at > ? THEN 0 ELSE 1 END,
+			last_used_at DESC,
+			created_at DESC
+		LIMIT 1`, typ, repo, formatResourceLockTime(now), formatResourceLockTime(now))
+	instance, err := scanAgentInstance(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AgentInstance{}, false, nil
+	}
+	if err != nil {
+		return AgentInstance{}, false, err
+	}
+	return instance, true, nil
+}
+
+func (s *Store) ListAgentInstances(ctx context.Context) ([]AgentInstance, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, preset_id, capabilities_json, state, created_at, last_used_at, expires_at
+		FROM agent_instances ORDER BY type, repo_full_name, name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	instances := []AgentInstance{}
+	for rows.Next() {
+		instance, err := scanAgentInstance(rows)
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, instance)
+	}
+	return instances, rows.Err()
+}
+
+func (s *Store) TouchAgentInstance(ctx context.Context, name string, now time.Time, idleTimeout time.Duration) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE agent_instances SET state = 'idle', last_used_at = ?, expires_at = ? WHERE name = ?`,
+		formatResourceLockTime(now), formatResourceLockTime(now.Add(idleTimeout)), name)
+	if err != nil {
+		return err
+	}
+	return requireAffected(result, "agent instance", name)
+}
+
+func (s *Store) MarkAgentInstanceRunning(ctx context.Context, name string, now time.Time, jobTimeout time.Duration) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE agent_instances SET state = 'running', last_used_at = ?, expires_at = ? WHERE name = ?`,
+		formatResourceLockTime(now), formatResourceLockTime(now.Add(jobTimeout)), name)
+	if err != nil {
+		return err
+	}
+	return requireAffected(result, "agent instance", name)
+}
+
+func (s *Store) DeleteExpiredAgentInstances(ctx context.Context, now time.Time) (int64, error) {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM agent_instances
+		WHERE state = 'idle'
+			AND expires_at <= ?
+			AND NOT EXISTS (
+				SELECT 1 FROM jobs
+				WHERE jobs.agent = agent_instances.name
+					AND jobs.state IN ('queued', 'running', 'failed', 'blocked', 'cancelled')
+			)`, formatResourceLockTime(now))
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+func scanAgentInstance(row interface{ Scan(dest ...any) error }) (AgentInstance, error) {
+	var instance AgentInstance
+	var capabilities string
+	if err := row.Scan(&instance.Name, &instance.Type, &instance.Runtime, &instance.RuntimeRef, &instance.RepoFullName, &instance.Role, &instance.PresetID, &capabilities, &instance.State, &instance.CreatedAt, &instance.LastUsedAt, &instance.ExpiresAt); err != nil {
+		return AgentInstance{}, err
+	}
+	if strings.TrimSpace(capabilities) != "" {
+		if err := json.Unmarshal([]byte(capabilities), &instance.Capabilities); err != nil {
+			return AgentInstance{}, err
+		}
+	}
+	return instance, nil
 }
 
 func (s *Store) InsertGoal(ctx context.Context, goal Goal) error {
@@ -1070,6 +1270,14 @@ func formatResourceLockTime(value time.Time) string {
 	return value.UTC().Format("2006-01-02T15:04:05.000000000Z")
 }
 
+func normalizeStoredTime(value string) string {
+	value = strings.TrimSpace(value)
+	if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return formatResourceLockTime(parsed)
+	}
+	return value
+}
+
 func (s *Store) AcquireLock(ctx context.Context, lock BranchLock) (bool, error) {
 	created, err := s.CreateLock(ctx, lock)
 	if err != nil {
@@ -1507,5 +1715,21 @@ CREATE TABLE resource_locks (
 	`,
 	`
 ALTER TABLE resource_locks ADD COLUMN owner_token TEXT NOT NULL DEFAULT '';
+	`,
+	`
+CREATE TABLE agent_instances (
+	name TEXT PRIMARY KEY,
+	type TEXT NOT NULL,
+	runtime TEXT NOT NULL,
+	runtime_ref TEXT NOT NULL,
+	repo_full_name TEXT NOT NULL,
+	role TEXT NOT NULL,
+	preset_id TEXT NOT NULL DEFAULT '',
+	capabilities_json TEXT NOT NULL DEFAULT '[]',
+	state TEXT NOT NULL,
+	created_at TEXT NOT NULL,
+	last_used_at TEXT NOT NULL,
+	expires_at TEXT NOT NULL
+);
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -225,6 +225,121 @@ func TestResourceLockDoesNotRecoverExpiredRunningOwner(t *testing.T) {
 	}
 }
 
+func TestAgentInstanceMethods(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	instance := AgentInstance{
+		Name:         "planner-bg-1",
+		Type:         "planner",
+		Runtime:      "codex",
+		RuntimeRef:   "550e8400-e29b-41d4-a716-446655440101",
+		RepoFullName: "owner/repo",
+		Role:         "planner",
+		Capabilities: []string{"ask"},
+		State:        "idle",
+		CreatedAt:    formatResourceLockTime(now),
+		LastUsedAt:   formatResourceLockTime(now),
+		ExpiresAt:    formatResourceLockTime(now.Add(time.Minute)),
+	}
+	if err := store.UpsertAgentInstance(ctx, instance); err != nil {
+		t.Fatalf("UpsertAgentInstance returned error: %v", err)
+	}
+	agent, err := store.GetAgent(ctx, instance.Name)
+	if err != nil {
+		t.Fatalf("GetAgent fallback returned error: %v", err)
+	}
+	if agent.Name != instance.Name || agent.RuntimeRef != instance.RuntimeRef || strings.Join(agent.Capabilities, ",") != "ask" {
+		t.Fatalf("fallback agent = %+v", agent)
+	}
+	allowed, err := store.AgentCanAccessRepo(ctx, instance.Name, "owner/repo")
+	if err != nil {
+		t.Fatalf("AgentCanAccessRepo returned error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("agent instance was not allowed on its repo")
+	}
+	reusable, ok, err := store.FindReusableAgentInstance(ctx, "planner", "owner/repo", now.Add(30*time.Second))
+	if err != nil || !ok {
+		t.Fatalf("FindReusableAgentInstance returned instance=%+v ok=%v err=%v", reusable, ok, err)
+	}
+	count, err := store.CountActiveAgentInstances(ctx, "planner", now.Add(30*time.Second))
+	if err != nil || count != 1 {
+		t.Fatalf("CountActiveAgentInstances = %d err=%v, want 1 nil", count, err)
+	}
+	if err := store.MarkAgentInstanceRunning(ctx, instance.Name, now.Add(time.Minute), 5*time.Minute); err != nil {
+		t.Fatalf("MarkAgentInstanceRunning returned error: %v", err)
+	}
+	if _, ok, err := store.FindReusableAgentInstance(ctx, "planner", "owner/repo", now.Add(30*time.Second)); err != nil || ok {
+		t.Fatalf("running FindReusableAgentInstance ok=%v err=%v, want false nil", ok, err)
+	}
+	if active, ok, err := store.FindActiveAgentInstance(ctx, "planner", "owner/repo", now.Add(30*time.Second)); err != nil || !ok || active.Name != instance.Name {
+		t.Fatalf("FindActiveAgentInstance returned instance=%+v ok=%v err=%v", active, ok, err)
+	}
+	deleted, err := store.DeleteExpiredAgentInstances(ctx, now.Add(4*time.Minute))
+	if err != nil {
+		t.Fatalf("running DeleteExpiredAgentInstances returned error: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("running expired instances deleted = %d, want 0", deleted)
+	}
+	if err := store.TouchAgentInstance(ctx, instance.Name, now.Add(2*time.Minute), time.Minute); err != nil {
+		t.Fatalf("TouchAgentInstance returned error: %v", err)
+	}
+	count, err = store.CountActiveAgentInstances(ctx, "planner", now.Add(4*time.Minute))
+	if err != nil || count != 0 {
+		t.Fatalf("expired idle CountActiveAgentInstances = %d err=%v, want 0 nil", count, err)
+	}
+	if err := store.CreateJob(ctx, Job{ID: "job-planner-1", Agent: instance.Name, Type: "ask", State: "queued", Payload: "{}"}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	count, err = store.CountActiveAgentInstances(ctx, "planner", now.Add(4*time.Minute))
+	if err != nil || count != 1 {
+		t.Fatalf("expired queued CountActiveAgentInstances = %d err=%v, want 1 nil", count, err)
+	}
+	if active, ok, err := store.FindActiveAgentInstance(ctx, "planner", "owner/repo", now.Add(4*time.Minute)); err != nil || !ok || active.Name != instance.Name {
+		t.Fatalf("expired queued FindActiveAgentInstance returned instance=%+v ok=%v err=%v", active, ok, err)
+	}
+	deleted, err = store.DeleteExpiredAgentInstances(ctx, now.Add(4*time.Minute))
+	if err != nil {
+		t.Fatalf("DeleteExpiredAgentInstances returned error: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("expired instance with queued job deleted = %d, want 0", deleted)
+	}
+	if ok, err := store.TransitionJobState(ctx, "job-planner-1", "queued", "done"); err != nil || !ok {
+		t.Fatalf("TransitionJobState returned ok=%v err=%v", ok, err)
+	}
+	if err := store.UpsertAgentInstance(ctx, instance); err != nil {
+		t.Fatalf("UpsertAgentInstance returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, Job{ID: "job-planner-retryable", Agent: instance.Name, Type: "ask", State: "failed", Payload: "{}"}); err != nil {
+		t.Fatalf("CreateJob retryable returned error: %v", err)
+	}
+	deleted, err = store.DeleteExpiredAgentInstances(ctx, now.Add(4*time.Minute))
+	if err != nil {
+		t.Fatalf("retryable DeleteExpiredAgentInstances returned error: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("expired instance with retryable job deleted = %d, want 0", deleted)
+	}
+	if ok, err := store.TransitionJobState(ctx, "job-planner-retryable", "failed", "done"); err != nil || !ok {
+		t.Fatalf("TransitionJobState retryable returned ok=%v err=%v", ok, err)
+	}
+	deleted, err = store.DeleteExpiredAgentInstances(ctx, now.Add(4*time.Minute))
+	if err != nil {
+		t.Fatalf("DeleteExpiredAgentInstances returned error: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expired instances deleted after queued job completed = %d, want 1", deleted)
+	}
+}
+
 func TestRepositoryMethods(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
WHAT: Add managed background agent types for on-demand Codex/Claude runtime sessions.

WHY: Gitmoot needs a simpler background execution model where users can configure an agent type once, enqueue background asks by type, and let the daemon reuse or start bounded runtime sessions.

CHANGES:
- Added `[agents.<type>]` config load/save support with runtime, preset, role, capabilities, `max_background`, `idle_timeout`, and `job_timeout`.
- Added `agent_instances` persistence and store helpers for reusable, active, running, expired, and GC-safe managed instances.
- Added `gitmoot agent type list|show|set`, `gitmoot agent gc`, and `gitmoot agent ask ... --type <type>` support.
- Added managed runtime startup for Codex/Claude with preset startup prompts and background-only dispatch.
- Added managed job timeout handling and instance state transitions in the daemon/job worker path.
- Added global agent-type reservation and max-background enforcement, plus GC protection for retryable jobs.
- Added focused config, store, CLI, and managed background ask regression tests.

RESULTS:
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/config ./internal/db ./internal/cli`
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/db ./internal/cli`
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./...`
- `git diff --check`
- `git diff --cached --check`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:

```text
No discrete correctness issues were found in the staged code changes or untracked goal documents. Test execution could not be completed because the required Go 1.26 toolchain download is blocked by the read-only module cache in this environment.
No discrete correctness issues were found in the staged code changes or untracked goal documents. Test execution could not be completed because the required Go 1.26 toolchain download is blocked by the read-only module cache in this environment.
```

RISK:
- Review sandbox could not run tests because it used host Go 1.22 with `GOTOOLCHAIN=local`; local verification used the cached Go 1.26.2 toolchain required by `go.mod`.
- `GOAL-AGENT-EXECUTION-UX.md` and `GOAL-README-UPDATE.md` are intentionally untracked and not included in this PR.
