### PR TITLE
feat: verify skillopt preview publishing

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -3795,6 +3795,22 @@ type skillOptTrainReviewPublishResult struct {
 	PreviewURLs int
 }
 
+type skillOptPreviewPublication struct {
+	URL          string
+	CommitSHA    string
+	PagesStatus  string
+	StatusReason string
+}
+
+type skillOptLatestPagesBuild struct {
+	Status string `json:"status"`
+	Error  struct {
+		Message string `json:"message"`
+	} `json:"error"`
+	CommitSHA string `json:"commit_sha"`
+	Commit    string `json:"commit"`
+}
+
 const skillOptReviewWatchDefaultStaleThreshold = 24 * time.Hour
 
 func autoSyncSkillOptTrainReviewFeedback(ctx context.Context, paths config.Paths, store *db.Store, iteration db.SkillOptTrainIteration) ([]string, bool) {
@@ -4178,7 +4194,7 @@ func publishSkillOptTrainPreviewURLs(ctx context.Context, paths config.Paths, st
 			_ = cleanup()
 			return publishedCount, err
 		}
-		url, err := publishGitHubPagesPreview(ctx, previewRepo, route, distDir)
+		publication, err := publishGitHubPagesPreview(ctx, previewRepo, route, distDir)
 		_ = cleanup()
 		if err != nil {
 			if policy.Mode == skillopt.TrainPreviewModeRequired {
@@ -4186,9 +4202,14 @@ func publishSkillOptTrainPreviewURLs(ctx context.Context, paths config.Paths, st
 			}
 			continue
 		}
-		metadata["preview_url"] = url
+		metadata["preview_url"] = publication.URL
 		metadata["preview_route"] = route
 		metadata["preview_repo"] = previewRepo.FullName()
+		metadata["preview_commit"] = publication.CommitSHA
+		metadata["preview_status"] = publication.PagesStatus
+		if strings.TrimSpace(publication.StatusReason) != "" {
+			metadata["preview_status_reason"] = publication.StatusReason
+		}
 		option.MetadataJSON = encodeOptionMetadata(metadata)
 		if err := store.UpsertEvalReviewOption(ctx, option); err != nil {
 			return publishedCount, err
@@ -4350,47 +4371,123 @@ func renderVueVitePreviewBundle(ctx context.Context, bundle skillopt.PreviewBund
 	return distDir, cleanup, nil
 }
 
-func publishGitHubPagesPreview(ctx context.Context, repo db.Repo, route string, distDir string) (string, error) {
+func publishGitHubPagesPreview(ctx context.Context, repo db.Repo, route string, distDir string) (skillOptPreviewPublication, error) {
 	checkout := strings.TrimSpace(repo.CheckoutPath)
 	if err := requireCleanPreviewRepo(ctx, checkout); err != nil {
-		return "", err
+		return skillOptPreviewPublication{}, err
 	}
 	head, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "rev-parse", "HEAD")
 	if err != nil {
-		return "", fmt.Errorf("read preview repo head: %w", err)
+		return skillOptPreviewPublication{}, fmt.Errorf("read preview repo head: %w", err)
 	}
 	headSHA := strings.TrimSpace(head.Stdout)
 	target, err := safeJoinPreviewPath(checkout, route)
 	if err != nil {
-		return "", err
+		return skillOptPreviewPublication{}, err
 	}
 	if err := os.RemoveAll(target); err != nil {
-		return "", err
+		return skillOptPreviewPublication{}, err
 	}
 	if err := copyDir(distDir, target); err != nil {
 		restorePreviewRoute(ctx, checkout, route, headSHA)
-		return "", err
+		return skillOptPreviewPublication{}, err
 	}
 	if _, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "add", "--", route); err != nil {
 		restorePreviewRoute(ctx, checkout, route, headSHA)
-		return "", fmt.Errorf("git add preview route: %w", err)
+		return skillOptPreviewPublication{}, fmt.Errorf("git add preview route: %w", err)
 	}
 	status, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "status", "--porcelain", "--", route)
 	if err != nil {
 		restorePreviewRoute(ctx, checkout, route, headSHA)
-		return "", fmt.Errorf("check preview route status: %w", err)
+		return skillOptPreviewPublication{}, fmt.Errorf("check preview route status: %w", err)
 	}
 	if strings.TrimSpace(status.Stdout) != "" {
 		if _, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "commit", "-m", "Publish SkillOpt preview "+strings.TrimSuffix(route, "/")); err != nil {
 			restorePreviewRoute(ctx, checkout, route, headSHA)
-			return "", fmt.Errorf("git commit preview route: %w", err)
+			return skillOptPreviewPublication{}, fmt.Errorf("git commit preview route: %w", err)
 		}
 		if _, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "push"); err != nil {
 			restorePreviewRoute(ctx, checkout, route, headSHA)
-			return "", fmt.Errorf("git push preview route: %w", err)
+			return skillOptPreviewPublication{}, fmt.Errorf("git push preview route: %w", err)
 		}
 	}
