### PR TITLE
docs: explain here and background agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ gitmoot agent ask planner --repo owner/repo --background "Write the implementati
 gitmoot job watch <job-id>
 ```
 
+Background jobs are conservative by default. The daemon starts with one worker,
+runtime session locks serialize jobs for the same Codex or Claude session, repo
+checkout locks protect local checkouts, and branch locks protect implementation
+ownership.
+
 Route work through PR comments:
 
 ```text

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,6 +39,12 @@ chat. In an installed Gitmoot skill package, use the packaged
 background `gitmoot agent ask` unless the user explicitly asks for background
 execution, PR-comment routing, or job tracking.
 
+For background work, keep Gitmoot's resource model explicit: repo checkout
+locks protect local checkouts, runtime session locks serialize delivery for the
+same Codex or Claude session, and branch locks protect implementation ownership.
+The daemon default is `--workers 1`; raise it only for independent runtime
+sessions or managed agent types with `max_background` greater than one.
+
 ## Before Acting
 
 1. Check whether `gitmoot` is installed with `gitmoot version`.

--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -521,6 +521,50 @@ Expected signals:
   gitmoot agent repos shell-smoke
   ```
 
+## Execution Model Smoke Test
+
+Goal: verify the final `here` versus `background` execution model and the
+resource scheduling rules.
+
+1. Confirm fast planner guidance does not start a background runtime job.
+
+   In a Codex or Claude chat with the Gitmoot skill installed, ask:
+
+   ```text
+   Use the Gitmoot planner here. Write a task-by-task implementation plan for a README wording update.
+   ```
+
+   Expected signal: the answer appears directly in the current chat, and
+   `gitmoot job list --repo owner/project` does not gain a new planner job.
+
+2. Queue two background asks to the same registered Codex or Claude agent.
+
+   ```sh
+   gitmoot agent ask planner --repo owner/project --background "Say first OK."
+   gitmoot agent ask planner --repo owner/project --background "Say second OK."
+   gitmoot job watch <first-job-id>
+   gitmoot job watch <second-job-id>
+   ```
+
+   Expected signal: both jobs finish, but their `job events` do not show
+   overlapping runtime delivery for the same `runtime:<runtime>:<runtime_ref>`.
+   If the session is already busy, the later job records `runtime_lock_wait` and
+   remains queued until a worker can retry it.
+
+3. Queue background asks that can use independent managed instances.
+
+   ```sh
+   gitmoot agent type set planner --runtime codex --preset gitmoot-plan-lite --max-background 2 --idle-timeout 20m
+   gitmoot daemon start --repo owner/project --workers 2
+   gitmoot agent ask planner --repo owner/project --background "Say planner A OK."
+   gitmoot agent ask planner --repo owner/project --background "Say planner B OK."
+   gitmoot job list --repo owner/project
+   ```
+
+   Expected signal: Gitmoot may create or reuse up to two managed planner
+   instances, different runtime references can run concurrently, and
+   `gitmoot agent gc` later removes expired idle instances.
+
 ## Recovery Checks
 
 Run these against one smoke job if you need to verify recovery UX:

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -23,6 +23,10 @@ gitmoot preset update thermo-nuclear-code-quality-review
 gitmoot agent start <name> --runtime codex|claude --repo owner/repo --path . --preset thermo-nuclear-code-quality-review --start-daemon
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
 gitmoot agent ask <name> "message" --repo owner/repo
+gitmoot agent ask <name> --background --repo owner/repo "message"
+gitmoot agent type list
+gitmoot agent type show planner
+gitmoot agent gc
 gitmoot agent start thermo-review --runtime codex --repo owner/repo --preset thermo-nuclear-code-quality-review
 gitmoot agent allow <name> --repo owner/repo
 gitmoot agent repos <name>
@@ -32,12 +36,13 @@ gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot job list
 gitmoot job show <job-id>
+gitmoot job watch <job-id>
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>
 gitmoot status --repo owner/repo
 gitmoot version --json
 gitmoot update --check
-gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon start --repo owner/repo --poll 30s --workers 1
 gitmoot daemon start
 gitmoot daemon status
 ```
