### PR TITLE
feat: add lightweight planner workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,17 @@ gitmoot agent start planner \
   --start-daemon
 ```
 
-Ask the registered agent directly from a local shell or from a runtime chat that
-can call shell commands:
+For fast planning in the current Codex or Claude chat, ask the runtime:
+
+```text
+Use the Gitmoot planner here. Write the implementation plan.
+```
+
+Ask the registered background planner when you want a queued Gitmoot job:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
+gitmoot job watch <job-id>
 ```
 
 Route work through PR comments:

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,8 +28,16 @@ This root `SKILL.md` is kept as a raw compatibility entrypoint for agents and
 Gitmoot is a local-first coordinator for AI agents working across repositories,
 goals, reviews, PR comments, and runtime workflows. Use this skill when the
 user wants PR-comment agent workflows, repo-scoped agent subscriptions,
-background daemon checks, Codex or Claude Code agent startup, preset agents,
-custom prompt agents, job status, or branch lock inspection.
+background daemon checks, Codex or Claude Code agent startup, structured
+implementation plans, standard goal files, preset agents, custom prompt agents,
+job status, or branch lock inspection.
+
+For fast planning, "use the Gitmoot planner here" means read and apply the
+repo `skills/gitmoot/presets/gitmoot-plan-lite.md` instructions in this current
+chat. In an installed Gitmoot skill package, use the packaged
+`presets/gitmoot-plan-lite.md` path. Do not route that request through a
+background `gitmoot agent ask` unless the user explicitly asks for background
+execution, PR-comment routing, or job tracking.
 
 ## Before Acting
 
@@ -88,9 +96,10 @@ Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`
 only when the user explicitly wants a foreground process.
 
 Use `gitmoot agent ask` when the user wants to invoke a registered Gitmoot
-agent from the current local chat. This is the same agent registry and runtime
-adapter path used by PR-comment ask jobs; the plugin only helps the runtime
-discover this skill and does not replace the `gitmoot` CLI.
+agent from the current local chat. Add `--background` only when the user wants a
+queued background job. This is the same agent registry and runtime adapter path
+used by PR-comment ask jobs; the plugin only helps the runtime discover this
+skill and does not replace the `gitmoot` CLI.
 
 ## PR Comment Commands
 

--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -236,8 +236,11 @@ it on a real PR.
    ```sh
    /tmp/gitmoot-current goal template | grep "codex exec review is clean; ready for manual /review."
    /tmp/gitmoot-current preset list --home "$GITMOOT_SMOKE_HOME" | grep gitmoot-plan-and-goal
+   /tmp/gitmoot-current preset list --home "$GITMOOT_SMOKE_HOME" | grep gitmoot-plan-lite
    /tmp/gitmoot-current preset update --home "$GITMOOT_SMOKE_HOME" gitmoot-plan-and-goal
+   /tmp/gitmoot-current preset update --home "$GITMOOT_SMOKE_HOME" gitmoot-plan-lite
    /tmp/gitmoot-current preset show --home "$GITMOOT_SMOKE_HOME" gitmoot-plan-and-goal
+   /tmp/gitmoot-current preset show --home "$GITMOOT_SMOKE_HOME" gitmoot-plan-lite
    ```
 
 3. From the test repo checkout, start the planner agent.
@@ -286,6 +289,8 @@ Expected signals:
 - `goal template` prints the canonical PR-per-task prompt.
 - `preset show` displays `default role: planner`, `default capabilities: ask`,
   and `mutation: true`.
+- `preset show gitmoot-plan-lite` displays `default role: planner`,
+  `default capabilities: ask`, and `mutation: false`.
 - `agent doctor planner-smoke` succeeds.
 - `agent ask planner-smoke` prints `state: succeeded`, `agent: planner-smoke`,
   `action: ask`, and a planner summary.

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -61,6 +61,11 @@ The plugins are guidance and discovery surfaces. They do not replace
 `gitmoot daemon start`, agent registration, GitHub CLI authentication, or the
 local SQLite workflow state.
 
+For fast planning in the current Codex or Claude chat, ask the runtime to use
+the Gitmoot planner here. That applies the lightweight `gitmoot-plan-lite`
+instructions directly in the current conversation and avoids the startup cost of
+a background planner job.
+
 If a Codex or Claude chat wants to invoke a registered Gitmoot agent directly,
 it should run `gitmoot agent ask <agent> --repo owner/repo "..."`. That uses the
 same local agent registry and runtime adapter path as PR-comment ask jobs.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -91,20 +91,32 @@ The agent should read the bundled skill, verify `gitmoot version`, check
 `gh auth status` before PR workflows, and use read-only Gitmoot status commands
 before mutating daemon, agent, job, or lock state.
 
-When you want the current Codex chat to invoke a registered Gitmoot agent, route
-that request through the CLI:
+For fast planning in the current Codex chat, do not route through a background
+planner unless the user asks for a queued job. Ask Codex:
 
 ```text
-$gitmoot:gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+Use the Gitmoot planner here. Write the implementation plan.
+```
+
+Codex should apply the packaged `presets/gitmoot-plan-lite.md` instructions,
+inspect the relevant repo files, search only for current external contracts when
+needed, and return the plan directly in the current conversation.
+
+When you want the current Codex chat to invoke a registered background-capable
+Gitmoot agent, route that request through the CLI:
+
+```text
+$gitmoot:gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
 ```
 
 Without the chat command bridge, ask Codex to run the same shell command:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
+gitmoot job watch <job-id>
 ```
 
