### PR TITLE
docs: document skillopt review operations

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -128,18 +128,51 @@ Register the preview checkout before publishing previews:
 gitmoot repo add owner/previews --path /path/to/previews
 ```
 
+GitHub-backed review operations require the GitHub CLI to be installed and
+authenticated for the expected review repository. Check `gh` before starting
+review publication or watching:
+
+```sh
+gh auth status --hostname github.com
+gh repo view owner/previews --json nameWithOwner
+```
+
+Gitmoot preflights GitHub issue/comment operations such as feedback publish,
+feedback sync, candidate review publication, and review watching. Preview
+publication itself still commits and pushes the Pages route before the review
+issue is created, so a later `gh` auth failure can leave preview commits in the
+preview repo even though the review issue was not posted.
+
 The currently implemented renderer/publisher pairs are `none/none` and
 `vue-vite/github-pages`. Vue/Vite generation is a constrained file-bundle
 contract; Gitmoot supplies the trusted Vite scaffold, builds the bundle in a
 temporary work directory, publishes only `dist/` into the preview repo under
 `runs/{run_id}/{item_id}/{option_label}/`, pushes that route, and stores
-`preview_url` on the generated option.
+`preview_url` on the generated option. The publication result also records the
+pushed `preview_commit`, `preview_status`, and optional
+`preview_status_reason`.
 
 Required previews block inline fallback: Gitmoot will not publish the human
 review issue until every generated option has a preview URL. Optional previews
 prefer URLs but can fall back to inline Markdown if preview publishing is not
 available. LaTeX/PDF, image, notebook, Storybook, and other preview types are
 future adapters and are not implemented in this workflow.
+
+For required Vue/Vite previews, each generated option is validated before the
+review item is accepted. If an option returns invalid preview-bundle JSON or a
+bundle that fails the current contract, Gitmoot retries that option once with
+the validation error appended to the generation prompt. Other valid options are
+kept. If the retry still fails, the iteration stops with a structured error that
+names the item, option, validation class, and retry count. Non-actionable
+backend failures do not loop.
+
+For GitHub Pages publication, Gitmoot observes the latest Pages build after the
+preview route is pushed. It waits briefly for the pushed commit to appear and
+for matching `queued` or `building` builds to become `built` or `errored`.
+Review links are rendered as ready `open` links only when status is ready; they
+are labeled `pending deployment`, `failed deployment`, or `stale deployment`
+when GitHub Pages has not completed, failed, or is still reporting an older
+commit.
 
 Use previews only when the artifact has to be inspected as a rendered surface:
 
@@ -396,11 +429,15 @@ gitmoot skillopt train continue --session planner-train --promote planner@v2
 gitmoot skillopt train continue --session planner-train --reject planner@v2 --reason "Too broad"
 ```
 
