### PR TITLE
feat(skillopt): generate train options with temporary agents

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -20,13 +20,14 @@ import (
 )
 
 type localAgentDispatchRequest struct {
-	RepoFlag     string
-	Agent        string
-	Action       string
-	Instructions string
-	Background   bool
-	Type         string
-	Home         string
+	RepoFlag         string
+	Agent            string
+	Action           string
+	Instructions     string
+	Background       bool
+	Type             string
+	Home             string
+	AllowManagedSync bool
 }
 
 type localAgentJobOutput struct {
@@ -53,8 +54,19 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
+	reservationReleased := false
+	releaseReservation := func(releaseCtx context.Context) error {
+		if reservationReleased {
+			return nil
+		}
+		if err := releaseAgentReservation(releaseCtx); err != nil {
+			return err
+		}
+		reservationReleased = true
+		return nil
+	}
 	defer func() {
-		_ = releaseAgentReservation(context.Background())
+		_ = releaseReservation(context.Background())
 	}()
 	if err := ensureLocalAgentAccess(ctx, store, agent, repo.FullName(), request.Action); err != nil {
 		return localAgentJobOutput{}, err
@@ -71,6 +83,9 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
+	if err := releaseReservation(ctx); err != nil {
+		return localAgentJobOutput{}, err
+	}
 	if request.Background {
 		return localAgentJobOutput{
 			JobID:          job.ID,
@@ -81,11 +96,15 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			RawOutputCount: 0,
 		}, nil
 	}
-	adapter, err := runtimeStartAdapter(newRuntimeFactory(), agent.Runtime, record.CheckoutPath)
+	managed, err := localManagedAgentDispatchConfigForAgent(ctx, store, request.Home, agent.Name)
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
-	releaseLock, acquired, lockKey, err := acquireRuntimeSessionLock(ctx, store, job.ID, runtimeAgent(agent), time.Now().UTC(), daemonRunningJobStaleAfter)
+	lockTTL := daemonRunningJobStaleAfter
+	if managed.OK {
+		lockTTL = managed.JobTimeout
+	}
+	releaseLock, acquired, lockKey, err := acquireRuntimeSessionLock(ctx, store, job.ID, runtimeAgent(agent), time.Now().UTC(), lockTTL)
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
@@ -102,7 +121,24 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	defer func() {
 		_ = releaseLock(context.Background())
 	}()
-	if _, err := (workflow.Mailbox{Store: store}).Run(ctx, job.ID, runtimeAgent(agent), adapter); err != nil {
+	adapter, err := runtimeStartAdapter(newRuntimeFactory(), agent.Runtime, record.CheckoutPath)
+	if err != nil {
+		return localAgentJobOutput{}, err
+	}
+	runCtx := ctx
+	if managed.OK {
+		now := time.Now().UTC()
+		if err := store.MarkAgentInstanceRunning(ctx, agent.Name, now, managed.JobTimeout); err != nil {
+			return localAgentJobOutput{}, err
+		}
+		defer func() {
+			_ = store.TouchAgentInstance(context.Background(), agent.Name, time.Now().UTC(), managed.IdleTimeout)
+		}()
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, managed.JobTimeout)
+		defer cancel()
+	}
+	if _, err := (workflow.Mailbox{Store: store}).Run(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {
 		return localAgentJobOutput{}, err
 	}
 	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_completed", Message: "workflow advancement completed"}); err != nil {
@@ -138,7 +174,7 @@ func resolveLocalDispatchAgent(ctx context.Context, store *db.Store, request loc
 			return db.Agent{}, noopAgentReservationRelease, err
 		}
 	}
-	if !request.Background {
+	if !request.Background && !request.AllowManagedSync {
 		return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("agent %q not found", request.Agent)
 	}
 	typeName := firstNonEmpty(forceType, request.Agent)
@@ -147,6 +183,39 @@ func resolveLocalDispatchAgent(ctx context.Context, store *db.Store, request loc
 
 func noopAgentReservationRelease(context.Context) error {
 	return nil
+}
+
+type localManagedAgentDispatchConfig struct {
+	OK          bool
+	IdleTimeout time.Duration
+	JobTimeout  time.Duration
+}
+
+func localManagedAgentDispatchConfigForAgent(ctx context.Context, store *db.Store, home string, agentName string) (localManagedAgentDispatchConfig, error) {
+	instance, err := store.GetAgentInstance(ctx, agentName)
+	if errors.Is(err, sql.ErrNoRows) {
+		return localManagedAgentDispatchConfig{}, nil
+	}
+	if err != nil {
+		return localManagedAgentDispatchConfig{}, err
+	}
+	types, err := loadAgentTypeConfig(home)
+	if err != nil {
+		return localManagedAgentDispatchConfig{}, err
+	}
+	agentType, ok := types[instance.Type]
+	if !ok {
+		return localManagedAgentDispatchConfig{}, fmt.Errorf("agent type %s not found for managed agent %s", instance.Type, agentName)
+	}
+	idleTimeout, err := time.ParseDuration(agentType.IdleTimeout)
+	if err != nil {
+		return localManagedAgentDispatchConfig{}, fmt.Errorf("agent type %s idle_timeout: %w", instance.Type, err)
+	}
+	jobTimeout, err := time.ParseDuration(agentType.JobTimeout)
+	if err != nil {
+		return localManagedAgentDispatchConfig{}, fmt.Errorf("agent type %s job_timeout: %w", instance.Type, err)
+	}
+	return localManagedAgentDispatchConfig{OK: true, IdleTimeout: idleTimeout, JobTimeout: jobTimeout}, nil
 }
 
 func ensureManagedAgentInstance(ctx context.Context, store *db.Store, home string, typeName string, repo string, record db.Repo) (db.Agent, func(context.Context) error, error) {
@@ -162,14 +231,19 @@ func ensureManagedAgentInstance(ctx context.Context, store *db.Store, home strin
 	if err != nil {
 		return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("agent type %s idle_timeout: %w", typeName, err)
 	}
+	jobTimeout, err := time.ParseDuration(agentType.JobTimeout)
+	if err != nil {
+		return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("agent type %s job_timeout: %w", typeName, err)
+	}
 	now := time.Now().UTC()
-	releaseTypeLock, acquiredTypeLock, typeLockKey, err := acquireManagedAgentTypeLock(ctx, store, typeName, now, daemonRunningJobStaleAfter)
+	releaseTypeLock, acquiredTypeLock, typeLockKey, err := acquireManagedAgentTypeLockWithWait(ctx, store, typeName, daemonRunningJobStaleAfter, jobTimeout)
 	if err != nil {
 		return db.Agent{}, noopAgentReservationRelease, err
 	}
 	if !acquiredTypeLock {
 		return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("managed agent type %s is busy reserving %s", typeName, typeLockKey)
 	}
+	now = time.Now().UTC()
 	releaseOnError := true
 	defer func() {
 		if releaseOnError {
@@ -198,6 +272,9 @@ func ensureManagedAgentInstance(ctx context.Context, store *db.Store, home strin
 		if err != nil {
 			return db.Agent{}, noopAgentReservationRelease, err
 		}
+		if ok && strings.TrimSpace(instance.State) == "starting" {
+			return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("managed agent type %s reached max_background while instances are still starting", typeName)
+		}
 		if ok {
 			agent, err := store.GetAgent(ctx, instance.Name)
 			if err != nil {
@@ -221,12 +298,36 @@ func ensureManagedAgentInstance(ctx context.Context, store *db.Store, home strin
 	if err != nil {
 		return db.Agent{}, noopAgentReservationRelease, err
 	}
+	reservedInstance := db.AgentInstance{
+		Name:         instanceAgent.Name,
+		Type:         agentType.Name,
+		Runtime:      instanceAgent.Runtime,
+		RuntimeRef:   "starting:" + instanceAgent.Name,
+		RepoFullName: repo,
+		Role:         instanceAgent.Role,
+		TemplateID:   instanceAgent.TemplateID,
+		Capabilities: instanceAgent.Capabilities,
+		State:        "starting",
+		CreatedAt:    formatManagedAgentTime(now),
+		LastUsedAt:   formatManagedAgentTime(now),
+		ExpiresAt:    formatManagedAgentTime(now.Add(jobTimeout)),
+	}
+	if err := store.UpsertAgentInstance(ctx, reservedInstance); err != nil {
+		return db.Agent{}, noopAgentReservationRelease, err
+	}
+	if err := releaseTypeLock(ctx); err != nil {
+		_ = store.DeleteAgentInstance(context.Background(), reservedInstance.Name)
+		return db.Agent{}, noopAgentReservationRelease, err
+	}
+	releaseOnError = false
 	started, err := adapter.Start(ctx, runtime.StartRequest{Agent: instanceAgent, Prompt: agentStartupPrompt(instanceAgent, cachedTemplate)})
 	if err != nil {
+		_ = store.DeleteAgentInstance(context.Background(), reservedInstance.Name)
 		return db.Agent{}, noopAgentReservationRelease, err
 	}
 	instanceAgent.RuntimeRef = strings.TrimSpace(started.RuntimeRef)
 	if err := runtime.ValidateAgent(instanceAgent); err != nil {
+		_ = store.DeleteAgentInstance(context.Background(), reservedInstance.Name)
 		return db.Agent{}, noopAgentReservationRelease, err
 	}
 	instance := db.AgentInstance{
@@ -238,20 +339,50 @@ func ensureManagedAgentInstance(ctx context.Context, store *db.Store, home strin
 		Role:         instanceAgent.Role,
 		TemplateID:   instanceAgent.TemplateID,
 		Capabilities: instanceAgent.Capabilities,
-		State:        "idle",
+		State:        "starting",
 		CreatedAt:    formatManagedAgentTime(now),
 		LastUsedAt:   formatManagedAgentTime(now),
-		ExpiresAt:    formatManagedAgentTime(now.Add(idleTimeout)),
+		ExpiresAt:    formatManagedAgentTime(now.Add(jobTimeout)),
 	}
 	if err := store.UpsertAgentInstance(ctx, instance); err != nil {
+		_ = store.DeleteAgentInstance(context.Background(), reservedInstance.Name)
 		return db.Agent{}, noopAgentReservationRelease, err
 	}
 	agent, err := store.GetAgent(ctx, instance.Name)
 	if err != nil {
 		return db.Agent{}, noopAgentReservationRelease, err
 	}
-	releaseOnError = false
-	return agent, releaseTypeLock, nil
+	return agent, func(releaseCtx context.Context) error {
+		return store.TouchAgentInstance(releaseCtx, instance.Name, time.Now().UTC(), idleTimeout)
+	}, nil
+}
+
+func acquireManagedAgentTypeLockWithWait(ctx context.Context, store *db.Store, typeName string, ttl time.Duration, waitTimeout time.Duration) (func(context.Context) error, bool, string, error) {
+	if waitTimeout <= 0 {
+		waitTimeout = ttl
+	}
+	deadline := time.Now().UTC().Add(waitTimeout)
+	var lastKey string
+	for {
+		release, acquired, key, err := acquireManagedAgentTypeLock(ctx, store, typeName, time.Now().UTC(), ttl)
+		lastKey = key
+		if err != nil || acquired {
+			return release, acquired, key, err
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return noopAgentReservationRelease, false, firstNonEmpty(lastKey, "agent-type:"+typeName), nil
+		}
+		sleep := 100 * time.Millisecond
+		if remaining < sleep {
+			sleep = remaining
+		}
+		select {
+		case <-ctx.Done():
+			return release, false, key, ctx.Err()
+		case <-time.After(sleep):
+		}
+	}
 }
 
 func acquireManagedAgentTypeLock(ctx context.Context, store *db.Store, typeName string, now time.Time, ttl time.Duration) (func(context.Context) error, bool, string, error) {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -721,6 +722,121 @@ func TestRunAgentTypeSetListShowAndManagedBackgroundAsk(t *testing.T) {
 	}
 	if len(jobs) != 2 || jobs[0].Agent != instances[0].Name || jobs[1].Agent != instances[0].Name {
 		t.Fatalf("jobs = %+v, instance = %+v", jobs, instances[0])
+	}
+}
+
+func TestDispatchManagedSyncUsesJobTimeoutForRuntimeLock(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--max-background", "1",
+		"--idle-timeout", "20m",
+		"--job-timeout", "45m",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	runner := &managedSyncLockRunner{
+		t:          t,
+		store:      store,
+		runtimeKey: "runtime:codex:550e8400-e29b-41d4-a716-446655440222",
+		minTTL:     44 * time.Minute,
+	}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	output, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		RepoFlag:         "owner/repo",
+		Agent:            "planner",
+		Action:           "ask",
+		Instructions:     "Check the managed sync lock timeout.",
+		Type:             "planner",
+		Home:             home,
+		AllowManagedSync: true,
+	})
+	if err != nil {
+		t.Fatalf("dispatchLocalAgentJob returned error: %v", err)
+	}
+	if output.Result == nil || output.Result.Decision != "implemented" {
+		t.Fatalf("dispatch output = %+v", output)
+	}
+	if !runner.checked {
+		t.Fatal("runner did not inspect runtime lock during resume")
+	}
+}
+
+func TestEnsureManagedAgentInstanceKeepsNewInstanceReservedUntilRelease(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--max-background", "2",
+		"--idle-timeout", "20m",
+		"--job-timeout", "45m",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	record := db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}
+	if err := store.UpsertRepo(context.Background(), record); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440333"}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	agent, release, err := ensureManagedAgentInstance(context.Background(), store, home, "planner", "owner/repo", record)
+	if err != nil {
+		t.Fatalf("ensureManagedAgentInstance returned error: %v", err)
+	}
+	instance, err := store.GetAgentInstance(context.Background(), agent.Name)
+	if err != nil {
+		t.Fatalf("GetAgentInstance returned error: %v", err)
+	}
+	if instance.State != "starting" || instance.RuntimeRef != "550e8400-e29b-41d4-a716-446655440333" {
+		t.Fatalf("instance before release = %+v", instance)
+	}
+	reusable, ok, err := store.FindReusableAgentInstance(context.Background(), "planner", "owner/repo", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("FindReusableAgentInstance returned error: %v", err)
+	}
+	if ok {
+		t.Fatalf("new managed instance is reusable before release: %+v", reusable)
+	}
+	if err := release(context.Background()); err != nil {
+		t.Fatalf("release returned error: %v", err)
+	}
+	instance, err = store.GetAgentInstance(context.Background(), agent.Name)
+	if err != nil {
+		t.Fatalf("GetAgentInstance after release returned error: %v", err)
+	}
+	if instance.State != "idle" {
+		t.Fatalf("instance state after release = %s, want idle", instance.State)
 	}
 }
 
@@ -1761,6 +1877,7 @@ func replaceRuntimeFactory(factory runtime.Factory) func() {
 }
 
 type agentStartRunner struct {
+	mu      sync.Mutex
 	results []subprocess.Result
 	errs    []error
 	calls   []agentStartCall
@@ -1772,7 +1889,54 @@ type agentStartCall struct {
 	args    []string
 }
 
+type managedSyncLockRunner struct {
+	t          *testing.T
+	store      *db.Store
+	runtimeKey string
+	minTTL     time.Duration
+	checked    bool
+}
+
+func (r *managedSyncLockRunner) Run(ctx context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	isResume := false
+	for _, arg := range args {
+		if arg == "resume" {
+			isResume = true
+			break
+		}
+	}
+	if !isResume {
+		return subprocess.Result{Command: command, Args: args, Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440222"}` + "\n"}, nil
+	}
+	lock, err := r.store.GetResourceLock(ctx, r.runtimeKey)
+	if err != nil {
+		r.t.Fatalf("GetResourceLock during resume returned error: %v", err)
+	}
+	acquiredAt, err := time.Parse(time.RFC3339Nano, lock.AcquiredAt)
+	if err != nil {
+		r.t.Fatalf("parse acquired_at %q: %v", lock.AcquiredAt, err)
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, lock.ExpiresAt)
+	if err != nil {
+		r.t.Fatalf("parse expires_at %q: %v", lock.ExpiresAt, err)
+	}
+	if ttl := expiresAt.Sub(acquiredAt); ttl < r.minTTL {
+		r.t.Fatalf("runtime lock ttl = %s, want at least %s", ttl, r.minTTL)
+	}
+	r.checked = true
+	return subprocess.Result{Command: command, Args: args, Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"}, nil
+}
+
+func (r *managedSyncLockRunner) LookPath(file string) (string, error) {
+	if file == "" {
+		return "", errors.New("empty file")
+	}
+	return "/usr/bin/" + file, nil
+}
+
 func (r *agentStartRunner) Run(_ context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.calls = append(r.calls, agentStartCall{dir: dir, command: command, args: append([]string{}, args...)})
 	index := len(r.calls) - 1
 	result := subprocess.Result{Command: command, Args: args}

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/feedback"
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
 	"gopkg.in/yaml.v3"
@@ -71,7 +73,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id>")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -100,7 +102,7 @@ func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id>")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -380,6 +382,8 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	sessionID := fs.String("session", "", "train session id")
+	generatorAgent := fs.String("generator-agent", "", "existing agent to use for option generation")
+	generatorType := fs.String("generator-type", "", "managed agent type to use for option generation; defaults to skillopt-generator")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -394,26 +398,510 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "skillopt train continue requires --session")
 		return 2
 	}
-	var session db.SkillOptTrainSession
-	var iteration *db.SkillOptTrainIteration
-	var counts skillopt.TrainStatusCounts
-	if err := withStore(*home, func(store *db.Store) error {
+	var output skillOptTrainContinueOutput
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
 		var err error
-		session, iteration, counts, err = loadSkillOptTrainStatus(context.Background(), store, *sessionID)
+		output, err = continueSkillOptTrain(context.Background(), paths, store, skillOptTrainContinueRequest{
+			Home:           *home,
+			SessionID:      *sessionID,
+			GeneratorAgent: *generatorAgent,
+			GeneratorType:  *generatorType,
+		})
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "skillopt train continue: %v\n", err)
 		return 1
 	}
-	summary := skillopt.BuildTrainStatusSummary(session, iteration, counts)
-	printSkillOptTrainStatus(stdout, summary, counts)
-	if summary.CurrentPhase == skillopt.TrainStateRunAbandoned {
+	printSkillOptTrainStatus(stdout, output.Summary, output.Counts)
+	if output.Summary.CurrentPhase == skillopt.TrainStateRunAbandoned {
 		fmt.Fprintln(stderr, "skillopt train continue: train session is abandoned")
 		return 1
 	}
-	writeLine(stdout, "continue_ready: false")
-	writeLine(stdout, "next: Task 3 will add workspace and item planning; use status for the current blocked step.")
+	writeLine(stdout, "continue_ready: %t", output.ContinueReady)
+	for _, line := range output.Lines {
+		writeLine(stdout, "%s", line)
+	}
 	return 0
+}
+
+type skillOptTrainContinueRequest struct {
+	Home              string
+	SessionID         string
+	GeneratorAgent    string
+	GeneratorType     string
+	GenerationLockTTL time.Duration
+}
+
+type skillOptTrainContinueOutput struct {
+	Summary       skillopt.TrainStatusSummary
+	Counts        skillopt.TrainStatusCounts
+	ContinueReady bool
+	Lines         []string
+}
+
+func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.Store, request skillOptTrainContinueRequest) (skillOptTrainContinueOutput, error) {
+	session, iteration, counts, err := loadSkillOptTrainStatus(ctx, store, request.SessionID)
+	if err != nil {
+		return skillOptTrainContinueOutput{}, err
+	}
+	summary := skillopt.BuildTrainStatusSummary(session, iteration, counts)
+	output := skillOptTrainContinueOutput{Summary: summary, Counts: counts}
+	if summary.CurrentPhase == skillopt.TrainStateRunAbandoned {
+		return output, nil
+	}
+	if iteration == nil {
+		output.Lines = []string{"next: train session has no iteration to continue"}
+		return output, nil
+	}
+	switch summary.CurrentPhase {
+	case skillopt.TrainStateItemsReady:
+		generationLockTTL, err := estimateSkillOptTrainGenerationLockTTL(ctx, store, request, *iteration)
+		if err != nil {
+			return output, err
+		}
+		request.GenerationLockTTL = generationLockTTL
+		releaseGenerationLock, _, err := acquireSkillOptTrainGenerationLock(ctx, store, session.ID, iteration.ID, generationLockTTL)
+		if err != nil {
+			return output, err
+		}
+		defer func() {
+			_ = releaseGenerationLock(context.Background())
+		}()
+		session, iteration, counts, err = loadSkillOptTrainStatus(ctx, store, request.SessionID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		summary = skillopt.BuildTrainStatusSummary(session, iteration, counts)
+		output = skillOptTrainContinueOutput{Summary: summary, Counts: counts}
+		if iteration == nil {
+			output.Lines = []string{"next: train session has no iteration to continue"}
+			return output, nil
+		}
+		if summary.CurrentPhase != skillopt.TrainStateItemsReady {
+			output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
+			return output, nil
+		}
+		result, err := generateSkillOptTrainOptions(ctx, paths, store, session, *iteration, request)
+		if err != nil {
+			if metaErr := recordSkillOptTrainGenerationFailure(ctx, store, session, *iteration, request, err); metaErr != nil {
+				return skillOptTrainContinueOutput{}, fmt.Errorf("%w; failed to record generation failure: %v", err, metaErr)
+			}
+			return skillOptTrainContinueOutput{}, err
+		}
+		session.State = skillopt.TrainStateOptionsGenerated
+		iteration.State = skillopt.TrainStateOptionsGenerated
+		session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "generation", result.Metadata)
+		iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "generation", result.Metadata)
+		if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		if err := store.UpsertSkillOptTrainIteration(ctx, *iteration); err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSession, updatedIteration, updatedCounts, err := loadSkillOptTrainStatus(ctx, store, session.ID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSummary := skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
+		return skillOptTrainContinueOutput{
+			Summary:       updatedSummary,
+			Counts:        updatedCounts,
+			ContinueReady: true,
+			Lines: []string{
+				fmt.Sprintf("generated_options: %d", result.GeneratedOptions),
+				fmt.Sprintf("jobs: %d", len(result.JobIDs)),
+				fmt.Sprintf("generator_agent: %s", result.AgentName),
+				fmt.Sprintf("generator_runtime: %s", result.Runtime),
+				"next: publish the human review packet",
+			},
+		}, nil
+	case skillopt.TrainStateOptionsGenerated:
+		output.Lines = []string{"next: options already generated; publish the human review packet"}
+		return output, nil
+	default:
+		output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
+		return output, nil
+	}
+}
+
+type skillOptTrainGenerationResult struct {
+	GeneratedOptions int
+	JobIDs           []string
+	AgentName        string
+	Runtime          string
+	Metadata         map[string]any
+}
+
+var errSkillOptTrainGenerationBusy = errors.New("skillopt train generation is already running")
+
+const skillOptTrainGenerationLockTTL = 2 * time.Hour
+
+const skillOptTrainGenerationLockBuffer = 10 * time.Minute
+
+func acquireSkillOptTrainGenerationLock(ctx context.Context, store *db.Store, sessionID string, iterationID string, ttl time.Duration) (func(context.Context) error, bool, error) {
+	key := skillOptTrainGenerationLockKey(sessionID, iterationID)
+	token, err := newRuntimeLockOwnerToken()
+	if err != nil {
+		return noopAgentReservationRelease, false, err
+	}
+	if ttl <= 0 {
+		ttl = skillOptTrainGenerationLockTTL
+	}
+	now := time.Now().UTC()
+	ownerJobID := localAgentJobID("skillopt-train-generation", strings.TrimSpace(sessionID))
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  ownerJobID,
+		OwnerToken:  token,
+		ExpiresAt:   now.Add(ttl).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		return noopAgentReservationRelease, false, err
+	}
+	if !acquired {
+		return noopAgentReservationRelease, false, fmt.Errorf("%w: %s", errSkillOptTrainGenerationBusy, key)
+	}
+	return func(releaseCtx context.Context) error {
+		_, err := store.ReleaseResourceLock(releaseCtx, key, ownerJobID, token)
+		return err
+	}, true, nil
+}
+
+func estimateSkillOptTrainGenerationLockTTL(ctx context.Context, store *db.Store, request skillOptTrainContinueRequest, iteration db.SkillOptTrainIteration) (time.Duration, error) {
+	run, err := store.GetEvalRun(ctx, iteration.EvalRunID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, fmt.Errorf("eval run %s not found", iteration.EvalRunID)
+		}
+		return 0, err
+	}
+	items, err := store.ListEvalReviewItems(ctx, run.ID)
+	if err != nil {
+		return 0, err
+	}
+	itemCount := len(items)
+	if itemCount <= 0 {
+		itemCount = 1
+	}
+	roles := len(skillOptTrainGenerationRoles(run))
+	if roles <= 0 {
+		roles = 2
+	}
+	_, dispatchType, err := skillOptTrainGeneratorSelection(request)
+	if err != nil {
+		return 0, err
+	}
+	jobTimeout := skillOptTrainGenerationJobTimeoutHint(request, dispatchType)
+	concurrency := skillOptTrainGenerationConcurrencyHint(request, dispatchType)
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	if concurrency > itemCount {
+		concurrency = itemCount
+	}
+	batches := (itemCount + concurrency - 1) / concurrency
+	estimated := time.Duration(batches*roles)*jobTimeout + skillOptTrainGenerationLockBuffer
+	if estimated < skillOptTrainGenerationLockTTL {
+		return skillOptTrainGenerationLockTTL, nil
+	}
+	return estimated, nil
+}
+
+func skillOptTrainGenerationJobTimeoutHint(request skillOptTrainContinueRequest, dispatchType string) time.Duration {
+	if strings.TrimSpace(dispatchType) == "" {
+		return daemonRunningJobStaleAfter
+	}
+	types, err := loadAgentTypeConfig(request.Home)
+	if err != nil {
+		return daemonRunningJobStaleAfter
+	}
+	agentType, ok := types[dispatchType]
+	if !ok {
+		return daemonRunningJobStaleAfter
+	}
+	jobTimeout, err := time.ParseDuration(agentType.JobTimeout)
+	if err != nil || jobTimeout <= 0 {
+		return daemonRunningJobStaleAfter
+	}
+	return jobTimeout
+}
+
+func skillOptTrainGenerationConcurrencyHint(request skillOptTrainContinueRequest, dispatchType string) int {
+	if strings.TrimSpace(dispatchType) == "" {
+		return 1
+	}
+	types, err := loadAgentTypeConfig(request.Home)
+	if err != nil {
+		return 1
+	}
+	agentType, ok := types[dispatchType]
+	if !ok || agentType.MaxBackground <= 0 {
+		return 1
+	}
+	return agentType.MaxBackground
+}
+
+func skillOptTrainGenerationLockKey(sessionID string, iterationID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	iterationID = strings.TrimSpace(iterationID)
+	if iterationID == "" {
+		return "skillopt-train-generation:" + sessionID
+	}
+	return "skillopt-train-generation:" + sessionID + ":" + iterationID
+}
+
+func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainContinueRequest) (skillOptTrainGenerationResult, error) {
+	if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateOptionsGenerated); err != nil {
+		return skillOptTrainGenerationResult{}, err
+	}
+	run, err := store.GetEvalRun(ctx, iteration.EvalRunID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return skillOptTrainGenerationResult{}, fmt.Errorf("eval run %s not found", iteration.EvalRunID)
+		}
+		return skillOptTrainGenerationResult{}, err
+	}
+	rankedRun := skillOptRunUsesRankedOptions(run)
+	items, err := store.ListEvalReviewItems(ctx, run.ID)
+	if err != nil {
+		return skillOptTrainGenerationResult{}, err
+	}
+	if len(items) == 0 {
+		return skillOptTrainGenerationResult{}, fmt.Errorf("eval run %s has no review items to generate", run.ID)
+	}
+	roles := skillOptTrainGenerationRoles(run)
+	if len(roles) < 2 {
+		return skillOptTrainGenerationResult{}, fmt.Errorf("eval run %s expects at least 2 options", run.ID)
+	}
+	existingGenerated := 0
+	completeExistingItems := 0
+	for _, item := range items {
+		if rankedRun {
+			existing, err := store.ListEvalReviewOptions(ctx, run.ID, item.ItemID)
+			if err != nil {
+				return skillOptTrainGenerationResult{}, err
+			}
+			if len(existing) > 0 {
+				if len(existing) == len(roles) {
+					existingGenerated += len(existing)
+					completeExistingItems++
+					continue
+				}
+				return skillOptTrainGenerationResult{}, fmt.Errorf("item %s has partial generated options; inspect or clear review options before continuing", item.ItemID)
+			}
+			continue
+		}
+		hasBaseline := strings.TrimSpace(item.BaselineArtifactID) != ""
+		hasCandidate := strings.TrimSpace(item.CandidateArtifactID) != ""
+		if hasBaseline || hasCandidate {
+			if hasBaseline && hasCandidate {
+				existingGenerated += 2
+				completeExistingItems++
+				continue
+			}
+			return skillOptTrainGenerationResult{}, fmt.Errorf("item %s has partial generated A/B artifacts; inspect or clear review item artifacts before continuing", item.ItemID)
+		}
+	}
+	if completeExistingItems > 0 {
+		if completeExistingItems == len(items) {
+			metadata := map[string]any{
+				"status":            "recovered",
+				"generated_options": existingGenerated,
+				"strategy":          skillOptTrainGenerationStrategy(run),
+				"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
+			}
+			return skillOptTrainGenerationResult{
+				GeneratedOptions: existingGenerated,
+				Metadata:         metadata,
+			}, nil
+		}
+		return skillOptTrainGenerationResult{}, fmt.Errorf("eval run %s has partial generated items; inspect or clear review artifacts before continuing", run.ID)
+	}
+	dispatchAgent, dispatchType, err := skillOptTrainGeneratorSelection(request)
+	if err != nil {
+		return skillOptTrainGenerationResult{}, err
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	concurrency, err := skillOptTrainGenerationConcurrency(request, dispatchType)
+	if err != nil {
+		return skillOptTrainGenerationResult{}, err
+	}
+	if err := ensureSkillOptTrainGenerationRepoReady(ctx, store, skillOptTrainGenerationRepo(session)); err != nil {
+		return skillOptTrainGenerationResult{}, err
+	}
+	generatedItems, err := generateSkillOptTrainItemOptions(ctx, store, blobStore, session, iteration, run, items, roles, rankedRun, request, dispatchAgent, dispatchType, concurrency)
+	if err != nil {
+		return skillOptTrainGenerationResult{}, err
+	}
+	writes := make([]db.EvalReviewGenerationWrite, 0, len(generatedItems))
+	generated := 0
+	jobIDs := []string{}
+	var generatorAgent string
+	var generatorRuntime string
+	promptRecords := []map[string]any{}
+	for _, item := range generatedItems {
+		generated += len(item.Artifacts)
+		jobIDs = append(jobIDs, item.JobIDs...)
+		if generatorAgent == "" {
+			generatorAgent = item.AgentName
+		}
+		if generatorRuntime == "" {
+			generatorRuntime = item.Runtime
+		}
+		promptRecords = append(promptRecords, item.Prompts...)
+		writes = append(writes, db.EvalReviewGenerationWrite{
+			ItemID:     item.ItemID,
+			ReviewItem: item.ReviewItem,
+			Artifacts:  item.Artifacts,
+			Options:    item.Options,
+		})
+	}
+	if err := store.ReplaceGeneratedEvalReviewArtifacts(ctx, run.ID, writes); err != nil {
+		return skillOptTrainGenerationResult{}, err
+	}
+	metadata := map[string]any{
+		"status":            "succeeded",
+		"generated_options": generated,
+		"jobs":              jobIDs,
+		"agent":             generatorAgent,
+		"runtime":           generatorRuntime,
+		"concurrency":       concurrency,
+		"lock_ttl":          request.GenerationLockTTL.String(),
+		"strategy":          skillOptTrainGenerationStrategy(run),
+		"prompts":           promptRecords,
+		"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	return skillOptTrainGenerationResult{
+		GeneratedOptions: generated,
+		JobIDs:           jobIDs,
+		AgentName:        generatorAgent,
+		Runtime:          generatorRuntime,
+		Metadata:         metadata,
+	}, nil
+}
+
+type skillOptTrainGeneratedItemOptions struct {
+	ItemID     string
+	ReviewItem *db.EvalReviewItem
+	Artifacts  []db.EvalArtifact
+	Options    []db.EvalReviewOption
+	JobIDs     []string
+	AgentName  string
+	Runtime    string
+	Prompts    []map[string]any
+}
+
+func generateSkillOptTrainItemOptions(ctx context.Context, store *db.Store, blobStore artifact.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, items []db.EvalReviewItem, roles []string, rankedRun bool, request skillOptTrainContinueRequest, dispatchAgent string, dispatchType string, concurrency int) ([]skillOptTrainGeneratedItemOptions, error) {
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	if concurrency > len(items) {
+		concurrency = len(items)
+	}
+	results := make([]skillOptTrainGeneratedItemOptions, len(items))
+	errs := make([]error, len(items))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, concurrency)
+	for index, item := range items {
+		index := index
+		item := item
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				errs[index] = ctx.Err()
+				return
+			}
+			result, err := generateSkillOptTrainSingleItemOptions(ctx, store, blobStore, session, iteration, run, item, roles, rankedRun, request, dispatchAgent, dispatchType)
+			if err != nil {
+				errs[index] = err
+				return
+			}
+			results[index] = result
+		}()
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}
+
+func generateSkillOptTrainSingleItemOptions(ctx context.Context, store *db.Store, blobStore artifact.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, item db.EvalReviewItem, roles []string, rankedRun bool, request skillOptTrainContinueRequest, dispatchAgent string, dispatchType string) (skillOptTrainGeneratedItemOptions, error) {
+	generatedItem := skillOptTrainGeneratedItemOptions{ItemID: item.ItemID}
+	replacementOptions := make([]db.EvalReviewOption, 0, len(roles))
+	artifactRecords := make([]db.EvalArtifact, 0, len(roles))
+	for _, role := range roles {
+		prompt := buildSkillOptTrainGenerationPrompt(session, iteration, run, item, role, rankedRun)
+		output, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+			RepoFlag:         skillOptTrainGenerationRepo(session),
+			Agent:            dispatchAgent,
+			Action:           "ask",
+			Instructions:     prompt,
+			Type:             dispatchType,
+			Home:             request.Home,
+			AllowManagedSync: dispatchType != "",
+		})
+		if err != nil {
+			return skillOptTrainGeneratedItemOptions{}, fmt.Errorf("generate %s for %s: %w", role, item.ItemID, err)
+		}
+		if output.Result == nil {
+			return skillOptTrainGeneratedItemOptions{}, fmt.Errorf("generate %s for %s: job %s did not return a result", role, item.ItemID, output.JobID)
+		}
+		if output.Result.Decision != "implemented" {
+			return skillOptTrainGeneratedItemOptions{}, fmt.Errorf("generate %s for %s: job %s returned %s, want implemented: %s", role, item.ItemID, output.JobID, output.Result.Decision, output.Result.Summary)
+		}
+		artifactRole := role
+		if rankedRun {
+			artifactRole = "option-" + role
+		}
+		artifactRecord, err := prepareReviewItemContentArtifact(blobStore, run.ID, item.ItemID, artifactRole, []byte(output.Result.Summary), "text/markdown", "text")
+		if err != nil {
+			return skillOptTrainGeneratedItemOptions{}, err
+		}
+		artifactRecords = append(artifactRecords, artifactRecord)
+		optionMetadata := skillOptTrainGeneratedOptionMetadata(output, prompt)
+		if rankedRun {
+			replacementOptions = append(replacementOptions, db.EvalReviewOption{
+				RunID:        run.ID,
+				ItemID:       item.ItemID,
+				Label:        role,
+				ArtifactID:   artifactRecord.ID,
+				Role:         "option",
+				MetadataJSON: optionMetadata,
+			})
+		} else if role == "baseline" {
+			item.BaselineArtifactID = artifactRecord.ID
+		} else if role == "candidate" {
+			item.CandidateArtifactID = artifactRecord.ID
+		}
+		generatedItem.JobIDs = append(generatedItem.JobIDs, output.JobID)
+		if generatedItem.AgentName == "" {
+			generatedItem.AgentName = output.Agent
+		}
+		if generatedItem.Runtime == "" {
+			if agent, err := store.GetAgent(ctx, output.Agent); err == nil {
+				generatedItem.Runtime = agent.Runtime
+			}
+		}
+		generatedItem.Prompts = append(generatedItem.Prompts, map[string]any{
+			"item_id": item.ItemID,
+			"role":    role,
+			"job_id":  output.JobID,
+			"prompt":  prompt,
+		})
+	}
+	generatedItem.Artifacts = artifactRecords
+	generatedItem.Options = replacementOptions
+	if !rankedRun {
+		generatedItem.ReviewItem = &item
+	}
+	return generatedItem, nil
 }
 
 func runSkillOptTrainStop(args []string, stdout, stderr io.Writer) int {
@@ -875,6 +1363,270 @@ func skillOptTrainDecisionMetadata(existing string, reason string) string {
 		return existing
 	}
 	return string(encoded)
+}
+
+func recordSkillOptTrainGenerationFailure(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainContinueRequest, failure error) error {
+	metadata := map[string]any{
+		"status":       "failed",
+		"agent":        strings.TrimSpace(request.GeneratorAgent),
+		"agent_type":   strings.TrimSpace(request.GeneratorType),
+		"error":        failure.Error(),
+		"completed_at": time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "generation", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "generation", metadata)
+	if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+		return err
+	}
+	return store.UpsertSkillOptTrainIteration(ctx, iteration)
+}
+
+func skillOptTrainGenerationRepo(session db.SkillOptTrainSession) string {
+	if repo := strings.TrimSpace(session.WorkspaceRepo); repo != "" {
+		return repo
+	}
+	return strings.TrimSpace(session.TargetRepo)
+}
+
+func ensureSkillOptTrainGenerationRepoReady(ctx context.Context, store *db.Store, repoName string) error {
+	repoName = strings.TrimSpace(repoName)
+	if repoName == "" {
+		return errors.New("skillopt train generation repo is required")
+	}
+	repo, err := daemon.ParseRepository(repoName)
+	if err != nil {
+		return err
+	}
+	if existing, err := store.GetRepo(ctx, repo.FullName()); err == nil {
+		if strings.TrimSpace(existing.CheckoutPath) == "" {
+			return fmt.Errorf("generation repo %s has no checkout path; run `gitmoot repo add %s --path /path/to/checkout` before train continue", repo.FullName(), repo.FullName())
+		}
+		record, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: existing.CheckoutPath})
+		if err != nil {
+			return fmt.Errorf("generation repo %s checkout is not ready: %w", repo.FullName(), err)
+		}
+		record.PollInterval = existing.PollInterval
+		return store.UpsertRepo(ctx, record)
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	record, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: "."})
+	if err != nil {
+		return fmt.Errorf("generation repo %s is not registered with a checkout path; run `gitmoot repo add %s --path /path/to/checkout` before train continue: %w", repo.FullName(), repo.FullName(), err)
+	}
+	return store.UpsertRepo(ctx, record)
+}
+
+func skillOptTrainGeneratorSelection(request skillOptTrainContinueRequest) (string, string, error) {
+	agent := strings.TrimSpace(request.GeneratorAgent)
+	agentType := strings.TrimSpace(request.GeneratorType)
+	if agent != "" && agentType != "" {
+		return "", "", errors.New("use only one of --generator-agent or --generator-type")
+	}
+	if agent != "" {
+		return agent, "", nil
+	}
+	if agentType == "" {
+		agentType = "skillopt-generator"
+	}
+	return agentType, agentType, nil
+}
+
+func skillOptTrainGenerationConcurrency(request skillOptTrainContinueRequest, dispatchType string) (int, error) {
+	if strings.TrimSpace(dispatchType) == "" {
+		return 1, nil
+	}
+	types, err := loadAgentTypeConfig(request.Home)
+	if err != nil {
+		return 0, err
+	}
+	agentType, ok := types[dispatchType]
+	if !ok {
+		return 0, fmt.Errorf("agent %q not found", dispatchType)
+	}
+	if agentType.MaxBackground <= 0 {
+		return 1, nil
+	}
+	return agentType.MaxBackground, nil
+}
+
+func skillOptTrainOptionLabels(count int) []string {
+	if count <= 0 {
+		count = 2
+	}
+	labels := make([]string, 0, count)
+	for index := 0; index < count; index++ {
+		if index < 26 {
+			labels = append(labels, string(rune('a'+index)))
+			continue
+		}
+		labels = append(labels, fmt.Sprintf("option-%d", index+1))
+	}
+	return labels
+}
+
+func skillOptTrainGenerationRoles(run db.EvalRun) []string {
+	if !skillOptRunUsesRankedOptions(run) {
+		return []string{"baseline", "candidate"}
+	}
+	return skillOptTrainOptionLabels(run.OptionsCount)
+}
+
+func buildSkillOptTrainGenerationPrompt(session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, item db.EvalReviewItem, role string, rankedRun bool) string {
+	itemMetadata := decodedSkillOptMetadata(item.MetadataJSON)
+	sessionMetadata := decodedSkillOptMetadata(session.MetadataJSON)
+	requestText := metadataString(sessionMetadata, "request")
+	if requestText == "" {
+		requestText = session.RequestSummary
+	}
+	var builder strings.Builder
+	builder.WriteString("Generate one review option for a Gitmoot SkillOpt training run.\n")
+	builder.WriteString("Return the generated artifact content in gitmoot_result.summary with decision implemented. Do not include commentary outside the artifact.\n\n")
+	builder.WriteString("Training request:\n")
+	builder.WriteString(requestText)
+	builder.WriteString("\n\n")
+	builder.WriteString("Session: ")
+	builder.WriteString(session.ID)
+	builder.WriteString("\nIteration: ")
+	builder.WriteString(iteration.ID)
+	builder.WriteString("\nEval run: ")
+	builder.WriteString(run.ID)
+	builder.WriteString("\nMode: ")
+	builder.WriteString(run.Mode)
+	builder.WriteString("\nExploration level: ")
+	builder.WriteString(run.ExplorationLevel)
+	if rankedRun {
+		builder.WriteString("\nOption label: ")
+		builder.WriteString(strings.ToUpper(role))
+	} else {
+		builder.WriteString("\nA/B artifact role: ")
+		builder.WriteString(role)
+	}
+	builder.WriteString("\nItem id: ")
+	builder.WriteString(item.ItemID)
+	builder.WriteString("\nTitle: ")
+	builder.WriteString(item.Title)
+	if brief := metadataString(itemMetadata, "brief"); brief != "" {
+		builder.WriteString("\nBrief: ")
+		builder.WriteString(brief)
+	}
+	if audience := metadataString(itemMetadata, "target_audience"); audience != "" {
+		builder.WriteString("\nTarget audience: ")
+		builder.WriteString(audience)
+	}
+	if outputType := metadataString(itemMetadata, "output_type"); outputType != "" {
+		builder.WriteString("\nOutput type: ")
+		builder.WriteString(outputType)
+	}
+	if hints, ok := itemMetadata["artifact_hints"].([]any); ok && len(hints) > 0 {
+		builder.WriteString("\nArtifact hints:")
+		for _, hint := range hints {
+			if text := strings.TrimSpace(fmt.Sprint(hint)); text != "" {
+				builder.WriteString("\n- ")
+				builder.WriteString(text)
+			}
+		}
+	}
+	builder.WriteString("\n\nGeneration rules:\n")
+	if rankedRun {
+		builder.WriteString("- Make this option meaningfully different from the other labels in layout, content strategy, and visual/interaction direction.\n")
+	} else if role == "baseline" {
+		builder.WriteString("- Generate the baseline artifact: a solid, conventional answer that satisfies the item brief.\n")
+	} else {
+		builder.WriteString("- Generate the candidate artifact: a meaningfully different improved answer intended to be compared against the baseline.\n")
+	}
+	switch run.ExplorationLevel {
+	case db.ExplorationLevelHigh:
+		builder.WriteString("- Use high exploration: vary the product explanation, proof/content structure, and visual direction substantially.\n")
+	case db.ExplorationLevelMedium:
+		builder.WriteString("- Use medium exploration: combine promising directions while keeping alternatives visibly different.\n")
+	case db.ExplorationLevelLow:
+		builder.WriteString("- Use low exploration: make narrow refinements and avoid broad direction changes.\n")
+	}
+	builder.WriteString("- Keep the artifact self-contained and directly reviewable.\n")
+	builder.WriteString("- Preserve the requested output type.\n")
+	return builder.String()
+}
+
+func prepareReviewItemContentArtifact(blobStore artifact.Store, runID string, itemID string, role string, content []byte, mediaType string, driver string) (db.EvalArtifact, error) {
+	if len(content) == 0 || strings.TrimSpace(string(content)) == "" {
+		return db.EvalArtifact{}, fmt.Errorf("%s content is required", role)
+	}
+	blob, err := blobStore.Put(content)
+	if err != nil {
+		return db.EvalArtifact{}, fmt.Errorf("store %s artifact blob: %w", role, err)
+	}
+	if strings.TrimSpace(mediaType) == "" {
+		mediaType = "text/plain"
+	}
+	if strings.TrimSpace(driver) == "" {
+		driver = "text"
+	}
+	return db.EvalArtifact{
+		ID:        reviewItemArtifactID(runID, itemID, role),
+		Hash:      blob.Hash,
+		MediaType: mediaType,
+		SizeBytes: blob.Size,
+		Driver:    driver,
+	}, nil
+}
+
+func skillOptTrainGeneratedOptionMetadata(output localAgentJobOutput, prompt string) string {
+	metadata := map[string]any{
+		"source":           "gitmoot skillopt train continue",
+		"job_id":           output.JobID,
+		"agent":            output.Agent,
+		"prompt":           prompt,
+		"raw_output_count": output.RawOutputCount,
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func skillOptTrainGenerationStrategy(run db.EvalRun) map[string]any {
+	return map[string]any{
+		"mode":              run.Mode,
+		"exploration_level": run.ExplorationLevel,
+		"options_count":     run.OptionsCount,
+	}
+}
+
+func mergeSkillOptTrainMetadata(existing string, key string, value map[string]any) string {
+	metadata := decodedSkillOptMetadata(existing)
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	metadata[key] = value
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return existing
+	}
+	return string(encoded)
+}
+
+func decodedSkillOptMetadata(value string) map[string]any {
+	var metadata map[string]any
+	if strings.TrimSpace(value) != "" {
+		_ = json.Unmarshal([]byte(value), &metadata)
+	}
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	return metadata
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if metadata == nil {
+		return ""
+	}
+	value, ok := metadata[key]
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
 }
 
 func skillOptTrainConfirmCommand(args []string, sessionID string) string {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -6,17 +6,22 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
 	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
 func TestSkillOptExportAndImportCommands(t *testing.T) {
@@ -721,6 +726,967 @@ func TestGeneratedSkillOptTrainSessionIDIncludesSubsecondEntropy(t *testing.T) {
 	if id == second {
 		t.Fatalf("generated session ids collided: %q", id)
 	}
+}
+
+func TestSkillOptTrainContinueGeneratesOptionsWithManagedAgent(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train landing page plans.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440201"}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nHero with strong product narrative.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nDashboard-led layout with proof metrics.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nCheckout analytics proof block.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nLifecycle commerce story with motion notes.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: options_generated",
+		"continue_ready: true",
+		"generated_options: 4",
+		"jobs: 4",
+		"generator_agent: skillopt-generator-bg-",
+		"generator_runtime: codex",
+		"next: publish the human review packet",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train continue stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if len(runner.calls) != 5 {
+		t.Fatalf("runtime calls = %+v, want start plus four deliveries", runner.calls)
+	}
+	runner.want(t, 0, repoDir, "codex", "exec", "--json", "--")
+	runner.want(t, 1, repoDir, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440201", "--")
+	if !strings.Contains(runner.calls[1].args[len(runner.calls[1].args)-1], "Option label: A") || !strings.Contains(runner.calls[1].args[len(runner.calls[1].args)-1], "Generate one review option") {
+		t.Fatalf("generation prompt = %q", runner.calls[1].args[len(runner.calls[1].args)-1])
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateOptionsGenerated || !strings.Contains(iteration.MetadataJSON, `"status":"succeeded"`) || !strings.Contains(iteration.MetadataJSON, `"prompts"`) {
+		t.Fatalf("iteration after continue = %+v metadata=%s", iteration, iteration.MetadataJSON)
+	}
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 4 {
+		t.Fatalf("jobs = %+v, want four generated jobs", jobs)
+	}
+	for _, job := range jobs {
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			t.Fatalf("daemonJobPayload returned error: %v", err)
+		}
+		if payload.Repo != "owner/workspace" {
+			t.Fatalf("generated job repo = %q, want owner/workspace", payload.Repo)
+		}
+	}
+	items, err := store.ListEvalReviewItems(context.Background(), "landing-train-review-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %+v", items)
+	}
+	for _, item := range items {
+		options, err := store.ListEvalReviewOptions(context.Background(), "landing-train-review-001", item.ItemID)
+		if err != nil {
+			t.Fatalf("ListEvalReviewOptions %s returned error: %v", item.ItemID, err)
+		}
+		if len(options) != 2 || options[0].Label != "a" || options[1].Label != "b" {
+			t.Fatalf("options for %s = %+v", item.ItemID, options)
+		}
+		artifactRecord, err := store.GetEvalArtifact(context.Background(), options[0].ArtifactID)
+		if err != nil {
+			t.Fatalf("GetEvalArtifact %s returned error: %v", options[0].ArtifactID, err)
+		}
+		if artifactRecord.MediaType != "text/markdown" || artifactRecord.Driver != "text" || !strings.Contains(options[0].MetadataJSON, `"job_id"`) {
+			t.Fatalf("artifact=%+v option=%+v", artifactRecord, options[0])
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("second train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "continue_ready: false") || !strings.Contains(stdout.String(), "options already generated") {
+		t.Fatalf("second continue stdout = %q", stdout.String())
+	}
+}
+
+func TestSkillOptTrainContinueRejectsNonImplementedGenerationResult(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train landing page plans.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440401"}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"changes_requested","summary":"This is a review finding, not generated content.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"changes_requested","summary":"This is still a review finding, not generated content.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "returned changes_requested, want implemented") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateItemsReady || !strings.Contains(iteration.MetadataJSON, `"status":"failed"`) {
+		t.Fatalf("iteration after failure = %+v metadata=%s", iteration, iteration.MetadataJSON)
+	}
+	options, err := store.ListEvalReviewOptions(context.Background(), "landing-train-review-001", "hero-saas")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 0 {
+		t.Fatalf("non-generation decision persisted options: %+v", options)
+	}
+}
+
+func TestSkillOptTrainContinueRefusesConcurrentGeneration(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train landing page plans.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey: skillOptTrainGenerationLockKey("landing-train", "landing-train-001"),
+		OwnerJobID:  "test-concurrent-continue",
+		OwnerToken:  "test-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+	}, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("AcquireResourceLock returned error: %v", err)
+	}
+	if !acquired {
+		t.Fatal("AcquireResourceLock did not acquire generation lock")
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close before continue returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "skillopt train generation is already running") {
+		t.Fatalf("train continue stderr = %q", stderr.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateItemsReady {
+		t.Fatalf("iteration state = %s, want %s", iteration.State, skillopt.TrainStateItemsReady)
+	}
+	if strings.Contains(iteration.MetadataJSON, `"status":"failed"`) {
+		t.Fatalf("busy generation lock recorded failed metadata: %s", iteration.MetadataJSON)
+	}
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("busy generation lock dispatched jobs: %+v", jobs)
+	}
+}
+
+func TestSkillOptTrainGenerationLockTTLScalesWithWorkload(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "2",
+		"--job-timeout", "45m",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:               "landing-train-review-001",
+		Mode:             db.EvalRunModeExplore,
+		ExplorationLevel: db.ExplorationLevelHigh,
+		OptionsCount:     4,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	for index := 0; index < 7; index++ {
+		itemID := fmt.Sprintf("item-%03d", index+1)
+		if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+			RunID:  "landing-train-review-001",
+			ItemID: itemID,
+			Title:  itemID,
+		}); err != nil {
+			t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+		}
+	}
+	ttl, err := estimateSkillOptTrainGenerationLockTTL(context.Background(), store, skillOptTrainContinueRequest{Home: home, GeneratorType: "skillopt-generator"}, db.SkillOptTrainIteration{
+		EvalRunID: "landing-train-review-001",
+	})
+	if err != nil {
+		t.Fatalf("estimateSkillOptTrainGenerationLockTTL returned error: %v", err)
+	}
+	want := 16*45*time.Minute + skillOptTrainGenerationLockBuffer
+	if ttl != want {
+		t.Fatalf("ttl = %s, want %s", ttl, want)
+	}
+	if ttl <= skillOptTrainGenerationLockTTL {
+		t.Fatalf("ttl = %s, want greater than fixed minimum %s", ttl, skillOptTrainGenerationLockTTL)
+	}
+}
+
+func TestSkillOptTrainContinueRecoversCompleteGeneratedOptions(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train landing page plans.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	items, err := store.ListEvalReviewItems(context.Background(), "landing-train-review-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	writes := make([]db.EvalReviewGenerationWrite, 0, len(items))
+	for _, item := range items {
+		var artifacts []db.EvalArtifact
+		var options []db.EvalReviewOption
+		for _, label := range []string{"a", "b"} {
+			artifactRecord, err := prepareReviewItemContentArtifact(blobStore, "landing-train-review-001", item.ItemID, "option-"+label, []byte("existing option "+label), "text/markdown", "text")
+			if err != nil {
+				t.Fatalf("prepareReviewItemContentArtifact returned error: %v", err)
+			}
+			artifacts = append(artifacts, artifactRecord)
+			options = append(options, db.EvalReviewOption{
+				RunID:      "landing-train-review-001",
+				ItemID:     item.ItemID,
+				Label:      label,
+				ArtifactID: artifactRecord.ID,
+				Role:       "option",
+			})
+		}
+		writes = append(writes, db.EvalReviewGenerationWrite{
+			ItemID:    item.ItemID,
+			Artifacts: artifacts,
+			Options:   options,
+		})
+	}
+	if err := store.ReplaceGeneratedEvalReviewArtifacts(context.Background(), "landing-train-review-001", writes); err != nil {
+		t.Fatalf("ReplaceGeneratedEvalReviewArtifacts returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after generated option seed returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue recovery exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: options_generated") || !strings.Contains(stdout.String(), "generated_options: 4") {
+		t.Fatalf("train continue recovery stdout = %s", stdout.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateOptionsGenerated || !strings.Contains(iteration.MetadataJSON, `"status":"recovered"`) {
+		t.Fatalf("iteration after recovery = %+v metadata=%s", iteration, iteration.MetadataJSON)
+	}
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("recovery should not create generation jobs: %+v", jobs)
+	}
+}
+
+func TestSkillOptTrainContinueUsesManagedGeneratorConcurrency(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "2",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train landing page plans.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	runner := &skillOptConcurrentGenerationRunner{startDelay: 300 * time.Millisecond}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: options_generated") || !strings.Contains(stdout.String(), "generated_options: 4") {
+		t.Fatalf("train continue stdout = %s", stdout.String())
+	}
+	if runner.maxActiveResumes < 2 {
+		t.Fatalf("max active resume calls = %d, want at least 2; calls=%+v", runner.maxActiveResumes, runner.calls)
+	}
+	if runner.startCalls < 2 {
+		t.Fatalf("start calls = %d, want at least two managed instances", runner.startCalls)
+	}
+}
+
+func TestSkillOptTrainContinueUsesRegisteredWorkspaceRepoCheckout(t *testing.T) {
+	home := t.TempDir()
+	targetDir := t.TempDir()
+	runGit(t, targetDir, "init")
+	runGit(t, targetDir, "branch", "-m", "main")
+	runGit(t, targetDir, "remote", "add", "origin", "https://github.com/owner/product.git")
+	workspaceDir := t.TempDir()
+	runGit(t, workspaceDir, "init")
+	runGit(t, workspaceDir, "branch", "-m", "main")
+	runGit(t, workspaceDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(targetDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train landing page plans.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue without workspace checkout exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "gitmoot repo add owner/workspace --path /path/to/checkout") {
+		t.Fatalf("stderr did not explain workspace registration:\n%s", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"repo", "add", "owner/workspace", "--home", home, "--path", workspaceDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("repo add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440401"}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nWorkspace hero A.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nWorkspace hero B.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nWorkspace proof A.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nWorkspace proof B.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue with workspace checkout exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: options_generated") {
+		t.Fatalf("train continue stdout = %s", stdout.String())
+	}
+	runner.want(t, 0, workspaceDir, "codex", "exec", "--json", "--")
+}
+
+func TestBuildSkillOptTrainGenerationPromptHonorsExplicitLowExploration(t *testing.T) {
+	prompt := buildSkillOptTrainGenerationPrompt(
+		db.SkillOptTrainSession{
+			ID:             "landing-train",
+			RequestSummary: "Train landing page outputs.",
+		},
+		db.SkillOptTrainIteration{ID: "landing-train-001"},
+		db.EvalRun{
+			ID:               "landing-train-review-001",
+			Mode:             db.EvalRunModeExplore,
+			ExplorationLevel: db.ExplorationLevelLow,
+			OptionsCount:     4,
+		},
+		db.EvalReviewItem{
+			ItemID: "hero-saas",
+			Title:  "SaaS hero",
+		},
+		"a",
+		true,
+	)
+	if strings.Contains(prompt, "Use high exploration") {
+		t.Fatalf("low exploration prompt included high exploration rule:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Use low exploration") {
+		t.Fatalf("low exploration prompt missing low exploration rule:\n%s", prompt)
+	}
+}
+
+func TestSkillOptTrainContinueGeneratesValidateArtifacts(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "validate-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train validation comparisons.",
+		"--mode", "validate",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440301"}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Baseline\n\nConventional hero.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Candidate\n\nImproved hero.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Baseline\n\nConventional proof.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Candidate\n\nImproved proof.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "validate-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: options_generated",
+		"generated_options: 4",
+		"generator_runtime: codex",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train continue stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if len(runner.calls) != 5 {
+		t.Fatalf("runtime calls = %+v, want start plus four deliveries", runner.calls)
+	}
+	if !strings.Contains(runner.calls[1].args[len(runner.calls[1].args)-1], "A/B artifact role: baseline") {
+		t.Fatalf("baseline prompt = %q", runner.calls[1].args[len(runner.calls[1].args)-1])
+	}
+	if !strings.Contains(runner.calls[2].args[len(runner.calls[2].args)-1], "A/B artifact role: candidate") {
+		t.Fatalf("candidate prompt = %q", runner.calls[2].args[len(runner.calls[2].args)-1])
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	items, err := store.ListEvalReviewItems(context.Background(), "validate-train-review-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %+v", items)
+	}
+	for _, item := range items {
+		if item.BaselineArtifactID == "" || item.CandidateArtifactID == "" {
+			t.Fatalf("validate item missing A/B artifacts: %+v", item)
+		}
+		options, err := store.ListEvalReviewOptions(context.Background(), "validate-train-review-001", item.ItemID)
+		if err != nil {
+			t.Fatalf("ListEvalReviewOptions %s returned error: %v", item.ItemID, err)
+		}
+		if len(options) != 0 {
+			t.Fatalf("validate item should not have ranked options: %+v", options)
+		}
+		if _, err := store.GetEvalArtifact(context.Background(), item.BaselineArtifactID); err != nil {
+			t.Fatalf("GetEvalArtifact baseline returned error: %v", err)
+		}
+		if _, err := store.GetEvalArtifact(context.Background(), item.CandidateArtifactID); err != nil {
+			t.Fatalf("GetEvalArtifact candidate returned error: %v", err)
+		}
+	}
+}
+
+func TestSkillOptTrainContinueRecordsGenerationFailureWithoutOptions(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train landing page plans.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue without generator exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `agent "skillopt-generator" not found`) {
+		t.Fatalf("continue failure stderr = %q", stderr.String())
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateItemsReady || !strings.Contains(iteration.MetadataJSON, `"status":"failed"`) {
+		t.Fatalf("iteration after failure = %+v metadata=%s", iteration, iteration.MetadataJSON)
+	}
+	items, err := store.ListEvalReviewItems(context.Background(), "landing-train-review-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	for _, item := range items {
+		options, err := store.ListEvalReviewOptions(context.Background(), "landing-train-review-001", item.ItemID)
+		if err != nil {
+			t.Fatalf("ListEvalReviewOptions %s returned error: %v", item.ItemID, err)
+		}
+		if len(options) != 0 {
+			t.Fatalf("failure persisted options for %s: %+v", item.ItemID, options)
+		}
+	}
+}
+
+type skillOptConcurrentGenerationRunner struct {
+	mu               sync.Mutex
+	calls            []agentStartCall
+	startCalls       int
+	activeResumes    int
+	maxActiveResumes int
+	startDelay       time.Duration
+}
+
+func (r *skillOptConcurrentGenerationRunner) Run(_ context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, agentStartCall{dir: dir, command: command, args: append([]string{}, args...)})
+	isResume := false
+	isStart := false
+	for _, arg := range args {
+		if arg == "resume" {
+			isResume = true
+		}
+		if arg == "--json" {
+			isStart = true
+		}
+	}
+	if isStart && !isResume {
+		r.startCalls++
+		threadID := fmt.Sprintf("550e8400-e29b-41d4-a716-%012d", 446655440500+r.startCalls)
+		startDelay := r.startDelay
+		r.mu.Unlock()
+		if startDelay > 0 {
+			time.Sleep(startDelay)
+		}
+		return subprocess.Result{Command: command, Args: args, Stdout: fmt.Sprintf(`{"type":"thread.started","thread_id":"%s"}`+"\n", threadID)}, nil
+	}
+	if isResume {
+		r.activeResumes++
+		if r.activeResumes > r.maxActiveResumes {
+			r.maxActiveResumes = r.activeResumes
+		}
+		r.mu.Unlock()
+		time.Sleep(750 * time.Millisecond)
+		r.mu.Lock()
+		r.activeResumes--
+		r.mu.Unlock()
+		prompt := ""
+		if len(args) > 0 {
+			prompt = args[len(args)-1]
+		}
+		summary := "# Generated option\n\n" + strings.Split(prompt, "\n")[0]
+		return subprocess.Result{Command: command, Args: args, Stdout: fmt.Sprintf(`{"gitmoot_result":{"decision":"implemented","summary":%q,"findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`+"\n", summary)}, nil
+	}
+	r.mu.Unlock()
+	return subprocess.Result{Command: command, Args: args}, nil
+}
+
+func (r *skillOptConcurrentGenerationRunner) LookPath(file string) (string, error) {
+	if file == "" {
+		return "", errors.New("empty file")
+	}
+	return "/usr/bin/" + file, nil
+}
+
+func writeSkillOptTrainItemsFile(t *testing.T) string {
+	t.Helper()
+	itemsPath := filepath.Join(t.TempDir(), "items.yml")
+	if err := os.WriteFile(itemsPath, []byte(`items:
+  - item_id: hero-saas
+    title: SaaS hero
+    brief: Design a landing page hero for a workflow SaaS product.
+    target_audience: founders
+    output_type: vue landing page
+    artifact_hints:
+      - clickable preview
+  - item_id: ecommerce-proof
+    title: Ecommerce proof section
+    brief: Design a social proof section for an ecommerce analytics product.
+    target_audience: growth teams
+    output_type: vue landing page
+`), 0o644); err != nil {
+		t.Fatalf("write items file: %v", err)
+	}
+	return itemsPath
 }
 
 func TestSkillOptTrainStartDryRunDoesNotInitializeFreshHome(t *testing.T) {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -261,6 +261,13 @@ type EvalReviewOption struct {
 	UpdatedAt    string
 }
 
+type EvalReviewGenerationWrite struct {
+	ItemID     string
+	ReviewItem *EvalReviewItem
+	Artifacts  []EvalArtifact
+	Options    []EvalReviewOption
+}
+
 type FeedbackEvent struct {
 	ID        string
 	RunID     string
@@ -1230,6 +1237,14 @@ func (s *Store) MarkAgentInstanceRunning(ctx context.Context, name string, now t
 	return requireAffected(result, "agent instance", name)
 }
 
+func (s *Store) DeleteAgentInstance(ctx context.Context, name string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM agent_instances WHERE name = ?`, strings.TrimSpace(name))
+	if err != nil {
+		return err
+	}
+	return requireAffected(result, "agent instance", name)
+}
+
 func (s *Store) DeleteExpiredAgentInstances(ctx context.Context, now time.Time) (int64, error) {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM agent_instances
 		WHERE state = 'idle'
@@ -1743,6 +1758,22 @@ func (s *Store) UpsertEvalArtifact(ctx context.Context, artifact EvalArtifact) e
 	return err
 }
 
+func upsertEvalArtifactTx(ctx context.Context, tx *sql.Tx, artifact EvalArtifact) error {
+	artifact, err := normalizeEvalArtifact(artifact)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO eval_artifacts(id, hash, media_type, size_bytes, driver, created_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			hash = excluded.hash,
+			media_type = excluded.media_type,
+			size_bytes = excluded.size_bytes,
+			driver = excluded.driver`,
+		artifact.ID, artifact.Hash, artifact.MediaType, artifact.SizeBytes, artifact.Driver)
+	return err
+}
+
 func insertEvalArtifactTx(ctx context.Context, tx *sql.Tx, artifact EvalArtifact) error {
 	artifact, err := normalizeEvalArtifact(artifact)
 	if err != nil {
@@ -2071,6 +2102,112 @@ func (s *Store) UpsertEvalReviewItem(ctx context.Context, item EvalReviewItem) e
 		item.ID, item.RunID, item.ItemID, item.Title, item.SourceArtifactID, item.BaselineArtifactID, item.CandidateArtifactID,
 		item.PreviewArtifactID, item.DiffArtifactID, item.MetadataJSON)
 	return err
+}
+
+func (s *Store) ReplaceGeneratedEvalReviewArtifacts(ctx context.Context, runID string, writes []EvalReviewGenerationWrite) error {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return errors.New("eval review generation run id is required")
+	}
+	normalized := make([]EvalReviewGenerationWrite, 0, len(writes))
+	for _, write := range writes {
+		itemID := strings.TrimSpace(write.ItemID)
+		if itemID == "" && write.ReviewItem != nil {
+			itemID = strings.TrimSpace(write.ReviewItem.ItemID)
+		}
+		if itemID == "" {
+			return errors.New("eval review generation item id is required")
+		}
+		next := EvalReviewGenerationWrite{ItemID: itemID}
+		for _, artifact := range write.Artifacts {
+			artifact, err := normalizeEvalArtifact(artifact)
+			if err != nil {
+				return err
+			}
+			next.Artifacts = append(next.Artifacts, artifact)
+		}
+		if write.ReviewItem != nil {
+			item := *write.ReviewItem
+			item.RunID = runID
+			item.ItemID = itemID
+			if strings.TrimSpace(item.ID) == "" {
+				item.ID = item.RunID + "/" + item.ItemID
+			}
+			if strings.TrimSpace(item.RunID) == "" {
+				return errors.New("eval review item run id is required")
+			}
+			if strings.TrimSpace(item.ItemID) == "" {
+				return errors.New("eval review item id is required")
+			}
+			next.ReviewItem = &item
+		}
+		seen := map[string]struct{}{}
+		for _, option := range write.Options {
+			option.RunID = runID
+			option.ItemID = itemID
+			option, err := normalizeEvalReviewOption(option)
+			if err != nil {
+				return err
+			}
+			if _, ok := seen[option.Label]; ok {
+				return fmt.Errorf("eval review option label %q is duplicated for item %q", option.Label, itemID)
+			}
+			seen[option.Label] = struct{}{}
+			next.Options = append(next.Options, option)
+		}
+		normalized = append(normalized, next)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, write := range normalized {
+		for _, artifact := range write.Artifacts {
+			if err := upsertEvalArtifactTx(ctx, tx, artifact); err != nil {
+				return err
+			}
+		}
+		if write.ReviewItem != nil {
+			item := *write.ReviewItem
+			if _, err := tx.ExecContext(ctx, `INSERT INTO eval_review_items(
+					id, run_id, item_id, title, source_artifact_id, baseline_artifact_id, candidate_artifact_id,
+					preview_artifact_id, diff_artifact_id, metadata_json, created_at, updated_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+				ON CONFLICT(id) DO UPDATE SET
+					run_id = excluded.run_id,
+					item_id = excluded.item_id,
+					title = excluded.title,
+					source_artifact_id = excluded.source_artifact_id,
+					baseline_artifact_id = excluded.baseline_artifact_id,
+					candidate_artifact_id = excluded.candidate_artifact_id,
+					preview_artifact_id = excluded.preview_artifact_id,
+					diff_artifact_id = excluded.diff_artifact_id,
+					metadata_json = excluded.metadata_json,
+					updated_at = CURRENT_TIMESTAMP`,
+				item.ID, item.RunID, item.ItemID, item.Title, item.SourceArtifactID, item.BaselineArtifactID, item.CandidateArtifactID,
+				item.PreviewArtifactID, item.DiffArtifactID, item.MetadataJSON); err != nil {
+				return err
+			}
+		}
+		if len(write.Options) == 0 {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM eval_review_options WHERE run_id = ? AND item_id = ?`, runID, write.ItemID); err != nil {
+			return err
+		}
+		for _, option := range write.Options {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO eval_review_options(
+					id, run_id, item_id, label, artifact_id, role, metadata_json, created_at, updated_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+				option.ID, option.RunID, option.ItemID, option.Label, option.ArtifactID, option.Role, option.MetadataJSON); err != nil {
+				return err
+			}
+		}
+	}
+	return tx.Commit()
 }
 
 func (s *Store) ListEvalReviewItems(ctx context.Context, runID string) ([]EvalReviewItem, error) {

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -510,6 +510,60 @@ func TestRankedReviewStorageRejectsOptionCountMismatch(t *testing.T) {
 	}
 }
 
+func TestReplaceGeneratedEvalReviewArtifactsRollsBackBatch(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	err = store.ReplaceGeneratedEvalReviewArtifacts(ctx, "run-generated", []EvalReviewGenerationWrite{
+		{
+			ItemID: "item-001",
+			Artifacts: []EvalArtifact{{
+				ID:        "run-generated/item-001/option-a",
+				Hash:      "sha256:aaa",
+				MediaType: "text/markdown",
+				SizeBytes: 12,
+				Driver:    "text",
+			}},
+			Options: []EvalReviewOption{{
+				Label:      "a",
+				ArtifactID: "run-generated/item-001/option-a",
+				Role:       "option",
+			}},
+		},
+		{
+			ItemID: "item-002",
+			Artifacts: []EvalArtifact{{
+				ID:        "run-generated/item-002/option-a",
+				Hash:      "sha256:bbb",
+				MediaType: "text/markdown",
+				SizeBytes: 12,
+				Driver:    "text",
+			}},
+			Options: []EvalReviewOption{{
+				Label: "a",
+				Role:  "option",
+			}},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "artifact id is required") {
+		t.Fatalf("ReplaceGeneratedEvalReviewArtifacts error = %v", err)
+	}
+	if _, err := store.GetEvalArtifact(ctx, "run-generated/item-001/option-a"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetEvalArtifact after rollback error = %v, want sql.ErrNoRows", err)
+	}
+	options, err := store.ListEvalReviewOptions(ctx, "run-generated", "item-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 0 {
+		t.Fatalf("options after rollback = %+v", options)
+	}
+}
+
 func TestFeedbackEventMethods(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
WHAT:
- Adds Task 4 train continuation behavior so `gitmoot skillopt train continue` can generate review artifacts from temporary Gitmoot-managed agents.

WHY:
- SkillOpt train mode needs generated review options before publishing human feedback packets, and generation must be reproducible, artifact-backed, concurrency-aware, and safe under managed runtime locks.

CHANGES:
- Adds `--generator-type` and `--generator-agent` support for train continuation.
- Dispatches temporary managed agents synchronously for generated options and records prompts, job IDs, runtime, concurrency, lock TTL, artifacts, and failures in train metadata.
- Adds generation locking with workload-derived TTLs to prevent duplicate concurrent generation during long runs.
- Persists generated review artifacts and ranked options atomically through a new DB batch helper.
- Keeps managed sync agent instances reserved until their job is queued, uses managed job timeout for runtime locks, and supports concurrent managed generators up to `max_background`.
- Adds failure, idempotency, recovery, workspace-checkout, validation/A-B, concurrency, and lock TTL tests.

RESULTS:
- `git diff --check`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrainContinue|SkillOptTrainGenerationLockTTL|DispatchManagedSyncUsesJobTimeoutForRuntimeLock|EnsureManagedAgentInstanceKeepsNewInstanceReservedUntilRelease' -timeout 240s`\n- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli ./internal/runtime ./internal/workflow ./internal/skillopt ./internal/db -timeout 5m`\n- `GOTOOLCHAIN=go1.26.2 go test ./... -timeout 8m`\n- Final `codex exec review --uncommitted` raw output:\n\n```text\nNo discrete, actionable correctness issues were found in the staged/unstaged/untracked changes. Go tests could not be executed in this sandbox because the required Go 1.26 toolchain download is blocked, so confidence is limited to static review.\n```\n\nRISK:\n- The final Codex review sandbox could not execute Go tests with `GOTOOLCHAIN=local` because the sandbox has Go 1.22.2 and the repo requires Go 1.26. Local verification used `GOTOOLCHAIN=go1.26.2` and passed.\n- `GOAL-SKILLOPT-TRAIN-ORCHESTRATION.md` remains untracked and intentionally is not part of this PR.\n