### PR TITLE
Add merge queue safe branch updates

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -363,7 +363,11 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    Agents review, request fixes, and rerun work through comments and job output.
    When required reviews are approved and the branch is ready, the merge gate
    checks the current PR head, local worktree cleanliness, branch freshness,
-   Gitmoot statuses, external CI if present, and mergeability.
+   Gitmoot statuses, external CI if present, and mergeability. Final merge work
+   is serialized per repository base branch. If a parallel PR became behind the
+   base branch because another PR merged first, Gitmoot asks GitHub to update
+   the PR branch with the expected head SHA and leaves the merge gate pending so
+   the daemon can reload the new head and checks on a later poll tick.
 
 9. Merge and continue.
 
@@ -378,6 +382,9 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
 
 - The machine running `gitmoot daemon start` must stay online.
 - Polling is the V1 mechanism; there is no webhook receiver yet.
+- Retryable merge-gate states are automatic only while the daemon is running.
+  The normal retry latency is the daemon poll interval, `30s` by default unless
+  `--poll` is configured differently.
 - Parallel implementation needs separate task worktrees. Checkout mutation
   operations are serialized per checkout path. If a Codex or Claude session is
   busy and `[parallel_sessions].same_session` is `fork_temp_session`, Gitmoot

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -401,7 +401,15 @@ git status --short
 Fixes:
 
 - Clean the local worktree before the daemon attempts the merge.