-This keeps local chat asks on the same Gitmoot agent registry, repo access,
+This keeps background asks on the same Gitmoot agent registry, repo access,
 runtime adapter, cached preset, and job history path as PR-comment ask jobs.
 
 ## Use From Claude Code
@@ -120,14 +132,19 @@ Claude should use the bundled Gitmoot skill content as guidance, then call the
 local `gitmoot` CLI only when the user asks for setup, status, agent
 coordination, or PR-comment workflow help.
 
-For a registered-agent ask from Claude Code, use the same CLI command:
+For a registered background-agent ask from Claude Code, use the same CLI
+command:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
+gitmoot job watch <job-id>
 ```
 
 The plugin is discovery and guidance. The `gitmoot` CLI is still the execution
 path.
+
+For fast current-chat planning, ask Claude Code to use the Gitmoot planner here
+instead of starting a background `gitmoot agent ask` job.
 
 ## Troubleshooting
 

--- a/internal/cli/preset_test.go
+++ b/internal/cli/preset_test.go
@@ -42,6 +42,37 @@ func TestPresetUpdateInstallsThermoPreset(t *testing.T) {
 	}
 }
 
+func TestPresetUpdateInstallsLitePlannerPreset(t *testing.T) {
+	restore := replacePresetFetcher(fakePresetFetcher{
+		commit:  "fed789",
+		content: "Plan quickly.",
+	})
+	defer restore()
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+
+	code := Run([]string{"preset", "update", "--home", home, "gitmoot-plan-lite"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("preset update exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "updated gitmoot-plan-lite at fed789") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"preset", "show", "--home", home, "gitmoot-plan-lite"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("preset show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"name: Gitmoot Plan Lite", "default role: planner", "default capabilities: ask", "mutation: false", "Plan quickly."} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("show output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
 func TestPresetDiffDoesNotMutateCachedPreset(t *testing.T) {
 	restore := replacePresetFetcher(fakePresetFetcher{
 		commit:  "abc123",
@@ -92,7 +123,7 @@ func TestPresetListShowsAvailableBuiltin(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("preset list exit code = %d, stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "thermo-nuclear-code-quality-review") || !strings.Contains(stdout.String(), "gitmoot-plan-and-goal") || !strings.Contains(stdout.String(), "available") {
+	if !strings.Contains(stdout.String(), "thermo-nuclear-code-quality-review") || !strings.Contains(stdout.String(), "gitmoot-plan-and-goal") || !strings.Contains(stdout.String(), "gitmoot-plan-lite") || !strings.Contains(stdout.String(), "available") {
 		t.Fatalf("stdout = %s", stdout.String())
 	}
 }

--- a/internal/pluginpack/pluginpack_test.go
+++ b/internal/pluginpack/pluginpack_test.go
@@ -115,10 +115,11 @@ func TestBuildUsesEmbeddedSkillByDefault(t *testing.T) {
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "SKILL.md"), "Gitmoot Agent Skill")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "SKILL.md"), "gitmoot agent ask <agent>")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "CLI.md"), "gitmoot agent ask planner --repo owner/repo")
-	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "WORKFLOWS.md"), "separate skill-only planning path")
+	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "WORKFLOWS.md"), "Planner Here")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "GOAL_TEMPLATE.md"), "codex exec review is clean; ready for manual /review.")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "RESULT_CONTRACT.md"), "gitmoot_result")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "presets", "gitmoot-plan-and-goal.md"), "Gitmoot Plan And Goal Writer")
+	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "presets", "gitmoot-plan-lite.md"), "Gitmoot Plan Lite")
 }
 
 func TestBuildRefusesOverwriteWithoutForce(t *testing.T) {

--- a/internal/preset/preset.go
+++ b/internal/preset/preset.go
@@ -20,6 +20,7 @@ import (
 
 const ThermoNuclearCodeQualityReviewID = "thermo-nuclear-code-quality-review"
 const GitmootPlanAndGoalID = "gitmoot-plan-and-goal"
+const GitmootPlanLiteID = "gitmoot-plan-lite"
 const LocalSourceRepo = "local"
 const LocalSourceRef = "file"
 const DefaultLocalDescription = "Local custom prompt preset."
@@ -69,6 +70,17 @@ var builtins = []Definition{
 		SourceRepo:          "jerryfane/gitmoot",
 		SourceRef:           "main",
 		SourcePath:          "skills/gitmoot/presets/gitmoot-plan-and-goal.md",
+	},
+	{
+		ID:                  GitmootPlanLiteID,
+		Name:                "Gitmoot Plan Lite",
+		Description:         "Fast structured planning preset for current-chat Gitmoot workflows.",
+		DefaultRole:         "planner",
+		DefaultCapabilities: []string{"ask"},
+		Mutation:            false,
+		SourceRepo:          "jerryfane/gitmoot",
+		SourceRef:           "main",
+		SourcePath:          "skills/gitmoot/presets/gitmoot-plan-lite.md",
 	},
 }
 

--- a/internal/preset/preset_test.go
+++ b/internal/preset/preset_test.go
@@ -16,8 +16,8 @@ import (
 
 func TestBuiltinsIncludesPlannerAndThermoPresets(t *testing.T) {
 	definitions := Builtins()
-	if len(definitions) != 2 {
-		t.Fatalf("builtin count = %d, want 2", len(definitions))
+	if len(definitions) != 3 {
+		t.Fatalf("builtin count = %d, want 3", len(definitions))
 	}
 	thermo, ok := Lookup(ThermoNuclearCodeQualityReviewID)
 	if !ok {
@@ -35,6 +35,16 @@ func TestBuiltinsIncludesPlannerAndThermoPresets(t *testing.T) {
 	}
 	if planner.SourceRepo != "jerryfane/gitmoot" || planner.SourcePath != "skills/gitmoot/presets/gitmoot-plan-and-goal.md" {
 		t.Fatalf("planner source = %+v", planner)
+	}
+	lite, ok := Lookup(GitmootPlanLiteID)
+	if !ok {
+		t.Fatal("lite planner preset missing")
+	}
+	if lite.Mutation || lite.DefaultRole != "planner" || !reflect.DeepEqual(lite.DefaultCapabilities, []string{"ask"}) {
+		t.Fatalf("lite planner definition = %+v", lite)
+	}
+	if lite.SourceRepo != "jerryfane/gitmoot" || lite.SourcePath != "skills/gitmoot/presets/gitmoot-plan-lite.md" {
+		t.Fatalf("lite planner source = %+v", lite)
 	}
 }
 
@@ -54,6 +64,25 @@ func TestUpdatePlannerPreset(t *testing.T) {
 	}
 	if updated.SourceRepo != "jerryfane/gitmoot" || updated.SourcePath != "skills/gitmoot/presets/gitmoot-plan-and-goal.md" {
 		t.Fatalf("updated source = %+v", updated)
+	}
+}
+
+func TestUpdateLitePlannerPreset(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	updated, err := Update(ctx, store, fakeFetcher{commit: "fed789", content: "Plan quickly."}, GitmootPlanLiteID)
+	if err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+	if updated.ID != GitmootPlanLiteID || updated.ResolvedCommit != "fed789" || updated.Content != "Plan quickly." {
+		t.Fatalf("updated lite planner preset = %+v", updated)
+	}
+	if updated.SourceRepo != "jerryfane/gitmoot" || updated.SourcePath != "skills/gitmoot/presets/gitmoot-plan-lite.md" {
+		t.Fatalf("updated lite source = %+v", updated)
 	}
 }
 

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -90,6 +90,7 @@ func TestCanonicalSkillDocumentsLocalAgentAsk(t *testing.T) {
 			want: []string{
 				"gitmoot agent ask <agent>",
 				"The plugin is only the runtime discovery surface",
+				"presets/gitmoot-plan-lite.md",
 			},
 		},
 		{
@@ -105,7 +106,7 @@ func TestCanonicalSkillDocumentsLocalAgentAsk(t *testing.T) {
 			text: workflows,
 			want: []string{
 				"gitmoot agent ask planner --repo owner/repo",
-				"separate skill-only planning path",
+				"Planner Here",
 			},
 		},
 	} {
@@ -143,6 +144,7 @@ func TestRootSkillCompatibilityEntrypoint(t *testing.T) {
 	}
 	for _, want := range []string{
 		"skills/gitmoot/",
+		"skills/gitmoot/presets/gitmoot-plan-lite.md",
 		"gitmoot.io/SKILL.md",
 		"gitmoot_result",
 		"branch locks",

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -17,6 +17,11 @@ background daemon checks, Codex or Claude Code agent startup, structured
 implementation plans, standard goal files, preset agents, custom prompt agents,
 job status, or branch lock inspection.
 
+For fast planning, "use the Gitmoot planner here" means read and apply the
+packaged `presets/gitmoot-plan-lite.md` instructions in this current chat. Do
+not route that request through a background `gitmoot agent ask` unless the user
+explicitly asks for background execution, PR-comment routing, or job tracking.
+
 ## Before Acting
 
 1. Check whether `gitmoot` is installed with `gitmoot version`.
@@ -32,11 +37,11 @@ job status, or branch lock inspection.
 Use `gitmoot status --repo owner/repo` for repo status, `gitmoot daemon status`
 for daemon state, `gitmoot agent list` for registered agents, and
 `gitmoot agent ask <agent> --repo owner/repo "..."` to invoke a registered
-Gitmoot agent from the current local chat. Use
-`gitmoot job list --repo owner/repo` for queued or recent jobs. Use
-`gitmoot plugin doctor` when checking whether Codex or Claude Code can discover
-Gitmoot through an installed runtime plugin. Use `gitmoot goal template` when
-writing a standard task-by-task goal file.
+Gitmoot agent from the current local chat. Add `--background` only when the user
+wants a queued background job. Use `gitmoot job list --repo owner/repo` for
+queued or recent jobs. Use `gitmoot plugin doctor` when checking whether Codex
+or Claude Code can discover Gitmoot through an installed runtime plugin. Use
+`gitmoot goal template` when writing a standard task-by-task goal file.
 
 The plugin is only the runtime discovery surface for this skill. Local agent
 invocation still goes through the `gitmoot` CLI and the same registered agent,

--- a/skills/gitmoot/presets/gitmoot-plan-lite.md
+++ b/skills/gitmoot/presets/gitmoot-plan-lite.md
@@ -1,0 +1,28 @@
+# Gitmoot Plan Lite
+
+You are a Gitmoot planner for fast current-chat planning. Your job is to turn a
+feature request into a clean task-by-task implementation plan. Create a goal
+file only when the user explicitly asks for one after the plan.
+
+## Planning Workflow
+
+1. Inspect the current repo state and only the relevant files needed to plan.
+2. Use web search when the plan depends on current external APIs, CLI
+   contracts, docs, standards, package behavior, deployment behavior, or
+   best-practice claims. Prefer official or primary sources.
+3. Ask clarifying questions only for high-impact decisions that cannot be
+   discovered from the repo or official sources.
+4. Write a decision-complete plan that another engineer or agent can implement
+   without guessing.
+5. Split the plan into tasks. Each task should include scope, acceptance
+   criteria, tests/checks, and a suggested commit message.
+6. Preserve existing behavior unless the request explicitly changes it. Avoid
+   broad rewrites.
+7. Avoid code duplication. When repeated logic appears, call out the helper or
+   abstraction that should be reused or extracted.
+
+## Output
+
+Return the plan directly in the current chat. Keep it concise, but include
+enough detail for safe implementation. Do not start implementation, create a
+branch, open a PR, or write a goal file unless the user explicitly asks.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -95,7 +95,7 @@ gitmoot agent doctor reviewer
 Ask a registered agent from the current local chat:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
 gitmoot agent ask planner --repo owner/repo --json "Return the plan status."
 ```
 
