### PR TITLE
runtime: kill the whole process group on job cancel (cockpit task 3)

### DIFF
--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -243,7 +243,9 @@ func (a CodexAdapter) runner() subprocess.Runner {
 	if a.Runner != nil {
 		return a.Runner
 	}
-	return subprocess.ExecRunner{}
+	// Group semantics so cancelling a job kills the runtime CLI's whole
+	// process tree, not just the immediate child.
+	return subprocess.GroupRunner{}
 }
 
 func (a CodexAdapter) verifySession(ctx context.Context, agent Agent) error {
@@ -351,7 +353,9 @@ func (a ClaudeAdapter) runner() subprocess.Runner {
 	if a.Runner != nil {
 		return a.Runner
 	}
-	return subprocess.ExecRunner{}
+	// Group semantics so cancelling a job kills the runtime CLI's whole
+	// process tree, not just the immediate child.
+	return subprocess.GroupRunner{}
 }
 
 func (a ClaudeAdapter) newRuntimeRef() (string, error) {
@@ -409,7 +413,9 @@ func (a ShellAdapter) runner() subprocess.Runner {
 	if a.Runner != nil {
 		return a.Runner
 	}
-	return subprocess.ExecRunner{}
+	// Group semantics so cancelling a job kills the runtime CLI's whole
+	// process tree, not just the immediate child.
+	return subprocess.GroupRunner{}
 }
 
 func commandError(result subprocess.Result, err error) error {

--- a/internal/subprocess/group.go
+++ b/internal/subprocess/group.go
@@ -1,0 +1,75 @@
+package subprocess
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// groupKillGrace is how long a cancelled process group gets to exit after
+// SIGTERM before the remaining processes are SIGKILLed.
+const groupKillGrace = 10 * time.Second
+
+// GroupRunner runs commands in their own process group and, on context
+// cancellation, signals the WHOLE group (SIGTERM, then SIGKILL after a grace
+// period). Plain exec.CommandContext only kills the immediate child, which
+// orphans grandchildren — runtime CLIs like codex/claude spawn helpers that
+// must die with the job. Used by the runtime adapters; short-lived tool calls
+// (gh, git) keep the plain ExecRunner.
+type GroupRunner struct{}
+
+func (GroupRunner) Run(ctx context.Context, dir string, command string, args ...string) (Result, error) {
+	return RunGroup(ctx, dir, command, args...)
+}
+
+func (GroupRunner) LookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
+// RunGroup is Run with process-group semantics: the child gets its own pgid
+// (Setpgid) so the daemon never signals itself, cancellation SIGTERMs the
+// group, Go's WaitDelay reaps a stuck main child after the grace period, and a
+// final best-effort SIGKILL sweeps any group members that ignored SIGTERM.
+func RunGroup(ctx context.Context, dir string, command string, args ...string) (Result, error) {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Dir = dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	// On ctx cancel, signal the whole group. The pgid is resolved HERE, while
+	// the process is alive, and remembered for the final sweep — re-resolving
+	// after the child is reaped could chase a reused pid into an unrelated
+	// process group. syscall.Kill takes the pgid negated (golang/go#53199).
+	var pgid int
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if id, err := syscall.Getpgid(cmd.Process.Pid); err == nil && id > 0 {
+			pgid = id
+			return syscall.Kill(-pgid, syscall.SIGTERM)
+		}
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+	// If the main child ignores SIGTERM, Wait force-kills it after the grace.
+	cmd.WaitDelay = groupKillGrace
+
+	err := cmd.Run()
+	if ctx.Err() != nil && pgid > 0 {
+		// The run was cancelled: sweep group members that survived SIGTERM and
+		// the main child's kill (orphaned grandchildren). A fully-dead group
+		// makes this a harmless ESRCH.
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	}
+	return Result{
+		Command: command,
+		Args:    args,
+		Stdout:  stdout.String(),
+		Stderr:  stderr.String(),
+	}, err
+}

--- a/internal/subprocess/group_test.go
+++ b/internal/subprocess/group_test.go
@@ -1,0 +1,75 @@
+package subprocess
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestRunGroupKillsGrandchildrenOnCancel proves that cancelling the context
+// terminates not just the shell but the background grandchild it spawned —
+// the failure mode plain exec.CommandContext leaves behind.
+func TestRunGroupKillsGrandchildrenOnCancel(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		// The shell spawns a long-lived grandchild, records its pid, then waits.
+		_, err := RunGroup(ctx, "", "sh", "-c", "sleep 300 & echo $! > "+pidFile+"; wait")
+		done <- err
+	}()
+
+	// Wait for the grandchild pid to appear.
+	var grandchild int
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(pidFile); err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid > 0 {
+				grandchild = pid
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if grandchild == 0 {
+		t.Fatal("grandchild pid never appeared")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("RunGroup did not return after cancellation")
+	}
+
+	// The grandchild must be gone (signal 0 probes existence). Allow a short
+	// settling window for the SIGKILL sweep.
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(grandchild, 0); err != nil {
+			return // dead — success
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("grandchild %d survived group cancellation", grandchild)
+}
+
+// TestRunGroupNormalCompletionUnaffected: group semantics must not change
+// successful runs.
+func TestRunGroupNormalCompletionUnaffected(t *testing.T) {
+	result, err := RunGroup(context.Background(), "", "sh", "-c", "echo hello")
+	if err != nil {
+		t.Fatalf("RunGroup: %v", err)
+	}
+	if strings.TrimSpace(result.Stdout) != "hello" {
+		t.Fatalf("stdout = %q", result.Stdout)
+	}
+}


### PR DESCRIPTION
Part of #243 (dashboard cockpit). **Task 3 of 10.**

## WHAT
Completes running-job cancellation: cancelling a job now kills the runtime CLI's **entire process tree**, not just the immediate child.

## Scope discovery (honest scoping)
Exploration showed the cooperative-cancel machinery already existed end-to-end: `workflow.CancelJob`, the worker's `runningJobContext` (polls `JobCancelled` every 250ms → ctx cancel), `exec.CommandContext`, the `cancel_settled` path with lock release, and even the `gitmoot job cancel` CLI — all with tests. The only real gap was orphaned grandchildren.

## CHANGES
- `subprocess.GroupRunner`/`RunGroup`: `Setpgid` (own group — the daemon can't signal itself), `cmd.Cancel` → SIGTERM to `-pgid` (the documented Getpgid form for Go's negative-pid quirk), `WaitDelay` 10s grace, then a best-effort SIGKILL sweep of the group.
- The pgid is resolved **while the process is alive** in `Cancel` and remembered for the sweep — re-resolving after reaping could chase a reused pid into an unrelated group (review finding, fixed).
- Codex/Claude/Shell adapters default to `GroupRunner`; injected runners and the plain `ExecRunner` (gh/git tool calls) unchanged.

## RESULTS
- New test proves a cancelled `sh -c 'sleep 300 & …; wait'` leaves **no surviving grandchild** (signal-0 probe), 3 consecutive runs.
- Existing daemon cancellation suites green: `TestRunQueuedJobsCancelsActiveDeliveryContext`, `…ReleasesRuntimeSessionLockAfterCancellation`, `…PreservesCancellationRace`. `go vet`/`gofmt`/`git diff --check` clean.

## RISK
Medium-by-nature (signal handling) but tightly scoped: only the three adapters' default runner changes; cancelled jobs may now take up to the 10s grace to settle (previously instant-kill of the main child only). All adapter call sites use cancellable job contexts.

## /code-review
High-effort review: 1 real finding (the pid-reuse race in the post-run sweep), **fixed** by capturing the pgid in `Cancel`. Verified: `Cancel` only runs for started processes; `WaitDelay` unblocks buffer-attached waits; no foreground adapter path relies on inheriting the parent's process group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)