### PR TITLE
cli: add gitmoot dashboard status client (#196)

### DIFF
--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -1,0 +1,331 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// dashboardSnapshot is a read-only view of local Gitmoot state. It is assembled
+// entirely from existing store/status sources; the dashboard never owns
+// workflow state.
+type dashboardSnapshot struct {
+	Home            string                  `json:"home"`
+	DatabasePath    string                  `json:"database_path"`
+	DatabaseExists  bool                    `json:"database_exists"`
+	Daemon          dashboardDaemon         `json:"daemon"`
+	Repos           []dashboardRepo         `json:"repos"`
+	Agents          []dashboardAgent        `json:"agents"`
+	RuntimeSessions []dashboardSession      `json:"runtime_sessions"`
+	Jobs            dashboardJobs           `json:"jobs"`
+	Worktrees       []dashboardWorktree     `json:"worktrees"`
+	BranchLocks     []dashboardBranchLock   `json:"branch_locks"`
+	TrainSessions   []dashboardTrainSession `json:"train_sessions"`
+	PendingPrompts  []dashboardPrompt       `json:"pending_prompts"`
+}
+
+type dashboardDaemon struct {
+	Running bool   `json:"running"`
+	PID     int    `json:"pid,omitempty"`
+	LogFile string `json:"log_file,omitempty"`
+}
+
+type dashboardRepo struct {
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}
+
+type dashboardAgent struct {
+	Name    string `json:"name"`
+	Runtime string `json:"runtime"`
+	Role    string `json:"role,omitempty"`
+	Health  string `json:"health,omitempty"`
+}
+
+type dashboardSession struct {
+	Name    string `json:"name"`
+	Runtime string `json:"runtime"`
+	Repo    string `json:"repo,omitempty"`
+	State   string `json:"state,omitempty"`
+}
+
+type dashboardJobs struct {
+	Total   int            `json:"total"`
+	ByState map[string]int `json:"by_state"`
+}
+
+type dashboardWorktree struct {
+	Task string `json:"task"`
+	Repo string `json:"repo,omitempty"`
+	Path string `json:"path"`
+}
+
+type dashboardBranchLock struct {
+	Repo   string `json:"repo"`
+	Branch string `json:"branch"`
+	Owner  string `json:"owner,omitempty"`
+}
+
+type dashboardTrainSession struct {
+	ID        string `json:"id"`
+	Phase     string `json:"phase"`
+	Candidate string `json:"candidate_version,omitempty"`
+	Repo      string `json:"repo,omitempty"`
+}
+
+type dashboardPrompt struct {
+	ID       string `json:"id"`
+	Question string `json:"question"`
+}
+
+func runDashboard(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("dashboard", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "write the snapshot as JSON")
+	answerID := fs.String("answer", "", "pending prompt id to answer before showing the snapshot")
+	answerValue := fs.String("value", "", "answer value to use with --answer")
+	answerSource := fs.String("source", "dashboard", "answer source recorded with --answer")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "dashboard does not accept positional arguments")
+		return 2
+	}
+
+	paths, err := initializedPaths(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "dashboard: %v\n", err)
+		return 1
+	}
+
+	// The only state the dashboard may mutate is answering a pending prompt, and
+	// it does so through the same store API as `gitmoot interactive answer`.
+	if strings.TrimSpace(*answerID) != "" {
+		if err := withStore(*home, func(store *db.Store) error {
+			_, err := store.AnswerInteractivePrompt(context.Background(), *answerID, *answerValue, *answerSource)
+			return err
+		}); err != nil {
+			fmt.Fprintf(stderr, "dashboard: answer prompt: %v\n", err)
+			return 1
+		}
+	}
+
+	snapshot, err := buildDashboardSnapshot(*home, paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "dashboard: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, snapshot); err != nil {
+			fmt.Fprintf(stderr, "dashboard: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printDashboardSnapshot(stdout, snapshot)
+	return 0
+}
+
+func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot, error) {
+	snapshot := dashboardSnapshot{
+		Home:            paths.Home,
+		DatabasePath:    paths.Database,
+		Jobs:            dashboardJobs{ByState: map[string]int{}},
+		Repos:           []dashboardRepo{},
+		Agents:          []dashboardAgent{},
+		RuntimeSessions: []dashboardSession{},
+		Worktrees:       []dashboardWorktree{},
+		BranchLocks:     []dashboardBranchLock{},
+		TrainSessions:   []dashboardTrainSession{},
+		PendingPrompts:  []dashboardPrompt{},
+	}
+	if info, err := os.Stat(paths.Database); err == nil && !info.IsDir() {
+		snapshot.DatabaseExists = true
+	}
+
+	state := daemonProcessState(paths)
+	if pid, _, err := currentDaemonPID(state); err == nil && pid > 0 {
+		snapshot.Daemon = dashboardDaemon{Running: true, PID: pid, LogFile: state.LogFile}
+	} else {
+		snapshot.Daemon = dashboardDaemon{Running: false, LogFile: state.LogFile}
+	}
+
+	err := withStore(home, func(store *db.Store) error {
+		ctx := context.Background()
+		repos, err := store.ListRepos(ctx)
+		if err != nil {
+			return err
+		}
+		for _, repo := range repos {
+			snapshot.Repos = append(snapshot.Repos, dashboardRepo{Name: repo.FullName(), Enabled: repo.Enabled})
+		}
+		agents, err := store.ListAgents(ctx)
+		if err != nil {
+			return err
+		}
+		for _, agent := range agents {
+			snapshot.Agents = append(snapshot.Agents, dashboardAgent{Name: agent.Name, Runtime: agent.Runtime, Role: agent.Role, Health: agent.HealthStatus})
+		}
+		instances, err := store.ListAgentInstances(ctx)
+		if err != nil {
+			return err
+		}
+		for _, instance := range instances {
+			snapshot.RuntimeSessions = append(snapshot.RuntimeSessions, dashboardSession{Name: instance.Name, Runtime: instance.Runtime, Repo: instance.RepoFullName, State: instance.State})
+		}
+		jobs, err := store.ListJobs(ctx)
+		if err != nil {
+			return err
+		}
+		snapshot.Jobs.Total = len(jobs)
+		for _, job := range jobs {
+			state := job.State
+			if strings.TrimSpace(state) == "" {
+				state = "unknown"
+			}
+			snapshot.Jobs.ByState[state]++
+		}
+		tasks, err := store.ListTasks(ctx)
+		if err != nil {
+			return err
+		}
+		for _, task := range tasks {
+			if strings.TrimSpace(task.WorktreePath) != "" {
+				snapshot.Worktrees = append(snapshot.Worktrees, dashboardWorktree{Task: task.ID, Repo: task.RepoFullName, Path: task.WorktreePath})
+			}
+		}
+		locks, err := store.ListBranchLocks(ctx, "")
+		if err != nil {
+			return err
+		}
+		for _, lock := range locks {
+			snapshot.BranchLocks = append(snapshot.BranchLocks, dashboardBranchLock{Repo: lock.RepoFullName, Branch: lock.Branch, Owner: lock.Owner})
+		}
+		trainSessions, err := store.ListSkillOptTrainSessions(ctx)
+		if err != nil {
+			return err
+		}
+		for _, session := range trainSessions {
+			entry := dashboardTrainSession{ID: session.ID, Phase: session.State, Repo: session.TargetRepo}
+			iteration, err := store.GetLatestSkillOptTrainIteration(ctx, session.ID)
+			switch {
+			case err == nil:
+				summary := skillopt.BuildTrainStatusSummary(session, &iteration, skillopt.TrainStatusCounts{})
+				entry.Phase = summary.CurrentPhase
+				entry.Candidate = summary.CandidateVersion
+			case errors.Is(err, sql.ErrNoRows):
+				// No iteration yet — keep the session-state fallback.
+			default:
+				return err
+			}
+			snapshot.TrainSessions = append(snapshot.TrainSessions, entry)
+		}
+		prompts, err := store.ListInteractivePrompts(ctx, db.InteractivePromptStatePending)
+		if err != nil {
+			return err
+		}
+		for _, prompt := range prompts {
+			snapshot.PendingPrompts = append(snapshot.PendingPrompts, dashboardPrompt{ID: prompt.ID, Question: prompt.Question})
+		}
+		return nil
+	})
+	if err != nil {
+		return dashboardSnapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func printDashboardSnapshot(stdout io.Writer, snapshot dashboardSnapshot) {
+	writeLine(stdout, "home: %s", snapshot.Home)
+	writeLine(stdout, "database: %s (%s)", snapshot.DatabasePath, presentOrMissing(snapshot.DatabaseExists))
+	if snapshot.Daemon.Running {
+		writeLine(stdout, "daemon: running pid %d", snapshot.Daemon.PID)
+	} else {
+		writeLine(stdout, "daemon: stopped")
+	}
+
+	writeLine(stdout, "repos: %d", len(snapshot.Repos))
+	for _, repo := range snapshot.Repos {
+		writeLine(stdout, "  %s (%s)", repo.Name, enabledOrDisabled(repo.Enabled))
+	}
+	writeLine(stdout, "agents: %d", len(snapshot.Agents))
+	for _, agent := range snapshot.Agents {
+		writeLine(stdout, "  %s [%s]%s", agent.Name, agent.Runtime, dashboardSuffix(agent.Role, agent.Health))
+	}
+	writeLine(stdout, "runtime_sessions: %d", len(snapshot.RuntimeSessions))
+	for _, session := range snapshot.RuntimeSessions {
+		writeLine(stdout, "  %s [%s] %s %s", session.Name, session.Runtime, emptyText(session.Repo), session.State)
+	}
+	writeLine(stdout, "jobs: %d", snapshot.Jobs.Total)
+	for _, state := range sortedKeys(snapshot.Jobs.ByState) {
+		writeLine(stdout, "  %s: %d", state, snapshot.Jobs.ByState[state])
+	}
+	writeLine(stdout, "worktrees: %d", len(snapshot.Worktrees))
+	for _, worktree := range snapshot.Worktrees {
+		writeLine(stdout, "  %s %s", worktree.Task, worktree.Path)
+	}
+	writeLine(stdout, "branch_locks: %d", len(snapshot.BranchLocks))
+	for _, lock := range snapshot.BranchLocks {
+		writeLine(stdout, "  %s@%s %s", lock.Repo, lock.Branch, emptyText(lock.Owner))
+	}
+	writeLine(stdout, "train_sessions: %d", len(snapshot.TrainSessions))
+	for _, train := range snapshot.TrainSessions {
+		writeLine(stdout, "  %s phase=%s candidate=%s", train.ID, train.Phase, emptyText(train.Candidate))
+	}
+	writeLine(stdout, "pending_prompts: %d", len(snapshot.PendingPrompts))
+	for _, prompt := range snapshot.PendingPrompts {
+		writeLine(stdout, "  %s\t%s", prompt.ID, prompt.Question)
+	}
+}
+
+func presentOrMissing(present bool) string {
+	if present {
+		return "present"
+	}
+	return "missing"
+}
+
+func enabledOrDisabled(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func dashboardSuffix(role, health string) string {
+	parts := []string{}
+	if strings.TrimSpace(role) != "" {
+		parts = append(parts, role)
+	}
+	if strings.TrimSpace(health) != "" {
+		parts = append(parts, health)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " " + strings.Join(parts, " ")
+}
+
+func sortedKeys(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/cli/dashboard_test.go
+++ b/internal/cli/dashboard_test.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func dashboardTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	return home
+}
+
+func seedDashboardPrompt(t *testing.T, home, id, question string, choices []string) {
+	t.Helper()
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertInteractivePrompt(context.Background(), db.InteractivePrompt{
+		ID:            id,
+		Question:      question,
+		Choices:       choices,
+		Required:      true,
+		AnswerFormat:  "text",
+		SourceCommand: "test",
+	}); err != nil {
+		t.Fatalf("UpsertInteractivePrompt returned error: %v", err)
+	}
+}
+
+func TestDashboardSnapshotRendersSections(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedDashboardPrompt(t, home, "dash.prompt.one", "Pick a value", nil)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"dashboard", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("dashboard exit code = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"daemon: stopped",
+		"repos: 0",
+		"agents: 0",
+		"runtime_sessions: 0",
+		"jobs: 0",
+		"branch_locks: 0",
+		"train_sessions: 0",
+		"pending_prompts: 1",
+		"dash.prompt.one\tPick a value",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dashboard output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDashboardJSONPromptsMatchInteractiveList(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedDashboardPrompt(t, home, "dash.prompt.alpha", "Alpha?", nil)
+	seedDashboardPrompt(t, home, "dash.prompt.beta", "Beta?", []string{"x", "y"})
+
+	var dashOut, dashErr bytes.Buffer
+	if code := Run([]string{"dashboard", "--home", home, "--json"}, &dashOut, &dashErr); code != 0 {
+		t.Fatalf("dashboard --json exit code = %d, stderr=%s", code, dashErr.String())
+	}
+	var snapshot dashboardSnapshot
+	if err := json.Unmarshal(dashOut.Bytes(), &snapshot); err != nil {
+		t.Fatalf("decode dashboard snapshot: %v\n%s", err, dashOut.String())
+	}
+	dashIDs := map[string]bool{}
+	for _, prompt := range snapshot.PendingPrompts {
+		dashIDs[prompt.ID] = true
+	}
+
+	var listOut, listErr bytes.Buffer
+	if code := Run([]string{"interactive", "list", "--home", home, "--state", "pending", "--json"}, &listOut, &listErr); code != 0 {
+		t.Fatalf("interactive list exit code = %d, stderr=%s", code, listErr.String())
+	}
+	var listPrompts []db.InteractivePrompt
+	if err := json.Unmarshal(listOut.Bytes(), &listPrompts); err != nil {
+		t.Fatalf("decode interactive list: %v\n%s", err, listOut.String())
+	}
+	if len(listPrompts) != len(snapshot.PendingPrompts) {
+		t.Fatalf("dashboard pending prompts (%d) != interactive list (%d)", len(snapshot.PendingPrompts), len(listPrompts))
+	}
+	for _, prompt := range listPrompts {
+		if !dashIDs[prompt.ID] {
+			t.Fatalf("interactive list prompt %q missing from dashboard: %+v", prompt.ID, snapshot.PendingPrompts)
+		}
+	}
+}
+
+func TestDashboardAnswerResolvesPromptThroughSharedAPI(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedDashboardPrompt(t, home, "dash.prompt.answerable", "Choose", []string{"keep", "drop"})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"dashboard", "--home", home, "--answer", "dash.prompt.answerable", "--value", "keep", "--source", "test"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("dashboard --answer exit code = %d, stderr=%s", code, stderr.String())
+	}
+	// The snapshot after answering shows no pending prompts.
+	if !strings.Contains(stdout.String(), "pending_prompts: 0") {
+		t.Fatalf("answered prompt should not remain pending:\n%s", stdout.String())
+	}
+	// The prompt is resolved through the same store API interactive answer uses.
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	prompt, err := store.GetInteractivePrompt(context.Background(), "dash.prompt.answerable")
+	if err != nil {
+		t.Fatalf("GetInteractivePrompt returned error: %v", err)
+	}
+	if prompt.State != db.InteractivePromptStateResolved || prompt.AnswerValue != "keep" || prompt.AnswerSource != "test" {
+		t.Fatalf("prompt not resolved via shared API: %+v", prompt)
+	}
+}
+
+func TestDashboardAnswerRejectsInvalidChoiceAndKeepsPrompt(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedDashboardPrompt(t, home, "dash.prompt.choice", "Choose", []string{"keep", "drop"})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"dashboard", "--home", home, "--answer", "dash.prompt.choice", "--value", "bogus"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("invalid dashboard answer exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	prompt, err := store.GetInteractivePrompt(context.Background(), "dash.prompt.choice")
+	if err != nil {
+		t.Fatalf("GetInteractivePrompt returned error: %v", err)
+	}
+	if prompt.State != db.InteractivePromptStatePending {
+		t.Fatalf("invalid answer should leave prompt pending: %+v", prompt)
+	}
+}
+
+func TestDashboardWithoutAnswerDoesNotMutate(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedDashboardPrompt(t, home, "dash.prompt.untouched", "Choose", nil)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"dashboard", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("dashboard exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	prompt, err := store.GetInteractivePrompt(context.Background(), "dash.prompt.untouched")
+	if err != nil {
+		t.Fatalf("GetInteractivePrompt returned error: %v", err)
+	}
+	if prompt.State != db.InteractivePromptStatePending {
+		t.Fatalf("dashboard without --answer must not resolve prompts: %+v", prompt)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -37,6 +37,7 @@ var rootCommands = []command{
 	{name: "job", summary: "inspect and recover jobs", run: runJob},
 	{name: "lock", summary: "inspect and release branch locks", run: runLock},
 	{name: "interactive", summary: "inspect and answer interactive prompts", run: runInteractive},
+	{name: "dashboard", summary: "show a snapshot of local Gitmoot state", run: runDashboard},
 	{name: "skillopt", summary: "export and import SkillOpt packages", run: runSkillOpt},
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2192,6 +2192,27 @@ func (s *Store) GetSkillOptTrainSession(ctx context.Context, id string) (SkillOp
 	return scanSkillOptTrainSession(row)
 }
 
+// ListSkillOptTrainSessions returns all SkillOpt train sessions, most recently
+// updated first.
+func (s *Store) ListSkillOptTrainSessions(ctx context.Context) ([]SkillOptTrainSession, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, template_id, template_version_id, target_repo, workspace_repo, preview_repo,
+			request_summary, task_kind, state, metadata_json, created_at, updated_at
+		FROM skillopt_train_sessions ORDER BY updated_at DESC, id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var sessions []SkillOptTrainSession
+	for rows.Next() {
+		session, err := scanSkillOptTrainSession(rows)
+		if err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, session)
+	}
+	return sessions, rows.Err()
+}
+
 func (s *Store) UpsertSkillOptTrainIteration(ctx context.Context, iteration SkillOptTrainIteration) error {
 	iteration, err := normalizeSkillOptTrainIteration(iteration)
 	if err != nil {

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -160,6 +160,42 @@ func TestInteractivePromptStorageAndAnswerValidation(t *testing.T) {
 	}
 }
 
+func TestListSkillOptTrainSessions(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	empty, err := store.ListSkillOptTrainSessions(ctx)
+	if err != nil {
+		t.Fatalf("ListSkillOptTrainSessions empty returned error: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected no sessions, got %d", len(empty))
+	}
+	for _, id := range []string{"session-a", "session-b"} {
+		if err := store.UpsertSkillOptTrainSession(ctx, SkillOptTrainSession{ID: id, TemplateID: "planner", State: "items_ready"}); err != nil {
+			t.Fatalf("UpsertSkillOptTrainSession(%s) returned error: %v", id, err)
+		}
+	}
+	sessions, err := store.ListSkillOptTrainSessions(ctx)
+	if err != nil {
+		t.Fatalf("ListSkillOptTrainSessions returned error: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(sessions))
+	}
+	seen := map[string]bool{}
+	for _, session := range sessions {
+		seen[session.ID] = true
+	}
+	if !seen["session-a"] || !seen["session-b"] {
+		t.Fatalf("missing sessions: %+v", sessions)
+	}
+}
+
 func TestSkillOptTrainSessionAndIterationStorage(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -59,6 +59,21 @@ user explicitly wants a foreground process. Keep the default `--workers 1`
 unless the Gitmoot home has multiple independent runtime sessions or managed
 agent types with `max_background` greater than one.
 
+`gitmoot dashboard` prints a read-only snapshot of local state — daemon health,
+repos, agents and runtime sessions, jobs by state, worktrees, branch locks,
+SkillOpt train phase/candidate, and pending interactive prompts. Add `--json`
+for a machine-readable snapshot. The pending prompts it lists are the same
+records as `gitmoot interactive list`, and a prompt can be answered in place
+with `gitmoot dashboard --answer <prompt-id> --value <value>` (the same
+mechanism as `gitmoot interactive answer`). Without `--answer` it never mutates
+state.
+
+```sh
+gitmoot dashboard
+gitmoot dashboard --json
+gitmoot dashboard --answer <prompt-id> --value <value>
+```
+
 ## Agent Setup
 
 Start a new runtime session managed by Gitmoot:


### PR DESCRIPTION
## WHAT
Task 4 of issue #196: a `gitmoot dashboard` status client — a read-only view over existing Gitmoot state, with a non-interactive/JSON mode and the ability to answer a pending prompt through the shared #195 mechanism.

## WHY
Issue #196 wants a dashboard/TUI that **reads** existing state and answers prompts through the same prompt/session model as the CLI/JSON clients, without owning workflow state. This delivers the non-interactive client (the foundation a live TUI would later render).

## CHANGES
- **`gitmoot dashboard`** (registered in root help). Aggregates: daemon health (reusing `daemonProcessState`/`currentDaemonPID`), config/db presence, repos, agents, runtime sessions (agent instances), jobs grouped by state, worktrees (from tasks), branch locks, SkillOpt train sessions with phase + candidate (via `BuildTrainStatusSummary`), and pending interactive prompts. Text output by default, `--json` for a machine-readable snapshot (slices initialized so empty lists marshal as `[]`, not `null`).
- **`--answer <id> --value <v> [--source]`**: resolves one pending prompt via `store.AnswerInteractivePrompt` — the exact API `gitmoot interactive answer` uses (choice/required validation included). Without `--answer`, the command never mutates workflow state.
- **`db.ListSkillOptTrainSessions`**: small, clean SELECT (mirrors `GetSkillOptTrainSession` columns) for the train view.
- CLI reference doc updated.

## RESULTS
- New tests: snapshot rendering, `--json` pending-prompts **match `interactive list`**, `--answer` resolves through the shared API, invalid choice is rejected and leaves the prompt pending, and dashboard-without-`--answer` does not resolve prompts. Plus a `ListSkillOptTrainSessions` store test (empty + populated).
- `go build ./...`, `gofmt`, `go vet` clean. `go test ./internal/cli ./internal/db` passes **except** the pre-existing `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` daemon failure (also fails on clean `main`; unrelated).

## RISK
Low — additive read-only command. The only write path is `--answer`, delegated to the existing validated store API. Note: like the existing `daemon status` read command, it uses `initializedPaths` (idempotently ensures the home) and `currentDaemonPID` (clears a *stale* daemon pid file) — consistent with that command; neither touches workflow state.

## /code-review
High-effort `/code-review`. One real finding fixed: the train-session loop swallowed non-`ErrNoRows` DB errors via `if err == nil`, masking real failures behind a stale phase; now it distinguishes `sql.ErrNoRows` (keep the session-state fallback) from other errors (propagate → stderr + exit 1). Other angles (flag parsing, `--answer` error surfacing, nil-slice JSON, the `state` shadow, `rows.Close`/`Err`) verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)