@@ -117,7 +117,7 @@ gitmoot agent start thermo-review \
   --start-daemon
 ```
 
-Install or refresh the built-in planner preset:
+Install or refresh the built-in full planner/goal preset:
 
 ```sh
 gitmoot preset update gitmoot-plan-and-goal
@@ -128,6 +128,23 @@ gitmoot agent start planner \
   --preset gitmoot-plan-and-goal \
   --start-daemon
 ```
+
+Install or refresh the lightweight planner preset when you want to run a
+planner as a registered background-capable agent:
+
+```sh
+gitmoot preset update gitmoot-plan-lite
+gitmoot agent start planner-lite \
+  --runtime codex \
+  --repo owner/repo \
+  --path . \
+  --preset gitmoot-plan-lite \
+  --start-daemon
+```
+
+For fast current-chat planning, use the Gitmoot skill with the packaged
+`presets/gitmoot-plan-lite.md` instructions instead of starting a background
+job. The CLI cannot control an already-running Codex or Claude chat.
 
 Create a local custom prompt preset:
 

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -69,10 +69,26 @@ Custom preset content is snapshotted into local Gitmoot state. After editing the
 source prompt file, run `gitmoot preset diff <id>` and `gitmoot preset update
 <id>` before expecting new jobs to use the changed prompt.
 
-## Planner And Goal File Agent
+## Planner Here
+
+Use the lightweight planner in the current Codex or Claude chat when the user
+wants a fast implementation plan and the current session already has the repo
+context. Read the packaged `presets/gitmoot-plan-lite.md` instructions, inspect
+only the relevant files, use web search only for current external contracts or
+best-practice claims, and return the plan directly in chat.
+
+```text
+Use the Gitmoot planner here. Write a task-by-task implementation plan for this feature.
+```
+
+If the user later asks for a standard goal file, read the canonical goal
+template and write the goal file then. Do not create the goal file during the
+lite planning pass unless explicitly requested.
+
+## Background Planner Agent
 
 Use the planner preset when the user wants a structured implementation plan or a
-standard Gitmoot goal file.
+standard Gitmoot goal file to run as a tracked Gitmoot background agent job.
 
 ```sh
 gitmoot preset update gitmoot-plan-and-goal
