### PR TITLE
skillopt: recover train optimizer artifacts

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -85,6 +85,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
+	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -100,6 +101,8 @@ func runSkillOptTrain(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptTrainStatus(args[1:], stdout, stderr)
 	case "continue":
 		return runSkillOptTrainContinue(args[1:], stdout, stderr)
+	case "recover":
+		return runSkillOptTrainRecover(args[1:], stdout, stderr)
 	case "stop":
 		return runSkillOptTrainStop(args[1:], stdout, stderr)
 	default:
@@ -114,6 +117,7 @@ func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--preview-mode none|optional|required] [--preview-renderer none|vue-vite] [--preview-publisher none|github-pages] [--preview-route-template template] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
+	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -561,6 +565,54 @@ func skillOptTrainStatusOutputSnapshot(snapshot skillOptTrainStatusSnapshot, ver
 	}
 	snapshot.Verbose = nil
 	return snapshot
+}
+
+func runSkillOptTrainRecover(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt train recover", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	sessionID := fs.String("session", "", "train session id")
+	outRoot := fs.String("out-root", "", "optimizer output directory; defaults to the persisted train optimizer path")
+	jsonOutput := fs.Bool("json", false, "print recovery result as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt train recover does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*sessionID) == "" {
+		fmt.Fprintln(stderr, "skillopt train recover requires --session")
+		return 2
+	}
+	var result skillOptTrainRecoverResult
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		var recoverErr error
+		result, recoverErr = recoverSkillOptTrainOptimizerArtifacts(context.Background(), paths, store, *sessionID, *outRoot)
+		return recoverErr
+	}); err != nil {
+		if result.SessionID != "" {
+			if *jsonOutput {
+				_ = writeJSON(stdout, result)
+			} else {
+				printSkillOptTrainRecoverResult(stdout, result)
+			}
+		}
+		fmt.Fprintf(stderr, "skillopt train recover: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, result); err != nil {
+			fmt.Fprintf(stderr, "skillopt train recover: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printSkillOptTrainRecoverResult(stdout, result)
+	return 0
 }
 
 func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
@@ -1207,6 +1259,21 @@ type skillOptTrainOptimizerResult struct {
 	CandidateVersionID    string
 	NoCandidateReason     string
 	NoCandidateNextAction string
+}
+
+type skillOptTrainRecoverResult struct {
+	SessionID            string   `json:"session_id"`
+	IterationID          string   `json:"iteration_id"`
+	Classification       string   `json:"classification"`
+	CurrentPhase         string   `json:"current_phase"`
+	CandidateVersionID   string   `json:"candidate_version_id,omitempty"`
+	NoCandidateReason    string   `json:"no_candidate_reason,omitempty"`
+	NextAction           string   `json:"next_action,omitempty"`
+	RecoveryAvailable    bool     `json:"recovery_available"`
+	OutRoot              string   `json:"out_root,omitempty"`
+	CandidatePackagePath string   `json:"candidate_package,omitempty"`
+	ArtifactDir          string   `json:"artifact_dir,omitempty"`
+	Artifacts            []string `json:"artifacts,omitempty"`
 }
 
 type skillOptTrainBackendResolution struct {
@@ -4255,6 +4322,10 @@ func buildSkillOptTrainStatusVerbose(ctx context.Context, store *db.Store, sessi
 		NoCandidateReason: metadataString(candidateImport, "no_candidate_reason"),
 	}
 	if optimizer := decodedSkillOptMetadataValue(iterationMetadata["optimizer"]); len(optimizer) > 0 {
+		optimizerPaths, err := resolveSkillOptTrainOptimizerPaths(config.Paths{}, session, *iteration, skillOptTrainOptimizerRequest{})
+		if err == nil {
+			optimizer["recovery_available"] = skillOptTrainOptimizerRecoveryAvailable(optimizerPaths)
+		}
 		details.Optimizer = optimizer
 	}
 	activeLocks, err := skillOptTrainActiveLocks(ctx, store, session.ID, iteration.ID)
@@ -4549,6 +4620,11 @@ func printSkillOptTrainStatusSnapshot(stdout io.Writer, snapshot skillOptTrainSt
 	}
 	if snapshot.Verbose.Candidate.NoCandidateReason != "" {
 		writeLine(stdout, "no_candidate_reason: %s", snapshot.Verbose.Candidate.NoCandidateReason)
+	}
+	if snapshot.Verbose.Optimizer != nil {
+		if available, ok := snapshot.Verbose.Optimizer["recovery_available"]; ok {
+			writeLine(stdout, "optimizer_recovery_available: %v", available)
+		}
 	}
 	for _, lock := range snapshot.Verbose.ActiveLocks {
 		writeLine(stdout, "active_lock: %s", skillOptTrainStatusLockText(lock))
@@ -5140,6 +5216,324 @@ func skillOptTrainOptimizerRecoveryAvailable(paths skillOptTrainOptimizerPaths) 
 		}
 	}
 	return false
+}
+
+func recoverSkillOptTrainOptimizerArtifacts(ctx context.Context, paths config.Paths, store *db.Store, sessionID string, outRoot string) (skillOptTrainRecoverResult, error) {
+	session, iteration, _, err := loadSkillOptTrainStatus(ctx, store, sessionID)
+	if err != nil {
+		return skillOptTrainRecoverResult{}, err
+	}
+	if iteration == nil {
+		return skillOptTrainRecoverResult{SessionID: strings.TrimSpace(session.ID), Classification: "unrecoverable"}, errors.New("train session has no iteration to recover")
+	}
+	optimizerPaths, err := resolveSkillOptTrainOptimizerPaths(paths, session, *iteration, skillOptTrainOptimizerRequest{OutRoot: outRoot})
+	if err != nil {
+		return skillOptTrainRecoverResult{}, err
+	}
+	result := skillOptTrainRecoverResult{
+		SessionID:            strings.TrimSpace(session.ID),
+		IterationID:          strings.TrimSpace(iteration.ID),
+		CurrentPhase:         skillopt.NormalizeTrainState(iteration.State),
+		RecoveryAvailable:    skillOptTrainOptimizerRecoveryAvailable(optimizerPaths),
+		OutRoot:              optimizerPaths.OutRoot,
+		CandidatePackagePath: optimizerPaths.CandidatePackagePath,
+		ArtifactDir:          optimizerPaths.ArtifactDir,
+		Artifacts:            existingSkillOptTrainOptimizerArtifacts(optimizerPaths),
+	}
+	switch skillopt.NormalizeTrainState(iteration.State) {
+	case skillopt.TrainStateCandidateCreated, skillopt.TrainStateCandidateReviewPublished, skillopt.TrainStateCandidatePromoted, skillopt.TrainStateCandidateRejected:
+		result.Classification = "already_completed_candidate"
+		result.CandidateVersionID = strings.TrimSpace(iteration.CandidateVersionID)
+		result.NextAction = "candidate already exists; continue with candidate review or decision"
+		return result, nil
+	case skillopt.TrainStateOptimizerCompletedNoCandidate:
+		result.Classification = "already_completed_no_candidate"
+		result.NoCandidateReason = skillOptMetadataString(iteration.MetadataJSON, "candidate_import", "no_candidate_reason")
+		result.NextAction = skillOptNoCandidateNextAction()
+		return result, nil
+	}
+	releaseOptimizerLock, _, err := acquireSkillOptTrainOptimizerLock(ctx, store, session.ID, iteration.ID, skillOptTrainOptimizerLockTTL, skillOptTrainOptimizerRequest{OutRoot: optimizerPaths.OutRoot})
+	if err != nil {
+		result.Classification = "optimizer_active"
+		result.NextAction = "wait for the active optimizer run to finish before recovering artifacts"
+		return result, err
+	}
+	defer func() {
+		_ = releaseOptimizerLock(context.Background())
+	}()
+	session, iteration, _, err = loadSkillOptTrainStatus(ctx, store, sessionID)
+	if err != nil {
+		result.Classification = "corrupted_unrecoverable"
+		return result, err
+	}
+	if iteration == nil {
+		result.CurrentPhase = ""
+		result.Classification = "unrecoverable"
+		return result, errors.New("train session has no iteration to recover")
+	}
+	optimizerPaths, err = resolveSkillOptTrainOptimizerPaths(paths, session, *iteration, skillOptTrainOptimizerRequest{OutRoot: outRoot})
+	if err != nil {
+		result.Classification = "corrupted_unrecoverable"
+		return result, err
+	}
+	result.CurrentPhase = skillopt.NormalizeTrainState(iteration.State)
+	result.RecoveryAvailable = skillOptTrainOptimizerRecoveryAvailable(optimizerPaths)
+	result.OutRoot = optimizerPaths.OutRoot
+	result.CandidatePackagePath = optimizerPaths.CandidatePackagePath
+	result.ArtifactDir = optimizerPaths.ArtifactDir
+	result.Artifacts = existingSkillOptTrainOptimizerArtifacts(optimizerPaths)
+	switch skillopt.NormalizeTrainState(iteration.State) {
+	case skillopt.TrainStateCandidateCreated, skillopt.TrainStateCandidateReviewPublished, skillopt.TrainStateCandidatePromoted, skillopt.TrainStateCandidateRejected:
+		result.Classification = "already_completed_candidate"
+		result.CandidateVersionID = strings.TrimSpace(iteration.CandidateVersionID)
+		result.NextAction = "candidate already exists; continue with candidate review or decision"
+		return result, nil
+	case skillopt.TrainStateOptimizerCompletedNoCandidate:
+		result.Classification = "already_completed_no_candidate"
+		result.NoCandidateReason = skillOptMetadataString(iteration.MetadataJSON, "candidate_import", "no_candidate_reason")
+		result.NextAction = skillOptNoCandidateNextAction()
+		return result, nil
+	}
+	candidateContent, err := os.ReadFile(optimizerPaths.CandidatePackagePath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			result.Classification = "corrupted_unrecoverable"
+			return result, fmt.Errorf("read optimizer candidate package: %w", err)
+		}
+		if reason := noCandidateReasonFromSkillOptTrainOptimizerArtifacts(optimizerPaths); reason != "" {
+			session, iteration, err = markSkillOptTrainOptimizerRecoveredComplete(ctx, store, session, *iteration, optimizerPaths)
+			if err != nil {
+				result.Classification = "corrupted_unrecoverable"
+				return result, err
+			}
+			if err := recordSkillOptTrainNoCandidate(ctx, store, session, *iteration, optimizerPaths, reason); err != nil {
+				result.Classification = "corrupted_unrecoverable"
+				return result, err
+			}
+			result.Classification = "completed_no_candidate"
+			result.CurrentPhase = skillopt.TrainStateOptimizerCompletedNoCandidate
+			result.NoCandidateReason = reason
+			result.NextAction = skillOptNoCandidateNextAction()
+			return result, nil
+		}
+		if result.RecoveryAvailable {
+			result.Classification = "incomplete_resumable"
+			result.NextAction = "candidate package is missing; rerun the optimizer with --rerun-optimizer or inspect the artifact directory"
+			return result, errors.New("optimizer artifacts are present but candidate.json is missing")
+		}
+		result.Classification = "unavailable"
+		result.NextAction = "run the optimizer before attempting recovery"
+		return result, errors.New("no recoverable optimizer artifacts found")
+	}
+	var candidate skillopt.CandidatePackage
+	if err := json.Unmarshal(candidateContent, &candidate); err != nil {
+		result.Classification = "corrupted_unrecoverable"
+		return result, fmt.Errorf("decode optimizer candidate package: %w", err)
+	}
+	if err := validateSkillOptTrainCandidatePackage(ctx, store, session, *iteration, candidate); err != nil {
+		if errors.Is(err, skillopt.ErrNoCandidate) {
+			reason := skillOptNoCandidateReason(err)
+			session, iteration, err = markSkillOptTrainOptimizerRecoveredComplete(ctx, store, session, *iteration, optimizerPaths)
+			if err != nil {
+				result.Classification = "corrupted_unrecoverable"
+				return result, err
+			}
+			if err := recordSkillOptTrainNoCandidate(ctx, store, session, *iteration, optimizerPaths, reason); err != nil {
+				result.Classification = "corrupted_unrecoverable"
+				return result, err
+			}
+			result.Classification = "completed_no_candidate"
+			result.CurrentPhase = skillopt.TrainStateOptimizerCompletedNoCandidate
+			result.NoCandidateReason = reason
+			result.NextAction = skillOptNoCandidateNextAction()
+			return result, nil
+		}
+		result.Classification = "corrupted_unrecoverable"
+		return result, err
+	}
+	if err := validateSkillOptTrainOptimizerRecoverableCompleteState(*iteration); err != nil {
+		result.Classification = "corrupted_unrecoverable"
+		return result, err
+	}
+	version, err := importSkillOptTrainCandidate(ctx, paths, store, session, *iteration, optimizerPaths)
+	if err != nil {
+		if errors.Is(err, skillopt.ErrNoCandidate) {
+			reason := skillOptNoCandidateReason(err)
+			session, iteration, err = markSkillOptTrainOptimizerRecoveredComplete(ctx, store, session, *iteration, optimizerPaths)
+			if err != nil {
+				result.Classification = "corrupted_unrecoverable"
+				return result, err
+			}
+			if err := recordSkillOptTrainNoCandidate(ctx, store, session, *iteration, optimizerPaths, reason); err != nil {
+				result.Classification = "corrupted_unrecoverable"
+				return result, err
+			}
+			result.Classification = "completed_no_candidate"
+			result.CurrentPhase = skillopt.TrainStateOptimizerCompletedNoCandidate
+			result.NoCandidateReason = reason
+			result.NextAction = skillOptNoCandidateNextAction()
+			return result, nil
+		}
+		result.Classification = "corrupted_unrecoverable"
+		return result, err
+	}
+	session, iteration, err = markSkillOptTrainOptimizerRecoveredComplete(ctx, store, session, *iteration, optimizerPaths)
+	if err != nil {
+		result.Classification = "corrupted_unrecoverable"
+		return result, err
+	}
+	metadata := map[string]any{
+		"status":            "recovered",
+		"candidate_version": version.ID,
+		"candidate_package": optimizerPaths.CandidatePackagePath,
+		"artifact_dir":      optimizerPaths.ArtifactDir,
+		"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
+		"source":            "gitmoot skillopt train recover",
+	}
+	session.State = skillopt.TrainStateCandidateCreated
+	iteration.State = skillopt.TrainStateCandidateCreated
+	iteration.CandidateVersionID = version.ID
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_import", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_import", metadata)
+	if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+		result.Classification = "corrupted_unrecoverable"
+		return result, err
+	}
+	if err := store.UpsertSkillOptTrainIteration(ctx, *iteration); err != nil {
+		result.Classification = "corrupted_unrecoverable"
+		return result, err
+	}
+	result.Classification = "completed_candidate"
+	result.CurrentPhase = skillopt.TrainStateCandidateCreated
+	result.CandidateVersionID = version.ID
+	result.NextAction = "publish candidate diff and preview review with train continue"
+	return result, nil
+}
+
+func validateSkillOptTrainOptimizerRecoverableCompleteState(iteration db.SkillOptTrainIteration) error {
+	state := skillopt.NormalizeTrainState(iteration.State)
+	switch state {
+	case skillopt.TrainStateOptimizerCompleted, skillopt.TrainStateTrainingPackageCreated:
+		return nil
+	default:
+		return fmt.Errorf("cannot recover optimizer artifacts while iteration is in state %s", state)
+	}
+}
+
+func markSkillOptTrainOptimizerRecoveredComplete(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, paths skillOptTrainOptimizerPaths) (db.SkillOptTrainSession, *db.SkillOptTrainIteration, error) {
+	if err := validateSkillOptTrainOptimizerRecoverableCompleteState(iteration); err != nil {
+		return db.SkillOptTrainSession{}, nil, err
+	}
+	if skillopt.NormalizeTrainState(iteration.State) == skillopt.TrainStateOptimizerCompleted {
+		return session, &iteration, nil
+	}
+	metadata := map[string]any{
+		"status":           "recovered",
+		"training_package": paths.TrainingPackagePath,
+		"out_root":         paths.OutRoot,
+		"artifact_root":    paths.ArtifactRoot,
+		"candidate_output": paths.CandidatePackagePath,
+		"artifact_dir":     paths.ArtifactDir,
+		"completed_at":     time.Now().UTC().Format(time.RFC3339Nano),
+		"source":           "gitmoot skillopt train recover",
+	}
+	session.State = skillopt.TrainStateOptimizerCompleted
+	iteration.State = skillopt.TrainStateOptimizerCompleted
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "optimizer", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "optimizer", metadata)
+	if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+		return db.SkillOptTrainSession{}, nil, err
+	}
+	if err := store.UpsertSkillOptTrainIteration(ctx, iteration); err != nil {
+		return db.SkillOptTrainSession{}, nil, err
+	}
+	return session, &iteration, nil
+}
+
+func existingSkillOptTrainOptimizerArtifacts(paths skillOptTrainOptimizerPaths) []string {
+	candidates := []string{
+		paths.CandidatePackagePath,
+		filepath.Join(paths.OutRoot, "summary.json"),
+		filepath.Join(paths.OutRoot, "runtime_state.json"),
+		filepath.Join(paths.OutRoot, "history.json"),
+		filepath.Join(paths.OutRoot, "best_skill.md"),
+	}
+	existing := []string{}
+	for _, path := range candidates {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		if _, err := os.Stat(path); err == nil {
+			existing = append(existing, path)
+		}
+	}
+	return existing
+}
+
+func noCandidateReasonFromSkillOptTrainOptimizerArtifacts(paths skillOptTrainOptimizerPaths) string {
+	for _, path := range []string{
+		filepath.Join(paths.OutRoot, "summary.json"),
+		filepath.Join(paths.OutRoot, "runtime_state.json"),
+		filepath.Join(paths.OutRoot, "history.json"),
+	} {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var data any
+		if err := json.Unmarshal(content, &data); err != nil {
+			continue
+		}
+		if reason := noCandidateReasonFromValue(data); reason != "" {
+			return reason
+		}
+	}
+	return ""
+}
+
+func noCandidateReasonFromValue(value any) string {
+	switch typed := value.(type) {
+	case map[string]any:
+		if raw, ok := typed["no_candidate_reason"]; ok {
+			if text, ok := raw.(string); ok {
+				reason := strings.TrimSpace(text)
+				if reason != "" {
+					return reason
+				}
+			}
+		}
+		for _, nested := range typed {
+			if reason := noCandidateReasonFromValue(nested); reason != "" {
+				return reason
+			}
+		}
+	case []any:
+		for _, nested := range typed {
+			if reason := noCandidateReasonFromValue(nested); reason != "" {
+				return reason
+			}
+		}
+	}
+	return ""
+}
+
+func printSkillOptTrainRecoverResult(stdout io.Writer, result skillOptTrainRecoverResult) {
+	writeLine(stdout, "session: %s", result.SessionID)
+	writeLine(stdout, "iteration: %s", emptyText(result.IterationID))
+	writeLine(stdout, "recovery_state: %s", emptyText(result.Classification))
+	writeLine(stdout, "current_phase: %s", emptyText(result.CurrentPhase))
+	writeLine(stdout, "recovery_available: %t", result.RecoveryAvailable)
+	writeLine(stdout, "optimizer_out_root: %s", emptyText(result.OutRoot))
+	writeLine(stdout, "candidate_package: %s", emptyText(result.CandidatePackagePath))
+	writeLine(stdout, "artifact_dir: %s", emptyText(result.ArtifactDir))
+	writeLine(stdout, "candidate: %s", emptyText(result.CandidateVersionID))
+	if result.NoCandidateReason != "" {
+		writeLine(stdout, "no_candidate_reason: %s", result.NoCandidateReason)
+	}
+	if len(result.Artifacts) > 0 {
+		writeLine(stdout, "artifacts: %s", strings.Join(result.Artifacts, ","))
+	}
+	writeLine(stdout, "next: %s", emptyText(result.NextAction))
 }
 
 func buildSkillOptTrainOptimizerCommand(iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest, paths skillOptTrainOptimizerPaths) (string, []string, error) {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -4567,6 +4567,16 @@ func TestSkillOptTrainContinueReportsRecoveryAfterOptimizerFailureArtifacts(t *t
 		t.Fatalf("candidate package was not written before failure: %v", err)
 	}
 
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "status", "--home", home, "--session", "optimizer-train", "--verbose"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train status after recoverable optimizer failure exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "optimizer_recovery_available: true") {
+		t.Fatalf("train status did not advertise recovery:\n%s", stdout.String())
+	}
+
 	store := openCLIJobStore(t, home)
 	defer store.Close()
 	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
