### PR TITLE
Document SkillOpt train workflow

### DIFF
--- a/docs/release-notes/v0.1.0-beta.8.md
+++ b/docs/release-notes/v0.1.0-beta.8.md
@@ -21,6 +21,12 @@ A/B validation.
 - Beta smoke-test documentation for clean-temp-home ranked exploration runs,
   Markdown packet import, pairwise expansion, training export inspection, and
   optional GitHub issue or PR feedback sync.
+- High-level `gitmoot skillopt train` documentation for session/iteration
+  orchestration, optimizer handoff, candidate review, explicit
+  promote/reject decisions, and start-next gate enforcement.
+- Deterministic `scripts/skillopt-train-smoke.sh` coverage for fake managed
+  generation, fake optimizer handoff, fake GitHub candidate review, and
+  promote/reject/start-next paths.
 
 ## Known Beta Limits
 
@@ -31,3 +37,5 @@ A/B validation.
 - Phase recommendations are advisory. Gitmoot does not automatically change
   modes, run the external optimizer, import candidates, or promote templates.
 - The external optimizer remains outside the main Gitmoot binary.
+- Train-mode smoke coverage uses fake GitHub and fake optimizer seams; real
+  GitHub review publication still depends on the authenticated `gh` environment.

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -4,6 +4,18 @@ Gitmoot keeps the SkillOpt optimizer outside the main binary. The boundary is a
 pair of JSON package formats handled by `gitmoot skillopt export` and
 `gitmoot skillopt import`.
 
+For the guided product workflow, use `gitmoot skillopt train` instead of
+assembling every low-level command manually. Train mode creates sessions and
+iterations, manages review items, generates options, publishes review packets,
+syncs feedback, exports the package, runs the external optimizer, imports a
+pending candidate, publishes candidate review context, and starts follow-up
+iterations only after an explicit decision. The low-level commands documented
+here are still useful for advanced debugging, custom research runs, and
+recovering individual train steps.
+
+See [SkillOpt Train Workflow](skillopt-train-workflow.md) for the end-to-end
+train-mode sequence.
+
 ## Training Package
 
 Export a local eval run:
@@ -442,6 +454,16 @@ Complete local review path:
 8. `gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]`
 9. `gitmoot skillopt candidate show <version-id>`
 10. `gitmoot skillopt candidate promote <version-id>` or `gitmoot skillopt candidate reject <version-id>`
+
+Complete train-mode path:
+
+1. `gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file items.yml --yes`
+2. `gitmoot skillopt train continue --session <session-id>` to generate options and publish the review packet.
+3. Human feedback is imported from the review surface.
+4. `gitmoot skillopt train continue --session <session-id>` to export the package, run `gitmoot-skillopt`, and import the pending candidate.
+5. `gitmoot skillopt train continue --session <session-id>` to publish candidate review context.
+6. `gitmoot skillopt train continue --session <session-id> --promote <version>` or `--reject <version> --reason <text>`.
+7. `gitmoot skillopt train continue --session <session-id> --start-next` only after the prior iteration is resolved.
 
 Complete GitHub review path:
 