-	return githubPagesURL(repo, route), nil
+	commit, err := skillOptTrainPreviewRunner.Run(ctx, checkout, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return skillOptPreviewPublication{}, fmt.Errorf("read published preview commit: %w", err)
+	}
+	commitSHA := strings.TrimSpace(commit.Stdout)
+	pagesStatus, pagesReason := observeGitHubPagesBuildStatus(ctx, repo, commitSHA)
+	return skillOptPreviewPublication{
+		URL:          githubPagesURL(repo, route),
+		CommitSHA:    commitSHA,
+		PagesStatus:  pagesStatus,
+		StatusReason: pagesReason,
+	}, nil
+}
+
+func observeGitHubPagesBuildStatus(ctx context.Context, repo db.Repo, commitSHA string) (string, string) {
+	return observeGitHubPagesBuildStatusWithPoll(ctx, repo, commitSHA, 15*time.Second, 2*time.Second)
+}
+
+func observeGitHubPagesBuildStatusWithPoll(ctx context.Context, repo db.Repo, commitSHA string, timeout time.Duration, interval time.Duration) (string, string) {
+	fullName := repo.FullName()
+	if strings.TrimSpace(fullName) == "" {
+		return "pending", "preview repo is unknown"
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		status, reason, done := readGitHubPagesBuildStatus(ctx, repo, commitSHA)
+		if done {
+			return status, reason
+		}
+		if timeout <= 0 || !time.Now().Before(deadline) {
+			return status, reason
+		}
+		select {
+		case <-ctx.Done():
+			return "pending", "latest GitHub Pages build wait was canceled: " + ctx.Err().Error()
+		case <-time.After(interval):
+		}
+	}
+}
+
+func readGitHubPagesBuildStatus(ctx context.Context, repo db.Repo, commitSHA string) (string, string, bool) {
+	fullName := repo.FullName()
+	result, err := skillOptTrainPreviewRunner.Run(ctx, strings.TrimSpace(repo.CheckoutPath), "gh", "api", "repos/"+fullName+"/pages/builds/latest")
+	if err != nil {
+		return "pending", "latest GitHub Pages build could not be read: " + err.Error(), true
+	}
+	var build skillOptLatestPagesBuild
+	if err := json.Unmarshal([]byte(result.Stdout), &build); err != nil {
+		return "pending", "latest GitHub Pages build response could not be decoded: " + err.Error(), true
+	}
+	status := normalizeGitHubPagesBuildStatus(build.Status)
+	buildCommit := firstNonEmpty(strings.TrimSpace(build.CommitSHA), strings.TrimSpace(build.Commit))
+	if buildCommit != "" && commitSHA != "" && !strings.EqualFold(buildCommit, commitSHA) {
+		return "stale", fmt.Sprintf("latest GitHub Pages build is for commit %s, expected %s", buildCommit, commitSHA), false
+	}
+	if status == "failed" && strings.TrimSpace(build.Error.Message) != "" {
+		return status, strings.TrimSpace(build.Error.Message), true
+	}
+	if status == "pending" {
+		return status, "", false
+	}
+	return status, "", true
+}
+
+func normalizeGitHubPagesBuildStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "built":
+		return "ready"
+	case "errored":
+		return "failed"
+	case "building", "queued":
+		return "pending"
+	case "":
+		return "pending"
+	default:
+		return strings.ToLower(strings.TrimSpace(status))
+	}
 }
 
 func restorePreviewRoute(ctx context.Context, checkout string, route string, headSHA string) {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1072,6 +1072,141 @@ func TestPublishGitHubPagesPreviewRestoresCheckoutOnCommitFailure(t *testing.T) 
 	}
 }
 
