### PR TITLE
skillopt: add verbose and watchable train status

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -365,11 +365,121 @@ func printSkillOptTrainStartPlan(stdout io.Writer, plan skillOptTrainStartPlan) 
 	writeLine(stdout, "next_action: %s", plan.Summary.NextAction)
 }
 
+type skillOptTrainStatusSnapshot struct {
+	SessionID        string                         `json:"session_id"`
+	IterationID      string                         `json:"iteration_id,omitempty"`
+	TemplateID       string                         `json:"template_id,omitempty"`
+	TemplateVersion  string                         `json:"template_version,omitempty"`
+	TargetRepo       string                         `json:"target_repo,omitempty"`
+	WorkspaceRepo    string                         `json:"workspace_repo,omitempty"`
+	TaskKind         string                         `json:"task_kind,omitempty"`
+	CurrentPhase     string                         `json:"current_phase"`
+	CurrentStep      string                         `json:"current_step"`
+	CompletedSteps   []string                       `json:"completed_steps"`
+	BlockedStep      string                         `json:"blocked_step,omitempty"`
+	NextAction       string                         `json:"next_action"`
+	IssueURL         string                         `json:"issue_url,omitempty"`
+	PullRequestURL   string                         `json:"pull_request_url,omitempty"`
+	CandidateVersion string                         `json:"candidate_version,omitempty"`
+	PreviewPolicy    skillOptTrainPreviewPolicyJSON `json:"preview_policy"`
+	Counts           skillOptTrainStatusCountsJSON  `json:"counts"`
+	Progress         skillOptTrainStatusProgress    `json:"progress"`
+	Verbose          *skillOptTrainStatusVerbose    `json:"verbose,omitempty"`
+}
+
+type skillOptTrainPreviewPolicyJSON struct {
+	Mode               string `json:"mode"`
+	Renderer           string `json:"renderer"`
+	Publisher          string `json:"publisher"`
+	Repo               string `json:"repo,omitempty"`
+	RouteTemplate      string `json:"route_template,omitempty"`
+	ExpectedReviewRepo string `json:"expected_review_repo,omitempty"`
+}
+
+type skillOptTrainStatusCountsJSON struct {
+	ReviewItems          int `json:"review_items"`
+	FeedbackEvents       int `json:"feedback_events"`
+	RankedFeedbackEvents int `json:"ranked_feedback_events"`
+	PairwisePreferences  int `json:"pairwise_preferences"`
+}
+
+type skillOptTrainStatusProgress struct {
+	ReviewItems          int    `json:"review_items"`
+	FeedbackEvents       int    `json:"feedback_events"`
+	RankedFeedbackEvents int    `json:"ranked_feedback_events"`
+	PairwisePreferences  int    `json:"pairwise_preferences"`
+	GeneratedOptions     int    `json:"generated_options"`
+	ETA                  string `json:"eta"`
+}
+
+type skillOptTrainStatusVerbose struct {
+	EvalRunID             string                         `json:"eval_run_id,omitempty"`
+	BaseTemplateVersionID string                         `json:"base_template_version_id,omitempty"`
+	Mode                  string                         `json:"mode,omitempty"`
+	ExplorationLevel      string                         `json:"exploration_level,omitempty"`
+	CreatedAt             string                         `json:"created_at,omitempty"`
+	UpdatedAt             string                         `json:"updated_at,omitempty"`
+	Elapsed               string                         `json:"elapsed"`
+	ReviewIssue           skillOptTrainStatusReviewIssue `json:"review_issue,omitempty"`
+	Candidate             skillOptTrainStatusCandidate   `json:"candidate,omitempty"`
+	Optimizer             map[string]any                 `json:"optimizer,omitempty"`
+	Jobs                  skillOptTrainStatusJobs        `json:"jobs"`
+	ActiveLocks           []skillOptTrainStatusLock      `json:"active_locks,omitempty"`
+	Items                 []skillOptTrainStatusItem      `json:"items,omitempty"`
+	MetadataStatus        map[string]string              `json:"metadata_status,omitempty"`
+}
+
+type skillOptTrainStatusReviewIssue struct {
+	Repo   string `json:"repo,omitempty"`
+	Number int64  `json:"number,omitempty"`
+	URL    string `json:"url,omitempty"`
+}
+
+type skillOptTrainStatusCandidate struct {
+	VersionID         string `json:"version_id,omitempty"`
+	PullRequestURL    string `json:"pull_request_url,omitempty"`
+	NoCandidateReason string `json:"no_candidate_reason,omitempty"`
+}
+
+type skillOptTrainStatusJobs struct {
+	Total     int                         `json:"total"`
+	Queued    int                         `json:"queued"`
+	Running   int                         `json:"running"`
+	Succeeded int                         `json:"succeeded"`
+	Failed    int                         `json:"failed"`
+	Other     int                         `json:"other"`
+	Items     []skillOptTrainStatusJobRef `json:"items,omitempty"`
+}
+
+type skillOptTrainStatusJobRef struct {
+	ID    string `json:"id"`
+	Agent string `json:"agent,omitempty"`
+	Type  string `json:"type,omitempty"`
+	State string `json:"state"`
+}
+
+type skillOptTrainStatusLock struct {
+	Name       string `json:"name"`
+	Key        string `json:"key"`
+	OwnerJobID string `json:"owner_job_id,omitempty"`
+	ExpiresAt  string `json:"expires_at,omitempty"`
+}
+
+type skillOptTrainStatusItem struct {
+	ItemID       string   `json:"item_id"`
+	Title        string   `json:"title,omitempty"`
+	OptionLabels []string `json:"option_labels,omitempty"`
+}
+
 func runSkillOptTrainStatus(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("skillopt train status", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	sessionID := fs.String("session", "", "train session id")
+	jsonOutput := fs.Bool("json", false, "print status as JSON")
+	verbose := fs.Bool("verbose", false, "include detailed progress and metadata")
+	watch := fs.Bool("watch", false, "refresh status until the session reaches a waiting or terminal phase")
+	poll := fs.Duration("poll", 2*time.Second, "watch poll interval")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -384,19 +494,63 @@ func runSkillOptTrainStatus(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "skillopt train status requires --session")
 		return 2
 	}
-	var session db.SkillOptTrainSession
-	var iteration *db.SkillOptTrainIteration
-	var counts skillopt.TrainStatusCounts
+	if *poll <= 0 {
+		fmt.Fprintln(stderr, "skillopt train status poll interval must be positive")
+		return 2
+	}
+	if *watch && *jsonOutput {
+		fmt.Fprintln(stderr, "skillopt train status does not support --watch with --json; use --watch for text refreshes or --json without --watch")
+		return 2
+	}
+	var snapshot skillOptTrainStatusSnapshot
 	if err := withStore(*home, func(store *db.Store) error {
-		var err error
-		session, iteration, counts, err = loadSkillOptTrainStatus(context.Background(), store, *sessionID)
-		return err
+		for {
+			loaded, err := loadSkillOptTrainStatusSnapshot(context.Background(), store, *sessionID, *verbose || *watch)
+			if err != nil {
+				return err
+			}
+			snapshot = loaded
+			outputSnapshot := skillOptTrainStatusOutputSnapshot(snapshot, *verbose)
+			if !*watch {
+				return nil
+			}
+			if *jsonOutput {
+				if err := writeJSON(stdout, outputSnapshot); err != nil {
+					return err
+				}
+			} else {
+				printSkillOptTrainStatusSnapshot(stdout, outputSnapshot, *verbose)
+				writeLine(stdout, "watch_state: %s", skillOptTrainWatchState(snapshot))
+			}
+			if skillOptTrainWatchDone(snapshot) {
+				return nil
+			}
+			time.Sleep(*poll)
+		}
 	}); err != nil {
 		fmt.Fprintf(stderr, "skillopt train status: %v\n", err)
 		return 1
 	}
-	printSkillOptTrainStatus(stdout, skillopt.BuildTrainStatusSummary(session, iteration, counts), counts)
+	if *watch {
+		return 0
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, skillOptTrainStatusOutputSnapshot(snapshot, *verbose)); err != nil {
+			fmt.Fprintf(stderr, "skillopt train status: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printSkillOptTrainStatusSnapshot(stdout, snapshot, *verbose)
 	return 0
+}
+
+func skillOptTrainStatusOutputSnapshot(snapshot skillOptTrainStatusSnapshot, verbose bool) skillOptTrainStatusSnapshot {
+	if verbose {
+		return snapshot
+	}
+	snapshot.Verbose = nil
+	return snapshot
 }
 
 func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
@@ -3509,6 +3663,343 @@ func loadSkillOptTrainStatusCounts(ctx context.Context, store *db.Store, runID s
 	}, nil
 }
 
+func loadSkillOptTrainStatusSnapshot(ctx context.Context, store *db.Store, sessionID string, verbose bool) (skillOptTrainStatusSnapshot, error) {
+	session, iteration, counts, err := loadSkillOptTrainStatus(ctx, store, sessionID)
+	if err != nil {
+		return skillOptTrainStatusSnapshot{}, err
+	}
+	summary := skillopt.BuildTrainStatusSummary(session, iteration, counts)
+	snapshot := buildSkillOptTrainStatusSnapshot(session, iteration, summary, counts)
+	if verbose {
+		details, err := buildSkillOptTrainStatusVerbose(ctx, store, session, iteration)
+		if err != nil {
+			return skillOptTrainStatusSnapshot{}, err
+		}
+		snapshot.Verbose = &details
+	}
+	return snapshot, nil
+}
+
+func buildSkillOptTrainStatusSnapshot(session db.SkillOptTrainSession, iteration *db.SkillOptTrainIteration, summary skillopt.TrainStatusSummary, counts skillopt.TrainStatusCounts) skillOptTrainStatusSnapshot {
+	policy := summary.PreviewPolicy
+	generatedOptions := 0
+	if iteration != nil {
+		generatedOptions = metadataNumber(decodedSkillOptMetadataValue(decodedSkillOptMetadata(iteration.MetadataJSON)["generation"]), "generated_options")
+	} else {
+		generatedOptions = metadataNumber(decodedSkillOptMetadataValue(decodedSkillOptMetadata(session.MetadataJSON)["generation"]), "generated_options")
+	}
+	currentStep := strings.TrimSpace(summary.BlockedStep)
+	if currentStep == "" {
+		currentStep = summary.CurrentPhase
+	}
+	return skillOptTrainStatusSnapshot{
+		SessionID:        summary.SessionID,
+		IterationID:      summary.IterationID,
+		TemplateID:       strings.TrimSpace(session.TemplateID),
+		TemplateVersion:  strings.TrimSpace(session.TemplateVersionID),
+		TargetRepo:       strings.TrimSpace(session.TargetRepo),
+		WorkspaceRepo:    strings.TrimSpace(session.WorkspaceRepo),
+		TaskKind:         strings.TrimSpace(session.TaskKind),
+		CurrentPhase:     summary.CurrentPhase,
+		CurrentStep:      currentStep,
+		CompletedSteps:   append([]string(nil), summary.CompletedSteps...),
+		BlockedStep:      summary.BlockedStep,
+		NextAction:       summary.NextAction,
+		IssueURL:         summary.IssueURL,
+		PullRequestURL:   summary.PullRequestURL,
+		CandidateVersion: summary.CandidateVersion,
+		PreviewPolicy: skillOptTrainPreviewPolicyJSON{
+			Mode:               policy.Mode,
+			Renderer:           policy.Renderer,
+			Publisher:          policy.Publisher,
+			Repo:               policy.Repo,
+			RouteTemplate:      policy.RouteTemplate,
+			ExpectedReviewRepo: policy.ExpectedReviewRepo,
+		},
+		Counts: skillOptTrainStatusCountsJSON{
+			ReviewItems:          counts.ReviewItems,
+			FeedbackEvents:       counts.FeedbackEvents,
+			RankedFeedbackEvents: counts.RankedFeedbackEvents,
+			PairwisePreferences:  counts.PairwisePreferences,
+		},
+		Progress: skillOptTrainStatusProgress{
+			ReviewItems:          counts.ReviewItems,
+			FeedbackEvents:       counts.FeedbackEvents,
+			RankedFeedbackEvents: counts.RankedFeedbackEvents,
+			PairwisePreferences:  counts.PairwisePreferences,
+			GeneratedOptions:     generatedOptions,
+			ETA:                  "unknown",
+		},
+	}
+}
+
+func buildSkillOptTrainStatusVerbose(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration *db.SkillOptTrainIteration) (skillOptTrainStatusVerbose, error) {
+	details := skillOptTrainStatusVerbose{
+		CreatedAt: session.CreatedAt,
+		UpdatedAt: session.UpdatedAt,
+		Elapsed:   skillOptElapsedText(session.CreatedAt),
+		Jobs:      skillOptTrainStatusJobs{},
+	}
+	statuses := map[string]string{}
+	addStatus := func(name string, metadata map[string]any) {
+		if status := metadataString(metadata, "status"); status != "" {
+			statuses[name] = status
+		}
+	}
+	statusMetadata := decodedSkillOptMetadata(session.MetadataJSON)
+	var iterationMetadata map[string]any
+	if iteration != nil {
+		iterationMetadata = decodedSkillOptMetadata(iteration.MetadataJSON)
+		statusMetadata = iterationMetadata
+	}
+	addStatus("generation", decodedSkillOptMetadataValue(statusMetadata["generation"]))
+	addStatus("review", decodedSkillOptMetadataValue(statusMetadata["review"]))
+	addStatus("feedback_sync", decodedSkillOptMetadataValue(statusMetadata["feedback_sync"]))
+	addStatus("optimizer", decodedSkillOptMetadataValue(statusMetadata["optimizer"]))
+	addStatus("candidate_import", decodedSkillOptMetadataValue(statusMetadata["candidate_import"]))
+	addStatus("candidate_review", decodedSkillOptMetadataValue(statusMetadata["candidate_review"]))
+	addStatus("candidate_decision", decodedSkillOptMetadataValue(statusMetadata["candidate_decision"]))
+	if len(statuses) > 0 {
+		details.MetadataStatus = statuses
+	}
+	if iteration == nil {
+		return details, nil
+	}
+	details.EvalRunID = strings.TrimSpace(iteration.EvalRunID)
+	details.BaseTemplateVersionID = strings.TrimSpace(iteration.BaseTemplateVersionID)
+	details.Mode = strings.TrimSpace(iteration.Mode)
+	details.ExplorationLevel = strings.TrimSpace(iteration.ExplorationLevel)
+	details.CreatedAt = iteration.CreatedAt
+	details.UpdatedAt = iteration.UpdatedAt
+	details.Elapsed = skillOptElapsedText(iteration.CreatedAt)
+	details.ReviewIssue = skillOptTrainStatusReviewIssue{
+		Repo:   strings.TrimSpace(iteration.IssueRepo),
+		Number: iteration.IssueNumber,
+		URL:    strings.TrimSpace(iteration.IssueURL),
+	}
+	candidateImport := decodedSkillOptMetadataValue(iterationMetadata["candidate_import"])
+	details.Candidate = skillOptTrainStatusCandidate{
+		VersionID:         strings.TrimSpace(iteration.CandidateVersionID),
+		PullRequestURL:    strings.TrimSpace(iteration.PullRequestURL),
+		NoCandidateReason: metadataString(candidateImport, "no_candidate_reason"),
+	}
+	if optimizer := decodedSkillOptMetadataValue(iterationMetadata["optimizer"]); len(optimizer) > 0 {
+		details.Optimizer = optimizer
+	}
+	activeLocks, err := skillOptTrainActiveLocks(ctx, store, session.ID, iteration.ID)
+	if err != nil {
+		return skillOptTrainStatusVerbose{}, err
+	}
+	details.ActiveLocks = activeLocks
+	jobs, err := skillOptTrainStatusJobSummary(ctx, store, iterationMetadata)
+	if err != nil {
+		return skillOptTrainStatusVerbose{}, err
+	}
+	details.Jobs = jobs
+	items, err := skillOptTrainStatusItems(ctx, store, iteration.EvalRunID)
+	if err != nil {
+		return skillOptTrainStatusVerbose{}, err
+	}
+	details.Items = items
+	return details, nil
+}
+
+func skillOptTrainActiveLocks(ctx context.Context, store *db.Store, sessionID string, iterationID string) ([]skillOptTrainStatusLock, error) {
+	candidates := []struct {
+		name string
+		key  string
+	}{
+		{name: "generation", key: skillOptTrainGenerationLockKey(sessionID, iterationID)},
+		{name: "review", key: skillOptTrainReviewLockKey(sessionID, iterationID)},
+		{name: "optimizer", key: skillOptTrainOptimizerLockKey(sessionID, iterationID)},
+		{name: "candidate_review", key: skillOptTrainCandidateReviewLockKey(sessionID, iterationID)},
+		{name: "start_next", key: skillOptTrainStartNextLockKey(sessionID)},
+	}
+	locks := []skillOptTrainStatusLock{}
+	now := time.Now().UTC()
+	for _, candidate := range candidates {
+		lock, err := store.GetResourceLock(ctx, candidate.key)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return nil, err
+		}
+		if !skillOptResourceLockActive(lock, now) {
+			continue
+		}
+		locks = append(locks, skillOptTrainStatusLock{
+			Name:       candidate.name,
+			Key:        lock.ResourceKey,
+			OwnerJobID: strings.TrimSpace(lock.OwnerJobID),
+			ExpiresAt:  strings.TrimSpace(lock.ExpiresAt),
+		})
+	}
+	return locks, nil
+}
+
+func skillOptResourceLockActive(lock db.ResourceLock, now time.Time) bool {
+	expiresAt := strings.TrimSpace(lock.ExpiresAt)
+	if expiresAt == "" {
+		return true
+	}
+	parsed, ok := parseSkillOptStatusTime(expiresAt)
+	if !ok {
+		return true
+	}
+	return parsed.After(now)
+}
+
+func skillOptTrainStatusJobSummary(ctx context.Context, store *db.Store, metadata map[string]any) (skillOptTrainStatusJobs, error) {
+	generation := decodedSkillOptMetadataValue(metadata["generation"])
+	jobIDs := metadataStringSlice(generation, "jobs")
+	summary := skillOptTrainStatusJobs{}
+	for _, jobID := range jobIDs {
+		job, err := store.GetJob(ctx, jobID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return skillOptTrainStatusJobs{}, err
+		}
+		summary.Total++
+		switch strings.TrimSpace(strings.ToLower(job.State)) {
+		case "queued":
+			summary.Queued++
+		case "running":
+			summary.Running++
+		case "succeeded":
+			summary.Succeeded++
+		case "failed":
+			summary.Failed++
+		default:
+			summary.Other++
+		}
+		summary.Items = append(summary.Items, skillOptTrainStatusJobRef{
+			ID:    strings.TrimSpace(job.ID),
+			Agent: strings.TrimSpace(job.Agent),
+			Type:  strings.TrimSpace(job.Type),
+			State: strings.TrimSpace(job.State),
+		})
+	}
+	return summary, nil
+}
+
+func skillOptTrainStatusItems(ctx context.Context, store *db.Store, runID string) ([]skillOptTrainStatusItem, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil, nil
+	}
+	run, err := store.GetEvalRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	rankedRun := skillOptRunUsesRankedOptions(run)
+	reviewItems, err := store.ListEvalReviewItems(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]skillOptTrainStatusItem, 0, len(reviewItems))
+	for _, item := range reviewItems {
+		statusItem := skillOptTrainStatusItem{
+			ItemID: strings.TrimSpace(item.ItemID),
+			Title:  strings.TrimSpace(item.Title),
+		}
+		options, err := store.ListEvalReviewOptions(ctx, runID, item.ItemID)
+		if err != nil {
+			return nil, err
+		}
+		for _, option := range options {
+			statusItem.OptionLabels = append(statusItem.OptionLabels, strings.ToUpper(strings.TrimSpace(option.Label)))
+		}
+		if len(statusItem.OptionLabels) == 0 && !rankedRun {
+			if strings.TrimSpace(item.BaselineArtifactID) != "" {
+				statusItem.OptionLabels = append(statusItem.OptionLabels, "BASELINE")
+			}
+			if strings.TrimSpace(item.CandidateArtifactID) != "" {
+				statusItem.OptionLabels = append(statusItem.OptionLabels, "CANDIDATE")
+			}
+			if len(statusItem.OptionLabels) == 0 {
+				statusItem.OptionLabels = append(statusItem.OptionLabels, "BASELINE", "CANDIDATE")
+			}
+		}
+		items = append(items, statusItem)
+	}
+	return items, nil
+}
+
+func metadataStringSlice(metadata map[string]any, key string) []string {
+	value, ok := metadata[key]
+	if !ok {
+		return nil
+	}
+	switch typed := value.(type) {
+	case []string:
+		return append([]string(nil), typed...)
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text := strings.TrimSpace(fmt.Sprint(item)); text != "" {
+				values = append(values, text)
+			}
+		}
+		return values
+	case string:
+		if strings.TrimSpace(typed) == "" {
+			return nil
+		}
+		return []string{strings.TrimSpace(typed)}
+	default:
+		return nil
+	}
+}
+
+func skillOptElapsedText(startedAt string) string {
+	started, ok := parseSkillOptStatusTime(startedAt)
+	if !ok {
+		return "unknown"
+	}
+	elapsed := time.Since(started)
+	if elapsed < 0 {
+		return "unknown"
+	}
+	return elapsed.Round(time.Second).String()
+}
+
+func parseSkillOptStatusTime(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05"} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func skillOptTrainWatchState(snapshot skillOptTrainStatusSnapshot) string {
+	if skillOptTrainWatchDone(snapshot) {
+		return "waiting"
+	}
+	return "active"
+}
+
+func skillOptTrainWatchDone(snapshot skillOptTrainStatusSnapshot) bool {
+	if skillopt.IsTerminalTrainState(snapshot.CurrentPhase) {
+		return true
+	}
+	if snapshot.Verbose == nil {
+		return true
+	}
+	if len(snapshot.Verbose.ActiveLocks) > 0 {
+		return false
+	}
+	return true
+}
+
 func printSkillOptTrainStatus(stdout io.Writer, summary skillopt.TrainStatusSummary, counts skillopt.TrainStatusCounts) {
 	writeLine(stdout, "session: %s", summary.SessionID)
 	writeLine(stdout, "iteration: %s", emptyText(summary.IterationID))
@@ -3528,6 +4019,53 @@ func printSkillOptTrainStatus(stdout io.Writer, summary skillopt.TrainStatusSumm
 	writeLine(stdout, "review_items: %d", counts.ReviewItems)
 	writeLine(stdout, "feedback: %d", summary.FeedbackCount)
 	writeLine(stdout, "pairwise_preferences: %d", counts.PairwisePreferences)
+}
+
+func printSkillOptTrainStatusSnapshot(stdout io.Writer, snapshot skillOptTrainStatusSnapshot, verbose bool) {
+	writeLine(stdout, "session: %s", snapshot.SessionID)
+	writeLine(stdout, "iteration: %s", emptyText(snapshot.IterationID))
+	writeLine(stdout, "preview_mode: %s", snapshot.PreviewPolicy.Mode)
+	writeLine(stdout, "preview_renderer: %s", snapshot.PreviewPolicy.Renderer)
+	writeLine(stdout, "preview_publisher: %s", snapshot.PreviewPolicy.Publisher)
+	writeLine(stdout, "preview_repo: %s", emptyText(snapshot.PreviewPolicy.Repo))
+	writeLine(stdout, "preview_route_template: %s", emptyText(snapshot.PreviewPolicy.RouteTemplate))
+	writeLine(stdout, "expected_review_repo: %s", emptyText(snapshot.PreviewPolicy.ExpectedReviewRepo))
+	writeLine(stdout, "current_phase: %s", snapshot.CurrentPhase)
+	writeLine(stdout, "completed_steps: %s", strings.Join(snapshot.CompletedSteps, ","))
+	writeLine(stdout, "blocked_step: %s", emptyText(snapshot.BlockedStep))
+	writeLine(stdout, "current_step: %s", snapshot.CurrentStep)
+	writeLine(stdout, "next_action: %s", snapshot.NextAction)
+	writeLine(stdout, "issue: %s", emptyText(snapshot.IssueURL))
+	writeLine(stdout, "pull_request: %s", emptyText(snapshot.PullRequestURL))
+	writeLine(stdout, "candidate: %s", emptyText(snapshot.CandidateVersion))
+	writeLine(stdout, "review_items: %d", snapshot.Counts.ReviewItems)
+	writeLine(stdout, "feedback: %d", snapshot.Counts.FeedbackEvents+snapshot.Counts.RankedFeedbackEvents)
+	writeLine(stdout, "pairwise_preferences: %d", snapshot.Counts.PairwisePreferences)
+	if !verbose || snapshot.Verbose == nil {
+		return
+	}
+	writeLine(stdout, "elapsed: %s", snapshot.Verbose.Elapsed)
+	writeLine(stdout, "eta: %s", snapshot.Progress.ETA)
+	writeLine(stdout, "generated_options: %d", snapshot.Progress.GeneratedOptions)
+	writeLine(stdout, "jobs_total: %d", snapshot.Verbose.Jobs.Total)
+	writeLine(stdout, "jobs_running: %d", snapshot.Verbose.Jobs.Running)
+	writeLine(stdout, "jobs_succeeded: %d", snapshot.Verbose.Jobs.Succeeded)
+	writeLine(stdout, "jobs_failed: %d", snapshot.Verbose.Jobs.Failed)
+	if snapshot.Verbose.EvalRunID != "" {
+		writeLine(stdout, "eval_run: %s", snapshot.Verbose.EvalRunID)
+	}
+	if snapshot.Verbose.Mode != "" {
+		writeLine(stdout, "mode: %s", snapshot.Verbose.Mode)
+	}
+	if snapshot.Verbose.ExplorationLevel != "" {
+		writeLine(stdout, "exploration_level: %s", snapshot.Verbose.ExplorationLevel)
+	}
+	if snapshot.Verbose.ReviewIssue.URL != "" {
+		writeLine(stdout, "review_issue: %s", snapshot.Verbose.ReviewIssue.URL)
+	}
+	if snapshot.Verbose.Candidate.NoCandidateReason != "" {
+		writeLine(stdout, "no_candidate_reason: %s", snapshot.Verbose.Candidate.NoCandidateReason)
+	}
 }
 
 func readSkillOptTrainRequest(requestText string, requestFile string) (string, error) {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -722,6 +722,83 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "status", "--home", home, "--session", "landing-train", "--json", "--verbose"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train status json exit code = %d, stderr=%s", code, stderr.String())
+	}
+	var statusJSON skillOptTrainStatusSnapshot
+	if err := json.Unmarshal(stdout.Bytes(), &statusJSON); err != nil {
+		t.Fatalf("train status json did not decode: %v\n%s", err, stdout.String())
+	}
+	if statusJSON.SessionID != "landing-train" ||
+		statusJSON.CurrentPhase != skillopt.TrainStateItemsReady ||
+		statusJSON.CurrentStep != skillopt.TrainStateOptionsGenerated ||
+		statusJSON.PreviewPolicy.ExpectedReviewRepo != "owner/previews" ||
+		statusJSON.Counts.ReviewItems != 2 ||
+		statusJSON.Progress.ETA != "unknown" ||
+		statusJSON.Verbose == nil ||
+		statusJSON.Verbose.EvalRunID != "landing-train-review-001" ||
+		len(statusJSON.Verbose.Items) != 2 {
+		t.Fatalf("train status json = %+v", statusJSON)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "status", "--home", home, "--session", "landing-train", "--watch", "--verbose", "--poll", "1ms"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train status watch exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: items_ready",
+		"current_step: options_generated",
+		"elapsed:",
+		"eta: unknown",
+		"watch_state: waiting",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train status watch stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "status", "--home", home, "--session", "landing-train", "--watch", "--json", "--poll", "1ms"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("train status watch json exit code = %d, want 2; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "does not support --watch with --json") {
+		t.Fatalf("train status watch json stderr = %q", stderr.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	lockExpiresAt := time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano)
+	if acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey: skillOptTrainGenerationLockKey("landing-train", "landing-train-001"),
+		OwnerJobID:  "test-generation",
+		OwnerToken:  "token-1",
+		ExpiresAt:   lockExpiresAt,
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	lockedStatus, err := loadSkillOptTrainStatusSnapshot(context.Background(), store, "landing-train", true)
+	if err != nil {
+		t.Fatalf("loadSkillOptTrainStatusSnapshot returned error: %v", err)
+	}
+	if lockedStatus.Verbose == nil || len(lockedStatus.Verbose.ActiveLocks) != 1 || lockedStatus.Verbose.ActiveLocks[0].Name != "generation" {
+		t.Fatalf("locked status active locks = %+v", lockedStatus.Verbose)
+	}
+	if skillOptTrainWatchDone(lockedStatus) {
+		t.Fatalf("watch marked locked status done: %+v", lockedStatus.Verbose.ActiveLocks)
+	}
+	if released, err := store.ReleaseResourceLock(context.Background(), skillOptTrainGenerationLockKey("landing-train", "landing-train-001"), "test-generation", "token-1"); err != nil || !released {
+		t.Fatalf("ReleaseResourceLock returned released=%v err=%v", released, err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after active lock test returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
 	code = Run([]string{"skillopt", "train", "stop", "--home", home, "--session", "landing-train", "--reason", "trial complete"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("train stop exit code = %d, stderr=%s", code, stderr.String())
@@ -784,6 +861,130 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	}
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close after terminal stop returned error: %v", err)
+	}
+}
+
+func TestSkillOptTrainStatusGeneratedProgressUsesCurrentIteration(t *testing.T) {
+	session := db.SkillOptTrainSession{
+		ID:           "landing-train",
+		State:        skillopt.TrainStateItemsReady,
+		MetadataJSON: `{"generation":{"status":"succeeded","generated_options":8}}`,
+	}
+	iteration := db.SkillOptTrainIteration{
+		ID:        "landing-train-002",
+		State:     skillopt.TrainStateItemsReady,
+		EvalRunID: "landing-train-review-002",
+	}
+	counts := skillopt.TrainStatusCounts{ReviewItems: 2}
+	summary := skillopt.BuildTrainStatusSummary(session, &iteration, counts)
+	snapshot := buildSkillOptTrainStatusSnapshot(session, &iteration, summary, counts)
+	if snapshot.Progress.GeneratedOptions != 0 {
+		t.Fatalf("generated options = %d, want 0 for current iteration without generation metadata", snapshot.Progress.GeneratedOptions)
+	}
+
+	iteration.MetadataJSON = `{"generation":{"status":"succeeded","generated_options":0}}`
+	summary = skillopt.BuildTrainStatusSummary(session, &iteration, counts)
+	snapshot = buildSkillOptTrainStatusSnapshot(session, &iteration, summary, counts)
+	if snapshot.Progress.GeneratedOptions != 0 {
+		t.Fatalf("generated options = %d, want explicit current iteration zero", snapshot.Progress.GeneratedOptions)
+	}
+
+	summary = skillopt.BuildTrainStatusSummary(session, nil, skillopt.TrainStatusCounts{})
+	snapshot = buildSkillOptTrainStatusSnapshot(session, nil, summary, skillopt.TrainStatusCounts{})
+	if snapshot.Progress.GeneratedOptions != 8 {
+		t.Fatalf("generated options = %d, want session fallback when no iteration exists", snapshot.Progress.GeneratedOptions)
+	}
+}
+
+func TestSkillOptTrainStatusVerboseUsesCurrentIterationMetadata(t *testing.T) {
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	session := db.SkillOptTrainSession{
+		ID:           "landing-train",
+		State:        skillopt.TrainStateItemsReady,
+		MetadataJSON: `{"generation":{"status":"running"}}`,
+	}
+	iteration := db.SkillOptTrainIteration{
+		ID:    "landing-train-002",
+		State: skillopt.TrainStateItemsReady,
+	}
+	details, err := buildSkillOptTrainStatusVerbose(context.Background(), store, session, &iteration)
+	if err != nil {
+		t.Fatalf("buildSkillOptTrainStatusVerbose returned error: %v", err)
+	}
+	if len(details.MetadataStatus) != 0 {
+		t.Fatalf("metadata status = %+v, want current iteration metadata without stale session generation", details.MetadataStatus)
+	}
+
+	iteration.MetadataJSON = `{"review":{"status":"publishing"}}`
+	details, err = buildSkillOptTrainStatusVerbose(context.Background(), store, session, &iteration)
+	if err != nil {
+		t.Fatalf("buildSkillOptTrainStatusVerbose with iteration metadata returned error: %v", err)
+	}
+	if details.MetadataStatus["review"] != "publishing" || details.MetadataStatus["generation"] != "" {
+		t.Fatalf("metadata status = %+v, want current iteration review only", details.MetadataStatus)
+	}
+
+	details, err = buildSkillOptTrainStatusVerbose(context.Background(), store, session, nil)
+	if err != nil {
+		t.Fatalf("buildSkillOptTrainStatusVerbose without iteration returned error: %v", err)
+	}
+	if details.MetadataStatus["generation"] != "running" {
+		t.Fatalf("metadata status = %+v, want session fallback without iteration", details.MetadataStatus)
+	}
+}
+
+func TestSkillOptTrainStatusItemsReportsABLabels(t *testing.T) {
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:           "landing-train-review-001",
+		Mode:         db.EvalRunModeValidate,
+		OptionsCount: 2,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:               "landing-train-review-001",
+		ItemID:              "item-001",
+		Title:               "Landing page",
+		BaselineArtifactID:  "artifact-baseline",
+		CandidateArtifactID: "artifact-candidate",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	items, err := skillOptTrainStatusItems(ctx, store, "landing-train-review-001")
+	if err != nil {
+		t.Fatalf("skillOptTrainStatusItems returned error: %v", err)
+	}
+	if len(items) != 1 || strings.Join(items[0].OptionLabels, ",") != "BASELINE,CANDIDATE" {
+		t.Fatalf("items = %+v, want A/B option labels", items)
+	}
+}
+
+func TestSkillOptTrainWatchDoneIgnoresStaleMetadataWithoutActiveLock(t *testing.T) {
+	snapshot := skillOptTrainStatusSnapshot{
+		CurrentPhase: skillopt.TrainStateOptionsGenerated,
+		Verbose: &skillOptTrainStatusVerbose{
+			MetadataStatus: map[string]string{"review": "publishing"},
+		},
+	}
+	if !skillOptTrainWatchDone(snapshot) {
+		t.Fatalf("watch treated stale metadata as active: %+v", snapshot.Verbose.MetadataStatus)
+	}
+
+	snapshot.Verbose.ActiveLocks = []skillOptTrainStatusLock{{Name: "review", Key: "skillopt-train-review:landing-train:landing-train-001"}}
+	if skillOptTrainWatchDone(snapshot) {
+		t.Fatalf("watch ignored active lock: %+v", snapshot.Verbose.ActiveLocks)
 	}
 }
 


### PR DESCRIPTION
## WHAT

Adds richer train status output for SkillOpt training loops:
- `gitmoot skillopt train status --json`
- `gitmoot skillopt train status --verbose`
- `gitmoot skillopt train status --watch`
- `--poll <duration>` for watch refresh cadence

## WHY

The train loop needs an operator-visible status surface that shows whether it is generating options, publishing reviews, waiting for feedback, optimizing, creating candidate reviews, or blocked by active work. This makes the training flow easier to follow without opening the database or guessing from issue state.

## CHANGES

- Adds a structured status snapshot with phase, current step, counts, preview policy, progress, ETA, verbose review/candidate/job/item/lock details.
- Adds watch mode that keeps polling while active train resource locks exist and exits once the session is waiting or terminal.
- Rejects `--watch --json` to avoid emitting multiple top-level JSON documents.
- Reports active train locks for generation, review publishing, optimizer, candidate review publishing, and start-next.
- Uses current iteration metadata for progress/status so stale previous iteration/session metadata does not confuse output.
- Includes A/B labels for validate-mode review items in verbose status.
- Adds focused coverage for JSON output, watch behavior, stale metadata handling, active locks, current-iteration generated progress, and A/B labels.

## RESULTS

Passed locally:
- `git diff --check`
- `GOTOOLCHAIN=go1.26.0 go test -timeout 300s ./internal/cli -run 'TestSkillOptTrain(StartStatusAndStop|StatusGeneratedProgressUsesCurrentIteration|StatusVerboseUsesCurrentIterationMetadata|StatusItemsReportsABLabels|WatchDoneIgnoresStaleMetadataWithoutActiveLock)'`
- `GOTOOLCHAIN=go1.26.0 go test -timeout 300s ./internal/cli ./internal/db`

Independent review also passed changed-area checks:
- `GOCACHE=/tmp/go-build /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/cli -run SkillOptTrain`
- `GOCACHE=/tmp/go-build /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.2.linux-amd64/bin/go test ./internal/skillopt ./internal/db`

Review attempted a full `./internal/cli` run, but it failed on an unrelated environment socket-permission case:
- `TestAgentTemplateValidateRejectsNonRegularFile`: `listen unix .../template.sock: setsockopt: operation not permitted`

Raw final review output:
```text
No discrete correctness issues were found in the current changes. Focused SkillOpt train and related internal package tests pass in the local checkout.
No discrete correctness issues were found in the current changes. Focused SkillOpt train and related internal package tests pass in the local checkout.
```

## RISK

Low to medium. This is mostly additive CLI/status behavior, but it reads several train/eval/job/lock tables and could expose stale metadata if future train phases write new keys without updating the status snapshot mapping.