### PR TITLE
Add task worktree inspection and allocation

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -9,7 +9,7 @@ statuses, and merges only after the merge gate passes.
 ## What Exists Today
 
 The current CLI supports local setup, multi-repo daemon management, agent
-registration, plan import, task branch startup, status, recovery, and updates:
+registration, plan import, task worktree startup, status, recovery, and updates:
 
 ```sh
 gitmoot setup --repo owner/repo --path . --agent lead --runtime codex --session <session-ref> --role lead
@@ -31,9 +31,11 @@ gitmoot agent start thermo-review --runtime codex --repo owner/repo --template t
 gitmoot agent allow <name> --repo owner/repo
 gitmoot agent repos <name>
 gitmoot agent list
+gitmoot agent show <name>
 gitmoot agent doctor <name>
 gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
+gitmoot task list --repo owner/repo
 gitmoot job list
 gitmoot job show <job-id>
 gitmoot job watch <job-id>
@@ -48,7 +50,8 @@ gitmoot daemon status
 ```
 
 Goal import turns Markdown headings shaped like `### Task N: Title` into local
-planned tasks. `task run` starts one task branch and records its branch lock.
+planned tasks. `task run` starts one task branch in a dedicated worktree,
+records its branch lock, and stores the worktree path on the task.
 
 ## Runtime Plugin Setup
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -42,6 +42,8 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 		return runAgentGC(args[1:], stdout, stderr)
 	case "subscribe":
 		return runAgentSubscribe(args[1:], stdout, stderr)
+	case "show":
+		return runAgentShow(args[1:], stdout, stderr)
 	case "list":
 		return runAgentList(args[1:], stdout, stderr)
 	case "remove":
@@ -74,6 +76,7 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent allow <name> --repo owner/repo")
 	fmt.Fprintln(w, "  gitmoot agent deny <name> --repo owner/repo")
 	fmt.Fprintln(w, "  gitmoot agent repos <name>")
+	fmt.Fprintln(w, "  gitmoot agent show <name> [--json]")
 	fmt.Fprintln(w, "  gitmoot agent list")
 	fmt.Fprintln(w, "  gitmoot agent remove <name>")
 	fmt.Fprintln(w, "  gitmoot agent doctor <name>")
@@ -972,6 +975,91 @@ func runAgentList(args []string, stdout, stderr io.Writer) int {
 	for _, agent := range agents {
 		fmt.Fprintf(stdout, "%-16s %-8s %-12s %-20s %s\n", agent.Name, agent.Runtime, agent.Role, strings.Join(agentRepos[agent.Name], ","), strings.Join(agent.Capabilities, ","))
 	}
+	return 0
+}
+
+type agentShowOutput struct {
+	Name         string   `json:"name"`
+	Runtime      string   `json:"runtime"`
+	RuntimeRef   string   `json:"runtime_ref"`
+	Role         string   `json:"role"`
+	Capabilities []string `json:"capabilities"`
+	Policy       string   `json:"policy"`
+	TemplateID   string   `json:"template_id,omitempty"`
+	HealthStatus string   `json:"health_status"`
+	RepoScope    string   `json:"repo_scope,omitempty"`
+	AllowedRepos []string `json:"allowed_repos"`
+}
+
+func runAgentShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "print agent as JSON")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent show requires exactly one name")
+			return 2
+		}
+		return 0
+	}
+	name := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent show requires exactly one name")
+		return 2
+	}
+
+	var output agentShowOutput
+	if err := withStore(*home, func(store *db.Store) error {
+		agent, err := store.GetAgent(context.Background(), name)
+		if err != nil {
+			return err
+		}
+		repos, err := store.ListAgentRepos(context.Background(), agent.Name)
+		if err != nil {
+			return err
+		}
+		output = agentShowOutput{
+			Name:         agent.Name,
+			Runtime:      agent.Runtime,
+			RuntimeRef:   agent.RuntimeRef,
+			Role:         agent.Role,
+			Capabilities: agent.Capabilities,
+			Policy:       runtime.NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy),
+			TemplateID:   agent.TemplateID,
+			HealthStatus: agent.HealthStatus,
+			RepoScope:    agent.RepoScope,
+			AllowedRepos: repos,
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent show: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "agent show: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeLine(stdout, "name: %s", output.Name)
+	writeLine(stdout, "runtime: %s", output.Runtime)
+	writeLine(stdout, "runtime_ref: %s", output.RuntimeRef)
+	writeLine(stdout, "role: %s", output.Role)
+	writeLine(stdout, "capabilities: %s", strings.Join(output.Capabilities, ","))
+	writeLine(stdout, "policy: %s", output.Policy)
+	writeLine(stdout, "template: %s", emptyText(output.TemplateID))
+	writeLine(stdout, "health: %s", output.HealthStatus)
+	writeLine(stdout, "repo_scope: %s", emptyText(output.RepoScope))
+	writeLine(stdout, "allowed_repos: %s", strings.Join(output.AllowedRepos, ","))
 	return 0
 }
 

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -94,6 +94,58 @@ func TestRunAgentSubscribeListRemove(t *testing.T) {
 	}
 }
 
