### PR TITLE
skillopt: add gate rejection contracts

### DIFF
--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -102,6 +102,27 @@ type EvaluatorFailurePacket struct {
 	StageStatus   []EvaluatorStageStatus `json:"stage_status,omitempty"`
 }
 
+type GateRejectionScores struct {
+	Hard      *float64 `json:"hard,omitempty"`
+	Soft      *float64 `json:"soft,omitempty"`
+	GateScore *float64 `json:"gate_score,omitempty"`
+}
+
+type GateRejectionPacket struct {
+	RejectionType    string              `json:"rejection_type,omitempty"`
+	Retryable        bool                `json:"retryable,omitempty"`
+	Baseline         GateRejectionScores `json:"baseline,omitempty"`
+	Candidate        GateRejectionScores `json:"candidate,omitempty"`
+	PrimaryReason    string              `json:"primary_reason,omitempty"`
+	HumanReason      string              `json:"human_reason,omitempty"`
+	OptimizerHint    string              `json:"optimizer_hint,omitempty"`
+	FailedDimensions []string            `json:"failed_dimensions,omitempty"`
+	Evidence         []string            `json:"evidence,omitempty"`
+	AttemptedPatch   string              `json:"attempted_patch,omitempty"`
+	RetryAttempts    string              `json:"retry_attempts,omitempty"`
+	NextAction       string              `json:"next_action,omitempty"`
+}
+
 type EvaluatorScore struct {
 	ProfileID              string                  `json:"profile_id,omitempty"`
 	TaskKind               string                  `json:"task_kind,omitempty"`
@@ -113,6 +134,7 @@ type EvaluatorScore struct {
 	DimensionScores        map[string]float64      `json:"dimension_scores,omitempty"`
 	FailReason             string                  `json:"fail_reason,omitempty"`
 	Failure                *EvaluatorFailurePacket `json:"failure,omitempty"`
+	GateRejection          *GateRejectionPacket    `json:"gate_rejection,omitempty"`
 	StageStatus            []EvaluatorStageStatus  `json:"stage_status,omitempty"`
 	Metadata               json.RawMessage         `json:"metadata,omitempty"`
 }
@@ -216,6 +238,7 @@ type CandidateSummary struct {
 	Metadata          json.RawMessage         `json:"metadata,omitempty"`
 	EvaluatorScore    *EvaluatorScore         `json:"evaluator_score,omitempty"`
 	Failure           *EvaluatorFailurePacket `json:"failure,omitempty"`
+	GateRejection     *GateRejectionPacket    `json:"gate_rejection,omitempty"`
 }
 
 type CandidateArtifactRef struct {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -152,6 +152,10 @@ func TestExportTrainingPackageIncludesPreferredGateMetadata(t *testing.T) {
 func TestEvaluatorProfileAndFailurePacketContractsRoundTrip(t *testing.T) {
 	hard := 0.0
 	soft := 0.12
+	baselineSoft := 0.78
+	baselineGate := 0.89
+	candidateSoft := 0.68
+	candidateGate := 0.84
 	training := TrainingPackage{
 		Kind:            TrainingPackageKind,
 		ContractVersion: ContractVersion,
@@ -237,9 +241,53 @@ func TestEvaluatorProfileAndFailurePacketContractsRoundTrip(t *testing.T) {
 						{Stage: "artifact_contract", Status: "failed", DurationMS: 7},
 					},
 				},
+				GateRejection: &GateRejectionPacket{
+					RejectionType: "candidate_score_regression",
+					Retryable:     true,
+					Baseline: GateRejectionScores{
+						Hard:      &hard,
+						Soft:      &baselineSoft,
+						GateScore: &baselineGate,
+					},
+					Candidate: GateRejectionScores{
+						Hard:      &hard,
+						Soft:      &candidateSoft,
+						GateScore: &candidateGate,
+					},
+					PrimaryReason:    "candidate_quality_regressed",
+					HumanReason:      "The patch did not improve the requested design qualities.",
+					OptimizerHint:    "Add guidance for branding, product visuals, animation, and mobile layout.",
+					FailedDimensions: []string{"human_feedback_alignment", "visual_quality"},
+					Evidence:         []string{"Candidate soft score dropped from 0.78 to 0.68."},
+					AttemptedPatch:   "Hard Artifact Delivery",
+					RetryAttempts:    "0/1",
+					NextAction:       "Retry once with the gate rejection hint.",
+				},
 				StageStatus: []EvaluatorStageStatus{
 					{Stage: "artifact_contract", Status: "failed"},
 				},
+			},
+			GateRejection: &GateRejectionPacket{
+				RejectionType: "candidate_score_regression",
+				Retryable:     true,
+				Baseline: GateRejectionScores{
+					Hard:      &hard,
+					Soft:      &baselineSoft,
+					GateScore: &baselineGate,
+				},
+				Candidate: GateRejectionScores{
+					Hard:      &hard,
+					Soft:      &candidateSoft,
+					GateScore: &candidateGate,
+				},
+				PrimaryReason:    "candidate_quality_regressed",
+				HumanReason:      "Candidate lost selection against baseline.",
+				OptimizerHint:    "Do not repeat the previous artifact-delivery-only patch.",
+				FailedDimensions: []string{"human_feedback_alignment", "visual_quality"},
+				Evidence:         []string{"candidate gate score 0.84 <= baseline gate score 0.89"},
+				AttemptedPatch:   "Hard Artifact Delivery",
+				RetryAttempts:    "0/1",
+				NextAction:       "Retry once or collect more feedback.",
 			},
 		},
 	}
@@ -275,6 +323,25 @@ func TestEvaluatorProfileAndFailurePacketContractsRoundTrip(t *testing.T) {
 		decodedCandidate.Summary.EvaluatorScore.QualityStatus != "not_run" ||
 		!strings.Contains(string(decodedCandidate.Summary.EvaluatorScore.HumanFeedbackAlignment), "stronger product visuals") {
 		t.Fatalf("decoded evaluator failure = %+v", decodedCandidate.Summary.EvaluatorScore)
+	}
+	gateRejection := decodedCandidate.Summary.GateRejection
+	if gateRejection == nil ||
+		gateRejection.RejectionType != "candidate_score_regression" ||
+		!gateRejection.Retryable ||
+		gateRejection.Baseline.GateScore == nil ||
+		*gateRejection.Baseline.GateScore != baselineGate ||
+		gateRejection.Candidate.Soft == nil ||
+		*gateRejection.Candidate.Soft != candidateSoft ||
+		gateRejection.FailedDimensions[0] != "human_feedback_alignment" ||
+		!strings.Contains(gateRejection.OptimizerHint, "artifact-delivery-only") {
+		t.Fatalf("decoded gate rejection = %+v", gateRejection)
+	}
+	scoreGateRejection := decodedCandidate.Summary.EvaluatorScore.GateRejection
+	if scoreGateRejection == nil ||
+		scoreGateRejection.Baseline.GateScore == nil ||
+		*scoreGateRejection.Baseline.GateScore != baselineGate ||
+		scoreGateRejection.RetryAttempts != "0/1" {
+		t.Fatalf("decoded evaluator score gate rejection = %+v", scoreGateRejection)
 	}
 }
 


### PR DESCRIPTION
WHAT
Add Gitmoot-side contract structs for structured SkillOpt gate rejection packets.

WHY
Issue #122 needs selection-gate rejections to carry baseline-vs-candidate scores, retryability, optimizer hints, evidence, attempted patch, retry attempts, and next action before later tasks wire runtime retry behavior.

CHANGES
- Added GateRejectionScores and GateRejectionPacket to internal/skillopt contracts.
- Added optional gate_rejection fields to evaluator score and candidate summary contracts.
- Extended the existing evaluator contract round-trip test to prove the new packet serializes with legacy failure packet data.

RESULTS
- GOTOOLCHAIN=go1.26.2 go test ./internal/skillopt -run TestEvaluatorProfileAndFailurePacketContractsRoundTrip
- GOTOOLCHAIN=go1.26.2 go test ./internal/skillopt ./internal/cli
- git diff --check
- codex exec review --uncommitted:
```text
The changes only add backward-compatible JSON contract fields and serialization coverage. I did not find a discrete issue that would break existing behavior.
```

RISK
This is contract-only and additive. Runtime gate rejection creation/retry behavior is intentionally left for later issue #122 tasks. Unrelated untracked local goal/input files were not included.