### PR TITLE
github: RepositoryExists + CreateRepository (train-run task 1)

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -19,6 +19,8 @@ import (
 type Client interface {
 	Ping(ctx context.Context) error
 	Preflight(ctx context.Context, repo Repository) error
+	RepositoryExists(ctx context.Context, repo Repository) (bool, error)
+	CreateRepository(ctx context.Context, repo Repository, private bool) error
 	ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error)
 	GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
@@ -316,6 +318,38 @@ func (c *GhClient) Preflight(ctx context.Context, repo Repository) error {
 		}
 	}
 	return nil
+}
+
+// RepositoryExists reports whether the repo is visible to the authenticated gh
+// user. A 404 (or "not found") maps to (false, nil); any other error (auth,
+// network, rate limit) propagates so callers never offer to create a repo on an
+// ambiguous failure.
+func (c *GhClient) RepositoryExists(ctx context.Context, repo Repository) (bool, error) {
+	if strings.TrimSpace(repo.FullName()) == "" {
+		return false, fmt.Errorf("repository owner/name is required")
+	}
+	result, err := c.run(ctx, false, "repo", "view", repo.FullName(), "--json", "nameWithOwner")
+	if err != nil {
+		if isNotFound(result) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// CreateRepository creates the repo via `gh repo create`. It rides the mutate
+// lock like other write operations.
+func (c *GhClient) CreateRepository(ctx context.Context, repo Repository, private bool) error {
+	if strings.TrimSpace(repo.FullName()) == "" {
+		return fmt.Errorf("repository owner/name is required")
+	}
+	visibility := "--public"
+	if private {
+		visibility = "--private"
+	}
+	_, err := c.run(ctx, true, "repo", "create", repo.FullName(), visibility)
+	return err
 }
 
 func (c *GhClient) ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error) {
@@ -843,6 +877,14 @@ func firstNonEmpty(values ...string) string {
 type NoopClient struct{}
 
 func (NoopClient) Ping(context.Context) error {
+	return nil
+}
+
+func (NoopClient) RepositoryExists(context.Context, Repository) (bool, error) {
+	return true, nil
+}
+
+func (NoopClient) CreateRepository(context.Context, Repository, bool) error {
 	return nil
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -11,6 +11,84 @@ import (
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
+func TestRepositoryExists(t *testing.T) {
+	repo := Repository{Owner: "o", Name: "r"}
+
+	t.Run("exists", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"nameWithOwner":"o/r"}`}}}
+		client := GhClient{Runner: runner}
+		ok, err := client.RepositoryExists(context.Background(), repo)
+		if err != nil || !ok {
+			t.Fatalf("RepositoryExists = (%v, %v), want (true, nil)", ok, err)
+		}
+		runner.wantArgs(t, 0, "repo", "view", "o/r", "--json", "nameWithOwner")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		runner := &fakeRunner{
+			results: []subprocess.Result{{Stderr: "HTTP 404: Not Found (https://api.github.com/repos/o/r)"}},
+			errs:    []error{errors.New("exit status 1")},
+		}
+		client := GhClient{Runner: runner}
+		ok, err := client.RepositoryExists(context.Background(), repo)
+		if err != nil || ok {
+			t.Fatalf("RepositoryExists = (%v, %v), want (false, nil)", ok, err)
+		}
+	})
+
+	t.Run("auth error propagates", func(t *testing.T) {
+		runner := &fakeRunner{
+			results: []subprocess.Result{{Stderr: "gh: To get started with GitHub CLI, please run: gh auth login"}},
+			errs:    []error{errors.New("exit status 4")},
+		}
+		client := GhClient{Runner: runner}
+		ok, err := client.RepositoryExists(context.Background(), repo)
+		if err == nil || ok {
+			t.Fatalf("RepositoryExists = (%v, %v), want (false, non-nil) on auth error", ok, err)
+		}
+	})
+
+	t.Run("empty repo", func(t *testing.T) {
+		client := GhClient{Runner: &fakeRunner{}}
+		if _, err := client.RepositoryExists(context.Background(), Repository{}); err == nil {
+			t.Fatal("expected error for empty repo")
+		}
+	})
+}
+
+func TestCreateRepository(t *testing.T) {
+	repo := Repository{Owner: "o", Name: "r"}
+
+	t.Run("private", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{}}}
+		client := GhClient{Runner: runner}
+		if err := client.CreateRepository(context.Background(), repo, true); err != nil {
+			t.Fatalf("CreateRepository: %v", err)
+		}
+		runner.wantArgs(t, 0, "repo", "create", "o/r", "--private")
+	})
+
+	t.Run("public", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{}}}
+		client := GhClient{Runner: runner}
+		if err := client.CreateRepository(context.Background(), repo, false); err != nil {
+			t.Fatalf("CreateRepository: %v", err)
+		}
+		runner.wantArgs(t, 0, "repo", "create", "o/r", "--public")
+	})
+
+	t.Run("error propagates", func(t *testing.T) {
+		runner := &fakeRunner{
+			results: []subprocess.Result{{Stderr: "name already exists"}},
+			errs:    []error{errors.New("exit status 1")},
+		}
+		client := GhClient{Runner: runner}
+		if err := client.CreateRepository(context.Background(), repo, true); err == nil {
+			t.Fatal("expected error to propagate")
+		}
+	})
+}
+
 func TestListIssueCommentsDedupesByID(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{


### PR DESCRIPTION
Part of #234 (train run TUI). **Task 1 of 6.**

## WHAT
Adds two `github.Client` methods the later repo-creation hooks need.

## CHANGES
- `RepositoryExists(ctx, repo)` — `gh repo view owner/name --json nameWithOwner`; 404/"not found" → `(false, nil)`; auth/network/rate-limit errors **propagate** (callers must not offer creation on ambiguity).
- `CreateRepository(ctx, repo, private)` — `gh repo create owner/name --private|--public` on the mutate path (`mutateMu`).
- Added to the `Client` interface and `NoopClient`; the test fakes (`skillOptFakeGitHub`, `cliPollFakeGitHub`) embed `NoopClient` and inherit them.

## RESULTS
- `go test ./internal/github` green (exists / not-found→false,nil / auth-error propagates / empty-repo guard / create private+public args / create error propagates).
- `go build ./...` green (all interface implementers satisfied); `go vet` / `git diff --check` clean.

## RISK
Low; ships dark (no caller yet). Known GitHub limitation: a private repo you can't access returns 404, so `RepositoryExists` reports false — a later create attempt then fails with a clear "already exists" error rather than corrupting anything.

## /code-review
High-effort correctness review: **no findings**. Confirmed `run` returns the populated `result` alongside the wrapped error (so `isNotFound` sees the 404 text), 404s aren't retried (non-rate-limit breaks immediately), the gh syntax is non-interactive, and the mutate lock is correct with no nesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)