### PR TITLE
feat(skillopt): import ranked feedback

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -407,6 +407,7 @@ func runSkillOptReviewStatus(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "state: %s\n", status.Run.State)
 	fmt.Fprintf(stdout, "items: %d\n", itemCount)
 	fmt.Fprintf(stdout, "feedback: %d\n", feedbackCount)
+	fmt.Fprintf(stdout, "pairwise_preferences: %d\n", len(status.PairwisePreferences))
 	fmt.Fprintf(stdout, "packet_blockers: %d\n", len(status.PacketBlockers))
 	fmt.Fprintf(stdout, "training_blockers: %d\n", len(status.TrainingBlockers))
 	fmt.Fprintf(stdout, "ready_for_packet: %t\n", status.PacketReady)
@@ -421,14 +422,15 @@ func runSkillOptReviewStatus(args []string, stdout, stderr io.Writer) int {
 }
 
 type skillOptReviewStatus struct {
-	Run              db.EvalRun
-	Items            []db.EvalReviewItem
-	Feedback         []db.FeedbackEvent
-	RankedFeedback   []db.RankedFeedbackEvent
-	PacketBlockers   []string
-	TrainingBlockers []string
-	PacketReady      bool
-	TrainingReady    bool
+	Run                 db.EvalRun
+	Items               []db.EvalReviewItem
+	Feedback            []db.FeedbackEvent
+	RankedFeedback      []db.RankedFeedbackEvent
+	PairwisePreferences []db.PairwisePreference
+	PacketBlockers      []string
+	TrainingBlockers    []string
+	PacketReady         bool
+	TrainingReady       bool
 }
 
 func loadSkillOptReviewStatus(ctx context.Context, store *db.Store, blobStore artifact.Store, runID string) (skillOptReviewStatus, error) {
@@ -451,17 +453,22 @@ func loadSkillOptReviewStatus(ctx context.Context, store *db.Store, blobStore ar
 	if err != nil {
 		return skillOptReviewStatus{}, err
 	}
+	pairwisePreferences, err := store.ListPairwisePreferences(ctx, run.ID)
+	if err != nil {
+		return skillOptReviewStatus{}, err
+	}
 	packetBlockers := reviewPacketBlockers(ctx, store, blobStore, run, items)
 	trainingBlockers := reviewTrainingBlockers(ctx, store, run, items, events, rankedEvents)
 	return skillOptReviewStatus{
-		Run:              run,
-		Items:            items,
-		Feedback:         events,
-		RankedFeedback:   rankedEvents,
-		PacketBlockers:   packetBlockers,
-		TrainingBlockers: trainingBlockers,
-		PacketReady:      len(packetBlockers) == 0,
-		TrainingReady:    len(packetBlockers) == 0 && len(trainingBlockers) == 0,
+		Run:                 run,
+		Items:               items,
+		Feedback:            events,
+		RankedFeedback:      rankedEvents,
+		PairwisePreferences: pairwisePreferences,
+		PacketBlockers:      packetBlockers,
+		TrainingBlockers:    trainingBlockers,
+		PacketReady:         len(packetBlockers) == 0,
+		TrainingReady:       len(packetBlockers) == 0 && len(trainingBlockers) == 0,
 	}, nil
 }
 

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1506,6 +1506,113 @@ func TestSkillOptReviewStatusRequiresExportableArtifacts(t *testing.T) {
 	}
 }
 
+func TestSkillOptReviewStatusShowsRankedPairwisePreferences(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	optionLabels := []string{"a", "b", "c", "d"}
+	for _, label := range optionLabels {
+		blob, err := blobStore.Put([]byte("option " + label))
+		if err != nil {
+			t.Fatalf("Put option %s returned error: %v", label, err)
+		}
+		artifactID := "option-" + label
+		if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+			ID:        artifactID,
+			Hash:      blob.Hash,
+			MediaType: "text/markdown",
+			SizeBytes: blob.Size,
+			Driver:    "text",
+		}); err != nil {
+			t.Fatalf("UpsertEvalArtifact %s returned error: %v", artifactID, err)
+		}
+	}
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:                "planner-ranked-1",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		Mode:              db.EvalRunModeExplore,
+		ExplorationLevel:  db.ExplorationLevelHigh,
+		OptionsCount:      4,
+		MetadataJSON:      `{"driver":"manual-review"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:  "planner-ranked-1",
+		ItemID: "item-001",
+		Title:  "Landing page",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	for _, label := range optionLabels {
+		if err := store.UpsertEvalReviewOption(context.Background(), db.EvalReviewOption{
+			RunID:      "planner-ranked-1",
+			ItemID:     "item-001",
+			Label:      label,
+			ArtifactID: "option-" + label,
+		}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	ranking, err := json.Marshal([]string{"c", "a", "d", "b"})
+	if err != nil {
+		t.Fatalf("marshal ranking: %v", err)
+	}
+	if err := store.UpsertRankedFeedbackEvent(context.Background(), db.RankedFeedbackEvent{
+		RunID:       "planner-ranked-1",
+		ItemID:      "item-001",
+		RankingJSON: string(ranking),
+		Winner:      "c",
+		Reasoning:   "C explains the product most clearly.",
+		Reviewer:    "jerry",
+		Source:      "github",
+		CreatedAt:   "2026-06-02T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertRankedFeedbackEvent returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "review", "status", "--home", home, "--run", "planner-ranked-1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt review status exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"items: 1",
+		"feedback: 1",
+		"pairwise_preferences: 6",
+		"packet_blockers: 0",
+		"training_blockers: 1",
+		"ready_for_packet: true",
+		"ready_for_training: false",
+		"training_blocker: ranked feedback export is not implemented yet",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("status stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
 func TestSkillOptReviewStatusRequiresExportableMetadata(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)


### PR DESCRIPTION
WHAT:
- Exposes derived ranked-feedback pairwise preference counts in `gitmoot skillopt review status`.
- Adds CLI coverage for a ranked review run that stores one ranked feedback event and reports the six derived pairwise preferences from a four-option ranking.

WHY:
- Task 3 requires imported ranked feedback to produce visible pairwise-derived preference signals while keeping the richer export contract scoped to the next task.

CHANGES:
- Loads `ListPairwisePreferences` as part of review status assembly.
- Prints `pairwise_preferences: <count>` in status output.
- Adds `TestSkillOptReviewStatusShowsRankedPairwisePreferences` for a 4-option ranked run.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./internal/feedback`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run SkillOptFeedback`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run SkillOptReviewStatus`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run SkillOpt`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/feedback ./internal/skillopt`
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `git diff --check`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:

```text
No actionable correctness issues were found in the current changes. Targeted Go tests could not be run because the toolchain download attempted to write to a read-only module cache.
No actionable correctness issues were found in the current changes. Targeted Go tests could not be run because the toolchain download attempted to write to a read-only module cache.
```

RISK:
- The review sandbox could not run Go tests due to its read-only module cache, but direct tests passed locally with `GOTOOLCHAIN=go1.26.0`.
- Ranked export remains intentionally blocked for Task 4.
