### PR TITLE
feat: preflight github cli for skillopt flows

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1371,6 +1371,9 @@ func publishSkillOptTrainCandidateReview(ctx context.Context, paths config.Paths
 		iteration.IssueRepo = repo.FullName()
 	}
 	client := newSkillOptGitHubClient()
+	if err := client.Preflight(ctx, repo); err != nil {
+		return skillOptTrainCandidateReviewResult{}, err
+	}
 	publishedFiles := existingSkillOptCandidateReviewPublishedFiles(session, iteration, repo, candidateID)
 	var filePublishErr error
 	if len(publishedFiles) == 0 {
@@ -3742,9 +3745,16 @@ func autoSyncSkillOptTrainReviewFeedback(ctx context.Context, paths config.Paths
 			fmt.Sprintf("github_feedback_error: invalid review repo %q: %v", repoText, err),
 		}, false
 	}
+	client := newSkillOptGitHubClient()
+	if err := client.Preflight(ctx, repo); err != nil {
+		return []string{
+			"github_feedback_sync: failed",
+			fmt.Sprintf("github_feedback_error: %v", err),
+		}, false
+	}
 	collector := feedback.GitHubCollector{
 		BlobStore: artifact.NewStore(paths.ArtifactBlobs),
-		GitHub:    newSkillOptGitHubClient(),
+		GitHub:    client,
 	}
 	result, err := collector.Sync(ctx, store, iteration.EvalRunID, repo, issueNumber)
 	if err != nil {
@@ -3787,6 +3797,10 @@ func publishSkillOptTrainReview(ctx context.Context, paths config.Paths, store *
 	if err != nil {
 		return skillOptTrainReviewPublishResult{}, err
 	}
+	client := newSkillOptGitHubClient()
+	if err := client.Preflight(ctx, repo); err != nil {
+		return skillOptTrainReviewPublishResult{}, err
+	}
 	publishingMetadata := map[string]any{
 		"status":       "publishing",
 		"repo":         repo.FullName(),
@@ -3807,7 +3821,6 @@ func publishSkillOptTrainReview(ctx context.Context, paths config.Paths, store *
 	if err != nil {
 		return skillOptTrainReviewPublishResult{}, err
 	}
-	client := newSkillOptGitHubClient()
 	postingMetadata := make(map[string]any, len(publishingMetadata)+2)
 	for key, value := range publishingMetadata {
 		postingMetadata[key] = value
@@ -7916,9 +7929,13 @@ func runSkillOptFeedbackGitHubPublish(args []string, stdout, stderr io.Writer) i
 		if err != nil {
 			return err
 		}
+		client := newSkillOptGitHubClient()
+		if err := client.Preflight(context.Background(), repo); err != nil {
+			return err
+		}
 		collector := feedback.GitHubCollector{
 			BlobStore: artifact.NewStore(paths.ArtifactBlobs),
-			GitHub:    newSkillOptGitHubClient(),
+			GitHub:    client,
 		}
 		result, err = collector.Publish(context.Background(), store, run.ID, feedback.GitHubPublishTarget{
 			Repo:        repo,
@@ -7977,9 +7994,13 @@ func runSkillOptFeedbackGitHubSync(args []string, stdout, stderr io.Writer) int 
 		if err != nil {
 			return err
 		}
+		client := newSkillOptGitHubClient()
+		if err := client.Preflight(context.Background(), repo); err != nil {
+			return err
+		}
 		collector := feedback.GitHubCollector{
 			BlobStore: artifact.NewStore(paths.ArtifactBlobs),
-			GitHub:    newSkillOptGitHubClient(),
+			GitHub:    client,
 		}
 		result, err = collector.Sync(context.Background(), store, run.ID, repo, targetNumber)
 		if err != nil {

--- a/internal/cli/skillopt_review_watcher.go
+++ b/internal/cli/skillopt_review_watcher.go
@@ -72,6 +72,9 @@ func pollSkillOptReviewWatch(ctx context.Context, paths config.Paths, store *db.
 	if err != nil {
 		return fmt.Errorf("skillopt review watch %s#%d: %w", watch.Repo, watch.IssueNumber, err)
 	}
+	if err := gh.Preflight(ctx, repo); err != nil {
+		return fmt.Errorf("skillopt review watch %s#%d: %w", watch.Repo, watch.IssueNumber, err)
+	}
 	comments, err := gh.ListIssueComments(ctx, repo, watch.IssueNumber)
 	if err != nil {
 		return fmt.Errorf("skillopt review watch %s#%d: list comments: %w", watch.Repo, watch.IssueNumber, err)

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -6335,22 +6335,48 @@ func TestSkillOptFeedbackGitHubCommandsEnforceTrainReviewRepo(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
+	fake.preflightErr = errors.New("gh auth missing")
 	code := Run([]string{"skillopt", "feedback", "github", "publish", "--home", home, "--run", "preview-train-review-001"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("github publish preflight failure exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "gh auth missing") {
+		t.Fatalf("github publish preflight failure stderr = %q", stderr.String())
+	}
+	if fake.createdIssue.Repo.FullName() != "" {
+		t.Fatalf("preflight failure created issue = %+v", fake.createdIssue)
+	}
+	if len(fake.preflightRepos) != 1 || fake.preflightRepos[0].FullName() != "owner/previews" {
+		t.Fatalf("preflight repos = %+v, want owner/previews", fake.preflightRepos)
+	}
+	fake.preflightErr = nil
+	fake.preflightRepos = nil
+	stdout.Reset()
+	stderr.Reset()
+
+	code = Run([]string{"skillopt", "feedback", "github", "publish", "--home", home, "--run", "preview-train-review-001"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("github publish default repo exit code = %d, stderr=%s", code, stderr.String())
 	}
 	if fake.createdIssue.Repo.FullName() != "owner/previews" {
 		t.Fatalf("created issue repo = %s, want owner/previews", fake.createdIssue.Repo.FullName())
 	}
+	if len(fake.preflightRepos) != 1 || fake.preflightRepos[0].FullName() != "owner/previews" {
+		t.Fatalf("preflight repos after publish = %+v, want owner/previews", fake.preflightRepos)
+	}
 
 	stdout.Reset()
 	stderr.Reset()
+	fake.preflightRepos = nil
 	code = Run([]string{"skillopt", "feedback", "github", "publish", "--home", home, "--run", "preview-train-review-001", "--repo", "Owner/Previews", "--pr", "9"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("github publish matching repo exit code = %d, stderr=%s", code, stderr.String())
 	}
 	if len(fake.postedComments) != 1 || !strings.EqualFold(fake.postedComments[0].Repo.FullName(), "owner/previews") || fake.postedComments[0].IssueNumber != 9 {
 		t.Fatalf("posted comments = %+v, want owner/previews#9", fake.postedComments)
+	}
+	if len(fake.preflightRepos) != 1 || !strings.EqualFold(fake.preflightRepos[0].FullName(), "owner/previews") {
+		t.Fatalf("preflight repos after pr publish = %+v, want owner/previews", fake.preflightRepos)
 	}
 
 	stdout.Reset()
@@ -6369,12 +6395,16 @@ func TestSkillOptFeedbackGitHubCommandsEnforceTrainReviewRepo(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
+	fake.preflightRepos = nil
 	code = Run([]string{"skillopt", "feedback", "github", "sync", "--home", home, "--run", "preview-train-review-001", "--issue", "8"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("github sync default repo exit code = %d, stderr=%s", code, stderr.String())
 	}
 	if len(fake.listedComments) != 1 || fake.listedComments[0].Repo.FullName() != "owner/previews" {
 		t.Fatalf("listed comments = %+v, want owner/previews", fake.listedComments)
+	}
+	if len(fake.preflightRepos) != 1 || fake.preflightRepos[0].FullName() != "owner/previews" {
+		t.Fatalf("preflight repos after sync = %+v, want owner/previews", fake.preflightRepos)
 	}
 
 	stdout.Reset()
@@ -8048,11 +8078,13 @@ type skillOptFakeGitHub struct {
 	upsertedFiles      []skillOptUpsertedGitHubFile
 	closedIssues       []skillOptClosedGitHubIssue
 	listedComments     []skillOptListedGitHubComments
+	preflightRepos     []github.Repository
 	comments           map[int64][]github.IssueComment
 	createIssueErr     error
 	postCommentErr     error
 	upsertFileErr      error
 	closeIssueErr      error
+	preflightErr       error
 	host               string
 	commentKinds       map[int64]string
 	commentURLOverride string
@@ -8079,6 +8111,14 @@ type skillOptClosedGitHubIssue struct {
 type skillOptListedGitHubComments struct {
 	Repo        github.Repository
 	IssueNumber int64
+}
+
+func (f *skillOptFakeGitHub) Preflight(_ context.Context, repo github.Repository) error {
+	f.preflightRepos = append(f.preflightRepos, repo)
+	if f.preflightErr != nil {
+		return f.preflightErr
+	}
+	return nil
 }
 
 func seedSkillOptReviewWatcherRun(t *testing.T) (string, *db.Store, artifact.Store) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1745,6 +1745,10 @@ func (f *fakeGitHub) Ping(context.Context) error {
 	return nil
 }
 
+func (f *fakeGitHub) Preflight(context.Context, github.Repository) error {
+	return nil
+}
+
 func (f *fakeGitHub) ListPullRequests(_ context.Context, _ github.Repository, state string) ([]github.PullRequest, error) {
 	f.listPullRequestsCalls++
 	if len(f.listPullRequestsErrs) > 0 {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -18,6 +18,7 @@ import (
 
 type Client interface {
 	Ping(ctx context.Context) error
+	Preflight(ctx context.Context, repo Repository) error
 	ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error)
 	GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
@@ -253,6 +254,21 @@ func NewClient(dir string) *GhClient {
 func (c *GhClient) Ping(ctx context.Context) error {
 	_, err := c.run(ctx, false, "repo", "view", "--json", "nameWithOwner")
 	return err
+}
+
+func (c *GhClient) Preflight(ctx context.Context, repo Repository) error {
+	if _, err := c.run(ctx, false, "--version"); err != nil {
+		return fmt.Errorf("GitHub CLI preflight failed: `gh --version` failed; install GitHub CLI (`gh`) and ensure it is on PATH: %w", err)
+	}
+	if _, err := c.run(ctx, false, "auth", "status", "--hostname", "github.com"); err != nil {
+		return fmt.Errorf("GitHub CLI preflight failed: `gh auth status --hostname github.com` failed; run `gh auth login --hostname github.com`: %w", err)
+	}
+	if strings.TrimSpace(repo.FullName()) != "" {
+		if _, err := c.run(ctx, false, "repo", "view", repo.FullName(), "--json", "nameWithOwner"); err != nil {
+			return fmt.Errorf("GitHub CLI preflight failed: cannot view expected repo %s; check repo access or run `gh auth login --hostname github.com`: %w", repo.FullName(), err)
+		}
+	}
+	return nil
 }
 
 func (c *GhClient) ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error) {
@@ -727,6 +743,10 @@ func firstNonEmpty(values ...string) string {
 type NoopClient struct{}
 
 func (NoopClient) Ping(context.Context) error {
+	return nil
+}
+
+func (NoopClient) Preflight(context.Context, Repository) error {
 	return nil
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -81,6 +81,62 @@ func TestCreateIssueUsesIssuesEndpoint(t *testing.T) {
 	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/issues", "-f", "title=Review run-1", "-f", "body=body")
 }
 
+func TestPreflightChecksGhAuthAndRepoAccess(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stdout: "gh version 2.45.0"},
+			{Stdout: "Logged in to github.com"},
+			{Stdout: `{"nameWithOwner":"jerryfane/gitmoot"}`},
+		},
+	}
+	client := GhClient{Runner: runner}
+
+	if err := client.Preflight(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}); err != nil {
+		t.Fatalf("Preflight returned error: %v", err)
+	}
+
+	runner.wantArgs(t, 0, "--version")
+	runner.wantArgs(t, 1, "auth", "status", "--hostname", "github.com")
+	runner.wantArgs(t, 2, "repo", "view", "jerryfane/gitmoot", "--json", "nameWithOwner")
+}
+
+func TestPreflightReportsAuthLoginHint(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stdout: "gh version 2.45.0"},
+			{Stderr: "not logged in"},
+		},
+		errs: []error{nil, errors.New("exit status 1")},
+	}
+	client := GhClient{Runner: runner}
+
+	err := client.Preflight(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"})
+
+	if err == nil || !strings.Contains(err.Error(), "gh auth login --hostname github.com") {
+		t.Fatalf("Preflight error = %v, want auth login hint", err)
+	}
+	runner.wantArgs(t, 1, "auth", "status", "--hostname", "github.com")
+}
+
+func TestPreflightReportsExpectedRepoAccess(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stdout: "gh version 2.45.0"},
+			{Stdout: "Logged in to github.com"},
+			{Stderr: "Could not resolve repository"},
+		},
+		errs: []error{nil, nil, errors.New("exit status 1")},
+	}
+	client := GhClient{Runner: runner}
+
+	err := client.Preflight(context.Background(), Repository{Owner: "owner", Name: "previews"})
+
+	if err == nil || !strings.Contains(err.Error(), "cannot view expected repo owner/previews") {
+		t.Fatalf("Preflight error = %v, want expected repo access error", err)
+	}
+	runner.wantArgs(t, 2, "repo", "view", "owner/previews", "--json", "nameWithOwner")
+}
+
 func TestCloseIssueUsesIssueEndpoint(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{


### PR DESCRIPTION
## Summary
- add a reusable GitHub CLI preflight on github.Client that checks gh availability, auth, and expected repo access
- run preflight before SkillOpt GitHub-backed review publish, candidate review publish, feedback sync, and review watcher polling
- add focused GitHub client and SkillOpt CLI regression tests for preflight behavior

## Verification
- /root/.local/toolchains/go1.26.4/bin/go test ./internal/github
- /root/.local/toolchains/go1.26.4/bin/go test ./internal/cli -run 'TestSkillOptFeedbackGitHubCommandsEnforceTrainReviewRepo|TestSkillOptReviewWatcherImportsValidYAML'\n- /root/.local/toolchains/go1.26.4/bin/go test ./internal/cli ./internal/github ./internal/skillopt ./internal/daemon\n- git diff --check\n- codex exec review --uncommitted