### PR TITLE
agent: validate autonomy policies

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -598,7 +598,7 @@ func runAgentStart(args []string, stdout, stderr io.Writer) int {
 		RepoScope:      repo.FullName(),
 		TemplateID:     strings.TrimSpace(*templateID),
 		Capabilities:   resolvedCapabilities,
-		AutonomyPolicy: *policy,
+		AutonomyPolicy: strings.TrimSpace(*policy),
 		HealthStatus:   "unknown",
 	}
 	if err := runtime.ValidateStartRequest(runtime.StartRequest{Agent: agent, Prompt: "preflight"}); err != nil {
@@ -749,7 +749,7 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 		RepoScope:      repoScope,
 		TemplateID:     strings.TrimSpace(*templateID),
 		Capabilities:   resolvedCapabilities,
-		AutonomyPolicy: *policy,
+		AutonomyPolicy: strings.TrimSpace(*policy),
 		HealthStatus:   "unknown",
 	}
 	if err := runtime.ValidateAgent(agent); err != nil {
@@ -1194,6 +1194,7 @@ func withStoreAndPaths(home string, fn func(config.Paths, *db.Store) error) erro
 }
 
 func dbAgent(agent runtime.Agent) db.Agent {
+	policy := runtime.NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy)
 	return db.Agent{
 		Name:           agent.Name,
 		Role:           agent.Role,
@@ -1202,12 +1203,13 @@ func dbAgent(agent runtime.Agent) db.Agent {
 		RepoScope:      agent.RepoScope,
 		TemplateID:     agent.TemplateID,
 		Capabilities:   agent.Capabilities,
-		AutonomyPolicy: agent.AutonomyPolicy,
+		AutonomyPolicy: policy,
 		HealthStatus:   agent.HealthStatus,
 	}
 }
 
 func runtimeAgent(agent db.Agent) runtime.Agent {
+	policy := runtime.NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy)
 	return runtime.Agent{
 		Name:           agent.Name,
 		Role:           agent.Role,
@@ -1216,7 +1218,7 @@ func runtimeAgent(agent db.Agent) runtime.Agent {
 		RepoScope:      agent.RepoScope,
 		TemplateID:     agent.TemplateID,
 		Capabilities:   agent.Capabilities,
-		AutonomyPolicy: agent.AutonomyPolicy,
+		AutonomyPolicy: policy,
 		HealthStatus:   agent.HealthStatus,
 	}
 }

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -94,6 +94,53 @@ func TestRunAgentSubscribeListRemove(t *testing.T) {
 	}
 }
 
+func TestRunAgentSubscribeValidatesAutonomyPolicy(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{
+		"agent", "subscribe", "audit",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "review",
+		"--policy", "workspace-write",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "audit")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.AutonomyPolicy != runtime.AutonomyPolicyWorkspaceWrite {
+		t.Fatalf("autonomy policy = %q", agent.AutonomyPolicy)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "subscribe", "badpolicy",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440002",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+		"--policy", "manual",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("invalid policy exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "autonomy policy") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
 func TestRunAgentAccessCommands(t *testing.T) {
 	home := t.TempDir()
 	var stdout, stderr bytes.Buffer

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -22,6 +22,11 @@ const (
 	LastRef       = "last"
 
 	healthPrompt = "Gitmoot health check. Reply OK only."
+
+	AutonomyPolicyAuto             = "auto"
+	AutonomyPolicyReadOnly         = "read-only"
+	AutonomyPolicyWorkspaceWrite   = "workspace-write"
+	AutonomyPolicyDangerFullAccess = "danger-full-access"
 )
 
 type Agent struct {
@@ -119,6 +124,9 @@ func validateStartRequest(agent Agent, runtimeName string, prompt string) error 
 }
 
 func validateAgentFields(agent Agent, requireRuntimeRef bool) error {
+	if _, err := NormalizeAutonomyPolicy(agent.AutonomyPolicy); err != nil {
+		return err
+	}
 	switch {
 	case strings.TrimSpace(agent.Name) == "":
 		return errors.New("agent name is required")
@@ -137,6 +145,29 @@ func validateAgentFields(agent Agent, requireRuntimeRef bool) error {
 		return err
 	}
 	return nil
+}
+
+func NormalizeAutonomyPolicy(policy string) (string, error) {
+	switch strings.TrimSpace(policy) {
+	case "", AutonomyPolicyAuto:
+		return AutonomyPolicyAuto, nil
+	case AutonomyPolicyReadOnly:
+		return AutonomyPolicyReadOnly, nil
+	case AutonomyPolicyWorkspaceWrite:
+		return AutonomyPolicyWorkspaceWrite, nil
+	case AutonomyPolicyDangerFullAccess:
+		return AutonomyPolicyDangerFullAccess, nil
+	default:
+		return "", fmt.Errorf("autonomy policy %q is not supported; use auto, read-only, workspace-write, or danger-full-access", strings.TrimSpace(policy))
+	}
+}
+
+func NormalizeStoredAutonomyPolicy(policy string) string {
+	normalized, err := NormalizeAutonomyPolicy(policy)
+	if err != nil {
+		return AutonomyPolicyAuto
+	}
+	return normalized
 }
 
 type CodexSessionResolver interface {

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -17,6 +17,17 @@ func TestValidateAgent(t *testing.T) {
 	if err := ValidateAgent(agent); err != nil {
 		t.Fatalf("ValidateAgent returned error: %v", err)
 	}
+	for _, policy := range []string{AutonomyPolicyAuto, AutonomyPolicyReadOnly, AutonomyPolicyWorkspaceWrite, AutonomyPolicyDangerFullAccess} {
+		agent.AutonomyPolicy = policy
+		if err := ValidateAgent(agent); err != nil {
+			t.Fatalf("ValidateAgent rejected policy %q: %v", policy, err)
+		}
+	}
+	agent.AutonomyPolicy = "manual"
+	if err := ValidateAgent(agent); err == nil {
+		t.Fatal("ValidateAgent accepted unsupported autonomy policy")
+	}
+	agent.AutonomyPolicy = ""
 	agent.RepoScope = ""
 	if err := ValidateAgent(agent); err != nil {
 		t.Fatalf("ValidateAgent rejected global agent without repo scope: %v", err)


### PR DESCRIPTION
## Summary
- add runtime-neutral autonomy policy constants and validation for auto, read-only, workspace-write, and danger-full-access
- normalize empty/legacy stored policies to auto when moving through CLI/runtime agent conversions
- cover subscribe persistence and invalid policy rejection in focused CLI/runtime tests

## Tests
- GOTOOLCHAIN=go1.26.0 go test ./internal/runtime -run TestValidateAgent -v
- GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestRunAgentSubscribeValidatesAutonomyPolicy|TestRunAgentSubscribeListRemove' -v -timeout 30s\n- GOTOOLCHAIN=go1.26.0 go test ./internal/db -run Test -timeout 30s\n- git diff --check\n\nNote: full `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -timeout 120s` was attempted earlier and timed out in unrelated `TestPublishGitHubPagesPreviewReportsPagesStatus/pending`.\n\n## Codex Review\n```text\ncodex\nNo discrete correctness issues were found in the current staged, unstaged, or untracked changes. The policy validation and normalization paths appear consistent with the new allowed autonomy policy values.\n```\n\nRefs #175