### PR TITLE
feat: add skillopt review item add

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/config"
@@ -53,6 +54,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt export --run <run-id> [--output package.json]")
 	fmt.Fprintln(w, "  gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]")
 	fmt.Fprintln(w, "  gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>")
+	fmt.Fprintln(w, "  gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]")
 	fmt.Fprintln(w, "  gitmoot skillopt review status --run <run-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate list [--template id]")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate show <version-id>")
@@ -72,6 +74,8 @@ func runSkillOptReview(args []string, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "create":
 		return runSkillOptReviewCreate(args[1:], stdout, stderr)
+	case "item":
+		return runSkillOptReviewItem(args[1:], stdout, stderr)
 	case "status":
 		return runSkillOptReviewStatus(args[1:], stdout, stderr)
 	default:
@@ -127,6 +131,97 @@ func runSkillOptReviewCreate(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	writeLine(stdout, "created review %s for %s", run.ID, run.TemplateVersionID)
+	return 0
+}
+
+func runSkillOptReviewItem(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSkillOptUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "add":
+		return runSkillOptReviewItemAdd(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skillopt review item command %q\n\n", args[0])
+		printSkillOptUsage(stderr)
+		return 2
+	}
+}
+
+func runSkillOptReviewItemAdd(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt review item add", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	runID := fs.String("run", "", "review run id")
+	itemID := fs.String("item", "", "review item id")
+	title := fs.String("title", "", "review item title")
+	baselinePath := fs.String("baseline", "", "baseline output file")
+	candidatePath := fs.String("candidate", "", "candidate output file")
+	metadataJSON := fs.String("metadata-json", "", "JSON metadata to attach to the review item")
+	mediaType := fs.String("media-type", "", "media type override for stored artifacts")
+	driver := fs.String("driver", "text", "artifact driver")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt review item add does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*runID) == "" || strings.TrimSpace(*itemID) == "" || strings.TrimSpace(*baselinePath) == "" || strings.TrimSpace(*candidatePath) == "" {
+		fmt.Fprintln(stderr, "skillopt review item add requires --run, --item, --baseline, and --candidate")
+		return 2
+	}
+	metadata, err := normalizeSkillOptMetadataJSON(*metadataJSON)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt review item add: %v\n", err)
+		return 2
+	}
+	var item db.EvalReviewItem
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		ctx := context.Background()
+		run, err := store.GetEvalRun(ctx, strings.TrimSpace(*runID))
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("review run %s not found", strings.TrimSpace(*runID))
+			}
+			return err
+		}
+		blobStore := artifact.NewStore(paths.ArtifactBlobs)
+		baseline, err := prepareReviewItemArtifact(blobStore, run.ID, *itemID, "baseline", *baselinePath, *mediaType, *driver)
+		if err != nil {
+			return err
+		}
+		candidate, err := prepareReviewItemArtifact(blobStore, run.ID, *itemID, "candidate", *candidatePath, *mediaType, *driver)
+		if err != nil {
+			return err
+		}
+		if baseline.ID == candidate.ID {
+			return errors.New("baseline and candidate artifact ids must be different")
+		}
+		if err := store.UpsertEvalArtifact(ctx, baseline); err != nil {
+			return fmt.Errorf("register baseline artifact: %w", err)
+		}
+		if err := store.UpsertEvalArtifact(ctx, candidate); err != nil {
+			return fmt.Errorf("register candidate artifact: %w", err)
+		}
+		item = db.EvalReviewItem{
+			RunID:               run.ID,
+			ItemID:              strings.TrimSpace(*itemID),
+			Title:               strings.TrimSpace(*title),
+			BaselineArtifactID:  baseline.ID,
+			CandidateArtifactID: candidate.ID,
+			MetadataJSON:        metadata,
+		}
+		return store.UpsertEvalReviewItem(ctx, item)
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt review item add: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "added review item %s to %s", item.ItemID, item.RunID)
 	return 0
 }
 
@@ -283,6 +378,76 @@ func validateReviewArtifactBlob(ctx context.Context, store *db.Store, blobStore 
 		return []string{fmt.Sprintf("item %s %s artifact %s blob is not readable: %v", itemID, role, artifactID, err)}
 	}
 	return nil