+func TestRunAgentShow(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "subscribe", "audit",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "review",
+		"--policy", "workspace-write",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "show", "audit", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"name: audit",
+		"runtime: codex",
+		"runtime_ref: 550e8400-e29b-41d4-a716-446655440001",
+		"role: reviewer",
+		"capabilities: review",
+		"policy: workspace-write",
+		"allowed_repos: jerryfane/gitmoot",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("agent show output missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "show", "audit", "--home", home, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent show --json exit code = %d, stderr=%s", code, stderr.String())
+	}
+	var decoded agentShowOutput
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("json output did not decode: %v\n%s", err, stdout.String())
+	}
+	if decoded.Name != "audit" || decoded.Policy != runtime.AutonomyPolicyWorkspaceWrite || strings.Join(decoded.AllowedRepos, ",") != "jerryfane/gitmoot" {
+		t.Fatalf("decoded = %+v", decoded)
+	}
+}
+
 func TestRunAgentSubscribeValidatesAutonomyPolicy(t *testing.T) {
 	home := t.TempDir()
 	var stdout, stderr bytes.Buffer

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -241,17 +241,98 @@ func runTask(args []string, stdout, stderr io.Writer) int {
 		printTaskUsage(stdout)
 		return 0
 	}
-	if args[0] != "run" {
+	switch args[0] {
+	case "run":
+		return runTaskRun(args[1:], stdout, stderr)
+	case "list":
+		return runTaskList(args[1:], stdout, stderr)
+	default:
 		fmt.Fprintf(stderr, "unknown task command %q\n\n", args[0])
 		printTaskUsage(stderr)
 		return 2
 	}
-	return runTaskRun(args[1:], stdout, stderr)
 }
 
 func printTaskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot task run <id> --repo owner/repo --owner <agent> [--branch <branch>] [--base <branch>]")
+	fmt.Fprintln(w, "  gitmoot task list [--repo owner/repo] [--state state] [--json]")
+}
+
+type taskListOutput struct {
+	ID           string `json:"id"`
+	Repo         string `json:"repo"`
+	GoalID       string `json:"goal_id"`
+	Title        string `json:"title"`
+	State        string `json:"state"`
+	Branch       string `json:"branch"`
+	WorktreePath string `json:"worktree_path"`
+}
+
+func runTaskList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("task list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repo := fs.String("repo", "", "repo scope as owner/repo")
+	state := fs.String("state", "", "task state filter")
+	jsonOutput := fs.Bool("json", false, "print tasks as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "task list does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*repo) != "" {
+		if _, err := normalizeRepoFlag(*repo); err != nil {
+			fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+			return 2
+		}
+	}
+
+	var tasks []db.Task
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		if strings.TrimSpace(*repo) != "" {
+			tasks, err = store.ListTasksByRepo(context.Background(), strings.TrimSpace(*repo))
+		} else {
+			tasks, err = store.ListTasks(context.Background())
+		}
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "task list: %v\n", err)
+		return 1
+	}
+	outputs := make([]taskListOutput, 0, len(tasks))
+	stateFilter := strings.TrimSpace(*state)
+	for _, task := range tasks {
+		if stateFilter != "" && task.State != stateFilter {
+			continue
+		}
+		outputs = append(outputs, taskListOutput{
+			ID:           task.ID,
+			Repo:         task.RepoFullName,
+			GoalID:       task.GoalID,
+			Title:        task.Title,
+			State:        task.State,
+			Branch:       task.Branch,
+			WorktreePath: task.WorktreePath,
+		})
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, outputs); err != nil {
+			fmt.Fprintf(stderr, "task list: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	for _, task := range outputs {
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\n", task.ID, task.State, task.Repo, task.Branch, task.WorktreePath, task.Title)
+	}
+	return 0
 }
 
 func runTaskRun(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
@@ -342,7 +343,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 	repo := fs.String("repo", "", "repo scope as owner/repo")
 	owner := fs.String("owner", "", "agent that will hold the branch lock")
 	branch := fs.String("branch", "", "task branch name")
-	base := fs.String("base", "", "base branch for git switch -c")
+	base := fs.String("base", "", "base branch for git worktree add")
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		fs.Usage()
 		if len(args) == 0 {
@@ -368,7 +369,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 	}
 
 	var started db.Task
-	if err := withStore(*home, func(store *db.Store) error {
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
 		task, err := store.GetTask(context.Background(), taskID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
@@ -397,7 +398,8 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		checkout := repoRecord.CheckoutPath
 		requestBranch := firstNonEmpty(*branch, task.Branch, task.ID)
 		engine := workflow.Engine{Store: store}
-		started, err = engine.StartTaskBranch(context.Background(), workflow.TaskBranchRequest{
+		started, err = engine.AllocateTaskWorktree(context.Background(), workflow.TaskWorktreeRequest{
+			Home:       paths.Home,
 			Repo:       requestRepo,
 			GoalID:     task.GoalID,
 			TaskID:     task.ID,
@@ -413,6 +415,9 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	fmt.Fprintf(stdout, "started %s on %s\n", started.ID, started.Branch)
+	if strings.TrimSpace(started.WorktreePath) != "" {
+		fmt.Fprintf(stdout, "worktree: %s\n", started.WorktreePath)
+	}
 	return 0
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -247,6 +248,64 @@ func TestRunGoalImportPreservesExistingTaskProgress(t *testing.T) {
 	}
 	if task.RepoFullName != "jerryfane/gitmoot" || task.Title != "Bootstrap Updated" || task.State != "implementing" || task.Branch != "custom-branch" {
 		t.Fatalf("task after reimport = %+v", task)
+	}
+}
+
+func TestRunTaskList(t *testing.T) {
+	home := t.TempDir()
+	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: Bootstrap\n\n### Task 2: Review\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"goal", "import", "--home", home, "--file", goalPath, "--repo", "jerryfane/gitmoot"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.UpsertTask(context.Background(), db.Task{
+		ID:           "task-001",
+		RepoFullName: "jerryfane/gitmoot",
+		GoalID:       "goal",
+		Title:        "Bootstrap",
+		State:        "implementing",
+		Branch:       "task-001-bootstrap",
+		WorktreePath: "/tmp/gitmoot/worktrees/jerryfane--gitmoot/task-001",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"task", "list", "--home", home, "--repo", "jerryfane/gitmoot", "--state", "implementing"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("task list exit code = %d, stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "task-001\timplementing\tjerryfane/gitmoot\ttask-001-bootstrap\t/tmp/gitmoot/worktrees/jerryfane--gitmoot/task-001\tBootstrap") {
+		t.Fatalf("task list output = %q", output)
+	}
+	if strings.Contains(output, "task-002") {
+		t.Fatalf("task list did not apply state filter:\n%s", output)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"task", "list", "--home", home, "--repo", "jerryfane/gitmoot", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("task list --json exit code = %d, stderr=%s", code, stderr.String())
+	}
+	var decoded []taskListOutput
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("json output did not decode: %v\n%s", err, stdout.String())
+	}
+	if len(decoded) != 2 || decoded[0].ID != "task-001" || decoded[0].WorktreePath == "" {
+		t.Fatalf("decoded = %+v", decoded)
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -441,6 +441,9 @@ func TestRunTaskRunRegistersCurrentRepo(t *testing.T) {
 	runGit(t, repoDir, "init")
 	runGit(t, repoDir, "branch", "-m", "main")
 	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/jerryfane/gitmoot.git")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "smoke\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "-c", "user.name=Gitmoot Test", "-c", "user.email=gitmoot@example.com", "commit", "-m", "initial")
 	withWorkingDirectory(t, repoDir)
 
 	stdout.Reset()
@@ -448,6 +451,9 @@ func TestRunTaskRunRegistersCurrentRepo(t *testing.T) {
 	code = Run([]string{"task", "run", "task-001", "--home", home, "--repo", "jerryfane/gitmoot", "--owner", "lead"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("task run exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "worktree: ") {
+		t.Fatalf("stdout missing worktree path: %q", stdout.String())
 	}
 
 	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
@@ -461,6 +467,30 @@ func TestRunTaskRunRegistersCurrentRepo(t *testing.T) {
 	}
 	if repo.CheckoutPath != repoDir || repo.RemoteURL != "https://github.com/jerryfane/gitmoot.git" {
 		t.Fatalf("repo = %+v", repo)
+	}
+	task, err := store.GetTask(context.Background(), "task-001")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	wantWorktree := filepath.Join(home, ".gitmoot", "worktrees", "jerryfane--gitmoot", "task-001")
+	if task.State != "implementing" || task.Branch != "task-001-bootstrap" || task.WorktreePath != wantWorktree {
+		t.Fatalf("task = %+v, want implementing task-001-bootstrap at %s", task, wantWorktree)
+	}
+	lock, err := store.GetBranchLock(context.Background(), "jerryfane/gitmoot", "task-001-bootstrap")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.Owner != "lead" {
+		t.Fatalf("branch lock owner = %q, want lead", lock.Owner)
+	}
+	if _, err := os.Stat(wantWorktree); err != nil {
+		t.Fatalf("worktree path was not created: %v", err)
+	}
+	if currentBranch := strings.TrimSpace(runGitOutput(t, repoDir, "branch", "--show-current")); currentBranch != "main" {
+		t.Fatalf("main checkout branch = %q, want main", currentBranch)
+	}
+	if worktreeBranch := strings.TrimSpace(runGitOutput(t, wantWorktree, "branch", "--show-current")); worktreeBranch != "task-001-bootstrap" {
+		t.Fatalf("task worktree branch = %q, want task-001-bootstrap", worktreeBranch)
 	}
 }
 
@@ -479,6 +509,9 @@ func TestRunTaskRunBlocksWhenCheckoutMutationLocked(t *testing.T) {
 	runGit(t, repoDir, "init")
 	runGit(t, repoDir, "branch", "-m", "main")
 	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/jerryfane/gitmoot.git")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "smoke\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "-c", "user.name=Gitmoot Test", "-c", "user.email=gitmoot@example.com", "commit", "-m", "initial")
 	withWorkingDirectory(t, repoDir)
 
 	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
@@ -514,6 +547,10 @@ func TestRunTaskRunBlocksWhenCheckoutMutationLocked(t *testing.T) {
 	branches := runGitOutput(t, repoDir, "branch", "--list", "task-001")
 	if strings.TrimSpace(branches) != "" {
 		t.Fatalf("task branch was created despite checkout lock: %q", branches)
+	}
+	worktreePath := filepath.Join(home, ".gitmoot", "worktrees", "jerryfane--gitmoot", "task-001")
+	if _, err := os.Stat(worktreePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("worktree path after checkout lock error = %v, want os.ErrNotExist", err)
 	}
 }
 

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -50,7 +50,7 @@ func (c Client) AddExistingBranchWorktree(ctx context.Context, branch string, pa
 	if err != nil {
 		return err
 	}
-	_, err = c.run(ctx, "worktree", "add", "--force", path, branch)
+	_, err = c.run(ctx, "worktree", "add", path, branch)
 	return err
 }
 

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -30,24 +30,47 @@ func (c Client) AddWorktree(ctx context.Context, branch string, path string, bas
 	if err := validateBranch(branch); err != nil {
 		return err
 	}
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return errors.New("worktree path is required")
+	path, err := validateWorktreePath(path)
+	if err != nil {
+		return err
 	}
 	args := []string{"worktree", "add", "-b", branch, path}
 	if strings.TrimSpace(base) != "" {
 		args = append(args, base)
 	}
-	_, err := c.run(ctx, args...)
+	_, err = c.run(ctx, args...)
 	return err
 }
 
-func (c Client) RemoveWorktree(ctx context.Context, path string) error {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return errors.New("worktree path is required")
+func (c Client) AddExistingBranchWorktree(ctx context.Context, branch string, path string) error {
+	if err := validateBranch(branch); err != nil {
+		return err
 	}
-	_, err := c.run(ctx, "worktree", "remove", path)
+	path, err := validateWorktreePath(path)
+	if err != nil {
+		return err
+	}
+	_, err = c.run(ctx, "worktree", "add", path, branch)
+	return err
+}
+
+func (c Client) BranchExists(ctx context.Context, branch string) (bool, error) {
+	if err := validateBranch(branch); err != nil {
+		return false, err
+	}
+	_, err := c.run(ctx, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (c Client) RemoveWorktree(ctx context.Context, path string) error {
+	path, err := validateWorktreePath(path)
+	if err != nil {
+		return err
+	}
+	_, err = c.run(ctx, "worktree", "remove", path)
 	return err
 }
 
@@ -172,4 +195,12 @@ func validateBranch(branch string) error {
 		return fmt.Errorf("branch %q must not end with .lock", branch)
 	}
 	return nil
+}
+
+func validateWorktreePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("worktree path is required")
+	}
+	return path, nil
 }

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -50,7 +50,7 @@ func (c Client) AddExistingBranchWorktree(ctx context.Context, branch string, pa
 	if err != nil {
 		return err
 	}
-	_, err = c.run(ctx, "worktree", "add", path, branch)
+	_, err = c.run(ctx, "worktree", "add", "--force", path, branch)
 	return err
 }
 

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -99,7 +99,7 @@ func TestClientWorktreeCommandConstruction(t *testing.T) {
 
 	runner.wantArgs(t, 0, "git", "worktree", "add", "-b", "task-1", "/worktrees/task-1", "main")
 	runner.wantArgs(t, 1, "git", "show-ref", "--verify", "--quiet", "refs/heads/task-1")
-	runner.wantArgs(t, 2, "git", "worktree", "add", "--force", "/worktrees/task-1-existing", "task-1")
+	runner.wantArgs(t, 2, "git", "worktree", "add", "/worktrees/task-1-existing", "task-1")
 	runner.wantArgs(t, 3, "git", "worktree", "remove", "/worktrees/task-1")
 }
 
@@ -206,6 +206,28 @@ func TestClientWorktreeCleanSmoke(t *testing.T) {
 	}
 	if clean {
 		t.Fatal("WorktreeClean did not report untracked file")
+	}
+}
+
+func TestClientAddExistingBranchWorktreeRefusesCheckedOutBranchSmoke(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, dir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# smoke\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "init")
+	runGit(t, dir, "switch", "-c", "task-branch")
+
+	client := Client{Dir: dir}
+	err := client.AddExistingBranchWorktree(context.Background(), "task-branch", filepath.Join(dir, "task-worktree"))
+	if err == nil {
+		t.Fatal("AddExistingBranchWorktree allowed a branch already checked out in the main worktree")
 	}
 }
 

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -99,7 +99,7 @@ func TestClientWorktreeCommandConstruction(t *testing.T) {
 
 	runner.wantArgs(t, 0, "git", "worktree", "add", "-b", "task-1", "/worktrees/task-1", "main")
 	runner.wantArgs(t, 1, "git", "show-ref", "--verify", "--quiet", "refs/heads/task-1")
-	runner.wantArgs(t, 2, "git", "worktree", "add", "/worktrees/task-1-existing", "task-1")
+	runner.wantArgs(t, 2, "git", "worktree", "add", "--force", "/worktrees/task-1-existing", "task-1")
 	runner.wantArgs(t, 3, "git", "worktree", "remove", "/worktrees/task-1")
 }
 

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -77,30 +77,63 @@ func TestClientRejectsUnsafeBranchNames(t *testing.T) {
 }
 
 func TestClientWorktreeCommandConstruction(t *testing.T) {
-	runner := &fakeRunner{results: []subprocess.Result{{}, {}}}
+	runner := &fakeRunner{results: []subprocess.Result{{}, {}, {}, {}}}
 	client := Client{Runner: runner, Dir: "/repo"}
 
 	if err := client.AddWorktree(context.Background(), "task-1", "/worktrees/task-1", "main"); err != nil {
 		t.Fatalf("AddWorktree returned error: %v", err)
+	}
+	exists, err := client.BranchExists(context.Background(), "task-1")
+	if err != nil {
+		t.Fatalf("BranchExists returned error: %v", err)
+	}
+	if !exists {
+		t.Fatal("BranchExists returned false after successful fake show-ref")
+	}
+	if err := client.AddExistingBranchWorktree(context.Background(), "task-1", "/worktrees/task-1-existing"); err != nil {
+		t.Fatalf("AddExistingBranchWorktree returned error: %v", err)
 	}
 	if err := client.RemoveWorktree(context.Background(), "/worktrees/task-1"); err != nil {
 		t.Fatalf("RemoveWorktree returned error: %v", err)
 	}
 
 	runner.wantArgs(t, 0, "git", "worktree", "add", "-b", "task-1", "/worktrees/task-1", "main")
-	runner.wantArgs(t, 1, "git", "worktree", "remove", "/worktrees/task-1")
+	runner.wantArgs(t, 1, "git", "show-ref", "--verify", "--quiet", "refs/heads/task-1")
+	runner.wantArgs(t, 2, "git", "worktree", "add", "/worktrees/task-1-existing", "task-1")
+	runner.wantArgs(t, 3, "git", "worktree", "remove", "/worktrees/task-1")
 }
 
 func TestClientAddWorktreeRejectsInvalidInput(t *testing.T) {
 	if err := (Client{}).AddWorktree(context.Background(), "bad branch", "/tmp/wt", "main"); err == nil {
 		t.Fatal("AddWorktree accepted unsafe branch")
 	}
+	if err := (Client{}).AddExistingBranchWorktree(context.Background(), "bad branch", "/tmp/wt"); err == nil {
+		t.Fatal("AddExistingBranchWorktree accepted unsafe branch")
+	}
+	if _, err := (Client{}).BranchExists(context.Background(), "bad branch"); err == nil {
+		t.Fatal("BranchExists accepted unsafe branch")
+	}
 	if err := (Client{}).AddWorktree(context.Background(), "task-1", "", "main"); err == nil {
 		t.Fatal("AddWorktree accepted empty path")
+	}
+	if err := (Client{}).AddExistingBranchWorktree(context.Background(), "task-1", " "); err == nil {
+		t.Fatal("AddExistingBranchWorktree accepted empty path")
 	}
 	if err := (Client{}).RemoveWorktree(context.Background(), " "); err == nil {
 		t.Fatal("RemoveWorktree accepted empty path")
 	}
+}
+
+func TestClientBranchExistsReturnsFalseForMissingBranch(t *testing.T) {
+	runner := &fakeRunner{errs: []error{errors.New("exit status 1")}}
+	exists, err := (Client{Runner: runner, Dir: "/repo"}).BranchExists(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("BranchExists returned error: %v", err)
+	}
+	if exists {
+		t.Fatal("BranchExists returned true for missing branch")
+	}
+	runner.wantArgs(t, 0, "git", "show-ref", "--verify", "--quiet", "refs/heads/missing")
 }
 
 func TestClientHeadSHA(t *testing.T) {

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -20,8 +20,11 @@ type TaskWorktreeRequest struct {
 	Home       string
 	Repo       string
 	TaskID     string
+	GoalID     string
+	TaskTitle  string
 	Branch     string
 	BaseBranch string
+	Owner      string
 	Checkout   string
 }
 
@@ -37,6 +40,9 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 	}
 	if strings.TrimSpace(request.Branch) == "" {
 		return db.Task{}, errors.New("task worktree branch is required")
+	}
+	if strings.TrimSpace(request.Owner) == "" {
+		return db.Task{}, errors.New("task worktree owner is required")
 	}
 	path, err := TaskWorktreePath(request.Home, request.Repo, request.TaskID)
 	if err != nil {
@@ -59,8 +65,35 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 	if err == nil && existing.ID != request.TaskID {
 		return db.Task{}, errors.New("task branch is already assigned to another task")
 	}
+	lock := db.BranchLock{RepoFullName: request.Repo, Branch: request.Branch, Owner: request.Owner}
+	createdLock, err := e.Store.CreateLock(ctx, lock)
+	if err != nil {
+		return db.Task{}, err
+	}
+	if !createdLock {
+		existingLock, err := e.Store.GetBranchLock(ctx, request.Repo, request.Branch)
+		if err != nil {
+			return db.Task{}, err
+		}
+		if existingLock.Owner != request.Owner {
+			return db.Task{}, BlockedError{Reason: "branch lock rejected action for " + request.Branch}
+		}
+	}
+	if task.Branch == request.Branch && task.WorktreePath == path {
+		task.State = string(TaskImplementing)
+		if err := e.Store.UpsertTask(ctx, task); err != nil {
+			if createdLock {
+				_, _ = e.Store.ReleaseLock(ctx, lock)
+			}
+			return db.Task{}, err
+		}
+		return task, nil
+	}
 	releaseCheckoutLock, _, err := acquireCheckoutMutationLock(ctx, e.Store, request.Checkout, "worktree:"+request.TaskID, time.Now().UTC())
 	if err != nil {
+		if createdLock {
+			_, _ = e.Store.ReleaseLock(ctx, lock)
+		}
 		return db.Task{}, err
 	}
 	defer func() {
@@ -69,17 +102,32 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 		}
 	}()
 	if err := manager.AddWorktree(ctx, request.Branch, path, request.BaseBranch); err != nil {
+		if createdLock {
+			_, _ = e.Store.ReleaseLock(ctx, lock)
+		}
 		return db.Task{}, err
 	}
-	if strings.TrimSpace(task.RepoFullName) == "" {
-		task.RepoFullName = request.Repo
+	taskGoalID := task.GoalID
+	if taskGoalID == "" {
+		taskGoalID = request.GoalID
 	}
-	task.Branch = request.Branch
-	task.WorktreePath = path
-	if strings.TrimSpace(task.State) == "" {
-		task.State = string(TaskPlanned)
+	taskTitle := task.Title
+	if taskTitle == "" {
+		taskTitle = request.TaskTitle
+	}
+	task = db.Task{
+		ID:           request.TaskID,
+		RepoFullName: request.Repo,
+		GoalID:       taskGoalID,
+		Title:        taskTitle,
+		State:        string(TaskImplementing),
+		Branch:       request.Branch,
+		WorktreePath: path,
 	}
 	if err := e.Store.UpsertTask(ctx, task); err != nil {
+		if createdLock {
+			_, _ = e.Store.ReleaseLock(ctx, lock)
+		}
 		return db.Task{}, err
 	}
 	return task, nil

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -16,6 +16,14 @@ type WorktreeManager interface {
 	AddWorktree(ctx context.Context, branch string, path string, base string) error
 }
 
+type ExistingBranchWorktreeManager interface {
+	AddExistingBranchWorktree(ctx context.Context, branch string, path string) error
+}
+
+type BranchExistenceChecker interface {
+	BranchExists(ctx context.Context, branch string) (bool, error)
+}
+
 type TaskWorktreeRequest struct {
 	Home       string
 	Repo       string
@@ -101,7 +109,7 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 			_ = releaseCheckoutLock(context.Background())
 		}
 	}()
-	if err := manager.AddWorktree(ctx, request.Branch, path, request.BaseBranch); err != nil {
+	if err := addTaskWorktree(ctx, manager, request.Branch, path, request.BaseBranch); err != nil {
 		if createdLock {
 			_, _ = e.Store.ReleaseLock(ctx, lock)
 		}
@@ -131,6 +139,23 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 		return db.Task{}, err
 	}
 	return task, nil
+}
+
+func addTaskWorktree(ctx context.Context, manager WorktreeManager, branch string, path string, base string) error {
+	if checker, ok := manager.(BranchExistenceChecker); ok {
+		exists, err := checker.BranchExists(ctx, branch)
+		if err != nil {
+			return err
+		}
+		if exists {
+			existingManager, ok := manager.(ExistingBranchWorktreeManager)
+			if !ok {
+				return errors.New("existing branch worktree manager is required")
+			}
+			return existingManager.AddExistingBranchWorktree(ctx, branch, path)
+		}
+	}
+	return manager.AddWorktree(ctx, branch, path, base)
 }
 
 func TaskWorktreePath(home string, repo string, taskID string) (string, error) {

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -290,10 +290,53 @@ func TestEngineAllocateTaskWorktreeReusesExistingTaskWorktree(t *testing.T) {
 	}
 }
 
+func TestEngineAllocateTaskWorktreeUsesExistingBranchWhenBranchAlreadyExists(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	home := t.TempDir()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-1",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-1",
+		Title:        "First",
+		State:        string(TaskImplementing),
+		Branch:       "task-1",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	manager := &fakeWorktreeManager{existingBranches: map[string]bool{"task-1": true}}
+
+	task, err := engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
+		Home:     home,
+		Repo:     "owner/repo",
+		TaskID:   "task-1",
+		Branch:   "task-1",
+		Owner:    "lead",
+		Checkout: t.TempDir(),
+	}, manager)
+
+	if err != nil {
+		t.Fatalf("AllocateTaskWorktree returned error: %v", err)
+	}
+	wantPath := filepath.Join(home, "worktrees", "owner--repo", "task-1")
+	if task.WorktreePath != wantPath {
+		t.Fatalf("worktree path = %q, want %q", task.WorktreePath, wantPath)
+	}
+	if len(manager.calls) != 0 {
+		t.Fatalf("AddWorktree ran for existing branch: %+v", manager.calls)
+	}
+	if len(manager.existingCalls) != 1 || manager.existingCalls[0].branch != "task-1" || manager.existingCalls[0].path != wantPath {
+		t.Fatalf("existing branch worktree calls = %+v", manager.existingCalls)
+	}
+}
+
 type fakeWorktreeManager struct {
-	err   error
-	onAdd func()
-	calls []worktreeCall
+	err              error
+	onAdd            func()
+	existingBranches map[string]bool
+	calls            []worktreeCall
+	existingCalls    []worktreeCall
 }
 
 type worktreeCall struct {
@@ -308,4 +351,16 @@ func (f *fakeWorktreeManager) AddWorktree(_ context.Context, branch string, path
 	}
 	f.calls = append(f.calls, worktreeCall{branch: branch, path: path, base: base})
 	return f.err
+}
+
+func (f *fakeWorktreeManager) AddExistingBranchWorktree(_ context.Context, branch string, path string) error {
+	if f.onAdd != nil {
+		f.onAdd()
+	}
+	f.existingCalls = append(f.existingCalls, worktreeCall{branch: branch, path: path})
+	return f.err
+}
+
+func (f *fakeWorktreeManager) BranchExists(_ context.Context, branch string) (bool, error) {
+	return f.existingBranches[branch], nil
 }

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -64,9 +64,12 @@ func TestEngineAllocateTaskWorktreeAddsGitWorktreeAndStoresPath(t *testing.T) {
 	task, err := engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
 		Home:       home,
 		Repo:       "owner/repo",
+		GoalID:     "goal-fallback",
 		TaskID:     "task-1",
+		TaskTitle:  "Fallback",
 		Branch:     "task-1",
 		BaseBranch: "main",
+		Owner:      "lead",
 		Checkout:   checkout,
 	}, manager)
 
@@ -76,6 +79,16 @@ func TestEngineAllocateTaskWorktreeAddsGitWorktreeAndStoresPath(t *testing.T) {
 	wantPath := filepath.Join(home, "worktrees", "owner--repo", "task-1")
 	if task.WorktreePath != wantPath || task.Branch != "task-1" {
 		t.Fatalf("task = %+v, want worktree path %q and branch task-1", task, wantPath)
+	}
+	if task.State != string(TaskImplementing) || task.GoalID != "goal-1" || task.Title != "First" {
+		t.Fatalf("task metadata = %+v", task)
+	}
+	lock, err := store.GetBranchLock(ctx, "owner/repo", "task-1")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.Owner != "lead" {
+		t.Fatalf("lock owner = %q, want lead", lock.Owner)
 	}
 	if len(manager.calls) != 1 || manager.calls[0].branch != "task-1" || manager.calls[0].path != wantPath || manager.calls[0].base != "main" {
 		t.Fatalf("worktree calls = %+v", manager.calls)
@@ -117,6 +130,7 @@ func TestEngineAllocateTaskWorktreeBlocksWhenCheckoutMutationLocked(t *testing.T
 		Repo:     "owner/repo",
 		TaskID:   "task-1",
 		Branch:   "task-1",
+		Owner:    "lead",
 		Checkout: checkout,
 	}, manager)
 
@@ -143,6 +157,7 @@ func TestEngineAllocateTaskWorktreeRejectsBranchAssignedToOtherTask(t *testing.T
 		Repo:     "owner/repo",
 		TaskID:   "task-2",
 		Branch:   "task-1",
+		Owner:    "lead",
 		Checkout: t.TempDir(),
 	}, manager)
 
@@ -168,6 +183,7 @@ func TestEngineAllocateTaskWorktreeRejectsTaskInAnotherRepo(t *testing.T) {
 		Repo:     "owner/repo",
 		TaskID:   "task-1",
 		Branch:   "task-1",
+		Owner:    "lead",
 		Checkout: t.TempDir(),
 	}, manager)
 
@@ -176,6 +192,101 @@ func TestEngineAllocateTaskWorktreeRejectsTaskInAnotherRepo(t *testing.T) {
 	}
 	if len(manager.calls) != 0 {
 		t.Fatalf("AddWorktree ran despite repo mismatch: %+v", manager.calls)
+	}
+}
+
+func TestEngineAllocateTaskWorktreeBlocksWhenBranchLocked(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "other"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	manager := &fakeWorktreeManager{}
+
+	_, err := engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
+		Home:     t.TempDir(),
+		Repo:     "owner/repo",
+		TaskID:   "task-1",
+		Branch:   "task-1",
+		Owner:    "lead",
+		Checkout: t.TempDir(),
+	}, manager)
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("error = %v, want BlockedError", err)
+	}
+	if len(manager.calls) != 0 {
+		t.Fatalf("AddWorktree ran despite branch lock: %+v", manager.calls)
+	}
+}
+
+func TestEngineAllocateTaskWorktreeReleasesCreatedBranchLockOnFailure(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	manager := &fakeWorktreeManager{err: errors.New("git failed")}
+
+	_, err := engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
+		Home:     t.TempDir(),
+		Repo:     "owner/repo",
+		TaskID:   "task-1",
+		Branch:   "task-1",
+		Owner:    "lead",
+		Checkout: t.TempDir(),
+	}, manager)
+
+	if err == nil {
+		t.Fatal("AllocateTaskWorktree succeeded despite worktree failure")
+	}
+	if _, lockErr := store.GetBranchLock(ctx, "owner/repo", "task-1"); !errors.Is(lockErr, sql.ErrNoRows) {
+		t.Fatalf("branch lock after failure error = %v, want sql.ErrNoRows", lockErr)
+	}
+}
+
+func TestEngineAllocateTaskWorktreeReusesExistingTaskWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	home := t.TempDir()
+	path, err := TaskWorktreePath(home, "owner/repo", "task-1")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-1",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-1",
+		Title:        "First",
+		State:        string(TaskPlanned),
+		Branch:       "task-1",
+		WorktreePath: path,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	manager := &fakeWorktreeManager{}
+
+	task, err := engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
+		Home:     home,
+		Repo:     "owner/repo",
+		TaskID:   "task-1",
+		Branch:   "task-1",
+		Owner:    "lead",
+		Checkout: t.TempDir(),
+	}, manager)
+
+	if err != nil {
+		t.Fatalf("AllocateTaskWorktree returned error: %v", err)
+	}
+	if task.State != string(TaskImplementing) || task.WorktreePath != path {
+		t.Fatalf("task = %+v, want implementing with existing path %q", task, path)
+	}
+	if len(manager.calls) != 0 {
+		t.Fatalf("AddWorktree ran despite existing task worktree: %+v", manager.calls)
 	}
 }
 

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -57,11 +57,12 @@ sessions or managed agent types with `max_background` greater than one.
 ## Common Commands
 
 Use `gitmoot status --repo owner/repo` for repo status, `gitmoot daemon status`
