### PR TITLE
cli: fix train start, repo add, and optimizer handoff follow-ups (#195)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ gitmoot skillopt train init templates --json
 gitmoot interactive list --state pending --json
 gitmoot interactive show <prompt-id> --json
 gitmoot interactive answer <prompt-id> <value> --source agent
-gitmoot skillopt train start --config .gitmoot/skillopt/<name>/config.toml --yes
+gitmoot skillopt train start --config .gitmoot/skillopt/<name>/config.toml --workspace-repo <owner/repo> --yes
 gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>
 gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]
 gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id> --mode explore --options 4

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -471,7 +471,7 @@ Complete local review path:
 
 Complete train-mode path:
 
-1. `gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file items.yml --yes`
+1. `gitmoot skillopt train start --template <id> --repo owner/repo --workspace-repo owner/workspace --request <text> --items-file items.yml --yes` (`--workspace-repo` is required; without it the session stays at `request_confirmed` and cannot reach option generation)
 2. `gitmoot skillopt train status --session <session-id> --json --verbose` or `--watch` to inspect `status_phase`, item progress, active locks with owner and heartbeat, review issue, candidate, recovery availability, no-candidate reason, and next action. `status_phase` is the stable automation field; it can pass through normal train states such as `items_ready` and can also report optimizer/blocker phases such as `preflight_running`, `optimizer_running`, `optimizer_heartbeat_stale`, `optimizer_completed_candidate`, `optimizer_completed_no_candidate`, `recovery_available`, `blocked_config`, `blocked_stale_lock`, or `failed_unrecoverable`.
 3. `gitmoot skillopt train continue --session <session-id>` to generate options and publish the review packet.
 4. Human feedback is imported from raw or fenced YAML comments; `train continue` auto-syncs GitHub comments when the review is published and feedback is missing.

