### PR TITLE
skillopt: add train backend presets

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -471,7 +471,7 @@ Complete train-mode path:
 3. `gitmoot skillopt train continue --session <session-id>` to generate options and publish the review packet.
 4. Human feedback is imported from raw or fenced YAML comments; `train continue` auto-syncs GitHub comments when the review is published and feedback is missing.
 5. Evaluator profiles run cheap artifact checks first, optional render adapters second, and LLM judges last. Structured failures flow into optimizer input with reasons, hints, evidence, failed checks, and stage status.
-6. `gitmoot skillopt train continue --session <session-id>` to export the package, run `gitmoot-skillopt`, and import the pending candidate, or record `optimizer_completed_no_candidate` if the optimizer produced no promotable content.
+6. `gitmoot skillopt train continue --session <session-id> --backend codex` to export the package, print the resolved backend/preflight report, run `gitmoot-skillopt`, and import the pending candidate, or record `optimizer_completed_no_candidate` if the optimizer produced no promotable content.
 7. `gitmoot skillopt train continue --session <session-id>` to publish candidate review context with separate selection score, evaluator/test scores, gate status, no-op status, and promotability.
 8. `gitmoot skillopt train continue --session <session-id> --promote <version>` or `--reject <version> --reason <text>`.
 9. `gitmoot skillopt train continue --session <session-id> --start-next` only after the prior iteration is resolved.

--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -234,6 +234,7 @@ returns unchanged baseline content, Gitmoot records
 gitmoot skillopt train continue \
   --session planner-train \
   --skillopt-bin /path/to/gitmoot-skillopt \
+  --backend codex \
   --out-root .gitmoot/skillopt/planner-train \
   --dry-run
 ```
@@ -246,10 +247,8 @@ gitmoot skillopt train continue \
   --session landing-page-train \
   --skillopt-bin /path/to/gitmoot-skillopt \
   --out-root .gitmoot/skillopt/landing-page-train \
-  --optimizer-backend openai_chat \
-  --target-backend codex_exec \
+  --backend codex \
   --evaluator-id landing_page_v1 \
-  --evaluator-backend openai_chat \
   --optimizer-model gpt-5.5 \
   --target-model gpt-5.5 \
   --evaluator-model gpt-5.5 \
@@ -259,14 +258,19 @@ gitmoot skillopt train continue \
   --gate mixed
 ```
 
-Before training starts, `gitmoot-skillopt` preflights the optimizer, target, and
-evaluator. The canaries must prove the target can return the exact requested
-text and that the evaluator can return structured hard/soft JSON. Optimizer
-failures record blocked status and do not promote or partially install
-candidate templates. If the optimizer selects the unchanged baseline, accepts no
-prompt edit, or returns content with the same hash as the base template, Gitmoot
-records `optimizer_completed_no_candidate` with `no_candidate_reason` and does
-not create or publish a pending candidate review.
+`--backend codex` resolves the user-facing optimizer, evaluator, and target
+provider to `codex`; Gitmoot passes the internal SkillOpt target adapter as
+`codex_exec`, so users do not need to remember that implementation detail.
+Before training starts, `train continue` prints the resolved backend report,
+config status, optimizer lock state, and recovery availability. Then
+`gitmoot-skillopt` preflights the optimizer, target, and evaluator. The
+canaries must prove the target can return the exact requested text and that the
+evaluator can return structured hard/soft JSON. Optimizer failures record
+blocked status and do not promote or partially install candidate templates. If
+the optimizer selects the unchanged baseline, accepts no prompt edit, or returns
+content with the same hash as the base template, Gitmoot records
+`optimizer_completed_no_candidate` with `no_candidate_reason` and does not
+create or publish a pending candidate review.
 
 ## Candidate Review And Next Iteration
 

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -82,7 +82,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -111,7 +111,7 @@ func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--preview-mode none|optional|required] [--preview-renderer none|vue-vite] [--preview-publisher none|github-pages] [--preview-route-template template] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -562,6 +562,7 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	generatorAgent := fs.String("generator-agent", "", "existing agent to use for option generation")
 	generatorType := fs.String("generator-type", "", "managed agent type to use for option generation; defaults to skillopt-generator")
 	skillOptBin := fs.String("skillopt-bin", "", "gitmoot-skillopt executable path; defaults to gitmoot-skillopt on PATH")