-for daemon state, `gitmoot agent list` for registered agents, and
-`gitmoot agent prompt <agent-or-template>` to import an agent prompt into the
-current chat. Use `gitmoot agent ask <agent> --repo owner/repo "..."` to invoke
-a registered Gitmoot agent through the runtime adapter path. Add `--background`
-only when the user wants a queued background job. Use
+for daemon state, `gitmoot agent list` and `gitmoot agent show <agent>` for
+registered agents, `gitmoot task list --repo owner/repo` for imported task
+state, and `gitmoot agent prompt <agent-or-template>` to import an agent prompt
+into the current chat. Use `gitmoot agent ask <agent> --repo owner/repo "..."`
+to invoke a registered Gitmoot agent through the runtime adapter path. Add
+`--background` only when the user wants a queued background job. Use
 `gitmoot job list --repo owner/repo` for queued or recent jobs. Use
 `gitmoot plugin doctor` when checking whether Codex or Claude Code can discover
 Gitmoot through an installed runtime plugin. Use `gitmoot goal template` when

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -90,6 +90,8 @@ Inspect agents:
 
 ```sh
 gitmoot agent list
+gitmoot agent show reviewer
+gitmoot agent show reviewer --json
 gitmoot agent repos reviewer
 gitmoot agent doctor reviewer
 ```
