### PR TITLE
Publish SkillOpt candidate skill files to review repo

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1322,6 +1322,13 @@ type skillOptTrainOptimizerPaths struct {
 type skillOptTrainCandidateReviewResult struct {
 	URL                string
 	CandidateVersionID string
+	PublishedFiles     []skillOptTrainCandidateReviewFile
+}
+
+type skillOptTrainCandidateReviewFile struct {
+	Label string
+	Path  string
+	URL   string
 }
 
 type skillOptTrainCandidateDecisionResult struct {
@@ -1358,15 +1365,20 @@ func publishSkillOptTrainCandidateReview(ctx context.Context, paths config.Paths
 	if err != nil {
 		return skillOptTrainCandidateReviewResult{}, err
 	}
-	body, err := skillOptTrainCandidateReviewBody(ctx, store, session, iteration, commandHome)
-	if err != nil {
-		return skillOptTrainCandidateReviewResult{}, err
-	}
-	client := newSkillOptGitHubClient()
 	if iteration.PullRequestNumber > 0 && iteration.IssueNumber == 0 {
 		iteration.PullRequestRepo = repo.FullName()
 	} else {
 		iteration.IssueRepo = repo.FullName()
+	}
+	client := newSkillOptGitHubClient()
+	publishedFiles, filePublishErr := publishSkillOptTrainCandidateReviewFiles(ctx, paths, store, client, repo, session, iteration)
+	filePublishWarnings := []string{}
+	if filePublishErr != nil {
+		filePublishWarnings = append(filePublishWarnings, filePublishErr.Error())
+	}
+	body, err := skillOptTrainCandidateReviewBody(ctx, store, session, iteration, commandHome, publishedFiles, filePublishWarnings)
+	if err != nil {
+		return skillOptTrainCandidateReviewResult{}, err
 	}
 	title := fmt.Sprintf("SkillOpt candidate review: %s", session.ID)
 	publishingMetadata := map[string]any{
@@ -1379,6 +1391,8 @@ func publishSkillOptTrainCandidateReview(ctx context.Context, paths config.Paths
 		"pull_request_number": iteration.PullRequestNumber,
 		"pull_request_url":    iteration.PullRequestURL,
 		"issue_title":         title,
+		"published_files":     skillOptCandidateReviewFilesMetadata(publishedFiles),
+		"file_publish_errors": filePublishWarnings,
 		"started_at":          time.Now().UTC().Format(time.RFC3339Nano),
 		"source":              "gitmoot skillopt train continue",
 	}
@@ -1462,7 +1476,7 @@ func publishSkillOptTrainCandidateReview(ctx context.Context, paths config.Paths
 		return skillOptTrainCandidateReviewResult{}, err
 	}
 	_ = removeSkillOptCandidateReviewRecovery(paths, session, iteration)
-	return skillOptTrainCandidateReviewResult{URL: url, CandidateVersionID: candidateID}, nil
+	return skillOptTrainCandidateReviewResult{URL: url, CandidateVersionID: candidateID, PublishedFiles: publishedFiles}, nil
 }
 
 func recoverSkillOptCandidateReviewPublication(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, candidateID string) (skillOptTrainCandidateReviewResult, bool, error) {
@@ -1883,7 +1897,148 @@ func requestedSkillOptTrainCandidateID(request skillOptTrainContinueRequest) str
 	return strings.TrimSpace(request.RejectCandidate)
 }
 
-func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, commandHome string) (string, error) {
+func publishSkillOptTrainCandidateReviewFiles(ctx context.Context, paths config.Paths, store *db.Store, client github.Client, repo github.Repository, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) ([]skillOptTrainCandidateReviewFile, error) {
+	candidateID := strings.TrimSpace(iteration.CandidateVersionID)
+	if candidateID == "" {
+		return nil, nil
+	}
+	version, err := store.GetAgentTemplateVersionByID(ctx, candidateID)
+	if err != nil {
+		return nil, fmt.Errorf("load candidate version %s for review files: %w", candidateID, err)
+	}
+	review, err := store.GetAgentTemplateCandidateReview(ctx, candidateID)
+	if err != nil {
+		return nil, fmt.Errorf("load candidate review %s for review files: %w", candidateID, err)
+	}
+	basePath := skillOptCandidateReviewFileBasePath(session.ID, iteration.ID, candidateID)
+	if basePath == "" {
+		return nil, errors.New("candidate review file path is required")
+	}
+	files := []struct {
+		label   string
+		name    string
+		content []byte
+	}{
+		{
+			label:   "Best skill",
+			name:    "best_skill.md",
+			content: []byte(strings.TrimRight(version.Content, "\n") + "\n"),
+		},
+	}
+	if baseID := firstNonEmpty(review.BaseVersionID, iteration.BaseTemplateVersionID); baseID != "" {
+		if baseVersion, err := store.GetAgentTemplateVersionByID(ctx, baseID); err == nil {
+			files = append(files, struct {
+				label   string
+				name    string
+				content []byte
+			}{
+				label:   "Base skill",
+				name:    "base_skill.md",
+				content: []byte(strings.TrimRight(baseVersion.Content, "\n") + "\n"),
+			})
+		}
+	}
+	if diffContent, err := skillOptCandidateReviewDiffContent(ctx, paths, store, review); err == nil && len(diffContent) > 0 {
+		files = append(files, struct {
+			label   string
+			name    string
+			content []byte
+		}{
+			label:   "Candidate diff",
+			name:    "candidate.diff.md",
+			content: diffContent,
+		})
+	} else if err != nil {
+		return nil, err
+	}
+	published := make([]skillOptTrainCandidateReviewFile, 0, len(files))
+	for _, file := range files {
+		repoPath := basePath + "/" + file.name
+		result, err := client.UpsertFile(ctx, github.UpsertFileInput{
+			Repo:    repo,
+			Path:    repoPath,
+			Content: file.content,
+			Message: fmt.Sprintf("Publish SkillOpt candidate review file %s", candidateID),
+		})
+		if err != nil {
+			return published, fmt.Errorf("publish candidate review file %s: %w", repoPath, err)
+		}
+		published = append(published, skillOptTrainCandidateReviewFile{
+			Label: file.label,
+			Path:  firstNonEmpty(result.Path, repoPath),
+			URL:   result.URL,
+		})
+	}
+	return published, nil
+}
+
+func skillOptCandidateReviewDiffContent(ctx context.Context, paths config.Paths, store *db.Store, review db.AgentTemplateCandidateReview) ([]byte, error) {
+	diffID := strings.TrimSpace(review.DiffArtifactID)
+	if diffID == "" {
+		return nil, nil
+	}
+	record, err := store.GetEvalArtifact(ctx, diffID)
+	if err != nil {
+		return nil, fmt.Errorf("load candidate diff artifact %s: %w", diffID, err)
+	}
+	if strings.TrimSpace(record.Hash) == "" {
+		return nil, nil
+	}
+	content, err := artifact.NewStore(paths.ArtifactBlobs).Read(record.Hash)
+	if err != nil {
+		return nil, fmt.Errorf("read candidate diff artifact %s: %w", diffID, err)
+	}
+	return content, nil
+}
+
+func skillOptCandidateReviewFileBasePath(sessionID string, iterationID string, candidateID string) string {
+	parts := []string{
+		"skillopt",
+		"runs",
+		skillOptCandidateReviewFileToken(sessionID),
+		skillOptCandidateReviewFileToken(iterationID),
+		skillOptCandidateReviewFileToken(candidateID),
+	}
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			return ""
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+func skillOptCandidateReviewFileToken(value string) string {
+	value = strings.TrimSpace(value)
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '.', r == '-', r == '_', r == '@':
+			builder.WriteRune(r)
+		default:
+			builder.WriteByte('-')
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func skillOptCandidateReviewFilesMetadata(files []skillOptTrainCandidateReviewFile) []map[string]string {
+	if len(files) == 0 {
+		return nil
+	}
+	metadata := make([]map[string]string, 0, len(files))
+	for _, file := range files {
+		metadata = append(metadata, map[string]string{
+			"label": file.Label,
+			"path":  file.Path,
+			"url":   file.URL,
+		})
+	}
+	return metadata
+}
+
+func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, commandHome string, publishedFiles []skillOptTrainCandidateReviewFile, filePublishWarnings []string) (string, error) {
 	candidateID := strings.TrimSpace(iteration.CandidateVersionID)
 	version, err := store.GetAgentTemplateVersionByID(ctx, candidateID)
 	if err != nil {
@@ -1919,6 +2074,28 @@ func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, sess
 		builder.WriteString("\n### Artifacts\n")
 		for _, artifactID := range artifactIDs {
 			fmt.Fprintf(&builder, "- `%s`\n", artifactID)
+		}
+	}
+	if len(publishedFiles) > 0 {
+		builder.WriteString("\n### GitHub Files\n")
+		for _, file := range publishedFiles {
+			label := strings.TrimSpace(file.Label)
+			if label == "" {
+				label = "File"
+			}
+			if strings.TrimSpace(file.URL) != "" {
+				fmt.Fprintf(&builder, "- %s: [%s](%s)\n", label, file.Path, file.URL)
+			} else {
+				fmt.Fprintf(&builder, "- %s: `%s`\n", label, file.Path)
+			}
+		}
+	}
+	if len(filePublishWarnings) > 0 {
+		if len(publishedFiles) == 0 {
+			builder.WriteString("\n### GitHub Files\n")
+		}
+		for _, warning := range filePublishWarnings {
+			fmt.Fprintf(&builder, "- File publish warning: `%s`\n", truncateForMetadata(warning))
 		}
 	}
 	if strings.TrimSpace(review.EvalReportJSON) != "" {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -3249,6 +3249,13 @@ func TestSkillOptTrainContinuePublishesCandidateReviewPromotesAndStartsNext(t *t
 		"SkillOpt Candidate Review",
 		"### Artifacts",
 		"`candidate-diff`",
+		"### GitHub Files",
+		"Best skill",
+		"best_skill.md",
+		"Base skill",
+		"base_skill.md",
+		"Candidate diff",
+		"candidate.diff.md",
 		"### Scores And Gate",
 		"Selection score: `0.73`",
 		"Best selection hard: `0.77`",
@@ -3273,6 +3280,18 @@ func TestSkillOptTrainContinuePublishesCandidateReviewPromotesAndStartsNext(t *t
 	} {
 		if !strings.Contains(fakeGitHub.createdIssue.Body, want) {
 			t.Fatalf("candidate review body missing %q:\n%s", want, fakeGitHub.createdIssue.Body)
+		}
+	}
+	if len(fakeGitHub.upsertedFiles) != 3 {
+		t.Fatalf("published candidate review files = %+v, want 3", fakeGitHub.upsertedFiles)
+	}
+	for _, want := range []string{
+		"skillopt/runs/optimizer-train/optimizer-train-001/planner@v2/best_skill.md",
+		"skillopt/runs/optimizer-train/optimizer-train-001/planner@v2/base_skill.md",
+		"skillopt/runs/optimizer-train/optimizer-train-001/planner@v2/candidate.diff.md",
+	} {
+		if !skillOptFakeGitHubUpsertedPath(fakeGitHub.upsertedFiles, want) {
+			t.Fatalf("candidate review did not publish %s; files=%+v", want, fakeGitHub.upsertedFiles)
 		}
 	}
 
@@ -3674,6 +3693,55 @@ func TestSkillOptTrainContinueRequiresReasonForExternalCandidateRejection(t *tes
 	}
 }
 
+func TestSkillOptTrainContinuePublishesCandidateReviewWhenSkillFileUploadFails(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with reviewable candidate guidance."),
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+	fakeGitHub := &skillOptFakeGitHub{upsertFileErr: errors.New("contents write denied")}
+	oldClient := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return fakeGitHub }
+	defer func() {
+		newSkillOptGitHubClient = oldClient
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue optimizer exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue candidate review with file upload failure exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: candidate_review_published") {
+		t.Fatalf("candidate review stdout = %s", stdout.String())
+	}
+	if !strings.Contains(fakeGitHub.createdIssue.Body, "File publish warning") ||
+		!strings.Contains(fakeGitHub.createdIssue.Body, "contents write denied") {
+		t.Fatalf("candidate review body missing file publish warning:\n%s", fakeGitHub.createdIssue.Body)
+	}
+	if len(fakeGitHub.upsertedFiles) != 0 {
+		t.Fatalf("file upload failure recorded uploaded files: %+v", fakeGitHub.upsertedFiles)
+	}
+}
+
 func TestSkillOptTrainCandidateReviewBodyMarksNoOpNotPromotable(t *testing.T) {
 	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
 	store := openCLIJobStore(t, home)
@@ -3701,7 +3769,7 @@ func TestSkillOptTrainCandidateReviewBodyMarksNoOpNotPromotable(t *testing.T) {
 		ID:                    "optimizer-train-001",
 		CandidateVersionID:    version.ID,
 		BaseTemplateVersionID: baseVersionID,
-	}, home)
+	}, home, nil, nil)
 	if err != nil {
 		t.Fatalf("skillOptTrainCandidateReviewBody returned error: %v", err)
 	}
@@ -3747,7 +3815,7 @@ func TestSkillOptTrainCandidateReviewBodyMarksNoOpNotPromotable(t *testing.T) {
 		ID:                    "optimizer-train-001",
 		CandidateVersionID:    version.ID,
 		BaseTemplateVersionID: baseVersionID,
-	}, home)
+	}, home, nil, nil)
 	if err != nil {
 		t.Fatalf("skillOptTrainCandidateReviewBody without reason returned error: %v", err)
 	}
