### PR TITLE
Add GitHub feedback collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,11 +277,21 @@ gitmoot skillopt export --run <run-id> --output training.json
 gitmoot skillopt import --file candidate.json
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
+gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
+gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
 The export/import boundary lets a future external `gitmoot-skillopt` optimizer
 train on local eval artifacts and return candidate template versions. Imported
 candidates stay pending until a human review workflow promotes them.
+
+Use the GitHub feedback collector when review should happen in an issue or an
+existing PR thread. Reviewers can reply with either the copy-paste YAML block or
+run-scoped short lines such as `run_id: run-1` followed by
+`item-001: b - More concrete.`. Gitmoot imports matching comments into
+canonical feedback events and ignores unrelated comments. Repo selection uses
+`--repo`, then the eval run target repo, then the template source repo, then
+optional `[feedback].repo = "owner/reviews"` in Gitmoot config.
 
 Detailed command coverage lives in
 [skills/gitmoot/references/CLI.md](skills/gitmoot/references/CLI.md).

--- a/SKILL.md
+++ b/SKILL.md
@@ -117,6 +117,8 @@ gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
+gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
+gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
 Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -98,3 +98,46 @@ uses `.assignments.json` to de-blind `a` and `b` so stored canonical feedback
 events use `choice: a` for the baseline artifact and `choice: b` for the
 candidate artifact. Each event includes `run_id`, `item_id`, `choice`, optional
 `reasoning`, `reviewer`, `source`, optional `source_url`, and `created_at`.
+
+## GitHub Feedback Collector
+
+Publish a collaborative blind A/B review packet to a new GitHub issue:
+
+```sh
+gitmoot skillopt feedback github publish \
+  --run run-2026-05-31 \
+  --repo owner/reviews
+```
+
+To publish the packet as a comment on an existing PR instead:
+
+```sh
+gitmoot skillopt feedback github publish \
+  --run run-2026-05-31 \
+  --repo owner/repo \
+  --pr 123
+```
+
+If `--repo` is omitted, Gitmoot resolves the target in this order: eval run
+target repo, template source repo, configured `[feedback].repo`, then an error
+asking for `--repo`.
+
+Reviewers can reply with the issue body's YAML block or with short-form lines:
+
+```text
+run_id: run-2026-05-31
+item-001: b - More concrete and easier to execute.
+item-002: tie
+```
+
+Sync comments back into canonical feedback events:
+
+```sh
+gitmoot skillopt feedback github sync \
+  --run run-2026-05-31 \
+  --repo owner/reviews \
+  --issue 42
+```
+
+For PR comment mode, use `--pr 123` instead of `--issue 42`. Sync ignores
+unrelated comments and de-duplicates repeated imports by comment URL.

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -13,10 +14,16 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/feedback"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
 )
+
+var newSkillOptGitHubClient = func() github.Client {
+	return github.NewClient("")
+}
 
 func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
@@ -43,6 +50,8 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt import --file candidate.json")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
+	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")
+	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
 }
 
 func runSkillOptExport(args []string, stdout, stderr io.Writer) int {
@@ -156,23 +165,35 @@ func runSkillOptFeedback(args []string, stdout, stderr io.Writer) int {
 		printSkillOptUsage(stdout)
 		return 0
 	}
-	if args[0] != "markdown" {
+	if args[0] != "markdown" && args[0] != "github" {
 		fmt.Fprintf(stderr, "unknown skillopt feedback collector %q\n\n", args[0])
 		printSkillOptUsage(stderr)
 		return 2
 	}
 	if len(args) < 2 {
-		fmt.Fprintln(stderr, "skillopt feedback markdown requires export or import")
+		fmt.Fprintf(stderr, "skillopt feedback %s requires a subcommand\n", args[0])
 		printSkillOptUsage(stderr)
 		return 2
 	}
+	if args[0] == "markdown" {
+		switch args[1] {
+		case "export":
+			return runSkillOptFeedbackMarkdownExport(args[2:], stdout, stderr)
+		case "import":
+			return runSkillOptFeedbackMarkdownImport(args[2:], stdout, stderr)
+		default:
+			fmt.Fprintf(stderr, "unknown skillopt feedback markdown command %q\n\n", args[1])
+			printSkillOptUsage(stderr)
+			return 2
+		}
+	}
 	switch args[1] {
-	case "export":
-		return runSkillOptFeedbackMarkdownExport(args[2:], stdout, stderr)
-	case "import":
-		return runSkillOptFeedbackMarkdownImport(args[2:], stdout, stderr)
+	case "publish":
+		return runSkillOptFeedbackGitHubPublish(args[2:], stdout, stderr)
+	case "sync":
+		return runSkillOptFeedbackGitHubSync(args[2:], stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "unknown skillopt feedback markdown command %q\n\n", args[1])
+		fmt.Fprintf(stderr, "unknown skillopt feedback github command %q\n\n", args[1])
 		printSkillOptUsage(stderr)
 		return 2
 	}
@@ -244,6 +265,149 @@ func runSkillOptFeedbackMarkdownImport(args []string, stdout, stderr io.Writer) 
 	}
 	writeLine(stdout, "imported %d feedback events", count)
 	return 0
+}
+
+func runSkillOptFeedbackGitHubPublish(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt feedback github publish", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	runID := fs.String("run", "", "eval run id")
+	repoFlag := fs.String("repo", "", "GitHub repository owner/repo")
+	pullRequest := fs.Int64("pr", 0, "existing pull request number to comment on instead of creating an issue")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt feedback github publish does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*runID) == "" {
+		fmt.Fprintln(stderr, "skillopt feedback github publish requires --run")
+		return 2
+	}
+	var result feedback.GitHubPublishResult
+	if err := withSkillOptStore(*home, func(paths config.Paths, store *db.Store) error {
+		run, err := store.GetEvalRun(context.Background(), strings.TrimSpace(*runID))
+		if err != nil {
+			return err
+		}
+		repo, err := resolveSkillOptFeedbackRepo(context.Background(), paths, store, run, *repoFlag)
+		if err != nil {
+			return err
+		}
+		collector := feedback.GitHubCollector{
+			BlobStore: artifact.NewStore(paths.ArtifactBlobs),
+			GitHub:    newSkillOptGitHubClient(),
+		}
+		result, err = collector.Publish(context.Background(), store, run.ID, feedback.GitHubPublishTarget{
+			Repo:        repo,
+			PullRequest: *pullRequest,
+		})
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt feedback github publish: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "published github feedback %s for %s to %s#%d: %s", result.Mode, strings.TrimSpace(*runID), result.Repo.FullName(), result.IssueNumber, result.URL)
+	return 0
+}
+
+func runSkillOptFeedbackGitHubSync(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt feedback github sync", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	runID := fs.String("run", "", "eval run id")
+	repoFlag := fs.String("repo", "", "GitHub repository owner/repo")
+	issueNumber := fs.Int64("issue", 0, "GitHub issue number containing feedback comments")
+	pullRequest := fs.Int64("pr", 0, "GitHub pull request number containing feedback comments")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt feedback github sync does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*runID) == "" {
+		fmt.Fprintln(stderr, "skillopt feedback github sync requires --run")
+		return 2
+	}
+	if *issueNumber > 0 && *pullRequest > 0 {
+		fmt.Fprintln(stderr, "skillopt feedback github sync accepts only one of --issue or --pr")
+		return 2
+	}
+	targetNumber := *issueNumber
+	if targetNumber == 0 {
+		targetNumber = *pullRequest
+	}
+	if targetNumber <= 0 {
+		fmt.Fprintln(stderr, "skillopt feedback github sync requires --issue or --pr")
+		return 2
+	}
+	var count int
+	if err := withSkillOptStore(*home, func(paths config.Paths, store *db.Store) error {
+		run, err := store.GetEvalRun(context.Background(), strings.TrimSpace(*runID))
+		if err != nil {
+			return err
+		}
+		repo, err := resolveSkillOptFeedbackRepo(context.Background(), paths, store, run, *repoFlag)
+		if err != nil {
+			return err
+		}
+		collector := feedback.GitHubCollector{
+			BlobStore: artifact.NewStore(paths.ArtifactBlobs),
+			GitHub:    newSkillOptGitHubClient(),
+		}
+		events, err := collector.Sync(context.Background(), store, run.ID, repo, targetNumber)
+		if err != nil {
+			return err
+		}
+		count = len(events)
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt feedback github sync: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "imported %d github feedback events", count)
+	return 0
+}
+
+func resolveSkillOptFeedbackRepo(ctx context.Context, paths config.Paths, store *db.Store, run db.EvalRun, repoFlag string) (github.Repository, error) {
+	if strings.TrimSpace(repoFlag) != "" {
+		return daemon.ParseRepository(repoFlag)
+	}
+	if strings.TrimSpace(run.TargetRepo) != "" {
+		if repo, err := daemon.ParseRepository(run.TargetRepo); err == nil {
+			return repo, nil
+		}
+	}
+	templateRef := strings.TrimSpace(run.TemplateVersionID)
+	if templateRef == "" {
+		templateRef = strings.TrimSpace(run.TemplateID)
+	}
+	if templateRef != "" {
+		template, err := store.GetAgentTemplateReference(ctx, templateRef)
+		if err == nil && strings.TrimSpace(template.SourceRepo) != "" {
+			if repo, err := daemon.ParseRepository(template.SourceRepo); err == nil {
+				return repo, nil
+			}
+		} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return github.Repository{}, err
+		}
+	}
+	defaultRepo, err := config.LoadDefaultFeedbackRepo(paths)
+	if err != nil {
+		return github.Repository{}, err
+	}
+	if strings.TrimSpace(defaultRepo) != "" {
+		return daemon.ParseRepository(defaultRepo)
+	}
+	return github.Repository{}, errors.New("skillopt feedback github requires --repo because no target repo, template source repo, or [feedback].repo default is configured")
 }
 
 func withSkillOptStore(home string, fn func(config.Paths, *db.Store) error) error {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
 )
 
