### PR TITLE
feat: clarify skillopt candidate decisions

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -389,14 +389,18 @@ evaluator gates. If stored metadata marks the candidate as no-op or not
 promotable, the review body says promotion is unavailable instead of showing a
 promote command.
 
-Promote or reject explicitly:
+Choose explicitly:
 
 ```sh
 gitmoot skillopt train continue --session planner-train --promote planner@v2
 gitmoot skillopt train continue --session planner-train --reject planner@v2 --reason "Too broad"
 ```
 
-After a decision, either stop or start the next iteration:
+Waiting is also a valid decision while a human is still reviewing: take no
+action and `gitmoot skillopt train status --session planner-train` keeps
+reporting the candidate decision gate. To keep improving, reject with an
+actionable reason such as "Improve product visuals and mobile polish", then
+start the next iteration after the rejection is recorded:
 
 ```sh
 gitmoot skillopt train continue --session planner-train --start-next

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1159,7 +1159,7 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 		lines := []string{
 			fmt.Sprintf("candidate_review: %s", result.URL),
 			fmt.Sprintf("candidate: %s", result.CandidateVersionID),
-			"next: promote with --promote, reject with --reject --reason, or wait for a human decision",
+			"next: choose promote, reject with a reason, or wait; keep improving by rejecting with an actionable reason and then running --start-next",
 		}
 		return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
 	case skillopt.TrainStateCandidateReviewPublished:
@@ -2157,7 +2157,8 @@ func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, sess
 		fmt.Fprintf(&builder, "- Promote: unavailable because %s.\n", reason)
 	}
 	fmt.Fprintf(&builder, "- Reject: `%s`\n", skillOptTrainCandidateDecisionCommand(usesCustomHome, session.ID, "--reject", candidateID, true))
-	fmt.Fprintf(&builder, "- Continue: `%s` after promote/reject completes.\n", skillOptTrainStartNextCommand(usesCustomHome, session.ID))
+	fmt.Fprintf(&builder, "- Wait: take no action; `%s` will keep reporting that a candidate decision is required.\n", skillOptTrainStatusCommand(usesCustomHome, session.ID))
+	fmt.Fprintf(&builder, "- Keep improving: reject with an actionable reason, then run `%s` after the rejection completes.\n", skillOptTrainStartNextCommand(usesCustomHome, session.ID))
 	return builder.String(), nil
 }
 
@@ -2399,6 +2400,15 @@ func skillOptTrainStartNextCommand(usesCustomHome bool, sessionID string) string
 		args = append(args, "--home", "<train-home>")
 	}
 	args = append(args, "--session", strings.TrimSpace(sessionID), "--start-next")
+	return shellArgs(args)
+}
+
+func skillOptTrainStatusCommand(usesCustomHome bool, sessionID string) string {
+	args := []string{"gitmoot", "skillopt", "train", "status"}
+	if usesCustomHome {
+		args = append(args, "--home", "<train-home>")
+	}
+	args = append(args, "--session", strings.TrimSpace(sessionID))
 	return shellArgs(args)
 }
 

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -3276,6 +3276,8 @@ func TestSkillOptTrainContinuePublishesCandidateReviewPromotesAndStartsNext(t *t
 		"planner@v2",
 		skillOptTrainCandidateDecisionCommand(true, "optimizer-train", "--promote", "planner@v2", false),
 		skillOptTrainCandidateDecisionCommand(true, "optimizer-train", "--reject", "planner@v2", true),
+		"Wait: take no action",
+		"Keep improving: reject with an actionable reason",
 		skillOptTrainStartNextCommand(true, "optimizer-train"),
 	} {
 		if !strings.Contains(fakeGitHub.createdIssue.Body, want) {
@@ -3782,6 +3784,8 @@ func TestSkillOptTrainCandidateReviewBodyMarksNoOpNotPromotable(t *testing.T) {
 		"No-op status: `blocked: best_origin_initial_skill`",
 		"Promotability: `not promotable: best_origin_initial_skill`",
 		"Promote: unavailable because best_origin_initial_skill.",
+		"Wait: take no action",
+		"Keep improving: reject with an actionable reason",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("candidate review body missing %q:\n%s", want, body)

--- a/internal/skillopt/train.go
+++ b/internal/skillopt/train.go
@@ -398,7 +398,7 @@ func trainBlockedStepAndAction(state string) (string, string) {
 	case TrainStateCandidateCreated:
 		return TrainStateCandidateReviewPublished, "publish candidate diff and preview review"
 	case TrainStateCandidateReviewPublished:
-		return "candidate decision", "promote, reject with a reason, or abandon the iteration"
+		return "candidate decision", "choose promote, reject with a reason, or wait for human decision; keep improving by rejecting with an actionable reason and starting the next iteration"
 	case TrainStateCandidatePromoted:
 		return "", "start the next iteration from the promoted candidate or stop"
 	case TrainStateCandidateRejected:

--- a/internal/skillopt/train_test.go
+++ b/internal/skillopt/train_test.go
@@ -90,6 +90,18 @@ func TestBuildTrainStatusSummaryReportsNextAction(t *testing.T) {
 	if summary.FeedbackCount != 4 || summary.IssueURL == "" || summary.CandidateVersion != "planner@v3" {
 		t.Fatalf("summary counts/links = %+v", summary)
 	}
+
+	iteration.State = TrainStateCandidateReviewPublished
+	summary = BuildTrainStatusSummary(
+		db.SkillOptTrainSession{ID: "landing-page", State: TrainStateCandidateReviewPublished},
+		&iteration,
+		TrainStatusCounts{},
+	)
+	if summary.BlockedStep != "candidate decision" ||
+		!strings.Contains(summary.NextAction, "wait for human decision") ||
+		!strings.Contains(summary.NextAction, "rejecting with an actionable reason") {
+		t.Fatalf("candidate decision summary = %+v", summary)
+	}
 }
 
 func TestBuildTrainStatusSummaryWithoutIteration(t *testing.T) {

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -155,11 +155,20 @@ score, evaluator/test scores, gate status, no-op status, and promotability. If
 metadata marks the candidate as no-op or not promotable, the review says
 promotion is unavailable instead of showing a promote command.
 
-Promote or reject explicitly:
+Choose explicitly:
 
 ```sh
 gitmoot skillopt train continue --session planner-train --promote planner@v2
 gitmoot skillopt train continue --session planner-train --reject planner@v2 --reason "Too broad"