--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -1,0 +1,181 @@
+# SkillOpt Train Workflow
+
+Use `gitmoot skillopt train` when a user wants Gitmoot to enforce the full
+human-feedback optimization loop for an agent template. Use the lower-level
+`gitmoot skillopt review`, `feedback`, `export`, `import`, and `candidate`
+commands only for advanced debugging, custom research runs, or recovering one
+step of an existing train session.
+
+Train mode keeps Gitmoot as the product/control layer. The external
+`gitmoot-skillopt` optimizer remains outside the Go binary and is invoked only
+after Gitmoot has collected review items and feedback.
+
+## Session Shape
+
+A train session is the long-lived workflow for one template and request. Each
+session has one or more iterations. An iteration has:
+
+- a pinned base template version;
+- an eval review run and review items;
+- workspace and optional preview repos;
+- preferred evaluation gate metadata;
+- generated option artifacts;
+- imported human feedback;
+- an optimizer package and candidate package;
+- an optional candidate review issue or PR link;
+- a terminal decision: promoted, rejected with a reason, or abandoned.
+
+The next iteration can start only after the prior iteration is promoted,
+rejected with a reason, or abandoned. If the prior candidate was promoted, the
+promoted candidate version becomes the next base template snapshot. Rejected
+candidates never become current silently.
+
+## High-Level Commands
+
+Start with a request, target repo, pinned template, and item plan:
+
+```sh
+gitmoot skillopt train start \
+  --template planner \
+  --session planner-train \
+  --repo owner/product \
+  --workspace-repo owner/product-workspace \
+  --preview-repo owner/product-previews \
+  --request "Improve release planning answers from reviewer feedback" \
+  --items-file train-items.yml \
+  --mode explore \
+  --exploration-level high \
+  --options 4 \
+  --preferred-gate hard_then_soft \
+  --yes
+```
+
+Use `--dry-run` first to inspect the inferred session id, request summary,
+task kind, preferred gate, item warnings, and next action without writing state.
+Without `--yes`, non-interactive runs print the exact confirmation command.
+
+Inspect progress at any point:
+
+```sh
+gitmoot skillopt train status --session planner-train
+```
+
+Advance the next required step:
+
+```sh
+gitmoot skillopt train continue --session planner-train
+```
+
+Stop instead of continuing:
+
+```sh
+gitmoot skillopt train stop --session planner-train --reason "Request changed"
+```
+
+## Items, Workspace, And Preview Repos
+
+The item file is YAML or JSON. Each item should describe a distinct task or
+audience so feedback is not overfit to one prompt.
+
+```yaml
+items:
+  - id: release-plan
+    title: Release planning answer
+    brief: Plan a small release with risk and verification steps.
+    target_audience: maintainer
+    output_type: markdown plan
+  - id: review-followup
+    title: Review follow-up answer
+    brief: Turn reviewer feedback into a concise fix plan.
+    target_audience: contributor
+    output_type: markdown checklist
+```
+
+Starting with too few items fails. Homogeneous item sets warn and require
+explicit acceptance. `workspace-repo` is where managed agents can work on
+generated outputs. `preview-repo` is where preview links can point when a
+workflow produces demos or rendered artifacts. Gitmoot records preview metadata,
+but it does not assume private GitHub Pages is available.
+
+## Review And Feedback
+
+`train continue` generates options through Gitmoot-managed temporary agents,
+stores artifact-backed review items/options, and publishes a concise GitHub
+review packet when the review step is ready. Reviewers can provide ranked
+feedback with optional quality and phase hints:
+
+```yaml
+run_id: planner-train-review-001
+reviewer: alice
+items:
+  - item_id: release-plan
+    ranking:
+      - C > A > D > B
+    quality: acceptable
+    continue_mode: refine
+    useful_traits:
+      C:
+        - clearer verification sequencing
+    rejected_traits:
+      B:
+        - too vague about rollback
+    reasoning: C is strongest, but A has a better risk summary.
+```
+
+Use `quality: poor` or `continue_mode: explore` when all options are weak and a
+stable winner should not narrow the search yet. Gitmoot keeps feedback parsing
+deterministic and stores imported events as canonical feedback for export.
+
+## Optimizer And Candidate Gate
+
+After feedback sync, `train continue` exports the training package, invokes the
+configured `gitmoot-skillopt optimize` command, imports the returned candidate
+package through the shared candidate validator, and leaves the candidate
+pending. Use `--dry-run` to validate the package and optimizer command shape
+without model calls.
+
+```sh
+gitmoot skillopt train continue \
+  --session planner-train \
+  --skillopt-bin /path/to/gitmoot-skillopt \
+  --out-root .gitmoot/skillopt/planner-train \
+  --dry-run
+```
+
+Optimizer failures record blocked status and do not promote or partially install
+candidate templates.
+
+## Candidate Review And Next Iteration
+
+The candidate review step publishes the candidate summary, eval report, template
+diff, preview/PR links when available, and copyable decision commands. Promote
+or reject explicitly:
+
+```sh
+gitmoot skillopt train continue --session planner-train --promote planner@v2
+gitmoot skillopt train continue --session planner-train --reject planner@v2 --reason "Too broad"
+```
+
+After a decision, either stop or start the next iteration:
+
+```sh
+gitmoot skillopt train continue --session planner-train --start-next
+```
+
+Manual append-style next iterations are not supported. The train state machine
+creates the next iteration atomically from the resolved previous decision, its
+eval run, and copied item plan.
+
+## Deterministic Smoke
+
+Run the local train smoke script before shipping train-mode changes:
+
+```sh
+scripts/skillopt-train-smoke.sh
+```
+
+The script runs focused CLI smoke tests with fake managed generation, fake
+`gitmoot-skillopt`, and fake GitHub publication. It covers local template
+creation, session setup, item/generation flow, feedback-to-optimizer handoff,
+candidate import, candidate review publication, promote/reject decisions, and
+start-next gate enforcement without real model calls or real GitHub mutation.

