### PR TITLE
Add ranked SkillOpt review data model

### DIFF
--- a/GOAL-SKILLOPT-RANKED-EXPLORATION.md
+++ b/GOAL-SKILLOPT-RANKED-EXPLORATION.md
@@ -1,0 +1,378 @@
+# SkillOpt Ranked Exploration Loop
+
+Implement ranked N-way exploration for Gitmoot SkillOpt reviews so early
+template learning explores broad output directions before narrowing into
+refinement, distillation, and final validation.
+
+The intended user-facing outcome is that Gitmoot can create review runs with
+more than two options, collect ranked human feedback plus trait-level notes,
+turn rankings into optimizer-ready preference signals, and preserve the current
+A/B workflow for final validation. This goal touches SkillOpt review storage,
+feedback parsing, review packet generation, export contracts, CLI help, tests,
+and docs. It does not require changing `gitmoot-skillopt` optimizer internals
+unless the export contract needs a small compatibility field.
+
+## Core Rules
+
+- Work one task at a time in the listed order by default.
+- If tasks are independent, have disjoint file ownership, and do not depend on
+  each other's results, they may be done in parallel on separate branches.
+- Do not start dependent work until the prerequisite task has passed checks,
+  passed `codex exec review --uncommitted`, been pushed, opened as a PR, merged,
+  and verified on the target branch.
+- Do not commit generated data, reports, caches, build artifacts, secrets,
+  credentials, session archives, cloned helper repos, local plugin build output,
+  or large outputs unless the plan explicitly says they are intended tracked
+  fixtures/artifacts.
+- Preserve existing behavior unless the current task explicitly changes it.
+- Keep changes clean, scoped, and organized. Avoid broad rewrites.
+- Avoid code duplication. When repeated logic appears, extract small reusable
+  helpers that match existing repo patterns.
+- If implementation depends on external APIs, docs, CLIs, data formats,
+  generated scripts, installers, service launchers, subprocess calls, env vars,
+  config formats, or third-party libraries, verify the real contract with local
+  commands and/or official sources before editing.
+
+## Before Starting
+
+1. Inspect current repo state with:
+   - `git status --short`
+   - current branch
+   - current remote
+2. If the target branch is unclear, the remote looks wrong, or the worktree has
+   unrelated existing changes that make task commits ambiguous, stop and ask
+   before continuing.
+3. Confirm the target base branch from the current repo. If unspecified, use the
+   current branch as the base.
+4. Inspect relevant existing patterns before editing.
+5. Verify PR tooling is available before the first PR:
+   - `gh auth status`
+   - repo remote resolves to the expected GitHub repository
+
+## Per-Task Branch Workflow
+
+1. Confirm the current task's scope.
+2. Create a task branch from the latest target base branch.
+3. Implement only that task.
+4. Add or update focused tests/checks appropriate to the task.
+5. Run focused tests for touched modules.
+6. Run broader checks when the task touches shared behavior, CLI/API surfaces,
+   data/model/evaluation logic, generated scripts, installers, service
+   launchers, docs build systems, or user-facing workflows.
+7. For wrapper, installer, CLI, subprocess, generated-script, env propagation,
+   service-launcher, or deployment changes, include an operational smoke test or
+   direct contract check. Syntax checks alone are not enough.
+8. Identify every repository where files changed. In each changed repo, run:
+   `codex exec review --uncommitted`
+9. Preserve the exact raw review output per repo.
+
+## Review-Fix Loop
+
+1. If review finds issues, do not only patch the literal line.
+2. Identify the underlying invariant/class of bug.
+3. Audit nearby and sibling paths for the same issue.
+4. Write a concise fix plan using:
+
+   ```text
+   Review found these issues: <<PASTE RAW REVIEW RESULTS BY REPO>>.
+   For each issue, identify the underlying invariant/class of bug, audit sibling
+   paths for the same issue, and plan the smallest safe fix. Verify external
+   assumptions with local commands and/or official sources. Preserve repo
+   patterns, avoid unnecessary refactors, and list tests/checks per repo.
+   ```
+
+5. Execute the fix plan.
+6. Re-run focused tests/checks and `codex exec review --uncommitted` in every
+   repo with uncommitted changes.
+7. Repeat until the final raw review output contains no findings, or stop if
+   blocked or if a finding is incorrect after verification.
+
+## Commit Gate
+
+1. Before committing, run `git diff --check` and inspect the final diff.
+2. Commit only the current task's intended tracked changes.
+3. Use the commit message specified by the plan. If the plan does not specify
+   one, use a concise conventional message that describes only the current task.
+4. Push the task branch.
+5. Verify the task branch worktree is clean after push, except for intentionally
+   ignored generated files.
+
+## Pull Request Gate
+
+1. Create one PR for the current task.
+2. The PR title must describe only the current task.
+3. The PR body must include:
+   - WHAT: what was changed
+   - WHY: why the task was needed
+   - CHANGES: concrete implementation changes
+   - RESULTS: tests/checks/review results
+   - RISK: skipped checks, blockers, or residual risk
+4. Include the exact raw final `codex exec review --uncommitted` output for each
+   changed repo in the PR body.
+5. If CI or required checks exist, wait for them and fix failures before merge.
+6. Merge the PR using the repository's configured/preferred merge method. If no
+   preference is discoverable, use squash merge for a clean task-level history.
+7. After merge, update the local target base branch and verify the worktree is
+   clean.
+8. Record the PR number, PR URL, branch name, and merged commit hash.
+9. Delete the task branch after merge only if the repository normally does so or
+   the merge command supports safe branch deletion.
+
+## Parallel Task Rules
+
+- Parallelize only when tasks are independent, have disjoint file ownership, and
+  can be reviewed and merged without order-dependent assumptions.
+- Use a separate branch per task.
+- Clearly assign each branch a task number and file ownership.
+- Do not duplicate work across branches.
+- If parallel branches conflict after one PR merges, rebase or update the
+  remaining branch on the latest target base and re-run its checks/review.
+- If a task becomes dependent on another task, stop treating it as parallel and
+  merge the dependency first.
+
+## Final Response After All Tasks
+
+- List completed tasks.
+- For each task, list branch, PR URL, merge status, and merged commit hash.
+- List tests/checks run.
+- Include exact final raw `codex exec review --uncommitted` output for the last
+  task/repo.
+- Mention skipped checks, blockers, or residual risk.
+- Do not claim interactive `/review` is clean. Say:
+  `codex exec review is clean; ready for manual /review.`
+
+## Implementation Tasks
+
+### Task 1: Add Ranked Review Data Model
+
+Scope:
+- Extend SkillOpt review data structures to support run mode and exploration
+  settings:
+  - `mode`: `explore`, `refine`, `distill`, or `validate`
+  - `exploration_level`: `high`, `medium`, or `low`
+  - `options`: expected option count for N-way review runs
+- Add storage for review item options beyond baseline/candidate while keeping
+  existing A/B fields working for validation runs.
+- Add canonical ranked feedback structures:
+  - ordered option ranking
+  - optional winner
+  - useful traits by option
+  - rejected traits by option
+  - free-form reasoning
+  - derived pairwise preferences
+- Preserve existing `a`, `b`, `tie`, `neither`, and `skip` feedback events for
+  current A/B callers.
+
+Acceptance criteria:
+- Existing A/B review tests still pass unchanged.
+- New model tests cover a 5-option ranked item and pairwise expansion.
+- Invalid modes, duplicate option labels, missing ranked options, and unknown
+  option references fail clearly.
+- Existing local database migrations keep old installs readable.
+
+Tests/checks:
+- `go test ./internal/db ./internal/feedback ./internal/skillopt`
+- `go test ./internal/cli -run SkillOpt`
+- `git diff --check`
+
+Suggested commit message:
+- `feat(skillopt): add ranked review data model`
+
+### Task 2: Add N-Way Review CLI And Packet Generation
+
+Scope:
+- Extend review creation and item-add commands so users can create exploration
+  runs with multiple options.
+- Keep the existing A/B command path simple and backward-compatible.
+- Add CLI support for adding option artifacts to a review item, using a clean
+  repeated flag or subcommand shape that avoids ad hoc positional parsing.
+- Update Markdown and GitHub review packets to render N-way ranked review
+  instructions.
+- Include a copy-paste feedback format such as:
+
+  ```text
+  run_id: landing-page-trial-010
+  item-011 ranking: C > A > D > B
+  best traits:
+  - C: clearest product explanation
+  - A: best visual style
+  - D: best motion
+  reject:
+  - B: too generic
+  ```
+
+Acceptance criteria:
+- `gitmoot skillopt review create` can create both A/B validation runs and
+  N-way exploration runs.
+- Review packet output is clear enough for a human to rank options without
+  knowing baseline/candidate identity.
+- GitHub packet output includes table-style option links when artifacts contain
+  preview URLs or output paths.
+- Existing A/B publish output remains stable except for intentional wording
+  improvements.
+
+Tests/checks:
+- `go test ./internal/cli -run SkillOpt`
+- `go test ./internal/feedback`
+- CLI smoke in a temp home:
+  - create an explore run
+  - add one item with four options
+  - publish/export a Markdown packet
+  - inspect generated feedback instructions
+
+Suggested commit message:
+- `feat(skillopt): generate ranked review packets`
+
+### Task 3: Parse Ranked Feedback And Derive Preference Signals
+
+Scope:
+- Extend GitHub and Markdown feedback importers to parse ranked comments.
+- Parse both YAML and short-form ranking syntax.
+- Store trait-level feedback in canonical form.
+- Derive pairwise preferences from rankings, for example `C > A > D > B`
+  becomes:
+  - `C beats A`
+  - `C beats D`
+  - `C beats B`
+  - `A beats D`
+  - `A beats B`
+  - `D beats B`
+- Keep deblinding/mapping correct when displayed option labels are randomized.
+- Fix the class of mapping bug found in the manual PR #8 trial by adding tests
+  that prove displayed choices map to internal option identities correctly.
+
+Acceptance criteria:
+- Ranked comments on GitHub import into canonical feedback events.
+- Unknown option labels, partial rankings, duplicate labels, and malformed trait
+  blocks produce actionable errors or documented skip behavior.
+- A/B comment import remains correct and covered by regression tests.
+- Pairwise-derived signals are visible in status/export output.
+
+Tests/checks:
+- `go test ./internal/feedback`
+- `go test ./internal/cli -run SkillOptFeedback`
+- Add regression tests for A/B deblinding and N-way deblinding.
+
+Suggested commit message:
+- `feat(skillopt): import ranked feedback`
+
+### Task 4: Update SkillOpt Export Contract For Exploration Feedback
+
+Scope:
+- Extend `gitmoot skillopt export` so exported training packages include ranked
+  feedback, trait notes, run mode, exploration level, and derived pairwise
+  preferences.
+- Keep the current A/B export schema consumable by `gitmoot-skillopt`.
+- If `gitmoot-skillopt` cannot yet consume the richer fields, include them as
+  additive metadata while preserving the existing baseline/candidate fields.
+- Add contract docs that explain:
+  - exploration data is for broad output-direction learning
+  - refinement data combines winning traits
+  - distillation updates template body
+  - validation compares current template vs candidate on fresh prompts
+
+Acceptance criteria:
+- Exported package validates for both A/B validation runs and N-way exploration
+  runs.
+- Existing `gitmoot-skillopt` runs are not broken by the new fields.
+- The export includes enough information for a future optimizer to combine
+  traits across ranked options.
+
+Tests/checks:
+- `go test ./internal/cli -run SkillOptExport`
+- `go test ./internal/skillopt`
+- Manual JSON inspection of an N-way fixture export.
+
+Suggested commit message:
+- `feat(skillopt): export ranked exploration feedback`
+
+### Task 5: Add Exploration-Level Recommendations
+
+Scope:
+- Add status logic that summarizes whether a run should stay in `explore`,
+  move to `refine`, move to `distill`, or run `validate`.
+- Keep this as a recommendation only; do not auto-promote or auto-change modes.
+- Suggested heuristic:
+  - `explore -> refine` when the same direction wins multiple rounds, top
+    options share traits, or reviewer language says the direction is close.
+  - `refine -> distill` when feedback becomes mostly specific improvements and
+    broad new directions stop winning.
+  - `distill -> validate` when enough ranked feedback exists to justify a
+    template update.
+  - `validate -> promote` only after candidate beats current template on fresh
+    review items.
+- Surface the recommendation in `review status`, Markdown packets, and GitHub
+  packet summaries.
+
+Acceptance criteria:
+- Status output explains the current mode, feedback count, ranking stability,
+  and recommended next mode.
+- Heuristic is deterministic and covered with tests.
+- The output does not overclaim; it should say "recommend" rather than forcing
+  a transition.
+
+Tests/checks:
+- `go test ./internal/cli -run SkillOptReviewStatus`
+- `go test ./internal/feedback ./internal/skillopt`
+
+Suggested commit message:
+- `feat(skillopt): recommend exploration phase transitions`
+
+### Task 6: Document The Ranked Exploration Workflow
+
+Scope:
+- Update Gitmoot docs and skill files so users understand the new flow:
+  1. Explore with 4-6 diverse options.
+  2. Rank options and identify useful/rejected traits.
+  3. Refine with 2-3 combined candidates.
+  4. Distill the template from accumulated feedback.
+  5. Validate old vs new on fresh prompts.
+- Update `docs/skillopt-exchange-contract.md`.
+- Update `skills/gitmoot/SKILL.md` and references if the CLI surface changes.
+- Add examples for landing pages and a non-visual text task.
+- Explicitly state that A/B remains the right mode for final validation.
+
+Acceptance criteria:
+- Docs explain when to use explore/refine/distill/validate.
+- Docs include exact CLI examples for Markdown and GitHub review collectors.
+- The Gitmoot skill tells agents not to run heavy SkillOpt after every tiny
+  feedback round unless the user explicitly wants that.
+
+Tests/checks:
+- `go test ./...`
+- Run any docs/example smoke checks present in the repo.
+- `git diff --check`
+
+Suggested commit message:
+- `docs(skillopt): document ranked exploration workflow`
+
+### Task 7: End-To-End Smoke Test And Release Notes
+
+Scope:
+- Add a focused smoke test or documented manual smoke under
+  `docs/beta-smoke-tests.md` for:
+  - N-way exploration review creation
+  - option artifact registration
+  - Markdown packet export/import
+  - GitHub packet publish/sync
+  - ranked feedback pairwise expansion
+  - export package inspection
+- Add release notes for the next beta.
+- If needed, add a small fixture package rather than generated previews or large
+  artifacts.
+
+Acceptance criteria:
+- A maintainer can run the smoke from a clean temp home without touching real
+  user state.
+- Release notes accurately describe ranked exploration as a beta feature.
+- No large generated preview outputs are committed unless they are tiny
+  intentional fixtures.
+
+Tests/checks:
+- `go test ./...`
+- Smoke commands from docs using a temp home.
+- `codex exec review --uncommitted`
+- `git diff --check`
+
+Suggested commit message:
+- `test(skillopt): add ranked exploration smoke coverage`

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -179,10 +179,24 @@ type EvalRun struct {
 	TemplateVersionID string
 	TargetRepo        string
 	State             string
+	Mode              string
+	ExplorationLevel  string
+	OptionsCount      int
 	MetadataJSON      string
 	CreatedAt         string
 	UpdatedAt         string
 }
