### PR TITLE
Serialize checkout mutations with resource locks

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -191,6 +191,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 				Store:        store,
 				GitHub:       gh,
 				Git:          gitutil.Client{Dir: checkout},
+				CheckoutPath: checkout,
 				DeleteBranch: true,
 			},
 		}
@@ -1821,6 +1822,7 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string) wo
 			Store:        store,
 			GitHub:       gh,
 			Git:          gitutil.Client{Dir: checkout},
+			CheckoutPath: checkout,
 			DeleteBranch: true,
 		},
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -324,6 +324,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 			Branch:     requestBranch,
 			BaseBranch: *base,
 			Owner:      *owner,
+			Checkout:   checkout,
 		}, gitutil.Client{Dir: checkout})
 		return err
 	}); err != nil {

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 )
@@ -401,6 +402,59 @@ func TestRunTaskRunRegistersCurrentRepo(t *testing.T) {
 	}
 	if repo.CheckoutPath != repoDir || repo.RemoteURL != "https://github.com/jerryfane/gitmoot.git" {
 		t.Fatalf("repo = %+v", repo)
+	}
+}
+
+func TestRunTaskRunBlocksWhenCheckoutMutationLocked(t *testing.T) {
+	home := t.TempDir()
+	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: Bootstrap\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", home, "--file", goalPath, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/jerryfane/gitmoot.git")
+	withWorkingDirectory(t, repoDir)
+
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	absoluteCheckout, err := filepath.Abs(repoDir)
+	if err != nil {
+		t.Fatalf("Abs returned error: %v", err)
+	}
+	if acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey: "checkout-mutation:" + filepath.Clean(absoluteCheckout),
+		OwnerJobID:  "task:other",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"task", "run", "task-001", "--home", home, "--repo", "jerryfane/gitmoot", "--owner", "lead"}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("task run exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "This checkout is already being mutated by another Gitmoot task") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	branches := runGitOutput(t, repoDir, "branch", "--list", "task-001")
+	if strings.TrimSpace(branches) != "" {
+		t.Fatalf("task branch was created despite checkout lock: %q", branches)
 	}
 }
 

