### PR TITLE
test: end-to-end train init UI smoke and docs closeout (#196)

### DIFF
--- a/internal/cli/train_init_ui_e2e_test.go
+++ b/internal/cli/train_init_ui_e2e_test.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// TestTrainInitUIEndToEnd exercises the two #196 UI surfaces together: the
+// line-oriented wizard completing a scaffold from stdin, and the dashboard
+// reporting pending prompts and SkillOpt train phase, including answering a
+// prompt through the shared interactive mechanism.
+func TestTrainInitUIEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	// Seed a train session so the dashboard's train view has something to show.
+	if err := store.UpsertSkillOptTrainSession(context.Background(), db.SkillOptTrainSession{
+		ID:         "e2e-train",
+		TemplateID: "planner",
+		TargetRepo: "owner/product",
+		State:      skillopt.TrainStateItemsReady,
+	}); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSession returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	// 1. Complete the wizard from stdin.
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+	defer restoreInteractive()
+	restoreStdin := replaceSkillOptTrainInitStdin("e2e-flow\nplanner\nowner/repo\ntext\ntext-table\nImprove planner answers.\n")
+	defer restoreStdin()
+	var wizOut, wizErr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "init", "--home", home}, &wizOut, &wizErr); code != 0 {
+		t.Fatalf("wizard init exit code = %d, stderr=%s", code, wizErr.String())
+	}
+	cfg, err := skillopt.LoadTrainInitConfig(filepath.Join(workspace, ".gitmoot", "skillopt", "e2e-flow", "config.toml"))
+	if err != nil {
+		t.Fatalf("LoadTrainInitConfig returned error: %v", err)
+	}
+	if cfg.Name != "e2e-flow" || cfg.Template != "planner" {
+		t.Fatalf("wizard config = %+v", cfg)
+	}
+
+	// 2. The dashboard reports the seeded train session phase.
+	var dashOut, dashErr bytes.Buffer
+	if code := Run([]string{"dashboard", "--home", home, "--json"}, &dashOut, &dashErr); code != 0 {
+		t.Fatalf("dashboard exit code = %d, stderr=%s", code, dashErr.String())
+	}
+	var snapshot dashboardSnapshot
+	if err := json.Unmarshal(dashOut.Bytes(), &snapshot); err != nil {
+		t.Fatalf("decode dashboard snapshot: %v\n%s", err, dashOut.String())
+	}
+	foundTrain := false
+	for _, train := range snapshot.TrainSessions {
+		if train.ID == "e2e-train" {
+			foundTrain = true
+			if train.Phase == "" {
+				t.Fatalf("train session phase is empty: %+v", train)
+			}
+		}
+	}
+	if !foundTrain {
+		t.Fatalf("dashboard did not report the train session: %+v", snapshot.TrainSessions)
+	}
+
+	// 3. Create a pending prompt with --prompts and confirm the dashboard shows
+	//    it, then answer it through the dashboard's shared mechanism.
+	var promptOut, promptErr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "init", "--home", home, "--prompts", "--name", "e2e-prompted"}, &promptOut, &promptErr); code != 0 {
+		t.Fatalf("train init --prompts exit code = %d, stderr=%s", code, promptErr.String())
+	}
+	pending := dashboardPendingPromptIDs(t, home)
+	if len(pending) == 0 {
+		t.Fatalf("expected pending prompts after --prompts")
+	}
+	// The dashboard's pending prompts match interactive list.
+	if !sameStringSet(pending, interactiveListPromptIDs(t, home)) {
+		t.Fatalf("dashboard pending prompts do not match interactive list")
+	}
+	// Answer the template prompt through the dashboard.
+	templatePrompt := ""
+	for _, id := range pending {
+		if strings.HasSuffix(id, ".template") {
+			templatePrompt = id
+		}
+	}
+	if templatePrompt == "" {
+		t.Fatalf("no template prompt among %v", pending)
+	}
+	var ansOut, ansErr bytes.Buffer
+	if code := Run([]string{"dashboard", "--home", home, "--answer", templatePrompt, "--value", "planner"}, &ansOut, &ansErr); code != 0 {
+		t.Fatalf("dashboard --answer exit code = %d, stderr=%s", code, ansErr.String())
+	}
+	if contains(dashboardPendingPromptIDs(t, home), templatePrompt) {
+		t.Fatalf("answered prompt %q should no longer be pending", templatePrompt)
+	}
+}
+
+func dashboardPendingPromptIDs(t *testing.T, home string) []string {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	if code := Run([]string{"dashboard", "--home", home, "--json"}, &out, &errBuf); code != 0 {
+		t.Fatalf("dashboard exit code = %d, stderr=%s", code, errBuf.String())
+	}
+	var snapshot dashboardSnapshot
+	if err := json.Unmarshal(out.Bytes(), &snapshot); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	ids := []string{}
+	for _, prompt := range snapshot.PendingPrompts {
+		ids = append(ids, prompt.ID)
+	}
+	return ids
+}
+
+func interactiveListPromptIDs(t *testing.T, home string) []string {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	if code := Run([]string{"interactive", "list", "--home", home, "--state", "pending", "--json"}, &out, &errBuf); code != 0 {
+		t.Fatalf("interactive list exit code = %d, stderr=%s", code, errBuf.String())
+	}
+	var prompts []db.InteractivePrompt
+	if err := json.Unmarshal(out.Bytes(), &prompts); err != nil {
+		t.Fatalf("decode interactive list: %v", err)
+	}
+	ids := []string{}
+	for _, prompt := range prompts {
+		ids = append(ids, prompt.ID)
+	}
+	return ids
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := map[string]bool{}
+	for _, value := range a {
+		set[value] = true
+	}
+	for _, value := range b {
+		if !set[value] {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -197,6 +197,18 @@ template-learning loop. Use low-level `skillopt review`, `feedback`, `export`,
 `import`, and `candidate` commands only for advanced/debug work, custom
 research runs, or one-step recovery.
 
+To scaffold a reusable train config, run `gitmoot skillopt train init`. On an
+interactive terminal it runs a line-oriented wizard (numbered template choices
+with a "Custom file" option, and the preview style); each question is also a
+prompt record an agent can answer with `gitmoot interactive answer`, or pass
+`--prompts` to emit them all at once. It prints the next `train start --config
+... --workspace-repo <owner/repo>` command. See
+[../../../docs/skillopt-train-workflow.md](../../../docs/skillopt-train-workflow.md)
+and the optional Herdr-pane flow in
+[../../../docs/herdr-composable-train-init.md](../../../docs/herdr-composable-train-init.md).
+Use `gitmoot dashboard` (add `--json`) to watch train phase, pending prompts,
+jobs, and daemon health.
+
 ```sh
 gitmoot skillopt train start \
   --template planner \


### PR DESCRIPTION
## WHAT
Task 5 (final) of issue #196: an end-to-end UI smoke tying the wizard and dashboard together, plus the train-mode workflow doc closeout.

## CHANGES
- **`TestTrainInitUIEndToEnd`**: in a temp home, installs the `planner` template and seeds a train session, completes the **wizard from stdin** (verifies the scaffold config), then runs the **dashboard** `--json` and asserts it reports the train session phase. It then emits prompts with `--prompts`, confirms the dashboard's pending prompts **match `interactive list`**, and answers the template prompt via `gitmoot dashboard --answer`, confirming it is no longer pending.
- **WORKFLOWS.md**: the SkillOpt train-mode reference now points at `train init` (wizard, `--prompts`, the printed `train start --config ... --workspace-repo` next step), the optional Herdr-pane flow, and `gitmoot dashboard`.

## RESULTS
- `go test ./...`: **21 packages pass**; the only failure is the pre-existing `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` daemon concurrency test, which also fails on clean `main` (unrelated to this work — touches no daemon code).
- `gofmt` clean.

## Docs coverage across #196
- Line-oriented wizard + agent-assisted prompt flow: `docs/skillopt-train-workflow.md`, in-CLI usage.
- Optional Herdr usage: `docs/herdr-composable-train-init.md` + `scripts/herdr-train-init-smoke.sh`.
- Dashboard: `skills/gitmoot/references/CLI.md`, WORKFLOWS.md.

## RISK
Minimal — a test file plus documentation. No production code changed.

## Review
Test-only + docs diff; self-reviewed (assertions, helper correctness, no production code) rather than the multi-agent `/code-review` used for the code tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)