### PR TITLE
cli: offer GitHub repo creation for missing train repos (train-run task 5)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1154,6 +1154,7 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 	minItems := fs.Int("min-items", 2, "minimum number of training review items")
 	preferredGate := fs.String("preferred-gate", "", "evaluation gate: hard, soft, or hard_then_soft")
 	dryRun := fs.Bool("dry-run", false, "print inferred session state without writing")
+	createRepos := fs.Bool("create-repos", false, "create the target and workspace repositories on GitHub if they do not exist")
 	yes := fs.Bool("yes", false, "confirm creation without an interactive prompt")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -1197,6 +1198,14 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 	if workspaceRepo == "" {
 		fmt.Fprintln(stderr, "skillopt train start requires --workspace-repo owner/repo; without it the session stays at request_confirmed and train continue cannot reach option generation")
 		return 2
+	}
+	if *createRepos {
+		for _, fullName := range []string{repo.FullName(), workspaceRepo} {
+			if err := ensureSkillOptTrainRepo(fullName, stdout); err != nil {
+				fmt.Fprintf(stderr, "skillopt train start: create repo %s: %v\n", fullName, err)
+				return 1
+			}
+		}
 	}
 	previewRepo, err := parseOptionalSkillOptTrainRepo("preview-repo", *previewRepoFlag)
 	if err != nil {
@@ -1301,6 +1310,34 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 	}
 	writeLine(stdout, "created train session %s", plan.Session.ID)
 	return 0
