### PR TITLE
docs: document agent permissions and worktrees

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -274,6 +274,14 @@ same checkout remain serialized even when the worker count is higher.
    registering all intended repos if one daemon should supervise the whole
    Gitmoot home.
 
+   Gitmoot records agent autonomy policy as `read-only`, `workspace-write`,
+   `danger-full-access`, or `auto`. For Codex these map to Codex sandbox
+   policies; for Claude Code they map to Claude permission modes. Implementation
+   jobs require a writable policy. If an implementation worker is read-only or
+   its runtime asks for write permission, Gitmoot blocks the job before treating
+   it as implementation work and tells the user to restart or subscribe a
+   writable worker.
+
 6. Start and open the first task PR.
 
    ```sh
@@ -281,9 +289,11 @@ same checkout remain serialized even when the worker count is higher.
    ```
 
    The lead agent or the human creates the task branch, implements the task,
-   pushes it, and opens a PR. The PR comments become the public audit trail.
-   The local Gitmoot database tracks the task, jobs, branch locks, PR head SHA,
-   and merge gate state.
+   pushes it, and opens a PR. When Gitmoot allocates a task worktree, writable
+   jobs for that task run from `$GITMOOT_HOME/worktrees/<owner>--<repo>/<task-id>/`
+   instead of moving the registered checkout. The PR comments become the public
+   audit trail. The local Gitmoot database tracks the task, jobs, branch locks,
+   worktree path, PR head SHA, and merge gate state.
 
 7. Route other agents through PR comments.
 
@@ -300,7 +310,8 @@ same checkout remain serialized even when the worker count is higher.
 
    Implement jobs require the agent to hold the branch lock. Review and ask jobs
    are routed through the runtime adapter and must return the `gitmoot_result`
-   JSON contract.
+   JSON contract. Jobs tied to a task worktree use that worktree for validation;
+   jobs without a task worktree use the registered checkout.
 
    For a local chat ask that should not go through a PR comment, call the same
    registered agent directly:
@@ -331,14 +342,20 @@ same checkout remain serialized even when the worker count is higher.
 9. Merge and continue.
 
    By default Gitmoot merges with a squash merge guarded by the current head SHA.
-   After merge it records the merged commit, releases the branch lock, updates
-   the local base branch, and can enqueue the next task once the task queueing
-   policy selects it.
+   After merge it records the merged commit, releases the branch lock, removes
+   the task worktree when one is recorded, updates the local base branch, and can
+   enqueue the next task once the task queueing policy selects it. If worktree
+   cleanup fails, the merge remains recorded and Gitmoot keeps the worktree path
+   on the task so it can be cleaned manually.
 
 ## Local-Only Limits
 
 - The machine running `gitmoot daemon start` must stay online.
 - Polling is the V1 mechanism; there is no webhook receiver yet.
+- Parallel implementation needs separate task worktrees and separate runtime
+  sessions or managed background instances. Checkout mutation operations are
+  serialized per checkout path; runtime session locks still serialize jobs that
+  reuse the same Codex or Claude session.
 - GitHub Checks are best implemented later through GitHub App mode. V1 uses
   commit statuses and `gh pr checks`.
 - Use explicit session ids for long workflows. `last` is convenient but can

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,6 +93,34 @@ Fixes:
 - Confirm `CODEX_HOME` if sessions are stored outside `~/.codex`.
 - Re-subscribe the agent with the correct session reference.
 
+## Read-Only Or Permission-Blocked Workers
+
+Symptoms:
+
+- An implementation job is blocked before the agent starts.
+- A job comment says the worker is read-only or cannot make changes.
+- Runtime output asks for permission or reports that writes are blocked.
+
+Checks:
+
+```sh
+gitmoot agent list
+gitmoot agent show <agent>
+gitmoot job show <job-id>
+gitmoot job events <job-id>
+```
+
+Fixes:
+
+- If read-only was intentional, do not rerun the implementation job with that
+  worker. Restart the agent in write mode or subscribe a writable worker, then
+  rerun the task.
+- For Codex agents, use an autonomy policy that permits writes for implementation
+  jobs. For Claude Code agents, use a permission mode that accepts edits for
+  implementation jobs.
+- Review and ask jobs can still run with read-only workers when they do not need
+  to modify files.
+
 ## Agent Templates
 
 Symptoms:
@@ -274,6 +302,37 @@ Fixes:
   runtime sessions or an agent type with `max_background` greater than one.
 - Use `gitmoot agent gc` to remove expired managed background instances.
 
