### PR TITLE
Add template candidate promotion workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ gitmoot lock release owner/repo <branch> --owner <agent>
 ```sh
 gitmoot skillopt export --run <run-id> --output training.json
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt candidate list [--template id]
+gitmoot skillopt candidate show <version-id>
+gitmoot skillopt candidate promote <version-id>
+gitmoot skillopt candidate reject <version-id> [--reason text]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
@@ -284,6 +288,9 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 The export/import boundary lets a future external `gitmoot-skillopt` optimizer
 train on local eval artifacts and return candidate template versions. Imported
 candidates stay pending until a human review workflow promotes them.
+Use `skillopt candidate show` to inspect the candidate metadata, eval report,
+feedback summary, and content diff before `promote` or `reject` records the
+decision.
 
 Use the GitHub feedback collector when review should happen in an issue or an
 existing PR thread. Reviewers can reply with either the copy-paste YAML block or

--- a/SKILL.md
+++ b/SKILL.md
@@ -115,6 +115,10 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt candidate list [--template id]
+gitmoot skillopt candidate show <version-id>
+gitmoot skillopt candidate promote <version-id>
+gitmoot skillopt candidate reject <version-id> [--reason text]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -53,6 +53,28 @@ Importing never promotes a candidate. Gitmoot stores it as a pending template
 version so later review and promotion commands can decide whether it becomes
 current.
 
+Review pending candidates:
+
+```sh
+gitmoot skillopt candidate list --template planner
+gitmoot skillopt candidate show planner@v2
+```
+
+`candidate show` includes the candidate state, source, content hash, base
+version, optimizer score, preference summary, eval report JSON, and a content
+diff against the base/current template version. It does not expose hidden A/B
+assignment mappings while blind reviews are active.
+
+Promote or reject after human review:
+
+```sh
+gitmoot skillopt candidate promote planner@v2
+gitmoot skillopt candidate reject planner@v3 --reason "Too broad for the current workflow"
+```
+
+Promotion updates the template's current version. Rejection records an audit
+reason and prevents the rejected candidate from being selected by `@latest`.
+
 ## Markdown Feedback Packet
 
 Generate a local blind A/B review packet:
@@ -141,3 +163,23 @@ gitmoot skillopt feedback github sync \
 
 For PR comment mode, use `--pr 123` instead of `--issue 42`. Sync ignores
 unrelated comments and de-duplicates repeated imports by comment URL.
+
+Complete local review path:
+
+1. `gitmoot skillopt export --run <run-id> --output training.json`
+2. External optimizer returns `candidate.json`.
+3. `gitmoot skillopt import --file candidate.json`
+4. `gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>`
+5. Human fills `feedback.yml`.
+6. `gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>`
+7. `gitmoot skillopt candidate show <version-id>`
+8. `gitmoot skillopt candidate promote <version-id>` or `gitmoot skillopt candidate reject <version-id>`
+
+Complete GitHub review path:
+
+1. `gitmoot skillopt import --file candidate.json`
+2. `gitmoot skillopt feedback github publish --run <run-id> --repo owner/reviews`
+3. Humans reply in GitHub comments using the run-scoped YAML or short-form block.
+4. `gitmoot skillopt feedback github sync --run <run-id> --repo owner/reviews --issue <number>`
+5. `gitmoot skillopt candidate show <version-id>`
+6. `gitmoot skillopt candidate promote <version-id>` or `gitmoot skillopt candidate reject <version-id>`

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -35,6 +35,8 @@ func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptExport(args[1:], stdout, stderr)
 	case "import":
 		return runSkillOptImport(args[1:], stdout, stderr)
+	case "candidate":
+		return runSkillOptCandidate(args[1:], stdout, stderr)
 	case "feedback":
 		return runSkillOptFeedback(args[1:], stdout, stderr)
 	default:
@@ -48,6 +50,10 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt export --run <run-id> [--output package.json]")
 	fmt.Fprintln(w, "  gitmoot skillopt import --file candidate.json")
+	fmt.Fprintln(w, "  gitmoot skillopt candidate list [--template id]")
+	fmt.Fprintln(w, "  gitmoot skillopt candidate show <version-id>")
+	fmt.Fprintln(w, "  gitmoot skillopt candidate promote <version-id>")
+	fmt.Fprintln(w, "  gitmoot skillopt candidate reject <version-id> [--reason text]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")
@@ -147,6 +153,251 @@ func runSkillOptImport(args []string, stdout, stderr io.Writer) int {
 	}
 	writeLine(stdout, "imported pending candidate %s", versionID)
 	return 0
+}
+
+func runSkillOptCandidate(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSkillOptUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "list":
+		return runSkillOptCandidateList(args[1:], stdout, stderr)
+	case "show":
+		return runSkillOptCandidateShow(args[1:], stdout, stderr)
+	case "promote":
+		return runSkillOptCandidatePromote(args[1:], stdout, stderr)
+	case "reject":
+		return runSkillOptCandidateReject(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skillopt candidate command %q\n\n", args[0])
+		printSkillOptUsage(stderr)
+		return 2
+	}
+}
+
+func runSkillOptCandidateList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt candidate list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	templateID := fs.String("template", "", "template id to filter")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt candidate list does not accept positional arguments")
+		return 2
+	}
+	var versions []db.AgentTemplateVersion
+	var reviews map[string]db.AgentTemplateCandidateReview
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		versions, err = store.ListPendingAgentTemplateVersions(context.Background(), *templateID)
+		if err != nil {
+			return err
+		}
+		reviews = make(map[string]db.AgentTemplateCandidateReview, len(versions))
+		for _, version := range versions {
+			review, err := store.GetAgentTemplateCandidateReview(context.Background(), version.ID)
+			if err == nil {
+				reviews[version.ID] = review
+			} else if !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt candidate list: %v\n", err)
+		return 1
+	}
+	if len(versions) == 0 {
+		writeLine(stdout, "no pending candidates")
+		return 0
+	}
+	fmt.Fprintf(stdout, "%-18s %-14s %-9s %-8s %s\n", "VERSION", "TEMPLATE", "STATE", "SCORE", "SUMMARY")
+	for _, version := range versions {
+		review := reviews[version.ID]
+		fmt.Fprintf(stdout, "%-18s %-14s %-9s %-8s %s\n", version.ID, version.TemplateID, version.State, scoreText(review.Score), firstLine(review.PreferenceSummary))
+	}
+	return 0
+}
+
+func runSkillOptCandidateShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt candidate show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "skillopt candidate show requires exactly one version id")
+		return 2
+	}
+	versionID := fs.Arg(0)
+	var version db.AgentTemplateVersion
+	var review db.AgentTemplateCandidateReview
+	var hasReview bool
+	var base db.AgentTemplate
+	var hasBase bool
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		version, err = store.GetAgentTemplateVersionByID(context.Background(), versionID)
+		if err != nil {
+			return err
+		}
+		review, err = store.GetAgentTemplateCandidateReview(context.Background(), version.ID)
+		if err == nil {
+			hasReview = true
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		baseRef := strings.TrimSpace(review.BaseVersionID)
+		if baseRef == "" {
+			current, err := store.GetAgentTemplate(context.Background(), version.TemplateID)
+			if err != nil {
+				return err
+			}
+			baseRef = current.VersionID
+		}
+		if baseRef != "" && baseRef != version.ID {
+			base, err = store.GetAgentTemplateReference(context.Background(), baseRef)
+			if err == nil {
+				hasBase = true
+			} else if !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt candidate show: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "version: %s\n", version.ID)
+	fmt.Fprintf(stdout, "template: %s\n", version.TemplateID)
+	fmt.Fprintf(stdout, "state: %s\n", version.State)
+	fmt.Fprintf(stdout, "source: %s@%s:%s\n", version.SourceRepo, version.SourceRef, version.SourcePath)
+	fmt.Fprintf(stdout, "content_hash: %s\n", version.ContentHash)
+	if hasReview {
+		fmt.Fprintf(stdout, "base_version: %s\n", emptyText(review.BaseVersionID))
+		fmt.Fprintf(stdout, "score: %s\n", scoreText(review.Score))
+		fmt.Fprintf(stdout, "preference_summary: %s\n", emptyText(review.PreferenceSummary))
+		fmt.Fprintf(stdout, "diff_artifact: %s\n", emptyText(review.DiffArtifactID))
+		if strings.TrimSpace(review.EvalReportJSON) != "" {
+			fmt.Fprintf(stdout, "eval_report:\n%s\n", indentJSON(review.EvalReportJSON))
+		}
+		if strings.TrimSpace(review.DecisionReason) != "" {
+			fmt.Fprintf(stdout, "decision_reason: %s\n", review.DecisionReason)
+		}
+	}
+	if hasBase {
+		diff := artifact.TextDriver{}.Diff(base.VersionID+".md", version.ID+".md", []byte(base.Content), []byte(version.Content))
+		fmt.Fprintf(stdout, "content_diff:\n%s", diff)
+	}
+	return 0
+}
+
+func runSkillOptCandidatePromote(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt candidate promote", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "skillopt candidate promote requires exactly one version id")
+		return 2
+	}
+	var promoted db.AgentTemplateVersion
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		promoted, err = store.PromoteAgentTemplateVersion(context.Background(), fs.Arg(0))
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt candidate promote: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "promoted candidate %s", promoted.ID)
+	return 0
+}
+
+func runSkillOptCandidateReject(args []string, stdout, stderr io.Writer) int {
+	parsed, help, ok := parseSkillOptCandidateRejectArgs(args, stderr)
+	if help {
+		printSkillOptUsage(stdout)
+		return 0
+	}
+	if !ok {
+		return 2
+	}
+	if parsed.versionID == "" {
+		fmt.Fprintln(stderr, "skillopt candidate reject requires exactly one version id")
+		return 2
+	}
+	if parsed.extraVersion {
+		fmt.Fprintln(stderr, "skillopt candidate reject requires exactly one version id")
+		return 2
+	}
+	var rejected db.AgentTemplateVersion
+	if err := withStore(parsed.home, func(store *db.Store) error {
+		var err error
+		rejected, err = store.RejectAgentTemplateVersion(context.Background(), parsed.versionID, parsed.reason)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt candidate reject: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "rejected candidate %s", rejected.ID)
+	return 0
+}
+
+type skillOptCandidateRejectArgs struct {
+	home         string
+	reason       string
+	versionID    string
+	extraVersion bool
+}
+
+func parseSkillOptCandidateRejectArgs(args []string, stderr io.Writer) (skillOptCandidateRejectArgs, bool, bool) {
+	var parsed skillOptCandidateRejectArgs
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-h" || arg == "--help":
+			return parsed, true, true
+		case arg == "--home" || arg == "--reason":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "skillopt candidate reject: %s requires a value\n", arg)
+				return parsed, false, false
+			}
+			i++
+			if arg == "--home" {
+				parsed.home = args[i]
+			} else {
+				parsed.reason = args[i]
+			}
+		case strings.HasPrefix(arg, "--home="):
+			parsed.home = strings.TrimPrefix(arg, "--home=")
+		case strings.HasPrefix(arg, "--reason="):
+			parsed.reason = strings.TrimPrefix(arg, "--reason=")
+		case strings.HasPrefix(arg, "-"):
+			fmt.Fprintf(stderr, "skillopt candidate reject: unknown flag %s\n", arg)
+			return parsed, false, false
+		case parsed.versionID == "":
+			parsed.versionID = arg
+		default:
+			parsed.extraVersion = true
+		}
+	}
+	return parsed, false, true
 }
 
 func writeSkillOptFile(path string, content []byte) error {
@@ -408,6 +659,48 @@ func resolveSkillOptFeedbackRepo(ctx context.Context, paths config.Paths, store 
 		return daemon.ParseRepository(defaultRepo)
 	}
 	return github.Repository{}, errors.New("skillopt feedback github requires --repo because no target repo, template source repo, or [feedback].repo default is configured")
+}
+
+func scoreText(score *float64) string {
+	if score == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.4g", *score)
+}
+
+func firstLine(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	if before, _, ok := strings.Cut(value, "\n"); ok {
+		return strings.TrimSpace(before)
+	}
+	return value
+}
+
+func emptyText(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func indentJSON(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(value), &decoded); err != nil {
+		return value
+	}
+	encoded, err := json.MarshalIndent(decoded, "  ", "  ")
+	if err != nil {
+		return value
+	}
+	return string(encoded)
 }
 
 func withSkillOptStore(home string, fn func(config.Paths, *db.Store) error) error {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -145,6 +145,11 @@ items:
 			Content:  candidateContent,
 			Metadata: parsed.Metadata,
 		},
+		EvalReport: json.RawMessage(`{"score":0.91}`),
+		Summary: skillopt.CandidateSummary{
+			Score:             floatPtr(0.91),
+			PreferenceSummary: "Candidate is more specific.",
+		},
 	}
 	candidatePath := filepath.Join(t.TempDir(), "candidate.json")
 	encodedCandidate, err := json.Marshal(candidate)
@@ -163,17 +168,43 @@ items:
 	if !strings.Contains(stdout.String(), "imported pending candidate planner@v2") {
 		t.Fatalf("import stdout = %q", stdout.String())
 	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "candidate", "list", "--home", home, "--template", "planner"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt candidate list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "planner@v2") || !strings.Contains(stdout.String(), "Candidate is more specific.") {
+		t.Fatalf("candidate list stdout = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "candidate", "show", "--home", home, "planner@v2"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt candidate show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "state: pending") || !strings.Contains(stdout.String(), "eval_report:") || !strings.Contains(stdout.String(), "content_diff:") {
+		t.Fatalf("candidate show stdout = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "candidate", "promote", "--home", home, "planner@v2"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt candidate promote exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "promoted candidate planner@v2") {
+		t.Fatalf("candidate promote stdout = %q", stdout.String())
+	}
 	store, err = db.Open(paths.Database)
 	if err != nil {
 		t.Fatalf("Open after import returned error: %v", err)
 	}
-	defer store.Close()
 	current, err := store.GetAgentTemplate(context.Background(), "planner")
 	if err != nil {
 		t.Fatalf("GetAgentTemplate current returned error: %v", err)
 	}
-	if current.VersionID != installed.VersionID {
-		t.Fatalf("current version = %q, want %q", current.VersionID, installed.VersionID)
+	if current.VersionID != "planner@v2" {
+		t.Fatalf("current version = %q, want planner@v2", current.VersionID)
 	}
 	latest, err := store.GetAgentTemplateReference(context.Background(), "planner@latest")
 	if err != nil {
@@ -182,6 +213,67 @@ items:
 	if latest.VersionID != "planner@v2" || latest.Content != candidateContent {
 		t.Fatalf("latest = %+v", latest)
 	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after promote returned error: %v", err)
+	}
+	rejectedContent := cliSkillOptTemplateContent("planner", "Plan the work and include every possible detail.")
+	rejectedParsed, err := agenttemplate.ParseTemplateContent(rejectedContent)
+	if err != nil {
+		t.Fatalf("ParseTemplateContent rejected returned error: %v", err)
+	}
+	candidate.Candidate.Content = rejectedContent
+	candidate.Candidate.Metadata = rejectedParsed.Metadata
+	encodedCandidate, err = json.Marshal(candidate)
+	if err != nil {
+		t.Fatalf("marshal rejected candidate: %v", err)
+	}
+	if err := os.WriteFile(candidatePath, encodedCandidate, 0o644); err != nil {
+		t.Fatalf("write rejected candidate: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "import", "--home", home, "--file", candidatePath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt import rejected exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "imported pending candidate planner@v3") {
+		t.Fatalf("second import stdout = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "candidate", "reject", "--home", home, "planner@v3", "--reason", "too verbose"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt candidate reject exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "rejected candidate planner@v3") {
+		t.Fatalf("candidate reject stdout = %q", stdout.String())
+	}
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open after reject returned error: %v", err)
+	}
+	defer store.Close()
+	rejected, err := store.GetAgentTemplateVersionByID(context.Background(), "planner@v3")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID rejected returned error: %v", err)
+	}
+	if rejected.State != "rejected" {
+		t.Fatalf("rejected = %+v", rejected)
+	}
+	rejectedReview, err := store.GetAgentTemplateCandidateReview(context.Background(), "planner@v3")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview rejected returned error: %v", err)
+	}
+	if rejectedReview.DecisionReason != "too verbose" {
+		t.Fatalf("rejected review = %+v", rejectedReview)
+	}
+	latest, err = store.GetAgentTemplateReference(context.Background(), "planner@latest")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateReference latest after reject returned error: %v", err)
+	}
+	if latest.VersionID != "planner@v2" {
+		t.Fatalf("latest after reject = %+v", latest)
+	}
 	events, err := store.ListFeedbackEvents(context.Background(), "run-1")
 	if err != nil {
 		t.Fatalf("ListFeedbackEvents returned error: %v", err)
@@ -189,6 +281,10 @@ items:
 	if len(events) != 1 || events[0].Choice != "a" {
 		t.Fatalf("feedback events = %+v", events)
 	}
+}
+
+func floatPtr(value float64) *float64 {
+	return &value
 }
 
 func TestSkillOptFeedbackRejectsIncompleteCommands(t *testing.T) {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -80,6 +80,22 @@ type AgentTemplateVersion struct {
 	PromotedAt     string
 }
 
+type AgentTemplateCandidateReview struct {
+	VersionID           string
+	TemplateID          string
+	BaseVersionID       string
+	DiffArtifactID      string
+	Score               *float64
+	PreferenceSummary   string
+	EvalReportJSON      string
+	SummaryMetadataJSON string
+	State               string
+	DecisionReason      string
+	CreatedAt           string
+	UpdatedAt           string
+	DecidedAt           string
+}
+
 type AgentRepo struct {
 	AgentName    string
 	RepoFullName string
@@ -728,9 +744,41 @@ func (s *Store) GetAgentTemplateVersion(ctx context.Context, templateID string, 
 	return scanAgentTemplateVersion(row)
 }
 
+func (s *Store) GetAgentTemplateVersionByID(ctx context.Context, versionID string) (AgentTemplateVersion, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
+		FROM agent_template_versions WHERE id = ?`, strings.TrimSpace(versionID))
+	return scanAgentTemplateVersion(row)
+}
+
 func (s *Store) ListAgentTemplateVersions(ctx context.Context, templateID string) ([]AgentTemplateVersion, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
 		FROM agent_template_versions WHERE template_id = ? ORDER BY version`, templateID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	versions := []AgentTemplateVersion{}
+	for rows.Next() {
+		version, err := scanAgentTemplateVersion(rows)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, version)
+	}
+	return versions, rows.Err()
+}
+
+func (s *Store) ListPendingAgentTemplateVersions(ctx context.Context, templateID string) ([]AgentTemplateVersion, error) {
+	templateID = strings.TrimSpace(templateID)
+	query := `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
+		FROM agent_template_versions WHERE state = 'pending'`
+	args := []any{}
+	if templateID != "" {
+		query += ` AND template_id = ?`
+		args = append(args, templateID)
+	}
+	query += ` ORDER BY template_id, version`
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -774,6 +822,138 @@ func (s *Store) AddPendingAgentTemplateVersion(ctx context.Context, template Age
 		return AgentTemplateVersion{}, err
 	}
 	return s.GetAgentTemplateVersion(ctx, template.ID, fmt.Sprintf("v%d", versionNumber))
+}
+
+func (s *Store) UpsertAgentTemplateCandidateReview(ctx context.Context, review AgentTemplateCandidateReview) error {
+	if strings.TrimSpace(review.VersionID) == "" {
+		return errors.New("candidate review version id is required")
+	}
+	if strings.TrimSpace(review.TemplateID) == "" {
+		return errors.New("candidate review template id is required")
+	}
+	if strings.TrimSpace(review.State) == "" {
+		review.State = "pending"
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO agent_template_candidate_reviews(
+			version_id, template_id, base_version_id, diff_artifact_id, score, preference_summary,
+			eval_report_json, summary_metadata_json, state, decision_reason, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(version_id) DO UPDATE SET
+			template_id = excluded.template_id,
+			base_version_id = excluded.base_version_id,
+			diff_artifact_id = excluded.diff_artifact_id,
+			score = excluded.score,
+			preference_summary = excluded.preference_summary,
+			eval_report_json = excluded.eval_report_json,
+			summary_metadata_json = excluded.summary_metadata_json,
+			state = excluded.state,
+			decision_reason = excluded.decision_reason,
+			updated_at = CURRENT_TIMESTAMP`,
+		strings.TrimSpace(review.VersionID),
+		strings.TrimSpace(review.TemplateID),
+		strings.TrimSpace(review.BaseVersionID),
+		strings.TrimSpace(review.DiffArtifactID),
+		review.Score,
+		strings.TrimSpace(review.PreferenceSummary),
+		strings.TrimSpace(review.EvalReportJSON),
+		strings.TrimSpace(review.SummaryMetadataJSON),
+		strings.TrimSpace(review.State),
+		strings.TrimSpace(review.DecisionReason))
+	return err
+}
+
+func (s *Store) GetAgentTemplateCandidateReview(ctx context.Context, versionID string) (AgentTemplateCandidateReview, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT version_id, template_id, base_version_id, diff_artifact_id, score, preference_summary,
+			eval_report_json, summary_metadata_json, state, decision_reason, created_at, updated_at, decided_at
+		FROM agent_template_candidate_reviews WHERE version_id = ?`, strings.TrimSpace(versionID))
+	return scanAgentTemplateCandidateReview(row)
+}
+
+func (s *Store) PromoteAgentTemplateVersion(ctx context.Context, versionID string) (AgentTemplateVersion, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	defer tx.Rollback()
+	target, err := getAgentTemplateVersionByIDTx(ctx, tx, versionID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if target.State != "pending" {
+		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not pending", target.ID, target.State)
+	}
+	current, hasCurrent, err := getCurrentAgentTemplateVersion(ctx, tx, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if hasCurrent {
+		if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'superseded', updated_at = CURRENT_TIMESTAMP WHERE id = ?`, current.ID); err != nil {
+			return AgentTemplateVersion{}, err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'current', promoted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, target.ID); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	latestID, err := latestSelectableVersionID(ctx, tx, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET
+			name = ?, description = ?, source_repo = ?, source_ref = ?, source_path = ?, resolved_commit = ?,
+			content = ?, metadata_json = ?, current_version_id = ?, latest_version_id = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?`,
+		target.Name, target.Description, target.SourceRepo, target.SourceRef, target.SourcePath, target.ResolvedCommit,
+		target.Content, target.MetadataJSON, target.ID, latestID, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := requireAffected(result, "agent template", target.TemplateID); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := upsertAgentTemplateCandidateReviewDecisionTx(ctx, tx, target, "promoted", ""); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	return s.GetAgentTemplateVersionByID(ctx, target.ID)
+}
+
+func (s *Store) RejectAgentTemplateVersion(ctx context.Context, versionID string, reason string) (AgentTemplateVersion, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	defer tx.Rollback()
+	target, err := getAgentTemplateVersionByIDTx(ctx, tx, versionID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if target.State != "pending" {
+		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not pending", target.ID, target.State)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'rejected', updated_at = CURRENT_TIMESTAMP WHERE id = ?`, target.ID); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	latestID, err := latestSelectableVersionID(ctx, tx, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET latest_version_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, latestID, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := requireAffected(result, "agent template", target.TemplateID); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := upsertAgentTemplateCandidateReviewDecisionTx(ctx, tx, target, "rejected", reason); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	return s.GetAgentTemplateVersionByID(ctx, target.ID)
 }
 
 func (s *Store) AgentCanAccessRepo(ctx context.Context, agentName string, repoFullName string) (bool, error) {
@@ -1982,6 +2162,18 @@ func scanAgentTemplateVersion(scanner agentTemplateScanner) (AgentTemplateVersio
 	return version, nil
 }
 
+func scanAgentTemplateCandidateReview(scanner agentTemplateScanner) (AgentTemplateCandidateReview, error) {
+	var review AgentTemplateCandidateReview
+	var score sql.NullFloat64
+	if err := scanner.Scan(&review.VersionID, &review.TemplateID, &review.BaseVersionID, &review.DiffArtifactID, &score, &review.PreferenceSummary, &review.EvalReportJSON, &review.SummaryMetadataJSON, &review.State, &review.DecisionReason, &review.CreatedAt, &review.UpdatedAt, &review.DecidedAt); err != nil {
+		return AgentTemplateCandidateReview{}, err
+	}
+	if score.Valid {
+		review.Score = &score.Float64
+	}
+	return review, nil
+}
+
 func agentTemplateFromVersion(version AgentTemplateVersion) AgentTemplate {
 	return AgentTemplate{
 		ID:             version.TemplateID,
@@ -2026,6 +2218,37 @@ func getCurrentAgentTemplateVersion(ctx context.Context, tx *sql.Tx, templateID 
 		return AgentTemplateVersion{}, false, err
 	}
 	return version, true, nil
+}
+
+func getAgentTemplateVersionByIDTx(ctx context.Context, tx *sql.Tx, versionID string) (AgentTemplateVersion, error) {
+	row := tx.QueryRowContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
+		FROM agent_template_versions WHERE id = ?`, strings.TrimSpace(versionID))
+	return scanAgentTemplateVersion(row)
+}
+
+func latestSelectableVersionID(ctx context.Context, tx *sql.Tx, templateID string) (string, error) {
+	var id string
+	err := tx.QueryRowContext(ctx, `SELECT id FROM agent_template_versions
+		WHERE template_id = ? AND state IN ('current', 'pending')
+		ORDER BY version DESC LIMIT 1`, templateID).Scan(&id)
+	return id, err
+}
+
+func upsertAgentTemplateCandidateReviewDecisionTx(ctx context.Context, tx *sql.Tx, version AgentTemplateVersion, state string, reason string) error {
+	_, err := tx.ExecContext(ctx, `INSERT INTO agent_template_candidate_reviews(
+			version_id, template_id, state, decision_reason, decided_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(version_id) DO UPDATE SET
+			state = excluded.state,
+			decision_reason = excluded.decision_reason,
+			decided_at = CURRENT_TIMESTAMP,
+			updated_at = CURRENT_TIMESTAMP`,
+		version.ID,
+		version.TemplateID,
+		strings.TrimSpace(state),
+		strings.TrimSpace(reason))
+	return err
 }
 
 func nextAgentTemplateVersionNumber(ctx context.Context, tx *sql.Tx, templateID string) (int, error) {
@@ -2374,6 +2597,23 @@ CREATE TABLE feedback_events (
 	source_url TEXT NOT NULL DEFAULT '',
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	UNIQUE(run_id, item_id, reviewer, source, source_url)
+);
+	`,
+	`
+CREATE TABLE agent_template_candidate_reviews (
+	version_id TEXT PRIMARY KEY,
+	template_id TEXT NOT NULL,
+	base_version_id TEXT NOT NULL DEFAULT '',
+	diff_artifact_id TEXT NOT NULL DEFAULT '',
+	score REAL,
+	preference_summary TEXT NOT NULL DEFAULT '',
+	eval_report_json TEXT NOT NULL DEFAULT '',
+	summary_metadata_json TEXT NOT NULL DEFAULT '',
+	state TEXT NOT NULL DEFAULT 'pending',
+	decision_reason TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	decided_at TEXT NOT NULL DEFAULT ''
 );
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -634,11 +634,155 @@ func TestRepositoryMethods(t *testing.T) {
 	if pinned.VersionID != "thermo@v1" || pinned.Content != "Review deeply." {
 		t.Fatalf("pinned template = %+v", pinned)
 	}
+	score := 0.82
+	if err := store.UpsertAgentTemplateCandidateReview(ctx, AgentTemplateCandidateReview{
+		VersionID:         pending.ID,
+		TemplateID:        pending.TemplateID,
+		BaseVersionID:     current.VersionID,
+		DiffArtifactID:    "diff-1",
+		Score:             &score,
+		PreferenceSummary: "Candidate is more actionable.",
+		EvalReportJSON:    `{"score":0.82}`,
+		State:             "pending",
+	}); err != nil {
+		t.Fatalf("UpsertAgentTemplateCandidateReview returned error: %v", err)
+	}
+	review, err := store.GetAgentTemplateCandidateReview(ctx, pending.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview returned error: %v", err)
+	}
+	if review.BaseVersionID != current.VersionID || review.Score == nil || *review.Score != score || review.PreferenceSummary == "" {
+		t.Fatalf("review = %+v", review)
+	}
+	newerPending, err := store.AddPendingAgentTemplateVersion(ctx, AgentTemplate{
+		ID:             "thermo",
+		Name:           "Thermo Candidate 2",
+		Description:    "Candidate review",
+		SourceRepo:     "local",
+		SourceRef:      "candidate",
+		SourcePath:     "candidate-2.md",
+		ResolvedCommit: "sha256:candidate2",
+		Content:        "Newer pending instructions.",
+		MetadataJSON:   `{"id":"thermo","name":"Thermo Candidate","description":"Candidate review","kind":"agent-template","version":1,"capabilities":["review"],"runtime_compatibility":["codex"],"tags":["review"],"inputs":["repo"],"outputs":["review_findings"]}`,
+	})
+	if err != nil {
+		t.Fatalf("AddPendingAgentTemplateVersion newer candidate returned error: %v", err)
+	}
+	pendingVersions, err := store.ListPendingAgentTemplateVersions(ctx, "thermo")
+	if err != nil {
+		t.Fatalf("ListPendingAgentTemplateVersions returned error: %v", err)
+	}
+	if len(pendingVersions) != 2 || pendingVersions[0].ID != pending.ID || pendingVersions[1].ID != newerPending.ID {
+		t.Fatalf("pending versions = %+v", pendingVersions)
+	}
+	promoted, err := store.PromoteAgentTemplateVersion(ctx, pending.ID)
+	if err != nil {
+		t.Fatalf("PromoteAgentTemplateVersion returned error: %v", err)
+	}
+	if promoted.State != "current" || promoted.PromotedAt == "" {
+		t.Fatalf("promoted = %+v", promoted)
+	}
+	currentAfterPromote, err := store.GetAgentTemplate(ctx, "thermo")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate after promote returned error: %v", err)
+	}
+	if currentAfterPromote.VersionID != pending.ID || currentAfterPromote.Content != "Candidate instructions." {
+		t.Fatalf("current after promote = %+v", currentAfterPromote)
+	}
+	latestAfterPromote, err := store.GetAgentTemplateReference(ctx, "thermo@latest")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateReference latest after promote returned error: %v", err)
+	}
+	if latestAfterPromote.VersionID != newerPending.ID || latestAfterPromote.VersionState != "pending" {
+		t.Fatalf("latest after promote = %+v", latestAfterPromote)
+	}
+	review, err = store.GetAgentTemplateCandidateReview(ctx, pending.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview after promote returned error: %v", err)
+	}
+	if review.State != "promoted" || review.DecidedAt == "" {
+		t.Fatalf("review after promote = %+v", review)
+	}
+	rejected, err := store.RejectAgentTemplateVersion(ctx, newerPending.ID, "too verbose")
+	if err != nil {
+		t.Fatalf("RejectAgentTemplateVersion returned error: %v", err)
+	}
+	if rejected.State != "rejected" {
+		t.Fatalf("rejected = %+v", rejected)
+	}
+	latestAfterReject, err := store.GetAgentTemplateReference(ctx, "thermo@latest")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateReference latest after reject returned error: %v", err)
+	}
+	if latestAfterReject.VersionID != pending.ID || latestAfterReject.VersionState == "rejected" {
+		t.Fatalf("latest selected rejected candidate: %+v", latestAfterReject)
+	}
+	rejectReview, err := store.GetAgentTemplateCandidateReview(ctx, newerPending.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview reject returned error: %v", err)
+	}
+	if rejectReview.State != "rejected" || rejectReview.DecisionReason != "too verbose" || rejectReview.DecidedAt == "" {
+		t.Fatalf("reject review = %+v", rejectReview)
+	}
+	if err := store.UpsertAgentTemplate(ctx, AgentTemplate{
+		ID:             "outoforder",
+		Name:           "Out Of Order",
+		Description:    "Promotion ordering",
+		SourceRepo:     "local",
+		SourceRef:      "main",
+		SourcePath:     "template.md",
+		ResolvedCommit: "sha256:one",
+		Content:        "Current one.",
+		MetadataJSON:   `{"id":"outoforder","name":"Out Of Order","description":"Promotion ordering","kind":"agent-template","version":1,"capabilities":["ask"],"runtime_compatibility":["codex"],"tags":["planning"],"inputs":["repo"],"outputs":["plan"]}`,
+	}); err != nil {
+		t.Fatalf("UpsertAgentTemplate outoforder returned error: %v", err)
+	}
+	olderPending, err := store.AddPendingAgentTemplateVersion(ctx, AgentTemplate{
+		ID:             "outoforder",
+		Name:           "Out Of Order Pending",
+		Description:    "Promotion ordering",
+		SourceRepo:     "local",
+		SourceRef:      "candidate",
+		SourcePath:     "candidate.md",
+		ResolvedCommit: "sha256:pending",
+		Content:        "Older pending candidate.",
+		MetadataJSON:   `{"id":"outoforder","name":"Out Of Order Pending","description":"Promotion ordering","kind":"agent-template","version":1,"capabilities":["ask"],"runtime_compatibility":["codex"],"tags":["planning"],"inputs":["repo"],"outputs":["plan"]}`,
+	})
+	if err != nil {
+		t.Fatalf("AddPendingAgentTemplateVersion outoforder returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(ctx, AgentTemplate{
+		ID:             "outoforder",
+		Name:           "Out Of Order New Current",
+		Description:    "Promotion ordering",
+		SourceRepo:     "local",
+		SourceRef:      "main",
+		SourcePath:     "template.md",
+		ResolvedCommit: "sha256:three",
+		Content:        "Newer current version.",
+		MetadataJSON:   `{"id":"outoforder","name":"Out Of Order New Current","description":"Promotion ordering","kind":"agent-template","version":1,"capabilities":["ask"],"runtime_compatibility":["codex"],"tags":["planning"],"inputs":["repo"],"outputs":["plan"]}`,
+	}); err != nil {
+		t.Fatalf("UpsertAgentTemplate outoforder newer returned error: %v", err)
+	}
+	promotedOutOfOrder, err := store.PromoteAgentTemplateVersion(ctx, olderPending.ID)
+	if err != nil {
+		t.Fatalf("PromoteAgentTemplateVersion outoforder returned error: %v", err)
+	}
+	if promotedOutOfOrder.ID != olderPending.ID || promotedOutOfOrder.State != "current" {
+		t.Fatalf("promoted outoforder = %+v", promotedOutOfOrder)
+	}
+	latestOutOfOrder, err := store.GetAgentTemplateReference(ctx, "outoforder@latest")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateReference outoforder latest returned error: %v", err)
+	}
+	if latestOutOfOrder.VersionID != olderPending.ID || latestOutOfOrder.VersionState == "superseded" {
+		t.Fatalf("outoforder latest selected wrong version: %+v", latestOutOfOrder)
+	}
 	templates, err := store.ListAgentTemplates(ctx)
 	if err != nil {
 		t.Fatalf("ListAgentTemplates returned error: %v", err)
 	}
-	if len(templates) != 1 || templates[0].ID != "thermo" {
+	if len(templates) != 2 || templates[0].ID != "outoforder" || templates[1].ID != "thermo" {
 		t.Fatalf("templates = %+v", templates)
 	}
 	if err := store.UpsertAgent(ctx, Agent{Name: "audit", Role: "reviewer", Runtime: "codex", RuntimeRef: "session", RepoScope: "jerryfane/gitmoot", TemplateID: "thermo", Capabilities: []string{"review"}, AutonomyPolicy: "auto", HealthStatus: "ok"}); err != nil {

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -1,6 +1,7 @@
 package skillopt
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -183,6 +184,11 @@ func ImportCandidatePackage(ctx context.Context, store *db.Store, candidate Cand
 	if err := validateCandidatePackage(ctx, store, candidate); err != nil {
 		return db.AgentTemplateVersion{}, err
 	}
+	templateID := strings.TrimSpace(candidate.TemplateID)
+	baseVersionID, err := candidateBaseVersionID(ctx, store, templateID, candidate.BaseVersionID)
+	if err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
 	metadataJSON, err := agenttemplate.MarshalMetadata(candidate.Candidate.Metadata)
 	if err != nil {
 		return db.AgentTemplateVersion{}, err
@@ -192,7 +198,7 @@ func ImportCandidatePackage(ctx context.Context, store *db.Store, candidate Cand
 		sourcePath = "candidate-package.json"
 	}
 	template := db.AgentTemplate{
-		ID:             strings.TrimSpace(candidate.TemplateID),
+		ID:             templateID,
 		Name:           candidate.Candidate.Metadata.Name,
 		Description:    candidate.Candidate.Metadata.Description,
 		SourceRepo:     CandidateSourceRepo,
@@ -202,7 +208,51 @@ func ImportCandidatePackage(ctx context.Context, store *db.Store, candidate Cand
 		Content:        candidate.Candidate.Content,
 		MetadataJSON:   metadataJSON,
 	}
-	return store.AddPendingAgentTemplateVersion(ctx, template)
+	version, err := store.AddPendingAgentTemplateVersion(ctx, template)
+	if err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
+	evalReportJSON, err := rawMessageStorage(candidate.EvalReport)
+	if err != nil {
+		return db.AgentTemplateVersion{}, fmt.Errorf("candidate eval_report: %w", err)
+	}
+	summaryMetadataJSON, err := rawMessageStorage(candidate.Summary.Metadata)
+	if err != nil {
+		return db.AgentTemplateVersion{}, fmt.Errorf("candidate summary metadata: %w", err)
+	}
+	if err := store.UpsertAgentTemplateCandidateReview(ctx, db.AgentTemplateCandidateReview{
+		VersionID:           version.ID,
+		TemplateID:          version.TemplateID,
+		BaseVersionID:       baseVersionID,
+		DiffArtifactID:      strings.TrimSpace(candidate.Summary.DiffArtifactID),
+		Score:               candidate.Summary.Score,
+		PreferenceSummary:   strings.TrimSpace(candidate.Summary.PreferenceSummary),
+		EvalReportJSON:      evalReportJSON,
+		SummaryMetadataJSON: summaryMetadataJSON,
+		State:               "pending",
+	}); err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
+	return version, nil
+}
+
+func candidateBaseVersionID(ctx context.Context, store *db.Store, templateID string, baseRef string) (string, error) {
+	baseRef = strings.TrimSpace(baseRef)
+	if baseRef == "" {
+		current, err := store.GetAgentTemplate(ctx, templateID)
+		if err != nil {
+			return "", fmt.Errorf("load current base version for %q: %w", templateID, err)
+		}
+		return current.VersionID, nil
+	}
+	base, err := store.GetAgentTemplateReference(ctx, baseRef)
+	if err != nil {
+		return "", fmt.Errorf("load base version %q: %w", baseRef, err)
+	}
+	if base.ID != templateID {
+		return "", fmt.Errorf("base version %q belongs to template %q, want %q", baseRef, base.ID, templateID)
+	}
+	return base.VersionID, nil
 }
 
 func validateCandidatePackage(ctx context.Context, store *db.Store, candidate CandidatePackage) error {
@@ -232,19 +282,19 @@ func validateCandidatePackage(ctx context.Context, store *db.Store, candidate Ca
 	if !sameMetadata(parsed.Metadata, candidate.Candidate.Metadata) {
 		return errors.New("candidate metadata does not match candidate template frontmatter")
 	}
-	if strings.TrimSpace(candidate.BaseVersionID) != "" {
-		base, err := store.GetAgentTemplateReference(ctx, candidate.BaseVersionID)
-		if err != nil {
-			return fmt.Errorf("load base version %q: %w", candidate.BaseVersionID, err)
-		}
-		if base.ID != templateID {
-			return fmt.Errorf("base version %q belongs to template %q, want %q", candidate.BaseVersionID, base.ID, templateID)
-		}
+	if _, err := candidateBaseVersionID(ctx, store, templateID, candidate.BaseVersionID); err != nil {
+		return err
 	}
 	if strings.TrimSpace(candidate.Summary.DiffArtifactID) != "" {
 		if _, err := store.GetEvalArtifact(ctx, candidate.Summary.DiffArtifactID); err != nil {
 			return fmt.Errorf("load summary diff artifact %q: %w", candidate.Summary.DiffArtifactID, err)
 		}
+	}
+	if _, err := rawMessageStorage(candidate.EvalReport); err != nil {
+		return fmt.Errorf("candidate eval_report: %w", err)
+	}
+	if _, err := rawMessageStorage(candidate.Summary.Metadata); err != nil {
+		return fmt.Errorf("candidate summary metadata: %w", err)
 	}
 	return nil
 }
@@ -358,6 +408,18 @@ func rawJSON(value string) (json.RawMessage, error) {
 		return nil, err
 	}
 	return json.RawMessage(value), nil
+}
+
+func rawMessageStorage(value json.RawMessage) (string, error) {
+	value = bytes.TrimSpace(value)
+	if len(value) == 0 {
+		return "", nil
+	}
+	var compacted bytes.Buffer
+	if err := json.Compact(&compacted, value); err != nil {
+		return "", err
+	}
+	return compacted.String(), nil
 }
 
 func sameMetadata(a agenttemplate.Metadata, b agenttemplate.Metadata) bool {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -129,7 +129,7 @@ func TestImportCandidatePackageCreatesPendingVersion(t *testing.T) {
 		Kind:            CandidatePackageKind,
 		ContractVersion: ContractVersion,
 		TemplateID:      "planner",
-		BaseVersionID:   current.VersionID,
+		BaseVersionID:   "planner@latest",
 		Candidate: CandidateTemplate{
 			Content:  candidateContent,
 			Metadata: parsed.Metadata,
@@ -160,6 +160,13 @@ func TestImportCandidatePackageCreatesPendingVersion(t *testing.T) {
 	}
 	if latest.VersionID != version.ID || latest.Content != candidateContent {
 		t.Fatalf("latest template = %+v", latest)
+	}
+	review, err := store.GetAgentTemplateCandidateReview(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview returned error: %v", err)
+	}
+	if review.BaseVersionID != current.VersionID || review.DiffArtifactID != "candidate-diff" || review.PreferenceSummary != "Candidate is more actionable." || review.EvalReportJSON != `{"score":0.82}` {
+		t.Fatalf("candidate review = %+v", review)
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -258,6 +258,10 @@ gitmoot lock show owner/repo <branch>
 ```sh
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt candidate list [--template id]
+gitmoot skillopt candidate show <version-id>
+gitmoot skillopt candidate promote <version-id>
+gitmoot skillopt candidate reject <version-id> [--reason text]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
@@ -268,10 +272,16 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 eval run, review items, artifact manifests, feedback events when present, and
 evaluator config. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate
-automatically. The Markdown feedback collector writes blind A/B review packets
-with `index.md`, per-item Markdown files, editable `feedback.yml`, and hidden
-assignment metadata that Gitmoot uses to validate the full response and import
-de-blinded canonical feedback events.
+automatically. `skillopt candidate show` displays candidate metadata, eval
+report JSON, preference summary, and a content diff against the base/current
+version. `skillopt candidate promote` makes a pending candidate current, while
+`skillopt candidate reject` records an auditable rejection and prevents that
+version from being selected by `@latest`.
+
+The Markdown feedback collector writes blind A/B review packets with `index.md`,
+per-item Markdown files, editable `feedback.yml`, and hidden assignment metadata
+that Gitmoot uses to validate the full response and import de-blinded canonical
+feedback events.
 
 The GitHub feedback collector publishes the same blind A/B review packet to a
 new issue by default, or to an existing PR when `--pr <number>` is provided.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -62,6 +62,10 @@ gitmoot lock list --repo owner/repo
 ```sh
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt candidate list [--template id]
+gitmoot skillopt candidate show <version-id>
+gitmoot skillopt candidate promote <version-id>
+gitmoot skillopt candidate reject <version-id> [--reason text]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -28,6 +28,17 @@ frontmatter, matching metadata, an optional eval report, and an optional summary
 Importing stores the candidate as a pending template version and never promotes
 it automatically.
 
+```sh
+gitmoot skillopt candidate list --template planner
+gitmoot skillopt candidate show planner@v2
+gitmoot skillopt candidate promote planner@v2
+gitmoot skillopt candidate reject planner@v3 --reason "Too broad"
+```
+
+`candidate show` includes the eval report, preference summary, and content diff.
+Promotion updates the current template version; rejection records an audit reason
+and keeps the rejected version out of `@latest`.
+
 ## Markdown Feedback Packet
 
 ```sh
@@ -91,3 +102,7 @@ gitmoot skillopt feedback github sync \
 
 For PR comment mode, sync with `--pr <number>`. Gitmoot ignores unrelated
 comments and de-duplicates repeated imports by GitHub comment URL.
+
+The complete review loop is: import a candidate, collect feedback with either
+the Markdown packet or GitHub collector, inspect the candidate with
+`gitmoot skillopt candidate show <version-id>`, then promote or reject it.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -285,6 +285,10 @@ gitmoot lock release owner/repo <branch> --owner <agent>
 ```sh
 gitmoot skillopt export --run <run-id> --output training.json
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt candidate list [--template id]
+gitmoot skillopt candidate show <version-id>
+gitmoot skillopt candidate promote <version-id>
+gitmoot skillopt candidate reject <version-id> [--reason text]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
@@ -294,6 +298,9 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 The export/import boundary lets a future external `gitmoot-skillopt` optimizer
 train on local eval artifacts and return candidate template versions. Imported
 candidates stay pending until a human review workflow promotes them.
+Use `skillopt candidate show` to inspect the candidate metadata, eval report,
+feedback summary, and content diff before `promote` or `reject` records the
+decision.
 
 Use the GitHub feedback collector when review should happen in an issue or an
 existing PR thread. Reviewers can reply with either the copy-paste YAML block or
@@ -481,6 +488,10 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt candidate list [--template id]
+gitmoot skillopt candidate show <version-id>
+gitmoot skillopt candidate promote <version-id>
+gitmoot skillopt candidate reject <version-id> [--reason text]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
@@ -2858,6 +2869,10 @@ gitmoot lock show owner/repo <branch>
 ```sh
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json
+gitmoot skillopt candidate list [--template id]
+gitmoot skillopt candidate show <version-id>
+gitmoot skillopt candidate promote <version-id>
+gitmoot skillopt candidate reject <version-id> [--reason text]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
@@ -2868,10 +2883,16 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 eval run, review items, artifact manifests, feedback events when present, and
 evaluator config. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate
-automatically. The Markdown feedback collector writes blind A/B review packets
-with `index.md`, per-item Markdown files, editable `feedback.yml`, and hidden
-assignment metadata that Gitmoot uses to validate the full response and import
-de-blinded canonical feedback events.
+automatically. `skillopt candidate show` displays candidate metadata, eval
+report JSON, preference summary, and a content diff against the base/current
+version. `skillopt candidate promote` makes a pending candidate current, while
+`skillopt candidate reject` records an auditable rejection and prevents that
+version from being selected by `@latest`.
+
+The Markdown feedback collector writes blind A/B review packets with `index.md`,
+per-item Markdown files, editable `feedback.yml`, and hidden assignment metadata
+that Gitmoot uses to validate the full response and import de-blinded canonical
+feedback events.
 
 The GitHub feedback collector publishes the same blind A/B review packet to a
 new issue by default, or to an existing PR when `--pr <number>` is provided.


### PR DESCRIPTION
WHAT
- Added the SkillOpt candidate review workflow for listing, inspecting, promoting, and rejecting pending template candidate versions.

WHY
- Imported SkillOpt candidates must remain pending until a human can inspect diffs, eval summaries, feedback summaries, and review artifacts before deciding whether to promote or reject them.

CHANGES
- Added candidate review persistence, promotion/rejection state transitions, and audit rows in SQLite.
- Stored concrete base version references, eval report metadata, scores, feedback summaries, and diff artifact links during candidate import.
- Added `gitmoot skillopt candidate list/show/promote/reject` CLI commands, including documented reject reason parsing.
- Updated focused DB, contract, and CLI tests for promotion, rejection, latest/current pointer behavior, and base-version pinning.
- Updated README, SKILL.md, skill CLI reference, exchange contract docs, website docs, and generated LLM docs.

RESULTS
- `/root/temp/ts/tool/go fmt ./internal/skillopt ./internal/db ./internal/cli`
- `/root/temp/ts/tool/go test ./internal/skillopt ./internal/db ./internal/cli`
- `/root/temp/ts/tool/go test ./...`
- `npm run build` in `website`
- `git diff --check`
- `git diff --cached --check`

Final raw `codex exec review --uncommitted` output for this repo:

```text
No actionable correctness issues were found in the changed code. I could not run the Go tests because the required Go 1.26 toolchain could not be downloaded in this sandbox.
No actionable correctness issues were found in the changed code. I could not run the Go tests because the required Go 1.26 toolchain could not be downloaded in this sandbox.
```

RISK
- `codex exec review --uncommitted` could not run Go tests inside its sandbox because it could not download Go 1.26. Local verification used the repo-compatible Go toolchain at `/root/temp/ts/tool/go` and passed `go test ./...`.
