### PR TITLE
Index agent template metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
 ```
 
+Discover templates by metadata:
+
+```sh
+gitmoot agent template list --runtime codex --output goal_file
+gitmoot agent template list --tag review --capability ask
+gitmoot agent template show frontend-reviewer
+```
+
 Reuse a custom agent prompt in the current Codex or Claude chat without
 starting a background job:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -178,6 +178,14 @@ gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
 ```
 
+Discover templates by metadata:
+
+```sh
+gitmoot agent template list --runtime codex --output goal_file
+gitmoot agent template list --tag review --capability ask
+gitmoot agent template show frontend-reviewer
+```
+
 Draft and validate a captured template before installing it:
 
 ```sh

--- a/internal/agenttemplate/agenttemplate.go
+++ b/internal/agenttemplate/agenttemplate.go
@@ -278,6 +278,10 @@ func AddLocal(ctx context.Context, store *db.Store, id string, path string, name
 	if parsed.Metadata.ID != id {
 		return db.AgentTemplate{}, fmt.Errorf("template id %q does not match frontmatter id %q", id, parsed.Metadata.ID)
 	}
+	metadataJSON, err := MarshalMetadata(parsed.Metadata)
+	if err != nil {
+		return db.AgentTemplate{}, err
+	}
 	name = strings.TrimSpace(name)
 	if name == "" {
 		name = parsed.Metadata.Name
@@ -295,6 +299,7 @@ func AddLocal(ctx context.Context, store *db.Store, id string, path string, name
 		SourcePath:     local.Path,
 		ResolvedCommit: HashContent(local.Content),
 		Content:        local.Content,
+		MetadataJSON:   metadataJSON,
 	}
 	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
 		return db.AgentTemplate{}, err
@@ -320,6 +325,10 @@ func UpdateLocal(ctx context.Context, store *db.Store, cached db.AgentTemplate) 
 	if parsed.Metadata.ID != cached.ID {
 		return db.AgentTemplate{}, fmt.Errorf("template id %q does not match frontmatter id %q", cached.ID, parsed.Metadata.ID)
 	}
+	metadataJSON, err := MarshalMetadata(parsed.Metadata)
+	if err != nil {
+		return db.AgentTemplate{}, err
+	}
 	updated := cached
 	updated.Name = parsed.Metadata.Name
 	updated.Description = parsed.Metadata.Description
@@ -328,6 +337,7 @@ func UpdateLocal(ctx context.Context, store *db.Store, cached db.AgentTemplate) 
 	updated.SourcePath = local.Path
 	updated.ResolvedCommit = HashContent(local.Content)
 	updated.Content = local.Content
+	updated.MetadataJSON = metadataJSON
 	if err := store.UpsertAgentTemplate(ctx, updated); err != nil {
 		return db.AgentTemplate{}, err
 	}
@@ -370,7 +380,11 @@ func Update(ctx context.Context, store *db.Store, fetcher Fetcher, id string) (d
 	if err != nil {
 		return db.AgentTemplate{}, err
 	}
-	content, err := ContentForDefinition(definition, file.Content)
+	content, metadata, err := ContentAndMetadataForDefinition(definition, file.Content)
+	if err != nil {
+		return db.AgentTemplate{}, err
+	}
+	metadataJSON, err := MarshalMetadata(metadata)
 	if err != nil {
 		return db.AgentTemplate{}, err
 	}
@@ -383,6 +397,7 @@ func Update(ctx context.Context, store *db.Store, fetcher Fetcher, id string) (d
 		SourcePath:     definition.SourcePath,
 		ResolvedCommit: resolvedCommit,
 		Content:        content,
+		MetadataJSON:   metadataJSON,
 	}
 	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
 		return db.AgentTemplate{}, err
@@ -391,17 +406,23 @@ func Update(ctx context.Context, store *db.Store, fetcher Fetcher, id string) (d
 }
 
 func ContentForDefinition(definition Definition, content string) (string, error) {
+	content, _, err := ContentAndMetadataForDefinition(definition, content)
+	return content, err
+}
+
+func ContentAndMetadataForDefinition(definition Definition, content string) (string, Metadata, error) {
 	if strings.TrimSpace(content) == "" {
-		return "", errors.New("template content is empty")
+		return "", Metadata{}, errors.New("template content is empty")
 	}
 	parsed, err := ParseTemplateContent(content)
 	if err == nil {
 		if parsed.Metadata.ID != definition.ID {
-			return "", fmt.Errorf("template id %q does not match built-in id %q", parsed.Metadata.ID, definition.ID)
+			return "", Metadata{}, fmt.Errorf("template id %q does not match built-in id %q", parsed.Metadata.ID, definition.ID)
 		}
-		return content, nil
+		return content, parsed.Metadata, nil
 	}
-	return FormatTemplateContent(metadataForDefinition(definition), content), nil
+	metadata := MetadataForDefinition(definition)
+	return FormatTemplateContent(metadata, content), metadata, nil
 }
 
 func InstructionsForContent(content string) string {
@@ -412,7 +433,7 @@ func InstructionsForContent(content string) string {
 	return parsed.Body
 }
 
-func metadataForDefinition(definition Definition) Metadata {
+func MetadataForDefinition(definition Definition) Metadata {
 	metadata := Metadata{
 		ID:                   definition.ID,
 		Name:                 definition.Name,

--- a/internal/agenttemplate/agenttemplate_test.go
+++ b/internal/agenttemplate/agenttemplate_test.go
@@ -50,7 +50,7 @@ func TestUpdatePlannerTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update returned error: %v", err)
 	}
-	if updated.ID != PlannerTemplateID || updated.ResolvedCommit != "def456" || updated.Content != content {
+	if updated.ID != PlannerTemplateID || updated.ResolvedCommit != "def456" || updated.Content != content || !strings.Contains(updated.MetadataJSON, `"id":"planner"`) || !strings.Contains(updated.MetadataJSON, `"outputs":["response"]`) {
 		t.Fatalf("updated planner template = %+v", updated)
 	}
 	if updated.SourceRepo != "jerryfane/gitmoot" || updated.SourcePath != "skills/gitmoot/agent-templates/planner.md" {
@@ -214,7 +214,7 @@ func TestAddLocalInstallsCustomTemplate(t *testing.T) {
 	if added.SourceRepo != LocalSourceRepo || added.SourceRef != LocalSourceRef || !filepath.IsAbs(added.SourcePath) {
 		t.Fatalf("added template source = %+v", added)
 	}
-	if added.ResolvedCommit != HashContent(content) || added.Content != content {
+	if added.ResolvedCommit != HashContent(content) || added.Content != content || !strings.Contains(added.MetadataJSON, `"id":"frontend-reviewer"`) {
 		t.Fatalf("added template content = %+v", added)
 	}
 }
@@ -299,7 +299,7 @@ func TestUpdateLocalRefreshesFromStoredPath(t *testing.T) {
 	if updated.Name != "Frontend Review Lead" || updated.Description != "Reviews frontend behavior and polish." {
 		t.Fatalf("UpdateLocal metadata = %+v", updated)
 	}
-	if updated.Content != newContent || updated.ResolvedCommit != HashContent(newContent) {
+	if updated.Content != newContent || updated.ResolvedCommit != HashContent(newContent) || !strings.Contains(updated.MetadataJSON, `"name":"Frontend Review Lead"`) {
 		t.Fatalf("UpdateLocal content = %+v", updated)
 	}
 }

--- a/internal/agenttemplate/frontmatter.go
+++ b/internal/agenttemplate/frontmatter.go
@@ -1,6 +1,7 @@
 package agenttemplate
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -25,17 +26,17 @@ var validTemplateRuntimes = map[string]struct{}{
 }
 
 type Metadata struct {
-	ID                   string            `yaml:"id"`
-	Name                 string            `yaml:"name"`
-	Description          string            `yaml:"description"`
-	Kind                 string            `yaml:"kind"`
-	Version              int               `yaml:"version"`
-	Capabilities         []string          `yaml:"capabilities"`
-	RuntimeCompatibility []string          `yaml:"runtime_compatibility"`
-	Tags                 []string          `yaml:"tags"`
-	Inputs               []string          `yaml:"inputs"`
-	Outputs              []string          `yaml:"outputs"`
-	Evaluation           map[string]string `yaml:"evaluation,omitempty"`
+	ID                   string            `json:"id" yaml:"id"`
+	Name                 string            `json:"name" yaml:"name"`
+	Description          string            `json:"description" yaml:"description"`
+	Kind                 string            `json:"kind" yaml:"kind"`
+	Version              int               `json:"version" yaml:"version"`
+	Capabilities         []string          `json:"capabilities" yaml:"capabilities"`
+	RuntimeCompatibility []string          `json:"runtime_compatibility" yaml:"runtime_compatibility"`
+	Tags                 []string          `json:"tags" yaml:"tags"`
+	Inputs               []string          `json:"inputs" yaml:"inputs"`
+	Outputs              []string          `json:"outputs" yaml:"outputs"`
+	Evaluation           map[string]string `json:"evaluation,omitempty" yaml:"evaluation,omitempty"`
 }
 
 type ParsedTemplate struct {
@@ -60,6 +61,34 @@ func ParseTemplateContent(content string) (ParsedTemplate, error) {
 		return ParsedTemplate{}, errors.New("template body is empty")
 	}
 	return ParsedTemplate{Metadata: metadata, Body: body}, nil
+}
+
+func MarshalMetadata(metadata Metadata) (string, error) {
+	metadata = normalizeMetadata(metadata)
+	if err := validateMetadata(metadata); err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return "", fmt.Errorf("encode template metadata: %w", err)
+	}
+	return string(encoded), nil
+}
+
+func UnmarshalMetadata(content string) (Metadata, error) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return Metadata{}, errors.New("template metadata is empty")
+	}
+	var metadata Metadata
+	if err := json.Unmarshal([]byte(content), &metadata); err != nil {
+		return Metadata{}, fmt.Errorf("decode template metadata: %w", err)
+	}
+	metadata = normalizeMetadata(metadata)
+	if err := validateMetadata(metadata); err != nil {
+		return Metadata{}, err
+	}
+	return metadata, nil
 }
 
 func splitFrontmatter(content string) (string, string, error) {

--- a/internal/cli/agent_template.go
+++ b/internal/cli/agent_template.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
@@ -190,6 +191,14 @@ func runAgentTemplateList(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("agent template list", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	var capabilityFilters repeatedFlag
+	var runtimeFilters repeatedFlag
+	var tagFilters repeatedFlag
+	var outputFilters repeatedFlag
+	fs.Var(&capabilityFilters, "capability", "filter by template capability")
+	fs.Var(&runtimeFilters, "runtime", "filter by compatible runtime")
+	fs.Var(&tagFilters, "tag", "filter by template tag")
+	fs.Var(&outputFilters, "output", "filter by template output")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -199,6 +208,12 @@ func runAgentTemplateList(args []string, stdout, stderr io.Writer) int {
 	if fs.NArg() != 0 {
 		fmt.Fprintln(stderr, "agent template list does not accept positional arguments")
 		return 2
+	}
+	filters := templateListFilters{
+		Capabilities: compactValues(capabilityFilters),
+		Runtimes:     compactValues(runtimeFilters),
+		Tags:         compactValues(tagFilters),
+		Outputs:      compactValues(outputFilters),
 	}
 	return withStoreExit(*home, stderr, "list agent templates", func(store *db.Store) error {
 		cachedTemplates, err := store.ListAgentTemplates(context.Background())
@@ -211,6 +226,10 @@ func runAgentTemplateList(args []string, stdout, stderr io.Writer) int {
 			if installedTemplate, ok := installed[definition.ID]; ok {
 				status = "installed@" + shortCommit(installedTemplate.ResolvedCommit)
 			}
+			metadata := metadataForTemplateDefinition(definition, installed[definition.ID])
+			if !filters.Match(metadata) {
+				continue
+			}
 			fmt.Fprintf(stdout, "%-36s %-18s %s\n", definition.ID, status, definition.SourceRepo+"/"+definition.SourcePath)
 		}
 		for _, cached := range cachedTemplates {
@@ -218,6 +237,10 @@ func runAgentTemplateList(args []string, stdout, stderr io.Writer) int {
 				continue
 			}
 			if agenttemplate.IsRetired(cached.ID) {
+				continue
+			}
+			metadata, ok := metadataForCachedTemplate(cached)
+			if !filters.MatchOptional(metadata, ok) {
 				continue
 			}
 			status := "installed@" + shortCommit(cached.ResolvedCommit)
@@ -255,6 +278,7 @@ func runAgentTemplateShow(args []string, stdout, stderr io.Writer) int {
 				return err
 			}
 			writeTemplateDefinition(stdout, definition)
+			writeTemplateMetadata(stdout, metadataForTemplateDefinition(definition, cached))
 			if !installed {
 				fmt.Fprintln(stdout, "installed: no")
 				return nil
@@ -412,7 +436,32 @@ func writeCustomTemplate(w io.Writer, cached db.AgentTemplate) {
 	fmt.Fprintln(w, "default role: ")
 	fmt.Fprintln(w, "default capabilities: ")
 	fmt.Fprintln(w, "mutation: false")
+	if metadata, ok := metadataForCachedTemplate(cached); ok {
+		writeTemplateMetadata(w, metadata)
+	}
 	writeInstalledTemplate(w, cached)
+}
+
+func writeTemplateMetadata(w io.Writer, metadata agenttemplate.Metadata) {
+	fmt.Fprintln(w, "metadata:")
+	fmt.Fprintf(w, "  kind: %s\n", metadata.Kind)
+	fmt.Fprintf(w, "  version: %d\n", metadata.Version)
+	fmt.Fprintf(w, "  capabilities: %s\n", strings.Join(metadata.Capabilities, ","))
+	fmt.Fprintf(w, "  runtime compatibility: %s\n", strings.Join(metadata.RuntimeCompatibility, ","))
+	fmt.Fprintf(w, "  tags: %s\n", strings.Join(metadata.Tags, ","))
+	fmt.Fprintf(w, "  inputs: %s\n", strings.Join(metadata.Inputs, ","))
+	fmt.Fprintf(w, "  outputs: %s\n", strings.Join(metadata.Outputs, ","))
+	if len(metadata.Evaluation) > 0 {
+		keys := make([]string, 0, len(metadata.Evaluation))
+		for key := range metadata.Evaluation {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		fmt.Fprintln(w, "  evaluation:")
+		for _, key := range keys {
+			fmt.Fprintf(w, "    %s: %s\n", key, metadata.Evaluation[key])
+		}
+	}
 }
 
 func writeInstalledTemplate(w io.Writer, cached db.AgentTemplate) {
@@ -421,6 +470,61 @@ func writeInstalledTemplate(w io.Writer, cached db.AgentTemplate) {
 	fmt.Fprintf(w, "updated: %s\n", cached.UpdatedAt)
 	fmt.Fprintln(w, "content:")
 	fmt.Fprintln(w, strings.TrimRight(cached.Content, "\n"))
+}
+
+type templateListFilters struct {
+	Capabilities []string
+	Runtimes     []string
+	Tags         []string
+	Outputs      []string
+}
+
+func (f templateListFilters) Empty() bool {
+	return len(f.Capabilities) == 0 && len(f.Runtimes) == 0 && len(f.Tags) == 0 && len(f.Outputs) == 0
+}
+
+func (f templateListFilters) MatchOptional(metadata agenttemplate.Metadata, ok bool) bool {
+	if !ok {
+		return f.Empty()
+	}
+	return f.Match(metadata)
+}
+
+func (f templateListFilters) Match(metadata agenttemplate.Metadata) bool {
+	return containsAll(metadata.Capabilities, f.Capabilities) &&
+		containsAll(metadata.RuntimeCompatibility, f.Runtimes) &&
+		containsAll(metadata.Tags, f.Tags) &&
+		containsAll(metadata.Outputs, f.Outputs)
+}
+
+func containsAll(values []string, filters []string) bool {
+	for _, filter := range filters {
+		if !containsValue(values, filter) {
+			return false
+		}
+	}
+	return true
+}
+
+func metadataForTemplateDefinition(definition agenttemplate.Definition, cached db.AgentTemplate) agenttemplate.Metadata {
+	if metadata, ok := metadataForCachedTemplate(cached); ok {
+		return metadata
+	}
+	return agenttemplate.MetadataForDefinition(definition)
+}
+
+func metadataForCachedTemplate(cached db.AgentTemplate) (agenttemplate.Metadata, bool) {
+	if strings.TrimSpace(cached.MetadataJSON) != "" {
+		metadata, err := agenttemplate.UnmarshalMetadata(cached.MetadataJSON)
+		if err == nil {
+			return metadata, true
+		}
+	}
+	parsed, err := agenttemplate.ParseTemplateContent(cached.Content)
+	if err != nil {
+		return agenttemplate.Metadata{}, false
+	}
+	return parsed.Metadata, true
 }
 
 func shortCommit(commit string) string {

--- a/internal/cli/agent_template_test.go
+++ b/internal/cli/agent_template_test.go
@@ -39,7 +39,7 @@ func TestAgentTemplateUpdateInstallsThermoTemplate(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("template show exit code = %d, stderr=%s", code, stderr.String())
 	}
-	for _, want := range []string{"installed: yes", "resolved commit: abc123", "Review deeply."} {
+	for _, want := range []string{"installed: yes", "resolved commit: abc123", "metadata:", "outputs: review_findings", "Review deeply."} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("show output missing %q:\n%s", want, stdout.String())
 		}
@@ -110,8 +110,9 @@ func TestAgentTemplateDiffDoesNotMutateCachedTemplate(t *testing.T) {
 
 func TestAgentTemplateListShowsAvailableBuiltin(t *testing.T) {
 	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
 
-	code := Run([]string{"agent", "template", "list", "--home", t.TempDir()}, &stdout, &stderr)
+	code := Run([]string{"agent", "template", "list", "--home", home}, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("template list exit code = %d, stderr=%s", code, stderr.String())
@@ -122,6 +123,18 @@ func TestAgentTemplateListShowsAvailableBuiltin(t *testing.T) {
 	removedPlannerHereID := "planner-" + "here"
 	if strings.Contains(stdout.String(), removedPlannerHereID) {
 		t.Fatalf("removed planner id should not be listed as a builtin:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "template", "show", "--home", home, "planner"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"installed: no", "metadata:", "outputs: plan,goal_file", "evaluation:"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("show output missing %q:\n%s", want, stdout.String())
+		}
 	}
 }
 
@@ -154,7 +167,7 @@ func TestAgentTemplateAddInstallsLocalCustomTemplate(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("template show exit code = %d, stderr=%s", code, stderr.String())
 	}
-	for _, want := range []string{"name: Frontend Reviewer", "description: Reviews UI.", "source: local@file:", "installed: yes", "Review frontend changes."} {
+	for _, want := range []string{"name: Frontend Reviewer", "description: Reviews UI.", "source: local@file:", "metadata:", "outputs: response", "installed: yes", "Review frontend changes."} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("show output missing %q:\n%s", want, stdout.String())
 		}
@@ -347,6 +360,66 @@ func TestAgentTemplateListShowsInstalledCustomTemplate(t *testing.T) {
 	}
 	if strings.Index(stdout.String(), "api-reviewer") > strings.Index(stdout.String(), "frontend-reviewer") {
 		t.Fatalf("custom agent templates are not sorted:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "template", "list", "--home", home, "--output", "goal_file", "--runtime", "codex"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template list filter exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "planner") || strings.Contains(stdout.String(), "frontend-reviewer") || strings.Contains(stdout.String(), "thermo-nuclear-code-quality-review") {
+		t.Fatalf("goal_file filter output =\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "template", "list", "--home", home, "--output", "response", "--tag", "review"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template list custom filter exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "api-reviewer") || !strings.Contains(stdout.String(), "frontend-reviewer") || strings.Contains(stdout.String(), "planner") {
+		t.Fatalf("response filter output =\n%s", stdout.String())
+	}
+}
+
+func TestAgentTemplateListFiltersMigratedFrontmatterTemplate(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+
+	if code := Run([]string{"init", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("init exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	seedCachedAgentTemplate(t, home, db.AgentTemplate{
+		ID:             "migrated-reviewer",
+		Name:           "Migrated Reviewer",
+		Description:    "Migrated custom template",
+		SourceRepo:     "local",
+		SourceRef:      "file",
+		SourcePath:     "/tmp/migrated-reviewer.md",
+		ResolvedCommit: "sha256:abc123",
+		Content:        testLocalTemplateContent("migrated-reviewer", "Review migrated changes.\n"),
+	})
+
+	code := Run([]string{"agent", "template", "list", "--home", home, "--output", "response", "--runtime", "codex"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "migrated-reviewer") {
+		t.Fatalf("migrated template missing from filtered list:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "template", "show", "--home", home, "migrated-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "metadata:") || !strings.Contains(stdout.String(), "outputs: response") {
+		t.Fatalf("migrated template metadata missing from show:\n%s", stdout.String())
 	}
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -50,6 +50,7 @@ type AgentTemplate struct {
 	SourcePath     string
 	ResolvedCommit string
 	Content        string
+	MetadataJSON   string
 	CreatedAt      string
 	UpdatedAt      string
 }
@@ -515,8 +516,8 @@ func (s *Store) ListAgentRepos(ctx context.Context, agentName string) ([]string,
 }
 
 func (s *Store) UpsertAgentTemplate(ctx context.Context, template AgentTemplate) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO agent_templates(id, name, description, source_repo, source_ref, source_path, resolved_commit, content, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO agent_templates(id, name, description, source_repo, source_ref, source_path, resolved_commit, content, metadata_json, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			name = excluded.name,
 			description = excluded.description,
@@ -525,19 +526,20 @@ func (s *Store) UpsertAgentTemplate(ctx context.Context, template AgentTemplate)
 			source_path = excluded.source_path,
 			resolved_commit = excluded.resolved_commit,
 			content = excluded.content,
+			metadata_json = excluded.metadata_json,
 			updated_at = CURRENT_TIMESTAMP`,