+}
+
+// ensureSkillOptTrainRepo creates the given repo as a private GitHub repo when it
+// does not already exist. Deduplicated callers pass distinct names; an empty name
+// is a no-op. An ambiguous existence check (e.g. auth error) is left alone so the
+// later Preflight surfaces it, rather than wrongly attempting a create.
+func ensureSkillOptTrainRepo(fullName string, stdout io.Writer) error {
+	if strings.TrimSpace(fullName) == "" {
+		return nil
+	}
+	repo, err := daemon.ParseRepository(fullName)
+	if err != nil {
+		return err
+	}
+	client := newSkillOptGitHubClient()
+	exists, err := client.RepositoryExists(context.Background(), repo)
+	if err != nil {
+		// Ambiguous (auth/network); do not attempt a create, let Preflight report.
+		return nil
+	}
+	if exists {
+		return nil
+	}
+	if err := client.CreateRepository(context.Background(), repo, true); err != nil {
+		return err
+	}
+	writeLine(stdout, "created_repo: %s", fullName)
+	return nil
 }
 
 func flagNamesSet(fs *flag.FlagSet) map[string]struct{} {

--- a/internal/cli/skillopt_repocreate_test.go
+++ b/internal/cli/skillopt_repocreate_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+// repoCreateFakeGitHub reports configured repos as missing and records creates.
+type repoCreateFakeGitHub struct {
+	github.NoopClient
+	existing map[string]bool
+	created  []string
+	existErr error
+}
+
+func (f *repoCreateFakeGitHub) RepositoryExists(_ context.Context, repo github.Repository) (bool, error) {
+	if f.existErr != nil {
+		return false, f.existErr
+	}
+	return f.existing[repo.FullName()], nil
+}
+
+func (f *repoCreateFakeGitHub) CreateRepository(_ context.Context, repo github.Repository, _ bool) error {
+	f.created = append(f.created, repo.FullName())
+	if f.existing == nil {
+		f.existing = map[string]bool{}
+	}
+	f.existing[repo.FullName()] = true
+	return nil
+}
+
+func replaceSkillOptGitHubClient(client github.Client) func() {
+	prev := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client { return client }
+	return func() { newSkillOptGitHubClient = prev }
+}
+
+func TestEnsureSkillOptTrainRepoCreatesMissing(t *testing.T) {
+	fake := &repoCreateFakeGitHub{existing: map[string]bool{"o/exists": true}}
+	restore := replaceSkillOptGitHubClient(fake)
+	defer restore()
+
+	var out bytes.Buffer
+	// Existing repo: no create, no output.
+	if err := ensureSkillOptTrainRepo("o/exists", &out); err != nil {
+		t.Fatalf("ensure existing: %v", err)
+	}
+	if len(fake.created) != 0 || out.Len() != 0 {
+		t.Fatalf("existing repo should be untouched: created=%v out=%q", fake.created, out.String())
+	}
+
+	// Missing repo: created + a created_repo line.
+	if err := ensureSkillOptTrainRepo("o/missing", &out); err != nil {
+		t.Fatalf("ensure missing: %v", err)
+	}
+	if len(fake.created) != 1 || fake.created[0] != "o/missing" {
+		t.Fatalf("created = %v, want [o/missing]", fake.created)
+	}
+	if !strings.Contains(out.String(), "created_repo: o/missing") {
+		t.Fatalf("expected created_repo line: %q", out.String())
+	}
+}
+
+func TestEnsureSkillOptTrainRepoSkipsOnAmbiguousError(t *testing.T) {
+	fake := &repoCreateFakeGitHub{existErr: context.DeadlineExceeded}
+	restore := replaceSkillOptGitHubClient(fake)
+	defer restore()
+
+	var out bytes.Buffer
+	if err := ensureSkillOptTrainRepo("o/repo", &out); err != nil {
+		t.Fatalf("ensure should not error on ambiguous check: %v", err)
+	}
+	if len(fake.created) != 0 {
+		t.Fatalf("ambiguous check must not create: %v", fake.created)
+	}
+}
+
+func TestSkillOptTrainRepoCheckerAndCreator(t *testing.T) {
+	fake := &repoCreateFakeGitHub{existing: map[string]bool{"o/here": true}}
+	restore := replaceSkillOptGitHubClient(fake)
+	defer restore()
+
+	check := skillOptTrainRepoChecker()
+	missing, err := check("o/here")
+	if err != nil || missing {
+		t.Fatalf("existing repo: (missing=%v, err=%v), want (false, nil)", missing, err)
+	}
+	missing, err = check("o/gone")
+	if err != nil || !missing {
+		t.Fatalf("absent repo: (missing=%v, err=%v), want (true, nil)", missing, err)
+	}
+	if _, err := check("not-a-repo-ref-without-slash"); err == nil {
+		t.Fatal("unparseable repo should error")
+	}
+
+	create := skillOptTrainRepoCreator()
+	if err := create("o/new"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if len(fake.created) != 1 || fake.created[0] != "o/new" {
+		t.Fatalf("created = %v", fake.created)
+	}
+}

--- a/internal/cli/skillopt_tui.go
+++ b/internal/cli/skillopt_tui.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/jerryfane/gitmoot/internal/cli/tui"
+	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
 )
@@ -98,12 +99,43 @@ func buildSkillOptTrainInitTUIFields(store *db.Store, scope string, values skill
 			for _, choice := range descriptor.Prompt.Choices {
 				entry.Choices = append(entry.Choices, tui.Choice{Value: choice, Label: choice})
 			}
+		case field == "review_repo":
+			entry.Kind = tui.FieldText
+			entry.CheckRepo = skillOptTrainRepoChecker()
+			entry.CreateRepo = skillOptTrainRepoCreator()
 		default:
 			entry.Kind = tui.FieldText
 		}
 		fields = append(fields, entry)
 	}
 	return fields, nil
+}
+
+// skillOptTrainRepoChecker reports whether a "owner/repo" value is missing on
+// GitHub. An unparseable value or an ambiguous (auth/network) check returns the
+// error so the form re-asks rather than offering a create.
+func skillOptTrainRepoChecker() func(string) (bool, error) {
+	return func(value string) (bool, error) {
+		repo, err := daemon.ParseRepository(value)
+		if err != nil {
+			return false, err
+		}
+		exists, err := newSkillOptGitHubClient().RepositoryExists(context.Background(), repo)
+		if err != nil {
+			return false, err
+		}
+		return !exists, nil
+	}
+}
+
+func skillOptTrainRepoCreator() func(string) error {
+	return func(value string) error {
+		repo, err := daemon.ParseRepository(value)
+		if err != nil {
+			return err
+		}
+		return newSkillOptGitHubClient().CreateRepository(context.Background(), repo, true)
+	}
 }
 
 // skillOptTrainInitTUISummaryRows renders the confirm-screen rows: each field's

