### PR TITLE
cli: tui root router; open any train session from the dashboard (cockpit task 4)

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -49,11 +49,18 @@ func stdinIsCharDevice() bool {
 	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
-// runDashboardTUI launches the bubbletea dashboard. It returns a process exit
-// code like the other dashboard paths.
+// runDashboardTUI launches the bubbletea dashboard inside the Root router so
+// pages can push full-screen child views (e.g. a train session's phase view).
+// It returns a process exit code like the other dashboard paths.
 func runDashboardTUI(home string, interval time.Duration, stdout, stderr io.Writer) int {
+	deps := dashboardTUIDeps(home, interval)
+	deps.OpenTrain = func(sessionID string) tea.Model {
+		trainDeps := skillOptTrainRunDeps(home, func() string { return sessionID })
+		trainDeps.Embedded = true
+		return tui.NewTrainRun(trainDeps)
+	}
 	program := tea.NewProgram(
-		tui.New(dashboardTUIDeps(home, interval)),
+		tui.NewRoot(tui.New(deps)),
 		tea.WithAltScreen(),
 		tea.WithOutput(stdout),
 	)

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -9,6 +9,7 @@ package tui
 import (
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jerryfane/gitmoot/internal/db"
 )
 
@@ -94,14 +95,17 @@ type ResourceLock struct {
 	Stale bool
 }
 
-// Deps are the data source and action callbacks the cli package injects. Answer
-// and Dismiss are unused by the read-only pages but are part of the stable
-// surface the Attention page (a later task) calls.
+// Deps are the data source and action callbacks the cli package injects.
 type Deps struct {
 	Load     func() (Snapshot, error)
 	Answer   func(id, value string) error
 	Dismiss  func(id string) error
 	Interval time.Duration
+
+	// OpenTrain, when set, builds the embedded train-run model for a session;
+	// the Trains page pushes it onto the Root stack instead of the inline
+	// detail view.
+	OpenTrain func(sessionID string) tea.Model
 }
 
 // snapshotMsg carries the result of a Deps.Load call.
@@ -111,8 +115,18 @@ type snapshotMsg struct {
 	at   time.Time
 }
 
-// tickMsg fires on the refresh interval.
-type tickMsg struct{}
+// tickMsg fires on the refresh interval. gen identifies the tick chain it
+// belongs to: while a child view covers the dashboard its ticks go unhandled
+// and the chain dies, so the pop-nudge starts a NEW generation — and a stale
+// pre-push tick that fires after a fast pop must be dropped, not re-armed,
+// or chains would accumulate.
+type tickMsg struct {
+	gen int
+}
+
+// refreshNudgeMsg asks a model to refresh once and restart its tick chain
+// under a new generation — sent by the Root when a pop resumes a model.
+type refreshNudgeMsg struct{}
 
 // answerResultMsg carries the outcome of a Deps.Answer call.
 type answerResultMsg struct {

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -72,6 +72,8 @@ type Model struct {
 	input        textinput.Model      // free-text answer in modeAnswerText
 	actionErr    string               // inline error from the last Answer/Dismiss attempt
 	actionBusy   bool                 // an action is in flight; suppress re-submit
+	showHelp     bool                 // '?' help overlay
+	tickGen      int                  // current tick chain; stale generations are dropped
 }
 
 // New returns a Model ready for tea.NewProgram. It starts in the loading state;
@@ -98,7 +100,7 @@ func (m Model) interval() time.Duration {
 
 // Init satisfies tea.Model.
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(loadSnapshot(m.deps), tick(m.interval()))
+	return tea.Batch(loadSnapshot(m.deps), tick(m.interval(), m.tickGen))
 }
 
 // Update satisfies tea.Model.
@@ -184,10 +186,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "enter":
 			if pages[m.selected].page == pageTrains {
+				// With a Root router, open the full train-run view; otherwise the
+				// inline detail (keeps the model usable standalone and old tests
+				// green).
+				if m.deps.OpenTrain != nil && len(m.snap.Trains) > 0 {
+					session := m.snap.Trains[m.trainCursor].ID
+					return m, Push(m.deps.OpenTrain(session))
+				}
 				m.openTrainDetail()
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
+		case "?":
+			m.showHelp = !m.showHelp
+			m.viewport.SetContent(m.content())
+			return m, tea.Batch(cmds...)
 		}
 		var cmd tea.Cmd
 		m.viewport, cmd = m.viewport.Update(msg)
@@ -231,11 +244,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampPromptCursor()
 			m.clampTrainCursor()
 		}
-	case tickMsg:
+	case refreshNudgeMsg:
+		// Resumed after a pop: the old tick chain died unhandled under the child
+		// view, so refresh now and start a NEW chain. Bumping the generation also
+		// kills a stale pre-push tick that would otherwise re-arm a second chain.
+		m.tickGen++
 		if cmd := m.queueLoad(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
-		cmds = append(cmds, tick(m.interval()))
+		cmds = append(cmds, tick(m.interval(), m.tickGen))
+	case tickMsg:
+		if msg.gen != m.tickGen {
+			break // a tick from a dead chain; do not re-arm
+		}
+		if cmd := m.queueLoad(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		cmds = append(cmds, tick(m.interval(), m.tickGen))
 	}
 	m.viewport.SetContent(m.content())
 	return m, tea.Batch(cmds...)
@@ -298,8 +323,8 @@ func loadSnapshot(deps Deps) tea.Cmd {
 	}
 }
 
-func tick(d time.Duration) tea.Cmd {
-	return tea.Tick(d, func(time.Time) tea.Msg { return tickMsg{} })
+func tick(d time.Duration, gen int) tea.Cmd {
+	return tea.Tick(d, func(time.Time) tea.Msg { return tickMsg{gen: gen} })
 }
 
 func max(a, b int) int {

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -148,8 +148,29 @@ func TestResizeUpdatesViewport(t *testing.T) {
 
 func TestTickRearmsAndRefreshes(t *testing.T) {
 	m := loadedModel(t)
-	_, cmd := m.Update(tickMsg{})
+	_, cmd := m.Update(tickMsg{gen: m.tickGen})
 	if cmd == nil {
 		t.Fatal("tick should produce commands (re-arm + load)")
+	}
+}
+
+func TestStaleTickGenerationDropped(t *testing.T) {
+	m := loadedModel(t)
+	// A pop-nudge starts a new tick generation…
+	next, cmd := m.Update(refreshNudgeMsg{})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("nudge should refresh and re-arm")
+	}
+	// …so a tick from the pre-push chain must be dropped without re-arming
+	// (otherwise fast push/pop cycles would accumulate parallel tick chains).
+	_, cmd = m.Update(tickMsg{gen: m.tickGen - 1})
+	if cmd != nil {
+		t.Fatal("a stale-generation tick must not re-arm")
+	}
+	// The current generation still works.
+	_, cmd = m.Update(tickMsg{gen: m.tickGen})
+	if cmd == nil {
+		t.Fatal("the current-generation tick should re-arm")
 	}
 }

--- a/internal/cli/tui/root.go
+++ b/internal/cli/tui/root.go
@@ -1,0 +1,90 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// PushModelMsg asks the Root to push a child model onto the navigation stack
+// (e.g. the dashboard opening a train session's phase view).
+type PushModelMsg struct {
+	Model tea.Model
+}
+
+// PopModelMsg asks the Root to pop the top model and return to the one below.
+type PopModelMsg struct{}
+
+// Push returns a command that pushes model onto the Root's stack.
+func Push(model tea.Model) tea.Cmd {
+	return func() tea.Msg { return PushModelMsg{Model: model} }
+}
+
+// Pop returns a command that pops the Root's top model.
+func Pop() tea.Cmd {
+	return func() tea.Msg { return PopModelMsg{} }
+}
+
+// Root is the navigation shell: a message router and screen compositor over a
+// stack of child models, with the dashboard at the bottom. It owns only
+// ctrl+c (global quit) and the push/pop messages; every other message is
+// delegated to the top of the stack, so child sub-modes (text inputs, confirm
+// overlays) keep full key ownership. Window sizes are broadcast to the whole
+// stack so a model resumed by a pop is already sized.
+type Root struct {
+	stack []tea.Model
+	size  *tea.WindowSizeMsg
+}
+
+// NewRoot returns a Root with base at the bottom of the stack.
+func NewRoot(base tea.Model) Root {
+	return Root{stack: []tea.Model{base}}
+}
+
+func (r Root) top() tea.Model { return r.stack[len(r.stack)-1] }
+
+// Init initializes the base model.
+func (r Root) Init() tea.Cmd {
+	return r.top().Init()
+}
+
+func (r Root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			return r, tea.Quit
+		}
+	case tea.WindowSizeMsg:
+		r.size = &msg
+		var cmds []tea.Cmd
+		for i, child := range r.stack {
+			next, cmd := child.Update(msg)
+			r.stack[i] = next
+			cmds = append(cmds, cmd)
+		}
+		return r, tea.Batch(cmds...)
+	case PushModelMsg:
+		r.stack = append(r.stack, msg.Model)
+		cmds := []tea.Cmd{msg.Model.Init()}
+		if r.size != nil {
+			next, cmd := r.top().Update(*r.size)
+			r.stack[len(r.stack)-1] = next
+			cmds = append(cmds, cmd)
+		}
+		return r, tea.Batch(cmds...)
+	case PopModelMsg:
+		if len(r.stack) > 1 {
+			r.stack = r.stack[:len(r.stack)-1]
+			// Nudge the resumed model to refresh immediately rather than
+			// waiting for its next interval tick (refreshNudgeMsg does NOT
+			// re-arm the tick, so pops cannot accumulate tick loops).
+			next, cmd := r.top().Update(refreshNudgeMsg{})
+			r.stack[len(r.stack)-1] = next
+			return r, cmd
+		}
+		return r, tea.Quit
+	}
+	next, cmd := r.top().Update(msg)
+	r.stack[len(r.stack)-1] = next
+	return r, cmd
+}
+
+func (r Root) View() string {
+	return r.top().View()
+}

--- a/internal/cli/tui/root_test.go
+++ b/internal/cli/tui/root_test.go
@@ -1,0 +1,143 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func rootWithDashboard(t *testing.T) Root {
+	t.Helper()
+	deps := Deps{
+		Load: func() (Snapshot, error) { return trainSnapshot(), nil },
+		OpenTrain: func(sessionID string) tea.Model {
+			td := TrainRunDeps{
+				Embedded: true,
+				Load: func() (TrainRunSnapshot, error) {
+					return TrainRunSnapshot{SessionID: sessionID, Phase: "items_ready"}, nil
+				},
+			}
+			return NewTrainRun(td)
+		},
+	}
+	dash := New(deps)
+	root := NewRoot(dash)
+	next, _ := root.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	root = next.(Root)
+	next, _ = root.Update(snapshotMsg{snap: trainSnapshot(), at: time.Unix(1, 0)})
+	return next.(Root)
+}
+
+// driveRoot applies a msg and any push/pop msgs its commands produce (the test
+// stand-in for the bubbletea runtime's command loop).
+func driveRoot(t *testing.T, root Root, msg tea.Msg) Root {
+	t.Helper()
+	next, cmd := root.Update(msg)
+	root = next.(Root)
+	for cmd != nil {
+		out := cmd()
+		switch out.(type) {
+		case PushModelMsg, PopModelMsg:
+			next, cmd2 := root.Update(out)
+			root = next.(Root)
+			cmd = cmd2
+		default:
+			cmd = nil
+		}
+	}
+	return root
+}
+
+func TestRootPushesTrainViewOnTrainsEnter(t *testing.T) {
+	root := rootWithDashboard(t)
+	// Tab to Trains, then enter.
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab})
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyEnter})
+	if len(root.stack) != 2 {
+		t.Fatalf("enter on Trains should push the train view, stack=%d", len(root.stack))
+	}
+	if _, ok := root.top().(TrainRunModel); !ok {
+		t.Fatalf("top of stack should be the train-run model, got %T", root.top())
+	}
+}
+
+func TestRootPopsBackToDashboard(t *testing.T) {
+	root := rootWithDashboard(t)
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab})
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyEnter})
+	if len(root.stack) != 2 {
+		t.Fatalf("setup: stack=%d", len(root.stack))
+	}
+	// q in the embedded train view pops, not quits.
+	root = driveRoot(t, root, key("q"))
+	if len(root.stack) != 1 {
+		t.Fatalf("q should pop back to the dashboard, stack=%d", len(root.stack))
+	}
+	if !strings.Contains(root.View(), "train-aaa") {
+		t.Fatalf("dashboard should be visible again:\n%s", root.View())
+	}
+}
+
+func TestRootCtrlCQuitsFromChild(t *testing.T) {
+	root := rootWithDashboard(t)
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab})
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyEnter})
+	_, cmd := root.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Fatal("ctrl+c should produce a quit command")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("ctrl+c should quit, got %T", cmd())
+	}
+}
+
+func TestRootBroadcastsWindowSize(t *testing.T) {
+	root := rootWithDashboard(t)
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab})
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyEnter})
+	next, _ := root.Update(tea.WindowSizeMsg{Width: 60, Height: 20})
+	root = next.(Root)
+	// Pop back; the dashboard below must have received the resize too.
+	root = driveRoot(t, root, key("q"))
+	dash := root.top().(Model)
+	if dash.width != 60 || dash.height != 20 {
+		t.Fatalf("dashboard missed the broadcast resize: %dx%d", dash.width, dash.height)
+	}
+}
+
+func TestRootPopOnBaseQuits(t *testing.T) {
+	root := rootWithDashboard(t)
+	_, cmd := root.Update(PopModelMsg{})
+	if cmd == nil {
+		t.Fatal("pop on the base should quit")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("expected quit, got %T", cmd())
+	}
+}
+
+func TestDashboardHelpOverlay(t *testing.T) {
+	m := loadedModel(t)
+	next, _ := m.Update(key("?"))
+	m = next.(Model)
+	if !strings.Contains(m.View(), "Help — Attention") {
+		t.Fatalf("expected the help overlay:\n%s", m.View())
+	}
+	next, _ = m.Update(key("?"))
+	m = next.(Model)
+	if strings.Contains(m.View(), "Help — Attention") {
+		t.Fatalf("? again should close help:\n%s", m.View())
+	}
+}
+
+func TestDashboardTrainsEnterWithoutOpenTrainKeepsDetail(t *testing.T) {
+	// Without OpenTrain the old inline detail still works (standalone use).
+	m := trainsModel(t)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if m.mode != modeTrainDetail {
+		t.Fatalf("without OpenTrain, enter should open the inline detail, mode=%v", m.mode)
+	}
+}

