### PR TITLE
feat: retry invalid skillopt review options

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -2952,6 +2952,8 @@ const skillOptTrainGenerationLockTTL = 2 * time.Hour
 
 const skillOptTrainGenerationLockBuffer = 10 * time.Minute
 
+const skillOptTrainReviewOptionRetryBudget = 1
+
 const skillOptTrainOptimizerLockTTL = 4 * time.Hour
 
 const skillOptTrainOptimizerLockBuffer = 10 * time.Minute
@@ -3373,6 +3375,16 @@ func estimateSkillOptTrainGenerationLockTTL(ctx context.Context, store *db.Store
 	if roles <= 0 {
 		roles = 2
 	}
+	attemptsPerRole := 1
+	if strings.TrimSpace(iteration.SessionID) != "" {
+		session, err := store.GetSkillOptTrainSession(ctx, iteration.SessionID)
+		if err != nil {
+			return 0, err
+		}
+		if skillOptTrainRequiresVuePreviewBundle(session) {
+			attemptsPerRole += skillOptTrainReviewOptionRetryBudget
+		}
+	}
 	_, dispatchType, err := skillOptTrainGeneratorSelection(request)
 	if err != nil {
 		return 0, err
@@ -3386,7 +3398,7 @@ func estimateSkillOptTrainGenerationLockTTL(ctx context.Context, store *db.Store
 		concurrency = itemCount
 	}
 	batches := (itemCount + concurrency - 1) / concurrency
-	estimated := time.Duration(batches*roles)*jobTimeout + skillOptTrainGenerationLockBuffer
+	estimated := time.Duration(batches*roles*attemptsPerRole)*jobTimeout + skillOptTrainGenerationLockBuffer
 	if estimated < skillOptTrainGenerationLockTTL {
 		return skillOptTrainGenerationLockTTL, nil
 	}
@@ -3577,6 +3589,19 @@ type skillOptTrainGeneratedItemOptions struct {
 	Prompts    []map[string]any
 }
 
+type skillOptTrainGeneratedOption struct {
+	Output                localAgentJobOutput
+	Content               []byte
+	MediaType             string
+	Driver                string
+	PreviewBundleMetadata *skillopt.PreviewBundleMetadata
+	Prompt                string
+	Prompts               []map[string]any
+	JobIDs                []string
+	RetryAttempts         int
+	ValidationErrors      []map[string]any
+}
+
 func generateSkillOptTrainItemOptions(ctx context.Context, store *db.Store, blobStore artifact.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, items []db.EvalReviewItem, roles []string, rankedRun bool, request skillOptTrainContinueRequest, dispatchAgent string, dispatchType string, concurrency int) ([]skillOptTrainGeneratedItemOptions, error) {
 	if concurrency <= 0 {
 		concurrency = 1
@@ -3625,56 +3650,20 @@ func generateSkillOptTrainSingleItemOptions(ctx context.Context, store *db.Store
 	wantsVuePreviewBundle := skillOptTrainWantsVuePreviewBundle(session)
 	requiresVuePreviewBundle := skillOptTrainRequiresVuePreviewBundle(session)
 	for _, role := range roles {
-		prompt := buildSkillOptTrainGenerationPrompt(session, iteration, run, item, role, rankedRun)
-		output, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
-			RepoFlag:         skillOptTrainGenerationRepo(session),
-			Agent:            dispatchAgent,
-			Action:           "ask",
-			Instructions:     prompt,
-			Type:             dispatchType,
-			Home:             request.Home,
-			AllowManagedSync: dispatchType != "",
-		})
+		generatedOption, err := generateSkillOptTrainSingleOption(ctx, store, session, iteration, run, item, role, rankedRun, request, dispatchAgent, dispatchType, wantsVuePreviewBundle, requiresVuePreviewBundle)
 		if err != nil {
-			return skillOptTrainGeneratedItemOptions{}, fmt.Errorf("generate %s for %s: %w", role, item.ItemID, err)
-		}
-		if output.Result == nil {
-			return skillOptTrainGeneratedItemOptions{}, fmt.Errorf("generate %s for %s: job %s did not return a result", role, item.ItemID, output.JobID)
-		}
-		if output.Result.Decision != "implemented" {
-			return skillOptTrainGeneratedItemOptions{}, fmt.Errorf("generate %s for %s: job %s returned %s, want implemented: %s", role, item.ItemID, output.JobID, output.Result.Decision, output.Result.Summary)
+			return skillOptTrainGeneratedItemOptions{}, err
 		}
 		artifactRole := role
 		if rankedRun {
 			artifactRole = "option-" + role
 		}
-		artifactContent := []byte(output.Result.Summary)
-		artifactMediaType := "text/markdown"
-		artifactDriver := "text"
-		var previewBundleMetadata *skillopt.PreviewBundleMetadata
-		if wantsVuePreviewBundle {
-			bundle, err := skillopt.ParsePreviewBundle([]byte(output.Result.Summary))
-			if err != nil {
-				if requiresVuePreviewBundle {
-					return skillOptTrainGeneratedItemOptions{}, fmt.Errorf("generate %s for %s: preview bundle: %w", role, item.ItemID, err)
-				}
-			} else {
-				artifactContent, err = json.Marshal(bundle)
-				if err != nil {
-					return skillOptTrainGeneratedItemOptions{}, fmt.Errorf("generate %s for %s: encode preview bundle: %w", role, item.ItemID, err)
-				}
-				metadata := bundle.Metadata()
-				previewBundleMetadata = &metadata
-				artifactMediaType = "application/json"
-				artifactDriver = skillopt.TrainPreviewRendererVueVite
-			}
-		}
-		artifactRecord, err := prepareReviewItemContentArtifact(blobStore, run.ID, item.ItemID, artifactRole, artifactContent, artifactMediaType, artifactDriver)
+		artifactRecord, err := prepareReviewItemContentArtifact(blobStore, run.ID, item.ItemID, artifactRole, generatedOption.Content, generatedOption.MediaType, generatedOption.Driver)
 		if err != nil {
 			return skillOptTrainGeneratedItemOptions{}, err
 		}
 		artifactRecords = append(artifactRecords, artifactRecord)
-		optionMetadata := skillOptTrainGeneratedOptionMetadata(output, prompt, previewBundleMetadata)
+		optionMetadata := skillOptTrainGeneratedOptionMetadata(generatedOption.Output, generatedOption.Prompt, generatedOption.PreviewBundleMetadata, generatedOption.RetryAttempts, generatedOption.ValidationErrors)
 		if rankedRun {
 			replacementOptions = append(replacementOptions, db.EvalReviewOption{
 				RunID:        run.ID,
@@ -3689,21 +3678,16 @@ func generateSkillOptTrainSingleItemOptions(ctx context.Context, store *db.Store
 		} else if role == "candidate" {
 			item.CandidateArtifactID = artifactRecord.ID
 		}
-		generatedItem.JobIDs = append(generatedItem.JobIDs, output.JobID)
+		generatedItem.JobIDs = append(generatedItem.JobIDs, generatedOption.JobIDs...)
 		if generatedItem.AgentName == "" {
-			generatedItem.AgentName = output.Agent
+			generatedItem.AgentName = generatedOption.Output.Agent
 		}
 		if generatedItem.Runtime == "" {
-			if agent, err := store.GetAgent(ctx, output.Agent); err == nil {
+			if agent, err := store.GetAgent(ctx, generatedOption.Output.Agent); err == nil {
 				generatedItem.Runtime = agent.Runtime
 			}
 		}
-		generatedItem.Prompts = append(generatedItem.Prompts, map[string]any{
-			"item_id": item.ItemID,
-			"role":    role,
-			"job_id":  output.JobID,
-			"prompt":  prompt,
-		})
+		generatedItem.Prompts = append(generatedItem.Prompts, generatedOption.Prompts...)
 	}
 	generatedItem.Artifacts = artifactRecords
 	generatedItem.Options = replacementOptions
@@ -3711,6 +3695,87 @@ func generateSkillOptTrainSingleItemOptions(ctx context.Context, store *db.Store
 		generatedItem.ReviewItem = &item
 	}
 	return generatedItem, nil
+}
+
+func generateSkillOptTrainSingleOption(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, item db.EvalReviewItem, role string, rankedRun bool, request skillOptTrainContinueRequest, dispatchAgent string, dispatchType string, wantsVuePreviewBundle bool, requiresVuePreviewBundle bool) (skillOptTrainGeneratedOption, error) {
+	basePrompt := buildSkillOptTrainGenerationPrompt(session, iteration, run, item, role, rankedRun)
+	prompt := basePrompt
+	retryBudget := 0
+	if wantsVuePreviewBundle && requiresVuePreviewBundle {
+		retryBudget = skillOptTrainReviewOptionRetryBudget
+	}
+	validationErrors := []map[string]any{}
+	promptRecords := []map[string]any{}
+	jobIDs := []string{}
+	for attempt := 0; ; attempt++ {
+		output, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+			RepoFlag:         skillOptTrainGenerationRepo(session),
+			Agent:            dispatchAgent,
+			Action:           "ask",
+			Instructions:     prompt,
+			Type:             dispatchType,
+			Home:             request.Home,
+			AllowManagedSync: dispatchType != "",
+		})
+		if err != nil {
+			return skillOptTrainGeneratedOption{}, fmt.Errorf("generate %s for %s: %w", role, item.ItemID, err)
+		}
+		promptRecord := map[string]any{
+			"item_id": item.ItemID,
+			"role":    role,
+			"attempt": attempt,
+			"job_id":  output.JobID,
+			"prompt":  prompt,
+		}
+		promptRecords = append(promptRecords, promptRecord)
+		jobIDs = append(jobIDs, output.JobID)
+		if output.Result == nil {
+			return skillOptTrainGeneratedOption{}, fmt.Errorf("generate %s for %s: job %s did not return a result", role, item.ItemID, output.JobID)
+		}
+		if output.Result.Decision != "implemented" {
+			return skillOptTrainGeneratedOption{}, fmt.Errorf("generate %s for %s: job %s returned %s, want implemented: %s", role, item.ItemID, output.JobID, output.Result.Decision, output.Result.Summary)
+		}
+		content := []byte(output.Result.Summary)
+		mediaType := "text/markdown"
+		driver := "text"
+		var previewBundleMetadata *skillopt.PreviewBundleMetadata
+		if wantsVuePreviewBundle {
+			bundle, err := skillopt.ParsePreviewBundle([]byte(output.Result.Summary))
+			if err != nil {
+				if requiresVuePreviewBundle {
+					validationError := skillOptTrainOptionValidationError(item.ItemID, role, attempt, err)
+					validationErrors = append(validationErrors, validationError)
+					promptRecord["validation_error"] = validationError
+					if attempt < retryBudget {
+						prompt = buildSkillOptTrainGenerationRetryPrompt(basePrompt, validationError)
+						continue
+					}
+					return skillOptTrainGeneratedOption{}, fmt.Errorf("generate option validation failed: item=%s option=%s validation_class=preview_bundle retry_count=%d error=%w", item.ItemID, role, attempt, err)
+				}
+			} else {
+				content, err = json.Marshal(bundle)
+				if err != nil {
+					return skillOptTrainGeneratedOption{}, fmt.Errorf("generate %s for %s: encode preview bundle: %w", role, item.ItemID, err)
+				}
+				metadata := bundle.Metadata()
+				previewBundleMetadata = &metadata
+				mediaType = "application/json"
+				driver = skillopt.TrainPreviewRendererVueVite
+			}
+		}
+		return skillOptTrainGeneratedOption{
+			Output:                output,
+			Content:               content,
+			MediaType:             mediaType,
+			Driver:                driver,
+			PreviewBundleMetadata: previewBundleMetadata,
+			Prompt:                prompt,
+			Prompts:               promptRecords,
+			JobIDs:                jobIDs,
+			RetryAttempts:         len(validationErrors),
+			ValidationErrors:      validationErrors,
+		}, nil
+	}
 }
 
 func skillOptTrainWantsVuePreviewBundle(session db.SkillOptTrainSession) bool {
@@ -6677,6 +6742,29 @@ func buildSkillOptTrainGenerationPrompt(session db.SkillOptTrainSession, iterati
 	return builder.String()
 }
 
+func buildSkillOptTrainGenerationRetryPrompt(basePrompt string, validationError map[string]any) string {
+	var builder strings.Builder
+	builder.WriteString(basePrompt)
+	builder.WriteString("\n\nRetry instruction:\n")
+	builder.WriteString("- Retry this same review option only; do not change the item id or option label.\n")
+	builder.WriteString("- The previous generated artifact failed validation. Fix the concrete validation error below and return a fresh artifact.\n")
+	builder.WriteString("- Do not repeat the same invalid output.\n")
+	builder.WriteString("\nValidation error:\n")
+	fmt.Fprintf(&builder, "- class: %s\n", validationError["class"])
+	fmt.Fprintf(&builder, "- message: %s\n", validationError["message"])
+	return builder.String()
+}
+
+func skillOptTrainOptionValidationError(itemID string, role string, attempt int, err error) map[string]any {
+	return map[string]any{
+		"class":   "preview_bundle",
+		"item_id": itemID,
+		"role":    role,
+		"attempt": attempt,
+		"message": strings.TrimSpace(err.Error()),
+	}
+}
+
 func prepareReviewItemContentArtifact(blobStore artifact.Store, runID string, itemID string, role string, content []byte, mediaType string, driver string) (db.EvalArtifact, error) {
 	if len(content) == 0 || strings.TrimSpace(string(content)) == "" {
 		return db.EvalArtifact{}, fmt.Errorf("%s content is required", role)
@@ -6700,7 +6788,7 @@ func prepareReviewItemContentArtifact(blobStore artifact.Store, runID string, it
 	}, nil
 }
 
-func skillOptTrainGeneratedOptionMetadata(output localAgentJobOutput, prompt string, previewBundleMetadata *skillopt.PreviewBundleMetadata) string {
+func skillOptTrainGeneratedOptionMetadata(output localAgentJobOutput, prompt string, previewBundleMetadata *skillopt.PreviewBundleMetadata, retryAttempts int, validationErrors []map[string]any) string {
 	metadata := map[string]any{
 		"source":           "gitmoot skillopt train continue",
 		"job_id":           output.JobID,
@@ -6710,6 +6798,10 @@ func skillOptTrainGeneratedOptionMetadata(output localAgentJobOutput, prompt str
 	}
 	if previewBundleMetadata != nil {
 		metadata["preview_bundle"] = *previewBundleMetadata
+	}
+	if retryAttempts > 0 {
+		metadata["retry_attempts"] = retryAttempts
+		metadata["validation_errors"] = validationErrors
 	}
 	encoded, err := json.Marshal(metadata)
 	if err != nil {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1506,6 +1506,139 @@ func TestSkillOptTrainContinueGeneratesRequiredVuePreviewBundles(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainContinueRetriesInvalidRequiredVuePreviewOption(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "preview-retry-train",
+		"--workspace-repo", "owner/workspace",
+		"--preview-repo", "owner/previews",
+		"--request", "Train landing page previews.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440504"}` + "\n"},
+		cliImplementedSummaryResult(t, "# Option A\n\nMarkdown is not a preview bundle."),
+		cliImplementedSummaryResult(t, cliVuePreviewBundleSummary(t, "Option A retry hero")),
+		cliImplementedSummaryResult(t, cliVuePreviewBundleSummary(t, "Option B hero")),
+		cliImplementedSummaryResult(t, cliVuePreviewBundleSummary(t, "Option A proof")),
+		cliImplementedSummaryResult(t, cliVuePreviewBundleSummary(t, "Option B proof")),
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "preview-retry-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: options_generated") ||
+		!strings.Contains(stdout.String(), "generated_options: 4") ||
+		!strings.Contains(stdout.String(), "jobs: 5") {
+		t.Fatalf("train continue stdout = %s", stdout.String())
+	}
+	if len(runner.calls) != 6 {
+		t.Fatalf("runtime calls = %+v, want start plus five deliveries", runner.calls)
+	}
+	retryPrompt := runner.calls[2].args[len(runner.calls[2].args)-1]
+	for _, want := range []string{
+		"Retry this same review option only",
+		"previous generated artifact failed validation",
+		"decode preview bundle JSON",
+		"Option label: A",
+	} {
+		if !strings.Contains(retryPrompt, want) {
+			t.Fatalf("retry prompt missing %q:\n%s", want, retryPrompt)
+		}
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	options, err := store.ListEvalReviewOptions(context.Background(), "preview-retry-train-review-001", "")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 4 {
+		t.Fatalf("options = %+v", options)
+	}
+	retriedOptions := 0
+	for _, option := range options {
+		var metadata map[string]any
+		if err := json.Unmarshal([]byte(option.MetadataJSON), &metadata); err != nil {
+			t.Fatalf("option metadata unmarshal returned error: %v", err)
+		}
+		retryAttempts, ok := metadata["retry_attempts"].(float64)
+		if !ok {
+			continue
+		}
+		retriedOptions++
+		if int(retryAttempts) != 1 {
+			t.Fatalf("retried option metadata = %+v", metadata)
+		}
+		if _, ok := metadata["validation_errors"].([]any); !ok {
+			t.Fatalf("retried option metadata missing validation_errors: %+v", metadata)
+		}
+		if !strings.Contains(option.MetadataJSON, "decode preview bundle JSON") {
+			t.Fatalf("retried option metadata missing validation error text: %s", option.MetadataJSON)
+		}
+	}
+	if retriedOptions != 1 {
+		t.Fatalf("retried options = %d, want 1; options=%+v", retriedOptions, options)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "preview-retry-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if !strings.Contains(iteration.MetadataJSON, `"attempt":1`) || !strings.Contains(iteration.MetadataJSON, `"validation_error"`) {
+		t.Fatalf("iteration metadata missing retry attempt/error: %s", iteration.MetadataJSON)
+	}
+}
+
 func TestSkillOptTrainContinueAllowsOptionalVuePreviewFallback(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()
@@ -1711,6 +1844,8 @@ func TestSkillOptTrainContinueFailsRequiredVuePreviewForProseOutput(t *testing.T
 		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440502"}` + "\n"},
 		cliImplementedSummaryResult(t, "# Option A\n\nMarkdown is not a preview bundle."),
 		cliImplementedSummaryResult(t, "# Option A\n\nMarkdown is not a preview bundle."),
+		cliImplementedSummaryResult(t, "# Option A\n\nMarkdown is not a preview bundle."),
+		cliImplementedSummaryResult(t, "# Option A\n\nMarkdown is not a preview bundle."),
 	}}
 	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
 	defer restoreFactory()
@@ -1721,8 +1856,22 @@ func TestSkillOptTrainContinueFailsRequiredVuePreviewForProseOutput(t *testing.T
 	if code != 1 {
 		t.Fatalf("train continue exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "preview bundle") || !strings.Contains(stderr.String(), "decode preview bundle JSON") {
+	if !strings.Contains(stderr.String(), "validation_class=preview_bundle") ||
+		!strings.Contains(stderr.String(), "retry_count=1") ||
+		!strings.Contains(stderr.String(), "decode preview bundle JSON") {
 		t.Fatalf("preview bundle failure stderr = %q", stderr.String())
+	}
+	if len(runner.calls) > 5 {
+		t.Fatalf("runtime calls = %+v, want bounded per-option retries only", runner.calls)
+	}
+	retryPrompts := 0
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && strings.Contains(call.args[len(call.args)-1], "Retry this same review option only") {
+			retryPrompts++
+		}
+	}
+	if retryPrompts == 0 || retryPrompts > 2 {
+		t.Fatalf("retry prompt count = %d calls=%+v", retryPrompts, runner.calls)
 	}
 	store = openCLIJobStore(t, home)
 	defer store.Close()
@@ -1811,6 +1960,11 @@ func TestSkillOptTrainContinueRejectsNonImplementedGenerationResult(t *testing.T
 	}
 	if !strings.Contains(stderr.String(), "returned changes_requested, want implemented") {
 		t.Fatalf("stderr = %q", stderr.String())
+	}
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && strings.Contains(call.args[len(call.args)-1], "Retry this same review option only") {
+			t.Fatalf("non-retryable generation failure retried: %+v", runner.calls)
+		}
 	}
 	store = openCLIJobStore(t, home)
 	defer store.Close()
@@ -1972,6 +2126,32 @@ func TestSkillOptTrainGenerationLockTTLScalesWithWorkload(t *testing.T) {
 	}
 	if ttl <= skillOptTrainGenerationLockTTL {
 		t.Fatalf("ttl = %s, want greater than fixed minimum %s", ttl, skillOptTrainGenerationLockTTL)
+	}
+	previewPolicy, err := skillopt.BuildTrainPreviewPolicy("owner/product", "owner/previews", skillopt.TrainPreviewModeRequired, skillopt.TrainPreviewRendererVueVite, skillopt.TrainPreviewPublisherGitHubPages, "")
+	if err != nil {
+		t.Fatalf("BuildTrainPreviewPolicy returned error: %v", err)
+	}
+	if err := store.UpsertSkillOptTrainSession(context.Background(), db.SkillOptTrainSession{
+		ID:           "preview-train",
+		TemplateID:   "planner",
+		TargetRepo:   "owner/product",
+		PreviewRepo:  "owner/previews",
+		TaskKind:     "design",
+		State:        skillopt.TrainStateItemsReady,
+		MetadataJSON: skillOptTrainStartMetadata("Train landing page previews.", db.EvalRunModeExplore, db.ExplorationLevelHigh, 4, "soft", nil, nil, previewPolicy),
+	}); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSession returned error: %v", err)
+	}
+	previewTTL, err := estimateSkillOptTrainGenerationLockTTL(context.Background(), store, skillOptTrainContinueRequest{Home: home, GeneratorType: "skillopt-generator"}, db.SkillOptTrainIteration{
+		SessionID: "preview-train",
+		EvalRunID: "landing-train-review-001",
+	})
+	if err != nil {
+		t.Fatalf("estimateSkillOptTrainGenerationLockTTL preview returned error: %v", err)
+	}
+	previewWant := 32*45*time.Minute + skillOptTrainGenerationLockBuffer
+	if previewTTL != previewWant {
+		t.Fatalf("preview ttl = %s, want %s", previewTTL, previewWant)
 	}
 }
 


### PR DESCRIPTION
## WHAT
Adds a bounded per-option retry for invalid SkillOpt review option generation when required Vue preview bundles fail validation.

## WHY
A single malformed generated Vue preview should not force the whole review item generation flow to fail without giving the generator the concrete validation error.

## CHANGES
- Added `review_option_retry_budget` behavior with the current budget set to 1.
- Retries only required Vue preview-bundle validation failures, not backend dispatch errors or non-implemented generation results.
- Appends the concrete preview-bundle validation error to the retry prompt.
- Records retry attempts and validation errors in option metadata and generation prompt metadata.
- Includes retry jobs in generated job metadata and generation lock TTL estimates for required preview sessions.

## RESULTS
- /root/.local/toolchains/go1.26.4/bin/go test ./internal/cli -run 'TestSkillOptTrainGenerationLockTTLScalesWithWorkload|TestSkillOptTrainContinueRetriesInvalidRequiredVuePreviewOption|TestSkillOptTrainContinueFailsRequiredVuePreviewForProseOutput|TestSkillOptTrainContinueRejectsNonImplementedGenerationResult'\n- /root/.local/toolchains/go1.26.4/bin/go test ./internal/cli ./internal/skillopt\n- git diff --check\n- codex exec review --uncommitted final output:\n```text\nNo discrete correctness issues were found in the reviewed changes. The retry flow, metadata recording, and TTL adjustment appear consistent with the existing generation path.\n```\n\n## RISK\nNo skipped required checks. Retry scope is intentionally narrow: required Vue preview validation failures only.