@@ -69,6 +74,33 @@ a background planner job.
 If a Codex or Claude chat wants to invoke a registered Gitmoot agent directly,
 it should run `gitmoot agent ask <agent> --repo owner/repo "..."`. That uses the
 same local agent registry and runtime adapter path as PR-comment ask jobs.
+
+## Execution Model
+
+Gitmoot has two execution paths:
+
+- **Here**: the current Codex or Claude chat reads Gitmoot skill and preset
+  instructions directly. This does not create a Gitmoot job and is the fastest
+  path for planning when the current chat already has context.
+- **Background**: Gitmoot creates a job, records events in SQLite, and the
+  daemon or `gitmoot job run <job-id>` delivers that job through the runtime
+  adapter.
+
+Background execution uses separate resource categories:
+
+- **Repo checkout locks**: daemon-side mutexes that prevent two enabled repo
+  ticks from mutating the same checkout at once.
+- **Runtime session locks**: SQLite resource locks keyed as
+  `runtime:<runtime>:<runtime_ref>`, shared by daemon jobs, `job run`, and
+  synchronous `agent ask`, so one Codex or Claude session is never resumed by
+  two jobs at the same time.
+- **Branch locks**: workflow ownership records used for implementation and
+  merge safety.
+
+The daemon defaults to `--workers 1`. Raise `--workers` only when the Gitmoot
+home has independent runtime sessions or managed agent types with
+`max_background` greater than one. Jobs that target the same runtime session or
+same checkout remain serialized even when the worker count is higher.
 
 ## End-To-End Demo Path
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -200,6 +200,33 @@ longer recoverable:
 gitmoot lock release owner/repo <branch> --force
 ```
 
+## Runtime Session Lock Waits
+
+Symptoms:
+
+- `gitmoot agent ask` fails with `runtime session ... is busy`.
+- A background job remains queued and its events include `runtime_lock_wait`.
+- Increasing `--workers` does not make two jobs run against the same Codex or
+  Claude session.
+
+Checks:
+
+```sh
+gitmoot job show <job-id>
+gitmoot job events <job-id>
+gitmoot daemon status
+gitmoot agent list
+```
+
+Fixes:
+
+- Wait for the active job using the same runtime session to finish.
+- Use a different registered agent or managed background instance when the work
+  is independent.
+- Keep `gitmoot daemon start --workers 1` unless you have multiple independent
+  runtime sessions or an agent type with `max_background` greater than one.
+- Use `gitmoot agent gc` to remove expired managed background instances.
+
 ## Malformed Agent Output
 
 Symptoms:

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -54,8 +54,8 @@ func runDaemon(args []string, stdout, stderr io.Writer) int {
 
 func printDaemonUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot daemon start [--repo owner/repo] [--poll 30s]")
-	fmt.Fprintln(w, "  gitmoot daemon run [--repo owner/repo] [--poll 30s]")
+	fmt.Fprintln(w, "  gitmoot daemon start [--repo owner/repo] [--poll 30s] [--workers 1]")
+	fmt.Fprintln(w, "  gitmoot daemon run [--repo owner/repo] [--poll 30s] [--workers 1]")
 	fmt.Fprintln(w, "  gitmoot daemon stop")
 	fmt.Fprintln(w, "  gitmoot daemon restart")
 	fmt.Fprintln(w, "  gitmoot daemon status")
@@ -1347,23 +1347,7 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 		}
 	}
 	for len(pending) > 0 {
-		queued := make([]db.Job, 0, limit)
-		remaining := make([]db.Job, 0, len(pending))
-		selectedCheckouts := map[string]bool{}
-		selectedRuntimeResources := map[string]bool{}
-		for _, job := range pending {
-			checkoutKey := queuedJobCheckoutKey(job)
-			runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
-			if len(queued) == limit || selectedCheckouts[checkoutKey] || (runtimeKey != "" && selectedRuntimeResources[runtimeKey]) {
-				remaining = append(remaining, job)
-				continue
-			}
-			queued = append(queued, job)
-			selectedCheckouts[checkoutKey] = true
-			if runtimeKey != "" {
-				selectedRuntimeResources[runtimeKey] = true
-			}
-		}
+		queued, remaining := selectRunnableQueuedJobs(ctx, worker.Store, pending, limit)
 		if len(queued) == 0 {
 			return nil
 		}
@@ -1388,6 +1372,49 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 		}
 	}
 	return nil
+}
+
+type queuedJobResourceSelector struct {
+	limit     int
+	checkouts map[string]bool
+	runtimes  map[string]bool
+}
+
+func selectRunnableQueuedJobs(ctx context.Context, store *db.Store, pending []db.Job, limit int) ([]db.Job, []db.Job) {
+	if limit <= 0 {
+		return nil, pending
+	}
+	selector := queuedJobResourceSelector{
+		limit:     limit,
+		checkouts: map[string]bool{},
+		runtimes:  map[string]bool{},
+	}
+	queued := make([]db.Job, 0, min(limit, len(pending)))
+	remaining := make([]db.Job, 0, len(pending))
+	for _, job := range pending {
+		if selector.selects(ctx, store, job, len(queued)) {
+			queued = append(queued, job)
+			continue
+		}
+		remaining = append(remaining, job)
+	}
+	return queued, remaining
+}
+
+func (s queuedJobResourceSelector) selects(ctx context.Context, store *db.Store, job db.Job, selected int) bool {
+	if selected >= s.limit {
+		return false
+	}
+	checkoutKey := queuedJobCheckoutKey(job)
+	runtimeKey := queuedJobRuntimeResourceKey(ctx, store, job)
+	if s.checkouts[checkoutKey] || (runtimeKey != "" && s.runtimes[runtimeKey]) {
+		return false
+	}
+	s.checkouts[checkoutKey] = true
+	if runtimeKey != "" {
+		s.runtimes[runtimeKey] = true
+	}
+	return true
 }
 
 func queuedJobMatchesRepo(job db.Job, repoFilter string) bool {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -67,6 +67,8 @@ func TestCanonicalSkillDocumentsResultAndRereadGuidance(t *testing.T) {
 		"blocked",
 		"failed",
 		"branch locks",
+		"runtime session locks",
+		"--workers 1",
 		"Reread this `SKILL.md`",
 	} {
 		if !strings.Contains(text, want) {
@@ -99,6 +101,8 @@ func TestCanonicalSkillDocumentsLocalAgentAsk(t *testing.T) {
 			want: []string{
 				"gitmoot agent ask planner --repo owner/repo",
 				"replace `gitmoot agent ask`",
+				"gitmoot agent type set planner",
+				"gitmoot job watch <job-id>",
 			},
 		},
 		{
@@ -107,6 +111,8 @@ func TestCanonicalSkillDocumentsLocalAgentAsk(t *testing.T) {
 			want: []string{
 				"gitmoot agent ask planner --repo owner/repo",
 				"Planner Here",
+				"Execution Model",
+				"runtime:<runtime>:<runtime_ref>",
 			},
 		},
 	} {
@@ -148,6 +154,7 @@ func TestRootSkillCompatibilityEntrypoint(t *testing.T) {
 		"gitmoot.io/SKILL.md",
 		"gitmoot_result",
 		"branch locks",
+		"runtime session locks",
 		"gitmoot agent ask <agent>",
 	} {
 		if !strings.Contains(text, want) {

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -22,6 +22,12 @@ packaged `presets/gitmoot-plan-lite.md` instructions in this current chat. Do
 not route that request through a background `gitmoot agent ask` unless the user
 explicitly asks for background execution, PR-comment routing, or job tracking.
 
+For background work, keep Gitmoot's resource model explicit: repo checkout
+locks protect local checkouts, runtime session locks serialize delivery for the
+same Codex or Claude session, and branch locks protect implementation ownership.
+The daemon default is `--workers 1`; raise it only for independent runtime
+sessions or managed agent types with `max_background` greater than one.
+
 ## Before Acting
 
 1. Check whether `gitmoot` is installed with `gitmoot version`.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -48,14 +48,16 @@ Claude scopes are supported with `--scope user|project|local`. Codex ignores
 ```sh
 gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
-gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon start --repo owner/repo --poll 30s --workers 1
 gitmoot daemon status
 gitmoot daemon logs
 gitmoot daemon stop
 ```
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
-user explicitly wants a foreground process.
+user explicitly wants a foreground process. Keep the default `--workers 1`
+unless the Gitmoot home has multiple independent runtime sessions or managed
+agent types with `max_background` greater than one.
 
 ## Agent Setup
 
@@ -95,14 +97,25 @@ gitmoot agent doctor reviewer
 Ask a registered agent from the current local chat:
 
 ```sh
+gitmoot agent ask planner --repo owner/repo "Return the plan status."
 gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
-gitmoot agent ask planner --repo owner/repo --json "Return the plan status."
+gitmoot job watch <job-id>
 ```
 
 This uses the same agent registry, repo access grants, cached preset snapshot,
 runtime adapter, and local job history as PR-comment ask jobs. The runtime
 plugin helps Codex or Claude Code discover Gitmoot guidance, but it does not
-replace `gitmoot agent ask`.
+replace `gitmoot agent ask`. Synchronous asks and queued jobs both use the same
+runtime session locks.
+
+Configure managed background agent types:
+
+```sh
+gitmoot agent type list
+gitmoot agent type show planner
+gitmoot agent type set planner --runtime codex --preset gitmoot-plan-lite --max-background 2 --idle-timeout 20m
+gitmoot agent gc
+```
 
 ## Presets
 
@@ -200,6 +213,7 @@ Use GitHub PR comments as the public audit trail:
 ```sh
 gitmoot job list --repo owner/repo
 gitmoot job show <job-id>
+gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -128,6 +128,24 @@ it explicitly:
 gitmoot goal import --file GOAL-feature.md --repo owner/repo
 ```
 
+## Execution Model
+
+Use `here` when the current chat should answer directly from the Gitmoot skill.
+Use `background` when Gitmoot should create a tracked job, store events, and run
+through a runtime adapter.
+
+Background jobs are scheduled against three distinct resources:
+
+- repo checkout mutexes for daemon ticks that use the same local checkout;
+- runtime session locks keyed as `runtime:<runtime>:<runtime_ref>` for Codex
+  and Claude delivery;
+- branch locks for implementation ownership and merge safety.
+
+The daemon default is `--workers 1`. Users can raise it when jobs target
+different runtime sessions or managed agent types with `max_background` greater
+than one. Gitmoot still serializes jobs for the same runtime session or checkout
+even when more workers are configured.
+
 ## Multi-Repo Work
 
 Agents are global identities with explicit per-repo access. When working across

--- a/website/docs/concepts/agents-presets-jobs-locks.md
+++ b/website/docs/concepts/agents-presets-jobs-locks.md
@@ -30,7 +30,19 @@ Jobs are units of routed work. They can come from PR comments, local
 
 ## Locks
 
-Branch locks prevent multiple agents from racing on the same branch. Review and
-ask jobs usually inspect and report. Implementation jobs should only mutate
-branches when Gitmoot assigned the job and the branch lock is held.
+Gitmoot uses separate locks for separate resources:
 
+- Repo checkout locks keep daemon ticks from using the same local checkout at
+  the same time.
+- Runtime session locks serialize Codex or Claude delivery for the same
+  `runtime:<runtime>:<runtime_ref>` across daemon jobs, `job run`, and
+  synchronous `agent ask`.
+- Branch locks prevent multiple agents from racing on the same implementation
+  branch.
+
+Review and ask jobs usually inspect and report. Implementation jobs should only
+mutate branches when Gitmoot assigned the job and the branch lock is held.
+
+The daemon defaults to `--workers 1`. Raise workers only when jobs use
+independent runtime sessions or managed agent types with `max_background`
+greater than one.

--- a/website/docs/operations/beta-smoke-tests.md
+++ b/website/docs/operations/beta-smoke-tests.md
@@ -31,6 +31,20 @@ gitmoot events --repo owner/project
 gh pr view <number> --repo owner/project --comments
 ```
 
