### PR TITLE
skillopt: complete train init prompt flow

### DIFF
--- a/internal/cli/agent_template_test.go
+++ b/internal/cli/agent_template_test.go
@@ -764,6 +764,18 @@ func replaceAgentTemplateFetcher(fetcher agenttemplate.Fetcher) func() {
 	}
 }
 
+func replaceSkillOptTrainInitInteractive(interactive bool) func() {
+	previous := skillOptTrainInitInteractive
+	active := true
+	skillOptTrainInitInteractive = func() bool {
+		return active && interactive
+	}
+	return func() {
+		active = false
+		skillOptTrainInitInteractive = previous
+	}
+}
+
 type fakeAgentTemplateFetcher struct {
 	commit  string
 	content string

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -42,6 +42,11 @@ var skillOptTrainOptimizerRunner subprocess.Runner = subprocess.ExecRunner{}
 
 var skillOptTrainPreviewRunner subprocess.Runner = subprocess.ExecRunner{}
 
+var skillOptTrainInitInteractive = func() bool {
+	info, err := os.Stdin.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
 func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		printSkillOptUsage(stdout)
@@ -160,6 +165,7 @@ func runSkillOptTrainInitCreate(args []string, stdout, stderr io.Writer) int {
 	mode := fs.String("mode", db.EvalRunModeExplore, "train mode: explore, refine, distill, or validate")
 	requestText := fs.String("request", "", "human training request for task.md")
 	requestFile := fs.String("request-file", "", "file containing the human training request")
+	yes := fs.Bool("yes", false, "do not create interactive prompts for missing fields")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -185,38 +191,65 @@ func runSkillOptTrainInitCreate(args []string, stdout, stderr io.Writer) int {
 		Mode:         strings.TrimSpace(*mode),
 		Request:      strings.TrimSpace(request),
 	}
+	setFlags := flagNamesSet(fs)
 	if values.TaskKind == "" {
 		values.TaskKind = "custom"
 	}
 	if values.Mode == "" {
 		values.Mode = db.EvalRunModeExplore
 	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt train init: get working directory: %v\n", err)
+		return 1
+	}
+	promptScope := skillOptTrainInitPromptScope(cwd, values.Name)
+	rerunCommand := skillOptTrainInitRerunCommand(*home, values, strings.TrimSpace(*requestFile), setFlags)
+	appliedPromptFields, err := applySkillOptTrainInitPromptAnswers(*home, promptScope, setFlags, &values)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
+		return 1
+	}
 	if missing := missingSkillOptTrainInitInputs(values); len(missing) > 0 {
+		if !*yes && skillOptTrainInitInteractive() {
+			prompts, err := createSkillOptTrainInitPrompts(*home, promptScope, values, missing)
+			if err != nil {
+				fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
+				return 1
+			}
+			printSkillOptTrainInitPromptInstructions(stdout, *home, rerunCommand, prompts)
+			return 0
+		}
 		fmt.Fprintf(stderr, "skillopt train init missing required fields: %s\n", strings.Join(missing, ", "))
 		fmt.Fprintf(stderr, "example: %s\n", skillOptTrainInitExampleCommand(values.Name))
 		return 2
 	}
 	if err := skillopt.ValidateTrainInitName(values.Name); err != nil {
+		clearSkillOptTrainInitPromptAnswerOnError(*home, promptScope, appliedPromptFields, "name")
 		fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
 		return 2
 	}
 	reviewRepo, err := daemon.ParseRepository(values.ReviewRepo)
 	if err != nil {
+		clearSkillOptTrainInitPromptAnswerOnError(*home, promptScope, appliedPromptFields, "review_repo")
 		fmt.Fprintf(stderr, "skillopt train init: review-repo: %v\n", err)
 		return 2
 	}
 	if _, err := normalizeSkillOptTrainTaskKind(values.TaskKind); err != nil {
+		clearSkillOptTrainInitPromptAnswerOnError(*home, promptScope, appliedPromptFields, "task_kind")
 		fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
 		return 2
 	}
 	normalizedPreview, err := normalizeSkillOptTrainInitPreview(values.Preview)
 	if err != nil {
+		clearSkillOptTrainInitPromptAnswerOnError(*home, promptScope, appliedPromptFields, "preview")
 		fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
 		return 2
 	}
 	values.Preview = normalizedPreview
 	normalizedMode, normalizedExploration, err := normalizeSkillOptTrainMode(values.Mode, "")
 	if err != nil {
+		clearSkillOptTrainInitPromptAnswerOnError(*home, promptScope, appliedPromptFields, "mode")
 		fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
 		return 2
 	}
@@ -227,6 +260,7 @@ func runSkillOptTrainInitCreate(args []string, stdout, stderr io.Writer) int {
 		template, err = skillopt.ResolveTrainInitTemplateChoice(context.Background(), store, newAgentTemplateFetcher(), values.Template)
 		return err
 	}); err != nil {
+		clearSkillOptTrainInitPromptAnswerOnError(*home, promptScope, appliedPromptFields, "template")
 		fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
 		return 1
 	}
@@ -241,17 +275,16 @@ func runSkillOptTrainInitCreate(args []string, stdout, stderr io.Writer) int {
 	config.Mode = values.Mode
 	config.ExplorationLevel = normalizedExploration
 	config.Options = skillOptTrainInitDefaultOptions(normalizedMode)
-	cwd, err := os.Getwd()
-	if err != nil {
-		fmt.Fprintf(stderr, "skillopt train init: get working directory: %v\n", err)
-		return 1
-	}
 	paths, err := skillopt.WriteTrainInitScaffold(cwd, skillopt.TrainInitScaffold{
 		Config:          config,
 		TaskMarkdown:    values.Request,
 		ReviewItemsYAML: skillOptTrainInitStarterReviewItemsYAML(values),
 	})
 	if err != nil {
+		fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
+		return 1
+	}
+	if err := consumeSkillOptTrainInitPromptAnswers(*home, promptScope); err != nil {
 		fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
 		return 1
 	}
@@ -273,6 +306,12 @@ type skillOptTrainInitInputs struct {
 	Request      string
 }
 
+type skillOptTrainInitPrompt struct {
+	Field  string
+	Flag   string
+	Prompt db.InteractivePrompt
+}
+
 func missingSkillOptTrainInitInputs(values skillOptTrainInitInputs) []string {
 	missing := []string{}
 	for field, value := range map[string]string{
@@ -291,6 +330,300 @@ func missingSkillOptTrainInitInputs(values skillOptTrainInitInputs) []string {
 	}
 	sort.Strings(missing)
 	return missing
+}
+
+func skillOptTrainInitPromptScope(workspaceRoot string, name string) string {
+	workspaceRoot = strings.TrimSpace(workspaceRoot)
+	if abs, err := filepath.Abs(workspaceRoot); err == nil {
+		workspaceRoot = abs
+	}
+	workspaceRoot = filepath.Clean(workspaceRoot)
+	sum := sha256.Sum256([]byte(workspaceRoot))
+	workspaceScope := "ws-" + hex.EncodeToString(sum[:8])
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return workspaceScope + "-empty"
+	}
+	return workspaceScope + "-name-" + hex.EncodeToString([]byte(name))
+}
+
+func skillOptTrainInitPromptID(scope string, field string) string {
+	return "skillopt-train-init." + strings.TrimSpace(scope) + "." + strings.ReplaceAll(field, "_", "-")
+}
+
+func applySkillOptTrainInitPromptAnswers(home string, scope string, setFlags map[string]struct{}, values *skillOptTrainInitInputs) (map[string]struct{}, error) {
+	if values == nil || !skillOptTrainInitPromptDatabaseExists(home) {
+		return nil, nil
+	}
+	paths, err := skillOptTrainInitConfigPaths(home)
+	if err != nil {
+		return nil, err
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	prompts, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		return nil, err
+	}
+	answers := map[string]string{}
+	for _, prompt := range prompts {
+		if prompt.State != db.InteractivePromptStateResolved {
+			continue
+		}
+		field, ok := skillOptTrainInitPromptField(scope, prompt.ID)
+		if !ok {
+			continue
+		}
+		answers[field] = prompt.AnswerValue
+	}
+	applied := map[string]struct{}{}
+	for field, answer := range answers {
+		if strings.TrimSpace(answer) == "" || skillOptTrainInitFieldWasSet(field, setFlags) {
+			continue
+		}
+		switch field {
+		case "name":
+			values.Name = answer
+		case "template":
+			values.Template = answer
+		case "review_repo":
+			values.ReviewRepo = answer
+		case "task_kind":
+			values.TaskKind = answer
+		case "artifact_kind":
+			values.ArtifactKind = answer
+		case "preview":
+			values.Preview = answer
+		case "mode":
+			values.Mode = answer
+		case "request":
+			values.Request = answer
+		}
+		applied[field] = struct{}{}
+	}
+	return applied, nil
+}
+
+func clearSkillOptTrainInitPromptAnswerOnError(home string, scope string, appliedPromptFields map[string]struct{}, field string) {
+	if _, ok := appliedPromptFields[field]; !ok {
+		return
+	}
+	_ = deleteSkillOptTrainInitPrompt(home, scope, field)
+}
+
+func deleteSkillOptTrainInitPrompt(home string, scope string, field string) error {
+	if !skillOptTrainInitPromptDatabaseExists(home) {
+		return nil
+	}
+	paths, err := skillOptTrainInitConfigPaths(home)
+	if err != nil {
+		return err
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	return store.DeleteInteractivePrompt(context.Background(), skillOptTrainInitPromptID(scope, field))
+}
+
+func consumeSkillOptTrainInitPromptAnswers(home string, scope string) error {
+	if !skillOptTrainInitPromptDatabaseExists(home) {
+		return nil
+	}
+	paths, err := skillOptTrainInitConfigPaths(home)
+	if err != nil {
+		return err
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	prompts, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		return err
+	}
+	for _, prompt := range prompts {
+		if _, ok := skillOptTrainInitPromptField(scope, prompt.ID); !ok {
+			continue
+		}
+		if err := store.DeleteInteractivePrompt(context.Background(), prompt.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func skillOptTrainInitPromptDatabaseExists(home string) bool {
+	paths, err := skillOptTrainInitConfigPaths(home)
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(paths.Database)
+	return err == nil && !info.IsDir()
+}
+
+func skillOptTrainInitConfigPaths(home string) (config.Paths, error) {
+	if strings.TrimSpace(home) != "" {
+		return config.PathsForHome(home), nil
+	}
+	return config.DefaultPaths()
+}
+
+func skillOptTrainInitPromptField(scope string, promptID string) (string, bool) {
+	prefix := "skillopt-train-init." + strings.TrimSpace(scope) + "."
+	if !strings.HasPrefix(promptID, prefix) {
+		return "", false
+	}
+	field := strings.TrimPrefix(promptID, prefix)
+	field = strings.ReplaceAll(field, "-", "_")
+	switch field {
+	case "name", "template", "review_repo", "task_kind", "artifact_kind", "preview", "mode", "request":
+		return field, true
+	default:
+		return "", false
+	}
+}
+
+func skillOptTrainInitFieldWasSet(field string, setFlags map[string]struct{}) bool {
+	switch field {
+	case "request":
+		return flagWasSet(setFlags, "request") || flagWasSet(setFlags, "request-file")
+	case "review_repo":
+		return flagWasSet(setFlags, "review-repo")
+	case "task_kind":
+		return flagWasSet(setFlags, "task-kind")
+	case "artifact_kind":
+		return flagWasSet(setFlags, "artifact-kind")
+	default:
+		return flagWasSet(setFlags, strings.ReplaceAll(field, "_", "-"))
+	}
+}
+
+func createSkillOptTrainInitPrompts(home string, scope string, values skillOptTrainInitInputs, missing []string) ([]skillOptTrainInitPrompt, error) {
+	var created []skillOptTrainInitPrompt
+	err := withStore(home, func(store *db.Store) error {
+		for _, field := range missing {
+			prompt := buildSkillOptTrainInitPrompt(scope, field, values)
+			if err := store.UpsertInteractivePrompt(context.Background(), prompt.Prompt); err != nil {
+				return err
+			}
+			created = append(created, prompt)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+func buildSkillOptTrainInitPrompt(scope string, field string, values skillOptTrainInitInputs) skillOptTrainInitPrompt {
+	descriptor := skillOptTrainInitPrompt{
+		Field: field,
+		Flag:  skillOptTrainInitFlagForField(field),
+		Prompt: db.InteractivePrompt{
+			ID:            skillOptTrainInitPromptID(scope, field),
+			Required:      true,
+			AnswerFormat:  "text",
+			SourceCommand: "gitmoot skillopt train init",
+		},
+	}
+	switch field {
+	case "name":
+		descriptor.Prompt.Question = "Training name? (flag: --name)"
+	case "template":
+		descriptor.Prompt.Question = "Agent template to train? (flag: --template)"
+	case "review_repo":
+		descriptor.Prompt.Question = "Review repository in owner/repo form? (flag: --review-repo)"
+	case "task_kind":
+		descriptor.Prompt.Question = "Task kind? (flag: --task-kind)"
+		descriptor.Prompt.Choices = []string{"correctness", "ux", "design", "writing", "data", "custom"}
+		descriptor.Prompt.Default = firstNonEmpty(values.TaskKind, "custom")
+		descriptor.Prompt.AnswerFormat = "choice"
+	case "artifact_kind":
+		descriptor.Prompt.Question = "Artifact kind to optimize? (flag: --artifact-kind)"
+	case "preview":
+		descriptor.Prompt.Question = "Preview kind? (flag: --preview)"
+		descriptor.Prompt.Choices = []string{"none", "text-table", "vue"}
+		descriptor.Prompt.AnswerFormat = "choice"
+	case "mode":
+		descriptor.Prompt.Question = "Training mode? (flag: --mode)"
+		descriptor.Prompt.Choices = []string{db.EvalRunModeExplore, db.EvalRunModeRefine, db.EvalRunModeDistill, db.EvalRunModeValidate}
+		descriptor.Prompt.Default = firstNonEmpty(values.Mode, db.EvalRunModeExplore)
+		descriptor.Prompt.AnswerFormat = "choice"
+	case "request":
+		descriptor.Prompt.Question = "Training request text? (flag: --request)"
+	default:
+		descriptor.Prompt.Question = field + "? (flag: " + descriptor.Flag + ")"
+	}
+	return descriptor
+}
+
+func skillOptTrainInitFlagForField(field string) string {
+	switch field {
+	case "review_repo":
+		return "--review-repo"
+	case "task_kind":
+		return "--task-kind"
+	case "artifact_kind":
+		return "--artifact-kind"
+	default:
+		return "--" + strings.ReplaceAll(field, "_", "-")
+	}
+}
+
+func printSkillOptTrainInitPromptInstructions(stdout io.Writer, home string, rerunCommand []string, prompts []skillOptTrainInitPrompt) {
+	writeLine(stdout, "interactive_prompts_created: %d", len(prompts))
+	for _, prompt := range prompts {
+		writeLine(stdout, "prompt: %s field=%s flag=%s", prompt.Prompt.ID, prompt.Field, prompt.Flag)
+		writeLine(stdout, "question: %s", prompt.Prompt.Question)
+		writeLine(stdout, "show_command: %s", shellArgs(append(skillOptTrainInitInteractiveCommandPrefix("show", home), prompt.Prompt.ID, "--json")))
+		writeLine(stdout, "answer_command: %s <value>", shellArgs(append(skillOptTrainInitInteractiveCommandPrefix("answer", home), prompt.Prompt.ID)))
+	}
+	writeLine(stdout, "next: answer the prompts, then rerun %s", shellArgs(rerunCommand))
+}
+
+func skillOptTrainInitInteractiveCommandPrefix(command string, home string) []string {
+	args := []string{"gitmoot", "interactive", command}
+	if strings.TrimSpace(home) != "" {
+		args = append(args, "--home", strings.TrimSpace(home))
+	}
+	return args
+}
+
+func skillOptTrainInitRerunCommand(home string, values skillOptTrainInitInputs, requestFile string, setFlags map[string]struct{}) []string {
+	args := []string{"gitmoot", "skillopt", "train", "init"}
+	if strings.TrimSpace(home) != "" {
+		args = append(args, "--home", strings.TrimSpace(home))
+	}
+	for _, field := range []struct {
+		flag  string
+		value string
+	}{
+		{"name", values.Name},
+		{"template", values.Template},
+		{"review-repo", values.ReviewRepo},
+		{"task-kind", values.TaskKind},
+		{"artifact-kind", values.ArtifactKind},
+		{"preview", values.Preview},
+		{"mode", values.Mode},
+		{"request", values.Request},
+		{"request-file", requestFile},
+	} {
+		if !flagWasSet(setFlags, field.flag) || strings.TrimSpace(field.value) == "" {
+			continue
+		}
+		if field.flag == "request-file" && strings.TrimSpace(values.Request) == "" {
+			continue
+		}
+		args = append(args, "--"+field.flag, strings.TrimSpace(field.value))
+	}
+	return args
 }
 
 func skillOptTrainInitExampleCommand(name string) string {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -984,6 +984,383 @@ func TestSkillOptTrainInitCreatesScaffold(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainInitCompletesFromPromptAnswers(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	scope := skillOptTrainInitPromptScope(workspace, "")
+	restoreFetcher := replaceAgentTemplateFetcher(fakeAgentTemplateFetcher{
+		commit:  "abc123",
+		content: "# Gitmoot Planner\n\nPlan work.",
+	})
+	defer restoreFetcher()
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+	defer restoreInteractive()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "interactive_prompts_created: 6") || !strings.Contains(stdout.String(), "gitmoot interactive answer --home "+home+" "+skillOptTrainInitPromptID(scope, "template")+" <value>") {
+		t.Fatalf("prompt stdout = %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "rerun gitmoot skillopt train init --home "+home) {
+		t.Fatalf("prompt stdout missing home-aware rerun command = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"interactive", "show", "--home", home, skillOptTrainInitPromptID(scope, "template"), "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("show template prompt exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var templatePrompt db.InteractivePrompt
+	if err := json.Unmarshal(stdout.Bytes(), &templatePrompt); err != nil {
+		t.Fatalf("decode template prompt: %v\n%s", err, stdout.String())
+	}
+	if templatePrompt.AnswerFormat != "text" || len(templatePrompt.Choices) != 0 {
+		t.Fatalf("template prompt should accept template refs without choice restriction: %+v", templatePrompt)
+	}
+
+	answers := map[string]string{
+		"name":          "prompt-flow",
+		"template":      "planner",
+		"review-repo":   "jerryfane/gitmoot",
+		"artifact-kind": "text",
+		"preview":       "text-table",
+		"request":       "Improve planner summaries.",
+	}
+	for field, value := range answers {
+		stdout.Reset()
+		stderr.Reset()
+		code = Run([]string{"interactive", "answer", "--home", home, skillOptTrainInitPromptID(scope, strings.ReplaceAll(field, "-", "_")), value, "--source", "agent"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("answer %s exit code = %d, stdout=%s stderr=%s", field, code, stdout.String(), stderr.String())
+		}
+	}
+
+	restoreInteractive()
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("prompt-backed train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	cfg, err := skillopt.LoadTrainInitConfig(filepath.Join(workspace, ".gitmoot", "skillopt", "prompt-flow", "config.toml"))
+	if err != nil {
+		t.Fatalf("LoadTrainInitConfig returned error: %v", err)
+	}
+	if cfg.Name != "prompt-flow" || cfg.Template != "planner" || cfg.ReviewRepo != "jerryfane/gitmoot" || cfg.ArtifactKind != "text" || cfg.Preview != "text-table" || cfg.Mode != db.EvalRunModeExplore {
+		t.Fatalf("config from prompts = %+v", cfg)
+	}
+	task, err := os.ReadFile(filepath.Join(workspace, ".gitmoot", "skillopt", "prompt-flow", "task.md"))
+	if err != nil {
+		t.Fatalf("ReadFile task.md returned error: %v", err)
+	}
+	if strings.TrimSpace(string(task)) != "Improve planner summaries." {
+		t.Fatalf("task.md = %q", string(task))
+	}
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open store returned error: %v", err)
+	}
+	defer store.Close()
+	prompts, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListInteractivePrompts returned error: %v", err)
+	}
+	if len(prompts) != 0 {
+		t.Fatalf("prompt answers should be consumed after scaffold creation: %+v", prompts)
+	}
+}
+
+func TestSkillOptTrainInitNamedPromptRerunIncludesName(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	scope := skillOptTrainInitPromptScope(workspace, "named-flow")
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+	defer restoreInteractive()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home, "--name", "named-flow"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("named interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), skillOptTrainInitPromptID(scope, "template")) {
+		t.Fatalf("named prompt stdout missing encoded scope:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "rerun gitmoot skillopt train init --home "+home+" --name named-flow") {
+		t.Fatalf("named prompt stdout missing name-aware rerun command:\n%s", stdout.String())
+	}
+}
+
+func TestSkillOptTrainInitPartialDefaultPromptRerunStaysDefaultScoped(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	scope := skillOptTrainInitPromptScope(workspace, "")
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+	defer restoreInteractive()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"interactive", "answer", "--home", home, skillOptTrainInitPromptID(scope, "name"), "partial-flow"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("answer name exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("partial prompt rerun exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "--name partial-flow") {
+		t.Fatalf("default-scoped partial rerun should not switch scopes:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), skillOptTrainInitPromptID(scope, "template")) {
+		t.Fatalf("default-scoped partial rerun should keep empty prompt ids:\n%s", stdout.String())
+	}
+}
+
+func TestSkillOptTrainInitPromptRerunPreservesSuppliedFlags(t *testing.T) {
+	home := t.TempDir()
+	_ = chdirTemp(t)
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+	defer restoreInteractive()
+
+	requestFile := filepath.Join(t.TempDir(), "request.md")
+	if err := os.WriteFile(requestFile, []byte("Improve prompts.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile request returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "init",
+		"--home", home,
+		"--template", "planner",
+		"--artifact-kind", "text",
+		"--request-file", requestFile,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"--template planner",
+		"--artifact-kind text",
+		"--request-file " + requestFile,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("prompt rerun command did not preserve %s:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "--request Improve prompts") {
+		t.Fatalf("prompt rerun command should preserve request-file, not inline request text:\n%s", output)
+	}
+}
+
+func TestSkillOptTrainInitPromptRerunDropsEmptyRequestFile(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	scope := skillOptTrainInitPromptScope(workspace, "")
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+	defer restoreInteractive()
+
+	requestFile := filepath.Join(t.TempDir(), "empty-request.md")
+	if err := os.WriteFile(requestFile, []byte(" \n\t\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile request returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "init",
+		"--home", home,
+		"--template", "planner",
+		"--request-file", requestFile,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "--request-file") {
+		t.Fatalf("empty request-file should not be preserved when request is prompted:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), skillOptTrainInitPromptID(scope, "request")) {
+		t.Fatalf("empty request-file should create request prompt:\n%s", stdout.String())
+	}
+}
+
+func TestSkillOptTrainInitClearsInvalidPromptAnswers(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	scope := skillOptTrainInitPromptScope(workspace, "")
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	answers := map[string]string{
+		"name":          "bad-prompt-flow",
+		"template":      "planner",
+		"review-repo":   "not-a-repo",
+		"artifact-kind": "text",
+		"preview":       "text-table",
+		"request":       "Improve planner summaries.",
+	}
+	for field, value := range answers {
+		stdout.Reset()
+		stderr.Reset()
+		code = Run([]string{"interactive", "answer", "--home", home, skillOptTrainInitPromptID(scope, strings.ReplaceAll(field, "-", "_")), value, "--source", "agent"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("answer %s exit code = %d, stdout=%s stderr=%s", field, code, stdout.String(), stderr.String())
+		}
+	}
+
+	restoreInteractive()
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("invalid prompt-backed init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "review-repo") {
+		t.Fatalf("stderr missing review repo validation error: %s", stderr.String())
+	}
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open store returned error: %v", err)
+	}
+	defer store.Close()
+	prompts, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListInteractivePrompts returned error: %v", err)
+	}
+	if len(prompts) != 5 {
+		t.Fatalf("only the invalid prompt answer should be cleared, got: %+v", prompts)
+	}
+	for _, prompt := range prompts {
+		if strings.Contains(prompt.ID, ".review-repo") {
+			t.Fatalf("invalid review repo prompt should be cleared: %+v", prompts)
+		}
+	}
+}
+
+func TestSkillOptTrainInitKeepsPromptAnswersForExplicitFlagErrors(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	scope := skillOptTrainInitPromptScope(workspace, "")
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home, "--preview", "bogus"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	answers := map[string]string{
+		"name":          "explicit-error-flow",
+		"template":      "planner",
+		"review-repo":   "jerryfane/gitmoot",
+		"artifact-kind": "text",
+		"request":       "Improve planner summaries.",
+	}
+	for field, value := range answers {
+		stdout.Reset()
+		stderr.Reset()
+		code = Run([]string{"interactive", "answer", "--home", home, skillOptTrainInitPromptID(scope, strings.ReplaceAll(field, "-", "_")), value, "--source", "agent"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("answer %s exit code = %d, stdout=%s stderr=%s", field, code, stdout.String(), stderr.String())
+		}
+	}
+
+	restoreInteractive()
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "init", "--home", home, "--preview", "bogus"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("explicit invalid preview init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open store returned error: %v", err)
+	}
+	defer store.Close()
+	prompts, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListInteractivePrompts returned error: %v", err)
+	}
+	if len(prompts) != len(answers) {
+		t.Fatalf("explicit flag error should not clear prompt answers: %+v", prompts)
+	}
+	for _, prompt := range prompts {
+		if prompt.State != db.InteractivePromptStateResolved {
+			t.Fatalf("prompt answer should remain resolved after explicit flag error: %+v", prompt)
+		}
+	}
+}
+
+func TestSkillOptTrainInitFullyFlaggedBypassesPromptCreation(t *testing.T) {
+	home := t.TempDir()
+	_ = chdirTemp(t)
+	restoreFetcher := replaceAgentTemplateFetcher(fakeAgentTemplateFetcher{
+		commit:  "abc123",
+		content: "# Gitmoot Planner\n\nPlan work.",
+	})
+	defer restoreFetcher()
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+	defer restoreInteractive()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "init",
+		"--home", home,
+		"--name", "flagged-flow",
+		"--template", "planner",
+		"--review-repo", "jerryfane/gitmoot",
+		"--task-kind", "writing",
+		"--artifact-kind", "text",
+		"--preview", "text-table",
+		"--request", "Improve this.",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open store returned error: %v", err)
+	}
+	defer store.Close()
+	prompts, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListInteractivePrompts returned error: %v", err)
+	}
+	if len(prompts) != 0 {
+		t.Fatalf("fully flagged init created prompts: %+v", prompts)
+	}
+}
+
+func TestSkillOptTrainInitPromptScopesDoNotCollide(t *testing.T) {
+	scopes := map[string]string{
+		"workspace-a-empty":   skillOptTrainInitPromptScope("/tmp/workspace-a", ""),
+		"workspace-b-empty":   skillOptTrainInitPromptScope("/tmp/workspace-b", ""),
+		"workspace-a-default": skillOptTrainInitPromptScope("/tmp/workspace-a", "default"),
+		"workspace-a-Foo":     skillOptTrainInitPromptScope("/tmp/workspace-a", "Foo"),
+		"workspace-a-foo":     skillOptTrainInitPromptScope("/tmp/workspace-a", "foo"),
+	}
+	seen := map[string]string{}
+	for label, scope := range scopes {
+		if previous, ok := seen[scope]; ok {
+			t.Fatalf("scope collision: %s and %s both use %s", previous, label, scope)
+		}
+		seen[scope] = label
+	}
+}
+
 func TestSkillOptTrainStartLoadsInitConfig(t *testing.T) {
 	home := t.TempDir()
 	workspace := chdirTemp(t)
@@ -1305,6 +1682,8 @@ func TestSkillOptTrainOptimizerDefaultsDoNotOverrideExplicitControls(t *testing.
 func TestSkillOptTrainInitMissingRequiredFieldsIsAtomic(t *testing.T) {
 	home := t.TempDir()
 	workspace := chdirTemp(t)
+	restoreInteractive := replaceSkillOptTrainInitInteractive(false)
+	defer restoreInteractive()
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{"skillopt", "train", "init", "--home", home, "--name", "missing-fields"}, &stdout, &stderr)
 	if code != 2 {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2691,6 +2691,15 @@ func (s *Store) AnswerInteractivePrompt(ctx context.Context, id string, value st
 	return s.GetInteractivePrompt(ctx, prompt.ID)
 }
 
+func (s *Store) DeleteInteractivePrompt(ctx context.Context, id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("interactive prompt id is required")
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM interactive_prompts WHERE id = ?`, id)
+	return err
+}
+
 func validateInteractivePromptAnswer(prompt InteractivePrompt, value string) (string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" && strings.TrimSpace(prompt.Default) != "" {


### PR DESCRIPTION
WHAT
- Adds prompt-backed completion for `gitmoot skillopt train init` when required fields are missing in an interactive terminal.
- Lets agents inspect and answer those prompts through the reusable `gitmoot interactive show/list/answer` flow.
- Consumes prompt answers after successful scaffold creation and scopes prompt IDs by workspace plus init name.

WHY
- Issue #195 requires an agent-safe structured IO path for training setup without adding a rich UI in this task.
- The init flow must support partial information, correction paths, and multiple pending workspaces under the same Gitmoot home.

CHANGES
- Added missing-field prompt creation for train init plus `--yes` to keep noninteractive atomic behavior.
- Added answer replay from resolved prompt records, with explicit CLI flags taking precedence.
- Added prompt lifecycle cleanup:
  - successful scaffold consumes the prompt set;
  - prompt-derived invalid values clear only the offending prompt;
  - explicit invalid flags do not delete valid prompt answers.
- Added workspace-aware prompt scopes to prevent answer leakage between repos using the same Gitmoot home.
- Added home-aware show/answer/rerun instructions and preserved supplied flags in rerun commands, including safe handling for empty `--request-file`.
- Added `DeleteInteractivePrompt` store helper.
- Added focused regression coverage for happy path, named/default scopes, partial reruns, flag preservation, invalid prompt answers, explicit flag errors, and scope collisions.

RESULTS
- PASS: `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./internal/cli ./internal/db -run 'SkillOptTrainInit|Interactive' -v`
- PASS: `git diff --check`
- REVIEW: `codex exec review --uncommitted`

Raw review output:
```text
No discrete correctness issues were identified in the current staged, unstaged, or untracked changes. The new prompt lifecycle appears scoped and cleaned up consistently with the added tests.
No discrete correctness issues were identified in the current staged, unstaged, or untracked changes. The new prompt lifecycle appears scoped and cleaned up consistently with the added tests.
```

Additional broad-suite note:
- `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./internal/cli -v` currently fails on `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos`.
- The same single test fails on clean `main` with `adapter calls = 1, want 2`, so this is a baseline daemon test failure, not introduced by this train-init prompt PR.

RISK
- Moderate: this adds lifecycle behavior around persisted prompts.
- Risk is contained to train init prompt handling and the generic prompt delete helper; noninteractive missing-field behavior remains atomic and covered.
