### PR TITLE
Add SkillOpt train preview policy

### DIFF
--- a/GOAL-SKILLOPT-VUE-PREVIEWS.md
+++ b/GOAL-SKILLOPT-VUE-PREVIEWS.md
@@ -1,0 +1,476 @@
+# SkillOpt Vue Preview Publishing
+
+Implement the plan task by task. Each task must be developed, reviewed, opened
+as its own pull request, merged, and verified before moving on, unless tasks are
+explicitly safe to run in parallel.
+
+Build the missing preview layer for `gitmoot skillopt train` so landing-page
+training runs produce real Vue/Vite preview links before GitHub review packets
+are published. The immediate implementation only needs two preview modes:
+`none` for text-only review packets and `vue-vite` for landing-page previews
+published through the preview repository. The design must stay composable so
+future renderers such as LaTeX/PDF can be added without rewriting the train
+state machine.
+
+This goal touches SkillOpt train metadata, option generation prompts, preview
+rendering/publishing, GitHub feedback publishing, review-repo enforcement,
+tests, docs, and the Gitmoot skill references. Do not implement LaTeX, image,
+Storybook, notebook, or other preview types in this goal.
+
+## Core Rules
+
+- Work one task at a time in the listed order by default.
+- If tasks are independent, have disjoint file ownership, and do not depend on
+  each other's results, they may be done in parallel on separate branches.
+- Do not start dependent work until the prerequisite task has passed checks,
+  passed `codex exec review --uncommitted`, been pushed, opened as a PR, merged,
+  and verified on the target branch.
+- Do not commit generated data, reports, caches, build artifacts, secrets,
+  credentials, session archives, cloned helper repos, local plugin build output,
+  or large outputs unless the plan explicitly says they are intended tracked
+  fixtures/artifacts.
+- Preserve existing behavior unless the current task explicitly changes it.
+- Keep changes clean, scoped, and organized. Avoid broad rewrites.
+- Avoid code duplication. When repeated logic appears, extract small reusable
+  helpers that match existing repo patterns.
+- If implementation depends on external APIs, docs, CLIs, data formats,
+  generated scripts, installers, service launchers, subprocess calls, env vars,
+  config formats, or third-party libraries, verify the real contract with local
+  commands and/or official sources before editing.
+
+## Before Starting
+
+1. Inspect current repo state with:
+   - `git status --short`
+   - current branch
+   - current remote
+2. If the target branch is unclear, the remote looks wrong, or the worktree has
+   unrelated existing changes that make task commits ambiguous, stop and ask
+   before continuing.
+3. Confirm the target base branch from the current repo. If unspecified, use the
+   current branch as the base.
+4. Inspect relevant existing patterns before editing.
+5. Verify PR tooling is available before the first PR:
+   - `gh auth status`
+   - repo remote resolves to the expected GitHub repository
+
+## Per-Task Branch Workflow
+
+1. Confirm the current task's scope.
+2. Create a task branch from the latest target base branch.
+3. Implement only that task.
+4. Add or update focused tests/checks appropriate to the task.
+5. Run focused tests for touched modules.
+6. Run broader checks when the task touches shared behavior, CLI/API surfaces,
+   data/model/evaluation logic, generated scripts, installers, service
+   launchers, docs build systems, or user-facing workflows.
+7. For wrapper, installer, CLI, subprocess, generated-script, env propagation,
+   service-launcher, or deployment changes, include an operational smoke test or
+   direct contract check. Syntax checks alone are not enough.
+8. Identify every repository where files changed. In each changed repo, run:
+   `codex exec review --uncommitted`
+9. Preserve the exact raw review output per repo.
+
+## Review-Fix Loop
+
+1. If review finds issues, do not only patch the literal line.
+2. Identify the underlying invariant/class of bug.
+3. Audit nearby and sibling paths for the same issue.
+4. Write a concise fix plan using:
+
+   ```text
+   Review found these issues: <<PASTE RAW REVIEW RESULTS BY REPO>>.
+   For each issue, identify the underlying invariant/class of bug, audit sibling
+   paths for the same issue, and plan the smallest safe fix. Verify external
+   assumptions with local commands and/or official sources. Preserve repo
+   patterns, avoid unnecessary refactors, and list tests/checks per repo.
+   ```
+
+5. Execute the fix plan.
+6. Re-run focused tests/checks and `codex exec review --uncommitted` in every
+   repo with uncommitted changes.
+7. Repeat until the final raw review output contains no findings, or stop if
+   blocked or if a finding is incorrect after verification.
+
+## Commit Gate
+
+1. Before committing, run `git diff --check` and inspect the final diff.
+2. Commit only the current task's intended tracked changes.
+3. Use the commit message specified by the plan. If the plan does not specify
+   one, use a concise conventional message that describes only the current task.
+4. Push the task branch.
+5. Verify the task branch worktree is clean after push, except for intentionally
+   ignored generated files.
+
+## Pull Request Gate
+
+1. Create one PR for the current task.
+2. The PR title must describe only the current task.
+3. The PR body must include:
+   - WHAT: what was changed
+   - WHY: why the task was needed
+   - CHANGES: concrete implementation changes
+   - RESULTS: tests/checks/review results
+   - RISK: skipped checks, blockers, or residual risk
+4. Include the exact raw final `codex exec review --uncommitted` output for each
+   changed repo in the PR body.
+5. If CI or required checks exist, wait for them and fix failures before merge.
+6. Merge the PR using the repository's configured/preferred merge method. If no
+   preference is discoverable, use squash merge for a clean task-level history.
+7. After merge, update the local target base branch and verify the worktree is
+   clean.
+8. Record the PR number, PR URL, branch name, and merged commit hash.
+9. Delete the task branch after merge only if the repository normally does so or
+   the merge command supports safe branch deletion.
+
+## Final Response After All Tasks
+
+- List completed tasks.
+- For each task, list branch, PR URL, merge status, and merged commit hash.
+- List tests/checks run.
+- Include exact final raw `codex exec review --uncommitted` output for the last
+  task/repo.
+- Mention skipped checks, blockers, or residual risk.
+- Do not claim interactive `/review` is clean. Say:
+  `codex exec review is clean; ready for manual /review.`
+
+## Design Direction
+
+Use two composable layers:
+
+```text
+generated option
+  -> renderer adapter
+  -> preview bundle
+  -> publisher adapter
+  -> review packet
+```
+
+Renderer adapters convert generated artifacts into reviewable output. Implement
+only:
+
+- `none`: no rendered preview; GitHub issue content is enough.
+- `vue-vite`: generated option must provide a machine-readable Vue/Vite file
+  bundle that can be built and published.
+
+Publisher adapters decide where reviewable output lives. Implement only:
+
+- `none`: no preview publication.
+- `github-pages`: copy built static output into the configured preview repo
+  under a deterministic route, commit, push, and store public URLs.
+
+For a train run with `preview.mode: required`, Gitmoot must not publish a human
+review packet until every generated option has a preview URL. Inline artifact
+fallback is allowed only for `preview.mode: none` or `preview.mode: optional`.
+
+## Implementation Tasks
+
+### Task 1: Add Preview Policy And Expected Review Repo
+
+Scope:
+
+- Add a small preview-policy model in the SkillOpt train layer, using session
+  metadata for backward compatibility unless explicit columns are clearly
+  simpler after inspection.
+- Supported fields:
+  - `preview.mode`: `none`, `optional`, or `required`
+  - `preview.renderer`: `none` or `vue-vite`
+  - `preview.publisher`: `none` or `github-pages`
+  - `preview.repo`
+  - `preview.route_template`
+  - `review.expected_repo`
+- `train start` should derive safe defaults:
+  - no `--preview-repo` and no preview flags: `mode=none`,
+    `renderer=none`, `publisher=none`, `expected_review_repo=<target repo>`.
+  - `--preview-repo` present: `mode=required`, `renderer=vue-vite`,
+    `publisher=github-pages`, `preview.repo=<preview repo>`,
+    `expected_review_repo=<preview repo>`.
+- Add explicit flags if needed, but keep the initial public surface small:
+  `--preview-mode`, `--preview-renderer`, `--preview-publisher`,
+  `--preview-route-template`.
+- Reject invalid combinations, including `mode=required` with
+  `renderer=none`, `publisher=none`, or missing preview repo.
+- Show the resolved preview policy and expected review repo in
+  `train start --dry-run`, `train start`, and `train status`.
+
+Acceptance criteria:
+
+- Existing train sessions without preview metadata load as `mode=none`.
+- Starting with `--preview-repo owner/previews` resolves to required Vue/Vite
+  previews and expected review repo `owner/previews`.
+- Starting without a preview repo keeps text-only behavior and expected review
+  repo equal to the target repo.
+- Invalid preview-policy combinations fail before writing state.
+
+Tests/checks:
+
+- `GOTOOLCHAIN=go1.26.2 go test ./internal/skillopt`
+- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrain.*Start|SkillOptTrain.*Status'`
+- `git diff --check`
+- `codex exec review --uncommitted`
+
+Suggested branch:
+
+- `task/skillopt-preview-policy`
+
+Suggested commit message:
+
+- `feat(skillopt): add train preview policy`
+
+### Task 2: Enforce Review Repository Selection
+
+Scope:
+
+- Update low-level `skillopt feedback github publish` and `sync` so runs that
+  belong to a train iteration resolve the expected review repo from the train
+  session policy.
+- If the user supplies `--repo` and it differs from `review.expected_repo`,
+  fail with a clear error instead of publishing.
+- If `--repo` is omitted for a train run, use `review.expected_repo`.
+- Preserve existing low-level behavior for non-train eval runs.
+- Add tests for both publish and sync to prevent review packets for preview
+  runs from being posted to the target repo by mistake.
+
+Acceptance criteria:
+
+- A train run with preview repo `owner/previews` cannot be published or synced
+  against `owner/product`.
+- The same train run publishes to `owner/previews` when `--repo` is omitted or
+  matches explicitly.
+- A text-only train run defaults to the target repo unless an explicit review
+  repo is configured.
+- Non-train low-level review runs keep the documented repo-resolution order.
+
+Tests/checks:
+
+- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptFeedbackGitHub|SkillOptTrain'`
+- `GOTOOLCHAIN=go1.26.2 go test ./internal/feedback`
+- `git diff --check`
+- `codex exec review --uncommitted`
+
+Suggested branch:
+
+- `task/skillopt-review-repo-guard`
+
+Suggested commit message:
+
+- `fix(skillopt): enforce train review repository`
+
+### Task 3: Add Vue/Vite Preview Bundle Contract
+
+Scope:
+
+- Add a machine-readable preview bundle contract for generated options when
+  `preview.renderer=vue-vite`.
+- Update the option-generation prompt so temporary agents must return a
+  structured Vue/Vite file bundle, not prose-only markdown, when previews are
+  required.
+- Keep the contract small and parseable. Suggested shape:
+
+  ```json
+  {
+    "renderer": "vue-vite",
+    "files": [
+      {"path": "package.json", "content": "..."},
+      {"path": "index.html", "content": "..."},
+      {"path": "src/main.js", "content": "..."},
+      {"path": "src/App.vue", "content": "..."}
+    ],
+    "build_command": "npm run build",
+    "dist_dir": "dist"
+  }
+  ```
+
+- Add parser/validator helpers that reject unsafe paths, missing required files,
+  empty content, unsupported renderer names, and bundles without a build output
+  contract.
+- Store parsed preview-bundle metadata with the generated option. Do not store
+  secrets, local absolute paths, dependency caches, or built outputs in the
+  Gitmoot database.
+- For `preview.mode=required`, generation should fail if any option does not
+  return a valid bundle.
+
+Acceptance criteria:
+
+- Vue/Vite preview-required generation prompts explicitly request the bundle
+  contract.
+- Valid bundles parse and attach to the generated option metadata.
+- Invalid or prose-only option output fails generation for required previews
+  instead of creating an unreviewable packet.
+- Text-only runs are not required to return preview bundles.
+
+Tests/checks:
+
+- `GOTOOLCHAIN=go1.26.2 go test ./internal/skillopt`
+- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrain.*Generate|SkillOptTrain.*Preview'`
+- `git diff --check`
+- `codex exec review --uncommitted`
+
+Suggested branch:
+
+- `task/skillopt-vue-preview-contract`
+
+Suggested commit message:
+
+- `feat(skillopt): add vue preview bundle contract`
+
+### Task 4: Build And Publish Vue/Vite Previews
+
+Scope:
+
+- Add a `vue-vite` renderer that writes each parsed bundle to a temp work
+  directory, installs dependencies using the repository's existing safe command
+  pattern, runs the configured build command, and verifies the configured
+  `dist_dir` exists with an `index.html`.
+- Add a `github-pages` publisher that writes built output into the configured
+  preview repo checkout using a deterministic route:
+
+  ```text
+  runs/{run_id}/{item_id}/{option_label}/
+  ```
+
+- Resolve the preview repo checkout from Gitmoot repo registration. If the
+  preview repo has no checkout path, fail with an actionable message such as:
+  `run gitmoot repo add owner/previews --path /path/to/checkout`.
+- Commit and push only the generated preview output in the preview repo. Do not
+  touch unrelated files. Do not commit temp work directories, logs, caches, or
+  `node_modules`.
+- Store the resulting public URL in each option's metadata as `preview_url`.
+- Preserve a route-template hook for future publishers, but do not overbuild
+  non-GitHub-Pages publishers in this task.
+
+Acceptance criteria:
+
+- For a generated Vue/Vite bundle, Gitmoot publishes a static page under the
+  preview repo and stores a usable `preview_url`.
+- Missing preview repo checkout, dirty preview repo, build failure, missing
+  `index.html`, or push failure stops with a clear error and does not publish a
+  misleading review packet.
+- Re-running after a successful publish is idempotent or updates the same route
+  deterministically.
+- The target product repo is not modified by preview publication.
+
+Tests/checks:
+
+- Unit tests for route construction, checkout validation, safe path handling,
+  and metadata updates.
+- Focused integration-style test with a fake preview repo and a tiny Vue/Vite
+  fixture where practical.
+- Manual smoke with a local temp Git repo if network/push is not appropriate in
+  tests.
+- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrain.*Preview|SkillOptTrain.*Continue'`
+- `GOTOOLCHAIN=go1.26.2 go test ./...`
+- `git diff --check`
+- `codex exec review --uncommitted`
+
+Suggested branch:
+
+- `task/skillopt-vue-preview-publish`
+
+Suggested commit message:
+
+- `feat(skillopt): publish vue train previews`
+
+### Task 5: Wire Preview Publishing Into Train Continue
+
+Scope:
+
+- Update `gitmoot skillopt train continue` so `options_generated` is no longer
+  a dead end.
+- For `preview.mode=required`, `continue` should:
+  1. render and publish missing previews,
+  2. verify every option has a `preview_url`,
+  3. publish the human review packet to `review.expected_repo`,
+  4. persist issue/PR metadata on the train iteration,
+  5. transition session and iteration to `review_published`.
+- For `preview.mode=none`, `continue` should publish the existing GitHub review
+  packet to the expected review repo and allow inline/text content.
+- For `preview.mode=optional`, use preview URLs when present, but allow inline
+  fallback when preview rendering is unavailable.
+- If `preview.mode=required`, disable inline fallback and fail before GitHub
+  publication when preview URLs are missing.
+- Add recovery metadata for in-progress preview publishing and GitHub packet
+  publication so interrupted runs can be retried without duplicating issues or
+  corrupting preview routes.
+
+Acceptance criteria:
+
+- A landing-page train run with `--preview-repo owner/previews` can progress:
+  `items_ready -> options_generated -> review_published`.
+- The review issue links to preview URLs instead of embedding large code
+  blocks.
+- The review issue is created in the expected preview/review repo without
+  manually passing `--repo`.
+- Interrupted runs can be retried without stale resource locks or duplicate
+  issue creation.
+- Text-only runs still publish review packets without preview URLs.
+
+Tests/checks:
+
+- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrain.*Continue|SkillOptFeedbackGitHub'`
+- `GOTOOLCHAIN=go1.26.2 go test ./internal/feedback`
+- `GOTOOLCHAIN=go1.26.2 go test ./...`
+- `scripts/skillopt-train-smoke.sh`
+- `git diff --check`
+- `codex exec review --uncommitted`
+
+Suggested branch:
+
+- `task/skillopt-train-preview-continue`
+
+Suggested commit message:
+
+- `feat(skillopt): publish train review previews`
+
+### Task 6: Update Docs, Skill References, And Smoke Coverage
+
+Scope:
+
+- Update docs and skill references to explain:
+  - preview modes: `none`, `optional`, `required`
+  - currently implemented renderer/publisher pairs: `none/none` and
+    `vue-vite/github-pages`
+  - required preview repo registration/checkouts
+  - review-repo enforcement
+  - why required previews block inline fallback
+  - the landing-page training command sequence
+- Update `scripts/skillopt-train-smoke.sh` or add a focused smoke script so the
+  basic flow covers expected review repo enforcement and required-preview
+  blocking.
+- Add a documented manual smoke for a real `jerryfane/gitmoot-previews` style
+  repo:
+
+  ```sh
+  gitmoot repo add owner/previews --path /path/to/previews
+  gitmoot skillopt train start --preview-repo owner/previews ...
+  gitmoot skillopt train continue --session landing-page-train
+  gitmoot skillopt train continue --session landing-page-train
+  ```
+
+- Document that LaTeX/PDF and other preview types are intentionally future
+  adapters, not part of this goal.
+
+Acceptance criteria:
+
+- A new user can understand when previews are required and how to configure the
+  preview repo.
+- Docs no longer imply `preview_repo` alone publishes previews.
+- The smoke test catches the wrong-repo class of bug.
+- The smoke test catches required-preview runs that would otherwise publish
+  inline code blocks.
+
+Tests/checks:
+
+- `scripts/skillopt-train-smoke.sh`
+- `GOTOOLCHAIN=go1.26.2 go test ./...`
+- `(cd website && npm run build)`
+- `git diff --check`
+- `codex exec review --uncommitted`
+
+Suggested branch:
+
+- `task/skillopt-preview-docs-smoke`
+
+Suggested commit message:
+
+- `docs(skillopt): document train preview publishing`

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -106,7 +106,7 @@ func runSkillOptTrain(args []string, stdout, stderr io.Writer) int {
 
 func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
+	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--preview-mode none|optional|required] [--preview-renderer none|vue-vite] [--preview-publisher none|github-pages] [--preview-route-template template] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
@@ -121,6 +121,10 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 	sessionID := fs.String("session", "", "train session id")
 	workspaceRepoFlag := fs.String("workspace-repo", "", "workspace repository in owner/repo form")
 	previewRepoFlag := fs.String("preview-repo", "", "preview repository in owner/repo form")
