### PR TITLE
feat(skillopt): recommend exploration phase transitions

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -405,9 +405,14 @@ func runSkillOptReviewStatus(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "template_version: %s\n", status.Run.TemplateVersionID)
 	fmt.Fprintf(stdout, "repo: %s\n", status.Run.TargetRepo)
 	fmt.Fprintf(stdout, "state: %s\n", status.Run.State)
+	fmt.Fprintf(stdout, "mode: %s\n", status.Recommendation.CurrentMode)
+	fmt.Fprintf(stdout, "exploration_level: %s\n", status.Recommendation.ExplorationLevel)
 	fmt.Fprintf(stdout, "items: %d\n", itemCount)
 	fmt.Fprintf(stdout, "feedback: %d\n", feedbackCount)
 	fmt.Fprintf(stdout, "pairwise_preferences: %d\n", len(status.PairwisePreferences))
+	fmt.Fprintf(stdout, "ranking_stability: %s\n", status.Recommendation.RankingStability)
+	fmt.Fprintf(stdout, "recommended_next_mode: %s\n", status.Recommendation.RecommendedMode)
+	fmt.Fprintf(stdout, "recommendation: %s\n", status.Recommendation.Summary())
 	fmt.Fprintf(stdout, "packet_blockers: %d\n", len(status.PacketBlockers))
 	fmt.Fprintf(stdout, "training_blockers: %d\n", len(status.TrainingBlockers))
 	fmt.Fprintf(stdout, "ready_for_packet: %t\n", status.PacketReady)