-		template.ID, template.Name, template.Description, template.SourceRepo, template.SourceRef, template.SourcePath, template.ResolvedCommit, template.Content)
+		template.ID, template.Name, template.Description, template.SourceRepo, template.SourceRef, template.SourcePath, template.ResolvedCommit, template.Content, template.MetadataJSON)
 	return err
 }
 
 func (s *Store) GetAgentTemplate(ctx context.Context, id string) (AgentTemplate, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, name, description, source_repo, source_ref, source_path, resolved_commit, content, created_at, updated_at
+	row := s.db.QueryRowContext(ctx, `SELECT id, name, description, source_repo, source_ref, source_path, resolved_commit, content, metadata_json, created_at, updated_at
 		FROM agent_templates WHERE id = ?`, id)
 	return scanAgentTemplate(row)
 }
 
 func (s *Store) ListAgentTemplates(ctx context.Context) ([]AgentTemplate, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, name, description, source_repo, source_ref, source_path, resolved_commit, content, created_at, updated_at
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, description, source_repo, source_ref, source_path, resolved_commit, content, metadata_json, created_at, updated_at
 		FROM agent_templates ORDER BY id`)
 	if err != nil {
 		return nil, err
@@ -1527,7 +1529,7 @@ type agentTemplateScanner interface {
 
 func scanAgentTemplate(scanner agentTemplateScanner) (AgentTemplate, error) {
 	var template AgentTemplate
-	if err := scanner.Scan(&template.ID, &template.Name, &template.Description, &template.SourceRepo, &template.SourceRef, &template.SourcePath, &template.ResolvedCommit, &template.Content, &template.CreatedAt, &template.UpdatedAt); err != nil {
+	if err := scanner.Scan(&template.ID, &template.Name, &template.Description, &template.SourceRepo, &template.SourceRef, &template.SourcePath, &template.ResolvedCommit, &template.Content, &template.MetadataJSON, &template.CreatedAt, &template.UpdatedAt); err != nil {
 		return AgentTemplate{}, err
 	}
 	return template, nil
@@ -1773,5 +1775,8 @@ UPDATE agents SET template_id = preset_id WHERE template_id = '' AND preset_id <
 
 ALTER TABLE agent_instances ADD COLUMN template_id TEXT NOT NULL DEFAULT '';
 UPDATE agent_instances SET template_id = preset_id WHERE template_id = '' AND preset_id <> '';
+	`,
+	`
+ALTER TABLE agent_templates ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -410,6 +410,7 @@ func TestRepositoryMethods(t *testing.T) {
 		SourcePath:     "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
 		ResolvedCommit: "abc123",
 		Content:        "Review deeply.",
+		MetadataJSON:   `{"id":"thermo","name":"Thermo","description":"Strict review","kind":"agent-template","version":1,"capabilities":["review"],"runtime_compatibility":["codex"],"tags":["review"],"inputs":["repo"],"outputs":["review_findings"]}`,
 	}); err != nil {
 		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
 	}
@@ -417,7 +418,7 @@ func TestRepositoryMethods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAgentTemplate returned error: %v", err)
 	}
-	if template.ResolvedCommit != "abc123" || template.Content != "Review deeply." || template.CreatedAt == "" || template.UpdatedAt == "" {
+	if template.ResolvedCommit != "abc123" || template.Content != "Review deeply." || !strings.Contains(template.MetadataJSON, `"kind":"agent-template"`) || template.CreatedAt == "" || template.UpdatedAt == "" {
 		t.Fatalf("template = %+v", template)
 	}
 	templates, err := store.ListAgentTemplates(ctx)
@@ -883,7 +884,14 @@ func TestMigrationCopiesPresetsToAgentTemplates(t *testing.T) {
 	)`); err != nil {
 		t.Fatalf("create schema_migrations returned error: %v", err)
 	}
