### PR TITLE
fix(skillopt): show no-candidate diagnostics in train status

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -5401,6 +5401,21 @@ func printSkillOptNoCandidateDetails(stdout io.Writer, details map[string]any) {
 	if duplicateRetry := metadataBoolPtr(details, "duplicate_retry_detected"); duplicateRetry != nil {
 		writeLine(stdout, "duplicate_retry_detected: %t", *duplicateRetry)
 	}
+	if diagnosticCategories := metadataStringSlice(details, "diagnostic_categories"); len(diagnosticCategories) > 0 {
+		writeLine(stdout, "diagnostic_categories: %s", strings.Join(diagnosticCategories, ","))
+	}
+	if selectionGateRelation := metadataString(details, "selection_gate_relation"); selectionGateRelation != "" {
+		writeLine(stdout, "selection_gate_relation: %s", selectionGateRelation)
+	}
+	if retryBudgetExhausted := metadataBoolPtr(details, "retry_budget_exhausted"); retryBudgetExhausted != nil {
+		writeLine(stdout, "retry_budget_exhausted: %t", *retryBudgetExhausted)
+	}
+	if retryStopReasons := metadataStringSlice(details, "retry_stop_reasons"); len(retryStopReasons) > 0 {
+		writeLine(stdout, "retry_stop_reasons: %s", strings.Join(retryStopReasons, ","))
+	}
+	if stopReason := metadataString(details, "stop_reason"); stopReason != "" {
+		writeLine(stdout, "stop_reason: %s", stopReason)
+	}
 	if evaluatorReason := metadataString(details, "evaluator_reason"); evaluatorReason != "" {
 		writeLine(stdout, "evaluator_reason: %s", evaluatorReason)
 	}
@@ -5409,6 +5424,9 @@ func printSkillOptNoCandidateDetails(stdout io.Writer, details map[string]any) {
 	}
 	if failedDimensions := metadataStringSlice(details, "failed_dimensions"); len(failedDimensions) > 0 {
 		writeLine(stdout, "failed_dimensions: %s", strings.Join(failedDimensions, ","))
+	}
+	if feedbackThemes := metadataStringSlice(details, "feedback_themes"); len(feedbackThemes) > 0 {
+		writeLine(stdout, "feedback_themes: %s", strings.Join(feedbackThemes, "; "))
 	}
 	printSkillOptHumanFeedbackContext(stdout, decodedSkillOptMetadataValue(details["human_feedback_context"]))
 	nextActions := metadataStringSlice(details, "next_actions")
@@ -6830,6 +6848,7 @@ func skillOptNoCandidatePackageMetadata(candidatePackagePath string) (string, st
 		if len(details) == 0 {
 			details = decodedSkillOptMetadataValue(source["no_candidate_details"])
 		}
+		details = skillOptNoCandidateDetailsWithDiagnostics(details, source)
 	}
 	for _, gateRejection := range []map[string]any{
 		decodedSkillOptMetadataValue(summary["gate_rejection"]),
@@ -6851,11 +6870,66 @@ func skillOptNoCandidatePackageMetadata(candidatePackagePath string) (string, st
 		if len(details) == 0 {
 			details = skillOptNoCandidateDetailsFromGateRejection(gateRejection)
 		}
+		details = skillOptNoCandidateDetailsWithDiagnostics(details, gateRejection)
 	}
 	if reason == "" {
 		return "", "", nil
 	}
 	return reason, nextAction, details
+}
+
+func skillOptNoCandidateDetailsWithDiagnostics(details map[string]any, source map[string]any) map[string]any {
+	if len(source) == 0 {
+		return details
+	}
+	diagnostics := decodedSkillOptMetadataValue(source["no_candidate_diagnostics"])
+	if len(diagnostics) == 0 {
+		diagnostics = decodedSkillOptMetadataValue(source["diagnostics"])
+	}
+	if len(diagnostics) == 0 {
+		diagnostics = map[string]any{}
+	}
+	if categories := metadataStringSlice(source, "diagnostic_categories"); len(categories) > 0 && len(metadataStringSlice(diagnostics, "categories")) == 0 {
+		diagnostics["categories"] = categories
+	}
+	for _, key := range []string{"selection_gate_relation", "stop_reason"} {
+		if value := metadataString(source, key); value != "" && metadataString(diagnostics, key) == "" {
+			diagnostics[key] = value
+		}
+	}
+	if value := metadataBoolPtr(source, "retry_budget_exhausted"); value != nil && metadataBoolPtr(diagnostics, "retry_budget_exhausted") == nil {
+		diagnostics["retry_budget_exhausted"] = *value
+	}
+	if stopReasons := metadataStringSlice(source, "retry_stop_reasons"); len(stopReasons) > 0 && len(metadataStringSlice(diagnostics, "retry_stop_reasons")) == 0 {
+		diagnostics["retry_stop_reasons"] = stopReasons
+	}
+	if len(diagnostics) == 0 && len(metadataStringSlice(source, "feedback_themes")) == 0 {
+		return details
+	}
+	if details == nil {
+		details = map[string]any{}
+	}
+	if len(diagnostics) > 0 {
+		details["diagnostics"] = diagnostics
+		if categories := metadataStringSlice(diagnostics, "categories"); len(categories) > 0 {
+			details["diagnostic_categories"] = categories
+		}
+		for _, key := range []string{"selection_gate_relation", "stop_reason"} {
+			if value := metadataString(diagnostics, key); value != "" {
+				details[key] = value
+			}
+		}
+		if value := metadataBoolPtr(diagnostics, "retry_budget_exhausted"); value != nil {
+			details["retry_budget_exhausted"] = *value
+		}
+		if stopReasons := metadataStringSlice(diagnostics, "retry_stop_reasons"); len(stopReasons) > 0 {
+			details["retry_stop_reasons"] = stopReasons
+		}
+	}
+	if themes := metadataStringSlice(source, "feedback_themes"); len(themes) > 0 {
+		details["feedback_themes"] = themes
+	}
+	return details
 }
 
 func skillOptNoCandidateDetailsFromGateRejection(gateRejection map[string]any) map[string]any {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -3237,6 +3237,16 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 			"candidate_gate": 0.84,
 			"retry_attempts": "1/1",
 			"duplicate_retry_detected": true,
+			"diagnostic_categories": [
+				"old_review_training_signal",
+				"candidate_feedback_unresolved",
+				"retry_budget_exhausted"
+			],
+			"selection_gate_relation": "candidate_below_baseline",
+			"retry_budget_exhausted": true,
+			"retry_stop_reasons": ["budget_exhausted"],
+			"stop_reason": "budget_exhausted",
+			"feedback_themes": ["MoonAI-style premium branding", "scroll animations"],
 			"evaluator_reason": "Candidate was valid but had weaker imagery.",
 			"optimizer_hint": "Resolve imported review themes and artifact contract.",
 			"failed_dimensions": ["human_feedback_alignment", "artifact_contract"],
@@ -3356,6 +3366,8 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		statusJSON.NoCandidateReason != "gate_rejected_best_origin_initial_skill" ||
 		statusJSON.NoCandidateDetails["attempted_patch"] != "artifact delivery only" ||
 		statusJSON.NoCandidateDetails["duplicate_retry_detected"] != true ||
+		statusJSON.NoCandidateDetails["selection_gate_relation"] != "candidate_below_baseline" ||
+		statusJSON.NoCandidateDetails["retry_budget_exhausted"] != true ||
 		statusJSON.NoCandidateDetails["optimizer_hint"] != "Resolve imported review themes and artifact contract." ||
 		statusJSON.NoCandidateDetails["human_feedback_context"] == nil ||
 		statusJSON.Verbose == nil ||
@@ -3380,9 +3392,15 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		"candidate_gate: 0.84",
 		"retry_attempts: 1/1",
 		"duplicate_retry_detected: true",
+		"diagnostic_categories: old_review_training_signal,candidate_feedback_unresolved,retry_budget_exhausted",
+		"selection_gate_relation: candidate_below_baseline",
+		"retry_budget_exhausted: true",
+		"retry_stop_reasons: budget_exhausted",
+		"stop_reason: budget_exhausted",
 		"evaluator_reason: Candidate was valid but had weaker imagery.",
 		"optimizer_hint: Resolve imported review themes and artifact contract.",
 		"failed_dimensions: human_feedback_alignment,artifact_contract",
+		"feedback_themes: MoonAI-style premium branding; scroll animations",
 		"human_feedback_source_item_ids: item-001",
 		"human_feedback_rankings: D > B > C > A",
 		"human_feedback_preserve: D: clean hero",
@@ -3411,6 +3429,52 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		!strings.Contains(stdout.String(), "started_iteration: optimizer-train-002") ||
 		!strings.Contains(stdout.String(), "base_version: "+baseVersionID) {
 		t.Fatalf("start-next after no-candidate stdout = %s", stdout.String())
+	}
+}
+
+func TestSkillOptNoCandidatePackageMetadataPreservesTopLevelDiagnostics(t *testing.T) {
+	candidate := cliSkillOptCandidatePackage(t, "planner", "planner@v1", "Plan the work.")
+	candidate.EvalReport = json.RawMessage(`{
+		"promotable": false,
+		"no_candidate_reason": "no_meaningful_skill_change",
+		"next_action": "Do not import or publish a candidate review; continue training with revised feedback or stop the run.",
+		"no_candidate_diagnostics": {
+			"categories": ["retry_budget_exhausted", "candidate_content_unchanged"],
+			"selection_gate_relation": "unknown",
+			"retry_budget_exhausted": true,
+			"retry_stop_reasons": ["noop_retry_budget_exhausted"]
+		},
+		"feedback_themes": ["better mobile layout", "stronger product visuals"]
+	}`)
+	candidate.Summary.Metadata = json.RawMessage(`{
+		"promotable": false,
+		"no_candidate_reason": "no_meaningful_skill_change"
+	}`)
+	path := filepath.Join(t.TempDir(), "candidate.json")
+	encoded, err := json.Marshal(candidate)
+	if err != nil {
+		t.Fatalf("marshal candidate: %v", err)
+	}
+	if err := os.WriteFile(path, encoded, 0o644); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+
+	reason, nextAction, details := skillOptNoCandidatePackageMetadata(path)
+	if reason != "no_meaningful_skill_change" ||
+		!strings.Contains(nextAction, "continue training") ||
+		metadataBoolPtr(details, "retry_budget_exhausted") == nil ||
+		!*metadataBoolPtr(details, "retry_budget_exhausted") ||
+		metadataString(details, "selection_gate_relation") != "unknown" {
+		t.Fatalf("metadata = reason=%q next=%q details=%+v", reason, nextAction, details)
+	}
+	if got := metadataStringSlice(details, "diagnostic_categories"); strings.Join(got, ",") != "retry_budget_exhausted,candidate_content_unchanged" {
+		t.Fatalf("diagnostic categories = %v", got)
+	}
+	if got := metadataStringSlice(details, "retry_stop_reasons"); strings.Join(got, ",") != "noop_retry_budget_exhausted" {
+		t.Fatalf("retry stop reasons = %v", got)
+	}
+	if got := metadataStringSlice(details, "feedback_themes"); strings.Join(got, "; ") != "better mobile layout; stronger product visuals" {
+		t.Fatalf("feedback themes = %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve top-level `no_candidate_diagnostics` from candidate packages in Gitmoot no-candidate status metadata
- print diagnostic categories, gate relation, retry exhaustion, stop reasons, and feedback themes in `skillopt train status`
- add regression coverage for nested gate diagnostics and top-level no-op diagnostics

## Verification
- `GOTOOLCHAIN=local /root/temp/ts/tool/go test ./internal/cli ./internal/skillopt -run 'TestSkillOptTrainContinueRecordsNoCandidateResult|TestSkillOptNoCandidatePackageMetadataPreservesTopLevelDiagnostics|TestImportCandidatePackageRejectsNoCandidateMetadata'` -> passed\n- `GO_BIN=/root/temp/ts/tool/go GOTOOLCHAIN=local scripts/skillopt-train-smoke.sh` -> passed\n- `git diff --check` -> passed\n- `TMPDIR=/root/tmp TEMP=/root/tmp TMP=/root/tmp codex exec review --uncommitted 2>&1` -> The changes consistently surface additional no-candidate diagnostics in stored status details and human-readable output. I did not identify a discrete regression in the modified paths.\n\nNote: `/usr/bin/go` attempted to download `go1.26` and failed because that toolchain is unavailable from the environment. Verification used the local Go 1.26.2 wrapper at `/root/temp/ts/tool/go`.