-Waiting is also a valid decision while a human is still reviewing: take no
-action and `gitmoot skillopt train status --session planner-train` keeps
-reporting the candidate decision gate. To keep improving, reject with an
-actionable reason such as "Improve product visuals and mobile polish", then
-start the next iteration after the rejection is recorded:
+The supported decisions are:
+
+- promote: accept the candidate as the next base version;
+- reject with reason: keep the current base and record why the candidate is not
+  acceptable;
+- wait: take no action while a human is still reviewing, and `train status`
+  keeps reporting the candidate decision gate;
+- keep improving: reject with an actionable reason, then start the next
+  iteration after the rejection is recorded.
 
 ```sh
 gitmoot skillopt train continue --session planner-train --start-next
@@ -444,14 +481,51 @@ packet, default final test skipping after selection reject, actionable
 gate-rejection retry, retry budget exhaustion, no-op retry separation, and the
 no-candidate package fields Gitmoot imports.
 
+Manual smoke scenarios for review operations:
+
+1. Candidate decision: run a fake or dry-run train flow until candidate review
+   is published. Confirm the review repo contains `best_skill.md`,
+   `base_skill.md`, and `candidate.diff.md` under
+   `skillopt/runs/<session>/<iteration>/<candidate>/`. Run
+   `gitmoot skillopt train status --session <id>` and confirm it is waiting for
+   a candidate decision. Then run either `--promote <version>` or
+   `--reject <version> --reason "<reason>"` and confirm status moves past the
+   candidate decision gate.
+2. Preview publication status: run a Vue/Vite preview session with
+   `--preview-repo owner/previews`, publish review items, and inspect the GitHub
+   issue option links. Ready links should render as `open`; builds that have not
+   completed should render as `pending deployment`; Pages failures should render
+   as `failed deployment` with the recorded reason; stale builds should show
+   the latest and expected commit in the reason.
+
 ## Troubleshooting
 
+- Missing GitHub CLI or auth: install `gh`, run
+  `gh auth status --hostname github.com`, and confirm
+  `gh repo view owner/repo --json nameWithOwner` succeeds for the expected
+  review repo before starting review publication. GitHub issue/comment
+  operations fail preflight when auth does not pass, but preview publication can
+  already have pushed Pages files before the review issue step fails.
 - Wrong repo: all train review publish/sync commands must target
   `review.expected_repo`. Use `gitmoot skillopt train status --session <id>` to
   confirm the expected review repo before publishing.
 - Missing preview links: confirm the run has `--preview-repo`, the preview repo
   checkout is registered with `gitmoot repo add`, and the generated option
   output type is compatible with the current `vue-vite` renderer.
+- Pending or failed preview links: pending means GitHub Pages had not completed
+  for the pushed preview commit during the bounded observation window. Failed
+  links include the Pages error when GitHub reports one. Stale links mean the
+  latest Pages build still points at another commit after the wait. Existing
+  review links keep their recorded label; `train continue` skips options that
+  already have a preview URL and does not refresh old deployment status.
+- Invalid generated preview bundles: required Vue/Vite options are retried once
+  when the validation error is actionable. If the retry also fails, inspect the
+  structured error for item id, option label, validation class, retry count, and
+  the appended validation error.
+- Candidate waiting for decision: use `gitmoot skillopt train status --session
+  <id>` to find the pending version, inspect the candidate review files in the
+  review repo, then promote, reject with a reason, or keep waiting. To keep
+  improving, reject first and then run `--start-next`.
 - Missing feedback import: reply with the fenced YAML block from the review
   issue or raw YAML. Then rerun `gitmoot skillopt train continue --session
   <id>`; it will attempt GitHub sync and report parse/import failures. With

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,6 +25,52 @@ Fixes:
 - Confirm the `--repo owner/repo` value matches the checkout remote.
 - Retry after GitHub rate limits clear.
 
+## SkillOpt Review Operations
+
+Symptoms:
+
+- `gitmoot skillopt train continue` refuses to publish or sync GitHub review
+  feedback.
+- Review issue links show `pending deployment`, `failed deployment`, or
+  `stale deployment`.
+- A candidate review keeps waiting for a promote/reject decision.
+- Required Vue/Vite review items fail during generation.
+
+Checks:
+
+```sh
+gh auth status --hostname github.com
+gh repo view owner/reviews --json nameWithOwner
+gitmoot skillopt train status --session <session-id> --verbose
+gitmoot repo list
+```
+
+Fixes:
+
+- GitHub review operations use `gh`; authenticate it for the expected review
+  repo before publishing, syncing, candidate review publication, or review
+  watching. Preview publication can push Pages files before a later review issue
+  preflight fails, so run the `gh` checks before starting review publication.
+- Confirm `review.expected_repo` in train status. Preview review runs must
+  publish and sync against the preview/review repo, not the target product repo.
+- `pending deployment` means GitHub Pages had not finished for the pushed
+  preview commit during Gitmoot's bounded wait. The stored review label is not
+  refreshed automatically after it is written; inspect the link or the Pages
+  build directly.
+- `failed deployment` includes the Pages error when GitHub reports one. Fix the
+  preview repo Pages configuration or generated output. Existing review links
+  keep their recorded label; generate a new review item or clear/recreate the
+  affected preview metadata if reviewers need an updated label.
+- `stale deployment` means the latest Pages build still points at a different
+  commit after the wait. Confirm the preview repo push and Pages build manually;
+  `train continue` skips options that already have a preview URL, so it does not
+  re-observe status for the old review option.
+- Candidate review decisions are explicit: promote, reject with a reason, wait,
+  or reject and `--start-next` to keep improving.
+- Required Vue/Vite options retry once when preview-bundle validation fails with
+  an actionable error. If the retry also fails, inspect the structured error for
+  the item id, option label, validation class, and retry count.
+
 ## Codex
 
 Symptoms:

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -245,8 +245,25 @@ Run `train continue` once to generate Vue/Vite bundles and a second time to
 publish GitHub Pages previews and create the human review issue. Required
 previews block inline fallback until every option has `preview_url`; optional
 previews use URLs when present and fall back to inline Markdown only when
-preview publication is unavailable. Low-level GitHub feedback publish/sync
-commands enforce the train run's expected review repo. LaTeX/PDF, Storybook,
+preview publication is unavailable.
+
+Check `gh auth status --hostname github.com` and
+`gh repo view owner/previews --json nameWithOwner` before GitHub-backed review
+publication or watching. Gitmoot preflights GitHub issue/comment operations,
+but preview publication can push Pages files before a later review issue
+preflight fails.
+
+Required Vue/Vite options are validated immediately. An actionable preview
+bundle validation failure retries that option once while keeping valid sibling
+options. GitHub Pages publication records `preview_commit`, `preview_status`,
+and `preview_status_reason`; review links can show `open`,
+`pending deployment`, `failed deployment`, or `stale deployment`. Existing
+review links keep their recorded status label; `train continue` skips options
+that already have a preview URL.
+
+Low-level GitHub feedback publish/sync commands enforce the train run's expected
+review repo. Candidate decisions are explicit: promote, reject with a reason,
+wait, or reject and `--start-next` to keep improving. LaTeX/PDF, Storybook,
 notebook, image, and other preview types are future adapters, not current
 renderer/publisher pairs.
 

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -17,6 +17,35 @@ gh repo view owner/repo --json nameWithOwner
 gh pr list --repo owner/repo --state open
 ```
 
