### PR TITLE
Add template capture smoke coverage

### DIFF
--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -463,6 +463,67 @@ Expected signals:
    /tmp/gitmoot-current daemon status --home "$GITMOOT_SMOKE_HOME"
    ```
 
+## Template Capture Smoke Test
+
+Goal: current-chat template capture semantics -> draft scaffold -> structural
+validation -> local template install -> prompt reuse, without requiring a live
+background agent or PR comment.
+
+Prerequisites: a Gitmoot build that includes `agent template draft` and
+`agent template validate`.
+
+1. Build a local test binary and use an isolated Gitmoot home.
+
+   ```sh
+   GOTOOLCHAIN=go1.26.0 go build -o /tmp/gitmoot-current ./cmd/gitmoot
+   export GITMOOT_SMOKE_HOME="$(mktemp -d)"
+   export GITMOOT_DRAFT_FILE="$GITMOOT_SMOKE_HOME/release-planner.md"
+   /tmp/gitmoot-current init --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+2. Scaffold a draft file.
+
+   ```sh
+   /tmp/gitmoot-current agent template draft release-planner \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --output "$GITMOOT_DRAFT_FILE"
+   ```
+
+3. In a Codex or Claude Code chat with the Gitmoot plugin/skill installed, fill
+   that draft from visible current-chat context:
+
+   ```text
+   Use Gitmoot to capture this session as agent template release-planner. Draft only.
+   ```
+
+4. After reviewing the filled draft, validate, install, and inspect the captured
+   template.
+
+   ```sh
+   /tmp/gitmoot-current agent template validate "$GITMOOT_DRAFT_FILE"
+   /tmp/gitmoot-current agent template add release-planner \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --file "$GITMOOT_DRAFT_FILE"
+   /tmp/gitmoot-current agent template show \
+     --home "$GITMOOT_SMOKE_HOME" \
+     release-planner
+   /tmp/gitmoot-current agent prompt release-planner \
+     --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+Expected signals:
+
+- `agent template draft` writes `$GITMOOT_DRAFT_FILE` with the standard
+  title and required sections.
+- The current-chat capture step fills the draft from visible context without
+  starting a daemon, queueing a job, or installing the template.
+- `agent template validate` succeeds for the draft and reports clear missing
+  sections or placeholders if the file is edited into an invalid state.
+- `agent template show` displays `source: local@file:` and
+  `resolved commit: sha256:...`.
+- `agent prompt release-planner` prints the installed template content for
+  current-chat reuse.
+
 ## Two-Repo Smoke Test
 
 Goal: one daemon -> two registered repos -> same allowed agent -> ask jobs in

--- a/website/docs/operations/beta-smoke-tests.md
+++ b/website/docs/operations/beta-smoke-tests.md
@@ -48,5 +48,35 @@ For concurrency checks, keep `--workers 1` by default and raise it only when
 jobs use independent runtime sessions or a managed agent type with
 `max_background` greater than one.
 
+## Template Capture Smoke
+
+This smoke does not need a live background agent:
+
+```sh
+export GITMOOT_SMOKE_HOME="$(mktemp -d)"
+export GITMOOT_DRAFT_FILE="$GITMOOT_SMOKE_HOME/release-planner.md"
+gitmoot init --home "$GITMOOT_SMOKE_HOME"
+gitmoot agent template draft release-planner --home "$GITMOOT_SMOKE_HOME" --output "$GITMOOT_DRAFT_FILE"
+```
+
+Then ask Codex or Claude Code to fill the draft from visible current-chat
+context:
+
+```text
+Use Gitmoot to capture this session as agent template release-planner. Draft only.
+```
+
+After reviewing the filled draft:
+
+```sh
+gitmoot agent template validate "$GITMOOT_DRAFT_FILE"
+gitmoot agent template add release-planner --home "$GITMOOT_SMOKE_HOME" --file "$GITMOOT_DRAFT_FILE"
+gitmoot agent template show --home "$GITMOOT_SMOKE_HOME" release-planner
+gitmoot agent prompt release-planner --home "$GITMOOT_SMOKE_HOME"
+```
+
+Expected signal: the chat fills the draft and does not start a daemon, queue a
+job, or install the template until explicitly asked.
+
 For the detailed release smoke path, see
 [`docs/beta-smoke-tests.md`](https://github.com/jerryfane/gitmoot/blob/main/docs/beta-smoke-tests.md).

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2140,6 +2140,67 @@ Expected signals:
    /tmp/gitmoot-current daemon status --home "$GITMOOT_SMOKE_HOME"
    ```
 
