### PR TITLE
docs: document skillopt evaluator and training status flow

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -147,6 +147,10 @@ The imported package must have:
 Importing never promotes a candidate. Gitmoot stores it as a pending template
 version so later review and promotion commands can decide whether it becomes
 current.
+If `eval_report` or `summary.metadata` marks `promotable: false` with
+`no_candidate_reason`, or if the candidate content hash matches the base
+version, Gitmoot rejects the import as `optimizer produced no candidate` instead
+of creating a fake pending version.
 If `artifacts` is present, `--artifact-dir` is required. Gitmoot rejects
 absolute paths, path traversal, missing files, hash mismatches, duplicate
 artifact ids, and invalid `summary.diff_artifact_id` references before creating
@@ -458,12 +462,14 @@ Complete local review path:
 Complete train-mode path:
 
 1. `gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file items.yml --yes`
-2. `gitmoot skillopt train continue --session <session-id>` to generate options and publish the review packet.
-3. Human feedback is imported from the review surface.
-4. `gitmoot skillopt train continue --session <session-id>` to export the package, run `gitmoot-skillopt`, and import the pending candidate.
-5. `gitmoot skillopt train continue --session <session-id>` to publish candidate review context.
-6. `gitmoot skillopt train continue --session <session-id> --promote <version>` or `--reject <version> --reason <text>`.
-7. `gitmoot skillopt train continue --session <session-id> --start-next` only after the prior iteration is resolved.
+2. `gitmoot skillopt train status --session <session-id> --json --verbose` or `--watch` to inspect live phase, item progress, active locks, review issue, candidate, and next action.
+3. `gitmoot skillopt train continue --session <session-id>` to generate options and publish the review packet.
+4. Human feedback is imported from raw or fenced YAML comments; `train continue` auto-syncs GitHub comments when the review is published and feedback is missing.
+5. Evaluator profiles run cheap artifact checks first, optional render adapters second, and LLM judges last. Structured failures flow into optimizer input with reasons, hints, evidence, failed checks, and stage status.
+6. `gitmoot skillopt train continue --session <session-id>` to export the package, run `gitmoot-skillopt`, and import the pending candidate, or record `optimizer_completed_no_candidate` if the optimizer produced no promotable content.
+7. `gitmoot skillopt train continue --session <session-id>` to publish candidate review context with separate selection score, evaluator/test scores, gate status, no-op status, and promotability.
+8. `gitmoot skillopt train continue --session <session-id> --promote <version>` or `--reject <version> --reason <text>`.
+9. `gitmoot skillopt train continue --session <session-id> --start-next` only after the prior iteration is resolved.
 
 Complete GitHub review path:
 

--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -58,7 +58,15 @@ Inspect progress at any point:
 
 ```sh
 gitmoot skillopt train status --session planner-train
+gitmoot skillopt train status --session planner-train --verbose
+gitmoot skillopt train status --session planner-train --json --verbose
+gitmoot skillopt train status --session planner-train --watch --poll 5s
 ```
+
+Verbose status separates the current phase, current step, review issue,
+candidate state, active generation/review/optimizer locks, item progress, and
+next action. JSON output is for automation. Watch mode is text-only and exits
+when the session is waiting for human input or terminal.
 
 Advance the next required step:
 
@@ -132,6 +140,14 @@ scores come from the evaluator result artifacts produced by
 `gitmoot-skillopt`; if the evaluator is missing, fails, or returns invalid
 JSON, the gate is blocked instead of treating the result as a numeric loss.
 
+Evaluator profiles describe the artifact contract and evaluation stages for a
+task. The landing-page profile uses cheap-first checks: validate the Vue/Vite
+bundle contract, optionally run a render smoke adapter, and call the LLM judge
+only after those checks pass. Failed checks produce structured failure packets
+with `primary_reason`, `optimizer_hint`, failed checks, evidence, and stage
+status so the optimizer can update the skill from the failure class instead of
+only seeing a zero score.
+
 ## Review And Feedback
 
 `train continue` generates options through Gitmoot-managed temporary agents,
@@ -159,6 +175,11 @@ Low-level `skillopt feedback github publish` and `sync` enforce
 `review.expected_repo` for train runs. If a preview train expects
 `owner/previews`, publishing or syncing against `owner/product` fails instead of
 posting to the wrong repository.
