### PR TITLE
skillopt: notify stale review watchers

### DIFF
--- a/internal/cli/skillopt_review_watcher.go
+++ b/internal/cli/skillopt_review_watcher.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/config"
@@ -22,6 +23,7 @@ import (
 
 const skillOptReviewWatchErrorMarker = "<!-- gitmoot:skillopt-review-watch-error -->"
 const skillOptReviewWatchSuccessMarker = "<!-- gitmoot:skillopt-review-watch-success -->"
+const skillOptReviewWatchStaleMarker = "<!-- gitmoot:skillopt-review-watch-stale -->"
 
 func pollSkillOptReviewWatches(ctx context.Context, paths config.Paths, store *db.Store, blobStore artifact.Store, gh github.Client, stdout io.Writer, dryRun bool, home string) (int, error) {
 	if store == nil {
@@ -39,6 +41,11 @@ func pollSkillOptReviewWatches(ctx context.Context, paths config.Paths, store *d
 		return 0, err
 	}
 	watches = append(watches, importedWatches...)
+	staleNotifiedWatches, err := store.ListSkillOptReviewWatches(ctx, db.SkillOptReviewWatchStatusStaleNotified)
+	if err != nil {
+		return 0, err
+	}
+	watches = append(watches, staleNotifiedWatches...)
 	polled := 0
 	var pollErr error
 	for _, watch := range watches {
@@ -73,6 +80,7 @@ func pollSkillOptReviewWatch(ctx context.Context, paths config.Paths, store *db.
 		return comments[i].ID < comments[j].ID
 	})
 	successPosted := hasGitmootSkillOptReviewWatchSuccessComment(comments)
+	stalePosted := hasGitmootSkillOptReviewWatchStaleComment(comments)
 	if watch.Status == db.SkillOptReviewWatchStatusImported {
 		result, err := skillOptReviewWatchImportResultFromStore(ctx, store, watch.RunID)
 		if err != nil {
@@ -90,6 +98,7 @@ func pollSkillOptReviewWatch(ctx context.Context, paths config.Paths, store *db.
 		return fmt.Errorf("skillopt review watch %s#%d: %w", watch.Repo, watch.IssueNumber, err)
 	}
 	collector := feedback.GitHubCollector{BlobStore: blobStore, GitHub: gh}
+	invalidFeedbackSeen := false
 	for _, comment := range comments {
 		if comment.ID <= watch.LastSeenCommentID || isGitmootSkillOptReviewWatchComment(comment.Body) {
 			continue
@@ -99,6 +108,7 @@ func pollSkillOptReviewWatch(ctx context.Context, paths config.Paths, store *db.
 			if err := postSkillOptReviewWatchImportError(ctx, store, gh, repo, &watch, comment, err); err != nil {
 				return err
 			}
+			invalidFeedbackSeen = true
 			continue
 		}
 		if !validation.Parseable {
@@ -112,6 +122,7 @@ func pollSkillOptReviewWatch(ctx context.Context, paths config.Paths, store *db.
 			if err := postSkillOptReviewWatchImportError(ctx, store, gh, repo, &watch, comment, err); err != nil {
 				return err
 			}
+			invalidFeedbackSeen = true
 			continue
 		}
 		watch.Status = db.SkillOptReviewWatchStatusImported
@@ -126,6 +137,12 @@ func pollSkillOptReviewWatch(ctx context.Context, paths config.Paths, store *db.
 		}
 		writeLine(stdout, "imported %d skillopt review feedback events from %s#%d comment %d", result.Count(), watch.Repo, watch.IssueNumber, comment.ID)
 		return nil
+	}
+	if invalidFeedbackSeen {
+		return store.UpsertSkillOptReviewWatch(ctx, watch)
+	}
+	if err := maybePostSkillOptReviewWatchStaleNotice(ctx, store, gh, repo, &watch, expected, stalePosted); err != nil {
+		return err
 	}
 	return store.UpsertSkillOptReviewWatch(ctx, watch)
 }
@@ -221,6 +238,7 @@ func isGitmootSkillOptReviewWatchComment(body string) bool {
 	body = strings.TrimSpace(body)
 	return strings.Contains(body, skillOptReviewWatchErrorMarker) ||
 		strings.Contains(body, skillOptReviewWatchSuccessMarker) ||
+		strings.Contains(body, skillOptReviewWatchStaleMarker) ||
 		strings.Contains(body, "<!-- gitmoot:skillopt-feedback-packet -->") ||
 		strings.HasPrefix(body, "# Gitmoot SkillOpt Feedback:")
 }
@@ -232,6 +250,57 @@ func hasGitmootSkillOptReviewWatchSuccessComment(comments []github.IssueComment)
 		}
 	}
 	return false
+}
+
+func hasGitmootSkillOptReviewWatchStaleComment(comments []github.IssueComment) bool {
+	for _, comment := range comments {
+		if strings.Contains(comment.Body, skillOptReviewWatchStaleMarker) {
+			return true
+		}
+	}
+	return false
+}
+
+func maybePostSkillOptReviewWatchStaleNotice(ctx context.Context, store *db.Store, gh github.Client, repo github.Repository, watch *db.SkillOptReviewWatch, expectedItemIDs []string, stalePosted bool) error {
+	if watch.Status != db.SkillOptReviewWatchStatusWatching || watch.StaleNotified || !skillOptReviewWatchIsStale(*watch, time.Now().UTC()) {
+		return nil
+	}
+	if stalePosted {
+		watch.Status = db.SkillOptReviewWatchStatusStaleNotified
+		watch.StaleNotified = true
+		return store.UpsertSkillOptReviewWatch(ctx, *watch)
+	}
+	continuation := skillOptReviewWatchContinuationForNotice(ctx, store, watch.RunID)
+	body := skillOptReviewWatchStaleNoticeComment(*watch, expectedItemIDs, continuation)
+	if _, err := gh.PostIssueComment(ctx, repo, watch.IssueNumber, body); err != nil {
+		return fmt.Errorf("skillopt review watch %s#%d: post stale notice: %w", watch.Repo, watch.IssueNumber, err)
+	}
+	watch.Status = db.SkillOptReviewWatchStatusStaleNotified
+	watch.StaleNotified = true
+	return store.UpsertSkillOptReviewWatch(ctx, *watch)
+}
+
+func skillOptReviewWatchIsStale(watch db.SkillOptReviewWatch, now time.Time) bool {
+	staleAfter := strings.TrimSpace(watch.StaleAfter)
+	if staleAfter == "" {
+		return false
+	}
+	deadline, err := time.Parse(time.RFC3339Nano, staleAfter)
+	if err != nil {
+		return false
+	}
+	return !now.Before(deadline)
+}
+
+func skillOptReviewWatchContinuationForNotice(ctx context.Context, store *db.Store, runID string) skillOptReviewWatchContinuation {
+	iteration, err := store.GetSkillOptTrainIterationByEvalRun(ctx, runID)
+	if err != nil {
+		return skillOptReviewWatchContinuation{}
+	}
+	return skillOptReviewWatchContinuation{
+		SessionID: iteration.SessionID,
+		Phase:     iteration.State,
+	}
 }
 
 func postSkillOptReviewWatchImportError(ctx context.Context, store *db.Store, gh github.Client, repo github.Repository, watch *db.SkillOptReviewWatch, comment github.IssueComment, importErr error) error {
@@ -265,6 +334,36 @@ func skillOptReviewWatchImportErrorComment(runID string, commentID int64, messag
 	builder.WriteString("- error: ")
 	builder.WriteString(strings.ReplaceAll(message, "\n", " "))
 	builder.WriteString("\n\nPlease reply with a complete fenced `yaml` block for the expected `run_id` and all review `item_id` values.\n")
+	return builder.String()
+}
+
+func skillOptReviewWatchStaleNoticeComment(watch db.SkillOptReviewWatch, expectedItemIDs []string, continuation skillOptReviewWatchContinuation) string {
+	var builder strings.Builder
+	builder.WriteString(skillOptReviewWatchStaleMarker)
+	builder.WriteString("\nGitmoot is still waiting for SkillOpt review feedback.\n\n")
+	fmt.Fprintf(&builder, "- review_issue: `%s#%d`\n", strings.TrimSpace(watch.Repo), watch.IssueNumber)
+	fmt.Fprintf(&builder, "- run_id: `%s`\n", strings.TrimSpace(watch.RunID))
+	if len(expectedItemIDs) > 0 {
+		fmt.Fprintf(&builder, "- waiting_for: complete YAML feedback for item_ids `%s`\n", strings.Join(expectedItemIDs, ", "))
+	} else {
+		builder.WriteString("- waiting_for: complete YAML feedback for this review run\n")
+	}
+	if continuation.SessionID != "" {
+		fmt.Fprintf(&builder, "- train_session: `%s`\n", continuation.SessionID)
+	}
+	if continuation.Phase != "" {
+		fmt.Fprintf(&builder, "- train_phase: `%s`\n", continuation.Phase)
+	}
+	builder.WriteString("\nAfter posting the feedback YAML, send this prompt to your agent:\n\n")
+	builder.WriteString("```text\n")
+	fmt.Fprintf(&builder, "I posted the SkillOpt review feedback for run %s on %s#%d. Please continue the Gitmoot SkillOpt review watcher flow, import the feedback if needed, and continue the train loop.\n", strings.TrimSpace(watch.RunID), strings.TrimSpace(watch.Repo), watch.IssueNumber)
+	builder.WriteString("```\n\n")
+	if continuation.SessionID != "" {
+		builder.WriteString("Equivalent CLI fallback:\n\n")
+		builder.WriteString("```sh\n")
+		fmt.Fprintf(&builder, "gitmoot skillopt train continue --session %s\n", shellArg(continuation.SessionID))
+		builder.WriteString("```\n")
+	}
 	return builder.String()
 }
 

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -6320,6 +6320,7 @@ func TestSkillOptReviewWatcherImportsValidYAML(t *testing.T) {
 func TestSkillOptReviewWatcherCommentsInvalidYAMLDeduped(t *testing.T) {
 	home, store, blobStore := seedSkillOptReviewWatcherRun(t)
 	defer store.Close()
+	setSkillOptReviewWatchStaleAfter(t, store, time.Now().UTC().Add(-time.Minute))
 	paths := config.PathsForHome(home)
 	fake := &skillOptFakeGitHub{
 		comments: map[int64][]github.IssueComment{
@@ -6338,6 +6339,9 @@ func TestSkillOptReviewWatcherCommentsInvalidYAMLDeduped(t *testing.T) {
 	if !strings.Contains(fake.postedComments[0].Body, skillOptReviewWatchErrorMarker) ||
 		!strings.Contains(fake.postedComments[0].Body, "missing feedback for expected item_id(s): item-002") {
 		t.Fatalf("error comment = %q", fake.postedComments[0].Body)
+	}
+	if strings.Contains(fake.postedComments[0].Body, skillOptReviewWatchStaleMarker) {
+		t.Fatalf("invalid feedback produced stale notice = %q", fake.postedComments[0].Body)
 	}
 	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
 	if err != nil {
@@ -6369,6 +6373,174 @@ func TestSkillOptReviewWatcherCommentsInvalidYAMLDeduped(t *testing.T) {
 	}
 	if len(events) != 2 {
 		t.Fatalf("ranked events after edit = %+v", events)
+	}
+}
+
+func TestSkillOptReviewWatcherPostsStaleNoticeOnce(t *testing.T) {
+	home, store, blobStore := seedSkillOptReviewWatcherRun(t)
+	defer store.Close()
+	setSkillOptReviewWatchStaleAfter(t, store, time.Now().UTC().Add(-time.Minute))
+	fake := &skillOptFakeGitHub{comments: map[int64][]github.IssueComment{67: {}}}
+	var stdout bytes.Buffer
+	paths := config.PathsForHome(home)
+
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err != nil {
+		t.Fatalf("pollSkillOptReviewWatches returned error: %v", err)
+	}
+
+	if len(fake.postedComments) != 1 {
+		t.Fatalf("posted comments = %+v", fake.postedComments)
+	}
+	body := fake.postedComments[0].Body
+	for _, want := range []string{
+		skillOptReviewWatchStaleMarker,
+		"review_issue: `owner/previews#67`",
+		"run_id: `watcher-review-001`",
+		"waiting_for: complete YAML feedback for item_ids `item-001, item-002`",
+		"I posted the SkillOpt review feedback for run watcher-review-001 on owner/previews#67.",
+		"gitmoot skillopt train continue --session watcher-train",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("stale notice missing %q:\n%s", want, body)
+		}
+	}
+	if len(fake.closedIssues) != 0 {
+		t.Fatalf("closed issues = %+v", fake.closedIssues)
+	}
+	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusStaleNotified || !watch.StaleNotified {
+		t.Fatalf("watch after stale notice = %+v", watch)
+	}
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err != nil {
+		t.Fatalf("second pollSkillOptReviewWatches returned error: %v", err)
+	}
+	if len(fake.postedComments) != 1 {
+		t.Fatalf("posted comments after second poll = %+v", fake.postedComments)
+	}
+
+	watch.Status = db.SkillOptReviewWatchStatusWatching
+	watch.StaleNotified = false
+	if err := store.UpsertSkillOptReviewWatch(context.Background(), watch); err != nil {
+		t.Fatalf("reset watch after stale notice returned error: %v", err)
+	}
+	fake.comments[67] = append(fake.comments[67], github.IssueComment{ID: 90, Body: body, Author: "gitmoot", CreatedAt: "2026-06-04T09:00:00Z"})
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err != nil {
+		t.Fatalf("third pollSkillOptReviewWatches returned error: %v", err)
+	}
+	if len(fake.postedComments) != 1 {
+		t.Fatalf("posted comments after remote stale marker = %+v", fake.postedComments)
+	}
+	watch, err = store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch after remote stale marker returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusStaleNotified || !watch.StaleNotified {
+		t.Fatalf("watch after remote stale marker = %+v", watch)
+	}
+
+	fake.comments[67] = append(fake.comments[67], github.IssueComment{ID: 100, Body: "run_id: watcher-review-001\nitems:\n  - item_id: item-001\n    ranking:\n      - C > A > D > B\n  - item_id: item-002\n    ranking:\n      - B > C > A > D\n", URL: "https://github.com/owner/previews/issues/67#issuecomment-100", Author: "alice", CreatedAt: "2026-06-04T10:00:00Z"})
+	if _, err := pollSkillOptReviewWatches(context.Background(), paths, store, blobStore, fake, &stdout, false, home); err != nil {
+		t.Fatalf("fourth pollSkillOptReviewWatches returned error: %v", err)
+	}
+	if len(fake.postedComments) != 2 || !strings.Contains(fake.postedComments[1].Body, skillOptReviewWatchSuccessMarker) {
+		t.Fatalf("posted comments after feedback = %+v", fake.postedComments)
+	}
+	if len(fake.closedIssues) != 1 {
+		t.Fatalf("closed issues after feedback = %+v", fake.closedIssues)
+	}
+	watch, err = store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch after feedback returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusClosed {
+		t.Fatalf("watch after stale feedback import = %+v", watch)
+	}
+}
+
+func TestSkillOptReviewWatcherDoesNotStaleBeforeThreshold(t *testing.T) {
+	home, store, blobStore := seedSkillOptReviewWatcherRun(t)
+	defer store.Close()
+	setSkillOptReviewWatchStaleAfter(t, store, time.Now().UTC().Add(time.Hour))
+	fake := &skillOptFakeGitHub{comments: map[int64][]github.IssueComment{67: {}}}
+	var stdout bytes.Buffer
+
+	if _, err := pollSkillOptReviewWatches(context.Background(), config.PathsForHome(home), store, blobStore, fake, &stdout, false, home); err != nil {
+		t.Fatalf("pollSkillOptReviewWatches returned error: %v", err)
+	}
+
+	if len(fake.postedComments) != 0 || len(fake.closedIssues) != 0 {
+		t.Fatalf("posted=%+v closed=%+v", fake.postedComments, fake.closedIssues)
+	}
+	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusWatching || watch.StaleNotified {
+		t.Fatalf("watch before stale threshold = %+v", watch)
+	}
+}
+
+func TestSkillOptReviewWatcherStalesAfterUnrelatedComment(t *testing.T) {
+	home, store, blobStore := seedSkillOptReviewWatcherRun(t)
+	defer store.Close()
+	setSkillOptReviewWatchStaleAfter(t, store, time.Now().UTC().Add(-time.Minute))
+	fake := &skillOptFakeGitHub{
+		comments: map[int64][]github.IssueComment{
+			67: {
+				{ID: 100, Body: "Can someone explain what item-002 means?", URL: "https://github.com/owner/previews/issues/67#issuecomment-100", Author: "alice", CreatedAt: "2026-06-04T10:00:00Z"},
+			},
+		},
+	}
+	var stdout bytes.Buffer
+
+	if _, err := pollSkillOptReviewWatches(context.Background(), config.PathsForHome(home), store, blobStore, fake, &stdout, false, home); err != nil {
+		t.Fatalf("pollSkillOptReviewWatches returned error: %v", err)
+	}
+
+	if len(fake.postedComments) != 1 || !strings.Contains(fake.postedComments[0].Body, skillOptReviewWatchStaleMarker) {
+		t.Fatalf("posted comments = %+v", fake.postedComments)
+	}
+	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusStaleNotified || !watch.StaleNotified {
+		t.Fatalf("watch after unrelated stale comment = %+v", watch)
+	}
+}
+
+func TestSkillOptReviewWatcherImportsFeedbackInsteadOfStaleNotice(t *testing.T) {
+	home, store, blobStore := seedSkillOptReviewWatcherRun(t)
+	defer store.Close()
+	setSkillOptReviewWatchStaleAfter(t, store, time.Now().UTC().Add(-time.Minute))
+	fake := &skillOptFakeGitHub{
+		comments: map[int64][]github.IssueComment{
+			67: {
+				{ID: 100, Body: "run_id: watcher-review-001\nitems:\n  - item_id: item-001\n    ranking:\n      - C > A > D > B\n  - item_id: item-002\n    ranking:\n      - B > C > A > D\n", URL: "https://github.com/owner/previews/issues/67#issuecomment-100", Author: "alice", CreatedAt: "2026-06-04T10:00:00Z"},
+			},
+		},
+	}
+	var stdout bytes.Buffer
+
+	if _, err := pollSkillOptReviewWatches(context.Background(), config.PathsForHome(home), store, blobStore, fake, &stdout, false, home); err != nil {
+		t.Fatalf("pollSkillOptReviewWatches returned error: %v", err)
+	}
+
+	if len(fake.postedComments) != 1 || !strings.Contains(fake.postedComments[0].Body, skillOptReviewWatchSuccessMarker) {
+		t.Fatalf("posted comments = %+v", fake.postedComments)
+	}
+	if strings.Contains(fake.postedComments[0].Body, skillOptReviewWatchStaleMarker) {
+		t.Fatalf("unexpected stale notice = %q", fake.postedComments[0].Body)
+	}
+	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	if watch.Status != db.SkillOptReviewWatchStatusClosed || watch.StaleNotified {
+		t.Fatalf("watch after valid stale-aged feedback = %+v", watch)
 	}
 }
 
@@ -7863,6 +8035,19 @@ func seedSkillOptReviewWatcherRun(t *testing.T) (string, *db.Store, artifact.Sto
 		t.Fatalf("UpsertSkillOptReviewWatch returned error: %v", err)
 	}
 	return home, store, blobStore
+}
+
+func setSkillOptReviewWatchStaleAfter(t *testing.T, store *db.Store, staleAfter time.Time) {
+	t.Helper()
+	watch, err := store.GetSkillOptReviewWatch(context.Background(), "owner/previews", 67)
+	if err != nil {
+		t.Fatalf("GetSkillOptReviewWatch returned error: %v", err)
+	}
+	watch.StaleAfter = staleAfter.UTC().Format(time.RFC3339Nano)
+	watch.StaleThresholdSeconds = int64((24 * time.Hour).Seconds())
+	if err := store.UpsertSkillOptReviewWatch(context.Background(), watch); err != nil {
+		t.Fatalf("UpsertSkillOptReviewWatch returned error: %v", err)
+	}
 }
 
 func (f *skillOptFakeGitHub) CreateIssue(_ context.Context, input github.CreateIssueInput) (github.Issue, error) {


### PR DESCRIPTION
## What
Add one-time stale notices for watched SkillOpt review issues after the configured stale threshold is reached.

## Why
When a review issue waits too long for feedback, users need a clear reminder that explains what Gitmoot is waiting for and how to resume the train loop after posting feedback.

## Changes
- Post a `skillopt-review-watch-stale` marker comment when a watched review issue is stale.
- Include the review issue, run id, expected item ids, train session/phase when available, a copy-paste agent prompt, and the equivalent `gitmoot skillopt train continue --session ...` fallback.
- Mark the watch as `stale_notified` without closing the issue.
- Keep stale-notified watches eligible for later valid feedback import while deduping stale notices from both DB state and the remote GitHub marker.
- Suppress stale transition when a new invalid feedback attempt was just handled, so the user can correct YAML without losing watcher import behavior.
- Allow unrelated comments to still reach the stale reminder path.

## Results
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli -run 'TestSkillOptReviewWatcher|TestSkillOptTrainContinueRefusesConcurrentOptimizer' -count=1 -v`
- `GOTOOLCHAIN=go1.26.2 go test ./internal/cli ./internal/db ./internal/feedback`
- `git diff --check`
- `codex exec review --uncommitted`

Codex review result:

> No discrete correctness issues were found in the changed review watcher logic or added tests. The new stale-notification flow appears to preserve existing import behavior and deduplicates notices appropriately.

## Risk
Low. The change is scoped to SkillOpt review watcher polling and covered with stale, invalid-feedback, unrelated-comment, dedupe, and post-stale import tests.
