### PR TITLE
fix(skillopt): canonicalize preview scaffolds

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -4168,7 +4168,7 @@ func buildSkillOptTrainGenerationPrompt(session db.SkillOptTrainSession, iterati
 		builder.WriteString("- Include build_command exactly \"npm run build\" and dist_dir \"dist\".\n")
 		builder.WriteString("- Include files with these required relative paths: package.json, index.html, src/main.js, src/App.vue.\n")
 		builder.WriteString("- package.json scripts must include only \"build\": \"vite build\". Do not include dependencies or devDependencies; Gitmoot supplies trusted build dependencies.\n")
-		builder.WriteString("- index.html and src/main.js must use the standard Vue mount scaffold exactly; Gitmoot overwrites them with trusted scaffold files before build.\n")
+		builder.WriteString("- index.html and src/main.js may use a simple Vue mount placeholder; Gitmoot canonicalizes and overwrites them with trusted scaffold files before build.\n")
 		builder.WriteString("- src/App.vue must be scriptless template/style Vue only. Do not include script blocks, imports, require, import.meta, @import, or CSS url().\n")
 		builder.WriteString("- Each file entry must have path and non-empty content. Use slash-separated relative paths only.\n")
 		builder.WriteString("- Do not include local absolute paths, path traversal, secrets, .env files, node_modules, dependency caches, dist, built outputs, vite.config.js, or files outside the required paths.\n")

--- a/internal/skillopt/preview_bundle.go
+++ b/internal/skillopt/preview_bundle.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"regexp"
 	"strings"
 )
 
@@ -16,6 +17,8 @@ const previewBundlePackageBuildScript = "vite build"
 const previewBundleDistDir = "dist"
 const previewBundleTrustedIndexHTML = `<div id="app"></div><script type="module" src="/src/main.js"></script>`
 const previewBundleTrustedMainJS = `import { createApp } from 'vue'; import App from './App.vue'; createApp(App).mount('#app');`
+
+var previewBundleHrefAttributePattern = regexp.MustCompile(`(?i)(?:^|[\s<])(?:xlink:)?href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))`)
 
 type PreviewBundle struct {
 	Renderer     string              `json:"renderer"`
@@ -125,11 +128,11 @@ func validatePreviewBundle(bundle PreviewBundle) (PreviewBundle, error) {
 				return PreviewBundle{}, err
 			}
 		}
