### PR TITLE
daemon: run implement jobs in task worktrees

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1443,7 +1443,7 @@ func (s queuedJobResourceSelector) selects(ctx context.Context, store *db.Store,
 	if selected >= s.limit {
 		return false
 	}
-	checkoutKey := queuedJobCheckoutKey(job)
+	checkoutKey := queuedJobCheckoutKey(ctx, store, job)
 	runtimeKey := queuedJobRuntimeResourceKey(ctx, store, job)
 	if s.checkouts[checkoutKey] || (runtimeKey != "" && s.runtimes[runtimeKey]) {
 		return false
@@ -1464,12 +1464,30 @@ func queuedJobMatchesRepo(job db.Job, repoFilter string) bool {
 	return err == nil && payload.Repo == repoFilter
 }
 
-func queuedJobCheckoutKey(job db.Job) string {
+func queuedJobCheckoutKey(ctx context.Context, store *db.Store, job db.Job) string {
 	payload, err := daemonJobPayload(job)
 	if err != nil || strings.TrimSpace(payload.Repo) == "" {
 		return "job:" + job.ID
 	}
+	if path, ok := queuedJobTaskWorktreePath(ctx, store, payload); ok {
+		return "worktree:" + path
+	}
 	return "repo:" + payload.Repo
+}
+
+func queuedJobTaskWorktreePath(ctx context.Context, store *db.Store, payload workflow.JobPayload) (string, bool) {
+	if store == nil || strings.TrimSpace(payload.TaskID) == "" {
+		return "", false
+	}
+	task, err := store.GetTask(ctx, payload.TaskID)
+	if err != nil {
+		return "", false
+	}
+	if strings.TrimSpace(task.RepoFullName) != "" && task.RepoFullName != payload.Repo {
+		return "", false
+	}
+	path, err := normalizeTaskWorktreePath(task.WorktreePath)
+	return path, err == nil && path != ""
 }
 
 func queuedJobRuntimeResourceKey(ctx context.Context, store *db.Store, job db.Job) string {
@@ -1765,19 +1783,8 @@ func (w jobWorker) refreshImplementedPayloadForRetry(ctx context.Context, job db
 	if job.Type != "implement" || payload.Result == nil || payload.Result.Decision != "implemented" {
 		return payload, false, nil
 	}
-	repoRecord, err := w.Store.GetRepo(ctx, payload.Repo)
+	checkout, err := w.resolveJobCheckout(ctx, job, payload)
 	if err != nil {
-		return workflow.JobPayload{}, false, err
-	}
-	checkout := strings.TrimSpace(repoRecord.CheckoutPath)
-	if checkout == "" {
-		return workflow.JobPayload{}, false, fmt.Errorf("repo %s has no checkout path", payload.Repo)
-	}
-	repo, err := daemon.ParseRepository(payload.Repo)
-	if err != nil {
-		return workflow.JobPayload{}, false, err
-	}
-	if err := preflightDaemonRepoCheckout(ctx, repo, checkout); err != nil {
 		return workflow.JobPayload{}, false, err
 	}
 	payload, err = refreshDaemonJobPayload(ctx, w.Store, checkout, job, payload)
@@ -1817,18 +1824,57 @@ func (w jobWorker) defaultCommenter(_ string) github.Client {
 
 func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string) workflow.Engine {
 	return workflow.Engine{
-		Store: store,
-		MergeGate: workflow.PolicyMergeGate{
-			Store:        store,
-			GitHub:       gh,
-			Git:          gitutil.Client{Dir: checkout},
-			CheckoutPath: checkout,
-			DeleteBranch: true,
-		},
+		Store:     store,
+		MergeGate: daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout},
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},
 	}
+}
+
+type daemonMergeGate struct {
+	Store            *db.Store
+	GitHub           github.Client
+	FallbackCheckout string
+}
+
+func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeRequest) (workflow.MergeDecision, error) {
+	checkout, err := mergeGateCheckout(ctx, g.Store, request.Repo, g.FallbackCheckout)
+	if err != nil {
+		return workflow.MergeDecision{}, err
+	}
+	return workflow.PolicyMergeGate{
+		Store:        g.Store,
+		GitHub:       g.githubClient(checkout),
+		Git:          gitutil.Client{Dir: checkout},
+		CheckoutPath: checkout,
+		DeleteBranch: true,
+	}.Evaluate(ctx, request)
+}
+
+func (g daemonMergeGate) githubClient(checkout string) github.Client {
+	if g.GitHub == nil {
+		return github.NewClient(checkout)
+	}
+	if _, ok := g.GitHub.(*github.GhClient); ok {
+		return github.NewClient(checkout)
+	}
+	return g.GitHub
+}
+
+func mergeGateCheckout(ctx context.Context, store *db.Store, repo string, fallback string) (string, error) {
+	if store == nil {
+		return strings.TrimSpace(fallback), nil
+	}
+	record, err := store.GetRepo(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	checkout := strings.TrimSpace(record.CheckoutPath)
+	if checkout == "" {
+		return "", fmt.Errorf("repo %s has no checkout path", repo)
+	}
+	return checkout, nil
 }
 
 func refreshDaemonJobPayload(ctx context.Context, store *db.Store, checkout string, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
@@ -1878,19 +1924,8 @@ func agentHasCapability(capabilities []string, target string) bool {
 }
 
 func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload workflow.JobPayload, agent runtime.Agent) (string, error) {
-	repoRecord, err := w.Store.GetRepo(ctx, payload.Repo)
+	checkout, err := w.resolveJobCheckout(ctx, job, payload)
 	if err != nil {
-		return "", err
-	}
-	checkout := strings.TrimSpace(repoRecord.CheckoutPath)
-	if checkout == "" {
-		return "", fmt.Errorf("repo %s has no checkout path", payload.Repo)
-	}
-	repo, err := daemon.ParseRepository(payload.Repo)
-	if err != nil {
-		return "", err
-	}
-	if err := preflightDaemonRepoCheckout(ctx, repo, checkout); err != nil {
 		return "", err
 	}
 	switch job.Type {
@@ -1913,6 +1948,75 @@ func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload work
 		}
 	}
 	return checkout, nil
+}
+
+func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload workflow.JobPayload) (string, error) {
+	repoRecord, err := w.Store.GetRepo(ctx, payload.Repo)
+	if err != nil {
+		return "", err
+	}
+	checkout := strings.TrimSpace(repoRecord.CheckoutPath)
+	if checkout == "" {
+		return "", fmt.Errorf("repo %s has no checkout path", payload.Repo)
+	}
+	repo, err := daemon.ParseRepository(payload.Repo)
+	if err != nil {
+		return "", err
+	}
+	if err := preflightDaemonRepoCheckout(ctx, repo, checkout); err != nil {
+		return "", err
+	}
+	taskCheckout, ok, err := w.taskWorktreeCheckout(ctx, payload)
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		checkout = taskCheckout
+		if err := preflightDaemonRepoCheckout(ctx, repo, checkout); err != nil {
+			return "", err
+		}
+	}
+	return checkout, nil
+}
+
+func (w jobWorker) taskWorktreeCheckout(ctx context.Context, payload workflow.JobPayload) (string, bool, error) {
+	if strings.TrimSpace(payload.TaskID) == "" {
+		return "", false, nil
+	}
+	task, err := w.Store.GetTask(ctx, payload.TaskID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if strings.TrimSpace(task.RepoFullName) != "" && task.RepoFullName != payload.Repo {
+		return "", false, fmt.Errorf("task %s belongs to repo %s, not %s", payload.TaskID, task.RepoFullName, payload.Repo)
+	}
+	if strings.TrimSpace(task.Branch) != "" && task.Branch != payload.Branch {
+		return "", false, fmt.Errorf("task %s branch is %s, not job branch %s", payload.TaskID, task.Branch, payload.Branch)
+	}
+	checkout := strings.TrimSpace(task.WorktreePath)
+	if checkout == "" {
+		return "", false, nil
+	}
+	checkout, err = normalizeTaskWorktreePath(checkout)
+	if err != nil {
+		return "", false, err
+	}
+	return checkout, true, nil
+}
+
+func normalizeTaskWorktreePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", nil
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("normalize task worktree path: %w", err)
+	}
+	return filepath.Clean(absolute), nil
 }
 
 func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.JobPayload, checkout string) error {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -1783,6 +1784,217 @@ func TestRunQueuedJobsFailsImplementWithoutBranchLockBeforeDelivery(t *testing.T
 	}
 }
 
