### PR TITLE
Generate ranked SkillOpt review packets

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -53,8 +53,9 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt export --run <run-id> [--output package.json]")
 	fmt.Fprintln(w, "  gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]")
-	fmt.Fprintln(w, "  gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>")
+	fmt.Fprintln(w, "  gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id> [--mode validate|explore|refine|distill] [--options N]")
 	fmt.Fprintln(w, "  gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]")
+	fmt.Fprintln(w, "  gitmoot skillopt review item add --run <run-id> --item <item-id> --option a=option-a.md --option b=option-b.md [...] [--title text]")
 	fmt.Fprintln(w, "  gitmoot skillopt review status --run <run-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate list [--template id]")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate show <version-id>")
@@ -92,6 +93,9 @@ func runSkillOptReviewCreate(args []string, stdout, stderr io.Writer) int {
 	templateID := fs.String("template", "", "agent template id or version to review")
 	repoFlag := fs.String("repo", "", "target repository in owner/repo form")
 	runID := fs.String("run", "", "review run id")
+	mode := fs.String("mode", "", "review mode: validate, explore, refine, or distill")
+	explorationLevel := fs.String("exploration-level", "", "exploration level: high, medium, or low")
+	optionsCount := fs.Int("options", 0, "expected number of review options")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -123,6 +127,9 @@ func runSkillOptReviewCreate(args []string, stdout, stderr io.Writer) int {
 			TemplateVersionID: template.VersionID,
 			TargetRepo:        repo.FullName(),
 			State:             "review",
+			Mode:              strings.TrimSpace(*mode),
+			ExplorationLevel:  strings.TrimSpace(*explorationLevel),
+			OptionsCount:      *optionsCount,
 			MetadataJSON:      `{"driver":"manual-review"}`,
 		}
 		return store.UpsertEvalRun(context.Background(), run)
@@ -149,6 +156,72 @@ func runSkillOptReviewItem(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
+type repeatedStringFlag []string
+
+func (f *repeatedStringFlag) String() string {
+	if f == nil {
+		return ""
+	}
+	return strings.Join(*f, ",")
+}
+
+func (f *repeatedStringFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+type skillOptOptionSpec struct {
+	Label string
+	Path  string
+}
+
+type preparedSkillOptOption struct {
+	Spec     skillOptOptionSpec
+	Artifact db.EvalArtifact
+	Metadata string
+}
+
+func parseSkillOptOptionFlags(values []string) ([]skillOptOptionSpec, error) {
+	specs := make([]skillOptOptionSpec, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		label, path, ok := strings.Cut(value, "=")
+		if !ok {
+			return nil, fmt.Errorf("--option must use label=path form")
+		}
+		label = strings.ToLower(strings.TrimSpace(label))
+		path = strings.TrimSpace(path)
+		if err := validateSkillOptOptionLabel(label); err != nil {
+			return nil, err
+		}
+		if path == "" {
+			return nil, fmt.Errorf("option %s path is required", label)
+		}
+		if _, ok := seen[label]; ok {
+			return nil, fmt.Errorf("duplicate option label %q", label)
+		}
+		seen[label] = struct{}{}
+		specs = append(specs, skillOptOptionSpec{Label: label, Path: path})
+	}
+	return specs, nil
+}
+
+func validateSkillOptOptionLabel(label string) error {
+	if label == "" {
+		return errors.New("option label is required")
+	}
+	for _, r := range label {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return fmt.Errorf("option label %q must use only letters, digits, dots, dashes, or underscores", label)
+		}
+	}
+	return nil
+}
+
 func runSkillOptReviewItemAdd(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("skillopt review item add", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -161,6 +234,8 @@ func runSkillOptReviewItemAdd(args []string, stdout, stderr io.Writer) int {
 	metadataJSON := fs.String("metadata-json", "", "JSON metadata to attach to the review item")
 	mediaType := fs.String("media-type", "", "media type override for stored artifacts")
 	driver := fs.String("driver", "text", "artifact driver")
+	var optionFlags repeatedStringFlag
+	fs.Var(&optionFlags, "option", "N-way option in label=path form; repeat once per option")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -171,8 +246,23 @@ func runSkillOptReviewItemAdd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "skillopt review item add does not accept positional arguments")
 		return 2
 	}
-	if strings.TrimSpace(*runID) == "" || strings.TrimSpace(*itemID) == "" || strings.TrimSpace(*baselinePath) == "" || strings.TrimSpace(*candidatePath) == "" {
-		fmt.Fprintln(stderr, "skillopt review item add requires --run, --item, --baseline, and --candidate")
+	if strings.TrimSpace(*runID) == "" || strings.TrimSpace(*itemID) == "" {
+		fmt.Fprintln(stderr, "skillopt review item add requires --run and --item")
+		return 2
+	}
+	hasAB := strings.TrimSpace(*baselinePath) != "" || strings.TrimSpace(*candidatePath) != ""
+	hasOptions := len(optionFlags) > 0
+	if hasAB && hasOptions {
+		fmt.Fprintln(stderr, "skillopt review item add accepts either --baseline/--candidate or repeated --option flags, not both")
+		return 2
+	}
+	if !hasOptions && (strings.TrimSpace(*baselinePath) == "" || strings.TrimSpace(*candidatePath) == "") {
+		fmt.Fprintln(stderr, "skillopt review item add requires --baseline and --candidate, or repeated --option label=path flags")
+		return 2
+	}
+	optionSpecs, err := parseSkillOptOptionFlags(optionFlags)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt review item add: %v\n", err)
 		return 2
 	}
 	metadata, err := normalizeSkillOptMetadataJSON(*metadataJSON)
@@ -191,6 +281,61 @@ func runSkillOptReviewItemAdd(args []string, stdout, stderr io.Writer) int {
 			return err
 		}
 		blobStore := artifact.NewStore(paths.ArtifactBlobs)
+		rankedRun := skillOptRunUsesRankedOptions(run)
+		if hasOptions && !rankedRun {
+			return fmt.Errorf("review run %s is validate/A/B mode; use --baseline and --candidate", run.ID)
+		}
+		if !hasOptions && rankedRun {
+			return fmt.Errorf("review run %s is ranked mode; use repeated --option label=path flags", run.ID)
+		}
+		if hasOptions {
+			if run.OptionsCount > 0 && len(optionSpecs) != run.OptionsCount {
+				return fmt.Errorf("review run %s expects %d options, got %d", run.ID, run.OptionsCount, len(optionSpecs))
+			}
+			preparedOptions := make([]preparedSkillOptOption, 0, len(optionSpecs))
+			for _, spec := range optionSpecs {
+				optionArtifact, err := prepareReviewItemArtifact(blobStore, run.ID, *itemID, "option-"+spec.Label, spec.Path, *mediaType, *driver)
+				if err != nil {
+					return err
+				}
+				optionMetadata, err := reviewOptionMetadataJSON(spec.Path)
+				if err != nil {
+					return err
+				}
+				preparedOptions = append(preparedOptions, preparedSkillOptOption{
+					Spec:     spec,
+					Artifact: optionArtifact,
+					Metadata: optionMetadata,
+				})
+			}
+			item = db.EvalReviewItem{
+				RunID:        run.ID,
+				ItemID:       strings.TrimSpace(*itemID),
+				Title:        strings.TrimSpace(*title),
+				MetadataJSON: metadata,
+			}
+			if err := store.UpsertEvalReviewItem(ctx, item); err != nil {
+				return err
+			}
+			replacementOptions := make([]db.EvalReviewOption, 0, len(preparedOptions))
+			for _, prepared := range preparedOptions {
+				if err := store.UpsertEvalArtifact(ctx, prepared.Artifact); err != nil {
+					return fmt.Errorf("register option %s artifact: %w", prepared.Spec.Label, err)
+				}
+				replacementOptions = append(replacementOptions, db.EvalReviewOption{
+					RunID:        run.ID,
+					ItemID:       strings.TrimSpace(*itemID),
+					Label:        prepared.Spec.Label,
+					ArtifactID:   prepared.Artifact.ID,
+					Role:         "option",
+					MetadataJSON: prepared.Metadata,
+				})
+			}
+			if err := store.ReplaceEvalReviewOptions(ctx, run.ID, strings.TrimSpace(*itemID), replacementOptions); err != nil {
+				return err
+			}
+			return nil
+		}
 		baseline, err := prepareReviewItemArtifact(blobStore, run.ID, *itemID, "baseline", *baselinePath, *mediaType, *driver)
 		if err != nil {
 			return err
@@ -254,7 +399,7 @@ func runSkillOptReviewStatus(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	itemCount := len(status.Items)
-	feedbackCount := len(status.Feedback)
+	feedbackCount := len(status.Feedback) + len(status.RankedFeedback)
 	fmt.Fprintf(stdout, "run: %s\n", status.Run.ID)
 	fmt.Fprintf(stdout, "template: %s\n", status.Run.TemplateID)
 	fmt.Fprintf(stdout, "template_version: %s\n", status.Run.TemplateVersionID)
@@ -279,6 +424,7 @@ type skillOptReviewStatus struct {
 	Run              db.EvalRun
 	Items            []db.EvalReviewItem
 	Feedback         []db.FeedbackEvent
+	RankedFeedback   []db.RankedFeedbackEvent
 	PacketBlockers   []string
 	TrainingBlockers []string
 	PacketReady      bool
@@ -301,12 +447,17 @@ func loadSkillOptReviewStatus(ctx context.Context, store *db.Store, blobStore ar
 	if err != nil {
 		return skillOptReviewStatus{}, err
 	}
-	packetBlockers := reviewPacketBlockers(ctx, store, blobStore, items)
-	trainingBlockers := reviewTrainingBlockers(ctx, store, run.ID, items, events)
+	rankedEvents, err := store.ListRankedFeedbackEvents(ctx, run.ID)
+	if err != nil {
+		return skillOptReviewStatus{}, err
+	}
+	packetBlockers := reviewPacketBlockers(ctx, store, blobStore, run, items)
+	trainingBlockers := reviewTrainingBlockers(ctx, store, run, items, events, rankedEvents)
 	return skillOptReviewStatus{
 		Run:              run,
 		Items:            items,
 		Feedback:         events,
+		RankedFeedback:   rankedEvents,
 		PacketBlockers:   packetBlockers,
 		TrainingBlockers: trainingBlockers,
 		PacketReady:      len(packetBlockers) == 0,
@@ -314,7 +465,7 @@ func loadSkillOptReviewStatus(ctx context.Context, store *db.Store, blobStore ar
 	}, nil
 }
 
-func reviewPacketBlockers(ctx context.Context, store *db.Store, blobStore artifact.Store, items []db.EvalReviewItem) []string {
+func reviewPacketBlockers(ctx context.Context, store *db.Store, blobStore artifact.Store, run db.EvalRun, items []db.EvalReviewItem) []string {
 	if len(items) == 0 {
 		return []string{"run has no review items"}
 	}
@@ -324,6 +475,25 @@ func reviewPacketBlockers(ctx context.Context, store *db.Store, blobStore artifa
 		itemID := strings.TrimSpace(item.ItemID)
 		if itemID == "" {
 			itemID = item.ID
+		}
+		if skillOptRunUsesRankedOptions(run) {
+			options, err := store.ListEvalReviewOptions(ctx, run.ID, item.ItemID)
+			if err != nil {
+				blockers = append(blockers, fmt.Sprintf("item %s options are not readable: %v", itemID, err))
+				continue
+			}
+			if len(options) == 0 {
+				blockers = append(blockers, fmt.Sprintf("item %s has no registered options", itemID))
+				continue
+			}
+			if run.OptionsCount > 0 && len(options) != run.OptionsCount {
+				blockers = append(blockers, fmt.Sprintf("item %s has %d options, want %d", itemID, len(options), run.OptionsCount))
+				continue
+			}
+			for _, option := range options {
+				blockers = append(blockers, validateReviewArtifactBlob(ctx, store, blobStore, itemID, "option "+option.Label, option.ArtifactID, validated)...)
+			}
+			continue
 		}
 		baseline := strings.TrimSpace(item.BaselineArtifactID)
 		candidate := strings.TrimSpace(item.CandidateArtifactID)
@@ -341,13 +511,20 @@ func reviewPacketBlockers(ctx context.Context, store *db.Store, blobStore artifa
 	return blockers
 }
 
-func reviewTrainingBlockers(ctx context.Context, store *db.Store, runID string, items []db.EvalReviewItem, events []db.FeedbackEvent) []string {
+func skillOptRunUsesRankedOptions(run db.EvalRun) bool {
+	return run.Mode != db.EvalRunModeValidate || run.OptionsCount > 2
+}
+
+func reviewTrainingBlockers(ctx context.Context, store *db.Store, run db.EvalRun, items []db.EvalReviewItem, events []db.FeedbackEvent, rankedEvents []db.RankedFeedbackEvent) []string {
 	if len(items) == 0 {
 		return []string{"run has no review items"}
 	}
 	var blockers []string
 	feedbackByItem := map[string]int{}
 	for _, event := range events {
+		feedbackByItem[strings.TrimSpace(event.ItemID)]++
+	}
+	for _, event := range rankedEvents {
 		feedbackByItem[strings.TrimSpace(event.ItemID)]++
 	}
 	for _, item := range items {
@@ -359,7 +536,10 @@ func reviewTrainingBlockers(ctx context.Context, store *db.Store, runID string, 
 			blockers = append(blockers, fmt.Sprintf("item %s has no imported feedback", itemID))
 		}
 	}
-	if _, err := skillopt.ExportTrainingPackage(ctx, store, runID); err != nil {
+	if skillOptRunUsesRankedOptions(run) && len(rankedEvents) > 0 {
+		blockers = append(blockers, "ranked feedback export is not implemented yet")
+	}
+	if _, err := skillopt.ExportTrainingPackage(ctx, store, run.ID); err != nil {
 		blockers = append(blockers, fmt.Sprintf("training export failed: %v", err))
 	}
 	return blockers
@@ -446,6 +626,18 @@ func normalizeSkillOptMetadataJSON(value string) (string, error) {
 	encoded, err := json.Marshal(decoded)
 	if err != nil {
 		return "", fmt.Errorf("metadata-json: %w", err)
+	}
+	return string(encoded), nil
+}
+
+func reviewOptionMetadataJSON(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", nil
+	}
+	encoded, err := json.Marshal(map[string]string{"path": path})
+	if err != nil {
+		return "", fmt.Errorf("option metadata: %w", err)
 	}
 	return string(encoded), nil
 }
@@ -899,11 +1091,11 @@ func runSkillOptFeedbackMarkdownImport(args []string, stdout, stderr io.Writer) 
 	var count int
 	if err := withSkillOptStore(*home, func(paths config.Paths, store *db.Store) error {
 		collector := feedback.MarkdownCollector{BlobStore: artifact.NewStore(paths.ArtifactBlobs)}
-		events, err := collector.ImportPacket(context.Background(), store, *packet, *reviewer)
+		result, err := collector.ImportPacket(context.Background(), store, *packet, *reviewer)
 		if err != nil {
 			return err
 		}
-		count = len(events)
+		count = result.Count()
 		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "skillopt feedback markdown import: %v\n", err)
@@ -1009,11 +1201,11 @@ func runSkillOptFeedbackGitHubSync(args []string, stdout, stderr io.Writer) int 
 			BlobStore: artifact.NewStore(paths.ArtifactBlobs),
 			GitHub:    newSkillOptGitHubClient(),
 		}
-		events, err := collector.Sync(context.Background(), store, run.ID, repo, targetNumber)
+		result, err := collector.Sync(context.Background(), store, run.ID, repo, targetNumber)
 		if err != nil {
 			return err
 		}
-		count = len(events)
+		count = result.Count()
 		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "skillopt feedback github sync: %v\n", err)

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -895,8 +895,231 @@ func TestSkillOptReviewItemAddStoresArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read feedback.yml: %v", err)
 	}
-	if !strings.Contains(string(feedbackYAML), "item_id: item-001") {
+	if !strings.Contains(string(feedbackYAML), "item_id: item-001") || !strings.Contains(string(feedbackYAML), "choice:") {
 		t.Fatalf("feedback.yml = %s", string(feedbackYAML))
+	}
+}
+
+func TestSkillOptRankedReviewItemAddAndMarkdownExport(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "review", "create",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/repo",
+		"--run", "planner-explore-1",
+		"--mode", "explore",
+		"--exploration-level", "high",
+		"--options", "4",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review create exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	inputDir := t.TempDir()
+	optionPaths := map[string]string{}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		path := filepath.Join(inputDir, label+".md")
+		if err := os.WriteFile(path, []byte("# Option "+strings.ToUpper(label)+"\n\nReview content.\n"), 0o644); err != nil {
+			t.Fatalf("write option %s: %v", label, err)
+		}
+		optionPaths[label] = path
+	}
+	missingOptionArgs := []string{
+		"skillopt", "review", "item", "add",
+		"--home", home,
+		"--run", "planner-explore-1",
+		"--item", "item-001",
+		"--title", "Landing page",
+		"--option", "a=" + optionPaths["a"],
+		"--option", "b=" + optionPaths["b"],
+		"--option", "c=" + optionPaths["c"],
+		"--option", "d=" + filepath.Join(inputDir, "missing.md"),
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run(missingOptionArgs, &stdout, &stderr)
+	if code == 0 || !strings.Contains(stderr.String(), "missing.md") {
+		t.Fatalf("ranked item add with missing option: code=%d stderr=%s", code, stderr.String())
+	}
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open after failed ranked item add returned error: %v", err)
+	}
+	options, err := store.ListEvalReviewOptions(context.Background(), "planner-explore-1", "item-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions after failed add returned error: %v", err)
+	}
+	if len(options) != 0 {
+		t.Fatalf("failed ranked item add persisted partial options: %+v", options)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after failed ranked item add returned error: %v", err)
+	}
+	rankedItemArgs := []string{
+		"skillopt", "review", "item", "add",
+		"--home", home,
+		"--run", "planner-explore-1",
+		"--item", "item-001",
+		"--title", "Landing page",
+		"--option", "a=" + optionPaths["a"],
+		"--option", "b=" + optionPaths["b"],
+		"--option", "c=" + optionPaths["c"],
+		"--option", "d=" + optionPaths["d"],
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run(rankedItemArgs, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review item add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run(rankedItemArgs, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review item add retry exit code = %d, stderr=%s", code, stderr.String())
+	}
+	replacementPath := filepath.Join(inputDir, "e.md")
+	if err := os.WriteFile(replacementPath, []byte("# Option E\n\nReplacement content.\n"), 0o644); err != nil {
+		t.Fatalf("write replacement option: %v", err)
+	}
+	rankedReplacementArgs := []string{
+		"skillopt", "review", "item", "add",
+		"--home", home,
+		"--run", "planner-explore-1",
+		"--item", "item-001",
+		"--title", "Landing page",
+		"--option", "a=" + optionPaths["a"],
+		"--option", "b=" + optionPaths["b"],
+		"--option", "c=" + optionPaths["c"],
+		"--option", "e=" + replacementPath,
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run(rankedReplacementArgs, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review item add replacement exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "review", "item", "add",
+		"--home", home,
+		"--run", "planner-explore-1",
+		"--item", "item-ab",
+		"--baseline", optionPaths["a"],
+		"--candidate", optionPaths["b"],
+	}, &stdout, &stderr)
+	if code == 0 || !strings.Contains(stderr.String(), "is ranked mode; use repeated --option") {
+		t.Fatalf("ranked run accepted A/B artifacts: code=%d stderr=%s", code, stderr.String())
+	}
+
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open after ranked item add returned error: %v", err)
+	}
+	run, err := store.GetEvalRun(context.Background(), "planner-explore-1")
+	if err != nil {
+		t.Fatalf("GetEvalRun returned error: %v", err)
+	}
+	if run.Mode != db.EvalRunModeExplore || run.ExplorationLevel != db.ExplorationLevelHigh || run.OptionsCount != 4 {
+		t.Fatalf("run = %+v", run)
+	}
+	options, err = store.ListEvalReviewOptions(context.Background(), "planner-explore-1", "item-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 4 || options[0].Label != "a" || options[3].Label != "e" || !strings.Contains(options[0].MetadataJSON, optionPaths["a"]) {
+		t.Fatalf("options = %+v", options)
+	}
+	for _, option := range options {
+		if option.Label == "d" {
+			t.Fatalf("replacement left stale option d: %+v", options)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after ranked checks returned error: %v", err)
+	}
+
+	packetDir := filepath.Join(t.TempDir(), "packet")
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "feedback", "markdown", "export", "--home", home, "--run", "planner-explore-1", "--output", packetDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt feedback markdown export exit code = %d, stderr=%s", code, stderr.String())
+	}
+	index, err := os.ReadFile(filepath.Join(packetDir, "index.md"))
+	if err != nil {
+		t.Fatalf("read index.md: %v", err)
+	}
+	if !strings.Contains(string(index), "ranking every option") || !strings.Contains(string(index), "A > B > C > E") {
+		t.Fatalf("index.md = %s", string(index))
+	}
+	itemFiles, err := os.ReadDir(filepath.Join(packetDir, "items"))
+	if err != nil {
+		t.Fatalf("read items dir: %v", err)
+	}
+	if len(itemFiles) != 1 {
+		t.Fatalf("item files = %d, want 1", len(itemFiles))
+	}
+	itemContent, err := os.ReadFile(filepath.Join(packetDir, "items", itemFiles[0].Name()))
+	if err != nil {
+		t.Fatalf("read item markdown: %v", err)
+	}
+	if !strings.Contains(string(itemContent), "| Option | Artifact | Reference |") || !strings.Contains(string(itemContent), "Option C") {
+		t.Fatalf("item markdown = %s", string(itemContent))
+	}
+	feedbackYAML, err := os.ReadFile(filepath.Join(packetDir, "feedback.yml"))
+	if err != nil {
+		t.Fatalf("read feedback.yml: %v", err)
+	}
+	if !strings.Contains(string(feedbackYAML), "ranking:") ||
+		!strings.Contains(string(feedbackYAML), "<replace with ranked option labels, best to worst>") ||
+		strings.Contains(string(feedbackYAML), "- C") {
+		t.Fatalf("feedback.yml = %s", string(feedbackYAML))
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "review", "create",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/repo",
+		"--run", "planner-validate-1",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("validate review create exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "review", "item", "add",
+		"--home", home,
+		"--run", "planner-validate-1",
+		"--item", "item-ranked",
+		"--option", "a=" + optionPaths["a"],
+		"--option", "b=" + optionPaths["b"],
+	}, &stdout, &stderr)
+	if code == 0 || !strings.Contains(stderr.String(), "is validate/A/B mode; use --baseline and --candidate") {
+		t.Fatalf("validate run accepted ranked options: code=%d stderr=%s", code, stderr.String())
 	}
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1874,19 +1874,63 @@ func (s *Store) UpsertEvalReviewOption(ctx context.Context, option EvalReviewOpt
 	if err != nil {
 		return err
 	}
-	var existingID string
-	if err := s.db.QueryRowContext(ctx, `SELECT id FROM eval_review_options WHERE run_id = ? AND item_id = ? AND label = ?`,
-		option.RunID, option.ItemID, option.Label).Scan(&existingID); err == nil {
-		return fmt.Errorf("eval review option label %q already exists for item %q", option.Label, option.ItemID)
-	} else if !errors.Is(err, sql.ErrNoRows) {
-		return err
-	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO eval_review_options(
 			id, run_id, item_id, label, artifact_id, role, metadata_json, created_at, updated_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(run_id, item_id, label) DO UPDATE SET
+			id = excluded.id,
+			artifact_id = excluded.artifact_id,
+			role = excluded.role,
+			metadata_json = excluded.metadata_json,
+			updated_at = CURRENT_TIMESTAMP`,
 		option.ID, option.RunID, option.ItemID, option.Label, option.ArtifactID, option.Role, option.MetadataJSON)
 	return err
+}
+
+func (s *Store) ReplaceEvalReviewOptions(ctx context.Context, runID string, itemID string, options []EvalReviewOption) error {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return errors.New("eval review option run id is required")
+	}
+	itemID = strings.TrimSpace(itemID)
+	if itemID == "" {
+		return errors.New("eval review option item id is required")
+	}
+	normalized := make([]EvalReviewOption, 0, len(options))
+	seen := map[string]struct{}{}
+	for _, option := range options {
+		option.RunID = runID
+		option.ItemID = itemID
+		option, err := normalizeEvalReviewOption(option)
+		if err != nil {
+			return err
+		}
+		if _, ok := seen[option.Label]; ok {
+			return fmt.Errorf("eval review option label %q is duplicated for item %q", option.Label, itemID)
+		}
+		seen[option.Label] = struct{}{}
+		normalized = append(normalized, option)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM eval_review_options WHERE run_id = ? AND item_id = ?`, runID, itemID); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	for _, option := range normalized {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO eval_review_options(
+				id, run_id, item_id, label, artifact_id, role, metadata_json, created_at, updated_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			option.ID, option.RunID, option.ItemID, option.Label, option.ArtifactID, option.Role, option.MetadataJSON); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 func normalizeEvalReviewOption(option EvalReviewOption) (EvalReviewOption, error) {

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -269,8 +269,34 @@ func TestRankedReviewStorageRejectsInvalidReferences(t *testing.T) {
 			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
 		}
 	}
-	if err := store.UpsertEvalReviewOption(ctx, EvalReviewOption{RunID: "run-ranked", ItemID: "item-001", Label: "A", ArtifactID: "artifact-duplicate"}); err == nil || !strings.Contains(err.Error(), "already exists") {
-		t.Fatalf("duplicate UpsertEvalReviewOption error = %v, want already exists", err)
+	if err := store.UpsertEvalReviewOption(ctx, EvalReviewOption{RunID: "run-ranked", ItemID: "item-001", Label: "A", ArtifactID: "artifact-updated"}); err != nil {
+		t.Fatalf("duplicate UpsertEvalReviewOption returned error: %v", err)
+	}
+	options, err := store.ListEvalReviewOptions(ctx, "run-ranked", "item-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions after update returned error: %v", err)
+	}
+	if len(options) != 3 || options[0].ArtifactID != "artifact-updated" {
+		t.Fatalf("updated options = %+v", options)
+	}
+	if err := store.ReplaceEvalReviewOptions(ctx, "run-ranked", "item-001", []EvalReviewOption{
+		{Label: "B", ArtifactID: "artifact-b"},
+		{Label: "C", ArtifactID: "artifact-c"},
+		{Label: "D", ArtifactID: "artifact-d"},
+	}); err != nil {
+		t.Fatalf("ReplaceEvalReviewOptions returned error: %v", err)
+	}
+	options, err = store.ListEvalReviewOptions(ctx, "run-ranked", "item-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions after replace returned error: %v", err)
+	}
+	if len(options) != 3 || options[0].Label != "b" || options[2].Label != "d" {
+		t.Fatalf("replaced options = %+v", options)
+	}
+	for _, option := range options {
+		if option.Label == "a" {
+			t.Fatalf("ReplaceEvalReviewOptions left stale option a: %+v", options)
+		}
 	}
 
 	tests := map[string]RankedFeedbackEvent{

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -78,6 +78,9 @@ func (c GitHubCollector) Body(ctx context.Context, store *db.Store, runID string
 	var builder strings.Builder
 	builder.WriteString(githubFeedbackPacketMarker + "\n")
 	fmt.Fprintf(&builder, "# Gitmoot SkillOpt Feedback: %s\n\n", run.ID)
+	if reviewUsesRankedOptions(run) {
+		return c.rankedBody(ctx, store, run, items, assignments)
+	}
 	builder.WriteString("Review each item without trying to infer which option is baseline or candidate.\n\n")
 	builder.WriteString("Reply in a comment with one of these formats. Allowed choices: `a`, `b`, `tie`, `neither`, `skip`.\n\n")
 	builder.WriteString("## Copy-Paste YAML Reply\n\n")
@@ -107,44 +110,97 @@ func (c GitHubCollector) Body(ctx context.Context, store *db.Store, runID string
 	return builder.String(), nil
 }
 
-func (c GitHubCollector) Sync(ctx context.Context, store *db.Store, runID string, repo github.Repository, issueNumber int64) ([]db.FeedbackEvent, error) {
+func (c GitHubCollector) rankedBody(ctx context.Context, store *db.Store, run db.EvalRun, items []db.EvalReviewItem, assignments map[string]githubAssignment) (string, error) {
+	var builder strings.Builder
+	builder.WriteString(githubFeedbackPacketMarker + "\n")
+	fmt.Fprintf(&builder, "# Gitmoot SkillOpt Feedback: %s\n\n", run.ID)
+	builder.WriteString("Rank every option for each item from best to worst. Use the option labels exactly as shown.\n\n")
+	builder.WriteString("Reply in a comment with this format:\n\n")
+	builder.WriteString("```yaml\n")
+	replyYAML, err := rankedReplyYAML(run.ID, items, assignments)
+	if err != nil {
+		return "", err
+	}
+	builder.WriteString(replyYAML)
+	builder.WriteString("```\n\n")
+	builder.WriteString("## Items\n")
+	for _, item := range items {
+		assignment := assignments[item.ItemID]
+		fmt.Fprintf(&builder, "\n### %s\n\n", itemTitle(item))
+		writeGitHubOptionReferenceTable(&builder, assignment.Options)
+		for _, option := range assignment.Options {
+			content, err := c.optionText(ctx, store, option.ArtifactID)
+			if err != nil {
+				return "", fmt.Errorf("item %s option %s: %w", item.ItemID, option.Label, err)
+			}
+			fmt.Fprintf(&builder, "#### Option %s\n\n", displayOptionLabel(option.Label))
+			writeMarkdownFence(&builder, content)
+			builder.WriteString("\n")
+		}
+	}
+	return builder.String(), nil
+}
+
+func rankedReplyYAML(runID string, items []db.EvalReviewItem, assignments map[string]githubAssignment) (string, error) {
+	type rankedReplyFile struct {
+		RunID string              `yaml:"run_id"`
+		Items []feedbackFileEntry `yaml:"items"`
+	}
+	packet := rankedReplyFile{RunID: runID}
+	for _, item := range items {
+		labels := displayOptionLabels(assignments[item.ItemID].Options)
+		packet.Items = append(packet.Items, feedbackFileEntry{
+			ItemID:    item.ItemID,
+			Ranking:   []string{fmt.Sprintf("<replace with ranked option labels, e.g. %s>", strings.Join(labels, " > "))},
+			Reasoning: "",
+		})
+	}
+	content, err := yaml.Marshal(packet)
+	if err != nil {
+		return "", fmt.Errorf("encode ranked feedback reply: %w", err)
+	}
+	return string(content), nil
+}
+
+func (c GitHubCollector) Sync(ctx context.Context, store *db.Store, runID string, repo github.Repository, issueNumber int64) (ImportResult, error) {
 	if c.GitHub == nil {
-		return nil, errors.New("github client is required")
+		return ImportResult{}, errors.New("github client is required")
 	}
 	if repo.FullName() == "" {
-		return nil, errors.New("github feedback repo is required")
+		return ImportResult{}, errors.New("github feedback repo is required")
 	}
 	if issueNumber <= 0 {
-		return nil, errors.New("github feedback issue or pull request number is required")
+		return ImportResult{}, errors.New("github feedback issue or pull request number is required")
 	}
 	comments, err := c.GitHub.ListIssueComments(ctx, repo, issueNumber)
 	if err != nil {
-		return nil, err
+		return ImportResult{}, err
 	}
 	return c.ImportComments(ctx, store, runID, comments)
 }
 
-func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, runID string, comments []github.IssueComment) ([]db.FeedbackEvent, error) {
+func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, runID string, comments []github.IssueComment) (ImportResult, error) {
 	if store == nil {
-		return nil, errors.New("store is required")
+		return ImportResult{}, errors.New("store is required")
 	}
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
-		return nil, errors.New("run id is required")
+		return ImportResult{}, errors.New("run id is required")
 	}
 	items, assignments, err := c.reviewItemsAndAssignments(ctx, store, runID)
 	if err != nil {
-		return nil, err
+		return ImportResult{}, err
 	}
 	knownItems := make(map[string]struct{}, len(items))
 	for _, item := range items {
 		knownItems[item.ItemID] = struct{}{}
 	}
 	var imported []db.FeedbackEvent
+	var importedRanked []db.RankedFeedbackEvent
 	for _, comment := range comments {
 		parsed, ok, err := ParseGitHubFeedbackComment(comment.Body)
 		if err != nil {
-			return nil, fmt.Errorf("comment %d: %w", comment.ID, err)
+			return ImportResult{}, fmt.Errorf("comment %d: %w", comment.ID, err)
 		}
 		if !ok {
 			continue
@@ -171,21 +227,31 @@ func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, ru
 			createdAt = c.now().UTC().Format(time.RFC3339)
 		}
 		commentEvents := make([]db.FeedbackEvent, 0, len(parsed.Items))
+		commentRankedEvents := make([]db.RankedFeedbackEvent, 0, len(parsed.Items))
 		for _, entry := range parsed.Items {
 			itemID := strings.TrimSpace(entry.ItemID)
 			if _, ok := knownItems[itemID]; !ok {
 				if parsed.ShortForm {
 					continue
 				}
-				return nil, fmt.Errorf("comment %d: unknown feedback item_id %q", comment.ID, itemID)
+				return ImportResult{}, fmt.Errorf("comment %d: unknown feedback item_id %q", comment.ID, itemID)
+			}
+			assignment := assignments[itemID].blindAssignment
+			if len(assignment.Options) > 0 {
+				event, err := rankedFeedbackEventFromEntry(runID, itemID, entry, assignment, reviewer, SourceGitHub, sourceURL, createdAt)
+				if err != nil {
+					return ImportResult{}, fmt.Errorf("comment %d item %s: %w", comment.ID, itemID, err)
+				}
+				commentRankedEvents = append(commentRankedEvents, event)
+				continue
 			}
 			choice, err := NormalizeChoice(entry.Choice)
 			if err != nil {
-				return nil, fmt.Errorf("comment %d item %s: %w", comment.ID, itemID, err)
+				return ImportResult{}, fmt.Errorf("comment %d item %s: %w", comment.ID, itemID, err)
 			}
-			choice, err = deblindChoice(choice, assignments[itemID].blindAssignment)
+			choice, err = deblindChoice(choice, assignment)
 			if err != nil {
-				return nil, fmt.Errorf("comment %d item %s: %w", comment.ID, itemID, err)
+				return ImportResult{}, fmt.Errorf("comment %d item %s: %w", comment.ID, itemID, err)
 			}
 			event := db.FeedbackEvent{
 				RunID:     runID,
@@ -200,13 +266,19 @@ func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, ru
 			commentEvents = append(commentEvents, event)
 		}
 		imported = append(imported, commentEvents...)
+		importedRanked = append(importedRanked, commentRankedEvents...)
 	}
 	for _, event := range imported {
 		if err := store.UpsertFeedbackEvent(ctx, event); err != nil {
-			return nil, err
+			return ImportResult{}, err
 		}
 	}
-	return imported, nil
+	for _, event := range importedRanked {
+		if err := store.UpsertRankedFeedbackEvent(ctx, event); err != nil {
+			return ImportResult{}, err
+		}
+	}
+	return ImportResult{FeedbackEvents: imported, RankedFeedbackEvents: importedRanked}, nil
 }
 
 type githubAssignment struct {
@@ -229,9 +301,13 @@ func (c GitHubCollector) reviewItemsAndAssignments(ctx context.Context, store *d
 	}
 	assignments := make(map[string]githubAssignment, len(items))
 	for _, item := range items {
-		assignment, err := validatedAssignmentFor(run.ID, item)
+		assignment, err := validatedAssignmentForReview(ctx, store, run, item)
 		if err != nil {
 			return nil, nil, err
+		}
+		if len(assignment.Options) > 0 {
+			assignments[item.ItemID] = githubAssignment{blindAssignment: assignment}
+			continue
 		}
 		optionA, err := c.optionText(ctx, store, assignment.A)
 		if err != nil {
@@ -306,11 +382,7 @@ func parseFullYAMLFeedback(content string) (feedbackFile, bool, error) {
 	if len(parsed.Items) == 0 {
 		return feedbackFile{}, false, nil
 	}
-	for index := range parsed.Items {
-		parsed.Items[index].ItemID = strings.TrimSpace(parsed.Items[index].ItemID)
-		parsed.Items[index].Choice = strings.TrimSpace(parsed.Items[index].Choice)
-		parsed.Items[index].Reasoning = strings.TrimSpace(parsed.Items[index].Reasoning)
-	}
+	normalizeFeedbackFileEntries(&parsed)
 	hasFeedbackItem := false
 	for _, item := range parsed.Items {
 		if item.ItemID != "" {
@@ -325,10 +397,15 @@ func parseFullYAMLFeedback(content string) (feedbackFile, bool, error) {
 }
 
 var shortFeedbackLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s*:\s*([A-Za-z]+)(?:\s*-\s*(.*))?$`)
+var shortRankingLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s+ranking\s*:\s*(.+)$`)
 var shortMetadataLine = regexp.MustCompile(`^(run_id|reviewer)\s*:\s*(.+)$`)
+var shortTraitHeaderLine = regexp.MustCompile(`^(best traits|useful traits|reject|rejected traits)\s*:\s*$`)
+var shortTraitLine = regexp.MustCompile(`^-\s*([^:]+):\s*(.+)$`)
 
 func parseShortFormFeedback(content string) (feedbackFile, bool, error) {
 	parsed := feedbackFile{ShortForm: true}
+	var traitTarget string
+	traitItemIndex := -1
 	for _, raw := range strings.Split(content, "\n") {
 		line := strings.TrimSpace(raw)
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "```") {
@@ -346,10 +423,56 @@ func parseShortFormFeedback(content string) (feedbackFile, bool, error) {
 			}
 			continue
 		}
+		if match := shortTraitHeaderLine.FindStringSubmatch(strings.ToLower(line)); match != nil {
+			if traitItemIndex < 0 {
+				continue
+			}
+			switch match[1] {
+			case "best traits", "useful traits":
+				traitTarget = "useful"
+			case "reject", "rejected traits":
+				traitTarget = "rejected"
+			}
+			continue
+		}
+		if traitTarget != "" {
+			if match := shortTraitLine.FindStringSubmatch(line); match != nil && traitItemIndex >= 0 {
+				label := strings.TrimSpace(match[1])
+				trait := strings.TrimSpace(match[2])
+				if trait != "" {
+					entry := &parsed.Items[traitItemIndex]
+					if traitTarget == "useful" {
+						if entry.UsefulTraits == nil {
+							entry.UsefulTraits = map[string][]string{}
+						}
+						entry.UsefulTraits[label] = append(entry.UsefulTraits[label], trait)
+					} else {
+						if entry.RejectedTraits == nil {
+							entry.RejectedTraits = map[string][]string{}
+						}
+						entry.RejectedTraits[label] = append(entry.RejectedTraits[label], trait)
+					}
+				}
+				continue
+			}
+			traitTarget = ""
+			traitItemIndex = -1
+		}
+		if match := shortRankingLine.FindStringSubmatch(line); match != nil {
+			parsed.Items = append(parsed.Items, feedbackFileEntry{
+				ItemID:  strings.TrimSpace(match[1]),
+				Ranking: splitRankingString(match[2]),
+			})
+			traitItemIndex = len(parsed.Items) - 1
+			traitTarget = ""
+			continue
+		}
 		match := shortFeedbackLine.FindStringSubmatch(line)
 		if match == nil {
 			continue
 		}
+		traitTarget = ""
+		traitItemIndex = -1
 		parsed.Items = append(parsed.Items, feedbackFileEntry{
 			ItemID:    strings.TrimSpace(match[1]),
 			Choice:    strings.TrimSpace(match[2]),
@@ -360,6 +483,63 @@ func parseShortFormFeedback(content string) (feedbackFile, bool, error) {
 		return feedbackFile{}, false, nil
 	}
 	return parsed, true, nil
+}
+
+func splitRankingString(value string) []string {
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == '>' || r == ',' || r == '|'
+	})
+	return splitRankingLabels(parts)
+}
+
+func splitRankingLabels(values []string) []string {
+	labels := make([]string, 0, len(values))
+	for _, value := range values {
+		parts := strings.FieldsFunc(value, func(r rune) bool {
+			return r == '>' || r == ',' || r == '|'
+		})
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				labels = append(labels, part)
+			}
+		}
+	}
+	return labels
+}
+
+func trimTraitMap(values map[string][]string) map[string][]string {
+	if len(values) == 0 {
+		return nil
+	}
+	trimmed := map[string][]string{}
+	for key, traits := range values {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		for _, trait := range traits {
+			trait = strings.TrimSpace(trait)
+			if trait != "" {
+				trimmed[key] = append(trimmed[key], trait)
+			}
+		}
+	}
+	if len(trimmed) == 0 {
+		return nil
+	}
+	return trimmed
+}
+
+func cloneTraitMap(values map[string][]string) map[string][]string {
+	if len(values) == 0 {
+		return nil
+	}
+	clone := make(map[string][]string, len(values))
+	for key, traits := range values {
+		clone[key] = append([]string(nil), traits...)
+	}
+	return clone
 }
 
 func fencedBlocks(content string) []string {

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -35,6 +35,11 @@ func TestParseGitHubFeedbackComment(t *testing.T) {
 			wantOK: true, wantRunID: "run-1", wantItems: 2, wantItem: "item-001", wantChoice: "b", wantReason: "More concrete and easier to execute.",
 		},
 		{
+			name:   "ranked short form",
+			body:   "run_id: ranked-1\nitem-001 ranking: C > A > D > B\nbest traits:\n- C: clearest product explanation\nreject:\n- B: too generic\n",
+			wantOK: true, wantRunID: "ranked-1", wantItems: 1, wantItem: "item-001",
+		},
+		{
 			name:   "unrelated",
 			body:   "Thanks, I will review this later.",
 			wantOK: false,
@@ -85,7 +90,43 @@ func TestParseGitHubFeedbackComment(t *testing.T) {
 			if parsed.Items[0].ItemID != tt.wantItem || parsed.Items[0].Choice != tt.wantChoice || parsed.Items[0].Reasoning != tt.wantReason {
 				t.Fatalf("first item = %+v", parsed.Items[0])
 			}
+			if tt.name == "ranked short form" {
+				if strings.Join(parsed.Items[0].Ranking, ",") != "C,A,D,B" ||
+					!strings.Contains(strings.Join(parsed.Items[0].UsefulTraits["C"], ","), "clearest product explanation") ||
+					!strings.Contains(strings.Join(parsed.Items[0].RejectedTraits["B"], ","), "too generic") {
+					t.Fatalf("ranked first item = %+v", parsed.Items[0])
+				}
+			}
 		})
+	}
+}
+
+func TestParseGitHubFeedbackCommentScopesRankedTraitsToItem(t *testing.T) {
+	body := "run_id: ranked-1\n" +
+		"item-001 ranking: C > A > D > B\n" +
+		"best traits:\n" +
+		"- C: clearest product explanation\n" +
+		"item-002 ranking: A > B > C > D\n" +
+		"reject:\n" +
+		"- D: too generic\n"
+	parsed, ok, err := ParseGitHubFeedbackComment(body)
+	if err != nil {
+		t.Fatalf("ParseGitHubFeedbackComment returned error: %v", err)
+	}
+	if !ok || len(parsed.Items) != 2 {
+		t.Fatalf("parsed ok=%t items=%+v", ok, parsed.Items)
+	}
+	if !strings.Contains(strings.Join(parsed.Items[0].UsefulTraits["C"], ","), "clearest product explanation") {
+		t.Fatalf("first item traits = %+v", parsed.Items[0])
+	}
+	if len(parsed.Items[0].RejectedTraits) != 0 {
+		t.Fatalf("first item received second item rejected traits: %+v", parsed.Items[0])
+	}
+	if !strings.Contains(strings.Join(parsed.Items[1].RejectedTraits["D"], ","), "too generic") {
+		t.Fatalf("second item traits = %+v", parsed.Items[1])
+	}
+	if len(parsed.Items[1].UsefulTraits) != 0 {
+		t.Fatalf("second item received first item useful traits: %+v", parsed.Items[1])
 	}
 }
 
@@ -113,6 +154,7 @@ func TestGitHubCollectorPublishesIssueBody(t *testing.T) {
 	for _, want := range []string{
 		"Allowed choices: `a`, `b`, `tie`, `neither`, `skip`",
 		"run_id: run-1",
+		"choice:",
 		"item-001: <choice> - optional reason",
 		"#### Option A",
 		"#### Option B",
@@ -122,6 +164,44 @@ func TestGitHubCollectorPublishesIssueBody(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Fatalf("issue body missing %q:\n%s", want, body)
 		}
+	}
+}
+
+func TestGitHubCollectorPublishesRankedIssueBody(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubRankedFeedbackRun(t, "ranked-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		issue: github.Issue{Number: 42, URL: "https://github.com/owner/repo/issues/42"},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	result, err := collector.Publish(ctx, store, "ranked-1", GitHubPublishTarget{
+		Repo: github.Repository{Owner: "owner", Name: "repo"},
+	})
+	if err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+	if result.Mode != "issue" || result.IssueNumber != 42 {
+		t.Fatalf("result = %+v", result)
+	}
+	body := fake.createdIssue.Body
+	for _, want := range []string{
+		"Rank every option",
+		"```yaml",
+		"run_id: ranked-1",
+		"item_id: item-001",
+		"<replace with ranked option labels, e.g. A > B > C > D>",
+		"| Option | Artifact | Reference |",
+		"[open](https://example.com/c)",
+		"#### Option C",
+		"option c answer",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("ranked issue body missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "/tmp/gitmoot-option-a.md") {
+		t.Fatalf("ranked issue body leaked local path:\n%s", body)
 	}
 }
 
@@ -197,10 +277,11 @@ func TestGitHubCollectorSyncImportsValidCommentsAndIgnoresUnrelated(t *testing.T
 		return time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
 	}}
 
-	events, err := collector.Sync(ctx, store, "run-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	result, err := collector.Sync(ctx, store, "run-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
 	if err != nil {
 		t.Fatalf("Sync returned error: %v", err)
 	}
+	events := result.FeedbackEvents
 	if len(events) != 1 {
 		t.Fatalf("events = %+v, want 1 imported event", events)
 	}
@@ -223,6 +304,93 @@ func TestGitHubCollectorSyncImportsValidCommentsAndIgnoresUnrelated(t *testing.T
 	}
 	if len(stored) != 1 {
 		t.Fatalf("duplicate sync persisted duplicate events: %+v", stored)
+	}
+}
+
+func TestGitHubCollectorSyncImportsRankedShortFormComment(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubRankedFeedbackRun(t, "ranked-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{
+			42: {
+				{ID: 1, Body: "run_id: ranked-1\nitem-001 ranking: C > A > D > B\nbest traits:\n- C: clearest product explanation\n- A: best visual style\nreject:\n- B: too generic\n", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-06-02T10:00:00Z"},
+			},
+		},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	result, err := collector.Sync(ctx, store, "ranked-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	if err != nil {
+		t.Fatalf("Sync returned error: %v", err)
+	}
+	if result.Count() != 1 || len(result.RankedFeedbackEvents) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	stored, err := store.ListRankedFeedbackEvents(ctx, "ranked-1")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Winner != "c" || stored[0].Reviewer != "alice" || stored[0].Source != SourceGitHub {
+		t.Fatalf("stored ranked feedback = %+v", stored)
+	}
+	if !strings.Contains(stored[0].UsefulTraitsJSON, `"c":["clearest product explanation"]`) || !strings.Contains(stored[0].RejectedTraitsJSON, `"b":["too generic"]`) {
+		t.Fatalf("stored traits useful=%s rejected=%s", stored[0].UsefulTraitsJSON, stored[0].RejectedTraitsJSON)
+	}
+	pairs, err := store.ListPairwisePreferences(ctx, "ranked-1")
+	if err != nil {
+		t.Fatalf("ListPairwisePreferences returned error: %v", err)
+	}
+	if len(pairs) != 6 || pairs[0].Preferred != "c" || pairs[0].Rejected != "a" {
+		t.Fatalf("pairwise preferences = %+v", pairs)
+	}
+}
+
+func TestGitHubCollectorSyncImportsRankedYAMLCommentWithColonItemID(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubRankedFeedbackRunWithItem(t, "ranked-1", "scenario:landing", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{
+			42: {
+				{ID: 1, Body: "```yaml\nrun_id: ranked-1\nitems:\n  - item_id: scenario:landing\n    ranking:\n      - C > A > D > B\n    reasoning: option c is strongest\n```\n", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-06-02T10:00:00Z"},
+			},
+		},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	result, err := collector.Sync(ctx, store, "ranked-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	if err != nil {
+		t.Fatalf("Sync returned error: %v", err)
+	}
+	if result.Count() != 1 || len(result.RankedFeedbackEvents) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if result.RankedFeedbackEvents[0].ItemID != "scenario:landing" || result.RankedFeedbackEvents[0].Winner != "c" {
+		t.Fatalf("ranked event = %+v", result.RankedFeedbackEvents[0])
+	}
+}
+
+func TestGitHubCollectorSyncRejectsUnchangedRankedTemplate(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubRankedFeedbackRun(t, "ranked-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{
+			42: {
+				{ID: 1, Body: "```yaml\nrun_id: ranked-1\nitems:\n  - item_id: item-001\n    ranking:\n      - <replace with ranked option labels, e.g. A > B > C > D>\n```\n", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-06-02T10:00:00Z"},
+			},
+		},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	_, err := collector.Sync(ctx, store, "ranked-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	if err == nil || !strings.Contains(err.Error(), "unknown option") {
+		t.Fatalf("Sync error = %v", err)
+	}
+	stored, err := store.ListRankedFeedbackEvents(ctx, "ranked-1")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 0 {
+		t.Fatalf("Sync persisted unchanged template feedback: %+v", stored)
 	}
 }
 
@@ -251,6 +419,61 @@ func TestGitHubCollectorSyncRejectsInvalidChoiceForKnownShortFormItem(t *testing
 	if len(stored) != 0 {
 		t.Fatalf("Sync persisted partial events after invalid known item choice: %+v", stored)
 	}
+}
+
+func setupGitHubRankedFeedbackRun(t *testing.T, runID string, targetRepo string) (*db.Store, artifact.Store) {
+	return setupGitHubRankedFeedbackRunWithItem(t, runID, "item-001", targetRepo)
+}
+
+func setupGitHubRankedFeedbackRunWithItem(t *testing.T, runID string, itemID string, targetRepo string) (*db.Store, artifact.Store) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	blobStore := artifact.NewStore(filepath.Join(t.TempDir(), "blobs"))
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:           runID,
+		TemplateID:   "planner",
+		TargetRepo:   targetRepo,
+		State:        "review",
+		Mode:         db.EvalRunModeExplore,
+		OptionsCount: 4,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:  runID,
+		ItemID: itemID,
+		Title:  "Ranked Item",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		content := []byte("option " + label + " answer")
+		blob, err := blobStore.Put(content)
+		if err != nil {
+			t.Fatalf("Put option %s returned error: %v", label, err)
+		}
+		artifactID := "option-" + label
+		if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: artifactID, Hash: blob.Hash, MediaType: "text/markdown", SizeBytes: blob.Size, Driver: "text"}); err != nil {
+			t.Fatalf("UpsertEvalArtifact %s returned error: %v", label, err)
+		}
+		metadata := `{"path":"/tmp/gitmoot-option-` + label + `.md"}`
+		if label == "c" {
+			metadata = `{"preview_url":"https://example.com/c"}`
+		}
+		if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{RunID: runID, ItemID: itemID, Label: label, ArtifactID: artifactID, Role: "option", MetadataJSON: metadata}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	return store, blobStore
 }
 
 func setupGitHubFeedbackRun(t *testing.T, runID string, targetRepo string) (*db.Store, artifact.Store) {

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -31,11 +31,19 @@ type assignmentFile struct {
 }
 
 type blindAssignment struct {
-	ItemID    string `json:"item_id"`
-	A         string `json:"a"`
-	B         string `json:"b"`
-	Baseline  string `json:"baseline"`
-	Candidate string `json:"candidate"`
+	ItemID    string                  `json:"item_id"`
+	A         string                  `json:"a"`
+	B         string                  `json:"b"`
+	Baseline  string                  `json:"baseline"`
+	Candidate string                  `json:"candidate"`
+	Options   []blindOptionAssignment `json:"options,omitempty"`
+}
+
+type blindOptionAssignment struct {
+	Label        string `json:"label"`
+	ArtifactID   string `json:"artifact_id"`
+	Role         string `json:"role,omitempty"`
+	MetadataJSON string `json:"metadata_json,omitempty"`
 }
 
 type feedbackFile struct {
@@ -46,9 +54,22 @@ type feedbackFile struct {
 }
 
 type feedbackFileEntry struct {
-	ItemID    string `yaml:"item_id"`
-	Choice    string `yaml:"choice"`
-	Reasoning string `yaml:"reasoning,omitempty"`
+	ItemID         string              `yaml:"item_id"`
+	Choice         string              `yaml:"choice"`
+	Ranking        []string            `yaml:"ranking,omitempty"`
+	Winner         string              `yaml:"winner,omitempty"`
+	UsefulTraits   map[string][]string `yaml:"useful_traits,omitempty"`
+	RejectedTraits map[string][]string `yaml:"rejected_traits,omitempty"`
+	Reasoning      string              `yaml:"reasoning,omitempty"`
+}
+
+type ImportResult struct {
+	FeedbackEvents       []db.FeedbackEvent
+	RankedFeedbackEvents []db.RankedFeedbackEvent
+}
+
+func (r ImportResult) Count() int {
+	return len(r.FeedbackEvents) + len(r.RankedFeedbackEvents)
 }
 
 func (c MarkdownCollector) WritePacket(ctx context.Context, store *db.Store, runID string, dir string) error {
@@ -75,7 +96,7 @@ func (c MarkdownCollector) WritePacket(ctx context.Context, store *db.Store, run
 	}
 	assignments := assignmentFile{RunID: run.ID}
 	for _, item := range items {
-		assignment, err := validatedAssignmentFor(run.ID, item)
+		assignment, err := validatedAssignmentForReview(ctx, store, run, item)
 		if err != nil {
 			return err
 		}
@@ -90,76 +111,85 @@ func (c MarkdownCollector) WritePacket(ctx context.Context, store *db.Store, run
 	if err := writeJSONFile(filepath.Join(dir, assignmentsName), assignments, 0o600); err != nil {
 		return err
 	}
-	if err := writeTextFile(filepath.Join(dir, "index.md"), indexMarkdown(run, items), 0o644); err != nil {
+	if err := writeTextFile(filepath.Join(dir, "index.md"), indexMarkdown(run, items, assignments), 0o644); err != nil {
 		return err
 	}
-	return writeFeedbackYAML(filepath.Join(dir, "feedback.yml"), run.ID, items)
+	return writeFeedbackYAML(filepath.Join(dir, "feedback.yml"), run.ID, assignments)
 }
 
-func (c MarkdownCollector) ImportPacket(ctx context.Context, store *db.Store, dir string, reviewerOverride string) ([]db.FeedbackEvent, error) {
+func (c MarkdownCollector) ImportPacket(ctx context.Context, store *db.Store, dir string, reviewerOverride string) (ImportResult, error) {
 	if store == nil {
-		return nil, errors.New("store is required")
+		return ImportResult{}, errors.New("store is required")
 	}
 	dir = strings.TrimSpace(dir)
 	if dir == "" {
-		return nil, errors.New("packet directory is required")
+		return ImportResult{}, errors.New("packet directory is required")
 	}
 	dir, err := filepath.Abs(filepath.Clean(dir))
 	if err != nil {
-		return nil, fmt.Errorf("resolve packet directory: %w", err)
+		return ImportResult{}, fmt.Errorf("resolve packet directory: %w", err)
 	}
 	assignments, err := readAssignments(filepath.Join(dir, assignmentsName))
 	if err != nil {
-		return nil, err
+		return ImportResult{}, err
 	}
 	feedback, err := readFeedbackYAML(filepath.Join(dir, "feedback.yml"))
 	if err != nil {
-		return nil, err
+		return ImportResult{}, err
 	}
 	if feedback.RunID != assignments.RunID {
-		return nil, fmt.Errorf("feedback run_id %q does not match assignments run_id %q", feedback.RunID, assignments.RunID)
+		return ImportResult{}, fmt.Errorf("feedback run_id %q does not match assignments run_id %q", feedback.RunID, assignments.RunID)
 	}
 	if err := validateAssignmentsAgainstStore(ctx, store, assignments); err != nil {
-		return nil, err
+		return ImportResult{}, err
 	}
 	reviewer := strings.TrimSpace(reviewerOverride)
 	if reviewer == "" {
 		reviewer = strings.TrimSpace(feedback.Reviewer)
 	}
 	if reviewer == "" {
-		return nil, errors.New("feedback reviewer is required")
+		return ImportResult{}, errors.New("feedback reviewer is required")
 	}
 	assignmentsByItem := map[string]blindAssignment{}
 	for _, assignment := range assignments.Items {
 		itemID := strings.TrimSpace(assignment.ItemID)
 		if itemID == "" {
-			return nil, errors.New("assignments contain an item with empty item_id")
+			return ImportResult{}, errors.New("assignments contain an item with empty item_id")
 		}
 		if _, ok := assignmentsByItem[itemID]; ok {
-			return nil, fmt.Errorf("assignments contain duplicate item_id %q", itemID)
+			return ImportResult{}, fmt.Errorf("assignments contain duplicate item_id %q", itemID)
 		}
 		assignmentsByItem[itemID] = assignment
 	}
 	now := c.now().UTC().Format(time.RFC3339)
 	events := make([]db.FeedbackEvent, 0, len(feedback.Items))
+	rankedEvents := make([]db.RankedFeedbackEvent, 0, len(feedback.Items))
 	seenItems := map[string]struct{}{}
 	for _, entry := range feedback.Items {
 		itemID := strings.TrimSpace(entry.ItemID)
 		assignment, ok := assignmentsByItem[itemID]
 		if !ok {
-			return nil, fmt.Errorf("unknown feedback item_id %q", itemID)
+			return ImportResult{}, fmt.Errorf("unknown feedback item_id %q", itemID)
 		}
 		if _, ok := seenItems[itemID]; ok {
-			return nil, fmt.Errorf("duplicate feedback item_id %q", itemID)
+			return ImportResult{}, fmt.Errorf("duplicate feedback item_id %q", itemID)
 		}
 		seenItems[itemID] = struct{}{}
+		if len(assignment.Options) > 0 {
+			event, err := rankedFeedbackEventFromEntry(feedback.RunID, itemID, entry, assignment, reviewer, SourceMarkdown, dir, now)
+			if err != nil {
+				return ImportResult{}, fmt.Errorf("item %s: %w", itemID, err)
+			}
+			rankedEvents = append(rankedEvents, event)
+			continue
+		}
 		choice, err := NormalizeChoice(entry.Choice)
 		if err != nil {
-			return nil, fmt.Errorf("item %s: %w", itemID, err)
+			return ImportResult{}, fmt.Errorf("item %s: %w", itemID, err)
 		}
 		choice, err = deblindChoice(choice, assignment)
 		if err != nil {
-			return nil, fmt.Errorf("item %s: %w", itemID, err)
+			return ImportResult{}, fmt.Errorf("item %s: %w", itemID, err)
 		}
 		event := db.FeedbackEvent{
 			RunID:     feedback.RunID,
@@ -181,17 +211,25 @@ func (c MarkdownCollector) ImportPacket(ctx context.Context, store *db.Store, di
 			}
 		}
 		sort.Strings(missing)
-		return nil, fmt.Errorf("feedback.yml missing feedback for item_id %q", missing[0])
+		return ImportResult{}, fmt.Errorf("feedback.yml missing feedback for item_id %q", missing[0])
 	}
 	for _, event := range events {
 		if err := store.UpsertFeedbackEvent(ctx, event); err != nil {
-			return nil, err
+			return ImportResult{}, err
 		}
 	}
-	return events, nil
+	for _, event := range rankedEvents {
+		if err := store.UpsertRankedFeedbackEvent(ctx, event); err != nil {
+			return ImportResult{}, err
+		}
+	}
+	return ImportResult{FeedbackEvents: events, RankedFeedbackEvents: rankedEvents}, nil
 }
 
 func (c MarkdownCollector) writeItem(ctx context.Context, store *db.Store, dir string, item db.EvalReviewItem, assignment blindAssignment) error {
+	if len(assignment.Options) > 0 {
+		return c.writeRankedItem(ctx, store, dir, item, assignment)
+	}
 	optionA, err := c.optionText(ctx, store, assignment.A)
 	if err != nil {
 		return fmt.Errorf("item %s option a: %w", item.ItemID, err)
@@ -208,6 +246,24 @@ func (c MarkdownCollector) writeItem(ctx context.Context, store *db.Store, dir s
 	writeMarkdownFence(&builder, optionB)
 	builder.WriteString("\n## Feedback\n\n")
 	builder.WriteString("Record this item in `../feedback.yml` with one of: `a`, `b`, `tie`, `neither`, `skip`.\n")
+	return writeTextFile(filepath.Join(dir, "items", itemFilename(item.ItemID)), builder.String(), 0o644)
+}
+
+func (c MarkdownCollector) writeRankedItem(ctx context.Context, store *db.Store, dir string, item db.EvalReviewItem, assignment blindAssignment) error {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "# %s\n\n", itemTitle(item))
+	builder.WriteString("Rank every option in `../feedback.yml` from best to worst. Use the option labels exactly as shown here.\n\n")
+	writeOptionReferenceTable(&builder, assignment.Options)
+	for _, option := range assignment.Options {
+		content, err := c.optionText(ctx, store, option.ArtifactID)
+		if err != nil {
+			return fmt.Errorf("item %s option %s: %w", item.ItemID, option.Label, err)
+		}
+		fmt.Fprintf(&builder, "\n## Option %s\n\n", displayOptionLabel(option.Label))
+		writeMarkdownFence(&builder, content)
+	}
+	builder.WriteString("\n## Feedback\n\n")
+	builder.WriteString("Record `ranking`, optional trait notes, and concise reasoning in `../feedback.yml`.\n")
 	return writeTextFile(filepath.Join(dir, "items", itemFilename(item.ItemID)), builder.String(), 0o644)
 }
 
@@ -250,6 +306,46 @@ func assignmentFor(runID string, item db.EvalReviewItem) blindAssignment {
 	return assignment
 }
 
+func validatedAssignmentForReview(ctx context.Context, store *db.Store, run db.EvalRun, item db.EvalReviewItem) (blindAssignment, error) {
+	if reviewUsesRankedOptions(run) {
+		return validatedRankedAssignmentFor(ctx, store, run, item)
+	}
+	return validatedAssignmentFor(run.ID, item)
+}
+
+func reviewUsesRankedOptions(run db.EvalRun) bool {
+	return run.Mode != "" && run.Mode != db.EvalRunModeValidate || run.OptionsCount > 2
+}
+
+func validatedRankedAssignmentFor(ctx context.Context, store *db.Store, run db.EvalRun, item db.EvalReviewItem) (blindAssignment, error) {
+	options, err := store.ListEvalReviewOptions(ctx, run.ID, item.ItemID)
+	if err != nil {
+		return blindAssignment{}, err
+	}
+	if len(options) == 0 {
+		return blindAssignment{}, fmt.Errorf("eval review item %s requires registered options", item.ItemID)
+	}
+	if run.OptionsCount > 0 && len(options) != run.OptionsCount {
+		return blindAssignment{}, fmt.Errorf("eval review item %s has %d options, want %d", item.ItemID, len(options), run.OptionsCount)
+	}
+	assignment := blindAssignment{ItemID: item.ItemID}
+	for _, option := range options {
+		if strings.TrimSpace(option.ArtifactID) == "" {
+			return blindAssignment{}, fmt.Errorf("eval review item %s option %s missing artifact", item.ItemID, option.Label)
+		}
+		assignment.Options = append(assignment.Options, blindOptionAssignment{
+			Label:        strings.TrimSpace(option.Label),
+			ArtifactID:   strings.TrimSpace(option.ArtifactID),
+			Role:         strings.TrimSpace(option.Role),
+			MetadataJSON: strings.TrimSpace(option.MetadataJSON),
+		})
+	}
+	sort.Slice(assignment.Options, func(i, j int) bool {
+		return assignment.Options[i].Label < assignment.Options[j].Label
+	})
+	return assignment, nil
+}
+
 func validatedAssignmentFor(runID string, item db.EvalReviewItem) (blindAssignment, error) {
 	baselineArtifactID := strings.TrimSpace(item.BaselineArtifactID)
 	candidateArtifactID := strings.TrimSpace(item.CandidateArtifactID)
@@ -284,6 +380,16 @@ func validateAssignmentsAgainstStore(ctx context.Context, store *db.Store, assig
 		if !ok {
 			return fmt.Errorf("packet assignment item_id %q is not in eval run %s", itemID, run.ID)
 		}
+		if len(assignment.Options) > 0 {
+			current, err := validatedRankedAssignmentFor(ctx, store, run, item)
+			if err != nil {
+				return err
+			}
+			if !rankedAssignmentsMatch(assignment, current) {
+				return fmt.Errorf("packet assignment item_id %q does not match stored review options", itemID)
+			}
+			continue
+		}
 		if strings.TrimSpace(assignment.Baseline) != strings.TrimSpace(item.BaselineArtifactID) ||
 			strings.TrimSpace(assignment.Candidate) != strings.TrimSpace(item.CandidateArtifactID) {
 			return fmt.Errorf("packet assignment item_id %q does not match stored baseline/candidate artifacts", itemID)
@@ -304,6 +410,162 @@ func validateAssignmentsAgainstStore(ctx context.Context, store *db.Store, assig
 		}
 	}
 	return nil
+}
+
+func rankedAssignmentsMatch(left blindAssignment, right blindAssignment) bool {
+	if len(left.Options) != len(right.Options) {
+		return false
+	}
+	for index := range left.Options {
+		if strings.TrimSpace(left.Options[index].Label) != strings.TrimSpace(right.Options[index].Label) ||
+			strings.TrimSpace(left.Options[index].ArtifactID) != strings.TrimSpace(right.Options[index].ArtifactID) {
+			return false
+		}
+	}
+	return true
+}
+
+func rankedFeedbackEventFromEntry(runID string, itemID string, entry feedbackFileEntry, assignment blindAssignment, reviewer string, source string, sourceURL string, createdAt string) (db.RankedFeedbackEvent, error) {
+	ranking, err := normalizedRanking(entry.Ranking)
+	if err != nil {
+		return db.RankedFeedbackEvent{}, err
+	}
+	if len(ranking) == 0 {
+		return db.RankedFeedbackEvent{}, errors.New("ranking is required")
+	}
+	known := map[string]struct{}{}
+	for _, option := range assignment.Options {
+		label := normalizeReviewOptionLabel(option.Label)
+		if label != "" {
+			known[label] = struct{}{}
+		}
+	}
+	for _, label := range ranking {
+		if _, ok := known[label]; !ok {
+			return db.RankedFeedbackEvent{}, fmt.Errorf("ranking references unknown option %q", label)
+		}
+	}
+	if len(ranking) != len(known) {
+		return db.RankedFeedbackEvent{}, fmt.Errorf("ranking includes %d options, want %d options", len(ranking), len(known))
+	}
+	for label := range known {
+		found := false
+		for _, ranked := range ranking {
+			if ranked == label {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return db.RankedFeedbackEvent{}, fmt.Errorf("ranking missing option %q", label)
+		}
+	}
+	if err := validateRankedTraitLabels(entry.UsefulTraits, known); err != nil {
+		return db.RankedFeedbackEvent{}, fmt.Errorf("useful_traits: %w", err)
+	}
+	if err := validateRankedTraitLabels(entry.RejectedTraits, known); err != nil {
+		return db.RankedFeedbackEvent{}, fmt.Errorf("rejected_traits: %w", err)
+	}
+	rankingJSON, err := json.Marshal(ranking)
+	if err != nil {
+		return db.RankedFeedbackEvent{}, err
+	}
+	usefulTraitsJSON, err := rankedTraitJSON(entry.UsefulTraits)
+	if err != nil {
+		return db.RankedFeedbackEvent{}, fmt.Errorf("useful_traits: %w", err)
+	}
+	rejectedTraitsJSON, err := rankedTraitJSON(entry.RejectedTraits)
+	if err != nil {
+		return db.RankedFeedbackEvent{}, fmt.Errorf("rejected_traits: %w", err)
+	}
+	winner := normalizeReviewOptionLabel(entry.Winner)
+	if winner == "" {
+		winner = ranking[0]
+	} else {
+		if _, ok := known[winner]; !ok {
+			return db.RankedFeedbackEvent{}, fmt.Errorf("winner references unknown option %q", winner)
+		}
+		if winner != ranking[0] {
+			return db.RankedFeedbackEvent{}, fmt.Errorf("winner %q does not match first ranked option %q", winner, ranking[0])
+		}
+	}
+	return db.RankedFeedbackEvent{
+		RunID:              strings.TrimSpace(runID),
+		ItemID:             strings.TrimSpace(itemID),
+		RankingJSON:        string(rankingJSON),
+		Winner:             winner,
+		UsefulTraitsJSON:   usefulTraitsJSON,
+		RejectedTraitsJSON: rejectedTraitsJSON,
+		Reasoning:          strings.TrimSpace(entry.Reasoning),
+		Reviewer:           strings.TrimSpace(reviewer),
+		Source:             strings.TrimSpace(source),
+		SourceURL:          strings.TrimSpace(sourceURL),
+		CreatedAt:          strings.TrimSpace(createdAt),
+	}, nil
+}
+
+func validateRankedTraitLabels(traits map[string][]string, known map[string]struct{}) error {
+	for label := range traits {
+		optionLabel := normalizeReviewOptionLabel(label)
+		if optionLabel == "" {
+			return errors.New("trait option label is required")
+		}
+		if _, ok := known[optionLabel]; !ok {
+			return fmt.Errorf("references unknown option %q", optionLabel)
+		}
+	}
+	return nil
+}
+
+func normalizedRanking(values []string) ([]string, error) {
+	ranking := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		label := normalizeReviewOptionLabel(value)
+		if label == "" {
+			return nil, errors.New("ranking contains an empty option label")
+		}
+		if _, ok := seen[label]; ok {
+			return nil, fmt.Errorf("ranking contains duplicate option label %q", label)
+		}
+		seen[label] = struct{}{}
+		ranking = append(ranking, label)
+	}
+	if len(ranking) < 2 {
+		return nil, errors.New("ranking must include at least two options")
+	}
+	return ranking, nil
+}
+
+func rankedTraitJSON(traits map[string][]string) (string, error) {
+	if len(traits) == 0 {
+		return "", nil
+	}
+	normalized := map[string][]string{}
+	for label, values := range traits {
+		optionLabel := normalizeReviewOptionLabel(label)
+		if optionLabel == "" {
+			return "", errors.New("trait option label is required")
+		}
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value != "" {
+				normalized[optionLabel] = append(normalized[optionLabel], value)
+			}
+		}
+		if _, ok := normalized[optionLabel]; !ok {
+			normalized[optionLabel] = []string{}
+		}
+	}
+	content, err := json.Marshal(normalized)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func normalizeReviewOptionLabel(label string) string {
+	return strings.ToLower(strings.TrimSpace(label))
 }
 
 func deblindChoice(choice string, assignment blindAssignment) (string, error) {
@@ -336,36 +598,118 @@ func canonicalChoiceForArtifact(artifactID string, assignment blindAssignment) (
 	}
 }
 
-func indexMarkdown(run db.EvalRun, items []db.EvalReviewItem) string {
+func indexMarkdown(run db.EvalRun, items []db.EvalReviewItem, assignments assignmentFile) string {
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "# Gitmoot Feedback Packet: %s\n\n", run.ID)
-	builder.WriteString("Review each item without trying to infer which option is baseline or candidate.\n\n")
+	if reviewUsesRankedOptions(run) {
+		builder.WriteString("Review each item by ranking every option from best to worst.\n\n")
+	} else {
+		builder.WriteString("Review each item without trying to infer which option is baseline or candidate.\n\n")
+	}
 	builder.WriteString("## How To Review\n\n")
 	builder.WriteString("1. Open this `index.md` file.\n")
 	builder.WriteString("2. Open each linked item in `items/*.md`.\n")
-	builder.WriteString("3. Compare Option A and Option B blind for each item.\n")
-	builder.WriteString("4. Edit `feedback.yml` in this packet directory and set `reviewer`.\n")
-	builder.WriteString("5. For every item, choose exactly one of: `a`, `b`, `tie`, `neither`, `skip`.\n")
-	builder.WriteString("6. Add concise `reasoning` when it helps explain the choice.\n")
-	builder.WriteString("7. Import the completed packet. If `reviewer` is not set in `feedback.yml`, pass `--reviewer <name>`:\n\n")
+	if reviewUsesRankedOptions(run) {
+		builder.WriteString("3. Rank every option for each item in `feedback.yml`.\n")
+		builder.WriteString("4. Add useful traits and rejected traits when they explain what should be kept or avoided.\n")
+		builder.WriteString("5. Import the completed packet. If `reviewer` is not set in `feedback.yml`, pass `--reviewer <name>`:\n\n")
+	} else {
+		builder.WriteString("3. Compare Option A and Option B blind for each item.\n")
+		builder.WriteString("4. Edit `feedback.yml` in this packet directory and set `reviewer`.\n")
+		builder.WriteString("5. For every item, choose exactly one of: `a`, `b`, `tie`, `neither`, `skip`.\n")
+		builder.WriteString("6. Add concise `reasoning` when it helps explain the choice.\n")
+		builder.WriteString("7. Import the completed packet. If `reviewer` is not set in `feedback.yml`, pass `--reviewer <name>`:\n\n")
+	}
 	builder.WriteString("   ```sh\n")
 	builder.WriteString("   gitmoot skillopt feedback markdown import --packet <packet-dir> --reviewer <name>\n")
 	builder.WriteString("   ```\n\n")
-	builder.WriteString("Keep `.assignments.json` untouched. It is hidden Gitmoot metadata used to preserve and validate the blind A/B mapping on import.\n\n")
+	builder.WriteString("Keep `.assignments.json` untouched. It is hidden Gitmoot metadata used to preserve and validate option mappings on import.\n\n")
 	builder.WriteString("## Items\n\n")
 	for _, item := range items {
 		fmt.Fprintf(&builder, "- [%s](items/%s)\n", itemTitle(item), itemFilename(item.ItemID))
+	}
+	if reviewUsesRankedOptions(run) {
+		builder.WriteString("\n## Ranking Labels\n\n")
+		assignmentsByItem := map[string]blindAssignment{}
+		for _, assignment := range assignments.Items {
+			assignmentsByItem[assignment.ItemID] = assignment
+		}
+		for _, item := range items {
+			assignment := assignmentsByItem[item.ItemID]
+			labels := displayOptionLabels(assignment.Options)
+			fmt.Fprintf(&builder, "- %s: `%s`\n", itemTitle(item), strings.Join(labels, " > "))
+		}
 	}
 	builder.WriteString("\n## Submit Feedback\n\n")
 	builder.WriteString("After all items are filled in `feedback.yml`, run the import command above.\n")
 	return builder.String()
 }
 
-func writeFeedbackYAML(path string, runID string, items []db.EvalReviewItem) error {
+func displayOptionLabels(options []blindOptionAssignment) []string {
+	labels := make([]string, 0, len(options))
+	for _, option := range options {
+		labels = append(labels, displayOptionLabel(option.Label))
+	}
+	return labels
+}
+
+func displayOptionLabel(label string) string {
+	label = strings.TrimSpace(label)
+	if len(label) == 1 {
+		return strings.ToUpper(label)
+	}
+	return label
+}
+
+func writeOptionReferenceTable(builder *strings.Builder, options []blindOptionAssignment) {
+	writeOptionReferenceTableWithLocalPaths(builder, options, true)
+}
+
+func writeGitHubOptionReferenceTable(builder *strings.Builder, options []blindOptionAssignment) {
+	writeOptionReferenceTableWithLocalPaths(builder, options, false)
+}
+
+func writeOptionReferenceTableWithLocalPaths(builder *strings.Builder, options []blindOptionAssignment, includeLocalPaths bool) {
+	builder.WriteString("| Option | Artifact | Reference |\n")
+	builder.WriteString("| --- | --- | --- |\n")
+	for _, option := range options {
+		fmt.Fprintf(builder, "| %s | `%s` | %s |\n", displayOptionLabel(option.Label), option.ArtifactID, optionReference(option, includeLocalPaths))
+	}
+	builder.WriteString("\n")
+}
+
+func optionReference(option blindOptionAssignment, includeLocalPaths bool) string {
+	metadata := map[string]string{}
+	if strings.TrimSpace(option.MetadataJSON) != "" {
+		_ = json.Unmarshal([]byte(option.MetadataJSON), &metadata)
+	}
+	for _, key := range []string{"preview_url", "url"} {
+		if value := strings.TrimSpace(metadata[key]); value != "" {
+			return fmt.Sprintf("[open](%s)", value)
+		}
+	}
+	if path := strings.TrimSpace(metadata["path"]); includeLocalPaths && path != "" {
+		return "`" + strings.ReplaceAll(path, "`", "") + "`"
+	}
+	return ""
+}
+
+func writeFeedbackYAML(path string, runID string, assignments assignmentFile) error {
 	packet := feedbackFile{RunID: runID, Reviewer: ""}
-	for _, item := range items {
+	for _, assignment := range assignments.Items {
+		if len(assignment.Options) > 0 {
+			packet.Items = append(packet.Items, feedbackFileEntry{
+				ItemID:         assignment.ItemID,
+				Ranking:        []string{"<replace with ranked option labels, best to worst>"},
+				Winner:         "",
+				UsefulTraits:   map[string][]string{},
+				RejectedTraits: map[string][]string{},
+				Reasoning:      "",
+			})
+			continue
+		}
 		packet.Items = append(packet.Items, feedbackFileEntry{
-			ItemID:    item.ItemID,
+			ItemID:    assignment.ItemID,
 			Choice:    "",
 			Reasoning: "",
 		})
@@ -390,7 +734,21 @@ func readFeedbackYAML(path string) (feedbackFile, error) {
 	if feedback.RunID == "" {
 		return feedbackFile{}, errors.New("feedback.yml missing run_id")
 	}
+	feedback.Reviewer = strings.TrimSpace(feedback.Reviewer)
+	normalizeFeedbackFileEntries(&feedback)
 	return feedback, nil
+}
+
+func normalizeFeedbackFileEntries(feedback *feedbackFile) {
+	for index := range feedback.Items {
+		feedback.Items[index].ItemID = strings.TrimSpace(feedback.Items[index].ItemID)
+		feedback.Items[index].Choice = strings.TrimSpace(feedback.Items[index].Choice)
+		feedback.Items[index].Ranking = splitRankingLabels(feedback.Items[index].Ranking)
+		feedback.Items[index].Winner = strings.TrimSpace(feedback.Items[index].Winner)
+		feedback.Items[index].UsefulTraits = trimTraitMap(feedback.Items[index].UsefulTraits)
+		feedback.Items[index].RejectedTraits = trimTraitMap(feedback.Items[index].RejectedTraits)
+		feedback.Items[index].Reasoning = strings.TrimSpace(feedback.Items[index].Reasoning)
+	}
 }
 
 func readAssignments(path string) (assignmentFile, error) {

--- a/internal/feedback/markdown_test.go
+++ b/internal/feedback/markdown_test.go
@@ -107,10 +107,11 @@ items:
 	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackContent), 0o644); err != nil {
 		t.Fatalf("write feedback.yml: %v", err)
 	}
-	events, err := collector.ImportPacket(ctx, store, packetDir+string(os.PathSeparator)+".", "")
+	result, err := collector.ImportPacket(ctx, store, packetDir+string(os.PathSeparator)+".", "")
 	if err != nil {
 		t.Fatalf("ImportPacket returned error: %v", err)
 	}
+	events := result.FeedbackEvents
 	if len(events) != 2 || events[0].Choice != "b" || events[1].Choice != "b" || events[0].CreatedAt != "2026-05-31T10:00:00Z" {
 		t.Fatalf("events = %+v", events)
 	}
@@ -130,6 +131,114 @@ items:
 	}
 	if len(stored) != 2 {
 		t.Fatalf("second import duplicated feedback events: %+v", stored)
+	}
+}
+
+func TestMarkdownCollectorImportsRankedPacket(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupMarkdownRankedFeedbackRun(t, "ranked-1")
+	packetDir := filepath.Join(t.TempDir(), "packet")
+	collector := MarkdownCollector{
+		BlobStore: blobs,
+		Now: func() time.Time {
+			return time.Date(2026, 6, 2, 10, 0, 0, 0, time.UTC)
+		},
+	}
+	if err := collector.WritePacket(ctx, store, "ranked-1", packetDir); err != nil {
+		t.Fatalf("WritePacket returned error: %v", err)
+	}
+	if _, err := collector.ImportPacket(ctx, store, packetDir, "jerry"); err == nil || !strings.Contains(err.Error(), "ranking") {
+		t.Fatalf("unchanged ranked packet import error = %v", err)
+	}
+	feedbackContent := `run_id: ranked-1
+reviewer: jerry
+items:
+  - item_id: item-001
+    ranking:
+      - C > A > D > B
+    useful_traits:
+      A:
+        - visual style
+      D:
+        - motion
+    rejected_traits:
+      B:
+        - too generic
+    reasoning: C explains the product best.
+`
+	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackContent), 0o644); err != nil {
+		t.Fatalf("write feedback.yml: %v", err)
+	}
+	result, err := collector.ImportPacket(ctx, store, packetDir, "")
+	if err != nil {
+		t.Fatalf("ImportPacket returned error: %v", err)
+	}
+	if result.Count() != 1 || len(result.RankedFeedbackEvents) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	stored, err := store.ListRankedFeedbackEvents(ctx, "ranked-1")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Winner != "c" || stored[0].Reasoning != "C explains the product best." || stored[0].Source != SourceMarkdown {
+		t.Fatalf("stored ranked events = %+v", stored)
+	}
+	if !strings.Contains(stored[0].UsefulTraitsJSON, `"a":["visual style"]`) || !strings.Contains(stored[0].RejectedTraitsJSON, `"b":["too generic"]`) {
+		t.Fatalf("stored traits useful=%s rejected=%s", stored[0].UsefulTraitsJSON, stored[0].RejectedTraitsJSON)
+	}
+	pairs, err := store.ListPairwisePreferences(ctx, "ranked-1")
+	if err != nil {
+		t.Fatalf("ListPairwisePreferences returned error: %v", err)
+	}
+	if len(pairs) != 6 || pairs[0].Preferred != "c" || pairs[0].Rejected != "a" || pairs[5].Preferred != "d" || pairs[5].Rejected != "b" {
+		t.Fatalf("pairwise preferences = %+v", pairs)
+	}
+}
+
+func TestMarkdownCollectorRejectsInvalidRankedWinnerWithoutPartialImport(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupMarkdownRankedFeedbackRun(t, "ranked-1")
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:  "ranked-1",
+		ItemID: "item-002",
+		Title:  "Second Ranked Item",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem item-002 returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{RunID: "ranked-1", ItemID: "item-002", Label: label, ArtifactID: "option-" + label, Role: "option"}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption item-002 %s returned error: %v", label, err)
+		}
+	}
+	packetDir := filepath.Join(t.TempDir(), "packet")
+	collector := MarkdownCollector{BlobStore: blobs}
+	if err := collector.WritePacket(ctx, store, "ranked-1", packetDir); err != nil {
+		t.Fatalf("WritePacket returned error: %v", err)
+	}
+	feedbackContent := `run_id: ranked-1
+reviewer: jerry
+items:
+  - item_id: item-001
+    ranking:
+      - C > A > D > B
+  - item_id: item-002
+    ranking:
+      - C > A > D > B
+    winner: B
+`
+	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackContent), 0o644); err != nil {
+		t.Fatalf("write feedback.yml: %v", err)
+	}
+	_, err := collector.ImportPacket(ctx, store, packetDir, "")
+	if err == nil || !strings.Contains(err.Error(), "winner") {
+		t.Fatalf("ImportPacket error = %v", err)
+	}
+	stored, err := store.ListRankedFeedbackEvents(ctx, "ranked-1")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 0 {
+		t.Fatalf("ImportPacket persisted partial ranked events: %+v", stored)
 	}
 }
 
@@ -346,4 +455,49 @@ func TestMarkdownCollectorUsesCollisionSafeItemFilenames(t *testing.T) {
 	if !strings.Contains(string(index), "items/"+first) || !strings.Contains(string(index), "items/"+second) {
 		t.Fatalf("index does not link distinct item files:\n%s", string(index))
 	}
+}
+
+func setupMarkdownRankedFeedbackRun(t *testing.T, runID string) (*db.Store, artifact.Store) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	blobStore := artifact.NewStore(filepath.Join(t.TempDir(), "blobs"))
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:           runID,
+		State:        "review",
+		Mode:         db.EvalRunModeExplore,
+		OptionsCount: 4,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:  runID,
+		ItemID: "item-001",
+		Title:  "Ranked Item",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		content := []byte("option " + label + " answer")
+		blob, err := blobStore.Put(content)
+		if err != nil {
+			t.Fatalf("Put option %s returned error: %v", label, err)
+		}
+		artifactID := "option-" + label
+		if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: artifactID, Hash: blob.Hash, MediaType: "text/markdown", SizeBytes: blob.Size, Driver: "text"}); err != nil {
+			t.Fatalf("UpsertEvalArtifact %s returned error: %v", label, err)
+		}
+		if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{RunID: runID, ItemID: "item-001", Label: label, ArtifactID: artifactID, Role: "option"}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	return store, blobStore
 }


### PR DESCRIPTION
WHAT: Added N-way ranked SkillOpt review creation, item registration, Markdown packet export/import, and GitHub packet publish/sync support.

WHY: Task 2 of the ranked exploration goal needs human reviewers to compare more than two generated options, rank them cleanly, and submit feedback without breaking the existing A/B validation workflow.

CHANGES:
- Extended `gitmoot skillopt review create` with review mode, exploration level, and expected option count.
- Added repeated `--option label=path` support for ranked review items while preserving baseline/candidate A/B item flow.
- Added ranked Markdown packets with option tables, invalid-by-default ranking placeholders, and ranked feedback import.
- Added ranked GitHub issue/PR packet bodies with safe public references and ranked YAML/short-form comment import.
- Added ranked feedback import results and status counts without enabling ranked training export yet; ranked export remains gated for the later export-contract task.
- Added storage replacement for ranked item options so re-adding an item cannot leave stale labels behind.
- Added regression coverage for invalid templates, local path leakage, colon item IDs, scoped trait notes, replacement semantics, and partial-import prevention.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./internal/feedback`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run SkillOpt`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/feedback ./internal/skillopt`
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `git diff --cached --check`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:

```text
No discrete correctness issues were identified in the staged changes. I could not run the Go test suite because the required Go 1.26 toolchain download was blocked by the read-only module cache in this environment.
```

RISK:
- The review sandbox could not run its own Go test suite because its local Go is 1.22 and its module/toolchain cache is read-only. The test suite was run directly with `GOTOOLCHAIN=go1.26.0` and passed.
- Ranked training export is intentionally still blocked until the later export-contract task in the goal.
