### PR TITLE
skillopt: auto-sync github review feedback

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -676,13 +676,26 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 			return skillOptTrainContinueOutput{}, err
 		}
 		feedbackCount := len(status.Feedback) + len(status.RankedFeedback)
+		var syncLines []string
 		if !status.TrainingReady {
-			lines := []string{
+			lines, synced := autoSyncSkillOptTrainReviewFeedback(ctx, paths, store, *iteration)
+			syncLines = append(syncLines, lines...)
+			if synced {
+				status, err = loadSkillOptReviewStatus(ctx, store, artifact.NewStore(paths.ArtifactBlobs), iteration.EvalRunID)
+				if err != nil {
+					return skillOptTrainContinueOutput{}, err
+				}
+				feedbackCount = len(status.Feedback) + len(status.RankedFeedback)
+			}
+		}
+		if !status.TrainingReady {
+			lines := append([]string{}, syncLines...)
+			lines = append(lines,
 				fmt.Sprintf("feedback_events: %d", feedbackCount),
 				fmt.Sprintf("pairwise_preferences: %d", len(status.PairwisePreferences)),
 				fmt.Sprintf("packet_blockers: %d", len(status.PacketBlockers)),
 				fmt.Sprintf("training_blockers: %d", len(status.TrainingBlockers)),
-			}
+			)
 			for _, blocker := range status.PacketBlockers {
 				lines = append(lines, fmt.Sprintf("packet_blocker: %s", blocker))
 			}
@@ -731,6 +744,9 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 			fmt.Sprintf("recommended_next_mode: %s", status.Recommendation.RecommendedMode),
 			fmt.Sprintf("ranking_stability: %s", status.Recommendation.RankingStability),
 			"next: export the training package before running the optimizer",
+		}
+		if len(syncLines) > 0 {
+			lines = append(syncLines, lines...)
 		}
 		return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
 	case skillopt.TrainStateFeedbackSynced, skillopt.TrainStateTrainingPackageCreated, skillopt.TrainStateOptimizerCompleted, skillopt.TrainStateOptimizerCompletedNoCandidate:
@@ -2684,6 +2700,40 @@ type skillOptTrainReviewPublishResult struct {
 	IssueNumber int64
 	URL         string
 	PreviewURLs int
+}
+
+func autoSyncSkillOptTrainReviewFeedback(ctx context.Context, paths config.Paths, store *db.Store, iteration db.SkillOptTrainIteration) ([]string, bool) {
+	repoText := strings.TrimSpace(iteration.IssueRepo)
+	issueNumber := iteration.IssueNumber
+	if repoText == "" || issueNumber <= 0 {
+		return nil, false
+	}
+	repo, err := daemon.ParseRepository(repoText)
+	if err != nil {
+		return []string{
+			"github_feedback_sync: failed",
+			fmt.Sprintf("github_feedback_error: invalid review repo %q: %v", repoText, err),
+		}, false
+	}
+	collector := feedback.GitHubCollector{
+		BlobStore: artifact.NewStore(paths.ArtifactBlobs),
+		GitHub:    newSkillOptGitHubClient(),
+	}
+	result, err := collector.Sync(ctx, store, iteration.EvalRunID, repo, issueNumber)
+	if err != nil {
+		return []string{
+			"github_feedback_sync: failed",
+			fmt.Sprintf("github_feedback_error: %v", err),
+		}, false
+	}
+	lines := []string{
+		"github_feedback_sync: imported",
+		fmt.Sprintf("github_feedback_events: %d", result.Count()),
+	}
+	for _, diagnostic := range result.Diagnostics {
+		lines = append(lines, fmt.Sprintf("github_feedback_diagnostic: %s", diagnostic))
+	}
+	return lines, result.Count() > 0
 }
 
 func publishSkillOptTrainReview(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) (skillOptTrainReviewPublishResult, error) {
@@ -5664,7 +5714,7 @@ func runSkillOptFeedbackGitHubSync(args []string, stdout, stderr io.Writer) int 
 		fmt.Fprintln(stderr, "skillopt feedback github sync requires --issue or --pr")
 		return 2
 	}
-	var count int
+	var result feedback.ImportResult
 	if err := withSkillOptStore(*home, func(paths config.Paths, store *db.Store) error {
 		run, err := store.GetEvalRun(context.Background(), strings.TrimSpace(*runID))
 		if err != nil {
@@ -5678,17 +5728,19 @@ func runSkillOptFeedbackGitHubSync(args []string, stdout, stderr io.Writer) int 
 			BlobStore: artifact.NewStore(paths.ArtifactBlobs),
 			GitHub:    newSkillOptGitHubClient(),
 		}
-		result, err := collector.Sync(context.Background(), store, run.ID, repo, targetNumber)
+		result, err = collector.Sync(context.Background(), store, run.ID, repo, targetNumber)
 		if err != nil {
 			return err
 		}
-		count = result.Count()
 		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "skillopt feedback github sync: %v\n", err)
 		return 1
 	}