-		if normalizedPath == "index.html" && strings.TrimSpace(file.Content) != previewBundleTrustedIndexHTML {
-			return PreviewBundle{}, errors.New("preview bundle index.html must use the trusted Gitmoot Vue mount scaffold")
+		if normalizedPath == "index.html" {
+			bundle.Files[index].Content = previewBundleTrustedIndexHTML
 		}
-		if normalizedPath == "src/main.js" && strings.TrimSpace(file.Content) != previewBundleTrustedMainJS {
-			return PreviewBundle{}, errors.New("preview bundle src/main.js must use the trusted Gitmoot Vue bootstrap")
+		if normalizedPath == "src/main.js" {
+			bundle.Files[index].Content = previewBundleTrustedMainJS
 		}
 		if normalizedPath == "src/App.vue" {
 			if err := validatePreviewBundleAppVue(file.Content); err != nil {
@@ -204,11 +207,23 @@ func validatePreviewBundleAppVue(content string) error {
 	lower := strings.ToLower(content)
 	for _, blocked := range []string{
 		"<script", "</script", "import ", "require(", "import.meta", "@import", "url(",
-		"<iframe", "<object", "<embed", "<link", " src=", " srcset=", " href=", " xlink:href=",
+		"<iframe", "<object", "<embed", "<link", " src=", " srcset=",
 		"http://", "https://", "javascript:", "data:",
 	} {
 		if strings.Contains(lower, blocked) {
 			return fmt.Errorf("preview bundle src/App.vue must not include executable or external-loading construct %q", blocked)
+		}
+	}
+	for _, match := range previewBundleHrefAttributePattern.FindAllStringSubmatch(content, -1) {
+		value := ""
+		for _, group := range match[1:] {
+			if group != "" {
+				value = strings.TrimSpace(group)
+				break
+			}
+		}
+		if !strings.HasPrefix(value, "#") {
+			return errors.New("preview bundle src/App.vue href attributes must point to local anchors")
 		}
 	}
 	if !strings.Contains(lower, "<template") || !strings.Contains(lower, "</template>") {

--- a/internal/skillopt/preview_bundle_test.go
+++ b/internal/skillopt/preview_bundle_test.go
@@ -20,6 +20,47 @@ func TestParsePreviewBundleAcceptsValidVueViteBundle(t *testing.T) {
 	}
 }
 
+func TestParsePreviewBundleCanonicalizesTrustedScaffoldFiles(t *testing.T) {
+	source := validPreviewBundle(t)
+	source.Files[1].Content = `<!doctype html><html><body><div id="app"></div><script type="module" src="/src/main.js"></script></body></html>`
+	source.Files[2].Content = `
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')
+`
+	encoded, err := json.Marshal(source)
+	if err != nil {
+		t.Fatalf("Marshal mutated bundle returned error: %v", err)
+	}
+	bundle, err := ParsePreviewBundle(encoded)
+	if err != nil {
+		t.Fatalf("ParsePreviewBundle returned error: %v", err)
+	}
+	files := map[string]string{}
+	for _, file := range bundle.Files {
+		files[file.Path] = file.Content
+	}
+	if files["index.html"] != previewBundleTrustedIndexHTML {
+		t.Fatalf("index.html was not canonicalized: %q", files["index.html"])
+	}
+	if files["src/main.js"] != previewBundleTrustedMainJS {
+		t.Fatalf("src/main.js was not canonicalized: %q", files["src/main.js"])
+	}
+}
+
+func TestParsePreviewBundleAllowsLocalAppVueAnchors(t *testing.T) {
+	source := validPreviewBundle(t)
+	source.Files[3].Content = `<template><main><a href="#details">Details</a></main></template>`
+	encoded, err := json.Marshal(source)
+	if err != nil {
+		t.Fatalf("Marshal mutated bundle returned error: %v", err)
+	}
+	if _, err := ParsePreviewBundle(encoded); err != nil {
+		t.Fatalf("ParsePreviewBundle returned error: %v", err)
+	}
+}
+
 func TestParsePreviewBundleRejectsInvalidBundles(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -94,6 +135,20 @@ func TestParsePreviewBundleRejectsInvalidBundles(t *testing.T) {
 				bundle.Files[3].Content = `<template><main><a href="javascript:alert(1)">Open</a></main></template>`
 			},
 			want: "must not include",
+		},
+		{
+			name: "app vue protocol relative svg href",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[3].Content = `<template><main><svg><image href="//attacker.example/pixel.svg" /></svg></main></template>`
+			},
+			want: "href attributes must point to local anchors",
+		},
+		{
+			name: "app vue non-anchor href",
+			mutate: func(bundle *PreviewBundle) {
+				bundle.Files[3].Content = `<template><main><a href="/external">Open</a></main></template>`
+			},
+			want: "href attributes must point to local anchors",
 		},
 		{
 			name: "empty content",


### PR DESCRIPTION
WHAT
Relax the Vue preview bundle validator around generated scaffold files while preserving the trusted runtime scaffold and external-resource safety checks.

WHY
A live `skillopt train continue` run failed because generated `index.html` did not match Gitmoot's scaffold byte-for-byte, even though Gitmoot overwrites `index.html` and `src/main.js` with trusted files before building. A second live run showed normal local anchor links in `App.vue` were also rejected by the previous blanket `href=` block.

CHANGES
- Canonicalize `index.html` and `src/main.js` to Gitmoot's trusted scaffold during preview bundle parsing.
- Update the generation prompt to tell agents that placeholders are accepted and canonicalized.
- Allow local anchor hrefs in `App.vue`.
- Keep external/protocol hrefs blocked by requiring `href` and `xlink:href` values to start with `#`.
- Add regression tests for scaffold canonicalization, local anchors, protocol-relative SVG hrefs, and non-anchor hrefs.

RESULTS
- `git diff --check`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/skillopt`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrainContinueGeneratesRequiredVuePreviewBundles|SkillOptTrainContinueFailsRequiredVuePreviewForProseOutput|TrustedVueViteScaffold'`
- `codex exec review --uncommitted`

Final raw `codex exec review --uncommitted` output:

```text
No actionable correctness issues were found in the current staged, unstaged, or untracked changes. Focused tests could not be run because the Go toolchain download attempted to write outside the sandbox.
```

RISK
Focused tests passed locally. The review sandbox could not run Go tests, but it found no correctness issues after inspecting the diff. The unrelated untracked `GOAL-SKILLOPT-TRAIN-ORCHESTRATION.md` file was left untouched.
