### PR TITLE
Add live Claude doctor check

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -17,11 +17,14 @@ import (
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
 var newRuntimeFactory = func() runtime.Factory {
 	return runtime.Factory{}
 }
+
+var agentDoctorRunner subprocess.Runner = subprocess.ExecRunner{}
 
 func runAgent(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
@@ -1207,6 +1210,7 @@ func runAgentDoctor(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("agent doctor", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	live := fs.Bool("live", false, "run an explicit live Claude print-mode smoke check")
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		fs.Usage()
 		if len(args) == 0 {
@@ -1259,10 +1263,19 @@ func runAgentDoctor(args []string, stdout, stderr io.Writer) int {
 			detail += "; " + warning
 		}
 		fmt.Fprintf(stdout, "claude-auth-env %s %s\n", status, detail)
-		if !auth.Ready() {
+		if !auth.Ready() && !*live {
 			_ = persistAgentHealth(*home, name, "failed")
 			fmt.Fprintf(stderr, "agent %s health failed: %s\n", rtAgent.Name, runtime.ClaudeAuthSetupMessage)
 			return 1
+		}
+		if *live {
+			if err := runtime.ClaudeLiveCheck(context.Background(), agentDoctorRunner, ""); err != nil {
+				_ = persistAgentHealth(*home, name, "failed")
+				fmt.Fprintf(stdout, "claude-live fail %s\n", err)
+				fmt.Fprintf(stderr, "agent %s health failed: %v\n", rtAgent.Name, err)
+				return 1
+			}
+			fmt.Fprintln(stdout, "claude-live ok live Claude print-mode check succeeded")
 		}
 		if err := persistAgentHealth(*home, name, "ok"); err != nil {
 			fmt.Fprintf(stderr, "update agent health: %v\n", err)

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -2155,6 +2155,66 @@ func TestRunAgentDoctorClaudeFailsWhenAuthEnvMissing(t *testing.T) {
 	}
 }
 
+func TestRunAgentDoctorClaudeLiveRunsSmoke(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	home := t.TempDir()
+	subscribeClaudeAgent(t, home, "claude-live")
+	runner := &agentStartRunner{results: []subprocess.Result{{Stdout: `{"result":"OK"}`}}}
+	restoreRunner := replaceAgentDoctorRunner(runner)
+	defer restoreRunner()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "doctor", "claude-live", "--home", home, "--live"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("doctor exit code = %d, stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "claude-auth-env warn") || !strings.Contains(stdout.String(), "claude-live ok") {
+		t.Fatalf("stdout missing live smoke result:\n%s", stdout.String())
+	}
+	runner.want(t, 0, "", "claude", "-p", "--output-format", "json", "--", runtime.ClaudeLiveCheckPrompt)
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "claude-live")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.HealthStatus != "ok" {
+		t.Fatalf("health status = %q, want ok", agent.HealthStatus)
+	}
+}
+
+func TestRunAgentDoctorClaudeLiveClassifiesAuthFailure(t *testing.T) {
+	withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
+	home := t.TempDir()
+	subscribeClaudeAgent(t, home, "claude-live-fail")
+	runner := &agentStartRunner{
+		results: []subprocess.Result{{Stderr: "401 Invalid authentication credentials"}},
+		errs:    []error{errors.New("exit 1")},
+	}
+	restoreRunner := replaceAgentDoctorRunner(runner)
+	defer restoreRunner()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "doctor", "claude-live-fail", "--home", home, "--live"}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("doctor exit code = %d, want 1; stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "claude-live fail") || !strings.Contains(stderr.String(), "claude setup-token") {
+		t.Fatalf("doctor output missing classified live failure:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "claude-live-fail")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.HealthStatus != "failed" {
+		t.Fatalf("health status = %q, want failed", agent.HealthStatus)
+	}
+}
+
 func subscribeClaudeAgent(t *testing.T, home string, name string) {
 	t.Helper()
 	var stdout, stderr bytes.Buffer
@@ -2361,4 +2421,12 @@ func withClaudeAuthEnv(t *testing.T, values map[string]string) {
 			}
 		}
 	})
+}
+
+func replaceAgentDoctorRunner(runner subprocess.Runner) func() {
+	original := agentDoctorRunner
+	agentDoctorRunner = runner
+	return func() {
+		agentDoctorRunner = original
+	}
 }

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -23,6 +23,7 @@ import (
 
 var pluginLookPath = exec.LookPath
 var pluginInstallRunner subprocess.Runner = subprocess.ExecRunner{}
+var pluginDoctorRunner subprocess.Runner = subprocess.ExecRunner{}
 
 type pluginCheck struct {
 	Name     string `json:"name"`
@@ -69,7 +70,7 @@ func printPluginUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot plugin build codex|claude")
 	fmt.Fprintln(w, "  gitmoot plugin install codex|claude")
 	fmt.Fprintln(w, "  gitmoot plugin path codex|claude")
-	fmt.Fprintln(w, "  gitmoot plugin doctor [codex|claude]")
+	fmt.Fprintln(w, "  gitmoot plugin doctor [codex|claude] [--live]")
 }
 
 func runPluginInstall(args []string, stdout, stderr io.Writer) int {
@@ -203,6 +204,7 @@ func runPluginDoctor(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	jsonOutput := fs.Bool("json", false, "print doctor output as JSON")
+	live := fs.Bool("live", false, "run an explicit live Claude print-mode smoke check")
 	selected, explicitRuntime, help, ok := parsePluginDoctorArgs(args, fs, stderr)
 	if help {
 		return 0
@@ -223,7 +225,7 @@ func runPluginDoctor(args []string, stdout, stderr io.Writer) int {
 
 	output := pluginDoctorOutput{Home: paths.Home}
 	for _, provider := range providers {
-		output.Runtimes = append(output.Runtimes, doctorRuntime(paths.Home, provider, explicitRuntime))
+		output.Runtimes = append(output.Runtimes, doctorRuntime(paths.Home, provider, explicitRuntime, *live))
 	}
 	if *jsonOutput {
 		if err := writeJSON(stdout, output); err != nil {
@@ -318,7 +320,7 @@ func parsePluginDoctorArgs(args []string, fs *flag.FlagSet, stderr io.Writer) (p
 	return provider, true, false, true
 }
 
-func doctorRuntime(home string, provider pluginpack.Provider, explicitRuntime bool) pluginDoctorRuntime {
+func doctorRuntime(home string, provider pluginpack.Provider, explicitRuntime bool, live bool) pluginDoctorRuntime {
 	packagePath := pluginpack.DefaultPackageDir(home, provider)
 	runtime := pluginDoctorRuntime{
 		Runtime: string(provider),
@@ -334,10 +336,20 @@ func doctorRuntime(home string, provider pluginpack.Provider, explicitRuntime bo
 	runtime.Checks = append(runtime.Checks, checkRuntimeCLI(provider, explicitRuntime))
 	if provider == pluginpack.ProviderClaude {
 		runtime.Checks = append(runtime.Checks, checkClaudeAuthEnv())
+		if live {
+			runtime.Checks = append(runtime.Checks, checkClaudeLive())
+		}
 	}
 	runtime.Checks = append(runtime.Checks, checkValidationCommand(provider, explicitRuntime))
 	runtime.Healthy = runtimeChecksHealthy(runtime.Checks)
 	return runtime
+}
+
+func checkClaudeLive() pluginCheck {
+	if err := runtime.ClaudeLiveCheck(context.Background(), pluginDoctorRunner, ""); err != nil {
+		return failCheck("runtime-live", err.Error(), true)
+	}
+	return okCheck("runtime-live", "live Claude print-mode check succeeded", true)
 }
 
 func checkHome(home string) pluginCheck {

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/pluginpack"
 	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
 func TestRunPluginPathPrintsPackagePath(t *testing.T) {
@@ -210,6 +211,75 @@ func TestRunPluginDoctorClaudeWarnsWhenAuthEnvMissing(t *testing.T) {
 	}
 }
 
+func TestRunPluginDoctorClaudeLiveRunsSmoke(t *testing.T) {
+	withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
+	home := t.TempDir()
+	if _, err := pluginpack.Build(pluginpack.BuildOptions{
+		Provider: pluginpack.ProviderClaude,
+		Home:     filepath.Join(home, ".gitmoot"),
+	}); err != nil {
+		t.Fatalf("build claude package: %v", err)
+	}
+	restorePath := stubPluginLookPath(map[string]string{"claude": "/tmp/bin/claude"})
+	defer restorePath()
+	runner := &agentStartRunner{results: []subprocess.Result{{Stdout: `{"result":"OK"}`}}}
+	restoreRunner := replacePluginDoctorRunner(runner)
+	defer restoreRunner()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "doctor", "claude", "--home", home, "--live", "--json"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin doctor exit code = %d, stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	var output pluginDoctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("doctor JSON did not parse: %v\n%s", err, stdout.String())
+	}
+	check := findDoctorCheck(t, output.Runtimes[0].Checks, "runtime-live")
+	if check.Status != "ok" {
+		t.Fatalf("runtime-live status = %q, want ok; checks=%+v", check.Status, output.Runtimes[0].Checks)
+	}
+	runner.want(t, 0, "", "claude", "-p", "--output-format", "json", "--", runtime.ClaudeLiveCheckPrompt)
+}
+
+func TestRunPluginDoctorClaudeLiveClassifiesAuthFailure(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	home := t.TempDir()
+	if _, err := pluginpack.Build(pluginpack.BuildOptions{
+		Provider: pluginpack.ProviderClaude,
+		Home:     filepath.Join(home, ".gitmoot"),
+	}); err != nil {
+		t.Fatalf("build claude package: %v", err)
+	}
+	restorePath := stubPluginLookPath(map[string]string{"claude": "/tmp/bin/claude"})
+	defer restorePath()
+	runner := &agentStartRunner{
+		results: []subprocess.Result{{Stderr: "401 Invalid authentication credentials"}},
+		errs:    []error{errors.New("exit 1")},
+	}
+	restoreRunner := replacePluginDoctorRunner(runner)
+	defer restoreRunner()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "doctor", "claude", "--home", home, "--live", "--json"}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("plugin doctor exit code = %d, want 1; stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	var output pluginDoctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("doctor JSON did not parse: %v\n%s", err, stdout.String())
+	}
+	check := findDoctorCheck(t, output.Runtimes[0].Checks, "runtime-live")
+	if check.Status != "fail" {
+		t.Fatalf("runtime-live status = %q, want fail; checks=%+v", check.Status, output.Runtimes[0].Checks)
+	}
+	if !strings.Contains(check.Detail, "claude setup-token") || !strings.Contains(check.Detail, "restart the Gitmoot daemon") {
+		t.Fatalf("runtime-live detail = %q, want classified auth guidance", check.Detail)
+	}
+}
+
 func TestRunPluginDoctorFailsExplicitUnhealthyRuntime(t *testing.T) {
 	restore := stubPluginLookPath(map[string]string{})
 	defer restore()
@@ -264,6 +334,14 @@ func stubPluginLookPath(paths map[string]string) func() {
 	}
 	return func() {
 		pluginLookPath = original
+	}
+}
+
+func replacePluginDoctorRunner(runner subprocess.Runner) func() {
+	original := pluginDoctorRunner
+	pluginDoctorRunner = runner
+	return func() {
+		pluginDoctorRunner = original
 	}
 }
 

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -424,6 +424,10 @@ func commandError(result subprocess.Result, err error) error {
 }
 
 func claudeCommandError(result subprocess.Result, err error) error {
+	return ClassifyClaudeCommandError(result, err)
+}
+
+func ClassifyClaudeCommandError(result subprocess.Result, err error) error {
 	base := commandError(result, err)
 	if !isClaudeAuthFailure(result) {
 		return base

--- a/internal/runtime/claude_auth.go
+++ b/internal/runtime/claude_auth.go
@@ -1,12 +1,20 @@
 package runtime
 
-import "strings"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
 
 const (
 	ClaudeOAuthTokenEnv    = "CLAUDE_CODE_OAUTH_TOKEN"
 	AnthropicAPIKeyEnv     = "ANTHROPIC_API_KEY"
 	AnthropicAuthTokenEnv  = "ANTHROPIC_AUTH_TOKEN"
 	ClaudeAuthSetupMessage = "Claude Code background jobs need non-interactive credentials. Run: claude setup-token; export CLAUDE_CODE_OAUTH_TOKEN=<token>; then restart the Gitmoot daemon so it inherits the token."
+	ClaudeLiveCheckPrompt  = "Gitmoot Claude live check. Return OK only."
 )
 
 type ClaudeAuthEnv struct {
@@ -52,6 +60,48 @@ func (e ClaudeAuthEnv) Warning() string {
 	default:
 		return ""
 	}
+}
+
+func ClaudeLiveCheck(ctx context.Context, runner subprocess.Runner, dir string) error {
+	if runner == nil {
+		runner = subprocess.ExecRunner{}
+	}
+	result, err := runner.Run(ctx, dir, "claude", "-p", "--output-format", "json", "--", ClaudeLiveCheckPrompt)
+	if err != nil && isClaudeJSONUnsupported(result) {
+		result, err = runner.Run(ctx, dir, "claude", "-p", "--", ClaudeLiveCheckPrompt)
+		if err != nil {
+			return ClassifyClaudeCommandError(result, err)
+		}
+		return validateClaudeLiveText(result.Stdout)
+	}
+	if err != nil {
+		return ClassifyClaudeCommandError(result, err)
+	}
+	return validateClaudeLiveJSON(result.Stdout)
+}
+
+func validateClaudeLiveJSON(stdout string) error {
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		return fmt.Errorf("Claude Code live check returned no stdout response")
+	}
+	var payload struct {
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+		return fmt.Errorf("Claude Code live check returned invalid JSON: %w", err)
+	}
+	if strings.TrimSpace(payload.Result) == "" {
+		return fmt.Errorf("Claude Code live check returned no result")
+	}
+	return nil
+}
+
+func validateClaudeLiveText(stdout string) error {
+	if strings.TrimSpace(stdout) == "" {
+		return fmt.Errorf("Claude Code live check returned no stdout response")
+	}
+	return nil
 }
 
 func setUnset(value bool) string {

--- a/internal/runtime/claude_auth_test.go
+++ b/internal/runtime/claude_auth_test.go
@@ -1,8 +1,12 @@
 package runtime
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
 func TestInspectClaudeAuthEnvMasksReadiness(t *testing.T) {
@@ -51,5 +55,82 @@ func TestInspectClaudeAuthEnvWarnsForAPIKeyPrecedence(t *testing.T) {
 	}
 	if !strings.Contains(auth.Warning(), "API-key billing") {
 		t.Fatalf("warning = %q, want API key warning", auth.Warning())
+	}
+}
+
+func TestClaudeLiveCheckRunsPrintModeSmoke(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"OK"}`}}}
+
+	if err := ClaudeLiveCheck(context.Background(), runner, "/repo"); err != nil {
+		t.Fatalf("ClaudeLiveCheck returned error: %v", err)
+	}
+
+	runner.want(t, 0, "claude", "-p", "--output-format", "json", "--", ClaudeLiveCheckPrompt)
+}
+
+func TestClaudeLiveCheckClassifiesAuthFailure(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "401 Invalid authentication credentials"}},
+		errs:    []error{errors.New("exit 1")},
+	}
+
+	err := ClaudeLiveCheck(context.Background(), runner, "/repo")
+
+	if err == nil {
+		t.Fatal("ClaudeLiveCheck accepted auth failure")
+	}
+	for _, want := range []string{"Claude Code authentication failed", "claude setup-token", "restart the Gitmoot daemon"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q:\n%s", want, err)
+		}
+	}
+}
+
+func TestClaudeLiveCheckFallsBackToText(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stderr: "unknown option '--output-format'"},
+			{Stdout: "OK\n"},
+		},
+		errs: []error{errors.New("exit 1"), nil},
+	}
+
+	if err := ClaudeLiveCheck(context.Background(), runner, "/repo"); err != nil {
+		t.Fatalf("ClaudeLiveCheck returned error: %v", err)
+	}
+
+	runner.want(t, 0, "claude", "-p", "--output-format", "json", "--", ClaudeLiveCheckPrompt)
+	runner.want(t, 1, "claude", "-p", "--", ClaudeLiveCheckPrompt)
+}
+
+func TestClaudeLiveCheckFallbackRejectsStderrOnlySuccess(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stderr: "unknown option '--output-format'"},
+			{Stderr: "diagnostic only"},
+		},
+		errs: []error{errors.New("exit 1"), nil},
+	}
+
+	err := ClaudeLiveCheck(context.Background(), runner, "/repo")
+
+	if err == nil {
+		t.Fatal("ClaudeLiveCheck accepted stderr-only fallback output")
+	}
+	if !strings.Contains(err.Error(), "no stdout response") {
+		t.Fatalf("error = %q, want no stdout response", err)
+	}
+}
+
+func TestClaudeLiveCheckRejectsStderrOnlySuccess(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stderr: "diagnostic only"}}}
+
+	err := ClaudeLiveCheck(context.Background(), runner, "/repo")
+
+	if err == nil {
+		t.Fatal("ClaudeLiveCheck accepted stderr-only output")
+	}
+	if !strings.Contains(err.Error(), "no stdout response") {
+		t.Fatalf("error = %q, want no stdout response", err)
 	}
 }


### PR DESCRIPTION
Refs #187

## Summary
- Add an explicit `--live` Claude smoke check for `gitmoot plugin doctor claude` and `gitmoot agent doctor <claude-agent>`.
- Keep default Claude doctor checks cheap/env-only while allowing a user-requested `claude -p` validation.
- Reuse classified Claude auth guidance for live-check failures and keep output credential-free.
- Preserve compatibility with Claude installs that do not support JSON output by falling back to text print mode.

## Checks
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli ./internal/runtime -run 'Claude|PluginDoctor|AgentDoctor' -v -timeout 180s`
- `git diff --check`
- `codex exec review --uncommitted`

## Review
```text
No discrete correctness issues were found in the changed code. Focused Go tests could not be executed in this sandbox because downloading the Go 1.26 toolchain is blocked.
```
