### PR TITLE
Add SkillOpt train candidate review flow

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -3,13 +3,16 @@ package cli
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	neturl "net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -76,7 +79,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -105,7 +108,7 @@ func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -396,6 +399,10 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	timeout := fs.String("timeout", "", "optimizer timeout duration")
 	dryRun := fs.Bool("dry-run", false, "ask gitmoot-skillopt to avoid model calls while still producing a candidate package")
 	rerunOptimizer := fs.Bool("rerun-optimizer", false, "rerun gitmoot-skillopt after optimizer completion instead of retrying the existing candidate import")
+	promote := fs.String("promote", "", "candidate version to promote after candidate review")
+	reject := fs.String("reject", "", "candidate version to reject after candidate review")
+	reason := fs.String("reason", "", "decision reason required with --reject")
+	startNext := fs.Bool("start-next", false, "start the next train iteration after a promote or reject decision")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -429,6 +436,10 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 				DryRun:         *dryRun,
 				RerunOptimizer: *rerunOptimizer,
 			},
+			PromoteCandidate: *promote,
+			RejectCandidate:  *reject,
+			DecisionReason:   *reason,
+			StartNext:        *startNext,
 		})
 		return err
 	}); err != nil {
@@ -454,6 +465,10 @@ type skillOptTrainContinueRequest struct {
 	GeneratorType     string
 	GenerationLockTTL time.Duration
 	Optimizer         skillOptTrainOptimizerRequest
+	PromoteCandidate  string
+	RejectCandidate   string
+	DecisionReason    string
+	StartNext         bool
 }
 
 type skillOptTrainOptimizerRequest struct {
@@ -488,6 +503,23 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 	if iteration == nil {
 		output.Lines = []string{"next: train session has no iteration to continue"}
 		return output, nil
+	}
+	if strings.TrimSpace(request.PromoteCandidate) != "" && strings.TrimSpace(request.RejectCandidate) != "" {
+		return skillOptTrainContinueOutput{}, errors.New("train continue accepts only one of --promote or --reject")
+	}
+	if skillOptTrainDecisionRequested(request) &&
+		summary.CurrentPhase != skillopt.TrainStateCandidateReviewPublished &&
+		summary.CurrentPhase != skillopt.TrainStateCandidateCreated &&
+		summary.CurrentPhase != skillopt.TrainStateCandidatePromoted &&
+		summary.CurrentPhase != skillopt.TrainStateCandidateRejected {
+		return skillOptTrainContinueOutput{}, fmt.Errorf("candidate decisions require train iteration at %s; current phase is %s", skillopt.TrainStateCandidateReviewPublished, summary.CurrentPhase)
+	}
+	if request.StartNext &&
+		summary.CurrentPhase != skillopt.TrainStateCandidateReviewPublished &&
+		summary.CurrentPhase != skillopt.TrainStateCandidateCreated &&
+		summary.CurrentPhase != skillopt.TrainStateCandidatePromoted &&
+		summary.CurrentPhase != skillopt.TrainStateCandidateRejected {
+		return skillOptTrainContinueOutput{}, fmt.Errorf("--start-next requires a promoted or rejected candidate; current phase is %s", summary.CurrentPhase)
 	}
 	switch summary.CurrentPhase {
 	case skillopt.TrainStateItemsReady:
@@ -611,10 +643,184 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 			ContinueReady: true,
 			Lines:         lines,
 		}, nil
+	case skillopt.TrainStateCandidateCreated:
+		releaseCandidateReviewLock, _, err := acquireSkillOptTrainCandidateReviewLock(ctx, store, session.ID, iteration.ID)
+		if err != nil {
+			return output, err
+		}
+		defer func() {
+			_ = releaseCandidateReviewLock(context.Background())
+		}()
+		session, iteration, counts, err = loadSkillOptTrainStatus(ctx, store, request.SessionID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		summary = skillopt.BuildTrainStatusSummary(session, iteration, counts)
+		output = skillOptTrainContinueOutput{Summary: summary, Counts: counts}
+		if iteration == nil {
+			output.Lines = []string{"next: train session has no iteration to continue"}
+			return output, nil
+		}
+		if skillOptTrainDecisionRequested(request) && summary.CurrentPhase == skillopt.TrainStateCandidateReviewPublished {
+			return continueSkillOptTrainCandidateDecision(ctx, store, session, *iteration, counts, request)
+		}
+		if summary.CurrentPhase != skillopt.TrainStateCandidateCreated {
+			output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
+			return output, nil
+		}
+		candidateID := strings.TrimSpace(iteration.CandidateVersionID)
+		if requestedCandidateID := requestedSkillOptTrainCandidateID(request); requestedCandidateID != "" && requestedCandidateID != candidateID {
+			return skillOptTrainContinueOutput{}, fmt.Errorf("candidate %s does not match train iteration candidate %s", requestedCandidateID, candidateID)
+		}
+		if result, err := syncSkillOptTrainCandidateDecision(ctx, store, session, *iteration, candidateID, requestedSkillOptTrainCandidateDecision(request), strings.TrimSpace(request.DecisionReason)); err != nil || result.Decided {
+			if err != nil {
+				return skillOptTrainContinueOutput{}, err
+			}
+			return continueSkillOptTrainAfterCandidateDecision(ctx, store, session.ID, request, result)
+		}
+		if request.StartNext {
+			return skillOptTrainContinueOutput{}, fmt.Errorf("--start-next requires a promoted or rejected candidate; current phase is %s", summary.CurrentPhase)
+		}
+		if skillOptTrainDecisionRequested(request) {
+			if candidateID == "" {
+				return skillOptTrainContinueOutput{}, errors.New("train iteration has no candidate version to review")
+			}
+			if _, recovered, err := recoverSkillOptCandidateReviewPublication(ctx, paths, store, session, *iteration, candidateID); err != nil {
+				return skillOptTrainContinueOutput{}, err
+			} else if !recovered {
+				return skillOptTrainContinueOutput{}, fmt.Errorf("candidate decisions require train iteration at %s; current phase is %s", skillopt.TrainStateCandidateReviewPublished, summary.CurrentPhase)
+			}
+			updatedSession, updatedIteration, updatedCounts, err := loadSkillOptTrainStatus(ctx, store, session.ID)
+			if err != nil {
+				return skillOptTrainContinueOutput{}, err
+			}
+			if updatedIteration == nil {
+				return skillOptTrainContinueOutput{}, errors.New("train session has no recovered iteration to decide")
+			}
+			return continueSkillOptTrainCandidateDecision(ctx, store, updatedSession, *updatedIteration, updatedCounts, request)
+		}
+		result, err := publishSkillOptTrainCandidateReview(ctx, paths, store, session, *iteration, request.Home)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSession, updatedIteration, updatedCounts, err := loadSkillOptTrainStatus(ctx, store, session.ID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSummary := skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
+		lines := []string{
+			fmt.Sprintf("candidate_review: %s", result.URL),
+			fmt.Sprintf("candidate: %s", result.CandidateVersionID),
+			"next: promote with --promote, reject with --reject --reason, or wait for a human decision",
+		}
+		return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
+	case skillopt.TrainStateCandidateReviewPublished:
+		return continueSkillOptTrainCandidateDecision(ctx, store, session, *iteration, counts, request)
+	case skillopt.TrainStateCandidatePromoted, skillopt.TrainStateCandidateRejected:
+		if err := validateTerminalSkillOptTrainDecisionRequest(*iteration, request); err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		if !request.StartNext {
+			output.Lines = []string{"next: stop or run --start-next"}
+			return output, nil
+		}
+		next, err := startNextSkillOptTrainIteration(ctx, store, session, *iteration)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSession, updatedIteration, updatedCounts, err := loadSkillOptTrainStatus(ctx, store, session.ID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSummary := skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
+		lines := []string{}
+		if decision := requestedSkillOptTrainCandidateDecision(request); decision != "" {
+			lines = append(lines, fmt.Sprintf("%s_candidate: %s", decision, requestedSkillOptTrainCandidateID(request)))
+		}
+		lines = append(lines,
+			fmt.Sprintf("started_iteration: %s", next.ID),
+			fmt.Sprintf("base_version: %s", next.BaseTemplateVersionID),
+			"next: generate review options with train continue",
+		)
+		return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
 	default:
 		output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
 		return output, nil
 	}
+}
+
+func continueSkillOptTrainCandidateDecision(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, counts skillopt.TrainStatusCounts, request skillOptTrainContinueRequest) (skillOptTrainContinueOutput, error) {
+	summary := skillopt.BuildTrainStatusSummary(session, &iteration, counts)
+	output := skillOptTrainContinueOutput{Summary: summary, Counts: counts}
+	result, err := decideSkillOptTrainCandidate(ctx, store, session, iteration, request)
+	if err != nil {
+		return skillOptTrainContinueOutput{}, err
+	}
+	if !result.Decided {
+		if request.StartNext {
+			return skillOptTrainContinueOutput{}, fmt.Errorf("--start-next requires a promoted or rejected candidate; current phase is %s", summary.CurrentPhase)
+		}
+		output.Lines = []string{"next: promote with --promote <candidate-version> or reject with --reject <candidate-version> --reason <text>"}
+		return output, nil
+	}
+	return continueSkillOptTrainAfterCandidateDecision(ctx, store, session.ID, request, result)
+}
+
+func continueSkillOptTrainAfterCandidateDecision(ctx context.Context, store *db.Store, sessionID string, request skillOptTrainContinueRequest, result skillOptTrainCandidateDecisionResult) (skillOptTrainContinueOutput, error) {
+	updatedSession, updatedIteration, updatedCounts, err := loadSkillOptTrainStatus(ctx, store, sessionID)
+	if err != nil {
+		return skillOptTrainContinueOutput{}, err
+	}
+	updatedSummary := skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
+	if request.StartNext {
+		if updatedIteration == nil {
+			return skillOptTrainContinueOutput{}, errors.New("train session has no decided iteration to continue")
+		}
+		next, err := startNextSkillOptTrainIteration(ctx, store, updatedSession, *updatedIteration)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSession, updatedIteration, updatedCounts, err = loadSkillOptTrainStatus(ctx, store, sessionID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSummary = skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
+		lines := []string{
+			fmt.Sprintf("%s_candidate: %s", result.Decision, result.CandidateVersionID),
+			fmt.Sprintf("started_iteration: %s", next.ID),
+			fmt.Sprintf("base_version: %s", next.BaseTemplateVersionID),
+			"next: generate review options with train continue",
+		}
+		return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
+	}
+	lines := []string{
+		fmt.Sprintf("%s_candidate: %s", result.Decision, result.CandidateVersionID),
+		"next: stop or run --start-next",
+	}
+	return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
+}
+
+func validateTerminalSkillOptTrainDecisionRequest(iteration db.SkillOptTrainIteration, request skillOptTrainContinueRequest) error {
+	decision := requestedSkillOptTrainCandidateDecision(request)
+	if decision == "" {
+		return nil
+	}
+	candidateID := requestedSkillOptTrainCandidateID(request)
+	expected := strings.TrimSpace(iteration.CandidateVersionID)
+	if candidateID != expected {
+		return fmt.Errorf("candidate %s does not match train iteration candidate %s", candidateID, expected)
+	}
+	currentDecision := ""
+	switch skillopt.NormalizeTrainState(iteration.State) {
+	case skillopt.TrainStateCandidatePromoted:
+		currentDecision = "promoted"
+	case skillopt.TrainStateCandidateRejected:
+		currentDecision = "rejected"
+	}
+	if currentDecision != "" && decision != currentDecision {
+		return fmt.Errorf("candidate %s is already %s, not %s", candidateID, currentDecision, decision)
+	}
+	return nil
 }
 
 type skillOptTrainOptimizerResult struct {
@@ -634,6 +840,945 @@ type skillOptTrainOptimizerPaths struct {
 	TrainingPackagePath  string
 	CandidatePackagePath string
 	ArtifactDir          string
+}
+
+type skillOptTrainCandidateReviewResult struct {
+	URL                string
+	CandidateVersionID string
+}
+
+type skillOptTrainCandidateDecisionResult struct {
+	Decided            bool
+	Decision           string
+	CandidateVersionID string
+}
+
+const (
+	skillOptCandidateReviewEvalReportLimit = 12000
+	skillOptCandidateReviewDiffLimit       = 32000
+)
+
+func publishSkillOptTrainCandidateReview(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, commandHome string) (skillOptTrainCandidateReviewResult, error) {
+	if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateCandidateReviewPublished); err != nil {
+		return skillOptTrainCandidateReviewResult{}, err
+	}
+	candidateID := strings.TrimSpace(iteration.CandidateVersionID)
+	if candidateID == "" {
+		return skillOptTrainCandidateReviewResult{}, errors.New("train iteration has no candidate version to review")
+	}
+	if result, recovered, err := recoverSkillOptCandidateReviewPublication(ctx, paths, store, session, iteration, candidateID); recovered || err != nil {
+		return result, err
+	}
+	refreshedSession, err := store.GetSkillOptTrainSession(ctx, session.ID)
+	if err != nil {
+		return skillOptTrainCandidateReviewResult{}, err
+	}
+	refreshedIteration, err := store.GetSkillOptTrainIteration(ctx, iteration.ID)
+	if err != nil {
+		return skillOptTrainCandidateReviewResult{}, err
+	}
+	session = refreshedSession
+	iteration = refreshedIteration
+	if err := preventDuplicateSkillOptCandidateReviewPublish(session, iteration, candidateID, time.Now().UTC()); err != nil {
+		return skillOptTrainCandidateReviewResult{}, err
+	}
+	repo, err := resolveSkillOptTrainCandidateReviewRepo(session, iteration)
+	if err != nil {
+		return skillOptTrainCandidateReviewResult{}, err
+	}
+	body, err := skillOptTrainCandidateReviewBody(ctx, store, session, iteration, commandHome)
+	if err != nil {
+		return skillOptTrainCandidateReviewResult{}, err
+	}
+	client := newSkillOptGitHubClient()
+	if iteration.PullRequestNumber > 0 && iteration.IssueNumber == 0 {
+		iteration.PullRequestRepo = repo.FullName()
+	} else {
+		iteration.IssueRepo = repo.FullName()
+	}
+	title := fmt.Sprintf("SkillOpt candidate review: %s", session.ID)
+	publishingMetadata := map[string]any{
+		"status":              "publishing",
+		"candidate_version":   candidateID,
+		"issue_repo":          iteration.IssueRepo,
+		"issue_number":        iteration.IssueNumber,
+		"issue_url":           iteration.IssueURL,
+		"pull_request_repo":   iteration.PullRequestRepo,
+		"pull_request_number": iteration.PullRequestNumber,
+		"pull_request_url":    iteration.PullRequestURL,
+		"issue_title":         title,
+		"started_at":          time.Now().UTC().Format(time.RFC3339Nano),
+		"source":              "gitmoot skillopt train continue",
+	}
+	if err := writeSkillOptCandidateReviewRecovery(paths, session, iteration, publishingMetadata); err != nil {
+		return skillOptTrainCandidateReviewResult{}, fmt.Errorf("write candidate review pre-publish recovery marker: %w", err)
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", publishingMetadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", publishingMetadata)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+		return skillOptTrainCandidateReviewResult{}, err
+	}
+	postingMetadata := make(map[string]any, len(publishingMetadata)+2)
+	for key, value := range publishingMetadata {
+		postingMetadata[key] = value
+	}
+	postingMetadata["status"] = "posting_external"
+	postingMetadata["external_post_started_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+	if err := writeSkillOptCandidateReviewRecovery(paths, session, iteration, postingMetadata); err != nil {
+		if metaErr := recordFailedSkillOptCandidateReviewPublish(ctx, store, session, iteration, publishingMetadata, err); metaErr != nil {
+			return skillOptTrainCandidateReviewResult{}, fmt.Errorf("%w; failed to record candidate review publish failure: %v", err, metaErr)
+		}
+		return skillOptTrainCandidateReviewResult{}, fmt.Errorf("write candidate review external-post recovery marker: %w", err)
+	}
+	var url string
+	if iteration.IssueNumber > 0 {
+		comment, err := client.PostIssueComment(ctx, repo, iteration.IssueNumber, body)
+		if err != nil {
+			if metaErr := recordFailedSkillOptCandidateReviewPublish(ctx, store, session, iteration, publishingMetadata, err); metaErr != nil {
+				return skillOptTrainCandidateReviewResult{}, fmt.Errorf("%w; failed to record candidate review publish failure: %v", err, metaErr)
+			}
+			return skillOptTrainCandidateReviewResult{}, err
+		}
+		url = comment.URL
+		if strings.TrimSpace(iteration.IssueURL) == "" {
+			iteration.IssueURL = skillOptReviewTargetURLFromCommentOrHost(comment.URL, repo, "issues", iteration.IssueNumber)
+		}
+	} else if iteration.PullRequestNumber > 0 {
+		comment, err := client.PostIssueComment(ctx, repo, iteration.PullRequestNumber, body)
+		if err != nil {
+			if metaErr := recordFailedSkillOptCandidateReviewPublish(ctx, store, session, iteration, publishingMetadata, err); metaErr != nil {
+				return skillOptTrainCandidateReviewResult{}, fmt.Errorf("%w; failed to record candidate review publish failure: %v", err, metaErr)
+			}
+			return skillOptTrainCandidateReviewResult{}, err
+		}
+		url = comment.URL
+		if strings.TrimSpace(iteration.PullRequestURL) == "" {
+			iteration.PullRequestURL = skillOptReviewTargetURLFromCommentOrHost(comment.URL, repo, "pull", iteration.PullRequestNumber)
+		}
+	} else {
+		issue, err := client.CreateIssue(ctx, github.CreateIssueInput{
+			Repo:  repo,
+			Title: title,
+			Body:  body,
+		})
+		if err != nil {
+			if metaErr := recordFailedSkillOptCandidateReviewPublish(ctx, store, session, iteration, publishingMetadata, err); metaErr != nil {
+				return skillOptTrainCandidateReviewResult{}, fmt.Errorf("%w; failed to record candidate review publish failure: %v", err, metaErr)
+			}
+			return skillOptTrainCandidateReviewResult{}, err
+		}
+		iteration.IssueNumber = issue.Number
+		iteration.IssueURL = issue.URL
+		url = issue.URL
+	}
+	externalMetadata := skillOptCandidateReviewPublicationMetadata(publishingMetadata, iteration, url, "published_external")
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", externalMetadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", externalMetadata)
+	recoveryErr := writeSkillOptCandidateReviewRecovery(paths, session, iteration, externalMetadata)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+		if recoveryErr != nil {
+			return skillOptTrainCandidateReviewResult{}, fmt.Errorf("%w; candidate review was published at %s but recovery marker write failed: %v", err, url, recoveryErr)
+		}
+		return skillOptTrainCandidateReviewResult{}, err
+	}
+	iteration.State = skillopt.TrainStateCandidateReviewPublished
+	session.State = skillopt.TrainStateCandidateReviewPublished
+	metadata := skillOptCandidateReviewPublicationMetadata(publishingMetadata, iteration, url, "published")
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", metadata)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+		return skillOptTrainCandidateReviewResult{}, err
+	}
+	_ = removeSkillOptCandidateReviewRecovery(paths, session, iteration)
+	return skillOptTrainCandidateReviewResult{URL: url, CandidateVersionID: candidateID}, nil
+}
+
+func recoverSkillOptCandidateReviewPublication(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, candidateID string) (skillOptTrainCandidateReviewResult, bool, error) {
+	sources := []map[string]any{
+		decodedSkillOptMetadataValue(decodedSkillOptMetadata(iteration.MetadataJSON)["candidate_review"]),
+		decodedSkillOptMetadataValue(decodedSkillOptMetadata(session.MetadataJSON)["candidate_review"]),
+	}
+	if review, ok, err := readSkillOptCandidateReviewRecovery(paths, session, iteration); err != nil {
+		return skillOptTrainCandidateReviewResult{}, true, err
+	} else if ok {
+		if metadataString(review, "status") == "publishing" && metadataString(review, "external_post_started_at") == "" {
+			metadata := make(map[string]any, len(review)+3)
+			for key, value := range review {
+				metadata[key] = value
+			}
+			metadata["status"] = "failed"
+			metadata["error"] = "candidate review publication interrupted before external post started"
+			metadata["failed_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+			session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", metadata)
+			iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", metadata)
+			if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+				return skillOptTrainCandidateReviewResult{}, true, err
+			}
+			_ = removeSkillOptCandidateReviewRecovery(paths, session, iteration)
+			return skillOptTrainCandidateReviewResult{}, false, nil
+		}
+		sources = append(sources, review)
+	}
+	for _, review := range sources {
+		status := metadataString(review, "status")
+		if status == "posting_external" {
+			target := skillOptCandidateReviewRecoveryTarget(review)
+			if target == "" {
+				target = "inspect the configured GitHub review surface before retrying"
+			}
+			return skillOptTrainCandidateReviewResult{}, true, fmt.Errorf("candidate review publication for %s was interrupted after external post started; %s", candidateID, target)
+		}
+		if status != "published_external" && status != "published" {
+			continue
+		}
+		reviewCandidate := metadataString(review, "candidate_version")
+		if reviewCandidate != "" && reviewCandidate != candidateID {
+			continue
+		}
+		url := skillOptCandidateReviewURLFromMetadata(review)
+		if url == "" {
+			return skillOptTrainCandidateReviewResult{}, true, fmt.Errorf("candidate review publication for %s is marked %s but has no recoverable review URL", candidateID, status)
+		}
+		applySkillOptCandidateReviewMetadataToIteration(review, &iteration)
+		iteration.State = skillopt.TrainStateCandidateReviewPublished
+		session.State = skillopt.TrainStateCandidateReviewPublished
+		metadata := make(map[string]any, len(review)+3)
+		for key, value := range review {
+			metadata[key] = value
+		}
+		metadata["status"] = "published"
+		metadata["review_url"] = url
+		metadata["recovered_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+		session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", metadata)
+		iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", metadata)
+		if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+			return skillOptTrainCandidateReviewResult{}, true, err
+		}
+		_ = removeSkillOptCandidateReviewRecovery(paths, session, iteration)
+		return skillOptTrainCandidateReviewResult{URL: url, CandidateVersionID: candidateID}, true, nil
+	}
+	return skillOptTrainCandidateReviewResult{}, false, nil
+}
+
+func preventDuplicateSkillOptCandidateReviewPublish(session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, candidateID string, now time.Time) error {
+	for _, source := range []struct {
+		name     string
+		metadata string
+	}{
+		{name: "iteration", metadata: iteration.MetadataJSON},
+		{name: "session", metadata: session.MetadataJSON},
+	} {
+		review := decodedSkillOptMetadataValue(decodedSkillOptMetadata(source.metadata)["candidate_review"])
+		status := metadataString(review, "status")
+		if status == "publishing" && !skillOptCandidateReviewPublishingFresh(review, now) {
+			continue
+		}
+		if status != "publishing" && status != "published" {
+			continue
+		}
+		reviewCandidate := metadataString(review, "candidate_version")
+		if reviewCandidate != "" && reviewCandidate != candidateID {
+			continue
+		}
+		target := skillOptCandidateReviewRecoveryTarget(review)
+		if target == "" {
+			target = "inspect candidate_review metadata before retrying"
+		}
+		return fmt.Errorf("candidate review publication for %s is marked %s in %s metadata; %s", candidateID, status, source.name, target)
+	}
+	return nil
+}
+
+func skillOptCandidateReviewPublishingFresh(review map[string]any, now time.Time) bool {
+	startedAt := metadataString(review, "started_at")
+	if startedAt == "" {
+		return false
+	}
+	started, err := time.Parse(time.RFC3339Nano, startedAt)
+	if err != nil {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return now.Before(started.Add(skillOptTrainCandidateReviewLockTTL))
+}
+
+func writeSkillOptCandidateReviewRecovery(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, metadata map[string]any) error {
+	path := skillOptCandidateReviewRecoveryPath(paths, session, iteration)
+	if path == "" {
+		return errors.New("candidate review recovery path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	encoded, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	tmpPath := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	if err := os.WriteFile(tmpPath, encoded, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+func readSkillOptCandidateReviewRecovery(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) (map[string]any, bool, error) {
+	path := skillOptCandidateReviewRecoveryPath(paths, session, iteration)
+	if path == "" {
+		return nil, false, nil
+	}
+	content, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(content, &metadata); err != nil {
+		return nil, true, fmt.Errorf("read candidate review recovery marker %s: %w", path, err)
+	}
+	return metadata, true, nil
+}
+
+func removeSkillOptCandidateReviewRecovery(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) error {
+	path := skillOptCandidateReviewRecoveryPath(paths, session, iteration)
+	if path == "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func skillOptCandidateReviewRecoveryPath(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) string {
+	if strings.TrimSpace(paths.Home) == "" {
+		return ""
+	}
+	name := skillOptCandidateReviewRecoveryName(session.ID, iteration.ID)
+	if name == "" {
+		return ""
+	}
+	return filepath.Join(paths.Home, "skillopt", "candidate-reviews", name+".json")
+}
+
+func skillOptCandidateReviewRecoveryName(sessionID string, iterationID string) string {
+	sessionID = encodeSkillOptCandidateReviewRecoveryToken(sessionID)
+	iterationID = encodeSkillOptCandidateReviewRecoveryToken(iterationID)
+	if sessionID == "" || iterationID == "" {
+		return ""
+	}
+	return sessionID + "-" + iterationID
+}
+
+func encodeSkillOptCandidateReviewRecoveryToken(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString([]byte(value))
+}
+
+func skillOptCandidateReviewPublicationMetadata(base map[string]any, iteration db.SkillOptTrainIteration, reviewURL string, status string) map[string]any {
+	metadata := make(map[string]any, len(base)+9)
+	for key, value := range base {
+		metadata[key] = value
+	}
+	metadata["status"] = status
+	metadata["issue_repo"] = iteration.IssueRepo
+	metadata["issue_number"] = iteration.IssueNumber
+	metadata["issue_url"] = iteration.IssueURL
+	metadata["pull_request_repo"] = iteration.PullRequestRepo
+	metadata["pull_request_number"] = iteration.PullRequestNumber
+	metadata["pull_request_url"] = iteration.PullRequestURL
+	metadata["review_url"] = reviewURL
+	metadata["published_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+	return metadata
+}
+
+func recordFailedSkillOptCandidateReviewPublish(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, publishingMetadata map[string]any, publishErr error) error {
+	metadata := make(map[string]any, len(publishingMetadata)+3)
+	for key, value := range publishingMetadata {
+		metadata[key] = value
+	}
+	metadata["status"] = "failed"
+	metadata["error"] = truncateForMetadata(publishErr.Error())
+	metadata["failed_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", metadata)
+	return store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration)
+}
+
+func applySkillOptCandidateReviewMetadataToIteration(review map[string]any, iteration *db.SkillOptTrainIteration) {
+	if value := metadataString(review, "issue_repo"); value != "" {
+		iteration.IssueRepo = value
+	}
+	if value := metadataString(review, "issue_number"); value != "" {
+		if number, err := strconv.ParseInt(value, 10, 64); err == nil {
+			iteration.IssueNumber = number
+		}
+	}
+	if value := metadataString(review, "issue_url"); value != "" {
+		iteration.IssueURL = value
+	}
+	if value := metadataString(review, "pull_request_repo"); value != "" {
+		iteration.PullRequestRepo = value
+	}
+	if value := metadataString(review, "pull_request_number"); value != "" {
+		if number, err := strconv.ParseInt(value, 10, 64); err == nil {
+			iteration.PullRequestNumber = number
+		}
+	}
+	if value := metadataString(review, "pull_request_url"); value != "" {
+		iteration.PullRequestURL = value
+	}
+}
+
+func skillOptCandidateReviewURLFromMetadata(review map[string]any) string {
+	for _, key := range []string{"review_url", "issue_url", "pull_request_url"} {
+		if value := metadataString(review, key); value != "" {
+			return value
+		}
+	}
+	repo := metadataString(review, "issue_repo")
+	number := metadataString(review, "issue_number")
+	if repo != "" && number != "" && number != "0" {
+		return "https://github.com/" + repo + "/issues/" + number
+	}
+	repo = metadataString(review, "pull_request_repo")
+	number = metadataString(review, "pull_request_number")
+	if repo != "" && number != "" && number != "0" {
+		return "https://github.com/" + repo + "/pull/" + number
+	}
+	return ""
+}
+
+func skillOptCandidateReviewRecoveryTarget(review map[string]any) string {
+	for _, key := range []string{"review_url", "issue_url", "pull_request_url"} {
+		if value := metadataString(review, key); value != "" {
+			return "review target: " + value
+		}
+	}
+	repo := metadataString(review, "issue_repo")
+	number := metadataString(review, "issue_number")
+	if repo != "" && number != "" && number != "0" {
+		return "review issue: " + repo + "#" + number
+	}
+	repo = metadataString(review, "pull_request_repo")
+	number = metadataString(review, "pull_request_number")
+	if repo != "" && number != "" && number != "0" {
+		return "review pull request: " + repo + "#" + number
+	}
+	if title := metadataString(review, "issue_title"); title != "" {
+		return "search for review issue title: " + title
+	}
+	return ""
+}
+
+func resolveSkillOptTrainCandidateReviewRepo(session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) (github.Repository, error) {
+	repoName := strings.TrimSpace(iteration.IssueRepo)
+	if iteration.IssueNumber > 0 {
+		if repoName == "" {
+			repoName = skillOptGitHubIssueURLRepo(iteration.IssueURL)
+		}
+		if repoName == "" {
+			return github.Repository{}, errors.New("candidate review issue repo is required when reusing an existing review issue")
+		}
+	} else if iteration.PullRequestNumber > 0 {
+		repoName = strings.TrimSpace(iteration.PullRequestRepo)
+		if repoName == "" {
+			repoName = skillOptGitHubPullRequestURLRepo(iteration.PullRequestURL)
+		}
+		if repoName == "" {
+			return github.Repository{}, errors.New("candidate review pull request repo is required when reusing an existing review pull request")
+		}
+	} else if repoName == "" {
+		repoName = strings.TrimSpace(session.WorkspaceRepo)
+		if repoName == "" {
+			repoName = strings.TrimSpace(session.TargetRepo)
+		}
+	}
+	repo, err := daemon.ParseRepository(repoName)
+	if err != nil {
+		return github.Repository{}, fmt.Errorf("candidate review repo: %w", err)
+	}
+	return repo, nil
+}
+
+func skillOptGitHubIssueURLRepo(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	parsed, err := neturl.Parse(value)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(parts) < 4 || parts[2] != "issues" {
+		return ""
+	}
+	repo, err := daemon.ParseRepository(parts[0] + "/" + parts[1])
+	if err != nil {
+		return ""
+	}
+	return repo.FullName()
+}
+
+func skillOptGitHubPullRequestURLRepo(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	parsed, err := neturl.Parse(value)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" {
+		return ""
+	}
+	repo, err := daemon.ParseRepository(parts[0] + "/" + parts[1])
+	if err != nil {
+		return ""
+	}
+	return repo.FullName()
+}
+
+func skillOptReviewTargetURLFromCommentURL(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	parsed, err := neturl.Parse(value)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(parts) < 4 || (parts[2] != "issues" && parts[2] != "pull") {
+		return ""
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
+func skillOptReviewTargetURLFromCommentOrHost(commentURL string, repo github.Repository, kind string, number int64) string {
+	if target := skillOptReviewTargetURLFromCommentURL(commentURL); target != "" {
+		return target
+	}
+	parsed, err := neturl.Parse(strings.TrimSpace(commentURL))
+	if err != nil || strings.TrimSpace(parsed.Host) == "" {
+		return ""
+	}
+	scheme := strings.TrimSpace(parsed.Scheme)
+	if scheme == "" {
+		scheme = "https"
+	}
+	target := neturl.URL{
+		Scheme: scheme,
+		Host:   parsed.Host,
+		Path:   "/" + repo.FullName() + "/" + strings.Trim(kind, "/") + "/" + fmt.Sprint(number),
+	}
+	return target.String()
+}
+
+func skillOptTrainDecisionRequested(request skillOptTrainContinueRequest) bool {
+	return strings.TrimSpace(request.PromoteCandidate) != "" || strings.TrimSpace(request.RejectCandidate) != ""
+}
+
+func requestedSkillOptTrainCandidateDecision(request skillOptTrainContinueRequest) string {
+	if strings.TrimSpace(request.PromoteCandidate) != "" {
+		return "promoted"
+	}
+	if strings.TrimSpace(request.RejectCandidate) != "" {
+		return "rejected"
+	}
+	return ""
+}
+
+func requestedSkillOptTrainCandidateID(request skillOptTrainContinueRequest) string {
+	if value := strings.TrimSpace(request.PromoteCandidate); value != "" {
+		return value
+	}
+	return strings.TrimSpace(request.RejectCandidate)
+}
+
+func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, commandHome string) (string, error) {
+	candidateID := strings.TrimSpace(iteration.CandidateVersionID)
+	version, err := store.GetAgentTemplateVersionByID(ctx, candidateID)
+	if err != nil {
+		return "", fmt.Errorf("load candidate version %s: %w", candidateID, err)
+	}
+	review, err := store.GetAgentTemplateCandidateReview(ctx, candidateID)
+	if err != nil {
+		return "", fmt.Errorf("load candidate review %s: %w", candidateID, err)
+	}
+	baseRef := strings.TrimSpace(review.BaseVersionID)
+	if baseRef == "" {
+		baseRef = strings.TrimSpace(iteration.BaseTemplateVersionID)
+	}
+	var base db.AgentTemplate
+	if baseRef != "" {
+		base, err = store.GetAgentTemplateReference(ctx, baseRef)
+		if err != nil {
+			return "", fmt.Errorf("load base version %s: %w", baseRef, err)
+		}
+	}
+	var builder strings.Builder
+	builder.WriteString("## SkillOpt Candidate Review\n\n")
+	fmt.Fprintf(&builder, "Session: `%s`\n", session.ID)
+	fmt.Fprintf(&builder, "Iteration: `%s`\n", iteration.ID)
+	fmt.Fprintf(&builder, "Template: `%s`\n", session.TemplateID)
+	fmt.Fprintf(&builder, "Base: `%s`\n", emptyText(baseRef))
+	fmt.Fprintf(&builder, "Candidate: `%s`\n", candidateID)
+	if summary := strings.TrimSpace(review.PreferenceSummary); summary != "" {
+		fmt.Fprintf(&builder, "\n### Candidate Summary\n%s\n", summary)
+	}
+	if review.Score != nil {
+		fmt.Fprintf(&builder, "\nScore: `%s`\n", scoreText(review.Score))
+	}
+	if strings.TrimSpace(session.PreviewRepo) != "" {
+		fmt.Fprintf(&builder, "\nPreview repo: `%s`\n", session.PreviewRepo)
+	}
+	if strings.TrimSpace(iteration.PullRequestURL) != "" {
+		fmt.Fprintf(&builder, "\nCandidate PR: %s\n", iteration.PullRequestURL)
+	}
+	if strings.TrimSpace(review.EvalReportJSON) != "" {
+		fmt.Fprintf(&builder, "\n### Eval Report\n```json\n%s\n```\n", limitSkillOptCandidateReviewText(indentJSON(review.EvalReportJSON), skillOptCandidateReviewEvalReportLimit, "eval report"))
+	}
+	if strings.TrimSpace(base.Content) != "" {
+		diff := artifact.TextDriver{}.Diff(base.VersionID+".md", version.ID+".md", []byte(base.Content), []byte(version.Content))
+		fmt.Fprintf(&builder, "\n### Candidate Template Diff\n```diff\n%s\n```\n", limitSkillOptCandidateReviewText(strings.TrimRight(diff, "\n"), skillOptCandidateReviewDiffLimit, "candidate template diff"))
+	}
+	builder.WriteString("\n### Decision\n")
+	usesCustomHome := strings.TrimSpace(commandHome) != ""
+	fmt.Fprintf(&builder, "- Promote: `%s`\n", skillOptTrainCandidateDecisionCommand(usesCustomHome, session.ID, "--promote", candidateID, false))
+	fmt.Fprintf(&builder, "- Reject: `%s`\n", skillOptTrainCandidateDecisionCommand(usesCustomHome, session.ID, "--reject", candidateID, true))
+	fmt.Fprintf(&builder, "- Continue: `%s` after promote/reject completes.\n", skillOptTrainStartNextCommand(usesCustomHome, session.ID))
+	return builder.String(), nil
+}
+
+func skillOptTrainCandidateDecisionCommand(usesCustomHome bool, sessionID, decisionFlag, candidateID string, includeReason bool) string {
+	args := []string{"gitmoot", "skillopt", "train", "continue"}
+	if usesCustomHome {
+		args = append(args, "--home", "<train-home>")
+	}
+	args = append(args, "--session", strings.TrimSpace(sessionID), decisionFlag, strings.TrimSpace(candidateID))
+	if includeReason {
+		args = append(args, "--reason", "...")
+	}
+	return shellArgs(args)
+}
+
+func skillOptTrainStartNextCommand(usesCustomHome bool, sessionID string) string {
+	args := []string{"gitmoot", "skillopt", "train", "continue"}
+	if usesCustomHome {
+		args = append(args, "--home", "<train-home>")
+	}
+	args = append(args, "--session", strings.TrimSpace(sessionID), "--start-next")
+	return shellArgs(args)
+}
+
+func limitSkillOptCandidateReviewText(value string, maxRunes int, label string) string {
+	value = strings.TrimRight(value, "\n")
+	if maxRunes <= 0 || utf8.RuneCountInString(value) <= maxRunes {
+		return value
+	}
+	runes := []rune(value)
+	omitted := len(runes) - maxRunes
+	suffix := fmt.Sprintf("\n\n... truncated %s after %d characters; %d characters omitted. Inspect the stored candidate artifacts for the full content.", strings.TrimSpace(label), maxRunes, omitted)
+	return string(runes[:maxRunes]) + suffix
+}
+
+func decideSkillOptTrainCandidate(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainContinueRequest) (skillOptTrainCandidateDecisionResult, error) {
+	promote := strings.TrimSpace(request.PromoteCandidate)
+	reject := strings.TrimSpace(request.RejectCandidate)
+	if promote != "" && reject != "" {
+		return skillOptTrainCandidateDecisionResult{}, errors.New("train continue accepts only one of --promote or --reject")
+	}
+	expected := strings.TrimSpace(iteration.CandidateVersionID)
+	if expected == "" {
+		return skillOptTrainCandidateDecisionResult{}, errors.New("train iteration has no candidate version")
+	}
+	candidateID := promote
+	decision := ""
+	if promote != "" {
+		decision = "promoted"
+	} else if reject != "" {
+		candidateID = reject
+		decision = "rejected"
+		if strings.TrimSpace(request.DecisionReason) == "" {
+			return skillOptTrainCandidateDecisionResult{}, errors.New("train candidate rejection requires --reason")
+		}
+	}
+	if candidateID != "" && candidateID != expected {
+		return skillOptTrainCandidateDecisionResult{}, fmt.Errorf("candidate %s does not match train iteration candidate %s", candidateID, expected)
+	}
+	if decision == "" {
+		return syncSkillOptTrainCandidateDecision(ctx, store, session, iteration, expected, "", "")
+	}
+	if result, err := syncSkillOptTrainCandidateDecision(ctx, store, session, iteration, expected, decision, strings.TrimSpace(request.DecisionReason)); err != nil || result.Decided {
+		return result, err
+	}
+	if err := skillopt.CanTransitionTrainIteration(iteration.State, map[string]string{
+		"promoted": skillopt.TrainStateCandidatePromoted,
+		"rejected": skillopt.TrainStateCandidateRejected,
+	}[decision]); err != nil {
+		return skillOptTrainCandidateDecisionResult{}, err
+	}
+	if decision == "promoted" {
+		session.TemplateVersionID = candidateID
+		session.State = skillopt.TrainStateCandidatePromoted
+		iteration.State = skillopt.TrainStateCandidatePromoted
+	} else {
+		session.State = skillopt.TrainStateCandidateRejected
+		iteration.State = skillopt.TrainStateCandidateRejected
+		iteration.DecisionReason = strings.TrimSpace(request.DecisionReason)
+	}
+	metadata := map[string]any{
+		"decision":          decision,
+		"candidate_version": candidateID,
+		"reason":            strings.TrimSpace(request.DecisionReason),
+		"decided_at":        time.Now().UTC().Format(time.RFC3339Nano),
+		"source":            "gitmoot skillopt train continue",
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_decision", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_decision", metadata)
+	if _, err := store.DecideSkillOptTrainCandidate(ctx, session, iteration, candidateID, decision); err != nil {
+		return skillOptTrainCandidateDecisionResult{}, err
+	}
+	return skillOptTrainCandidateDecisionResult{Decided: true, Decision: decision, CandidateVersionID: candidateID}, nil
+}
+
+func syncSkillOptTrainCandidateDecision(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, candidateID string, expectedDecision string, fallbackReason string) (skillOptTrainCandidateDecisionResult, error) {
+	candidateID = strings.TrimSpace(candidateID)
+	if candidateID == "" {
+		return skillOptTrainCandidateDecisionResult{}, nil
+	}
+	candidate, err := store.GetAgentTemplateVersionByID(ctx, candidateID)
+	if err != nil {
+		return skillOptTrainCandidateDecisionResult{}, fmt.Errorf("load candidate version %s: %w", candidateID, err)
+	}
+	review, reviewErr := store.GetAgentTemplateCandidateReview(ctx, candidateID)
+	if reviewErr != nil && !errors.Is(reviewErr, sql.ErrNoRows) {
+		return skillOptTrainCandidateDecisionResult{}, fmt.Errorf("load candidate review %s: %w", candidateID, reviewErr)
+	}
+	var decision string
+	switch candidate.State {
+	case "current":
+		decision = "promoted"
+	case "rejected":
+		decision = "rejected"
+	default:
+		if reviewErr == nil {
+			switch strings.TrimSpace(review.State) {
+			case "promoted":
+				decision = "promoted"
+			case "rejected":
+				decision = "rejected"
+			}
+		}
+		if decision == "" {
+			return skillOptTrainCandidateDecisionResult{}, nil
+		}
+	}
+	if expectedDecision != "" && expectedDecision != decision {
+		return skillOptTrainCandidateDecisionResult{}, fmt.Errorf("candidate %s is already %s, not %s", candidateID, decision, expectedDecision)
+	}
+	targetState := map[string]string{
+		"promoted": skillopt.TrainStateCandidatePromoted,
+		"rejected": skillopt.TrainStateCandidateRejected,
+	}[decision]
+	switch skillopt.NormalizeTrainState(iteration.State) {
+	case skillopt.TrainStateCandidateCreated, skillopt.TrainStateCandidateReviewPublished:
+	default:
+		if err := skillopt.CanTransitionTrainIteration(iteration.State, targetState); err != nil {
+			return skillOptTrainCandidateDecisionResult{}, err
+		}
+	}
+	reason := strings.TrimSpace(fallbackReason)
+	if decision == "rejected" {
+		if reviewErr == nil && strings.TrimSpace(review.DecisionReason) != "" {
+			reason = strings.TrimSpace(review.DecisionReason)
+		}
+		if reason == "" {
+			return skillOptTrainCandidateDecisionResult{}, errors.New("train candidate rejection requires --reason")
+		}
+	}
+	if decision == "promoted" {
+		session.TemplateVersionID = candidateID
+		session.State = skillopt.TrainStateCandidatePromoted
+		iteration.State = skillopt.TrainStateCandidatePromoted
+	} else {
+		session.State = skillopt.TrainStateCandidateRejected
+		iteration.State = skillopt.TrainStateCandidateRejected
+		iteration.DecisionReason = reason
+	}
+	metadata := map[string]any{
+		"decision":          decision,
+		"candidate_version": candidateID,
+		"reason":            reason,
+		"decided_at":        time.Now().UTC().Format(time.RFC3339Nano),
+		"source":            "gitmoot skillopt train continue synced candidate state",
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_decision", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_decision", metadata)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+		return skillOptTrainCandidateDecisionResult{}, err
+	}
+	return skillOptTrainCandidateDecisionResult{Decided: true, Decision: decision, CandidateVersionID: candidateID}, nil
+}
+
+func startNextSkillOptTrainIteration(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, previous db.SkillOptTrainIteration) (db.SkillOptTrainIteration, error) {
+	if err := skillopt.CanStartNextTrainIteration(previous); err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	releaseStartNextLock, _, err := acquireSkillOptTrainStartNextLock(ctx, store, session.ID)
+	if err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	defer func() {
+		_ = releaseStartNextLock(context.Background())
+	}()
+	baseVersion := strings.TrimSpace(previous.BaseTemplateVersionID)
+	if skillopt.NormalizeTrainState(previous.State) == skillopt.TrainStateCandidatePromoted {
+		baseVersion = strings.TrimSpace(previous.CandidateVersionID)
+	}
+	if baseVersion == "" {
+		return db.SkillOptTrainIteration{}, errors.New("next train iteration base version is required")
+	}
+	previousRun, err := store.GetEvalRun(ctx, previous.EvalRunID)
+	if err != nil {
+		return db.SkillOptTrainIteration{}, fmt.Errorf("load previous eval run %s: %w", previous.EvalRunID, err)
+	}
+	iterations, err := store.ListSkillOptTrainIterations(ctx, session.ID)
+	if err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	nextNumber := len(iterations) + 1
+	nextID := fmt.Sprintf("%s-%03d", session.ID, nextNumber)
+	nextRunID := fmt.Sprintf("%s-review-%03d", session.ID, nextNumber)
+	if _, err := store.GetSkillOptTrainIteration(ctx, nextID); err == nil {
+		return db.SkillOptTrainIteration{}, fmt.Errorf("train iteration %s already exists; inspect it with gitmoot skillopt train status --session %s", nextID, session.ID)
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return db.SkillOptTrainIteration{}, err
+	}
+	if _, err := store.GetEvalRun(ctx, nextRunID); err == nil {
+		return db.SkillOptTrainIteration{}, fmt.Errorf("eval run %s already exists; inspect it with gitmoot skillopt review status --run %s", nextRunID, nextRunID)
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return db.SkillOptTrainIteration{}, err
+	}
+	metadata := skillOptTrainNextIterationMetadata(session.MetadataJSON, previous.MetadataJSON, map[string]any{
+		"id":         previous.ID,
+		"state":      previous.State,
+		"candidate":  previous.CandidateVersionID,
+		"started_at": time.Now().UTC().Format(time.RFC3339Nano),
+	})
+	items, err := store.ListEvalReviewItems(ctx, previous.EvalRunID)
+	if err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	feedbackEvents, err := store.ListFeedbackEvents(ctx, previous.EvalRunID)
+	if err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	rankedFeedbackEvents, err := store.ListRankedFeedbackEvents(ctx, previous.EvalRunID)
+	if err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	pairwisePreferences, err := store.ListPairwisePreferences(ctx, previous.EvalRunID)
+	if err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	recommendation := skillopt.RecommendPhaseForItems(previousRun, items, feedbackEvents, rankedFeedbackEvents, pairwisePreferences)
+	nextMode := skillOptTrainNextIterationMode(previous.Mode, recommendation.RecommendedMode)
+	nextExplorationLevel := strings.TrimSpace(recommendation.ExplorationLevel)
+	if nextExplorationLevel == "" {
+		nextExplorationLevel = previous.ExplorationLevel
+	}
+	metadata = mergeSkillOptTrainMetadata(metadata, "phase_recommendation", map[string]any{
+		"current_mode":     recommendation.CurrentMode,
+		"recommended_mode": recommendation.RecommendedMode,
+		"selected_mode":    nextMode,
+		"reason":           recommendation.Reason,
+	})
+	next := db.SkillOptTrainIteration{
+		ID:                    nextID,
+		SessionID:             session.ID,
+		EvalRunID:             nextRunID,
+		BaseTemplateVersionID: baseVersion,
+		Mode:                  nextMode,
+		ExplorationLevel:      nextExplorationLevel,
+		State:                 skillopt.TrainStateItemsReady,
+		MetadataJSON:          metadata,
+	}
+	run := db.EvalRun{
+		ID:                nextRunID,
+		TemplateID:        session.TemplateID,
+		TemplateVersionID: baseVersion,
+		TargetRepo:        session.TargetRepo,
+		State:             "review",
+		Mode:              nextMode,
+		ExplorationLevel:  nextExplorationLevel,
+		OptionsCount:      previousRun.OptionsCount,
+		MetadataJSON:      metadata,
+	}
+	session.TemplateVersionID = baseVersion
+	session.State = skillopt.TrainStateItemsReady
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "next_iteration", map[string]any{
+		"id":           next.ID,
+		"base_version": baseVersion,
+		"source":       "gitmoot skillopt train continue",
+	})
+	nextItems := make([]db.EvalReviewItem, 0, len(items))
+	for _, item := range items {
+		item.RunID = nextRunID
+		item.ID = ""
+		item.BaselineArtifactID = ""
+		item.CandidateArtifactID = ""
+		item.PreviewArtifactID = ""
+		item.DiffArtifactID = ""
+		nextItems = append(nextItems, item)
+	}
+	if err := store.UpsertSkillOptTrainNextIteration(ctx, session, next, run, nextItems); err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	return next, nil
+}
+
+func skillOptTrainNextIterationMetadata(sessionMetadata string, previousMetadata string, previousIteration map[string]any) string {
+	metadata := map[string]any{
+		"previous_iteration": previousIteration,
+	}
+	for _, source := range []string{previousMetadata, sessionMetadata} {
+		evaluation := decodedSkillOptMetadataValue(decodedSkillOptMetadata(source)["evaluation"])
+		if len(evaluation) > 0 {
+			metadata["evaluation"] = evaluation
+			break
+		}
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func skillOptTrainNextIterationMode(previousMode string, recommendedMode string) string {
+	switch strings.TrimSpace(recommendedMode) {
+	case db.EvalRunModeExplore, db.EvalRunModeRefine, db.EvalRunModeDistill, db.EvalRunModeValidate:
+		return strings.TrimSpace(recommendedMode)
+	default:
+		return strings.TrimSpace(previousMode)
+	}
 }
 
 func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest) (skillOptTrainOptimizerResult, error) {
@@ -756,6 +1901,10 @@ var errSkillOptTrainGenerationBusy = errors.New("skillopt train generation is al
 
 var errSkillOptTrainOptimizerBusy = errors.New("skillopt train optimizer is already running")
 
+var errSkillOptTrainCandidateReviewBusy = errors.New("skillopt train candidate review is already publishing")
+
+var errSkillOptTrainStartNextBusy = errors.New("skillopt train next iteration is already starting")
+
 const skillOptTrainGenerationLockTTL = 2 * time.Hour
 
 const skillOptTrainGenerationLockBuffer = 10 * time.Minute
@@ -763,6 +1912,75 @@ const skillOptTrainGenerationLockBuffer = 10 * time.Minute
 const skillOptTrainOptimizerLockTTL = 4 * time.Hour
 
 const skillOptTrainOptimizerLockBuffer = 10 * time.Minute
+
+const skillOptTrainCandidateReviewLockTTL = 30 * time.Minute
+
+const skillOptTrainStartNextLockTTL = 30 * time.Minute
+
+func acquireSkillOptTrainCandidateReviewLock(ctx context.Context, store *db.Store, sessionID string, iterationID string) (func(context.Context) error, bool, error) {
+	key := skillOptTrainCandidateReviewLockKey(sessionID, iterationID)
+	token, err := newRuntimeLockOwnerToken()
+	if err != nil {
+		return noopAgentReservationRelease, false, err
+	}
+	now := time.Now().UTC()
+	ownerJobID := localAgentJobID("skillopt-train-candidate-review", strings.TrimSpace(sessionID))
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  ownerJobID,
+		OwnerToken:  token,
+		ExpiresAt:   now.Add(skillOptTrainCandidateReviewLockTTL).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		return noopAgentReservationRelease, false, err
+	}
+	if !acquired {
+		return noopAgentReservationRelease, false, fmt.Errorf("%w: %s", errSkillOptTrainCandidateReviewBusy, key)
+	}
+	return func(releaseCtx context.Context) error {
+		_, err := store.ReleaseResourceLock(releaseCtx, key, ownerJobID, token)
+		return err
+	}, true, nil
+}
+
+func skillOptTrainCandidateReviewLockKey(sessionID string, iterationID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	iterationID = strings.TrimSpace(iterationID)
+	if iterationID == "" {
+		return "skillopt-train-candidate-review:" + sessionID
+	}
+	return "skillopt-train-candidate-review:" + sessionID + ":" + iterationID
+}
+
+func acquireSkillOptTrainStartNextLock(ctx context.Context, store *db.Store, sessionID string) (func(context.Context) error, bool, error) {
+	key := skillOptTrainStartNextLockKey(sessionID)
+	token, err := newRuntimeLockOwnerToken()
+	if err != nil {
+		return noopAgentReservationRelease, false, err
+	}
+	now := time.Now().UTC()
+	ownerJobID := localAgentJobID("skillopt-train-start-next", strings.TrimSpace(sessionID))
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  ownerJobID,
+		OwnerToken:  token,
+		ExpiresAt:   now.Add(skillOptTrainStartNextLockTTL).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		return noopAgentReservationRelease, false, err
+	}
+	if !acquired {
+		return noopAgentReservationRelease, false, fmt.Errorf("%w: %s", errSkillOptTrainStartNextBusy, key)
+	}
+	return func(releaseCtx context.Context) error {
+		_, err := store.ReleaseResourceLock(releaseCtx, key, ownerJobID, token)
+		return err
+	}, true, nil
+}
+
+func skillOptTrainStartNextLockKey(sessionID string) string {
+	return "skillopt-train-start-next:" + strings.TrimSpace(sessionID)
+}
 
 func acquireSkillOptTrainOptimizerLock(ctx context.Context, store *db.Store, sessionID string, iterationID string, ttl time.Duration) (func(context.Context) error, bool, error) {
 	key := skillOptTrainOptimizerLockKey(sessionID, iterationID)

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1825,6 +1825,1333 @@ echo "fake optimizer ok"
 	}
 }
 
+func TestSkillOptTrainContinuePublishesCandidateReviewPromotesAndStartsNext(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	store := openCLIJobStore(t, home)
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	session.WorkspaceRepo = "owner/workspace"
+	if err := store.UpsertSkillOptTrainSession(context.Background(), session); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSession workspace returned error: %v", err)
+	}
+	run, err := store.GetEvalRun(context.Background(), "optimizer-train-review-001")
+	if err != nil {
+		t.Fatalf("GetEvalRun returned error: %v", err)
+	}
+	run.OptionsCount = 4
+	if err := store.UpsertEvalRun(context.Background(), run); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	optionBlobStore := artifact.NewStore(config.PathsForHome(home).ArtifactBlobs)
+	for _, label := range []string{"a", "b", "c", "d"} {
+		content := []byte("option " + label)
+		blob, err := optionBlobStore.Put(content)
+		if err != nil {
+			t.Fatalf("Put option %s returned error: %v", label, err)
+		}
+		if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+			ID:        "option-" + label,
+			Hash:      blob.Hash,
+			MediaType: "text/markdown",
+			SizeBytes: blob.Size,
+			Driver:    "text",
+		}); err != nil {
+			t.Fatalf("UpsertEvalArtifact option %s returned error: %v", label, err)
+		}
+		if err := store.UpsertEvalReviewOption(context.Background(), db.EvalReviewOption{
+			RunID:      run.ID,
+			ItemID:     "item-001",
+			Label:      label,
+			ArtifactID: "option-" + label,
+			Role:       "option",
+		}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	ranking, err := json.Marshal([]string{"b", "a", "c", "d"})
+	if err != nil {
+		t.Fatalf("marshal ranking: %v", err)
+	}
+	if err := store.UpsertRankedFeedbackEvent(context.Background(), db.RankedFeedbackEvent{
+		RunID:        run.ID,
+		ItemID:       "item-001",
+		RankingJSON:  string(ranking),
+		Winner:       "b",
+		ContinueMode: db.EvalRunModeExplore,
+		Reviewer:     "github:jerry",
+		Source:       "github",
+		SourceURL:    "https://github.com/owner/product/issues/1#issuecomment-ranked",
+		CreatedAt:    "2026-06-02T10:01:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertRankedFeedbackEvent returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after options count update returned error: %v", err)
+	}
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with candidate review guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--promote", "planner@v2",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("premature promote exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "candidate decisions require train iteration at candidate_review_published") {
+		t.Fatalf("premature promote stderr = %q", stderr.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "" || len(fakeGitHub.postedComments) != 0 {
+		t.Fatalf("premature promote published github state: issue=%+v comments=%+v", fakeGitHub.createdIssue, fakeGitHub.postedComments)
+	}
+
+	fakeGitHub.createIssueErr = errors.New("github unavailable")
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue failed candidate review exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "github unavailable") {
+		t.Fatalf("failed candidate review stderr = %q", stderr.String())
+	}
+	store = openCLIJobStore(t, home)
+	session, err = store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession after failed publish returned error: %v", err)
+	}
+	failedIteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration after failed publish returned error: %v", err)
+	}
+	if session.State != skillopt.TrainStateCandidateCreated || failedIteration.State != skillopt.TrainStateCandidateCreated {
+		t.Fatalf("state after failed candidate review publish: session=%s iteration=%s", session.State, failedIteration.State)
+	}
+	if failedIteration.IssueNumber != 0 || strings.TrimSpace(failedIteration.IssueURL) != "" || strings.Contains(failedIteration.MetadataJSON, `"status":"published"`) {
+		t.Fatalf("iteration recorded failed candidate review publish: %+v", failedIteration)
+	}
+	markerPath := skillOptCandidateReviewRecoveryPath(config.PathsForHome(home), session, failedIteration)
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("failed candidate review recovery marker err=%v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after failed candidate review publish returned error: %v", err)
+	}
+
+	fakeGitHub.createIssueErr = nil
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue after ambiguous publish error exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "external post started") || !strings.Contains(stderr.String(), "SkillOpt candidate review: optimizer-train") {
+		t.Fatalf("ambiguous publish retry stderr = %q", stderr.String())
+	}
+	if err := removeSkillOptCandidateReviewRecovery(config.PathsForHome(home), session, failedIteration); err != nil {
+		t.Fatalf("remove ambiguous publish recovery marker returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue candidate review exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_review_published") || !strings.Contains(stdout.String(), "candidate_review: https://github.com/owner/workspace/issues/8") {
+		t.Fatalf("candidate review stdout = %s", stdout.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "owner/workspace" {
+		t.Fatalf("created issue repo = %+v", fakeGitHub.createdIssue.Repo)
+	}
+	for _, want := range []string{
+		"SkillOpt Candidate Review",
+		"Candidate Template Diff",
+		"planner@v2",
+		skillOptTrainCandidateDecisionCommand(true, "optimizer-train", "--promote", "planner@v2", false),
+		skillOptTrainCandidateDecisionCommand(true, "optimizer-train", "--reject", "planner@v2", true),
+		skillOptTrainStartNextCommand(true, "optimizer-train"),
+	} {
+		if !strings.Contains(fakeGitHub.createdIssue.Body, want) {
+			t.Fatalf("candidate review body missing %q:\n%s", want, fakeGitHub.createdIssue.Body)
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--promote", "planner@v2",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue promote exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_promoted") || !strings.Contains(stdout.String(), "promoted_candidate: planner@v2") {
+		t.Fatalf("promote stdout = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--promote", "planner@v2",
+		"--start-next",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue promote retry/start-next exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: items_ready") || !strings.Contains(stdout.String(), "promoted_candidate: planner@v2") || !strings.Contains(stdout.String(), "started_iteration: optimizer-train-002") || !strings.Contains(stdout.String(), "base_version: planner@v2") {
+		t.Fatalf("promote retry/start-next stdout = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--start-next",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue duplicate start-next exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--start-next requires a promoted or rejected candidate; current phase is items_ready") {
+		t.Fatalf("duplicate start-next stderr = %q", stderr.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	current, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if current.VersionID != "planner@v2" {
+		t.Fatalf("current template version = %q, want planner@v2", current.VersionID)
+	}
+	latest, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if latest.ID != "optimizer-train-002" || latest.BaseTemplateVersionID != "planner@v2" || latest.State != skillopt.TrainStateItemsReady || latest.Mode != db.EvalRunModeExplore {
+		t.Fatalf("latest iteration = %+v", latest)
+	}
+	if strings.Contains(latest.MetadataJSON, `"optimizer"`) {
+		t.Fatalf("next iteration inherited optimizer metadata: %s", latest.MetadataJSON)
+	}
+	gate, err := skillOptTrainOptimizerGate(latest, skillOptTrainOptimizerRequest{})
+	if err != nil {
+		t.Fatalf("skillOptTrainOptimizerGate returned error: %v", err)
+	}
+	if gate != "mixed" {
+		t.Fatalf("next iteration optimizer gate = %q, want mixed", gate)
+	}
+	items, err := store.ListEvalReviewItems(context.Background(), latest.EvalRunID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	if len(items) != 1 || items[0].BaselineArtifactID != "" || items[0].CandidateArtifactID != "" {
+		t.Fatalf("next iteration items = %+v", items)
+	}
+	nextRun, err := store.GetEvalRun(context.Background(), latest.EvalRunID)
+	if err != nil {
+		t.Fatalf("GetEvalRun next returned error: %v", err)
+	}
+	if nextRun.OptionsCount != 4 {
+		t.Fatalf("next run options count = %d, want 4", nextRun.OptionsCount)
+	}
+	if nextRun.Mode != db.EvalRunModeExplore {
+		t.Fatalf("next run mode = %q, want explore", nextRun.Mode)
+	}
+	if strings.Contains(nextRun.MetadataJSON, `"optimizer"`) {
+		t.Fatalf("next run inherited optimizer metadata: %s", nextRun.MetadataJSON)
+	}
+}
+
+func TestSkillOptTrainContinueSyncsHumanCandidatePromotionAndStartsNext(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with externally promoted candidate guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue candidate review exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_review_published") || fakeGitHub.createdIssue.Repo.FullName() != "owner/product" {
+		t.Fatalf("candidate review stdout=%s github=%+v", stdout.String(), fakeGitHub.createdIssue)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "candidate", "promote",
+		"--home", home,
+		"planner@v2",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("candidate promote exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	supersedeStore := openCLIJobStore(t, home)
+	newerCandidate, err := supersedeStore.AddPendingAgentTemplateVersion(context.Background(), cliSkillOptTemplate("planner", "Plan with later promoted guidance."))
+	if err != nil {
+		t.Fatalf("AddPendingAgentTemplateVersion newer candidate returned error: %v", err)
+	}
+	if _, err := supersedeStore.PromoteAgentTemplateVersion(context.Background(), newerCandidate.ID); err != nil {
+		t.Fatalf("PromoteAgentTemplateVersion newer candidate returned error: %v", err)
+	}
+	superseded, err := supersedeStore.GetAgentTemplateVersionByID(context.Background(), "planner@v2")
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID superseded train candidate returned error: %v", err)
+	}
+	if superseded.State != "superseded" {
+		t.Fatalf("train candidate state after later promotion = %s, want superseded", superseded.State)
+	}
+	if err := supersedeStore.Close(); err != nil {
+		t.Fatalf("Close supersede store returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--promote", "planner@v2",
+		"--reject", "planner@v2",
+		"--reason", "conflicting",
+		"--start-next",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue conflicting decision exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "accepts only one of --promote or --reject") {
+		t.Fatalf("conflicting decision stderr = %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--start-next",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue sync/start-next exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: items_ready") || !strings.Contains(stdout.String(), "promoted_candidate: planner@v2") || !strings.Contains(stdout.String(), "started_iteration: optimizer-train-002") {
+		t.Fatalf("sync/start-next stdout = %s", stdout.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	previous, err := store.GetSkillOptTrainIteration(context.Background(), "optimizer-train-001")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainIteration previous returned error: %v", err)
+	}
+	if previous.State != skillopt.TrainStateCandidatePromoted {
+		t.Fatalf("previous iteration = %+v", previous)
+	}
+	if !strings.Contains(previous.MetadataJSON, `"source":"gitmoot skillopt train continue synced candidate state"`) {
+		t.Fatalf("previous iteration metadata = %s", previous.MetadataJSON)
+	}
+	latest, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if latest.ID != "optimizer-train-002" || latest.BaseTemplateVersionID != "planner@v2" || latest.State != skillopt.TrainStateItemsReady {
+		t.Fatalf("latest iteration = %+v", latest)
+	}
+}
+
+func TestSkillOptTrainContinueSyncsHumanCandidatePromotionBeforeReviewPublish(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with pre-review human promotion guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_created") {
+		t.Fatalf("optimizer stdout = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "candidate", "promote",
+		"--home", home,
+		"planner@v2",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("candidate promote exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--start-next",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue sync/start-next exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: items_ready") || !strings.Contains(stdout.String(), "promoted_candidate: planner@v2") || !strings.Contains(stdout.String(), "started_iteration: optimizer-train-002") {
+		t.Fatalf("sync/start-next stdout = %s", stdout.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "" || len(fakeGitHub.postedComments) != 0 {
+		t.Fatalf("pre-review sync published github state: issue=%+v comments=%+v", fakeGitHub.createdIssue, fakeGitHub.postedComments)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	previous, err := store.GetSkillOptTrainIteration(context.Background(), "optimizer-train-001")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainIteration previous returned error: %v", err)
+	}
+	if previous.State != skillopt.TrainStateCandidatePromoted || previous.IssueNumber != 0 || strings.TrimSpace(previous.IssueURL) != "" {
+		t.Fatalf("previous iteration = %+v", previous)
+	}
+	latest, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if latest.ID != "optimizer-train-002" || latest.BaseTemplateVersionID != "planner@v2" || latest.State != skillopt.TrainStateItemsReady {
+		t.Fatalf("latest iteration = %+v", latest)
+	}
+}
+
+func TestSkillOptTrainContinueRequiresReasonForExternalCandidateRejection(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with externally rejected candidate guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "candidate", "reject",
+		"--home", home,
+		"planner@v2",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("candidate reject exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--start-next",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue external reject without reason exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "train candidate rejection requires --reason") {
+		t.Fatalf("external reject without reason stderr = %q", stderr.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "" || len(fakeGitHub.postedComments) != 0 {
+		t.Fatalf("external reject without reason published github state: issue=%+v comments=%+v", fakeGitHub.createdIssue, fakeGitHub.postedComments)
+	}
+	store := openCLIJobStore(t, home)
+	previous, err := store.GetSkillOptTrainIteration(context.Background(), "optimizer-train-001")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainIteration previous returned error: %v", err)
+	}
+	if previous.State != skillopt.TrainStateCandidateCreated || strings.TrimSpace(previous.DecisionReason) != "" {
+		t.Fatalf("previous iteration after failed sync = %+v", previous)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after failed external reject sync returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--reject", "planner@v2",
+		"--reason", "too broad",
+		"--start-next",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue external reject with reason exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: items_ready") || !strings.Contains(stdout.String(), "rejected_candidate: planner@v2") || !strings.Contains(stdout.String(), "started_iteration: optimizer-train-002") {
+		t.Fatalf("external reject with reason stdout = %s", stdout.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	previous, err = store.GetSkillOptTrainIteration(context.Background(), "optimizer-train-001")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainIteration previous after sync returned error: %v", err)
+	}
+	if previous.State != skillopt.TrainStateCandidateRejected || previous.DecisionReason != "too broad" {
+		t.Fatalf("previous iteration after external reject sync = %+v", previous)
+	}
+	latest, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if latest.ID != "optimizer-train-002" || latest.BaseTemplateVersionID != baseVersionID || latest.State != skillopt.TrainStateItemsReady {
+		t.Fatalf("latest iteration = %+v", latest)
+	}
+}
+
+func TestSkillOptTrainContinuePublishesCandidateReviewAndRejects(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with rejectable candidate guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{
+		host:               "https://github.example.com",
+		commentURLOverride: "https://github.example.com/api/v3/repos/owner/review/issues/comments/1",
+	}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	legacyStore := openCLIJobStore(t, home)
+	iteration, err := legacyStore.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration after optimizer returned error: %v", err)
+	}
+	iteration.IssueNumber = 67
+	iteration.IssueRepo = "owner/review"
+	if err := legacyStore.UpsertSkillOptTrainIteration(context.Background(), iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainIteration legacy review issue returned error: %v", err)
+	}
+	if err := legacyStore.Close(); err != nil {
+		t.Fatalf("Close after legacy review issue update returned error: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue candidate review exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(fakeGitHub.postedComments) != 1 || fakeGitHub.postedComments[0].Repo.FullName() != "owner/review" || fakeGitHub.postedComments[0].IssueNumber != 67 {
+		t.Fatalf("candidate review comments = %+v", fakeGitHub.postedComments)
+	}
+	commentStore := openCLIJobStore(t, home)
+	publishedIteration, err := commentStore.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration after existing issue publish returned error: %v", err)
+	}
+	if publishedIteration.IssueURL != "https://github.example.com/owner/review/issues/67" {
+		t.Fatalf("published issue url = %q", publishedIteration.IssueURL)
+	}
+	if err := commentStore.Close(); err != nil {
+		t.Fatalf("Close after existing issue publish returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--reject", "planner@v2",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue reject without reason exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "requires --reason") {
+		t.Fatalf("reject without reason stderr = %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--reject", "planner@v2",
+		"--reason", "too broad",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue reject exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_rejected") || !strings.Contains(stdout.String(), "rejected_candidate: planner@v2") {
+		t.Fatalf("reject stdout = %s", stdout.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	current, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if current.VersionID != baseVersionID {
+		t.Fatalf("current template version = %q, want %q", current.VersionID, baseVersionID)
+	}
+	finalIteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if finalIteration.State != skillopt.TrainStateCandidateRejected || finalIteration.DecisionReason != "too broad" {
+		t.Fatalf("iteration after reject = %+v", finalIteration)
+	}
+}
+
+func TestSkillOptTrainContinuePublishesCandidateReviewToExistingPullRequest(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with PR review guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{
+		host:               "https://github.example.com",
+		commentKinds:       map[int64]string{77: "pull"},
+		commentURLOverride: "https://github.example.com/api/v3/repos/owner/review/issues/comments/1",
+	}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration after optimizer returned error: %v", err)
+	}
+	iteration.PullRequestNumber = 77
+	iteration.PullRequestRepo = "owner/review"
+	if err := store.UpsertSkillOptTrainIteration(context.Background(), iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainIteration PR review returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after PR review update returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue candidate PR review exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(fakeGitHub.postedComments) != 1 || fakeGitHub.postedComments[0].Repo.FullName() != "owner/review" || fakeGitHub.postedComments[0].IssueNumber != 77 {
+		t.Fatalf("candidate PR review comments = %+v", fakeGitHub.postedComments)
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "" {
+		t.Fatalf("candidate PR review created issue unexpectedly: %+v", fakeGitHub.createdIssue)
+	}
+	store = openCLIJobStore(t, home)
+	iteration, err = store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration after PR publish returned error: %v", err)
+	}
+	if iteration.PullRequestURL != "https://github.example.com/owner/review/pull/77" {
+		t.Fatalf("published pull request url = %q", iteration.PullRequestURL)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after PR publish check returned error: %v", err)
+	}
+}
+
+func TestSkillOptTrainContinueDoesNotRepostCandidateReviewWhilePublishing(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with publishing recovery guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	marker := map[string]any{
+		"status":            "publishing",
+		"candidate_version": iteration.CandidateVersionID,
+		"issue_repo":        "owner/product",
+		"issue_title":       "SkillOpt candidate review: optimizer-train",
+		"started_at":        time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", marker)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", marker)
+	if err := store.UpsertSkillOptTrainSession(context.Background(), session); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSession marker returned error: %v", err)
+	}
+	if err := store.UpsertSkillOptTrainIteration(context.Background(), iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainIteration marker returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close marker store returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue publishing marker exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "marked publishing") || !strings.Contains(stderr.String(), "SkillOpt candidate review: optimizer-train") {
+		t.Fatalf("publishing marker stderr = %q", stderr.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "" || len(fakeGitHub.postedComments) != 0 {
+		t.Fatalf("publishing marker reposted github state: issue=%+v comments=%+v", fakeGitHub.createdIssue, fakeGitHub.postedComments)
+	}
+
+	store = openCLIJobStore(t, home)
+	session, err = store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession before recovery returned error: %v", err)
+	}
+	iteration, err = store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration before recovery returned error: %v", err)
+	}
+	marker["status"] = "published_external"
+	marker["issue_number"] = int64(8)
+	marker["issue_url"] = "https://github.com/owner/product/issues/8"
+	marker["review_url"] = "https://github.com/owner/product/issues/8"
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", marker)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", marker)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(context.Background(), session, iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSessionAndIteration recovery marker returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close recovery marker store returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue recovery marker exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_review_published") || !strings.Contains(stdout.String(), "candidate_review: https://github.com/owner/product/issues/8") {
+		t.Fatalf("recovery marker stdout = %s", stdout.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "" || len(fakeGitHub.postedComments) != 0 {
+		t.Fatalf("recovery marker reposted github state: issue=%+v comments=%+v", fakeGitHub.createdIssue, fakeGitHub.postedComments)
+	}
+}
+
+func TestSkillOptTrainContinueRetriesStaleCandidateReviewPublishingMarker(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with stale publishing recovery guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	marker := map[string]any{
+		"status":            "publishing",
+		"candidate_version": iteration.CandidateVersionID,
+		"issue_repo":        "owner/product",
+		"issue_title":       "SkillOpt candidate review: optimizer-train",
+		"started_at":        time.Now().UTC().Add(-skillOptTrainCandidateReviewLockTTL - time.Minute).Format(time.RFC3339Nano),
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", marker)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", marker)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(context.Background(), session, iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSessionAndIteration stale marker returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close stale marker store returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue stale publishing marker exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_review_published") || !strings.Contains(stdout.String(), "candidate_review: https://github.com/owner/product/issues/8") {
+		t.Fatalf("stale publishing marker stdout = %s", stdout.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "owner/product" || len(fakeGitHub.postedComments) != 0 {
+		t.Fatalf("stale publishing marker github state: issue=%+v comments=%+v", fakeGitHub.createdIssue, fakeGitHub.postedComments)
+	}
+}
+
+func TestSkillOptTrainContinueRetriesAfterCandidateReviewMarkerWriteFailure(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with marker failure recovery guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	_, err = publishSkillOptTrainCandidateReview(context.Background(), config.Paths{}, store, session, iteration, home)
+	if err == nil || !strings.Contains(err.Error(), "write candidate review pre-publish recovery marker") {
+		t.Fatalf("publishSkillOptTrainCandidateReview marker write failure err = %v", err)
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "" || len(fakeGitHub.postedComments) != 0 {
+		t.Fatalf("marker write failure posted github state: issue=%+v comments=%+v", fakeGitHub.createdIssue, fakeGitHub.postedComments)
+	}
+	iteration, err = store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration after marker failure returned error: %v", err)
+	}
+	if strings.Contains(iteration.MetadataJSON, `"status":"publishing"`) {
+		t.Fatalf("marker write failure recorded publishing metadata: %+v", iteration)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close marker failure store returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue retry after marker failure exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_review_published") || fakeGitHub.createdIssue.Repo.FullName() == "" {
+		t.Fatalf("retry after marker failure stdout=%s github=%+v", stdout.String(), fakeGitHub.createdIssue)
+	}
+}
+
+func TestSkillOptTrainContinueRetriesInterruptedBeforeCandidateReviewExternalPost(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with interrupted pre-external recovery guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	marker := map[string]any{
+		"status":            "publishing",
+		"candidate_version": iteration.CandidateVersionID,
+		"issue_repo":        "owner/product",
+		"issue_title":       "SkillOpt candidate review: optimizer-train",
+		"started_at":        time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", marker)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", marker)
+	if err := writeSkillOptCandidateReviewRecovery(config.PathsForHome(home), session, iteration, marker); err != nil {
+		t.Fatalf("writeSkillOptCandidateReviewRecovery pre-external marker returned error: %v", err)
+	}
+	if err := store.UpsertSkillOptTrainSessionAndIteration(context.Background(), session, iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSessionAndIteration pre-external marker returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close pre-external marker store returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue pre-external retry exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_review_published") || fakeGitHub.createdIssue.Repo.FullName() == "" {
+		t.Fatalf("pre-external retry stdout=%s github=%+v", stdout.String(), fakeGitHub.createdIssue)
+	}
+}
+
+func TestSkillOptTrainContinueBlocksInterruptedCandidateReviewExternalPost(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with interrupted external post recovery guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	stalePublishing := map[string]any{
+		"status":            "publishing",
+		"candidate_version": iteration.CandidateVersionID,
+		"issue_repo":        "owner/product",
+		"issue_title":       "SkillOpt candidate review: optimizer-train",
+		"started_at":        time.Now().UTC().Add(-skillOptTrainCandidateReviewLockTTL - time.Minute).Format(time.RFC3339Nano),
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", stalePublishing)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", stalePublishing)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(context.Background(), session, iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSessionAndIteration stale marker returned error: %v", err)
+	}
+	posting := map[string]any{
+		"status":                   "posting_external",
+		"candidate_version":        iteration.CandidateVersionID,
+		"issue_repo":               "owner/product",
+		"issue_title":              "SkillOpt candidate review: optimizer-train",
+		"external_post_started_at": time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+	}
+	if err := writeSkillOptCandidateReviewRecovery(config.PathsForHome(home), session, iteration, posting); err != nil {
+		t.Fatalf("writeSkillOptCandidateReviewRecovery posting marker returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close interrupted marker store returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue interrupted external post exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "external post started") || !strings.Contains(stderr.String(), "SkillOpt candidate review: optimizer-train") {
+		t.Fatalf("interrupted external post stderr = %q", stderr.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "" || len(fakeGitHub.postedComments) != 0 {
+		t.Fatalf("interrupted external post reposted github state: issue=%+v comments=%+v", fakeGitHub.createdIssue, fakeGitHub.postedComments)
+	}
+}
+
+func TestSkillOptTrainContinueRecoversCandidateReviewFromSidecar(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with sidecar recovery guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	publishing := map[string]any{
+		"status":            "publishing",
+		"candidate_version": iteration.CandidateVersionID,
+		"issue_repo":        "owner/product",
+		"issue_title":       "SkillOpt candidate review: optimizer-train",
+		"started_at":        time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_review", publishing)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_review", publishing)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(context.Background(), session, iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSessionAndIteration publishing marker returned error: %v", err)
+	}
+	sidecar := map[string]any{
+		"status":            "published_external",
+		"candidate_version": iteration.CandidateVersionID,
+		"issue_repo":        "owner/product",
+		"issue_number":      int64(8),
+		"issue_url":         "https://github.com/owner/product/issues/8",
+		"review_url":        "https://github.com/owner/product/issues/8",
+	}
+	paths := config.PathsForHome(home)
+	if err := writeSkillOptCandidateReviewRecovery(paths, session, iteration, sidecar); err != nil {
+		t.Fatalf("writeSkillOptCandidateReviewRecovery returned error: %v", err)
+	}
+	sidecarPath := skillOptCandidateReviewRecoveryPath(paths, session, iteration)
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close sidecar marker store returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--promote", "planner@v2"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue sidecar recovery exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_promoted") || !strings.Contains(stdout.String(), "promoted_candidate: planner@v2") {
+		t.Fatalf("sidecar recovery stdout = %s", stdout.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "" || len(fakeGitHub.postedComments) != 0 {
+		t.Fatalf("sidecar recovery reposted github state: issue=%+v comments=%+v", fakeGitHub.createdIssue, fakeGitHub.postedComments)
+	}
+	if _, err := os.Stat(sidecarPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("sidecar still exists err=%v", err)
+	}
+}
+
+func TestSkillOptCandidateReviewRecoveryNameAvoidsSanitizationCollisions(t *testing.T) {
+	first := skillOptCandidateReviewRecoveryName("feature/foo", "iter")
+	second := skillOptCandidateReviewRecoveryName("feature?foo", "iter")
+	if first == "" || second == "" {
+		t.Fatalf("recovery names are empty: first=%q second=%q", first, second)
+	}
+	if first == second {
+		t.Fatalf("recovery names collided: %q", first)
+	}
+}
+
+func TestSkillOptTrainContinueStartNextRejectsEvalRunCollision(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with collision guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue candidate review exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--promote", "planner@v2"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue promote exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:         "optimizer-train-review-002",
+		TemplateID: "planner",
+		TargetRepo: "owner/product",
+		State:      "review",
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun collision returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close collision store returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--start-next"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue start-next collision exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "eval run optimizer-train-review-002 already exists") {
+		t.Fatalf("start-next collision stderr = %q", stderr.String())
+	}
+}
+
+func TestSkillOptTrainContinueStartNextRejectsBusyLock(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with start-next lock guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue candidate review exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--promote", "planner@v2"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue promote exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	now := time.Now().UTC()
+	acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey: skillOptTrainStartNextLockKey("optimizer-train"),
+		OwnerJobID:  "test-start-next",
+		OwnerToken:  "token",
+		ExpiresAt:   now.Add(skillOptTrainStartNextLockTTL).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		t.Fatalf("AcquireResourceLock returned error: %v", err)
+	}
+	if !acquired {
+		t.Fatal("AcquireResourceLock did not acquire start-next lock")
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close lock store returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--start-next"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue start-next busy exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "next iteration is already starting") {
+		t.Fatalf("start-next busy stderr = %q", stderr.String())
+	}
+}
+
+func TestLimitSkillOptCandidateReviewText(t *testing.T) {
+	value := strings.Repeat("x", 20)
+	limited := limitSkillOptCandidateReviewText(value, 7, "eval report")
+	if !strings.HasPrefix(limited, strings.Repeat("x", 7)) || !strings.Contains(limited, "truncated eval report") || !strings.Contains(limited, "13 characters omitted") {
+		t.Fatalf("limited review text = %q", limited)
+	}
+	if got := limitSkillOptCandidateReviewText("short\n", 20, "diff"); got != "short" {
+		t.Fatalf("unlimited review text = %q", got)
+	}
+}
+
 func TestSkillOptTrainContinueRecordsOptimizerFailureAtPackageGate(t *testing.T) {
 	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
 	outRoot := filepath.Join(t.TempDir(), "optimizer")
@@ -3971,17 +5298,55 @@ func TestSkillOptReviewStatusRejectsMissingRun(t *testing.T) {
 type skillOptFakeGitHub struct {
 	github.NoopClient
 
-	createdIssue github.CreateIssueInput
-	comments     map[int64][]github.IssueComment
+	createdIssue       github.CreateIssueInput
+	postedComments     []skillOptPostedGitHubComment
+	comments           map[int64][]github.IssueComment
+	createIssueErr     error
+	postCommentErr     error
+	host               string
+	commentKinds       map[int64]string
+	commentURLOverride string
+}
+
+type skillOptPostedGitHubComment struct {
+	Repo        github.Repository
+	IssueNumber int64
+	Body        string
 }
 
 func (f *skillOptFakeGitHub) CreateIssue(_ context.Context, input github.CreateIssueInput) (github.Issue, error) {
+	if f.createIssueErr != nil {
+		return github.Issue{}, f.createIssueErr
+	}
 	f.createdIssue = input
-	return github.Issue{Number: 8, URL: "https://github.com/" + input.Repo.FullName() + "/issues/8"}, nil
+	return github.Issue{Number: 8, URL: f.baseURL() + "/" + input.Repo.FullName() + "/issues/8"}, nil
+}
+
+func (f *skillOptFakeGitHub) PostIssueComment(_ context.Context, repo github.Repository, issueNumber int64, body string) (github.IssueComment, error) {
+	if f.postCommentErr != nil {
+		return github.IssueComment{}, f.postCommentErr
+	}
+	f.postedComments = append(f.postedComments, skillOptPostedGitHubComment{Repo: repo, IssueNumber: issueNumber, Body: body})
+	kind := "issues"
+	if f.commentKinds != nil && f.commentKinds[issueNumber] != "" {
+		kind = f.commentKinds[issueNumber]
+	}
+	url := f.baseURL() + "/" + repo.FullName() + "/" + kind + "/" + fmt.Sprint(issueNumber) + "#issuecomment-" + fmt.Sprint(len(f.postedComments))
+	if strings.TrimSpace(f.commentURLOverride) != "" {
+		url = strings.TrimSpace(f.commentURLOverride)
+	}
+	return github.IssueComment{ID: int64(len(f.postedComments)), Body: body, URL: url}, nil
 }
 
 func (f *skillOptFakeGitHub) ListIssueComments(_ context.Context, _ github.Repository, issueNumber int64) ([]github.IssueComment, error) {
 	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
+}
+
+func (f *skillOptFakeGitHub) baseURL() string {
+	if strings.TrimSpace(f.host) == "" {
+		return "https://github.com"
+	}
+	return strings.TrimRight(strings.TrimSpace(f.host), "/")
 }
 
 func seedSkillOptTrainFeedbackSynced(t *testing.T) (string, string) {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1099,6 +1099,101 @@ func (s *Store) RejectAgentTemplateVersion(ctx context.Context, versionID string
 	return s.GetAgentTemplateVersionByID(ctx, target.ID)
 }
 
+func (s *Store) DecideSkillOptTrainCandidate(ctx context.Context, session SkillOptTrainSession, iteration SkillOptTrainIteration, candidateID string, decision string) (AgentTemplateVersion, error) {
+	session, err := normalizeSkillOptTrainSession(session)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	iteration, err = normalizeSkillOptTrainIteration(iteration)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	defer tx.Rollback()
+	target, err := getAgentTemplateVersionByIDTx(ctx, tx, candidateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if target.State != "pending" {
+		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not pending", target.ID, target.State)
+	}
+	switch strings.TrimSpace(decision) {
+	case "promoted":
+		current, hasCurrent, err := getCurrentAgentTemplateVersion(ctx, tx, target.TemplateID)
+		if err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		if hasCurrent {
+			if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'superseded', updated_at = CURRENT_TIMESTAMP WHERE id = ?`, current.ID); err != nil {
+				return AgentTemplateVersion{}, err
+			}
+		}
+		stateResult, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'current', promoted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = 'pending'`, target.ID)
+		if err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		if err := requireAffected(stateResult, "pending agent template version", target.ID); err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		latestID, err := latestSelectableVersionID(ctx, tx, target.TemplateID)
+		if err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET
+				name = ?, description = ?, source_repo = ?, source_ref = ?, source_path = ?, resolved_commit = ?,
+				content = ?, metadata_json = ?, current_version_id = ?, latest_version_id = ?, updated_at = CURRENT_TIMESTAMP
+			WHERE id = ?`,
+			target.Name, target.Description, target.SourceRepo, target.SourceRef, target.SourcePath, target.ResolvedCommit,
+			target.Content, target.MetadataJSON, target.ID, latestID, target.TemplateID)
+		if err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		if err := requireAffected(result, "agent template", target.TemplateID); err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		if err := upsertAgentTemplateCandidateReviewDecisionTx(ctx, tx, target, "promoted", ""); err != nil {
+			return AgentTemplateVersion{}, err
+		}
+	case "rejected":
+		stateResult, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'rejected', updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = 'pending'`, target.ID)
+		if err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		if err := requireAffected(stateResult, "pending agent template version", target.ID); err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		latestID, err := latestSelectableVersionID(ctx, tx, target.TemplateID)
+		if err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET latest_version_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, latestID, target.TemplateID)
+		if err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		if err := requireAffected(result, "agent template", target.TemplateID); err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		if err := upsertAgentTemplateCandidateReviewDecisionTx(ctx, tx, target, "rejected", iteration.DecisionReason); err != nil {
+			return AgentTemplateVersion{}, err
+		}
+	default:
+		return AgentTemplateVersion{}, fmt.Errorf("candidate decision %q is not supported", decision)
+	}
+	if err := upsertSkillOptTrainSessionTx(ctx, tx, session); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := upsertSkillOptTrainIterationTx(ctx, tx, iteration); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	return s.GetAgentTemplateVersionByID(ctx, target.ID)
+}
+
 func (s *Store) AgentCanAccessRepo(ctx context.Context, agentName string, repoFullName string) (bool, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_repos WHERE agent_name = ? AND repo_full_name = ?`, agentName, repoFullName).Scan(&count)
@@ -1816,7 +1911,11 @@ func (s *Store) UpsertEvalRun(ctx context.Context, run EvalRun) error {
 	if err != nil {
 		return err
 	}
-	_, err = s.db.ExecContext(ctx, `INSERT INTO eval_runs(id, template_id, template_version_id, target_repo, state, mode, exploration_level, options_count, metadata_json, created_at, updated_at)
+	return upsertEvalRunExec(ctx, s.db, run)
+}
+
+func upsertEvalRunExec(ctx context.Context, exec sqlExecer, run EvalRun) error {
+	_, err := exec.ExecContext(ctx, `INSERT INTO eval_runs(id, template_id, template_version_id, target_repo, state, mode, exploration_level, options_count, metadata_json, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			template_id = excluded.template_id,
@@ -1894,7 +1993,19 @@ func (s *Store) UpsertSkillOptTrainSession(ctx context.Context, session SkillOpt
 	if err != nil {
 		return err
 	}
-	_, err = s.db.ExecContext(ctx, `INSERT INTO skillopt_train_sessions(
+	return upsertSkillOptTrainSessionExec(ctx, s.db, session)
+}
+
+func upsertSkillOptTrainSessionTx(ctx context.Context, tx *sql.Tx, session SkillOptTrainSession) error {
+	session, err := normalizeSkillOptTrainSession(session)
+	if err != nil {
+		return err
+	}
+	return upsertSkillOptTrainSessionExec(ctx, tx, session)
+}
+
+func upsertSkillOptTrainSessionExec(ctx context.Context, exec sqlExecer, session SkillOptTrainSession) error {
+	_, err := exec.ExecContext(ctx, `INSERT INTO skillopt_train_sessions(
 			id, template_id, template_version_id, target_repo, workspace_repo, preview_repo,
 			request_summary, task_kind, state, metadata_json, created_at, updated_at
 		)
@@ -1953,7 +2064,19 @@ func (s *Store) UpsertSkillOptTrainIteration(ctx context.Context, iteration Skil
 	if err != nil {
 		return err
 	}
-	_, err = s.db.ExecContext(ctx, `INSERT INTO skillopt_train_iterations(
+	return upsertSkillOptTrainIterationExec(ctx, s.db, iteration)
+}
+
+func upsertSkillOptTrainIterationTx(ctx context.Context, tx *sql.Tx, iteration SkillOptTrainIteration) error {
+	iteration, err := normalizeSkillOptTrainIteration(iteration)
+	if err != nil {
+		return err
+	}
+	return upsertSkillOptTrainIterationExec(ctx, tx, iteration)
+}
+
+func upsertSkillOptTrainIterationExec(ctx context.Context, exec sqlExecer, iteration SkillOptTrainIteration) error {
+	_, err := exec.ExecContext(ctx, `INSERT INTO skillopt_train_iterations(
 			id, session_id, eval_run_id, base_template_version_id, candidate_version_id,
 			mode, exploration_level, state, issue_repo, issue_number, issue_url,
 			pull_request_repo, pull_request_number, pull_request_url, decision_reason, metadata_json, created_at, updated_at
@@ -1980,6 +2103,56 @@ func (s *Store) UpsertSkillOptTrainIteration(ctx context.Context, iteration Skil
 		iteration.Mode, iteration.ExplorationLevel, iteration.State, iteration.IssueRepo, iteration.IssueNumber, iteration.IssueURL,
 		iteration.PullRequestRepo, iteration.PullRequestNumber, iteration.PullRequestURL, iteration.DecisionReason, iteration.MetadataJSON)
 	return err
+}
+
+func (s *Store) UpsertSkillOptTrainSessionAndIteration(ctx context.Context, session SkillOptTrainSession, iteration SkillOptTrainIteration) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := upsertSkillOptTrainSessionTx(ctx, tx, session); err != nil {
+		return err
+	}
+	if err := upsertSkillOptTrainIterationTx(ctx, tx, iteration); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) UpsertSkillOptTrainNextIteration(ctx context.Context, session SkillOptTrainSession, iteration SkillOptTrainIteration, run EvalRun, items []EvalReviewItem) error {
+	session, err := normalizeSkillOptTrainSession(session)
+	if err != nil {
+		return err
+	}
+	iteration, err = normalizeSkillOptTrainIteration(iteration)
+	if err != nil {
+		return err
+	}
+	run, err = normalizeEvalRun(run)
+	if err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := upsertSkillOptTrainSessionExec(ctx, tx, session); err != nil {
+		return err
+	}
+	if err := upsertSkillOptTrainIterationExec(ctx, tx, iteration); err != nil {
+		return err
+	}
+	if err := upsertEvalRunExec(ctx, tx, run); err != nil {
+		return err
+	}
+	for _, item := range items {
+		if err := upsertEvalReviewItemExec(ctx, tx, item); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 func normalizeSkillOptTrainIteration(iteration SkillOptTrainIteration) (SkillOptTrainIteration, error) {
@@ -2089,6 +2262,10 @@ func (s *Store) GetSkillOptTrainIterationByEvalRun(ctx context.Context, evalRunI
 }
 
 func (s *Store) UpsertEvalReviewItem(ctx context.Context, item EvalReviewItem) error {
+	return upsertEvalReviewItemExec(ctx, s.db, item)
+}
+
+func upsertEvalReviewItemExec(ctx context.Context, exec sqlExecer, item EvalReviewItem) error {
 	if strings.TrimSpace(item.ID) == "" {
 		item.ID = item.RunID + "/" + item.ItemID
 	}
@@ -2098,7 +2275,7 @@ func (s *Store) UpsertEvalReviewItem(ctx context.Context, item EvalReviewItem) e
 	if strings.TrimSpace(item.ItemID) == "" {
 		return errors.New("eval review item id is required")
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO eval_review_items(
+	_, err := exec.ExecContext(ctx, `INSERT INTO eval_review_items(
 			id, run_id, item_id, title, source_artifact_id, baseline_artifact_id, candidate_artifact_id,
 			preview_artifact_id, diff_artifact_id, metadata_json, created_at, updated_at
 		)


### PR DESCRIPTION
## What
- Adds `gitmoot skillopt train continue` candidate review publication for optimizer candidates.
- Adds train candidate `--promote`, `--reject --reason`, and `--start-next` handling.
- Adds atomic DB helpers for candidate decisions and next-iteration creation.

## Why
Task 7 needs the training loop to publish a candidate review surface, accept human/CLI candidate decisions, and safely start the next iteration from the resolved candidate outcome.

## Changes
- Publishes candidate review issues or existing issue/PR comments with durable recovery sidecars.
- Blocks ambiguous GitHub write failures after external posting starts to avoid duplicate reviews.
- Recovers published review metadata without reposting and retries only pre-external interrupted publication.
- Syncs external candidate decisions, including promoted candidates later superseded by another promotion.
- Preserves enterprise GitHub hosts when deriving issue/PR review URLs from comment responses.
- Starts the next train iteration atomically with its eval run and review items.

## Results
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run SkillOpt`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/feedback ./internal/github ./internal/skillopt ./internal/db`
- `GOTOOLCHAIN=go1.26.2 go test ./... -timeout 8m`
- `git diff --check`
- `codex exec review --uncommitted --ignore-user-config -m codex-auto-review --disable image_generation`

Final automated review output:
```
I did not find any discrete, actionable bugs in the current changes. The new candidate-review and next-iteration flows appear internally consistent and are covered by substantial test additions.
```

## Risk
Medium. This changes a multi-step train workflow with external GitHub publication. The implementation is guarded by focused recovery/idempotency tests and the full repo test suite. No real GitHub issue or PR was created during verification; GitHub publication paths are covered by fake-client tests.