### PR TITLE
Document template capture workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,36 @@ The runtime should load the prompt with:
 gitmoot agent prompt frontend-reviewer
 ```
 
+### Template Capture
+
+Template capture turns a useful current Codex or Claude chat workflow into a
+reusable agent template. Capture happens in the current chat from visible
+conversation context and inspected files; Gitmoot does not read hidden model
+state or runtime memory.
+
+Draft a blank structure when starting from scratch:
+
+```sh
+gitmoot agent template draft release-planner
+```
+
+Or ask the current chat to fill the structure from the visible session:
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+Review the draft before installing it:
+
+```sh
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+gitmoot agent prompt release-planner
+```
+
+Installed custom templates are snapshots. After editing the source file, run
+`gitmoot agent template diff <id>` and `gitmoot agent template update <id>`.
+
 ### Jobs, Locks, And Recovery
 
 ```sh

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,6 +50,10 @@ agent template from this chat" mean read
 current-chat context into a draft template. Gitmoot cannot read hidden model
 memory or runtime internals. Do not install, overwrite, or update a permanent
 template unless the user explicitly approves that step.
+Use `gitmoot agent template draft <id>` for a blank scaffold,
+`gitmoot agent template validate <file>` for a structural check,
+`gitmoot agent template add <id> --file <file>` to install a snapshot, and
+`gitmoot agent prompt <id>` to reuse the installed template in the current chat.
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
@@ -168,6 +172,15 @@ After editing a local prompt file, refresh Gitmoot's cached snapshot explicitly:
 ```sh
 gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
+```
+
+Draft and validate a captured template before installing it:
+
+```sh
+gitmoot agent template draft release-planner
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+gitmoot agent prompt release-planner
 ```
 
 ## Agent Job Contract

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -199,6 +199,32 @@ same checkout remain serialized even when the worker count is higher.
    gitmoot agent template update frontend-reviewer
    ```
 
+   To create a new custom template from a successful current chat, use template
+   capture. The current Codex or Claude chat distills visible conversation,
+   inspected files, commands, corrections, and durable workflow rules into a
+   draft. Gitmoot cannot read hidden model memory, so capture is always
+   draft-first and user-reviewed.
+
+   ```text
+   Use Gitmoot to capture this session as agent template release-planner. Draft only.
+   ```
+
+   A blank scaffold is also available when you want to write the template by
+   hand:
+
+   ```sh
+   gitmoot agent template draft release-planner
+   gitmoot agent template validate .gitmoot/templates/release-planner.md
+   gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+   gitmoot agent prompt release-planner
+   ```
+
+   `agent template draft` creates the structure, current-chat capture fills it
+   from visible context, `agent template validate` performs a structural check,
+   `agent template add` installs a snapshot, `agent prompt` reuses it in the
+   current chat, and `agent start --template` creates a runnable background
+   agent instance.
+
    After startup, open a created Codex session later with the session id printed
    by Gitmoot:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -112,6 +112,21 @@ gitmoot agent prompt <agent-or-template>
 Then Codex should apply the returned prompt content in the current chat without
 creating a Gitmoot job.
 
+For template capture, keep the work in the current chat. Ask Codex to read the
+Gitmoot template-capture instructions and draft a file from visible context:
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+Codex should not call `gitmoot agent ask`, start a daemon, or install the
+template unless the user explicitly asks. After review, install the draft with:
+
+```sh
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+```
+
 When you want the current Codex chat to invoke a registered background-capable
 Gitmoot agent, route that request through the CLI:
 
@@ -155,6 +170,16 @@ path.
 
 For fast current-chat planning, ask Claude Code to use the Gitmoot planner here
 instead of starting a background `gitmoot agent ask` job.
+
+For current-chat template capture, ask Claude Code:
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+Claude Code should apply the bundled template-capture instructions locally,
+write or return a draft, and wait for explicit approval before validation or
+installation.
 
 ## Troubleshooting
 

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -33,6 +33,10 @@ agent template from this chat" mean read [TEMPLATE_CAPTURE.md](references/TEMPLA
 and distill the visible current-chat context into a draft template. Gitmoot
 cannot read hidden model memory or runtime internals. Do not install, overwrite,
 or update a permanent template unless the user explicitly approves that step.
+Use `gitmoot agent template draft <id>` for a blank scaffold,
+`gitmoot agent template validate <file>` for a structural check,
+`gitmoot agent template add <id> --file <file>` to install a snapshot, and
+`gitmoot agent prompt <id>` to reuse the installed template in the current chat.
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -160,6 +160,19 @@ This prints the prompt content for the current chat to apply locally. It does
 not create a job, start a daemon, resume a runtime session, or post a PR
 comment.
 
+Draft and validate a captured template before installing it:
+
+```sh
+gitmoot agent template draft release-planner
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+```
+
+`agent template draft` only creates the standard markdown structure. For
+current-chat capture, the active Codex or Claude chat reads
+`references/TEMPLATE_CAPTURE.md` and fills that structure from visible
+conversation context. Gitmoot does not extract hidden runtime memory.
+
 Create a local custom prompt template:
 
 ```sh

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -107,6 +107,44 @@ start a daemon, resume a runtime session, or post a PR comment. If the user
 wants tracked background execution, use `gitmoot agent ask <agent> --background`
 instead.
 
