### PR TITLE
Show SkillOpt feedback target diagnostics

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -5386,17 +5386,38 @@ func printSkillOptNoCandidateDetails(stdout io.Writer, details map[string]any) {
 	if len(details) == 0 {
 		return
 	}
+	for _, key := range []string{
+		"feedback_source",
+		"feedback_target",
+		"review_issue",
+		"review_run_id",
+		"reviewed_skill_version",
+		"score_basis",
+	} {
+		if value := metadataString(details, key); value != "" {
+			writeLine(stdout, "%s: %s", key, value)
+		}
+	}
 	if attemptedPatch := metadataString(details, "attempted_patch"); attemptedPatch != "" {
 		writeLine(stdout, "attempted_patch: %s", attemptedPatch)
 	}
-	if baselineGate := metadataString(details, "baseline_gate"); baselineGate != "" {
-		writeLine(stdout, "baseline_gate: %s", baselineGate)
-	}
-	if candidateGate := metadataString(details, "candidate_gate"); candidateGate != "" {
-		writeLine(stdout, "candidate_gate: %s", candidateGate)
+	for _, key := range []string{
+		"baseline_hard",
+		"baseline_soft",
+		"baseline_gate",
+		"candidate_hard",
+		"candidate_soft",
+		"candidate_gate",
+	} {
+		if value := metadataString(details, key); value != "" {
+			writeLine(stdout, "%s: %s", key, value)
+		}
 	}
 	if retryAttempts := metadataString(details, "retry_attempts"); retryAttempts != "" {
 		writeLine(stdout, "retry_attempts: %s", retryAttempts)
+	}
+	if retryBudget := metadataString(details, "retry_budget"); retryBudget != "" {
+		writeLine(stdout, "retry_budget: %s", retryBudget)
 	}
 	if duplicateRetry := metadataBoolPtr(details, "duplicate_retry_detected"); duplicateRetry != nil {
 		writeLine(stdout, "duplicate_retry_detected: %t", *duplicateRetry)
@@ -5458,9 +5479,23 @@ func printSkillOptHumanFeedbackContext(stdout io.Writer, context map[string]any)
 	if len(context) == 0 {
 		return
 	}
-	for _, key := range []string{"source_item_ids", "rankings", "preserve", "improve", "avoid"} {
+	for _, key := range []string{
+		"feedback_source",
+		"feedback_target",
+		"review_issue",
+		"review_run_id",
+		"reviewed_skill_version",
+		"source_item_ids",
+		"rankings",
+		"themes",
+		"preserve",
+		"improve",
+		"avoid",
+	} {
 		if values := metadataStringSlice(context, key); len(values) > 0 {
 			writeLine(stdout, "human_feedback_%s: %s", key, strings.Join(values, "; "))
+		} else if value := metadataString(context, key); value != "" {
+			writeLine(stdout, "human_feedback_%s: %s", key, value)
 		}
 	}
 }
@@ -6880,7 +6915,7 @@ func skillOptNoCandidatePackageMetadata(candidatePackagePath string) (string, st
 
 func skillOptNoCandidateDetailsWithDiagnostics(details map[string]any, source map[string]any) map[string]any {
 	if len(source) == 0 {
-		return details
+		return skillOptNoCandidateDetailsWithFeedbackContext(details, nil)
 	}
 	diagnostics := decodedSkillOptMetadataValue(source["no_candidate_diagnostics"])
 	if len(diagnostics) == 0 {
@@ -6904,7 +6939,7 @@ func skillOptNoCandidateDetailsWithDiagnostics(details map[string]any, source ma
 		diagnostics["retry_stop_reasons"] = stopReasons
 	}
 	if len(diagnostics) == 0 && len(metadataStringSlice(source, "feedback_themes")) == 0 {
-		return details
+		return skillOptNoCandidateDetailsWithFeedbackContext(details, source)
 	}
 	if details == nil {
 		details = map[string]any{}
@@ -6929,7 +6964,10 @@ func skillOptNoCandidateDetailsWithDiagnostics(details map[string]any, source ma
 	if themes := metadataStringSlice(source, "feedback_themes"); len(themes) > 0 {
 		details["feedback_themes"] = themes
 	}
-	return details
+	if retryBudget := skillOptRetryBudgetFromAttempts(metadataString(details, "retry_attempts")); retryBudget != "" && metadataString(details, "retry_budget") == "" {
+		details["retry_budget"] = retryBudget
+	}
+	return skillOptNoCandidateDetailsWithFeedbackContext(details, source)
 }
 
 func skillOptNoCandidateDetailsFromGateRejection(gateRejection map[string]any) map[string]any {
@@ -6950,6 +6988,9 @@ func skillOptNoCandidateDetailsFromGateRejection(gateRejection map[string]any) m
 		details["next_action"] = nextActions[0]
 		details["next_actions"] = nextActions
 	}
+	if retryBudget := skillOptRetryBudgetFromAttempts(metadataString(gateRejection, "retry_attempts")); retryBudget != "" {
+		details["retry_budget"] = retryBudget
+	}
 	if value := metadataBoolPtr(gateRejection, "duplicate_retry_detected"); value != nil {
 		details["duplicate_retry_detected"] = *value
 	}
@@ -6959,6 +7000,12 @@ func skillOptNoCandidateDetailsFromGateRejection(gateRejection map[string]any) m
 			rejection[key] = value
 			if gateScore := metadataString(value, "gate_score"); gateScore != "" {
 				details[key+"_gate"] = gateScore
+			}
+			if hard := metadataString(value, "hard"); hard != "" {
+				details[key+"_hard"] = hard
+			}
+			if soft := metadataString(value, "soft"); soft != "" {
+				details[key+"_soft"] = soft
 			}
 		}
 	}
@@ -6983,10 +7030,52 @@ func skillOptNoCandidateDetailsFromGateRejection(gateRejection map[string]any) m
 	}
 	if humanFeedbackContext := decodedSkillOptMetadataValue(gateRejection["human_feedback_context"]); len(humanFeedbackContext) > 0 {
 		rejection["human_feedback_context"] = humanFeedbackContext
-		details["human_feedback_context"] = humanFeedbackContext
 	}
 	if len(rejection) > 0 {
 		details["rejection"] = rejection
+	}
+	return skillOptNoCandidateDetailsWithFeedbackContext(details, gateRejection)
+}
+
+func skillOptRetryBudgetFromAttempts(retryAttempts string) string {
+	retryAttempts = strings.TrimSpace(retryAttempts)
+	if retryAttempts == "" {
+		return ""
+	}
+	parts := strings.Split(retryAttempts, "/")
+	if len(parts) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+func skillOptNoCandidateDetailsWithFeedbackContext(details map[string]any, source map[string]any) map[string]any {
+	context := decodedSkillOptMetadataValue(nil)
+	if len(details) > 0 {
+		context = decodedSkillOptMetadataValue(details["human_feedback_context"])
+	}
+	if len(context) == 0 && len(source) > 0 {
+		context = decodedSkillOptMetadataValue(source["human_feedback_context"])
+	}
+	if len(context) == 0 {
+		return details
+	}
+	if details == nil {
+		details = map[string]any{}
+	}
+	details["human_feedback_context"] = context
+	for _, key := range []string{"feedback_source", "feedback_target", "review_issue", "review_run_id", "reviewed_skill_version"} {
+		if value := metadataString(context, key); value != "" && metadataString(details, key) == "" {
+			details[key] = value
+		}
+	}
+	if metadataString(details, "score_basis") == "" && strings.EqualFold(metadataString(context, "feedback_target"), "baseline_review_outputs") {
+		details["score_basis"] = "feedback_resolution"
+	}
+	if len(metadataStringSlice(details, "feedback_themes")) == 0 {
+		if themes := metadataStringSlice(context, "themes"); len(themes) > 0 {
+			details["feedback_themes"] = themes
+		}
 	}
 	return details
 }

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -3252,8 +3252,14 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 			"optimizer_hint": "Resolve imported review themes and artifact contract.",
 			"failed_dimensions": ["human_feedback_alignment", "artifact_contract"],
 			"human_feedback_context": {
+				"feedback_source": "imported_human_review",
+				"feedback_target": "baseline_review_outputs",
+				"review_issue": "jerryfane/gitmoot-previews#21",
+				"review_run_id": "landing-page-preview-trial-005-review-004",
+				"reviewed_skill_version": "landing-page-builder@v10",
 				"source_item_ids": ["item-001"],
 				"rankings": ["D > B > C > A"],
+				"themes": ["MoonAI-style premium branding", "scroll animations"],
 				"preserve": ["D: clean hero"],
 				"improve": ["MoonAI-style premium branding", "scroll animations"],
 				"avoid": ["C: overlapping text"]
@@ -3273,8 +3279,14 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 	baselineGateScore := 0.89
 	candidateGateScore := 0.84
 	humanFeedbackContext := json.RawMessage(`{
+		"feedback_source": "imported_human_review",
+		"feedback_target": "baseline_review_outputs",
+		"review_issue": "jerryfane/gitmoot-previews#21",
+		"review_run_id": "landing-page-preview-trial-005-review-004",
+		"reviewed_skill_version": "landing-page-builder@v10",
 		"source_item_ids": ["item-001"],
 		"rankings": ["D > B > C > A"],
+		"themes": ["MoonAI-style premium branding", "scroll animations"],
 		"preserve": ["D: clean hero"],
 		"improve": ["MoonAI-style premium branding", "scroll animations"],
 		"avoid": ["C: overlapping text"]
@@ -3340,6 +3352,9 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 	if !strings.Contains(iteration.MetadataJSON, `"status":"no_candidate"`) ||
 		!strings.Contains(iteration.MetadataJSON, `"no_candidate_reason":"gate_rejected_best_origin_initial_skill"`) ||
 		!strings.Contains(iteration.MetadataJSON, `"attempted_patch":"artifact delivery only"`) ||
+		!strings.Contains(iteration.MetadataJSON, `"feedback_target":"baseline_review_outputs"`) ||
+		!strings.Contains(iteration.MetadataJSON, `"score_basis":"feedback_resolution"`) ||
+		!strings.Contains(iteration.MetadataJSON, `"retry_budget":"1"`) ||
 		!strings.Contains(iteration.MetadataJSON, `"duplicate_retry_detected":true`) ||
 		!strings.Contains(iteration.MetadataJSON, `"evaluator_reason":"Candidate was valid but had weaker imagery."`) ||
 		!strings.Contains(iteration.MetadataJSON, `"optimizer_hint":"Resolve imported review themes and artifact contract."`) ||
@@ -3366,6 +3381,9 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 	if statusJSON.StatusPhase != "optimizer_completed_no_candidate" ||
 		statusJSON.NoCandidateReason != "gate_rejected_best_origin_initial_skill" ||
 		statusJSON.NoCandidateDetails["attempted_patch"] != "artifact delivery only" ||
+		statusJSON.NoCandidateDetails["feedback_target"] != "baseline_review_outputs" ||
+		statusJSON.NoCandidateDetails["score_basis"] != "feedback_resolution" ||
+		statusJSON.NoCandidateDetails["retry_budget"] != "1" ||
 		statusJSON.NoCandidateDetails["duplicate_retry_detected"] != true ||
 		statusJSON.NoCandidateDetails["selection_gate_relation"] != "candidate_below_baseline" ||
 		statusJSON.NoCandidateDetails["retry_budget_exhausted"] != true ||
@@ -3388,10 +3406,17 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		"optimizer_attempt: attempt-001",
 		"optimizer_attempt_state: completed_no_candidate",
 		"optimizer_attempt_path: " + filepath.Join(outRoot, "attempts", "attempt-001"),
+		"feedback_source: imported_human_review",
+		"feedback_target: baseline_review_outputs",
+		"review_issue: jerryfane/gitmoot-previews#21",
+		"review_run_id: landing-page-preview-trial-005-review-004",
+		"reviewed_skill_version: landing-page-builder@v10",
+		"score_basis: feedback_resolution",
 		"attempted_patch: artifact delivery only",
 		"baseline_gate: 0.89",
 		"candidate_gate: 0.84",
 		"retry_attempts: 1/1",
+		"retry_budget: 1",
 		"duplicate_retry_detected: true",
 		"diagnostic_categories: old_review_training_signal,candidate_feedback_unresolved,retry_budget_exhausted",
 		"selection_gate_relation: candidate_below_baseline",
@@ -3402,8 +3427,14 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		"optimizer_hint: Resolve imported review themes and artifact contract.",
 		"failed_dimensions: human_feedback_alignment,artifact_contract",
 		"feedback_themes: MoonAI-style premium branding; scroll animations",
+		"human_feedback_feedback_source: imported_human_review",
+		"human_feedback_feedback_target: baseline_review_outputs",
+		"human_feedback_review_issue: jerryfane/gitmoot-previews#21",
+		"human_feedback_review_run_id: landing-page-preview-trial-005-review-004",
+		"human_feedback_reviewed_skill_version: landing-page-builder@v10",
 		"human_feedback_source_item_ids: item-001",
 		"human_feedback_rankings: D > B > C > A",
+		"human_feedback_themes: MoonAI-style premium branding; scroll animations",
 		"human_feedback_preserve: D: clean hero",
 		"human_feedback_improve: MoonAI-style premium branding; scroll animations",
 		"human_feedback_avoid: C: overlapping text",
@@ -3475,6 +3506,41 @@ func TestSkillOptNoCandidatePackageMetadataPreservesTopLevelDiagnostics(t *testi
 		t.Fatalf("retry stop reasons = %v", got)
 	}
 	if got := metadataStringSlice(details, "feedback_themes"); strings.Join(got, "; ") != "better mobile layout; stronger product visuals" {
+		t.Fatalf("feedback themes = %v", got)
+	}
+}
+
+func TestSkillOptNoCandidatePackageMetadataPreservesFeedbackContextWithoutDiagnostics(t *testing.T) {
+	candidate := cliSkillOptCandidatePackage(t, "planner", "planner@v1", "Plan the work.")
+	candidate.EvalReport = json.RawMessage(`{
+		"promotable": false,
+		"no_candidate_reason": "gate_rejected_best_origin_initial_skill",
+		"human_feedback_context": {
+			"feedback_source": "imported_human_review",
+			"feedback_target": "baseline_review_outputs",
+			"review_issue": "jerryfane/gitmoot-previews#21",
+			"themes": ["better mobile layout"]
+		}
+	}`)
+	path := filepath.Join(t.TempDir(), "candidate.json")
+	encoded, err := json.Marshal(candidate)
+	if err != nil {
+		t.Fatalf("marshal candidate: %v", err)
+	}
+	if err := os.WriteFile(path, encoded, 0o644); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+
+	reason, _, details := skillOptNoCandidatePackageMetadata(path)
+	if reason != "gate_rejected_best_origin_initial_skill" {
+		t.Fatalf("reason = %q", reason)
+	}
+	if metadataString(details, "feedback_target") != "baseline_review_outputs" ||
+		metadataString(details, "score_basis") != "feedback_resolution" ||
+		metadataString(details, "review_issue") != "jerryfane/gitmoot-previews#21" {
+		t.Fatalf("feedback context details = %+v", details)
+	}
+	if got := metadataStringSlice(details, "feedback_themes"); strings.Join(got, "; ") != "better mobile layout" {
 		t.Fatalf("feedback themes = %v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- surface imported human feedback source/target, review issue/run, reviewed skill version, and score basis in no-candidate status output
- show baseline/candidate hard, soft, and gate score components plus retry budget
- preserve context-only human feedback metadata even when no diagnostics block exists

## Verification
- git diff --check
- codex exec review --uncommitted
- go test ./internal/cli -run 'TestSkillOpt(NoCandidatePackageMetadataPreservesFeedbackContextWithoutDiagnostics|NoCandidatePackageMetadataPreservesTopLevelDiagnostics|TrainContinueRecordsNoCandidateResult)' *(blocked: go.mod requires Go 1.26; local toolchain download unavailable)*