+func TestPublishGitHubPagesPreviewReportsPagesStatus(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		pages      string
+		pagesError string
+		wantStatus string
+		wantReason string
+	}{
+		{name: "ready", pages: "built", wantStatus: "ready"},
+		{name: "pending", pages: "queued", wantStatus: "pending"},
+		{name: "failed", pages: "errored", pagesError: "Pages build failed", wantStatus: "failed", wantReason: "Pages build failed"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			previewDir := t.TempDir()
+			runGit(t, previewDir, "init")
+			runGit(t, previewDir, "config", "user.email", "gitmoot@example.com")
+			runGit(t, previewDir, "config", "user.name", "Gitmoot")
+			runGit(t, previewDir, "branch", "-m", "main")
+			if err := os.WriteFile(filepath.Join(previewDir, "README.md"), []byte("previews\n"), 0o644); err != nil {
+				t.Fatalf("write README: %v", err)
+			}
+			runGit(t, previewDir, "add", "README.md")
+			runGit(t, previewDir, "commit", "-m", "init")
+			distDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(distDir, "index.html"), []byte("<main>preview</main>\n"), 0o644); err != nil {
+				t.Fatalf("write dist index: %v", err)
+			}
+			previewRunner := &skillOptTrainFakePreviewRunner{pagesStatus: tt.pages, pagesError: tt.pagesError}
+			oldPreviewRunner := skillOptTrainPreviewRunner
+			skillOptTrainPreviewRunner = previewRunner
+			defer func() {
+				skillOptTrainPreviewRunner = oldPreviewRunner
+			}()
+
+			result, err := publishGitHubPagesPreview(context.Background(), db.Repo{Owner: "owner", Name: "previews", CheckoutPath: previewDir}, "runs/run-1/item/a/", distDir)
+			if err != nil {
+				t.Fatalf("publishGitHubPagesPreview returned error: %v", err)
+			}
+			if result.PagesStatus != tt.wantStatus || !strings.Contains(result.StatusReason, tt.wantReason) {
+				t.Fatalf("publication = %+v, want status=%s reason=%q", result, tt.wantStatus, tt.wantReason)
+			}
+			if result.CommitSHA == "" || result.URL != "https://owner.github.io/previews/runs/run-1/item/a/" {
+				t.Fatalf("publication missing commit/url: %+v", result)
+			}
+		})
+	}
+}
+
+func TestObserveGitHubPagesBuildStatusWaitsForPublishedCommit(t *testing.T) {
+	previewRunner := &skillOptTrainFakePreviewRunner{
+		pagesStatus:  "built",
+		pagesCommits: []string{"old-commit", "new-commit"},
+	}
+	oldPreviewRunner := skillOptTrainPreviewRunner
+	skillOptTrainPreviewRunner = previewRunner
+	defer func() {
+		skillOptTrainPreviewRunner = oldPreviewRunner
+	}()
+
+	status, reason := observeGitHubPagesBuildStatusWithPoll(
+		context.Background(),
+		db.Repo{Owner: "owner", Name: "previews", CheckoutPath: t.TempDir()},
+		"new-commit",
+		50*time.Millisecond,
+		time.Millisecond,
+	)
+	if status != "ready" || reason != "" {
+		t.Fatalf("status=%q reason=%q, want ready with no reason", status, reason)
+	}
+	ghCalls := 0
+	for _, call := range previewRunner.calls {
+		if call.command == "gh" {
+			ghCalls++
+		}
+	}
+	if ghCalls < 2 {
+		t.Fatalf("gh api calls = %d, want at least 2", ghCalls)
+	}
+}
+
+func TestObserveGitHubPagesBuildStatusPollsMatchingPendingBuild(t *testing.T) {
+	previewRunner := &skillOptTrainFakePreviewRunner{
+		pagesStatuses: []string{"queued", "building", "built"},
+		pagesCommits:  []string{"new-commit"},
+	}
+	oldPreviewRunner := skillOptTrainPreviewRunner
+	skillOptTrainPreviewRunner = previewRunner
+	defer func() {
+		skillOptTrainPreviewRunner = oldPreviewRunner
+	}()
+
+	status, reason := observeGitHubPagesBuildStatusWithPoll(
+		context.Background(),
+		db.Repo{Owner: "owner", Name: "previews", CheckoutPath: t.TempDir()},
+		"new-commit",
+		50*time.Millisecond,
+		time.Millisecond,
+	)
+	if status != "ready" || reason != "" {
+		t.Fatalf("status=%q reason=%q, want ready with no reason", status, reason)
+	}
+	ghCalls := 0
+	for _, call := range previewRunner.calls {
+		if call.command == "gh" {
+			ghCalls++
+		}
+	}
+	if ghCalls < 3 {
+		t.Fatalf("gh api calls = %d, want at least 3", ghCalls)
+	}
+}
+
+func TestObserveGitHubPagesBuildStatusMarksStaleAfterTimeout(t *testing.T) {
+	previewRunner := &skillOptTrainFakePreviewRunner{
+		pagesStatus:  "built",
+		pagesCommits: []string{"old-commit"},
+	}
+	oldPreviewRunner := skillOptTrainPreviewRunner
+	skillOptTrainPreviewRunner = previewRunner
+	defer func() {
+		skillOptTrainPreviewRunner = oldPreviewRunner
+	}()
+
+	status, reason := observeGitHubPagesBuildStatusWithPoll(
+		context.Background(),
+		db.Repo{Owner: "owner", Name: "previews", CheckoutPath: t.TempDir()},
+		"new-commit",
+		0,
+		time.Millisecond,
+	)
+	if status != "stale" || !strings.Contains(reason, "old-commit") || !strings.Contains(reason, "new-commit") {
+		t.Fatalf("status=%q reason=%q, want stale reason with commit mismatch", status, reason)
+	}
+}
+
 func runGitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	result, err := subprocess.ExecRunner{}.Run(context.Background(), dir, "git", args...)
