### PR TITLE
Add task worktree helpers and state

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -131,6 +131,7 @@ type Task struct {
 	Title        string
 	State        string
 	Branch       string
+	WorktreePath string
 }
 
 type PullRequest struct {
@@ -1463,16 +1464,20 @@ func (s *Store) UpsertTask(ctx context.Context, task Task) error {
 }
 
 func upsertTask(ctx context.Context, execer sqlExecer, task Task) error {
-	_, err := execer.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	_, err := execer.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, worktree_path, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
 			repo_full_name = excluded.repo_full_name,
 			goal_id = excluded.goal_id,
 			title = excluded.title,
 			state = excluded.state,
 			branch = excluded.branch,
+			worktree_path = CASE
+				WHEN excluded.worktree_path <> '' THEN excluded.worktree_path
+				ELSE tasks.worktree_path
+			END,
 			updated_at = CURRENT_TIMESTAMP`,
-		task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch)
+		task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch, task.WorktreePath)
 	return err
 }
 
@@ -1495,8 +1500,8 @@ func (s *Store) UpsertGoalWithTasks(ctx context.Context, goal Goal, tasks []Task
 }
 
 func upsertImportedTask(ctx context.Context, execer sqlExecer, task Task) error {
-	_, err := execer.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	_, err := execer.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, worktree_path, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 			ON CONFLICT(id) DO UPDATE SET
 				repo_full_name = CASE
 					WHEN excluded.repo_full_name <> '' THEN excluded.repo_full_name
@@ -1506,28 +1511,25 @@ func upsertImportedTask(ctx context.Context, execer sqlExecer, task Task) error 
 				title = excluded.title,
 				state = tasks.state,
 			branch = tasks.branch,
+			worktree_path = tasks.worktree_path,
 			updated_at = CURRENT_TIMESTAMP`,
-		task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch)
+		task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch, task.WorktreePath)
 	return err
 }
 
 func (s *Store) GetTask(ctx context.Context, id string) (Task, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch FROM tasks WHERE id = ?`, id)
-	var task Task
-	if err := row.Scan(&task.ID, &task.RepoFullName, &task.GoalID, &task.Title, &task.State, &task.Branch); err != nil {
-		return Task{}, err
-	}
-	return task, nil
+	row := s.db.QueryRowContext(ctx, taskSelectSQL()+` FROM tasks WHERE id = ?`, id)
+	return scanTask(row)
 }
 
 func (s *Store) GetTaskByBranch(ctx context.Context, branch string) (Task, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch
+	row := s.db.QueryRowContext(ctx, taskSelectSQL()+`
 		FROM tasks WHERE branch = ? ORDER BY updated_at DESC, id LIMIT 1`, branch)
 	return scanTask(row)
 }
 
 func (s *Store) GetTaskByRepoBranch(ctx context.Context, repoFullName string, branch string) (Task, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch
+	row := s.db.QueryRowContext(ctx, taskSelectSQL()+`
 		FROM tasks
 		WHERE branch = ? AND (repo_full_name = ? OR repo_full_name = '')
 		ORDER BY CASE WHEN repo_full_name = ? THEN 0 ELSE 1 END, updated_at DESC, id
@@ -1536,7 +1538,7 @@ func (s *Store) GetTaskByRepoBranch(ctx context.Context, repoFullName string, br
 }
 
 func (s *Store) ListTasks(ctx context.Context) ([]Task, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch FROM tasks ORDER BY id`)
+	rows, err := s.db.QueryContext(ctx, taskSelectSQL()+` FROM tasks ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}
@@ -1553,7 +1555,7 @@ func (s *Store) ListTasks(ctx context.Context) ([]Task, error) {
 }
 
 func (s *Store) ListTasksByRepo(ctx context.Context, repoFullName string) ([]Task, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch
+	rows, err := s.db.QueryContext(ctx, taskSelectSQL()+`
 		FROM tasks
 		WHERE repo_full_name = ? OR repo_full_name = ''
 		ORDER BY CASE WHEN repo_full_name = ? THEN 0 ELSE 1 END, id`, repoFullName, repoFullName)
@@ -1573,7 +1575,7 @@ func (s *Store) ListTasksByRepo(ctx context.Context, repoFullName string) ([]Tas
 }
 
 func (s *Store) ListTasksByRepoState(ctx context.Context, repoFullName string, state string) ([]Task, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, repo_full_name, goal_id, title, state, branch
+	rows, err := s.db.QueryContext(ctx, taskSelectSQL()+`
 		FROM tasks
 		WHERE repo_full_name = ? AND state = ?
 		ORDER BY id`, repoFullName, state)
@@ -1594,10 +1596,14 @@ func (s *Store) ListTasksByRepoState(ctx context.Context, repoFullName string, s
 
 func scanTask(row interface{ Scan(dest ...any) error }) (Task, error) {
 	var task Task
-	if err := row.Scan(&task.ID, &task.RepoFullName, &task.GoalID, &task.Title, &task.State, &task.Branch); err != nil {
+	if err := row.Scan(&task.ID, &task.RepoFullName, &task.GoalID, &task.Title, &task.State, &task.Branch, &task.WorktreePath); err != nil {
 		return Task{}, err
 	}
 	return task, nil
+}
+
+func taskSelectSQL() string {
+	return `SELECT id, repo_full_name, goal_id, title, state, branch, worktree_path`
 }
 
 func (s *Store) UpsertPullRequest(ctx context.Context, pr PullRequest) error {
@@ -4193,5 +4199,8 @@ ALTER TABLE ranked_feedback_events ADD COLUMN tie_groups_json TEXT NOT NULL DEFA
 	`,
 	`
 ALTER TABLE agent_instances ADD COLUMN autonomy_policy TEXT NOT NULL DEFAULT 'auto';
+	`,
+	`
+ALTER TABLE tasks ADD COLUMN worktree_path TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1944,6 +1944,74 @@ func TestMigrateAppendsAgentInstanceAutonomyPolicy(t *testing.T) {
 	}
 }
 
+func TestMigrateAppendsTaskWorktreePath(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open returned error: %v", err)
+	}
+	store := &Store{db: raw}
+	for version, migration := range migrations[:len(migrations)-1] {
+		if err := store.applyMigration(ctx, version+1, migration); err != nil {
+			t.Fatalf("applyMigration(%d) returned error: %v", version+1, err)
+		}
+	}
+	if _, err := raw.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch)
+		VALUES ('task-legacy', 'owner/repo', 'goal-1', 'Legacy', 'planned', 'task-legacy')`); err != nil {
+		t.Fatalf("insert legacy task returned error: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw Close returned error: %v", err)
+	}
+
+	upgraded, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open upgraded DB returned error: %v", err)
+	}
+	defer upgraded.Close()
+	task, err := upgraded.GetTask(ctx, "task-legacy")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.WorktreePath != "" {
+		t.Fatalf("worktree path = %q, want empty default", task.WorktreePath)
+	}
+}
+
+func TestTaskWorktreePathStorage(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.UpsertTask(ctx, Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "First", State: "planned", Branch: "task-1", WorktreePath: "/tmp/gitmoot/worktrees/owner--repo/task-1"}); err != nil {
+		t.Fatalf("UpsertTask with worktree returned error: %v", err)
+	}
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.WorktreePath != "/tmp/gitmoot/worktrees/owner--repo/task-1" {
+		t.Fatalf("worktree path = %q", task.WorktreePath)
+	}
+	if err := store.UpsertTask(ctx, Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Updated", State: "implementing", Branch: "task-1"}); err != nil {
+		t.Fatalf("UpsertTask update returned error: %v", err)
+	}
+	updated, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask updated returned error: %v", err)
+	}
+	if updated.WorktreePath != task.WorktreePath {
+		t.Fatalf("worktree path was not preserved: %q", updated.WorktreePath)
+	}
+	if updated.State != "implementing" || updated.Title != "Updated" {
+		t.Fatalf("task update did not apply: %+v", updated)
+	}
+}
+
 func TestTasksRequireUniqueNonEmptyBranches(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -26,6 +26,31 @@ func (c Client) CreateBranch(ctx context.Context, branch string, base string) er
 	return err
 }
 
+func (c Client) AddWorktree(ctx context.Context, branch string, path string, base string) error {
+	if err := validateBranch(branch); err != nil {
+		return err
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return errors.New("worktree path is required")
+	}
+	args := []string{"worktree", "add", "-b", branch, path}
+	if strings.TrimSpace(base) != "" {
+		args = append(args, base)
+	}
+	_, err := c.run(ctx, args...)
+	return err
+}
+
+func (c Client) RemoveWorktree(ctx context.Context, path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return errors.New("worktree path is required")
+	}
+	_, err := c.run(ctx, "worktree", "remove", path)
+	return err
+}
+
 func (c Client) CurrentBranch(ctx context.Context) (string, error) {
 	result, err := c.run(ctx, "branch", "--show-current")
 	if err != nil {

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -76,6 +76,33 @@ func TestClientRejectsUnsafeBranchNames(t *testing.T) {
 	}
 }
 
+func TestClientWorktreeCommandConstruction(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{}, {}}}
+	client := Client{Runner: runner, Dir: "/repo"}
+
+	if err := client.AddWorktree(context.Background(), "task-1", "/worktrees/task-1", "main"); err != nil {
+		t.Fatalf("AddWorktree returned error: %v", err)
+	}
+	if err := client.RemoveWorktree(context.Background(), "/worktrees/task-1"); err != nil {
+		t.Fatalf("RemoveWorktree returned error: %v", err)
+	}
+
+	runner.wantArgs(t, 0, "git", "worktree", "add", "-b", "task-1", "/worktrees/task-1", "main")
+	runner.wantArgs(t, 1, "git", "worktree", "remove", "/worktrees/task-1")
+}
+
+func TestClientAddWorktreeRejectsInvalidInput(t *testing.T) {
+	if err := (Client{}).AddWorktree(context.Background(), "bad branch", "/tmp/wt", "main"); err == nil {
+		t.Fatal("AddWorktree accepted unsafe branch")
+	}
+	if err := (Client{}).AddWorktree(context.Background(), "task-1", "", "main"); err == nil {
+		t.Fatal("AddWorktree accepted empty path")
+	}
+	if err := (Client{}).RemoveWorktree(context.Background(), " "); err == nil {
+		t.Fatal("RemoveWorktree accepted empty path")
+	}
+}
+
 func TestClientHeadSHA(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "abc123\n"}}}
 	sha, err := (Client{Runner: runner, Dir: "/repo"}).HeadSHA(context.Background())

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -1,0 +1,139 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+type WorktreeManager interface {
+	AddWorktree(ctx context.Context, branch string, path string, base string) error
+}
+
+type TaskWorktreeRequest struct {
+	Home       string
+	Repo       string
+	TaskID     string
+	Branch     string
+	BaseBranch string
+	Checkout   string
+}
+
+func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRequest, manager WorktreeManager) (db.Task, error) {
+	if err := e.validate(); err != nil {
+		return db.Task{}, err
+	}
+	if manager == nil {
+		return db.Task{}, errors.New("worktree manager is required")
+	}
+	if strings.TrimSpace(request.TaskID) == "" {
+		return db.Task{}, errors.New("task worktree task id is required")
+	}
+	if strings.TrimSpace(request.Branch) == "" {
+		return db.Task{}, errors.New("task worktree branch is required")
+	}
+	path, err := TaskWorktreePath(request.Home, request.Repo, request.TaskID)
+	if err != nil {
+		return db.Task{}, err
+	}
+	task, err := e.Store.GetTask(ctx, request.TaskID)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return db.Task{}, err
+		}
+		task = db.Task{ID: request.TaskID, RepoFullName: request.Repo, State: string(TaskPlanned)}
+	}
+	if strings.TrimSpace(task.RepoFullName) != "" && task.RepoFullName != request.Repo {
+		return db.Task{}, fmt.Errorf("task %s belongs to repo %s, not %s", request.TaskID, task.RepoFullName, request.Repo)
+	}
+	existing, err := e.Store.GetTaskByRepoBranch(ctx, request.Repo, request.Branch)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return db.Task{}, err
+	}
+	if err == nil && existing.ID != request.TaskID {
+		return db.Task{}, errors.New("task branch is already assigned to another task")
+	}
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLock(ctx, e.Store, request.Checkout, "worktree:"+request.TaskID, time.Now().UTC())
+	if err != nil {
+		return db.Task{}, err
+	}
+	defer func() {
+		if releaseCheckoutLock != nil {
+			_ = releaseCheckoutLock(context.Background())
+		}
+	}()
+	if err := manager.AddWorktree(ctx, request.Branch, path, request.BaseBranch); err != nil {
+		return db.Task{}, err
+	}
+	if strings.TrimSpace(task.RepoFullName) == "" {
+		task.RepoFullName = request.Repo
+	}
+	task.Branch = request.Branch
+	task.WorktreePath = path
+	if strings.TrimSpace(task.State) == "" {
+		task.State = string(TaskPlanned)
+	}
+	if err := e.Store.UpsertTask(ctx, task); err != nil {
+		return db.Task{}, err
+	}
+	return task, nil
+}
+
+func TaskWorktreePath(home string, repo string, taskID string) (string, error) {
+	home = strings.TrimSpace(home)
+	if home == "" {
+		return "", errors.New("task worktree home is required")
+	}
+	repoSegment, err := taskWorktreeRepoSegment(repo)
+	if err != nil {
+		return "", err
+	}
+	taskSegment, err := taskWorktreePathSegment(taskID, "task id")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "worktrees", repoSegment, taskSegment), nil
+}
+
+func taskWorktreeRepoSegment(repo string) (string, error) {
+	owner, name, ok := strings.Cut(strings.TrimSpace(repo), "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return "", fmt.Errorf("invalid task worktree repo %q", repo)
+	}
+	ownerSegment, err := taskWorktreePathSegment(owner, "repo owner")
+	if err != nil {
+		return "", err
+	}
+	nameSegment, err := taskWorktreePathSegment(name, "repo name")
+	if err != nil {
+		return "", err
+	}
+	return ownerSegment + "--" + nameSegment, nil
+}
+
+func taskWorktreePathSegment(value string, label string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s is required", label)
+	}
+	if value == "." || value == ".." || strings.ContainsAny(value, `/\`) {
+		return "", fmt.Errorf("%s %q is not safe for a worktree path", label, value)
+	}
+	for _, char := range value {
+		switch {
+		case char >= 'a' && char <= 'z':
+		case char >= 'A' && char <= 'Z':
+		case char >= '0' && char <= '9':
+		case char == '-' || char == '_' || char == '.':
+		default:
+			return "", fmt.Errorf("%s %q contains unsupported path characters", label, value)
+		}
+	}
+	return value, nil
+}

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -1,0 +1,200 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestTaskWorktreePath(t *testing.T) {
+	path, err := TaskWorktreePath("/home/gitmoot", "owner/repo", "task-1")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	want := filepath.Join("/home/gitmoot", "worktrees", "owner--repo", "task-1")
+	if path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+	for _, tc := range []struct {
+		name string
+		repo string
+		task string
+	}{
+		{name: "empty repo", repo: "", task: "task-1"},
+		{name: "nested repo", repo: "owner/repo/extra", task: "task-1"},
+		{name: "unsafe task", repo: "owner/repo", task: "../task"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := TaskWorktreePath("/home/gitmoot", tc.repo, tc.task); err == nil {
+				t.Fatal("TaskWorktreePath accepted invalid input")
+			}
+		})
+	}
+}
+
+func TestEngineAllocateTaskWorktreeAddsGitWorktreeAndStoresPath(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "First", State: string(TaskPlanned)}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	home := t.TempDir()
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	manager := &fakeWorktreeManager{onAdd: func() {
+		lock, err := store.GetResourceLock(ctx, key)
+		if err != nil {
+			t.Fatalf("GetResourceLock during AddWorktree returned error: %v", err)
+		}
+		if lock.OwnerJobID != "worktree:task-1" {
+			t.Fatalf("checkout lock owner = %q, want worktree:task-1", lock.OwnerJobID)
+		}
+	}}
+
+	task, err := engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
+		Home:       home,
+		Repo:       "owner/repo",
+		TaskID:     "task-1",
+		Branch:     "task-1",
+		BaseBranch: "main",
+		Checkout:   checkout,
+	}, manager)
+
+	if err != nil {
+		t.Fatalf("AllocateTaskWorktree returned error: %v", err)
+	}
+	wantPath := filepath.Join(home, "worktrees", "owner--repo", "task-1")
+	if task.WorktreePath != wantPath || task.Branch != "task-1" {
+		t.Fatalf("task = %+v, want worktree path %q and branch task-1", task, wantPath)
+	}
+	if len(manager.calls) != 1 || manager.calls[0].branch != "task-1" || manager.calls[0].path != wantPath || manager.calls[0].base != "main" {
+		t.Fatalf("worktree calls = %+v", manager.calls)
+	}
+	if _, err := store.GetResourceLock(ctx, key); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("checkout lock after AddWorktree error = %v, want sql.ErrNoRows", err)
+	}
+	reloaded, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if reloaded.WorktreePath != wantPath {
+		t.Fatalf("reloaded worktree path = %q, want %q", reloaded.WorktreePath, wantPath)
+	}
+}
+
+func TestEngineAllocateTaskWorktreeBlocksWhenCheckoutMutationLocked(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	home := t.TempDir()
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  "task:other",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	manager := &fakeWorktreeManager{}
+
+	_, err = engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
+		Home:     home,
+		Repo:     "owner/repo",
+		TaskID:   "task-1",
+		Branch:   "task-1",
+		Checkout: checkout,
+	}, manager)
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || blocked.Reason != checkoutMutationBusyMessage {
+		t.Fatalf("error = %v, want checkout busy BlockedError", err)
+	}
+	if len(manager.calls) != 0 {
+		t.Fatalf("AddWorktree ran despite checkout lock: %+v", manager.calls)
+	}
+}
+
+func TestEngineAllocateTaskWorktreeRejectsBranchAssignedToOtherTask(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-existing", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Existing", State: string(TaskPlanned), Branch: "task-1"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	manager := &fakeWorktreeManager{}
+
+	_, err := engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
+		Home:     t.TempDir(),
+		Repo:     "owner/repo",
+		TaskID:   "task-2",
+		Branch:   "task-1",
+		Checkout: t.TempDir(),
+	}, manager)
+
+	if err == nil || !strings.Contains(err.Error(), "another task") {
+		t.Fatalf("error = %v, want branch assignment error", err)
+	}
+	if len(manager.calls) != 0 {
+		t.Fatalf("AddWorktree ran despite assignment conflict: %+v", manager.calls)
+	}
+}
+
+func TestEngineAllocateTaskWorktreeRejectsTaskInAnotherRepo(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/other", GoalID: "goal-1", Title: "First", State: string(TaskPlanned)}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	manager := &fakeWorktreeManager{}
+
+	_, err := engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
+		Home:     t.TempDir(),
+		Repo:     "owner/repo",
+		TaskID:   "task-1",
+		Branch:   "task-1",
+		Checkout: t.TempDir(),
+	}, manager)
+
+	if err == nil || !strings.Contains(err.Error(), "belongs to repo owner/other") {
+		t.Fatalf("error = %v, want repo mismatch error", err)
+	}
+	if len(manager.calls) != 0 {
+		t.Fatalf("AddWorktree ran despite repo mismatch: %+v", manager.calls)
+	}
+}
+
+type fakeWorktreeManager struct {
+	err   error
+	onAdd func()
+	calls []worktreeCall
+}
+
+type worktreeCall struct {
+	branch string
+	path   string
+	base   string
+}
+
+func (f *fakeWorktreeManager) AddWorktree(_ context.Context, branch string, path string, base string) error {
+	if f.onAdd != nil {
+		f.onAdd()
+	}
+	f.calls = append(f.calls, worktreeCall{branch: branch, path: path, base: base})
+	return f.err
+}


### PR DESCRIPTION
## WHAT

Adds Task 5 worktree foundation for safe parallel implementation: git worktree helpers, persisted task worktree paths, and workflow allocation guarded by the checkout mutation lock.

## WHY

Gitmoot needs per-task checkout isolation before implementation jobs can run safely in parallel. This task adds the state and low-level allocation path without changing job dispatch yet.

## CHANGES

- Added `git worktree add -b <branch> <path> <base>` and `git worktree remove <path>` helpers with command-construction tests.
- Added `tasks.worktree_path` migration and task scan/upsert support, preserving existing paths on ordinary task updates/imports.
- Added deterministic worktree path generation under `$GITMOOT_HOME/worktrees/<owner>--<repo>/<task-id>`.
- Added `Engine.AllocateTaskWorktree` with checkout mutation locking, branch-assignment validation, and repo-mismatch validation before mutating git.
- Added workflow tests for path generation, state persistence, checkout lock blocking, branch conflict rejection, and repo mismatch rejection.

## RESULTS

- `GOTOOLCHAIN=go1.26.0 go test ./internal/git ./internal/db ./internal/workflow -run 'TestClientWorktree|TestClientAddWorktree|TestTaskWorktree|TestMigrateAppendsTaskWorktreePath|TestEngineAllocateTaskWorktree' -v -timeout 120s`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/git ./internal/db ./internal/workflow -v -timeout 150s`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestRunGoal|TestRunTaskRun|TestRunStatus' -v -timeout 120s`
- `git diff --check`

Final raw `codex exec review --uncommitted` output:

```text
I did not identify any discrete correctness issues in the staged, unstaged, or untracked code changes. Go tests could not be executed in this sandbox because the required Go 1.26 toolchain could not be downloaded/written under the restricted filesystem.
```

## RISK

- Job dispatch does not use task worktrees yet; that is Task 6.
- Worktree cleanup/docs/SQLite hardening remain for Task 7.
- The review sandbox could not run Go 1.26, but the explicit local checks above passed with `GOTOOLCHAIN=go1.26.0`.
