### PR TITLE
gitmoot: isolate skillopt optimizer rerun attempts

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1276,6 +1276,9 @@ type skillOptTrainOptimizerResult struct {
 	OutRoot               string
 	CandidatePackagePath  string
 	ArtifactDir           string
+	OptimizerRoot         string
+	OptimizerAttempt      string
+	OptimizerAttemptPath  string
 	Command               string
 	Args                  []string
 	DryRun                bool
@@ -1297,6 +1300,9 @@ type skillOptTrainRecoverResult struct {
 	NextAction           string   `json:"next_action,omitempty"`
 	RecoveryAvailable    bool     `json:"recovery_available"`
 	OutRoot              string   `json:"out_root,omitempty"`
+	OptimizerRoot        string   `json:"optimizer_root,omitempty"`
+	OptimizerAttempt     string   `json:"optimizer_attempt,omitempty"`
+	OptimizerAttemptPath string   `json:"optimizer_attempt_path,omitempty"`
 	CandidatePackagePath string   `json:"candidate_package,omitempty"`
 	ArtifactDir          string   `json:"artifact_dir,omitempty"`
 	Artifacts            []string `json:"artifacts,omitempty"`
@@ -1313,6 +1319,9 @@ type skillOptTrainBackendResolution struct {
 
 type skillOptTrainOptimizerPaths struct {
 	OutRoot              string
+	OptimizerRoot        string
+	OptimizerAttempt     string
+	OptimizerAttemptPath string
 	ArtifactRoot         string
 	TrainingPackagePath  string
 	CandidatePackagePath string
@@ -2736,18 +2745,17 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		OutRoot:              optimizerPaths.OutRoot,
 		CandidatePackagePath: optimizerPaths.CandidatePackagePath,
 		ArtifactDir:          optimizerPaths.ArtifactDir,
+		OptimizerRoot:        optimizerPaths.OptimizerRoot,
+		OptimizerAttempt:     optimizerPaths.OptimizerAttempt,
+		OptimizerAttemptPath: optimizerPaths.OptimizerAttemptPath,
 		DryRun:               request.DryRun,
 		BackendResolution:    backendResolution,
 		RecoveryAvailable:    skillOptTrainOptimizerRecoveryAvailable(optimizerPaths),
 		OptimizerLockState:   skillOptTrainOptimizerLockState(request),
 	}
 	state := skillopt.NormalizeTrainState(iteration.State)
-	if state == skillopt.TrainStateOptimizerCompleted && request.RerunOptimizer {
-		state = skillopt.TrainStateTrainingPackageCreated
-	}
-	if state == skillopt.TrainStateOptimizerCompletedNoCandidate && request.RerunOptimizer {
-		session.State = skillopt.TrainStateTrainingPackageCreated
-		iteration.State = skillopt.TrainStateTrainingPackageCreated
+	rerunFromCompletedOptimizer := request.RerunOptimizer && (state == skillopt.TrainStateOptimizerCompleted || state == skillopt.TrainStateOptimizerCompletedNoCandidate)
+	if rerunFromCompletedOptimizer {
 		state = skillopt.TrainStateTrainingPackageCreated
 	}
 	if state == skillopt.TrainStateFeedbackSynced {
@@ -2771,26 +2779,30 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		state = skillopt.TrainStateTrainingPackageCreated
 	}
 	if state == skillopt.TrainStateTrainingPackageCreated {
-		if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateOptimizerCompleted); err != nil {
-			return skillOptTrainOptimizerResult{}, err
+		if !rerunFromCompletedOptimizer {
+			if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateOptimizerCompleted); err != nil {
+				return skillOptTrainOptimizerResult{}, err
+			}
 		}
 		command, args, err := buildSkillOptTrainOptimizerCommand(iteration, request, optimizerPaths)
 		if err != nil {
+			if rerunFromCompletedOptimizer {
+				return result, err
+			}
 			if metaErr := recordSkillOptTrainOptimizerFailure(ctx, store, session, iteration, request, optimizerPaths, command, args, subprocess.Result{}, err); metaErr != nil {
 				return result, fmt.Errorf("%w; failed to record optimizer failure: %v", err, metaErr)
 			}
 			return result, err
 		}
+		if rerunFromCompletedOptimizer {
+			session.State = skillopt.TrainStateTrainingPackageCreated
+			iteration.State = skillopt.TrainStateTrainingPackageCreated
+		}
+		if err := recordSkillOptTrainOptimizerStarted(ctx, store, &session, &iteration, request, optimizerPaths, command, args); err != nil {
+			return result, err
+		}
 		result.Command = command
 		result.Args = args
-		if request.RerunOptimizer {
-			if err := cleanSkillOptTrainOptimizerRerunArtifacts(optimizerPaths); err != nil {
-				if metaErr := recordSkillOptTrainOptimizerFailure(ctx, store, session, iteration, request, optimizerPaths, command, args, subprocess.Result{}, err); metaErr != nil {
-					return result, fmt.Errorf("%w; failed to record optimizer failure: %v", err, metaErr)
-				}
-				return result, err
-			}
-		}
 		runResult, err := runSkillOptTrainOptimizer(ctx, optimizerPaths, request, command, args)
 		result.RecoveryAvailable = skillOptTrainOptimizerRecoveryAvailable(optimizerPaths)
 		if err != nil {
@@ -2834,12 +2846,15 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		}
 		result.CandidateVersionID = version.ID
 		metadata := map[string]any{
-			"status":            "succeeded",
-			"candidate_version": version.ID,
-			"candidate_package": optimizerPaths.CandidatePackagePath,
-			"artifact_dir":      optimizerPaths.ArtifactDir,
-			"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
-			"source":            "gitmoot skillopt train continue",
+			"status":                 "succeeded",
+			"candidate_version":      version.ID,
+			"candidate_package":      optimizerPaths.CandidatePackagePath,
+			"artifact_dir":           optimizerPaths.ArtifactDir,
+			"optimizer_root":         optimizerPaths.OptimizerRoot,
+			"optimizer_attempt":      optimizerPaths.OptimizerAttempt,
+			"optimizer_attempt_path": optimizerPaths.OptimizerAttemptPath,
+			"completed_at":           time.Now().UTC().Format(time.RFC3339Nano),
+			"source":                 "gitmoot skillopt train continue",
 		}
 		session.State = skillopt.TrainStateCandidateCreated
 		iteration.State = skillopt.TrainStateCandidateCreated
@@ -2855,71 +2870,6 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		return result, nil
 	}
 	return skillOptTrainOptimizerResult{}, fmt.Errorf("train iteration %s is at %s; expected %s, %s, or %s", iteration.ID, iteration.State, skillopt.TrainStateFeedbackSynced, skillopt.TrainStateTrainingPackageCreated, skillopt.TrainStateOptimizerCompleted)
-}
-
-func cleanSkillOptTrainOptimizerRerunArtifacts(paths skillOptTrainOptimizerPaths) error {
-	outRoot := strings.TrimSpace(paths.OutRoot)
-	if outRoot == "" {
-		return errors.New("optimizer out-root is required for rerun cleanup")
-	}
-	absOutRoot, err := filepath.Abs(outRoot)
-	if err != nil {
-		return fmt.Errorf("resolve optimizer out-root for rerun cleanup: %w", err)
-	}
-	if err := os.MkdirAll(absOutRoot, 0o755); err != nil {
-		return fmt.Errorf("create optimizer out-root for rerun cleanup: %w", err)
-	}
-	trainingPackagePath := strings.TrimSpace(paths.TrainingPackagePath)
-	preserveTrainingPackage := ""
-	if trainingPackagePath != "" {
-		if absTrainingPackage, err := filepath.Abs(trainingPackagePath); err == nil {
-			preserveTrainingPackage = filepath.Clean(absTrainingPackage)
-		}
-	}
-	for _, name := range []string{
-		"candidate.json",
-		"summary.json",
-		"runtime_state.json",
-		"history.json",
-		"best_skill.md",
-		"initial_skill.md",
-		"config.json",
-		"lr_history.jsonl",
-		"token_summary.json",
-		"optimizer",
-		"steps",
-		"skills",
-		"artifacts",
-		"selection_eval_baseline",
-		"test_eval_baseline",
-		"test_eval",
-	} {
-		path := filepath.Join(absOutRoot, name)
-		if preserveTrainingPackage != "" && filepath.Clean(path) == preserveTrainingPackage {
-			continue
-		}
-		if err := os.RemoveAll(path); err != nil {
-			return fmt.Errorf("remove stale optimizer artifact %s: %w", path, err)
-		}
-	}
-	for _, path := range []string{paths.CandidatePackagePath, paths.ArtifactDir} {
-		path = strings.TrimSpace(path)
-		if path == "" {
-			continue
-		}
-		absPath, err := filepath.Abs(path)
-		if err != nil {
-			return fmt.Errorf("resolve optimizer artifact path for rerun cleanup: %w", err)
-		}
-		cleanPath := filepath.Clean(absPath)
-		if cleanPath == preserveTrainingPackage || strings.HasPrefix(cleanPath, filepath.Clean(absOutRoot)+string(os.PathSeparator)) {
-			continue
-		}
-		if err := os.RemoveAll(cleanPath); err != nil {
-			return fmt.Errorf("remove stale optimizer artifact %s: %w", cleanPath, err)
-		}
-	}
-	return nil
 }
 
 func skillOptTrainOptimizerLockState(request skillOptTrainOptimizerRequest) string {
@@ -4969,6 +4919,10 @@ func buildSkillOptTrainStatusVerbose(ctx context.Context, store *db.Store, sessi
 		NoCandidateDetails: decodedSkillOptMetadataValue(candidateImport["no_candidate_details"]),
 	}
 	if optimizer := decodedSkillOptMetadataValue(iterationMetadata["optimizer"]); len(optimizer) > 0 {
+		candidateImport := decodedSkillOptMetadataValue(iterationMetadata["candidate_import"])
+		if attemptState := skillOptTrainOptimizerAttemptState(skillopt.NormalizeTrainState(iteration.State), optimizer, candidateImport); attemptState != "" {
+			optimizer["optimizer_attempt_state"] = attemptState
+		}
 		optimizerPaths, err := resolveSkillOptTrainOptimizerPaths(config.Paths{}, session, *iteration, skillOptTrainOptimizerRequest{})
 		if err == nil {
 			optimizer["recovery_available"] = skillOptTrainOptimizerRecoveryAvailable(optimizerPaths)
@@ -5278,6 +5232,15 @@ func printSkillOptTrainStatusSnapshot(stdout io.Writer, snapshot skillOptTrainSt
 		printSkillOptNoCandidateDetails(stdout, snapshot.Verbose.Candidate.NoCandidateDetails)
 	}
 	if snapshot.Verbose.Optimizer != nil {
+		if attempt := metadataString(snapshot.Verbose.Optimizer, "optimizer_attempt"); attempt != "" {
+			writeLine(stdout, "optimizer_attempt: %s", attempt)
+		}
+		if status := metadataString(snapshot.Verbose.Optimizer, "optimizer_attempt_state"); status != "" {
+			writeLine(stdout, "optimizer_attempt_state: %s", status)
+		}
+		if path := metadataString(snapshot.Verbose.Optimizer, "optimizer_attempt_path"); path != "" {
+			writeLine(stdout, "optimizer_attempt_path: %s", path)
+		}
 		if available, ok := snapshot.Verbose.Optimizer["recovery_available"]; ok {
 			writeLine(stdout, "optimizer_recovery_available: %v", available)
 		}
@@ -5285,6 +5248,33 @@ func printSkillOptTrainStatusSnapshot(stdout io.Writer, snapshot skillOptTrainSt
 	for _, lock := range snapshot.Verbose.ActiveLocks {
 		writeLine(stdout, "active_lock: %s", skillOptTrainStatusLockText(lock))
 	}
+}
+
+func skillOptTrainOptimizerAttemptState(currentPhase string, optimizer map[string]any, candidateImport map[string]any) string {
+	optimizerStatus := metadataString(optimizer, "status")
+	if optimizerStatus == "running" {
+		return "running"
+	}
+	switch strings.TrimSpace(currentPhase) {
+	case skillopt.TrainStateOptimizerCompletedNoCandidate:
+		return "completed_no_candidate"
+	case skillopt.TrainStateCandidateCreated, skillopt.TrainStateCandidateReviewPublished, skillopt.TrainStateCandidatePromoted, skillopt.TrainStateCandidateRejected:
+		return "completed_candidate"
+	}
+	optimizerAttempt := metadataString(optimizer, "optimizer_attempt")
+	importAttempt := metadataString(candidateImport, "optimizer_attempt")
+	if optimizerAttempt != "" && importAttempt != "" && optimizerAttempt != importAttempt {
+		candidateImport = nil
+	}
+	switch metadataString(candidateImport, "status") {
+	case "no_candidate":
+		return "completed_no_candidate"
+	case "succeeded", "recovered":
+		return "completed_candidate"
+	case "failed":
+		return "candidate_import_failed"
+	}
+	return optimizerStatus
 }
 
 func printSkillOptNoCandidateDetails(stdout io.Writer, details map[string]any) {
@@ -5795,61 +5785,163 @@ func skillOptTrainBackendConfigStatus(resolution skillOptTrainBackendResolution)
 func resolveSkillOptTrainOptimizerPaths(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest) (skillOptTrainOptimizerPaths, error) {
 	outRoot := strings.TrimSpace(request.OutRoot)
 	optimizerMetadata := decodedSkillOptMetadataValue(decodedSkillOptMetadata(iteration.MetadataJSON)["optimizer"])
+	persistedOptimizerRoot := metadataString(optimizerMetadata, "optimizer_root")
+	persistedAttempt := metadataString(optimizerMetadata, "optimizer_attempt")
+	persistedAttemptPath := metadataString(optimizerMetadata, "optimizer_attempt_path")
 	persistedOutRoot := metadataString(optimizerMetadata, "out_root")
 	persistedTrainingPackage := metadataString(optimizerMetadata, "training_package")
 	persistedCandidateOutput := metadataString(optimizerMetadata, "candidate_output")
 	persistedArtifactDir := metadataString(optimizerMetadata, "artifact_dir")
+	persistedBaseRoot := persistedOptimizerRoot
+	if persistedBaseRoot == "" {
+		persistedBaseRoot = inferSkillOptTrainOptimizerRoot(persistedOutRoot, persistedAttempt)
+	}
 	if persistedTrainingPackage != "" && skillopt.NormalizeTrainState(iteration.State) != skillopt.TrainStateFeedbackSynced {
 		if outRoot != "" {
 			absRequestedOutRoot, err := filepath.Abs(outRoot)
 			if err != nil {
 				return skillOptTrainOptimizerPaths{}, fmt.Errorf("resolve optimizer out-root: %w", err)
 			}
-			absPersistedOutRoot := persistedOutRoot
-			if absPersistedOutRoot == "" {
-				absPersistedOutRoot = filepath.Dir(persistedTrainingPackage)
+			absPersistedRoot := persistedBaseRoot
+			if absPersistedRoot == "" {
+				absPersistedRoot = persistedOutRoot
 			}
-			if absPersistedOutRoot, err = filepath.Abs(absPersistedOutRoot); err != nil {
+			if absPersistedRoot == "" {
+				absPersistedRoot = filepath.Dir(persistedTrainingPackage)
+			}
+			if absPersistedRoot, err = filepath.Abs(absPersistedRoot); err != nil {
 				return skillOptTrainOptimizerPaths{}, fmt.Errorf("resolve persisted optimizer out-root: %w", err)
 			}
-			if absRequestedOutRoot != absPersistedOutRoot {
+			absPersistedOutRoot := ""
+			if persistedOutRoot != "" {
+				if absPersistedOutRoot, err = filepath.Abs(persistedOutRoot); err != nil {
+					return skillOptTrainOptimizerPaths{}, fmt.Errorf("resolve persisted optimizer attempt out-root: %w", err)
+				}
+			}
+			if absRequestedOutRoot != absPersistedRoot && absRequestedOutRoot != absPersistedOutRoot {
 				return skillOptTrainOptimizerPaths{}, fmt.Errorf("optimizer package already exported at %s; retry with the same --out-root or omit --out-root", persistedTrainingPackage)
 			}
 		}
-		outRoot = persistedOutRoot
+		outRoot = persistedBaseRoot
 		if outRoot == "" {
-			outRoot = filepath.Dir(persistedTrainingPackage)
+			outRoot = persistedOutRoot
+		}
+		if outRoot == "" {
+			outRoot = filepath.Dir(filepath.Dir(filepath.Dir(persistedTrainingPackage)))
 		}
 	}
 	if outRoot == "" {
-		outRoot = persistedOutRoot
+		outRoot = persistedBaseRoot
+	}
+	if outRoot == "" {
+		outRoot = inferSkillOptTrainOptimizerRoot(persistedOutRoot, persistedAttempt)
 	}
 	if outRoot == "" {
 		outRoot = filepath.Join(paths.Evals, "train", session.ID, iteration.ID, "optimizer")
 	}
-	absOutRoot, err := filepath.Abs(outRoot)
+	absOptimizerRoot, err := filepath.Abs(outRoot)
 	if err != nil {
 		return skillOptTrainOptimizerPaths{}, fmt.Errorf("resolve optimizer out-root: %w", err)
 	}
-	trainingPackagePath := filepath.Join(absOutRoot, "training.json")
-	candidatePackagePath := filepath.Join(absOutRoot, "candidate.json")
-	artifactDir := filepath.Join(absOutRoot, "artifacts")
-	if persistedTrainingPackage != "" && skillopt.NormalizeTrainState(iteration.State) != skillopt.TrainStateFeedbackSynced {
-		trainingPackagePath = persistedTrainingPackage
-		if persistedCandidateOutput != "" {
-			candidatePackagePath = persistedCandidateOutput
+	state := skillopt.NormalizeTrainState(iteration.State)
+	attempt := persistedAttempt
+	attemptPath := persistedAttemptPath
+	if state == skillopt.TrainStateFeedbackSynced || persistedTrainingPackage == "" {
+		attempt = "attempt-001"
+		attemptPath = filepath.Join(absOptimizerRoot, "attempts", attempt)
+	} else if request.RerunOptimizer {
+		nextAttempt, err := nextSkillOptTrainOptimizerAttempt(absOptimizerRoot, attempt)
+		if err != nil {
+			return skillOptTrainOptimizerPaths{}, err
 		}
-		if persistedArtifactDir != "" {
-			artifactDir = persistedArtifactDir
+		attempt = nextAttempt
+		attemptPath = filepath.Join(absOptimizerRoot, "attempts", attempt)
+	} else if attemptPath == "" {
+		attemptPath = persistedOutRoot
+	}
+	if attemptPath == "" {
+		attemptPath = filepath.Join(absOptimizerRoot, "attempts", firstNonEmpty(attempt, "attempt-001"))
+	}
+	absAttemptPath, err := filepath.Abs(attemptPath)
+	if err != nil {
+		return skillOptTrainOptimizerPaths{}, fmt.Errorf("resolve optimizer attempt path: %w", err)
+	}
+	if attempt == "" {
+		attempt = filepath.Base(absAttemptPath)
+	}
+	trainingPackagePath := filepath.Join(absAttemptPath, "training.json")
+	candidatePackagePath := filepath.Join(absAttemptPath, "candidate.json")
+	artifactDir := filepath.Join(absAttemptPath, "artifacts")
+	if persistedTrainingPackage != "" && state != skillopt.TrainStateFeedbackSynced {
+		trainingPackagePath = persistedTrainingPackage
+		if request.RerunOptimizer {
+			candidatePackagePath = filepath.Join(absAttemptPath, "candidate.json")
+			artifactDir = filepath.Join(absAttemptPath, "artifacts")
+		} else {
+			if persistedCandidateOutput != "" {
+				candidatePackagePath = persistedCandidateOutput
+			}
+			if persistedArtifactDir != "" {
+				artifactDir = persistedArtifactDir
+			}
 		}
 	}
 	return skillOptTrainOptimizerPaths{
-		OutRoot:              absOutRoot,
+		OutRoot:              absAttemptPath,
+		OptimizerRoot:        absOptimizerRoot,
+		OptimizerAttempt:     attempt,
+		OptimizerAttemptPath: absAttemptPath,
 		ArtifactRoot:         paths.ArtifactBlobs,
 		TrainingPackagePath:  trainingPackagePath,
 		CandidatePackagePath: candidatePackagePath,
 		ArtifactDir:          artifactDir,
 	}, nil
+}
+
+func inferSkillOptTrainOptimizerRoot(outRoot string, attempt string) string {
+	outRoot = strings.TrimSpace(outRoot)
+	attempt = strings.TrimSpace(attempt)
+	if outRoot == "" || attempt == "" {
+		return outRoot
+	}
+	clean := filepath.Clean(outRoot)
+	if filepath.Base(clean) != attempt {
+		return outRoot
+	}
+	attemptsDir := filepath.Dir(clean)
+	if filepath.Base(attemptsDir) != "attempts" {
+		return outRoot
+	}
+	return filepath.Dir(attemptsDir)
+}
+
+func nextSkillOptTrainOptimizerAttempt(root string, currentAttempt string) (string, error) {
+	maxAttempt := skillOptTrainOptimizerAttemptNumber(currentAttempt)
+	entries, err := os.ReadDir(filepath.Join(root, "attempts"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("read optimizer attempts: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if number := skillOptTrainOptimizerAttemptNumber(entry.Name()); number > maxAttempt {
+			maxAttempt = number
+		}
+	}
+	return fmt.Sprintf("attempt-%03d", maxAttempt+1), nil
+}
+
+func skillOptTrainOptimizerAttemptNumber(attempt string) int {
+	attempt = strings.TrimSpace(attempt)
+	if !strings.HasPrefix(attempt, "attempt-") {
+		return 0
+	}
+	number, err := strconv.Atoi(strings.TrimPrefix(attempt, "attempt-"))
+	if err != nil || number < 0 {
+		return 0
+	}
+	return number
 }
 
 func exportSkillOptTrainPackage(ctx context.Context, store *db.Store, iteration db.SkillOptTrainIteration, paths skillOptTrainOptimizerPaths) (map[string]any, error) {
@@ -5866,14 +5958,17 @@ func exportSkillOptTrainPackage(ctx context.Context, store *db.Store, iteration 
 		return nil, fmt.Errorf("write training package: %w", err)
 	}
 	return map[string]any{
-		"status":           "package_created",
-		"training_package": paths.TrainingPackagePath,
-		"out_root":         paths.OutRoot,
-		"artifact_root":    paths.ArtifactRoot,
-		"candidate_output": paths.CandidatePackagePath,
-		"artifact_dir":     paths.ArtifactDir,
-		"created_at":       time.Now().UTC().Format(time.RFC3339Nano),
-		"source":           "gitmoot skillopt train continue",
+		"status":                 "package_created",
+		"training_package":       paths.TrainingPackagePath,
+		"out_root":               paths.OutRoot,
+		"optimizer_root":         paths.OptimizerRoot,
+		"optimizer_attempt":      paths.OptimizerAttempt,
+		"optimizer_attempt_path": paths.OptimizerAttemptPath,
+		"artifact_root":          paths.ArtifactRoot,
+		"candidate_output":       paths.CandidatePackagePath,
+		"artifact_dir":           paths.ArtifactDir,
+		"created_at":             time.Now().UTC().Format(time.RFC3339Nano),
+		"source":                 "gitmoot skillopt train continue",
 	}, nil
 }
 
@@ -5913,6 +6008,9 @@ func recoverSkillOptTrainOptimizerArtifacts(ctx context.Context, paths config.Pa
 		CurrentPhase:         skillopt.NormalizeTrainState(iteration.State),
 		RecoveryAvailable:    skillOptTrainOptimizerRecoveryAvailable(optimizerPaths),
 		OutRoot:              optimizerPaths.OutRoot,
+		OptimizerRoot:        optimizerPaths.OptimizerRoot,
+		OptimizerAttempt:     optimizerPaths.OptimizerAttempt,
+		OptimizerAttemptPath: optimizerPaths.OptimizerAttemptPath,
 		CandidatePackagePath: optimizerPaths.CandidatePackagePath,
 		ArtifactDir:          optimizerPaths.ArtifactDir,
 		Artifacts:            existingSkillOptTrainOptimizerArtifacts(optimizerPaths),
@@ -5956,6 +6054,9 @@ func recoverSkillOptTrainOptimizerArtifacts(ctx context.Context, paths config.Pa
 	result.CurrentPhase = skillopt.NormalizeTrainState(iteration.State)
 	result.RecoveryAvailable = skillOptTrainOptimizerRecoveryAvailable(optimizerPaths)
 	result.OutRoot = optimizerPaths.OutRoot
+	result.OptimizerRoot = optimizerPaths.OptimizerRoot
+	result.OptimizerAttempt = optimizerPaths.OptimizerAttempt
+	result.OptimizerAttemptPath = optimizerPaths.OptimizerAttemptPath
 	result.CandidatePackagePath = optimizerPaths.CandidatePackagePath
 	result.ArtifactDir = optimizerPaths.ArtifactDir
 	result.Artifacts = existingSkillOptTrainOptimizerArtifacts(optimizerPaths)
@@ -6060,12 +6161,15 @@ func recoverSkillOptTrainOptimizerArtifacts(ctx context.Context, paths config.Pa
 		return result, err
 	}
 	metadata := map[string]any{
-		"status":            "recovered",
-		"candidate_version": version.ID,
-		"candidate_package": optimizerPaths.CandidatePackagePath,
-		"artifact_dir":      optimizerPaths.ArtifactDir,
-		"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
-		"source":            "gitmoot skillopt train recover",
+		"status":                 "recovered",
+		"candidate_version":      version.ID,
+		"candidate_package":      optimizerPaths.CandidatePackagePath,
+		"artifact_dir":           optimizerPaths.ArtifactDir,
+		"optimizer_root":         optimizerPaths.OptimizerRoot,
+		"optimizer_attempt":      optimizerPaths.OptimizerAttempt,
+		"optimizer_attempt_path": optimizerPaths.OptimizerAttemptPath,
+		"completed_at":           time.Now().UTC().Format(time.RFC3339Nano),
+		"source":                 "gitmoot skillopt train recover",
 	}
 	session.State = skillopt.TrainStateCandidateCreated
 	iteration.State = skillopt.TrainStateCandidateCreated
@@ -6105,14 +6209,17 @@ func markSkillOptTrainOptimizerRecoveredComplete(ctx context.Context, store *db.
 		return session, &iteration, nil
 	}
 	metadata := map[string]any{
-		"status":           "recovered",
-		"training_package": paths.TrainingPackagePath,
-		"out_root":         paths.OutRoot,
-		"artifact_root":    paths.ArtifactRoot,
-		"candidate_output": paths.CandidatePackagePath,
-		"artifact_dir":     paths.ArtifactDir,
-		"completed_at":     time.Now().UTC().Format(time.RFC3339Nano),
-		"source":           "gitmoot skillopt train recover",
+		"status":                 "recovered",
+		"training_package":       paths.TrainingPackagePath,
+		"out_root":               paths.OutRoot,
+		"optimizer_root":         paths.OptimizerRoot,
+		"optimizer_attempt":      paths.OptimizerAttempt,
+		"optimizer_attempt_path": paths.OptimizerAttemptPath,
+		"artifact_root":          paths.ArtifactRoot,
+		"candidate_output":       paths.CandidatePackagePath,
+		"artifact_dir":           paths.ArtifactDir,
+		"completed_at":           time.Now().UTC().Format(time.RFC3339Nano),
+		"source":                 "gitmoot skillopt train recover",
 	}
 	session.State = skillopt.TrainStateOptimizerCompleted
 	iteration.State = skillopt.TrainStateOptimizerCompleted
@@ -6201,6 +6308,9 @@ func printSkillOptTrainRecoverResult(stdout io.Writer, result skillOptTrainRecov
 	writeLine(stdout, "current_phase: %s", emptyText(result.CurrentPhase))
 	writeLine(stdout, "recovery_available: %t", result.RecoveryAvailable)
 	writeLine(stdout, "optimizer_out_root: %s", emptyText(result.OutRoot))
+	writeLine(stdout, "optimizer_root: %s", emptyText(result.OptimizerRoot))
+	writeLine(stdout, "optimizer_attempt: %s", emptyText(result.OptimizerAttempt))
+	writeLine(stdout, "optimizer_attempt_path: %s", emptyText(result.OptimizerAttemptPath))
 	writeLine(stdout, "candidate_package: %s", emptyText(result.CandidatePackagePath))
 	writeLine(stdout, "artifact_dir: %s", emptyText(result.ArtifactDir))
 	writeLine(stdout, "candidate: %s", emptyText(result.CandidateVersionID))
@@ -6353,23 +6463,50 @@ func subprocessDiagnostics(result subprocess.Result) string {
 
 func skillOptTrainOptimizerMetadata(request skillOptTrainOptimizerRequest, paths skillOptTrainOptimizerPaths, command string, args []string, result subprocess.Result, status string, failure error) map[string]any {
 	metadata := map[string]any{
-		"status":           status,
-		"command":          command,
-		"args":             args,
-		"training_package": paths.TrainingPackagePath,
-		"out_root":         paths.OutRoot,
-		"candidate_output": paths.CandidatePackagePath,
-		"artifact_dir":     paths.ArtifactDir,
-		"dry_run":          request.DryRun,
-		"stdout":           truncateForMetadata(result.Stdout),
-		"stderr":           truncateForMetadata(result.Stderr),
-		"completed_at":     time.Now().UTC().Format(time.RFC3339Nano),
-		"source":           "gitmoot skillopt train continue",
+		"status":                 status,
+		"command":                command,
+		"args":                   args,
+		"training_package":       paths.TrainingPackagePath,
+		"out_root":               paths.OutRoot,
+		"optimizer_root":         paths.OptimizerRoot,
+		"optimizer_attempt":      paths.OptimizerAttempt,
+		"optimizer_attempt_path": paths.OptimizerAttemptPath,
+		"candidate_output":       paths.CandidatePackagePath,
+		"artifact_dir":           paths.ArtifactDir,
+		"dry_run":                request.DryRun,
+		"stdout":                 truncateForMetadata(result.Stdout),
+		"stderr":                 truncateForMetadata(result.Stderr),
+		"completed_at":           time.Now().UTC().Format(time.RFC3339Nano),
+		"source":                 "gitmoot skillopt train continue",
 	}
 	if failure != nil {
 		metadata["error"] = failure.Error()
 	}
 	return metadata
+}
+
+func recordSkillOptTrainOptimizerStarted(ctx context.Context, store *db.Store, session *db.SkillOptTrainSession, iteration *db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest, paths skillOptTrainOptimizerPaths, command string, args []string) error {
+	metadata := map[string]any{
+		"status":                 "running",
+		"command":                command,
+		"args":                   args,
+		"training_package":       paths.TrainingPackagePath,
+		"out_root":               paths.OutRoot,
+		"optimizer_root":         paths.OptimizerRoot,
+		"optimizer_attempt":      paths.OptimizerAttempt,
+		"optimizer_attempt_path": paths.OptimizerAttemptPath,
+		"candidate_output":       paths.CandidatePackagePath,
+		"artifact_dir":           paths.ArtifactDir,
+		"dry_run":                request.DryRun,
+		"started_at":             time.Now().UTC().Format(time.RFC3339Nano),
+		"source":                 "gitmoot skillopt train continue",
+	}
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "optimizer", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "optimizer", metadata)
+	if err := store.UpsertSkillOptTrainSession(ctx, *session); err != nil {
+		return err
+	}
+	return store.UpsertSkillOptTrainIteration(ctx, *iteration)
 }
 
 func recordSkillOptTrainOptimizerFailure(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest, paths skillOptTrainOptimizerPaths, command string, args []string, result subprocess.Result, failure error) error {
@@ -6384,12 +6521,15 @@ func recordSkillOptTrainOptimizerFailure(ctx context.Context, store *db.Store, s
 
 func recordSkillOptTrainCandidateImportFailure(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, paths skillOptTrainOptimizerPaths, failure error) error {
 	metadata := map[string]any{
-		"status":            "failed",
-		"candidate_package": paths.CandidatePackagePath,
-		"artifact_dir":      paths.ArtifactDir,
-		"error":             failure.Error(),
-		"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
-		"source":            "gitmoot skillopt train continue",
+		"status":                 "failed",
+		"candidate_package":      paths.CandidatePackagePath,
+		"artifact_dir":           paths.ArtifactDir,
+		"optimizer_root":         paths.OptimizerRoot,
+		"optimizer_attempt":      paths.OptimizerAttempt,
+		"optimizer_attempt_path": paths.OptimizerAttemptPath,
+		"error":                  failure.Error(),
+		"completed_at":           time.Now().UTC().Format(time.RFC3339Nano),
+		"source":                 "gitmoot skillopt train continue",
 	}
 	session.State = skillopt.TrainStateOptimizerCompleted
 	iteration.State = skillopt.TrainStateOptimizerCompleted
@@ -6414,13 +6554,16 @@ func recordSkillOptTrainNoCandidate(ctx context.Context, store *db.Store, sessio
 		nextAction = packageNextAction
 	}
 	metadata := map[string]any{
-		"status":              "no_candidate",
-		"candidate_package":   paths.CandidatePackagePath,
-		"artifact_dir":        paths.ArtifactDir,
-		"no_candidate_reason": reason,
-		"next_action":         nextAction,
-		"completed_at":        time.Now().UTC().Format(time.RFC3339Nano),
-		"source":              "gitmoot skillopt train continue",
+		"status":                 "no_candidate",
+		"candidate_package":      paths.CandidatePackagePath,
+		"artifact_dir":           paths.ArtifactDir,
+		"optimizer_root":         paths.OptimizerRoot,
+		"optimizer_attempt":      paths.OptimizerAttempt,
+		"optimizer_attempt_path": paths.OptimizerAttemptPath,
+		"no_candidate_reason":    reason,
+		"next_action":            nextAction,
+		"completed_at":           time.Now().UTC().Format(time.RFC3339Nano),
+		"source":                 "gitmoot skillopt train continue",
 	}
 	if len(packageDetails) > 0 {
 		metadata["no_candidate_details"] = packageDetails
@@ -6558,6 +6701,9 @@ func skillOptTrainOptimizerReportLines(result skillOptTrainOptimizerResult) []st
 	lines := []string{
 		fmt.Sprintf("training_package: %s", result.TrainingPackagePath),
 		fmt.Sprintf("optimizer_out_root: %s", result.OutRoot),
+		fmt.Sprintf("optimizer_root: %s", result.OptimizerRoot),
+		fmt.Sprintf("optimizer_attempt: %s", result.OptimizerAttempt),
+		fmt.Sprintf("optimizer_attempt_path: %s", result.OptimizerAttemptPath),
 		fmt.Sprintf("candidate_package: %s", result.CandidatePackagePath),
 		fmt.Sprintf("artifact_dir: %s", result.ArtifactDir),
 		fmt.Sprintf("backend: %s", result.BackendResolution.Backend),

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2821,12 +2821,16 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("train continue optimizer exit code = %d, stderr=%s", code, stderr.String())
 	}
+	attemptRoot := filepath.Join(outRoot, "attempts", "attempt-001")
 	for _, want := range []string{
 		"current_phase: candidate_created",
 		"candidate: planner@v2",
 		"continue_ready: true",
-		"training_package: " + filepath.Join(outRoot, "training.json"),
-		"candidate_package: " + filepath.Join(outRoot, "candidate.json"),
+		"training_package: " + filepath.Join(attemptRoot, "training.json"),
+		"optimizer_root: " + outRoot,
+		"optimizer_attempt: attempt-001",
+		"optimizer_attempt_path: " + attemptRoot,
+		"candidate_package: " + filepath.Join(attemptRoot, "candidate.json"),
 		"optimizer_dry_run: true",
 		"imported_candidate: planner@v2",
 		"next: publish candidate diff and preview review",
@@ -2841,11 +2845,11 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 	call := runner.calls[0]
 	for _, want := range []string{
 		"optimize",
-		"--training-package", filepath.Join(outRoot, "training.json"),
+		"--training-package", filepath.Join(attemptRoot, "training.json"),
 		"--artifact-root", config.PathsForHome(home).ArtifactBlobs,
-		"--out-root", outRoot,
-		"--candidate-output", filepath.Join(outRoot, "candidate.json"),
-		"--artifact-dir", filepath.Join(outRoot, "artifacts"),
+		"--out-root", attemptRoot,
+		"--candidate-output", filepath.Join(attemptRoot, "candidate.json"),
+		"--artifact-dir", filepath.Join(attemptRoot, "artifacts"),
 		"--gate-metric", "mixed",
 		"--optimizer-model", "gpt-5.5",
 		"--target-model", "gpt-5.5",
@@ -2863,7 +2867,7 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 			t.Fatalf("optimizer args missing %q: %+v", want, call.args)
 		}
 	}
-	trainingPackage, err := os.ReadFile(filepath.Join(outRoot, "training.json"))
+	trainingPackage, err := os.ReadFile(filepath.Join(attemptRoot, "training.json"))
 	if err != nil {
 		t.Fatalf("read training package: %v", err)
 	}
@@ -3057,7 +3061,9 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		"current_phase: optimizer_completed_no_candidate",
 		"candidate: -",
 		"continue_ready: true",
-		"candidate_package: " + filepath.Join(outRoot, "candidate.json"),
+		"optimizer_attempt: attempt-001",
+		"optimizer_attempt_path: " + filepath.Join(outRoot, "attempts", "attempt-001"),
+		"candidate_package: " + filepath.Join(outRoot, "attempts", "attempt-001", "candidate.json"),
 		"optimizer_dry_run: true",
 		"no_candidate_reason: gate_rejected_best_origin_initial_skill",
 		"next: Do not import or publish a candidate review; collect more feedback",
@@ -3098,7 +3104,10 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 	}
 	if statusJSON.StatusPhase != "optimizer_completed_no_candidate" ||
 		statusJSON.NoCandidateReason != "gate_rejected_best_origin_initial_skill" ||
-		statusJSON.NoCandidateDetails["attempted_patch"] != "artifact delivery only" {
+		statusJSON.NoCandidateDetails["attempted_patch"] != "artifact delivery only" ||
+		statusJSON.Verbose == nil ||
+		statusJSON.Verbose.Optimizer["optimizer_attempt"] != "attempt-001" ||
+		statusJSON.Verbose.Optimizer["optimizer_attempt_state"] != "completed_no_candidate" {
 		t.Fatalf("train status no-candidate json = %+v", statusJSON)
 	}
 
@@ -3110,6 +3119,9 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 	}
 	for _, want := range []string{
 		"no_candidate_reason: gate_rejected_best_origin_initial_skill",
+		"optimizer_attempt: attempt-001",
+		"optimizer_attempt_state: completed_no_candidate",
+		"optimizer_attempt_path: " + filepath.Join(outRoot, "attempts", "attempt-001"),
 		"attempted_patch: artifact delivery only",
 		"retry_attempts: 1/1",
 		"rejection: baseline_gate=0.89 candidate_gate=0.84",
@@ -3163,6 +3175,10 @@ func TestSkillOptTrainContinueRerunsOptimizerAfterNoCandidate(t *testing.T) {
 	if len(runner.calls) != 1 {
 		t.Fatalf("optimizer calls after no-candidate = %+v, want one", runner.calls)
 	}
+	firstAttemptRoot := argValue(runner.calls[0].args, "--out-root")
+	if firstAttemptRoot != filepath.Join(outRoot, "attempts", "attempt-001") {
+		t.Fatalf("first optimizer attempt out-root = %q, want attempt-001 under %q", firstAttemptRoot, outRoot)
+	}
 
 	runner.candidate = cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with rerun candidate guidance.")
 	stdout.Reset()
@@ -3179,8 +3195,13 @@ func TestSkillOptTrainContinueRerunsOptimizerAfterNoCandidate(t *testing.T) {
 	if len(runner.calls) != 2 {
 		t.Fatalf("optimizer calls after rerun = %+v, want two", runner.calls)
 	}
+	secondAttemptRoot := argValue(runner.calls[1].args, "--out-root")
+	if secondAttemptRoot != filepath.Join(outRoot, "attempts", "attempt-002") {
+		t.Fatalf("second optimizer attempt out-root = %q, want attempt-002 under %q", secondAttemptRoot, outRoot)
+	}
 	if !strings.Contains(stdout.String(), "current_phase: candidate_created") ||
-		!strings.Contains(stdout.String(), "imported_candidate: planner@v2") {
+		!strings.Contains(stdout.String(), "imported_candidate: planner@v2") ||
+		!strings.Contains(stdout.String(), "optimizer_attempt: attempt-002") {
 		t.Fatalf("rerun after no-candidate stdout = %s", stdout.String())
 	}
 }
@@ -3368,10 +3389,11 @@ echo "fake optimizer ok"
 	if !strings.Contains(stdout.String(), "current_phase: candidate_created") || !strings.Contains(stdout.String(), "imported_candidate: planner@v2") {
 		t.Fatalf("fake executable stdout = %s", stdout.String())
 	}
-	if _, err := os.Stat(filepath.Join(outRoot, "training.json")); err != nil {
+	attemptRoot := filepath.Join(outRoot, "attempts", "attempt-001")
+	if _, err := os.Stat(filepath.Join(attemptRoot, "training.json")); err != nil {
 		t.Fatalf("training package was not written: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(outRoot, "candidate.json")); err != nil {
+	if _, err := os.Stat(filepath.Join(attemptRoot, "candidate.json")); err != nil {
 		t.Fatalf("candidate package was not written: %v", err)
 	}
 }
@@ -4985,7 +5007,8 @@ func TestSkillOptTrainContinueRecordsOptimizerFailureAtPackageGate(t *testing.T)
 		t.Fatalf("optimizer calls after retry = %+v, want two", runner.calls)
 	}
 	retryCall := runner.calls[1]
-	if argValue(retryCall.args, "--out-root") != outRoot || argValue(retryCall.args, "--training-package") != filepath.Join(outRoot, "training.json") {
+	attemptRoot := filepath.Join(outRoot, "attempts", "attempt-001")
+	if argValue(retryCall.args, "--out-root") != attemptRoot || argValue(retryCall.args, "--training-package") != filepath.Join(attemptRoot, "training.json") {
 		t.Fatalf("retry did not reuse persisted optimizer paths: %+v", retryCall.args)
 	}
 	if !strings.Contains(stdout.String(), "current_phase: candidate_created") || !strings.Contains(stdout.String(), "imported_candidate: planner@v2") {
@@ -5023,7 +5046,8 @@ func TestSkillOptTrainContinueReportsRecoveryAfterOptimizerFailureArtifacts(t *t
 	if !strings.Contains(stdout.String(), "recovery_available: true") {
 		t.Fatalf("optimizer failure stdout did not report recovery:\n%s", stdout.String())
 	}
-	if _, err := os.Stat(filepath.Join(outRoot, "candidate.json")); err != nil {
+	attemptRoot := filepath.Join(outRoot, "attempts", "attempt-001")
+	if _, err := os.Stat(filepath.Join(attemptRoot, "candidate.json")); err != nil {
 		t.Fatalf("candidate package was not written before failure: %v", err)
 	}
 
@@ -5180,7 +5204,8 @@ func TestSkillOptTrainRecoverReportsIncompleteArtifacts(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("train continue failed optimizer exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if err := os.WriteFile(filepath.Join(outRoot, "summary.json"), []byte(`{"status":"failed","reason":"timeout","no_candidate_reason":null}`), 0o644); err != nil {
+	attemptRoot := filepath.Join(outRoot, "attempts", "attempt-001")
+	if err := os.WriteFile(filepath.Join(attemptRoot, "summary.json"), []byte(`{"status":"failed","reason":"timeout","no_candidate_reason":null}`), 0o644); err != nil {
 		t.Fatalf("write summary artifact returned error: %v", err)
 	}
 
@@ -5220,7 +5245,8 @@ func TestSkillOptTrainRecoverRejectsCorruptedCandidateArtifacts(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("train continue failed optimizer exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if err := os.WriteFile(filepath.Join(outRoot, "candidate.json"), []byte(`{not-json`), 0o644); err != nil {
+	attemptRoot := filepath.Join(outRoot, "attempts", "attempt-001")
+	if err := os.WriteFile(filepath.Join(attemptRoot, "candidate.json"), []byte(`{not-json`), 0o644); err != nil {
 		t.Fatalf("write corrupted candidate returned error: %v", err)
 	}
 
@@ -5263,7 +5289,8 @@ func TestSkillOptTrainRecoverLeavesStateOnMissingCandidateArtifact(t *testing.T)
 	if code != 1 {
 		t.Fatalf("train continue recoverable failure exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if err := os.Remove(filepath.Join(outRoot, "artifacts", "candidate.diff.md")); err != nil {
+	attemptRoot := filepath.Join(outRoot, "attempts", "attempt-001")
+	if err := os.Remove(filepath.Join(attemptRoot, "artifacts", "candidate.diff.md")); err != nil {
 		t.Fatalf("remove candidate diff artifact returned error: %v", err)
 	}
 
@@ -5294,7 +5321,8 @@ func TestSkillOptTrainRecoverLeavesStateOnMissingCandidateArtifact(t *testing.T)
 func TestSkillOptTrainRecoverRejectsCandidateBeforePackageState(t *testing.T) {
 	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
 	outRoot := filepath.Join(t.TempDir(), "optimizer")
-	artifactDir := filepath.Join(outRoot, "artifacts")
+	attemptRoot := filepath.Join(outRoot, "attempts", "attempt-001")
+	artifactDir := filepath.Join(attemptRoot, "artifacts")
 	diffContent := []byte("candidate diff\n")
 	diffSize := int64(len(diffContent))
 	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
@@ -5317,7 +5345,7 @@ func TestSkillOptTrainRecoverRejectsCandidateBeforePackageState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal candidate package returned error: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(outRoot, "candidate.json"), encoded, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(attemptRoot, "candidate.json"), encoded, 0o644); err != nil {
 		t.Fatalf("write candidate package returned error: %v", err)
 	}
 
@@ -5522,18 +5550,48 @@ func TestSkillOptTrainContinueRejectsCandidateForDifferentSessionTemplate(t *tes
 		t.Fatalf("deterministic import retry reran optimizer: %+v", runner.calls)
 	}
 
-	staleOutRoot := argValue(runner.calls[0].args, "--out-root")
-	if staleOutRoot == "" {
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--rerun-optimizer",
+		"--gate", "unsupported",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("train continue rerun setup failure exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `optimizer gate "unsupported" is not supported`) {
+		t.Fatalf("rerun setup failure stderr = %q", stderr.String())
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("rerun setup failure started optimizer: %+v", runner.calls)
+	}
+	store = openCLIJobStore(t, home)
+	afterSetupFailure, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration after rerun setup failure returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after rerun setup failure returned error: %v", err)
+	}
+	if afterSetupFailure.State != skillopt.TrainStateOptimizerCompleted || afterSetupFailure.MetadataJSON != iteration.MetadataJSON {
+		t.Fatalf("rerun setup failure changed completed optimizer state: before=%+v after=%+v", iteration, afterSetupFailure)
+	}
+
+	firstAttemptRoot := argValue(runner.calls[0].args, "--out-root")
+	if firstAttemptRoot == "" {
 		t.Fatalf("first optimizer call did not include --out-root: %+v", runner.calls[0].args)
 	}
 	staleFiles := []string{
-		filepath.Join(staleOutRoot, "candidate.json"),
-		filepath.Join(staleOutRoot, "history.json"),
-		filepath.Join(staleOutRoot, "summary.json"),
-		filepath.Join(staleOutRoot, "runtime_state.json"),
-		filepath.Join(staleOutRoot, "best_skill.md"),
-		filepath.Join(staleOutRoot, "steps", "step_0001", "step_record.json"),
-		filepath.Join(staleOutRoot, "artifacts", "stale.diff.md"),
+		filepath.Join(firstAttemptRoot, "candidate.json"),
+		filepath.Join(firstAttemptRoot, "history.json"),
+		filepath.Join(firstAttemptRoot, "summary.json"),
+		filepath.Join(firstAttemptRoot, "runtime_state.json"),
+		filepath.Join(firstAttemptRoot, "best_skill.md"),
+		filepath.Join(firstAttemptRoot, "steps", "step_0001", "step_record.json"),
+		filepath.Join(firstAttemptRoot, "artifacts", "stale.diff.md"),
 	}
 	for _, path := range staleFiles {
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -5543,37 +5601,60 @@ func TestSkillOptTrainContinueRejectsCandidateForDifferentSessionTemplate(t *tes
 			t.Fatalf("write stale optimizer artifact returned error: %v", err)
 		}
 	}
-	unrelatedFile := filepath.Join(staleOutRoot, "unrelated", "keep.txt")
+	unrelatedFile := filepath.Join(firstAttemptRoot, "unrelated", "keep.txt")
 	if err := os.MkdirAll(filepath.Dir(unrelatedFile), 0o755); err != nil {
 		t.Fatalf("create unrelated out-root file dir returned error: %v", err)
 	}
 	if err := os.WriteFile(unrelatedFile, []byte("do not remove\n"), 0o644); err != nil {
 		t.Fatalf("write unrelated out-root file returned error: %v", err)
 	}
-	trainingPackagePath := filepath.Join(staleOutRoot, "training.json")
+	trainingPackagePath := filepath.Join(firstAttemptRoot, "training.json")
 	if _, err := os.Stat(trainingPackagePath); err != nil {
 		t.Fatalf("expected persisted training package before rerun: %v", err)
 	}
+	secondAttemptRoot := filepath.Join(outRoot, "attempts", "attempt-002")
 	runner.beforeRun = func(dir string, args []string) error {
 		if len(runner.calls) != 2 {
 			return nil
 		}
-		if dir != staleOutRoot || argValue(args, "--out-root") != staleOutRoot {
-			return fmt.Errorf("rerun did not reuse optimizer out-root; dir=%s args=%v", dir, args)
+		if dir != secondAttemptRoot || argValue(args, "--out-root") != secondAttemptRoot {
+			return fmt.Errorf("rerun did not use isolated optimizer attempt; dir=%s args=%v", dir, args)
 		}
 		if _, err := os.Stat(trainingPackagePath); err != nil {
-			return fmt.Errorf("rerun cleanup removed training package: %w", err)
+			return fmt.Errorf("rerun removed previous attempt training package: %w", err)
 		}
 		if _, err := os.Stat(unrelatedFile); err != nil {
-			return fmt.Errorf("rerun cleanup removed unrelated out-root file: %w", err)
+			return fmt.Errorf("rerun removed previous attempt unrelated file: %w", err)
 		}
 		for _, path := range staleFiles {
-			if path == trainingPackagePath {
-				continue
+			if _, err := os.Stat(path); err != nil {
+				return fmt.Errorf("previous attempt artifact was not preserved before rerun: %s: %w", path, err)
 			}
-			if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("stale optimizer artifact still exists before rerun: %s", path)
-			}
+		}
+		if _, err := os.Stat(filepath.Join(secondAttemptRoot, "candidate.json")); !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("new attempt unexpectedly contains stale candidate before rerun")
+		}
+		store := openCLIJobStore(t, home)
+		iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+		if err != nil {
+			_ = store.Close()
+			return fmt.Errorf("GetLatestSkillOptTrainIteration during rerun returned error: %w", err)
+		}
+		if err := store.Close(); err != nil {
+			return fmt.Errorf("Close during rerun returned error: %w", err)
+		}
+		if iteration.State != skillopt.TrainStateTrainingPackageCreated {
+			return fmt.Errorf("active optimizer rerun state = %s, want %s", iteration.State, skillopt.TrainStateTrainingPackageCreated)
+		}
+		optimizer := decodedSkillOptMetadataValue(decodedSkillOptMetadata(iteration.MetadataJSON)["optimizer"])
+		if metadataString(optimizer, "status") != "running" ||
+			metadataString(optimizer, "optimizer_attempt") != "attempt-002" ||
+			metadataString(optimizer, "optimizer_attempt_path") != secondAttemptRoot {
+			return fmt.Errorf("active optimizer attempt was not persisted before rerun launch: %s", iteration.MetadataJSON)
+		}
+		candidateImport := decodedSkillOptMetadataValue(decodedSkillOptMetadata(iteration.MetadataJSON)["candidate_import"])
+		if attemptState := skillOptTrainOptimizerAttemptState(skillopt.NormalizeTrainState(iteration.State), optimizer, candidateImport); attemptState != "running" {
+			return fmt.Errorf("active optimizer attempt state = %q, want running; metadata=%s", attemptState, iteration.MetadataJSON)
 		}
 		return nil
 	}
@@ -5592,8 +5673,15 @@ func TestSkillOptTrainContinueRejectsCandidateForDifferentSessionTemplate(t *tes
 	if len(runner.calls) != 2 {
 		t.Fatalf("optimizer calls after explicit optimizer rerun = %+v, want two", runner.calls)
 	}
-	if !strings.Contains(stdout.String(), "current_phase: candidate_created") || !strings.Contains(stdout.String(), "imported_candidate: planner@v2") {
+	if !strings.Contains(stdout.String(), "current_phase: candidate_created") ||
+		!strings.Contains(stdout.String(), "imported_candidate: planner@v2") ||
+		!strings.Contains(stdout.String(), "optimizer_attempt: attempt-002") {
 		t.Fatalf("explicit optimizer rerun stdout = %s", stdout.String())
+	}
+	for _, path := range staleFiles {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("previous attempt artifact was not preserved after rerun: %s: %v", path, err)
+		}
 	}
 }
 


### PR DESCRIPTION
WHAT
- Isolates SkillOpt optimizer reruns into per-attempt directories under a stable optimizer root.
- Adds active attempt metadata to continue/status/recover output.

WHY
- Reruns previously reused the same optimizer output directory, so stale candidate, summary, history, and artifact files could contaminate debugging, status, and recovery.
- Interrupted reruns needed a persisted active attempt so status/recover can identify the current optimizer attempt.

CHANGES
- Resolves optimizer output as `optimizer/attempts/attempt-001`, `attempt-002`, etc. while preserving the stable optimizer root.
- Stops deleting prior rerun artifacts; older attempts remain inspectable.
- Persists `optimizer_root`, `optimizer_attempt`, and `optimizer_attempt_path` across optimizer, candidate import, no-candidate, and recovery metadata.
- Records a rerun attempt as `running` immediately before launching the optimizer, after setup succeeds.
- Keeps previous completed optimizer state intact when rerun setup fails before launch.
- Ignores stale candidate import metadata from older attempts when computing active attempt state.
- Updates status/recover text and JSON to show active attempt information.
- Updates CLI tests for first runs, reruns, active attempt metadata, stale artifact preservation, no-candidate status, recovery paths, and pre-launch rerun setup failure.

RESULTS
- `git diff --check`: passed.
- `GOTOOLCHAIN=local go test ./internal/skillopt ./internal/cli`: blocked locally because this environment has Go 1.22.2 and `go.mod` requires Go >= 1.26.

Raw local Go test output:

```text
go: go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local)
```

- `codex exec review --uncommitted`: clean.

Raw final review output:

```text
I did not identify any discrete correctness issues in the changed code paths. The changes consistently isolate optimizer attempts and preserve/reuse persisted paths as intended.
```

RISK
- Local unit tests could not be executed until a Go 1.26 toolchain is available in the environment.
- The change is intentionally limited to Gitmoot optimizer attempt orchestration and does not add a package refresh command.
