### PR TITLE
Document ranked SkillOpt exploration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ gitmoot lock release owner/repo <branch> --owner <agent>
 ```sh
 gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>
 gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]
+gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id> --mode explore --options 4
+gitmoot skillopt review item add --run <run-id> --item <item-id> --option a=option-a.md --option b=option-b.md [...]
 gitmoot skillopt review status --run <run-id>
 gitmoot skillopt export --run <run-id> --output training.json
 gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
@@ -291,6 +293,11 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 Create a review run, add saved baseline/candidate outputs as review items,
 export a Markdown or GitHub feedback packet, import the completed feedback, then
 export `training.json` for a future external `gitmoot-skillopt` optimizer.
+Use ranked exploration when the template needs broad search: start with
+`--mode explore --options 4` to `6`, rank every option, record useful/rejected
+traits, then narrow into `refine`, `distill`, and finally A/B `validate`.
+`skillopt review status` reports ranking stability and the recommended next
+mode, but the recommendation is advisory only.
 Dry-run optimization validates the contract without model calls:
 
 ```sh
@@ -327,6 +334,10 @@ run-scoped short lines such as `run_id: run-1` followed by
 canonical feedback events and ignores unrelated comments. Repo selection uses
 `--repo`, then the eval run target repo, then the template source repo, then
 optional `[feedback].repo = "owner/reviews"` in Gitmoot config.
+
+Detailed ranked exploration examples, including a landing-page visual task and
+a non-visual writing task, live in
+[docs/skillopt-exchange-contract.md](docs/skillopt-exchange-contract.md).
 
 Detailed command coverage lives in
 [skills/gitmoot/references/CLI.md](skills/gitmoot/references/CLI.md).

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -73,6 +73,43 @@ includes `ranked_event_id`, which matches the corresponding
 feedback event so a future optimizer can combine useful traits across multiple
 winning options rather than only copying the top option.
 
+## Ranked Exploration Workflow
+
+Use ranked exploration when the template is still ambiguous and humans need to
+compare meaningfully different directions. Use A/B validation when the question
+is whether a specific candidate should replace the current template.
+
+1. `explore`: generate four to six diverse options for each review item. Ask
+   reviewers to rank every option and name useful and rejected traits. Keep
+   `exploration_level` set to `high` while the best direction is still unclear.
+2. `refine`: use two to three candidates that combine the strongest traits
+   discovered during exploration. Keep asking for rankings and trait notes, but
+   focus the alternatives around the same product/workflow goal.
+3. `distill`: convert accumulated ranked feedback into a candidate template
+   update. This phase should not require broad new directions.
+4. `validate`: compare the current template against the candidate on fresh
+   review items. Use the A/B path by default for final promotion decisions.
+
+`gitmoot skillopt review status --run <run-id>` reports the current mode,
+feedback count, pairwise preference count, ranking stability, and recommended
+next mode. Recommendations are advisory only. Gitmoot does not change the run
+mode, import a candidate, or promote a template automatically.
+
+Phase recommendations intentionally wait until every review item has imported
+feedback. This prevents one heavily reviewed item from advancing a whole run
+while other items are untouched. Blind Markdown and GitHub packets hide
+outcome-bearing recommendation details after feedback exists so later reviewers
+do not see the current winner before responding.
+
+Do not run heavy SkillOpt optimization after every tiny feedback update unless
+the user explicitly wants that. A practical cadence is:
+
+- collect enough rankings to make the status recommendation stable;
+- export the training package;
+- run the external optimizer;
+- import the candidate;
+- review or validate the candidate with fresh items before promotion.
+
 ## Candidate Package
 
 Import a candidate produced by an external optimizer:
@@ -253,6 +290,77 @@ events use `choice: a` for the baseline artifact and `choice: b` for the
 candidate artifact. Each event includes `run_id`, `item_id`, `choice`, optional
 `reasoning`, `reviewer`, `source`, optional `source_url`, and `created_at`.
 
