### PR TITLE
Document forkable temp workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,11 @@ gitmoot agent ask project-planner --repo owner/repo --background "Write the impl
 gitmoot job watch <job-id>
 ```
 
-Background jobs are conservative by default. The daemon starts with one worker,
-runtime session locks serialize jobs for the same Codex or Claude session, repo
-checkout locks protect local checkouts, and branch locks protect implementation
-ownership.
+Background jobs are safe by default. The daemon starts with one worker, repo
+checkout locks protect local checkouts, branch locks protect implementation
+ownership, and busy Codex/Claude runtime sessions can fork bounded temporary
+workers when `[parallel_sessions]` allows it. Temp workers still require
+checkout/worktree safety and write-capable agents for implementation jobs.
 
 Route work through PR comments:
 

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -103,10 +103,22 @@ Background execution uses separate resource categories:
 - **Branch locks**: workflow ownership records used for implementation and
   merge safety.
 
-The daemon defaults to `--workers 1`. Raise `--workers` only when the Gitmoot
-home has independent runtime sessions or managed agent types with
-`max_background` greater than one. Jobs that target the same runtime session or
-same checkout remain serialized even when the worker count is higher.
+The daemon defaults to `--workers 1`. Raise `--workers` when the Gitmoot home
+has independent runtime sessions, managed agent types with `max_background`
+greater than one, or forkable temporary workers enabled. By default,
+`[parallel_sessions]` uses:
+
+```toml
+same_session = "fork_temp_session"
+merge_back = "summary"
+max_temp_sessions_per_agent = 4
+eligible_actions = ["ask", "review", "implement"]
+```
+
+When a Codex or Claude runtime session is busy, Gitmoot can start a bounded
+temporary worker with the same template and repo scope. Implementation jobs only
+fork when the task has a recorded worktree and the original agent is writable.
+If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
 
 ## End-To-End Demo Path
 
@@ -355,10 +367,11 @@ same checkout remain serialized even when the worker count is higher.
 
 - The machine running `gitmoot daemon start` must stay online.
 - Polling is the V1 mechanism; there is no webhook receiver yet.
-- Parallel implementation needs separate task worktrees and separate runtime
-  sessions or managed background instances. Checkout mutation operations are
-  serialized per checkout path; runtime session locks still serialize jobs that
-  reuse the same Codex or Claude session.
+- Parallel implementation needs separate task worktrees. Checkout mutation
+  operations are serialized per checkout path. If a Codex or Claude session is
+  busy and `[parallel_sessions].same_session` is `fork_temp_session`, Gitmoot
+  can use a bounded temp worker and queue a summary merge-back to the original
+  agent; otherwise same-session jobs wait.
 - GitHub Checks are best implemented later through GitHub App mode. V1 uses
   commit statuses and `gh pr checks`.
 - Use explicit session ids for long workflows. `last` is convenient but can

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -281,8 +281,7 @@ Symptoms:
 
 - `gitmoot agent ask` fails with `runtime session ... is busy`.
 - A background job remains queued and its events include `runtime_lock_wait`.
-- Increasing `--workers` does not make two jobs run against the same Codex or
-  Claude session.
+- Increasing `--workers` does not start a temp worker for the job.
 
 Checks:
 
@@ -295,11 +294,16 @@ gitmoot agent list
 
 Fixes:
 
-- Wait for the active job using the same runtime session to finish.
-- Use a different registered agent or managed background instance when the work
-  is independent.
-- Keep `gitmoot daemon start --workers 1` unless you have multiple independent
-  runtime sessions or an agent type with `max_background` greater than one.
+- Check `[parallel_sessions]`. The default is `same_session = "fork_temp_session"`,
+  `merge_back = "summary"`, `max_temp_sessions_per_agent = 4`, and
+  `eligible_actions = ["ask", "review", "implement"]`.
+- If the job still waits, inspect the job events for the ineligibility reason:
+  unsupported runtime, action not eligible, temp-worker cap reached, read-only
+  implementation agent, missing task worktree, or summary merge-back waiting for
+  the original session.
+- Wait for the active job using the same runtime session to finish, or use a
+  different registered agent or managed background instance when the work is
+  independent.
 - Use `gitmoot agent gc` to remove expired managed background instances.
 
 ## Parallel Implementation And Worktrees
@@ -326,12 +330,12 @@ Fixes:
   worktree path on the task and routes task-tied jobs there.
 - Keep the registered checkout clean. Gitmoot still uses it for base branch
   updates and merge-gate cleanup.
-- Use separate runtime sessions or managed background instances for jobs that
-  should truly run concurrently. Worktrees isolate files; runtime session locks
-  still serialize reuse of the same Codex or Claude session.
-- Temporary forkable workers, such as the future #177 flow, should remain gated
-  on task worktree isolation. Forking sessions without checkout isolation only
-  moves the contention from runtime memory to local git state.
+- Use separate runtime sessions, managed background instances, or forkable temp
+  workers for jobs that should truly run concurrently. Worktrees isolate files;
+  temp workers isolate busy Codex/Claude runtime sessions when eligible.
+- Forked implementation sessions remain gated on task worktree isolation.
+  Forking sessions without checkout isolation only moves the contention from
+  runtime memory to local git state.
 - For the full Claude implementation-worker smoke checklist, see
   [Claude Runtime Validation](claude-runtime-validation.md).
 

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1753,7 +1753,7 @@ func TestSkillOptTrainContinueRetriesInvalidRequiredVuePreviewOption(t *testing.
 
 	stdout.Reset()
 	stderr.Reset()
-	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "preview-retry-train"}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "preview-retry-train", "--generator-type", "skillopt-generator"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
 	}
@@ -1886,7 +1886,7 @@ func TestSkillOptTrainContinueAllowsOptionalVuePreviewFallback(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optional-preview-train"}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optional-preview-train", "--generator-type", "skillopt-generator"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
 	}
@@ -1950,7 +1950,7 @@ func TestSkillOptTrainContinueAllowsOptionalVuePreviewFallback(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optional-preview-train"}, &stdout, &stderr)
+	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optional-preview-train", "--generator-type", "skillopt-generator"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("second train continue exit code = %d, stderr=%s", code, stderr.String())
 	}
@@ -2032,7 +2032,7 @@ func TestSkillOptTrainContinueFailsRequiredVuePreviewForProseOutput(t *testing.T
 
 	stdout.Reset()
 	stderr.Reset()
-	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "preview-train"}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "preview-train", "--generator-type", "skillopt-generator"}, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("train continue exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -2134,7 +2134,7 @@ func TestSkillOptTrainContinueRejectsNonImplementedGenerationResult(t *testing.T
 
 	stdout.Reset()
 	stderr.Reset()
-	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train", "--generator-type", "skillopt-generator"}, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("train continue exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -2224,7 +2224,7 @@ func TestSkillOptTrainContinueRefusesConcurrentGeneration(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train", "--generator-type", "skillopt-generator"}, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("train continue exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -2500,7 +2500,7 @@ func TestSkillOptTrainContinueUsesManagedGeneratorConcurrency(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train", "--generator-type", "skillopt-generator"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
 	}
@@ -2599,7 +2599,7 @@ func TestSkillOptTrainContinueUsesRegisteredWorkspaceRepoCheckout(t *testing.T) 
 
 	stdout.Reset()
 	stderr.Reset()
-	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train", "--generator-type", "skillopt-generator"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("train continue with workspace checkout exit code = %d, stderr=%s", code, stderr.String())
 	}
@@ -2700,7 +2700,7 @@ func TestSkillOptTrainContinueGeneratesValidateArtifacts(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "validate-train"}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "validate-train", "--generator-type", "skillopt-generator"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
 	}
@@ -2798,7 +2798,7 @@ func TestSkillOptTrainContinueRecordsGenerationFailureWithoutOptions(t *testing.
 
 	stdout.Reset()
 	stderr.Reset()
-	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train", "--generator-type", "skillopt-generator"}, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("train continue without generator exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -354,9 +354,13 @@ Background jobs are scheduled against three distinct resources:
 - branch locks for implementation ownership and merge safety.
 
 The daemon default is `--workers 1`. Users can raise it when jobs target
-different runtime sessions or managed agent types with `max_background` greater
-than one. Gitmoot still serializes jobs for the same runtime session or checkout
-even when more workers are configured.
+different runtime sessions, managed agent types with `max_background` greater
+than one, or forkable temporary workers. By default `[parallel_sessions]` uses
+`same_session = "fork_temp_session"`, `merge_back = "summary"`,
+`max_temp_sessions_per_agent = 4`, and
+`eligible_actions = ["ask", "review", "implement"]`. Same-checkout work remains
+serialized; same-runtime Codex/Claude jobs can fork only when the action is
+eligible and implementation jobs have a safe task worktree.
 
 ## Multi-Repo Work
 


### PR DESCRIPTION
## Summary
- Document forkable temporary workers as the default parallel-session behavior.
- Add troubleshooting guidance for temp-worker eligibility, caps, missing worktrees, read-only implementation agents, and summary merge-back waits.
- Update packaged Gitmoot workflow docs to match runtime behavior.
- Make legacy SkillOpt managed-generator tests explicitly request `--generator-type skillopt-generator`, since current-skill generation is now the default when a template skill exists.

## Validation
- `GOTOOLCHAIN=go1.26.0 go test ./internal/cli -run 'TestSkillOptTrainContinue(GeneratesOptionsWithCurrentSkill|RetriesInvalidRequiredVuePreviewOption|AllowsOptionalVuePreviewFallback|FailsRequiredVuePreviewForProseOutput|RejectsNonImplementedGenerationResult|UsesManagedGeneratorConcurrency|UsesRegisteredWorkspaceRepoCheckout|GeneratesValidateArtifacts|RecordsGenerationFailureWithoutOptions)' -v -count=1 -timeout 180s`\n- `GOTOOLCHAIN=go1.26.0 go test ./... -timeout 300s`\n- `git diff --check`\n- `codex exec review --uncommitted`: no findings. The review also attempted local `go test` without `GOTOOLCHAIN=go1.26.0` and hit the host Go/toolchain read-only cache limitation, so the authoritative suite above used the project-required toolchain override.\n\n## Issue\n- Final docs/test task for #177.