### PR TITLE
Explain no-candidate gate retry status

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -5284,8 +5284,27 @@ func printSkillOptNoCandidateDetails(stdout io.Writer, details map[string]any) {
 	if attemptedPatch := metadataString(details, "attempted_patch"); attemptedPatch != "" {
 		writeLine(stdout, "attempted_patch: %s", attemptedPatch)
 	}
+	if baselineGate := metadataString(details, "baseline_gate"); baselineGate != "" {
+		writeLine(stdout, "baseline_gate: %s", baselineGate)
+	}
+	if candidateGate := metadataString(details, "candidate_gate"); candidateGate != "" {
+		writeLine(stdout, "candidate_gate: %s", candidateGate)
+	}
 	if retryAttempts := metadataString(details, "retry_attempts"); retryAttempts != "" {
 		writeLine(stdout, "retry_attempts: %s", retryAttempts)
+	}
+	if duplicateRetry := metadataBoolPtr(details, "duplicate_retry_detected"); duplicateRetry != nil {
+		writeLine(stdout, "duplicate_retry_detected: %t", *duplicateRetry)
+	}
+	if evaluatorReason := metadataString(details, "evaluator_reason"); evaluatorReason != "" {
+		writeLine(stdout, "evaluator_reason: %s", evaluatorReason)
+	}
+	nextActions := metadataStringSlice(details, "next_actions")
+	if len(nextActions) == 0 {
+		nextActions = metadataStringSlice(details, "next_action")
+	}
+	for _, nextAction := range nextActions {
+		writeLine(stdout, "next_action_option: %s", nextAction)
 	}
 	rejection := decodedSkillOptMetadataValue(details["rejection"])
 	if len(rejection) == 0 {
@@ -6670,16 +6689,33 @@ func skillOptNoCandidateDetailsFromGateRejection(gateRejection map[string]any) m
 		return nil
 	}
 	details := map[string]any{}
-	for _, key := range []string{"attempted_patch", "retry_attempts", "next_action"} {
+	for _, key := range []string{"attempted_patch", "retry_attempts"} {
 		if value := metadataString(gateRejection, key); value != "" {
 			details[key] = value
 		}
+	}
+	nextActions := metadataStringSlice(gateRejection, "next_actions")
+	if len(nextActions) == 0 {
+		nextActions = metadataStringSlice(gateRejection, "next_action")
+	}
+	if len(nextActions) > 0 {
+		details["next_action"] = nextActions[0]
+		details["next_actions"] = nextActions
+	}
+	if value := metadataBoolPtr(gateRejection, "duplicate_retry_detected"); value != nil {
+		details["duplicate_retry_detected"] = *value
 	}
 	rejection := map[string]any{}
 	for _, key := range []string{"baseline", "candidate"} {
 		if value := decodedSkillOptMetadataValue(gateRejection[key]); len(value) > 0 {
 			rejection[key] = value
+			if gateScore := metadataString(value, "gate_score"); gateScore != "" {
+				details[key+"_gate"] = gateScore
+			}
 		}
+	}
+	if evaluatorReason := skillOptNoCandidateEvaluatorReason(gateRejection, rejection); evaluatorReason != "" {
+		details["evaluator_reason"] = evaluatorReason
 	}
 	for _, key := range []string{"primary_reason", "human_reason", "optimizer_hint"} {
 		if value := metadataString(gateRejection, key); value != "" {
@@ -6695,6 +6731,21 @@ func skillOptNoCandidateDetailsFromGateRejection(gateRejection map[string]any) m
 		details["rejection"] = rejection
 	}
 	return details
+}
+
+func skillOptNoCandidateEvaluatorReason(gateRejection map[string]any, rejection map[string]any) string {
+	for _, source := range []map[string]any{
+		decodedSkillOptMetadataValue(rejection["candidate"]),
+		decodedSkillOptMetadataValue(rejection["baseline"]),
+		gateRejection,
+	} {
+		for _, key := range []string{"evaluator_reason", "evaluator_reasoning", "reasoning", "human_reason", "optimizer_hint", "primary_reason"} {
+			if value := metadataString(source, key); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
 }
 
 func skillOptTrainOptimizerReportLines(result skillOptTrainOptimizerResult) []string {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -3016,7 +3016,20 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 	candidate := cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan the work.")
 	candidate.EvalReport = json.RawMessage(`{
 		"promotable": false,
-		"no_candidate_reason": "gate_rejected_best_origin_initial_skill"
+		"no_candidate_reason": "gate_rejected_best_origin_initial_skill",
+		"no_candidate_details": {
+			"attempted_patch": "artifact delivery only",
+			"baseline_gate": 0.89,
+			"candidate_gate": 0.84,
+			"retry_attempts": "1/1",
+			"duplicate_retry_detected": true,
+			"evaluator_reason": "Candidate was valid but had weaker imagery.",
+			"next_action": [
+				"collect more feedback",
+				"rerun with higher retry budget",
+				"manually revise skill direction"
+			]
+		}
 	}`)
 	candidate.Summary.Metadata = json.RawMessage(`{
 		"promotable": false,
@@ -3082,7 +3095,9 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 	}
 	if !strings.Contains(iteration.MetadataJSON, `"status":"no_candidate"`) ||
 		!strings.Contains(iteration.MetadataJSON, `"no_candidate_reason":"gate_rejected_best_origin_initial_skill"`) ||
-		!strings.Contains(iteration.MetadataJSON, `"attempted_patch":"artifact delivery only"`) {
+		!strings.Contains(iteration.MetadataJSON, `"attempted_patch":"artifact delivery only"`) ||
+		!strings.Contains(iteration.MetadataJSON, `"duplicate_retry_detected":true`) ||
+		!strings.Contains(iteration.MetadataJSON, `"evaluator_reason":"Candidate was valid but had weaker imagery."`) {
 		t.Fatalf("iteration metadata after no-candidate = %s", iteration.MetadataJSON)
 	}
 	if _, err := store.GetAgentTemplateVersionByID(context.Background(), "planner@v2"); !errors.Is(err, sql.ErrNoRows) {
@@ -3105,6 +3120,7 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 	if statusJSON.StatusPhase != "optimizer_completed_no_candidate" ||
 		statusJSON.NoCandidateReason != "gate_rejected_best_origin_initial_skill" ||
 		statusJSON.NoCandidateDetails["attempted_patch"] != "artifact delivery only" ||
+		statusJSON.NoCandidateDetails["duplicate_retry_detected"] != true ||
 		statusJSON.Verbose == nil ||
 		statusJSON.Verbose.Optimizer["optimizer_attempt"] != "attempt-001" ||
 		statusJSON.Verbose.Optimizer["optimizer_attempt_state"] != "completed_no_candidate" {
@@ -3123,8 +3139,13 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		"optimizer_attempt_state: completed_no_candidate",
 		"optimizer_attempt_path: " + filepath.Join(outRoot, "attempts", "attempt-001"),
 		"attempted_patch: artifact delivery only",
+		"baseline_gate: 0.89",
+		"candidate_gate: 0.84",
 		"retry_attempts: 1/1",
-		"rejection: baseline_gate=0.89 candidate_gate=0.84",
+		"duplicate_retry_detected: true",
+		"evaluator_reason: Candidate was valid but had weaker imagery.",
+		"next_action_option: collect more feedback",
+		"next_action_option: rerun with higher retry budget",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("train status no-candidate text missing %q:\n%s", want, stdout.String())


### PR DESCRIPTION
## What

Surfaces richer SkillOpt no-candidate gate rejection details in `gitmoot skillopt train status`.

## Why

`gitmoot-skillopt` now writes structured no-candidate packages with attempted patch summaries, baseline-vs-candidate gate scores, duplicate retry detection, evaluator rationale, retry accounting, and next actions. Gitmoot should display those fields clearly instead of only reporting that no candidate was created.

## Changes

- Prints no-candidate details in verbose status:
  - `attempted_patch`
  - `baseline_gate`
  - `candidate_gate`
  - `retry_attempts`
  - `duplicate_retry_detected`
  - `evaluator_reason`
  - `next_action_option`
- Accepts both `next_actions` and documented singular-list `next_action` detail shapes.
- Derives flat gate score/evaluator fields from older nested `gate_rejection` packets when no explicit `no_candidate_details` map exists.
- Extends the existing train continue/status no-candidate test fixture to verify the richer details are recorded and rendered.

## Results

Diff check:

```text
git diff --check
```

Passed.

Go tests attempted:

```text
GOTOOLCHAIN=local go test ./internal/skillopt ./internal/cli
```

Blocked locally:

```text
go: go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local)
```

Codex review:

```text
No actionable correctness issues were identified in the current changes. I could not run the Go tests because the toolchain download attempted to write outside the writable sandbox.
```

## Risk

Low. The output fields are additive, older packages still work, and the fallback logic only runs when no explicit `no_candidate_details` map is present.