+## Execution Model Smoke
+
+Use the Gitmoot planner here from the current chat for fast planning, then use
+background asks when you need tracked jobs:
+
+```sh
+gitmoot agent ask planner --repo owner/project --background "Say OK."
+gitmoot job watch <job-id>
+gitmoot job events <job-id>
+```
+
+For concurrency checks, keep `--workers 1` by default and raise it only when
+jobs use independent runtime sessions or a managed agent type with
+`max_background` greater than one.
+
 For the detailed release smoke path, see
 [`docs/beta-smoke-tests.md`](https://github.com/jerryfane/gitmoot/blob/main/docs/beta-smoke-tests.md).
-

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -24,9 +24,15 @@ point at the wrong session if another runtime session starts later.
 
 ```sh
 gitmoot agent doctor <name>
+gitmoot job events <job-id>
 codex exec resume --help
 claude --help
 ```
+
+If a job reports `runtime_lock_wait` or `runtime session ... is busy`, another
+job is already using that Codex or Claude session. Wait for it to finish, use a
+different runtime session, or configure a managed agent type with
+`max_background` greater than one.
 
 ## Presets
 
@@ -46,4 +52,3 @@ gitmoot lock show owner/repo <branch>
 
 For the longer troubleshooting reference, see
 [`docs/troubleshooting.md`](https://github.com/jerryfane/gitmoot/blob/main/docs/troubleshooting.md).
-

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -17,7 +17,7 @@ gitmoot plugin doctor
 gitmoot init
 gitmoot repo add owner/repo --path . --poll 30s
 gitmoot status --repo owner/repo
-gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon start --repo owner/repo --poll 30s --workers 1
 gitmoot daemon status
 ```
 
@@ -28,6 +28,8 @@ gitmoot agent start <name> --runtime codex --repo owner/repo --preset <preset>
 gitmoot agent subscribe <name> --runtime codex --session <id> --repo owner/repo
 gitmoot agent ask <name> --repo owner/repo "question"
 gitmoot agent ask <name> --repo owner/repo --background "queued task"
+gitmoot agent type list
+gitmoot agent gc
 gitmoot agent list
 gitmoot agent doctor <name>
 ```
@@ -47,6 +49,7 @@ gitmoot preset diff <id>
 ```sh
 gitmoot job list --repo owner/repo
 gitmoot job show <job-id>
+gitmoot job watch <job-id>
 gitmoot job retry <job-id>
 gitmoot lock list --repo owner/repo
 ```

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -110,6 +110,11 @@ gitmoot agent ask planner --repo owner/repo --background "Write the implementati
 gitmoot job watch <job-id>
 ```
 
+Background jobs are conservative by default. The daemon starts with one worker,
+runtime session locks serialize jobs for the same Codex or Claude session, repo
+checkout locks protect local checkouts, and branch locks protect implementation
+ownership.
+
 Route work through PR comments:
 
 ```text
@@ -315,6 +320,12 @@ chat. In an installed Gitmoot skill package, use the packaged
 background `gitmoot agent ask` unless the user explicitly asks for background
 execution, PR-comment routing, or job tracking.
 
+For background work, keep Gitmoot's resource model explicit: repo checkout
+locks protect local checkouts, runtime session locks serialize delivery for the
+same Codex or Claude session, and branch locks protect implementation ownership.
+The daemon default is `--workers 1`; raise it only for independent runtime
+sessions or managed agent types with `max_background` greater than one.
+
 ## Before Acting
 
 1. Check whether `gitmoot` is installed with `gitmoot version`.
@@ -497,6 +508,10 @@ gitmoot preset update thermo-nuclear-code-quality-review
 gitmoot agent start <name> --runtime codex|claude --repo owner/repo --path . --preset thermo-nuclear-code-quality-review --start-daemon
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
 gitmoot agent ask <name> "message" --repo owner/repo
+gitmoot agent ask <name> --background --repo owner/repo "message"
+gitmoot agent type list
+gitmoot agent type show planner
+gitmoot agent gc
 gitmoot agent start thermo-review --runtime codex --repo owner/repo --preset thermo-nuclear-code-quality-review
 gitmoot agent allow <name> --repo owner/repo
 gitmoot agent repos <name>
@@ -506,12 +521,13 @@ gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot job list
 gitmoot job show <job-id>
+gitmoot job watch <job-id>
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>
 gitmoot status --repo owner/repo
 gitmoot version --json
 gitmoot update --check
-gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon start --repo owner/repo --poll 30s --workers 1
 gitmoot daemon start
 gitmoot daemon status
 ```
@@ -543,6 +559,33 @@ a background planner job.
 If a Codex or Claude chat wants to invoke a registered Gitmoot agent directly,
 it should run `gitmoot agent ask <agent> --repo owner/repo "..."`. That uses the
 same local agent registry and runtime adapter path as PR-comment ask jobs.
+
+## Execution Model
+
+Gitmoot has two execution paths:
+
+- **Here**: the current Codex or Claude chat reads Gitmoot skill and preset
+  instructions directly. This does not create a Gitmoot job and is the fastest
+  path for planning when the current chat already has context.
+- **Background**: Gitmoot creates a job, records events in SQLite, and the
+  daemon or `gitmoot job run <job-id>` delivers that job through the runtime
+  adapter.
+
+Background execution uses separate resource categories:
+
+- **Repo checkout locks**: daemon-side mutexes that prevent two enabled repo
+  ticks from mutating the same checkout at once.
+- **Runtime session locks**: SQLite resource locks keyed as
+  `runtime:<runtime>:<runtime_ref>`, shared by daemon jobs, `job run`, and
+  synchronous `agent ask`, so one Codex or Claude session is never resumed by
+  two jobs at the same time.
+- **Branch locks**: workflow ownership records used for implementation and
+  merge safety.
+
+The daemon defaults to `--workers 1`. Raise `--workers` only when the Gitmoot
+home has independent runtime sessions or managed agent types with
+`max_background` greater than one. Jobs that target the same runtime session or
+same checkout remain serialized even when the worker count is higher.
 
 ## End-To-End Demo Path
 
@@ -1397,6 +1440,33 @@ longer recoverable:
 gitmoot lock release owner/repo <branch> --force
 ```
 
+## Runtime Session Lock Waits
+
+Symptoms:
+
+- `gitmoot agent ask` fails with `runtime session ... is busy`.
+- A background job remains queued and its events include `runtime_lock_wait`.
+- Increasing `--workers` does not make two jobs run against the same Codex or
+  Claude session.
+
+Checks:
+
+```sh
+gitmoot job show <job-id>
+gitmoot job events <job-id>
+gitmoot daemon status
+gitmoot agent list
+```
+
+Fixes:
+
+- Wait for the active job using the same runtime session to finish.
+- Use a different registered agent or managed background instance when the work
+  is independent.
+- Keep `gitmoot daemon start --workers 1` unless you have multiple independent
+  runtime sessions or an agent type with `max_background` greater than one.
+- Use `gitmoot agent gc` to remove expired managed background instances.
+
 ## Malformed Agent Output
 
 Symptoms:
@@ -1990,6 +2060,50 @@ Expected signals:
   gitmoot agent repos shell-smoke
   ```
 
+## Execution Model Smoke Test
+
+Goal: verify the final `here` versus `background` execution model and the
+resource scheduling rules.
+
+1. Confirm fast planner guidance does not start a background runtime job.
+
+   In a Codex or Claude chat with the Gitmoot skill installed, ask:
+
+   ```text
+   Use the Gitmoot planner here. Write a task-by-task implementation plan for a README wording update.
+   ```
+
+   Expected signal: the answer appears directly in the current chat, and
+   `gitmoot job list --repo owner/project` does not gain a new planner job.
+
+2. Queue two background asks to the same registered Codex or Claude agent.
+
+   ```sh
+   gitmoot agent ask planner --repo owner/project --background "Say first OK."
+   gitmoot agent ask planner --repo owner/project --background "Say second OK."
+   gitmoot job watch <first-job-id>
+   gitmoot job watch <second-job-id>
+   ```
+
+   Expected signal: both jobs finish, but their `job events` do not show
+   overlapping runtime delivery for the same `runtime:<runtime>:<runtime_ref>`.
+   If the session is already busy, the later job records `runtime_lock_wait` and
+   remains queued until a worker can retry it.
+
+3. Queue background asks that can use independent managed instances.
+
+   ```sh
+   gitmoot agent type set planner --runtime codex --preset gitmoot-plan-lite --max-background 2 --idle-timeout 20m
+   gitmoot daemon start --repo owner/project --workers 2
+   gitmoot agent ask planner --repo owner/project --background "Say planner A OK."
+   gitmoot agent ask planner --repo owner/project --background "Say planner B OK."
+   gitmoot job list --repo owner/project
+   ```
+
+   Expected signal: Gitmoot may create or reuse up to two managed planner
+   instances, different runtime references can run concurrently, and
+   `gitmoot agent gc` later removes expired idle instances.
+
 ## Recovery Checks
 
 Run these against one smoke job if you need to verify recovery UX:
@@ -2043,6 +2157,12 @@ For fast planning, "use the Gitmoot planner here" means read and apply the
 packaged `presets/gitmoot-plan-lite.md` instructions in this current chat. Do
 not route that request through a background `gitmoot agent ask` unless the user
 explicitly asks for background execution, PR-comment routing, or job tracking.
+
+For background work, keep Gitmoot's resource model explicit: repo checkout
+locks protect local checkouts, runtime session locks serialize delivery for the
+same Codex or Claude session, and branch locks protect implementation ownership.
+The daemon default is `--workers 1`; raise it only for independent runtime
+sessions or managed agent types with `max_background` greater than one.
 
 ## Before Acting
 
@@ -2239,14 +2359,16 @@ Claude scopes are supported with `--scope user|project|local`. Codex ignores
 ```sh
 gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
-gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon start --repo owner/repo --poll 30s --workers 1
 gitmoot daemon status
 gitmoot daemon logs
 gitmoot daemon stop
 ```
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
-user explicitly wants a foreground process.
+user explicitly wants a foreground process. Keep the default `--workers 1`
+unless the Gitmoot home has multiple independent runtime sessions or managed
+agent types with `max_background` greater than one.
 
 ## Agent Setup
 
@@ -2286,14 +2408,25 @@ gitmoot agent doctor reviewer
 Ask a registered agent from the current local chat:
 
 ```sh
+gitmoot agent ask planner --repo owner/repo "Return the plan status."
 gitmoot agent ask planner --repo owner/repo --background "Write the implementation plan and goal file."
-gitmoot agent ask planner --repo owner/repo --json "Return the plan status."
+gitmoot job watch <job-id>
 ```
 
 This uses the same agent registry, repo access grants, cached preset snapshot,
 runtime adapter, and local job history as PR-comment ask jobs. The runtime
 plugin helps Codex or Claude Code discover Gitmoot guidance, but it does not
-replace `gitmoot agent ask`.
+replace `gitmoot agent ask`. Synchronous asks and queued jobs both use the same
+runtime session locks.
+
+Configure managed background agent types:
+
+```sh
+gitmoot agent type list
+gitmoot agent type show planner
+gitmoot agent type set planner --runtime codex --preset gitmoot-plan-lite --max-background 2 --idle-timeout 20m
+gitmoot agent gc
+```
 
 ## Presets
 
@@ -2391,6 +2524,7 @@ Use GitHub PR comments as the public audit trail:
 ```sh
 gitmoot job list --repo owner/repo
 gitmoot job show <job-id>
+gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>
@@ -2531,6 +2665,24 @@ it explicitly:
 ```sh
 gitmoot goal import --file GOAL-feature.md --repo owner/repo
 ```
+
+## Execution Model
+
+Use `here` when the current chat should answer directly from the Gitmoot skill.
+Use `background` when Gitmoot should create a tracked job, store events, and run
+through a runtime adapter.
+
+Background jobs are scheduled against three distinct resources:
+
+- repo checkout mutexes for daemon ticks that use the same local checkout;
+- runtime session locks keyed as `runtime:<runtime>:<runtime_ref>` for Codex
+  and Claude delivery;
+- branch locks for implementation ownership and merge safety.
+
+The daemon default is `--workers 1`. Users can raise it when jobs target
+different runtime sessions or managed agent types with `max_background` greater
+than one. Gitmoot still serializes jobs for the same runtime session or checkout
+even when more workers are configured.
 
 ## Multi-Repo Work
 


### PR DESCRIPTION
WHAT:
- Documents the final Gitmoot execution model across README, root/canonical skills, docs, website docs, and generated LLM context.
- Extracts daemon queued-job resource selection into a small helper while preserving existing scheduling behavior.
- Updates daemon help to show the conservative default `--workers 1`.

WHY:
- Users need a clear distinction between fast current-chat planning (`here`) and tracked Gitmoot background jobs.
- The worker/concurrency model needs to be explicit: repo checkout locks, runtime session locks, and branch locks are separate safety resources.

CHANGES:
- Added execution-model guidance for `here`, `background`, `max_background`, `idle_timeout`, runtime-session waits, and worker-count guidance.
- Added smoke-test docs for current-chat planner usage, same-session serialization, and managed instance concurrency.
- Updated CLI reference docs with `agent type`, `agent gc`, `job watch`, and `--workers 1`.
- Added skill regression expectations for runtime session locks and execution-model docs.
- Regenerated `website/static/llms-full.txt`.

RESULTS:
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/cli ./internal/skill`
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./...`
- `cd website && npm run build`
- `node website/scripts/build-llms-full.mjs`
- `git diff --cached --check && git diff --check`
- `rg -n "warm|ephemeral|pool|fleet" README.md SKILL.md docs skills/gitmoot website/docs || true`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:
```
No actionable correctness issues were found in the staged or untracked changes. `git diff --cached --check` passed; full Go tests could not run because this environment has Go 1.22 while go.mod requires Go 1.26 and toolchain download is blocked by filesystem permissions.
No actionable correctness issues were found in the staged or untracked changes. `git diff --cached --check` passed; full Go tests could not run because this environment has Go 1.22 while go.mod requires Go 1.26 and toolchain download is blocked by filesystem permissions.
```

RISK:
- No skipped project checks. The review subprocess could not run host `GOTOOLCHAIN=local go test ./...` because host Go is 1.22; the explicit cached Go 1.26.2 test runs passed.
- Untracked `GOAL-AGENT-EXECUTION-UX.md` and `GOAL-README-UPDATE.md` were intentionally excluded from this PR.