+
+Review issues include a fenced `yaml` block so reviewers can copy, edit, and
+submit parseable feedback. `train continue` automatically syncs GitHub comments
+when the iteration is waiting in `review_published` and no feedback has been
+imported yet. Raw YAML and fenced YAML are both supported.
 
 Reviewers can provide ranked feedback with optional quality and phase hints:
 
@@ -202,8 +223,9 @@ After feedback sync, `train continue` exports the training package, invokes the
 configured `gitmoot-skillopt optimize` command, imports the returned candidate
 package through the shared candidate validator, and leaves the candidate
 pending. Use `--dry-run` only on a disposable or reset train session to validate
-the package and optimizer command shape without model calls; dry-runs still
-import a candidate and advance the iteration to candidate review.
+the package and optimizer command shape without model calls. If the dry-run
+returns unchanged baseline content, Gitmoot records
+`optimizer_completed_no_candidate` instead of publishing a candidate review.
 
 ```sh
 gitmoot skillopt train continue \
@@ -238,13 +260,22 @@ Before training starts, `gitmoot-skillopt` preflights the optimizer, target, and
 evaluator. The canaries must prove the target can return the exact requested
 text and that the evaluator can return structured hard/soft JSON. Optimizer
 failures record blocked status and do not promote or partially install
-candidate templates.
+candidate templates. If the optimizer selects the unchanged baseline, accepts no
+prompt edit, or returns content with the same hash as the base template, Gitmoot
+records `optimizer_completed_no_candidate` with `no_candidate_reason` and does
+not create or publish a pending candidate review.
 
 ## Candidate Review And Next Iteration
 
-The candidate review step publishes the candidate summary, eval report, template
-diff, preview/PR links when available, and copyable decision commands. Promote
-or reject explicitly:
+The candidate review step publishes the candidate summary, template diff,
+preview/PR links when available, and copyable decision commands. It separates
+selection score, evaluator/test scores, gate status, no-op status, and
+promotability so a candidate selected by the optimizer is not confused with a
+candidate that passed evaluator gates. If stored metadata marks the candidate as
+no-op or not promotable, the review body says promotion is unavailable instead
+of showing a promote command.
+
+Promote or reject explicitly:
 
 ```sh
 gitmoot skillopt train continue --session planner-train --promote planner@v2
@@ -285,9 +316,24 @@ calls or real GitHub mutation.
 - Missing preview links: confirm the run has `--preview-repo`, the preview repo
   checkout is registered with `gitmoot repo add`, and the generated option
   output type is compatible with the current `vue-vite` renderer.
+- Missing feedback import: reply with the fenced YAML block from the review
+  issue or raw YAML. Then rerun `gitmoot skillopt train continue --session
+  <id>`; it will attempt GitHub sync and report parse/import failures.
+- Invalid YAML: status output names wrong `run_id`, missing item feedback,
+  invalid ranking, unknown option, invalid signal values, no parseable YAML, or
+  no comments.
+- No candidate created: inspect `no_candidate_reason` in `train status
+  --verbose`; usually the optimizer kept the initial skill, accepted no update,
+  or produced content with the same hash as the base version.
+- Render adapter unavailable: install the profile's render dependency or run a
+  profile/config that does not require render smoke. Required render profiles
+  fail before the LLM judge so the optimizer receives a structured blocker.
 - Missing evaluator: pass `--evaluator-id landing_page_v1` for landing-page
   runs. Text-only flows can rely on the package evaluator config or the default
   LLM judge.
+- Evaluator skipped: check the evaluator profile and artifact contract. Cheap
+  checks can intentionally skip expensive render/LLM stages after a hard
+  contract failure.
 - Invalid evaluator JSON: fix the evaluator prompt/model/backend and rerun
   `train continue`. Invalid hard/soft scores are blockers, not candidate
   rejections.

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -12,6 +12,7 @@ import (
 	neturl "net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1783,9 +1784,7 @@ func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, sess
 	if summary := strings.TrimSpace(review.PreferenceSummary); summary != "" {
 		fmt.Fprintf(&builder, "\n### Candidate Summary\n%s\n", summary)
 	}
-	if review.Score != nil {
-		fmt.Fprintf(&builder, "\nScore: `%s`\n", scoreText(review.Score))
-	}
+	skillOptWriteCandidateReviewScores(&builder, review)
 	if strings.TrimSpace(session.PreviewRepo) != "" {
 		fmt.Fprintf(&builder, "\nPreview repo: `%s`\n", session.PreviewRepo)
 	}
@@ -1803,10 +1802,209 @@ func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, sess
 	}
 	builder.WriteString("\n### Decision\n")
 	usesCustomHome := strings.TrimSpace(commandHome) != ""
