### PR TITLE
Classify Claude auth failures

### DIFF
--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -302,7 +302,7 @@ func (a ClaudeAdapter) Start(ctx context.Context, request StartRequest) (StartRe
 	args := append(claudePermissionArgs(request.Agent), "--session-id", runtimeRef, "-p", "--output-format", "json", "--", request.Prompt)
 	result, err := a.runner().Run(ctx, a.Dir, "claude", args...)
 	if err != nil {
-		return StartResult{Raw: result.Stdout + result.Stderr}, commandError(result, err)
+		return StartResult{Raw: result.Stdout + result.Stderr}, claudeCommandError(result, err)
 	}
 	return StartResult{RuntimeRef: runtimeRef, Raw: result.Stdout}, nil
 }
@@ -321,7 +321,7 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 		result, err = a.runner().Run(ctx, a.Dir, "claude", claudeArgs(agent, job.Prompt, false)...)
 	}
 	if err != nil {
-		return Result{Raw: result.Stdout + result.Stderr}, commandError(result, err)
+		return Result{Raw: result.Stdout + result.Stderr}, claudeCommandError(result, err)
 	}
 	parsed := Result{Raw: result.Stdout}
 	var payload struct {
@@ -421,6 +421,31 @@ func commandError(result subprocess.Result, err error) error {
 		return err
 	}
 	return fmt.Errorf("%s: %w", detail, err)
+}
+
+func claudeCommandError(result subprocess.Result, err error) error {
+	base := commandError(result, err)
+	if !isClaudeAuthFailure(result) {
+		return base
+	}
+	return fmt.Errorf("Claude Code authentication failed. %s: %w", ClaudeAuthSetupMessage, base)
+}
+
+func isClaudeAuthFailure(result subprocess.Result) bool {
+	text := strings.ToLower(strings.Join([]string{
+		result.Stdout,
+		result.Stderr,
+	}, "\n"))
+	if strings.Contains(text, "authentication_error") {
+		return true
+	}
+	if strings.Contains(text, "invalid authentication credentials") {
+		return true
+	}
+	if strings.Contains(text, "invalid x-api-key") {
+		return true
+	}
+	return strings.Contains(text, "401") && strings.Contains(text, "authentication")
 }
 
 func parseCodexStartedThreadID(output string) (string, error) {

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -306,6 +306,36 @@ func TestClaudeStartDoesNotStoreSessionIDWhenCommandFails(t *testing.T) {
 	runner.want(t, 0, "claude", "--session-id", "550e8400-e29b-41d4-a716-446655440010", "-p", "--output-format", "json", "--", "initialize")
 }
 
+func TestClaudeStartClassifiesAuthFailure(t *testing.T) {
+	raw := `{"error":{"type":"authentication_error","message":"401 Invalid authentication credentials"}}`
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: raw}},
+		errs:    []error{errors.New("exit 1")},
+	}
+	adapter := ClaudeAdapter{
+		Runner: runner,
+		NewRuntimeRef: func() (string, error) {
+			return "550e8400-e29b-41d4-a716-446655440010", nil
+		},
+	}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Start(context.Background(), StartRequest{Agent: agent, Prompt: "initialize"})
+
+	if err == nil {
+		t.Fatal("Start accepted auth failure")
+	}
+	errText := err.Error()
+	for _, want := range []string{"Claude Code authentication failed", "claude setup-token", "restart the Gitmoot daemon", "401 Invalid authentication credentials"} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error missing %q:\n%s", want, errText)
+		}
+	}
+	if result.Raw != raw {
+		t.Fatalf("raw = %q, want %q", result.Raw, raw)
+	}
+}
+
 func TestClaudeDeliverLastSessionCommand(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"done"}`}}}
 	adapter := ClaudeAdapter{Runner: runner}
@@ -363,6 +393,31 @@ func TestClaudeDeliverFallsBackToText(t *testing.T) {
 	runner.want(t, 1, "claude", "--resume", "550e8400-e29b-41d4-a716-446655440002", "-p", "--", "review")
 }
 
+func TestClaudeDeliverClassifiesAuthFailure(t *testing.T) {
+	raw := "401 Invalid authentication credentials"
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stdout: raw}},
+		errs:    []error{errors.New("exit 1")},
+	}
+	adapter := ClaudeAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+
+	if err == nil {
+		t.Fatal("Deliver accepted auth failure")
+	}
+	errText := err.Error()
+	for _, want := range []string{"Claude Code authentication failed", "claude setup-token", "restart the Gitmoot daemon", raw} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error missing %q:\n%s", want, errText)
+		}
+	}
+	if result.Raw != raw {
+		t.Fatalf("raw = %q, want %q", result.Raw, raw)
+	}
+}
+
 func TestClaudeHealthUsesRegisteredSession(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"OK"}`}}}
 	adapter := ClaudeAdapter{Runner: runner}
@@ -372,6 +427,27 @@ func TestClaudeHealthUsesRegisteredSession(t *testing.T) {
 		t.Fatalf("Health returned error: %v", err)
 	}
 	runner.want(t, 0, "claude", "--resume", "550e8400-e29b-41d4-a716-446655440002", "-p", "--output-format", "json", "--", healthPrompt)
+}
+
+func TestClaudeHealthClassifiesAuthFailure(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "401 Invalid authentication credentials"}},
+		errs:    []error{errors.New("exit 1")},
+	}
+	adapter := ClaudeAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	err := adapter.Health(context.Background(), agent)
+
+	if err == nil {
+		t.Fatal("Health accepted auth failure")
+	}
+	errText := err.Error()
+	for _, want := range []string{"Claude Code authentication failed", "claude setup-token", "restart the Gitmoot daemon"} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error missing %q:\n%s", want, errText)
+		}
+	}
 }
 
 func TestClaudeHealthRejectsBrokenSession(t *testing.T) {


### PR DESCRIPTION
## Summary
- Classify Claude runtime auth failures at the adapter boundary for start, deliver, and health commands.
- Keep Codex and Shell runtime failure handling unchanged.
- Preserve existing raw output return values for Claude start/deliver failures while adding actionable setup guidance.

## Checks
- GOTOOLCHAIN=go1.26.0 go test ./internal/runtime ./internal/cli -run 'Claude|AgentDoctor|AgentStart|AgentAsk|Daemon' -v -timeout 180s\n- git diff --check\n- codex exec review --uncommitted\n\n## Codex Review\n```text\nNo correctness issues were found in the changed runtime auth-failure classification or tests. Focused test execution was blocked by the sandboxed Go toolchain cache being read-only, but the diff itself appears sound.\n```\n\nRefs #187