### PR TITLE
Stabilize stale review lifecycle reconciliation

### DIFF
--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -3070,7 +3070,7 @@ func TestRunQueuedJobsFailsReviewOnWrongCheckoutHeadBeforeDelivery(t *testing.T)
 	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
 	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
 	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
-	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-review", Agent: "reviewer", Action: "review", Repo: "owner/repo", Branch: "task-1", PullRequest: 1, HeadSHA: strings.Repeat("0", 40)})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-review", Agent: "reviewer", Action: "review", Repo: "owner/repo", Branch: "task-1", PullRequest: 1, HeadSHA: strings.Repeat("0", 40), TaskID: "task-1"})
 	adapter := &cliWorkerFakeAdapter{
 		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
 	}

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -655,7 +655,7 @@ func TestTaskRunJobMatchesDelegatedImplementJob(t *testing.T) {
 	}
 }
 
-func TestRunTaskRunBlocksWhenCheckoutMutationLocked(t *testing.T) {
+func TestRunTaskRunWaitsWhenCheckoutMutationLocked(t *testing.T) {
 	home := t.TempDir()
 	goalPath := filepath.Join(t.TempDir(), "GOAL.md")
 	writeFile(t, goalPath, "# Build Gitmoot\n\n### Task 1: Bootstrap\n")
@@ -692,27 +692,31 @@ func TestRunTaskRunBlocksWhenCheckoutMutationLocked(t *testing.T) {
 	}, time.Now().UTC()); err != nil || !acquired {
 		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
 	}
-	if err := store.Close(); err != nil {
-		t.Fatalf("close store: %v", err)
-	}
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		time.Sleep(20 * time.Millisecond)
+		_, _ = store.ReleaseResourceLock(context.Background(), "checkout-mutation:"+filepath.Clean(absoluteCheckout), "task:other", "other-token")
+	}()
 
 	stdout.Reset()
 	stderr.Reset()
 	code = Run([]string{"task", "run", "task-001", "--home", home, "--repo", "jerryfane/gitmoot", "--owner", "lead"}, &stdout, &stderr)
+	<-released
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
 
