### PR TITLE
Document SkillOpt retry reliability controls

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -364,18 +364,43 @@ Gate-rejection retry is bounded separately from no-op retry:
 
 - `noop_retry_budget`: defaults to `1` and is used when the optimizer produced
   no meaningful skill change.
-- `gate_reject_retry_budget`: defaults to `1` and is used only when a changed
+- `gate_reject_retry_budget`: defaults to `3` and is used only when a changed
   candidate loses selection eval and the rejection packet contains actionable
   new information.
+- `wrong_artifact_retry_budget`: defaults to `1` and is used when the
+  evaluator says the target produced the wrong artifact type or otherwise
+  failed the artifact contract.
 
-A gate rejection is retryable only when the evaluator supplied an
-`optimizer_hint`, the candidate actually changed, the rejection is not a repeat
-of the same reason, and budget remains. The retry prompt includes the previous
-patch summary, baseline-vs-candidate score deltas, failed dimensions, why the
-candidate lost, and guidance not to repeat the same patch direction. If the
-retry also loses, repeats the same reason, produces a no-op, or exhausts the
-budget, the run stops with `optimizer_completed_no_candidate` and a precise
-reason such as `gate_rejected_best_origin_initial_skill`.
+The retry budgets can be changed when continuing training:
+
+```sh
+gitmoot skillopt train continue \
+  --session planner-train \
+  --gate-reject-retry-budget 3 \
+  --noop-retry-budget 1 \
+  --wrong-artifact-retry-budget 1
+```
+
+A gate rejection is retryable only when the evaluator supplied actionable
+information, the candidate actually changed, the rejection is not just repeated
+noise, and budget remains. The retry prompt includes the previous patch
+summary, baseline-vs-candidate score deltas, failed dimensions, why the
+candidate lost, and guidance not to repeat the same patch direction. Near-miss
+selection rejects can also retry adaptively when the candidate is close enough
+to the baseline according to `gate_reject_retry_close_gap`, which defaults to
+`0.03`.
+
+Duplicate retry candidates do not get silently accepted or loop forever. If a
+retry produces the same candidate hash, the next retry is forced to include
+stronger duplicate-specific context. If the optimizer repeats the duplicate,
+the run stops with duplicate retry metadata instead of creating a candidate.
+Wrong-artifact retries have their own budget and do not consume the generic
+gate-rejection retry budget.
+
+If the retry also loses, repeats the same reason, produces a no-op, repeats a
+duplicate, or exhausts the relevant budget, the run stops with
+`optimizer_completed_no_candidate` and a precise reason such as
+`gate_rejected_best_origin_initial_skill`.
 
 Use verbose status to see why the run stopped and what to do next:
 
@@ -384,12 +409,23 @@ gitmoot skillopt train status --session planner-train --verbose
 ```
 
 For gate rejections, status includes the baseline/candidate score comparison,
-attempted patch, failed dimensions, retry count such as `1/1`, and a
-`next_action`. The normal user choices are to collect more feedback, rerun after
-changing the retry/config inputs, or inspect the candidate package manually.
-Gitmoot does not create a pending candidate record when the best selected prompt
-is the unchanged baseline or the candidate content hash matches the base
-template.
+attempted patch, retry count such as `1/3`, duplicate retry detection,
+evaluator reason, and concise `next_action_option` lines. The normal user
+choices are to collect more feedback, rerun after changing the retry/config
+inputs, or inspect the candidate package manually. Gitmoot does not create a
+pending candidate record when the best selected prompt is the unchanged
+baseline or the candidate content hash matches the base template.
+
+Every optimizer run writes into a numbered attempt directory:
+
+```text
+<out-root>/attempts/attempt-001/
+<out-root>/attempts/attempt-002/
+```
+
+Gitmoot records `optimizer_attempt` and `optimizer_attempt_path` in train
+metadata. Status and recovery use the active recorded attempt, so reruns do not
+reuse stale candidate packages from older attempts.
 
 If the optimizer wrapper fails after writing completed artifacts, status reports
 `status_phase: recovery_available`. Recover the artifacts through Gitmoot
@@ -460,7 +496,8 @@ The script runs focused CLI smoke tests with fake managed generation, fake
 covers local template creation, session setup, item/generation flow, required
 preview blocking, expected review repo enforcement, preview URL review packets,
 feedback-to-optimizer handoff, candidate import, candidate review publication,
-optimizer recovery, structured no-candidate status, stable status phases,
+optimizer attempt directories, optimizer recovery, structured no-candidate
+status, active attempt status/import selection, stable status phases,
 promote/reject decisions, start-next gate enforcement, watched review feedback
 import, review issue close/continue behavior, invalid-feedback comments, and
 one-time stale notices without real model calls or real GitHub mutation.
@@ -478,7 +515,9 @@ PYTHONDONTWRITEBYTECODE=1 python -m pytest \
 
 Those tests cover selection rejection creating a structured gate-rejection
 packet, default final test skipping after selection reject, actionable
-gate-rejection retry, retry budget exhaustion, no-op retry separation, and the
+gate-rejection retry, configurable retry budget defaults, adaptive retry close
+gap, duplicate retry context and metadata, wrong-artifact retry separation,
+retry budget exhaustion, no-op retry separation, evaluator rationale, and the
 no-candidate package fields Gitmoot imports.
 
 Manual smoke scenarios for review operations:
@@ -542,7 +581,8 @@ Manual smoke scenarios for review operations:
   --verbose`; usually the optimizer kept the initial skill, accepted no update,
   produced content with the same hash as the base version, or lost the
   selection gate. Gate rejection details show baseline and candidate scores,
