### PR TITLE
feat(skillopt): orchestrate train optimizer handoff

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -23,12 +23,15 @@ import (
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 	"gopkg.in/yaml.v3"
 )
 
 var newSkillOptGitHubClient = func() github.Client {
 	return github.NewClient("")
 }
+
+var skillOptTrainOptimizerRunner subprocess.Runner = subprocess.ExecRunner{}
 
 func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
@@ -73,7 +76,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -102,7 +105,7 @@ func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -384,6 +387,15 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	sessionID := fs.String("session", "", "train session id")
 	generatorAgent := fs.String("generator-agent", "", "existing agent to use for option generation")
 	generatorType := fs.String("generator-type", "", "managed agent type to use for option generation; defaults to skillopt-generator")
+	skillOptBin := fs.String("skillopt-bin", "", "gitmoot-skillopt executable path; defaults to gitmoot-skillopt on PATH")
+	model := fs.String("model", "", "model name to pass to both optimizer and target when specific model flags are omitted")
+	optimizerModel := fs.String("optimizer-model", "", "optimizer model name")
+	targetModel := fs.String("target-model", "", "target model name")
+	gate := fs.String("gate", "", "optimizer gate metric: hard, soft, or mixed")
+	outRoot := fs.String("out-root", "", "optimizer output directory")
+	timeout := fs.String("timeout", "", "optimizer timeout duration")
+	dryRun := fs.Bool("dry-run", false, "ask gitmoot-skillopt to avoid model calls while still producing a candidate package")
+	rerunOptimizer := fs.Bool("rerun-optimizer", false, "rerun gitmoot-skillopt after optimizer completion instead of retrying the existing candidate import")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -406,6 +418,17 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 			SessionID:      *sessionID,
 			GeneratorAgent: *generatorAgent,
 			GeneratorType:  *generatorType,
