### PR TITLE
docs: document skillopt train init flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,12 @@ gitmoot lock release owner/repo <branch> --owner <agent>
 ### SkillOpt Exchange
 
 ```sh
+gitmoot skillopt train init --name <name> --template <id> --review-repo owner/repo --artifact-kind kind --preview kind (--request text|--request-file path)
+gitmoot skillopt train init templates --json
+gitmoot interactive list --state pending --json
+gitmoot interactive show <prompt-id> --json
+gitmoot interactive answer <prompt-id> <value> --source agent
+gitmoot skillopt train start --config .gitmoot/skillopt/<name>/config.toml --yes
 gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>
 gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]
 gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id> --mode explore --options 4
@@ -300,7 +306,15 @@ gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--p
 gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
 ```
 
-Create a review run, add saved baseline/candidate outputs as review items,
+Use `skillopt train init` to create a local scaffold under
+`.gitmoot/skillopt/<name>/` without starting model work. The scaffold pins the
+template/version, writes `config.toml`, `task.md`, and starter
+`review-items.yml`, and prints the exact `train start --config` command. Agents
+can list template choices with `train init templates --json`; when an
+interactive setup needs missing values, they can answer the stored prompts with
+`gitmoot interactive list/show/answer`.
+
+For lower-level debugging, create a review run, add saved baseline/candidate outputs as review items,
 export a Markdown or GitHub feedback packet, import the completed feedback, then
 export `training.json` for a future external `gitmoot-skillopt` optimizer.
 Use ranked exploration when the template needs broad search: start with

--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -32,9 +32,54 @@ candidates never become current silently.
 
 ## High-Level Commands
 
-Start with a request, target repo, pinned template, and item plan:
+Initialize a reusable training scaffold before expensive training work:
 
 ```sh
+gitmoot skillopt train init \
+  --name planner-train \
+  --template planner \
+  --review-repo owner/product \
+  --task-kind writing \
+  --artifact-kind text \
+  --preview text-table \
+  --mode explore \
+  --request "Improve release planning answers from reviewer feedback"
+```
+
+`train init` writes `.gitmoot/skillopt/<name>/config.toml`, `task.md`, and a
+starter `review-items.yml`. It pins the selected template/version, records the
+review repository, applies default generation/evaluator/optimizer settings, and
+prints the next `gitmoot skillopt train start --config ...` command. It does not
+start optimization, create review items, call models, or publish GitHub issues.
+
+List machine-readable template choices for agents before initializing:
+
+```sh
+gitmoot skillopt train init templates --json
+```
+
+If required fields are missing in an interactive terminal, Gitmoot stores
+structured prompt requests that agents can inspect and answer:
+
+```sh
+gitmoot interactive list --state pending --json
+gitmoot interactive show <prompt-id> --json
+gitmoot interactive answer <prompt-id> <value> --source agent
+gitmoot skillopt train init
+```
+
+If required fields are missing in non-interactive mode, `train init` exits before
+creating a scaffold or train session and prints the missing fields plus a fully
+flagged example command.
+
+Start from the scaffold, or pass the request, target repo, pinned template, and
+item plan directly:
+
+```sh
+gitmoot skillopt train start \
+  --config .gitmoot/skillopt/planner-train/config.toml \
+  --yes
+
 gitmoot skillopt train start \
   --template planner \
   --session planner-train \


### PR DESCRIPTION
## WHAT
Document the new `gitmoot skillopt train init` structured-I/O flow and the agent prompt controls that were implemented for issue #195.

## WHY
Task 6 of the train-init goal required docs/help coverage plus an end-to-end smoke so agents and humans can see how to initialize a scaffold without starting expensive training.

## CHANGES
- Added init-first guidance to `docs/skillopt-train-workflow.md`.
- Added README command references for `skillopt train init`, template JSON listing, interactive prompt answers, and config-driven `train start`.
- Clarified that init writes `.gitmoot/skillopt/<name>/config.toml`, `task.md`, and `review-items.yml`, then stops before model work.

## RESULTS
- PASS: built temporary binary with `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go build -o /tmp/gitmoot-task6-smoke ./cmd/gitmoot`.
- PASS: disposable smoke installed `planner`, listed `skillopt train init templates --json`, created `.gitmoot/skillopt/smoke-train`, inspected generated `config.toml`/`task.md`/`review-items.yml`, and ran `skillopt train start --config ... --dry-run` successfully.
- PASS: non-interactive missing-field init exited with code 2 and left the temp home/workspace empty.
- PASS: `GOTOOLCHAIN=local /tmp/go1.26.4/bin/go test ./internal/skillopt ./internal/db ./internal/cli -run 'TrainInit|Interactive' -v`.
- PASS: `git diff --check`.
- BLOCKED: `codex exec review --uncommitted`, `codex-face exec review --uncommitted`, and `codex-crazyj exec review --uncommitted` all failed before review due Codex usage limits.

## RAW REVIEW OUTPUT
```text
codex exec review --uncommitted
ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jun 14th, 2026 1:53 PM.
Review was interrupted. Please re-run /review and wait for it to complete.

codex-face exec review --uncommitted
ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jun 14th, 2026 1:53 PM.
Review was interrupted. Please re-run /review and wait for it to complete.

codex-crazyj exec review --uncommitted
ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jun 11th, 2026 2:44 PM.
Review was interrupted. Please re-run /review and wait for it to complete.
```

## RISK
Docs-only change. The only residual risk is that the required model review was unavailable due quota; focused tests and live CLI smoke passed.