+func TestRunQueuedJobsUsesTaskWorktreeForImplement(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	worktree := filepath.Join(t.TempDir(), "task-1")
+	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-1", worktree, "main")
+	head, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "reviewer", Role: "reviewer", Runtime: runtime.ShellRuntime, RuntimeRef: "unused", RepoScope: "owner/repo", Capabilities: []string{"review"}, AutonomyPolicy: runtime.AutonomyPolicyAuto, HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent reviewer returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-implement-worktree", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, HeadSHA: head, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"implemented","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	adapterCheckout := ""
+	worker.AdapterFactory = func(_ runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
+		adapterCheckout = checkout
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(checkout string) workflow.Engine {
+		return workflow.Engine{
+			Store:             store,
+			RequiredReviewers: []string{"reviewer"},
+			PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
+				return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
+			},
+		}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	wantCheckout, err := filepath.Abs(worktree)
+	if err != nil {
+		t.Fatalf("Abs returned error: %v", err)
+	}
+	if adapterCheckout != filepath.Clean(wantCheckout) {
+		t.Fatalf("adapter checkout = %q, want %q", adapterCheckout, filepath.Clean(wantCheckout))
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+}
+
+func TestRunQueuedJobsUsesTaskWorktreeForReview(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	worktree := filepath.Join(t.TempDir(), "task-1")
+	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-1", worktree, "main")
+	head, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskReviewing), Branch: "task-1", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-review-worktree", Agent: "reviewer", Action: "review", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, HeadSHA: head, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	adapterCheckout := ""
+	worker.AdapterFactory = func(_ runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
+		adapterCheckout = checkout
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	wantCheckout, err := filepath.Abs(worktree)
+	if err != nil {
+		t.Fatalf("Abs returned error: %v", err)
+	}
+	if adapterCheckout != filepath.Clean(wantCheckout) {
+		t.Fatalf("adapter checkout = %q, want %q", adapterCheckout, filepath.Clean(wantCheckout))
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+}
+
+func TestRunQueuedJobsKeepsReviewOnRegisteredCheckoutWithoutTaskWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "task-1")
+	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskReviewing), Branch: "task-1"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-review-main-checkout", Agent: "reviewer", Action: "review", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, HeadSHA: head, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	adapterCheckout := ""
+	worker.AdapterFactory = func(_ runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
+		adapterCheckout = checkout
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if adapterCheckout != checkout {
+		t.Fatalf("adapter checkout = %q, want registered checkout %q", adapterCheckout, checkout)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+}
+
+func TestMergeGateCheckoutUsesRegisteredCheckoutOverTaskWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	worktree := filepath.Join(t.TempDir(), "task-1")
+	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-1", worktree, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	got, err := mergeGateCheckout(ctx, store, "owner/repo", worktree)
+	if err != nil {
+		t.Fatalf("mergeGateCheckout returned error: %v", err)
+	}
+	if got != checkout {
+		t.Fatalf("merge gate checkout = %q, want registered checkout %q", got, checkout)
+	}
+}
+
+func TestDaemonMergeGatePreservesInjectedGitHubClient(t *testing.T) {
+	fake := github.NoopClient{}
+	gate := daemonMergeGate{GitHub: fake}
+
+	if got := gate.githubClient("/tmp/checkout"); got != fake {
+		t.Fatalf("github client = %#v, want injected fake %#v", got, fake)
+	}
+}
+
+func TestSelectRunnableQueuedJobsAllowsSeparateTaskWorktrees(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "lead-a", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "lead-b", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-a", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: "task-a", WorktreePath: "/tmp/gitmoot/task-a"}); err != nil {
+		t.Fatalf("UpsertTask task-a returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-b", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: "task-b", WorktreePath: "/tmp/gitmoot/task-b"}); err != nil {
+		t.Fatalf("UpsertTask task-b returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "lead-a", Action: "implement", Repo: "owner/repo", Branch: "task-a", TaskID: "task-a"})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "lead-b", Action: "implement", Repo: "owner/repo", Branch: "task-b", TaskID: "task-b"})
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+
+	selected, remaining := selectRunnableQueuedJobs(ctx, store, jobs, 2)
+
+	if len(selected) != 2 || len(remaining) != 0 {
+		t.Fatalf("selected=%d remaining=%d, want two selected separate worktrees", len(selected), len(remaining))
+	}
+}
+
+func TestSelectRunnableQueuedJobsKeepsSameRuntimeSerializedAcrossWorktrees(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "lead-a", runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "lead-b", runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-a", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: "task-a", WorktreePath: "/tmp/gitmoot/task-a"}); err != nil {
+		t.Fatalf("UpsertTask task-a returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-b", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: "task-b", WorktreePath: "/tmp/gitmoot/task-b"}); err != nil {
+		t.Fatalf("UpsertTask task-b returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "lead-a", Action: "implement", Repo: "owner/repo", Branch: "task-a", TaskID: "task-a"})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "lead-b", Action: "implement", Repo: "owner/repo", Branch: "task-b", TaskID: "task-b"})
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+
+	selected, remaining := selectRunnableQueuedJobs(ctx, store, jobs, 2)
+
+	if len(selected) != 1 || len(remaining) != 1 {
+		t.Fatalf("selected=%d remaining=%d, want same runtime session serialized", len(selected), len(remaining))
+	}
+}
+
 func TestRunQueuedJobsFailsReviewOnWrongCheckoutBranchBeforeDelivery(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -2706,6 +2918,31 @@ func daemonWorkerStore(t *testing.T) *db.Store {
 		}
 	})
 	return store
+}
+
+func createDaemonWorkerGitCheckout(t *testing.T, branch string) string {
+	t.Helper()
+	checkout := t.TempDir()
+	runDaemonWorkerGit(t, checkout, "init", "-b", branch)
+	runDaemonWorkerGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runDaemonWorkerGit(t, checkout, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("test\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile README returned error: %v", err)
+	}
+	runDaemonWorkerGit(t, checkout, "add", "README.md")
+	runDaemonWorkerGit(t, checkout, "commit", "-m", "initial")
+	runDaemonWorkerGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	return checkout
+}
+
+func runDaemonWorkerGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
 }
 
 func seedDaemonWorkerRepo(t *testing.T, store *db.Store, fullName string, checkout string) {


### PR DESCRIPTION
## What
- Resolve task-tied daemon jobs to the task worktree when one is assigned.
- Keep merge-gate base updates and branch cleanup on the registered checkout.
- Use worktree-aware resource keys so separate task worktrees can run concurrently while same runtime sessions still serialize.

## Why
This supports parallel implementation without moving one shared registered checkout under multiple workers.

## Changes
- Added worktree-aware queued-job checkout resource selection.
- Added daemon checkout resolution for task worktrees.
- Refreshed retry payloads from the selected task worktree.
- Wrapped merge-gate checkout resolution so local base mutation stays on the registered checkout.
- Added daemon regression tests for implement/review checkout routing, merge-gate checkout selection, and runtime serialization.

## Checks
- `gofmt -w internal/cli/daemon.go internal/cli/daemon_test.go`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestRunQueuedJobsUsesTaskWorktreeForImplement|TestRunQueuedJobsUsesTaskWorktreeForReview|TestRunQueuedJobsKeepsReviewOnRegisteredCheckoutWithoutTaskWorktree|TestMergeGateCheckoutUsesRegisteredCheckoutOverTaskWorktree|TestDaemonMergeGatePreservesInjectedGitHubClient|TestSelectRunnableQueuedJobsAllowsSeparateTaskWorktrees|TestSelectRunnableQueuedJobsKeepsSameRuntimeSerializedAcrossWorktrees' -v -timeout 120s`\n- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestRunQueuedJobs|TestSelectRunnableQueuedJobs|TestRunDaemon|TestRunTaskRun|TestMergeGateCheckout|TestDaemonMergeGate' -v -timeout 150s`\n- `GOTOOLCHAIN=go1.26.0 go test ./internal/workflow ./internal/runtime -v -timeout 150s`\n- `git diff --check`\n- `codex exec review --uncommitted` clean after fixing review findings\n\n## Risk\nA full `go test ./internal/cli` was not re-run after the final fixes. An earlier full CLI run with `GOTOOLCHAIN=go1.26.0` failed in unrelated SkillOpt Codex-start tests, while the focused daemon/workflow/runtime checks passed.