### PR TITLE
skillopt: track review issues for watching

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -3399,6 +3399,8 @@ type skillOptTrainReviewPublishResult struct {
 	PreviewURLs int
 }
 
+const skillOptReviewWatchDefaultStaleThreshold = 24 * time.Hour
+
 func autoSyncSkillOptTrainReviewFeedback(ctx context.Context, paths config.Paths, store *db.Store, iteration db.SkillOptTrainIteration) ([]string, bool) {
 	repoText := strings.TrimSpace(iteration.IssueRepo)
 	issueNumber := iteration.IssueNumber
@@ -3518,7 +3520,11 @@ func publishSkillOptTrainReview(ctx context.Context, paths config.Paths, store *
 	dbMetadata["status"] = "published"
 	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "review", dbMetadata)
 	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "review", dbMetadata)
-	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+	watch, watchErr := skillOptTrainReviewWatch(ctx, store, iteration, published.Repo, published.IssueNumber, published.URL, previewURLs, "gitmoot skillopt train continue")
+	if watchErr != nil {
+		return skillOptTrainReviewPublishResult{}, fmt.Errorf("review was published at %s but watch registration preparation failed: %w", published.URL, watchErr)
+	}
+	if err := store.UpsertSkillOptTrainSessionIterationAndReviewWatch(ctx, session, iteration, watch); err != nil {
 		if externalMarkerErr != nil {
 			return skillOptTrainReviewPublishResult{}, fmt.Errorf("%w; review was published at %s but recovery marker write failed: %v", err, published.URL, externalMarkerErr)
 		}
@@ -3566,11 +3572,60 @@ func recoverSkillOptTrainReviewPublication(ctx context.Context, paths config.Pat
 	}
 	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "review", metadata)
 	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "review", metadata)
-	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+	watch, err := skillOptTrainReviewWatch(ctx, store, iteration, repo, issueNumber, url, previewURLs, "gitmoot skillopt train recover")
+	if err != nil {
+		return skillOptTrainReviewPublishResult{}, true, err
+	}
+	if err := store.UpsertSkillOptTrainSessionIterationAndReviewWatch(ctx, session, iteration, watch); err != nil {
 		return skillOptTrainReviewPublishResult{}, true, err
 	}
 	_ = removeSkillOptTrainReviewRecovery(paths, session, iteration)
 	return skillOptTrainReviewPublishResult{Repo: repo, IssueNumber: issueNumber, URL: url, PreviewURLs: previewURLs}, true, nil
