### PR TITLE
Enqueue task implementation jobs from task run

### DIFF
--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/jerryfane/gitmoot/internal/config"
@@ -369,6 +370,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 	}
 
 	var started db.Task
+	var startedJob db.Job
 	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
 		task, err := store.GetTask(context.Background(), taskID)
 		if err != nil {
@@ -395,6 +397,13 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err := store.UpsertRepo(context.Background(), repoRecord); err != nil {
 			return err
 		}
+		agent, err := store.GetAgent(context.Background(), strings.TrimSpace(*owner))
+		if err != nil {
+			return fmt.Errorf("load task owner agent %q: %w", strings.TrimSpace(*owner), err)
+		}
+		if err := ensureLocalAgentAccess(context.Background(), store, agent, requestRepo, "implement"); err != nil {
+			return err
+		}
 		checkout := repoRecord.CheckoutPath
 		requestBranch := firstNonEmpty(*branch, task.Branch, task.ID)
 		engine := workflow.Engine{Store: store}
@@ -409,6 +418,14 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 			Owner:      *owner,
 			Checkout:   checkout,
 		}, gitutil.Client{Dir: checkout})
+		if err != nil {
+			return err
+		}
+		headSHA, err := (gitutil.Client{Dir: started.WorktreePath}).HeadSHA(context.Background())
+		if err != nil {
+			return fmt.Errorf("resolve task worktree head: %w", err)
+		}
+		startedJob, err = enqueueTaskRunImplementJob(context.Background(), store, started, strings.TrimSpace(*owner), headSHA)
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "run task: %v\n", err)
@@ -418,7 +435,102 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 	if strings.TrimSpace(started.WorktreePath) != "" {
 		fmt.Fprintf(stdout, "worktree: %s\n", started.WorktreePath)
 	}
+	if strings.TrimSpace(startedJob.ID) != "" {
+		fmt.Fprintf(stdout, "job: %s\n", startedJob.ID)
+		if startedJob.State == string(workflow.JobQueued) {
+			fmt.Fprintf(stdout, "next: %s\n", jobRunCommand(startedJob.ID, *home))
+		} else {
+			fmt.Fprintf(stdout, "next: %s\n", jobWatchCommand(startedJob.ID, *home))
+		}
+	}
 	return 0