+## Template Capture Smoke Test
+
+Goal: current-chat template capture semantics -> draft scaffold -> structural
+validation -> local template install -> prompt reuse, without requiring a live
+background agent or PR comment.
+
+Prerequisites: a Gitmoot build that includes `agent template draft` and
+`agent template validate`.
+
+1. Build a local test binary and use an isolated Gitmoot home.
+
+   ```sh
+   GOTOOLCHAIN=go1.26.0 go build -o /tmp/gitmoot-current ./cmd/gitmoot
+   export GITMOOT_SMOKE_HOME="$(mktemp -d)"
+   export GITMOOT_DRAFT_FILE="$GITMOOT_SMOKE_HOME/release-planner.md"
+   /tmp/gitmoot-current init --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+2. Scaffold a draft file.
+
+   ```sh
+   /tmp/gitmoot-current agent template draft release-planner \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --output "$GITMOOT_DRAFT_FILE"
+   ```
+
+3. In a Codex or Claude Code chat with the Gitmoot plugin/skill installed, fill
+   that draft from visible current-chat context:
+
+   ```text
+   Use Gitmoot to capture this session as agent template release-planner. Draft only.
+   ```
+
+4. After reviewing the filled draft, validate, install, and inspect the captured
+   template.
+
+   ```sh
+   /tmp/gitmoot-current agent template validate "$GITMOOT_DRAFT_FILE"
+   /tmp/gitmoot-current agent template add release-planner \
+     --home "$GITMOOT_SMOKE_HOME" \
+     --file "$GITMOOT_DRAFT_FILE"
+   /tmp/gitmoot-current agent template show \
+     --home "$GITMOOT_SMOKE_HOME" \
+     release-planner
+   /tmp/gitmoot-current agent prompt release-planner \
+     --home "$GITMOOT_SMOKE_HOME"
+   ```
+
+Expected signals:
+
+- `agent template draft` writes `$GITMOOT_DRAFT_FILE` with the standard
+  title and required sections.
+- The current-chat capture step fills the draft from visible context without
+  starting a daemon, queueing a job, or installing the template.
+- `agent template validate` succeeds for the draft and reports clear missing
+  sections or placeholders if the file is edited into an invalid state.
+- `agent template show` displays `source: local@file:` and
+  `resolved commit: sha256:...`.
+- `agent prompt release-planner` prints the installed template content for
+  current-chat reuse.
+
 ## Two-Repo Smoke Test
 
 Goal: one daemon -> two registered repos -> same allowed agent -> ask jobs in


### PR DESCRIPTION
WHAT: Adds beta smoke coverage for the agent template capture workflow.

WHY: Template capture needs a release-smoke path that verifies draft-first behavior, validation, local template install, and current-chat reuse without requiring a live background agent or PR comment.

CHANGES:
- Added a detailed Template Capture Smoke Test to docs/beta-smoke-tests.md.
- Added the condensed website operations smoke path.
- Regenerated website/static/llms-full.txt.
- Ordered the workflow as scaffold -> current-chat fill -> validate/install/reuse so the installed template is the reviewed capture, not just the blank scaffold.

RESULTS:
- /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/cli
- Built-binary template capture CLI smoke with an isolated temporary Gitmoot home.
- npm run build:llms from website/
- npm run build from website/
- git diff --check
- codex exec review --uncommitted

Final codex exec review --uncommitted output:
```text
The current tracked changes are documentation-only additions for the template capture smoke path, and the documented command forms align with the existing CLI parsing and generated llms-full source flow. The untracked GOAL files are planning documents and do not introduce a correctness regression in executable code.
```

RISK:
- The current-chat capture fill step is intentionally human/runtime-assisted; the CLI smoke verifies scaffold, validation, install, show, and prompt reuse with a freshly built binary.
- The installed /root/.local/bin/gitmoot may lag the branch during development, so command smoke used a freshly built binary.