-	for version, migration := range migrations[:len(migrations)-1] {
+	templateMigration := len(migrations) - 1
+	for i, migration := range migrations {
+		if strings.Contains(migration, "DROP TABLE presets") {
+			templateMigration = i
+			break
+		}
+	}
+	for version, migration := range migrations[:templateMigration] {
 		if _, err := raw.ExecContext(ctx, migration); err != nil {
 			t.Fatalf("apply seed migration %d returned error: %v", version+1, err)
 		}
@@ -917,7 +925,7 @@ func TestMigrationCopiesPresetsToAgentTemplates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAgentTemplate returned error: %v", err)
 	}
-	if template.Content != "legacy instructions" || template.ResolvedCommit != "abc123" {
+	if template.Content != "legacy instructions" || template.ResolvedCommit != "abc123" || template.MetadataJSON != "" {
 		t.Fatalf("template = %+v", template)
 	}
 	agent, err := store.GetAgent(ctx, "legacy-agent")

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -197,6 +197,14 @@ gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
 ```
 
+Discover templates by metadata:
+
+```sh
+gitmoot agent template list --runtime codex --output goal_file
+gitmoot agent template list --tag review --capability ask
+gitmoot agent template show frontend-reviewer
+```
+
 ## Goals
 
 Print the standard Gitmoot goal prompt template:

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -211,6 +211,14 @@ gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
 ```
 
+Discover templates by metadata:
+
+```sh
+gitmoot agent template list --runtime codex --output goal_file
+gitmoot agent template list --tag review --capability ask
+gitmoot agent template show frontend-reviewer
+```
+
 Reuse a custom agent prompt in the current Codex or Claude chat without
 starting a background job:
 
@@ -505,6 +513,14 @@ After editing a local template file, refresh Gitmoot's cached snapshot explicitl
 ```sh
 gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
+```
+
+Discover templates by metadata:
+
+```sh
+gitmoot agent template list --runtime codex --output goal_file
+gitmoot agent template list --tag review --capability ask
+gitmoot agent template show frontend-reviewer
 ```
 
 Draft and validate a captured template before installing it:
@@ -2738,6 +2754,14 @@ After editing a local template file, refresh Gitmoot's cached snapshot:
 ```sh
 gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
+```
+
+Discover templates by metadata:
+
+```sh
+gitmoot agent template list --runtime codex --output goal_file
+gitmoot agent template list --tag review --capability ask
+gitmoot agent template show frontend-reviewer
 ```
 
 ## Goals


### PR DESCRIPTION
WHAT: Indexed parsed agent template metadata alongside template content and exposed metadata filters for template discovery.

WHY: Skill-like templates need reusable metadata for discovery by capability, runtime, tag, and output without reparsing every listing path.

CHANGES:
- Added metadata_json storage for agent_templates with migration coverage.
- Added JSON marshal/unmarshal helpers for validated template metadata.
- Stored parsed metadata for local and built-in template installs/updates, including fetched built-in frontmatter.
- Added agent template list filters: --capability, --runtime, --tag, --output.
- Updated agent template show to print parsed metadata.
- Preserved fallback parsing for migrated templates that have frontmatter content but no metadata_json.
- Updated README, SKILL.md, CLI reference, and generated llms docs.

RESULTS:
- /root/temp/ts/tool/go test ./internal/db ./internal/agenttemplate ./internal/cli
- /root/temp/ts/tool/go test ./...
- git diff --check
- CLI smoke: built-in metadata filter/show for planner
- CLI smoke: custom template add, metadata filter/show
- codex exec review --uncommitted final output:

```text
I found no discrete correctness issues in the staged changes. Targeted tests could not be run because the sandbox cannot download the required Go 1.26 toolchain.
I found no discrete correctness issues in the staged changes. Targeted tests could not be run because the sandbox cannot download the required Go 1.26 toolchain.
```

RISK: Codex review could not run tests inside its own sandbox because it could not download the Go 1.26 toolchain. Local tests were run successfully with /root/temp/ts/tool/go.