+	backend := fs.String("backend", "", "backend preset for optimizer, target, and evaluator; currently supports codex")
 	model := fs.String("model", "", "model name to pass to both optimizer and target when specific model flags are omitted")
 	optimizerModel := fs.String("optimizer-model", "", "optimizer model name")
 	targetModel := fs.String("target-model", "", "target model name")
@@ -614,6 +615,7 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 			GeneratorType:  *generatorType,
 			Optimizer: skillOptTrainOptimizerRequest{
 				SkillOptBin:      *skillOptBin,
+				Backend:          *backend,
 				Model:            *model,
 				OptimizerModel:   *optimizerModel,
 				TargetModel:      *targetModel,
@@ -638,19 +640,28 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 		})
 		return err
 	}); err != nil {
+		if output.Summary.CurrentPhase != "" || len(output.Lines) > 0 {
+			printSkillOptTrainContinueOutput(stdout, output)
+		}
 		fmt.Fprintf(stderr, "skillopt train continue: %v\n", err)
 		return 1
 	}
-	printSkillOptTrainStatus(stdout, output.Summary, output.Counts)
+	printSkillOptTrainContinueOutput(stdout, output)
 	if output.Summary.CurrentPhase == skillopt.TrainStateRunAbandoned {
 		fmt.Fprintln(stderr, "skillopt train continue: train session is abandoned")
 		return 1
+	}
+	return 0
+}
+
+func printSkillOptTrainContinueOutput(stdout io.Writer, output skillOptTrainContinueOutput) {
+	if output.Summary.CurrentPhase != "" {
+		printSkillOptTrainStatus(stdout, output.Summary, output.Counts)
 	}
 	writeLine(stdout, "continue_ready: %t", output.ContinueReady)
 	for _, line := range output.Lines {
 		writeLine(stdout, "%s", line)
 	}
-	return 0
 }
 
 type skillOptTrainContinueRequest struct {
@@ -668,6 +679,7 @@ type skillOptTrainContinueRequest struct {
 
 type skillOptTrainOptimizerRequest struct {
 	SkillOptBin      string
+	Backend          string
 	Model            string
 	OptimizerModel   string
 	TargetModel      string
@@ -962,21 +974,17 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 		}
 		result, err := continueSkillOptTrainOptimizer(ctx, paths, store, session, *iteration, request.Optimizer)
 		if err != nil {
-			return skillOptTrainContinueOutput{}, err
+			if skillOptTrainOptimizerResultHasReport(result) {
+				output.Lines = skillOptTrainOptimizerReportLines(result)
+			}
+			return output, err
 		}
 		updatedSession, updatedIteration, updatedCounts, err := loadSkillOptTrainStatus(ctx, store, session.ID)
 		if err != nil {
 			return skillOptTrainContinueOutput{}, err
 		}
 		updatedSummary := skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
-		lines := []string{
-			fmt.Sprintf("training_package: %s", result.TrainingPackagePath),
-			fmt.Sprintf("optimizer_out_root: %s", result.OutRoot),
-			fmt.Sprintf("candidate_package: %s", result.CandidatePackagePath),
-			fmt.Sprintf("artifact_dir: %s", result.ArtifactDir),
-			fmt.Sprintf("optimizer_command: %s", shellArgs(append([]string{result.Command}, result.Args...))),
-			fmt.Sprintf("optimizer_dry_run: %t", result.DryRun),
-		}
+		lines := skillOptTrainOptimizerReportLines(result)
 		if result.NoCandidateReason != "" {
 			lines = append(lines,
 				fmt.Sprintf("no_candidate_reason: %s", result.NoCandidateReason),
@@ -1182,9 +1190,21 @@ type skillOptTrainOptimizerResult struct {
 	Command               string
 	Args                  []string
 	DryRun                bool
+	BackendResolution     skillOptTrainBackendResolution
+	RecoveryAvailable     bool
+	OptimizerLockState    string
 	CandidateVersionID    string
 	NoCandidateReason     string
 	NoCandidateNextAction string
+}
+
+type skillOptTrainBackendResolution struct {
+	Backend               string
+	OptimizerBackend      string
+	TargetBackend         string
+	InternalTargetAdapter string
+	EvaluatorBackend      string
+	ConfigStatus          string
 }
 
 type skillOptTrainOptimizerPaths struct {
@@ -2361,6 +2381,11 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 	if strings.TrimSpace(iteration.EvalRunID) == "" {
 		return skillOptTrainOptimizerResult{}, fmt.Errorf("train iteration %s has no eval run id", iteration.ID)
 	}
+	resolvedRequest, backendResolution, err := resolveSkillOptTrainBackendRequest(request)
+	if err != nil {
+		return skillOptTrainOptimizerResult{}, err
+	}
+	request = resolvedRequest
 	optimizerPaths, err := resolveSkillOptTrainOptimizerPaths(paths, session, iteration, request)
 	if err != nil {
 		return skillOptTrainOptimizerResult{}, err
@@ -2371,6 +2396,9 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		CandidatePackagePath: optimizerPaths.CandidatePackagePath,
 		ArtifactDir:          optimizerPaths.ArtifactDir,
 		DryRun:               request.DryRun,
+		BackendResolution:    backendResolution,
+		RecoveryAvailable:    skillOptTrainOptimizerRecoveryAvailable(optimizerPaths),
+		OptimizerLockState:   "acquired",
 	}
 	state := skillopt.NormalizeTrainState(iteration.State)
 	if state == skillopt.TrainStateOptimizerCompleted && request.RerunOptimizer {
@@ -2387,17 +2415,17 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		}
 		exportMetadata, err := exportSkillOptTrainPackage(ctx, store, iteration, optimizerPaths)
 		if err != nil {
-			return skillOptTrainOptimizerResult{}, err
+			return result, err
 		}
 		session.State = skillopt.TrainStateTrainingPackageCreated
 		iteration.State = skillopt.TrainStateTrainingPackageCreated
 		session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "optimizer", exportMetadata)
 		iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "optimizer", exportMetadata)
 		if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
-			return skillOptTrainOptimizerResult{}, err
+			return result, err
 		}
 		if err := store.UpsertSkillOptTrainIteration(ctx, iteration); err != nil {
-			return skillOptTrainOptimizerResult{}, err
+			return result, err
 		}
 		state = skillopt.TrainStateTrainingPackageCreated
 	}
@@ -2408,18 +2436,19 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		command, args, err := buildSkillOptTrainOptimizerCommand(iteration, request, optimizerPaths)
 		if err != nil {
 			if metaErr := recordSkillOptTrainOptimizerFailure(ctx, store, session, iteration, request, optimizerPaths, command, args, subprocess.Result{}, err); metaErr != nil {
-				return skillOptTrainOptimizerResult{}, fmt.Errorf("%w; failed to record optimizer failure: %v", err, metaErr)
+				return result, fmt.Errorf("%w; failed to record optimizer failure: %v", err, metaErr)
 			}
-			return skillOptTrainOptimizerResult{}, err
+			return result, err
 		}
 		result.Command = command
 		result.Args = args
 		runResult, err := runSkillOptTrainOptimizer(ctx, optimizerPaths, request, command, args)
+		result.RecoveryAvailable = skillOptTrainOptimizerRecoveryAvailable(optimizerPaths)
 		if err != nil {
 			if metaErr := recordSkillOptTrainOptimizerFailure(ctx, store, session, iteration, request, optimizerPaths, command, args, runResult, err); metaErr != nil {
-				return skillOptTrainOptimizerResult{}, fmt.Errorf("%w; failed to record optimizer failure: %v", err, metaErr)
+				return result, fmt.Errorf("%w; failed to record optimizer failure: %v", err, metaErr)
 			}
-			return skillOptTrainOptimizerResult{}, err
+			return result, err
 		}
 		metadata := skillOptTrainOptimizerMetadata(request, optimizerPaths, command, args, runResult, "succeeded", nil)
 		session.State = skillopt.TrainStateOptimizerCompleted
@@ -2427,10 +2456,10 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "optimizer", metadata)
 		iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "optimizer", metadata)
 		if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
