### PR TITLE
workflow: wait for checkout locks during task worktree setup

### DIFF
--- a/internal/workflow/checkout_lock.go
+++ b/internal/workflow/checkout_lock.go
@@ -15,6 +15,8 @@ import (
 
 const (
 	checkoutMutationLockTTL     = 30 * time.Minute
+	checkoutMutationWaitTimeout = 2 * time.Minute
+	checkoutMutationWaitBackoff = 100 * time.Millisecond
 	checkoutMutationBusyMessage = "This checkout is already being mutated by another Gitmoot task. Run tasks sequentially or enable per-task worktrees for parallel implementation."
 )
 
@@ -50,6 +52,58 @@ func acquireCheckoutMutationLock(ctx context.Context, store *db.Store, checkoutP
 		_, err := store.ReleaseResourceLock(releaseCtx, key, ownerID, token)
 		return err
 	}, key, nil
+}
+
+func acquireCheckoutMutationLockWithWait(ctx context.Context, store *db.Store, checkoutPath string, ownerID string, now time.Time) (func(context.Context) error, string, error) {
+	return acquireCheckoutMutationLockWithWaitBudget(ctx, store, checkoutPath, ownerID, now, checkoutMutationWaitTimeout, checkoutMutationWaitBackoff)
+}
+
+func acquireCheckoutMutationLockWithWaitBudget(ctx context.Context, store *db.Store, checkoutPath string, ownerID string, now time.Time, waitBudget time.Duration, backoff time.Duration) (func(context.Context) error, string, error) {
+	release, key, err := acquireCheckoutMutationLock(ctx, store, checkoutPath, ownerID, now)
+	if err == nil {
+		return release, key, nil
+	}
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || waitBudget <= 0 {
+		return nil, key, err
+	}
+	if backoff <= 0 {
+		backoff = checkoutMutationWaitBackoff
+	}
+	deadline := now.UTC().Add(waitBudget)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, key, checkoutMutationWaitExpired(waitBudget)
+		}
+		sleepFor := backoff
+		if remaining < sleepFor {
+			sleepFor = remaining
+		}
+		timer := time.NewTimer(sleepFor)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return nil, key, ctx.Err()
+		case <-timer.C:
+		}
+		release, key, err = acquireCheckoutMutationLock(ctx, store, checkoutPath, ownerID, time.Now().UTC())
+		if err == nil {
+			return release, key, nil
+		}
+		if !errors.As(err, &blocked) {
+			return nil, key, err
+		}
+	}
+}
+
+func checkoutMutationWaitExpired(waitBudget time.Duration) BlockedError {
+	return BlockedError{Reason: fmt.Sprintf("%s Waited up to %s for the checkout mutation lock.", checkoutMutationBusyMessage, waitBudget.Round(time.Second))}
 }
 
 func checkoutMutationLockKey(checkoutPath string) (string, error) {

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -97,7 +97,7 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 		}
 		return task, nil
 	}
-	releaseCheckoutLock, _, err := acquireCheckoutMutationLock(ctx, e.Store, request.Checkout, "worktree:"+request.TaskID, time.Now().UTC())
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(ctx, e.Store, request.Checkout, "worktree:"+request.TaskID, time.Now().UTC())
 	if err != nil {
 		if createdLock {
 			_, _ = e.Store.ReleaseLock(ctx, lock)

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -105,7 +105,7 @@ func TestEngineAllocateTaskWorktreeAddsGitWorktreeAndStoresPath(t *testing.T) {
 	}
 }
 
-func TestEngineAllocateTaskWorktreeBlocksWhenCheckoutMutationLocked(t *testing.T) {
+func TestEngineAllocateTaskWorktreeWaitsForCheckoutMutationLock(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	engine := testEngine(store)
@@ -124,8 +124,14 @@ func TestEngineAllocateTaskWorktreeBlocksWhenCheckoutMutationLocked(t *testing.T
 		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
 	}
 	manager := &fakeWorktreeManager{}
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		time.Sleep(20 * time.Millisecond)
+		_, _ = store.ReleaseResourceLock(context.Background(), key, "task:other", "other-token")
+	}()
 
-	_, err = engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
+	task, err := engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
 		Home:     home,
 		Repo:     "owner/repo",
 		TaskID:   "task-1",
@@ -134,12 +140,40 @@ func TestEngineAllocateTaskWorktreeBlocksWhenCheckoutMutationLocked(t *testing.T
 		Checkout: checkout,
 	}, manager)
 
-	var blocked BlockedError
-	if !errors.As(err, &blocked) || blocked.Reason != checkoutMutationBusyMessage {
-		t.Fatalf("error = %v, want checkout busy BlockedError", err)
+	if err != nil {
+		t.Fatalf("AllocateTaskWorktree returned error: %v", err)
 	}
-	if len(manager.calls) != 0 {
-		t.Fatalf("AddWorktree ran despite checkout lock: %+v", manager.calls)
+	<-released
+	if task.WorktreePath == "" {
+		t.Fatalf("task worktree path is empty: %+v", task)
+	}
+	if len(manager.calls) != 1 {
+		t.Fatalf("AddWorktree calls = %+v, want one call after checkout lock release", manager.calls)
+	}
+}
+
+func TestAcquireCheckoutMutationLockWithWaitBudgetTimesOutWhenLocked(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	if acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  "task:other",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+
+	_, _, err = acquireCheckoutMutationLockWithWaitBudget(ctx, store, checkout, "worktree:task-1", time.Now().UTC(), 20*time.Millisecond, 5*time.Millisecond)
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "Waited up to") {
+		t.Fatalf("error = %v, want checkout wait timeout BlockedError", err)
 	}
 }
 


### PR DESCRIPTION
WHAT
- Added bounded wait/retry for checkout mutation locks during task worktree allocation.

WHY
- Concurrent `gitmoot task run` / `gitmoot agent implement` can briefly contend on the registered checkout while creating per-task worktrees. This should wait for transient setup contention instead of failing immediately.

CHANGES
- Added `acquireCheckoutMutationLockWithWait` with a 2 minute wait budget and 100ms retry backoff.
- Wired the wait path into `Engine.AllocateTaskWorktree` only.
- Kept existing fail-fast checkout lock behavior for branch setup and merge-gate paths.
- Added coverage for transient lock release and explicit wait-budget timeout.

RESULTS
- `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./internal/workflow -run 'TestEngineAllocateTaskWorktree|TestAcquireCheckoutMutationLockWithWaitBudget|TestEngineStartTaskBranch|TestPolicyMergeGate' -v -timeout 180s` passed.
- `git diff --check` passed.
- `codex exec review --uncommitted` final raw output:

```text
No correctness issues were found in the current changes. The new wait path preserves lock acquisition/release behavior and adds timeout coverage for the blocked-lock case.
```

RISK
- This changes task worktree allocation from fail-fast to wait-and-retry for checkout lock contention. Cancellation still returns `ctx.Err()` and non-lock errors are unchanged.
