### PR TITLE
runtime: pass autonomy policy to adapters

### DIFF
--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -191,7 +191,9 @@ func (a CodexAdapter) Start(ctx context.Context, request StartRequest) (StartRes
 	if err := validateStartRequest(request.Agent, a.Name(), request.Prompt); err != nil {
 		return StartResult{}, err
 	}
-	result, err := a.runner().Run(ctx, a.Dir, "codex", "exec", "--json", "--", request.Prompt)
+	args := append([]string{"exec"}, codexSandboxArgs(request.Agent)...)
+	args = append(args, "--json", "--", request.Prompt)
+	result, err := a.runner().Run(ctx, a.Dir, "codex", args...)
 	if err != nil {
 		return StartResult{Raw: result.Stdout + result.Stderr}, commandError(result, err)
 	}
@@ -213,7 +215,8 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 	if err := a.verifySession(ctx, agent); err != nil {
 		return Result{}, err
 	}
-	args := []string{"exec", "resume"}
+	args := append([]string{"exec"}, codexSandboxArgs(agent)...)
+	args = append(args, "resume")
 	if agent.RuntimeRef == "last" {
 		args = append(args, "--last")
 	} else {
@@ -267,6 +270,19 @@ func (a CodexAdapter) sessionResolver() CodexSessionResolver {
 	return CodexSessionIndex{}
 }
 
+func codexSandboxArgs(agent Agent) []string {
+	switch NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy) {
+	case AutonomyPolicyReadOnly:
+		return []string{"--sandbox", "read-only"}
+	case AutonomyPolicyWorkspaceWrite:
+		return []string{"--sandbox", "workspace-write"}
+	case AutonomyPolicyDangerFullAccess:
+		return []string{"--sandbox", "danger-full-access"}
+	default:
+		return nil
+	}
+}
+
 type ClaudeAdapter struct {
 	Runner        subprocess.Runner
 	Dir           string
@@ -283,7 +299,7 @@ func (a ClaudeAdapter) Start(ctx context.Context, request StartRequest) (StartRe
 	if err != nil {
 		return StartResult{}, err
 	}
-	args := []string{"--session-id", runtimeRef, "-p", "--output-format", "json", "--", request.Prompt}
+	args := append(claudePermissionArgs(request.Agent), "--session-id", runtimeRef, "-p", "--output-format", "json", "--", request.Prompt)
 	result, err := a.runner().Run(ctx, a.Dir, "claude", args...)
 	if err != nil {
 		return StartResult{Raw: result.Stdout + result.Stderr}, commandError(result, err)
@@ -445,7 +461,7 @@ func newUUID() (string, error) {
 }
 
 func claudeArgs(agent Agent, prompt string, jsonOutput bool) []string {
-	args := []string{}
+	args := claudePermissionArgs(agent)
 	if agent.RuntimeRef == "last" {
 		args = append(args, "--continue")
 	} else {
@@ -456,6 +472,19 @@ func claudeArgs(agent Agent, prompt string, jsonOutput bool) []string {
 		args = append(args, "--output-format", "json")
 	}
 	return append(args, "--", prompt)
+}
+
+func claudePermissionArgs(agent Agent) []string {
+	switch NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy) {
+	case AutonomyPolicyReadOnly:
+		return []string{"--permission-mode", "plan"}
+	case AutonomyPolicyWorkspaceWrite:
+		return []string{"--permission-mode", "acceptEdits"}
+	case AutonomyPolicyDangerFullAccess:
+		return []string{"--permission-mode", "bypassPermissions"}
+	default:
+		return nil
+	}
 }
 
 func isClaudeJSONUnsupported(result subprocess.Result) bool {

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -96,6 +96,29 @@ func TestCodexStartCommandParsesThreadID(t *testing.T) {
 	runner.want(t, 0, "codex", "exec", "--json", "--", "initialize")
 }
 
+func TestCodexStartCommandAppliesAutonomyPolicy(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		policy  string
+		sandbox string
+	}{
+		{name: "read_only", policy: AutonomyPolicyReadOnly, sandbox: "read-only"},
+		{name: "workspace_write", policy: AutonomyPolicyWorkspaceWrite, sandbox: "workspace-write"},
+		{name: "danger_full_access", policy: AutonomyPolicyDangerFullAccess, sandbox: "danger-full-access"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: "not json\n" + `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440009"}` + "\n"}}}
+			adapter := CodexAdapter{Runner: runner}
+			agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RepoScope: "jerryfane/gitmoot", AutonomyPolicy: tt.policy}
+
+			if _, err := adapter.Start(context.Background(), StartRequest{Agent: agent, Prompt: "initialize"}); err != nil {
+				t.Fatalf("Start returned error: %v", err)
+			}
+			runner.want(t, 0, "codex", "exec", "--sandbox", tt.sandbox, "--json", "--", "initialize")
+		})
+	}
+}
+
 func TestCodexStartRejectsMissingThreadID(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"type":"turn.completed"}` + "\n"}}}
 	adapter := CodexAdapter{Runner: runner}
@@ -116,6 +139,29 @@ func TestCodexDeliverLastSessionCommand(t *testing.T) {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
 	runner.want(t, 0, "codex", "exec", "resume", "--last", "--", "continue")
+}
+
+func TestCodexDeliverCommandAppliesAutonomyPolicy(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		policy  string
+		sandbox string
+	}{
+		{name: "read_only", policy: AutonomyPolicyReadOnly, sandbox: "read-only"},
+		{name: "workspace_write", policy: AutonomyPolicyWorkspaceWrite, sandbox: "workspace-write"},
+		{name: "danger_full_access", policy: AutonomyPolicyDangerFullAccess, sandbox: "danger-full-access"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: "done"}}}
+			adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{exists: true}}
+			agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot", AutonomyPolicy: tt.policy}
+
+			if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
+				t.Fatalf("Deliver returned error: %v", err)
+			}
+			runner.want(t, 0, "codex", "exec", "--sandbox", tt.sandbox, "resume", "550e8400-e29b-41d4-a716-446655440001", "--", "review")
+		})
+	}
 }
 
 func TestCodexDeliverVerifiesNamedSession(t *testing.T) {
@@ -213,6 +259,34 @@ func TestClaudeStartCommandUsesGeneratedSessionID(t *testing.T) {
 	runner.want(t, 0, "claude", "--session-id", "550e8400-e29b-41d4-a716-446655440010", "-p", "--output-format", "json", "--", "initialize")
 }
 
+func TestClaudeStartCommandAppliesAutonomyPolicy(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		policy string
+		mode   string
+	}{
+		{name: "read_only", policy: AutonomyPolicyReadOnly, mode: "plan"},
+		{name: "workspace_write", policy: AutonomyPolicyWorkspaceWrite, mode: "acceptEdits"},
+		{name: "danger_full_access", policy: AutonomyPolicyDangerFullAccess, mode: "bypassPermissions"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"ready"}`}}}
+			adapter := ClaudeAdapter{
+				Runner: runner,
+				NewRuntimeRef: func() (string, error) {
+					return "550e8400-e29b-41d4-a716-446655440010", nil
+				},
+			}
+			agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RepoScope: "jerryfane/gitmoot", AutonomyPolicy: tt.policy}
+
+			if _, err := adapter.Start(context.Background(), StartRequest{Agent: agent, Prompt: "initialize"}); err != nil {
+				t.Fatalf("Start returned error: %v", err)
+			}
+			runner.want(t, 0, "claude", "--permission-mode", tt.mode, "--session-id", "550e8400-e29b-41d4-a716-446655440010", "-p", "--output-format", "json", "--", "initialize")
+		})
+	}
+}
+
 func TestClaudeStartDoesNotStoreSessionIDWhenCommandFails(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{Stderr: "failed"}},