--- a/internal/workflow/branch.go
+++ b/internal/workflow/branch.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 )
@@ -21,6 +22,7 @@ type TaskBranchRequest struct {
 	Branch     string
 	BaseBranch string
 	Owner      string
+	Checkout   string
 }
 
 func (e Engine) StartTaskBranch(ctx context.Context, request TaskBranchRequest, brancher BranchCreator) (db.Task, error) {
@@ -40,6 +42,15 @@ func (e Engine) StartTaskBranch(ctx context.Context, request TaskBranchRequest, 
 	if err == nil && existing.ID != request.TaskID {
 		return db.Task{}, errors.New("task branch is already assigned to another task")
 	}
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLock(ctx, e.Store, request.Checkout, "task:"+request.TaskID, time.Now().UTC())
+	if err != nil {
+		return db.Task{}, err
+	}
+	defer func() {
+		if releaseCheckoutLock != nil {
+			_ = releaseCheckoutLock(context.Background())
+		}
+	}()
 	lock := db.BranchLock{RepoFullName: request.Repo, Branch: request.Branch, Owner: request.Owner}
 	createdLock, err := e.Store.CreateLock(ctx, lock)
 	if err != nil {

--- a/internal/workflow/branch_test.go
+++ b/internal/workflow/branch_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 )
@@ -44,6 +45,75 @@ func TestEngineStartTaskBranchCreatesBranchAndLock(t *testing.T) {
 	}
 }
 
+func TestEngineStartTaskBranchAcquiresCheckoutMutationLockBeforeBranchSetup(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	brancher := &fakeBranchCreator{onCreate: func() {
+		lock, err := store.GetResourceLock(ctx, key)
+		if err != nil {
+			t.Fatalf("GetResourceLock during branch setup returned error: %v", err)
+		}
+		if lock.OwnerJobID != "task:task-8" {
+			t.Fatalf("checkout lock owner = %q, want task:task-8", lock.OwnerJobID)
+		}
+	}}
+
+	if _, err := engine.StartTaskBranch(ctx, TaskBranchRequest{
+		Repo:     "jerryfane/gitmoot",
+		TaskID:   "task-8",
+		Branch:   "task-8",
+		Owner:    "lead",
+		Checkout: checkout,
+	}, brancher); err != nil {
+		t.Fatalf("StartTaskBranch returned error: %v", err)
+	}
+	if _, err := store.GetResourceLock(ctx, key); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("checkout lock after branch setup error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestEngineStartTaskBranchBlocksWhenCheckoutMutationLocked(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  "task:other",
+		OwnerToken:  "other-token",
+		ExpiresAt:   "2099-01-01T00:00:00Z",
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	brancher := &fakeBranchCreator{}
+
+	_, err = engine.StartTaskBranch(ctx, TaskBranchRequest{
+		Repo:     "jerryfane/gitmoot",
+		TaskID:   "task-8",
+		Branch:   "task-8",
+		Owner:    "lead",
+		Checkout: checkout,
+	}, brancher)
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || blocked.Reason != checkoutMutationBusyMessage {
+		t.Fatalf("error = %v, want checkout busy BlockedError", err)
+	}
+	if len(brancher.calls) != 0 {
+		t.Fatalf("branch was created despite checkout lock: %+v", brancher.calls)
+	}
+}
+
 func TestEngineStartTaskBranchReleasesLockOnBranchCreateFailure(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -62,6 +132,33 @@ func TestEngineStartTaskBranchReleasesLockOnBranchCreateFailure(t *testing.T) {
 	}
 	if _, lockErr := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-8"); !errors.Is(lockErr, sql.ErrNoRows) {
 		t.Fatalf("lock after failure error = %v, want sql.ErrNoRows", lockErr)
+	}
+}
+
+func TestEngineStartTaskBranchReleasesCheckoutMutationLockOnBranchCreateFailure(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	brancher := &fakeBranchCreator{err: errors.New("git failed")}
+
+	_, err = engine.StartTaskBranch(ctx, TaskBranchRequest{
+		Repo:     "jerryfane/gitmoot",
+		TaskID:   "task-8",
+		Branch:   "task-8",
+		Owner:    "lead",
+		Checkout: checkout,
+	}, brancher)
+
+	if err == nil {
+		t.Fatal("StartTaskBranch succeeded despite branch failure")
+	}
+	if _, err := store.GetResourceLock(ctx, key); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("checkout lock after branch setup failure error = %v, want sql.ErrNoRows", err)
 	}
 }
 
@@ -193,8 +290,9 @@ func TestEngineStartTaskBranchAllowsSameBranchInAnotherRepo(t *testing.T) {
 }
 
 type fakeBranchCreator struct {
-	err   error
-	calls []branchCall
+	err      error
+	onCreate func()
+	calls    []branchCall
 }
 
 type branchCall struct {
@@ -203,6 +301,9 @@ type branchCall struct {
 }
 
 func (f *fakeBranchCreator) CreateBranch(_ context.Context, branch string, base string) error {
+	if f.onCreate != nil {
+		f.onCreate()
+	}
 	f.calls = append(f.calls, branchCall{branch: branch, base: base})
 	return f.err
 }

--- a/internal/workflow/checkout_lock.go
+++ b/internal/workflow/checkout_lock.go
@@ -1,0 +1,73 @@
+package workflow
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+const (
+	checkoutMutationLockTTL     = 30 * time.Minute
+	checkoutMutationBusyMessage = "This checkout is already being mutated by another Gitmoot task. Run tasks sequentially or enable per-task worktrees for parallel implementation."
+)
+
+func acquireCheckoutMutationLock(ctx context.Context, store *db.Store, checkoutPath string, ownerID string, now time.Time) (func(context.Context) error, string, error) {
+	key, err := checkoutMutationLockKey(checkoutPath)
+	if err != nil {
+		return nil, "", err
+	}
+	if key == "" {
+		return func(context.Context) error { return nil }, "", nil
+	}
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return nil, key, errors.New("checkout mutation lock owner is required")
+	}
+	token, err := newCheckoutMutationOwnerToken()
+	if err != nil {
+		return nil, key, err
+	}
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  ownerID,
+		OwnerToken:  token,
+		ExpiresAt:   now.UTC().Add(checkoutMutationLockTTL).Format(time.RFC3339Nano),
+	}, now.UTC())
+	if err != nil {
+		return nil, key, err
+	}
+	if !acquired {
+		return nil, key, BlockedError{Reason: checkoutMutationBusyMessage}
+	}
+	return func(releaseCtx context.Context) error {
+		_, err := store.ReleaseResourceLock(releaseCtx, key, ownerID, token)
+		return err
+	}, key, nil
+}
+
+func checkoutMutationLockKey(checkoutPath string) (string, error) {
+	checkoutPath = strings.TrimSpace(checkoutPath)
+	if checkoutPath == "" {
+		return "", nil
+	}
+	absolute, err := filepath.Abs(checkoutPath)
+	if err != nil {
+		return "", fmt.Errorf("normalize checkout path: %w", err)
+	}
+	return "checkout-mutation:" + filepath.Clean(absolute), nil
+}
+
+func newCheckoutMutationOwnerToken() (string, error) {
+	var bytes [16]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return "", fmt.Errorf("generate checkout mutation lock owner token: %w", err)
+	}
+	return hex.EncodeToString(bytes[:]), nil
+}

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
@@ -40,6 +42,7 @@ type PolicyMergeGate struct {
 	GitHub       MergeGateGitHub
 	Git          MergeGateGit
 	NextTasks    NextTaskEnqueuer
+	CheckoutPath string
 	DeleteBranch bool
 	MergeMethod  string
 }
