### PR TITLE
Add template capture instructions

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, PR comments, daemon jobs, branch locks, agent templates, custom prompt agents, and Codex or Claude Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, PR comments, daemon jobs, branch locks, agent templates, template capture, custom prompt agents, and Codex or Claude Code runtime workflows.
 version: 0.1.0
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
@@ -29,8 +29,8 @@ Gitmoot is a local-first coordinator for AI agents working across repositories,
 goals, reviews, PR comments, and runtime workflows. Use this skill when the
 user wants PR-comment agent workflows, repo-scoped agent subscriptions,
 background daemon checks, Codex or Claude Code agent startup, structured
-implementation plans, standard goal files, agent template workflows, custom prompt agents,
-job status, or branch lock inspection.
+implementation plans, standard goal files, agent template workflows, template
+capture, custom prompt agents, job status, or branch lock inspection.
 
 For current-chat prompt import, "use <agent> here" means run
 `gitmoot agent prompt <agent>` and apply the returned prompt content in this
@@ -42,6 +42,14 @@ For fast planning, "use the Gitmoot planner here" is the natural-language
 shortcut for `gitmoot agent prompt planner`. If the planner template is not
 cached, read and apply the packaged `skills/gitmoot/agent-templates/planner.md`
 instructions directly.
+
+For template capture, phrases like "capture this session as a Gitmoot agent
+template", "turn this workflow into a Gitmoot template", or "draft a reusable
+agent template from this chat" mean read
+`skills/gitmoot/references/TEMPLATE_CAPTURE.md` and distill the visible
+current-chat context into a draft template. Gitmoot cannot read hidden model
+memory or runtime internals. Do not install, overwrite, or update a permanent
+template unless the user explicitly approves that step.
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the

--- a/internal/pluginpack/pluginpack_test.go
+++ b/internal/pluginpack/pluginpack_test.go
@@ -117,6 +117,7 @@ func TestBuildUsesEmbeddedSkillByDefault(t *testing.T) {
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "SKILL.md"), "gitmoot agent prompt <agent>")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "CLI.md"), "gitmoot agent ask project-planner --repo owner/repo")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "WORKFLOWS.md"), "Current-Chat Custom Agent Prompt")
+	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "TEMPLATE_CAPTURE.md"), "Template capture is current-chat distillation")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "GOAL_TEMPLATE.md"), "codex exec review is clean; ready for manual /review.")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "references", "RESULT_CONTRACT.md"), "gitmoot_result")
 	assertFileContains(t, filepath.Join(out, "skills", "gitmoot", "agent-templates", "planner.md"), "Gitmoot Planner")

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -31,6 +31,7 @@ func TestCanonicalSkillFrontmatter(t *testing.T) {
 		"jobs",
 		"branch locks",
 		"agent-templates",
+		"template capture",
 		"custom prompt agents",
 		"Codex",
 		"Claude Code",
@@ -46,6 +47,7 @@ func TestCanonicalSkillReferencesExist(t *testing.T) {
 	for _, ref := range []string{
 		"references/CLI.md",
 		"references/WORKFLOWS.md",
+		"references/TEMPLATE_CAPTURE.md",
 		"references/GOAL_TEMPLATE.md",
 		"references/RESULT_CONTRACT.md",
 		"references/SAFETY.md",
@@ -93,6 +95,7 @@ func TestCanonicalSkillDocumentsLocalAgentAsk(t *testing.T) {
 				"gitmoot agent ask <agent>",
 				"The plugin is only the runtime discovery surface",
 				"gitmoot agent prompt <agent-or-template>",
+				"TEMPLATE_CAPTURE.md",
 			},
 		},
 		{
@@ -121,6 +124,42 @@ func TestCanonicalSkillDocumentsLocalAgentAsk(t *testing.T) {
 			if !strings.Contains(check.text, want) {
 				t.Fatalf("%s missing %q", check.name, want)
 			}
+		}
+	}
+}
+
+func TestCanonicalSkillDocumentsTemplateCapture(t *testing.T) {
+	text := readRepoFile(t, "skills", "gitmoot", "SKILL.md")
+	capture := readRepoFile(t, "skills", "gitmoot", "references", "TEMPLATE_CAPTURE.md")
+	for _, want := range []string{
+		"capture this session as a Gitmoot agent",
+		"template\", \"turn this workflow into a Gitmoot template\"",
+		"draft a reusable",
+		"agent template from this chat",
+		"cannot read hidden model memory",
+		"Do not install, overwrite,",
+		"or update a permanent template",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("canonical SKILL.md missing template capture guidance %q", want)
+		}
+	}
+	for _, want := range []string{
+		"Template capture is current-chat distillation",
+		"Draft Structure",
+		"## Role",
+		"## When To Use",
+		"## Workflow",
+		"## Inputs And Context",
+		"## Commands And Tools",
+		"## Output Contract",
+		"## Safety Rules",
+		"## Examples",
+		"## Non-Goals",
+		"gitmoot agent template add",
+	} {
+		if !strings.Contains(capture, want) {
+			t.Fatalf("TEMPLATE_CAPTURE.md missing %q", want)
 		}
 	}
 }