-  attempted patch, failed dimensions, retry attempts, and next action.
+  attempted patch, duplicate retry detection, evaluator reason, retry attempts,
+  and next action options.
 - Optimizer wrapper failed after artifacts: if `status_phase` is
   `recovery_available`, run `gitmoot skillopt train recover --session <id>
   --out-root <optimizer-output-root>`.

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -640,6 +640,9 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	skillUpdateMode := fs.String("skill-update-mode", "", "SkillOpt update mode")
 	numEpochs := fs.Int("num-epochs", 0, "optimizer epoch count")
 	batchSize := fs.Int("batch-size", 0, "optimizer batch size")
+	noopRetryBudget := fs.Int("noop-retry-budget", -1, "noop optimizer retry budget; omit to use gitmoot-skillopt default")
+	gateRejectRetryBudget := fs.Int("gate-reject-retry-budget", -1, "gate-rejection optimizer retry budget; omit to use gitmoot-skillopt default")
+	wrongArtifactRetryBudget := fs.Int("wrong-artifact-retry-budget", -1, "wrong-artifact optimizer retry budget; omit to use gitmoot-skillopt default")
 	gate := fs.String("gate", "", "optimizer gate metric: hard, soft, or mixed")
 	outRoot := fs.String("out-root", "", "optimizer output directory")
 	timeout := fs.String("timeout", "", "optimizer timeout duration")
@@ -655,6 +658,10 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 		}
 		return 2
 	}
+	setFlags := map[string]bool{}
+	fs.Visit(func(flag *flag.Flag) {
+		setFlags[flag.Name] = true
+	})
 	if fs.NArg() != 0 {
 		fmt.Fprintln(stderr, "skillopt train continue does not accept positional arguments")
 		return 2
@@ -671,6 +678,18 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "skillopt train continue: --batch-size must be zero or greater")
 		return 2
 	}
+	if setFlags["noop-retry-budget"] && *noopRetryBudget < 0 {
+		fmt.Fprintln(stderr, "skillopt train continue: --noop-retry-budget must be zero or greater")
+		return 2
+	}
+	if setFlags["gate-reject-retry-budget"] && *gateRejectRetryBudget < 0 {
+		fmt.Fprintln(stderr, "skillopt train continue: --gate-reject-retry-budget must be zero or greater")
+		return 2
+	}
+	if setFlags["wrong-artifact-retry-budget"] && *wrongArtifactRetryBudget < 0 {
+		fmt.Fprintln(stderr, "skillopt train continue: --wrong-artifact-retry-budget must be zero or greater")
+		return 2
+	}
 	var output skillOptTrainContinueOutput
 	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
 		var err error
