### PR TITLE
cli: dashboard dismiss and train detail (TUI task 4)

### DIFF
--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -33,6 +33,26 @@ func (m *Model) openAnswer() tea.Cmd {
 	return m.input.Focus()
 }
 
+// openDismiss enters the dismiss-confirm overlay for the prompt under the cursor.
+func (m *Model) openDismiss() {
+	if pages[m.selected].page != pageAttention || len(m.snap.Prompts) == 0 {
+		return
+	}
+	m.active = m.snap.Prompts[m.promptCursor]
+	m.actionErr = ""
+	m.actionBusy = false
+	m.mode = modeConfirmDismiss
+}
+
+func dismissCmd(deps Deps, id string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.Dismiss == nil {
+			return dismissResultMsg{id: id}
+		}
+		return dismissResultMsg{id: id, err: deps.Dismiss(id)}
+	}
+}
+
 // updateOverlay handles keys while an answer overlay is active.
 func (m Model) updateOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
@@ -47,6 +67,29 @@ func (m Model) updateOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch m.mode {
+	case modeConfirmDismiss:
+		switch msg.String() {
+		case "y", "Y":
+			if !m.actionBusy {
+				m.actionBusy = true
+				m.actionErr = ""
+				cmd := dismissCmd(m.deps, m.active.ID)
+				m.viewport.SetContent(m.content())
+				return m, cmd
+			}
+		default:
+			// Any other key cancels the dismissal.
+			m.mode = modeNormal
+			m.actionErr = ""
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case modeTrainDetail:
+		if msg.String() == "enter" {
+			m.mode = modeNormal
+			m.viewport.SetContent(m.content())
+		}
+		return m, nil
 	case modeAnswerChoice:
 		switch msg.String() {
 		case "up", "k":
@@ -99,8 +142,11 @@ func answerCmd(deps Deps, id, value string) tea.Cmd {
 // attentionContent renders the Attention page: pending prompts (selectable),
 // then blocked/failed job counts, stale resource locks, and branch locks.
 func (m Model) attentionContent() string {
-	if m.mode == modeAnswerChoice || m.mode == modeAnswerText {
+	switch m.mode {
+	case modeAnswerChoice, modeAnswerText:
 		return m.answerOverlay()
+	case modeConfirmDismiss:
+		return m.dismissOverlay()
 	}
 	var b strings.Builder
 	wrote := false
@@ -200,6 +246,28 @@ func (m Model) answerOverlay() string {
 		b.WriteString(mutedStyle.Render("submitting…"))
 	} else {
 		b.WriteString(mutedStyle.Render("enter submit  esc cancel"))
+	}
+	return b.String()
+}
+
+func (m Model) dismissOverlay() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("dismiss " + m.active.ID))
+	b.WriteString("\n\n")
+	b.WriteString(truncate(m.active.Question, 70))
+	b.WriteString("\n\n")
+	b.WriteString("Delete this prompt? (y/n)")
+	b.WriteByte('\n')
+	if m.actionErr != "" {
+		b.WriteString("\n")
+		b.WriteString(errorStyle.Render(m.actionErr))
+		b.WriteByte('\n')
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("dismissing…"))
+	} else {
+		b.WriteString(mutedStyle.Render("y delete  n/esc cancel"))
 	}
 	return b.String()
 }

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -119,3 +119,9 @@ type answerResultMsg struct {
 	id  string
 	err error
 }
+
+// dismissResultMsg carries the outcome of a Deps.Dismiss call.
+type dismissResultMsg struct {
+	id  string
+	err error
+}

--- a/internal/cli/tui/dismiss_train_test.go
+++ b/internal/cli/tui/dismiss_train_test.go
@@ -1,0 +1,185 @@
+package tui
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestDismissConfirmYes(t *testing.T) {
+	var dismissed string
+	deps := Deps{
+		Load:    func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
+		Dismiss: func(id string) error { dismissed = id; return nil },
+	}
+	m := attentionModel(t, deps, promptSnap(choicePrompt()))
+
+	next, _ := m.Update(key("d"))
+	m = next.(Model)
+	if m.mode != modeConfirmDismiss {
+		t.Fatalf("d should open the dismiss confirm, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "Delete this prompt?") {
+		t.Fatalf("confirm prompt missing:\n%s", m.View())
+	}
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("y should submit a dismiss command")
+	}
+	_ = cmd()
+	if dismissed != "choice.p" {
+		t.Fatalf("Dismiss called with %q, want choice.p", dismissed)
+	}
+}
+
+func TestDismissConfirmCancel(t *testing.T) {
+	called := false
+	deps := Deps{
+		Load:    func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
+		Dismiss: func(id string) error { called = true; return nil },
+	}
+	m := attentionModel(t, deps, promptSnap(choicePrompt()))
+
+	next, _ := m.Update(key("d"))
+	m = next.(Model)
+	// 'n' cancels.
+	next, _ = m.Update(key("n"))
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("n should cancel the dismiss, mode=%v", m.mode)
+	}
+	if called {
+		t.Fatal("cancel must not call Dismiss")
+	}
+}
+
+func TestDismissNotFoundTreatedAsSuccess(t *testing.T) {
+	deps := Deps{
+		Load: func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
+		Dismiss: func(id string) error {
+			return fmt.Errorf("interactive prompt %q: %w", id, db.ErrInteractivePromptNotFound)
+		},
+	}
+	m := attentionModel(t, deps, promptSnap(choicePrompt()))
+
+	next, _ := m.Update(key("d"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("a not-found prompt should still close the overlay, mode=%v", m.mode)
+	}
+	if m.actionErr != "" {
+		t.Fatalf("not-found should not surface an error, got %q", m.actionErr)
+	}
+}
+
+func TestDismissRealErrorKeepsOverlay(t *testing.T) {
+	deps := Deps{
+		Load:    func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
+		Dismiss: func(id string) error { return errors.New("database is locked") },
+	}
+	m := attentionModel(t, deps, promptSnap(choicePrompt()))
+
+	next, _ := m.Update(key("d"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeConfirmDismiss {
+		t.Fatalf("a real error should keep the confirm open, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "database is locked") {
+		t.Fatalf("expected the error in view:\n%s", m.View())
+	}
+}
+
+func trainSnapshot() Snapshot {
+	return Snapshot{
+		Trains: []TrainSession{
+			{ID: "train-aaa", Phase: "generating_options", Candidate: "c@v1", Repo: "owner/a"},
+			{ID: "train-bbb", Phase: "run_abandoned", Repo: "owner/b"},
+		},
+		ResourceLocks: []ResourceLock{
+			{Key: "generation:train-aaa", Owner: "pid:1", Stale: false},
+			{Key: "optimizer:train-bbb", Owner: "pid:2", Stale: true},
+		},
+	}
+}
+
+func trainsModel(t *testing.T) Model {
+	t.Helper()
+	deps := Deps{Load: func() (Snapshot, error) { return trainSnapshot(), nil }}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: trainSnapshot(), at: time.Unix(1, 0)})
+	m = next.(Model)
+	// Tab from Attention to Trains.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	return next.(Model)
+}
+
+func TestTrainDetailShowsSessionLocksOnly(t *testing.T) {
+	m := trainsModel(t)
+	if pages[m.selected].page != pageTrains {
+		t.Fatalf("expected to be on the Trains page")
+	}
+	// Open detail for the first train.
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if m.mode != modeTrainDetail {
+		t.Fatalf("enter should open train detail, mode=%v", m.mode)
+	}
+	view := m.View()
+	if !strings.Contains(view, "generating_options") || !strings.Contains(view, "generation:train-aaa") {
+		t.Fatalf("detail should show the session phase and its lock:\n%s", view)
+	}
+	if strings.Contains(view, "optimizer:train-bbb") {
+		t.Fatalf("detail must not show another session's lock:\n%s", view)
+	}
+	// Esc returns to the list.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("esc should leave detail, mode=%v", m.mode)
+	}
+}
+
+func TestTrainLocksMatchWholeSegmentNotPrefix(t *testing.T) {
+	locks := []ResourceLock{
+		{Key: "generation:train-a"},
+		{Key: "generation:train-aaa"},
+		{Key: "skillopt-train:train-a:iter-1"},
+	}
+	got := trainLocks(locks, "train-a")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 locks for train-a (exact segment), got %d: %+v", len(got), got)
+	}
+	for _, l := range got {
+		if l.Key == "generation:train-aaa" {
+			t.Fatalf("train-a must not match train-aaa's lock: %+v", got)
+		}
+	}
+}
+
+func TestTrainCursorClampedOnRefresh(t *testing.T) {
+	m := trainsModel(t)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	if m.trainCursor != 1 {
+		t.Fatalf("train cursor should be 1, got %d", m.trainCursor)
+	}
+	next, _ = m.Update(snapshotMsg{snap: Snapshot{}, at: time.Unix(2, 0)})
+	m = next.(Model)
+	if m.trainCursor != 0 {
+		t.Fatalf("train cursor should clamp to 0, got %d", m.trainCursor)
+	}
+}

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -14,6 +15,7 @@ type page int
 
 const (
 	pageAttention page = iota
+	pageTrains
 	pageAgents
 	pageSessions
 	pageJobs
@@ -25,6 +27,7 @@ var pages = []struct {
 	label string
 }{
 	{pageAttention, "Attention"},
+	{pageTrains, "Trains"},
 	{pageAgents, "Agents"},
 	{pageSessions, "Sessions"},
 	{pageJobs, "Jobs"},
@@ -39,6 +42,8 @@ const (
 	modeNormal mode = iota
 	modeAnswerChoice
 	modeAnswerText
+	modeConfirmDismiss
+	modeTrainDetail
 )
 
 const defaultInterval = 5 * time.Second
@@ -57,14 +62,16 @@ type Model struct {
 	loadErr  string
 	inFlight bool
 
-	// Attention page interaction state.
+	// Attention / Trains page interaction state.
 	mode         mode
 	promptCursor int                  // selected row in snap.Prompts on the Attention page
-	active       db.InteractivePrompt // prompt being answered in an overlay
+	trainCursor  int                  // selected row in snap.Trains on the Trains page
+	active       db.InteractivePrompt // prompt being answered/dismissed in an overlay
+	activeTrain  TrainSession         // train shown in modeTrainDetail
 	choiceIdx    int                  // selected choice in modeAnswerChoice
 	input        textinput.Model      // free-text answer in modeAnswerText
-	actionErr    string               // inline error from the last Answer attempt
-	actionBusy   bool                 // an Answer is in flight; suppress re-submit
+	actionErr    string               // inline error from the last Answer/Dismiss attempt
+	actionBusy   bool                 // an action is in flight; suppress re-submit
 }
 
 // New returns a Model ready for tea.NewProgram. It starts in the loading state;
@@ -139,10 +146,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
+			if pages[m.selected].page == pageTrains && len(m.snap.Trains) > 0 {
+				if m.trainCursor > 0 {
+					m.trainCursor--
+				}
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
 		case "down", "j":
 			if pages[m.selected].page == pageAttention && len(m.snap.Prompts) > 0 {
 				if m.promptCursor < len(m.snap.Prompts)-1 {
 					m.promptCursor++
+				}
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
+			if pages[m.selected].page == pageTrains && len(m.snap.Trains) > 0 {
+				if m.trainCursor < len(m.snap.Trains)-1 {
+					m.trainCursor++
 				}
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
@@ -152,6 +173,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if cmd := m.openAnswer(); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
+		case "d":
+			if pages[m.selected].page == pageAttention {
+				m.openDismiss()
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
+		case "enter":
+			if pages[m.selected].page == pageTrains {
+				m.openTrainDetail()
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
@@ -174,6 +207,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, cmd)
 			}
 		}
+	case dismissResultMsg:
+		m.actionBusy = false
+		// A prompt already gone (removed by another terminal or a prior refresh)
+		// is treated as success, since the goal was to remove it.
+		if msg.err != nil && !errors.Is(msg.err, db.ErrInteractivePromptNotFound) {
+			m.actionErr = msg.err.Error()
+		} else {
+			m.mode = modeNormal
+			m.actionErr = ""
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
 	case snapshotMsg:
 		m.inFlight = false
 		if msg.err != nil {
@@ -183,6 +229,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.snap = msg.snap
 			m.loadedAt = msg.at
 			m.clampPromptCursor()
+			m.clampTrainCursor()
 		}
 	case tickMsg:
 		if cmd := m.queueLoad(); cmd != nil {
@@ -231,6 +278,16 @@ func (m *Model) clampPromptCursor() {
 	}
 	if m.promptCursor < 0 {
 		m.promptCursor = 0
+	}
+}
+
+// clampTrainCursor keeps the Trains cursor within the current session list.
+func (m *Model) clampTrainCursor() {
+	if m.trainCursor >= len(m.snap.Trains) {
+		m.trainCursor = len(m.snap.Trains) - 1
+	}
+	if m.trainCursor < 0 {
+		m.trainCursor = 0
 	}
 }
 

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -36,6 +36,7 @@ func sampleSnapshot() Snapshot {
 			{Name: "solo", Runtime: "codex", Repo: "owner/repo", State: "running"},
 		},
 		Jobs:        Jobs{Total: 3, ByState: map[string]int{"failed": 1, "succeeded": 2}},
+		Trains:      []TrainSession{{ID: "train-s1", Phase: "items_ready", Candidate: "smithyx@v3", Repo: "owner/repo"}},
 		BranchLocks: []BranchLock{{Repo: "owner/repo", Branch: "main", Owner: "agent"}},
 		ResourceLocks: []ResourceLock{
 			{Key: "generation:s1", Owner: "pid:1", Stale: false},
@@ -54,8 +55,8 @@ func loadedModel(t *testing.T) Model {
 
 func TestPagesRenderExpectedContent(t *testing.T) {
 	m := loadedModel(t)
-	// Page order: Attention, Agents, Sessions, Jobs, Locks.
-	wants := []string{"pending prompts", "planner", "skillopt-generator", "failed", "branch locks"}
+	// Page order: Attention, Trains, Agents, Sessions, Jobs, Locks.
+	wants := []string{"pending prompts", "train-s1", "planner", "skillopt-generator", "failed", "branch locks"}
 	for i, want := range wants {
 		if i > 0 {
 			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
@@ -104,7 +105,10 @@ func TestLoadErrorKeepsStaleData(t *testing.T) {
 	m := loadedModel(t)
 	next, _ := m.Update(snapshotMsg{err: errors.New("db locked"), at: time.Unix(2, 0)})
 	m = next.(Model)
-	// Move to the Agents page where the stale data is visible.
+	// Move to the Agents page (Attention → Trains → Agents) where the stale
+	// data is visible.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(Model)
 	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = next.(Model)
 	view := m.View()

--- a/internal/cli/tui/trains.go
+++ b/internal/cli/tui/trains.go
@@ -1,0 +1,94 @@
+package tui
+
+import "strings"
+
+// openTrainDetail shows the detail view for the train under the cursor.
+func (m *Model) openTrainDetail() {
+	if pages[m.selected].page != pageTrains || len(m.snap.Trains) == 0 {
+		return
+	}
+	m.activeTrain = m.snap.Trains[m.trainCursor]
+	m.mode = modeTrainDetail
+}
+
+func (m Model) trainsContent() string {
+	if m.mode == modeTrainDetail {
+		return m.trainDetail()
+	}
+	if len(m.snap.Trains) == 0 {
+		return m.loadingOr("No train sessions.", !m.loadedAt.IsZero())
+	}
+	var b strings.Builder
+	for i, t := range m.snap.Trains {
+		cursor := "  "
+		phase := t.Phase
+		if deadTrainPhase(t.Phase) {
+			phase = mutedStyle.Render(t.Phase)
+		}
+		line := t.ID + "  " + phase
+		if i == m.trainCursor {
+			cursor = "▸ "
+			line = selectedRowStyle.Render(t.ID) + "  " + phase
+		}
+		b.WriteString(cursor + line + "\n")
+	}
+	b.WriteString(mutedStyle.Render("enter detail"))
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func (m Model) trainDetail() string {
+	t := m.activeTrain
+	var b strings.Builder
+	b.WriteString(headerStyle.Render(t.ID))
+	b.WriteString("\n\n")
+	rows := [][]string{
+		{"phase", dash(t.Phase)},
+		{"candidate", dash(t.Candidate)},
+		{"repo", dash(t.Repo)},
+	}
+	b.WriteString(renderRows(rows))
+	b.WriteByte('\n')
+	b.WriteString(headerStyle.Render("locks"))
+	b.WriteByte('\n')
+	locks := trainLocks(m.snap.ResourceLocks, t.ID)
+	if len(locks) == 0 {
+		b.WriteString(mutedStyle.Render("none"))
+		b.WriteByte('\n')
+	} else {
+		for _, l := range locks {
+			state := "active"
+			if l.Stale {
+				state = redStyle.Render("stale")
+			}
+			b.WriteString(l.Key + "  " + state + "\n")
+		}
+	}
+	return b.String()
+}
+
+// trainLocks returns the resource locks for a session. Train lock keys have the
+// form "<resource>:<sessionID>[:<iterationID>]", so the session id is matched as
+// a whole colon-delimited segment — substring matching would cross-match
+// sessions whose ids are prefixes of one another (e.g. "s1" vs "s12").
+func trainLocks(locks []ResourceLock, sessionID string) []ResourceLock {
+	out := []ResourceLock{}
+	for _, l := range locks {
+		for _, seg := range strings.Split(l.Key, ":") {
+			if seg == sessionID {
+				out = append(out, l)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func deadTrainPhase(phase string) bool {
+	switch phase {
+	case "run_abandoned", "candidate_rejected", "candidate_promoted":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -73,6 +73,8 @@ func (m Model) content() string {
 	switch pages[m.selected].page {
 	case pageAttention:
 		b.WriteString(m.attentionContent())
+	case pageTrains:
+		b.WriteString(m.trainsContent())
 	case pageAgents:
 		b.WriteString(m.agentsContent())
 	case pageSessions:
@@ -89,14 +91,21 @@ func (m Model) content() string {
 
 // footerHelp is the key-hint line for the current page/mode.
 func (m Model) footerHelp() string {
-	if m.mode == modeAnswerChoice {
+	switch m.mode {
+	case modeAnswerChoice:
 		return "↑/↓ choose  enter submit  esc cancel"
-	}
-	if m.mode == modeAnswerText {
+	case modeAnswerText:
 		return "type answer  enter submit  esc cancel"
+	case modeConfirmDismiss:
+		return "y delete  n/esc cancel"
+	case modeTrainDetail:
+		return "enter/esc back"
 	}
-	if pages[m.selected].page == pageAttention {
-		return "tab/←→ page  ↑/↓ select  a answer  r refresh  q quit"
+	switch pages[m.selected].page {
+	case pageAttention:
+		return "tab/←→ page  ↑/↓ select  a answer  d dismiss  r refresh  q quit"
+	case pageTrains:
+		return "tab/←→ page  ↑/↓ select  enter detail  r refresh  q quit"
 	}
 	return "tab/←→ page  j/k or wheel scroll  r refresh  q quit"
 }


### PR DESCRIPTION
Part of #226 (interactive TUI). **Task 4 of 7.**

## WHAT
Adds prompt dismissal from the Attention page and a per-session Trains detail view.

## CHANGES
- Attention: `d` opens a `y/n` dismiss confirm → `Deps.Dismiss`. A prompt already gone (`ErrInteractivePromptNotFound`) is treated as success and refreshes; a real error keeps the confirm open with the message inline. `actionBusy` guards double-submit.
- New **Trains** page (second in the sidebar): selectable session rows with dead phases (`run_abandoned`/`candidate_rejected`/`candidate_promoted`) dimmed; `enter` opens a detail view (phase, candidate, repo, and that session's resource locks); `esc`/`enter` returns.
- `trainLocks` matches the session id as a whole colon-delimited segment of the lock key (`<resource>:<sessionID>[:<iterationID>]`), not a substring — a session id that is a prefix of another no longer cross-matches its locks.
- `trainCursor` + `clampTrainCursor`; per-page/mode footer help updated.

## RESULTS
- `go test ./internal/cli/tui` green (incl. dismiss y/n/not-found/real-error, train detail lock isolation, the prefix-match regression test, cursor clamps).
- `go vet` / `gofmt` / `git diff --check` clean.

## RISK
Low; confined to the `tui` package, reachable only on a real terminal.

## /code-review
High-effort correctness review found **one real bug**, now fixed: `trainLocks` used `strings.Contains`, which would cross-match locks between sessions whose ids are prefixes of each other (e.g. `train-a` vs `train-aaa`). Changed to whole-segment matching and added a regression test. Page-index shift (Trains at index 1) verified safe — all cursor/page logic keys off the page enum, not raw indices; esc/enter exit detail correctly; the not-found sentinel propagates through the `Deps.Dismiss` closure via `%w`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)