### PR TITLE
cli: dashboard attention page with inline answer (TUI task 3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -1,0 +1,231 @@
+package tui
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// openAnswer enters the answer overlay for the prompt under the cursor. Choice
+// prompts get a selectable list with the default preselected; free-text prompts
+// get a text input prefilled with the default. Returns the textinput blink cmd
+// when relevant.
+func (m *Model) openAnswer() tea.Cmd {
+	if pages[m.selected].page != pageAttention || len(m.snap.Prompts) == 0 {
+		return nil
+	}
+	p := m.snap.Prompts[m.promptCursor]
+	m.active = p
+	m.actionErr = ""
+	m.actionBusy = false
+	if len(p.Choices) > 0 {
+		m.mode = modeAnswerChoice
+		m.choiceIdx = indexOf(p.Choices, p.Default)
+		return nil
+	}
+	m.mode = modeAnswerText
+	ti := textinput.New()
+	ti.SetValue(p.Default)
+	ti.CursorEnd()
+	m.input = ti
+	return m.input.Focus()
+}
+
+// updateOverlay handles keys while an answer overlay is active.
+func (m Model) updateOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		m.mode = modeNormal
+		m.actionErr = ""
+		m.actionBusy = false
+		m.viewport.SetContent(m.content())
+		return m, nil
+	}
+
+	switch m.mode {
+	case modeAnswerChoice:
+		switch msg.String() {
+		case "up", "k":
+			if m.choiceIdx > 0 {
+				m.choiceIdx--
+			}
+		case "down", "j":
+			if m.choiceIdx < len(m.active.Choices)-1 {
+				m.choiceIdx++
+			}
+		case "enter":
+			if !m.actionBusy && len(m.active.Choices) > 0 {
+				m.actionBusy = true
+				m.actionErr = ""
+				cmd := answerCmd(m.deps, m.active.ID, m.active.Choices[m.choiceIdx])
+				m.viewport.SetContent(m.content())
+				return m, cmd
+			}
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case modeAnswerText:
+		if msg.String() == "enter" {
+			if !m.actionBusy {
+				m.actionBusy = true
+				m.actionErr = ""
+				cmd := answerCmd(m.deps, m.active.ID, strings.TrimSpace(m.input.Value()))
+				m.viewport.SetContent(m.content())
+				return m, cmd
+			}
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		m.viewport.SetContent(m.content())
+		return m, cmd
+	}
+	return m, nil
+}
+
+func answerCmd(deps Deps, id, value string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.Answer == nil {
+			return answerResultMsg{id: id}
+		}
+		return answerResultMsg{id: id, err: deps.Answer(id, value)}
+	}
+}
+
+// attentionContent renders the Attention page: pending prompts (selectable),
+// then blocked/failed job counts, stale resource locks, and branch locks.
+func (m Model) attentionContent() string {
+	if m.mode == modeAnswerChoice || m.mode == modeAnswerText {
+		return m.answerOverlay()
+	}
+	var b strings.Builder
+	wrote := false
+
+	b.WriteString(headerStyle.Render("pending prompts"))
+	b.WriteByte('\n')
+	if len(m.snap.Prompts) == 0 {
+		b.WriteString(mutedStyle.Render("none"))
+		b.WriteByte('\n')
+	} else {
+		for i, p := range m.snap.Prompts {
+			cursor := "  "
+			line := p.ID + "  " + truncate(p.Question, 60)
+			if i == m.promptCursor {
+				cursor = "▸ "
+				line = selectedRowStyle.Render(line)
+			}
+			b.WriteString(cursor)
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+		b.WriteString(mutedStyle.Render("a answer  d dismiss"))
+		b.WriteByte('\n')
+		wrote = true
+	}
+
+	if blocked := m.snap.Jobs.ByState["blocked"]; blocked > 0 {
+		b.WriteString("\n")
+		b.WriteString(redStyle.Render(plural(blocked, "blocked job", "blocked jobs")))
+		b.WriteByte('\n')
+		wrote = true
+	}
+	if failed := m.snap.Jobs.ByState["failed"]; failed > 0 {
+		b.WriteString(redStyle.Render(plural(failed, "failed job", "failed jobs")))
+		b.WriteByte('\n')
+		wrote = true
+	}
+
+	stale := staleLocks(m.snap.ResourceLocks)
+	if len(stale) > 0 {
+		b.WriteString("\n")
+		b.WriteString(headerStyle.Render("stale locks"))
+		b.WriteByte('\n')
+		for _, l := range stale {
+			b.WriteString(redStyle.Render(l.Key))
+			b.WriteByte('\n')
+		}
+		wrote = true
+	}
+
+	if len(m.snap.BranchLocks) > 0 {
+		b.WriteString("\n")
+		b.WriteString(headerStyle.Render("branch locks"))
+		b.WriteByte('\n')
+		for _, l := range m.snap.BranchLocks {
+			b.WriteString(l.Repo + " " + l.Branch + " (" + dash(l.Owner) + ")")
+			b.WriteByte('\n')
+		}
+		wrote = true
+	}
+
+	if !wrote {
+		return "Nothing needs attention."
+	}
+	return b.String()
+}
+
+func (m Model) answerOverlay() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("answer " + m.active.ID))
+	b.WriteString("\n\n")
+	b.WriteString(m.active.Question)
+	b.WriteString("\n\n")
+	switch m.mode {
+	case modeAnswerChoice:
+		for i, choice := range m.active.Choices {
+			cursor, label := "  ", choice
+			if i == m.choiceIdx {
+				cursor, label = "▸ ", selectedRowStyle.Render(choice)
+			}
+			if choice == m.active.Default {
+				label += mutedStyle.Render(" (default)")
+			}
+			b.WriteString(cursor + label + "\n")
+		}
+	case modeAnswerText:
+		b.WriteString(m.input.View())
+		b.WriteByte('\n')
+	}
+	if m.actionErr != "" {
+		b.WriteString("\n")
+		b.WriteString(errorStyle.Render(m.actionErr))
+		b.WriteByte('\n')
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("submitting…"))
+	} else {
+		b.WriteString(mutedStyle.Render("enter submit  esc cancel"))
+	}
+	return b.String()
+}
+
+func indexOf(items []string, value string) int {
+	for i, item := range items {
+		if item == value {
+			return i
+		}
+	}
+	return 0
+}
+
+func staleLocks(locks []ResourceLock) []ResourceLock {
+	out := []ResourceLock{}
+	for _, l := range locks {
+		if l.Stale {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return "1 " + one
+	}
+	return strconv.Itoa(n) + " " + many
+}

--- a/internal/cli/tui/attention_test.go
+++ b/internal/cli/tui/attention_test.go
@@ -1,0 +1,191 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func promptSnap(prompts ...db.InteractivePrompt) Snapshot {
+	return Snapshot{Prompts: prompts}
+}
+
+func choicePrompt() db.InteractivePrompt {
+	return db.InteractivePrompt{ID: "choice.p", Question: "Pick one", Choices: []string{"keep", "drop"}, Default: "keep", State: db.InteractivePromptStatePending}
+}
+
+func textPrompt() db.InteractivePrompt {
+	return db.InteractivePrompt{ID: "text.p", Question: "Training name?", State: db.InteractivePromptStatePending}
+}
+
+func attentionModel(t *testing.T, deps Deps, snap Snapshot) Model {
+	t.Helper()
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	if pages[m.selected].page != pageAttention {
+		t.Fatalf("expected Attention to be the default page")
+	}
+	return m
+}
+
+func key(s string) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)} }
+
+func TestAnswerChoiceHappyPath(t *testing.T) {
+	var gotID, gotVal string
+	deps := Deps{
+		Load:   func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
+		Answer: func(id, value string) error { gotID, gotVal = id, value; return nil },
+	}
+	m := attentionModel(t, deps, promptSnap(choicePrompt()))
+
+	next, _ := m.Update(key("a"))
+	m = next.(Model)
+	if m.mode != modeAnswerChoice {
+		t.Fatalf("expected choice overlay, mode=%v", m.mode)
+	}
+	if m.choiceIdx != 0 {
+		t.Fatalf("default 'keep' should be preselected, idx=%d", m.choiceIdx)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if !m.actionBusy || cmd == nil {
+		t.Fatalf("expected an in-flight answer command")
+	}
+	msg := cmd()
+	if gotID != "choice.p" || gotVal != "drop" {
+		t.Fatalf("Answer called with (%q,%q), want (choice.p,drop)", gotID, gotVal)
+	}
+	next, _ = m.Update(msg)
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("successful answer should return to normal mode, got %v", m.mode)
+	}
+}
+
+func TestAnswerTextHappyPath(t *testing.T) {
+	var gotVal string
+	deps := Deps{
+		Load:   func() (Snapshot, error) { return promptSnap(textPrompt()), nil },
+		Answer: func(id, value string) error { gotVal = value; return nil },
+	}
+	m := attentionModel(t, deps, promptSnap(textPrompt()))
+
+	next, _ := m.Update(key("a"))
+	m = next.(Model)
+	if m.mode != modeAnswerText {
+		t.Fatalf("expected text overlay, mode=%v", m.mode)
+	}
+	next, _ = m.Update(key("smithyx"))
+	m = next.(Model)
+	// Typed text must land in the input, not trigger globals.
+	if !strings.Contains(m.input.Value(), "smithyx") {
+		t.Fatalf("typed text missing from input: %q", m.input.Value())
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("expected answer command")
+	}
+	_ = cmd()
+	if gotVal != "smithyx" {
+		t.Fatalf("Answer value = %q, want smithyx", gotVal)
+	}
+}
+
+func TestAnswerInvalidKeepsOverlay(t *testing.T) {
+	deps := Deps{
+		Load:   func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
+		Answer: func(id, value string) error { return errors.New("value \"drop\" is not one of the choices") },
+	}
+	m := attentionModel(t, deps, promptSnap(choicePrompt()))
+
+	next, _ := m.Update(key("a"))
+	m = next.(Model)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeAnswerChoice {
+		t.Fatalf("invalid answer should keep the overlay open, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "not one of") {
+		t.Fatalf("expected inline error in view:\n%s", m.View())
+	}
+	if len(m.snap.Prompts) != 1 {
+		t.Fatalf("prompt should remain pending: %+v", m.snap.Prompts)
+	}
+}
+
+func TestAnswerCancelDoesNotMutate(t *testing.T) {
+	called := false
+	deps := Deps{
+		Load:   func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
+		Answer: func(id, value string) error { called = true; return nil },
+	}
+	m := attentionModel(t, deps, promptSnap(choicePrompt()))
+
+	next, _ := m.Update(key("a"))
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("esc should close the overlay, mode=%v", m.mode)
+	}
+	if called {
+		t.Fatal("cancel must not call Answer")
+	}
+}
+
+func TestAnswerDoubleSubmitSuppressed(t *testing.T) {
+	count := 0
+	deps := Deps{
+		Load:   func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
+		Answer: func(id, value string) error { count++; return nil },
+	}
+	m := attentionModel(t, deps, promptSnap(choicePrompt()))
+
+	next, _ := m.Update(key("a"))
+	m = next.(Model)
+	next, cmd1 := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	next, cmd2 := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd1 == nil {
+		t.Fatal("first enter should submit")
+	}
+	if cmd2 != nil {
+		t.Fatal("second enter while busy should be suppressed")
+	}
+	cmd1()
+	if count != 1 {
+		t.Fatalf("Answer should be called once, got %d", count)
+	}
+}
+
+func TestAttentionCursorClampedOnRefresh(t *testing.T) {
+	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
+	m := attentionModel(t, deps, promptSnap(choicePrompt(), textPrompt()))
+	// Move cursor to the second prompt.
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	if m.promptCursor != 1 {
+		t.Fatalf("cursor should be at 1, got %d", m.promptCursor)
+	}
+	// Refresh with an empty prompt list must not leave a dangling cursor.
+	next, _ = m.Update(snapshotMsg{snap: Snapshot{}, at: time.Unix(2, 0)})
+	m = next.(Model)
+	if m.promptCursor != 0 {
+		t.Fatalf("cursor should clamp to 0 when prompts empty, got %d", m.promptCursor)
+	}
+	if !strings.Contains(m.View(), "Nothing needs attention") {
+		t.Fatalf("empty attention page expected:\n%s", m.View())
+	}
+}

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -113,3 +113,9 @@ type snapshotMsg struct {
 
 // tickMsg fires on the refresh interval.
 type tickMsg struct{}
+
+// answerResultMsg carries the outcome of a Deps.Answer call.
+type answerResultMsg struct {
+	id  string
+	err error
+}

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -3,15 +3,18 @@ package tui
 import (
 	"time"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/jerryfane/gitmoot/internal/db"
 )
 
 type page int
 
 const (
-	pageAgents page = iota
+	pageAttention page = iota
+	pageAgents
 	pageSessions
 	pageJobs
 	pageLocks
@@ -21,11 +24,22 @@ var pages = []struct {
 	page  page
 	label string
 }{
+	{pageAttention, "Attention"},
 	{pageAgents, "Agents"},
 	{pageSessions, "Sessions"},
 	{pageJobs, "Jobs"},
 	{pageLocks, "Locks"},
 }
+
+// mode is the interaction mode; modeNormal navigates pages, the others are
+// modal overlays that capture keys until dismissed.
+type mode int
+
+const (
+	modeNormal mode = iota
+	modeAnswerChoice
+	modeAnswerText
+)
 
 const defaultInterval = 5 * time.Second
 
@@ -42,6 +56,15 @@ type Model struct {
 	loadedAt time.Time
 	loadErr  string
 	inFlight bool
+
+	// Attention page interaction state.
+	mode         mode
+	promptCursor int                  // selected row in snap.Prompts on the Attention page
+	active       db.InteractivePrompt // prompt being answered in an overlay
+	choiceIdx    int                  // selected choice in modeAnswerChoice
+	input        textinput.Model      // free-text answer in modeAnswerText
+	actionErr    string               // inline error from the last Answer attempt
+	actionBusy   bool                 // an Answer is in flight; suppress re-submit
 }
 
 // New returns a Model ready for tea.NewProgram. It starts in the loading state;
@@ -82,6 +105,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.resizeViewport()
 		}
 	case tea.KeyMsg:
+		// Modal overlays capture keys first; only ctrl+c stays global.
+		if m.mode != modeNormal {
+			return m.updateOverlay(msg)
+		}
 		switch msg.String() {
 		case "ctrl+c", "q", "esc":
 			return m, tea.Quit
@@ -104,6 +131,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.viewport.SetContent(m.content())
 			return m, tea.Batch(cmds...)
+		case "up", "k":
+			if pages[m.selected].page == pageAttention && len(m.snap.Prompts) > 0 {
+				if m.promptCursor > 0 {
+					m.promptCursor--
+				}
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
+		case "down", "j":
+			if pages[m.selected].page == pageAttention && len(m.snap.Prompts) > 0 {
+				if m.promptCursor < len(m.snap.Prompts)-1 {
+					m.promptCursor++
+				}
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
+		case "a":
+			if pages[m.selected].page == pageAttention {
+				if cmd := m.openAnswer(); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
 		}
 		var cmd tea.Cmd
 		m.viewport, cmd = m.viewport.Update(msg)
@@ -112,6 +163,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.viewport, cmd = m.viewport.Update(msg)
 		cmds = append(cmds, cmd)
+	case answerResultMsg:
+		m.actionBusy = false
+		if msg.err != nil {
+			m.actionErr = msg.err.Error()
+		} else {
+			m.mode = modeNormal
+			m.actionErr = ""
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
 	case snapshotMsg:
 		m.inFlight = false
 		if msg.err != nil {
@@ -120,6 +182,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.loadErr = ""
 			m.snap = msg.snap
 			m.loadedAt = msg.at
+			m.clampPromptCursor()
 		}
 	case tickMsg:
 		if cmd := m.queueLoad(); cmd != nil {
@@ -158,6 +221,17 @@ func (m *Model) queueLoad() tea.Cmd {
 	}
 	m.inFlight = true
 	return loadSnapshot(m.deps)
+}
+
+// clampPromptCursor keeps the Attention cursor within the current prompt list
+// after a refresh removes rows.
+func (m *Model) clampPromptCursor() {
+	if m.promptCursor >= len(m.snap.Prompts) {
+		m.promptCursor = len(m.snap.Prompts) - 1
+	}
+	if m.promptCursor < 0 {
+		m.promptCursor = 0
+	}
 }
 
 func loadSnapshot(deps Deps) tea.Cmd {

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -54,7 +54,8 @@ func loadedModel(t *testing.T) Model {
 
 func TestPagesRenderExpectedContent(t *testing.T) {
 	m := loadedModel(t)
-	wants := []string{"planner", "skillopt-generator", "failed", "branch locks"}
+	// Page order: Attention, Agents, Sessions, Jobs, Locks.
+	wants := []string{"pending prompts", "planner", "skillopt-generator", "failed", "branch locks"}
 	for i, want := range wants {
 		if i > 0 {
 			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
@@ -102,6 +103,9 @@ func TestRefreshSuppressionWhileInFlight(t *testing.T) {
 func TestLoadErrorKeepsStaleData(t *testing.T) {
 	m := loadedModel(t)
 	next, _ := m.Update(snapshotMsg{err: errors.New("db locked"), at: time.Unix(2, 0)})
+	m = next.(Model)
+	// Move to the Agents page where the stale data is visible.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = next.(Model)
 	view := m.View()
 	if !strings.Contains(view, "refresh error: db locked") {

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -34,9 +34,10 @@ var (
 	headerStyle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(lipgloss.Color("81"))
-	redStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
-	greenStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
-	cyanStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("44"))
+	redStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+	greenStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
+	cyanStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("44"))
+	selectedRowStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
 )
 
 func renderSidebar(selected, width, height int) string {
@@ -70,6 +71,8 @@ func (m Model) content() string {
 		b.WriteString("\n\n")
 	}
 	switch pages[m.selected].page {
+	case pageAttention:
+		b.WriteString(m.attentionContent())
 	case pageAgents:
 		b.WriteString(m.agentsContent())
 	case pageSessions:
@@ -80,8 +83,22 @@ func (m Model) content() string {
 		b.WriteString(m.locksContent())
 	}
 	b.WriteString("\n\n")
-	b.WriteString(mutedStyle.Render("tab/←→ page  j/k or wheel scroll  r refresh  q quit"))
+	b.WriteString(mutedStyle.Render(m.footerHelp()))
 	return b.String()
+}
+
+// footerHelp is the key-hint line for the current page/mode.
+func (m Model) footerHelp() string {
+	if m.mode == modeAnswerChoice {
+		return "↑/↓ choose  enter submit  esc cancel"
+	}
+	if m.mode == modeAnswerText {
+		return "type answer  enter submit  esc cancel"
+	}
+	if pages[m.selected].page == pageAttention {
+		return "tab/←→ page  ↑/↓ select  a answer  r refresh  q quit"
+	}
+	return "tab/←→ page  j/k or wheel scroll  r refresh  q quit"
 }
 
 func (m Model) loadingOr(empty string, loaded bool) string {
@@ -274,4 +291,18 @@ func dash(value string) string {
 		return "-"
 	}
 	return value
+}
+
+// truncate collapses internal whitespace and shortens value to limit runes with
+// a trailing ellipsis.
+func truncate(value string, limit int) string {
+	value = strings.Join(strings.Fields(value), " ")
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	if limit <= 1 {
+		return string(runes[:max(0, limit)])
+	}
+	return string(runes[:limit-1]) + "…"
 }


### PR DESCRIPTION
Part of #226 (interactive TUI). **Task 3 of 7.**

## WHAT
Adds the **Attention** page (first in the dashboard sidebar) and inline answering of pending interactive prompts.

## WHY
The whole point of an interactive dashboard is to act on what needs a human — answering the agent-wizard / train-init prompts that the #217 overhaul started surfacing, without dropping to `gitmoot interactive answer` in another terminal (#226 design).

## CHANGES
- Attention page: selectable pending-prompt rows, then blocked/failed job counts, stale resource locks, branch locks.
- `a` opens an answer overlay: cursor list with the default preselected for choice prompts; `bubbles/textinput` prefilled with the default for free-text. Enter submits via `Deps.Answer`; a store validation error renders inline and the overlay stays open (prompt stays pending); success refreshes the snapshot.
- Mode-first key dispatch (typing `q`/`r`/`a` into the input no longer triggers globals); `esc` cancels; `actionBusy` guards double-submit.
- `promptCursor` + `clampPromptCursor` on refresh; per-page/mode footer help line.
- `bubbles/textinput` pulled in `atotto/clipboard` (pure Go) via `go mod tidy`.

## RESULTS
- `go test ./internal/cli/tui` green (13 tests incl. choice/text happy paths, invalid-keeps-overlay, cancel, double-submit suppression, cursor clamp).
- `go build ./...` / `go vet` / `gofmt` / `git diff --check` clean.

## RISK
Low, and confined to the `tui` package — still only reachable on a real terminal (Task 2 gate). No CLI/JSON/plain behavior change.

## /code-review
High-effort review (correctness + cleanup finders). Correctness pass found **no bugs** (bounds-checked cursor, value-copy `m.active` safe against mid-overlay refresh, actionBusy lifecycle correct, bubbletea serializes Update so no races). Cleanup: simplified the duplicated `(default)` suffix in the choice overlay (now computed once). Accepted as-is with rationale: the attention-items rendering mirrors `cli.printDashboardAttention` across packages (different render stack, low divergence risk) and the per-key `SetContent`+return tail matches the agent-tools reference pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)