### PR TITLE
cli: drive train phases from the train run TUI (train-run task 4)

### DIFF
--- a/internal/cli/skillopt_trainrun_tui.go
+++ b/internal/cli/skillopt_trainrun_tui.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -145,8 +148,26 @@ func resolveSkillOptTrainRunSession(home, sessionID, configPath string) (string,
 	return resolved, nil
 }
 
-// skillOptTrainRunDeps wires the snapshot loader into tui.TrainRunDeps.
+// skillOptTrainRunDeps wires the snapshot loader and phase actions into
+// tui.TrainRunDeps.
 func skillOptTrainRunDeps(home, sessionID string) tui.TrainRunDeps {
+	runContinue := func(mutate func(*skillOptTrainContinueRequest)) (tui.TrainRunActionResult, error) {
+		paths, err := initializedPaths(home)
+		if err != nil {
+			return tui.TrainRunActionResult{}, err
+		}
+		var out skillOptTrainContinueOutput
+		err = withStore(home, func(store *db.Store) error {
+			request := skillOptTrainContinueRequest{Home: home, SessionID: sessionID}
+			if mutate != nil {
+				mutate(&request)
+			}
+			var runErr error
+			out, runErr = continueSkillOptTrain(context.Background(), paths, store, request)
+			return runErr
+		})
+		return tui.TrainRunActionResult{Lines: out.Lines}, err
+	}
 	return tui.TrainRunDeps{
 		Interval: 2 * time.Second,
 		Load: func() (tui.TrainRunSnapshot, error) {
@@ -163,7 +184,70 @@ func skillOptTrainRunDeps(home, sessionID string) tui.TrainRunDeps {
 			}
 			return toTrainRunSnapshot(snapshot), nil
 		},
+		Continue: func() (tui.TrainRunActionResult, error) { return runContinue(nil) },
+		Decide: func(promote bool, candidate, reason string) (tui.TrainRunActionResult, error) {
+			return runContinue(func(r *skillOptTrainContinueRequest) {
+				if promote {
+					r.PromoteCandidate = candidate
+				} else {
+					r.RejectCandidate = candidate
+					r.DecisionReason = reason
+				}
+			})
+		},
+		StartNext: func() (tui.TrainRunActionResult, error) {
+			return runContinue(func(r *skillOptTrainContinueRequest) { r.StartNext = true })
+		},
+		SpawnContinue: func() (string, error) { return spawnSkillOptTrainContinueChild(home, sessionID) },
 	}
+}
+
+// spawnSkillOptTrainContinueChild launches `gitmoot skillopt train continue` as a
+// detached background process so the long generation/optimizer phases survive
+// the TUI quitting. It is a var so tests can stub it. Returns the log path the
+// child's stdout/stderr are appended to.
+var spawnSkillOptTrainContinueChild = func(home, sessionID string) (string, error) {
+	paths, err := initializedPaths(home)
+	if err != nil {
+		return "", err
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	logPath := filepath.Join(paths.Logs, "skillopt-train-"+skillOptTrainLogSlug(sessionID)+".log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", err
+	}
+	defer logFile.Close()
+	args := []string{"skillopt", "train", "continue", "--session", sessionID}
+	if strings.TrimSpace(home) != "" {
+		args = append(args, "--home", home)
+	}
+	cmd := exec.Command(executable, args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return "", err
+	}
+	return logPath, nil
+}
+
+// skillOptTrainLogSlug makes a session id safe for a log filename.
+func skillOptTrainLogSlug(sessionID string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, sessionID)
 }
 
 // toTrainRunSnapshot maps the cli status snapshot to the tui-facing shape.