-			return skillOptTrainOptimizerResult{}, err
+			return result, err
 		}
 		if err := store.UpsertSkillOptTrainIteration(ctx, iteration); err != nil {
-			return skillOptTrainOptimizerResult{}, err
+			return result, err
 		}
 		state = skillopt.TrainStateOptimizerCompleted
 	}
@@ -4637,6 +4666,109 @@ func recordSkillOptTrainGenerationFailure(ctx context.Context, store *db.Store, 
 	return store.UpsertSkillOptTrainIteration(ctx, iteration)
 }
 
+func resolveSkillOptTrainBackendRequest(request skillOptTrainOptimizerRequest) (skillOptTrainOptimizerRequest, skillOptTrainBackendResolution, error) {
+	preset := strings.TrimSpace(strings.ToLower(request.Backend))
+	switch preset {
+	case "":
+		optimizerBackend := strings.TrimSpace(request.OptimizerBackend)
+		if optimizerBackend == "" {
+			optimizerBackend = "openai_chat"
+		}
+		internalTargetAdapter := strings.TrimSpace(request.TargetBackend)
+		if internalTargetAdapter == "" {
+			internalTargetAdapter = "openai_chat"
+		}
+		evaluatorBackend := strings.TrimSpace(request.EvaluatorBackend)
+		if evaluatorBackend == "" {
+			evaluatorBackend = optimizerBackend
+		}
+		resolution := skillOptTrainBackendResolution{
+			Backend:               "custom",
+			OptimizerBackend:      optimizerBackend,
+			TargetBackend:         skillOptTrainDisplayTargetBackend(internalTargetAdapter),
+			InternalTargetAdapter: internalTargetAdapter,
+			EvaluatorBackend:      evaluatorBackend,
+		}
+		resolution.ConfigStatus = skillOptTrainBackendConfigStatus(resolution)
+		return request, resolution, nil
+	case "codex":
+		if err := skillOptTrainBackendPresetConflict("--optimizer-backend", request.OptimizerBackend, "codex"); err != nil {
+			return skillOptTrainOptimizerRequest{}, skillOptTrainBackendResolution{}, err
+		}
+		if err := skillOptTrainCodexTargetBackendConflict(request.TargetBackend); err != nil {
+			return skillOptTrainOptimizerRequest{}, skillOptTrainBackendResolution{}, err
+		}
+		if err := skillOptTrainBackendPresetConflict("--evaluator-backend", request.EvaluatorBackend, "codex"); err != nil {
+			return skillOptTrainOptimizerRequest{}, skillOptTrainBackendResolution{}, err
+		}
+		request.OptimizerBackend = "codex"
+		request.TargetBackend = "codex_exec"
+		request.EvaluatorBackend = "codex"
+		resolution := skillOptTrainBackendResolution{
+			Backend:               "codex",
+			OptimizerBackend:      "codex",
+			TargetBackend:         "codex",
+			InternalTargetAdapter: "codex_exec",
+			EvaluatorBackend:      "codex",
+			ConfigStatus:          "codex_no_azure_or_openai_required",
+		}
+		return request, resolution, nil
+	default:
+		return skillOptTrainOptimizerRequest{}, skillOptTrainBackendResolution{}, fmt.Errorf("backend preset %q is not supported; use codex or explicit backend flags", preset)
+	}
+}
+
+func skillOptTrainBackendPresetConflict(flagName string, value string, expected string) error {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" || value == expected {
+		return nil
+	}
+	return fmt.Errorf("--backend codex conflicts with %s %q; omit %s or set it to %s", flagName, value, flagName, expected)
+}
+
+func skillOptTrainCodexTargetBackendConflict(value string) error {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" || value == "codex" || value == "codex_exec" {
+		return nil
+	}
+	return fmt.Errorf("--backend codex conflicts with --target-backend %q; omit --target-backend or use codex/codex_exec", value)
+}
+
+func skillOptTrainDisplayTargetBackend(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, "codex_exec") {
+		return "codex"
+	}
+	return value
+}
+
+func skillOptTrainBackendConfigStatus(resolution skillOptTrainBackendResolution) string {
+	backends := []string{
+		resolution.OptimizerBackend,
+		resolution.InternalTargetAdapter,
+		resolution.EvaluatorBackend,
+	}
+	anyBackend := false
+	externalCredentials := false
+	for _, backend := range backends {
+		backend = strings.TrimSpace(strings.ToLower(backend))
+		if backend == "" {
+			continue
+		}
+		anyBackend = true
+		if backend == "openai_chat" || backend == "azure_openai" || strings.Contains(backend, "openai") || strings.Contains(backend, "azure") {
+			externalCredentials = true
+		}
+	}
+	if !anyBackend {
+		return "using_optimizer_defaults"
+	}
+	if externalCredentials {
+		return "external_credentials_may_be_required"
+	}
+	return "no_azure_or_openai_required"
+}
+
 func resolveSkillOptTrainOptimizerPaths(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest) (skillOptTrainOptimizerPaths, error) {
 	outRoot := strings.TrimSpace(request.OutRoot)
 	optimizerMetadata := decodedSkillOptMetadataValue(decodedSkillOptMetadata(iteration.MetadataJSON)["optimizer"])
@@ -4722,7 +4854,30 @@ func exportSkillOptTrainPackage(ctx context.Context, store *db.Store, iteration 
 	}, nil
 }
 