@@ -680,24 +699,30 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 			GeneratorAgent: *generatorAgent,
 			GeneratorType:  *generatorType,
 			Optimizer: skillOptTrainOptimizerRequest{
-				SkillOptBin:      *skillOptBin,
-				Backend:          *backend,
-				Model:            *model,
-				OptimizerModel:   *optimizerModel,
-				TargetModel:      *targetModel,
-				OptimizerBackend: *optimizerBackend,
-				TargetBackend:    *targetBackend,
-				EvaluatorID:      *evaluatorID,
-				EvaluatorModel:   *evaluatorModel,
-				EvaluatorBackend: *evaluatorBackend,
-				SkillUpdateMode:  *skillUpdateMode,
-				NumEpochs:        *numEpochs,
-				BatchSize:        *batchSize,
-				Gate:             *gate,
-				OutRoot:          *outRoot,
-				Timeout:          *timeout,
-				DryRun:           *dryRun,
-				RerunOptimizer:   *rerunOptimizer,
+				SkillOptBin:                 *skillOptBin,
+				Backend:                     *backend,
+				Model:                       *model,
+				OptimizerModel:              *optimizerModel,
+				TargetModel:                 *targetModel,
+				OptimizerBackend:            *optimizerBackend,
+				TargetBackend:               *targetBackend,
+				EvaluatorID:                 *evaluatorID,
+				EvaluatorModel:              *evaluatorModel,
+				EvaluatorBackend:            *evaluatorBackend,
+				SkillUpdateMode:             *skillUpdateMode,
+				NumEpochs:                   *numEpochs,
+				BatchSize:                   *batchSize,
+				NoopRetryBudget:             *noopRetryBudget,
+				NoopRetryBudgetSet:          setFlags["noop-retry-budget"],
+				GateRejectRetryBudget:       *gateRejectRetryBudget,
+				GateRejectRetryBudgetSet:    setFlags["gate-reject-retry-budget"],
+				WrongArtifactRetryBudget:    *wrongArtifactRetryBudget,
+				WrongArtifactRetryBudgetSet: setFlags["wrong-artifact-retry-budget"],
+				Gate:                        *gate,
+				OutRoot:                     *outRoot,
+				Timeout:                     *timeout,
+				DryRun:                      *dryRun,
+				RerunOptimizer:              *rerunOptimizer,
 			},
 			PromoteCandidate: *promote,
 			RejectCandidate:  *reject,