@@ -91,16 +107,19 @@ Ask from a PR comment:
 ```
 
 Ask directly from a local Codex or Claude Code chat by having the runtime call
-the Gitmoot CLI:
+the Gitmoot CLI when the user explicitly wants a registered background-capable
+agent path:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write a task-by-task implementation plan for this feature, then create the goal file prompt."
+gitmoot agent ask planner --repo owner/repo --background "Write a task-by-task implementation plan for this feature, then create the goal file prompt."
+gitmoot job watch <job-id>
 ```
 
 If the Codex plugin exposes a Gitmoot command bridge in chat, the equivalent
-form is `$gitmoot:gitmoot agent ask planner --repo owner/repo "..."`. The
-important part is that the request goes through `gitmoot agent ask`, not a
-separate skill-only planning path.
+form is `$gitmoot:gitmoot agent ask planner --repo owner/repo --background "..."`. The
+important part is that background planner work goes through `gitmoot agent ask`;
+fast "here" planning stays in the current chat and does not claim to control the
+current chat through a CLI command.
 
 If the planner writes a goal file and the user wants Gitmoot to track it, import
 it explicitly:

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -22,10 +22,17 @@ gitmoot agent start planner \
   --start-daemon
 ```
 
-Ask the agent directly:
+For fast planning in the current Codex or Claude chat, ask the runtime:
+
+```text
+Use the Gitmoot planner here. Write the implementation plan.
+```
+
+Ask the registered background planner when you want a queued Gitmoot job:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
+gitmoot job watch <job-id>
 ```
 
 Or route work through PR comments:
