### PR TITLE
feat: add skillopt review create and status

### DIFF
--- a/GOAL-SKILLOPT-HUMAN-FEEDBACK-TRIAL.md
+++ b/GOAL-SKILLOPT-HUMAN-FEEDBACK-TRIAL.md
@@ -1,0 +1,374 @@
+# SkillOpt Human Feedback Trial Workflow
+
+Implement the plan task by task. Each task must be developed, reviewed, opened
+as its own pull request, merged, and verified before moving on, unless tasks are
+explicitly safe to run in parallel.
+
+Build the missing operator-facing workflow needed to run a real Gitmoot
+SkillOpt human A/B feedback trial without manual database seeding. The outcome
+should let a user create a review run, attach baseline/candidate outputs from
+files, export a Markdown feedback packet, import completed feedback, export a
+training package, run Gitmoot-SkillOpt, import the candidate, and promote or
+reject it. Preserve the existing SkillOpt storage/export/import contracts and
+keep Gitmoot as the product/control layer; do not embed the external
+`gitmoot-skillopt` optimizer into the Go CLI.
+
+## Core Rules
+
+- Work one task at a time in the listed order by default.
+- If tasks are independent, have disjoint file ownership, and do not depend on
+  each other's results, they may be done in parallel on separate branches.
+- Do not start dependent work until the prerequisite task has passed checks,
+  passed `codex exec review --uncommitted`, been pushed, opened as a PR, merged,
+  and verified on the target branch.
+- Do not commit generated data, reports, caches, build artifacts, secrets,
+  credentials, session archives, cloned helper repos, local plugin build output,
+  or large outputs unless the plan explicitly says they are intended tracked
+  fixtures/artifacts.
+- Preserve existing behavior unless the current task explicitly changes it.
+- Keep changes clean, scoped, and organized. Avoid broad rewrites.
+- Avoid code duplication. When repeated logic appears, extract small reusable
+  helpers that match existing repo patterns.
+- If implementation depends on external APIs, docs, CLIs, data formats,
+  generated scripts, installers, service launchers, subprocess calls, env vars,
+  config formats, or third-party libraries, verify the real contract with local
+  commands and/or official sources before editing.
+
+## Before Starting
+
+1. Inspect current repo state with:
+   - `git status --short`
+   - current branch
+   - current remote
+2. If the target branch is unclear, the remote looks wrong, or the worktree has
+   unrelated existing changes that make task commits ambiguous, stop and ask
+   before continuing.
+3. Confirm the target base branch from the current repo. If unspecified, use the
+   current branch as the base.
+4. Inspect relevant existing patterns before editing.
+5. Verify PR tooling is available before the first PR:
+   - `gh auth status`
+   - repo remote resolves to the expected GitHub repository
+
+## Per-Task Branch Workflow
+
+1. Confirm the current task's scope.
+2. Create a task branch from the latest target base branch.
+3. Implement only that task.
+4. Add or update focused tests/checks appropriate to the task.
+5. Run focused tests for touched modules.
+6. Run broader checks when the task touches shared behavior, CLI/API surfaces,
+   data/model/evaluation logic, generated scripts, installers, service
+   launchers, docs build systems, or user-facing workflows.
+7. For wrapper, installer, CLI, subprocess, generated-script, env propagation,
+   service-launcher, or deployment changes, include an operational smoke test or
+   direct contract check. Syntax checks alone are not enough.
+8. Identify every repository where files changed. In each changed repo, run:
+   `codex exec review --uncommitted`
+9. Preserve the exact raw review output per repo.
+
+## Review-Fix Loop
+
+1. If review finds issues, do not only patch the literal line.
+2. Identify the underlying invariant/class of bug.
+3. Audit nearby and sibling paths for the same issue.
+4. Write a concise fix plan using:
+
+   ```text
+   Review found these issues: <<PASTE RAW REVIEW RESULTS BY REPO>>.
+   For each issue, identify the underlying invariant/class of bug, audit sibling
+   paths for the same issue, and plan the smallest safe fix. Verify external
+   assumptions with local commands and/or official sources. Preserve repo
+   patterns, avoid unnecessary refactors, and list tests/checks per repo.
+   ```
+
+5. Execute the fix plan.
+6. Re-run focused tests/checks and `codex exec review --uncommitted` in every
+   repo with uncommitted changes.
+7. Repeat until the final raw review output contains no findings, or stop if
+   blocked or if a finding is incorrect after verification.
+
+## Commit Gate
+
+1. Before committing, run `git diff --check` and inspect the final diff.
+2. Commit only the current task's intended tracked changes.
+3. Use the commit message specified by the plan. If the plan does not specify
+   one, use a concise conventional message that describes only the current task.
+4. Push the task branch.
+5. Verify the task branch worktree is clean after push, except for intentionally
+   ignored generated files.
+
+## Pull Request Gate
+
+1. Create one PR for the current task.
+2. The PR title must describe only the current task.
+3. The PR body must include:
+   - WHAT: what was changed
+   - WHY: why the task was needed
+   - CHANGES: concrete implementation changes
+   - RESULTS: tests/checks/review results
+   - RISK: skipped checks, blockers, or residual risk
+4. Include the exact raw final `codex exec review --uncommitted` output for each
+   changed repo in the PR body.
+5. If CI or required checks exist, wait for them and fix failures before merge.
+6. Merge the PR using the repository's configured/preferred merge method. If no
+   preference is discoverable, use squash merge for a clean task-level history.
+7. After merge, update the local target base branch and verify the worktree is
+   clean.
+8. Record the PR number, PR URL, branch name, and merged commit hash.
+9. Delete the task branch after merge only if the repository normally does so or
+   the merge command supports safe branch deletion.
+
+## Parallel Task Rules
+
+- Parallelize only when tasks are independent, have disjoint file ownership, and
+  can be reviewed and merged without order-dependent assumptions.
+- Use a separate branch per task.
+- Clearly assign each branch a task number and file ownership.
+- Do not duplicate work across branches.
+- If parallel branches conflict after one PR merges, rebase or update the
+  remaining branch on the latest target base and re-run its checks/review.
+- If a task becomes dependent on another task, stop treating it as parallel and
+  merge the dependency first.
+
+## Final Response After All Tasks
+
+- List completed tasks.
+- For each task, list branch, PR URL, merge status, and merged commit hash.
+- List tests/checks run.
+- Include exact final raw `codex exec review --uncommitted` output for the last
+  task/repo.
+- Mention skipped checks, blockers, or residual risk.
+- Do not claim interactive `/review` is clean. Say:
+  `codex exec review is clean; ready for manual /review.`
+
+## Implementation Tasks
+
+### Task 1: Add SkillOpt Review Run Creation And Status
+
+Scope:
+
+- Add a `gitmoot skillopt review` command group to the existing SkillOpt CLI
+  surface.
+- Add `gitmoot skillopt review create` with this intended shape:
+
+  ```sh
+  gitmoot skillopt review create \
+    --template planner \
+    --repo owner/repo \
+    --run planner-ab-1
+  ```
+
+- Resolve and store the selected template's current version id at creation time.
+- Create or update the `eval_runs` row with state suitable for human review.
+- Add `gitmoot skillopt review status --run planner-ab-1`.
+- Status should report template id/version, target repo, state, review item
+  count, imported feedback count, and readiness for packet/training export.
+- Keep the implementation in the existing CLI/store style; extract small
+  helpers where status/count logic would otherwise duplicate export or feedback
+  code.
+
+Acceptance criteria:
+
+- `gitmoot skillopt --help` includes the review commands.
+- Creating a review run with an installed template succeeds.
+- Creating a review run for an unknown template returns a clear actionable
+  error.
+- Status works for runs with zero items and for missing runs.
+- Existing `skillopt export`, feedback, candidate, and import commands keep
+  their behavior.
+
+Tests/checks:
+
+- Focused Go tests for `internal/cli` covering review create and status.
+- Focused Go tests for any new `internal/skillopt` or helper package logic.
+- `go test ./internal/cli ./internal/skillopt ./internal/db`.
+- Broader `go test ./...` because this touches a CLI/API surface.
+- `git diff --check`.
+- `codex exec review --uncommitted`.
+
+Suggested branch:
+
+- `task/skillopt-review-create-status`
+
+Suggested commit message:
+
+- `feat: add skillopt review create and status`
+
+### Task 2: Add Artifact-Backed Review Item Creation
+
+Scope:
+
+- Add `gitmoot skillopt review item add` with this intended shape:
+
+  ```sh
+  gitmoot skillopt review item add \
+    --run planner-ab-1 \
+    --item item-001 \
+    --title "README planning task" \
+    --baseline baseline.md \
+    --candidate candidate.md
+  ```
+
+- Read baseline and candidate files from disk, store their bytes in Gitmoot's
+  content-addressed artifact blob store, register `eval_artifacts`, and create
+  the corresponding `eval_review_items` row.
+- Use deterministic, collision-resistant artifact ids scoped to the run/item and
+  artifact role, for example `planner-ab-1/item-001/baseline` and
+  `planner-ab-1/item-001/candidate`, unless existing repo patterns suggest a
+  better local convention.
+- Infer `media_type` conservatively from file extension/content where practical,
+  defaulting to `text/markdown` or `text/plain` for Markdown/text files.
+- Add optional flags only if they stay simple and aligned with existing storage:
+  `--source`, `--preview`, `--diff`, `--metadata-json`, or `--driver`.
+- Reject missing files, identical baseline/candidate artifact ids, unsupported
+  binary inputs without a clear media type, invalid JSON metadata, and missing
+  runs with clear errors.
+- Update `review status` so item and feedback counts reflect items added by the
+  new command.
+
+Acceptance criteria:
+
+- Users can add multiple review items to one run.
+- Markdown feedback export works immediately after adding at least one complete
+  baseline/candidate item.
+- The command does not duplicate file blobs unnecessarily; the blob store remains
+  content-addressed.
+- The generated review item records satisfy existing Markdown and GitHub
+  feedback collector validation.
+
+Tests/checks:
+
+- Go CLI tests for successful item add with Markdown files.
+- Go CLI tests for missing files, missing run, invalid metadata, and incomplete
+  arguments.
+- Go tests that export a Markdown packet after adding an item through the CLI.
+- `go test ./internal/cli ./internal/feedback ./internal/db`.
+- Broader `go test ./...`.
+- `git diff --check`.
+- `codex exec review --uncommitted`.
+
+Suggested branch:
+
+- `task/skillopt-review-item-add`
+
+Suggested commit message:
+
+- `feat: add skillopt review item creation`
+
+### Task 3: Polish Human Feedback Packet And Trial Documentation
+
+Scope:
+
+- Improve Markdown packet guidance so a first-time reviewer knows exactly what
+  to open and edit:
+  - open `index.md`
+  - review `items/*.md`
+  - edit `feedback.yml`
+  - use only `a`, `b`, `tie`, `neither`, or `skip`
+  - import the completed packet with the exact command
+- Keep `.assignments.json` hidden/internal and preserve the blind A/B mapping.
+- Add a concise happy-path trial section to `docs/skillopt-exchange-contract.md`
+  and any relevant skill/reference docs:
+
+  ```text
+  review create
+  review item add
+  feedback markdown export
+  edit feedback.yml
+  feedback markdown import
+  skillopt export
+  gitmoot-skillopt optimize
+  skillopt import
+  candidate show
+  candidate promote/reject
+  ```
+
+- Add model/backend configuration notes for the non-`--dry-run`
+  `gitmoot-skillopt optimize` step. State the exact local commands/env checks to
+  run and clearly separate dry-run contract validation from real model-backed
+  optimization.
+- If a lightweight `review open` command is straightforward and follows repo
+  style, add it only as a convenience that prints or opens the packet path; do
+  not let it distract from the required trial flow.
+
+Acceptance criteria:
+
+- A user can follow docs from no review run to imported feedback without manual
+  DB seeding.
+- The packet instructions are clear enough to complete `feedback.yml` without
+  reading source code.
+- Docs distinguish saved-output A/B review from future live pairwise evaluation.
+- Docs do not imply candidates auto-promote.
+
+Tests/checks:
+
+- Existing feedback tests continue to pass.
+- Add focused tests only if packet output text changes are validated in tests.
+- `go test ./internal/feedback ./internal/cli`.
+- `go test ./...`.
+- If docs site/build tooling exists and is lightweight, run the relevant docs
+  check/build; otherwise record that no docs build is configured.
+- `git diff --check`.
+- `codex exec review --uncommitted`.
+
+Suggested branch:
+
+- `task/skillopt-feedback-trial-docs`
+
+Suggested commit message:
+
+- `docs: add skillopt human feedback trial workflow`
+
+### Task 4: Add End-To-End Human Feedback Trial Smoke
+
+Scope:
+
+- Add a deterministic local smoke test or script that exercises the new
+  user-facing commands without touching the user's real `~/.gitmoot`.
+- The smoke should use a temp Gitmoot home and small tracked or temp Markdown
+  files.
+- It should cover:
+  1. `gitmoot skillopt review create`
+  2. `gitmoot skillopt review item add`
+  3. `gitmoot skillopt feedback markdown export`
+  4. writing a completed `feedback.yml`
+  5. `gitmoot skillopt feedback markdown import`
+  6. `gitmoot skillopt export --output training.json`
+  7. `gitmoot-skillopt optimize --dry-run` when the external repo is available,
+     or a documented local-only boundary substitute if cross-repo execution is
+     too brittle for CI
+  8. `gitmoot skillopt import --file candidate.json --artifact-dir artifacts`
+  9. `gitmoot skillopt candidate show`
+  10. `gitmoot skillopt candidate reject --reason "trial smoke"`
+- Prefer testing Gitmoot-owned commands inside `/root/gitmoot`; only add
+  cross-repo smoke references when they are stable and do not require generated
+  outputs to be committed.
+
+Acceptance criteria:
+
+- The smoke proves the human-feedback-trial path no longer needs manual DB
+  seeding.
+- The smoke proves imported feedback reaches `training.json`.
+- The smoke proves the imported candidate remains pending until explicit
+  promote/reject.
+- The smoke output or documented expected output is included in the PR body and
+  final task summary.
+
+Tests/checks:
+
+- Focused smoke command or Go integration test.
+- `go test ./internal/cli ./internal/feedback ./internal/skillopt ./internal/db`.
+- Broader `go test ./...`.
+- If cross-repo `gitmoot-skillopt` smoke is run, record exact command and
+  output.
+- `git diff --check`.
+- `codex exec review --uncommitted`.
+
+Suggested branch:
+
+- `task/skillopt-human-feedback-smoke`
+
+Suggested commit message:
+
+- `test: add skillopt human feedback trial smoke`

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -35,6 +35,8 @@ func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptExport(args[1:], stdout, stderr)
 	case "import":
 		return runSkillOptImport(args[1:], stdout, stderr)
