### PR TITLE
github: DeleteRepository via gh repo delete (cockpit task 2)

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1964,6 +1964,10 @@ func (f *fakeGitHub) CreateRepository(context.Context, github.Repository, bool) 
 	return nil
 }
 
+func (f *fakeGitHub) DeleteRepository(context.Context, github.Repository) error {
+	return nil
+}
+
 func (f *fakeGitHub) ListPullRequests(_ context.Context, _ github.Repository, state string) ([]github.PullRequest, error) {
 	f.listPullRequestsCalls++
 	if len(f.listPullRequestsErrs) > 0 {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -21,6 +21,7 @@ type Client interface {
 	Preflight(ctx context.Context, repo Repository) error
 	RepositoryExists(ctx context.Context, repo Repository) (bool, error)
 	CreateRepository(ctx context.Context, repo Repository, private bool) error
+	DeleteRepository(ctx context.Context, repo Repository) error
 	ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error)
 	GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
@@ -350,6 +351,26 @@ func (c *GhClient) CreateRepository(ctx context.Context, repo Repository, privat
 	}
 	_, err := c.run(ctx, true, "repo", "create", repo.FullName(), visibility)
 	return err
+}
+
+// DeleteRepository deletes the repo via `gh repo delete`. GitHub requires the
+// non-default delete_repo token scope; a scope failure is mapped to the exact
+// remedy so callers can show it verbatim.
+func (c *GhClient) DeleteRepository(ctx context.Context, repo Repository) error {
+	if strings.TrimSpace(repo.FullName()) == "" {
+		return fmt.Errorf("repository owner/name is required")
+	}
+	result, err := c.run(ctx, true, "repo", "delete", repo.FullName(), "--yes")
+	if err != nil && isMissingDeleteRepoScope(result) {
+		return fmt.Errorf("deleting %s requires the delete_repo token scope; run `gh auth refresh -h github.com -s delete_repo` and retry: %w", repo.FullName(), err)
+	}
+	return err
+}
+
+func isMissingDeleteRepoScope(result subprocess.Result) bool {
+	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	return strings.Contains(text, "delete_repo") ||
+		(strings.Contains(text, "http 403") && strings.Contains(text, "scope"))
 }
 
 func (c *GhClient) ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error) {
@@ -885,6 +906,10 @@ func (NoopClient) RepositoryExists(context.Context, Repository) (bool, error) {
 }
 
 func (NoopClient) CreateRepository(context.Context, Repository, bool) error {
+	return nil
+}
+
+func (NoopClient) DeleteRepository(context.Context, Repository) error {
 	return nil
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -89,6 +89,50 @@ func TestCreateRepository(t *testing.T) {
 	})
 }
 
+func TestDeleteRepository(t *testing.T) {
+	repo := Repository{Owner: "o", Name: "r"}
+
+	t.Run("deletes", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{}}}
+		client := GhClient{Runner: runner}
+		if err := client.DeleteRepository(context.Background(), repo); err != nil {
+			t.Fatalf("DeleteRepository: %v", err)
+		}
+		runner.wantArgs(t, 0, "repo", "delete", "o/r", "--yes")
+	})
+
+	t.Run("missing delete_repo scope maps to remedy", func(t *testing.T) {
+		runner := &fakeRunner{
+			results: []subprocess.Result{{Stderr: "HTTP 403: Must have admin rights... This API operation needs the \"delete_repo\" scope"}},
+			errs:    []error{errors.New("exit status 1")},
+		}
+		client := GhClient{Runner: runner}
+		err := client.DeleteRepository(context.Background(), repo)
+		if err == nil || !strings.Contains(err.Error(), "gh auth refresh -h github.com -s delete_repo") {
+			t.Fatalf("expected the scope remedy in the error, got %v", err)
+		}
+	})
+
+	t.Run("other errors propagate unchanged", func(t *testing.T) {
+		runner := &fakeRunner{
+			results: []subprocess.Result{{Stderr: "HTTP 404: Not Found"}},
+			errs:    []error{errors.New("exit status 1")},
+		}
+		client := GhClient{Runner: runner}
+		err := client.DeleteRepository(context.Background(), repo)
+		if err == nil || strings.Contains(err.Error(), "delete_repo") {
+			t.Fatalf("non-scope error should propagate without the remedy, got %v", err)
+		}
+	})
+
+	t.Run("empty repo", func(t *testing.T) {
+		client := GhClient{Runner: &fakeRunner{}}
+		if err := client.DeleteRepository(context.Background(), Repository{}); err == nil {
+			t.Fatal("expected error for empty repo")
+		}
+	})
+}
+
 func TestListIssueCommentsDedupesByID(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{


### PR DESCRIPTION
Part of #243 (dashboard cockpit). **Task 2 of 10.**

## WHAT
Adds `github.Client.DeleteRepository` — `gh repo delete owner/name --yes` on the mutate path — for the train-session repo-cleanup flow (which only ever offers deletion of repos recorded in `created_repos`).

## CHANGES
- GhClient impl + interface + NoopClient + the daemon test fake (explicit implementer — the #240 lesson applied proactively).
- Missing `delete_repo` scope maps to the exact remedy `gh auth refresh -h github.com -s delete_repo`, wrapping (`%w`) the original error.

## RESULTS
- `go test ./internal/github` green (args, scope remedy, non-scope propagation, empty guard); **full `go test ./...`** green except the pre-existing daemon flake `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos`; `go vet`/`gofmt`/`git diff --check` clean.

## RISK
Low; ships dark (no caller yet). Destructive op rides `mutateMu` like other writes.

## /code-review
High-effort review: **no findings**. Confirmed the scope matcher fits gh's real error text (which itself names `delete_repo`), `%w` preserves errors.Is/As, mutate lock correct, all interface implementers covered, and the `--yes` syntax is the documented non-interactive form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)