### PR TITLE
skillopt: split evaluator contract and quality signals

### DIFF
--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -103,15 +103,18 @@ type EvaluatorFailurePacket struct {
 }
 
 type EvaluatorScore struct {
-	ProfileID       string                  `json:"profile_id,omitempty"`
-	TaskKind        string                  `json:"task_kind,omitempty"`
-	Hard            *float64                `json:"hard,omitempty"`
-	Soft            *float64                `json:"soft,omitempty"`
-	DimensionScores map[string]float64      `json:"dimension_scores,omitempty"`
-	FailReason      string                  `json:"fail_reason,omitempty"`
-	Failure         *EvaluatorFailurePacket `json:"failure,omitempty"`
-	StageStatus     []EvaluatorStageStatus  `json:"stage_status,omitempty"`
-	Metadata        json.RawMessage         `json:"metadata,omitempty"`
+	ProfileID              string                  `json:"profile_id,omitempty"`
+	TaskKind               string                  `json:"task_kind,omitempty"`
+	ContractStatus         string                  `json:"contract_status,omitempty"`
+	QualityStatus          string                  `json:"quality_status,omitempty"`
+	HumanFeedbackAlignment json.RawMessage         `json:"human_feedback_alignment,omitempty"`
+	Hard                   *float64                `json:"hard,omitempty"`
+	Soft                   *float64                `json:"soft,omitempty"`
+	DimensionScores        map[string]float64      `json:"dimension_scores,omitempty"`
+	FailReason             string                  `json:"fail_reason,omitempty"`
+	Failure                *EvaluatorFailurePacket `json:"failure,omitempty"`
+	StageStatus            []EvaluatorStageStatus  `json:"stage_status,omitempty"`
+	Metadata               json.RawMessage         `json:"metadata,omitempty"`
 }
 
 type EvalRun struct {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -209,10 +209,13 @@ func TestEvaluatorProfileAndFailurePacketContractsRoundTrip(t *testing.T) {
 		TemplateID:      "planner",
 		Summary: CandidateSummary{
 			EvaluatorScore: &EvaluatorScore{
-				ProfileID: "vue_landing_page_v1",
-				TaskKind:  "vue_landing_page",
-				Hard:      &hard,
-				Soft:      &soft,
+				ProfileID:              "vue_landing_page_v1",
+				TaskKind:               "vue_landing_page",
+				ContractStatus:         "failed",
+				QualityStatus:          "not_run",
+				HumanFeedbackAlignment: json.RawMessage(`{"status":"feedback_available","required_improvements":["stronger product visuals"]}`),
+				Hard:                   &hard,
+				Soft:                   &soft,
 				DimensionScores: map[string]float64{
 					"artifact_contract": 0,
 				},
@@ -267,7 +270,10 @@ func TestEvaluatorProfileAndFailurePacketContractsRoundTrip(t *testing.T) {
 	if failure == nil ||
 		failure.PrimaryReason != "missing_required_artifact" ||
 		failure.FailedChecks[0].Check != "artifact_contract.required_files" ||
-		*decodedCandidate.Summary.EvaluatorScore.Soft != soft {
+		*decodedCandidate.Summary.EvaluatorScore.Soft != soft ||
+		decodedCandidate.Summary.EvaluatorScore.ContractStatus != "failed" ||
+		decodedCandidate.Summary.EvaluatorScore.QualityStatus != "not_run" ||
+		!strings.Contains(string(decodedCandidate.Summary.EvaluatorScore.HumanFeedbackAlignment), "stronger product visuals") {
 		t.Fatalf("decoded evaluator failure = %+v", decodedCandidate.Summary.EvaluatorScore)
 	}
 }


### PR DESCRIPTION
## Summary
- adds structured evaluator status fields to the Gitmoot SkillOpt score contract
- preserves backward compatibility with legacy evaluator JSON
- updates the contract round-trip coverage for the new fields

Paired Gitmoot-SkillOpt implementation PR: https://github.com/jerryfane/gitmoot-skillopt/pull/23

## Verification
- `GOTOOLCHAIN=go1.26.2 go test ./internal/skillopt ./internal/cli`
- `git diff --check`
- `codex exec review --uncommitted`

Review result:
`No discrete correctness issues were found in the current changes. The Go contract additions are backward-compatible JSON fields and the updated round-trip test covers the new fields.`