@@ -241,6 +315,29 @@ func TestClaudeDeliverLastSessionCommand(t *testing.T) {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
 	runner.want(t, 0, "claude", "--continue", "-p", "--output-format", "json", "--", "review")
+}
+
+func TestClaudeDeliverCommandAppliesAutonomyPolicy(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		policy string
+		mode   string
+	}{
+		{name: "read_only", policy: AutonomyPolicyReadOnly, mode: "plan"},
+		{name: "workspace_write", policy: AutonomyPolicyWorkspaceWrite, mode: "acceptEdits"},
+		{name: "danger_full_access", policy: AutonomyPolicyDangerFullAccess, mode: "bypassPermissions"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"done"}`}}}
+			adapter := ClaudeAdapter{Runner: runner}
+			agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot", AutonomyPolicy: tt.policy}
+
+			if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
+				t.Fatalf("Deliver returned error: %v", err)
+			}
+			runner.want(t, 0, "claude", "--permission-mode", tt.mode, "--resume", "550e8400-e29b-41d4-a716-446655440002", "-p", "--output-format", "json", "--", "review")
+		})
+	}
 }
 
 func TestClaudeDeliverFallsBackToText(t *testing.T) {


### PR DESCRIPTION
## Summary
- map Gitmoot autonomy policies to runtime-specific Codex and Claude Code command flags
- apply the mappings to both session startup and job delivery/resume paths
- add fake-runner command tests for all non-auto policies across Codex and Claude start/deliver

## Why
This keeps permission policy names runtime-neutral in Gitmoot while letting each runtime adapter translate them at the command boundary.

## Tests
- codex exec --help
- codex exec resume --help
- codex exec --sandbox read-only resume --help
- codex exec --sandbox read-only resume --last --help
- claude --help
- GOTOOLCHAIN=go1.26.0 go test ./internal/runtime -run 'TestCodex(StartCommandParsesThreadID|StartCommandAppliesAutonomyPolicy|DeliverCommand|DeliverCommandAppliesAutonomyPolicy|DeliverLastSessionCommand)|TestClaude(StartCommandUsesGeneratedSessionID|StartCommandAppliesAutonomyPolicy|DeliverCommand|DeliverCommandAppliesAutonomyPolicy|DeliverLastSessionCommand|DeliverFallsBackToText)' -v\n- GOTOOLCHAIN=go1.26.0 go test ./internal/runtime -v\n- git diff --check\n\n## Codex Review\n```text\ncodex\nNo discrete correctness issues were found in the changed runtime adapter code or added tests. Focused Go tests could not be executed because the required toolchain download attempted to write outside the sandbox.\n```\n\n## Risk\nThe review sandbox could not run Go 1.26 tests itself, but the same focused runtime package tests passed locally with `GOTOOLCHAIN=go1.26.0`.\n\nRefs #175