### PR TITLE
Report Claude auth readiness

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -1244,6 +1245,31 @@ func runAgentDoctor(args []string, stdout, stderr io.Writer) int {
 		_ = persistAgentHealth(*home, name, "failed")
 		fmt.Fprintf(stderr, "invalid agent: %v\n", err)
 		return 1
+	}
+	if rtAgent.Runtime == runtime.ClaudeRuntime {
+		auth := runtime.InspectClaudeAuthEnv(os.LookupEnv)
+		status := "ok"
+		if !auth.Ready() {
+			status = "warn"
+		} else if auth.Warning() != "" {
+			status = "warn"
+		}
+		detail := auth.MaskedDetail()
+		if warning := auth.Warning(); warning != "" {
+			detail += "; " + warning
+		}
+		fmt.Fprintf(stdout, "claude-auth-env %s %s\n", status, detail)
+		if !auth.Ready() {
+			_ = persistAgentHealth(*home, name, "failed")
+			fmt.Fprintf(stderr, "agent %s health failed: %s\n", rtAgent.Name, runtime.ClaudeAuthSetupMessage)
+			return 1
+		}
+		if err := persistAgentHealth(*home, name, "ok"); err != nil {
+			fmt.Fprintf(stderr, "update agent health: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "agent %s ok\n", rtAgent.Name)
+		return 0
 	}
 	if err := adapter.Health(context.Background(), rtAgent); err != nil {
 		_ = persistAgentHealth(*home, name, "failed")

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -2102,6 +2102,75 @@ func TestRunAgentDoctorPersistsHealth(t *testing.T) {
 	}
 }
 
+func TestRunAgentDoctorClaudeReportsMaskedAuthEnv(t *testing.T) {
+	withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
+	home := t.TempDir()
+	subscribeClaudeAgent(t, home, "claude-ok")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "doctor", "claude-ok", "--home", home}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("doctor exit code = %d, stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "claude-auth-env ok") {
+		t.Fatalf("stdout missing claude auth status:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), runtime.ClaudeOAuthTokenEnv+"=set") || strings.Contains(stdout.String(), "secret-token") {
+		t.Fatalf("stdout leaked or missed masked auth detail:\n%s", stdout.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "claude-ok")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.HealthStatus != "ok" {
+		t.Fatalf("health status = %q, want ok", agent.HealthStatus)
+	}
+}
+
+func TestRunAgentDoctorClaudeFailsWhenAuthEnvMissing(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	home := t.TempDir()
+	subscribeClaudeAgent(t, home, "claude-missing")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "doctor", "claude-missing", "--home", home}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("doctor exit code = %d, want 1; stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "claude-auth-env warn") || !strings.Contains(stderr.String(), "claude setup-token") {
+		t.Fatalf("doctor output missing setup guidance:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "claude-missing")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.HealthStatus != "failed" {
+		t.Fatalf("health status = %q, want failed", agent.HealthStatus)
+	}
+}
+
+func subscribeClaudeAgent(t *testing.T, home string, name string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "subscribe", name,
+		"--home", home,
+		"--runtime", "claude",
+		"--session", "550e8400-e29b-41d4-a716-446655440099",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+}
+
 func seedThermoTemplate(t *testing.T, home string) {
 	t.Helper()
 	var stdout, stderr bytes.Buffer
@@ -2258,4 +2327,38 @@ func (r *agentStartRunner) want(t *testing.T, index int, dir string, command str
 	if len(call.args) < len(wantPrefix) || !reflect.DeepEqual(call.args[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("call %d args = %s\nwant prefix %s", index, strings.Join(call.args, " "), strings.Join(wantPrefix, " "))
 	}
+}
+
+func withClaudeAuthEnv(t *testing.T, values map[string]string) {
+	t.Helper()
+	names := []string{
+		runtime.ClaudeOAuthTokenEnv,
+		runtime.AnthropicAPIKeyEnv,
+		runtime.AnthropicAuthTokenEnv,
+	}
+	previous := make(map[string]string, len(names))
+	present := make(map[string]bool, len(names))
+	for _, name := range names {
+		if value, ok := os.LookupEnv(name); ok {
+			previous[name] = value
+			present[name] = true
+		}
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatalf("unset %s: %v", name, err)
+		}
+	}
+	for name, value := range values {
+		if err := os.Setenv(name, value); err != nil {
+			t.Fatalf("set %s: %v", name, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, name := range names {
+			if present[name] {
+				_ = os.Setenv(name, previous[name])
+			} else {
+				_ = os.Unsetenv(name)
+			}
+		}
+	})
 }

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/buildinfo"
 	"github.com/jerryfane/gitmoot/internal/plugininstall"
 	"github.com/jerryfane/gitmoot/internal/pluginpack"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 	"github.com/jerryfane/gitmoot/skills"
 )
@@ -331,6 +332,9 @@ func doctorRuntime(home string, provider pluginpack.Provider, explicitRuntime bo
 	runtime.Checks = append(runtime.Checks, checkCopiedSkill(packagePath))
 	runtime.Checks = append(runtime.Checks, checkMarketplacePath(home, provider))
 	runtime.Checks = append(runtime.Checks, checkRuntimeCLI(provider, explicitRuntime))
+	if provider == pluginpack.ProviderClaude {
+		runtime.Checks = append(runtime.Checks, checkClaudeAuthEnv())
+	}
 	runtime.Checks = append(runtime.Checks, checkValidationCommand(provider, explicitRuntime))
 	runtime.Healthy = runtimeChecksHealthy(runtime.Checks)
 	return runtime
@@ -405,6 +409,18 @@ func checkRuntimeCLI(provider pluginpack.Provider, explicitRuntime bool) pluginC
 		return warnCheck("runtime-cli", binary+" was not found on PATH", false)
 	}
 	return okCheck("runtime-cli", path, true)
+}
+
+func checkClaudeAuthEnv() pluginCheck {
+	auth := runtime.InspectClaudeAuthEnv(os.LookupEnv)
+	detail := auth.MaskedDetail()
+	if warning := auth.Warning(); warning != "" {
+		detail += "; " + warning
+	}
+	if auth.Ready() && auth.Warning() == "" {
+		return okCheck("runtime-auth-env", detail, false)
+	}
+	return warnCheck("runtime-auth-env", detail, false)
 }
 
 func checkValidationCommand(provider pluginpack.Provider, explicitRuntime bool) pluginCheck {

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/pluginpack"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
 func TestRunPluginPathPrintsPackagePath(t *testing.T) {
@@ -144,6 +145,71 @@ func TestRunPluginDoctorJSON(t *testing.T) {
 	assertDoctorCheck(t, output.Runtimes[0].Checks, "validation-command", "warn")
 }
 
+func TestRunPluginDoctorClaudeReportsMaskedAuthEnv(t *testing.T) {
+	withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
+	home := t.TempDir()
+	if _, err := pluginpack.Build(pluginpack.BuildOptions{
+		Provider: pluginpack.ProviderClaude,
+		Home:     filepath.Join(home, ".gitmoot"),
+	}); err != nil {
+		t.Fatalf("build claude package: %v", err)
+	}
+	restore := stubPluginLookPath(map[string]string{"claude": "/tmp/bin/claude"})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "doctor", "claude", "--home", home, "--json"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin doctor exit code = %d, stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	var output pluginDoctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("doctor JSON did not parse: %v\n%s", err, stdout.String())
+	}
+	if len(output.Runtimes) != 1 || output.Runtimes[0].Runtime != "claude" {
+		t.Fatalf("unexpected runtimes: %+v", output.Runtimes)
+	}
+	check := findDoctorCheck(t, output.Runtimes[0].Checks, "runtime-auth-env")
+	if check.Status != "ok" {
+		t.Fatalf("runtime-auth-env status = %q, want ok; checks=%+v", check.Status, output.Runtimes[0].Checks)
+	}
+	if !strings.Contains(check.Detail, runtime.ClaudeOAuthTokenEnv+"=set") || strings.Contains(check.Detail, "secret-token") {
+		t.Fatalf("runtime-auth-env detail = %q", check.Detail)
+	}
+}
+
+func TestRunPluginDoctorClaudeWarnsWhenAuthEnvMissing(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	home := t.TempDir()
+	if _, err := pluginpack.Build(pluginpack.BuildOptions{
+		Provider: pluginpack.ProviderClaude,
+		Home:     filepath.Join(home, ".gitmoot"),
+	}); err != nil {
+		t.Fatalf("build claude package: %v", err)
+	}
+	restore := stubPluginLookPath(map[string]string{"claude": "/tmp/bin/claude"})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "doctor", "claude", "--home", home, "--json"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin doctor exit code = %d, stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	var output pluginDoctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("doctor JSON did not parse: %v\n%s", err, stdout.String())
+	}
+	check := findDoctorCheck(t, output.Runtimes[0].Checks, "runtime-auth-env")
+	if check.Status != "warn" {
+		t.Fatalf("runtime-auth-env status = %q, want warn; checks=%+v", check.Status, output.Runtimes[0].Checks)
+	}
+	if !strings.Contains(check.Detail, "claude setup-token") {
+		t.Fatalf("runtime-auth-env detail = %q, want setup-token guidance", check.Detail)
+	}
+}
+
 func TestRunPluginDoctorFailsExplicitUnhealthyRuntime(t *testing.T) {
 	restore := stubPluginLookPath(map[string]string{})
 	defer restore()
@@ -203,13 +269,19 @@ func stubPluginLookPath(paths map[string]string) func() {
 
 func assertDoctorCheck(t *testing.T, checks []pluginCheck, name string, status string) {
 	t.Helper()
+	check := findDoctorCheck(t, checks, name)
+	if check.Status != status {
+		t.Fatalf("%s status = %q, want %q; checks=%+v", name, check.Status, status, checks)
+	}
+}
+
+func findDoctorCheck(t *testing.T, checks []pluginCheck, name string) pluginCheck {
+	t.Helper()
 	for _, check := range checks {
 		if check.Name == name {
-			if check.Status != status {
-				t.Fatalf("%s status = %q, want %q; checks=%+v", name, check.Status, status, checks)
-			}
-			return
+			return check
 		}
 	}
 	t.Fatalf("missing check %q in %+v", name, checks)
+	return pluginCheck{}
 }

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -3,9 +3,11 @@ package doctor
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
@@ -32,6 +34,7 @@ func (c Checker) Run(ctx context.Context) []Check {
 		c.command(ctx, runner, "gh", true, "--version"),
 		c.command(ctx, runner, "codex", true, "--version"),
 		c.command(ctx, runner, "claude", false, "--help"),
+		c.claudeAuthEnv(),
 		c.ghAuth(ctx, runner),
 		c.repoRemote(ctx, runner),
 		c.baseBranch(ctx, runner),
@@ -86,6 +89,15 @@ func (c Checker) baseBranch(ctx context.Context, runner subprocess.Runner) Check
 		return Check{Name: "base branch", Required: true, Detail: "detached HEAD"}
 	}
 	return Check{Name: "base branch", OK: true, Required: true, Detail: branch}
+}
+
+func (c Checker) claudeAuthEnv() Check {
+	auth := runtime.InspectClaudeAuthEnv(os.LookupEnv)
+	detail := auth.MaskedDetail()
+	if warning := auth.Warning(); warning != "" {
+		detail += "; " + warning
+	}
+	return Check{Name: "claude auth", OK: auth.Ready(), Required: false, Detail: detail}
 }
 
 func FailedRequired(checks []Check) error {

--- a/internal/doctor/checker_test.go
+++ b/internal/doctor/checker_test.go
@@ -3,9 +3,11 @@ package doctor
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
@@ -29,6 +31,7 @@ func (f fakeRunner) Run(ctx context.Context, dir string, command string, args ..
 }
 
 func TestCheckerRun(t *testing.T) {
+	withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
 	runner := fakeRunner{
 		paths: map[string]bool{"git": true, "gh": true, "codex": true},
 		runs: map[string]subprocess.Result{
@@ -46,6 +49,22 @@ func TestCheckerRun(t *testing.T) {
 	if err := FailedRequired(checks); err != nil {
 		t.Fatalf("FailedRequired returned error: %v\nchecks=%+v", err, checks)
 	}
+	foundClaudeAuth := false
+	for _, check := range checks {
+		if check.Name != "claude auth" {
+			continue
+		}
+		foundClaudeAuth = true
+		if !check.OK || check.Required {
+			t.Fatalf("claude auth check = %+v, want optional ok check", check)
+		}
+		if !strings.Contains(check.Detail, "CLAUDE_CODE_OAUTH_TOKEN=set") || strings.Contains(check.Detail, "secret-token") {
+			t.Fatalf("claude auth detail = %q", check.Detail)
+		}
+	}
+	if !foundClaudeAuth {
+		t.Fatalf("checks missing claude auth: %+v", checks)
+	}
 }
 
 func TestCheckerFailsOnMissingRequiredCommand(t *testing.T) {
@@ -53,6 +72,23 @@ func TestCheckerFailsOnMissingRequiredCommand(t *testing.T) {
 	if err := FailedRequired(checks); err == nil {
 		t.Fatal("FailedRequired returned nil, want error")
 	}
+}
+
+func TestCheckerWarnsWhenClaudeAuthEnvMissing(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	checks := Checker{Runner: fakeRunner{paths: map[string]bool{}}}.Run(context.Background())
+	for _, check := range checks {
+		if check.Name == "claude auth" {
+			if check.OK || check.Required {
+				t.Fatalf("claude auth check = %+v, want optional warning", check)
+			}
+			if !strings.Contains(check.Detail, "claude setup-token") {
+				t.Fatalf("claude auth detail = %q, want setup-token guidance", check.Detail)
+			}
+			return
+		}
+	}
+	t.Fatalf("checks missing claude auth: %+v", checks)
 }
 
 func TestCheckerRunsGlobalChecksOutsideRepoDir(t *testing.T) {
@@ -102,4 +138,38 @@ func (r dirSensitiveRunner) Run(ctx context.Context, dir string, command string,
 		return subprocess.Result{}, fmt.Errorf("bad dir was used for %s", key)
 	}
 	return r.fakeRunner.Run(ctx, dir, command, args...)
+}
+
+func withClaudeAuthEnv(t *testing.T, values map[string]string) {
+	t.Helper()
+	names := []string{
+		runtime.ClaudeOAuthTokenEnv,
+		runtime.AnthropicAPIKeyEnv,
+		runtime.AnthropicAuthTokenEnv,
+	}
+	previous := make(map[string]string, len(names))
+	present := make(map[string]bool, len(names))
+	for _, name := range names {
+		if value, ok := os.LookupEnv(name); ok {
+			previous[name] = value
+			present[name] = true
+		}
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatalf("unset %s: %v", name, err)
+		}
+	}
+	for name, value := range values {
+		if err := os.Setenv(name, value); err != nil {
+			t.Fatalf("set %s: %v", name, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, name := range names {
+			if present[name] {
+				_ = os.Setenv(name, previous[name])
+			} else {
+				_ = os.Unsetenv(name)
+			}
+		}
+	})
 }

--- a/internal/runtime/claude_auth.go
+++ b/internal/runtime/claude_auth.go
@@ -1,0 +1,67 @@
+package runtime
+
+import "strings"
+
+const (
+	ClaudeOAuthTokenEnv    = "CLAUDE_CODE_OAUTH_TOKEN"
+	AnthropicAPIKeyEnv     = "ANTHROPIC_API_KEY"
+	AnthropicAuthTokenEnv  = "ANTHROPIC_AUTH_TOKEN"
+	ClaudeAuthSetupMessage = "Claude Code background jobs need non-interactive credentials. Run: claude setup-token; export CLAUDE_CODE_OAUTH_TOKEN=<token>; then restart the Gitmoot daemon so it inherits the token."
+)
+
+type ClaudeAuthEnv struct {
+	ClaudeOAuthToken   bool
+	AnthropicAPIKey    bool
+	AnthropicAuthToken bool
+}
+
+func InspectClaudeAuthEnv(lookup func(string) (string, bool)) ClaudeAuthEnv {
+	if lookup == nil {
+		return ClaudeAuthEnv{}
+	}
+	oauth := hasEnvValue(lookup, ClaudeOAuthTokenEnv)
+	apiKey := hasEnvValue(lookup, AnthropicAPIKeyEnv)
+	authToken := hasEnvValue(lookup, AnthropicAuthTokenEnv)
+	return ClaudeAuthEnv{
+		ClaudeOAuthToken:   oauth,
+		AnthropicAPIKey:    apiKey,
+		AnthropicAuthToken: authToken,
+	}
+}
+
+func (e ClaudeAuthEnv) Ready() bool {
+	return e.ClaudeOAuthToken || e.AnthropicAPIKey || e.AnthropicAuthToken
+}
+
+func (e ClaudeAuthEnv) MaskedDetail() string {
+	return strings.Join([]string{
+		ClaudeOAuthTokenEnv + "=" + setUnset(e.ClaudeOAuthToken),
+		AnthropicAPIKeyEnv + "=" + setUnset(e.AnthropicAPIKey),
+		AnthropicAuthTokenEnv + "=" + setUnset(e.AnthropicAuthToken),
+	}, "; ")
+}
+
+func (e ClaudeAuthEnv) Warning() string {
+	switch {
+	case !e.Ready():
+		return ClaudeAuthSetupMessage
+	case e.AnthropicAPIKey:
+		return "ANTHROPIC_API_KEY is set; Claude Code may use API-key billing and this can override Claude OAuth behavior."
+	case e.AnthropicAuthToken:
+		return "ANTHROPIC_AUTH_TOKEN is set; it can affect Claude auth precedence."
+	default:
+		return ""
+	}
+}
+
+func setUnset(value bool) string {
+	if value {
+		return "set"
+	}
+	return "unset"
+}
+
+func hasEnvValue(lookup func(string) (string, bool), name string) bool {
+	value, ok := lookup(name)
+	return ok && strings.TrimSpace(value) != ""
+}

--- a/internal/runtime/claude_auth_test.go
+++ b/internal/runtime/claude_auth_test.go
@@ -1,0 +1,55 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInspectClaudeAuthEnvMasksReadiness(t *testing.T) {
+	auth := InspectClaudeAuthEnv(func(name string) (string, bool) {
+		switch name {
+		case ClaudeOAuthTokenEnv:
+			return "secret-token", true
+		default:
+			return "", false
+		}
+	})
+
+	if !auth.Ready() {
+		t.Fatal("auth env was not ready despite OAuth token")
+	}
+	detail := auth.MaskedDetail()
+	if !strings.Contains(detail, ClaudeOAuthTokenEnv+"=set") || strings.Contains(detail, "secret-token") {
+		t.Fatalf("masked detail = %q", detail)
+	}
+	if warning := auth.Warning(); warning != "" {
+		t.Fatalf("warning = %q, want none", warning)
+	}
+}
+
+func TestInspectClaudeAuthEnvWarnsForMissingCredentials(t *testing.T) {
+	auth := InspectClaudeAuthEnv(func(string) (string, bool) { return "", false })
+
+	if auth.Ready() {
+		t.Fatal("auth env is ready despite no credentials")
+	}
+	if !strings.Contains(auth.Warning(), "claude setup-token") {
+		t.Fatalf("warning = %q, want setup-token guidance", auth.Warning())
+	}
+}
+
+func TestInspectClaudeAuthEnvWarnsForAPIKeyPrecedence(t *testing.T) {
+	auth := InspectClaudeAuthEnv(func(name string) (string, bool) {
+		if name == AnthropicAPIKeyEnv {
+			return "secret-key", true
+		}
+		return "", false
+	})
+
+	if !auth.Ready() {
+		t.Fatal("auth env was not ready despite API key")
+	}
+	if !strings.Contains(auth.Warning(), "API-key billing") {
+		t.Fatalf("warning = %q, want API key warning", auth.Warning())
+	}
+}


### PR DESCRIPTION
## Summary
- Add a cheap Claude auth environment helper that reports masked readiness for CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, and ANTHROPIC_AUTH_TOKEN.
- Surface the check in gitmoot doctor, plugin doctor claude, and agent doctor for Claude agents without invoking claude -p.
- Add deterministic tests for masked ready/missing-auth behavior across runtime, doctor, plugin, and agent doctor paths.

## Checks
- GOTOOLCHAIN=go1.26.0 go test ./internal/runtime ./internal/doctor ./internal/cli -run 'Claude|Doctor' -v -timeout 180s\n- git diff --check\n- codex exec review --uncommitted\n\n## Codex Review\n```text\nI did not identify any discrete correctness, security, performance, or maintainability issues in the current staged, unstaged, and untracked changes.\n```\n\nRefs #187