+## SkillOpt Review Operations
+
+```sh
+gh auth status --hostname github.com
+gh repo view owner/reviews --json nameWithOwner
+gitmoot skillopt train status --session <session-id> --verbose
+gitmoot repo list
+```
+
+GitHub review operations use `gh`; authenticate it for the expected review repo
+before publishing, syncing, candidate review publication, or review watching.
+Preview publication can push Pages files before a later review issue preflight
+fails, so run the `gh` checks before starting review publication.
+
+Confirm `review.expected_repo` in train status. Preview review runs must publish
+and sync against the preview/review repo, not the target product repo.
+
+Preview links can be labeled `pending deployment`, `failed deployment`, or
+`stale deployment`. Pending means Pages had not finished within the bounded
+wait, failed includes the Pages error when available, and stale means the latest
+build still points at another commit. Existing review links keep their recorded
+label; `train continue` skips options that already have a preview URL and does
+not refresh old deployment status.
+
+Candidate review decisions are explicit: promote, reject with a reason, wait,
+or reject and `--start-next` to keep improving. Required Vue/Vite options retry
+once for actionable preview-bundle validation errors; repeated failures stop
+with item, option, validation class, and retry count.
+
 ## Runtime Sessions
 
 Use explicit session IDs when possible. `last` is convenient for demos but can

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -86,11 +86,35 @@ Register the preview checkout before publishing:
 gitmoot repo add owner/previews --path /path/to/previews
 ```
 
+GitHub-backed review operations require `gh` to be installed and authenticated
+for the expected review repository. Check it before starting review publication
+or watching:
+
+```sh
+gh auth status --hostname github.com
+gh repo view owner/previews --json nameWithOwner
+```
+
+Gitmoot preflights GitHub issue/comment operations such as feedback publish,
+feedback sync, candidate review publication, and review watching. Preview
+publication itself still commits and pushes the Pages route before the review
+issue is created, so a later `gh` auth failure can leave preview commits in the
+preview repo even though the review issue was not posted.
+
 The currently implemented renderer/publisher pairs are `none/none` and
 `vue-vite/github-pages`. Required previews block inline fallback until every
 generated option has a `preview_url`; optional previews use URLs when available
 and fall back to inline Markdown only when preview publishing is unavailable.
-LaTeX/PDF and other preview types are future adapters.
+Required Vue/Vite options are validated as soon as they are generated. An
+actionable preview-bundle validation failure retries that option once while
+keeping valid sibling options.
+
+GitHub Pages publication records `preview_commit`, `preview_status`, and
+`preview_status_reason` with each option. Gitmoot waits briefly for the pushed
+commit and for matching queued/building builds to become ready or failed.
+Review links render as `open`, `pending deployment`, `failed deployment`, or
+`stale deployment` based on that status. LaTeX/PDF and other preview types are
+future adapters.
 
 ## Review, Feedback, And Optimizer Gate
 
@@ -162,11 +186,10 @@ gitmoot skillopt train continue --session planner-train --promote planner@v2
 gitmoot skillopt train continue --session planner-train --reject planner@v2 --reason "Too broad"
 ```
 