+Generate a local ranked exploration packet by creating a ranked run and adding
+repeated option artifacts:
+
+```sh
+gitmoot skillopt review create \
+  --template landing-page-designer \
+  --repo owner/gitmoot-web \
+  --run landing-page-explore-001 \
+  --mode explore \
+  --exploration-level high \
+  --options 4
+
+gitmoot skillopt review item add \
+  --run landing-page-explore-001 \
+  --item hero-001 \
+  --title "Gitmoot landing page hero" \
+  --option a=previews/hero-a.md \
+  --option b=previews/hero-b.md \
+  --option c=previews/hero-c.md \
+  --option d=previews/hero-d.md \
+  --metadata-json '{"task":"landing-page","preview_url":"https://owner.github.io/gitmoot-previews/hero-001/"}'
+
+gitmoot skillopt feedback markdown export \
+  --run landing-page-explore-001 \
+  --output .gitmoot/evals/landing-page-explore-001
+```
+
+Humans fill ranked feedback with ordered options and trait notes:
+
+```yaml
+run_id: landing-page-explore-001
+reviewer: alice
+items:
+  - item_id: hero-001
+    ranking:
+      - C > A > D > B
+    useful_traits:
+      C:
+        - explains what Gitmoot does before the fold
+      A:
+        - strongest mascot placement
+    rejected_traits:
+      B:
+        - too generic for a developer tool
+    reasoning: C is clearest overall, but A has the better visual identity.
+```
+
+A non-visual text task uses the same structure:
+
+```sh
+gitmoot skillopt review create \
+  --template x-post-writer \
+  --repo owner/content-workflows \
+  --run x-post-style-explore-001 \
+  --mode explore \
+  --options 5
+
+gitmoot skillopt review item add \
+  --run x-post-style-explore-001 \
+  --item thread-hook-001 \
+  --title "Launch-thread opening post" \
+  --option a=posts/hook-a.txt \
+  --option b=posts/hook-b.txt \
+  --option c=posts/hook-c.txt \
+  --option d=posts/hook-d.txt \
+  --option e=posts/hook-e.txt
+```
+
+Rank every option from best to worst and use trait notes for style signals such
+as pacing, specificity, voice, sentence length, and phrases to avoid.
+
 ## GitHub Feedback Collector
 
 Publish a collaborative blind A/B review packet to a new GitHub issue:
@@ -295,6 +403,32 @@ gitmoot skillopt feedback github sync \
 
 For PR comment mode, use `--pr 123` instead of `--issue 42`. Sync ignores
 unrelated comments and de-duplicates repeated imports by comment URL.
+
+Ranked GitHub review uses the same run and item setup as the Markdown ranked
+workflow, then publishes to a review issue or PR:
+
+```sh
+gitmoot skillopt feedback github publish \
+  --run landing-page-explore-001 \
+  --repo owner/gitmoot-previews
+
+gitmoot skillopt feedback github sync \
+  --run landing-page-explore-001 \
+  --repo owner/gitmoot-previews \
+  --issue 42
+```
+
+Reviewers can reply with the YAML ranked block or a short ranking form:
+
+```text
+run_id: landing-page-explore-001
+hero-001 ranking: C > A > D > B
+best traits:
+- C: clearest product explanation
+- A: best mascot placement
+reject:
+- B: too generic
+```
 
 Complete local review path:
 

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -71,6 +71,14 @@ The plugin is only the runtime discovery surface for this skill. Local agent
 invocation still goes through the `gitmoot` CLI and the same registered agent,
 repo access, runtime adapter, and job history model used by PR-comment jobs.
 
+For SkillOpt template learning, use ranked exploration when the user needs broad
+search across multiple directions, then narrow through refine and distill before
+final validation. Keep final promotion decisions on fresh A/B validation items
+unless the user explicitly asks for another evaluation design. Treat
+`gitmoot skillopt review status` recommendations as advisory. Do not run heavy
+SkillOpt optimization after every tiny feedback round unless the user explicitly
+wants that; collect enough rankings and trait notes first.
+
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).
 For current-chat template capture, read

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -258,6 +258,8 @@ gitmoot lock show owner/repo <branch>
 ```sh
 gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>
 gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]
+gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id> --mode explore --exploration-level high --options 4
+gitmoot skillopt review item add --run <run-id> --item <item-id> --option a=option-a.md --option b=option-b.md [...]
 gitmoot skillopt review status --run <run-id>
 gitmoot skillopt export --run <run-id> [--output training.json]
 gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
@@ -272,10 +274,14 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 ```
 
 `skillopt review create` starts a review run for a template and target repo.
-`skillopt review item add` stores saved baseline/candidate outputs as artifact
-backed A/B review items. `skillopt review status` reports whether the run has
-items, complete artifacts, imported feedback for every item, and enough metadata
-to export.
+Use the default A/B shape for validation, or pass `--mode explore|refine|distill`
+with `--options N` for ranked exploration. `skillopt review item add` stores
+saved baseline/candidate outputs as artifact-backed A/B review items, or
+repeated `--option label=path` artifacts for ranked N-way items. `skillopt
+review status` reports whether the run has items, complete artifacts, imported
+feedback for every item, ranking stability, pairwise preference count, and a
+recommended next mode. Recommendations are advisory; Gitmoot never changes mode,
+imports a candidate, or promotes a template automatically.
 
 `skillopt export` writes a JSON training package with the template snapshot,
 eval run, review items, artifact manifests, feedback events when present, and
@@ -301,6 +307,10 @@ that Gitmoot uses to validate the full response and import de-blinded canonical
 feedback events. Open `index.md`, review every file in `items/*.md`, set
 `reviewer`, edit `feedback.yml` with exactly one of `a`, `b`, `tie`, `neither`,
 or `skip` for every item, and leave `.assignments.json` untouched.
