### PR TITLE
fix(skillopt): show text candidate sample previews

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1455,6 +1455,7 @@ type skillOptTrainCandidateReviewPreview struct {
 	Route        string
 	URL          string
 	Renderer     string
+	Content      string
 	Status       string
 	StatusReason string
 	Error        string
@@ -2233,11 +2234,6 @@ func publishSkillOptTrainCandidateSamplePreviews(ctx context.Context, paths conf
 		ArtifactID: artifactID,
 		Renderer:   skillopt.TrainPreviewRendererVueVite,
 	}
-	policy := skillopt.ResolveTrainPreviewPolicy(session)
-	if policy.Mode == skillopt.TrainPreviewModeNone || policy.Renderer != skillopt.TrainPreviewRendererVueVite || policy.Publisher != skillopt.TrainPreviewPublisherGitHubPages {
-		preview.Error = "candidate sample preview publishing is not configured for vue-vite GitHub Pages"
-		return []skillOptTrainCandidateReviewPreview{preview}
-	}
 	record, err := store.GetEvalArtifact(ctx, artifactID)
 	if err != nil {
 		preview.Error = err.Error()
@@ -2248,9 +2244,24 @@ func publishSkillOptTrainCandidateSamplePreviews(ctx context.Context, paths conf
 		preview.Error = err.Error()
 		return []skillOptTrainCandidateReviewPreview{preview}
 	}
+	policy := skillopt.ResolveTrainPreviewPolicy(session)
 	bundle, err := skillopt.ParsePreviewBundle(content)
 	if err != nil {
-		preview.Error = err.Error()
+		if policy.Mode == skillopt.TrainPreviewModeRequired && policy.Renderer == skillopt.TrainPreviewRendererVueVite {
+			preview.Error = err.Error()
+			return []skillOptTrainCandidateReviewPreview{preview}
+		}
+		textPreview, ok := skillOptTextArtifactPreview(record, content)
+		if !ok {
+			preview.Error = err.Error()
+			return []skillOptTrainCandidateReviewPreview{preview}
+		}
+		preview.Renderer = firstNonEmpty(strings.TrimSpace(record.Driver), strings.TrimSpace(record.MediaType), "text")
+		preview.Content = textPreview
+		return []skillOptTrainCandidateReviewPreview{preview}
+	}
+	if policy.Mode == skillopt.TrainPreviewModeNone || policy.Renderer != skillopt.TrainPreviewRendererVueVite || policy.Publisher != skillopt.TrainPreviewPublisherGitHubPages {
+		preview.Error = "candidate sample preview publishing is not configured for vue-vite GitHub Pages"
 		return []skillOptTrainCandidateReviewPreview{preview}
 	}
 	preview.Renderer = bundle.Renderer
@@ -2280,6 +2291,27 @@ func publishSkillOptTrainCandidateSamplePreviews(ctx context.Context, paths conf
 	preview.Status = publication.PagesStatus
 	preview.StatusReason = publication.StatusReason
 	return []skillOptTrainCandidateReviewPreview{preview}
+}
+
+func skillOptTextArtifactPreview(record db.EvalArtifact, content []byte) (string, bool) {
+	if !utf8.Valid(content) {
+		return "", false
+	}
+	mediaType := strings.ToLower(strings.TrimSpace(record.MediaType))
+	driver := strings.ToLower(strings.TrimSpace(record.Driver))
+	if driver != "" && driver != "text" {
+		return "", false
+	}
+	if !strings.HasPrefix(mediaType, "text/") &&
+		mediaType != "application/json" &&
+		mediaType != "application/x-ndjson" {
+		return "", false
+	}
+	text := truncateForMetadata(feedback.TextArtifactPreview(string(content)))
+	if strings.TrimSpace(text) == "" {
+		return "", false
+	}
+	return text, true
 }
 
 func skillOptCandidateSelectionSampleArtifactID(ctx context.Context, store *db.Store, candidateID string) string {
@@ -2329,6 +2361,7 @@ func skillOptCandidateReviewPreviewsMetadata(previews []skillOptTrainCandidateRe
 			"route":         preview.Route,
 			"url":           preview.URL,
 			"renderer":      preview.Renderer,
+			"content":       preview.Content,
 			"status":        preview.Status,
 			"status_reason": preview.StatusReason,
 			"error":         preview.Error,
@@ -2365,6 +2398,7 @@ func skillOptCandidateReviewPreviewsFromMetadata(value any) []skillOptTrainCandi
 			Route:        metadataString(metadata, "route"),
 			URL:          metadataString(metadata, "url"),
 			Renderer:     metadataString(metadata, "renderer"),
+			Content:      metadataString(metadata, "content"),
 			Status:       metadataString(metadata, "status"),
 			StatusReason: metadataString(metadata, "status_reason"),
 			Error:        metadataString(metadata, "error"),
@@ -2435,7 +2469,10 @@ func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, sess
 				fmt.Fprintf(&builder, "- %s: publish failed for `%s`: `%s`\n", label, preview.ArtifactID, truncateForMetadata(preview.Error))
 				continue
 			}
-			if strings.TrimSpace(preview.URL) != "" {
+			if strings.TrimSpace(preview.Content) != "" {
+				fmt.Fprintf(&builder, "- %s: inline preview from `%s`\n", label, preview.ArtifactID)
+				writeSkillOptMarkdownFence(&builder, preview.Content)
+			} else if strings.TrimSpace(preview.URL) != "" {
 				fmt.Fprintf(&builder, "- %s: [%s](%s)\n", label, preview.URL, preview.URL)
 			} else {
 				fmt.Fprintf(&builder, "- %s: `%s`\n", label, preview.ArtifactID)

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -4624,6 +4624,167 @@ func TestSkillOptTrainCandidateReviewBodyMarksNoOpNotPromotable(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainCandidateReviewBodyShowsTextSamplePreview(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	paths := config.PathsForHome(home)
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	candidate := cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with a text reply candidate.")
+	version, err := skillopt.ImportCandidatePackage(context.Background(), store, candidate, "candidate.json")
+	if err != nil {
+		t.Fatalf("ImportCandidatePackage returned error: %v", err)
+	}
+	review, err := store.GetAgentTemplateCandidateReview(context.Background(), version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview returned error: %v", err)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	content := []byte(`{"reply":"so thats why my limits vanished before lunch","risk":"low"}`)
+	blob, err := blobStore.Put(content)
+	if err != nil {
+		t.Fatalf("Put sample artifact returned error: %v", err)
+	}
+	sampleID := "optimizer-train/optimizer-train-001/planner@v2/candidate-selection-sample"
+	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+		ID:        sampleID,
+		Hash:      blob.Hash,
+		MediaType: "application/json",
+		SizeBytes: blob.Size,
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact sample returned error: %v", err)
+	}
+	review.SummaryMetadataJSON = fmt.Sprintf(`{"artifact_ids":[%q]}`, sampleID)
+	if err := store.UpsertAgentTemplateCandidateReview(context.Background(), review); err != nil {
+		t.Fatalf("UpsertAgentTemplateCandidateReview returned error: %v", err)
+	}
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration := db.SkillOptTrainIteration{
+		ID:                    "optimizer-train-001",
+		CandidateVersionID:    version.ID,
+		BaseTemplateVersionID: baseVersionID,
+	}
+	optionalPolicy, err := skillopt.BuildTrainPreviewPolicy("owner/product", "owner/previews", skillopt.TrainPreviewModeOptional, skillopt.TrainPreviewRendererVueVite, skillopt.TrainPreviewPublisherGitHubPages, "")
+	if err != nil {
+		t.Fatalf("BuildTrainPreviewPolicy optional returned error: %v", err)
+	}
+	optionalSession := session
+	optionalSession.MetadataJSON = skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil, optionalPolicy)
+	for _, tt := range []struct {
+		name    string
+		session db.SkillOptTrainSession
+	}{
+		{name: "no preview policy", session: session},
+		{name: "optional vue preview policy", session: optionalSession},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			previews := publishSkillOptTrainCandidateSamplePreviews(context.Background(), paths, store, tt.session, iteration)
+			body, err := skillOptTrainCandidateReviewBody(context.Background(), store, tt.session, iteration, home, nil, previews, nil)
+			if err != nil {
+				t.Fatalf("skillOptTrainCandidateReviewBody returned error: %v", err)
+			}
+			for _, want := range []string{
+				"### Candidate Sample Preview",
+				"Selection sample: inline preview from `optimizer-train/optimizer-train-001/planner@v2/candidate-selection-sample`",
+				"so thats why my limits vanished before lunch",
+				"Renderer: `text`",
+			} {
+				if !strings.Contains(body, want) {
+					t.Fatalf("candidate review body missing %q:\n%s", want, body)
+				}
+			}
+			for _, unwanted := range []string{
+				"Preview: no selected candidate sample artifact was available to publish.",
+				"candidate sample preview publishing is not configured",
+				`"risk"`,
+			} {
+				if strings.Contains(body, unwanted) {
+					t.Fatalf("candidate review body contained %q:\n%s", unwanted, body)
+				}
+			}
+		})
+	}
+	record, err := store.GetEvalArtifact(context.Background(), sampleID)
+	if err != nil {
+		t.Fatalf("GetEvalArtifact sample returned error: %v", err)
+	}
+	record.Driver = skillopt.TrainPreviewRendererVueVite
+	if err := store.UpsertEvalArtifact(context.Background(), record); err != nil {
+		t.Fatalf("UpsertEvalArtifact malformed preview driver returned error: %v", err)
+	}
+	previews := publishSkillOptTrainCandidateSamplePreviews(context.Background(), paths, store, optionalSession, iteration)
+	if len(previews) != 1 || previews[0].Error == "" {
+		t.Fatalf("optional malformed preview result = %+v, want bundle validation error", previews)
+	}
+	if strings.TrimSpace(previews[0].Content) != "" {
+		t.Fatalf("optional malformed preview unexpectedly used inline content: %+v", previews[0])
+	}
+}
+
+func TestSkillOptTrainCandidateReviewRequiredPreviewKeepsBundleFailure(t *testing.T) {
+	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
+	paths := config.PathsForHome(home)
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	candidate := cliSkillOptCandidatePackage(t, "planner", baseVersionID, "Plan with a text reply candidate.")
+	version, err := skillopt.ImportCandidatePackage(context.Background(), store, candidate, "candidate.json")
+	if err != nil {
+		t.Fatalf("ImportCandidatePackage returned error: %v", err)
+	}
+	review, err := store.GetAgentTemplateCandidateReview(context.Background(), version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview returned error: %v", err)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	content := []byte(`{"reply":"so thats why my limits vanished before lunch"}`)
+	blob, err := blobStore.Put(content)
+	if err != nil {
+		t.Fatalf("Put sample artifact returned error: %v", err)
+	}
+	sampleID := "optimizer-train/optimizer-train-001/planner@v2/candidate-selection-sample"
+	if err := store.UpsertEvalArtifact(context.Background(), db.EvalArtifact{
+		ID:        sampleID,
+		Hash:      blob.Hash,
+		MediaType: "application/json",
+		SizeBytes: blob.Size,
+		Driver:    "text",
+	}); err != nil {
+		t.Fatalf("UpsertEvalArtifact sample returned error: %v", err)
+	}
+	review.SummaryMetadataJSON = fmt.Sprintf(`{"artifact_ids":[%q]}`, sampleID)
+	if err := store.UpsertAgentTemplateCandidateReview(context.Background(), review); err != nil {
+		t.Fatalf("UpsertAgentTemplateCandidateReview returned error: %v", err)
+	}
+	requiredPolicy, err := skillopt.BuildTrainPreviewPolicy("owner/product", "owner/previews", skillopt.TrainPreviewModeRequired, skillopt.TrainPreviewRendererVueVite, skillopt.TrainPreviewPublisherGitHubPages, "")
+	if err != nil {
+		t.Fatalf("BuildTrainPreviewPolicy required returned error: %v", err)
+	}
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	session.MetadataJSON = skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil, requiredPolicy)
+	previews := publishSkillOptTrainCandidateSamplePreviews(context.Background(), paths, store, session, db.SkillOptTrainIteration{
+		ID:                    "optimizer-train-001",
+		CandidateVersionID:    version.ID,
+		BaseTemplateVersionID: baseVersionID,
+	})
+	if len(previews) != 1 || previews[0].Error == "" {
+		t.Fatalf("required preview result = %+v, want bundle validation error", previews)
+	}
+	if !strings.Contains(previews[0].Error, "preview bundle") {
+		t.Fatalf("required preview error = %q", previews[0].Error)
+	}
+	if strings.TrimSpace(previews[0].Content) != "" {
+		t.Fatalf("required preview unexpectedly used inline content: %+v", previews[0])
+	}
+}
+
 func TestSkillOptTrainContinuePublishesCandidateReviewAndRejects(t *testing.T) {
 	home, baseVersionID := seedSkillOptTrainFeedbackSynced(t)
 	runner := &skillOptTrainFakeOptimizerRunner{


### PR DESCRIPTION
## What
Show text candidate sample previews inline in SkillOpt candidate decision comments when the selected sample artifact is a text/JSON reply artifact.

## Why
For text reply skills, especially X-post/reply skills, the human should see the candidate output directly in the review/decision issue instead of a missing-preview message or raw JSON metadata. Vue/Vite preview behavior should remain strict when a Vue preview is required.

## Changes
- Preserve candidate sample preview content in candidate review preview metadata.
- Render inline fenced text for text/JSON candidate sample artifacts.
- Extract the human-facing JSON field through `feedback.TextArtifactPreview`, so reply text is shown without raw JSON fields like risk metadata.
- Keep malformed `vue-vite` preview artifacts as bundle errors instead of masking them as text.
- Add focused tests for optional/no preview text samples and required Vue preview failures.

## Checks
- `git diff --check` passed.
- `GOTOOLCHAIN=local go test ./internal/cli` is blocked on this host because local Go is 1.22.2 and `go.mod` requires Go 1.26.
- `codex exec review --uncommitted` raw output:

```text
No actionable correctness issues were identified in the changed code. The new inline text preview path preserves the existing Vue/Vite error/publish behavior while adding focused tests for text samples and required preview failures.
```

## Risk
Low. This only changes candidate decision comment rendering and leaves required Vue preview validation intact.