### PR TITLE
skillopt: resolve train init template choices

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -83,6 +83,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
+	fmt.Fprintln(w, "  gitmoot skillopt train init templates --json")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
@@ -96,6 +97,8 @@ func runSkillOptTrain(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 	switch args[0] {
+	case "init":
+		return runSkillOptTrainInit(args[1:], stdout, stderr)
 	case "start":
 		return runSkillOptTrainStart(args[1:], stdout, stderr)
 	case "status":
@@ -115,11 +118,62 @@ func runSkillOptTrain(args []string, stdout, stderr io.Writer) int {
 
 func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot skillopt train init templates --json")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--preview-mode none|optional|required] [--preview-renderer none|vue-vite] [--preview-publisher none|github-pages] [--preview-route-template template] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
+}
+
+func runSkillOptTrainInit(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSkillOptTrainInitUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "templates":
+		return runSkillOptTrainInitTemplates(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skillopt train init command %q\n\n", args[0])
+		printSkillOptTrainInitUsage(stderr)
+		return 2
+	}
+}
+
+func printSkillOptTrainInitUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot skillopt train init templates --json")
+}
+
+func runSkillOptTrainInitTemplates(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt train init templates", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "write template choices as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt train init templates does not accept positional arguments")
+		return 2
+	}
+	if !*jsonOutput {
+		fmt.Fprintln(stderr, "skillopt train init templates requires --json")
+		return 2
+	}
+	return withStoreExit(*home, stderr, "list skillopt train init templates", func(store *db.Store) error {
+		choices, err := skillopt.ListTrainInitTemplateChoices(context.Background(), store)
+		if err != nil {
+			return err
+		}
+		encoder := json.NewEncoder(stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(choices)
+	})
 }
 
 func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -867,6 +867,68 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainInitTemplatesJSON(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("custom-writer", "Write short posts.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:         "writer",
+		Role:         "writer",
+		Runtime:      "codex",
+		TemplateID:   "custom-writer",
+		Capabilities: []string{"ask"},
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "templates", "--home", home, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("templates exit code = %d, stderr=%s", code, stderr.String())
+	}
+	var choices []skillopt.TrainInitTemplateChoice
+	if err := json.Unmarshal(stdout.Bytes(), &choices); err != nil {
+		t.Fatalf("decode choices: %v\n%s", err, stdout.String())
+	}
+	planner := cliTrainInitChoiceByID(t, choices, "planner")
+	if planner.Source != skillopt.TrainInitTemplateChoiceSourceBuiltin || planner.Label == "" {
+		t.Fatalf("planner choice = %+v", planner)
+	}
+	custom := cliTrainInitChoiceByID(t, choices, "custom-writer")
+	if !custom.Installed || !custom.Current || custom.CurrentVersion != "custom-writer@v1" || len(custom.Agents) != 1 || custom.Agents[0] != "writer" {
+		t.Fatalf("custom choice = %+v", custom)
+	}
+}
+
+func TestSkillOptTrainInitTemplatesRequiresJSON(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "templates", "--home", home}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "requires --json") {
+		t.Fatalf("templates without json code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func cliTrainInitChoiceByID(t *testing.T, choices []skillopt.TrainInitTemplateChoice, id string) skillopt.TrainInitTemplateChoice {
+	t.Helper()
+	for _, choice := range choices {
+		if choice.ID == id {
+			return choice
+		}
+	}
+	t.Fatalf("choice %s not found in %+v", id, choices)
+	return skillopt.TrainInitTemplateChoice{}
+}
+
 func TestSkillOptTrainStatusGeneratedProgressUsesCurrentIteration(t *testing.T) {
 	session := db.SkillOptTrainSession{
 		ID:           "landing-train",

--- a/internal/skillopt/train_init_templates.go
+++ b/internal/skillopt/train_init_templates.go
@@ -1,0 +1,268 @@
+package skillopt
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+const (
+	TrainInitTemplateChoiceSourceBuiltin   = "builtin"
+	TrainInitTemplateChoiceSourceInstalled = "installed"
+	TrainInitTemplateChoiceSourceAgent     = "agent"
+)
+
+type TrainInitTemplateChoice struct {
+	ID             string                 `json:"id"`
+	Label          string                 `json:"label"`
+	Source         string                 `json:"source"`
+	Installed      bool                   `json:"installed"`
+	Current        bool                   `json:"current"`
+	CurrentVersion string                 `json:"current_version,omitempty"`
+	VersionID      string                 `json:"version_id,omitempty"`
+	VersionNumber  int                    `json:"version_number,omitempty"`
+	VersionState   string                 `json:"version_state,omitempty"`
+	Name           string                 `json:"name,omitempty"`
+	Description    string                 `json:"description,omitempty"`
+	SourceRepo     string                 `json:"source_repo,omitempty"`
+	SourceRef      string                 `json:"source_ref,omitempty"`
+	SourcePath     string                 `json:"source_path,omitempty"`
+	ResolvedCommit string                 `json:"resolved_commit,omitempty"`
+	ContentHash    string                 `json:"content_hash,omitempty"`
+	Agents         []string               `json:"agents,omitempty"`
+	Metadata       agenttemplate.Metadata `json:"metadata,omitempty"`
+}
+
+func ListTrainInitTemplateChoices(ctx context.Context, store *db.Store) ([]TrainInitTemplateChoice, error) {
+	if store == nil {
+		return nil, errors.New("template store is required")
+	}
+	installedTemplates, err := store.ListAgentTemplates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	installed := map[string]db.AgentTemplate{}
+	for _, template := range installedTemplates {
+		installed[template.ID] = template
+	}
+	agentsByTemplate, err := trainInitAgentsByTemplate(ctx, store)
+	if err != nil {
+		return nil, err
+	}
+	choicesByID := map[string]TrainInitTemplateChoice{}
+	for _, definition := range agenttemplate.Builtins() {
+		if agenttemplate.IsRetired(definition.ID) {
+			continue
+		}
+		template, ok := installed[definition.ID]
+		choice := trainInitChoiceFromDefinition(definition, template, ok)
+		choice.Agents = agentsByTemplate[definition.ID]
+		choicesByID[definition.ID] = choice
+	}
+	for _, template := range installedTemplates {
+		if agenttemplate.IsRetired(template.ID) {
+			continue
+		}
+		if _, ok := choicesByID[template.ID]; ok {
+			continue
+		}
+		choice := trainInitChoiceFromInstalled(template)
+		choice.Agents = agentsByTemplate[template.ID]
+		choicesByID[template.ID] = choice
+	}
+	for templateID, agents := range agentsByTemplate {
+		if agenttemplate.IsRetired(templateID) {
+			continue
+		}
+		if _, ok := choicesByID[templateID]; ok {
+			continue
+		}
+		choicesByID[templateID] = TrainInitTemplateChoice{
+			ID:        templateID,
+			Label:     templateID + " (used by " + strings.Join(agents, ", ") + ")",
+			Source:    TrainInitTemplateChoiceSourceAgent,
+			Installed: false,
+			Current:   false,
+			Agents:    agents,
+		}
+	}
+	choices := make([]TrainInitTemplateChoice, 0, len(choicesByID))
+	for _, choice := range choicesByID {
+		choice.Agents = sortedUniqueStrings(choice.Agents)
+		choices = append(choices, choice)
+	}
+	sort.SliceStable(choices, func(i, j int) bool {
+		if choices[i].ID != choices[j].ID {
+			return choices[i].ID < choices[j].ID
+		}
+		return choices[i].Source < choices[j].Source
+	})
+	return choices, nil
+}
+
+func ResolveTrainInitTemplateChoice(ctx context.Context, store *db.Store, fetcher agenttemplate.Fetcher, templateRef string) (db.AgentTemplate, error) {
+	if store == nil {
+		return db.AgentTemplate{}, errors.New("template store is required")
+	}
+	templateID, versionRef := db.SplitAgentTemplateReference(templateRef)
+	if strings.TrimSpace(templateID) == "" {
+		return db.AgentTemplate{}, errors.New("template is required")
+	}
+	if agenttemplate.IsRetired(templateID) {
+		return db.AgentTemplate{}, fmt.Errorf("agent template %s is retired; use %s", templateID, agenttemplate.PlannerTemplateID)
+	}
+	template, err := store.GetAgentTemplateReference(ctx, templateRef)
+	if err == nil {
+		return template, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return db.AgentTemplate{}, err
+	}
+	if _, ok := agenttemplate.Lookup(templateID); !ok {
+		return db.AgentTemplate{}, fmt.Errorf("unknown or uninstalled agent template %q; run gitmoot agent template add %s --file <path>", templateID, templateID)
+	}
+	if strings.TrimSpace(versionRef) != "" {
+		return db.AgentTemplate{}, fmt.Errorf("agent template %s is not installed; run gitmoot agent template update %s before selecting %s", templateID, templateID, templateRef)
+	}
+	if fetcher == nil {
+		return db.AgentTemplate{}, errors.New("agent template fetcher is required to install available template")
+	}
+	return agenttemplate.Update(ctx, store, fetcher, templateID)
+}
+
+func trainInitChoiceFromDefinition(definition agenttemplate.Definition, template db.AgentTemplate, installed bool) TrainInitTemplateChoice {
+	metadata := agenttemplate.MetadataForDefinition(definition)
+	if installed {
+		metadata = trainInitTemplateMetadata(template, metadata)
+	}
+	choice := TrainInitTemplateChoice{
+		ID:          definition.ID,
+		Label:       definition.Name,
+		Source:      TrainInitTemplateChoiceSourceBuiltin,
+		Installed:   installed,
+		Current:     installed && template.VersionID != "",
+		Name:        definition.Name,
+		Description: definition.Description,
+		SourceRepo:  definition.SourceRepo,
+		SourceRef:   definition.SourceRef,
+		SourcePath:  definition.SourcePath,
+		Metadata:    metadata,
+	}
+	if installed {
+		choice = applyTrainInitInstalledTemplate(choice, template)
+	}
+	return choice
+}
+
+func trainInitChoiceFromInstalled(template db.AgentTemplate) TrainInitTemplateChoice {
+	choice := TrainInitTemplateChoice{
+		ID:          template.ID,
+		Label:       firstNonEmpty(template.Name, template.ID),
+		Source:      TrainInitTemplateChoiceSourceInstalled,
+		Installed:   true,
+		Current:     template.VersionID != "",
+		Name:        template.Name,
+		Description: template.Description,
+		Metadata:    trainInitTemplateMetadata(template, agenttemplate.Metadata{}),
+	}
+	return applyTrainInitInstalledTemplate(choice, template)
+}
+
+func applyTrainInitInstalledTemplate(choice TrainInitTemplateChoice, template db.AgentTemplate) TrainInitTemplateChoice {
+	choice.VersionID = template.VersionID
+	choice.CurrentVersion = template.VersionID
+	choice.VersionNumber = template.VersionNumber
+	choice.VersionState = template.VersionState
+	choice.SourceRepo = template.SourceRepo
+	choice.SourceRef = template.SourceRef
+	choice.SourcePath = template.SourcePath
+	choice.ResolvedCommit = template.ResolvedCommit
+	choice.ContentHash = template.ContentHash
+	if template.Name != "" {
+		choice.Name = template.Name
+		choice.Label = template.Name
+	}
+	if template.Description != "" {
+		choice.Description = template.Description
+	}
+	return choice
+}
+
+func trainInitTemplateMetadata(template db.AgentTemplate, fallback agenttemplate.Metadata) agenttemplate.Metadata {
+	if strings.TrimSpace(template.MetadataJSON) != "" {
+		if metadata, err := agenttemplate.UnmarshalMetadata(template.MetadataJSON); err == nil {
+			return metadata
+		}
+	}
+	if strings.TrimSpace(template.Content) != "" {
+		if parsed, err := agenttemplate.ParseTemplateContent(template.Content); err == nil {
+			return parsed.Metadata
+		}
+	}
+	return fallback
+}
+
+func trainInitAgentsByTemplate(ctx context.Context, store *db.Store) (map[string][]string, error) {
+	agentsByTemplate := map[string][]string{}
+	agents, err := store.ListAgents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, agent := range agents {
+		addTrainInitAgentTemplate(agentsByTemplate, agent.TemplateID, agent.Name)
+	}
+	instances, err := store.ListAgentInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, instance := range instances {
+		addTrainInitAgentTemplate(agentsByTemplate, instance.TemplateID, instance.Name)
+	}
+	for templateID, agents := range agentsByTemplate {
+		agentsByTemplate[templateID] = sortedUniqueStrings(agents)
+	}
+	return agentsByTemplate, nil
+}
+
+func addTrainInitAgentTemplate(agentsByTemplate map[string][]string, templateID string, agentName string) {
+	templateID, _ = db.SplitAgentTemplateReference(templateID)
+	templateID = strings.TrimSpace(templateID)
+	agentName = strings.TrimSpace(agentName)
+	if templateID == "" || agentName == "" {
+		return
+	}
+	agentsByTemplate[templateID] = append(agentsByTemplate[templateID], agentName)
+}
+
+func sortedUniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	sort.Strings(unique)
+	return unique
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/skillopt/train_init_templates_test.go
+++ b/internal/skillopt/train_init_templates_test.go
@@ -1,0 +1,165 @@
+package skillopt
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestListTrainInitTemplateChoicesIncludesBuiltinInstalledAndAgents(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertAgentTemplate(ctx, db.AgentTemplate{
+		ID:             "custom-writer",
+		Name:           "Custom Writer",
+		Description:    "Writes short posts.",
+		SourceRepo:     "local",
+		SourceRef:      "file",
+		SourcePath:     "/tmp/custom.md",
+		ResolvedCommit: "sha256:custom",
+		Content:        trainInitTemplateTestContent("custom-writer", "Custom Writer"),
+		MetadataJSON:   `{"id":"custom-writer","name":"Custom Writer","description":"Writes short posts.","kind":"agent-template","version":1,"capabilities":["ask"],"runtime_compatibility":["codex"],"tags":["writing"],"inputs":["post"],"outputs":["reply"]}`,
+	}); err != nil {
+		t.Fatalf("UpsertAgentTemplate custom returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:         "writer",
+		Role:         "writer",
+		Runtime:      "codex",
+		TemplateID:   "custom-writer",
+		Capabilities: []string{"ask"},
+	}); err != nil {
+		t.Fatalf("UpsertAgent writer returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:         "versioned-writer",
+		Role:         "writer",
+		Runtime:      "codex",
+		TemplateID:   "custom-writer@v1",
+		Capabilities: []string{"ask"},
+	}); err != nil {
+		t.Fatalf("UpsertAgent versioned writer returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:         "missing-agent",
+		Role:         "writer",
+		Runtime:      "codex",
+		TemplateID:   "missing-template",
+		Capabilities: []string{"ask"},
+	}); err != nil {
+		t.Fatalf("UpsertAgent missing returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:         "retired-agent",
+		Role:         "planner",
+		Runtime:      "codex",
+		TemplateID:   "planner-here",
+		Capabilities: []string{"ask"},
+	}); err != nil {
+		t.Fatalf("UpsertAgent retired returned error: %v", err)
+	}
+
+	choices, err := ListTrainInitTemplateChoices(ctx, store)
+	if err != nil {
+		t.Fatalf("ListTrainInitTemplateChoices returned error: %v", err)
+	}
+	planner := trainInitChoiceByID(t, choices, "planner")
+	if planner.Source != TrainInitTemplateChoiceSourceBuiltin || planner.Installed || planner.Label == "" {
+		t.Fatalf("planner choice = %+v", planner)
+	}
+	custom := trainInitChoiceByID(t, choices, "custom-writer")
+	if custom.Source != TrainInitTemplateChoiceSourceInstalled || !custom.Installed || !custom.Current || custom.CurrentVersion != "custom-writer@v1" || len(custom.Agents) != 2 || custom.Agents[0] != "versioned-writer" || custom.Agents[1] != "writer" {
+		t.Fatalf("custom choice = %+v", custom)
+	}
+	if _, ok := trainInitFindChoiceByID(choices, "custom-writer@v1"); ok {
+		t.Fatalf("versioned agent template ref should be grouped under logical template id: %+v", choices)
+	}
+	if custom.Metadata.ID != "custom-writer" || len(custom.Metadata.Outputs) != 1 || custom.Metadata.Outputs[0] != "reply" {
+		t.Fatalf("custom metadata = %+v", custom.Metadata)
+	}
+	missing := trainInitChoiceByID(t, choices, "missing-template")
+	if missing.Source != TrainInitTemplateChoiceSourceAgent || missing.Installed || len(missing.Agents) != 1 || missing.Agents[0] != "missing-agent" {
+		t.Fatalf("missing choice = %+v", missing)
+	}
+	if _, ok := trainInitFindChoiceByID(choices, "planner-here"); ok {
+		t.Fatalf("retired agent-only template should be hidden: %+v", choices)
+	}
+}
+
+func TestResolveTrainInitTemplateChoiceInstallsAvailableBuiltin(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	template, err := ResolveTrainInitTemplateChoice(ctx, store, trainInitFakeFetcher{content: "# Gitmoot Planner\n\nPlan."}, "planner")
+	if err != nil {
+		t.Fatalf("ResolveTrainInitTemplateChoice returned error: %v", err)
+	}
+	if template.ID != "planner" || template.VersionID != "planner@v1" || template.ResolvedCommit != "resolved-sha" {
+		t.Fatalf("template = %+v", template)
+	}
+	choices, err := ListTrainInitTemplateChoices(ctx, store)
+	if err != nil {
+		t.Fatalf("ListTrainInitTemplateChoices returned error: %v", err)
+	}
+	planner := trainInitChoiceByID(t, choices, "planner")
+	if !planner.Installed || !planner.Current || planner.CurrentVersion != "planner@v1" {
+		t.Fatalf("planner after install = %+v", planner)
+	}
+}
+
+func TestResolveTrainInitTemplateChoiceRejectsMissingCustom(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if _, err := ResolveTrainInitTemplateChoice(ctx, store, trainInitFakeFetcher{}, "custom-writer"); err == nil {
+		t.Fatal("ResolveTrainInitTemplateChoice succeeded for missing custom template")
+	}
+}
+
+func trainInitChoiceByID(t *testing.T, choices []TrainInitTemplateChoice, id string) TrainInitTemplateChoice {
+	t.Helper()
+	if choice, ok := trainInitFindChoiceByID(choices, id); ok {
+		return choice
+	}
+	t.Fatalf("choice %s not found in %+v", id, choices)
+	return TrainInitTemplateChoice{}
+}
+
+func trainInitFindChoiceByID(choices []TrainInitTemplateChoice, id string) (TrainInitTemplateChoice, bool) {
+	for _, choice := range choices {
+		if choice.ID == id {
+			return choice, true
+		}
+	}
+	return TrainInitTemplateChoice{}, false
+}
+
+func trainInitTemplateTestContent(id string, name string) string {
+	return "---\nid: " + id + "\nname: " + name + "\ndescription: Test template.\nkind: agent-template\nversion: 1\ncapabilities:\n  - ask\nruntime_compatibility:\n  - codex\ntags:\n  - test\ninputs:\n  - prompt\noutputs:\n  - response\n---\n# " + name + "\n\nTest body.\n"
+}
+
+type trainInitFakeFetcher struct {
+	content string
+}
+
+func (f trainInitFakeFetcher) ResolveRef(context.Context, string, string) (string, error) {
+	return "resolved-sha", nil
+}
+
+func (f trainInitFakeFetcher) FetchFile(context.Context, string, string, string) (agenttemplate.File, error) {
+	return agenttemplate.File{Content: f.content}, nil
+}


### PR DESCRIPTION
## WHAT
Add template-choice discovery for `gitmoot skillopt train init`.

## WHY
The structured train-init flow needs a machine-readable way to list selectable agent templates, including built-ins, installed custom templates, and templates currently used by registered agents.

## CHANGES
- Added `skillopt.ListTrainInitTemplateChoices` and `ResolveTrainInitTemplateChoice`.
- Included built-in, installed, and agent-referenced templates with stable JSON fields.
- Normalized pinned agent template refs like `custom@v1` back to the logical template id.
- Filtered retired template ids from fallback choices.
- Added `gitmoot skillopt train init templates --json`.
- Added CLI and internal tests for listing and resolving choices.

## RESULTS
- `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./internal/skillopt ./internal/cli ./internal/agenttemplate -run 'Template|TrainInit' -v`
- `git diff --check`
- `codex exec review --uncommitted`

Final review output:

```text
I found no discrete correctness issues in the staged changes. The new command and template-choice helpers appear consistent with the existing CLI and store patterns.
```

Note: the review process attempted `GOTOOLCHAIN=local go test` using the system Go 1.22 binary, which cannot satisfy this repo's Go 1.26 requirement. The focused suite above passed with the repo-local Go 1.26.4 binary.

## RISK
Low. This adds a new train-init subcommand and internal helpers without changing existing train-start behavior.