+}
+
+func prepareReviewItemArtifact(blobStore artifact.Store, runID string, itemID string, role string, path string, mediaTypeOverride string, driver string) (db.EvalArtifact, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return db.EvalArtifact{}, fmt.Errorf("%s path is required", role)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return db.EvalArtifact{}, fmt.Errorf("read %s file: %w", role, err)
+	}
+	mediaType, err := reviewArtifactMediaType(path, content, mediaTypeOverride)
+	if err != nil {
+		return db.EvalArtifact{}, fmt.Errorf("%s file: %w", role, err)
+	}
+	blob, err := blobStore.Put(content)
+	if err != nil {
+		return db.EvalArtifact{}, fmt.Errorf("store %s artifact blob: %w", role, err)
+	}
+	artifactRecord := db.EvalArtifact{
+		ID:        reviewItemArtifactID(runID, itemID, role),
+		Hash:      blob.Hash,
+		MediaType: mediaType,
+		SizeBytes: blob.Size,
+		Driver:    strings.TrimSpace(driver),
+	}
+	if artifactRecord.Driver == "" {
+		artifactRecord.Driver = "text"
+	}
+	return artifactRecord, nil
+}
+
+func reviewItemArtifactID(runID string, itemID string, role string) string {
+	return strings.TrimSpace(runID) + "/" + strings.TrimSpace(itemID) + "/" + strings.TrimSpace(role)
+}
+
+func reviewArtifactMediaType(path string, content []byte, override string) (string, error) {
+	if mediaType := strings.TrimSpace(override); mediaType != "" {
+		return mediaType, nil
+	}
+	if !utf8.Valid(content) {
+		return "", errors.New("binary content requires --media-type")
+	}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".md", ".markdown":
+		return "text/markdown", nil
+	case ".txt", ".text", ".diff", ".patch":
+		return "text/plain", nil
+	case ".csv":
+		return "text/csv", nil
+	case ".json":
+		return "application/json", nil
+	}
+	return "text/plain", nil
+}
+
+func normalizeSkillOptMetadataJSON(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(value), &decoded); err != nil {
+		return "", fmt.Errorf("metadata-json: %w", err)
+	}
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		return "", fmt.Errorf("metadata-json: %w", err)
+	}
+	return string(encoded), nil
 }
 
 func runSkillOptExport(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -776,6 +776,233 @@ func TestSkillOptReviewCreateAndStatus(t *testing.T) {
 	}
 }
 