@@ -4575,6 +4585,332 @@ func TestSkillOptTrainContinueReportsRecoveryAfterOptimizerFailureArtifacts(t *t
 	}
 	if iteration.State != skillopt.TrainStateTrainingPackageCreated || iteration.CandidateVersionID != "" {
 		t.Fatalf("iteration after recoverable optimizer failure = %+v", iteration)
+	}
+}
+
+func TestSkillOptTrainRecoverImportsCandidateArtifacts(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate:          cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with recovered candidate guidance."),
+		failAfterCandidate: true,
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--out-root", outRoot}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue recoverable failure exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train recover candidate exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"recovery_state: completed_candidate",
+		"current_phase: candidate_created",
+		"candidate: planner@v2",
+		"next: publish candidate diff and preview review",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train recover candidate stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateCandidateCreated || iteration.CandidateVersionID != "planner@v2" {
+		t.Fatalf("iteration after candidate recovery = %+v", iteration)
+	}
+	if _, err := store.GetAgentTemplateCandidateReview(context.Background(), "planner@v2"); err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview recovered candidate returned error: %v", err)
+	}
+}
+
+func TestSkillOptTrainRecoverRecordsNoCandidateArtifacts(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate:          cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan the work."),
+		failAfterCandidate: true,
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--out-root", outRoot}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue no-candidate recoverable failure exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train recover no-candidate exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"recovery_state: completed_no_candidate",
+		"current_phase: optimizer_completed_no_candidate",
+		"no_candidate_reason: candidate content is unchanged from the base version",
+		"next: do not publish a candidate review",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("train recover no-candidate stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateOptimizerCompletedNoCandidate || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after no-candidate recovery = %+v", iteration)
+	}
+}
+
+func TestSkillOptTrainRecoverReportsIncompleteArtifacts(t *testing.T) {
+	home, _ := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{fail: true}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--out-root", outRoot}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue failed optimizer exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if err := os.WriteFile(filepath.Join(outRoot, "summary.json"), []byte(`{"status":"failed","reason":"timeout","no_candidate_reason":null}`), 0o644); err != nil {
+		t.Fatalf("write summary artifact returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train recover incomplete exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "recovery_state: incomplete_resumable") ||
+		!strings.Contains(stderr.String(), "candidate.json is missing") {
+		t.Fatalf("train recover incomplete stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateTrainingPackageCreated || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after incomplete recovery = %+v", iteration)
+	}
+}
+
+func TestSkillOptTrainRecoverRejectsCorruptedCandidateArtifacts(t *testing.T) {
+	home, _ := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{fail: true}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--out-root", outRoot}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue failed optimizer exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if err := os.WriteFile(filepath.Join(outRoot, "candidate.json"), []byte(`{not-json`), 0o644); err != nil {
+		t.Fatalf("write corrupted candidate returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train recover corrupted exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "recovery_state: corrupted_unrecoverable") ||
+		!strings.Contains(stderr.String(), "decode optimizer candidate package") {
+		t.Fatalf("train recover corrupted stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateTrainingPackageCreated || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after corrupted recovery = %+v", iteration)
+	}
+}
+
+func TestSkillOptTrainRecoverLeavesStateOnMissingCandidateArtifact(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate:          cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with missing artifact recovery guidance."),
+		failAfterCandidate: true,
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--out-root", outRoot}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue recoverable failure exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if err := os.Remove(filepath.Join(outRoot, "artifacts", "candidate.diff.md")); err != nil {
+		t.Fatalf("remove candidate diff artifact returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train recover missing artifact exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "recovery_state: corrupted_unrecoverable") ||
+		!strings.Contains(stderr.String(), `candidate artifact "candidate-diff"`) {
+		t.Fatalf("train recover missing artifact stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateTrainingPackageCreated || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after missing artifact recovery = %+v", iteration)
+	}
+	if _, err := store.GetAgentTemplateCandidateReview(context.Background(), "planner@v2"); err == nil {
+		t.Fatalf("missing artifact recovery unexpectedly imported candidate review")
+	}
+}
+
+func TestSkillOptTrainRecoverRejectsCandidateBeforePackageState(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	artifactDir := filepath.Join(outRoot, "artifacts")
+	diffContent := []byte("candidate diff\n")
+	diffSize := int64(len(diffContent))
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("create artifact dir returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactDir, "candidate.diff.md"), diffContent, 0o644); err != nil {
+		t.Fatalf("write candidate diff artifact returned error: %v", err)
+	}
+	candidate := cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with premature recovery guidance.")
+	candidate.Summary.DiffArtifactID = "candidate-diff"
+	candidate.Artifacts = []skillopt.CandidateArtifactRef{{
+		ID:        "candidate-diff",
+		Path:      "candidate.diff.md",
+		Hash:      artifact.ContentHash(diffContent),
+		MediaType: "text/markdown",
+		Driver:    "text",
+		SizeBytes: &diffSize,
+	}}
+	encoded, err := json.Marshal(candidate)
+	if err != nil {
+		t.Fatalf("marshal candidate package returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outRoot, "candidate.json"), encoded, 0o644); err != nil {
+		t.Fatalf("write candidate package returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "optimizer-train", "--out-root", outRoot}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train recover premature candidate exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "recovery_state: corrupted_unrecoverable") ||
+		!strings.Contains(stderr.String(), "cannot recover optimizer artifacts while iteration is in state feedback_synced") {
+		t.Fatalf("train recover premature candidate stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateFeedbackSynced || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after premature recovery = %+v", iteration)
+	}
+	if _, err := store.GetAgentTemplateCandidateReview(context.Background(), "planner@v2"); err == nil {
+		t.Fatalf("premature recovery unexpectedly imported candidate review")
+	}
+}
+
+func TestSkillOptTrainRecoverRefusesActiveOptimizerLock(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate:          cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with locked recovery guidance."),
+		failAfterCandidate: true,
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train", "--out-root", outRoot}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue recoverable failure exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	release, _, err := acquireSkillOptTrainOptimizerLock(context.Background(), store, "optimizer-train", "optimizer-train-001", time.Hour, skillOptTrainOptimizerRequest{OutRoot: outRoot})
+	if err != nil {
+		t.Fatalf("acquire optimizer lock returned error: %v", err)
+	}
+	defer store.Close()
+	defer func() {
+		_ = release(context.Background())
+	}()
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train recover locked optimizer exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "recovery_state: optimizer_active") ||
+		!strings.Contains(stderr.String(), "skillopt train optimizer is already running") {
+		t.Fatalf("train recover locked stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateTrainingPackageCreated || iteration.CandidateVersionID != "" {
+		t.Fatalf("iteration after locked recovery = %+v", iteration)
+	}
+	if _, err := store.GetAgentTemplateCandidateReview(context.Background(), "planner@v2"); err == nil {
+		t.Fatalf("locked recovery unexpectedly imported candidate review")
 	}
 }
 


### PR DESCRIPTION
## WHAT

Adds `gitmoot skillopt train recover --session <id>` for recovering completed SkillOpt optimizer artifacts after wrapper/process failures.

## WHY

SkillOpt train runs can leave recoverable optimizer artifacts on disk while Gitmoot state is still before candidate import. Operators should not need manual SQLite edits, and recovery must not duplicate candidate review issues or corrupt state.

## CHANGES

- Adds `skillopt train recover` CLI support with text and JSON result output.
- Classifies optimizer artifacts as completed candidate, completed no-candidate, incomplete/resumable, unavailable, active optimizer, or corrupted/unrecoverable.
- Imports valid recovered candidates and records recovered no-candidate outcomes.
- Advertises `optimizer_recovery_available` in verbose train status when optimizer artifacts exist.
- Guards recovery with the optimizer lock, reloads state under lock, validates recoverable state before DB writes, and avoids treating `no_candidate_reason: null` as a real reason.
- Adds regression coverage for candidate recovery, no-candidate recovery, incomplete/corrupted artifacts, active locks, missing candidate artifacts, premature recovery state, and status recovery signals.

## RESULTS

- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'SkillOptTrainRecover|SkillOptTrainContinueReportsRecoveryAfterOptimizerFailureArtifacts'`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run SkillOptTrain`
- `git diff --check`
- `timeout 240 codex exec review --uncommitted`

Final raw Codex review output:

```text
No discrete correctness issues were identified in the current staged, unstaged, or untracked changes.
```

## RISK

No skipped required checks for this task. The local worktree still has unrelated untracked planning files that were intentionally not committed.