-	if code != 1 {
-		t.Fatalf("task run exit code = %d, want 1; stderr=%s", code, stderr.String())
+	if code != 0 {
+		t.Fatalf("task run exit code = %d, want 0; stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "This checkout is already being mutated by another Gitmoot task") {
-		t.Fatalf("stderr = %q", stderr.String())
-	}
-	branches := runGitOutput(t, repoDir, "branch", "--list", "task-001")
-	if strings.TrimSpace(branches) != "" {
-		t.Fatalf("task branch was created despite checkout lock: %q", branches)
+	branches := runGitOutput(t, repoDir, "branch", "--list", "task-001-bootstrap")
+	if strings.TrimSpace(branches) == "" {
+		t.Fatal("task branch was not created after checkout lock release")
 	}
 	worktreePath := filepath.Join(home, ".gitmoot", "worktrees", "jerryfane--gitmoot", "task-001")
-	if _, err := os.Stat(worktreePath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("worktree path after checkout lock error = %v, want os.ErrNotExist", err)
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Fatalf("worktree path after checkout lock release = %v, want existing worktree", err)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -107,6 +107,9 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 				return err
 			}
 		}
+		if err := d.reconcileReviewingPullRequest(ctx, pull); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
 	if err := d.retryClosedReadyToMerge(ctx, openBranches); err != nil && firstErr == nil {
 		firstErr = err
@@ -186,12 +189,7 @@ func (d Daemon) pullRequestWorkflowRouting(ctx context.Context, pull github.Pull
 		if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
 			return pullRequestRouting{}, fmt.Errorf("parse job payload %q: %w", job.ID, err)
 		}
-		if payload.Repo == d.Repo.FullName() &&
-			payload.PullRequest == int(pull.Number) &&
-			payload.Branch == pull.HeadRef &&
-			strings.TrimSpace(payload.LeadAgent) != "" &&
-			strings.TrimSpace(payload.ReviewRound) != "" &&
-			len(payload.Reviewers) > 0 {
+		if workflowReviewJobMatchesPull(d.Repo.FullName(), pull, payload) {
 			if strings.TrimSpace(payload.HeadSHA) == pull.HeadSHA {
 				return pullRequestRouting{}, nil
 			}
@@ -227,6 +225,9 @@ func (d Daemon) pullRequestStoredMerged(ctx context.Context, pull github.PullReq
 func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullRequest) error {
 	if d.Workflow == nil {
 		return nil
+	}
+	if err := d.supersedeStaleReviewJobs(ctx, pull); err != nil {
+		return err
 	}
 	lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef)
 	if err != nil {
@@ -266,6 +267,42 @@ func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullR
 		Sender:            "github",
 		RequiredReviewers: reviewers,
 	})
+}
+
+func (d Daemon) supersedeStaleReviewJobs(ctx context.Context, pull github.PullRequest) error {
+	jobs, err := d.Store.ListJobs(ctx)
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		payload, err := workflowPayload(job)
+		if err != nil {
+			return err
+		}
+		if !workflowReviewJobMatchesPull(d.Repo.FullName(), pull, payload) {
+			continue
+		}
+		if strings.TrimSpace(payload.HeadSHA) == pull.HeadSHA {
+			continue
+		}
+		reason := fmt.Sprintf("review job superseded_stale_head: PR #%d moved from head %q to %q", pull.Number, strings.TrimSpace(payload.HeadSHA), pull.HeadSHA)
+		if _, _, err := workflow.SupersedeStaleHeadJob(ctx, d.Store, job.ID, reason); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func workflowReviewJobMatchesPull(repoFullName string, pull github.PullRequest, payload workflow.JobPayload) bool {
+	return payload.Repo == repoFullName &&
+		payload.PullRequest == int(pull.Number) &&
+		payload.Branch == pull.HeadRef &&
+		strings.TrimSpace(payload.LeadAgent) != "" &&
+		strings.TrimSpace(payload.ReviewRound) != "" &&
+		len(payload.Reviewers) > 0
 }
 
 func (d Daemon) pullRequestReadyToMerge(ctx context.Context, pull github.PullRequest) (bool, error) {
@@ -310,6 +347,71 @@ func (d Daemon) handleReadyToMergeWorkflow(ctx context.Context, pull github.Pull
 		LeadAgent:   leadAgent,
 		Sender:      "github",
 	})
+}
+
+func (d Daemon) reconcileReviewingPullRequest(ctx context.Context, pull github.PullRequest) error {
+	if d.Workflow == nil {
+		return nil
+	}
+	task, err := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+	if task.State != string(workflow.TaskReviewing) {
+		return nil
+	}
+	jobs, err := d.Store.ListJobs(ctx)
+	if err != nil {
+		return err
+	}
+	hasCurrentReview := false
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		payload, err := workflowPayload(job)
+		if err != nil {
+			return err
+		}
+		if !workflowReviewJobMatchesPull(d.Repo.FullName(), pull, payload) {
+			continue
+		}
+		if strings.TrimSpace(payload.TaskID) != "" && payload.TaskID != task.ID {
+			continue
+		}
+		if strings.TrimSpace(payload.HeadSHA) != pull.HeadSHA {
+			continue
+		}
+		hasCurrentReview = true
+		switch job.State {
+		case string(workflow.JobQueued), string(workflow.JobRunning):
+			return nil
+		}
+		if payload.Result == nil {
+			continue
+		}
+		if err := d.Workflow.AdvanceJob(ctx, job.ID); err != nil {
+			var blocked workflow.BlockedError
+			if errors.As(err, &blocked) {
+				return nil
+			}
+			return err
+		}
+		updated, err := d.Store.GetTask(ctx, task.ID)
+		if err != nil {
+			return err
+		}
+		if updated.State != string(workflow.TaskReviewing) {
+			return nil
+		}
+	}
+	if hasCurrentReview {
+		return nil
+	}
+	return d.handlePullRequestWorkflow(ctx, pull)
 }
 
 func (d Daemon) retryClosedReadyToMerge(ctx context.Context, openBranches map[string]struct{}) error {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -506,12 +506,132 @@ func TestPollOnceReroutesLegacyReviewWithoutHeadSHA(t *testing.T) {
 	if err := daemon.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce returned error: %v", err)
 	}
+	oldJob, err := store.GetJob(ctx, "review-audit-task-7-review-1")
+	if err != nil {
+		t.Fatalf("GetJob legacy review returned error: %v", err)
+	}
+	if oldJob.State != string(workflow.JobCancelled) {
+		t.Fatalf("legacy review state = %q, want cancelled", oldJob.State)
+	}
+	events, err := store.ListJobEvents(ctx, oldJob.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !hasDaemonJobEvent(events, workflow.JobEventSupersededStaleHead) {
+		t.Fatalf("legacy review events = %+v, want superseded stale head", events)
+	}
 	job, err := store.GetJob(ctx, "review-audit-task-7-review-2")
 	if err != nil {
 		t.Fatalf("GetJob rerouted review returned error: %v", err)
 	}
 	if !strings.Contains(job.Payload, `"head_sha":"abc123"`) {
 		t.Fatalf("rerouted job payload missing head sha: %s", job.Payload)
+	}
+}
+
+func TestPollOnceReconcilesReviewingPullRequestWithApprovedCurrentReview(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Role:           "lead",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-007",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1",
+		Title:        "Task 7",
+		State:        string(workflow.TaskReviewing),
+		Branch:       "task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-7",
+		PullRequest: 7,
+		HeadSHA:     "abc123",
+		TaskID:      "task-007",
+		TaskTitle:   "Task 7",
+		LeadAgent:   "lead",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-1",
+		Result:      &workflow.AgentResult{Decision: "approved", Summary: "approved"},
+	})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID:      "review-audit-task-007-review-1",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(workflow.JobSucceeded),
+		Payload: string(payload),
+	}, db.JobEvent{Kind: string(workflow.JobSucceeded), Message: "review completed before daemon reconciliation"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       7,
+		HeadBranch:   "task-7",
+		BaseBranch:   "main",
+		HeadSHA:      "abc123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	task, err := store.GetTask(ctx, "task-007")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskReadyToMerge) {
+		t.Fatalf("task state = %q, want ready_to_merge", task.State)
+	}
+	if len(gate.requests) != 1 || gate.requests[0].HeadSHA != "abc123" {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
 	}
 }
 
