### PR TITLE
skillopt: continue training after review import

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -841,7 +841,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 				return err
 			}
 			if watchSkillOptReviews {
-				if _, err := pollSkillOptReviewWatches(ctx, store, blobStore, reviewGitHub, stdout, dryRun); err != nil {
+				if _, err := pollSkillOptReviewWatches(ctx, paths, store, blobStore, reviewGitHub, stdout, dryRun, home); err != nil {
 					writeLine(stdout, "skillopt review watch poll error: %s", err)
 				}
 			}

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -905,6 +905,27 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 		}
 		return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
 	case skillopt.TrainStateReviewPublished:
+		releaseReviewSyncLock, _, err := acquireSkillOptTrainReviewLock(ctx, store, session.ID, iteration.ID)
+		if err != nil {
+			return output, err
+		}
+		defer func() {
+			_ = releaseReviewSyncLock(context.Background())
+		}()
+		session, iteration, counts, err = loadSkillOptTrainStatus(ctx, store, request.SessionID)
+		if err != nil {
+			return skillOptTrainContinueOutput{}, err
+		}
+		summary = skillopt.BuildTrainStatusSummary(session, iteration, counts)
+		output = skillOptTrainContinueOutput{Summary: summary, Counts: counts}
+		if iteration == nil {
+			output.Lines = []string{"next: train session has no iteration to continue"}
+			return output, nil
+		}
+		if summary.CurrentPhase != skillopt.TrainStateReviewPublished {
+			output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
+			return output, nil
+		}
 		status, err := loadSkillOptReviewStatus(ctx, store, artifact.NewStore(paths.ArtifactBlobs), iteration.EvalRunID)
 		if err != nil {
 			return skillOptTrainContinueOutput{}, err

--- a/internal/cli/skillopt_review_watcher.go
+++ b/internal/cli/skillopt_review_watcher.go
@@ -12,15 +12,18 @@ import (
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/feedback"
 	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
 )
 
 const skillOptReviewWatchErrorMarker = "<!-- gitmoot:skillopt-review-watch-error -->"
+const skillOptReviewWatchSuccessMarker = "<!-- gitmoot:skillopt-review-watch-success -->"
 
-func pollSkillOptReviewWatches(ctx context.Context, store *db.Store, blobStore artifact.Store, gh github.Client, stdout io.Writer, dryRun bool) (int, error) {
+func pollSkillOptReviewWatches(ctx context.Context, paths config.Paths, store *db.Store, blobStore artifact.Store, gh github.Client, stdout io.Writer, dryRun bool, home string) (int, error) {
 	if store == nil {
 		return 0, fmt.Errorf("store is required")
 	}
@@ -31,6 +34,11 @@ func pollSkillOptReviewWatches(ctx context.Context, store *db.Store, blobStore a
 	if err != nil {
 		return 0, err
 	}
+	importedWatches, err := store.ListSkillOptReviewWatches(ctx, db.SkillOptReviewWatchStatusImported)
+	if err != nil {
+		return 0, err
+	}
+	watches = append(watches, importedWatches...)
 	polled := 0
 	var pollErr error
 	for _, watch := range watches {
@@ -39,7 +47,7 @@ func pollSkillOptReviewWatches(ctx context.Context, store *db.Store, blobStore a
 			polled++
 			continue
 		}
-		if err := pollSkillOptReviewWatch(ctx, store, blobStore, gh, stdout, watch); err != nil {
+		if err := pollSkillOptReviewWatch(ctx, paths, store, blobStore, gh, stdout, watch, home); err != nil {
 			writeLine(stdout, "skillopt review watch %s#%d: %s", watch.Repo, watch.IssueNumber, err)
 			pollErr = errors.Join(pollErr, err)
 			continue
@@ -52,7 +60,7 @@ func pollSkillOptReviewWatches(ctx context.Context, store *db.Store, blobStore a
 	return polled, pollErr
 }
 
-func pollSkillOptReviewWatch(ctx context.Context, store *db.Store, blobStore artifact.Store, gh github.Client, stdout io.Writer, watch db.SkillOptReviewWatch) error {
+func pollSkillOptReviewWatch(ctx context.Context, paths config.Paths, store *db.Store, blobStore artifact.Store, gh github.Client, stdout io.Writer, watch db.SkillOptReviewWatch, home string) error {
 	repo, err := daemon.ParseRepository(watch.Repo)
 	if err != nil {
 		return fmt.Errorf("skillopt review watch %s#%d: %w", watch.Repo, watch.IssueNumber, err)
@@ -64,6 +72,19 @@ func pollSkillOptReviewWatch(ctx context.Context, store *db.Store, blobStore art
 	sort.SliceStable(comments, func(i, j int) bool {
 		return comments[i].ID < comments[j].ID
 	})
+	successPosted := hasGitmootSkillOptReviewWatchSuccessComment(comments)
+	if watch.Status == db.SkillOptReviewWatchStatusImported {
+		result, err := skillOptReviewWatchImportResultFromStore(ctx, store, watch.RunID)
+		if err != nil {
+			return err
+		}
+		continuation := continueImportedSkillOptReviewWatchTraining(ctx, paths, store, watch, home)
+		if err := acknowledgeAndCloseSkillOptReviewWatch(ctx, store, gh, repo, &watch, result, continuation, successPosted); err != nil {
+			return err
+		}
+		writeLine(stdout, "acknowledged imported skillopt review feedback from %s#%d", watch.Repo, watch.IssueNumber)
+		return nil
+	}
 	expected, err := skillOptReviewWatchExpectedItemIDs(watch)
 	if err != nil {
 		return fmt.Errorf("skillopt review watch %s#%d: %w", watch.Repo, watch.IssueNumber, err)
@@ -99,10 +120,89 @@ func pollSkillOptReviewWatch(ctx context.Context, store *db.Store, blobStore art
 		if err := store.UpsertSkillOptReviewWatch(ctx, watch); err != nil {
 			return err
 		}
+		continuation := continueSkillOptReviewWatchTraining(ctx, paths, store, watch, home)
+		if err := acknowledgeAndCloseSkillOptReviewWatch(ctx, store, gh, repo, &watch, result, continuation, successPosted); err != nil {
+			return err
+		}
 		writeLine(stdout, "imported %d skillopt review feedback events from %s#%d comment %d", result.Count(), watch.Repo, watch.IssueNumber, comment.ID)
 		return nil
 	}
 	return store.UpsertSkillOptReviewWatch(ctx, watch)
+}
+
+type skillOptReviewWatchContinuation struct {
+	SessionID string
+	Phase     string
+	Lines     []string
+	Busy      bool
+	Err       error
+}
+
+func continueSkillOptReviewWatchTraining(ctx context.Context, paths config.Paths, store *db.Store, watch db.SkillOptReviewWatch, home string) skillOptReviewWatchContinuation {
+	iteration, err := store.GetSkillOptTrainIterationByEvalRun(ctx, watch.RunID)
+	if err != nil {
+		return skillOptReviewWatchContinuation{Err: fmt.Errorf("load train iteration for review run %s: %w", watch.RunID, err)}
+	}
+	output, err := continueSkillOptTrain(ctx, paths, store, skillOptTrainContinueRequest{
+		Home:      home,
+		SessionID: iteration.SessionID,
+	})
+	continuation := skillOptReviewWatchContinuation{
+		SessionID: iteration.SessionID,
+		Phase:     output.Summary.CurrentPhase,
+		Lines:     append([]string(nil), output.Lines...),
+		Err:       err,
+	}
+	if err != nil {
+		continuation.Busy = isSkillOptTrainBusyError(err)
+	}
+	return continuation
+}
+
+func continueImportedSkillOptReviewWatchTraining(ctx context.Context, paths config.Paths, store *db.Store, watch db.SkillOptReviewWatch, home string) skillOptReviewWatchContinuation {
+	iteration, err := store.GetSkillOptTrainIterationByEvalRun(ctx, watch.RunID)
+	if err != nil {
+		return skillOptReviewWatchContinuation{Err: fmt.Errorf("load train iteration for review run %s: %w", watch.RunID, err)}
+	}
+	if iteration.State == skillopt.TrainStateReviewPublished {
+		return continueSkillOptReviewWatchTraining(ctx, paths, store, watch, home)
+	}
+	return skillOptReviewWatchContinuation{
+		SessionID: iteration.SessionID,
+		Phase:     iteration.State,
+	}
+}
+
+func acknowledgeAndCloseSkillOptReviewWatch(ctx context.Context, store *db.Store, gh github.Client, repo github.Repository, watch *db.SkillOptReviewWatch, result feedback.ImportResult, continuation skillOptReviewWatchContinuation, successPosted bool) error {
+	if !successPosted {
+		body := skillOptReviewWatchSuccessComment(watch.RunID, result, continuation)
+		if _, err := gh.PostIssueComment(ctx, repo, watch.IssueNumber, body); err != nil {
+			return fmt.Errorf("skillopt review watch %s#%d: post import success: %w", watch.Repo, watch.IssueNumber, err)
+		}
+	}
+	if !skillOptReviewWatchShouldCloseAfterContinuation(continuation) {
+		return store.UpsertSkillOptReviewWatch(ctx, *watch)
+	}
+	if _, err := gh.CloseIssue(ctx, repo, watch.IssueNumber); err != nil {
+		return fmt.Errorf("skillopt review watch %s#%d: close review issue: %w", watch.Repo, watch.IssueNumber, err)
+	}
+	watch.Status = db.SkillOptReviewWatchStatusClosed
+	return store.UpsertSkillOptReviewWatch(ctx, *watch)
+}
+
+func skillOptReviewWatchImportResultFromStore(ctx context.Context, store *db.Store, runID string) (feedback.ImportResult, error) {
+	events, err := store.ListFeedbackEvents(ctx, runID)
+	if err != nil {
+		return feedback.ImportResult{}, err
+	}
+	rankedEvents, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		return feedback.ImportResult{}, err
+	}
+	return feedback.ImportResult{
+		FeedbackEvents:       events,
+		RankedFeedbackEvents: rankedEvents,
+	}, nil
 }
 
 func skillOptReviewWatchExpectedItemIDs(watch db.SkillOptReviewWatch) ([]string, error) {
@@ -120,8 +220,18 @@ func skillOptReviewWatchExpectedItemIDs(watch db.SkillOptReviewWatch) ([]string,
 func isGitmootSkillOptReviewWatchComment(body string) bool {
 	body = strings.TrimSpace(body)
 	return strings.Contains(body, skillOptReviewWatchErrorMarker) ||
+		strings.Contains(body, skillOptReviewWatchSuccessMarker) ||
 		strings.Contains(body, "<!-- gitmoot:skillopt-feedback-packet -->") ||
 		strings.HasPrefix(body, "# Gitmoot SkillOpt Feedback:")
+}
+
+func hasGitmootSkillOptReviewWatchSuccessComment(comments []github.IssueComment) bool {
+	for _, comment := range comments {
+		if strings.Contains(comment.Body, skillOptReviewWatchSuccessMarker) {
+			return true
+		}
+	}
+	return false
 }
 
 func postSkillOptReviewWatchImportError(ctx context.Context, store *db.Store, gh github.Client, repo github.Repository, watch *db.SkillOptReviewWatch, comment github.IssueComment, importErr error) error {
@@ -156,4 +266,70 @@ func skillOptReviewWatchImportErrorComment(runID string, commentID int64, messag
 	builder.WriteString(strings.ReplaceAll(message, "\n", " "))
 	builder.WriteString("\n\nPlease reply with a complete fenced `yaml` block for the expected `run_id` and all review `item_id` values.\n")
 	return builder.String()
+}
+
+func skillOptReviewWatchSuccessComment(runID string, result feedback.ImportResult, continuation skillOptReviewWatchContinuation) string {
+	var builder strings.Builder
+	builder.WriteString(skillOptReviewWatchSuccessMarker)
+	builder.WriteString("\nGitmoot imported the SkillOpt review feedback.\n\n")
+	fmt.Fprintf(&builder, "- run_id: `%s`\n", strings.TrimSpace(runID))
+	fmt.Fprintf(&builder, "- feedback_events: `%d`\n", result.Count())
+	if items := importedSkillOptReviewWatchItemIDs(result); len(items) > 0 {
+		fmt.Fprintf(&builder, "- item_ids: `%s`\n", strings.Join(items, ", "))
+	}
+	if continuation.SessionID != "" {
+		fmt.Fprintf(&builder, "- train_session: `%s`\n", continuation.SessionID)
+	}
+	switch {
+	case continuation.Err == nil:
+		if continuation.Phase != "" {
+			fmt.Fprintf(&builder, "- train_phase: `%s`\n", continuation.Phase)
+		}
+		builder.WriteString("- next: Gitmoot continued the train loop after import.\n")
+	case continuation.Busy:
+		builder.WriteString("- next: Feedback is imported. A train operation is already active; it can pick this up, or run `gitmoot skillopt train continue` again after it finishes.\n")
+	default:
+		builder.WriteString("- next: Feedback is imported, but automatic continuation failed. Run `gitmoot skillopt train continue` manually after checking daemon logs.\n")
+		fmt.Fprintf(&builder, "- continue_error: `%s`\n", strings.ReplaceAll(continuation.Err.Error(), "`", "'"))
+	}
+	return builder.String()
+}
+
+func importedSkillOptReviewWatchItemIDs(result feedback.ImportResult) []string {
+	seen := map[string]struct{}{}
+	var itemIDs []string
+	for _, event := range result.FeedbackEvents {
+		itemID := strings.TrimSpace(event.ItemID)
+		if itemID == "" {
+			continue
+		}
+		if _, ok := seen[itemID]; !ok {
+			seen[itemID] = struct{}{}
+			itemIDs = append(itemIDs, itemID)
+		}
+	}
+	for _, event := range result.RankedFeedbackEvents {
+		itemID := strings.TrimSpace(event.ItemID)
+		if itemID == "" {
+			continue
+		}
+		if _, ok := seen[itemID]; !ok {
+			seen[itemID] = struct{}{}
+			itemIDs = append(itemIDs, itemID)
+		}
+	}
+	sort.Strings(itemIDs)
+	return itemIDs
+}
+
+func isSkillOptTrainBusyError(err error) bool {
+	return errors.Is(err, errSkillOptTrainGenerationBusy) ||
+		errors.Is(err, errSkillOptTrainReviewBusy) ||
+		errors.Is(err, errSkillOptTrainOptimizerBusy) ||
+		errors.Is(err, errSkillOptTrainCandidateReviewBusy) ||
+		errors.Is(err, errSkillOptTrainStartNextBusy)
+}
+
+func skillOptReviewWatchShouldCloseAfterContinuation(continuation skillOptReviewWatchContinuation) bool {
+	return continuation.Err == nil && continuation.Phase != skillopt.TrainStateReviewPublished
 }

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -6271,7 +6271,8 @@ func TestSkillOptReviewWatcherImportsValidYAML(t *testing.T) {
 		},
 	}
 	var stdout bytes.Buffer
-	if _, err := pollSkillOptReviewWatches(context.Background(), store, blobStore, fake, &stdout, false); err != nil {
+	paths := config.PathsForHome(home)
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err != nil {
 		t.Fatalf("pollSkillOptReviewWatches returned error: %v", err)
 	}
 	events, err := store.ListRankedFeedbackEvents(context.Background(), "watcher-review-001")
@@ -6285,16 +6286,26 @@ func TestSkillOptReviewWatcherImportsValidYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
 	}
-	if watch.Status != db.SkillOptReviewWatchStatusImported || watch.LastSeenCommentID != 100 {
+	if watch.Status != db.SkillOptReviewWatchStatusClosed || watch.LastSeenCommentID != 100 {
 		t.Fatalf("watch = %+v", watch)
 	}
-	if len(fake.postedComments) != 0 {
+	if len(fake.postedComments) != 1 || !strings.Contains(fake.postedComments[0].Body, skillOptReviewWatchSuccessMarker) {
 		t.Fatalf("posted comments = %+v", fake.postedComments)
+	}
+	if len(fake.closedIssues) != 1 || fake.closedIssues[0].IssueNumber != 67 {
+		t.Fatalf("closed issues = %+v", fake.closedIssues)
+	}
+	iteration, err := store.GetSkillOptTrainIteration(context.Background(), "watcher-train-001")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateFeedbackSynced {
+		t.Fatalf("iteration state = %s, want %s", iteration.State, skillopt.TrainStateFeedbackSynced)
 	}
 	if !strings.Contains(stdout.String(), "imported 2 skillopt review feedback events") {
 		t.Fatalf("stdout = %q; home=%s", stdout.String(), home)
 	}
-	if _, err := pollSkillOptReviewWatches(context.Background(), store, blobStore, fake, &stdout, false); err != nil {
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err != nil {
 		t.Fatalf("second pollSkillOptReviewWatches returned error: %v", err)
 	}
 	events, err = store.ListRankedFeedbackEvents(context.Background(), "watcher-review-001")
@@ -6307,8 +6318,9 @@ func TestSkillOptReviewWatcherImportsValidYAML(t *testing.T) {
 }
 
 func TestSkillOptReviewWatcherCommentsInvalidYAMLDeduped(t *testing.T) {
-	_, store, blobStore := seedSkillOptReviewWatcherRun(t)
+	home, store, blobStore := seedSkillOptReviewWatcherRun(t)
 	defer store.Close()
+	paths := config.PathsForHome(home)
 	fake := &skillOptFakeGitHub{
 		comments: map[int64][]github.IssueComment{
 			67: {
@@ -6317,7 +6329,7 @@ func TestSkillOptReviewWatcherCommentsInvalidYAMLDeduped(t *testing.T) {
 		},
 	}
 	var stdout bytes.Buffer
-	if _, err := pollSkillOptReviewWatches(context.Background(), store, blobStore, fake, &stdout, false); err != nil {
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err != nil {
 		t.Fatalf("pollSkillOptReviewWatches returned error: %v", err)
 	}
 	if len(fake.postedComments) != 1 {
@@ -6334,7 +6346,7 @@ func TestSkillOptReviewWatcherCommentsInvalidYAMLDeduped(t *testing.T) {
 	if watch.Status != db.SkillOptReviewWatchStatusWatching || watch.LastSeenCommentID != 0 || watch.LastImportErrorHash == "" {
 		t.Fatalf("watch after invalid import = %+v", watch)
 	}
-	if _, err := pollSkillOptReviewWatches(context.Background(), store, blobStore, fake, &stdout, false); err != nil {
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err != nil {
 		t.Fatalf("second pollSkillOptReviewWatches returned error: %v", err)
 	}
 	if len(fake.postedComments) != 1 {
@@ -6348,7 +6360,7 @@ func TestSkillOptReviewWatcherCommentsInvalidYAMLDeduped(t *testing.T) {
 		t.Fatalf("ranked events = %+v", events)
 	}
 	fake.comments[67][0].Body = "run_id: watcher-review-001\nitems:\n  - item_id: item-001\n    ranking:\n      - C > A > D > B\n  - item_id: item-002\n    ranking:\n      - B > C > A > D\n"
-	if _, err := pollSkillOptReviewWatches(context.Background(), store, blobStore, fake, &stdout, false); err != nil {
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err != nil {
 		t.Fatalf("third pollSkillOptReviewWatches returned error: %v", err)
 	}
 	events, err = store.ListRankedFeedbackEvents(context.Background(), "watcher-review-001")
@@ -6357,6 +6369,109 @@ func TestSkillOptReviewWatcherCommentsInvalidYAMLDeduped(t *testing.T) {
 	}
 	if len(events) != 2 {
 		t.Fatalf("ranked events after edit = %+v", events)
+	}
+}
+
+func TestSkillOptReviewWatcherKeepsImportedWhenTrainReviewLockBusy(t *testing.T) {
+	home, store, blobStore := seedSkillOptReviewWatcherRun(t)
+	defer store.Close()
+	release, _, err := acquireSkillOptTrainReviewLock(context.Background(), store, "watcher-train", "watcher-train-001")
+	if err != nil {
+		t.Fatalf("acquireSkillOptTrainReviewLock returned error: %v", err)
+	}
+	defer func() {
+		_ = release(context.Background())
+	}()
+	fake := &skillOptFakeGitHub{
+		comments: map[int64][]github.IssueComment{
+			67: {
+				{ID: 100, Body: "run_id: watcher-review-001\nitems:\n  - item_id: item-001\n    ranking:\n      - C > A > D > B\n  - item_id: item-002\n    ranking:\n      - B > C > A > D\n", URL: "https://github.com/owner/previews/issues/67#issuecomment-100", Author: "alice", CreatedAt: "2026-06-04T10:00:00Z"},
+			},
+		},
+	}
+	var stdout bytes.Buffer
+	if _, err := pollSkillOptReviewWatches(context.Background(), config.PathsForHome(home), store, blobStore, fake, &stdout, false, home); err != nil {
+		t.Fatalf("pollSkillOptReviewWatches returned error: %v", err)
+	}
+	if len(fake.postedComments) != 1 ||
+		!strings.Contains(fake.postedComments[0].Body, "already active") ||
+		!strings.Contains(fake.postedComments[0].Body, skillOptReviewWatchSuccessMarker) {
+		t.Fatalf("posted comments = %+v", fake.postedComments)
+	}
+	if len(fake.closedIssues) != 0 {
+		t.Fatalf("closed issues = %+v", fake.closedIssues)
+	}
+	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusImported {
+		t.Fatalf("watch status = %s, want imported while lock is active", watch.Status)
+	}
+	iteration, err := store.GetSkillOptTrainIteration(context.Background(), "watcher-train-001")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateReviewPublished {
+		t.Fatalf("iteration state = %s, want review_published while lock is active", iteration.State)
+	}
+}
+
+func TestSkillOptReviewWatcherRetriesImportedAckAndClose(t *testing.T) {
+	home, store, blobStore := seedSkillOptReviewWatcherRun(t)
+	defer store.Close()
+	fake := &skillOptFakeGitHub{
+		comments: map[int64][]github.IssueComment{
+			67: {
+				{ID: 100, Body: "run_id: watcher-review-001\nitems:\n  - item_id: item-001\n    ranking:\n      - C > A > D > B\n  - item_id: item-002\n    ranking:\n      - B > C > A > D\n", URL: "https://github.com/owner/previews/issues/67#issuecomment-100", Author: "alice", CreatedAt: "2026-06-04T10:00:00Z"},
+			},
+		},
+		closeIssueErr: errors.New("temporary close failure"),
+	}
+	paths := config.PathsForHome(home)
+	var stdout bytes.Buffer
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err == nil || !strings.Contains(err.Error(), "temporary close failure") {
+		t.Fatalf("first poll error = %v, want close failure", err)
+	}
+	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusImported {
+		t.Fatalf("watch status after failed close = %s, want imported", watch.Status)
+	}
+	if len(fake.postedComments) != 1 || len(fake.closedIssues) != 0 {
+		t.Fatalf("posted=%+v closed=%+v", fake.postedComments, fake.closedIssues)
+	}
+	fake.comments[67] = append(fake.comments[67], github.IssueComment{ID: 101, Body: fake.postedComments[0].Body, Author: "gitmoot"})
+	fake.closeIssueErr = nil
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err != nil {
+		t.Fatalf("second pollSkillOptReviewWatches returned error: %v", err)
+	}
+	watch, err = store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch after retry returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusClosed {
+		t.Fatalf("watch status after retry = %s, want closed", watch.Status)
+	}
+	if len(fake.postedComments) != 1 {
+		t.Fatalf("posted comments after retry = %+v, want no duplicate success comment", fake.postedComments)
+	}
+	if len(fake.closedIssues) != 1 {
+		t.Fatalf("closed issues = %+v", fake.closedIssues)
+	}
+}
+
+func TestSkillOptReviewWatcherCloseDecisionKeepsBlockedReviewOpen(t *testing.T) {
+	if skillOptReviewWatchShouldCloseAfterContinuation(skillOptReviewWatchContinuation{Phase: skillopt.TrainStateReviewPublished}) {
+		t.Fatal("review_published continuation should keep the review issue open")
+	}
+	if !skillOptReviewWatchShouldCloseAfterContinuation(skillOptReviewWatchContinuation{Phase: skillopt.TrainStateFeedbackSynced}) {
+		t.Fatal("advanced continuation should close the review issue")
+	}
+	if skillOptReviewWatchShouldCloseAfterContinuation(skillOptReviewWatchContinuation{Phase: skillopt.TrainStateReviewPublished, Busy: true, Err: errSkillOptTrainReviewBusy}) {
+		t.Fatal("busy continuation should keep the review issue open so the watcher can retry")
 	}
 }
 
@@ -7630,10 +7745,12 @@ type skillOptFakeGitHub struct {
 
 	createdIssue       github.CreateIssueInput
 	postedComments     []skillOptPostedGitHubComment
+	closedIssues       []skillOptClosedGitHubIssue
 	listedComments     []skillOptListedGitHubComments
 	comments           map[int64][]github.IssueComment
 	createIssueErr     error
 	postCommentErr     error
+	closeIssueErr      error
 	host               string
 	commentKinds       map[int64]string
 	commentURLOverride string
@@ -7643,6 +7760,11 @@ type skillOptPostedGitHubComment struct {
 	Repo        github.Repository
 	IssueNumber int64
 	Body        string
+}
+
+type skillOptClosedGitHubIssue struct {
+	Repo        github.Repository
+	IssueNumber int64
 }
 
 type skillOptListedGitHubComments struct {
@@ -7662,13 +7784,45 @@ func seedSkillOptReviewWatcherRun(t *testing.T) (string, *db.Store, artifact.Sto
 		t.Fatalf("Open returned error: %v", err)
 	}
 	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	template := cliSkillOptTemplate("planner", "Plan landing page improvements.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertSkillOptTrainSession(context.Background(), db.SkillOptTrainSession{
+		ID:                "watcher-train",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/product",
+		State:             skillopt.TrainStateReviewPublished,
+	}); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSession returned error: %v", err)
+	}
+	if err := store.UpsertSkillOptTrainIteration(context.Background(), db.SkillOptTrainIteration{
+		ID:                    "watcher-train-001",
+		SessionID:             "watcher-train",
+		EvalRunID:             "watcher-review-001",
+		Mode:                  db.EvalRunModeExplore,
+		ExplorationLevel:      db.ExplorationLevelHigh,
+		State:                 skillopt.TrainStateReviewPublished,
+		IssueRepo:             "owner/previews",
+		IssueNumber:           67,
+		BaseTemplateVersionID: installed.VersionID,
+	}); err != nil {
+		t.Fatalf("UpsertSkillOptTrainIteration returned error: %v", err)
+	}
 	if err := store.UpsertEvalRun(context.Background(), db.EvalRun{
-		ID:               "watcher-review-001",
-		TargetRepo:       "owner/product",
-		State:            "review",
-		Mode:             db.EvalRunModeExplore,
-		ExplorationLevel: db.ExplorationLevelHigh,
-		OptionsCount:     4,
+		ID:                "watcher-review-001",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/product",
+		State:             "review",
+		Mode:              db.EvalRunModeExplore,
+		ExplorationLevel:  db.ExplorationLevelHigh,
+		OptionsCount:      4,
 	}); err != nil {
 		t.Fatalf("UpsertEvalRun returned error: %v", err)
 	}
@@ -7717,6 +7871,14 @@ func (f *skillOptFakeGitHub) CreateIssue(_ context.Context, input github.CreateI
 	}
 	f.createdIssue = input
 	return github.Issue{Number: 8, URL: f.baseURL() + "/" + input.Repo.FullName() + "/issues/8"}, nil
+}
+
+func (f *skillOptFakeGitHub) CloseIssue(_ context.Context, repo github.Repository, issueNumber int64) (github.Issue, error) {
+	if f.closeIssueErr != nil {
+		return github.Issue{}, f.closeIssueErr
+	}
+	f.closedIssues = append(f.closedIssues, skillOptClosedGitHubIssue{Repo: repo, IssueNumber: issueNumber})
+	return github.Issue{Number: issueNumber, State: "closed", URL: f.baseURL() + "/" + repo.FullName() + "/issues/" + fmt.Sprint(issueNumber)}, nil
 }
 
 func (f *skillOptFakeGitHub) PostIssueComment(_ context.Context, repo github.Repository, issueNumber int64, body string) (github.IssueComment, error) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1768,6 +1768,10 @@ func (f *fakeGitHub) CreateIssue(context.Context, github.CreateIssueInput) (gith
 	return github.Issue{}, errors.New("not implemented")
 }
 
+func (f *fakeGitHub) CloseIssue(context.Context, github.Repository, int64) (github.Issue, error) {
+	return github.Issue{}, errors.New("not implemented")
+}
+
 func (f *fakeGitHub) ListIssueComments(_ context.Context, _ github.Repository, issueNumber int64) ([]github.IssueComment, error) {
 	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -21,6 +21,7 @@ type Client interface {
 	GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
 	CreateIssue(ctx context.Context, input CreateIssueInput) (Issue, error)
+	CloseIssue(ctx context.Context, repo Repository, issueNumber int64) (Issue, error)
 	ListIssueComments(ctx context.Context, repo Repository, issueNumber int64) ([]IssueComment, error)
 	PostIssueComment(ctx context.Context, repo Repository, issueNumber int64, body string) (IssueComment, error)
 	GetUserPermission(ctx context.Context, repo Repository, username string) (UserPermission, error)
@@ -286,6 +287,12 @@ func (c *GhClient) CreateIssue(ctx context.Context, input CreateIssueInput) (Iss
 		endpoint(input.Repo, "issues"),
 		"-f", "title="+input.Title,
 		"-f", "body="+input.Body)
+	return issue, err
+}
+
+func (c *GhClient) CloseIssue(ctx context.Context, repo Repository, issueNumber int64) (Issue, error) {
+	var issue Issue
+	err := c.apiJSON(ctx, true, &issue, "-X", "PATCH", endpoint(repo, "issues", issueNumber), "-f", "state=closed")
 	return issue, err
 }
 
@@ -662,6 +669,10 @@ func (NoopClient) CreatePullRequest(context.Context, CreatePullRequestInput) (Pu
 }
 
 func (NoopClient) CreateIssue(context.Context, CreateIssueInput) (Issue, error) {
+	return Issue{}, errors.ErrUnsupported
+}
+
+func (NoopClient) CloseIssue(context.Context, Repository, int64) (Issue, error) {
 	return Issue{}, errors.ErrUnsupported
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -81,6 +81,25 @@ func TestCreateIssueUsesIssuesEndpoint(t *testing.T) {
 	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/issues", "-f", "title=Review run-1", "-f", "body=body")
 }
 
+func TestCloseIssueUsesIssueEndpoint(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"number": 8, "title": "Review run-1", "state": "closed", "html_url": "https://github.com/jerryfane/gitmoot/issues/8"}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	issue, err := client.CloseIssue(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, 8)
+
+	if err != nil {
+		t.Fatalf("CloseIssue returned error: %v", err)
+	}
+	if issue.Number != 8 || issue.State != "closed" {
+		t.Fatalf("issue = %+v", issue)
+	}
+	runner.wantArgs(t, 0, "api", "-X", "PATCH", "repos/jerryfane/gitmoot/issues/8", "-f", "state=closed")
+}
+
 func TestGetUserPermissionUsesCollaboratorPermissionEndpoint(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{


### PR DESCRIPTION
## WHAT

Task 7 for issue #122: after watched SkillOpt review feedback imports successfully, Gitmoot now acknowledges the import, closes the review issue when continuation has actually advanced, and continues the train loop safely.

## WHY

The previous watcher imported YAML feedback but still required a manual continuation step. This left the human flow half-automated and made it easy for review issues to remain open after feedback had already been consumed.

## CHANGES

- Added `github.Client.CloseIssue` implemented through `gh api -X PATCH repos/{repo}/issues/{n} -f state=closed`.
- Added watcher success comments with imported `run_id`, feedback count, item ids, train session, train phase, and next action.
- After a valid import, the watcher runs `continueSkillOptTrain` for the owning train session.
- Added a review sync lock around the `review_published` continuation branch so manual and watcher-triggered continuation do not race.
- Treats `imported` watch status as acknowledgement/close pending so transient GitHub failures are retried.
- Keeps busy or still-blocked review watches at `imported` instead of closing them, so the daemon can retry continuation after locks clear.
- Closes the review issue only after continuation advances away from `review_published`.
- Added focused tests for success close/continue, invalid YAML dedupe, busy lock retry behavior, transient close retry, and close-decision semantics.

## RESULTS

- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'TestSkillOptReviewWatcher|TestSkillOptTrainContinueRefusesConcurrentOptimizer' -count=1 -v`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/daemon ./internal/github ./internal/cli ./internal/feedback ./internal/db`
- `git diff --check`
- `codex exec review --uncommitted`

Final raw review result:

```text
codex
No actionable correctness issues were identified in the changed code. Local tests could not be run because the sandbox cannot download the required Go 1.26 toolchain.
No actionable correctness issues were identified in the changed code. Local tests could not be run because the sandbox cannot download the required Go 1.26 toolchain.
```

## RISK

The watcher still does not implement a durable queue. When continuation is busy, the watch intentionally remains `imported` and open so the daemon can retry after the active train lock clears. Stale notice behavior remains Task 8.
