### PR TITLE
cli: add zero-dep style package (#217)

### DIFF
--- a/internal/cli/style/style.go
+++ b/internal/cli/style/style.go
@@ -1,0 +1,188 @@
+// Package style is a zero-dependency terminal styling helper shared by the
+// gitmoot CLI. Styling is decided per writer: a styled writer is a real
+// character device honoring the NO_COLOR / CLICOLOR_FORCE / TERM conventions.
+// When styling is disabled (the default for pipes and bytes.Buffer in tests)
+// every wrapper is the identity function, so callers can render unconditionally
+// and tests observe plain output.
+package style
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	ansiReset  = "\x1b[0m"
+	ansiBold   = "\x1b[1m"
+	ansiDim    = "\x1b[2m"
+	ansiRed    = "\x1b[31m"
+	ansiGreen  = "\x1b[32m"
+	ansiYellow = "\x1b[33m"
+	ansiCyan   = "\x1b[36m"
+)
+
+// Style applies terminal styling when enabled. The zero value is a disabled
+// Style whose wrappers all return their input unchanged.
+type Style struct {
+	enabled bool
+}
+
+// Enabled reports whether this Style emits ANSI codes.
+func (s Style) Enabled() bool { return s.enabled }
+
+func (s Style) wrap(code, text string) string {
+	if !s.enabled || text == "" {
+		return text
+	}
+	return code + text + ansiReset
+}
+
+// Bold returns text wrapped in bold when styling is enabled.
+func (s Style) Bold(text string) string { return s.wrap(ansiBold, text) }
+
+// Dim returns text wrapped in faint when styling is enabled.
+func (s Style) Dim(text string) string { return s.wrap(ansiDim, text) }
+
+// Red returns text wrapped in red when styling is enabled.
+func (s Style) Red(text string) string { return s.wrap(ansiRed, text) }
+
+// Green returns text wrapped in green when styling is enabled.
+func (s Style) Green(text string) string { return s.wrap(ansiGreen, text) }
+
+// Yellow returns text wrapped in yellow when styling is enabled.
+func (s Style) Yellow(text string) string { return s.wrap(ansiYellow, text) }
+
+// Cyan returns text wrapped in cyan when styling is enabled.
+func (s Style) Cyan(text string) string { return s.wrap(ansiCyan, text) }
+
+// Enabled returns an always-on Style, for callers that have already decided to
+// style (or for tests).
+func Enabled() Style { return Style{enabled: true} }
+
+// Disabled returns an always-off Style.
+func Disabled() Style { return Style{enabled: false} }
+
+// For returns a Style for w, enabled per the resolved environment and whether w
+// is a real terminal.
+func For(w io.Writer) Style {
+	return Style{enabled: enabledFor(w, os.LookupEnv, runtime.GOOS)}
+}
+
+// enabledFor is the testable core of For. Precedence: an explicit NO_COLOR
+// disable wins; then CLICOLOR_FORCE forces on; then TERM=dumb disables; then the
+// writer must be a character device (and, on Windows, the terminal must look
+// VT-capable).
+func enabledFor(w io.Writer, lookup func(string) (string, bool), goos string) bool {
+	if value, ok := lookup("NO_COLOR"); ok && value != "" {
+		return false
+	}
+	if value, ok := lookup("CLICOLOR_FORCE"); ok && value != "" && value != "0" {
+		return true
+	}
+	if value, ok := lookup("TERM"); ok && value == "dumb" {
+		return false
+	}
+	if !isCharDevice(w) {
+		return false
+	}
+	if goos == "windows" {
+		return windowsVTCapable(lookup)
+	}
+	return true
+}
+
+func windowsVTCapable(lookup func(string) (string, bool)) bool {
+	if _, ok := lookup("WT_SESSION"); ok {
+		return true
+	}
+	if value, ok := lookup("ConEmuANSI"); ok && value == "ON" {
+		return true
+	}
+	if value, ok := lookup("TERM"); ok && value != "" {
+		return true
+	}
+	return false
+}
+
+func isCharDevice(w io.Writer) bool {
+	stater, ok := w.(interface {
+		Stat() (os.FileInfo, error)
+	})
+	if !ok {
+		return false
+	}
+	info, err := stater.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+// Columns aligns a table of cells into left-justified, space-padded lines, two
+// spaces between columns. Widths are measured in runes; ragged rows (differing
+// cell counts) are aligned per column and trailing padding is trimmed. Styling
+// escape codes in cells are not measured, so apply color after Columns, not
+// before.
+func Columns(rows [][]string) []string {
+	widths := map[int]int{}
+	for _, row := range rows {
+		for col, cell := range row {
+			if w := utf8.RuneCountInString(cell); w > widths[col] {
+				widths[col] = w
+			}
+		}
+	}
+	lines := make([]string, 0, len(rows))
+	for _, row := range rows {
+		var builder strings.Builder
+		for col, cell := range row {
+			if col > 0 {
+				builder.WriteString("  ")
+			}
+			builder.WriteString(cell)
+			builder.WriteString(strings.Repeat(" ", widths[col]-utf8.RuneCountInString(cell)))
+		}
+		lines = append(lines, strings.TrimRight(builder.String(), " "))
+	}
+	return lines
+}
+
+// TopN returns the first n items and the count of items omitted. n <= 0 keeps
+// everything. The returned slice aliases items (it is a sub-slice with the
+// original capacity); callers must treat it as read-only and not append to it.
+func TopN[T any](items []T, n int) (shown []T, hidden int) {
+	if n <= 0 || len(items) <= n {
+		return items, 0
+	}
+	return items[:n], len(items) - n
+}
+
+// GroupSuffix splits a generated session name such as "<type>-bg-<hex>" on its
+// final "-bg-" marker and returns the type prefix. ok is false when no marker
+// is present.
+func GroupSuffix(name string) (prefix string, ok bool) {
+	index := strings.LastIndex(name, "-bg-")
+	if index < 0 {
+		return "", false
+	}
+	return name[:index], true
+}
+
+// MiddleTruncate shortens s to at most max runes, keeping the head and tail and
+// inserting a single "…" in the middle. max < 5 falls back to a plain head cut.
+func MiddleTruncate(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max < 5 {
+		if max <= 0 {
+			return ""
+		}
+		return string(runes[:max])
+	}
+	keep := max - 1
+	head := (keep + 1) / 2
+	tail := keep - head
+	return string(runes[:head]) + "…" + string(runes[len(runes)-tail:])
+}

--- a/internal/cli/style/style_test.go
+++ b/internal/cli/style/style_test.go
@@ -1,0 +1,164 @@
+package style
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEnabledForPrecedence(t *testing.T) {
+	tty := charDevice{}
+	pipe := &bytes.Buffer{}
+	env := func(pairs map[string]string) func(string) (string, bool) {
+		return func(key string) (string, bool) {
+			value, ok := pairs[key]
+			return value, ok
+		}
+	}
+	cases := []struct {
+		name string
+		writ bool // whether to use the tty writer
+		envs map[string]string
+		goos string
+		want bool
+	}{
+		{name: "tty default on", writ: true, envs: nil, goos: "linux", want: true},
+		{name: "pipe off", writ: false, envs: nil, goos: "linux", want: false},
+		{name: "NO_COLOR disables tty", writ: true, envs: map[string]string{"NO_COLOR": "1"}, goos: "linux", want: false},
+		{name: "empty NO_COLOR ignored", writ: true, envs: map[string]string{"NO_COLOR": ""}, goos: "linux", want: true},
+		{name: "CLICOLOR_FORCE forces pipe on", writ: false, envs: map[string]string{"CLICOLOR_FORCE": "1"}, goos: "linux", want: true},
+		{name: "CLICOLOR_FORCE=0 ignored", writ: false, envs: map[string]string{"CLICOLOR_FORCE": "0"}, goos: "linux", want: false},
+		{name: "NO_COLOR beats CLICOLOR_FORCE", writ: true, envs: map[string]string{"NO_COLOR": "1", "CLICOLOR_FORCE": "1"}, goos: "linux", want: false},
+		{name: "TERM dumb disables tty", writ: true, envs: map[string]string{"TERM": "dumb"}, goos: "linux", want: false},
+		{name: "windows needs VT hint", writ: true, envs: nil, goos: "windows", want: false},
+		{name: "windows WT_SESSION on", writ: true, envs: map[string]string{"WT_SESSION": "x"}, goos: "windows", want: true},
+		{name: "windows TERM hint on", writ: true, envs: map[string]string{"TERM": "xterm"}, goos: "windows", want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var w interface{ Write([]byte) (int, error) }
+			if tc.writ {
+				w = tty
+			} else {
+				w = pipe
+			}
+			got := enabledFor(w, env(tc.envs), tc.goos)
+			if got != tc.want {
+				t.Fatalf("enabledFor = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStyleWrapsOnlyWhenEnabled(t *testing.T) {
+	on := Enabled()
+	if got := on.Bold("hi"); got != "\x1b[1mhi\x1b[0m" {
+		t.Fatalf("enabled Bold = %q", got)
+	}
+	if got := on.Bold(""); got != "" {
+		t.Fatalf("empty string should not be wrapped, got %q", got)
+	}
+	off := Disabled()
+	for _, got := range []string{off.Bold("hi"), off.Dim("hi"), off.Red("hi"), off.Green("hi"), off.Yellow("hi"), off.Cyan("hi")} {
+		if got != "hi" {
+			t.Fatalf("disabled style should be identity, got %q", got)
+		}
+	}
+}
+
+func TestForBufferIsPlain(t *testing.T) {
+	var buf bytes.Buffer
+	if For(&buf).Enabled() {
+		t.Fatalf("a bytes.Buffer must never be styled")
+	}
+}
+
+func TestColumns(t *testing.T) {
+	lines := Columns([][]string{
+		{"a", "longvalue", "x"},
+		{"bbb", "v", "y"},
+	})
+	want := []string{
+		"a    longvalue  x",
+		"bbb  v          y",
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Fatalf("Columns line %d = %q, want %q", i, lines[i], want[i])
+		}
+	}
+
+	// Ragged rows: a short row's interior cell is still padded to its column,
+	// and trailing padding is trimmed.
+	ragged := Columns([][]string{{"a", "bb", "ccc"}, {"x", "y"}})
+	if ragged[1] != "x  y" {
+		t.Fatalf("ragged row = %q, want %q", ragged[1], "x  y")
+	}
+	// Rune width: a 5-rune multibyte cell pads to 5 columns, not its byte length.
+	runed := Columns([][]string{{"héllo", "z"}, {"ab", "z"}})
+	if runed[1] != "ab     z" {
+		t.Fatalf("multibyte row = %q, want %q", runed[1], "ab     z")
+	}
+}
+
+func TestTopN(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5}
+	shown, hidden := TopN(items, 3)
+	if len(shown) != 3 || hidden != 2 {
+		t.Fatalf("TopN(3) = %v, %d", shown, hidden)
+	}
+	shown, hidden = TopN(items, 0)
+	if len(shown) != 5 || hidden != 0 {
+		t.Fatalf("TopN(0) should keep all: %v, %d", shown, hidden)
+	}
+	shown, hidden = TopN(items, 10)
+	if len(shown) != 5 || hidden != 0 {
+		t.Fatalf("TopN(10) over-length: %v, %d", shown, hidden)
+	}
+}
+
+func TestGroupSuffix(t *testing.T) {
+	prefix, ok := GroupSuffix("skillopt-generator-bg-18b7a8b38da37938")
+	if !ok || prefix != "skillopt-generator" {
+		t.Fatalf("GroupSuffix = %q, %v", prefix, ok)
+	}
+	if _, ok := GroupSuffix("planner"); ok {
+		t.Fatalf("GroupSuffix on plain name should be false")
+	}
+	// last -bg- wins
+	prefix, ok = GroupSuffix("a-bg-1-bg-2")
+	if !ok || prefix != "a-bg-1" {
+		t.Fatalf("GroupSuffix last marker = %q, %v", prefix, ok)
+	}
+}
+
+func TestMiddleTruncate(t *testing.T) {
+	if got := MiddleTruncate("short", 10); got != "short" {
+		t.Fatalf("no truncation expected, got %q", got)
+	}
+	got := MiddleTruncate("abcdefghijklmnop", 9)
+	if len([]rune(got)) != 9 || !strings.Contains(got, "…") {
+		t.Fatalf("MiddleTruncate = %q (len %d)", got, len([]rune(got)))
+	}
+	if got := MiddleTruncate("abcdef", 3); got != "abc" {
+		t.Fatalf("small max fallback = %q", got)
+	}
+}
+
+// charDevice is a writer whose Stat reports a character device, for detection
+// tests without touching the real terminal.
+type charDevice struct{}
+
+func (charDevice) Write(p []byte) (int, error) { return len(p), nil }
+func (charDevice) Stat() (os.FileInfo, error)  { return charDeviceInfo{}, nil }
+
+type charDeviceInfo struct{}
+
+func (charDeviceInfo) Name() string       { return "tty" }
+func (charDeviceInfo) Size() int64        { return 0 }
+func (charDeviceInfo) Mode() os.FileMode  { return os.ModeCharDevice }
+func (charDeviceInfo) ModTime() time.Time { return time.Time{} }
+func (charDeviceInfo) IsDir() bool        { return false }
+func (charDeviceInfo) Sys() any           { return nil }


### PR DESCRIPTION
## WHAT
Task 1 of #217 (TUI/UX overhaul): a new zero-dependency `internal/cli/style` package — the shared presentation layer the rest of the overhaul renders through. No behavior change to any command.

## WHY
The dashboard/wizard/train-continue surfaces each do ad-hoc `fmt.Fprintf`; #216 showed the result (no color/structure on a TTY). This package centralizes the decision of *whether* to style (per writer) and the primitives to do it, so styling stays consistent and tests stay plain.

## CHANGES
- `style.For(io.Writer) Style` — enabled only when the writer is a real char device AND env conventions allow: `NO_COLOR` present-and-non-empty disables; `CLICOLOR_FORCE` non-empty/non-`0` forces on; `TERM=dumb` disables; on Windows a VT-capability hint (`WT_SESSION`/`ConEmuANSI=ON`/non-empty `TERM`) is also required. A `bytes.Buffer` never satisfies the char-device assertion, so test output is always plain.
- `Style` color wrappers (`Bold/Dim/Red/Green/Yellow/Cyan`) are identity functions when disabled; `Enabled()`, plus `Enabled()`/`Disabled()` constructors for callers/tests.
- Helpers: `Columns` (rune-width aligned, ragged-row safe, trailing-trimmed), `TopN[T]` (first-N + hidden count), `GroupSuffix` (split on the last `-bg-` for runtime-session grouping), `MiddleTruncate`.

## RESULTS
- `go test ./internal/cli/style` green (precedence matrix, buffer-is-plain, helpers incl. ragged + multibyte Columns); `gofmt`/`go vet` clean. No other package imports it yet, so nothing else is affected.

## RISK
Minimal — additive, self-contained, no callers yet.

## /code-review
High-effort `/code-review`; three real findings, all fixed: `Columns` measured byte length (multibyte misalignment) → now rune-counted; `Columns` suppressed padding on each row's last cell (ragged misalignment) → now pads every column and trims trailing space; `TopN` aliasing footgun → documented read-only contract (callers only iterate). `enabledFor` precedence, `isCharDevice`, and `MiddleTruncate` bounds verified correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)