-	fmt.Fprintf(&builder, "- Promote: `%s`\n", skillOptTrainCandidateDecisionCommand(usesCustomHome, session.ID, "--promote", candidateID, false))
+	promotable, reason := skillOptCandidateReviewPromotability(review)
+	if promotable {
+		fmt.Fprintf(&builder, "- Promote: `%s`\n", skillOptTrainCandidateDecisionCommand(usesCustomHome, session.ID, "--promote", candidateID, false))
+	} else {
+		fmt.Fprintf(&builder, "- Promote: unavailable because %s.\n", reason)
+	}
 	fmt.Fprintf(&builder, "- Reject: `%s`\n", skillOptTrainCandidateDecisionCommand(usesCustomHome, session.ID, "--reject", candidateID, true))
 	fmt.Fprintf(&builder, "- Continue: `%s` after promote/reject completes.\n", skillOptTrainStartNextCommand(usesCustomHome, session.ID))
 	return builder.String(), nil
+}
+
+func skillOptWriteCandidateReviewScores(builder *strings.Builder, review db.AgentTemplateCandidateReview) {
+	evalReport := decodedSkillOptMetadata(review.EvalReportJSON)
+	summaryMetadata := decodedSkillOptMetadata(review.SummaryMetadataJSON)
+	builder.WriteString("\n### Scores And Gate\n")
+	fmt.Fprintf(builder, "- Selection score: `%s`\n", scoreText(review.Score))
+	skillOptWriteCandidateReviewScoreLine(builder, "Best selection hard", metadataFloatPtr(evalReport, "best_selection_hard"))
+	skillOptWriteCandidateReviewScoreLine(builder, "Best selection soft", metadataFloatPtr(evalReport, "best_selection_soft"))
+	skillOptWriteCandidateReviewScoreLine(builder, "Baseline selection hard", metadataFloatPtr(evalReport, "baseline_selection_hard"))
+	skillOptWriteCandidateReviewScoreLine(builder, "Baseline selection soft", metadataFloatPtr(evalReport, "baseline_selection_soft"))
+	if score := metadataFloatPtr(evalReport, "score"); score != nil {
+		fmt.Fprintf(builder, "- Test score: `%s`\n", scoreText(score))
+	} else {
+		builder.WriteString("- Test score: `-`\n")
+	}
+	if hard := metadataFloatPtr(evalReport, "hard"); hard != nil {
+		fmt.Fprintf(builder, "- Hard score: `%s`\n", scoreText(hard))
+	}
+	if soft := metadataFloatPtr(evalReport, "soft"); soft != nil {
+		fmt.Fprintf(builder, "- Soft score: `%s`\n", scoreText(soft))
+	}
+	skillOptWriteCandidateReviewScoreLine(builder, "Test hard", metadataFloatPtr(evalReport, "test_hard"))
+	skillOptWriteCandidateReviewScoreLine(builder, "Test soft", metadataFloatPtr(evalReport, "test_soft"))
+	skillOptWriteCandidateReviewScoreLine(builder, "Baseline test hard", metadataFloatPtr(evalReport, "baseline_test_hard"))
+	skillOptWriteCandidateReviewScoreLine(builder, "Baseline test soft", metadataFloatPtr(evalReport, "baseline_test_soft"))
+	if dimensions := metadataScoreMap(evalReport, "dimension_scores"); len(dimensions) > 0 {
+		labels := make([]string, 0, len(dimensions))
+		for label := range dimensions {
+			labels = append(labels, label)
+		}
+		sort.Strings(labels)
+		parts := make([]string, 0, len(labels))
+		for _, label := range labels {
+			score := dimensions[label]
+			parts = append(parts, fmt.Sprintf("%s=%s", label, scoreText(&score)))
+		}
+		fmt.Fprintf(builder, "- Dimension scores: `%s`\n", strings.Join(parts, ", "))
+	}
+	fmt.Fprintf(builder, "- Gate status: `%s`\n", firstNonEmpty(
+		metadataString(evalReport, "gate_status"),
+		metadataString(evalReport, "gate"),
+		metadataString(summaryMetadata, "gate_status"),
+		metadataString(summaryMetadata, "gate"),
+		"unknown",
+	))
+	fmt.Fprintf(builder, "- No-op status: `%s`\n", skillOptCandidateReviewNoOpStatus(evalReport, summaryMetadata))
+	promotable, reason := skillOptCandidateReviewPromotability(review)
+	if promotable {
+		builder.WriteString("- Promotability: `promotable`\n")
+	} else {
+		fmt.Fprintf(builder, "- Promotability: `not promotable: %s`\n", reason)
+	}
+}
+
+func skillOptWriteCandidateReviewScoreLine(builder *strings.Builder, label string, score *float64) {
+	if score != nil {
+		fmt.Fprintf(builder, "- %s: `%s`\n", label, scoreText(score))
+	}
+}
+
+func skillOptCandidateReviewPromotability(review db.AgentTemplateCandidateReview) (bool, string) {
+	for _, metadata := range []map[string]any{
+		decodedSkillOptMetadata(review.EvalReportJSON),
+		decodedSkillOptMetadata(review.SummaryMetadataJSON),
+	} {
+		if promotable := metadataBoolPtr(metadata, "promotable"); promotable != nil && !*promotable {
+			reason := metadataString(metadata, "no_candidate_reason")
+			if reason == "" {
+				reason = metadataString(metadata, "promotability_reason")
+			}
+			if reason == "" {
+				reason = metadataString(metadata, "reason")
+			}
+			if reason == "" {
+				reason = skillOptCandidateReviewNoOpMetadataReason(metadata)
+			}
+			if reason == "" {
+				reason = "candidate metadata marks it as not promotable"
+			}
+			return false, reason
+		}
+		if skillOptCandidateReviewExplicitPromotable(metadata) {
+			continue
+		}
+		if reason := metadataString(metadata, "no_candidate_reason"); reason != "" {
+			return false, reason
+		}
+		if reason := skillOptCandidateReviewNoOpMetadataReason(metadata); reason != "" {
+			return false, reason
+		}
+	}
+	return true, ""
+}
+
+func skillOptCandidateReviewNoOpStatus(evalReport map[string]any, summaryMetadata map[string]any) string {
+	for _, metadata := range []map[string]any{evalReport, summaryMetadata} {
+		if skillOptCandidateReviewExplicitPromotable(metadata) {
+			continue
+		}
+		if reason := metadataString(metadata, "no_candidate_reason"); reason != "" {
+			return "blocked: " + reason
+		}
+	}
+	for _, metadata := range []map[string]any{summaryMetadata, evalReport} {
+		if skillOptCandidateReviewExplicitPromotable(metadata) {
+			continue
+		}
+		if reason := skillOptCandidateReviewNoOpMetadataReason(metadata); reason != "" {
+			return "blocked: " + reason
+		}
+	}
+	bestOrigin := firstNonEmpty(metadataString(summaryMetadata, "best_origin"), metadataString(evalReport, "best_origin"))
+	totalAccepts := firstNonEmpty(metadataString(summaryMetadata, "total_accepts"), metadataString(evalReport, "total_accepts"))
+	if bestOrigin != "" || totalAccepts != "" {
+		parts := []string{"not detected"}
+		if bestOrigin != "" {
+			parts = append(parts, "best_origin="+bestOrigin)
+		}
+		if totalAccepts != "" {
+			parts = append(parts, "total_accepts="+totalAccepts)
+		}
+		return strings.Join(parts, "; ")
+	}
+	return "not reported"
+}
+
+func skillOptCandidateReviewExplicitPromotable(metadata map[string]any) bool {
+	promotable := metadataBoolPtr(metadata, "promotable")
+	return promotable != nil && *promotable
+}
+
+func skillOptCandidateReviewNoOpMetadataReason(metadata map[string]any) string {
+	if strings.EqualFold(metadataString(metadata, "best_origin"), "initial_skill") {
+		return "best_origin_initial_skill"
+	}
+	if metadataString(metadata, "total_accepts") == "0" {
+		return "total_accepts_zero"
+	}
+	return ""
+}
+
+func metadataFloatPtr(metadata map[string]any, key string) *float64 {
+	switch value := metadata[key].(type) {
+	case float64:
+		return &value
+	case int:
+		score := float64(value)
+		return &score
+	case int64:
+		score := float64(value)
+		return &score
+	case json.Number:
+		if score, err := value.Float64(); err == nil {
+			return &score
+		}
+	case string:
+		if score, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil {
+			return &score
+		}
+	}
+	return nil
+}
+
+func metadataBoolPtr(metadata map[string]any, key string) *bool {
+	switch value := metadata[key].(type) {
+	case bool:
+		return &value
+	case string:
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "true", "yes":
+			parsed := true
+			return &parsed
+		case "false", "no":
+			parsed := false
+			return &parsed
+		}
+	}
+	return nil
+}
+
+func metadataScoreMap(metadata map[string]any, key string) map[string]float64 {
+	raw, ok := metadata[key].(map[string]any)
+	if !ok {
+		return nil
+	}
+	scores := map[string]float64{}
+	for label, value := range raw {
+		nested := map[string]any{"score": value}
+		if score := metadataFloatPtr(nested, "score"); score != nil {
+			scores[strings.TrimSpace(label)] = *score
+		}
+	}
+	return scores
 }
 
 func skillOptCandidateReviewArtifactIDs(review db.AgentTemplateCandidateReview) []string {
@@ -1880,6 +2078,11 @@ func decideSkillOptTrainCandidate(ctx context.Context, store *db.Store, session 
 	if candidateID != "" && candidateID != expected {
 		return skillOptTrainCandidateDecisionResult{}, fmt.Errorf("candidate %s does not match train iteration candidate %s", candidateID, expected)
 	}
+	if decision == "promoted" {
+		if err := validateSkillOptTrainCandidatePromotableForDecision(ctx, store, candidateID); err != nil {
+			return skillOptTrainCandidateDecisionResult{}, err
+		}
+	}
 	if decision == "" {
 		return syncSkillOptTrainCandidateDecision(ctx, store, session, iteration, expected, "", "")
 	}
@@ -1914,6 +2117,21 @@ func decideSkillOptTrainCandidate(ctx context.Context, store *db.Store, session 
 		return skillOptTrainCandidateDecisionResult{}, err
 	}
 	return skillOptTrainCandidateDecisionResult{Decided: true, Decision: decision, CandidateVersionID: candidateID}, nil
+}
+
+func validateSkillOptTrainCandidatePromotableForDecision(ctx context.Context, store *db.Store, candidateID string) error {
+	review, err := store.GetAgentTemplateCandidateReview(ctx, candidateID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("load candidate review %s: %w", candidateID, err)
+	}
+	promotable, reason := skillOptCandidateReviewPromotability(review)
+	if promotable {
+		return nil
+	}
+	return fmt.Errorf("candidate %s is not promotable: %s", candidateID, reason)
 }
 
 func syncSkillOptTrainCandidateDecision(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, candidateID string, expectedDecision string, fallbackReason string) (skillOptTrainCandidateDecisionResult, error) {
@@ -5063,6 +5281,9 @@ func metadataString(metadata map[string]any, key string) string {
 	}
 	value, ok := metadata[key]
 	if !ok {
+		return ""
+	}
+	if value == nil {
 		return ""
 	}
 	return strings.TrimSpace(fmt.Sprint(value))

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2939,8 +2939,13 @@ func TestSkillOptTrainContinuePublishesCandidateReviewPromotesAndStartsNext(t *t
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close after options count update returned error: %v", err)
 	}
+	candidatePackage := cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with candidate review guidance.")
+	selectionScore := 0.73
+	candidatePackage.Summary.Score = &selectionScore
+	candidatePackage.Summary.Metadata = json.RawMessage(`{"best_origin":"candidate","total_accepts":2,"promotable":true,"no_candidate_reason":null}`)
+	candidatePackage.EvalReport = json.RawMessage(`{"score":0.86,"hard":0.91,"soft":0.84,"best_selection_hard":0.77,"best_selection_soft":0.78,"baseline_selection_hard":0.55,"baseline_selection_soft":0.56,"test_hard":0.72,"test_soft":0.74,"baseline_test_hard":0.5,"baseline_test_soft":0.52,"dimension_scores":{"hero_quality":0.8},"gate_status":"passed","promotable":true,"no_candidate_reason":"stale_non_blocking_reason"}`)
 	runner := &skillOptTrainFakeOptimizerRunner{
-		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with candidate review guidance."),
+		candidate: candidatePackage,
 	}
 	previousRunner := skillOptTrainOptimizerRunner
 	skillOptTrainOptimizerRunner = runner
@@ -3057,6 +3062,23 @@ func TestSkillOptTrainContinuePublishesCandidateReviewPromotesAndStartsNext(t *t
 		"SkillOpt Candidate Review",
 		"### Artifacts",
 		"`candidate-diff`",
+		"### Scores And Gate",
+		"Selection score: `0.73`",
+		"Best selection hard: `0.77`",
+		"Best selection soft: `0.78`",
+		"Baseline selection hard: `0.55`",
+		"Baseline selection soft: `0.56`",
+		"Test score: `0.86`",
+		"Hard score: `0.91`",
+		"Soft score: `0.84`",
+		"Test hard: `0.72`",
+		"Test soft: `0.74`",
+		"Baseline test hard: `0.5`",
+		"Baseline test soft: `0.52`",
+		"Dimension scores: `hero_quality=0.8`",
+		"Gate status: `passed`",
+		"No-op status: `not detected; best_origin=candidate; total_accepts=2`",
+		"Promotability: `promotable`",
 		"planner@v2",
 		skillOptTrainCandidateDecisionCommand(true, "optimizer-train", "--promote", "planner@v2", false),
 		skillOptTrainCandidateDecisionCommand(true, "optimizer-train", "--reject", "planner@v2", true),
@@ -3462,6 +3484,94 @@ func TestSkillOptTrainContinueRequiresReasonForExternalCandidateRejection(t *tes
 	}
 	if latest.ID != "optimizer-train-002" || latest.BaseTemplateVersionID != baseVersionID || latest.State != skillopt.TrainStateItemsReady {
 		t.Fatalf("latest iteration = %+v", latest)
+	}
+}
+
+func TestSkillOptTrainCandidateReviewBodyMarksNoOpNotPromotable(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	candidate := cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with a changed candidate.")
+	version, err := skillopt.ImportCandidatePackage(context.Background(), store, candidate, "candidate.json")
+	if err != nil {
+		t.Fatalf("ImportCandidatePackage returned error: %v", err)
+	}
+	review, err := store.GetAgentTemplateCandidateReview(context.Background(), version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview returned error: %v", err)
+	}
+	review.EvalReportJSON = `{"score":0,"hard":0,"soft":0,"gate_status":"blocked","promotable":false,"no_candidate_reason":"best_origin_initial_skill"}`
+	review.SummaryMetadataJSON = `{"best_origin":"initial_skill","total_accepts":0,"promotable":false,"no_candidate_reason":"best_origin_initial_skill"}`
+	if err := store.UpsertAgentTemplateCandidateReview(context.Background(), review); err != nil {
+		t.Fatalf("UpsertAgentTemplateCandidateReview returned error: %v", err)
+	}
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	body, err := skillOptTrainCandidateReviewBody(context.Background(), store, session, db.SkillOptTrainIteration{
+		ID:                    "optimizer-train-001",
+		CandidateVersionID:    version.ID,
+		BaseTemplateVersionID: baseVersionID,
+	}, home)
+	if err != nil {
+		t.Fatalf("skillOptTrainCandidateReviewBody returned error: %v", err)
+	}
+	for _, want := range []string{
+		"### Scores And Gate",
+		"Test score: `0`",
+		"Hard score: `0`",
+		"Soft score: `0`",
+		"Gate status: `blocked`",
+		"No-op status: `blocked: best_origin_initial_skill`",
+		"Promotability: `not promotable: best_origin_initial_skill`",
+		"Promote: unavailable because best_origin_initial_skill.",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("candidate review body missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "--promote "+version.ID) {
+		t.Fatalf("candidate review body exposed promote command for no-op metadata:\n%s", body)
+	}
+	_, err = decideSkillOptTrainCandidate(context.Background(), store, session, db.SkillOptTrainIteration{
+		ID:                 "optimizer-train-001",
+		State:              skillopt.TrainStateCandidateReviewPublished,
+		CandidateVersionID: version.ID,
+	}, skillOptTrainContinueRequest{PromoteCandidate: version.ID})
+	if err == nil || !strings.Contains(err.Error(), "candidate planner@v2 is not promotable: best_origin_initial_skill") {
+		t.Fatalf("decideSkillOptTrainCandidate promote error = %v", err)
+	}
+	blockedVersion, err := store.GetAgentTemplateVersionByID(context.Background(), version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID after blocked promote returned error: %v", err)
+	}
+	if blockedVersion.State != "pending" {
+		t.Fatalf("blocked promote changed version state = %+v", blockedVersion)
+	}
+
+	review.EvalReportJSON = `{"score":0,"hard":0,"soft":0,"gate_status":"blocked"}`
+	review.SummaryMetadataJSON = `{"best_origin":"initial_skill","total_accepts":0}`
+	if err := store.UpsertAgentTemplateCandidateReview(context.Background(), review); err != nil {
+		t.Fatalf("UpsertAgentTemplateCandidateReview without reason returned error: %v", err)
+	}
+	body, err = skillOptTrainCandidateReviewBody(context.Background(), store, session, db.SkillOptTrainIteration{
+		ID:                    "optimizer-train-001",
+		CandidateVersionID:    version.ID,
+		BaseTemplateVersionID: baseVersionID,
+	}, home)
+	if err != nil {
+		t.Fatalf("skillOptTrainCandidateReviewBody without reason returned error: %v", err)
+	}
+	for _, want := range []string{
+		"No-op status: `blocked: best_origin_initial_skill`",
+		"Promotability: `not promotable: best_origin_initial_skill`",
+		"Promote: unavailable because best_origin_initial_skill.",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("candidate review body without reason missing %q:\n%s", want, body)
+		}
 	}
 }
 

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -35,7 +35,10 @@ frontmatter, matching metadata, an optional eval report, an optional summary,
 and optional artifact manifest entries. When artifact entries are present,
 `--artifact-dir` is required; Gitmoot verifies relative paths and SHA256 hashes,
 stores the blobs, and registers artifact metadata before creating the pending
-candidate. Importing never promotes it automatically.
+candidate. Importing never promotes it automatically. If the eval report or
+summary metadata marks `promotable: false` with `no_candidate_reason`, or if the
+candidate content hash matches the base version, Gitmoot rejects the package as
+no candidate instead of creating a fake pending version.
 
 ```sh
 gitmoot skillopt candidate list --template planner
@@ -47,6 +50,11 @@ gitmoot skillopt candidate reject planner@v3 --reason "Too broad"
 `candidate show` includes the eval report, preference summary, and content diff.
 Promotion updates the current template version; rejection records an audit reason
 and keeps the rejected version out of `@latest`.
+
+Train-mode candidate reviews separate selection score, evaluator/test scores,
+gate status, no-op status, and promotability. Review bodies do not show a
+promote command when stored metadata marks a candidate as no-op or not
+promotable.
 
 ## Human Feedback Trial Happy Path
 

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -44,9 +44,16 @@ gate, and next action without writing state.
 
 ```sh
 gitmoot skillopt train status --session planner-train
+gitmoot skillopt train status --session planner-train --json --verbose
+gitmoot skillopt train status --session planner-train --watch --poll 5s
 gitmoot skillopt train continue --session planner-train
 gitmoot skillopt train stop --session planner-train --reason "Request changed"
 ```
+
+Verbose status reports the current phase, step, review issue, candidate state,
+active work locks, item progress, and next action. JSON output is for
+automation; watch mode is text-only and exits when the session waits for human
+input or reaches a terminal phase.
 
 The item file is YAML or JSON:
 
@@ -99,8 +106,10 @@ gitmoot skillopt train continue --session planner-train
 
 Low-level GitHub feedback publish/sync commands enforce the train run's
 expected review repo, so preview reviews cannot accidentally publish to the
-target product repo. Reviewers can use ranked feedback with optional quality and
-phase hints:
+target product repo. Review issues include a fenced `yaml` block for copyable
+feedback, and `train continue` auto-syncs GitHub comments when the review is
+published and no feedback has been imported yet. Reviewers can use ranked
+feedback with optional quality and phase hints:
 
 ```yaml
 run_id: planner-train-review-001
@@ -122,7 +131,20 @@ After feedback sync, train mode exports the training package, invokes
 candidate validator, and leaves the candidate pending. Use optimizer `--dry-run`
 flags to validate command shape without model calls.
 
-## Candidate Decision
+Evaluator profiles define artifact contracts and stages. Landing-page runs use
+cheap-first Vue/Vite checks, optional render smoke, and then the LLM judge.
+Structured failures include reasons, optimizer hints, failed checks, evidence,
+and stage status so the optimizer can update the skill from failure classes. If
+the optimizer returns the unchanged baseline, accepts no prompt edit, or returns
+the same content hash, Gitmoot records `optimizer_completed_no_candidate` and
+does not publish a candidate review.
+
+## Candidate Review And Decision
+
+Candidate reviews separate selection score, evaluator/test scores, gate status,
+no-op status, and promotability. If metadata marks the candidate as no-op or not
+promotable, the review says promotion is unavailable instead of showing a
+promote command.
 
 Promote or reject explicitly:
 
@@ -146,3 +168,17 @@ The smoke script runs focused CLI tests with fake managed generation, fake
 preview publication, fake `gitmoot-skillopt`, and fake GitHub publication. It
 covers preview blocking, review-repo enforcement, the train loop, and candidate
 decisions without real model calls or real GitHub mutation.
+
+## Troubleshooting
+
+- Missing feedback import: reply with the fenced YAML block or raw YAML, then
+  rerun `gitmoot skillopt train continue --session <id>` to auto-sync comments.
+- Invalid YAML: sync output reports wrong `run_id`, missing item feedback,
+  invalid ranking, unknown option, invalid signal value, no parseable YAML, or
+  no comments.
+- No candidate created: inspect `no_candidate_reason` with `train status
+  --verbose`.
+- Render adapter unavailable: install the required render dependency or use a
+  profile that does not require render smoke.
+- Evaluator skipped: cheap hard checks can intentionally stop render/LLM stages
+  after an artifact-contract failure.


### PR DESCRIPTION
## WHAT

Updates Task 9 behavior and documentation for SkillOpt candidate reviews and the training-loop UX.

## WHY

Candidate reviews needed to expose selection scores, evaluator/test scores, gate state, no-op state, and promotability separately. The docs also needed to make the new evaluator/profile, feedback sync, status/watch, and no-op guardrails discoverable.

## CHANGES

- Candidate review bodies now include a `Scores And Gate` section with selection, test/evaluator, dimension, gate, no-op, and promotability fields.
- Review text suppresses the copied promote command when stored candidate review metadata marks a candidate no-op or not promotable.
- Train promotion now enforces the same promotability check, so a manually typed `--promote` cannot bypass the review gate.
- Metadata parsing treats JSON `null` values as absent and mirrors the import contract where explicit `promotable: true` overrides stale no-candidate reasons from that metadata source.
- Docs and website docs now cover evaluator profiles, cheap-first checks, structured failures, feedback sync formatting, train status/watch, no-op guardrails, candidate review score separation, and troubleshooting.

## RESULTS

Passed locally:
- `git diff --check`
- `rg -n 'dry-runs still|optimizer_completed_no_candidate|fenced `yaml`|Scores And Gate|Promotability|no_candidate_reason' docs/skillopt-train-workflow.md docs/skillopt-exchange-contract.md website/docs/workflows/skillopt-train-workflow.md website/docs/reference/skillopt-exchange-contract.md internal/cli/skillopt_test.go`
- `GOTOOLCHAIN=go1.26.0 go test -timeout 300s ./internal/cli -run 'TestSkillOptTrainContinuePublishesCandidateReview(PromotesAndStartsNext|AndRejects|ToExistingPullRequest)|TestSkillOptTrainCandidateReviewBodyMarksNoOpNotPromotable'`
- `GOTOOLCHAIN=go1.26.0 go test -timeout 300s ./internal/cli ./internal/skillopt`

Raw final review output:
```text
No discrete correctness issues were found in the reviewed changes. The new review formatting and promotion guardrails appear consistent with the existing SkillOpt no-candidate metadata behavior.
No discrete correctness issues were found in the reviewed changes. The new review formatting and promotion guardrails appear consistent with the existing SkillOpt no-candidate metadata behavior.
```

## RISK

Low to medium. This changes candidate-review presentation and train promotion behavior when no-op/not-promotable metadata exists. The guard is intentionally aligned with the candidate import contract and covered by focused tests.