+## Current-Chat Template Capture
+
+Use template capture when the user wants to turn a successful visible Codex or
+Claude Code conversation into a reusable agent template.
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+The current chat reads `references/TEMPLATE_CAPTURE.md`, extracts durable
+workflow rules from visible conversation context and inspected files, and writes
+or returns a draft. It must not route the request through `gitmoot agent ask`,
+start a daemon, queue a job, or install/replace a template without explicit user
+approval.
+
+For a blank starting point, scaffold the required sections:
+
+```sh
+gitmoot agent template draft release-planner
+```
+
+After the user reviews the draft:
+
+```sh
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+gitmoot agent prompt release-planner
+```
+
+The capture pieces are distinct:
+
+- `agent template draft`: scaffold a blank structure.
+- "capture here": current chat fills that structure from visible context.
+- `agent template validate`: structural check.
+- `agent template add`: install a snapshot.
+- `agent prompt`: reuse the installed prompt in the current chat.
+- `agent start --template`: create a runnable background agent instance.
+
 ## Background Planner Agent
 
 Use the planner template when the user wants a structured implementation plan or a

--- a/website/docs/concepts/agents-templates-jobs-locks.md
+++ b/website/docs/concepts/agents-templates-jobs-locks.md
@@ -20,8 +20,14 @@ into each job so the job has reproducible instructions.
 ```sh
 gitmoot agent template update planner
 gitmoot agent template update thermo-nuclear-code-quality-review
+gitmoot agent template draft release-planner
+gitmoot agent template validate .gitmoot/templates/release-planner.md
 gitmoot agent template add frontend-reviewer --file agents/frontend-reviewer.md
 ```
+
+Template capture is the current-chat path for creating new custom templates
+from a successful visible workflow. The current Codex or Claude chat fills a
+draft from visible context; `agent template add` installs the reviewed snapshot.
 
 ## Jobs
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -14,6 +14,8 @@ hosted control plane in the current beta.
 - Keep Codex, Claude Code, shell, and future runtimes behind one agent model.
 - Start or subscribe agents with explicit repo access and capabilities.
 - Use agent templates for reusable planner, review, or custom prompt agents.
+- Capture a successful current chat as a reviewed, reusable agent template
+  draft.
 - Import a cached agent prompt into the current chat with
   `gitmoot agent prompt <agent-or-template>`.
 - Track jobs, branch locks, goals, tasks, reviews, and merges locally.

--- a/website/docs/plugins/codex-claude.md
+++ b/website/docs/plugins/codex-claude.md
@@ -28,6 +28,16 @@ gitmoot agent prompt <agent-or-template>
 
 This keeps the work in the current chat and does not create a Gitmoot job.
 
+For template capture from the current chat:
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+The plugin should guide the runtime to read Gitmoot's template-capture
+instructions, draft from visible context, and wait for explicit approval before
+validation or installation.
+
 For registered background-agent work from a runtime chat that supports command
 execution:
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -41,6 +41,8 @@ gitmoot agent doctor <name>
 gitmoot agent template list
 gitmoot agent template show <id>
 gitmoot agent template update <id>
+gitmoot agent template draft <id>
+gitmoot agent template validate .gitmoot/templates/<id>.md
 gitmoot agent template add <id> --file agents/<id>.md
 gitmoot agent template diff <id>
 ```

--- a/website/docs/workflows/template-capture-workflow.md
+++ b/website/docs/workflows/template-capture-workflow.md
@@ -1,0 +1,53 @@
+# Template Capture Workflow
+
+Template capture turns a useful current Codex or Claude Code conversation into
+a reusable Gitmoot agent template.
+
+Capture happens in the current chat. The runtime reads the Gitmoot skill and
+template-capture instructions, then distills visible conversation context,
+inspected files, commands, corrections, and durable workflow rules into a
+draft. Gitmoot cannot read hidden model memory or private runtime state.
+
+## Capture From The Current Chat
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+The chat should draft the template and wait. It should not start a daemon,
+queue a `gitmoot agent ask` job, install the template, or replace an existing
+template unless you explicitly ask.
+
+## Scaffold, Validate, Install
+
+Start with a blank template structure:
+
+```sh
+gitmoot agent template draft release-planner
+```
+
+After the draft is filled and reviewed:
+
+```sh
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+gitmoot agent prompt release-planner
+```
+
+## What Each Step Does
+
+- `agent template draft` creates the markdown structure.
+- "capture here" fills that structure from visible current-chat context.
+- `agent template validate` checks title, required sections, regular file
+  status, and unresolved placeholders.
+- `agent template add` installs a snapshot into local Gitmoot state.
+- `agent prompt` reuses the installed prompt in the current chat.
+- `agent start --template` creates a runnable background agent instance.
+
+Installed custom templates are snapshots. If you edit the source file later,
+run:
+
+```sh
+gitmoot agent template diff release-planner
+gitmoot agent template update release-planner
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'workflows/pr-comment-workflow',
         'workflows/planner-goal-workflow',
