### PR TITLE
Block no-op SkillOpt candidate imports

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -565,9 +565,10 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 	if request.StartNext &&
 		summary.CurrentPhase != skillopt.TrainStateCandidateReviewPublished &&
 		summary.CurrentPhase != skillopt.TrainStateCandidateCreated &&
+		summary.CurrentPhase != skillopt.TrainStateOptimizerCompletedNoCandidate &&
 		summary.CurrentPhase != skillopt.TrainStateCandidatePromoted &&
 		summary.CurrentPhase != skillopt.TrainStateCandidateRejected {
-		return skillOptTrainContinueOutput{}, fmt.Errorf("--start-next requires a promoted or rejected candidate; current phase is %s", summary.CurrentPhase)
+		return skillOptTrainContinueOutput{}, fmt.Errorf("--start-next requires a promoted candidate, rejected candidate, or no-candidate optimizer result; current phase is %s", summary.CurrentPhase)
 	}
 	switch summary.CurrentPhase {
 	case skillopt.TrainStateItemsReady:
@@ -732,10 +733,33 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 			"next: export the training package before running the optimizer",
 		}
 		return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
-	case skillopt.TrainStateFeedbackSynced, skillopt.TrainStateTrainingPackageCreated, skillopt.TrainStateOptimizerCompleted:
+	case skillopt.TrainStateFeedbackSynced, skillopt.TrainStateTrainingPackageCreated, skillopt.TrainStateOptimizerCompleted, skillopt.TrainStateOptimizerCompletedNoCandidate:
 		if iteration == nil {
 			output.Lines = []string{"next: train session has no iteration to continue"}
 			return output, nil
+		}
+		if summary.CurrentPhase == skillopt.TrainStateOptimizerCompletedNoCandidate {
+			if request.StartNext {
+				next, err := startNextSkillOptTrainIteration(ctx, store, session, *iteration)
+				if err != nil {
+					return skillOptTrainContinueOutput{}, err
+				}
+				updatedSession, updatedIteration, updatedCounts, err := loadSkillOptTrainStatus(ctx, store, session.ID)
+				if err != nil {
+					return skillOptTrainContinueOutput{}, err
+				}
+				updatedSummary := skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
+				lines := []string{
+					fmt.Sprintf("started_iteration: %s", next.ID),
+					fmt.Sprintf("base_version: %s", next.BaseTemplateVersionID),
+					"next: generate review options with train continue",
+				}
+				return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
+			}
+			if !request.Optimizer.RerunOptimizer {
+				output.Lines = []string{"next: revise feedback and run --start-next, rerun the optimizer with --rerun-optimizer, or stop"}
+				return output, nil
+			}
 		}
 		optimizerLockTTL, err := skillOptTrainOptimizerLockTTLForRequest(request.Optimizer)
 		if err != nil {
@@ -760,7 +784,8 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 		}
 		if summary.CurrentPhase != skillopt.TrainStateFeedbackSynced &&
 			summary.CurrentPhase != skillopt.TrainStateTrainingPackageCreated &&