--- a/internal/cli/tui/trainrun.go
+++ b/internal/cli/tui/trainrun.go
@@ -70,6 +70,10 @@ type TrainRunDeps struct {
 	// returning any new lines and the next offset. Used to show live progress
 	// during the long generate/optimizer phases.
 	TailLog func(offset int64) (lines []string, next int64, err error)
+
+	// Embedded marks the model as a child of the Root router: q/esc pop back to
+	// the dashboard instead of quitting the program.
+	Embedded bool
 }
 
 type trainRunMode int
@@ -283,6 +287,9 @@ func (m TrainRunModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.confirming {
 		switch msg.String() {
 		case "esc", "q":
+			if m.deps.Embedded {
+				return m, Pop()
+			}
 			return m, tea.Quit
 		case "enter":
 			if m.creating {
@@ -331,6 +338,9 @@ func (m TrainRunModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.String() {
 	case "q", "esc":
+		if m.deps.Embedded {
+			return m, Pop()
+		}
 		return m, tea.Quit
 	case "r":
 		return m, m.queueLoad()

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -59,6 +59,9 @@ func renderSidebar(selected, width, height int) string {
 }
 
 func (m Model) content() string {
+	if m.showHelp {
+		return m.helpContent()
+	}
 	var b strings.Builder
 	b.WriteString(titleStyle.Render(pages[m.selected].label))
 	if !m.loadedAt.IsZero() {
@@ -86,6 +89,30 @@ func (m Model) content() string {
 	}
 	b.WriteString("\n\n")
 	b.WriteString(mutedStyle.Render(m.footerHelp()))
+	return b.String()
+}
+
+// helpContent is the '?' overlay: every key for the current page plus globals.
+func (m Model) helpContent() string {
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("Help — " + pages[m.selected].label))
+	b.WriteString("\n\n")
+	switch pages[m.selected].page {
+	case pageAttention:
+		b.WriteString("↑/↓  select a pending prompt\n")
+		b.WriteString("a    answer the selected prompt (choices or text)\n")
+		b.WriteString("d    dismiss (delete) the selected prompt\n")
+	case pageTrains:
+		b.WriteString("↑/↓  select a train session\n")
+		b.WriteString("enter open the session (live phase view; esc returns)\n")
+	default:
+		b.WriteString("j/k or wheel  scroll\n")
+	}
+	b.WriteString("\nGlobal:\n")
+	b.WriteString("tab/shift+tab or ←/→  switch page\n")
+	b.WriteString("r  refresh now\n")
+	b.WriteString("?  close this help\n")
+	b.WriteString("q  quit (background work keeps running)\n")
 	return b.String()
 }
 


### PR DESCRIPTION
Part of #243 (dashboard cockpit). **Task 4 of 10.**

## WHAT
The structural piece: `tui.Root`, a navigation stack over the dashboard, and the first real use — `enter` on a Trains row opens the **full train-run phase view** for that exact session (any session, killing the newest-only quirk), `esc` pops back.

## CHANGES
- `tui.Root`: message router + compositor over a model stack (documented bubbletea pattern). Root owns only **ctrl+c** and the Push/Pop messages; everything else is delegated to the stack top so child sub-modes (text inputs, confirms) keep full key ownership. Window sizes broadcast to the whole stack.
- `Deps.OpenTrain` (cli builds the embedded `TrainRunModel`); `TrainRunDeps.Embedded` makes q/esc pop instead of quit (incl. the confirm screen). Without `OpenTrain`, the old inline detail remains — standalone use and all existing tests untouched.
- `?` help overlay on the dashboard — handled **inside** the model (mode-aware) rather than at the root, deliberately, so `?` typed into a text input is never swallowed. Per-page key listing.
- **Tick generations**: covered models' interval ticks die unhandled (routed to the stack top); the pop nudge refreshes and starts a new generation, and stale pre-push ticks are dropped instead of re-arming.

## RESULTS
- Full `go test ./internal/cli/tui` green (router push/pop/ctrl+c/broadcast/base-pop, help toggle, standalone fallback, stale-generation drop) plus every pre-existing dashboard/train test. `go build ./...` / vet / fmt / `git diff --check` clean.

## RISK
Medium (structural), contained: the dashboard model itself is unchanged in rendering and stays fully usable standalone; the Root only adds routing.

## /code-review
High-effort review caught a **real bug** in my first pop design: the dashboard's tick chain dies while covered (its typed ticks route to the child), and the plain refresh-on-pop never re-armed it — and the naive "send a tick on pop" fix would **double** chains on fast push/pop (the pre-push timer still pending). Fixed with tick **generations** (the same staleness discipline as the train-init form): pop bumps the generation + re-arms; stale ticks drop. Regression test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)