@@ -43,4 +50,3 @@ gitmoot status --repo owner/repo
 gitmoot job list --repo owner/repo
 gitmoot events --repo owner/repo
 ```
-

--- a/website/docs/plugins/codex-claude.md
+++ b/website/docs/plugins/codex-claude.md
@@ -11,17 +11,24 @@ gitmoot plugin doctor
 ```
 
 The plugins do not replace the CLI. Use the CLI for agent registration, daemon
-management, status checks, and direct agent asks.
+management, status checks, and background agent asks.
 
-From a runtime chat that supports command execution:
+For fast planning in the current chat, ask the runtime:
 
 ```text
-$gitmoot:gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+Use the Gitmoot planner here. Write the implementation plan.
+```
+
+For registered background-agent work from a runtime chat that supports command
+execution:
+
+```text
+$gitmoot:gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
 ```
 
 Without the command bridge, ask the runtime to run:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
+gitmoot job watch <job-id>
 ```
-

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -27,6 +27,7 @@ gitmoot daemon status
 gitmoot agent start <name> --runtime codex --repo owner/repo --preset <preset>
 gitmoot agent subscribe <name> --runtime codex --session <id> --repo owner/repo
 gitmoot agent ask <name> --repo owner/repo "question"
+gitmoot agent ask <name> --repo owner/repo --background "queued task"
 gitmoot agent list
 gitmoot agent doctor <name>
 ```
@@ -49,4 +50,3 @@ gitmoot job show <job-id>
 gitmoot job retry <job-id>
 gitmoot lock list --repo owner/repo
 ```
-

--- a/website/docs/workflows/planner-goal-workflow.md
+++ b/website/docs/workflows/planner-goal-workflow.md
@@ -13,10 +13,17 @@ gitmoot agent start planner \
   --start-daemon
 ```
 
-Ask the planner for a task-by-task plan:
+For fast planning in the current Codex or Claude chat, ask the runtime:
+
+```text
+Use the Gitmoot planner here. Write the implementation plan.
+```
+
+Ask the registered background planner when you want a queued Gitmoot job:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
+gitmoot job watch <job-id>
 ```
 
 Goal files should use task headings shaped like:
@@ -31,4 +38,3 @@ Then import and run tasks through Gitmoot:
 gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner planner --base main
 ```
-