@@ -7973,11 +8041,13 @@ type skillOptFakeGitHub struct {
 
 	createdIssue       github.CreateIssueInput
 	postedComments     []skillOptPostedGitHubComment
+	upsertedFiles      []skillOptUpsertedGitHubFile
 	closedIssues       []skillOptClosedGitHubIssue
 	listedComments     []skillOptListedGitHubComments
 	comments           map[int64][]github.IssueComment
 	createIssueErr     error
 	postCommentErr     error
+	upsertFileErr      error
 	closeIssueErr      error
 	host               string
 	commentKinds       map[int64]string
@@ -7988,6 +8058,13 @@ type skillOptPostedGitHubComment struct {
 	Repo        github.Repository
 	IssueNumber int64
 	Body        string
+}
+
+type skillOptUpsertedGitHubFile struct {
+	Repo    github.Repository
+	Path    string
+	Content string
+	Message string
 }
 
 type skillOptClosedGitHubIssue struct {
@@ -8138,6 +8215,24 @@ func (f *skillOptFakeGitHub) PostIssueComment(_ context.Context, repo github.Rep
 	return github.IssueComment{ID: int64(len(f.postedComments)), Body: body, URL: url}, nil
 }
 
+func (f *skillOptFakeGitHub) UpsertFile(_ context.Context, input github.UpsertFileInput) (github.RepositoryFile, error) {
+	if f.upsertFileErr != nil {
+		return github.RepositoryFile{}, f.upsertFileErr
+	}
+	f.upsertedFiles = append(f.upsertedFiles, skillOptUpsertedGitHubFile{
+		Repo:    input.Repo,
+		Path:    strings.Trim(strings.TrimSpace(input.Path), "/"),
+		Content: string(input.Content),
+		Message: input.Message,
+	})
+	path := strings.Trim(strings.TrimSpace(input.Path), "/")
+	return github.RepositoryFile{
+		Path: path,
+		URL:  f.baseURL() + "/" + input.Repo.FullName() + "/blob/main/" + path,
+		SHA:  "fake-sha",
+	}, nil
+}
+
 func (f *skillOptFakeGitHub) ListIssueComments(_ context.Context, repo github.Repository, issueNumber int64) ([]github.IssueComment, error) {
 	f.listedComments = append(f.listedComments, skillOptListedGitHubComments{Repo: repo, IssueNumber: issueNumber})
 	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
@@ -8148,6 +8243,15 @@ func (f *skillOptFakeGitHub) baseURL() string {
 		return "https://github.com"
 	}
 	return strings.TrimRight(strings.TrimSpace(f.host), "/")
+}
+
+func skillOptFakeGitHubUpsertedPath(files []skillOptUpsertedGitHubFile, path string) bool {
+	for _, file := range files {
+		if file.Path == path {
+			return true
+		}
+	}
+	return false
 }
 
 func seedSkillOptTrainFeedbackSynced(t *testing.T) (string, string) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1828,6 +1828,10 @@ func (f *fakeGitHub) ListPullRequestCommits(context.Context, github.Repository, 
 	return nil, errors.New("not implemented")
 }
 
+func (f *fakeGitHub) UpsertFile(context.Context, github.UpsertFileInput) (github.RepositoryFile, error) {
+	return github.RepositoryFile{}, errors.New("not implemented")
+}
+
 type fakeWorkflowMergeGate struct {
 	decision   workflow.MergeDecision
 	onEvaluate func(workflow.MergeRequest)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -32,6 +33,7 @@ type Client interface {
 	CreateCommitStatus(ctx context.Context, input CommitStatusInput) (CommitStatus, error)
 	ListPullRequestFiles(ctx context.Context, repo Repository, number int64) ([]PullRequestFile, error)
 	ListPullRequestCommits(ctx context.Context, repo Repository, number int64) ([]PullRequestCommit, error)
+	UpsertFile(ctx context.Context, input UpsertFileInput) (RepositoryFile, error)
 }
 
 type Repository struct {
@@ -219,6 +221,20 @@ type PullRequestFile struct {
 
 type PullRequestCommit struct {
 	SHA string `json:"sha"`
+}
+
+type UpsertFileInput struct {
+	Repo    Repository
+	Path    string
+	Content []byte
+	Message string
+	Branch  string
+}
+
+type RepositoryFile struct {
+	Path string
+	URL  string
+	SHA  string
 }
 
 type GhClient struct {
@@ -489,6 +505,64 @@ func (c *GhClient) ListPullRequestCommits(ctx context.Context, repo Repository, 
 	return apiPaginatedJSON[PullRequestCommit](ctx, c, endpoint(repo, "pulls", number, "commits"))
 }
 
+func (c *GhClient) UpsertFile(ctx context.Context, input UpsertFileInput) (RepositoryFile, error) {
+	path := strings.Trim(strings.TrimSpace(input.Path), "/")
+	if input.Repo.FullName() == "" {
+		return RepositoryFile{}, errors.New("repository is required")
+	}
+	if path == "" {
+		return RepositoryFile{}, errors.New("file path is required")
+	}
+	message := strings.TrimSpace(input.Message)
+	if message == "" {
+		message = "Update " + path
+	}
+	sha := ""
+	var existing struct {
+		SHA string `json:"sha"`
+	}
+	getArgs := []string{"api", "-X", "GET", endpoint(input.Repo, "contents", path)}
+	if branch := strings.TrimSpace(input.Branch); branch != "" {
+		getArgs = append(getArgs, "-f", "ref="+branch)
+	}
+	result, err := c.run(ctx, false, getArgs...)
+	if err == nil {
+		if decodeErr := json.Unmarshal([]byte(result.Stdout), &existing); decodeErr != nil {
+			return RepositoryFile{}, fmt.Errorf("decode github contents response: %w", decodeErr)
+		}
+		sha = strings.TrimSpace(existing.SHA)
+	} else if !isNotFound(result) {
+		return RepositoryFile{}, err
+	}
+	args := []string{
+		"-X", "PUT",
+		endpoint(input.Repo, "contents", path),
+		"-f", "message=" + message,
+		"-f", "content=" + base64.StdEncoding.EncodeToString(input.Content),
+	}
+	if sha != "" {
+		args = append(args, "-f", "sha="+sha)
+	}
+	if branch := strings.TrimSpace(input.Branch); branch != "" {
+		args = append(args, "-f", "branch="+branch)
+	}
+	var response struct {
+		Content struct {
+			Path string `json:"path"`
+			URL  string `json:"html_url"`
+			SHA  string `json:"sha"`
+		} `json:"content"`
+	}
+	if err := c.apiJSON(ctx, true, &response, args...); err != nil {
+		return RepositoryFile{}, err
+	}
+	return RepositoryFile{
+		Path: firstNonEmpty(response.Content.Path, path),
+		URL:  response.Content.URL,
+		SHA:  response.Content.SHA,
+	}, nil
+}
+
 func (c *GhClient) getPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error) {
 	var pr PullRequest
 	err := c.apiJSON(ctx, false, &pr, endpoint(repo, "pulls", number))
@@ -714,4 +788,8 @@ func (NoopClient) ListPullRequestFiles(context.Context, Repository, int64) ([]Pu
 
 func (NoopClient) ListPullRequestCommits(context.Context, Repository, int64) ([]PullRequestCommit, error) {
 	return nil, errors.ErrUnsupported
+}
+
+func (NoopClient) UpsertFile(context.Context, UpsertFileInput) (RepositoryFile, error) {
+	return RepositoryFile{}, errors.ErrUnsupported
 }


### PR DESCRIPTION
## WHAT
Publish candidate skill review files into the working review repo when a SkillOpt candidate review is published.

## WHY
Humans should be able to inspect the trained skill and its diff directly from GitHub, not only from local optimizer artifacts or opaque artifact IDs.

## CHANGES
- Add a GitHub client `UpsertFile` helper using the Contents API.
- During candidate review publishing, best-effort upload:
  - `best_skill.md`
  - `base_skill.md`
  - `candidate.diff.md`
- Store files under `skillopt/runs/<session>/<iteration>/<candidate>/` in the resolved review repo.
- Link uploaded files in the candidate review issue/comment under `### GitHub Files`.
- Keep file upload best-effort: if contents writes fail, still publish the candidate review and include a file-publish warning.
- Update test fakes and candidate review tests for successful upload and upload-failure fallback.

## RESULTS
- `gofmt -w internal/github/client.go internal/cli/skillopt.go internal/cli/skillopt_test.go internal/daemon/daemon_test.go`
- `git diff --check`
- `codex exec review --uncommitted`

Final review output:
```text
No discrete correctness issues were identified in the changed code. Tests could not be run in this environment because the required Go 1.26 toolchain download attempts to write to a read-only module cache.
```

## RISK
Go tests could not run locally because this environment has Go 1.22.2 while the module requires Go 1.26. The blocked command was:

```text
GOTOOLCHAIN=local go test ./internal/cli -run 'TestSkillOptTrainContinuePublishesCandidateReview'
go: go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local)
```