### PR TITLE
skillopt: separate training mode from evaluator config

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -28,6 +28,8 @@ The exported package has:
 
 - `kind: gitmoot-skillopt-training-package`
 - `contract_version: 1`
+- `training_mode`: the Gitmoot training/review workflow mode, such as
+  `explore`, `refine`, `distill`, or `validate`
 - `template`: the logical template id, current or pinned version id, content
   hash, metadata, source, and exact template content
 - `eval_run`: run id, target repo, state, mode, exploration level, option
@@ -42,7 +44,10 @@ The exported package has:
   reasoning
 - `pairwise_preferences`: derived pairwise preferences expanded from ranked
   feedback, for example `C > A > D > B` becomes six ordered preferences
-- `evaluator_config`: the run metadata used by the external optimizer
+- `evaluator_config`: evaluator and run metadata used by the external
+  optimizer. Top-level workflow mode is exported as `training_mode`, not as
+  `evaluator_config.mode`; `evaluator_config.mode` is reserved for evaluator
+  implementation ids or drivers.
 
 Artifact package entries reference local SHA256 blobs stored under Gitmoot home.
 The export does not copy blobs into the repository by default.

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -217,6 +217,7 @@ type PairwisePreference struct {
 type TrainingPackage struct {
 	Kind                 string                `json:"kind"`
 	ContractVersion      int                   `json:"contract_version"`
+	TrainingMode         string                `json:"training_mode,omitempty"`
 	Template             TemplateSnapshot      `json:"template"`
 	EvalRun              EvalRun               `json:"eval_run"`
 	Items                []EvalItem            `json:"items"`
@@ -337,10 +338,15 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 	if err != nil {
 		return TrainingPackage{}, fmt.Errorf("eval run metadata_json: %w", err)
 	}
-	evaluatorProfile := EvaluatorProfileFromConfig(metadata)
+	evaluatorConfig, err := evaluatorConfigFromRunMetadata(metadata)
+	if err != nil {
+		return TrainingPackage{}, fmt.Errorf("eval run evaluator_config: %w", err)
+	}
+	evaluatorProfile := EvaluatorProfileFromConfig(evaluatorConfig)
 	return TrainingPackage{
 		Kind:            TrainingPackageKind,
 		ContractVersion: ContractVersion,
+		TrainingMode:    run.Mode,
 		Template:        snapshot,
 		EvalRun: EvalRun{
 			ID:                run.ID,
@@ -359,9 +365,43 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 		RankedFeedbackEvents: rankedFeedbackEvents,
 		PairwisePreferences:  pairwisePreferences,
 		FeedbackContext:      feedbackContext,
-		EvaluatorConfig:      metadata,
+		EvaluatorConfig:      evaluatorConfig,
 		EvaluatorProfile:     evaluatorProfile,
 	}, nil
+}
+
+func evaluatorConfigFromRunMetadata(metadata json.RawMessage) (json.RawMessage, error) {
+	metadata = bytes.TrimSpace(metadata)
+	if len(metadata) == 0 {
+		return nil, nil
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(metadata, &decoded); err != nil {
+		return nil, err
+	}
+	if rawMode, ok := decoded["mode"]; ok {
+		var mode string
+		if err := json.Unmarshal(rawMode, &mode); err == nil && isTrainingMode(mode) {
+			delete(decoded, "mode")
+		}
+	}
+	if len(decoded) == 0 {
+		return nil, nil
+	}
+	raw, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func isTrainingMode(value string) bool {
+	switch strings.TrimSpace(value) {
+	case db.EvalRunModeExplore, db.EvalRunModeRefine, db.EvalRunModeDistill, db.EvalRunModeValidate:
+		return true
+	default:
+		return false
+	}
 }
 
 func buildTrainingFeedbackContext(run db.EvalRun, feedback []FeedbackEvent, ranked []RankedFeedbackEvent) (json.RawMessage, error) {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -122,7 +122,7 @@ func TestExportTrainingPackageIncludesPreferredGateMetadata(t *testing.T) {
 		Mode:              db.EvalRunModeExplore,
 		ExplorationLevel:  db.ExplorationLevelHigh,
 		OptionsCount:      4,
-		MetadataJSON:      `{"evaluation":{"preferred_gate":"soft"},"source":"gitmoot skillopt train start"}`,
+		MetadataJSON:      `{"mode":"explore","evaluation":{"preferred_gate":"soft"},"source":"gitmoot skillopt train start"}`,
 	}); err != nil {
 		t.Fatalf("UpsertEvalRun returned error: %v", err)
 	}
@@ -143,9 +143,97 @@ func TestExportTrainingPackageIncludesPreferredGateMetadata(t *testing.T) {
 	if err := json.Unmarshal(pkg.EvaluatorConfig, &evaluator); err != nil {
 		t.Fatalf("decode evaluator config: %v", err)
 	}
+	if pkg.TrainingMode != db.EvalRunModeExplore {
+		t.Fatalf("training mode = %q, want %q", pkg.TrainingMode, db.EvalRunModeExplore)
+	}
+	if evaluator["mode"] != nil {
+		t.Fatalf("evaluator config leaked training mode = %s", string(pkg.EvaluatorConfig))
+	}
 	evaluation, ok := evaluator["evaluation"].(map[string]any)
 	if !ok || evaluation["preferred_gate"] != "soft" {
 		t.Fatalf("evaluator config = %s", string(pkg.EvaluatorConfig))
+	}
+}
+
+func TestExportTrainingPackagePreservesEvaluatorMode(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("judge", "Judge carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "judge")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "judge-run-1",
+		TemplateID:        "judge",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		Mode:              db.EvalRunModeRefine,
+		MetadataJSON:      `{"mode":"llm_judge","evaluation":{"preferred_gate":"soft"}}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+
+	pkg, err := ExportTrainingPackage(ctx, store, "judge-run-1")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	if pkg.TrainingMode != db.EvalRunModeRefine {
+		t.Fatalf("training mode = %q, want %q", pkg.TrainingMode, db.EvalRunModeRefine)
+	}
+	var evaluator map[string]any
+	if err := json.Unmarshal(pkg.EvaluatorConfig, &evaluator); err != nil {
+		t.Fatalf("decode evaluator config: %v", err)
+	}
+	if evaluator["mode"] != "llm_judge" {
+		t.Fatalf("evaluator config did not preserve evaluator mode: %s", string(pkg.EvaluatorConfig))
+	}
+}
+
+func TestExportTrainingPackagePreservesEvaluatorConfigNumberFidelity(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("judge", "Judge carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "judge")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "judge-run-2",
+		TemplateID:        "judge",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		Mode:              db.EvalRunModeExplore,
+		MetadataJSON:      `{"mode":"explore","evaluation":{"seed":9007199254740993123}}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+
+	pkg, err := ExportTrainingPackage(ctx, store, "judge-run-2")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	if strings.Contains(string(pkg.EvaluatorConfig), `"mode"`) {
+		t.Fatalf("evaluator config leaked training mode = %s", string(pkg.EvaluatorConfig))
+	}
+	if !strings.Contains(string(pkg.EvaluatorConfig), `9007199254740993123`) {
+		t.Fatalf("evaluator config rewrote large numeric value: %s", string(pkg.EvaluatorConfig))
 	}
 }
 


### PR DESCRIPTION
WHAT:
- Adds top-level `training_mode` to Gitmoot SkillOpt training packages.
- Removes top-level workflow phases from exported `evaluator_config.mode` while preserving real evaluator modes.
- Documents the package schema split.

WHY:
- Fixes the namespace collision from issue #158 where `evaluator_config.mode: explore` was interpreted by gitmoot-skillopt as evaluator id `explore`.

CHANGES:
- Adds `TrainingMode` to `TrainingPackage`.
- Adds `evaluatorConfigFromRunMetadata` to strip only workflow modes from top-level run metadata.
- Uses `map[string]json.RawMessage` so unrelated evaluator metadata, including large numeric values, is not rewritten.
- Adds regression tests for training mode export, evaluator mode preservation, and numeric metadata fidelity.
- Updates `docs/skillopt-exchange-contract.md`.

RESULTS:
- `gofmt -w internal/skillopt/contract.go internal/skillopt/contract_test.go`: passed.
- `git diff --check`: passed.
- `go test ./internal/skillopt ./internal/cli ./internal/feedback`: not run successfully in this environment because Go tried to download `go1.26` and failed with `toolchain not available`.
- `codex exec review --uncommitted`: clean after one fixed finding.

Raw final codex review output:
```text
The changes cleanly separate the top-level training mode from evaluator configuration while preserving real evaluator modes and metadata used for evaluator profiles. I did not identify any discrete correctness issues in the modified or untracked files.
```

RISK:
- Local Go test execution is blocked by unavailable Go 1.26 toolchain in this environment; CI should verify the Go suite.

Refs jerryfane/gitmoot#158.