+        'workflows/template-capture-workflow',
         'workflows/review-agent-workflow',
       ],
     },
@@ -63,4 +64,3 @@ const sidebars: SidebarsConfig = {
 };
 
 export default sidebars;
-

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -222,6 +222,36 @@ The runtime should load the prompt with:
 gitmoot agent prompt frontend-reviewer
 ```
 
+### Template Capture
+
+Template capture turns a useful current Codex or Claude chat workflow into a
+reusable agent template. Capture happens in the current chat from visible
+conversation context and inspected files; Gitmoot does not read hidden model
+state or runtime memory.
+
+Draft a blank structure when starting from scratch:
+
+```sh
+gitmoot agent template draft release-planner
+```
+
+Or ask the current chat to fill the structure from the visible session:
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+Review the draft before installing it:
+
+```sh
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+gitmoot agent prompt release-planner
+```
+
+Installed custom templates are snapshots. After editing the source file, run
+`gitmoot agent template diff <id>` and `gitmoot agent template update <id>`.
+
 ### Jobs, Locks, And Recovery
 
 ```sh
@@ -347,6 +377,10 @@ agent template from this chat" mean read
 current-chat context into a draft template. Gitmoot cannot read hidden model
 memory or runtime internals. Do not install, overwrite, or update a permanent
 template unless the user explicitly approves that step.
+Use `gitmoot agent template draft <id>` for a blank scaffold,
+`gitmoot agent template validate <file>` for a structural check,
+`gitmoot agent template add <id> --file <file>` to install a snapshot, and
+`gitmoot agent prompt <id>` to reuse the installed template in the current chat.
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
@@ -465,6 +499,15 @@ After editing a local prompt file, refresh Gitmoot's cached snapshot explicitly:
 ```sh
 gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
+```
+
+Draft and validate a captured template before installing it:
+
+```sh
+gitmoot agent template draft release-planner
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+gitmoot agent prompt release-planner
 ```
 
 ## Agent Job Contract
@@ -714,6 +757,32 @@ same checkout remain serialized even when the worker count is higher.
    gitmoot agent template diff frontend-reviewer
    gitmoot agent template update frontend-reviewer
    ```
+
+   To create a new custom template from a successful current chat, use template
+   capture. The current Codex or Claude chat distills visible conversation,
+   inspected files, commands, corrections, and durable workflow rules into a
+   draft. Gitmoot cannot read hidden model memory, so capture is always
+   draft-first and user-reviewed.
+
+   ```text
+   Use Gitmoot to capture this session as agent template release-planner. Draft only.
+   ```
+
+   A blank scaffold is also available when you want to write the template by
+   hand:
+
+   ```sh
+   gitmoot agent template draft release-planner
+   gitmoot agent template validate .gitmoot/templates/release-planner.md
+   gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+   gitmoot agent prompt release-planner
+   ```
+
+   `agent template draft` creates the structure, current-chat capture fills it
+   from visible context, `agent template validate` performs a structural check,
+   `agent template add` installs a snapshot, `agent prompt` reuses it in the
+   current chat, and `agent start --template` creates a runnable background
+   agent instance.
 
    After startup, open a created Codex session later with the session id printed
    by Gitmoot:
@@ -1008,6 +1077,21 @@ gitmoot agent prompt <agent-or-template>
 Then Codex should apply the returned prompt content in the current chat without
 creating a Gitmoot job.
 
+For template capture, keep the work in the current chat. Ask Codex to read the
+Gitmoot template-capture instructions and draft a file from visible context:
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+Codex should not call `gitmoot agent ask`, start a daemon, or install the
+template unless the user explicitly asks. After review, install the draft with:
+
+```sh
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+```
+
 When you want the current Codex chat to invoke a registered background-capable
 Gitmoot agent, route that request through the CLI:
 
@@ -1051,6 +1135,16 @@ path.
 
 For fast current-chat planning, ask Claude Code to use the Gitmoot planner here
 instead of starting a background `gitmoot agent ask` job.
+
+For current-chat template capture, ask Claude Code:
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+Claude Code should apply the bundled template-capture instructions locally,
+write or return a draft, and wait for explicit approval before validation or
+installation.
 
 ## Troubleshooting
 
@@ -2208,6 +2302,10 @@ agent template from this chat" mean read [TEMPLATE_CAPTURE.md](references/TEMPLA
 and distill the visible current-chat context into a draft template. Gitmoot
 cannot read hidden model memory or runtime internals. Do not install, overwrite,
 or update a permanent template unless the user explicitly approves that step.
+Use `gitmoot agent template draft <id>` for a blank scaffold,
+`gitmoot agent template validate <file>` for a structural check,
+`gitmoot agent template add <id> --file <file>` to install a snapshot, and
+`gitmoot agent prompt <id>` to reuse the installed template in the current chat.
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
@@ -2503,6 +2601,19 @@ This prints the prompt content for the current chat to apply locally. It does
 not create a job, start a daemon, resume a runtime session, or post a PR
 comment.
 
+Draft and validate a captured template before installing it:
+
+```sh
+gitmoot agent template draft release-planner
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+```
+
+`agent template draft` only creates the standard markdown structure. For
+current-chat capture, the active Codex or Claude chat reads
+`references/TEMPLATE_CAPTURE.md` and fills that structure from visible
+conversation context. Gitmoot does not extract hidden runtime memory.
+
 Create a local custom prompt template:
 
 ```sh
