### PR TITLE
docs(skillopt): document tied rankings and text review tables

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -224,7 +224,11 @@ Low-level `skillopt feedback github publish` and `sync` enforce
 posting to the wrong repository.
 
 Review issues include a fenced `yaml` block so reviewers can copy, edit, and
-submit parseable feedback. `train continue` automatically syncs GitHub comments
+submit parseable feedback. Text reply skills render each review item as an
+`Option | Reply` table; JSON option artifacts show the human-facing text field
+such as `reply`, `tweet`, `text`, `post`, `content`, `message`, or `summary`
+instead of raw JSON metadata. Vue/Vite review items keep using preview links
+and missing-preview errors. `train continue` automatically syncs GitHub comments
 when the iteration is waiting in `review_published` and no feedback has been
 imported yet. Raw YAML and fenced YAML are both supported.
 
@@ -259,7 +263,11 @@ reminder, the watcher can still import it. If the watcher is not running, post
 the feedback YAML and use the prompt from the stale notice or run the CLI
 fallback manually.
 
-Reviewers can provide ranked feedback with optional quality and phase hints:
+Reviewers can provide ranked feedback with optional quality and phase hints.
+Use `>` for ordered preferences and `=` for ties. Gitmoot preserves tie groups
+when deriving pairwise preferences, so `A = B = C = D` imports as all tied and
+creates no pairwise winner, while `A > B = C > D` creates preferences across
+groups but not between `B` and `C`.
 
 ```yaml
 run_id: planner-train-review-001
@@ -267,7 +275,7 @@ reviewer: alice
 items:
   - item_id: release-plan
     ranking:
-      - C > A > D > B
+      - C > A = D > B
     quality: acceptable
     continue_mode: refine
     useful_traits:
@@ -493,9 +501,12 @@ These files let reviewers inspect the proposed skill, the baseline skill, and
 the candidate diff directly in GitHub. The review also separates selection
 score, evaluator/test scores, gate status, no-op status, and promotability so a
 candidate selected by the optimizer is not confused with a candidate that passed
-evaluator gates. If stored metadata marks the candidate as no-op or not
-promotable, the review body says promotion is unavailable instead of showing a
-promote command.
+evaluator gates. If the selected candidate sample is text or JSON, the review
+shows the same human-facing text inline under `Candidate Sample Preview`;
+Vue/Vite samples keep using GitHub Pages preview URLs, and missing samples keep
+the explicit no-sample message. If stored metadata marks the candidate as no-op
+or not promotable, the review body says promotion is unavailable instead of
+showing a promote command.
 
 Choose explicitly:
 
@@ -564,12 +575,16 @@ Manual smoke scenarios for review operations:
 1. Candidate decision: run a fake or dry-run train flow until candidate review
    is published. Confirm the review repo contains `best_skill.md`,
    `base_skill.md`, and `candidate.diff.md` under
-   `skillopt/runs/<session>/<iteration>/<candidate>/`. Run
+   `skillopt/runs/<session>/<iteration>/<candidate>/`, plus either a Vue preview
+   URL or inline text sample under `Candidate Sample Preview`. Run
    `gitmoot skillopt train status --session <id>` and confirm it is waiting for
    a candidate decision. Then run either `--promote <version>` or
    `--reject <version> --reason "<reason>"` and confirm status moves past the
    candidate decision gate.
-2. Preview publication status: run a Vue/Vite preview session with
+2. Text review display: publish a text/JSON review item and confirm the GitHub
+   issue shows an `Option | Reply` table and that tied rankings such as
+   `A = B = C = D` and `A > B = C > D` sync successfully.
+3. Preview publication status: run a Vue/Vite preview session with
    `--preview-repo owner/previews`, publish review items, and inspect the GitHub
    issue option links. Ready links should render as `open`; builds that have not
    completed should render as `pending deployment`; Pages failures should render

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -131,9 +131,15 @@ gitmoot skillopt train continue --session planner-train
 Low-level GitHub feedback publish/sync commands enforce the train run's
 expected review repo, so preview reviews cannot accidentally publish to the
 target product repo. Review issues include a fenced `yaml` block for copyable
-feedback, and `train continue` auto-syncs GitHub comments when the review is
+feedback. Text reply skills render each item as an `Option | Reply` table; JSON
+option artifacts show the human-facing text field such as `reply`, `tweet`,
+`text`, `post`, `content`, `message`, or `summary` instead of raw JSON
+metadata. Vue/Vite review items keep using preview links and missing-preview
+errors. `train continue` auto-syncs GitHub comments when the review is
 published and no feedback has been imported yet. Reviewers can use ranked
-feedback with optional quality and phase hints:
+feedback with optional quality and phase hints. Use `>` for ordered preferences
+and `=` for ties: `A = B = C = D` imports as all tied, while `A > B = C > D`
+creates preferences across tie groups but not between `B` and `C`.
 
 ```yaml
 run_id: planner-train-review-001
