### PR TITLE
skillopt: live progress for generation and optimizer (#217)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -4445,7 +4445,9 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		result.Command = command
 		result.Args = args
 		announceSkillOptTrainOptimizerLaunch(progress, request)
+		stopHeartbeat := startSkillOptTrainOptimizerHeartbeat(progress)
 		runResult, err := runSkillOptTrainOptimizer(ctx, optimizerPaths, request, command, args)
+		stopHeartbeat()
 		result.RecoveryAvailable = skillOptTrainOptimizerRecoveryAvailable(optimizerPaths)
 		if err != nil {
 			if metaErr := recordSkillOptTrainOptimizerFailure(ctx, store, session, iteration, request, optimizerPaths, command, args, runResult, err); metaErr != nil {
@@ -5086,6 +5088,65 @@ func skillOptTrainGenerationLockKey(sessionID string, iterationID string) string
 	return "skillopt-train-generation:" + sessionID + ":" + iterationID
 }
 
+// skillOptTrainGenerationProgress emits human-facing, one-line-per-option
+// progress to a writer (typically stderr) while option jobs run concurrently.
+// A nil receiver or nil writer is a no-op, so automated callers (the review
+// watcher passes a nil Progress) stay silent. Writes are mutex-guarded because
+// options across items complete on concurrent goroutines.
+type skillOptTrainGenerationProgress struct {
+	mu    sync.Mutex
+	w     io.Writer
+	done  int
+	total int
+}
+
+func newSkillOptTrainGenerationProgress(w io.Writer, total int) *skillOptTrainGenerationProgress {
+	return &skillOptTrainGenerationProgress{w: w, total: total}
+}
+
+func (p *skillOptTrainGenerationProgress) start(items, perItem int, runtime string) {
+	if p == nil || p.w == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	suffix := ""
+	if strings.TrimSpace(runtime) != "" {
+		suffix = " with " + runtime
+	}
+	fmt.Fprintf(p.w, "generating %d options (%d items x %d)%s...\n", p.total, items, perItem, suffix)
+}
+
+func (p *skillOptTrainGenerationProgress) optionDone(itemID, role string, elapsed time.Duration, failed bool) {
+	if p == nil || p.w == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.done++
+	status := "done"
+	if failed {
+		status = "failed"
+	}
+	fmt.Fprintf(p.w, "option %s/%s %s (%d/%d) - %s\n", itemID, role, status, p.done, p.total, formatShortDuration(elapsed))
+}
+
+func formatShortDuration(d time.Duration) string {
+	if d < time.Second {
+		return d.Round(time.Millisecond).String()
+	}
+	return d.Round(time.Second).String()
+}
+
+// skillOptTrainGenerationRuntimeLabel is a best-effort runtime name for the
+// generation start line, taken from the resolved target/optimizer backend.
+func skillOptTrainGenerationRuntimeLabel(request skillOptTrainContinueRequest) string {
+	if backend := strings.TrimSpace(request.Optimizer.TargetBackend); backend != "" {
+		return backend
+	}
+	return strings.TrimSpace(request.Optimizer.Backend)
+}
+
 func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainContinueRequest) (skillOptTrainGenerationResult, error) {
 	if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateOptionsGenerated); err != nil {
 		return skillOptTrainGenerationResult{}, err
@@ -5165,7 +5226,9 @@ func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store
 	if err := ensureSkillOptTrainGenerationRepoReady(ctx, store, skillOptTrainGenerationRepo(session)); err != nil {
 		return skillOptTrainGenerationResult{}, err
 	}
-	generatedItems, err := generateSkillOptTrainItemOptions(ctx, store, blobStore, session, iteration, run, items, roles, rankedRun, request, dispatch, concurrency)
+	progress := newSkillOptTrainGenerationProgress(request.Progress, len(items)*len(roles))
+	progress.start(len(items), len(roles), skillOptTrainGenerationRuntimeLabel(request))
+	generatedItems, err := generateSkillOptTrainItemOptions(ctx, store, blobStore, session, iteration, run, items, roles, rankedRun, request, dispatch, concurrency, progress)
 	if err != nil {
 		return skillOptTrainGenerationResult{}, err
 	}
@@ -5247,7 +5310,7 @@ type skillOptTrainGeneratedOption struct {
 	ValidationErrors      []map[string]any
 }
 
-func generateSkillOptTrainItemOptions(ctx context.Context, store *db.Store, blobStore artifact.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, items []db.EvalReviewItem, roles []string, rankedRun bool, request skillOptTrainContinueRequest, dispatch skillOptTrainGenerationDispatch, concurrency int) ([]skillOptTrainGeneratedItemOptions, error) {
+func generateSkillOptTrainItemOptions(ctx context.Context, store *db.Store, blobStore artifact.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, items []db.EvalReviewItem, roles []string, rankedRun bool, request skillOptTrainContinueRequest, dispatch skillOptTrainGenerationDispatch, concurrency int, progress *skillOptTrainGenerationProgress) ([]skillOptTrainGeneratedItemOptions, error) {
 	if concurrency <= 0 {
 		concurrency = 1
 	}
@@ -5271,7 +5334,7 @@ func generateSkillOptTrainItemOptions(ctx context.Context, store *db.Store, blob
 				errs[index] = ctx.Err()
 				return
 			}
-			result, err := generateSkillOptTrainSingleItemOptions(ctx, store, blobStore, session, iteration, run, item, roles, rankedRun, request, dispatch)
+			result, err := generateSkillOptTrainSingleItemOptions(ctx, store, blobStore, session, iteration, run, item, roles, rankedRun, request, dispatch, progress)
 			if err != nil {
 				errs[index] = err
 				return
@@ -5288,17 +5351,20 @@ func generateSkillOptTrainItemOptions(ctx context.Context, store *db.Store, blob
 	return results, nil
 }
 
-func generateSkillOptTrainSingleItemOptions(ctx context.Context, store *db.Store, blobStore artifact.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, item db.EvalReviewItem, roles []string, rankedRun bool, request skillOptTrainContinueRequest, dispatch skillOptTrainGenerationDispatch) (skillOptTrainGeneratedItemOptions, error) {
+func generateSkillOptTrainSingleItemOptions(ctx context.Context, store *db.Store, blobStore artifact.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, item db.EvalReviewItem, roles []string, rankedRun bool, request skillOptTrainContinueRequest, dispatch skillOptTrainGenerationDispatch, progress *skillOptTrainGenerationProgress) (skillOptTrainGeneratedItemOptions, error) {
 	generatedItem := skillOptTrainGeneratedItemOptions{ItemID: item.ItemID}
 	replacementOptions := make([]db.EvalReviewOption, 0, len(roles))
 	artifactRecords := make([]db.EvalArtifact, 0, len(roles))
 	wantsVuePreviewBundle := skillOptTrainWantsVuePreviewBundle(session)
 	requiresVuePreviewBundle := skillOptTrainRequiresVuePreviewBundle(session)
 	for _, role := range roles {
+		optionStart := time.Now()
 		generatedOption, err := generateSkillOptTrainSingleOption(ctx, store, session, iteration, run, item, role, rankedRun, request, dispatch, wantsVuePreviewBundle, requiresVuePreviewBundle)
 		if err != nil {
+			progress.optionDone(item.ItemID, role, time.Since(optionStart), true)
 			return skillOptTrainGeneratedItemOptions{}, err
 		}
+		progress.optionDone(item.ItemID, role, time.Since(optionStart), false)
 		artifactRole := role
 		if rankedRun {
 			artifactRole = "option-" + role
@@ -8557,6 +8623,40 @@ func announceSkillOptTrainOptimizerLaunch(progress io.Writer, request skillOptTr
 		return
 	}
 	fmt.Fprintln(progress, "skillopt train continue: launching optimizer; this runs long-lived model calls and will not stream output until it finishes")
+}
+
+// skillOptTrainOptimizerProgressInterval is how often the optimizer heartbeat
+// reports elapsed time; it is a var so tests can shorten it.
+var skillOptTrainOptimizerProgressInterval = 30 * time.Second
+
+// startSkillOptTrainOptimizerHeartbeat prints an elapsed-time line every
+// interval while the (output-buffered, long-lived) optimizer subprocess runs,
+// so the operator can tell it is alive. It returns a stop func; a nil progress
+// writer makes it a no-op.
+func startSkillOptTrainOptimizerHeartbeat(progress io.Writer) func() {
+	if progress == nil {
+		return func() {}
+	}
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	start := time.Now()
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(skillOptTrainOptimizerProgressInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				fmt.Fprintf(progress, "optimizer running - %s\n", formatShortDuration(time.Since(start)))
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		<-stopped
+	}
 }
 
 func runSkillOptTrainOptimizer(ctx context.Context, paths skillOptTrainOptimizerPaths, request skillOptTrainOptimizerRequest, command string, args []string) (subprocess.Result, error) {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2623,6 +2623,13 @@ func TestSkillOptTrainContinueGeneratesOptionsWithCurrentSkill(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
 	}
+	// Live generation progress goes to stderr: a start line and one line per
+	// completed option, ending at (4/4).
+	for _, want := range []string{"generating 4 options (2 items x 2)", "option ", " done (4/4) - "} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("generation progress stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
 	for _, want := range []string{
 		"current_phase: options_generated",
 		"continue_ready: true",
@@ -11101,4 +11108,20 @@ func cliSkillOptTemplateContent(id string, body string) string {
 		Inputs:               []string{"task"},
 		Outputs:              []string{"plan"},
 	}, "# Planner\n\n"+body+"\n")
+}
+
+func TestSkillOptTrainOptimizerHeartbeat(t *testing.T) {
+	prev := skillOptTrainOptimizerProgressInterval
+	skillOptTrainOptimizerProgressInterval = 10 * time.Millisecond
+	defer func() { skillOptTrainOptimizerProgressInterval = prev }()
+
+	var buf bytes.Buffer
+	stop := startSkillOptTrainOptimizerHeartbeat(&buf)
+	time.Sleep(45 * time.Millisecond)
+	stop() // joins the heartbeat goroutine, so reading buf afterwards is race-free
+	if !strings.Contains(buf.String(), "optimizer running - ") {
+		t.Fatalf("expected at least one heartbeat line, got %q", buf.String())
+	}
+	// A nil writer is a no-op and must not panic.
+	startSkillOptTrainOptimizerHeartbeat(nil)()
 }


### PR DESCRIPTION
## WHAT
Task 5 of #217: live progress during the two black-box long ops — option generation and the optimizer (issue #216 §3).

## WHY
During multi-minute generation the pane showed only the command line (looked hung), and `status` stayed frozen. The optimizer run was equally opaque.

## CHANGES (`internal/cli/skillopt.go`)
- **Generation**: a mutex-guarded, nil-safe `skillOptTrainGenerationProgress` sink over the existing `request.Progress` writer. Prints a start line (`generating 4 options (2 items x 2) with claude...`) and **one line per completed option** (`option item-002/B done (2/4) - 41s`) from the per-item role loop. The counter is mutex-guarded because items generate concurrently; it counts **options, not jobs** (vue-preview retries dispatch multiple jobs per option). A failed option prints a failure line; no success summary comes from the sink.
- **Optimizer**: an elapsed-time heartbeat (`optimizer running - 2m10s`) every ~30s (`skillOptTrainOptimizerProgressInterval`, a var for tests) while the output-buffered subprocess runs, stopped and goroutine-joined on completion.
- The review-watcher path passes a nil `Progress`, so automated runs stay silent.

## RESULTS
- Extended the current-skill generation test to assert the stderr start line and per-option lines ending at `(4/4)`. New `TestSkillOptTrainOptimizerHeartbeat` (shortened interval + nil-writer no-op). **`go test -race`** on the generation test passes (concurrent `optionDone` writes are race-free).
- `go test ./internal/cli` passes except the pre-existing `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` daemon failure. `gofmt`/`go vet` clean.

## RISK
Low. Output-only on stderr; no change to generation results or the optimizer. Concurrency reviewed (mutex covers counter+write; heartbeat goroutine always stopped and joined, no leak; phases are mutually exclusive so the two sinks never write concurrently).

## /code-review
High-effort `/code-review` with a concurrency-focused finder (data race, heartbeat lifecycle, concurrent writers, nil-safety, counter correctness, start-line placement). Result: **no findings** — all six verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)