@@ -2677,6 +2788,44 @@ import, not true system-prompt injection, and it does not create a Gitmoot job,
 start a daemon, resume a runtime session, or post a PR comment. If the user
 wants tracked background execution, use `gitmoot agent ask <agent> --background`
 instead.
+
+## Current-Chat Template Capture
+
+Use template capture when the user wants to turn a successful visible Codex or
+Claude Code conversation into a reusable agent template.
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+The current chat reads `references/TEMPLATE_CAPTURE.md`, extracts durable
+workflow rules from visible conversation context and inspected files, and writes
+or returns a draft. It must not route the request through `gitmoot agent ask`,
+start a daemon, queue a job, or install/replace a template without explicit user
+approval.
+
+For a blank starting point, scaffold the required sections:
+
+```sh
+gitmoot agent template draft release-planner
+```
+
+After the user reviews the draft:
+
+```sh
+gitmoot agent template validate .gitmoot/templates/release-planner.md
+gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
+gitmoot agent prompt release-planner
+```
+
+The capture pieces are distinct:
+
+- `agent template draft`: scaffold a blank structure.
+- "capture here": current chat fills that structure from visible context.
+- `agent template validate`: structural check.
+- `agent template add`: install a snapshot.
+- `agent prompt`: reuse the installed prompt in the current chat.
+- `agent start --template`: create a runnable background agent instance.
 
 ## Background Planner Agent
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -12,6 +12,7 @@ workflows.
 - [Quick Start](https://gitmoot.io/docs/getting-started/quick-start): Register a repo, start a planner, and route work.
 - [PR Comment Workflow](https://gitmoot.io/docs/workflows/pr-comment-workflow): Route auditable work from GitHub comments.
 - [Planner And Goal Workflow](https://gitmoot.io/docs/workflows/planner-goal-workflow): Create structured plans and goal files.
+- [Template Capture Workflow](https://gitmoot.io/docs/workflows/template-capture-workflow): Turn a current chat workflow into a reviewed reusable template.
 
 ## References
 


### PR DESCRIPTION
WHAT:
- Documented the Gitmoot template capture workflow across README, skills, CLI/workflow references, plugin docs, and website docs.

WHY:
- Users and runtime plugins need a clear current-chat path for turning a visible successful session into a reusable agent template without confusing it with background jobs.

CHANGES:
- Added draft/validate/install flow examples and explicit current-chat capture guidance.
- Added a Docusaurus template capture workflow page and sidebar entry.
- Updated website CLI/concepts/plugin docs and the `llms.txt` index.
- Regenerated `website/static/llms-full.txt`.

RESULTS:
- `/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/pluginpack ./internal/skill`
- `npm run build` from `website/`
- `git diff --check`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:
```text
No actionable correctness issues were found in the current staged, unstaged, or untracked changes. The website build also succeeds with the new workflow page and sidebar entry.
```

RISK:
- The installed `/root/.local/bin/gitmoot` binary on this host predates Task 2, so its help output does not show `agent template draft` until this branch is released/installed. The source docs match the merged CLI implementation.