+}
+
+func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Task, owner string, headSHA string) (db.Job, error) {
+	baseJobID := taskRunImplementJobID(task.ID, owner)
+	jobID := baseJobID
+	request := taskRunImplementJobRequest(jobID, task, owner, headSHA)
+	if existing, err := store.GetJob(ctx, jobID); err == nil {
+		if (existing.State == string(workflow.JobQueued) || existing.State == string(workflow.JobRunning)) && taskRunJobMatchesRequest(existing, request) {
+			return existing, nil
+		}
+		if active, ok, err := findActiveTaskRunJob(ctx, store, request); err != nil {
+			return db.Job{}, err
+		} else if ok {
+			return active, nil
+		}
+		jobID = baseJobID + "-" + shortHash(existing.State+"\x00"+headSHA+"\x00"+time.Now().UTC().Format(time.RFC3339Nano))
+		request = taskRunImplementJobRequest(jobID, task, owner, headSHA)
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return db.Job{}, err
+	}
+	return (workflow.Mailbox{Store: store}).Enqueue(ctx, request)
+}
+
+func findActiveTaskRunJob(ctx context.Context, store *db.Store, request workflow.JobRequest) (db.Job, bool, error) {
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return db.Job{}, false, err
+	}
+	for _, job := range jobs {
+		if job.State != string(workflow.JobQueued) && job.State != string(workflow.JobRunning) {
+			continue
+		}
+		if taskRunJobMatchesRequest(job, request) {
+			return job, true, nil
+		}
+	}
+	return db.Job{}, false, nil
+}
+
+func taskRunImplementJobRequest(jobID string, task db.Task, owner string, headSHA string) workflow.JobRequest {
+	title := strings.TrimSpace(task.Title)
+	label := task.ID
+	if title != "" {
+		label += ": " + title
+	}
+	return workflow.JobRequest{
+		ID:           jobID,
+		Agent:        owner,
+		Action:       "implement",
+		Repo:         task.RepoFullName,
+		Branch:       task.Branch,
+		HeadSHA:      headSHA,
+		GoalID:       task.GoalID,
+		TaskID:       task.ID,
+		TaskTitle:    task.Title,
+		LeadAgent:    owner,
+		Sender:       "task run",
+		Instructions: "Implement task " + label + ".",
+	}
+}
+
+func taskRunJobMatchesRequest(job db.Job, request workflow.JobRequest) bool {
+	if job.Agent != request.Agent || job.Type != request.Action {
+		return false
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return false
+	}
+	return payload.Repo == request.Repo &&
+		payload.Branch == request.Branch &&
+		payload.PullRequest == request.PullRequest &&
+		payload.HeadSHA == request.HeadSHA &&
+		payload.GoalID == request.GoalID &&
+		payload.TaskID == request.TaskID &&
+		payload.TaskTitle == request.TaskTitle &&
+		payload.LeadAgent == request.LeadAgent &&
+		payload.Sender == request.Sender &&
+		payload.Instructions == request.Instructions
+}
+
+func taskRunImplementJobID(taskID string, owner string) string {
+	value := slug("task-" + taskID + "-implement-" + owner)
+	if value == "" {
+		return "task-implement-" + shortHash(taskID+"\x00"+owner)
+	}
+	return value
 }
 
 func parseGoalFile(path string, repo string) (importedGoal, error) {

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -382,6 +382,7 @@ func TestRunTaskRunRejectsRepoMismatch(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
 	}
+	subscribeShellImplementAgent(t, home, "lead", "jerryfane/gitmoot")
 
 	repoDir := t.TempDir()
 	runGit(t, repoDir, "init")
@@ -409,6 +410,7 @@ func TestRunTaskRunRejectsWrongCheckout(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
 	}
+	subscribeShellImplementAgent(t, home, "lead", "jerryfane/gitmoot")
 
 	repoDir := t.TempDir()
 	runGit(t, repoDir, "init")
@@ -436,6 +438,7 @@ func TestRunTaskRunRegistersCurrentRepo(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
 	}
+	subscribeShellImplementAgent(t, home, "lead", "jerryfane/gitmoot")
 
 	repoDir := t.TempDir()
 	runGit(t, repoDir, "init")
@@ -455,12 +458,14 @@ func TestRunTaskRunRegistersCurrentRepo(t *testing.T) {
 	if !strings.Contains(stdout.String(), "worktree: ") {
 		t.Fatalf("stdout missing worktree path: %q", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "job: task-task-001-implement-lead") {
+		t.Fatalf("stdout missing task job id: %q", stdout.String())
+	}
 
 	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
-	defer store.Close()
 	repo, err := store.GetRepo(context.Background(), "jerryfane/gitmoot")
 	if err != nil {
 		t.Fatalf("GetRepo returned error: %v", err)
@@ -492,6 +497,116 @@ func TestRunTaskRunRegistersCurrentRepo(t *testing.T) {
 	if worktreeBranch := strings.TrimSpace(runGitOutput(t, wantWorktree, "branch", "--show-current")); worktreeBranch != "task-001-bootstrap" {
 		t.Fatalf("task worktree branch = %q, want task-001-bootstrap", worktreeBranch)
 	}
+	job, err := store.GetJob(context.Background(), "task-task-001-implement-lead")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.Agent != "lead" || job.Type != "implement" || job.State != "queued" {
+		t.Fatalf("job = %+v", job)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if payload.TaskID != "task-001" || payload.Branch != "task-001-bootstrap" || payload.PullRequest != 0 || payload.LeadAgent != "lead" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.HeadSHA == "" {
+		t.Fatalf("payload missing head SHA: %+v", payload)
+	}
+	task.Title = "Bootstrap Updated"
+	if err := store.UpsertTask(context.Background(), task); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store before stale rerun: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"task", "run", "task-001", "--home", home, "--repo", "jerryfane/gitmoot", "--owner", "lead"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("stale rerun task run exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "job: task-task-001-implement-lead-") {
+		t.Fatalf("stale rerun stdout missing fresh task job id: %q", stdout.String())
+	}
+	store, err = db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("reopen store after stale rerun: %v", err)
+	}
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs after stale rerun returned error: %v", err)
+	}
+	updatedQueuedJobID := ""
+	for _, job := range jobs {
+		if !strings.HasPrefix(job.ID, "task-task-001-implement-lead-") || job.State != "queued" {
+			continue
+		}
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			t.Fatalf("daemonJobPayload(%s) returned error: %v", job.ID, err)
+		}
+		if payload.TaskTitle == "Bootstrap Updated" && strings.Contains(payload.Instructions, "Bootstrap Updated") {
+			updatedQueuedJobID = job.ID
+		}
+	}
+	if updatedQueuedJobID == "" {
+		t.Fatalf("jobs = %+v, want fresh queued rerun job with updated task metadata", jobs)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store before duplicate rerun: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"task", "run", "task-001", "--home", home, "--repo", "jerryfane/gitmoot", "--owner", "lead"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("duplicate rerun task run exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "job: "+updatedQueuedJobID) {
+		t.Fatalf("duplicate rerun stdout = %q, want existing job %s", stdout.String(), updatedQueuedJobID)
+	}
+	store, err = db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("reopen store after duplicate rerun: %v", err)
+	}
+	if err := store.UpdateJobState(context.Background(), "task-task-001-implement-lead", "succeeded"); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	store = nil
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"task", "run", "task-001", "--home", home, "--repo", "jerryfane/gitmoot", "--owner", "lead"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("rerun task run exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "job: task-task-001-implement-lead-") {
+		t.Fatalf("rerun stdout missing fresh task job id: %q", stdout.String())
+	}
+	store, err = db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer store.Close()
+	jobs, err = store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	foundFreshQueued := false
+	for _, job := range jobs {
+		if strings.HasPrefix(job.ID, "task-task-001-implement-lead-") && job.State == "queued" {
+			foundFreshQueued = true
+		}
+	}
+	if !foundFreshQueued {
+		t.Fatalf("jobs = %+v, want fresh queued rerun job", jobs)
+	}
 }
 
 func TestRunTaskRunBlocksWhenCheckoutMutationLocked(t *testing.T) {
@@ -504,6 +619,7 @@ func TestRunTaskRunBlocksWhenCheckoutMutationLocked(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("goal import exit code = %d, stderr=%s", code, stderr.String())
 	}
+	subscribeShellImplementAgent(t, home, "lead", "jerryfane/gitmoot")
 
 	repoDir := t.TempDir()
 	runGit(t, repoDir, "init")
@@ -557,6 +673,24 @@ func TestRunTaskRunBlocksWhenCheckoutMutationLocked(t *testing.T) {
 func TestTaskBranchNameFallsBackToTaskID(t *testing.T) {
 	if got := taskBranchName("task-001", "!!!"); got != "task-001" {
 		t.Fatalf("taskBranchName returned %q, want task-001", got)
+	}
+}
+
+func subscribeShellImplementAgent(t *testing.T, home string, name string, repo string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "subscribe", name,
+		"--home", home,
+		"--runtime", "shell",
+		"--session", `printf '%s\n' '{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}'`,
+		"--role", "lead",
+		"--repo", repo,
+		"--capability", "implement",
+		"--policy", "workspace-write",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent subscribe exit code = %d, stderr=%s", code, stderr.String())
 	}
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -264,6 +264,9 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 		if payload.Result.Decision != "implemented" {
 			return nil
 		}
+		if payload.PullRequest <= 0 {
+			return e.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_skipped_no_pr", Message: "no pull request is attached; skipping PR advancement"})
+		}
 		leadAgent := strings.TrimSpace(payload.LeadAgent)
 		if leadAgent == "" {
 			leadAgent = job.Agent

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -231,6 +231,42 @@ func TestEngineAdvanceImplementDefaultsLeadAgent(t *testing.T) {
 	mustJob(t, store, "review-audit-task-7-review-1")
 }
 
+func TestEngineAdvanceImplementSkipsPullRequestFlowWhenNoPullRequest(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-job",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-7",
+		GoalID:    "goal-1",
+		TaskID:    "task-7",
+		TaskTitle: "Workflow Engine",
+		LeadAgent: "lead",
+		Result:    &AgentResult{Decision: "implemented", Summary: "done locally"},
+	})
+
+	err := engine.AdvanceJob(ctx, "implement-job")
+
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	events, err := store.ListJobEvents(ctx, "implement-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == "advance_skipped_no_pr" {
+			return
+		}
+	}
+	t.Fatalf("events = %+v, want advance_skipped_no_pr", events)
+}
+
 func TestEngineRunJobAdvancesCompletedResult(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)


### PR DESCRIPTION
## What
- Make `gitmoot task run` enqueue the implementation job after allocating the task worktree.
- Validate the owner agent has implement access before mutating checkout state.
- Reuse only active task-run jobs that match the current task/worktree/head payload; create fresh suffixed jobs for stale or terminal reruns.
- Skip PR advancement cleanly for local/no-PR implementation jobs.

## Why
Issue #176 validation found that `task run` created branches/worktrees but did not start the normal implementation job path. Local smoke jobs also succeeded and then produced noisy advancement retries because they had no PR number.

## Checks
- `git diff --check`
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestRunTaskRun|TestRunTaskList' -v -timeout 120s`\n- `GOTOOLCHAIN=go1.26.0 go test ./internal/workflow -run 'TestEngineAdvanceImplement|TestEngineRunJobAdvancesCompletedResult' -v -timeout 120s`\n- `codex-face exec review --uncommitted`: no discrete correctness issues found in changed Go workflow/CLI logic or tests.\n\n## Note\nA broader `go test ./internal/cli ./internal/workflow` run still hit unrelated SkillOpt tests that require Codex runtime startup and failed with `codex start did not emit thread.started thread_id`; the focused task/workflow tests passed.\n\nFixes part of #176.