### PR TITLE
fix(skillopt): render text review options in tables

### DIFF
--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1377,7 +1377,10 @@ func TestSkillOptTrainContinueGeneratesOptionsWithManagedAgent(t *testing.T) {
 		!strings.Contains(stdout.String(), "preview_urls: 0") {
 		t.Fatalf("second continue stdout = %q", stdout.String())
 	}
-	if fakeGitHub.createdIssue.Repo.FullName() != "owner/product" || !strings.Contains(fakeGitHub.createdIssue.Body, "## Inline Options Without Public Links") {
+	if fakeGitHub.createdIssue.Repo.FullName() != "owner/product" ||
+		!strings.Contains(fakeGitHub.createdIssue.Body, "## Review Items") ||
+		!strings.Contains(fakeGitHub.createdIssue.Body, "| Option | Reply |") ||
+		strings.Contains(fakeGitHub.createdIssue.Body, "## Inline Options Without Public Links") {
 		t.Fatalf("created review issue = %+v", fakeGitHub.createdIssue)
 	}
 
@@ -1615,7 +1618,7 @@ func TestSkillOptTrainContinueGeneratesRequiredVuePreviewBundles(t *testing.T) {
 	}
 	wantPreviewURL := "https://owner.github.io/previews/runs/preview-train-review-001/hero-saas/a/"
 	if fakeGitHub.createdIssue.Repo.FullName() != "owner/previews" ||
-		!strings.Contains(fakeGitHub.createdIssue.Body, "Option A: [open]("+wantPreviewURL+")") ||
+		!strings.Contains(fakeGitHub.createdIssue.Body, "| A | [open]("+wantPreviewURL+") |") ||
 		strings.Contains(fakeGitHub.createdIssue.Body, "## Inline Options Without Public Links") ||
 		strings.Contains(fakeGitHub.createdIssue.Body, `"renderer":"vue-vite"`) {
 		t.Fatalf("created preview review issue = %+v\n%s", fakeGitHub.createdIssue, fakeGitHub.createdIssue.Body)

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -2,6 +2,7 @@ package feedback
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -172,16 +173,15 @@ func (c GitHubCollector) rankedBody(ctx context.Context, store *db.Store, run db
 		fmt.Fprintf(&builder, "- Train session: `%s`\n", iteration.SessionID)
 		fmt.Fprintf(&builder, "- Train iteration: `%s`\n", iteration.ID)
 	}
-	builder.WriteString("- Compare each item across the option links below.\n")
+	builder.WriteString("- Compare each item across the option links or inline text below.\n")
 	builder.WriteString("- Rank every option from best to worst using the exact labels shown.\n")
 	builder.WriteString("- Reply by copying the fenced `yaml` block below into a new comment and filling every item.\n")
 	builder.WriteString("- Valid `quality` values: `poor`, `acceptable`, `strong`.\n")
 	builder.WriteString("- Valid `continue_mode` values: `explore`, `refine`, `distill`, `validate`.\n")
 	builder.WriteString("- Valid `promote` values: `yes`, `no`.\n\n")
 	writePhaseRecommendation(&builder, recommendation)
-	builder.WriteString("## Review Table\n\n")
-	writeGitHubRankedReviewTable(&builder, items, assignments)
-	if err := c.writeUnlinkedRankedOptionContent(ctx, store, &builder, items, assignments); err != nil {
+	builder.WriteString("## Review Items\n\n")
+	if err := c.writeGitHubRankedReviewItems(ctx, store, &builder, items, assignments); err != nil {
 		return "", err
 	}
 	builder.WriteString("## Copy-Paste YAML Reply\n\n")
@@ -195,55 +195,137 @@ func (c GitHubCollector) rankedBody(ctx context.Context, store *db.Store, run db
 	return builder.String(), nil
 }
 
-func (c GitHubCollector) writeUnlinkedRankedOptionContent(ctx context.Context, store *db.Store, builder *strings.Builder, items []db.EvalReviewItem, assignments map[string]githubAssignment) error {
-	wroteHeader := false
+func (c GitHubCollector) writeGitHubRankedReviewItems(ctx context.Context, store *db.Store, builder *strings.Builder, items []db.EvalReviewItem, assignments map[string]githubAssignment) error {
 	for _, item := range items {
 		assignment := assignments[item.ItemID]
-		wroteItem := false
+		fmt.Fprintf(builder, "### `%s` - %s\n\n", item.ItemID, itemTitle(item))
+		if original := c.reviewItemOriginalText(ctx, store, item); original != "" {
+			builder.WriteString("Original post:\n")
+			writeMarkdownQuote(builder, original)
+			builder.WriteString("\n")
+		}
+		if contextText := reviewItemContextText(item); contextText != "" {
+			fmt.Fprintf(builder, "Context: %s\n\n", contextText)
+		}
+		builder.WriteString("| Option | Reply |\n")
+		builder.WriteString("| --- | --- |\n")
 		for _, option := range assignment.Options {
 			if optionHasPreviewBundleWithoutReference(option) {
 				return missingPreviewURLForBundleError(item.ItemID, option.Label)
 			}
-			if optionReference(option, false) != "" {
-				continue
-			}
-			content, err := c.optionText(ctx, store, option.ArtifactID)
+			preview, err := c.reviewOptionPreview(ctx, store, option)
 			if err != nil {
 				return fmt.Errorf("item %s option %s: %w", item.ItemID, option.Label, err)
 			}
-			if !wroteHeader {
-				builder.WriteString("## Inline Options Without Public Links\n\n")
-				builder.WriteString("These options do not have preview URLs yet, so their content is included here to keep the review actionable.\n\n")
-				wroteHeader = true
-			}
-			if !wroteItem {
-				fmt.Fprintf(builder, "### %s\n\n", itemTitle(item))
-				wroteItem = true
-			}
-			fmt.Fprintf(builder, "#### Option %s\n\n", displayOptionLabel(option.Label))
-			writeMarkdownFence(builder, content)
-			builder.WriteString("\n")
+			fmt.Fprintf(builder, "| %s | %s |\n", displayOptionLabel(option.Label), preview.MarkdownTableCell())
 		}
+		builder.WriteString("\n")
 	}
 	return nil
 }
 
-func writeGitHubRankedReviewTable(builder *strings.Builder, items []db.EvalReviewItem, assignments map[string]githubAssignment) {
-	builder.WriteString("| Item | What to compare | Options |\n")
-	builder.WriteString("| --- | --- | --- |\n")
-	for _, item := range items {
-		assignment := assignments[item.ItemID]
-		optionRefs := make([]string, 0, len(assignment.Options))
-		for _, option := range assignment.Options {
-			ref := optionReference(option, false)
-			if ref == "" {
-				ref = "`" + strings.ReplaceAll(option.ArtifactID, "`", "") + "`"
-			}
-			optionRefs = append(optionRefs, fmt.Sprintf("Option %s: %s", displayOptionLabel(option.Label), ref))
-		}
-		fmt.Fprintf(builder, "| `%s` | %s | %s |\n", item.ItemID, markdownTableCell(itemTitle(item)), markdownTableCell(strings.Join(optionRefs, "<br>")))
+type githubOptionPreview struct {
+	Content    string
+	IsMarkdown bool
+}
+
+func (p githubOptionPreview) MarkdownTableCell() string {
+	if p.IsMarkdown {
+		return markdownTableCell(p.Content)
 	}
-	builder.WriteString("\n")
+	return markdownTableCell(markdownInlineCode(p.Content))
+}
+
+func (c GitHubCollector) reviewOptionPreview(ctx context.Context, store *db.Store, option blindOptionAssignment) (githubOptionPreview, error) {
+	if ref := optionReference(option, false); ref != "" {
+		return githubOptionPreview{Content: ref, IsMarkdown: true}, nil
+	}
+	content, err := c.optionText(ctx, store, option.ArtifactID)
+	if err != nil {
+		return githubOptionPreview{}, err
+	}
+	return githubOptionPreview{Content: TextArtifactPreview(content)}, nil
+}
+
+func (c GitHubCollector) reviewItemOriginalText(ctx context.Context, store *db.Store, item db.EvalReviewItem) string {
+	metadata := reviewItemMetadata(item)
+	for _, key := range []string{"original_post", "original", "tweet", "post", "source_text", "input"} {
+		if value := metadataString(metadata, key); value != "" {
+			return value
+		}
+	}
+	if strings.TrimSpace(item.SourceArtifactID) == "" {
+		return ""
+	}
+	content, err := c.optionText(ctx, store, item.SourceArtifactID)
+	if err != nil {
+		return ""
+	}
+	return TextArtifactPreview(content)
+}
+
+func reviewItemContextText(item db.EvalReviewItem) string {
+	metadata := reviewItemMetadata(item)
+	for _, key := range []string{"context", "brief", "description"} {
+		if value := metadataString(metadata, key); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func reviewItemMetadata(item db.EvalReviewItem) map[string]any {
+	metadata := map[string]any{}
+	if strings.TrimSpace(item.MetadataJSON) != "" {
+		_ = json.Unmarshal([]byte(item.MetadataJSON), &metadata)
+	}
+	return metadata
+}
+
+func writeMarkdownQuote(builder *strings.Builder, value string) {
+	for _, line := range strings.Split(strings.TrimSpace(value), "\n") {
+		fmt.Fprintf(builder, "> %s\n", strings.TrimSpace(line))
+	}
+}
+
+func TextArtifactPreview(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(content), &decoded); err == nil {
+		if preview := textPreviewFromJSON(decoded); preview != "" {
+			return preview
+		}
+		if compact, err := json.Marshal(decoded); err == nil {
+			return string(compact)
+		}
+	}
+	return content
+}
+
+func textPreviewFromJSON(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case map[string]any:
+		for _, key := range []string{"reply", "tweet", "text", "post", "content", "message", "summary", "original_post", "original", "source_text", "input"} {
+			if text, ok := typed[key].(string); ok && strings.TrimSpace(text) != "" {
+				return strings.TrimSpace(text)
+			}
+		}
+	}
+	return ""
+}
+
+func markdownInlineCode(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "\n", " ")
+	value = strings.ReplaceAll(value, "`", "'")
+	if value == "" {
+		return "-"
+	}
+	return "`" + value + "`"
 }
 
 func markdownTableCell(value string) string {

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -173,6 +173,32 @@ func TestGitHubCollectorPublishesIssueBody(t *testing.T) {
 func TestGitHubCollectorPublishesRankedIssueBody(t *testing.T) {
 	ctx := context.Background()
 	store, blobs := setupGitHubRankedFeedbackRun(t, "ranked-1", "owner/repo")
+	sourceBlob, err := blobs.Put([]byte(`{"tweet":"original post text"}`))
+	if err != nil {
+		t.Fatalf("Put source returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "source-post", Hash: sourceBlob.Hash, MediaType: "application/json", SizeBytes: sourceBlob.Size, Driver: "text"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact source-post returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:            "ranked-1",
+		ItemID:           "item-001",
+		Title:            "Ranked Item",
+		SourceArtifactID: "source-post",
+		MetadataJSON:     `{"brief":"Pick the reply that sounds most human."}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem source update returned error: %v", err)
+	}
+	optionABlob, err := blobs.Put([]byte(`{"reply":"@team did each worker get its own meter [link](https://example.com)","risk":"low"}`))
+	if err != nil {
+		t.Fatalf("Put option a json returned error: %v", err)
+	}
+	if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{ID: "option-a-json", Hash: optionABlob.Hash, MediaType: "application/json", SizeBytes: optionABlob.Size, Driver: "text"}); err != nil {
+		t.Fatalf("UpsertEvalArtifact option-a-json returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{RunID: "ranked-1", ItemID: "item-001", Label: "a", ArtifactID: "option-a-json", Role: "option", MetadataJSON: `{"path":"/tmp/gitmoot-option-a.md"}`}); err != nil {
+		t.Fatalf("UpsertEvalReviewOption option-a-json returned error: %v", err)
+	}
 	fake := &fakeFeedbackGitHub{
 		issue: github.Issue{Number: 42, URL: "https://github.com/owner/repo/issues/42"},
 	}
@@ -194,14 +220,17 @@ func TestGitHubCollectorPublishesRankedIssueBody(t *testing.T) {
 		"Valid `quality` values: `poor`, `acceptable`, `strong`",
 		"Valid `continue_mode` values: `explore`, `refine`, `distill`, `validate`",
 		"Valid `promote` values: `yes`, `no`",
-		"## Review Table",
+		"## Review Items",
 		"## Phase Recommendation",
 		"recommend continue explore",
-		"| Item | What to compare | Options |",
-		"Option C: [open](https://example.com/c)",
-		"## Inline Options Without Public Links",
-		"#### Option A",
-		"option a answer",
+		"### `item-001` - Ranked Item",
+		"Original post:",
+		"> original post text",
+		"Context: Pick the reply that sounds most human.",
+		"| Option | Reply |",
+		"| A | `@team did each worker get its own meter [link](https://example.com)` |",
+		"| B | `option b answer` |",
+		"| C | [open](https://example.com/c) |",
 		"```yaml",
 		"run_id: ranked-1",
 		"item_id: item-001",
@@ -214,10 +243,32 @@ func TestGitHubCollectorPublishesRankedIssueBody(t *testing.T) {
 			t.Fatalf("ranked issue body missing %q:\n%s", want, body)
 		}
 	}
-	for _, leaked := range []string{"/tmp/gitmoot-option-a.md", "#### Option C", "option c answer"} {
+	for _, leaked := range []string{"## Review Table", "## Inline Options Without Public Links", "/tmp/gitmoot-option-a.md", "#### Option C", "option c answer", `"risk"`} {
 		if strings.Contains(body, leaked) {
 			t.Fatalf("ranked issue body leaked %q:\n%s", leaked, body)
 		}
+	}
+}
+
+func TestTextArtifactPreviewExtractsHumanFacingJSONField(t *testing.T) {
+	tests := map[string]struct {
+		content string
+		want    string
+	}{
+		"reply field":    {content: `{"reply":"hello there","risk":"low"}`, want: "hello there"},
+		"tweet field":    {content: `{"tweet":"tweet text"}`, want: "tweet text"},
+		"source field":   {content: `{"original_post":"source text"}`, want: "source text"},
+		"input field":    {content: `{"input":"input text"}`, want: "input text"},
+		"json string":    {content: `"plain json string"`, want: "plain json string"},
+		"compact object": {content: `{"z":2, "a":1}`, want: `{"a":1,"z":2}`},
+		"raw text":       {content: "not json", want: "not json"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := TextArtifactPreview(tt.content); got != tt.want {
+				t.Fatalf("TextArtifactPreview() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
WHAT
- Render ranked GitHub review items as per-item tables for text-style artifacts.
- Extract human-facing JSON fields such as reply/tweet/text before showing options.
- Preserve clickable preview links for Vue/GitHub Pages options.

WHY
- Text reply skills should show plain, reviewable tweets/replies instead of raw JSON blobs or separate fenced-code sections.
- Reviewers should be able to compare each item in the same table shape used manually in the Smithyx review issues.

CHANGES
- Replaced the old generic Review Table plus Inline Options Without Public Links section with per-item Review Items sections.
- Added original/source text and item context rendering when metadata or source artifacts are available.
- Added text preview extraction for common JSON fields while keeping preview_url links as markdown links.
- Updated GitHub feedback and skillopt CLI tests for the new table layout.

RESULTS
- `git diff --check` passed.
- `GOTOOLCHAIN=local go test ./internal/feedback ./internal/cli` could not run on this host because `go.mod` requires Go 1.26 and local Go is 1.22.2.

Raw final review output:
```text
No discrete correctness issues were found in the changed implementation or tests. The untracked GOAL files are planning documents and do not introduce runtime behavior.
```

RISK
- Low. The change is limited to GitHub feedback issue rendering and tests, with existing preview URL validation preserved.