@@ -141,7 +147,7 @@ reviewer: alice
 items:
   - item_id: release-plan
     ranking:
-      - C > A > D > B
+      - C > A = D > B
     quality: acceptable
     continue_mode: refine
     reasoning: C is strongest, but A has a better risk summary.
@@ -193,8 +199,11 @@ commands. The review repo file contract is:
 These files let reviewers inspect the proposed skill, the baseline skill, and
 the candidate diff directly in GitHub. Candidate reviews also separate selection
 score, evaluator/test scores, gate status, no-op status, and promotability. If
-metadata marks the candidate as no-op or not promotable, the review says
-promotion is unavailable instead of showing a promote command.
+the selected candidate sample is text or JSON, the review shows the same
+human-facing text inline under `Candidate Sample Preview`; Vue/Vite samples keep
+using GitHub Pages preview URLs, and missing samples keep the explicit
+no-sample message. If metadata marks the candidate as no-op or not promotable,
+the review says promotion is unavailable instead of showing a promote command.
 
 Choose explicitly:
 
@@ -230,9 +239,13 @@ decisions without real model calls or real GitHub mutation.
 Manual smoke scenarios:
 
 1. Candidate decision: publish a candidate review, confirm the review repo has
-   `best_skill.md`, `base_skill.md`, and `candidate.diff.md`, then use status to
-   confirm the decision gate before promoting or rejecting with a reason.
-2. Preview publication status: publish Vue/Vite review options and confirm the
+   `best_skill.md`, `base_skill.md`, `candidate.diff.md`, and either a Vue
+   preview URL or inline text sample, then use status to confirm the decision
+   gate before promoting or rejecting with a reason.
+2. Text review display: publish a text/JSON review item and confirm the issue
+   shows an `Option | Reply` table and that tied rankings such as
+   `A = B = C = D` and `A > B = C > D` sync successfully.
+3. Preview publication status: publish Vue/Vite review options and confirm the
    issue links are labeled `open`, `pending deployment`, `failed deployment`,
    or `stale deployment` according to the GitHub Pages build state.
 


### PR DESCRIPTION
## WHAT
Document the ranked text-review UX added for issue #168 in both workflow docs.

## WHY
Task 4 of `GOAL-skillopt-ranked-review-ux.md` requires the SkillOpt workflow docs to explain tied rankings, text/JSON review tables, and inline candidate text samples.

## CHANGES
- Document tied ranking syntax with `A = B = C = D` and `A > B = C > D`.
- Document text/JSON review items rendering as `Option | Reply` tables with human-facing text fields.
- Document inline text/JSON candidate sample previews under `Candidate Sample Preview`.
- Update manual smoke scenarios to include text review display and candidate sample preview checks.
- Mirror the same behavior in the website workflow docs.

## RESULTS
- `git diff --check` passed.
- `GOTOOLCHAIN=local go test ./internal/feedback ./internal/db ./internal/skillopt ./internal/cli` is blocked because local Go is 1.22.2 and `go.mod` requires Go 1.26.
- `go test ./internal/feedback ./internal/db ./internal/skillopt ./internal/cli` attempted automatic toolchain download, but Go reported `toolchain not available` for go1.26.
- `GOTOOLCHAIN=local scripts/skillopt-train-smoke.sh` is blocked by the same local Go 1.22.2 vs Go 1.26 requirement.
- `codex exec review --uncommitted` raw output:

```text
The visible changes are documentation/goal-plan updates, and I did not find a discrete correctness issue introduced by them.
```

## RISK
Docs-only change. Runtime coverage for this final docs task could not run on this host because the required Go 1.26 toolchain is unavailable.