@@ -62,6 +65,19 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	headSHA := strings.TrimSpace(pr.HeadSHA)
 	if headSHA == "" {
 		return g.block(ctx, request, "", "pull request head SHA is missing")
+	}
+	releaseCheckoutLock, err := g.acquireLocalCheckoutMutationLock(ctx, request)
+	if err != nil {
+		var blocked BlockedError
+		if errors.As(err, &blocked) {
+			return g.block(ctx, request, headSHA, blocked.Reason)
+		}
+		return MergeDecision{}, err
+	}
+	if releaseCheckoutLock != nil {
+		defer func() {
+			_ = releaseCheckoutLock(context.Background())
+		}()
 	}
 	if pullRequestMerged(pr) {
 		return g.finishMerged(ctx, request, pr, strings.TrimSpace(pr.MergeSHA))
@@ -161,6 +177,17 @@ func (g PolicyMergeGate) finishMerged(ctx context.Context, request MergeRequest,
 		_ = g.Store.UpsertMergeGate(ctx, db.MergeGate{RepoFullName: request.Repo, PullRequest: int64(request.PullRequest), State: "merged", Reason: reason})
 	}
 	return MergeDecision{Ready: true, Merged: true, MergeCommitSHA: mergeSHA, Reason: reason}, nil
+}
+
+func (g PolicyMergeGate) acquireLocalCheckoutMutationLock(ctx context.Context, request MergeRequest) (func(context.Context) error, error) {
+	if g.Git == nil {
+		return nil, nil
+	}
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLock(ctx, g.Store, g.CheckoutPath, "merge:"+request.Repo+"#"+strconv.Itoa(request.PullRequest), time.Now().UTC())
+	if err != nil {
+		return nil, err
+	}
+	return releaseCheckoutLock, nil
 }
 
 func (g PolicyMergeGate) validate() error {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
@@ -48,7 +49,7 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	git := &fakeMergeGateGit{clean: true}
-	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: git, DeleteBranch: true}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: git, CheckoutPath: t.TempDir(), DeleteBranch: true}
 
 	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9", Reviewer: "audit"})
 
