### PR TITLE
skillopt: add line-oriented train init wizard (#196)

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -58,19 +58,26 @@ List machine-readable template choices for agents before initializing:
 gitmoot skillopt train init templates --json
 ```
 
-If required fields are missing in an interactive terminal, Gitmoot stores
-structured prompt requests that agents can inspect and answer:
+If required fields are missing in an interactive terminal, `train init` runs a
+line-oriented wizard that asks for them one at a time (numbered choices for the
+template, with a "Custom file" option, and for the preview style).
+
+For agents that prefer answering asynchronously, pass `--prompts` to store
+structured prompt requests instead of running the wizard, then inspect and
+answer them and rerun:
 
 ```sh
+gitmoot skillopt train init --prompts
 gitmoot interactive list --state pending --json
 gitmoot interactive show <prompt-id> --json
 gitmoot interactive answer <prompt-id> <value> --source agent
 gitmoot skillopt train init
 ```
 
-If required fields are missing in non-interactive mode, `train init` exits before
-creating a scaffold or train session and prints the missing fields plus a fully
-flagged example command.
+If required fields are missing in non-interactive mode (and `--prompts` is not
+set), `train init` exits before creating a scaffold or train session and prints
+the missing fields plus a fully flagged example command. Pass `--yes` to force
+that fail-fast behavior even on an interactive terminal.
 
 Start from the scaffold, or pass the request, target repo, pinned template, and
 item plan directly:

--- a/internal/cli/agent_template_test.go
+++ b/internal/cli/agent_template_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -773,6 +774,16 @@ func replaceSkillOptTrainInitInteractive(interactive bool) func() {
 	return func() {
 		active = false
 		skillOptTrainInitInteractive = previous
+	}
+}
+
+func replaceSkillOptTrainInitStdin(input string) func() {
+	previous := skillOptTrainInitStdin
+	skillOptTrainInitStdin = func() io.Reader {
+		return strings.NewReader(input)
+	}
+	return func() {
+		skillOptTrainInitStdin = previous
 	}
 }
 

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -46,6 +47,10 @@ var skillOptTrainInitInteractive = func() bool {
 	info, err := os.Stdin.Stat()
 	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
+
+// skillOptTrainInitStdin is the reader the interactive train-init wizard reads
+// answers from. It is a function so tests can substitute a scripted stdin.
+var skillOptTrainInitStdin = func() io.Reader { return os.Stdin }
 
 func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
@@ -150,6 +155,10 @@ func printSkillOptTrainInitUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt train init --name <name> --template <id> --review-repo owner/repo --artifact-kind kind --preview kind (--request text|--request-file path) [--task-kind kind] [--mode explore|refine|distill|validate]")
 	fmt.Fprintln(w, "  gitmoot skillopt train init templates --json")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "With missing fields, an interactive terminal runs a line-oriented wizard.")
+	fmt.Fprintln(w, "Use --prompts to emit interactive prompt records instead (answer them with")
+	fmt.Fprintln(w, "gitmoot interactive answer, then rerun), or --yes to fail on missing fields.")
 }
 
 func runSkillOptTrainInitCreate(args []string, stdout, stderr io.Writer) int {
@@ -165,7 +174,8 @@ func runSkillOptTrainInitCreate(args []string, stdout, stderr io.Writer) int {
 	mode := fs.String("mode", db.EvalRunModeExplore, "train mode: explore, refine, distill, or validate")
 	requestText := fs.String("request", "", "human training request for task.md")
 	requestFile := fs.String("request-file", "", "file containing the human training request")
-	yes := fs.Bool("yes", false, "do not create interactive prompts for missing fields")
+	yes := fs.Bool("yes", false, "do not prompt for missing fields; fail if any are missing")
+	prompts := fs.Bool("prompts", false, "emit interactive prompt records for missing fields instead of running the inline wizard")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -211,18 +221,34 @@ func runSkillOptTrainInitCreate(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if missing := missingSkillOptTrainInitInputs(values); len(missing) > 0 {
-		if !*yes && skillOptTrainInitInteractive() {
-			prompts, err := createSkillOptTrainInitPrompts(*home, promptScope, values, missing)
+		switch {
+		case *yes:
+			fmt.Fprintf(stderr, "skillopt train init missing required fields: %s\n", strings.Join(missing, ", "))
+			fmt.Fprintf(stderr, "example: %s\n", skillOptTrainInitExampleCommand(values.Name))
+			return 2
+		case *prompts:
+			created, err := createSkillOptTrainInitPrompts(*home, promptScope, values, missing)
 			if err != nil {
 				fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
 				return 1
 			}
-			printSkillOptTrainInitPromptInstructions(stdout, *home, rerunCommand, prompts)
+			printSkillOptTrainInitPromptInstructions(stdout, *home, rerunCommand, created)
 			return 0
+		case skillOptTrainInitInteractive():
+			if err := runSkillOptTrainInitWizard(*home, skillOptTrainInitStdin(), stdout, &values, missing); err != nil {
+				fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
+				return 1
+			}
+			if stillMissing := missingSkillOptTrainInitInputs(values); len(stillMissing) > 0 {
+				fmt.Fprintf(stderr, "skillopt train init missing required fields: %s\n", strings.Join(stillMissing, ", "))
+				fmt.Fprintf(stderr, "example: %s\n", skillOptTrainInitExampleCommand(values.Name))
+				return 2
+			}
+		default:
+			fmt.Fprintf(stderr, "skillopt train init missing required fields: %s\n", strings.Join(missing, ", "))
+			fmt.Fprintf(stderr, "example: %s\n", skillOptTrainInitExampleCommand(values.Name))
+			return 2
 		}
-		fmt.Fprintf(stderr, "skillopt train init missing required fields: %s\n", strings.Join(missing, ", "))
-		fmt.Fprintf(stderr, "example: %s\n", skillOptTrainInitExampleCommand(values.Name))
-		return 2
 	}
 	if err := skillopt.ValidateTrainInitName(values.Name); err != nil {
 		clearSkillOptTrainInitPromptAnswerOnError(*home, promptScope, appliedPromptFields, "name")
@@ -520,6 +546,171 @@ func createSkillOptTrainInitPrompts(home string, scope string, values skillOptTr
 		return nil, err
 	}
 	return created, nil
+}
+
+// runSkillOptTrainInitWizard fills the missing train-init fields by asking the
+// human one question at a time on stdout and reading answers from stdin. It
+// uses numbered choices for template/preview/task-kind/mode (the template list
+// includes a "Custom file" option) and free text for the remaining fields.
+// Semantic validation of the answers happens in the caller after the wizard
+// returns.
+func runSkillOptTrainInitWizard(home string, stdin io.Reader, stdout io.Writer, values *skillOptTrainInitInputs, missing []string) error {
+	reader := bufio.NewReader(stdin)
+	missingSet := make(map[string]struct{}, len(missing))
+	for _, field := range missing {
+		missingSet[field] = struct{}{}
+	}
+	// task_kind and mode are defaulted before missing-field detection, so they
+	// never reach the wizard; the remaining fields are asked in a stable order.
+	for _, field := range []string{"name", "template", "review_repo", "artifact_kind", "preview", "request"} {
+		if _, ok := missingSet[field]; !ok {
+			continue
+		}
+		switch field {
+		case "template":
+			value, err := skillOptTrainInitWizardTemplate(home, reader, stdout)
+			if err != nil {
+				return err
+			}
+			values.Template = value
+		case "preview":
+			values.Preview = skillOptTrainInitWizardChoice(reader, stdout, "Choose a preview style:", []string{"none", "text-table", "vue"}, "")
+		case "name":
+			values.Name = skillOptTrainInitWizardText(reader, stdout, "Training name:")
+		case "review_repo":
+			values.ReviewRepo = skillOptTrainInitWizardText(reader, stdout, "Review repository (owner/repo):")
+		case "artifact_kind":
+			values.ArtifactKind = skillOptTrainInitWizardText(reader, stdout, "Artifact kind to optimize (text, vue, pdf, custom):")
+		case "request":
+			values.Request = skillOptTrainInitWizardText(reader, stdout, "Training request:")
+		}
+	}
+	return nil
+}
+
+// skillOptTrainInitWizardText prints question and returns the next non-empty
+// trimmed line. It re-asks on a blank line and returns "" at EOF.
+func skillOptTrainInitWizardText(reader *bufio.Reader, stdout io.Writer, question string) string {
+	for {
+		fmt.Fprintf(stdout, "%s ", question)
+		line, err := reader.ReadString('\n')
+		if value := strings.TrimSpace(line); value != "" {
+			return value
+		}
+		if err != nil {
+			return ""
+		}
+	}
+}
+
+// skillOptTrainInitWizardChoice prints numbered choices and returns the selected
+// value. It accepts a 1-based number or a literal choice value, falls back to
+// defaultChoice on a blank line, and re-asks on unrecognized input until EOF.
+func skillOptTrainInitWizardChoice(reader *bufio.Reader, stdout io.Writer, header string, choices []string, defaultChoice string) string {
+	for {
+		fmt.Fprintln(stdout, header)
+		for i, choice := range choices {
+			suffix := ""
+			if choice == defaultChoice {
+				suffix = " (default)"
+			}
+			fmt.Fprintf(stdout, "%d. %s%s\n", i+1, choice, suffix)
+		}
+		fmt.Fprint(stdout, "Enter number or value: ")
+		line, err := reader.ReadString('\n')
+		value := strings.TrimSpace(line)
+		if value == "" {
+			if defaultChoice != "" {
+				return defaultChoice
+			}
+			if err != nil {
+				return ""
+			}
+			continue
+		}
+		if n, convErr := strconv.Atoi(value); convErr == nil {
+			if n >= 1 && n <= len(choices) {
+				return choices[n-1]
+			}
+		} else {
+			for _, choice := range choices {
+				if strings.EqualFold(value, choice) {
+					return choice
+				}
+			}
+		}
+		if err != nil {
+			return value
+		}
+		fmt.Fprintf(stdout, "Please enter a number 1-%d or one of the listed values.\n", len(choices))
+	}
+}
+
+// skillOptTrainInitWizardTemplate lists the available templates as numbered
+// choices plus a trailing "Custom file" option and returns the chosen template
+// reference.
+func skillOptTrainInitWizardTemplate(home string, reader *bufio.Reader, stdout io.Writer) (string, error) {
+	var choices []skillopt.TrainInitTemplateChoice
+	if err := withStore(home, func(store *db.Store) error {
+		var err error
+		choices, err = skillopt.ListTrainInitTemplateChoices(context.Background(), store)
+		return err
+	}); err != nil {
+		return "", err
+	}
+	customIndex := len(choices) + 1
+	for {
+		fmt.Fprintln(stdout, "Choose a template:")
+		for i, choice := range choices {
+			fmt.Fprintf(stdout, "%d. %s\n", i+1, skillOptTrainInitTemplateChoiceLabel(choice))
+		}
+		fmt.Fprintf(stdout, "%d. Custom file\n", customIndex)
+		fmt.Fprint(stdout, "Enter number: ")
+		line, err := reader.ReadString('\n')
+		value := strings.TrimSpace(line)
+		if value == "" {
+			if err != nil {
+				return "", nil
+			}
+			continue
+		}
+		if n, convErr := strconv.Atoi(value); convErr == nil {
+			if n >= 1 && n <= len(choices) {
+				return choices[n-1].ID, nil
+			}
+			if n == customIndex {
+				return skillOptTrainInitWizardText(reader, stdout, "Enter a template id, version, or file path:"), nil
+			}
+		} else {
+			for _, choice := range choices {
+				if strings.EqualFold(value, choice.ID) {
+					return choice.ID, nil
+				}
+			}
+		}
+		if err != nil {
+			return value, nil
+		}
+		fmt.Fprintf(stdout, "Please enter a number 1-%d.\n", customIndex)
+	}
+}
+
+func skillOptTrainInitTemplateChoiceLabel(choice skillopt.TrainInitTemplateChoice) string {
+	label := choice.ID
+	if choice.CurrentVersion != "" {
+		label += " @" + choice.CurrentVersion
+	}
+	status := choice.Source
+	if !choice.Installed {
+		if status != "" {
+			status += ", "
+		}
+		status += "not installed"
+	}
+	if status != "" {
+		label += " (" + status + ")"
+	}
+	return label
 }
 
 func buildSkillOptTrainInitPrompt(scope string, field string, values skillOptTrainInitInputs) skillOptTrainInitPrompt {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"database/sql"
@@ -1055,7 +1056,7 @@ func TestSkillOptTrainInitCompletesFromPromptAnswers(t *testing.T) {
 	defer restoreInteractive()
 
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "init", "--prompts", "--home", home}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -1131,6 +1132,90 @@ func TestSkillOptTrainInitCompletesFromPromptAnswers(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainInitWizardCompletesFromStdin(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+	defer restoreInteractive()
+	restoreStdin := replaceSkillOptTrainInitStdin("wizard-flow\nplanner\njerryfane/gitmoot\ntext\ntext-table\nImprove planner summaries.\n")
+	defer restoreStdin()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("wizard train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"Training name:", "Choose a template:", "planner", "Custom file", "Choose a preview style:"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("wizard stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	cfg, err := skillopt.LoadTrainInitConfig(filepath.Join(workspace, ".gitmoot", "skillopt", "wizard-flow", "config.toml"))
+	if err != nil {
+		t.Fatalf("LoadTrainInitConfig returned error: %v", err)
+	}
+	if cfg.Name != "wizard-flow" || cfg.Template != "planner" || cfg.ReviewRepo != "jerryfane/gitmoot" || cfg.ArtifactKind != "text" || cfg.Preview != "text-table" || cfg.Mode != db.EvalRunModeExplore {
+		t.Fatalf("config from wizard = %+v", cfg)
+	}
+}
+
+func TestSkillOptTrainInitWizardIncompleteFailsCleanly(t *testing.T) {
+	home := t.TempDir()
+	_ = chdirTemp(t)
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+	defer restoreInteractive()
+	// Only the name is answered; stdin then hits EOF for the remaining fields.
+	restoreStdin := replaceSkillOptTrainInitStdin("partial-wizard\n")
+	defer restoreStdin()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("incomplete wizard exit code = %d, want 2; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "missing required fields") {
+		t.Fatalf("incomplete wizard stderr = %q", stderr.String())
+	}
+}
+
+func TestSkillOptTrainInitWizardChoiceSelection(t *testing.T) {
+	choices := []string{"none", "text-table", "vue"}
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "by number", input: "2\n", want: "text-table"},
+		{name: "by literal value", input: "vue\n", want: "vue"},
+		{name: "blank uses default", input: "\n", want: "text-table"},
+		{name: "reasks then accepts", input: "9\n1\n", want: "none"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := bufio.NewReader(strings.NewReader(tc.input))
+			var stdout bytes.Buffer
+			got := skillOptTrainInitWizardChoice(reader, &stdout, "Choose a preview style:", choices, "text-table")
+			if got != tc.want {
+				t.Fatalf("choice = %q, want %q (stdout=%s)", got, tc.want, stdout.String())
+			}
+		})
+	}
+}
+
 func TestSkillOptTrainInitNamedPromptRerunIncludesName(t *testing.T) {
 	home := t.TempDir()
 	workspace := chdirTemp(t)
@@ -1139,7 +1224,7 @@ func TestSkillOptTrainInitNamedPromptRerunIncludesName(t *testing.T) {
 	defer restoreInteractive()
 
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"skillopt", "train", "init", "--home", home, "--name", "named-flow"}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "init", "--prompts", "--home", home, "--name", "named-flow"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("named interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -1159,7 +1244,7 @@ func TestSkillOptTrainInitPartialDefaultPromptRerunStaysDefaultScoped(t *testing
 	defer restoreInteractive()
 
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "init", "--prompts", "--home", home}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -1173,7 +1258,7 @@ func TestSkillOptTrainInitPartialDefaultPromptRerunStaysDefaultScoped(t *testing
 
 	stdout.Reset()
 	stderr.Reset()
-	code = Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	code = Run([]string{"skillopt", "train", "init", "--prompts", "--home", home}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("partial prompt rerun exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -1199,6 +1284,7 @@ func TestSkillOptTrainInitPromptRerunPreservesSuppliedFlags(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{
 		"skillopt", "train", "init",
+		"--prompts",
 		"--home", home,
 		"--template", "planner",
 		"--artifact-kind", "text",
@@ -1237,6 +1323,7 @@ func TestSkillOptTrainInitPromptRerunDropsEmptyRequestFile(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{
 		"skillopt", "train", "init",
+		"--prompts",
 		"--home", home,
 		"--template", "planner",
 		"--request-file", requestFile,
@@ -1259,7 +1346,7 @@ func TestSkillOptTrainInitClearsInvalidPromptAnswers(t *testing.T) {
 	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
 
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "init", "--prompts", "--home", home}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -1316,7 +1403,7 @@ func TestSkillOptTrainInitKeepsPromptAnswersForExplicitFlagErrors(t *testing.T) 
 	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
 
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"skillopt", "train", "init", "--home", home, "--preview", "bogus"}, &stdout, &stderr)
+	code := Run([]string{"skillopt", "train", "init", "--prompts", "--home", home, "--preview", "bogus"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("interactive train init exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}


### PR DESCRIPTION
## WHAT
Task 1 of issue #196: the human-facing line-oriented wizard for `gitmoot skillopt train init`, built on the #195 structured train-init foundation.

## WHY
Before this, a missing-fields `train init` on an interactive terminal created prompt records and exited — a clunky create-records-then-`interactive answer`-then-rerun dance for a human. Issue #196 wants a human at a TTY to complete setup inline.

## CHANGES
- **Inline wizard**: when required fields are missing and stdin is an interactive terminal, `train init` asks for them one at a time, reading answers from stdin (a mockable `skillOptTrainInitStdin`). Numbered choices for the template (with a trailing **"Custom file"** option) and the preview style; free text for name/review-repo/artifact-kind/request. Template choices come from the existing `ListTrainInitTemplateChoices`.
- **`--prompts` flag**: selects the previous prompt-record flow (the async agent path, refined in task 2/#196 Task 3) — create records, answer with `gitmoot interactive answer`, rerun. The gate is now an explicit precedence: `--yes` → fail-fast on missing; `--prompts` → prompt records; interactive terminal → wizard; otherwise → fail-fast error.
- **Incomplete-input safety**: if stdin ends before every field is answered, the wizard reports the still-missing fields and exits 2 without writing a partial scaffold.
- `task_kind`/`mode` continue to default (`custom`/`explore`) per #195 and are not asked (matching established behavior confirmed by the 2026-06-09 E2E test).
- Docs (`skillopt-train-workflow.md`) updated: wizard is the interactive default; `--prompts` documented for the agent flow.

## RESULTS
- New tests: `TestSkillOptTrainInitWizardCompletesFromStdin` (full stdin-driven run + asserts the template list and "Custom file" render), `TestSkillOptTrainInitWizardChoiceSelection` (number/literal/default/re-ask), `TestSkillOptTrainInitWizardIncompleteFailsCleanly` (EOF → exit 2). The 8 existing prompt-record tests updated to use `--prompts`.
- `go build ./...`, `gofmt`, `go vet` clean.
- `go test ./internal/cli` passes **except** `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos`, the pre-existing daemon concurrency-test failure that also fails on clean `main` (unrelated; touches no daemon code).

## RISK
Medium. Behavior change: an interactive `train init` with missing fields now runs the wizard instead of emitting prompt records; agents wanting the old behavior pass `--prompts`. The documented agent workflow was updated accordingly. Non-interactive and `--yes` behavior is unchanged.

## /code-review
High-effort `/code-review`; three findings, all addressed:
1. Dead `task_kind`/`mode` wizard branches (unreachable because both default before missing-detection) → removed.
2. No post-wizard re-check → an EOF mid-wizard could reach downstream validation with an inconsistent exit code → added an explicit re-check that exits 2 with the missing-fields message (+ test).
3. Doc regression: `skillopt-train-workflow.md` described the interactive flow as creating prompt records → updated to document the wizard and `--prompts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)