### PR TITLE
Import SkillOpt candidate artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ gitmoot lock release owner/repo <branch> --owner <agent>
 
 ```sh
 gitmoot skillopt export --run <run-id> --output training.json
-gitmoot skillopt import --file candidate.json
+gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
 gitmoot skillopt candidate show <version-id>
 gitmoot skillopt candidate promote <version-id>
@@ -288,6 +288,9 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 The export/import boundary lets a future external `gitmoot-skillopt` optimizer
 train on local eval artifacts and return candidate template versions. Imported
 candidates stay pending until a human review workflow promotes them.
+When a candidate package includes new artifact manifest entries, pass
+`--artifact-dir` to the directory containing those files; Gitmoot verifies
+relative paths and SHA256 hashes before storing blobs.
 Use `skillopt candidate show` to inspect the candidate metadata, eval report,
 feedback summary, and content diff before `promote` or `reject` records the
 decision.

--- a/SKILL.md
+++ b/SKILL.md
@@ -114,7 +114,7 @@ gitmoot job events <job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 gitmoot skillopt export --run <run-id> [--output training.json]
-gitmoot skillopt import --file candidate.json
+gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
 gitmoot skillopt candidate show <version-id>
 gitmoot skillopt candidate promote <version-id>

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -34,7 +34,7 @@ The export does not copy blobs into the repository by default.
 Import a candidate produced by an external optimizer:
 
 ```sh
