### PR TITLE
feat(skillopt): add train workspace and item metadata

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/feedback"
 	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"gopkg.in/yaml.v3"
 )
 
 var newSkillOptGitHubClient = func() github.Client {
@@ -68,7 +69,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
-	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> [--yes]")
+	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
@@ -97,7 +98,7 @@ func runSkillOptTrain(args []string, stdout, stderr io.Writer) int {
 
 func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--dry-run] [--yes]")
+	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
@@ -118,6 +119,9 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 	mode := fs.String("mode", db.EvalRunModeExplore, "train mode: explore, refine, distill, or validate")
 	explorationLevel := fs.String("exploration-level", "", "exploration level: high, medium, or low")
 	optionsCount := fs.Int("options", 0, "expected number of review options")
+	itemsFile := fs.String("items-file", "", "YAML or JSON file describing training review items")
+	minItems := fs.Int("min-items", 2, "minimum number of training review items")
+	preferredGate := fs.String("preferred-gate", "", "evaluation gate: hard, soft, or hard_then_soft")
 	dryRun := fs.Bool("dry-run", false, "print inferred session state without writing")
 	yes := fs.Bool("yes", false, "confirm creation without an interactive prompt")
 	if err := fs.Parse(args); err != nil {
@@ -168,6 +172,27 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "skillopt train start: --options must be zero or at least 2")
 		return 2
 	}
+	effectiveOptionsCount := effectiveSkillOptOptionsCount(normalizedMode, *optionsCount)
+	items, itemWarnings, err := readSkillOptTrainItems(*itemsFile)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt train start: %v\n", err)
+		return 2
+	}
+	if *minItems < 2 {
+		fmt.Fprintln(stderr, "skillopt train start: --min-items must be at least 2")
+		return 2
+	}
+	if len(items) < *minItems {
+		fmt.Fprintf(stderr, "skillopt train start: --items-file must contain at least %d items, got %d\n", *minItems, len(items))
+		return 2
+	}
+	normalizedGate, err := normalizeSkillOptPreferredGate(*preferredGate, normalizedTaskKind)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt train start: %v\n", err)
+		return 2
+	}
+	itemWarnings = append(itemWarnings, detectSkillOptTrainItemWarnings(items)...)
+	itemWarnings = append(itemWarnings, detectSkillOptTrainPreviewWarnings(previewRepo)...)
 	var plan skillOptTrainStartPlan
 	openStore := withStore
 	if *dryRun || !*yes {
@@ -178,7 +203,7 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return err
 		}
-		plan = buildSkillOptTrainStartPlan(template, repo.FullName(), workspaceRepo, previewRepo, strings.TrimSpace(*sessionID), request, normalizedTaskKind, normalizedMode, normalizedExploration, *optionsCount)
+		plan = buildSkillOptTrainStartPlan(template, repo.FullName(), workspaceRepo, previewRepo, strings.TrimSpace(*sessionID), request, normalizedTaskKind, normalizedMode, normalizedExploration, effectiveOptionsCount, normalizedGate, items, itemWarnings)
 		if *dryRun {
 			return nil
 		}
@@ -190,10 +215,26 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
+		if _, err := store.GetEvalRun(context.Background(), plan.EvalRun.ID); err == nil {
+			return fmt.Errorf("eval run %s already exists; use a different --session or inspect it with gitmoot skillopt review status --run %s", plan.EvalRun.ID, plan.EvalRun.ID)
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
 		if err := store.UpsertSkillOptTrainSession(context.Background(), plan.Session); err != nil {
 			return err
 		}
-		return store.UpsertSkillOptTrainIteration(context.Background(), plan.Iteration)
+		if err := store.UpsertSkillOptTrainIteration(context.Background(), plan.Iteration); err != nil {
+			return err
+		}
+		if err := store.UpsertEvalRun(context.Background(), plan.EvalRun); err != nil {
+			return err
+		}
+		for _, item := range plan.Items {
+			if err := store.UpsertEvalReviewItem(context.Background(), item); err != nil {
+				return err
+			}
+		}
+		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "skillopt train start: %v\n", err)
 		return 1
@@ -215,15 +256,22 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 type skillOptTrainStartPlan struct {
 	Session   db.SkillOptTrainSession
 	Iteration db.SkillOptTrainIteration
+	EvalRun   db.EvalRun
+	Items     []db.EvalReviewItem
+	Warnings  []string
 	Summary   skillopt.TrainStatusSummary
 }
 
