### PR TITLE
Add parallel session policy config

### DIFF
--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -36,5 +36,11 @@ logs = %q
 workspaces = %q
 evals = %q
 artifact_blobs = %q
+
+[parallel_sessions]
+same_session = "fork_temp_session"
+merge_back = "summary"
+max_temp_sessions_per_agent = 4
+eligible_actions = ["ask", "review", "implement"]
 `, paths.Database, paths.Logs, paths.Workspaces, paths.Evals, paths.ArtifactBlobs)
 }

--- a/internal/config/init_test.go
+++ b/internal/config/init_test.go
@@ -31,4 +31,7 @@ func TestInitializeCreatesLocalState(t *testing.T) {
 	if !strings.Contains(string(config), "artifact_blobs") {
 		t.Fatalf("config missing artifact blob path:\n%s", string(config))
 	}
+	if !strings.Contains(string(config), "[parallel_sessions]") {
+		t.Fatalf("config missing parallel session policy:\n%s", string(config))
+	}
 }

--- a/internal/config/parallel_sessions.go
+++ b/internal/config/parallel_sessions.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	ParallelSessionQueue           = "queue"
+	ParallelSessionForkTempSession = "fork_temp_session"
+
+	ParallelSessionMergeBackOff     = "off"
+	ParallelSessionMergeBackSummary = "summary"
+)
+
+type ParallelSessionPolicy struct {
+	SameSession             string
+	MergeBack               string
+	MaxTempSessionsPerAgent int
+	EligibleActions         []string
+}
+
+func DefaultParallelSessionPolicy() ParallelSessionPolicy {
+	return ParallelSessionPolicy{
+		SameSession:             ParallelSessionForkTempSession,
+		MergeBack:               ParallelSessionMergeBackSummary,
+		MaxTempSessionsPerAgent: 4,
+		EligibleActions:         []string{"ask", "review", "implement"},
+	}
+}
+
+func LoadParallelSessionPolicy(paths Paths) (ParallelSessionPolicy, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return ParallelSessionPolicy{}, err
+	}
+	policy := DefaultParallelSessionPolicy()
+	current := false
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			current = strings.TrimSpace(section) == "parallel_sessions"
+			continue
+		}
+		if !current {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if err := applyParallelSessionPolicyField(&policy, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
+			return ParallelSessionPolicy{}, fmt.Errorf("parse [parallel_sessions].%s: %w", strings.TrimSpace(key), err)
+		}
+	}
+	if err := validateParallelSessionPolicy(policy); err != nil {
+		return ParallelSessionPolicy{}, err
+	}
+	return policy, nil
+}
+
+func applyParallelSessionPolicyField(policy *ParallelSessionPolicy, key string, value string) error {
+	switch key {
+	case "same_session":
+		parsed, err := parseConfigString(value)
+		policy.SameSession = strings.TrimSpace(parsed)
+		return err
+	case "merge_back":
+		parsed, err := parseConfigString(value)
+		policy.MergeBack = strings.TrimSpace(parsed)
+		return err
+	case "max_temp_sessions_per_agent":
+		parsed, err := strconv.Atoi(value)
+		policy.MaxTempSessionsPerAgent = parsed
+		return err
+	case "eligible_actions":
+		parsed, err := parseConfigStringArray(value)
+		policy.EligibleActions = compactConfigStrings(parsed)
+		return err
+	default:
+		return nil
+	}
+}
+
+func validateParallelSessionPolicy(policy ParallelSessionPolicy) error {
+	switch policy.SameSession {
+	case ParallelSessionQueue, ParallelSessionForkTempSession:
+	default:
+		return fmt.Errorf("unsupported parallel_sessions.same_session %q; use queue or fork_temp_session", policy.SameSession)
+	}
+	switch policy.MergeBack {
+	case ParallelSessionMergeBackOff, ParallelSessionMergeBackSummary:
+	default:
+		return fmt.Errorf("unsupported parallel_sessions.merge_back %q; use off or summary", policy.MergeBack)
+	}
+	if policy.MaxTempSessionsPerAgent < 1 {
+		return fmt.Errorf("parallel_sessions.max_temp_sessions_per_agent must be positive")
+	}
+	for _, action := range policy.EligibleActions {
+		switch strings.TrimSpace(action) {
+		case "ask", "review", "implement":
+		default:
+			return fmt.Errorf("unsupported parallel_sessions.eligible_actions value %q; use ask, review, or implement", action)
+		}
+	}
+	return nil
+}

--- a/internal/config/parallel_sessions_test.go
+++ b/internal/config/parallel_sessions_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoadParallelSessionPolicyDefaults(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+
+	policy, err := LoadParallelSessionPolicy(paths)
+
+	if err != nil {
+		t.Fatalf("LoadParallelSessionPolicy returned error: %v", err)
+	}
+	if policy.SameSession != ParallelSessionForkTempSession {
+		t.Fatalf("SameSession = %q, want %q", policy.SameSession, ParallelSessionForkTempSession)
+	}
+	if policy.MergeBack != ParallelSessionMergeBackSummary {
+		t.Fatalf("MergeBack = %q, want %q", policy.MergeBack, ParallelSessionMergeBackSummary)
+	}
+	if policy.MaxTempSessionsPerAgent != 4 {
+		t.Fatalf("MaxTempSessionsPerAgent = %d, want 4", policy.MaxTempSessionsPerAgent)
+	}
+	if strings.Join(policy.EligibleActions, ",") != "ask,review,implement" {
+		t.Fatalf("EligibleActions = %v", policy.EligibleActions)
+	}
+}
+
+func TestLoadParallelSessionPolicyOverrides(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[parallel_sessions]
+same_session = "queue"
+merge_back = "off"
+max_temp_sessions_per_agent = 2
+eligible_actions = ["ask", "review"]
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	policy, err := LoadParallelSessionPolicy(paths)
+
+	if err != nil {
+		t.Fatalf("LoadParallelSessionPolicy returned error: %v", err)
+	}
+	if policy.SameSession != ParallelSessionQueue || policy.MergeBack != ParallelSessionMergeBackOff || policy.MaxTempSessionsPerAgent != 2 || strings.Join(policy.EligibleActions, ",") != "ask,review" {
+		t.Fatalf("policy = %+v", policy)
+	}
+}
+
+func TestLoadParallelSessionPolicyRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "same_session",
+			body: `
+[parallel_sessions]
+same_session = "clone_hidden_state"
+`,
+			wantErr: "unsupported parallel_sessions.same_session",
+		},
+		{
+			name: "merge_back",
+			body: `
+[parallel_sessions]
+merge_back = "full"
+`,
+			wantErr: "unsupported parallel_sessions.merge_back",
+		},
+		{
+			name: "max_temp_sessions_per_agent",
+			body: `
+[parallel_sessions]
+max_temp_sessions_per_agent = 0
+`,
+			wantErr: "max_temp_sessions_per_agent must be positive",
+		},
+		{
+			name: "eligible_actions",
+			body: `
+[parallel_sessions]
+eligible_actions = ["ask", "deploy"]
+`,
+			wantErr: "unsupported parallel_sessions.eligible_actions",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if err := Initialize(paths); err != nil {
+				t.Fatalf("Initialize returned error: %v", err)
+			}
+			if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+tt.body), 0o600); err != nil {
+				t.Fatalf("write config returned error: %v", err)
+			}
+
+			_, err := LoadParallelSessionPolicy(paths)
+
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("LoadParallelSessionPolicy error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
WHAT
- Adds typed `parallel_sessions` config loading with issue #177 defaults.

WHY
- Forkable temporary workers need a single config contract before daemon routing, delegation, and merge-back behavior can depend on it.

CHANGES
- Adds `ParallelSessionPolicy` with defaults: `fork_temp_session`, `summary`, cap `4`, and eligible actions `ask/review/implement`.
- Adds parser validation for unsupported `same_session`, `merge_back`, non-positive temp caps, and unsupported actions.
- Adds the `[parallel_sessions]` block to newly initialized config files.
- Adds focused config tests.

RESULTS
- `GOTOOLCHAIN=go1.26.0 go test ./internal/config -v -timeout 180s` passed.
- `git diff --check` passed.
- `codex exec review --uncommitted` final raw output:

```text
No discrete correctness issues were found in the current staged, unstaged, or untracked changes. I could not run Go tests because the environment attempted to download the Go 1.26 toolchain into a read-only module cache.
```

RISK
- The new config is not consumed by daemon/runtime behavior yet; that is handled by later #177 tasks.
- Existing configs remain compatible because missing `[parallel_sessions]` uses defaults.