@@ -8675,6 +8810,10 @@ func (r *skillOptTrainFakeOptimizerRunner) LookPath(file string) (string, error)
 
 type skillOptTrainFakePreviewRunner struct {
 	failGitCommit bool
+	pagesStatus   string
+	pagesError    string
+	pagesStatuses []string
+	pagesCommits  []string
 	calls         []skillOptTrainFakePreviewCall
 }
 
@@ -8713,7 +8852,50 @@ func (r *skillOptTrainFakePreviewRunner) Run(ctx context.Context, dir string, co
 		result.Stderr = "commit failed\n"
 		return result, errors.New("exit status 1")
 	}
+	if command == "gh" && len(args) == 2 && args[0] == "api" && strings.HasSuffix(args[1], "/pages/builds/latest") {
+		status := strings.TrimSpace(r.pagesStatus)
+		if len(r.pagesStatuses) > 0 {
+			status = strings.TrimSpace(r.pagesStatuses[0])
+			if len(r.pagesStatuses) > 1 {
+				r.pagesStatuses = r.pagesStatuses[1:]
+			}
+		}
+		if status == "" {
+			status = "built"
+		}
+		commitSHA := ""
+		if len(r.pagesCommits) > 0 {
+			commitSHA = strings.TrimSpace(r.pagesCommits[0])
+			if len(r.pagesCommits) > 1 {
+				r.pagesCommits = r.pagesCommits[1:]
+			}
+		}
+		if commitSHA == "" {
+			commitSHA = strings.TrimSpace(runGitOutputFromRunner(ctx, dir, "rev-parse", "HEAD"))
+		}
+		payload := map[string]any{
+			"status":     status,
+			"commit_sha": commitSHA,
+		}
+		if strings.TrimSpace(r.pagesError) != "" {
+			payload["error"] = map[string]any{"message": strings.TrimSpace(r.pagesError)}
+		}
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return result, err
+		}
+		result.Stdout = string(encoded)
+		return result, nil
+	}
 	return subprocess.ExecRunner{}.Run(ctx, dir, command, args...)