-func buildSkillOptTrainStartPlan(template db.AgentTemplate, repo string, workspaceRepo string, previewRepo string, sessionID string, request string, taskKind string, mode string, explorationLevel string, optionsCount int) skillOptTrainStartPlan {
+func buildSkillOptTrainStartPlan(template db.AgentTemplate, repo string, workspaceRepo string, previewRepo string, sessionID string, request string, taskKind string, mode string, explorationLevel string, optionsCount int, preferredGate string, itemPlans []skillOptTrainItemPlan, warnings []string) skillOptTrainStartPlan {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
 		sessionID = generatedSkillOptTrainSessionID(template.ID)
 	}
-	metadata := skillOptTrainStartMetadata(request, mode, explorationLevel, optionsCount)
+	state := skillopt.TrainStateRequestConfirmed
+	if workspaceRepo != "" {
+		state = skillopt.TrainStateItemsReady
+	}
+	metadata := skillOptTrainStartMetadata(request, mode, explorationLevel, optionsCount, preferredGate, itemPlans, warnings)
 	session := db.SkillOptTrainSession{
 		ID:                sessionID,
 		TemplateID:        template.ID,
@@ -233,7 +281,7 @@ func buildSkillOptTrainStartPlan(template db.AgentTemplate, repo string, workspa
 		PreviewRepo:       previewRepo,
 		RequestSummary:    firstLine(request),
 		TaskKind:          taskKind,
-		State:             skillopt.TrainStateRequestConfirmed,
+		State:             state,
 		MetadataJSON:      metadata,
 	}
 	iteration := db.SkillOptTrainIteration{
@@ -243,11 +291,31 @@ func buildSkillOptTrainStartPlan(template db.AgentTemplate, repo string, workspa
 		BaseTemplateVersionID: template.VersionID,
 		Mode:                  mode,
 		ExplorationLevel:      explorationLevel,
-		State:                 skillopt.TrainStateRequestConfirmed,
+		State:                 state,
 		MetadataJSON:          metadata,
 	}
+	run := db.EvalRun{
+		ID:                iteration.EvalRunID,
+		TemplateID:        template.ID,
+		TemplateVersionID: template.VersionID,
+		TargetRepo:        repo,
+		State:             "review",
+		Mode:              mode,
+		ExplorationLevel:  explorationLevel,
+		OptionsCount:      optionsCount,
+		MetadataJSON:      metadata,
+	}
+	items := make([]db.EvalReviewItem, 0, len(itemPlans))
+	for _, item := range itemPlans {
+		items = append(items, db.EvalReviewItem{
+			RunID:        run.ID,
+			ItemID:       item.ItemID,
+			Title:        item.Title,
+			MetadataJSON: skillOptTrainItemMetadata(item),
+		})
+	}
 	summary := skillopt.BuildTrainStatusSummary(session, &iteration, skillopt.TrainStatusCounts{})
-	return skillOptTrainStartPlan{Session: session, Iteration: iteration, Summary: summary}
+	return skillOptTrainStartPlan{Session: session, Iteration: iteration, EvalRun: run, Items: items, Warnings: warnings, Summary: summary}
 }
 
 func printSkillOptTrainStartPlan(stdout io.Writer, plan skillOptTrainStartPlan) {
@@ -263,6 +331,11 @@ func printSkillOptTrainStartPlan(stdout io.Writer, plan skillOptTrainStartPlan) 
 	writeLine(stdout, "eval_run: %s", plan.Iteration.EvalRunID)
 	writeLine(stdout, "mode: %s", plan.Iteration.Mode)
 	writeLine(stdout, "exploration_level: %s", plan.Iteration.ExplorationLevel)
+	writeLine(stdout, "preferred_gate: %s", skillOptMetadataString(plan.EvalRun.MetadataJSON, "evaluation", "preferred_gate"))
+	writeLine(stdout, "items: %d", len(plan.Items))
+	for _, warning := range plan.Warnings {
+		writeLine(stdout, "warning: %s", warning)
+	}
 	writeLine(stdout, "current_phase: %s", plan.Summary.CurrentPhase)
 	writeLine(stdout, "blocked_step: %s", plan.Summary.BlockedStep)
 	writeLine(stdout, "next_action: %s", plan.Summary.NextAction)
@@ -488,6 +561,156 @@ func readSkillOptTrainRequest(requestText string, requestFile string) (string, e
 	return strings.TrimSpace(string(content)), nil
 }
 
+type skillOptTrainItemsFile struct {
+	Items []skillOptTrainItemPlan `json:"items" yaml:"items"`
+}
+
+type skillOptTrainItemPlan struct {
+	ItemID         string   `json:"item_id" yaml:"item_id"`
+	Title          string   `json:"title" yaml:"title"`
+	Brief          string   `json:"brief" yaml:"brief"`
+	TargetAudience string   `json:"target_audience" yaml:"target_audience"`
+	OutputType     string   `json:"output_type" yaml:"output_type"`
+	ArtifactHints  []string `json:"artifact_hints" yaml:"artifact_hints"`
+}
+
+func readSkillOptTrainItems(path string) ([]skillOptTrainItemPlan, []string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, nil, errors.New("skillopt train start requires --items-file")
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read items-file: %w", err)
+	}
+	var wrapped skillOptTrainItemsFile
+	wrappedErr := yaml.Unmarshal(content, &wrapped)
+	items := wrapped.Items
+	if wrappedErr != nil && len(items) > 0 {
+		return nil, nil, fmt.Errorf("decode items-file: %w", wrappedErr)
+	}
+	if len(items) == 0 {
+		var direct []skillOptTrainItemPlan
+		if err := yaml.Unmarshal(content, &direct); err != nil {
+			if wrappedErr != nil {
+				return nil, nil, fmt.Errorf("decode items-file: %w", wrappedErr)
+			}
+			return nil, nil, fmt.Errorf("decode items-file: %w", err)
+		}
+		items = direct
+	}
+	normalized := make([]skillOptTrainItemPlan, 0, len(items))
+	seen := map[string]struct{}{}
+	for index, item := range items {
+		item.ItemID = strings.TrimSpace(item.ItemID)
+		if item.ItemID == "" {
+			item.ItemID = fmt.Sprintf("item-%03d", index+1)
+		}
+		item.Title = strings.TrimSpace(item.Title)
+		item.Brief = strings.TrimSpace(item.Brief)
+		item.TargetAudience = strings.TrimSpace(item.TargetAudience)
+		item.OutputType = strings.TrimSpace(item.OutputType)
+		item.ArtifactHints = trimStringSlice(item.ArtifactHints)
+		if item.Title == "" {
+			return nil, nil, fmt.Errorf("items-file item %s title is required", item.ItemID)
+		}
+		if item.Brief == "" {
+			return nil, nil, fmt.Errorf("items-file item %s brief is required", item.ItemID)
+		}
+		if item.OutputType == "" {
+			return nil, nil, fmt.Errorf("items-file item %s output_type is required", item.ItemID)
+		}
+		if _, exists := seen[item.ItemID]; exists {
+			return nil, nil, fmt.Errorf("items-file item id %q is duplicated", item.ItemID)
+		}
+		seen[item.ItemID] = struct{}{}
+		normalized = append(normalized, item)
+	}
+	return normalized, nil, nil
+}
+
+func detectSkillOptTrainItemWarnings(items []skillOptTrainItemPlan) []string {
+	warnings := []string{}
+	titleCounts := map[string]int{}
+	briefCounts := map[string]int{}
+	distinctTerms := map[string]struct{}{}
+	for _, item := range items {
+		titleCounts[strings.ToLower(item.Title)]++
+		briefCounts[strings.ToLower(item.Brief)]++
+		for _, term := range skillOptTrainItemTerms(item.Title + " " + item.Brief + " " + item.OutputType) {
+			distinctTerms[term] = struct{}{}
+		}
+	}
+	for title, count := range titleCounts {
+		if title != "" && count > 1 {
+			warnings = append(warnings, fmt.Sprintf("duplicate item title %q appears %d times", title, count))
+		}
+	}
+	for brief, count := range briefCounts {
+		if brief != "" && count > 1 {
+			warnings = append(warnings, fmt.Sprintf("duplicate item brief %q appears %d times", brief, count))
+		}
+	}
+	if len(items) >= 3 && len(distinctTerms) < len(items)*2 {
+		warnings = append(warnings, "training items look homogeneous; add more distinct products, audiences, formats, or constraints for stronger feedback")
+	}
+	return warnings
+}
+
+func detectSkillOptTrainPreviewWarnings(previewRepo string) []string {
+	if strings.TrimSpace(previewRepo) == "" {
+		return nil
+	}
+	return []string{"preview repo must be public or GitHub Pages-enabled before clickable demos can be published"}
+}
+
+func skillOptTrainItemTerms(value string) []string {
+	parts := strings.FieldsFunc(strings.ToLower(value), func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	})
+	terms := make([]string, 0, len(parts))
+	stop := map[string]struct{}{
+		"and": {}, "for": {}, "the": {}, "with": {}, "that": {}, "this": {}, "from": {}, "into": {},
+		"page": {}, "build": {}, "create": {}, "make": {}, "write": {}, "design": {}, "output": {},
+	}
+	for _, part := range parts {
+		if len(part) < 4 {
+			continue
+		}
+		if _, skip := stop[part]; skip {
+			continue
+		}
+		terms = append(terms, part)
+	}
+	return terms
+}
+
+func skillOptTrainItemMetadata(item skillOptTrainItemPlan) string {
+	metadata := map[string]any{
+		"brief":           item.Brief,
+		"target_audience": item.TargetAudience,
+		"output_type":     item.OutputType,
+		"artifact_hints":  item.ArtifactHints,
+		"source":          "gitmoot skillopt train start",
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func trimStringSlice(values []string) []string {
+	output := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			output = append(output, value)
+		}
+	}
+	return output
+}
+
 func parseOptionalSkillOptTrainRepo(name string, value string) (string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -542,6 +765,36 @@ func normalizeSkillOptTrainMode(mode string, explorationLevel string) (string, s
 	}
 }
 
+func normalizeSkillOptPreferredGate(value string, taskKind string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		switch taskKind {
+		case "correctness", "data":
+			value = "hard"
+		case "ux", "design", "writing":
+			value = "soft"
+		default:
+			value = "hard_then_soft"
+		}
+	}
+	switch value {
+	case "hard", "soft", "hard_then_soft":
+		return value, nil
+	default:
+		return "", fmt.Errorf("preferred gate %q is not supported", value)
+	}
+}
+
+func effectiveSkillOptOptionsCount(mode string, optionsCount int) int {
+	if optionsCount != 0 {
+		return optionsCount
+	}
+	if mode == db.EvalRunModeExplore {
+		return 5
+	}
+	return 2
+}
+
 func generatedSkillOptTrainSessionID(templateID string) string {
 	base := strings.ToLower(strings.TrimSpace(templateID))
 	if base == "" {
@@ -564,7 +817,7 @@ func generatedSkillOptTrainSessionID(templateID string) string {
 	return "train-" + strings.Trim(b.String(), "-_") + "-" + now.Format("20060102-150405") + fmt.Sprintf("-%09d", now.Nanosecond())
 }
 
-func skillOptTrainStartMetadata(request string, mode string, explorationLevel string, optionsCount int) string {
+func skillOptTrainStartMetadata(request string, mode string, explorationLevel string, optionsCount int, preferredGate string, items []skillOptTrainItemPlan, warnings []string) string {
 	lines := strings.Count(request, "\n") + 1
 	words := len(strings.Fields(request))
 	metadata := map[string]any{
@@ -575,13 +828,36 @@ func skillOptTrainStartMetadata(request string, mode string, explorationLevel st
 		"mode":              mode,
 		"exploration_level": explorationLevel,
 		"options_count":     optionsCount,
-		"source":            "gitmoot skillopt train start",
+		"items_count":       len(items),
+		"item_warnings":     warnings,
+		"evaluation": map[string]any{
+			"preferred_gate": preferredGate,
+		},
+		"source": "gitmoot skillopt train start",
 	}
 	encoded, err := json.Marshal(metadata)
 	if err != nil {
 		return ""
 	}
 	return string(encoded)
+}
+
+func skillOptMetadataString(metadataJSON string, path ...string) string {
+	var current any
+	if err := json.Unmarshal([]byte(metadataJSON), &current); err != nil {
+		return ""
+	}
+	for _, key := range path {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = object[key]
+	}
+	if value, ok := current.(string); ok {
+		return value
+	}
+	return ""
 }
 
 func skillOptTrainDecisionMetadata(existing string, reason string) string {
@@ -868,6 +1144,9 @@ func runSkillOptReviewItemAdd(args []string, stdout, stderr io.Writer) int {
 				Title:        strings.TrimSpace(*title),
 				MetadataJSON: metadata,
 			}
+			if err := preserveExistingSkillOptReviewItemDetails(ctx, store, &item); err != nil {
+				return err
+			}
 			if err := store.UpsertEvalReviewItem(ctx, item); err != nil {
 				return err
 			}
@@ -914,6 +1193,9 @@ func runSkillOptReviewItemAdd(args []string, stdout, stderr io.Writer) int {
 			BaselineArtifactID:  baseline.ID,
 			CandidateArtifactID: candidate.ID,
 			MetadataJSON:        metadata,
+		}
+		if err := preserveExistingSkillOptReviewItemDetails(ctx, store, &item); err != nil {
+			return err
 		}
 		return store.UpsertEvalReviewItem(ctx, item)
 	}); err != nil {
@@ -978,6 +1260,32 @@ func runSkillOptReviewStatus(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "training_blocker: %s\n", blocker)
 	}
 	return 0
+}
+
+func preserveExistingSkillOptReviewItemDetails(ctx context.Context, store *db.Store, item *db.EvalReviewItem) error {
+	if store == nil || item == nil {
+		return nil
+	}
+	if strings.TrimSpace(item.Title) != "" && strings.TrimSpace(item.MetadataJSON) != "" {
+		return nil
+	}
+	items, err := store.ListEvalReviewItems(ctx, item.RunID)
+	if err != nil {
+		return err
+	}
+	for _, existing := range items {
+		if strings.TrimSpace(existing.ItemID) != strings.TrimSpace(item.ItemID) {
+			continue
+		}
+		if strings.TrimSpace(item.Title) == "" {
+			item.Title = existing.Title
+		}
+		if strings.TrimSpace(item.MetadataJSON) == "" {
+			item.MetadataJSON = existing.MetadataJSON
+		}
+		return nil
+	}
+	return nil
 }
 
 type skillOptReviewStatus struct {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -415,6 +415,23 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	if err := os.WriteFile(requestPath, []byte("Train landing page plans with diverse review items."), 0o644); err != nil {
 		t.Fatalf("write request file: %v", err)
 	}
+	itemsPath := filepath.Join(t.TempDir(), "items.yml")
+	if err := os.WriteFile(itemsPath, []byte(`items:
+  - item_id: hero-saas
+    title: SaaS hero
+    brief: Design a landing page hero for a workflow SaaS product.
+    target_audience: founders
+    output_type: vue landing page
+    artifact_hints:
+      - clickable preview
+  - item_id: ecommerce-proof
+    title: Ecommerce proof section
+    brief: Design a social proof section for an ecommerce analytics product.
+    target_audience: growth teams
+    output_type: vue landing page
+`), 0o644); err != nil {
+		t.Fatalf("write items file: %v", err)
+	}
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{
 		"skillopt", "train", "start",
@@ -428,6 +445,7 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 		"--task-kind", "design",
 		"--mode", "explore",
 		"--options", "4",
+		"--items-file", itemsPath,
 		"--dry-run",
 	}, &stdout, &stderr)
 	if code != 0 {
@@ -475,6 +493,7 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 		"--repo", "owner/product",
 		"--session", "landing-train",
 		"--request", "Train landing page plans.",
+		"--items-file", itemsPath,
 	}, &stdout, &stderr)
 	if code != 2 {
 		t.Fatalf("train start without yes exit code = %d, want 2; stderr=%s stdout=%s", code, stderr.String(), stdout.String())
@@ -497,12 +516,13 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 		"--task-kind", "design",
 		"--mode", "explore",
 		"--options", "4",
+		"--items-file", itemsPath,
 		"--yes",
 	}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "created train session landing-train") {
+	if !strings.Contains(stdout.String(), "created train session landing-train") || !strings.Contains(stdout.String(), "preferred_gate: soft") || !strings.Contains(stdout.String(), "items: 2") || !strings.Contains(stdout.String(), "warning: preview repo must be public or GitHub Pages-enabled") {
 		t.Fatalf("train start stdout = %q", stdout.String())
 	}
 	store, err = db.Open(paths.Database)
@@ -520,8 +540,25 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
 	}
