### PR TITLE
feat(skillopt): export ranked exploration feedback

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -18,16 +18,60 @@ The exported package has:
 - `contract_version: 1`
 - `template`: the logical template id, current or pinned version id, content
   hash, metadata, source, and exact template content
-- `eval_run`: run id, target repo, state, metadata, and template version
+- `eval_run`: run id, target repo, state, mode, exploration level, option
+  count, metadata, and template version
 - `items`: review/eval items with artifact references for source, baseline,
-  candidate, preview, and diff artifacts
+  candidate, preview, diff, and ranked option artifacts
 - `artifacts`: local artifact manifests with content hashes, media type, size,
   and driver
 - `feedback_events`: canonical human feedback events when available
+- `ranked_feedback_events`: canonical N-way ranked feedback events when
+  available, including the ordered ranking, optional winner, trait notes, and
+  reasoning
+- `pairwise_preferences`: derived pairwise preferences expanded from ranked
+  feedback, for example `C > A > D > B` becomes six ordered preferences
 - `evaluator_config`: the run metadata used by the external optimizer
 
 Artifact package entries reference local SHA256 blobs stored under Gitmoot home.
 The export does not copy blobs into the repository by default.
+
+A/B validation runs keep the existing `feedback_events` shape. Ranked
+exploration data is additive: optimizers that only consume A/B validation can
+ignore `items[].options`, `ranked_feedback_events`, and
+`pairwise_preferences`.
+
+## Ranked Exploration Export
+
+Ranked runs use `mode` to tell the optimizer how broad the update should be:
+
+- `explore`: learn broad directions from four to six diverse options.
+- `refine`: combine winning traits into a smaller set of stronger candidates.
+- `distill`: update the template body from accumulated feedback.
+- `validate`: compare the current template against a candidate on fresh review
+  items.
+
+The `exploration_level` field describes how much variation the optimizer should
+try in the next candidate set:
+
+- `high`: prioritize wider exploration and visibly different outputs.
+- `medium`: combine promising traits while still testing alternatives.
+- `low`: make narrow refinements and prepare for validation.
+
+Each ranked item exports `options` with the blind option label, artifact id,
+role, and optional metadata such as preview URLs. Ranked feedback exports:
+
+- `ranking`: canonical option labels ordered best to worst
+- `winner`: optional first-place option
+- `useful_traits`: JSON object keyed by canonical option label
+- `rejected_traits`: JSON object keyed by canonical option label
+- `reasoning`: reviewer notes
+
+Derived `pairwise_preferences` are provided so an optimizer can use simple
+preference comparisons without reparsing every ranking. Each pairwise row
+includes `ranked_event_id`, which matches the corresponding
+`ranked_feedback_events[].id`. Trait notes remain attached to the ranked
+feedback event so a future optimizer can combine useful traits across multiple
+winning options rather than only copying the top option.
 
 ## Candidate Package
 

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -543,9 +543,6 @@ func reviewTrainingBlockers(ctx context.Context, store *db.Store, run db.EvalRun
 			blockers = append(blockers, fmt.Sprintf("item %s has no imported feedback", itemID))
 		}
 	}
-	if skillOptRunUsesRankedOptions(run) && len(rankedEvents) > 0 {
-		blockers = append(blockers, "ranked feedback export is not implemented yet")
-	}
 	if _, err := skillopt.ExportTrainingPackage(ctx, store, run.ID); err != nil {
 		blockers = append(blockers, fmt.Sprintf("training export failed: %v", err))
 	}

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -283,6 +283,111 @@ items:
 	}
 }
 
