### PR TITLE
cli: skillopt train run TUI with live phase view (train-run task 3)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -116,6 +116,8 @@ func runSkillOptTrain(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptTrainStart(args[1:], stdout, stderr)
 	case "status":
 		return runSkillOptTrainStatus(args[1:], stdout, stderr)
+	case "run":
+		return runSkillOptTrainRun(args[1:], stdout, stderr)
 	case "continue":
 		return runSkillOptTrainContinue(args[1:], stdout, stderr)
 	case "recover":

--- a/internal/cli/skillopt_trainrun_tui.go
+++ b/internal/cli/skillopt_trainrun_tui.go
@@ -1,0 +1,211 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jerryfane/gitmoot/internal/cli/tui"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// skillOptTrainRunTUICapable reports whether the train run TUI may launch: both
+// stdin and stdout must be terminals and the user must not have opted out. A var
+// so tests can stub it.
+var skillOptTrainRunTUICapable = func() bool {
+	if os.Getenv("GITMOOT_NO_TUI") != "" || os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	in, errIn := os.Stdin.Stat()
+	out, errOut := os.Stdout.Stat()
+	return errIn == nil && errOut == nil &&
+		in.Mode()&os.ModeCharDevice != 0 && out.Mode()&os.ModeCharDevice != 0
+}
+
+// runSkillOptTrainRunTUI launches the bubbletea program. A var so dispatch tests
+// can stub the actual run.
+var runSkillOptTrainRunTUI = func(home, sessionID string, stdout, stderr io.Writer) int {
+	program := tea.NewProgram(tui.NewTrainRun(skillOptTrainRunDeps(home, sessionID)), tea.WithOutput(stdout))
+	if _, err := program.Run(); err != nil {
+		fmt.Fprintf(stderr, "skillopt train run: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runSkillOptTrainRun(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt train run", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	configPath := fs.String("config", "", "train init config path to resolve the latest session")
+	sessionID := fs.String("session", "", "train session id")
+	plain := fs.Bool("plain", false, "print a one-shot status snapshot instead of the interactive TUI")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt train run does not accept positional arguments")
+		return 2
+	}
+
+	resolved, err := resolveSkillOptTrainRunSession(*home, *sessionID, *configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt train run: %v\n", err)
+		return 1
+	}
+	if resolved == "" {
+		// No session yet for this config. Task 4 adds an interactive confirm
+		// screen; for now point at train start.
+		writeLine(stdout, "no train session yet for this config")
+		if strings.TrimSpace(*configPath) != "" {
+			writeLine(stdout, "next: gitmoot skillopt train start --config %s --workspace-repo <owner/repo>", *configPath)
+		}
+		return 0
+	}
+
+	if !*plain && skillOptTrainRunTUICapable() {
+		return runSkillOptTrainRunTUI(*home, resolved, stdout, stderr)
+	}
+	return runSkillOptTrainRunPlain(*home, resolved, stdout, stderr)
+}
+
+// runSkillOptTrainRunPlain prints a one-shot status snapshot plus the
+// continue-from-github link and a next-step hint, for non-terminal/--plain use.
+func runSkillOptTrainRunPlain(home, sessionID string, stdout, stderr io.Writer) int {
+	var snapshot skillOptTrainStatusSnapshot
+	if err := withStore(home, func(store *db.Store) error {
+		loaded, err := loadSkillOptTrainStatusSnapshot(context.Background(), store, sessionID, true)
+		if err != nil {
+			return err
+		}
+		snapshot = loaded
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt train run: %v\n", err)
+		return 1
+	}
+	printSkillOptTrainStatusSnapshot(stdout, skillOptTrainStatusOutputSnapshot(snapshot, false), false)
+	writeLine(stdout, "next: gitmoot skillopt train continue --session %s", sessionID)
+	return 0
+}
+
+// resolveSkillOptTrainRunSession returns the session id to show. An explicit
+// --session wins; otherwise --config resolves the newest session matching the
+// config's template. Returns "" when a config has no session yet.
+func resolveSkillOptTrainRunSession(home, sessionID, configPath string) (string, error) {
+	if id := strings.TrimSpace(sessionID); id != "" {
+		return id, nil
+	}
+	if strings.TrimSpace(configPath) == "" {
+		return "", errors.New("requires --session or --config")
+	}
+	config, err := skillopt.LoadTrainInitConfig(configPath)
+	if err != nil {
+		return "", err
+	}
+	template := strings.TrimSpace(config.Template)
+	var resolved string
+	if err := withStore(home, func(store *db.Store) error {
+		sessions, err := store.ListSkillOptTrainSessions(context.Background())
+		if err != nil {
+			return err
+		}
+		matching := make([]db.SkillOptTrainSession, 0, len(sessions))
+		for _, session := range sessions {
+			if template == "" || session.TemplateID == template {
+				matching = append(matching, session)
+			}
+		}
+		// Newest first by CreatedAt, then id as a stable tiebreaker.
+		sort.Slice(matching, func(i, j int) bool {
+			if matching[i].CreatedAt != matching[j].CreatedAt {
+				return matching[i].CreatedAt > matching[j].CreatedAt
+			}
+			return matching[i].ID > matching[j].ID
+		})
+		if len(matching) > 0 {
+			resolved = matching[0].ID
+		}
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+// skillOptTrainRunDeps wires the snapshot loader into tui.TrainRunDeps.
+func skillOptTrainRunDeps(home, sessionID string) tui.TrainRunDeps {
+	return tui.TrainRunDeps{
+		Interval: 2 * time.Second,
+		Load: func() (tui.TrainRunSnapshot, error) {
+			var snapshot skillOptTrainStatusSnapshot
+			if err := withStore(home, func(store *db.Store) error {
+				loaded, err := loadSkillOptTrainStatusSnapshot(context.Background(), store, sessionID, true)
+				if err != nil {
+					return err
+				}
+				snapshot = loaded
+				return nil
+			}); err != nil {
+				return tui.TrainRunSnapshot{}, err
+			}
+			return toTrainRunSnapshot(snapshot), nil
+		},
+	}
+}
+
+// toTrainRunSnapshot maps the cli status snapshot to the tui-facing shape.
+func toTrainRunSnapshot(s skillOptTrainStatusSnapshot) tui.TrainRunSnapshot {
+	// TemplateVersion is the full version id (e.g. "planner@v3"); strip the
+	// redundant "<id>@" prefix so the label reads "planner @v3" rather than
+	// doubling the template id.
+	template := strings.TrimSpace(s.TemplateID)
+	if v := strings.TrimSpace(s.TemplateVersion); v != "" {
+		template += " @" + strings.TrimPrefix(v, strings.TrimSpace(s.TemplateID)+"@")
+	}
+	out := tui.TrainRunSnapshot{
+		SessionID:         s.SessionID,
+		IterationID:       s.IterationID,
+		Template:          template,
+		ReviewRepo:        strings.TrimSpace(s.TargetRepo),
+		WorkspaceRepo:     strings.TrimSpace(s.WorkspaceRepo),
+		Phase:             s.StatusPhase,
+		NextAction:        s.NextAction,
+		IssueURL:          skillOptTrainContinueFromGitHubURL(s.CurrentPhase, s.IssueURL),
+		CandidateVersion:  s.CandidateVersion,
+		NoCandidateReason: s.NoCandidateReason,
+		ReviewItems:       s.Counts.ReviewItems,
+		FeedbackCount:     s.Counts.FeedbackEvents + s.Counts.RankedFeedbackEvents,
+		GeneratedOptions:  s.Progress.GeneratedOptions,
+		ETA:               s.Progress.ETA,
+		Terminal:          skillOptTrainRunTerminalPhase(s.StatusPhase),
+	}
+	if s.Verbose != nil {
+		out.Elapsed = s.Verbose.Elapsed
+		out.JobsRunning = s.Verbose.Jobs.Running
+		out.JobsSucceeded = s.Verbose.Jobs.Succeeded
+		out.JobsFailed = s.Verbose.Jobs.Failed
+	}
+	return out
+}
+
+func skillOptTrainRunTerminalPhase(phase string) bool {
+	switch phase {
+	case "candidate_promoted", "candidate_rejected", "run_abandoned", "optimizer_completed_no_candidate":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/cli/skillopt_trainrun_tui_test.go
+++ b/internal/cli/skillopt_trainrun_tui_test.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func replaceSkillOptTrainRunTUI(capable bool, run func(home, sessionID string, stdout, stderr io.Writer) int) func() {
+	prevCapable := skillOptTrainRunTUICapable
+	prevRun := runSkillOptTrainRunTUI
+	skillOptTrainRunTUICapable = func() bool { return capable }
+	if run != nil {
+		runSkillOptTrainRunTUI = run
+	}
+	return func() {
+		skillOptTrainRunTUICapable = prevCapable
+		runSkillOptTrainRunTUI = prevRun
+	}
+}
+
+func seedTrainSession(t *testing.T, home string, session db.SkillOptTrainSession) {
+	t.Helper()
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertSkillOptTrainSession(context.Background(), session); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSession: %v", err)
+	}
+}
+
+func TestResolveSkillOptTrainRunSession(t *testing.T) {
+	home := t.TempDir()
+
+	if id, err := resolveSkillOptTrainRunSession(home, "sess-direct", ""); err != nil || id != "sess-direct" {
+		t.Fatalf("explicit session = (%q, %v), want (sess-direct, nil)", id, err)
+	}
+	if _, err := resolveSkillOptTrainRunSession(home, "", ""); err == nil {
+		t.Fatal("expected error with neither --session nor --config")
+	}
+}
+
+func TestResolveSkillOptTrainRunSessionFromConfigNewest(t *testing.T) {
+	home := t.TempDir()
+	if err := config.Initialize(config.PathsForHome(home)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	// Real session IDs embed a sortable timestamp; the resolver breaks the
+	// coarse created_at tie by id descending, so the later-timestamped id wins.
+	seedTrainSession(t, home, db.SkillOptTrainSession{ID: "train-planner-20260101-000000-1", TemplateID: "planner", TargetRepo: "o/r", State: "items_ready"})
+	seedTrainSession(t, home, db.SkillOptTrainSession{ID: "train-planner-20260201-000000-1", TemplateID: "planner", TargetRepo: "o/r", State: "items_ready"})
+	seedTrainSession(t, home, db.SkillOptTrainSession{ID: "train-writer-20260301-000000-1", TemplateID: "writer", TargetRepo: "o/r", State: "items_ready"})
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := "name = \"x\"\ntemplate = \"planner\"\ntemplate_version = \"planner@v1\"\nreview_repo = \"o/r\"\ntask_kind = \"custom\"\nartifact_kind = \"text\"\npreview = \"none\"\nmode = \"explore\"\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	id, err := resolveSkillOptTrainRunSession(home, "", cfgPath)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if id != "train-planner-20260201-000000-1" {
+		t.Fatalf("resolved newest matching session = %q, want train-planner-20260201-000000-1", id)
+	}
+}
+
+func TestSkillOptTrainRunDispatchLaunchesTUI(t *testing.T) {
+	var gotSession string
+	restore := replaceSkillOptTrainRunTUI(true, func(_, sessionID string, _, _ io.Writer) int {
+		gotSession = sessionID
+		return 0
+	})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "run", "--session", "s1", "--home", t.TempDir()}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if gotSession != "s1" {
+		t.Fatalf("TUI launched with session %q, want s1", gotSession)
+	}
+}
+
+func TestSkillOptTrainRunDispatchPlainFallback(t *testing.T) {
+	home := t.TempDir()
+	if err := config.Initialize(config.PathsForHome(home)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	seedTrainSession(t, home, db.SkillOptTrainSession{ID: "s1", TemplateID: "planner", TargetRepo: "o/r", State: "items_ready", CreatedAt: "2026-01-01T00:00:00Z"})
+
+	restore := replaceSkillOptTrainRunTUI(false, nil) // not capable → plain fallback
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "run", "--session", "s1", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "session: s1") || !strings.Contains(out, "next: gitmoot skillopt train continue --session s1") {
+		t.Fatalf("plain fallback output unexpected:\n%s", out)
+	}
+}
+
+func TestToTrainRunSnapshot(t *testing.T) {
+	snap := skillOptTrainStatusSnapshot{
+		SessionID:       "s1",
+		IterationID:     "s1-001",
+		TemplateID:      "smithyx",
+		TemplateVersion: "smithyx@v9",
+		TargetRepo:      "o/r",
+		StatusPhase:     "review_published",
+		CurrentPhase:    "review_published",
+		IssueURL:        "https://github.com/o/r/issues/7",
+		Counts:          skillOptTrainStatusCountsJSON{ReviewItems: 2, FeedbackEvents: 1, RankedFeedbackEvents: 2},
+		Progress:        skillOptTrainStatusProgress{GeneratedOptions: 4, ETA: "41s"},
+		Verbose:         &skillOptTrainStatusVerbose{Elapsed: "2m", Jobs: skillOptTrainStatusJobs{Running: 1, Succeeded: 3, Failed: 0}},
+	}
+	out := toTrainRunSnapshot(snap)
+	if out.Template != "smithyx @v9" {
+		t.Fatalf("template label = %q, want \"smithyx @v9\" (no doubled id)", out.Template)
+	}
+	if out.Phase != "review_published" || out.IssueURL != "https://github.com/o/r/issues/7" {
+		t.Fatalf("phase/issue mapping wrong: %+v", out)
+	}
+	if out.FeedbackCount != 3 || out.ReviewItems != 2 || out.GeneratedOptions != 4 {
+		t.Fatalf("counts mapping wrong: %+v", out)
+	}
+	if out.JobsRunning != 1 || out.JobsSucceeded != 3 || out.Elapsed != "2m" {
+		t.Fatalf("verbose mapping wrong: %+v", out)
+	}
+}

--- a/internal/cli/tui/trainrun.go
+++ b/internal/cli/tui/trainrun.go
@@ -1,0 +1,127 @@
+package tui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TrainRunSnapshot is the TUI-facing view of one train session's live state,
+// adapted by the cli from the skillopt status snapshot.
+type TrainRunSnapshot struct {
+	SessionID         string
+	IterationID       string
+	Template          string // "<id>@<version>"
+	ReviewRepo        string
+	WorkspaceRepo     string
+	Phase             string // lock-aware stable status phase
+	NextAction        string
+	IssueURL          string // review issue (or candidate review issue) URL
+	CandidateVersion  string
+	NoCandidateReason string
+	FeedbackCount     int
+	ReviewItems       int
+	GeneratedOptions  int
+	JobsRunning       int
+	JobsSucceeded     int
+	JobsFailed        int
+	ETA               string
+	Elapsed           string
+	Terminal          bool
+}
+
+// TrainRunDeps are the data source (and, from Task 4, action callbacks) the cli
+// injects. The tui package stays store-free.
+type TrainRunDeps struct {
+	Interval time.Duration
+	Load     func() (TrainRunSnapshot, error)
+}
+
+type trainSnapshotMsg struct {
+	snap TrainRunSnapshot
+	err  error
+	at   time.Time
+}
+
+type trainTickMsg struct{}
+
+// TrainRunModel renders a single train session as a live phase view.
+type TrainRunModel struct {
+	deps     TrainRunDeps
+	snap     TrainRunSnapshot
+	loadedAt time.Time
+	loadErr  string
+	inFlight bool
+	width    int
+	height   int
+}
+
+// NewTrainRun returns a model ready for tea.NewProgram.
+func NewTrainRun(deps TrainRunDeps) TrainRunModel {
+	return TrainRunModel{deps: deps, width: 100, height: 30, inFlight: true}
+}
+
+func (m TrainRunModel) interval() time.Duration {
+	if m.deps.Interval <= 0 {
+		return defaultInterval
+	}
+	return m.deps.Interval
+}
+
+// Init issues the first load and arms the refresh tick.
+func (m TrainRunModel) Init() tea.Cmd {
+	return tea.Batch(loadTrainSnapshot(m.deps), trainTick(m.interval()))
+}
+
+func (m TrainRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		if msg.Width > 0 && msg.Height > 0 {
+			m.width, m.height = msg.Width, msg.Height
+		}
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			return m, tea.Quit
+		case "r":
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+	case trainSnapshotMsg:
+		m.inFlight = false
+		if msg.err != nil {
+			m.loadErr = msg.err.Error()
+		} else {
+			m.loadErr = ""
+			m.snap = msg.snap
+			m.loadedAt = msg.at
+		}
+	case trainTickMsg:
+		if cmd := m.queueLoad(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		cmds = append(cmds, trainTick(m.interval()))
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m *TrainRunModel) queueLoad() tea.Cmd {
+	if m.inFlight {
+		return nil
+	}
+	m.inFlight = true
+	return loadTrainSnapshot(m.deps)
+}
+
+func loadTrainSnapshot(deps TrainRunDeps) tea.Cmd {
+	return func() tea.Msg {
+		snap, err := deps.Load()
+		return trainSnapshotMsg{snap: snap, err: err, at: time.Now()}
+	}
+}
+
+func trainTick(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(time.Time) tea.Msg { return trainTickMsg{} })
+}

--- a/internal/cli/tui/trainrun_test.go
+++ b/internal/cli/tui/trainrun_test.go
@@ -1,0 +1,114 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func trainRunModel(t *testing.T, snap TrainRunSnapshot) TrainRunModel {
+	t.Helper()
+	m := NewTrainRun(TrainRunDeps{Load: func() (TrainRunSnapshot, error) { return snap, nil }})
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = next.(TrainRunModel)
+	next, _ = m.Update(trainSnapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	return next.(TrainRunModel)
+}
+
+func TestTrainPhaseSegment(t *testing.T) {
+	cases := map[string]int{
+		"items_ready":                0,
+		"generating_options":         0,
+		"options_generated":          0,
+		"review_published":           1,
+		"feedback_synced":            1,
+		"optimizer_running":          2,
+		"candidate_created":          2,
+		"candidate_review_published": 3,
+		"candidate_promoted":         3,
+		"something_unknown":          0,
+	}
+	for phase, want := range cases {
+		if got := trainPhaseSegment(phase); got != want {
+			t.Fatalf("trainPhaseSegment(%q) = %d, want %d", phase, got, want)
+		}
+	}
+}
+
+func TestTrainRunRendersHeaderAndPhaseBar(t *testing.T) {
+	m := trainRunModel(t, TrainRunSnapshot{
+		SessionID: "train-abc", Template: "smithyx@v9", ReviewRepo: "o/r",
+		Phase: "items_ready", ReviewItems: 2, NextAction: "generate review options",
+	})
+	view := m.View()
+	for _, want := range []string{"train-abc", "smithyx@v9", "o/r", "generate", "review", "optimize", "promote", "2 review items", "next: generate review options"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestTrainRunReviewPhaseShowsIssueLink(t *testing.T) {
+	m := trainRunModel(t, TrainRunSnapshot{
+		SessionID: "s", Phase: "review_published",
+		IssueURL: "https://github.com/o/r/issues/7", FeedbackCount: 3,
+	})
+	view := m.View()
+	if !strings.Contains(view, "review issue: https://github.com/o/r/issues/7") {
+		t.Fatalf("expected the issue link:\n%s", view)
+	}
+	if !strings.Contains(view, "the review watcher picks it up") {
+		t.Fatalf("expected the continue-from-github hint:\n%s", view)
+	}
+	if !strings.Contains(view, "feedback so far: 3") {
+		t.Fatalf("expected feedback count:\n%s", view)
+	}
+}
+
+func TestTrainRunGeneratingShowsJobCounts(t *testing.T) {
+	m := trainRunModel(t, TrainRunSnapshot{
+		SessionID: "s", Phase: "generating_options",
+		JobsRunning: 1, JobsSucceeded: 2, JobsFailed: 0, ETA: "41s",
+	})
+	view := m.View()
+	if !strings.Contains(view, "1 running") || !strings.Contains(view, "2 done") {
+		t.Fatalf("expected job counts:\n%s", view)
+	}
+}
+
+func TestTrainRunLoadErrorKeepsStaleData(t *testing.T) {
+	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Template: "t@v1", Phase: "items_ready"})
+	next, _ := m.Update(trainSnapshotMsg{err: errors.New("db locked"), at: time.Unix(2, 0)})
+	m = next.(TrainRunModel)
+	view := m.View()
+	if !strings.Contains(view, "refresh error: db locked") {
+		t.Fatalf("expected error banner:\n%s", view)
+	}
+	if !strings.Contains(view, "t@v1") {
+		t.Fatalf("stale data should remain:\n%s", view)
+	}
+}
+
+func TestTrainRunRefreshSuppression(t *testing.T) {
+	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Phase: "items_ready"})
+	if m.inFlight {
+		t.Fatal("should be idle after a snapshot")
+	}
+	if cmd := m.queueLoad(); cmd == nil {
+		t.Fatal("first queueLoad should return a command")
+	}
+	if cmd := m.queueLoad(); cmd != nil {
+		t.Fatal("overlapping queueLoad should be suppressed")
+	}
+}
+
+func TestTrainRunTickRearms(t *testing.T) {
+	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Phase: "items_ready"})
+	_, cmd := m.Update(trainTickMsg{})
+	if cmd == nil {
+		t.Fatal("tick should re-arm and refresh")
+	}
+}

--- a/internal/cli/tui/trainrun_view.go
+++ b/internal/cli/tui/trainrun_view.go
@@ -1,0 +1,137 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// trainPhaseSegments are the four coarse stages shown in the phase bar.
+var trainPhaseSegments = []string{"generate", "review", "optimize", "promote"}
+
+// trainPhaseSegment maps a fine-grained status phase to a coarse segment index
+// (0..3). Unknown phases map to 0.
+func trainPhaseSegment(phase string) int {
+	switch phase {
+	case "request_confirmed", "workspace_ready", "items_ready",
+		"generating_options", "generating_options_heartbeat_stale", "options_generated":
+		return 0
+	case "review_published", "feedback_synced":
+		return 1
+	case "training_package_created", "optimizer_running", "optimizer_heartbeat_stale",
+		"optimizer_completed", "optimizer_completed_no_candidate", "candidate_created":
+		return 2
+	case "candidate_review_published", "candidate_promoted", "candidate_rejected":
+		return 3
+	default:
+		return 0
+	}
+}
+
+func (m TrainRunModel) View() string {
+	if m.snap.SessionID == "" && m.loadedAt.IsZero() && m.loadErr == "" {
+		return "Loading…"
+	}
+	var b strings.Builder
+
+	// Header.
+	header := m.snap.SessionID
+	if m.snap.Template != "" {
+		header += " · " + m.snap.Template
+	}
+	if m.snap.ReviewRepo != "" {
+		header += " · " + m.snap.ReviewRepo
+	}
+	b.WriteString(headerStyle.Render(header))
+	if !m.loadedAt.IsZero() {
+		b.WriteString("  " + mutedStyle.Render("updated "+m.loadedAt.Format("15:04:05")))
+	}
+	b.WriteString("\n\n")
+
+	b.WriteString(m.phaseBar())
+	b.WriteString("\n\n")
+
+	if m.loadErr != "" {
+		b.WriteString(errorStyle.Render("refresh error: " + m.loadErr))
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString(m.body())
+	b.WriteString("\n\n")
+	b.WriteString(mutedStyle.Render("r refresh  q quit"))
+	return b.String()
+}
+
+func (m TrainRunModel) phaseBar() string {
+	active := trainPhaseSegment(m.snap.Phase)
+	parts := make([]string, len(trainPhaseSegments))
+	for i, seg := range trainPhaseSegments {
+		switch {
+		case i == active:
+			parts[i] = selectedRowStyle.Render(seg)
+		case i < active:
+			parts[i] = greenStyle.Render(seg)
+		default:
+			parts[i] = mutedStyle.Render(seg)
+		}
+	}
+	line := strings.Join(parts, mutedStyle.Render(" → "))
+	return line + "    " + mutedStyle.Render("phase: "+dash(m.snap.Phase))
+}
+
+func (m TrainRunModel) body() string {
+	var b strings.Builder
+	s := m.snap
+
+	switch s.Phase {
+	case "items_ready", "request_confirmed", "workspace_ready":
+		b.WriteString(fmt.Sprintf("%d review items ready to generate options\n", s.ReviewItems))
+	case "generating_options", "generating_options_heartbeat_stale":
+		b.WriteString(fmt.Sprintf("generating options — %d running · %d done · %d failed", s.JobsRunning, s.JobsSucceeded, s.JobsFailed))
+		if s.ETA != "" && s.ETA != "unknown" {
+			b.WriteString("  (eta " + s.ETA + ")")
+		}
+		b.WriteByte('\n')
+	case "options_generated":
+		b.WriteString(fmt.Sprintf("%d options generated — ready to publish the review\n", s.GeneratedOptions))
+	case "review_published":
+		b.WriteString(m.issueBlock())
+		b.WriteString(fmt.Sprintf("feedback so far: %d\n", s.FeedbackCount))
+	case "optimizer_running", "optimizer_heartbeat_stale", "training_package_created":
+		b.WriteString("optimizer running")
+		if s.Elapsed != "" {
+			b.WriteString(" · " + s.Elapsed)
+		}
+		b.WriteByte('\n')
+	case "candidate_created":
+		b.WriteString(fmt.Sprintf("candidate %s created — ready to publish the candidate review\n", dash(s.CandidateVersion)))
+	case "candidate_review_published":
+		b.WriteString(m.issueBlock())
+		b.WriteString(fmt.Sprintf("candidate: %s\n", dash(s.CandidateVersion)))
+	case "optimizer_completed_no_candidate":
+		b.WriteString("optimizer produced no candidate")
+		if s.NoCandidateReason != "" {
+			b.WriteString(": " + s.NoCandidateReason)
+		}
+		b.WriteByte('\n')
+	case "candidate_promoted":
+		b.WriteString(greenStyle.Render(fmt.Sprintf("candidate %s promoted", dash(s.CandidateVersion))) + "\n")
+	case "candidate_rejected":
+		b.WriteString(fmt.Sprintf("candidate %s rejected\n", dash(s.CandidateVersion)))
+	}
+
+	if s.NextAction != "" {
+		b.WriteString(mutedStyle.Render("next: " + s.NextAction))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// issueBlock renders the GitHub issue URL prominently with the continue-from-
+// GitHub hint.
+func (m TrainRunModel) issueBlock() string {
+	if strings.TrimSpace(m.snap.IssueURL) == "" {
+		return ""
+	}
+	return selectedRowStyle.Render("review issue: "+m.snap.IssueURL) + "\n" +
+		mutedStyle.Render("comment on the issue — the review watcher picks it up") + "\n"
+}


### PR DESCRIPTION
Part of #234 (train run TUI). **Task 3 of 6.**

## WHAT
Adds the `gitmoot skillopt train run` verb with a read-only live phase view. Actions land in Task 4.

## CHANGES
- New verb `train run [--config | --session] [--plain]`. TTY (both ends, no `--plain`/`GITMOOT_NO_TUI`/`TERM=dumb`) → interactive TUI; everything else → one-shot status snapshot + `next: train continue --session <id>` hint, exit 0.
- Session resolution: `--session` direct; `--config` → newest matching session (ids embed a sortable timestamp; created_at is coarse so id-desc dominates).
- `internal/cli/tui/trainrun.go` + `trainrun_view.go`: `TrainRunModel` (snapshot/tick refresh + in-flight suppression); header; 4-segment phase bar derived from the **lock-aware** status phase (current highlighted, done dimmed); per-phase read-only bodies; the review issue URL shown prominently with the "comment on the issue — the review watcher picks it up" hint; `r`/`q`.
- Template label strips the redundant `id@` prefix (same fix as train-init).

## RESULTS
- `go test ./internal/cli/tui` + `./internal/cli` (train-run subset) green; `go vet` / `gofmt` / `git diff --check` clean.
- Tests: phase-segment mapping, render of header/bar/body, issue link at review_published, job counts, load-error keeps stale data, refresh suppression, tick re-arm; dispatch gating, `--config` newest-session resolution, snapshot mapping.

## RISK
Low; read-only, additive verb. Non-TTY never launches the TUI.

## /code-review
High-effort review: **no findings**. Confirmed the gate is false under `go test`; missing-args and bad-session exit 1 cleanly (no panic); the body switches on the lock-aware `StatusPhase` while the issue link uses `CurrentPhase`, and the only lock-derived phases are generating/optimizer (review_published/candidate_review_published are identical in both fields, so the link is always present when the body needs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)