+}
+
+func skillOptTrainReviewWatch(ctx context.Context, store *db.Store, iteration db.SkillOptTrainIteration, repo github.Repository, issueNumber int64, url string, previewURLs int, source string) (db.SkillOptReviewWatch, error) {
+	if store == nil {
+		return db.SkillOptReviewWatch{}, errors.New("store is required")
+	}
+	runID := strings.TrimSpace(iteration.EvalRunID)
+	if runID == "" {
+		return db.SkillOptReviewWatch{}, errors.New("train review watch run id is required")
+	}
+	items, err := store.ListEvalReviewItems(ctx, runID)
+	if err != nil {
+		return db.SkillOptReviewWatch{}, err
+	}
+	itemIDs := make([]string, 0, len(items))
+	for _, item := range items {
+		if itemID := strings.TrimSpace(item.ItemID); itemID != "" {
+			itemIDs = append(itemIDs, itemID)
+		}
+	}
+	itemIDsJSON, err := json.Marshal(itemIDs)
+	if err != nil {
+		return db.SkillOptReviewWatch{}, err
+	}
+	metadata := map[string]any{
+		"session_id":   strings.TrimSpace(iteration.SessionID),
+		"iteration_id": strings.TrimSpace(iteration.ID),
+		"issue_url":    strings.TrimSpace(url),
+		"preview_urls": previewURLs,
+		"source":       strings.TrimSpace(source),
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return db.SkillOptReviewWatch{}, err
+	}
+	return db.SkillOptReviewWatch{
+		Repo:                  repo.FullName(),
+		IssueNumber:           issueNumber,
+		RunID:                 runID,
+		ExpectedItemIDsJSON:   string(itemIDsJSON),
+		Status:                db.SkillOptReviewWatchStatusWatching,
+		StaleAfter:            time.Now().UTC().Add(skillOptReviewWatchDefaultStaleThreshold).Format(time.RFC3339Nano),
+		StaleThresholdSeconds: int64(skillOptReviewWatchDefaultStaleThreshold.Seconds()),
+		MetadataJSON:          string(metadataJSON),
+	}, nil
 }
 
 func writeSkillOptTrainReviewRecovery(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, metadata map[string]any) error {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1484,6 +1484,16 @@ func TestSkillOptTrainContinueGeneratesRequiredVuePreviewBundles(t *testing.T) {
 		strings.Contains(fakeGitHub.createdIssue.Body, `"renderer":"vue-vite"`) {
 		t.Fatalf("created preview review issue = %+v\n%s", fakeGitHub.createdIssue, fakeGitHub.createdIssue.Body)
 	}
+	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 8)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if watch.RunID != "preview-train-review-001" ||
+		watch.Status != db.SkillOptReviewWatchStatusWatching ||
+		watch.StaleThresholdSeconds != int64(skillOptReviewWatchDefaultStaleThreshold.Seconds()) ||
+		!strings.Contains(watch.ExpectedItemIDsJSON, "hero-saas") {
+		t.Fatalf("review watch = %+v", watch)
+	}
 	if _, err := os.Stat(filepath.Join(previewDir, "runs", "preview-train-review-001", "hero-saas", "a", "index.html")); err != nil {
 		t.Fatalf("preview index was not published: %v", err)
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -223,6 +223,22 @@ type SkillOptTrainIteration struct {
 	UpdatedAt             string
 }
 
+type SkillOptReviewWatch struct {
+	Repo                  string
+	IssueNumber           int64
+	RunID                 string
+	ExpectedItemIDsJSON   string
+	Status                string
+	LastSeenCommentID     int64
+	LastImportErrorHash   string
+	StaleAfter            string
+	StaleThresholdSeconds int64
+	StaleNotified         bool
+	MetadataJSON          string
+	CreatedAt             string
+	UpdatedAt             string
+}
+
 const (
 	EvalRunModeExplore  = "explore"
 	EvalRunModeRefine   = "refine"
@@ -232,6 +248,12 @@ const (
 	ExplorationLevelHigh   = "high"
 	ExplorationLevelMedium = "medium"
 	ExplorationLevelLow    = "low"
+
+	SkillOptReviewWatchStatusWatching      = "watching"
+	SkillOptReviewWatchStatusImported      = "imported"
+	SkillOptReviewWatchStatusClosed        = "closed"
+	SkillOptReviewWatchStatusStaleNotified = "stale_notified"
+	SkillOptReviewWatchStatusFailed        = "failed"
 )
 
 type EvalReviewItem struct {
@@ -2124,6 +2146,36 @@ func (s *Store) UpsertSkillOptTrainSessionAndIteration(ctx context.Context, sess
 	return tx.Commit()
 }
 
+func (s *Store) UpsertSkillOptTrainSessionIterationAndReviewWatch(ctx context.Context, session SkillOptTrainSession, iteration SkillOptTrainIteration, watch SkillOptReviewWatch) error {
+	session, err := normalizeSkillOptTrainSession(session)
+	if err != nil {
+		return err
+	}
+	iteration, err = normalizeSkillOptTrainIteration(iteration)
+	if err != nil {
+		return err
+	}
+	watch, err = normalizeSkillOptReviewWatch(watch)
+	if err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := upsertSkillOptTrainSessionExec(ctx, tx, session); err != nil {
+		return err
+	}
+	if err := upsertSkillOptTrainIterationExec(ctx, tx, iteration); err != nil {
+		return err
+	}
+	if err := upsertSkillOptReviewWatchExec(ctx, tx, watch); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func (s *Store) UpsertSkillOptTrainNextIteration(ctx context.Context, session SkillOptTrainSession, iteration SkillOptTrainIteration, run EvalRun, items []EvalReviewItem) error {
 	session, err := normalizeSkillOptTrainSession(session)
 	if err != nil {
@@ -2263,6 +2315,110 @@ func (s *Store) GetSkillOptTrainIterationByEvalRun(ctx context.Context, evalRunI
 		ORDER BY rowid DESC
 		LIMIT 1`, strings.TrimSpace(evalRunID))
 	return scanSkillOptTrainIteration(row)
+}
+
+func (s *Store) UpsertSkillOptReviewWatch(ctx context.Context, watch SkillOptReviewWatch) error {
+	watch, err := normalizeSkillOptReviewWatch(watch)
+	if err != nil {
+		return err
+	}
+	return upsertSkillOptReviewWatchExec(ctx, s.db, watch)
+}
+
+func upsertSkillOptReviewWatchExec(ctx context.Context, exec sqlExecer, watch SkillOptReviewWatch) error {
+	_, err := exec.ExecContext(ctx, `INSERT INTO skillopt_review_watches(
+			repo, issue_number, run_id, expected_item_ids_json, status, last_seen_comment_id,
+			last_import_error_hash, stale_after, stale_threshold_seconds, stale_notified,
+			metadata_json, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(repo, issue_number) DO UPDATE SET
+			run_id = excluded.run_id,
+			expected_item_ids_json = excluded.expected_item_ids_json,
+			status = excluded.status,
+			last_seen_comment_id = excluded.last_seen_comment_id,
+			last_import_error_hash = excluded.last_import_error_hash,
+			stale_after = excluded.stale_after,
+			stale_threshold_seconds = excluded.stale_threshold_seconds,
+			stale_notified = excluded.stale_notified,
+			metadata_json = excluded.metadata_json,
+			updated_at = CURRENT_TIMESTAMP`,
+		watch.Repo, watch.IssueNumber, watch.RunID, watch.ExpectedItemIDsJSON, watch.Status, watch.LastSeenCommentID,
+		watch.LastImportErrorHash, watch.StaleAfter, watch.StaleThresholdSeconds, boolInt(watch.StaleNotified), watch.MetadataJSON)
+	return err
+}
+
+func normalizeSkillOptReviewWatch(watch SkillOptReviewWatch) (SkillOptReviewWatch, error) {
+	watch.Repo = strings.TrimSpace(watch.Repo)
+	if watch.Repo == "" {
+		return SkillOptReviewWatch{}, errors.New("skillopt review watch repo is required")
+	}
+	if watch.IssueNumber <= 0 {
+		return SkillOptReviewWatch{}, errors.New("skillopt review watch issue number is required")
+	}
+	watch.RunID = strings.TrimSpace(watch.RunID)
+	if watch.RunID == "" {
+		return SkillOptReviewWatch{}, errors.New("skillopt review watch run id is required")
+	}
+	watch.ExpectedItemIDsJSON = strings.TrimSpace(watch.ExpectedItemIDsJSON)
+	watch.Status = strings.TrimSpace(strings.ToLower(watch.Status))
+	if watch.Status == "" {
+		watch.Status = SkillOptReviewWatchStatusWatching
+	}
+	switch watch.Status {
+	case SkillOptReviewWatchStatusWatching, SkillOptReviewWatchStatusImported, SkillOptReviewWatchStatusClosed, SkillOptReviewWatchStatusStaleNotified, SkillOptReviewWatchStatusFailed:
+	default:
+		return SkillOptReviewWatch{}, fmt.Errorf("skillopt review watch status %q is not supported", watch.Status)
+	}
+	watch.LastImportErrorHash = strings.TrimSpace(watch.LastImportErrorHash)
+	watch.StaleAfter = strings.TrimSpace(watch.StaleAfter)
+	if watch.StaleThresholdSeconds < 0 {
+		return SkillOptReviewWatch{}, errors.New("skillopt review watch stale threshold must not be negative")
+	}
+	watch.MetadataJSON = strings.TrimSpace(watch.MetadataJSON)
+	return watch, nil
+}
+
+func (s *Store) GetSkillOptReviewWatch(ctx context.Context, repo string, issueNumber int64) (SkillOptReviewWatch, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT repo, issue_number, run_id, expected_item_ids_json, status,
+			last_seen_comment_id, last_import_error_hash, stale_after, stale_threshold_seconds,
+			stale_notified, metadata_json, created_at, updated_at
+		FROM skillopt_review_watches
+		WHERE repo = ? AND issue_number = ?`, strings.TrimSpace(repo), issueNumber)
+	return scanSkillOptReviewWatch(row)
+}
+
+func (s *Store) ListSkillOptReviewWatches(ctx context.Context, status string) ([]SkillOptReviewWatch, error) {
+	status = strings.TrimSpace(strings.ToLower(status))
+	var rows *sql.Rows
+	var err error
+	if status == "" {
+		rows, err = s.db.QueryContext(ctx, `SELECT repo, issue_number, run_id, expected_item_ids_json, status,
+				last_seen_comment_id, last_import_error_hash, stale_after, stale_threshold_seconds,
+				stale_notified, metadata_json, created_at, updated_at
+			FROM skillopt_review_watches
+			ORDER BY rowid`)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `SELECT repo, issue_number, run_id, expected_item_ids_json, status,
+				last_seen_comment_id, last_import_error_hash, stale_after, stale_threshold_seconds,
+				stale_notified, metadata_json, created_at, updated_at
+			FROM skillopt_review_watches
+			WHERE status = ?
+			ORDER BY rowid`, status)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	watches := []SkillOptReviewWatch{}
+	for rows.Next() {
+		watch, err := scanSkillOptReviewWatch(rows)
+		if err != nil {
+			return nil, err
+		}
+		watches = append(watches, watch)
+	}
+	return watches, rows.Err()
 }
 
 func (s *Store) UpsertEvalReviewItem(ctx context.Context, item EvalReviewItem) error {
@@ -2579,6 +2735,18 @@ func scanSkillOptTrainIteration(row interface{ Scan(dest ...any) error }) (Skill
 	return iteration, nil
 }
 
+func scanSkillOptReviewWatch(row interface{ Scan(dest ...any) error }) (SkillOptReviewWatch, error) {
+	var watch SkillOptReviewWatch
+	var staleNotified int
+	if err := row.Scan(&watch.Repo, &watch.IssueNumber, &watch.RunID, &watch.ExpectedItemIDsJSON, &watch.Status,
+		&watch.LastSeenCommentID, &watch.LastImportErrorHash, &watch.StaleAfter, &watch.StaleThresholdSeconds,
+		&staleNotified, &watch.MetadataJSON, &watch.CreatedAt, &watch.UpdatedAt); err != nil {
+		return SkillOptReviewWatch{}, err
+	}
+	watch.StaleNotified = staleNotified != 0
+	return watch, nil
+}
+
 func scanEvalReviewItem(row interface{ Scan(dest ...any) error }) (EvalReviewItem, error) {
 	var item EvalReviewItem
 	if err := row.Scan(&item.ID, &item.RunID, &item.ItemID, &item.Title, &item.SourceArtifactID, &item.BaselineArtifactID,
@@ -2594,6 +2762,13 @@ func scanEvalReviewOption(row interface{ Scan(dest ...any) error }) (EvalReviewO
 		return EvalReviewOption{}, err
 	}
 	return option, nil
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 func (s *Store) UpsertFeedbackEvent(ctx context.Context, event FeedbackEvent) error {
@@ -3894,5 +4069,26 @@ ALTER TABLE ranked_feedback_events ADD COLUMN required_improvements_json TEXT NO
 ALTER TABLE resource_locks ADD COLUMN owner_pid INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE resource_locks ADD COLUMN owner_hostname TEXT NOT NULL DEFAULT '';
 ALTER TABLE resource_locks ADD COLUMN command_hash TEXT NOT NULL DEFAULT '';
+	`,
+	`
+CREATE TABLE skillopt_review_watches (
+	repo TEXT NOT NULL,
+	issue_number INTEGER NOT NULL,
+	run_id TEXT NOT NULL,
+	expected_item_ids_json TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL DEFAULT 'watching',
+	last_seen_comment_id INTEGER NOT NULL DEFAULT 0,
+	last_import_error_hash TEXT NOT NULL DEFAULT '',
+	stale_after TEXT NOT NULL DEFAULT '',
+	stale_threshold_seconds INTEGER NOT NULL DEFAULT 0,
+	stale_notified INTEGER NOT NULL DEFAULT 0,
+	metadata_json TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY(repo, issue_number)
+);
+
+CREATE INDEX idx_skillopt_review_watches_status ON skillopt_review_watches(status);
+CREATE INDEX idx_skillopt_review_watches_run_id ON skillopt_review_watches(run_id);
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -43,6 +43,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"ranked_feedback_events",
 		"skillopt_train_sessions",
 		"skillopt_train_iterations",
+		"skillopt_review_watches",
 	} {
 		ok, err := store.HasTable(ctx, table)
 		if err != nil {
@@ -194,6 +195,106 @@ func TestSkillOptTrainStorageDefaultsAndValidation(t *testing.T) {
 	}
 	if iteration.Mode != EvalRunModeExplore || iteration.ExplorationLevel != ExplorationLevelHigh || iteration.State != "request_confirmed" {
 		t.Fatalf("iteration defaults = %+v", iteration)
+	}
+}
+
+func TestSkillOptReviewWatchStorage(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	expectedItems, err := json.Marshal([]string{"item-001", "item-002"})
+	if err != nil {
+		t.Fatalf("marshal expected items: %v", err)
+	}
+	watch := SkillOptReviewWatch{
+		Repo:                  " owner/previews ",
+		IssueNumber:           67,
+		RunID:                 " landing-page-review-001 ",
+		ExpectedItemIDsJSON:   string(expectedItems),
+		LastSeenCommentID:     100,
+		LastImportErrorHash:   " error-hash ",
+		StaleAfter:            "2026-06-05T12:00:00Z",
+		StaleThresholdSeconds: 86400,
+		StaleNotified:         true,
+		MetadataJSON:          `{"source":"test"}`,
+	}
+	if err := store.UpsertSkillOptReviewWatch(ctx, watch); err != nil {
+		t.Fatalf("UpsertSkillOptReviewWatch returned error: %v", err)
+	}
+	stored, err := store.GetSkillOptReviewWatch(ctx, "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if stored.Repo != "owner/previews" ||
+		stored.RunID != "landing-page-review-001" ||
+		stored.Status != SkillOptReviewWatchStatusWatching ||
+		stored.LastSeenCommentID != 100 ||
+		stored.LastImportErrorHash != "error-hash" ||
+		stored.StaleAfter != watch.StaleAfter ||
+		stored.StaleThresholdSeconds != 86400 ||
+		!stored.StaleNotified ||
+		stored.ExpectedItemIDsJSON != string(expectedItems) {
+		t.Fatalf("stored watch = %+v", stored)
+	}
+	if err := store.UpsertSkillOptReviewWatch(ctx, SkillOptReviewWatch{
+		Repo:        "owner/previews",
+		IssueNumber: 67,
+		RunID:       "landing-page-review-001",
+		Status:      SkillOptReviewWatchStatusImported,
+	}); err != nil {
+		t.Fatalf("UpsertSkillOptReviewWatch update returned error: %v", err)
+	}
+	watches, err := store.ListSkillOptReviewWatches(ctx, SkillOptReviewWatchStatusImported)
+	if err != nil {
+		t.Fatalf("ListSkillOptReviewWatches returned error: %v", err)
+	}
+	if len(watches) != 1 || watches[0].Status != SkillOptReviewWatchStatusImported || watches[0].IssueNumber != 67 {
+		t.Fatalf("imported watches = %+v", watches)
+	}
+	if err := store.UpsertSkillOptReviewWatch(ctx, SkillOptReviewWatch{Repo: "owner/previews", IssueNumber: 68, RunID: "run", Status: "paused"}); err == nil || !strings.Contains(err.Error(), "status") {
+		t.Fatalf("invalid status error = %v", err)
+	}
+}
+
+func TestSkillOptTrainPublicationAndReviewWatchStorageIsTransactional(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	session := SkillOptTrainSession{ID: "session-1", TemplateID: "planner", State: "review_published"}
+	iteration := SkillOptTrainIteration{ID: "session-1-001", SessionID: "session-1", EvalRunID: "review-001", State: "review_published", IssueRepo: "owner/review", IssueNumber: 8}
+	watch := SkillOptReviewWatch{Repo: "owner/review", IssueNumber: 8, RunID: "review-001", Status: SkillOptReviewWatchStatusWatching}
+	if err := store.UpsertSkillOptTrainSessionIterationAndReviewWatch(ctx, session, iteration, watch); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSessionIterationAndReviewWatch returned error: %v", err)
+	}
+	storedIteration, err := store.GetSkillOptTrainIteration(ctx, "session-1-001")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainIteration returned error: %v", err)
+	}
+	storedWatch, err := store.GetSkillOptReviewWatch(ctx, "owner/review", 8)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if storedIteration.State != "review_published" || storedWatch.RunID != "review-001" {
+		t.Fatalf("stored iteration=%+v watch=%+v", storedIteration, storedWatch)
+	}
+
+	if err := store.UpsertSkillOptTrainSessionIterationAndReviewWatch(ctx,
+		SkillOptTrainSession{ID: "session-2", TemplateID: "planner", State: "review_published"},
+		SkillOptTrainIteration{ID: "session-2-001", SessionID: "session-2", EvalRunID: "review-002", State: "review_published", IssueRepo: "owner/review", IssueNumber: 9},
+		SkillOptReviewWatch{Repo: "owner/review", IssueNumber: 9, RunID: "review-002", Status: "paused"},
+	); err == nil || !strings.Contains(err.Error(), "status") {
+		t.Fatalf("invalid transactional watch error = %v", err)
+	}
+	if _, err := store.GetSkillOptTrainSession(ctx, "session-2"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("invalid transactional upsert stored session err=%v", err)
 	}
 }
 


### PR DESCRIPTION
WHAT
- Added local SkillOpt review watch storage.
- Registered watch rows when `gitmoot skillopt train continue` publishes or recovers a review issue.

WHY
- The watcher flow needs a local list of known Gitmoot-created review issues so later tasks can poll only those issues instead of scanning arbitrary GitHub repos.

CHANGES
- Added `skillopt_review_watches` migration with repo, issue number, run id, expected item ids, status, last seen comment id, last import error hash, stale timing, stale notification flag, metadata, and timestamps.
- Added store APIs to upsert, get, and list watches.
- Added a transactional store method that writes review-published session/iteration state and the watch row atomically.
- Registered watches for normal train review publication and recovery-marker publication recovery.
- Added DB and CLI coverage for watch storage, status filtering, transactional rollback, and review publication registration.

RESULTS
- `GOTOOLCHAIN=go1.26.2 go test ./internal/db ./internal/cli` passed.
- `git diff --check` passed.
- `codex exec review --uncommitted` final raw output: No discrete, actionable correctness issues were found in the current changes. The new review watch storage and registration appear scoped and compatible with the existing publication flow.

RISK
- No skipped local checks. The review sandbox attempted `GOTOOLCHAIN=local go test` and could not run because local Go is 1.22.2 while this repo requires Go 1.26; the required focused tests passed with `GOTOOLCHAIN=go1.26.2`.