### PR TITLE
Add artifact-backed eval storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /repos/
+/.gitmoot/evals/

--- a/internal/artifact/store.go
+++ b/internal/artifact/store.go
@@ -1,0 +1,136 @@
+package artifact
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	HashPrefix = "sha256:"
+)
+
+type Blob struct {
+	Hash string
+	Size int64
+	Path string
+}
+
+type Store struct {
+	Root string
+}
+
+func NewStore(root string) Store {
+	return Store{Root: root}
+}
+
+func (s Store) Put(content []byte) (Blob, error) {
+	root := strings.TrimSpace(s.Root)
+	if root == "" {
+		return Blob{}, errors.New("artifact blob root is required")
+	}
+	hash := ContentHash(content)
+	path, err := s.Path(hash)
+	if err != nil {
+		return Blob{}, err
+	}
+	if info, err := os.Stat(path); err == nil {
+		if info.Size() != int64(len(content)) {
+			return Blob{}, fmt.Errorf("artifact blob %s has size %d, want %d", hash, info.Size(), len(content))
+		}
+		return Blob{Hash: hash, Size: info.Size(), Path: path}, nil
+	} else if !os.IsNotExist(err) {
+		return Blob{}, fmt.Errorf("stat artifact blob: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return Blob{}, fmt.Errorf("create artifact blob directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".blob-*")
+	if err != nil {
+		return Blob{}, fmt.Errorf("create temporary artifact blob: %w", err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return Blob{}, fmt.Errorf("write artifact blob: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return Blob{}, fmt.Errorf("chmod artifact blob: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return Blob{}, fmt.Errorf("close artifact blob: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		if _, statErr := os.Stat(path); statErr == nil {
+			committed = true
+			return Blob{Hash: hash, Size: int64(len(content)), Path: path}, nil
+		}
+		return Blob{}, fmt.Errorf("commit artifact blob: %w", err)
+	}
+	committed = true
+	return Blob{Hash: hash, Size: int64(len(content)), Path: path}, nil
+}
+
+func (s Store) Read(hash string) ([]byte, error) {
+	path, err := s.Path(hash)
+	if err != nil {
+		return nil, err
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("artifact blob %s not found", NormalizeHashForMessage(hash))
+		}
+		return nil, fmt.Errorf("read artifact blob: %w", err)
+	}
+	return content, nil
+}
+
+func (s Store) Path(hash string) (string, error) {
+	normalized, err := NormalizeHash(hash)
+	if err != nil {
+		return "", err
+	}
+	root := strings.TrimSpace(s.Root)
+	if root == "" {
+		return "", errors.New("artifact blob root is required")
+	}
+	hexHash := strings.TrimPrefix(normalized, HashPrefix)
+	return filepath.Join(root, "sha256", hexHash[:2], hexHash), nil
+}
+
+func ContentHash(content []byte) string {
+	sum := sha256.Sum256(content)
+	return HashPrefix + hex.EncodeToString(sum[:])
+}
+
+func NormalizeHash(hash string) (string, error) {
+	hash = strings.ToLower(strings.TrimSpace(hash))
+	hash = strings.TrimPrefix(hash, HashPrefix)
+	if len(hash) != sha256.Size*2 {
+		return "", fmt.Errorf("artifact hash must be %d hex characters", sha256.Size*2)
+	}
+	if _, err := hex.DecodeString(hash); err != nil {
+		return "", fmt.Errorf("artifact hash is not valid hex: %w", err)
+	}
+	return HashPrefix + hash, nil
+}
+
+func NormalizeHashForMessage(hash string) string {
+	normalized, err := NormalizeHash(hash)
+	if err != nil {
+		return strings.TrimSpace(hash)
+	}
+	return normalized
+}

--- a/internal/artifact/store_test.go
+++ b/internal/artifact/store_test.go
@@ -1,0 +1,64 @@
+package artifact
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestStorePutDedupeAndRead(t *testing.T) {
+	store := NewStore(t.TempDir())
+	content := []byte("hello artifact\n")
+
+	first, err := store.Put(content)
+	if err != nil {
+		t.Fatalf("Put first returned error: %v", err)
+	}
+	second, err := store.Put(content)
+	if err != nil {
+		t.Fatalf("Put second returned error: %v", err)
+	}
+	if first.Hash != second.Hash || first.Path != second.Path {
+		t.Fatalf("dedupe blob mismatch: first=%+v second=%+v", first, second)
+	}
+	if first.Size != int64(len(content)) {
+		t.Fatalf("blob size = %d, want %d", first.Size, len(content))
+	}
+	read, err := store.Read(first.Hash)
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+	if string(read) != string(content) {
+		t.Fatalf("read content = %q, want %q", string(read), string(content))
+	}
+	if !strings.Contains(first.Path, strings.TrimPrefix(first.Hash, HashPrefix)[:2]) {
+		t.Fatalf("blob path does not shard by hash: %s", first.Path)
+	}
+}
+
+func TestStoreReadMissingBlob(t *testing.T) {
+	store := NewStore(t.TempDir())
+	hash := ContentHash([]byte("missing"))
+
+	_, err := store.Read(hash)
+	if err == nil {
+		t.Fatal("Read missing blob returned nil error")
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Read returned raw os.ErrNotExist, want contextual error")
+	}
+	if !strings.Contains(err.Error(), hash) {
+		t.Fatalf("Read error = %q, want hash", err.Error())
+	}
+}
+
+func TestNormalizeHashRejectsInvalidInput(t *testing.T) {
+	for _, input := range []string{"", "abc", "sha256:not-hex"} {
+		t.Run(input, func(t *testing.T) {
+			if _, err := NormalizeHash(input); err == nil {
+				t.Fatalf("NormalizeHash(%q) returned nil error", input)
+			}
+		})
+	}
+}

--- a/internal/artifact/text.go
+++ b/internal/artifact/text.go
@@ -1,0 +1,119 @@
+package artifact
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+const (
+	DefaultPreviewLines = 80
+)
+
+type TextDriver struct {
+	PreviewLines int
+}
+
+func (d TextDriver) Preview(content []byte) string {
+	limit := d.PreviewLines
+	if limit <= 0 {
+		limit = DefaultPreviewLines
+	}
+	lines := splitLines(content)
+	if len(lines) <= limit {
+		return strings.Join(lines, "\n")
+	}
+	preview := append([]string{}, lines[:limit]...)
+	preview = append(preview, fmt.Sprintf("... %d more lines", len(lines)-limit))
+	return strings.Join(preview, "\n")
+}
+
+func (d TextDriver) Diff(oldName, newName string, oldContent, newContent []byte) string {
+	oldLines := splitLines(oldContent)
+	newLines := splitLines(newContent)
+	ops := diffLines(oldLines, newLines)
+	var out bytes.Buffer
+	if strings.TrimSpace(oldName) == "" {
+		oldName = "a"
+	}
+	if strings.TrimSpace(newName) == "" {
+		newName = "b"
+	}
+	fmt.Fprintf(&out, "--- %s\n", oldName)
+	fmt.Fprintf(&out, "+++ %s\n", newName)
+	for _, op := range ops {
+		switch op.kind {
+		case equalLine:
+			fmt.Fprintf(&out, " %s\n", op.text)
+		case deleteLine:
+			fmt.Fprintf(&out, "-%s\n", op.text)
+		case insertLine:
+			fmt.Fprintf(&out, "+%s\n", op.text)
+		}
+	}
+	return out.String()
+}
+
+func splitLines(content []byte) []string {
+	normalized := strings.ReplaceAll(string(content), "\r\n", "\n")
+	normalized = strings.TrimSuffix(normalized, "\n")
+	if normalized == "" {
+		return []string{}
+	}
+	return strings.Split(normalized, "\n")
+}
+
+type lineKind int
+
+const (
+	equalLine lineKind = iota
+	deleteLine
+	insertLine
+)
+
+type lineOp struct {
+	kind lineKind
+	text string
+}
+
+func diffLines(oldLines, newLines []string) []lineOp {
+	table := make([][]int, len(oldLines)+1)
+	for i := range table {
+		table[i] = make([]int, len(newLines)+1)
+	}
+	for i := len(oldLines) - 1; i >= 0; i-- {
+		for j := len(newLines) - 1; j >= 0; j-- {
+			if oldLines[i] == newLines[j] {
+				table[i][j] = table[i+1][j+1] + 1
+			} else if table[i+1][j] >= table[i][j+1] {
+				table[i][j] = table[i+1][j]
+			} else {
+				table[i][j] = table[i][j+1]
+			}
+		}
+	}
+	var ops []lineOp
+	i, j := 0, 0
+	for i < len(oldLines) && j < len(newLines) {
+		if oldLines[i] == newLines[j] {
+			ops = append(ops, lineOp{kind: equalLine, text: oldLines[i]})
+			i++
+			j++
+		} else if table[i+1][j] >= table[i][j+1] {
+			ops = append(ops, lineOp{kind: deleteLine, text: oldLines[i]})
+			i++
+		} else {
+			ops = append(ops, lineOp{kind: insertLine, text: newLines[j]})
+			j++
+		}
+	}
+	for i < len(oldLines) {
+		ops = append(ops, lineOp{kind: deleteLine, text: oldLines[i]})
+		i++
+	}
+	for j < len(newLines) {
+		ops = append(ops, lineOp{kind: insertLine, text: newLines[j]})
+		j++
+	}
+	return ops
+}

--- a/internal/artifact/text_test.go
+++ b/internal/artifact/text_test.go
@@ -1,0 +1,30 @@
+package artifact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTextDriverPreview(t *testing.T) {
+	driver := TextDriver{PreviewLines: 2}
+
+	preview := driver.Preview([]byte("one\ntwo\nthree\n"))
+
+	for _, want := range []string{"one", "two", "... 1 more lines"} {
+		if !strings.Contains(preview, want) {
+			t.Fatalf("preview missing %q:\n%s", want, preview)
+		}
+	}
+}
+
+func TestTextDriverDiff(t *testing.T) {
+	driver := TextDriver{}
+
+	diff := driver.Diff("before.md", "after.md", []byte("title\nold\nsame\n"), []byte("title\nnew\nsame\n"))
+
+	for _, want := range []string{"--- before.md", "+++ after.md", " title", "-old", "+new", " same"} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("diff missing %q:\n%s", want, diff)
+		}
+	}
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Initialize(paths Paths) error {
-	for _, dir := range []string{paths.Home, paths.Logs, paths.Workspaces} {
+	for _, dir := range []string{paths.Home, paths.Logs, paths.Workspaces, paths.Evals, paths.ArtifactBlobs} {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return fmt.Errorf("create %s: %w", dir, err)
 		}
@@ -34,5 +34,7 @@ func DefaultConfig(paths Paths) string {
 database = %q
 logs = %q
 workspaces = %q
-`, paths.Database, paths.Logs, paths.Workspaces)
+evals = %q
+artifact_blobs = %q
+`, paths.Database, paths.Logs, paths.Workspaces, paths.Evals, paths.ArtifactBlobs)
 }

--- a/internal/config/init_test.go
+++ b/internal/config/init_test.go
@@ -13,7 +13,7 @@ func TestInitializeCreatesLocalState(t *testing.T) {
 		t.Fatalf("Initialize returned error: %v", err)
 	}
 
-	for _, dir := range []string{paths.Home, paths.Logs, paths.Workspaces} {
+	for _, dir := range []string{paths.Home, paths.Logs, paths.Workspaces, paths.Evals, paths.ArtifactBlobs} {
 		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 			t.Fatalf("%s was not created as directory, info=%v err=%v", dir, info, err)
 		} else if info.Mode().Perm() != 0o700 {
@@ -27,5 +27,8 @@ func TestInitializeCreatesLocalState(t *testing.T) {
 	}
 	if !strings.Contains(string(config), "database") {
 		t.Fatalf("config missing database path:\n%s", string(config))
+	}
+	if !strings.Contains(string(config), "artifact_blobs") {
+		t.Fatalf("config missing artifact blob path:\n%s", string(config))
 	}
 }

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -11,14 +11,18 @@ const (
 	DBName     = "gitmoot.db"
 	LogsDir    = "logs"
 	WorkDir    = "workspaces"
+	EvalsDir   = "evals"
+	BlobsDir   = "blobs"
 )
 
 type Paths struct {
-	Home       string
-	ConfigFile string
-	Database   string
-	Logs       string
-	Workspaces string
+	Home          string
+	ConfigFile    string
+	Database      string
+	Logs          string
+	Workspaces    string
+	Evals         string
+	ArtifactBlobs string
 }
 
 func DefaultPaths() (Paths, error) {
@@ -32,10 +36,12 @@ func DefaultPaths() (Paths, error) {
 func PathsForHome(home string) Paths {
 	root := filepath.Join(home, DirName)
 	return Paths{
-		Home:       root,
-		ConfigFile: filepath.Join(root, ConfigName),
-		Database:   filepath.Join(root, DBName),
-		Logs:       filepath.Join(root, LogsDir),
-		Workspaces: filepath.Join(root, WorkDir),
+		Home:          root,
+		ConfigFile:    filepath.Join(root, ConfigName),
+		Database:      filepath.Join(root, DBName),
+		Logs:          filepath.Join(root, LogsDir),
+		Workspaces:    filepath.Join(root, WorkDir),
+		Evals:         filepath.Join(root, EvalsDir),
+		ArtifactBlobs: filepath.Join(root, EvalsDir, BlobsDir),
 	}
 }

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -14,4 +14,10 @@ func TestPathsForHome(t *testing.T) {
 	if paths.Database != filepath.Join("/tmp/example", ".gitmoot", "gitmoot.db") {
 		t.Fatalf("Database = %q", paths.Database)
 	}
+	if paths.Evals != filepath.Join("/tmp/example", ".gitmoot", "evals") {
+		t.Fatalf("Evals = %q", paths.Evals)
+	}
+	if paths.ArtifactBlobs != filepath.Join("/tmp/example", ".gitmoot", "evals", "blobs") {
+		t.Fatalf("ArtifactBlobs = %q", paths.ArtifactBlobs)
+	}
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -148,6 +148,41 @@ type JobEvent struct {
 	Message string
 }
 
+type EvalArtifact struct {
+	ID        string
+	Hash      string
+	MediaType string
+	SizeBytes int64
+	Driver    string
+	CreatedAt string
+}
+
+type EvalRun struct {
+	ID                string
+	TemplateID        string
+	TemplateVersionID string
+	TargetRepo        string
+	State             string
+	MetadataJSON      string
+	CreatedAt         string
+	UpdatedAt         string
+}
+
+type EvalReviewItem struct {
+	ID                  string
+	RunID               string
+	ItemID              string
+	Title               string
+	SourceArtifactID    string
+	BaselineArtifactID  string
+	CandidateArtifactID string
+	PreviewArtifactID   string
+	DiffArtifactID      string
+	MetadataJSON        string
+	CreatedAt           string
+	UpdatedAt           string
+}
+
 type BranchLock struct {
 	RepoFullName string
 	Branch       string
@@ -1367,6 +1402,134 @@ func (s *Store) ListJobEvents(ctx context.Context, jobID string) ([]JobEvent, er
 	return events, rows.Err()
 }
 
+func (s *Store) UpsertEvalArtifact(ctx context.Context, artifact EvalArtifact) error {
+	if strings.TrimSpace(artifact.ID) == "" {
+		artifact.ID = artifact.Hash
+	}
+	if strings.TrimSpace(artifact.Hash) == "" {
+		return errors.New("eval artifact hash is required")
+	}
+	if artifact.SizeBytes < 0 {
+		return errors.New("eval artifact size cannot be negative")
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO eval_artifacts(id, hash, media_type, size_bytes, driver, created_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			hash = excluded.hash,
+			media_type = excluded.media_type,
+			size_bytes = excluded.size_bytes,
+			driver = excluded.driver`,
+		artifact.ID, artifact.Hash, artifact.MediaType, artifact.SizeBytes, artifact.Driver)
+	return err
+}
+
+func (s *Store) GetEvalArtifact(ctx context.Context, id string) (EvalArtifact, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, hash, media_type, size_bytes, driver, created_at
+		FROM eval_artifacts WHERE id = ?`, id)
+	return scanEvalArtifact(row)
+}
+
+func (s *Store) UpsertEvalRun(ctx context.Context, run EvalRun) error {
+	if strings.TrimSpace(run.ID) == "" {
+		return errors.New("eval run id is required")
+	}
+	if strings.TrimSpace(run.State) == "" {
+		run.State = "draft"
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO eval_runs(id, template_id, template_version_id, target_repo, state, metadata_json, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			template_id = excluded.template_id,
+			template_version_id = excluded.template_version_id,
+			target_repo = excluded.target_repo,
+			state = excluded.state,
+			metadata_json = excluded.metadata_json,
+			updated_at = CURRENT_TIMESTAMP`,
+		run.ID, run.TemplateID, run.TemplateVersionID, run.TargetRepo, run.State, run.MetadataJSON)
+	return err
+}
+
+func (s *Store) GetEvalRun(ctx context.Context, id string) (EvalRun, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, template_id, template_version_id, target_repo, state, metadata_json, created_at, updated_at
+		FROM eval_runs WHERE id = ?`, id)
+	return scanEvalRun(row)
+}
+
+func (s *Store) UpsertEvalReviewItem(ctx context.Context, item EvalReviewItem) error {
+	if strings.TrimSpace(item.ID) == "" {
+		item.ID = item.RunID + "/" + item.ItemID
+	}
+	if strings.TrimSpace(item.RunID) == "" {
+		return errors.New("eval review item run id is required")
+	}
+	if strings.TrimSpace(item.ItemID) == "" {
+		return errors.New("eval review item id is required")
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO eval_review_items(
+			id, run_id, item_id, title, source_artifact_id, baseline_artifact_id, candidate_artifact_id,
+			preview_artifact_id, diff_artifact_id, metadata_json, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			run_id = excluded.run_id,
+			item_id = excluded.item_id,
+			title = excluded.title,
+			source_artifact_id = excluded.source_artifact_id,
+			baseline_artifact_id = excluded.baseline_artifact_id,
+			candidate_artifact_id = excluded.candidate_artifact_id,
+			preview_artifact_id = excluded.preview_artifact_id,
+			diff_artifact_id = excluded.diff_artifact_id,
+			metadata_json = excluded.metadata_json,
+			updated_at = CURRENT_TIMESTAMP`,
+		item.ID, item.RunID, item.ItemID, item.Title, item.SourceArtifactID, item.BaselineArtifactID, item.CandidateArtifactID,
+		item.PreviewArtifactID, item.DiffArtifactID, item.MetadataJSON)
+	return err
+}
+
+func (s *Store) ListEvalReviewItems(ctx context.Context, runID string) ([]EvalReviewItem, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, run_id, item_id, title, source_artifact_id, baseline_artifact_id,
+			candidate_artifact_id, preview_artifact_id, diff_artifact_id, metadata_json, created_at, updated_at
+		FROM eval_review_items WHERE run_id = ? ORDER BY item_id`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []EvalReviewItem
+	for rows.Next() {
+		item, err := scanEvalReviewItem(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func scanEvalArtifact(row interface{ Scan(dest ...any) error }) (EvalArtifact, error) {
+	var artifact EvalArtifact
+	if err := row.Scan(&artifact.ID, &artifact.Hash, &artifact.MediaType, &artifact.SizeBytes, &artifact.Driver, &artifact.CreatedAt); err != nil {
+		return EvalArtifact{}, err
+	}
+	return artifact, nil
+}
+
+func scanEvalRun(row interface{ Scan(dest ...any) error }) (EvalRun, error) {
+	var run EvalRun
+	if err := row.Scan(&run.ID, &run.TemplateID, &run.TemplateVersionID, &run.TargetRepo, &run.State, &run.MetadataJSON, &run.CreatedAt, &run.UpdatedAt); err != nil {
+		return EvalRun{}, err
+	}
+	return run, nil
+}
+
+func scanEvalReviewItem(row interface{ Scan(dest ...any) error }) (EvalReviewItem, error) {
+	var item EvalReviewItem
+	if err := row.Scan(&item.ID, &item.RunID, &item.ItemID, &item.Title, &item.SourceArtifactID, &item.BaselineArtifactID,
+		&item.CandidateArtifactID, &item.PreviewArtifactID, &item.DiffArtifactID, &item.MetadataJSON, &item.CreatedAt, &item.UpdatedAt); err != nil {
+		return EvalReviewItem{}, err
+	}
+	return item, nil
+}
+
 func (s *Store) AcquireResourceLock(ctx context.Context, lock ResourceLock, now time.Time) (bool, error) {
 	resourceKey := strings.TrimSpace(lock.ResourceKey)
 	ownerJobID := strings.TrimSpace(lock.OwnerJobID)
@@ -2077,5 +2240,42 @@ UPDATE agent_templates
 SET current_version_id = id || '@v1',
 	latest_version_id = id || '@v1'
 WHERE current_version_id = '';
+	`,
+	`
+CREATE TABLE eval_artifacts (
+	id TEXT PRIMARY KEY,
+	hash TEXT NOT NULL,
+	media_type TEXT NOT NULL DEFAULT '',
+	size_bytes INTEGER NOT NULL DEFAULT 0,
+	driver TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE eval_runs (
+	id TEXT PRIMARY KEY,
+	template_id TEXT NOT NULL DEFAULT '',
+	template_version_id TEXT NOT NULL DEFAULT '',
+	target_repo TEXT NOT NULL DEFAULT '',
+	state TEXT NOT NULL DEFAULT 'draft',
+	metadata_json TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE eval_review_items (
+	id TEXT PRIMARY KEY,
+	run_id TEXT NOT NULL,
+	item_id TEXT NOT NULL,
+	title TEXT NOT NULL DEFAULT '',
+	source_artifact_id TEXT NOT NULL DEFAULT '',
+	baseline_artifact_id TEXT NOT NULL DEFAULT '',
+	candidate_artifact_id TEXT NOT NULL DEFAULT '',
+	preview_artifact_id TEXT NOT NULL DEFAULT '',
+	diff_artifact_id TEXT NOT NULL DEFAULT '',
+	metadata_json TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	UNIQUE(run_id, item_id)
+);
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -33,6 +33,9 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"agent_repos",
 		"agent_templates",
 		"agent_template_versions",
+		"eval_artifacts",
+		"eval_runs",
+		"eval_review_items",
 	} {
 		ok, err := store.HasTable(ctx, table)
 		if err != nil {
@@ -45,6 +48,77 @@ func TestOpenMigratesSchema(t *testing.T) {
 
 	if err := store.Migrate(ctx); err != nil {
 		t.Fatalf("second Migrate returned error: %v", err)
+	}
+}
+
+func TestEvalStorageMethods(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	artifact := EvalArtifact{
+		ID:        "artifact-a",
+		Hash:      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		MediaType: "text/markdown",
+		SizeBytes: 42,
+		Driver:    "text",
+	}
+	if err := store.UpsertEvalArtifact(ctx, artifact); err != nil {
+		t.Fatalf("UpsertEvalArtifact returned error: %v", err)
+	}
+	storedArtifact, err := store.GetEvalArtifact(ctx, artifact.ID)
+	if err != nil {
+		t.Fatalf("GetEvalArtifact returned error: %v", err)
+	}
+	if storedArtifact.Hash != artifact.Hash || storedArtifact.MediaType != "text/markdown" || storedArtifact.Driver != "text" {
+		t.Fatalf("stored artifact = %+v", storedArtifact)
+	}
+
+	run := EvalRun{
+		ID:                "run-1",
+		TemplateID:        "planner",
+		TemplateVersionID: "planner@v2",
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		MetadataJSON:      `{"seed":1}`,
+	}
+	if err := store.UpsertEvalRun(ctx, run); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	storedRun, err := store.GetEvalRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetEvalRun returned error: %v", err)
+	}
+	if storedRun.TemplateVersionID != "planner@v2" || storedRun.MetadataJSON != `{"seed":1}` {
+		t.Fatalf("stored run = %+v", storedRun)
+	}
+
+	item := EvalReviewItem{
+		RunID:               run.ID,
+		ItemID:              "item-001",
+		Title:               "README plan",
+		SourceArtifactID:    artifact.ID,
+		BaselineArtifactID:  artifact.ID,
+		CandidateArtifactID: artifact.ID,
+		PreviewArtifactID:   artifact.ID,
+		DiffArtifactID:      artifact.ID,
+		MetadataJSON:        `{"path":"README.md"}`,
+	}
+	if err := store.UpsertEvalReviewItem(ctx, item); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	items, err := store.ListEvalReviewItems(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("review items len = %d, want 1", len(items))
+	}
+	if items[0].ID != "run-1/item-001" || items[0].DiffArtifactID != artifact.ID || items[0].MetadataJSON != `{"path":"README.md"}` {
+		t.Fatalf("review item = %+v", items[0])
 	}
 }
 


### PR DESCRIPTION
WHAT: Added foundational local eval artifact storage for future SkillOpt feedback workflows.

WHY: Gitmoot needs deterministic, local, content-addressed storage for eval outputs, previews, diffs, reports, and source artifacts before it can export/import SkillOpt packages or collect human review feedback.

CHANGES:
- Added internal/artifact with SHA256-addressed blob storage under Gitmoot home and deterministic hash-sharded paths.
- Added text/Markdown preview and diff support for the first review driver.
- Added eval_artifacts, eval_runs, and eval_review_items SQLite tables plus store methods for artifact manifests and review item references.
- Added eval and artifact blob paths to Gitmoot local config initialization.
- Ignored repo-local .gitmoot/evals review packets by default.
- Added artifact, config, and DB tests for dedupe/read/missing blobs, previews/diffs, migrations, and manifest references.

RESULTS:
- /root/temp/ts/tool/go test ./internal/artifact ./internal/config ./internal/db
- /root/temp/ts/tool/go test ./internal/...
- /root/temp/ts/tool/go test ./...
- git diff --check
- git diff --cached --check
- codex exec review --uncommitted final output:

```
No discrete correctness issues were found in the staged, unstaged, or untracked changes. Tests could not be run here because the required Go 1.26 toolchain download is blocked in this sandbox, so confidence is limited.
No discrete correctness issues were found in the staged, unstaged, or untracked changes. Tests could not be run here because the required Go 1.26 toolchain download is blocked in this sandbox, so confidence is limited.
```

RISK: codex exec review could not run tests inside its sandbox because it cannot download Go 1.26; tests were run directly with /root/temp/ts/tool/go.