### PR TITLE
cli: train init tui form model (TUI task 5)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -790,6 +790,14 @@ func skillOptTrainInitWizardReadLine(lines <-chan skillOptTrainInitWizardLine, s
 // returns status "ok" (use value), "custom" (template custom-file selected, the
 // caller must read the path), or "reask".
 func skillOptTrainInitWizardInterpret(field, text string, prompt db.InteractivePrompt, templateChoices []skillopt.TrainInitTemplateChoice) (string, string) {
+	return skillOptTrainInitInterpretCore(field, text, prompt, templateChoices)
+}
+
+// skillOptTrainInitInterpretCore is the shared validation core for a train-init
+// field answer, used by both the line wizard and the bubbletea TUI form. It
+// returns status "ok" (use value), "custom" (template custom-file selected), or
+// "reask".
+func skillOptTrainInitInterpretCore(field, text string, prompt db.InteractivePrompt, templateChoices []skillopt.TrainInitTemplateChoice) (string, string) {
 	value := strings.TrimSpace(text)
 	if field == "template" {
 		if value == "" {

--- a/internal/cli/tui/traininit.go
+++ b/internal/cli/tui/traininit.go
@@ -1,0 +1,336 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+type tiState int
+
+const (
+	tiField tiState = iota
+	tiCustomPath
+	tiConfirm
+	tiDone
+)
+
+// defaultTrainInitPoll is how often the form checks whether the current field's
+// prompt was answered externally (mirrors the line wizard's 200ms ticker).
+const defaultTrainInitPoll = 200 * time.Millisecond
+
+// TrainInitModel is the bubbletea form for `skillopt train init`. It walks the
+// fields one at a time, publishing a prompt record per field so an agent can
+// answer it with `gitmoot interactive answer` while a human uses the keyboard.
+type TrainInitModel struct {
+	store     PromptStore
+	fields    []Field
+	summary   func(answers map[string]string) [][]string
+	interpret Interpret
+	poll      time.Duration
+
+	state     tiState
+	idx       int
+	gen       int // bumped on every field transition; stale poll msgs are dropped
+	answers   map[string]string
+	external  bool
+	flash     string // "answered externally by <source>"
+	inlineErr string
+
+	input     textinput.Model
+	choiceIdx int
+
+	pendingPromptID string
+	aborted         bool
+}
+
+// NewTrainInit builds the form. summary renders the confirm-screen rows from the
+// collected answers (the caller folds in defaulted fields like task_kind/mode).
+func NewTrainInit(store PromptStore, fields []Field, summary func(map[string]string) [][]string, interpret Interpret, poll time.Duration) TrainInitModel {
+	if poll <= 0 {
+		poll = defaultTrainInitPoll
+	}
+	return TrainInitModel{
+		store:     store,
+		fields:    fields,
+		summary:   summary,
+		interpret: interpret,
+		poll:      poll,
+		answers:   map[string]string{},
+	}
+}
+
+// Result is read by the caller after the program exits.
+func (m TrainInitModel) Result() Result {
+	return Result{Values: m.answers, Aborted: m.aborted, ExternallyAnswered: m.external}
+}
+
+// Init kicks off field setup. The actual enterField mutation happens in Update
+// (on initMsg) because Init's value receiver cannot persist state changes.
+func (m TrainInitModel) Init() tea.Cmd {
+	return func() tea.Msg { return initMsg{} }
+}
+
+func (m TrainInitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case initMsg:
+		if len(m.fields) == 0 {
+			m.state = tiConfirm
+			return m, nil
+		}
+		return m, m.enterField(0)
+	case tea.KeyMsg:
+		return m.updateKey(msg)
+	case promptReadyMsg:
+		if msg.gen == m.gen && msg.err != nil {
+			m.inlineErr = "prompt publish failed: " + msg.err.Error()
+		}
+		return m, nil
+	case pollTickMsg:
+		if msg.gen != m.gen {
+			return m, nil // stale tick from a field we already left
+		}
+		return m, checkPromptCmd(m.store, m.pendingPromptID, m.gen)
+	case pollResultMsg:
+		if msg.gen != m.gen {
+			return m, nil
+		}
+		if msg.err == nil && msg.prompt.State == db.InteractivePromptStateResolved {
+			m.external = true
+			m.flash = "answered externally by " + emptyOr(msg.prompt.AnswerSource, "agent")
+			return m.commit(msg.prompt.AnswerValue)
+		}
+		// Not answered yet (or the record is not visible yet) — keep polling.
+		return m, pollTick(m.poll, m.gen)
+	}
+	return m, nil
+}
+
+func (m TrainInitModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "ctrl+c" {
+		return m.abort()
+	}
+	// A keypress dismisses a lingering "answered externally" flash.
+	m.flash = ""
+	switch m.state {
+	case tiField:
+		return m.updateFieldKey(msg)
+	case tiCustomPath:
+		return m.updateCustomPathKey(msg)
+	case tiConfirm:
+		switch msg.String() {
+		case "y", "Y", "enter":
+			m.state = tiDone
+			return m, tea.Quit
+		case "n", "N", "esc":
+			return m.abort()
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m TrainInitModel) updateFieldKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	field := m.fields[m.idx]
+	if msg.String() == "esc" {
+		return m.abort()
+	}
+	if field.Kind == FieldText {
+		if msg.String() == "enter" {
+			value, status := m.validate(field.Name, m.input.Value())
+			if status != "ok" {
+				m.inlineErr = "value required"
+				return m, nil
+			}
+			return m.commit(value)
+		}
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		return m, cmd
+	}
+	// FieldChoice / FieldTemplate: a cursor list.
+	switch msg.String() {
+	case "up", "k":
+		if m.choiceIdx > 0 {
+			m.choiceIdx--
+		}
+	case "down", "j":
+		if m.choiceIdx < len(field.Choices)-1 {
+			m.choiceIdx++
+		}
+	case "enter":
+		choice := field.Choices[m.choiceIdx]
+		if choice.Custom {
+			m.state = tiCustomPath
+			m.inlineErr = ""
+			m.input = newPathInput()
+			return m, m.input.Focus()
+		}
+		return m.commit(choice.Value)
+	}
+	return m, nil
+}
+
+func (m TrainInitModel) updateCustomPathKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		// Back to the template list; the prompt record stays live (same gen).
+		m.state = tiField
+		m.inlineErr = ""
+		return m, nil
+	case "enter":
+		value := strings.TrimSpace(m.input.Value())
+		if value == "" {
+			m.inlineErr = "enter a template id, version, or file path"
+			return m, nil
+		}
+		return m.commit(value)
+	}
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	return m, cmd
+}
+
+func (m TrainInitModel) validate(field, text string) (string, string) {
+	if m.interpret != nil {
+		return m.interpret(field, text)
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", "reask"
+	}
+	return strings.TrimSpace(text), "ok"
+}
+
+// commit records the answer for the current field, deletes its prompt record,
+// and advances to the next field or the confirm screen.
+func (m TrainInitModel) commit(value string) (tea.Model, tea.Cmd) {
+	field := m.fields[m.idx]
+	m.answers[field.Name] = value
+	cmds := []tea.Cmd{deletePromptCmd(m.store, field.Prompt.ID)}
+	if m.idx+1 < len(m.fields) {
+		cmds = append(cmds, m.enterField(m.idx+1))
+		return m, tea.Batch(cmds...)
+	}
+	// All fields answered → confirm (auto-accept when an agent drove the form).
+	m.gen++
+	m.pendingPromptID = ""
+	if m.external {
+		m.state = tiDone
+		cmds = append(cmds, tea.Quit)
+		return m, tea.Batch(cmds...)
+	}
+	m.state = tiConfirm
+	return m, tea.Batch(cmds...)
+}
+
+// enterField sets up the widget for field i, publishes its prompt record, and
+// starts the external-answer poll. It mutates m through the pointer receiver and
+// returns the batched commands.
+func (m *TrainInitModel) enterField(i int) tea.Cmd {
+	m.state = tiField
+	m.idx = i
+	m.gen++
+	// Note: m.flash is intentionally NOT reset here, so an "answered externally"
+	// flash set just before advancing remains visible on the next field until the
+	// user presses a key (cleared in updateKey).
+	m.inlineErr = ""
+	field := m.fields[i]
+	m.pendingPromptID = field.Prompt.ID
+	cmds := []tea.Cmd{
+		upsertPromptCmd(m.store, field.Prompt, m.gen),
+		pollTick(m.poll, m.gen),
+	}
+	if field.Kind == FieldText {
+		ti := textinput.New()
+		ti.SetValue(field.Default)
+		ti.CursorEnd()
+		m.input = ti
+		cmds = append(cmds, m.input.Focus())
+	} else {
+		m.choiceIdx = choiceIndex(field.Choices, field.Default)
+	}
+	return tea.Batch(cmds...)
+}
+
+func (m TrainInitModel) abort() (tea.Model, tea.Cmd) {
+	m.aborted = true
+	m.state = tiDone
+	cmds := []tea.Cmd{tea.Quit}
+	if m.pendingPromptID != "" {
+		cmds = append(cmds, deletePromptCmd(m.store, m.pendingPromptID))
+	}
+	m.gen++
+	return m, tea.Batch(cmds...)
+}
+
+func newPathInput() textinput.Model {
+	ti := textinput.New()
+	ti.Placeholder = "template id, version, or file path"
+	return ti
+}
+
+func choiceIndex(choices []Choice, value string) int {
+	if value == "" {
+		return 0 // no default → first item (avoids matching a Custom entry's empty Value)
+	}
+	for i, c := range choices {
+		if c.Value == value {
+			return i
+		}
+	}
+	return 0
+}
+
+func emptyOr(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+// --- messages and commands ---
+
+// initMsg triggers first-field setup inside Update (where mutations persist).
+type initMsg struct{}
+
+type promptReadyMsg struct {
+	gen int
+	err error
+}
+
+type pollTickMsg struct{ gen int }
+
+type pollResultMsg struct {
+	gen    int
+	prompt db.InteractivePrompt
+	err    error
+}
+
+type promptGoneMsg struct{ err error }
+
+func upsertPromptCmd(store PromptStore, prompt db.InteractivePrompt, gen int) tea.Cmd {
+	return func() tea.Msg {
+		return promptReadyMsg{gen: gen, err: store.UpsertInteractivePrompt(context.Background(), prompt)}
+	}
+}
+
+func pollTick(d time.Duration, gen int) tea.Cmd {
+	return tea.Tick(d, func(time.Time) tea.Msg { return pollTickMsg{gen: gen} })
+}
+
+func checkPromptCmd(store PromptStore, id string, gen int) tea.Cmd {
+	return func() tea.Msg {
+		prompt, err := store.GetInteractivePrompt(context.Background(), id)
+		return pollResultMsg{gen: gen, prompt: prompt, err: err}
+	}
+}
+
+func deletePromptCmd(store PromptStore, id string) tea.Cmd {
+	return func() tea.Msg {
+		return promptGoneMsg{err: store.DeleteInteractivePrompt(context.Background(), id)}
+	}
+}

--- a/internal/cli/tui/traininit_field.go
+++ b/internal/cli/tui/traininit_field.go
@@ -1,0 +1,57 @@
+package tui
+
+import (
+	"context"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// FieldKind selects the input widget for a train-init field.
+type FieldKind int
+
+const (
+	// FieldText collects free text in a single-line input.
+	FieldText FieldKind = iota
+	// FieldChoice picks one of a fixed list of values.
+	FieldChoice
+	// FieldTemplate is a choice list whose final "Custom file" entry switches to
+	// a free-text path sub-state.
+	FieldTemplate
+)
+
+// Choice is one selectable option in a FieldChoice/FieldTemplate list.
+type Choice struct {
+	Value  string // value stored as the answer
+	Label  string // display text
+	Custom bool   // template "Custom file" sentinel → path sub-state
+}
+
+// Field describes one train-init question the form walks through.
+type Field struct {
+	Name    string               // field key, e.g. "name", "template"
+	Label   string               // human header, e.g. "Training name"
+	Kind    FieldKind            //
+	Prompt  db.InteractivePrompt // record upserted so an agent can answer externally
+	Choices []Choice             // for FieldChoice/FieldTemplate
+	Default string               // text prefill / preselected choice value
+}
+
+// PromptStore is the subset of *db.Store the form needs to publish a prompt
+// record per field and observe external answers.
+type PromptStore interface {
+	UpsertInteractivePrompt(ctx context.Context, prompt db.InteractivePrompt) error
+	GetInteractivePrompt(ctx context.Context, id string) (db.InteractivePrompt, error)
+	DeleteInteractivePrompt(ctx context.Context, id string) error
+}
+
+// Interpret validates a free-text answer for a field, returning the cleaned
+// value and a status of "ok" or "reask". The cli wraps skillopt's interpret
+// core so the TUI and line wizard share identical validation.
+type Interpret func(field, text string) (value, status string)
+
+// Result is what the caller reads after the program exits.
+type Result struct {
+	Values             map[string]string
+	Aborted            bool
+	ExternallyAnswered bool
+}

--- a/internal/cli/tui/traininit_test.go
+++ b/internal/cli/tui/traininit_test.go
@@ -1,0 +1,283 @@
+package tui
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+type fakeStore struct {
+	upserts  []string
+	deletes  []string
+	resolved map[string]db.InteractivePrompt
+}
+
+func newFakeStore() *fakeStore { return &fakeStore{resolved: map[string]db.InteractivePrompt{}} }
+
+func (f *fakeStore) UpsertInteractivePrompt(_ context.Context, p db.InteractivePrompt) error {
+	f.upserts = append(f.upserts, p.ID)
+	return nil
+}
+
+func (f *fakeStore) GetInteractivePrompt(_ context.Context, id string) (db.InteractivePrompt, error) {
+	if p, ok := f.resolved[id]; ok {
+		return p, nil
+	}
+	return db.InteractivePrompt{ID: id, State: db.InteractivePromptStatePending}, nil
+}
+
+func (f *fakeStore) DeleteInteractivePrompt(_ context.Context, id string) error {
+	f.deletes = append(f.deletes, id)
+	return nil
+}
+
+func tiFields() []Field {
+	return []Field{
+		{Name: "name", Label: "Training name", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "ti.name"}},
+		{Name: "template", Label: "Template", Kind: FieldTemplate, Prompt: db.InteractivePrompt{ID: "ti.template"}, Choices: []Choice{
+			{Value: "planner", Label: "planner"},
+			{Value: "writer", Label: "writer"},
+			{Custom: true, Label: "Custom file"},
+		}},
+		{Name: "preview", Label: "Preview", Kind: FieldChoice, Prompt: db.InteractivePrompt{ID: "ti.preview"}, Default: "text-table", Choices: []Choice{
+			{Value: "none", Label: "none"},
+			{Value: "text-table", Label: "text-table"},
+			{Value: "vue", Label: "vue"},
+		}},
+	}
+}
+
+func tiSummary(answers map[string]string) [][]string {
+	return [][]string{{"name", answers["name"]}, {"template", answers["template"]}, {"preview", answers["preview"]}}
+}
+
+func startTI(t *testing.T, store PromptStore, fields []Field) TrainInitModel {
+	t.Helper()
+	m := NewTrainInit(store, fields, tiSummary, nil, time.Millisecond)
+	next, _ := m.Update(initMsg{})
+	tm := next.(TrainInitModel)
+	if tm.state != tiField || tm.idx != 0 {
+		t.Fatalf("expected first field active, state=%v idx=%d", tm.state, tm.idx)
+	}
+	return tm
+}
+
+func TestTrainInitTextSubmitAdvances(t *testing.T) {
+	m := startTI(t, newFakeStore(), tiFields())
+	next, _ := m.Update(key("smithyx"))
+	m = next.(TrainInitModel)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainInitModel)
+	if m.Result().Values["name"] != "smithyx" {
+		t.Fatalf("name not recorded: %+v", m.Result().Values)
+	}
+	if m.idx != 1 || m.fields[m.idx].Name != "template" {
+		t.Fatalf("expected to advance to template, idx=%d", m.idx)
+	}
+}
+
+func TestTrainInitEmptyTextInlineError(t *testing.T) {
+	m := startTI(t, newFakeStore(), tiFields())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainInitModel)
+	if m.idx != 0 || m.state != tiField {
+		t.Fatalf("empty submit must not advance, idx=%d state=%v", m.idx, m.state)
+	}
+	if m.inlineErr == "" || !strings.Contains(m.View(), m.inlineErr) {
+		t.Fatalf("expected inline error in view:\n%s", m.View())
+	}
+}
+
+func TestTrainInitChoiceDefaultPreselected(t *testing.T) {
+	m := startTI(t, newFakeStore(), tiFields())
+	// name → template → preview.
+	m = advanceText(t, m, "smithyx")
+	m = advanceChoice(t, m) // template: select first (planner)
+	if m.fields[m.idx].Name != "preview" {
+		t.Fatalf("expected preview field, got %s", m.fields[m.idx].Name)
+	}
+	if m.choiceIdx != 1 {
+		t.Fatalf("default 'text-table' should preselect idx 1, got %d", m.choiceIdx)
+	}
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainInitModel)
+	if m.Result().Values["preview"] != "text-table" {
+		t.Fatalf("preview answer = %q", m.Result().Values["preview"])
+	}
+}
+
+func TestTrainInitTemplateCustomFile(t *testing.T) {
+	m := startTI(t, newFakeStore(), tiFields())
+	m = advanceText(t, m, "smithyx")
+	// On template field: move to "Custom file" (index 2).
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(TrainInitModel)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(TrainInitModel)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainInitModel)
+	if m.state != tiCustomPath {
+		t.Fatalf("custom file should open the path sub-state, state=%v", m.state)
+	}
+	// Esc returns to the list, prompt record still pending (same field).
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(TrainInitModel)
+	if m.state != tiField || m.idx != 1 {
+		t.Fatalf("esc should return to the template list, state=%v idx=%d", m.state, m.idx)
+	}
+	// Re-open and submit a path.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainInitModel)
+	next, _ = m.Update(key("./my/template.md"))
+	m = next.(TrainInitModel)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainInitModel)
+	if m.Result().Values["template"] != "./my/template.md" {
+		t.Fatalf("custom path answer = %q", m.Result().Values["template"])
+	}
+}
+
+func TestTrainInitExternalAnswerAdvancesWithFlash(t *testing.T) {
+	m := startTI(t, newFakeStore(), tiFields())
+	resolved := db.InteractivePrompt{ID: "ti.name", State: db.InteractivePromptStateResolved, AnswerValue: "remote-name", AnswerSource: "agent"}
+	next, _ := m.Update(pollResultMsg{gen: m.gen, prompt: resolved})
+	m = next.(TrainInitModel)
+	if m.Result().Values["name"] != "remote-name" {
+		t.Fatalf("external answer not recorded: %+v", m.Result().Values)
+	}
+	if !m.external {
+		t.Fatal("external flag should be set")
+	}
+	if !strings.Contains(m.flash, "answered externally by agent") {
+		t.Fatalf("flash = %q", m.flash)
+	}
+	if m.idx != 1 {
+		t.Fatalf("should advance after external answer, idx=%d", m.idx)
+	}
+}
+
+func TestTrainInitStalePollIgnored(t *testing.T) {
+	m := startTI(t, newFakeStore(), tiFields())
+	before := m.idx
+	resolved := db.InteractivePrompt{ID: "ti.name", State: db.InteractivePromptStateResolved, AnswerValue: "x"}
+	next, _ := m.Update(pollResultMsg{gen: m.gen - 1, prompt: resolved})
+	m = next.(TrainInitModel)
+	if m.idx != before || len(m.Result().Values) != 0 {
+		t.Fatalf("stale poll result must be ignored, idx=%d values=%+v", m.idx, m.Result().Values)
+	}
+	_, cmd := m.Update(pollTickMsg{gen: m.gen - 1})
+	if cmd != nil {
+		t.Fatal("stale tick should produce no command")
+	}
+}
+
+func TestTrainInitConfirmAcceptDeclineAbort(t *testing.T) {
+	single := []Field{{Name: "name", Label: "Name", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "ti.name"}}}
+
+	// Accept.
+	m := startTI(t, newFakeStore(), single)
+	m = advanceText(t, m, "n")
+	if m.state != tiConfirm {
+		t.Fatalf("last field should reach confirm, state=%v", m.state)
+	}
+	next, _ := m.Update(key("y"))
+	m = next.(TrainInitModel)
+	if m.state != tiDone || m.Result().Aborted {
+		t.Fatalf("y should accept: state=%v aborted=%v", m.state, m.Result().Aborted)
+	}
+
+	// Decline.
+	m = startTI(t, newFakeStore(), single)
+	m = advanceText(t, m, "n")
+	next, _ = m.Update(key("n"))
+	m = next.(TrainInitModel)
+	if !m.Result().Aborted {
+		t.Fatal("n should abort at confirm")
+	}
+
+	// Esc aborts from a field.
+	m = startTI(t, newFakeStore(), single)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(TrainInitModel)
+	if !m.Result().Aborted {
+		t.Fatal("esc should abort")
+	}
+}
+
+func TestTrainInitAutoAcceptWhenExternallyAnswered(t *testing.T) {
+	single := []Field{{Name: "name", Label: "Name", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "ti.name"}}}
+	m := startTI(t, newFakeStore(), single)
+	resolved := db.InteractivePrompt{ID: "ti.name", State: db.InteractivePromptStateResolved, AnswerValue: "x", AnswerSource: "agent"}
+	next, _ := m.Update(pollResultMsg{gen: m.gen, prompt: resolved})
+	m = next.(TrainInitModel)
+	if m.state != tiDone {
+		t.Fatalf("externally-answered last field should auto-accept, state=%v", m.state)
+	}
+	if m.Result().Aborted || !m.Result().ExternallyAnswered {
+		t.Fatalf("result = %+v", m.Result())
+	}
+}
+
+func TestTrainInitProgressHeader(t *testing.T) {
+	m := startTI(t, newFakeStore(), tiFields())
+	if !strings.Contains(m.View(), "[1/3]") {
+		t.Fatalf("expected progress header:\n%s", m.View())
+	}
+}
+
+// TestTrainInitPromptCmdsAgainstRealStore proves the upsert/check/delete commands
+// drive real SQL and observe an external answer, one prompt at a time.
+func TestTrainInitPromptCmdsAgainstRealStore(t *testing.T) {
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+
+	prompt := db.InteractivePrompt{ID: "ti.name", Question: "Training name?", Required: true}
+	if msg := upsertPromptCmd(store, prompt, 1)(); msg.(promptReadyMsg).err != nil {
+		t.Fatalf("upsert: %v", msg.(promptReadyMsg).err)
+	}
+	res := checkPromptCmd(store, "ti.name", 1)().(pollResultMsg)
+	if res.err != nil || res.prompt.State != db.InteractivePromptStatePending {
+		t.Fatalf("expected pending, got state=%q err=%v", res.prompt.State, res.err)
+	}
+	if _, err := store.AnswerInteractivePrompt(context.Background(), "ti.name", "remote", "agent"); err != nil {
+		t.Fatalf("answer: %v", err)
+	}
+	res = checkPromptCmd(store, "ti.name", 1)().(pollResultMsg)
+	if res.prompt.State != db.InteractivePromptStateResolved || res.prompt.AnswerValue != "remote" {
+		t.Fatalf("expected resolved 'remote', got %+v", res.prompt)
+	}
+	if msg := deletePromptCmd(store, "ti.name")(); msg.(promptGoneMsg).err != nil {
+		t.Fatalf("delete: %v", msg.(promptGoneMsg).err)
+	}
+	remaining, err := store.ListInteractivePrompts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("prompt should be gone: %+v", remaining)
+	}
+}
+
+// advanceText types value into the current text field and submits.
+func advanceText(t *testing.T, m TrainInitModel, value string) TrainInitModel {
+	t.Helper()
+	next, _ := m.Update(key(value))
+	m = next.(TrainInitModel)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	return next.(TrainInitModel)
+}
+
+// advanceChoice selects the current choice (enter) on a choice/template field.
+func advanceChoice(t *testing.T, m TrainInitModel) TrainInitModel {
+	t.Helper()
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	return next.(TrainInitModel)
+}