-gitmoot skillopt import --file candidate.json
+gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 ```
 
 The imported package must have:
@@ -48,10 +48,17 @@ The imported package must have:
   frontmatter
 - `eval_report`: optional optimizer report
 - `summary`: optional diff, score, and preference summary
+- `artifacts`: optional candidate artifact manifest entries with `id`, relative
+  `path`, SHA256 `hash`, `media_type`, `driver`, and optional `size_bytes`
 
 Importing never promotes a candidate. Gitmoot stores it as a pending template
 version so later review and promotion commands can decide whether it becomes
 current.
+If `artifacts` is present, `--artifact-dir` is required. Gitmoot rejects
+absolute paths, path traversal, missing files, hash mismatches, duplicate
+artifact ids, and invalid `summary.diff_artifact_id` references before creating
+the pending candidate version. Verified blobs are stored in Gitmoot's
+content-addressed artifact store and registered in SQLite.
 
 Review pending candidates:
 
@@ -168,7 +175,7 @@ Complete local review path:
 
 1. `gitmoot skillopt export --run <run-id> --output training.json`
 2. External optimizer returns `candidate.json`.
-3. `gitmoot skillopt import --file candidate.json`
+3. `gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]`
 4. `gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>`
 5. Human fills `feedback.yml`.
 6. `gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>`
@@ -177,7 +184,7 @@ Complete local review path:
 
 Complete GitHub review path:
 
-1. `gitmoot skillopt import --file candidate.json`
+1. `gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]`
 2. `gitmoot skillopt feedback github publish --run <run-id> --repo owner/reviews`
 3. Humans reply in GitHub comments using the run-scoped YAML or short-form block.
 4. `gitmoot skillopt feedback github sync --run <run-id> --repo owner/reviews --issue <number>`

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1172,6 +1172,12 @@ func persistAgentHealth(home, name, status string) error {
 }
 
 func withStore(home string, fn func(*db.Store) error) error {
+	return withStoreAndPaths(home, func(_ config.Paths, store *db.Store) error {
+		return fn(store)
+	})
+}
+
+func withStoreAndPaths(home string, fn func(config.Paths, *db.Store) error) error {
 	paths, err := pathsFromFlag(home)
 	if err != nil {
 		return err
@@ -1184,7 +1190,7 @@ func withStore(home string, fn func(*db.Store) error) error {
 		return err
 	}
 	defer store.Close()
-	return fn(store)
+	return fn(paths, store)
 }
 
 func dbAgent(agent runtime.Agent) db.Agent {

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -49,7 +49,7 @@ func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt export --run <run-id> [--output package.json]")
-	fmt.Fprintln(w, "  gitmoot skillopt import --file candidate.json")
+	fmt.Fprintln(w, "  gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate list [--template id]")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate show <version-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate promote <version-id>")
@@ -115,6 +115,7 @@ func runSkillOptImport(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	file := fs.String("file", "", "candidate package JSON file to import")
+	artifactDir := fs.String("artifact-dir", "", "directory containing candidate package artifacts")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -140,8 +141,12 @@ func runSkillOptImport(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	var versionID string
-	if err := withStore(*home, func(store *db.Store) error {
-		version, err := skillopt.ImportCandidatePackage(context.Background(), store, pkg, *file)
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		version, err := skillopt.ImportCandidatePackageWithOptions(context.Background(), store, pkg, skillopt.CandidateImportOptions{
+			SourcePath:  *file,
+			ArtifactDir: *artifactDir,
+			BlobStore:   artifact.NewStore(paths.ArtifactBlobs),
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -283,6 +283,204 @@ items:
 	}
 }
 
+func TestSkillOptImportCandidateArtifacts(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	artifactDir := t.TempDir()
+	diffContent := []byte("candidate diff\n")
+	diffHash := artifact.ContentHash(diffContent)
+	if err := os.WriteFile(filepath.Join(artifactDir, "candidate.diff.md"), diffContent, 0o644); err != nil {
+		t.Fatalf("write diff artifact: %v", err)
+	}
+	diffSize := int64(len(diffContent))
+	candidate := cliSkillOptCandidatePackage(t, "planner", installed.VersionID, "Plan with a concise risk section.")
+	candidate.Summary.DiffArtifactID = "candidate-diff"
+	candidate.Artifacts = []skillopt.CandidateArtifactRef{{
+		ID:        "candidate-diff",
+		Path:      "candidate.diff.md",
+		Hash:      diffHash,
+		MediaType: "text/markdown",
+		Driver:    "text",
+		SizeBytes: &diffSize,
+	}}
+	candidatePath := filepath.Join(t.TempDir(), "candidate.json")
+	encodedCandidate, err := json.Marshal(candidate)
+	if err != nil {
+		t.Fatalf("marshal candidate: %v", err)
+	}
+	if err := os.WriteFile(candidatePath, encodedCandidate, 0o644); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "import", "--home", home, "--file", candidatePath, "--artifact-dir", artifactDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt import exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "imported pending candidate planner@v2") {
+		t.Fatalf("import stdout = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "candidate", "show", "--home", home, "planner@v2"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt candidate show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "diff_artifact: candidate-diff") {
+		t.Fatalf("candidate show stdout = %q", stdout.String())
+	}
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open after import returned error: %v", err)
+	}
+	defer store.Close()
+	stored, err := store.GetEvalArtifact(context.Background(), "candidate-diff")
+	if err != nil {
+		t.Fatalf("GetEvalArtifact returned error: %v", err)
+	}
+	if stored.Hash != diffHash || stored.SizeBytes != diffSize || stored.MediaType != "text/markdown" {
+		t.Fatalf("stored artifact = %+v", stored)
+	}
+	blobContent, err := artifact.NewStore(paths.ArtifactBlobs).Read(diffHash)
+	if err != nil {
+		t.Fatalf("Read stored artifact returned error: %v", err)
+	}
+	if string(blobContent) != string(diffContent) {
+		t.Fatalf("stored artifact content = %q", string(blobContent))
+	}
+}
+
+func TestSkillOptImportCandidateArtifactFailuresDoNotCreatePendingCandidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		hash        string
+		artifactDir bool
+		writeFile   bool
+		wantErr     string
+	}{
+		{
+			name:        "missing artifact dir",
+			path:        "candidate.diff.md",
+			hash:        artifact.ContentHash([]byte("candidate diff\n")),
+			artifactDir: false,
+			writeFile:   false,
+			wantErr:     "candidate artifacts require --artifact-dir",
+		},
+		{
+			name:        "invalid hash",
+			path:        "candidate.diff.md",
+			hash:        artifact.ContentHash([]byte("other")),
+			artifactDir: true,
+			writeFile:   true,
+			wantErr:     "hash is",
+		},
+		{
+			name:        "path traversal",
+			path:        "../candidate.diff.md",
+			hash:        artifact.ContentHash([]byte("candidate diff\n")),
+			artifactDir: true,
+			writeFile:   false,
+			wantErr:     "relative path inside artifact-dir",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			paths := config.PathsForHome(home)
+			if err := config.Initialize(paths); err != nil {
+				t.Fatalf("Initialize returned error: %v", err)
+			}
+			store, err := db.Open(paths.Database)
+			if err != nil {
+				t.Fatalf("Open returned error: %v", err)
+			}
+			if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+				t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+			}
+			installed, err := store.GetAgentTemplate(context.Background(), "planner")
+			if err != nil {
+				t.Fatalf("GetAgentTemplate returned error: %v", err)
+			}
+			if err := store.Close(); err != nil {
+				t.Fatalf("Close returned error: %v", err)
+			}
+			artifactDir := ""
+			if tt.artifactDir {
+				artifactDir = t.TempDir()
+				if tt.writeFile {
+					if err := os.WriteFile(filepath.Join(artifactDir, "candidate.diff.md"), []byte("candidate diff\n"), 0o644); err != nil {
+						t.Fatalf("write diff artifact: %v", err)
+					}
+				}
+			}
+			candidate := cliSkillOptCandidatePackage(t, "planner", installed.VersionID, "Plan with a concise risk section.")
+			candidate.Summary.DiffArtifactID = "candidate-diff"
+			candidate.Artifacts = []skillopt.CandidateArtifactRef{{
+				ID:        "candidate-diff",
+				Path:      tt.path,
+				Hash:      tt.hash,
+				MediaType: "text/markdown",
+				Driver:    "text",
+			}}
+			candidatePath := filepath.Join(t.TempDir(), "candidate.json")
+			encodedCandidate, err := json.Marshal(candidate)
+			if err != nil {
+				t.Fatalf("marshal candidate: %v", err)
+			}
+			if err := os.WriteFile(candidatePath, encodedCandidate, 0o644); err != nil {
+				t.Fatalf("write candidate: %v", err)
+			}
+			args := []string{"skillopt", "import", "--home", home, "--file", candidatePath}
+			if artifactDir != "" {
+				args = append(args, "--artifact-dir", artifactDir)
+			}
+			var stdout, stderr bytes.Buffer
+			code := Run(args, &stdout, &stderr)
+			if code == 0 {
+				t.Fatalf("skillopt import exit code = 0, stdout=%s", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tt.wantErr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tt.wantErr)
+			}
+			store, err = db.Open(paths.Database)
+			if err != nil {
+				t.Fatalf("Open after failed import returned error: %v", err)
+			}
+			defer store.Close()
+			pending, err := store.ListPendingAgentTemplateVersions(context.Background(), "planner")
+			if err != nil {
+				t.Fatalf("ListPendingAgentTemplateVersions returned error: %v", err)
+			}
+			if len(pending) != 0 {
+				t.Fatalf("pending versions = %+v, want none", pending)
+			}
+			if _, err := store.GetEvalArtifact(context.Background(), "candidate-diff"); err == nil {
+				t.Fatalf("candidate artifact was registered despite failed import")
+			}
+		})
+	}
+}
+
 func floatPtr(value float64) *float64 {
 	return &value
 }
@@ -480,6 +678,29 @@ func cliSkillOptTemplate(id string, body string) db.AgentTemplate {
 		ResolvedCommit: agenttemplate.HashContent(content),
 		Content:        content,
 		MetadataJSON:   metadataJSON,
+	}
+}
+
+func cliSkillOptCandidatePackage(t *testing.T, templateID string, baseVersionID string, body string) skillopt.CandidatePackage {
+	t.Helper()
+	candidateContent := cliSkillOptTemplateContent(templateID, body)
+	parsed, err := agenttemplate.ParseTemplateContent(candidateContent)
+	if err != nil {
+		t.Fatalf("ParseTemplateContent returned error: %v", err)
+	}
+	return skillopt.CandidatePackage{
+		Kind:            skillopt.CandidatePackageKind,
+		ContractVersion: skillopt.ContractVersion,
+		TemplateID:      templateID,
+		BaseVersionID:   baseVersionID,
+		Candidate: skillopt.CandidateTemplate{
+			Content:  candidateContent,
+			Metadata: parsed.Metadata,
+		},
+		EvalReport: json.RawMessage(`{"score":0.82}`),
+		Summary: skillopt.CandidateSummary{
+			PreferenceSummary: "Candidate is more actionable.",
+		},
 	}
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -800,22 +800,8 @@ func (s *Store) AddPendingAgentTemplateVersion(ctx context.Context, template Age
 		return AgentTemplateVersion{}, err
 	}
 	defer tx.Rollback()
-	versionNumber, err := nextAgentTemplateVersionNumber(ctx, tx, template.ID)
+	_, versionNumber, err := addPendingAgentTemplateVersionTx(ctx, tx, template)
 	if err != nil {
-		return AgentTemplateVersion{}, err
-	}
-	versionID := agentTemplateVersionID(template.ID, versionNumber)
-	contentHash := templateContentHash(template.Content)
-	if _, err := tx.ExecContext(ctx, `INSERT INTO agent_template_versions(id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, updated_at)
-		VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
-		versionID, template.ID, versionNumber, template.Name, template.Description, template.SourceRepo, template.SourceRef, template.SourcePath, template.ResolvedCommit, contentHash, template.Content, template.MetadataJSON); err != nil {
-		return AgentTemplateVersion{}, err
-	}
-	result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET latest_version_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, versionID, template.ID)
-	if err != nil {
-		return AgentTemplateVersion{}, err
-	}
-	if err := requireAffected(result, "agent template", template.ID); err != nil {
 		return AgentTemplateVersion{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -824,7 +810,61 @@ func (s *Store) AddPendingAgentTemplateVersion(ctx context.Context, template Age
 	return s.GetAgentTemplateVersion(ctx, template.ID, fmt.Sprintf("v%d", versionNumber))
 }
 
+func (s *Store) AddPendingAgentTemplateCandidate(ctx context.Context, template AgentTemplate, review AgentTemplateCandidateReview, artifacts []EvalArtifact) (AgentTemplateVersion, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	defer tx.Rollback()
+	versionID, versionNumber, err := addPendingAgentTemplateVersionTx(ctx, tx, template)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	for _, artifact := range artifacts {
+		if err := insertEvalArtifactTx(ctx, tx, artifact); err != nil {
+			return AgentTemplateVersion{}, err
+		}
+	}
+	review.VersionID = versionID
+	if strings.TrimSpace(review.TemplateID) == "" {
+		review.TemplateID = template.ID
+	}
+	if err := insertAgentTemplateCandidateReviewTx(ctx, tx, review); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	return s.GetAgentTemplateVersion(ctx, template.ID, fmt.Sprintf("v%d", versionNumber))
+}
+
+func addPendingAgentTemplateVersionTx(ctx context.Context, tx *sql.Tx, template AgentTemplate) (string, int, error) {
+	versionNumber, err := nextAgentTemplateVersionNumber(ctx, tx, template.ID)
+	if err != nil {
+		return "", 0, err
+	}
+	versionID := agentTemplateVersionID(template.ID, versionNumber)
+	contentHash := templateContentHash(template.Content)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO agent_template_versions(id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, updated_at)
+		VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		versionID, template.ID, versionNumber, template.Name, template.Description, template.SourceRepo, template.SourceRef, template.SourcePath, template.ResolvedCommit, contentHash, template.Content, template.MetadataJSON); err != nil {
+		return "", 0, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET latest_version_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, versionID, template.ID)
+	if err != nil {
+		return "", 0, err
+	}
+	if err := requireAffected(result, "agent template", template.ID); err != nil {
+		return "", 0, err
+	}
+	return versionID, versionNumber, nil
+}
+
 func (s *Store) UpsertAgentTemplateCandidateReview(ctx context.Context, review AgentTemplateCandidateReview) error {
+	return upsertAgentTemplateCandidateReview(ctx, s.db, review)
+}
+
+func upsertAgentTemplateCandidateReview(ctx context.Context, execer sqlExecer, review AgentTemplateCandidateReview) error {
 	if strings.TrimSpace(review.VersionID) == "" {
 		return errors.New("candidate review version id is required")
 	}
@@ -834,7 +874,7 @@ func (s *Store) UpsertAgentTemplateCandidateReview(ctx context.Context, review A
 	if strings.TrimSpace(review.State) == "" {
 		review.State = "pending"
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO agent_template_candidate_reviews(
+	_, err := execer.ExecContext(ctx, `INSERT INTO agent_template_candidate_reviews(
 			version_id, template_id, base_version_id, diff_artifact_id, score, preference_summary,
 			eval_report_json, summary_metadata_json, state, decision_reason, updated_at
 		)
@@ -861,6 +901,10 @@ func (s *Store) UpsertAgentTemplateCandidateReview(ctx context.Context, review A
 		strings.TrimSpace(review.State),
 		strings.TrimSpace(review.DecisionReason))
 	return err
+}
+
+func insertAgentTemplateCandidateReviewTx(ctx context.Context, tx *sql.Tx, review AgentTemplateCandidateReview) error {
+	return upsertAgentTemplateCandidateReview(ctx, tx, review)
 }
 
 func (s *Store) GetAgentTemplateCandidateReview(ctx context.Context, versionID string) (AgentTemplateCandidateReview, error) {
@@ -1595,16 +1639,11 @@ func (s *Store) ListJobEvents(ctx context.Context, jobID string) ([]JobEvent, er
 }
 
 func (s *Store) UpsertEvalArtifact(ctx context.Context, artifact EvalArtifact) error {
-	if strings.TrimSpace(artifact.ID) == "" {
-		artifact.ID = artifact.Hash
+	artifact, err := normalizeEvalArtifact(artifact)
+	if err != nil {
+		return err
 	}
-	if strings.TrimSpace(artifact.Hash) == "" {
-		return errors.New("eval artifact hash is required")
-	}
-	if artifact.SizeBytes < 0 {
-		return errors.New("eval artifact size cannot be negative")
-	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO eval_artifacts(id, hash, media_type, size_bytes, driver, created_at)
+	_, err = s.db.ExecContext(ctx, `INSERT INTO eval_artifacts(id, hash, media_type, size_bytes, driver, created_at)
 		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			hash = excluded.hash,
@@ -1613,6 +1652,34 @@ func (s *Store) UpsertEvalArtifact(ctx context.Context, artifact EvalArtifact) e
 			driver = excluded.driver`,
 		artifact.ID, artifact.Hash, artifact.MediaType, artifact.SizeBytes, artifact.Driver)
 	return err
+}
+
+func insertEvalArtifactTx(ctx context.Context, tx *sql.Tx, artifact EvalArtifact) error {
+	artifact, err := normalizeEvalArtifact(artifact)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO eval_artifacts(id, hash, media_type, size_bytes, driver, created_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		artifact.ID, artifact.Hash, artifact.MediaType, artifact.SizeBytes, artifact.Driver)
+	return err
+}
+
+func normalizeEvalArtifact(artifact EvalArtifact) (EvalArtifact, error) {
+	if strings.TrimSpace(artifact.ID) == "" {
+		artifact.ID = artifact.Hash
+	}
+	if strings.TrimSpace(artifact.Hash) == "" {
+		return EvalArtifact{}, errors.New("eval artifact hash is required")
+	}
+	if artifact.SizeBytes < 0 {
+		return EvalArtifact{}, errors.New("eval artifact size cannot be negative")
+	}
+	artifact.ID = strings.TrimSpace(artifact.ID)
+	artifact.Hash = strings.TrimSpace(artifact.Hash)
+	artifact.MediaType = strings.TrimSpace(artifact.MediaType)
+	artifact.Driver = strings.TrimSpace(artifact.Driver)
+	return artifact, nil
 }
 
 func (s *Store) GetEvalArtifact(ctx context.Context, id string) (EvalArtifact, error) {

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1086,6 +1087,79 @@ func TestRepositoryMethods(t *testing.T) {
 	}
 	if removed {
 		t.Fatal("second RemoveAgent removed missing agent")
+	}
+}
+
+func TestAddPendingAgentTemplateCandidateRollsBackArtifacts(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := AgentTemplate{
+		ID:             "planner",
+		Name:           "Planner",
+		Description:    "Plans work",
+		SourceRepo:     "local",
+		SourceRef:      "current",
+		SourcePath:     "planner.md",
+		ResolvedCommit: "abc123",
+		Content:        "Plan carefully.",
+		MetadataJSON:   `{"id":"planner","name":"Planner","description":"Plans work","kind":"agent-template","version":1,"capabilities":["ask"],"runtime_compatibility":["codex"],"tags":["planning"],"inputs":["task"],"outputs":["plan"]}`,
+	}
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	current, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	_, err = store.AddPendingAgentTemplateCandidate(ctx, AgentTemplate{
+		ID:             "planner",
+		Name:           "Planner Candidate",
+		Description:    "Plans work",
+		SourceRepo:     "gitmoot-skillopt",
+		SourceRef:      "candidate",
+		SourcePath:     "candidate.json",
+		ResolvedCommit: "def456",
+		Content:        "Plan carefully with risks.",
+		MetadataJSON:   template.MetadataJSON,
+	}, AgentTemplateCandidateReview{
+		TemplateID:     "planner",
+		BaseVersionID:  current.VersionID,
+		DiffArtifactID: "candidate-diff",
+		State:          "pending",
+	}, []EvalArtifact{
+		{ID: "candidate-diff", Hash: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", MediaType: "text/markdown", SizeBytes: 10, Driver: "text"},
+		{ID: "candidate-diff", Hash: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", MediaType: "text/markdown", SizeBytes: 11, Driver: "text"},
+	})
+	if err == nil {
+		t.Fatal("AddPendingAgentTemplateCandidate returned nil error for duplicate artifact ids")
+	}
+	if _, err := store.GetEvalArtifact(ctx, "candidate-diff"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetEvalArtifact after rollback error = %v, want sql.ErrNoRows", err)
+	}
+	pending, err := store.ListPendingAgentTemplateVersions(ctx, "planner")
+	if err != nil {
+		t.Fatalf("ListPendingAgentTemplateVersions returned error: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending versions = %+v, want none", pending)
+	}
+	after, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate after rollback returned error: %v", err)
+	}
+	if after.VersionID != current.VersionID {
+		t.Fatalf("template changed after rollback: before=%+v after=%+v", current, after)
+	}
+	latest, err := store.GetAgentTemplateReference(ctx, "planner@latest")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateReference latest after rollback returned error: %v", err)
+	}
+	if latest.VersionID != current.VersionID {
+		t.Fatalf("latest template changed after rollback: latest=%+v current=%+v", latest, current)
 	}
 }
 

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -7,10 +7,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/db"
 )
 
@@ -100,14 +103,30 @@ type CandidateSummary struct {
 	Metadata          json.RawMessage `json:"metadata,omitempty"`
 }
 
+type CandidateArtifactRef struct {
+	ID        string `json:"id"`
+	Path      string `json:"path"`
+	Hash      string `json:"hash"`
+	MediaType string `json:"media_type"`
+	Driver    string `json:"driver"`
+	SizeBytes *int64 `json:"size_bytes,omitempty"`
+}
+
 type CandidatePackage struct {
-	Kind            string            `json:"kind"`
-	ContractVersion int               `json:"contract_version"`
-	TemplateID      string            `json:"template_id"`
-	BaseVersionID   string            `json:"base_version_id,omitempty"`
-	Candidate       CandidateTemplate `json:"candidate"`
-	EvalReport      json.RawMessage   `json:"eval_report,omitempty"`
-	Summary         CandidateSummary  `json:"summary,omitempty"`
+	Kind            string                 `json:"kind"`
+	ContractVersion int                    `json:"contract_version"`
+	TemplateID      string                 `json:"template_id"`
+	BaseVersionID   string                 `json:"base_version_id,omitempty"`
+	Candidate       CandidateTemplate      `json:"candidate"`
+	EvalReport      json.RawMessage        `json:"eval_report,omitempty"`
+	Summary         CandidateSummary       `json:"summary,omitempty"`
+	Artifacts       []CandidateArtifactRef `json:"artifacts,omitempty"`
+}
+
+type CandidateImportOptions struct {
+	SourcePath  string
+	ArtifactDir string
+	BlobStore   artifact.Store
 }
 
 func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (TrainingPackage, error) {
@@ -178,10 +197,28 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 }
 
 func ImportCandidatePackage(ctx context.Context, store *db.Store, candidate CandidatePackage, sourcePath string) (db.AgentTemplateVersion, error) {
+	return ImportCandidatePackageWithOptions(ctx, store, candidate, CandidateImportOptions{SourcePath: sourcePath})
+}
+
+func ImportCandidatePackageWithOptions(ctx context.Context, store *db.Store, candidate CandidatePackage, options CandidateImportOptions) (db.AgentTemplateVersion, error) {
 	if store == nil {
 		return db.AgentTemplateVersion{}, errors.New("store is required")
 	}
-	if err := validateCandidatePackage(ctx, store, candidate); err != nil {
+	preparedArtifacts, candidateArtifactIDs, err := prepareCandidateArtifacts(options.ArtifactDir, candidate.Artifacts)
+	if err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
+	if len(preparedArtifacts) > 0 && strings.TrimSpace(options.BlobStore.Root) == "" {
+		return db.AgentTemplateVersion{}, errors.New("artifact blob store is required")
+	}
+	if err := validateCandidatePackage(ctx, store, candidate, candidateArtifactIDs); err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
+	if err := validateCandidateArtifactIDsAvailable(ctx, store, candidateArtifactIDs); err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
+	evalArtifacts, err := storeCandidateArtifactBlobs(options.BlobStore, preparedArtifacts)
+	if err != nil {
 		return db.AgentTemplateVersion{}, err
 	}
 	templateID := strings.TrimSpace(candidate.TemplateID)
@@ -193,7 +230,7 @@ func ImportCandidatePackage(ctx context.Context, store *db.Store, candidate Cand
 	if err != nil {
 		return db.AgentTemplateVersion{}, err
 	}
-	sourcePath = strings.TrimSpace(sourcePath)
+	sourcePath := strings.TrimSpace(options.SourcePath)
 	if sourcePath == "" {
 		sourcePath = "candidate-package.json"
 	}
@@ -208,10 +245,6 @@ func ImportCandidatePackage(ctx context.Context, store *db.Store, candidate Cand
 		Content:        candidate.Candidate.Content,
 		MetadataJSON:   metadataJSON,
 	}
-	version, err := store.AddPendingAgentTemplateVersion(ctx, template)
-	if err != nil {
-		return db.AgentTemplateVersion{}, err
-	}
 	evalReportJSON, err := rawMessageStorage(candidate.EvalReport)
 	if err != nil {
 		return db.AgentTemplateVersion{}, fmt.Errorf("candidate eval_report: %w", err)
@@ -220,9 +253,8 @@ func ImportCandidatePackage(ctx context.Context, store *db.Store, candidate Cand
 	if err != nil {
 		return db.AgentTemplateVersion{}, fmt.Errorf("candidate summary metadata: %w", err)
 	}
-	if err := store.UpsertAgentTemplateCandidateReview(ctx, db.AgentTemplateCandidateReview{
-		VersionID:           version.ID,
-		TemplateID:          version.TemplateID,
+	version, err := store.AddPendingAgentTemplateCandidate(ctx, template, db.AgentTemplateCandidateReview{
+		TemplateID:          template.ID,
 		BaseVersionID:       baseVersionID,
 		DiffArtifactID:      strings.TrimSpace(candidate.Summary.DiffArtifactID),
 		Score:               candidate.Summary.Score,
@@ -230,10 +262,18 @@ func ImportCandidatePackage(ctx context.Context, store *db.Store, candidate Cand
 		EvalReportJSON:      evalReportJSON,
 		SummaryMetadataJSON: summaryMetadataJSON,
 		State:               "pending",
-	}); err != nil {
+	}, evalArtifacts)
+	if err != nil {
 		return db.AgentTemplateVersion{}, err
 	}
 	return version, nil
+}
+
+type preparedCandidateArtifact struct {
+	ref     CandidateArtifactRef
+	hash    string
+	size    int64
+	content []byte
 }
 
 func candidateBaseVersionID(ctx context.Context, store *db.Store, templateID string, baseRef string) (string, error) {
@@ -255,7 +295,7 @@ func candidateBaseVersionID(ctx context.Context, store *db.Store, templateID str
 	return base.VersionID, nil
 }
 
-func validateCandidatePackage(ctx context.Context, store *db.Store, candidate CandidatePackage) error {
+func validateCandidatePackage(ctx context.Context, store *db.Store, candidate CandidatePackage, candidateArtifactIDs map[string]struct{}) error {
 	if candidate.Kind != CandidatePackageKind {
 		return fmt.Errorf("candidate package kind must be %q", CandidatePackageKind)
 	}
@@ -286,8 +326,11 @@ func validateCandidatePackage(ctx context.Context, store *db.Store, candidate Ca
 		return err
 	}
 	if strings.TrimSpace(candidate.Summary.DiffArtifactID) != "" {
-		if _, err := store.GetEvalArtifact(ctx, candidate.Summary.DiffArtifactID); err != nil {
-			return fmt.Errorf("load summary diff artifact %q: %w", candidate.Summary.DiffArtifactID, err)
+		diffArtifactID := strings.TrimSpace(candidate.Summary.DiffArtifactID)
+		if _, ok := candidateArtifactIDs[diffArtifactID]; !ok {
+			if _, err := store.GetEvalArtifact(ctx, diffArtifactID); err != nil {
+				return fmt.Errorf("load summary diff artifact %q: %w", candidate.Summary.DiffArtifactID, err)
+			}
 		}
 	}
 	if _, err := rawMessageStorage(candidate.EvalReport); err != nil {
@@ -297,6 +340,126 @@ func validateCandidatePackage(ctx context.Context, store *db.Store, candidate Ca
 		return fmt.Errorf("candidate summary metadata: %w", err)
 	}
 	return nil
+}
+
+func validateCandidateArtifactIDsAvailable(ctx context.Context, store *db.Store, ids map[string]struct{}) error {
+	for id := range ids {
+		if _, err := store.GetEvalArtifact(ctx, id); err == nil {
+			return fmt.Errorf("candidate artifact %q already exists", id)
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("load candidate artifact %q: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func prepareCandidateArtifacts(artifactDir string, refs []CandidateArtifactRef) ([]preparedCandidateArtifact, map[string]struct{}, error) {
+	ids := make(map[string]struct{}, len(refs))
+	if len(refs) == 0 {
+		return nil, ids, nil
+	}
+	if strings.TrimSpace(artifactDir) == "" {
+		return nil, nil, errors.New("candidate artifacts require --artifact-dir")
+	}
+	prepared := make([]preparedCandidateArtifact, 0, len(refs))
+	for index, ref := range refs {
+		ref.ID = strings.TrimSpace(ref.ID)
+		ref.Path = strings.TrimSpace(ref.Path)
+		ref.Hash = strings.TrimSpace(ref.Hash)
+		ref.MediaType = strings.TrimSpace(ref.MediaType)
+		ref.Driver = strings.TrimSpace(ref.Driver)
+		if ref.ID == "" {
+			return nil, nil, fmt.Errorf("candidate artifact %d id is required", index+1)
+		}
+		if _, exists := ids[ref.ID]; exists {
+			return nil, nil, fmt.Errorf("candidate artifact %q is duplicated", ref.ID)
+		}
+		ids[ref.ID] = struct{}{}
+		if ref.MediaType == "" {
+			return nil, nil, fmt.Errorf("candidate artifact %q media_type is required", ref.ID)
+		}
+		if ref.Driver == "" {
+			return nil, nil, fmt.Errorf("candidate artifact %q driver is required", ref.ID)
+		}
+		if ref.SizeBytes != nil && *ref.SizeBytes < 0 {
+			return nil, nil, fmt.Errorf("candidate artifact %q size_bytes cannot be negative", ref.ID)
+		}
+		expectedHash, err := artifact.NormalizeHash(ref.Hash)
+		if err != nil {
+			return nil, nil, fmt.Errorf("candidate artifact %q hash: %w", ref.ID, err)
+		}
+		path, err := resolveCandidateArtifactPath(artifactDir, ref.Path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("candidate artifact %q path: %w", ref.ID, err)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read candidate artifact %q: %w", ref.ID, err)
+		}
+		size := int64(len(content))
+		if ref.SizeBytes != nil && *ref.SizeBytes != size {
+			return nil, nil, fmt.Errorf("candidate artifact %q size_bytes is %d, want %d", ref.ID, *ref.SizeBytes, size)
+		}
+		actualHash := artifact.ContentHash(content)
+		if actualHash != expectedHash {
+			return nil, nil, fmt.Errorf("candidate artifact %q hash is %s, want %s", ref.ID, actualHash, expectedHash)
+		}
+		ref.Hash = expectedHash
+		prepared = append(prepared, preparedCandidateArtifact{ref: ref, hash: actualHash, size: size, content: content})
+	}
+	return prepared, ids, nil
+}
+
+func resolveCandidateArtifactPath(artifactDir string, artifactPath string) (string, error) {
+	artifactPath = strings.TrimSpace(artifactPath)
+	if artifactPath == "" {
+		return "", errors.New("path is required")
+	}
+	if filepath.IsAbs(artifactPath) || !filepath.IsLocal(artifactPath) {
+		return "", fmt.Errorf("%q must be a relative path inside artifact-dir", artifactPath)
+	}
+	root, err := filepath.Abs(strings.TrimSpace(artifactDir))
+	if err != nil {
+		return "", fmt.Errorf("resolve artifact-dir: %w", err)
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve artifact-dir symlinks: %w", err)
+	}
+	candidatePath := filepath.Join(root, filepath.Clean(artifactPath))
+	candidatePath, err = filepath.EvalSymlinks(candidatePath)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(root, candidatePath)
+	if err != nil {
+		return "", fmt.Errorf("verify artifact path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("%q resolves outside artifact-dir", artifactPath)
+	}
+	return candidatePath, nil
+}
+
+func storeCandidateArtifactBlobs(blobStore artifact.Store, preparedArtifacts []preparedCandidateArtifact) ([]db.EvalArtifact, error) {
+	evalArtifacts := make([]db.EvalArtifact, 0, len(preparedArtifacts))
+	for _, prepared := range preparedArtifacts {
+		blob, err := blobStore.Put(prepared.content)
+		if err != nil {
+			return nil, fmt.Errorf("store candidate artifact %q blob: %w", prepared.ref.ID, err)
+		}
+		if blob.Hash != prepared.hash {
+			return nil, fmt.Errorf("store candidate artifact %q blob hash is %s, want %s", prepared.ref.ID, blob.Hash, prepared.hash)
+		}
+		evalArtifacts = append(evalArtifacts, db.EvalArtifact{
+			ID:        prepared.ref.ID,
+			Hash:      prepared.hash,
+			MediaType: prepared.ref.MediaType,
+			SizeBytes: prepared.size,
+			Driver:    prepared.ref.Driver,
+		})
+	}
+	return evalArtifacts, nil
 }
 
 func templateSnapshot(template db.AgentTemplate) (TemplateSnapshot, error) {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -3,7 +3,9 @@ package skillopt
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
@@ -170,6 +172,284 @@ func TestImportCandidatePackageCreatesPendingVersion(t *testing.T) {
 	}
 }
 
+func TestImportCandidatePackageWithArtifacts(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertAgentTemplate(ctx, testTemplate("planner", "Plan carefully.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	current, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	artifactDir := t.TempDir()
+	diffContent := []byte("candidate diff\n")
+	diffHash := artifact.ContentHash(diffContent)
+	if err := os.WriteFile(filepath.Join(artifactDir, "candidate.diff.md"), diffContent, 0o644); err != nil {
+		t.Fatalf("write diff artifact: %v", err)
+	}
+	blobStore := artifact.NewStore(filepath.Join(t.TempDir(), "blobs"))
+	candidate := testCandidatePackage(t, "planner", current.VersionID, "Plan carefully with artifact-backed evidence.")
+	diffSize := int64(len(diffContent))
+	candidate.Summary.DiffArtifactID = "candidate-diff"
+	candidate.Artifacts = []CandidateArtifactRef{{
+		ID:        "candidate-diff",
+		Path:      "candidate.diff.md",
+		Hash:      diffHash,
+		MediaType: "text/markdown",
+		Driver:    "text",
+		SizeBytes: &diffSize,
+	}}
+
+	version, err := ImportCandidatePackageWithOptions(ctx, store, candidate, CandidateImportOptions{
+		SourcePath:  "candidate.json",
+		ArtifactDir: artifactDir,
+		BlobStore:   blobStore,
+	})
+	if err != nil {
+		t.Fatalf("ImportCandidatePackageWithOptions returned error: %v", err)
+	}
+	review, err := store.GetAgentTemplateCandidateReview(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview returned error: %v", err)
+	}
+	if review.DiffArtifactID != "candidate-diff" {
+		t.Fatalf("review diff artifact id = %q", review.DiffArtifactID)
+	}
+	stored, err := store.GetEvalArtifact(ctx, "candidate-diff")
+	if err != nil {
+		t.Fatalf("GetEvalArtifact returned error: %v", err)
+	}
+	if stored.Hash != diffHash || stored.SizeBytes != diffSize || stored.MediaType != "text/markdown" || stored.Driver != "text" {
+		t.Fatalf("stored artifact = %+v", stored)
+	}
+	storedContent, err := blobStore.Read(diffHash)
+	if err != nil {
+		t.Fatalf("Read stored blob returned error: %v", err)
+	}
+	if string(storedContent) != string(diffContent) {
+		t.Fatalf("stored blob content = %q", string(storedContent))
+	}
+}
+
+func TestImportCandidatePackageArtifactValidationFailsBeforeCandidateState(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		hash        string
+		artifactDir string
+		writeFile   bool
+		wantErr     string
+	}{
+		{
+			name:        "missing artifact dir",
+			path:        "candidate.diff.md",
+			hash:        artifact.ContentHash([]byte("candidate diff\n")),
+			artifactDir: "",
+			writeFile:   true,
+			wantErr:     "candidate artifacts require --artifact-dir",
+		},
+		{
+			name:        "invalid hash",
+			path:        "candidate.diff.md",
+			hash:        artifact.ContentHash([]byte("other")),
+			artifactDir: "set",
+			writeFile:   true,
+			wantErr:     "hash is",
+		},
+		{
+			name:        "path traversal",
+			path:        "../candidate.diff.md",
+			hash:        artifact.ContentHash([]byte("candidate diff\n")),
+			artifactDir: "set",
+			writeFile:   false,
+			wantErr:     "relative path inside artifact-dir",
+		},
+		{
+			name:        "absolute path",
+			path:        "/tmp/candidate.diff.md",
+			hash:        artifact.ContentHash([]byte("candidate diff\n")),
+			artifactDir: "set",
+			writeFile:   false,
+			wantErr:     "relative path inside artifact-dir",
+		},
+		{
+			name:        "missing file",
+			path:        "missing.diff.md",
+			hash:        artifact.ContentHash([]byte("candidate diff\n")),
+			artifactDir: "set",
+			writeFile:   false,
+			wantErr:     "no such file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+			if err != nil {
+				t.Fatalf("Open returned error: %v", err)
+			}
+			defer store.Close()
+			if err := store.UpsertAgentTemplate(ctx, testTemplate("planner", "Plan carefully.")); err != nil {
+				t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+			}
+			current, err := store.GetAgentTemplate(ctx, "planner")
+			if err != nil {
+				t.Fatalf("GetAgentTemplate returned error: %v", err)
+			}
+			artifactDir := ""
+			if tt.artifactDir == "set" {
+				artifactDir = t.TempDir()
+			}
+			if tt.writeFile && artifactDir != "" {
+				if err := os.WriteFile(filepath.Join(artifactDir, "candidate.diff.md"), []byte("candidate diff\n"), 0o644); err != nil {
+					t.Fatalf("write diff artifact: %v", err)
+				}
+			}
+			candidate := testCandidatePackage(t, "planner", current.VersionID, "Plan carefully with artifact-backed evidence.")
+			candidate.Summary.DiffArtifactID = "candidate-diff"
+			candidate.Artifacts = []CandidateArtifactRef{{
+				ID:        "candidate-diff",
+				Path:      tt.path,
+				Hash:      tt.hash,
+				MediaType: "text/markdown",
+				Driver:    "text",
+			}}
+
+			_, err = ImportCandidatePackageWithOptions(ctx, store, candidate, CandidateImportOptions{
+				SourcePath:  "candidate.json",
+				ArtifactDir: artifactDir,
+				BlobStore:   artifact.NewStore(filepath.Join(t.TempDir(), "blobs")),
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ImportCandidatePackageWithOptions error = %v, want substring %q", err, tt.wantErr)
+			}
+			pending, err := store.ListPendingAgentTemplateVersions(ctx, "planner")
+			if err != nil {
+				t.Fatalf("ListPendingAgentTemplateVersions returned error: %v", err)
+			}
+			if len(pending) != 0 {
+				t.Fatalf("pending versions = %+v, want none", pending)
+			}
+			if _, err := store.GetEvalArtifact(ctx, "candidate-diff"); err == nil {
+				t.Fatalf("candidate artifact was registered despite failed import")
+			}
+		})
+	}
+}
+
+func TestImportCandidatePackageRejectsDuplicateCandidateArtifactIDs(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertAgentTemplate(ctx, testTemplate("planner", "Plan carefully.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	current, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	artifactDir := t.TempDir()
+	content := []byte("candidate diff\n")
+	hash := artifact.ContentHash(content)
+	if err := os.WriteFile(filepath.Join(artifactDir, "candidate.diff.md"), content, 0o644); err != nil {
+		t.Fatalf("write diff artifact: %v", err)
+	}
+	candidate := testCandidatePackage(t, "planner", current.VersionID, "Plan carefully with artifact-backed evidence.")
+	candidate.Summary.DiffArtifactID = "candidate-diff"
+	candidate.Artifacts = []CandidateArtifactRef{
+		{ID: "candidate-diff", Path: "candidate.diff.md", Hash: hash, MediaType: "text/markdown", Driver: "text"},
+		{ID: "candidate-diff", Path: "candidate.diff.md", Hash: hash, MediaType: "text/markdown", Driver: "text"},
+	}
+
+	_, err = ImportCandidatePackageWithOptions(ctx, store, candidate, CandidateImportOptions{
+		SourcePath:  "candidate.json",
+		ArtifactDir: artifactDir,
+		BlobStore:   artifact.NewStore(filepath.Join(t.TempDir(), "blobs")),
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicated") {
+		t.Fatalf("ImportCandidatePackageWithOptions error = %v, want duplicate id", err)
+	}
+	pending, err := store.ListPendingAgentTemplateVersions(ctx, "planner")
+	if err != nil {
+		t.Fatalf("ListPendingAgentTemplateVersions returned error: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending versions = %+v, want none", pending)
+	}
+}
+
+func TestImportCandidatePackageRejectsExistingCandidateArtifactID(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertAgentTemplate(ctx, testTemplate("planner", "Plan carefully.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	originalHash := artifact.ContentHash([]byte("old diff\n"))
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{
+		ID:        "candidate-diff",
+		Hash:      originalHash,
+		MediaType: "text/markdown",
+		SizeBytes: int64(len("old diff\n")),
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact returned error: %v", err)
+	}
+	current, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	artifactDir := t.TempDir()
+	content := []byte("new diff\n")
+	hash := artifact.ContentHash(content)
+	if err := os.WriteFile(filepath.Join(artifactDir, "candidate.diff.md"), content, 0o644); err != nil {
+		t.Fatalf("write diff artifact: %v", err)
+	}
+	candidate := testCandidatePackage(t, "planner", current.VersionID, "Plan carefully with artifact-backed evidence.")
+	candidate.Summary.DiffArtifactID = "candidate-diff"
+	candidate.Artifacts = []CandidateArtifactRef{{
+		ID:        "candidate-diff",
+		Path:      "candidate.diff.md",
+		Hash:      hash,
+		MediaType: "text/markdown",
+		Driver:    "text",
+	}}
+
+	_, err = ImportCandidatePackageWithOptions(ctx, store, candidate, CandidateImportOptions{
+		SourcePath:  "candidate.json",
+		ArtifactDir: artifactDir,
+		BlobStore:   artifact.NewStore(filepath.Join(t.TempDir(), "blobs")),
+	})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("ImportCandidatePackageWithOptions error = %v, want existing artifact rejection", err)
+	}
+	stored, err := store.GetEvalArtifact(ctx, "candidate-diff")
+	if err != nil {
+		t.Fatalf("GetEvalArtifact returned error: %v", err)
+	}
+	if stored.Hash != originalHash {
+		t.Fatalf("stored artifact hash = %q, want original %q", stored.Hash, originalHash)
+	}
+	pending, err := store.ListPendingAgentTemplateVersions(ctx, "planner")
+	if err != nil {
+		t.Fatalf("ListPendingAgentTemplateVersions returned error: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending versions = %+v, want none", pending)
+	}
+}
+
 func testTemplate(id string, body string) db.AgentTemplate {
 	content := testTemplateContent(id, body)
 	parsed, err := agenttemplate.ParseTemplateContent(content)
@@ -190,6 +470,29 @@ func testTemplate(id string, body string) db.AgentTemplate {
 		ResolvedCommit: agenttemplate.HashContent(content),
 		Content:        content,
 		MetadataJSON:   metadataJSON,
+	}
+}
+
+func testCandidatePackage(t *testing.T, templateID string, baseVersionID string, body string) CandidatePackage {
+	t.Helper()
+	candidateContent := testTemplateContent(templateID, body)
+	parsed, err := agenttemplate.ParseTemplateContent(candidateContent)
+	if err != nil {
+		t.Fatalf("ParseTemplateContent returned error: %v", err)
+	}
+	return CandidatePackage{
+		Kind:            CandidatePackageKind,
+		ContractVersion: ContractVersion,
+		TemplateID:      templateID,
+		BaseVersionID:   baseVersionID,
+		Candidate: CandidateTemplate{
+			Content:  candidateContent,
+			Metadata: parsed.Metadata,
+		},
+		EvalReport: json.RawMessage(`{"score":0.82}`),
+		Summary: CandidateSummary{
+			PreferenceSummary: "Candidate is more actionable.",
+		},
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -257,7 +257,7 @@ gitmoot lock show owner/repo <branch>
 
 ```sh
 gitmoot skillopt export --run <run-id> [--output training.json]
-gitmoot skillopt import --file candidate.json
+gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
 gitmoot skillopt candidate show <version-id>
 gitmoot skillopt candidate promote <version-id>
@@ -272,7 +272,9 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 eval run, review items, artifact manifests, feedback events when present, and
 evaluator config. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate
-automatically. `skillopt candidate show` displays candidate metadata, eval
+automatically. If the candidate package includes new artifact manifest entries,
+pass `--artifact-dir` so Gitmoot can verify relative paths and SHA256 hashes
+before storing blobs. `skillopt candidate show` displays candidate metadata, eval
 report JSON, preference summary, and a content diff against the base/current
 version. `skillopt candidate promote` makes a pending candidate current, while
 `skillopt candidate reject` records an auditable rejection and prevents that

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -61,7 +61,7 @@ gitmoot lock list --repo owner/repo
 
 ```sh
 gitmoot skillopt export --run <run-id> [--output training.json]
-gitmoot skillopt import --file candidate.json
+gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
 gitmoot skillopt candidate show <version-id>
 gitmoot skillopt candidate promote <version-id>

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -20,13 +20,15 @@ are not copied into the repository by default.
 ## Candidate Package
 
 ```sh
-gitmoot skillopt import --file candidate.json
+gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 ```
 
 The candidate package contains full agent-template Markdown with YAML
-frontmatter, matching metadata, an optional eval report, and an optional summary.
-Importing stores the candidate as a pending template version and never promotes
-it automatically.
+frontmatter, matching metadata, an optional eval report, an optional summary,
+and optional artifact manifest entries. When artifact entries are present,
+`--artifact-dir` is required; Gitmoot verifies relative paths and SHA256 hashes,
+stores the blobs, and registers artifact metadata before creating the pending
+candidate. Importing never promotes it automatically.
 
 ```sh
 gitmoot skillopt candidate list --template planner

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -284,7 +284,7 @@ gitmoot lock release owner/repo <branch> --owner <agent>
 
 ```sh
 gitmoot skillopt export --run <run-id> --output training.json
-gitmoot skillopt import --file candidate.json
+gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
 gitmoot skillopt candidate show <version-id>
 gitmoot skillopt candidate promote <version-id>
@@ -298,6 +298,9 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 The export/import boundary lets a future external `gitmoot-skillopt` optimizer
 train on local eval artifacts and return candidate template versions. Imported
 candidates stay pending until a human review workflow promotes them.
+When a candidate package includes new artifact manifest entries, pass
+`--artifact-dir` to the directory containing those files; Gitmoot verifies
+relative paths and SHA256 hashes before storing blobs.
 Use `skillopt candidate show` to inspect the candidate metadata, eval report,
 feedback summary, and content diff before `promote` or `reject` records the
 decision.
@@ -487,7 +490,7 @@ gitmoot job events <job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 gitmoot skillopt export --run <run-id> [--output training.json]
-gitmoot skillopt import --file candidate.json
+gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
 gitmoot skillopt candidate show <version-id>
 gitmoot skillopt candidate promote <version-id>
@@ -2868,7 +2871,7 @@ gitmoot lock show owner/repo <branch>
 
 ```sh
 gitmoot skillopt export --run <run-id> [--output training.json]
-gitmoot skillopt import --file candidate.json
+gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
 gitmoot skillopt candidate show <version-id>
 gitmoot skillopt candidate promote <version-id>
@@ -2883,7 +2886,9 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 eval run, review items, artifact manifests, feedback events when present, and
 evaluator config. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate
-automatically. `skillopt candidate show` displays candidate metadata, eval
+automatically. If the candidate package includes new artifact manifest entries,
+pass `--artifact-dir` so Gitmoot can verify relative paths and SHA256 hashes
+before storing blobs. `skillopt candidate show` displays candidate metadata, eval
 report JSON, preference summary, and a content diff against the base/current
 version. `skillopt candidate promote` makes a pending candidate current, while
 `skillopt candidate reject` records an auditable rejection and prevents that


### PR DESCRIPTION
WHAT: Add artifact manifest import support for Gitmoot SkillOpt candidate packages.

WHY: SkillOpt candidates can now include generated diff/report artifacts that Gitmoot must verify, store, and attach to pending template versions before human review.

CHANGES:
- Added optional candidate artifact manifest entries with id, path, hash, media_type, driver, and optional size_bytes.
- Extended `gitmoot skillopt import --file candidate.json --artifact-dir artifacts` to verify path safety, hashes, file presence, and artifact id availability before importing.
- Stores verified artifact blobs in Gitmoot content-addressed storage and registers artifact metadata atomically with the pending candidate version/review row.
- Preserved imports for candidate packages without artifacts.
- Updated candidate import tests, DB rollback coverage, CLI e2e/failure tests, README, SKILL.md, CLI docs, SkillOpt exchange docs, and llms-full.txt.

RESULTS:
- `/root/temp/ts/tool/go test ./internal/skillopt ./internal/cli ./internal/artifact ./internal/db` passed.
- `/root/temp/ts/tool/go test ./...` passed.
- `npm run build` in `website` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `codex exec review --uncommitted` final raw output:

```text
codex
I did not identify any discrete correctness issues in the current staged, unstaged, or untracked changes. Test execution was blocked by the sandboxed Go toolchain cache, so confidence is based on static review.
I did not identify any discrete correctness issues in the current staged, unstaged, or untracked changes. Test execution was blocked by the sandboxed Go toolchain cache, so confidence is based on static review.
```

RISK: `codex exec review` could not run tests with its sandboxed Go toolchain cache, but the required Go suites and website build were run directly with the repo toolchain and passed.