### PR TITLE
docs: add skillopt feedback trial workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ gitmoot lock release owner/repo <branch> --owner <agent>
 ### SkillOpt Exchange
 
 ```sh
+gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>
+gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]
+gitmoot skillopt review status --run <run-id>
 gitmoot skillopt export --run <run-id> --output training.json
 gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
@@ -285,9 +288,24 @@ gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--p
 gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
-The export/import boundary lets a future external `gitmoot-skillopt` optimizer
-train on local eval artifacts and return candidate template versions. Imported
-candidates stay pending until a human review workflow promotes them.
+Create a review run, add saved baseline/candidate outputs as review items,
+export a Markdown or GitHub feedback packet, import the completed feedback, then
+export `training.json` for a future external `gitmoot-skillopt` optimizer.
+Dry-run optimization validates the contract without model calls:
+
+```sh
+gitmoot-skillopt optimize \
+  --training-package training.json \
+  --artifact-root ~/.gitmoot/evals/blobs \
+  --out-root .gitmoot/skillopt/run-2026-05-31 \
+  --candidate-output candidate.json \
+  --dry-run
+```
+
+Before real model-backed optimization, run `gitmoot-skillopt optimize --help`
+and verify required model/backend environment variables for the installed
+optimizer version. Imported candidates stay pending until a human review
+workflow promotes them.
 When a candidate package includes new artifact manifest entries, pass
 `--artifact-dir` to the directory containing those files; Gitmoot verifies
 relative paths and SHA256 hashes before storing blobs.
@@ -296,6 +314,11 @@ The external optimizer walkthrough lives in
 Use `skillopt candidate show` to inspect the candidate metadata, eval report,
 feedback summary, and content diff before `promote` or `reject` records the
 decision.
+
+Use the Markdown feedback collector for a local blind A/B packet: open
+`index.md`, review `items/*.md`, set `reviewer`, edit `feedback.yml` with `a`,
+`b`, `tie`, `neither`, or `skip`, and import it. Keep `.assignments.json`
+untouched so Gitmoot can validate and de-blind the mapping.
 
 Use the GitHub feedback collector when review should happen in an issue or an
 existing PR thread. Reviewers can reply with either the copy-paste YAML block or

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -82,6 +82,87 @@ gitmoot skillopt candidate reject planner@v3 --reason "Too broad for the current
 Promotion updates the template's current version. Rejection records an audit
 reason and prevents the rejected candidate from being selected by `@latest`.
 
+## Human Feedback Trial Happy Path
+
+Create an eval review run and add saved baseline/candidate outputs:
+
+```sh
+gitmoot skillopt review create \
+  --template planner \
+  --repo owner/repo \
+  --run run-2026-05-31
+
+gitmoot skillopt review item add \
+  --run run-2026-05-31 \
+  --item item-001 \
+  --title "README planning task" \
+  --baseline baseline.md \
+  --candidate candidate.md \
+  --metadata-json '{"path":"README.md"}'
+
+gitmoot skillopt review status --run run-2026-05-31
+```
+
+Then export a blind local packet, collect human feedback, and import it:
+
+```sh
+gitmoot skillopt feedback markdown export \
+  --run run-2026-05-31 \
+  --output .gitmoot/evals/run-2026-05-31
+
+# Human opens index.md, reviews items/*.md, sets reviewer, and edits feedback.yml.
+
+gitmoot skillopt feedback markdown import \
+  --packet .gitmoot/evals/run-2026-05-31
+```
+
+When every review item has imported feedback, export the training package for
+the external optimizer:
+
+```sh
+gitmoot skillopt review status --run run-2026-05-31
+gitmoot skillopt export --run run-2026-05-31 --output training.json
+```
+
+Use `--dry-run` first to validate the exchange contract without model calls:
+
+```sh
+gitmoot-skillopt optimize \
+  --training-package training.json \
+  --artifact-root ~/.gitmoot/evals/blobs \
+  --out-root .gitmoot/skillopt/run-2026-05-31 \
+  --candidate-output candidate.json \
+  --dry-run
+```
+
+For real model-backed optimization, verify the installed optimizer contract and
+environment before running it:
+
+```sh
+gitmoot-skillopt --help
+gitmoot-skillopt optimize --help
+for name in OPENAI_API_KEY ANTHROPIC_API_KEY GITMOOT_SKILLOPT_BACKEND; do
+  if [ -n "${!name:-}" ]; then
+    printf '%s=set\n' "$name"
+  else
+    printf '%s=missing\n' "$name"
+  fi
+done
+```
+
+Use the backend, model, and budget flags shown by your installed
+`gitmoot-skillopt optimize --help`. Do not assume flag names without checking
+the local optimizer version.
+
+Import and review the candidate. Importing never promotes automatically:
+
+```sh
+gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
+gitmoot skillopt candidate show <version-id>
+gitmoot skillopt candidate promote <version-id>
+gitmoot skillopt candidate reject <version-id> --reason "Needs narrower instructions"
+```
+
 ## Markdown Feedback Packet
 
 Generate a local blind A/B review packet:
@@ -173,14 +254,16 @@ unrelated comments and de-duplicates repeated imports by comment URL.
 
 Complete local review path:
 
-1. `gitmoot skillopt export --run <run-id> --output training.json`
-2. External optimizer returns `candidate.json`.
-3. `gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]`
-4. `gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>`
-5. Human fills `feedback.yml`.
-6. `gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>`
-7. `gitmoot skillopt candidate show <version-id>`
-8. `gitmoot skillopt candidate promote <version-id>` or `gitmoot skillopt candidate reject <version-id>`
+1. `gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>`
+2. `gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md`
+3. `gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>`
+4. Human opens `index.md`, reviews `items/*.md`, sets `reviewer`, and fills `feedback.yml`.
+5. `gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>`
+6. `gitmoot skillopt export --run <run-id> --output training.json`
+7. `gitmoot-skillopt optimize --training-package training.json --artifact-root ~/.gitmoot/evals/blobs --out-root .gitmoot/skillopt/<run-id> --candidate-output candidate.json --dry-run`
+8. `gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]`
+9. `gitmoot skillopt candidate show <version-id>`
+10. `gitmoot skillopt candidate promote <version-id>` or `gitmoot skillopt candidate reject <version-id>`
 
 Complete GitHub review path:
 

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -207,7 +207,7 @@ func (c MarkdownCollector) writeItem(ctx context.Context, store *db.Store, dir s
 	builder.WriteString("\n## Option B\n\n")
 	writeMarkdownFence(&builder, optionB)
 	builder.WriteString("\n## Feedback\n\n")
-	builder.WriteString("Fill `feedback.yml` with one of: `a`, `b`, `tie`, `neither`, `skip`.\n")
+	builder.WriteString("Record this item in `../feedback.yml` with one of: `a`, `b`, `tie`, `neither`, `skip`.\n")
 	return writeTextFile(filepath.Join(dir, "items", itemFilename(item.ItemID)), builder.String(), 0o644)
 }
 
@@ -340,13 +340,24 @@ func indexMarkdown(run db.EvalRun, items []db.EvalReviewItem) string {
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "# Gitmoot Feedback Packet: %s\n\n", run.ID)
 	builder.WriteString("Review each item without trying to infer which option is baseline or candidate.\n\n")
-	builder.WriteString("Allowed choices: `a`, `b`, `tie`, `neither`, `skip`.\n\n")
+	builder.WriteString("## How To Review\n\n")
+	builder.WriteString("1. Open this `index.md` file.\n")
+	builder.WriteString("2. Open each linked item in `items/*.md`.\n")
+	builder.WriteString("3. Compare Option A and Option B blind for each item.\n")
+	builder.WriteString("4. Edit `feedback.yml` in this packet directory and set `reviewer`.\n")
+	builder.WriteString("5. For every item, choose exactly one of: `a`, `b`, `tie`, `neither`, `skip`.\n")
+	builder.WriteString("6. Add concise `reasoning` when it helps explain the choice.\n")
+	builder.WriteString("7. Import the completed packet. If `reviewer` is not set in `feedback.yml`, pass `--reviewer <name>`:\n\n")
+	builder.WriteString("   ```sh\n")
+	builder.WriteString("   gitmoot skillopt feedback markdown import --packet <packet-dir> --reviewer <name>\n")
+	builder.WriteString("   ```\n\n")
+	builder.WriteString("Keep `.assignments.json` untouched. It is hidden Gitmoot metadata used to preserve and validate the blind A/B mapping on import.\n\n")
 	builder.WriteString("## Items\n\n")
 	for _, item := range items {
 		fmt.Fprintf(&builder, "- [%s](items/%s)\n", itemTitle(item), itemFilename(item.ItemID))
 	}
 	builder.WriteString("\n## Submit Feedback\n\n")
-	builder.WriteString("Edit `feedback.yml`, then import it with Gitmoot.\n")
+	builder.WriteString("After all items are filled in `feedback.yml`, run the import command above.\n")
 	return builder.String()
 }
 

--- a/internal/feedback/markdown_test.go
+++ b/internal/feedback/markdown_test.go
@@ -69,7 +69,10 @@ func TestMarkdownCollectorWriteAndImportPacket(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read index: %v", err)
 	}
-	if !strings.Contains(string(index), "Allowed choices") {
+	if !strings.Contains(string(index), "Open each linked item") ||
+		!strings.Contains(string(index), "set `reviewer`") ||
+		!strings.Contains(string(index), "gitmoot skillopt feedback markdown import --packet <packet-dir> --reviewer <name>") ||
+		!strings.Contains(string(index), ".assignments.json") {
 		t.Fatalf("index content misses instructions:\n%s", string(index))
 	}
 	itemContent, err := os.ReadFile(filepath.Join(packetDir, "items", itemFilename("item-001")))
@@ -78,6 +81,9 @@ func TestMarkdownCollectorWriteAndImportPacket(t *testing.T) {
 	}
 	if !strings.Contains(string(itemContent), "Option A") || !strings.Contains(string(itemContent), "Option B") {
 		t.Fatalf("item content missing options:\n%s", string(itemContent))
+	}
+	if !strings.Contains(string(itemContent), "../feedback.yml") {
+		t.Fatalf("item content missing feedback.yml guidance:\n%s", string(itemContent))
 	}
 	if !strings.Contains(string(itemContent), "````text") || !strings.Contains(string(itemContent), "```go") {
 		t.Fatalf("item content does not preserve nested Markdown fences:\n%s", string(itemContent))

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -256,6 +256,9 @@ gitmoot lock show owner/repo <branch>
 ## SkillOpt Exchange
 
 ```sh
+gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>
+gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]
+gitmoot skillopt review status --run <run-id>
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
@@ -268,10 +271,22 @@ gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--p
 gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
+`skillopt review create` starts a review run for a template and target repo.
+`skillopt review item add` stores saved baseline/candidate outputs as artifact
+backed A/B review items. `skillopt review status` reports whether the run has
+items, complete artifacts, imported feedback for every item, and enough metadata
+to export.
+
 `skillopt export` writes a JSON training package with the template snapshot,
 eval run, review items, artifact manifests, feedback events when present, and
-evaluator config. `skillopt import` validates a candidate package and stores the
-candidate template as a pending version; it never promotes the candidate
+evaluator config. Use `gitmoot-skillopt optimize --training-package
+training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
+.gitmoot/skillopt/<run-id> --candidate-output candidate.json --dry-run` first
+to validate the contract without model calls.
+Before real model-backed optimization, check `gitmoot-skillopt optimize --help`
+and verify required model/backend environment variables for the installed
+optimizer version. `skillopt import` validates a candidate package and stores
+the candidate template as a pending version; it never promotes the candidate
 automatically. If the candidate package includes new artifact manifest entries,
 pass `--artifact-dir` so Gitmoot can verify relative paths and SHA256 hashes
 before storing blobs. `skillopt candidate show` displays candidate metadata, eval
@@ -283,7 +298,9 @@ version from being selected by `@latest`.
 The Markdown feedback collector writes blind A/B review packets with `index.md`,
 per-item Markdown files, editable `feedback.yml`, and hidden assignment metadata
 that Gitmoot uses to validate the full response and import de-blinded canonical
-feedback events.
+feedback events. Open `index.md`, review every file in `items/*.md`, set
+`reviewer`, edit `feedback.yml` with exactly one of `a`, `b`, `tie`, `neither`,
+or `skip` for every item, and leave `.assignments.json` untouched.
 
 The GitHub feedback collector publishes the same blind A/B review packet to a
 new issue by default, or to an existing PR when `--pr <number>` is provided.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -60,6 +60,9 @@ gitmoot lock list --repo owner/repo
 ## SkillOpt Exchange
 
 ```sh
+gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>
+gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]
+gitmoot skillopt review status --run <run-id>
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -41,6 +41,36 @@ gitmoot skillopt candidate reject planner@v3 --reason "Too broad"
 Promotion updates the current template version; rejection records an audit reason
 and keeps the rejected version out of `@latest`.
 
+## Human Feedback Trial Happy Path
+
+Create a run and add saved baseline/candidate outputs:
+
+```sh
+gitmoot skillopt review create --template planner --repo owner/repo --run run-2026-05-31
+gitmoot skillopt review item add --run run-2026-05-31 --item item-001 --title "README planning task" --baseline baseline.md --candidate candidate.md --metadata-json '{"path":"README.md"}'
+gitmoot skillopt review status --run run-2026-05-31
+```
+
+Export a blind packet, have the human edit `feedback.yml`, and import it:
+
+```sh
+gitmoot skillopt feedback markdown export --run run-2026-05-31 --output .gitmoot/evals/run-2026-05-31
+# Human opens index.md, reviews items/*.md, sets reviewer, and edits feedback.yml.
+gitmoot skillopt feedback markdown import --packet .gitmoot/evals/run-2026-05-31
+```
+
+Export training data and validate the external optimizer contract:
+
+```sh
+gitmoot skillopt export --run run-2026-05-31 --output training.json
+gitmoot-skillopt optimize --training-package training.json --artifact-root ~/.gitmoot/evals/blobs --out-root .gitmoot/skillopt/run-2026-05-31 --candidate-output candidate.json --dry-run
+```
+
+For real model-backed optimization, check `gitmoot-skillopt optimize --help`
+and verify required backend/model environment variables for your installed
+optimizer version. Importing the candidate keeps it pending until a human
+explicitly promotes or rejects it.
+
 ## Markdown Feedback Packet
 
 ```sh
@@ -51,7 +81,7 @@ gitmoot skillopt feedback markdown export \
 
 The packet contains `index.md`, one Markdown file per item, editable
 `feedback.yml`, and hidden `.assignments.json` metadata that lets Gitmoot recover
-the blind A/B mapping.
+the blind A/B mapping. Keep `.assignments.json` untouched.
 
 Humans fill `feedback.yml` with `a`, `b`, `tie`, `neither`, or `skip`:
 
@@ -105,9 +135,11 @@ gitmoot skillopt feedback github sync \
 For PR comment mode, sync with `--pr <number>`. Gitmoot ignores unrelated
 comments and de-duplicates repeated imports by GitHub comment URL.
 
-The complete review loop is: import a candidate, collect feedback with either
-the Markdown packet or GitHub collector, inspect the candidate with
-`gitmoot skillopt candidate show <version-id>`, then promote or reject it.
+The complete saved-output review loop is: create a review run, add artifact
+backed review items, collect feedback with either the Markdown packet or GitHub
+collector, export training data, run the external optimizer, import the pending
+candidate, inspect it with `gitmoot skillopt candidate show <version-id>`, then
+promote or reject it.
 
 ## Future Live Pairwise Evaluation
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -283,6 +283,9 @@ gitmoot lock release owner/repo <branch> --owner <agent>
 ### SkillOpt Exchange
 
 ```sh
+gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>
+gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]
+gitmoot skillopt review status --run <run-id>
 gitmoot skillopt export --run <run-id> --output training.json
 gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
@@ -295,15 +298,37 @@ gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--p
 gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
-The export/import boundary lets a future external `gitmoot-skillopt` optimizer
-train on local eval artifacts and return candidate template versions. Imported
-candidates stay pending until a human review workflow promotes them.
+Create a review run, add saved baseline/candidate outputs as review items,
+export a Markdown or GitHub feedback packet, import the completed feedback, then
+export `training.json` for a future external `gitmoot-skillopt` optimizer.
+Dry-run optimization validates the contract without model calls:
+
+```sh
+gitmoot-skillopt optimize \
+  --training-package training.json \
+  --artifact-root ~/.gitmoot/evals/blobs \
+  --out-root .gitmoot/skillopt/run-2026-05-31 \
+  --candidate-output candidate.json \
+  --dry-run
+```
+
+Before real model-backed optimization, run `gitmoot-skillopt optimize --help`
+and verify required model/backend environment variables for the installed
+optimizer version. Imported candidates stay pending until a human review
+workflow promotes them.
 When a candidate package includes new artifact manifest entries, pass
 `--artifact-dir` to the directory containing those files; Gitmoot verifies
 relative paths and SHA256 hashes before storing blobs.
+The external optimizer walkthrough lives in
+[`jerryfane/gitmoot-skillopt`](https://github.com/jerryfane/gitmoot-skillopt/blob/main/docs/guide/gitmoot-mvp-workflow.md).
 Use `skillopt candidate show` to inspect the candidate metadata, eval report,
 feedback summary, and content diff before `promote` or `reject` records the
 decision.
+
+Use the Markdown feedback collector for a local blind A/B packet: open
+`index.md`, review `items/*.md`, set `reviewer`, edit `feedback.yml` with `a`,
+`b`, `tie`, `neither`, or `skip`, and import it. Keep `.assignments.json`
+untouched so Gitmoot can validate and de-blind the mapping.
 
 Use the GitHub feedback collector when review should happen in an issue or an
 existing PR thread. Reviewers can reply with either the copy-paste YAML block or
@@ -2870,6 +2895,9 @@ gitmoot lock show owner/repo <branch>
 ## SkillOpt Exchange
 
 ```sh
+gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>
+gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]
+gitmoot skillopt review status --run <run-id>
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
 gitmoot skillopt candidate list [--template id]
@@ -2882,10 +2910,22 @@ gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--p
 gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
+`skillopt review create` starts a review run for a template and target repo.
+`skillopt review item add` stores saved baseline/candidate outputs as artifact
+backed A/B review items. `skillopt review status` reports whether the run has
+items, complete artifacts, imported feedback for every item, and enough metadata
+to export.
+
 `skillopt export` writes a JSON training package with the template snapshot,
 eval run, review items, artifact manifests, feedback events when present, and
-evaluator config. `skillopt import` validates a candidate package and stores the
-candidate template as a pending version; it never promotes the candidate
+evaluator config. Use `gitmoot-skillopt optimize --training-package
+training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
+.gitmoot/skillopt/<run-id> --candidate-output candidate.json --dry-run` first
+to validate the contract without model calls.
+Before real model-backed optimization, check `gitmoot-skillopt optimize --help`
+and verify required model/backend environment variables for the installed
+optimizer version. `skillopt import` validates a candidate package and stores
+the candidate template as a pending version; it never promotes the candidate
 automatically. If the candidate package includes new artifact manifest entries,
 pass `--artifact-dir` so Gitmoot can verify relative paths and SHA256 hashes
 before storing blobs. `skillopt candidate show` displays candidate metadata, eval
@@ -2897,7 +2937,9 @@ version from being selected by `@latest`.
 The Markdown feedback collector writes blind A/B review packets with `index.md`,
 per-item Markdown files, editable `feedback.yml`, and hidden assignment metadata
 that Gitmoot uses to validate the full response and import de-blinded canonical
-feedback events.
+feedback events. Open `index.md`, review every file in `items/*.md`, set
+`reviewer`, edit `feedback.yml` with exactly one of `a`, `b`, `tie`, `neither`,
+or `skip` for every item, and leave `.assignments.json` untouched.
 
 The GitHub feedback collector publishes the same blind A/B review packet to a
 new issue by default, or to an existing PR when `--pr <number>` is provided.


### PR DESCRIPTION
WHAT: Polished the SkillOpt human feedback trial docs and generated Markdown packet instructions.

WHY: A first-time reviewer needs a complete path from review-run creation through A/B packet feedback, optimizer handoff, candidate import, and explicit promotion or rejection.

CHANGES:
- Expanded generated Markdown packet instructions to explain index/item review, required reviewer identity, valid choices, import command, and hidden assignment metadata.
- Added assertions for the generated packet guidance.
- Updated README, canonical SkillOpt contract docs, Gitmoot skill CLI reference, website docs, and generated llms-full context with the review create/item/status flow.
- Documented the actual gitmoot-skillopt optimize dry-run flags, safe env presence checks, and the distinction between saved-output A/B review and future live pairwise evaluation.

RESULTS:
- /root/temp/ts/tool/go test ./internal/feedback ./internal/cli
- /root/temp/ts/tool/go test ./...
- npm run build (website)
- git diff --check
- codex exec review --uncommitted

Final raw codex exec review --uncommitted output:

```text
I did not find any discrete correctness issues in the changed code or documentation. The relevant tests could not be run because the Go toolchain download lock path is read-only in this environment.
I did not find any discrete correctness issues in the changed code or documentation. The relevant tests could not be run because the Go toolchain download lock path is read-only in this environment.
```

RISK: The external gitmoot-skillopt binary is not installed on this machine, so the docs use the local cloned optimizer CLI source as the verified command contract. Runtime model-backed optimization remains dependent on the installed optimizer version and configured backend credentials.