### PR TITLE
Enforce SkillOpt train review repository

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -4682,7 +4682,21 @@ func runSkillOptFeedbackGitHubSync(args []string, stdout, stderr io.Writer) int 
 
 func resolveSkillOptFeedbackRepo(ctx context.Context, paths config.Paths, store *db.Store, run db.EvalRun, repoFlag string) (github.Repository, error) {
 	if strings.TrimSpace(repoFlag) != "" {
-		return daemon.ParseRepository(repoFlag)
+		requested, err := daemon.ParseRepository(repoFlag)
+		if err != nil {
+			return github.Repository{}, err
+		}
+		if expected, ok, err := resolveSkillOptTrainFeedbackRepo(ctx, store, run); err != nil {
+			return github.Repository{}, err
+		} else if ok && expected.FullName() != "" && !strings.EqualFold(requested.FullName(), expected.FullName()) {
+			return github.Repository{}, fmt.Errorf("train run %s expects github feedback repo %s; got %s", run.ID, expected.FullName(), requested.FullName())
+		}
+		return requested, nil
+	}
+	if expected, ok, err := resolveSkillOptTrainFeedbackRepo(ctx, store, run); err != nil {
+		return github.Repository{}, err
+	} else if ok && expected.FullName() != "" {
+		return expected, nil
 	}
 	if expectedRepo := skillOptMetadataString(run.MetadataJSON, "review", "expected_repo"); expectedRepo != "" {
 		if repo, err := daemon.ParseRepository(expectedRepo); err == nil {
@@ -4716,6 +4730,30 @@ func resolveSkillOptFeedbackRepo(ctx context.Context, paths config.Paths, store 
 		return daemon.ParseRepository(defaultRepo)
 	}
 	return github.Repository{}, errors.New("skillopt feedback github requires --repo because no target repo, template source repo, or [feedback].repo default is configured")
+}
+
+func resolveSkillOptTrainFeedbackRepo(ctx context.Context, store *db.Store, run db.EvalRun) (github.Repository, bool, error) {
+	iteration, err := store.GetSkillOptTrainIterationByEvalRun(ctx, run.ID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return github.Repository{}, false, nil
+	}
+	if err != nil {
+		return github.Repository{}, true, err
+	}
+	session, err := store.GetSkillOptTrainSession(ctx, iteration.SessionID)
+	if err != nil {
+		return github.Repository{}, true, err
+	}
+	policy := skillopt.ResolveTrainPreviewPolicy(session)
+	expectedRepo := strings.TrimSpace(policy.ExpectedReviewRepo)
+	if expectedRepo == "" {
+		return github.Repository{}, true, nil
+	}
+	repo, err := daemon.ParseRepository(expectedRepo)
+	if err != nil {
+		return github.Repository{}, true, fmt.Errorf("train expected review repo: %w", err)
+	}
+	return repo, true, nil
 }
 
 func scoreText(score *float64) string {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -4135,6 +4135,183 @@ func TestSkillOptFeedbackGitHubCommands(t *testing.T) {
 	}
 }
 
+func TestSkillOptFeedbackGitHubCommandsEnforceTrainReviewRepo(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	previewPolicy, err := skillopt.BuildTrainPreviewPolicy("owner/product", "owner/previews", "", "", "", "")
+	if err != nil {
+		t.Fatalf("BuildTrainPreviewPolicy returned error: %v", err)
+	}
+	metadata := skillOptTrainStartMetadata("Train landing page reviews.", db.EvalRunModeExplore, db.ExplorationLevelHigh, 4, "soft", nil, nil, previewPolicy)
+	session := db.SkillOptTrainSession{
+		ID:           "preview-train",
+		TemplateID:   "planner",
+		TargetRepo:   "owner/product",
+		PreviewRepo:  "owner/previews",
+		TaskKind:     "design",
+		State:        skillopt.TrainStateItemsReady,
+		MetadataJSON: metadata,
+	}
+	iteration := db.SkillOptTrainIteration{
+		ID:               "preview-train-001",
+		SessionID:        session.ID,
+		EvalRunID:        "preview-train-review-001",
+		Mode:             db.EvalRunModeExplore,
+		ExplorationLevel: db.ExplorationLevelHigh,
+		State:            skillopt.TrainStateItemsReady,
+		MetadataJSON:     metadata,
+	}
+	run := db.EvalRun{
+		ID:               iteration.EvalRunID,
+		TemplateID:       "planner",
+		TargetRepo:       "owner/product",
+		State:            "review",
+		Mode:             db.EvalRunModeExplore,
+		ExplorationLevel: db.ExplorationLevelHigh,
+		OptionsCount:     4,
+		MetadataJSON:     metadata,
+	}
+	if err := store.UpsertSkillOptTrainSession(context.Background(), session); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSession returned error: %v", err)
+	}
+	if err := store.UpsertSkillOptTrainIteration(context.Background(), iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainIteration returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(context.Background(), run); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:  run.ID,
+		ItemID: "item-001",
+		Title:  "Landing page",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		content := []byte("option " + label)
+		blob, err := blobStore.Put(content)
+		if err != nil {
+			t.Fatalf("Put option %s returned error: %v", label, err)
+		}
+		artifactID := "train-option-" + label
+		if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{ID: artifactID, Hash: blob.Hash, MediaType: "text/markdown", SizeBytes: blob.Size, Driver: "text"}); err != nil {
+			t.Fatalf("UpsertEvalArtifact %s returned error: %v", label, err)
+		}
+		if err := store.UpsertEvalReviewOption(context.Background(), db.EvalReviewOption{RunID: run.ID, ItemID: "item-001", Label: label, ArtifactID: artifactID, Role: "option"}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	fake := &skillOptFakeGitHub{
+		comments: map[int64][]github.IssueComment{
+			8: {
+				{ID: 100, Body: "run_id: preview-train-review-001\nitem-001 ranking: C > A > D > B\n", URL: "https://github.com/owner/previews/issues/8#issuecomment-100", Author: "alice", CreatedAt: "2026-05-31T10:00:00Z"},
+			},
+		},
+	}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fake }
+	t.Cleanup(func() {
+		newSkillOptGitHubClient = oldClient
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "feedback", "github", "publish", "--home", home, "--run", "preview-train-review-001"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("github publish default repo exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if fake.createdIssue.Repo.FullName() != "owner/previews" {
+		t.Fatalf("created issue repo = %s, want owner/previews", fake.createdIssue.Repo.FullName())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "feedback", "github", "publish", "--home", home, "--run", "preview-train-review-001", "--repo", "Owner/Previews", "--pr", "9"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("github publish matching repo exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if len(fake.postedComments) != 1 || !strings.EqualFold(fake.postedComments[0].Repo.FullName(), "owner/previews") || fake.postedComments[0].IssueNumber != 9 {
+		t.Fatalf("posted comments = %+v, want owner/previews#9", fake.postedComments)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	fake.createdIssue = github.CreateIssueInput{}
+	code = Run([]string{"skillopt", "feedback", "github", "publish", "--home", home, "--run", "preview-train-review-001", "--repo", "owner/product"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("github publish wrong repo exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "expects github feedback repo owner/previews; got owner/product") {
+		t.Fatalf("github publish wrong repo stderr = %q", stderr.String())
+	}
+	if fake.createdIssue.Repo.FullName() != "" {
+		t.Fatalf("wrong repo publish created issue = %+v", fake.createdIssue)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "feedback", "github", "sync", "--home", home, "--run", "preview-train-review-001", "--issue", "8"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("github sync default repo exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if len(fake.listedComments) != 1 || fake.listedComments[0].Repo.FullName() != "owner/previews" {
+		t.Fatalf("listed comments = %+v, want owner/previews", fake.listedComments)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "feedback", "github", "sync", "--home", home, "--run", "preview-train-review-001", "--repo", "owner/product", "--issue", "8"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("github sync wrong repo exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "expects github feedback repo owner/previews; got owner/product") {
+		t.Fatalf("github sync wrong repo stderr = %q", stderr.String())
+	}
+}
+
+func TestSkillOptFeedbackRepoResolutionPreservesNonTrainExpectedRepoFallback(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	run := db.EvalRun{
+		ID:           "standalone-run",
+		TargetRepo:   "owner/product",
+		MetadataJSON: `{"review":{"expected_repo":"owner/previews"}}`,
+	}
+	repo, err := resolveSkillOptFeedbackRepo(context.Background(), paths, store, run, "")
+	if err != nil {
+		t.Fatalf("resolveSkillOptFeedbackRepo returned error: %v", err)
+	}
+	if repo.FullName() != "owner/previews" {
+		t.Fatalf("resolved repo = %s, want owner/previews", repo.FullName())
+	}
+	explicit, err := resolveSkillOptFeedbackRepo(context.Background(), paths, store, run, "owner/explicit")
+	if err != nil {
+		t.Fatalf("resolveSkillOptFeedbackRepo explicit returned error: %v", err)
+	}
+	if explicit.FullName() != "owner/explicit" {
+		t.Fatalf("explicit repo = %s, want owner/explicit", explicit.FullName())
+	}
+}
+
 func TestSkillOptReviewCreateAndStatus(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)
@@ -5370,6 +5547,7 @@ type skillOptFakeGitHub struct {
 
 	createdIssue       github.CreateIssueInput
 	postedComments     []skillOptPostedGitHubComment
+	listedComments     []skillOptListedGitHubComments
 	comments           map[int64][]github.IssueComment
 	createIssueErr     error
 	postCommentErr     error
@@ -5382,6 +5560,11 @@ type skillOptPostedGitHubComment struct {
 	Repo        github.Repository
 	IssueNumber int64
 	Body        string
+}
+
+type skillOptListedGitHubComments struct {
+	Repo        github.Repository
+	IssueNumber int64
 }
 
 func (f *skillOptFakeGitHub) CreateIssue(_ context.Context, input github.CreateIssueInput) (github.Issue, error) {
@@ -5408,7 +5591,8 @@ func (f *skillOptFakeGitHub) PostIssueComment(_ context.Context, repo github.Rep
 	return github.IssueComment{ID: int64(len(f.postedComments)), Body: body, URL: url}, nil
 }
 
-func (f *skillOptFakeGitHub) ListIssueComments(_ context.Context, _ github.Repository, issueNumber int64) ([]github.IssueComment, error) {
+func (f *skillOptFakeGitHub) ListIssueComments(_ context.Context, repo github.Repository, issueNumber int64) ([]github.IssueComment, error) {
+	f.listedComments = append(f.listedComments, skillOptListedGitHubComments{Repo: repo, IssueNumber: issueNumber})
 	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
 }
 


### PR DESCRIPTION
WHAT
- Adds Task 2 of GOAL-SKILLOPT-VUE-PREVIEWS.md.
- Enforces the expected GitHub feedback/review repository for train runs.

WHY
- Preview-backed train runs must not publish or sync human feedback against the target product repo by accident.
- Low-level feedback commands need to respect the train session review policy when they are operating on a train eval run.

CHANGES
- Made `resolveSkillOptFeedbackRepo` train-aware by resolving train iteration and session policy for eval runs that belong to train iterations.
- Rejects explicit `--repo` values that differ from the train run expected review repo, using case-insensitive GitHub repo matching.
- Defaults omitted `--repo` to the train policy expected review repo.
- Preserves non-train behavior, including existing `review.expected_repo` metadata fallback and explicit `--repo` precedence.
- Added publish and sync tests for default repo, matching explicit repo, wrong explicit repo, and non-train fallback behavior.

RESULTS
- GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptFeedbackGitHub|SkillOptTrain'\n- GOTOOLCHAIN=go1.26.2 go test ./internal/feedback\n- GOTOOLCHAIN=go1.26.2 go test ./...\n- git diff --check\n\nFinal raw codex exec review --uncommitted output:\n\n```text\nThe changes correctly enforce train review repository resolution while preserving non-train fallback behavior, and the focused and full Go test suites pass locally.\nThe changes correctly enforce train review repository resolution while preserving non-train fallback behavior, and the focused and full Go test suites pass locally.\n```\n\nRISK\n- The default review sandbox repeatedly hit an unrelated Unix socket permission failure in `TestAgentTemplateValidateRejectsNonRegularFile`, so the final review gate was rerun with Codex exec no-sandbox mode. The review then ran `GOTOOLCHAIN=go1.26.2 go test ./...` successfully.\n- Task 3+ preview bundle/render/publish work remains intentionally unimplemented.