### PR TITLE
Pass retry optimizer views through train CLI

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -334,6 +334,7 @@ gitmoot skillopt train continue \
   --num-epochs 1 \
   --batch-size 2 \
   --optimizer-views 4 \
+  --retry-optimizer-views auto \
   --gate mixed
 ```
 
@@ -378,6 +379,7 @@ The retry budgets can be changed when continuing training:
 gitmoot skillopt train continue \
   --session planner-train \
   --gate-reject-retry-budget 3 \
+  --retry-optimizer-views auto \
   --noop-retry-budget 1 \
   --wrong-artifact-retry-budget 1
 ```
@@ -391,9 +393,13 @@ when the same small feedback set should be analyzed by multiple independent
 optimizer perspectives before merge. Each view receives the full feedback set,
 but Gitmoot forces the view reflection minibatch size to one so views do not
 collapse into one analyst prompt. For exploratory human-feedback iterations,
-`--skill-update-mode full_rewrite_minibatch --optimizer-views 4` is the
-recommended compact-skill path; patch mode still prefers `replace`/`delete`
-edits over append-only prompt growth.
+combine `--skill-update-mode full_rewrite_minibatch`, `--optimizer-views 4`,
+and `--retry-optimizer-views auto` as the recommended compact-skill path; patch
+mode still prefers `replace`/`delete` edits over append-only prompt growth.
+Retry optimizer views accept `auto`, `inherit`, or a positive integer. `auto`
+inherits the initial view count for full-rewrite minibatch retries and keeps
+patch-mode retries cheap; `inherit` always reuses the initial view count.
+Explicit retry view counts cannot exceed the initial optimizer view count.
 
 The retry prompt includes the previous patch summary, baseline-vs-candidate
 score deltas, failed dimensions, why the candidate lost, all reviewed feedback

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -84,7 +84,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
@@ -116,7 +116,7 @@ func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--preview-mode none|optional|required] [--preview-renderer none|vue-vite] [--preview-publisher none|github-pages] [--preview-route-template template] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
@@ -641,6 +641,7 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	numEpochs := fs.Int("num-epochs", 0, "optimizer epoch count")
 	batchSize := fs.Int("batch-size", 0, "optimizer batch size")
 	optimizerViews := fs.Int("optimizer-views", 0, "independent optimizer perspectives over imported human review feedback; omit to use gitmoot-skillopt default")
+	retryOptimizerViews := fs.String("retry-optimizer-views", "", "optimizer perspectives for gate-reject retries: auto, inherit, or a positive integer; omit to use gitmoot-skillopt default")
 	noopRetryBudget := fs.Int("noop-retry-budget", -1, "noop optimizer retry budget; omit to use gitmoot-skillopt default")
 	gateRejectRetryBudget := fs.Int("gate-reject-retry-budget", -1, "gate-rejection optimizer retry budget; omit to use gitmoot-skillopt default")
 	wrongArtifactRetryBudget := fs.Int("wrong-artifact-retry-budget", -1, "wrong-artifact optimizer retry budget; omit to use gitmoot-skillopt default")