-			summary.CurrentPhase != skillopt.TrainStateOptimizerCompleted {
+			summary.CurrentPhase != skillopt.TrainStateOptimizerCompleted &&
+			summary.CurrentPhase != skillopt.TrainStateOptimizerCompletedNoCandidate {
 			output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
 			return output, nil
 		}
@@ -780,8 +805,17 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 			fmt.Sprintf("artifact_dir: %s", result.ArtifactDir),
 			fmt.Sprintf("optimizer_command: %s", shellArgs(append([]string{result.Command}, result.Args...))),
 			fmt.Sprintf("optimizer_dry_run: %t", result.DryRun),
-			fmt.Sprintf("imported_candidate: %s", result.CandidateVersionID),
-			"next: publish candidate diff and preview review",
+		}
+		if result.NoCandidateReason != "" {
+			lines = append(lines,
+				fmt.Sprintf("no_candidate_reason: %s", result.NoCandidateReason),
+				fmt.Sprintf("next: %s", result.NoCandidateNextAction),
+			)
+		} else {
+			lines = append(lines,
+				fmt.Sprintf("imported_candidate: %s", result.CandidateVersionID),
+				"next: publish candidate diff and preview review",
+			)
 		}
 		return skillOptTrainContinueOutput{
 			Summary:       updatedSummary,
@@ -970,14 +1004,16 @@ func validateTerminalSkillOptTrainDecisionRequest(iteration db.SkillOptTrainIter
 }
 
 type skillOptTrainOptimizerResult struct {
-	TrainingPackagePath  string
-	OutRoot              string
-	CandidatePackagePath string
-	ArtifactDir          string
-	Command              string
-	Args                 []string
-	DryRun               bool
-	CandidateVersionID   string
+	TrainingPackagePath   string
+	OutRoot               string
+	CandidatePackagePath  string
+	ArtifactDir           string
+	Command               string
+	Args                  []string
+	DryRun                bool
+	CandidateVersionID    string
+	NoCandidateReason     string
+	NoCandidateNextAction string
 }
 
 type skillOptTrainOptimizerPaths struct {
@@ -1952,6 +1988,11 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 	if state == skillopt.TrainStateOptimizerCompleted && request.RerunOptimizer {
 		state = skillopt.TrainStateTrainingPackageCreated
 	}
+	if state == skillopt.TrainStateOptimizerCompletedNoCandidate && request.RerunOptimizer {
+		session.State = skillopt.TrainStateTrainingPackageCreated
+		iteration.State = skillopt.TrainStateTrainingPackageCreated
+		state = skillopt.TrainStateTrainingPackageCreated
+	}
 	if state == skillopt.TrainStateFeedbackSynced {
 		if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateTrainingPackageCreated); err != nil {
 			return skillOptTrainOptimizerResult{}, err
@@ -2011,6 +2052,15 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		}
 		version, err := importSkillOptTrainCandidate(ctx, paths, store, session, iteration, optimizerPaths)
 		if err != nil {
+			if errors.Is(err, skillopt.ErrNoCandidate) {
+				reason := skillOptNoCandidateReason(err)
+				if metaErr := recordSkillOptTrainNoCandidate(ctx, store, session, iteration, optimizerPaths, reason); metaErr != nil {
+					return skillOptTrainOptimizerResult{}, fmt.Errorf("%w; failed to record no-candidate result: %v", err, metaErr)
+				}
+				result.NoCandidateReason = reason
+				result.NoCandidateNextAction = skillOptNoCandidateNextAction()
+				return result, nil
+			}
 			if metaErr := recordSkillOptTrainCandidateImportFailure(ctx, store, session, iteration, optimizerPaths, err); metaErr != nil {
 				return skillOptTrainOptimizerResult{}, fmt.Errorf("%w; failed to record candidate import failure: %v", err, metaErr)
 			}
@@ -4047,6 +4097,43 @@ func recordSkillOptTrainCandidateImportFailure(ctx context.Context, store *db.St
 		return err
 	}
 	return store.UpsertSkillOptTrainIteration(ctx, iteration)
+}
+
+func recordSkillOptTrainNoCandidate(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, paths skillOptTrainOptimizerPaths, reason string) error {
+	if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateOptimizerCompletedNoCandidate); err != nil {
+		return err
+	}
+	metadata := map[string]any{
+		"status":              "no_candidate",
+		"candidate_package":   paths.CandidatePackagePath,
+		"artifact_dir":        paths.ArtifactDir,
+		"no_candidate_reason": reason,
+		"next_action":         skillOptNoCandidateNextAction(),
+		"completed_at":        time.Now().UTC().Format(time.RFC3339Nano),
+		"source":              "gitmoot skillopt train continue",
+	}
+	session.State = skillopt.TrainStateOptimizerCompletedNoCandidate
+	iteration.State = skillopt.TrainStateOptimizerCompletedNoCandidate
+	iteration.CandidateVersionID = ""
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_import", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_import", metadata)
+	if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+		return err
+	}
+	return store.UpsertSkillOptTrainIteration(ctx, iteration)
+}
+
+func skillOptNoCandidateReason(err error) string {
+	text := strings.TrimSpace(err.Error())
+	marker := skillopt.ErrNoCandidate.Error() + ":"
+	if index := strings.LastIndex(text, marker); index >= 0 {
+		return strings.TrimSpace(text[index+len(marker):])
+	}
+	return text
+}
+
+func skillOptNoCandidateNextAction() string {
+	return "do not publish a candidate review; revise feedback and start another iteration, rerun the optimizer with --rerun-optimizer, or stop"
 }
 
 func importSkillOptTrainCandidate(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, optimizerPaths skillOptTrainOptimizerPaths) (db.AgentTemplateVersion, error) {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2294,6 +2294,125 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan the work."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--out-root", outRoot,
+		"--dry-run",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue no-candidate exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: optimizer_completed_no_candidate",
+		"candidate: -",
+		"continue_ready: true",
+		"candidate_package: " + filepath.Join(outRoot, "candidate.json"),
+		"optimizer_dry_run: true",
+		"no_candidate_reason: candidate content is unchanged from the base version",
+		"next: do not publish a candidate review",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train continue no-candidate stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateOptimizerCompletedNoCandidate || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after no-candidate = %+v", iteration)
+	}
+	if !strings.Contains(iteration.MetadataJSON, `"status":"no_candidate"`) ||
+		!strings.Contains(iteration.MetadataJSON, `"no_candidate_reason":"candidate content is unchanged from the base version"`) {
+		t.Fatalf("iteration metadata after no-candidate = %s", iteration.MetadataJSON)
+	}
+	if _, err := store.GetAgentTemplateVersionByID(context.Background(), "planner@v2"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("no-candidate imported planner@v2 err=%v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--start-next",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue start-next after no-candidate exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: items_ready") ||
+		!strings.Contains(stdout.String(), "started_iteration: optimizer-train-002") ||
+		!strings.Contains(stdout.String(), "base_version: "+baseVersionID) {
+		t.Fatalf("start-next after no-candidate stdout = %s", stdout.String())
+	}
+}
+
+func TestSkillOptTrainContinueRerunsOptimizerAfterNoCandidate(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan the work."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--out-root", outRoot,
+		"--dry-run",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue no-candidate exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("optimizer calls after no-candidate = %+v, want one", runner.calls)
+	}
+
+	runner.candidate = cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with rerun candidate guidance.")
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--rerun-optimizer",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue rerun after no-candidate exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("optimizer calls after rerun = %+v, want two", runner.calls)
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_created") ||
+		!strings.Contains(stdout.String(), "imported_candidate: planner@v2") {
+		t.Fatalf("rerun after no-candidate stdout = %s", stdout.String())
+	}
+}
+
 func TestSkillOptTrainContinueMarksReviewPublishedFeedbackSynced(t *testing.T) {
 	home, _ := seedSkillOptTrainFeedbackSynced(t)
 	store := openCLIJobStore(t, home)
@@ -2720,7 +2839,7 @@ func TestSkillOptTrainContinuePublishesCandidateReviewPromotesAndStartsNext(t *t
 	if code != 1 {
 		t.Fatalf("train continue duplicate start-next exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "--start-next requires a promoted or rejected candidate; current phase is items_ready") {
+	if !strings.Contains(stderr.String(), "--start-next requires a promoted candidate, rejected candidate, or no-candidate optimizer result; current phase is items_ready") {
 		t.Fatalf("duplicate start-next stderr = %q", stderr.String())
 	}
 

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -27,6 +27,8 @@ const (
 	CandidateSourceRef  = "candidate"
 )
 
+var ErrNoCandidate = errors.New("optimizer produced no candidate")
+
 type TemplateSnapshot struct {
 	ID             string                 `json:"id"`
 	VersionID      string                 `json:"version_id"`
@@ -346,12 +348,15 @@ func ImportCandidatePackageWithOptions(ctx context.Context, store *db.Store, can
 	if err := validateCandidateArtifactIDsAvailable(ctx, store, candidateArtifactIDs); err != nil {
 		return db.AgentTemplateVersion{}, err
 	}
-	evalArtifacts, err := storeCandidateArtifactBlobs(options.BlobStore, preparedArtifacts)
+	templateID := strings.TrimSpace(candidate.TemplateID)
+	baseVersionID, err := candidateBaseVersionID(ctx, store, templateID, candidate.BaseVersionID)
 	if err != nil {
 		return db.AgentTemplateVersion{}, err
 	}
-	templateID := strings.TrimSpace(candidate.TemplateID)
-	baseVersionID, err := candidateBaseVersionID(ctx, store, templateID, candidate.BaseVersionID)
+	if err := validateCandidateCreatesPendingVersion(ctx, store, candidate, baseVersionID); err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
+	evalArtifacts, err := storeCandidateArtifactBlobs(options.BlobStore, preparedArtifacts)
 	if err != nil {
 		return db.AgentTemplateVersion{}, err
 	}
@@ -422,6 +427,47 @@ func candidateBaseVersionID(ctx context.Context, store *db.Store, templateID str
 		return "", fmt.Errorf("base version %q belongs to template %q, want %q", baseRef, base.ID, templateID)
 	}
 	return base.VersionID, nil
+}
+
+func validateCandidateCreatesPendingVersion(ctx context.Context, store *db.Store, candidate CandidatePackage, baseVersionID string) error {
+	reason := candidateNoCandidateReason(candidate)
+	if reason != "" {
+		return fmt.Errorf("%w: %s", ErrNoCandidate, reason)
+	}
+	base, err := store.GetAgentTemplateVersionByID(ctx, strings.TrimSpace(baseVersionID))
+	if err != nil {
+		return fmt.Errorf("load candidate base version %q: %w", baseVersionID, err)
+	}
+	candidateHash := agenttemplate.HashContent(candidate.Candidate.Content)
+	if strings.TrimSpace(base.ContentHash) == candidateHash || agenttemplate.HashContent(base.Content) == candidateHash {
+		return fmt.Errorf("%w: candidate content is unchanged from the base version", ErrNoCandidate)
+	}
+	return nil
+}
+
+func candidateNoCandidateReason(candidate CandidatePackage) string {
+	for _, source := range []json.RawMessage{candidate.EvalReport, candidate.Summary.Metadata} {
+		reason := rawNoCandidateReason(source)
+		if reason != "" {
+			return reason
+		}
+	}
+	return ""
+}
+
+func rawNoCandidateReason(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var data map[string]any
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return ""
+	}
+	if promotable, ok := data["promotable"].(bool); ok && promotable {
+		return ""
+	}
+	reason, _ := data["no_candidate_reason"].(string)
+	return strings.TrimSpace(reason)
 }
 
 func validateCandidatePackage(ctx context.Context, store *db.Store, candidate CandidatePackage, candidateArtifactIDs map[string]struct{}) error {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -3,6 +3,7 @@ package skillopt
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -465,6 +466,78 @@ func TestImportCandidatePackageCreatesPendingVersion(t *testing.T) {
 	}
 	if review.BaseVersionID != current.VersionID || review.DiffArtifactID != "candidate-diff" || review.PreferenceSummary != "Candidate is more actionable." || review.EvalReportJSON != `{"score":0.82}` {
 		t.Fatalf("candidate review = %+v", review)
+	}
+}
+
+func TestImportCandidatePackageRejectsNoCandidateMetadata(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("planner", "Plan carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	candidateContent := testTemplateContent("planner", "Plan carefully with a concise risk section.")
+	parsed, err := agenttemplate.ParseTemplateContent(candidateContent)
+	if err != nil {
+		t.Fatalf("ParseTemplateContent returned error: %v", err)
+	}
+
+	_, err = ImportCandidatePackage(ctx, store, CandidatePackage{
+		Kind:            CandidatePackageKind,
+		ContractVersion: ContractVersion,
+		TemplateID:      "planner",
+		BaseVersionID:   "planner@latest",
+		Candidate: CandidateTemplate{
+			Content:  candidateContent,
+			Metadata: parsed.Metadata,
+		},
+		EvalReport: json.RawMessage(`{"promotable":false,"no_candidate_reason":"best_origin_initial_skill"}`),
+		Summary: CandidateSummary{
+			Metadata: json.RawMessage(`{"promotable":false,"no_candidate_reason":"best_origin_initial_skill"}`),
+		},
+	}, "candidate.json")
+	if !errors.Is(err, ErrNoCandidate) || !strings.Contains(err.Error(), "optimizer produced no candidate: best_origin_initial_skill") {
+		t.Fatalf("ImportCandidatePackage error = %v", err)
+	}
+}
+
+func TestImportCandidatePackageRejectsUnchangedContent(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("planner", "Plan carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	current, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	parsed, err := agenttemplate.ParseTemplateContent(current.Content)
+	if err != nil {
+		t.Fatalf("ParseTemplateContent returned error: %v", err)
+	}
+
+	_, err = ImportCandidatePackage(ctx, store, CandidatePackage{
+		Kind:            CandidatePackageKind,
+		ContractVersion: ContractVersion,
+		TemplateID:      "planner",
+		BaseVersionID:   current.VersionID,
+		Candidate: CandidateTemplate{
+			Content:  current.Content,
+			Metadata: parsed.Metadata,
+		},
+		Summary: CandidateSummary{},
+	}, "candidate.json")
+	if !errors.Is(err, ErrNoCandidate) || !strings.Contains(err.Error(), "optimizer produced no candidate: candidate content is unchanged") {
+		t.Fatalf("ImportCandidatePackage error = %v", err)
 	}
 }
 

--- a/internal/skillopt/train.go
+++ b/internal/skillopt/train.go
@@ -10,19 +10,20 @@ import (
 )
 
 const (
-	TrainStateRequestConfirmed         = "request_confirmed"
-	TrainStateWorkspaceReady           = "workspace_ready"
-	TrainStateItemsReady               = "items_ready"
-	TrainStateOptionsGenerated         = "options_generated"
-	TrainStateReviewPublished          = "review_published"
-	TrainStateFeedbackSynced           = "feedback_synced"
-	TrainStateTrainingPackageCreated   = "training_package_created"
-	TrainStateOptimizerCompleted       = "optimizer_completed"
-	TrainStateCandidateCreated         = "candidate_created"
-	TrainStateCandidateReviewPublished = "candidate_review_published"
-	TrainStateCandidatePromoted        = "candidate_promoted"
-	TrainStateCandidateRejected        = "candidate_rejected"
-	TrainStateRunAbandoned             = "run_abandoned"
+	TrainStateRequestConfirmed              = "request_confirmed"
+	TrainStateWorkspaceReady                = "workspace_ready"
+	TrainStateItemsReady                    = "items_ready"
+	TrainStateOptionsGenerated              = "options_generated"
+	TrainStateReviewPublished               = "review_published"
+	TrainStateFeedbackSynced                = "feedback_synced"
+	TrainStateTrainingPackageCreated        = "training_package_created"
+	TrainStateOptimizerCompleted            = "optimizer_completed"
+	TrainStateOptimizerCompletedNoCandidate = "optimizer_completed_no_candidate"
+	TrainStateCandidateCreated              = "candidate_created"
+	TrainStateCandidateReviewPublished      = "candidate_review_published"
+	TrainStateCandidatePromoted             = "candidate_promoted"
+	TrainStateCandidateRejected             = "candidate_rejected"
+	TrainStateRunAbandoned                  = "run_abandoned"
 )
 
 const (
@@ -96,7 +97,7 @@ func NormalizeTrainState(state string) string {
 
 func IsTerminalTrainState(state string) bool {
 	switch NormalizeTrainState(state) {
-	case TrainStateCandidatePromoted, TrainStateCandidateRejected, TrainStateRunAbandoned:
+	case TrainStateOptimizerCompletedNoCandidate, TrainStateCandidatePromoted, TrainStateCandidateRejected, TrainStateRunAbandoned:
 		return true
 	default:
 		return false
@@ -119,6 +120,12 @@ func CanTransitionTrainIteration(from string, to string) error {
 		return fmt.Errorf("cannot transition train iteration from terminal state %s to %s", from, to)
 	}
 	if IsTerminalTrainState(to) {
+		if to == TrainStateOptimizerCompletedNoCandidate {
+			if from != TrainStateOptimizerCompleted {
+				return fmt.Errorf("cannot transition train iteration from %s to %s before optimizer completes", from, to)
+			}
+			return nil
+		}
 		if to != TrainStateRunAbandoned && from != TrainStateCandidateReviewPublished {
 			return fmt.Errorf("cannot transition train iteration from %s to %s before candidate review is published", from, to)
 		}
@@ -144,7 +151,7 @@ func CanTransitionTrainIteration(from string, to string) error {
 func CanStartNextTrainIteration(previous db.SkillOptTrainIteration) error {
 	state := NormalizeTrainState(previous.State)
 	switch state {
-	case TrainStateCandidatePromoted, TrainStateRunAbandoned:
+	case TrainStateOptimizerCompletedNoCandidate, TrainStateCandidatePromoted, TrainStateRunAbandoned:
 		return nil
 	case TrainStateCandidateRejected:
 		if strings.TrimSpace(previous.DecisionReason) == "" {
@@ -358,6 +365,9 @@ func completedTrainSteps(state string) []string {
 			if state == TrainStateRunAbandoned {
 				return nil
 			}
+			if state == TrainStateOptimizerCompletedNoCandidate {
+				return append([]string{}, orderedTrainStates[:trainStateOrder[TrainStateOptimizerCompleted]+1]...)
+			}
 			return append([]string{}, orderedTrainStates...)
 		}
 		return nil
@@ -383,6 +393,8 @@ func trainBlockedStepAndAction(state string) (string, string) {
 		return TrainStateOptimizerCompleted, "run the external gitmoot-skillopt optimizer"
 	case TrainStateOptimizerCompleted:
 		return TrainStateCandidateCreated, "import the optimizer candidate package"
+	case TrainStateOptimizerCompletedNoCandidate:
+		return "", "no candidate was created; revise feedback and start another iteration, rerun the optimizer, or stop"
 	case TrainStateCandidateCreated:
 		return TrainStateCandidateReviewPublished, "publish candidate diff and preview review"
 	case TrainStateCandidateReviewPublished:

--- a/internal/skillopt/train_test.go
+++ b/internal/skillopt/train_test.go
@@ -38,6 +38,15 @@ func TestCanTransitionTrainIterationAllowsTerminalDecisions(t *testing.T) {
 	}
 }
 
+func TestCanTransitionTrainIterationAllowsNoCandidateAfterOptimizer(t *testing.T) {
+	if err := CanTransitionTrainIteration(TrainStateOptimizerCompleted, TrainStateOptimizerCompletedNoCandidate); err != nil {
+		t.Fatalf("no-candidate transition returned error: %v", err)
+	}
+	if err := CanTransitionTrainIteration(TrainStateTrainingPackageCreated, TrainStateOptimizerCompletedNoCandidate); err == nil || !strings.Contains(err.Error(), "optimizer completes") {
+		t.Fatalf("early no-candidate transition error = %v", err)
+	}
+}
+
 func TestCanStartNextTrainIterationRequiresResolvedPreviousIteration(t *testing.T) {
 	if err := CanStartNextTrainIteration(db.SkillOptTrainIteration{ID: "iter-1", State: TrainStateCandidateCreated}); err == nil || !strings.Contains(err.Error(), TrainStateCandidateCreated) {
 		t.Fatalf("active iteration error = %v", err)
@@ -49,6 +58,7 @@ func TestCanStartNextTrainIterationRequiresResolvedPreviousIteration(t *testing.
 		t.Fatalf("rejected without reason error = %v", err)
 	}
 	for _, iteration := range []db.SkillOptTrainIteration{
+		{ID: "iter-1", State: TrainStateOptimizerCompletedNoCandidate},
 		{ID: "iter-1", State: TrainStateCandidatePromoted},
 		{ID: "iter-1", State: TrainStateRunAbandoned},
 		{ID: "iter-1", State: TrainStateCandidateRejected, DecisionReason: "too broad"},


### PR DESCRIPTION
## What
- Reject SkillOpt candidate imports when no-candidate metadata is present or candidate content matches the base version.
- Add `optimizer_completed_no_candidate` train state and clear CLI output with `no_candidate_reason`.
- Prevent candidate review publication for no-op outputs while allowing `--start-next` and `--rerun-optimizer` from the no-candidate state.

## Why
Task 6 of issue #109 needs Gitmoot to enforce that no-op optimizer output cannot create pending template candidates or candidate reviews.

## Verification
- `GOTOOLCHAIN=go1.26.0 go test -timeout 300s ./internal/skillopt ./internal/cli` -> passed
- `git diff --check` -> clean

## Independent Review
First review finding fixed:
- `optimizer_completed_no_candidate` advertised rerun but ignored `--rerun-optimizer`.

Second review after fix:
No findings in the tracked uncommitted diff.

Reviewer did not run tests.