### PR TITLE
docs: dashboard and train init tui (TUI task 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,12 @@ template/version, writes `config.toml`, `task.md`, and starter
 `review-items.yml`, and prints the exact `train start --config` command. Agents
 can list template choices with `train init templates --json`; when an
 interactive setup needs missing values, they can answer the stored prompts with
-`gitmoot interactive list/show/answer`.
+`gitmoot interactive list/show/answer`. On a real terminal, missing fields are
+collected through an interactive form (arrow-key template/preview pickers, inline
+validation); each field is still published as a prompt record, so another
+terminal can answer it with `gitmoot interactive answer` and the form advances
+automatically. Set `GITMOOT_NO_TUI=1` (or pipe stdin) to use the line-based
+wizard instead.
 
 For lower-level debugging, create a review run, add saved baseline/candidate outputs as review items,
 export a Markdown or GitHub feedback packet, import the completed feedback, then

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -59,28 +59,38 @@ user explicitly wants a foreground process. Keep the default `--workers 1`
 unless the Gitmoot home has multiple independent runtime sessions or managed
 agent types with `max_background` greater than one.
 
-`gitmoot dashboard` prints a read-only snapshot of local state — daemon health,
-repos, agents and runtime sessions, jobs by state, worktrees, branch locks,
-SkillOpt train phase/candidate, and pending interactive prompts. Add `--json`
-for a machine-readable snapshot. The pending prompts it lists are the same
-records as `gitmoot interactive list`, and a prompt can be answered in place
-with `gitmoot dashboard --answer <prompt-id> --value <value>` (the same
-mechanism as `gitmoot interactive answer`). Without `--answer` it never mutates
-state.
+`gitmoot dashboard` shows local state — daemon health, repos, agents and runtime
+sessions, jobs by state, worktrees, branch locks, SkillOpt train phase/candidate,
+and pending interactive prompts.
+
+On a real terminal (stdin and stdout both a TTY) and with no other output/mutation
+flag, `gitmoot dashboard` launches an **interactive TUI**: a sidebar of pages
+(Attention, Trains, Agents, Sessions, Jobs, Locks) that auto-refreshes. Navigate
+with `tab`/`shift+tab` or `←/→`; on the Attention page select a pending prompt
+with `↑/↓` and `a` to answer it inline (a choice list or a text field) or `d` to
+dismiss it; on the Trains page `enter` opens a per-session detail with its locks;
+`r` refreshes, `q` quits. Inline answers/dismissals use the same store APIs as
+`gitmoot interactive answer` / `clear`.
+
+Everywhere else — pipes, redirects, CI, `--plain`, `--json`, `--all`, `--watch`,
+`--answer`, `--dismiss` — it prints the one-shot snapshot instead, unchanged. Set
+`GITMOOT_NO_TUI=1` or `TERM=dumb` to force the non-interactive path globally.
 
 ```sh
-gitmoot dashboard
+gitmoot dashboard                  # interactive TUI on a terminal
+gitmoot dashboard --plain          # one-shot snapshot on a terminal
 gitmoot dashboard --json
 gitmoot dashboard --all
 gitmoot dashboard --answer <prompt-id> --value <value>
-gitmoot dashboard --watch          # refresh until Ctrl-C (terminal only)
+gitmoot dashboard --dismiss <prompt-id>
+gitmoot dashboard --watch          # plain redraw until Ctrl-C (terminal only)
 gitmoot dashboard --watch --interval 2s
 ```
 
-In styled (terminal) output the dashboard leads with a "needs attention" block,
+In the one-shot styled output the dashboard leads with a "needs attention" block,
 colors and truncates long lists, and groups near-identical runtime sessions;
-`--all` shows everything. `--watch` redraws on an interval (default 5s) and
-cannot be combined with `--json` or `--answer`.
+`--all` shows everything. `--watch` redraws on an interval (default 5s) and cannot
+be combined with `--json`, `--answer`, or `--dismiss`.
 
 ## Agent Setup
 


### PR DESCRIPTION
Part of #226 (interactive TUI). **Task 7 of 7 (final).**

## WHAT
Documents the interactive TUI and records the end-to-end hand test. Polish items from the plan (per-page/mode footer help, empty states, viewport clamping) landed in Tasks 1–5 and render correctly; this task is docs + verification.

## CHANGES
- `skills/gitmoot/references/CLI.md`: rewrote the dashboard section — interactive TUI on a terminal (sidebar pages; `a` answer, `d` dismiss, `enter` train detail; `r`/`q`), and the full set of flags / non-terminal cases that keep the one-shot snapshot, plus `GITMOOT_NO_TUI` / `TERM=dumb`.
- `README.md`: `skillopt train init` now notes the interactive form on a terminal (still publishing a prompt record per field for external answering) and the `GITMOOT_NO_TUI` / piped-stdin fallback to the line wizard.

## RESULTS — real-terminal hand test (Herdr pane, local release `v0.2.0-beta.2+local.202606101204`)
- **Dashboard TUI**: launched against the real home; sidebar rendered (Attention → "7 blocked jobs / 2 failed jobs / branch locks"); `tab` navigated to the Agents table; `q` exited cleanly to the shell.
- **Train-init TUI**: launched the form `[1/6] Training name`; answering the field from a second shell with `gitmoot interactive answer` advanced it to `[2/6] Choose a template` with the green "answered externally by cli" flash and the real template list; `esc` printed "aborted: no scaffold written", left **no orphan prompts** (`interactive list` empty) and **no scaffold**.
- **Non-terminal fallback**: `echo | gitmoot dashboard` prints the plain "needs attention" snapshot — the TUI does not launch.
- `go test ./...` green except the pre-existing daemon flake `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos`.

## RISK
None — docs only.

## /code-review
Docs-only diff; self-reviewed for accuracy against the hand-tested behavior above (no code finders — there is no code to analyze in this task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)