--- a/scripts/skillopt-train-smoke.sh
+++ b/scripts/skillopt-train-smoke.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GO_BIN="${GO_BIN:-go}"
+GO_TOOLCHAIN="${GOTOOLCHAIN:-go1.26.2}"
+
+TEST_PATTERN='TestSkillOptTrainContinueGeneratesOptionsWithManagedAgent|TestSkillOptTrainContinuePublishesCandidateReviewPromotesAndStartsNext|TestSkillOptTrainContinueSyncsHumanCandidatePromotionAndStartsNext|TestSkillOptTrainContinueSyncsHumanCandidatePromotionBeforeReviewPublish|TestSkillOptTrainContinueRequiresReasonForExternalCandidateRejection|TestSkillOptTrainContinuePublishesCandidateReviewAndRejects|TestSkillOptTrainContinueStartNextRejectsEvalRunCollision'
+
+cd "$ROOT_DIR"
+GOTOOLCHAIN="$GO_TOOLCHAIN" "$GO_BIN" test ./internal/cli -run "$TEST_PATTERN"
+
+echo "skillopt train smoke passed"
+echo "covered: fake managed generation, fake optimizer handoff, fake GitHub candidate review, promote/reject, start-next gates"

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -71,13 +71,14 @@ The plugin is only the runtime discovery surface for this skill. Local agent
 invocation still goes through the `gitmoot` CLI and the same registered agent,
 repo access, runtime adapter, and job history model used by PR-comment jobs.
 
-For SkillOpt template learning, use ranked exploration when the user needs broad
-search across multiple directions, then narrow through refine and distill before
-final validation. Keep final promotion decisions on fresh A/B validation items
-unless the user explicitly asks for another evaluation design. Treat
-`gitmoot skillopt review status` recommendations as advisory. Do not run heavy
-SkillOpt optimization after every tiny feedback round unless the user explicitly
-wants that; collect enough rankings and trait notes first.
+For SkillOpt template learning, prefer the high-level
+`gitmoot skillopt train start/status/continue/stop` workflow when the user wants
+Gitmoot to enforce the full feedback, optimizer, candidate-review, and
+promotion loop. Use low-level `gitmoot skillopt review`, `feedback`, `export`,
+`import`, and `candidate` commands for advanced/debug work or when recovering a
+specific step. In train mode, collect enough ranked feedback and trait notes
+before optimizer handoff, keep promotion decisions explicit, and start follow-up
+iterations only through `train continue --start-next`.
 
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -271,7 +271,20 @@ gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
 gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
+gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file items.yml [--yes]
+gitmoot skillopt train status --session <id>
+gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
+gitmoot skillopt train stop --session <id> --reason <text>
 ```
+
+Use `skillopt train` for the product workflow. It pins the template version,
+tracks sessions and iterations, validates item diversity, generates temporary
+agent options, publishes review packets, syncs feedback, hands off to the
+external optimizer, imports pending candidates, publishes candidate review
+context, and starts follow-up iterations only after a promoted/rejected/abandoned
+decision. Use `skillopt review`, `feedback`, `export`, `import`, and
+`candidate` directly only for advanced debugging, custom research runs, or
+recovering one step of a train session.
 
 `skillopt review create` starts a review run for a template and target repo.
 Use the default A/B shape for validation, or pass `--mode explore|refine|distill`

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -190,6 +190,52 @@ it explicitly:
 gitmoot goal import --file GOAL-feature.md --repo owner/repo
 ```
 