@@ -427,6 +432,7 @@ type skillOptReviewStatus struct {
 	Feedback            []db.FeedbackEvent
 	RankedFeedback      []db.RankedFeedbackEvent
 	PairwisePreferences []db.PairwisePreference
+	Recommendation      skillopt.PhaseRecommendation
 	PacketBlockers      []string
 	TrainingBlockers    []string
 	PacketReady         bool
@@ -459,12 +465,14 @@ func loadSkillOptReviewStatus(ctx context.Context, store *db.Store, blobStore ar
 	}
 	packetBlockers := reviewPacketBlockers(ctx, store, blobStore, run, items)
 	trainingBlockers := reviewTrainingBlockers(ctx, store, run, items, events, rankedEvents)
+	recommendation := skillopt.RecommendPhaseForItems(run, items, events, rankedEvents, pairwisePreferences)
 	return skillOptReviewStatus{
 		Run:                 run,
 		Items:               items,
 		Feedback:            events,
 		RankedFeedback:      rankedEvents,
 		PairwisePreferences: pairwisePreferences,
+		Recommendation:      recommendation,
 		PacketBlockers:      packetBlockers,
 		TrainingBlockers:    trainingBlockers,
 		PacketReady:         len(packetBlockers) == 0,

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1689,9 +1689,23 @@ func TestSkillOptReviewStatusShowsRankedPairwisePreferences(t *testing.T) {
 		Reasoning:   "C explains the product most clearly.",
 		Reviewer:    "jerry",
 		Source:      "github",
+		SourceURL:   "https://github.com/owner/repo/issues/1#issuecomment-1",
 		CreatedAt:   "2026-06-02T10:00:00Z",
 	}); err != nil {
 		t.Fatalf("UpsertRankedFeedbackEvent returned error: %v", err)
+	}
+	if err := store.UpsertRankedFeedbackEvent(context.Background(), db.RankedFeedbackEvent{
+		RunID:       "planner-ranked-1",
+		ItemID:      "item-001",
+		RankingJSON: string(ranking),
+		Winner:      "c",
+		Reasoning:   "C is still strongest.",
+		Reviewer:    "jerry",
+		Source:      "github",
+		SourceURL:   "https://github.com/owner/repo/issues/1#issuecomment-2",
+		CreatedAt:   "2026-06-02T11:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertRankedFeedbackEvent second returned error: %v", err)
 	}
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close returned error: %v", err)
@@ -1704,8 +1718,13 @@ func TestSkillOptReviewStatusShowsRankedPairwisePreferences(t *testing.T) {
 	}
 	for _, want := range []string{
 		"items: 1",
-		"feedback: 1",
-		"pairwise_preferences: 6",
+		"feedback: 2",
+		"pairwise_preferences: 12",
+		"mode: explore",
+		"exploration_level: high",
+		"ranking_stability: c 2/2",
+		"recommended_next_mode: refine",
+		"recommendation: recommend refine",
 		"packet_blockers: 0",
 		"training_blockers: 0",
 		"ready_for_packet: true",

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
 	"gopkg.in/yaml.v3"
 )
 
@@ -75,13 +76,18 @@ func (c GitHubCollector) Body(ctx context.Context, store *db.Store, runID string
 	if err != nil {
 		return "", err
 	}
+	recommendation, err := phaseRecommendationForRun(ctx, store, run, items)
+	if err != nil {
+		return "", err
+	}
 	var builder strings.Builder
 	builder.WriteString(githubFeedbackPacketMarker + "\n")
 	fmt.Fprintf(&builder, "# Gitmoot SkillOpt Feedback: %s\n\n", run.ID)
 	if reviewUsesRankedOptions(run) {
-		return c.rankedBody(ctx, store, run, items, assignments)
+		return c.rankedBody(ctx, store, run, items, assignments, recommendation)
 	}
 	builder.WriteString("Review each item without trying to infer which option is baseline or candidate.\n\n")
+	writePhaseRecommendation(&builder, recommendation)
 	builder.WriteString("Reply in a comment with one of these formats. Allowed choices: `a`, `b`, `tie`, `neither`, `skip`.\n\n")
 	builder.WriteString("## Copy-Paste YAML Reply\n\n")
 	builder.WriteString("```yaml\n")
@@ -110,11 +116,12 @@ func (c GitHubCollector) Body(ctx context.Context, store *db.Store, runID string
 	return builder.String(), nil
 }
 
-func (c GitHubCollector) rankedBody(ctx context.Context, store *db.Store, run db.EvalRun, items []db.EvalReviewItem, assignments map[string]githubAssignment) (string, error) {
+func (c GitHubCollector) rankedBody(ctx context.Context, store *db.Store, run db.EvalRun, items []db.EvalReviewItem, assignments map[string]githubAssignment, recommendation skillopt.PhaseRecommendation) (string, error) {
 	var builder strings.Builder
 	builder.WriteString(githubFeedbackPacketMarker + "\n")
 	fmt.Fprintf(&builder, "# Gitmoot SkillOpt Feedback: %s\n\n", run.ID)
 	builder.WriteString("Rank every option for each item from best to worst. Use the option labels exactly as shown.\n\n")
+	writePhaseRecommendation(&builder, recommendation)
 	builder.WriteString("Reply in a comment with this format:\n\n")
 	builder.WriteString("```yaml\n")
 	replyYAML, err := rankedReplyYAML(run.ID, items, assignments)

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -153,6 +153,8 @@ func TestGitHubCollectorPublishesIssueBody(t *testing.T) {
 	body := fake.createdIssue.Body
 	for _, want := range []string{
 		"Allowed choices: `a`, `b`, `tie`, `neither`, `skip`",
+		"## Phase Recommendation",
+		"recommend continue validate",
 		"run_id: run-1",
 		"choice:",
 		"item-001: <choice> - optional reason",
@@ -187,6 +189,8 @@ func TestGitHubCollectorPublishesRankedIssueBody(t *testing.T) {
 	body := fake.createdIssue.Body
 	for _, want := range []string{
 		"Rank every option",
+		"## Phase Recommendation",
+		"recommend continue explore",
 		"```yaml",
 		"run_id: ranked-1",
 		"item_id: item-001",

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
 	"gopkg.in/yaml.v3"
 )
 
@@ -111,7 +112,11 @@ func (c MarkdownCollector) WritePacket(ctx context.Context, store *db.Store, run
 	if err := writeJSONFile(filepath.Join(dir, assignmentsName), assignments, 0o600); err != nil {
 		return err
 	}
-	if err := writeTextFile(filepath.Join(dir, "index.md"), indexMarkdown(run, items, assignments), 0o644); err != nil {
+	recommendation, err := phaseRecommendationForRun(ctx, store, run, items)
+	if err != nil {
+		return err
+	}
+	if err := writeTextFile(filepath.Join(dir, "index.md"), indexMarkdown(run, items, assignments, recommendation), 0o644); err != nil {
 		return err
 	}
 	return writeFeedbackYAML(filepath.Join(dir, "feedback.yml"), run.ID, assignments)
@@ -598,7 +603,7 @@ func canonicalChoiceForArtifact(artifactID string, assignment blindAssignment) (
 	}
 }
 
-func indexMarkdown(run db.EvalRun, items []db.EvalReviewItem, assignments assignmentFile) string {
+func indexMarkdown(run db.EvalRun, items []db.EvalReviewItem, assignments assignmentFile, recommendation skillopt.PhaseRecommendation) string {
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "# Gitmoot Feedback Packet: %s\n\n", run.ID)
 	if reviewUsesRankedOptions(run) {
@@ -624,6 +629,7 @@ func indexMarkdown(run db.EvalRun, items []db.EvalReviewItem, assignments assign
 	builder.WriteString("   gitmoot skillopt feedback markdown import --packet <packet-dir> --reviewer <name>\n")
 	builder.WriteString("   ```\n\n")
 	builder.WriteString("Keep `.assignments.json` untouched. It is hidden Gitmoot metadata used to preserve and validate option mappings on import.\n\n")
+	writePhaseRecommendation(&builder, recommendation)
 	builder.WriteString("## Items\n\n")
 	for _, item := range items {
 		fmt.Fprintf(&builder, "- [%s](items/%s)\n", itemTitle(item), itemFilename(item.ItemID))
@@ -643,6 +649,35 @@ func indexMarkdown(run db.EvalRun, items []db.EvalReviewItem, assignments assign
 	builder.WriteString("\n## Submit Feedback\n\n")
 	builder.WriteString("After all items are filled in `feedback.yml`, run the import command above.\n")
 	return builder.String()
+}
+
+func phaseRecommendationForRun(ctx context.Context, store *db.Store, run db.EvalRun, items []db.EvalReviewItem) (skillopt.PhaseRecommendation, error) {
+	feedbackEvents, err := store.ListFeedbackEvents(ctx, run.ID)
+	if err != nil {
+		return skillopt.PhaseRecommendation{}, err
+	}
+	rankedEvents, err := store.ListRankedFeedbackEvents(ctx, run.ID)
+	if err != nil {
+		return skillopt.PhaseRecommendation{}, err
+	}
+	pairwisePreferences, err := store.ListPairwisePreferences(ctx, run.ID)
+	if err != nil {
+		return skillopt.PhaseRecommendation{}, err
+	}
+	return skillopt.RecommendPhaseForItems(run, items, feedbackEvents, rankedEvents, pairwisePreferences), nil
+}
+
+func writePhaseRecommendation(builder *strings.Builder, recommendation skillopt.PhaseRecommendation) {
+	builder.WriteString("## Phase Recommendation\n\n")
+	fmt.Fprintf(builder, "- Current mode: `%s`\n", recommendation.CurrentMode)
+	if recommendation.FeedbackCount > 0 {
+		builder.WriteString("- Outcome recommendation is hidden in blind review packets after feedback exists to avoid biasing reviewers.\n")
+		builder.WriteString("- Run `gitmoot skillopt review status --run <run-id>` after importing feedback to inspect the full recommendation.\n\n")
+		return
+	}
+	fmt.Fprintf(builder, "- Ranking stability: `%s`\n", recommendation.RankingStability)
+	fmt.Fprintf(builder, "- Recommended next mode: `%s`\n", recommendation.RecommendedMode)
+	fmt.Fprintf(builder, "- %s\n\n", recommendation.Summary())
 }
 
 func displayOptionLabels(options []blindOptionAssignment) []string {

--- a/internal/feedback/markdown_test.go
+++ b/internal/feedback/markdown_test.go
@@ -2,6 +2,7 @@ package feedback
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,6 +72,8 @@ func TestMarkdownCollectorWriteAndImportPacket(t *testing.T) {
 	}
 	if !strings.Contains(string(index), "Open each linked item") ||
 		!strings.Contains(string(index), "set `reviewer`") ||
+		!strings.Contains(string(index), "## Phase Recommendation") ||
+		!strings.Contains(string(index), "recommend continue validate") ||
 		!strings.Contains(string(index), "gitmoot skillopt feedback markdown import --packet <packet-dir> --reviewer <name>") ||
 		!strings.Contains(string(index), ".assignments.json") {
 		t.Fatalf("index content misses instructions:\n%s", string(index))
@@ -147,6 +150,13 @@ func TestMarkdownCollectorImportsRankedPacket(t *testing.T) {
 	if err := collector.WritePacket(ctx, store, "ranked-1", packetDir); err != nil {
 		t.Fatalf("WritePacket returned error: %v", err)
 	}
+	index, err := os.ReadFile(filepath.Join(packetDir, "index.md"))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	if !strings.Contains(string(index), "## Phase Recommendation") || !strings.Contains(string(index), "recommend continue explore") {
+		t.Fatalf("ranked index missing phase recommendation:\n%s", string(index))
+	}
 	if _, err := collector.ImportPacket(ctx, store, packetDir, "jerry"); err == nil || !strings.Contains(err.Error(), "ranking") {
 		t.Fatalf("unchanged ranked packet import error = %v", err)
 	}
@@ -192,6 +202,37 @@ items:
 	}
 	if len(pairs) != 6 || pairs[0].Preferred != "c" || pairs[0].Rejected != "a" || pairs[5].Preferred != "d" || pairs[5].Rejected != "b" {
 		t.Fatalf("pairwise preferences = %+v", pairs)
+	}
+	ranking, err := json.Marshal([]string{"c", "a", "d", "b"})
+	if err != nil {
+		t.Fatalf("marshal ranking: %v", err)
+	}
+	if err := store.UpsertRankedFeedbackEvent(ctx, db.RankedFeedbackEvent{
+		RunID:       "ranked-1",
+		ItemID:      "item-001",
+		RankingJSON: string(ranking),
+		Winner:      "c",
+		Reviewer:    "second-reviewer",
+		Source:      SourceMarkdown,
+		SourceURL:   packetDir + "#second",
+		CreatedAt:   "2026-06-02T11:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertRankedFeedbackEvent second returned error: %v", err)
+	}
+	secondPacketDir := filepath.Join(t.TempDir(), "packet-with-feedback")
+	if err := collector.WritePacket(ctx, store, "ranked-1", secondPacketDir); err != nil {
+		t.Fatalf("WritePacket with feedback returned error: %v", err)
+	}
+	secondIndex, err := os.ReadFile(filepath.Join(secondPacketDir, "index.md"))
+	if err != nil {
+		t.Fatalf("read second index: %v", err)
+	}
+	if !strings.Contains(string(secondIndex), "Outcome recommendation is hidden") ||
+		strings.Contains(string(secondIndex), "recommend refine") ||
+		strings.Contains(string(secondIndex), "top option") ||
+		strings.Contains(string(secondIndex), "Ranking stability") ||
+		strings.Contains(string(secondIndex), "Recommended next mode") {
+		t.Fatalf("ranked index leaks outcome recommendation:\n%s", string(secondIndex))
 	}
 }
 

--- a/internal/skillopt/phase.go
+++ b/internal/skillopt/phase.go
@@ -1,0 +1,271 @@
+package skillopt
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+const PromoteRecommendation = "promote"
+
+type PhaseRecommendation struct {
+	CurrentMode             string
+	RecommendedMode         string
+	ExplorationLevel        string
+	ReviewItemCount         int
+	FeedbackItemCount       int
+	MissingFeedbackCount    int
+	FeedbackCount           int
+	RankedFeedbackCount     int
+	PairwisePreferenceCount int
+	RankingStability        string
+	Reason                  string
+}
+
+func (r PhaseRecommendation) Summary() string {
+	mode := strings.TrimSpace(r.RecommendedMode)
+	if mode == "" {
+		mode = normalizeRecommendationMode(r.CurrentMode)
+	}
+	if mode == normalizeRecommendationMode(r.CurrentMode) {
+		return fmt.Sprintf("recommend continue %s - %s", mode, strings.TrimSpace(r.Reason))
+	}
+	return fmt.Sprintf("recommend %s - %s", mode, strings.TrimSpace(r.Reason))
+}
+
+func RecommendPhase(run db.EvalRun, feedback []db.FeedbackEvent, ranked []db.RankedFeedbackEvent, pairwise []db.PairwisePreference) PhaseRecommendation {
+	return RecommendPhaseForItems(run, nil, feedback, ranked, pairwise)
+}
+
+func RecommendPhaseForItems(run db.EvalRun, items []db.EvalReviewItem, feedback []db.FeedbackEvent, ranked []db.RankedFeedbackEvent, pairwise []db.PairwisePreference) PhaseRecommendation {
+	currentMode := normalizeRecommendationMode(run.Mode)
+	explorationLevel := strings.TrimSpace(run.ExplorationLevel)
+	stability := rankingStability(ranked)
+	itemCount, feedbackItemCount, missingFeedbackCount := feedbackCoverage(items, feedback, ranked)
+	recommendation := PhaseRecommendation{
+		CurrentMode:             currentMode,
+		RecommendedMode:         currentMode,
+		ExplorationLevel:        explorationLevel,
+		ReviewItemCount:         itemCount,
+		FeedbackItemCount:       feedbackItemCount,
+		MissingFeedbackCount:    missingFeedbackCount,
+		FeedbackCount:           len(feedback) + len(ranked),
+		RankedFeedbackCount:     len(ranked),
+		PairwisePreferenceCount: len(pairwise),
+		RankingStability:        stability,
+	}
+	if missingFeedbackCount > 0 {
+		recommendation.Reason = fmt.Sprintf("%d of %d review items have imported feedback; collect feedback for every item before changing phases.", feedbackItemCount, itemCount)
+		return recommendation
+	}
+
+	switch currentMode {
+	case db.EvalRunModeExplore:
+		recommendation.RecommendedMode, recommendation.Reason = recommendExplore(ranked, stability)
+	case db.EvalRunModeRefine:
+		recommendation.RecommendedMode, recommendation.Reason = recommendRefine(ranked, pairwise, stability)
+	case db.EvalRunModeDistill:
+		recommendation.RecommendedMode, recommendation.Reason = recommendDistill(ranked, pairwise)
+	case db.EvalRunModeValidate:
+		recommendation.RecommendedMode, recommendation.Reason = recommendValidate(feedback, ranked)
+	default:
+		recommendation.RecommendedMode = currentMode
+		recommendation.Reason = "current mode is not recognized, so keep collecting feedback before changing phases."
+	}
+	return recommendation
+}
+
+func feedbackCoverage(items []db.EvalReviewItem, feedback []db.FeedbackEvent, ranked []db.RankedFeedbackEvent) (int, int, int) {
+	if len(items) == 0 {
+		return 0, 0, 0
+	}
+	itemIDs := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		itemID := reviewItemID(item)
+		if itemID != "" {
+			itemIDs[itemID] = struct{}{}
+		}
+	}
+	covered := map[string]struct{}{}
+	for _, event := range feedback {
+		itemID := strings.TrimSpace(event.ItemID)
+		if _, ok := itemIDs[itemID]; ok {
+			covered[itemID] = struct{}{}
+		}
+	}
+	for _, event := range ranked {
+		itemID := strings.TrimSpace(event.ItemID)
+		if _, ok := itemIDs[itemID]; ok {
+			covered[itemID] = struct{}{}
+		}
+	}
+	return len(itemIDs), len(covered), len(itemIDs) - len(covered)
+}
+
+func reviewItemID(item db.EvalReviewItem) string {
+	itemID := strings.TrimSpace(item.ItemID)
+	if itemID != "" {
+		return itemID
+	}
+	return strings.TrimSpace(item.ID)
+}
+
+func recommendExplore(ranked []db.RankedFeedbackEvent, stability string) (string, string) {
+	winner, count, total := topWinner(ranked)
+	if winner != "tie" && total >= 2 && count >= 2 {
+		return db.EvalRunModeRefine, fmt.Sprintf("top option %s leads %d of %d ranked feedback events, so broad exploration has a stable direction.", winner, count, total)
+	}
+	if total == 0 {
+		return db.EvalRunModeExplore, "no ranked feedback has been imported yet, so keep exploring broad alternatives."
+	}
+	return db.EvalRunModeExplore, fmt.Sprintf("ranking stability is %s; collect more ranked feedback before narrowing.", stability)
+}
+
+func recommendRefine(ranked []db.RankedFeedbackEvent, pairwise []db.PairwisePreference, stability string) (string, string) {
+	winner, count, total := topWinner(ranked)
+	stableWinner := winner != "tie" && total >= 2 && count >= 2
+	traitCount := rankedTraitCount(ranked)
+	if stableWinner && traitCount >= 2 {
+		return db.EvalRunModeDistill, fmt.Sprintf("ranked feedback includes %d trait notes, so refine learnings are ready to distill into template guidance.", traitCount)
+	}
+	if stableWinner && len(pairwise) >= 12 {
+		return db.EvalRunModeDistill, fmt.Sprintf("ranked feedback produced %d pairwise preferences with %s stability, so the direction is specific enough to distill.", len(pairwise), stability)
+	}
+	if len(ranked) == 0 {
+		return db.EvalRunModeRefine, "no ranked feedback has been imported yet, so keep refining with focused alternatives."
+	}
+	return db.EvalRunModeRefine, "feedback is still broad; collect more specific useful and rejected traits before distilling."
+}
+
+func recommendDistill(ranked []db.RankedFeedbackEvent, pairwise []db.PairwisePreference) (string, string) {
+	if len(ranked) > 0 && len(pairwise) > 0 {
+		return db.EvalRunModeValidate, fmt.Sprintf("distillation has %d ranked feedback events and %d pairwise preferences, so prepare a fresh validation run.", len(ranked), len(pairwise))
+	}
+	return db.EvalRunModeDistill, "distill candidate guidance first, then validate against fresh items."
+}
+
+func recommendValidate(feedback []db.FeedbackEvent, ranked []db.RankedFeedbackEvent) (string, string) {
+	if len(ranked) > 0 {
+		winner, count, total := topWinner(ranked)
+		if winner != "tie" && total >= 2 && count >= 2 {
+			return PromoteRecommendation, fmt.Sprintf("ranked validation option %s wins %d of %d fresh feedback events.", winner, count, total)
+		}
+		return db.EvalRunModeValidate, fmt.Sprintf("ranked validation stability is %s; keep validating before promotion.", rankingStability(ranked))
+	}
+	baselineWins := 0
+	candidateWins := 0
+	for _, event := range feedback {
+		switch strings.TrimSpace(strings.ToLower(event.Choice)) {
+		case "a":
+			baselineWins++
+		case "b":
+			candidateWins++
+		}
+	}
+	if candidateWins >= 2 && candidateWins > baselineWins {
+		return PromoteRecommendation, fmt.Sprintf("candidate wins %d validation feedback events against %d baseline wins on fresh items.", candidateWins, baselineWins)
+	}
+	if len(feedback) == 0 {
+		return db.EvalRunModeValidate, "no validation feedback has been imported yet, so keep validating before promotion."
+	}
+	return db.EvalRunModeValidate, fmt.Sprintf("candidate wins %d validation feedback events against %d baseline wins; keep validating before promotion.", candidateWins, baselineWins)
+}
+
+func normalizeRecommendationMode(mode string) string {
+	switch strings.TrimSpace(mode) {
+	case db.EvalRunModeExplore:
+		return db.EvalRunModeExplore
+	case db.EvalRunModeRefine:
+		return db.EvalRunModeRefine
+	case db.EvalRunModeDistill:
+		return db.EvalRunModeDistill
+	case db.EvalRunModeValidate:
+		return db.EvalRunModeValidate
+	}
+	return db.EvalRunModeValidate
+}
+
+func rankingStability(ranked []db.RankedFeedbackEvent) string {
+	winner, count, total := topWinner(ranked)
+	if total == 0 {
+		return "none"
+	}
+	return fmt.Sprintf("%s %d/%d", winner, count, total)
+}
+
+func topWinner(ranked []db.RankedFeedbackEvent) (string, int, int) {
+	counts := map[string]int{}
+	total := 0
+	for _, event := range ranked {
+		winner := normalizedWinner(event)
+		if winner == "" {
+			continue
+		}
+		counts[winner]++
+		total++
+	}
+	if total == 0 {
+		return "none", 0, 0
+	}
+	labels := make([]string, 0, len(counts))
+	for label := range counts {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	best := labels[0]
+	tied := false
+	for _, label := range labels[1:] {
+		if counts[label] > counts[best] {
+			best = label
+			tied = false
+			continue
+		}
+		if counts[label] == counts[best] {
+			tied = true
+		}
+	}
+	if tied {
+		return "tie", counts[best], total
+	}
+	return best, counts[best], total
+}
+
+func normalizedWinner(event db.RankedFeedbackEvent) string {
+	winner := strings.TrimSpace(strings.ToLower(event.Winner))
+	if winner != "" {
+		return winner
+	}
+	var ranking []string
+	if err := json.Unmarshal([]byte(event.RankingJSON), &ranking); err != nil || len(ranking) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(strings.ToLower(ranking[0]))
+}
+
+func rankedTraitCount(ranked []db.RankedFeedbackEvent) int {
+	total := 0
+	for _, event := range ranked {
+		total += traitJSONCount(event.UsefulTraitsJSON)
+		total += traitJSONCount(event.RejectedTraitsJSON)
+	}
+	return total
+}
+
+func traitJSONCount(value string) int {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	var traits map[string][]string
+	if err := json.Unmarshal([]byte(value), &traits); err != nil {
+		return 0
+	}
+	total := 0
+	for _, values := range traits {
+		total += len(values)
+	}
+	return total
+}

--- a/internal/skillopt/phase_test.go
+++ b/internal/skillopt/phase_test.go
@@ -1,0 +1,187 @@
+package skillopt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestRecommendPhaseExploreToRefine(t *testing.T) {
+	ranked := []db.RankedFeedbackEvent{
+		rankedEvent(t, "c", "c", "a", "d", "b"),
+		rankedEvent(t, "c", "c", "d", "a", "b"),
+	}
+	recommendation := RecommendPhase(
+		db.EvalRun{ID: "run-1", Mode: db.EvalRunModeExplore, ExplorationLevel: db.ExplorationLevelHigh},
+		nil,
+		ranked,
+		pairwisePreferences(12),
+	)
+
+	if recommendation.CurrentMode != db.EvalRunModeExplore || recommendation.RecommendedMode != db.EvalRunModeRefine {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+	if recommendation.RankingStability != "c 2/2" {
+		t.Fatalf("ranking stability = %q", recommendation.RankingStability)
+	}
+}
+
+func TestRecommendPhaseExploreTieStaysExplore(t *testing.T) {
+	ranked := []db.RankedFeedbackEvent{
+		rankedEvent(t, "c", "c", "a", "d", "b"),
+		rankedEvent(t, "d", "d", "c", "a", "b"),
+	}
+	recommendation := RecommendPhase(
+		db.EvalRun{ID: "run-1", Mode: db.EvalRunModeExplore, ExplorationLevel: db.ExplorationLevelHigh},
+		nil,
+		ranked,
+		pairwisePreferences(12),
+	)
+
+	if recommendation.RecommendedMode != db.EvalRunModeExplore || recommendation.RankingStability != "tie 1/2" {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+}
+
+func TestRecommendPhaseForItemsMissingFeedbackStaysCurrent(t *testing.T) {
+	items := []db.EvalReviewItem{
+		{ItemID: "item-001"},
+		{ItemID: "item-002"},
+	}
+	ranked := []db.RankedFeedbackEvent{
+		rankedEventForItem(t, "item-001", "c", "c", "a", "d", "b"),
+		rankedEventForItem(t, "item-001", "c", "c", "d", "a", "b"),
+	}
+	recommendation := RecommendPhaseForItems(
+		db.EvalRun{ID: "run-1", Mode: db.EvalRunModeExplore, ExplorationLevel: db.ExplorationLevelHigh},
+		items,
+		nil,
+		ranked,
+		pairwisePreferences(12),
+	)
+
+	if recommendation.RecommendedMode != db.EvalRunModeExplore || recommendation.MissingFeedbackCount != 1 {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+}
+
+func TestRecommendPhaseRefineToDistill(t *testing.T) {
+	useful, err := json.Marshal(map[string][]string{"c": {"clear product explanation"}, "a": {"best visual tone"}})
+	if err != nil {
+		t.Fatalf("marshal useful traits: %v", err)
+	}
+	ranked := []db.RankedFeedbackEvent{
+		rankedEvent(t, "c", "c", "a", "d", "b"),
+		rankedEvent(t, "c", "c", "d", "a", "b"),
+	}
+	ranked[0].UsefulTraitsJSON = string(useful)
+
+	recommendation := RecommendPhase(db.EvalRun{ID: "run-1", Mode: db.EvalRunModeRefine}, nil, ranked, pairwisePreferences(12))
+
+	if recommendation.RecommendedMode != db.EvalRunModeDistill {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+}
+
+func TestRecommendPhaseRefineTieStaysRefine(t *testing.T) {
+	useful, err := json.Marshal(map[string][]string{"c": {"clear product explanation"}, "d": {"best motion"}})
+	if err != nil {
+		t.Fatalf("marshal useful traits: %v", err)
+	}
+	ranked := []db.RankedFeedbackEvent{
+		rankedEvent(t, "c", "c", "a", "d", "b"),
+		rankedEvent(t, "d", "d", "c", "a", "b"),
+	}
+	ranked[0].UsefulTraitsJSON = string(useful)
+
+	recommendation := RecommendPhase(db.EvalRun{ID: "run-1", Mode: db.EvalRunModeRefine}, nil, ranked, pairwisePreferences(12))
+
+	if recommendation.RecommendedMode != db.EvalRunModeRefine || recommendation.RankingStability != "tie 1/2" {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+}
+
+func TestRecommendPhaseDistillToValidate(t *testing.T) {
+	recommendation := RecommendPhase(
+		db.EvalRun{ID: "run-1", Mode: db.EvalRunModeDistill},
+		nil,
+		[]db.RankedFeedbackEvent{rankedEvent(t, "b", "b", "a")},
+		pairwisePreferences(1),
+	)
+
+	if recommendation.RecommendedMode != db.EvalRunModeValidate {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+}
+
+func TestRecommendPhaseValidateToPromote(t *testing.T) {
+	feedback := []db.FeedbackEvent{
+		{Choice: "b"},
+		{Choice: "b"},
+		{Choice: "a"},
+	}
+	recommendation := RecommendPhase(db.EvalRun{ID: "run-1", Mode: db.EvalRunModeValidate}, feedback, nil, nil)
+
+	if recommendation.RecommendedMode != PromoteRecommendation {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+}
+
+func TestRecommendPhaseRankedValidateToPromote(t *testing.T) {
+	ranked := []db.RankedFeedbackEvent{
+		rankedEvent(t, "c", "c", "a", "d", "b"),
+		rankedEvent(t, "c", "c", "d", "a", "b"),
+	}
+	recommendation := RecommendPhase(db.EvalRun{ID: "run-1", Mode: db.EvalRunModeValidate, OptionsCount: 4}, nil, ranked, pairwisePreferences(12))
+
+	if recommendation.RecommendedMode != PromoteRecommendation {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+}
+
+func TestRecommendPhaseRankedValidateTieStaysValidate(t *testing.T) {
+	ranked := []db.RankedFeedbackEvent{
+		rankedEvent(t, "c", "c", "a", "d", "b"),
+		rankedEvent(t, "d", "d", "c", "a", "b"),
+	}
+	recommendation := RecommendPhase(db.EvalRun{ID: "run-1", Mode: db.EvalRunModeValidate, OptionsCount: 4}, nil, ranked, pairwisePreferences(12))
+
+	if recommendation.RecommendedMode != db.EvalRunModeValidate || recommendation.RankingStability != "tie 1/2" {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+}
+
+func TestRecommendPhaseNoFeedbackContinuesCurrentMode(t *testing.T) {
+	recommendation := RecommendPhase(db.EvalRun{ID: "run-1", Mode: db.EvalRunModeExplore}, nil, nil, nil)
+
+	if recommendation.RecommendedMode != db.EvalRunModeExplore || recommendation.RankingStability != "none" {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+}
+
+func rankedEvent(t *testing.T, winner string, ranking ...string) db.RankedFeedbackEvent {
+	t.Helper()
+	return rankedEventForItem(t, "", winner, ranking...)
+}
+
+func rankedEventForItem(t *testing.T, itemID string, winner string, ranking ...string) db.RankedFeedbackEvent {
+	t.Helper()
+	encoded, err := json.Marshal(ranking)
+	if err != nil {
+		t.Fatalf("marshal ranking: %v", err)
+	}
+	return db.RankedFeedbackEvent{
+		ItemID:      itemID,
+		Winner:      winner,
+		RankingJSON: string(encoded),
+	}
+}
+
+func pairwisePreferences(count int) []db.PairwisePreference {
+	preferences := make([]db.PairwisePreference, count)
+	for i := range preferences {
+		preferences[i] = db.PairwisePreference{Preferred: "c", Rejected: "a"}
+	}
+	return preferences
+}


### PR DESCRIPTION
WHAT:
- Add deterministic SkillOpt phase recommendations for explore, refine, distill, validate, and promote guidance.
- Surface recommendations in `gitmoot skillopt review status` and safe phase guidance in Markdown/GitHub feedback packets.

WHY:
- Ranked exploration needs clear guidance for when to keep exploring, narrow to refinement, distill template changes, validate, or promote.

CHANGES:
- Added `internal/skillopt/phase.go` with phase recommendation logic, ranking stability, item-coverage gating, tie handling, and validation promotion guidance.
- Updated review status output with mode, exploration level, ranking stability, recommended next mode, and recommendation summary.
- Added phase guidance to Markdown and GitHub packets while hiding outcome-bearing recommendations when prior feedback exists to avoid biasing blind reviewers.
- Added tests for stable/tied rankings, ranked validation promotion, missing item coverage, packet guidance, and packet outcome hiding.

RESULTS:
- `GOTOOLCHAIN=go1.26.0 go test ./internal/skillopt ./internal/feedback` passed.
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run SkillOptReviewStatus` passed.
- `GOTOOLCHAIN=go1.26.0 go test ./...` passed.
- `git diff --check` passed.
- Review findings during the loop were fixed:
  - ranked validation feedback now participates in promotion recommendations.
  - tied ranked winners no longer advance explore or validation.
  - tied/conflicting refine feedback no longer advances to distill only because pairwise count is high.
  - advancement is gated on feedback coverage across all review items.
  - blind packets hide outcome-bearing recommendation fields after feedback exists.

RISK:
- The review subprocess could not run Go tests with `GOTOOLCHAIN=local` because the sandboxed local Go is 1.22.2 and the repo requires Go 1.26. The explicit Go 1.26 test commands above passed in this environment.

Final `codex exec review --uncommitted` output:

```text
No actionable correctness issues were found in the staged, unstaged, or untracked changes. Tests could not be run in this sandbox because the Go 1.26 toolchain download needs write access outside the workspace.
No actionable correctness issues were found in the staged, unstaged, or untracked changes. Tests could not be run in this sandbox because the Go 1.26 toolchain download needs write access outside the workspace.
```