### PR TITLE
Add SkillOpt exchange contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,17 @@ gitmoot lock list --repo owner/repo
 gitmoot lock release owner/repo <branch> --owner <agent>
 ```
 
+### SkillOpt Exchange
+
+```sh
+gitmoot skillopt export --run <run-id> --output training.json
+gitmoot skillopt import --file candidate.json
+```
+
+The export/import boundary lets a future external `gitmoot-skillopt` optimizer
+train on local eval artifacts and return candidate template versions. Imported
+candidates stay pending until a human review workflow promotes them.
+
 Detailed command coverage lives in
 [skills/gitmoot/references/CLI.md](skills/gitmoot/references/CLI.md).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -113,6 +113,8 @@ gitmoot job show <job-id>
 gitmoot job events <job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
+gitmoot skillopt export --run <run-id> [--output training.json]
+gitmoot skillopt import --file candidate.json
 ```
 
 Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -1,0 +1,54 @@
+# Gitmoot-SkillOpt Exchange Contract
+
+Gitmoot keeps the SkillOpt optimizer outside the main binary. The boundary is a
+pair of JSON package formats handled by `gitmoot skillopt export` and
+`gitmoot skillopt import`.
+
+## Training Package
+
+Export a local eval run:
+
+```sh
+gitmoot skillopt export --run run-2026-05-31 --output training.json
+```
+
+The exported package has:
+
+- `kind: gitmoot-skillopt-training-package`
+- `contract_version: 1`
+- `template`: the logical template id, current or pinned version id, content
+  hash, metadata, source, and exact template content
+- `eval_run`: run id, target repo, state, metadata, and template version
+- `items`: review/eval items with artifact references for source, baseline,
+  candidate, preview, and diff artifacts
+- `artifacts`: local artifact manifests with content hashes, media type, size,
+  and driver
+- `feedback_events`: canonical human feedback events when available
+- `evaluator_config`: the run metadata used by the external optimizer
+
+Artifact package entries reference local SHA256 blobs stored under Gitmoot home.
+The export does not copy blobs into the repository by default.
+
+## Candidate Package
+
+Import a candidate produced by an external optimizer:
+
+```sh
+gitmoot skillopt import --file candidate.json
+```
+
+The imported package must have:
+
+- `kind: gitmoot-skillopt-candidate-package`
+- `contract_version: 1`
+- `template_id`: an installed Gitmoot agent template id
+- `base_version_id`: optional pinned version used by the optimizer
+- `candidate.content`: full agent-template Markdown with YAML frontmatter
+- `candidate.metadata`: metadata that exactly matches the candidate
+  frontmatter
+- `eval_report`: optional optimizer report
+- `summary`: optional diff, score, and preference summary
+
+Importing never promotes a candidate. Gitmoot stores it as a pending template
+version so later review and promotion commands can decide whether it becomes
+current.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -36,6 +36,7 @@ var rootCommands = []command{
 	{name: "task", summary: "run or inspect tasks", run: runTask},
 	{name: "job", summary: "inspect and recover jobs", run: runJob},
 	{name: "lock", summary: "inspect and release branch locks", run: runLock},
+	{name: "skillopt", summary: "export and import SkillOpt packages", run: runSkillOpt},
 }
 
 func Run(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -53,7 +53,7 @@ func TestRunInitCreatesState(t *testing.T) {
 }
 
 func TestRunSubcommandHelpSucceeds(t *testing.T) {
-	for _, command := range []string{"init", "doctor", "version", "config", "update", "setup", "repo", "agent", "plugin", "events", "job", "lock"} {
+	for _, command := range []string{"init", "doctor", "version", "config", "update", "setup", "repo", "agent", "plugin", "events", "job", "lock", "skillopt"} {
 		t.Run(command, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+func runSkillOpt(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSkillOptUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "export":
+		return runSkillOptExport(args[1:], stdout, stderr)
+	case "import":
+		return runSkillOptImport(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skillopt command %q\n\n", args[0])
+		printSkillOptUsage(stderr)
+		return 2
+	}
+}
+
+func printSkillOptUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot skillopt export --run <run-id> [--output package.json]")
+	fmt.Fprintln(w, "  gitmoot skillopt import --file candidate.json")
+}
+
+func runSkillOptExport(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt export", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	runID := fs.String("run", "", "eval run id to export")
+	output := fs.String("output", "", "path to write the training package; stdout when omitted")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt export does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*runID) == "" {
+		fmt.Fprintln(stderr, "skillopt export requires --run")
+		return 2
+	}
+	var pkg skillopt.TrainingPackage
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		pkg, err = skillopt.ExportTrainingPackage(context.Background(), store, *runID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt export: %v\n", err)
+		return 1
+	}
+	encoded, err := json.MarshalIndent(pkg, "", "  ")
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt export: %v\n", err)
+		return 1
+	}
+	encoded = append(encoded, '\n')
+	if strings.TrimSpace(*output) == "" {
+		_, err = stdout.Write(encoded)
+	} else {
+		err = writeSkillOptFile(*output, encoded)
+		if err == nil {
+			writeLine(stdout, "exported %s to %s", pkg.EvalRun.ID, *output)
+		}
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt export: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runSkillOptImport(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt import", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	file := fs.String("file", "", "candidate package JSON file to import")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt import does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*file) == "" {
+		fmt.Fprintln(stderr, "skillopt import requires --file")
+		return 2
+	}
+	content, err := os.ReadFile(*file)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt import: read candidate package: %v\n", err)
+		return 1
+	}
+	var pkg skillopt.CandidatePackage
+	if err := json.Unmarshal(content, &pkg); err != nil {
+		fmt.Fprintf(stderr, "skillopt import: decode candidate package: %v\n", err)
+		return 1
+	}
+	var versionID string
+	if err := withStore(*home, func(store *db.Store) error {
+		version, err := skillopt.ImportCandidatePackage(context.Background(), store, pkg, *file)
+		if err != nil {
+			return err
+		}
+		versionID = version.ID
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt import: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "imported pending candidate %s", versionID)
+	return 0
+}
+
+func writeSkillOptFile(path string, content []byte) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return errors.New("output path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	return os.WriteFile(path, content, 0o644)
+}

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+func TestSkillOptExportAndImportCommands(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+		ID:        "baseline",
+		Hash:      artifact.ContentHash([]byte("baseline")),
+		MediaType: "text/markdown",
+		SizeBytes: int64(len("baseline")),
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:                "run-1",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "ready",
+		MetadataJSON:      `{"driver":"planner"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:              "run-1",
+		ItemID:             "item-001",
+		BaselineArtifactID: "baseline",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	exportPath := filepath.Join(t.TempDir(), "training.json")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "export", "--home", home, "--run", "run-1", "--output", exportPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt export exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "exported run-1") {
+		t.Fatalf("export stdout = %q", stdout.String())
+	}
+	exportedContent, err := os.ReadFile(exportPath)
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+	var training skillopt.TrainingPackage
+	if err := json.Unmarshal(exportedContent, &training); err != nil {
+		t.Fatalf("decode training package: %v\n%s", err, string(exportedContent))
+	}
+	if training.Template.VersionID != installed.VersionID || len(training.Items) != 1 || len(training.Artifacts) != 1 {
+		t.Fatalf("training package = %+v", training)
+	}
+
+	candidateContent := cliSkillOptTemplateContent("planner", "Plan the work and include risks.")
+	parsed, err := agenttemplate.ParseTemplateContent(candidateContent)
+	if err != nil {
+		t.Fatalf("ParseTemplateContent returned error: %v", err)
+	}
+	candidate := skillopt.CandidatePackage{
+		Kind:            skillopt.CandidatePackageKind,
+		ContractVersion: skillopt.ContractVersion,
+		TemplateID:      "planner",
+		BaseVersionID:   installed.VersionID,
+		Candidate: skillopt.CandidateTemplate{
+			Content:  candidateContent,
+			Metadata: parsed.Metadata,
+		},
+	}
+	candidatePath := filepath.Join(t.TempDir(), "candidate.json")
+	encodedCandidate, err := json.Marshal(candidate)
+	if err != nil {
+		t.Fatalf("marshal candidate: %v", err)
+	}
+	if err := os.WriteFile(candidatePath, encodedCandidate, 0o644); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "import", "--home", home, "--file", candidatePath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt import exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "imported pending candidate planner@v2") {
+		t.Fatalf("import stdout = %q", stdout.String())
+	}
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open after import returned error: %v", err)
+	}
+	defer store.Close()
+	current, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate current returned error: %v", err)
+	}
+	if current.VersionID != installed.VersionID {
+		t.Fatalf("current version = %q, want %q", current.VersionID, installed.VersionID)
+	}
+	latest, err := store.GetAgentTemplateReference(context.Background(), "planner@latest")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateReference latest returned error: %v", err)
+	}
+	if latest.VersionID != "planner@v2" || latest.Content != candidateContent {
+		t.Fatalf("latest = %+v", latest)
+	}
+}
+
+func cliSkillOptTemplate(id string, body string) db.AgentTemplate {
+	content := cliSkillOptTemplateContent(id, body)
+	parsed, err := agenttemplate.ParseTemplateContent(content)
+	if err != nil {
+		panic(err)
+	}
+	metadataJSON, err := agenttemplate.MarshalMetadata(parsed.Metadata)
+	if err != nil {
+		panic(err)
+	}
+	return db.AgentTemplate{
+		ID:             id,
+		Name:           parsed.Metadata.Name,
+		Description:    parsed.Metadata.Description,
+		SourceRepo:     agenttemplate.LocalSourceRepo,
+		SourceRef:      agenttemplate.LocalSourceRef,
+		SourcePath:     id + ".md",
+		ResolvedCommit: agenttemplate.HashContent(content),
+		Content:        content,
+		MetadataJSON:   metadataJSON,
+	}
+}
+
+func cliSkillOptTemplateContent(id string, body string) string {
+	return agenttemplate.FormatTemplateContent(agenttemplate.Metadata{
+		ID:                   id,
+		Name:                 "Planner",
+		Description:          "Plans implementation work.",
+		Kind:                 agenttemplate.TemplateKind,
+		Version:              agenttemplate.TemplateVersion,
+		Capabilities:         []string{"ask"},
+		RuntimeCompatibility: []string{"codex"},
+		Tags:                 []string{"planning"},
+		Inputs:               []string{"task"},
+		Outputs:              []string{"plan"},
+	}, "# Planner\n\n"+body+"\n")
+}

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -1,0 +1,348 @@
+package skillopt
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+const (
+	ContractVersion = 1
+
+	TrainingPackageKind  = "gitmoot-skillopt-training-package"
+	CandidatePackageKind = "gitmoot-skillopt-candidate-package"
+
+	CandidateSourceRepo = "gitmoot-skillopt"
+	CandidateSourceRef  = "candidate"
+)
+
+type TemplateSnapshot struct {
+	ID             string                 `json:"id"`
+	VersionID      string                 `json:"version_id"`
+	VersionNumber  int                    `json:"version_number"`
+	VersionState   string                 `json:"version_state"`
+	ContentHash    string                 `json:"content_hash"`
+	SourceRepo     string                 `json:"source_repo"`
+	SourceRef      string                 `json:"source_ref"`
+	SourcePath     string                 `json:"source_path"`
+	ResolvedCommit string                 `json:"resolved_commit"`
+	Metadata       agenttemplate.Metadata `json:"metadata"`
+	Content        string                 `json:"content"`
+}
+
+type ArtifactRef struct {
+	ID        string `json:"id"`
+	Hash      string `json:"hash"`
+	MediaType string `json:"media_type"`
+	SizeBytes int64  `json:"size_bytes"`
+	Driver    string `json:"driver"`
+}
+
+type EvalRun struct {
+	ID                string          `json:"id"`
+	TemplateID        string          `json:"template_id"`
+	TemplateVersionID string          `json:"template_version_id"`
+	TargetRepo        string          `json:"target_repo"`
+	State             string          `json:"state"`
+	Metadata          json.RawMessage `json:"metadata,omitempty"`
+}
+
+type EvalItem struct {
+	ID                  string          `json:"id"`
+	Title               string          `json:"title,omitempty"`
+	SourceArtifactID    string          `json:"source_artifact_id,omitempty"`
+	BaselineArtifactID  string          `json:"baseline_artifact_id,omitempty"`
+	CandidateArtifactID string          `json:"candidate_artifact_id,omitempty"`
+	PreviewArtifactID   string          `json:"preview_artifact_id,omitempty"`
+	DiffArtifactID      string          `json:"diff_artifact_id,omitempty"`
+	Metadata            json.RawMessage `json:"metadata,omitempty"`
+}
+
+type FeedbackEvent struct {
+	RunID     string `json:"run_id"`
+	ItemID    string `json:"item_id"`
+	Choice    string `json:"choice"`
+	Reasoning string `json:"reasoning,omitempty"`
+	Reviewer  string `json:"reviewer"`
+	Source    string `json:"source"`
+	SourceURL string `json:"source_url,omitempty"`
+	CreatedAt string `json:"created_at"`
+}
+
+type TrainingPackage struct {
+	Kind            string           `json:"kind"`
+	ContractVersion int              `json:"contract_version"`
+	Template        TemplateSnapshot `json:"template"`
+	EvalRun         EvalRun          `json:"eval_run"`
+	Items           []EvalItem       `json:"items"`
+	Artifacts       []ArtifactRef    `json:"artifacts"`
+	FeedbackEvents  []FeedbackEvent  `json:"feedback_events"`
+	EvaluatorConfig json.RawMessage  `json:"evaluator_config,omitempty"`
+}
+
+type CandidateTemplate struct {
+	Content  string                 `json:"content"`
+	Metadata agenttemplate.Metadata `json:"metadata"`
+}
+
+type CandidateSummary struct {
+	DiffArtifactID    string          `json:"diff_artifact_id,omitempty"`
+	Score             *float64        `json:"score,omitempty"`
+	PreferenceSummary string          `json:"preference_summary,omitempty"`
+	Metadata          json.RawMessage `json:"metadata,omitempty"`
+}
+
+type CandidatePackage struct {
+	Kind            string            `json:"kind"`
+	ContractVersion int               `json:"contract_version"`
+	TemplateID      string            `json:"template_id"`
+	BaseVersionID   string            `json:"base_version_id,omitempty"`
+	Candidate       CandidateTemplate `json:"candidate"`
+	EvalReport      json.RawMessage   `json:"eval_report,omitempty"`
+	Summary         CandidateSummary  `json:"summary,omitempty"`
+}
+
+func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (TrainingPackage, error) {
+	if store == nil {
+		return TrainingPackage{}, errors.New("store is required")
+	}
+	run, err := store.GetEvalRun(ctx, strings.TrimSpace(runID))
+	if err != nil {
+		return TrainingPackage{}, err
+	}
+	templateRef := run.TemplateID
+	if strings.TrimSpace(run.TemplateVersionID) != "" {
+		templateRef = run.TemplateVersionID
+	}
+	template, err := store.GetAgentTemplateReference(ctx, templateRef)
+	if err != nil {
+		return TrainingPackage{}, fmt.Errorf("load template %q: %w", templateRef, err)
+	}
+	snapshot, err := templateSnapshot(template)
+	if err != nil {
+		return TrainingPackage{}, err
+	}
+	items, err := store.ListEvalReviewItems(ctx, run.ID)
+	if err != nil {
+		return TrainingPackage{}, err
+	}
+	exportItems := make([]EvalItem, 0, len(items))
+	artifactIDs := map[string]struct{}{}
+	for _, item := range items {
+		exportItem, err := evalItem(item)
+		if err != nil {
+			return TrainingPackage{}, err
+		}
+		exportItems = append(exportItems, exportItem)
+		for _, id := range itemArtifactIDs(item) {
+			artifactIDs[id] = struct{}{}
+		}
+	}
+	artifacts, err := loadArtifactRefs(ctx, store, artifactIDs)
+	if err != nil {
+		return TrainingPackage{}, err
+	}
+	metadata, err := rawJSON(run.MetadataJSON)
+	if err != nil {
+		return TrainingPackage{}, fmt.Errorf("eval run metadata_json: %w", err)
+	}
+	return TrainingPackage{
+		Kind:            TrainingPackageKind,
+		ContractVersion: ContractVersion,
+		Template:        snapshot,
+		EvalRun: EvalRun{
+			ID:                run.ID,
+			TemplateID:        run.TemplateID,
+			TemplateVersionID: run.TemplateVersionID,
+			TargetRepo:        run.TargetRepo,
+			State:             run.State,
+			Metadata:          metadata,
+		},
+		Items:           exportItems,
+		Artifacts:       artifacts,
+		FeedbackEvents:  []FeedbackEvent{},
+		EvaluatorConfig: metadata,
+	}, nil
+}
+
+func ImportCandidatePackage(ctx context.Context, store *db.Store, candidate CandidatePackage, sourcePath string) (db.AgentTemplateVersion, error) {
+	if store == nil {
+		return db.AgentTemplateVersion{}, errors.New("store is required")
+	}
+	if err := validateCandidatePackage(ctx, store, candidate); err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
+	metadataJSON, err := agenttemplate.MarshalMetadata(candidate.Candidate.Metadata)
+	if err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
+	sourcePath = strings.TrimSpace(sourcePath)
+	if sourcePath == "" {
+		sourcePath = "candidate-package.json"
+	}
+	template := db.AgentTemplate{
+		ID:             strings.TrimSpace(candidate.TemplateID),
+		Name:           candidate.Candidate.Metadata.Name,
+		Description:    candidate.Candidate.Metadata.Description,
+		SourceRepo:     CandidateSourceRepo,
+		SourceRef:      CandidateSourceRef,
+		SourcePath:     sourcePath,
+		ResolvedCommit: agenttemplate.HashContent(candidate.Candidate.Content),
+		Content:        candidate.Candidate.Content,
+		MetadataJSON:   metadataJSON,
+	}
+	return store.AddPendingAgentTemplateVersion(ctx, template)
+}
+
+func validateCandidatePackage(ctx context.Context, store *db.Store, candidate CandidatePackage) error {
+	if candidate.Kind != CandidatePackageKind {
+		return fmt.Errorf("candidate package kind must be %q", CandidatePackageKind)
+	}
+	if candidate.ContractVersion != ContractVersion {
+		return fmt.Errorf("candidate package contract_version must be %d", ContractVersion)
+	}
+	templateID := strings.TrimSpace(candidate.TemplateID)
+	if err := agenttemplate.ValidateID(templateID); err != nil {
+		return err
+	}
+	if _, err := store.GetAgentTemplate(ctx, templateID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("agent template %s is not installed", templateID)
+		}
+		return err
+	}
+	parsed, err := agenttemplate.ParseTemplateContent(candidate.Candidate.Content)
+	if err != nil {
+		return fmt.Errorf("validate candidate template: %w", err)
+	}
+	if parsed.Metadata.ID != templateID {
+		return fmt.Errorf("candidate template id %q does not match package template_id %q", parsed.Metadata.ID, templateID)
+	}
+	if !sameMetadata(parsed.Metadata, candidate.Candidate.Metadata) {
+		return errors.New("candidate metadata does not match candidate template frontmatter")
+	}
+	if strings.TrimSpace(candidate.BaseVersionID) != "" {
+		base, err := store.GetAgentTemplateReference(ctx, candidate.BaseVersionID)
+		if err != nil {
+			return fmt.Errorf("load base version %q: %w", candidate.BaseVersionID, err)
+		}
+		if base.ID != templateID {
+			return fmt.Errorf("base version %q belongs to template %q, want %q", candidate.BaseVersionID, base.ID, templateID)
+		}
+	}
+	if strings.TrimSpace(candidate.Summary.DiffArtifactID) != "" {
+		if _, err := store.GetEvalArtifact(ctx, candidate.Summary.DiffArtifactID); err != nil {
+			return fmt.Errorf("load summary diff artifact %q: %w", candidate.Summary.DiffArtifactID, err)
+		}
+	}
+	return nil
+}
+
+func templateSnapshot(template db.AgentTemplate) (TemplateSnapshot, error) {
+	metadata, err := agenttemplate.UnmarshalMetadata(template.MetadataJSON)
+	if err != nil {
+		return TemplateSnapshot{}, err
+	}
+	return TemplateSnapshot{
+		ID:             template.ID,
+		VersionID:      template.VersionID,
+		VersionNumber:  template.VersionNumber,
+		VersionState:   template.VersionState,
+		ContentHash:    template.ContentHash,
+		SourceRepo:     template.SourceRepo,
+		SourceRef:      template.SourceRef,
+		SourcePath:     template.SourcePath,
+		ResolvedCommit: template.ResolvedCommit,
+		Metadata:       metadata,
+		Content:        template.Content,
+	}, nil
+}
+
+func evalItem(item db.EvalReviewItem) (EvalItem, error) {
+	metadata, err := rawJSON(item.MetadataJSON)
+	if err != nil {
+		return EvalItem{}, fmt.Errorf("eval item %s metadata_json: %w", item.ItemID, err)
+	}
+	return EvalItem{
+		ID:                  item.ItemID,
+		Title:               item.Title,
+		SourceArtifactID:    item.SourceArtifactID,
+		BaselineArtifactID:  item.BaselineArtifactID,
+		CandidateArtifactID: item.CandidateArtifactID,
+		PreviewArtifactID:   item.PreviewArtifactID,
+		DiffArtifactID:      item.DiffArtifactID,
+		Metadata:            metadata,
+	}, nil
+}
+
+func itemArtifactIDs(item db.EvalReviewItem) []string {
+	values := []string{
+		item.SourceArtifactID,
+		item.BaselineArtifactID,
+		item.CandidateArtifactID,
+		item.PreviewArtifactID,
+		item.DiffArtifactID,
+	}
+	ids := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			ids = append(ids, value)
+		}
+	}
+	return ids
+}
+
+func loadArtifactRefs(ctx context.Context, store *db.Store, ids map[string]struct{}) ([]ArtifactRef, error) {
+	sortedIDs := make([]string, 0, len(ids))
+	for id := range ids {
+		sortedIDs = append(sortedIDs, id)
+	}
+	sort.Strings(sortedIDs)
+	refs := make([]ArtifactRef, 0, len(sortedIDs))
+	for _, id := range sortedIDs {
+		artifact, err := store.GetEvalArtifact(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("load artifact %q: %w", id, err)
+		}
+		refs = append(refs, ArtifactRef{
+			ID:        artifact.ID,
+			Hash:      artifact.Hash,
+			MediaType: artifact.MediaType,
+			SizeBytes: artifact.SizeBytes,
+			Driver:    artifact.Driver,
+		})
+	}
+	return refs, nil
+}
+
+func rawJSON(value string) (json.RawMessage, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(value), &decoded); err != nil {
+		return nil, err
+	}
+	return json.RawMessage(value), nil
+}
+
+func sameMetadata(a agenttemplate.Metadata, b agenttemplate.Metadata) bool {
+	encodedA, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	encodedB, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return string(encodedA) == string(encodedB)
+}

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -1,0 +1,188 @@
+package skillopt
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestExportTrainingPackage(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("planner", "Plan carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	blobHash := artifact.ContentHash([]byte("baseline output"))
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{
+		ID:        "baseline",
+		Hash:      blobHash,
+		MediaType: "text/markdown",
+		SizeBytes: int64(len("baseline output")),
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "run-1",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "ready",
+		MetadataJSON:      `{"driver":"planner"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:              "run-1",
+		ItemID:             "item-001",
+		Title:              "README",
+		BaselineArtifactID: "baseline",
+		MetadataJSON:       `{"path":"README.md"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+
+	pkg, err := ExportTrainingPackage(ctx, store, "run-1")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+
+	if pkg.Kind != TrainingPackageKind || pkg.ContractVersion != ContractVersion {
+		t.Fatalf("package header = %s v%d", pkg.Kind, pkg.ContractVersion)
+	}
+	if pkg.Template.ID != "planner" || pkg.Template.VersionID != installed.VersionID || pkg.Template.Content == "" {
+		t.Fatalf("template snapshot = %+v", pkg.Template)
+	}
+	if len(pkg.Items) != 1 || pkg.Items[0].BaselineArtifactID != "baseline" {
+		t.Fatalf("items = %+v", pkg.Items)
+	}
+	if len(pkg.Artifacts) != 1 || pkg.Artifacts[0].Hash != blobHash {
+		t.Fatalf("artifacts = %+v", pkg.Artifacts)
+	}
+	if string(pkg.EvaluatorConfig) != `{"driver":"planner"}` {
+		t.Fatalf("evaluator config = %s", string(pkg.EvaluatorConfig))
+	}
+	if _, err := json.Marshal(pkg); err != nil {
+		t.Fatalf("exported package did not marshal: %v", err)
+	}
+}
+
+func TestImportCandidatePackageCreatesPendingVersion(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("planner", "Plan carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{
+		ID:        "candidate-diff",
+		Hash:      artifact.ContentHash([]byte("diff")),
+		MediaType: "text/plain",
+		SizeBytes: int64(len("diff")),
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact returned error: %v", err)
+	}
+	current, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	candidateContent := testTemplateContent("planner", "Plan carefully with a concise risk section.")
+	parsed, err := agenttemplate.ParseTemplateContent(candidateContent)
+	if err != nil {
+		t.Fatalf("ParseTemplateContent returned error: %v", err)
+	}
+
+	version, err := ImportCandidatePackage(ctx, store, CandidatePackage{
+		Kind:            CandidatePackageKind,
+		ContractVersion: ContractVersion,
+		TemplateID:      "planner",
+		BaseVersionID:   current.VersionID,
+		Candidate: CandidateTemplate{
+			Content:  candidateContent,
+			Metadata: parsed.Metadata,
+		},
+		EvalReport: json.RawMessage(`{"score":0.82}`),
+		Summary: CandidateSummary{
+			DiffArtifactID:    "candidate-diff",
+			PreferenceSummary: "Candidate is more actionable.",
+		},
+	}, "candidate.json")
+	if err != nil {
+		t.Fatalf("ImportCandidatePackage returned error: %v", err)
+	}
+
+	if version.State != "pending" || version.TemplateID != "planner" {
+		t.Fatalf("candidate version = %+v", version)
+	}
+	after, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate after import returned error: %v", err)
+	}
+	if after.VersionID != current.VersionID || after.Content != current.Content {
+		t.Fatalf("current template changed: before=%+v after=%+v", current, after)
+	}
+	latest, err := store.GetAgentTemplateReference(ctx, "planner@latest")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateReference latest returned error: %v", err)
+	}
+	if latest.VersionID != version.ID || latest.Content != candidateContent {
+		t.Fatalf("latest template = %+v", latest)
+	}
+}
+
+func testTemplate(id string, body string) db.AgentTemplate {
+	content := testTemplateContent(id, body)
+	parsed, err := agenttemplate.ParseTemplateContent(content)
+	if err != nil {
+		panic(err)
+	}
+	metadataJSON, err := agenttemplate.MarshalMetadata(parsed.Metadata)
+	if err != nil {
+		panic(err)
+	}
+	return db.AgentTemplate{
+		ID:             id,
+		Name:           parsed.Metadata.Name,
+		Description:    parsed.Metadata.Description,
+		SourceRepo:     agenttemplate.LocalSourceRepo,
+		SourceRef:      agenttemplate.LocalSourceRef,
+		SourcePath:     id + ".md",
+		ResolvedCommit: agenttemplate.HashContent(content),
+		Content:        content,
+		MetadataJSON:   metadataJSON,
+	}
+}
+
+func testTemplateContent(id string, body string) string {
+	return agenttemplate.FormatTemplateContent(agenttemplate.Metadata{
+		ID:                   id,
+		Name:                 "Planner",
+		Description:          "Plans implementation work.",
+		Kind:                 agenttemplate.TemplateKind,
+		Version:              agenttemplate.TemplateVersion,
+		Capabilities:         []string{"ask"},
+		RuntimeCompatibility: []string{"codex"},
+		Tags:                 []string{"planning"},
+		Inputs:               []string{"task"},
+		Outputs:              []string{"plan"},
+	}, "# Planner\n\n"+body+"\n")
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -252,3 +252,16 @@ gitmoot job cancel <job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+## SkillOpt Exchange
+
+```sh
+gitmoot skillopt export --run <run-id> [--output training.json]
+gitmoot skillopt import --file candidate.json
+```
+
+`skillopt export` writes a JSON training package with the template snapshot,
+eval run, review items, artifact manifests, feedback events when present, and
+evaluator config. `skillopt import` validates a candidate package and stores the
+candidate template as a pending version; it never promotes the candidate
+automatically.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -56,3 +56,10 @@ gitmoot job watch <job-id>
 gitmoot job retry <job-id>
 gitmoot lock list --repo owner/repo
 ```
+
+## SkillOpt Exchange
+
+```sh
+gitmoot skillopt export --run <run-id> [--output training.json]
+gitmoot skillopt import --file candidate.json
+```

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -1,0 +1,29 @@
+---
+title: SkillOpt Exchange Contract
+---
+
+Gitmoot keeps the SkillOpt optimizer outside the main binary. The boundary is a
+pair of JSON package formats handled by `gitmoot skillopt export` and
+`gitmoot skillopt import`.
+
+## Training Package
+
+```sh
+gitmoot skillopt export --run run-2026-05-31 --output training.json
+```
+
+The package contains the template snapshot, eval run, review items, artifact
+manifests, canonical feedback events when available, and evaluator config.
+Artifact entries reference local SHA256 blobs stored under Gitmoot home; blobs
+are not copied into the repository by default.
+
+## Candidate Package
+
+```sh
+gitmoot skillopt import --file candidate.json
+```
+
+The candidate package contains full agent-template Markdown with YAML
+frontmatter, matching metadata, an optional eval report, and an optional summary.
+Importing stores the candidate as a pending template version and never promotes
+it automatically.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -42,6 +42,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'reference/cli',
         'reference/runtime-adapters',
+        'reference/skillopt-exchange-contract',
       ],
     },
     {

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -280,6 +280,17 @@ gitmoot lock list --repo owner/repo
 gitmoot lock release owner/repo <branch> --owner <agent>
 ```
 
+### SkillOpt Exchange
+
+```sh
+gitmoot skillopt export --run <run-id> --output training.json
+gitmoot skillopt import --file candidate.json
+```
+
+The export/import boundary lets a future external `gitmoot-skillopt` optimizer
+train on local eval artifacts and return candidate template versions. Imported
+candidates stay pending until a human review workflow promotes them.
+
 Detailed command coverage lives in
 [skills/gitmoot/references/CLI.md](skills/gitmoot/references/CLI.md).
 
@@ -456,6 +467,8 @@ gitmoot job show <job-id>
 gitmoot job events <job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
+gitmoot skillopt export --run <run-id> [--output training.json]
+gitmoot skillopt import --file candidate.json
 ```
 
 Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`
@@ -2823,6 +2836,19 @@ gitmoot job cancel <job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+## SkillOpt Exchange
+
+```sh
+gitmoot skillopt export --run <run-id> [--output training.json]
+gitmoot skillopt import --file candidate.json
+```
+
+`skillopt export` writes a JSON training package with the template snapshot,
+eval run, review items, artifact manifests, feedback events when present, and
+evaluator config. `skillopt import` validates a candidate package and stores the
+candidate template as a pending version; it never promotes the candidate
+automatically.
 
 ---
 


### PR DESCRIPTION
WHAT: Added Gitmoot-side SkillOpt exchange package support.

WHY: Gitmoot needs a stable JSON boundary so an external gitmoot-skillopt optimizer can consume local eval artifacts and return candidate agent-template versions without being embedded in the main binary.

CHANGES:
- Added internal/skillopt contract types for training and candidate packages.
- Added export logic for template snapshots, eval runs, review items, artifact manifests, feedback-event placeholders, and evaluator config.
- Added import validation for package kind/version, template frontmatter metadata, base template version compatibility, and summary artifact references.
- Candidate import creates a pending agent-template version and does not promote it.
- Added gitmoot skillopt export/import commands.
- Documented the JSON exchange contract in docs and website reference pages; regenerated llms-full docs.
- Added package and CLI tests for export/import behavior.

RESULTS:
- /root/temp/ts/tool/go test ./internal/skillopt ./internal/cli ./internal/db ./internal/artifact
- /root/temp/ts/tool/go test ./internal/...
- /root/temp/ts/tool/go test ./...
- npm run build (from website/)
- git diff --check
- git diff --cached --check
- codex exec review --uncommitted final output:

```
No discrete correctness issues were found in the current staged, unstaged, and untracked changes. Test execution was blocked by the environment trying to download the Go 1.26 toolchain into a read-only cache.
No discrete correctness issues were found in the current staged, unstaged, and untracked changes. Test execution was blocked by the environment trying to download the Go 1.26 toolchain into a read-only cache.
```

RISK: codex exec review could not run tests inside its sandbox because it cannot download/use Go 1.26 there; tests were run directly with /root/temp/ts/tool/go.