@@ -83,6 +84,101 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 	}
 	if len(git.updated) != 1 || git.updated[0] != "origin/main" {
 		t.Fatalf("updated base calls = %+v", git.updated)
+	}
+}
+
+func TestPolicyMergeGateLocksCheckoutDuringLocalBaseUpdate(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, State: "open", URL: "https://github.com/jerryfane/gitmoot/pull/9", HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	git := &fakeMergeGateGit{clean: true, onUpdate: func() {
+		lock, err := store.GetResourceLock(ctx, key)
+		if err != nil {
+			t.Fatalf("GetResourceLock during UpdateBase returned error: %v", err)
+		}
+		if lock.OwnerJobID != "merge:jerryfane/gitmoot#9" {
+			t.Fatalf("checkout lock owner = %q, want merge:jerryfane/gitmoot#9", lock.OwnerJobID)
+		}
+	}}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: git, CheckoutPath: checkout}
+
+	if _, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9", Reviewer: "audit"}); err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if _, err := store.GetResourceLock(ctx, key); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("checkout lock after UpdateBase error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestPolicyMergeGateReportsBusyCheckoutForLocalBaseUpdate(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  "task:other",
+		OwnerToken:  "other-token",
+		ExpiresAt:   "2099-01-01T00:00:00Z",
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, State: "open", URL: "https://github.com/jerryfane/gitmoot/pull/9", HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	git := &fakeMergeGateGit{clean: true}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: git, CheckoutPath: checkout}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9", Reviewer: "audit"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready || decision.Merged || !strings.Contains(decision.Reason, checkoutMutationBusyMessage) {
+		t.Fatalf("decision = %+v, want blocked checkout busy decision", decision)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge ran despite checkout lock: %+v", gh.merges)
+	}
+	if len(git.updated) != 0 {
+		t.Fatalf("UpdateBase ran despite checkout lock: %+v", git.updated)
 	}
 }
 
@@ -624,8 +720,9 @@ func (f *fakeMergeGateGitHub) MergePullRequest(_ context.Context, input github.M
 }
 
 type fakeMergeGateGit struct {
-	clean   bool
-	updated []string
+	clean    bool
+	onUpdate func()
+	updated  []string
 }
 
 func (f *fakeMergeGateGit) WorktreeClean(context.Context) (bool, error) {
@@ -633,6 +730,9 @@ func (f *fakeMergeGateGit) WorktreeClean(context.Context) (bool, error) {
 }
 
 func (f *fakeMergeGateGit) UpdateBase(_ context.Context, remote string, branch string) error {
+	if f.onUpdate != nil {
+		f.onUpdate()
+	}
 	f.updated = append(f.updated, remote+"/"+branch)
 	return nil
 }


### PR DESCRIPTION
Refs #176

## What
Added a process-safe checkout mutation lock backed by `resource_locks`, keyed by the normalized absolute checkout path.

## Why
Parallel Gitmoot processes can otherwise mutate the same registered checkout at the same time during branch setup or merge-gate local base updates, causing branch/sqlite/checkout contention.

## Changes
- Added `checkout-mutation:<absolute-path>` resource locks in workflow code.
- Wrapped `task run` branch creation with the checkout mutation lock.
- Passed checkout paths from CLI and daemon merge-gate construction.
- Wrapped merge-gate local checkout work with the same lock.
- Busy checkout locks now block before remote merge, instead of skipping the post-merge local base update.
- Added tests for lock acquisition, busy-lock blocking, release on branch setup failure, CLI `task run` contention, and merge-gate local update locking.

## Results
- `GOTOOLCHAIN=go1.26.0 go test ./internal/workflow -run 'TestEngineStartTaskBranch|TestPolicyMergeGate' -v -timeout 120s`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestRunTaskRun|TestDaemon|TestRunQueuedJobs' -v -timeout 150s`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/workflow -v -timeout 150s`
- `git diff --check`
- `codex exec review --uncommitted`: first review found a post-merge busy-lock skip bug; fixed by blocking before merge finalization. Final review found no discrete correctness issues.

## Risk
Low to medium. This touches merge-gate timing and branch setup. Busy checkout now blocks merge-gate before remote merge rather than allowing a stale local checkout update to be skipped. The review sandbox could not run `GOTOOLCHAIN=local go test` because local Go is 1.22 while the repo requires Go >= 1.26; explicit Go 1.26 tests passed.

## Review Output
```text
First review finding:
[P2] Retry busy checkout updates instead of dropping them — /root/gitmoot/internal/workflow/merge_gate.go:149-151
When a PR merges while another process holds the checkout mutation lock, updateLocalBase returns a BlockedError, but this path records it only as a post-merge warning and continues with the merge finalized. That permanently skips the local fetch/switch/pull, so after the lock holder finishes the shared checkout's base branch can remain stale and later task branches may be created from pre-merge code; this contention case should be retried or blocked instead of treated as a non-actionable warning.

Final review output:
I did not find any discrete correctness issues in the checkout mutation locking changes. The new lock paths are wired into task branch creation and merge-gate local checkout mutation, with focused tests for acquisition, contention, and release behavior.
```