@@ -154,6 +193,7 @@ func TestRootSkillCompatibilityEntrypoint(t *testing.T) {
 		"gitmoot agent prompt <agent-or-template>",
 		"gitmoot.io/SKILL.md",
 		"gitmoot_result",
+		"template capture",
 		"branch locks",
 		"runtime session locks",
 		"gitmoot agent ask <agent>",

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, jobs, branch locks, agent-templates, custom prompt agents, and Codex or Claude Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, jobs, branch locks, agent-templates, template capture, custom prompt agents, and Codex or Claude Code runtime workflows.
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
 metadata:
@@ -15,7 +15,7 @@ goals, reviews, PR comments, and runtime workflows. Use this skill when the
 user wants PR-comment agent workflows, repo-scoped agent subscriptions,
 background daemon checks, Codex or Claude Code agent startup, structured
 implementation plans, standard goal files, agent template workflows, custom
-prompt agents, job status, or branch lock inspection.
+prompt agents, template capture, job status, or branch lock inspection.
 
 For current-chat prompt import, "use <agent> here" or "use Gitmoot agent
 <agent> here" means run `gitmoot agent prompt <agent>` and apply the returned
@@ -26,6 +26,13 @@ template is not cached, read and apply the packaged
 `agent-templates/planner.md` instructions directly. Do not route a "here"
 request through a background `gitmoot agent ask` unless the user explicitly
 asks for background execution, PR-comment routing, or job tracking.
+
+For template capture, phrases like "capture this session as a Gitmoot agent
+template", "turn this workflow into a Gitmoot template", or "draft a reusable
+agent template from this chat" mean read [TEMPLATE_CAPTURE.md](references/TEMPLATE_CAPTURE.md)
+and distill the visible current-chat context into a draft template. Gitmoot
+cannot read hidden model memory or runtime internals. Do not install, overwrite,
+or update a permanent template unless the user explicitly approves that step.
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
@@ -62,6 +69,8 @@ repo access, runtime adapter, and job history model used by PR-comment jobs.
 
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).
+For current-chat template capture, read
+[TEMPLATE_CAPTURE.md](references/TEMPLATE_CAPTURE.md).
 For the canonical goal prompt template, read
 [GOAL_TEMPLATE.md](references/GOAL_TEMPLATE.md) only when the user asks for a
 goal file.

