### PR TITLE
Link Gitmoot SkillOpt workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ candidates stay pending until a human review workflow promotes them.
 When a candidate package includes new artifact manifest entries, pass
 `--artifact-dir` to the directory containing those files; Gitmoot verifies
 relative paths and SHA256 hashes before storing blobs.
+The external optimizer walkthrough lives in
+[`jerryfane/gitmoot-skillopt`](https://github.com/jerryfane/gitmoot-skillopt/blob/main/docs/guide/gitmoot-mvp-workflow.md).
 Use `skillopt candidate show` to inspect the candidate metadata, eval report,
 feedback summary, and content diff before `promote` or `reject` records the
 decision.


### PR DESCRIPTION
WHAT: Link Gitmoot's SkillOpt Exchange README section to the external Gitmoot-SkillOpt workflow guide.

WHY: The optimizer flow now lives in `jerryfane/gitmoot-skillopt`; Gitmoot users need a direct pointer from the import/export command docs.

CHANGES:
- Added a README link to the Gitmoot-SkillOpt MVP workflow guide.

RESULTS:
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Docs/static build skipped: the repo root has no `package.json`, and this change only touches README.
- `codex exec review --uncommitted` final raw output:

```text
codex
The change only adds a README link to the external optimizer walkthrough and does not affect runtime behavior or existing documented commands.
The change only adds a README link to the external optimizer walkthrough and does not affect runtime behavior or existing documented commands.
```

RISK: No runtime risk expected; README-only change.

Related Gitmoot-SkillOpt PR: https://github.com/jerryfane/gitmoot-skillopt/pull/5