+## Parallel Implementation And Worktrees
+
+Symptoms:
+
+- Parallel tasks contend on one checkout.
+- A job reports that the checkout is already being mutated.
+- Two jobs using different branches still block each other because they share one
+  registered checkout.
+
+Checks:
+
+```sh
+gitmoot task list --repo owner/repo
+gitmoot job list --repo owner/repo
+gitmoot job events <job-id>
+gitmoot lock list --repo owner/repo
+```
+
+Fixes:
+
+- Use task worktrees for parallel implementation. Gitmoot stores each task
+  worktree path on the task and routes task-tied jobs there.
+- Keep the registered checkout clean. Gitmoot still uses it for base branch
+  updates and merge-gate cleanup.
+- Use separate runtime sessions or managed background instances for jobs that
+  should truly run concurrently. Worktrees isolate files; runtime session locks
+  still serialize reuse of the same Codex or Claude session.
+- Temporary forkable workers, such as the future #177 flow, should remain gated
+  on task worktree isolation. Forking sessions without checkout isolation only
+  moves the contention from runtime memory to local git state.
+
 ## Malformed Agent Output
 
 Symptoms:
@@ -339,3 +398,6 @@ Fixes:
 - Update the PR branch if it is behind or diverged from base.
 - Fix failing external CI or Gitmoot statuses.
 - Rerun reviews after the PR head SHA changes.
