### PR TITLE
docs: describe herdr-composable train init flow (#196)

### DIFF
--- a/docs/herdr-composable-train-init.md
+++ b/docs/herdr-composable-train-init.md
@@ -1,0 +1,67 @@
+# Running the train-init wizard in a Herdr pane
+
+[Herdr](https://github.com/jerryfane/herdr) is a terminal workspace manager for
+AI coding agents. Gitmoot's `skillopt train init` wizard works well inside a
+visible Herdr pane, but **Herdr is an optional frontend, not a dependency**:
+Gitmoot imports no Herdr code and never calls Herdr. The integration is purely
+compositional — it uses Herdr's standard pane commands plus Gitmoot's existing
+process, stdin/stdout, and `gitmoot interactive ... --json` surfaces.
+
+## Why it composes
+
+The interactive wizard (see [skillopt-train-workflow.md](./skillopt-train-workflow.md))
+publishes each question as an interactive prompt record and blocks until that
+question is answered on the pane's stdin **or** resolved externally with
+`gitmoot interactive answer`. That second path is what makes Herdr optional: an
+agent can run the wizard in a pane for a human to watch, yet answer the current
+question from its own session without typing into the pane at all.
+
+## Pane-based flow
+
+Run the wizard in a new pane that the human can see, and drive it from the
+agent's session:
+
+```sh
+# 1. Split a visible pane next to the current one and start the wizard there.
+PANE=$(herdr pane split "$HERDR_PANE_ID" --direction right --cwd "$REPO" --no-focus)
+herdr pane send-text "$PANE" 'gitmoot skillopt train init'
+herdr pane send-keys "$PANE" Enter
+
+# 2. The wizard now waits on its first question. Inspect the pending prompt
+#    from the agent's own session (no pane scraping needed).
+gitmoot interactive list --state pending --json
+gitmoot interactive show <prompt-id> --json   # question + choices for the human
+
+# 3. Relay the question to the human, then answer on their behalf. The wizard,
+#    running in the pane, unblocks and renders the next question.
+gitmoot interactive answer <prompt-id> <value> --source agent
+
+# 4. Repeat list/show/answer until the wizard prints the scaffold summary, then
+#    optionally read the pane to confirm and close it.
+herdr pane read "$PANE" --source recent --lines 40
+herdr pane close "$PANE"
+```
+
+Notes:
+
+- The human can also type answers directly into the pane (`herdr pane send-text`
+  / `send-keys`); stdin and `interactive answer` are interchangeable for the
+  same question.
+- `herdr pane read` is only for relaying/confirming output to a human — answers
+  flow through `gitmoot interactive answer`, never by parsing pane text.
+
+## Pure CLI fallback (no Herdr)
+
+Nothing above needs Herdr. The same flow works in any terminal, and an agent
+that cannot open a pane can answer everything in one asynchronous pass:
+
+```sh
+gitmoot skillopt train init --prompts          # emit all prompt records, then exit
+gitmoot interactive list --state pending --json
+gitmoot interactive answer <prompt-id> <value> --source agent   # for each field
+gitmoot skillopt train init                     # rerun; applies the answers
+```
+
+An optional smoke script, [`scripts/herdr-train-init-smoke.sh`](../scripts/herdr-train-init-smoke.sh),
+exercises the pane flow when `herdr` is on `PATH` and skips cleanly otherwise, so
+it never fails a normal checkout that has no Herdr installed.

--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -72,6 +72,11 @@ gitmoot interactive list --state pending --json
 gitmoot interactive answer <prompt-id> <value> --source agent
 ```
 
+To run the wizard in a visible terminal pane that a human can watch while the
+agent answers from its own session, see
+[herdr-composable-train-init.md](./herdr-composable-train-init.md); Herdr is an
+optional frontend, not a Gitmoot dependency.
+
 For agents that prefer answering everything asynchronously in one pass, pass
 `--prompts` to store all the prompt requests at once and exit instead of running
 the wizard, then answer them and rerun:

--- a/scripts/herdr-train-init-smoke.sh
+++ b/scripts/herdr-train-init-smoke.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Optional smoke for the Herdr-composable train-init flow.
+#
+# It verifies the prompt/answer surface that makes Herdr optional (the wizard's
+# questions are answerable through `gitmoot interactive answer`), and, when run
+# inside a live Herdr session, also drives the wizard in a real pane. It SKIPS
+# cleanly (exit 0) when Herdr or gitmoot is unavailable so it never fails a
+# normal checkout.
+set -euo pipefail
+
+skip() {
+  echo "herdr-train-init-smoke: SKIP — $1"
+  exit 0
+}
+
+command -v herdr >/dev/null 2>&1 || skip "herdr is not on PATH"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+
+# Use an explicit GITMOOT_BIN if provided, otherwise build a current binary from
+# this checkout so the smoke always matches the code under review.
+if [ -n "${GITMOOT_BIN:-}" ]; then
+  command -v "$GITMOOT_BIN" >/dev/null 2>&1 || skip "GITMOOT_BIN=$GITMOOT_BIN is not executable"
+else
+  command -v go >/dev/null 2>&1 || skip "go is not on PATH to build gitmoot (or set GITMOOT_BIN)"
+  GITMOOT_BIN="$WORK/gitmoot"
+  echo "herdr-train-init-smoke: building gitmoot from $ROOT_DIR"
+  ( cd "$ROOT_DIR" && GOTOOLCHAIN="${GOTOOLCHAIN:-go1.26.0}" go build -o "$GITMOOT_BIN" ./cmd/gitmoot ) \
+    || skip "could not build gitmoot from this checkout"
+fi
+
+HOME_DIR="$WORK/home"
+REPO_DIR="$WORK/repo"
+mkdir -p "$HOME_DIR" "$REPO_DIR"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+gm() { "$GITMOOT_BIN" "$@" --home "$HOME_DIR"; }
+
+echo "herdr-train-init-smoke: verifying the composable prompt/answer surface"
+gm init >/dev/null
+
+# Emit the prompt records the Herdr pane flow answers through, then resolve them
+# exactly as an agent would from its own session.
+( cd "$REPO_DIR" && gm skillopt train init --prompts >/dev/null )
+
+answer() { gm interactive answer "$1" "$2" --source smoke >/dev/null; }
+scope_prompt() { gm interactive list --state pending --json | grep -o "\"id\": \"[^\"]*\.$1\"" | head -1 | sed 's/.*: "//; s/"$//'; }
+
+answer "$(scope_prompt name)"          "herdr-smoke"
+answer "$(scope_prompt template)"      "planner"
+answer "$(scope_prompt review-repo)"   "owner/repo"
+answer "$(scope_prompt artifact-kind)" "text"
+answer "$(scope_prompt preview)"       "text-table"
+answer "$(scope_prompt request)"       "Smoke the herdr-composable flow."
+
+( cd "$REPO_DIR" && gm skillopt train init >/dev/null )
+test -f "$REPO_DIR/.gitmoot/skillopt/herdr-smoke/config.toml" \
+  || { echo "herdr-train-init-smoke: FAIL — scaffold not created"; exit 1; }
+echo "herdr-train-init-smoke: prompt/answer surface OK"
+
+# The live-pane demo only runs inside an active Herdr session.
+if [ -z "${HERDR_PANE_ID:-}" ] || ! herdr pane list >/dev/null 2>&1; then
+  skip "not inside an active Herdr session — pane demo not run (the composable surface above already passed)"
+fi
+
+echo "herdr-train-init-smoke: driving the wizard in a Herdr pane"
+SPLIT_JSON="$(herdr pane split "$HERDR_PANE_ID" --direction right --cwd "$REPO_DIR" --no-focus)"
+PANE="$(printf '%s' "$SPLIT_JSON" | grep -o '"pane_id":"[^"]*"' | head -1 | sed 's/.*:"//; s/"$//')"
+[ -n "$PANE" ] || { echo "herdr-train-init-smoke: FAIL — could not parse pane id from: $SPLIT_JSON"; exit 1; }
+trap 'herdr pane close "$PANE" >/dev/null 2>&1 || true; cleanup' EXIT
+herdr pane send-text "$PANE" "$GITMOOT_BIN skillopt train init --home $HOME_DIR --name pane-smoke"
+herdr pane send-keys "$PANE" Enter
+herdr pane read "$PANE" --source recent --lines 20 || true
+echo "herdr-train-init-smoke: pane demo launched (answer its prompts with gitmoot interactive answer)"


### PR DESCRIPTION
## WHAT
Task 3 of issue #196: document running the train-init wizard in a Herdr pane, keeping Herdr an optional frontend (no Gitmoot dependency).

## WHY
Issue #196 requires Herdr composability to remain external — Gitmoot exposes stable stdin/stdout prompts and `interactive ... --json`, and agents create Herdr panes themselves. The agent-assisted wizard (#212) makes this real: questions are prompt records answerable via `interactive answer`, so an agent can run the wizard in a pane a human watches yet answer from its own session.

## CHANGES
- **`docs/herdr-composable-train-init.md`**: explains Herdr is optional (Gitmoot imports no Herdr code), shows the pane-based flow (`herdr pane split` → run the wizard → `interactive list/show/answer` → `pane read`/`close`), and a pure-CLI fallback (`--prompts` + `interactive answer` + rerun) that needs no Herdr.
- **`scripts/herdr-train-init-smoke.sh`**: optional smoke. Builds a current gitmoot from the checkout (or honors `GITMOOT_BIN`), verifies the composable prompt/answer surface end-to-end (scaffold created), and — only inside a live Herdr session — drives the wizard in a real pane. **Skips cleanly (exit 0)** when `herdr`/`go` are absent or there's no active session, so it never fails a normal checkout or `go test`.
- Cross-link from `skillopt-train-workflow.md`.

## RESULTS
- Verified no Gitmoot→Herdr import exists (`grep -rni herdr internal/` → none).
- Ran the smoke script locally: builds gitmoot, "prompt/answer surface OK", and drives a real pane (an active Herdr session was present). Re-confirmed it exits 0.
- Doc-relative links checked.

## RISK
Low — documentation plus one optional, self-skipping script. No Go code changed; not part of `go test`.

## Review
The diff is docs + one bash script; I did a focused manual review of the script (`set -euo pipefail`, clean-skip on missing deps, temp-dir cleanup trap, pane-id parsed from `pane split` JSON, pane closed on exit) rather than the multi-agent `/code-review` used for the Go-code tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)