### PR TITLE
Add SkillOpt feedback target metadata

### DIFF
--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -223,6 +224,7 @@ type TrainingPackage struct {
 	FeedbackEvents       []FeedbackEvent       `json:"feedback_events"`
 	RankedFeedbackEvents []RankedFeedbackEvent `json:"ranked_feedback_events,omitempty"`
 	PairwisePreferences  []PairwisePreference  `json:"pairwise_preferences,omitempty"`
+	FeedbackContext      json.RawMessage       `json:"feedback_context,omitempty"`
 	EvaluatorConfig      json.RawMessage       `json:"evaluator_config,omitempty"`
 	EvaluatorProfile     *EvaluatorProfile     `json:"evaluator_profile,omitempty"`
 }
@@ -327,6 +329,10 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 	if err != nil {
 		return TrainingPackage{}, err
 	}
+	feedbackContext, err := buildTrainingFeedbackContext(run, feedbackEvents, rankedFeedbackEvents)
+	if err != nil {
+		return TrainingPackage{}, err
+	}
 	metadata, err := rawJSON(run.MetadataJSON)
 	if err != nil {
 		return TrainingPackage{}, fmt.Errorf("eval run metadata_json: %w", err)
@@ -352,9 +358,73 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 		FeedbackEvents:       feedbackEvents,
 		RankedFeedbackEvents: rankedFeedbackEvents,
 		PairwisePreferences:  pairwisePreferences,
+		FeedbackContext:      feedbackContext,
 		EvaluatorConfig:      metadata,
 		EvaluatorProfile:     evaluatorProfile,
 	}, nil
+}
+
+func buildTrainingFeedbackContext(run db.EvalRun, feedback []FeedbackEvent, ranked []RankedFeedbackEvent) (json.RawMessage, error) {
+	if len(feedback) == 0 && len(ranked) == 0 {
+		return nil, nil
+	}
+	context := map[string]any{
+		"feedback_source":        "imported_human_review",
+		"feedback_target":        "baseline_review_outputs",
+		"review_run_id":          run.ID,
+		"reviewed_skill_version": run.TemplateVersionID,
+	}
+	if issue := reviewIssueFromFeedback(feedback, ranked); issue != "" {
+		context["review_issue"] = issue
+	}
+	if run.TargetRepo != "" {
+		context["target_repo"] = run.TargetRepo
+	}
+	raw, err := json.Marshal(context)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func reviewIssueFromFeedback(feedback []FeedbackEvent, ranked []RankedFeedbackEvent) string {
+	for _, event := range ranked {
+		if issue := reviewIssueFromSourceURL(event.SourceURL); issue != "" {
+			return issue
+		}
+	}
+	for _, event := range feedback {
+		if issue := reviewIssueFromSourceURL(event.SourceURL); issue != "" {
+			return issue
+		}
+	}
+	return ""
+}
+
+func reviewIssueFromSourceURL(sourceURL string) string {
+	value := strings.TrimSpace(sourceURL)
+	if value == "" {
+		return ""
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return ""
+	}
+	host := strings.TrimSpace(parsed.Host)
+	if host != "github.com" && !strings.HasSuffix(host, ".github.com") {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) < 4 || (parts[2] != "issues" && parts[2] != "pull") {
+		return ""
+	}
+	owner := strings.TrimSpace(parts[0])
+	repo := strings.TrimSpace(parts[1])
+	number := strings.TrimSpace(parts[3])
+	if owner == "" || repo == "" || number == "" {
+		return ""
+	}
+	return owner + "/" + repo + "#" + number
 }
 
 func EvaluatorProfileFromConfig(config json.RawMessage) *EvaluatorProfile {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -527,8 +527,31 @@ func TestExportTrainingPackageIncludesRankedExplorationFeedback(t *testing.T) {
 	if len(pkg.PairwisePreferences) != 6 || pkg.PairwisePreferences[0].Preferred != "c" || pkg.PairwisePreferences[5].Rejected != "b" || pkg.PairwisePreferences[0].RankedEventID != pkg.RankedFeedbackEvents[0].ID {
 		t.Fatalf("pairwise preferences = %+v", pkg.PairwisePreferences)
 	}
+	var feedbackContext map[string]any
+	if err := json.Unmarshal(pkg.FeedbackContext, &feedbackContext); err != nil {
+		t.Fatalf("feedback context did not unmarshal: %v", err)
+	}
+	if feedbackContext["feedback_source"] != "imported_human_review" || feedbackContext["feedback_target"] != "baseline_review_outputs" {
+		t.Fatalf("feedback context source/target = %+v", feedbackContext)
+	}
+	if feedbackContext["review_issue"] != "owner/repo#1" || feedbackContext["review_run_id"] != "ranked-1" || feedbackContext["reviewed_skill_version"] != installed.VersionID {
+		t.Fatalf("feedback context review metadata = %+v", feedbackContext)
+	}
 	if _, err := json.Marshal(pkg); err != nil {
 		t.Fatalf("exported ranked package did not marshal: %v", err)
+	}
+}
+
+func TestReviewIssueFromSourceURLSupportsIssueAndPullTargets(t *testing.T) {
+	tests := map[string]string{
+		"https://github.com/owner/repo/issues/1#issuecomment-1": "owner/repo#1",
+		"https://github.com/owner/repo/pull/2#issuecomment-2":   "owner/repo#2",
+		"https://example.com/owner/repo/issues/3":               "",
+	}
+	for sourceURL, want := range tests {
+		if got := reviewIssueFromSourceURL(sourceURL); got != want {
+			t.Fatalf("reviewIssueFromSourceURL(%q) = %q, want %q", sourceURL, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## WHAT

Adds optional `feedback_context` metadata to exported SkillOpt training packages.

## WHY

Issue #150 needs imported human review feedback to be represented as feedback about the reviewed baseline outputs, not as a direct judgment of an unseen optimizer candidate.

## CHANGES

- Adds optional top-level `feedback_context` to `TrainingPackage`.
- Populates:
  - `feedback_source: imported_human_review`
  - `feedback_target: baseline_review_outputs`
  - `review_run_id`
  - `reviewed_skill_version`
  - `review_issue` when derivable from GitHub issue or PR comment URLs
  - `target_repo`
- Adds regression coverage for ranked feedback export metadata.
- Adds direct URL parsing coverage for both `/issues/<n>` and `/pull/<n>` feedback URLs.

## RESULTS

- `gofmt -w internal/skillopt/contract.go internal/skillopt/contract_test.go`
- `git diff --check`
- `codex exec review --uncommitted`

Final raw review output:

```text
No actionable bugs were found in the current changes. The added feedback context is optional, preserves existing package consumers, and derives review metadata without disrupting existing export paths.
```

Skipped:

```text
GOTOOLCHAIN=local go test ./internal/skillopt
```

This environment has Go 1.22.2, while `go.mod` requires Go >= 1.26:

```text
go: go.mod requires go >= 1.26 (running go 1.22.2; GOTOOLCHAIN=local)
```

The default toolchain download also failed because Go 1.26 was unavailable in this environment.

## RISK

Low. The new field is optional and only populated during training package export when feedback exists. Older consumers can ignore it.