### PR TITLE
test: lock candidate skill review file publishing

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -373,13 +373,21 @@ modifying the train state.
 
 ## Candidate Review And Next Iteration
 
-The candidate review step publishes the candidate summary, template diff,
-preview/PR links when available, and copyable decision commands. It separates
-selection score, evaluator/test scores, gate status, no-op status, and
-promotability so a candidate selected by the optimizer is not confused with a
-candidate that passed evaluator gates. If stored metadata marks the candidate as
-no-op or not promotable, the review body says promotion is unavailable instead
-of showing a promote command.
+The candidate review step publishes the candidate summary, preview/PR links
+when available, GitHub links to the candidate skill files, and copyable decision
+commands. The review repo file contract is:
+
+- `skillopt/runs/<session>/<iteration>/<candidate>/best_skill.md`
+- `skillopt/runs/<session>/<iteration>/<candidate>/base_skill.md`
+- `skillopt/runs/<session>/<iteration>/<candidate>/candidate.diff.md`
+
+These files let reviewers inspect the proposed skill, the baseline skill, and
+the candidate diff directly in GitHub. The review also separates selection
+score, evaluator/test scores, gate status, no-op status, and promotability so a
+candidate selected by the optimizer is not confused with a candidate that passed
+evaluator gates. If stored metadata marks the candidate as no-op or not
+promotable, the review body says promotion is unavailable instead of showing a
+promote command.
 
 Promote or reject explicitly:
 

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1371,7 +1371,11 @@ func publishSkillOptTrainCandidateReview(ctx context.Context, paths config.Paths
 		iteration.IssueRepo = repo.FullName()
 	}
 	client := newSkillOptGitHubClient()
-	publishedFiles, filePublishErr := publishSkillOptTrainCandidateReviewFiles(ctx, paths, store, client, repo, session, iteration)
+	publishedFiles := existingSkillOptCandidateReviewPublishedFiles(session, iteration, repo, candidateID)
+	var filePublishErr error
+	if len(publishedFiles) == 0 {
+		publishedFiles, filePublishErr = publishSkillOptTrainCandidateReviewFiles(ctx, paths, store, client, repo, session, iteration)
+	}
 	filePublishWarnings := []string{}
 	if filePublishErr != nil {
 		filePublishWarnings = append(filePublishWarnings, filePublishErr.Error())
@@ -2036,6 +2040,49 @@ func skillOptCandidateReviewFilesMetadata(files []skillOptTrainCandidateReviewFi
 		})
 	}
 	return metadata
+}
+
+func existingSkillOptCandidateReviewPublishedFiles(session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, repo github.Repository, candidateID string) []skillOptTrainCandidateReviewFile {
+	for _, metadataJSON := range []string{iteration.MetadataJSON, session.MetadataJSON} {
+		review := decodedSkillOptMetadataValue(decodedSkillOptMetadata(metadataJSON)["candidate_review"])
+		if metadataString(review, "candidate_version") != candidateID {
+			continue
+		}
+		if firstNonEmpty(metadataString(review, "issue_repo"), metadataString(review, "pull_request_repo")) != repo.FullName() {
+			continue
+		}
+		if len(metadataSlice(review["file_publish_errors"])) > 0 {
+			continue
+		}
+		files := skillOptCandidateReviewFilesFromMetadata(review["published_files"])
+		if len(files) > 0 {
+			return files
+		}
+	}
+	return nil
+}
+
+func skillOptCandidateReviewFilesFromMetadata(value any) []skillOptTrainCandidateReviewFile {
+	values := metadataSlice(value)
+	if len(values) == 0 {
+		return nil
+	}
+	files := make([]skillOptTrainCandidateReviewFile, 0, len(values))
+	for _, raw := range values {
+		metadata := decodedSkillOptMetadataValue(raw)
+		label := metadataString(metadata, "label")
+		path := metadataString(metadata, "path")
+		url := metadataString(metadata, "url")
+		if label == "" || path == "" {
+			continue
+		}
+		files = append(files, skillOptTrainCandidateReviewFile{
+			Label: label,
+			Path:  path,
+			URL:   url,
+		})
+	}
+	return files
 }
 
 func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, commandHome string, publishedFiles []skillOptTrainCandidateReviewFile, filePublishWarnings []string) (string, error) {
@@ -6685,6 +6732,31 @@ func decodedSkillOptMetadataValue(value any) map[string]any {
 		return object
 	}
 	return map[string]any{}
+}
+
+func metadataSlice(value any) []any {
+	switch typed := value.(type) {
+	case []any:
+		return typed
+	case []map[string]any:
+		values := make([]any, 0, len(typed))
+		for _, item := range typed {
+			values = append(values, item)
+		}
+		return values
+	case []map[string]string:
+		values := make([]any, 0, len(typed))
+		for _, item := range typed {
+			metadata := make(map[string]any, len(item))
+			for key, value := range item {
+				metadata[key] = value
+			}
+			values = append(values, metadata)
+		}
+		return values
+	default:
+		return nil
+	}
 }
 
 func metadataString(metadata map[string]any, key string) string {

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -141,10 +141,19 @@ does not publish a candidate review.
 
 ## Candidate Review And Decision
 
-Candidate reviews separate selection score, evaluator/test scores, gate status,
-no-op status, and promotability. If metadata marks the candidate as no-op or not
-promotable, the review says promotion is unavailable instead of showing a
-promote command.
+Candidate reviews publish the candidate summary, preview/PR links when
+available, GitHub links to the candidate skill files, and copyable decision
+commands. The review repo file contract is:
+
+- `skillopt/runs/<session>/<iteration>/<candidate>/best_skill.md`
+- `skillopt/runs/<session>/<iteration>/<candidate>/base_skill.md`
+- `skillopt/runs/<session>/<iteration>/<candidate>/candidate.diff.md`
+
+These files let reviewers inspect the proposed skill, the baseline skill, and
+the candidate diff directly in GitHub. Candidate reviews also separate selection
+score, evaluator/test scores, gate status, no-op status, and promotability. If
+metadata marks the candidate as no-op or not promotable, the review says
+promotion is unavailable instead of showing a promote command.
 
 Promote or reject explicitly:
 


### PR DESCRIPTION
WHAT:
- Reuse already-published SkillOpt candidate review files when retrying a failed candidate review publish.
- Scope cached file reuse to the resolved review repo so corrected repo configuration republishes files in the right place.
- Document the review-repo file contract for `best_skill.md`, `base_skill.md`, and `candidate.diff.md`.

WHY:
- Candidate skill files should be stable and inspectable in the working review repo.
- A failed external issue/comment publish should not unnecessarily upsert the same candidate files again on retry.
- Humans and future agents need the concrete review-repo paths documented.

CHANGES:
- Added metadata-based reuse for previously published candidate review files.
- Added metadata slice decoding for persisted `published_files` records.
- Updated SkillOpt train workflow docs and website docs with deterministic review-repo paths.

RESULTS:
- `/root/.local/toolchains/go1.26.4/bin/go test ./internal/cli -run 'TestSkillOptTrainContinuePublishesCandidateReview'` passed.
- `/root/.local/toolchains/go1.26.4/bin/go test ./internal/cli ./internal/skillopt` passed.
- `git diff --check` passed.
- Final `codex exec review --uncommitted` raw output:

```text
No discrete correctness issues were found in the modified code or documentation. The new reuse path for previously published candidate review files appears consistent with the existing recovery metadata flow.
```

RISK:
- Default `go` tried to download `go1.26` and failed with `toolchain not available`, so checks used the local installed `/root/.local/toolchains/go1.26.4/bin/go` toolchain.
