### PR TITLE
skillopt: import watched review comments

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -54,8 +55,8 @@ func runDaemon(args []string, stdout, stderr io.Writer) int {
 
 func printDaemonUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot daemon start [--repo owner/repo] [--poll 30s] [--workers 1]")
-	fmt.Fprintln(w, "  gitmoot daemon run [--repo owner/repo] [--poll 30s] [--workers 1]")
+	fmt.Fprintln(w, "  gitmoot daemon start [--repo owner/repo] [--poll 30s] [--workers 1] [--watch-skillopt-reviews]")
+	fmt.Fprintln(w, "  gitmoot daemon run [--repo owner/repo] [--poll 30s] [--workers 1] [--watch-skillopt-reviews]")
 	fmt.Fprintln(w, "  gitmoot daemon stop")
 	fmt.Fprintln(w, "  gitmoot daemon restart")
 	fmt.Fprintln(w, "  gitmoot daemon status")
@@ -105,7 +106,7 @@ func runDaemonStartWithWorkDir(args []string, workDir string, stdout, stderr io.
 		}
 	}
 
-	started, err := startDaemonChild(cfg.Home, cfg.Poll.String(), cfg.Workers, state, resolvedWorkDir)
+	started, err := startDaemonChild(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, state, resolvedWorkDir)
 	if err != nil {
 		fmt.Fprintf(stderr, "daemon start: %v\n", err)
 		return 1
@@ -128,6 +129,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	poll := fs.Duration("poll", 30*time.Second, "poll interval")
 	workers := fs.Int("workers", 1, "worker count")
 	dryRun := fs.Bool("dry-run", false, "run without mutating external systems")
+	watchSkillOptReviews := fs.Bool("watch-skillopt-reviews", false, "poll watched SkillOpt review issue comments and import valid feedback")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -155,7 +157,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	defer stop()
 
 	if *repoFlag == "" {
-		err := runRegisteredRepoSupervisor(ctx, *home, *poll, *workers, *dryRun, stdout)
+		err := runRegisteredRepoSupervisor(ctx, *home, *poll, *workers, *dryRun, *watchSkillOptReviews, stdout)
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return 0
 		}
@@ -398,16 +400,18 @@ type daemonMeta struct {
 }
 
 type daemonStartConfig struct {
-	Home                string
-	RepoFlag            string
-	Repo                github.Repository
-	RepoSet             bool
-	Poll                time.Duration
-	Workers             int
-	ExplicitStartConfig bool
-	ExplicitRepo        bool
-	ExplicitPoll        bool
-	ExplicitWorkers     bool
+	Home                         string
+	RepoFlag                     string
+	Repo                         github.Repository
+	RepoSet                      bool
+	Poll                         time.Duration
+	Workers                      int
+	ExplicitStartConfig          bool
+	ExplicitRepo                 bool
+	ExplicitPoll                 bool
+	ExplicitWorkers              bool
+	WatchSkillOptReviews         bool
+	ExplicitWatchSkillOptReviews bool
 }
 
 const daemonHelp = -1
@@ -419,6 +423,7 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 	repoFlag := fs.String("repo", "", "GitHub repository as owner/repo")
 	poll := fs.Duration("poll", 30*time.Second, "poll interval")
 	workers := fs.Int("workers", 1, "worker count")
+	watchSkillOptReviews := fs.Bool("watch-skillopt-reviews", false, "poll watched SkillOpt review issue comments and import valid feedback")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return daemonStartConfig{}, daemonHelp
@@ -430,10 +435,11 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 		return daemonStartConfig{}, 2
 	}
 	cfg := daemonStartConfig{
-		Home:     *home,
-		RepoFlag: *repoFlag,
-		Poll:     *poll,
-		Workers:  *workers,
+		Home:                 *home,
+		RepoFlag:             *repoFlag,
+		Poll:                 *poll,
+		Workers:              *workers,
+		WatchSkillOptReviews: *watchSkillOptReviews,
 	}
 	fs.Visit(func(f *flag.Flag) {
 		switch f.Name {
@@ -445,6 +451,9 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 			cfg.ExplicitStartConfig = true
 		case "workers":
 			cfg.ExplicitWorkers = true
+			cfg.ExplicitStartConfig = true
+		case "watch-skillopt-reviews":
+			cfg.ExplicitWatchSkillOptReviews = true
 			cfg.ExplicitStartConfig = true
 		}
 	})
