### PR TITLE
skillopt: confirm summary before writing scaffold (#217)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -238,6 +238,10 @@ func runSkillOptTrainInitCreate(args []string, stdout, stderr io.Writer) int {
 			return 0
 		case skillOptTrainInitInteractive():
 			if err := runSkillOptTrainInitWizard(*home, promptScope, skillOptTrainInitStdin(), stdout, &values, missing); err != nil {
+				if errors.Is(err, errSkillOptTrainInitAborted) {
+					writeLine(stdout, "aborted: no scaffold written")
+					return 0
+				}
 				fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
 				return 1
 			}
@@ -610,9 +614,10 @@ func runSkillOptTrainInitWizard(home, scope string, stdin io.Reader, stdout io.W
 	}
 
 	stdinClosed := false
+	externallyAnswered := false
 	return withStore(home, func(store *db.Store) error {
 		for index, field := range ask {
-			value, err := skillOptTrainInitAwaitField(store, scope, field, *values, stdout, st, index+1, len(ask), lines, &stdinClosed)
+			value, err := skillOptTrainInitAwaitField(store, scope, field, *values, stdout, st, index+1, len(ask), lines, &stdinClosed, &externallyAnswered)
 			if err != nil {
 				return err
 			}
@@ -631,15 +636,71 @@ func runSkillOptTrainInitWizard(home, scope string, stdin io.Reader, stdout io.W
 				values.Request = value
 			}
 		}
+		// Only confirm when every field was actually answered (a cut-short stdin
+		// leaves missing fields for the caller to report) and when a human drove
+		// the wizard on stdin (an external driver answered each field
+		// deliberately, so auto-proceed).
+		if len(missingSkillOptTrainInitInputs(*values)) == 0 {
+			if !skillOptTrainInitWizardConfirm(stdout, st, *values, lines, stdinClosed, externallyAnswered) {
+				return errSkillOptTrainInitAborted
+			}
+		}
 		return nil
 	})
+}
+
+// errSkillOptTrainInitAborted signals that the human declined the wizard's
+// confirm step; the caller exits cleanly without writing a scaffold.
+var errSkillOptTrainInitAborted = errors.New("train init aborted by user")
+
+// skillOptTrainInitWizardConfirm prints a summary of the answers and asks for
+// confirmation. It auto-accepts when the wizard was driven externally (via
+// `gitmoot interactive answer`) or stdin has closed, so the agent-assisted and
+// scripted flows proceed without blocking. A blank line or EOF accepts; "n"/"no"
+// declines.
+func skillOptTrainInitWizardConfirm(stdout io.Writer, st style.Style, values skillOptTrainInitInputs, lines <-chan skillOptTrainInitWizardLine, stdinClosed, externallyAnswered bool) bool {
+	fmt.Fprintln(stdout, st.Bold("Review:"))
+	rows := [][]string{
+		{"name", values.Name},
+		{"template", values.Template},
+		{"review repo", values.ReviewRepo},
+		{"task kind", values.TaskKind},
+		{"artifact kind", values.ArtifactKind},
+		{"preview", values.Preview},
+		{"mode", values.Mode},
+		{"request", firstLine(values.Request)},
+	}
+	for _, line := range style.Columns(rows) {
+		fmt.Fprintf(stdout, "  %s\n", st.Dim(line))
+	}
+	if externallyAnswered || stdinClosed {
+		return true
+	}
+	for {
+		fmt.Fprint(stdout, st.Bold("Create scaffold? [Y/n] "))
+		msg, ok := <-lines
+		if !ok {
+			return true
+		}
+		switch strings.ToLower(strings.TrimSpace(msg.text)) {
+		case "", "y", "yes":
+			return true
+		case "n", "no":
+			return false
+		default:
+			if msg.eof {
+				return true
+			}
+			// Unrecognized non-EOF input: re-ask.
+		}
+	}
 }
 
 // skillOptTrainInitAwaitField publishes the prompt record for one field, renders
 // the question, and blocks until an answer arrives on stdin or the prompt is
 // resolved externally. It returns "" (and marks stdin closed) when stdin ends
 // before the field is answered, leaving the caller to report the missing field.