+func skillOptTrainOptimizerRecoveryAvailable(paths skillOptTrainOptimizerPaths) bool {
+	for _, path := range []string{
+		paths.CandidatePackagePath,
+		filepath.Join(paths.OutRoot, "summary.json"),
+		filepath.Join(paths.OutRoot, "runtime_state.json"),
+		filepath.Join(paths.OutRoot, "history.json"),
+		filepath.Join(paths.OutRoot, "best_skill.md"),
+	} {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 func buildSkillOptTrainOptimizerCommand(iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest, paths skillOptTrainOptimizerPaths) (string, []string, error) {
+	resolvedRequest, _, err := resolveSkillOptTrainBackendRequest(request)
+	if err != nil {
+		return "", nil, err
+	}
+	request = resolvedRequest
 	executable := strings.TrimSpace(request.SkillOptBin)
 	if executable == "" {
 		executable = "gitmoot-skillopt"
@@ -4940,6 +5095,38 @@ func skillOptNoCandidateReason(err error) string {
 
 func skillOptNoCandidateNextAction() string {
 	return "do not publish a candidate review; revise feedback and start another iteration, rerun the optimizer with --rerun-optimizer, or stop"
+}
+
+func skillOptTrainOptimizerReportLines(result skillOptTrainOptimizerResult) []string {
+	lines := []string{
+		fmt.Sprintf("training_package: %s", result.TrainingPackagePath),
+		fmt.Sprintf("optimizer_out_root: %s", result.OutRoot),
+		fmt.Sprintf("candidate_package: %s", result.CandidatePackagePath),
+		fmt.Sprintf("artifact_dir: %s", result.ArtifactDir),
+		fmt.Sprintf("backend: %s", result.BackendResolution.Backend),
+		fmt.Sprintf("optimizer_backend: %s", emptyText(result.BackendResolution.OptimizerBackend)),
+		fmt.Sprintf("target_backend: %s", emptyText(result.BackendResolution.TargetBackend)),
+		fmt.Sprintf("internal_target_adapter: %s", emptyText(result.BackendResolution.InternalTargetAdapter)),
+		fmt.Sprintf("evaluator_backend: %s", emptyText(result.BackendResolution.EvaluatorBackend)),
+		fmt.Sprintf("backend_config_status: %s", result.BackendResolution.ConfigStatus),
+		fmt.Sprintf("optimizer_lock: %s", result.OptimizerLockState),
+		fmt.Sprintf("recovery_available: %t", result.RecoveryAvailable),
+	}
+	if strings.TrimSpace(result.Command) != "" {
+		lines = append(lines, fmt.Sprintf("optimizer_command: %s", shellArgs(append([]string{result.Command}, result.Args...))))
+	} else {
+		lines = append(lines, "optimizer_command: -")
+	}
+	lines = append(lines, fmt.Sprintf("optimizer_dry_run: %t", result.DryRun))
+	return lines
+}
+
+func skillOptTrainOptimizerResultHasReport(result skillOptTrainOptimizerResult) bool {
+	return strings.TrimSpace(result.TrainingPackagePath) != "" ||
+		strings.TrimSpace(result.OutRoot) != "" ||
+		strings.TrimSpace(result.CandidatePackagePath) != "" ||
+		strings.TrimSpace(result.ArtifactDir) != "" ||
+		strings.TrimSpace(result.BackendResolution.Backend) != ""
 }
 
 func importSkillOptTrainCandidate(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, optimizerPaths skillOptTrainOptimizerPaths) (db.AgentTemplateVersion, error) {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2564,6 +2564,121 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainContinueBackendCodexResolvesPresetAndReportsPreflight(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	candidate := cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with codex backend preset guidance.")
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: candidate,
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--backend", "codex",
+		"--target-backend", "codex",
+		"--evaluator-id", "landing_page_v1",
+		"--out-root", outRoot,
+		"--dry-run",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue codex backend exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: candidate_created",
+		"backend: codex",
+		"optimizer_backend: codex",
+		"target_backend: codex",
+		"internal_target_adapter: codex_exec",
+		"evaluator_backend: codex",
+		"backend_config_status: codex_no_azure_or_openai_required",
+		"optimizer_lock: acquired",
+		"recovery_available: true",
+		"optimizer_dry_run: true",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train continue codex backend stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("optimizer calls = %+v, want one", runner.calls)
+	}
+	call := runner.calls[0]
+	for _, want := range []string{
+		"--optimizer-backend", "codex",
+		"--target-backend", "codex_exec",
+		"--evaluator-backend", "codex",
+		"--evaluator-id", "landing_page_v1",
+		"--dry-run",
+	} {
+		if !containsString(call.args, want) {
+			t.Fatalf("optimizer args missing %q: %+v", want, call.args)
+		}
+	}
+}
+
+func TestSkillOptTrainContinueBackendCodexRejectsConflictingAdvancedBackend(t *testing.T) {
+	home, _ := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--backend", "codex",
+		"--optimizer-backend", "openai_chat",
+		"--dry-run",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue conflict exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--backend codex conflicts with --optimizer-backend") {
+		t.Fatalf("conflict stderr = %q", stderr.String())
+	}
+	for _, unwanted := range []string{
+		"training_package:",
+		"optimizer_backend:",
+		"optimizer_lock:",
+	} {
+		if strings.Contains(stdout.String(), unwanted) {
+			t.Fatalf("conflict stdout included optimizer report field %q:\n%s", unwanted, stdout.String())
+		}
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("optimizer started despite backend conflict: %+v", runner.calls)
+	}
+}
+
+func TestResolveSkillOptTrainBackendRequestReportsDefaultOpenAIBackends(t *testing.T) {
+	_, resolution, err := resolveSkillOptTrainBackendRequest(skillOptTrainOptimizerRequest{
+		TargetBackend: "codex_exec",
+	})
+	if err != nil {
+		t.Fatalf("resolveSkillOptTrainBackendRequest returned error: %v", err)
+	}
+	if resolution.Backend != "custom" ||
+		resolution.OptimizerBackend != "openai_chat" ||
+		resolution.TargetBackend != "codex" ||
+		resolution.InternalTargetAdapter != "codex_exec" ||
+		resolution.EvaluatorBackend != "openai_chat" ||
+		resolution.ConfigStatus != "external_credentials_may_be_required" {
+		t.Fatalf("resolution = %+v", resolution)
+	}
+}
+
 func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
 	outRoot := filepath.Join(t.TempDir(), "optimizer")
@@ -4343,6 +4458,19 @@ func TestSkillOptTrainContinueRecordsOptimizerFailureAtPackageGate(t *testing.T)
 	if !strings.Contains(stderr.String(), "optimizer failed") || !strings.Contains(stderr.String(), "optimizer stderr") {
 		t.Fatalf("optimizer failure stderr = %q", stderr.String())
 	}
+	for _, want := range []string{
+		"backend: custom",
+		"optimizer_backend: openai_chat",
+		"target_backend: openai_chat",
+		"evaluator_backend: openai_chat",
+		"backend_config_status: external_credentials_may_be_required",
+		"optimizer_lock: acquired",
+		"recovery_available: false",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("optimizer failure stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
 
 	store := openCLIJobStore(t, home)
 	defer store.Close()
@@ -4406,6 +4534,50 @@ func TestSkillOptTrainContinueRecordsOptimizerFailureAtPackageGate(t *testing.T)
 	}
 }
 
+func TestSkillOptTrainContinueReportsRecoveryAfterOptimizerFailureArtifacts(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate:          cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with recoverable candidate guidance."),
+		failAfterCandidate: true,
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--out-root", outRoot,
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue failing optimizer exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "optimizer stderr after candidate") {
+		t.Fatalf("optimizer failure stderr = %q", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "recovery_available: true") {
+		t.Fatalf("optimizer failure stdout did not report recovery:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(outRoot, "candidate.json")); err != nil {
+		t.Fatalf("candidate package was not written before failure: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateTrainingPackageCreated || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after recoverable optimizer failure = %+v", iteration)
+	}
+}
+
 func TestSkillOptTrainContinueRecordsOptimizerSetupFailure(t *testing.T) {
 	home, _ := seedSkillOptTrainFeedbackSynced(t)
 	runner := &skillOptTrainFakeOptimizerRunner{}
@@ -4427,6 +4599,19 @@ func TestSkillOptTrainContinueRecordsOptimizerSetupFailure(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), `optimizer gate "unsupported" is not supported`) {
 		t.Fatalf("invalid gate stderr = %q", stderr.String())
+	}
+	for _, want := range []string{
+		"backend: custom",
+		"optimizer_backend: openai_chat",
+		"target_backend: openai_chat",
+		"evaluator_backend: openai_chat",
+		"backend_config_status: external_credentials_may_be_required",
+		"optimizer_lock: acquired",
+		"optimizer_command: -",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("optimizer setup failure stdout missing %q:\n%s", want, stdout.String())
+		}
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("optimizer ran after setup failure: %+v", runner.calls)
@@ -5478,6 +5663,9 @@ func TestSkillOptReviewCreateAndStatus(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "gitmoot skillopt review create") || !strings.Contains(stdout.String(), "gitmoot skillopt review status") {
 		t.Fatalf("skillopt help missing review commands:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "gitmoot skillopt train continue --session <id> [--backend codex]") {
+		t.Fatalf("skillopt help missing train backend preset:\n%s", stdout.String())
 	}
 
 	stdout.Reset()
@@ -6847,10 +7035,11 @@ func seedSkillOptTrainFeedbackSynced(t *testing.T) (string, string) {
 }
 
 type skillOptTrainFakeOptimizerRunner struct {
-	candidate     skillopt.CandidatePackage
-	fail          bool
-	lookPathValue string
-	calls         []skillOptTrainFakeOptimizerCall
+	candidate          skillopt.CandidatePackage
+	fail               bool
+	failAfterCandidate bool
+	lookPathValue      string
+	calls              []skillOptTrainFakeOptimizerCall
 }
 
 type skillOptTrainFakeOptimizerCall struct {
@@ -6862,7 +7051,7 @@ type skillOptTrainFakeOptimizerCall struct {
 func (r *skillOptTrainFakeOptimizerRunner) Run(_ context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
 	r.calls = append(r.calls, skillOptTrainFakeOptimizerCall{dir: dir, command: command, args: append([]string{}, args...)})
 	result := subprocess.Result{Command: command, Args: args}
-	if r.fail {
+	if r.fail && !r.failAfterCandidate {
 		result.Stderr = "optimizer stderr"
 		return result, errors.New("exit status 2")
 	}
@@ -6906,6 +7095,10 @@ func (r *skillOptTrainFakeOptimizerRunner) Run(_ context.Context, dir string, co
 		return result, err
 	}
 	result.Stdout = "wrote candidate package: " + candidateOutput + "\n"
+	if r.failAfterCandidate {
+		result.Stderr = "optimizer stderr after candidate"
+		return result, errors.New("exit status 2")
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
WHAT
Add a user-facing `--backend codex` preset for `gitmoot skillopt train continue`, plus optimizer preflight reporting.

WHY
The previous flow required users to know that the visible Codex target should be passed internally as `codex_exec`, and failures could make backend/config state unclear. This makes the common Codex flow explicit and easier to diagnose.

CHANGES
- Added `--backend` to `skillopt train continue` help and command parsing.
- Resolves `--backend codex` to optimizer `codex`, evaluator `codex`, displayed target `codex`, and internal target adapter `codex_exec`.
- Keeps explicit advanced backend flags and rejects conflicts with the preset.
- Prints optimizer report lines for resolved backend, optimizer/evaluator/target, internal adapter, config status, optimizer lock state, recovery availability, command, and dry-run state.
- Preserves useful report output on optimizer setup/run failures without printing blank reports for early preset conflicts.
- Refreshes recovery availability after optimizer execution so recoverable artifacts created during failed runs are reported correctly.
- Updated SkillOpt train docs to prefer `--backend codex`.

RESULTS
- `gofmt -w internal/cli/skillopt.go internal/cli/skillopt_test.go`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run SkillOptTrain` passed: `ok github.com/jerryfane/gitmoot/internal/cli 62.756s`
- `git diff --check` passed.
- `codex exec review --uncommitted` final raw output:

```text
The backend preset wiring, reporting changes, and related tests appear consistent with existing optimizer flow; focused SkillOpt train-continue tests pass, with only a broader suite failure caused by sandbox restrictions on Unix socket setup.
The backend preset wiring, reporting changes, and related tests appear consistent with existing optimizer flow; focused SkillOpt train-continue tests pass, with only a broader suite failure caused by sandbox restrictions on Unix socket setup.
```

RISK
The reviewer attempted a broader `go test ./internal/cli` run and hit an unrelated sandbox limitation in `TestAgentTemplateValidateRejectsNonRegularFile` while opening a Unix socket. Focused SkillOpt train tests passed with Go 1.26.x.