+	previewMode := fs.String("preview-mode", "", "preview mode: none, optional, or required")
+	previewRenderer := fs.String("preview-renderer", "", "preview renderer: none or vue-vite")
+	previewPublisher := fs.String("preview-publisher", "", "preview publisher: none or github-pages")
+	previewRouteTemplate := fs.String("preview-route-template", "", "preview route template for published options")
 	requestText := fs.String("request", "", "human training request")
 	requestFile := fs.String("request-file", "", "file containing the human training request")
 	taskKind := fs.String("task-kind", "custom", "task kind: correctness, ux, design, writing, data, or custom")
@@ -166,6 +170,11 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "skillopt train start: %v\n", err)
 		return 2
 	}
+	policy, err := skillopt.BuildTrainPreviewPolicy(repo.FullName(), previewRepo, *previewMode, *previewRenderer, *previewPublisher, *previewRouteTemplate)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt train start: %v\n", err)
+		return 2
+	}
 	normalizedTaskKind, err := normalizeSkillOptTrainTaskKind(*taskKind)
 	if err != nil {
 		fmt.Fprintf(stderr, "skillopt train start: %v\n", err)
@@ -200,7 +209,7 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	itemWarnings = append(itemWarnings, detectSkillOptTrainItemWarnings(items)...)
-	itemWarnings = append(itemWarnings, detectSkillOptTrainPreviewWarnings(previewRepo)...)
+	itemWarnings = append(itemWarnings, detectSkillOptTrainPreviewWarnings(policy)...)
 	var plan skillOptTrainStartPlan
 	openStore := withStore
 	if *dryRun || !*yes {
@@ -211,7 +220,7 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return err
 		}
-		plan = buildSkillOptTrainStartPlan(template, repo.FullName(), workspaceRepo, previewRepo, strings.TrimSpace(*sessionID), request, normalizedTaskKind, normalizedMode, normalizedExploration, effectiveOptionsCount, normalizedGate, items, itemWarnings)
+		plan = buildSkillOptTrainStartPlan(template, repo.FullName(), workspaceRepo, policy, strings.TrimSpace(*sessionID), request, normalizedTaskKind, normalizedMode, normalizedExploration, effectiveOptionsCount, normalizedGate, items, itemWarnings)
 		if *dryRun {
 			return nil
 		}
@@ -270,7 +279,7 @@ type skillOptTrainStartPlan struct {
 	Summary   skillopt.TrainStatusSummary
 }
 
-func buildSkillOptTrainStartPlan(template db.AgentTemplate, repo string, workspaceRepo string, previewRepo string, sessionID string, request string, taskKind string, mode string, explorationLevel string, optionsCount int, preferredGate string, itemPlans []skillOptTrainItemPlan, warnings []string) skillOptTrainStartPlan {
+func buildSkillOptTrainStartPlan(template db.AgentTemplate, repo string, workspaceRepo string, previewPolicy skillopt.TrainPreviewPolicy, sessionID string, request string, taskKind string, mode string, explorationLevel string, optionsCount int, preferredGate string, itemPlans []skillOptTrainItemPlan, warnings []string) skillOptTrainStartPlan {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
 		sessionID = generatedSkillOptTrainSessionID(template.ID)
@@ -279,14 +288,14 @@ func buildSkillOptTrainStartPlan(template db.AgentTemplate, repo string, workspa
 	if workspaceRepo != "" {
 		state = skillopt.TrainStateItemsReady
 	}
-	metadata := skillOptTrainStartMetadata(request, mode, explorationLevel, optionsCount, preferredGate, itemPlans, warnings)
+	metadata := skillOptTrainStartMetadata(request, mode, explorationLevel, optionsCount, preferredGate, itemPlans, warnings, previewPolicy)
 	session := db.SkillOptTrainSession{
 		ID:                sessionID,
 		TemplateID:        template.ID,
 		TemplateVersionID: template.VersionID,
 		TargetRepo:        repo,
 		WorkspaceRepo:     workspaceRepo,
-		PreviewRepo:       previewRepo,
+		PreviewRepo:       previewPolicy.Repo,
 		RequestSummary:    firstLine(request),
 		TaskKind:          taskKind,
 		State:             state,
@@ -333,6 +342,11 @@ func printSkillOptTrainStartPlan(stdout io.Writer, plan skillOptTrainStartPlan) 
 	writeLine(stdout, "repo: %s", plan.Session.TargetRepo)
 	writeLine(stdout, "workspace_repo: %s", emptyText(plan.Session.WorkspaceRepo))
 	writeLine(stdout, "preview_repo: %s", emptyText(plan.Session.PreviewRepo))
+	writeLine(stdout, "preview_mode: %s", plan.Summary.PreviewPolicy.Mode)
+	writeLine(stdout, "preview_renderer: %s", plan.Summary.PreviewPolicy.Renderer)
+	writeLine(stdout, "preview_publisher: %s", plan.Summary.PreviewPolicy.Publisher)
+	writeLine(stdout, "preview_route_template: %s", emptyText(plan.Summary.PreviewPolicy.RouteTemplate))
+	writeLine(stdout, "expected_review_repo: %s", emptyText(plan.Summary.PreviewPolicy.ExpectedReviewRepo))
 	writeLine(stdout, "task_kind: %s", plan.Session.TaskKind)
 	writeLine(stdout, "request_summary: %s", plan.Session.RequestSummary)
 	writeLine(stdout, "iteration: %s", plan.Iteration.ID)
@@ -2522,6 +2536,12 @@ func loadSkillOptTrainStatusCounts(ctx context.Context, store *db.Store, runID s
 func printSkillOptTrainStatus(stdout io.Writer, summary skillopt.TrainStatusSummary, counts skillopt.TrainStatusCounts) {
 	writeLine(stdout, "session: %s", summary.SessionID)
 	writeLine(stdout, "iteration: %s", emptyText(summary.IterationID))
+	writeLine(stdout, "preview_mode: %s", summary.PreviewPolicy.Mode)
+	writeLine(stdout, "preview_renderer: %s", summary.PreviewPolicy.Renderer)
+	writeLine(stdout, "preview_publisher: %s", summary.PreviewPolicy.Publisher)
+	writeLine(stdout, "preview_repo: %s", emptyText(summary.PreviewPolicy.Repo))
+	writeLine(stdout, "preview_route_template: %s", emptyText(summary.PreviewPolicy.RouteTemplate))
+	writeLine(stdout, "expected_review_repo: %s", emptyText(summary.PreviewPolicy.ExpectedReviewRepo))
 	writeLine(stdout, "current_phase: %s", summary.CurrentPhase)
 	writeLine(stdout, "completed_steps: %s", strings.Join(summary.CompletedSteps, ","))
 	writeLine(stdout, "blocked_step: %s", emptyText(summary.BlockedStep))
@@ -2646,8 +2666,8 @@ func detectSkillOptTrainItemWarnings(items []skillOptTrainItemPlan) []string {
 	return warnings
 }
 
-func detectSkillOptTrainPreviewWarnings(previewRepo string) []string {
-	if strings.TrimSpace(previewRepo) == "" {
+func detectSkillOptTrainPreviewWarnings(policy skillopt.TrainPreviewPolicy) []string {
+	if policy.Publisher != skillopt.TrainPreviewPublisherGitHubPages || strings.TrimSpace(policy.Repo) == "" {
 		return nil
 	}
 	return []string{"preview repo must be public or GitHub Pages-enabled before clickable demos can be published"}
@@ -2806,9 +2826,10 @@ func generatedSkillOptTrainSessionID(templateID string) string {
 	return "train-" + strings.Trim(b.String(), "-_") + "-" + now.Format("20060102-150405") + fmt.Sprintf("-%09d", now.Nanosecond())
 }
 
-func skillOptTrainStartMetadata(request string, mode string, explorationLevel string, optionsCount int, preferredGate string, items []skillOptTrainItemPlan, warnings []string) string {
+func skillOptTrainStartMetadata(request string, mode string, explorationLevel string, optionsCount int, preferredGate string, items []skillOptTrainItemPlan, warnings []string, previewPolicy skillopt.TrainPreviewPolicy) string {
 	lines := strings.Count(request, "\n") + 1
 	words := len(strings.Fields(request))
+	previewMetadata, reviewMetadata := previewPolicy.Metadata()
 	metadata := map[string]any{
 		"request":           request,
 		"request_lines":     lines,
@@ -2822,7 +2843,9 @@ func skillOptTrainStartMetadata(request string, mode string, explorationLevel st
 		"evaluation": map[string]any{
 			"preferred_gate": preferredGate,
 		},
-		"source": "gitmoot skillopt train start",
+		"preview": previewMetadata,
+		"review":  reviewMetadata,
+		"source":  "gitmoot skillopt train start",
 	}
 	encoded, err := json.Marshal(metadata)
 	if err != nil {
@@ -4660,6 +4683,11 @@ func runSkillOptFeedbackGitHubSync(args []string, stdout, stderr io.Writer) int 
 func resolveSkillOptFeedbackRepo(ctx context.Context, paths config.Paths, store *db.Store, run db.EvalRun, repoFlag string) (github.Repository, error) {
 	if strings.TrimSpace(repoFlag) != "" {
 		return daemon.ParseRepository(repoFlag)
+	}
+	if expectedRepo := skillOptMetadataString(run.MetadataJSON, "review", "expected_repo"); expectedRepo != "" {
+		if repo, err := daemon.ParseRepository(expectedRepo); err == nil {
+			return repo, nil
+		}
 	}
 	if strings.TrimSpace(run.TargetRepo) != "" {
 		if repo, err := daemon.ParseRepository(run.TargetRepo); err == nil {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -459,6 +459,17 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	if !strings.Contains(stdout.String(), "dry_run: true") || !strings.Contains(stdout.String(), "template_version: "+installed.VersionID) {
 		t.Fatalf("dry-run stdout = %q", stdout.String())
 	}
+	for _, want := range []string{
+		"preview_mode: required",
+		"preview_renderer: vue-vite",
+		"preview_publisher: github-pages",
+		"preview_route_template: runs/{run_id}/{item_id}/{option_label}/",
+		"expected_review_repo: owner/previews",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("dry-run stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
 	store, err = db.Open(paths.Database)
 	if err != nil {
 		t.Fatalf("Open after dry-run returned error: %v", err)
@@ -487,6 +498,26 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "--options must be zero or at least 2") {
 		t.Fatalf("one-option stderr = %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--request", "Train landing page plans.",
+		"--items-file", itemsPath,
+		"--preview-mode", "required",
+		"--preview-renderer", "none",
+		"--yes",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("train start with invalid preview policy exit code = %d, want 2; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "preview renderer is required") {
+		t.Fatalf("invalid preview policy stderr = %q", stderr.String())
 	}
 
 	stdout.Reset()
@@ -530,6 +561,9 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	if !strings.Contains(stdout.String(), "created train session landing-train") || !strings.Contains(stdout.String(), "preferred_gate: soft") || !strings.Contains(stdout.String(), "items: 2") || !strings.Contains(stdout.String(), "warning: preview repo must be public or GitHub Pages-enabled") {
 		t.Fatalf("train start stdout = %q", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "expected_review_repo: owner/previews") {
+		t.Fatalf("train start stdout missing expected review repo: %q", stdout.String())
+	}
 	store, err = db.Open(paths.Database)
 	if err != nil {
 		t.Fatalf("Open after start returned error: %v", err)
@@ -540,6 +574,10 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	}
 	if session.TemplateVersionID != installed.VersionID || session.WorkspaceRepo != "owner/workspace" || session.PreviewRepo != "owner/previews" || session.TaskKind != "design" {
 		t.Fatalf("session = %+v", session)
+	}
+	policy := skillopt.ResolveTrainPreviewPolicy(session)
+	if policy.Mode != skillopt.TrainPreviewModeRequired || policy.Renderer != skillopt.TrainPreviewRendererVueVite || policy.Publisher != skillopt.TrainPreviewPublisherGitHubPages || policy.ExpectedReviewRepo != "owner/previews" {
+		t.Fatalf("preview policy = %+v metadata=%s", policy, session.MetadataJSON)
 	}
 	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
 	if err != nil {
@@ -557,6 +595,16 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	}
 	if !strings.Contains(run.MetadataJSON, "preview repo must be public or GitHub Pages-enabled") {
 		t.Fatalf("eval run metadata did not include preview warning: %s", run.MetadataJSON)
+	}
+	if skillOptMetadataString(run.MetadataJSON, "review", "expected_repo") != "owner/previews" {
+		t.Fatalf("eval run metadata missing expected review repo: %s", run.MetadataJSON)
+	}
+	feedbackRepo, err := resolveSkillOptFeedbackRepo(context.Background(), paths, store, run, "")
+	if err != nil {
+		t.Fatalf("resolveSkillOptFeedbackRepo returned error: %v", err)
+	}
+	if feedbackRepo.FullName() != "owner/previews" {
+		t.Fatalf("feedback repo = %s, want owner/previews", feedbackRepo.FullName())
 	}
 	items, err := store.ListEvalReviewItems(context.Background(), "landing-train-review-001")
 	if err != nil {
@@ -600,6 +648,28 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	}
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close after duplicate start returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "status",
+		"--home", home,
+		"--session", "landing-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train status exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"preview_mode: required",
+		"preview_renderer: vue-vite",
+		"preview_publisher: github-pages",
+		"preview_repo: owner/previews",
+		"expected_review_repo: owner/previews",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train status stdout missing %q:\n%s", want, stdout.String())
+		}
 	}
 
 	if err := config.Initialize(paths); err != nil {
@@ -5386,7 +5456,11 @@ func seedSkillOptTrainFeedbackSynced(t *testing.T) (string, string) {
 			t.Fatalf("UpsertEvalArtifact returned error: %v", err)
 		}
 	}
-	metadata := skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil)
+	previewPolicy, err := skillopt.BuildTrainPreviewPolicy("owner/product", "", "", "", "", "")
+	if err != nil {
+		t.Fatalf("BuildTrainPreviewPolicy returned error: %v", err)
+	}
+	metadata := skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil, previewPolicy)
 	session := db.SkillOptTrainSession{
 		ID:                "optimizer-train",
 		TemplateID:        "planner",

--- a/internal/skillopt/train.go
+++ b/internal/skillopt/train.go
@@ -1,6 +1,7 @@
 package skillopt
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -24,11 +25,34 @@ const (
 	TrainStateRunAbandoned             = "run_abandoned"
 )
 
+const (
+	TrainPreviewModeNone     = "none"
+	TrainPreviewModeOptional = "optional"
+	TrainPreviewModeRequired = "required"
+
+	TrainPreviewRendererNone    = "none"
+	TrainPreviewRendererVueVite = "vue-vite"
+
+	TrainPreviewPublisherNone        = "none"
+	TrainPreviewPublisherGitHubPages = "github-pages"
+
+	DefaultTrainPreviewRouteTemplate = "runs/{run_id}/{item_id}/{option_label}/"
+)
+
 type TrainStatusCounts struct {
 	ReviewItems          int
 	FeedbackEvents       int
 	RankedFeedbackEvents int
 	PairwisePreferences  int
+}
+
+type TrainPreviewPolicy struct {
+	Mode               string
+	Renderer           string
+	Publisher          string
+	Repo               string
+	RouteTemplate      string
+	ExpectedReviewRepo string
 }
 
 type TrainStatusSummary struct {
@@ -42,6 +66,7 @@ type TrainStatusSummary struct {
 	PullRequestURL   string
 	CandidateVersion string
 	FeedbackCount    int
+	PreviewPolicy    TrainPreviewPolicy
 }
 
 var orderedTrainStates = []string{
@@ -136,6 +161,7 @@ func BuildTrainStatusSummary(session db.SkillOptTrainSession, iteration *db.Skil
 		SessionID:     strings.TrimSpace(session.ID),
 		CurrentPhase:  NormalizeTrainState(session.State),
 		FeedbackCount: counts.FeedbackEvents + counts.RankedFeedbackEvents,
+		PreviewPolicy: ResolveTrainPreviewPolicy(session),
 	}
 	if summary.CurrentPhase == "" {
 		summary.CurrentPhase = TrainStateRequestConfirmed
@@ -156,6 +182,172 @@ func BuildTrainStatusSummary(session db.SkillOptTrainSession, iteration *db.Skil
 	summary.CompletedSteps = completedTrainSteps(summary.CurrentPhase)
 	summary.BlockedStep, summary.NextAction = trainBlockedStepAndAction(summary.CurrentPhase)
 	return summary
+}
+
+func BuildTrainPreviewPolicy(targetRepo string, previewRepo string, mode string, renderer string, publisher string, routeTemplate string) (TrainPreviewPolicy, error) {
+	policy := TrainPreviewPolicy{
+		Mode:          strings.TrimSpace(strings.ToLower(mode)),
+		Renderer:      strings.TrimSpace(strings.ToLower(renderer)),
+		Publisher:     strings.TrimSpace(strings.ToLower(publisher)),
+		Repo:          strings.TrimSpace(previewRepo),
+		RouteTemplate: strings.TrimSpace(routeTemplate),
+	}
+	targetRepo = strings.TrimSpace(targetRepo)
+	if policy.Mode == "" {
+		if policy.Repo != "" || policy.Renderer != "" || policy.Publisher != "" || policy.RouteTemplate != "" {
+			policy.Mode = TrainPreviewModeRequired
+		} else {
+			policy.Mode = TrainPreviewModeNone
+		}
+	}
+	if policy.Renderer == "" {
+		if policy.Mode == TrainPreviewModeNone || (policy.Mode == TrainPreviewModeOptional && policy.Repo == "") {
+			policy.Renderer = TrainPreviewRendererNone
+		} else {
+			policy.Renderer = TrainPreviewRendererVueVite
+		}
+	}
+	if policy.Publisher == "" {
+		if policy.Mode == TrainPreviewModeNone || (policy.Mode == TrainPreviewModeOptional && policy.Repo == "") {
+			policy.Publisher = TrainPreviewPublisherNone
+		} else {
+			policy.Publisher = TrainPreviewPublisherGitHubPages
+		}
+	}
+	if policy.RouteTemplate == "" && policy.Publisher == TrainPreviewPublisherGitHubPages {
+		policy.RouteTemplate = DefaultTrainPreviewRouteTemplate
+	}
+	if err := policy.Validate(); err != nil {
+		return TrainPreviewPolicy{}, err
+	}
+	if policy.Mode == TrainPreviewModeNone || policy.Repo == "" {
+		policy.ExpectedReviewRepo = targetRepo
+	} else {
+		policy.ExpectedReviewRepo = policy.Repo
+	}
+	return policy, nil
+}
+
+func ResolveTrainPreviewPolicy(session db.SkillOptTrainSession) TrainPreviewPolicy {
+	targetRepo := strings.TrimSpace(session.TargetRepo)
+	metadata := decodedTrainMetadata(session.MetadataJSON)
+	preview := decodedTrainMetadataValue(metadata["preview"])
+	review := decodedTrainMetadataValue(metadata["review"])
+	policy := TrainPreviewPolicy{
+		Mode:               strings.ToLower(metadataString(preview, "mode")),
+		Renderer:           strings.ToLower(metadataString(preview, "renderer")),
+		Publisher:          strings.ToLower(metadataString(preview, "publisher")),
+		Repo:               metadataString(preview, "repo"),
+		RouteTemplate:      metadataString(preview, "route_template"),
+		ExpectedReviewRepo: metadataString(review, "expected_repo"),
+	}
+	if policy.Mode == "" {
+		policy.Mode = TrainPreviewModeNone
+	}
+	if policy.Renderer == "" {
+		policy.Renderer = TrainPreviewRendererNone
+	}
+	if policy.Publisher == "" {
+		policy.Publisher = TrainPreviewPublisherNone
+	}
+	if policy.ExpectedReviewRepo == "" {
+		if policy.Mode == TrainPreviewModeNone || policy.Repo == "" {
+			policy.ExpectedReviewRepo = targetRepo
+		} else {
+			policy.ExpectedReviewRepo = policy.Repo
+		}
+	}
+	return policy
+}
+
+func (p TrainPreviewPolicy) Validate() error {
+	switch p.Mode {
+	case TrainPreviewModeNone, TrainPreviewModeOptional, TrainPreviewModeRequired:
+	default:
+		return fmt.Errorf("preview mode %q is not supported", p.Mode)
+	}
+	switch p.Renderer {
+	case TrainPreviewRendererNone, TrainPreviewRendererVueVite:
+	default:
+		return fmt.Errorf("preview renderer %q is not supported", p.Renderer)
+	}
+	switch p.Publisher {
+	case TrainPreviewPublisherNone, TrainPreviewPublisherGitHubPages:
+	default:
+		return fmt.Errorf("preview publisher %q is not supported", p.Publisher)
+	}
+	if strings.TrimSpace(p.RouteTemplate) != "" && p.Publisher != TrainPreviewPublisherGitHubPages {
+		return fmt.Errorf("preview route template requires preview publisher %q", TrainPreviewPublisherGitHubPages)
+	}
+	if p.Mode == TrainPreviewModeNone {
+		if p.Renderer != TrainPreviewRendererNone {
+			return fmt.Errorf("preview renderer must be %q when preview mode is %q", TrainPreviewRendererNone, TrainPreviewModeNone)
+		}
+		if p.Publisher != TrainPreviewPublisherNone {
+			return fmt.Errorf("preview publisher must be %q when preview mode is %q", TrainPreviewPublisherNone, TrainPreviewModeNone)
+		}
+		return nil
+	}
+	if p.Mode == TrainPreviewModeRequired {
+		if p.Renderer == TrainPreviewRendererNone {
+			return errors.New("preview renderer is required when preview mode is required")
+		}
+		if p.Publisher == TrainPreviewPublisherNone {
+			return errors.New("preview publisher is required when preview mode is required")
+		}
+	}
+	if p.Publisher == TrainPreviewPublisherGitHubPages && strings.TrimSpace(p.Repo) == "" {
+		return errors.New("preview repo is required when preview publisher is github-pages")
+	}
+	return nil
+}
+
+func (p TrainPreviewPolicy) Metadata() (map[string]any, map[string]any) {
+	preview := map[string]any{
+		"mode":      p.Mode,
+		"renderer":  p.Renderer,
+		"publisher": p.Publisher,
+	}
+	if strings.TrimSpace(p.Repo) != "" {
+		preview["repo"] = strings.TrimSpace(p.Repo)
+	}
+	if strings.TrimSpace(p.RouteTemplate) != "" {
+		preview["route_template"] = strings.TrimSpace(p.RouteTemplate)
+	}
+	review := map[string]any{}
+	if strings.TrimSpace(p.ExpectedReviewRepo) != "" {
+		review["expected_repo"] = strings.TrimSpace(p.ExpectedReviewRepo)
+	}
+	return preview, review
+}
+
+func decodedTrainMetadata(value string) map[string]any {
+	var metadata map[string]any
+	if strings.TrimSpace(value) != "" {
+		_ = json.Unmarshal([]byte(value), &metadata)
+	}
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	return metadata
+}
+
+func decodedTrainMetadataValue(value any) map[string]any {
+	if object, ok := value.(map[string]any); ok {
+		return object
+	}
+	return map[string]any{}
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if metadata == nil {
+		return ""
+	}
+	value, ok := metadata[key]
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
 }
 
 func completedTrainSteps(state string) []string {

--- a/internal/skillopt/train_test.go
+++ b/internal/skillopt/train_test.go
@@ -120,3 +120,64 @@ func TestBuildTrainStatusSummaryForAbandonedIterationDoesNotCompleteAllSteps(t *
 		t.Fatalf("abandoned completed steps = %+v", summary.CompletedSteps)
 	}
 }
+
+func TestBuildTrainPreviewPolicyDefaultsForTextOnlyAndPreviewRepo(t *testing.T) {
+	textOnly, err := BuildTrainPreviewPolicy("owner/product", "", "", "", "", "")
+	if err != nil {
+		t.Fatalf("text-only BuildTrainPreviewPolicy returned error: %v", err)
+	}
+	if textOnly.Mode != TrainPreviewModeNone || textOnly.Renderer != TrainPreviewRendererNone || textOnly.Publisher != TrainPreviewPublisherNone || textOnly.ExpectedReviewRepo != "owner/product" {
+		t.Fatalf("text-only policy = %+v", textOnly)
+	}
+
+	withPreview, err := BuildTrainPreviewPolicy("owner/product", "owner/previews", "", "", "", "")
+	if err != nil {
+		t.Fatalf("preview BuildTrainPreviewPolicy returned error: %v", err)
+	}
+	if withPreview.Mode != TrainPreviewModeRequired || withPreview.Renderer != TrainPreviewRendererVueVite || withPreview.Publisher != TrainPreviewPublisherGitHubPages || withPreview.Repo != "owner/previews" || withPreview.ExpectedReviewRepo != "owner/previews" {
+		t.Fatalf("preview policy = %+v", withPreview)
+	}
+	if withPreview.RouteTemplate != DefaultTrainPreviewRouteTemplate {
+		t.Fatalf("preview route template = %q", withPreview.RouteTemplate)
+	}
+}
+
+func TestBuildTrainPreviewPolicyRejectsInvalidRequiredCombinations(t *testing.T) {
+	if _, err := BuildTrainPreviewPolicy("owner/product", "owner/previews", TrainPreviewModeRequired, TrainPreviewRendererNone, "", ""); err == nil || !strings.Contains(err.Error(), "renderer") {
+		t.Fatalf("required without renderer error = %v", err)
+	}
+	if _, err := BuildTrainPreviewPolicy("owner/product", "", TrainPreviewModeRequired, TrainPreviewRendererVueVite, TrainPreviewPublisherGitHubPages, ""); err == nil || !strings.Contains(err.Error(), "preview repo") {
+		t.Fatalf("required without repo error = %v", err)
+	}
+	if _, err := BuildTrainPreviewPolicy("owner/product", "", TrainPreviewModeNone, TrainPreviewRendererVueVite, TrainPreviewPublisherNone, ""); err == nil || !strings.Contains(err.Error(), "preview renderer") {
+		t.Fatalf("none with renderer error = %v", err)
+	}
+	if _, err := BuildTrainPreviewPolicy("owner/product", "", "", "", "", "custom/{run_id}/"); err == nil || !strings.Contains(err.Error(), "preview repo") {
+		t.Fatalf("route template without preview repo error = %v", err)
+	}
+	if _, err := BuildTrainPreviewPolicy("owner/product", "", TrainPreviewModeNone, "", "", "custom/{run_id}/"); err == nil || !strings.Contains(err.Error(), "route template") {
+		t.Fatalf("route template with disabled publisher error = %v", err)
+	}
+}
+
+func TestBuildTrainPreviewPolicyAllowsOptionalWithoutPublisher(t *testing.T) {
+	policy, err := BuildTrainPreviewPolicy("owner/product", "", TrainPreviewModeOptional, "", "", "")
+	if err != nil {
+		t.Fatalf("optional without publisher returned error: %v", err)
+	}
+	if policy.Mode != TrainPreviewModeOptional || policy.Renderer != TrainPreviewRendererNone || policy.Publisher != TrainPreviewPublisherNone || policy.ExpectedReviewRepo != "owner/product" {
+		t.Fatalf("optional policy = %+v", policy)
+	}
+}
+
+func TestResolveTrainPreviewPolicyTreatsLegacyPreviewRepoAsNone(t *testing.T) {
+	session := db.SkillOptTrainSession{
+		ID:          "legacy",
+		TargetRepo:  "owner/product",
+		PreviewRepo: "owner/previews",
+	}
+	policy := ResolveTrainPreviewPolicy(session)
+	if policy.Mode != TrainPreviewModeNone || policy.ExpectedReviewRepo != "owner/product" {
+		t.Fatalf("legacy policy = %+v", policy)
+	}
+}


### PR DESCRIPTION
WHAT
- Adds Task 1 of GOAL-SKILLOPT-VUE-PREVIEWS.md.
- Adds a composable SkillOpt train preview policy and expected review repo metadata.

WHY
- Landing-page train runs need to declare when Vue/Vite previews are required and where review packets should be published before the preview renderer/publisher work lands.
- Text-only train runs must continue to default to the target repo without preview requirements.

CHANGES
- Added preview policy fields for mode, renderer, publisher, repo, route template, and expected review repo.
- Added train start flags: --preview-mode, --preview-renderer, --preview-publisher, and --preview-route-template.
- Derived safe defaults for text-only runs and --preview-repo runs.
- Persisted preview/review policy metadata and surfaced it in train start and status output.
- Updated feedback repo resolution to prefer review.expected_repo when no explicit --repo is supplied.
- Added focused tests for defaults, invalid combinations, legacy sessions, status output, and expected review repo resolution.
- Added GOAL-SKILLOPT-VUE-PREVIEWS.md with the full task-by-task plan.

RESULTS
- GOTOOLCHAIN=go1.26.2 go test ./internal/skillopt
- GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrain.*Start|SkillOptTrain.*Status|SkillOptFeedbackGitHub'\n- GOTOOLCHAIN=go1.26.2 go test ./...\n- git diff --check\n\nFinal raw codex exec review --uncommitted output:\n\n```text\nNo discrete correctness issues were identified in the changed or untracked files. Focused tests could not be executed in this sandbox because the required Go 1.26 toolchain download is blocked.\nNo discrete correctness issues were identified in the changed or untracked files. Focused tests could not be executed in this sandbox because the required Go 1.26 toolchain download is blocked.\n```\n\nRISK\n- codex exec review could not run tests in its own sandbox because its local Go was 1.22.2 and toolchain download was blocked there. The required local checks passed in this workspace with GOTOOLCHAIN=go1.26.2.\n- Full review repo mismatch rejection for explicit wrong --repo remains Task 2; this task only records and defaults to expected_review_repo.