### PR TITLE
Version agent templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
 ```
 
+Template updates are versioned locally. `gitmoot agent template show <id>`
+prints the current version, content hash, source commit, and promotion state.
+Agents use the current promoted version by default, or a pinned version when
+configured with a reference such as `--template frontend-reviewer@v1`.
+Queued jobs keep the exact template content snapshot they were created with.
+
 Discover templates by metadata:
 
 ```sh

--- a/SKILL.md
+++ b/SKILL.md
@@ -178,6 +178,12 @@ gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
 ```
 
+Template updates are versioned locally. `gitmoot agent template show <id>`
+prints the current version, content hash, source commit, and promotion state.
+Agents use the current promoted version by default, or a pinned version when
+configured with a reference such as `--template frontend-reviewer@v1`.
+Queued jobs keep the exact template content snapshot they were created with.
+
 Discover templates by metadata:
 
 ```sh

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -796,9 +796,10 @@ func resolveAgentDefaults(templateID string, role string, capabilities []string,
 		}
 		return role, resolvedCapabilities, nil
 	}
-	definition, ok := agenttemplate.Lookup(templateID)
+	logicalTemplateID, _ := db.SplitAgentTemplateReference(templateID)
+	definition, ok := agenttemplate.Lookup(logicalTemplateID)
 	if !ok {
-		if err := agenttemplate.ValidateID(templateID); err != nil {
+		if err := agenttemplate.ValidateID(logicalTemplateID); err != nil {
 			return "", nil, err
 		}
 		if role == "" {
@@ -828,15 +829,16 @@ func resolveAgentDefaults(templateID string, role string, capabilities []string,
 }
 
 func loadInstalledTemplate(ctx context.Context, store *db.Store, templateID string) (db.AgentTemplate, error) {
-	if agenttemplate.IsRetired(templateID) {
-		return db.AgentTemplate{}, retiredAgentTemplateError(templateID)
+	logicalTemplateID, _ := db.SplitAgentTemplateReference(templateID)
+	if agenttemplate.IsRetired(logicalTemplateID) {
+		return db.AgentTemplate{}, retiredAgentTemplateError(logicalTemplateID)
 	}
-	cached, err := store.GetAgentTemplate(ctx, templateID)
+	cached, err := store.GetAgentTemplateReference(ctx, templateID)
 	if errors.Is(err, sql.ErrNoRows) {
-		if _, ok := agenttemplate.Lookup(templateID); !ok {
-			return db.AgentTemplate{}, fmt.Errorf("agent template %s is not installed; run gitmoot agent template add %s --file <path>", templateID, templateID)
+		if _, ok := agenttemplate.Lookup(logicalTemplateID); !ok {
+			return db.AgentTemplate{}, fmt.Errorf("agent template %s is not installed; run gitmoot agent template add %s --file <path>", logicalTemplateID, logicalTemplateID)
 		}
-		return db.AgentTemplate{}, fmt.Errorf("agent template %s is not installed; run gitmoot agent template update %s", templateID, templateID)
+		return db.AgentTemplate{}, fmt.Errorf("agent template %s is not installed; run gitmoot agent template update %s", logicalTemplateID, logicalTemplateID)
 	}
 	return cached, err
 }

--- a/internal/cli/agent_template.go
+++ b/internal/cli/agent_template.go
@@ -466,6 +466,14 @@ func writeTemplateMetadata(w io.Writer, metadata agenttemplate.Metadata) {
 
 func writeInstalledTemplate(w io.Writer, cached db.AgentTemplate) {
 	fmt.Fprintln(w, "installed: yes")
+	if cached.VersionID != "" {
+		fmt.Fprintf(w, "version: v%d\n", cached.VersionNumber)
+		fmt.Fprintf(w, "version id: %s\n", cached.VersionID)
+		fmt.Fprintf(w, "promotion state: %s\n", cached.VersionState)
+	}
+	if cached.ContentHash != "" {
+		fmt.Fprintf(w, "content hash: %s\n", cached.ContentHash)
+	}
 	fmt.Fprintf(w, "resolved commit: %s\n", cached.ResolvedCommit)
 	fmt.Fprintf(w, "updated: %s\n", cached.UpdatedAt)
 	fmt.Fprintln(w, "content:")

--- a/internal/cli/agent_template_test.go
+++ b/internal/cli/agent_template_test.go
@@ -39,7 +39,7 @@ func TestAgentTemplateUpdateInstallsThermoTemplate(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("template show exit code = %d, stderr=%s", code, stderr.String())
 	}
-	for _, want := range []string{"installed: yes", "resolved commit: abc123", "metadata:", "outputs: review_findings", "Review deeply."} {
+	for _, want := range []string{"installed: yes", "version: v1", "version id: thermo-nuclear-code-quality-review@v1", "promotion state: current", "content hash: sha256:", "resolved commit: abc123", "metadata:", "outputs: review_findings", "Review deeply."} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("show output missing %q:\n%s", want, stdout.String())
 		}
@@ -167,7 +167,7 @@ func TestAgentTemplateAddInstallsLocalCustomTemplate(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("template show exit code = %d, stderr=%s", code, stderr.String())
 	}
-	for _, want := range []string{"name: Frontend Reviewer", "description: Reviews UI.", "source: local@file:", "metadata:", "outputs: response", "installed: yes", "Review frontend changes."} {
+	for _, want := range []string{"name: Frontend Reviewer", "description: Reviews UI.", "source: local@file:", "metadata:", "outputs: response", "installed: yes", "version: v1", "promotion state: current", "content hash: sha256:", "Review frontend changes."} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("show output missing %q:\n%s", want, stdout.String())
 		}
@@ -467,6 +467,17 @@ func TestAgentTemplateUpdateAndDiffLocalCustomTemplate(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "updated frontend-reviewer at sha256:") {
 		t.Fatalf("stdout = %s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "template", "show", "--home", home, "frontend-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template show after update exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"version: v2", "version id: frontend-reviewer@v2", "promotion state: current", "New prompt."} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("show after update missing %q:\n%s", want, stdout.String())
+		}
 	}
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -51,8 +53,31 @@ type AgentTemplate struct {
 	ResolvedCommit string
 	Content        string
 	MetadataJSON   string
+	VersionID      string
+	VersionNumber  int
+	VersionState   string
+	ContentHash    string
 	CreatedAt      string
 	UpdatedAt      string
+}
+
+type AgentTemplateVersion struct {
+	ID             string
+	TemplateID     string
+	VersionNumber  int
+	State          string
+	Name           string
+	Description    string
+	SourceRepo     string
+	SourceRef      string
+	SourcePath     string
+	ResolvedCommit string
+	ContentHash    string
+	Content        string
+	MetadataJSON   string
+	CreatedAt      string
+	UpdatedAt      string
+	PromotedAt     string
 }
 
 type AgentRepo struct {
@@ -516,8 +541,55 @@ func (s *Store) ListAgentRepos(ctx context.Context, agentName string) ([]string,
 }
 
 func (s *Store) UpsertAgentTemplate(ctx context.Context, template AgentTemplate) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO agent_templates(id, name, description, source_repo, source_ref, source_path, resolved_commit, content, metadata_json, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	contentHash := templateContentHash(template.Content)
+	current, hasCurrent, err := getCurrentAgentTemplateVersion(ctx, tx, template.ID)
+	if err != nil {
+		return err
+	}
+	versionID := current.ID
+	versionNumber := current.VersionNumber
+	if !hasCurrent || current.ContentHash != contentHash {
+		versionNumber, err = nextAgentTemplateVersionNumber(ctx, tx, template.ID)
+		if err != nil {
+			return err
+		}
+		versionID = agentTemplateVersionID(template.ID, versionNumber)
+		if hasCurrent {
+			if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'superseded', updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = 'current'`, current.ID); err != nil {
+				return err
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO agent_template_versions(id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, promoted_at, updated_at)
+			VALUES (?, ?, ?, 'current', ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			versionID, template.ID, versionNumber, template.Name, template.Description, template.SourceRepo, template.SourceRef, template.SourcePath, template.ResolvedCommit, contentHash, template.Content, template.MetadataJSON); err != nil {
+			return err
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions
+			SET state = 'current',
+				name = ?,
+				description = ?,
+				source_repo = ?,
+				source_ref = ?,
+				source_path = ?,
+				resolved_commit = ?,
+				content_hash = ?,
+				content = ?,
+				metadata_json = ?,
+				updated_at = CURRENT_TIMESTAMP
+			WHERE id = ?`,
+			template.Name, template.Description, template.SourceRepo, template.SourceRef, template.SourcePath, template.ResolvedCommit, contentHash, template.Content, template.MetadataJSON, current.ID); err != nil {
+			return err
+		}
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO agent_templates(id, name, description, source_repo, source_ref, source_path, resolved_commit, content, metadata_json, current_version_id, latest_version_id, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			name = excluded.name,
 			description = excluded.description,
@@ -527,33 +599,134 @@ func (s *Store) UpsertAgentTemplate(ctx context.Context, template AgentTemplate)
 			resolved_commit = excluded.resolved_commit,
 			content = excluded.content,
 			metadata_json = excluded.metadata_json,
+			current_version_id = excluded.current_version_id,
+			latest_version_id = CASE
+				WHEN agent_templates.current_version_id = excluded.current_version_id AND agent_templates.latest_version_id <> '' THEN agent_templates.latest_version_id
+				ELSE excluded.latest_version_id
+			END,
 			updated_at = CURRENT_TIMESTAMP`,
-		template.ID, template.Name, template.Description, template.SourceRepo, template.SourceRef, template.SourcePath, template.ResolvedCommit, template.Content, template.MetadataJSON)
-	return err
+		template.ID, template.Name, template.Description, template.SourceRepo, template.SourceRef, template.SourcePath, template.ResolvedCommit, template.Content, template.MetadataJSON, versionID, versionID)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) GetAgentTemplate(ctx context.Context, id string) (AgentTemplate, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, name, description, source_repo, source_ref, source_path, resolved_commit, content, metadata_json, created_at, updated_at
-		FROM agent_templates WHERE id = ?`, id)
-	return scanAgentTemplate(row)
+	row := s.db.QueryRowContext(ctx, `SELECT t.id, t.name, t.description, t.source_repo, t.source_ref, t.source_path, t.resolved_commit, t.content, t.metadata_json,
+			COALESCE(v.id, ''), COALESCE(v.version, 0), COALESCE(v.state, ''), COALESCE(NULLIF(v.content_hash, ''), ''), t.created_at, t.updated_at
+		FROM agent_templates t
+		LEFT JOIN agent_template_versions v ON v.id = t.current_version_id
+		WHERE t.id = ?`, id)
+	return scanAgentTemplateWithVersion(row)
 }
 
 func (s *Store) ListAgentTemplates(ctx context.Context) ([]AgentTemplate, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, name, description, source_repo, source_ref, source_path, resolved_commit, content, metadata_json, created_at, updated_at
-		FROM agent_templates ORDER BY id`)
+	rows, err := s.db.QueryContext(ctx, `SELECT t.id, t.name, t.description, t.source_repo, t.source_ref, t.source_path, t.resolved_commit, t.content, t.metadata_json,
+			COALESCE(v.id, ''), COALESCE(v.version, 0), COALESCE(v.state, ''), COALESCE(NULLIF(v.content_hash, ''), ''), t.created_at, t.updated_at
+		FROM agent_templates t
+		LEFT JOIN agent_template_versions v ON v.id = t.current_version_id
+		ORDER BY t.id`)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 	templates := []AgentTemplate{}
 	for rows.Next() {
-		template, err := scanAgentTemplate(rows)
+		template, err := scanAgentTemplateWithVersion(rows)
 		if err != nil {
 			return nil, err
 		}
 		templates = append(templates, template)
 	}
 	return templates, rows.Err()
+}
+
+func (s *Store) GetAgentTemplateReference(ctx context.Context, ref string) (AgentTemplate, error) {
+	templateID, versionRef := SplitAgentTemplateReference(ref)
+	if versionRef == "" || versionRef == "current" {
+		return s.GetAgentTemplate(ctx, templateID)
+	}
+	if versionRef == "latest" {
+		return s.GetLatestAgentTemplateVersion(ctx, templateID)
+	}
+	version, err := s.GetAgentTemplateVersion(ctx, templateID, versionRef)
+	if err != nil {
+		return AgentTemplate{}, err
+	}
+	return agentTemplateFromVersion(version), nil
+}
+
+func (s *Store) GetLatestAgentTemplateVersion(ctx context.Context, templateID string) (AgentTemplate, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT v.id, v.template_id, v.version, v.state, v.name, v.description, v.source_repo, v.source_ref, v.source_path, v.resolved_commit, v.content_hash, v.content, v.metadata_json, v.created_at, v.updated_at, v.promoted_at
+		FROM agent_templates t
+		JOIN agent_template_versions v ON v.id = t.latest_version_id
+		WHERE t.id = ?`, strings.TrimSpace(templateID))
+	version, err := scanAgentTemplateVersion(row)
+	if err != nil {
+		return AgentTemplate{}, err
+	}
+	return agentTemplateFromVersion(version), nil
+}
+
+func (s *Store) GetAgentTemplateVersion(ctx context.Context, templateID string, versionRef string) (AgentTemplateVersion, error) {
+	templateID = strings.TrimSpace(templateID)
+	versionRef = strings.TrimSpace(versionRef)
+	if strings.HasPrefix(versionRef, "v") && len(versionRef) > 1 {
+		versionRef = versionRef[1:]
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
+		FROM agent_template_versions
+		WHERE template_id = ? AND (id = ? OR CAST(version AS TEXT) = ?)`, templateID, templateID+"@v"+versionRef, versionRef)
+	return scanAgentTemplateVersion(row)
+}
+
+func (s *Store) ListAgentTemplateVersions(ctx context.Context, templateID string) ([]AgentTemplateVersion, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
+		FROM agent_template_versions WHERE template_id = ? ORDER BY version`, templateID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	versions := []AgentTemplateVersion{}
+	for rows.Next() {
+		version, err := scanAgentTemplateVersion(rows)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, version)
+	}
+	return versions, rows.Err()
+}
+
+func (s *Store) AddPendingAgentTemplateVersion(ctx context.Context, template AgentTemplate) (AgentTemplateVersion, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	defer tx.Rollback()
+	versionNumber, err := nextAgentTemplateVersionNumber(ctx, tx, template.ID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	versionID := agentTemplateVersionID(template.ID, versionNumber)
+	contentHash := templateContentHash(template.Content)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO agent_template_versions(id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, updated_at)
+		VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		versionID, template.ID, versionNumber, template.Name, template.Description, template.SourceRepo, template.SourceRef, template.SourcePath, template.ResolvedCommit, contentHash, template.Content, template.MetadataJSON); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET latest_version_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, versionID, template.ID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := requireAffected(result, "agent template", template.ID); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	return s.GetAgentTemplateVersion(ctx, template.ID, fmt.Sprintf("v%d", versionNumber))
 }
 
 func (s *Store) AgentCanAccessRepo(ctx context.Context, agentName string, repoFullName string) (bool, error) {
@@ -1532,7 +1705,100 @@ func scanAgentTemplate(scanner agentTemplateScanner) (AgentTemplate, error) {
 	if err := scanner.Scan(&template.ID, &template.Name, &template.Description, &template.SourceRepo, &template.SourceRef, &template.SourcePath, &template.ResolvedCommit, &template.Content, &template.MetadataJSON, &template.CreatedAt, &template.UpdatedAt); err != nil {
 		return AgentTemplate{}, err
 	}
+	template.ContentHash = templateContentHash(template.Content)
+	template.VersionState = "current"
 	return template, nil
+}
+
+func scanAgentTemplateWithVersion(scanner agentTemplateScanner) (AgentTemplate, error) {
+	var template AgentTemplate
+	if err := scanner.Scan(&template.ID, &template.Name, &template.Description, &template.SourceRepo, &template.SourceRef, &template.SourcePath, &template.ResolvedCommit, &template.Content, &template.MetadataJSON, &template.VersionID, &template.VersionNumber, &template.VersionState, &template.ContentHash, &template.CreatedAt, &template.UpdatedAt); err != nil {
+		return AgentTemplate{}, err
+	}
+	if template.ContentHash == "" {
+		template.ContentHash = templateContentHash(template.Content)
+	}
+	if template.VersionState == "" {
+		template.VersionState = "current"
+	}
+	return template, nil
+}
+
+func scanAgentTemplateVersion(scanner agentTemplateScanner) (AgentTemplateVersion, error) {
+	var version AgentTemplateVersion
+	if err := scanner.Scan(&version.ID, &version.TemplateID, &version.VersionNumber, &version.State, &version.Name, &version.Description, &version.SourceRepo, &version.SourceRef, &version.SourcePath, &version.ResolvedCommit, &version.ContentHash, &version.Content, &version.MetadataJSON, &version.CreatedAt, &version.UpdatedAt, &version.PromotedAt); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if version.ContentHash == "" {
+		version.ContentHash = templateContentHash(version.Content)
+	}
+	return version, nil
+}
+
+func agentTemplateFromVersion(version AgentTemplateVersion) AgentTemplate {
+	return AgentTemplate{
+		ID:             version.TemplateID,
+		Name:           version.Name,
+		Description:    version.Description,
+		SourceRepo:     version.SourceRepo,
+		SourceRef:      version.SourceRef,
+		SourcePath:     version.SourcePath,
+		ResolvedCommit: version.ResolvedCommit,
+		Content:        version.Content,
+		MetadataJSON:   version.MetadataJSON,
+		VersionID:      version.ID,
+		VersionNumber:  version.VersionNumber,
+		VersionState:   version.State,
+		ContentHash:    version.ContentHash,
+		CreatedAt:      version.CreatedAt,
+		UpdatedAt:      version.UpdatedAt,
+	}
+}
+
+func SplitAgentTemplateReference(ref string) (string, string) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", ""
+	}
+	if index := strings.LastIndex(ref, "@"); index > 0 {
+		return strings.TrimSpace(ref[:index]), strings.TrimSpace(ref[index+1:])
+	}
+	return ref, ""
+}
+
+func getCurrentAgentTemplateVersion(ctx context.Context, tx *sql.Tx, templateID string) (AgentTemplateVersion, bool, error) {
+	row := tx.QueryRowContext(ctx, `SELECT v.id, v.template_id, v.version, v.state, v.name, v.description, v.source_repo, v.source_ref, v.source_path, v.resolved_commit, v.content_hash, v.content, v.metadata_json, v.created_at, v.updated_at, v.promoted_at
+		FROM agent_templates t
+		JOIN agent_template_versions v ON v.id = t.current_version_id
+		WHERE t.id = ?`, templateID)
+	version, err := scanAgentTemplateVersion(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AgentTemplateVersion{}, false, nil
+	}
+	if err != nil {
+		return AgentTemplateVersion{}, false, err
+	}
+	return version, true, nil
+}
+
+func nextAgentTemplateVersionNumber(ctx context.Context, tx *sql.Tx, templateID string) (int, error) {
+	var current sql.NullInt64
+	if err := tx.QueryRowContext(ctx, `SELECT MAX(version) FROM agent_template_versions WHERE template_id = ?`, templateID).Scan(&current); err != nil {
+		return 0, err
+	}
+	if !current.Valid {
+		return 1, nil
+	}
+	return int(current.Int64) + 1, nil
+}
+
+func agentTemplateVersionID(templateID string, version int) string {
+	return fmt.Sprintf("%s@v%d", strings.TrimSpace(templateID), version)
+}
+
+func templateContentHash(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func requireAffected(result sql.Result, subject string, id string) error {
@@ -1778,5 +2044,38 @@ UPDATE agent_instances SET template_id = preset_id WHERE template_id = '' AND pr
 	`,
 	`
 ALTER TABLE agent_templates ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '';
+	`,
+	`
+CREATE TABLE agent_template_versions (
+	id TEXT PRIMARY KEY,
+	template_id TEXT NOT NULL,
+	version INTEGER NOT NULL,
+	state TEXT NOT NULL,
+	name TEXT NOT NULL,
+	description TEXT NOT NULL DEFAULT '',
+	source_repo TEXT NOT NULL,
+	source_ref TEXT NOT NULL,
+	source_path TEXT NOT NULL,
+	resolved_commit TEXT NOT NULL,
+	content_hash TEXT NOT NULL DEFAULT '',
+	content TEXT NOT NULL,
+	metadata_json TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	promoted_at TEXT NOT NULL DEFAULT '',
+	UNIQUE(template_id, version)
+);
+
+INSERT OR REPLACE INTO agent_template_versions(id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at)
+SELECT id || '@v1', id, 1, 'current', name, description, source_repo, source_ref, source_path, resolved_commit, '', content, metadata_json, created_at, updated_at, updated_at
+FROM agent_templates;
+
+ALTER TABLE agent_templates ADD COLUMN current_version_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE agent_templates ADD COLUMN latest_version_id TEXT NOT NULL DEFAULT '';
+
+UPDATE agent_templates
+SET current_version_id = id || '@v1',
+	latest_version_id = id || '@v1'
+WHERE current_version_id = '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -32,6 +32,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"merge_gates",
 		"agent_repos",
 		"agent_templates",
+		"agent_template_versions",
 	} {
 		ok, err := store.HasTable(ctx, table)
 		if err != nil {
@@ -418,8 +419,73 @@ func TestRepositoryMethods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAgentTemplate returned error: %v", err)
 	}
-	if template.ResolvedCommit != "abc123" || template.Content != "Review deeply." || !strings.Contains(template.MetadataJSON, `"kind":"agent-template"`) || template.CreatedAt == "" || template.UpdatedAt == "" {
+	if template.ResolvedCommit != "abc123" || template.Content != "Review deeply." || !strings.Contains(template.MetadataJSON, `"kind":"agent-template"`) || template.VersionID != "thermo@v1" || template.VersionNumber != 1 || template.VersionState != "current" || !strings.HasPrefix(template.ContentHash, "sha256:") || template.CreatedAt == "" || template.UpdatedAt == "" {
 		t.Fatalf("template = %+v", template)
+	}
+	if err := store.UpsertAgentTemplate(ctx, AgentTemplate{
+		ID:             "thermo",
+		Name:           "Thermo",
+		Description:    "Strict review",
+		SourceRepo:     "cursor/plugins",
+		SourceRef:      "main",
+		SourcePath:     "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+		ResolvedCommit: "def456",
+		Content:        "Review deeply again.",
+		MetadataJSON:   `{"id":"thermo","name":"Thermo","description":"Strict review","kind":"agent-template","version":1,"capabilities":["review"],"runtime_compatibility":["codex"],"tags":["review"],"inputs":["repo"],"outputs":["review_findings"]}`,
+	}); err != nil {
+		t.Fatalf("second UpsertAgentTemplate returned error: %v", err)
+	}
+	template, err = store.GetAgentTemplate(ctx, "thermo")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate second returned error: %v", err)
+	}
+	if template.VersionID != "thermo@v2" || template.VersionNumber != 2 || template.ResolvedCommit != "def456" {
+		t.Fatalf("template second version = %+v", template)
+	}
+	versions, err := store.ListAgentTemplateVersions(ctx, "thermo")
+	if err != nil {
+		t.Fatalf("ListAgentTemplateVersions returned error: %v", err)
+	}
+	if len(versions) != 2 || versions[0].State != "superseded" || versions[1].State != "current" {
+		t.Fatalf("versions = %+v", versions)
+	}
+	pending, err := store.AddPendingAgentTemplateVersion(ctx, AgentTemplate{
+		ID:             "thermo",
+		Name:           "Thermo Candidate",
+		Description:    "Candidate review",
+		SourceRepo:     "local",
+		SourceRef:      "candidate",
+		SourcePath:     "candidate.md",
+		ResolvedCommit: "sha256:candidate",
+		Content:        "Candidate instructions.",
+		MetadataJSON:   `{"id":"thermo","name":"Thermo Candidate","description":"Candidate review","kind":"agent-template","version":1,"capabilities":["review"],"runtime_compatibility":["codex"],"tags":["review"],"inputs":["repo"],"outputs":["review_findings"]}`,
+	})
+	if err != nil {
+		t.Fatalf("AddPendingAgentTemplateVersion returned error: %v", err)
+	}
+	if pending.State != "pending" || pending.VersionNumber != 3 {
+		t.Fatalf("pending version = %+v", pending)
+	}
+	current, err := store.GetAgentTemplate(ctx, "thermo")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate current returned error: %v", err)
+	}
+	if current.VersionID != "thermo@v2" || current.Content != "Review deeply again." {
+		t.Fatalf("pending changed current template = %+v", current)
+	}
+	latest, err := store.GetAgentTemplateReference(ctx, "thermo@latest")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateReference latest returned error: %v", err)
+	}
+	if latest.VersionID != "thermo@v3" || latest.VersionState != "pending" || latest.Content != "Candidate instructions." {
+		t.Fatalf("latest template = %+v", latest)
+	}
+	pinned, err := store.GetAgentTemplateReference(ctx, "thermo@v1")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateReference returned error: %v", err)
+	}
+	if pinned.VersionID != "thermo@v1" || pinned.Content != "Review deeply." {
+		t.Fatalf("pinned template = %+v", pinned)
 	}
 	templates, err := store.ListAgentTemplates(ctx)
 	if err != nil {
@@ -927,6 +993,13 @@ func TestMigrationCopiesPresetsToAgentTemplates(t *testing.T) {
 	}
 	if template.Content != "legacy instructions" || template.ResolvedCommit != "abc123" || template.MetadataJSON != "" {
 		t.Fatalf("template = %+v", template)
+	}
+	versions, err := store.ListAgentTemplateVersions(ctx, "legacy-template")
+	if err != nil {
+		t.Fatalf("ListAgentTemplateVersions returned error: %v", err)
+	}
+	if len(versions) != 1 || versions[0].ID != "legacy-template@v1" || versions[0].State != "current" || versions[0].Content != "legacy instructions" {
+		t.Fatalf("legacy versions = %+v", versions)
 	}
 	agent, err := store.GetAgent(ctx, "legacy-agent")
 	if err != nil {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -121,7 +121,7 @@ func (m Mailbox) templateSnapshot(ctx context.Context, agentName string) (db.Age
 	if strings.TrimSpace(agent.TemplateID) == "" {
 		return db.AgentTemplate{}, nil
 	}
-	template, err := m.Store.GetAgentTemplate(ctx, agent.TemplateID)
+	template, err := m.Store.GetAgentTemplateReference(ctx, agent.TemplateID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return db.AgentTemplate{}, fmt.Errorf("agent %q references missing template %q", agent.Name, agent.TemplateID)

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -109,6 +109,37 @@ func TestMailboxEnqueueSnapshotsAgentTemplate(t *testing.T) {
 	if payload.TemplateID != "thermo" || payload.TemplateResolvedCommit != "abc123" || payload.TemplateContent != "Review deeply." {
 		t.Fatalf("payload template snapshot = %+v", payload)
 	}
+
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:         "audit-pinned",
+		Role:         "reviewer",
+		Runtime:      "codex",
+		RuntimeRef:   "last",
+		RepoScope:    "jerryfane/gitmoot",
+		TemplateID:   "thermo@v1",
+		Capabilities: []string{"review"},
+	}); err != nil {
+		t.Fatalf("UpsertAgent pinned returned error: %v", err)
+	}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:     "job-2",
+		Agent:  "audit-pinned",
+		Action: "review",
+		Repo:   "jerryfane/gitmoot",
+	}); err != nil {
+		t.Fatalf("Enqueue pinned returned error: %v", err)
+	}
+	pinnedJob, err := store.GetJob(ctx, "job-2")
+	if err != nil {
+		t.Fatalf("GetJob pinned returned error: %v", err)
+	}
+	pinnedPayload, err := unmarshalPayload(pinnedJob.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload pinned returned error: %v", err)
+	}
+	if pinnedPayload.TemplateID != "thermo" || pinnedPayload.TemplateResolvedCommit != "abc123" || pinnedPayload.TemplateContent != "Review deeply." {
+		t.Fatalf("pinned payload template snapshot = %+v", pinnedPayload)
+	}
 }
 
 func TestMailboxRunIncludesTemplateSnapshotInPrompt(t *testing.T) {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -197,6 +197,12 @@ gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
 ```
 
+Template updates are versioned locally. `gitmoot agent template show <id>`
+prints the current version, content hash, source commit, and promotion state.
+Agents use the current promoted version by default, or a pinned version when
+configured with a reference such as `--template frontend-reviewer@v1`.
+Queued jobs keep the exact template content snapshot they were created with.
+
 Discover templates by metadata:
 
 ```sh

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -211,6 +211,12 @@ gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
 ```
 
+Template updates are versioned locally. `gitmoot agent template show <id>`
+prints the current version, content hash, source commit, and promotion state.
+Agents use the current promoted version by default, or a pinned version when
+configured with a reference such as `--template frontend-reviewer@v1`.
+Queued jobs keep the exact template content snapshot they were created with.
+
 Discover templates by metadata:
 
 ```sh
@@ -514,6 +520,12 @@ After editing a local template file, refresh Gitmoot's cached snapshot explicitl
 gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
 ```
+
+Template updates are versioned locally. `gitmoot agent template show <id>`
+prints the current version, content hash, source commit, and promotion state.
+Agents use the current promoted version by default, or a pinned version when
+configured with a reference such as `--template frontend-reviewer@v1`.
+Queued jobs keep the exact template content snapshot they were created with.
 
 Discover templates by metadata:
 
@@ -2755,6 +2767,12 @@ After editing a local template file, refresh Gitmoot's cached snapshot:
 gitmoot agent template diff frontend-reviewer
 gitmoot agent template update frontend-reviewer
 ```
+
+Template updates are versioned locally. `gitmoot agent template show <id>`
+prints the current version, content hash, source commit, and promotion state.
+Agents use the current promoted version by default, or a pinned version when
+configured with a reference such as `--template frontend-reviewer@v1`.
+Queued jobs keep the exact template content snapshot they were created with.
 
 Discover templates by metadata:
 


### PR DESCRIPTION
WHAT: Added versioned storage for agent templates, including logical template records, version rows, current/latest pointers, pinned references, and queued-job snapshot resolution.

WHY: SkillOpt/template feedback workflows need rollback-safe template versions and pending candidates without changing the template content already captured by queued work.

CHANGES:
- Added agent_template_versions migration and storage APIs for current/latest/pinned template references.
- Updated template update/show flows to surface version id, version number, promotion state, and content hash.
- Updated agent/template loading and mailbox snapshotting to resolve pinned template references.
- Added migration, CLI, and mailbox tests for version creation, pending versions, latest/current behavior, and pinned snapshots.
- Updated README, SKILL.md, CLI reference, and regenerated website llms-full output.

RESULTS:
- /root/temp/ts/tool/go fmt ./internal/db
- /root/temp/ts/tool/go test ./internal/db ./internal/agenttemplate ./internal/workflow ./internal/cli
- /root/temp/ts/tool/go test ./...
- git diff --cached --check
- Version smoke test showed version-smoke@v2 with current state and sha256 content hash.
- codex exec review --uncommitted final output:

```
No blocking issues were identified in the staged template-versioning changes. Tests could not be run because the required Go 1.26 toolchain download is blocked in this environment.
No blocking issues were identified in the staged template-versioning changes. Tests could not be run because the required Go 1.26 toolchain download is blocked in this environment.
```

RISK: codex exec review could not run tests inside its sandbox because it cannot download Go 1.26; tests were run directly with /root/temp/ts/tool/go.