### PR TITLE
interactive: add prompt session primitives

### DIFF
--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -1,0 +1,207 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func runInteractive(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printInteractiveUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "list":
+		return runInteractiveList(args[1:], stdout, stderr)
+	case "show":
+		return runInteractiveShow(args[1:], stdout, stderr)
+	case "answer":
+		return runInteractiveAnswer(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown interactive command %q\n\n", args[0])
+		printInteractiveUsage(stderr)
+		return 2
+	}
+}
+
+func printInteractiveUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot interactive list [--state pending|resolved|all] [--json]")
+	fmt.Fprintln(w, "  gitmoot interactive show <id> --json")
+	fmt.Fprintln(w, "  gitmoot interactive answer <id> <value> [--source source]")
+}
+
+func runInteractiveList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("interactive list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	state := fs.String("state", db.InteractivePromptStatePending, "prompt state: pending, resolved, or all")
+	jsonOutput := fs.Bool("json", false, "write prompts as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "interactive list does not accept positional arguments")
+		return 2
+	}
+	normalizedState, err := normalizeInteractivePromptState(*state)
+	if err != nil {
+		fmt.Fprintf(stderr, "interactive list: %v\n", err)
+		return 2
+	}
+	var prompts []db.InteractivePrompt
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		prompts, err = store.ListInteractivePrompts(context.Background(), normalizedState)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "interactive list: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, prompts); err != nil {
+			fmt.Fprintf(stderr, "interactive list: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	for _, prompt := range prompts {
+		writeLine(stdout, "%s\t%s\t%s", prompt.ID, prompt.State, prompt.Question)
+	}
+	return 0
+}
+
+func runInteractiveShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("interactive show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "write prompt as JSON")
+	parsedArgs, err := reorderInteractiveFlags(args, map[string]struct{}{"home": {}}, map[string]struct{}{"json": {}})
+	if err != nil {
+		fmt.Fprintf(stderr, "interactive show: %v\n", err)
+		return 2
+	}
+	if err := fs.Parse(parsedArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "interactive show requires exactly one prompt id")
+		return 2
+	}
+	if !*jsonOutput {
+		fmt.Fprintln(stderr, "interactive show requires --json")
+		return 2
+	}
+	var prompt db.InteractivePrompt
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		prompt, err = store.GetInteractivePrompt(context.Background(), fs.Arg(0))
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "interactive show: %v\n", err)
+		return 1
+	}
+	if err := writeJSON(stdout, prompt); err != nil {
+		fmt.Fprintf(stderr, "interactive show: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runInteractiveAnswer(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("interactive answer", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	source := fs.String("source", "cli", "answer source")
+	parsedArgs, err := reorderInteractiveFlags(args, map[string]struct{}{"home": {}, "source": {}}, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "interactive answer: %v\n", err)
+		return 2
+	}
+	if err := fs.Parse(parsedArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 2 {
+		fmt.Fprintln(stderr, "interactive answer requires a prompt id and value")
+		return 2
+	}
+	var prompt db.InteractivePrompt
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		prompt, err = store.AnswerInteractivePrompt(context.Background(), fs.Arg(0), fs.Arg(1), *source)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "interactive answer: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "answered %s: %s", prompt.ID, prompt.AnswerValue)
+	return 0
+}
+
+func normalizeInteractivePromptState(state string) (string, error) {
+	state = strings.TrimSpace(strings.ToLower(state))
+	switch state {
+	case "", "all":
+		return "", nil
+	case db.InteractivePromptStatePending, db.InteractivePromptStateResolved:
+		return state, nil
+	default:
+		return "", fmt.Errorf("state %q is not supported", state)
+	}
+}
+
+func reorderInteractiveFlags(args []string, stringFlags map[string]struct{}, boolFlags map[string]struct{}) ([]string, error) {
+	flags := []string{}
+	positionals := []string{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if arg == "--" {
+			positionals = append(positionals, args[index+1:]...)
+			break
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			positionals = append(positionals, arg)
+			continue
+		}
+		name, hasInlineValue := splitInteractiveFlagName(arg)
+		if _, ok := boolFlags[name]; ok {
+			flags = append(flags, arg)
+			continue
+		}
+		if _, ok := stringFlags[name]; ok {
+			flags = append(flags, arg)
+			if !hasInlineValue {
+				if index+1 >= len(args) {
+					return nil, fmt.Errorf("flag needs an argument: %s", arg)
+				}
+				index++
+				flags = append(flags, args[index])
+			}
+			continue
+		}
+		flags = append(flags, arg)
+	}
+	return append(flags, positionals...), nil
+}
+
+func splitInteractiveFlagName(arg string) (string, bool) {
+	arg = strings.TrimLeft(arg, "-")
+	name, value, hasInlineValue := strings.Cut(arg, "=")
+	_ = value
+	return name, hasInlineValue
+}

--- a/internal/cli/interactive_test.go
+++ b/internal/cli/interactive_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestInteractiveListShowAndAnswer(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertInteractivePrompt(context.Background(), db.InteractivePrompt{
+		ID:            "train-init-template",
+		Question:      "Which template should Gitmoot train?",
+		Choices:       []string{"planner", "writer"},
+		Default:       "planner",
+		Required:      true,
+		AnswerFormat:  "choice",
+		SourceCommand: "gitmoot skillopt train init",
+	}); err != nil {
+		t.Fatalf("UpsertInteractivePrompt returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var listStdout, listStderr bytes.Buffer
+	code := Run([]string{"interactive", "list", "--home", home, "--json"}, &listStdout, &listStderr)
+	if code != 0 {
+		t.Fatalf("interactive list code=%d stderr=%s", code, listStderr.String())
+	}
+	var prompts []db.InteractivePrompt
+	if err := json.Unmarshal(listStdout.Bytes(), &prompts); err != nil {
+		t.Fatalf("decode list JSON: %v\n%s", err, listStdout.String())
+	}
+	if len(prompts) != 1 || prompts[0].ID != "train-init-template" || prompts[0].State != db.InteractivePromptStatePending {
+		t.Fatalf("prompts = %+v", prompts)
+	}
+
+	var showStdout, showStderr bytes.Buffer
+	code = Run([]string{"interactive", "show", "--home", home, "train-init-template", "--json"}, &showStdout, &showStderr)
+	if code != 0 {
+		t.Fatalf("interactive show code=%d stderr=%s", code, showStderr.String())
+	}
+	var shown db.InteractivePrompt
+	if err := json.Unmarshal(showStdout.Bytes(), &shown); err != nil {
+		t.Fatalf("decode show JSON: %v\n%s", err, showStdout.String())
+	}
+	if shown.Question == "" || len(shown.Choices) != 2 || shown.Default != "planner" {
+		t.Fatalf("shown prompt = %+v", shown)
+	}
+
+	var answerStdout, answerStderr bytes.Buffer
+	code = Run([]string{"interactive", "answer", "--home", home, "train-init-template", "writer", "--source", "agent"}, &answerStdout, &answerStderr)
+	if code != 0 {
+		t.Fatalf("interactive answer code=%d stderr=%s", code, answerStderr.String())
+	}
+	if !strings.Contains(answerStdout.String(), "answered train-init-template: writer") {
+		t.Fatalf("answer stdout = %q", answerStdout.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	resolved, err := store.GetInteractivePrompt(context.Background(), "train-init-template")
+	if err != nil {
+		t.Fatalf("GetInteractivePrompt returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if resolved.State != db.InteractivePromptStateResolved || resolved.AnswerValue != "writer" || resolved.AnswerSource != "agent" {
+		t.Fatalf("resolved prompt = %+v", resolved)
+	}
+}
+
+func TestInteractiveAnswerRejectsInvalidChoice(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertInteractivePrompt(context.Background(), db.InteractivePrompt{
+		ID:       "mode",
+		Question: "Which mode?",
+		Choices:  []string{"explore", "refine"},
+		Required: true,
+	}); err != nil {
+		t.Fatalf("UpsertInteractivePrompt returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"interactive", "answer", "--home", home, "mode", "validate"}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "not one of") {
+		t.Fatalf("invalid answer code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	prompt, err := store.GetInteractivePrompt(context.Background(), "mode")
+	if err != nil {
+		t.Fatalf("GetInteractivePrompt returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if prompt.State != db.InteractivePromptStatePending || prompt.AnswerValue != "" {
+		t.Fatalf("prompt after invalid answer = %+v", prompt)
+	}
+}
+
+func TestInteractiveAnswerAcceptsDashPrefixedTextAfterDelimiter(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertInteractivePrompt(context.Background(), db.InteractivePrompt{
+		ID:       "text",
+		Question: "What text?",
+		Required: true,
+	}); err != nil {
+		t.Fatalf("UpsertInteractivePrompt returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"interactive", "answer", "--home", home, "text", "--", "--force"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("dash-prefixed answer code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	prompt, err := store.GetInteractivePrompt(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("GetInteractivePrompt returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if prompt.AnswerValue != "--force" {
+		t.Fatalf("prompt answer = %+v", prompt)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -36,6 +36,7 @@ var rootCommands = []command{
 	{name: "task", summary: "run or inspect tasks", run: runTask},
 	{name: "job", summary: "inspect and recover jobs", run: runJob},
 	{name: "lock", summary: "inspect and release branch locks", run: runLock},
+	{name: "interactive", summary: "inspect and answer interactive prompts", run: runInteractive},
 	{name: "skillopt", summary: "export and import SkillOpt packages", run: runSkillOpt},
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -241,6 +241,22 @@ type SkillOptReviewWatch struct {
 	UpdatedAt             string
 }
 
+type InteractivePrompt struct {
+	ID            string   `json:"id"`
+	Question      string   `json:"question"`
+	Choices       []string `json:"choices,omitempty"`
+	Default       string   `json:"default,omitempty"`
+	Required      bool     `json:"required"`
+	AnswerFormat  string   `json:"answer_format"`
+	SourceCommand string   `json:"source_command"`
+	State         string   `json:"state"`
+	AnswerValue   string   `json:"answer_value,omitempty"`
+	AnswerSource  string   `json:"answer_source,omitempty"`
+	CreatedAt     string   `json:"created_at,omitempty"`
+	UpdatedAt     string   `json:"updated_at,omitempty"`
+	AnsweredAt    string   `json:"answered_at,omitempty"`
+}
+
 const (
 	EvalRunModeExplore  = "explore"
 	EvalRunModeRefine   = "refine"
@@ -256,6 +272,9 @@ const (
 	SkillOptReviewWatchStatusClosed        = "closed"
 	SkillOptReviewWatchStatusStaleNotified = "stale_notified"
 	SkillOptReviewWatchStatusFailed        = "failed"
+
+	InteractivePromptStatePending  = "pending"
+	InteractivePromptStateResolved = "resolved"
 )
 
 type EvalReviewItem struct {
@@ -2509,6 +2528,183 @@ func (s *Store) ListSkillOptReviewWatches(ctx context.Context, status string) ([
 	return watches, rows.Err()
 }
 
+func (s *Store) UpsertInteractivePrompt(ctx context.Context, prompt InteractivePrompt) error {
+	prompt, err := normalizeInteractivePrompt(prompt)
+	if err != nil {
+		return err
+	}
+	choicesJSON, err := json.Marshal(prompt.Choices)
+	if err != nil {
+		return fmt.Errorf("encode prompt choices: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO interactive_prompts(
+			id, question, choices_json, default_value, required, answer_format, source_command,
+			state, answer_value, answer_source, answered_at, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			question = excluded.question,
+			choices_json = excluded.choices_json,
+			default_value = excluded.default_value,
+			required = excluded.required,
+			answer_format = excluded.answer_format,
+			source_command = excluded.source_command,
+			state = CASE
+				WHEN interactive_prompts.state = 'resolved' AND excluded.state = 'pending' THEN interactive_prompts.state
+				ELSE excluded.state
+			END,
+			answer_value = CASE
+				WHEN interactive_prompts.state = 'resolved' AND excluded.state = 'pending' THEN interactive_prompts.answer_value
+				ELSE excluded.answer_value
+			END,
+			answer_source = CASE
+				WHEN interactive_prompts.state = 'resolved' AND excluded.state = 'pending' THEN interactive_prompts.answer_source
+				ELSE excluded.answer_source
+			END,
+			answered_at = CASE
+				WHEN interactive_prompts.state = 'resolved' AND excluded.state = 'pending' THEN interactive_prompts.answered_at
+				ELSE excluded.answered_at
+			END,
+			updated_at = CURRENT_TIMESTAMP`,
+		prompt.ID, prompt.Question, string(choicesJSON), prompt.Default, boolInt(prompt.Required), prompt.AnswerFormat, prompt.SourceCommand,
+		prompt.State, prompt.AnswerValue, prompt.AnswerSource, prompt.AnsweredAt)
+	return err
+}
+
+func normalizeInteractivePrompt(prompt InteractivePrompt) (InteractivePrompt, error) {
+	prompt.ID = strings.TrimSpace(prompt.ID)
+	if prompt.ID == "" {
+		return InteractivePrompt{}, errors.New("interactive prompt id is required")
+	}
+	prompt.Question = strings.TrimSpace(prompt.Question)
+	if prompt.Question == "" {
+		return InteractivePrompt{}, errors.New("interactive prompt question is required")
+	}
+	prompt.Choices = trimUniqueStrings(prompt.Choices)
+	prompt.Default = strings.TrimSpace(prompt.Default)
+	if prompt.Default != "" && len(prompt.Choices) > 0 && !stringInSlice(prompt.Default, prompt.Choices) {
+		return InteractivePrompt{}, fmt.Errorf("interactive prompt default %q is not one of the allowed choices", prompt.Default)
+	}
+	prompt.AnswerFormat = strings.TrimSpace(prompt.AnswerFormat)
+	if prompt.AnswerFormat == "" {
+		if len(prompt.Choices) > 0 {
+			prompt.AnswerFormat = "choice"
+		} else {
+			prompt.AnswerFormat = "text"
+		}
+	}
+	prompt.SourceCommand = strings.TrimSpace(prompt.SourceCommand)
+	prompt.State = strings.TrimSpace(strings.ToLower(prompt.State))
+	if prompt.State == "" {
+		prompt.State = InteractivePromptStatePending
+	}
+	switch prompt.State {
+	case InteractivePromptStatePending, InteractivePromptStateResolved:
+	default:
+		return InteractivePrompt{}, fmt.Errorf("interactive prompt state %q is not supported", prompt.State)
+	}
+	prompt.AnswerValue = strings.TrimSpace(prompt.AnswerValue)
+	prompt.AnswerSource = strings.TrimSpace(prompt.AnswerSource)
+	prompt.AnsweredAt = strings.TrimSpace(prompt.AnsweredAt)
+	if prompt.State == InteractivePromptStateResolved {
+		value, err := validateInteractivePromptAnswer(prompt, prompt.AnswerValue)
+		if err != nil {
+			return InteractivePrompt{}, err
+		}
+		prompt.AnswerValue = value
+		if prompt.AnswerSource == "" {
+			prompt.AnswerSource = "unknown"
+		}
+		if prompt.AnsweredAt == "" {
+			prompt.AnsweredAt = time.Now().UTC().Format(time.RFC3339)
+		}
+	}
+	return prompt, nil
+}
+
+func (s *Store) ListInteractivePrompts(ctx context.Context, state string) ([]InteractivePrompt, error) {
+	state = strings.TrimSpace(strings.ToLower(state))
+	var rows *sql.Rows
+	var err error
+	if state == "" {
+		rows, err = s.db.QueryContext(ctx, `SELECT id, question, choices_json, default_value, required, answer_format,
+				source_command, state, answer_value, answer_source, created_at, updated_at, answered_at
+			FROM interactive_prompts
+			ORDER BY created_at, id`)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `SELECT id, question, choices_json, default_value, required, answer_format,
+				source_command, state, answer_value, answer_source, created_at, updated_at, answered_at
+			FROM interactive_prompts
+			WHERE state = ?
+			ORDER BY created_at, id`, state)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	prompts := []InteractivePrompt{}
+	for rows.Next() {
+		prompt, err := scanInteractivePrompt(rows)
+		if err != nil {
+			return nil, err
+		}
+		prompts = append(prompts, prompt)
+	}
+	return prompts, rows.Err()
+}
+
+func (s *Store) GetInteractivePrompt(ctx context.Context, id string) (InteractivePrompt, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, question, choices_json, default_value, required, answer_format,
+			source_command, state, answer_value, answer_source, created_at, updated_at, answered_at
+		FROM interactive_prompts
+		WHERE id = ?`, strings.TrimSpace(id))
+	return scanInteractivePrompt(row)
+}
+
+func (s *Store) AnswerInteractivePrompt(ctx context.Context, id string, value string, source string) (InteractivePrompt, error) {
+	prompt, err := s.GetInteractivePrompt(ctx, id)
+	if err != nil {
+		return InteractivePrompt{}, err
+	}
+	if prompt.State == InteractivePromptStateResolved {
+		return InteractivePrompt{}, fmt.Errorf("interactive prompt %s is already resolved", prompt.ID)
+	}
+	value, err = validateInteractivePromptAnswer(prompt, value)
+	if err != nil {
+		return InteractivePrompt{}, err
+	}
+	source = strings.TrimSpace(source)
+	if source == "" {
+		source = "cli"
+	}
+	answeredAt := time.Now().UTC().Format(time.RFC3339)
+	result, err := s.db.ExecContext(ctx, `UPDATE interactive_prompts
+		SET state = ?, answer_value = ?, answer_source = ?, answered_at = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND state = ?`,
+		InteractivePromptStateResolved, value, source, answeredAt, prompt.ID, InteractivePromptStatePending)
+	if err != nil {
+		return InteractivePrompt{}, err
+	}
+	if err := requireAffected(result, "interactive prompt", prompt.ID); err != nil {
+		return InteractivePrompt{}, err
+	}
+	return s.GetInteractivePrompt(ctx, prompt.ID)
+}
+
+func validateInteractivePromptAnswer(prompt InteractivePrompt, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" && strings.TrimSpace(prompt.Default) != "" {
+		value = strings.TrimSpace(prompt.Default)
+	}
+	if value == "" && prompt.Required {
+		return "", fmt.Errorf("interactive prompt %s requires an answer", prompt.ID)
+	}
+	if value != "" && len(prompt.Choices) > 0 && !stringInSlice(value, prompt.Choices) {
+		return "", fmt.Errorf("interactive prompt %s answer %q is not one of: %s", prompt.ID, value, strings.Join(prompt.Choices, ", "))
+	}
+	return value, nil
+}
+
 func (s *Store) UpsertEvalReviewItem(ctx context.Context, item EvalReviewItem) error {
 	return upsertEvalReviewItemExec(ctx, s.db, item)
 }
@@ -2835,6 +3031,24 @@ func scanSkillOptReviewWatch(row interface{ Scan(dest ...any) error }) (SkillOpt
 	return watch, nil
 }
 
+func scanInteractivePrompt(row interface{ Scan(dest ...any) error }) (InteractivePrompt, error) {
+	var prompt InteractivePrompt
+	var choicesJSON string
+	var required int
+	if err := row.Scan(&prompt.ID, &prompt.Question, &choicesJSON, &prompt.Default, &required, &prompt.AnswerFormat,
+		&prompt.SourceCommand, &prompt.State, &prompt.AnswerValue, &prompt.AnswerSource, &prompt.CreatedAt, &prompt.UpdatedAt, &prompt.AnsweredAt); err != nil {
+		return InteractivePrompt{}, err
+	}
+	if strings.TrimSpace(choicesJSON) != "" {
+		if err := json.Unmarshal([]byte(choicesJSON), &prompt.Choices); err != nil {
+			return InteractivePrompt{}, fmt.Errorf("decode interactive prompt choices: %w", err)
+		}
+	}
+	prompt.Choices = trimUniqueStrings(prompt.Choices)
+	prompt.Required = required != 0
+	return prompt, nil
+}
+
 func scanEvalReviewItem(row interface{ Scan(dest ...any) error }) (EvalReviewItem, error) {
 	var item EvalReviewItem
 	if err := row.Scan(&item.ID, &item.RunID, &item.ItemID, &item.Title, &item.SourceArtifactID, &item.BaselineArtifactID,
@@ -2857,6 +3071,32 @@ func boolInt(value bool) int {
 		return 1
 	}
 	return 0
+}
+
+func trimUniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	output := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		output = append(output, value)
+	}
+	return output
+}
+
+func stringInSlice(value string, values []string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Store) UpsertFeedbackEvent(ctx context.Context, event FeedbackEvent) error {
@@ -4262,5 +4502,24 @@ ALTER TABLE agent_instances ADD COLUMN autonomy_policy TEXT NOT NULL DEFAULT 'au
 	`,
 	`
 ALTER TABLE tasks ADD COLUMN worktree_path TEXT NOT NULL DEFAULT '';
+	`,
+	`
+CREATE TABLE interactive_prompts (
+	id TEXT PRIMARY KEY,
+	question TEXT NOT NULL,
+	choices_json TEXT NOT NULL DEFAULT '[]',
+	default_value TEXT NOT NULL DEFAULT '',
+	required INTEGER NOT NULL DEFAULT 1,
+	answer_format TEXT NOT NULL DEFAULT 'text',
+	source_command TEXT NOT NULL DEFAULT '',
+	state TEXT NOT NULL DEFAULT 'pending',
+	answer_value TEXT NOT NULL DEFAULT '',
+	answer_source TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	answered_at TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX idx_interactive_prompts_state ON interactive_prompts(state);
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -44,6 +44,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"skillopt_train_sessions",
 		"skillopt_train_iterations",
 		"skillopt_review_watches",
+		"interactive_prompts",
 	} {
 		ok, err := store.HasTable(ctx, table)
 		if err != nil {
@@ -94,6 +95,68 @@ func TestOpenConfiguresSQLiteContentionPragmas(t *testing.T) {
 	}
 	if busyTimeout != sqliteBusyTimeoutMillis {
 		t.Fatalf("read-only busy_timeout = %d, want %d", busyTimeout, sqliteBusyTimeoutMillis)
+	}
+}
+
+func TestInteractivePromptStorageAndAnswerValidation(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	prompt := InteractivePrompt{
+		ID:            "train-init-template",
+		Question:      "Which template should Gitmoot train?",
+		Choices:       []string{"planner", "writer", "planner"},
+		Default:       "planner",
+		Required:      true,
+		AnswerFormat:  "choice",
+		SourceCommand: "gitmoot skillopt train init",
+	}
+	if err := store.UpsertInteractivePrompt(ctx, prompt); err != nil {
+		t.Fatalf("UpsertInteractivePrompt returned error: %v", err)
+	}
+
+	pending, err := store.ListInteractivePrompts(ctx, InteractivePromptStatePending)
+	if err != nil {
+		t.Fatalf("ListInteractivePrompts returned error: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ID != prompt.ID || len(pending[0].Choices) != 2 {
+		t.Fatalf("pending prompts = %+v", pending)
+	}
+
+	if _, err := store.AnswerInteractivePrompt(ctx, prompt.ID, "missing", "test"); err == nil || !strings.Contains(err.Error(), "not one of") {
+		t.Fatalf("AnswerInteractivePrompt invalid value error = %v", err)
+	}
+	answered, err := store.AnswerInteractivePrompt(ctx, prompt.ID, "", "agent")
+	if err != nil {
+		t.Fatalf("AnswerInteractivePrompt default returned error: %v", err)
+	}
+	if answered.State != InteractivePromptStateResolved || answered.AnswerValue != "planner" || answered.AnswerSource != "agent" || answered.AnsweredAt == "" {
+		t.Fatalf("answered prompt = %+v", answered)
+	}
+	if _, err := store.AnswerInteractivePrompt(ctx, prompt.ID, "writer", "agent"); err == nil || !strings.Contains(err.Error(), "already resolved") {
+		t.Fatalf("AnswerInteractivePrompt second answer error = %v", err)
+	}
+	if err := store.UpsertInteractivePrompt(ctx, InteractivePrompt{
+		ID:            prompt.ID,
+		Question:      "Which template should Gitmoot train now?",
+		Choices:       []string{"planner", "writer"},
+		Default:       "writer",
+		Required:      true,
+		AnswerFormat:  "choice",
+		SourceCommand: "gitmoot skillopt train init",
+	}); err != nil {
+		t.Fatalf("UpsertInteractivePrompt retry returned error: %v", err)
+	}
+	preserved, err := store.GetInteractivePrompt(ctx, prompt.ID)
+	if err != nil {
+		t.Fatalf("GetInteractivePrompt returned error: %v", err)
+	}
+	if preserved.State != InteractivePromptStateResolved || preserved.AnswerValue != "planner" || preserved.AnswerSource != "agent" || preserved.AnsweredAt != answered.AnsweredAt {
+		t.Fatalf("preserved prompt = %+v, answered_at before %q", preserved, answered.AnsweredAt)
 	}
 }
 


### PR DESCRIPTION
WHAT
- Add reusable interactive prompt/session storage primitives.
- Add `gitmoot interactive list/show/answer` for inspecting and resolving prompts.

WHY
- SkillOpt train init needs a durable, reusable question/answer channel that agents and future UI surfaces can share without baking train-init-specific logic into each caller.

CHANGES
- Added `interactive_prompts` schema and store APIs for upsert/list/get/answer.
- Added validation for pending/resolved states, required answers, defaults, exact choice matching, and duplicate choice cleanup.
- Preserved an already-resolved answer when a producer re-registers the same prompt as pending.
- Added root CLI command `interactive` with `list`, `show --json`, and `answer` subcommands.
- Supported documented trailing flags and `--` delimiter for dash-prefixed answer values.
- Added DB and CLI tests covering storage, validation, JSON output, trailing flags, invalid choices, and dash-prefixed text answers.

RESULTS
- `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./internal/db ./internal/cli -run 'Interactive|PromptSession' -v`
- `git diff --check`
- `codex exec review --uncommitted` final output:

```text
No discrete correctness issues were found in the staged changes. Targeted tests could not be run because the Go 1.26 toolchain download is blocked by the read-only module cache in this environment.
```

RISK
- Low to moderate: this adds a DB migration and a new root command, but the behavior is isolated to a new interactive prompt surface.
