### PR TITLE
Add agent template draft validation

### DIFF
--- a/internal/agenttemplate/agenttemplate.go
+++ b/internal/agenttemplate/agenttemplate.go
@@ -25,6 +25,19 @@ const LocalSourceRef = "file"
 const DefaultLocalDescription = "Local custom prompt agent template."
 
 var idPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$`)
+var obviousPlaceholderPattern = regexp.MustCompile(`(?i)(<\s*template\s+name\s*>|\bTODO\b)`)
+
+var CaptureTemplateSections = []string{
+	"Role",
+	"When To Use",
+	"Workflow",
+	"Inputs And Context",
+	"Commands And Tools",
+	"Output Contract",
+	"Safety Rules",
+	"Examples",
+	"Non-Goals",
+}
 
 type Definition struct {
 	ID                  string
@@ -106,6 +119,115 @@ func ValidateID(id string) error {
 		return fmt.Errorf("invalid agent template id %q; use lowercase letters, numbers, and single dashes", id)
 	}
 	return nil
+}
+
+func DraftCaptureTemplate(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if err := ValidateID(id); err != nil {
+		return "", err
+	}
+	name := titleFromID(id)
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "# %s\n\n", name)
+	builder.WriteString("## Role\n\n")
+	builder.WriteString("Describe the durable responsibility this agent should handle.\n\n")
+	builder.WriteString("## When To Use\n\n")
+	builder.WriteString("- Use this template for requests that match the repeated workflow being captured.\n")
+	builder.WriteString("- Keep the scope explicit so future sessions know when to import or run it.\n\n")
+	builder.WriteString("## Workflow\n\n")
+	builder.WriteString("1. Inspect the relevant visible conversation context and repo files.\n")
+	builder.WriteString("2. Apply the captured workflow rules in order.\n")
+	builder.WriteString("3. Return the agreed output without performing extra implementation unless requested.\n\n")
+	builder.WriteString("## Inputs And Context\n\n")
+	builder.WriteString("- Current user request and visible conversation context.\n")
+	builder.WriteString("- Relevant repository files, command output, and documentation checked during the task.\n\n")
+	builder.WriteString("## Commands And Tools\n\n")
+	builder.WriteString("- Prefer local commands for repo state and verification.\n")
+	builder.WriteString("- Use official sources for external contracts that may change.\n")
+	builder.WriteString("- Preserve unrelated local changes.\n\n")
+	builder.WriteString("## Output Contract\n\n")
+	builder.WriteString("Return the concrete artifact requested by the user, plus concise verification notes when checks run.\n\n")
+	builder.WriteString("## Safety Rules\n\n")
+	builder.WriteString("- Do not expose secrets or private state.\n")
+	builder.WriteString("- Do not mutate files, install templates, or start background work unless explicitly requested.\n")
+	builder.WriteString("- Ask for clarification when required scope or approval is missing.\n\n")
+	builder.WriteString("## Examples\n\n")
+	builder.WriteString("- \"Use this template here to draft the workflow.\" Return the drafted output in chat.\n")
+	builder.WriteString("- \"Install this template.\" Validate the file, then add it with Gitmoot.\n\n")
+	builder.WriteString("## Non-Goals\n\n")
+	builder.WriteString("- Do not capture one-off debugging details, temporary mistakes, secrets, or hidden model state.\n")
+	return builder.String(), nil
+}
+
+func ValidateCaptureTemplateFile(path string) error {
+	local, err := readLocal(path)
+	if err != nil {
+		return err
+	}
+	return ValidateCaptureTemplateContent(local.Content)
+}
+
+func ValidateCaptureTemplateContent(content string) error {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return errors.New("template content is empty")
+	}
+	title, ok := firstMarkdownTitle(content)
+	if !ok {
+		return errors.New("template must start with a markdown title heading")
+	}
+	if obviousPlaceholderPattern.MatchString(title) {
+		return errors.New("template title contains an unresolved placeholder")
+	}
+	for _, section := range CaptureTemplateSections {
+		if !hasMarkdownHeading(content, 2, section) {
+			return fmt.Errorf("template missing required section %q", section)
+		}
+	}
+	if obviousPlaceholderPattern.MatchString(content) {
+		return errors.New("template contains unresolved placeholder text")
+	}
+	return nil
+}
+
+func firstMarkdownTitle(content string) (string, bool) {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "# ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "# ")), true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+func hasMarkdownHeading(content string, level int, title string) bool {
+	prefix := strings.Repeat("#", level) + " "
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		heading := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		if strings.EqualFold(heading, title) {
+			return true
+		}
+	}
+	return false
+}
+
+func titleFromID(id string) string {
+	parts := strings.Split(id, "-")
+	for index, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[index] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
 }
 
 func AddLocal(ctx context.Context, store *db.Store, id string, path string, name string, description string) (db.AgentTemplate, error) {
@@ -318,8 +440,8 @@ func readLocal(path string) (localFile, error) {
 	if err != nil {
 		return localFile{}, fmt.Errorf("read template file %s: %w", abs, err)
 	}
-	if info.IsDir() {
-		return localFile{}, fmt.Errorf("template file %s is a directory", abs)
+	if !info.Mode().IsRegular() {
+		return localFile{}, fmt.Errorf("template file %s is not a regular file", abs)
 	}
 	data, err := os.ReadFile(abs)
 	if err != nil {

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -66,7 +66,7 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent start <name> --runtime codex|claude --repo owner/repo [--path .] [--template <template-id>] [--start-daemon]")
 	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot agent type list|show|set ...")
-	fmt.Fprintln(w, "  gitmoot agent template list|show|add|update|diff ...")
+	fmt.Fprintln(w, "  gitmoot agent template list|show|add|draft|validate|update|diff ...")
 	fmt.Fprintln(w, "  gitmoot agent prompt <agent-or-template> [--json]")
 	fmt.Fprintln(w, "  gitmoot agent gc")
 	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> [--repo owner/repo...] --capability <capability>")

--- a/internal/cli/agent_template.go
+++ b/internal/cli/agent_template.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
@@ -25,8 +27,12 @@ func runAgentTemplate(args []string, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "add":
 		return runAgentTemplateAdd(args[1:], stdout, stderr)
+	case "draft":
+		return runAgentTemplateDraft(args[1:], stdout, stderr)
 	case "list":
 		return runAgentTemplateList(args[1:], stdout, stderr)
+	case "validate":
+		return runAgentTemplateValidate(args[1:], stdout, stderr)
 	case "show":
 		return runAgentTemplateShow(args[1:], stdout, stderr)
 	case "update":
@@ -43,6 +49,8 @@ func runAgentTemplate(args []string, stdout, stderr io.Writer) int {
 func printAgentTemplateUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot agent template add <template-id> --file ./agents/<template-id>.md [--name <name>] [--description <text>]")
+	fmt.Fprintln(w, "  gitmoot agent template draft <template-id> [--output .gitmoot/templates/<template-id>.md] [--force]")
+	fmt.Fprintln(w, "  gitmoot agent template validate <file>")
 	fmt.Fprintln(w, "  gitmoot agent template list")
 	fmt.Fprintln(w, "  gitmoot agent template show thermo-nuclear-code-quality-review")
 	fmt.Fprintln(w, "  gitmoot agent template update thermo-nuclear-code-quality-review")
@@ -93,6 +101,89 @@ func leadingID(args []string) (string, []string) {
 		return "", args
 	}
 	return args[0], args[1:]
+}
+
+func runAgentTemplateDraft(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent template draft", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	_ = fs.String("home", "", "accepted for command consistency; not used")
+	output := fs.String("output", "", "path to write the draft template")
+	force := fs.Bool("force", false, "overwrite an existing draft file")
+	id, flagArgs := leadingID(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if id == "" {
+		if fs.NArg() == 1 {
+			id = fs.Arg(0)
+		} else {
+			fmt.Fprintln(stderr, "agent template draft requires exactly one template id")
+			return 2
+		}
+	} else if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent template draft requires exactly one template id")
+		return 2
+	}
+	content, err := agenttemplate.DraftCaptureTemplate(id)
+	if err != nil {
+		fmt.Fprintf(stderr, "draft agent template: %v\n", err)
+		return 1
+	}
+	path := strings.TrimSpace(*output)
+	if path == "" {
+		path = filepath.Join(".gitmoot", "templates", id+".md")
+	}
+	if err := writeAgentTemplateDraft(path, content, *force); err != nil {
+		fmt.Fprintf(stderr, "draft agent template: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "drafted %s at %s", id, path)
+	return 0
+}
+
+func writeAgentTemplateDraft(path string, content string, force bool) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return errors.New("output path is required")
+	}
+	if _, err := os.Stat(path); err == nil && !force {
+		return fmt.Errorf("template draft %s already exists; pass --force to overwrite", path)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect template draft %s: %w", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create template draft directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write template draft %s: %w", path, err)
+	}
+	return nil
+}
+
+func runAgentTemplateValidate(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent template validate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	_ = fs.String("home", "", "accepted for command consistency; not used")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "agent template validate requires exactly one file path")
+		return 2
+	}
+	path := fs.Arg(0)
+	if err := agenttemplate.ValidateCaptureTemplateFile(path); err != nil {
+		fmt.Fprintf(stderr, "validate agent template: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "valid agent template: %s", path)
+	return 0
 }
 
 func runAgentTemplateList(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/agent_template_test.go
+++ b/internal/cli/agent_template_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -180,6 +182,118 @@ func TestAgentTemplateAddRejectsInvalidLocalFiles(t *testing.T) {
 		if code := Run(args, &stdout, &stderr); code == 0 {
 			t.Fatalf("Run(%v) exit code = 0, stdout=%s stderr=%s", args, stdout.String(), stderr.String())
 		}
+	}
+}
+
+func TestAgentTemplateDraftWritesDefaultTemplatePath(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cwd := chdirTemp(t)
+
+	code := Run([]string{"agent", "template", "draft", "release-planner"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("template draft exit code = %d, stderr=%s", code, stderr.String())
+	}
+	path := filepath.Join(cwd, ".gitmoot", "templates", "release-planner.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	for _, want := range []string{"# Release Planner", "## Role", "## Non-Goals"} {
+		if !strings.Contains(string(content), want) {
+			t.Fatalf("draft missing %q:\n%s", want, string(content))
+		}
+	}
+	if !strings.Contains(stdout.String(), "drafted release-planner at "+filepath.Join(".gitmoot", "templates", "release-planner.md")) {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func TestAgentTemplateDraftOutputOverwriteRules(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	path := filepath.Join(t.TempDir(), "custom.md")
+
+	code := Run([]string{"agent", "template", "draft", "custom-reviewer", "--output", path}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template draft exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Stat returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "template", "draft", "custom-reviewer", "--output", path}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("template draft overwrite exit code = 0, stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "already exists; pass --force") {
+		t.Fatalf("stderr missing overwrite guidance:\n%s", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "template", "draft", "custom-reviewer", "--output", path, "--force"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template draft --force exit code = %d, stderr=%s", code, stderr.String())
+	}
+}
+
+func TestAgentTemplateValidateAcceptsDraftedTemplate(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	path := filepath.Join(t.TempDir(), "planner.md")
+	if code := Run([]string{"agent", "template", "draft", "planner-reviewer", "--output", path}, &stdout, &stderr); code != 0 {
+		t.Fatalf("template draft exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"agent", "template", "validate", path}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("template validate exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "valid agent template: "+path) {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func TestAgentTemplateValidateRejectsIncompleteTemplate(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	path := filepath.Join(t.TempDir(), "bad.md")
+	if err := os.WriteFile(path, []byte("# Bad\n\n## Role\n\nTODO\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	code := Run([]string{"agent", "template", "validate", path}, &stdout, &stderr)
+
+	if code == 0 {
+		t.Fatalf("template validate exit code = 0, stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "missing required section") {
+		t.Fatalf("stderr missing validation detail:\n%s", stderr.String())
+	}
+}
+
+func TestAgentTemplateValidateRejectsNonRegularFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket fixture is not portable to windows")
+	}
+	var stdout, stderr bytes.Buffer
+	path := filepath.Join(t.TempDir(), "template.sock")
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("Listen returned error: %v", err)
+	}
+	defer listener.Close()
+
+	code := Run([]string{"agent", "template", "validate", path}, &stdout, &stderr)
+
+	if code == 0 {
+		t.Fatalf("template validate exit code = 0, stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "is not a regular file") {
+		t.Fatalf("stderr missing non-regular-file detail:\n%s", stderr.String())
 	}
 }
 
@@ -531,4 +645,22 @@ func (f fakeAgentTemplateFetcher) ResolveRef(context.Context, string, string) (s
 
 func (f fakeAgentTemplateFetcher) FetchFile(context.Context, string, string, string) (agenttemplate.File, error) {
 	return agenttemplate.File{Content: f.content}, nil
+}
+
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd returned error: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Fatalf("restore Chdir returned error: %v", err)
+		}
+	})
+	return dir
 }


### PR DESCRIPTION
WHAT:
- Added `gitmoot agent template draft` and `gitmoot agent template validate`.

WHY:
- Template capture needs CLI support for scaffolding a visible draft file and checking its structure before installing it with `agent template add`.

CHANGES:
- Added shared captured-template section definitions, draft generation, and structural validation helpers in `internal/agenttemplate`.
- Reused the local template reader while tightening it to reject non-regular files before reading.
- Added draft/validate subcommands under `gitmoot agent template` and updated agent help text.
- Added focused CLI tests for default draft path, custom output, overwrite refusal, `--force`, validation success, incomplete template failure, and non-regular file rejection.

RESULTS:
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/agenttemplate ./internal/cli`
- `git diff --check`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:
```text
No actionable correctness issues were found in the inspected staged, unstaged, and untracked changes. Test execution was limited because the required Go 1.26 toolchain could not be downloaded in this environment.
```

RISK:
- The host default `go` is 1.22.2 and cannot satisfy this repo without the installed Go 1.26 toolchain path used above. No skipped focused checks beyond that toolchain caveat.