@@ -567,6 +576,9 @@ func overlayDaemonStartArgs(args []string, cfg daemonStartConfig) []string {
 	if cfg.ExplicitWorkers {
 		args = withDaemonFlagArg(args, "workers", strconv.Itoa(cfg.Workers))
 	}
+	if cfg.ExplicitWatchSkillOptReviews {
+		args = withDaemonBoolFlagArg(args, "watch-skillopt-reviews", cfg.WatchSkillOptReviews)
+	}
 	return args
 }
 
@@ -587,6 +599,21 @@ func withDaemonFlagArg(args []string, name string, value string) []string {
 		return cleaned
 	}
 	return append(cleaned, flagName, value)
+}
+
+func withDaemonBoolFlagArg(args []string, name string, enabled bool) []string {
+	flagName := "--" + name
+	cleaned := make([]string, 0, len(args)+1)
+	for _, arg := range args {
+		if arg == flagName || strings.HasPrefix(arg, flagName+"=") {
+			continue
+		}
+		cleaned = append(cleaned, arg)
+	}
+	if enabled {
+		return append(cleaned, flagName)
+	}
+	return cleaned
 }
 
 func currentDaemonPID(state daemonState) (pid int, stale bool, err error) {
@@ -613,7 +640,7 @@ func currentDaemonPID(state daemonState) (pid int, stale bool, err error) {
 	return pid, false, nil
 }
 
-func startDaemonChild(home string, poll string, workers int, state daemonState, workDir string) (daemonMeta, error) {
+func startDaemonChild(home string, poll string, workers int, watchSkillOptReviews bool, state daemonState, workDir string) (daemonMeta, error) {
 	executable, err := os.Executable()
 	if err != nil {
 		return daemonMeta{}, err
@@ -623,7 +650,7 @@ func startDaemonChild(home string, poll string, workers int, state daemonState, 
 		return daemonMeta{}, err
 	}
 	defer logFile.Close()
-	args := daemonChildArgs(home, poll, workers)
+	args := daemonChildArgs(home, poll, workers, watchSkillOptReviews)
 	cmd := exec.Command(executable, args...)
 	cmd.Dir = workDir
 	cmd.Stdout = logFile
@@ -646,10 +673,13 @@ func startDaemonChild(home string, poll string, workers int, state daemonState, 
 	}, nil
 }
 
-func daemonChildArgs(home string, poll string, workers int) []string {
+func daemonChildArgs(home string, poll string, workers int, watchSkillOptReviews bool) []string {
 	args := []string{"daemon", "run", "--poll", poll, "--workers", strconv.Itoa(workers)}
 	if home != "" {
 		args = append(args, "--home", home)
+	}
+	if watchSkillOptReviews {
+		args = append(args, "--watch-skillopt-reviews")
 	}
 	return args
 }
@@ -777,13 +807,15 @@ func hasWhitespace(value string) bool {
 	return strings.ContainsAny(value, " \t\r\n")
 }
 
-func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Duration, workers int, dryRun bool, stdout io.Writer) error {
-	return withStore(home, func(store *db.Store) error {
+func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Duration, workers int, dryRun bool, watchSkillOptReviews bool, stdout io.Writer) error {
+	return withStoreAndPaths(home, func(paths config.Paths, store *db.Store) error {
 		schedule := registeredRepoSchedule{
 			NextPoll:    map[string]time.Time{},
 			ErrorStreak: map[string]int{},
 		}
 		poller := defaultRegisteredRepoPoller(store, workers, dryRun, stdout)
+		blobStore := artifact.NewStore(paths.ArtifactBlobs)
+		reviewGitHub := newSkillOptGitHubClient()
 		worker := defaultJobWorker(store, stdout, home)
 		worker.CommenterFactory = worker.defaultCommenter
 		checkoutLocks := &repoCheckoutLocks{}
@@ -807,6 +839,11 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			wait, err := pollRegisteredReposWithPoller(ctx, poller, schedule, time.Now().UTC(), poll)
 			if err != nil {
 				return err
+			}
+			if watchSkillOptReviews {
+				if _, err := pollSkillOptReviewWatches(ctx, store, blobStore, reviewGitHub, stdout, dryRun); err != nil {
+					writeLine(stdout, "skillopt review watch poll error: %s", err)
+				}
 			}
 			timer := time.NewTimer(wait)
 			select {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -211,7 +211,7 @@ func TestDaemonRestartOverlayPreservesSavedArgs(t *testing.T) {
 }
 
 func TestDaemonChildArgsRunAllRepoSupervisor(t *testing.T) {
-	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 2)
+	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 2, true)
 
 	for i, arg := range args {
 		if arg == "--repo" || strings.HasPrefix(arg, "--repo=") {
@@ -225,7 +225,7 @@ func TestDaemonChildArgsRunAllRepoSupervisor(t *testing.T) {
 	if parsed.RepoSet {
 		t.Fatalf("daemon child args selected single-repo mode: %v", args)
 	}
-	if parsed.Workers != 2 || parsed.Poll != 30*time.Second {
+	if parsed.Workers != 2 || parsed.Poll != 30*time.Second || !parsed.WatchSkillOptReviews {
 		t.Fatalf("parsed child args = %+v", parsed)
 	}
 }

--- a/internal/cli/skillopt_review_watcher.go
+++ b/internal/cli/skillopt_review_watcher.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/daemon"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/feedback"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+const skillOptReviewWatchErrorMarker = "<!-- gitmoot:skillopt-review-watch-error -->"
+
+func pollSkillOptReviewWatches(ctx context.Context, store *db.Store, blobStore artifact.Store, gh github.Client, stdout io.Writer, dryRun bool) (int, error) {
+	if store == nil {
+		return 0, fmt.Errorf("store is required")
+	}
+	if gh == nil {
+		return 0, fmt.Errorf("github client is required")
+	}
+	watches, err := store.ListSkillOptReviewWatches(ctx, db.SkillOptReviewWatchStatusWatching)
+	if err != nil {
+		return 0, err
+	}
+	polled := 0
+	var pollErr error
+	for _, watch := range watches {
+		if dryRun {
+			writeLine(stdout, "skillopt review watch dry_run repo=%s issue=%d run=%s", watch.Repo, watch.IssueNumber, watch.RunID)
+			polled++
+			continue
+		}
+		if err := pollSkillOptReviewWatch(ctx, store, blobStore, gh, stdout, watch); err != nil {
+			writeLine(stdout, "skillopt review watch %s#%d: %s", watch.Repo, watch.IssueNumber, err)
+			pollErr = errors.Join(pollErr, err)
+			continue
+		}
+		polled++
+	}
+	if len(watches) > 0 {
+		writeLine(stdout, "polled %d skillopt review watches", polled)
+	}
+	return polled, pollErr
+}
+
+func pollSkillOptReviewWatch(ctx context.Context, store *db.Store, blobStore artifact.Store, gh github.Client, stdout io.Writer, watch db.SkillOptReviewWatch) error {
+	repo, err := daemon.ParseRepository(watch.Repo)
+	if err != nil {
+		return fmt.Errorf("skillopt review watch %s#%d: %w", watch.Repo, watch.IssueNumber, err)
+	}
+	comments, err := gh.ListIssueComments(ctx, repo, watch.IssueNumber)
+	if err != nil {
+		return fmt.Errorf("skillopt review watch %s#%d: list comments: %w", watch.Repo, watch.IssueNumber, err)
+	}
+	sort.SliceStable(comments, func(i, j int) bool {
+		return comments[i].ID < comments[j].ID
+	})
+	expected, err := skillOptReviewWatchExpectedItemIDs(watch)
+	if err != nil {
+		return fmt.Errorf("skillopt review watch %s#%d: %w", watch.Repo, watch.IssueNumber, err)
+	}
+	collector := feedback.GitHubCollector{BlobStore: blobStore, GitHub: gh}
+	for _, comment := range comments {
+		if comment.ID <= watch.LastSeenCommentID || isGitmootSkillOptReviewWatchComment(comment.Body) {
+			continue
+		}
+		validation, err := feedback.ValidateGitHubReviewComment(comment.Body, watch.RunID, expected)
+		if err != nil {
+			if err := postSkillOptReviewWatchImportError(ctx, store, gh, repo, &watch, comment, err); err != nil {
+				return err
+			}
+			continue
+		}
+		if !validation.Parseable {
+			if err := store.UpsertSkillOptReviewWatch(ctx, watch); err != nil {
+				return err
+			}
+			continue
+		}
+		result, err := collector.ImportComments(ctx, store, watch.RunID, []github.IssueComment{comment})
+		if err != nil {
+			if err := postSkillOptReviewWatchImportError(ctx, store, gh, repo, &watch, comment, err); err != nil {
+				return err
+			}
+			continue
+		}
+		watch.Status = db.SkillOptReviewWatchStatusImported
+		watch.LastSeenCommentID = comment.ID
+		watch.LastImportErrorHash = ""
+		if err := store.UpsertSkillOptReviewWatch(ctx, watch); err != nil {
+			return err
+		}
+		writeLine(stdout, "imported %d skillopt review feedback events from %s#%d comment %d", result.Count(), watch.Repo, watch.IssueNumber, comment.ID)
+		return nil
+	}
+	return store.UpsertSkillOptReviewWatch(ctx, watch)
+}
+
+func skillOptReviewWatchExpectedItemIDs(watch db.SkillOptReviewWatch) ([]string, error) {
+	content := strings.TrimSpace(watch.ExpectedItemIDsJSON)
+	if content == "" {
+		return nil, nil
+	}
+	var itemIDs []string
+	if err := json.Unmarshal([]byte(content), &itemIDs); err != nil {
+		return nil, fmt.Errorf("decode expected item ids: %w", err)
+	}
+	return itemIDs, nil
+}
+
+func isGitmootSkillOptReviewWatchComment(body string) bool {
+	body = strings.TrimSpace(body)
+	return strings.Contains(body, skillOptReviewWatchErrorMarker) ||
+		strings.Contains(body, "<!-- gitmoot:skillopt-feedback-packet -->") ||
+		strings.HasPrefix(body, "# Gitmoot SkillOpt Feedback:")
+}
+
+func postSkillOptReviewWatchImportError(ctx context.Context, store *db.Store, gh github.Client, repo github.Repository, watch *db.SkillOptReviewWatch, comment github.IssueComment, importErr error) error {
+	message := strings.TrimSpace(importErr.Error())
+	if message == "" {
+		message = "feedback comment could not be imported"
+	}
+	hash := skillOptReviewWatchImportErrorHash(watch.RunID, comment.ID, message)
+	if hash != watch.LastImportErrorHash {
+		body := skillOptReviewWatchImportErrorComment(watch.RunID, comment.ID, message)
+		if _, err := gh.PostIssueComment(ctx, repo, watch.IssueNumber, body); err != nil {
+			return fmt.Errorf("skillopt review watch %s#%d: post import error: %w", watch.Repo, watch.IssueNumber, err)
+		}
+		watch.LastImportErrorHash = hash
+	}
+	watch.Status = db.SkillOptReviewWatchStatusWatching
+	return store.UpsertSkillOptReviewWatch(ctx, *watch)
+}
+
+func skillOptReviewWatchImportErrorHash(runID string, commentID int64, message string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(runID) + "\n" + fmt.Sprint(commentID) + "\n" + strings.TrimSpace(message)))
+	return hex.EncodeToString(sum[:12])
+}
+
+func skillOptReviewWatchImportErrorComment(runID string, commentID int64, message string) string {
+	var builder strings.Builder
+	builder.WriteString(skillOptReviewWatchErrorMarker)
+	builder.WriteString("\nGitmoot could not import the SkillOpt review feedback yet.\n\n")
+	fmt.Fprintf(&builder, "- run_id: `%s`\n", strings.TrimSpace(runID))
+	fmt.Fprintf(&builder, "- comment_id: `%d`\n", commentID)
+	builder.WriteString("- error: ")
+	builder.WriteString(strings.ReplaceAll(message, "\n", " "))
+	builder.WriteString("\n\nPlease reply with a complete fenced `yaml` block for the expected `run_id` and all review `item_id` values.\n")
+	return builder.String()
+}

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -6260,6 +6260,106 @@ func TestSkillOptFeedbackGitHubCommandsEnforceTrainReviewRepo(t *testing.T) {
 	}
 }
 
+func TestSkillOptReviewWatcherImportsValidYAML(t *testing.T) {
+	home, store, blobStore := seedSkillOptReviewWatcherRun(t)
+	defer store.Close()
+	fake := &skillOptFakeGitHub{
+		comments: map[int64][]github.IssueComment{
+			67: {
+				{ID: 100, Body: "```yaml\nrun_id: watcher-review-001\nitems:\n  - item_id: item-001\n    ranking:\n      - C > A > D > B\n  - item_id: item-002\n    ranking:\n      - B > C > A > D\n```\n", URL: "https://github.com/owner/previews/issues/67#issuecomment-100", Author: "alice", CreatedAt: "2026-06-04T10:00:00Z"},
+			},
+		},
+	}
+	var stdout bytes.Buffer
+	if _, err := pollSkillOptReviewWatches(context.Background(), store, blobStore, fake, &stdout, false); err != nil {
+		t.Fatalf("pollSkillOptReviewWatches returned error: %v", err)
+	}
+	events, err := store.ListRankedFeedbackEvents(context.Background(), "watcher-review-001")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
+	}
+	if len(events) != 2 || events[0].Reviewer != "alice" {
+		t.Fatalf("ranked events = %+v", events)
+	}
+	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusImported || watch.LastSeenCommentID != 100 {
+		t.Fatalf("watch = %+v", watch)
+	}
+	if len(fake.postedComments) != 0 {
+		t.Fatalf("posted comments = %+v", fake.postedComments)
+	}
+	if !strings.Contains(stdout.String(), "imported 2 skillopt review feedback events") {
+		t.Fatalf("stdout = %q; home=%s", stdout.String(), home)
+	}
+	if _, err := pollSkillOptReviewWatches(context.Background(), store, blobStore, fake, &stdout, false); err != nil {
+		t.Fatalf("second pollSkillOptReviewWatches returned error: %v", err)
+	}
+	events, err = store.ListRankedFeedbackEvents(context.Background(), "watcher-review-001")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents after second poll returned error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("ranked events after second poll = %+v", events)
+	}
+}
+
+func TestSkillOptReviewWatcherCommentsInvalidYAMLDeduped(t *testing.T) {
+	_, store, blobStore := seedSkillOptReviewWatcherRun(t)
+	defer store.Close()
+	fake := &skillOptFakeGitHub{
+		comments: map[int64][]github.IssueComment{
+			67: {
+				{ID: 100, Body: "run_id: watcher-review-001\nitems:\n  - item_id: item-001\n    ranking:\n      - C > A > D > B\n", URL: "https://github.com/owner/previews/issues/67#issuecomment-100", Author: "alice", CreatedAt: "2026-06-04T10:00:00Z"},
+			},
+		},
+	}
+	var stdout bytes.Buffer
+	if _, err := pollSkillOptReviewWatches(context.Background(), store, blobStore, fake, &stdout, false); err != nil {
+		t.Fatalf("pollSkillOptReviewWatches returned error: %v", err)
+	}
+	if len(fake.postedComments) != 1 {
+		t.Fatalf("posted comments = %+v", fake.postedComments)
+	}
+	if !strings.Contains(fake.postedComments[0].Body, skillOptReviewWatchErrorMarker) ||
+		!strings.Contains(fake.postedComments[0].Body, "missing feedback for expected item_id(s): item-002") {
+		t.Fatalf("error comment = %q", fake.postedComments[0].Body)
+	}
+	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusWatching || watch.LastSeenCommentID != 0 || watch.LastImportErrorHash == "" {
+		t.Fatalf("watch after invalid import = %+v", watch)
+	}
+	if _, err := pollSkillOptReviewWatches(context.Background(), store, blobStore, fake, &stdout, false); err != nil {
+		t.Fatalf("second pollSkillOptReviewWatches returned error: %v", err)
+	}
+	if len(fake.postedComments) != 1 {
+		t.Fatalf("posted comments after second poll = %+v", fake.postedComments)
+	}
+	events, err := store.ListRankedFeedbackEvents(context.Background(), "watcher-review-001")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("ranked events = %+v", events)
+	}
+	fake.comments[67][0].Body = "run_id: watcher-review-001\nitems:\n  - item_id: item-001\n    ranking:\n      - C > A > D > B\n  - item_id: item-002\n    ranking:\n      - B > C > A > D\n"
+	if _, err := pollSkillOptReviewWatches(context.Background(), store, blobStore, fake, &stdout, false); err != nil {
+		t.Fatalf("third pollSkillOptReviewWatches returned error: %v", err)
+	}
+	events, err = store.ListRankedFeedbackEvents(context.Background(), "watcher-review-001")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents after edit returned error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("ranked events after edit = %+v", events)
+	}
+}
+
 func TestSkillOptFeedbackRepoResolutionPreservesNonTrainExpectedRepoFallback(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)
@@ -7548,6 +7648,67 @@ type skillOptPostedGitHubComment struct {
 type skillOptListedGitHubComments struct {
 	Repo        github.Repository
 	IssueNumber int64
+}
+
+func seedSkillOptReviewWatcherRun(t *testing.T) (string, *db.Store, artifact.Store) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
+		ID:               "watcher-review-001",
+		TargetRepo:       "owner/product",
+		State:            "review",
+		Mode:             db.EvalRunModeExplore,
+		ExplorationLevel: db.ExplorationLevelHigh,
+		OptionsCount:     4,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	for _, itemID := range []string{"item-001", "item-002"} {
+		if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+			RunID:  "watcher-review-001",
+			ItemID: itemID,
+			Title:  itemID,
+		}); err != nil {
+			t.Fatalf("UpsertEvalReviewItem %s returned error: %v", itemID, err)
+		}
+		for _, label := range []string{"a", "b", "c", "d"} {
+			content := []byte(itemID + " option " + label)
+			blob, err := blobStore.Put(content)
+			if err != nil {
+				t.Fatalf("Put %s %s returned error: %v", itemID, label, err)
+			}
+			artifactID := itemID + "-option-" + label
+			if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{ID: artifactID, Hash: blob.Hash, MediaType: "text/markdown", SizeBytes: blob.Size, Driver: "text"}); err != nil {
+				t.Fatalf("UpsertEvalArtifact %s returned error: %v", artifactID, err)
+			}
+			if err := store.UpsertEvalReviewOption(context.Background(), db.EvalReviewOption{RunID: "watcher-review-001", ItemID: itemID, Label: label, ArtifactID: artifactID, Role: "option"}); err != nil {
+				t.Fatalf("UpsertEvalReviewOption %s %s returned error: %v", itemID, label, err)
+			}
+		}
+	}
+	itemIDsJSON, err := json.Marshal([]string{"item-001", "item-002"})
+	if err != nil {
+		t.Fatalf("Marshal item ids returned error: %v", err)
+	}
+	if err := store.UpsertSkillOptReviewWatch(context.Background(), db.SkillOptReviewWatch{
+		Repo:                "owner/previews",
+		IssueNumber:         67,
+		RunID:               "watcher-review-001",
+		ExpectedItemIDsJSON: string(itemIDsJSON),
+		Status:              db.SkillOptReviewWatchStatusWatching,
+	}); err != nil {
+		t.Fatalf("UpsertSkillOptReviewWatch returned error: %v", err)
+	}
+	return home, store, blobStore
 }
 
 func (f *skillOptFakeGitHub) CreateIssue(_ context.Context, input github.CreateIssueInput) (github.Issue, error) {

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -35,6 +35,54 @@ type GitHubPublishResult struct {
 
 const githubFeedbackPacketMarker = "<!-- gitmoot:skillopt-feedback-packet -->"
 
+type GitHubReviewCommentValidation struct {
+	Parseable bool
+	ItemIDs   []string
+}
+
+func ValidateGitHubReviewComment(body string, runID string, expectedItemIDs []string) (GitHubReviewCommentValidation, error) {
+	parsed, ok, err := ParseGitHubFeedbackComment(body)
+	if err != nil {
+		return GitHubReviewCommentValidation{Parseable: true}, feedbackImportErrorHint(err)
+	}
+	if !ok {
+		return GitHubReviewCommentValidation{}, nil
+	}
+	runID = strings.TrimSpace(runID)
+	if parsed.RunID == "" {
+		return GitHubReviewCommentValidation{Parseable: true}, errors.New("missing run_id")
+	}
+	if parsed.RunID != runID {
+		return GitHubReviewCommentValidation{Parseable: true}, fmt.Errorf("wrong run_id %q, want %q", parsed.RunID, runID)
+	}
+	seen := map[string]struct{}{}
+	itemIDs := make([]string, 0, len(parsed.Items))
+	for _, entry := range parsed.Items {
+		itemID := strings.TrimSpace(entry.ItemID)
+		if itemID == "" {
+			return GitHubReviewCommentValidation{Parseable: true}, fmt.Errorf("missing item_id in feedback for run %q", runID)
+		}
+		if _, ok := seen[itemID]; !ok {
+			seen[itemID] = struct{}{}
+			itemIDs = append(itemIDs, itemID)
+		}
+	}
+	missing := []string{}
+	for _, expected := range expectedItemIDs {
+		expected = strings.TrimSpace(expected)
+		if expected == "" {
+			continue
+		}
+		if _, ok := seen[expected]; !ok {
+			missing = append(missing, expected)
+		}
+	}
+	if len(missing) > 0 {
+		return GitHubReviewCommentValidation{Parseable: true, ItemIDs: itemIDs}, fmt.Errorf("missing feedback for expected item_id(s): %s", strings.Join(missing, ", "))
+	}
+	return GitHubReviewCommentValidation{Parseable: true, ItemIDs: itemIDs}, nil
+}
+
 func (c GitHubCollector) Publish(ctx context.Context, store *db.Store, runID string, target GitHubPublishTarget) (GitHubPublishResult, error) {
 	if c.GitHub == nil {
 		return GitHubPublishResult{}, errors.New("github client is required")


### PR DESCRIPTION
WHAT
- Adds a local gh-backed SkillOpt review watcher that imports valid watched issue feedback comments without a manual sync command.

WHY
- Task 6 needs Gitmoot to poll only registered SkillOpt review issues, import complete review YAML, and guide humans when feedback is malformed.

CHANGES
- Added `--watch-skillopt-reviews` support for `gitmoot daemon run` and `gitmoot daemon start`, including persisted child/restart args.
- Added watcher polling for `watching` SkillOpt review records using the existing `gh` GitHub client abstraction.
- Skips Gitmoot/template/error-marker comments and already imported successful comments.
- Validates expected `run_id` and all expected `item_id` values before import.
- Reuses existing GitHub feedback import logic for ranking validation and idempotent DB upserts.
- Posts one deduplicated error comment per distinct import error hash.
- Keeps invalid comments retryable so edited GitHub comments can later import successfully.
- Logs watcher polling failures without stopping the whole daemon.

RESULTS
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli ./internal/feedback ./internal/db`
- `git diff --check`
- untracked watcher file whitespace check via `git diff --no-index --check /dev/null internal/cli/skillopt_review_watcher.go`
- `codex exec review --uncommitted`

Final Codex review raw output:
```text
No discrete correctness issues were found in the current changes. The review watcher path, validation, daemon flag propagation, and idempotency handling appear consistent with the scoped behavior.
```

RISK
- This task imports feedback only. Auto-closing the review issue and continuing training are intentionally left for Task 7.