--- a/internal/cli/tui/trainrun.go
+++ b/internal/cli/tui/trainrun.go
@@ -1,8 +1,10 @@
 package tui
 
 import (
+	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -30,12 +32,31 @@ type TrainRunSnapshot struct {
 	Terminal          bool
 }
 
-// TrainRunDeps are the data source (and, from Task 4, action callbacks) the cli
-// injects. The tui package stays store-free.
-type TrainRunDeps struct {
-	Interval time.Duration
-	Load     func() (TrainRunSnapshot, error)
+// TrainRunActionResult carries the output lines from a short in-process phase
+// action (publish review, sync, promote, …).
+type TrainRunActionResult struct {
+	Lines []string
 }
+
+// TrainRunDeps are the data source and action callbacks the cli injects. The tui
+// package stays store-free. Continue advances a short (seconds) phase in
+// process; SpawnContinue launches the detached child for the long phases
+// (generation, optimizer) so quitting the TUI does not kill the run.
+type TrainRunDeps struct {
+	Interval      time.Duration
+	Load          func() (TrainRunSnapshot, error)
+	Continue      func() (TrainRunActionResult, error)
+	Decide        func(promote bool, candidate, reason string) (TrainRunActionResult, error)
+	StartNext     func() (TrainRunActionResult, error)
+	SpawnContinue func() (logPath string, err error)
+}
+
+type trainRunMode int
+
+const (
+	trainModeNormal trainRunMode = iota
+	trainModeReject
+)
 
 type trainSnapshotMsg struct {
 	snap TrainRunSnapshot
@@ -44,6 +65,16 @@ type trainSnapshotMsg struct {
 }
 
 type trainTickMsg struct{}
+
+type trainActionMsg struct {
+	result TrainRunActionResult
+	err    error
+}
+
+type trainSpawnMsg struct {
+	logPath string
+	err     error
+}
 
 // TrainRunModel renders a single train session as a live phase view.
 type TrainRunModel struct {
@@ -54,6 +85,12 @@ type TrainRunModel struct {
 	inFlight bool
 	width    int
 	height   int
+
+	mode        trainRunMode
+	actionBusy  bool
+	actionErr   string
+	resultLines []string
+	rejectInput textinput.Model
 }
 
 // NewTrainRun returns a model ready for tea.NewProgram.
@@ -81,10 +118,25 @@ func (m TrainRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.width, m.height = msg.Width, msg.Height
 		}
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "q", "esc":
-			return m, tea.Quit
-		case "r":
+		return m.updateKey(msg)
+	case trainActionMsg:
+		m.actionBusy = false
+		if msg.err != nil {
+			m.actionErr = msg.err.Error()
+		} else {
+			m.actionErr = ""
+			m.resultLines = msg.result.Lines
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+	case trainSpawnMsg:
+		m.actionBusy = false
+		if msg.err != nil {
+			m.actionErr = msg.err.Error()
+		} else {
+			m.actionErr = ""
+			m.resultLines = []string{"started in the background — watch the phase above (q quits, the run keeps going)"}
 			if cmd := m.queueLoad(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
@@ -105,6 +157,116 @@ func (m TrainRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, trainTick(m.interval()))
 	}
 	return m, tea.Batch(cmds...)
+}
+
+// updateKey handles all key input: the reject-reason sub-mode first, then the
+// global keys, then the per-phase action keys.
+func (m TrainRunModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "ctrl+c" {
+		return m, tea.Quit
+	}
+	if m.mode == trainModeReject {
+		switch msg.String() {
+		case "esc":
+			m.mode = trainModeNormal
+			m.actionErr = ""
+			return m, nil
+		case "enter":
+			reason := strings.TrimSpace(m.rejectInput.Value())
+			if reason == "" {
+				m.actionErr = "a reject reason is required"
+				return m, nil
+			}
+			m.mode = trainModeNormal
+			m.actionBusy = true
+			m.actionErr = ""
+			return m, decideCmd(m.deps, false, m.snap.CandidateVersion, reason)
+		}
+		var cmd tea.Cmd
+		m.rejectInput, cmd = m.rejectInput.Update(msg)
+		return m, cmd
+	}
+
+	switch msg.String() {
+	case "q", "esc":
+		return m, tea.Quit
+	case "r":
+		return m, m.queueLoad()
+	}
+	if m.actionBusy {
+		return m, nil // an action is in flight; ignore until it returns
+	}
+	switch msg.String() {
+	case "enter":
+		switch m.snap.Phase {
+		case "items_ready", "feedback_synced", "training_package_created":
+			m.actionBusy, m.actionErr = true, ""
+			return m, spawnCmd(m.deps)
+		case "options_generated", "review_published", "candidate_created":
+			m.actionBusy, m.actionErr = true, ""
+			return m, continueCmd(m.deps)
+		}
+	case "p":
+		if m.snap.Phase == "candidate_review_published" {
+			m.actionBusy, m.actionErr = true, ""
+			return m, decideCmd(m.deps, true, m.snap.CandidateVersion, "")
+		}
+	case "x":
+		if m.snap.Phase == "candidate_review_published" {
+			m.mode = trainModeReject
+			m.actionErr = ""
+			ti := textinput.New()
+			ti.Placeholder = "reason for rejecting"
+			m.rejectInput = ti
+			return m, m.rejectInput.Focus()
+		}
+	case "n":
+		if m.snap.Terminal {
+			m.actionBusy, m.actionErr = true, ""
+			return m, startNextCmd(m.deps)
+		}
+	}
+	return m, nil
+}
+
+func continueCmd(d TrainRunDeps) tea.Cmd {
+	return func() tea.Msg {
+		if d.Continue == nil {
+			return trainActionMsg{}
+		}
+		res, err := d.Continue()
+		return trainActionMsg{result: res, err: err}
+	}
+}
+
+func decideCmd(d TrainRunDeps, promote bool, candidate, reason string) tea.Cmd {
+	return func() tea.Msg {
+		if d.Decide == nil {
+			return trainActionMsg{}
+		}
+		res, err := d.Decide(promote, candidate, reason)
+		return trainActionMsg{result: res, err: err}
+	}
+}
+
+func startNextCmd(d TrainRunDeps) tea.Cmd {
+	return func() tea.Msg {
+		if d.StartNext == nil {
+			return trainActionMsg{}
+		}
+		res, err := d.StartNext()
+		return trainActionMsg{result: res, err: err}
+	}
+}
+
+func spawnCmd(d TrainRunDeps) tea.Cmd {
+	return func() tea.Msg {
+		if d.SpawnContinue == nil {
+			return trainSpawnMsg{}
+		}
+		path, err := d.SpawnContinue()
+		return trainSpawnMsg{logPath: path, err: err}
+	}
 }
 
 func (m *TrainRunModel) queueLoad() tea.Cmd {

--- a/internal/cli/tui/trainrun_test.go
+++ b/internal/cli/tui/trainrun_test.go
@@ -112,3 +112,170 @@ func TestTrainRunTickRearms(t *testing.T) {
 		t.Fatal("tick should re-arm and refresh")
 	}
 }
+
+func trainRunModelWithDeps(t *testing.T, deps TrainRunDeps, snap TrainRunSnapshot) TrainRunModel {
+	t.Helper()
+	m := NewTrainRun(deps)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = next.(TrainRunModel)
+	next, _ = m.Update(trainSnapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	return next.(TrainRunModel)
+}
+
+func TestTrainRunGenerateSpawnsChild(t *testing.T) {
+	spawned := false
+	deps := TrainRunDeps{
+		Load:          func() (TrainRunSnapshot, error) { return TrainRunSnapshot{SessionID: "s", Phase: "items_ready"}, nil },
+		SpawnContinue: func() (string, error) { spawned = true; return "/tmp/log", nil },
+	}
+	m := trainRunModelWithDeps(t, deps, TrainRunSnapshot{SessionID: "s", Phase: "items_ready"})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainRunModel)
+	if !m.actionBusy || cmd == nil {
+		t.Fatal("enter on items_ready should spawn and mark busy")
+	}
+	cmd() // execute the spawn command
+	if !spawned {
+		t.Fatal("SpawnContinue should have been called")
+	}
+}
+
+func TestTrainRunPublishUsesInProcessContinue(t *testing.T) {
+	called := false
+	deps := TrainRunDeps{
+		Load: func() (TrainRunSnapshot, error) {
+			return TrainRunSnapshot{SessionID: "s", Phase: "options_generated"}, nil
+		},
+		Continue: func() (TrainRunActionResult, error) {
+			called = true
+			return TrainRunActionResult{Lines: []string{"review: url"}}, nil
+		},
+	}
+	m := trainRunModelWithDeps(t, deps, TrainRunSnapshot{SessionID: "s", Phase: "options_generated"})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainRunModel)
+	if cmd == nil {
+		t.Fatal("enter on options_generated should run continue")
+	}
+	msg := cmd()
+	if !called {
+		t.Fatal("Continue should have been called")
+	}
+	next, _ = m.Update(msg)
+	m = next.(TrainRunModel)
+	if m.actionBusy {
+		t.Fatal("action result should clear busy")
+	}
+}
+
+func TestTrainRunPromote(t *testing.T) {
+	var gotPromote bool
+	var gotCandidate string
+	deps := TrainRunDeps{
+		Load: func() (TrainRunSnapshot, error) {
+			return TrainRunSnapshot{SessionID: "s", Phase: "candidate_review_published", CandidateVersion: "c@v2"}, nil
+		},
+		Decide: func(promote bool, candidate, reason string) (TrainRunActionResult, error) {
+			gotPromote, gotCandidate = promote, candidate
+			return TrainRunActionResult{}, nil
+		},
+	}
+	m := trainRunModelWithDeps(t, deps, TrainRunSnapshot{SessionID: "s", Phase: "candidate_review_published", CandidateVersion: "c@v2"})
+	next, cmd := m.Update(key("p"))
+	m = next.(TrainRunModel)
+	if cmd == nil {
+		t.Fatal("p should promote")
+	}
+	cmd()
+	if !gotPromote || gotCandidate != "c@v2" {
+		t.Fatalf("Decide(promote) called with (%v,%q)", gotPromote, gotCandidate)
+	}
+}
+
+func TestTrainRunRejectRequiresReason(t *testing.T) {
+	var gotReason string
+	decided := false
+	deps := TrainRunDeps{
+		Load: func() (TrainRunSnapshot, error) {
+			return TrainRunSnapshot{SessionID: "s", Phase: "candidate_review_published", CandidateVersion: "c@v2"}, nil
+		},
+		Decide: func(promote bool, candidate, reason string) (TrainRunActionResult, error) {
+			decided, gotReason = true, reason
+			return TrainRunActionResult{}, nil
+		},
+	}
+	m := trainRunModelWithDeps(t, deps, TrainRunSnapshot{SessionID: "s", Phase: "candidate_review_published", CandidateVersion: "c@v2"})
+	// x opens the reject reason input.
+	next, _ := m.Update(key("x"))
+	m = next.(TrainRunModel)
+	if m.mode != trainModeReject {
+		t.Fatalf("x should open the reject input, mode=%v", m.mode)
+	}
+	// enter with empty reason is rejected.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainRunModel)
+	if decided || m.actionErr == "" {
+		t.Fatal("empty reason should not submit and should show an error")
+	}
+	// type a reason and submit.
+	next, _ = m.Update(key("not good enough"))
+	m = next.(TrainRunModel)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainRunModel)
+	if cmd == nil {
+		t.Fatal("enter with a reason should submit")
+	}
+	cmd()
+	if !decided || gotReason != "not good enough" {
+		t.Fatalf("Decide(reject) reason = %q", gotReason)
+	}
+}
+
+func TestTrainRunStartNextOnTerminal(t *testing.T) {
+	called := false
+	deps := TrainRunDeps{
+		Load: func() (TrainRunSnapshot, error) {
+			return TrainRunSnapshot{SessionID: "s", Phase: "candidate_promoted", Terminal: true}, nil
+		},
+		StartNext: func() (TrainRunActionResult, error) { called = true; return TrainRunActionResult{}, nil },
+	}
+	m := trainRunModelWithDeps(t, deps, TrainRunSnapshot{SessionID: "s", Phase: "candidate_promoted", Terminal: true})
+	next, cmd := m.Update(key("n"))
+	m = next.(TrainRunModel)
+	if cmd == nil {
+		t.Fatal("n should start next on a terminal phase")
+	}
+	cmd()
+	if !called {
+		t.Fatal("StartNext should have been called")
+	}
+}
+
+func TestTrainRunActionBusySuppressesReentry(t *testing.T) {
+	deps := TrainRunDeps{
+		Load: func() (TrainRunSnapshot, error) {
+			return TrainRunSnapshot{SessionID: "s", Phase: "options_generated"}, nil
+		},
+		Continue: func() (TrainRunActionResult, error) { return TrainRunActionResult{}, nil },
+	}
+	m := trainRunModelWithDeps(t, deps, TrainRunSnapshot{SessionID: "s", Phase: "options_generated"})
+	next, cmd1 := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainRunModel)
+	next, cmd2 := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd1 == nil || cmd2 != nil {
+		t.Fatal("second enter while busy must be suppressed")
+	}
+	_ = next
+}
+
+func TestTrainRunActionErrorShown(t *testing.T) {
+	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Phase: "options_generated"})
+	next, _ := m.Update(trainActionMsg{err: errors.New("another worker holds the lock")})
+	m = next.(TrainRunModel)
+	if m.actionBusy {
+		t.Fatal("error result should clear busy")
+	}
+	if !strings.Contains(m.View(), "another worker holds the lock") {
+		t.Fatalf("expected the action error in view:\n%s", m.View())
+	}
+}

