### PR TITLE
Pass optimizer views through skillopt train

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -333,6 +333,7 @@ gitmoot skillopt train continue \
   --skill-update-mode full_rewrite_minibatch \
   --num-epochs 1 \
   --batch-size 2 \
+  --optimizer-views 4 \
   --gate mixed
 ```
 
@@ -385,10 +386,18 @@ A gate rejection is retryable when the evaluator supplied actionable
 information, the candidate actually changed, the rejection is not just repeated
 noise, and budget remains. In imported human-review mode, the optimizer context
 includes all reviewed feedback items; it does not optimize from only the sampled
-item that happened to be in the current minibatch. The retry prompt includes the
-previous patch summary, baseline-vs-candidate score deltas, failed dimensions,
-why the candidate lost, all reviewed feedback themes, and guidance not to repeat
-the same patch direction.
+item that happened to be in the current minibatch. Use `--optimizer-views N`
+when the same small feedback set should be analyzed by multiple independent
+optimizer perspectives before merge. Each view receives the full feedback set,
+but Gitmoot forces the view reflection minibatch size to one so views do not
+collapse into one analyst prompt. For exploratory human-feedback iterations,
+`--skill-update-mode full_rewrite_minibatch --optimizer-views 4` is the
+recommended compact-skill path; patch mode still prefers `replace`/`delete`
+edits over append-only prompt growth.
+
+The retry prompt includes the previous patch summary, baseline-vs-candidate
+score deltas, failed dimensions, why the candidate lost, all reviewed feedback
+themes, and guidance not to repeat the same patch direction.
 
 Large score gaps and `hard=0` candidate scores are not automatic retry blockers
 when the rejection packet is actionable. They are recorded as retry metadata,

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -84,7 +84,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
@@ -116,7 +116,7 @@ func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--preview-mode none|optional|required] [--preview-renderer none|vue-vite] [--preview-publisher none|github-pages] [--preview-route-template template] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
@@ -640,6 +640,7 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	skillUpdateMode := fs.String("skill-update-mode", "", "SkillOpt update mode")
 	numEpochs := fs.Int("num-epochs", 0, "optimizer epoch count")
 	batchSize := fs.Int("batch-size", 0, "optimizer batch size")
+	optimizerViews := fs.Int("optimizer-views", 0, "independent optimizer perspectives over imported human review feedback; omit to use gitmoot-skillopt default")
 	noopRetryBudget := fs.Int("noop-retry-budget", -1, "noop optimizer retry budget; omit to use gitmoot-skillopt default")
 	gateRejectRetryBudget := fs.Int("gate-reject-retry-budget", -1, "gate-rejection optimizer retry budget; omit to use gitmoot-skillopt default")
 	wrongArtifactRetryBudget := fs.Int("wrong-artifact-retry-budget", -1, "wrong-artifact optimizer retry budget; omit to use gitmoot-skillopt default")
@@ -680,6 +681,10 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	}
 	if *batchSize < 0 {
 		fmt.Fprintln(stderr, "skillopt train continue: --batch-size must be zero or greater")
+		return 2
+	}
+	if setFlags["optimizer-views"] && *optimizerViews <= 0 {
+		fmt.Fprintln(stderr, "skillopt train continue: --optimizer-views must be greater than zero")
 		return 2
 	}
 	if setFlags["noop-retry-budget"] && *noopRetryBudget < 0 {
@@ -728,6 +733,8 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 				SkillUpdateMode:              *skillUpdateMode,
 				NumEpochs:                    *numEpochs,
 				BatchSize:                    *batchSize,
+				OptimizerViews:               *optimizerViews,
+				OptimizerViewsSet:            setFlags["optimizer-views"],
 				NoopRetryBudget:              *noopRetryBudget,
 				NoopRetryBudgetSet:           setFlags["noop-retry-budget"],
 				GateRejectRetryBudget:        *gateRejectRetryBudget,
@@ -804,6 +811,8 @@ type skillOptTrainOptimizerRequest struct {
 	SkillUpdateMode              string
 	NumEpochs                    int
 	BatchSize                    int
+	OptimizerViews               int
+	OptimizerViewsSet            bool
 	NoopRetryBudget              int
 	NoopRetryBudgetSet           bool
 	GateRejectRetryBudget        int
@@ -3490,6 +3499,10 @@ func skillOptTrainOptimizerRequestHash(request skillOptTrainOptimizerRequest) st
 		"skill_update_mode": strings.TrimSpace(request.SkillUpdateMode),
 		"num_epochs":        request.NumEpochs,
 		"batch_size":        request.BatchSize,
+		"optimizer_views": map[string]any{
+			"set":   request.OptimizerViewsSet,
+			"value": request.OptimizerViews,
+		},
 		"noop_retry_budget": map[string]any{
 			"set":   request.NoopRetryBudgetSet,
 			"value": request.NoopRetryBudget,
@@ -5571,6 +5584,7 @@ func printSkillOptTrainStatusSnapshot(stdout io.Writer, snapshot skillOptTrainSt
 			writeLine(stdout, "feedback_direct_mode: %s", mode)
 		}
 		for _, key := range []string{
+			"optimizer_views",
 			"target_artifact_retry_budget",
 			"hard_failure_retry_budget",
 			"noop_retry_budget",
@@ -6845,6 +6859,9 @@ func buildSkillOptTrainOptimizerCommand(iteration db.SkillOptTrainIteration, req
 	if request.BatchSize > 0 {
 		args = append(args, "--batch-size", strconv.Itoa(request.BatchSize))
 	}
+	if request.OptimizerViewsSet {
+		args = append(args, "--optimizer-views", strconv.Itoa(request.OptimizerViews))
+	}
 	if request.NoopRetryBudgetSet {
 		args = append(args, "--noop-retry-budget", strconv.Itoa(request.NoopRetryBudget))
 	}
@@ -6965,6 +6982,9 @@ func addSkillOptTrainOptimizerConfigMetadata(metadata map[string]any, request sk
 	}
 	if request.FinalEval {
 		metadata["final_eval"] = true
+	}
+	if request.OptimizerViewsSet {
+		metadata["optimizer_views"] = request.OptimizerViews
 	}
 	if request.TargetArtifactRetryBudgetSet {
 		metadata["target_artifact_retry_budget"] = request.TargetArtifactRetryBudget
@@ -7373,6 +7393,9 @@ func skillOptTrainOptimizerReportLines(result skillOptTrainOptimizerResult) []st
 	}
 	if mode := strings.TrimSpace(result.Request.FeedbackDirectMode); mode != "" {
 		lines = append(lines, fmt.Sprintf("feedback_direct_mode: %s", mode))
+	}
+	if result.Request.OptimizerViewsSet {
+		lines = append(lines, fmt.Sprintf("optimizer_views: %d", result.Request.OptimizerViews))
 	}
 	if result.Request.FinalEval {
 		lines = append(lines, "final_eval: true")

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2814,6 +2814,7 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 		"--skill-update-mode", "full_rewrite_minibatch",
 		"--num-epochs", "2",
 		"--batch-size", "3",
+		"--optimizer-views", "4",
 		"--gate", "mixed",
 		"--out-root", outRoot,
 		"--timeout", "5m",
@@ -2833,6 +2834,7 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 		"optimizer_attempt: attempt-001",
 		"optimizer_attempt_path: " + attemptRoot,
 		"candidate_package: " + filepath.Join(attemptRoot, "candidate.json"),
+		"optimizer_views: 4",
 		"optimizer_dry_run: true",
 		"final_eval: true",
 		"imported_candidate: planner@v2",
@@ -2864,6 +2866,7 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 		"--skill-update-mode", "full_rewrite_minibatch",
 		"--num-epochs", "2",
 		"--batch-size", "3",
+		"--optimizer-views", "4",
 		"--eval-test",
 		"--dry-run",
 	} {
@@ -3173,6 +3176,11 @@ func TestSkillOptTrainContinueRejectsInvalidOptimizerControls(t *testing.T) {
 		args []string
 		want string
 	}{
+		{
+			name: "zero optimizer views",
+			args: []string{"--optimizer-views", "0"},
+			want: "--optimizer-views must be greater than zero",
+		},
 		{
 			name: "negative noop retry budget",
 			args: []string{"--noop-retry-budget", "-1"},

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -75,7 +75,7 @@ gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--p
 gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file items.yml [--workspace-repo owner/workspace] [--preview-repo owner/previews] [--preview-mode none|optional|required] [--preview-renderer none|vue-vite] [--preview-publisher none|github-pages] [--preview-route-template template] [--yes]
 gitmoot skillopt train status --session <id>
-gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
+gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
 gitmoot skillopt train stop --session <id> --reason <text>
 ```
 

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -150,6 +150,19 @@ items:
 Use `quality: poor` or `continue_mode: explore` when all options are weak and a
 stable winner should not narrow the search yet.
 