+Ranked packets use the same files, but `feedback.yml` contains ordered rankings
+plus optional `useful_traits`, `rejected_traits`, and reasoning. After feedback
+exists, packet summaries hide outcome-bearing phase details so later blind
+reviewers do not see the current winner before responding.
 
 The GitHub feedback collector publishes the same blind A/B review packet to a
 new issue by default, or to an existing PR when `--pr <number>` is provided.
@@ -310,3 +320,6 @@ Gitmoot config. Reviewers can reply with full YAML or run-scoped short-form
 lines such as `run_id: run-1` followed by `item-001: b - More concrete.`.
 `github sync` imports valid comments into canonical feedback events and ignores
 unrelated comments safely.
+Ranked GitHub comments can use `item-001 ranking: C > A > D > B` plus trait
+notes. Use the ranked workflow for exploration/refinement and return to A/B
+validation for final promotion decisions on fresh items.

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -190,6 +190,73 @@ it explicitly:
 gitmoot goal import --file GOAL-feature.md --repo owner/repo
 ```
 
+## SkillOpt Ranked Exploration
+
+Use ranked exploration when a template needs broad search before final
+validation. Keep final promotion decisions on fresh A/B validation items unless
+the user explicitly asks for a different evaluation design.
+
+1. Explore with four to six diverse options per item.
+2. Rank every option and capture useful/rejected traits.
+3. Refine with two to three combined candidates once a direction stabilizes.
+4. Distill the accumulated feedback into a candidate template.
+5. Validate current template vs candidate on fresh A/B items.
+
+Landing-page example:
+
+```sh
+gitmoot skillopt review create \
+  --template landing-page-designer \
+  --repo owner/gitmoot-web \
+  --run landing-page-explore-001 \
+  --mode explore \
+  --exploration-level high \
+  --options 4
+
+gitmoot skillopt review item add \
+  --run landing-page-explore-001 \
+  --item hero-001 \
+  --title "Gitmoot landing page hero" \
+  --option a=previews/hero-a.md \
+  --option b=previews/hero-b.md \
+  --option c=previews/hero-c.md \
+  --option d=previews/hero-d.md
+
+gitmoot skillopt feedback markdown export \
+  --run landing-page-explore-001 \
+  --output .gitmoot/evals/landing-page-explore-001
+```
+
+Non-visual writing tasks use the same shape with text artifacts:
+
+```sh
+gitmoot skillopt review create \
+  --template x-post-writer \
+  --repo owner/content-workflows \
+  --run x-post-style-explore-001 \
+  --mode explore \
+  --options 5
+
+gitmoot skillopt review item add \
+  --run x-post-style-explore-001 \
+  --item thread-hook-001 \
+  --option a=posts/hook-a.txt \
+  --option b=posts/hook-b.txt \
+  --option c=posts/hook-c.txt \
+  --option d=posts/hook-d.txt \
+  --option e=posts/hook-e.txt
+```
+
+After importing feedback, inspect:
+
+```sh
+gitmoot skillopt review status --run landing-page-explore-001
+```
+
+Only run the external optimizer when the user wants a candidate update and the
+status recommendation is stable enough for the current phase. Do not run heavy
+SkillOpt optimization after every tiny feedback round by default.
+
 ## Execution Model
 
 Use `here` when the current chat should answer directly from the Gitmoot skill.


### PR DESCRIPTION
WHAT
- Document the ranked SkillOpt exploration workflow across the README, exchange contract, Gitmoot skill, and skill reference docs.

WHY
- Task 6 requires users and agents to understand when to explore, refine, distill, and validate ranked SkillOpt review runs, including the rule that final promotion should still use fresh A/B validation by default.

CHANGES
- Added a ranked exploration workflow section to `docs/skillopt-exchange-contract.md`.
- Added exact Markdown and GitHub collector examples for ranked runs, including landing-page and non-visual writing examples.
- Updated README and skill CLI/workflow references with ranked review commands and phase guidance.
- Updated `skills/gitmoot/SKILL.md` to tell agents not to run heavy SkillOpt optimization after every tiny feedback round unless the user explicitly asks.

RESULTS
- `GOTOOLCHAIN=go1.26.0 go test ./...` passed.
- `git diff --check` passed.
- `codex exec review --uncommitted` final raw output:

```text
The changes are documentation-only and the described ranked SkillOpt workflow, flags, and feedback formats appear consistent with the existing CLI and parser behavior. I did not identify any actionable correctness issues in the modified files.
The changes are documentation-only and the described ranked SkillOpt workflow, flags, and feedback formats appear consistent with the existing CLI and parser behavior. I did not identify any actionable correctness issues in the modified files.
```

RISK
- Documentation-only change. No skipped checks.