### PR TITLE
Clarify merge conflict repair path

### DIFF
--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -416,10 +416,20 @@ func (g PolicyMergeGate) postMergeConflictComment(ctx context.Context, repo gith
 		"",
 		"- reason: " + reason,
 		"- retry: stopped; this is not retryable until the branch is fixed",
-		"- next action: resolve the conflict manually or run an explicit implement/fix job, then rerun review/merge",
+		"- task: " + mergeConflictTaskLabel(request),
+		"- next action: resolve the conflict manually, or queue a Gitmoot implement/fix job so Gitmoot applies file changes in the task worktree and owns commit/push/PR refresh",
+		"- after fix: rerun review/merge on the updated pull request head",
 	}, "\n")
 	_, err := g.GitHub.PostIssueComment(ctx, repo, int64(request.PullRequest), body)
 	return err
+}
+
+func mergeConflictTaskLabel(request MergeRequest) string {
+	taskID := strings.TrimSpace(request.TaskID)
+	if taskID == "" {
+		return "unknown"
+	}
+	return taskID
 }
 
 func (g PolicyMergeGate) ensureReviewMatchesHead(payload JobPayload, headSHA string, agent string) error {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -570,7 +570,10 @@ func TestPolicyMergeGateBlocksStaleBranchUpdateConflict(t *testing.T) {
 	if !hasStatus(gh.statuses, gitmootMergeGateContext, "failure") {
 		t.Fatalf("statuses = %+v", gh.statuses)
 	}
-	if len(gh.comments) != 1 || !strings.Contains(gh.comments[0], "not retryable") {
+	if len(gh.comments) != 1 || !strings.Contains(gh.comments[0], "not retryable") ||
+		!strings.Contains(gh.comments[0], "task: task-9") ||
+		!strings.Contains(gh.comments[0], "Gitmoot applies file changes in the task worktree") ||
+		!strings.Contains(gh.comments[0], "rerun review/merge") {
 		t.Fatalf("comments = %+v", gh.comments)
 	}
 }


### PR DESCRIPTION
## What

Clarify Gitmoot merge-conflict blocking comments.

## Why

Issue #50 testing showed that branch-update conflicts need a clear handoff: Gitmoot stops automatic retry, the PR remains blocked, and the next action must be either manual branch repair or a Gitmoot-owned implement/fix job that edits files in the task worktree while Gitmoot owns commit/push/PR refresh.

## Changes

- Add task id and explicit Gitmoot-owned repair instructions to merge-conflict comments.
- Tell users to rerun review/merge after the updated PR head is fixed.
- Strengthen the merge-gate conflict test to assert the actionable guidance is rendered.

## Verification

- `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./internal/workflow -run 'TestPolicyMergeGateBlocksStaleBranchUpdateConflict|TestPolicyMergeGateKeepsStaleHeadRacePending|TestPolicyMergeGateRequestsBranchUpdateBeforeMerge|TestPolicyMergeGate' -v -timeout 180s`
- `git diff --check`
- `codex exec review --uncommitted`

Final Codex review result:

> The changes only extend the merge-conflict comment with task/action guidance and update the corresponding test assertions. I found no correctness issues in the modified logic.
