### PR TITLE
Route busy runtime jobs through temp workers

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1133,13 +1133,15 @@ func shorterWait(current time.Duration, candidate time.Duration, set *bool) time
 }
 
 type jobWorker struct {
-	Store             *db.Store
-	Stdout            io.Writer
-	ConfigHome        string
-	AdapterFactory    func(runtime.Agent, string) (workflow.DeliveryAdapter, error)
-	CheckoutValidator func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error)
-	WorkflowFactory   func(string) workflow.Engine
-	CommenterFactory  func(string) github.Client
+	Store               *db.Store
+	Stdout              io.Writer
+	ConfigHome          string
+	ConfigHomeExplicit  bool
+	AdapterFactory      func(runtime.Agent, string) (workflow.DeliveryAdapter, error)
+	StartAdapterFactory func(string, string) (runtime.Adapter, error)
+	CheckoutValidator   func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error)
+	WorkflowFactory     func(string) workflow.Engine
+	CommenterFactory    func(string) github.Client
 }
 
 const daemonRunningJobStaleAfter = 30 * time.Minute
@@ -1148,13 +1150,21 @@ const daemonWorkerLoopInterval = 1 * time.Second
 
 var errRuntimeSessionBusy = errors.New("runtime session is busy")
 
+type tempWorkerEligibility struct {
+	Eligible bool
+	Reason   string
+}
+
 func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWorker {
 	configHome := ""
+	configHomeExplicit := false
 	if len(home) > 0 {
 		configHome = home[0]
+		configHomeExplicit = true
 	}
-	worker := jobWorker{Store: store, Stdout: stdout, ConfigHome: configHome}
+	worker := jobWorker{Store: store, Stdout: stdout, ConfigHome: configHome, ConfigHomeExplicit: configHomeExplicit}
 	worker.AdapterFactory = worker.defaultAdapter
+	worker.StartAdapterFactory = worker.defaultStartAdapter
 	worker.CheckoutValidator = worker.defaultCheckout
 	worker.WorkflowFactory = worker.defaultWorkflow
 	return worker
@@ -1379,7 +1389,11 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 		}
 	}
 	for len(pending) > 0 {
-		queued, remaining := selectRunnableQueuedJobs(ctx, worker.Store, pending, limit)
+		policy, err := worker.parallelSessionPolicy()
+		if err != nil {
+			policy = config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue}
+		}
+		queued, remaining := selectRunnableQueuedJobsWithPolicy(ctx, worker.Store, pending, limit, policy)
 		if len(queued) == 0 {
 			return nil
 		}
@@ -1407,19 +1421,27 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 }
 
 type queuedJobResourceSelector struct {
-	limit     int
-	checkouts map[string]bool
-	runtimes  map[string]bool
+	limit            int
+	policy           config.ParallelSessionPolicy
+	checkouts        map[string]bool
+	runtimes         map[string]bool
+	tempReservations map[string]int
 }
 
 func selectRunnableQueuedJobs(ctx context.Context, store *db.Store, pending []db.Job, limit int) ([]db.Job, []db.Job) {
+	return selectRunnableQueuedJobsWithPolicy(ctx, store, pending, limit, config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue})
+}
+
+func selectRunnableQueuedJobsWithPolicy(ctx context.Context, store *db.Store, pending []db.Job, limit int, policy config.ParallelSessionPolicy) ([]db.Job, []db.Job) {
 	if limit <= 0 {
 		return nil, pending
 	}
 	selector := queuedJobResourceSelector{
-		limit:     limit,
-		checkouts: map[string]bool{},
-		runtimes:  map[string]bool{},
+		limit:            limit,
+		policy:           policy,
+		checkouts:        map[string]bool{},
+		runtimes:         map[string]bool{},
+		tempReservations: map[string]int{},
 	}
 	queued := make([]db.Job, 0, min(limit, len(pending)))
 	remaining := make([]db.Job, 0, len(pending))
@@ -1439,13 +1461,57 @@ func (s queuedJobResourceSelector) selects(ctx context.Context, store *db.Store,
 	}
 	checkoutKey := queuedJobCheckoutKey(ctx, store, job)
 	runtimeKey := queuedJobRuntimeResourceKey(ctx, store, job)
-	if s.checkouts[checkoutKey] || (runtimeKey != "" && s.runtimes[runtimeKey]) {
+	if s.checkouts[checkoutKey] {
 		return false
+	}
+	runtimeAlreadySelected := runtimeKey != "" && s.runtimes[runtimeKey]
+	runtimeAlreadyLocked := runtimeKey != "" && !runtimeAlreadySelected && runtimeResourceLocked(ctx, store, runtimeKey)
+	if runtimeAlreadySelected || runtimeAlreadyLocked {
+		if !s.canUseTempWorker(ctx, store, job) && runtimeAlreadySelected {
+			return false
+		}
 	}
 	s.checkouts[checkoutKey] = true
 	if runtimeKey != "" {
 		s.runtimes[runtimeKey] = true
 	}
+	return true
+}
+
+func runtimeResourceLocked(ctx context.Context, store *db.Store, runtimeKey string) bool {
+	if store == nil || strings.TrimSpace(runtimeKey) == "" {
+		return false
+	}
+	_, err := store.GetResourceLock(ctx, runtimeKey)
+	return err == nil
+}
+
+func (s queuedJobResourceSelector) canUseTempWorker(ctx context.Context, store *db.Store, job db.Job) bool {
+	if store == nil {
+		return false
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return false
+	}
+	dbAgent, err := store.GetAgent(ctx, job.Agent)
+	if err != nil {
+		return false
+	}
+	agent := runtimeAgent(dbAgent)
+	typ := tempWorkerAgentType(agent.Name)
+	count, err := store.CountActiveAgentInstances(ctx, typ, agent.AutonomyPolicy, time.Now().UTC())
+	if err != nil {
+		return false
+	}
+	if count+s.tempReservations[typ] >= s.policy.MaxTempSessionsPerAgent {
+		return false
+	}
+	eligible := tempWorkerEligible(ctx, store, job, payload, agent, s.policy, time.Now().UTC())
+	if !eligible.Eligible {
+		return false
+	}
+	s.tempReservations[typ]++
 	return true
 }
 
@@ -1566,6 +1632,24 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	}
 	if !acquired {
 		message := fmt.Sprintf("runtime session %s is busy", lockKey)
+		policy, policyErr := w.parallelSessionPolicy()
+		if policyErr != nil {
+			if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, policyErr); finishErr != nil {
+				return finishErr
+			}
+			_ = w.postJobResultComment(ctx, job.ID, agent, checkout, policyErr)
+			return nil
+		}
+		eligibility := tempWorkerEligible(ctx, w.Store, job, payload, agent, policy, time.Now().UTC())
+		if eligibility.Eligible {
+			eligibleMessage := fmt.Sprintf("%s; temp worker eligible", message)
+			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "temp_worker_eligible", Message: eligibleMessage}); eventErr != nil {
+				return eventErr
+			}
+			return w.runWithTempWorker(ctx, job, payload, agent, checkout, policy, eligibleMessage)
+		} else if strings.TrimSpace(eligibility.Reason) != "" {
+			message = fmt.Sprintf("%s; temp worker ineligible: %s", message, eligibility.Reason)
+		}
 		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: message}); eventErr != nil {
 			return eventErr
 		}
@@ -1621,6 +1705,382 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	return nil
 }
 