-	if iteration.BaseTemplateVersionID != installed.VersionID || iteration.Mode != db.EvalRunModeExplore || iteration.ExplorationLevel != db.ExplorationLevelHigh || iteration.EvalRunID != "landing-train-review-001" {
+	if iteration.BaseTemplateVersionID != installed.VersionID || iteration.Mode != db.EvalRunModeExplore || iteration.ExplorationLevel != db.ExplorationLevelHigh || iteration.EvalRunID != "landing-train-review-001" || iteration.State != skillopt.TrainStateItemsReady {
 		t.Fatalf("iteration = %+v", iteration)
+	}
+	run, err := store.GetEvalRun(context.Background(), "landing-train-review-001")
+	if err != nil {
+		t.Fatalf("GetEvalRun returned error: %v", err)
+	}
+	if run.TemplateVersionID != installed.VersionID || run.TargetRepo != "owner/product" || run.OptionsCount != 4 || skillOptMetadataString(run.MetadataJSON, "evaluation", "preferred_gate") != "soft" {
+		t.Fatalf("eval run = %+v metadata=%s", run, run.MetadataJSON)
+	}
+	if !strings.Contains(run.MetadataJSON, "preview repo must be public or GitHub Pages-enabled") {
+		t.Fatalf("eval run metadata did not include preview warning: %s", run.MetadataJSON)
+	}
+	items, err := store.ListEvalReviewItems(context.Background(), "landing-train-review-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	if len(items) != 2 || items[0].ItemID != "ecommerce-proof" || !strings.Contains(items[0].MetadataJSON, "growth teams") {
+		t.Fatalf("items = %+v", items)
 	}
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close after start returned error: %v", err)
@@ -536,6 +573,7 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 		"--repo", "owner/product",
 		"--session", "landing-train",
 		"--request", "Overwrite existing train session.",
+		"--items-file", itemsPath,
 		"--yes",
 	}, &stdout, &stderr)
 	if code != 1 {
@@ -559,13 +597,51 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 		t.Fatalf("Close after duplicate start returned error: %v", err)
 	}
 
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize before eval-run collision returned error: %v", err)
+	}
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open before eval-run collision returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:                "eval-collision-review-001",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/other",
+		State:             "review",
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun collision returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close before eval-run collision returned error: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "eval-collision",
+		"--request", "Train landing page plans.",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("eval-run collision train start exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "eval run eval-collision-review-001 already exists") {
+		t.Fatalf("eval-run collision stderr = %q", stderr.String())
+	}
+
 	stdout.Reset()
 	stderr.Reset()
 	code = Run([]string{"skillopt", "train", "status", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("train status exit code = %d, stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "current_phase: request_confirmed") || !strings.Contains(stdout.String(), "blocked_step: workspace_ready") {
+	if !strings.Contains(stdout.String(), "current_phase: items_ready") || !strings.Contains(stdout.String(), "blocked_step: options_generated") || !strings.Contains(stdout.String(), "review_items: 2") {
 		t.Fatalf("status stdout = %q", stdout.String())
 	}
 
@@ -649,6 +725,17 @@ func TestGeneratedSkillOptTrainSessionIDIncludesSubsecondEntropy(t *testing.T) {
 
 func TestSkillOptTrainStartDryRunDoesNotInitializeFreshHome(t *testing.T) {
 	home := t.TempDir()
+	itemsPath := filepath.Join(t.TempDir(), "items.yml")
+	if err := os.WriteFile(itemsPath, []byte(`items:
+  - title: One
+    brief: First item.
+    output_type: markdown
+  - title: Two
+    brief: Second item.
+    output_type: markdown
+`), 0o644); err != nil {
+		t.Fatalf("write items file: %v", err)
+	}
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{
 		"skillopt", "train", "start",
@@ -656,6 +743,7 @@ func TestSkillOptTrainStartDryRunDoesNotInitializeFreshHome(t *testing.T) {
 		"--template", "planner",
 		"--repo", "owner/product",
 		"--request", "Train landing page plans.",
+		"--items-file", itemsPath,
 		"--dry-run",
 	}, &stdout, &stderr)
 	if code != 1 {
@@ -666,6 +754,121 @@ func TestSkillOptTrainStartDryRunDoesNotInitializeFreshHome(t *testing.T) {
 	}
 	if _, err := os.Stat(config.PathsForHome(home).Home); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("dry-run initialized home, stat err=%v", err)
+	}
+}
+
+func TestSkillOptTrainStartRejectsTooFewItemsAndWarnsOnHomogeneousItems(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("designer", "Design well.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	dir := t.TempDir()
+	tooFewPath := filepath.Join(dir, "too-few.yml")
+	if err := os.WriteFile(tooFewPath, []byte(`items:
+  - title: Landing page
+    brief: Create a product landing page.
+    output_type: vue
+`), 0o644); err != nil {
+		t.Fatalf("write too-few items: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "designer",
+		"--repo", "owner/product",
+		"--request", "Train generic landing pages.",
+		"--items-file", tooFewPath,
+		"--yes",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("too-few train start exit code = %d, want 2; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "at least 2 items, got 1") {
+		t.Fatalf("too-few stderr = %q", stderr.String())
+	}
+
+	homogeneousPath := filepath.Join(dir, "homogeneous.yml")
+	if err := os.WriteFile(homogeneousPath, []byte(`items:
+  - title: Landing page
+    brief: Create a product landing page.
+    output_type: vue
+  - title: Landing page
+    brief: Create a product landing page.
+    output_type: vue
+  - title: Landing page
+    brief: Create a product landing page.
+    output_type: vue
+`), 0o644); err != nil {
+		t.Fatalf("write homogeneous items: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "designer",
+		"--repo", "owner/product",
+		"--session", "homogeneous-train",
+		"--request", "Train generic landing pages.",
+		"--items-file", homogeneousPath,
+		"--task-kind", "custom",
+		"--yes",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("homogeneous train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "preferred_gate: hard_then_soft") || !strings.Contains(stdout.String(), "warning: duplicate item title") || !strings.Contains(stdout.String(), "warning: training items look homogeneous") {
+		t.Fatalf("homogeneous stdout = %q", stdout.String())
+	}
+}
+
+func TestReadSkillOptTrainItemsAcceptsTopLevelArray(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "items.yml")
+	if err := os.WriteFile(path, []byte(`- item_id: alpha
+  title: Alpha item
+  brief: Create an alpha output.
+  output_type: markdown
+- item_id: beta
+  title: Beta item
+  brief: Create a beta output.
+  output_type: markdown
+`), 0o644); err != nil {
+		t.Fatalf("write items file: %v", err)
+	}
+	items, warnings, err := readSkillOptTrainItems(path)
+	if err != nil {
+		t.Fatalf("readSkillOptTrainItems returned error: %v", err)
+	}
+	if len(items) != 2 || items[0].ItemID != "alpha" || len(warnings) != 0 {
+		t.Fatalf("items=%+v warnings=%+v", items, warnings)
+	}
+}
+
+func TestReadSkillOptTrainItemsRejectsMalformedWrappedItems(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "items.yml")
+	if err := os.WriteFile(path, []byte(`items:
+  - item_id: alpha
+    title: Alpha item
+    brief: Create an alpha output.
+    output_type: markdown
+    artifact_hints: scalar-not-list
+`), 0o644); err != nil {
+		t.Fatalf("write items file: %v", err)
+	}
+	if _, _, err := readSkillOptTrainItems(path); err == nil || !strings.Contains(err.Error(), "decode items-file") {
+		t.Fatalf("readSkillOptTrainItems error = %v", err)
 	}
 }
 
@@ -1221,7 +1424,6 @@ func TestSkillOptReviewItemAddStoresArtifacts(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("skillopt review create exit code = %d, stderr=%s", code, stderr.String())
 	}
-
 	inputDir := t.TempDir()
 	baselinePath := filepath.Join(inputDir, "baseline.md")
 	candidatePath := filepath.Join(inputDir, "candidate.md")
@@ -1348,6 +1550,21 @@ func TestSkillOptRankedReviewItemAddAndMarkdownExport(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("skillopt review create exit code = %d, stderr=%s", code, stderr.String())
 	}
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open before preseeded review item returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:        "planner-explore-1",
+		ItemID:       "item-001",
+		Title:        "Preplanned landing page",
+		MetadataJSON: `{"brief":"Preserve this brief","output_type":"vue"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem preseed returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after preseeded review item returned error: %v", err)
+	}
 
 	inputDir := t.TempDir()
 	optionPaths := map[string]string{}
@@ -1464,6 +1681,13 @@ func TestSkillOptRankedReviewItemAddAndMarkdownExport(t *testing.T) {
 	}
 	if len(options) != 4 || options[0].Label != "a" || options[3].Label != "e" || !strings.Contains(options[0].MetadataJSON, optionPaths["a"]) {
 		t.Fatalf("options = %+v", options)
+	}
+	items, err := store.ListEvalReviewItems(context.Background(), "planner-explore-1")
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	if len(items) != 1 || items[0].Title != "Landing page" || !strings.Contains(items[0].MetadataJSON, "Preserve this brief") {
+		t.Fatalf("item metadata was not preserved after option add: %+v", items)
 	}
 	for _, option := range options {
 		if option.Label == "d" {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -97,6 +97,57 @@ func TestExportTrainingPackage(t *testing.T) {
 	}
 }
 
+func TestExportTrainingPackageIncludesPreferredGateMetadata(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("designer", "Design carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "designer")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "train-run-1",
+		TemplateID:        "designer",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		Mode:              db.EvalRunModeExplore,
+		ExplorationLevel:  db.ExplorationLevelHigh,
+		OptionsCount:      4,
+		MetadataJSON:      `{"evaluation":{"preferred_gate":"soft"},"source":"gitmoot skillopt train start"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:        "train-run-1",
+		ItemID:       "item-001",
+		Title:        "Landing page",
+		MetadataJSON: `{"brief":"Create a landing page.","output_type":"vue"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+
+	pkg, err := ExportTrainingPackage(ctx, store, "train-run-1")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	var evaluator map[string]any
+	if err := json.Unmarshal(pkg.EvaluatorConfig, &evaluator); err != nil {
+		t.Fatalf("decode evaluator config: %v", err)
+	}
+	evaluation, ok := evaluator["evaluation"].(map[string]any)
+	if !ok || evaluation["preferred_gate"] != "soft" {
+		t.Fatalf("evaluator config = %s", string(pkg.EvaluatorConfig))
+	}
+}
+
 func TestExportTrainingPackageIncludesRankedExplorationFeedback(t *testing.T) {
 	ctx := context.Background()
 	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
WHAT: Added SkillOpt train workspace/item planning metadata for train-created review runs.

WHY: Task 3 of GOAL-SKILLOPT-TRAIN.md needs train sessions to capture workspace/preview repos, diverse training items, and evaluator gate preferences before temporary agent generation starts.

CHANGES:
- Added `gitmoot skillopt train start --items-file`, `--min-items`, and `--preferred-gate` handling.
- Store train-created eval runs and review item shells with item metadata from YAML/JSON item files.
- Added deterministic warnings for homogeneous training item sets and preview repos that must be public or GitHub Pages-enabled for clickable demos.
- Added preferred gate metadata under `evaluation.preferred_gate` and contract coverage proving it appears in exported training packages.
- Preserved pre-planned review item title/metadata when later adding generated N-way options or A/B artifacts.

RESULTS:
- `git diff --check`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptRankedReviewItemAdd|SkillOptReviewItemAddStoresArtifacts|SkillOptTrain'`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run SkillOpt`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/config ./internal/skillopt ./internal/db`
- `GOTOOLCHAIN=go1.26.2 go run ./cmd/gitmoot skillopt train --help`
- `GOTOOLCHAIN=go1.26.2 go run ./cmd/gitmoot skillopt --help`
- `GOTOOLCHAIN=go1.26.2 go test ./...`

Final raw `codex exec review --uncommitted` output:

```text
No discrete, actionable correctness issues were found in the current staged, unstaged, or untracked changes. Local tests could not be executed because the required Go 1.26 toolchain download is blocked in this sandbox, but the diff review did not reveal breaking issues.
No discrete, actionable correctness issues were found in the current staged, unstaged, or untracked changes. Local tests could not be executed because the required Go 1.26 toolchain download is blocked in this sandbox, but the diff review did not reveal breaking issues.
```

RISK: The review sandbox could not execute its own Go tests with `GOTOOLCHAIN=local`, but the required Go 1.26.2 test and smoke commands above passed locally. Preview repo validation is intentionally warning-only in this task; actual preview generation/publishing is deferred to later train workflow tasks.