@@ -686,6 +687,21 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	if setFlags["optimizer-views"] && *optimizerViews <= 0 {
 		fmt.Fprintln(stderr, "skillopt train continue: --optimizer-views must be greater than zero")
 		return 2
+	}
+	normalizedRetryOptimizerViews := ""
+	if setFlags["retry-optimizer-views"] {
+		var err error
+		normalizedRetryOptimizerViews, err = normalizeSkillOptRetryOptimizerViews(*retryOptimizerViews)
+		if err != nil {
+			fmt.Fprintf(stderr, "skillopt train continue: %v\n", err)
+			return 2
+		}
+		if setFlags["optimizer-views"] {
+			if retryViews, ok := parseSkillOptRetryOptimizerViewsNumber(normalizedRetryOptimizerViews); ok && retryViews > *optimizerViews {
+				fmt.Fprintln(stderr, "skillopt train continue: --retry-optimizer-views cannot exceed --optimizer-views")
+				return 2
+			}
+		}
 	}
 	if setFlags["noop-retry-budget"] && *noopRetryBudget < 0 {
 		fmt.Fprintln(stderr, "skillopt train continue: --noop-retry-budget must be zero or greater")
@@ -735,6 +751,8 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 				BatchSize:                    *batchSize,
 				OptimizerViews:               *optimizerViews,
 				OptimizerViewsSet:            setFlags["optimizer-views"],
+				RetryOptimizerViews:          normalizedRetryOptimizerViews,
+				RetryOptimizerViewsSet:       setFlags["retry-optimizer-views"],
 				NoopRetryBudget:              *noopRetryBudget,
 				NoopRetryBudgetSet:           setFlags["noop-retry-budget"],
 				GateRejectRetryBudget:        *gateRejectRetryBudget,
@@ -772,6 +790,25 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+func normalizeSkillOptRetryOptimizerViews(value string) (string, error) {
+	trimmed := strings.TrimSpace(strings.ToLower(value))
+	if trimmed == "auto" || trimmed == "inherit" {
+		return trimmed, nil
+	}
+	if parsed, err := strconv.Atoi(trimmed); err == nil && parsed > 0 {
+		return strconv.Itoa(parsed), nil
+	}
+	return "", fmt.Errorf("--retry-optimizer-views must be auto, inherit, or a positive integer")
+}
+
+func parseSkillOptRetryOptimizerViewsNumber(value string) (int, bool) {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || parsed <= 0 {
+		return 0, false
+	}
+	return parsed, true
 }
 
 func printSkillOptTrainContinueOutput(stdout io.Writer, output skillOptTrainContinueOutput) {
@@ -813,6 +850,8 @@ type skillOptTrainOptimizerRequest struct {
 	BatchSize                    int
 	OptimizerViews               int
 	OptimizerViewsSet            bool
+	RetryOptimizerViews          string
+	RetryOptimizerViewsSet       bool
 	NoopRetryBudget              int
 	NoopRetryBudgetSet           bool
 	GateRejectRetryBudget        int
@@ -3503,6 +3542,10 @@ func skillOptTrainOptimizerRequestHash(request skillOptTrainOptimizerRequest) st
 			"set":   request.OptimizerViewsSet,
 			"value": request.OptimizerViews,
 		},
+		"retry_optimizer_views": map[string]any{
+			"set":   request.RetryOptimizerViewsSet,
+			"value": strings.TrimSpace(request.RetryOptimizerViews),
+		},
 		"noop_retry_budget": map[string]any{
 			"set":   request.NoopRetryBudgetSet,
 			"value": request.NoopRetryBudget,
@@ -5585,6 +5628,7 @@ func printSkillOptTrainStatusSnapshot(stdout io.Writer, snapshot skillOptTrainSt
 		}
 		for _, key := range []string{
 			"optimizer_views",
+			"retry_optimizer_views",
 			"target_artifact_retry_budget",
 			"hard_failure_retry_budget",
 			"noop_retry_budget",
@@ -6862,6 +6906,9 @@ func buildSkillOptTrainOptimizerCommand(iteration db.SkillOptTrainIteration, req
 	if request.OptimizerViewsSet {
 		args = append(args, "--optimizer-views", strconv.Itoa(request.OptimizerViews))
 	}
+	if request.RetryOptimizerViewsSet {
+		args = append(args, "--retry-optimizer-views", strings.TrimSpace(request.RetryOptimizerViews))
+	}
 	if request.NoopRetryBudgetSet {
 		args = append(args, "--noop-retry-budget", strconv.Itoa(request.NoopRetryBudget))
 	}
@@ -6985,6 +7032,9 @@ func addSkillOptTrainOptimizerConfigMetadata(metadata map[string]any, request sk
 	}
 	if request.OptimizerViewsSet {
 		metadata["optimizer_views"] = request.OptimizerViews
+	}
+	if request.RetryOptimizerViewsSet {
+		metadata["retry_optimizer_views"] = strings.TrimSpace(request.RetryOptimizerViews)
 	}
 	if request.TargetArtifactRetryBudgetSet {
 		metadata["target_artifact_retry_budget"] = request.TargetArtifactRetryBudget
@@ -7396,6 +7446,9 @@ func skillOptTrainOptimizerReportLines(result skillOptTrainOptimizerResult) []st
 	}
 	if result.Request.OptimizerViewsSet {
 		lines = append(lines, fmt.Sprintf("optimizer_views: %d", result.Request.OptimizerViews))
+	}
+	if result.Request.RetryOptimizerViewsSet {
+		lines = append(lines, fmt.Sprintf("retry_optimizer_views: %s", strings.TrimSpace(result.Request.RetryOptimizerViews)))
 	}
 	if result.Request.FinalEval {
 		lines = append(lines, "final_eval: true")

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2815,6 +2815,7 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 		"--num-epochs", "2",
 		"--batch-size", "3",
 		"--optimizer-views", "4",
+		"--retry-optimizer-views", "inherit",
 		"--gate", "mixed",
 		"--out-root", outRoot,
 		"--timeout", "5m",
@@ -2835,6 +2836,7 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 		"optimizer_attempt_path: " + attemptRoot,
 		"candidate_package: " + filepath.Join(attemptRoot, "candidate.json"),
 		"optimizer_views: 4",
+		"retry_optimizer_views: inherit",
 		"optimizer_dry_run: true",
 		"final_eval: true",
 		"imported_candidate: planner@v2",
@@ -2867,6 +2869,7 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 		"--num-epochs", "2",
 		"--batch-size", "3",
 		"--optimizer-views", "4",
+		"--retry-optimizer-views", "inherit",
 		"--eval-test",
 		"--dry-run",
 	} {
@@ -3182,6 +3185,21 @@ func TestSkillOptTrainContinueRejectsInvalidOptimizerControls(t *testing.T) {
 			want: "--optimizer-views must be greater than zero",
 		},
 		{
+			name: "invalid retry optimizer views",
+			args: []string{"--retry-optimizer-views", "bogus"},
+			want: "--retry-optimizer-views must be auto, inherit, or a positive integer",
+		},
+		{
+			name: "zero retry optimizer views",
+			args: []string{"--retry-optimizer-views", "0"},
+			want: "--retry-optimizer-views must be auto, inherit, or a positive integer",
+		},
+		{
+			name: "retry optimizer views exceeds optimizer views",
+			args: []string{"--optimizer-views", "2", "--retry-optimizer-views", "3"},
+			want: "--retry-optimizer-views cannot exceed --optimizer-views",
+		},
+		{
 			name: "negative noop retry budget",
 			args: []string{"--noop-retry-budget", "-1"},
 			want: "--noop-retry-budget must be zero or greater",
@@ -3337,6 +3355,8 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		"--home", home,
 		"--session", "optimizer-train",
 		"--out-root", outRoot,
+		"--optimizer-views", "4",
+		"--retry-optimizer-views", "inherit",
 		"--dry-run",
 	}, &stdout, &stderr)
 	if code != 0 {
@@ -3349,6 +3369,8 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		"optimizer_attempt: attempt-001",
 		"optimizer_attempt_path: " + filepath.Join(outRoot, "attempts", "attempt-001"),
 		"candidate_package: " + filepath.Join(outRoot, "attempts", "attempt-001", "candidate.json"),
+		"optimizer_views: 4",
+		"retry_optimizer_views: inherit",
 		"optimizer_dry_run: true",
 		"no_candidate_reason: gate_rejected_best_origin_initial_skill",
 		"next: Do not import or publish a candidate review; collect more feedback",
@@ -3412,7 +3434,8 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		statusJSON.NoCandidateDetails["human_feedback_context"] == nil ||
 		statusJSON.Verbose == nil ||
 		statusJSON.Verbose.Optimizer["optimizer_attempt"] != "attempt-001" ||
-		statusJSON.Verbose.Optimizer["optimizer_attempt_state"] != "completed_no_candidate" {
+		statusJSON.Verbose.Optimizer["optimizer_attempt_state"] != "completed_no_candidate" ||
+		statusJSON.Verbose.Optimizer["retry_optimizer_views"] != "inherit" {
 		t.Fatalf("train status no-candidate json = %+v", statusJSON)
 	}
 
@@ -3427,6 +3450,8 @@ func TestSkillOptTrainContinueRecordsNoCandidateResult(t *testing.T) {
 		"optimizer_attempt: attempt-001",
 		"optimizer_attempt_state: completed_no_candidate",
 		"optimizer_attempt_path: " + filepath.Join(outRoot, "attempts", "attempt-001"),
+		"optimizer_views: 4",
+		"retry_optimizer_views: inherit",
 		"feedback_source: imported_human_review",
 		"feedback_target: baseline_review_outputs",
 		"review_issue: jerryfane/gitmoot-previews#21",

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -75,7 +75,7 @@ gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--p
 gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file items.yml [--workspace-repo owner/workspace] [--preview-repo owner/previews] [--preview-mode none|optional|required] [--preview-renderer none|vue-vite] [--preview-publisher none|github-pages] [--preview-route-template template] [--yes]
 gitmoot skillopt train status --session <id>
-gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
+gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
 gitmoot skillopt train stop --session <id> --reason <text>
 ```
 

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -156,12 +156,16 @@ For exploratory human-feedback optimization, prefer:
 gitmoot skillopt train continue \
   --session planner-train \
   --skill-update-mode full_rewrite_minibatch \
-  --optimizer-views 4
+  --optimizer-views 4 \
+  --retry-optimizer-views auto
 ```
 
 `--optimizer-views` runs independent optimizer perspectives over the same full
 review feedback set before merge, while the compact update mode rewrites the
-skill instead of only appending more prompt rules.
+skill instead of only appending more prompt rules. `--retry-optimizer-views`
+controls whether gate-reject retries also use multiple optimizer perspectives;
+use `auto` to inherit the initial view count for full-rewrite minibatch retries
+while keeping cheaper patch-mode retries at one view.
 
 After feedback sync, train mode exports the training package, invokes
 `gitmoot-skillopt optimize`, imports the returned candidate through the shared


### PR DESCRIPTION
WHAT
- Adds Gitmoot `skillopt train continue --retry-optimizer-views auto|inherit|N` pass-through support.

WHY
- Issue #166 added retry optimizer views in `gitmoot-skillopt`; the parent Gitmoot CLI needed to expose and persist that setting so retry runs can inherit multi-view exploration.

CHANGES
- Adds CLI parsing, normalization, validation, request hashing, optimizer command wiring, metadata, continue output, and verbose status output for `retry_optimizer_views`.
- Extends CLI tests for command pass-through, invalid values, no-candidate metadata, and later verbose status visibility.
- Updates workflow and website CLI docs.

RESULTS
- `git diff --check`: pass.
- `codex exec review --uncommitted`: clean after fixing the status visibility finding.
- `go test ./internal/cli`: blocked before compile because this environment tries to download Go 1.26 and reports `toolchain not available` / local Go is 1.22.2 while `go.mod` requires `go 1.26`.

Final review output:
```text
I did not identify any actionable correctness issues in the changed or untracked files. Focused Go tests could not be run because the environment attempted to download the Go 1.26 toolchain into a read-only module cache.
```

RISK
- Go tests were not executable in this environment due to unavailable Go 1.26 toolchain. The change is covered by focused test edits but not locally compiled here.

Part of #166.