### PR TITLE
cli: add interactive clear and dashboard --dismiss for stale prompts

### DIFF
--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -113,6 +113,7 @@ func runDashboard(args []string, stdout, stderr io.Writer) int {
 	answerID := fs.String("answer", "", "pending prompt id to answer before showing the snapshot")
 	answerValue := fs.String("value", "", "answer value to use with --answer")
 	answerSource := fs.String("source", "dashboard", "answer source recorded with --answer")
+	dismissID := fs.String("dismiss", "", "pending prompt id to delete before showing the snapshot")
 	watch := fs.Bool("watch", false, "refresh the snapshot on an interval until interrupted (terminal only)")
 	interval := fs.Duration("interval", 5*time.Second, "refresh interval for --watch")
 	if err := fs.Parse(args); err != nil {
@@ -126,8 +127,8 @@ func runDashboard(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	if *watch {
-		if *jsonOutput || strings.TrimSpace(*answerID) != "" {
-			fmt.Fprintln(stderr, "dashboard --watch cannot be combined with --json or --answer")
+		if *jsonOutput || strings.TrimSpace(*answerID) != "" || strings.TrimSpace(*dismissID) != "" {
+			fmt.Fprintln(stderr, "dashboard --watch cannot be combined with --json, --answer, or --dismiss")
 			return 2
 		}
 		if !style.IsTerminal(stdout) {
@@ -147,14 +148,23 @@ func runDashboard(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	// The only state the dashboard may mutate is answering a pending prompt, and
-	// it does so through the same store API as `gitmoot interactive answer`.
+	// The only state the dashboard may mutate is a pending prompt: answering it
+	// (same store API as `gitmoot interactive answer`) or dismissing it (same as
+	// `gitmoot interactive clear`).
 	if strings.TrimSpace(*answerID) != "" {
 		if err := withStore(*home, func(store *db.Store) error {
 			_, err := store.AnswerInteractivePrompt(context.Background(), *answerID, *answerValue, *answerSource)
 			return err
 		}); err != nil {
 			fmt.Fprintf(stderr, "dashboard: answer prompt: %v\n", err)
+			return 1
+		}
+	}
+	if strings.TrimSpace(*dismissID) != "" {
+		if err := withStore(*home, func(store *db.Store) error {
+			return store.DeleteInteractivePrompt(context.Background(), *dismissID)
+		}); err != nil {
+			fmt.Fprintf(stderr, "dashboard: dismiss prompt: %v\n", err)
 			return 1
 		}
 	}

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -113,7 +113,7 @@ func runDashboard(args []string, stdout, stderr io.Writer) int {
 	answerID := fs.String("answer", "", "pending prompt id to answer before showing the snapshot")
 	answerValue := fs.String("value", "", "answer value to use with --answer")
 	answerSource := fs.String("source", "dashboard", "answer source recorded with --answer")
-	dismissID := fs.String("dismiss", "", "pending prompt id to delete before showing the snapshot")
+	dismissID := fs.String("dismiss", "", "prompt id to delete before showing the snapshot")
 	watch := fs.Bool("watch", false, "refresh the snapshot on an interval until interrupted (terminal only)")
 	interval := fs.Duration("interval", 5*time.Second, "refresh interval for --watch")
 	if err := fs.Parse(args); err != nil {

--- a/internal/cli/dashboard_test.go
+++ b/internal/cli/dashboard_test.go
@@ -177,6 +177,42 @@ func TestDashboardWithoutAnswerDoesNotMutate(t *testing.T) {
 	}
 }
 
+func TestDashboardDismissDeletesPrompt(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedDashboardPrompt(t, home, "dash.prompt.dismiss", "Choose", nil)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"dashboard", "--home", home, "--dismiss", "dash.prompt.dismiss"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("dashboard --dismiss exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "pending_prompts: 0") {
+		t.Fatalf("dismissed prompt should not remain pending:\n%s", stdout.String())
+	}
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	prompts, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListInteractivePrompts returned error: %v", err)
+	}
+	if len(prompts) != 0 {
+		t.Fatalf("dismiss should delete the prompt entirely: %+v", prompts)
+	}
+}
+
+func TestDashboardDismissMissingPromptFails(t *testing.T) {
+	home := dashboardTestHome(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"dashboard", "--home", home, "--dismiss", "ghost"}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "not found") {
+		t.Fatalf("dashboard --dismiss missing code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
 func TestDashboardAttentionBlock(t *testing.T) {
 	home := dashboardTestHome(t)
 	seedDashboardPrompt(t, home, "attn.prompt", "Pick", nil)
@@ -274,6 +310,7 @@ func TestDashboardWatchRejectsInvalidCombos(t *testing.T) {
 	cases := [][]string{
 		{"dashboard", "--home", home, "--watch", "--json"},
 		{"dashboard", "--home", home, "--watch", "--answer", "p1", "--value", "x"},
+		{"dashboard", "--home", home, "--watch", "--dismiss", "p1"},
 		{"dashboard", "--home", home, "--watch"}, // stdout is a bytes.Buffer, not a terminal
 	}
 	for _, args := range cases {

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -23,6 +23,8 @@ func runInteractive(args []string, stdout, stderr io.Writer) int {
 		return runInteractiveShow(args[1:], stdout, stderr)
 	case "answer":
 		return runInteractiveAnswer(args[1:], stdout, stderr)
+	case "clear":
+		return runInteractiveClear(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown interactive command %q\n\n", args[0])
 		printInteractiveUsage(stderr)
@@ -35,6 +37,7 @@ func printInteractiveUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot interactive list [--state pending|resolved|all] [--json]")
 	fmt.Fprintln(w, "  gitmoot interactive show <id> --json")
 	fmt.Fprintln(w, "  gitmoot interactive answer <id> <value> [--source source]")
+	fmt.Fprintln(w, "  gitmoot interactive clear <id> [<id>...] | --resolved | --all")
 }
 
 func runInteractiveList(args []string, stdout, stderr io.Writer) int {
@@ -150,6 +153,73 @@ func runInteractiveAnswer(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	writeLine(stdout, "answered %s: %s", prompt.ID, prompt.AnswerValue)
+	return 0
+}
+
+func runInteractiveClear(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("interactive clear", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	resolved := fs.Bool("resolved", false, "clear all resolved prompts")
+	all := fs.Bool("all", false, "clear all prompts (pending and resolved)")
+	parsedArgs, err := reorderFlagArgs(args, map[string]struct{}{"home": {}}, map[string]struct{}{"resolved": {}, "all": {}})
+	if err != nil {
+		fmt.Fprintf(stderr, "interactive clear: %v\n", err)
+		return 2
+	}
+	if err := fs.Parse(parsedArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if *resolved && *all {
+		fmt.Fprintln(stderr, "interactive clear: --resolved and --all are mutually exclusive")
+		return 2
+	}
+	sweep := *resolved || *all
+	ids := fs.Args()
+	if sweep && len(ids) != 0 {
+		fmt.Fprintln(stderr, "interactive clear: cannot combine prompt ids with --resolved or --all")
+		return 2
+	}
+	if !sweep && len(ids) == 0 {
+		fmt.Fprintln(stderr, "interactive clear requires a prompt id, --resolved, or --all")
+		return 2
+	}
+
+	if sweep {
+		state := ""
+		if *resolved {
+			state = db.InteractivePromptStateResolved
+		}
+		var removed int64
+		if err := withStore(*home, func(store *db.Store) error {
+			var err error
+			removed, err = store.DeleteInteractivePromptsByState(context.Background(), state)
+			return err
+		}); err != nil {
+			fmt.Fprintf(stderr, "interactive clear: %v\n", err)
+			return 1
+		}
+		writeLine(stdout, "cleared %d prompt(s)", removed)
+		return 0
+	}
+
+	if err := withStore(*home, func(store *db.Store) error {
+		for _, id := range ids {
+			if err := store.DeleteInteractivePrompt(context.Background(), id); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "interactive clear: %v\n", err)
+		return 1
+	}
+	for _, id := range ids {
+		writeLine(stdout, "cleared %s", id)
+	}
 	return 0
 }
 

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -206,19 +206,19 @@ func runInteractiveClear(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
+	// Deletes are not wrapped in a transaction; report each id as it succeeds so
+	// that on a mid-list failure the user can see exactly what was removed.
 	if err := withStore(*home, func(store *db.Store) error {
 		for _, id := range ids {
 			if err := store.DeleteInteractivePrompt(context.Background(), id); err != nil {
 				return err
 			}
+			writeLine(stdout, "cleared %s", id)
 		}
 		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "interactive clear: %v\n", err)
 		return 1
-	}
-	for _, id := range ids {
-		writeLine(stdout, "cleared %s", id)
 	}
 	return 0
 }

--- a/internal/cli/interactive_test.go
+++ b/internal/cli/interactive_test.go
@@ -76,6 +76,151 @@ func TestInteractiveListShowAndAnswer(t *testing.T) {
 	}
 }
 
+func TestInteractiveClearByID(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	for _, id := range []string{"alpha", "beta"} {
+		if err := store.UpsertInteractivePrompt(context.Background(), db.InteractivePrompt{
+			ID:       id,
+			Question: "Question " + id,
+			Required: true,
+		}); err != nil {
+			t.Fatalf("UpsertInteractivePrompt(%s) returned error: %v", id, err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"interactive", "clear", "--home", home, "alpha"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("interactive clear code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "cleared alpha") {
+		t.Fatalf("clear stdout = %q", stdout.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	remaining, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListInteractivePrompts returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].ID != "beta" {
+		t.Fatalf("remaining prompts = %+v", remaining)
+	}
+}
+
+func TestInteractiveClearMissingIDFails(t *testing.T) {
+	home := t.TempDir()
+	openCLIJobStore(t, home).Close()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"interactive", "clear", "--home", home, "ghost"}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "not found") {
+		t.Fatalf("clear missing code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestInteractiveClearResolvedSweep(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertInteractivePrompt(context.Background(), db.InteractivePrompt{
+		ID: "pending-one", Question: "q1", Required: true,
+	}); err != nil {
+		t.Fatalf("UpsertInteractivePrompt returned error: %v", err)
+	}
+	if err := store.UpsertInteractivePrompt(context.Background(), db.InteractivePrompt{
+		ID: "resolved-one", Question: "q2", Required: true,
+	}); err != nil {
+		t.Fatalf("UpsertInteractivePrompt returned error: %v", err)
+	}
+	if _, err := store.AnswerInteractivePrompt(context.Background(), "resolved-one", "done", "test"); err != nil {
+		t.Fatalf("AnswerInteractivePrompt returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"interactive", "clear", "--home", home, "--resolved"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("clear --resolved code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "cleared 1 prompt(s)") {
+		t.Fatalf("clear --resolved stdout = %q", stdout.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	remaining, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListInteractivePrompts returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].ID != "pending-one" {
+		t.Fatalf("remaining prompts = %+v", remaining)
+	}
+}
+
+func TestInteractiveClearAllSweep(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	for _, id := range []string{"a", "b", "c"} {
+		if err := store.UpsertInteractivePrompt(context.Background(), db.InteractivePrompt{
+			ID: id, Question: "q", Required: true,
+		}); err != nil {
+			t.Fatalf("UpsertInteractivePrompt(%s) returned error: %v", id, err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"interactive", "clear", "--home", home, "--all"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("clear --all code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "cleared 3 prompt(s)") {
+		t.Fatalf("clear --all stdout = %q", stdout.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	remaining, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListInteractivePrompts returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("remaining prompts = %+v", remaining)
+	}
+}
+
+func TestInteractiveClearRejectsConflictingArgs(t *testing.T) {
+	home := t.TempDir()
+	openCLIJobStore(t, home).Close()
+
+	cases := [][]string{
+		{"interactive", "clear", "--home", home},                        // no id and no sweep flag
+		{"interactive", "clear", "--home", home, "--all", "id"},         // sweep + positional id
+		{"interactive", "clear", "--home", home, "--resolved", "--all"}, // both sweep flags
+	}
+	for _, args := range cases {
+		var stdout, stderr bytes.Buffer
+		code := Run(args, &stdout, &stderr)
+		if code != 2 {
+			t.Fatalf("args %v: code=%d stdout=%q stderr=%q", args, code, stdout.String(), stderr.String())
+		}
+	}
+}
+
 func TestInteractiveAnswerRejectsInvalidChoice(t *testing.T) {
 	home := t.TempDir()
 	store := openCLIJobStore(t, home)

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -483,7 +483,7 @@ func consumeSkillOptTrainInitPromptAnswers(home string, scope string) error {
 		if _, ok := skillOptTrainInitPromptField(scope, prompt.ID); !ok {
 			continue
 		}
-		if err := store.DeleteInteractivePrompt(context.Background(), prompt.ID); err != nil {
+		if err := store.DeleteInteractivePrompt(context.Background(), prompt.ID); err != nil && !errors.Is(err, db.ErrInteractivePromptNotFound) {
 			return err
 		}
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2717,8 +2717,35 @@ func (s *Store) DeleteInteractivePrompt(ctx context.Context, id string) error {
 	if id == "" {
 		return errors.New("interactive prompt id is required")
 	}
-	_, err := s.db.ExecContext(ctx, `DELETE FROM interactive_prompts WHERE id = ?`, id)
-	return err
+	result, err := s.db.ExecContext(ctx, `DELETE FROM interactive_prompts WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return fmt.Errorf("interactive prompt %q not found", id)
+	}
+	return nil
+}
+
+// DeleteInteractivePromptsByState deletes every prompt in the given state and
+// returns the number removed. An empty state deletes all prompts regardless of
+// state.
+func (s *Store) DeleteInteractivePromptsByState(ctx context.Context, state string) (int64, error) {
+	var result sql.Result
+	var err error
+	if state == "" {
+		result, err = s.db.ExecContext(ctx, `DELETE FROM interactive_prompts`)
+	} else {
+		result, err = s.db.ExecContext(ctx, `DELETE FROM interactive_prompts WHERE state = ?`, state)
+	}
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 func validateInteractivePromptAnswer(prompt InteractivePrompt, value string) (string, error) {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2712,6 +2712,11 @@ func (s *Store) AnswerInteractivePrompt(ctx context.Context, id string, value st
 	return s.GetInteractivePrompt(ctx, prompt.ID)
 }
 
+// ErrInteractivePromptNotFound is returned by DeleteInteractivePrompt when no
+// prompt with the given id exists. Callers performing best-effort cleanup of a
+// prompt that may already be gone can ignore it via errors.Is.
+var ErrInteractivePromptNotFound = errors.New("interactive prompt not found")
+
 func (s *Store) DeleteInteractivePrompt(ctx context.Context, id string) error {
 	id = strings.TrimSpace(id)
 	if id == "" {
@@ -2726,7 +2731,7 @@ func (s *Store) DeleteInteractivePrompt(ctx context.Context, id string) error {
 		return err
 	}
 	if affected == 0 {
-		return fmt.Errorf("interactive prompt %q not found", id)
+		return fmt.Errorf("interactive prompt %q: %w", id, ErrInteractivePromptNotFound)
 	}
 	return nil
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -160,6 +160,70 @@ func TestInteractivePromptStorageAndAnswerValidation(t *testing.T) {
 	}
 }
 
+func TestDeleteInteractivePrompt(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.UpsertInteractivePrompt(ctx, InteractivePrompt{ID: "present", Question: "q", Required: true}); err != nil {
+		t.Fatalf("UpsertInteractivePrompt returned error: %v", err)
+	}
+	if err := store.DeleteInteractivePrompt(ctx, "present"); err != nil {
+		t.Fatalf("DeleteInteractivePrompt returned error: %v", err)
+	}
+	if err := store.DeleteInteractivePrompt(ctx, "present"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("DeleteInteractivePrompt missing error = %v", err)
+	}
+	if err := store.DeleteInteractivePrompt(ctx, "  "); err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("DeleteInteractivePrompt empty id error = %v", err)
+	}
+}
+
+func TestDeleteInteractivePromptsByState(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	for _, id := range []string{"p1", "p2", "r1"} {
+		if err := store.UpsertInteractivePrompt(ctx, InteractivePrompt{ID: id, Question: "q", Required: true}); err != nil {
+			t.Fatalf("UpsertInteractivePrompt(%s) returned error: %v", id, err)
+		}
+	}
+	if _, err := store.AnswerInteractivePrompt(ctx, "r1", "done", "test"); err != nil {
+		t.Fatalf("AnswerInteractivePrompt returned error: %v", err)
+	}
+
+	removed, err := store.DeleteInteractivePromptsByState(ctx, InteractivePromptStateResolved)
+	if err != nil {
+		t.Fatalf("DeleteInteractivePromptsByState(resolved) returned error: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("resolved removed = %d, want 1", removed)
+	}
+
+	removedAll, err := store.DeleteInteractivePromptsByState(ctx, "")
+	if err != nil {
+		t.Fatalf("DeleteInteractivePromptsByState(all) returned error: %v", err)
+	}
+	if removedAll != 2 {
+		t.Fatalf("all removed = %d, want 2", removedAll)
+	}
+
+	remaining, err := store.ListInteractivePrompts(ctx, "")
+	if err != nil {
+		t.Fatalf("ListInteractivePrompts returned error: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("remaining prompts = %+v", remaining)
+	}
+}
+
 func TestListSkillOptTrainSessions(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
## WHAT
Adds a first-class way to delete stale interactive prompts from the CLI and dashboard, exposing the already-present `store.DeleteInteractivePrompt`.

- `gitmoot interactive clear <id> [<id>...]` — delete prompts by id (reports each as it is removed)
- `gitmoot interactive clear --resolved` — sweep all answered prompts
- `gitmoot interactive clear --all` — sweep every prompt
- `gitmoot dashboard --dismiss <id>` — delete a prompt before rendering the snapshot (rejected with `--watch`, like `--answer`)

## WHY
Interactive prompts are DB rows that only leave the table when answered or deleted by the code that created them. Orphans from abandoned `train init` / `--prompts` runs lingered forever in `interactive list` and — after the #217 overhaul — in the dashboard's "needs attention" block, with no way to remove them except answering (which writes a meaningless resolved record). During the #216 hand-test these had to be deleted straight from SQLite. This closes that gap.

## CHANGES
- `internal/db/store.go`: `DeleteInteractivePrompt` now returns a not-found error (sentinel `ErrInteractivePromptNotFound`) when no row matches; new `DeleteInteractivePromptsByState` for the sweep modes.
- `internal/cli/interactive.go`: `clear` subcommand + usage line.
- `internal/cli/dashboard.go`: `--dismiss` flag mirroring the `--answer` mutation path.
- `internal/cli/skillopt.go`: train-init prompt cleanup loop ignores `ErrInteractivePromptNotFound` so a concurrently-removed prompt no longer fails the consume step (preserves prior silent-success behavior on that path).

## RESULTS
- `go test ./internal/cli ./internal/db` green (only the pre-existing, unrelated daemon flake `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` is red on clean main).
- `go vet` clean; `gofmt` clean; `git diff --check` clean.
- New tests: store not-found + by-state counts; `clear` by-id / missing-id / `--resolved` / `--all` / conflicting-args; dashboard `--dismiss` delete + missing-id + `--watch --dismiss` rejection.

## RISK
Low. `DeleteInteractivePrompt` gaining a not-found return is the only behavior change to existing code; all three internal callers either swallow the error (`_ =`) or, for the consume loop, now explicitly ignore the sentinel. No change to how prompts are created or answered.

A high-effort `/code-review` (7-angle finders + verify) ran on this branch; its findings (partial-delete feedback, the caller regression, and the help-text nit) are all addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)