-	writeLine(stdout, "imported %d github feedback events", count)
+	writeLine(stdout, "imported %d github feedback events", result.Count())
+	for _, diagnostic := range result.Diagnostics {
+		writeLine(stdout, "github_feedback_diagnostic: %s", diagnostic)
+	}
 	return 0
 }
 

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1041,6 +1041,75 @@ func TestSkillOptTrainContinueGeneratesOptionsWithManagedAgent(t *testing.T) {
 	if fakeGitHub.createdIssue.Repo.FullName() != "owner/product" || !strings.Contains(fakeGitHub.createdIssue.Body, "## Inline Options Without Public Links") {
 		t.Fatalf("created review issue = %+v", fakeGitHub.createdIssue)
 	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("third train continue without comments exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: review_published",
+		"github_feedback_sync: failed",
+		"github_feedback_error: no comments found",
+		"next: sync human feedback from the review surface",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("third continue without comments stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	fakeGitHub.comments = map[int64][]github.IssueComment{
+		8: {
+			{
+				ID: 11,
+				Body: `LGTM, copying the review block.
+
+` + "```yaml" + `
+run_id: landing-train-review-001
+items:
+  - item_id: hero-saas
+    ranking:
+      - B > A
+    quality: acceptable
+    continue_mode: refine
+    promote: no
+    reasoning: Option B has the clearer hero.
+  - item_id: ecommerce-proof
+    ranking:
+      - A > B
+    quality: acceptable
+    continue_mode: refine
+    promote: no
+    reasoning: Option A has stronger proof.
+` + "```",
+				URL:       "https://github.com/owner/product/issues/8#issuecomment-11",
+				Author:    "jerry",
+				CreatedAt: "2026-06-03T12:00:00Z",
+			},
+		},
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("fourth train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: feedback_synced",
+		"continue_ready: true",
+		"github_feedback_sync: imported",
+		"github_feedback_events: 2",
+		"feedback_events: 2",
+		"next: export the training package before running the optimizer",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("fourth continue stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if len(fakeGitHub.listedComments) != 2 || fakeGitHub.listedComments[1].Repo.FullName() != "owner/product" || fakeGitHub.listedComments[1].IssueNumber != 8 {
+		t.Fatalf("listed comments = %+v", fakeGitHub.listedComments)
+	}
 }
 
 func TestSkillOptTrainContinueGeneratesRequiredVuePreviewBundles(t *testing.T) {

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -88,7 +88,7 @@ func (c GitHubCollector) Body(ctx context.Context, store *db.Store, runID string
 	}
 	builder.WriteString("Review each item without trying to infer which option is baseline or candidate.\n\n")
 	writePhaseRecommendation(&builder, recommendation)
-	builder.WriteString("Reply in a comment with one of these formats. Allowed choices: `a`, `b`, `tie`, `neither`, `skip`.\n\n")
+	builder.WriteString("Reply by copying the fenced `yaml` block below into a new comment and filling every item. Allowed choices: `a`, `b`, `tie`, `neither`, `skip`.\n\n")
 	builder.WriteString("## Copy-Paste YAML Reply\n\n")
 	builder.WriteString("```yaml\n")
 	yamlTemplate, err := githubFeedbackYAMLTemplate(run.ID, items)
@@ -126,7 +126,10 @@ func (c GitHubCollector) rankedBody(ctx context.Context, store *db.Store, run db
 	}
 	builder.WriteString("- Compare each item across the option links below.\n")
 	builder.WriteString("- Rank every option from best to worst using the exact labels shown.\n")
-	builder.WriteString("- Optional `quality`, `continue_mode`, and `promote` fields help Gitmoot decide whether to explore more, refine, validate, or promote.\n\n")
+	builder.WriteString("- Reply by copying the fenced `yaml` block below into a new comment and filling every item.\n")
+	builder.WriteString("- Valid `quality` values: `poor`, `acceptable`, `strong`.\n")
+	builder.WriteString("- Valid `continue_mode` values: `explore`, `refine`, `distill`, `validate`.\n")
+	builder.WriteString("- Valid `promote` values: `yes`, `no`.\n\n")
 	writePhaseRecommendation(&builder, recommendation)
 	builder.WriteString("## Review Table\n\n")
 	writeGitHubRankedReviewTable(&builder, items, assignments)
@@ -263,18 +266,25 @@ func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, ru
 	}
 	var imported []db.FeedbackEvent
 	var importedRanked []db.RankedFeedbackEvent
+	var diagnostics []string
+	if len(comments) == 0 {
+		return ImportResult{}, errors.New("no comments found on GitHub issue or pull request")
+	}
 	for _, comment := range comments {
 		parsed, ok, err := ParseGitHubFeedbackComment(comment.Body)
 		if err != nil {
 			return ImportResult{}, fmt.Errorf("comment %d: %w", comment.ID, feedbackImportErrorHint(err))
 		}
 		if !ok {
+			diagnostics = append(diagnostics, fmt.Sprintf("comment %d: no parseable feedback YAML or short-form feedback", comment.ID))
 			continue
 		}
 		if parsed.RunID == "" {
+			diagnostics = append(diagnostics, fmt.Sprintf("comment %d: missing run_id", comment.ID))
 			continue
 		}
 		if parsed.RunID != runID {
+			diagnostics = append(diagnostics, fmt.Sprintf("comment %d: wrong run_id %q, want %q", comment.ID, parsed.RunID, runID))
 			continue
 		}
 		reviewer := strings.TrimSpace(comment.Author)
@@ -294,14 +304,23 @@ func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, ru
 		}
 		commentEvents := make([]db.FeedbackEvent, 0, len(parsed.Items))
 		commentRankedEvents := make([]db.RankedFeedbackEvent, 0, len(parsed.Items))
+		seenKnownItem := false
+		reportedMissingItemFeedback := false
 		for _, entry := range parsed.Items {
 			itemID := strings.TrimSpace(entry.ItemID)
+			if itemID == "" {
+				diagnostics = append(diagnostics, fmt.Sprintf("comment %d: missing item feedback for run %q", comment.ID, runID))
+				reportedMissingItemFeedback = true
+				continue
+			}
 			if _, ok := knownItems[itemID]; !ok {
 				if parsed.ShortForm {
+					diagnostics = append(diagnostics, fmt.Sprintf("comment %d: unknown feedback item_id %q", comment.ID, itemID))
 					continue
 				}
 				return ImportResult{}, fmt.Errorf("comment %d: unknown feedback item_id %q", comment.ID, itemID)
 			}
+			seenKnownItem = true
 			assignment := assignments[itemID].blindAssignment
 			if len(assignment.Options) > 0 {
 				event, err := rankedFeedbackEventFromEntry(runID, itemID, entry, assignment, reviewer, SourceGitHub, sourceURL, createdAt)
@@ -331,8 +350,18 @@ func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, ru
 			}
 			commentEvents = append(commentEvents, event)
 		}
+		if !seenKnownItem && !reportedMissingItemFeedback {
+			diagnostics = append(diagnostics, fmt.Sprintf("comment %d: missing item feedback for run %q", comment.ID, runID))
+		}
 		imported = append(imported, commentEvents...)
 		importedRanked = append(importedRanked, commentRankedEvents...)
+	}
+	result := ImportResult{FeedbackEvents: imported, RankedFeedbackEvents: importedRanked, Diagnostics: diagnostics}
+	if result.Count() == 0 {
+		if len(diagnostics) > 0 {
+			return ImportResult{}, fmt.Errorf("no github feedback imported: %s", strings.Join(diagnostics, "; "))
+		}
+		return ImportResult{}, errors.New("no parseable feedback YAML or short-form comments found")
 	}
 	for _, event := range imported {
 		if err := store.UpsertFeedbackEvent(ctx, event); err != nil {
@@ -344,7 +373,7 @@ func (c GitHubCollector) ImportComments(ctx context.Context, store *db.Store, ru
 			return ImportResult{}, err
 		}
 	}
-	return ImportResult{FeedbackEvents: imported, RankedFeedbackEvents: importedRanked}, nil
+	return result, nil
 }
 
 type githubAssignment struct {
@@ -446,6 +475,9 @@ func parseFullYAMLFeedback(content string) (feedbackFile, bool, error) {
 	parsed.RunID = strings.TrimSpace(parsed.RunID)
 	parsed.Reviewer = strings.TrimSpace(parsed.Reviewer)
 	if len(parsed.Items) == 0 {
+		if parsed.RunID != "" && strings.Contains(content, "items:") {
+			return parsed, true, nil
+		}
 		return feedbackFile{}, false, nil
 	}
 	normalizeFeedbackFileEntries(&parsed)
@@ -457,7 +489,7 @@ func parseFullYAMLFeedback(content string) (feedbackFile, bool, error) {
 		}
 	}
 	if !hasFeedbackItem {
-		return feedbackFile{}, false, nil
+		return parsed, true, nil
 	}
 	return parsed, true, nil
 }

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -152,6 +152,7 @@ func TestGitHubCollectorPublishesIssueBody(t *testing.T) {
 	}
 	body := fake.createdIssue.Body
 	for _, want := range []string{
+		"Reply by copying the fenced `yaml` block below",
 		"Allowed choices: `a`, `b`, `tie`, `neither`, `skip`",
 		"## Phase Recommendation",
 		"recommend continue validate",
@@ -189,6 +190,10 @@ func TestGitHubCollectorPublishesRankedIssueBody(t *testing.T) {
 	body := fake.createdIssue.Body
 	for _, want := range []string{
 		"Rank every option",
+		"Reply by copying the fenced `yaml` block below",
+		"Valid `quality` values: `poor`, `acceptable`, `strong`",
+		"Valid `continue_mode` values: `explore`, `refine`, `distill`, `validate`",
+		"Valid `promote` values: `yes`, `no`",
 		"## Review Table",
 		"## Phase Recommendation",
 		"recommend continue explore",
@@ -332,6 +337,9 @@ func TestGitHubCollectorSyncImportsValidCommentsAndIgnoresUnrelated(t *testing.T
 	if len(events) != 1 {
 		t.Fatalf("events = %+v, want 1 imported event", events)
 	}
+	if len(result.Diagnostics) == 0 {
+		t.Fatalf("diagnostics = %+v, want ignored-comment diagnostics", result.Diagnostics)
+	}
 	if events[0].RunID != "run-1" || events[0].ItemID != "item-001" || events[0].Reviewer != "bob" || events[0].Source != SourceGitHub || events[0].SourceURL != "https://github.com/owner/repo/issues/42#issuecomment-2" {
 		t.Fatalf("event = %+v", events[0])
 	}
@@ -351,6 +359,56 @@ func TestGitHubCollectorSyncImportsValidCommentsAndIgnoresUnrelated(t *testing.T
 	}
 	if len(stored) != 1 {
 		t.Fatalf("duplicate sync persisted duplicate events: %+v", stored)
+	}
+}
+
+func TestGitHubCollectorSyncReportsNoComments(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubFeedbackRun(t, "run-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{42: nil},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	_, err := collector.Sync(ctx, store, "run-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	if err == nil || !strings.Contains(err.Error(), "no comments found") {
+		t.Fatalf("Sync err = %v, want no comments diagnostic", err)
+	}
+}
+
+func TestGitHubCollectorSyncReportsWrongRunIDWhenNoValidFeedback(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubFeedbackRun(t, "run-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{
+			42: {
+				{ID: 1, Body: "```yaml\nrun_id: other-run\nitems:\n  - item_id: item-001\n    choice: b\n```", Author: "alice"},
+			},
+		},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	_, err := collector.Sync(ctx, store, "run-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	if err == nil || !strings.Contains(err.Error(), `wrong run_id "other-run", want "run-1"`) {
+		t.Fatalf("Sync err = %v, want wrong run_id diagnostic", err)
+	}
+}
+
+func TestGitHubCollectorSyncReportsMissingItemFeedback(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubFeedbackRun(t, "run-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{
+			42: {
+				{ID: 1, Body: "```yaml\nrun_id: run-1\nitems:\n  - choice: b\n```", Author: "alice"},
+			},
+		},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	_, err := collector.Sync(ctx, store, "run-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	if err == nil || !strings.Contains(err.Error(), `missing item feedback for run "run-1"`) {
+		t.Fatalf("Sync err = %v, want missing item feedback diagnostic", err)
 	}
 }
 

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -70,6 +70,7 @@ type feedbackFileEntry struct {
 type ImportResult struct {
 	FeedbackEvents       []db.FeedbackEvent
 	RankedFeedbackEvents []db.RankedFeedbackEvent
+	Diagnostics          []string
 }
 
 func (r ImportResult) Count() int {


### PR DESCRIPTION
## Summary
- clarify GitHub review packets so reviewers copy the fenced YAML and use valid signal values
- add feedback import diagnostics for no comments, no parseable feedback, wrong run_id, missing item feedback, unknown item IDs, and existing validation errors
- auto-sync GitHub review issue comments during train continue from review_published before checking training readiness

## Verification
- GOTOOLCHAIN=go1.26.0 go test -timeout 300s ./internal/feedback ./internal/cli
- git diff --check