### PR TITLE
feat(skillopt): report actionable retry context

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -381,14 +381,23 @@ gitmoot skillopt train continue \
   --wrong-artifact-retry-budget 1
 ```
 
-A gate rejection is retryable only when the evaluator supplied actionable
+A gate rejection is retryable when the evaluator supplied actionable
 information, the candidate actually changed, the rejection is not just repeated
-noise, and budget remains. The retry prompt includes the previous patch
-summary, baseline-vs-candidate score deltas, failed dimensions, why the
-candidate lost, and guidance not to repeat the same patch direction. Near-miss
-selection rejects can also retry adaptively when the candidate is close enough
-to the baseline according to `gate_reject_retry_close_gap`, which defaults to
-`0.03`.
+noise, and budget remains. In imported human-review mode, the optimizer context
+includes all reviewed feedback items; it does not optimize from only the sampled
+item that happened to be in the current minibatch. The retry prompt includes the
+previous patch summary, baseline-vs-candidate score deltas, failed dimensions,
+why the candidate lost, all reviewed feedback themes, and guidance not to repeat
+the same patch direction.
+
+Large score gaps and `hard=0` candidate scores are not automatic retry blockers
+when the rejection packet is actionable. They are recorded as retry metadata,
+for example `score_gap_handling: retry_context` or
+`hard_score_handling: retryable_if_actionable`, so the next optimizer attempt
+can use them as stronger context. Gitmoot stops retry only when budget is
+exhausted, the structured rejection is missing, actionable guidance is missing,
+the same candidate/reason repeats after duplicate handling, or an explicit
+external/config failure cannot be fixed by changing the skill.
 
 Duplicate retry candidates do not get silently accepted or loop forever. If a
 retry produces the same candidate hash, the next retry is forced to include
@@ -409,12 +418,27 @@ gitmoot skillopt train status --session planner-train --verbose
 ```
 
 For gate rejections, status includes the baseline/candidate score comparison,