--- a/internal/cli/tui/trainrun_view.go
+++ b/internal/cli/tui/trainrun_view.go
@@ -56,9 +56,47 @@ func (m TrainRunModel) View() string {
 	}
 
 	b.WriteString(m.body())
-	b.WriteString("\n\n")
-	b.WriteString(mutedStyle.Render("r refresh  q quit"))
+
+	if m.mode == trainModeReject {
+		b.WriteString("\nreject reason: " + m.rejectInput.View() + "\n")
+	}
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	for _, line := range m.resultLines {
+		b.WriteString(mutedStyle.Render(line) + "\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(mutedStyle.Render(m.footer()))
 	return b.String()
+}
+
+// footer is the phase-aware key hint line.
+func (m TrainRunModel) footer() string {
+	if m.mode == trainModeReject {
+		return "type reason  enter reject  esc cancel"
+	}
+	if m.actionBusy {
+		return "working…  q quit"
+	}
+	action := ""
+	switch m.snap.Phase {
+	case "items_ready", "feedback_synced", "training_package_created":
+		action = "enter generate  "
+	case "options_generated":
+		action = "enter publish review  "
+	case "review_published":
+		action = "enter sync feedback  "
+	case "candidate_created":
+		action = "enter publish candidate review  "
+	case "candidate_review_published":
+		action = "p promote  x reject  "
+	}
+	if m.snap.Terminal {
+		action = "n start next iteration  "
+	}
+	return action + "r refresh  q quit"
 }
 
 func (m TrainRunModel) phaseBar() string {


### PR DESCRIPTION
Part of #234 (train run TUI). **Task 4 of 6.**

## WHAT
Makes the `train run` TUI drive the whole phase loop with single keypresses — no `train continue` re-runs or flags.

## CHANGES
- Per-phase keys: `enter` generates (items_ready / feedback_synced → **detached child** so `q` quits and the run keeps going), or publishes review / syncs feedback / publishes candidate review (short, in-process `continueSkillOptTrain`); `p` promote, `x` reject (with a reason input), `n` start next on terminal phases.
- `spawnSkillOptTrainContinueChild`: `train continue --session <id>` with `Setsid` + a per-session log file (cloned from `startDaemonChild`); stubbable var.
- Deps wire `Continue`/`Decide`/`StartNext` over `continueSkillOptTrain` and `SpawnContinue` over the child. `actionBusy` guards re-entry; errors (incl. lock-busy) render inline; the phase bar advances on the next refresh tick.
- Reject-reason textinput sub-mode; phase-aware footer.

## Deferred (noted on #234, follow-up)
- The `--config` **confirm screen** that creates a session in-TUI — it needs lifting `train start`'s plan builder, too large/risky to cram here safely. `train run` still requires an existing session; `train start`'s confirm output is unchanged.
- The generation/optimizer **log tail** — the phase bar + live job counts/ETA already show progress; tailing is incremental polish.

## RESULTS
- `go test ./internal/cli/tui` green (generate→spawn, publish→in-process, promote, reject-requires-reason, start-next, actionBusy suppression, action error shown); `go vet`/`gofmt`/`git diff --check` clean.

## RISK
Low; TUI-only, reachable only on a terminal. The TUI takes no locks — long phases run in the detached child (same locks the daemon/review-watcher already coordinate on); lock-busy surfaces as an inline message.

## Key choice
Reject is `x` (not `r`) because `r` is the global refresh; the phase-aware footer shows `p promote · x reject`.

## /code-review
High-effort review: **no findings**. Verified the detached-child fd handling, the in-process/spawn split never runs generation/optimizer in-process (freezing the UI), no stuck-busy path, key guards per phase, and that `continueSkillOptTrain` dispatches correctly from a bare {Home,SessionID} request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)