@@ -1939,4 +2059,13 @@ func (f *fakeWorkflowMergeGate) Evaluate(_ context.Context, request workflow.Mer
 		f.onEvaluate(request)
 	}
 	return f.decision, nil
+}
+
+func hasDaemonJobEvent(events []db.JobEvent, kind string) bool {
+	for _, event := range events {
+		if event.Kind == kind {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -3,9 +3,12 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 )
+
+const JobEventSupersededStaleHead = "superseded_stale_head"
 
 func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error) {
 	if store == nil {
@@ -66,8 +69,9 @@ func latestCancellationWasFromRunning(ctx context.Context, store *db.Store, jobI
 		if event.Kind == "cancel_settled" {
 			return false, nil
 		}
-		if event.Kind == string(JobCancelled) {
-			return event.Message == "cancel requested from running", nil
+		switch event.Kind {
+		case string(JobCancelled), JobEventSupersededStaleHead:
+			return strings.HasPrefix(event.Message, "cancel requested from running"), nil
 		}
 	}
 	return false, nil
@@ -126,4 +130,43 @@ func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, erro
 		return db.Job{}, fmt.Errorf("job %s is %s; cancel requires queued or running", latest.ID, latest.State)
 	}
 	return store.GetJob(ctx, job.ID)
+}
+
+func SupersedeStaleHeadJob(ctx context.Context, store *db.Store, jobID string, reason string) (db.Job, bool, error) {
+	if store == nil {
+		return db.Job{}, false, fmt.Errorf("store is required")
+	}
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		return db.Job{}, false, err
+	}
+	switch job.State {
+	case string(JobQueued), string(JobRunning):
+	default:
+		return job, false, nil
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "review job superseded by newer pull request head"
+	}
+	if job.State == string(JobRunning) && !strings.HasPrefix(reason, "cancel requested from running") {
+		reason = "cancel requested from running: " + reason
+	}
+	transitioned, err := store.TransitionJobStateWithEvent(ctx, job.ID, job.State, string(JobCancelled), db.JobEvent{
+		JobID:   job.ID,
+		Kind:    JobEventSupersededStaleHead,
+		Message: reason,
+	})
+	if err != nil {
+		return db.Job{}, false, err
+	}
+	if !transitioned {
+		latest, getErr := store.GetJob(ctx, job.ID)
+		if getErr != nil {
+			return db.Job{}, false, getErr
+		}
+		return latest, false, nil
+	}
+	updated, err := store.GetJob(ctx, job.ID)
+	return updated, true, err
 }

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -91,6 +91,41 @@ func TestRetryJobAllowsRunningCancellationAfterWorkerSettles(t *testing.T) {
 	}
 }
 
