### PR TITLE
db: cockpit mutation foundations (cockpit task 1)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1199,6 +1199,39 @@ func persistAgentSubscription(ctx context.Context, store *db.Store, agent runtim
 	return store.ReplaceAgentRepos(ctx, agent.Name, repos)
 }
 
+// registerAgentOnly persists an agent record without launching a runtime
+// session — the shared body behind the dashboard's create-agent form. The agent
+// becomes addressable for jobs; a runtime session starts lazily when work is
+// delivered.
+func registerAgentOnly(ctx context.Context, store *db.Store, name, runtimeName, templateID, repoFullName string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("agent name is required")
+	}
+	runtimeName = strings.TrimSpace(runtimeName)
+	if runtimeName == "" {
+		return errors.New("agent runtime is required")
+	}
+	agent := runtime.Agent{
+		Name:       name,
+		Runtime:    runtimeName,
+		TemplateID: strings.TrimSpace(templateID),
+		RepoScope:  strings.TrimSpace(repoFullName),
+	}
+	repos := []string{}
+	if agent.RepoScope != "" {
+		repo, err := daemon.ParseRepository(agent.RepoScope)
+		if err != nil {
+			return err
+		}
+		if err := store.UpsertRepo(ctx, db.Repo{Owner: repo.Owner, Name: repo.Name}); err != nil {
+			return err
+		}
+		repos = append(repos, agent.RepoScope)
+	}
+	return persistAgentSubscription(ctx, store, agent, repos)
+}
+
 func agentStartupPrompt(agent runtime.Agent, cachedTemplate db.AgentTemplate) string {
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "You are a Gitmoot-managed agent named %s.\n", agent.Name)

