### PR TITLE
Clean stale SkillOpt artifacts on optimizer rerun

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -2546,6 +2546,14 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		}
 		result.Command = command
 		result.Args = args
+		if request.RerunOptimizer {
+			if err := cleanSkillOptTrainOptimizerRerunArtifacts(optimizerPaths); err != nil {
+				if metaErr := recordSkillOptTrainOptimizerFailure(ctx, store, session, iteration, request, optimizerPaths, command, args, subprocess.Result{}, err); metaErr != nil {
+					return result, fmt.Errorf("%w; failed to record optimizer failure: %v", err, metaErr)
+				}
+				return result, err
+			}
+		}
 		runResult, err := runSkillOptTrainOptimizer(ctx, optimizerPaths, request, command, args)
 		result.RecoveryAvailable = skillOptTrainOptimizerRecoveryAvailable(optimizerPaths)
 		if err != nil {
@@ -2610,6 +2618,71 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		return result, nil
 	}
 	return skillOptTrainOptimizerResult{}, fmt.Errorf("train iteration %s is at %s; expected %s, %s, or %s", iteration.ID, iteration.State, skillopt.TrainStateFeedbackSynced, skillopt.TrainStateTrainingPackageCreated, skillopt.TrainStateOptimizerCompleted)
+}
+
+func cleanSkillOptTrainOptimizerRerunArtifacts(paths skillOptTrainOptimizerPaths) error {
+	outRoot := strings.TrimSpace(paths.OutRoot)
+	if outRoot == "" {
+		return errors.New("optimizer out-root is required for rerun cleanup")
+	}
+	absOutRoot, err := filepath.Abs(outRoot)
+	if err != nil {
+		return fmt.Errorf("resolve optimizer out-root for rerun cleanup: %w", err)
+	}
+	if err := os.MkdirAll(absOutRoot, 0o755); err != nil {
+		return fmt.Errorf("create optimizer out-root for rerun cleanup: %w", err)
+	}
+	trainingPackagePath := strings.TrimSpace(paths.TrainingPackagePath)
+	preserveTrainingPackage := ""
+	if trainingPackagePath != "" {
+		if absTrainingPackage, err := filepath.Abs(trainingPackagePath); err == nil {
+			preserveTrainingPackage = filepath.Clean(absTrainingPackage)
+		}
+	}
+	for _, name := range []string{
+		"candidate.json",
+		"summary.json",
+		"runtime_state.json",
+		"history.json",
+		"best_skill.md",
+		"initial_skill.md",
+		"config.json",
+		"lr_history.jsonl",
+		"token_summary.json",
+		"optimizer",
+		"steps",
+		"skills",
+		"artifacts",
+		"selection_eval_baseline",
+		"test_eval_baseline",
+		"test_eval",
+	} {
+		path := filepath.Join(absOutRoot, name)
+		if preserveTrainingPackage != "" && filepath.Clean(path) == preserveTrainingPackage {
+			continue
+		}
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("remove stale optimizer artifact %s: %w", path, err)
+		}
+	}
+	for _, path := range []string{paths.CandidatePackagePath, paths.ArtifactDir} {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return fmt.Errorf("resolve optimizer artifact path for rerun cleanup: %w", err)
+		}
+		cleanPath := filepath.Clean(absPath)
+		if cleanPath == preserveTrainingPackage || strings.HasPrefix(cleanPath, filepath.Clean(absOutRoot)+string(os.PathSeparator)) {
+			continue
+		}
+		if err := os.RemoveAll(cleanPath); err != nil {
+			return fmt.Errorf("remove stale optimizer artifact %s: %w", cleanPath, err)
+		}
+	}
+	return nil
 }
 
 func skillOptTrainOptimizerLockState(request skillOptTrainOptimizerRequest) string {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -5135,6 +5135,62 @@ func TestSkillOptTrainContinueRejectsCandidateForDifferentSessionTemplate(t *tes
 		t.Fatalf("deterministic import retry reran optimizer: %+v", runner.calls)
 	}
 
+	staleOutRoot := argValue(runner.calls[0].args, "--out-root")
+	if staleOutRoot == "" {
+		t.Fatalf("first optimizer call did not include --out-root: %+v", runner.calls[0].args)
+	}
+	staleFiles := []string{
+		filepath.Join(staleOutRoot, "candidate.json"),
+		filepath.Join(staleOutRoot, "history.json"),
+		filepath.Join(staleOutRoot, "summary.json"),
+		filepath.Join(staleOutRoot, "runtime_state.json"),
+		filepath.Join(staleOutRoot, "best_skill.md"),
+		filepath.Join(staleOutRoot, "steps", "step_0001", "step_record.json"),
+		filepath.Join(staleOutRoot, "artifacts", "stale.diff.md"),
+	}
+	for _, path := range staleFiles {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create stale optimizer artifact dir returned error: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("stale optimizer artifact\n"), 0o644); err != nil {
+			t.Fatalf("write stale optimizer artifact returned error: %v", err)
+		}
+	}
+	unrelatedFile := filepath.Join(staleOutRoot, "unrelated", "keep.txt")
+	if err := os.MkdirAll(filepath.Dir(unrelatedFile), 0o755); err != nil {
+		t.Fatalf("create unrelated out-root file dir returned error: %v", err)
+	}
+	if err := os.WriteFile(unrelatedFile, []byte("do not remove\n"), 0o644); err != nil {
+		t.Fatalf("write unrelated out-root file returned error: %v", err)
+	}
+	trainingPackagePath := filepath.Join(staleOutRoot, "training.json")
+	if _, err := os.Stat(trainingPackagePath); err != nil {
+		t.Fatalf("expected persisted training package before rerun: %v", err)
+	}
+	runner.beforeRun = func(dir string, args []string) error {
+		if len(runner.calls) != 2 {
+			return nil
+		}
+		if dir != staleOutRoot || argValue(args, "--out-root") != staleOutRoot {
+			return fmt.Errorf("rerun did not reuse optimizer out-root; dir=%s args=%v", dir, args)
+		}
+		if _, err := os.Stat(trainingPackagePath); err != nil {
+			return fmt.Errorf("rerun cleanup removed training package: %w", err)
+		}
+		if _, err := os.Stat(unrelatedFile); err != nil {
+			return fmt.Errorf("rerun cleanup removed unrelated out-root file: %w", err)
+		}
+		for _, path := range staleFiles {
+			if path == trainingPackagePath {
+				continue
+			}
+			if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("stale optimizer artifact still exists before rerun: %s", path)
+			}
+		}
+		return nil
+	}
+
 	stdout.Reset()
 	stderr.Reset()
 	code = Run([]string{
@@ -8206,6 +8262,7 @@ type skillOptTrainFakeOptimizerRunner struct {
 	failAfterCandidate       bool
 	failAfterCandidateStderr string
 	lookPathValue            string
+	beforeRun                func(dir string, args []string) error
 	calls                    []skillOptTrainFakeOptimizerCall
 }
 
@@ -8218,6 +8275,12 @@ type skillOptTrainFakeOptimizerCall struct {
 func (r *skillOptTrainFakeOptimizerRunner) Run(_ context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
 	r.calls = append(r.calls, skillOptTrainFakeOptimizerCall{dir: dir, command: command, args: append([]string{}, args...)})
 	result := subprocess.Result{Command: command, Args: args}
+	if r.beforeRun != nil {
+		if err := r.beforeRun(dir, args); err != nil {
+			result.Stderr = err.Error()
+			return result, err
+		}
+	}
 	if r.fail && !r.failAfterCandidate {
 		result.Stderr = "optimizer stderr"
 		return result, errors.New("exit status 2")


### PR DESCRIPTION
## WHAT
Clean stale SkillOpt optimizer outputs before an explicit `gitmoot skillopt train continue --rerun-optimizer` run.

## WHY
A real rerun for `landing-page-preview-trial-005` reused stale `history.json`/`steps/` artifacts, so SkillOpt resumed the old rejected step instead of running the new gate-rejection retry path. The output improved from `0/0` to `0/1`, but `gate_reject_retry_attempts` was still empty because the optimizer workspace was stale.

## CHANGES
- Add rerun cleanup before invoking `gitmoot-skillopt`.
- Preserve the exported `training.json` package.
- Remove only known optimizer-generated artifacts: candidate package, summaries, runtime state, history, generated skills, steps, artifacts, and eval output dirs.
- Add a fake optimizer pre-run hook and regression coverage proving stale artifacts are removed while unrelated out-root files are preserved.

## RESULTS
- `gofmt -w internal/cli/skillopt.go internal/cli/skillopt_test.go`
- `git diff --check`
- `codex exec review --uncommitted`

Final review output:
```text
No discrete correctness issues were identified in the current staged, unstaged, or untracked changes. The added cleanup is scoped to known optimizer rerun artifacts and preserves the training package before invoking the optimizer.
```

## RISK
Go tests could not run in this environment because the module requires Go 1.26 and local Go is 1.22.2; auto-download failed with `toolchain not available`.

Blocked command:
```text
GOTOOLCHAIN=local go test ./internal/cli -run 'TestSkillOptTrainContinueRejectsCandidateForDifferentSessionTemplate'
go: go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local)
```