@@ -203,7 +204,7 @@ func TestSkillOptFeedbackRejectsIncompleteCommands(t *testing.T) {
 		{
 			name:         "feedback help",
 			args:         []string{"skillopt", "feedback", "--help"},
-			wantStdout:   "gitmoot skillopt feedback markdown export",
+			wantStdout:   "gitmoot skillopt feedback github publish",
 			wantExitCode: 0,
 			wantNoStderr: true,
 		},
@@ -217,7 +218,21 @@ func TestSkillOptFeedbackRejectsIncompleteCommands(t *testing.T) {
 		{
 			name:         "missing markdown subcommand",
 			args:         []string{"skillopt", "feedback", "markdown"},
-			wantErr:      "skillopt feedback markdown requires export or import",
+			wantErr:      "skillopt feedback markdown requires a subcommand",
+			wantExitCode: 2,
+			wantNoStdout: true,
+		},
+		{
+			name:         "missing github subcommand",
+			args:         []string{"skillopt", "feedback", "github"},
+			wantErr:      "skillopt feedback github requires a subcommand",
+			wantExitCode: 2,
+			wantNoStdout: true,
+		},
+		{
+			name:         "missing github sync target",
+			args:         []string{"skillopt", "feedback", "github", "sync", "--run", "run-1"},
+			wantErr:      "skillopt feedback github sync requires --issue or --pr",
 			wantExitCode: 2,
 			wantNoStdout: true,
 		},
@@ -243,6 +258,110 @@ func TestSkillOptFeedbackRejectsIncompleteCommands(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSkillOptFeedbackGitHubCommands(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	baselineBlob, err := blobStore.Put([]byte("baseline"))
+	if err != nil {
+		t.Fatalf("Put baseline returned error: %v", err)
+	}
+	candidateBlob, err := blobStore.Put([]byte("candidate"))
+	if err != nil {
+		t.Fatalf("Put candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{ID: "baseline", Hash: baselineBlob.Hash, MediaType: "text/markdown", SizeBytes: baselineBlob.Size, Driver: "text"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact baseline returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{ID: "candidate", Hash: candidateBlob.Hash, MediaType: "text/markdown", SizeBytes: candidateBlob.Size, Driver: "text"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{ID: "run-1", TargetRepo: "owner/repo", State: "review"}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:               "run-1",
+		ItemID:              "item-001",
+		BaselineArtifactID:  "baseline",
+		CandidateArtifactID: "candidate",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	fake := &skillOptFakeGitHub{
+		comments: map[int64][]github.IssueComment{
+			8: {
+				{ID: 100, Body: "run_id: run-1\nitem-001: b - More concrete.", URL: "https://github.com/owner/repo/issues/8#issuecomment-100", Author: "alice", CreatedAt: "2026-05-31T10:00:00Z"},
+			},
+		},
+	}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fake }
+	t.Cleanup(func() {
+		newSkillOptGitHubClient = oldClient
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "feedback", "github", "publish", "--home", home, "--run", "run-1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("github publish exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "published github feedback issue for run-1 to owner/repo#8") {
+		t.Fatalf("publish stdout = %q", stdout.String())
+	}
+	if fake.createdIssue.Repo.FullName() != "owner/repo" || !strings.Contains(fake.createdIssue.Body, "Copy-Paste YAML Reply") {
+		t.Fatalf("created issue = %+v", fake.createdIssue)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "feedback", "github", "sync", "--home", home, "--run", "run-1", "--issue", "8"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("github sync exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "imported 1 github feedback events") {
+		t.Fatalf("sync stdout = %q", stdout.String())
+	}
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open after sync returned error: %v", err)
+	}
+	defer store.Close()
+	events, err := store.ListFeedbackEvents(context.Background(), "run-1")
+	if err != nil {
+		t.Fatalf("ListFeedbackEvents returned error: %v", err)
+	}
+	if len(events) != 1 || events[0].Reviewer != "alice" || events[0].Source != "github" {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+type skillOptFakeGitHub struct {
+	github.NoopClient
+
+	createdIssue github.CreateIssueInput
+	comments     map[int64][]github.IssueComment
+}
+
+func (f *skillOptFakeGitHub) CreateIssue(_ context.Context, input github.CreateIssueInput) (github.Issue, error) {
+	f.createdIssue = input
+	return github.Issue{Number: 8, URL: "https://github.com/" + input.Repo.FullName() + "/issues/8"}, nil
+}
+
+func (f *skillOptFakeGitHub) ListIssueComments(_ context.Context, _ github.Repository, issueNumber int64) ([]github.IssueComment, error) {
+	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
 }
 
 func cliSkillOptTemplate(id string, body string) db.AgentTemplate {

--- a/internal/config/agent_types_test.go
+++ b/internal/config/agent_types_test.go
@@ -82,3 +82,25 @@ runtime = "codex"
 		t.Fatalf("SaveAgentType wrote template from retired alias:\n%s", string(content))
 	}
 }
+
+func TestLoadDefaultFeedbackRepo(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[feedback]
+repo = "owner/reviews"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	repo, err := LoadDefaultFeedbackRepo(paths)
+
+	if err != nil {
+		t.Fatalf("LoadDefaultFeedbackRepo returned error: %v", err)
+	}
+	if repo != "owner/reviews" {
+		t.Fatalf("repo = %q, want owner/reviews", repo)
+	}
+}

--- a/internal/config/feedback.go
+++ b/internal/config/feedback.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+func LoadDefaultFeedbackRepo(paths Paths) (string, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return "", err
+	}
+	current := ""
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			continue
+		}
+		if current != "feedback" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "repo" {
+			continue
+		}
+		parsed, err := parseConfigString(strings.TrimSpace(value))
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(parsed), nil
+	}
+	return "", nil
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1764,6 +1764,10 @@ func (f *fakeGitHub) CreatePullRequest(context.Context, github.CreatePullRequest
 	return github.PullRequest{}, errors.New("not implemented")
 }
 
+func (f *fakeGitHub) CreateIssue(context.Context, github.CreateIssueInput) (github.Issue, error) {
+	return github.Issue{}, errors.New("not implemented")
+}
+
 func (f *fakeGitHub) ListIssueComments(_ context.Context, _ github.Repository, issueNumber int64) ([]github.IssueComment, error) {
 	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
 }

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -14,6 +14,7 @@ const (
 	ChoiceSkip    = "skip"
 
 	SourceMarkdown = "markdown"
+	SourceGitHub   = "github"
 )
 
 var validChoices = map[string]struct{}{

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -1,0 +1,418 @@
+package feedback
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"gopkg.in/yaml.v3"
+)
+
+type GitHubCollector struct {
+	BlobStore artifact.Store
+	GitHub    github.Client
+	Now       func() time.Time
+}
+
+type GitHubPublishTarget struct {
+	Repo        github.Repository
+	PullRequest int64
+}
+
+type GitHubPublishResult struct {
+	Repo        github.Repository
+	IssueNumber int64
+	URL         string
+	Mode        string
+}
+
+const githubFeedbackPacketMarker = "<!-- gitmoot:skillopt-feedback-packet -->"
+
+func (c GitHubCollector) Publish(ctx context.Context, store *db.Store, runID string, target GitHubPublishTarget) (GitHubPublishResult, error) {
+	if c.GitHub == nil {
+		return GitHubPublishResult{}, errors.New("github client is required")
+	}
+	if target.Repo.FullName() == "" {
+		return GitHubPublishResult{}, errors.New("github feedback repo is required")
+	}
+	body, err := c.Body(ctx, store, runID)
+	if err != nil {
+		return GitHubPublishResult{}, err
+	}
+	if target.PullRequest > 0 {
+		comment, err := c.GitHub.PostIssueComment(ctx, target.Repo, target.PullRequest, body)
+		if err != nil {
+			return GitHubPublishResult{}, err
+		}
+		return GitHubPublishResult{Repo: target.Repo, IssueNumber: target.PullRequest, URL: comment.URL, Mode: "pr-comment"}, nil
+	}
+	issue, err := c.GitHub.CreateIssue(ctx, github.CreateIssueInput{
+		Repo:  target.Repo,
+		Title: fmt.Sprintf("Gitmoot SkillOpt feedback: %s", strings.TrimSpace(runID)),
+		Body:  body,
+	})
+	if err != nil {
+		return GitHubPublishResult{}, err
+	}
+	return GitHubPublishResult{Repo: target.Repo, IssueNumber: issue.Number, URL: issue.URL, Mode: "issue"}, nil
+}
+
+func (c GitHubCollector) Body(ctx context.Context, store *db.Store, runID string) (string, error) {
+	if store == nil {
+		return "", errors.New("store is required")
+	}
+	run, err := store.GetEvalRun(ctx, strings.TrimSpace(runID))
+	if err != nil {
+		return "", err
+	}
+	items, assignments, err := c.reviewItemsAndAssignments(ctx, store, run.ID)
+	if err != nil {
+		return "", err
+	}
+	var builder strings.Builder
+	builder.WriteString(githubFeedbackPacketMarker + "\n")
+	fmt.Fprintf(&builder, "# Gitmoot SkillOpt Feedback: %s\n\n", run.ID)
+	builder.WriteString("Review each item without trying to infer which option is baseline or candidate.\n\n")
+	builder.WriteString("Reply in a comment with one of these formats. Allowed choices: `a`, `b`, `tie`, `neither`, `skip`.\n\n")
+	builder.WriteString("## Copy-Paste YAML Reply\n\n")
+	builder.WriteString("```yaml\n")
+	yamlTemplate, err := githubFeedbackYAMLTemplate(run.ID, items)
+	if err != nil {
+		return "", err
+	}
+	builder.WriteString(yamlTemplate)
+	builder.WriteString("```\n\n")
+	builder.WriteString("## Short-Form Reply\n\n")
+	builder.WriteString("```text\n")
+	builder.WriteString("run_id: " + run.ID + "\n")
+	for _, item := range items {
+		builder.WriteString(item.ItemID + ": <choice> - optional reason\n")
+	}
+	builder.WriteString("```\n\n")
+	builder.WriteString("## Items\n")
+	for _, item := range items {
+		assignment := assignments[item.ItemID]
+		fmt.Fprintf(&builder, "\n### %s\n\n", itemTitle(item))
+		builder.WriteString("#### Option A\n\n")
+		writeMarkdownFence(&builder, assignment.OptionA)
+		builder.WriteString("\n#### Option B\n\n")
+		writeMarkdownFence(&builder, assignment.OptionB)
+	}
+	return builder.String(), nil
+}
+
+func (c GitHubCollector) Sync(ctx context.Context, store *db.Store, runID string, repo github.Repository, issueNumber int64) ([]db.FeedbackEvent, error) {
+	if c.GitHub == nil {
+		return nil, errors.New("github client is required")
+	}
+	if repo.FullName() == "" {
+		return nil, errors.New("github feedback repo is required")
+	}
+	if issueNumber <= 0 {
+		return nil, errors.New("github feedback issue or pull request number is required")
+	}
+	comments, err := c.GitHub.ListIssueComments(ctx, repo, issueNumber)
+	if err != nil {
+		return nil, err
+	}
+	return c.ImportComments(ctx, store, runID, comments)
+}
+
+func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, runID string, comments []github.IssueComment) ([]db.FeedbackEvent, error) {
+	if store == nil {
+		return nil, errors.New("store is required")
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil, errors.New("run id is required")
+	}
+	items, assignments, err := c.reviewItemsAndAssignments(ctx, store, runID)
+	if err != nil {
+		return nil, err
+	}
+	knownItems := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		knownItems[item.ItemID] = struct{}{}
+	}
+	var imported []db.FeedbackEvent
+	for _, comment := range comments {
+		parsed, ok, err := ParseGitHubFeedbackComment(comment.Body)
+		if err != nil {
+			return nil, fmt.Errorf("comment %d: %w", comment.ID, err)
+		}
+		if !ok {
+			continue
+		}
+		if parsed.RunID == "" {
+			continue
+		}
+		if parsed.RunID != runID {
+			continue
+		}
+		reviewer := strings.TrimSpace(comment.Author)
+		if reviewer == "" {
+			reviewer = strings.TrimSpace(parsed.Reviewer)
+		}
+		if reviewer == "" {
+			reviewer = "github"
+		}
+		sourceURL := strings.TrimSpace(comment.URL)
+		if sourceURL == "" {
+			sourceURL = fmt.Sprintf("github-comment:%d", comment.ID)
+		}
+		createdAt := strings.TrimSpace(comment.CreatedAt)
+		if createdAt == "" {
+			createdAt = c.now().UTC().Format(time.RFC3339)
+		}
+		commentEvents := make([]db.FeedbackEvent, 0, len(parsed.Items))
+		for _, entry := range parsed.Items {
+			itemID := strings.TrimSpace(entry.ItemID)
+			if _, ok := knownItems[itemID]; !ok {
+				if parsed.ShortForm {
+					continue
+				}
+				return nil, fmt.Errorf("comment %d: unknown feedback item_id %q", comment.ID, itemID)
+			}
+			choice, err := NormalizeChoice(entry.Choice)
+			if err != nil {
+				return nil, fmt.Errorf("comment %d item %s: %w", comment.ID, itemID, err)
+			}
+			choice, err = deblindChoice(choice, assignments[itemID].blindAssignment)
+			if err != nil {
+				return nil, fmt.Errorf("comment %d item %s: %w", comment.ID, itemID, err)
+			}
+			event := db.FeedbackEvent{
+				RunID:     runID,
+				ItemID:    itemID,
+				Choice:    choice,
+				Reasoning: strings.TrimSpace(entry.Reasoning),
+				Reviewer:  reviewer,
+				Source:    SourceGitHub,
+				SourceURL: sourceURL,
+				CreatedAt: createdAt,
+			}
+			commentEvents = append(commentEvents, event)
+		}
+		imported = append(imported, commentEvents...)
+	}
+	for _, event := range imported {
+		if err := store.UpsertFeedbackEvent(ctx, event); err != nil {
+			return nil, err
+		}
+	}
+	return imported, nil
+}
+
+type githubAssignment struct {
+	blindAssignment
+	OptionA string
+	OptionB string
+}
+
+func (c GitHubCollector) reviewItemsAndAssignments(ctx context.Context, store *db.Store, runID string) ([]db.EvalReviewItem, map[string]githubAssignment, error) {
+	run, err := store.GetEvalRun(ctx, runID)
+	if err != nil {
+		return nil, nil, err
+	}
+	items, err := store.ListEvalReviewItems(ctx, run.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(items) == 0 {
+		return nil, nil, fmt.Errorf("eval run %s has no review items", run.ID)
+	}
+	assignments := make(map[string]githubAssignment, len(items))
+	for _, item := range items {
+		assignment, err := validatedAssignmentFor(run.ID, item)
+		if err != nil {
+			return nil, nil, err
+		}
+		optionA, err := c.optionText(ctx, store, assignment.A)
+		if err != nil {
+			return nil, nil, fmt.Errorf("item %s option a: %w", item.ItemID, err)
+		}
+		optionB, err := c.optionText(ctx, store, assignment.B)
+		if err != nil {
+			return nil, nil, fmt.Errorf("item %s option b: %w", item.ItemID, err)
+		}
+		assignments[item.ItemID] = githubAssignment{blindAssignment: assignment, OptionA: optionA, OptionB: optionB}
+	}
+	return items, assignments, nil
+}
+
+func (c GitHubCollector) optionText(ctx context.Context, store *db.Store, artifactID string) (string, error) {
+	artifactID = strings.TrimSpace(artifactID)
+	if artifactID == "" {
+		return "", nil
+	}
+	record, err := store.GetEvalArtifact(ctx, artifactID)
+	if err != nil {
+		return "", err
+	}
+	content, err := c.BlobStore.Read(record.Hash)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func (c GitHubCollector) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+func ParseGitHubFeedbackComment(body string) (feedbackFile, bool, error) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return feedbackFile{}, false, nil
+	}
+	if isGitHubFeedbackPacket(body) {
+		return feedbackFile{}, false, nil
+	}
+	blocks := fencedBlocks(body)
+	for _, block := range blocks {
+		parsed, ok, err := parseFullYAMLFeedback(block)
+		if ok || err != nil {
+			return parsed, ok, err
+		}
+	}
+	if len(blocks) == 0 && !hasQuotedLines(body) {
+		parsed, ok, err := parseFullYAMLFeedback(body)
+		if ok || err != nil {
+			return parsed, ok, err
+		}
+	}
+	return parseShortFormFeedback(body)
+}
+
+func parseFullYAMLFeedback(content string) (feedbackFile, bool, error) {
+	if !strings.Contains(content, "items:") && !strings.Contains(content, "run_id:") {
+		return feedbackFile{}, false, nil
+	}
+	var parsed feedbackFile
+	if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+		return feedbackFile{}, true, fmt.Errorf("parse feedback yaml: %w", err)
+	}
+	parsed.RunID = strings.TrimSpace(parsed.RunID)
+	parsed.Reviewer = strings.TrimSpace(parsed.Reviewer)
+	if len(parsed.Items) == 0 {
+		return feedbackFile{}, false, nil
+	}
+	for index := range parsed.Items {
+		parsed.Items[index].ItemID = strings.TrimSpace(parsed.Items[index].ItemID)
+		parsed.Items[index].Choice = strings.TrimSpace(parsed.Items[index].Choice)
+		parsed.Items[index].Reasoning = strings.TrimSpace(parsed.Items[index].Reasoning)
+	}
+	hasFeedbackItem := false
+	for _, item := range parsed.Items {
+		if item.ItemID != "" {
+			hasFeedbackItem = true
+			break
+		}
+	}
+	if !hasFeedbackItem {
+		return feedbackFile{}, false, nil
+	}
+	return parsed, true, nil
+}
+
+var shortFeedbackLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s*:\s*([A-Za-z]+)(?:\s*-\s*(.*))?$`)
+var shortMetadataLine = regexp.MustCompile(`^(run_id|reviewer)\s*:\s*(.+)$`)
+
+func parseShortFormFeedback(content string) (feedbackFile, bool, error) {
+	parsed := feedbackFile{ShortForm: true}
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "```") {
+			continue
+		}
+		if strings.HasPrefix(line, ">") {
+			continue
+		}
+		if match := shortMetadataLine.FindStringSubmatch(line); match != nil {
+			switch strings.ToLower(strings.TrimSpace(match[1])) {
+			case "run_id":
+				parsed.RunID = strings.TrimSpace(match[2])
+			case "reviewer":
+				parsed.Reviewer = strings.TrimSpace(match[2])
+			}
+			continue
+		}
+		match := shortFeedbackLine.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		parsed.Items = append(parsed.Items, feedbackFileEntry{
+			ItemID:    strings.TrimSpace(match[1]),
+			Choice:    strings.TrimSpace(match[2]),
+			Reasoning: strings.TrimSpace(match[3]),
+		})
+	}
+	if len(parsed.Items) == 0 {
+		return feedbackFile{}, false, nil
+	}
+	return parsed, true, nil
+}
+
+func fencedBlocks(content string) []string {
+	var blocks []string
+	var builder strings.Builder
+	inFence := false
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if strings.HasPrefix(line, "```") {
+			if inFence {
+				blocks = append(blocks, builder.String())
+				builder.Reset()
+				inFence = false
+				continue
+			}
+			inFence = true
+			continue
+		}
+		if inFence {
+			builder.WriteString(raw)
+			builder.WriteByte('\n')
+		}
+	}
+	return blocks
+}
+
+func isGitHubFeedbackPacket(body string) bool {
+	body = strings.TrimSpace(body)
+	return strings.Contains(body, githubFeedbackPacketMarker) ||
+		strings.HasPrefix(body, "# Gitmoot SkillOpt Feedback:")
+}
+
+func hasQuotedLines(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), ">") {
+			return true
+		}
+	}
+	return false
+}
+
+func githubFeedbackYAMLTemplate(runID string, items []db.EvalReviewItem) (string, error) {
+	packet := feedbackFile{RunID: runID}
+	for _, item := range items {
+		packet.Items = append(packet.Items, feedbackFileEntry{
+			ItemID:    item.ItemID,
+			Choice:    "",
+			Reasoning: "",
+		})
+	}
+	content, err := yaml.Marshal(packet)
+	if err != nil {
+		return "", fmt.Errorf("encode github feedback yaml: %w", err)
+	}
+	return string(content), nil
+}

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -1,0 +1,330 @@
+package feedback
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+func TestParseGitHubFeedbackComment(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantOK     bool
+		wantRunID  string
+		wantItems  int
+		wantItem   string
+		wantChoice string
+		wantReason string
+		wantErr    string
+	}{
+		{
+			name:   "fenced yaml",
+			body:   "Looks good.\n\n```yaml\nrun_id: run-1\nreviewer: jerry\nitems:\n  - item_id: item-001\n    choice: b\n    reasoning: More concrete.\n```\n",
+			wantOK: true, wantRunID: "run-1", wantItems: 1, wantItem: "item-001", wantChoice: "b", wantReason: "More concrete.",
+		},
+		{
+			name:   "short form",
+			body:   "run_id: run-1\nitem-001: b - More concrete and easier to execute.\nitem-002: tie\n",
+			wantOK: true, wantRunID: "run-1", wantItems: 2, wantItem: "item-001", wantChoice: "b", wantReason: "More concrete and easier to execute.",
+		},
+		{
+			name:   "unrelated",
+			body:   "Thanks, I will review this later.",
+			wantOK: false,
+		},
+		{
+			name:   "published packet",
+			body:   githubFeedbackPacketMarker + "\n# Gitmoot SkillOpt Feedback: run-1\n\n```yaml\nrun_id: run-1\nitems:\n  - item_id: item-001\n    choice: \n```",
+			wantOK: false,
+		},
+		{
+			name:   "quoted short form",
+			body:   "> run_id: run-1\n> item-001: b - quoted feedback\n\nI agree with this.",
+			wantOK: false,
+		},
+		{
+			name:       "raw short form choice",
+			body:       "item-001: yes",
+			wantOK:     true,
+			wantItems:  1,
+			wantItem:   "item-001",
+			wantChoice: "yes",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, ok, err := ParseGitHubFeedbackComment(tt.body)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseGitHubFeedbackComment returned error: %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if parsed.RunID != tt.wantRunID {
+				t.Fatalf("run_id = %q, want %q", parsed.RunID, tt.wantRunID)
+			}
+			if len(parsed.Items) != tt.wantItems {
+				t.Fatalf("items = %+v, want %d", parsed.Items, tt.wantItems)
+			}
+			if parsed.Items[0].ItemID != tt.wantItem || parsed.Items[0].Choice != tt.wantChoice || parsed.Items[0].Reasoning != tt.wantReason {
+				t.Fatalf("first item = %+v", parsed.Items[0])
+			}
+		})
+	}
+}
+
+func TestGitHubCollectorPublishesIssueBody(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubFeedbackRun(t, "run-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		issue: github.Issue{Number: 42, URL: "https://github.com/owner/repo/issues/42"},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	result, err := collector.Publish(ctx, store, "run-1", GitHubPublishTarget{
+		Repo: github.Repository{Owner: "owner", Name: "repo"},
+	})
+	if err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+	if result.Mode != "issue" || result.IssueNumber != 42 || result.URL != fake.issue.URL {
+		t.Fatalf("result = %+v", result)
+	}
+	if fake.createdIssue.Title != "Gitmoot SkillOpt feedback: run-1" {
+		t.Fatalf("created issue = %+v", fake.createdIssue)
+	}
+	body := fake.createdIssue.Body
+	for _, want := range []string{
+		"Allowed choices: `a`, `b`, `tie`, `neither`, `skip`",
+		"run_id: run-1",
+		"item-001: <choice> - optional reason",
+		"#### Option A",
+		"#### Option B",
+		"baseline answer",
+		"candidate answer",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("issue body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestGitHubCollectorYAMLTemplateHandlesSpecialIDs(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubFeedbackRunWithItem(t, "run: 1 # x", "- item: 001", "owner/repo")
+	collector := GitHubCollector{BlobStore: blobs, GitHub: &fakeFeedbackGitHub{}}
+
+	body, err := collector.Body(ctx, store, "run: 1 # x")
+	if err != nil {
+		t.Fatalf("Body returned error: %v", err)
+	}
+	blocks := fencedBlocks(body)
+	if len(blocks) == 0 {
+		t.Fatalf("body has no yaml block:\n%s", body)
+	}
+	parsed, ok, err := parseFullYAMLFeedback(blocks[0])
+	if err != nil {
+		t.Fatalf("parseFullYAMLFeedback returned error: %v\n%s", err, blocks[0])
+	}
+	if !ok {
+		t.Fatalf("yaml block was not parsed as feedback:\n%s", blocks[0])
+	}
+	if parsed.RunID != "run: 1 # x" || len(parsed.Items) != 1 || parsed.Items[0].ItemID != "- item: 001" {
+		t.Fatalf("parsed = %+v", parsed)
+	}
+}
+
+func TestGitHubCollectorPublishesPRComment(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubFeedbackRun(t, "run-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	result, err := collector.Publish(ctx, store, "run-1", GitHubPublishTarget{
+		Repo:        github.Repository{Owner: "owner", Name: "repo"},
+		PullRequest: 7,
+	})
+	if err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+	if result.Mode != "pr-comment" || result.IssueNumber != 7 {
+		t.Fatalf("result = %+v", result)
+	}
+	if fake.createdIssue.Title != "" {
+		t.Fatalf("CreateIssue was called in PR mode: %+v", fake.createdIssue)
+	}
+	if len(fake.postedComments) != 1 || fake.postedComments[0].IssueNumber != 7 {
+		t.Fatalf("posted comments = %+v", fake.postedComments)
+	}
+	if !strings.Contains(fake.postedComments[0].Body, "Short-Form Reply") {
+		t.Fatalf("PR comment body missing feedback instructions:\n%s", fake.postedComments[0].Body)
+	}
+}
+
+func TestGitHubCollectorSyncImportsValidCommentsAndIgnoresUnrelated(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubFeedbackRun(t, "run-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{
+			42: {
+				{ID: 1, Body: "LGTM", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-05-31T10:00:00Z"},
+				{ID: 4, Body: "status: done", URL: "https://github.com/owner/repo/issues/42#issuecomment-4", Author: "alice", CreatedAt: "2026-05-31T10:30:00Z"},
+				{ID: 5, Body: "```yaml\nitems:\n  - name: docs\n```", URL: "https://github.com/owner/repo/issues/42#issuecomment-5", Author: "alice", CreatedAt: "2026-05-31T10:45:00Z"},
+				{ID: 6, Body: "item-001: b - stale unscoped reply", URL: "https://github.com/owner/repo/issues/42#issuecomment-6", Author: "dan", CreatedAt: "2026-05-31T10:50:00Z"},
+				{ID: 7, Body: "```yaml\nitems:\n  - item_id: item-001\n    choice: b\n```", URL: "https://github.com/owner/repo/issues/42#issuecomment-7", Author: "erin", CreatedAt: "2026-05-31T10:55:00Z"},
+				{ID: 2, Body: "run_id: run-1\nitem-001: b - More concrete.", URL: "https://github.com/owner/repo/issues/42#issuecomment-2", Author: "bob", CreatedAt: "2026-05-31T11:00:00Z"},
+				{ID: 3, Body: "```yaml\nrun_id: other-run\nitems:\n  - item_id: item-001\n    choice: a\n```", URL: "https://github.com/owner/repo/issues/42#issuecomment-3", Author: "carol", CreatedAt: "2026-05-31T12:00:00Z"},
+			},
+		},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake, Now: func() time.Time {
+		return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	}}
+
+	events, err := collector.Sync(ctx, store, "run-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	if err != nil {
+		t.Fatalf("Sync returned error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %+v, want 1 imported event", events)
+	}
+	if events[0].RunID != "run-1" || events[0].ItemID != "item-001" || events[0].Reviewer != "bob" || events[0].Source != SourceGitHub || events[0].SourceURL != "https://github.com/owner/repo/issues/42#issuecomment-2" {
+		t.Fatalf("event = %+v", events[0])
+	}
+	stored, err := store.ListFeedbackEvents(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("ListFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 1 {
+		t.Fatalf("stored events = %+v", stored)
+	}
+	if _, err := collector.Sync(ctx, store, "run-1", github.Repository{Owner: "owner", Name: "repo"}, 42); err != nil {
+		t.Fatalf("second Sync returned error: %v", err)
+	}
+	stored, err = store.ListFeedbackEvents(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("second ListFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 1 {
+		t.Fatalf("duplicate sync persisted duplicate events: %+v", stored)
+	}
+}
+
+func TestGitHubCollectorSyncRejectsInvalidChoiceForKnownShortFormItem(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubFeedbackRun(t, "run-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{
+			42: {
+				{ID: 1, Body: "status: done", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-05-31T10:00:00Z"},
+				{ID: 2, Body: "run_id: run-1\nitem-001: yes", URL: "https://github.com/owner/repo/issues/42#issuecomment-2", Author: "bob", CreatedAt: "2026-05-31T11:00:00Z"},
+			},
+		},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	_, err := collector.Sync(ctx, store, "run-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+
+	if err == nil || !strings.Contains(err.Error(), `comment 2 item item-001: invalid feedback choice "yes"`) {
+		t.Fatalf("Sync error = %v", err)
+	}
+	stored, err := store.ListFeedbackEvents(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("ListFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 0 {
+		t.Fatalf("Sync persisted partial events after invalid known item choice: %+v", stored)
+	}
+}
+
+func setupGitHubFeedbackRun(t *testing.T, runID string, targetRepo string) (*db.Store, artifact.Store) {
+	return setupGitHubFeedbackRunWithItem(t, runID, "item-001", targetRepo)
+}
+
+func setupGitHubFeedbackRunWithItem(t *testing.T, runID string, itemID string, targetRepo string) (*db.Store, artifact.Store) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	blobStore := artifact.NewStore(filepath.Join(t.TempDir(), "blobs"))
+	baseline, err := blobStore.Put([]byte("baseline answer"))
+	if err != nil {
+		t.Fatalf("Put baseline returned error: %v", err)
+	}
+	candidate, err := blobStore.Put([]byte("candidate answer"))
+	if err != nil {
+		t.Fatalf("Put candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "baseline", Hash: baseline.Hash, MediaType: "text/markdown", SizeBytes: baseline.Size, Driver: "text"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact baseline returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "candidate", Hash: candidate.Hash, MediaType: "text/markdown", SizeBytes: candidate.Size, Driver: "text"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{ID: runID, TemplateID: "planner", TargetRepo: targetRepo, State: "review"}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:               runID,
+		ItemID:              itemID,
+		BaselineArtifactID:  "baseline",
+		CandidateArtifactID: "candidate",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	return store, blobStore
+}
+
+type fakeFeedbackGitHub struct {
+	github.NoopClient
+
+	issue          github.Issue
+	createdIssue   github.CreateIssueInput
+	postedComments []postedFeedbackComment
+	comments       map[int64][]github.IssueComment
+}
+
+type postedFeedbackComment struct {
+	IssueNumber int64
+	Body        string
+}
+
+func (f *fakeFeedbackGitHub) CreateIssue(_ context.Context, input github.CreateIssueInput) (github.Issue, error) {
+	f.createdIssue = input
+	if f.issue.Number == 0 {
+		f.issue = github.Issue{Number: 1, URL: "https://github.com/" + input.Repo.FullName() + "/issues/1"}
+	}
+	return f.issue, nil
+}
+
+func (f *fakeFeedbackGitHub) PostIssueComment(_ context.Context, repo github.Repository, issueNumber int64, body string) (github.IssueComment, error) {
+	f.postedComments = append(f.postedComments, postedFeedbackComment{IssueNumber: issueNumber, Body: body})
+	return github.IssueComment{ID: int64(len(f.postedComments)), Body: body, URL: "https://github.com/" + repo.FullName() + "/issues/" + "7#issuecomment-1"}, nil
+}
+
+func (f *fakeFeedbackGitHub) ListIssueComments(_ context.Context, _ github.Repository, issueNumber int64) ([]github.IssueComment, error) {
+	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
+}

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -39,9 +39,10 @@ type blindAssignment struct {
 }
 
 type feedbackFile struct {
-	RunID    string              `yaml:"run_id"`
-	Reviewer string              `yaml:"reviewer"`
-	Items    []feedbackFileEntry `yaml:"items"`
+	RunID     string              `yaml:"run_id"`
+	Reviewer  string              `yaml:"reviewer"`
+	Items     []feedbackFileEntry `yaml:"items"`
+	ShortForm bool                `yaml:"-"`
 }
 
 type feedbackFileEntry struct {
@@ -74,15 +75,10 @@ func (c MarkdownCollector) WritePacket(ctx context.Context, store *db.Store, run
 	}
 	assignments := assignmentFile{RunID: run.ID}
 	for _, item := range items {
-		baselineArtifactID := strings.TrimSpace(item.BaselineArtifactID)
-		candidateArtifactID := strings.TrimSpace(item.CandidateArtifactID)
-		if baselineArtifactID == "" || candidateArtifactID == "" {
-			return fmt.Errorf("eval review item %s requires both baseline and candidate artifacts", item.ItemID)
+		assignment, err := validatedAssignmentFor(run.ID, item)
+		if err != nil {
+			return err
 		}
-		if baselineArtifactID == candidateArtifactID {
-			return fmt.Errorf("eval review item %s requires distinct baseline and candidate artifacts", item.ItemID)
-		}
-		assignment := assignmentFor(run.ID, item)
 		assignments.Items = append(assignments.Items, assignment)
 		if err := c.writeItem(ctx, store, dir, item, assignment); err != nil {
 			return err
@@ -252,6 +248,18 @@ func assignmentFor(runID string, item db.EvalReviewItem) blindAssignment {
 		assignment.B = item.BaselineArtifactID
 	}
 	return assignment
+}
+
+func validatedAssignmentFor(runID string, item db.EvalReviewItem) (blindAssignment, error) {
+	baselineArtifactID := strings.TrimSpace(item.BaselineArtifactID)
+	candidateArtifactID := strings.TrimSpace(item.CandidateArtifactID)
+	if baselineArtifactID == "" || candidateArtifactID == "" {
+		return blindAssignment{}, fmt.Errorf("eval review item %s requires both baseline and candidate artifacts", item.ItemID)
+	}
+	if baselineArtifactID == candidateArtifactID {
+		return blindAssignment{}, fmt.Errorf("eval review item %s requires distinct baseline and candidate artifacts", item.ItemID)
+	}
+	return assignmentFor(runID, item), nil
 }
 
 func validateAssignmentsAgainstStore(ctx context.Context, store *db.Store, assignments assignmentFile) error {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -20,6 +20,7 @@ type Client interface {
 	ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error)
 	GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
+	CreateIssue(ctx context.Context, input CreateIssueInput) (Issue, error)
 	ListIssueComments(ctx context.Context, repo Repository, issueNumber int64) ([]IssueComment, error)
 	PostIssueComment(ctx context.Context, repo Repository, issueNumber int64, body string) (IssueComment, error)
 	GetUserPermission(ctx context.Context, repo Repository, username string) (UserPermission, error)
@@ -130,6 +131,19 @@ func (c *IssueComment) UnmarshalJSON(data []byte) error {
 	c.CreatedAt = decoded.CreatedAt
 	c.UpdatedAt = decoded.UpdatedAt
 	return nil
+}
+
+type Issue struct {
+	Number int64  `json:"number"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+	URL    string `json:"html_url"`
+}
+
+type CreateIssueInput struct {
+	Repo  Repository
+	Title string
+	Body  string
 }
 
 type CreatePullRequestInput struct {
@@ -264,6 +278,15 @@ func (c *GhClient) PostIssueComment(ctx context.Context, repo Repository, issueN
 	var comment IssueComment
 	err := c.apiJSON(ctx, true, &comment, endpoint(repo, "issues", issueNumber, "comments"), "-f", "body="+body)
 	return comment, err
+}
+
+func (c *GhClient) CreateIssue(ctx context.Context, input CreateIssueInput) (Issue, error) {
+	var issue Issue
+	err := c.apiJSON(ctx, true, &issue,
+		endpoint(input.Repo, "issues"),
+		"-f", "title="+input.Title,
+		"-f", "body="+input.Body)
+	return issue, err
 }
 
 func (c *GhClient) GetUserPermission(ctx context.Context, repo Repository, username string) (UserPermission, error) {
@@ -636,6 +659,10 @@ func (NoopClient) GetPullRequest(context.Context, Repository, int64) (PullReques
 
 func (NoopClient) CreatePullRequest(context.Context, CreatePullRequestInput) (PullRequest, error) {
 	return PullRequest{}, errors.ErrUnsupported
+}
+
+func (NoopClient) CreateIssue(context.Context, CreateIssueInput) (Issue, error) {
+	return Issue{}, errors.ErrUnsupported
 }
 
 func (NoopClient) ListIssueComments(context.Context, Repository, int64) ([]IssueComment, error) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -58,6 +58,29 @@ func TestPostIssueCommentUsesIssueCommentsEndpoint(t *testing.T) {
 	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/issues/2/comments", "-f", "body=done")
 }
 
+func TestCreateIssueUsesIssuesEndpoint(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"number": 8, "title": "Review run-1", "state": "open", "html_url": "https://github.com/jerryfane/gitmoot/issues/8"}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	issue, err := client.CreateIssue(context.Background(), CreateIssueInput{
+		Repo:  Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Title: "Review run-1",
+		Body:  "body",
+	})
+
+	if err != nil {
+		t.Fatalf("CreateIssue returned error: %v", err)
+	}
+	if issue.Number != 8 || issue.URL != "https://github.com/jerryfane/gitmoot/issues/8" {
+		t.Fatalf("issue = %+v", issue)
+	}
+	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/issues", "-f", "title=Review run-1", "-f", "body=body")
+}
+
 func TestGetUserPermissionUsesCollaboratorPermissionEndpoint(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -260,6 +260,8 @@ gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
+gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
+gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
 `skillopt export` writes a JSON training package with the template snapshot,
@@ -270,3 +272,12 @@ automatically. The Markdown feedback collector writes blind A/B review packets
 with `index.md`, per-item Markdown files, editable `feedback.yml`, and hidden
 assignment metadata that Gitmoot uses to validate the full response and import
 de-blinded canonical feedback events.
+
+The GitHub feedback collector publishes the same blind A/B review packet to a
+new issue by default, or to an existing PR when `--pr <number>` is provided.
+Repository resolution uses `--repo`, then the eval run target repo, then the
+template source repo, then optional `[feedback].repo = "owner/reviews"` in
+Gitmoot config. Reviewers can reply with full YAML or run-scoped short-form
+lines such as `run_id: run-1` followed by `item-001: b - More concrete.`.
+`github sync` imports valid comments into canonical feedback events and ignores
+unrelated comments safely.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -64,4 +64,6 @@ gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
+gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
+gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -59,3 +59,35 @@ gitmoot skillopt feedback markdown import \
 Gitmoot validates the complete file before writing events. It uses the hidden
 assignment metadata to de-blind `a` and `b`, so exported feedback events use
 `a` for baseline and `b` for candidate.
+
+## GitHub Feedback Collector
+
+```sh
+gitmoot skillopt feedback github publish \
+  --run run-2026-05-31 \
+  --repo owner/reviews
+```
+
+Use `--pr <number>` to publish the packet as a comment on an existing pull
+request instead of creating a new issue.
+
+If `--repo` is omitted, Gitmoot tries the eval run target repo, the template
+source repo, and then configured `[feedback].repo = "owner/reviews"`.
+
+Humans can reply with the YAML block in the issue body or short-form lines:
+
+```text
+run_id: run-2026-05-31
+item-001: b - More concrete and easier to execute.
+item-002: tie
+```
+
+```sh
+gitmoot skillopt feedback github sync \
+  --run run-2026-05-31 \
+  --repo owner/reviews \
+  --issue 42
+```
+
+For PR comment mode, sync with `--pr <number>`. Gitmoot ignores unrelated
+comments and de-duplicates repeated imports by GitHub comment URL.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -287,11 +287,21 @@ gitmoot skillopt export --run <run-id> --output training.json
 gitmoot skillopt import --file candidate.json
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
+gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
+gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
 The export/import boundary lets a future external `gitmoot-skillopt` optimizer
 train on local eval artifacts and return candidate template versions. Imported
 candidates stay pending until a human review workflow promotes them.
+
+Use the GitHub feedback collector when review should happen in an issue or an
+existing PR thread. Reviewers can reply with either the copy-paste YAML block or
+run-scoped short lines such as `run_id: run-1` followed by
+`item-001: b - More concrete.`. Gitmoot imports matching comments into
+canonical feedback events and ignores unrelated comments. Repo selection uses
+`--repo`, then the eval run target repo, then the template source repo, then
+optional `[feedback].repo = "owner/reviews"` in Gitmoot config.
 
 Detailed command coverage lives in
 [skills/gitmoot/references/CLI.md](skills/gitmoot/references/CLI.md).
@@ -473,6 +483,8 @@ gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
+gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
+gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
 Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`
@@ -2848,6 +2860,8 @@ gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
+gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
+gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
 `skillopt export` writes a JSON training package with the template snapshot,
@@ -2858,6 +2872,15 @@ automatically. The Markdown feedback collector writes blind A/B review packets
 with `index.md`, per-item Markdown files, editable `feedback.yml`, and hidden
 assignment metadata that Gitmoot uses to validate the full response and import
 de-blinded canonical feedback events.
+
+The GitHub feedback collector publishes the same blind A/B review packet to a
+new issue by default, or to an existing PR when `--pr <number>` is provided.
+Repository resolution uses `--repo`, then the eval run target repo, then the
+template source repo, then optional `[feedback].repo = "owner/reviews"` in
+Gitmoot config. Reviewers can reply with full YAML or run-scoped short-form
+lines such as `run_id: run-1` followed by `item-001: b - More concrete.`.
+`github sync` imports valid comments into canonical feedback events and ignores
+unrelated comments safely.
 
 ---
 


### PR DESCRIPTION
WHAT
- Added a GitHub SkillOpt feedback collector that publishes blind A/B review packets to GitHub issues or existing PR comments.
- Added GitHub comment sync into canonical feedback events.

WHY
- Gitmoot needs a collaborative feedback collector that fits the existing GitHub-centered workflow and can feed future SkillOpt/template optimization loops.

CHANGES
- Added GitHub issue creation support to the GitHub client.
- Added `gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]`.
- Added `gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)`.
- Added repository resolution for explicit `--repo`, eval run target repo, template source repo, and `[feedback].repo` config fallback.
- Added GitHub feedback body generation with copy-paste YAML and run-scoped short-form replies.
- Added safe comment parsing that ignores unrelated comments, published packets, quoted feedback, stale unscoped comments, and duplicate syncs.
- Reused Markdown feedback assignment/deblinding helpers for the GitHub collector.
- Updated README, SKILL, CLI references, website docs, and generated `llms-full.txt`.

RESULTS
- `/root/temp/ts/tool/go fmt ./internal/feedback ./internal/cli ./internal/github ./internal/config ./internal/daemon`
- `/root/temp/ts/tool/go test ./internal/feedback ./internal/github ./internal/config ./internal/cli ./internal/daemon`
- `/root/temp/ts/tool/go test ./internal/feedback ./internal/cli`
- `/root/temp/ts/tool/go test ./...`
- `npm run build` in `website`
- `git diff --check`
- `git diff --cached --check`
- `gh auth status`
- Operational GitHub smoke: created, commented on, and closed `https://github.com/jerryfane/gitmoot-live-test/issues/7`.

Final `codex exec review --uncommitted` raw output:

```text
No discrete correctness issues were found in the current staged, unstaged, or untracked changes. Targeted new tests passed where runnable; a broader CLI test run hit an environment socket-permission limitation unrelated to these changes.
No discrete correctness issues were found in the current staged, unstaged, or untracked changes. Targeted new tests passed where runnable; a broader CLI test run hit an environment socket-permission limitation unrelated to these changes.
```

RISK
- The review sandbox uses a different Go toolchain/environment than the repo-required local Go toolchain; one broad CLI run inside review hit a Unix socket permission limitation unrelated to this change. Full local checks passed with `/root/temp/ts/tool/go`.
