### PR TITLE
feat(skillopt): add train feedback quality signals

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -288,6 +288,9 @@ type RankedFeedbackEvent struct {
 	Winner             string
 	UsefulTraitsJSON   string
 	RejectedTraitsJSON string
+	Quality            string
+	ContinueMode       string
+	Promote            string
 	Reasoning          string
 	Reviewer           string
 	Source             string
@@ -2073,6 +2076,18 @@ func (s *Store) GetLatestSkillOptTrainIteration(ctx context.Context, sessionID s
 	return scanSkillOptTrainIteration(row)
 }
 
+func (s *Store) GetSkillOptTrainIterationByEvalRun(ctx context.Context, evalRunID string) (SkillOptTrainIteration, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, session_id, eval_run_id, base_template_version_id,
+			candidate_version_id, mode, exploration_level, state, issue_repo, issue_number,
+			issue_url, pull_request_repo, pull_request_number, pull_request_url, decision_reason, metadata_json,
+			created_at, updated_at
+		FROM skillopt_train_iterations
+		WHERE eval_run_id = ?
+		ORDER BY rowid DESC
+		LIMIT 1`, strings.TrimSpace(evalRunID))
+	return scanSkillOptTrainIteration(row)
+}
+
 func (s *Store) UpsertEvalReviewItem(ctx context.Context, item EvalReviewItem) error {
 	if strings.TrimSpace(item.ID) == "" {
 		item.ID = item.RunID + "/" + item.ItemID
@@ -2472,22 +2487,25 @@ func (s *Store) UpsertRankedFeedbackEvent(ctx context.Context, event RankedFeedb
 	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO ranked_feedback_events(
 			id, run_id, item_id, ranking_json, winner, useful_traits_json, rejected_traits_json,
-			reasoning, reviewer, source, source_url, created_at
+			quality, continue_mode, promote, reasoning, reviewer, source, source_url, created_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(run_id, item_id, reviewer, source, source_url) DO UPDATE SET
 			id = excluded.id,
 			ranking_json = excluded.ranking_json,
 			winner = excluded.winner,
 			useful_traits_json = excluded.useful_traits_json,
 			rejected_traits_json = excluded.rejected_traits_json,
+			quality = excluded.quality,
+			continue_mode = excluded.continue_mode,
+			promote = excluded.promote,
 			reasoning = excluded.reasoning,
 			reviewer = excluded.reviewer,
 			source = excluded.source,
 			source_url = excluded.source_url,
 			created_at = excluded.created_at`,
 		event.ID, event.RunID, event.ItemID, event.RankingJSON, event.Winner, event.UsefulTraitsJSON, event.RejectedTraitsJSON,
-		event.Reasoning, event.Reviewer, event.Source, event.SourceURL, event.CreatedAt)
+		event.Quality, event.ContinueMode, event.Promote, event.Reasoning, event.Reviewer, event.Source, event.SourceURL, event.CreatedAt)
 	return err
 }
 
@@ -2587,6 +2605,18 @@ func normalizeRankedFeedbackEvent(event RankedFeedbackEvent) (RankedFeedbackEven
 	}
 	event.UsefulTraitsJSON = strings.TrimSpace(event.UsefulTraitsJSON)
 	event.RejectedTraitsJSON = strings.TrimSpace(event.RejectedTraitsJSON)
