### PR TITLE
Track live pairwise evaluation follow-up

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -183,3 +183,16 @@ Complete GitHub review path:
 4. `gitmoot skillopt feedback github sync --run <run-id> --repo owner/reviews --issue <number>`
 5. `gitmoot skillopt candidate show <version-id>`
 6. `gitmoot skillopt candidate promote <version-id>` or `gitmoot skillopt candidate reject <version-id>`
+
+## Future Live Pairwise Evaluation
+
+The MVP exchange contract compares candidates against saved baseline outputs.
+This keeps local review deterministic and avoids rerunning every baseline for
+each candidate import.
+
+Future live pairwise mode is tracked in
+[GitHub issue #77](https://github.com/jerryfane/gitmoot/issues/77). That mode
+would run the current promoted template and the pending candidate live for every
+validation item before collecting blind A/B feedback. The tradeoff is more
+faithful comparisons and better protection against stale baseline outputs, at
+the cost of higher latency, token spend, and runtime/session complexity.

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -106,3 +106,13 @@ comments and de-duplicates repeated imports by GitHub comment URL.
 The complete review loop is: import a candidate, collect feedback with either
 the Markdown packet or GitHub collector, inspect the candidate with
 `gitmoot skillopt candidate show <version-id>`, then promote or reject it.
+
+## Future Live Pairwise Evaluation
+
+The MVP compares candidates against saved baseline outputs so local review stays
+deterministic and inexpensive. Future live pairwise evaluation is tracked in
+[GitHub issue #77](https://github.com/jerryfane/gitmoot/issues/77): it would run
+the current promoted template and pending candidate live for every validation
+item before collecting blind A/B feedback. This is more faithful and protects
+against stale baselines, but adds latency, token cost, and runtime/session
+complexity.


### PR DESCRIPTION
WHAT
- Created GitHub issue #77 to track future SkillOpt live pairwise evaluation.
- Linked the follow-up from the SkillOpt exchange contract docs and website reference docs.

WHY
- The goal requires documenting the future live pairwise mode while keeping the MVP on saved baseline outputs.

CHANGES
- Added a Future Live Pairwise Evaluation section to `docs/skillopt-exchange-contract.md`.
- Added the same follow-up note to `website/docs/reference/skillopt-exchange-contract.md`.

RESULTS
- Created issue: https://github.com/jerryfane/gitmoot/issues/77
- `npm run build` in `website`
- `git diff --check`
- `git diff --cached --check`

Final raw `codex exec review --uncommitted` output for this repo:

```text
The changes only add documentation about future live pairwise evaluation and do not appear to break existing behavior or docs structure.
The changes only add documentation about future live pairwise evaluation and do not appear to break existing behavior or docs structure.
```

RISK
- Docs-only change. No code tests were required for this task.