-Waiting is also a valid decision while a human is still reviewing: take no
-action and `gitmoot skillopt train status --session planner-train` keeps
-reporting the candidate decision gate. To keep improving, reject with an
-actionable reason such as "Improve product visuals and mobile polish", then
-start the next iteration after the rejection is recorded:
+The supported decisions are promote, reject with reason, wait, and keep
+improving. Waiting means taking no action while status keeps reporting the
+candidate decision gate. Keep improving means rejecting with an actionable
+reason, then starting the next iteration after the rejection is recorded:
 
 ```sh
 gitmoot skillopt train continue --session planner-train --start-next
@@ -187,8 +210,32 @@ preview publication, fake `gitmoot-skillopt`, and fake GitHub publication. It
 covers preview blocking, review-repo enforcement, the train loop, and candidate
 decisions without real model calls or real GitHub mutation.
 
+Manual smoke scenarios:
+
+1. Candidate decision: publish a candidate review, confirm the review repo has
+   `best_skill.md`, `base_skill.md`, and `candidate.diff.md`, then use status to
+   confirm the decision gate before promoting or rejecting with a reason.
+2. Preview publication status: publish Vue/Vite review options and confirm the
+   issue links are labeled `open`, `pending deployment`, `failed deployment`,
+   or `stale deployment` according to the GitHub Pages build state.
+
 ## Troubleshooting
 
+- Missing `gh` auth: run `gh auth status --hostname github.com` and confirm
+  `gh repo view owner/repo --json nameWithOwner` succeeds for the expected
+  review repo before starting review publication. Preview publication can
+  already have pushed Pages files before a later review issue preflight fails.
+- Pending or failed preview links: pending means Pages had not completed within
+  the bounded wait, failed includes the Pages error when available, and stale
+  means the latest build still points at another commit. Existing review links
+  keep their recorded label; `train continue` does not refresh old deployment
+  status for options that already have a preview URL.
+- Invalid generated preview bundles: required Vue/Vite options retry once for
+  actionable validation errors; repeated failures stop with item, option,
+  validation class, and retry count.
+- Candidate waiting for decision: inspect the candidate files in the review repo
+  and then promote, reject with a reason, keep waiting, or reject and
+  `--start-next` to keep improving.
 - Missing feedback import: reply with the fenced YAML block or raw YAML, then
   rerun `gitmoot skillopt train continue --session <id>` to auto-sync comments.
 - Invalid YAML: sync output reports wrong `run_id`, missing item feedback,

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1519,6 +1519,52 @@ Fixes:
 - Confirm the `--repo owner/repo` value matches the checkout remote.
 - Retry after GitHub rate limits clear.
 
+## SkillOpt Review Operations
+
+Symptoms:
+
+- `gitmoot skillopt train continue` refuses to publish or sync GitHub review
+  feedback.
+- Review issue links show `pending deployment`, `failed deployment`, or
+  `stale deployment`.
+- A candidate review keeps waiting for a promote/reject decision.
+- Required Vue/Vite review items fail during generation.
+
+Checks:
+
+```sh
+gh auth status --hostname github.com
+gh repo view owner/reviews --json nameWithOwner
+gitmoot skillopt train status --session <session-id> --verbose
+gitmoot repo list
+```
+
+Fixes:
+
+- GitHub review operations use `gh`; authenticate it for the expected review
+  repo before publishing, syncing, candidate review publication, or review
+  watching. Preview publication can push Pages files before a later review issue
+  preflight fails, so run the `gh` checks before starting review publication.
+- Confirm `review.expected_repo` in train status. Preview review runs must
+  publish and sync against the preview/review repo, not the target product repo.
+- `pending deployment` means GitHub Pages had not finished for the pushed
+  preview commit during Gitmoot's bounded wait. The stored review label is not
+  refreshed automatically after it is written; inspect the link or the Pages
+  build directly.
+- `failed deployment` includes the Pages error when GitHub reports one. Fix the
+  preview repo Pages configuration or generated output. Existing review links
+  keep their recorded label; generate a new review item or clear/recreate the
+  affected preview metadata if reviewers need an updated label.
+- `stale deployment` means the latest Pages build still points at a different
+  commit after the wait. Confirm the preview repo push and Pages build manually;
+  `train continue` skips options that already have a preview URL, so it does not
+  re-observe status for the old review option.
+- Candidate review decisions are explicit: promote, reject with a reason, wait,
+  or reject and `--start-next` to keep improving.
+- Required Vue/Vite options retry once when preview-bundle validation fails with
+  an actionable error. If the retry also fails, inspect the structured error for
+  the item id, option label, validation class, and retry count.
+
 ## Codex
 
 Symptoms:
@@ -3409,8 +3455,25 @@ Run `train continue` once to generate Vue/Vite bundles and a second time to
 publish GitHub Pages previews and create the human review issue. Required
 previews block inline fallback until every option has `preview_url`; optional
 previews use URLs when present and fall back to inline Markdown only when
-preview publication is unavailable. Low-level GitHub feedback publish/sync
-commands enforce the train run's expected review repo. LaTeX/PDF, Storybook,
+preview publication is unavailable.
+
+Check `gh auth status --hostname github.com` and
+`gh repo view owner/previews --json nameWithOwner` before GitHub-backed review
+publication or watching. Gitmoot preflights GitHub issue/comment operations,
+but preview publication can push Pages files before a later review issue
+preflight fails.
+
+Required Vue/Vite options are validated immediately. An actionable preview
+bundle validation failure retries that option once while keeping valid sibling
+options. GitHub Pages publication records `preview_commit`, `preview_status`,
+and `preview_status_reason`; review links can show `open`,
+`pending deployment`, `failed deployment`, or `stale deployment`. Existing
+review links keep their recorded status label; `train continue` skips options
+that already have a preview URL.
+
+Low-level GitHub feedback publish/sync commands enforce the train run's expected
+review repo. Candidate decisions are explicit: promote, reject with a reason,
+wait, or reject and `--start-next` to keep improving. LaTeX/PDF, Storybook,
 notebook, image, and other preview types are future adapters, not current
 renderer/publisher pairs.
 


### PR DESCRIPTION
WHAT:
- Documented the hardened SkillOpt review-operations workflow across canonical docs, website docs, troubleshooting, and the Gitmoot skill workflow reference.

WHY:
- Users and future agents need accurate guidance for candidate skill review files, explicit candidate decisions, GitHub CLI preflight requirements, preview option validation retries, and preview deployment status labels.

CHANGES:
- Updated `docs/skillopt-train-workflow.md` with GitHub CLI checks, preview publication status behavior, validation retry behavior, explicit promote/reject/wait/keep-improving decisions, and manual smoke scenarios.
- Added SkillOpt review-operations troubleshooting to `docs/troubleshooting.md` and `website/docs/operations/troubleshooting.md`.
- Mirrored the workflow guidance into `website/docs/workflows/skillopt-train-workflow.md`.
- Updated `skills/gitmoot/references/WORKFLOWS.md` so future-agent context matches the new behavior.
- Regenerated `website/static/llms-full.txt` with `npm run build:llms` through the full docs build.

RESULTS:
- `git diff --check`
- `cd website && npm run build`
- `codex exec review --uncommitted`

Final raw review output:
```text
The changes are documentation and planning artifacts, and I did not find any discrete correctness issue introduced by them.
```

RISK:
- No runtime code changed in this task.
- The docs explicitly note that existing preview links keep their recorded deployment label; `train continue` does not refresh old preview status for options that already have a preview URL.