-- Update the PR branch if it is behind or diverged from base.
+- If the PR branch is merely behind or diverged from base, keep the daemon
+  running. Gitmoot serializes the base-branch merge gate, asks GitHub to update
+  the PR branch safely, then retries on a later daemon poll tick. The default
+  poll interval is `30s` unless `--poll` was configured differently.
+- If GitHub reports a branch update conflict, Gitmoot stops retrying, posts a
+  PR comment, marks `gitmoot/merge-gate` as failed, records `advance_blocked`
+  when the block came from job advancement, and shows the reason in
+  `gitmoot task list` / `gitmoot job events <job-id>`. Resolve the conflict
+  manually or run an explicit implement/fix job, then rerun review/merge.
 - Fix failing external CI or Gitmoot statuses.
 - Rerun reviews after the PR head SHA changes.
 - If a merged task reports a worktree cleanup warning, inspect the stored task

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -529,6 +529,21 @@ func TestPollOnceRetriesReadyToMergePullRequestWithoutHeadChange(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "builder",
+		Role:           "builder",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "builder"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
 	if err := store.UpsertPullRequest(ctx, db.PullRequest{
 		RepoFullName: repo.FullName(),
 		Number:       7,
@@ -561,6 +576,78 @@ func TestPollOnceRetriesReadyToMergePullRequestWithoutHeadChange(t *testing.T) {
 	}
 	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 || gate.requests[0].HeadSHA != "abc123" {
 		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestPollOnceRetriesReadyToMergePullRequestAfterBranchUpdateHeadChange(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-7",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1",
+		Title:        "Task 7",
+		State:        string(workflow.TaskReadyToMerge),
+		Branch:       "task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "builder",
+		Role:           "builder",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "builder"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       7,
+		URL:          "https://github.com/jerryfane/gitmoot/pull/7",
+		HeadBranch:   "task-7",
+		BaseBranch:   "main",
+		HeadSHA:      "old123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "old123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true, Reason: "branch update requested"}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("first PollOnce returned error: %v", err)
+	}
+	client.pulls[0].HeadSHA = "new456"
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("second PollOnce returned error: %v", err)
+	}
+
+	if len(gate.requests) != 2 {
+		t.Fatalf("merge gate requests = %+v, want 2", gate.requests)
+	}
+	if gate.requests[0].HeadSHA != "old123" || gate.requests[1].HeadSHA != "new456" {
+		t.Fatalf("merge gate request heads = %q, %q; want old123 then new456", gate.requests[0].HeadSHA, gate.requests[1].HeadSHA)
 	}
 }
 
@@ -1802,6 +1889,10 @@ func (f *fakeGitHub) GetUserPermission(_ context.Context, _ github.Repository, u
 
 func (f *fakeGitHub) MergePullRequest(context.Context, github.MergePullRequestInput) (github.MergeResult, error) {
 	return github.MergeResult{}, errors.New("not implemented")
+}
+
+func (f *fakeGitHub) UpdatePullRequestBranch(context.Context, github.UpdatePullRequestBranchInput) (github.UpdatePullRequestBranchResult, error) {
+	return github.UpdatePullRequestBranchResult{}, errors.New("not implemented")
 }
 
 func (f *fakeGitHub) GetPullRequest(context.Context, github.Repository, int64) (github.PullRequest, error) {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -28,6 +28,7 @@ type Client interface {
 	PostIssueComment(ctx context.Context, repo Repository, issueNumber int64, body string) (IssueComment, error)
 	GetUserPermission(ctx context.Context, repo Repository, username string) (UserPermission, error)
 	MergePullRequest(ctx context.Context, input MergePullRequestInput) (MergeResult, error)
+	UpdatePullRequestBranch(ctx context.Context, input UpdatePullRequestBranchInput) (UpdatePullRequestBranchResult, error)
 	GetCombinedStatus(ctx context.Context, repo Repository, ref string) (CombinedStatus, error)
 	CompareCommits(ctx context.Context, repo Repository, base string, head string) (CompareResult, error)
 	ListPullRequestChecks(ctx context.Context, repo Repository, number int64) ([]PullRequestCheck, error)
@@ -173,6 +174,52 @@ type MergeResult struct {
 	SHA     string `json:"sha"`
 	Merged  bool   `json:"merged"`
 	Message string `json:"message"`
+}
+
+type UpdatePullRequestBranchInput struct {
+	Repo            Repository
+	Number          int64
+	ExpectedHeadSHA string
+}
+
+type UpdatePullRequestBranchResult struct {
+	Message string `json:"message"`
+	URL     string `json:"url"`
+}
+
+type UpdatePullRequestBranchErrorKind string
+
+const (
+	UpdatePullRequestBranchErrorStaleHead   UpdatePullRequestBranchErrorKind = "stale_head"
+	UpdatePullRequestBranchErrorConflict    UpdatePullRequestBranchErrorKind = "conflict"
+	UpdatePullRequestBranchErrorUnsupported UpdatePullRequestBranchErrorKind = "unsupported"
+	UpdatePullRequestBranchErrorTransient   UpdatePullRequestBranchErrorKind = "transient"
+)
+
+type UpdatePullRequestBranchError struct {
+	Kind   UpdatePullRequestBranchErrorKind
+	Detail string
+	Err    error
+}
+
+func (e UpdatePullRequestBranchError) Error() string {
+	detail := strings.TrimSpace(e.Detail)
+	if detail == "" && e.Err != nil {
+		detail = e.Err.Error()
+	}
+	if detail == "" {
+		detail = string(e.Kind)
+	}
+	return "update pull request branch " + string(e.Kind) + ": " + detail
+}
+
+func (e UpdatePullRequestBranchError) Unwrap() error {
+	return e.Err
+}
+
+func IsUpdatePullRequestBranchError(err error, kind UpdatePullRequestBranchErrorKind) bool {
+	var updateErr UpdatePullRequestBranchError
+	return errors.As(err, &updateErr) && updateErr.Kind == kind
 }
 
 type CombinedStatus struct {
@@ -382,6 +429,32 @@ func (c *GhClient) MergePullRequest(ctx context.Context, input MergePullRequestI
 		return MergeResult{Message: fmt.Sprintf("pull request merge is pending; current state is %q", pr.State)}, nil
 	}
 	return MergeResult{SHA: pr.MergeSHA, Merged: true}, nil
+}
+
+func (c *GhClient) UpdatePullRequestBranch(ctx context.Context, input UpdatePullRequestBranchInput) (UpdatePullRequestBranchResult, error) {
+	if strings.TrimSpace(input.Repo.FullName()) == "" {
+		return UpdatePullRequestBranchResult{}, errors.New("repository is required")
+	}
+	if input.Number <= 0 {
+		return UpdatePullRequestBranchResult{}, errors.New("pull request number is required")
+	}
+	args := []string{
+		"api",
+		"-X", "PUT",
+		endpoint(input.Repo, "pulls", input.Number, "update-branch"),
+	}
+	if expected := strings.TrimSpace(input.ExpectedHeadSHA); expected != "" {
+		args = append(args, "-f", "expected_head_sha="+expected)
+	}
+	result, err := c.run(ctx, true, args...)
+	if err != nil {
+		return UpdatePullRequestBranchResult{}, classifyUpdatePullRequestBranchError(result, err)
+	}
+	var response UpdatePullRequestBranchResult
+	if err := json.Unmarshal([]byte(result.Stdout), &response); err != nil {
+		return UpdatePullRequestBranchResult{}, fmt.Errorf("decode gh update-branch response: %w", err)
+	}
+	return response, nil
 }
 
 func (c *GhClient) GetCombinedStatus(ctx context.Context, repo Repository, ref string) (CombinedStatus, error) {
@@ -699,6 +772,33 @@ func isUnsupportedJSONFlag(result subprocess.Result) bool {
 	return strings.Contains(text, "unknown flag: --json") || strings.Contains(text, "unknown shorthand flag") && strings.Contains(text, "json")
 }
 
+func classifyUpdatePullRequestBranchError(result subprocess.Result, err error) error {
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	text := strings.ToLower(detail + "\n" + err.Error())
+	kind := UpdatePullRequestBranchErrorTransient
+	switch {
+	case strings.Contains(text, "expected_head_sha") ||
+		strings.Contains(text, "expected head sha") ||
+		strings.Contains(text, "head sha") && strings.Contains(text, "does not match"):
+		kind = UpdatePullRequestBranchErrorStaleHead
+	case strings.Contains(text, "merge conflict") ||
+		strings.Contains(text, "cannot be cleanly merged") ||
+		strings.Contains(text, "not mergeable") ||
+		strings.Contains(text, "conflict"):
+		kind = UpdatePullRequestBranchErrorConflict
+	case strings.Contains(text, "forbidden") ||
+		strings.Contains(text, "permission") ||
+		strings.Contains(text, "protected branch") ||
+		strings.Contains(text, "head repository") ||
+		strings.Contains(text, "fork"):
+		kind = UpdatePullRequestBranchErrorUnsupported
+	}
+	return UpdatePullRequestBranchError{Kind: kind, Detail: detail, Err: err}
+}
+
 func endpoint(repo Repository, parts ...any) string {
 	values := []string{"repos", repo.Owner, repo.Name}
 	for _, part := range parts {
@@ -784,6 +884,10 @@ func (NoopClient) GetUserPermission(context.Context, Repository, string) (UserPe
 
 func (NoopClient) MergePullRequest(context.Context, MergePullRequestInput) (MergeResult, error) {
 	return MergeResult{}, errors.ErrUnsupported
+}
+
+func (NoopClient) UpdatePullRequestBranch(context.Context, UpdatePullRequestBranchInput) (UpdatePullRequestBranchResult, error) {
+	return UpdatePullRequestBranchResult{}, errors.ErrUnsupported
 }
 
 func (NoopClient) GetCombinedStatus(context.Context, Repository, string) (CombinedStatus, error) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -263,6 +263,88 @@ func TestCompareCommitsUsesEscapedCompareEndpoint(t *testing.T) {
 	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/compare/release%2F1.0...head123")
 }
 
+func TestUpdatePullRequestBranchUsesExpectedHeadSHA(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"message":"Updating pull request branch.","url":"https://github.com/repos/jerryfane/gitmoot/pulls/2"}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	result, err := client.UpdatePullRequestBranch(context.Background(), UpdatePullRequestBranchInput{
+		Repo:            Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Number:          2,
+		ExpectedHeadSHA: "head123",
+	})
+
+	if err != nil {
+		t.Fatalf("UpdatePullRequestBranch returned error: %v", err)
+	}
+	if result.Message != "Updating pull request branch." || result.URL == "" {
+		t.Fatalf("result = %+v", result)
+	}
+	runner.wantArgs(t, 0,
+		"api",
+		"-X", "PUT",
+		"repos/jerryfane/gitmoot/pulls/2/update-branch",
+		"-f", "expected_head_sha=head123",
+	)
+}
+
+func TestUpdatePullRequestBranchClassifiesStaleHead(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "HTTP 422: expected_head_sha does not match"}},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	client := GhClient{Runner: runner}
+
+	_, err := client.UpdatePullRequestBranch(context.Background(), UpdatePullRequestBranchInput{
+		Repo:            Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Number:          2,
+		ExpectedHeadSHA: "old",
+	})
+
+	if !IsUpdatePullRequestBranchError(err, UpdatePullRequestBranchErrorStaleHead) {
+		t.Fatalf("error = %v, want stale head", err)
+	}
+}
+
+func TestUpdatePullRequestBranchClassifiesConflict(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "HTTP 422: branch cannot be cleanly merged due to conflicts"}},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	client := GhClient{Runner: runner}
+
+	_, err := client.UpdatePullRequestBranch(context.Background(), UpdatePullRequestBranchInput{
+		Repo:            Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Number:          2,
+		ExpectedHeadSHA: "head123",
+	})
+
+	if !IsUpdatePullRequestBranchError(err, UpdatePullRequestBranchErrorConflict) {
+		t.Fatalf("error = %v, want conflict", err)
+	}
+}
+
+func TestUpdatePullRequestBranchClassifiesUnsupported(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "HTTP 403: Resource not accessible by integration; missing permission to write head repository"}},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	client := GhClient{Runner: runner}
+
+	_, err := client.UpdatePullRequestBranch(context.Background(), UpdatePullRequestBranchInput{
+		Repo:            Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Number:          2,
+		ExpectedHeadSHA: "head123",
+	})
+
+	if !IsUpdatePullRequestBranchError(err, UpdatePullRequestBranchErrorUnsupported) {
+		t.Fatalf("error = %v, want unsupported", err)
+	}
+}
+
 func TestListPullRequestChecksUsesGhChecksOutput(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -17,6 +17,7 @@ const (
 	gitmootMergeGateContext         = "gitmoot/merge-gate"
 	gitmootNoCIContext              = "gitmoot/ci"
 	commitStatusDescriptionMaxRunes = 140
+	mergeQueueLockTTL               = 30 * time.Minute
 )
 
 type MergeGateGitHub interface {
@@ -25,6 +26,8 @@ type MergeGateGitHub interface {
 	CompareCommits(ctx context.Context, repo github.Repository, base string, head string) (github.CompareResult, error)
 	ListPullRequestChecks(ctx context.Context, repo github.Repository, number int64) ([]github.PullRequestCheck, error)
 	CreateCommitStatus(ctx context.Context, input github.CommitStatusInput) (github.CommitStatus, error)
+	PostIssueComment(ctx context.Context, repo github.Repository, issueNumber int64, body string) (github.IssueComment, error)
+	UpdatePullRequestBranch(ctx context.Context, input github.UpdatePullRequestBranchInput) (github.UpdatePullRequestBranchResult, error)
 	MergePullRequest(ctx context.Context, input github.MergePullRequestInput) (github.MergeResult, error)
 }
 
@@ -99,16 +102,29 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 			return g.block(ctx, request, headSHA, "local worktree is not clean")
 		}
 	}
-	if pr.Mergeable != nil && !*pr.Mergeable {
-		return g.block(ctx, request, headSHA, "pull request is not mergeable; rebase or update the branch")
-	}
-	if err := g.ensureBranchFresh(ctx, repo, pr, headSHA); err != nil {
-		return g.block(ctx, request, headSHA, err.Error())
-	}
 	if !request.ReviewOptional {
 		if err := g.ensureFinalReviewCaptured(ctx, request, headSHA); err != nil {
 			return g.block(ctx, request, headSHA, err.Error())
 		}
+	}
+	releaseMergeQueueLock, err := g.acquireMergeQueueLock(ctx, request, pr)
+	if err != nil {
+		var pending mergePending
+		if errors.As(err, &pending) {
+			return g.pending(ctx, request, headSHA, pending.reason)
+		}
+		return MergeDecision{}, err
+	}
+	defer func() {
+		_ = releaseMergeQueueLock(context.Background())
+	}()
+	if decision, handled, err := g.ensureBranchFresh(ctx, repo, request, pr, headSHA); err != nil {
+		return MergeDecision{}, err
+	} else if handled {
+		return decision, nil
+	}
+	if pr.Mergeable != nil && !*pr.Mergeable {
+		return g.block(ctx, request, headSHA, "pull request is not mergeable; rebase or update the branch")
 	}
 	if err := g.ensureStatuses(ctx, repo, int64(request.PullRequest), headSHA); err != nil {
 		var pending mergePending
@@ -229,6 +245,43 @@ func (g PolicyMergeGate) acquireLocalCheckoutMutationLock(ctx context.Context, r
 	return releaseCheckoutLock, nil
 }
 
+func (g PolicyMergeGate) acquireMergeQueueLock(ctx context.Context, request MergeRequest, pr github.PullRequest) (func(context.Context) error, error) {
+	base := strings.TrimSpace(pr.BaseRef)
+	if base == "" {
+		base = strings.TrimSpace(pr.BaseSHA)
+	}
+	if base == "" {
+		return nil, errors.New("pull request base ref is missing")
+	}
+	key := mergeQueueLockKey(request.Repo, base)
+	ownerID := "merge-queue:" + request.Repo + "#" + strconv.Itoa(request.PullRequest)
+	token, err := newCheckoutMutationOwnerToken()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	acquired, err := g.Store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  ownerID,
+		OwnerToken:  token,
+		ExpiresAt:   now.Add(mergeQueueLockTTL).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		return nil, err
+	}
+	if !acquired {
+		return nil, mergePending{reason: fmt.Sprintf("merge queue for %s/%s is busy; daemon will retry", request.Repo, base)}
+	}
+	return func(releaseCtx context.Context) error {
+		_, err := g.Store.ReleaseResourceLock(releaseCtx, key, ownerID, token)
+		return err
+	}, nil
+}
+
+func mergeQueueLockKey(repoFullName string, base string) string {
+	return "merge-queue:" + strings.TrimSpace(repoFullName) + ":" + strings.TrimSpace(base)
+}
+
 func (g PolicyMergeGate) validate() error {
 	if g.Store == nil {
 		return errors.New("merge gate store is required")
@@ -300,26 +353,73 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	return nil
 }
 
-func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repository, pr github.PullRequest, headSHA string) error {
+func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repository, request MergeRequest, pr github.PullRequest, headSHA string) (MergeDecision, bool, error) {
 	base := strings.TrimSpace(pr.BaseRef)
 	if base == "" {
 		base = strings.TrimSpace(pr.BaseSHA)
 	}
 	if base == "" {
-		return errors.New("pull request base ref is missing")
+		decision, err := g.block(ctx, request, headSHA, "pull request base ref is missing")
+		return decision, true, err
 	}
 	compare, err := g.GitHub.CompareCommits(ctx, repo, base, headSHA)
 	if err != nil {
-		return err
+		return MergeDecision{}, false, err
 	}
 	status := strings.ToLower(strings.TrimSpace(compare.Status))
 	if compare.BehindBy > 0 || status == "behind" || status == "diverged" {
-		return fmt.Errorf("pull request branch is behind base %s; update the branch before merging", base)
+		_, err := g.GitHub.UpdatePullRequestBranch(ctx, github.UpdatePullRequestBranchInput{
+			Repo:            repo,
+			Number:          int64(request.PullRequest),
+			ExpectedHeadSHA: headSHA,
+		})
+		if err == nil {
+			decision, pendingErr := g.pending(ctx, request, headSHA, fmt.Sprintf("pull request branch update from %s requested; daemon will retry after GitHub refreshes the head SHA and checks", base))
+			return decision, true, pendingErr
+		}
+		switch {
+		case github.IsUpdatePullRequestBranchError(err, github.UpdatePullRequestBranchErrorStaleHead):
+			decision, pendingErr := g.pending(ctx, request, headSHA, "pull request head changed while updating branch; daemon will retry with the latest head SHA")
+			return decision, true, pendingErr
+		case github.IsUpdatePullRequestBranchError(err, github.UpdatePullRequestBranchErrorConflict):
+			reason := fmt.Sprintf("branch update conflicts with %s; manual or agent fix required", base)
+			_ = g.postMergeConflictComment(ctx, repo, request, pr, reason)
+			decision, blockErr := g.block(ctx, request, headSHA, reason)
+			return decision, true, blockErr
+		case github.IsUpdatePullRequestBranchError(err, github.UpdatePullRequestBranchErrorUnsupported):
+			decision, blockErr := g.block(ctx, request, headSHA, fmt.Sprintf("GitHub cannot update this pull request branch automatically: %s", err))
+			return decision, true, blockErr
+		default:
+			decision, pendingErr := g.pending(ctx, request, headSHA, fmt.Sprintf("GitHub branch update failed transiently: %s; daemon will retry", err))
+			return decision, true, pendingErr
+		}
 	}
 	if status != "" && status != "ahead" && status != "identical" {
-		return fmt.Errorf("pull request branch freshness is unknown: compare status %q", compare.Status)
+		decision, err := g.block(ctx, request, headSHA, fmt.Sprintf("pull request branch freshness is unknown: compare status %q", compare.Status))
+		return decision, true, err
 	}
-	return nil
+	return MergeDecision{}, false, nil
+}
+
+func (g PolicyMergeGate) postMergeConflictComment(ctx context.Context, repo github.Repository, request MergeRequest, pr github.PullRequest, reason string) error {
+	if request.PullRequest <= 0 {
+		return nil
+	}
+	base := strings.TrimSpace(pr.BaseRef)
+	if base == "" {
+		base = strings.TrimSpace(pr.BaseSHA)
+	}
+	body := strings.Join([]string{
+		"Gitmoot merge gate is blocked.",
+		"",
+		"Gitmoot could not update this pull request branch before merge because it conflicts with `" + base + "`.",
+		"",
+		"- reason: " + reason,
+		"- retry: stopped; this is not retryable until the branch is fixed",
+		"- next action: resolve the conflict manually or run an explicit implement/fix job, then rerun review/merge",
+	}, "\n")
+	_, err := g.GitHub.PostIssueComment(ctx, repo, int64(request.PullRequest), body)
+	return err
 }
 
 func (g PolicyMergeGate) ensureReviewMatchesHead(payload JobPayload, headSHA string, agent string) error {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -501,7 +501,7 @@ func TestPolicyMergeGateAllowsSkippedExternalCI(t *testing.T) {
 	}
 }
 
-func TestPolicyMergeGateBlocksStaleBranch(t *testing.T) {
+func TestPolicyMergeGateUpdatesStaleBranchAndStaysPending(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
@@ -525,13 +525,127 @@ func TestPolicyMergeGateBlocksStaleBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Evaluate returned error: %v", err)
 	}
-	if decision.Ready || !strings.Contains(decision.Reason, "behind base") {
+	if !decision.Ready || decision.Merged || !strings.Contains(decision.Reason, "branch update") {
 		t.Fatalf("decision = %+v", decision)
 	}
 	if len(gh.merges) != 0 {
 		t.Fatalf("merge inputs = %+v", gh.merges)
 	}
+	if len(gh.updates) != 1 || gh.updates[0].ExpectedHeadSHA != "head123" {
+		t.Fatalf("update inputs = %+v", gh.updates)
+	}
+	if !hasStatus(gh.statuses, gitmootMergeGateContext, "pending") {
+		t.Fatalf("statuses = %+v", gh.statuses)
+	}
+}
+
+func TestPolicyMergeGateBlocksStaleBranchUpdateConflict(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:        github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:    github.CombinedStatus{State: "success"},
+		compare:   github.CompareResult{Status: "behind", BehindBy: 1},
+		updateErr: github.UpdatePullRequestBranchError{Kind: github.UpdatePullRequestBranchErrorConflict, Detail: "conflict"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready || !strings.Contains(decision.Reason, "conflicts with main") {
+		t.Fatalf("decision = %+v", decision)
+	}
 	if !hasStatus(gh.statuses, gitmootMergeGateContext, "failure") {
+		t.Fatalf("statuses = %+v", gh.statuses)
+	}
+	if len(gh.comments) != 1 || !strings.Contains(gh.comments[0], "not retryable") {
+		t.Fatalf("comments = %+v", gh.comments)
+	}
+}
+
+func TestPolicyMergeGateKeepsStaleHeadRacePending(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:        github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:    github.CombinedStatus{State: "success"},
+		compare:   github.CompareResult{Status: "behind", BehindBy: 1},
+		updateErr: github.UpdatePullRequestBranchError{Kind: github.UpdatePullRequestBranchErrorStaleHead, Detail: "stale head"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Ready || decision.Merged || !strings.Contains(decision.Reason, "head changed") {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if !hasStatus(gh.statuses, gitmootMergeGateContext, "pending") {
+		t.Fatalf("statuses = %+v", gh.statuses)
+	}
+}
+
+func TestPolicyMergeGateKeepsMergeQueueBusyPending(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: mergeQueueLockKey("jerryfane/gitmoot", "main"),
+		OwnerJobID:  "merge-queue:jerryfane/gitmoot#8",
+		OwnerToken:  "token",
+		ExpiresAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:     github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status: github.CombinedStatus{State: "success"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Ready || decision.Merged || !strings.Contains(decision.Reason, "merge queue") {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+	if !hasStatus(gh.statuses, gitmootMergeGateContext, "pending") {
 		t.Fatalf("statuses = %+v", gh.statuses)
 	}
 }
@@ -834,8 +948,11 @@ type fakeMergeGateGitHub struct {
 	compare     github.CompareResult
 	checks      []github.PullRequestCheck
 	mergeResult github.MergeResult
+	updateErr   error
 	statuses    []github.CommitStatusInput
 	merges      []github.MergePullRequestInput
+	updates     []github.UpdatePullRequestBranchInput
+	comments    []string
 }
 
 func (f *fakeMergeGateGitHub) GetPullRequest(context.Context, github.Repository, int64) (github.PullRequest, error) {
@@ -860,6 +977,16 @@ func (f *fakeMergeGateGitHub) ListPullRequestChecks(context.Context, github.Repo
 func (f *fakeMergeGateGitHub) CreateCommitStatus(_ context.Context, input github.CommitStatusInput) (github.CommitStatus, error) {
 	f.statuses = append(f.statuses, input)
 	return github.CommitStatus{State: input.State, Context: input.Context}, nil
+}
+
+func (f *fakeMergeGateGitHub) PostIssueComment(_ context.Context, _ github.Repository, _ int64, body string) (github.IssueComment, error) {
+	f.comments = append(f.comments, body)
+	return github.IssueComment{Body: body}, nil
+}
+
+func (f *fakeMergeGateGitHub) UpdatePullRequestBranch(_ context.Context, input github.UpdatePullRequestBranchInput) (github.UpdatePullRequestBranchResult, error) {
+	f.updates = append(f.updates, input)
+	return github.UpdatePullRequestBranchResult{Message: "Updating pull request branch."}, f.updateErr
 }
 
 func (f *fakeMergeGateGitHub) MergePullRequest(_ context.Context, input github.MergePullRequestInput) (github.MergeResult, error) {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -277,6 +277,11 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
 
+Merge-gate retries are automatic while the daemon is running. Retryable states,
+such as a busy base-branch merge queue or a GitHub branch update in progress,
+are retried on the next daemon poll tick. The default poll interval is `30s`
+unless the daemon was started with a different `--poll`.
+
 ## SkillOpt Exchange
 
 ```sh

--- a/skills/gitmoot/references/GOAL_TEMPLATE.md
+++ b/skills/gitmoot/references/GOAL_TEMPLATE.md
@@ -124,8 +124,9 @@ main systems touched, and any explicit exclusions.
 - Use a separate branch per task.
 - Clearly assign each branch a task number and file ownership.
 - Do not duplicate work across branches.
-- If parallel branches conflict after one PR merges, rebase or update the
-  remaining branch on the latest target base and re-run its checks/review.
+- For Gitmoot-owned task PRs, let the merge gate update stale branches and
+  retry. If a real content conflict remains, resolve it in an explicit fix task
+  and re-run checks/review.
 - If a task becomes dependent on another task, stop treating it as parallel and
   merge the dependency first.
 

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -14,6 +14,13 @@ by the assigned agent.
 Review and ask jobs should inspect and report without mutating branches unless
 the task explicitly instructs otherwise.
 
+Do not ask child agents to run PR lifecycle commands such as `git pull`,
+`git merge`, `git push`, or `gh pr merge` to make parallel task PRs mergeable.
+Gitmoot owns the final merge gate. It serializes merge attempts per base branch,
+updates stale PR branches through GitHub when possible, retries pending states
+through the daemon, and blocks clearly when GitHub reports a real merge
+conflict.
+
 Useful commands:
 
 ```sh


### PR DESCRIPTION
## What

Adds a Gitmoot-owned merge queue path for PRs that become stale while parallel task PRs are being merged.

## Why

Parallel Gitmoot implementation jobs can produce independent PRs against the same base branch. If one PR merges first, the remaining PRs may become behind `main`. Child agents should not own `git pull`, branch update, PR merge, or `gh pr merge`; Gitmoot should own that final gate centrally.

## Changes

- Add GitHub `update-branch` support through `PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch` with `expected_head_sha`.
- Classify update failures as stale-head race, conflict, unsupported, or transient.
- Add a base-branch merge queue lock around final merge-gate evaluation.
- Replace stale branch blocking with a safe branch update request plus daemon retry.
- Block real update conflicts clearly and post a PR comment with next action.
- Add daemon regression coverage proving ready-to-merge PRs are retried after a branch update changes the head SHA.
- Update docs and Gitmoot skill guidance so child agents leave PR lifecycle work to the merge gate.

## Verification

- `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./... -timeout 300s`
- `git diff --check`
- `codex exec review --uncommitted`

## Codex Review

No discrete correctness issues were found in the current staged/unstaged changes. Tests could not be run in the review sandbox because Go attempted to download the 1.26 toolchain into a read-only cache.

## Risk

The GitHub update-branch behavior is covered by client/unit tests and daemon retry regression tests. Real GitHub timing can still vary, so the merge gate keeps update-in-progress and stale-head races pending for the daemon to retry instead of treating them as hard failures.

Fixes #50.