--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -78,6 +78,7 @@ item plan directly:
 ```sh
 gitmoot skillopt train start \
   --config .gitmoot/skillopt/planner-train/config.toml \
+  --workspace-repo owner/product-workspace \
   --yes
 
 gitmoot skillopt train start \
@@ -356,9 +357,13 @@ deterministic and stores imported events as canonical feedback for export.
 After feedback sync, `train continue` exports the training package, invokes the
 configured `gitmoot-skillopt optimize` command, imports the returned candidate
 package through the shared candidate validator, and leaves the candidate
-pending. Use `--dry-run` only on a disposable or reset train session to validate
-the package and optimizer command shape without model calls. If the dry-run
-returns unchanged baseline content, Gitmoot records
+pending. Because the optimizer launches long-lived model calls, `train continue`
+announces the launch before starting it. To export the training package and stop
+before that launch, pass `--export-only`; the session lands at
+`training_package_created` and a later `train continue` (without `--export-only`)
+runs the optimizer. Use `--dry-run` only on a disposable or reset train session
+to validate the package and optimizer command shape without model calls. If the
+dry-run returns unchanged baseline content, Gitmoot records
 `optimizer_completed_no_candidate` instead of publishing a candidate review.
 
 ```sh

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -85,7 +85,7 @@ func runInteractiveShow(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	jsonOutput := fs.Bool("json", false, "write prompt as JSON")
-	parsedArgs, err := reorderInteractiveFlags(args, map[string]struct{}{"home": {}}, map[string]struct{}{"json": {}})
+	parsedArgs, err := reorderFlagArgs(args, map[string]struct{}{"home": {}}, map[string]struct{}{"json": {}})
 	if err != nil {
 		fmt.Fprintf(stderr, "interactive show: %v\n", err)
 		return 2
@@ -125,7 +125,7 @@ func runInteractiveAnswer(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	source := fs.String("source", "cli", "answer source")
-	parsedArgs, err := reorderInteractiveFlags(args, map[string]struct{}{"home": {}, "source": {}}, nil)
+	parsedArgs, err := reorderFlagArgs(args, map[string]struct{}{"home": {}, "source": {}}, nil)
 	if err != nil {
 		fmt.Fprintf(stderr, "interactive answer: %v\n", err)
 		return 2
@@ -165,7 +165,11 @@ func normalizeInteractivePromptState(state string) (string, error) {
 	}
 }
 
-func reorderInteractiveFlags(args []string, stringFlags map[string]struct{}, boolFlags map[string]struct{}) ([]string, error) {
+// reorderFlagArgs moves recognized flags ahead of positional arguments so the
+// standard library flag parser, which stops at the first positional, accepts
+// flags written before or after the positionals. stringFlags are flags that
+// consume a following value when not given inline; boolFlags stand alone.
+func reorderFlagArgs(args []string, stringFlags map[string]struct{}, boolFlags map[string]struct{}) ([]string, error) {
 	flags := []string{}
 	positionals := []string{}
 	for index := 0; index < len(args); index++ {
@@ -178,7 +182,7 @@ func reorderInteractiveFlags(args []string, stringFlags map[string]struct{}, boo
 			positionals = append(positionals, arg)
 			continue
 		}
-		name, hasInlineValue := splitInteractiveFlagName(arg)
+		name, hasInlineValue := splitFlagName(arg)
 		if _, ok := boolFlags[name]; ok {
 			flags = append(flags, arg)
 			continue
@@ -199,7 +203,7 @@ func reorderInteractiveFlags(args []string, stringFlags map[string]struct{}, boo
 	return append(flags, positionals...), nil
 }
 
-func splitInteractiveFlagName(arg string) (string, bool) {
+func splitFlagName(arg string) (string, bool) {
 	arg = strings.TrimLeft(arg, "-")
 	name, value, hasInlineValue := strings.Cut(arg, "=")
 	_ = value

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -39,12 +39,38 @@ func runRepo(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
+// parseRepoPositional reorders args so the owner/repo positional may appear
+// before or after flags, parses them into fs, and returns the single
+// positional. The returned code is -1 when parsing succeeded (use repoArg) or a
+// process exit code the caller should return immediately (0 for --help, 2 for a
+// parse or arity error). stringFlags lists fs flags that consume a value.
+func parseRepoPositional(fs *flag.FlagSet, command string, args []string, stringFlags map[string]struct{}, stderr io.Writer) (string, int) {
+	parsedArgs, err := reorderFlagArgs(args, stringFlags, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", command, err)
+		return "", 2
+	}
+	if err := fs.Parse(parsedArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return "", 0
+		}
+		return "", 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintf(stderr, "%s requires exactly one owner/repo\n", command)
+		return "", 2
+	}
+	return fs.Arg(0), -1
+}
+
 func printRepoUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot repo add owner/repo --path <path> [--poll 30s]")
 	fmt.Fprintln(w, "  gitmoot repo list")
 	fmt.Fprintln(w, "  gitmoot repo remove owner/repo")
 	fmt.Fprintln(w, "  gitmoot repo doctor owner/repo")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "owner/repo may be given before or after the flags.")
 }
 
 func runRepoAdd(args []string, stdout, stderr io.Writer) int {
@@ -61,16 +87,9 @@ func runRepoAdd(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 	}
-	repoArg := args[0]
-	if err := fs.Parse(args[1:]); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
-			return 0
-		}
-		return 2
-	}
-	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "repo add requires exactly one owner/repo")
-		return 2
+	repoArg, code := parseRepoPositional(fs, "repo add", args, map[string]struct{}{"home": {}, "path": {}, "poll": {}}, stderr)
+	if code >= 0 {
+		return code
 	}
 	if *poll <= 0 {
 		fmt.Fprintln(stderr, "poll interval must be positive")
@@ -142,16 +161,9 @@ func runRepoRemove(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 	}
-	repoArg := args[0]
-	if err := fs.Parse(args[1:]); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
-			return 0
-		}
-		return 2
-	}
-	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "repo remove requires exactly one owner/repo")
-		return 2
+	repoArg, code := parseRepoPositional(fs, "repo remove", args, map[string]struct{}{"home": {}}, stderr)
+	if code >= 0 {
+		return code
 	}
 	repo, err := daemon.ParseRepository(repoArg)
 	if err != nil {
@@ -187,16 +199,9 @@ func runRepoDoctor(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 	}
-	repoArg := args[0]
-	if err := fs.Parse(args[1:]); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
-			return 0
-		}
-		return 2
-	}
-	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "repo doctor requires exactly one owner/repo")
-		return 2
+	repoArg, code := parseRepoPositional(fs, "repo doctor", args, map[string]struct{}{"home": {}}, stderr)
+	if code >= 0 {
+		return code
 	}
 	repo, err := daemon.ParseRepository(repoArg)
 	if err != nil {

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -58,6 +58,50 @@ func TestRunRepoAddListDoctorRemove(t *testing.T) {
 	}
 }
 
+func TestRunRepoAddAcceptsFlagsBeforeOrAfterPositional(t *testing.T) {
+	cases := []struct {
+		name string
+		args func(home, repoDir string) []string
+	}{
+		{
+			name: "flags after positional",
+			args: func(home, repoDir string) []string {
+				return []string{"repo", "add", "jerryfane/gitmoot", "--home", home, "--path", repoDir}
+			},
+		},
+		{
+			name: "flags before positional",
+			args: func(home, repoDir string) []string {
+				return []string{"repo", "add", "--home", home, "--path", repoDir, "jerryfane/gitmoot"}
+			},
+		},
+		{
+			name: "positional between flags",
+			args: func(home, repoDir string) []string {
+				return []string{"repo", "add", "--home", home, "jerryfane/gitmoot", "--path", repoDir}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			repoDir := t.TempDir()
+			runGit(t, repoDir, "init")
+			runGit(t, repoDir, "branch", "-m", "main")
+			runGit(t, repoDir, "remote", "add", "origin", "https://github.com/jerryfane/gitmoot.git")
+
+			var stdout, stderr bytes.Buffer
+			code := Run(tc.args(home, repoDir), &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("repo add exit code = %d, stderr=%s", code, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "registered jerryfane/gitmoot") {
+				t.Fatalf("repo add output = %q", stdout.String())
+			}
+		})
+	}
+}
+
 func TestRunRepoAddRejectsWrongOrigin(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -93,7 +93,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt train start --config .gitmoot/skillopt/<name>/config.toml [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--export-only] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
@@ -130,7 +130,7 @@ func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt train start --config .gitmoot/skillopt/<name>/config.toml [--session <id>] [--items-file path] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --template <id> --repo owner/repo --request <text> --items-file path [--session <id>] [--workspace-repo owner/repo] [--preview-repo owner/repo] [--preview-mode none|optional|required] [--preview-renderer none|vue-vite] [--preview-publisher none|github-pages] [--preview-route-template template] [--request-file path] [--task-kind kind] [--mode explore|refine|distill|validate] [--exploration-level high|medium|low] [--options N] [--min-items N] [--preferred-gate hard|soft|hard_then_soft] [--dry-run] [--yes]")
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
-	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--promote version|--reject version --reason text] [--start-next]")
+	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--export-only] [--promote version|--reject version --reason text] [--start-next]")
 	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
@@ -291,7 +291,7 @@ func runSkillOptTrainInitCreate(args []string, stdout, stderr io.Writer) int {
 	writeLine(stdout, "created train init scaffold %s", relativeOrAbsolutePath(cwd, paths.Root))
 	writeLine(stdout, "config: %s", relativeOrAbsolutePath(cwd, paths.ConfigPath))
 	writeLine(stdout, "task: %s", relativeOrAbsolutePath(cwd, paths.TaskPath))
-	writeLine(stdout, "next: gitmoot skillopt train start --config %s", filepath.ToSlash(filepath.Join(".gitmoot", skillopt.TrainInitScaffoldDirName, values.Name, skillopt.TrainInitConfigFileName)))
+	writeLine(stdout, "next: gitmoot skillopt train start --config %s --workspace-repo <owner/repo>", filepath.ToSlash(filepath.Join(".gitmoot", skillopt.TrainInitScaffoldDirName, values.Name, skillopt.TrainInitConfigFileName)))
 	return 0
 }
 
@@ -770,6 +770,10 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 	workspaceRepo, err := parseOptionalSkillOptTrainRepo("workspace-repo", *workspaceRepoFlag)
 	if err != nil {
 		fmt.Fprintf(stderr, "skillopt train start: %v\n", err)
+		return 2
+	}
+	if workspaceRepo == "" {
+		fmt.Fprintln(stderr, "skillopt train start requires --workspace-repo owner/repo; without it the session stays at request_confirmed and train continue cannot reach option generation")
 		return 2
 	}
 	previewRepo, err := parseOptionalSkillOptTrainRepo("preview-repo", *previewRepoFlag)
@@ -1446,6 +1450,7 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	timeout := fs.String("timeout", "", "optimizer timeout duration")
 	dryRun := fs.Bool("dry-run", false, "ask gitmoot-skillopt to avoid model calls while still producing a candidate package")
 	rerunOptimizer := fs.Bool("rerun-optimizer", false, "rerun gitmoot-skillopt after optimizer completion instead of retrying the existing candidate import")
+	exportOnly := fs.Bool("export-only", false, "export the training package and stop before launching the optimizer")
 	promote := fs.String("promote", "", "candidate version to promote after candidate review")
 	reject := fs.String("reject", "", "candidate version to reject after candidate review")
 	reason := fs.String("reason", "", "decision reason required with --reject")
@@ -1467,6 +1472,14 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 	if strings.TrimSpace(*sessionID) == "" {
 		fmt.Fprintln(stderr, "skillopt train continue requires --session")
 		return 2
+	}
+	if *exportOnly {
+		for _, conflicting := range []string{"rerun-optimizer", "dry-run", "promote", "reject", "start-next"} {
+			if setFlags[conflicting] {
+				fmt.Fprintf(stderr, "skillopt train continue: --export-only cannot be combined with --%s\n", conflicting)
+				return 2
+			}
+		}
 	}
 	if *numEpochs < 0 {
 		fmt.Fprintln(stderr, "skillopt train continue: --num-epochs must be zero or greater")
@@ -1563,7 +1576,9 @@ func runSkillOptTrainContinue(args []string, stdout, stderr io.Writer) int {
 				Timeout:                      *timeout,
 				DryRun:                       *dryRun,
 				RerunOptimizer:               *rerunOptimizer,
+				ExportOnly:                   *exportOnly,
 			},
+			Progress:         stderr,
 			PromoteCandidate: *promote,
 			RejectCandidate:  *reject,
 			DecisionReason:   *reason,
@@ -1625,6 +1640,10 @@ type skillOptTrainContinueRequest struct {
 	RejectCandidate   string
 	DecisionReason    string
 	StartNext         bool
+	// Progress receives human-facing notices emitted while a continue step runs,
+	// such as announcing a long-lived optimizer launch. It is nil for automated
+	// callers (the review watcher) that have no attached terminal.
+	Progress io.Writer
 }
 
 type skillOptTrainOptimizerRequest struct {
@@ -1663,6 +1682,7 @@ type skillOptTrainOptimizerRequest struct {
 	Timeout                      string
 	DryRun                       bool
 	RerunOptimizer               bool
+	ExportOnly                   bool
 	OptimizerLockState           string
 }
 
@@ -1966,7 +1986,7 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 			output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
 			return output, nil
 		}
-		result, err := continueSkillOptTrainOptimizer(ctx, paths, store, session, *iteration, request.Optimizer)
+		result, err := continueSkillOptTrainOptimizer(ctx, paths, store, session, *iteration, request.Optimizer, request.Progress)
 		if err != nil {
 			if skillOptTrainOptimizerResultHasReport(result) {
 				output.Lines = skillOptTrainOptimizerReportLines(result)
@@ -1979,6 +1999,18 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 		}
 		updatedSummary := skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
 		lines := skillOptTrainOptimizerReportLines(result)
+		if result.ExportedOnly {
+			lines = append(lines,
+				fmt.Sprintf("training_package: %s", result.TrainingPackagePath),
+				"next: run train continue without --export-only to launch the optimizer",
+			)
+			return skillOptTrainContinueOutput{
+				Summary:       updatedSummary,
+				Counts:        updatedCounts,
+				ContinueReady: true,
+				Lines:         lines,
+			}, nil
+		}
 		if result.NoCandidateReason != "" {
 			lines = append(lines,
 				fmt.Sprintf("no_candidate_reason: %s", result.NoCandidateReason),
@@ -2194,6 +2226,7 @@ type skillOptTrainOptimizerResult struct {
 	CandidateVersionID    string
 	NoCandidateReason     string
 	NoCandidateNextAction string
+	ExportedOnly          bool
 }
 
 type skillOptTrainRecoverResult struct {
@@ -3918,7 +3951,7 @@ func skillOptTrainNextIterationMode(previousMode string, recommendedMode string)
 	}
 }
 
-func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest) (skillOptTrainOptimizerResult, error) {
+func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest, progress io.Writer) (skillOptTrainOptimizerResult, error) {
 	if strings.TrimSpace(iteration.EvalRunID) == "" {
 		return skillOptTrainOptimizerResult{}, fmt.Errorf("train iteration %s has no eval run id", iteration.ID)
 	}
@@ -3970,6 +4003,15 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		}
 		state = skillopt.TrainStateTrainingPackageCreated
 	}
+	if request.ExportOnly && state == skillopt.TrainStateTrainingPackageCreated {
+		// The training package now exists (exported above or already created)
+		// and the optimizer has not run yet. Stop here so the caller can inspect
+		// it before paying for a real optimizer run. For later states (the
+		// optimizer already ran) export-only is a no-op and the normal
+		// candidate-import path below proceeds.
+		result.ExportedOnly = true
+		return result, nil
+	}
 	if state == skillopt.TrainStateTrainingPackageCreated {
 		if !rerunFromCompletedOptimizer {
 			if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateOptimizerCompleted); err != nil {
@@ -4007,6 +4049,7 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		}
 		result.Command = command
 		result.Args = args
+		announceSkillOptTrainOptimizerLaunch(progress, request)
 		runResult, err := runSkillOptTrainOptimizer(ctx, optimizerPaths, request, command, args)
 		result.RecoveryAvailable = skillOptTrainOptimizerRecoveryAvailable(optimizerPaths)
 		if err != nil {
@@ -8103,6 +8146,22 @@ func skillOptTrainOptimizerGate(iteration db.SkillOptTrainIteration, request ski
 	default:
 		return "", fmt.Errorf("optimizer gate %q is not supported; use hard, soft, or mixed", gate)
 	}
+}
+
+// announceSkillOptTrainOptimizerLaunch notifies the operator that a long-lived
+// optimizer run is about to start, since the run blocks with no streamed output
+// until it completes. It is a notice only and never blocks for confirmation, so
+// automated continue flows are unaffected. progress is nil for callers without a
+// terminal.
+func announceSkillOptTrainOptimizerLaunch(progress io.Writer, request skillOptTrainOptimizerRequest) {
+	if progress == nil {
+		return
+	}
+	if request.DryRun {
+		fmt.Fprintln(progress, "skillopt train continue: launching optimizer dry run; this skips model calls but may still take a while")
+		return
+	}
+	fmt.Fprintln(progress, "skillopt train continue: launching optimizer; this runs long-lived model calls and will not stream output until it finishes")
 }
 
 func runSkillOptTrainOptimizer(ctx context.Context, paths skillOptTrainOptimizerPaths, request skillOptTrainOptimizerRequest, command string, args []string) (subprocess.Result, error) {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -396,6 +396,59 @@ func TestSkillOptExportIncludesRankedFields(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainStartRequiresWorkspaceRepo(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	itemsPath := filepath.Join(t.TempDir(), "items.yml")
+	if err := os.WriteFile(itemsPath, []byte(`items:
+  - item_id: hero
+    title: Hero
+    brief: Design a hero section.
+  - item_id: proof
+    title: Proof
+    brief: Design a social proof section.
+`), 0o644); err != nil {
+		t.Fatalf("write items file: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--request", "Train landing page plans.",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("train start without workspace-repo exit code = %d, want 2; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "requires --workspace-repo") {
+		t.Fatalf("missing workspace-repo error = %q", stderr.String())
+	}
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open after failed start returned error: %v", err)
+	}
+	defer store.Close()
+	if _, err := store.GetSkillOptTrainSession(context.Background(), "owner-product"); err == nil {
+		t.Fatalf("failed start created a train session")
+	}
+}
+
 func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)
@@ -491,6 +544,7 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 		"--home", home,
 		"--template", "planner",
 		"--repo", "owner/product",
+		"--workspace-repo", "owner/workspace",
 		"--request", "Train landing page plans.",
 		"--options", "1",
 	}, &stdout, &stderr)
@@ -508,6 +562,7 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 		"--home", home,
 		"--template", "planner",
 		"--repo", "owner/product",
+		"--workspace-repo", "owner/workspace",
 		"--request", "Train landing page plans.",
 		"--items-file", itemsPath,
 		"--preview-mode", "required",
@@ -529,6 +584,7 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 		"--template", "planner",
 		"--repo", "owner/product",
 		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
 		"--request", "Train landing page plans.",
 		"--items-file", itemsPath,
 	}, &stdout, &stderr)
@@ -622,6 +678,7 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	stderr.Reset()
 	code = Run([]string{
 		"skillopt", "train", "start",
+		"--workspace-repo", "owner/workspace",
 		"--home", home,
 		"--template", "planner",
 		"--repo", "owner/product",
@@ -696,6 +753,7 @@ func TestSkillOptTrainStartStatusAndStop(t *testing.T) {
 	stderr.Reset()
 	code = Run([]string{
 		"skillopt", "train", "start",
+		"--workspace-repo", "owner/workspace",
 		"--home", home,
 		"--template", "planner",
 		"--repo", "owner/product",
@@ -1389,6 +1447,7 @@ func TestSkillOptTrainStartLoadsInitConfig(t *testing.T) {
 	stderr.Reset()
 	code = Run([]string{
 		"skillopt", "train", "start",
+		"--workspace-repo", "owner/workspace",
 		"--home", home,
 		"--config", filepath.Join(scaffoldDir, "config.toml"),
 		"--session", "config-start-session",
@@ -1463,6 +1522,7 @@ func TestSkillOptTrainStartConfigPreviewModeOverrideDisablesVue(t *testing.T) {
 	stderr.Reset()
 	code = Run([]string{
 		"skillopt", "train", "start",
+		"--workspace-repo", "owner/workspace",
 		"--home", home,
 		"--config", filepath.Join(scaffoldDir, "config.toml"),
 		"--preview-mode", "none",
@@ -1516,6 +1576,7 @@ func TestSkillOptTrainStartConfigPreviewFlagsOverrideNone(t *testing.T) {
 	stderr.Reset()
 	code = Run([]string{
 		"skillopt", "train", "start",
+		"--workspace-repo", "owner/workspace",
 		"--home", home,
 		"--config", filepath.Join(scaffoldDir, "config.toml"),
 		"--preview-repo", "jerryfane/gitmoot-previews",
@@ -1601,6 +1662,7 @@ func TestSkillOptTrainStartConfigRepoOverrideDrivesVuePreviewRepo(t *testing.T) 
 	stderr.Reset()
 	code = Run([]string{
 		"skillopt", "train", "start",
+		"--workspace-repo", "owner/workspace",
 		"--home", home,
 		"--config", filepath.Join(scaffoldDir, "config.toml"),
 		"--repo", "jerryfane/gitmoot",
@@ -3797,6 +3859,9 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("train continue optimizer exit code = %d, stderr=%s", code, stderr.String())
 	}
+	if !strings.Contains(stderr.String(), "launching optimizer dry run") {
+		t.Fatalf("missing optimizer launch announcement: %q", stderr.String())
+	}
 	attemptRoot := filepath.Join(outRoot, "attempts", "attempt-001")
 	for _, want := range []string{
 		"current_phase: candidate_created",
@@ -3886,6 +3951,71 @@ func TestSkillOptTrainContinueRunsOptimizerAndImportsCandidate(t *testing.T) {
 	}
 	if version.State != "pending" {
 		t.Fatalf("candidate version = %+v", version)
+	}
+}
+
+func TestSkillOptTrainContinueExportOnlyStopsBeforeOptimizer(t *testing.T) {
+	home, _ := seedSkillOptTrainFeedbackSynced(t)
+	outRoot := filepath.Join(t.TempDir(), "optimizer")
+	runner := &skillOptTrainFakeOptimizerRunner{}
+	previousRunner := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = runner
+	defer func() {
+		skillOptTrainOptimizerRunner = previousRunner
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--out-root", outRoot,
+		"--export-only",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("export-only continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("optimizer ran during export-only: %+v", runner.calls)
+	}
+	if strings.Contains(stderr.String(), "launching optimizer") {
+		t.Fatalf("export-only should not announce an optimizer launch: %q", stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: training_package_created",
+		"training_package: ",
+		"next: run train continue without --export-only to launch the optimizer",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("export-only stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateTrainingPackageCreated {
+		t.Fatalf("iteration state = %q, want training_package_created", iteration.State)
+	}
+}
+
+func TestSkillOptTrainContinueExportOnlyRejectsConflicts(t *testing.T) {
+	home, _ := seedSkillOptTrainFeedbackSynced(t)
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"skillopt", "train", "continue",
+		"--home", home,
+		"--session", "optimizer-train",
+		"--export-only",
+		"--rerun-optimizer",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("export-only with rerun-optimizer exit code = %d, want 2; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--export-only cannot be combined with --rerun-optimizer") {
+		t.Fatalf("conflict stderr = %q", stderr.String())
 	}
 }
 
@@ -4020,7 +4150,7 @@ func TestSkillOptTrainRerunFromPackageCreatedExportsFreshPackage(t *testing.T) {
 		RerunOptimizer: true,
 		EvaluatorID:    "landing_page_v1",
 		EvaluatorModel: "rerun-evaluator",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("continueSkillOptTrainOptimizer rerun returned error: %v", err)
 	}
@@ -7711,6 +7841,7 @@ func TestSkillOptTrainStartDryRunDoesNotInitializeFreshHome(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{
 		"skillopt", "train", "start",
+		"--workspace-repo", "owner/workspace",
 		"--home", home,
 		"--template", "planner",
 		"--repo", "owner/product",
@@ -7757,6 +7888,7 @@ func TestSkillOptTrainStartRejectsTooFewItemsAndWarnsOnHomogeneousItems(t *testi
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{
 		"skillopt", "train", "start",
+		"--workspace-repo", "owner/workspace",
 		"--home", home,
 		"--template", "designer",
 		"--repo", "owner/product",
@@ -7789,6 +7921,7 @@ func TestSkillOptTrainStartRejectsTooFewItemsAndWarnsOnHomogeneousItems(t *testi
 	stderr.Reset()
 	code = Run([]string{
 		"skillopt", "train", "start",
+		"--workspace-repo", "owner/workspace",
 		"--home", home,
 		"--template", "designer",
 		"--repo", "owner/product",


### PR DESCRIPTION
## WHAT
Task 1 of the SkillOpt train-init UI goal (#196): fix the three train-flow follow-ups recorded on #195 from the 2026-06-09 end-to-end train test, so later UI work builds on corrected behavior.

## WHY
The E2E test surfaced three issues:
1. `train start` without `--workspace-repo` silently stalls at `request_confirmed` (no forward path, no error).
2. `repo add` rejected flags-before-positional despite its `--help` showing that order — an agent followed the help and failed repeatedly.
3. The first `train continue` after feedback sync immediately launched the real (long, expensive) optimizer with no way to export-and-inspect first and no announcement.

## CHANGES
- **`repo add`/`remove`/`doctor`**: accept `owner/repo` before or after flags via a new `parseRepoPositional` helper built on the generalized `reorderFlagArgs`/`splitFlagName` (renamed from the interactive-specific names; both interactive call sites updated). Usage text documents the relaxed order.
- **`train start`**: fail fast with an actionable error when `--workspace-repo` is empty. `train init`'s printed next-step and the README/workflow/contract docs now include `--workspace-repo`.
- **`train continue`**: new `--export-only` exports the training package and stops before the optimizer (gated to the pre-optimizer `training_package_created` state so it never skips candidate import at later states); rejected in combination with `--rerun-optimizer`/`--dry-run`/`--promote`/`--reject`/`--start-next`. A progress notice announces the optimizer launch before the blocking run (threaded via a nil-safe `progress` writer; the automated review-watcher passes nil).

Out of scope (per goal): prompt-id `-`/`_` normalization and `train status --session` defaulting.

## RESULTS
- `GOTOOLCHAIN=go1.26.0 go build ./...` — clean; `gofmt`/`go vet` clean.
- New tests: `TestRunRepoAddAcceptsFlagsBeforeOrAfterPositional` (3 orders), `TestSkillOptTrainStartRequiresWorkspaceRepo`, `TestSkillOptTrainContinueExportOnlyStopsBeforeOptimizer`, `TestSkillOptTrainContinueExportOnlyRejectsConflicts`, plus an optimizer-launch announcement assertion. Existing `train start` tests updated to pass `--workspace-repo`.
- `go test ./internal/cli ./internal/skillopt` — all pass **except** `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos`, a pre-existing daemon concurrency-test failure that also fails on clean `main` (unrelated to this change; touches no daemon/worker code).

## RISK
Low–medium. `train start` now requires `--workspace-repo` (a deliberate behavior change, including for `--dry-run`/`--config`); all in-repo invocations, the init next-step, README, and docs were updated to match. The reorder helper rename is mechanical with no remaining references to the old names.

## /code-review
High-effort `/code-review` run; two real findings, both fixed in this branch:
1. `--export-only` early return short-circuited even at post-optimizer states, skipping candidate import with a misleading message → gated on `training_package_created`.
2. `train init`'s printed `train start --config` next-step (and the README example) omitted `--workspace-repo` and would fail the new check → both updated to include it.
Remaining finder candidates were a pre-existing `interactive answer` dash-value limitation (not introduced here; repo positionals never start with `-`) and a benign export-only no-op at candidate-decision phases — neither warranted a change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)