### PR TITLE
cli: tail generation/optimizer progress in the train run TUI

### DIFF
--- a/internal/cli/skillopt_trainrun_tui.go
+++ b/internal/cli/skillopt_trainrun_tui.go
@@ -254,7 +254,61 @@ func skillOptTrainRunDeps(home string, sessionID func() string) tui.TrainRunDeps
 			return runContinue(func(r *skillOptTrainContinueRequest) { r.StartNext = true })
 		},
 		SpawnContinue: func() (string, error) { return spawnSkillOptTrainContinueChild(home, sessionID()) },
+		TailLog: func(offset int64) ([]string, int64, error) {
+			return tailSkillOptTrainLog(home, sessionID(), offset)
+		},
 	}
+}
+
+// tailSkillOptTrainLog reads new complete lines from the current session's
+// detached-child log starting at offset, returning them and the next offset. A
+// missing log (the child hasn't started) yields no lines. Partial trailing lines
+// are left for the next read.
+func tailSkillOptTrainLog(home, sessionID string, offset int64) ([]string, int64, error) {
+	if strings.TrimSpace(sessionID) == "" {
+		return nil, offset, nil
+	}
+	paths, err := initializedPaths(home)
+	if err != nil {
+		return nil, offset, err
+	}
+	path := filepath.Join(paths.Logs, "skillopt-train-"+skillOptTrainLogSlug(sessionID)+".log")
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, offset, nil // no log yet
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, offset, err
+	}
+	size := info.Size()
+	if offset > size {
+		offset = 0 // truncated/rotated — restart
+	}
+	if offset >= size {
+		return nil, offset, nil
+	}
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, offset, err
+	}
+	data := make([]byte, size-offset)
+	n, err := io.ReadFull(f, data)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return nil, offset, err
+	}
+	data = data[:n]
+	lastNL := bytes.LastIndexByte(data, '\n')
+	if lastNL < 0 {
+		return nil, offset, nil // no complete line yet
+	}
+	lines := []string{}
+	for _, line := range strings.Split(string(data[:lastNL]), "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines, offset + int64(lastNL+1), nil
 }
 
 // buildSkillOptTrainRunPlan loads the config into a confirm-screen plan.

--- a/internal/cli/skillopt_trainrun_tui_test.go
+++ b/internal/cli/skillopt_trainrun_tui_test.go
@@ -189,6 +189,53 @@ func TestCreateSkillOptTrainRunSession(t *testing.T) {
 	}
 }
 