+
+const (
+	EvalRunModeExplore  = "explore"
+	EvalRunModeRefine   = "refine"
+	EvalRunModeDistill  = "distill"
+	EvalRunModeValidate = "validate"
+
+	ExplorationLevelHigh   = "high"
+	ExplorationLevelMedium = "medium"
+	ExplorationLevelLow    = "low"
+)
 
 type EvalReviewItem struct {
 	ID                  string
@@ -199,6 +213,18 @@ type EvalReviewItem struct {
 	UpdatedAt           string
 }
 
+type EvalReviewOption struct {
+	ID           string
+	RunID        string
+	ItemID       string
+	Label        string
+	ArtifactID   string
+	Role         string
+	MetadataJSON string
+	CreatedAt    string
+	UpdatedAt    string
+}
+
 type FeedbackEvent struct {
 	ID        string
 	RunID     string
@@ -209,6 +235,33 @@ type FeedbackEvent struct {
 	Source    string
 	SourceURL string
 	CreatedAt string
+}
+
+type RankedFeedbackEvent struct {
+	ID                 string
+	RunID              string
+	ItemID             string
+	RankingJSON        string
+	Winner             string
+	UsefulTraitsJSON   string
+	RejectedTraitsJSON string
+	Reasoning          string
+	Reviewer           string
+	Source             string
+	SourceURL          string
+	CreatedAt          string
+}
+
+type PairwisePreference struct {
+	RunID         string
+	ItemID        string
+	Preferred     string
+	Rejected      string
+	RankedEventID string
+	Reviewer      string
+	Source        string
+	SourceURL     string
+	CreatedAt     string
 }
 
 type BranchLock struct {
@@ -1689,27 +1742,79 @@ func (s *Store) GetEvalArtifact(ctx context.Context, id string) (EvalArtifact, e
 }
 
 func (s *Store) UpsertEvalRun(ctx context.Context, run EvalRun) error {
-	if strings.TrimSpace(run.ID) == "" {
-		return errors.New("eval run id is required")
+	run, err := normalizeEvalRun(run)
+	if err != nil {
+		return err
 	}
-	if strings.TrimSpace(run.State) == "" {
-		run.State = "draft"
-	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO eval_runs(id, template_id, template_version_id, target_repo, state, metadata_json, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	_, err = s.db.ExecContext(ctx, `INSERT INTO eval_runs(id, template_id, template_version_id, target_repo, state, mode, exploration_level, options_count, metadata_json, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			template_id = excluded.template_id,
 			template_version_id = excluded.template_version_id,
 			target_repo = excluded.target_repo,
 			state = excluded.state,
+			mode = excluded.mode,
+			exploration_level = excluded.exploration_level,
+			options_count = excluded.options_count,
 			metadata_json = excluded.metadata_json,
 			updated_at = CURRENT_TIMESTAMP`,
-		run.ID, run.TemplateID, run.TemplateVersionID, run.TargetRepo, run.State, run.MetadataJSON)
+		run.ID, run.TemplateID, run.TemplateVersionID, run.TargetRepo, run.State, run.Mode, run.ExplorationLevel, run.OptionsCount, run.MetadataJSON)
 	return err
 }
 
+func normalizeEvalRun(run EvalRun) (EvalRun, error) {
+	run.ID = strings.TrimSpace(run.ID)
+	if run.ID == "" {
+		return EvalRun{}, errors.New("eval run id is required")
+	}
+	run.TemplateID = strings.TrimSpace(run.TemplateID)
+	run.TemplateVersionID = strings.TrimSpace(run.TemplateVersionID)
+	run.TargetRepo = strings.TrimSpace(run.TargetRepo)
+	run.State = strings.TrimSpace(run.State)
+	if run.State == "" {
+		run.State = "draft"
+	}
+	run.Mode = strings.TrimSpace(strings.ToLower(run.Mode))
+	if run.Mode == "" {
+		run.Mode = EvalRunModeValidate
+	}
+	switch run.Mode {
+	case EvalRunModeExplore, EvalRunModeRefine, EvalRunModeDistill, EvalRunModeValidate:
+	default:
+		return EvalRun{}, fmt.Errorf("eval run mode %q is not supported", run.Mode)
+	}
+	run.ExplorationLevel = strings.TrimSpace(strings.ToLower(run.ExplorationLevel))
+	if run.ExplorationLevel == "" {
+		switch run.Mode {
+		case EvalRunModeExplore:
+			run.ExplorationLevel = ExplorationLevelHigh
+		case EvalRunModeRefine:
+			run.ExplorationLevel = ExplorationLevelMedium
+		default:
+			run.ExplorationLevel = ExplorationLevelLow
+		}
+	}
+	switch run.ExplorationLevel {
+	case ExplorationLevelHigh, ExplorationLevelMedium, ExplorationLevelLow:
+	default:
+		return EvalRun{}, fmt.Errorf("eval run exploration level %q is not supported", run.ExplorationLevel)
+	}
+	if run.OptionsCount == 0 {
+		if run.Mode == EvalRunModeExplore {
+			run.OptionsCount = 5
+		} else {
+			run.OptionsCount = 2
+		}
+	}
+	if run.OptionsCount < 2 {
+		return EvalRun{}, errors.New("eval run options count must be at least 2")
+	}
+	run.MetadataJSON = strings.TrimSpace(run.MetadataJSON)
+	return run, nil
+}
+
 func (s *Store) GetEvalRun(ctx context.Context, id string) (EvalRun, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, template_id, template_version_id, target_repo, state, metadata_json, created_at, updated_at
+	row := s.db.QueryRowContext(ctx, `SELECT id, template_id, template_version_id, target_repo, state, mode, exploration_level, options_count, metadata_json, created_at, updated_at
 		FROM eval_runs WHERE id = ?`, id)
 	return scanEvalRun(row)
 }
@@ -1764,6 +1869,80 @@ func (s *Store) ListEvalReviewItems(ctx context.Context, runID string) ([]EvalRe
 	return items, rows.Err()
 }
 
+func (s *Store) UpsertEvalReviewOption(ctx context.Context, option EvalReviewOption) error {
+	option, err := normalizeEvalReviewOption(option)
+	if err != nil {
+		return err
+	}
+	var existingID string
+	if err := s.db.QueryRowContext(ctx, `SELECT id FROM eval_review_options WHERE run_id = ? AND item_id = ? AND label = ?`,
+		option.RunID, option.ItemID, option.Label).Scan(&existingID); err == nil {
+		return fmt.Errorf("eval review option label %q already exists for item %q", option.Label, option.ItemID)
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO eval_review_options(
+			id, run_id, item_id, label, artifact_id, role, metadata_json, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		option.ID, option.RunID, option.ItemID, option.Label, option.ArtifactID, option.Role, option.MetadataJSON)
+	return err
+}
+
+func normalizeEvalReviewOption(option EvalReviewOption) (EvalReviewOption, error) {
+	option.RunID = strings.TrimSpace(option.RunID)
+	if option.RunID == "" {
+		return EvalReviewOption{}, errors.New("eval review option run id is required")
+	}
+	option.ItemID = strings.TrimSpace(option.ItemID)
+	if option.ItemID == "" {
+		return EvalReviewOption{}, errors.New("eval review option item id is required")
+	}
+	option.Label = normalizeOptionLabel(option.Label)
+	if option.Label == "" {
+		return EvalReviewOption{}, errors.New("eval review option label is required")
+	}
+	option.ArtifactID = strings.TrimSpace(option.ArtifactID)
+	if option.ArtifactID == "" {
+		return EvalReviewOption{}, errors.New("eval review option artifact id is required")
+	}
+	option.Role = strings.TrimSpace(strings.ToLower(option.Role))
+	if option.ID == "" {
+		option.ID = option.RunID + "/" + option.ItemID + "/" + option.Label
+	}
+	option.MetadataJSON = strings.TrimSpace(option.MetadataJSON)
+	return option, nil
+}
+
+func (s *Store) ListEvalReviewOptions(ctx context.Context, runID string, itemID string) ([]EvalReviewOption, error) {
+	runID = strings.TrimSpace(runID)
+	itemID = strings.TrimSpace(itemID)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if itemID == "" {
+		rows, err = s.db.QueryContext(ctx, `SELECT id, run_id, item_id, label, artifact_id, role, metadata_json, created_at, updated_at
+			FROM eval_review_options WHERE run_id = ? ORDER BY item_id, label`, runID)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `SELECT id, run_id, item_id, label, artifact_id, role, metadata_json, created_at, updated_at
+			FROM eval_review_options WHERE run_id = ? AND item_id = ? ORDER BY label`, runID, itemID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var options []EvalReviewOption
+	for rows.Next() {
+		option, err := scanEvalReviewOption(rows)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, option)
+	}
+	return options, rows.Err()
+}
+
 func scanEvalArtifact(row interface{ Scan(dest ...any) error }) (EvalArtifact, error) {
 	var artifact EvalArtifact
 	if err := row.Scan(&artifact.ID, &artifact.Hash, &artifact.MediaType, &artifact.SizeBytes, &artifact.Driver, &artifact.CreatedAt); err != nil {
@@ -1774,7 +1953,7 @@ func scanEvalArtifact(row interface{ Scan(dest ...any) error }) (EvalArtifact, e
 
 func scanEvalRun(row interface{ Scan(dest ...any) error }) (EvalRun, error) {
 	var run EvalRun
-	if err := row.Scan(&run.ID, &run.TemplateID, &run.TemplateVersionID, &run.TargetRepo, &run.State, &run.MetadataJSON, &run.CreatedAt, &run.UpdatedAt); err != nil {
+	if err := row.Scan(&run.ID, &run.TemplateID, &run.TemplateVersionID, &run.TargetRepo, &run.State, &run.Mode, &run.ExplorationLevel, &run.OptionsCount, &run.MetadataJSON, &run.CreatedAt, &run.UpdatedAt); err != nil {
 		return EvalRun{}, err
 	}
 	return run, nil
@@ -1787,6 +1966,14 @@ func scanEvalReviewItem(row interface{ Scan(dest ...any) error }) (EvalReviewIte
 		return EvalReviewItem{}, err
 	}
 	return item, nil
+}
+
+func scanEvalReviewOption(row interface{ Scan(dest ...any) error }) (EvalReviewOption, error) {
+	var option EvalReviewOption
+	if err := row.Scan(&option.ID, &option.RunID, &option.ItemID, &option.Label, &option.ArtifactID, &option.Role, &option.MetadataJSON, &option.CreatedAt, &option.UpdatedAt); err != nil {
+		return EvalReviewOption{}, err
+	}
+	return option, nil
 }
 
 func (s *Store) UpsertFeedbackEvent(ctx context.Context, event FeedbackEvent) error {
@@ -1851,6 +2038,241 @@ func scanFeedbackEvent(row interface{ Scan(dest ...any) error }) (FeedbackEvent,
 	return event, nil
 }
 
+func (s *Store) UpsertRankedFeedbackEvent(ctx context.Context, event RankedFeedbackEvent) error {
+	event, err := normalizeRankedFeedbackEvent(event)
+	if err != nil {
+		return err
+	}
+	if err := s.validateRankedFeedbackEventOptions(ctx, event); err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO ranked_feedback_events(
+			id, run_id, item_id, ranking_json, winner, useful_traits_json, rejected_traits_json,
+			reasoning, reviewer, source, source_url, created_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(run_id, item_id, reviewer, source, source_url) DO UPDATE SET
+			id = excluded.id,
+			ranking_json = excluded.ranking_json,
+			winner = excluded.winner,
+			useful_traits_json = excluded.useful_traits_json,
+			rejected_traits_json = excluded.rejected_traits_json,
+			reasoning = excluded.reasoning,
+			reviewer = excluded.reviewer,
+			source = excluded.source,
+			source_url = excluded.source_url,
+			created_at = excluded.created_at`,
+		event.ID, event.RunID, event.ItemID, event.RankingJSON, event.Winner, event.UsefulTraitsJSON, event.RejectedTraitsJSON,
+		event.Reasoning, event.Reviewer, event.Source, event.SourceURL, event.CreatedAt)
+	return err
+}
+
+func (s *Store) validateRankedFeedbackEventOptions(ctx context.Context, event RankedFeedbackEvent) error {
+	run, err := s.GetEvalRun(ctx, event.RunID)
+	if err != nil {
+		return err
+	}
+	options, err := s.ListEvalReviewOptions(ctx, event.RunID, event.ItemID)
+	if err != nil {
+		return err
+	}
+	if len(options) == 0 {
+		return fmt.Errorf("ranked feedback item %s has no registered review options", event.ItemID)
+	}
+	ranking, err := rankedFeedbackRanking(event)
+	if err != nil {
+		return err
+	}
+	expectedOptions := len(options)
+	if run.OptionsCount > 0 {
+		expectedOptions = run.OptionsCount
+		if len(options) != expectedOptions {
+			return fmt.Errorf("ranked feedback item %s has %d registered options, want %d run options", event.ItemID, len(options), expectedOptions)
+		}
+	}
+	if len(ranking) != expectedOptions {
+		return fmt.Errorf("ranked feedback item %s ranking includes %d options, want %d options", event.ItemID, len(ranking), expectedOptions)
+	}
+	known := make(map[string]struct{}, len(options))
+	for _, option := range options {
+		known[normalizeOptionLabel(option.Label)] = struct{}{}
+	}
+	ranked := make(map[string]struct{}, len(ranking))
+	for _, label := range ranking {
+		if _, ok := known[label]; !ok {
+			return fmt.Errorf("ranked feedback item %s references unknown option %q", event.ItemID, label)
+		}
+		ranked[label] = struct{}{}
+	}
+	for label := range known {
+		if _, ok := ranked[label]; !ok {
+			return fmt.Errorf("ranked feedback item %s missing registered option %q", event.ItemID, label)
+		}
+	}
+	if event.Winner != "" {
+		if _, ok := known[event.Winner]; !ok {
+			return fmt.Errorf("ranked feedback item %s winner references unknown option %q", event.ItemID, event.Winner)
+		}
+		if event.Winner != ranking[0] {
+			return fmt.Errorf("ranked feedback item %s winner %q does not match first ranked option %q", event.ItemID, event.Winner, ranking[0])
+		}
+	}
+	for _, traits := range []struct {
+		name string
+		json string
+	}{
+		{name: "useful_traits_json", json: event.UsefulTraitsJSON},
+		{name: "rejected_traits_json", json: event.RejectedTraitsJSON},
+	} {
+		if strings.TrimSpace(traits.json) == "" {
+			continue
+		}
+		var decoded map[string][]string
+		if err := json.Unmarshal([]byte(traits.json), &decoded); err != nil {
+			return fmt.Errorf("ranked feedback %s must be a JSON object keyed by option label: %w", traits.name, err)
+		}
+		for label := range decoded {
+			normalized := normalizeOptionLabel(label)
+			if normalized == "" {
+				return fmt.Errorf("ranked feedback %s contains an empty option label", traits.name)
+			}
+			if _, ok := known[normalized]; !ok {
+				return fmt.Errorf("ranked feedback %s references unknown option %q", traits.name, normalized)
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeRankedFeedbackEvent(event RankedFeedbackEvent) (RankedFeedbackEvent, error) {
+	event.RunID = strings.TrimSpace(event.RunID)
+	if event.RunID == "" {
+		return RankedFeedbackEvent{}, errors.New("ranked feedback run id is required")
+	}
+	event.ItemID = strings.TrimSpace(event.ItemID)
+	if event.ItemID == "" {
+		return RankedFeedbackEvent{}, errors.New("ranked feedback item id is required")
+	}
+	event.Winner = normalizeOptionLabel(event.Winner)
+	event.RankingJSON = strings.TrimSpace(event.RankingJSON)
+	if event.RankingJSON == "" {
+		return RankedFeedbackEvent{}, errors.New("ranked feedback ranking_json is required")
+	}
+	if _, err := rankedFeedbackRanking(event); err != nil {
+		return RankedFeedbackEvent{}, err
+	}
+	event.UsefulTraitsJSON = strings.TrimSpace(event.UsefulTraitsJSON)
+	event.RejectedTraitsJSON = strings.TrimSpace(event.RejectedTraitsJSON)
+	event.Reasoning = strings.TrimSpace(event.Reasoning)
+	event.Reviewer = strings.TrimSpace(event.Reviewer)
+	if event.Reviewer == "" {
+		return RankedFeedbackEvent{}, errors.New("ranked feedback reviewer is required")
+	}
+	event.Source = strings.TrimSpace(event.Source)
+	if event.Source == "" {
+		return RankedFeedbackEvent{}, errors.New("ranked feedback source is required")
+	}
+	event.SourceURL = strings.TrimSpace(event.SourceURL)
+	if strings.TrimSpace(event.CreatedAt) == "" {
+		event.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if strings.TrimSpace(event.ID) == "" {
+		event.ID = rankedFeedbackEventID(event)
+	}
+	return event, nil
+}
+
+func rankedFeedbackRanking(event RankedFeedbackEvent) ([]string, error) {
+	var ranking []string
+	if err := json.Unmarshal([]byte(event.RankingJSON), &ranking); err != nil {
+		return nil, fmt.Errorf("ranked feedback ranking_json must be a JSON array of option labels: %w", err)
+	}
+	if len(ranking) < 2 {
+		return nil, errors.New("ranked feedback ranking must include at least two options")
+	}
+	seen := map[string]struct{}{}
+	for index, label := range ranking {
+		normalized := normalizeOptionLabel(label)
+		if normalized == "" {
+			return nil, fmt.Errorf("ranked feedback ranking contains empty option label at position %d", index+1)
+		}
+		if _, ok := seen[normalized]; ok {
+			return nil, fmt.Errorf("ranked feedback ranking contains duplicate option label %q", normalized)
+		}
+		seen[normalized] = struct{}{}
+		ranking[index] = normalized
+	}
+	return ranking, nil
+}
+
+func (s *Store) ListRankedFeedbackEvents(ctx context.Context, runID string) ([]RankedFeedbackEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, run_id, item_id, ranking_json, winner, useful_traits_json, rejected_traits_json,
+			reasoning, reviewer, source, source_url, created_at
+		FROM ranked_feedback_events WHERE run_id = ? ORDER BY item_id, reviewer, source, source_url`, strings.TrimSpace(runID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var events []RankedFeedbackEvent
+	for rows.Next() {
+		event, err := scanRankedFeedbackEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+func scanRankedFeedbackEvent(row interface{ Scan(dest ...any) error }) (RankedFeedbackEvent, error) {
+	var event RankedFeedbackEvent
+	if err := row.Scan(&event.ID, &event.RunID, &event.ItemID, &event.RankingJSON, &event.Winner, &event.UsefulTraitsJSON, &event.RejectedTraitsJSON,
+		&event.Reasoning, &event.Reviewer, &event.Source, &event.SourceURL, &event.CreatedAt); err != nil {
+		return RankedFeedbackEvent{}, err
+	}
+	return event, nil
+}
+
+func (s *Store) ListPairwisePreferences(ctx context.Context, runID string) ([]PairwisePreference, error) {
+	events, err := s.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	preferences := []PairwisePreference{}
+	for _, event := range events {
+		eventPreferences, err := PairwisePreferencesForRankedFeedback(event)
+		if err != nil {
+			return nil, err
+		}
+		preferences = append(preferences, eventPreferences...)
+	}
+	return preferences, nil
+}
+
+func PairwisePreferencesForRankedFeedback(event RankedFeedbackEvent) ([]PairwisePreference, error) {
+	ranking, err := rankedFeedbackRanking(event)
+	if err != nil {
+		return nil, err
+	}
+	preferences := make([]PairwisePreference, 0, len(ranking)*(len(ranking)-1)/2)
+	for preferredIndex, preferred := range ranking {
+		for _, rejected := range ranking[preferredIndex+1:] {
+			preferences = append(preferences, PairwisePreference{
+				RunID:         event.RunID,
+				ItemID:        event.ItemID,
+				Preferred:     preferred,
+				Rejected:      rejected,
+				RankedEventID: event.ID,
+				Reviewer:      event.Reviewer,
+				Source:        event.Source,
+				SourceURL:     event.SourceURL,
+				CreatedAt:     event.CreatedAt,
+			})
+		}
+	}
+	return preferences, nil
+}
+
 func feedbackEventID(event FeedbackEvent) string {
 	parts := []string{event.RunID, event.ItemID, event.Reviewer, event.Source, event.SourceURL}
 	for index, part := range parts {
@@ -1859,6 +2281,20 @@ func feedbackEventID(event FeedbackEvent) string {
 	content, _ := json.Marshal(parts)
 	sum := sha256.Sum256(content)
 	return "feedback:" + hex.EncodeToString(sum[:])
+}
+
+func rankedFeedbackEventID(event RankedFeedbackEvent) string {
+	parts := []string{event.RunID, event.ItemID, event.Reviewer, event.Source, event.SourceURL}
+	for index, part := range parts {
+		parts[index] = strings.TrimSpace(part)
+	}
+	content, _ := json.Marshal(parts)
+	sum := sha256.Sum256(content)
+	return "ranked-feedback:" + hex.EncodeToString(sum[:])
+}
+
+func normalizeOptionLabel(label string) string {
+	return strings.ToLower(strings.TrimSpace(label))
 }
 
 func (s *Store) AcquireResourceLock(ctx context.Context, lock ResourceLock, now time.Time) (bool, error) {
@@ -2681,6 +3117,40 @@ CREATE TABLE agent_template_candidate_reviews (
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	decided_at TEXT NOT NULL DEFAULT ''
+);
+	`,
+	`
+ALTER TABLE eval_runs ADD COLUMN mode TEXT NOT NULL DEFAULT 'validate';
+ALTER TABLE eval_runs ADD COLUMN exploration_level TEXT NOT NULL DEFAULT 'low';
+ALTER TABLE eval_runs ADD COLUMN options_count INTEGER NOT NULL DEFAULT 2;
+
+CREATE TABLE eval_review_options (
+	id TEXT PRIMARY KEY,
+	run_id TEXT NOT NULL,
+	item_id TEXT NOT NULL,
+	label TEXT NOT NULL,
+	artifact_id TEXT NOT NULL,
+	role TEXT NOT NULL DEFAULT '',
+	metadata_json TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	UNIQUE(run_id, item_id, label)
+);
+
+CREATE TABLE ranked_feedback_events (
+	id TEXT PRIMARY KEY,
+	run_id TEXT NOT NULL,
+	item_id TEXT NOT NULL,
+	ranking_json TEXT NOT NULL,
+	winner TEXT NOT NULL DEFAULT '',
+	useful_traits_json TEXT NOT NULL DEFAULT '',
+	rejected_traits_json TEXT NOT NULL DEFAULT '',
+	reasoning TEXT NOT NULL DEFAULT '',
+	reviewer TEXT NOT NULL,
+	source TEXT NOT NULL,
+	source_url TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	UNIQUE(run_id, item_id, reviewer, source, source_url)
 );
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -37,7 +38,9 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"eval_artifacts",
 		"eval_runs",
 		"eval_review_items",
+		"eval_review_options",
 		"feedback_events",
+		"ranked_feedback_events",
 	} {
 		ok, err := store.HasTable(ctx, table)
 		if err != nil {
@@ -85,6 +88,9 @@ func TestEvalStorageMethods(t *testing.T) {
 		TemplateVersionID: "planner@v2",
 		TargetRepo:        "owner/repo",
 		State:             "review",
+		Mode:              EvalRunModeExplore,
+		ExplorationLevel:  ExplorationLevelHigh,
+		OptionsCount:      5,
 		MetadataJSON:      `{"seed":1}`,
 	}
 	if err := store.UpsertEvalRun(ctx, run); err != nil {
@@ -94,7 +100,7 @@ func TestEvalStorageMethods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetEvalRun returned error: %v", err)
 	}
-	if storedRun.TemplateVersionID != "planner@v2" || storedRun.MetadataJSON != `{"seed":1}` {
+	if storedRun.TemplateVersionID != "planner@v2" || storedRun.Mode != EvalRunModeExplore || storedRun.ExplorationLevel != ExplorationLevelHigh || storedRun.OptionsCount != 5 || storedRun.MetadataJSON != `{"seed":1}` {
 		t.Fatalf("stored run = %+v", storedRun)
 	}
 
@@ -121,6 +127,219 @@ func TestEvalStorageMethods(t *testing.T) {
 	}
 	if items[0].ID != "run-1/item-001" || items[0].DiffArtifactID != artifact.ID || items[0].MetadataJSON != `{"path":"README.md"}` {
 		t.Fatalf("review item = %+v", items[0])
+	}
+}
+
+func TestEvalRunDefaultsToValidationMode(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.UpsertEvalRun(ctx, EvalRun{ID: "run-1", State: "review"}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	run, err := store.GetEvalRun(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("GetEvalRun returned error: %v", err)
+	}
+	if run.Mode != EvalRunModeValidate || run.ExplorationLevel != ExplorationLevelLow || run.OptionsCount != 2 {
+		t.Fatalf("run defaults = %+v", run)
+	}
+}
+
+func TestEvalRunRejectsInvalidModeAndExplorationLevel(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.UpsertEvalRun(ctx, EvalRun{ID: "run-1", Mode: "wide"}); err == nil || !strings.Contains(err.Error(), "mode") {
+		t.Fatalf("invalid mode error = %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, EvalRun{ID: "run-1", ExplorationLevel: "huge"}); err == nil || !strings.Contains(err.Error(), "exploration level") {
+		t.Fatalf("invalid exploration level error = %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, EvalRun{ID: "run-1", OptionsCount: 1}); err == nil || !strings.Contains(err.Error(), "at least 2") {
+		t.Fatalf("invalid options count error = %v", err)
+	}
+}
+
+func TestRankedReviewStorageAndPairwisePreferences(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.UpsertEvalRun(ctx, EvalRun{
+		ID:               "run-ranked",
+		State:            "review",
+		Mode:             EvalRunModeExplore,
+		ExplorationLevel: ExplorationLevelHigh,
+		OptionsCount:     5,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, EvalReviewItem{RunID: "run-ranked", ItemID: "item-001", Title: "Landing page"}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d", "e"} {
+		if err := store.UpsertEvalReviewOption(ctx, EvalReviewOption{
+			RunID:      "run-ranked",
+			ItemID:     "item-001",
+			Label:      label,
+			ArtifactID: "artifact-" + label,
+		}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	options, err := store.ListEvalReviewOptions(ctx, "run-ranked", "item-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 5 || options[0].Label != "a" || options[4].ArtifactID != "artifact-e" {
+		t.Fatalf("options = %+v", options)
+	}
+
+	ranking, _ := json.Marshal([]string{"c", "a", "d", "b", "e"})
+	useful, _ := json.Marshal(map[string][]string{
+		"a": {"visual style"},
+		"d": {"motion"},
+	})
+	rejected, _ := json.Marshal(map[string][]string{
+		"b": {"generic"},
+	})
+	event := RankedFeedbackEvent{
+		RunID:              "run-ranked",
+		ItemID:             "item-001",
+		RankingJSON:        string(ranking),
+		Winner:             "c",
+		UsefulTraitsJSON:   string(useful),
+		RejectedTraitsJSON: string(rejected),
+		Reasoning:          "C is clearest.",
+		Reviewer:           "jerry",
+		Source:             "github",
+		SourceURL:          "https://github.com/example/repo/pull/1#issuecomment-1",
+		CreatedAt:          "2026-06-02T10:00:00Z",
+	}
+	if err := store.UpsertRankedFeedbackEvent(ctx, event); err != nil {
+		t.Fatalf("UpsertRankedFeedbackEvent returned error: %v", err)
+	}
+	stored, err := store.ListRankedFeedbackEvents(ctx, "run-ranked")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Winner != "c" || stored[0].ID == "" {
+		t.Fatalf("stored ranked feedback = %+v", stored)
+	}
+	pairs, err := store.ListPairwisePreferences(ctx, "run-ranked")
+	if err != nil {
+		t.Fatalf("ListPairwisePreferences returned error: %v", err)
+	}
+	if len(pairs) != 10 {
+		t.Fatalf("pairwise preferences len = %d, want 10: %+v", len(pairs), pairs)
+	}
+	if pairs[0].Preferred != "c" || pairs[0].Rejected != "a" || pairs[9].Preferred != "b" || pairs[9].Rejected != "e" {
+		t.Fatalf("pairwise preferences = %+v", pairs)
+	}
+}
+
+func TestRankedReviewStorageRejectsInvalidReferences(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.UpsertEvalRun(ctx, EvalRun{ID: "run-ranked", Mode: EvalRunModeExplore, OptionsCount: 3}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, EvalReviewItem{RunID: "run-ranked", ItemID: "item-001"}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c"} {
+		if err := store.UpsertEvalReviewOption(ctx, EvalReviewOption{RunID: "run-ranked", ItemID: "item-001", Label: label, ArtifactID: "artifact-" + label}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	if err := store.UpsertEvalReviewOption(ctx, EvalReviewOption{RunID: "run-ranked", ItemID: "item-001", Label: "A", ArtifactID: "artifact-duplicate"}); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("duplicate UpsertEvalReviewOption error = %v, want already exists", err)
+	}
+
+	tests := map[string]RankedFeedbackEvent{
+		"duplicate label": {
+			RankingJSON: `["a","a"]`,
+		},
+		"partial ranking": {
+			RankingJSON: `["a","b"]`,
+		},
+		"unknown option": {
+			RankingJSON: `["a","b","d"]`,
+		},
+		"unknown winner": {
+			RankingJSON: `["a","b","c"]`,
+			Winner:      "d",
+		},
+		"winner contradicts ranking": {
+			RankingJSON: `["a","b","c"]`,
+			Winner:      "b",
+		},
+		"unknown useful trait option": {
+			RankingJSON:      `["a","b","c"]`,
+			UsefulTraitsJSON: `{"d":["motion"]}`,
+		},
+	}
+	for name, event := range tests {
+		t.Run(name, func(t *testing.T) {
+			event.RunID = "run-ranked"
+			event.ItemID = "item-001"
+			event.Reviewer = "jerry"
+			event.Source = "github"
+			event.SourceURL = name
+			err := store.UpsertRankedFeedbackEvent(ctx, event)
+			if err == nil {
+				t.Fatal("UpsertRankedFeedbackEvent returned nil error")
+			}
+		})
+	}
+}
+
+func TestRankedReviewStorageRejectsOptionCountMismatch(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.UpsertEvalRun(ctx, EvalRun{ID: "run-ranked", Mode: EvalRunModeExplore, OptionsCount: 5}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, EvalReviewItem{RunID: "run-ranked", ItemID: "item-001"}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		if err := store.UpsertEvalReviewOption(ctx, EvalReviewOption{RunID: "run-ranked", ItemID: "item-001", Label: label, ArtifactID: "artifact-" + label}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	err = store.UpsertRankedFeedbackEvent(ctx, RankedFeedbackEvent{
+		RunID:       "run-ranked",
+		ItemID:      "item-001",
+		RankingJSON: `["a","b","c","d"]`,
+		Reviewer:    "jerry",
+		Source:      "github",
+		SourceURL:   "mismatch",
+	})
+	if err == nil || !strings.Contains(err.Error(), "registered options") {
+		t.Fatalf("option count mismatch error = %v, want registered options", err)
 	}
 }
 


### PR DESCRIPTION
WHAT:
- Adds the SkillOpt ranked-exploration goal file.
- Adds ranked review run metadata, N-way review options, ranked feedback events, and derived pairwise preference storage helpers.
- Adds database migrations and regression tests for ranked feedback invariants.

WHY:
- Gitmoot SkillOpt needs an N-way exploration data layer before CLI packets, feedback import, export, and phase recommendation work can build on it.

CHANGES:
- Extended eval runs with mode, exploration level, and expected options count.
- Added eval review option storage with duplicate normalized-label rejection.
- Added ranked feedback validation for complete rankings, registered option counts, unknown labels, duplicate labels, winner consistency, and trait label references.
- Added pairwise preference derivation from ranked feedback.
- Added schema migration coverage and focused db tests for defaults, invalid modes, 5-option ranking, pairwise expansion, option count mismatch, and invalid references.

RESULTS:
- GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/feedback ./internal/skillopt
- GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run SkillOpt
- git diff --cached --check
- codex exec review --uncommitted final raw output:

```text
No discrete correctness issues were found in the staged changes. The new ranked review data structures, validation, migrations, and tests appear consistent with the task scope.
```

RISK:
- This task adds the storage/data-model layer only. N-way CLI packet generation, ranked feedback import, export contract updates, phase recommendations, docs, and smoke coverage remain for later goal tasks.