--- a/internal/cli/tui/traininit.go
+++ b/internal/cli/tui/traininit.go
@@ -15,6 +15,8 @@ type tiState int
 const (
 	tiField tiState = iota
 	tiCustomPath
+	tiRepoCheck
+	tiRepoMissing
 	tiConfirm
 	tiDone
 )
@@ -46,6 +48,10 @@ type TrainInitModel struct {
 
 	pendingPromptID string
 	aborted         bool
+
+	// pendingValue holds a validated free-text answer awaiting a repo
+	// existence check / creation decision (tiRepoCheck / tiRepoMissing).
+	pendingValue string
 }
 
 // NewTrainInit builds the form. summary renders the confirm-screen rows from the
@@ -106,8 +112,52 @@ func (m TrainInitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Not answered yet (or the record is not visible yet) — keep polling.
 		return m, pollTick(m.poll, m.gen)
+	case repoCheckMsg:
+		if msg.gen != m.gen || m.state != tiRepoCheck {
+			return m, nil
+		}
+		if msg.err != nil {
+			m.state = tiField
+			m.inlineErr = "repo check failed: " + msg.err.Error()
+			return m, nil
+		}
+		if !msg.missing {
+			return m.commit(msg.value)
+		}
+		m.state = tiRepoMissing
+		return m, nil
+	case repoCreatedMsg:
+		if msg.gen != m.gen || m.state != tiRepoMissing {
+			return m, nil // the user re-entered the field before the create returned
+		}
+		if msg.err != nil {
+			m.state = tiRepoMissing
+			m.inlineErr = "create failed: " + msg.err.Error()
+			return m, nil
+		}
+		return m.commit(msg.value)
 	}
 	return m, nil
