### PR TITLE
Add coordinator-safe agent delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,20 @@ Use the Gitmoot planner here. Write the implementation plan.
 That uses the same `planner` template as the background agent, but imports the
 prompt into the current chat instead of creating a Gitmoot job.
 
-Ask the registered background planner when you want a queued Gitmoot job:
+Ask the registered background planner when you want a queued analysis or
+planning job:
 
 ```sh
 gitmoot agent ask project-planner --repo owner/repo --background "Write the implementation plan and goal file."
 gitmoot job watch <job-id>
+```
+
+For coordinator delegation where the request may require review or file edits,
+use `agent run` and let Gitmoot select the safe workflow path:
+
+```sh
+gitmoot agent run lead --repo owner/repo --task task-001 --background "Implement this task."
+gitmoot agent run reviewer --repo owner/repo --pr 12 --background "Review this PR."
 ```
 
 Background jobs are safe by default. The daemon starts with one worker, repo

--- a/SKILL.md
+++ b/SKILL.md
@@ -107,6 +107,9 @@ gitmoot plugin doctor
 gitmoot agent list
 gitmoot agent doctor <agent>
 gitmoot agent prompt <agent-or-template>
+gitmoot agent run <agent> --repo owner/repo "question, review, or implementation request"
+gitmoot agent review <agent> --repo owner/repo --pr <number> "review request"
+gitmoot agent implement <agent> --repo owner/repo --task <task-id> "implementation request"
 gitmoot agent ask <agent> --repo owner/repo "question or instructions"
 gitmoot job list --repo owner/repo
 gitmoot job show <job-id>