+	case "review":
+		return runSkillOptReview(args[1:], stdout, stderr)
 	case "candidate":
 		return runSkillOptCandidate(args[1:], stdout, stderr)
 	case "feedback":
@@ -50,6 +52,8 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt export --run <run-id> [--output package.json]")
 	fmt.Fprintln(w, "  gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]")
+	fmt.Fprintln(w, "  gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>")
+	fmt.Fprintln(w, "  gitmoot skillopt review status --run <run-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate list [--template id]")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate show <version-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate promote <version-id>")
@@ -58,6 +62,227 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
+}
+
+func runSkillOptReview(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSkillOptUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "create":
+		return runSkillOptReviewCreate(args[1:], stdout, stderr)
+	case "status":
+		return runSkillOptReviewStatus(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skillopt review command %q\n\n", args[0])
+		printSkillOptUsage(stderr)
+		return 2
+	}
+}
+
+func runSkillOptReviewCreate(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt review create", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	templateID := fs.String("template", "", "agent template id or version to review")
+	repoFlag := fs.String("repo", "", "target repository in owner/repo form")
+	runID := fs.String("run", "", "review run id")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt review create does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*templateID) == "" || strings.TrimSpace(*repoFlag) == "" || strings.TrimSpace(*runID) == "" {
+		fmt.Fprintln(stderr, "skillopt review create requires --template, --repo, and --run")
+		return 2
+	}
+	repo, err := daemon.ParseRepository(*repoFlag)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt review create: %v\n", err)
+		return 2
+	}
+	var run db.EvalRun
+	if err := withStore(*home, func(store *db.Store) error {
+		template, err := loadInstalledTemplate(context.Background(), store, *templateID)
+		if err != nil {
+			return err
+		}
+		run = db.EvalRun{
+			ID:                strings.TrimSpace(*runID),
+			TemplateID:        template.ID,
+			TemplateVersionID: template.VersionID,
+			TargetRepo:        repo.FullName(),
+			State:             "review",
+			MetadataJSON:      `{"driver":"manual-review"}`,
+		}
+		return store.UpsertEvalRun(context.Background(), run)
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt review create: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "created review %s for %s", run.ID, run.TemplateVersionID)
+	return 0
+}
+
+func runSkillOptReviewStatus(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt review status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	runID := fs.String("run", "", "review run id")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt review status does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*runID) == "" {
+		fmt.Fprintln(stderr, "skillopt review status requires --run")
+		return 2
+	}
+	var status skillOptReviewStatus
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		var err error
+		status, err = loadSkillOptReviewStatus(context.Background(), store, artifact.NewStore(paths.ArtifactBlobs), *runID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt review status: %v\n", err)
+		return 1
+	}
+	itemCount := len(status.Items)
+	feedbackCount := len(status.Feedback)
+	fmt.Fprintf(stdout, "run: %s\n", status.Run.ID)
+	fmt.Fprintf(stdout, "template: %s\n", status.Run.TemplateID)
+	fmt.Fprintf(stdout, "template_version: %s\n", status.Run.TemplateVersionID)
+	fmt.Fprintf(stdout, "repo: %s\n", status.Run.TargetRepo)
+	fmt.Fprintf(stdout, "state: %s\n", status.Run.State)
+	fmt.Fprintf(stdout, "items: %d\n", itemCount)
+	fmt.Fprintf(stdout, "feedback: %d\n", feedbackCount)
+	fmt.Fprintf(stdout, "packet_blockers: %d\n", len(status.PacketBlockers))
+	fmt.Fprintf(stdout, "training_blockers: %d\n", len(status.TrainingBlockers))
+	fmt.Fprintf(stdout, "ready_for_packet: %t\n", status.PacketReady)
+	fmt.Fprintf(stdout, "ready_for_training: %t\n", status.TrainingReady)
+	for _, blocker := range status.PacketBlockers {
+		fmt.Fprintf(stdout, "packet_blocker: %s\n", blocker)
+	}
+	for _, blocker := range status.TrainingBlockers {
+		fmt.Fprintf(stdout, "training_blocker: %s\n", blocker)
+	}
+	return 0
+}
+
+type skillOptReviewStatus struct {
+	Run              db.EvalRun
+	Items            []db.EvalReviewItem
+	Feedback         []db.FeedbackEvent
+	PacketBlockers   []string
+	TrainingBlockers []string
+	PacketReady      bool
+	TrainingReady    bool
+}
+
+func loadSkillOptReviewStatus(ctx context.Context, store *db.Store, blobStore artifact.Store, runID string) (skillOptReviewStatus, error) {
+	run, err := store.GetEvalRun(ctx, strings.TrimSpace(runID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return skillOptReviewStatus{}, fmt.Errorf("review run %s not found", strings.TrimSpace(runID))
+		}
+		return skillOptReviewStatus{}, err
+	}
+	items, err := store.ListEvalReviewItems(ctx, run.ID)
+	if err != nil {
+		return skillOptReviewStatus{}, err
+	}
+	events, err := store.ListFeedbackEvents(ctx, run.ID)
+	if err != nil {
+		return skillOptReviewStatus{}, err
+	}
+	packetBlockers := reviewPacketBlockers(ctx, store, blobStore, items)
+	trainingBlockers := reviewTrainingBlockers(ctx, store, run.ID, items, events)
+	return skillOptReviewStatus{
+		Run:              run,
+		Items:            items,
+		Feedback:         events,
+		PacketBlockers:   packetBlockers,
+		TrainingBlockers: trainingBlockers,
+		PacketReady:      len(packetBlockers) == 0,
+		TrainingReady:    len(packetBlockers) == 0 && len(trainingBlockers) == 0,
+	}, nil
+}
+
+func reviewPacketBlockers(ctx context.Context, store *db.Store, blobStore artifact.Store, items []db.EvalReviewItem) []string {
+	if len(items) == 0 {
+		return []string{"run has no review items"}
+	}
+	var blockers []string
+	validated := map[string]struct{}{}
+	for _, item := range items {
+		itemID := strings.TrimSpace(item.ItemID)
+		if itemID == "" {
+			itemID = item.ID
+		}
+		baseline := strings.TrimSpace(item.BaselineArtifactID)
+		candidate := strings.TrimSpace(item.CandidateArtifactID)
+		if baseline == "" || candidate == "" {
+			blockers = append(blockers, fmt.Sprintf("item %s is missing a baseline or candidate artifact", itemID))
+			continue
+		}
+		if baseline == candidate {
+			blockers = append(blockers, fmt.Sprintf("item %s uses the same artifact for baseline and candidate", itemID))
+			continue
+		}
+		blockers = append(blockers, validateReviewArtifactBlob(ctx, store, blobStore, itemID, "baseline", baseline, validated)...)
+		blockers = append(blockers, validateReviewArtifactBlob(ctx, store, blobStore, itemID, "candidate", candidate, validated)...)
+	}
+	return blockers
+}
+
+func reviewTrainingBlockers(ctx context.Context, store *db.Store, runID string, items []db.EvalReviewItem, events []db.FeedbackEvent) []string {
+	if len(items) == 0 {
+		return []string{"run has no review items"}
+	}
+	var blockers []string
+	feedbackByItem := map[string]int{}
+	for _, event := range events {
+		feedbackByItem[strings.TrimSpace(event.ItemID)]++
+	}
+	for _, item := range items {
+		itemID := strings.TrimSpace(item.ItemID)
+		if itemID == "" {
+			itemID = item.ID
+		}
+		if feedbackByItem[itemID] == 0 {
+			blockers = append(blockers, fmt.Sprintf("item %s has no imported feedback", itemID))
+		}
+	}
+	if _, err := skillopt.ExportTrainingPackage(ctx, store, runID); err != nil {
+		blockers = append(blockers, fmt.Sprintf("training export failed: %v", err))
+	}
+	return blockers
+}
+
+func validateReviewArtifactBlob(ctx context.Context, store *db.Store, blobStore artifact.Store, itemID string, role string, artifactID string, validated map[string]struct{}) []string {
+	if _, ok := validated[artifactID]; ok {
+		return nil
+	}
+	validated[artifactID] = struct{}{}
+	record, err := store.GetEvalArtifact(ctx, artifactID)
+	if err != nil {
+		return []string{fmt.Sprintf("item %s %s artifact %s is not registered: %v", itemID, role, artifactID, err)}
+	}
+	if _, err := blobStore.Read(record.Hash); err != nil {
+		return []string{fmt.Sprintf("item %s %s artifact %s blob is not readable: %v", itemID, role, artifactID, err)}
+	}
+	return nil
 }
 
 func runSkillOptExport(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -642,6 +642,429 @@ func TestSkillOptFeedbackGitHubCommands(t *testing.T) {
 	}
 }
 