+## SkillOpt Train Mode
+
+Use `gitmoot skillopt train` when a user wants Gitmoot to enforce the complete
+template-learning loop. Use low-level `skillopt review`, `feedback`, `export`,
+`import`, and `candidate` commands only for advanced/debug work, custom
+research runs, or one-step recovery.
+
+```sh
+gitmoot skillopt train start \
+  --template planner \
+  --session planner-train \
+  --repo owner/product \
+  --workspace-repo owner/product-workspace \
+  --preview-repo owner/product-previews \
+  --request "Improve release planning answers from reviewer feedback" \
+  --items-file train-items.yml \
+  --mode explore \
+  --exploration-level high \
+  --options 4 \
+  --preferred-gate hard_then_soft \
+  --yes
+
+gitmoot skillopt train status --session planner-train
+gitmoot skillopt train continue --session planner-train
+```
+
+Train sessions contain one or more iterations. Each iteration pins a base
+template version, owns one eval review run, stores workspace/preview metadata,
+collects ranked or A/B feedback, exports a training package, imports one
+pending optimizer candidate, and records an explicit promote/reject/abandon
+decision. The next iteration starts only through:
+
+```sh
+gitmoot skillopt train continue --session planner-train --start-next
+```
+
+If the previous candidate was promoted, the promoted candidate version becomes
+the next base. Rejections require a reason. Manual append-style next iterations
+are not part of the train workflow.
+
+Run the deterministic smoke before changing train behavior:
+
+```sh
+scripts/skillopt-train-smoke.sh
+```
+
 ## SkillOpt Ranked Exploration
 
 Use ranked exploration when a template needs broad search before final

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -73,4 +73,12 @@ gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
 gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
+gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file items.yml [--yes]
+gitmoot skillopt train status --session <id>
+gitmoot skillopt train continue --session <id> [--promote version|--reject version --reason text] [--start-next]
+gitmoot skillopt train stop --session <id> --reason <text>
 ```
+
+Use `skillopt train` for the guided product workflow. Use low-level
+`skillopt review`, `feedback`, `export`, `import`, and `candidate` commands for
+advanced/debug work or custom research runs.

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -6,6 +6,13 @@ Gitmoot keeps the SkillOpt optimizer outside the main binary. The boundary is a
 pair of JSON package formats handled by `gitmoot skillopt export` and
 `gitmoot skillopt import`.
 
+For the guided product workflow, use `gitmoot skillopt train` instead of
+assembling every low-level command manually. Train mode creates sessions and
+iterations, manages items, generates options, publishes review packets, syncs
+feedback, exports the package, runs the external optimizer, imports a pending
+candidate, and starts follow-up iterations only after an explicit decision. See
+[SkillOpt Train Workflow](/workflows/skillopt-train-workflow).
+
 ## Training Package
 
 ```sh

--- a/website/docs/release-notes/v0.1.0-beta.8.md
+++ b/website/docs/release-notes/v0.1.0-beta.8.md
@@ -16,6 +16,11 @@ A/B validation.
   pairwise preference counts, and advisory next-mode guidance
 - clean-temp-home smoke-test documentation for ranked Markdown packets,
   training export inspection, and optional GitHub issue or PR feedback sync
+- `gitmoot skillopt train` documentation for session/iteration orchestration,
+  optimizer handoff, candidate review, explicit promote/reject decisions, and
+  start-next gate enforcement
+- `scripts/skillopt-train-smoke.sh` deterministic smoke coverage with fake
+  managed generation, fake optimizer handoff, and fake GitHub publication
 
 ## Beta Limits
 
@@ -25,6 +30,8 @@ A/B validation.
 - phase recommendations are advisory and do not automatically change modes,
   import candidates, run optimizers, or promote templates
 - the external optimizer remains outside the main Gitmoot binary
