### PR TITLE
feat(skillopt): export evaluator profiles

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -2793,7 +2793,7 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateTrainingPackageCreated); err != nil {
 			return skillOptTrainOptimizerResult{}, err
 		}
-		exportMetadata, err := exportSkillOptTrainPackage(ctx, store, iteration, optimizerPaths)
+		exportMetadata, err := exportSkillOptTrainPackage(ctx, store, iteration, optimizerPaths, request)
 		if err != nil {
 			return result, err
 		}
@@ -2825,9 +2825,21 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 			}
 			return result, err
 		}
-		if rerunFromCompletedOptimizer {
+		if request.RerunOptimizer {
+			exportMetadata, err := exportSkillOptTrainPackage(ctx, store, iteration, optimizerPaths, request)
+			if err != nil {
+				return result, err
+			}
 			session.State = skillopt.TrainStateTrainingPackageCreated
 			iteration.State = skillopt.TrainStateTrainingPackageCreated
+			session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "optimizer", exportMetadata)
+			iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "optimizer", exportMetadata)
+			if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+				return result, err
+			}
+			if err := store.UpsertSkillOptTrainIteration(ctx, iteration); err != nil {
+				return result, err
+			}
 		}
 		if err := recordSkillOptTrainOptimizerStarted(ctx, store, &session, &iteration, request, optimizerPaths, command, args); err != nil {
 			return result, err
@@ -5935,11 +5947,8 @@ func resolveSkillOptTrainOptimizerPaths(paths config.Paths, session db.SkillOptT
 	candidatePackagePath := filepath.Join(absAttemptPath, "candidate.json")
 	artifactDir := filepath.Join(absAttemptPath, "artifacts")
 	if persistedTrainingPackage != "" && state != skillopt.TrainStateFeedbackSynced {
-		trainingPackagePath = persistedTrainingPackage
-		if request.RerunOptimizer {
-			candidatePackagePath = filepath.Join(absAttemptPath, "candidate.json")
-			artifactDir = filepath.Join(absAttemptPath, "artifacts")
-		} else {
+		if !request.RerunOptimizer {
+			trainingPackagePath = persistedTrainingPackage
 			if persistedCandidateOutput != "" {
 				candidatePackagePath = persistedCandidateOutput
 			}
@@ -6006,10 +6015,13 @@ func skillOptTrainOptimizerAttemptNumber(attempt string) int {
 	return number
 }
 
-func exportSkillOptTrainPackage(ctx context.Context, store *db.Store, iteration db.SkillOptTrainIteration, paths skillOptTrainOptimizerPaths) (map[string]any, error) {
+func exportSkillOptTrainPackage(ctx context.Context, store *db.Store, iteration db.SkillOptTrainIteration, paths skillOptTrainOptimizerPaths, request skillOptTrainOptimizerRequest) (map[string]any, error) {
 	pkg, err := skillopt.ExportTrainingPackage(ctx, store, iteration.EvalRunID)
 	if err != nil {
 		return nil, fmt.Errorf("export training package: %w", err)
+	}
+	if profile := skillopt.BuildEvaluatorProfile(request.EvaluatorID, request.EvaluatorModel, pkg.EvaluatorConfig); profile != nil {
+		pkg.EvaluatorProfile = profile
 	}
 	encoded, err := json.MarshalIndent(pkg, "", "  ")
 	if err != nil {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2874,6 +2874,18 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 	if !strings.Contains(string(trainingPackage), `"kind": "gitmoot-skillopt-training-package"`) {
 		t.Fatalf("training package = %s", string(trainingPackage))
 	}
+	var decodedTrainingPackage skillopt.TrainingPackage
+	if err := json.Unmarshal(trainingPackage, &decodedTrainingPackage); err != nil {
+		t.Fatalf("decode training package: %v", err)
+	}
+	if decodedTrainingPackage.EvaluatorProfile == nil ||
+		decodedTrainingPackage.EvaluatorProfile.ProfileID != "landing_page_v1" ||
+		decodedTrainingPackage.EvaluatorProfile.ArtifactContract != "vue_vite_bundle" ||
+		decodedTrainingPackage.EvaluatorProfile.PreviewAdapter != "vue_vite" ||
+		decodedTrainingPackage.EvaluatorProfile.Judge == nil ||
+		decodedTrainingPackage.EvaluatorProfile.Judge.Model != "gpt-evaluator" {
+		t.Fatalf("training package evaluator profile = %+v", decodedTrainingPackage.EvaluatorProfile)
+	}
 
 	store := openCLIJobStore(t, home)
 	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
@@ -2892,6 +2904,149 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 	}
 	if version.State != "pending" {
 		t.Fatalf("candidate version = %+v", version)
+	}
+}
+
+func TestSkillOptTrainRerunRefreshesEvaluatorProfilePackage(t *testing.T) {
+	home, _ := seedSkillOptTrainFeedbackSynced(t)
+	paths := config.PathsForHome(home)
+	ctx := context.Background()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	session, err := store.GetSkillOptTrainSession(ctx, "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(ctx, "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+
+	request := skillOptTrainOptimizerRequest{
+		OutRoot:        filepath.Join(t.TempDir(), "optimizer"),
+		EvaluatorID:    "landing_page_v1",
+		EvaluatorModel: "initial-evaluator",
+	}
+	firstPaths, err := resolveSkillOptTrainOptimizerPaths(paths, session, iteration, request)
+	if err != nil {
+		t.Fatalf("resolve first optimizer paths: %v", err)
+	}
+	firstMetadata, err := exportSkillOptTrainPackage(ctx, store, iteration, firstPaths, request)
+	if err != nil {
+		t.Fatalf("export first training package: %v", err)
+	}
+	session.State = skillopt.TrainStateOptimizerCompleted
+	iteration.State = skillopt.TrainStateOptimizerCompleted
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "optimizer", firstMetadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "optimizer", firstMetadata)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+		t.Fatalf("persist completed optimizer state: %v", err)
+	}
+
+	rerunRequest := request
+	rerunRequest.RerunOptimizer = true
+	rerunRequest.EvaluatorModel = "rerun-evaluator"
+	rerunPaths, err := resolveSkillOptTrainOptimizerPaths(paths, session, iteration, rerunRequest)
+	if err != nil {
+		t.Fatalf("resolve rerun optimizer paths: %v", err)
+	}
+	if rerunPaths.TrainingPackagePath == firstPaths.TrainingPackagePath {
+		t.Fatalf("rerun reused first training package path: %s", rerunPaths.TrainingPackagePath)
+	}
+	if _, err := exportSkillOptTrainPackage(ctx, store, iteration, rerunPaths, rerunRequest); err != nil {
+		t.Fatalf("export rerun training package: %v", err)
+	}
+	content, err := os.ReadFile(rerunPaths.TrainingPackagePath)
+	if err != nil {
+		t.Fatalf("read rerun training package: %v", err)
+	}
+	var pkg skillopt.TrainingPackage
+	if err := json.Unmarshal(content, &pkg); err != nil {
+		t.Fatalf("decode rerun training package: %v", err)
+	}
+	if pkg.EvaluatorProfile == nil ||
+		pkg.EvaluatorProfile.ProfileID != "landing_page_v1" ||
+		pkg.EvaluatorProfile.Judge == nil ||
+		pkg.EvaluatorProfile.Judge.Model != "rerun-evaluator" {
+		t.Fatalf("rerun training package evaluator profile = %+v", pkg.EvaluatorProfile)
+	}
+}
+
+func TestSkillOptTrainRerunFromPackageCreatedExportsFreshPackage(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	paths := config.PathsForHome(home)
+	ctx := context.Background()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	session, err := store.GetSkillOptTrainSession(ctx, "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(ctx, "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+
+	request := skillOptTrainOptimizerRequest{OutRoot: filepath.Join(t.TempDir(), "optimizer")}
+	firstPaths, err := resolveSkillOptTrainOptimizerPaths(paths, session, iteration, request)
+	if err != nil {
+		t.Fatalf("resolve first optimizer paths: %v", err)
+	}
+	firstMetadata, err := exportSkillOptTrainPackage(ctx, store, iteration, firstPaths, request)
+	if err != nil {
+		t.Fatalf("export first training package: %v", err)
+	}
+	session.State = skillopt.TrainStateTrainingPackageCreated
+	iteration.State = skillopt.TrainStateTrainingPackageCreated
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "optimizer", firstMetadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "optimizer", firstMetadata)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+		t.Fatalf("persist package-created state: %v", err)
+	}
+
+	runner := &skillOptTrainFakeOptimizerRunner{
+		candidate: cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with rerun candidate guidance."),
+	}
+	runner.beforeRun = func(dir string, args []string) error {
+		trainingPackage := argValue(args, "--training-package")
+		if trainingPackage == "" {
+			return errors.New("missing --training-package")
+		}
+		content, err := os.ReadFile(trainingPackage)
+		if err != nil {
+			return fmt.Errorf("read rerun training package: %w", err)
+		}
+		var pkg skillopt.TrainingPackage
+		if err := json.Unmarshal(content, &pkg); err != nil {
+			return fmt.Errorf("decode rerun training package: %w", err)
+		}
+		if pkg.EvaluatorProfile == nil ||
+			pkg.EvaluatorProfile.Judge == nil ||
+			pkg.EvaluatorProfile.Judge.Model != "rerun-evaluator" {
+			return fmt.Errorf("rerun training package evaluator profile = %+v", pkg.EvaluatorProfile)
+		}
+		return nil
+	}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	_, err = continueSkillOptTrainOptimizer(ctx, paths, store, session, iteration, skillOptTrainOptimizerRequest{
+		OutRoot:        request.OutRoot,
+		RerunOptimizer: true,
+		EvaluatorID:    "landing_page_v1",
+		EvaluatorModel: "rerun-evaluator",
+	})
+	if err != nil {
+		t.Fatalf("continueSkillOptTrainOptimizer rerun returned error: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("optimizer calls = %+v, want one", runner.calls)
+	}
+	if argValue(runner.calls[0].args, "--training-package") == firstPaths.TrainingPackagePath {
+		t.Fatalf("rerun reused first training package path: %s", firstPaths.TrainingPackagePath)
 	}
 }
 
@@ -5654,7 +5809,7 @@ func TestSkillOptTrainContinueRejectsCandidateForDifferentSessionTemplate(t *tes
 	if _, err := os.Stat(trainingPackagePath); err != nil {
 		t.Fatalf("expected persisted training package before rerun: %v", err)
 	}
-	secondAttemptRoot := filepath.Join(outRoot, "attempts", "attempt-002")
+	secondAttemptRoot := filepath.Join(filepath.Dir(firstAttemptRoot), "attempt-002")
 	runner.beforeRun = func(dir string, args []string) error {
 		if len(runner.calls) != 2 {
 			return nil

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -330,6 +330,7 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 	if err != nil {
 		return TrainingPackage{}, fmt.Errorf("eval run metadata_json: %w", err)
 	}
+	evaluatorProfile := EvaluatorProfileFromConfig(metadata)
 	return TrainingPackage{
 		Kind:            TrainingPackageKind,
 		ContractVersion: ContractVersion,
@@ -351,7 +352,76 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 		RankedFeedbackEvents: rankedFeedbackEvents,
 		PairwisePreferences:  pairwisePreferences,
 		EvaluatorConfig:      metadata,
+		EvaluatorProfile:     evaluatorProfile,
 	}, nil
+}
+
+func EvaluatorProfileFromConfig(config json.RawMessage) *EvaluatorProfile {
+	var metadata map[string]any
+	if len(bytes.TrimSpace(config)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(config, &metadata); err != nil {
+		return nil
+	}
+	evaluatorID := evaluatorProfileMetadataString(metadata, "evaluator_id")
+	if evaluatorID == "" {
+		evaluatorID = evaluatorProfileMetadataString(metadata, "evaluation", "evaluator_id")
+	}
+	evaluatorModel := evaluatorProfileMetadataString(metadata, "evaluator_model")
+	if evaluatorModel == "" {
+		evaluatorModel = evaluatorProfileMetadataString(metadata, "evaluation", "evaluator_model")
+	}
+	return BuildEvaluatorProfile(evaluatorID, evaluatorModel, config)
+}
+
+func BuildEvaluatorProfile(evaluatorID string, evaluatorModel string, metadata json.RawMessage) *EvaluatorProfile {
+	profileID := strings.TrimSpace(evaluatorID)
+	evaluatorID = strings.ToLower(profileID)
+	if evaluatorID == "" {
+		return nil
+	}
+	judge := &EvaluatorJudgeConfig{Type: "llm_judge", When: "checks_pass"}
+	if model := strings.TrimSpace(evaluatorModel); model != "" {
+		judge.Model = model
+	}
+	switch evaluatorID {
+	case "landing_page_v1", "vue_landing_page_v1":
+		return &EvaluatorProfile{
+			ProfileID:        "landing_page_v1",
+			TaskKind:         "vue_landing_page",
+			ArtifactContract: "vue_vite_bundle",
+			PreviewAdapter:   "vue_vite",
+			Checks: []EvaluatorCheckConfig{
+				{ID: "required_files", Type: "artifact_contract", Required: true},
+				{ID: "render_smoke", Type: "playwright", When: "checks_pass"},
+			},
+			Judge:    judge,
+			Metadata: metadata,
+		}
+	default:
+		return &EvaluatorProfile{
+			ProfileID: profileID,
+			TaskKind:  "generic",
+			Judge:     judge,
+			Metadata:  metadata,
+		}
+	}
+}
+
+func evaluatorProfileMetadataString(metadata map[string]any, path ...string) string {
+	var current any = metadata
+	for _, key := range path {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = object[key]
+	}
+	if value, ok := current.(string); ok {
+		return strings.TrimSpace(value)
+	}
+	return ""
 }
 
 func ImportCandidatePackage(ctx context.Context, store *db.Store, candidate CandidatePackage, sourcePath string) (db.AgentTemplateVersion, error) {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -149,6 +149,63 @@ func TestExportTrainingPackageIncludesPreferredGateMetadata(t *testing.T) {
 	}
 }
 
+func TestExportTrainingPackageBuildsEvaluatorProfileFromMetadata(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("designer", "Design carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "designer")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "train-run-1",
+		TemplateID:        "designer",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		MetadataJSON:      `{"evaluation":{"evaluator_id":"landing_page_v1","evaluator_model":"gpt-evaluator"}}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+
+	pkg, err := ExportTrainingPackage(ctx, store, "train-run-1")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	if pkg.EvaluatorProfile == nil ||
+		pkg.EvaluatorProfile.ProfileID != "landing_page_v1" ||
+		pkg.EvaluatorProfile.TaskKind != "vue_landing_page" ||
+		pkg.EvaluatorProfile.ArtifactContract != "vue_vite_bundle" ||
+		pkg.EvaluatorProfile.PreviewAdapter != "vue_vite" ||
+		pkg.EvaluatorProfile.Judge == nil ||
+		pkg.EvaluatorProfile.Judge.Model != "gpt-evaluator" {
+		t.Fatalf("evaluator profile = %+v", pkg.EvaluatorProfile)
+	}
+}
+
+func TestBuildEvaluatorProfilePreservesCustomEvaluatorID(t *testing.T) {
+	profile := BuildEvaluatorProfile("CustomJudgeV2", "gpt-evaluator", json.RawMessage(`{"kind":"custom"}`))
+	if profile == nil {
+		t.Fatal("BuildEvaluatorProfile returned nil")
+	}
+	if profile.ProfileID != "CustomJudgeV2" {
+		t.Fatalf("ProfileID = %q, want CustomJudgeV2", profile.ProfileID)
+	}
+	if profile.TaskKind != "generic" {
+		t.Fatalf("TaskKind = %q, want generic", profile.TaskKind)
+	}
+	if profile.Judge == nil || profile.Judge.Model != "gpt-evaluator" {
+		t.Fatalf("Judge = %+v", profile.Judge)
+	}
+}
+
 func TestEvaluatorProfileAndFailurePacketContractsRoundTrip(t *testing.T) {
 	hard := 0.0
 	soft := 0.12


### PR DESCRIPTION
## Summary
- export SkillOpt training packages with evaluator_profile derived from eval metadata
- let CLI evaluator flags override the exported package profile for optimizer runs
- refresh rerun training packages per optimizer attempt so evaluator model/profile flags do not go stale
- preserve custom evaluator IDs while normalizing only the known-profile switch key

## Tests
- `/tmp/go1.26.4/bin/go test ./internal/skillopt -run 'TestExportTrainingPackage|TestBuildEvaluatorProfile|TestEvaluatorProfileAndFailurePacketContractsRoundTrip'`\n- `/tmp/go1.26.4/bin/go test ./internal/cli -run 'TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate|TestSkillOptTrainRerunRefreshesEvaluatorProfilePackage|TestSkillOptTrainRerunFromPackageCreatedExportsFreshPackage'`\n- `codex exec review --uncommitted` => clean: no discrete actionable correctness issues\n\nNote: full `go test ./internal/skillopt ./internal/cli` still has pre-existing unrelated internal/cli failures around relative optimizer binary path and deterministic metadata timestamp behavior.