+func TestSkillOptReviewCreateAndStatus(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt help exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "gitmoot skillopt review create") || !strings.Contains(stdout.String(), "gitmoot skillopt review status") {
+		t.Fatalf("skillopt help missing review commands:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "review", "create",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/repo",
+		"--run", "planner-ab-1",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review create exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "created review planner-ab-1 for "+installed.VersionID) {
+		t.Fatalf("review create stdout = %q", stdout.String())
+	}
+
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open after create returned error: %v", err)
+	}
+	run, err := store.GetEvalRun(context.Background(), "planner-ab-1")
+	if err != nil {
+		t.Fatalf("GetEvalRun returned error: %v", err)
+	}
+	if run.TemplateID != "planner" || run.TemplateVersionID != installed.VersionID || run.TargetRepo != "owner/repo" || run.State != "review" {
+		t.Fatalf("eval run = %+v", run)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	baselineBlob, err := blobStore.Put([]byte("baseline"))
+	if err != nil {
+		t.Fatalf("Put baseline returned error: %v", err)
+	}
+	candidateBlob, err := blobStore.Put([]byte("candidate"))
+	if err != nil {
+		t.Fatalf("Put candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+		ID:        "baseline",
+		Hash:      baselineBlob.Hash,
+		MediaType: "text/markdown",
+		SizeBytes: baselineBlob.Size,
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact baseline returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+		ID:        "candidate",
+		Hash:      candidateBlob.Hash,
+		MediaType: "text/markdown",
+		SizeBytes: candidateBlob.Size,
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:               "planner-ab-1",
+		ItemID:              "item-001",
+		Title:               "README planning task",
+		BaselineArtifactID:  "baseline",
+		CandidateArtifactID: "candidate",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	if err := store.UpsertFeedbackEvent(context.Background(), db.FeedbackEvent{
+		RunID:     "planner-ab-1",
+		ItemID:    "item-001",
+		Choice:    "b",
+		Reasoning: "More concrete.",
+		Reviewer:  "jerry",
+		Source:    "markdown",
+		CreatedAt: "2026-05-31T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertFeedbackEvent returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after seed returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "review", "status", "--home", home, "--run", "planner-ab-1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review status exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"run: planner-ab-1",
+		"template: planner",
+		"template_version: " + installed.VersionID,
+		"repo: owner/repo",
+		"state: review",
+		"items: 1",
+		"feedback: 1",
+		"packet_blockers: 0",
+		"training_blockers: 0",
+		"ready_for_packet: true",
+		"ready_for_training: true",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("status stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestSkillOptReviewStatusRequiresExportableArtifacts(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:                "planner-ab-1",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		MetadataJSON:      `{"driver":"manual-review"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:               "planner-ab-1",
+		ItemID:              "item-001",
+		BaselineArtifactID:  "baseline",
+		CandidateArtifactID: "candidate",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	if err := store.UpsertFeedbackEvent(context.Background(), db.FeedbackEvent{
+		RunID:     "planner-ab-1",
+		ItemID:    "item-001",
+		Choice:    "b",
+		Reviewer:  "jerry",
+		Source:    "markdown",
+		CreatedAt: "2026-05-31T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertFeedbackEvent returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "review", "status", "--home", home, "--run", "planner-ab-1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review status exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"items: 1",
+		"feedback: 1",
+		"packet_blockers: 2",
+		"training_blockers: 1",
+		"ready_for_packet: false",
+		"ready_for_training: false",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("status stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestSkillOptReviewStatusRequiresExportableMetadata(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	baselineBlob, err := blobStore.Put([]byte("baseline"))
+	if err != nil {
+		t.Fatalf("Put baseline returned error: %v", err)
+	}
+	candidateBlob, err := blobStore.Put([]byte("candidate"))
+	if err != nil {
+		t.Fatalf("Put candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+		ID:        "baseline",
+		Hash:      baselineBlob.Hash,
+		MediaType: "text/markdown",
+		SizeBytes: baselineBlob.Size,
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact baseline returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+		ID:        "candidate",
+		Hash:      candidateBlob.Hash,
+		MediaType: "text/markdown",
+		SizeBytes: candidateBlob.Size,
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact candidate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:                "planner-ab-1",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		MetadataJSON:      `{"driver":"manual-review"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:               "planner-ab-1",
+		ItemID:              "item-001",
+		BaselineArtifactID:  "baseline",
+		CandidateArtifactID: "candidate",
+		MetadataJSON:        `{not-json`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	if err := store.UpsertFeedbackEvent(context.Background(), db.FeedbackEvent{
+		RunID:     "planner-ab-1",
+		ItemID:    "item-001",
+		Choice:    "b",
+		Reviewer:  "jerry",
+		Source:    "markdown",
+		CreatedAt: "2026-05-31T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertFeedbackEvent returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "review", "status", "--home", home, "--run", "planner-ab-1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review status exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"packet_blockers: 0",
+		"training_blockers: 1",
+		"ready_for_packet: true",
+		"ready_for_training: false",
+		"training_blocker: training export failed: eval item item-001 metadata_json:",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("status stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestSkillOptReviewStatusRequiresFeedbackForEveryItem(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	for _, fixture := range []struct {
+		id      string
+		content string
+	}{
+		{id: "item-001-baseline", content: "item 1 baseline"},
+		{id: "item-001-candidate", content: "item 1 candidate"},
+		{id: "item-002-baseline", content: "item 2 baseline"},
+		{id: "item-002-candidate", content: "item 2 candidate"},
+	} {
+		blob, err := blobStore.Put([]byte(fixture.content))
+		if err != nil {
+			t.Fatalf("Put %s returned error: %v", fixture.id, err)
+		}
+		if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+			ID:        fixture.id,
+			Hash:      blob.Hash,
+			MediaType: "text/markdown",
+			SizeBytes: blob.Size,
+			Driver:    "text",
+		}); err != nil {
+			t.Fatalf("UpsertEvalArtifact %s returned error: %v", fixture.id, err)
+		}
+	}
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:                "planner-ab-1",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		MetadataJSON:      `{"driver":"manual-review"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	for _, item := range []db.EvalReviewItem{
+		{RunID: "planner-ab-1", ItemID: "item-001", BaselineArtifactID: "item-001-baseline", CandidateArtifactID: "item-001-candidate"},
+		{RunID: "planner-ab-1", ItemID: "item-002", BaselineArtifactID: "item-002-baseline", CandidateArtifactID: "item-002-candidate"},
+	} {
+		if err := store.UpsertEvalReviewItem(context.Background(), item); err != nil {
+			t.Fatalf("UpsertEvalReviewItem %s returned error: %v", item.ItemID, err)
+		}
+	}
+	if err := store.UpsertFeedbackEvent(context.Background(), db.FeedbackEvent{
+		RunID:     "planner-ab-1",
+		ItemID:    "item-001",
+		Choice:    "b",
+		Reviewer:  "jerry",
+		Source:    "markdown",
+		CreatedAt: "2026-05-31T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertFeedbackEvent returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "review", "status", "--home", home, "--run", "planner-ab-1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review status exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"items: 2",
+		"feedback: 1",
+		"packet_blockers: 0",
+		"training_blockers: 1",
+		"ready_for_packet: true",
+		"ready_for_training: false",
+		"training_blocker: item item-002 has no imported feedback",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("status stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestSkillOptReviewCreateRejectsUnknownTemplate(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "review", "create",
+		"--home", home,
+		"--template", "missing-template",
+		"--repo", "owner/repo",
+		"--run", "planner-ab-1",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("skillopt review create exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "agent template missing-template is not installed") {
+		t.Fatalf("review create stderr = %q", stderr.String())
+	}
+}
+
+func TestSkillOptReviewStatusRejectsMissingRun(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "review", "status", "--home", home, "--run", "missing-run"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("skillopt review status exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "review run missing-run not found") {
+		t.Fatalf("review status stderr = %q", stderr.String())
+	}
+}
+
 type skillOptFakeGitHub struct {
 	github.NoopClient
 


### PR DESCRIPTION
WHAT:
Add the first operator-facing SkillOpt human feedback trial commands: `gitmoot skillopt review create` and `gitmoot skillopt review status`.

WHY:
Users need a supported way to create and inspect SkillOpt review runs before adding review items, exporting feedback packets, and producing training packages.

CHANGES:
- Added the `gitmoot skillopt review` command group.
- Added `review create` to persist a review-state eval run for an installed agent template and target repo.
- Added `review status` with template/version/repo/state, item and feedback counts, packet/training readiness, and readiness blockers.
- Validated packet readiness against baseline/candidate artifact completeness and readable blobs.
- Validated training readiness against complete per-item feedback and the existing `skillopt.ExportTrainingPackage` contract.
- Added the task goal file for the full SkillOpt human feedback trial workflow.
- Added focused CLI tests for create/status, missing templates, missing runs, invalid artifacts, invalid export metadata, and partial feedback.

RESULTS:
- `/root/temp/ts/tool/go test ./internal/cli -run 'TestSkillOptReview|TestSkillOptExportAndImportCommands'`
- `/root/temp/ts/tool/go test ./internal/cli ./internal/skillopt ./internal/db`
- `/root/temp/ts/tool/go test ./...`
- `git diff --check`
- Manual smoke:

```text
updated planner at a5126710752910f5fb65243c025adf4c50e5a912
created review planner-ab-1 for planner@v1
run: planner-ab-1
template: planner
template_version: planner@v1
repo: owner/repo
state: review
items: 0
feedback: 0
packet_blockers: 1
training_blockers: 1
ready_for_packet: false
ready_for_training: false
packet_blocker: run has no review items
training_blocker: run has no review items
```

Final raw `codex exec review --uncommitted` output:

```text
No discrete correctness issues were found in the current changes. I was unable to run the Go tests because the sandbox could not download the required Go 1.26 toolchain, but the reviewed diff itself did not reveal blocking bugs.
No discrete correctness issues were found in the current changes. I was unable to run the Go tests because the sandbox could not download the required Go 1.26 toolchain, but the reviewed diff itself did not reveal blocking bugs.
```

RISK:
- Codex review could not run Go tests inside its sandbox because it only had Go 1.22 and the repo requires Go 1.26. Tests were run locally with `/root/temp/ts/tool/go`.
- This task does not add review item creation yet; that is the next task in the goal.