--- a/internal/cli/tui/traininit_view.go
+++ b/internal/cli/tui/traininit_view.go
@@ -1,0 +1,94 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// View renders the current form step.
+func (m TrainInitModel) View() string {
+	switch m.state {
+	case tiConfirm:
+		return m.confirmView()
+	case tiDone:
+		return ""
+	case tiCustomPath:
+		return m.customPathView()
+	default:
+		return m.fieldView()
+	}
+}
+
+func (m TrainInitModel) fieldView() string {
+	field := m.fields[m.idx]
+	var b strings.Builder
+	b.WriteString(headerStyle.Render(fmt.Sprintf("[%d/%d] %s", m.idx+1, len(m.fields), field.Label)))
+	b.WriteByte('\n')
+	b.WriteString(mutedStyle.Render("answer from another terminal: gitmoot interactive answer " + field.Prompt.ID + " <value>"))
+	b.WriteString("\n\n")
+
+	if field.Kind == FieldText {
+		b.WriteString(m.input.View())
+		b.WriteByte('\n')
+	} else {
+		for i, choice := range field.Choices {
+			cursor, label := "  ", choice.Label
+			if i == m.choiceIdx {
+				cursor, label = "▸ ", selectedRowStyle.Render(choice.Label)
+			}
+			if choice.Value != "" && choice.Value == field.Default {
+				label += mutedStyle.Render(" (default)")
+			}
+			b.WriteString(cursor + label + "\n")
+		}
+	}
+
+	b.WriteString(m.statusLines())
+	b.WriteString("\n")
+	if field.Kind == FieldText {
+		b.WriteString(mutedStyle.Render("enter submit  esc abort"))
+	} else {
+		b.WriteString(mutedStyle.Render("↑/↓ choose  enter select  esc abort"))
+	}
+	return b.String()
+}
+
+func (m TrainInitModel) customPathView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("Custom template"))
+	b.WriteString("\n\n")
+	b.WriteString(m.input.View())
+	b.WriteByte('\n')
+	b.WriteString(m.statusLines())
+	b.WriteString("\n")
+	b.WriteString(mutedStyle.Render("enter use  esc back"))
+	return b.String()
+}
+
+func (m TrainInitModel) confirmView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("Review"))
+	b.WriteString("\n\n")
+	for _, row := range m.summary(m.answers) {
+		b.WriteString("  " + strings.Join(row, ": ") + "\n")
+	}
+	b.WriteByte('\n')
+	b.WriteString("Create scaffold? [Y/n]")
+	return b.String()
+}
+
+// statusLines renders the inline error and the external-answer flash, each on
+// its own line when present.
+func (m TrainInitModel) statusLines() string {
+	var b strings.Builder
+	if m.inlineErr != "" {
+		b.WriteString("\n")
+		b.WriteString(errorStyle.Render(m.inlineErr))
+		b.WriteByte('\n')
+	}
+	if m.flash != "" {
+		b.WriteString(greenStyle.Render(m.flash))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}


### PR DESCRIPTION
Part of #226 (interactive TUI). **Task 5 of 7.**

## WHAT
Adds the bubbletea form model for `skillopt train init` and extracts the shared validation core. Ships **dark** — nothing dispatches to the model yet (wiring is Task 6), so no user-facing change.

## CHANGES
- `skillopt.go`: extract `skillOptTrainInitInterpretCore`; `skillOptTrainInitWizardInterpret` is now a one-line wrapper, so `TestSkillOptTrainInitWizardInterpret{Choice,Template}` pass unchanged.
- `traininit_field.go`: public surface — `FieldKind`, `Choice`, `Field`, `PromptStore` interface (satisfied by `*db.Store`), `Interpret`, `Result`.
- `traininit.go`: `TrainInitModel` state machine — per-field text input / cursor list, template "Custom file" → path sub-state, confirm screen (auto-accepts when externally answered, matching the line wizard). A prompt record is upserted per field and polled via `tea.Tick` for an external `gitmoot interactive answer`; a `gen` counter drops stale poll messages. First-field setup runs on an `initMsg` in `Update` because the value-receiver `Init` cannot persist mutations.
- `traininit_view.go`: `[n/N]` header, a per-field tip showing the concrete prompt id, inline validation error, green "answered externally by &lt;source&gt;" flash.

## RESULTS
- `go test ./internal/cli/tui` green (text submit/empty, choice default preselect, template custom-file + esc-back, external-answer advance + flash, stale-gen drop, confirm accept/decline/abort, auto-accept-external, progress header, and the upsert/check/delete commands against a real sqlite store proving one-prompt-at-a-time).
- `go test ./internal/cli -run SkillOptTrainInitWizardInterpret` green (wrapper unchanged); `go vet` / `gofmt` / `git diff --check` clean.

## RISK
Low; ships dark. The agent-answer contract is preserved (per-field record + poll), which Task 6 will exercise via dispatch.

## /code-review
High-effort correctness review found **no bugs**. Two issues were caught by the test pass and fixed before review: `choiceIndex` matched the template "Custom file" entry's empty `Value` against an empty default (now returns 0 for empty), and `enterField` was wiping the external-answer flash on advance (now preserved until the next keypress). Also dropped unused `width`/`height` fields. Verified: value-receiver mutation persists through `Init→initMsg`/`commit→enterField`, the `gen` guard prevents cross-field poll resolution, and abort during the custom-path still deletes the live prompt record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)