### PR TITLE
skillopt: add evaluator failure packet contracts

### DIFF
--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -49,6 +49,69 @@ type ArtifactRef struct {
 	Driver    string `json:"driver"`
 }
 
+type EvaluatorProfile struct {
+	ProfileID        string                 `json:"profile_id,omitempty"`
+	TaskKind         string                 `json:"task_kind,omitempty"`
+	ArtifactContract string                 `json:"artifact_contract,omitempty"`
+	PreviewAdapter   string                 `json:"preview_adapter,omitempty"`
+	Checks           []EvaluatorCheckConfig `json:"checks,omitempty"`
+	Judge            *EvaluatorJudgeConfig  `json:"judge,omitempty"`
+	Metadata         json.RawMessage        `json:"metadata,omitempty"`
+}
+
+type EvaluatorCheckConfig struct {
+	ID       string          `json:"id,omitempty"`
+	Type     string          `json:"type,omitempty"`
+	When     string          `json:"when,omitempty"`
+	Required bool            `json:"required,omitempty"`
+	Config   json.RawMessage `json:"config,omitempty"`
+}
+
+type EvaluatorJudgeConfig struct {
+	Type   string          `json:"type,omitempty"`
+	When   string          `json:"when,omitempty"`
+	Model  string          `json:"model,omitempty"`
+	Config json.RawMessage `json:"config,omitempty"`
+}
+
+type EvaluatorStageStatus struct {
+	Stage      string          `json:"stage,omitempty"`
+	Status     string          `json:"status,omitempty"`
+	StartedAt  string          `json:"started_at,omitempty"`
+	FinishedAt string          `json:"finished_at,omitempty"`
+	DurationMS int64           `json:"duration_ms,omitempty"`
+	Details    json.RawMessage `json:"details,omitempty"`
+}
+
+type EvaluatorCheckResult struct {
+	Check    string          `json:"check,omitempty"`
+	Severity string          `json:"severity,omitempty"`
+	Reason   string          `json:"reason,omitempty"`
+	Evidence []string        `json:"evidence,omitempty"`
+	Metadata json.RawMessage `json:"metadata,omitempty"`
+}
+
+type EvaluatorFailurePacket struct {
+	PrimaryReason string                 `json:"primary_reason,omitempty"`
+	HumanReason   string                 `json:"human_reason,omitempty"`
+	OptimizerHint string                 `json:"optimizer_hint,omitempty"`
+	FailedChecks  []EvaluatorCheckResult `json:"failed_checks,omitempty"`
+	Evidence      []string               `json:"evidence,omitempty"`
+	StageStatus   []EvaluatorStageStatus `json:"stage_status,omitempty"`
+}
+
+type EvaluatorScore struct {
+	ProfileID       string                  `json:"profile_id,omitempty"`
+	TaskKind        string                  `json:"task_kind,omitempty"`
+	Hard            *float64                `json:"hard,omitempty"`
+	Soft            *float64                `json:"soft,omitempty"`
+	DimensionScores map[string]float64      `json:"dimension_scores,omitempty"`
+	FailReason      string                  `json:"fail_reason,omitempty"`
+	Failure         *EvaluatorFailurePacket `json:"failure,omitempty"`
+	StageStatus     []EvaluatorStageStatus  `json:"stage_status,omitempty"`
+	Metadata        json.RawMessage         `json:"metadata,omitempty"`
+}
+
 type EvalRun struct {
 	ID                string          `json:"id"`
 	TemplateID        string          `json:"template_id"`
@@ -132,6 +195,7 @@ type TrainingPackage struct {
 	RankedFeedbackEvents []RankedFeedbackEvent `json:"ranked_feedback_events,omitempty"`
 	PairwisePreferences  []PairwisePreference  `json:"pairwise_preferences,omitempty"`
 	EvaluatorConfig      json.RawMessage       `json:"evaluator_config,omitempty"`
+	EvaluatorProfile     *EvaluatorProfile     `json:"evaluator_profile,omitempty"`
 }
 
 type CandidateTemplate struct {
@@ -140,10 +204,12 @@ type CandidateTemplate struct {
 }
 
 type CandidateSummary struct {
-	DiffArtifactID    string          `json:"diff_artifact_id,omitempty"`
-	Score             *float64        `json:"score,omitempty"`
-	PreferenceSummary string          `json:"preference_summary,omitempty"`
-	Metadata          json.RawMessage `json:"metadata,omitempty"`
+	DiffArtifactID    string                  `json:"diff_artifact_id,omitempty"`
+	Score             *float64                `json:"score,omitempty"`
+	PreferenceSummary string                  `json:"preference_summary,omitempty"`
+	Metadata          json.RawMessage         `json:"metadata,omitempty"`
+	EvaluatorScore    *EvaluatorScore         `json:"evaluator_score,omitempty"`
+	Failure           *EvaluatorFailurePacket `json:"failure,omitempty"`
 }
 
 type CandidateArtifactRef struct {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -148,6 +148,129 @@ func TestExportTrainingPackageIncludesPreferredGateMetadata(t *testing.T) {
 	}
 }
 
+func TestEvaluatorProfileAndFailurePacketContractsRoundTrip(t *testing.T) {
+	hard := 0.0
+	soft := 0.12
+	training := TrainingPackage{
+		Kind:            TrainingPackageKind,
+		ContractVersion: ContractVersion,
+		Template: TemplateSnapshot{
+			ID:            "planner",
+			VersionID:     "planner@v1",
+			VersionNumber: 1,
+			VersionState:  "active",
+			ContentHash:   "sha256:abc",
+			Metadata: agenttemplate.Metadata{
+				ID:          "planner",
+				Name:        "Planner",
+				Description: "Plans work.",
+				Kind:        "agent-template",
+				Version:     1,
+				Capabilities: []string{
+					"ask",
+				},
+				RuntimeCompatibility: []string{
+					"codex",
+				},
+				Tags: []string{
+					"planning",
+				},
+				Inputs: []string{
+					"request",
+				},
+				Outputs: []string{
+					"plan",
+				},
+			},
+			Content: "Plan carefully.",
+		},
+		EvalRun: EvalRun{
+			ID:         "run-1",
+			TemplateID: "planner",
+			State:      "review",
+		},
+		EvaluatorProfile: &EvaluatorProfile{
+			ProfileID:        "vue_landing_page_v1",
+			TaskKind:         "vue_landing_page",
+			ArtifactContract: "vue_vite_bundle",
+			PreviewAdapter:   "vue_vite",
+			Checks: []EvaluatorCheckConfig{
+				{ID: "required_files", Type: "artifact_contract", Required: true},
+				{ID: "render_smoke", Type: "playwright", When: "checks_pass"},
+			},
+			Judge:    &EvaluatorJudgeConfig{Type: "screenshot_llm", When: "checks_pass", Model: "gpt-evaluator"},
+			Metadata: json.RawMessage(`{"source":"test"}`),
+		},
+	}
+	candidate := CandidatePackage{
+		Kind:            CandidatePackageKind,
+		ContractVersion: ContractVersion,
+		TemplateID:      "planner",
+		Summary: CandidateSummary{
+			EvaluatorScore: &EvaluatorScore{
+				ProfileID: "vue_landing_page_v1",
+				TaskKind:  "vue_landing_page",
+				Hard:      &hard,
+				Soft:      &soft,
+				DimensionScores: map[string]float64{
+					"artifact_contract": 0,
+				},
+				FailReason: "missing required artifact",
+				Failure: &EvaluatorFailurePacket{
+					PrimaryReason: "missing_required_artifact",
+					HumanReason:   "The response did not include the required Vue/Vite preview bundle.",
+					OptimizerHint: "Return serialized bundle JSON with required files.",
+					FailedChecks: []EvaluatorCheckResult{
+						{
+							Check:    "artifact_contract.required_files",
+							Severity: "hard_blocker",
+							Reason:   "src/App.vue was not present.",
+							Evidence: []string{"src/App.vue missing"},
+						},
+					},
+					Evidence: []string{"bundle JSON shape missing"},
+					StageStatus: []EvaluatorStageStatus{
+						{Stage: "artifact_contract", Status: "failed", DurationMS: 7},
+					},
+				},
+				StageStatus: []EvaluatorStageStatus{
+					{Stage: "artifact_contract", Status: "failed"},
+				},
+			},
+		},
+	}
+
+	trainingBytes, err := json.Marshal(training)
+	if err != nil {
+		t.Fatalf("marshal training package: %v", err)
+	}
+	var decodedTraining TrainingPackage
+	if err := json.Unmarshal(trainingBytes, &decodedTraining); err != nil {
+		t.Fatalf("unmarshal training package: %v", err)
+	}
+	if decodedTraining.EvaluatorProfile == nil ||
+		decodedTraining.EvaluatorProfile.ProfileID != "vue_landing_page_v1" ||
+		decodedTraining.EvaluatorProfile.Checks[1].ID != "render_smoke" {
+		t.Fatalf("decoded evaluator profile = %+v", decodedTraining.EvaluatorProfile)
+	}
+
+	candidateBytes, err := json.Marshal(candidate)
+	if err != nil {
+		t.Fatalf("marshal candidate package: %v", err)
+	}
+	var decodedCandidate CandidatePackage
+	if err := json.Unmarshal(candidateBytes, &decodedCandidate); err != nil {
+		t.Fatalf("unmarshal candidate package: %v", err)
+	}
+	failure := decodedCandidate.Summary.EvaluatorScore.Failure
+	if failure == nil ||
+		failure.PrimaryReason != "missing_required_artifact" ||
+		failure.FailedChecks[0].Check != "artifact_contract.required_files" ||
+		*decodedCandidate.Summary.EvaluatorScore.Soft != soft {
+		t.Fatalf("decoded evaluator failure = %+v", decodedCandidate.Summary.EvaluatorScore)
+	}
+}
+
 func TestExportTrainingPackageIncludesRankedExplorationFeedback(t *testing.T) {
 	ctx := context.Background()
 	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
## What

Adds the Gitmoot-side SkillOpt contract fields for composable evaluator profiles and structured evaluator failure packets.

## Why

Issue 109 needs evaluator failures to be explicit, inspectable, and reusable by the optimizer instead of becoming ambiguous zero scores. This contract update gives the planner/package layer stable JSON fields for evaluator profiles, evaluator scores, failed checks, stage status, evidence, and optimizer hints.

## Changes

- Add `EvaluatorProfile` to training packages.
- Add `EvaluatorScore` and `EvaluatorFailurePacket` to candidate summaries.
- Add round-trip contract coverage for the new package fields.

## Results

- `gofmt -w internal/skillopt/contract.go internal/skillopt/contract_test.go`
- `git diff --check`
- `go test ./internal/skillopt ./internal/cli` could not complete locally because this checkout requires Go 1.26 and the installed Go 1.22.2 toolchain reports: `go: download go1.26 for linux/amd64: toolchain not available`.

## Review

`codex exec review --uncommitted` final output:

```text
I found no discrete, actionable bugs in the current staged, unstaged, or untracked changes. I could not run the Go tests because the toolchain download attempted to write under a read-only /root/go cache.
```

## Risk

Low. This is additive JSON contract surface with focused round-trip coverage.

Part of issue #109.