+}
+
+func checkRepoCmd(field Field, value string, gen int) tea.Cmd {
+	return func() tea.Msg {
+		if field.CheckRepo == nil {
+			return repoCheckMsg{gen: gen, value: value}
+		}
+		missing, err := field.CheckRepo(value)
+		return repoCheckMsg{gen: gen, value: value, missing: missing, err: err}
+	}
+}
+
+func createRepoCmd(field Field, value string, gen int) tea.Cmd {
+	return func() tea.Msg {
+		var err error
+		if field.CreateRepo != nil {
+			err = field.CreateRepo(value)
+		}
+		return repoCreatedMsg{gen: gen, value: value, err: err}
+	}
 }
 
 func (m TrainInitModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -121,6 +171,27 @@ func (m TrainInitModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.updateFieldKey(msg)
 	case tiCustomPath:
 		return m.updateCustomPathKey(msg)
+	case tiRepoCheck:
+		if msg.String() == "esc" {
+			return m.abort()
+		}
+		return m, nil // checking; ignore keys until the result arrives
+	case tiRepoMissing:
+		switch msg.String() {
+		case "c", "C":
+			m.inlineErr = ""
+			return m, createRepoCmd(m.fields[m.idx], m.pendingValue, m.gen)
+		case "e", "E", "esc":
+			// Re-enter the field with the value prefilled.
+			m.state = tiField
+			m.inlineErr = ""
+			ti := textinput.New()
+			ti.SetValue(m.pendingValue)
+			ti.CursorEnd()
+			m.input = ti
+			return m, m.input.Focus()
+		}
+		return m, nil
 	case tiConfirm:
 		switch msg.String() {
 		case "y", "Y", "enter":
@@ -145,6 +216,12 @@ func (m TrainInitModel) updateFieldKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if status != "ok" {
 				m.inlineErr = "value required"
 				return m, nil
+			}
+			if field.CheckRepo != nil {
+				m.pendingValue = value
+				m.state = tiRepoCheck
+				m.inlineErr = ""
+				return m, checkRepoCmd(field, value, m.gen)
 			}
 			return m.commit(value)
 		}
@@ -311,6 +388,19 @@ type pollResultMsg struct {
 }
 
 type promptGoneMsg struct{ err error }
+
+type repoCheckMsg struct {
+	gen     int
+	value   string
+	missing bool
+	err     error
+}
+
+type repoCreatedMsg struct {
+	gen   int
+	value string
+	err   error
+}
 
 func upsertPromptCmd(store PromptStore, prompt db.InteractivePrompt, gen int) tea.Cmd {
 	return func() tea.Msg {

--- a/internal/cli/tui/traininit_field.go
+++ b/internal/cli/tui/traininit_field.go
@@ -34,6 +34,11 @@ type Field struct {
 	Prompt  db.InteractivePrompt // record upserted so an agent can answer externally
 	Choices []Choice             // for FieldChoice/FieldTemplate
 	Default string               // text prefill / preselected choice value
+
+	// CheckRepo / CreateRepo, when set on a FieldText, gate advancing on the
+	// answer being an existing GitHub repo; a missing repo offers creation.
+	CheckRepo  func(value string) (missing bool, err error)
+	CreateRepo func(value string) error
 }
 
 // PromptStore is the subset of *db.Store the form needs to publish a prompt

--- a/internal/cli/tui/traininit_test.go
+++ b/internal/cli/tui/traininit_test.go
@@ -223,6 +223,80 @@ func TestTrainInitAutoAcceptWhenExternallyAnswered(t *testing.T) {
 	}
 }
 
+func TestTrainInitRepoCreateFlow(t *testing.T) {
+	created := ""
+	fields := []Field{
+		{Name: "review_repo", Label: "Review repository", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "ti.review_repo"},
+			CheckRepo:  func(value string) (bool, error) { return true, nil }, // always missing
+			CreateRepo: func(value string) error { created = value; return nil }},
+		{Name: "name", Label: "Name", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "ti.name"}},
+	}
+	m := startTI(t, newFakeStore(), fields)
+
+	// Type a repo and submit → repo check runs.
+	next, _ := m.Update(key("owner/repo"))
+	m = next.(TrainInitModel)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainInitModel)
+	if m.state != tiRepoCheck || cmd == nil {
+		t.Fatalf("enter should start a repo check, state=%v", m.state)
+	}
+	next, _ = m.Update(cmd()) // repoCheckMsg{missing:true}
+	m = next.(TrainInitModel)
+	if m.state != tiRepoMissing {
+		t.Fatalf("missing repo should offer creation, state=%v", m.state)
+	}
+	if !strings.Contains(m.View(), "does not exist") {
+		t.Fatalf("expected the missing-repo prompt:\n%s", m.View())
+	}
+
+	// c creates the repo, then advances to the next field.
+	next, cmd = m.Update(key("c"))
+	m = next.(TrainInitModel)
+	if cmd == nil {
+		t.Fatal("c should run create")
+	}
+	next, _ = m.Update(cmd()) // repoCreatedMsg
+	m = next.(TrainInitModel)
+	if created != "owner/repo" {
+		t.Fatalf("CreateRepo called with %q", created)
+	}
+	if m.Result().Values["review_repo"] != "owner/repo" || m.idx != 1 {
+		t.Fatalf("should record the repo and advance: values=%+v idx=%d", m.Result().Values, m.idx)
+	}
+}
+
+func TestTrainInitRepoReEnter(t *testing.T) {
+	createCalls := 0
+	fields := []Field{
+		{Name: "review_repo", Label: "Review repository", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "ti.review_repo"},
+			CheckRepo:  func(value string) (bool, error) { return true, nil },
+			CreateRepo: func(value string) error { createCalls++; return nil }},
+	}
+	m := startTI(t, newFakeStore(), fields)
+	next, _ := m.Update(key("owner/typo"))
+	m = next.(TrainInitModel)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainInitModel)
+	next, _ = m.Update(cmd())
+	m = next.(TrainInitModel)
+	if m.state != tiRepoMissing {
+		t.Fatalf("expected tiRepoMissing, got %v", m.state)
+	}
+	// e re-enters the field with the value prefilled; no create.
+	next, _ = m.Update(key("e"))
+	m = next.(TrainInitModel)
+	if m.state != tiField {
+		t.Fatalf("e should return to the field, state=%v", m.state)
+	}
+	if !strings.Contains(m.input.Value(), "owner/typo") {
+		t.Fatalf("re-enter should prefill the value, got %q", m.input.Value())
+	}
+	if createCalls != 0 {
+		t.Fatal("re-enter must not create")
+	}
+}
+
 func TestTrainInitProgressHeader(t *testing.T) {
 	m := startTI(t, newFakeStore(), tiFields())
 	if !strings.Contains(m.View(), "[1/3]") {

--- a/internal/cli/tui/traininit_view.go
+++ b/internal/cli/tui/traininit_view.go
@@ -14,9 +14,31 @@ func (m TrainInitModel) View() string {
 		return ""
 	case tiCustomPath:
 		return m.customPathView()
+	case tiRepoCheck:
+		return m.repoCheckView()
+	case tiRepoMissing:
+		return m.repoMissingView()
 	default:
 		return m.fieldView()
 	}
+}
+
+func (m TrainInitModel) repoCheckView() string {
+	return headerStyle.Render(m.fields[m.idx].Label) + "\n\n" +
+		mutedStyle.Render("checking "+m.pendingValue+" on GitHub…")
+}
+
+func (m TrainInitModel) repoMissingView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render(m.fields[m.idx].Label))
+	b.WriteString("\n\n")
+	b.WriteString("repo " + m.pendingValue + " does not exist on GitHub\n")
+	if m.inlineErr != "" {
+		b.WriteString(errorStyle.Render(m.inlineErr) + "\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(mutedStyle.Render("c create private repo  e re-enter  esc re-enter"))
+	return b.String()
 }
 
 func (m TrainInitModel) fieldView() string {


### PR DESCRIPTION
Part of #234 (train run TUI). **Task 5 of 6.**

## WHAT
Lets gitmoot create a missing GitHub repo instead of failing later, at the two entry points where you name one.

## CHANGES
- **train-init TUI** `review_repo` field: checks existence on submit; a missing repo opens `[c] create private repo · [e] re-enter` (esc also re-enters). Ambiguous/auth errors re-ask (never auto-create). Line wizard / non-TTY init untouched.
- **`train start --create-repos`**: creates the target and workspace repos if missing (private), printing `created_repo:`. Without the flag, `train start` makes **zero gh calls** and is byte-identical.
- `ensureSkillOptTrainRepo` leaves an ambiguous existence check alone so `Preflight` reports it.

## RESULTS
- `go test ./internal/cli ./internal/cli/tui` green (ensure creates-missing/skips-existing/skips-ambiguous; checker+creator; form create flow + re-enter; existing `SkillOptTrainStart` tests pass → byte-stable). `go vet`/`gofmt`/`git diff --check` clean.

## Note (deferred from Task 4)
The `train run` confirm-screen `[c]` hook isn't included because the confirm screen itself was deferred (it needs lifting `train start`'s plan builder). Tracked on #234.

## RISK
Low. The headless `train start` path is unchanged without `--create-repos`; the form hook only runs on a TTY.

## /code-review
High-effort review found **one real race**, fixed: the `repoCreatedMsg` handler now also guards on `m.state == tiRepoMissing`, so pressing `c` then `e` before the create returns can't stray-advance the form. Re-verified byte-stability, ambiguous-error handling (never creates), and that the form's gen/poll stay valid across re-enter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)