### PR TITLE
Add markdown SkillOpt feedback collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ gitmoot lock release owner/repo <branch> --owner <agent>
 ```sh
 gitmoot skillopt export --run <run-id> --output training.json
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
+gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
 ```
 
 The export/import boundary lets a future external `gitmoot-skillopt` optimizer

--- a/SKILL.md
+++ b/SKILL.md
@@ -115,6 +115,8 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
+gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
 ```
 
 Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -52,3 +52,49 @@ The imported package must have:
 Importing never promotes a candidate. Gitmoot stores it as a pending template
 version so later review and promotion commands can decide whether it becomes
 current.
+
+## Markdown Feedback Packet
+
+Generate a local blind A/B review packet:
+
+```sh
+gitmoot skillopt feedback markdown export \
+  --run run-2026-05-31 \
+  --output .gitmoot/evals/run-2026-05-31
+```
+
+The packet contains:
+
+- `index.md`: review instructions and item links
+- `items/*.md`: one file per item with Option A and Option B
+- `feedback.yml`: the editable response file
+- `.assignments.json`: hidden A/B assignment metadata used by Gitmoot on import
+
+Humans fill `feedback.yml` with choices:
+
+```yaml
+run_id: run-2026-05-31
+reviewer: alice
+items:
+  - item_id: item-001
+    choice: b
+    reasoning: More concrete and easier to execute.
+  - item_id: item-002
+    choice: tie
+```
+
+Allowed choices are exactly `a`, `b`, `tie`, `neither`, and `skip`. Reasoning is
+optional.
+
+Import the completed feedback:
+
+```sh
+gitmoot skillopt feedback markdown import \
+  --packet .gitmoot/evals/run-2026-05-31
+```
+
+Gitmoot validates the full response before writing any events. On import, it
+uses `.assignments.json` to de-blind `a` and `b` so stored canonical feedback
+events use `choice: a` for the baseline artifact and `choice: b` for the
+candidate artifact. Each event includes `run_id`, `item_id`, `choice`, optional
+`reasoning`, `reviewer`, `source`, optional `source_url`, and `created_at`.

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -11,7 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/feedback"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
 )
 
@@ -25,6 +28,8 @@ func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptExport(args[1:], stdout, stderr)
 	case "import":
 		return runSkillOptImport(args[1:], stdout, stderr)
+	case "feedback":
+		return runSkillOptFeedback(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown skillopt command %q\n\n", args[0])
 		printSkillOptUsage(stderr)
@@ -36,6 +41,8 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt export --run <run-id> [--output package.json]")
 	fmt.Fprintln(w, "  gitmoot skillopt import --file candidate.json")
+	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>")
+	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
 }
 
 func runSkillOptExport(args []string, stdout, stderr io.Writer) int {
@@ -142,4 +149,115 @@ func writeSkillOptFile(path string, content []byte) error {
 		return fmt.Errorf("create output directory: %w", err)
 	}
 	return os.WriteFile(path, content, 0o644)
+}
+
+func runSkillOptFeedback(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSkillOptUsage(stdout)
+		return 0
+	}
+	if args[0] != "markdown" {
+		fmt.Fprintf(stderr, "unknown skillopt feedback collector %q\n\n", args[0])
+		printSkillOptUsage(stderr)
+		return 2
+	}
+	if len(args) < 2 {
+		fmt.Fprintln(stderr, "skillopt feedback markdown requires export or import")
+		printSkillOptUsage(stderr)
+		return 2
+	}
+	switch args[1] {
+	case "export":
+		return runSkillOptFeedbackMarkdownExport(args[2:], stdout, stderr)
+	case "import":
+		return runSkillOptFeedbackMarkdownImport(args[2:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skillopt feedback markdown command %q\n\n", args[1])
+		printSkillOptUsage(stderr)
+		return 2
+	}
+}
+
+func runSkillOptFeedbackMarkdownExport(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt feedback markdown export", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	runID := fs.String("run", "", "eval run id")
+	output := fs.String("output", "", "packet output directory")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt feedback markdown export does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*runID) == "" || strings.TrimSpace(*output) == "" {
+		fmt.Fprintln(stderr, "skillopt feedback markdown export requires --run and --output")
+		return 2
+	}
+	if err := withSkillOptStore(*home, func(paths config.Paths, store *db.Store) error {
+		collector := feedback.MarkdownCollector{BlobStore: artifact.NewStore(paths.ArtifactBlobs)}
+		return collector.WritePacket(context.Background(), store, *runID, *output)
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt feedback markdown export: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "wrote markdown feedback packet for %s to %s", *runID, *output)
+	return 0
+}
+
+func runSkillOptFeedbackMarkdownImport(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt feedback markdown import", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	packet := fs.String("packet", "", "packet directory containing feedback.yml")
+	reviewer := fs.String("reviewer", "", "reviewer name override")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt feedback markdown import does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*packet) == "" {
+		fmt.Fprintln(stderr, "skillopt feedback markdown import requires --packet")
+		return 2
+	}
+	var count int
+	if err := withSkillOptStore(*home, func(paths config.Paths, store *db.Store) error {
+		collector := feedback.MarkdownCollector{BlobStore: artifact.NewStore(paths.ArtifactBlobs)}
+		events, err := collector.ImportPacket(context.Background(), store, *packet, *reviewer)
+		if err != nil {
+			return err
+		}
+		count = len(events)
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt feedback markdown import: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "imported %d feedback events", count)
+	return 0
+}
+
+func withSkillOptStore(home string, fn func(config.Paths, *db.Store) error) error {
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return err
+	}
+	if err := config.Initialize(paths); err != nil {
+		return err
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	return fn(paths, store)
 }

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -34,11 +34,29 @@ func TestSkillOptExportAndImportCommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAgentTemplate returned error: %v", err)
 	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	baselineBlob, err := blobStore.Put([]byte("baseline"))
+	if err != nil {
+		t.Fatalf("Put baseline returned error: %v", err)
+	}
+	candidateBlob, err := blobStore.Put([]byte("candidate"))
+	if err != nil {
+		t.Fatalf("Put candidate returned error: %v", err)
+	}
 	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
 		ID:        "baseline",
-		Hash:      artifact.ContentHash([]byte("baseline")),
+		Hash:      baselineBlob.Hash,
 		MediaType: "text/markdown",
-		SizeBytes: int64(len("baseline")),
+		SizeBytes: baselineBlob.Size,
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+		ID:        "candidate",
+		Hash:      candidateBlob.Hash,
+		MediaType: "text/markdown",
+		SizeBytes: candidateBlob.Size,
 		Driver:    "text",
 	}); err != nil {
 		t.Fatalf("UpsertEvalArtifact returned error: %v", err)
@@ -54,9 +72,10 @@ func TestSkillOptExportAndImportCommands(t *testing.T) {
 		t.Fatalf("UpsertEvalRun returned error: %v", err)
 	}
 	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
-		RunID:              "run-1",
-		ItemID:             "item-001",
-		BaselineArtifactID: "baseline",
+		RunID:               "run-1",
+		ItemID:              "item-001",
+		BaselineArtifactID:  "baseline",
+		CandidateArtifactID: "candidate",
 	}); err != nil {
 		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
 	}
@@ -81,8 +100,34 @@ func TestSkillOptExportAndImportCommands(t *testing.T) {
 	if err := json.Unmarshal(exportedContent, &training); err != nil {
 		t.Fatalf("decode training package: %v\n%s", err, string(exportedContent))
 	}
-	if training.Template.VersionID != installed.VersionID || len(training.Items) != 1 || len(training.Artifacts) != 1 {
+	if training.Template.VersionID != installed.VersionID || len(training.Items) != 1 || len(training.Artifacts) != 2 {
 		t.Fatalf("training package = %+v", training)
+	}
+	packetDir := filepath.Join(t.TempDir(), "packet")
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "feedback", "markdown", "export", "--home", home, "--run", "run-1", "--output", packetDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt feedback markdown export exit code = %d, stderr=%s", code, stderr.String())
+	}
+	feedbackYAML := `run_id: run-1
+reviewer: jerry
+items:
+  - item_id: item-001
+    choice: a
+    reasoning: Clearer.
+`
+	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackYAML), 0o644); err != nil {
+		t.Fatalf("write feedback.yml: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "feedback", "markdown", "import", "--home", home, "--packet", packetDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt feedback markdown import exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "imported 1 feedback events") {
+		t.Fatalf("feedback import stdout = %q", stdout.String())
 	}
 
 	candidateContent := cliSkillOptTemplateContent("planner", "Plan the work and include risks.")
@@ -135,6 +180,68 @@ func TestSkillOptExportAndImportCommands(t *testing.T) {
 	}
 	if latest.VersionID != "planner@v2" || latest.Content != candidateContent {
 		t.Fatalf("latest = %+v", latest)
+	}
+	events, err := store.ListFeedbackEvents(context.Background(), "run-1")
+	if err != nil {
+		t.Fatalf("ListFeedbackEvents returned error: %v", err)
+	}
+	if len(events) != 1 || events[0].Choice != "a" {
+		t.Fatalf("feedback events = %+v", events)
+	}
+}
+
+func TestSkillOptFeedbackRejectsIncompleteCommands(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantErr      string
+		wantStdout   string
+		wantExitCode int
+		wantNoStderr bool
+		wantNoStdout bool
+	}{
+		{
+			name:         "feedback help",
+			args:         []string{"skillopt", "feedback", "--help"},
+			wantStdout:   "gitmoot skillopt feedback markdown export",
+			wantExitCode: 0,
+			wantNoStderr: true,
+		},
+		{
+			name:         "unknown collector",
+			args:         []string{"skillopt", "feedback", "json"},
+			wantErr:      `unknown skillopt feedback collector "json"`,
+			wantExitCode: 2,
+			wantNoStdout: true,
+		},
+		{
+			name:         "missing markdown subcommand",
+			args:         []string{"skillopt", "feedback", "markdown"},
+			wantErr:      "skillopt feedback markdown requires export or import",
+			wantExitCode: 2,
+			wantNoStdout: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := Run(tt.args, &stdout, &stderr)
+			if code != tt.wantExitCode {
+				t.Fatalf("exit code = %d, want %d; stdout=%s stderr=%s", code, tt.wantExitCode, stdout.String(), stderr.String())
+			}
+			if tt.wantStdout != "" && !strings.Contains(stdout.String(), tt.wantStdout) {
+				t.Fatalf("stdout = %q, want substring %q", stdout.String(), tt.wantStdout)
+			}
+			if tt.wantErr != "" && !strings.Contains(stderr.String(), tt.wantErr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tt.wantErr)
+			}
+			if tt.wantNoStdout && stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if tt.wantNoStderr && stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -183,6 +183,18 @@ type EvalReviewItem struct {
 	UpdatedAt           string
 }
 
+type FeedbackEvent struct {
+	ID        string
+	RunID     string
+	ItemID    string
+	Choice    string
+	Reasoning string
+	Reviewer  string
+	Source    string
+	SourceURL string
+	CreatedAt string
+}
+
 type BranchLock struct {
 	RepoFullName string
 	Branch       string
@@ -1530,6 +1542,78 @@ func scanEvalReviewItem(row interface{ Scan(dest ...any) error }) (EvalReviewIte
 	return item, nil
 }
 
+func (s *Store) UpsertFeedbackEvent(ctx context.Context, event FeedbackEvent) error {
+	if strings.TrimSpace(event.ID) == "" {
+		event.ID = feedbackEventID(event)
+	}
+	if strings.TrimSpace(event.RunID) == "" {
+		return errors.New("feedback event run id is required")
+	}
+	if strings.TrimSpace(event.ItemID) == "" {
+		return errors.New("feedback event item id is required")
+	}
+	if strings.TrimSpace(event.Choice) == "" {
+		return errors.New("feedback event choice is required")
+	}
+	if strings.TrimSpace(event.Reviewer) == "" {
+		return errors.New("feedback event reviewer is required")
+	}
+	if strings.TrimSpace(event.Source) == "" {
+		return errors.New("feedback event source is required")
+	}
+	if strings.TrimSpace(event.CreatedAt) == "" {
+		event.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO feedback_events(id, run_id, item_id, choice, reasoning, reviewer, source, source_url, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(run_id, item_id, reviewer, source, source_url) DO UPDATE SET
+			id = excluded.id,
+			choice = excluded.choice,
+			reasoning = excluded.reasoning,
+			reviewer = excluded.reviewer,
+			source = excluded.source,
+			source_url = excluded.source_url,
+			created_at = excluded.created_at`,
+		event.ID, event.RunID, event.ItemID, event.Choice, event.Reasoning, event.Reviewer, event.Source, event.SourceURL, event.CreatedAt)
+	return err
+}
+
+func (s *Store) ListFeedbackEvents(ctx context.Context, runID string) ([]FeedbackEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, run_id, item_id, choice, reasoning, reviewer, source, source_url, created_at
+		FROM feedback_events WHERE run_id = ? ORDER BY item_id, reviewer, source, source_url`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var events []FeedbackEvent
+	for rows.Next() {
+		event, err := scanFeedbackEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+func scanFeedbackEvent(row interface{ Scan(dest ...any) error }) (FeedbackEvent, error) {
+	var event FeedbackEvent
+	if err := row.Scan(&event.ID, &event.RunID, &event.ItemID, &event.Choice, &event.Reasoning, &event.Reviewer, &event.Source, &event.SourceURL, &event.CreatedAt); err != nil {
+		return FeedbackEvent{}, err
+	}
+	return event, nil
+}
+
+func feedbackEventID(event FeedbackEvent) string {
+	parts := []string{event.RunID, event.ItemID, event.Reviewer, event.Source, event.SourceURL}
+	for index, part := range parts {
+		parts[index] = strings.TrimSpace(part)
+	}
+	content, _ := json.Marshal(parts)
+	sum := sha256.Sum256(content)
+	return "feedback:" + hex.EncodeToString(sum[:])
+}
+
 func (s *Store) AcquireResourceLock(ctx context.Context, lock ResourceLock, now time.Time) (bool, error) {
 	resourceKey := strings.TrimSpace(lock.ResourceKey)
 	ownerJobID := strings.TrimSpace(lock.OwnerJobID)
@@ -2276,6 +2360,20 @@ CREATE TABLE eval_review_items (
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	UNIQUE(run_id, item_id)
+);
+	`,
+	`
+CREATE TABLE feedback_events (
+	id TEXT PRIMARY KEY,
+	run_id TEXT NOT NULL,
+	item_id TEXT NOT NULL,
+	choice TEXT NOT NULL,
+	reasoning TEXT NOT NULL DEFAULT '',
+	reviewer TEXT NOT NULL,
+	source TEXT NOT NULL,
+	source_url TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	UNIQUE(run_id, item_id, reviewer, source, source_url)
 );
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -36,6 +36,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"eval_artifacts",
 		"eval_runs",
 		"eval_review_items",
+		"feedback_events",
 	} {
 		ok, err := store.HasTable(ctx, table)
 		if err != nil {
@@ -119,6 +120,78 @@ func TestEvalStorageMethods(t *testing.T) {
 	}
 	if items[0].ID != "run-1/item-001" || items[0].DiffArtifactID != artifact.ID || items[0].MetadataJSON != `{"path":"README.md"}` {
 		t.Fatalf("review item = %+v", items[0])
+	}
+}
+
+func TestFeedbackEventMethods(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	event := FeedbackEvent{
+		RunID:     "run-1",
+		ItemID:    "item-001",
+		Choice:    "b",
+		Reasoning: "More concrete.",
+		Reviewer:  "jerry",
+		Source:    "markdown",
+		SourceURL: "packet",
+		CreatedAt: "2026-05-31T10:00:00Z",
+	}
+	if err := store.UpsertFeedbackEvent(ctx, event); err != nil {
+		t.Fatalf("UpsertFeedbackEvent returned error: %v", err)
+	}
+	event.Choice = "tie"
+	event.Reasoning = "Both work."
+	if err := store.UpsertFeedbackEvent(ctx, event); err != nil {
+		t.Fatalf("second UpsertFeedbackEvent returned error: %v", err)
+	}
+	events, err := store.ListFeedbackEvents(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("ListFeedbackEvents returned error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(events))
+	}
+	if events[0].Choice != "tie" || events[0].Reasoning != "Both work." || events[0].ID == "" {
+		t.Fatalf("event = %+v", events[0])
+	}
+
+	collisionA := FeedbackEvent{
+		RunID:     "a/b",
+		ItemID:    "c",
+		Choice:    "a",
+		Reviewer:  "reviewer",
+		Source:    "markdown",
+		CreatedAt: "2026-05-31T10:00:00Z",
+	}
+	collisionB := FeedbackEvent{
+		RunID:     "a",
+		ItemID:    "b/c",
+		Choice:    "b",
+		Reviewer:  "reviewer",
+		Source:    "markdown",
+		CreatedAt: "2026-05-31T10:00:00Z",
+	}
+	if err := store.UpsertFeedbackEvent(ctx, collisionA); err != nil {
+		t.Fatalf("collisionA UpsertFeedbackEvent returned error: %v", err)
+	}
+	if err := store.UpsertFeedbackEvent(ctx, collisionB); err != nil {
+		t.Fatalf("collisionB UpsertFeedbackEvent returned error: %v", err)
+	}
+	aEvents, err := store.ListFeedbackEvents(ctx, "a/b")
+	if err != nil {
+		t.Fatalf("ListFeedbackEvents a/b returned error: %v", err)
+	}
+	bEvents, err := store.ListFeedbackEvents(ctx, "a")
+	if err != nil {
+		t.Fatalf("ListFeedbackEvents a returned error: %v", err)
+	}
+	if len(aEvents) != 1 || len(bEvents) != 1 || aEvents[0].ItemID != "c" || bEvents[0].ItemID != "b/c" {
+		t.Fatalf("collision events a=%+v b=%+v", aEvents, bEvents)
 	}
 }
 

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -1,0 +1,44 @@
+package feedback
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	ChoiceA       = "a"
+	ChoiceB       = "b"
+	ChoiceTie     = "tie"
+	ChoiceNeither = "neither"
+	ChoiceSkip    = "skip"
+
+	SourceMarkdown = "markdown"
+)
+
+var validChoices = map[string]struct{}{
+	ChoiceA:       {},
+	ChoiceB:       {},
+	ChoiceTie:     {},
+	ChoiceNeither: {},
+	ChoiceSkip:    {},
+}
+
+func ValidateChoice(choice string) error {
+	choice = strings.TrimSpace(strings.ToLower(choice))
+	if _, ok := validChoices[choice]; !ok {
+		return fmt.Errorf("invalid feedback choice %q; use a, b, tie, neither, or skip", choice)
+	}
+	return nil
+}
+
+func NormalizeChoice(choice string) (string, error) {
+	choice = strings.TrimSpace(strings.ToLower(choice))
+	if choice == "" {
+		return "", errors.New("feedback choice is required")
+	}
+	if err := ValidateChoice(choice); err != nil {
+		return "", err
+	}
+	return choice, nil
+}

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -1,0 +1,474 @@
+package feedback
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"gopkg.in/yaml.v3"
+)
+
+const assignmentsName = ".assignments.json"
+
+type MarkdownCollector struct {
+	BlobStore artifact.Store
+	Now       func() time.Time
+}
+
+type assignmentFile struct {
+	RunID string            `json:"run_id"`
+	Items []blindAssignment `json:"items"`
+}
+
+type blindAssignment struct {
+	ItemID    string `json:"item_id"`
+	A         string `json:"a"`
+	B         string `json:"b"`
+	Baseline  string `json:"baseline"`
+	Candidate string `json:"candidate"`
+}
+
+type feedbackFile struct {
+	RunID    string              `yaml:"run_id"`
+	Reviewer string              `yaml:"reviewer"`
+	Items    []feedbackFileEntry `yaml:"items"`
+}
+
+type feedbackFileEntry struct {
+	ItemID    string `yaml:"item_id"`
+	Choice    string `yaml:"choice"`
+	Reasoning string `yaml:"reasoning,omitempty"`
+}
+
+func (c MarkdownCollector) WritePacket(ctx context.Context, store *db.Store, runID string, dir string) error {
+	if store == nil {
+		return errors.New("store is required")
+	}
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return errors.New("packet output directory is required")
+	}
+	run, err := store.GetEvalRun(ctx, runID)
+	if err != nil {
+		return err
+	}
+	items, err := store.ListEvalReviewItems(ctx, run.ID)
+	if err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		return fmt.Errorf("eval run %s has no review items", run.ID)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "items"), 0o755); err != nil {
+		return fmt.Errorf("create packet directory: %w", err)
+	}
+	assignments := assignmentFile{RunID: run.ID}
+	for _, item := range items {
+		baselineArtifactID := strings.TrimSpace(item.BaselineArtifactID)
+		candidateArtifactID := strings.TrimSpace(item.CandidateArtifactID)
+		if baselineArtifactID == "" || candidateArtifactID == "" {
+			return fmt.Errorf("eval review item %s requires both baseline and candidate artifacts", item.ItemID)
+		}
+		if baselineArtifactID == candidateArtifactID {
+			return fmt.Errorf("eval review item %s requires distinct baseline and candidate artifacts", item.ItemID)
+		}
+		assignment := assignmentFor(run.ID, item)
+		assignments.Items = append(assignments.Items, assignment)
+		if err := c.writeItem(ctx, store, dir, item, assignment); err != nil {
+			return err
+		}
+	}
+	sort.Slice(assignments.Items, func(i, j int) bool {
+		return assignments.Items[i].ItemID < assignments.Items[j].ItemID
+	})
+	if err := writeJSONFile(filepath.Join(dir, assignmentsName), assignments, 0o600); err != nil {
+		return err
+	}
+	if err := writeTextFile(filepath.Join(dir, "index.md"), indexMarkdown(run, items), 0o644); err != nil {
+		return err
+	}
+	return writeFeedbackYAML(filepath.Join(dir, "feedback.yml"), run.ID, items)
+}
+
+func (c MarkdownCollector) ImportPacket(ctx context.Context, store *db.Store, dir string, reviewerOverride string) ([]db.FeedbackEvent, error) {
+	if store == nil {
+		return nil, errors.New("store is required")
+	}
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil, errors.New("packet directory is required")
+	}
+	dir, err := filepath.Abs(filepath.Clean(dir))
+	if err != nil {
+		return nil, fmt.Errorf("resolve packet directory: %w", err)
+	}
+	assignments, err := readAssignments(filepath.Join(dir, assignmentsName))
+	if err != nil {
+		return nil, err
+	}
+	feedback, err := readFeedbackYAML(filepath.Join(dir, "feedback.yml"))
+	if err != nil {
+		return nil, err
+	}
+	if feedback.RunID != assignments.RunID {
+		return nil, fmt.Errorf("feedback run_id %q does not match assignments run_id %q", feedback.RunID, assignments.RunID)
+	}
+	if err := validateAssignmentsAgainstStore(ctx, store, assignments); err != nil {
+		return nil, err
+	}
+	reviewer := strings.TrimSpace(reviewerOverride)
+	if reviewer == "" {
+		reviewer = strings.TrimSpace(feedback.Reviewer)
+	}
+	if reviewer == "" {
+		return nil, errors.New("feedback reviewer is required")
+	}
+	assignmentsByItem := map[string]blindAssignment{}
+	for _, assignment := range assignments.Items {
+		itemID := strings.TrimSpace(assignment.ItemID)
+		if itemID == "" {
+			return nil, errors.New("assignments contain an item with empty item_id")
+		}
+		if _, ok := assignmentsByItem[itemID]; ok {
+			return nil, fmt.Errorf("assignments contain duplicate item_id %q", itemID)
+		}
+		assignmentsByItem[itemID] = assignment
+	}
+	now := c.now().UTC().Format(time.RFC3339)
+	events := make([]db.FeedbackEvent, 0, len(feedback.Items))
+	seenItems := map[string]struct{}{}
+	for _, entry := range feedback.Items {
+		itemID := strings.TrimSpace(entry.ItemID)
+		assignment, ok := assignmentsByItem[itemID]
+		if !ok {
+			return nil, fmt.Errorf("unknown feedback item_id %q", itemID)
+		}
+		if _, ok := seenItems[itemID]; ok {
+			return nil, fmt.Errorf("duplicate feedback item_id %q", itemID)
+		}
+		seenItems[itemID] = struct{}{}
+		choice, err := NormalizeChoice(entry.Choice)
+		if err != nil {
+			return nil, fmt.Errorf("item %s: %w", itemID, err)
+		}
+		choice, err = deblindChoice(choice, assignment)
+		if err != nil {
+			return nil, fmt.Errorf("item %s: %w", itemID, err)
+		}
+		event := db.FeedbackEvent{
+			RunID:     feedback.RunID,
+			ItemID:    itemID,
+			Choice:    choice,
+			Reasoning: strings.TrimSpace(entry.Reasoning),
+			Reviewer:  reviewer,
+			Source:    SourceMarkdown,
+			SourceURL: dir,
+			CreatedAt: now,
+		}
+		events = append(events, event)
+	}
+	if len(seenItems) != len(assignmentsByItem) {
+		missing := make([]string, 0, len(assignmentsByItem)-len(seenItems))
+		for itemID := range assignmentsByItem {
+			if _, ok := seenItems[itemID]; !ok {
+				missing = append(missing, itemID)
+			}
+		}
+		sort.Strings(missing)
+		return nil, fmt.Errorf("feedback.yml missing feedback for item_id %q", missing[0])
+	}
+	for _, event := range events {
+		if err := store.UpsertFeedbackEvent(ctx, event); err != nil {
+			return nil, err
+		}
+	}
+	return events, nil
+}
+
+func (c MarkdownCollector) writeItem(ctx context.Context, store *db.Store, dir string, item db.EvalReviewItem, assignment blindAssignment) error {
+	optionA, err := c.optionText(ctx, store, assignment.A)
+	if err != nil {
+		return fmt.Errorf("item %s option a: %w", item.ItemID, err)
+	}
+	optionB, err := c.optionText(ctx, store, assignment.B)
+	if err != nil {
+		return fmt.Errorf("item %s option b: %w", item.ItemID, err)
+	}
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "# %s\n\n", itemTitle(item))
+	builder.WriteString("## Option A\n\n")
+	writeMarkdownFence(&builder, optionA)
+	builder.WriteString("\n## Option B\n\n")
+	writeMarkdownFence(&builder, optionB)
+	builder.WriteString("\n## Feedback\n\n")
+	builder.WriteString("Fill `feedback.yml` with one of: `a`, `b`, `tie`, `neither`, `skip`.\n")
+	return writeTextFile(filepath.Join(dir, "items", itemFilename(item.ItemID)), builder.String(), 0o644)
+}
+
+func (c MarkdownCollector) optionText(ctx context.Context, store *db.Store, artifactID string) (string, error) {
+	artifactID = strings.TrimSpace(artifactID)
+	if artifactID == "" {
+		return "", nil
+	}
+	record, err := store.GetEvalArtifact(ctx, artifactID)
+	if err != nil {
+		return "", err
+	}
+	content, err := c.BlobStore.Read(record.Hash)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func (c MarkdownCollector) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+func assignmentFor(runID string, item db.EvalReviewItem) blindAssignment {
+	assignment := blindAssignment{
+		ItemID:    item.ItemID,
+		A:         item.BaselineArtifactID,
+		B:         item.CandidateArtifactID,
+		Baseline:  item.BaselineArtifactID,
+		Candidate: item.CandidateArtifactID,
+	}
+	sum := sha256.Sum256([]byte(runID + "\x00" + item.ItemID))
+	if sum[0]%2 == 1 {
+		assignment.A = item.CandidateArtifactID
+		assignment.B = item.BaselineArtifactID
+	}
+	return assignment
+}
+
+func validateAssignmentsAgainstStore(ctx context.Context, store *db.Store, assignments assignmentFile) error {
+	run, err := store.GetEvalRun(ctx, assignments.RunID)
+	if err != nil {
+		return fmt.Errorf("load eval run %s: %w", assignments.RunID, err)
+	}
+	items, err := store.ListEvalReviewItems(ctx, run.ID)
+	if err != nil {
+		return err
+	}
+	itemsByID := make(map[string]db.EvalReviewItem, len(items))
+	for _, item := range items {
+		itemsByID[item.ItemID] = item
+	}
+	if len(itemsByID) != len(assignments.Items) {
+		return fmt.Errorf("packet assignments contain %d items, store has %d review items for run %s", len(assignments.Items), len(itemsByID), run.ID)
+	}
+	for _, assignment := range assignments.Items {
+		itemID := strings.TrimSpace(assignment.ItemID)
+		item, ok := itemsByID[itemID]
+		if !ok {
+			return fmt.Errorf("packet assignment item_id %q is not in eval run %s", itemID, run.ID)
+		}
+		if strings.TrimSpace(assignment.Baseline) != strings.TrimSpace(item.BaselineArtifactID) ||
+			strings.TrimSpace(assignment.Candidate) != strings.TrimSpace(item.CandidateArtifactID) {
+			return fmt.Errorf("packet assignment item_id %q does not match stored baseline/candidate artifacts", itemID)
+		}
+		if strings.TrimSpace(item.BaselineArtifactID) == strings.TrimSpace(item.CandidateArtifactID) {
+			return fmt.Errorf("packet assignment item_id %q stored baseline and candidate artifacts must be distinct", itemID)
+		}
+		optionA, err := canonicalChoiceForArtifact(assignment.A, assignment)
+		if err != nil {
+			return fmt.Errorf("packet assignment item_id %q option a: %w", itemID, err)
+		}
+		optionB, err := canonicalChoiceForArtifact(assignment.B, assignment)
+		if err != nil {
+			return fmt.Errorf("packet assignment item_id %q option b: %w", itemID, err)
+		}
+		if optionA == optionB {
+			return fmt.Errorf("packet assignment item_id %q options a and b must map to different baseline/candidate artifacts", itemID)
+		}
+	}
+	return nil
+}
+
+func deblindChoice(choice string, assignment blindAssignment) (string, error) {
+	switch choice {
+	case ChoiceTie, ChoiceNeither, ChoiceSkip:
+		return choice, nil
+	case ChoiceA:
+		return canonicalChoiceForArtifact(assignment.A, assignment)
+	case ChoiceB:
+		return canonicalChoiceForArtifact(assignment.B, assignment)
+	default:
+		return "", fmt.Errorf("invalid feedback choice %q; use a, b, tie, neither, or skip", choice)
+	}
+}
+
+func canonicalChoiceForArtifact(artifactID string, assignment blindAssignment) (string, error) {
+	artifactID = strings.TrimSpace(artifactID)
+	baseline := strings.TrimSpace(assignment.Baseline)
+	candidate := strings.TrimSpace(assignment.Candidate)
+	if baseline == "" || candidate == "" {
+		return "", errors.New("assignment missing baseline or candidate mapping")
+	}
+	switch artifactID {
+	case baseline:
+		return ChoiceA, nil
+	case candidate:
+		return ChoiceB, nil
+	default:
+		return "", fmt.Errorf("assignment artifact %q is not baseline or candidate", artifactID)
+	}
+}
+
+func indexMarkdown(run db.EvalRun, items []db.EvalReviewItem) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "# Gitmoot Feedback Packet: %s\n\n", run.ID)
+	builder.WriteString("Review each item without trying to infer which option is baseline or candidate.\n\n")
+	builder.WriteString("Allowed choices: `a`, `b`, `tie`, `neither`, `skip`.\n\n")
+	builder.WriteString("## Items\n\n")
+	for _, item := range items {
+		fmt.Fprintf(&builder, "- [%s](items/%s)\n", itemTitle(item), itemFilename(item.ItemID))
+	}
+	builder.WriteString("\n## Submit Feedback\n\n")
+	builder.WriteString("Edit `feedback.yml`, then import it with Gitmoot.\n")
+	return builder.String()
+}
+
+func writeFeedbackYAML(path string, runID string, items []db.EvalReviewItem) error {
+	packet := feedbackFile{RunID: runID, Reviewer: ""}
+	for _, item := range items {
+		packet.Items = append(packet.Items, feedbackFileEntry{
+			ItemID:    item.ItemID,
+			Choice:    "",
+			Reasoning: "",
+		})
+	}
+	content, err := yaml.Marshal(packet)
+	if err != nil {
+		return fmt.Errorf("encode feedback.yml: %w", err)
+	}
+	return writeTextFile(path, string(content), 0o644)
+}
+
+func readFeedbackYAML(path string) (feedbackFile, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return feedbackFile{}, fmt.Errorf("read feedback.yml: %w", err)
+	}
+	var feedback feedbackFile
+	if err := yaml.Unmarshal(content, &feedback); err != nil {
+		return feedbackFile{}, fmt.Errorf("parse feedback.yml: %w", err)
+	}
+	feedback.RunID = strings.TrimSpace(feedback.RunID)
+	if feedback.RunID == "" {
+		return feedbackFile{}, errors.New("feedback.yml missing run_id")
+	}
+	return feedback, nil
+}
+
+func readAssignments(path string) (assignmentFile, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return assignmentFile{}, fmt.Errorf("read assignments: %w", err)
+	}
+	var assignments assignmentFile
+	if err := json.Unmarshal(content, &assignments); err != nil {
+		return assignmentFile{}, fmt.Errorf("parse assignments: %w", err)
+	}
+	assignments.RunID = strings.TrimSpace(assignments.RunID)
+	if assignments.RunID == "" {
+		return assignmentFile{}, errors.New("assignments missing run_id")
+	}
+	return assignments, nil
+}
+
+func writeJSONFile(path string, value any, perm os.FileMode) error {
+	content, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", filepath.Base(path), err)
+	}
+	content = append(content, '\n')
+	return os.WriteFile(path, content, perm)
+}
+
+func writeTextFile(path string, content string, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	return os.WriteFile(path, []byte(content), perm)
+}
+
+func writeMarkdownFence(builder *strings.Builder, content string) {
+	fence := markdownFenceFor(content)
+	builder.WriteString(fence)
+	builder.WriteString("text\n")
+	builder.WriteString(strings.TrimRight(content, "\n"))
+	builder.WriteString("\n")
+	builder.WriteString(fence)
+	builder.WriteString("\n")
+}
+
+func markdownFenceFor(content string) string {
+	maxRun := 0
+	current := 0
+	for _, r := range content {
+		if r == '`' {
+			current++
+			if current > maxRun {
+				maxRun = current
+			}
+			continue
+		}
+		current = 0
+	}
+	if maxRun < 3 {
+		maxRun = 3
+	} else {
+		maxRun++
+	}
+	return strings.Repeat("`", maxRun)
+}
+
+func itemTitle(item db.EvalReviewItem) string {
+	if strings.TrimSpace(item.Title) != "" {
+		return strings.TrimSpace(item.Title)
+	}
+	return item.ItemID
+}
+
+func safeItemFilename(itemID string) string {
+	itemID = strings.TrimSpace(itemID)
+	var builder strings.Builder
+	for _, r := range itemID {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			builder.WriteRune(r)
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			builder.WriteRune(r)
+		default:
+			builder.WriteRune('_')
+		}
+	}
+	value := strings.Trim(builder.String(), "._-")
+	if value == "" {
+		return "item"
+	}
+	return value
+}
+
+func itemFilename(itemID string) string {
+	sum := sha256.Sum256([]byte(itemID))
+	return fmt.Sprintf("%s-%s.md", safeItemFilename(itemID), hex.EncodeToString(sum[:])[:12])
+}

--- a/internal/feedback/markdown_test.go
+++ b/internal/feedback/markdown_test.go
@@ -1,0 +1,343 @@
+package feedback
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestMarkdownCollectorWriteAndImportPacket(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	blobStore := artifact.NewStore(filepath.Join(t.TempDir(), "blobs"))
+	baseline, err := blobStore.Put([]byte("baseline answer\n```go\nfmt.Println(\"baseline\")\n```"))
+	if err != nil {
+		t.Fatalf("Put baseline returned error: %v", err)
+	}
+	candidate, err := blobStore.Put([]byte("candidate answer"))
+	if err != nil {
+		t.Fatalf("Put candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "baseline", Hash: baseline.Hash, MediaType: "text/markdown", SizeBytes: baseline.Size, Driver: "text"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact baseline returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "candidate", Hash: candidate.Hash, MediaType: "text/markdown", SizeBytes: candidate.Size, Driver: "text"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{ID: "run-1", State: "review"}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:               "run-1",
+		ItemID:              "item-001",
+		Title:               "Item One",
+		BaselineArtifactID:  "baseline",
+		CandidateArtifactID: "candidate",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:               "run-1",
+		ItemID:              "x",
+		Title:               "Swapped Item",
+		BaselineArtifactID:  "baseline",
+		CandidateArtifactID: "candidate",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem swapped returned error: %v", err)
+	}
+	packetDir := filepath.Join(t.TempDir(), "packet")
+	collector := MarkdownCollector{
+		BlobStore: blobStore,
+		Now: func() time.Time {
+			return time.Date(2026, 5, 31, 10, 0, 0, 0, time.UTC)
+		},
+	}
+	if err := collector.WritePacket(ctx, store, "run-1", packetDir); err != nil {
+		t.Fatalf("WritePacket returned error: %v", err)
+	}
+	index, err := os.ReadFile(filepath.Join(packetDir, "index.md"))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	if !strings.Contains(string(index), "Allowed choices") {
+		t.Fatalf("index content misses instructions:\n%s", string(index))
+	}
+	itemContent, err := os.ReadFile(filepath.Join(packetDir, "items", itemFilename("item-001")))
+	if err != nil {
+		t.Fatalf("read item: %v", err)
+	}
+	if !strings.Contains(string(itemContent), "Option A") || !strings.Contains(string(itemContent), "Option B") {
+		t.Fatalf("item content missing options:\n%s", string(itemContent))
+	}
+	if !strings.Contains(string(itemContent), "````text") || !strings.Contains(string(itemContent), "```go") {
+		t.Fatalf("item content does not preserve nested Markdown fences:\n%s", string(itemContent))
+	}
+	assignments, err := os.ReadFile(filepath.Join(packetDir, assignmentsName))
+	if err != nil {
+		t.Fatalf("read assignments: %v", err)
+	}
+	if !strings.Contains(string(assignments), `"baseline"`) || !strings.Contains(string(assignments), `"candidate"`) {
+		t.Fatalf("assignments do not preserve mapping:\n%s", string(assignments))
+	}
+	feedbackContent := `run_id: run-1
+reviewer: jerry
+items:
+    - item_id: item-001
+      choice: b
+      reasoning: More concrete.
+    - item_id: x
+      choice: a
+`
+	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackContent), 0o644); err != nil {
+		t.Fatalf("write feedback.yml: %v", err)
+	}
+	events, err := collector.ImportPacket(ctx, store, packetDir+string(os.PathSeparator)+".", "")
+	if err != nil {
+		t.Fatalf("ImportPacket returned error: %v", err)
+	}
+	if len(events) != 2 || events[0].Choice != "b" || events[1].Choice != "b" || events[0].CreatedAt != "2026-05-31T10:00:00Z" {
+		t.Fatalf("events = %+v", events)
+	}
+	stored, err := store.ListFeedbackEvents(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("ListFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 2 || stored[0].Reasoning != "More concrete." || stored[1].Reasoning != "" || stored[0].Source != SourceMarkdown {
+		t.Fatalf("stored events = %+v", stored)
+	}
+	if _, err := collector.ImportPacket(ctx, store, packetDir, ""); err != nil {
+		t.Fatalf("second ImportPacket returned error: %v", err)
+	}
+	stored, err = store.ListFeedbackEvents(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("second ListFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 2 {
+		t.Fatalf("second import duplicated feedback events: %+v", stored)
+	}
+}
+
+func TestMarkdownCollectorRejectsInvalidFeedback(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{ID: "run-1", State: "review"}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	for _, itemID := range []string{"item-001", "item-002"} {
+		if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+			RunID:               "run-1",
+			ItemID:              itemID,
+			BaselineArtifactID:  "baseline",
+			CandidateArtifactID: "candidate",
+		}); err != nil {
+			t.Fatalf("UpsertEvalReviewItem %s returned error: %v", itemID, err)
+		}
+	}
+	packetDir := t.TempDir()
+	assignments := `{"run_id":"run-1","items":[{"item_id":"item-001","a":"baseline","b":"candidate","baseline":"baseline","candidate":"candidate"},{"item_id":"item-002","a":"baseline","b":"candidate","baseline":"baseline","candidate":"candidate"}]}`
+	if err := os.WriteFile(filepath.Join(packetDir, assignmentsName), []byte(assignments), 0o600); err != nil {
+		t.Fatalf("write assignments: %v", err)
+	}
+	tests := map[string]string{
+		"unknown item":   "run_id: run-1\nreviewer: jerry\nitems:\n  - item_id: item-001\n    choice: a\n  - item_id: item-404\n    choice: a\n",
+		"bad choice":     "run_id: run-1\nreviewer: jerry\nitems:\n  - item_id: item-001\n    choice: yes\n",
+		"missing item":   "run_id: run-1\nreviewer: jerry\nitems:\n  - item_id: item-001\n    choice: a\n",
+		"duplicate item": "run_id: run-1\nreviewer: jerry\nitems:\n  - item_id: item-001\n    choice: a\n  - item_id: item-001\n    choice: b\n",
+	}
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(content), 0o644); err != nil {
+				t.Fatalf("write feedback.yml: %v", err)
+			}
+			_, err := (MarkdownCollector{}).ImportPacket(ctx, store, packetDir, "")
+			if err == nil {
+				t.Fatal("ImportPacket returned nil error")
+			}
+			events, err := store.ListFeedbackEvents(ctx, "run-1")
+			if err != nil {
+				t.Fatalf("ListFeedbackEvents returned error: %v", err)
+			}
+			if len(events) != 0 {
+				t.Fatalf("ImportPacket persisted partial events after validation error: %+v", events)
+			}
+		})
+	}
+
+	t.Run("corrupt assignment permutation", func(t *testing.T) {
+		corruptAssignments := `{"run_id":"run-1","items":[{"item_id":"item-001","a":"baseline","b":"baseline","baseline":"baseline","candidate":"candidate"},{"item_id":"item-002","a":"baseline","b":"candidate","baseline":"baseline","candidate":"candidate"}]}`
+		if err := os.WriteFile(filepath.Join(packetDir, assignmentsName), []byte(corruptAssignments), 0o600); err != nil {
+			t.Fatalf("write assignments: %v", err)
+		}
+		content := "run_id: run-1\nreviewer: jerry\nitems:\n  - item_id: item-001\n    choice: a\n  - item_id: item-002\n    choice: b\n"
+		if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(content), 0o644); err != nil {
+			t.Fatalf("write feedback.yml: %v", err)
+		}
+		_, err := (MarkdownCollector{}).ImportPacket(ctx, store, packetDir, "")
+		if err == nil || !strings.Contains(err.Error(), "options a and b must map to different") {
+			t.Fatalf("ImportPacket error = %v", err)
+		}
+		events, err := store.ListFeedbackEvents(ctx, "run-1")
+		if err != nil {
+			t.Fatalf("ListFeedbackEvents returned error: %v", err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("ImportPacket persisted partial events after corrupt assignment: %+v", events)
+		}
+	})
+}
+
+func TestMarkdownCollectorRejectsIncompleteABItems(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{ID: "run-1", State: "review"}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:              "run-1",
+		ItemID:             "item-001",
+		BaselineArtifactID: "baseline",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	err = (MarkdownCollector{}).WritePacket(ctx, store, "run-1", filepath.Join(t.TempDir(), "packet"))
+	if err == nil || !strings.Contains(err.Error(), "requires both baseline and candidate artifacts") {
+		t.Fatalf("WritePacket error = %v", err)
+	}
+}
+
+func TestMarkdownCollectorRejectsIdenticalABItems(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{ID: "run-1", State: "review"}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:               "run-1",
+		ItemID:              "item-001",
+		BaselineArtifactID:  "same",
+		CandidateArtifactID: "same",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	err = (MarkdownCollector{}).WritePacket(ctx, store, "run-1", filepath.Join(t.TempDir(), "packet"))
+	if err == nil || !strings.Contains(err.Error(), "requires distinct baseline and candidate artifacts") {
+		t.Fatalf("WritePacket error = %v", err)
+	}
+
+	packetDir := t.TempDir()
+	assignments := `{"run_id":"run-1","items":[{"item_id":"item-001","a":"same","b":"same","baseline":"same","candidate":"same"}]}`
+	if err := os.WriteFile(filepath.Join(packetDir, assignmentsName), []byte(assignments), 0o600); err != nil {
+		t.Fatalf("write assignments: %v", err)
+	}
+	feedbackYAML := "run_id: run-1\nreviewer: jerry\nitems:\n  - item_id: item-001\n    choice: tie\n"
+	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackYAML), 0o644); err != nil {
+		t.Fatalf("write feedback.yml: %v", err)
+	}
+	_, err = (MarkdownCollector{}).ImportPacket(ctx, store, packetDir, "")
+	if err == nil || !strings.Contains(err.Error(), "stored baseline and candidate artifacts must be distinct") {
+		t.Fatalf("ImportPacket error = %v", err)
+	}
+}
+
+func TestMarkdownCollectorRejectsPacketWithoutStoredRun(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	packetDir := t.TempDir()
+	assignments := `{"run_id":"run-1","items":[{"item_id":"item-001","a":"baseline","b":"candidate","baseline":"baseline","candidate":"candidate"}]}`
+	if err := os.WriteFile(filepath.Join(packetDir, assignmentsName), []byte(assignments), 0o600); err != nil {
+		t.Fatalf("write assignments: %v", err)
+	}
+	feedbackYAML := "run_id: run-1\nreviewer: jerry\nitems:\n  - item_id: item-001\n    choice: a\n"
+	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackYAML), 0o644); err != nil {
+		t.Fatalf("write feedback.yml: %v", err)
+	}
+	_, err = (MarkdownCollector{}).ImportPacket(ctx, store, packetDir, "")
+	if err == nil || !strings.Contains(err.Error(), "load eval run run-1") {
+		t.Fatalf("ImportPacket error = %v", err)
+	}
+}
+
+func TestMarkdownCollectorUsesCollisionSafeItemFilenames(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	blobStore := artifact.NewStore(filepath.Join(t.TempDir(), "blobs"))
+	baseline, err := blobStore.Put([]byte("baseline answer"))
+	if err != nil {
+		t.Fatalf("Put baseline returned error: %v", err)
+	}
+	candidate, err := blobStore.Put([]byte("candidate answer"))
+	if err != nil {
+		t.Fatalf("Put candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "baseline", Hash: baseline.Hash, MediaType: "text/markdown", SizeBytes: baseline.Size, Driver: "text"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact baseline returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "candidate", Hash: candidate.Hash, MediaType: "text/markdown", SizeBytes: candidate.Size, Driver: "text"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{ID: "run-1", State: "review"}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	for _, itemID := range []string{"foo/bar", "foo:bar"} {
+		if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+			RunID:               "run-1",
+			ItemID:              itemID,
+			BaselineArtifactID:  "baseline",
+			CandidateArtifactID: "candidate",
+		}); err != nil {
+			t.Fatalf("UpsertEvalReviewItem %s returned error: %v", itemID, err)
+		}
+	}
+	packetDir := filepath.Join(t.TempDir(), "packet")
+	collector := MarkdownCollector{BlobStore: blobStore}
+	if err := collector.WritePacket(ctx, store, "run-1", packetDir); err != nil {
+		t.Fatalf("WritePacket returned error: %v", err)
+	}
+	first := itemFilename("foo/bar")
+	second := itemFilename("foo:bar")
+	if first == second {
+		t.Fatalf("item filenames collide: %s", first)
+	}
+	for _, name := range []string{first, second} {
+		if _, err := os.Stat(filepath.Join(packetDir, "items", name)); err != nil {
+			t.Fatalf("expected item file %s: %v", name, err)
+		}
+	}
+	index, err := os.ReadFile(filepath.Join(packetDir, "index.md"))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	if !strings.Contains(string(index), "items/"+first) || !strings.Contains(string(index), "items/"+second) {
+		t.Fatalf("index does not link distinct item files:\n%s", string(index))
+	}
+}

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -149,6 +149,10 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 	if err != nil {
 		return TrainingPackage{}, err
 	}
+	feedbackEvents, err := loadFeedbackEvents(ctx, store, run.ID)
+	if err != nil {
+		return TrainingPackage{}, err
+	}
 	metadata, err := rawJSON(run.MetadataJSON)
 	if err != nil {
 		return TrainingPackage{}, fmt.Errorf("eval run metadata_json: %w", err)
@@ -167,7 +171,7 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 		},
 		Items:           exportItems,
 		Artifacts:       artifacts,
-		FeedbackEvents:  []FeedbackEvent{},
+		FeedbackEvents:  feedbackEvents,
 		EvaluatorConfig: metadata,
 	}, nil
 }
@@ -321,6 +325,27 @@ func loadArtifactRefs(ctx context.Context, store *db.Store, ids map[string]struc
 		})
 	}
 	return refs, nil
+}
+
+func loadFeedbackEvents(ctx context.Context, store *db.Store, runID string) ([]FeedbackEvent, error) {
+	events, err := store.ListFeedbackEvents(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	output := make([]FeedbackEvent, 0, len(events))
+	for _, event := range events {
+		output = append(output, FeedbackEvent{
+			RunID:     event.RunID,
+			ItemID:    event.ItemID,
+			Choice:    event.Choice,
+			Reasoning: event.Reasoning,
+			Reviewer:  event.Reviewer,
+			Source:    event.Source,
+			SourceURL: event.SourceURL,
+			CreatedAt: event.CreatedAt,
+		})
+	}
+	return output, nil
 }
 
 func rawJSON(value string) (json.RawMessage, error) {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -55,6 +55,17 @@ func TestExportTrainingPackage(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
 	}
+	if err := store.UpsertFeedbackEvent(ctx, db.FeedbackEvent{
+		RunID:     "run-1",
+		ItemID:    "item-001",
+		Choice:    "b",
+		Reasoning: "More specific.",
+		Reviewer:  "jerry",
+		Source:    "markdown",
+		CreatedAt: "2026-05-31T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertFeedbackEvent returned error: %v", err)
+	}
 
 	pkg, err := ExportTrainingPackage(ctx, store, "run-1")
 	if err != nil {
@@ -75,6 +86,9 @@ func TestExportTrainingPackage(t *testing.T) {
 	}
 	if string(pkg.EvaluatorConfig) != `{"driver":"planner"}` {
 		t.Fatalf("evaluator config = %s", string(pkg.EvaluatorConfig))
+	}
+	if len(pkg.FeedbackEvents) != 1 || pkg.FeedbackEvents[0].Choice != "b" {
+		t.Fatalf("feedback events = %+v", pkg.FeedbackEvents)
 	}
 	if _, err := json.Marshal(pkg); err != nil {
 		t.Fatalf("exported package did not marshal: %v", err)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -258,10 +258,15 @@ gitmoot lock show owner/repo <branch>
 ```sh
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
+gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 ```
 
 `skillopt export` writes a JSON training package with the template snapshot,
 eval run, review items, artifact manifests, feedback events when present, and
 evaluator config. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate
-automatically.
+automatically. The Markdown feedback collector writes blind A/B review packets
+with `index.md`, per-item Markdown files, editable `feedback.yml`, and hidden
+assignment metadata that Gitmoot uses to validate the full response and import
+de-blinded canonical feedback events.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -62,4 +62,6 @@ gitmoot lock list --repo owner/repo
 ```sh
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
+gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 ```

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -27,3 +27,35 @@ The candidate package contains full agent-template Markdown with YAML
 frontmatter, matching metadata, an optional eval report, and an optional summary.
 Importing stores the candidate as a pending template version and never promotes
 it automatically.
+
+## Markdown Feedback Packet
+
+```sh
+gitmoot skillopt feedback markdown export \
+  --run run-2026-05-31 \
+  --output .gitmoot/evals/run-2026-05-31
+```
+
+The packet contains `index.md`, one Markdown file per item, editable
+`feedback.yml`, and hidden `.assignments.json` metadata that lets Gitmoot recover
+the blind A/B mapping.
+
+Humans fill `feedback.yml` with `a`, `b`, `tie`, `neither`, or `skip`:
+
+```yaml
+run_id: run-2026-05-31
+reviewer: alice
+items:
+  - item_id: item-001
+    choice: b
+    reasoning: More concrete and easier to execute.
+```
+
+```sh
+gitmoot skillopt feedback markdown import \
+  --packet .gitmoot/evals/run-2026-05-31
+```
+
+Gitmoot validates the complete file before writing events. It uses the hidden
+assignment metadata to de-blind `a` and `b`, so exported feedback events use
+`a` for baseline and `b` for candidate.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -285,6 +285,8 @@ gitmoot lock release owner/repo <branch> --owner <agent>
 ```sh
 gitmoot skillopt export --run <run-id> --output training.json
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
+gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
 ```
 
 The export/import boundary lets a future external `gitmoot-skillopt` optimizer
@@ -469,6 +471,8 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
+gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
 ```
 
 Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`
@@ -2842,13 +2846,18 @@ gitmoot lock show owner/repo <branch>
 ```sh
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
+gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 ```
 
 `skillopt export` writes a JSON training package with the template snapshot,
 eval run, review items, artifact manifests, feedback events when present, and
 evaluator config. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate
-automatically.
+automatically. The Markdown feedback collector writes blind A/B review packets
+with `index.md`, per-item Markdown files, editable `feedback.yml`, and hidden
+assignment metadata that Gitmoot uses to validate the full response and import
+de-blinded canonical feedback events.
 
 ---
 


### PR DESCRIPTION
WHAT:
- Added canonical SkillOpt feedback events and a local Markdown feedback collector.

WHY:
- Gitmoot needs a first human-in-the-loop feedback collector for blind A/B SkillOpt review packets before adding GitHub issue/comment collectors and promotion workflows.

CHANGES:
- Added `feedback_events` storage with stable upsert/list helpers.
- Added `internal/feedback` with allowed choices, blind A/B assignment metadata, Markdown packet export, full-file validation, de-blinding, and import into canonical feedback events.
- Added `gitmoot skillopt feedback markdown export/import` CLI commands.
- Included feedback events in SkillOpt training package export.
- Updated README, SKILL.md, skill CLI reference, docs site reference, and regenerated `llms-full.txt`.

RESULTS:
- `/root/temp/ts/tool/go fmt ./internal/feedback ./internal/db ./internal/skillopt ./internal/cli`
- `/root/temp/ts/tool/go test ./internal/feedback ./internal/db ./internal/skillopt ./internal/cli`
- `/root/temp/ts/tool/go test ./...`
- `npm run build` in `website`
- `git diff --check`
- `git diff --cached --check`
- `codex exec review --uncommitted` final raw output:

```text
I did not identify any discrete correctness issues in the current staged, unstaged, or untracked changes. Tests could not be run because the required Go toolchain download is blocked in this environment.
I did not identify any discrete correctness issues in the current staged, unstaged, or untracked changes. Tests could not be run because the required Go toolchain download is blocked in this environment.
```

RISK:
- The review sandbox could not run tests because its Go runtime is 1.22.2 while this repo requires Go 1.26. The required tests passed outside that sandbox with `/root/temp/ts/tool/go`.