+```
+
+Waiting is also a valid decision while a human is still reviewing: take no
+action and `gitmoot skillopt train status --session planner-train` keeps
+reporting the candidate decision gate. To keep improving, reject with an
+actionable reason such as "Improve product visuals and mobile polish", then
+start the next iteration after the rejection is recorded:
+
+```sh
 gitmoot skillopt train continue --session planner-train --start-next
 ```
 


### PR DESCRIPTION
WHAT:
- Clarify SkillOpt candidate review decisions in issue body, CLI next-action text, status summary, and docs.

WHY:
- Candidate review needed a clearer human/operator gate: promote, reject with reason, or wait.
- "Keep improving" should be expressed as reject with actionable feedback plus starting the next iteration, not an ambiguous extra terminal decision.

CHANGES:
- Candidate review issue body now lists:
  - Promote command when promotable.
  - Reject command with required reason placeholder.
  - Wait as a no-op status path with a runnable `gitmoot skillopt train status --session ...` command.
  - Keep improving as reject-with-reason followed by `--start-next`.
- Status/next-action text now calls out promote, reject, wait, and keep-improving semantics.
- Docs and website docs mirror the decision model.
- Tests cover candidate review body copy and candidate decision status summary.

RESULTS:
- `/root/.local/toolchains/go1.26.4/bin/go test ./internal/cli -run 'TestSkillOptTrainContinuePublishesCandidateReview|TestSkillOptTrainCandidateReviewBodyMarksNoOpNotPromotable'` passed.
- `/root/.local/toolchains/go1.26.4/bin/go test ./internal/skillopt -run 'TestBuildTrainStatusSummaryReportsNextAction'` passed.
- `/root/.local/toolchains/go1.26.4/bin/go test ./internal/cli ./internal/skillopt` passed.
- `git diff --check` passed.
- Final `codex exec review --uncommitted` raw output:

```text
No discrete correctness issues were found in the changed code or docs. Focused Go tests could not be run because the sandbox prevented the Go toolchain download lock from being created.
```

RISK:
- The local default `go` wrapper still cannot download `go1.26`, so checks used the installed `/root/.local/toolchains/go1.26.4/bin/go` toolchain.
