### PR TITLE
skillopt: heartbeat optimizer train locks

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -460,10 +462,17 @@ type skillOptTrainStatusJobRef struct {
 }
 
 type skillOptTrainStatusLock struct {
-	Name       string `json:"name"`
-	Key        string `json:"key"`
-	OwnerJobID string `json:"owner_job_id,omitempty"`
-	ExpiresAt  string `json:"expires_at,omitempty"`
+	Name          string `json:"name"`
+	Key           string `json:"key"`
+	Status        string `json:"status,omitempty"`
+	OwnerJobID    string `json:"owner_job_id,omitempty"`
+	OwnerPID      int64  `json:"owner_pid,omitempty"`
+	OwnerHostname string `json:"owner_hostname,omitempty"`
+	CommandHash   string `json:"command_hash,omitempty"`
+	AcquiredAt    string `json:"acquired_at,omitempty"`
+	UpdatedAt     string `json:"updated_at,omitempty"`
+	ExpiresAt     string `json:"expires_at,omitempty"`
+	Elapsed       string `json:"elapsed,omitempty"`
 }
 
 type skillOptTrainStatusItem struct {
@@ -678,24 +687,25 @@ type skillOptTrainContinueRequest struct {
 }
 
 type skillOptTrainOptimizerRequest struct {
-	SkillOptBin      string
-	Backend          string
-	Model            string
-	OptimizerModel   string
-	TargetModel      string
-	OptimizerBackend string
-	TargetBackend    string
-	EvaluatorID      string
-	EvaluatorModel   string
-	EvaluatorBackend string
-	SkillUpdateMode  string
-	NumEpochs        int
-	BatchSize        int
-	Gate             string
-	OutRoot          string
-	Timeout          string
-	DryRun           bool
-	RerunOptimizer   bool
+	SkillOptBin        string
+	Backend            string
+	Model              string
+	OptimizerModel     string
+	TargetModel        string
+	OptimizerBackend   string
+	TargetBackend      string
+	EvaluatorID        string
+	EvaluatorModel     string
+	EvaluatorBackend   string
+	SkillUpdateMode    string
+	NumEpochs          int
+	BatchSize          int
+	Gate               string
+	OutRoot            string
+	Timeout            string
+	DryRun             bool
+	RerunOptimizer     bool
+	OptimizerLockState string
 }
 
 type skillOptTrainContinueOutput struct {
@@ -948,10 +958,11 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 		if err != nil {
 			return skillOptTrainContinueOutput{}, err
 		}
-		releaseOptimizerLock, _, err := acquireSkillOptTrainOptimizerLock(ctx, store, session.ID, iteration.ID, optimizerLockTTL)
+		releaseOptimizerLock, optimizerLockState, err := acquireSkillOptTrainOptimizerLock(ctx, store, session.ID, iteration.ID, optimizerLockTTL, request.Optimizer)
 		if err != nil {
 			return output, err
 		}
+		request.Optimizer.OptimizerLockState = optimizerLockState
 		defer func() {
 			_ = releaseOptimizerLock(context.Background())
 		}()
@@ -2398,7 +2409,7 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		DryRun:               request.DryRun,
 		BackendResolution:    backendResolution,
 		RecoveryAvailable:    skillOptTrainOptimizerRecoveryAvailable(optimizerPaths),
-		OptimizerLockState:   "acquired",
+		OptimizerLockState:   skillOptTrainOptimizerLockState(request),
 	}
 	state := skillopt.NormalizeTrainState(iteration.State)
 	if state == skillopt.TrainStateOptimizerCompleted && request.RerunOptimizer {
@@ -2508,6 +2519,14 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 	return skillOptTrainOptimizerResult{}, fmt.Errorf("train iteration %s is at %s; expected %s, %s, or %s", iteration.ID, iteration.State, skillopt.TrainStateFeedbackSynced, skillopt.TrainStateTrainingPackageCreated, skillopt.TrainStateOptimizerCompleted)
 }
 
+func skillOptTrainOptimizerLockState(request skillOptTrainOptimizerRequest) string {
+	state := strings.TrimSpace(request.OptimizerLockState)
+	if state == "" {
+		return "acquired"
+	}
+	return state
+}
+
 type skillOptTrainGenerationResult struct {
 	GeneratedOptions int
 	JobIDs           []string
@@ -2533,6 +2552,10 @@ const skillOptTrainGenerationLockBuffer = 10 * time.Minute
 const skillOptTrainOptimizerLockTTL = 4 * time.Hour
 
 const skillOptTrainOptimizerLockBuffer = 10 * time.Minute
+
+const skillOptTrainOptimizerHeartbeatLeaseTTL = 2 * time.Minute
+
+const skillOptTrainOptimizerExpiredHeartbeatGrace = 10 * time.Minute
 
 const skillOptTrainCandidateReviewLockTTL = 30 * time.Minute
 
@@ -2640,42 +2663,243 @@ func skillOptTrainStartNextLockKey(sessionID string) string {
 	return "skillopt-train-start-next:" + strings.TrimSpace(sessionID)
 }
 
-func acquireSkillOptTrainOptimizerLock(ctx context.Context, store *db.Store, sessionID string, iterationID string, ttl time.Duration) (func(context.Context) error, bool, error) {
-	key := skillOptTrainOptimizerLockKey(sessionID, iterationID)
+func acquireSkillOptTrainOptimizerLock(ctx context.Context, store *db.Store, sessionID string, iterationID string, ttl time.Duration, request skillOptTrainOptimizerRequest) (func(context.Context) error, string, error) {
 	token, err := newRuntimeLockOwnerToken()
 	if err != nil {
-		return noopAgentReservationRelease, false, err
+		return noopAgentReservationRelease, "", err
+	}
+	legacyToken, err := newRuntimeLockOwnerToken()
+	if err != nil {
+		return noopAgentReservationRelease, "", err
 	}
 	if ttl <= 0 {
 		ttl = skillOptTrainOptimizerLockTTL
 	}
+	leaseTTL := skillOptTrainOptimizerLeaseTTL(ttl)
 	now := time.Now().UTC()
+	lockKeys := skillOptTrainOptimizerLockKeys(sessionID, iterationID)
+	lockState := "acquired"
+	for _, existingKey := range lockKeys {
+		if existing, err := store.GetResourceLock(ctx, existingKey); err == nil {
+			if skillOptTrainOptimizerLockStatus(existing, now) == "stale" {
+				released, releaseErr := store.ReleaseResourceLock(ctx, existingKey, existing.OwnerJobID, existing.OwnerToken)
+				if releaseErr != nil {
+					return noopAgentReservationRelease, "", releaseErr
+				}
+				if !released {
+					return noopAgentReservationRelease, "", skillOptTrainOptimizerLockBusyError(existingKey, existing, now)
+				}
+				lockState = "recovered_stale"
+				continue
+			}
+			return noopAgentReservationRelease, "", skillOptTrainOptimizerLockBusyError(existingKey, existing, now)
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return noopAgentReservationRelease, "", err
+		}
+	}
 	ownerJobID := localAgentJobID("skillopt-train-optimizer", strings.TrimSpace(sessionID))
-	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
-		ResourceKey: key,
-		OwnerJobID:  ownerJobID,
-		OwnerToken:  token,
-		ExpiresAt:   now.Add(ttl).Format(time.RFC3339Nano),
-	}, now)
+	hostname, _ := os.Hostname()
+	newKey := skillOptTrainOptimizerLockKey(sessionID, iterationID)
+	legacyKey := skillOptTrainLegacyOptimizerLockKey(sessionID, iterationID)
+	lockMetadata := db.ResourceLock{
+		OwnerJobID:    ownerJobID,
+		OwnerToken:    token,
+		OwnerPID:      int64(os.Getpid()),
+		OwnerHostname: hostname,
+		CommandHash:   skillOptTrainOptimizerRequestHash(request),
+		ExpiresAt:     now.Add(leaseTTL).Format(time.RFC3339Nano),
+	}
+	lockMetadata.ResourceKey = newKey
+	acquired, err := store.AcquireResourceLock(ctx, lockMetadata, now)
 	if err != nil {
-		return noopAgentReservationRelease, false, err
+		return noopAgentReservationRelease, "", err
 	}
 	if !acquired {
-		return noopAgentReservationRelease, false, fmt.Errorf("%w: %s", errSkillOptTrainOptimizerBusy, key)
+		if existing, lockErr := store.GetResourceLock(ctx, newKey); lockErr == nil {
+			return noopAgentReservationRelease, "", skillOptTrainOptimizerLockBusyError(newKey, existing, time.Now().UTC())
+		}
+		return noopAgentReservationRelease, "", fmt.Errorf("%w: %s", errSkillOptTrainOptimizerBusy, newKey)
 	}
+	lockMetadata.ResourceKey = legacyKey
+	lockMetadata.OwnerToken = legacyToken
+	legacyAcquired, err := store.AcquireResourceLock(ctx, lockMetadata, now)
+	if err != nil {
+		_, _ = store.ReleaseResourceLock(context.Background(), newKey, ownerJobID, token)
+		return noopAgentReservationRelease, "", err
+	}
+	if !legacyAcquired {
+		_, _ = store.ReleaseResourceLock(context.Background(), newKey, ownerJobID, token)
+		if existing, lockErr := store.GetResourceLock(ctx, legacyKey); lockErr == nil {
+			return noopAgentReservationRelease, "", skillOptTrainOptimizerLockBusyError(legacyKey, existing, time.Now().UTC())
+		}
+		return noopAgentReservationRelease, "", fmt.Errorf("%w: %s", errSkillOptTrainOptimizerBusy, legacyKey)
+	}
+	stopHeartbeat := startSkillOptTrainOptimizerLockHeartbeat(context.Background(), store, newKey, ownerJobID, token, leaseTTL)
+	stopLegacyHeartbeat := startSkillOptTrainOptimizerLockHeartbeat(context.Background(), store, legacyKey, ownerJobID, legacyToken, leaseTTL)
 	return func(releaseCtx context.Context) error {
-		_, err := store.ReleaseResourceLock(releaseCtx, key, ownerJobID, token)
-		return err
-	}, true, nil
+		stopHeartbeat()
+		stopLegacyHeartbeat()
+		_, err := store.ReleaseResourceLock(releaseCtx, newKey, ownerJobID, token)
+		_, legacyErr := store.ReleaseResourceLock(releaseCtx, legacyKey, ownerJobID, legacyToken)
+		if err != nil {
+			return err
+		}
+		return legacyErr
+	}, lockState, nil
 }
 
 func skillOptTrainOptimizerLockKey(sessionID string, iterationID string) string {
 	sessionID = strings.TrimSpace(sessionID)
 	iterationID = strings.TrimSpace(iterationID)
 	if iterationID == "" {
+		return "skillopt-train:" + sessionID
+	}
+	return "skillopt-train:" + sessionID + ":" + iterationID
+}
+
+func skillOptTrainLegacyOptimizerLockKey(sessionID string, iterationID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	iterationID = strings.TrimSpace(iterationID)
+	if iterationID == "" {
 		return "skillopt-train-optimizer:" + sessionID
 	}
 	return "skillopt-train-optimizer:" + sessionID + ":" + iterationID
+}
+
+func skillOptTrainOptimizerLockKeys(sessionID string, iterationID string) []string {
+	return []string{
+		skillOptTrainOptimizerLockKey(sessionID, iterationID),
+		skillOptTrainLegacyOptimizerLockKey(sessionID, iterationID),
+	}
+}
+
+func skillOptTrainOptimizerLeaseTTL(maxRuntimeTTL time.Duration) time.Duration {
+	if maxRuntimeTTL > 0 && maxRuntimeTTL < skillOptTrainOptimizerHeartbeatLeaseTTL {
+		return maxRuntimeTTL
+	}
+	return skillOptTrainOptimizerHeartbeatLeaseTTL
+}
+
+func startSkillOptTrainOptimizerLockHeartbeat(ctx context.Context, store *db.Store, key string, ownerJobID string, ownerToken string, leaseTTL time.Duration) func() {
+	heartbeatEvery := skillOptTrainOptimizerHeartbeatInterval(leaseTTL)
+	heartbeatCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(heartbeatEvery)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case now := <-ticker.C:
+				_, _ = store.HeartbeatResourceLock(context.Background(), key, ownerJobID, ownerToken, now.UTC(), now.UTC().Add(leaseTTL))
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
+}
+
+func skillOptTrainOptimizerHeartbeatInterval(ttl time.Duration) time.Duration {
+	if ttl <= 0 {
+		return 30 * time.Second
+	}
+	interval := ttl / 4
+	if interval <= 0 {
+		return time.Second
+	}
+	if interval > 30*time.Second {
+		return 30 * time.Second
+	}
+	return interval
+}
+
+func skillOptTrainOptimizerRequestHash(request skillOptTrainOptimizerRequest) string {
+	content, err := json.Marshal(map[string]any{
+		"backend":           strings.TrimSpace(request.Backend),
+		"model":             strings.TrimSpace(request.Model),
+		"optimizer_model":   strings.TrimSpace(request.OptimizerModel),
+		"target_model":      strings.TrimSpace(request.TargetModel),
+		"optimizer_backend": strings.TrimSpace(request.OptimizerBackend),
+		"target_backend":    strings.TrimSpace(request.TargetBackend),
+		"evaluator_id":      strings.TrimSpace(request.EvaluatorID),
+		"evaluator_model":   strings.TrimSpace(request.EvaluatorModel),
+		"evaluator_backend": strings.TrimSpace(request.EvaluatorBackend),
+		"skill_update_mode": strings.TrimSpace(request.SkillUpdateMode),
+		"num_epochs":        request.NumEpochs,
+		"batch_size":        request.BatchSize,
+		"gate":              strings.TrimSpace(request.Gate),
+		"timeout":           strings.TrimSpace(request.Timeout),
+		"dry_run":           request.DryRun,
+		"rerun_optimizer":   request.RerunOptimizer,
+	})
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+func skillOptTrainOptimizerLockBusyError(key string, lock db.ResourceLock, now time.Time) error {
+	status := skillOptTrainOptimizerLockStatus(lock, now)
+	message := fmt.Sprintf("%s (%s owner=%s pid=%s host=%s heartbeat=%s expires=%s elapsed=%s hash=%s)",
+		key,
+		status,
+		emptyText(lock.OwnerJobID),
+		skillOptLockPIDText(lock.OwnerPID),
+		emptyText(lock.OwnerHostname),
+		emptyText(lock.UpdatedAt),
+		emptyText(lock.ExpiresAt),
+		skillOptLockElapsedText(lock.AcquiredAt, now),
+		emptyText(lock.CommandHash),
+	)
+	return fmt.Errorf("%w: %s", errSkillOptTrainOptimizerBusy, message)
+}
+
+func skillOptTrainOptimizerLockStatus(lock db.ResourceLock, now time.Time) string {
+	expired := false
+	var expiresAt time.Time
+	if parsed, ok := parseSkillOptStatusTime(lock.ExpiresAt); ok {
+		expiresAt = parsed
+		expired = !expiresAt.After(now)
+	}
+	if expired {
+		if !skillOptOwnerPIDLive(lock.OwnerPID) || now.Sub(expiresAt) >= skillOptTrainOptimizerExpiredHeartbeatGrace {
+			return "stale"
+		}
+		return "active_expired_heartbeat"
+	}
+	return "active"
+}
+
+func skillOptOwnerPIDLive(pid int64) bool {
+	if pid <= 0 {
+		return false
+	}
+	running, err := processRunning(int(pid))
+	return err == nil && running
+}
+
+func skillOptLockPIDText(pid int64) string {
+	if pid <= 0 {
+		return "-"
+	}
+	return strconv.FormatInt(pid, 10)
+}
+
+func skillOptLockElapsedText(acquiredAt string, now time.Time) string {
+	acquired, ok := parseSkillOptStatusTime(acquiredAt)
+	if !ok {
+		return "unknown"
+	}
+	elapsed := now.Sub(acquired)
+	if elapsed < 0 {
+		return "unknown"
+	}
+	return elapsed.Round(time.Second).String()
 }
 
 func skillOptTrainOptimizerLockTTLForRequest(request skillOptTrainOptimizerRequest) (time.Duration, error) {
@@ -4059,6 +4283,7 @@ func skillOptTrainActiveLocks(ctx context.Context, store *db.Store, sessionID st
 		{name: "generation", key: skillOptTrainGenerationLockKey(sessionID, iterationID)},
 		{name: "review", key: skillOptTrainReviewLockKey(sessionID, iterationID)},
 		{name: "optimizer", key: skillOptTrainOptimizerLockKey(sessionID, iterationID)},
+		{name: "optimizer_legacy", key: skillOptTrainLegacyOptimizerLockKey(sessionID, iterationID)},
 		{name: "candidate_review", key: skillOptTrainCandidateReviewLockKey(sessionID, iterationID)},
 		{name: "start_next", key: skillOptTrainStartNextLockKey(sessionID)},
 	}
@@ -4072,14 +4297,24 @@ func skillOptTrainActiveLocks(ctx context.Context, store *db.Store, sessionID st
 			}
 			return nil, err
 		}
-		if !skillOptResourceLockActive(lock, now) {
+		status := "active"
+		if candidate.name == "optimizer" || candidate.name == "optimizer_legacy" {
+			status = skillOptTrainOptimizerLockStatus(lock, now)
+		} else if !skillOptResourceLockActive(lock, now) {
 			continue
 		}
 		locks = append(locks, skillOptTrainStatusLock{
-			Name:       candidate.name,
-			Key:        lock.ResourceKey,
-			OwnerJobID: strings.TrimSpace(lock.OwnerJobID),
-			ExpiresAt:  strings.TrimSpace(lock.ExpiresAt),
+			Name:          candidate.name,
+			Key:           lock.ResourceKey,
+			Status:        status,
+			OwnerJobID:    strings.TrimSpace(lock.OwnerJobID),
+			OwnerPID:      lock.OwnerPID,
+			OwnerHostname: strings.TrimSpace(lock.OwnerHostname),
+			CommandHash:   strings.TrimSpace(lock.CommandHash),
+			AcquiredAt:    strings.TrimSpace(lock.AcquiredAt),
+			UpdatedAt:     strings.TrimSpace(lock.UpdatedAt),
+			ExpiresAt:     strings.TrimSpace(lock.ExpiresAt),
+			Elapsed:       skillOptLockElapsedText(lock.AcquiredAt, now),
 		})
 	}
 	return locks, nil
@@ -4241,8 +4476,10 @@ func skillOptTrainWatchDone(snapshot skillOptTrainStatusSnapshot) bool {
 	if snapshot.Verbose == nil {
 		return true
 	}
-	if len(snapshot.Verbose.ActiveLocks) > 0 {
-		return false
+	for _, lock := range snapshot.Verbose.ActiveLocks {
+		if strings.TrimSpace(lock.Status) != "stale" {
+			return false
+		}
 	}
 	return true
 }
@@ -4313,6 +4550,39 @@ func printSkillOptTrainStatusSnapshot(stdout io.Writer, snapshot skillOptTrainSt
 	if snapshot.Verbose.Candidate.NoCandidateReason != "" {
 		writeLine(stdout, "no_candidate_reason: %s", snapshot.Verbose.Candidate.NoCandidateReason)
 	}
+	for _, lock := range snapshot.Verbose.ActiveLocks {
+		writeLine(stdout, "active_lock: %s", skillOptTrainStatusLockText(lock))
+	}
+}
+
+func skillOptTrainStatusLockText(lock skillOptTrainStatusLock) string {
+	parts := []string{
+		strings.TrimSpace(lock.Name),
+		strings.TrimSpace(lock.Key),
+		"status=" + emptyText(lock.Status),
+	}
+	if strings.TrimSpace(lock.OwnerJobID) != "" {
+		parts = append(parts, "owner="+strings.TrimSpace(lock.OwnerJobID))
+	}
+	if lock.OwnerPID > 0 {
+		parts = append(parts, "pid="+strconv.FormatInt(lock.OwnerPID, 10))
+	}
+	if strings.TrimSpace(lock.OwnerHostname) != "" {
+		parts = append(parts, "host="+strings.TrimSpace(lock.OwnerHostname))
+	}
+	if strings.TrimSpace(lock.UpdatedAt) != "" {
+		parts = append(parts, "heartbeat="+strings.TrimSpace(lock.UpdatedAt))
+	}
+	if strings.TrimSpace(lock.ExpiresAt) != "" {
+		parts = append(parts, "expires="+strings.TrimSpace(lock.ExpiresAt))
+	}
+	if strings.TrimSpace(lock.Elapsed) != "" {
+		parts = append(parts, "elapsed="+strings.TrimSpace(lock.Elapsed))
+	}
+	if strings.TrimSpace(lock.CommandHash) != "" {
+		parts = append(parts, "hash="+strings.TrimSpace(lock.CommandHash))
+	}
+	return strings.Join(parts, " ")
 }
 
 func readSkillOptTrainRequest(requestText string, requestFile string) (string, error) {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -4761,6 +4761,21 @@ func TestSkillOptTrainContinueOptimizerHandlesMissingIteration(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainOptimizerLockStatusBoundsExpiredPIDLiveness(t *testing.T) {
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	lock := db.ResourceLock{
+		OwnerPID:  int64(os.Getpid()),
+		ExpiresAt: now.Add(-time.Minute).Format(time.RFC3339Nano),
+	}
+	if got := skillOptTrainOptimizerLockStatus(lock, now); got != "active_expired_heartbeat" {
+		t.Fatalf("recent expired live-pid lock status = %q, want active_expired_heartbeat", got)
+	}
+	lock.ExpiresAt = now.Add(-skillOptTrainOptimizerExpiredHeartbeatGrace).Format(time.RFC3339Nano)
+	if got := skillOptTrainOptimizerLockStatus(lock, now); got != "stale" {
+		t.Fatalf("old expired live-pid lock status = %q, want stale", got)
+	}
+}
+
 func TestSkillOptTrainContinueRefusesConcurrentOptimizer(t *testing.T) {
 	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
 	runner := &skillOptTrainFakeOptimizerRunner{
@@ -4772,9 +4787,40 @@ func TestSkillOptTrainContinueRefusesConcurrentOptimizer(t *testing.T) {
 		skillOptTrainOptimizerRunner = previousRunner
 	}()
 	store := openCLIJobStore(t, home)
-	release, _, err := acquireSkillOptTrainOptimizerLock(context.Background(), store, "optimizer-train", "optimizer-train-001", time.Hour)
+	release, _, err := acquireSkillOptTrainOptimizerLock(context.Background(), store, "optimizer-train", "optimizer-train-001", time.Hour, skillOptTrainOptimizerRequest{Backend: "codex"})
 	if err != nil {
 		t.Fatalf("acquire optimizer lock returned error: %v", err)
+	}
+	lock, err := store.GetResourceLock(context.Background(), skillOptTrainOptimizerLockKey("optimizer-train", "optimizer-train-001"))
+	if err != nil {
+		t.Fatalf("GetResourceLock optimizer returned error: %v", err)
+	}
+	if lock.ResourceKey != "skillopt-train:optimizer-train:optimizer-train-001" ||
+		lock.OwnerPID <= 0 ||
+		strings.TrimSpace(lock.OwnerHostname) == "" ||
+		strings.TrimSpace(lock.CommandHash) == "" {
+		t.Fatalf("optimizer lock metadata = %+v", lock)
+	}
+	acquiredAt, ok := parseSkillOptStatusTime(lock.AcquiredAt)
+	if !ok {
+		t.Fatalf("optimizer lock acquired_at = %q, want parseable time", lock.AcquiredAt)
+	}
+	expiresAt, ok := parseSkillOptStatusTime(lock.ExpiresAt)
+	if !ok {
+		t.Fatalf("optimizer lock expires_at = %q, want parseable time", lock.ExpiresAt)
+	}
+	if lease := expiresAt.Sub(acquiredAt); lease <= 0 || lease > skillOptTrainOptimizerHeartbeatLeaseTTL+time.Second {
+		t.Fatalf("optimizer lock lease = %s, want short heartbeat lease around %s", lease, skillOptTrainOptimizerHeartbeatLeaseTTL)
+	}
+	legacyLock, err := store.GetResourceLock(context.Background(), skillOptTrainLegacyOptimizerLockKey("optimizer-train", "optimizer-train-001"))
+	if err != nil {
+		t.Fatalf("GetResourceLock legacy optimizer returned error: %v", err)
+	}
+	if legacyLock.OwnerJobID != lock.OwnerJobID ||
+		legacyLock.OwnerPID != lock.OwnerPID ||
+		legacyLock.OwnerHostname != lock.OwnerHostname ||
+		legacyLock.CommandHash != lock.CommandHash {
+		t.Fatalf("legacy optimizer lock metadata = %+v, want owner metadata matching %+v", legacyLock, lock)
 	}
 	defer store.Close()
 	defer func() {
@@ -4793,8 +4839,172 @@ func TestSkillOptTrainContinueRefusesConcurrentOptimizer(t *testing.T) {
 	if !strings.Contains(stderr.String(), "skillopt train optimizer is already running") {
 		t.Fatalf("locked optimizer stderr = %q", stderr.String())
 	}
+	for _, want := range []string{
+		"skillopt-train:optimizer-train:optimizer-train-001",
+		"active owner=",
+		"pid=",
+		"heartbeat=",
+		"hash=",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("locked optimizer stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("optimizer ran while lock was held: %+v", runner.calls)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "status", "--home", home, "--session", "optimizer-train", "--verbose"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train status with optimizer lock exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"active_lock: optimizer skillopt-train:optimizer-train:optimizer-train-001 status=active",
+		"active_lock: optimizer_legacy skillopt-train-optimizer:optimizer-train:optimizer-train-001 status=active",
+		"owner=local-skillopt-train-optimizer-optimizer-train",
+		"pid=",
+		"heartbeat=",
+		"expires=",
+		"elapsed=",
+		"hash=",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train status active lock stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestSkillOptTrainContinueReportsStaleOptimizerLock(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with stale-lock-safe candidate guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	store := openCLIJobStore(t, home)
+	now := time.Now().UTC()
+	acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey:   skillOptTrainOptimizerLockKey("optimizer-train", "optimizer-train-001"),
+		OwnerJobID:    "stale-optimizer",
+		OwnerToken:    "stale-token",
+		OwnerPID:      0,
+		OwnerHostname: "stale-host",
+		CommandHash:   "stale-hash",
+		ExpiresAt:     now.Add(-time.Minute).Format(time.RFC3339Nano),
+	}, now.Add(-2*time.Minute))
+	if err != nil {
+		t.Fatalf("AcquireResourceLock stale returned error: %v", err)
+	}
+	if !acquired {
+		t.Fatal("AcquireResourceLock did not create stale optimizer lock")
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close stale lock store returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "status", "--home", home, "--session", "optimizer-train", "--verbose"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train status stale lock exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "active_lock: optimizer skillopt-train:optimizer-train:optimizer-train-001 status=stale") {
+		t.Fatalf("train status stale lock stdout = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "status", "--home", home, "--session", "optimizer-train", "--watch", "--verbose", "--poll", "1ms"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train status watch stale lock exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "active_lock: optimizer skillopt-train:optimizer-train:optimizer-train-001 status=stale") ||
+		!strings.Contains(stdout.String(), "watch_state: waiting") {
+		t.Fatalf("train status watch stale lock stdout = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue stale lock recovery exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"optimizer_lock: recovered_stale",
+		"current_phase: candidate_created",
+		"imported_candidate: planner@v2",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train continue stale lock recovery stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("optimizer calls after stale lock recovery = %+v, want one", runner.calls)
+	}
+}
+
+func TestSkillOptTrainContinueRefusesLegacyOptimizerLock(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with legacy-lock-safe candidate guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	store := openCLIJobStore(t, home)
+	now := time.Now().UTC()
+	acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey: skillOptTrainLegacyOptimizerLockKey("optimizer-train", "optimizer-train-001"),
+		OwnerJobID:  "legacy-optimizer",
+		OwnerToken:  "legacy-token",
+		ExpiresAt:   now.Add(time.Minute).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		t.Fatalf("AcquireResourceLock legacy returned error: %v", err)
+	}
+	if !acquired {
+		t.Fatal("AcquireResourceLock did not create legacy optimizer lock")
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close legacy lock store returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue legacy lock exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "skillopt-train-optimizer:optimizer-train:optimizer-train-001") {
+		t.Fatalf("legacy optimizer stderr = %q", stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("optimizer ran while legacy lock was held: %+v", runner.calls)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "status", "--home", home, "--session", "optimizer-train", "--verbose"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train status legacy lock exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "active_lock: optimizer_legacy skillopt-train-optimizer:optimizer-train:optimizer-train-001 status=active") {
+		t.Fatalf("train status legacy lock stdout = %s", stdout.String())
 	}
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -326,12 +326,15 @@ type BranchLockEvent struct {
 }
 
 type ResourceLock struct {
-	ResourceKey string
-	OwnerJobID  string
-	OwnerToken  string
-	AcquiredAt  string
-	UpdatedAt   string
-	ExpiresAt   string
+	ResourceKey   string
+	OwnerJobID    string
+	OwnerToken    string
+	OwnerPID      int64
+	OwnerHostname string
+	CommandHash   string
+	AcquiredAt    string
+	UpdatedAt     string
+	ExpiresAt     string
 }
 
 type MergeGate struct {
@@ -3009,8 +3012,8 @@ func (s *Store) AcquireResourceLock(ctx context.Context, lock ResourceLock, now 
 			)`, resourceKey, nowText); err != nil {
 		return false, err
 	}
-	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO resource_locks(resource_key, owner_job_id, owner_token, acquired_at, updated_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?)`, resourceKey, ownerJobID, ownerToken, nowText, nowText, expiresAt)
+	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO resource_locks(resource_key, owner_job_id, owner_token, owner_pid, owner_hostname, command_hash, acquired_at, updated_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, resourceKey, ownerJobID, ownerToken, lock.OwnerPID, strings.TrimSpace(lock.OwnerHostname), strings.TrimSpace(lock.CommandHash), nowText, nowText, expiresAt)
 	if err != nil {
 		return false, err
 	}
@@ -3025,12 +3028,27 @@ func (s *Store) AcquireResourceLock(ctx context.Context, lock ResourceLock, now 
 }
 
 func (s *Store) GetResourceLock(ctx context.Context, resourceKey string) (ResourceLock, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT resource_key, owner_job_id, owner_token, acquired_at, updated_at, expires_at FROM resource_locks WHERE resource_key = ?`, resourceKey)
+	row := s.db.QueryRowContext(ctx, `SELECT resource_key, owner_job_id, owner_token, owner_pid, owner_hostname, command_hash, acquired_at, updated_at, expires_at FROM resource_locks WHERE resource_key = ?`, resourceKey)
 	var lock ResourceLock
-	if err := row.Scan(&lock.ResourceKey, &lock.OwnerJobID, &lock.OwnerToken, &lock.AcquiredAt, &lock.UpdatedAt, &lock.ExpiresAt); err != nil {
+	if err := row.Scan(&lock.ResourceKey, &lock.OwnerJobID, &lock.OwnerToken, &lock.OwnerPID, &lock.OwnerHostname, &lock.CommandHash, &lock.AcquiredAt, &lock.UpdatedAt, &lock.ExpiresAt); err != nil {
 		return ResourceLock{}, err
 	}
 	return lock, nil
+}
+
+func (s *Store) HeartbeatResourceLock(ctx context.Context, resourceKey string, ownerJobID string, ownerToken string, now time.Time, expiresAt time.Time) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `UPDATE resource_locks
+		SET updated_at = ?, expires_at = ?
+		WHERE resource_key = ? AND owner_job_id = ? AND owner_token = ?`,
+		formatResourceLockTime(now), formatResourceLockTime(expiresAt), strings.TrimSpace(resourceKey), strings.TrimSpace(ownerJobID), strings.TrimSpace(ownerToken))
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
 }
 
 func (s *Store) ReleaseResourceLock(ctx context.Context, resourceKey string, ownerJobID string, ownerToken string) (bool, error) {
@@ -3048,6 +3066,7 @@ func (s *Store) ReleaseResourceLock(ctx context.Context, resourceKey string, own
 func (s *Store) DeleteExpiredResourceLocks(ctx context.Context, now time.Time) (int64, error) {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks
 		WHERE expires_at <= ?
+			AND owner_pid <= 0
 			AND NOT EXISTS (
 				SELECT 1 FROM jobs
 				WHERE jobs.id = resource_locks.owner_job_id
@@ -3870,5 +3889,10 @@ ALTER TABLE ranked_feedback_events ADD COLUMN promote TEXT NOT NULL DEFAULT '';
 	`,
 	`
 ALTER TABLE ranked_feedback_events ADD COLUMN required_improvements_json TEXT NOT NULL DEFAULT '';
+	`,
+	`
+ALTER TABLE resource_locks ADD COLUMN owner_pid INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE resource_locks ADD COLUMN owner_hostname TEXT NOT NULL DEFAULT '';
+ALTER TABLE resource_locks ADD COLUMN command_hash TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -669,10 +669,13 @@ func TestResourceLockMethods(t *testing.T) {
 
 	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
 	lock := ResourceLock{
-		ResourceKey: "runtime:codex:session-a",
-		OwnerJobID:  "job-a",
-		OwnerToken:  "token-a",
-		ExpiresAt:   now.Add(time.Minute).Format(time.RFC3339Nano),
+		ResourceKey:   "runtime:codex:session-a",
+		OwnerJobID:    "job-a",
+		OwnerToken:    "token-a",
+		OwnerPID:      12345,
+		OwnerHostname: "host-a",
+		CommandHash:   "hash-a",
+		ExpiresAt:     now.Add(time.Minute).Format(time.RFC3339Nano),
 	}
 	acquired, err := store.AcquireResourceLock(ctx, lock, now)
 	if err != nil {
@@ -709,11 +712,24 @@ func TestResourceLockMethods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetResourceLock returned error: %v", err)
 	}
-	if stored.OwnerJobID != "job-a" || stored.OwnerToken != "token-a" || stored.AcquiredAt == "" || stored.UpdatedAt == "" || stored.ExpiresAt == "" {
+	if stored.OwnerJobID != "job-a" || stored.OwnerToken != "token-a" || stored.OwnerPID != 12345 || stored.OwnerHostname != "host-a" || stored.CommandHash != "hash-a" || stored.AcquiredAt == "" || stored.UpdatedAt == "" || stored.ExpiresAt == "" {
 		t.Fatalf("resource lock = %+v", stored)
 	}
 	if stored.ExpiresAt != formatResourceLockTime(now.Add(time.Minute)) {
 		t.Fatalf("resource lock expiry = %q, want fixed-width timestamp", stored.ExpiresAt)
+	}
+	if updated, err := store.HeartbeatResourceLock(ctx, lock.ResourceKey, "job-a", "wrong-token", now.Add(20*time.Second), now.Add(2*time.Minute)); err != nil || updated {
+		t.Fatalf("wrong-token HeartbeatResourceLock returned updated=%v err=%v", updated, err)
+	}
+	if updated, err := store.HeartbeatResourceLock(ctx, lock.ResourceKey, "job-a", "token-a", now.Add(30*time.Second), now.Add(2*time.Minute)); err != nil || !updated {
+		t.Fatalf("HeartbeatResourceLock returned updated=%v err=%v", updated, err)
+	}
+	stored, err = store.GetResourceLock(ctx, lock.ResourceKey)
+	if err != nil {
+		t.Fatalf("GetResourceLock after heartbeat returned error: %v", err)
+	}
+	if stored.UpdatedAt != formatResourceLockTime(now.Add(30*time.Second)) || stored.ExpiresAt != formatResourceLockTime(now.Add(2*time.Minute)) {
+		t.Fatalf("heartbeat lock times = updated %q expires %q", stored.UpdatedAt, stored.ExpiresAt)
 	}
 	released, err := store.ReleaseResourceLock(ctx, lock.ResourceKey, "job-b", "token-a")
 	if err != nil {
@@ -783,6 +799,42 @@ func TestResourceLockRecoversExpiredLock(t *testing.T) {
 	}
 	if deleted != 1 {
 		t.Fatalf("expired locks deleted = %d, want 1", deleted)
+	}
+}
+
+func TestResourceLockCleanupSkipsPIDBackedLease(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	if acquired, err := store.AcquireResourceLock(ctx, ResourceLock{
+		ResourceKey:   "skillopt-train:session-a:iteration-a",
+		OwnerJobID:    "local-skillopt-train-optimizer-a",
+		OwnerToken:    "token-a",
+		OwnerPID:      12345,
+		OwnerHostname: "host-a",
+		CommandHash:   "hash-a",
+		ExpiresAt:     now.Add(time.Minute).Format(time.RFC3339Nano),
+	}, now); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	deleted, err := store.DeleteExpiredResourceLocks(ctx, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("DeleteExpiredResourceLocks returned error: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("expired pid-backed locks deleted = %d, want 0", deleted)
+	}
+	stored, err := store.GetResourceLock(ctx, "skillopt-train:session-a:iteration-a")
+	if err != nil {
+		t.Fatalf("GetResourceLock returned error: %v", err)
+	}
+	if stored.OwnerPID != 12345 || stored.CommandHash != "hash-a" {
+		t.Fatalf("resource lock metadata = pid %d hash %q, want pid 12345 hash-a", stored.OwnerPID, stored.CommandHash)
 	}
 }
 


### PR DESCRIPTION
WHAT

Add lease-style heartbeat locking for SkillOpt train optimizer runs.

WHY

Issue #115 called out optimizer wrapper runs getting stuck or duplicated during long SkillOpt training flows. The train loop needs a clear active/stale owner signal, bounded stale recovery, and status output that explains who owns the optimizer lock.

CHANGES

- Changed optimizer lock keying to `skillopt-train:{session}:{iteration}` while also acquiring/checking the legacy optimizer key for mixed-version safety.
- Added resource lock metadata: owner PID, hostname, command/config hash, acquired time, updated heartbeat time, and expiry.
- Added token-scoped heartbeat updates for optimizer locks.
- Added short heartbeat leases separate from optimizer runtime timeout, with a bounded expired-heartbeat grace period to avoid indefinite PID-reuse blocks.
- Added active/stale/active-expired-heartbeat status reporting in verbose train status output.
- Prevented daemon cleanup from deleting expired PID-backed optimizer leases; SkillOpt status/continue now handles stale recovery explicitly.
- Added tests for metadata round-trip, heartbeat token scoping, daemon cleanup behavior, duplicate optimizer blocking, stale recovery, legacy lock compatibility, watch behavior, and bounded PID liveness.

RESULTS

- `gofmt -w internal/cli/skillopt.go internal/cli/skillopt_test.go internal/db/store.go internal/db/store_test.go`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/db ./internal/cli -run 'ResourceLock|SkillOptTrainOptimizerLockStatus|SkillOptTrainContinueRefusesConcurrentOptimizer|SkillOptTrainContinueReportsStaleOptimizerLock|SkillOptTrainContinueRefusesLegacyOptimizerLock|SkillOptTrainWatchDone|SkillOptTrainStatus'` passed.
- `GOTOOLCHAIN=go1.26.2 go test ./internal/db ./internal/cli` passed:
  - `ok   github.com/jerryfane/gitmoot/internal/db   (cached)`
  - `ok   github.com/jerryfane/gitmoot/internal/cli  191.612s`
- `git diff --check` passed.
- Final `codex exec review --uncommitted` output:

```text
I found no discrete correctness issues in the staged, unstaged, or untracked changes.
```

RISK

No skipped required checks. The review sandbox's default `GOTOOLCHAIN=local` used Go 1.22.2 and could not run this Go 1.26 repo, so the required tests were run directly with `GOTOOLCHAIN=go1.26.2`.
