### PR TITLE
Block read-only implementation jobs before runtime

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -270,7 +270,7 @@ func printAgentTypeUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot agent type list")
 	fmt.Fprintln(w, "  gitmoot agent type show <type>")
-	fmt.Fprintln(w, "  gitmoot agent type set <type> --runtime codex|claude --template <template-id> --max-background 2 --idle-timeout 20m")
+	fmt.Fprintln(w, "  gitmoot agent type set <type> --runtime codex|claude --template <template-id> --policy workspace-write --max-background 2 --idle-timeout 20m")
 }
 
 func runAgentTypeList(args []string, stdout, stderr io.Writer) int {
@@ -348,6 +348,7 @@ func runAgentTypeSet(args []string, stdout, stderr io.Writer) int {
 	runtimeName := fs.String("runtime", "", "agent runtime: codex or claude")
 	templateID := fs.String("template", "", "agent template")
 	role := fs.String("role", "", "agent role")
+	policy := fs.String("policy", "", "agent autonomy policy: auto, read-only, workspace-write, or danger-full-access")
 	maxBackground := fs.Int("max-background", -1, "maximum managed background instances")
 	idleTimeout := fs.String("idle-timeout", "", "managed instance idle timeout")
 	jobTimeout := fs.String("job-timeout", "", "managed job timeout")
@@ -403,6 +404,14 @@ func runAgentTypeSet(args []string, stdout, stderr io.Writer) int {
 	}
 	if strings.TrimSpace(*role) != "" {
 		entry.Role = strings.TrimSpace(*role)
+	}
+	if strings.TrimSpace(*policy) != "" {
+		normalized, err := runtime.NormalizeAutonomyPolicy(*policy)
+		if err != nil {
+			fmt.Fprintf(stderr, "invalid policy: %v\n", err)
+			return 2
+		}
+		entry.AutonomyPolicy = normalized
 	}
 	if *maxBackground == 0 || *maxBackground < -1 {
 		fmt.Fprintln(stderr, "max background must be positive")
@@ -526,6 +535,7 @@ func printAgentType(stdout io.Writer, entry config.AgentType) {
 	writeLine(stdout, "template: %s", entry.Template)
 	writeLine(stdout, "role: %s", entry.Role)
 	writeLine(stdout, "capabilities: %s", strings.Join(entry.Capabilities, ","))
+	writeLine(stdout, "policy: %s", runtime.NormalizeStoredAutonomyPolicy(entry.AutonomyPolicy))
 	writeLine(stdout, "max_background: %d", entry.MaxBackground)
 	writeLine(stdout, "idle_timeout: %s", entry.IdleTimeout)
 	writeLine(stdout, "job_timeout: %s", entry.JobTimeout)

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -51,6 +51,33 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err := store.UpsertRepo(ctx, record); err != nil {
 		return localAgentJobOutput{}, err
 	}
+	if agent, blocked, err := readOnlyManagedImplementationBlock(ctx, store, request, repo.FullName()); err != nil {
+		return localAgentJobOutput{}, err
+	} else if blocked {
+		job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+			ID:           localAgentJobID(request.Action, agent.Name),
+			Agent:        agent.Name,
+			Action:       request.Action,
+			Repo:         repo.FullName(),
+			Branch:       record.DefaultBranch,
+			Sender:       "local",
+			Instructions: request.Instructions,
+		})
+		if err != nil {
+			return localAgentJobOutput{}, err
+		}
+		if _, err := markJobPermissionBlocked(ctx, store, job.ID); err != nil {
+			return localAgentJobOutput{}, err
+		}
+		return localAgentJobOutput{
+			JobID:          job.ID,
+			State:          string(workflow.JobBlocked),
+			Repo:           repo.FullName(),
+			Agent:          job.Agent,
+			Action:         job.Type,
+			RawOutputCount: 0,
+		}, nil
+	}
 	agent, releaseAgentReservation, err := resolveLocalDispatchAgent(ctx, store, request, repo.FullName(), record)
 	if err != nil {
 		return localAgentJobOutput{}, err
@@ -86,6 +113,19 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	}
 	if err := releaseReservation(ctx); err != nil {
 		return localAgentJobOutput{}, err
+	}
+	if readOnlyImplementationBlocked(job.Type, runtimeAgent(agent)) {
+		if _, err := markJobPermissionBlocked(ctx, store, job.ID); err != nil {
+			return localAgentJobOutput{}, err
+		}
+		return localAgentJobOutput{
+			JobID:          job.ID,
+			State:          string(workflow.JobBlocked),
+			Repo:           repo.FullName(),
+			Agent:          job.Agent,
+			Action:         job.Type,
+			RawOutputCount: 0,
+		}, nil
 	}
 	if request.Background {
 		return localAgentJobOutput{
@@ -188,6 +228,37 @@ func resolveLocalDispatchAgent(ctx context.Context, store *db.Store, request loc
 	return ensureManagedAgentInstance(ctx, store, request.Home, typeName, repo, record)
 }
 
+func readOnlyManagedImplementationBlock(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string) (runtime.Agent, bool, error) {
+	if strings.TrimSpace(request.Action) != "implement" {
+		return runtime.Agent{}, false, nil
+	}
+	forceType := strings.TrimSpace(request.Type)
+	if forceType == "" {
+		if _, err := store.GetAgent(ctx, request.Agent); err == nil {
+			return runtime.Agent{}, false, nil
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return runtime.Agent{}, false, err
+		}
+	}
+	if !request.Background && !request.AllowManagedSync {
+		return runtime.Agent{}, false, nil
+	}
+	typeName := firstNonEmpty(forceType, request.Agent)
+	types, err := loadAgentTypeConfig(request.Home)
+	if err != nil {
+		return runtime.Agent{}, false, err
+	}
+	agentType, ok := types[typeName]
+	if !ok {
+		return runtime.Agent{}, false, nil
+	}
+	agent := runtimeAgentFromType(agentType, repo, typeName)
+	if !agentHasCapability(agent.Capabilities, request.Action) {
+		return runtime.Agent{}, false, fmt.Errorf("agent %q lacks %s capability", agent.Name, request.Action)
+	}
+	return agent, readOnlyImplementationBlocked(request.Action, agent), nil
+}
+
 func noopAgentReservationRelease(context.Context) error {
 	return nil
 }
@@ -257,7 +328,7 @@ func ensureManagedAgentInstance(ctx context.Context, store *db.Store, home strin
 			_ = releaseTypeLock(context.Background())
 		}
 	}()
-	if instance, ok, err := store.FindReusableAgentInstance(ctx, typeName, repo, now); err != nil {
+	if instance, ok, err := store.FindReusableAgentInstance(ctx, typeName, repo, agentType.AutonomyPolicy, now); err != nil {
 		return db.Agent{}, noopAgentReservationRelease, err
 	} else if ok {
 		if err := store.TouchAgentInstance(ctx, instance.Name, now, idleTimeout); err != nil {
@@ -270,12 +341,12 @@ func ensureManagedAgentInstance(ctx context.Context, store *db.Store, home strin
 		releaseOnError = false
 		return agent, releaseTypeLock, nil
 	}
-	count, err := store.CountActiveAgentInstances(ctx, typeName, now)
+	count, err := store.CountActiveAgentInstances(ctx, typeName, agentType.AutonomyPolicy, now)
 	if err != nil {
 		return db.Agent{}, noopAgentReservationRelease, err
 	}
 	if count >= agentType.MaxBackground {
-		instance, ok, err := store.FindActiveAgentInstance(ctx, typeName, repo, now)
+		instance, ok, err := store.FindActiveAgentInstance(ctx, typeName, repo, agentType.AutonomyPolicy, now)
 		if err != nil {
 			return db.Agent{}, noopAgentReservationRelease, err
 		}
@@ -306,18 +377,19 @@ func ensureManagedAgentInstance(ctx context.Context, store *db.Store, home strin
 		return db.Agent{}, noopAgentReservationRelease, err
 	}
 	reservedInstance := db.AgentInstance{
-		Name:         instanceAgent.Name,
-		Type:         agentType.Name,
-		Runtime:      instanceAgent.Runtime,
-		RuntimeRef:   "starting:" + instanceAgent.Name,
-		RepoFullName: repo,
-		Role:         instanceAgent.Role,
-		TemplateID:   instanceAgent.TemplateID,
-		Capabilities: instanceAgent.Capabilities,
-		State:        "starting",
-		CreatedAt:    formatManagedAgentTime(now),
-		LastUsedAt:   formatManagedAgentTime(now),
-		ExpiresAt:    formatManagedAgentTime(now.Add(jobTimeout)),
+		Name:           instanceAgent.Name,
+		Type:           agentType.Name,
+		Runtime:        instanceAgent.Runtime,
+		RuntimeRef:     "starting:" + instanceAgent.Name,
+		RepoFullName:   repo,
+		Role:           instanceAgent.Role,
+		TemplateID:     instanceAgent.TemplateID,
+		Capabilities:   instanceAgent.Capabilities,
+		AutonomyPolicy: instanceAgent.AutonomyPolicy,
+		State:          "starting",
+		CreatedAt:      formatManagedAgentTime(now),
+		LastUsedAt:     formatManagedAgentTime(now),
+		ExpiresAt:      formatManagedAgentTime(now.Add(jobTimeout)),
 	}
 	if err := store.UpsertAgentInstance(ctx, reservedInstance); err != nil {
 		return db.Agent{}, noopAgentReservationRelease, err
@@ -338,18 +410,19 @@ func ensureManagedAgentInstance(ctx context.Context, store *db.Store, home strin
 		return db.Agent{}, noopAgentReservationRelease, err
 	}
 	instance := db.AgentInstance{
-		Name:         instanceAgent.Name,
-		Type:         agentType.Name,
-		Runtime:      instanceAgent.Runtime,
-		RuntimeRef:   instanceAgent.RuntimeRef,
-		RepoFullName: repo,
-		Role:         instanceAgent.Role,
-		TemplateID:   instanceAgent.TemplateID,
-		Capabilities: instanceAgent.Capabilities,
-		State:        "starting",
-		CreatedAt:    formatManagedAgentTime(now),
-		LastUsedAt:   formatManagedAgentTime(now),
-		ExpiresAt:    formatManagedAgentTime(now.Add(jobTimeout)),
+		Name:           instanceAgent.Name,
+		Type:           agentType.Name,
+		Runtime:        instanceAgent.Runtime,
+		RuntimeRef:     instanceAgent.RuntimeRef,
+		RepoFullName:   repo,
+		Role:           instanceAgent.Role,
+		TemplateID:     instanceAgent.TemplateID,
+		Capabilities:   instanceAgent.Capabilities,
+		AutonomyPolicy: instanceAgent.AutonomyPolicy,
+		State:          "starting",
+		CreatedAt:      formatManagedAgentTime(now),
+		LastUsedAt:     formatManagedAgentTime(now),
+		ExpiresAt:      formatManagedAgentTime(now.Add(jobTimeout)),
 	}
 	if err := store.UpsertAgentInstance(ctx, instance); err != nil {
 		_ = store.DeleteAgentInstance(context.Background(), reservedInstance.Name)
@@ -425,7 +498,7 @@ func runtimeAgentFromType(agentType config.AgentType, repo string, name string) 
 		RepoScope:      repo,
 		TemplateID:     agentType.Template,
 		Capabilities:   agentType.Capabilities,
-		AutonomyPolicy: "auto",
+		AutonomyPolicy: runtime.NormalizeStoredAutonomyPolicy(agentType.AutonomyPolicy),
 		HealthStatus:   "idle",
 	}
 }

--- a/internal/cli/agent_permissions.go
+++ b/internal/cli/agent_permissions.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+const agentPermissionBlockedMessage = "This Gitmoot worker does not have write permissions, so implementation was not started. Start or subscribe a writable worker for implementation tasks, then rerun."
+
+func readOnlyImplementationBlocked(jobType string, agent runtime.Agent) bool {
+	return strings.TrimSpace(jobType) == "implement" &&
+		runtime.NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy) == runtime.AutonomyPolicyReadOnly
+}
+
+func markJobPermissionBlocked(ctx context.Context, store *db.Store, jobID string) (bool, error) {
+	if store == nil {
+		return false, errors.New("job store is required")
+	}
+	for _, from := range []workflow.JobState{workflow.JobQueued, workflow.JobRunning, workflow.JobFailed} {
+		transitioned, err := store.TransitionJobStateWithEvent(ctx, jobID, string(from), string(workflow.JobBlocked), db.JobEvent{
+			JobID:   jobID,
+			Kind:    string(workflow.JobBlocked),
+			Message: agentPermissionBlockedMessage,
+		})
+		if err != nil {
+			return false, err
+		}
+		if transitioned {
+			if err := store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: "permission_blocked", Message: agentPermissionBlockedMessage}); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func runtimePermissionFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, pattern := range []string{
+		"read-only file system",
+		"read-only mode",
+		"sandbox rejected write",
+		"sandbox denied write",
+		"sandbox blocked write",
+		"sandbox prevented write",
+		"sandbox is read-only",
+		"write permissions",
+		"write permission",
+		"write access denied",
+		"write operation denied",
+		"not allowed to write",
+		"cannot write",
+		"can't write",
+	} {
+		if strings.Contains(message, pattern) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -688,6 +688,7 @@ func TestRunAgentTypeSetListShowAndManagedBackgroundAsk(t *testing.T) {
 		"--home", home,
 		"--runtime", "codex",
 		"--role", "planner",
+		"--policy", "workspace-write",
 		"--max-background", "1",
 		"--idle-timeout", "20m",
 		"--job-timeout", "5m",
@@ -714,7 +715,7 @@ func TestRunAgentTypeSetListShowAndManagedBackgroundAsk(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("agent type show exit code = %d, stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "max_background: 1") || !strings.Contains(stdout.String(), "capabilities: ask") {
+	if !strings.Contains(stdout.String(), "max_background: 1") || !strings.Contains(stdout.String(), "capabilities: ask") || !strings.Contains(stdout.String(), "policy: workspace-write") {
 		t.Fatalf("agent type show output = %q", stdout.String())
 	}
 
@@ -736,7 +737,7 @@ func TestRunAgentTypeSetListShowAndManagedBackgroundAsk(t *testing.T) {
 	if len(runner.calls) != 1 {
 		t.Fatalf("runtime start calls = %+v, want one", runner.calls)
 	}
-	runner.want(t, 0, repoDir, "codex", "exec", "--json", "--")
+	runner.want(t, 0, repoDir, "codex", "exec", "--sandbox", "workspace-write", "--json", "--")
 
 	stdout.Reset()
 	stderr.Reset()
@@ -753,7 +754,7 @@ func TestRunAgentTypeSetListShowAndManagedBackgroundAsk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListAgentInstances returned error: %v", err)
 	}
-	if len(instances) != 1 || instances[0].Type != "planner" || instances[0].RuntimeRef != "550e8400-e29b-41d4-a716-446655440111" {
+	if len(instances) != 1 || instances[0].Type != "planner" || instances[0].RuntimeRef != "550e8400-e29b-41d4-a716-446655440111" || instances[0].AutonomyPolicy != runtime.AutonomyPolicyWorkspaceWrite {
 		t.Fatalf("instances = %+v", instances)
 	}
 	config, err := (jobWorker{Store: store, ConfigHome: home}).managedJobConfig(context.Background(), instances[0].Name)
@@ -824,6 +825,190 @@ func TestDispatchManagedSyncUsesJobTimeoutForRuntimeLock(t *testing.T) {
 	}
 }
 
+func TestDispatchManagedAgentStartsFreshInstanceWhenPolicyChanges(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--max-background", "1",
+		"--capability", "ask",
+		"--policy", "read-only",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set read-only exit code = %d, stderr=%s", code, stderr.String())
+	}
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440411"}` + "\n"},
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440412"}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "planner", "First", "--home", home, "--repo", "owner/repo", "--background"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("first managed ask exit code = %d, stderr=%s", code, stderr.String())
+	}
+	runner.want(t, 0, repoDir, "codex", "exec", "--sandbox", "read-only", "--json", "--")
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--max-background", "1",
+		"--capability", "ask",
+		"--policy", "workspace-write",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set workspace-write exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "ask", "planner", "Second", "--home", home, "--repo", "owner/repo", "--background"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("second managed ask exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("runtime start calls = %+v, want two", runner.calls)
+	}
+	runner.want(t, 1, repoDir, "codex", "exec", "--sandbox", "workspace-write", "--json", "--")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	instances, err := store.ListAgentInstances(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgentInstances returned error: %v", err)
+	}
+	policies := map[string]int{}
+	for _, instance := range instances {
+		policies[instance.AutonomyPolicy]++
+	}
+	if policies[runtime.AutonomyPolicyReadOnly] != 1 || policies[runtime.AutonomyPolicyWorkspaceWrite] != 1 {
+		t.Fatalf("instances = %+v, want one read-only and one workspace-write", instances)
+	}
+}
+
+func TestDispatchLocalAgentJobBlocksReadOnlyImplement(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(context.Background(), db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:           "lead",
+		Role:           "implementer",
+		Runtime:        runtime.ShellRuntime,
+		RuntimeRef:     "unused",
+		RepoScope:      "owner/repo",
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: runtime.AutonomyPolicyReadOnly,
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+
+	output, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		RepoFlag:     "owner/repo",
+		Agent:        "lead",
+		Action:       "implement",
+		Instructions: "Implement task 1.",
+		Home:         home,
+	})
+	if err != nil {
+		t.Fatalf("dispatchLocalAgentJob returned error: %v", err)
+	}
+
+	if output.State != string(workflow.JobBlocked) || output.Action != "implement" {
+		t.Fatalf("dispatch output = %+v", output)
+	}
+	job, err := store.GetJob(context.Background(), output.JobID)
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobBlocked) {
+		t.Fatalf("job state = %q, want blocked", job.State)
+	}
+	events, err := store.ListJobEvents(context.Background(), job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "permission_blocked") {
+		t.Fatalf("events = %+v, want permission_blocked", events)
+	}
+}
+
+func TestDispatchLocalAgentJobBlocksReadOnlyManagedImplementBeforeStart(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "type", "set", "builder",
+		"--home", home,
+		"--runtime", "codex",
+		"--policy", "read-only",
+		"--max-background", "1",
+		"--idle-timeout", "20m",
+		"--job-timeout", "45m",
+		"--capability", "implement",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	output, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		RepoFlag:         "owner/repo",
+		Agent:            "builder",
+		Action:           "implement",
+		Instructions:     "Implement task 1.",
+		Type:             "builder",
+		Home:             home,
+		AllowManagedSync: true,
+	})
+	if err != nil {
+		t.Fatalf("dispatchLocalAgentJob returned error: %v", err)
+	}
+
+	if output.State != string(workflow.JobBlocked) || output.Action != "implement" || output.Agent != "builder" {
+		t.Fatalf("dispatch output = %+v", output)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runtime was started before read-only block: %+v", runner.calls)
+	}
+	events, err := store.ListJobEvents(context.Background(), output.JobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "permission_blocked") {
+		t.Fatalf("events = %+v, want permission_blocked", events)
+	}
+}
+
 func TestEnsureManagedAgentInstanceKeepsNewInstanceReservedUntilRelease(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()
@@ -868,7 +1053,7 @@ func TestEnsureManagedAgentInstanceKeepsNewInstanceReservedUntilRelease(t *testi
 	if instance.State != "starting" || instance.RuntimeRef != "550e8400-e29b-41d4-a716-446655440333" {
 		t.Fatalf("instance before release = %+v", instance)
 	}
-	reusable, ok, err := store.FindReusableAgentInstance(context.Background(), "planner", "owner/repo", time.Now().UTC())
+	reusable, ok, err := store.FindReusableAgentInstance(context.Background(), "planner", "owner/repo", "auto", time.Now().UTC())
 	if err != nil {
 		t.Fatalf("FindReusableAgentInstance returned error: %v", err)
 	}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1500,6 +1500,21 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		return nil
 	}
 	agent := runtimeAgent(dbAgent)
+	if readOnlyImplementationBlocked(job.Type, agent) {
+		transitioned, err := markJobPermissionBlocked(ctx, w.Store, job.ID)
+		if err != nil {
+			return err
+		}
+		if !transitioned {
+			return nil
+		}
+		if err := blockTaskForPermissionBlockedJob(ctx, w.Store, job); err != nil {
+			return err
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, "", errors.New(agentPermissionBlockedMessage))
+		writeLine(w.Stdout, "job %s blocked: %s", job.ID, agentPermissionBlockedMessage)
+		return nil
+	}
 	checkout, err := w.CheckoutValidator(ctx, job, payload, agent)
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
@@ -1577,7 +1592,14 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		if markErr := w.handleRunJobError(ctx, job.ID, err); markErr != nil {
 			return markErr
 		}
-		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
+		commentErr := err
+		if job.Type == "implement" && runtimePermissionFailure(err) {
+			latest, latestErr := w.Store.GetJob(ctx, job.ID)
+			if latestErr == nil && latest.State == string(workflow.JobBlocked) {
+				commentErr = errors.New(agentPermissionBlockedMessage)
+			}
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, commentErr)
 		writeLine(w.Stdout, "job %s failed: %v", job.ID, err)
 		return nil
 	}
@@ -1649,6 +1671,43 @@ func (w jobWorker) runningJobContext(ctx context.Context, jobID string) (context
 		cancel()
 		<-done
 	}
+}
+
+func blockTaskForPermissionBlockedJob(ctx context.Context, store *db.Store, job db.Job) error {
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(payload.TaskID) == "" {
+		return nil
+	}
+	task := db.Task{
+		ID:           payload.TaskID,
+		RepoFullName: payload.Repo,
+		GoalID:       payload.GoalID,
+		Title:        payload.TaskTitle,
+		State:        string(workflow.TaskBlocked),
+		Branch:       payload.Branch,
+	}
+	existing, err := store.GetTask(ctx, payload.TaskID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	if err == nil {
+		if task.RepoFullName == "" {
+			task.RepoFullName = existing.RepoFullName
+		}
+		if task.GoalID == "" {
+			task.GoalID = existing.GoalID
+		}
+		if task.Title == "" {
+			task.Title = existing.Title
+		}
+		if task.Branch == "" {
+			task.Branch = existing.Branch
+		}
+	}
+	return store.UpsertTask(ctx, task)
 }
 
 func (w jobWorker) jobNeedsAdvanceRetry(ctx context.Context, jobID string) (bool, error) {
@@ -1914,6 +1973,18 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause er
 	latest, err := w.Store.GetJob(ctx, jobID)
 	if err != nil {
 		return err
+	}
+	if latest.Type == "implement" && runtimePermissionFailure(cause) {
+		payload, payloadErr := daemonJobPayload(latest)
+		if payloadErr != nil || payload.Result == nil {
+			transitioned, err := markJobPermissionBlocked(ctx, w.Store, jobID)
+			if err != nil {
+				return err
+			}
+			if transitioned {
+				return blockTaskForPermissionBlockedJob(ctx, w.Store, latest)
+			}
+		}
 	}
 	if latest.State == string(workflow.JobQueued) {
 		state := workflow.JobFailed

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -580,6 +580,313 @@ func TestRunQueuedJobsMarksShellAdapterFailure(t *testing.T) {
 	}
 }
 
+func TestRunQueuedJobsBlocksReadOnlyImplementBeforeRuntime(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskChangesRequested), Branch: "task-1"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-readonly-implement", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
+	comments := &cliPollFakeGitHub{}
+	checkoutCalls := 0
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"should not run","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		checkoutCalls++
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if checkoutCalls != 0 {
+		t.Fatalf("checkout validator calls = %d, want 0", checkoutCalls)
+	}
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want 0", adapter.calls)
+	}
+	job, err := store.GetJob(ctx, "job-readonly-implement")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobBlocked) {
+		t.Fatalf("job state = %q, want blocked", job.State)
+	}
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task state = %q, want blocked", task.State)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, string(workflow.JobBlocked)) || !daemonWorkerHasEvent(events, "permission_blocked") {
+		t.Fatalf("events = %+v, want blocked and permission_blocked", events)
+	}
+	if len(comments.posted) != 1 {
+		t.Fatalf("posted comments = %+v, want 1", comments.posted)
+	}
+	body := comments.posted[0].body
+	if !strings.Contains(body, "**Decision:** `blocked`") || !strings.Contains(body, agentPermissionBlockedMessage) {
+		t.Fatalf("comment body missing permission block:\n%s", body)
+	}
+}
+
+func TestRunQueuedJobsSkipsReadOnlySideEffectsWhenJobAlreadyMoved(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskChangesRequested), Branch: "task-1"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-readonly-race", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
+	jobSnapshot, err := store.GetJob(ctx, "job-readonly-race")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if transitioned, err := store.TransitionJobState(ctx, jobSnapshot.ID, string(workflow.JobQueued), string(workflow.JobCancelled)); err != nil || !transitioned {
+		t.Fatalf("TransitionJobState returned transitioned=%v err=%v", transitioned, err)
+	}
+	comments := &cliPollFakeGitHub{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		t.Fatal("checkout validator should not run")
+		return "", nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
+	}
+
+	if err := worker.run(ctx, jobSnapshot); err != nil {
+		t.Fatalf("worker.run returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-readonly-race")
+	if err != nil {
+		t.Fatalf("GetJob after run returned error: %v", err)
+	}
+	if job.State != string(workflow.JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskChangesRequested) {
+		t.Fatalf("task state = %q, want changes_requested", task.State)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if daemonWorkerHasEvent(events, "permission_blocked") {
+		t.Fatalf("events = %+v, did not want permission_blocked", events)
+	}
+	if len(comments.posted) != 0 {
+		t.Fatalf("posted comments = %+v, want none", comments.posted)
+	}
+}
+
+func TestRunQueuedJobsAllowsReadOnlyAsk(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgentWithPolicy(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-readonly-ask", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"approved","summary":"ask ran","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+	job, err := store.GetJob(ctx, "job-readonly-ask")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded", job.State)
+	}
+}
+
+func TestRunQueuedJobsNormalizesRuntimePermissionFailure(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskReviewing), Branch: "task-1"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-permission-fail", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
+	comments := &cliPollFakeGitHub{}
+	adapter := &cliWorkerFakeAdapter{err: errors.New("sandbox rejected write: permission denied")}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-permission-fail")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobBlocked) {
+		t.Fatalf("job state = %q, want blocked", job.State)
+	}
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task state = %q, want blocked", task.State)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "permission_blocked") {
+		t.Fatalf("events = %+v, want permission_blocked", events)
+	}
+	if len(comments.posted) != 1 || !strings.Contains(comments.posted[0].body, agentPermissionBlockedMessage) {
+		t.Fatalf("posted comments = %+v, want permission block comment", comments.posted)
+	}
+}
+
+func TestRunQueuedJobsPreservesGenericRuntimePermissionFailure(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskReviewing), Branch: "task-1"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-generic-permission-fail", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
+	comments := &cliPollFakeGitHub{}
+	adapter := &cliWorkerFakeAdapter{err: errors.New("permission denied reading api token")}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-generic-permission-fail")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskReviewing) {
+		t.Fatalf("task state = %q, want reviewing", task.State)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if daemonWorkerHasEvent(events, "permission_blocked") {
+		t.Fatalf("events = %+v, did not want permission_blocked", events)
+	}
+	if len(comments.posted) != 1 || strings.Contains(comments.posted[0].body, agentPermissionBlockedMessage) {
+		t.Fatalf("posted comments = %+v, want original failure comment", comments.posted)
+	}
+}
+
+func TestRunQueuedJobsPreservesAdvanceRetryForPostDeliveryPermissionError(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-advance-permission", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7})
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"implemented","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{
+			Store: store,
+			PayloadRefresher: func(context.Context, db.Job, workflow.JobPayload) (workflow.JobPayload, error) {
+				return workflow.JobPayload{}, errors.New("permission denied while refreshing implemented head")
+			},
+		}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-advance-permission")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded result preserved", job.State)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "advance_retry") {
+		t.Fatalf("events = %+v, want advance_retry", events)
+	}
+	if daemonWorkerHasEvent(events, "permission_blocked") {
+		t.Fatalf("events = %+v, did not want permission_blocked", events)
+	}
+}
+
 func TestRunQueuedJobsUsesMailboxRepairForMalformedOutput(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -2332,6 +2639,7 @@ func (f *cliPollFakeGitHub) GetUserPermission(context.Context, github.Repository
 type cliWorkerFakeAdapter struct {
 	mu                   sync.Mutex
 	output               string
+	err                  error
 	calls                int
 	delivered            []string
 	onDeliver            func()
@@ -2355,6 +2663,9 @@ func (f *cliWorkerFakeAdapter) Deliver(ctx context.Context, _ runtime.Agent, job
 		f.contextCancelled = true
 		f.mu.Unlock()
 		return runtime.Result{}, ctx.Err()
+	}
+	if f.err != nil {
+		return runtime.Result{}, f.err
 	}
 	return runtime.Result{Raw: f.output}, nil
 }
@@ -2410,6 +2721,11 @@ func seedDaemonWorkerRepo(t *testing.T, store *db.Store, fullName string, checko
 
 func seedDaemonWorkerAgent(t *testing.T, store *db.Store, name string, runtimeName string, runtimeRef string, capabilities []string, repo string) {
 	t.Helper()
+	seedDaemonWorkerAgentWithPolicy(t, store, name, runtimeName, runtimeRef, capabilities, repo, runtime.AutonomyPolicyAuto)
+}
+
+func seedDaemonWorkerAgentWithPolicy(t *testing.T, store *db.Store, name string, runtimeName string, runtimeRef string, capabilities []string, repo string, policy string) {
+	t.Helper()
 	if err := store.UpsertAgent(context.Background(), db.Agent{
 		Name:           name,
 		Role:           "worker",
@@ -2417,7 +2733,7 @@ func seedDaemonWorkerAgent(t *testing.T, store *db.Store, name string, runtimeNa
 		RuntimeRef:     runtimeRef,
 		RepoScope:      repo,
 		Capabilities:   capabilities,
-		AutonomyPolicy: "auto",
+		AutonomyPolicy: policy,
 		HealthStatus:   "ok",
 	}); err != nil {
 		t.Fatalf("UpsertAgent returned error: %v", err)

--- a/internal/config/agent_types.go
+++ b/internal/config/agent_types.go
@@ -9,14 +9,15 @@ import (
 )
 
 type AgentType struct {
-	Name          string
-	Runtime       string
-	Template      string
-	Role          string
-	Capabilities  []string
-	MaxBackground int
-	IdleTimeout   string
-	JobTimeout    string
+	Name           string
+	Runtime        string
+	Template       string
+	Role           string
+	Capabilities   []string
+	AutonomyPolicy string
+	MaxBackground  int
+	IdleTimeout    string
+	JobTimeout     string
 }
 
 func LoadAgentTypes(paths Paths) (map[string]AgentType, error) {
@@ -103,6 +104,9 @@ func applyAgentTypeDefaults(entry *AgentType) {
 	if len(entry.Capabilities) == 0 {
 		entry.Capabilities = []string{"ask"}
 	}
+	if strings.TrimSpace(entry.AutonomyPolicy) == "" {
+		entry.AutonomyPolicy = "auto"
+	}
 	if entry.MaxBackground <= 0 {
 		entry.MaxBackground = 1
 	}
@@ -132,6 +136,17 @@ func applyAgentTypeField(entry *AgentType, key string, value string) error {
 		parsed, err := parseConfigStringArray(value)
 		entry.Capabilities = parsed
 		return err
+	case "autonomy_policy":
+		parsed, err := parseConfigString(value)
+		if err != nil {
+			return err
+		}
+		parsed = strings.TrimSpace(parsed)
+		if err := validateAgentTypeAutonomyPolicy(parsed); err != nil {
+			return err
+		}
+		entry.AutonomyPolicy = parsed
+		return nil
 	case "max_background":
 		parsed, err := strconv.Atoi(value)
 		entry.MaxBackground = parsed
@@ -146,6 +161,15 @@ func applyAgentTypeField(entry *AgentType, key string, value string) error {
 		return err
 	default:
 		return nil
+	}
+}
+
+func validateAgentTypeAutonomyPolicy(policy string) error {
+	switch strings.TrimSpace(policy) {
+	case "", "auto", "read-only", "workspace-write", "danger-full-access":
+		return nil
+	default:
+		return fmt.Errorf("unsupported autonomy policy %q; use auto, read-only, workspace-write, or danger-full-access", strings.TrimSpace(policy))
 	}
 }
 
@@ -234,7 +258,9 @@ func writeAgentTypeBlock(builder *strings.Builder, entry AgentType) {
 		}
 		builder.WriteString(strconv.Quote(capability))
 	}
-	builder.WriteString("]\nmax_background = ")
+	builder.WriteString("]\nautonomy_policy = ")
+	builder.WriteString(strconv.Quote(entry.AutonomyPolicy))
+	builder.WriteString("\nmax_background = ")
 	builder.WriteString(strconv.Itoa(entry.MaxBackground))
 	builder.WriteString("\nidle_timeout = ")
 	builder.WriteString(strconv.Quote(entry.IdleTimeout))

--- a/internal/config/agent_types_test.go
+++ b/internal/config/agent_types_test.go
@@ -17,6 +17,7 @@ runtime = "codex"
 template = "planner"
 role = "planner"
 capabilities = ["ask", "review"]
+autonomy_policy = " workspace-write "
 max_background = 2
 idle_timeout = "15m"
 job_timeout = "5m"
@@ -28,12 +29,13 @@ job_timeout = "5m"
 		t.Fatalf("LoadAgentTypes returned error: %v", err)
 	}
 	planner := types["planner"]
-	if planner.Runtime != "codex" || planner.Template != "planner" || planner.Role != "planner" || planner.MaxBackground != 2 || planner.IdleTimeout != "15m" || strings.Join(planner.Capabilities, ",") != "ask,review" {
+	if planner.Runtime != "codex" || planner.Template != "planner" || planner.Role != "planner" || planner.AutonomyPolicy != "workspace-write" || planner.MaxBackground != 2 || planner.IdleTimeout != "15m" || strings.Join(planner.Capabilities, ",") != "ask,review" {
 		t.Fatalf("planner type = %+v", planner)
 	}
 
 	planner.MaxBackground = 3
 	planner.Capabilities = []string{"ask"}
+	planner.AutonomyPolicy = "read-only"
 	if err := SaveAgentType(paths, planner); err != nil {
 		t.Fatalf("SaveAgentType returned error: %v", err)
 	}
@@ -41,7 +43,7 @@ job_timeout = "5m"
 	if err != nil {
 		t.Fatalf("LoadAgentTypes after save returned error: %v", err)
 	}
-	if updated["planner"].MaxBackground != 3 || strings.Join(updated["planner"].Capabilities, ",") != "ask" {
+	if updated["planner"].MaxBackground != 3 || updated["planner"].AutonomyPolicy != "read-only" || strings.Join(updated["planner"].Capabilities, ",") != "ask" {
 		t.Fatalf("updated planner type = %+v", updated["planner"])
 	}
 }
@@ -80,6 +82,25 @@ runtime = "codex"
 	}
 	if strings.Contains(string(content), `template = "planner"`) {
 		t.Fatalf("SaveAgentType wrote template from retired alias:\n%s", string(content))
+	}
+}
+
+func TestLoadAgentTypesRejectsInvalidAutonomyPolicy(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[agents.planner]
+runtime = "codex"
+autonomy_policy = "read_only"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	_, err := LoadAgentTypes(paths)
+	if err == nil || !strings.Contains(err.Error(), "unsupported autonomy policy") {
+		t.Fatalf("LoadAgentTypes error = %v, want unsupported autonomy policy", err)
 	}
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -102,18 +102,19 @@ type AgentRepo struct {
 }
 
 type AgentInstance struct {
-	Name         string
-	Type         string
-	Runtime      string
-	RuntimeRef   string
-	RepoFullName string
-	Role         string
-	TemplateID   string
-	Capabilities []string
-	State        string
-	CreatedAt    string
-	LastUsedAt   string
-	ExpiresAt    string
+	Name           string
+	Type           string
+	Runtime        string
+	RuntimeRef     string
+	RepoFullName   string
+	Role           string
+	TemplateID     string
+	Capabilities   []string
+	AutonomyPolicy string
+	State          string
+	CreatedAt      string
+	LastUsedAt     string
+	ExpiresAt      string
 }
 
 type Goal struct {
@@ -595,6 +596,10 @@ func (s *Store) GetAgent(ctx context.Context, name string) (Agent, error) {
 	if err != nil {
 		return Agent{}, err
 	}
+	policy := strings.TrimSpace(instance.AutonomyPolicy)
+	if policy == "" {
+		policy = "auto"
+	}
 	return Agent{
 		Name:           instance.Name,
 		Role:           instance.Role,
@@ -603,7 +608,7 @@ func (s *Store) GetAgent(ctx context.Context, name string) (Agent, error) {
 		RepoScope:      instance.RepoFullName,
 		TemplateID:     instance.TemplateID,
 		Capabilities:   instance.Capabilities,
-		AutonomyPolicy: "auto",
+		AutonomyPolicy: policy,
 		HealthStatus:   instance.State,
 	}, nil
 }
@@ -1239,8 +1244,11 @@ func (s *Store) UpsertAgentInstance(ctx context.Context, instance AgentInstance)
 	instance.CreatedAt = normalizeStoredTime(instance.CreatedAt)
 	instance.LastUsedAt = normalizeStoredTime(instance.LastUsedAt)
 	instance.ExpiresAt = normalizeStoredTime(instance.ExpiresAt)
-	_, err = s.db.ExecContext(ctx, `INSERT INTO agent_instances(name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, state, created_at, last_used_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	if strings.TrimSpace(instance.AutonomyPolicy) == "" {
+		instance.AutonomyPolicy = "auto"
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO agent_instances(name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, autonomy_policy, state, created_at, last_used_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(name) DO UPDATE SET
 			type = excluded.type,
 			runtime = excluded.runtime,
@@ -1249,23 +1257,27 @@ func (s *Store) UpsertAgentInstance(ctx context.Context, instance AgentInstance)
 			role = excluded.role,
 			template_id = excluded.template_id,
 			capabilities_json = excluded.capabilities_json,
+			autonomy_policy = excluded.autonomy_policy,
 			state = excluded.state,
 			last_used_at = excluded.last_used_at,
 			expires_at = excluded.expires_at`,
-		instance.Name, instance.Type, instance.Runtime, instance.RuntimeRef, instance.RepoFullName, instance.Role, instance.TemplateID, string(capabilities), instance.State, instance.CreatedAt, instance.LastUsedAt, instance.ExpiresAt)
+		instance.Name, instance.Type, instance.Runtime, instance.RuntimeRef, instance.RepoFullName, instance.Role, instance.TemplateID, string(capabilities), instance.AutonomyPolicy, instance.State, instance.CreatedAt, instance.LastUsedAt, instance.ExpiresAt)
 	return err
 }
 
 func (s *Store) GetAgentInstance(ctx context.Context, name string) (AgentInstance, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, state, created_at, last_used_at, expires_at
+	row := s.db.QueryRowContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, autonomy_policy, state, created_at, last_used_at, expires_at
 		FROM agent_instances WHERE name = ?`, name)
 	return scanAgentInstance(row)
 }
 
-func (s *Store) FindReusableAgentInstance(ctx context.Context, typ string, repo string, now time.Time) (AgentInstance, bool, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, state, created_at, last_used_at, expires_at
+func (s *Store) FindReusableAgentInstance(ctx context.Context, typ string, repo string, autonomyPolicy string, now time.Time) (AgentInstance, bool, error) {
+	if strings.TrimSpace(autonomyPolicy) == "" {
+		autonomyPolicy = "auto"
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, autonomy_policy, state, created_at, last_used_at, expires_at
 		FROM agent_instances
-		WHERE type = ? AND repo_full_name = ? AND expires_at > ?
+		WHERE type = ? AND repo_full_name = ? AND autonomy_policy = ? AND expires_at > ?
 			AND state = 'idle'
 			AND NOT EXISTS (
 				SELECT 1 FROM jobs
@@ -1273,7 +1285,7 @@ func (s *Store) FindReusableAgentInstance(ctx context.Context, typ string, repo 
 					AND jobs.state IN ('queued', 'running')
 			)
 		ORDER BY last_used_at DESC, created_at DESC
-		LIMIT 1`, typ, repo, formatResourceLockTime(now))
+		LIMIT 1`, typ, repo, autonomyPolicy, formatResourceLockTime(now))
 	instance, err := scanAgentInstance(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return AgentInstance{}, false, nil
@@ -1284,10 +1296,13 @@ func (s *Store) FindReusableAgentInstance(ctx context.Context, typ string, repo 
 	return instance, true, nil
 }
 
-func (s *Store) CountActiveAgentInstances(ctx context.Context, typ string, now time.Time) (int, error) {
+func (s *Store) CountActiveAgentInstances(ctx context.Context, typ string, autonomyPolicy string, now time.Time) (int, error) {
+	if strings.TrimSpace(autonomyPolicy) == "" {
+		autonomyPolicy = "auto"
+	}
 	var count int
 	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_instances
-		WHERE type = ?
+		WHERE type = ? AND autonomy_policy = ?
 			AND (
 				expires_at > ?
 				OR EXISTS (
@@ -1295,14 +1310,17 @@ func (s *Store) CountActiveAgentInstances(ctx context.Context, typ string, now t
 					WHERE jobs.agent = agent_instances.name
 						AND jobs.state IN ('queued', 'running')
 				)
-			)`, typ, formatResourceLockTime(now)).Scan(&count)
+			)`, typ, autonomyPolicy, formatResourceLockTime(now)).Scan(&count)
 	return count, err
 }
 
-func (s *Store) FindActiveAgentInstance(ctx context.Context, typ string, repo string, now time.Time) (AgentInstance, bool, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, state, created_at, last_used_at, expires_at
+func (s *Store) FindActiveAgentInstance(ctx context.Context, typ string, repo string, autonomyPolicy string, now time.Time) (AgentInstance, bool, error) {
+	if strings.TrimSpace(autonomyPolicy) == "" {
+		autonomyPolicy = "auto"
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, autonomy_policy, state, created_at, last_used_at, expires_at
 		FROM agent_instances
-		WHERE type = ? AND repo_full_name = ?
+		WHERE type = ? AND repo_full_name = ? AND autonomy_policy = ?
 			AND (
 				expires_at > ?
 				OR EXISTS (
@@ -1315,7 +1333,7 @@ func (s *Store) FindActiveAgentInstance(ctx context.Context, typ string, repo st
 			CASE WHEN expires_at > ? THEN 0 ELSE 1 END,
 			last_used_at DESC,
 			created_at DESC
-		LIMIT 1`, typ, repo, formatResourceLockTime(now), formatResourceLockTime(now))
+		LIMIT 1`, typ, repo, autonomyPolicy, formatResourceLockTime(now), formatResourceLockTime(now))
 	instance, err := scanAgentInstance(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return AgentInstance{}, false, nil
@@ -1327,7 +1345,7 @@ func (s *Store) FindActiveAgentInstance(ctx context.Context, typ string, repo st
 }
 
 func (s *Store) ListAgentInstances(ctx context.Context) ([]AgentInstance, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, state, created_at, last_used_at, expires_at
+	rows, err := s.db.QueryContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, autonomy_policy, state, created_at, last_used_at, expires_at
 		FROM agent_instances ORDER BY type, repo_full_name, name`)
 	if err != nil {
 		return nil, err
@@ -1388,8 +1406,11 @@ func (s *Store) DeleteExpiredAgentInstances(ctx context.Context, now time.Time) 
 func scanAgentInstance(row interface{ Scan(dest ...any) error }) (AgentInstance, error) {
 	var instance AgentInstance
 	var capabilities string
-	if err := row.Scan(&instance.Name, &instance.Type, &instance.Runtime, &instance.RuntimeRef, &instance.RepoFullName, &instance.Role, &instance.TemplateID, &capabilities, &instance.State, &instance.CreatedAt, &instance.LastUsedAt, &instance.ExpiresAt); err != nil {
+	if err := row.Scan(&instance.Name, &instance.Type, &instance.Runtime, &instance.RuntimeRef, &instance.RepoFullName, &instance.Role, &instance.TemplateID, &capabilities, &instance.AutonomyPolicy, &instance.State, &instance.CreatedAt, &instance.LastUsedAt, &instance.ExpiresAt); err != nil {
 		return AgentInstance{}, err
+	}
+	if strings.TrimSpace(instance.AutonomyPolicy) == "" {
+		instance.AutonomyPolicy = "auto"
 	}
 	if strings.TrimSpace(capabilities) != "" {
 		if err := json.Unmarshal([]byte(capabilities), &instance.Capabilities); err != nil {
@@ -4169,5 +4190,8 @@ CREATE INDEX idx_skillopt_review_watches_run_id ON skillopt_review_watches(run_i
 	`,
 	`
 ALTER TABLE ranked_feedback_events ADD COLUMN tie_groups_json TEXT NOT NULL DEFAULT '';
+	`,
+	`
+ALTER TABLE agent_instances ADD COLUMN autonomy_policy TEXT NOT NULL DEFAULT 'auto';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1079,17 +1079,18 @@ func TestAgentInstanceMethods(t *testing.T) {
 
 	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
 	instance := AgentInstance{
-		Name:         "planner-bg-1",
-		Type:         "planner",
-		Runtime:      "codex",
-		RuntimeRef:   "550e8400-e29b-41d4-a716-446655440101",
-		RepoFullName: "owner/repo",
-		Role:         "planner",
-		Capabilities: []string{"ask"},
-		State:        "idle",
-		CreatedAt:    formatResourceLockTime(now),
-		LastUsedAt:   formatResourceLockTime(now),
-		ExpiresAt:    formatResourceLockTime(now.Add(time.Minute)),
+		Name:           "planner-bg-1",
+		Type:           "planner",
+		Runtime:        "codex",
+		RuntimeRef:     "550e8400-e29b-41d4-a716-446655440101",
+		RepoFullName:   "owner/repo",
+		Role:           "planner",
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: "read-only",
+		State:          "idle",
+		CreatedAt:      formatResourceLockTime(now),
+		LastUsedAt:     formatResourceLockTime(now),
+		ExpiresAt:      formatResourceLockTime(now.Add(time.Minute)),
 	}
 	if err := store.UpsertAgentInstance(ctx, instance); err != nil {
 		t.Fatalf("UpsertAgentInstance returned error: %v", err)
@@ -1098,7 +1099,7 @@ func TestAgentInstanceMethods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAgent fallback returned error: %v", err)
 	}
-	if agent.Name != instance.Name || agent.RuntimeRef != instance.RuntimeRef || strings.Join(agent.Capabilities, ",") != "ask" {
+	if agent.Name != instance.Name || agent.RuntimeRef != instance.RuntimeRef || agent.AutonomyPolicy != "read-only" || strings.Join(agent.Capabilities, ",") != "ask" {
 		t.Fatalf("fallback agent = %+v", agent)
 	}
 	allowed, err := store.AgentCanAccessRepo(ctx, instance.Name, "owner/repo")
@@ -1108,22 +1109,32 @@ func TestAgentInstanceMethods(t *testing.T) {
 	if !allowed {
 		t.Fatal("agent instance was not allowed on its repo")
 	}
-	reusable, ok, err := store.FindReusableAgentInstance(ctx, "planner", "owner/repo", now.Add(30*time.Second))
+	reusable, ok, err := store.FindReusableAgentInstance(ctx, "planner", "owner/repo", "read-only", now.Add(30*time.Second))
 	if err != nil || !ok {
 		t.Fatalf("FindReusableAgentInstance returned instance=%+v ok=%v err=%v", reusable, ok, err)
 	}
-	count, err := store.CountActiveAgentInstances(ctx, "planner", now.Add(30*time.Second))
+	if _, ok, err := store.FindReusableAgentInstance(ctx, "planner", "owner/repo", "workspace-write", now.Add(30*time.Second)); err != nil || ok {
+		t.Fatalf("FindReusableAgentInstance with mismatched policy ok=%v err=%v, want false nil", ok, err)
+	}
+	count, err := store.CountActiveAgentInstances(ctx, "planner", "read-only", now.Add(30*time.Second))
 	if err != nil || count != 1 {
 		t.Fatalf("CountActiveAgentInstances = %d err=%v, want 1 nil", count, err)
+	}
+	count, err = store.CountActiveAgentInstances(ctx, "planner", "workspace-write", now.Add(30*time.Second))
+	if err != nil || count != 0 {
+		t.Fatalf("CountActiveAgentInstances with mismatched policy = %d err=%v, want 0 nil", count, err)
 	}
 	if err := store.MarkAgentInstanceRunning(ctx, instance.Name, now.Add(time.Minute), 5*time.Minute); err != nil {
 		t.Fatalf("MarkAgentInstanceRunning returned error: %v", err)
 	}
-	if _, ok, err := store.FindReusableAgentInstance(ctx, "planner", "owner/repo", now.Add(30*time.Second)); err != nil || ok {
+	if _, ok, err := store.FindReusableAgentInstance(ctx, "planner", "owner/repo", "read-only", now.Add(30*time.Second)); err != nil || ok {
 		t.Fatalf("running FindReusableAgentInstance ok=%v err=%v, want false nil", ok, err)
 	}
-	if active, ok, err := store.FindActiveAgentInstance(ctx, "planner", "owner/repo", now.Add(30*time.Second)); err != nil || !ok || active.Name != instance.Name {
+	if active, ok, err := store.FindActiveAgentInstance(ctx, "planner", "owner/repo", "read-only", now.Add(30*time.Second)); err != nil || !ok || active.Name != instance.Name {
 		t.Fatalf("FindActiveAgentInstance returned instance=%+v ok=%v err=%v", active, ok, err)
+	}
+	if _, ok, err := store.FindActiveAgentInstance(ctx, "planner", "owner/repo", "workspace-write", now.Add(30*time.Second)); err != nil || ok {
+		t.Fatalf("FindActiveAgentInstance with mismatched policy ok=%v err=%v, want false nil", ok, err)
 	}
 	deleted, err := store.DeleteExpiredAgentInstances(ctx, now.Add(4*time.Minute))
 	if err != nil {
@@ -1135,18 +1146,18 @@ func TestAgentInstanceMethods(t *testing.T) {
 	if err := store.TouchAgentInstance(ctx, instance.Name, now.Add(2*time.Minute), time.Minute); err != nil {
 		t.Fatalf("TouchAgentInstance returned error: %v", err)
 	}
-	count, err = store.CountActiveAgentInstances(ctx, "planner", now.Add(4*time.Minute))
+	count, err = store.CountActiveAgentInstances(ctx, "planner", "read-only", now.Add(4*time.Minute))
 	if err != nil || count != 0 {
 		t.Fatalf("expired idle CountActiveAgentInstances = %d err=%v, want 0 nil", count, err)
 	}
 	if err := store.CreateJob(ctx, Job{ID: "job-planner-1", Agent: instance.Name, Type: "ask", State: "queued", Payload: "{}"}); err != nil {
 		t.Fatalf("CreateJob returned error: %v", err)
 	}
-	count, err = store.CountActiveAgentInstances(ctx, "planner", now.Add(4*time.Minute))
+	count, err = store.CountActiveAgentInstances(ctx, "planner", "read-only", now.Add(4*time.Minute))
 	if err != nil || count != 1 {
 		t.Fatalf("expired queued CountActiveAgentInstances = %d err=%v, want 1 nil", count, err)
 	}
-	if active, ok, err := store.FindActiveAgentInstance(ctx, "planner", "owner/repo", now.Add(4*time.Minute)); err != nil || !ok || active.Name != instance.Name {
+	if active, ok, err := store.FindActiveAgentInstance(ctx, "planner", "owner/repo", "read-only", now.Add(4*time.Minute)); err != nil || !ok || active.Name != instance.Name {
 		t.Fatalf("expired queued FindActiveAgentInstance returned instance=%+v ok=%v err=%v", active, ok, err)
 	}
 	deleted, err = store.DeleteExpiredAgentInstances(ctx, now.Add(4*time.Minute))
@@ -1895,6 +1906,41 @@ func TestMigrateCopiesAgentRepoScopeToAgentRepos(t *testing.T) {
 	}
 	if len(repos) != 1 || repos[0] != "jerryfane/gitmoot" {
 		t.Fatalf("repos = %+v", repos)
+	}
+}
+
+func TestMigrateAppendsAgentInstanceAutonomyPolicy(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open returned error: %v", err)
+	}
+	store := &Store{db: raw}
+	for version, migration := range migrations[:len(migrations)-1] {
+		if err := store.applyMigration(ctx, version+1, migration); err != nil {
+			t.Fatalf("applyMigration(%d) returned error: %v", version+1, err)
+		}
+	}
+	if _, err := raw.ExecContext(ctx, `INSERT INTO agent_instances(name, type, runtime, runtime_ref, repo_full_name, role, template_id, capabilities_json, state, created_at, last_used_at, expires_at)
+		VALUES ('planner-bg-legacy', 'planner', 'codex', 'session-id', 'owner/repo', 'planner', '', '["ask"]', 'idle', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-01T01:00:00Z')`); err != nil {
+		t.Fatalf("insert legacy agent instance returned error: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw Close returned error: %v", err)
+	}
+
+	upgraded, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open upgraded DB returned error: %v", err)
+	}
+	defer upgraded.Close()
+	instance, err := upgraded.GetAgentInstance(ctx, "planner-bg-legacy")
+	if err != nil {
+		t.Fatalf("GetAgentInstance returned error: %v", err)
+	}
+	if instance.AutonomyPolicy != "auto" {
+		t.Fatalf("autonomy policy = %q, want auto", instance.AutonomyPolicy)
 	}
 }
 


### PR DESCRIPTION
Refs #175

## What
Block implementation jobs early when the selected worker is configured read-only, and normalize specific runtime write-permission failures into a clear blocked state.

## Why
A Gitmoot user hit read-only runtime failures during implementation work. Gitmoot should not keep trying to write in that mode or expose low-level runtime flags as the user-facing fix.

## Changes
- Added an autonomy policy field for managed agent types, persisted into agent instances.
- Added CLI support for `agent type set --policy ...` and `agent type show` policy output.
- Prevented read-only `implement` jobs from starting managed or subscribed runtime sessions.
- Marked permission-blocked jobs as `blocked`, emitted `permission_blocked`, blocked the task, and posted a clear result comment.
- Normalized only specific read-only/write-permission runtime failures, while preserving generic runtime failures and post-delivery retry paths.
- Scoped managed instance reuse/counting by autonomy policy so stale read-only/write sessions are not reused incorrectly.

## Results
- `GOTOOLCHAIN=go1.26.0 go test ./internal/config -v`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestRunAgent(Start|Subscribe|Type|GC)|TestDispatchLocalAgentJob|TestRunQueuedJobs' -v -timeout 120s`\n- `GOTOOLCHAIN=go1.26.0 go test ./internal/db -v -timeout 90s`\n- `GOTOOLCHAIN=go1.26.0 go test ./internal/workflow ./internal/runtime -v -timeout 120s`\n- `git diff --check`\n- `codex exec review --uncommitted`: no discrete correctness issues found. The review sandbox could not run Go tests with `GOTOOLCHAIN=local` because local Go is 1.22 and this repo requires Go >= 1.26; explicit Go 1.26 tests above passed.\n\n## Risk\nLow to medium. This touches daemon/local dispatch state transitions and managed agent instance reuse. Coverage includes daemon preflight, runtime failure normalization, config parsing, managed policy reuse, and DB migration behavior.\n\n## Review Output\n```text\nNo discrete correctness issues were found in the current staged, unstaged, or untracked changes. Static review and git diff --check passed; go test could not be run because the required Go 1.26 toolchain download is blocked in this sandbox.\n```