--- a/website/scripts/build-llms-full.mjs
+++ b/website/scripts/build-llms-full.mjs
@@ -15,6 +15,8 @@ const sources = [
   'docs/troubleshooting.md',
   'docs/beta-smoke-tests.md',
   'skills/gitmoot/SKILL.md',
+  'skills/gitmoot/presets/gitmoot-plan-and-goal.md',
+  'skills/gitmoot/presets/gitmoot-plan-lite.md',
   'skills/gitmoot/references/CLI.md',
   'skills/gitmoot/references/WORKFLOWS.md',
   'skills/gitmoot/references/SAFETY.md',
@@ -39,4 +41,3 @@ for (const source of sources) {
 
 await mkdir(staticDir, {recursive: true});
 await writeFile(path.join(staticDir, 'llms-full.txt'), `${parts.join('')}\n`);
-

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -97,11 +97,17 @@ gitmoot agent start planner \
   --start-daemon
 ```
 
-Ask the registered agent directly from a local shell or from a runtime chat that
-can call shell commands:
+For fast planning in the current Codex or Claude chat, ask the runtime:
+
+```text
+Use the Gitmoot planner here. Write the implementation plan.
+```
+
+Ask the registered background planner when you want a queued Gitmoot job:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
+gitmoot job watch <job-id>
 ```
 
 Route work through PR comments:
@@ -298,8 +304,16 @@ This root `SKILL.md` is kept as a raw compatibility entrypoint for agents and
 Gitmoot is a local-first coordinator for AI agents working across repositories,
 goals, reviews, PR comments, and runtime workflows. Use this skill when the
 user wants PR-comment agent workflows, repo-scoped agent subscriptions,
-background daemon checks, Codex or Claude Code agent startup, preset agents,
-custom prompt agents, job status, or branch lock inspection.
+background daemon checks, Codex or Claude Code agent startup, structured
+implementation plans, standard goal files, preset agents, custom prompt agents,
+job status, or branch lock inspection.
+
+For fast planning, "use the Gitmoot planner here" means read and apply the
+repo `skills/gitmoot/presets/gitmoot-plan-lite.md` instructions in this current
+chat. In an installed Gitmoot skill package, use the packaged
+`presets/gitmoot-plan-lite.md` path. Do not route that request through a
+background `gitmoot agent ask` unless the user explicitly asks for background
+execution, PR-comment routing, or job tracking.
 
 ## Before Acting
 
@@ -358,9 +372,10 @@ Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`
 only when the user explicitly wants a foreground process.
 
 Use `gitmoot agent ask` when the user wants to invoke a registered Gitmoot
-agent from the current local chat. This is the same agent registry and runtime
-adapter path used by PR-comment ask jobs; the plugin only helps the runtime
-discover this skill and does not replace the `gitmoot` CLI.
+agent from the current local chat. Add `--background` only when the user wants a
+queued background job. This is the same agent registry and runtime adapter path
+used by PR-comment ask jobs; the plugin only helps the runtime discover this
+skill and does not replace the `gitmoot` CLI.
 
 ## PR Comment Commands
 
@@ -519,6 +534,11 @@ gitmoot plugin doctor
 The plugins are guidance and discovery surfaces. They do not replace
 `gitmoot daemon start`, agent registration, GitHub CLI authentication, or the
 local SQLite workflow state.
+
+For fast planning in the current Codex or Claude chat, ask the runtime to use
+the Gitmoot planner here. That applies the lightweight `gitmoot-plan-lite`
+instructions directly in the current conversation and avoids the startup cost of
+a background planner job.
 
 If a Codex or Claude chat wants to invoke a registered Gitmoot agent directly,
 it should run `gitmoot agent ask <agent> --repo owner/repo "..."`. That uses the
@@ -890,20 +910,32 @@ The agent should read the bundled skill, verify `gitmoot version`, check
 `gh auth status` before PR workflows, and use read-only Gitmoot status commands
 before mutating daemon, agent, job, or lock state.
 
-When you want the current Codex chat to invoke a registered Gitmoot agent, route
-that request through the CLI:
+For fast planning in the current Codex chat, do not route through a background
+planner unless the user asks for a queued job. Ask Codex:
 
 ```text
-$gitmoot:gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+Use the Gitmoot planner here. Write the implementation plan.
+```
+
+Codex should apply the packaged `presets/gitmoot-plan-lite.md` instructions,
+inspect the relevant repo files, search only for current external contracts when
+needed, and return the plan directly in the current conversation.
+
+When you want the current Codex chat to invoke a registered background-capable
+Gitmoot agent, route that request through the CLI:
+
+```text
+$gitmoot:gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
 ```
 
 Without the chat command bridge, ask Codex to run the same shell command:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
+gitmoot job watch <job-id>
 ```
 
-This keeps local chat asks on the same Gitmoot agent registry, repo access,
+This keeps background asks on the same Gitmoot agent registry, repo access,
 runtime adapter, cached preset, and job history path as PR-comment ask jobs.
 
 ## Use From Claude Code
@@ -919,14 +951,19 @@ Claude should use the bundled Gitmoot skill content as guidance, then call the
 local `gitmoot` CLI only when the user asks for setup, status, agent
 coordination, or PR-comment workflow help.
 
-For a registered-agent ask from Claude Code, use the same CLI command:
+For a registered background-agent ask from Claude Code, use the same CLI
+command:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
+gitmoot job watch <job-id>
 ```
 
 The plugin is discovery and guidance. The `gitmoot` CLI is still the execution
 path.
+
+For fast current-chat planning, ask Claude Code to use the Gitmoot planner here
+instead of starting a background `gitmoot agent ask` job.
 
 ## Troubleshooting
 
@@ -1668,8 +1705,11 @@ it on a real PR.
    ```sh
    /tmp/gitmoot-current goal template | grep "codex exec review is clean; ready for manual /review."
    /tmp/gitmoot-current preset list --home "$GITMOOT_SMOKE_HOME" | grep gitmoot-plan-and-goal
+   /tmp/gitmoot-current preset list --home "$GITMOOT_SMOKE_HOME" | grep gitmoot-plan-lite
    /tmp/gitmoot-current preset update --home "$GITMOOT_SMOKE_HOME" gitmoot-plan-and-goal
+   /tmp/gitmoot-current preset update --home "$GITMOOT_SMOKE_HOME" gitmoot-plan-lite
    /tmp/gitmoot-current preset show --home "$GITMOOT_SMOKE_HOME" gitmoot-plan-and-goal
+   /tmp/gitmoot-current preset show --home "$GITMOOT_SMOKE_HOME" gitmoot-plan-lite
    ```
 
 3. From the test repo checkout, start the planner agent.
@@ -1718,6 +1758,8 @@ Expected signals:
 - `goal template` prints the canonical PR-per-task prompt.
 - `preset show` displays `default role: planner`, `default capabilities: ask`,
   and `mutation: true`.
+- `preset show gitmoot-plan-lite` displays `default role: planner`,
+  `default capabilities: ask`, and `mutation: false`.
 - `agent doctor planner-smoke` succeeds.
 - `agent ask planner-smoke` prints `state: succeeded`, `agent: planner-smoke`,
   `action: ask`, and a planner summary.
@@ -1980,7 +2022,7 @@ exact-owner stale lock; use `--force` only when the stored owner is stale.
 
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, PR comments, daemon jobs, branch locks, presets, custom prompt agents, and Codex or Claude Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, jobs, branch locks, presets, custom prompt agents, and Codex or Claude Code runtime workflows.
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
 metadata:
@@ -1997,6 +2039,11 @@ background daemon checks, Codex or Claude Code agent startup, structured
 implementation plans, standard goal files, preset agents, custom prompt agents,
 job status, or branch lock inspection.
 
+For fast planning, "use the Gitmoot planner here" means read and apply the
+packaged `presets/gitmoot-plan-lite.md` instructions in this current chat. Do
+not route that request through a background `gitmoot agent ask` unless the user
+explicitly asks for background execution, PR-comment routing, or job tracking.
+
 ## Before Acting
 
 1. Check whether `gitmoot` is installed with `gitmoot version`.
@@ -2012,11 +2059,11 @@ job status, or branch lock inspection.
 Use `gitmoot status --repo owner/repo` for repo status, `gitmoot daemon status`
 for daemon state, `gitmoot agent list` for registered agents, and
 `gitmoot agent ask <agent> --repo owner/repo "..."` to invoke a registered
-Gitmoot agent from the current local chat. Use
-`gitmoot job list --repo owner/repo` for queued or recent jobs. Use
-`gitmoot plugin doctor` when checking whether Codex or Claude Code can discover
-Gitmoot through an installed runtime plugin. Use `gitmoot goal template` when
-writing a standard task-by-task goal file.
+Gitmoot agent from the current local chat. Add `--background` only when the user
+wants a queued background job. Use `gitmoot job list --repo owner/repo` for
+queued or recent jobs. Use `gitmoot plugin doctor` when checking whether Codex
+or Claude Code can discover Gitmoot through an installed runtime plugin. Use
+`gitmoot goal template` when writing a standard task-by-task goal file.
 
 The plugin is only the runtime discovery surface for this skill. Local agent
 invocation still goes through the `gitmoot` CLI and the same registered agent,
@@ -2050,6 +2097,93 @@ For detailed safety and lock rules, read [SAFETY.md](references/SAFETY.md).
 
 Reread this `SKILL.md`, then inspect `/gitmoot help`, `gitmoot status`, and the
 relevant job events before acting.
+
+---
+
+# Source: skills/gitmoot/presets/gitmoot-plan-and-goal.md
+
+# Gitmoot Plan And Goal Writer
+
+You are a Gitmoot planner agent. Your job is to turn feature requests into
+clean implementation plans and, when asked, write a standard Gitmoot goal file.
+
+## Planning Workflow
+
+1. Inspect the current repo state and relevant existing patterns before writing
+   the plan.
+2. Use web search when the request depends on current external APIs, CLI
+   contracts, docs, standards, package behavior, deployment behavior, or
+   best-practice claims. Prefer official or primary sources.
+3. Ask clarifying questions only for high-impact product decisions that cannot
+   be discovered from the repo or official sources.
+4. Write a decision-complete plan that another engineer or agent can implement
+   without guessing.
+5. Split the plan into tasks. Each task should have a clear scope, PR boundary,
+   acceptance criteria, tests/checks, and suggested commit message.
+6. Keep the plan clean and organized. Preserve existing behavior unless the
+   requested feature explicitly changes it. Avoid broad rewrites.
+7. Avoid code duplication. When repeated logic appears, call out the helper or
+   abstraction that should be reused or extracted.
+
+## Goal File Workflow
+
+When asked to write the goal file:
+
+1. Read the canonical standard template with:
+
+   ```sh
+   gitmoot goal template
+   ```
+
+2. Create a goal file named `GOAL-<short-slug>.md`.
+3. Fill the template with the approved plan.
+4. Ensure each implementation task uses a heading in this exact form:
+
+   ```markdown
+   ### Task N: Task Title
+   ```
+
+5. Return the exact prompt the user should run:
+
+   ```text
+   /goal GOAL-<short-slug>.md
+   ```
+
+Do not implement the planned feature unless the user explicitly asks after the
+plan and goal file are complete.
+
+---
+
+# Source: skills/gitmoot/presets/gitmoot-plan-lite.md
+
+# Gitmoot Plan Lite
+
+You are a Gitmoot planner for fast current-chat planning. Your job is to turn a
+feature request into a clean task-by-task implementation plan. Create a goal
+file only when the user explicitly asks for one after the plan.
+
+## Planning Workflow
+
+1. Inspect the current repo state and only the relevant files needed to plan.
+2. Use web search when the plan depends on current external APIs, CLI
+   contracts, docs, standards, package behavior, deployment behavior, or
+   best-practice claims. Prefer official or primary sources.
+3. Ask clarifying questions only for high-impact decisions that cannot be
+   discovered from the repo or official sources.
+4. Write a decision-complete plan that another engineer or agent can implement
+   without guessing.
+5. Split the plan into tasks. Each task should include scope, acceptance
+   criteria, tests/checks, and a suggested commit message.
+6. Preserve existing behavior unless the request explicitly changes it. Avoid
+   broad rewrites.
+7. Avoid code duplication. When repeated logic appears, call out the helper or
+   abstraction that should be reused or extracted.
+
+## Output
+
+Return the plan directly in the current chat. Keep it concise, but include
+enough detail for safe implementation. Do not start implementation, create a
+branch, open a PR, or write a goal file unless the user explicitly asks.
 
 ---
 
@@ -2152,7 +2286,7 @@ gitmoot agent doctor reviewer
 Ask a registered agent from the current local chat:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write the implementation plan and goal file."
+gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
 gitmoot agent ask planner --repo owner/repo --json "Return the plan status."
 ```
 
@@ -2174,7 +2308,7 @@ gitmoot agent start thermo-review \
   --start-daemon
 ```
 
-Install or refresh the built-in planner preset:
+Install or refresh the built-in full planner/goal preset:
 
 ```sh
 gitmoot preset update gitmoot-plan-and-goal
@@ -2185,6 +2319,23 @@ gitmoot agent start planner \
   --preset gitmoot-plan-and-goal \
   --start-daemon
 ```
+
+Install or refresh the lightweight planner preset when you want to run a
+planner as a registered background-capable agent:
+
+```sh
+gitmoot preset update gitmoot-plan-lite
+gitmoot agent start planner-lite \
+  --runtime codex \
+  --repo owner/repo \
+  --path . \
+  --preset gitmoot-plan-lite \
+  --start-daemon
+```
+
+For fast current-chat planning, use the Gitmoot skill with the packaged
+`presets/gitmoot-plan-lite.md` instructions instead of starting a background
+job. The CLI cannot control an already-running Codex or Claude chat.
 
 Create a local custom prompt preset:
 
@@ -2322,10 +2473,26 @@ Custom preset content is snapshotted into local Gitmoot state. After editing the
 source prompt file, run `gitmoot preset diff <id>` and `gitmoot preset update
 <id>` before expecting new jobs to use the changed prompt.
 
-## Planner And Goal File Agent
+## Planner Here
+
+Use the lightweight planner in the current Codex or Claude chat when the user
+wants a fast implementation plan and the current session already has the repo
+context. Read the packaged `presets/gitmoot-plan-lite.md` instructions, inspect
+only the relevant files, use web search only for current external contracts or
+best-practice claims, and return the plan directly in chat.
+
+```text
+Use the Gitmoot planner here. Write a task-by-task implementation plan for this feature.
+```
+
+If the user later asks for a standard goal file, read the canonical goal
+template and write the goal file then. Do not create the goal file during the
+lite planning pass unless explicitly requested.
+
+## Background Planner Agent
 
 Use the planner preset when the user wants a structured implementation plan or a
-standard Gitmoot goal file.
+standard Gitmoot goal file to run as a tracked Gitmoot background agent job.
 
 ```sh
 gitmoot preset update gitmoot-plan-and-goal
@@ -2344,16 +2511,19 @@ Ask from a PR comment:
 ```
 
 Ask directly from a local Codex or Claude Code chat by having the runtime call
-the Gitmoot CLI:
+the Gitmoot CLI when the user explicitly wants a registered background-capable
+agent path:
 
 ```sh
-gitmoot agent ask planner --repo owner/repo "Write a task-by-task implementation plan for this feature, then create the goal file prompt."
+gitmoot agent ask planner --repo owner/repo --background "Write a task-by-task implementation plan for this feature, then create the goal file prompt."
+gitmoot job watch <job-id>
 ```
 
 If the Codex plugin exposes a Gitmoot command bridge in chat, the equivalent
-form is `$gitmoot:gitmoot agent ask planner --repo owner/repo "..."`. The
-important part is that the request goes through `gitmoot agent ask`, not a
-separate skill-only planning path.
+form is `$gitmoot:gitmoot agent ask planner --repo owner/repo --background "..."`. The
+important part is that background planner work goes through `gitmoot agent ask`;
+fast "here" planning stays in the current chat and does not claim to control the
+current chat through a CLI command.
 
 If the planner writes a goal file and the user wants Gitmoot to track it, import
 it explicitly:


### PR DESCRIPTION
WHAT:
- Adds a lightweight `gitmoot-plan-lite` built-in preset for fast current-chat planning.
- Updates Gitmoot skill, plugin, README, docs, smoke tests, and LLM context so current-chat planning is distinct from queued background planner jobs.

WHY:
- The full background planner path is useful for auditable queued work, but too slow for simple planning in an already-open Codex or Claude chat.
- Runtime plugin guidance needed a clear path that does not imply Gitmoot can control the current chat through `gitmoot agent ask`.

CHANGES:
- Added `gitmoot-plan-lite` preset metadata and packaged preset Markdown.
- Added/updated preset, plugin-pack, and skill regression tests.
- Documented “Use the Gitmoot planner here” as the fast current-chat flow.
- Changed background examples to use `gitmoot agent ask ... --background` plus `gitmoot job watch`.
- Regenerated `website/static/llms-full.txt` with both planner preset sources included.

RESULTS:
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/skill ./internal/pluginpack ./internal/preset ./internal/cli`
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./...`
- `cd website && npm run build`
- `node website/scripts/build-llms-full.mjs`
- `git diff --cached --check && git diff --check`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:
```
I did not find any discrete, actionable bugs in the staged or untracked changes. The new preset wiring, docs updates, and generated llms-full output appear consistent with the current code paths.
```

RISK:
- No skipped checks.
- Host `GOTOOLCHAIN=local go test` is not used because `/usr/bin/go` is 1.22 while this repo requires Go 1.26; cached Go 1.26.2 toolchain test runs are the verification source.
- Untracked `GOAL-AGENT-EXECUTION-UX.md` and `GOAL-README-UPDATE.md` were intentionally excluded from this PR.