@@ -129,12 +132,14 @@ Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`
 only when the user explicitly wants a foreground process.
 
 Use `gitmoot agent prompt <agent-or-template>` when the user wants to reuse a
-Gitmoot agent prompt in the current chat. Use `gitmoot agent ask` when the user
-wants to invoke a registered Gitmoot agent through the Gitmoot runtime path. Add
-`--background` only when the user wants a queued background job. This is the
-same agent registry and runtime adapter path used by PR-comment ask jobs; the
-plugin only helps the runtime discover this skill and does not replace the
-`gitmoot` CLI.
+Gitmoot agent prompt in the current chat. Use `gitmoot agent run` for
+coordinator delegation through a registered Gitmoot agent; Gitmoot will route to
+ask, review, or implement and own worktrees, branch locks, commits, pushes, PRs,
+and workflow advancement. Use `gitmoot agent ask` only for analysis, planning,
+or questions. Add `--background` only when the user wants a queued background
+job. This is the same agent registry and runtime adapter path used by PR-comment
+jobs; the plugin only helps the runtime discover this skill and does not replace
+the `gitmoot` CLI.
 
 ## PR Comment Commands
 

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -22,6 +22,9 @@ gitmoot agent template add frontend-reviewer --file agents/frontend-reviewer.md
 gitmoot agent template update thermo-nuclear-code-quality-review
 gitmoot agent start <name> --runtime codex|claude --repo owner/repo --path . --template thermo-nuclear-code-quality-review --start-daemon
 gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
+gitmoot agent run <name> "message" --repo owner/repo [--task task-id] [--pr number] [--background]
+gitmoot agent review <name> "message" --repo owner/repo --pr number [--background]
+gitmoot agent implement <name> "message" --repo owner/repo [--task task-id] [--background]
 gitmoot agent ask <name> "message" --repo owner/repo
 gitmoot agent ask <name> --background --repo owner/repo "message"
 gitmoot agent type list
@@ -76,10 +79,12 @@ planner job.
 
 If a Codex or Claude chat wants to reuse a registered Gitmoot agent prompt in
 the current chat, it should run `gitmoot agent prompt <agent-or-template>` and
-apply the returned prompt content locally. If it wants to invoke a registered
-Gitmoot agent through the runtime adapter path, it should run
-`gitmoot agent ask <agent> --repo owner/repo "..."`. That uses the same local
-agent registry and runtime adapter path as PR-comment ask jobs.
+apply the returned prompt content locally. If it wants to delegate work through
+the runtime adapter path, it should prefer `gitmoot agent run <agent> --repo
+owner/repo "..."`. `agent run` routes to `ask`, `review`, or `implement` from
+explicit flags and message intent. Use `agent ask` only for analysis, planning,
+or questions; use `agent review` for a PR review decision; use `agent implement`
+for code, docs, tests, or file edits.
 
 ## Execution Model
 
@@ -102,6 +107,12 @@ Background execution uses separate resource categories:
   two jobs at the same time.
 - **Branch locks**: workflow ownership records used for implementation and
   merge safety.
+
+Gitmoot owns repository orchestration for implementation jobs. Child agents
+should not be asked to create branches, commit, push, or open PRs through
+`agent ask`; use `agent run`, `agent implement`, or `task run` so Gitmoot can
+allocate worktrees, hold branch locks, commit changes, push branches, open PRs,
+and advance review state.
 
 The daemon defaults to `--workers 1`. Raise `--workers` when the Gitmoot home
 has independent runtime sessions, managed agent types with `max_background`

--- a/docs/release-notes/v0.2.0-beta.1.md
+++ b/docs/release-notes/v0.2.0-beta.1.md
@@ -43,9 +43,10 @@ readiness, and forkable temp-worker changes into the public beta line.
 
 ## Known Beta Limits
 
-- `gitmoot agent review` and `gitmoot agent implement` are not local CLI
-  commands yet. Review and implement already exist as workflow/job actions via
-  PR comments, task runs, queued jobs, and daemon processing.
+- Local coordinator delegation now has first-class `gitmoot agent run`,
+  `gitmoot agent review`, and `gitmoot agent implement` command paths. They are
+  intended to keep worktree, branch, commit, push, PR, and advancement lifecycle
+  inside Gitmoot rather than child-agent prompts.
 - SkillOpt live pairwise candidate-vs-current promotion validation is still a
   future optional mode.
 - Preset prompt delivery for resumed agents can still be optimized further.

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,6 +37,12 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 		return runAgentStart(args[1:], stdout, stderr)
 	case "ask":
 		return runAgentAsk(args[1:], stdout, stderr)
+	case "run":
+		return runAgentRun(args[1:], stdout, stderr)
+	case "review":
+		return runAgentReview(args[1:], stdout, stderr)
+	case "implement":
+		return runAgentImplement(args[1:], stdout, stderr)
 	case "type":
 		return runAgentType(args[1:], stdout, stderr)
 	case "template":
@@ -71,6 +78,9 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot agent start <name> --runtime codex|claude --repo owner/repo [--path .] [--template <template-id>] [--start-daemon]")
 	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot agent run <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--background] [--type type] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--head-sha sha] [--branch branch] [--background] [--type type] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot agent implement <name> \"message\" [--repo owner/repo] [--task task-id] [--branch branch] [--background] [--type type] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot agent type list|show|set ...")
 	fmt.Fprintln(w, "  gitmoot agent template list|show|add|draft|validate|update|diff ...")
 	fmt.Fprintln(w, "  gitmoot agent prompt <agent-or-template> [--json]")
@@ -92,6 +102,7 @@ type agentAskOptions struct {
 	jsonOutput bool
 	background bool
 	typeName   string
+	force      bool
 	agent      string
 	message    string
 }
@@ -104,17 +115,25 @@ func runAgentAsk(args []string, stdout, stderr io.Writer) int {
 		}
 		return 2
 	}
+	if !options.force && looksLikeWorkflowOrchestration(options.message) {
+		fmt.Fprintln(stderr, "This looks like implementation workflow orchestration.")
+		fmt.Fprintln(stderr, "Use `gitmoot agent run` or `gitmoot agent implement` so Gitmoot can manage worktrees, branches, commits, and PRs safely.")
+		return 2
+	}
 	var output localAgentJobOutput
 	if err := withStore(options.home, func(store *db.Store) error {
 		var err error
 		output, err = dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
-			RepoFlag:     options.repo,
-			Agent:        options.agent,
-			Action:       "ask",
-			Instructions: options.message,
-			Background:   options.background,
-			Type:         options.typeName,
-			Home:         options.home,
+			RepoFlag:             options.repo,
+			Agent:                options.agent,
+			Action:               "ask",
+			Instructions:         options.message,
+			Background:           options.background,
+			Type:                 options.typeName,
+			Home:                 options.home,
+			SelectedAction:       "ask",
+			SelectedActionReason: "explicit agent ask",
+			ExecutionPath:        "agent_ask",
 		})
 		return err
 	}); err != nil {
@@ -161,6 +180,8 @@ func parseAgentAskOptions(args []string, stderr io.Writer) (agentAskOptions, boo
 		switch {
 		case arg == "--background":
 			options.background = true
+		case arg == "--force":
+			options.force = true
 		case arg == "--type":
 			if index+1 >= len(args) {
 				fmt.Fprintln(stderr, "agent ask requires a value for --type")
@@ -218,7 +239,318 @@ func containsHelpFlag(args []string) bool {
 
 func printAgentAskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--type type] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--type type] [--home path] [--json] [--force]")
+}
+
+type agentRunOptions struct {
+	home       string
+	repo       string
+	jsonOutput bool
+	background bool
+	typeName   string
+	taskID     string
+	prNumber   int
+	headSHA    string
+	branch     string
+	agent      string
+	message    string
+}
+
+func runAgentRun(args []string, stdout, stderr io.Writer) int {
+	options, ok := parseAgentRunOptions("run", args, stderr)
+	if !ok {
+		if containsHelpFlag(args) {
+			return 0
+		}
+		return 2
+	}
+	selected, reason := selectAgentRunAction(options)
+	output, exit := dispatchAgentCommand(options, selected, reason, "agent_run", stdout, stderr)
+	if exit != 0 {
+		return exit
+	}
+	if options.jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "agent run: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printLocalAgentJobOutput(stdout, output)
+	printQueuedDaemonHint(stdout, output, options.background, options.home)
+	return 0
+}
+
+func runAgentReview(args []string, stdout, stderr io.Writer) int {
+	options, ok := parseAgentRunOptions("review", args, stderr)
+	if !ok {
+		if containsHelpFlag(args) {
+			return 0
+		}
+		return 2
+	}
+	if strings.TrimSpace(options.repo) == "" {
+		fmt.Fprintln(stderr, "agent review requires --repo owner/repo")
+		return 2
+	}
+	if options.prNumber <= 0 {
+		fmt.Fprintln(stderr, "agent review requires --pr number")
+		return 2
+	}
+	output, exit := dispatchAgentCommand(options, "review", "explicit agent review", "agent_review", stdout, stderr)
+	if exit != 0 {
+		return exit
+	}
+	if options.jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "agent review: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printLocalAgentJobOutput(stdout, output)
+	printQueuedDaemonHint(stdout, output, options.background, options.home)
+	return 0
+}
+
+func runAgentImplement(args []string, stdout, stderr io.Writer) int {
+	options, ok := parseAgentRunOptions("implement", args, stderr)
+	if !ok {
+		if containsHelpFlag(args) {
+			return 0
+		}
+		return 2
+	}
+	output, exit := dispatchAgentCommand(options, "implement", "explicit agent implement", "agent_implement", stdout, stderr)
+	if exit != 0 {
+		return exit
+	}
+	if options.jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "agent implement: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printLocalAgentJobOutput(stdout, output)
+	printQueuedDaemonHint(stdout, output, options.background, options.home)
+	return 0
+}
+
+func dispatchAgentCommand(options agentRunOptions, action string, reason string, executionPath string, stdout, stderr io.Writer) (localAgentJobOutput, int) {
+	var output localAgentJobOutput
+	if err := withStore(options.home, func(store *db.Store) error {
+		var err error
+		output, err = dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+			RepoFlag:             options.repo,
+			Agent:                options.agent,
+			Action:               action,
+			Instructions:         options.message,
+			Background:           options.background,
+			Type:                 options.typeName,
+			Home:                 options.home,
+			TaskID:               options.taskID,
+			PullRequest:          options.prNumber,
+			HeadSHA:              options.headSHA,
+			Branch:               options.branch,
+			SelectedAction:       action,
+			SelectedActionReason: reason,
+			ExecutionPath:        executionPath,
+		})
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent %s: %v\n", action, err)
+		return localAgentJobOutput{}, 1
+	}
+	if options.background {
+		output.WatchCommand = jobWatchCommand(output.JobID, options.home)
+		running, err := daemonIsRunning(options.home)
+		if err != nil {
+			fmt.Fprintf(stderr, "agent %s: %v\n", action, err)
+			return localAgentJobOutput{}, 1
+		}
+		output.DaemonRunning = running
+	}
+	return output, 0
+}
+
+func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agentRunOptions, bool) {
+	if len(args) == 0 || containsHelpFlag(args) {
+		printAgentRunUsage(stderr, command)
+		if len(args) == 0 {
+			fmt.Fprintf(stderr, "agent %s requires exactly one agent and one message\n", command)
+		}
+		return agentRunOptions{}, false
+	}
+	options := agentRunOptions{}
+	positionals := []string{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "--background":
+			options.background = true
+		case arg == "--json":
+			options.jsonOutput = true
+		case arg == "--type" || arg == "--repo" || arg == "--home" || arg == "--task" || arg == "--pr" || arg == "--head-sha" || arg == "--branch":
+			if index+1 >= len(args) {
+				fmt.Fprintf(stderr, "agent %s requires a value for %s\n", command, arg)
+				return agentRunOptions{}, false
+			}
+			index++
+			if !setAgentRunOption(&options, arg, args[index], stderr) {
+				return agentRunOptions{}, false
+			}
+		case strings.HasPrefix(arg, "--type="):
+			options.typeName = strings.TrimPrefix(arg, "--type=")
+		case strings.HasPrefix(arg, "--repo="):
+			options.repo = strings.TrimPrefix(arg, "--repo=")
+		case strings.HasPrefix(arg, "--home="):
+			options.home = strings.TrimPrefix(arg, "--home=")
+		case strings.HasPrefix(arg, "--task="):
+			options.taskID = strings.TrimPrefix(arg, "--task=")
+		case strings.HasPrefix(arg, "--pr="):
+			if !setAgentRunOption(&options, "--pr", strings.TrimPrefix(arg, "--pr="), stderr) {
+				return agentRunOptions{}, false
+			}
+		case strings.HasPrefix(arg, "--head-sha="):
+			options.headSHA = strings.TrimPrefix(arg, "--head-sha=")
+		case strings.HasPrefix(arg, "--branch="):
+			options.branch = strings.TrimPrefix(arg, "--branch=")
+		case strings.HasPrefix(arg, "-") && len(positionals) >= 2:
+			fmt.Fprintf(stderr, "unknown agent %s flag %q\n", command, arg)
+			return agentRunOptions{}, false
+		default:
+			positionals = append(positionals, arg)
+		}
+	}
+	if len(positionals) != 2 {
+		fmt.Fprintf(stderr, "agent %s requires exactly one agent and one message\n", command)
+		return agentRunOptions{}, false
+	}
+	options.agent = strings.TrimSpace(positionals[0])
+	options.message = strings.TrimSpace(positionals[1])
+	if options.agent == "" || options.message == "" {
+		fmt.Fprintf(stderr, "agent %s requires exactly one agent and one message\n", command)
+		return agentRunOptions{}, false
+	}
+	return options, true
+}
+
+func setAgentRunOption(options *agentRunOptions, flagName string, value string, stderr io.Writer) bool {
+	value = strings.TrimSpace(value)
+	switch flagName {
+	case "--type":
+		options.typeName = value
+	case "--repo":
+		options.repo = value
+	case "--home":
+		options.home = value
+	case "--task":
+		options.taskID = value
+	case "--head-sha":
+		options.headSHA = value
+	case "--branch":
+		options.branch = value
+	case "--pr":
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed <= 0 {
+			fmt.Fprintln(stderr, "agent command requires a positive integer for --pr")
+			return false
+		}
+		options.prNumber = parsed
+	}
+	return true
+}
+
+func printAgentRunUsage(w io.Writer, command string) {
+	fmt.Fprintln(w, "Usage:")
+	switch command {
+	case "review":
+		fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--head-sha sha] [--branch branch] [--background] [--type type] [--home path] [--json]")
+	case "implement":
+		fmt.Fprintln(w, "  gitmoot agent implement <name> \"message\" [--repo owner/repo] [--task task-id] [--branch branch] [--background] [--type type] [--home path] [--json]")
+	default:
+		fmt.Fprintln(w, "  gitmoot agent run <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--background] [--type type] [--home path] [--json]")
+	}
+}
+
+func selectAgentRunAction(options agentRunOptions) (string, string) {
+	if strings.TrimSpace(options.taskID) != "" {
+		return "implement", "--task selects implementation workflow"
+	}
+	if options.prNumber > 0 {
+		return "review", "--pr selects review workflow"
+	}
+	if strings.TrimSpace(options.headSHA) != "" {
+		return "review", "--head-sha selects review workflow"
+	}
+	if looksLikeReviewRequest(options.message) {
+		return "review", "message asks for PR review or approval"
+	}
+	if looksLikeImplementationRequest(options.message) {
+		return "implement", "message asks for code, docs, tests, or file changes"
+	}
+	return "ask", "message is analysis, planning, or a question"
+}
+
+func looksLikeWorkflowOrchestration(message string) bool {
+	lower := strings.ToLower(message)
+	phrases := []string{
+		"create branch",
+		"commit and push",
+		"commit, push",
+		"commit changes",
+		"make a commit",
+		"git commit",
+		"push branch",
+		"push changes",
+		"git push",
+		"open pr",
+		"open a pr",
+		"create pr",
+		"create a pr",
+		"create pull request",
+		"open pull request",
+		"merge pr",
+		"merge pull request",
+		"full implementation workflow",
+	}
+	for _, phrase := range phrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeReviewRequest(message string) bool {
+	lower := strings.ToLower(message)
+	phrases := []string{"review pr", "review this pr", "review pull request", "code review", "approve pr", "approve pull request", "request changes", "audit pr", "audit pull request"}
+	for _, phrase := range phrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeImplementationRequest(message string) bool {
+	lower := strings.ToLower(message)
+	phrases := []string{"implement", "edit", "change file", "update file", "write tests", "add test", "fix bug", "patch", "modify", "refactor", "update docs", "documentation", "write code", "change code", "code change"}
+	for _, phrase := range phrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func printQueuedDaemonHint(stdout io.Writer, output localAgentJobOutput, background bool, home string) {
+	if background && !output.DaemonRunning {
+		writeLine(stdout, "queued: daemon is not running")
+		writeLine(stdout, "process: %s", daemonStartHint(home, output.Repo))
+		writeLine(stdout, "or: %s", jobRunCommand(output.JobID, home))
+	}
 }
 
 func daemonIsRunning(home string) (bool, error) {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -20,27 +21,41 @@ import (
 )
 
 type localAgentDispatchRequest struct {
-	RepoFlag         string
-	Agent            string
-	Action           string
-	Instructions     string
-	Background       bool
-	Type             string
-	Home             string
-	AllowManagedSync bool
-	JobTimeout       time.Duration
+	RepoFlag             string
+	Agent                string
+	Action               string
+	Instructions         string
+	Background           bool
+	Type                 string
+	Home                 string
+	AllowManagedSync     bool
+	JobTimeout           time.Duration
+	TaskID               string
+	PullRequest          int
+	HeadSHA              string
+	Branch               string
+	GoalID               string
+	TaskTitle            string
+	LeadAgent            string
+	Reviewers            []string
+	SelectedAction       string
+	SelectedActionReason string
+	ExecutionPath        string
 }
 
 type localAgentJobOutput struct {
-	JobID          string                `json:"job_id"`
-	State          string                `json:"state"`
-	Repo           string                `json:"repo"`
-	Agent          string                `json:"agent"`
-	Action         string                `json:"action"`
-	Result         *workflow.AgentResult `json:"result,omitempty"`
-	RawOutputCount int                   `json:"raw_output_count"`
-	WatchCommand   string                `json:"watch_command,omitempty"`
-	DaemonRunning  bool                  `json:"daemon_running,omitempty"`
+	JobID                string                `json:"job_id"`
+	State                string                `json:"state"`
+	Repo                 string                `json:"repo"`
+	Agent                string                `json:"agent"`
+	Action               string                `json:"action"`
+	SelectedAction       string                `json:"selected_action,omitempty"`
+	SelectedActionReason string                `json:"selected_action_reason,omitempty"`
+	ExecutionPath        string                `json:"execution_path,omitempty"`
+	Result               *workflow.AgentResult `json:"result,omitempty"`
+	RawOutputCount       int                   `json:"raw_output_count"`
+	WatchCommand         string                `json:"watch_command,omitempty"`
+	DaemonRunning        bool                  `json:"daemon_running,omitempty"`
 }
 
 func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAgentDispatchRequest) (localAgentJobOutput, error) {
@@ -51,32 +66,12 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err := store.UpsertRepo(ctx, record); err != nil {
 		return localAgentJobOutput{}, err
 	}
+	var checkoutPath string
+	checkoutPath = record.CheckoutPath
 	if agent, blocked, err := readOnlyManagedImplementationBlock(ctx, store, request, repo.FullName()); err != nil {
 		return localAgentJobOutput{}, err
 	} else if blocked {
-		job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
-			ID:           localAgentJobID(request.Action, agent.Name),
-			Agent:        agent.Name,
-			Action:       request.Action,
-			Repo:         repo.FullName(),
-			Branch:       record.DefaultBranch,
-			Sender:       "local",
-			Instructions: request.Instructions,
-		})
-		if err != nil {
-			return localAgentJobOutput{}, err
-		}
-		if _, err := markJobPermissionBlocked(ctx, store, job.ID); err != nil {
-			return localAgentJobOutput{}, err
-		}
-		return localAgentJobOutput{
-			JobID:          job.ID,
-			State:          string(workflow.JobBlocked),
-			Repo:           repo.FullName(),
-			Agent:          job.Agent,
-			Action:         job.Type,
-			RawOutputCount: 0,
-		}, nil
+		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), record.DefaultBranch, agent.Name)
 	}
 	agent, releaseAgentReservation, err := resolveLocalDispatchAgent(ctx, store, request, repo.FullName(), record)
 	if err != nil {
@@ -99,12 +94,45 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err := ensureLocalAgentAccess(ctx, store, agent, repo.FullName(), request.Action); err != nil {
 		return localAgentJobOutput{}, err
 	}
+	request.Agent = agent.Name
+	if readOnlyImplementationBlocked(request.Action, runtimeAgent(agent)) {
+		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), record.DefaultBranch, agent.Name)
+	}
+	switch request.Action {
+	case "review":
+		var checkout string
+		var err error
+		request, checkout, err = prepareLocalReviewDispatchRequest(ctx, store, record, repo, request)
+		if err != nil {
+			return localAgentJobOutput{}, err
+		}
+		if strings.TrimSpace(checkout) != "" {
+			checkoutPath = checkout
+		}
+	case "implement":
+		var task db.Task
+		var err error
+		task, request, err = prepareLocalImplementDispatchRequest(ctx, store, record, repo, request)
+		if err != nil {
+			return localAgentJobOutput{}, err
+		}
+		if strings.TrimSpace(task.WorktreePath) != "" {
+			checkoutPath = task.WorktreePath
+		}
+	}
 	job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
 		ID:           localAgentJobID(request.Action, agent.Name),
 		Agent:        agent.Name,
 		Action:       request.Action,
 		Repo:         repo.FullName(),
-		Branch:       record.DefaultBranch,
+		Branch:       firstNonEmpty(request.Branch, record.DefaultBranch),
+		PullRequest:  request.PullRequest,
+		HeadSHA:      request.HeadSHA,
+		GoalID:       request.GoalID,
+		TaskID:       request.TaskID,
+		TaskTitle:    request.TaskTitle,
+		LeadAgent:    firstNonEmpty(request.LeadAgent, agent.Name),
+		Reviewers:    request.Reviewers,
 		Sender:       "local",
 		Instructions: request.Instructions,
 	})
@@ -114,27 +142,20 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err := releaseReservation(ctx); err != nil {
 		return localAgentJobOutput{}, err
 	}
-	if readOnlyImplementationBlocked(job.Type, runtimeAgent(agent)) {
-		if _, err := markJobPermissionBlocked(ctx, store, job.ID); err != nil {
-			return localAgentJobOutput{}, err
-		}
-		return localAgentJobOutput{
-			JobID:          job.ID,
-			State:          string(workflow.JobBlocked),
-			Repo:           repo.FullName(),
-			Agent:          job.Agent,
-			Action:         job.Type,
-			RawOutputCount: 0,
-		}, nil
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "route_selected", Message: routeSelectedMessage(request)}); err != nil {
+		return localAgentJobOutput{}, err
 	}
 	if request.Background {
 		return localAgentJobOutput{
-			JobID:          job.ID,
-			State:          job.State,
-			Repo:           repo.FullName(),
-			Agent:          job.Agent,
-			Action:         job.Type,
-			RawOutputCount: 0,
+			JobID:                job.ID,
+			State:                job.State,
+			Repo:                 repo.FullName(),
+			Agent:                job.Agent,
+			Action:               job.Type,
+			SelectedAction:       request.SelectedAction,
+			SelectedActionReason: request.SelectedActionReason,
+			ExecutionPath:        request.ExecutionPath,
+			RawOutputCount:       0,
 		}, nil
 	}
 	managed, err := localManagedAgentDispatchConfigForAgent(ctx, store, request.Home, agent.Name)
@@ -166,7 +187,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	defer func() {
 		_ = releaseLock(context.Background())
 	}()
-	adapter, err := runtimeStartAdapter(newRuntimeFactory(), agent.Runtime, record.CheckoutPath)
+	adapter, err := runtimeStartAdapter(newRuntimeFactory(), agent.Runtime, checkoutPath)
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
@@ -185,11 +206,18 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		runCtx, cancel = context.WithTimeout(ctx, jobTimeout)
 		defer cancel()
 	}
-	if _, err := (workflow.Mailbox{Store: store}).Run(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {
-		return localAgentJobOutput{}, err
-	}
-	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_completed", Message: "workflow advancement completed"}); err != nil {
-		return localAgentJobOutput{}, err
+	if request.Action == "ask" {
+		if _, err := (workflow.Mailbox{Store: store}).Run(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {
+			return localAgentJobOutput{}, err
+		}
+		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_completed", Message: "workflow advancement completed"}); err != nil {
+			return localAgentJobOutput{}, err
+		}
+	} else {
+		engine := daemonWorkflowEngine(store, github.NewClient(checkoutPath), checkoutPath)
+		if _, err := engine.RunJob(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {
+			return localAgentJobOutput{}, err
+		}
 	}
 	latest, err := store.GetJob(ctx, job.ID)
 	if err != nil {
@@ -200,14 +228,235 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		return localAgentJobOutput{}, err
 	}
 	return localAgentJobOutput{
-		JobID:          latest.ID,
-		State:          latest.State,
-		Repo:           payload.Repo,
-		Agent:          latest.Agent,
-		Action:         latest.Type,
-		Result:         payload.Result,
-		RawOutputCount: len(payload.RawOutputs),
+		JobID:                latest.ID,
+		State:                latest.State,
+		Repo:                 payload.Repo,
+		Agent:                latest.Agent,
+		Action:               latest.Type,
+		SelectedAction:       request.SelectedAction,
+		SelectedActionReason: request.SelectedActionReason,
+		ExecutionPath:        request.ExecutionPath,
+		Result:               payload.Result,
+		RawOutputCount:       len(payload.RawOutputs),
 	}, nil
+}
+
+func enqueuePermissionBlockedLocalAgentJob(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string, defaultBranch string, agentName string) (localAgentJobOutput, error) {
+	job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+		ID:           localAgentJobID(request.Action, agentName),
+		Agent:        agentName,
+		Action:       request.Action,
+		Repo:         repo,
+		Branch:       firstNonEmpty(request.Branch, defaultBranch),
+		PullRequest:  request.PullRequest,
+		HeadSHA:      request.HeadSHA,
+		GoalID:       request.GoalID,
+		TaskID:       request.TaskID,
+		TaskTitle:    request.TaskTitle,
+		LeadAgent:    request.LeadAgent,
+		Reviewers:    request.Reviewers,
+		Sender:       "local",
+		Instructions: request.Instructions,
+	})
+	if err != nil {
+		return localAgentJobOutput{}, err
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "route_selected", Message: routeSelectedMessage(request)}); err != nil {
+		return localAgentJobOutput{}, err
+	}
+	if _, err := markJobPermissionBlocked(ctx, store, job.ID); err != nil {
+		return localAgentJobOutput{}, err
+	}
+	return localAgentJobOutput{
+		JobID:                job.ID,
+		State:                string(workflow.JobBlocked),
+		Repo:                 repo,
+		Agent:                job.Agent,
+		Action:               job.Type,
+		SelectedAction:       request.SelectedAction,
+		SelectedActionReason: request.SelectedActionReason,
+		ExecutionPath:        request.ExecutionPath,
+		RawOutputCount:       0,
+	}, nil
+}
+
+func routeSelectedMessage(request localAgentDispatchRequest) string {
+	action := strings.TrimSpace(request.SelectedAction)
+	if action == "" {
+		action = request.Action
+	}
+	reason := strings.TrimSpace(request.SelectedActionReason)
+	if reason == "" {
+		reason = "explicit action"
+	}
+	path := strings.TrimSpace(request.ExecutionPath)
+	if path == "" {
+		path = "local_agent"
+	}
+	return fmt.Sprintf("selected %s via %s: %s", action, path, reason)
+}
+
+func prepareLocalReviewDispatchRequest(ctx context.Context, store *db.Store, record db.Repo, repo github.Repository, request localAgentDispatchRequest) (localAgentDispatchRequest, string, error) {
+	if request.PullRequest <= 0 {
+		return localAgentDispatchRequest{}, "", errors.New("agent review requires --pr number")
+	}
+	if strings.TrimSpace(request.Branch) != "" && strings.TrimSpace(request.HeadSHA) != "" {
+		return prepareLocalReviewWorktree(ctx, store, record, repo, request)
+	}
+	pr, err := github.NewClient(record.CheckoutPath).GetPullRequest(ctx, repo, int64(request.PullRequest))
+	if err != nil {
+		return localAgentDispatchRequest{}, "", fmt.Errorf("resolve pull request #%d: %w", request.PullRequest, err)
+	}
+	if strings.TrimSpace(request.Branch) == "" {
+		request.Branch = pr.HeadRef
+	}
+	if strings.TrimSpace(request.HeadSHA) == "" {
+		request.HeadSHA = pr.HeadSHA
+	}
+	return prepareLocalReviewWorktree(ctx, store, record, repo, request)
+}
+
+func prepareLocalReviewWorktree(ctx context.Context, store *db.Store, record db.Repo, repo github.Repository, request localAgentDispatchRequest) (localAgentDispatchRequest, string, error) {
+	if strings.TrimSpace(request.HeadSHA) == "" {
+		return localAgentDispatchRequest{}, "", errors.New("agent review requires a pull request head SHA")
+	}
+	if strings.TrimSpace(request.Branch) != "" {
+		if task, err := store.GetTaskByRepoBranch(ctx, repo.FullName(), request.Branch); err == nil && strings.TrimSpace(task.WorktreePath) != "" {
+			head, headErr := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
+			if headErr != nil {
+				return localAgentDispatchRequest{}, "", headErr
+			}
+			if head == request.HeadSHA {
+				request.TaskID = task.ID
+				request.GoalID = firstNonEmpty(request.GoalID, task.GoalID)
+				request.TaskTitle = firstNonEmpty(request.TaskTitle, task.Title)
+				return request, task.WorktreePath, nil
+			}
+		} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return localAgentDispatchRequest{}, "", err
+		}
+	}
+	paths, err := initializedPaths(request.Home)
+	if err != nil {
+		return localAgentDispatchRequest{}, "", err
+	}
+	taskID := strings.TrimSpace(request.TaskID)
+	if taskID == "" {
+		taskID = fmt.Sprintf("review-pr-%d-%s", request.PullRequest, shortHash(repo.FullName()+"\x00"+request.HeadSHA))
+	}
+	path, err := workflow.TaskWorktreePath(paths.Home, repo.FullName(), taskID)
+	if err != nil {
+		return localAgentDispatchRequest{}, "", err
+	}
+	if _, err := os.Stat(path); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return localAgentDispatchRequest{}, "", err
+		}
+		git := gitutil.Client{Dir: record.CheckoutPath}
+		if err := git.AddDetachedWorktree(ctx, path, request.HeadSHA); err != nil {
+			if fetchErr := git.FetchPullRequest(ctx, "origin", request.PullRequest); fetchErr != nil {
+				return localAgentDispatchRequest{}, "", fmt.Errorf("create PR review worktree: %w; fetch PR ref: %v", err, fetchErr)
+			}
+			if retryErr := git.AddDetachedWorktree(ctx, path, request.HeadSHA); retryErr != nil {
+				return localAgentDispatchRequest{}, "", fmt.Errorf("create PR review worktree after fetch: %w", retryErr)
+			}
+		}
+	}
+	task := db.Task{
+		ID:           taskID,
+		RepoFullName: repo.FullName(),
+		GoalID:       firstNonEmpty(request.GoalID, "local-review"),
+		Title:        firstNonEmpty(request.TaskTitle, fmt.Sprintf("Review PR #%d", request.PullRequest)),
+		State:        string(workflow.TaskReviewing),
+		WorktreePath: path,
+	}
+	if err := store.UpsertTask(ctx, task); err != nil {
+		return localAgentDispatchRequest{}, "", err
+	}
+	request.TaskID = task.ID
+	request.GoalID = task.GoalID
+	request.TaskTitle = task.Title
+	return request, path, nil
+}
+
+func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, record db.Repo, repo github.Repository, request localAgentDispatchRequest) (db.Task, localAgentDispatchRequest, error) {
+	paths, err := initializedPaths(request.Home)
+	if err != nil {
+		return db.Task{}, localAgentDispatchRequest{}, err
+	}
+	taskID := strings.TrimSpace(request.TaskID)
+	taskTitle := strings.TrimSpace(request.TaskTitle)
+	goalID := strings.TrimSpace(request.GoalID)
+	if taskID == "" {
+		taskID = "adhoc-" + shortHash(request.Instructions+"\x00"+time.Now().UTC().Format(time.RFC3339Nano))
+		taskTitle = firstNonEmpty(taskTitle, shortTaskTitle(request.Instructions))
+		goalID = firstNonEmpty(goalID, "local-agent")
+		if err := store.UpsertTask(ctx, db.Task{
+			ID:           taskID,
+			RepoFullName: repo.FullName(),
+			GoalID:       goalID,
+			Title:        taskTitle,
+			State:        string(workflow.TaskPlanned),
+			Branch:       firstNonEmpty(request.Branch, "gitmoot/"+taskID),
+		}); err != nil {
+			return db.Task{}, localAgentDispatchRequest{}, err
+		}
+	}
+	task, err := store.GetTask(ctx, taskID)
+	if err != nil {
+		return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("load task %q: %w", taskID, err)
+	}
+	if strings.TrimSpace(task.RepoFullName) != "" && task.RepoFullName != repo.FullName() {
+		return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("task %s belongs to repo %s, not %s", task.ID, task.RepoFullName, repo.FullName())
+	}
+	if strings.TrimSpace(task.RepoFullName) == "" {
+		task.RepoFullName = repo.FullName()
+	}
+	if strings.TrimSpace(task.Title) == "" {
+		task.Title = firstNonEmpty(taskTitle, shortTaskTitle(request.Instructions))
+	}
+	if strings.TrimSpace(task.GoalID) == "" {
+		task.GoalID = firstNonEmpty(goalID, "local-agent")
+	}
+	branch := firstNonEmpty(request.Branch, task.Branch, "gitmoot/"+task.ID)
+	owner := strings.TrimSpace(request.Agent)
+	started, err := (workflow.Engine{Store: store}).AllocateTaskWorktree(ctx, workflow.TaskWorktreeRequest{
+		Home:       paths.Home,
+		Repo:       repo.FullName(),
+		GoalID:     task.GoalID,
+		TaskID:     task.ID,
+		TaskTitle:  task.Title,
+		Branch:     branch,
+		BaseBranch: record.DefaultBranch,
+		Owner:      owner,
+		Checkout:   record.CheckoutPath,
+	}, gitutil.Client{Dir: record.CheckoutPath})
+	if err != nil {
+		return db.Task{}, localAgentDispatchRequest{}, err
+	}
+	headSHA, err := (gitutil.Client{Dir: started.WorktreePath}).HeadSHA(ctx)
+	if err != nil {
+		return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("resolve task worktree head: %w", err)
+	}
+	request.TaskID = started.ID
+	request.GoalID = started.GoalID
+	request.TaskTitle = started.Title
+	request.Branch = started.Branch
+	request.HeadSHA = headSHA
+	request.LeadAgent = owner
+	return started, request, nil
+}
+
+func shortTaskTitle(message string) string {
+	fields := strings.Fields(strings.TrimSpace(message))
+	if len(fields) > 8 {
+		fields = fields[:8]
+	}
+	title := strings.Join(fields, " ")
+	if title == "" {
+		return "Local agent implementation"
+	}
+	return title
 }
 
 func resolveLocalDispatchAgent(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string, record db.Repo) (db.Agent, func(context.Context) error, error) {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 	"github.com/jerryfane/gitmoot/internal/workflow"
@@ -621,6 +623,192 @@ func TestRunAgentAskDispatchesAndStoresResult(t *testing.T) {
 	}
 	if jsonPayload.Branch != "feature/local-ask" || jsonPayload.Instructions != "- Write JSON" {
 		t.Fatalf("json ask payload = %+v", jsonPayload)
+	}
+}
+
+func TestSelectAgentRunAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		options agentRunOptions
+		action  string
+	}{
+		{name: "task selects implement", options: agentRunOptions{taskID: "task-1", message: "anything"}, action: "implement"},
+		{name: "pr selects review", options: agentRunOptions{prNumber: 7, message: "anything"}, action: "review"},
+		{name: "head sha selects review", options: agentRunOptions{headSHA: strings.Repeat("a", 40), message: "anything"}, action: "review"},
+		{name: "review language selects review", options: agentRunOptions{message: "please review this PR"}, action: "review"},
+		{name: "implementation language selects implement", options: agentRunOptions{message: "update docs and add tests"}, action: "implement"},
+		{name: "write code selects implement", options: agentRunOptions{message: "write code for the new command"}, action: "implement"},
+		{name: "code question selects ask", options: agentRunOptions{message: "what does this code do?"}, action: "ask"},
+		{name: "plain question selects ask", options: agentRunOptions{message: "what is the risk here?"}, action: "ask"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action, _ := selectAgentRunAction(tt.options)
+			if action != tt.action {
+				t.Fatalf("action = %q, want %q", action, tt.action)
+			}
+		})
+	}
+}
+
+func TestRunAgentAskBlocksWorkflowOrchestration(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "ask", "planner", "create branch, commit, push, and open PR"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "This looks like implementation workflow orchestration") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestWorkflowOrchestrationGuardAllowsCommitQuestions(t *testing.T) {
+	if looksLikeWorkflowOrchestration("Which commit introduced this regression?") {
+		t.Fatal("commit analysis question was incorrectly treated as workflow orchestration")
+	}
+	if !looksLikeWorkflowOrchestration("commit and push the branch, then open a PR") {
+		t.Fatal("explicit commit/push/PR workflow was not treated as workflow orchestration")
+	}
+}
+
+func TestPrepareLocalReviewDispatchRequestCreatesReviewWorktree(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "switch", "-c", "feature/review")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "feature")
+	head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	runGit(t, repoDir, "switch", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
+	request, checkout, err := prepareLocalReviewDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
+		Home:         home,
+		Agent:        "audit",
+		Action:       "review",
+		Instructions: "Review this PR.",
+		PullRequest:  12,
+		Branch:       "feature/review",
+		HeadSHA:      head,
+	})
+	if err != nil {
+		t.Fatalf("prepareLocalReviewDispatchRequest returned error: %v", err)
+	}
+	if request.TaskID == "" || checkout == "" {
+		t.Fatalf("request.TaskID=%q checkout=%q", request.TaskID, checkout)
+	}
+	reviewHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("review HeadSHA returned error: %v", err)
+	}
+	if reviewHead != head {
+		t.Fatalf("review worktree head = %q, want %q", reviewHead, head)
+	}
+	branch, err := (gitutil.Client{Dir: repoDir}).CurrentBranch(ctx)
+	if err != nil {
+		t.Fatalf("CurrentBranch returned error: %v", err)
+	}
+	if branch != "main" {
+		t.Fatalf("registered checkout branch = %q, want main", branch)
+	}
+	task, err := store.GetTask(ctx, request.TaskID)
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.WorktreePath != checkout || task.State != string(workflow.TaskReviewing) {
+		t.Fatalf("task = %+v, checkout=%q", task, checkout)
+	}
+}
+
+func TestPrepareLocalReviewDispatchRequestDoesNotReuseStaleReviewWorktree(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	staleWorktree := filepath.Join(home, "stale")
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "switch", "-c", "feature/review")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("old feature\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "old feature")
+	oldHead, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("old HeadSHA returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "--detach", staleWorktree, oldHead)
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("new feature\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "new feature")
+	newHead, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("new HeadSHA returned error: %v", err)
+	}
+	runGit(t, repoDir, "switch", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{ID: "stale-review", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Stale review", State: string(workflow.TaskReviewing), Branch: "feature/review", WorktreePath: staleWorktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
+	request, checkout, err := prepareLocalReviewDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
+		Home:         home,
+		Agent:        "audit",
+		Action:       "review",
+		Instructions: "Review this PR.",
+		PullRequest:  12,
+		Branch:       "feature/review",
+		HeadSHA:      newHead,
+	})
+	if err != nil {
+		t.Fatalf("prepareLocalReviewDispatchRequest returned error: %v", err)
+	}
+	if checkout == staleWorktree || request.TaskID == "stale-review" {
+		t.Fatalf("reused stale checkout=%q taskID=%q", checkout, request.TaskID)
+	}
+	reviewHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("review HeadSHA returned error: %v", err)
+	}
+	if reviewHead != newHead {
+		t.Fatalf("review worktree head = %q, want %q", reviewHead, newHead)
+	}
+	staleHead, err := (gitutil.Client{Dir: staleWorktree}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("stale HeadSHA returned error: %v", err)
+	}
+	if staleHead != oldHead {
+		t.Fatalf("stale worktree head = %q, want %q", staleHead, oldHead)
 	}
 }
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2301,12 +2301,210 @@ func (w jobWorker) defaultCommenter(_ string) github.Client {
 
 func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string) workflow.Engine {
 	return workflow.Engine{
-		Store:     store,
-		MergeGate: daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout},
+		Store:                   store,
+		MergeGate:               daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout},
+		ImplementationFinalizer: daemonImplementationFinalizer{Store: store, GitHub: gh, FallbackCheckout: checkout},
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},
 	}
+}
+
+type daemonImplementationFinalizer struct {
+	Store            *db.Store
+	GitHub           github.Client
+	FallbackCheckout string
+}
+
+func (f daemonImplementationFinalizer) FinalizeImplementation(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
+	if f.Store == nil {
+		return workflow.JobPayload{}, errors.New("implementation finalizer store is required")
+	}
+	if strings.TrimSpace(payload.TaskID) == "" {
+		return payload, workflow.BlockedError{Reason: "implemented job has no task id; cannot finalize branch and PR"}
+	}
+	task, err := f.Store.GetTask(ctx, payload.TaskID)
+	if err != nil {
+		return payload, fmt.Errorf("load task %s for implementation finalizer: %w", payload.TaskID, err)
+	}
+	if strings.TrimSpace(task.WorktreePath) == "" {
+		return payload, workflow.BlockedError{Reason: "implemented task has no worktree path; rerun through gitmoot task run or gitmoot agent implement"}
+	}
+	if strings.TrimSpace(task.Branch) == "" {
+		return payload, workflow.BlockedError{Reason: "implemented task has no branch; cannot push or open PR"}
+	}
+	git := gitutil.Client{Dir: task.WorktreePath}
+	branch, err := git.CurrentBranch(ctx)
+	if err != nil {
+		return payload, fmt.Errorf("resolve implementation branch: %w", err)
+	}
+	if branch != task.Branch {
+		return payload, workflow.BlockedError{Reason: fmt.Sprintf("implemented task worktree is on branch %s, not %s", branch, task.Branch)}
+	}
+	status, err := git.StatusPorcelain(ctx)
+	if err != nil {
+		return payload, fmt.Errorf("inspect implementation diff: %w", err)
+	}
+	if strings.TrimSpace(status) == "" {
+		head, err := git.HeadSHA(ctx)
+		if err != nil {
+			return payload, fmt.Errorf("resolve clean implementation head: %w", err)
+		}
+		if strings.TrimSpace(payload.HeadSHA) == "" || head == payload.HeadSHA {
+			if payload.PullRequest > 0 && head == payload.HeadSHA {
+				payload.Branch = task.Branch
+				return payload, nil
+			}
+			return payload, workflow.BlockedError{Reason: "implemented job produced no changes in the task worktree"}
+		}
+	} else {
+		message := "Gitmoot implement " + task.ID
+		if err := git.CommitAll(ctx, message); err != nil {
+			return payload, workflow.BlockedError{Reason: "commit implementation changes failed: " + err.Error()}
+		}
+	}
+	head, err := git.HeadSHA(ctx)
+	if err != nil {
+		return payload, fmt.Errorf("resolve implementation head after commit: %w", err)
+	}
+	if err := git.PushBranch(ctx, "origin", task.Branch); err != nil {
+		return payload, workflow.BlockedError{Reason: "push implementation branch failed: " + err.Error()}
+	}
+	repo, err := daemon.ParseRepository(payload.Repo)
+	if err != nil {
+		return payload, err
+	}
+	record, err := f.Store.GetRepo(ctx, payload.Repo)
+	if err != nil {
+		return payload, err
+	}
+	base := strings.TrimSpace(record.DefaultBranch)
+	if base == "" {
+		base = "main"
+	}
+	if existing, ok, err := existingBranchPullRequest(ctx, f.Store, payload.Repo, task.Branch); err != nil {
+		return payload, err
+	} else if ok {
+		payload.PullRequest = int(existing.Number)
+		payload.HeadSHA = head
+		payload.Branch = task.Branch
+		if err := f.Store.UpsertPullRequest(ctx, db.PullRequest{
+			RepoFullName: payload.Repo,
+			Number:       existing.Number,
+			URL:          existing.URL,
+			HeadBranch:   task.Branch,
+			BaseBranch:   firstNonEmpty(existing.BaseBranch, base),
+			HeadSHA:      head,
+			State:        firstNonEmpty(existing.State, "open"),
+		}); err != nil {
+			return payload, err
+		}
+		return payload, nil
+	}
+	pr, err := f.githubClient(task.WorktreePath).CreatePullRequest(ctx, github.CreatePullRequestInput{
+		Repo:  repo,
+		Title: finalizerPullRequestTitle(task),
+		Body:  finalizerPullRequestBody(job, payload, task),
+		Head:  task.Branch,
+		Base:  base,
+	})
+	if err != nil {
+		return payload, workflow.BlockedError{Reason: "open implementation PR failed: " + err.Error()}
+	}
+	payload.PullRequest = int(pr.Number)
+	payload.Branch = task.Branch
+	payload.HeadSHA = firstNonEmpty(pr.HeadSHA, head)
+	if payload.TaskTitle == "" {
+		payload.TaskTitle = task.Title
+	}
+	if payload.GoalID == "" {
+		payload.GoalID = task.GoalID
+	}
+	if err := f.Store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: payload.Repo,
+		Number:       pr.Number,
+		URL:          pr.URL,
+		HeadBranch:   firstNonEmpty(pr.HeadRef, task.Branch),
+		BaseBranch:   firstNonEmpty(pr.BaseRef, base),
+		HeadSHA:      payload.HeadSHA,
+		State:        firstNonEmpty(pr.State, "open"),
+	}); err != nil {
+		return payload, err
+	}
+	return payload, nil
+}
+
+func (f daemonImplementationFinalizer) githubClient(checkout string) github.Client {
+	if f.GitHub == nil {
+		return github.NewClient(checkout)
+	}
+	if _, ok := f.GitHub.(*github.GhClient); ok {
+		return github.NewClient(checkout)
+	}
+	return f.GitHub
+}
+
+func existingBranchPullRequest(ctx context.Context, store *db.Store, repo string, branch string) (db.PullRequest, bool, error) {
+	pr, err := store.GetPullRequestByRepoBranch(ctx, repo, branch)
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.PullRequest{}, false, nil
+	}
+	if err != nil {
+		return db.PullRequest{}, false, err
+	}
+	if strings.EqualFold(pr.State, "closed") || strings.EqualFold(pr.State, "merged") {
+		return db.PullRequest{}, false, nil
+	}
+	return pr, true, nil
+}
+
+func finalizerPullRequestTitle(task db.Task) string {
+	title := strings.TrimSpace(task.Title)
+	if title == "" {
+		title = task.ID
+	}
+	return "Gitmoot: " + title
+}
+
+func finalizerPullRequestBody(job db.Job, payload workflow.JobPayload, task db.Task) string {
+	summary := ""
+	if payload.Result != nil {
+		summary = strings.TrimSpace(payload.Result.Summary)
+	}
+	if summary == "" {
+		summary = "Implementation completed by " + job.Agent + "."
+	}
+	body, err := workflow.RenderPullRequestBody(workflow.PullRequestBody{
+		TaskID:          task.ID,
+		AgentNames:      []string{job.Agent},
+		What:            summary,
+		Why:             "Gitmoot finalized this implementation from a task worktree.",
+		Changes:         []string{"Committed changes from " + task.WorktreePath},
+		Results:         finalizerResults(payload),
+		Risk:            "Review the generated diff before merging.",
+		RawReviewOutput: rawFinalizerOutput(payload),
+	})
+	if err == nil {
+		return body
+	}
+	return summary
+}
+
+func finalizerResults(payload workflow.JobPayload) []string {
+	if payload.Result == nil || len(payload.Result.TestsRun) == 0 {
+		return []string{"No tests reported by the implementing agent."}
+	}
+	return append([]string{}, payload.Result.TestsRun...)
+}
+
+func rawFinalizerOutput(payload workflow.JobPayload) string {
+	if payload.Result != nil && strings.TrimSpace(payload.Result.Summary) != "" {
+		return payload.Result.Summary
+	}
+	if len(payload.RawOutputs) > 0 {
+		return payload.RawOutputs[len(payload.RawOutputs)-1]
+	}
+	return "Implementation completed."
 }
 
 type daemonMergeGate struct {
@@ -2363,11 +2561,13 @@ func refreshDaemonJobPayload(ctx context.Context, store *db.Store, checkout stri
 	if job.Type != "implement" || payload.Result == nil || payload.Result.Decision != "implemented" {
 		return payload, nil
 	}
-	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
-	if err != nil {
-		return workflow.JobPayload{}, err
+	if !payloadHasTaskWorktree(ctx, store, payload) {
+		head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+		if err != nil {
+			return workflow.JobPayload{}, err
+		}
+		payload.HeadSHA = head
 	}
-	payload.HeadSHA = head
 	if len(payload.Reviewers) == 0 {
 		reviewers, err := daemonReviewers(ctx, store, payload.Repo)
 		if err != nil {
@@ -2376,6 +2576,21 @@ func refreshDaemonJobPayload(ctx context.Context, store *db.Store, checkout stri
 		payload.Reviewers = reviewers
 	}
 	return payload, nil
+}
+
+func payloadHasTaskWorktree(ctx context.Context, store *db.Store, payload workflow.JobPayload) bool {
+	if store == nil {
+		return false
+	}
+	taskID := strings.TrimSpace(payload.TaskID)
+	if taskID == "" {
+		return false
+	}
+	task, err := store.GetTask(ctx, taskID)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(task.WorktreePath) != ""
 }
 
 func daemonReviewers(ctx context.Context, store *db.Store, repo string) ([]string, error) {
@@ -2419,8 +2634,14 @@ func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload work
 			return "", err
 		}
 	case "review":
-		if err := w.validateTargetCheckout(ctx, payload, checkout); err != nil {
-			return "", err
+		if payload.PullRequest > 0 && strings.TrimSpace(payload.TaskID) != "" {
+			if err := w.validateReviewCheckout(ctx, payload, checkout); err != nil {
+				return "", err
+			}
+		} else {
+			if err := w.validateTargetCheckout(ctx, payload, checkout); err != nil {
+				return "", err
+			}
 		}
 	case "ask":
 		if payload.PullRequest > 0 {
@@ -2527,6 +2748,29 @@ func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.
 	}
 	if head != expectedHead {
 		return fmt.Errorf("checkout head is %s, not job head %s", head, expectedHead)
+	}
+	return nil
+}
+
+func (w jobWorker) validateReviewCheckout(ctx context.Context, payload workflow.JobPayload, checkout string) error {
+	git := gitutil.Client{Dir: checkout}
+	clean, err := git.WorktreeClean(ctx)
+	if err != nil {
+		return err
+	}
+	if !clean {
+		return fmt.Errorf("checkout %s has uncommitted changes", checkout)
+	}
+	expectedHead := strings.TrimSpace(payload.HeadSHA)
+	if expectedHead == "" {
+		return fmt.Errorf("review job for PR #%d has no head SHA", payload.PullRequest)
+	}
+	head, err := git.HeadSHA(ctx)
+	if err != nil {
+		return err
+	}
+	if head != expectedHead {
+		return fmt.Errorf("checkout head is %s, not review job head %s", head, expectedHead)
 	}
 	return nil
 }

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -2238,6 +2238,75 @@ func TestRunQueuedJobsUsesTaskWorktreeForImplement(t *testing.T) {
 	}
 }
 
+func TestRefreshDaemonJobPayloadPreservesTaskWorktreeHeadForFinalizer(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	checkout := filepath.Join(home, "repo")
+	worktree := filepath.Join(home, "task-1")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, checkout)
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot Test")
+	if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "branch", "-m", "main")
+	runGit(t, checkout, "push", "-u", "origin", "main")
+	runGit(t, checkout, "worktree", "add", "-b", "task-1", worktree, "main")
+	oldHead, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{RepoFullName: "owner/repo", Number: 12, URL: "https://github.com/owner/repo/pull/12", HeadBranch: "task-1", BaseBranch: "main", HeadSHA: oldHead, State: "open"}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, "feature.txt"), []byte("self committed\n"), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+	runGit(t, worktree, "add", "feature.txt")
+	runGit(t, worktree, "commit", "-m", "agent self commit")
+	newHead, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	if newHead == oldHead {
+		t.Fatal("worker did not create a new commit")
+	}
+	payload := workflow.JobPayload{Repo: "owner/repo", Branch: "task-1", PullRequest: 12, HeadSHA: oldHead, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1", Result: &workflow.AgentResult{Decision: "implemented", Summary: "done"}}
+	refreshed, err := refreshDaemonJobPayload(ctx, store, worktree, db.Job{ID: "job-implement-worktree", Agent: "lead", Type: "implement"}, payload)
+	if err != nil {
+		t.Fatalf("refreshDaemonJobPayload returned error: %v", err)
+	}
+	if refreshed.HeadSHA != oldHead {
+		t.Fatalf("refreshed head = %q, want original %q", refreshed.HeadSHA, oldHead)
+	}
+	finalized, err := (daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}).FinalizeImplementation(ctx, db.Job{ID: "job-implement-worktree", Agent: "lead", Type: "implement"}, refreshed)
+	if err != nil {
+		t.Fatalf("FinalizeImplementation returned error: %v", err)
+	}
+	if finalized.HeadSHA != newHead {
+		t.Fatalf("finalized head = %q, want %q", finalized.HeadSHA, newHead)
+	}
+	remoteHead := strings.TrimSpace(runGitOutput(t, checkout, "ls-remote", "origin", "refs/heads/task-1"))
+	if !strings.Contains(remoteHead, newHead) {
+		t.Fatalf("remote task branch %q does not contain local head %q", remoteHead, newHead)
+	}
+}
+
 func TestRunQueuedJobsResumesDelegatedImplementWithOriginalBranchLock(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -2348,6 +2417,246 @@ func TestRunQueuedJobsUsesTaskWorktreeForReview(t *testing.T) {
 	}
 	if adapter.calls != 1 {
 		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+}
+
+func TestDaemonImplementationFinalizerCommitsBeforeReusingExistingPullRequest(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	runGit(t, repoDir, "switch", "-c", "task-1")
+	if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("new work\n"), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: repoDir}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{RepoFullName: "owner/repo", Number: 12, URL: "https://github.com/owner/repo/pull/12", HeadBranch: "task-1", BaseBranch: "main", HeadSHA: "old", State: "open"}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}
+	payload := workflow.JobPayload{
+		Repo:      "owner/repo",
+		Branch:    "task-1",
+		GoalID:    "goal-1",
+		TaskID:    "task-1",
+		TaskTitle: "Task 1",
+		LeadAgent: "lead",
+		Result:    &workflow.AgentResult{Decision: "implemented", Summary: "done"},
+	}
+
+	finalized, err := finalizer.FinalizeImplementation(ctx, db.Job{ID: "job-1", Agent: "lead", Type: "implement"}, payload)
+	if err != nil {
+		t.Fatalf("FinalizeImplementation returned error: %v", err)
+	}
+
+	if finalized.PullRequest != 12 {
+		t.Fatalf("pull request = %d, want 12", finalized.PullRequest)
+	}
+	clean, err := (gitutil.Client{Dir: repoDir}).WorktreeClean(ctx)
+	if err != nil {
+		t.Fatalf("WorktreeClean returned error: %v", err)
+	}
+	if !clean {
+		t.Fatal("worktree still has uncommitted changes")
+	}
+	localHead, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	if finalized.HeadSHA != localHead {
+		t.Fatalf("finalized head = %q, want %q", finalized.HeadSHA, localHead)
+	}
+	remoteHead := strings.TrimSpace(runGitOutput(t, repoDir, "ls-remote", "origin", "refs/heads/task-1"))
+	if !strings.Contains(remoteHead, localHead) {
+		t.Fatalf("remote task branch %q does not contain local head %q", remoteHead, localHead)
+	}
+}
+
+func TestDaemonImplementationFinalizerPushesAlreadyCommittedWork(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	runGit(t, repoDir, "switch", "-c", "task-1")
+	oldHead, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("already committed\n"), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+	runGit(t, repoDir, "add", "feature.txt")
+	runGit(t, repoDir, "commit", "-m", "agent commit")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: repoDir}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{RepoFullName: "owner/repo", Number: 12, URL: "https://github.com/owner/repo/pull/12", HeadBranch: "task-1", BaseBranch: "main", HeadSHA: oldHead, State: "open"}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}
+	payload := workflow.JobPayload{
+		Repo:      "owner/repo",
+		Branch:    "task-1",
+		HeadSHA:   oldHead,
+		GoalID:    "goal-1",
+		TaskID:    "task-1",
+		TaskTitle: "Task 1",
+		LeadAgent: "lead",
+		Result:    &workflow.AgentResult{Decision: "implemented", Summary: "done"},
+	}
+
+	finalized, err := finalizer.FinalizeImplementation(ctx, db.Job{ID: "job-1", Agent: "lead", Type: "implement"}, payload)
+	if err != nil {
+		t.Fatalf("FinalizeImplementation returned error: %v", err)
+	}
+	localHead, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	if finalized.HeadSHA != localHead || finalized.HeadSHA == oldHead {
+		t.Fatalf("finalized head = %q, local=%q old=%q", finalized.HeadSHA, localHead, oldHead)
+	}
+	remoteHead := strings.TrimSpace(runGitOutput(t, repoDir, "ls-remote", "origin", "refs/heads/task-1"))
+	if !strings.Contains(remoteHead, localHead) {
+		t.Fatalf("remote task branch %q does not contain local head %q", remoteHead, localHead)
+	}
+}
+
+func TestDaemonImplementationFinalizerBlocksWrongBranch(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	runGit(t, repoDir, "switch", "-c", "wrong-branch")
+	if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("wrong branch work\n"), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: repoDir}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}
+	payload := workflow.JobPayload{
+		Repo:      "owner/repo",
+		Branch:    "task-1",
+		GoalID:    "goal-1",
+		TaskID:    "task-1",
+		TaskTitle: "Task 1",
+		LeadAgent: "lead",
+		Result:    &workflow.AgentResult{Decision: "implemented", Summary: "done"},
+	}
+
+	_, err := finalizer.FinalizeImplementation(ctx, db.Job{ID: "job-1", Agent: "lead", Type: "implement"}, payload)
+	var blocked workflow.BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("FinalizeImplementation error = %v, want BlockedError", err)
+	}
+	if !strings.Contains(blocked.Reason, "not task-1") {
+		t.Fatalf("blocked reason = %q", blocked.Reason)
+	}
+}
+
+func TestDaemonImplementationFinalizerAllowsAlreadyFinalizedPullRequest(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	runGit(t, repoDir, "switch", "-c", "task-1")
+	head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: repoDir}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}
+	payload := workflow.JobPayload{
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 12,
+		HeadSHA:     head,
+		GoalID:      "goal-1",
+		TaskID:      "task-1",
+		TaskTitle:   "Task 1",
+		LeadAgent:   "lead",
+		Result:      &workflow.AgentResult{Decision: "implemented", Summary: "done"},
+	}
+
+	finalized, err := finalizer.FinalizeImplementation(ctx, db.Job{ID: "job-1", Agent: "lead", Type: "implement"}, payload)
+	if err != nil {
+		t.Fatalf("FinalizeImplementation returned error: %v", err)
+	}
+	if finalized.HeadSHA != head || finalized.PullRequest != 12 || finalized.Branch != "task-1" {
+		t.Fatalf("finalized payload = %+v", finalized)
 	}
 }
 

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -54,6 +54,18 @@ func (c Client) AddExistingBranchWorktree(ctx context.Context, branch string, pa
 	return err
 }
 
+func (c Client) AddDetachedWorktree(ctx context.Context, path string, ref string) error {
+	path, err := validateWorktreePath(path)
+	if err != nil {
+		return err
+	}
+	if err := validateRef(ref); err != nil {
+		return err
+	}
+	_, err = c.run(ctx, "worktree", "add", "--detach", path, ref)
+	return err
+}
+
 func (c Client) BranchExists(ctx context.Context, branch string) (bool, error) {
 	if err := validateBranch(branch); err != nil {
 		return false, err
@@ -97,6 +109,17 @@ func (c Client) PushBranch(ctx context.Context, remote string, branch string) er
 	return err
 }
 
+func (c Client) FetchPullRequest(ctx context.Context, remote string, number int) error {
+	if strings.TrimSpace(remote) == "" {
+		remote = "origin"
+	}
+	if number <= 0 {
+		return errors.New("pull request number must be positive")
+	}
+	_, err := c.run(ctx, "fetch", remote, fmt.Sprintf("pull/%d/head", number))
+	return err
+}
+
 func (c Client) Root(ctx context.Context) (string, error) {
 	result, err := c.run(ctx, "rev-parse", "--show-toplevel")
 	if err != nil {
@@ -127,6 +150,26 @@ func (c Client) WorktreeClean(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	return strings.TrimSpace(result.Stdout) == "", nil
+}
+
+func (c Client) StatusPorcelain(ctx context.Context) (string, error) {
+	result, err := c.run(ctx, "status", "--porcelain")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result.Stdout), nil
+}
+
+func (c Client) CommitAll(ctx context.Context, message string) error {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return errors.New("commit message is required")
+	}
+	if _, err := c.run(ctx, "add", "-A"); err != nil {
+		return err
+	}
+	_, err := c.run(ctx, "commit", "-m", message)
+	return err
 }
 
 func (c Client) HeadSHA(ctx context.Context) (string, error) {
@@ -193,6 +236,19 @@ func validateBranch(branch string) error {
 		return fmt.Errorf("branch %q must not start or end with '/'", branch)
 	case strings.HasSuffix(branch, ".lock"):
 		return fmt.Errorf("branch %q must not end with .lock", branch)
+	}
+	return nil
+}
+
+func validateRef(ref string) error {
+	ref = strings.TrimSpace(ref)
+	switch {
+	case ref == "":
+		return errors.New("git ref is required")
+	case strings.HasPrefix(ref, "-"):
+		return fmt.Errorf("git ref %q must not start with '-'", ref)
+	case strings.ContainsAny(ref, " \t\r\n"):
+		return fmt.Errorf("git ref %q must not contain whitespace", ref)
 	}
 	return nil
 }

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -92,6 +92,7 @@ func TestCanonicalSkillDocumentsLocalAgentAsk(t *testing.T) {
 			name: "skill",
 			text: text,
 			want: []string{
+				"gitmoot agent run <agent>",
 				"gitmoot agent ask <agent>",
 				"The plugin is only the runtime discovery surface",
 				"gitmoot agent prompt <agent-or-template>",
@@ -102,9 +103,10 @@ func TestCanonicalSkillDocumentsLocalAgentAsk(t *testing.T) {
 			name: "cli",
 			text: cli,
 			want: []string{
+				"gitmoot agent run project-planner --repo owner/repo",
 				"gitmoot agent ask project-planner --repo owner/repo",
 				"gitmoot agent prompt frontend-reviewer",
-				"replace `gitmoot agent ask`",
+				"agent ask` is for analysis, planning, and questions only",
 				"gitmoot agent type set planner",
 				"gitmoot job watch <job-id>",
 			},

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -14,11 +14,12 @@ import (
 )
 
 type Engine struct {
-	Store             *db.Store
-	RequiredReviewers []string
-	MergeGate         MergeGate
-	JobID             func(JobRequest) string
-	PayloadRefresher  func(context.Context, db.Job, JobPayload) (JobPayload, error)
+	Store                   *db.Store
+	RequiredReviewers       []string
+	MergeGate               MergeGate
+	JobID                   func(JobRequest) string
+	PayloadRefresher        func(context.Context, db.Job, JobPayload) (JobPayload, error)
+	ImplementationFinalizer ImplementationFinalizer
 }
 
 type PullRequestEvent struct {
@@ -53,6 +54,10 @@ type MergeDecision struct {
 
 type MergeGate interface {
 	Evaluate(ctx context.Context, request MergeRequest) (MergeDecision, error)
+}
+
+type ImplementationFinalizer interface {
+	FinalizeImplementation(ctx context.Context, job db.Job, payload JobPayload) (JobPayload, error)
 }
 
 type BlockedError struct {
@@ -259,6 +264,20 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 		if payload.Result.Decision != "implemented" {
 			return nil
 		}
+		if e.implementationNeedsFinalizer(ctx, payload) {
+			finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
+			if err != nil {
+				return err
+			}
+			encoded, err := marshalPayload(finalized)
+			if err != nil {
+				return err
+			}
+			if err := e.Store.UpdateJobPayload(ctx, job.ID, encoded); err != nil {
+				return err
+			}
+			payload = finalized
+		}
 		if payload.PullRequest <= 0 {
 			return e.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_skipped_no_pr", Message: "no pull request is attached; skipping PR advancement"})
 		}
@@ -305,6 +324,21 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 		}
 	}
 	return nil
+}
+
+func (e Engine) implementationNeedsFinalizer(ctx context.Context, payload JobPayload) bool {
+	if e.ImplementationFinalizer == nil {
+		return false
+	}
+	taskID := strings.TrimSpace(payload.TaskID)
+	if taskID == "" {
+		return false
+	}
+	task, err := e.Store.GetTask(ctx, taskID)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(task.WorktreePath) != ""
 }
 
 func reviewDecisionAgent(job db.Job, payload JobPayload) string {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -267,6 +267,163 @@ func TestEngineAdvanceImplementSkipsPullRequestFlowWhenNoPullRequest(t *testing.
 	t.Fatalf("events = %+v, want advance_skipped_no_pr", events)
 }
 
+func TestEngineAdvanceImplementDoesNotFinalizeWithoutTaskWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{err: errors.New("finalizer should not run")}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-job",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-7",
+		GoalID:    "goal-1",
+		TaskID:    "task-7",
+		TaskTitle: "Workflow Engine",
+		LeadAgent: "lead",
+		Result:    &AgentResult{Decision: "implemented", Summary: "done locally"},
+	})
+
+	err := engine.AdvanceJob(ctx, "implement-job")
+
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	events, err := store.ListJobEvents(ctx, "implement-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == "advance_skipped_no_pr" {
+			return
+		}
+	}
+	t.Fatalf("events = %+v, want advance_skipped_no_pr", events)
+}
+
+func TestEngineAdvanceImplementUsesFinalizerBeforePullRequestFlow(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RequiredReviewers = []string{"audit"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-7",
+		RepoFullName: "jerryfane/gitmoot",
+		GoalID:       "goal-1",
+		Title:        "Workflow Engine",
+		State:        string(TaskImplementing),
+		Branch:       "task-7",
+		WorktreePath: "/tmp/gitmoot-task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{
+		payload: JobPayload{
+			Repo:        "jerryfane/gitmoot",
+			Branch:      "task-7",
+			PullRequest: 8,
+			HeadSHA:     "head-after-finalizer",
+			GoalID:      "goal-1",
+			TaskID:      "task-7",
+			TaskTitle:   "Workflow Engine",
+			LeadAgent:   "lead",
+			Result:      &AgentResult{Decision: "implemented", Summary: "done locally"},
+		},
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-job",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-7",
+		GoalID:    "goal-1",
+		TaskID:    "task-7",
+		TaskTitle: "Workflow Engine",
+		LeadAgent: "lead",
+		Result:    &AgentResult{Decision: "implemented", Summary: "done locally"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "implement-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	latest := mustJob(t, store, "implement-job")
+	payload, err := unmarshalPayload(latest.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.PullRequest != 8 || payload.HeadSHA != "head-after-finalizer" {
+		t.Fatalf("payload PR/head = #%d %q", payload.PullRequest, payload.HeadSHA)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+	mustJob(t, store, "review-audit-task-7-review-1")
+}
+
+func TestEngineAdvanceExistingPullRequestImplementStillUsesFinalizer(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-7",
+		RepoFullName: "jerryfane/gitmoot",
+		GoalID:       "goal-1",
+		Title:        "Workflow Engine",
+		State:        string(TaskImplementing),
+		Branch:       "task-7",
+		WorktreePath: "/tmp/gitmoot-task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{
+		payload: JobPayload{
+			Repo:        "jerryfane/gitmoot",
+			Branch:      "task-7",
+			PullRequest: 7,
+			HeadSHA:     "head-after-finalizer",
+			GoalID:      "goal-1",
+			TaskID:      "task-7",
+			TaskTitle:   "Workflow Engine",
+			LeadAgent:   "lead",
+			Result:      &AgentResult{Decision: "implemented", Summary: "fixed requested changes"},
+		},
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-job",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		HeadSHA:     "old-head",
+		GoalID:      "goal-1",
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "implemented", Summary: "fixed requested changes"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "implement-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	latest := mustJob(t, store, "implement-job")
+	payload, err := unmarshalPayload(latest.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.HeadSHA != "head-after-finalizer" {
+		t.Fatalf("payload HeadSHA = %q, want finalizer head", payload.HeadSHA)
+	}
+}
+
 func TestEngineRunJobAdvancesCompletedResult(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -1392,6 +1549,18 @@ func mustJob(t *testing.T, store *db.Store, jobID string) db.Job {
 		t.Fatalf("GetJob(%s) returned error: %v", jobID, err)
 	}
 	return job
+}
+
+type fakeImplementationFinalizer struct {
+	payload JobPayload
+	err     error
+}
+
+func (f fakeImplementationFinalizer) FinalizeImplementation(context.Context, db.Job, JobPayload) (JobPayload, error) {
+	if f.err != nil {
+		return JobPayload{}, f.err
+	}
+	return f.payload, nil
 }
 
 type fakeMergeGate struct {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -75,7 +75,7 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	if err != nil {
 		var blocked BlockedError
 		if errors.As(err, &blocked) {
-			return g.block(ctx, request, headSHA, blocked.Reason)
+			return MergeDecision{}, fmt.Errorf("merge gate checkout is busy: %s", blocked.Reason)
 		}
 		return MergeDecision{}, err
 	}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -270,7 +270,7 @@ func TestPolicyMergeGateLocksCheckoutDuringLocalBaseUpdate(t *testing.T) {
 	}
 }
 
-func TestPolicyMergeGateReportsBusyCheckoutForLocalBaseUpdate(t *testing.T) {
+func TestPolicyMergeGateReturnsRetryableErrorForBusyCheckout(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
@@ -306,17 +306,27 @@ func TestPolicyMergeGateReportsBusyCheckoutForLocalBaseUpdate(t *testing.T) {
 
 	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9", Reviewer: "audit"})
 
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
+	if err == nil {
+		t.Fatal("Evaluate returned nil error, want retryable checkout-busy error")
 	}
-	if decision.Ready || decision.Merged || !strings.Contains(decision.Reason, checkoutMutationBusyMessage) {
-		t.Fatalf("decision = %+v, want blocked checkout busy decision", decision)
+	var blocked BlockedError
+	if errors.As(err, &blocked) {
+		t.Fatalf("Evaluate error = %v, should not expose checkout contention as policy BlockedError", err)
+	}
+	if !strings.Contains(err.Error(), checkoutMutationBusyMessage) {
+		t.Fatalf("Evaluate error = %v, want checkout busy message", err)
+	}
+	if decision.Ready || decision.Merged {
+		t.Fatalf("decision = %+v, want no merge decision on checkout contention", decision)
 	}
 	if len(gh.merges) != 0 {
 		t.Fatalf("merge ran despite checkout lock: %+v", gh.merges)
 	}
 	if len(git.updated) != 0 {
 		t.Fatalf("UpdateBase ran despite checkout lock: %+v", git.updated)
+	}
+	if _, err := store.GetMergeGate(ctx, "jerryfane/gitmoot", 9); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetMergeGate after checkout contention = %v, want sql.ErrNoRows", err)
 	}
 }
 

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -60,9 +60,14 @@ Use `gitmoot status --repo owner/repo` for repo status, `gitmoot daemon status`
 for daemon state, `gitmoot agent list` and `gitmoot agent show <agent>` for
 registered agents, `gitmoot task list --repo owner/repo` for imported task
 state, and `gitmoot agent prompt <agent-or-template>` to import an agent prompt
-into the current chat. Use `gitmoot agent ask <agent> --repo owner/repo "..."`
-to invoke a registered Gitmoot agent through the runtime adapter path. Add
-`--background` only when the user wants a queued background job. Use
+into the current chat. Use `gitmoot agent run <agent> --repo owner/repo "..."`
+for coordinator delegation so Gitmoot can route to ask, review, or implement
+and own worktrees, branch locks, commits, pushes, PRs, and workflow
+advancement. Use `gitmoot agent ask <agent> --repo owner/repo "..."` only for
+analysis, planning, or questions. Use `gitmoot agent review <agent> --repo
+owner/repo --pr <number> "..."` for PR review decisions and `gitmoot agent
+implement <agent> --repo owner/repo --task <task-id> "..."` for file changes.
+Add `--background` only when the user wants a queued background job. Use
 `gitmoot job list --repo owner/repo` for queued or recent jobs. Use
 `gitmoot plugin doctor` when checking whether Codex or Claude Code can discover
 Gitmoot through an installed runtime plugin. Use `gitmoot goal template` when

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -96,18 +96,28 @@ gitmoot agent repos reviewer
 gitmoot agent doctor reviewer
 ```
 
-Ask a registered agent from the current local chat:
+Delegate to a registered agent from the current local chat:
 
 ```sh
+gitmoot agent run project-planner --repo owner/repo "Return the plan status."
+gitmoot agent run lead --repo owner/repo --task task-001 --background "Implement this task."
+gitmoot agent run reviewer --repo owner/repo --pr 12 --background "Review this PR."
+gitmoot agent review reviewer --repo owner/repo --pr 12 "Review this PR."
+gitmoot agent implement lead --repo owner/repo --task task-001 "Implement this task."
 gitmoot agent ask project-planner --repo owner/repo "Return the plan status."
 gitmoot agent ask project-planner --repo owner/repo --background "Write the implementation plan and goal file."
 gitmoot job watch <job-id>
 ```
 
 This uses the same agent registry, repo access grants, cached template snapshot,
-runtime adapter, and local job history as PR-comment ask jobs. The runtime
+runtime adapter, and local job history as PR-comment jobs. `agent run` is the
+default coordinator-safe entrypoint because it routes to `ask`, `review`, or
+`implement` and keeps branch, worktree, commit, push, PR, and workflow lifecycle
+inside Gitmoot. `agent ask` is for analysis, planning, and questions only; it
+blocks obvious branch/commit/push/PR orchestration unless `--force` is supplied.
+The runtime
 plugin helps Codex or Claude Code discover Gitmoot guidance, but it does not
-replace `gitmoot agent ask`. Synchronous asks and queued jobs both use the same
+replace the Gitmoot CLI. Synchronous jobs and queued jobs both use the same
 runtime session locks.
 
 Configure managed background agent types:

--- a/skills/gitmoot/references/GOAL_TEMPLATE.md
+++ b/skills/gitmoot/references/GOAL_TEMPLATE.md
@@ -23,6 +23,10 @@ main systems touched, and any explicit exclusions.
 - Keep changes clean, scoped, and organized. Avoid broad rewrites.
 - Avoid code duplication. When repeated logic appears, extract small reusable
   helpers that match existing repo patterns.
+- When delegating to Gitmoot agents, use `gitmoot agent run`,
+  `gitmoot agent implement`, `gitmoot agent review`, or `gitmoot task run`.
+  Do not put branch creation, commit, push, PR creation, or merge instructions
+  inside `gitmoot agent ask`; Gitmoot owns repository orchestration.
 - If implementation depends on external APIs, docs, CLIs, data formats,
   generated scripts, installers, service launchers, subprocess calls, env vars,
   config formats, or third-party libraries, verify the real contract with local


### PR DESCRIPTION
## Summary
- Add first-class `gitmoot agent run`, `gitmoot agent review`, and `gitmoot agent implement` paths so coordinators can delegate through Gitmoot-managed workflows instead of asking child agents to self-manage branches, commits, pushes, and PRs.
- Route review jobs through exact PR-head worktrees and implementation jobs through task worktrees, branch locks, and a daemon finalizer that commits, pushes, opens or reuses PRs, and advances review state.
- Add `agent ask` guardrails for branch/commit/push/PR orchestration prompts, plus docs and skill references for the safer command split.

Closes #50.

## Verification
- `git diff --check`
- `/tmp/go1.26.4/bin/go test ./... -timeout 300s`
- `codex exec review --uncommitted` attempted twice; both sessions inspected the diff extensively but exited without a final findings summary. The deterministic checks above passed with Go 1.26.