+			Optimizer: skillOptTrainOptimizerRequest{
+				SkillOptBin:    *skillOptBin,
+				Model:          *model,
+				OptimizerModel: *optimizerModel,
+				TargetModel:    *targetModel,
+				Gate:           *gate,
+				OutRoot:        *outRoot,
+				Timeout:        *timeout,
+				DryRun:         *dryRun,
+				RerunOptimizer: *rerunOptimizer,
+			},
 		})
 		return err
 	}); err != nil {
@@ -430,6 +453,19 @@ type skillOptTrainContinueRequest struct {
 	GeneratorAgent    string
 	GeneratorType     string
 	GenerationLockTTL time.Duration
+	Optimizer         skillOptTrainOptimizerRequest
+}
+
+type skillOptTrainOptimizerRequest struct {
+	SkillOptBin    string
+	Model          string
+	OptimizerModel string
+	TargetModel    string
+	Gate           string
+	OutRoot        string
+	Timeout        string
+	DryRun         bool
+	RerunOptimizer bool
 }
 
 type skillOptTrainContinueOutput struct {
@@ -518,10 +554,194 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 	case skillopt.TrainStateOptionsGenerated:
 		output.Lines = []string{"next: options already generated; publish the human review packet"}
 		return output, nil
+	case skillopt.TrainStateFeedbackSynced, skillopt.TrainStateTrainingPackageCreated, skillopt.TrainStateOptimizerCompleted:
+		if iteration == nil {
+			output.Lines = []string{"next: train session has no iteration to continue"}
+			return output, nil
+		}
+		optimizerLockTTL, err := skillOptTrainOptimizerLockTTLForRequest(request.Optimizer)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		releaseOptimizerLock, _, err := acquireSkillOptTrainOptimizerLock(ctx, store, session.ID, iteration.ID, optimizerLockTTL)
+		if err != nil {
+			return output, err
+		}
+		defer func() {
+			_ = releaseOptimizerLock(context.Background())
+		}()
+		session, iteration, counts, err = loadSkillOptTrainStatus(ctx, store, request.SessionID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		summary = skillopt.BuildTrainStatusSummary(session, iteration, counts)
+		output = skillOptTrainContinueOutput{Summary: summary, Counts: counts}
+		if iteration == nil {
+			output.Lines = []string{"next: train session has no iteration to continue"}
+			return output, nil
+		}
+		if summary.CurrentPhase != skillopt.TrainStateFeedbackSynced &&
+			summary.CurrentPhase != skillopt.TrainStateTrainingPackageCreated &&
+			summary.CurrentPhase != skillopt.TrainStateOptimizerCompleted {
+			output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
+			return output, nil
+		}
+		result, err := continueSkillOptTrainOptimizer(ctx, paths, store, session, *iteration, request.Optimizer)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSession, updatedIteration, updatedCounts, err := loadSkillOptTrainStatus(ctx, store, session.ID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSummary := skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
+		lines := []string{
+			fmt.Sprintf("training_package: %s", result.TrainingPackagePath),
+			fmt.Sprintf("optimizer_out_root: %s", result.OutRoot),
+			fmt.Sprintf("candidate_package: %s", result.CandidatePackagePath),
+			fmt.Sprintf("artifact_dir: %s", result.ArtifactDir),
+			fmt.Sprintf("optimizer_command: %s", shellArgs(append([]string{result.Command}, result.Args...))),
+			fmt.Sprintf("optimizer_dry_run: %t", result.DryRun),
+			fmt.Sprintf("imported_candidate: %s", result.CandidateVersionID),
+			"next: publish candidate diff and preview review",
+		}
+		return skillOptTrainContinueOutput{
+			Summary:       updatedSummary,
+			Counts:        updatedCounts,
+			ContinueReady: true,
+			Lines:         lines,
+		}, nil
 	default:
 		output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
 		return output, nil
 	}
+}
+
+type skillOptTrainOptimizerResult struct {
+	TrainingPackagePath  string
+	OutRoot              string
+	CandidatePackagePath string
+	ArtifactDir          string
+	Command              string
+	Args                 []string
+	DryRun               bool
+	CandidateVersionID   string
+}
+
+type skillOptTrainOptimizerPaths struct {
+	OutRoot              string
+	ArtifactRoot         string
+	TrainingPackagePath  string
+	CandidatePackagePath string
+	ArtifactDir          string
+}
+
+func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest) (skillOptTrainOptimizerResult, error) {
+	if strings.TrimSpace(iteration.EvalRunID) == "" {
+		return skillOptTrainOptimizerResult{}, fmt.Errorf("train iteration %s has no eval run id", iteration.ID)
+	}
+	optimizerPaths, err := resolveSkillOptTrainOptimizerPaths(paths, session, iteration, request)
+	if err != nil {
+		return skillOptTrainOptimizerResult{}, err
+	}
+	result := skillOptTrainOptimizerResult{
+		TrainingPackagePath:  optimizerPaths.TrainingPackagePath,
+		OutRoot:              optimizerPaths.OutRoot,
+		CandidatePackagePath: optimizerPaths.CandidatePackagePath,
+		ArtifactDir:          optimizerPaths.ArtifactDir,
+		DryRun:               request.DryRun,
+	}
+	state := skillopt.NormalizeTrainState(iteration.State)
+	if state == skillopt.TrainStateOptimizerCompleted && request.RerunOptimizer {
+		state = skillopt.TrainStateTrainingPackageCreated
+	}
+	if state == skillopt.TrainStateFeedbackSynced {
+		if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateTrainingPackageCreated); err != nil {
+			return skillOptTrainOptimizerResult{}, err
+		}
+		exportMetadata, err := exportSkillOptTrainPackage(ctx, store, iteration, optimizerPaths)
+		if err != nil {
+			return skillOptTrainOptimizerResult{}, err
+		}
+		session.State = skillopt.TrainStateTrainingPackageCreated
+		iteration.State = skillopt.TrainStateTrainingPackageCreated
+		session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "optimizer", exportMetadata)
+		iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "optimizer", exportMetadata)
+		if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+			return skillOptTrainOptimizerResult{}, err
+		}
+		if err := store.UpsertSkillOptTrainIteration(ctx, iteration); err != nil {
+			return skillOptTrainOptimizerResult{}, err
+		}
+		state = skillopt.TrainStateTrainingPackageCreated
+	}
+	if state == skillopt.TrainStateTrainingPackageCreated {
+		if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateOptimizerCompleted); err != nil {
+			return skillOptTrainOptimizerResult{}, err
+		}
+		command, args, err := buildSkillOptTrainOptimizerCommand(iteration, request, optimizerPaths)
+		if err != nil {
+			if metaErr := recordSkillOptTrainOptimizerFailure(ctx, store, session, iteration, request, optimizerPaths, command, args, subprocess.Result{}, err); metaErr != nil {
+				return skillOptTrainOptimizerResult{}, fmt.Errorf("%w; failed to record optimizer failure: %v", err, metaErr)
+			}
+			return skillOptTrainOptimizerResult{}, err
+		}
+		result.Command = command
+		result.Args = args
+		runResult, err := runSkillOptTrainOptimizer(ctx, optimizerPaths, request, command, args)
+		if err != nil {
+			if metaErr := recordSkillOptTrainOptimizerFailure(ctx, store, session, iteration, request, optimizerPaths, command, args, runResult, err); metaErr != nil {
+				return skillOptTrainOptimizerResult{}, fmt.Errorf("%w; failed to record optimizer failure: %v", err, metaErr)
+			}
+			return skillOptTrainOptimizerResult{}, err
+		}
+		metadata := skillOptTrainOptimizerMetadata(request, optimizerPaths, command, args, runResult, "succeeded", nil)
+		session.State = skillopt.TrainStateOptimizerCompleted
+		iteration.State = skillopt.TrainStateOptimizerCompleted
+		session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "optimizer", metadata)
+		iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "optimizer", metadata)
+		if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+			return skillOptTrainOptimizerResult{}, err
+		}
+		if err := store.UpsertSkillOptTrainIteration(ctx, iteration); err != nil {
+			return skillOptTrainOptimizerResult{}, err
+		}
+		state = skillopt.TrainStateOptimizerCompleted
+	}
+	if state == skillopt.TrainStateOptimizerCompleted {
+		if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateCandidateCreated); err != nil {
+			return skillOptTrainOptimizerResult{}, err
+		}
+		version, err := importSkillOptTrainCandidate(ctx, paths, store, session, iteration, optimizerPaths)
+		if err != nil {
+			if metaErr := recordSkillOptTrainCandidateImportFailure(ctx, store, session, iteration, optimizerPaths, err); metaErr != nil {
+				return skillOptTrainOptimizerResult{}, fmt.Errorf("%w; failed to record candidate import failure: %v", err, metaErr)
+			}
+			return skillOptTrainOptimizerResult{}, err
+		}
+		result.CandidateVersionID = version.ID
+		metadata := map[string]any{
+			"status":            "succeeded",
+			"candidate_version": version.ID,
+			"candidate_package": optimizerPaths.CandidatePackagePath,
+			"artifact_dir":      optimizerPaths.ArtifactDir,
+			"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
+			"source":            "gitmoot skillopt train continue",
+		}
+		session.State = skillopt.TrainStateCandidateCreated
+		iteration.State = skillopt.TrainStateCandidateCreated
+		iteration.CandidateVersionID = version.ID
+		session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_import", metadata)
+		iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_import", metadata)
+		if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+			return skillOptTrainOptimizerResult{}, err
+		}
+		if err := store.UpsertSkillOptTrainIteration(ctx, iteration); err != nil {
+			return skillOptTrainOptimizerResult{}, err
+		}
+		return result, nil
+	}
+	return skillOptTrainOptimizerResult{}, fmt.Errorf("train iteration %s is at %s; expected %s, %s, or %s", iteration.ID, iteration.State, skillopt.TrainStateFeedbackSynced, skillopt.TrainStateTrainingPackageCreated, skillopt.TrainStateOptimizerCompleted)
 }
 
 type skillOptTrainGenerationResult struct {
@@ -534,9 +754,72 @@ type skillOptTrainGenerationResult struct {
 
 var errSkillOptTrainGenerationBusy = errors.New("skillopt train generation is already running")
 
+var errSkillOptTrainOptimizerBusy = errors.New("skillopt train optimizer is already running")
+
 const skillOptTrainGenerationLockTTL = 2 * time.Hour
 
 const skillOptTrainGenerationLockBuffer = 10 * time.Minute
+
+const skillOptTrainOptimizerLockTTL = 4 * time.Hour
+
+const skillOptTrainOptimizerLockBuffer = 10 * time.Minute
+
+func acquireSkillOptTrainOptimizerLock(ctx context.Context, store *db.Store, sessionID string, iterationID string, ttl time.Duration) (func(context.Context) error, bool, error) {
+	key := skillOptTrainOptimizerLockKey(sessionID, iterationID)
+	token, err := newRuntimeLockOwnerToken()
+	if err != nil {
+		return noopAgentReservationRelease, false, err
+	}
+	if ttl <= 0 {
+		ttl = skillOptTrainOptimizerLockTTL
+	}
+	now := time.Now().UTC()
+	ownerJobID := localAgentJobID("skillopt-train-optimizer", strings.TrimSpace(sessionID))
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  ownerJobID,
+		OwnerToken:  token,
+		ExpiresAt:   now.Add(ttl).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		return noopAgentReservationRelease, false, err
+	}
+	if !acquired {
+		return noopAgentReservationRelease, false, fmt.Errorf("%w: %s", errSkillOptTrainOptimizerBusy, key)
+	}
+	return func(releaseCtx context.Context) error {
+		_, err := store.ReleaseResourceLock(releaseCtx, key, ownerJobID, token)
+		return err
+	}, true, nil
+}
+
+func skillOptTrainOptimizerLockKey(sessionID string, iterationID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	iterationID = strings.TrimSpace(iterationID)
+	if iterationID == "" {
+		return "skillopt-train-optimizer:" + sessionID
+	}
+	return "skillopt-train-optimizer:" + sessionID + ":" + iterationID
+}
+
+func skillOptTrainOptimizerLockTTLForRequest(request skillOptTrainOptimizerRequest) (time.Duration, error) {
+	timeout := strings.TrimSpace(request.Timeout)
+	if timeout == "" {
+		return skillOptTrainOptimizerLockTTL, nil
+	}
+	duration, err := time.ParseDuration(timeout)
+	if err != nil {
+		return 0, fmt.Errorf("parse optimizer timeout: %w", err)
+	}
+	if duration <= 0 {
+		return 0, errors.New("optimizer timeout must be greater than zero")
+	}
+	ttl := duration + skillOptTrainOptimizerLockBuffer
+	if ttl < skillOptTrainOptimizerLockTTL {
+		return skillOptTrainOptimizerLockTTL, nil
+	}
+	return ttl, nil
+}
 
 func acquireSkillOptTrainGenerationLock(ctx context.Context, store *db.Store, sessionID string, iterationID string, ttl time.Duration) (func(context.Context) error, bool, error) {
 	key := skillOptTrainGenerationLockKey(sessionID, iterationID)
@@ -1381,6 +1664,314 @@ func recordSkillOptTrainGenerationFailure(ctx context.Context, store *db.Store, 
 	return store.UpsertSkillOptTrainIteration(ctx, iteration)
 }
 
+func resolveSkillOptTrainOptimizerPaths(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest) (skillOptTrainOptimizerPaths, error) {
+	outRoot := strings.TrimSpace(request.OutRoot)
+	optimizerMetadata := decodedSkillOptMetadataValue(decodedSkillOptMetadata(iteration.MetadataJSON)["optimizer"])
+	persistedOutRoot := metadataString(optimizerMetadata, "out_root")
+	persistedTrainingPackage := metadataString(optimizerMetadata, "training_package")
+	persistedCandidateOutput := metadataString(optimizerMetadata, "candidate_output")
+	persistedArtifactDir := metadataString(optimizerMetadata, "artifact_dir")
+	if persistedTrainingPackage != "" && skillopt.NormalizeTrainState(iteration.State) != skillopt.TrainStateFeedbackSynced {
+		if outRoot != "" {
+			absRequestedOutRoot, err := filepath.Abs(outRoot)
+			if err != nil {
+				return skillOptTrainOptimizerPaths{}, fmt.Errorf("resolve optimizer out-root: %w", err)
+			}
+			absPersistedOutRoot := persistedOutRoot
+			if absPersistedOutRoot == "" {
+				absPersistedOutRoot = filepath.Dir(persistedTrainingPackage)
+			}
+			if absPersistedOutRoot, err = filepath.Abs(absPersistedOutRoot); err != nil {
+				return skillOptTrainOptimizerPaths{}, fmt.Errorf("resolve persisted optimizer out-root: %w", err)
+			}
+			if absRequestedOutRoot != absPersistedOutRoot {
+				return skillOptTrainOptimizerPaths{}, fmt.Errorf("optimizer package already exported at %s; retry with the same --out-root or omit --out-root", persistedTrainingPackage)
+			}
+		}
+		outRoot = persistedOutRoot
+		if outRoot == "" {
+			outRoot = filepath.Dir(persistedTrainingPackage)
+		}
+	}
+	if outRoot == "" {
+		outRoot = persistedOutRoot
+	}
+	if outRoot == "" {
+		outRoot = filepath.Join(paths.Evals, "train", session.ID, iteration.ID, "optimizer")
+	}
+	absOutRoot, err := filepath.Abs(outRoot)
+	if err != nil {
+		return skillOptTrainOptimizerPaths{}, fmt.Errorf("resolve optimizer out-root: %w", err)
+	}
+	trainingPackagePath := filepath.Join(absOutRoot, "training.json")
+	candidatePackagePath := filepath.Join(absOutRoot, "candidate.json")
+	artifactDir := filepath.Join(absOutRoot, "artifacts")
+	if persistedTrainingPackage != "" && skillopt.NormalizeTrainState(iteration.State) != skillopt.TrainStateFeedbackSynced {
+		trainingPackagePath = persistedTrainingPackage
+		if persistedCandidateOutput != "" {
+			candidatePackagePath = persistedCandidateOutput
+		}
+		if persistedArtifactDir != "" {
+			artifactDir = persistedArtifactDir
+		}
+	}
+	return skillOptTrainOptimizerPaths{
+		OutRoot:              absOutRoot,
+		ArtifactRoot:         paths.ArtifactBlobs,
+		TrainingPackagePath:  trainingPackagePath,
+		CandidatePackagePath: candidatePackagePath,
+		ArtifactDir:          artifactDir,
+	}, nil
+}
+
+func exportSkillOptTrainPackage(ctx context.Context, store *db.Store, iteration db.SkillOptTrainIteration, paths skillOptTrainOptimizerPaths) (map[string]any, error) {
+	pkg, err := skillopt.ExportTrainingPackage(ctx, store, iteration.EvalRunID)
+	if err != nil {
+		return nil, fmt.Errorf("export training package: %w", err)
+	}
+	encoded, err := json.MarshalIndent(pkg, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode training package: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	if err := writeSkillOptFile(paths.TrainingPackagePath, encoded); err != nil {
+		return nil, fmt.Errorf("write training package: %w", err)
+	}
+	return map[string]any{
+		"status":           "package_created",
+		"training_package": paths.TrainingPackagePath,
+		"out_root":         paths.OutRoot,
+		"artifact_root":    paths.ArtifactRoot,
+		"candidate_output": paths.CandidatePackagePath,
+		"artifact_dir":     paths.ArtifactDir,
+		"created_at":       time.Now().UTC().Format(time.RFC3339Nano),
+		"source":           "gitmoot skillopt train continue",
+	}, nil
+}
+
+func buildSkillOptTrainOptimizerCommand(iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest, paths skillOptTrainOptimizerPaths) (string, []string, error) {
+	executable := strings.TrimSpace(request.SkillOptBin)
+	if executable == "" {
+		executable = "gitmoot-skillopt"
+	}
+	resolved, err := skillOptTrainOptimizerRunner.LookPath(executable)
+	if err != nil {
+		return "", nil, fmt.Errorf("find gitmoot-skillopt executable %q: %w", executable, err)
+	}
+	if !filepath.IsAbs(resolved) {
+		resolved, err = filepath.Abs(resolved)
+		if err != nil {
+			return "", nil, fmt.Errorf("resolve gitmoot-skillopt executable %q: %w", resolved, err)
+		}
+	}
+	gate, err := skillOptTrainOptimizerGate(iteration, request)
+	if err != nil {
+		return "", nil, err
+	}
+	args := []string{
+		"optimize",
+		"--training-package", paths.TrainingPackagePath,
+		"--artifact-root", paths.ArtifactRoot,
+		"--out-root", paths.OutRoot,
+		"--candidate-output", paths.CandidatePackagePath,
+		"--artifact-dir", paths.ArtifactDir,
+		"--gate-metric", gate,
+	}
+	optimizerModel := strings.TrimSpace(request.OptimizerModel)
+	targetModel := strings.TrimSpace(request.TargetModel)
+	if model := strings.TrimSpace(request.Model); model != "" {
+		if optimizerModel == "" {
+			optimizerModel = model
+		}
+		if targetModel == "" {
+			targetModel = model
+		}
+	}
+	if optimizerModel != "" {
+		args = append(args, "--optimizer-model", optimizerModel)
+	}
+	if targetModel != "" {
+		args = append(args, "--target-model", targetModel)
+	}
+	if request.DryRun {
+		args = append(args, "--dry-run")
+	}
+	return resolved, args, nil
+}
+
+func skillOptTrainOptimizerGate(iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest) (string, error) {
+	gate := strings.TrimSpace(strings.ToLower(request.Gate))
+	if gate == "" {
+		gate = skillOptMetadataString(iteration.MetadataJSON, "evaluation", "preferred_gate")
+	}
+	gate = strings.TrimSpace(strings.ToLower(gate))
+	if gate == "hard_then_soft" {
+		gate = "mixed"
+	}
+	if gate == "" {
+		gate = "hard"
+	}
+	switch gate {
+	case "hard", "soft", "mixed":
+		return gate, nil
+	default:
+		return "", fmt.Errorf("optimizer gate %q is not supported; use hard, soft, or mixed", gate)
+	}
+}
+
+func runSkillOptTrainOptimizer(ctx context.Context, paths skillOptTrainOptimizerPaths, request skillOptTrainOptimizerRequest, command string, args []string) (subprocess.Result, error) {
+	timeout := strings.TrimSpace(request.Timeout)
+	if timeout != "" {
+		duration, err := time.ParseDuration(timeout)
+		if err != nil {
+			return subprocess.Result{}, fmt.Errorf("parse optimizer timeout: %w", err)
+		}
+		if duration <= 0 {
+			return subprocess.Result{}, errors.New("optimizer timeout must be greater than zero")
+		}
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, duration)
+		defer cancel()
+	}
+	if err := os.MkdirAll(paths.OutRoot, 0o755); err != nil {
+		return subprocess.Result{}, fmt.Errorf("create optimizer out-root: %w", err)
+	}
+	result, err := skillOptTrainOptimizerRunner.Run(ctx, paths.OutRoot, command, args...)
+	if err != nil {
+		return result, fmt.Errorf("optimizer failed: %w%s", err, subprocessDiagnostics(result))
+	}
+	return result, nil
+}
+
+func subprocessDiagnostics(result subprocess.Result) string {
+	stderr := strings.TrimSpace(result.Stderr)
+	stdout := strings.TrimSpace(result.Stdout)
+	switch {
+	case stderr != "" && stdout != "":
+		return fmt.Sprintf(" (stderr: %s; stdout: %s)", truncateForMetadata(stderr), truncateForMetadata(stdout))
+	case stderr != "":
+		return fmt.Sprintf(" (stderr: %s)", truncateForMetadata(stderr))
+	case stdout != "":
+		return fmt.Sprintf(" (stdout: %s)", truncateForMetadata(stdout))
+	default:
+		return ""
+	}
+}
+
+func skillOptTrainOptimizerMetadata(request skillOptTrainOptimizerRequest, paths skillOptTrainOptimizerPaths, command string, args []string, result subprocess.Result, status string, failure error) map[string]any {
+	metadata := map[string]any{
+		"status":           status,
+		"command":          command,
+		"args":             args,
+		"training_package": paths.TrainingPackagePath,
+		"out_root":         paths.OutRoot,
+		"candidate_output": paths.CandidatePackagePath,
+		"artifact_dir":     paths.ArtifactDir,
+		"dry_run":          request.DryRun,
+		"stdout":           truncateForMetadata(result.Stdout),
+		"stderr":           truncateForMetadata(result.Stderr),
+		"completed_at":     time.Now().UTC().Format(time.RFC3339Nano),
+		"source":           "gitmoot skillopt train continue",
+	}
+	if failure != nil {
+		metadata["error"] = failure.Error()
+	}
+	return metadata
+}
+
+func recordSkillOptTrainOptimizerFailure(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest, paths skillOptTrainOptimizerPaths, command string, args []string, result subprocess.Result, failure error) error {
+	metadata := skillOptTrainOptimizerMetadata(request, paths, command, args, result, "failed", failure)
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "optimizer", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "optimizer", metadata)
+	if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+		return err
+	}
+	return store.UpsertSkillOptTrainIteration(ctx, iteration)
+}
+
+func recordSkillOptTrainCandidateImportFailure(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, paths skillOptTrainOptimizerPaths, failure error) error {
+	metadata := map[string]any{
+		"status":            "failed",
+		"candidate_package": paths.CandidatePackagePath,
+		"artifact_dir":      paths.ArtifactDir,
+		"error":             failure.Error(),
+		"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
+		"source":            "gitmoot skillopt train continue",
+	}
+	session.State = skillopt.TrainStateOptimizerCompleted
+	iteration.State = skillopt.TrainStateOptimizerCompleted
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_import", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_import", metadata)
+	if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+		return err
+	}
+	return store.UpsertSkillOptTrainIteration(ctx, iteration)
+}
+
+func importSkillOptTrainCandidate(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, optimizerPaths skillOptTrainOptimizerPaths) (db.AgentTemplateVersion, error) {
+	content, err := os.ReadFile(optimizerPaths.CandidatePackagePath)
+	if err != nil {
+		return db.AgentTemplateVersion{}, fmt.Errorf("read optimizer candidate package: %w", err)
+	}
+	var candidate skillopt.CandidatePackage
+	if err := json.Unmarshal(content, &candidate); err != nil {
+		return db.AgentTemplateVersion{}, fmt.Errorf("decode optimizer candidate package: %w", err)
+	}
+	if err := validateSkillOptTrainCandidatePackage(ctx, store, session, iteration, candidate); err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
+	version, err := skillopt.ImportCandidatePackageWithOptions(ctx, store, candidate, skillopt.CandidateImportOptions{
+		SourcePath:  optimizerPaths.CandidatePackagePath,
+		ArtifactDir: optimizerPaths.ArtifactDir,
+		BlobStore:   artifact.NewStore(paths.ArtifactBlobs),
+	})
+	if err != nil {
+		return db.AgentTemplateVersion{}, fmt.Errorf("import optimizer candidate package: %w", err)
+	}
+	return version, nil
+}
+
+func validateSkillOptTrainCandidatePackage(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, candidate skillopt.CandidatePackage) error {
+	templateID := strings.TrimSpace(candidate.TemplateID)
+	if templateID != strings.TrimSpace(session.TemplateID) {
+		return fmt.Errorf("optimizer candidate template_id %q does not match train session template %q", templateID, strings.TrimSpace(session.TemplateID))
+	}
+	expectedBase := strings.TrimSpace(iteration.BaseTemplateVersionID)
+	if expectedBase == "" {
+		expectedBase = strings.TrimSpace(session.TemplateVersionID)
+	}
+	baseRef := strings.TrimSpace(candidate.BaseVersionID)
+	if baseRef == "" {
+		base, err := store.GetAgentTemplate(ctx, templateID)
+		if err != nil {
+			return fmt.Errorf("load optimizer candidate current base for %q: %w", templateID, err)
+		}
+		if base.VersionID != expectedBase {
+			return fmt.Errorf("optimizer candidate omitted base_version_id and current base is %q, want active train base %q", base.VersionID, expectedBase)
+		}
+		return nil
+	}
+	base, err := store.GetAgentTemplateReference(ctx, baseRef)
+	if err != nil {
+		return fmt.Errorf("load optimizer candidate base version %q: %w", baseRef, err)
+	}
+	if base.ID != templateID {
+		return fmt.Errorf("optimizer candidate base_version_id %q belongs to template %q, want %q", baseRef, base.ID, templateID)
+	}
+	if base.VersionID != expectedBase {
+		return fmt.Errorf("optimizer candidate base_version_id %q resolved to %q, want active train base %q", baseRef, base.VersionID, expectedBase)
+	}
+	return nil
+}
+
+func truncateForMetadata(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= 2000 {
+		return value
+	}
+	return value[:2000] + "...<truncated>"
+}
+
 func skillOptTrainGenerationRepo(session db.SkillOptTrainSession) string {
 	if repo := strings.TrimSpace(session.WorkspaceRepo); repo != "" {
 		return repo
@@ -1616,6 +2207,13 @@ func decodedSkillOptMetadata(value string) map[string]any {
 		metadata = map[string]any{}
 	}
 	return metadata
+}
+
+func decodedSkillOptMetadataValue(value any) map[string]any {
+	if object, ok := value.(map[string]any); ok {
+		return object
+	}
+	return map[string]any{}
 }
 
 func metadataString(metadata map[string]any, key string) string {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1607,6 +1607,517 @@ func TestSkillOptTrainContinueRecordsGenerationFailureWithoutOptions(t *testing.
 	}
 }
 
+func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	candidate := cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with stronger candidate guidance.")
+	candidate.BaseVersionID = ""
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: candidate,
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--skillopt-bin", "gitmoot-skillopt",
+		"--model", "gpt-5.5",
+		"--gate", "mixed",
+		"--out-root", outRoot,
+		"--timeout", "5m",
+		"--dry-run",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: candidate_created",
+		"candidate: planner@v2",
+		"continue_ready: true",
+		"training_package: " + filepath.Join(outRoot, "training.json"),
+		"candidate_package: " + filepath.Join(outRoot, "candidate.json"),
+		"optimizer_dry_run: true",
+		"imported_candidate: planner@v2",
+		"next: publish candidate diff and preview review",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train continue stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("optimizer calls = %+v, want one", runner.calls)
+	}
+	call := runner.calls[0]
+	for _, want := range []string{
+		"optimize",
+		"--training-package", filepath.Join(outRoot, "training.json"),
+		"--artifact-root", config.PathsForHome(home).ArtifactBlobs,
+		"--out-root", outRoot,
+		"--candidate-output", filepath.Join(outRoot, "candidate.json"),
+		"--artifact-dir", filepath.Join(outRoot, "artifacts"),
+		"--gate-metric", "mixed",
+		"--optimizer-model", "gpt-5.5",
+		"--target-model", "gpt-5.5",
+		"--dry-run",
+	} {
+		if !containsString(call.args, want) {
+			t.Fatalf("optimizer args missing %q: %+v", want, call.args)
+		}
+	}
+	trainingPackage, err := os.ReadFile(filepath.Join(outRoot, "training.json"))
+	if err != nil {
+		t.Fatalf("read training package: %v", err)
+	}
+	if !strings.Contains(string(trainingPackage), `"kind": "gitmoot-skillopt-training-package"`) {
+		t.Fatalf("training package = %s", string(trainingPackage))
+	}
+
+	store := openCLIJobStore(t, home)
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateCandidateCreated || iteration.CandidateVersionID != "planner@v2" {
+		t.Fatalf("iteration = %+v", iteration)
+	}
+	if !strings.Contains(iteration.MetadataJSON, `"candidate_version":"planner@v2"`) || !strings.Contains(iteration.MetadataJSON, `--gate-metric`) {
+		t.Fatalf("iteration metadata = %s", iteration.MetadataJSON)
+	}
+	version, err := store.GetAgentTemplateVersionByID(context.Background(), "planner@v2")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if version.State != "pending" {
+		t.Fatalf("candidate version = %+v", version)
+	}
+}
+
+func TestSkillOptTrainContinueResolvesRelativeOptimizerBinary(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	repoDir := t.TempDir()
+	t.Chdir(repoDir)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate:     cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with relative binary-safe guidance."),
+		lookPathValue: filepath.Join(".", "bin", "gitmoot-skillopt"),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--skillopt-bin", filepath.Join(".", "bin", "gitmoot-skillopt"),
+		"--out-root", outRoot,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue relative optimizer exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("optimizer calls = %+v, want one", runner.calls)
+	}
+	wantCommand := filepath.Join(repoDir, "bin", "gitmoot-skillopt")
+	if runner.calls[0].command != wantCommand {
+		t.Fatalf("optimizer command = %q, want absolute %q", runner.calls[0].command, wantCommand)
+	}
+	if runner.calls[0].dir != outRoot {
+		t.Fatalf("optimizer dir = %q, want %q", runner.calls[0].dir, outRoot)
+	}
+}
+
+func TestSkillOptTrainContinueRunsLocalFakeOptimizerExecutable(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	candidate := cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with executable smoke guidance.")
+	candidateJSON, err := json.MarshalIndent(candidate, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent candidate returned error: %v", err)
+	}
+	fakeBin := filepath.Join(t.TempDir(), "gitmoot-skillopt")
+	fakeScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+if [ "${1:-}" != "optimize" ]; then
+  echo "expected optimize subcommand" >&2
+  exit 64
+fi
+shift
+candidate_output=""
+artifact_dir=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --training-package)
+      shift
+      test -f "$1"
+      ;;
+    --candidate-output)
+      shift
+      candidate_output="$1"
+      ;;
+    --artifact-dir)
+      shift
+      artifact_dir="$1"
+      ;;
+    --out-root|--artifact-root|--gate-metric|--optimizer-model|--target-model)
+      shift
+      ;;
+    --dry-run)
+      ;;
+  esac
+  shift
+done
+if [ "$candidate_output" = "" ]; then
+  echo "missing --candidate-output" >&2
+  exit 65
+fi
+if [ "$artifact_dir" = "" ]; then
+  echo "missing --artifact-dir" >&2
+  exit 66
+fi
+mkdir -p "$artifact_dir"
+mkdir -p "$(dirname "$candidate_output")"
+cat > "$candidate_output" <<'GITMOOT_CANDIDATE_JSON'
+%s
+GITMOOT_CANDIDATE_JSON
+echo "fake optimizer ok"
+`, string(candidateJSON))
+	if err := os.WriteFile(fakeBin, []byte(fakeScript), 0o755); err != nil {
+		t.Fatalf("WriteFile fake optimizer returned error: %v", err)
+	}
+
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = subprocess.ExecRunner{}
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--skillopt-bin", fakeBin,
+		"--out-root", outRoot,
+		"--gate", "soft",
+		"--dry-run",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue fake executable exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_created") || !strings.Contains(stdout.String(), "imported_candidate: planner@v2") {
+		t.Fatalf("fake executable stdout = %s", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(outRoot, "training.json")); err != nil {
+		t.Fatalf("training package was not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outRoot, "candidate.json")); err != nil {
+		t.Fatalf("candidate package was not written: %v", err)
+	}
+}
+
+func TestSkillOptTrainContinueRecordsOptimizerFailureAtPackageGate(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{fail: true}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--out-root", outRoot,
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue failing optimizer exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "optimizer failed") || !strings.Contains(stderr.String(), "optimizer stderr") {
+		t.Fatalf("optimizer failure stderr = %q", stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateTrainingPackageCreated || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after optimizer failure = %+v", iteration)
+	}
+	if !strings.Contains(iteration.MetadataJSON, `"status":"failed"`) || !strings.Contains(iteration.MetadataJSON, "optimizer stderr") {
+		t.Fatalf("iteration metadata after failure = %s", iteration.MetadataJSON)
+	}
+	if _, err := store.GetAgentTemplateVersionByID(context.Background(), "planner@v2"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("optimizer failure created candidate err=%v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after optimizer failure returned error: %v", err)
+	}
+
+	changedOutRoot := filepath.Join(t.TempDir(), "changed-optimizer")
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--out-root", changedOutRoot,
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue changed out-root retry exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "optimizer package already exported") {
+		t.Fatalf("changed out-root retry stderr = %q", stderr.String())
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("changed out-root retry ran optimizer: %+v", runner.calls)
+	}
+
+	runner.fail = false
+	runner.candidate = cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with retry-safe candidate guidance.")
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue retry exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("optimizer calls after retry = %+v, want two", runner.calls)
+	}
+	retryCall := runner.calls[1]
+	if argValue(retryCall.args, "--out-root") != outRoot || argValue(retryCall.args, "--training-package") != filepath.Join(outRoot, "training.json") {
+		t.Fatalf("retry did not reuse persisted optimizer paths: %+v", retryCall.args)
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_created") || !strings.Contains(stdout.String(), "imported_candidate: planner@v2") {
+		t.Fatalf("retry stdout = %s", stdout.String())
+	}
+}
+
+func TestSkillOptTrainContinueRecordsOptimizerSetupFailure(t *testing.T) {
+	home, _ := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--gate", "unsupported",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue invalid gate exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `optimizer gate "unsupported" is not supported`) {
+		t.Fatalf("invalid gate stderr = %q", stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("optimizer ran after setup failure: %+v", runner.calls)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateTrainingPackageCreated || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after optimizer setup failure = %+v", iteration)
+	}
+	if !strings.Contains(iteration.MetadataJSON, `"status":"failed"`) || !strings.Contains(iteration.MetadataJSON, "unsupported") {
+		t.Fatalf("iteration metadata after setup failure = %s", iteration.MetadataJSON)
+	}
+}
+
+func TestSkillOptTrainContinueRejectsCandidateForDifferentSessionTemplate(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("other", "Do different work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate other returned error: %v", err)
+	}
+	other, err := store.GetAgentTemplate(context.Background(), "other")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate other returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after other template seed returned error: %v", err)
+	}
+
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "other", other.VersionID, "Do unrelated candidate work."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue mismatched candidate exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `optimizer candidate template_id "other" does not match train session template "planner"`) {
+		t.Fatalf("mismatched candidate stderr = %q", stderr.String())
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("optimizer calls = %+v, want one", runner.calls)
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateOptimizerCompleted || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after mismatched candidate = %+v", iteration)
+	}
+	if !strings.Contains(iteration.MetadataJSON, `"candidate_import"`) || !strings.Contains(iteration.MetadataJSON, `"status":"failed"`) {
+		t.Fatalf("iteration metadata after mismatched candidate = %s", iteration.MetadataJSON)
+	}
+	if _, err := store.GetAgentTemplateVersionByID(context.Background(), "other@v2"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("mismatched candidate imported other version err=%v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after mismatched candidate returned error: %v", err)
+	}
+
+	runner.candidate = cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with recovered candidate guidance.")
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue deterministic import retry exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("deterministic import retry reran optimizer: %+v", runner.calls)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--rerun-optimizer",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue after explicit optimizer rerun exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("optimizer calls after explicit optimizer rerun = %+v, want two", runner.calls)
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_created") || !strings.Contains(stdout.String(), "imported_candidate: planner@v2") {
+		t.Fatalf("explicit optimizer rerun stdout = %s", stdout.String())
+	}
+}
+
+func TestSkillOptTrainContinueOptimizerHandlesMissingIteration(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertSkillOptTrainSession(context.Background(), db.SkillOptTrainSession{
+		ID:             "optimizer-train-empty",
+		TemplateID:     "planner",
+		TargetRepo:     "owner/product",
+		RequestSummary: "Train planner outputs from human feedback.",
+		TaskKind:       "custom",
+		State:          skillopt.TrainStateFeedbackSynced,
+	}); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSession returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train-empty",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue missing iteration exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "next: train session has no iteration to continue") {
+		t.Fatalf("missing iteration stdout = %s", stdout.String())
+	}
+}
+
+func TestSkillOptTrainContinueRefusesConcurrentOptimizer(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with lock-safe candidate guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	store := openCLIJobStore(t, home)
+	release, _, err := acquireSkillOptTrainOptimizerLock(context.Background(), store, "optimizer-train", "optimizer-train-001", time.Hour)
+	if err != nil {
+		t.Fatalf("acquire optimizer lock returned error: %v", err)
+	}
+	defer store.Close()
+	defer func() {
+		_ = release(context.Background())
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue locked optimizer exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "skillopt train optimizer is already running") {
+		t.Fatalf("locked optimizer stderr = %q", stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("optimizer ran while lock was held: %+v", runner.calls)
+	}
+}
+
 type skillOptConcurrentGenerationRunner struct {
 	mu               sync.Mutex
 	calls            []agentStartCall
@@ -3471,6 +3982,199 @@ func (f *skillOptFakeGitHub) CreateIssue(_ context.Context, input github.CreateI
 
 func (f *skillOptFakeGitHub) ListIssueComments(_ context.Context, _ github.Repository, issueNumber int64) ([]github.IssueComment, error) {
 	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
+}
+
+func seedSkillOptTrainFeedbackSynced(t *testing.T) (string, string) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	baselineBlob, err := blobStore.Put([]byte("# Baseline\n\nPlan the edit.\n"))
+	if err != nil {
+		t.Fatalf("Put baseline returned error: %v", err)
+	}
+	candidateBlob, err := blobStore.Put([]byte("# Candidate\n\nPlan the edit and verification.\n"))
+	if err != nil {
+		t.Fatalf("Put candidate returned error: %v", err)
+	}
+	for _, record := range []db.EvalArtifact{
+		{ID: "baseline-artifact", Hash: baselineBlob.Hash, MediaType: "text/markdown", SizeBytes: baselineBlob.Size, Driver: "text"},
+		{ID: "candidate-artifact", Hash: candidateBlob.Hash, MediaType: "text/markdown", SizeBytes: candidateBlob.Size, Driver: "text"},
+	} {
+		if err := store.UpsertEvalArtifact(context.Background(), record); err != nil {
+			t.Fatalf("UpsertEvalArtifact returned error: %v", err)
+		}
+	}
+	metadata := skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil)
+	session := db.SkillOptTrainSession{
+		ID:                "optimizer-train",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/product",
+		RequestSummary:    "Train planner outputs from human feedback.",
+		TaskKind:          "custom",
+		State:             skillopt.TrainStateFeedbackSynced,
+		MetadataJSON:      metadata,
+	}
+	iteration := db.SkillOptTrainIteration{
+		ID:                    "optimizer-train-001",
+		SessionID:             session.ID,
+		EvalRunID:             "optimizer-train-review-001",
+		BaseTemplateVersionID: installed.VersionID,
+		Mode:                  db.EvalRunModeValidate,
+		ExplorationLevel:      db.ExplorationLevelLow,
+		State:                 skillopt.TrainStateFeedbackSynced,
+		MetadataJSON:          metadata,
+	}
+	run := db.EvalRun{
+		ID:                iteration.EvalRunID,
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/product",
+		State:             "review",
+		Mode:              db.EvalRunModeValidate,
+		ExplorationLevel:  db.ExplorationLevelLow,
+		OptionsCount:      2,
+		MetadataJSON:      metadata,
+	}
+	if err := store.UpsertSkillOptTrainSession(context.Background(), session); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSession returned error: %v", err)
+	}
+	if err := store.UpsertSkillOptTrainIteration(context.Background(), iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainIteration returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(context.Background(), run); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:               run.ID,
+		ItemID:              "item-001",
+		Title:               "README plan",
+		BaselineArtifactID:  "baseline-artifact",
+		CandidateArtifactID: "candidate-artifact",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	if err := store.UpsertFeedbackEvent(context.Background(), db.FeedbackEvent{
+		RunID:     run.ID,
+		ItemID:    "item-001",
+		Choice:    "b",
+		Reasoning: "Candidate is more complete.",
+		Reviewer:  "github:jerry",
+		Source:    "github",
+		SourceURL: "https://github.com/owner/product/issues/1#issuecomment-1",
+		CreatedAt: "2026-06-02T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertFeedbackEvent returned error: %v", err)
+	}
+	return home, installed.VersionID
+}
+
+type skillOptTrainFakeOptimizerRunner struct {
+	candidate     skillopt.CandidatePackage
+	fail          bool
+	lookPathValue string
+	calls         []skillOptTrainFakeOptimizerCall
+}
+
+type skillOptTrainFakeOptimizerCall struct {
+	dir     string
+	command string
+	args    []string
+}
+
+func (r *skillOptTrainFakeOptimizerRunner) Run(_ context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
+	r.calls = append(r.calls, skillOptTrainFakeOptimizerCall{dir: dir, command: command, args: append([]string{}, args...)})
+	result := subprocess.Result{Command: command, Args: args}
+	if r.fail {
+		result.Stderr = "optimizer stderr"
+		return result, errors.New("exit status 2")
+	}
+	candidateOutput := argValue(args, "--candidate-output")
+	artifactDir := argValue(args, "--artifact-dir")
+	if candidateOutput == "" || artifactDir == "" {
+		result.Stderr = "missing output paths"
+		return result, errors.New("missing output paths")
+	}
+	diffContent := []byte("candidate diff\n")
+	diffSize := int64(len(diffContent))
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		result.Stderr = err.Error()
+		return result, err
+	}
+	if err := os.WriteFile(filepath.Join(artifactDir, "candidate.diff.md"), diffContent, 0o644); err != nil {
+		result.Stderr = err.Error()
+		return result, err
+	}
+	candidate := r.candidate
+	candidate.Summary.DiffArtifactID = "candidate-diff"
+	candidate.Artifacts = []skillopt.CandidateArtifactRef{{
+		ID:        "candidate-diff",
+		Path:      "candidate.diff.md",
+		Hash:      artifact.ContentHash(diffContent),
+		MediaType: "text/markdown",
+		Driver:    "text",
+		SizeBytes: &diffSize,
+	}}
+	encoded, err := json.Marshal(candidate)
+	if err != nil {
+		result.Stderr = err.Error()
+		return result, err
+	}
+	if err := os.MkdirAll(filepath.Dir(candidateOutput), 0o755); err != nil {
+		result.Stderr = err.Error()
+		return result, err
+	}
+	if err := os.WriteFile(candidateOutput, encoded, 0o644); err != nil {
+		result.Stderr = err.Error()
+		return result, err
+	}
+	result.Stdout = "wrote candidate package: " + candidateOutput + "\n"
+	return result, nil
+}
+
+func (r *skillOptTrainFakeOptimizerRunner) LookPath(file string) (string, error) {
+	if strings.TrimSpace(file) == "" {
+		return "", errors.New("empty file")
+	}
+	if strings.TrimSpace(r.lookPathValue) != "" {
+		return r.lookPathValue, nil
+	}
+	return "/fake/bin/" + file, nil
+}
+
+func argValue(args []string, name string) string {
+	for index := 0; index < len(args)-1; index++ {
+		if args[index] == name {
+			return args[index+1]
+		}
+	}
+	return ""
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func cliSkillOptTemplate(id string, body string) db.AgentTemplate {


### PR DESCRIPTION
WHAT
- Adds `gitmoot skillopt train continue` optimizer orchestration for feedback-synced train iterations.
- Exports the training package, runs the external `gitmoot-skillopt optimize` command, imports the candidate package as a pending template version, and advances to `candidate_created` without promotion.

WHY
- SkillOpt train needs the product/control-layer handoff to the external optimizer so human feedback can become a reviewable candidate template version.

CHANGES
- Added optimizer flags: `--skillopt-bin`, `--model`, `--optimizer-model`, `--target-model`, `--gate`, `--out-root`, `--timeout`, `--dry-run`, and `--rerun-optimizer`.
- Added optimizer path resolution, training package export, sanitized metadata recording, subprocess execution, candidate import validation, and per-iteration optimizer locking.
- Reuses exported package paths on retry and rejects changed `--out-root` after package export.
- Candidate import failures now keep `optimizer_completed` for deterministic import retry; `--rerun-optimizer` intentionally replaces the candidate package.
- Passes explicit `--artifact-dir` to the external optimizer and supports candidate packages that omit `base_version_id` when the active base still matches.
- Added focused CLI tests with fake subprocess runners plus a local fake executable smoke test.

RESULTS
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrainContinue.*Optimizer|SkillOptTrainContinueRecordsOptimizer|SkillOptTrainContinueRejectsCandidate'`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli ./internal/skillopt ./internal/subprocess ./internal/db`
- `GOTOOLCHAIN=go1.26.2 go test ./... -timeout 8m`
- `git diff --check`
- `codex exec review --uncommitted --ignore-user-config -m codex-auto-review --disable image_generation`

Final raw review output:
```text
codex
I did not identify any discrete, actionable bugs in the current changeset that would clearly break existing behavior or merit blocking the patch. The new optimizer orchestration path appears internally consistent and is covered by focused tests for the main success and failure modes.
I did not identify any discrete, actionable bugs in the current changeset that would clearly break existing behavior or merit blocking the patch. The new optimizer orchestration path appears internally consistent and is covered by focused tests for the main success and failure modes.
```

RISK
- `gitmoot-skillopt` is not installed on PATH in this environment, so the real `gitmoot-skillopt optimize --help` contract could not be checked locally. The command shape is covered by fake runner tests and a local fake executable smoke test.
- Earlier default review attempts failed because the local Codex review tool tried to use unavailable `gpt-image-2`; the final review was run with image generation disabled.