### PR TITLE
skillopt: preserve ranked review reasoning

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -76,6 +76,8 @@ role, and optional metadata such as preview URLs. Ranked feedback exports:
 - `winner`: optional first-place option
 - `useful_traits`: JSON object keyed by canonical option label
 - `rejected_traits`: JSON object keyed by canonical option label
+- `required_improvements`: JSON array of requested improvements not tied to one
+  option
 - `reasoning`: reviewer notes
 
 Derived `pairwise_preferences` are provided so an optimizer can use simple
@@ -350,6 +352,9 @@ items:
     rejected_traits:
       B:
         - too generic for a developer tool
+    required_improvements:
+      - better mobile layout
+      - stronger product visuals
     reasoning: C is clearest overall, but A has the better visual identity.
 ```
 

--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -198,6 +198,9 @@ items:
     rejected_traits:
       B:
         - too vague about rollback
+    required_improvements:
+      - clearer owner handoff
+      - stronger rollout checks
     reasoning: C is strongest, but A has a better risk summary.
 ```
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -281,21 +281,22 @@ type FeedbackEvent struct {
 }
 
 type RankedFeedbackEvent struct {
-	ID                 string
-	RunID              string
-	ItemID             string
-	RankingJSON        string
-	Winner             string
-	UsefulTraitsJSON   string
-	RejectedTraitsJSON string
-	Quality            string
-	ContinueMode       string
-	Promote            string
-	Reasoning          string
-	Reviewer           string
-	Source             string
-	SourceURL          string
-	CreatedAt          string
+	ID                       string
+	RunID                    string
+	ItemID                   string
+	RankingJSON              string
+	Winner                   string
+	UsefulTraitsJSON         string
+	RejectedTraitsJSON       string
+	RequiredImprovementsJSON string
+	Quality                  string
+	ContinueMode             string
+	Promote                  string
+	Reasoning                string
+	Reviewer                 string
+	Source                   string
+	SourceURL                string
+	CreatedAt                string
 }
 
 type PairwisePreference struct {
@@ -2664,15 +2665,16 @@ func (s *Store) UpsertRankedFeedbackEvent(ctx context.Context, event RankedFeedb
 	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO ranked_feedback_events(
 			id, run_id, item_id, ranking_json, winner, useful_traits_json, rejected_traits_json,
-			quality, continue_mode, promote, reasoning, reviewer, source, source_url, created_at
+			required_improvements_json, quality, continue_mode, promote, reasoning, reviewer, source, source_url, created_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(run_id, item_id, reviewer, source, source_url) DO UPDATE SET
 			id = excluded.id,
 			ranking_json = excluded.ranking_json,
 			winner = excluded.winner,
 			useful_traits_json = excluded.useful_traits_json,
 			rejected_traits_json = excluded.rejected_traits_json,
+			required_improvements_json = excluded.required_improvements_json,
 			quality = excluded.quality,
 			continue_mode = excluded.continue_mode,
 			promote = excluded.promote,
@@ -2681,7 +2683,7 @@ func (s *Store) UpsertRankedFeedbackEvent(ctx context.Context, event RankedFeedb
 			source = excluded.source,
 			source_url = excluded.source_url,
 			created_at = excluded.created_at`,
-		event.ID, event.RunID, event.ItemID, event.RankingJSON, event.Winner, event.UsefulTraitsJSON, event.RejectedTraitsJSON,
+		event.ID, event.RunID, event.ItemID, event.RankingJSON, event.Winner, event.UsefulTraitsJSON, event.RejectedTraitsJSON, event.RequiredImprovementsJSON,
 		event.Quality, event.ContinueMode, event.Promote, event.Reasoning, event.Reviewer, event.Source, event.SourceURL, event.CreatedAt)
 	return err
 }
@@ -2782,6 +2784,13 @@ func normalizeRankedFeedbackEvent(event RankedFeedbackEvent) (RankedFeedbackEven
 	}
 	event.UsefulTraitsJSON = strings.TrimSpace(event.UsefulTraitsJSON)
 	event.RejectedTraitsJSON = strings.TrimSpace(event.RejectedTraitsJSON)
+	event.RequiredImprovementsJSON = strings.TrimSpace(event.RequiredImprovementsJSON)
+	if event.RequiredImprovementsJSON != "" {
+		var decoded any
+		if err := json.Unmarshal([]byte(event.RequiredImprovementsJSON), &decoded); err != nil {
+			return RankedFeedbackEvent{}, fmt.Errorf("ranked feedback required_improvements_json must be valid JSON: %w", err)
+		}
+	}
 	event.Quality = normalizeRankedFeedbackQuality(event.Quality)
 	if event.Quality == "__invalid__" {
 		return RankedFeedbackEvent{}, errors.New("ranked feedback quality must be one of poor, acceptable, or strong")
@@ -2870,7 +2879,7 @@ func rankedFeedbackRanking(event RankedFeedbackEvent) ([]string, error) {
 
 func (s *Store) ListRankedFeedbackEvents(ctx context.Context, runID string) ([]RankedFeedbackEvent, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, run_id, item_id, ranking_json, winner, useful_traits_json, rejected_traits_json,
-			quality, continue_mode, promote, reasoning, reviewer, source, source_url, created_at
+			required_improvements_json, quality, continue_mode, promote, reasoning, reviewer, source, source_url, created_at
 		FROM ranked_feedback_events WHERE run_id = ? ORDER BY item_id, reviewer, source, source_url`, strings.TrimSpace(runID))
 	if err != nil {
 		return nil, err
@@ -2890,7 +2899,7 @@ func (s *Store) ListRankedFeedbackEvents(ctx context.Context, runID string) ([]R
 func scanRankedFeedbackEvent(row interface{ Scan(dest ...any) error }) (RankedFeedbackEvent, error) {
 	var event RankedFeedbackEvent
 	if err := row.Scan(&event.ID, &event.RunID, &event.ItemID, &event.RankingJSON, &event.Winner, &event.UsefulTraitsJSON, &event.RejectedTraitsJSON,
-		&event.Quality, &event.ContinueMode, &event.Promote, &event.Reasoning, &event.Reviewer, &event.Source, &event.SourceURL, &event.CreatedAt); err != nil {
+		&event.RequiredImprovementsJSON, &event.Quality, &event.ContinueMode, &event.Promote, &event.Reasoning, &event.Reviewer, &event.Source, &event.SourceURL, &event.CreatedAt); err != nil {
 		return RankedFeedbackEvent{}, err
 	}
 	return event, nil
@@ -3858,5 +3867,8 @@ CREATE TABLE skillopt_train_iterations (
 ALTER TABLE ranked_feedback_events ADD COLUMN quality TEXT NOT NULL DEFAULT '';
 ALTER TABLE ranked_feedback_events ADD COLUMN continue_mode TEXT NOT NULL DEFAULT '';
 ALTER TABLE ranked_feedback_events ADD COLUMN promote TEXT NOT NULL DEFAULT '';
+	`,
+	`
+ALTER TABLE ranked_feedback_events ADD COLUMN required_improvements_json TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -356,21 +356,23 @@ func TestRankedReviewStorageAndPairwisePreferences(t *testing.T) {
 	rejected, _ := json.Marshal(map[string][]string{
 		"b": {"generic"},
 	})
+	required, _ := json.Marshal([]string{"stronger visuals", "better mobile"})
 	event := RankedFeedbackEvent{
-		RunID:              "run-ranked",
-		ItemID:             "item-001",
-		RankingJSON:        string(ranking),
-		Winner:             "c",
-		UsefulTraitsJSON:   string(useful),
-		RejectedTraitsJSON: string(rejected),
-		Quality:            "Poor",
-		ContinueMode:       "Explore",
-		Promote:            "false",
-		Reasoning:          "C is clearest.",
-		Reviewer:           "jerry",
-		Source:             "github",
-		SourceURL:          "https://github.com/example/repo/pull/1#issuecomment-1",
-		CreatedAt:          "2026-06-02T10:00:00Z",
+		RunID:                    "run-ranked",
+		ItemID:                   "item-001",
+		RankingJSON:              string(ranking),
+		Winner:                   "c",
+		UsefulTraitsJSON:         string(useful),
+		RejectedTraitsJSON:       string(rejected),
+		RequiredImprovementsJSON: string(required),
+		Quality:                  "Poor",
+		ContinueMode:             "Explore",
+		Promote:                  "false",
+		Reasoning:                "C is clearest.",
+		Reviewer:                 "jerry",
+		Source:                   "github",
+		SourceURL:                "https://github.com/example/repo/pull/1#issuecomment-1",
+		CreatedAt:                "2026-06-02T10:00:00Z",
 	}
 	if err := store.UpsertRankedFeedbackEvent(ctx, event); err != nil {
 		t.Fatalf("UpsertRankedFeedbackEvent returned error: %v", err)
@@ -384,6 +386,9 @@ func TestRankedReviewStorageAndPairwisePreferences(t *testing.T) {
 	}
 	if stored[0].Quality != "poor" || stored[0].ContinueMode != "explore" || stored[0].Promote != "no" {
 		t.Fatalf("stored ranked feedback signals = %+v", stored[0])
+	}
+	if !strings.Contains(stored[0].RequiredImprovementsJSON, "stronger visuals") || !strings.Contains(stored[0].RequiredImprovementsJSON, "better mobile") {
+		t.Fatalf("stored required improvements = %s", stored[0].RequiredImprovementsJSON)
 	}
 	pairs, err := store.ListPairwisePreferences(ctx, "run-ranked")
 	if err != nil {

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -674,6 +674,23 @@ func trimTraitMap(values map[string][]string) map[string][]string {
 	return trimmed
 }
 
+func trimStringList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			trimmed = append(trimmed, value)
+		}
+	}
+	if len(trimmed) == 0 {
+		return nil
+	}
+	return trimmed
+}
+
 func cloneTraitMap(values map[string][]string) map[string][]string {
 	if len(values) == 0 {
 		return nil

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -456,7 +456,7 @@ func TestGitHubCollectorSyncImportsRankedYAMLCommentWithColonItemID(t *testing.T
 	fake := &fakeFeedbackGitHub{
 		comments: map[int64][]github.IssueComment{
 			42: {
-				{ID: 1, Body: "```yaml\nrun_id: ranked-1\nitems:\n  - item_id: scenario:landing\n    ranking:\n      - C > A > D > B\n    quality: poor\n    continue_mode: explore\n    promote: no\n    reasoning: option c is strongest\n```\n", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-06-02T10:00:00Z"},
+				{ID: 1, Body: "```yaml\nrun_id: ranked-1\nitems:\n  - item_id: scenario:landing\n    ranking:\n      - C > A > D > B\n    quality: poor\n    continue_mode: explore\n    promote: no\n    choice: option c is strongest, but improve mobile and visuals\n    required_improvements:\n      - better mobile layout\n      - stronger product visuals\n```\n", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-06-02T10:00:00Z"},
 			},
 		},
 	}
@@ -474,6 +474,9 @@ func TestGitHubCollectorSyncImportsRankedYAMLCommentWithColonItemID(t *testing.T
 	}
 	if result.RankedFeedbackEvents[0].Quality != "poor" || result.RankedFeedbackEvents[0].ContinueMode != "explore" || result.RankedFeedbackEvents[0].Promote != "no" {
 		t.Fatalf("ranked event signals = %+v", result.RankedFeedbackEvents[0])
+	}
+	if !strings.Contains(result.RankedFeedbackEvents[0].Reasoning, "improve mobile") || !strings.Contains(result.RankedFeedbackEvents[0].RequiredImprovementsJSON, "stronger product visuals") {
+		t.Fatalf("ranked event reasoning/improvements = %+v", result.RankedFeedbackEvents[0])
 	}
 }
 

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -55,16 +55,17 @@ type feedbackFile struct {
 }
 
 type feedbackFileEntry struct {
-	ItemID         string              `yaml:"item_id"`
-	Choice         string              `yaml:"choice"`
-	Ranking        []string            `yaml:"ranking,omitempty"`
-	Winner         string              `yaml:"winner,omitempty"`
-	UsefulTraits   map[string][]string `yaml:"useful_traits,omitempty"`
-	RejectedTraits map[string][]string `yaml:"rejected_traits,omitempty"`
-	Quality        string              `yaml:"quality"`
-	ContinueMode   string              `yaml:"continue_mode"`
-	Promote        string              `yaml:"promote"`
-	Reasoning      string              `yaml:"reasoning,omitempty"`
+	ItemID               string              `yaml:"item_id"`
+	Choice               string              `yaml:"choice"`
+	Ranking              []string            `yaml:"ranking,omitempty"`
+	Winner               string              `yaml:"winner,omitempty"`
+	UsefulTraits         map[string][]string `yaml:"useful_traits,omitempty"`
+	RejectedTraits       map[string][]string `yaml:"rejected_traits,omitempty"`
+	RequiredImprovements []string            `yaml:"required_improvements,omitempty"`
+	Quality              string              `yaml:"quality"`
+	ContinueMode         string              `yaml:"continue_mode"`
+	Promote              string              `yaml:"promote"`
+	Reasoning            string              `yaml:"reasoning,omitempty"`
 }
 
 type ImportResult struct {
@@ -494,6 +495,10 @@ func rankedFeedbackEventFromEntry(runID string, itemID string, entry feedbackFil
 	if err != nil {
 		return db.RankedFeedbackEvent{}, fmt.Errorf("rejected_traits: %w", err)
 	}
+	requiredImprovementsJSON, err := rankedStringListJSON(entry.RequiredImprovements)
+	if err != nil {
+		return db.RankedFeedbackEvent{}, fmt.Errorf("required_improvements: %w", err)
+	}
 	winner := normalizeReviewOptionLabel(entry.Winner)
 	if winner == "" {
 		winner = ranking[0]
@@ -510,20 +515,21 @@ func rankedFeedbackEventFromEntry(runID string, itemID string, entry feedbackFil
 		return db.RankedFeedbackEvent{}, err
 	}
 	return db.RankedFeedbackEvent{
-		RunID:              strings.TrimSpace(runID),
-		ItemID:             strings.TrimSpace(itemID),
-		RankingJSON:        string(rankingJSON),
-		Winner:             winner,
-		UsefulTraitsJSON:   usefulTraitsJSON,
-		RejectedTraitsJSON: rejectedTraitsJSON,
-		Quality:            quality,
-		ContinueMode:       continueMode,
-		Promote:            promote,
-		Reasoning:          strings.TrimSpace(entry.Reasoning),
-		Reviewer:           strings.TrimSpace(reviewer),
-		Source:             strings.TrimSpace(source),
-		SourceURL:          strings.TrimSpace(sourceURL),
-		CreatedAt:          strings.TrimSpace(createdAt),
+		RunID:                    strings.TrimSpace(runID),
+		ItemID:                   strings.TrimSpace(itemID),
+		RankingJSON:              string(rankingJSON),
+		Winner:                   winner,
+		UsefulTraitsJSON:         usefulTraitsJSON,
+		RejectedTraitsJSON:       rejectedTraitsJSON,
+		RequiredImprovementsJSON: requiredImprovementsJSON,
+		Quality:                  quality,
+		ContinueMode:             continueMode,
+		Promote:                  promote,
+		Reasoning:                rankedFeedbackReasoning(entry),
+		Reviewer:                 strings.TrimSpace(reviewer),
+		Source:                   strings.TrimSpace(source),
+		SourceURL:                strings.TrimSpace(sourceURL),
+		CreatedAt:                strings.TrimSpace(createdAt),
 	}, nil
 }
 
@@ -612,6 +618,29 @@ func rankedTraitJSON(traits map[string][]string) (string, error) {
 		return "", err
 	}
 	return string(content), nil
+}
+
+func rankedStringListJSON(values []string) (string, error) {
+	values = trimStringList(values)
+	if len(values) == 0 {
+		return "", nil
+	}
+	content, err := json.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func rankedFeedbackReasoning(entry feedbackFileEntry) string {
+	reasoning := strings.TrimSpace(entry.Reasoning)
+	if reasoning != "" {
+		return reasoning
+	}
+	if len(entry.Ranking) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(entry.Choice)
 }
 
 func normalizeReviewOptionLabel(label string) string {
@@ -869,6 +898,7 @@ func normalizeFeedbackFileEntries(feedback *feedbackFile) {
 		feedback.Items[index].Winner = strings.TrimSpace(feedback.Items[index].Winner)
 		feedback.Items[index].UsefulTraits = trimTraitMap(feedback.Items[index].UsefulTraits)
 		feedback.Items[index].RejectedTraits = trimTraitMap(feedback.Items[index].RejectedTraits)
+		feedback.Items[index].RequiredImprovements = trimStringList(feedback.Items[index].RequiredImprovements)
 		feedback.Items[index].Quality = strings.TrimSpace(feedback.Items[index].Quality)
 		feedback.Items[index].ContinueMode = strings.TrimSpace(feedback.Items[index].ContinueMode)
 		feedback.Items[index].Promote = strings.TrimSpace(feedback.Items[index].Promote)

--- a/internal/feedback/markdown_test.go
+++ b/internal/feedback/markdown_test.go
@@ -174,10 +174,13 @@ items:
     rejected_traits:
       B:
         - too generic
+    required_improvements:
+      - stronger branding
+      - richer animation
     quality: poor
     continue_mode: explore
     promote: no
-    reasoning: C explains the product best.
+    choice: C explains the product best and still needs more visual polish.
 `
 	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackContent), 0o644); err != nil {
 		t.Fatalf("write feedback.yml: %v", err)
@@ -193,7 +196,7 @@ items:
 	if err != nil {
 		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
 	}
-	if len(stored) != 1 || stored[0].Winner != "c" || stored[0].Reasoning != "C explains the product best." || stored[0].Source != SourceMarkdown {
+	if len(stored) != 1 || stored[0].Winner != "c" || stored[0].Reasoning != "C explains the product best and still needs more visual polish." || stored[0].Source != SourceMarkdown {
 		t.Fatalf("stored ranked events = %+v", stored)
 	}
 	if stored[0].Quality != "poor" || stored[0].ContinueMode != "explore" || stored[0].Promote != "no" {
@@ -201,6 +204,9 @@ items:
 	}
 	if !strings.Contains(stored[0].UsefulTraitsJSON, `"a":["visual style"]`) || !strings.Contains(stored[0].RejectedTraitsJSON, `"b":["too generic"]`) {
 		t.Fatalf("stored traits useful=%s rejected=%s", stored[0].UsefulTraitsJSON, stored[0].RejectedTraitsJSON)
+	}
+	if !strings.Contains(stored[0].RequiredImprovementsJSON, "stronger branding") || !strings.Contains(stored[0].RequiredImprovementsJSON, "richer animation") {
+		t.Fatalf("stored required improvements = %s", stored[0].RequiredImprovementsJSON)
 	}
 	pairs, err := store.ListPairwisePreferences(ctx, "ranked-1")
 	if err != nil {

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -157,21 +157,22 @@ type FeedbackEvent struct {
 }
 
 type RankedFeedbackEvent struct {
-	ID             string          `json:"id"`
-	RunID          string          `json:"run_id"`
-	ItemID         string          `json:"item_id"`
-	Ranking        []string        `json:"ranking"`
-	Winner         string          `json:"winner,omitempty"`
-	UsefulTraits   json.RawMessage `json:"useful_traits,omitempty"`
-	RejectedTraits json.RawMessage `json:"rejected_traits,omitempty"`
-	Quality        string          `json:"quality,omitempty"`
-	ContinueMode   string          `json:"continue_mode,omitempty"`
-	Promote        string          `json:"promote,omitempty"`
-	Reasoning      string          `json:"reasoning,omitempty"`
-	Reviewer       string          `json:"reviewer"`
-	Source         string          `json:"source"`
-	SourceURL      string          `json:"source_url,omitempty"`
-	CreatedAt      string          `json:"created_at"`
+	ID                   string          `json:"id"`
+	RunID                string          `json:"run_id"`
+	ItemID               string          `json:"item_id"`
+	Ranking              []string        `json:"ranking"`
+	Winner               string          `json:"winner,omitempty"`
+	UsefulTraits         json.RawMessage `json:"useful_traits,omitempty"`
+	RejectedTraits       json.RawMessage `json:"rejected_traits,omitempty"`
+	RequiredImprovements json.RawMessage `json:"required_improvements,omitempty"`
+	Quality              string          `json:"quality,omitempty"`
+	ContinueMode         string          `json:"continue_mode,omitempty"`
+	Promote              string          `json:"promote,omitempty"`
+	Reasoning            string          `json:"reasoning,omitempty"`
+	Reviewer             string          `json:"reviewer"`
+	Source               string          `json:"source"`
+	SourceURL            string          `json:"source_url,omitempty"`
+	CreatedAt            string          `json:"created_at"`
 }
 
 type PairwisePreference struct {
@@ -777,22 +778,27 @@ func loadRankedFeedbackEvents(ctx context.Context, store *db.Store, runID string
 		if err != nil {
 			return nil, fmt.Errorf("ranked feedback %s rejected_traits_json: %w", event.ID, err)
 		}
+		requiredImprovements, err := rawJSON(event.RequiredImprovementsJSON)
+		if err != nil {
+			return nil, fmt.Errorf("ranked feedback %s required_improvements_json: %w", event.ID, err)
+		}
 		output = append(output, RankedFeedbackEvent{
-			ID:             event.ID,
-			RunID:          event.RunID,
-			ItemID:         event.ItemID,
-			Ranking:        ranking,
-			Winner:         event.Winner,
-			UsefulTraits:   usefulTraits,
-			RejectedTraits: rejectedTraits,
-			Quality:        event.Quality,
-			ContinueMode:   event.ContinueMode,
-			Promote:        event.Promote,
-			Reasoning:      event.Reasoning,
-			Reviewer:       event.Reviewer,
-			Source:         event.Source,
-			SourceURL:      event.SourceURL,
-			CreatedAt:      event.CreatedAt,
+			ID:                   event.ID,
+			RunID:                event.RunID,
+			ItemID:               event.ItemID,
+			Ranking:              ranking,
+			Winner:               event.Winner,
+			UsefulTraits:         usefulTraits,
+			RejectedTraits:       rejectedTraits,
+			RequiredImprovements: requiredImprovements,
+			Quality:              event.Quality,
+			ContinueMode:         event.ContinueMode,
+			Promote:              event.Promote,
+			Reasoning:            event.Reasoning,
+			Reviewer:             event.Reviewer,
+			Source:               event.Source,
+			SourceURL:            event.SourceURL,
+			CreatedAt:            event.CreatedAt,
 		})
 	}
 	return output, nil

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -344,21 +344,26 @@ func TestExportTrainingPackageIncludesRankedExplorationFeedback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal rejected traits: %v", err)
 	}
+	required, err := json.Marshal([]string{"stronger visual identity", "responsive hero"})
+	if err != nil {
+		t.Fatalf("marshal required improvements: %v", err)
+	}
 	if err := store.UpsertRankedFeedbackEvent(ctx, db.RankedFeedbackEvent{
-		RunID:              "ranked-1",
-		ItemID:             "item-001",
-		RankingJSON:        string(ranking),
-		Winner:             "c",
-		UsefulTraitsJSON:   string(useful),
-		RejectedTraitsJSON: string(rejected),
-		Quality:            "acceptable",
-		ContinueMode:       db.EvalRunModeRefine,
-		Promote:            "no",
-		Reasoning:          "C is the clearest direction.",
-		Reviewer:           "jerry",
-		Source:             "github",
-		SourceURL:          "https://github.com/owner/repo/issues/1#issuecomment-1",
-		CreatedAt:          "2026-06-02T10:00:00Z",
+		RunID:                    "ranked-1",
+		ItemID:                   "item-001",
+		RankingJSON:              string(ranking),
+		Winner:                   "c",
+		UsefulTraitsJSON:         string(useful),
+		RejectedTraitsJSON:       string(rejected),
+		RequiredImprovementsJSON: string(required),
+		Quality:                  "acceptable",
+		ContinueMode:             db.EvalRunModeRefine,
+		Promote:                  "no",
+		Reasoning:                "C is the clearest direction.",
+		Reviewer:                 "jerry",
+		Source:                   "github",
+		SourceURL:                "https://github.com/owner/repo/issues/1#issuecomment-1",
+		CreatedAt:                "2026-06-02T10:00:00Z",
 	}); err != nil {
 		t.Fatalf("UpsertRankedFeedbackEvent returned error: %v", err)
 	}
@@ -382,6 +387,9 @@ func TestExportTrainingPackageIncludesRankedExplorationFeedback(t *testing.T) {
 	}
 	if !strings.Contains(string(pkg.RankedFeedbackEvents[0].UsefulTraits), "clearest explanation") || !strings.Contains(string(pkg.RankedFeedbackEvents[0].RejectedTraits), "too generic") {
 		t.Fatalf("ranked traits useful=%s rejected=%s", pkg.RankedFeedbackEvents[0].UsefulTraits, pkg.RankedFeedbackEvents[0].RejectedTraits)
+	}
+	if !strings.Contains(string(pkg.RankedFeedbackEvents[0].RequiredImprovements), "stronger visual identity") || !strings.Contains(string(pkg.RankedFeedbackEvents[0].RequiredImprovements), "responsive hero") {
+		t.Fatalf("ranked required improvements = %s", pkg.RankedFeedbackEvents[0].RequiredImprovements)
 	}
 	if pkg.RankedFeedbackEvents[0].Quality != "acceptable" || pkg.RankedFeedbackEvents[0].ContinueMode != db.EvalRunModeRefine || pkg.RankedFeedbackEvents[0].Promote != "no" {
 		t.Fatalf("ranked feedback signals = %+v", pkg.RankedFeedbackEvents[0])


### PR DESCRIPTION
## What
Preserve long ranked-review text and structured improvement asks through Gitmoot feedback import, storage, and SkillOpt training export.

## Why
Human review YAML often puts detailed ranked feedback in `choice:` because that is the field users naturally fill in. Before this change, ranked imports only exported explicit `reasoning`, so important feedback could be dropped before the optimizer saw it.

## Changes
- Use ranked `choice` as preserved `reasoning` when `reasoning` is empty.
- Add `required_improvements` to ranked YAML import, DB storage, and exported `training.json` ranked feedback events.
- Preserve useful traits, rejected traits, required improvements, and reviewer reasoning in the SkillOpt package.
- Add a backward-compatible migration for existing `ranked_feedback_events` tables.
- Update docs and examples for the new ranked feedback field.

## Results
- `GOTOOLCHAIN=go1.26.2 go test ./internal/feedback ./internal/skillopt ./internal/db`
- `git diff --check`
- `codex exec review --uncommitted`

Independent review output:

```text
No correctness issues were found in the reviewed changes. Focused tests for internal/db, internal/feedback, and internal/skillopt passed with Go 1.26.2.
```

## Risk
Low. The migration is additive, the new YAML field is optional, and existing A/B feedback behavior is unchanged.