+- train-mode smoke coverage uses fake GitHub and fake optimizer seams; real
+  GitHub review publication still depends on authenticated `gh`
 
 For current release artifacts, see
 [GitHub releases](https://github.com/jerryfane/gitmoot/releases).

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -1,0 +1,118 @@
+---
+title: SkillOpt Train Workflow
+---
+
+Use `gitmoot skillopt train` for the full human-feedback optimization loop for
+an agent template. The lower-level `skillopt review`, `feedback`, `export`,
+`import`, and `candidate` commands remain available for advanced debugging,
+custom research runs, and recovery of individual steps.
+
+Train mode keeps Gitmoot as the product/control layer. The external
+`gitmoot-skillopt` optimizer stays outside the Gitmoot binary.
+
+## Sessions And Iterations
+
+A train session tracks one template and one human request. Each iteration pins a
+base template version, owns an eval review run, records workspace and optional
+preview repos, stores generated option artifacts, imports human feedback, runs
+the optimizer, imports a pending candidate, and records a final decision.
+
+The next iteration can start only after the previous iteration is promoted,
+rejected with a reason, or abandoned. Promoted candidates become the next base
+template snapshot. Rejected candidates never become current silently.
+
+## Start And Continue
+
+```sh
+gitmoot skillopt train start \
+  --template planner \
+  --session planner-train \
+  --repo owner/product \
+  --workspace-repo owner/product-workspace \
+  --preview-repo owner/product-previews \
+  --request "Improve release planning answers from reviewer feedback" \
+  --items-file train-items.yml \
+  --mode explore \
+  --exploration-level high \
+  --options 4 \
+  --preferred-gate hard_then_soft \
+  --yes
+```
+
+Use `--dry-run` first to inspect the inferred session, item warnings, preferred
+gate, and next action without writing state.
+
+```sh
+gitmoot skillopt train status --session planner-train
+gitmoot skillopt train continue --session planner-train
+gitmoot skillopt train stop --session planner-train --reason "Request changed"
+```
+
+The item file is YAML or JSON:
+
+```yaml
+items:
+  - id: release-plan
+    title: Release planning answer
+    brief: Plan a small release with risk and verification steps.
+    target_audience: maintainer
+    output_type: markdown plan
+  - id: review-followup
+    title: Review follow-up answer
+    brief: Turn reviewer feedback into a concise fix plan.
+    target_audience: contributor
+    output_type: markdown checklist
+```
+
+Starting with too few items fails. Homogeneous item sets warn and require
+explicit confirmation.
+
+## Review, Feedback, And Optimizer Gate
+
+`train continue` generates options through Gitmoot-managed temporary agents and
+publishes a concise GitHub review packet. Reviewers can use ranked feedback with
+optional quality and phase hints:
+
+```yaml
+run_id: planner-train-review-001
+reviewer: alice
+items:
+  - item_id: release-plan
+    ranking:
+      - C > A > D > B
+    quality: acceptable
+    continue_mode: refine
+    reasoning: C is strongest, but A has a better risk summary.
+```
+
+Use `quality: poor` or `continue_mode: explore` when all options are weak and a
+stable winner should not narrow the search yet.
+
+After feedback sync, train mode exports the training package, invokes
+`gitmoot-skillopt optimize`, imports the returned candidate through the shared
+candidate validator, and leaves the candidate pending. Use optimizer `--dry-run`
+flags to validate command shape without model calls.
+
+## Candidate Decision
+
+Promote or reject explicitly:
+
+```sh
+gitmoot skillopt train continue --session planner-train --promote planner@v2
+gitmoot skillopt train continue --session planner-train --reject planner@v2 --reason "Too broad"
+gitmoot skillopt train continue --session planner-train --start-next
+```
+
+Manual append-style next iterations are not supported. The train state machine
+creates the next iteration atomically from the resolved previous decision, its
+eval run, and copied item plan.
+
+## Smoke Test
+
+```sh
+scripts/skillopt-train-smoke.sh
+```
+
+The smoke script runs focused CLI tests with fake managed generation, fake
+`gitmoot-skillopt`, and fake GitHub publication. It covers the train loop
+without real model calls or real GitHub mutation.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -27,6 +27,7 @@ const sidebars: SidebarsConfig = {
         'workflows/planner-goal-workflow',
         'workflows/template-capture-workflow',
         'workflows/review-agent-workflow',
+        'workflows/skillopt-train-workflow',
       ],
     },
     {

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2684,13 +2684,14 @@ The plugin is only the runtime discovery surface for this skill. Local agent
 invocation still goes through the `gitmoot` CLI and the same registered agent,
 repo access, runtime adapter, and job history model used by PR-comment jobs.
 
-For SkillOpt template learning, use ranked exploration when the user needs broad
-search across multiple directions, then narrow through refine and distill before
-final validation. Keep final promotion decisions on fresh A/B validation items
-unless the user explicitly asks for another evaluation design. Treat
-`gitmoot skillopt review status` recommendations as advisory. Do not run heavy
-SkillOpt optimization after every tiny feedback round unless the user explicitly
-wants that; collect enough rankings and trait notes first.
+For SkillOpt template learning, prefer the high-level
+`gitmoot skillopt train start/status/continue/stop` workflow when the user wants
+Gitmoot to enforce the full feedback, optimizer, candidate-review, and
+promotion loop. Use low-level `gitmoot skillopt review`, `feedback`, `export`,
+`import`, and `candidate` commands for advanced/debug work or when recovering a
+specific step. In train mode, collect enough ranked feedback and trait notes
+before optimizer handoff, keep promotion decisions explicit, and start follow-up
+iterations only through `train continue --start-next`.
 
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).
@@ -3091,7 +3092,20 @@ gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
 gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
+gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file items.yml [--yes]
+gitmoot skillopt train status --session <id>
+gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
+gitmoot skillopt train stop --session <id> --reason <text>
 ```
+
+Use `skillopt train` for the product workflow. It pins the template version,
+tracks sessions and iterations, validates item diversity, generates temporary
+agent options, publishes review packets, syncs feedback, hands off to the
+external optimizer, imports pending candidates, publishes candidate review
+context, and starts follow-up iterations only after a promoted/rejected/abandoned
+decision. Use `skillopt review`, `feedback`, `export`, `import`, and
+`candidate` directly only for advanced debugging, custom research runs, or
+recovering one step of a train session.
 
 `skillopt review create` starts a review run for a template and target repo.
 Use the default A/B shape for validation, or pass `--mode explore|refine|distill`
@@ -3338,6 +3352,52 @@ it explicitly:
 
 ```sh
 gitmoot goal import --file GOAL-feature.md --repo owner/repo
+```
+
+## SkillOpt Train Mode
+
+Use `gitmoot skillopt train` when a user wants Gitmoot to enforce the complete
+template-learning loop. Use low-level `skillopt review`, `feedback`, `export`,
+`import`, and `candidate` commands only for advanced/debug work, custom
+research runs, or one-step recovery.
+
+```sh
+gitmoot skillopt train start \
+  --template planner \
+  --session planner-train \
+  --repo owner/product \
+  --workspace-repo owner/product-workspace \
+  --preview-repo owner/product-previews \
+  --request "Improve release planning answers from reviewer feedback" \
+  --items-file train-items.yml \
+  --mode explore \
+  --exploration-level high \
+  --options 4 \
+  --preferred-gate hard_then_soft \
+  --yes
+
+gitmoot skillopt train status --session planner-train
+gitmoot skillopt train continue --session planner-train
+```
+
+Train sessions contain one or more iterations. Each iteration pins a base
+template version, owns one eval review run, stores workspace/preview metadata,
+collects ranked or A/B feedback, exports a training package, imports one
+pending optimizer candidate, and records an explicit promote/reject/abandon
+decision. The next iteration starts only through:
+
+```sh
+gitmoot skillopt train continue --session planner-train --start-next
+```
+
+If the previous candidate was promoted, the promoted candidate version becomes
+the next base. Rejections require a reason. Manual append-style next iterations
+are not part of the train workflow.
+
+Run the deterministic smoke before changing train behavior:
+
+```sh
+scripts/skillopt-train-smoke.sh
 ```
 
 ## SkillOpt Ranked Exploration


### PR DESCRIPTION
## WHAT
- Adds a SkillOpt train workflow guide for repository docs and website docs.
- Updates SkillOpt exchange docs, CLI references, Gitmoot skill guidance, workflow references, release notes, website sidebar, and generated `llms-full` context.
- Adds `scripts/skillopt-train-smoke.sh` for deterministic train-mode smoke coverage.

## WHY
Task 8 requires new users and agent skill references to understand the high-level `gitmoot skillopt train` workflow, when to use low-level commands, and how to verify train mode without real model calls or real GitHub mutation.

## CHANGES
- Documents sessions/iterations, workspace vs preview repos, item files, ranked feedback quality fields, optimizer handoff, candidate review, promote/reject, and `--start-next`.
- States that low-level `skillopt review`/`feedback`/`export`/`import`/`candidate` commands are advanced/debug surfaces.
- Adds website sidebar entry for the train workflow page.
- Adds a smoke script that runs focused CLI tests using fake managed generation, fake optimizer handoff, fake GitHub publication, promote/reject, and start-next gates.

## RESULTS
- `scripts/skillopt-train-smoke.sh`
- `GOTOOLCHAIN=go1.26.2 go test ./... -timeout 8m`
- `(cd website && npm run build)`
- `git diff --check`
- `codex exec review --uncommitted --ignore-user-config -m codex-auto-review --disable image_generation`

Final automated review output:
```
The changes are limited to documentation, sidebar wiring, and a focused smoke-test helper, and I did not find a discrete correctness issue that would clearly mislead users or break existing behavior. The documented `skillopt train` flows and referenced test names line up with the current CLI/test surface.
```

Note: I also ran `npm run build` once from the repo root by mistake; it failed because the root has no `package.json`. The actual website build from `website/` passed.

## RISK
Docs/smoke-only change. The smoke uses fake GitHub and fake optimizer seams; real GitHub review publication still depends on authenticated `gh` and repository permissions.