--- a/skills/gitmoot/references/TEMPLATE_CAPTURE.md
+++ b/skills/gitmoot/references/TEMPLATE_CAPTURE.md
@@ -1,0 +1,109 @@
+# Template Capture
+
+Use template capture when the user wants to turn the current Codex or Claude
+Code session into a reusable Gitmoot agent template.
+
+Template capture is current-chat distillation. Gitmoot cannot read hidden model
+memory, runtime internals, or private state outside the visible conversation and
+files you inspect. Capture only durable, user-approved behavior that can be
+reused safely by future agents.
+
+## Trigger Phrases
+
+Use this workflow for requests like:
+
+- "capture this session as a Gitmoot agent template"
+- "turn this workflow into a Gitmoot template"
+- "draft a reusable agent template from this chat"
+- "make this current agent behavior reusable"
+
+Do not route template capture through `gitmoot agent ask`, PR comments, or the
+daemon unless the user explicitly asks for a background job. Capture from
+"here" means the current chat writes a draft.
+
+## Capture Rules
+
+- Draft first. Do not install, overwrite, or update a permanent template unless
+  the user explicitly approves that step.
+- Extract durable workflow rules, role, trigger conditions, inputs, commands,
+  output contract, safety rules, examples, and non-goals.
+- Exclude one-off mistakes, temporary debugging, private secrets, unrelated repo
+  details, hidden model memory, and unverified assumptions.
+- Prefer project-agnostic language unless the template is intentionally scoped
+  to one project or repo.
+- Preserve important user preferences that were corrected repeatedly, but write
+  them as actionable rules instead of emotional transcript summaries.
+- Mark uncertainty as a question or assumption rather than turning it into a
+  permanent instruction.
+- Ask before installing or replacing an existing template.
+
+## Draft Structure
+
+Use this structure for captured templates:
+
+```markdown
+# <Template Name>
+
+## Role
+
+Describe what this agent is responsible for.
+
+## When To Use
+
+List the request types, project contexts, or trigger phrases that should use
+this template.
+
+## Workflow
+
+Give the repeatable step-by-step operating procedure.
+
+## Inputs And Context
+
+List the files, commands, tools, docs, conversation context, or repo state the
+agent should inspect.
+
+## Commands And Tools
+
+List important CLI commands, runtime commands, web/source lookup requirements,
+or tool usage constraints.
+
+## Output Contract
+
+Describe exactly what the agent should return or create.
+
+## Safety Rules
+
+List boundaries, approval gates, non-destructive behavior, secret handling, and
+when to stop or ask.
+
+## Examples
+
+Provide a few concise example requests and the expected style of response.
+
+## Non-Goals
+
+List work this template should not do.
+```
+
+## Suggested Current-Chat Flow
+
+1. Confirm the requested template id and intended scope if unclear.
+2. Inspect relevant visible conversation context and repo files.
+3. Draft the markdown template in chat, or write it to the path the user
+   requested.
+4. Tell the user to check the draft against the structure above before
+   installing it:
+
+   ```sh
+   gitmoot agent template add <template-id> --file .gitmoot/templates/<template-id>.md
+   ```
+
+5. If the user approves installation, check that required sections are filled
+   in, then install with `gitmoot agent template add`.
+
+## Result Expectations
+
+The final capture response should say what was drafted, where it is saved if a
+file was written, whether validation ran, and whether the template was
+installed. If installation was not explicitly requested, say that the draft is
+not installed yet.