+func TestSkillOptReviewItemAddStoresArtifacts(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "review", "create",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/repo",
+		"--run", "planner-ab-1",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review create exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	inputDir := t.TempDir()
+	baselinePath := filepath.Join(inputDir, "baseline.md")
+	candidatePath := filepath.Join(inputDir, "candidate.md")
+	if err := os.WriteFile(baselinePath, []byte("# Baseline\n\nShort plan.\n"), 0o644); err != nil {
+		t.Fatalf("write baseline: %v", err)
+	}
+	if err := os.WriteFile(candidatePath, []byte("# Candidate\n\nShort plan with risks.\n"), 0o644); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "review", "item", "add",
+		"--home", home,
+		"--run", "planner-ab-1",
+		"--item", "item-001",
+		"--title", "README planning task",
+		"--baseline", baselinePath,
+		"--candidate", candidatePath,
+		"--metadata-json", `{"path":"README.md"}`,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review item add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "added review item item-001 to planner-ab-1") {
+		t.Fatalf("review item add stdout = %q", stdout.String())
+	}
+
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open after item add returned error: %v", err)
+	}
+	items, err := store.ListEvalReviewItems(context.Background(), "planner-ab-1")
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("review item count = %d, want 1", len(items))
+	}
+	item := items[0]
+	if item.Title != "README planning task" || item.BaselineArtifactID != "planner-ab-1/item-001/baseline" || item.CandidateArtifactID != "planner-ab-1/item-001/candidate" || item.MetadataJSON != `{"path":"README.md"}` {
+		t.Fatalf("review item = %+v", item)
+	}
+	baseline, err := store.GetEvalArtifact(context.Background(), item.BaselineArtifactID)
+	if err != nil {
+		t.Fatalf("GetEvalArtifact baseline returned error: %v", err)
+	}
+	candidate, err := store.GetEvalArtifact(context.Background(), item.CandidateArtifactID)
+	if err != nil {
+		t.Fatalf("GetEvalArtifact candidate returned error: %v", err)
+	}
+	if baseline.MediaType != "text/markdown" || candidate.MediaType != "text/markdown" || baseline.Driver != "text" || candidate.Driver != "text" {
+		t.Fatalf("artifacts = %+v %+v", baseline, candidate)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after artifact check returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "review", "status", "--home", home, "--run", "planner-ab-1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review status exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"items: 1",
+		"feedback: 0",
+		"packet_blockers: 0",
+		"training_blockers: 1",
+		"ready_for_packet: true",
+		"ready_for_training: false",
+		"training_blocker: item item-001 has no imported feedback",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("status stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	packetDir := filepath.Join(t.TempDir(), "packet")
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "feedback", "markdown", "export", "--home", home, "--run", "planner-ab-1", "--output", packetDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt feedback markdown export exit code = %d, stderr=%s", code, stderr.String())
+	}
+	feedbackYAML, err := os.ReadFile(filepath.Join(packetDir, "feedback.yml"))
+	if err != nil {
+		t.Fatalf("read feedback.yml: %v", err)
+	}
+	if !strings.Contains(string(feedbackYAML), "item_id: item-001") {
+		t.Fatalf("feedback.yml = %s", string(feedbackYAML))
+	}
+}
+
+func TestSkillOptReviewItemAddRejectsInvalidInputs(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:                "planner-ab-1",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		MetadataJSON:      `{"driver":"manual-review"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	inputDir := t.TempDir()
+	baselinePath := filepath.Join(inputDir, "baseline.md")
+	candidatePath := filepath.Join(inputDir, "candidate.md")
+	binaryPath := filepath.Join(inputDir, "candidate.bin")
+	if err := os.WriteFile(baselinePath, []byte("baseline\n"), 0o644); err != nil {
+		t.Fatalf("write baseline: %v", err)
+	}
+	if err := os.WriteFile(candidatePath, []byte("candidate\n"), 0o644); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte{0xff, 0x00, 0x01}, 0o644); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "missing run",
+			args: []string{
+				"skillopt", "review", "item", "add",
+				"--home", home,
+				"--run", "missing-run",
+				"--item", "item-001",
+				"--baseline", baselinePath,
+				"--candidate", candidatePath,
+			},
+			wantErr: "review run missing-run not found",
+		},
+		{
+			name: "invalid metadata",
+			args: []string{
+				"skillopt", "review", "item", "add",
+				"--home", home,
+				"--run", "planner-ab-1",
+				"--item", "item-001",
+				"--baseline", baselinePath,
+				"--candidate", candidatePath,
+				"--metadata-json", "{not-json",
+			},
+			wantErr: "metadata-json:",
+		},
+		{
+			name: "binary without media type",
+			args: []string{
+				"skillopt", "review", "item", "add",
+				"--home", home,
+				"--run", "planner-ab-1",
+				"--item", "item-001",
+				"--baseline", baselinePath,
+				"--candidate", binaryPath,
+			},
+			wantErr: "binary content requires --media-type",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := Run(tt.args, &stdout, &stderr)
+			if code == 0 {
+				t.Fatalf("exit code = 0, stdout=%s", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tt.wantErr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestSkillOptReviewStatusRequiresExportableArtifacts(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)


### PR DESCRIPTION
WHAT:
Add `gitmoot skillopt review item add` for attaching baseline/candidate output files to a SkillOpt review run.

WHY:
The human feedback trial flow needs a supported way to create review items and artifacts without manually seeding SQLite rows.

CHANGES:
- Added `gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline <file> --candidate <file>`.
- Stores baseline and candidate file bytes in the content-addressed artifact blob store.
- Registers deterministic run/item/role artifact ids such as `<run>/<item>/baseline` and `<run>/<item>/candidate`.
- Creates or updates the `eval_review_items` row with title and optional compacted JSON metadata.
- Infers text media types from common extensions and rejects binary content unless `--media-type` is explicit.
- Added tests for item creation, status readiness, Markdown packet export, missing runs, invalid metadata, and binary input rejection.

RESULTS:
- `/root/temp/ts/tool/go test ./internal/cli -run 'TestSkillOptReview(Item|Create|Status)|TestSkillOptExportAndImportCommands'`
- `/root/temp/ts/tool/go test ./internal/cli ./internal/feedback ./internal/db`
- `/root/temp/ts/tool/go test ./...`
- `git diff --check`
- Manual smoke:

```text
updated planner at 92dd5c7e53ecce702d1940c8149f5d177345ba67
created review planner-ab-1 for planner@v1
added review item item-001 to planner-ab-1
run: planner-ab-1
template: planner
template_version: planner@v1
repo: owner/repo
state: review
items: 1
feedback: 0
packet_blockers: 0
training_blockers: 1
ready_for_packet: true
ready_for_training: false
training_blocker: item item-001 has no imported feedback
wrote markdown feedback packet for planner-ab-1 to /tmp/tmp.eVA2Yhy4tl/packet
```

Final raw `codex exec review --uncommitted` output:

```text
No actionable correctness issues were found in the current diff. Tests could not be run in this sandbox because Go attempted to download the 1.26 toolchain into a read-only module cache.
No actionable correctness issues were found in the current diff. Tests could not be run in this sandbox because Go attempted to download the 1.26 toolchain into a read-only module cache.
```

RISK:
- Codex review could not run Go tests inside its sandbox because Go 1.26 toolchain download hit a read-only cache. Tests were run locally with `/root/temp/ts/tool/go`.
- This task only covers local baseline/candidate review item creation; docs and end-to-end smoke are separate planned tasks.