--- a/internal/cli/agent_template.go
+++ b/internal/cli/agent_template.go
@@ -40,6 +40,8 @@ func runAgentTemplate(args []string, stdout, stderr io.Writer) int {
 		return runAgentTemplateUpdate(args[1:], stdout, stderr)
 	case "diff":
 		return runAgentTemplateDiff(args[1:], stdout, stderr)
+	case "revert":
+		return runAgentTemplateRevert(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown agent template command %q\n\n", args[0])
 		printAgentTemplateUsage(stderr)
@@ -56,6 +58,41 @@ func printAgentTemplateUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent template show thermo-nuclear-code-quality-review")
 	fmt.Fprintln(w, "  gitmoot agent template update thermo-nuclear-code-quality-review")
 	fmt.Fprintln(w, "  gitmoot agent template diff thermo-nuclear-code-quality-review")
+	fmt.Fprintln(w, "  gitmoot agent template revert <template-id> --version <version-id>")
+}
+
+// runAgentTemplateRevert rolls a template back to a previously current
+// (superseded) version.
+func runAgentTemplateRevert(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent template revert", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	versionRef := fs.String("version", "", "superseded version id to make current again")
+	id, flagArgs := leadingID(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if strings.TrimSpace(id) == "" || strings.TrimSpace(*versionRef) == "" {
+		fmt.Fprintln(stderr, "agent template revert requires <template-id> and --version")
+		return 2
+	}
+	var reverted db.AgentTemplateVersion
+	if err := withStore(*home, func(store *db.Store) error {
+		version, err := store.GetAgentTemplateVersion(context.Background(), strings.TrimSpace(id), strings.TrimSpace(*versionRef))
+		if err != nil {
+			return err
+		}
+		reverted, err = store.RevertAgentTemplateVersion(context.Background(), strings.TrimSpace(id), version.ID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent template revert: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "reverted %s to %s", strings.TrimSpace(id), reverted.ID)
+	return 0
 }
 
 func runAgentTemplateAdd(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1203,7 +1203,7 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 	}
 	if *createRepos {
 		for _, fullName := range []string{repo.FullName(), workspaceRepo} {
-			if err := ensureSkillOptTrainRepo(fullName, stdout); err != nil {
+			if err := ensureSkillOptTrainRepo(*home, fullName, "train", strings.TrimSpace(*sessionID), stdout); err != nil {
 				fmt.Fprintf(stderr, "skillopt train start: create repo %s: %v\n", fullName, err)
 				return 1
 			}
@@ -1315,10 +1315,12 @@ func runSkillOptTrainStart(args []string, stdout, stderr io.Writer) int {
 }
 
 // ensureSkillOptTrainRepo creates the given repo as a private GitHub repo when it
-// does not already exist. Deduplicated callers pass distinct names; an empty name
-// is a no-op. An ambiguous existence check (e.g. auth error) is left alone so the
-// later Preflight surfaces it, rather than wrongly attempting a create.
-func ensureSkillOptTrainRepo(fullName string, stdout io.Writer) error {
+// does not already exist, recording it in created_repos so cleanup flows can
+// offer deletion of exactly the repos gitmoot created. Deduplicated callers pass
+// distinct names; an empty name is a no-op. An ambiguous existence check (e.g.
+// auth error) is left alone so the later Preflight surfaces it, rather than
+// wrongly attempting a create.
+func ensureSkillOptTrainRepo(home, fullName, purpose, sessionID string, stdout io.Writer) error {
 	if strings.TrimSpace(fullName) == "" {
 		return nil
 	}
@@ -1337,6 +1339,12 @@ func ensureSkillOptTrainRepo(fullName string, stdout io.Writer) error {
 	}
 	if err := client.CreateRepository(context.Background(), repo, true); err != nil {
 		return err
+	}
+	if err := withStore(home, func(store *db.Store) error {
+		return store.RecordCreatedRepo(context.Background(), db.CreatedRepo{Repo: fullName, Purpose: purpose, SessionID: strings.TrimSpace(sessionID)})
+	}); err != nil {
+		// The repo exists either way; a failed record only loses the cleanup offer.
+		fmt.Fprintf(stdout, "warning: could not record created repo %s: %v\n", fullName, err)
 	}
 	writeLine(stdout, "created_repo: %s", fullName)
 	return nil
@@ -6601,33 +6609,8 @@ func runSkillOptTrainStop(args []string, stdout, stderr io.Writer) int {
 	}
 	var stopped db.SkillOptTrainIteration
 	if err := withStore(*home, func(store *db.Store) error {
-		ctx := context.Background()
-		session, err := store.GetSkillOptTrainSession(ctx, strings.TrimSpace(*sessionID))
+		iteration, err := stopSkillOptTrainSession(context.Background(), store, strings.TrimSpace(*sessionID), strings.TrimSpace(*reason))
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("train session %s not found", strings.TrimSpace(*sessionID))
-			}
-			return err
-		}
-		iteration, err := store.GetLatestSkillOptTrainIteration(ctx, session.ID)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("train session %s has no iteration to stop", session.ID)
-			}
-			return err
-		}
-		if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateRunAbandoned); err != nil {
-			return err
-		}
-		session.State = skillopt.TrainStateRunAbandoned
-		session.MetadataJSON = skillOptTrainDecisionMetadata(session.MetadataJSON, *reason)
-		iteration.State = skillopt.TrainStateRunAbandoned
-		iteration.DecisionReason = strings.TrimSpace(*reason)
-		iteration.MetadataJSON = skillOptTrainDecisionMetadata(iteration.MetadataJSON, *reason)
-		if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
-			return err
-		}
-		if err := store.UpsertSkillOptTrainIteration(ctx, iteration); err != nil {
 			return err
 		}
 		stopped = iteration
@@ -6640,6 +6623,43 @@ func runSkillOptTrainStop(args []string, stdout, stderr io.Writer) int {
 	writeLine(stdout, "iteration: %s", stopped.ID)
 	writeLine(stdout, "reason: %s", strings.TrimSpace(*reason))
 	return 0
+}
+
+// stopSkillOptTrainSession abandons a train session with a reason — the shared
+// body behind `train stop` and the dashboard's stop action.
+func stopSkillOptTrainSession(ctx context.Context, store *db.Store, sessionID string, reason string) (db.SkillOptTrainIteration, error) {
+	if sessionID == "" || strings.TrimSpace(reason) == "" {
+		return db.SkillOptTrainIteration{}, errors.New("a session id and a reason are required")
+	}
+	session, err := store.GetSkillOptTrainSession(ctx, sessionID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return db.SkillOptTrainIteration{}, fmt.Errorf("train session %s not found", sessionID)
+		}
+		return db.SkillOptTrainIteration{}, err
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(ctx, session.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return db.SkillOptTrainIteration{}, fmt.Errorf("train session %s has no iteration to stop", session.ID)
+		}
+		return db.SkillOptTrainIteration{}, err
+	}
+	if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateRunAbandoned); err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	session.State = skillopt.TrainStateRunAbandoned
+	session.MetadataJSON = skillOptTrainDecisionMetadata(session.MetadataJSON, reason)
+	iteration.State = skillopt.TrainStateRunAbandoned
+	iteration.DecisionReason = strings.TrimSpace(reason)
+	iteration.MetadataJSON = skillOptTrainDecisionMetadata(iteration.MetadataJSON, reason)
+	if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	if err := store.UpsertSkillOptTrainIteration(ctx, iteration); err != nil {
+		return db.SkillOptTrainIteration{}, err
+	}
+	return iteration, nil
 }
 
 func loadSkillOptTrainStatus(ctx context.Context, store *db.Store, sessionID string) (db.SkillOptTrainSession, *db.SkillOptTrainIteration, skillopt.TrainStatusCounts, error) {

--- a/internal/cli/skillopt_repocreate_test.go
+++ b/internal/cli/skillopt_repocreate_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
 )
 
@@ -40,21 +42,25 @@ func replaceSkillOptGitHubClient(client github.Client) func() {
 }
 
 func TestEnsureSkillOptTrainRepoCreatesMissing(t *testing.T) {
+	home := t.TempDir()
+	if err := config.Initialize(config.PathsForHome(home)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
 	fake := &repoCreateFakeGitHub{existing: map[string]bool{"o/exists": true}}
 	restore := replaceSkillOptGitHubClient(fake)
 	defer restore()
 
 	var out bytes.Buffer
-	// Existing repo: no create, no output.
-	if err := ensureSkillOptTrainRepo("o/exists", &out); err != nil {
+	// Existing repo: no create, no output, no record.
+	if err := ensureSkillOptTrainRepo(home, "o/exists", "train", "sess-1", &out); err != nil {
 		t.Fatalf("ensure existing: %v", err)
 	}
 	if len(fake.created) != 0 || out.Len() != 0 {
 		t.Fatalf("existing repo should be untouched: created=%v out=%q", fake.created, out.String())
 	}
 
-	// Missing repo: created + a created_repo line.
-	if err := ensureSkillOptTrainRepo("o/missing", &out); err != nil {
+	// Missing repo: created + a created_repo line + a created_repos record.
+	if err := ensureSkillOptTrainRepo(home, "o/missing", "train", "sess-1", &out); err != nil {
 		t.Fatalf("ensure missing: %v", err)
 	}
 	if len(fake.created) != 1 || fake.created[0] != "o/missing" {
@@ -63,15 +69,28 @@ func TestEnsureSkillOptTrainRepoCreatesMissing(t *testing.T) {
 	if !strings.Contains(out.String(), "created_repo: o/missing") {
 		t.Fatalf("expected created_repo line: %q", out.String())
 	}
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+	records, err := store.ListCreatedReposForSession(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("list created repos: %v", err)
+	}
+	if len(records) != 1 || records[0].Repo != "o/missing" {
+		t.Fatalf("created_repos records = %+v", records)
+	}
 }
 
 func TestEnsureSkillOptTrainRepoSkipsOnAmbiguousError(t *testing.T) {
+	home := t.TempDir()
 	fake := &repoCreateFakeGitHub{existErr: context.DeadlineExceeded}
 	restore := replaceSkillOptGitHubClient(fake)
 	defer restore()
 
 	var out bytes.Buffer
-	if err := ensureSkillOptTrainRepo("o/repo", &out); err != nil {
+	if err := ensureSkillOptTrainRepo(home, "o/repo", "train", "", &out); err != nil {
 		t.Fatalf("ensure should not error on ambiguous check: %v", err)
 	}
 	if len(fake.created) != 0 {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -699,6 +699,46 @@ func (s *Store) RemoveAgent(ctx context.Context, name string) (bool, error) {
 	return affected > 0, tx.Commit()
 }
 
+// DeleteAgentChecked removes an agent (and its instances) unless queued or
+// running jobs still reference it, in which case it refuses so in-flight work is
+// never orphaned.
+func (s *Store) DeleteAgentChecked(ctx context.Context, name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("agent name is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var active int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs WHERE agent = ? AND state IN ('queued', 'running')`, name).Scan(&active); err != nil {
+		return err
+	}
+	if active > 0 {
+		return fmt.Errorf("agent %s has %d queued or running job(s); cancel them first", name, active)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM agent_repos WHERE agent_name = ?`, name); err != nil {
+		return err
+	}
+	// agent_instances are NOT deleted: their `type` column references a managed
+	// agent type, not this agents.name, so deleting by name could remove another
+	// type's instances. Instances are ephemeral (expiry-reaped) either way.
+	result, err := tx.ExecContext(ctx, `DELETE FROM agents WHERE name = ?`, name)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return fmt.Errorf("agent %q not found", name)
+	}
+	return tx.Commit()
+}
+
 func (s *Store) AllowAgentRepo(ctx context.Context, agentName string, repoFullName string) error {
 	result, err := s.db.ExecContext(ctx, `UPDATE agents
 		SET repo_scope = CASE WHEN repo_scope = '' THEN ? ELSE repo_scope END,
@@ -1170,6 +1210,60 @@ func (s *Store) RejectAgentTemplateVersion(ctx context.Context, versionID string
 		return AgentTemplateVersion{}, err
 	}
 	if err := upsertAgentTemplateCandidateReviewDecisionTx(ctx, tx, target, "rejected", reason); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	return s.GetAgentTemplateVersionByID(ctx, target.ID)
+}
+
+// RevertAgentTemplateVersion makes a previously superseded version current
+// again (a rollback). It mirrors PromoteAgentTemplateVersion's pointer/state
+// writes but accepts a superseded target instead of a pending one, and records
+// no candidate-review decision (reverts are not candidate decisions).
+func (s *Store) RevertAgentTemplateVersion(ctx context.Context, templateID string, versionID string) (AgentTemplateVersion, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	defer tx.Rollback()
+	target, err := getAgentTemplateVersionByIDTx(ctx, tx, versionID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if target.TemplateID != strings.TrimSpace(templateID) {
+		return AgentTemplateVersion{}, fmt.Errorf("version %s belongs to template %s, not %s", target.ID, target.TemplateID, templateID)
+	}
+	if target.State != "superseded" {
+		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not superseded; only a previously current version can be reverted to", target.ID, target.State)
+	}
+	current, hasCurrent, err := getCurrentAgentTemplateVersion(ctx, tx, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if hasCurrent {
+		if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'superseded', updated_at = CURRENT_TIMESTAMP WHERE id = ?`, current.ID); err != nil {
+			return AgentTemplateVersion{}, err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'current', promoted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, target.ID); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	latestID, err := latestSelectableVersionID(ctx, tx, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET
+			name = ?, description = ?, source_repo = ?, source_ref = ?, source_path = ?, resolved_commit = ?,
+			content = ?, metadata_json = ?, current_version_id = ?, latest_version_id = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?`,
+		target.Name, target.Description, target.SourceRepo, target.SourceRef, target.SourcePath, target.ResolvedCommit,
+		target.Content, target.MetadataJSON, target.ID, latestID, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := requireAffected(result, "agent template", target.TemplateID); err != nil {
 		return AgentTemplateVersion{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -2387,6 +2481,165 @@ func normalizeSkillOptTrainIteration(iteration SkillOptTrainIteration) (SkillOpt
 	iteration.DecisionReason = strings.TrimSpace(iteration.DecisionReason)
 	iteration.MetadataJSON = strings.TrimSpace(iteration.MetadataJSON)
 	return iteration, nil
+}
+
+// DeleteSkillOptTrainSession removes a train session and everything keyed by it
+// in one transaction: iterations, each iteration's eval run with its review
+// items/options and (ranked) feedback events, review watches, and the session's
+// resource locks (matched as a whole colon-delimited key segment). It refuses
+// while a non-expired lock exists for the session so an in-flight generation or
+// optimizer is never pulled out from under its worker. Interactive prompt
+// records carry no session linkage (train-init prompts are workspace-scoped and
+// deleted by their own flows), so none are touched here.
+func (s *Store) DeleteSkillOptTrainSession(ctx context.Context, sessionID string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return errors.New("train session id is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var exists int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM skillopt_train_sessions WHERE id = ?`, sessionID).Scan(&exists); err != nil {
+		return err
+	}
+	if exists == 0 {
+		return fmt.Errorf("train session %q not found", sessionID)
+	}
+
+	// Collect lock keys referencing the session as a whole segment, and refuse
+	// while any of them is still live.
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000000000Z")
+	lockRows, err := tx.QueryContext(ctx, `SELECT resource_key, expires_at FROM resource_locks`)
+	if err != nil {
+		return err
+	}
+	sessionLockKeys := []string{}
+	for lockRows.Next() {
+		var key, expiresAt string
+		if err := lockRows.Scan(&key, &expiresAt); err != nil {
+			lockRows.Close()
+			return err
+		}
+		matched := false
+		for _, segment := range strings.Split(key, ":") {
+			if segment == sessionID {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		if expiresAt > now {
+			lockRows.Close()
+			return fmt.Errorf("train session %s has an active resource lock (%s); wait for it to finish or recover it first", sessionID, key)
+		}
+		sessionLockKeys = append(sessionLockKeys, key)
+	}
+	if err := lockRows.Err(); err != nil {
+		lockRows.Close()
+		return err
+	}
+	lockRows.Close()
+
+	runRows, err := tx.QueryContext(ctx, `SELECT eval_run_id FROM skillopt_train_iterations WHERE session_id = ? AND eval_run_id <> ''`, sessionID)
+	if err != nil {
+		return err
+	}
+	runIDs := []string{}
+	for runRows.Next() {
+		var runID string
+		if err := runRows.Scan(&runID); err != nil {
+			runRows.Close()
+			return err
+		}
+		runIDs = append(runIDs, runID)
+	}
+	if err := runRows.Err(); err != nil {
+		runRows.Close()
+		return err
+	}
+	runRows.Close()
+
+	for _, runID := range runIDs {
+		for _, stmt := range []string{
+			`DELETE FROM eval_review_items WHERE run_id = ?`,
+			`DELETE FROM eval_review_options WHERE run_id = ?`,
+			`DELETE FROM feedback_events WHERE run_id = ?`,
+			`DELETE FROM ranked_feedback_events WHERE run_id = ?`,
+			`DELETE FROM skillopt_review_watches WHERE run_id = ?`,
+			`DELETE FROM eval_runs WHERE id = ?`,
+		} {
+			if _, err := tx.ExecContext(ctx, stmt, runID); err != nil {
+				return err
+			}
+		}
+	}
+	for _, key := range sessionLockKeys {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM resource_locks WHERE resource_key = ?`, key); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM skillopt_train_iterations WHERE session_id = ?`, sessionID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM skillopt_train_sessions WHERE id = ?`, sessionID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// CreatedRepo records a GitHub repository gitmoot itself created, so cleanup
+// flows can offer deletion of exactly those repos and never others.
+type CreatedRepo struct {
+	Repo      string `json:"repo"`
+	Purpose   string `json:"purpose,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// RecordCreatedRepo remembers that gitmoot created the repo. A repo can only be
+// created once, so on conflict the ORIGINAL creator linkage is preserved (a
+// later session re-recording the same name must not steal the cleanup offer).
+func (s *Store) RecordCreatedRepo(ctx context.Context, record CreatedRepo) error {
+	record.Repo = strings.TrimSpace(record.Repo)
+	if record.Repo == "" {
+		return errors.New("created repo name is required")
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO created_repos(repo, purpose, session_id, created_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(repo) DO NOTHING`,
+		record.Repo, record.Purpose, record.SessionID)
+	return err
+}
+
+// ListCreatedReposForSession returns the repos gitmoot created for a session.
+func (s *Store) ListCreatedReposForSession(ctx context.Context, sessionID string) ([]CreatedRepo, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT repo, purpose, session_id, created_at FROM created_repos WHERE session_id = ? ORDER BY created_at`, strings.TrimSpace(sessionID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	records := []CreatedRepo{}
+	for rows.Next() {
+		var record CreatedRepo
+		if err := rows.Scan(&record.Repo, &record.Purpose, &record.SessionID, &record.CreatedAt); err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+// DeleteCreatedRepoRecord forgets a created-repo record (after the repo itself
+// was deleted, or to stop offering cleanup for it).
+func (s *Store) DeleteCreatedRepoRecord(ctx context.Context, repo string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM created_repos WHERE repo = ?`, strings.TrimSpace(repo))
+	return err
 }
 
 func (s *Store) GetSkillOptTrainIteration(ctx context.Context, id string) (SkillOptTrainIteration, error) {
@@ -4601,5 +4854,15 @@ CREATE TABLE interactive_prompts (
 );
 
 CREATE INDEX idx_interactive_prompts_state ON interactive_prompts(state);
+	`,
+	`
+CREATE TABLE created_repos (
+	repo TEXT PRIMARY KEY,
+	purpose TEXT NOT NULL DEFAULT '',
+	session_id TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_created_repos_session ON created_repos(session_id);
 	`,
 }

--- a/internal/db/store_cockpit_test.go
+++ b/internal/db/store_cockpit_test.go
@@ -1,0 +1,208 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func openCockpitStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func seedCockpitTrainSession(t *testing.T, store *Store, sessionID string) {
+	t.Helper()
+	ctx := context.Background()
+	runID := sessionID + "-review-001"
+	if err := store.UpsertSkillOptTrainSession(ctx, SkillOptTrainSession{ID: sessionID, TemplateID: "planner", TargetRepo: "o/r", State: "items_ready"}); err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	if err := store.UpsertSkillOptTrainIteration(ctx, SkillOptTrainIteration{ID: sessionID + "-001", SessionID: sessionID, EvalRunID: runID, State: "items_ready"}); err != nil {
+		t.Fatalf("iteration: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, EvalRun{ID: runID, TemplateID: "planner", TargetRepo: "o/r", State: "draft"}); err != nil {
+		t.Fatalf("eval run: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, EvalReviewItem{ID: runID + "-item-1", RunID: runID, ItemID: "item-1", Title: "One"}); err != nil {
+		t.Fatalf("item: %v", err)
+	}
+	if err := store.UpsertSkillOptReviewWatch(ctx, SkillOptReviewWatch{RunID: runID, Repo: "o/r", IssueNumber: 1, Status: "watching"}); err != nil {
+		t.Fatalf("watch: %v", err)
+	}
+}
+
+func TestDeleteSkillOptTrainSessionCascades(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	seedCockpitTrainSession(t, store, "del-sess")
+	seedCockpitTrainSession(t, store, "keep-sess")
+
+	// An EXPIRED lock for the session must not block deletion and must be swept.
+	expired := time.Now().UTC().Add(-time.Hour).Format("2006-01-02T15:04:05.000000000Z")
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO resource_locks(resource_key, owner_job_id, owner_token, acquired_at, expires_at, updated_at)
+		VALUES ('skillopt-train:del-sess:del-sess-001', 'job-x', 'tok', CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)`, expired); err != nil {
+		t.Fatalf("seed lock: %v", err)
+	}
+
+	if err := store.DeleteSkillOptTrainSession(ctx, "del-sess"); err != nil {
+		t.Fatalf("DeleteSkillOptTrainSession: %v", err)
+	}
+
+	for _, check := range []struct {
+		query string
+		arg   string
+	}{
+		{`SELECT COUNT(*) FROM skillopt_train_sessions WHERE id = ?`, "del-sess"},
+		{`SELECT COUNT(*) FROM skillopt_train_iterations WHERE session_id = ?`, "del-sess"},
+		{`SELECT COUNT(*) FROM eval_runs WHERE id = ?`, "del-sess-review-001"},
+		{`SELECT COUNT(*) FROM eval_review_items WHERE run_id = ?`, "del-sess-review-001"},
+		{`SELECT COUNT(*) FROM skillopt_review_watches WHERE run_id = ?`, "del-sess-review-001"},
+		{`SELECT COUNT(*) FROM resource_locks WHERE resource_key = ?`, "skillopt-train:del-sess:del-sess-001"},
+	} {
+		var count int
+		if err := store.db.QueryRowContext(ctx, check.query, check.arg).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", check.query, err)
+		}
+		if count != 0 {
+			t.Fatalf("expected 0 rows for %s (%s), got %d", check.query, check.arg, count)
+		}
+	}
+	// The unrelated session is intact.
+	if _, err := store.GetSkillOptTrainSession(ctx, "keep-sess"); err != nil {
+		t.Fatalf("keep-sess should survive: %v", err)
+	}
+}
+
+func TestDeleteSkillOptTrainSessionRefusesActiveLock(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	seedCockpitTrainSession(t, store, "busy-sess")
+	live := time.Now().UTC().Add(time.Hour).Format("2006-01-02T15:04:05.000000000Z")
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO resource_locks(resource_key, owner_job_id, owner_token, acquired_at, expires_at, updated_at)
+		VALUES ('skillopt-train:busy-sess:busy-sess-001', 'job-x', 'tok', CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)`, live); err != nil {
+		t.Fatalf("seed lock: %v", err)
+	}
+	err := store.DeleteSkillOptTrainSession(ctx, "busy-sess")
+	if err == nil || !strings.Contains(err.Error(), "active resource lock") {
+		t.Fatalf("expected active-lock refusal, got %v", err)
+	}
+	if _, err := store.GetSkillOptTrainSession(ctx, "busy-sess"); err != nil {
+		t.Fatalf("session must survive a refused delete: %v", err)
+	}
+}
+
+func TestDeleteSkillOptTrainSessionNotFound(t *testing.T) {
+	store := openCockpitStore(t)
+	if err := store.DeleteSkillOptTrainSession(context.Background(), "ghost"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found, got %v", err)
+	}
+}
+
+func TestCreatedRepoRecords(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	if err := store.RecordCreatedRepo(ctx, CreatedRepo{Repo: "o/ws", Purpose: "train", SessionID: "s1"}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if err := store.RecordCreatedRepo(ctx, CreatedRepo{Repo: "o/other", Purpose: "train", SessionID: "s2"}); err != nil {
+		t.Fatalf("record 2: %v", err)
+	}
+	records, err := store.ListCreatedReposForSession(ctx, "s1")
+	if err != nil || len(records) != 1 || records[0].Repo != "o/ws" {
+		t.Fatalf("list = %+v err=%v", records, err)
+	}
+	if err := store.DeleteCreatedRepoRecord(ctx, "o/ws"); err != nil {
+		t.Fatalf("delete record: %v", err)
+	}
+	records, err = store.ListCreatedReposForSession(ctx, "s1")
+	if err != nil || len(records) != 0 {
+		t.Fatalf("after delete = %+v err=%v", records, err)
+	}
+}
+
+func TestRevertAgentTemplateVersion(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	base := AgentTemplate{ID: "planner", Name: "Planner", SourceRepo: "o/r", SourceRef: "main", SourcePath: "p.md", ResolvedCommit: "abc", Content: "v1 content"}
+	if err := store.UpsertAgentTemplate(ctx, base); err != nil {
+		t.Fatalf("upsert template: %v", err)
+	}
+	v1, err := store.GetLatestAgentTemplateVersion(ctx, "planner")
+	if err != nil {
+		t.Fatalf("latest v1: %v", err)
+	}
+	// Add and promote a v2 so v1 becomes superseded.
+	v2Template := base
+	v2Template.Content = "v2 content"
+	v2Template.ResolvedCommit = "def"
+	v2, err := store.AddPendingAgentTemplateVersion(ctx, v2Template)
+	if err != nil {
+		t.Fatalf("add v2: %v", err)
+	}
+	if _, err := store.PromoteAgentTemplateVersion(ctx, v2.ID); err != nil {
+		t.Fatalf("promote v2: %v", err)
+	}
+
+	// Revert to v1.
+	reverted, err := store.RevertAgentTemplateVersion(ctx, "planner", v1.VersionID)
+	if err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+	if reverted.State != "current" {
+		t.Fatalf("reverted state = %q", reverted.State)
+	}
+	current, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("get template: %v", err)
+	}
+	if current.Content != "v1 content" {
+		t.Fatalf("template content after revert = %q, want v1 content", current.Content)
+	}
+	// v2 is now superseded.
+	v2After, err := store.GetAgentTemplateVersionByID(ctx, v2.ID)
+	if err != nil {
+		t.Fatalf("get v2: %v", err)
+	}
+	if v2After.State != "superseded" {
+		t.Fatalf("v2 state after revert = %q", v2After.State)
+	}
+	// Reverting a non-superseded version is refused.
+	if _, err := store.RevertAgentTemplateVersion(ctx, "planner", v2.ID); err != nil {
+		t.Fatalf("revert back to v2 (superseded now) should work: %v", err)
+	}
+	if _, err := store.RevertAgentTemplateVersion(ctx, "planner", v2.ID); err == nil {
+		t.Fatal("reverting the CURRENT version should be refused")
+	}
+}
+
+func TestDeleteAgentChecked(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	if err := store.UpsertAgent(ctx, Agent{Name: "worker", Runtime: "codex"}); err != nil {
+		t.Fatalf("upsert agent: %v", err)
+	}
+	if err := store.CreateJob(ctx, Job{ID: "j1", Agent: "worker", Type: "ask", State: "queued"}); err != nil {
+		t.Fatalf("job: %v", err)
+	}
+	// Refused while a queued job references the agent.
+	if err := store.DeleteAgentChecked(ctx, "worker"); err == nil || !strings.Contains(err.Error(), "queued or running") {
+		t.Fatalf("expected job-reference refusal, got %v", err)
+	}
+	if err := store.UpdateJobState(ctx, "j1", "succeeded"); err != nil {
+		t.Fatalf("settle job: %v", err)
+	}
+	if err := store.DeleteAgentChecked(ctx, "worker"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := store.DeleteAgentChecked(ctx, "worker"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found on second delete, got %v", err)
+	}
+}


### PR DESCRIPTION
Part of #243 (dashboard cockpit). **Task 1 of 10.**

## WHAT
Store/CLI groundwork every later cockpit task builds on. No TUI changes yet.

## CHANGES
- `DeleteSkillOptTrainSession`: single-tx cascade (iterations → eval runs → review items/options, feedback + ranked feedback, review watches → session resource locks by whole-segment key match); refuses while a non-expired session lock is live; expired locks are swept.
- `created_repos` table + `RecordCreatedRepo`/`ListCreatedReposForSession`/`DeleteCreatedRepoRecord`; `ensureSkillOptTrainRepo` records what it creates (failed record = warning only).
- `RevertAgentTemplateVersion` + `gitmoot agent template revert <id> --version <ref>` — rollback to a superseded version (mirrors promote minus the pending guard).
- `DeleteAgentChecked` — refuses with queued/running jobs referencing the agent.
- Extracted reusable bodies: `stopSkillOptTrainSession`, `registerAgentOnly`.

## RESULTS
- `go test ./internal/db` green (cascade incl. active-lock refusal + expired-lock sweep; created-repo records; revert round-trip v2→v1→v2 with current-version refusal; delete-agent guard). Focused `./internal/cli` suites green; `go build ./...` green; `git diff --check` clean.

## RISK
Low-medium: the cascade is destructive but transaction-wrapped, lock-guarded, and only called by flows that confirm; everything else is additive. `train stop` behavior unchanged (extraction only).

## /code-review
High-effort review: 3 findings, 1 refuted + 2 fixed.
- **Refuted**: "latest pointer wrong after revert" — `latestSelectableVersionID` filters `state IN ('current','pending')`, so the newly-superseded version is excluded (verified in code).
- **Fixed**: dropped the `agent_instances WHERE type = name` deletion (type references a managed agent TYPE, not agents.name — could have deleted another type's instances; instances are expiry-reaped anyway).
- **Fixed**: `created_repos` upsert now `ON CONFLICT DO NOTHING` so a later same-name record can't steal the original creator's cleanup linkage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)