-attempted patch, retry count such as `1/3`, duplicate retry detection,
-evaluator reason, and concise `next_action_option` lines. The normal user
-choices are to collect more feedback, rerun after changing the retry/config
-inputs, or inspect the candidate package manually. Gitmoot does not create a
-pending candidate record when the best selected prompt is the unchanged
-baseline or the candidate content hash matches the base template.
+attempted patch, retry count such as `1/3`, optimizer context items, duplicate
+retry detection, score-gap handling, hard-score handling, evaluator reason, and
+concise `next_action_option` lines. The normal user choices are to collect more
+feedback, rerun after changing the retry/config inputs, or inspect the candidate
+package manually. Gitmoot does not create a pending candidate record when the
+best selected prompt is the unchanged baseline or the candidate content hash
+matches the base template.
+
+```mermaid
+flowchart TD
+  A[Import GitHub review feedback] --> B[Build optimizer context from all reviewed items]
+  B --> C[Optimizer creates candidate skill]
+  C --> D[Target generates outputs]
+  D --> E[Judge compares candidate vs baseline]
+  E -->|candidate wins| F[Publish candidate for human decision]
+  E -->|candidate loses| G[Structured rejection packet]
+  G --> H{Budget remains + actionable guidance?}
+  H -->|yes| I[Retry optimizer with full review + rejection]
+  I --> C
+  H -->|no| J[Stop with clear reason]
+```
 
 Every optimizer run writes into a numbered attempt directory:
 

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -5669,6 +5669,18 @@ func printSkillOptNoCandidateDetails(stdout io.Writer, details map[string]any) {
 	if retryStopReasons := metadataStringSlice(details, "retry_stop_reasons"); len(retryStopReasons) > 0 {
 		writeLine(stdout, "retry_stop_reasons: %s", strings.Join(retryStopReasons, ","))
 	}
+	if optimizerContextItems := metadataStringSlice(details, "optimizer_context_items"); len(optimizerContextItems) > 0 {
+		writeLine(stdout, "optimizer_context_items: %s", strings.Join(optimizerContextItems, ","))
+	}
+	if scoreGap := metadataString(details, "score_gap"); scoreGap != "" {
+		writeLine(stdout, "score_gap: %s", scoreGap)
+	}
+	if scoreGapHandling := metadataString(details, "score_gap_handling"); scoreGapHandling != "" {
+		writeLine(stdout, "score_gap_handling: %s", scoreGapHandling)
+	}
+	if hardScoreHandling := metadataString(details, "hard_score_handling"); hardScoreHandling != "" {
+		writeLine(stdout, "hard_score_handling: %s", hardScoreHandling)
+	}
 	if stopReason := metadataString(details, "stop_reason"); stopReason != "" {
 		writeLine(stdout, "stop_reason: %s", stopReason)
 	}

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -3238,19 +3238,24 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		"no_candidate_details": {
 			"attempted_patch": "artifact delivery only",
 			"baseline_gate": 0.89,
-			"candidate_gate": 0.84,
-			"retry_attempts": "1/1",
-			"duplicate_retry_detected": true,
+				"candidate_gate": 0.84,
+				"retry_attempts": "1/1",
+				"retry_budget": "1",
+				"duplicate_retry_detected": true,
 			"diagnostic_categories": [
 				"old_review_training_signal",
 				"candidate_feedback_unresolved",
 				"retry_budget_exhausted"
 			],
 			"selection_gate_relation": "candidate_below_baseline",
-			"retry_budget_exhausted": true,
-			"retry_stop_reasons": ["budget_exhausted"],
-			"stop_reason": "budget_exhausted",
-			"feedback_themes": ["MoonAI-style premium branding", "scroll animations"],
+				"retry_budget_exhausted": true,
+				"retry_stop_reasons": ["budget_exhausted"],
+				"optimizer_context_items": ["item-001", "item-002"],
+				"score_gap": 0.05,
+				"score_gap_handling": "retry_context",
+				"hard_score_handling": "retryable_if_actionable",
+				"stop_reason": "budget_exhausted",
+				"feedback_themes": ["MoonAI-style premium branding", "scroll animations"],
 			"evaluator_reason": "Candidate was valid but had weaker imagery.",
 			"optimizer_hint": "Resolve imported review themes and artifact contract.",
 			"failed_dimensions": ["human_feedback_alignment", "artifact_contract"],
@@ -3361,6 +3366,9 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		!strings.Contains(iteration.MetadataJSON, `"duplicate_retry_detected":true`) ||
 		!strings.Contains(iteration.MetadataJSON, `"evaluator_reason":"Candidate was valid but had weaker imagery."`) ||
 		!strings.Contains(iteration.MetadataJSON, `"optimizer_hint":"Resolve imported review themes and artifact contract."`) ||
+		!strings.Contains(iteration.MetadataJSON, `"optimizer_context_items":["item-001","item-002"]`) ||
+		!strings.Contains(iteration.MetadataJSON, `"score_gap_handling":"retry_context"`) ||
+		!strings.Contains(iteration.MetadataJSON, `"hard_score_handling":"retryable_if_actionable"`) ||
 		!strings.Contains(iteration.MetadataJSON, `"source_item_ids":["item-001"]`) {
 		t.Fatalf("iteration metadata after no-candidate = %s", iteration.MetadataJSON)
 	}
@@ -3390,6 +3398,8 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		statusJSON.NoCandidateDetails["duplicate_retry_detected"] != true ||
 		statusJSON.NoCandidateDetails["selection_gate_relation"] != "candidate_below_baseline" ||
 		statusJSON.NoCandidateDetails["retry_budget_exhausted"] != true ||
+		statusJSON.NoCandidateDetails["score_gap_handling"] != "retry_context" ||
+		statusJSON.NoCandidateDetails["hard_score_handling"] != "retryable_if_actionable" ||
 		statusJSON.NoCandidateDetails["optimizer_hint"] != "Resolve imported review themes and artifact contract." ||
 		statusJSON.NoCandidateDetails["human_feedback_context"] == nil ||
 		statusJSON.Verbose == nil ||
@@ -3425,6 +3435,10 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		"selection_gate_relation: candidate_below_baseline",
 		"retry_budget_exhausted: true",
 		"retry_stop_reasons: budget_exhausted",
+		"optimizer_context_items: item-001,item-002",
+		"score_gap: 0.05",
+		"score_gap_handling: retry_context",
+		"hard_score_handling: retryable_if_actionable",
 		"stop_reason: budget_exhausted",
 		"evaluator_reason: Candidate was valid but had weaker imagery.",
 		"optimizer_hint: Resolve imported review themes and artifact contract.",


### PR DESCRIPTION
WHAT
- Shows actionable retry metadata in Gitmoot SkillOpt no-candidate status output.
- Updates SkillOpt train workflow docs for all-feedback optimizer context and actionable retry semantics.

WHY
- Issue #160 needs user-facing status to explain why retry happened or stopped, including optimizer context item coverage, score-gap handling, and hard-score handling.

CHANGES
- Prints optimizer_context_items, score_gap, score_gap_handling, and hard_score_handling in verbose no-candidate status details.
- Updates CLI tests to assert the new metadata is preserved and displayed.
- Updates docs with the new retry policy and Mermaid flow.

RESULTS
- GOTOOLCHAIN=local /root/.local/toolchains/go1.26.4/bin/go test ./internal/cli -run SkillOpt
  - ok github.com/jerryfane/gitmoot/internal/cli 117.488s
- git diff --check

Final codex exec review --uncommitted output:
```text
The changes add status output for additional no-candidate metadata and update tests/docs accordingly. I did not find any discrete correctness issues in the modified code.
The changes add status output for additional no-candidate metadata and update tests/docs accordingly. I did not find any discrete correctness issues in the modified code.
```

RISK
- Existing unrelated untracked GOAL files were left untouched and are not part of this PR.

References #160.