@@ -224,6 +226,18 @@ Import a goal file into local Gitmoot state:
 ```sh
 gitmoot goal import --file GOAL-feature.md --repo owner/repo
 ```
+
+Start a task in its dedicated branch worktree and inspect task state:
+
+```sh
+gitmoot task run task-001 --repo owner/repo --owner lead --base main
+gitmoot task list --repo owner/repo
+gitmoot task list --repo owner/repo --state implementing --json
+```
+
+`task run` stores the deterministic task worktree path under
+`$GITMOOT_HOME/worktrees/<owner>--<repo>/<task-id>/` and leaves the registered
+checkout on its current branch.
 
 ## PR Comments
 


### PR DESCRIPTION
## Summary

- Add `gitmoot agent show <agent> [--json]` for inspecting one registered agent, including runtime, policy, health, repo scope, and allowed repos.
- Add `gitmoot task list [--repo owner/repo] [--state state] [--json]` for inspecting imported task state, branches, and worktree paths.
- Change `gitmoot task run` to allocate a deterministic dedicated task worktree under the Gitmoot home, store the path on the task, and keep the registered checkout from being moved.
- Preserve branch-lock semantics for task worktrees and route queued task jobs through the task worktree when one is recorded.
- Handle existing task branches safely without force-checking the same branch into multiple worktrees.
- Update local workflow docs and the bundled Gitmoot skill CLI references.

## Verification

- `GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/git ./internal/workflow -v -timeout 180s`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestRunQueuedJobs|TestSelectRunnableQueuedJobs|TestRunDaemon|TestRunTaskRun|TestRunTaskList|TestRunAgentShow|TestMergeGateCheckout|TestNewDaemonPolicyMergeGate|TestDaemonMergeGate|TestAgent|TestTask' -v -timeout 180s`
- `git diff --check`
- Local smoke: built `gitmoot`, created a temporary repo, imported a 2-task goal, subscribed a shell agent, ran `agent show`, `task run`, and `task list --json`; verified the registered checkout stayed on `main` and the task worktree was on the task branch.
- Migration smoke: verified existing branch refs can be attached as worktrees when not already checked out.
- Safety smoke: verified existing branches already checked out in the registered checkout are rejected instead of force-added into a second worktree.
- `codex-face exec review --uncommitted` on the full PR diff: no discrete correctness issues found. The review sandbox could not download Go 1.26, so Go tests were run locally with `GOTOOLCHAIN=go1.26.0`.


## Related

- Related: #175
- Related: #176