### PR TITLE
skillopt: train init tui dispatch (TUI task 6)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -236,6 +236,23 @@ func runSkillOptTrainInitCreate(args []string, stdout, stderr io.Writer) int {
 			}
 			printSkillOptTrainInitPromptInstructions(stdout, *home, rerunCommand, created)
 			return 0
+		case skillOptTrainInitTUICapable():
+			// A real terminal: run the interactive form. Ordered before the line
+			// wizard so that under `go test` (pipes, not char devices) capable() is
+			// false and the existing wizard path runs unchanged.
+			if err := runSkillOptTrainInitTUI(*home, promptScope, stdout, &values, missing); err != nil {
+				if errors.Is(err, errSkillOptTrainInitAborted) {
+					writeLine(stdout, "aborted: no scaffold written")
+					return 0
+				}
+				fmt.Fprintf(stderr, "skillopt train init: %v\n", err)
+				return 1
+			}
+			if stillMissing := missingSkillOptTrainInitInputs(values); len(stillMissing) > 0 {
+				fmt.Fprintf(stderr, "skillopt train init missing required fields: %s\n", strings.Join(stillMissing, ", "))
+				fmt.Fprintf(stderr, "example: %s\n", skillOptTrainInitExampleCommand(values.Name))
+				return 2
+			}
 		case skillOptTrainInitInteractive():
 			if err := runSkillOptTrainInitWizard(*home, promptScope, skillOptTrainInitStdin(), stdout, &values, missing); err != nil {
 				if errors.Is(err, errSkillOptTrainInitAborted) {

--- a/internal/cli/skillopt_tui.go
+++ b/internal/cli/skillopt_tui.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jerryfane/gitmoot/internal/cli/tui"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// skillOptTrainInitTUICapable reports whether the interactive train-init form
+// should run: both stdin and stdout must be terminals (bubbletea needs raw-mode
+// keys and a screen), and the user must not have opted out. It is a var so
+// dispatch tests can stub it.
+var skillOptTrainInitTUICapable = func() bool {
+	if os.Getenv("GITMOOT_NO_TUI") != "" || os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	in, errIn := os.Stdin.Stat()
+	out, errOut := os.Stdout.Stat()
+	return errIn == nil && errOut == nil &&
+		in.Mode()&os.ModeCharDevice != 0 && out.Mode()&os.ModeCharDevice != 0
+}
+
+// runSkillOptTrainInitTUI runs the bubbletea form to fill the missing fields. It
+// is a var so dispatch tests can stub the whole run.
+var runSkillOptTrainInitTUI = runSkillOptTrainInitTUIImpl
+
+func runSkillOptTrainInitTUIImpl(home, scope string, stdout io.Writer, values *skillOptTrainInitInputs, missing []string) error {
+	return withStore(home, func(store *db.Store) error {
+		fields, err := buildSkillOptTrainInitTUIFields(store, scope, *values, missing)
+		if err != nil {
+			return err
+		}
+		// Belt-and-braces: a Quit batched with a delete command may exit before the
+		// delete runs, so sweep any leftover PENDING records for the form's fields
+		// on the way out. Resolved answers are left for a rerun to consume.
+		defer cleanupSkillOptTrainInitTUIPrompts(store, scope, missing)
+
+		current := *values
+		interpret := func(field, text string) (string, string) {
+			return skillOptTrainInitInterpretCore(field, text, db.InteractivePrompt{}, nil)
+		}
+		summary := func(answers map[string]string) [][]string {
+			return skillOptTrainInitTUISummaryRows(current, answers)
+		}
+		model := tui.NewTrainInit(store, fields, summary, interpret, skillOptTrainInitWizardPoll)
+		final, err := tea.NewProgram(model, tea.WithOutput(stdout)).Run()
+		if err != nil {
+			return err
+		}
+		result := final.(tui.TrainInitModel).Result()
+		if result.Aborted {
+			return errSkillOptTrainInitAborted
+		}
+		applySkillOptTrainInitTUIResult(values, result.Values)
+		return nil
+	})
+}
+
+// buildSkillOptTrainInitTUIFields builds the form fields for the missing inputs,
+// in the same stable order as the line wizard.
+func buildSkillOptTrainInitTUIFields(store *db.Store, scope string, values skillOptTrainInitInputs, missing []string) ([]tui.Field, error) {
+	missingSet := make(map[string]struct{}, len(missing))
+	for _, field := range missing {
+		missingSet[field] = struct{}{}
+	}
+	fields := make([]tui.Field, 0, len(missing))
+	for _, field := range []string{"name", "template", "review_repo", "artifact_kind", "preview", "request"} {
+		if _, ok := missingSet[field]; !ok {
+			continue
+		}
+		descriptor := buildSkillOptTrainInitPrompt(scope, field, values)
+		entry := tui.Field{
+			Name:    field,
+			Label:   skillOptTrainInitWizardLabel(field),
+			Prompt:  descriptor.Prompt,
+			Default: descriptor.Prompt.Default,
+		}
+		switch {
+		case field == "template":
+			choices, err := skillopt.ListTrainInitTemplateChoices(context.Background(), store)
+			if err != nil {
+				return nil, err
+			}
+			entry.Kind = tui.FieldTemplate
+			entry.Label = "Choose a template"
+			for _, choice := range choices {
+				entry.Choices = append(entry.Choices, tui.Choice{Value: choice.ID, Label: skillOptTrainInitTemplateChoiceLabel(choice)})
+			}
+			entry.Choices = append(entry.Choices, tui.Choice{Custom: true, Label: "Custom file"})
+		case len(descriptor.Prompt.Choices) > 0:
+			entry.Kind = tui.FieldChoice
+			for _, choice := range descriptor.Prompt.Choices {
+				entry.Choices = append(entry.Choices, tui.Choice{Value: choice, Label: choice})
+			}
+		default:
+			entry.Kind = tui.FieldText
+		}
+		fields = append(fields, entry)
+	}
+	return fields, nil
+}
+
+// skillOptTrainInitTUISummaryRows renders the confirm-screen rows: each field's
+// collected answer if the form gathered it, otherwise the pre-supplied value
+// (flags / defaults for task_kind and mode).
+func skillOptTrainInitTUISummaryRows(values skillOptTrainInitInputs, answers map[string]string) [][]string {
+	pick := func(field, current string) string {
+		if value, ok := answers[field]; ok {
+			return value
+		}
+		return current
+	}
+	return [][]string{
+		{"name", pick("name", values.Name)},
+		{"template", pick("template", values.Template)},
+		{"review repo", pick("review_repo", values.ReviewRepo)},
+		{"task kind", values.TaskKind},
+		{"artifact kind", pick("artifact_kind", values.ArtifactKind)},
+		{"preview", pick("preview", values.Preview)},
+		{"mode", values.Mode},
+		{"request", firstLine(pick("request", values.Request))},
+	}
+}
+
+// applySkillOptTrainInitTUIResult copies the collected answers back into values.
+func applySkillOptTrainInitTUIResult(values *skillOptTrainInitInputs, answers map[string]string) {
+	for field, value := range answers {
+		switch field {
+		case "name":
+			values.Name = value
+		case "template":
+			values.Template = value
+		case "review_repo":
+			values.ReviewRepo = value
+		case "artifact_kind":
+			values.ArtifactKind = value
+		case "preview":
+			values.Preview = value
+		case "request":
+			values.Request = value
+		}
+	}
+}
+
+// cleanupSkillOptTrainInitTUIPrompts deletes any still-pending prompt records for
+// the form's fields. Resolved records are left intact so a rerun can consume an
+// answer that arrived externally.
+func cleanupSkillOptTrainInitTUIPrompts(store *db.Store, scope string, fields []string) {
+	ctx := context.Background()
+	for _, field := range fields {
+		id := skillOptTrainInitPromptID(scope, field)
+		prompt, err := store.GetInteractivePrompt(ctx, id)
+		if err != nil {
+			continue
+		}
+		if prompt.State == db.InteractivePromptStatePending {
+			_ = store.DeleteInteractivePrompt(ctx, id)
+		}
+	}
+}

--- a/internal/cli/skillopt_tui_test.go
+++ b/internal/cli/skillopt_tui_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// replaceSkillOptTrainInitTUI stubs the TUI gate and (optionally) the runner.
+func replaceSkillOptTrainInitTUI(capable bool, run func(home, scope string, stdout io.Writer, values *skillOptTrainInitInputs, missing []string) error) func() {
+	prevCapable := skillOptTrainInitTUICapable
+	prevRun := runSkillOptTrainInitTUI
+	skillOptTrainInitTUICapable = func() bool { return capable }
+	if run != nil {
+		runSkillOptTrainInitTUI = run
+	}
+	return func() {
+		skillOptTrainInitTUICapable = prevCapable
+		runSkillOptTrainInitTUI = prevRun
+	}
+}
+
+func TestSkillOptTrainInitTUIDispatchWritesScaffold(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	seedPlannerTemplate(t, home)
+
+	restore := replaceSkillOptTrainInitTUI(true, func(_, _ string, _ io.Writer, values *skillOptTrainInitInputs, _ []string) error {
+		values.Name = "tui-flow"
+		values.Template = "planner"
+		values.ReviewRepo = "jerryfane/gitmoot"
+		values.ArtifactKind = "text"
+		values.Preview = "text-table"
+		values.Request = "Improve planner summaries."
+		return nil
+	})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	cfg, err := skillopt.LoadTrainInitConfig(filepath.Join(workspace, ".gitmoot", "skillopt", "tui-flow", "config.toml"))
+	if err != nil {
+		t.Fatalf("LoadTrainInitConfig: %v", err)
+	}
+	if cfg.Name != "tui-flow" || cfg.Template != "planner" || cfg.ReviewRepo != "jerryfane/gitmoot" || cfg.Preview != "text-table" {
+		t.Fatalf("config = %+v", cfg)
+	}
+}
+
+func TestSkillOptTrainInitTUIDispatchAbortWritesNothing(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	seedPlannerTemplate(t, home)
+
+	restore := replaceSkillOptTrainInitTUI(true, func(_, _ string, _ io.Writer, _ *skillOptTrainInitInputs, _ []string) error {
+		return errSkillOptTrainInitAborted
+	})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("abort exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "aborted: no scaffold written") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if _, err := skillopt.LoadTrainInitConfig(filepath.Join(workspace, ".gitmoot", "skillopt", "any", "config.toml")); err == nil {
+		t.Fatal("no scaffold should have been written on abort")
+	}
+}
+
+func TestSkillOptTrainInitTUIDispatchPartialFails(t *testing.T) {
+	home := t.TempDir()
+	chdirTemp(t)
+	seedPlannerTemplate(t, home)
+
+	restore := replaceSkillOptTrainInitTUI(true, func(_, _ string, _ io.Writer, values *skillOptTrainInitInputs, _ []string) error {
+		values.Name = "tui-flow" // leaves the other required fields empty
+		return nil
+	})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("partial exit = %d, want 2; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "missing required fields") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+// TestSkillOptTrainInitTUIIncapableFallsBackToLineWizard proves the dispatch
+// ordering: when the TUI is not capable (the `go test` reality — pipes, not
+// char devices), the existing line wizard runs unchanged.
+func TestSkillOptTrainInitTUIIncapableFallsBackToLineWizard(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	seedPlannerTemplate(t, home)
+
+	restore := replaceSkillOptTrainInitTUI(false, nil) // not capable; runner must not be called
+	defer restore()
+	restoreInteractive := replaceSkillOptTrainInitInteractive(true)
+	defer restoreInteractive()
+	restoreStdin := replaceSkillOptTrainInitStdin("line-flow\nplanner\njerryfane/gitmoot\ntext\ntext-table\nImprove planner.\n")
+	defer restoreStdin()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "init", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("line wizard exit = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Choose a template:") {
+		t.Fatalf("expected the line wizard to run:\n%s", stdout.String())
+	}
+	cfg, err := skillopt.LoadTrainInitConfig(filepath.Join(workspace, ".gitmoot", "skillopt", "line-flow", "config.toml"))
+	if err != nil {
+		t.Fatalf("LoadTrainInitConfig: %v", err)
+	}
+	if cfg.Name != "line-flow" {
+		t.Fatalf("config = %+v", cfg)
+	}
+}


### PR DESCRIPTION
Part of #226 (interactive TUI). **Task 6 of 7.**

## WHAT
Dispatches a real terminal to the bubbletea train-init form (Task 5), preserving the line wizard everywhere else.

## CHANGES
- `skillOptTrainInitTUICapable`: stdin AND stdout must be char devices; honors `GITMOOT_NO_TUI` and `TERM=dumb` off-switches. A var so tests can stub it.
- New `case skillOptTrainInitTUICapable():` in `runSkillOptTrainInitCreate`, ordered **before** the line-wizard case. Under `go test` (pipes, not char devices) it's false, so every existing wizard test runs the line wizard unchanged.
- `runSkillOptTrainInitTUIImpl`: builds fields in the line-wizard order (template choices via `ListTrainInitTemplateChoices` + a "Custom file" entry), runs `tea.NewProgram` **inline** (no alt-screen, so the final frame and the post-run "created…" lines stay in scrollback), maps `Result.Aborted` → `errSkillOptTrainInitAborted` ("aborted: no scaffold written", exit 0), applies answers, and on any exit sweeps leftover **pending** prompt records for the form's fields (resolved answers are left for a rerun to consume — Ctrl+C in raw mode may exit before the model's own delete cmd runs).
- Text-field validation reuses `skillOptTrainInitInterpretCore` via a closure (identical semantics to the line wizard).

## RESULTS
- `go test ./...` green except the pre-existing, unrelated daemon flake `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` (red on clean main).
- New dispatch tests: scaffold written on completion; abort writes nothing; partial answers exit 2 with "missing required fields"; **capable=false falls back to the line wizard** (ordering proof). All existing `skillopt` wizard tests pass untouched.
- `go vet` / `gofmt` / `git diff --check` clean.

## RISK
Low. The only reachable change for non-terminals is none (gate is false); the agent-answer contract is preserved (per-field record + poll, swept on abort).

## /code-review
High-effort correctness review returned **no bugs**: the gate is false under `go test`; the shared `*db.Store` is safe across the program's cmd goroutines (modernc sqlite, `MaxOpenConns=1`); `interpret` is only invoked for text fields (empty prompt/nil choices are correct there); field-name keys (`review_repo`) map correctly to the struct and apply switch; cleanup deletes only pending records (resolved survive); and `tea.Program.Run()` always returns a `TrainInitModel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)