+}
+
+func runGitOutputFromRunner(ctx context.Context, dir string, args ...string) string {
+	result, err := subprocess.ExecRunner{}.Run(ctx, dir, "git", args...)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(result.Stdout)
 }
 
 func (r *skillOptTrainFakePreviewRunner) LookPath(file string) (string, error) {

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -791,7 +791,19 @@ func optionReference(option blindOptionAssignment, includeLocalPaths bool) strin
 	metadata := optionMetadata(option)
 	for _, key := range []string{"preview_url", "url"} {
 		if value := metadataString(metadata, key); value != "" {
-			return fmt.Sprintf("[open](%s)", value)
+			label := "open"
+			switch strings.ToLower(strings.TrimSpace(metadataString(metadata, "preview_status"))) {
+			case "pending":
+				label = "pending deployment"
+			case "failed":
+				label = "failed deployment"
+			case "stale":
+				label = "stale deployment"
+			}
+			if reason := metadataString(metadata, "preview_status_reason"); reason != "" && label != "open" {
+				return fmt.Sprintf("[%s](%s) (%s)", label, value, strings.ReplaceAll(reason, "\n", " "))
+			}
+			return fmt.Sprintf("[%s](%s)", label, value)
 		}
 	}
 	if path := metadataString(metadata, "path"); includeLocalPaths && path != "" {

--- a/internal/feedback/markdown_test.go
+++ b/internal/feedback/markdown_test.go
@@ -624,6 +624,26 @@ func TestMarkdownCollectorUsesCollisionSafeItemFilenames(t *testing.T) {
 	}
 }
 
+func TestOptionReferenceLabelsPreviewDeploymentStatus(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		metadata string
+		want     string
+	}{
+		{name: "ready", metadata: `{"preview_url":"https://example.com/a","preview_status":"ready"}`, want: "[open](https://example.com/a)"},
+		{name: "pending", metadata: `{"preview_url":"https://example.com/a","preview_status":"pending"}`, want: "[pending deployment](https://example.com/a)"},
+		{name: "failed", metadata: `{"preview_url":"https://example.com/a","preview_status":"failed","preview_status_reason":"Pages build failed"}`, want: "[failed deployment](https://example.com/a) (Pages build failed)"},
+		{name: "stale", metadata: `{"preview_url":"https://example.com/a","preview_status":"stale"}`, want: "[stale deployment](https://example.com/a)"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := optionReference(blindOptionAssignment{Label: "a", ArtifactID: "artifact-a", MetadataJSON: tt.metadata}, false)
+			if got != tt.want {
+				t.Fatalf("optionReference = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func setupMarkdownRankedFeedbackRun(t *testing.T, runID string) (*db.Store, artifact.Store) {
 	t.Helper()
 	ctx := context.Background()


### PR DESCRIPTION
WHAT:
- Hardened SkillOpt Vue preview publishing so review options carry GitHub Pages deployment status and published commit metadata.

WHY:
- Review packets could previously present preview links as ready immediately after pushing, even when GitHub Pages had not built them yet or was still serving an older commit.

CHANGES:
- `publishGitHubPagesPreview` now returns publication metadata: URL, pushed commit SHA, Pages status, and status reason.
- Preview option metadata now stores `preview_commit`, `preview_status`, and `preview_status_reason` alongside the preview URL/route/repo.
- GitHub Pages latest-build status is observed with bounded polling: old build commits and matching queued/building builds keep polling; failures surface reasons; timeout can mark stale/pending.
- GitHub review packet option links now distinguish ready links from `pending deployment`, `failed deployment`, and `stale deployment` links.
- Added tests for ready, pending, failed, stale, previous-commit polling, and queued/building-to-built polling.

RESULTS:
- `/root/.local/toolchains/go1.26.4/bin/go test ./internal/cli -run 'TestPublishGitHubPagesPreviewReportsPagesStatus|TestObserveGitHubPagesBuildStatusWaitsForPublishedCommit|TestObserveGitHubPagesBuildStatusPollsMatchingPendingBuild|TestObserveGitHubPagesBuildStatusMarksStaleAfterTimeout|TestSkillOptTrainContinueGeneratesRequiredVuePreviewBundles'`
- `/root/.local/toolchains/go1.26.4/bin/go test ./internal/feedback -run 'TestOptionReferenceLabelsPreviewDeploymentStatus|TestGitHubCollectorPublishesRankedIssueBody'`
- `/root/.local/toolchains/go1.26.4/bin/go test ./internal/cli ./internal/feedback ./internal/skillopt`
- `git diff --check`
- `codex exec review --uncommitted`

Final raw review output:
```text
I did not find any discrete correctness issues in the current changes. The new preview publication metadata and Markdown rendering behavior appear consistent with the surrounding code and tests.
```

RISK:
- No live preview-repo smoke publish was run in this task; the behavior is covered with focused fake-runner tests and uses `gh api repos/<owner>/<repo>/pages/builds/latest` for Pages status observation.
