### PR TITLE
cli: create the train session from the train run confirm screen

### DIFF
--- a/internal/cli/skillopt_trainrun_tui.go
+++ b/internal/cli/skillopt_trainrun_tui.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -34,15 +36,63 @@ var skillOptTrainRunTUICapable = func() bool {
 		in.Mode()&os.ModeCharDevice != 0 && out.Mode()&os.ModeCharDevice != 0
 }
 
-// runSkillOptTrainRunTUI launches the bubbletea program. A var so dispatch tests
-// can stub the actual run.
+// runSkillOptTrainRunTUI launches the bubbletea program for an existing session.
+// A var so dispatch tests can stub the actual run.
 var runSkillOptTrainRunTUI = func(home, sessionID string, stdout, stderr io.Writer) int {
-	program := tea.NewProgram(tui.NewTrainRun(skillOptTrainRunDeps(home, sessionID)), tea.WithOutput(stdout))
+	deps := skillOptTrainRunDeps(home, func() string { return sessionID })
+	program := tea.NewProgram(tui.NewTrainRun(deps), tea.WithOutput(stdout))
 	if _, err := program.Run(); err != nil {
 		fmt.Fprintf(stderr, "skillopt train run: %v\n", err)
 		return 1
 	}
 	return 0
+}
+
+// runSkillOptTrainRunConfirmTUI launches the bubbletea program on the confirm
+// screen for a config with no session yet: it creates the session (via
+// train start --yes) and then shows the live phase view. A var so tests can stub it.
+var runSkillOptTrainRunConfirmTUI = func(home, configPath, workspaceRepo string, stdout, stderr io.Writer) int {
+	plan, err := buildSkillOptTrainRunPlan(configPath, workspaceRepo)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt train run: %v\n", err)
+		return 1
+	}
+	created := &skillOptTrainRunSessionRef{}
+	deps := skillOptTrainRunDeps(home, created.get)
+	deps.Plan = plan
+	deps.CreateSession = func(ws string) (string, error) {
+		id, err := createSkillOptTrainRunSession(home, configPath, ws, stderr)
+		if err != nil {
+			return "", err
+		}
+		created.set(id)
+		return id, nil
+	}
+	program := tea.NewProgram(tui.NewTrainRun(deps), tea.WithOutput(stdout))
+	if _, err := program.Run(); err != nil {
+		fmt.Fprintf(stderr, "skillopt train run: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// skillOptTrainRunSessionRef holds the session id the confirm flow creates, read
+// concurrently by tea.Cmd goroutines (Load/Continue/…).
+type skillOptTrainRunSessionRef struct {
+	mu sync.Mutex
+	id string
+}
+
+func (r *skillOptTrainRunSessionRef) get() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.id
+}
+
+func (r *skillOptTrainRunSessionRef) set(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.id = id
 }
 
 func runSkillOptTrainRun(args []string, stdout, stderr io.Writer) int {
@@ -51,6 +101,7 @@ func runSkillOptTrainRun(args []string, stdout, stderr io.Writer) int {
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	configPath := fs.String("config", "", "train init config path to resolve the latest session")
 	sessionID := fs.String("session", "", "train session id")
+	workspaceRepo := fs.String("workspace-repo", "", "workspace repository to use when creating a session from --config")
 	plain := fs.Bool("plain", false, "print a one-shot status snapshot instead of the interactive TUI")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -69,8 +120,11 @@ func runSkillOptTrainRun(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if resolved == "" {
-		// No session yet for this config. Task 4 adds an interactive confirm
-		// screen; for now point at train start.
+		// No session yet for this config. On a terminal, open the confirm screen
+		// to create one; otherwise point at train start.
+		if !*plain && strings.TrimSpace(*configPath) != "" && skillOptTrainRunTUICapable() {
+			return runSkillOptTrainRunConfirmTUI(*home, *configPath, strings.TrimSpace(*workspaceRepo), stdout, stderr)
+		}
 		writeLine(stdout, "no train session yet for this config")
 		if strings.TrimSpace(*configPath) != "" {
 			writeLine(stdout, "next: gitmoot skillopt train start --config %s --workspace-repo <owner/repo>", *configPath)
@@ -149,8 +203,9 @@ func resolveSkillOptTrainRunSession(home, sessionID, configPath string) (string,
 }
 
 // skillOptTrainRunDeps wires the snapshot loader and phase actions into
-// tui.TrainRunDeps.
-func skillOptTrainRunDeps(home, sessionID string) tui.TrainRunDeps {
+// tui.TrainRunDeps. sessionID is a getter so the confirm flow (which creates the
+// session mid-program) and the resolved-session flow can share one builder.
+func skillOptTrainRunDeps(home string, sessionID func() string) tui.TrainRunDeps {
 	runContinue := func(mutate func(*skillOptTrainContinueRequest)) (tui.TrainRunActionResult, error) {
 		paths, err := initializedPaths(home)
 		if err != nil {
@@ -158,7 +213,7 @@ func skillOptTrainRunDeps(home, sessionID string) tui.TrainRunDeps {
 		}
 		var out skillOptTrainContinueOutput
 		err = withStore(home, func(store *db.Store) error {
-			request := skillOptTrainContinueRequest{Home: home, SessionID: sessionID}
+			request := skillOptTrainContinueRequest{Home: home, SessionID: sessionID()}
 			if mutate != nil {
 				mutate(&request)
 			}
@@ -173,7 +228,7 @@ func skillOptTrainRunDeps(home, sessionID string) tui.TrainRunDeps {
 		Load: func() (tui.TrainRunSnapshot, error) {
 			var snapshot skillOptTrainStatusSnapshot
 			if err := withStore(home, func(store *db.Store) error {
-				loaded, err := loadSkillOptTrainStatusSnapshot(context.Background(), store, sessionID, true)
+				loaded, err := loadSkillOptTrainStatusSnapshot(context.Background(), store, sessionID(), true)
 				if err != nil {
 					return err
 				}
@@ -198,8 +253,55 @@ func skillOptTrainRunDeps(home, sessionID string) tui.TrainRunDeps {
 		StartNext: func() (tui.TrainRunActionResult, error) {
 			return runContinue(func(r *skillOptTrainContinueRequest) { r.StartNext = true })
 		},
-		SpawnContinue: func() (string, error) { return spawnSkillOptTrainContinueChild(home, sessionID) },
+		SpawnContinue: func() (string, error) { return spawnSkillOptTrainContinueChild(home, sessionID()) },
 	}
+}
+
+// buildSkillOptTrainRunPlan loads the config into a confirm-screen plan.
+func buildSkillOptTrainRunPlan(configPath, workspaceRepo string) (*tui.TrainRunPlan, error) {
+	config, err := skillopt.LoadTrainInitConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+	template := strings.TrimSpace(config.Template)
+	if v := strings.TrimSpace(config.TemplateVersion); v != "" {
+		template += " @" + strings.TrimPrefix(v, strings.TrimSpace(config.Template)+"@")
+	}
+	return &tui.TrainRunPlan{
+		Name:              strings.TrimSpace(config.Name),
+		Template:          template,
+		ReviewRepo:        strings.TrimSpace(config.ReviewRepo),
+		WorkspaceRepo:     strings.TrimSpace(workspaceRepo),
+		NeedWorkspaceRepo: strings.TrimSpace(workspaceRepo) == "",
+	}, nil
+}
+
+// createSkillOptTrainRunSession creates a session from a config by invoking the
+// real `train start --yes` in process (no plan-building duplication), capturing
+// its output so it does not corrupt the TUI. Missing repos are created
+// (--create-repos). Returns the new session id.
+func createSkillOptTrainRunSession(home, configPath, workspaceRepo string, stderr io.Writer) (string, error) {
+	if strings.TrimSpace(workspaceRepo) == "" {
+		return "", errors.New("workspace repo is required")
+	}
+	config, err := skillopt.LoadTrainInitConfig(configPath)
+	if err != nil {
+		return "", err
+	}
+	sessionID := generatedSkillOptTrainSessionID(config.Template)
+	args := []string{
+		"--home", home,
+		"--config", configPath,
+		"--workspace-repo", workspaceRepo,
+		"--session", sessionID,
+		"--create-repos",
+		"--yes",
+	}
+	var buf bytes.Buffer
+	if code := runSkillOptTrainStart(args, &buf, &buf); code != 0 {
+		return "", fmt.Errorf("train start failed: %s", strings.TrimSpace(buf.String()))
+	}
+	return sessionID, nil
 }
 
 // spawnSkillOptTrainContinueChild launches `gitmoot skillopt train continue` as a

--- a/internal/cli/skillopt_trainrun_tui_test.go
+++ b/internal/cli/skillopt_trainrun_tui_test.go
@@ -115,6 +115,80 @@ func TestSkillOptTrainRunDispatchPlainFallback(t *testing.T) {
 	}
 }
 
+func TestBuildSkillOptTrainRunPlan(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := "name = \"x\"\ntemplate = \"planner\"\ntemplate_version = \"planner@v1\"\nreview_repo = \"o/r\"\ntask_kind = \"custom\"\nartifact_kind = \"text\"\npreview = \"none\"\nmode = \"explore\"\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	// No workspace repo → confirm screen must ask for it; template label not doubled.
+	plan, err := buildSkillOptTrainRunPlan(cfgPath, "")
+	if err != nil {
+		t.Fatalf("buildSkillOptTrainRunPlan: %v", err)
+	}
+	if !plan.NeedWorkspaceRepo || plan.Template != "planner @v1" || plan.ReviewRepo != "o/r" {
+		t.Fatalf("plan = %+v", plan)
+	}
+	// With a workspace repo → no prompt needed.
+	plan, err = buildSkillOptTrainRunPlan(cfgPath, "o/ws")
+	if err != nil {
+		t.Fatalf("buildSkillOptTrainRunPlan: %v", err)
+	}
+	if plan.NeedWorkspaceRepo || plan.WorkspaceRepo != "o/ws" {
+		t.Fatalf("plan = %+v", plan)
+	}
+}
+
+func TestCreateSkillOptTrainRunSession(t *testing.T) {
+	home := t.TempDir()
+	workspace := chdirTemp(t)
+	seedPlannerTemplate(t, home)
+	// A scaffold config + items the start command can read.
+	scaffold := filepath.Join(workspace, ".gitmoot", "skillopt", "runsess")
+	if err := os.MkdirAll(scaffold, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(scaffold, "config.toml")
+	cfg := "name = \"runsess\"\ntemplate = \"planner\"\ntemplate_version = \"planner@v1\"\nreview_repo = \"jerryfane/gitmoot\"\ntask_kind = \"custom\"\nartifact_kind = \"text\"\npreview = \"none\"\nmode = \"explore\"\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	itemsPath := filepath.Join(scaffold, "review-items.yml")
+	if err := os.WriteFile(itemsPath, []byte("items:\n  - title: One\n    brief: First item.\n    output_type: markdown\n  - title: Two\n    brief: Second item.\n    output_type: markdown\n"), 0o644); err != nil {
+		t.Fatalf("write items: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scaffold, "task.md"), []byte("Improve the planner summaries.\n"), 0o644); err != nil {
+		t.Fatalf("write task.md: %v", err)
+	}
+
+	// Stub GitHub so --create-repos does not hit the network.
+	restore := replaceSkillOptGitHubClient(&repoCreateFakeGitHub{existing: map[string]bool{"jerryfane/gitmoot": true, "jerryfane/gitmoot-ws": true}})
+	defer restore()
+
+	id, err := createSkillOptTrainRunSession(home, cfgPath, "jerryfane/gitmoot-ws", &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("createSkillOptTrainRunSession: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected a session id")
+	}
+	// The session exists and is loadable.
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+	if _, err := store.GetSkillOptTrainSession(context.Background(), id); err != nil {
+		t.Fatalf("created session not found: %v", err)
+	}
+
+	// Missing workspace repo → error, no session.
+	if _, err := createSkillOptTrainRunSession(home, cfgPath, "", &bytes.Buffer{}); err == nil {
+		t.Fatal("empty workspace repo should error")
+	}
+}
+
 func TestToTrainRunSnapshot(t *testing.T) {
 	snap := skillOptTrainStatusSnapshot{
 		SessionID:       "s1",

--- a/internal/cli/tui/trainrun.go
+++ b/internal/cli/tui/trainrun.go
@@ -38,6 +38,16 @@ type TrainRunActionResult struct {
 	Lines []string
 }
 
+// TrainRunPlan is shown on the confirm screen when there is no session yet for a
+// --config. CreateSession (below) writes it.
+type TrainRunPlan struct {
+	Name              string
+	Template          string // "<id>@<version>"
+	ReviewRepo        string
+	WorkspaceRepo     string // pre-supplied via --workspace-repo; else collected
+	NeedWorkspaceRepo bool
+}
+
 // TrainRunDeps are the data source and action callbacks the cli injects. The tui
 // package stays store-free. Continue advances a short (seconds) phase in
 // process; SpawnContinue launches the detached child for the long phases
@@ -49,6 +59,12 @@ type TrainRunDeps struct {
 	Decide        func(promote bool, candidate, reason string) (TrainRunActionResult, error)
 	StartNext     func() (TrainRunActionResult, error)
 	SpawnContinue func() (logPath string, err error)
+
+	// Plan, when non-nil, opens the confirm screen first (no session yet for the
+	// --config). CreateSession writes the session and returns its id; afterwards
+	// Load/Continue/… operate on the new session.
+	Plan          *TrainRunPlan
+	CreateSession func(workspaceRepo string) (sessionID string, err error)
 }
 
 type trainRunMode int
@@ -76,6 +92,11 @@ type trainSpawnMsg struct {
 	err     error
 }
 
+type trainCreatedMsg struct {
+	sessionID string
+	err       error
+}
+
 // TrainRunModel renders a single train session as a live phase view.
 type TrainRunModel struct {
 	deps     TrainRunDeps
@@ -91,11 +112,28 @@ type TrainRunModel struct {
 	actionErr   string
 	resultLines []string
 	rejectInput textinput.Model
+
+	// Confirm-screen state (deps.Plan != nil and no session yet).
+	confirming bool
+	creating   bool
+	createErr  string
+	wsInput    textinput.Model
 }
 
 // NewTrainRun returns a model ready for tea.NewProgram.
 func NewTrainRun(deps TrainRunDeps) TrainRunModel {
-	return TrainRunModel{deps: deps, width: 100, height: 30, inFlight: true}
+	m := TrainRunModel{deps: deps, width: 100, height: 30, inFlight: true}
+	if deps.Plan != nil {
+		m.confirming = true
+		m.inFlight = false
+		if deps.Plan.NeedWorkspaceRepo {
+			ti := textinput.New()
+			ti.Placeholder = "owner/repo"
+			m.wsInput = ti
+			m.wsInput.Focus() // focus state must be set here (Init's value receiver cannot persist it)
+		}
+	}
+	return m
 }
 
 func (m TrainRunModel) interval() time.Duration {
@@ -105,8 +143,16 @@ func (m TrainRunModel) interval() time.Duration {
 	return m.deps.Interval
 }
 
-// Init issues the first load and arms the refresh tick.
+// Init issues the first load and arms the refresh tick — unless a confirm screen
+// is pending (no session yet), in which case it waits for [enter] to create one
+// (the workspace-repo input, if any, was already focused in NewTrainRun).
 func (m TrainRunModel) Init() tea.Cmd {
+	if m.confirming {
+		if m.deps.Plan != nil && m.deps.Plan.NeedWorkspaceRepo {
+			return textinput.Blink
+		}
+		return nil
+	}
 	return tea.Batch(loadTrainSnapshot(m.deps), trainTick(m.interval()))
 }
 
@@ -129,6 +175,17 @@ func (m TrainRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if cmd := m.queueLoad(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
+		}
+	case trainCreatedMsg:
+		m.creating = false
+		if msg.err != nil {
+			m.createErr = msg.err.Error()
+		} else {
+			// Session created — leave the confirm screen and start the live view.
+			m.confirming = false
+			m.createErr = ""
+			m.inFlight = true
+			cmds = append(cmds, loadTrainSnapshot(m.deps), trainTick(m.interval()))
 		}
 	case trainSpawnMsg:
 		m.actionBusy = false
@@ -164,6 +221,33 @@ func (m TrainRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m TrainRunModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.String() == "ctrl+c" {
 		return m, tea.Quit
+	}
+	if m.confirming {
+		switch msg.String() {
+		case "esc", "q":
+			return m, tea.Quit
+		case "enter":
+			if m.creating {
+				return m, nil
+			}
+			ws := m.deps.Plan.WorkspaceRepo
+			if m.deps.Plan.NeedWorkspaceRepo {
+				ws = strings.TrimSpace(m.wsInput.Value())
+				if ws == "" {
+					m.createErr = "workspace repo (owner/repo) is required"
+					return m, nil
+				}
+			}
+			m.creating = true
+			m.createErr = ""
+			return m, createSessionCmd(m.deps, ws)
+		}
+		if m.deps.Plan.NeedWorkspaceRepo && !m.creating {
+			var cmd tea.Cmd
+			m.wsInput, cmd = m.wsInput.Update(msg)
+			return m, cmd
+		}
+		return m, nil
 	}
 	if m.mode == trainModeReject {
 		switch msg.String() {
@@ -256,6 +340,16 @@ func startNextCmd(d TrainRunDeps) tea.Cmd {
 		}
 		res, err := d.StartNext()
 		return trainActionMsg{result: res, err: err}
+	}
+}
+
+func createSessionCmd(d TrainRunDeps, workspaceRepo string) tea.Cmd {
+	return func() tea.Msg {
+		if d.CreateSession == nil {
+			return trainCreatedMsg{}
+		}
+		id, err := d.CreateSession(workspaceRepo)
+		return trainCreatedMsg{sessionID: id, err: err}
 	}
 }
 

--- a/internal/cli/tui/trainrun_test.go
+++ b/internal/cli/tui/trainrun_test.go
@@ -268,6 +268,89 @@ func TestTrainRunActionBusySuppressesReentry(t *testing.T) {
 	_ = next
 }
 
+func TestTrainRunConfirmCreatesAndEntersPhase(t *testing.T) {
+	var gotWS string
+	created := false
+	deps := TrainRunDeps{
+		Plan:          &TrainRunPlan{Name: "n", Template: "t @v1", ReviewRepo: "o/r", WorkspaceRepo: "o/ws"},
+		CreateSession: func(ws string) (string, error) { created = true; gotWS = ws; return "sess-new", nil },
+		Load: func() (TrainRunSnapshot, error) {
+			return TrainRunSnapshot{SessionID: "sess-new", Phase: "items_ready"}, nil
+		},
+	}
+	m := NewTrainRun(deps)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = next.(TrainRunModel)
+	if !m.confirming {
+		t.Fatal("a plan should open the confirm screen")
+	}
+	if !strings.Contains(m.View(), "Create training session") || !strings.Contains(m.View(), "o/r") {
+		t.Fatalf("confirm view missing plan:\n%s", m.View())
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainRunModel)
+	if !m.creating || cmd == nil {
+		t.Fatal("enter should start session creation")
+	}
+	next, _ = m.Update(cmd()) // trainCreatedMsg
+	m = next.(TrainRunModel)
+	if !created || gotWS != "o/ws" {
+		t.Fatalf("CreateSession called=%v ws=%q", created, gotWS)
+	}
+	if m.confirming {
+		t.Fatal("after creation the confirm screen should close")
+	}
+}
+
+func TestTrainRunConfirmNeedsWorkspaceRepo(t *testing.T) {
+	called := false
+	deps := TrainRunDeps{
+		Plan:          &TrainRunPlan{Name: "n", Template: "t @v1", ReviewRepo: "o/r", NeedWorkspaceRepo: true},
+		CreateSession: func(ws string) (string, error) { called = true; return "s", nil },
+		Load:          func() (TrainRunSnapshot, error) { return TrainRunSnapshot{SessionID: "s"}, nil },
+	}
+	m := NewTrainRun(deps)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = next.(TrainRunModel)
+	// enter with no workspace repo → error, no create.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainRunModel)
+	if called || m.createErr == "" {
+		t.Fatal("empty workspace repo should block creation with an error")
+	}
+	// type a repo then enter → create with it.
+	next, _ = m.Update(key("o/ws"))
+	m = next.(TrainRunModel)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(TrainRunModel)
+	if cmd == nil {
+		t.Fatal("enter with a workspace repo should create")
+	}
+	cmd()
+	if !called {
+		t.Fatal("CreateSession should have been called")
+	}
+}
+
+func TestTrainRunConfirmAbort(t *testing.T) {
+	called := false
+	deps := TrainRunDeps{
+		Plan:          &TrainRunPlan{Name: "n", Template: "t", ReviewRepo: "o/r", WorkspaceRepo: "o/ws"},
+		CreateSession: func(ws string) (string, error) { called = true; return "s", nil },
+		Load:          func() (TrainRunSnapshot, error) { return TrainRunSnapshot{}, nil },
+	}
+	m := NewTrainRun(deps)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = next.(TrainRunModel)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("esc should quit")
+	}
+	if called {
+		t.Fatal("esc must not create a session")
+	}
+}
+
 func TestTrainRunActionErrorShown(t *testing.T) {
 	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Phase: "options_generated"})
 	next, _ := m.Update(trainActionMsg{err: errors.New("another worker holds the lock")})

--- a/internal/cli/tui/trainrun_view.go
+++ b/internal/cli/tui/trainrun_view.go
@@ -28,6 +28,9 @@ func trainPhaseSegment(phase string) int {
 }
 
 func (m TrainRunModel) View() string {
+	if m.confirming {
+		return m.confirmView()
+	}
 	if m.snap.SessionID == "" && m.loadedAt.IsZero() && m.loadErr == "" {
 		return "Loading…"
 	}
@@ -97,6 +100,36 @@ func (m TrainRunModel) footer() string {
 		action = "n start next iteration  "
 	}
 	return action + "r refresh  q quit"
+}
+
+func (m TrainRunModel) confirmView() string {
+	p := m.deps.Plan
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("Create training session"))
+	b.WriteString("\n\n")
+	rows := [][]string{
+		{"name", dash(p.Name)},
+		{"template", dash(p.Template)},
+		{"review repo", dash(p.ReviewRepo)},
+	}
+	if !p.NeedWorkspaceRepo {
+		rows = append(rows, []string{"workspace repo", dash(p.WorkspaceRepo)})
+	}
+	b.WriteString(renderRows(rows))
+	b.WriteByte('\n')
+	if p.NeedWorkspaceRepo {
+		b.WriteString("workspace repo: " + m.wsInput.View() + "\n")
+	}
+	if m.createErr != "" {
+		b.WriteString(errorStyle.Render(m.createErr) + "\n")
+	}
+	b.WriteString("\n")
+	if m.creating {
+		b.WriteString(mutedStyle.Render("creating session… (missing repos are created private)"))
+	} else {
+		b.WriteString(mutedStyle.Render("enter create session  esc cancel"))
+	}
+	return b.String()
 }
 
 func (m TrainRunModel) phaseBar() string {


### PR DESCRIPTION
Finishes the on-ramp deferred from #234 (the confirm-screen spec). **Task 1 of 2.**

## WHAT
`gitmoot skillopt train run --config <path>` with no session now opens a **confirm screen** and creates the session for you — no more `train start` `confirm_command` repaste for the interactive path. After creating, it drops straight into the live phase view in the same program.

## CHANGES
- `TrainRunModel` confirm state (`deps.Plan != nil`): plan summary (name, template@version, review repo) + a workspace-repo `textinput` when `--workspace-repo` wasn't supplied; `enter` → `CreateSession` → load the phase screen; `esc`/`q` aborts with no write.
- Session id is shared with the `Load`/`Continue`/`SpawnContinue` closures via a **mutex-guarded ref** (tea.Cmds run in goroutines); `Load` only fires after creation.
- `createSkillOptTrainRunSession` invokes the real `train start --yes --create-repos` in-process with a generated session id, capturing output so it never corrupts the TUI — **zero plan-building duplication**. Missing repos are created.
- New `train run --workspace-repo` flag; the confirm TUI launches only on a terminal with `--config` and no session (non-TTY/`--plain` keep the existing hint).

## RESULTS
- `go test ./internal/cli ./internal/cli/tui` green: confirm renders the plan; enter creates + enters the phase view; missing workspace repo required then accepted; esc aborts without creating; `buildSkillOptTrainRunPlan` (label not doubled); real-store `createSkillOptTrainRunSession` writes a loadable session. `go vet`/`gofmt`/`git diff --check` clean.

## RISK
Low. New interactive path only; resolved-session and non-TTY/`--plain` paths unchanged. `train start` itself is untouched (reused as-is). The confirm flow passes `--create-repos` (interactive create is expected here).

## /code-review
High-effort review: **no findings**. Verified the session-id mutex (no `Load` with empty id — `Load` is issued only after `CreateSession` sets it), `NewTrainRun` focus persistence, the create-then-enter transition, the retry-after-error path (stays on the confirm screen), and byte-stability of the other dispatch paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)