### PR TITLE
cli: launch dashboard TUI on terminals (TUI task 2)

### DIFF
--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -42,6 +42,11 @@ type dashboardSnapshot struct {
 	TrainSessions   []dashboardTrainSession `json:"train_sessions"`
 	ResourceLocks   []dashboardResourceLock `json:"resource_locks"`
 	PendingPrompts  []dashboardPrompt       `json:"pending_prompts"`
+
+	// promptDetails carries the full pending interactive-prompt records for the
+	// TUI's inline answer flow. Unexported so it never appears in --json output
+	// or the plain renderer, keeping those contracts byte-stable.
+	promptDetails []db.InteractivePrompt
 }
 
 type dashboardResourceLock struct {
@@ -114,6 +119,7 @@ func runDashboard(args []string, stdout, stderr io.Writer) int {
 	answerValue := fs.String("value", "", "answer value to use with --answer")
 	answerSource := fs.String("source", "dashboard", "answer source recorded with --answer")
 	dismissID := fs.String("dismiss", "", "prompt id to delete before showing the snapshot")
+	plain := fs.Bool("plain", false, "print a one-shot snapshot instead of launching the interactive TUI")
 	watch := fs.Bool("watch", false, "refresh the snapshot on an interval until interrupted (terminal only)")
 	interval := fs.Duration("interval", 5*time.Second, "refresh interval for --watch")
 	if err := fs.Parse(args); err != nil {
@@ -140,6 +146,22 @@ func runDashboard(args []string, stdout, stderr io.Writer) int {
 			return 2
 		}
 		return runDashboardWatch(stdout, *home, *all, *interval)
+	}
+
+	// On a real terminal with no machine-output or mutation flags, launch the
+	// interactive TUI. Every other case (pipes, --json/--all/--plain/--answer/
+	// --dismiss, non-terminal stdin) falls through to the one-shot snapshot, so
+	// scripts, tests, and CI are unaffected.
+	flags := dashboardFlags{
+		plain:      *plain,
+		jsonOutput: *jsonOutput,
+		all:        *all,
+		watch:      *watch,
+		answerID:   *answerID,
+		dismissID:  *dismissID,
+	}
+	if shouldLaunchTUI(flags, style.IsTerminal(stdout), stdinIsCharDevice()) {
+		return runDashboardTUI(*home, *interval, stdout, stderr)
 	}
 
 	paths, err := initializedPaths(*home)
@@ -350,6 +372,7 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 		for _, prompt := range prompts {
 			snapshot.PendingPrompts = append(snapshot.PendingPrompts, dashboardPrompt{ID: prompt.ID, Question: prompt.Question})
 		}
+		snapshot.promptDetails = prompts
 		return nil
 	})
 	if err != nil {

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jerryfane/gitmoot/internal/cli/tui"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// dashboardFlags is the subset of dashboard flags that decide whether the
+// interactive TUI launches.
+type dashboardFlags struct {
+	plain      bool
+	jsonOutput bool
+	all        bool
+	watch      bool
+	answerID   string
+	dismissID  string
+}
+
+// shouldLaunchTUI reports whether `gitmoot dashboard` should open the interactive
+// TUI rather than print a one-shot snapshot. The TUI needs a real terminal on
+// both stdout (to draw) and stdin (raw-mode keys), and must yield to every
+// machine-output or one-shot mutation flag so existing behavior is preserved.
+func shouldLaunchTUI(f dashboardFlags, stdoutTTY, stdinTTY bool) bool {
+	if !stdoutTTY || !stdinTTY {
+		return false
+	}
+	if f.plain || f.jsonOutput || f.all || f.watch {
+		return false
+	}
+	if strings.TrimSpace(f.answerID) != "" || strings.TrimSpace(f.dismissID) != "" {
+		return false
+	}
+	return true
+}
+
+// stdinIsCharDevice reports whether stdin is a terminal, so the TUI is not
+// launched when stdin is piped or redirected (bubbletea needs raw-mode keys).
+func stdinIsCharDevice() bool {
+	info, err := os.Stdin.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+// runDashboardTUI launches the bubbletea dashboard. It returns a process exit
+// code like the other dashboard paths.
+func runDashboardTUI(home string, interval time.Duration, stdout, stderr io.Writer) int {
+	program := tea.NewProgram(
+		tui.New(dashboardTUIDeps(home, interval)),
+		tea.WithAltScreen(),
+		tea.WithOutput(stdout),
+	)
+	if _, err := program.Run(); err != nil {
+		fmt.Fprintf(stderr, "dashboard: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// dashboardTUIDeps adapts the existing snapshot builder and prompt store APIs
+// into the tui.Deps the model consumes. Each Load reopens the store (cheap, pure
+// DB) so the TUI always reflects current state, including live train phases.
+func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
+	return tui.Deps{
+		Interval: interval,
+		Load: func() (tui.Snapshot, error) {
+			paths, err := initializedPaths(home)
+			if err != nil {
+				return tui.Snapshot{}, err
+			}
+			snapshot, err := buildDashboardSnapshot(home, paths)
+			if err != nil {
+				return tui.Snapshot{}, err
+			}
+			return toTUISnapshot(snapshot), nil
+		},
+		Answer: func(id, value string) error {
+			return withStore(home, func(store *db.Store) error {
+				_, err := store.AnswerInteractivePrompt(context.Background(), id, value, "dashboard-tui")
+				return err
+			})
+		},
+		Dismiss: func(id string) error {
+			return withStore(home, func(store *db.Store) error {
+				return store.DeleteInteractivePrompt(context.Background(), id)
+			})
+		},
+	}
+}
+
+// toTUISnapshot copies the cli dashboardSnapshot into the tui-facing Snapshot.
+func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
+	out := tui.Snapshot{
+		Home:           s.Home,
+		DatabaseExists: s.DatabaseExists,
+		Daemon:         tui.Daemon{Running: s.Daemon.Running, PID: s.Daemon.PID, LogFile: s.Daemon.LogFile},
+		Jobs:           tui.Jobs{Total: s.Jobs.Total, ByState: s.Jobs.ByState},
+		Prompts:        s.promptDetails,
+	}
+	for _, r := range s.Repos {
+		out.Repos = append(out.Repos, tui.Repo{Name: r.Name, Enabled: r.Enabled})
+	}
+	for _, a := range s.Agents {
+		out.Agents = append(out.Agents, tui.Agent{Name: a.Name, Runtime: a.Runtime, Role: a.Role, Health: a.Health})
+	}
+	for _, sess := range s.RuntimeSessions {
+		out.Sessions = append(out.Sessions, tui.Session{Name: sess.Name, Runtime: sess.Runtime, Repo: sess.Repo, State: sess.State})
+	}
+	for _, w := range s.Worktrees {
+		out.Worktrees = append(out.Worktrees, tui.Worktree{Task: w.Task, Repo: w.Repo, Path: w.Path})
+	}
+	for _, l := range s.BranchLocks {
+		out.BranchLocks = append(out.BranchLocks, tui.BranchLock{Repo: l.Repo, Branch: l.Branch, Owner: l.Owner})
+	}
+	for _, t := range s.TrainSessions {
+		out.Trains = append(out.Trains, tui.TrainSession{ID: t.ID, Phase: t.Phase, Candidate: t.Candidate, Repo: t.Repo})
+	}
+	for _, l := range s.ResourceLocks {
+		out.ResourceLocks = append(out.ResourceLocks, tui.ResourceLock{Key: l.Key, Owner: l.Owner, Stale: l.Stale})
+	}
+	return out
+}

--- a/internal/cli/dashboard_tui_test.go
+++ b/internal/cli/dashboard_tui_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestShouldLaunchTUI(t *testing.T) {
+	cases := []struct {
+		name       string
+		flags      dashboardFlags
+		stdoutTTY  bool
+		stdinTTY   bool
+		wantLaunch bool
+	}{
+		{"both ttys no flags", dashboardFlags{}, true, true, true},
+		{"stdout not tty", dashboardFlags{}, false, true, false},
+		{"stdin not tty", dashboardFlags{}, true, false, false},
+		{"plain", dashboardFlags{plain: true}, true, true, false},
+		{"json", dashboardFlags{jsonOutput: true}, true, true, false},
+		{"all", dashboardFlags{all: true}, true, true, false},
+		{"watch", dashboardFlags{watch: true}, true, true, false},
+		{"answer", dashboardFlags{answerID: "p1"}, true, true, false},
+		{"answer whitespace", dashboardFlags{answerID: "  "}, true, true, true},
+		{"dismiss", dashboardFlags{dismissID: "p1"}, true, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldLaunchTUI(tc.flags, tc.stdoutTTY, tc.stdinTTY); got != tc.wantLaunch {
+				t.Fatalf("shouldLaunchTUI(%+v, %v, %v) = %v, want %v", tc.flags, tc.stdoutTTY, tc.stdinTTY, got, tc.wantLaunch)
+			}
+		})
+	}
+}
+
+// TestDashboardNonTTYStaysPlain guards the core compatibility promise: with a
+// bytes.Buffer (never a terminal), the dashboard prints the one-shot snapshot
+// and never launches the TUI, regardless of the new --plain flag default.
+func TestDashboardNonTTYStaysPlain(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedDashboardPrompt(t, home, "compat.prompt", "Choose", nil)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"dashboard", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("dashboard exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"daemon:", "pending_prompts: 1", "needs attention:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected plain snapshot to contain %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestToTUISnapshotCarriesPromptDetails verifies the snapshot exposes the full
+// prompt records the TUI needs, sourced from the same store query.
+func TestToTUISnapshotCarriesPromptDetails(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedDashboardPrompt(t, home, "detail.prompt", "Pick one", []string{"a", "b"})
+
+	paths, err := initializedPaths(home)
+	if err != nil {
+		t.Fatalf("initializedPaths: %v", err)
+	}
+	snap, err := buildDashboardSnapshot(home, paths)
+	if err != nil {
+		t.Fatalf("buildDashboardSnapshot: %v", err)
+	}
+	if len(snap.promptDetails) != 1 || snap.promptDetails[0].ID != "detail.prompt" {
+		t.Fatalf("promptDetails = %+v", snap.promptDetails)
+	}
+	tuiSnap := toTUISnapshot(snap)
+	if len(tuiSnap.Prompts) != 1 || tuiSnap.Prompts[0].ID != "detail.prompt" || len(tuiSnap.Prompts[0].Choices) != 2 {
+		t.Fatalf("tui prompts = %+v", tuiSnap.Prompts)
+	}
+}
+
+// TestDashboardTUIDepsActions exercises the injected Answer/Dismiss closures end
+// to end against a real store, the same APIs the model will call.
+func TestDashboardTUIDepsActions(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedDashboardPrompt(t, home, "act.answer", "Choose", []string{"keep", "drop"})
+	seedDashboardPrompt(t, home, "act.dismiss", "Choose", nil)
+
+	deps := dashboardTUIDeps(home, 0)
+	if err := deps.Answer("act.answer", "keep"); err != nil {
+		t.Fatalf("Answer: %v", err)
+	}
+	if err := deps.Dismiss("act.dismiss"); err != nil {
+		t.Fatalf("Dismiss: %v", err)
+	}
+
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+	answered, err := store.GetInteractivePrompt(context.Background(), "act.answer")
+	if err != nil {
+		t.Fatalf("get answered: %v", err)
+	}
+	if answered.State != db.InteractivePromptStateResolved || answered.AnswerValue != "keep" || answered.AnswerSource != "dashboard-tui" {
+		t.Fatalf("answered prompt = %+v", answered)
+	}
+	remaining, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].ID != "act.answer" {
+		t.Fatalf("dismiss should remove act.dismiss only: %+v", remaining)
+	}
+}


### PR DESCRIPTION
Part of #226 (interactive TUI). **Task 2 of 7.**

## WHAT
Wires the `internal/cli/tui` dashboard into `gitmoot dashboard`. On a real terminal with no machine-output or mutation flags, the dashboard now opens the interactive TUI; every other path prints the one-shot snapshot exactly as before.

## WHY
Task 1 shipped the TUI package dark. This task makes it reachable while guaranteeing byte-for-byte compatibility for scripts, pipes, CI, and the existing flags (#226 design rule 1).

## CHANGES
- `shouldLaunchTUI(flags, stdoutTTY, stdinTTY)` — pure decision: TUI only when both stdout and stdin are terminals and none of `--plain/--json/--all/--watch/--answer/--dismiss` are set. Table-tested.
- New `--plain` flag to force the one-shot snapshot on a terminal.
- Unexported `promptDetails []db.InteractivePrompt` on `dashboardSnapshot`, populated from the existing `ListInteractivePrompts` query (no new query). Unexported → skipped by `encoding/json` and the plain renderer, so `--json` and plain output stay byte-stable.
- `dashboard_tui.go`: `Deps` adapter (Load → `buildDashboardSnapshot` + `toTUISnapshot`; Answer → `AnswerInteractivePrompt` source `dashboard-tui`; Dismiss → `DeleteInteractivePrompt`) and `runDashboardTUI` launching `tea.NewProgram` with alt-screen, mapping errors to exit 1.

## RESULTS
- `go test ./internal/cli ./internal/cli/tui` green except the pre-existing, unrelated daemon flake `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` (red on clean main). All `Dashboard*` tests pass, including the byte-exact plain/JSON contracts.
- `go vet` / `gofmt` / `git diff --check` clean.
- New tests: `shouldLaunchTUI` table; non-TTY stays plain; `promptDetails` carried into `tui.Snapshot`; Answer/Dismiss closures against a real store.

## RISK
Low. The TUI branch is unreachable for any non-terminal writer (tests use `bytes.Buffer`), and every pre-existing flag short-circuits before it. No change to snapshot JSON or plain output.

## /code-review
High-effort review ran on the diff (correctness + compatibility finders) and returned no findings: the unexported field is confirmed invisible to JSON, the TUI branch cannot fire for piped/test output, ordering preserves the answer/dismiss/watch paths, and `toTUISnapshot` maps every field without aliasing issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)