@@ -744,25 +769,31 @@ type skillOptTrainContinueRequest struct {
 }
 
 type skillOptTrainOptimizerRequest struct {
-	SkillOptBin        string
-	Backend            string
-	Model              string
-	OptimizerModel     string
-	TargetModel        string
-	OptimizerBackend   string
-	TargetBackend      string
-	EvaluatorID        string
-	EvaluatorModel     string
-	EvaluatorBackend   string
-	SkillUpdateMode    string
-	NumEpochs          int
-	BatchSize          int
-	Gate               string
-	OutRoot            string
-	Timeout            string
-	DryRun             bool
-	RerunOptimizer     bool
-	OptimizerLockState string
+	SkillOptBin                 string
+	Backend                     string
+	Model                       string
+	OptimizerModel              string
+	TargetModel                 string
+	OptimizerBackend            string
+	TargetBackend               string
+	EvaluatorID                 string
+	EvaluatorModel              string
+	EvaluatorBackend            string
+	SkillUpdateMode             string
+	NumEpochs                   int
+	BatchSize                   int
+	NoopRetryBudget             int
+	NoopRetryBudgetSet          bool
+	GateRejectRetryBudget       int
+	GateRejectRetryBudgetSet    bool
+	WrongArtifactRetryBudget    int
+	WrongArtifactRetryBudgetSet bool
+	Gate                        string
+	OutRoot                     string
+	Timeout                     string
+	DryRun                      bool
+	RerunOptimizer              bool
+	OptimizerLockState          string
 }
 
 type skillOptTrainContinueOutput struct {
@@ -3186,10 +3217,22 @@ func skillOptTrainOptimizerRequestHash(request skillOptTrainOptimizerRequest) st
 		"skill_update_mode": strings.TrimSpace(request.SkillUpdateMode),
 		"num_epochs":        request.NumEpochs,
 		"batch_size":        request.BatchSize,
-		"gate":              strings.TrimSpace(request.Gate),
-		"timeout":           strings.TrimSpace(request.Timeout),
-		"dry_run":           request.DryRun,
-		"rerun_optimizer":   request.RerunOptimizer,
+		"noop_retry_budget": map[string]any{
+			"set":   request.NoopRetryBudgetSet,
+			"value": request.NoopRetryBudget,
+		},
+		"gate_reject_retry_budget": map[string]any{
+			"set":   request.GateRejectRetryBudgetSet,
+			"value": request.GateRejectRetryBudget,
+		},
+		"wrong_artifact_retry_budget": map[string]any{
+			"set":   request.WrongArtifactRetryBudgetSet,
+			"value": request.WrongArtifactRetryBudget,
+		},
+		"gate":            strings.TrimSpace(request.Gate),
+		"timeout":         strings.TrimSpace(request.Timeout),
+		"dry_run":         request.DryRun,
+		"rerun_optimizer": request.RerunOptimizer,
 	})
 	if err != nil {
 		return ""
@@ -6414,6 +6457,15 @@ func buildSkillOptTrainOptimizerCommand(iteration db.SkillOptTrainIteration, req
 	}
 	if request.BatchSize > 0 {
 		args = append(args, "--batch-size", strconv.Itoa(request.BatchSize))
+	}
+	if request.NoopRetryBudgetSet {
+		args = append(args, "--noop-retry-budget", strconv.Itoa(request.NoopRetryBudget))
+	}
+	if request.GateRejectRetryBudgetSet {
+		args = append(args, "--gate-reject-retry-budget", strconv.Itoa(request.GateRejectRetryBudget))
+	}
+	if request.WrongArtifactRetryBudgetSet {
+		args = append(args, "--wrong-artifact-retry-budget", strconv.Itoa(request.WrongArtifactRetryBudget))
 	}
 	if request.DryRun {
 		args = append(args, "--dry-run")

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2917,6 +2917,9 @@ func TestSkillOptTrainContinueBackendCodexResolvesPresetAndReportsPreflight(t *t
 		"--target-backend", "codex",
 		"--evaluator-id", "landing_page_v1",
 		"--out-root", outRoot,
+		"--gate-reject-retry-budget", "3",
+		"--noop-retry-budget", "1",
+		"--wrong-artifact-retry-budget", "1",
 		"--dry-run",
 	}, &stdout, &stderr)
 	if code != 0 {
@@ -2947,6 +2950,9 @@ func TestSkillOptTrainContinueBackendCodexResolvesPresetAndReportsPreflight(t *t
 		"--target-backend", "codex_exec",
 		"--evaluator-backend", "codex",
 		"--evaluator-id", "landing_page_v1",
+		"--gate-reject-retry-budget", "3",
+		"--noop-retry-budget", "1",
+		"--wrong-artifact-retry-budget", "1",
 		"--dry-run",
 	} {
 		if !containsString(call.args, want) {
@@ -2990,6 +2996,21 @@ func TestSkillOptTrainContinueBackendCodexRejectsConflictingAdvancedBackend(t *t
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("optimizer started despite backend conflict: %+v", runner.calls)
+	}
+}
+
+func TestSkillOptTrainContinueRejectsNegativeRetryBudget(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--session", "optimizer-train",
+		"--noop-retry-budget", "-1",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("negative retry budget exit code = %d, want 2; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--noop-retry-budget must be zero or greater") {
+		t.Fatalf("negative retry budget stderr = %q", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## What

Documents the SkillOpt retry reliability controls and exposes the retry budget flags through `gitmoot skillopt train continue` so the documented command is real.

## Why

The train workflow docs were stale after the gate-retry reliability work: `gate_reject_retry_budget` now defaults to `3`, wrong-artifact retry has a separate budget, duplicate retry candidates are handled explicitly, and optimizer reruns use numbered attempt directories. The docs also need a working user-facing way to configure retry budgets from Gitmoot.

## Changes

- Updates `docs/skillopt-train-workflow.md` with:
  - current retry defaults: `gate_reject_retry_budget: 3`, `noop_retry_budget: 1`, `wrong_artifact_retry_budget: 1`;
  - adaptive close-gap behavior;
  - duplicate retry handling;
  - wrong-artifact retry separation;
  - optimizer attempt directories and active attempt status/import selection;
  - updated smoke coverage notes and troubleshooting guidance.
- Adds `gitmoot skillopt train continue` flags:
  - `--gate-reject-retry-budget`
  - `--noop-retry-budget`
  - `--wrong-artifact-retry-budget`
- Validates explicitly provided retry budgets as non-negative.
- Passes set retry-budget flags through to `gitmoot-skillopt optimize` and includes them in optimizer lock hashing.
- Extends CLI tests for retry budget passthrough and negative budget rejection.

## Results

Diff check:

```text
git diff --check
```

Passed.

SkillOpt fixture smoke:

```text
PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest tests/test_gate_fail_closed.py tests/test_gitmoot_optimize_cli.py tests/test_gitmoot_package.py -q
```

```text
........................................................................ [ 70%]
..............................                                           [100%]
102 passed in 0.99s
```

Gitmoot Go tests attempted:

```text
GOTOOLCHAIN=local go test ./internal/skillopt ./internal/cli
```

Blocked locally:

```text
go: go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local)
```

Auto toolchain attempt:

```text
go test ./internal/skillopt ./internal/cli
```

Blocked locally:

```text
go: downloading go1.26 (linux/amd64)
go: download go1.26 for linux/amd64: toolchain not available
```

Codex review:

```text
No discrete correctness issues were identified in the changed code. The new retry budget flags are validated, preserved through backend resolution, included in command construction only when explicitly set, and covered by focused tests.
```

## Risk

Low to moderate. The new CLI flags are additive and omitted flags preserve `gitmoot-skillopt` defaults. Go tests could not run locally because the required Go 1.26 toolchain is unavailable in this environment.