+func TestTailSkillOptTrainLog(t *testing.T) {
+	home := t.TempDir()
+	if err := config.Initialize(config.PathsForHome(home)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	logPath := filepath.Join(config.PathsForHome(home).Logs, "skillopt-train-sess.log")
+
+	// Missing log → no lines, offset unchanged.
+	lines, off, err := tailSkillOptTrainLog(home, "sess", 0)
+	if err != nil || len(lines) != 0 || off != 0 {
+		t.Fatalf("missing log: lines=%v off=%d err=%v", lines, off, err)
+	}
+
+	// Write two complete lines + a partial (no trailing newline).
+	if err := os.WriteFile(logPath, []byte("first\nsecond\npartial"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	lines, off, err = tailSkillOptTrainLog(home, "sess", 0)
+	if err != nil {
+		t.Fatalf("tail: %v", err)
+	}
+	if len(lines) != 2 || lines[0] != "first" || lines[1] != "second" {
+		t.Fatalf("complete lines = %v (partial should be withheld)", lines)
+	}
+	// Offset is past "first\nsecond\n" (13 bytes), before "partial".
+	if off != 13 {
+		t.Fatalf("offset = %d, want 13", off)
+	}
+
+	// From that offset, after the partial line is completed, it appears.
+	if err := os.WriteFile(logPath, []byte("first\nsecond\npartial now done\n"), 0o644); err != nil {
+		t.Fatalf("rewrite log: %v", err)
+	}
+	lines, off2, err := tailSkillOptTrainLog(home, "sess", off)
+	if err != nil {
+		t.Fatalf("tail2: %v", err)
+	}
+	if len(lines) != 1 || lines[0] != "partial now done" || off2 <= off {
+		t.Fatalf("second tail = %v off=%d", lines, off2)
+	}
+
+	// Empty session id → no-op.
+	if l, _, err := tailSkillOptTrainLog(home, "", 5); err != nil || len(l) != 0 {
+		t.Fatalf("empty session: lines=%v err=%v", l, err)
+	}
+}
+
 func TestToTrainRunSnapshot(t *testing.T) {
 	snap := skillOptTrainStatusSnapshot{
 		SessionID:       "s1",

--- a/internal/cli/tui/trainrun.go
+++ b/internal/cli/tui/trainrun.go
@@ -65,6 +65,11 @@ type TrainRunDeps struct {
 	// Load/Continue/… operate on the new session.
 	Plan          *TrainRunPlan
 	CreateSession func(workspaceRepo string) (sessionID string, err error)
+
+	// TailLog reads the current session's detached-child log from a byte offset,
+	// returning any new lines and the next offset. Used to show live progress
+	// during the long generate/optimizer phases.
+	TailLog func(offset int64) (lines []string, next int64, err error)
 }
 
 type trainRunMode int
@@ -97,6 +102,11 @@ type trainCreatedMsg struct {
 	err       error
 }
 
+type trainLogMsg struct {
+	lines  []string
+	offset int64
+}
+
 // TrainRunModel renders a single train session as a live phase view.
 type TrainRunModel struct {
 	deps     TrainRunDeps
@@ -118,6 +128,27 @@ type TrainRunModel struct {
 	creating   bool
 	createErr  string
 	wsInput    textinput.Model
+
+	// Log tail (long phases): a monotonic byte offset into the per-session child
+	// log (generation and optimizer append to the same file, so the offset is
+	// never reset on phase change — only on truncation, handled by the reader),
+	// and the last few complete lines to show.
+	logOffset int64
+	logLines  []string
+}
+
+const trainLogTailLines = 8
+
+// isLongTrainPhase reports whether the phase runs in the detached child and so
+// has a log worth tailing.
+func isLongTrainPhase(phase string) bool {
+	switch phase {
+	case "generating_options", "generating_options_heartbeat_stale",
+		"optimizer_running", "optimizer_heartbeat_stale":
+		return true
+	default:
+		return false
+	}
 }
 
 // NewTrainRun returns a model ready for tea.NewProgram.
@@ -206,14 +237,41 @@ func (m TrainRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.loadErr = ""
 			m.snap = msg.snap
 			m.loadedAt = msg.at
+			// Clear the displayed lines when not in a long phase so stale output
+			// does not linger; the byte offset stays monotonic (one per-session
+			// log spans generation and optimizer).
+			if !isLongTrainPhase(msg.snap.Phase) {
+				m.logLines = nil
+			}
 		}
+	case trainLogMsg:
+		if len(msg.lines) > 0 {
+			m.logLines = append(m.logLines, msg.lines...)
+			if len(m.logLines) > trainLogTailLines {
+				m.logLines = m.logLines[len(m.logLines)-trainLogTailLines:]
+			}
+		}
+		m.logOffset = msg.offset
 	case trainTickMsg:
 		if cmd := m.queueLoad(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+		if isLongTrainPhase(m.snap.Phase) && m.deps.TailLog != nil {
+			cmds = append(cmds, tailLogCmd(m.deps, m.logOffset))
+		}
 		cmds = append(cmds, trainTick(m.interval()))
 	}
 	return m, tea.Batch(cmds...)
+}
+
+func tailLogCmd(d TrainRunDeps, offset int64) tea.Cmd {
+	return func() tea.Msg {
+		lines, next, err := d.TailLog(offset)
+		if err != nil {
+			return trainLogMsg{offset: offset} // keep the offset; transient read errors are ignored
+		}
+		return trainLogMsg{lines: lines, offset: next}
+	}
 }
 
 // updateKey handles all key input: the reject-reason sub-mode first, then the

--- a/internal/cli/tui/trainrun_test.go
+++ b/internal/cli/tui/trainrun_test.go
@@ -351,6 +351,83 @@ func TestTrainRunConfirmAbort(t *testing.T) {
 	}
 }
 
+func TestTrainRunTailsLogDuringLongPhase(t *testing.T) {
+	tailCalls := 0
+	deps := TrainRunDeps{
+		Load: func() (TrainRunSnapshot, error) {
+			return TrainRunSnapshot{SessionID: "s", Phase: "generating_options"}, nil
+		},
+		TailLog: func(offset int64) ([]string, int64, error) {
+			tailCalls++
+			return []string{"option item-001/A done"}, offset + 10, nil
+		},
+	}
+	m := trainRunModelWithDeps(t, deps, TrainRunSnapshot{SessionID: "s", Phase: "generating_options"})
+	// A tick during a long phase should issue a tail.
+	next, cmd := m.Update(trainTickMsg{})
+	m = next.(TrainRunModel)
+	if cmd == nil {
+		t.Fatal("tick should produce commands")
+	}
+	// Feed a log message directly and verify it renders.
+	next, _ = m.Update(trainLogMsg{lines: []string{"option item-001/A done"}, offset: 10})
+	m = next.(TrainRunModel)
+	if m.logOffset != 10 {
+		t.Fatalf("log offset = %d, want 10", m.logOffset)
+	}
+	if !strings.Contains(m.View(), "option item-001/A done") {
+		t.Fatalf("expected the log line in view:\n%s", m.View())
+	}
+}
+
+func TestTrainRunLogClearsDisplayButKeepsOffset(t *testing.T) {
+	deps := TrainRunDeps{Load: func() (TrainRunSnapshot, error) {
+		return TrainRunSnapshot{SessionID: "s", Phase: "generating_options"}, nil
+	}}
+	m := trainRunModelWithDeps(t, deps, TrainRunSnapshot{SessionID: "s", Phase: "generating_options"})
+	next, _ := m.Update(trainLogMsg{lines: []string{"line a", "line b"}, offset: 20})
+	m = next.(TrainRunModel)
+	if len(m.logLines) != 2 || m.logOffset != 20 {
+		t.Fatalf("log state = %+v off=%d", m.logLines, m.logOffset)
+	}
+	// Leaving a long phase clears the displayed lines but keeps the monotonic
+	// offset (generation + optimizer share one per-session log).
+	next, _ = m.Update(trainSnapshotMsg{snap: TrainRunSnapshot{SessionID: "s", Phase: "options_generated"}, at: time.Unix(2, 0)})
+	m = next.(TrainRunModel)
+	if len(m.logLines) != 0 {
+		t.Fatalf("displayed lines should clear off a long phase: %+v", m.logLines)
+	}
+	if m.logOffset != 20 {
+		t.Fatalf("offset must stay monotonic across phases, got %d", m.logOffset)
+	}
+	// A heartbeat flap (still a long phase) keeps the displayed lines.
+	next, _ = m.Update(trainSnapshotMsg{snap: TrainRunSnapshot{SessionID: "s", Phase: "optimizer_running"}, at: time.Unix(3, 0)})
+	m = next.(TrainRunModel)
+	next, _ = m.Update(trainLogMsg{lines: []string{"opt 1"}, offset: 25})
+	m = next.(TrainRunModel)
+	next, _ = m.Update(trainSnapshotMsg{snap: TrainRunSnapshot{SessionID: "s", Phase: "optimizer_heartbeat_stale"}, at: time.Unix(4, 0)})
+	m = next.(TrainRunModel)
+	if len(m.logLines) != 1 {
+		t.Fatalf("heartbeat flap should not clear the log display: %+v", m.logLines)
+	}
+}
+
+func TestTrainRunLogCapsLines(t *testing.T) {
+	deps := TrainRunDeps{Load: func() (TrainRunSnapshot, error) {
+		return TrainRunSnapshot{SessionID: "s", Phase: "optimizer_running"}, nil
+	}}
+	m := trainRunModelWithDeps(t, deps, TrainRunSnapshot{SessionID: "s", Phase: "optimizer_running"})
+	many := make([]string, 20)
+	for i := range many {
+		many[i] = "l"
+	}
+	next, _ := m.Update(trainLogMsg{lines: many, offset: 1})
+	m = next.(TrainRunModel)
+	if len(m.logLines) != trainLogTailLines {
+		t.Fatalf("log lines should cap at %d, got %d", trainLogTailLines, len(m.logLines))
+	}
+}
+
 func TestTrainRunActionErrorShown(t *testing.T) {
 	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Phase: "options_generated"})
 	next, _ := m.Update(trainActionMsg{err: errors.New("another worker holds the lock")})

--- a/internal/cli/tui/trainrun_view.go
+++ b/internal/cli/tui/trainrun_view.go
@@ -190,6 +190,14 @@ func (m TrainRunModel) body() string {
 		b.WriteString(fmt.Sprintf("candidate %s rejected\n", dash(s.CandidateVersion)))
 	}
 
+	if isLongTrainPhase(s.Phase) && len(m.logLines) > 0 {
+		b.WriteByte('\n')
+		for _, line := range m.logLines {
+			b.WriteString(mutedStyle.Render("│ " + line))
+			b.WriteByte('\n')
+		}
+	}
+
 	if s.NextAction != "" {
 		b.WriteString(mutedStyle.Render("next: " + s.NextAction))
 		b.WriteByte('\n')


### PR DESCRIPTION
Finishes the last deferred spec from #234 (the generation log tail). **Task 2 of 2.**

## WHAT
During the long generate/optimizer phases, the train run TUI now shows the last few lines of the detached child's log — live progress text alongside the phase bar and job counts.

## CHANGES
- `TrainRunDeps.TailLog(offset)` → `tailSkillOptTrainLog` reads the per-session child log (`<paths.Logs>/skillopt-train-<slug>.log`) from a byte offset, returning only complete lines and withholding a partial trailing line for the next read; handles a truncated/rotated file (offset > size → restart).
- The model tails on each refresh tick while in a long phase, appends new lines (capped at the last 8), and renders them dim under the body.
- The byte offset is **monotonic** across generation and optimizer (they share one per-session log), so a heartbeat-stale flap or a phase change never re-reads the file; only the *displayed* lines clear when leaving a long phase.

## RESULTS
- `go test ./internal/cli ./internal/cli/tui` green; `go test ./...` green except the pre-existing flake `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos`. `go vet`/`gofmt`/`git diff --check` clean.
- Tests: tick-tails-and-renders; offset monotonic while display clears off a long phase and survives a heartbeat flap; 8-line cap; `tailSkillOptTrainLog` complete-lines-only / partial-withheld / missing-log no-op.

## RISK
Low; read-only file tail, TUI-only, additive.

## /code-review
High-effort review caught a real bug (now fixed): resetting the offset on phase change re-read the **whole** per-session log (generation + optimizer share one file), duplicating output — and a `*_heartbeat_stale` flap triggered it too. Now the offset is monotonic (truncation reset handled in the reader) and only the displayed lines clear off a long phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)