### PR TITLE
fix(skillopt): preserve tied ranked feedback semantics

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -307,6 +307,7 @@ type RankedFeedbackEvent struct {
 	RunID                    string
 	ItemID                   string
 	RankingJSON              string
+	TieGroupsJSON            string
 	Winner                   string
 	UsefulTraitsJSON         string
 	RejectedTraitsJSON       string
@@ -2842,13 +2843,14 @@ func (s *Store) UpsertRankedFeedbackEvent(ctx context.Context, event RankedFeedb
 		return err
 	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO ranked_feedback_events(
-			id, run_id, item_id, ranking_json, winner, useful_traits_json, rejected_traits_json,
+			id, run_id, item_id, ranking_json, tie_groups_json, winner, useful_traits_json, rejected_traits_json,
 			required_improvements_json, quality, continue_mode, promote, reasoning, reviewer, source, source_url, created_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(run_id, item_id, reviewer, source, source_url) DO UPDATE SET
 			id = excluded.id,
 			ranking_json = excluded.ranking_json,
+			tie_groups_json = excluded.tie_groups_json,
 			winner = excluded.winner,
 			useful_traits_json = excluded.useful_traits_json,
 			rejected_traits_json = excluded.rejected_traits_json,
@@ -2861,7 +2863,7 @@ func (s *Store) UpsertRankedFeedbackEvent(ctx context.Context, event RankedFeedb
 			source = excluded.source,
 			source_url = excluded.source_url,
 			created_at = excluded.created_at`,
-		event.ID, event.RunID, event.ItemID, event.RankingJSON, event.Winner, event.UsefulTraitsJSON, event.RejectedTraitsJSON, event.RequiredImprovementsJSON,
+		event.ID, event.RunID, event.ItemID, event.RankingJSON, event.TieGroupsJSON, event.Winner, event.UsefulTraitsJSON, event.RejectedTraitsJSON, event.RequiredImprovementsJSON,
 		event.Quality, event.ContinueMode, event.Promote, event.Reasoning, event.Reviewer, event.Source, event.SourceURL, event.CreatedAt)
 	return err
 }
@@ -2879,6 +2881,10 @@ func (s *Store) validateRankedFeedbackEventOptions(ctx context.Context, event Ra
 		return fmt.Errorf("ranked feedback item %s has no registered review options", event.ItemID)
 	}
 	ranking, err := rankedFeedbackRanking(event)
+	if err != nil {
+		return err
+	}
+	tieGroups, err := rankedFeedbackTieGroups(event)
 	if err != nil {
 		return err
 	}
@@ -2912,8 +2918,8 @@ func (s *Store) validateRankedFeedbackEventOptions(ctx context.Context, event Ra
 		if _, ok := known[event.Winner]; !ok {
 			return fmt.Errorf("ranked feedback item %s winner references unknown option %q", event.ItemID, event.Winner)
 		}
-		if event.Winner != ranking[0] {
-			return fmt.Errorf("ranked feedback item %s winner %q does not match first ranked option %q", event.ItemID, event.Winner, ranking[0])
+		if len(tieGroups) == 0 || !stringSliceContains(tieGroups[0], event.Winner) {
+			return fmt.Errorf("ranked feedback item %s winner %q is not in first ranked group", event.ItemID, event.Winner)
 		}
 	}
 	for _, traits := range []struct {
@@ -2959,6 +2965,17 @@ func normalizeRankedFeedbackEvent(event RankedFeedbackEvent) (RankedFeedbackEven
 	}
 	if _, err := rankedFeedbackRanking(event); err != nil {
 		return RankedFeedbackEvent{}, err
+	}
+	tieGroups, err := rankedFeedbackTieGroups(event)
+	if err != nil {
+		return RankedFeedbackEvent{}, err
+	}
+	if strings.TrimSpace(event.TieGroupsJSON) != "" {
+		encoded, err := json.Marshal(tieGroups)
+		if err != nil {
+			return RankedFeedbackEvent{}, err
+		}
+		event.TieGroupsJSON = string(encoded)
 	}
 	event.UsefulTraitsJSON = strings.TrimSpace(event.UsefulTraitsJSON)
 	event.RejectedTraitsJSON = strings.TrimSpace(event.RejectedTraitsJSON)
@@ -3055,8 +3072,54 @@ func rankedFeedbackRanking(event RankedFeedbackEvent) ([]string, error) {
 	return ranking, nil
 }
 
+func rankedFeedbackTieGroups(event RankedFeedbackEvent) ([][]string, error) {
+	ranking, err := rankedFeedbackRanking(event)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(event.TieGroupsJSON) == "" {
+		groups := make([][]string, 0, len(ranking))
+		for _, label := range ranking {
+			groups = append(groups, []string{label})
+		}
+		return groups, nil
+	}
+	var groups [][]string
+	if err := json.Unmarshal([]byte(event.TieGroupsJSON), &groups); err != nil {
+		return nil, fmt.Errorf("ranked feedback tie_groups_json must be a JSON array of option label arrays: %w", err)
+	}
+	flattened := make([]string, 0, len(ranking))
+	seen := map[string]struct{}{}
+	for groupIndex, group := range groups {
+		if len(group) == 0 {
+			return nil, fmt.Errorf("ranked feedback tie group %d is empty", groupIndex+1)
+		}
+		for labelIndex, label := range group {
+			normalized := normalizeOptionLabel(label)
+			if normalized == "" {
+				return nil, fmt.Errorf("ranked feedback tie group %d contains empty option label at position %d", groupIndex+1, labelIndex+1)
+			}
+			if _, ok := seen[normalized]; ok {
+				return nil, fmt.Errorf("ranked feedback tie groups contain duplicate option label %q", normalized)
+			}
+			seen[normalized] = struct{}{}
+			groups[groupIndex][labelIndex] = normalized
+			flattened = append(flattened, normalized)
+		}
+	}
+	if len(flattened) != len(ranking) {
+		return nil, fmt.Errorf("ranked feedback tie groups include %d options, want %d ranking options", len(flattened), len(ranking))
+	}
+	for index, label := range ranking {
+		if flattened[index] != label {
+			return nil, fmt.Errorf("ranked feedback tie groups do not match ranking order at position %d", index+1)
+		}
+	}
+	return groups, nil
+}
+
 func (s *Store) ListRankedFeedbackEvents(ctx context.Context, runID string) ([]RankedFeedbackEvent, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, run_id, item_id, ranking_json, winner, useful_traits_json, rejected_traits_json,
+	rows, err := s.db.QueryContext(ctx, `SELECT id, run_id, item_id, ranking_json, tie_groups_json, winner, useful_traits_json, rejected_traits_json,
 			required_improvements_json, quality, continue_mode, promote, reasoning, reviewer, source, source_url, created_at
 		FROM ranked_feedback_events WHERE run_id = ? ORDER BY item_id, reviewer, source, source_url`, strings.TrimSpace(runID))
 	if err != nil {
@@ -3076,7 +3139,7 @@ func (s *Store) ListRankedFeedbackEvents(ctx context.Context, runID string) ([]R
 
 func scanRankedFeedbackEvent(row interface{ Scan(dest ...any) error }) (RankedFeedbackEvent, error) {
 	var event RankedFeedbackEvent
-	if err := row.Scan(&event.ID, &event.RunID, &event.ItemID, &event.RankingJSON, &event.Winner, &event.UsefulTraitsJSON, &event.RejectedTraitsJSON,
+	if err := row.Scan(&event.ID, &event.RunID, &event.ItemID, &event.RankingJSON, &event.TieGroupsJSON, &event.Winner, &event.UsefulTraitsJSON, &event.RejectedTraitsJSON,
 		&event.RequiredImprovementsJSON, &event.Quality, &event.ContinueMode, &event.Promote, &event.Reasoning, &event.Reviewer, &event.Source, &event.SourceURL, &event.CreatedAt); err != nil {
 		return RankedFeedbackEvent{}, err
 	}
@@ -3100,27 +3163,40 @@ func (s *Store) ListPairwisePreferences(ctx context.Context, runID string) ([]Pa
 }
 
 func PairwisePreferencesForRankedFeedback(event RankedFeedbackEvent) ([]PairwisePreference, error) {
-	ranking, err := rankedFeedbackRanking(event)
+	tieGroups, err := rankedFeedbackTieGroups(event)
 	if err != nil {
 		return nil, err
 	}
-	preferences := make([]PairwisePreference, 0, len(ranking)*(len(ranking)-1)/2)
-	for preferredIndex, preferred := range ranking {
-		for _, rejected := range ranking[preferredIndex+1:] {
-			preferences = append(preferences, PairwisePreference{
-				RunID:         event.RunID,
-				ItemID:        event.ItemID,
-				Preferred:     preferred,
-				Rejected:      rejected,
-				RankedEventID: event.ID,
-				Reviewer:      event.Reviewer,
-				Source:        event.Source,
-				SourceURL:     event.SourceURL,
-				CreatedAt:     event.CreatedAt,
-			})
+	preferences := []PairwisePreference{}
+	for preferredGroupIndex, preferredGroup := range tieGroups {
+		for _, rejectedGroup := range tieGroups[preferredGroupIndex+1:] {
+			for _, preferred := range preferredGroup {
+				for _, rejected := range rejectedGroup {
+					preferences = append(preferences, PairwisePreference{
+						RunID:         event.RunID,
+						ItemID:        event.ItemID,
+						Preferred:     preferred,
+						Rejected:      rejected,
+						RankedEventID: event.ID,
+						Reviewer:      event.Reviewer,
+						Source:        event.Source,
+						SourceURL:     event.SourceURL,
+						CreatedAt:     event.CreatedAt,
+					})
+				}
+			}
 		}
 	}
 	return preferences, nil
+}
+
+func stringSliceContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func feedbackEventID(event FeedbackEvent) string {
@@ -4090,5 +4166,8 @@ CREATE TABLE skillopt_review_watches (
 
 CREATE INDEX idx_skillopt_review_watches_status ON skillopt_review_watches(status);
 CREATE INDEX idx_skillopt_review_watches_run_id ON skillopt_review_watches(run_id);
+	`,
+	`
+ALTER TABLE ranked_feedback_events ADD COLUMN tie_groups_json TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -503,6 +503,81 @@ func TestRankedReviewStorageAndPairwisePreferences(t *testing.T) {
 	}
 }
 
+func TestRankedReviewTieGroupsSkipInGroupPairwisePreferences(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.UpsertEvalRun(ctx, EvalRun{ID: "run-tied", State: "review", Mode: EvalRunModeExplore, OptionsCount: 4}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, EvalReviewItem{RunID: "run-tied", ItemID: "item-001", Title: "Tweet"}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	for _, label := range []string{"a", "b", "c", "d"} {
+		if err := store.UpsertEvalReviewOption(ctx, EvalReviewOption{RunID: "run-tied", ItemID: "item-001", Label: label, ArtifactID: "artifact-" + label}); err != nil {
+			t.Fatalf("UpsertEvalReviewOption %s returned error: %v", label, err)
+		}
+	}
+	if err := store.UpsertRankedFeedbackEvent(ctx, RankedFeedbackEvent{
+		RunID:         "run-tied",
+		ItemID:        "item-001",
+		RankingJSON:   `["a","b","c","d"]`,
+		TieGroupsJSON: `[["a","b","c","d"]]`,
+		Reviewer:      "jerry",
+		Source:        "github",
+		SourceURL:     "all-tied",
+	}); err != nil {
+		t.Fatalf("UpsertRankedFeedbackEvent all tied returned error: %v", err)
+	}
+	pairs, err := store.ListPairwisePreferences(ctx, "run-tied")
+	if err != nil {
+		t.Fatalf("ListPairwisePreferences all tied returned error: %v", err)
+	}
+	if len(pairs) != 0 {
+		t.Fatalf("all-tied pairwise preferences = %+v, want none", pairs)
+	}
+
+	if err := store.UpsertRankedFeedbackEvent(ctx, RankedFeedbackEvent{
+		RunID:         "run-tied",
+		ItemID:        "item-001",
+		RankingJSON:   `["a","b","c","d"]`,
+		TieGroupsJSON: `[["a"],["b","c"],["d"]]`,
+		Winner:        "a",
+		Reviewer:      "jerry",
+		Source:        "github",
+		SourceURL:     "partial-tie",
+	}); err != nil {
+		t.Fatalf("UpsertRankedFeedbackEvent partial tie returned error: %v", err)
+	}
+	events, err := store.ListRankedFeedbackEvents(ctx, "run-tied")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents returned error: %v", err)
+	}
+	var partial RankedFeedbackEvent
+	for _, event := range events {
+		if event.SourceURL == "partial-tie" {
+			partial = event
+			break
+		}
+	}
+	partialPairs, err := PairwisePreferencesForRankedFeedback(partial)
+	if err != nil {
+		t.Fatalf("PairwisePreferencesForRankedFeedback partial tie returned error: %v", err)
+	}
+	if len(partialPairs) != 5 {
+		t.Fatalf("partial tie pairwise preference len = %d, want 5: %+v", len(partialPairs), partialPairs)
+	}
+	for _, pair := range partialPairs {
+		if (pair.Preferred == "b" && pair.Rejected == "c") || (pair.Preferred == "c" && pair.Rejected == "b") {
+			t.Fatalf("partial tie emitted in-group preference: %+v", partialPairs)
+		}
+	}
+}
+
 func TestRankedReviewStorageRejectsInvalidReferences(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
@@ -585,6 +660,10 @@ func TestRankedReviewStorageRejectsInvalidReferences(t *testing.T) {
 		"invalid promote": {
 			RankingJSON: `["a","b","c"]`,
 			Promote:     "maybe",
+		},
+		"tie groups mismatch ranking": {
+			RankingJSON:   `["a","b","c"]`,
+			TieGroupsJSON: `[["a"],["c","b"]]`,
 		},
 	}
 	for name, event := range tests {

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -544,7 +544,7 @@ func parseFullYAMLFeedback(content string) (feedbackFile, bool, error) {
 
 var shortFeedbackLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s*:\s*([A-Za-z]+)(?:\s*-\s*(.*))?$`)
 var shortRankingLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s+ranking\s*:\s*(.+)$`)
-var shortDirectRankingLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s*:\s*([A-Za-z][A-Za-z0-9._/-]*(?:\s*(?:>|,|\|)\s*[A-Za-z][A-Za-z0-9._/-]*)+)(?:\s*-\s*(.*))?$`)
+var shortDirectRankingLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s*:\s*([A-Za-z][A-Za-z0-9._/-]*(?:\s*(?:>|=|,|\|)\s*[A-Za-z][A-Za-z0-9._/-]*)+)(?:\s*-\s*(.*))?$`)
 var shortMetadataLine = regexp.MustCompile(`^(run_id|reviewer)\s*:\s*(.+)$`)
 var shortItemSignalLine = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._/-]*)\s+(quality|continue_mode|promote)\s*:\s*(.+)$`)
 var shortBareSignalLine = regexp.MustCompile(`^(quality|continue_mode|promote)\s*:\s*(.+)$`)
@@ -618,18 +618,22 @@ func parseShortFormFeedback(content string) (feedbackFile, bool, error) {
 			traitItemIndex = -1
 		}
 		if match := shortRankingLine.FindStringSubmatch(line); match != nil {
+			ranking, tieGroups := splitRankingStringWithTieGroups(match[2])
 			parsed.Items = append(parsed.Items, feedbackFileEntry{
-				ItemID:  strings.TrimSpace(match[1]),
-				Ranking: splitRankingString(match[2]),
+				ItemID:    strings.TrimSpace(match[1]),
+				Ranking:   ranking,
+				TieGroups: tieGroups,
 			})
 			traitItemIndex = len(parsed.Items) - 1
 			traitTarget = ""
 			continue
 		}
 		if match := shortDirectRankingLine.FindStringSubmatch(line); match != nil {
+			ranking, tieGroups := splitRankingStringWithTieGroups(match[2])
 			parsed.Items = append(parsed.Items, feedbackFileEntry{
 				ItemID:    strings.TrimSpace(match[1]),
-				Ranking:   splitRankingString(match[2]),
+				Ranking:   ranking,
+				TieGroups: tieGroups,
 				Reasoning: strings.TrimSpace(match[3]),
 			})
 			traitItemIndex = len(parsed.Items) - 1
@@ -677,26 +681,44 @@ func setFeedbackItemSignal(entry *feedbackFileEntry, key string, value string) {
 }
 
 func splitRankingString(value string) []string {
-	parts := strings.FieldsFunc(value, func(r rune) bool {
-		return r == '>' || r == ',' || r == '|'
-	})
-	return splitRankingLabels(parts)
+	labels, _ := splitRankingStringWithTieGroups(value)
+	return labels
+}
+
+func splitRankingStringWithTieGroups(value string) ([]string, [][]string) {
+	return splitRankingLabelsAndTieGroups([]string{value})
 }
 
 func splitRankingLabels(values []string) []string {
+	labels, _ := splitRankingLabelsAndTieGroups(values)
+	return labels
+}
+
+func splitRankingLabelsAndTieGroups(values []string) ([]string, [][]string) {
 	labels := make([]string, 0, len(values))
+	groups := [][]string{}
 	for _, value := range values {
-		parts := strings.FieldsFunc(value, func(r rune) bool {
+		orderedParts := strings.FieldsFunc(value, func(r rune) bool {
 			return r == '>' || r == ',' || r == '|'
 		})
-		for _, part := range parts {
-			part = strings.TrimSpace(part)
-			if part != "" {
-				labels = append(labels, part)
+		for _, orderedPart := range orderedParts {
+			tieParts := strings.FieldsFunc(orderedPart, func(r rune) bool {
+				return r == '='
+			})
+			group := []string{}
+			for _, part := range tieParts {
+				part = strings.TrimSpace(part)
+				if part != "" {
+					labels = append(labels, part)
+					group = append(group, part)
+				}
+			}
+			if len(group) > 0 {
+				groups = append(groups, group)
 			}
 		}
 	}
-	return labels
+	return labels, groups
 }
 
 func trimTraitMap(values map[string][]string) map[string][]string {

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -450,6 +450,43 @@ func TestGitHubCollectorSyncImportsRankedShortFormComment(t *testing.T) {
 	}
 }
 
+func TestGitHubCollectorSyncImportsTiedRankedShortFormComment(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupGitHubRankedFeedbackRun(t, "ranked-1", "owner/repo")
+	fake := &fakeFeedbackGitHub{
+		comments: map[int64][]github.IssueComment{
+			42: {
+				{ID: 1, Body: "run_id: ranked-1\nitem-001 ranking: A > B = C > D\n", URL: "https://github.com/owner/repo/issues/42#issuecomment-1", Author: "alice", CreatedAt: "2026-06-02T10:00:00Z"},
+			},
+		},
+	}
+	collector := GitHubCollector{BlobStore: blobs, GitHub: fake}
+
+	result, err := collector.Sync(ctx, store, "ranked-1", github.Repository{Owner: "owner", Name: "repo"}, 42)
+	if err != nil {
+		t.Fatalf("Sync returned error: %v", err)
+	}
+	if result.Count() != 1 || len(result.RankedFeedbackEvents) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.RankedFeedbackEvents[0]
+	if event.Winner != "a" || event.TieGroupsJSON != `[["a"],["b","c"],["d"]]` {
+		t.Fatalf("tied ranked event = %+v", event)
+	}
+	pairs, err := store.ListPairwisePreferences(ctx, "ranked-1")
+	if err != nil {
+		t.Fatalf("ListPairwisePreferences returned error: %v", err)
+	}
+	if len(pairs) != 5 {
+		t.Fatalf("partial tie pairwise preferences len = %d, want 5: %+v", len(pairs), pairs)
+	}
+	for _, pair := range pairs {
+		if (pair.Preferred == "b" && pair.Rejected == "c") || (pair.Preferred == "c" && pair.Rejected == "b") {
+			t.Fatalf("partial tie emitted in-group preference: %+v", pairs)
+		}
+	}
+}
+
 func TestGitHubCollectorSyncImportsRankedYAMLCommentWithColonItemID(t *testing.T) {
 	ctx := context.Background()
 	store, blobs := setupGitHubRankedFeedbackRunWithItem(t, "ranked-1", "scenario:landing", "owner/repo")

--- a/internal/feedback/markdown.go
+++ b/internal/feedback/markdown.go
@@ -58,6 +58,7 @@ type feedbackFileEntry struct {
 	ItemID               string              `yaml:"item_id"`
 	Choice               string              `yaml:"choice"`
 	Ranking              []string            `yaml:"ranking,omitempty"`
+	TieGroups            [][]string          `yaml:"-"`
 	Winner               string              `yaml:"winner,omitempty"`
 	UsefulTraits         map[string][]string `yaml:"useful_traits,omitempty"`
 	RejectedTraits       map[string][]string `yaml:"rejected_traits,omitempty"`
@@ -443,7 +444,7 @@ func rankedAssignmentsMatch(left blindAssignment, right blindAssignment) bool {
 }
 
 func rankedFeedbackEventFromEntry(runID string, itemID string, entry feedbackFileEntry, assignment blindAssignment, reviewer string, source string, sourceURL string, createdAt string) (db.RankedFeedbackEvent, error) {
-	ranking, err := normalizedRanking(entry.Ranking)
+	ranking, tieGroups, err := normalizedRankingWithTieGroups(entry)
 	if err != nil {
 		return db.RankedFeedbackEvent{}, err
 	}
@@ -487,6 +488,14 @@ func rankedFeedbackEventFromEntry(runID string, itemID string, entry feedbackFil
 	if err != nil {
 		return db.RankedFeedbackEvent{}, err
 	}
+	tieGroupsJSON := ""
+	if rankingHasTies(tieGroups) {
+		encoded, err := json.Marshal(tieGroups)
+		if err != nil {
+			return db.RankedFeedbackEvent{}, err
+		}
+		tieGroupsJSON = string(encoded)
+	}
 	usefulTraitsJSON, err := rankedTraitJSON(entry.UsefulTraits)
 	if err != nil {
 		return db.RankedFeedbackEvent{}, fmt.Errorf("useful_traits: %w", err)
@@ -501,13 +510,15 @@ func rankedFeedbackEventFromEntry(runID string, itemID string, entry feedbackFil
 	}
 	winner := normalizeReviewOptionLabel(entry.Winner)
 	if winner == "" {
-		winner = ranking[0]
+		if len(tieGroups) > 0 && len(tieGroups[0]) == 1 {
+			winner = ranking[0]
+		}
 	} else {
 		if _, ok := known[winner]; !ok {
 			return db.RankedFeedbackEvent{}, fmt.Errorf("winner references unknown option %q", winner)
 		}
-		if winner != ranking[0] {
-			return db.RankedFeedbackEvent{}, fmt.Errorf("winner %q does not match first ranked option %q", winner, ranking[0])
+		if len(tieGroups) == 0 || !rankingGroupContains(tieGroups[0], winner) {
+			return db.RankedFeedbackEvent{}, fmt.Errorf("winner %q is not in first ranked group", winner)
 		}
 	}
 	quality, continueMode, promote, err := normalizeRankedFeedbackSignals(entry)
@@ -518,6 +529,7 @@ func rankedFeedbackEventFromEntry(runID string, itemID string, entry feedbackFil
 		RunID:                    strings.TrimSpace(runID),
 		ItemID:                   strings.TrimSpace(itemID),
 		RankingJSON:              string(rankingJSON),
+		TieGroupsJSON:            tieGroupsJSON,
 		Winner:                   winner,
 		UsefulTraitsJSON:         usefulTraitsJSON,
 		RejectedTraitsJSON:       rejectedTraitsJSON,
@@ -573,24 +585,55 @@ func validateRankedTraitLabels(traits map[string][]string, known map[string]stru
 	return nil
 }
 
-func normalizedRanking(values []string) ([]string, error) {
-	ranking := make([]string, 0, len(values))
+func normalizedRankingWithTieGroups(entry feedbackFileEntry) ([]string, [][]string, error) {
+	groups := entry.TieGroups
+	if len(groups) == 0 {
+		_, groups = splitRankingLabelsAndTieGroups(entry.Ranking)
+	}
+	ranking := make([]string, 0, len(entry.Ranking))
+	tieGroups := make([][]string, 0, len(groups))
 	seen := map[string]struct{}{}
-	for _, value := range values {
-		label := normalizeReviewOptionLabel(value)
-		if label == "" {
-			return nil, errors.New("ranking contains an empty option label")
+	for groupIndex, group := range groups {
+		if len(group) == 0 {
+			return nil, nil, fmt.Errorf("ranking contains an empty tie group at position %d", groupIndex+1)
 		}
-		if _, ok := seen[label]; ok {
-			return nil, fmt.Errorf("ranking contains duplicate option label %q", label)
+		normalizedGroup := make([]string, 0, len(group))
+		for _, value := range group {
+			label := normalizeReviewOptionLabel(value)
+			if label == "" {
+				return nil, nil, errors.New("ranking contains an empty option label")
+			}
+			if _, ok := seen[label]; ok {
+				return nil, nil, fmt.Errorf("ranking contains duplicate option label %q", label)
+			}
+			seen[label] = struct{}{}
+			normalizedGroup = append(normalizedGroup, label)
+			ranking = append(ranking, label)
 		}
-		seen[label] = struct{}{}
-		ranking = append(ranking, label)
+		tieGroups = append(tieGroups, normalizedGroup)
 	}
 	if len(ranking) < 2 {
-		return nil, errors.New("ranking must include at least two options")
+		return nil, nil, errors.New("ranking must include at least two options")
 	}
-	return ranking, nil
+	return ranking, tieGroups, nil
+}
+
+func rankingHasTies(groups [][]string) bool {
+	for _, group := range groups {
+		if len(group) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func rankingGroupContains(group []string, label string) bool {
+	for _, value := range group {
+		if value == label {
+			return true
+		}
+	}
+	return false
 }
 
 func rankedTraitJSON(traits map[string][]string) (string, error) {
@@ -906,7 +949,7 @@ func normalizeFeedbackFileEntries(feedback *feedbackFile) {
 	for index := range feedback.Items {
 		feedback.Items[index].ItemID = strings.TrimSpace(feedback.Items[index].ItemID)
 		feedback.Items[index].Choice = strings.TrimSpace(feedback.Items[index].Choice)
-		feedback.Items[index].Ranking = splitRankingLabels(feedback.Items[index].Ranking)
+		feedback.Items[index].Ranking, feedback.Items[index].TieGroups = splitRankingLabelsAndTieGroups(feedback.Items[index].Ranking)
 		feedback.Items[index].Winner = strings.TrimSpace(feedback.Items[index].Winner)
 		feedback.Items[index].UsefulTraits = trimTraitMap(feedback.Items[index].UsefulTraits)
 		feedback.Items[index].RejectedTraits = trimTraitMap(feedback.Items[index].RejectedTraits)

--- a/internal/feedback/markdown_test.go
+++ b/internal/feedback/markdown_test.go
@@ -248,6 +248,48 @@ items:
 	}
 }
 
+func TestMarkdownCollectorImportsTiedRankedPacket(t *testing.T) {
+	ctx := context.Background()
+	store, blobs := setupMarkdownRankedFeedbackRun(t, "ranked-1")
+	packetDir := filepath.Join(t.TempDir(), "packet")
+	collector := MarkdownCollector{BlobStore: blobs}
+	if err := collector.WritePacket(ctx, store, "ranked-1", packetDir); err != nil {
+		t.Fatalf("WritePacket returned error: %v", err)
+	}
+	feedbackContent := `run_id: ranked-1
+reviewer: jerry
+items:
+  - item_id: item-001
+    ranking:
+      - A = B = C = D
+    quality: poor
+    continue_mode: explore
+    promote: no
+    choice: All options are equally weak.
+`
+	if err := os.WriteFile(filepath.Join(packetDir, "feedback.yml"), []byte(feedbackContent), 0o644); err != nil {
+		t.Fatalf("write feedback.yml: %v", err)
+	}
+	result, err := collector.ImportPacket(ctx, store, packetDir, "")
+	if err != nil {
+		t.Fatalf("ImportPacket returned error: %v", err)
+	}
+	if result.Count() != 1 || len(result.RankedFeedbackEvents) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.RankedFeedbackEvents[0]
+	if event.Winner != "" || event.TieGroupsJSON != `[["a","b","c","d"]]` {
+		t.Fatalf("tied ranked event = %+v", event)
+	}
+	pairs, err := store.ListPairwisePreferences(ctx, "ranked-1")
+	if err != nil {
+		t.Fatalf("ListPairwisePreferences returned error: %v", err)
+	}
+	if len(pairs) != 0 {
+		t.Fatalf("tied ranking pairwise preferences = %+v, want none", pairs)
+	}
+}
+
 func TestMarkdownCollectorRejectsInvalidRankedWinnerWithoutPartialImport(t *testing.T) {
 	ctx := context.Background()
 	store, blobs := setupMarkdownRankedFeedbackRun(t, "ranked-1")

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -188,6 +188,7 @@ type RankedFeedbackEvent struct {
 	RunID                string          `json:"run_id"`
 	ItemID               string          `json:"item_id"`
 	Ranking              []string        `json:"ranking"`
+	TieGroups            [][]string      `json:"tie_groups,omitempty"`
 	Winner               string          `json:"winner,omitempty"`
 	UsefulTraits         json.RawMessage `json:"useful_traits,omitempty"`
 	RejectedTraits       json.RawMessage `json:"rejected_traits,omitempty"`
@@ -977,6 +978,10 @@ func loadRankedFeedbackEvents(ctx context.Context, store *db.Store, runID string
 		if err != nil {
 			return nil, err
 		}
+		tieGroups, err := rankedFeedbackTieGroups(event, ranking)
+		if err != nil {
+			return nil, err
+		}
 		usefulTraits, err := rawJSON(event.UsefulTraitsJSON)
 		if err != nil {
 			return nil, fmt.Errorf("ranked feedback %s useful_traits_json: %w", event.ID, err)
@@ -994,6 +999,7 @@ func loadRankedFeedbackEvents(ctx context.Context, store *db.Store, runID string
 			RunID:                event.RunID,
 			ItemID:               event.ItemID,
 			Ranking:              ranking,
+			TieGroups:            tieGroups,
 			Winner:               event.Winner,
 			UsefulTraits:         usefulTraits,
 			RejectedTraits:       rejectedTraits,
@@ -1017,6 +1023,31 @@ func rankedFeedbackRanking(event db.RankedFeedbackEvent) ([]string, error) {
 		return nil, fmt.Errorf("ranked feedback %s ranking_json: %w", event.ID, err)
 	}
 	return ranking, nil
+}
+
+func rankedFeedbackTieGroups(event db.RankedFeedbackEvent, ranking []string) ([][]string, error) {
+	if strings.TrimSpace(event.TieGroupsJSON) == "" {
+		return nil, nil
+	}
+	var groups [][]string
+	if err := json.Unmarshal([]byte(event.TieGroupsJSON), &groups); err != nil {
+		return nil, fmt.Errorf("ranked feedback %s tie_groups_json: %w", event.ID, err)
+	}
+	flattened := make([]string, 0, len(ranking))
+	for _, group := range groups {
+		for _, label := range group {
+			flattened = append(flattened, strings.TrimSpace(strings.ToLower(label)))
+		}
+	}
+	if len(flattened) != len(ranking) {
+		return nil, fmt.Errorf("ranked feedback %s tie_groups_json does not match ranking length", event.ID)
+	}
+	for index, label := range ranking {
+		if flattened[index] != strings.TrimSpace(strings.ToLower(label)) {
+			return nil, fmt.Errorf("ranked feedback %s tie_groups_json does not match ranking order", event.ID)
+		}
+	}
+	return groups, nil
 }
 
 func loadPairwisePreferences(ctx context.Context, store *db.Store, runID string) ([]PairwisePreference, error) {

--- a/internal/skillopt/phase.go
+++ b/internal/skillopt/phase.go
@@ -283,6 +283,15 @@ func normalizedWinner(event db.RankedFeedbackEvent) string {
 	if winner != "" {
 		return winner
 	}
+	if strings.TrimSpace(event.TieGroupsJSON) != "" {
+		var groups [][]string
+		if err := json.Unmarshal([]byte(event.TieGroupsJSON), &groups); err == nil && len(groups) > 0 {
+			if len(groups[0]) != 1 {
+				return "tie"
+			}
+			return strings.TrimSpace(strings.ToLower(groups[0][0]))
+		}
+	}
 	var ranking []string
 	if err := json.Unmarshal([]byte(event.RankingJSON), &ranking); err != nil || len(ranking) == 0 {
 		return ""

--- a/internal/skillopt/phase_test.go
+++ b/internal/skillopt/phase_test.go
@@ -84,6 +84,26 @@ func TestRecommendPhaseExploreTieStaysExplore(t *testing.T) {
 	}
 }
 
+func TestRecommendPhaseCountsTopTieAsFeedback(t *testing.T) {
+	tiedTop := rankedEvent(t, "", "a", "b", "c", "d")
+	tiedTop.TieGroupsJSON = `[["a","b","c","d"]]`
+	ranked := []db.RankedFeedbackEvent{
+		rankedEvent(t, "c", "c", "a", "d", "b"),
+		rankedEvent(t, "c", "c", "d", "a", "b"),
+		tiedTop,
+	}
+	recommendation := RecommendPhase(
+		db.EvalRun{ID: "run-1", Mode: db.EvalRunModeExplore, ExplorationLevel: db.ExplorationLevelHigh},
+		nil,
+		ranked,
+		pairwisePreferences(12),
+	)
+
+	if recommendation.RankingStability != "c 2/3" {
+		t.Fatalf("ranking stability = %q, want c 2/3", recommendation.RankingStability)
+	}
+}
+
 func TestRecommendPhaseForItemsMissingFeedbackStaysCurrent(t *testing.T) {
 	items := []db.EvalReviewItem{
 		{ItemID: "item-001"},


### PR DESCRIPTION
WHAT
- Preserves tied ranked feedback semantics for SkillOpt review feedback.

WHY
- Gitmoot ranked feedback needed to accept rankings such as `A = B = C = D` without converting ties into fake ordered pairwise preferences.

CHANGES
- Added `tie_groups_json` storage for ranked feedback events with an appended SQLite migration.
- Updated YAML and GitHub short-form feedback parsing to accept `=` tie groups.
- Preserved flat `ranking_json` for backward compatibility while exporting optional `tie_groups` in training packages.
- Updated pairwise preference generation to emit preferences only across tie groups, never inside the same tie group.
- Avoided fake winners for fully tied first groups and counted top ties correctly in phase stability.
- Added focused tests for all-tied rankings, partial ties, GitHub short form, Markdown import, invalid tie metadata, and phase stability.

RESULTS
- `git diff --check`: pass.
- `GOTOOLCHAIN=local go test ./internal/feedback ./internal/db ./internal/skillopt`: blocked before compile because this host has Go 1.22.2 and `go.mod` requires Go 1.26.
- `codex exec review --uncommitted`: no findings.

Raw final review output:
```text
No discrete correctness issues were found in the current code changes. Tests could not be run in this environment because the required Go 1.26 toolchain download was blocked by filesystem restrictions.
```

RISK
- Focused Go tests could not be executed locally due to the unavailable Go 1.26 toolchain. The changes are covered by new tests, but they need CI or a Go 1.26 environment to run.