--- a/website/scripts/build-llms-full.mjs
+++ b/website/scripts/build-llms-full.mjs
@@ -18,6 +18,7 @@ const sources = [
   'skills/gitmoot/agent-templates/planner.md',
   'skills/gitmoot/references/CLI.md',
   'skills/gitmoot/references/WORKFLOWS.md',
+  'skills/gitmoot/references/TEMPLATE_CAPTURE.md',
   'skills/gitmoot/references/SAFETY.md',
   'skills/gitmoot/references/RESULT_CONTRACT.md',
   'skills/gitmoot/references/GOAL_TEMPLATE.md',

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -297,7 +297,7 @@ go vet ./...
 
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, PR comments, daemon jobs, branch locks, agent templates, custom prompt agents, and Codex or Claude Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, PR comments, daemon jobs, branch locks, agent templates, template capture, custom prompt agents, and Codex or Claude Code runtime workflows.
 version: 0.1.0
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
@@ -326,8 +326,8 @@ Gitmoot is a local-first coordinator for AI agents working across repositories,
 goals, reviews, PR comments, and runtime workflows. Use this skill when the
 user wants PR-comment agent workflows, repo-scoped agent subscriptions,
 background daemon checks, Codex or Claude Code agent startup, structured
-implementation plans, standard goal files, agent template workflows, custom prompt agents,
-job status, or branch lock inspection.
+implementation plans, standard goal files, agent template workflows, template
+capture, custom prompt agents, job status, or branch lock inspection.
 
 For current-chat prompt import, "use <agent> here" means run
 `gitmoot agent prompt <agent>` and apply the returned prompt content in this
@@ -339,6 +339,14 @@ For fast planning, "use the Gitmoot planner here" is the natural-language
 shortcut for `gitmoot agent prompt planner`. If the planner template is not
 cached, read and apply the packaged `skills/gitmoot/agent-templates/planner.md`
 instructions directly.
+
+For template capture, phrases like "capture this session as a Gitmoot agent
+template", "turn this workflow into a Gitmoot template", or "draft a reusable
+agent template from this chat" mean read
+`skills/gitmoot/references/TEMPLATE_CAPTURE.md` and distill the visible
+current-chat context into a draft template. Gitmoot cannot read hidden model
+memory or runtime internals. Do not install, overwrite, or update a permanent
+template unless the user explicitly approves that step.
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
@@ -2167,7 +2175,7 @@ exact-owner stale lock; use `--force` only when the stored owner is stale.
 
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, jobs, branch locks, agent-templates, custom prompt agents, and Codex or Claude Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, jobs, branch locks, agent-templates, template capture, custom prompt agents, and Codex or Claude Code runtime workflows.
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
 metadata:
@@ -2182,7 +2190,7 @@ goals, reviews, PR comments, and runtime workflows. Use this skill when the
 user wants PR-comment agent workflows, repo-scoped agent subscriptions,
 background daemon checks, Codex or Claude Code agent startup, structured
 implementation plans, standard goal files, agent template workflows, custom
-prompt agents, job status, or branch lock inspection.
+prompt agents, template capture, job status, or branch lock inspection.
 
 For current-chat prompt import, "use <agent> here" or "use Gitmoot agent
 <agent> here" means run `gitmoot agent prompt <agent>` and apply the returned
@@ -2193,6 +2201,13 @@ template is not cached, read and apply the packaged
 `agent-templates/planner.md` instructions directly. Do not route a "here"
 request through a background `gitmoot agent ask` unless the user explicitly
 asks for background execution, PR-comment routing, or job tracking.
+
+For template capture, phrases like "capture this session as a Gitmoot agent
+template", "turn this workflow into a Gitmoot template", or "draft a reusable
+agent template from this chat" mean read [TEMPLATE_CAPTURE.md](references/TEMPLATE_CAPTURE.md)
+and distill the visible current-chat context into a draft template. Gitmoot
+cannot read hidden model memory or runtime internals. Do not install, overwrite,
+or update a permanent template unless the user explicitly approves that step.
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
@@ -2229,6 +2244,8 @@ repo access, runtime adapter, and job history model used by PR-comment jobs.
 
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).
+For current-chat template capture, read
+[TEMPLATE_CAPTURE.md](references/TEMPLATE_CAPTURE.md).
 For the canonical goal prompt template, read
 [GOAL_TEMPLATE.md](references/GOAL_TEMPLATE.md) only when the user asks for a
 goal file.