+- If a merged task reports a worktree cleanup warning, inspect the stored task
+  worktree path, clean or remove that worktree manually, then clear stale local
+  state only after confirming the path is no longer needed.

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -186,14 +186,8 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		checkout := repoRecord.CheckoutPath
 		gh := github.NewClient(checkout)
 		engine := workflow.Engine{
-			Store: store,
-			MergeGate: workflow.PolicyMergeGate{
-				Store:        store,
-				GitHub:       gh,
-				Git:          gitutil.Client{Dir: checkout},
-				CheckoutPath: checkout,
-				DeleteBranch: true,
-			},
+			Store:     store,
+			MergeGate: newDaemonPolicyMergeGate(store, gh, checkout),
 		}
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
 		return runSingleRepoSupervisor(ctx, *home, daemon.Daemon{
@@ -1843,13 +1837,7 @@ func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeReq
 	if err != nil {
 		return workflow.MergeDecision{}, err
 	}
-	return workflow.PolicyMergeGate{
-		Store:        g.Store,
-		GitHub:       g.githubClient(checkout),
-		Git:          gitutil.Client{Dir: checkout},
-		CheckoutPath: checkout,
-		DeleteBranch: true,
-	}.Evaluate(ctx, request)
+	return newDaemonPolicyMergeGate(g.Store, g.githubClient(checkout), checkout).Evaluate(ctx, request)
 }
 
 func (g daemonMergeGate) githubClient(checkout string) github.Client {
@@ -1875,6 +1863,17 @@ func mergeGateCheckout(ctx context.Context, store *db.Store, repo string, fallba
 		return "", fmt.Errorf("repo %s has no checkout path", repo)
 	}
 	return checkout, nil
+}
+
+func newDaemonPolicyMergeGate(store *db.Store, gh github.Client, checkout string) workflow.PolicyMergeGate {
+	return workflow.PolicyMergeGate{
+		Store:        store,
+		GitHub:       gh,
+		Git:          gitutil.Client{Dir: checkout},
+		Worktrees:    gitutil.Client{Dir: checkout},
+		CheckoutPath: checkout,
+		DeleteBranch: true,
+	}
 }
 
 func refreshDaemonJobPayload(ctx context.Context, store *db.Store, checkout string, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -1936,6 +1936,20 @@ func TestMergeGateCheckoutUsesRegisteredCheckoutOverTaskWorktree(t *testing.T) {
 	}
 }
 
+func TestNewDaemonPolicyMergeGateIncludesWorktreeCleaner(t *testing.T) {
+	gate := newDaemonPolicyMergeGate(nil, github.NoopClient{}, "/tmp/gitmoot-checkout")
+
+	if gate.Worktrees == nil {
+		t.Fatal("daemon merge gate missing worktree cleaner")
+	}
+	if gate.CheckoutPath != "/tmp/gitmoot-checkout" {
+		t.Fatalf("checkout path = %q", gate.CheckoutPath)
+	}
+	if !gate.DeleteBranch {
+		t.Fatal("daemon merge gate should delete merged branches")
+	}
+}
+
 func TestDaemonMergeGatePreservesInjectedGitHubClient(t *testing.T) {
 	fake := github.NoopClient{}
 	gate := daemonMergeGate{GitHub: fake}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -378,6 +378,8 @@ type sqlExecer interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
+const sqliteBusyTimeoutMillis = 5000
+
 func Open(path string) (*Store, error) {
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -386,6 +388,10 @@ func Open(path string) (*Store, error) {
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 
+	if err := configureWritableSQLite(context.Background(), db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	store := &Store{db: db}
 	if err := store.Migrate(context.Background()); err != nil {
 		_ = db.Close()
@@ -402,11 +408,32 @@ func OpenReadOnly(path string) (*Store, error) {
 	}
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
+	if err := configureReadOnlySQLite(context.Background(), db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	if err := db.PingContext(context.Background()); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
 	return &Store{db: db}, nil
+}
+
+func configureWritableSQLite(ctx context.Context, db *sql.DB) error {
+	if err := configureReadOnlySQLite(ctx, db); err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, `PRAGMA journal_mode=WAL`); err != nil {
+		return fmt.Errorf("configure sqlite WAL: %w", err)
+	}
+	return nil
+}
+
+func configureReadOnlySQLite(ctx context.Context, db *sql.DB) error {
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(`PRAGMA busy_timeout=%d`, sqliteBusyTimeoutMillis)); err != nil {
+		return fmt.Errorf("configure sqlite busy timeout: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) Close() error {
@@ -1461,6 +1488,11 @@ func (s *Store) ListGoals(ctx context.Context) ([]Goal, error) {
 
 func (s *Store) UpsertTask(ctx context.Context, task Task) error {
 	return upsertTask(ctx, s.db, task)
+}
+
+func (s *Store) ClearTaskWorktreePath(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE tasks SET worktree_path = '', updated_at = CURRENT_TIMESTAMP WHERE id = ?`, id)
+	return err
 }
 
 func upsertTask(ctx context.Context, execer sqlExecer, task Task) error {

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -59,6 +59,44 @@ func TestOpenMigratesSchema(t *testing.T) {
 	}
 }
 
+func TestOpenConfiguresSQLiteContentionPragmas(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+
+	var busyTimeout int
+	if err := store.db.QueryRowContext(context.Background(), `PRAGMA busy_timeout`).Scan(&busyTimeout); err != nil {
+		t.Fatalf("PRAGMA busy_timeout returned error: %v", err)
+	}
+	if busyTimeout != sqliteBusyTimeoutMillis {
+		t.Fatalf("busy_timeout = %d, want %d", busyTimeout, sqliteBusyTimeoutMillis)
+	}
+	var journalMode string
+	if err := store.db.QueryRowContext(context.Background(), `PRAGMA journal_mode`).Scan(&journalMode); err != nil {
+		t.Fatalf("PRAGMA journal_mode returned error: %v", err)
+	}
+	if journalMode != "wal" {
+		t.Fatalf("journal_mode = %q, want wal", journalMode)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	readOnly, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly returned error: %v", err)
+	}
+	defer readOnly.Close()
+	if err := readOnly.db.QueryRowContext(context.Background(), `PRAGMA busy_timeout`).Scan(&busyTimeout); err != nil {
+		t.Fatalf("read-only PRAGMA busy_timeout returned error: %v", err)
+	}
+	if busyTimeout != sqliteBusyTimeoutMillis {
+		t.Fatalf("read-only busy_timeout = %d, want %d", busyTimeout, sqliteBusyTimeoutMillis)
+	}
+}
+
 func TestSkillOptTrainSessionAndIterationStorage(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
@@ -2009,6 +2047,16 @@ func TestTaskWorktreePathStorage(t *testing.T) {
 	}
 	if updated.State != "implementing" || updated.Title != "Updated" {
 		t.Fatalf("task update did not apply: %+v", updated)
+	}
+	if err := store.ClearTaskWorktreePath(ctx, "task-1"); err != nil {
+		t.Fatalf("ClearTaskWorktreePath returned error: %v", err)
+	}
+	cleared, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask cleared returned error: %v", err)
+	}
+	if cleared.WorktreePath != "" {
+		t.Fatalf("cleared worktree path = %q, want empty", cleared.WorktreePath)
 	}
 }
 

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -37,10 +37,15 @@ type NextTaskEnqueuer interface {
 	EnqueueNextTask(ctx context.Context, completedTaskID string) error
 }
 
+type WorktreeCleaner interface {
+	RemoveWorktree(ctx context.Context, path string) error
+}
+
 type PolicyMergeGate struct {
 	Store        *db.Store
 	GitHub       MergeGateGitHub
 	Git          MergeGateGit
+	Worktrees    WorktreeCleaner
 	NextTasks    NextTaskEnqueuer
 	CheckoutPath string
 	DeleteBranch bool
@@ -161,6 +166,9 @@ func (g PolicyMergeGate) finishMerged(ctx context.Context, request MergeRequest,
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		postMergeWarnings = append(postMergeWarnings, "load branch lock: "+err.Error())
 	}
+	if err := g.cleanupTaskWorktree(ctx, request, pr.HeadRef); err != nil {
+		postMergeWarnings = append(postMergeWarnings, "cleanup task worktree: "+err.Error())
+	}
 	if g.Git != nil && strings.TrimSpace(pr.BaseRef) != "" {
 		if err := g.Git.UpdateBase(ctx, "origin", pr.BaseRef); err != nil {
 			postMergeWarnings = append(postMergeWarnings, "update base: "+err.Error())
@@ -177,6 +185,37 @@ func (g PolicyMergeGate) finishMerged(ctx context.Context, request MergeRequest,
 		_ = g.Store.UpsertMergeGate(ctx, db.MergeGate{RepoFullName: request.Repo, PullRequest: int64(request.PullRequest), State: "merged", Reason: reason})
 	}
 	return MergeDecision{Ready: true, Merged: true, MergeCommitSHA: mergeSHA, Reason: reason}, nil
+}
+
+func (g PolicyMergeGate) cleanupTaskWorktree(ctx context.Context, request MergeRequest, headBranch string) error {
+	if g.Worktrees == nil || strings.TrimSpace(request.TaskID) == "" {
+		return nil
+	}
+	task, err := g.Store.GetTask(ctx, request.TaskID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	path := strings.TrimSpace(task.WorktreePath)
+	if path == "" {
+		return nil
+	}
+	if strings.TrimSpace(task.RepoFullName) != "" && task.RepoFullName != request.Repo {
+		return fmt.Errorf("task %s belongs to repo %s, not %s", request.TaskID, task.RepoFullName, request.Repo)
+	}
+	expectedBranch := strings.TrimSpace(request.Branch)
+	if expectedBranch == "" {
+		expectedBranch = strings.TrimSpace(headBranch)
+	}
+	if strings.TrimSpace(task.Branch) != "" && task.Branch != expectedBranch {
+		return fmt.Errorf("task %s branch is %s, not merged branch %s", request.TaskID, task.Branch, expectedBranch)
+	}
+	if err := g.Worktrees.RemoveWorktree(ctx, path); err != nil {
+		return err
+	}
+	return g.Store.ClearTaskWorktreePath(ctx, request.TaskID)
 }
 
 func (g PolicyMergeGate) acquireLocalCheckoutMutationLock(ctx context.Context, request MergeRequest) (func(context.Context) error, error) {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -87,6 +87,144 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 	}
 }
 
+func TestPolicyMergeGateCleansTaskWorktreeAfterMerge(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-9", RepoFullName: "jerryfane/gitmoot", GoalID: "goal-1", Title: "Task 9", State: string(TaskReadyToMerge), Branch: "task-9", WorktreePath: "/tmp/gitmoot/worktrees/jerryfane--gitmoot/task-9"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, State: "open", URL: "https://github.com/jerryfane/gitmoot/pull/9", HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	cleaner := &fakeWorktreeCleaner{}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, Worktrees: cleaner}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9", Reviewer: "audit"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged || decision.Reason != "merged" {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(cleaner.removed) != 1 || cleaner.removed[0] != "/tmp/gitmoot/worktrees/jerryfane--gitmoot/task-9" {
+		t.Fatalf("removed worktrees = %+v", cleaner.removed)
+	}
+	task, err := store.GetTask(ctx, "task-9")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.WorktreePath != "" {
+		t.Fatalf("task worktree path = %q, want cleared", task.WorktreePath)
+	}
+}
+
+func TestPolicyMergeGateReportsWorktreeCleanupWarning(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-9", RepoFullName: "jerryfane/gitmoot", GoalID: "goal-1", Title: "Task 9", State: string(TaskReadyToMerge), Branch: "task-9", WorktreePath: "/tmp/gitmoot/worktrees/jerryfane--gitmoot/task-9"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, State: "open", URL: "https://github.com/jerryfane/gitmoot/pull/9", HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	cleaner := &fakeWorktreeCleaner{err: errors.New("worktree has uncommitted files")}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, Worktrees: cleaner}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9", Reviewer: "audit"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged || !strings.Contains(decision.Reason, "cleanup task worktree") {
+		t.Fatalf("decision = %+v, want cleanup warning", decision)
+	}
+	task, err := store.GetTask(ctx, "task-9")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.WorktreePath == "" {
+		t.Fatal("task worktree path was cleared despite cleanup failure")
+	}
+}
+
+func TestPolicyMergeGateDoesNotCleanWorktreeForMismatchedTaskBranch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-8", RepoFullName: "jerryfane/gitmoot", GoalID: "goal-1", Title: "Task 8", State: string(TaskImplementing), Branch: "task-8", WorktreePath: "/tmp/gitmoot/worktrees/jerryfane--gitmoot/task-8"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-8",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, State: "open", URL: "https://github.com/jerryfane/gitmoot/pull/9", HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	cleaner := &fakeWorktreeCleaner{}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, Worktrees: cleaner}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", Branch: "task-9", PullRequest: 9, TaskID: "task-8", Reviewer: "audit"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged || !strings.Contains(decision.Reason, "task task-8 branch is task-8") {
+		t.Fatalf("decision = %+v, want branch mismatch cleanup warning", decision)
+	}
+	if len(cleaner.removed) != 0 {
+		t.Fatalf("removed worktrees = %+v, want none", cleaner.removed)
+	}
+	task, err := store.GetTask(ctx, "task-8")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.WorktreePath == "" {
+		t.Fatal("mismatched task worktree path was cleared")
+	}
+}
+
 func TestPolicyMergeGateLocksCheckoutDuringLocalBaseUpdate(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -735,6 +873,16 @@ func (f *fakeMergeGateGit) UpdateBase(_ context.Context, remote string, branch s
 	}
 	f.updated = append(f.updated, remote+"/"+branch)
 	return nil
+}
+
+type fakeWorktreeCleaner struct {
+	removed []string
+	err     error
+}
+
+func (f *fakeWorktreeCleaner) RemoveWorktree(_ context.Context, path string) error {
+	f.removed = append(f.removed, path)
+	return f.err
 }
 
 func hasStatus(statuses []github.CommitStatusInput, context string, state string) bool {


### PR DESCRIPTION
## What
- Add safe task worktree cleanup after merge.
- Harden SQLite opens with `busy_timeout` and WAL for writable stores.
- Document read-only/permission-blocked worker behavior, Codex/Claude policy mapping, checkout mutation locks, task worktrees, and #177 temporary worker gating.

## Why
This closes the final cleanup/docs slice for the agent permissions and task-worktree plan: users need clear behavior for read-only workers and parallel implementation, and merged task worktrees should not linger when cleanup is safe.

## Changes
- Added `PolicyMergeGate.Worktrees` cleanup on successful merge, clearing `worktree_path` only after `git worktree remove` succeeds.
- Guarded cleanup by repo and branch so a stale same-repo `TaskID` cannot remove another task worktree.
- Reused one daemon merge-gate constructor so single-repo and registered-repo daemon paths both include worktree cleanup.
- Added SQLite `busy_timeout` on writable/read-only opens and `journal_mode=WAL` on writable opens.
- Added docs for read-only implementation blocking, task worktrees, runtime-session locks, checkout mutation locks, and #177 gating.

## Checks
- `gofmt -w internal/cli/daemon.go internal/cli/daemon_test.go internal/db/store.go internal/db/store_test.go internal/workflow/merge_gate.go internal/workflow/merge_gate_test.go`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/workflow -run 'TestPolicyMergeGateCleansTaskWorktreeAfterMerge|TestPolicyMergeGateReportsWorktreeCleanupWarning|TestPolicyMergeGateDoesNotCleanWorktreeForMismatchedTaskBranch|TestPolicyMergeGateMergesPassingPullRequest' -v -timeout 120s`\n- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestRunDaemon|TestMergeGateCheckoutUsesRegisteredCheckoutOverTaskWorktree|TestNewDaemonPolicyMergeGateIncludesWorktreeCleaner|TestDaemonMergeGatePreservesInjectedGitHubClient' -v -timeout 120s`\n- `GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/workflow -v -timeout 180s`\n- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestRunQueuedJobs|TestSelectRunnableQueuedJobs|TestRunDaemon|TestRunTaskRun|TestMergeGateCheckout|TestNewDaemonPolicyMergeGate|TestDaemonMergeGate' -v -timeout 180s`\n- `git diff --check`\n- `codex exec review --uncommitted` found one P2 branch-mismatch cleanup issue; fixed with branch validation and regression test.\n- Final `codex exec review --uncommitted`: clean. Reviewer note: Go tests could not be run inside the review sandbox because the local Go toolchain is 1.22.2 and Go 1.26 download would need writes outside the workspace; checks above were run manually with `GOTOOLCHAIN=go1.26.0`.\n\n## Risk\nFull `go test ./internal/cli` was not run because prior full CLI runs include unrelated long SkillOpt Codex-start tests. Focused daemon/worktree CLI tests and full DB/workflow tests passed.