+	event.Quality = normalizeRankedFeedbackQuality(event.Quality)
+	if event.Quality == "__invalid__" {
+		return RankedFeedbackEvent{}, errors.New("ranked feedback quality must be one of poor, acceptable, or strong")
+	}
+	event.ContinueMode = normalizeRankedFeedbackContinueMode(event.ContinueMode)
+	if event.ContinueMode == "__invalid__" {
+		return RankedFeedbackEvent{}, errors.New("ranked feedback continue_mode must be one of explore, refine, distill, or validate")
+	}
+	event.Promote = normalizeRankedFeedbackPromote(event.Promote)
+	if event.Promote == "__invalid__" {
+		return RankedFeedbackEvent{}, errors.New("ranked feedback promote must be yes or no")
+	}
 	event.Reasoning = strings.TrimSpace(event.Reasoning)
 	event.Reviewer = strings.TrimSpace(event.Reviewer)
 	if event.Reviewer == "" {
@@ -2604,6 +2634,38 @@ func normalizeRankedFeedbackEvent(event RankedFeedbackEvent) (RankedFeedbackEven
 		event.ID = rankedFeedbackEventID(event)
 	}
 	return event, nil
+}
+
+func normalizeRankedFeedbackQuality(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "":
+		return ""
+	case "poor", "acceptable", "strong":
+		return strings.TrimSpace(strings.ToLower(value))
+	}
+	return "__invalid__"
+}
+
+func normalizeRankedFeedbackContinueMode(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "":
+		return ""
+	case EvalRunModeExplore, EvalRunModeRefine, EvalRunModeDistill, EvalRunModeValidate:
+		return strings.TrimSpace(strings.ToLower(value))
+	}
+	return "__invalid__"
+}
+
+func normalizeRankedFeedbackPromote(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "":
+		return ""
+	case "yes", "y", "true":
+		return "yes"
+	case "no", "n", "false":
+		return "no"
+	}
+	return "__invalid__"
 }
 
 func rankedFeedbackRanking(event RankedFeedbackEvent) ([]string, error) {
@@ -2631,7 +2693,7 @@ func rankedFeedbackRanking(event RankedFeedbackEvent) ([]string, error) {
 
 func (s *Store) ListRankedFeedbackEvents(ctx context.Context, runID string) ([]RankedFeedbackEvent, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, run_id, item_id, ranking_json, winner, useful_traits_json, rejected_traits_json,
-			reasoning, reviewer, source, source_url, created_at
+			quality, continue_mode, promote, reasoning, reviewer, source, source_url, created_at
 		FROM ranked_feedback_events WHERE run_id = ? ORDER BY item_id, reviewer, source, source_url`, strings.TrimSpace(runID))
 	if err != nil {
 		return nil, err
@@ -2651,7 +2713,7 @@ func (s *Store) ListRankedFeedbackEvents(ctx context.Context, runID string) ([]R
 func scanRankedFeedbackEvent(row interface{ Scan(dest ...any) error }) (RankedFeedbackEvent, error) {
 	var event RankedFeedbackEvent
 	if err := row.Scan(&event.ID, &event.RunID, &event.ItemID, &event.RankingJSON, &event.Winner, &event.UsefulTraitsJSON, &event.RejectedTraitsJSON,
-		&event.Reasoning, &event.Reviewer, &event.Source, &event.SourceURL, &event.CreatedAt); err != nil {
+		&event.Quality, &event.ContinueMode, &event.Promote, &event.Reasoning, &event.Reviewer, &event.Source, &event.SourceURL, &event.CreatedAt); err != nil {
 		return RankedFeedbackEvent{}, err
 	}
 	return event, nil
@@ -3614,5 +3676,10 @@ CREATE TABLE skillopt_train_iterations (
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	UNIQUE(session_id, id)
 );
+	`,
+	`
+ALTER TABLE ranked_feedback_events ADD COLUMN quality TEXT NOT NULL DEFAULT '';
+ALTER TABLE ranked_feedback_events ADD COLUMN continue_mode TEXT NOT NULL DEFAULT '';
+ALTER TABLE ranked_feedback_events ADD COLUMN promote TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -363,6 +363,9 @@ func TestRankedReviewStorageAndPairwisePreferences(t *testing.T) {
 		Winner:             "c",
 		UsefulTraitsJSON:   string(useful),
 		RejectedTraitsJSON: string(rejected),
+		Quality:            "Poor",
+		ContinueMode:       "Explore",
+		Promote:            "false",
 		Reasoning:          "C is clearest.",
 		Reviewer:           "jerry",
 		Source:             "github",
@@ -378,6 +381,9 @@ func TestRankedReviewStorageAndPairwisePreferences(t *testing.T) {
 	}
 	if len(stored) != 1 || stored[0].Winner != "c" || stored[0].ID == "" {
 		t.Fatalf("stored ranked feedback = %+v", stored)
+	}
+	if stored[0].Quality != "poor" || stored[0].ContinueMode != "explore" || stored[0].Promote != "no" {
+		t.Fatalf("stored ranked feedback signals = %+v", stored[0])
 	}
 	pairs, err := store.ListPairwisePreferences(ctx, "run-ranked")
 	if err != nil {
@@ -461,6 +467,18 @@ func TestRankedReviewStorageRejectsInvalidReferences(t *testing.T) {
 		"unknown useful trait option": {
 			RankingJSON:      `["a","b","c"]`,
 			UsefulTraitsJSON: `{"d":["motion"]}`,
+		},
+		"invalid quality": {
+			RankingJSON: `["a","b","c"]`,
+			Quality:     "ok",
+		},
+		"invalid continue mode": {
+			RankingJSON:  `["a","b","c"]`,
+			ContinueMode: "widen",
+		},
+		"invalid promote": {
+			RankingJSON: `["a","b","c"]`,
+			Promote:     "maybe",
 		},
 	}
 	for name, event := range tests {

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -120,9 +120,20 @@ func (c GitHubCollector) rankedBody(ctx context.Context, store *db.Store, run db
 	var builder strings.Builder
 	builder.WriteString(githubFeedbackPacketMarker + "\n")
 	fmt.Fprintf(&builder, "# Gitmoot SkillOpt Feedback: %s\n\n", run.ID)
-	builder.WriteString("Rank every option for each item from best to worst. Use the option labels exactly as shown.\n\n")
+	if iteration, err := store.GetSkillOptTrainIterationByEvalRun(ctx, run.ID); err == nil {
+		fmt.Fprintf(&builder, "- Train session: `%s`\n", iteration.SessionID)
+		fmt.Fprintf(&builder, "- Train iteration: `%s`\n", iteration.ID)
+	}
+	builder.WriteString("- Compare each item across the option links below.\n")
+	builder.WriteString("- Rank every option from best to worst using the exact labels shown.\n")
+	builder.WriteString("- Optional `quality`, `continue_mode`, and `promote` fields help Gitmoot decide whether to explore more, refine, validate, or promote.\n\n")
 	writePhaseRecommendation(&builder, recommendation)
-	builder.WriteString("Reply in a comment with this format:\n\n")
+	builder.WriteString("## Review Table\n\n")
+	writeGitHubRankedReviewTable(&builder, items, assignments)
+	if err := c.writeUnlinkedRankedOptionContent(ctx, store, &builder, items, assignments); err != nil {
+		return "", err
+	}
+	builder.WriteString("## Copy-Paste YAML Reply\n\n")
 	builder.WriteString("```yaml\n")
 	replyYAML, err := rankedReplyYAML(run.ID, items, assignments)
 	if err != nil {
@@ -130,22 +141,64 @@ func (c GitHubCollector) rankedBody(ctx context.Context, store *db.Store, run db
 	}
 	builder.WriteString(replyYAML)
 	builder.WriteString("```\n\n")
-	builder.WriteString("## Items\n")
+	return builder.String(), nil
+}
+
+func (c GitHubCollector) writeUnlinkedRankedOptionContent(ctx context.Context, store *db.Store, builder *strings.Builder, items []db.EvalReviewItem, assignments map[string]githubAssignment) error {
+	wroteHeader := false
 	for _, item := range items {
 		assignment := assignments[item.ItemID]
-		fmt.Fprintf(&builder, "\n### %s\n\n", itemTitle(item))
-		writeGitHubOptionReferenceTable(&builder, assignment.Options)
+		wroteItem := false
 		for _, option := range assignment.Options {
+			if optionReference(option, false) != "" {
+				continue
+			}
 			content, err := c.optionText(ctx, store, option.ArtifactID)
 			if err != nil {
-				return "", fmt.Errorf("item %s option %s: %w", item.ItemID, option.Label, err)
+				return fmt.Errorf("item %s option %s: %w", item.ItemID, option.Label, err)
 			}
-			fmt.Fprintf(&builder, "#### Option %s\n\n", displayOptionLabel(option.Label))
-			writeMarkdownFence(&builder, content)
+			if !wroteHeader {
+				builder.WriteString("## Inline Options Without Public Links\n\n")
+				builder.WriteString("These options do not have preview URLs yet, so their content is included here to keep the review actionable.\n\n")
+				wroteHeader = true
+			}
+			if !wroteItem {
+				fmt.Fprintf(builder, "### %s\n\n", itemTitle(item))
+				wroteItem = true
+			}
+			fmt.Fprintf(builder, "#### Option %s\n\n", displayOptionLabel(option.Label))
+			writeMarkdownFence(builder, content)
 			builder.WriteString("\n")
 		}
 	}
-	return builder.String(), nil
+	return nil
+}
+
+func writeGitHubRankedReviewTable(builder *strings.Builder, items []db.EvalReviewItem, assignments map[string]githubAssignment) {
+	builder.WriteString("| Item | What to compare | Options |\n")
+	builder.WriteString("| --- | --- | --- |\n")
+	for _, item := range items {
+		assignment := assignments[item.ItemID]
+		optionRefs := make([]string, 0, len(assignment.Options))
+		for _, option := range assignment.Options {
+			ref := optionReference(option, false)
+			if ref == "" {
+				ref = "`" + strings.ReplaceAll(option.ArtifactID, "`", "") + "`"
+			}
+			optionRefs = append(optionRefs, fmt.Sprintf("Option %s: %s", displayOptionLabel(option.Label), ref))
+		}
+		fmt.Fprintf(builder, "| `%s` | %s | %s |\n", item.ItemID, markdownTableCell(itemTitle(item)), markdownTableCell(strings.Join(optionRefs, "<br>")))
+	}
+	builder.WriteString("\n")
+}
+
+func markdownTableCell(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "\n", " ")
+	value = strings.ReplaceAll(value, "|", "\\|")
+	if value == "" {
+		return "-"
+	}
+	return value
 }
 
 func rankedReplyYAML(runID string, items []db.EvalReviewItem, assignments map[string]githubAssignment) (string, error) {
@@ -157,9 +210,12 @@ func rankedReplyYAML(runID string, items []db.EvalReviewItem, assignments map[st
 	for _, item := range items {
 		labels := displayOptionLabels(assignments[item.ItemID].Options)
 		packet.Items = append(packet.Items, feedbackFileEntry{
-			ItemID:    item.ItemID,
-			Ranking:   []string{fmt.Sprintf("<replace with ranked option labels, e.g. %s>", strings.Join(labels, " > "))},
-			Reasoning: "",
+			ItemID:       item.ItemID,
+			Ranking:      []string{fmt.Sprintf("<replace with ranked option labels, e.g. %s>", strings.Join(labels, " > "))},
+			Quality:      "",
+			ContinueMode: "",
+			Promote:      "",
+			Reasoning:    "",
 		})
 	}
 	content, err := yaml.Marshal(packet)
@@ -207,7 +263,7 @@ func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, ru
 	for _, comment := range comments {
 		parsed, ok, err := ParseGitHubFeedbackComment(comment.Body)
 		if err != nil {
-			return ImportResult{}, fmt.Errorf("comment %d: %w", comment.ID, err)
+			return ImportResult{}, fmt.Errorf("comment %d: %w", comment.ID, feedbackImportErrorHint(err))
 		}
 		if !ok {
 			continue
@@ -247,7 +303,7 @@ func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, ru
 			if len(assignment.Options) > 0 {
 				event, err := rankedFeedbackEventFromEntry(runID, itemID, entry, assignment, reviewer, SourceGitHub, sourceURL, createdAt)
 				if err != nil {
-					return ImportResult{}, fmt.Errorf("comment %d item %s: %w", comment.ID, itemID, err)
+					return ImportResult{}, fmt.Errorf("comment %d item %s: %w", comment.ID, itemID, feedbackImportErrorHint(err))
 				}
 				commentRankedEvents = append(commentRankedEvents, event)
 				continue
@@ -405,7 +461,10 @@ func parseFullYAMLFeedback(content string) (feedbackFile, bool, error) {
 
 var shortFeedbackLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s*:\s*([A-Za-z]+)(?:\s*-\s*(.*))?$`)
 var shortRankingLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s+ranking\s*:\s*(.+)$`)
+var shortDirectRankingLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s*:\s*([A-Za-z][A-Za-z0-9._/-]*(?:\s*(?:>|,|\|)\s*[A-Za-z][A-Za-z0-9._/-]*)+)(?:\s*-\s*(.*))?$`)
 var shortMetadataLine = regexp.MustCompile(`^(run_id|reviewer)\s*:\s*(.+)$`)
+var shortItemSignalLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s+(quality|continue_mode|promote)\s*:\s*(.+)$`)
+var shortBareSignalLine = regexp.MustCompile(`^(quality|continue_mode|promote)\s*:\s*(.+)$`)
 var shortTraitHeaderLine = regexp.MustCompile(`^(best traits|useful traits|reject|rejected traits)\s*:\s*$`)
 var shortTraitLine = regexp.MustCompile(`^-\s*([^:]+):\s*(.+)$`)
 
@@ -428,6 +487,16 @@ func parseShortFormFeedback(content string) (feedbackFile, bool, error) {
 			case "reviewer":
 				parsed.Reviewer = strings.TrimSpace(match[2])
 			}
+			continue
+		}
+		if match := shortItemSignalLine.FindStringSubmatch(line); match != nil {
+			if index := findFeedbackItemIndex(parsed.Items, strings.TrimSpace(match[1])); index >= 0 {
+				setFeedbackItemSignal(&parsed.Items[index], match[2], match[3])
+			}
+			continue
+		}
+		if match := shortBareSignalLine.FindStringSubmatch(line); match != nil && traitItemIndex >= 0 {
+			setFeedbackItemSignal(&parsed.Items[traitItemIndex], match[1], match[2])
 			continue
 		}
 		if match := shortTraitHeaderLine.FindStringSubmatch(strings.ToLower(line)); match != nil {
@@ -474,6 +543,16 @@ func parseShortFormFeedback(content string) (feedbackFile, bool, error) {
 			traitTarget = ""
 			continue
 		}
+		if match := shortDirectRankingLine.FindStringSubmatch(line); match != nil {
+			parsed.Items = append(parsed.Items, feedbackFileEntry{
+				ItemID:    strings.TrimSpace(match[1]),
+				Ranking:   splitRankingString(match[2]),
+				Reasoning: strings.TrimSpace(match[3]),
+			})
+			traitItemIndex = len(parsed.Items) - 1
+			traitTarget = ""
+			continue
+		}
 		match := shortFeedbackLine.FindStringSubmatch(line)
 		if match == nil {
 			continue
@@ -490,6 +569,28 @@ func parseShortFormFeedback(content string) (feedbackFile, bool, error) {
 		return feedbackFile{}, false, nil
 	}
 	return parsed, true, nil
+}
+
+func findFeedbackItemIndex(items []feedbackFileEntry, itemID string) int {
+	itemID = strings.TrimSpace(itemID)
+	for index := range items {
+		if strings.TrimSpace(items[index].ItemID) == itemID {
+			return index
+		}
+	}
+	return -1
+}
+
+func setFeedbackItemSignal(entry *feedbackFileEntry, key string, value string) {
+	value = strings.TrimSpace(value)
+	switch strings.TrimSpace(strings.ToLower(key)) {
+	case "quality":
+		entry.Quality = value
+	case "continue_mode":
+		entry.ContinueMode = value
+	case "promote":
+		entry.Promote = value
+	}
 }
 
 func splitRankingString(value string) []string {

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -189,23 +189,30 @@ func TestGitHubCollectorPublishesRankedIssueBody(t *testing.T) {
 	body := fake.createdIssue.Body
 	for _, want := range []string{
 		"Rank every option",
+		"## Review Table",
 		"## Phase Recommendation",
 		"recommend continue explore",
+		"| Item | What to compare | Options |",
+		"Option C: [open](https://example.com/c)",
+		"## Inline Options Without Public Links",
+		"#### Option A",
+		"option a answer",
 		"```yaml",
 		"run_id: ranked-1",
 		"item_id: item-001",
 		"<replace with ranked option labels, e.g. A > B > C > D>",
-		"| Option | Artifact | Reference |",
-		"[open](https://example.com/c)",
-		"#### Option C",
-		"option c answer",
+		"quality: \"\"",
+		"continue_mode: \"\"",
+		"promote: \"\"",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("ranked issue body missing %q:\n%s", want, body)
 		}
 	}
-	if strings.Contains(body, "/tmp/gitmoot-option-a.md") {
-		t.Fatalf("ranked issue body leaked local path:\n%s", body)
+	for _, leaked := range []string{"/tmp/gitmoot-option-a.md", "#### Option C", "option c answer"} {
+		if strings.Contains(body, leaked) {
+			t.Fatalf("ranked issue body leaked %q:\n%s", leaked, body)
+		}
 	}
 }
 
@@ -355,7 +362,7 @@ func TestGitHubCollectorSyncImportsRankedYAMLCommentWithColonItemID(t *testing.T
 	fake := &fakeFeedbackGitHub{
 		comments: map[int64][]github.IssueComment{
 			42: {
-				{ID: 1, Body: "```yaml\nrun_id: ranked-1\nitems:\n  - item_id: scenario:landing\n    ranking:\n      - C > A > D > B\n    reasoning: option c is strongest\n```\n", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-06-02T10:00:00Z"},
+				{ID: 1, Body: "```yaml\nrun_id: ranked-1\nitems:\n  - item_id: scenario:landing\n    ranking:\n      - C > A > D > B\n    quality: poor\n    continue_mode: explore\n    promote: no\n    reasoning: option c is strongest\n```\n", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-06-02T10:00:00Z"},
 			},
 		},
 	}
@@ -370,6 +377,62 @@ func TestGitHubCollectorSyncImportsRankedYAMLCommentWithColonItemID(t *testing.T
 	}
 	if result.RankedFeedbackEvents[0].ItemID != "scenario:landing" || result.RankedFeedbackEvents[0].Winner != "c" {
 		t.Fatalf("ranked event = %+v", result.RankedFeedbackEvents[0])
+	}
+	if result.RankedFeedbackEvents[0].Quality != "poor" || result.RankedFeedbackEvents[0].ContinueMode != "explore" || result.RankedFeedbackEvents[0].Promote != "no" {
+		t.Fatalf("ranked event signals = %+v", result.RankedFeedbackEvents[0])
+	}
+}
+
+func TestGitHubCollectorSyncImportsRankedDirectShortFormWithSignals(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubRankedFeedbackRun(t, "ranked-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{
+			42: {
+				{ID: 1, Body: "run_id: ranked-1\nitem-001: C > A > D > B - all options are still weak\nitem-001 quality: poor\nitem-001 continue_mode: explore\nitem-001 promote: no\n", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-06-02T10:00:00Z"},
+			},
+		},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	result, err := collector.Sync(ctx, store, "ranked-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	if err != nil {
+		t.Fatalf("Sync returned error: %v", err)
+	}
+	if result.Count() != 1 || len(result.RankedFeedbackEvents) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.RankedFeedbackEvents[0]
+	if event.Winner != "c" || event.Quality != "poor" || event.ContinueMode != "explore" || event.Promote != "no" || !strings.Contains(event.Reasoning, "weak") {
+		t.Fatalf("ranked event = %+v", event)
+	}
+}
+
+func TestGitHubCollectorSyncRejectsInvalidRankedSignalWithoutPartialImport(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubRankedFeedbackRun(t, "ranked-1", "owner/repo")
+	if err := addGitHubRankedFeedbackItem(ctx, store, blobs, "ranked-1", "item-002"); err != nil {
+		t.Fatalf("addGitHubRankedFeedbackItem returned error: %v", err)
+	}
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{
+			42: {
+				{ID: 1, Body: "```yaml\nrun_id: ranked-1\nitems:\n  - item_id: item-001\n    ranking:\n      - C > A > D > B\n    quality: poor\n  - item_id: item-002\n    ranking:\n      - C > A > D > B\n    quality: ok\n```\n", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-06-02T10:00:00Z"},
+			},
+		},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	_, err := collector.Sync(ctx, store, "ranked-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	if err == nil || !strings.Contains(err.Error(), "quality") {
+		t.Fatalf("Sync error = %v", err)
+	}
+	stored, err := store.ListRankedFeedbackEvents(ctx, "ranked-1")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 0 {
+		t.Fatalf("Sync persisted partial ranked events: %+v", stored)
 	}
 }
 
@@ -478,6 +541,27 @@ func setupGitHubRankedFeedbackRunWithItem(t *testing.T, runID string, itemID str
 		}
 	}
 	return store, blobStore
+}
+
+func addGitHubRankedFeedbackItem(ctx context.Context, store *db.Store, blobStore artifact.Store, runID string, itemID string) error {
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{RunID: runID, ItemID: itemID, Title: "Ranked Item"}); err != nil {
+		return err
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		content := []byte("option " + label + " answer")
+		blob, err := blobStore.Put(content)
+		if err != nil {
+			return err
+		}
+		artifactID := itemID + "-option-" + label
+		if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: artifactID, Hash: blob.Hash, MediaType: "text/markdown", SizeBytes: blob.Size, Driver: "text"}); err != nil {
+			return err
+		}
+		if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{RunID: runID, ItemID: itemID, Label: label, ArtifactID: artifactID, Role: "option"}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func setupGitHubFeedbackRun(t *testing.T, runID string, targetRepo string) (*db.Store, artifact.Store) {

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -61,6 +61,9 @@ type feedbackFileEntry struct {
 	Winner         string              `yaml:"winner,omitempty"`
 	UsefulTraits   map[string][]string `yaml:"useful_traits,omitempty"`
 	RejectedTraits map[string][]string `yaml:"rejected_traits,omitempty"`
+	Quality        string              `yaml:"quality"`
+	ContinueMode   string              `yaml:"continue_mode"`
+	Promote        string              `yaml:"promote"`
 	Reasoning      string              `yaml:"reasoning,omitempty"`
 }
 
@@ -183,7 +186,7 @@ func (c MarkdownCollector) ImportPacket(ctx context.Context, store *db.Store, di
 		if len(assignment.Options) > 0 {
 			event, err := rankedFeedbackEventFromEntry(feedback.RunID, itemID, entry, assignment, reviewer, SourceMarkdown, dir, now)
 			if err != nil {
-				return ImportResult{}, fmt.Errorf("item %s: %w", itemID, err)
+				return ImportResult{}, fmt.Errorf("item %s: %w", itemID, feedbackImportErrorHint(err))
 			}
 			rankedEvents = append(rankedEvents, event)
 			continue
@@ -494,6 +497,10 @@ func rankedFeedbackEventFromEntry(runID string, itemID string, entry feedbackFil
 			return db.RankedFeedbackEvent{}, fmt.Errorf("winner %q does not match first ranked option %q", winner, ranking[0])
 		}
 	}
+	quality, continueMode, promote, err := normalizeRankedFeedbackSignals(entry)
+	if err != nil {
+		return db.RankedFeedbackEvent{}, err
+	}
 	return db.RankedFeedbackEvent{
 		RunID:              strings.TrimSpace(runID),
 		ItemID:             strings.TrimSpace(itemID),
@@ -501,12 +508,42 @@ func rankedFeedbackEventFromEntry(runID string, itemID string, entry feedbackFil
 		Winner:             winner,
 		UsefulTraitsJSON:   usefulTraitsJSON,
 		RejectedTraitsJSON: rejectedTraitsJSON,
+		Quality:            quality,
+		ContinueMode:       continueMode,
+		Promote:            promote,
 		Reasoning:          strings.TrimSpace(entry.Reasoning),
 		Reviewer:           strings.TrimSpace(reviewer),
 		Source:             strings.TrimSpace(source),
 		SourceURL:          strings.TrimSpace(sourceURL),
 		CreatedAt:          strings.TrimSpace(createdAt),
 	}, nil
+}
+
+func normalizeRankedFeedbackSignals(entry feedbackFileEntry) (string, string, string, error) {
+	quality := strings.TrimSpace(strings.ToLower(entry.Quality))
+	switch quality {
+	case "", "poor", "acceptable", "strong":
+	default:
+		return "", "", "", errors.New("quality must be one of poor, acceptable, or strong")
+	}
+	continueMode := strings.TrimSpace(strings.ToLower(entry.ContinueMode))
+	switch continueMode {
+	case "", db.EvalRunModeExplore, db.EvalRunModeRefine, db.EvalRunModeDistill, db.EvalRunModeValidate:
+	default:
+		return "", "", "", errors.New("continue_mode must be one of explore, refine, distill, or validate")
+	}
+	promote := strings.TrimSpace(strings.ToLower(entry.Promote))
+	switch promote {
+	case "", "yes", "y", "true":
+		if promote != "" {
+			promote = "yes"
+		}
+	case "no", "n", "false":
+		promote = "no"
+	default:
+		return "", "", "", errors.New("promote must be yes or no")
+	}
+	return quality, continueMode, promote, nil
 }
 
 func validateRankedTraitLabels(traits map[string][]string, known map[string]struct{}) error {
@@ -739,6 +776,9 @@ func writeFeedbackYAML(path string, runID string, assignments assignmentFile) er
 				Winner:         "",
 				UsefulTraits:   map[string][]string{},
 				RejectedTraits: map[string][]string{},
+				Quality:        "",
+				ContinueMode:   "",
+				Promote:        "",
 				Reasoning:      "",
 			})
 			continue
@@ -782,8 +822,25 @@ func normalizeFeedbackFileEntries(feedback *feedbackFile) {
 		feedback.Items[index].Winner = strings.TrimSpace(feedback.Items[index].Winner)
 		feedback.Items[index].UsefulTraits = trimTraitMap(feedback.Items[index].UsefulTraits)
 		feedback.Items[index].RejectedTraits = trimTraitMap(feedback.Items[index].RejectedTraits)
+		feedback.Items[index].Quality = strings.TrimSpace(feedback.Items[index].Quality)
+		feedback.Items[index].ContinueMode = strings.TrimSpace(feedback.Items[index].ContinueMode)
+		feedback.Items[index].Promote = strings.TrimSpace(feedback.Items[index].Promote)
 		feedback.Items[index].Reasoning = strings.TrimSpace(feedback.Items[index].Reasoning)
 	}
+}
+
+func feedbackImportErrorHint(err error) error {
+	if err == nil {
+		return nil
+	}
+	message := err.Error()
+	if strings.Contains(message, "reasoning: |") || strings.Contains(message, "block-scalar") {
+		return err
+	}
+	if strings.Contains(message, "yaml") || strings.Contains(message, "mapping values are not allowed") || strings.Contains(message, "did not find expected") || strings.Contains(message, "ranking") {
+		return fmt.Errorf("%w; for long reasoning or text containing colons, use block-scalar YAML like `reasoning: |`", err)
+	}
+	return err
 }
 
 func readAssignments(path string) (assignmentFile, error) {

--- a/internal/feedback/markdown_test.go
+++ b/internal/feedback/markdown_test.go
@@ -174,6 +174,9 @@ items:
     rejected_traits:
       B:
         - too generic
+    quality: poor
+    continue_mode: explore
+    promote: no
     reasoning: C explains the product best.
 `
 	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackContent), 0o644); err != nil {
@@ -192,6 +195,9 @@ items:
 	}
 	if len(stored) != 1 || stored[0].Winner != "c" || stored[0].Reasoning != "C explains the product best." || stored[0].Source != SourceMarkdown {
 		t.Fatalf("stored ranked events = %+v", stored)
+	}
+	if stored[0].Quality != "poor" || stored[0].ContinueMode != "explore" || stored[0].Promote != "no" {
+		t.Fatalf("stored ranked event signals = %+v", stored[0])
 	}
 	if !strings.Contains(stored[0].UsefulTraitsJSON, `"a":["visual style"]`) || !strings.Contains(stored[0].RejectedTraitsJSON, `"b":["too generic"]`) {
 		t.Fatalf("stored traits useful=%s rejected=%s", stored[0].UsefulTraitsJSON, stored[0].RejectedTraitsJSON)
@@ -272,6 +278,54 @@ items:
 	}
 	_, err := collector.ImportPacket(ctx, store, packetDir, "")
 	if err == nil || !strings.Contains(err.Error(), "winner") {
+		t.Fatalf("ImportPacket error = %v", err)
+	}
+	stored, err := store.ListRankedFeedbackEvents(ctx, "ranked-1")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
+	}
+	if len(stored) != 0 {
+		t.Fatalf("ImportPacket persisted partial ranked events: %+v", stored)
+	}
+}
+
+func TestMarkdownCollectorRejectsInvalidRankedSignalWithoutPartialImport(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupMarkdownRankedFeedbackRun(t, "ranked-1")
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:  "ranked-1",
+		ItemID: "item-002",
+		Title:  "Second Ranked Item",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem item-002 returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{RunID: "ranked-1", ItemID: "item-002", Label: label, ArtifactID: "option-" + label, Role: "option"}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption item-002 %s returned error: %v", label, err)
+		}
+	}
+	packetDir := filepath.Join(t.TempDir(), "packet")
+	collector := MarkdownCollector{BlobStore: blobs}
+	if err := collector.WritePacket(ctx, store, "ranked-1", packetDir); err != nil {
+		t.Fatalf("WritePacket returned error: %v", err)
+	}
+	feedbackContent := `run_id: ranked-1
+reviewer: jerry
+items:
+  - item_id: item-001
+    ranking:
+      - C > A > D > B
+    quality: poor
+  - item_id: item-002
+    ranking:
+      - C > A > D > B
+    quality: ok
+`
+	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackContent), 0o644); err != nil {
+		t.Fatalf("write feedback.yml: %v", err)
+	}
+	_, err := collector.ImportPacket(ctx, store, packetDir, "")
+	if err == nil || !strings.Contains(err.Error(), "quality") {
 		t.Fatalf("ImportPacket error = %v", err)
 	}
 	stored, err := store.ListRankedFeedbackEvents(ctx, "ranked-1")

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -99,6 +99,9 @@ type RankedFeedbackEvent struct {
 	Winner         string          `json:"winner,omitempty"`
 	UsefulTraits   json.RawMessage `json:"useful_traits,omitempty"`
 	RejectedTraits json.RawMessage `json:"rejected_traits,omitempty"`
+	Quality        string          `json:"quality,omitempty"`
+	ContinueMode   string          `json:"continue_mode,omitempty"`
+	Promote        string          `json:"promote,omitempty"`
 	Reasoning      string          `json:"reasoning,omitempty"`
 	Reviewer       string          `json:"reviewer"`
 	Source         string          `json:"source"`
@@ -670,6 +673,9 @@ func loadRankedFeedbackEvents(ctx context.Context, store *db.Store, runID string
 			Winner:         event.Winner,
 			UsefulTraits:   usefulTraits,
 			RejectedTraits: rejectedTraits,
+			Quality:        event.Quality,
+			ContinueMode:   event.ContinueMode,
+			Promote:        event.Promote,
 			Reasoning:      event.Reasoning,
 			Reviewer:       event.Reviewer,
 			Source:         event.Source,

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -227,6 +227,9 @@ func TestExportTrainingPackageIncludesRankedExplorationFeedback(t *testing.T) {
 		Winner:             "c",
 		UsefulTraitsJSON:   string(useful),
 		RejectedTraitsJSON: string(rejected),
+		Quality:            "acceptable",
+		ContinueMode:       db.EvalRunModeRefine,
+		Promote:            "no",
 		Reasoning:          "C is the clearest direction.",
 		Reviewer:           "jerry",
 		Source:             "github",
@@ -255,6 +258,9 @@ func TestExportTrainingPackageIncludesRankedExplorationFeedback(t *testing.T) {
 	}
 	if !strings.Contains(string(pkg.RankedFeedbackEvents[0].UsefulTraits), "clearest explanation") || !strings.Contains(string(pkg.RankedFeedbackEvents[0].RejectedTraits), "too generic") {
 		t.Fatalf("ranked traits useful=%s rejected=%s", pkg.RankedFeedbackEvents[0].UsefulTraits, pkg.RankedFeedbackEvents[0].RejectedTraits)
+	}
+	if pkg.RankedFeedbackEvents[0].Quality != "acceptable" || pkg.RankedFeedbackEvents[0].ContinueMode != db.EvalRunModeRefine || pkg.RankedFeedbackEvents[0].Promote != "no" {
+		t.Fatalf("ranked feedback signals = %+v", pkg.RankedFeedbackEvents[0])
 	}
 	if len(pkg.PairwisePreferences) != 6 || pkg.PairwisePreferences[0].Preferred != "c" || pkg.PairwisePreferences[5].Rejected != "b" || pkg.PairwisePreferences[0].RankedEventID != pkg.RankedFeedbackEvents[0].ID {
 		t.Fatalf("pairwise preferences = %+v", pkg.PairwisePreferences)

--- a/internal/skillopt/phase.go
+++ b/internal/skillopt/phase.go
@@ -61,6 +61,11 @@ func RecommendPhaseForItems(run db.EvalRun, items []db.EvalReviewItem, feedback 
 		recommendation.Reason = fmt.Sprintf("%d of %d review items have imported feedback; collect feedback for every item before changing phases.", feedbackItemCount, itemCount)
 		return recommendation
 	}
+	if shouldContinueExploration(ranked) {
+		recommendation.RecommendedMode = db.EvalRunModeExplore
+		recommendation.Reason = explorationSignalReason(ranked)
+		return recommendation
+	}
 
 	switch currentMode {
 	case db.EvalRunModeExplore:
@@ -76,6 +81,46 @@ func RecommendPhaseForItems(run db.EvalRun, items []db.EvalReviewItem, feedback 
 		recommendation.Reason = "current mode is not recognized, so keep collecting feedback before changing phases."
 	}
 	return recommendation
+}
+
+func shouldContinueExploration(ranked []db.RankedFeedbackEvent) bool {
+	if len(ranked) == 0 {
+		return false
+	}
+	if hasContinueMode(ranked, db.EvalRunModeExplore) {
+		return true
+	}
+	return allRankedQuality(ranked, "poor")
+}
+
+func explorationSignalReason(ranked []db.RankedFeedbackEvent) string {
+	if hasContinueMode(ranked, db.EvalRunModeExplore) {
+		return "ranked feedback explicitly requested continue_mode: explore, so keep exploring broader alternatives."
+	}
+	return "all ranked feedback is marked quality: poor, so ranking stability is only relative and broad exploration should continue."
+}
+
+func hasContinueMode(ranked []db.RankedFeedbackEvent, mode string) bool {
+	mode = strings.TrimSpace(mode)
+	for _, event := range ranked {
+		if strings.TrimSpace(event.ContinueMode) == mode {
+			return true
+		}
+	}
+	return false
+}
+
+func allRankedQuality(ranked []db.RankedFeedbackEvent, quality string) bool {
+	if len(ranked) == 0 {
+		return false
+	}
+	quality = strings.TrimSpace(quality)
+	for _, event := range ranked {
+		if strings.TrimSpace(event.Quality) != quality {
+			return false
+		}
+	}
+	return true
 }
 
 func feedbackCoverage(items []db.EvalReviewItem, feedback []db.FeedbackEvent, ranked []db.RankedFeedbackEvent) (int, int, int) {

--- a/internal/skillopt/phase_test.go
+++ b/internal/skillopt/phase_test.go
@@ -2,6 +2,7 @@ package skillopt
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -24,6 +25,45 @@ func TestRecommendPhaseExploreToRefine(t *testing.T) {
 	}
 	if recommendation.RankingStability != "c 2/2" {
 		t.Fatalf("ranking stability = %q", recommendation.RankingStability)
+	}
+}
+
+func TestRecommendPhaseExploreStableWinnerWithPoorQualityStaysExplore(t *testing.T) {
+	ranked := []db.RankedFeedbackEvent{
+		rankedEvent(t, "c", "c", "a", "d", "b"),
+		rankedEvent(t, "c", "c", "d", "a", "b"),
+	}
+	ranked[0].Quality = "poor"
+	ranked[1].Quality = "poor"
+
+	recommendation := RecommendPhase(
+		db.EvalRun{ID: "run-1", Mode: db.EvalRunModeExplore, ExplorationLevel: db.ExplorationLevelHigh},
+		nil,
+		ranked,
+		pairwisePreferences(12),
+	)
+
+	if recommendation.RecommendedMode != db.EvalRunModeExplore || !strings.Contains(recommendation.Reason, "quality: poor") {
+		t.Fatalf("recommendation = %+v", recommendation)
+	}
+}
+
+func TestRecommendPhaseExploreExplicitContinueModeStaysExplore(t *testing.T) {
+	ranked := []db.RankedFeedbackEvent{
+		rankedEvent(t, "c", "c", "a", "d", "b"),
+		rankedEvent(t, "c", "c", "d", "a", "b"),
+	}
+	ranked[0].ContinueMode = db.EvalRunModeExplore
+
+	recommendation := RecommendPhase(
+		db.EvalRun{ID: "run-1", Mode: db.EvalRunModeExplore, ExplorationLevel: db.ExplorationLevelHigh},
+		nil,
+		ranked,
+		pairwisePreferences(12),
+	)
+
+	if recommendation.RecommendedMode != db.EvalRunModeExplore || !strings.Contains(recommendation.Reason, "continue_mode: explore") {
+		t.Fatalf("recommendation = %+v", recommendation)
 	}
 }
 


### PR DESCRIPTION
WHAT: Add concise train-aware ranked GitHub review packets and optional ranked feedback quality signals.

WHY: Early SkillOpt train loops need richer human feedback than ranking alone. Poor absolute quality or explicit exploration requests should keep the loop exploring instead of prematurely refining.

CHANGES:
- Render ranked GitHub feedback issues with a compact table, train session/iteration context, preview links, and inline fallbacks for options without public URLs.
- Parse and persist optional ranked feedback fields: `quality`, `continue_mode`, and `promote`.
- Export those fields in SkillOpt training packages.
- Normalize short-form ranked feedback and validate optional signal values before persistence to avoid partial imports.
- Update phase recommendation logic so `quality: poor` across reviewed items or `continue_mode: explore` keeps exploration active.
- Add focused coverage for GitHub/Markdown feedback import, DB persistence, export, and phase recommendations.

RESULTS:
- `GOTOOLCHAIN=go1.26.2 go test ./internal/feedback ./internal/skillopt`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run SkillOpt`
- `GOTOOLCHAIN=go1.26.2 go test ./... -timeout 8m`
- `git diff --check`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:

```text
No correctness issues were identified in the reviewed staged, unstaged, and untracked changes. Go tests could not be run because the required Go 1.26 toolchain download is blocked in this environment.
No correctness issues were identified in the reviewed staged, unstaged, and untracked changes. Go tests could not be run because the required Go 1.26 toolchain download is blocked in this environment.
```

RISK: The Codex review sandbox could not run Go tests because its Go 1.26 toolchain download was blocked; local tests passed with `GOTOOLCHAIN=go1.26.2`. Untracked `GOAL-SKILLOPT-TRAIN-ORCHESTRATION.md` remains local and was not committed.