@@ -2734,6 +2751,120 @@ gitmoot agent allow reviewer --repo owner/project-b
 gitmoot status --repo owner/project-a
 gitmoot status --repo owner/project-b
 ```
+
+---
+
+# Source: skills/gitmoot/references/TEMPLATE_CAPTURE.md
+
+# Template Capture
+
+Use template capture when the user wants to turn the current Codex or Claude
+Code session into a reusable Gitmoot agent template.
+
+Template capture is current-chat distillation. Gitmoot cannot read hidden model
+memory, runtime internals, or private state outside the visible conversation and
+files you inspect. Capture only durable, user-approved behavior that can be
+reused safely by future agents.
+
+## Trigger Phrases
+
+Use this workflow for requests like:
+
+- "capture this session as a Gitmoot agent template"
+- "turn this workflow into a Gitmoot template"
+- "draft a reusable agent template from this chat"
+- "make this current agent behavior reusable"
+
+Do not route template capture through `gitmoot agent ask`, PR comments, or the
+daemon unless the user explicitly asks for a background job. Capture from
+"here" means the current chat writes a draft.
+
+## Capture Rules
+
+- Draft first. Do not install, overwrite, or update a permanent template unless
+  the user explicitly approves that step.
+- Extract durable workflow rules, role, trigger conditions, inputs, commands,
+  output contract, safety rules, examples, and non-goals.
+- Exclude one-off mistakes, temporary debugging, private secrets, unrelated repo
+  details, hidden model memory, and unverified assumptions.
+- Prefer project-agnostic language unless the template is intentionally scoped
+  to one project or repo.
+- Preserve important user preferences that were corrected repeatedly, but write
+  them as actionable rules instead of emotional transcript summaries.
+- Mark uncertainty as a question or assumption rather than turning it into a
+  permanent instruction.
+- Ask before installing or replacing an existing template.
+
+## Draft Structure
+
+Use this structure for captured templates:
+
+```markdown
+# <Template Name>
+
+## Role
+
+Describe what this agent is responsible for.
+
+## When To Use
+
+List the request types, project contexts, or trigger phrases that should use
+this template.
+
+## Workflow
+
+Give the repeatable step-by-step operating procedure.
+
+## Inputs And Context
+
+List the files, commands, tools, docs, conversation context, or repo state the
+agent should inspect.
+
+## Commands And Tools
+
+List important CLI commands, runtime commands, web/source lookup requirements,
+or tool usage constraints.
+
+## Output Contract
+
+Describe exactly what the agent should return or create.
+
+## Safety Rules
+
+List boundaries, approval gates, non-destructive behavior, secret handling, and
+when to stop or ask.
+
+## Examples
+
+Provide a few concise example requests and the expected style of response.
+
+## Non-Goals
+
+List work this template should not do.
+```
+
+## Suggested Current-Chat Flow
+
+1. Confirm the requested template id and intended scope if unclear.
+2. Inspect relevant visible conversation context and repo files.
+3. Draft the markdown template in chat, or write it to the path the user
+   requested.
+4. Tell the user to check the draft against the structure above before
+   installing it:
+
+   ```sh
+   gitmoot agent template add <template-id> --file .gitmoot/templates/<template-id>.md
+   ```
+
+5. If the user approves installation, check that required sections are filled
+   in, then install with `gitmoot agent template add`.
+
+## Result Expectations
+
+The final capture response should say what was drafted, where it is saved if a
+file was written, whether validation ran, and whether the template was
+installed. If installation was not explicitly requested, say that the draft is
+not installed yet.
 
 ---
 


### PR DESCRIPTION
WHAT:
- Added packaged current-chat template capture instructions.
- Updated Gitmoot skill discovery/routing and raw SKILL compatibility entrypoint.
- Included the new reference in plugin packaging tests and published llms-full generation.

WHY:
- Users need a clear draft-first workflow for turning visible current-session behavior into reusable Gitmoot agent templates without implying hidden runtime memory extraction.

CHANGES:
- Added skills/gitmoot/references/TEMPLATE_CAPTURE.md.
- Updated SKILL.md and skills/gitmoot/SKILL.md with template capture discovery and routing guidance.
- Updated skill/plugin packaging tests.
- Added TEMPLATE_CAPTURE.md to website/scripts/build-llms-full.mjs and refreshed website/static/llms-full.txt.

RESULTS:
- /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/skill ./internal/pluginpack
- npm run build:llms
- git diff --cached --check
- codex exec review --uncommitted

Final codex exec review --uncommitted output:
```text
No discrete correctness, packaging, or documentation-contract bugs were found in the current changes.
```

RISK:
- Default go command on this host attempts to download go1.26 and fails; tests were run with the installed Go 1.26.2 toolchain path.
- Unrelated untracked GOAL-*.md files remain in the worktree and were not included in this PR.