### PR TITLE
Render text SkillOpt previews as tables

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -2464,34 +2464,7 @@ func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, sess
 	if len(publishedPreviews) == 0 {
 		builder.WriteString("- Preview: no selected candidate sample artifact was available to publish.\n")
 	} else {
-		for _, preview := range publishedPreviews {
-			label := firstNonEmpty(strings.TrimSpace(preview.Label), "Selection sample")
-			if strings.TrimSpace(preview.Error) != "" {
-				fmt.Fprintf(&builder, "- %s: publish failed for `%s`: `%s`\n", label, preview.ArtifactID, truncateForMetadata(preview.Error))
-				continue
-			}
-			if strings.TrimSpace(preview.Content) != "" {
-				fmt.Fprintf(&builder, "- %s: inline preview from `%s`\n", label, preview.ArtifactID)
-				writeSkillOptMarkdownFence(&builder, preview.Content)
-			} else if strings.TrimSpace(preview.URL) != "" {
-				fmt.Fprintf(&builder, "- %s: [%s](%s)\n", label, preview.URL, preview.URL)
-			} else {
-				fmt.Fprintf(&builder, "- %s: `%s`\n", label, preview.ArtifactID)
-			}
-			if strings.TrimSpace(preview.ArtifactID) != "" {
-				fmt.Fprintf(&builder, "  - Evaluated artifact: `%s`\n", preview.ArtifactID)
-			}
-			if strings.TrimSpace(preview.Renderer) != "" {
-				fmt.Fprintf(&builder, "  - Renderer: `%s`\n", preview.Renderer)
-			}
-			if strings.TrimSpace(preview.Status) != "" {
-				statusText := preview.Status
-				if strings.TrimSpace(preview.StatusReason) != "" {
-					statusText += ": " + preview.StatusReason
-				}
-				fmt.Fprintf(&builder, "  - Pages status: `%s`\n", truncateForMetadata(statusText))
-			}
-		}
+		writeSkillOptCandidateSamplePreviewTable(&builder, publishedPreviews)
 	}
 	skillOptWriteCandidateReviewFinalEval(&builder, review)
 	if len(filePublishWarnings) > 0 {
@@ -2517,6 +2490,50 @@ func skillOptTrainCandidateReviewBody(ctx context.Context, store *db.Store, sess
 	fmt.Fprintf(&builder, "- Wait: take no action; `%s` will keep reporting that a candidate decision is required.\n", skillOptTrainStatusCommand(usesCustomHome, session.ID))
 	fmt.Fprintf(&builder, "- Keep improving: reject with an actionable reason, then run `%s` after the rejection completes.\n", skillOptTrainStartNextCommand(usesCustomHome, session.ID))
 	return builder.String(), nil
+}
+
+func writeSkillOptCandidateSamplePreviewTable(builder *strings.Builder, previews []skillOptTrainCandidateReviewPreview) {
+	builder.WriteString("| Sample | Preview | Artifact | Renderer | Status |\n")
+	builder.WriteString("| --- | --- | --- | --- | --- |\n")
+	for _, preview := range previews {
+		label := firstNonEmpty(strings.TrimSpace(preview.Label), "Selection sample")
+		fmt.Fprintf(
+			builder,
+			"| %s | %s | %s | %s | %s |\n",
+			skillOptMarkdownTableCell(label),
+			skillOptCandidateSamplePreviewCell(preview),
+			skillOptMarkdownTableCell(skillOptMarkdownInlineCode(preview.ArtifactID)),
+			skillOptMarkdownTableCell(skillOptMarkdownInlineCode(preview.Renderer)),
+			skillOptCandidateSamplePreviewStatusCell(preview),
+		)
+	}
+}
+
+func skillOptCandidateSamplePreviewCell(preview skillOptTrainCandidateReviewPreview) string {
+	if strings.TrimSpace(preview.Error) != "" {
+		return skillOptMarkdownTableCell(skillOptMarkdownInlineCode("publish failed"))
+	}
+	if strings.TrimSpace(preview.Content) != "" {
+		return skillOptMarkdownTableCell(skillOptMarkdownInlineCode(preview.Content))
+	}
+	if strings.TrimSpace(preview.URL) != "" {
+		return skillOptMarkdownTableCell(fmt.Sprintf("[open](%s)", strings.TrimSpace(preview.URL)))
+	}
+	return skillOptMarkdownTableCell(skillOptMarkdownInlineCode(preview.ArtifactID))
+}
+
+func skillOptCandidateSamplePreviewStatusCell(preview skillOptTrainCandidateReviewPreview) string {
+	if strings.TrimSpace(preview.Error) != "" {
+		return skillOptMarkdownTableCell(skillOptMarkdownInlineCode("publish failed: " + truncateForMetadata(preview.Error)))
+	}
+	statusText := strings.TrimSpace(preview.Status)
+	if statusText == "" {
+		return "-"
+	}
+	if strings.TrimSpace(preview.StatusReason) != "" {
+		statusText += ": " + strings.TrimSpace(preview.StatusReason)
+	}
+	return skillOptMarkdownTableCell(skillOptMarkdownInlineCode(truncateForMetadata(statusText)))
 }
 
 func skillOptWriteCandidateReviewScores(builder *strings.Builder, review db.AgentTemplateCandidateReview) {
@@ -4775,6 +4792,24 @@ func previewBundleInlineFallback(bundle skillopt.PreviewBundle) string {
 		builder.WriteString("\n")
 	}
 	return builder.String()
+}
+
+func skillOptMarkdownInlineCode(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "\n", " ")
+	value = strings.ReplaceAll(value, "`", "'")
+	if value == "" {
+		return "-"
+	}
+	return "`" + value + "`"
+}
+
+func skillOptMarkdownTableCell(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "\n", " ")
+	value = strings.ReplaceAll(value, "|", "\\|")
+	if value == "" {
+		return "-"
+	}
+	return value
 }
 
 func writeSkillOptMarkdownFence(builder *strings.Builder, content string) {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -4730,9 +4730,8 @@ func TestSkillOptTrainCandidateReviewBodyShowsTextSamplePreview(t *testing.T) {
 			}
 			for _, want := range []string{
 				"### Candidate Sample Preview",
-				"Selection sample: inline preview from `optimizer-train/optimizer-train-001/planner@v2/candidate-selection-sample`",
-				"so thats why my limits vanished before lunch",
-				"Renderer: `text`",
+				"| Sample | Preview | Artifact | Renderer | Status |",
+				"| Selection sample | `so thats why my limits vanished before lunch` | `optimizer-train/optimizer-train-001/planner@v2/candidate-selection-sample` | `text` | - |",
 			} {
 				if !strings.Contains(body, want) {
 					t.Fatalf("candidate review body missing %q:\n%s", want, body)
@@ -4742,6 +4741,7 @@ func TestSkillOptTrainCandidateReviewBodyShowsTextSamplePreview(t *testing.T) {
 				"Preview: no selected candidate sample artifact was available to publish.",
 				"candidate sample preview publishing is not configured",
 				`"risk"`,
+				"```text",
 			} {
 				if strings.Contains(body, unwanted) {
 					t.Fatalf("candidate review body contained %q:\n%s", unwanted, body)

--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -310,6 +310,14 @@ func textPreviewFromJSON(value any) string {
 	case string:
 		return strings.TrimSpace(typed)
 	case map[string]any:
+		if worthReply, ok := typed["worth_reply"].(bool); ok && !worthReply {
+			for _, key := range []string{"reason", "skip_reason", "rationale", "summary"} {
+				if text, ok := typed[key].(string); ok && strings.TrimSpace(text) != "" {
+					return "skip: " + strings.TrimSpace(text)
+				}
+			}
+			return "skip"
+		}
 		for _, key := range []string{"reply", "tweet", "text", "post", "content", "message", "summary", "original_post", "original", "source_text", "input"} {
 			if text, ok := typed[key].(string); ok && strings.TrimSpace(text) != "" {
 				return strings.TrimSpace(text)

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -257,6 +257,8 @@ func TestTextArtifactPreviewExtractsHumanFacingJSONField(t *testing.T) {
 	}{
 		"reply field":    {content: `{"reply":"hello there","risk":"low"}`, want: "hello there"},
 		"tweet field":    {content: `{"tweet":"tweet text"}`, want: "tweet text"},
+		"skip decision":  {content: `{"worth_reply":false,"reason":"does not fit the voice"}`, want: "skip: does not fit the voice"},
+		"skip no reason": {content: `{"worth_reply":false}`, want: "skip"},
 		"source field":   {content: `{"original_post":"source text"}`, want: "source text"},
 		"input field":    {content: `{"input":"input text"}`, want: "input text"},
 		"json string":    {content: `"plain json string"`, want: "plain json string"},


### PR DESCRIPTION
## Summary
- render candidate sample previews in a compact markdown table
- preserve existing ranked review option tables for issue review items
- show text JSON artifacts with human-facing preview fields
- display worth_reply=false outputs as skip previews

## Checks
- GOTOOLCHAIN=go1.26.0 go test ./internal/feedback ./internal/cli -run 'TestGitHubCollectorPublishesRankedIssueBody|TestTextArtifactPreviewExtractsHumanFacingJSONField|TestSkillOptTrainCandidateReviewBodyShowsTextSamplePreview|TestSkillOptTrainCandidateReviewRequiredPreviewKeepsBundleFailure'
- git diff --check
- codex exec review --uncommitted