+func TestSkillOptExportIncludesRankedFields(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		content := []byte("option " + label)
+		if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+			ID:        "option-" + label,
+			Hash:      artifact.ContentHash(content),
+			MediaType: "text/markdown",
+			SizeBytes: int64(len(content)),
+			Driver:    "text",
+		}); err != nil {
+			t.Fatalf("UpsertEvalArtifact %s returned error: %v", label, err)
+		}
+	}
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:                "ranked-export-1",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		Mode:              db.EvalRunModeExplore,
+		ExplorationLevel:  db.ExplorationLevelHigh,
+		OptionsCount:      4,
+		MetadataJSON:      `{"driver":"manual-review"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:  "ranked-export-1",
+		ItemID: "item-001",
+		Title:  "Landing page",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		if err := store.UpsertEvalReviewOption(context.Background(), db.EvalReviewOption{
+			RunID:      "ranked-export-1",
+			ItemID:     "item-001",
+			Label:      label,
+			ArtifactID: "option-" + label,
+			Role:       "option",
+		}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	ranking, err := json.Marshal([]string{"c", "a", "d", "b"})
+	if err != nil {
+		t.Fatalf("marshal ranking: %v", err)
+	}
+	if err := store.UpsertRankedFeedbackEvent(context.Background(), db.RankedFeedbackEvent{
+		RunID:       "ranked-export-1",
+		ItemID:      "item-001",
+		RankingJSON: string(ranking),
+		Winner:      "c",
+		Reviewer:    "jerry",
+		Source:      "github",
+		CreatedAt:   "2026-06-02T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertRankedFeedbackEvent returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "training.json")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "export", "--home", home, "--run", "ranked-export-1", "--output", outputPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt export exit code = %d, stderr=%s", code, stderr.String())
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read training package: %v", err)
+	}
+	var training skillopt.TrainingPackage
+	if err := json.Unmarshal(content, &training); err != nil {
+		t.Fatalf("decode training package: %v\n%s", err, string(content))
+	}
+	if training.EvalRun.Mode != db.EvalRunModeExplore || len(training.Items) != 1 || len(training.Items[0].Options) != 4 {
+		t.Fatalf("ranked training package run/items = %+v %+v", training.EvalRun, training.Items)
+	}
+	if len(training.RankedFeedbackEvents) != 1 || len(training.PairwisePreferences) != 6 {
+		t.Fatalf("ranked training feedback = %+v pairwise=%+v", training.RankedFeedbackEvents, training.PairwisePreferences)
+	}
+	if training.RankedFeedbackEvents[0].ID == "" || training.PairwisePreferences[0].RankedEventID != training.RankedFeedbackEvents[0].ID {
+		t.Fatalf("ranked feedback provenance = %+v pairwise=%+v", training.RankedFeedbackEvents, training.PairwisePreferences)
+	}
+}
+
 func TestSkillOptImportCandidateArtifacts(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)
@@ -1602,10 +1707,9 @@ func TestSkillOptReviewStatusShowsRankedPairwisePreferences(t *testing.T) {
 		"feedback: 1",
 		"pairwise_preferences: 6",
 		"packet_blockers: 0",
-		"training_blockers: 1",
+		"training_blockers: 0",
 		"ready_for_packet: true",
-		"ready_for_training: false",
-		"training_blocker: ranked feedback export is not implemented yet",
+		"ready_for_training: true",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("status stdout missing %q:\n%s", want, stdout.String())

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -55,18 +55,29 @@ type EvalRun struct {
 	TemplateVersionID string          `json:"template_version_id"`
 	TargetRepo        string          `json:"target_repo"`
 	State             string          `json:"state"`
+	Mode              string          `json:"mode,omitempty"`
+	ExplorationLevel  string          `json:"exploration_level,omitempty"`
+	OptionsCount      int             `json:"options_count,omitempty"`
 	Metadata          json.RawMessage `json:"metadata,omitempty"`
 }
 
+type EvalReviewOption struct {
+	Label      string          `json:"label"`
+	ArtifactID string          `json:"artifact_id"`
+	Role       string          `json:"role,omitempty"`
+	Metadata   json.RawMessage `json:"metadata,omitempty"`
+}
+
 type EvalItem struct {
-	ID                  string          `json:"id"`
-	Title               string          `json:"title,omitempty"`
-	SourceArtifactID    string          `json:"source_artifact_id,omitempty"`
-	BaselineArtifactID  string          `json:"baseline_artifact_id,omitempty"`
-	CandidateArtifactID string          `json:"candidate_artifact_id,omitempty"`
-	PreviewArtifactID   string          `json:"preview_artifact_id,omitempty"`
-	DiffArtifactID      string          `json:"diff_artifact_id,omitempty"`
-	Metadata            json.RawMessage `json:"metadata,omitempty"`
+	ID                  string             `json:"id"`
+	Title               string             `json:"title,omitempty"`
+	SourceArtifactID    string             `json:"source_artifact_id,omitempty"`
+	BaselineArtifactID  string             `json:"baseline_artifact_id,omitempty"`
+	CandidateArtifactID string             `json:"candidate_artifact_id,omitempty"`
+	PreviewArtifactID   string             `json:"preview_artifact_id,omitempty"`
+	DiffArtifactID      string             `json:"diff_artifact_id,omitempty"`
+	Options             []EvalReviewOption `json:"options,omitempty"`
+	Metadata            json.RawMessage    `json:"metadata,omitempty"`
 }
 
 type FeedbackEvent struct {
@@ -80,15 +91,44 @@ type FeedbackEvent struct {
 	CreatedAt string `json:"created_at"`
 }
 
+type RankedFeedbackEvent struct {
+	ID             string          `json:"id"`
+	RunID          string          `json:"run_id"`
+	ItemID         string          `json:"item_id"`
+	Ranking        []string        `json:"ranking"`
+	Winner         string          `json:"winner,omitempty"`
+	UsefulTraits   json.RawMessage `json:"useful_traits,omitempty"`
+	RejectedTraits json.RawMessage `json:"rejected_traits,omitempty"`
+	Reasoning      string          `json:"reasoning,omitempty"`
+	Reviewer       string          `json:"reviewer"`
+	Source         string          `json:"source"`
+	SourceURL      string          `json:"source_url,omitempty"`
+	CreatedAt      string          `json:"created_at"`
+}
+
+type PairwisePreference struct {
+	RunID         string `json:"run_id"`
+	ItemID        string `json:"item_id"`
+	Preferred     string `json:"preferred"`
+	Rejected      string `json:"rejected"`
+	RankedEventID string `json:"ranked_event_id"`
+	Reviewer      string `json:"reviewer"`
+	Source        string `json:"source"`
+	SourceURL     string `json:"source_url,omitempty"`
+	CreatedAt     string `json:"created_at"`
+}
+
 type TrainingPackage struct {
-	Kind            string           `json:"kind"`
-	ContractVersion int              `json:"contract_version"`
-	Template        TemplateSnapshot `json:"template"`
-	EvalRun         EvalRun          `json:"eval_run"`
-	Items           []EvalItem       `json:"items"`
-	Artifacts       []ArtifactRef    `json:"artifacts"`
-	FeedbackEvents  []FeedbackEvent  `json:"feedback_events"`
-	EvaluatorConfig json.RawMessage  `json:"evaluator_config,omitempty"`
+	Kind                 string                `json:"kind"`
+	ContractVersion      int                   `json:"contract_version"`
+	Template             TemplateSnapshot      `json:"template"`
+	EvalRun              EvalRun               `json:"eval_run"`
+	Items                []EvalItem            `json:"items"`
+	Artifacts            []ArtifactRef         `json:"artifacts"`
+	FeedbackEvents       []FeedbackEvent       `json:"feedback_events"`
+	RankedFeedbackEvents []RankedFeedbackEvent `json:"ranked_feedback_events,omitempty"`
+	PairwisePreferences  []PairwisePreference  `json:"pairwise_preferences,omitempty"`
+	EvaluatorConfig      json.RawMessage       `json:"evaluator_config,omitempty"`
 }
 
 type CandidateTemplate struct {
@@ -156,7 +196,11 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 	exportItems := make([]EvalItem, 0, len(items))
 	artifactIDs := map[string]struct{}{}
 	for _, item := range items {
-		exportItem, err := evalItem(item)
+		options, err := loadEvalReviewOptions(ctx, store, run.ID, item.ItemID)
+		if err != nil {
+			return TrainingPackage{}, fmt.Errorf("load item %s options: %w", item.ItemID, err)
+		}
+		exportItem, err := evalItem(item, options)
 		if err != nil {
 			return TrainingPackage{}, err
 		}
@@ -164,12 +208,23 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 		for _, id := range itemArtifactIDs(item) {
 			artifactIDs[id] = struct{}{}
 		}
+		for _, option := range options {
+			artifactIDs[option.ArtifactID] = struct{}{}
+		}
 	}
 	artifacts, err := loadArtifactRefs(ctx, store, artifactIDs)
 	if err != nil {
 		return TrainingPackage{}, err
 	}
 	feedbackEvents, err := loadFeedbackEvents(ctx, store, run.ID)
+	if err != nil {
+		return TrainingPackage{}, err
+	}
+	rankedFeedbackEvents, err := loadRankedFeedbackEvents(ctx, store, run.ID)
+	if err != nil {
+		return TrainingPackage{}, err
+	}
+	pairwisePreferences, err := loadPairwisePreferences(ctx, store, run.ID)
 	if err != nil {
 		return TrainingPackage{}, err
 	}
@@ -187,12 +242,17 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 			TemplateVersionID: run.TemplateVersionID,
 			TargetRepo:        run.TargetRepo,
 			State:             run.State,
+			Mode:              run.Mode,
+			ExplorationLevel:  run.ExplorationLevel,
+			OptionsCount:      run.OptionsCount,
 			Metadata:          metadata,
 		},
-		Items:           exportItems,
-		Artifacts:       artifacts,
-		FeedbackEvents:  feedbackEvents,
-		EvaluatorConfig: metadata,
+		Items:                exportItems,
+		Artifacts:            artifacts,
+		FeedbackEvents:       feedbackEvents,
+		RankedFeedbackEvents: rankedFeedbackEvents,
+		PairwisePreferences:  pairwisePreferences,
+		EvaluatorConfig:      metadata,
 	}, nil
 }
 
@@ -482,7 +542,7 @@ func templateSnapshot(template db.AgentTemplate) (TemplateSnapshot, error) {
 	}, nil
 }
 
-func evalItem(item db.EvalReviewItem) (EvalItem, error) {
+func evalItem(item db.EvalReviewItem, options []EvalReviewOption) (EvalItem, error) {
 	metadata, err := rawJSON(item.MetadataJSON)
 	if err != nil {
 		return EvalItem{}, fmt.Errorf("eval item %s metadata_json: %w", item.ItemID, err)
@@ -495,8 +555,30 @@ func evalItem(item db.EvalReviewItem) (EvalItem, error) {
 		CandidateArtifactID: item.CandidateArtifactID,
 		PreviewArtifactID:   item.PreviewArtifactID,
 		DiffArtifactID:      item.DiffArtifactID,
+		Options:             options,
 		Metadata:            metadata,
 	}, nil
+}
+
+func loadEvalReviewOptions(ctx context.Context, store *db.Store, runID string, itemID string) ([]EvalReviewOption, error) {
+	options, err := store.ListEvalReviewOptions(ctx, runID, itemID)
+	if err != nil {
+		return nil, err
+	}
+	output := make([]EvalReviewOption, 0, len(options))
+	for _, option := range options {
+		metadata, err := rawJSON(option.MetadataJSON)
+		if err != nil {
+			return nil, fmt.Errorf("review option %s metadata_json: %w", option.Label, err)
+		}
+		output = append(output, EvalReviewOption{
+			Label:      option.Label,
+			ArtifactID: option.ArtifactID,
+			Role:       option.Role,
+			Metadata:   metadata,
+		})
+	}
+	return output, nil
 }
 
 func itemArtifactIDs(item db.EvalReviewItem) []string {
@@ -556,6 +638,73 @@ func loadFeedbackEvents(ctx context.Context, store *db.Store, runID string) ([]F
 			Source:    event.Source,
 			SourceURL: event.SourceURL,
 			CreatedAt: event.CreatedAt,
+		})
+	}
+	return output, nil
+}
+
+func loadRankedFeedbackEvents(ctx context.Context, store *db.Store, runID string) ([]RankedFeedbackEvent, error) {
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	output := make([]RankedFeedbackEvent, 0, len(events))
+	for _, event := range events {
+		ranking, err := rankedFeedbackRanking(event)
+		if err != nil {
+			return nil, err
+		}
+		usefulTraits, err := rawJSON(event.UsefulTraitsJSON)
+		if err != nil {
+			return nil, fmt.Errorf("ranked feedback %s useful_traits_json: %w", event.ID, err)
+		}
+		rejectedTraits, err := rawJSON(event.RejectedTraitsJSON)
+		if err != nil {
+			return nil, fmt.Errorf("ranked feedback %s rejected_traits_json: %w", event.ID, err)
+		}
+		output = append(output, RankedFeedbackEvent{
+			ID:             event.ID,
+			RunID:          event.RunID,
+			ItemID:         event.ItemID,
+			Ranking:        ranking,
+			Winner:         event.Winner,
+			UsefulTraits:   usefulTraits,
+			RejectedTraits: rejectedTraits,
+			Reasoning:      event.Reasoning,
+			Reviewer:       event.Reviewer,
+			Source:         event.Source,
+			SourceURL:      event.SourceURL,
+			CreatedAt:      event.CreatedAt,
+		})
+	}
+	return output, nil
+}
+
+func rankedFeedbackRanking(event db.RankedFeedbackEvent) ([]string, error) {
+	var ranking []string
+	if err := json.Unmarshal([]byte(event.RankingJSON), &ranking); err != nil {
+		return nil, fmt.Errorf("ranked feedback %s ranking_json: %w", event.ID, err)
+	}
+	return ranking, nil
+}
+
+func loadPairwisePreferences(ctx context.Context, store *db.Store, runID string) ([]PairwisePreference, error) {
+	preferences, err := store.ListPairwisePreferences(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	output := make([]PairwisePreference, 0, len(preferences))
+	for _, preference := range preferences {
+		output = append(output, PairwisePreference{
+			RunID:         preference.RunID,
+			ItemID:        preference.ItemID,
+			Preferred:     preference.Preferred,
+			Rejected:      preference.Rejected,
+			RankedEventID: preference.RankedEventID,
+			Reviewer:      preference.Reviewer,
+			Source:        preference.Source,
+			SourceURL:     preference.SourceURL,
+			CreatedAt:     preference.CreatedAt,
 		})
 	}
 	return output, nil

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -97,6 +97,122 @@ func TestExportTrainingPackage(t *testing.T) {
 	}
 }
 
+func TestExportTrainingPackageIncludesRankedExplorationFeedback(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("planner", "Plan carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		content := []byte("option " + label)
+		if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{
+			ID:        "option-" + label,
+			Hash:      artifact.ContentHash(content),
+			MediaType: "text/markdown",
+			SizeBytes: int64(len(content)),
+			Driver:    "text",
+		}); err != nil {
+			t.Fatalf("UpsertEvalArtifact %s returned error: %v", label, err)
+		}
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "ranked-1",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		Mode:              db.EvalRunModeExplore,
+		ExplorationLevel:  db.ExplorationLevelHigh,
+		OptionsCount:      4,
+		MetadataJSON:      `{"driver":"manual-review"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:        "ranked-1",
+		ItemID:       "item-001",
+		Title:        "Landing page",
+		MetadataJSON: `{"prompt":"build landing page"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{
+			RunID:        "ranked-1",
+			ItemID:       "item-001",
+			Label:        label,
+			ArtifactID:   "option-" + label,
+			Role:         "option",
+			MetadataJSON: `{"preview_url":"https://example.com/` + label + `"}`,
+		}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	ranking, err := json.Marshal([]string{"c", "a", "d", "b"})
+	if err != nil {
+		t.Fatalf("marshal ranking: %v", err)
+	}
+	useful, err := json.Marshal(map[string][]string{"c": {"clearest explanation"}, "d": {"motion"}})
+	if err != nil {
+		t.Fatalf("marshal useful traits: %v", err)
+	}
+	rejected, err := json.Marshal(map[string][]string{"b": {"too generic"}})
+	if err != nil {
+		t.Fatalf("marshal rejected traits: %v", err)
+	}
+	if err := store.UpsertRankedFeedbackEvent(ctx, db.RankedFeedbackEvent{
+		RunID:              "ranked-1",
+		ItemID:             "item-001",
+		RankingJSON:        string(ranking),
+		Winner:             "c",
+		UsefulTraitsJSON:   string(useful),
+		RejectedTraitsJSON: string(rejected),
+		Reasoning:          "C is the clearest direction.",
+		Reviewer:           "jerry",
+		Source:             "github",
+		SourceURL:          "https://github.com/owner/repo/issues/1#issuecomment-1",
+		CreatedAt:          "2026-06-02T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertRankedFeedbackEvent returned error: %v", err)
+	}
+
+	pkg, err := ExportTrainingPackage(ctx, store, "ranked-1")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+
+	if pkg.EvalRun.Mode != db.EvalRunModeExplore || pkg.EvalRun.ExplorationLevel != db.ExplorationLevelHigh || pkg.EvalRun.OptionsCount != 4 {
+		t.Fatalf("eval run = %+v", pkg.EvalRun)
+	}
+	if len(pkg.Items) != 1 || len(pkg.Items[0].Options) != 4 || pkg.Items[0].Options[2].ArtifactID != "option-c" {
+		t.Fatalf("items = %+v", pkg.Items)
+	}
+	if len(pkg.Artifacts) != 4 {
+		t.Fatalf("artifacts = %+v", pkg.Artifacts)
+	}
+	if len(pkg.RankedFeedbackEvents) != 1 || pkg.RankedFeedbackEvents[0].ID == "" || pkg.RankedFeedbackEvents[0].Winner != "c" || len(pkg.RankedFeedbackEvents[0].Ranking) != 4 {
+		t.Fatalf("ranked feedback = %+v", pkg.RankedFeedbackEvents)
+	}
+	if !strings.Contains(string(pkg.RankedFeedbackEvents[0].UsefulTraits), "clearest explanation") || !strings.Contains(string(pkg.RankedFeedbackEvents[0].RejectedTraits), "too generic") {
+		t.Fatalf("ranked traits useful=%s rejected=%s", pkg.RankedFeedbackEvents[0].UsefulTraits, pkg.RankedFeedbackEvents[0].RejectedTraits)
+	}
+	if len(pkg.PairwisePreferences) != 6 || pkg.PairwisePreferences[0].Preferred != "c" || pkg.PairwisePreferences[5].Rejected != "b" || pkg.PairwisePreferences[0].RankedEventID != pkg.RankedFeedbackEvents[0].ID {
+		t.Fatalf("pairwise preferences = %+v", pkg.PairwisePreferences)
+	}
+	if _, err := json.Marshal(pkg); err != nil {
+		t.Fatalf("exported ranked package did not marshal: %v", err)
+	}
+}
+
 func TestImportCandidatePackageCreatesPendingVersion(t *testing.T) {
 	ctx := context.Background()
 	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
WHAT:
- Extends `gitmoot skillopt export` so ranked exploration runs export ranked options, run mode fields, ranked feedback events, trait notes, and derived pairwise preferences.
- Removes the temporary ranked-export training blocker now that ranked training packages are exportable.
- Documents the ranked exploration export contract.

WHY:
- Task 4 requires N-way ranked feedback to cross the Gitmoot to gitmoot-skillopt boundary without breaking existing A/B validation package consumers.

CHANGES:
- Adds optional export fields for `eval_run.mode`, `eval_run.exploration_level`, `eval_run.options_count`, `items[].options`, `ranked_feedback_events`, and `pairwise_preferences`.
- Exports ranked feedback IDs so each pairwise preference can join back to the event-level reasoning and useful/rejected trait notes.
- Includes option artifact refs in exported artifacts.
- Keeps existing A/B `feedback_events` package shape intact.
- Adds contract and CLI tests for ranked package export.
- Updates `docs/skillopt-exchange-contract.md` with ranked exploration semantics and provenance details.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./internal/skillopt`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run SkillOptExport`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run SkillOptReviewStatus`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/feedback ./internal/skillopt`
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `git diff --check`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:

```text
I did not identify any discrete correctness issues in the current changes. Targeted tests could not be run because the Go toolchain download attempted to write to a read-only cache, but the diff itself appears consistent.
I did not identify any discrete correctness issues in the current changes. Targeted tests could not be run because the Go toolchain download attempted to write to a read-only cache, but the diff itself appears consistent.
```

RISK:
- The review sandbox could not run Go tests due to its read-only toolchain/cache path, but the direct Go 1.26 test suite passed locally with `GOTOOLCHAIN=go1.26.0`.
- This is an additive contract extension at contract version 1; older A/B-only consumers should ignore the new ranked fields.