+func TestRetryJobRejectsRunningSupersededReviewUntilWorkerSettles(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "review", State: string(JobRunning), Payload: `{"repo":"owner/repo"}`}, db.JobEvent{
+		Kind:    string(JobRunning),
+		Message: "running",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	job, transitioned, err := SupersedeStaleHeadJob(ctx, store, "job-1", "review job superseded_stale_head: PR #1 moved from head \"old\" to \"new\"")
+	if err != nil {
+		t.Fatalf("SupersedeStaleHeadJob returned error: %v", err)
+	}
+	if !transitioned || job.State != string(JobCancelled) {
+		t.Fatalf("superseded job transitioned=%v state=%q, want cancelled transition", transitioned, job.State)
+	}
+	if _, err := RetryJob(ctx, store, "job-1"); err == nil {
+		t.Fatal("RetryJob accepted running superseded review before worker settled")
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if len(events) < 2 || events[1].Kind != JobEventSupersededStaleHead || !strings.HasPrefix(events[1].Message, "cancel requested from running") {
+		t.Fatalf("events = %+v, want running supersede marker", events)
+	}
+	if _, err := SettleCancelledRunningJob(ctx, store, "job-1", "cancelled job worker settled"); err != nil {
+		t.Fatalf("SettleCancelledRunningJob returned error: %v", err)
+	}
+	if _, err := RetryJob(ctx, store, "job-1"); err != nil {
+		t.Fatalf("RetryJob rejected settled running superseded review: %v", err)
+	}
+}
+
 func TestCancelJobCancelsQueuedOrRunningJob(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)


### PR DESCRIPTION
## What

Stabilize Gitmoot's review lifecycle when PR heads move or daemon advancement is interrupted.

## Why

Issue #50 testing exposed two lifecycle problems:

- stale review jobs could remain around after a PR head changed
- tasks could remain stuck in `reviewing` after a completed current-head review was stored but advancement did not finish

## Changes

- Add `SupersedeStaleHeadJob` and `superseded_stale_head` job events for daemon-confirmed stale review jobs.
- Preserve running-cancel semantics for running jobs superseded by a newer PR head, so retries wait for the original worker to settle.
- Let the daemon cancel queued/running stale review jobs only after comparing the job payload head against the current GitHub PR head.
- Reconcile `reviewing` tasks on daemon poll by advancing completed current-head review jobs or enqueueing a missing current-head review.
- Keep worker-side wrong-head checkout validation as a normal preflight failure, since local checkout state alone does not prove the PR moved.
- Update checkout mutation lock tests to expect the new wait/retry behavior from PR #199.

## Verification

- `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./internal/workflow -run 'TestRetryJob|TestSupersede|TestEngineAdvanceReviewApproval|TestEngineAdvanceStaleReview|TestEngineHandlePullRequestOpened' -v -timeout 180s`
- `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./internal/cli -run 'TestRunQueuedJobsFailsReviewOnWrongCheckoutHeadBeforeDelivery|TestRunQueuedJobsFailsReviewOnWrongCheckoutBranchBeforeDelivery|TestRunQueuedJobsFailsPRScopedAskOnWrongCheckoutHeadBeforeDelivery|TestRunTaskRunWaitsWhenCheckoutMutationLocked' -v -timeout 180s`
- `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./internal/workflow ./internal/daemon ./internal/cli -timeout 420s`
- `git diff --check`
- `codex exec review --uncommitted`

Final Codex review result:

> No actionable correctness issues were found in the current staged/unstaged changes. I could not run the Go test suite because the required Go 1.26 toolchain download is blocked in this environment.