+func (w jobWorker) parallelSessionPolicy() (config.ParallelSessionPolicy, error) {
+	if !w.ConfigHomeExplicit && strings.TrimSpace(w.ConfigHome) == "" {
+		return config.DefaultParallelSessionPolicy(), nil
+	}
+	paths, err := initializedPaths(w.ConfigHome)
+	if err != nil {
+		return config.ParallelSessionPolicy{}, err
+	}
+	return config.LoadParallelSessionPolicy(paths)
+}
+
+func tempWorkerEligible(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload, agent runtime.Agent, policy config.ParallelSessionPolicy, now time.Time) tempWorkerEligibility {
+	if payload.DelegationReason == "temp_worker_merge_back" {
+		return tempWorkerEligibility{Reason: "merge-back waits for original runtime session"}
+	}
+	if payload.DelegationReason == "runtime_session_busy" {
+		return tempWorkerEligibility{Reason: "delegated temp worker waits for assigned runtime session"}
+	}
+	if policy.SameSession != config.ParallelSessionForkTempSession {
+		return tempWorkerEligibility{Reason: "parallel_sessions.same_session is queue"}
+	}
+	switch agent.Runtime {
+	case runtime.CodexRuntime, runtime.ClaudeRuntime:
+	default:
+		return tempWorkerEligibility{Reason: fmt.Sprintf("runtime %s does not support temp workers", agent.Runtime)}
+	}
+	if !parallelSessionActionAllowed(job.Type, policy.EligibleActions) {
+		return tempWorkerEligibility{Reason: fmt.Sprintf("action %s is not eligible", job.Type)}
+	}
+	if readOnlyImplementationBlocked(job.Type, agent) {
+		return tempWorkerEligibility{Reason: "implementation requires writable agent policy"}
+	}
+	if strings.TrimSpace(job.Type) == "implement" {
+		path, ok := queuedJobTaskWorktreePath(ctx, store, payload)
+		if !ok {
+			return tempWorkerEligibility{Reason: "implementation requires task worktree"}
+		}
+		if info, err := os.Stat(path); err != nil || !info.IsDir() {
+			return tempWorkerEligibility{Reason: "implementation task worktree is missing"}
+		}
+	}
+	if store != nil {
+		count, err := store.CountActiveAgentInstances(ctx, tempWorkerAgentType(agent.Name), agent.AutonomyPolicy, now)
+		if err != nil {
+			return tempWorkerEligibility{Reason: fmt.Sprintf("count active temp workers: %v", err)}
+		}
+		if count >= policy.MaxTempSessionsPerAgent {
+			return tempWorkerEligibility{Reason: fmt.Sprintf("max temp workers reached for %s", agent.Name)}
+		}
+	}
+	return tempWorkerEligibility{Eligible: true}
+}
+
+func parallelSessionActionAllowed(action string, eligibleActions []string) bool {
+	action = strings.TrimSpace(action)
+	for _, candidate := range eligibleActions {
+		if strings.TrimSpace(candidate) == action {
+			return true
+		}
+	}
+	return false
+}
+
+func tempWorkerAgentType(agentName string) string {
+	return "temp:" + strings.TrimSpace(agentName)
+}
+
+type tempWorkerStartResult struct {
+	Agent       runtime.Agent
+	IdleTimeout time.Duration
+	JobTimeout  time.Duration
+}
+
+func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload workflow.JobPayload, original runtime.Agent, checkout string, policy config.ParallelSessionPolicy, reason string) error {
+	started, err := w.startTempWorker(ctx, job, payload, original, checkout)
+	if err != nil {
+		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "temp_worker_failed", Message: err.Error()}); eventErr != nil {
+			return eventErr
+		}
+		waitMessage := fmt.Sprintf("%s; temp worker start failed: %v", reason, err)
+		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: waitMessage}); eventErr != nil {
+			return eventErr
+		}
+		writeLine(w.Stdout, "job %s waiting: %s", job.ID, waitMessage)
+		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, waitMessage)
+	}
+	payload.OriginalAgent = original.Name
+	payload.DelegatedAgent = started.Agent.Name
+	payload.DelegationReason = "runtime_session_busy"
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	delegated, err := w.Store.DelegateQueuedJob(ctx, job.ID, original.Name, started.Agent.Name, string(encoded), db.JobEvent{
+		JobID:   job.ID,
+		Kind:    "temp_worker_delegated",
+		Message: fmt.Sprintf("delegated from %s to %s: %s", original.Name, started.Agent.Name, reason),
+	})
+	if err != nil {
+		w.cleanupTempWorker(context.Background(), started.Agent.Name)
+		return err
+	}
+	if !delegated {
+		w.cleanupTempWorker(context.Background(), started.Agent.Name)
+		return nil
+	}
+	delegatedJob, err := w.Store.GetJob(ctx, job.ID)
+	if err != nil {
+		return err
+	}
+	adapter, err := w.AdapterFactory(started.Agent, checkout)
+	if err != nil {
+		if finishErr := w.finishQueuedJob(ctx, delegatedJob.ID, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, err)
+		return nil
+	}
+	writeLine(w.Stdout, "running job %s for temporary worker %s in %s", job.ID, started.Agent.Name, payload.Repo)
+	releaseLock, acquired, lockKey, err := acquireRuntimeSessionLock(ctx, w.Store, delegatedJob.ID, started.Agent, time.Now().UTC(), started.JobTimeout)
+	if err != nil {
+		if finishErr := w.finishQueuedJob(ctx, delegatedJob.ID, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, err)
+		return nil
+	}
+	if !acquired {
+		message := fmt.Sprintf("runtime session %s is busy", lockKey)
+		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: delegatedJob.ID, Kind: "runtime_lock_wait", Message: message}); eventErr != nil {
+			return eventErr
+		}
+		writeLine(w.Stdout, "job %s waiting: %s", delegatedJob.ID, message)
+		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, message)
+	}
+	defer func() {
+		if err := releaseLock(context.Background()); err != nil {
+			writeLine(w.Stdout, "job %s temp runtime lock release failed: %v", delegatedJob.ID, err)
+		}
+	}()
+	if err := w.Store.MarkAgentInstanceRunning(ctx, started.Agent.Name, time.Now().UTC(), started.JobTimeout); err != nil {
+		if finishErr := w.finishQueuedJob(ctx, delegatedJob.ID, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, err)
+		return nil
+	}
+	defer func() {
+		if err := w.Store.TouchAgentInstance(context.Background(), started.Agent.Name, time.Now().UTC(), started.IdleTimeout); err != nil {
+			writeLine(w.Stdout, "job %s temp worker state update failed: %v", delegatedJob.ID, err)
+		}
+	}()
+	runCtx, stopRun := w.runningJobContext(ctx, job.ID)
+	defer stopRun()
+	if started.JobTimeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(runCtx, started.JobTimeout)
+		defer cancel()
+	}
+	engine := w.WorkflowFactory(checkout)
+	_, err = engine.RunJob(runCtx, delegatedJob.ID, started.Agent, adapter)
+	if err != nil {
+		if markErr := w.handleRunJobError(ctx, delegatedJob.ID, err); markErr != nil {
+			return markErr
+		}
+		_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, err)
+		writeLine(w.Stdout, "job %s failed: %v", delegatedJob.ID, err)
+		return nil
+	}
+	if policy.MergeBack == config.ParallelSessionMergeBackSummary {
+		if err := w.queueTempWorkerMergeBack(ctx, delegatedJob.ID, original, started.Agent); err != nil {
+			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: delegatedJob.ID, Kind: "temp_worker_merge_back_failed", Message: err.Error()}); eventErr != nil {
+				return eventErr
+			}
+			return err
+		}
+	}
+	_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, nil)
+	writeLine(w.Stdout, "job %s completed by temporary worker %s", delegatedJob.ID, started.Agent.Name)
+	return nil
+}
+
+func (w jobWorker) queueTempWorkerMergeBack(ctx context.Context, completedJobID string, original runtime.Agent, tempAgent runtime.Agent) error {
+	completedJob, err := w.Store.GetJob(ctx, completedJobID)
+	if err != nil {
+		return err
+	}
+	payload, err := daemonJobPayload(completedJob)
+	if err != nil {
+		return err
+	}
+	if payload.Result == nil {
+		return fmt.Errorf("completed temp-worker job %s has no result", completedJob.ID)
+	}
+	mergeBackID := completedJob.ID + "-merge-back"
+	if _, err := w.Store.GetJob(ctx, mergeBackID); err == nil {
+		return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: completedJob.ID, Kind: "temp_worker_merge_back_existing", Message: fmt.Sprintf("summary merge-back job %s already exists", mergeBackID)})
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	request := workflow.JobRequest{
+		ID:               mergeBackID,
+		Agent:            original.Name,
+		Action:           "ask",
+		Repo:             payload.Repo,
+		Branch:           payload.Branch,
+		GoalID:           payload.GoalID,
+		TaskID:           payload.TaskID,
+		TaskTitle:        payload.TaskTitle,
+		LeadAgent:        payload.LeadAgent,
+		Reviewers:        payload.Reviewers,
+		ReviewRound:      payload.ReviewRound,
+		Sender:           tempAgent.Name,
+		Instructions:     tempWorkerMergeBackInstructions(completedJob, payload, tempAgent.Name),
+		OriginalAgent:    original.Name,
+		DelegatedAgent:   tempAgent.Name,
+		DelegationReason: "temp_worker_merge_back",
+		Constraints: []string{
+			"This is a temp-worker merge-back summary only.",
+			"Do not edit files, create commits, open pull requests, or dispatch more agents unless the summary explicitly requires follow-up.",
+		},
+	}
+	if _, err := (workflow.Mailbox{Store: w.Store}).Enqueue(ctx, request); err != nil {
+		return err
+	}
+	return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: completedJob.ID, Kind: "temp_worker_merge_back_queued", Message: fmt.Sprintf("queued summary merge-back job %s for %s", mergeBackID, original.Name)})
+}
+
+func tempWorkerMergeBackInstructions(job db.Job, payload workflow.JobPayload, tempAgentName string) string {
+	result := payload.Result
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "Temporary worker %s completed job %s.\n", tempAgentName, job.ID)
+	fmt.Fprintf(&builder, "Repo: %s\n", payload.Repo)
+	if strings.TrimSpace(payload.Branch) != "" {
+		fmt.Fprintf(&builder, "Branch: %s\n", payload.Branch)
+	}
+	if payload.PullRequest > 0 {
+		fmt.Fprintf(&builder, "Pull request: #%d\n", payload.PullRequest)
+	}
+	if strings.TrimSpace(payload.HeadSHA) != "" {
+		fmt.Fprintf(&builder, "Head SHA: %s\n", payload.HeadSHA)
+	}
+	fmt.Fprintf(&builder, "Decision: %s\n", result.Decision)
+	if strings.TrimSpace(result.Summary) != "" {
+		fmt.Fprintf(&builder, "Summary: %s\n", result.Summary)
+	}
+	appendMergeBackList(&builder, "Changes made", result.ChangesMade)
+	appendMergeBackList(&builder, "Tests run", result.TestsRun)
+	appendMergeBackList(&builder, "Needs", result.Needs)
+	builder.WriteString("\nAcknowledge the summary and keep any follow-up concise.")
+	return builder.String()
+}
+
+func appendMergeBackList(builder *strings.Builder, label string, values []string) {
+	values = compactMergeBackStrings(values)
+	if len(values) == 0 {
+		return
+	}
+	fmt.Fprintf(builder, "%s:\n", label)
+	for _, value := range values {
+		fmt.Fprintf(builder, "- %s\n", value)
+	}
+}
+
+func compactMergeBackStrings(values []string) []string {
+	out := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func (w jobWorker) startTempWorker(ctx context.Context, job db.Job, payload workflow.JobPayload, original runtime.Agent, checkout string) (tempWorkerStartResult, error) {
+	idleTimeout := 20 * time.Minute
+	jobTimeout := daemonRunningJobStaleAfter
+	if managed, err := w.managedJobConfig(ctx, original.Name); err == nil && managed.OK {
+		idleTimeout = managed.IdleTimeout
+		jobTimeout = managed.JobTimeout
+	} else if err != nil {
+		return tempWorkerStartResult{}, err
+	}
+	tempAgent := original
+	tempAgent.Name = tempWorkerInstanceName(original.Name, job.ID)
+	tempAgent.RuntimeRef = ""
+	var cachedTemplate db.AgentTemplate
+	if tempAgent.TemplateID != "" {
+		var err error
+		cachedTemplate, err = loadInstalledTemplate(ctx, w.Store, tempAgent.TemplateID)
+		if err != nil {
+			return tempWorkerStartResult{}, err
+		}
+	}
+	now := time.Now().UTC()
+	reserved := db.AgentInstance{
+		Name:           tempAgent.Name,
+		Type:           tempWorkerAgentType(original.Name),
+		Runtime:        tempAgent.Runtime,
+		RuntimeRef:     "starting:" + tempAgent.Name,
+		RepoFullName:   payload.Repo,
+		Role:           tempAgent.Role,
+		TemplateID:     tempAgent.TemplateID,
+		Capabilities:   tempAgent.Capabilities,
+		AutonomyPolicy: tempAgent.AutonomyPolicy,
+		State:          "starting",
+		CreatedAt:      formatManagedAgentTime(now),
+		LastUsedAt:     formatManagedAgentTime(now),
+		ExpiresAt:      formatManagedAgentTime(now.Add(jobTimeout)),
+	}
+	if err := w.Store.UpsertAgentInstance(ctx, reserved); err != nil {
+		return tempWorkerStartResult{}, err
+	}
+	adapter, err := w.StartAdapterFactory(tempAgent.Runtime, checkout)
+	if err != nil {
+		_ = w.Store.DeleteAgentInstance(context.Background(), reserved.Name)
+		return tempWorkerStartResult{}, err
+	}
+	started, err := adapter.Start(ctx, runtime.StartRequest{Agent: tempAgent, Prompt: agentStartupPrompt(tempAgent, cachedTemplate)})
+	if err != nil {
+		_ = w.Store.DeleteAgentInstance(context.Background(), reserved.Name)
+		return tempWorkerStartResult{}, err
+	}
+	tempAgent.RuntimeRef = strings.TrimSpace(started.RuntimeRef)
+	if err := runtime.ValidateAgent(tempAgent); err != nil {
+		_ = w.Store.DeleteAgentInstance(context.Background(), reserved.Name)
+		return tempWorkerStartResult{}, err
+	}
+	instance := reserved
+	instance.RuntimeRef = tempAgent.RuntimeRef
+	instance.State = "idle"
+	if err := w.Store.UpsertAgentInstance(ctx, instance); err != nil {
+		_ = w.Store.DeleteAgentInstance(context.Background(), reserved.Name)
+		return tempWorkerStartResult{}, err
+	}
+	return tempWorkerStartResult{Agent: tempAgent, IdleTimeout: idleTimeout, JobTimeout: jobTimeout}, nil
+}
+
+func (w jobWorker) cleanupTempWorker(ctx context.Context, agentName string) {
+	if err := w.Store.DeleteAgentInstance(ctx, agentName); err != nil {
+		writeLine(w.Stdout, "temp worker %s instance cleanup failed: %v", agentName, err)
+	}
+	if removed, err := w.Store.RemoveAgent(ctx, agentName); err != nil {
+		writeLine(w.Stdout, "temp worker %s agent cleanup failed: %v", agentName, err)
+	} else if removed {
+		writeLine(w.Stdout, "temp worker %s agent cleanup removed regular agent row", agentName)
+	}
+}
+
+func tempWorkerInstanceName(agentName string, jobID string) string {
+	base := strings.Trim(strings.ToLower(agentName), "-_ ")
+	if base == "" {
+		base = "agent"
+	}
+	job := strings.Trim(strings.ToLower(jobID), "-_ ")
+	if job == "" {
+		job = strconv.FormatInt(time.Now().UTC().UnixNano(), 16)
+	}
+	name := base + "-temp-" + job
+	var builder strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r)
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '-' || r == '_':
+			builder.WriteRune(r)
+		default:
+			builder.WriteRune('-')
+		}
+	}
+	return strings.Trim(builder.String(), "-_")
+}
+
 type managedJobRuntimeConfig struct {
 	OK          bool
 	JobTimeout  time.Duration
@@ -1635,29 +2095,48 @@ func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (mana
 	if err != nil {
 		return managedJobRuntimeConfig{}, err
 	}
+	configType := instance.Type
+	if original := originalAgentForTempWorkerType(instance.Type); original != "" {
+		originalInstance, err := w.Store.GetAgentInstance(ctx, original)
+		if errors.Is(err, sql.ErrNoRows) {
+			return managedJobRuntimeConfig{}, nil
+		}
+		if err != nil {
+			return managedJobRuntimeConfig{}, err
+		}
+		configType = originalInstance.Type
+	}
 	types, err := loadAgentTypeConfig(w.ConfigHome)
 	if err != nil {
 		return managedJobRuntimeConfig{}, err
 	}
-	agentType, ok := types[instance.Type]
+	agentType, ok := types[configType]
 	if !ok {
-		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %q not found for managed instance %s", instance.Type, agentName)
+		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %q not found for managed instance %s", configType, agentName)
 	}
 	jobTimeout, err := time.ParseDuration(agentType.JobTimeout)
 	if err != nil {
-		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s job_timeout: %w", instance.Type, err)
+		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s job_timeout: %w", configType, err)
 	}
 	if jobTimeout <= 0 {
-		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s job_timeout must be positive", instance.Type)
+		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s job_timeout must be positive", configType)
 	}
 	idleTimeout, err := time.ParseDuration(agentType.IdleTimeout)
 	if err != nil {
-		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s idle_timeout: %w", instance.Type, err)
+		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s idle_timeout: %w", configType, err)
 	}
 	if idleTimeout <= 0 {
-		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s idle_timeout must be positive", instance.Type)
+		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s idle_timeout must be positive", configType)
 	}
 	return managedJobRuntimeConfig{OK: true, JobTimeout: jobTimeout, IdleTimeout: idleTimeout}, nil
+}
+
+func originalAgentForTempWorkerType(typ string) string {
+	original, ok := strings.CutPrefix(strings.TrimSpace(typ), "temp:")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(original)
 }
 
 func (w jobWorker) runningJobContext(ctx context.Context, jobID string) (context.Context, func()) {
@@ -1808,6 +2287,10 @@ func (w jobWorker) defaultAdapter(agent runtime.Agent, checkout string) (workflo
 	}
 }
 
+func (w jobWorker) defaultStartAdapter(runtimeName string, checkout string) (runtime.Adapter, error) {
+	return runtimeStartAdapter(newRuntimeFactory(), runtimeName, checkout)
+}
+
 func (w jobWorker) defaultWorkflow(checkout string) workflow.Engine {
 	return daemonWorkflowEngine(w.Store, github.NewClient(checkout), checkout)
 }
@@ -1932,7 +2415,7 @@ func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload work
 		if err := w.validateTargetCheckout(ctx, payload, checkout); err != nil {
 			return "", err
 		}
-		if err := w.validateImplementationLock(ctx, payload, agent); err != nil {
+		if err := w.validateImplementationLock(ctx, payload, implementationLockOwner(agent, payload)); err != nil {
 			return "", err
 		}
 	case "review":
@@ -2048,13 +2531,20 @@ func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.
 	return nil
 }
 
-func (w jobWorker) validateImplementationLock(ctx context.Context, payload workflow.JobPayload, agent runtime.Agent) error {
+func implementationLockOwner(agent runtime.Agent, payload workflow.JobPayload) string {
+	if payload.DelegationReason == "runtime_session_busy" && payload.DelegatedAgent == agent.Name && strings.TrimSpace(payload.OriginalAgent) != "" {
+		return payload.OriginalAgent
+	}
+	return agent.Name
+}
+
+func (w jobWorker) validateImplementationLock(ctx context.Context, payload workflow.JobPayload, owner string) error {
 	lock, err := w.Store.GetBranchLock(ctx, payload.Repo, payload.Branch)
 	if err != nil {
 		return err
 	}
-	if lock.Owner != agent.Name {
-		return fmt.Errorf("branch %s is locked by %s, not %s", payload.Branch, lock.Owner, agent.Name)
+	if lock.Owner != owner {
+		return fmt.Errorf("branch %s is locked by %s, not %s", payload.Branch, lock.Owner, owner)
 	}
 	return nil
 }

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -1503,6 +1503,15 @@ func TestRunQueuedJobsAllowsDifferentRuntimeSessionsAcrossRepos(t *testing.T) {
 func TestRunQueuedJobsLeavesBusyRuntimeSessionQueued(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	content := strings.Replace(config.DefaultConfig(paths), `same_session = "fork_temp_session"`, `same_session = "queue"`, 1)
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile config returned error: %v", err)
+	}
 	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
 	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
@@ -1517,7 +1526,7 @@ func TestRunQueuedJobsLeavesBusyRuntimeSessionQueued(t *testing.T) {
 	adapter := &cliWorkerFakeAdapter{
 		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
 	}
-	worker := defaultJobWorker(store, io.Discard)
+	worker := defaultJobWorker(store, io.Discard, home)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		return t.TempDir(), nil
 	}
@@ -1545,6 +1554,396 @@ func TestRunQueuedJobsLeavesBusyRuntimeSessionQueued(t *testing.T) {
 	}
 	if !daemonWorkerHasEvent(events, "runtime_lock_wait") {
 		t.Fatalf("events = %+v, want runtime_lock_wait", events)
+	}
+}
+
+func TestRunQueuedJobsDelegatesBusyRuntimeToTempWorker(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskReviewing), Branch: "task-1"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:          "job-a",
+		Agent:       "audit",
+		Action:      "ask",
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 7,
+		HeadSHA:     "abc123",
+		GoalID:      "goal-1",
+		TaskID:      "task-1",
+		TaskTitle:   "Task 1",
+	})
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: "runtime:codex:session-1",
+		OwnerJobID:  "other-job",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	startAdapter := &cliWorkerFakeAdapter{startRuntimeRef: "550e8400-e29b-41d4-a716-446655440111"}
+	tempRuntimeLockKey := "runtime:codex:550e8400-e29b-41d4-a716-446655440111"
+	var lockObservedMu sync.Mutex
+	lockObserved := false
+	deliveryAdapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		onDeliver: func() {
+			if _, err := store.GetResourceLock(ctx, tempRuntimeLockKey); err != nil {
+				t.Errorf("GetResourceLock during temp delivery returned error: %v", err)
+				return
+			}
+			lockObservedMu.Lock()
+			lockObserved = true
+			lockObservedMu.Unlock()
+		},
+	}
+	startCheckouts := []string{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.StartAdapterFactory = func(_ string, path string) (runtime.Adapter, error) {
+		startCheckouts = append(startCheckouts, path)
+		return startAdapter, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return deliveryAdapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded", job.State)
+	}
+	if job.Agent == "audit" || !strings.HasPrefix(job.Agent, "audit-temp-job-a") {
+		t.Fatalf("job agent = %q, want temp worker", job.Agent)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if payload.OriginalAgent != "audit" || payload.DelegatedAgent != job.Agent || payload.DelegationReason != "runtime_session_busy" {
+		t.Fatalf("delegation payload = %+v, job agent=%s", payload, job.Agent)
+	}
+	if startAdapter.startCalls != 1 || deliveryAdapter.calls != 1 {
+		t.Fatalf("start calls=%d delivery calls=%d, want 1 each", startAdapter.startCalls, deliveryAdapter.calls)
+	}
+	lockObservedMu.Lock()
+	observed := lockObserved
+	lockObservedMu.Unlock()
+	if !observed {
+		t.Fatal("temp worker delivery did not observe runtime session lock")
+	}
+	if _, err := store.GetResourceLock(ctx, tempRuntimeLockKey); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetResourceLock after temp delivery returned error %v, want no rows", err)
+	}
+	if len(startCheckouts) != 1 || startCheckouts[0] != checkout {
+		t.Fatalf("start checkouts = %+v, want %q", startCheckouts, checkout)
+	}
+	instance, err := store.GetAgentInstance(ctx, job.Agent)
+	if err != nil {
+		t.Fatalf("GetAgentInstance returned error: %v", err)
+	}
+	if instance.Type != tempWorkerAgentType("audit") || instance.RuntimeRef != "550e8400-e29b-41d4-a716-446655440111" {
+		t.Fatalf("temp instance = %+v", instance)
+	}
+	agents, err := store.ListAgents(ctx)
+	if err != nil {
+		t.Fatalf("ListAgents returned error: %v", err)
+	}
+	for _, agent := range agents {
+		if agent.Name == job.Agent {
+			t.Fatalf("temp worker %q was persisted as regular agent: %+v", job.Agent, agents)
+		}
+	}
+	events, err := store.ListJobEvents(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	for _, want := range []string{"temp_worker_eligible", "temp_worker_delegated", "temp_worker_merge_back_queued"} {
+		if !daemonWorkerHasEvent(events, want) {
+			t.Fatalf("events = %+v, want %s", events, want)
+		}
+	}
+	mergeBack, err := store.GetJob(ctx, "job-a-merge-back")
+	if err != nil {
+		t.Fatalf("GetJob merge-back returned error: %v", err)
+	}
+	if mergeBack.Agent != "audit" || mergeBack.Type != "ask" || mergeBack.State != string(workflow.JobQueued) {
+		t.Fatalf("merge-back job = %+v, want queued ask for original agent", mergeBack)
+	}
+	mergePayload, err := daemonJobPayload(mergeBack)
+	if err != nil {
+		t.Fatalf("daemonJobPayload merge-back returned error: %v", err)
+	}
+	if mergePayload.Sender != job.Agent || !strings.Contains(mergePayload.Instructions, "Temporary worker") || !strings.Contains(mergePayload.Instructions, "completed job job-a") {
+		t.Fatalf("merge-back payload = %+v", mergePayload)
+	}
+	if mergePayload.Branch != "task-1" || mergePayload.PullRequest != 0 || mergePayload.HeadSHA != "" {
+		t.Fatalf("merge-back payload checkout fields = %+v, want branch only", mergePayload)
+	}
+	if !strings.Contains(mergePayload.Instructions, "Pull request: #7") || !strings.Contains(mergePayload.Instructions, "Head SHA: abc123") {
+		t.Fatalf("merge-back instructions missing PR context: %q", mergePayload.Instructions)
+	}
+	if mergePayload.OriginalAgent != "audit" || mergePayload.DelegatedAgent != job.Agent || mergePayload.DelegationReason != "temp_worker_merge_back" {
+		t.Fatalf("merge-back delegation payload = %+v, completed job agent=%s", mergePayload, job.Agent)
+	}
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs merge-back returned error: %v", err)
+	}
+	mergeBack, err = store.GetJob(ctx, "job-a-merge-back")
+	if err != nil {
+		t.Fatalf("GetJob merge-back after retry returned error: %v", err)
+	}
+	if mergeBack.State != string(workflow.JobQueued) {
+		t.Fatalf("merge-back state after busy original runtime = %q, want queued", mergeBack.State)
+	}
+	if startAdapter.startCalls != 1 || deliveryAdapter.calls != 1 {
+		t.Fatalf("calls after merge-back retry start=%d delivery=%d, want no recursive temp worker", startAdapter.startCalls, deliveryAdapter.calls)
+	}
+	mergeEvents, err := store.ListJobEvents(ctx, "job-a-merge-back")
+	if err != nil {
+		t.Fatalf("ListJobEvents merge-back returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(mergeEvents, "runtime_lock_wait") {
+		t.Fatalf("merge-back events = %+v, want runtime_lock_wait", mergeEvents)
+	}
+}
+
+func TestRunQueuedJobsResumesDelegatedTempWorkerAfterRestart(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := config.SaveAgentType(paths, config.AgentType{
+		Name:           "planner",
+		Runtime:        runtime.CodexRuntime,
+		Role:           "planner",
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: runtime.AutonomyPolicyAuto,
+		IdleTimeout:    "17m",
+		JobTimeout:     "3m",
+	}); err != nil {
+		t.Fatalf("SaveAgentType returned error: %v", err)
+	}
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo")
+	now := time.Now().UTC()
+	if err := store.UpsertAgentInstance(ctx, db.AgentInstance{
+		Name:           "audit",
+		Type:           "planner",
+		Runtime:        runtime.CodexRuntime,
+		RuntimeRef:     "session-1",
+		RepoFullName:   "owner/repo",
+		Role:           "planner",
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: runtime.AutonomyPolicyAuto,
+		State:          "running",
+		CreatedAt:      now.Format(time.RFC3339Nano),
+		LastUsedAt:     now.Format(time.RFC3339Nano),
+		ExpiresAt:      now.Add(time.Hour).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("UpsertAgentInstance original returned error: %v", err)
+	}
+	if err := store.UpsertAgentInstance(ctx, db.AgentInstance{
+		Name:           "audit-temp-job-a",
+		Type:           tempWorkerAgentType("audit"),
+		Runtime:        runtime.CodexRuntime,
+		RuntimeRef:     "550e8400-e29b-41d4-a716-446655440333",
+		RepoFullName:   "owner/repo",
+		Role:           "planner",
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: runtime.AutonomyPolicyAuto,
+		State:          "idle",
+		CreatedAt:      now.Format(time.RFC3339Nano),
+		LastUsedAt:     now.Format(time.RFC3339Nano),
+		ExpiresAt:      now.Add(time.Hour).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("UpsertAgentInstance temp returned error: %v", err)
+	}
+	if _, err := store.GetAgent(ctx, "audit-temp-job-a"); err != nil {
+		t.Fatalf("GetAgent temp instance fallback returned error: %v", err)
+	}
+	agents, err := store.ListAgents(ctx)
+	if err != nil {
+		t.Fatalf("ListAgents returned error: %v", err)
+	}
+	for _, agent := range agents {
+		if agent.Name == "audit-temp-job-a" {
+			t.Fatalf("temp worker %q was persisted as regular agent: %+v", agent.Name, agents)
+		}
+	}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:             "owner/repo",
+		Branch:           "main",
+		Sender:           "tester",
+		Instructions:     "continue",
+		OriginalAgent:    "audit",
+		DelegatedAgent:   "audit-temp-job-a",
+		DelegationReason: "runtime_session_busy",
+	})
+	if err != nil {
+		t.Fatalf("Marshal payload returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-a", Agent: "audit-temp-job-a", Type: "ask", State: string(workflow.JobQueued), Payload: string(payload)}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "queued"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	deliveryAdapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"resumed","findings":[],"changes_made":[],"tests_run":["go test"],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return deliveryAdapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded", job.State)
+	}
+	instance, err := store.GetAgentInstance(ctx, "audit-temp-job-a")
+	if err != nil {
+		t.Fatalf("GetAgentInstance returned error: %v", err)
+	}
+	if instance.State != "idle" {
+		t.Fatalf("temp instance state = %q, want idle", instance.State)
+	}
+}
+
+func TestRunQueuedJobsReturnsTempWorkerIdleAfterDeliveryError(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main"})
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: "runtime:codex:session-1",
+		OwnerJobID:  "other-job",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	startAdapter := &cliWorkerFakeAdapter{startRuntimeRef: "550e8400-e29b-41d4-a716-446655440222"}
+	deliveryAdapter := &cliWorkerFakeAdapter{err: errors.New("delivery failed")}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.StartAdapterFactory = func(string, string) (runtime.Adapter, error) {
+		return startAdapter, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return deliveryAdapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+	instance, err := store.GetAgentInstance(ctx, job.Agent)
+	if err != nil {
+		t.Fatalf("GetAgentInstance returned error: %v", err)
+	}
+	if instance.State != "idle" {
+		t.Fatalf("temp instance state = %q, want idle", instance.State)
+	}
+}
+
+func TestRunQueuedJobsCleansTempWorkerWhenDelegationRaceLoses(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main"})
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: "runtime:codex:session-1",
+		OwnerJobID:  "other-job",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	startAdapter := &cliWorkerFakeAdapter{
+		startRuntimeRef: "550e8400-e29b-41d4-a716-446655440444",
+		onStart: func() {
+			if _, err := workflow.CancelJob(ctx, store, "job-a"); err != nil {
+				t.Fatalf("CancelJob returned error: %v", err)
+			}
+		},
+	}
+	deliveryAdapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.StartAdapterFactory = func(string, string) (runtime.Adapter, error) {
+		return startAdapter, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return deliveryAdapter, nil
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+	if _, err := store.GetAgentInstance(ctx, "audit-temp-job-a"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetAgentInstance temp error = %v, want no rows", err)
+	}
+	if _, err := store.GetAgent(ctx, "audit-temp-job-a"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetAgent temp error = %v, want no rows", err)
 	}
 }
 
@@ -1839,6 +2238,76 @@ func TestRunQueuedJobsUsesTaskWorktreeForImplement(t *testing.T) {
 	}
 }
 
+func TestRunQueuedJobsResumesDelegatedImplementWithOriginalBranchLock(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	worktree := filepath.Join(t.TempDir(), "task-1")
+	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-1", worktree, "main")
+	head, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "lead-temp-job-implement", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:               "job-implement",
+		Agent:            "lead-temp-job-implement",
+		Action:           "implement",
+		Repo:             "owner/repo",
+		Branch:           "task-1",
+		HeadSHA:          head,
+		GoalID:           "goal-1",
+		TaskID:           "task-1",
+		TaskTitle:        "Task 1",
+		LeadAgent:        "lead",
+		OriginalAgent:    "lead",
+		DelegatedAgent:   "lead-temp-job-implement",
+		DelegationReason: "runtime_session_busy",
+	})
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"implemented","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	adapterCheckout := ""
+	worker.AdapterFactory = func(_ runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
+		adapterCheckout = checkout
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(checkout string) workflow.Engine {
+		return workflow.Engine{
+			Store: store,
+			PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
+				return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
+			},
+		}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-implement")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded", job.State)
+	}
+	wantCheckout := filepath.Clean(worktree)
+	if adapterCheckout != wantCheckout {
+		t.Fatalf("adapter checkout = %q, want %q", adapterCheckout, wantCheckout)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+}
+
 func TestRunQueuedJobsUsesTaskWorktreeForReview(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -2006,6 +2475,228 @@ func TestSelectRunnableQueuedJobsKeepsSameRuntimeSerializedAcrossWorktrees(t *te
 
 	if len(selected) != 1 || len(remaining) != 1 {
 		t.Fatalf("selected=%d remaining=%d, want same runtime session serialized", len(selected), len(remaining))
+	}
+}
+
+func TestSelectRunnableQueuedJobsAllowsForkEligibleSameRuntime(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgentWithPolicy(t, store, "lead-a", runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+	seedDaemonWorkerAgentWithPolicy(t, store, "lead-b", runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+	worktreeA := t.TempDir()
+	worktreeB := t.TempDir()
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-a", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: "task-a", WorktreePath: worktreeA}); err != nil {
+		t.Fatalf("UpsertTask task-a returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-b", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: "task-b", WorktreePath: worktreeB}); err != nil {
+		t.Fatalf("UpsertTask task-b returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "lead-a", Action: "implement", Repo: "owner/repo", Branch: "task-a", TaskID: "task-a"})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "lead-b", Action: "implement", Repo: "owner/repo", Branch: "task-b", TaskID: "task-b"})
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+
+	selected, remaining := selectRunnableQueuedJobsWithPolicy(ctx, store, jobs, 2, config.DefaultParallelSessionPolicy())
+
+	if len(selected) != 2 || len(remaining) != 0 {
+		t.Fatalf("selected=%d remaining=%d, want fork-eligible same runtime selected", len(selected), len(remaining))
+	}
+}
+
+func TestSelectRunnableQueuedJobsCountsExternallyBusyRuntimeAgainstTempCap(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+	worktreeA := t.TempDir()
+	worktreeB := t.TempDir()
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-a", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: "task-a", WorktreePath: worktreeA}); err != nil {
+		t.Fatalf("UpsertTask task-a returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-b", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: "task-b", WorktreePath: worktreeB}); err != nil {
+		t.Fatalf("UpsertTask task-b returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-a", TaskID: "task-a"})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-b", TaskID: "task-b"})
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: "runtime:codex:session-1",
+		OwnerJobID:  "other-job",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+	policy := config.DefaultParallelSessionPolicy()
+	policy.MaxTempSessionsPerAgent = 1
+
+	selected, remaining := selectRunnableQueuedJobsWithPolicy(ctx, store, jobs, 2, policy)
+
+	if len(selected) != 1 || len(remaining) != 1 {
+		t.Fatalf("selected=%d remaining=%d, want external busy runtime counted against temp cap", len(selected), len(remaining))
+	}
+}
+
+func TestTempWorkerEligibleAllowsWritableImplementWithTaskWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worktree := t.TempDir()
+	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-a", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: "task-a", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-a", TaskID: "task-a"})
+	job, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+
+	got := tempWorkerEligible(ctx, store, job, payload, runtime.Agent{Name: "lead", Runtime: runtime.CodexRuntime, AutonomyPolicy: runtime.AutonomyPolicyWorkspaceWrite}, config.DefaultParallelSessionPolicy(), time.Now().UTC())
+
+	if !got.Eligible {
+		t.Fatalf("tempWorkerEligible = %+v, want eligible", got)
+	}
+}
+
+func TestTempWorkerEligibleRejectsQueuePolicy(t *testing.T) {
+	policy := config.DefaultParallelSessionPolicy()
+	policy.SameSession = config.ParallelSessionQueue
+
+	got := tempWorkerEligible(context.Background(), nil, db.Job{ID: "job-a", Type: "ask"}, workflow.JobPayload{}, runtime.Agent{Name: "lead", Runtime: runtime.CodexRuntime}, policy, time.Now().UTC())
+
+	if got.Eligible || !strings.Contains(got.Reason, "same_session is queue") {
+		t.Fatalf("tempWorkerEligible = %+v, want queue policy rejection", got)
+	}
+}
+
+func TestTempWorkerEligibleRejectsAlreadyDelegatedJob(t *testing.T) {
+	got := tempWorkerEligible(context.Background(), nil, db.Job{ID: "job-a", Type: "ask"}, workflow.JobPayload{DelegationReason: "runtime_session_busy"}, runtime.Agent{Name: "lead-temp-job-a", Runtime: runtime.CodexRuntime}, config.DefaultParallelSessionPolicy(), time.Now().UTC())
+
+	if got.Eligible || !strings.Contains(got.Reason, "delegated temp worker waits") {
+		t.Fatalf("tempWorkerEligible = %+v, want delegated job rejection", got)
+	}
+}
+
+func TestJobWorkerParallelSessionPolicyUsesDefaultWhenHomeNotExplicit(t *testing.T) {
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard)
+
+	got, err := worker.parallelSessionPolicy()
+	if err != nil {
+		t.Fatalf("parallelSessionPolicy returned error: %v", err)
+	}
+
+	if got.SameSession != config.ParallelSessionForkTempSession {
+		t.Fatalf("same_session = %q, want default fork_temp_session", got.SameSession)
+	}
+}
+
+func TestJobWorkerParallelSessionPolicyLoadsExplicitHome(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	content := strings.Replace(config.DefaultConfig(paths), `same_session = "fork_temp_session"`, `same_session = "queue"`, 1)
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile config returned error: %v", err)
+	}
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
+
+	got, err := worker.parallelSessionPolicy()
+	if err != nil {
+		t.Fatalf("parallelSessionPolicy returned error: %v", err)
+	}
+
+	if got.SameSession != config.ParallelSessionQueue {
+		t.Fatalf("same_session = %q, want explicit queue config", got.SameSession)
+	}
+}
+
+func TestTempWorkerEligibleRejectsReadOnlyImplementation(t *testing.T) {
+	got := tempWorkerEligible(context.Background(), nil, db.Job{ID: "job-a", Type: "implement"}, workflow.JobPayload{}, runtime.Agent{Name: "lead", Runtime: runtime.CodexRuntime, AutonomyPolicy: runtime.AutonomyPolicyReadOnly}, config.DefaultParallelSessionPolicy(), time.Now().UTC())
+
+	if got.Eligible || !strings.Contains(got.Reason, "writable agent policy") {
+		t.Fatalf("tempWorkerEligible = %+v, want read-only implementation rejection", got)
+	}
+}
+
+func TestTempWorkerEligibleRejectsImplementationWithoutTaskWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+
+	got := tempWorkerEligible(ctx, store, db.Job{ID: "job-a", Type: "implement"}, workflow.JobPayload{Repo: "owner/repo", TaskID: "task-a"}, runtime.Agent{Name: "lead", Runtime: runtime.CodexRuntime, AutonomyPolicy: runtime.AutonomyPolicyWorkspaceWrite}, config.DefaultParallelSessionPolicy(), time.Now().UTC())
+
+	if got.Eligible || !strings.Contains(got.Reason, "task worktree") {
+		t.Fatalf("tempWorkerEligible = %+v, want missing worktree rejection", got)
+	}
+}
+
+func TestTempWorkerEligibleRejectsMaxTempWorkers(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	now := time.Now().UTC()
+	for i := 0; i < 4; i++ {
+		if err := store.UpsertAgentInstance(ctx, db.AgentInstance{
+			Name:           fmt.Sprintf("lead-temp-%d", i),
+			Type:           tempWorkerAgentType("lead"),
+			Runtime:        runtime.CodexRuntime,
+			RuntimeRef:     fmt.Sprintf("session-%d", i),
+			RepoFullName:   "owner/repo",
+			Role:           "worker",
+			AutonomyPolicy: runtime.AutonomyPolicyAuto,
+			State:          "idle",
+			CreatedAt:      now.Format(time.RFC3339),
+			LastUsedAt:     now.Format(time.RFC3339),
+			ExpiresAt:      now.Add(time.Hour).Format(time.RFC3339),
+		}); err != nil {
+			t.Fatalf("UpsertAgentInstance %d returned error: %v", i, err)
+		}
+	}
+
+	got := tempWorkerEligible(ctx, store, db.Job{ID: "job-a", Type: "ask"}, workflow.JobPayload{}, runtime.Agent{Name: "lead", Runtime: runtime.CodexRuntime, AutonomyPolicy: runtime.AutonomyPolicyAuto}, config.DefaultParallelSessionPolicy(), now)
+
+	if got.Eligible || !strings.Contains(got.Reason, "max temp workers reached") {
+		t.Fatalf("tempWorkerEligible = %+v, want cap rejection", got)
+	}
+}
+
+func TestDaemonReviewersIgnoresTempWorkerInstances(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"review"}, "owner/repo")
+	now := time.Now().UTC()
+	if err := store.UpsertAgentInstance(ctx, db.AgentInstance{
+		Name:           "audit-temp-job-a",
+		Type:           tempWorkerAgentType("audit"),
+		Runtime:        runtime.CodexRuntime,
+		RuntimeRef:     "550e8400-e29b-41d4-a716-446655440555",
+		RepoFullName:   "owner/repo",
+		Role:           "reviewer",
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: runtime.AutonomyPolicyAuto,
+		State:          "idle",
+		CreatedAt:      now.Format(time.RFC3339),
+		LastUsedAt:     now.Format(time.RFC3339),
+		ExpiresAt:      now.Add(time.Hour).Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("UpsertAgentInstance returned error: %v", err)
+	}
+
+	reviewers, err := daemonReviewers(ctx, store, "owner/repo")
+	if err != nil {
+		t.Fatalf("daemonReviewers returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(reviewers, []string{"audit"}) {
+		t.Fatalf("reviewers = %+v, want only regular configured reviewer", reviewers)
 	}
 }
 
@@ -2866,11 +3557,42 @@ type cliWorkerFakeAdapter struct {
 	mu                   sync.Mutex
 	output               string
 	err                  error
+	startRuntimeRef      string
+	startErr             error
+	startCalls           int
+	startCheckouts       []string
 	calls                int
 	delivered            []string
+	onStart              func()
 	onDeliver            func()
 	waitForContextCancel bool
 	contextCancelled     bool
+}
+
+func (f *cliWorkerFakeAdapter) Name() string {
+	return "fake"
+}
+
+func (f *cliWorkerFakeAdapter) Start(_ context.Context, _ runtime.StartRequest) (runtime.StartResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startCalls++
+	if f.startErr != nil {
+		return runtime.StartResult{}, f.startErr
+	}
+	onStart := f.onStart
+	ref := strings.TrimSpace(f.startRuntimeRef)
+	if ref == "" {
+		ref = "550e8400-e29b-41d4-a716-446655440000"
+	}
+	if onStart != nil {
+		onStart()
+	}
+	return runtime.StartResult{RuntimeRef: ref}, nil
+}
+
+func (f *cliWorkerFakeAdapter) Validate(context.Context, runtime.Agent) error {
+	return nil
 }
 
 func (f *cliWorkerFakeAdapter) Deliver(ctx context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
@@ -2894,6 +3616,14 @@ func (f *cliWorkerFakeAdapter) Deliver(ctx context.Context, _ runtime.Agent, job
 		return runtime.Result{}, f.err
 	}
 	return runtime.Result{Raw: f.output}, nil
+}
+
+func (f *cliWorkerFakeAdapter) Health(context.Context, runtime.Agent) error {
+	return nil
+}
+
+func (f *cliWorkerFakeAdapter) Capabilities(context.Context) ([]string, error) {
+	return nil, nil
 }
 
 func (f *cliWorkerFakeAdapter) observedContextCancel() bool {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -506,11 +506,17 @@ func taskRunImplementJobRequest(jobID string, task db.Task, owner string, headSH
 }
 
 func taskRunJobMatchesRequest(job db.Job, request workflow.JobRequest) bool {
-	if job.Agent != request.Agent || job.Type != request.Action {
+	if job.Type != request.Action {
 		return false
 	}
 	payload, err := daemonJobPayload(job)
 	if err != nil {
+		return false
+	}
+	if job.Agent != request.Agent &&
+		!(payload.DelegationReason == "runtime_session_busy" &&
+			payload.DelegatedAgent == job.Agent &&
+			payload.OriginalAgent == request.Agent) {
 		return false
 	}
 	return payload.Repo == request.Repo &&

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
 func TestRunGoalImportAndStatus(t *testing.T) {
@@ -606,6 +607,51 @@ func TestRunTaskRunRegistersCurrentRepo(t *testing.T) {
 	}
 	if !foundFreshQueued {
 		t.Fatalf("jobs = %+v, want fresh queued rerun job", jobs)
+	}
+}
+
+func TestTaskRunJobMatchesDelegatedImplementJob(t *testing.T) {
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:             "jerryfane/gitmoot",
+		Branch:           "task-001-bootstrap",
+		HeadSHA:          "head123",
+		GoalID:           "goal-1",
+		TaskID:           "task-001",
+		TaskTitle:        "Bootstrap",
+		LeadAgent:        "lead",
+		Sender:           "task run",
+		Instructions:     "Implement task task-001: Bootstrap.",
+		OriginalAgent:    "lead",
+		DelegatedAgent:   "lead-temp-task-001",
+		DelegationReason: "runtime_session_busy",
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	job := db.Job{
+		ID:      "task-task-001-implement-lead",
+		Agent:   "lead-temp-task-001",
+		Type:    "implement",
+		State:   string(workflow.JobQueued),
+		Payload: string(payload),
+	}
+	request := workflow.JobRequest{
+		ID:           "task-task-001-implement-lead",
+		Agent:        "lead",
+		Action:       "implement",
+		Repo:         "jerryfane/gitmoot",
+		Branch:       "task-001-bootstrap",
+		HeadSHA:      "head123",
+		GoalID:       "goal-1",
+		TaskID:       "task-001",
+		TaskTitle:    "Bootstrap",
+		LeadAgent:    "lead",
+		Sender:       "task run",
+		Instructions: "Implement task task-001: Bootstrap.",
+	}
+
+	if !taskRunJobMatchesRequest(job, request) {
+		t.Fatalf("taskRunJobMatchesRequest returned false for delegated task-run job")
 	}
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1895,6 +1895,34 @@ func (s *Store) TransitionJobStatePayloadWithEvent(ctx context.Context, id strin
 	return true, tx.Commit()
 }
 
+func (s *Store) DelegateQueuedJob(ctx context.Context, id string, fromAgent string, toAgent string, payload string, event JobEvent) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	result, err := tx.ExecContext(ctx, `UPDATE jobs SET agent = ?, payload = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND agent = ? AND state = ?`,
+		strings.TrimSpace(toAgent), payload, id, strings.TrimSpace(fromAgent), "queued")
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		return false, tx.Commit()
+	}
+	if event.JobID == "" {
+		event.JobID = id
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
+		return false, err
+	}
+	return true, tx.Commit()
+}
+
 func (s *Store) UpdateJobPayload(ctx context.Context, id string, payload string) error {
 	result, err := s.db.ExecContext(ctx, `UPDATE jobs SET payload = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, payload, id)
 	if err != nil {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -179,12 +179,7 @@ func (e Engine) RunJob(ctx context.Context, jobID string, agent runtime.Agent, a
 	if err != nil {
 		return AgentResult{}, err
 	}
-	if err := e.ensureAgentAllowed(ctx, JobRequest{
-		Agent:  job.Agent,
-		Action: job.Type,
-		Repo:   payload.Repo,
-		Branch: payload.Branch,
-	}, taskRefFromPayload(payload)); err != nil {
+	if err := e.ensureJobExecutorAllowed(ctx, job, payload, taskRefFromPayload(payload)); err != nil {
 		return AgentResult{}, err
 	}
 	result, err := (Mailbox{Store: e.Store}).Run(ctx, jobID, agent, adapter)
@@ -270,6 +265,11 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 		leadAgent := strings.TrimSpace(payload.LeadAgent)
 		if leadAgent == "" {
 			leadAgent = job.Agent
+			if payload.DelegationReason == "runtime_session_busy" &&
+				payload.DelegatedAgent == job.Agent &&
+				strings.TrimSpace(payload.OriginalAgent) != "" {
+				leadAgent = payload.OriginalAgent
+			}
 		}
 		event := PullRequestEvent{
 			Repo:              payload.Repo,
@@ -285,25 +285,36 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 		}
 		return e.HandlePullRequestOpened(ctx, event)
 	case "review":
+		reviewer := reviewDecisionAgent(job, payload)
 		switch payload.Result.Decision {
 		case "changes_requested":
 			if err := e.setTaskState(ctx, ref, TaskChangesRequested); err != nil {
 				return err
 			}
-			return e.dispatchFix(ctx, job.Agent, payload, *payload.Result, ref)
+			return e.dispatchFix(ctx, reviewer, payload, *payload.Result, ref)
 		case "approved":
-			ready, err := e.allRequiredReviewersApproved(ctx, job.Agent, payload)
+			ready, err := e.allRequiredReviewersApproved(ctx, reviewer, payload)
 			if err != nil {
 				return err
 			}
 			if !ready {
 				return e.setReviewingIfNotChangesRequested(ctx, ref)
 			}
-			_, err = e.runMergeGate(ctx, job.Agent, payload, ref)
+			_, err = e.runMergeGate(ctx, reviewer, payload, ref)
 			return err
 		}
 	}
 	return nil
+}
+
+func reviewDecisionAgent(job db.Job, payload JobPayload) string {
+	if job.Type == "review" &&
+		payload.DelegationReason == "runtime_session_busy" &&
+		payload.DelegatedAgent == job.Agent &&
+		strings.TrimSpace(payload.OriginalAgent) != "" {
+		return payload.OriginalAgent
+	}
+	return job.Agent
 }
 
 func (e Engine) jobPayload(ctx context.Context, jobID string) (db.Job, JobPayload, error) {
@@ -448,7 +459,7 @@ func (e Engine) allRequiredReviewersApproved(ctx context.Context, currentReviewe
 			continue
 		}
 		if jobPayload.Result.Decision == "approved" {
-			approved[job.Agent] = true
+			approved[reviewDecisionAgent(job, jobPayload)] = true
 		}
 	}
 
@@ -587,14 +598,26 @@ func (e Engine) existingJobMatchesRequest(ctx context.Context, request JobReques
 		}
 		return false, err
 	}
-	if job.Agent != request.Agent || job.Type != request.Action {
+	if job.Type != request.Action {
 		return false, nil
 	}
 	payload, err := unmarshalPayload(job.Payload)
 	if err != nil {
 		return false, err
 	}
+	if !jobMatchesRequestAgent(job, payload, request.Agent) {
+		return false, nil
+	}
 	return payloadMatchesRequest(payload, request), nil
+}
+
+func jobMatchesRequestAgent(job db.Job, payload JobPayload, requestAgent string) bool {
+	if job.Agent == requestAgent {
+		return true
+	}
+	return payload.DelegationReason == "runtime_session_busy" &&
+		payload.DelegatedAgent == job.Agent &&
+		payload.OriginalAgent == requestAgent
 }
 
 func payloadMatchesRequest(payload JobPayload, request JobRequest) bool {
@@ -609,8 +632,22 @@ func payloadMatchesRequest(payload JobPayload, request JobRequest) bool {
 		payload.ReviewRound == request.ReviewRound &&
 		payload.Sender == request.Sender &&
 		payload.Instructions == request.Instructions &&
+		payloadDelegationMatchesRequest(payload, request) &&
 		equalStrings(payload.Reviewers, compactStrings(request.Reviewers)) &&
 		equalStrings(payload.Constraints, compactStrings(request.Constraints))
+}
+
+func payloadDelegationMatchesRequest(payload JobPayload, request JobRequest) bool {
+	if payload.OriginalAgent == request.OriginalAgent &&
+		payload.DelegatedAgent == request.DelegatedAgent &&
+		payload.DelegationReason == request.DelegationReason {
+		return true
+	}
+	return request.OriginalAgent == "" &&
+		request.DelegatedAgent == "" &&
+		request.DelegationReason == "" &&
+		payload.DelegationReason == "runtime_session_busy" &&
+		payload.OriginalAgent == request.Agent
 }
 
 func equalStrings(left []string, right []string) bool {
@@ -626,6 +663,30 @@ func equalStrings(left []string, right []string) bool {
 }
 
 func (e Engine) ensureAgentAllowed(ctx context.Context, request JobRequest, ref taskRef) error {
+	return e.ensureAgentAllowedWithBranchOwner(ctx, request, request.Agent, ref, false)
+}
+
+func (e Engine) ensureJobExecutorAllowed(ctx context.Context, job db.Job, payload JobPayload, ref taskRef) error {
+	branchOwner := job.Agent
+	authorizationAgent := job.Agent
+	if job.Type == "implement" && payload.DelegationReason == "runtime_session_busy" && payload.DelegatedAgent == job.Agent && strings.TrimSpace(payload.OriginalAgent) != "" {
+		branchOwner = payload.OriginalAgent
+	}
+	if payload.DelegationReason == "runtime_session_busy" && payload.DelegatedAgent == job.Agent && strings.TrimSpace(payload.OriginalAgent) != "" {
+		authorizationAgent = payload.OriginalAgent
+	}
+	allowMissingCapability := job.Type == "ask" &&
+		payload.DelegationReason == "temp_worker_merge_back" &&
+		payload.OriginalAgent == job.Agent
+	return e.ensureAgentAllowedWithBranchOwner(ctx, JobRequest{
+		Agent:  authorizationAgent,
+		Action: job.Type,
+		Repo:   payload.Repo,
+		Branch: payload.Branch,
+	}, branchOwner, ref, allowMissingCapability)
+}
+
+func (e Engine) ensureAgentAllowedWithBranchOwner(ctx context.Context, request JobRequest, branchOwner string, ref taskRef, allowMissingCapability bool) error {
 	agent, err := e.Store.GetAgent(ctx, request.Agent)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -640,11 +701,11 @@ func (e Engine) ensureAgentAllowed(ctx context.Context, request JobRequest, ref 
 	if !allowed {
 		return e.block(ctx, ref, fmt.Sprintf("agent %q is not allowed on %q", agent.Name, request.Repo))
 	}
-	if !contains(agent.Capabilities, request.Action) {
+	if !contains(agent.Capabilities, request.Action) && !allowMissingCapability {
 		return e.block(ctx, ref, fmt.Sprintf("agent %q lacks %q capability", agent.Name, request.Action))
 	}
 	if request.Action == "implement" {
-		if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, request.Agent, ref); err != nil {
+		if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, branchOwner, ref); err != nil {
 			return err
 		}
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -304,6 +304,90 @@ func TestEngineRunJobAdvancesCompletedResult(t *testing.T) {
 	mustJob(t, store, "review-audit-task-7-review-1")
 }
 
+func TestEngineRunJobAllowsDelegatedImplementWithOriginalBranchLock(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	payload, err := marshalPayload(JobPayload{
+		Repo:             "jerryfane/gitmoot",
+		Branch:           "task-7",
+		PullRequest:      7,
+		HeadSHA:          "head123",
+		TaskID:           "task-7",
+		Reviewers:        []string{"audit"},
+		OriginalAgent:    "lead",
+		DelegatedAgent:   "lead-temp-job-1",
+		DelegationReason: "runtime_session_busy",
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: "job-1", Agent: "lead-temp-job-1", Type: "implement", State: string(JobQueued), Payload: payload}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	engine := testEngine(store)
+	agent := runtime.Agent{Name: "lead-temp-job-1", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "lead"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}}
+
+	if _, err := engine.RunJob(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("RunJob returned error: %v", err)
+	}
+
+	job := mustJob(t, store, "job-1")
+	if job.State != string(JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded", job.State)
+	}
+	lock, err := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-7")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.Owner != "lead" {
+		t.Fatalf("branch lock owner = %q, want original lead", lock.Owner)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+	mustJob(t, store, "review-audit-task-7-review-1")
+}
+
+func TestEngineRunJobAllowsMergeBackAskForImplementOnlyOriginal(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	payload, err := marshalPayload(JobPayload{
+		Repo:             "jerryfane/gitmoot",
+		Branch:           "task-7",
+		TaskID:           "task-7",
+		OriginalAgent:    "lead",
+		DelegatedAgent:   "lead-temp-job-1",
+		DelegationReason: "temp_worker_merge_back",
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: "job-merge-back", Agent: "lead", Type: "ask", State: string(JobQueued), Payload: payload}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	engine := testEngine(store)
+	agent := runtime.Agent{Name: "lead", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "lead"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"ack","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+	}}
+
+	if _, err := engine.RunJob(ctx, "job-merge-back", agent, adapter); err != nil {
+		t.Fatalf("RunJob returned error: %v", err)
+	}
+
+	job := mustJob(t, store, "job-merge-back")
+	if job.State != string(JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded", job.State)
+	}
+}
+
 func TestEngineRunJobPreflightsPolicyBeforeDelivery(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -485,6 +569,88 @@ func TestEngineAdvanceReviewApprovalRunsMergeGate(t *testing.T) {
 	}
 }
 
+func TestEngineAdvanceDelegatedReviewApprovalUsesOriginalReviewer(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit-temp-job-a",
+		Type:  "review",
+	}, JobPayload{
+		Repo:             "jerryfane/gitmoot",
+		Branch:           "task-7",
+		PullRequest:      7,
+		TaskID:           "task-7",
+		TaskTitle:        "Workflow Engine",
+		Reviewers:        []string{"audit"},
+		OriginalAgent:    "audit",
+		DelegatedAgent:   "audit-temp-job-a",
+		DelegationReason: "runtime_session_busy",
+		Result:           &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-job")
+
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+	if len(gate.requests) != 1 || gate.requests[0].Reviewer != "audit" || gate.requests[0].PullRequest != 7 {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestEngineAdvanceReviewApprovalCountsPriorDelegatedReviewer(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+	reviewers := []string{"audit", "security"}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "audit-review",
+		Agent: "audit-temp-job-a",
+		Type:  "review",
+	}, JobPayload{
+		Repo:             "jerryfane/gitmoot",
+		Branch:           "task-7",
+		PullRequest:      7,
+		TaskID:           "task-7",
+		TaskTitle:        "Workflow Engine",
+		Reviewers:        reviewers,
+		OriginalAgent:    "audit",
+		DelegatedAgent:   "audit-temp-job-a",
+		DelegationReason: "runtime_session_busy",
+		Result:           &AgentResult{Decision: "approved", Summary: "audit ready"},
+	})
+	insertCompletedJob(t, store, db.Job{
+		ID:    "security-review",
+		Agent: "security",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		Reviewers:   reviewers,
+		Result:      &AgentResult{Decision: "approved", Summary: "security ready"},
+	})
+
+	err := engine.AdvanceJob(ctx, "security-review")
+
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+	if len(gate.requests) != 1 || gate.requests[0].Reviewer != "security" {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
 func TestEngineAdvanceReviewApprovalWaitsForAllRequiredReviewers(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -612,6 +778,65 @@ func TestEngineHandlePullRequestOpenedCreatesNewReviewRoundForUpdates(t *testing
 
 	mustJob(t, store, "review-audit-task-7-review-1")
 	mustJob(t, store, "review-audit-task-7-review-2")
+}
+
+func TestEngineHandlePullRequestOpenedIsIdempotentAfterDelegatedReview(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	event := PullRequestEvent{
+		Repo:              "jerryfane/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		HeadSHA:           "head123",
+		TaskID:            "task-7",
+		TaskTitle:         "Workflow Engine",
+		LeadAgent:         "lead",
+		RequiredReviewers: []string{"audit"},
+	}
+
+	if err := engine.HandlePullRequestOpened(ctx, event); err != nil {
+		t.Fatalf("first HandlePullRequestOpened returned error: %v", err)
+	}
+	job := mustJob(t, store, "review-audit-task-7-review-1")
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	payload.OriginalAgent = "audit"
+	payload.DelegatedAgent = "audit-temp-review-1"
+	payload.DelegationReason = "runtime_session_busy"
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	delegated, err := store.DelegateQueuedJob(ctx, job.ID, "audit", "audit-temp-review-1", encoded, db.JobEvent{
+		JobID:   job.ID,
+		Kind:    "temp_worker_delegated",
+		Message: "delegated for replay test",
+	})
+	if err != nil || !delegated {
+		t.Fatalf("DelegateQueuedJob returned delegated=%v err=%v", delegated, err)
+	}
+
+	if err := engine.HandlePullRequestOpened(ctx, event); err != nil {
+		t.Fatalf("second HandlePullRequestOpened returned error: %v", err)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	reviewJobs := 0
+	for _, candidate := range jobs {
+		if candidate.Type == "review" {
+			reviewJobs++
+		}
+	}
+	if reviewJobs != 1 {
+		t.Fatalf("review job count = %d, want 1; jobs=%+v", reviewJobs, jobs)
+	}
 }
 
 func TestEngineHandlePullRequestOpenedPreflightsReviewersBeforeEnqueue(t *testing.T) {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -19,22 +19,25 @@ type Mailbox struct {
 }
 
 type JobRequest struct {
-	ID           string
-	Agent        string
-	Action       string
-	Repo         string
-	Branch       string
-	PullRequest  int
-	HeadSHA      string
-	GoalID       string
-	TaskID       string
-	TaskTitle    string
-	LeadAgent    string
-	Reviewers    []string
-	ReviewRound  string
-	Sender       string
-	Instructions string
-	Constraints  []string
+	ID               string
+	Agent            string
+	Action           string
+	Repo             string
+	Branch           string
+	PullRequest      int
+	HeadSHA          string
+	GoalID           string
+	TaskID           string
+	TaskTitle        string
+	LeadAgent        string
+	Reviewers        []string
+	ReviewRound      string
+	Sender           string
+	Instructions     string
+	Constraints      []string
+	OriginalAgent    string
+	DelegatedAgent   string
+	DelegationReason string
 }
 
 type JobPayload struct {
@@ -54,6 +57,9 @@ type JobPayload struct {
 	TemplateID             string       `json:"template_id,omitempty"`
 	TemplateResolvedCommit string       `json:"template_resolved_commit,omitempty"`
 	TemplateContent        string       `json:"template_content,omitempty"`
+	OriginalAgent          string       `json:"original_agent,omitempty"`
+	DelegatedAgent         string       `json:"delegated_agent,omitempty"`
+	DelegationReason       string       `json:"delegation_reason,omitempty"`
 	RawOutputs             []string     `json:"raw_outputs,omitempty"`
 	Result                 *AgentResult `json:"result,omitempty"`
 }
@@ -92,6 +98,9 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		TemplateID:             snapshot.ID,
 		TemplateResolvedCommit: snapshot.ResolvedCommit,
 		TemplateContent:        snapshot.Content,
+		OriginalAgent:          request.OriginalAgent,
+		DelegatedAgent:         request.DelegatedAgent,
+		DelegationReason:       request.DelegationReason,
 	})
 	if err != nil {
 		return db.Job{}, err


### PR DESCRIPTION
## What
- Routes jobs blocked by a busy Codex/Claude runtime session through bounded temporary worker instances when `parallel_sessions.same_session = "fork_temp_session"`.
- Keeps same checkout/worktree serialization intact while allowing eligible same-runtime work to fork.
- Adds delegation metadata so task-run idempotence, branch-lock ownership, review attribution, and merge-gate decisions still point at the original agent.
- Queues summary merge-back jobs for original agents without reusing stale PR checkout validation.

## Why
This covers Tasks 2-6 from issue #177. Implementation and review showed the pieces are coupled: eligibility, routing, temp-worker lifecycle, delegated job auditing, summary merge-back, and selector policy all need to agree for forked sessions to be safe.

## Changes
- Added temp-worker eligibility checks for policy, runtime, action, writable implement jobs, task worktrees, recursion, and per-agent caps.
- Added temp-worker startup and cleanup via `agent_instances` only, so temporary workers do not appear as normal reviewer/agent registrations.
- Added delegated job metadata to mailbox payloads and DB delegation support.
- Updated workflow authorization, task-run matching, review attribution, merge-gate reviewer accounting, and implement branch-lock checks for delegated jobs.
- Updated selector logic so externally busy runtime locks count against temp-worker capacity during a scheduling tick.

## Verification
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'Test(RunQueuedJobs|TempWorkerEligible|SelectRunnableQueuedJobs|JobWorkerParallelSessionPolicy|DaemonReviewers|TaskRunJobMatches)' -v -timeout 300s`\n- `GOTOOLCHAIN=go1.26.0 go test ./internal/db ./internal/workflow -run 'Test(Delegate|EngineRunJobAllows|EngineAdvanceDelegatedReview|EngineAdvanceReviewApproval|EngineHandlePullRequestOpened|Mailbox|PolicyMergeGate|TaskWorktree|MigrateAppendsTaskWorktreePath|TaskWorktreePathStorage)' -v -timeout 300s`\n- `git diff --check`\n\n## Review Note\n- Ran `codex exec review --uncommitted`; it inspected the diff for several minutes but did not return a final finding list, so I terminated the hung process.\n- The review transcript did confirm `GOTOOLCHAIN=local go test ...` fails because local Go is `go1.22.2` while `go.mod` requires Go >= 1.26. The explicit `GOTOOLCHAIN=go1.26.0` focused suites above passed.\n\n## Risk\nMedium. This touches daemon scheduling and workflow advancement. The new behavior is gated by parallel-session policy and temp-worker eligibility; queue mode and existing checkout serialization remain covered by tests.