+For exploratory human-feedback optimization, prefer:
+
+```sh
+gitmoot skillopt train continue \
+  --session planner-train \
+  --skill-update-mode full_rewrite_minibatch \
+  --optimizer-views 4
+```
+
+`--optimizer-views` runs independent optimizer perspectives over the same full
+review feedback set before merge, while the compact update mode rewrites the
+skill instead of only appending more prompt rules.
+
 After feedback sync, train mode exports the training package, invokes
 `gitmoot-skillopt optimize`, imports the returned candidate through the shared
 candidate validator, and leaves the candidate pending. Use optimizer `--dry-run`


### PR DESCRIPTION
## Summary
- adds `gitmoot skillopt train continue --optimizer-views N` with validation and subprocess pass-through to gitmoot-skillopt
- threads optimizer views through request hashing, optimizer metadata, verbose status, and optimizer result reporting
- updates SkillOpt train docs to recommend `full_rewrite_minibatch --optimizer-views 4` for exploratory human-feedback iterations

This pairs with jerryfane/gitmoot-skillopt#66, which implements replicated full-feedback optimizer views and compact patch guidance.

Closes #164.

## Validation
- `git diff --check`
- `codex exec review --uncommitted` clean
- Go tests could not run locally: this checkout requires Go 1.26, local Go is 1.22.2, and the Go 1.26 toolchain download is unavailable in this environment.