-func skillOptTrainInitAwaitField(store *db.Store, scope, field string, values skillOptTrainInitInputs, stdout io.Writer, st style.Style, index, total int, lines <-chan skillOptTrainInitWizardLine, stdinClosed *bool) (string, error) {
+func skillOptTrainInitAwaitField(store *db.Store, scope, field string, values skillOptTrainInitInputs, stdout io.Writer, st style.Style, index, total int, lines <-chan skillOptTrainInitWizardLine, stdinClosed, externallyAnswered *bool) (string, error) {
 	ctx := context.Background()
 	prompt := buildSkillOptTrainInitPrompt(scope, field, values).Prompt
 	if err := store.UpsertInteractivePrompt(ctx, prompt); err != nil {
@@ -700,6 +761,8 @@ func skillOptTrainInitAwaitField(store *db.Store, scope, field string, values sk
 				return "", err
 			}
 			if current.State == db.InteractivePromptStateResolved {
+				// Resolved by an external `gitmoot interactive answer`, not stdin.
+				*externallyAnswered = true
 				return current.AnswerValue, nil
 			}
 		}

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -1132,6 +1132,61 @@ func TestSkillOptTrainInitCompletesFromPromptAnswers(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainInitWizardConfirm(t *testing.T) {
+	answers := "confirm-flow\nplanner\njerryfane/gitmoot\ntext\ntext-table\nImprove planner summaries.\n"
+	cases := []struct {
+		name         string
+		stdin        string
+		wantScaffold bool
+		wantOut      string
+	}{
+		{name: "accept with y", stdin: answers + "y\n", wantScaffold: true, wantOut: "Review:"},
+		{name: "accept with blank", stdin: answers + "\n", wantScaffold: true, wantOut: "Create scaffold?"},
+		{name: "decline with n", stdin: answers + "n\n", wantScaffold: false, wantOut: "aborted: no scaffold written"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := chdirTemp(t)
+			paths := config.PathsForHome(home)
+			if err := config.Initialize(paths); err != nil {
+				t.Fatalf("Initialize returned error: %v", err)
+			}
+			store, err := db.Open(paths.Database)
+			if err != nil {
+				t.Fatalf("Open returned error: %v", err)
+			}
+			if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+				t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+			}
+			if err := store.Close(); err != nil {
+				t.Fatalf("Close returned error: %v", err)
+			}
+			restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+			defer restoreInteractive()
+			restoreStdin := replaceSkillOptTrainInitStdin(tc.stdin)
+			defer restoreStdin()
+
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stdout.String(), tc.wantOut) {
+				t.Fatalf("stdout missing %q:\n%s", tc.wantOut, stdout.String())
+			}
+			scaffold := filepath.Join(workspace, ".gitmoot", "skillopt", "confirm-flow", "config.toml")
+			_, statErr := os.Stat(scaffold)
+			if tc.wantScaffold && statErr != nil {
+				t.Fatalf("expected scaffold, stat err = %v", statErr)
+			}
+			if !tc.wantScaffold && statErr == nil {
+				t.Fatalf("declined wizard should not write a scaffold")
+			}
+		})
+	}
+}
+
 func TestSkillOptTrainInitWizardCompletesFromStdin(t *testing.T) {
 	home := t.TempDir()
 	workspace := chdirTemp(t)


### PR DESCRIPTION
## WHAT
Task 3 of #217: a final summary + confirm step in the `skillopt train init` wizard before it writes the scaffold.

## WHY
The wizard wrote the scaffold immediately after the last answer, with no chance to review or back out.

## CHANGES (`internal/cli/skillopt.go`)
- After all fields are answered, `skillOptTrainInitWizardConfirm` prints a styled `Review:` summary (name/template/repo/kinds/preview/mode/request) and asks `Create scaffold? [Y/n]`, reading from the same stdin line channel.
- `n`/`no` declines → `errSkillOptTrainInitAborted` → caller prints `aborted: no scaffold written` and exits 0; **nothing is written**. Blank line or EOF accepts.
- **Deliberately not a prompt record and no new flag.** The agent-assisted flow (which answers via `gitmoot interactive answer` over a blocking stdin) is handled by a new `externallyAnswered` flag (set when a field resolves via the DB poll): the confirm auto-accepts in that case, so it never blocks on stdin. Same for an already-closed stdin.
- Confirm runs only when `missingSkillOptTrainInitInputs == 0`; a cut-short stdin still falls through to the caller's missing-field error (exit 2).

## RESULTS
- New `TestSkillOptTrainInitWizardConfirm` (accept-`y`, accept-blank, decline-`n` → no scaffold). Existing stdin/e2e (EOF auto-accept) and agent-assisted (external auto-accept, no hang) tests pass unchanged.
- `go test ./internal/cli` passes except the pre-existing `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` daemon failure. `gofmt`/`go vet` clean.

## RISK
Low–medium (touches the wizard's stdin/channel interaction). The blocking-confirm-vs-channel interaction was the focus of review: confirm only reads `<-lines` when stdin is open and a field hasn't consumed the goroutine's EOF, so it can't block forever; `errSkillOptTrainInitAborted` propagates unwrapped through `withStore` so `errors.Is` matches.

## /code-review
High-effort `/code-review` with a finder dedicated to the channel/EOF/blocking and propagation concerns. Result: **no findings** — every interleaving (EOF mid-field, trailing EOF message, external answer, garbage re-ask) verified safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)