### PR TITLE
cli: dashboard jobs page with retry/cancel and daemon start

### DIFF
--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -47,6 +47,15 @@ type dashboardSnapshot struct {
 	// TUI's inline answer flow. Unexported so it never appears in --json output
 	// or the plain renderer, keeping those contracts byte-stable.
 	promptDetails []db.InteractivePrompt
+	// jobRows carries per-job rows (and, for blocked/failed jobs, the latest
+	// event message) for the TUI's Jobs page. Unexported for the same reason.
+	jobRows []dashboardJobRow
+}
+
+// dashboardJobRow is one job with the context the TUI needs to act on it.
+type dashboardJobRow struct {
+	db.Job
+	LatestEvent string
 }
 
 type dashboardResourceLock struct {
@@ -303,12 +312,23 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 			return err
 		}
 		snapshot.Jobs.Total = len(jobs)
+		// One batched read of every job's latest event; blocked/failed rows
+		// surface WHY in the attention list.
+		latestEvents, err := store.LatestJobEvents(ctx)
+		if err != nil {
+			return err
+		}
 		for _, job := range jobs {
 			state := job.State
 			if strings.TrimSpace(state) == "" {
 				state = "unknown"
 			}
 			snapshot.Jobs.ByState[state]++
+			row := dashboardJobRow{Job: job}
+			if job.State == "blocked" || job.State == "failed" {
+				row.LatestEvent = latestEvents[job.ID].Message
+			}
+			snapshot.jobRows = append(snapshot.jobRows, row)
 		}
 		tasks, err := store.ListTasks(ctx)
 		if err != nil {

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/cli/tui"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
 // dashboardFlags is the subset of dashboard flags that decide whether the
@@ -99,6 +101,45 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 				return store.DeleteInteractivePrompt(context.Background(), id)
 			})
 		},
+		JobEvents: func(id string) ([]tui.JobEventView, error) {
+			var views []tui.JobEventView
+			err := withStore(home, func(store *db.Store) error {
+				events, err := store.ListJobEvents(context.Background(), id)
+				if err != nil {
+					return err
+				}
+				for _, event := range events {
+					views = append(views, tui.JobEventView{Kind: event.Kind, Message: event.Message})
+				}
+				return nil
+			})
+			return views, err
+		},
+		RetryJob: func(id string) error {
+			// workflow.RetryJob is the same path `gitmoot job retry` takes: it
+			// clears the stale payload.Result and emits the retry_queued event
+			// the daemon's retry bookkeeping keys on.
+			return withStore(home, func(store *db.Store) error {
+				_, err := workflow.RetryJob(context.Background(), store, id)
+				return err
+			})
+		},
+		CancelJob: func(id string) error {
+			return withStore(home, func(store *db.Store) error {
+				_, err := workflow.CancelJob(context.Background(), store, id)
+				return err
+			})
+		},
+		StartDaemon: func() error {
+			// Restart rather than start: it tolerates a stopped daemon and
+			// restores the previously persisted flags (workers, poll, watch)
+			// instead of silently reverting to defaults.
+			var out bytes.Buffer
+			if code := runDaemonRestart([]string{"--home", home}, &out, &out); code != 0 {
+				return fmt.Errorf("daemon start failed: %s", strings.TrimSpace(out.String()))
+			}
+			return nil
+		},
 	}
 }
 
@@ -131,6 +172,16 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 	}
 	for _, l := range s.ResourceLocks {
 		out.ResourceLocks = append(out.ResourceLocks, tui.ResourceLock{Key: l.Key, Owner: l.Owner, Stale: l.Stale})
+	}
+	for _, row := range s.jobRows {
+		out.JobRows = append(out.JobRows, tui.JobRow{
+			ID:          row.ID,
+			Agent:       row.Agent,
+			Type:        row.Type,
+			State:       row.State,
+			UpdatedAt:   row.UpdatedAt,
+			LatestEvent: row.LatestEvent,
+		})
 	}
 	return out
 }

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -1,22 +1,57 @@
 package tui
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jerryfane/gitmoot/internal/db"
 )
+
+// attnItem is one selectable row on the Attention page: a pending prompt or a
+// blocked/failed job.
+type attnItem struct {
+	prompt *db.InteractivePrompt
+	job    *JobRow
+}
+
+// attentionItems lists the actionable attention rows: pending prompts first,
+// then blocked/failed jobs.
+func (m Model) attentionItems() []attnItem {
+	items := make([]attnItem, 0, len(m.snap.Prompts))
+	for i := range m.snap.Prompts {
+		items = append(items, attnItem{prompt: &m.snap.Prompts[i]})
+	}
+	for i := range m.snap.JobRows {
+		if m.snap.JobRows[i].State == "blocked" || m.snap.JobRows[i].State == "failed" {
+			items = append(items, attnItem{job: &m.snap.JobRows[i]})
+		}
+	}
+	return items
+}
+
+// attentionPrompt returns the prompt under the attention cursor, if the
+// selected item is a prompt.
+func (m Model) attentionPrompt() (db.InteractivePrompt, bool) {
+	items := m.attentionItems()
+	if m.promptCursor < len(items) && items[m.promptCursor].prompt != nil {
+		return *items[m.promptCursor].prompt, true
+	}
+	return db.InteractivePrompt{}, false
+}
 
 // openAnswer enters the answer overlay for the prompt under the cursor. Choice
 // prompts get a selectable list with the default preselected; free-text prompts
 // get a text input prefilled with the default. Returns the textinput blink cmd
 // when relevant.
 func (m *Model) openAnswer() tea.Cmd {
-	if pages[m.selected].page != pageAttention || len(m.snap.Prompts) == 0 {
+	if pages[m.selected].page != pageAttention {
 		return nil
 	}
-	p := m.snap.Prompts[m.promptCursor]
+	p, ok := m.attentionPrompt()
+	if !ok {
+		return nil
+	}
 	m.active = p
 	m.actionErr = ""
 	m.actionBusy = false
@@ -35,10 +70,14 @@ func (m *Model) openAnswer() tea.Cmd {
 
 // openDismiss enters the dismiss-confirm overlay for the prompt under the cursor.
 func (m *Model) openDismiss() {
-	if pages[m.selected].page != pageAttention || len(m.snap.Prompts) == 0 {
+	if pages[m.selected].page != pageAttention {
 		return
 	}
-	m.active = m.snap.Prompts[m.promptCursor]
+	p, ok := m.attentionPrompt()
+	if !ok {
+		return
+	}
+	m.active = p
 	m.actionErr = ""
 	m.actionBusy = false
 	m.mode = modeConfirmDismiss
@@ -151,38 +190,54 @@ func (m Model) attentionContent() string {
 	var b strings.Builder
 	wrote := false
 
-	b.WriteString(headerStyle.Render("pending prompts"))
-	b.WriteByte('\n')
-	if len(m.snap.Prompts) == 0 {
-		b.WriteString(mutedStyle.Render("none"))
+	if !m.snap.Daemon.Running && !m.loadedAt.IsZero() {
+		hint := "press s to start"
+		if m.daemonBusy {
+			hint = "starting…"
+		}
+		b.WriteString(redStyle.Render("daemon stopped — jobs will not run") + "  " + mutedStyle.Render(hint))
 		b.WriteByte('\n')
-	} else {
-		for i, p := range m.snap.Prompts {
-			cursor := "  "
-			line := p.ID + "  " + truncate(p.Question, 60)
-			if i == m.promptCursor {
-				cursor = "▸ "
-				line = selectedRowStyle.Render(line)
-			}
-			b.WriteString(cursor)
-			b.WriteString(line)
+		if m.daemonErr != "" {
+			b.WriteString(errorStyle.Render(m.daemonErr))
 			b.WriteByte('\n')
 		}
-		b.WriteString(mutedStyle.Render("a answer  d dismiss"))
 		b.WriteByte('\n')
 		wrote = true
 	}
 
-	if blocked := m.snap.Jobs.ByState["blocked"]; blocked > 0 {
-		b.WriteString("\n")
-		b.WriteString(redStyle.Render(plural(blocked, "blocked job", "blocked jobs")))
+	items := m.attentionItems()
+	b.WriteString(headerStyle.Render("needs attention"))
+	b.WriteByte('\n')
+	if len(items) == 0 {
+		b.WriteString(mutedStyle.Render("none"))
+		b.WriteByte('\n')
+	} else {
+		for i, item := range items {
+			cursor := "  "
+			var line string
+			switch {
+			case item.prompt != nil:
+				line = "prompt " + item.prompt.ID + "  " + truncate(item.prompt.Question, 56)
+			case item.job != nil:
+				line = "job " + item.job.ID + "  " + item.job.Type + "  " + jobStateColor(item.job.State)
+				if item.job.LatestEvent != "" {
+					line += "  " + mutedStyle.Render(truncate(item.job.LatestEvent, 48))
+				}
+			}
+			if i == m.promptCursor {
+				cursor = "▸ "
+				line = selectedRowStyle.Render("• ") + line
+			}
+			b.WriteString(cursor + line + "\n")
+		}
+		// Attention only lists blocked/failed jobs, so cancel never applies here.
+		b.WriteString(mutedStyle.Render("prompts: a answer · d dismiss   jobs: enter detail · R retry"))
 		b.WriteByte('\n')
 		wrote = true
 	}
-	if failed := m.snap.Jobs.ByState["failed"]; failed > 0 {
-		b.WriteString(redStyle.Render(plural(failed, "failed job", "failed jobs")))
-		b.WriteByte('\n')
-		wrote = true
+
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
 	}
 
 	stale := staleLocks(m.snap.ResourceLocks)
@@ -289,11 +344,4 @@ func staleLocks(locks []ResourceLock) []ResourceLock {
 		}
 	}
 	return out
-}
-
-func plural(n int, one, many string) string {
-	if n == 1 {
-		return "1 " + one
-	}
-	return strconv.Itoa(n) + " " + many
 }

--- a/internal/cli/tui/attention_test.go
+++ b/internal/cli/tui/attention_test.go
@@ -180,7 +180,7 @@ func TestAttentionCursorClampedOnRefresh(t *testing.T) {
 		t.Fatalf("cursor should be at 1, got %d", m.promptCursor)
 	}
 	// Refresh with an empty prompt list must not leave a dangling cursor.
-	next, _ = m.Update(snapshotMsg{snap: Snapshot{}, at: time.Unix(2, 0)})
+	next, _ = m.Update(snapshotMsg{snap: Snapshot{Daemon: Daemon{Running: true}}, at: time.Unix(2, 0)})
 	m = next.(Model)
 	if m.promptCursor != 0 {
 		t.Fatalf("cursor should clamp to 0 when prompts empty, got %d", m.promptCursor)

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -29,6 +29,7 @@ type Snapshot struct {
 	Trains         []TrainSession
 	ResourceLocks  []ResourceLock
 	Prompts        []db.InteractivePrompt
+	JobRows        []JobRow
 }
 
 // Daemon mirrors cli.dashboardDaemon.
@@ -64,6 +65,23 @@ type Session struct {
 type Jobs struct {
 	Total   int
 	ByState map[string]int
+}
+
+// JobRow is one job the Jobs page can act on. LatestEvent is filled for
+// blocked/failed jobs (the "why" shown in the attention list).
+type JobRow struct {
+	ID          string
+	Agent       string
+	Type        string
+	State       string
+	UpdatedAt   string
+	LatestEvent string
+}
+
+// JobEventView is one entry of a job's event history shown in the detail view.
+type JobEventView struct {
+	Kind    string
+	Message string
 }
 
 // Worktree mirrors cli.dashboardWorktree.
@@ -106,6 +124,16 @@ type Deps struct {
 	// the Trains page pushes it onto the Root stack instead of the inline
 	// detail view.
 	OpenTrain func(sessionID string) tea.Model
+
+	// Job actions: event history (detail view), retry a failed/blocked job,
+	// cancel a queued/running one (cooperative — the daemon settles it).
+	JobEvents func(id string) ([]JobEventView, error)
+	RetryJob  func(id string) error
+	CancelJob func(id string) error
+
+	// StartDaemon starts the background daemon when the attention list shows it
+	// stopped.
+	StartDaemon func() error
 }
 
 // snapshotMsg carries the result of a Deps.Load call.
@@ -137,5 +165,25 @@ type answerResultMsg struct {
 // dismissResultMsg carries the outcome of a Deps.Dismiss call.
 type dismissResultMsg struct {
 	id  string
+	err error
+}
+
+// jobEventsMsg carries a job's event history for the detail view.
+type jobEventsMsg struct {
+	id     string
+	events []JobEventView
+	err    error
+}
+
+// jobActionMsg carries the outcome of a retry/cancel action.
+type jobActionMsg struct {
+	verb string // "retry" or "cancel"
+	id   string
+	err  error
+}
+
+// daemonStartMsg carries the outcome of a daemon start, separate from
+// jobActionMsg so it cannot close or pollute an open job confirm.
+type daemonStartMsg struct {
 	err error
 }

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -1,0 +1,231 @@
+package tui
+
+import (
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// openJobDetail enters the job detail view for the job under the Jobs cursor
+// and lazily loads its event history.
+func (m *Model) openJobDetail(job JobRow) tea.Cmd {
+	m.activeJob = job
+	m.jobEvents = nil
+	m.jobEventsLoaded = false
+	m.jobEventsErr = ""
+	m.actionErr = ""
+	m.actionBusy = false
+	m.mode = modeJobDetail
+	return jobEventsCmd(m.deps, job.ID)
+}
+
+// openJobConfirm enters the retry or cancel confirmation for the given job.
+func (m *Model) openJobConfirm(job JobRow, cancel bool) {
+	m.activeJob = job
+	m.actionErr = ""
+	m.actionBusy = false
+	if cancel {
+		m.mode = modeConfirmJobCancel
+	} else {
+		m.mode = modeConfirmJobRetry
+	}
+}
+
+// jobUnderCursor returns the selected job for the current page (Jobs page
+// cursor, or an attention job item), if any.
+func (m Model) jobUnderCursor() (JobRow, bool) {
+	switch pages[m.selected].page {
+	case pageJobs:
+		if len(m.snap.JobRows) == 0 {
+			return JobRow{}, false
+		}
+		return m.snap.JobRows[m.jobCursor], true
+	case pageAttention:
+		items := m.attentionItems()
+		if m.promptCursor < len(items) && items[m.promptCursor].job != nil {
+			return *items[m.promptCursor].job, true
+		}
+	}
+	return JobRow{}, false
+}
+
+// jobRetryable / jobCancelable mirror workflow.RetryJob / workflow.CancelJob's
+// accepted source states.
+func jobRetryable(state string) bool {
+	return state == "failed" || state == "blocked" || state == "cancelled"
+}
+
+func jobCancelable(state string) bool {
+	return state == "queued" || state == "running"
+}
+
+// updateJobOverlay handles keys in the job detail and confirm modes.
+func (m Model) updateJobOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.mode {
+	case modeJobDetail:
+		switch msg.String() {
+		case "esc", "enter", "q":
+			m.mode = modeNormal
+		case "R":
+			if jobRetryable(m.activeJob.State) {
+				m.mode = modeConfirmJobRetry
+			}
+		case "c":
+			if jobCancelable(m.activeJob.State) {
+				m.mode = modeConfirmJobCancel
+			}
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case modeConfirmJobRetry, modeConfirmJobCancel:
+		switch msg.String() {
+		case "y", "Y":
+			if m.actionBusy {
+				return m, nil
+			}
+			m.actionBusy = true
+			m.actionErr = ""
+			var cmd tea.Cmd
+			if m.mode == modeConfirmJobCancel {
+				cmd = jobActionCmd(m.deps.CancelJob, "cancel", m.activeJob.ID)
+			} else {
+				cmd = jobActionCmd(m.deps.RetryJob, "retry", m.activeJob.ID)
+			}
+			m.viewport.SetContent(m.content())
+			return m, cmd
+		default:
+			// While the action is in flight, keep the confirm open so its
+			// eventual result (especially an error) is not silently dropped.
+			if m.actionBusy {
+				return m, nil
+			}
+			m.mode = modeNormal
+			m.actionErr = ""
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	}
+	return m, nil
+}
+
+func jobEventsCmd(deps Deps, id string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.JobEvents == nil {
+			return jobEventsMsg{id: id}
+		}
+		events, err := deps.JobEvents(id)
+		return jobEventsMsg{id: id, events: events, err: err}
+	}
+}
+
+func jobActionCmd(action func(string) error, verb, id string) tea.Cmd {
+	return func() tea.Msg {
+		if action == nil {
+			return jobActionMsg{verb: verb, id: id}
+		}
+		return jobActionMsg{verb: verb, id: id, err: action(id)}
+	}
+}
+
+func daemonStartCmd(deps Deps) tea.Cmd {
+	return func() tea.Msg {
+		if deps.StartDaemon == nil {
+			return daemonStartMsg{}
+		}
+		return daemonStartMsg{err: deps.StartDaemon()}
+	}
+}
+
+// jobsContentInteractive renders the Jobs page as a selectable list. Job
+// overlays (detail/confirm) are dispatched once in content(), not here.
+func (m Model) jobsContentInteractive() string {
+	if len(m.snap.JobRows) == 0 {
+		return m.loadingOr("No jobs.", !m.loadedAt.IsZero())
+	}
+	var b strings.Builder
+	summary := []string{}
+	for _, state := range sortedKeys(m.snap.Jobs.ByState) {
+		summary = append(summary, jobStateColor(state)+" "+strconv.Itoa(m.snap.Jobs.ByState[state]))
+	}
+	b.WriteString(mutedStyle.Render(strconv.Itoa(m.snap.Jobs.Total)+" total") + "  " + strings.Join(summary, "  "))
+	b.WriteString("\n\n")
+	for i, job := range m.snap.JobRows {
+		cursor, id := "  ", job.ID
+		state := job.State
+		if _, pending := m.cancelling[job.ID]; pending && jobCancelable(job.State) {
+			state = "cancelling…"
+		}
+		if i == m.jobCursor {
+			cursor, id = "▸ ", selectedRowStyle.Render(job.ID)
+		}
+		b.WriteString(cursor + id + "  " + job.Agent + "  " + job.Type + "  " + jobStateColor(state) + "\n")
+	}
+	b.WriteString(mutedStyle.Render("enter detail  R retry  c cancel"))
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func (m Model) jobDetailView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("job " + m.activeJob.ID))
+	b.WriteString("\n\n")
+	rows := [][]string{
+		{"agent", dash(m.activeJob.Agent)},
+		{"type", dash(m.activeJob.Type)},
+		{"state", m.activeJob.State},
+		{"updated", dash(m.activeJob.UpdatedAt)},
+	}
+	b.WriteString(renderRows(rows))
+	b.WriteByte('\n')
+	b.WriteString(headerStyle.Render("events"))
+	b.WriteByte('\n')
+	switch {
+	case m.jobEventsErr != "":
+		b.WriteString(errorStyle.Render(m.jobEventsErr) + "\n")
+	case !m.jobEventsLoaded:
+		b.WriteString(mutedStyle.Render("loading…") + "\n")
+	case len(m.jobEvents) == 0:
+		b.WriteString(mutedStyle.Render("no events") + "\n")
+	default:
+		const maxEvents = 20
+		events := m.jobEvents
+		if len(events) > maxEvents {
+			b.WriteString(mutedStyle.Render(strconv.Itoa(len(events)-maxEvents)+" earlier events omitted") + "\n")
+			events = events[len(events)-maxEvents:]
+		}
+		for _, event := range events {
+			line := event.Kind
+			if event.Message != "" {
+				line += "  " + truncate(event.Message, 80)
+			}
+			b.WriteString(line + "\n")
+		}
+	}
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	return b.String()
+}
+
+func (m Model) jobConfirmView() string {
+	verb := "Retry"
+	if m.mode == modeConfirmJobCancel {
+		verb = "Cancel"
+	}
+	var b strings.Builder
+	b.WriteString(headerStyle.Render(verb + " job " + m.activeJob.ID))
+	b.WriteString("\n\n")
+	b.WriteString(m.activeJob.Type + " · " + m.activeJob.Agent + " · " + m.activeJob.State + "\n\n")
+	b.WriteString(verb + " this job? (y/n)\n")
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("working…"))
+	} else {
+		b.WriteString(mutedStyle.Render("y confirm  n/esc cancel"))
+	}
+	return b.String()
+}

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -1,0 +1,291 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func jobsSnapshot() Snapshot {
+	return Snapshot{
+		Daemon: Daemon{Running: true},
+		JobRows: []JobRow{
+			{ID: "j-failed", Agent: "planner", Type: "ask", State: "failed", LatestEvent: "boom"},
+			{ID: "j-running", Agent: "planner", Type: "implement", State: "running"},
+			{ID: "j-done", Agent: "planner", Type: "review", State: "succeeded"},
+		},
+	}
+}
+
+func jobsModel(t *testing.T, deps Deps, snap Snapshot) Model {
+	t.Helper()
+	if deps.Load == nil {
+		deps.Load = func() (Snapshot, error) { return snap, nil }
+	}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	// Tab to the Jobs page (Attention → Trains → Agents → Sessions → Jobs).
+	for i := 0; i < 4; i++ {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+	}
+	if pages[m.selected].page != pageJobs {
+		t.Fatalf("expected Jobs page, got %v", pages[m.selected].page)
+	}
+	return m
+}
+
+func TestJobsPageDetailLoadsEvents(t *testing.T) {
+	var asked string
+	deps := Deps{JobEvents: func(id string) ([]JobEventView, error) {
+		asked = id
+		return []JobEventView{{Kind: "failed", Message: "boom"}}, nil
+	}}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if m.mode != modeJobDetail || cmd == nil {
+		t.Fatalf("enter should open the job detail, mode=%v", m.mode)
+	}
+	next, _ = m.Update(cmd()) // jobEventsMsg
+	m = next.(Model)
+	if asked != "j-failed" {
+		t.Fatalf("JobEvents asked for %q", asked)
+	}
+	if !strings.Contains(m.View(), "boom") {
+		t.Fatalf("event message missing:\n%s", m.View())
+	}
+}
+
+func TestJobsRetryConfirmFlow(t *testing.T) {
+	var retried string
+	deps := Deps{RetryJob: func(id string) error { retried = id; return nil }}
+	m := jobsModel(t, deps, jobsSnapshot())
+	// Cursor on j-failed (first row); R opens the confirm.
+	next, _ := m.Update(key("R"))
+	m = next.(Model)
+	if m.mode != modeConfirmJobRetry {
+		t.Fatalf("R should confirm retry, mode=%v", m.mode)
+	}
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("y should run the retry")
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if retried != "j-failed" {
+		t.Fatalf("RetryJob called with %q", retried)
+	}
+	if m.mode != modeNormal {
+		t.Fatalf("success should close the confirm, mode=%v", m.mode)
+	}
+}
+
+func TestJobsCancelRunningShowsCancelling(t *testing.T) {
+	var cancelled string
+	snap := jobsSnapshot()
+	deps := Deps{
+		Load:      func() (Snapshot, error) { return snap, nil },
+		CancelJob: func(id string) error { cancelled = id; return nil },
+	}
+	m := jobsModel(t, deps, snap)
+	// Move to the running job (row 2).
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, _ = m.Update(key("c"))
+	m = next.(Model)
+	if m.mode != modeConfirmJobCancel {
+		t.Fatalf("c should confirm cancel, mode=%v", m.mode)
+	}
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if cancelled != "j-running" {
+		t.Fatalf("CancelJob called with %q", cancelled)
+	}
+	if !strings.Contains(m.View(), "cancelling…") {
+		t.Fatalf("running row should show cancelling…:\n%s", m.View())
+	}
+	// Once a refresh shows the job settled, the transitional label clears.
+	settled := jobsSnapshot()
+	settled.JobRows[1].State = "cancelled"
+	next, _ = m.Update(snapshotMsg{snap: settled, at: time.Unix(2, 0)})
+	m = next.(Model)
+	if strings.Contains(m.View(), "cancelling…") {
+		t.Fatalf("settled job should drop the cancelling label:\n%s", m.View())
+	}
+}
+
+func TestJobsRetryOnNonRetryableIgnored(t *testing.T) {
+	deps := Deps{RetryJob: func(id string) error { t.Fatal("must not retry"); return nil }}
+	m := jobsModel(t, deps, jobsSnapshot())
+	// Move to the succeeded job (row 3).
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, _ = m.Update(key("R"))
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("R on a succeeded job must be a no-op, mode=%v", m.mode)
+	}
+}
+
+func TestAttentionJobRowsActionable(t *testing.T) {
+	var retried string
+	snap := jobsSnapshot()
+	deps := Deps{
+		Load:     func() (Snapshot, error) { return snap, nil },
+		RetryJob: func(id string) error { retried = id; return nil },
+	}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	// Attention page: no prompts, so the first item is the failed job.
+	view := m.View()
+	if !strings.Contains(view, "job j-failed") || !strings.Contains(view, "boom") {
+		t.Fatalf("attention should list the failed job with its reason:\n%s", view)
+	}
+	next, _ = m.Update(key("R"))
+	m = next.(Model)
+	if m.mode != modeConfirmJobRetry {
+		t.Fatalf("R on an attention job row should confirm retry, mode=%v", m.mode)
+	}
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	_, _ = m.Update(cmd())
+	if retried != "j-failed" {
+		t.Fatalf("RetryJob called with %q", retried)
+	}
+}
+
+func TestAttentionDaemonStart(t *testing.T) {
+	started := false
+	snap := jobsSnapshot()
+	snap.Daemon.Running = false
+	deps := Deps{
+		Load:        func() (Snapshot, error) { return snap, nil },
+		StartDaemon: func() error { started = true; return nil },
+	}
+	m := sizedModel(deps)
+	// Before the first snapshot the daemon state is unknown; s must be inert.
+	if _, cmd := m.Update(key("s")); cmd != nil {
+		t.Fatal("s before the first snapshot must not start the daemon")
+	}
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	if !strings.Contains(m.View(), "daemon stopped") {
+		t.Fatalf("expected the daemon-stopped banner:\n%s", m.View())
+	}
+	next, cmd := m.Update(key("s"))
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("s should start the daemon")
+	}
+	if !strings.Contains(m.View(), "starting…") {
+		t.Fatalf("banner should show the start is in flight:\n%s", m.View())
+	}
+	// A second press while in flight must not fire again.
+	next, second := m.Update(key("s"))
+	m = next.(Model)
+	if second != nil {
+		t.Fatal("s while a start is in flight must be a no-op")
+	}
+	msg := cmd()
+	if !started {
+		t.Fatal("StartDaemon should have been called")
+	}
+	next, _ = m.Update(msg)
+	m = next.(Model)
+	if m.daemonBusy {
+		t.Fatal("daemonStartMsg should clear the in-flight flag")
+	}
+}
+
+func TestDaemonStartResultDoesNotCloseJobConfirm(t *testing.T) {
+	snap := jobsSnapshot()
+	snap.Daemon.Running = false
+	deps := Deps{
+		Load:        func() (Snapshot, error) { return snap, nil },
+		StartDaemon: func() error { return errors.New("spawn failed") },
+		RetryJob:    func(id string) error { return nil },
+	}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	next, daemonCmd := m.Update(key("s"))
+	m = next.(Model)
+	// Open a retry confirm while the daemon start is still in flight.
+	next, _ = m.Update(key("R"))
+	m = next.(Model)
+	if m.mode != modeConfirmJobRetry {
+		t.Fatalf("expected the retry confirm, mode=%v", m.mode)
+	}
+	next, _ = m.Update(daemonCmd())
+	m = next.(Model)
+	if m.mode != modeConfirmJobRetry {
+		t.Fatalf("the daemon result must not close the job confirm, mode=%v", m.mode)
+	}
+	if strings.Contains(m.View(), "spawn failed") {
+		t.Fatalf("the daemon error must not render inside the job confirm:\n%s", m.View())
+	}
+}
+
+func TestJobDetailZeroEventsShowsNoEvents(t *testing.T) {
+	deps := Deps{JobEvents: func(id string) ([]JobEventView, error) { return nil, nil }}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if !strings.Contains(m.View(), "loading…") {
+		t.Fatalf("detail should show loading before the events arrive:\n%s", m.View())
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if !strings.Contains(m.View(), "no events") {
+		t.Fatalf("an empty (loaded) history should say so, not keep loading:\n%s", m.View())
+	}
+}
+
+func TestJobConfirmStaysOpenWhileActionInFlight(t *testing.T) {
+	deps := Deps{RetryJob: func(id string) error { return nil }}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, _ := m.Update(key("R"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	// esc while the retry is in flight must not close the confirm, or its
+	// eventual error would be dropped silently.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if m.mode != modeConfirmJobRetry {
+		t.Fatalf("confirm must stay open while busy, mode=%v", m.mode)
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("success should close the confirm, mode=%v", m.mode)
+	}
+}
+
+func TestJobActionErrorKeepsConfirm(t *testing.T) {
+	deps := Deps{RetryJob: func(id string) error { return errors.New("db locked") }}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, _ := m.Update(key("R"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeConfirmJobRetry {
+		t.Fatalf("error should keep the confirm open, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "db locked") {
+		t.Fatalf("error should render:\n%s", m.View())
+	}
+}

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -44,6 +44,9 @@ const (
 	modeAnswerText
 	modeConfirmDismiss
 	modeTrainDetail
+	modeJobDetail
+	modeConfirmJobRetry
+	modeConfirmJobCancel
 )
 
 const defaultInterval = 5 * time.Second
@@ -74,17 +77,28 @@ type Model struct {
 	actionBusy   bool                 // an action is in flight; suppress re-submit
 	showHelp     bool                 // '?' help overlay
 	tickGen      int                  // current tick chain; stale generations are dropped
+
+	// Jobs page interaction state.
+	jobCursor       int                 // selected row in snap.JobRows
+	activeJob       JobRow              // job shown in detail / being confirmed
+	jobEvents       []JobEventView      // lazy-loaded event history for the detail view
+	jobEventsLoaded bool                // the detail's event load has returned (possibly empty)
+	jobEventsErr    string              // error from the detail's event load
+	cancelling      map[string]struct{} // jobs with a cancel requested, until settled
+	daemonBusy      bool                // a daemon start is in flight; suppress re-submit
+	daemonErr       string              // error from the last daemon start attempt
 }
 
 // New returns a Model ready for tea.NewProgram. It starts in the loading state;
 // Init issues the first Load and arms the refresh tick.
 func New(deps Deps) Model {
 	m := Model{
-		deps:     deps,
-		width:    100,
-		height:   30,
-		viewport: viewport.New(80, 20),
-		inFlight: true,
+		deps:       deps,
+		width:      100,
+		height:     30,
+		viewport:   viewport.New(80, 20),
+		inFlight:   true,
+		cancelling: map[string]struct{}{},
 	}
 	m.resizeViewport()
 	m.viewport.SetContent(m.content())
@@ -115,6 +129,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case tea.KeyMsg:
 		// Modal overlays capture keys first; only ctrl+c stays global.
+		if m.mode == modeJobDetail || m.mode == modeConfirmJobRetry || m.mode == modeConfirmJobCancel {
+			if msg.String() == "ctrl+c" {
+				return m, tea.Quit
+			}
+			return m.updateJobOverlay(msg)
+		}
 		if m.mode != modeNormal {
 			return m.updateOverlay(msg)
 		}
@@ -141,31 +161,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.viewport.SetContent(m.content())
 			return m, tea.Batch(cmds...)
 		case "up", "k":
-			if pages[m.selected].page == pageAttention && len(m.snap.Prompts) > 0 {
-				if m.promptCursor > 0 {
-					m.promptCursor--
-				}
-				m.viewport.SetContent(m.content())
-				return m, tea.Batch(cmds...)
-			}
-			if pages[m.selected].page == pageTrains && len(m.snap.Trains) > 0 {
-				if m.trainCursor > 0 {
-					m.trainCursor--
+			if cursor, n := m.pageCursor(); cursor != nil && n > 0 {
+				if *cursor > 0 {
+					*cursor--
 				}
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
 		case "down", "j":
-			if pages[m.selected].page == pageAttention && len(m.snap.Prompts) > 0 {
-				if m.promptCursor < len(m.snap.Prompts)-1 {
-					m.promptCursor++
-				}
-				m.viewport.SetContent(m.content())
-				return m, tea.Batch(cmds...)
-			}
-			if pages[m.selected].page == pageTrains && len(m.snap.Trains) > 0 {
-				if m.trainCursor < len(m.snap.Trains)-1 {
-					m.trainCursor++
+			if cursor, n := m.pageCursor(); cursor != nil && n > 0 {
+				if *cursor < n-1 {
+					*cursor++
 				}
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
@@ -194,6 +200,35 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, Push(m.deps.OpenTrain(session))
 				}
 				m.openTrainDetail()
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
+			if job, ok := m.jobUnderCursor(); ok {
+				cmd := m.openJobDetail(job)
+				m.viewport.SetContent(m.content())
+				return m, cmd
+			}
+		case "R":
+			if job, ok := m.jobUnderCursor(); ok && jobRetryable(job.State) {
+				m.openJobConfirm(job, false)
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
+		case "c":
+			if job, ok := m.jobUnderCursor(); ok && jobCancelable(job.State) {
+				m.openJobConfirm(job, true)
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
+		case "s":
+			// Only once the first snapshot confirmed the daemon is down (the
+			// zero-value snapshot also reads as not-running), and never while a
+			// start is already in flight.
+			if pages[m.selected].page == pageAttention && !m.snap.Daemon.Running &&
+				!m.loadedAt.IsZero() && !m.daemonBusy {
+				m.daemonBusy = true
+				m.daemonErr = ""
+				cmds = append(cmds, daemonStartCmd(m.deps))
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
@@ -233,6 +268,44 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, cmd)
 			}
 		}
+	case jobEventsMsg:
+		if msg.id == m.activeJob.ID {
+			m.jobEventsLoaded = true
+			if msg.err != nil {
+				m.jobEventsErr = msg.err.Error()
+			} else {
+				m.jobEventsErr = ""
+				m.jobEvents = msg.events
+			}
+		}
+	case daemonStartMsg:
+		// Daemon start has its own busy/error state so its result cannot close
+		// or pollute an unrelated job confirm that opened in the meantime.
+		m.daemonBusy = false
+		if msg.err != nil {
+			m.daemonErr = msg.err.Error()
+		} else {
+			m.daemonErr = ""
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+	case jobActionMsg:
+		m.actionBusy = false
+		if msg.err != nil {
+			m.actionErr = msg.err.Error()
+		} else {
+			if msg.verb == "cancel" && msg.id != "" {
+				m.cancelling[msg.id] = struct{}{}
+			}
+			if m.mode == modeConfirmJobRetry || m.mode == modeConfirmJobCancel {
+				m.mode = modeNormal
+			}
+			m.actionErr = ""
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
 	case snapshotMsg:
 		m.inFlight = false
 		if msg.err != nil {
@@ -243,6 +316,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.loadedAt = msg.at
 			m.clampPromptCursor()
 			m.clampTrainCursor()
+			m.clampJobCursor()
+			// A cancel-requested job that has settled no longer needs the
+			// transitional "cancelling…" label.
+			for id := range m.cancelling {
+				settled := true
+				for _, job := range m.snap.JobRows {
+					if job.ID == id && jobCancelable(job.State) {
+						settled = false
+						break
+					}
+				}
+				if settled {
+					delete(m.cancelling, id)
+				}
+			}
 		}
 	case refreshNudgeMsg:
 		// Resumed after a pop: the old tick chain died unhandled under the child
@@ -295,25 +383,45 @@ func (m *Model) queueLoad() tea.Cmd {
 	return loadSnapshot(m.deps)
 }
 
-// clampPromptCursor keeps the Attention cursor within the current prompt list
-// after a refresh removes rows.
+// pageCursor returns the selected page's cursor and list length, or nil for
+// pages without a selectable list. New cursored pages only need a case here.
+func (m *Model) pageCursor() (*int, int) {
+	switch pages[m.selected].page {
+	case pageAttention:
+		return &m.promptCursor, len(m.attentionItems())
+	case pageTrains:
+		return &m.trainCursor, len(m.snap.Trains)
+	case pageJobs:
+		return &m.jobCursor, len(m.snap.JobRows)
+	}
+	return nil, 0
+}
+
+// clampCursor keeps a list cursor within [0, n-1] after a refresh removes rows.
+func clampCursor(cursor, n int) int {
+	if cursor >= n {
+		cursor = n - 1
+	}
+	if cursor < 0 {
+		cursor = 0
+	}
+	return cursor
+}
+
+// clampPromptCursor keeps the Attention cursor within the current item list
+// (prompts plus blocked/failed jobs) after a refresh removes rows.
 func (m *Model) clampPromptCursor() {
-	if m.promptCursor >= len(m.snap.Prompts) {
-		m.promptCursor = len(m.snap.Prompts) - 1
-	}
-	if m.promptCursor < 0 {
-		m.promptCursor = 0
-	}
+	m.promptCursor = clampCursor(m.promptCursor, len(m.attentionItems()))
 }
 
 // clampTrainCursor keeps the Trains cursor within the current session list.
 func (m *Model) clampTrainCursor() {
-	if m.trainCursor >= len(m.snap.Trains) {
-		m.trainCursor = len(m.snap.Trains) - 1
-	}
-	if m.trainCursor < 0 {
-		m.trainCursor = 0
-	}
+	m.trainCursor = clampCursor(m.trainCursor, len(m.snap.Trains))
+}
+
+// clampJobCursor keeps the Jobs cursor within the current job list.
+func (m *Model) clampJobCursor() {
+	m.jobCursor = clampCursor(m.jobCursor, len(m.snap.JobRows))
 }
 
 func loadSnapshot(deps Deps) tea.Cmd {

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -35,7 +35,11 @@ func sampleSnapshot() Snapshot {
 			{Name: "skillopt-generator-bg-bb22", Runtime: "claude", State: "idle"},
 			{Name: "solo", Runtime: "codex", Repo: "owner/repo", State: "running"},
 		},
-		Jobs:        Jobs{Total: 3, ByState: map[string]int{"failed": 1, "succeeded": 2}},
+		Jobs: Jobs{Total: 3, ByState: map[string]int{"failed": 1, "succeeded": 2}},
+		JobRows: []JobRow{
+			{ID: "job-1", Agent: "planner", Type: "ask", State: "failed", LatestEvent: "agent returned an error"},
+			{ID: "job-2", Agent: "planner", Type: "review", State: "succeeded"},
+		},
 		Trains:      []TrainSession{{ID: "train-s1", Phase: "items_ready", Candidate: "smithyx@v3", Repo: "owner/repo"}},
 		BranchLocks: []BranchLock{{Repo: "owner/repo", Branch: "main", Owner: "agent"}},
 		ResourceLocks: []ResourceLock{
@@ -56,7 +60,7 @@ func loadedModel(t *testing.T) Model {
 func TestPagesRenderExpectedContent(t *testing.T) {
 	m := loadedModel(t)
 	// Page order: Attention, Trains, Agents, Sessions, Jobs, Locks.
-	wants := []string{"pending prompts", "train-s1", "planner", "skillopt-generator", "failed", "branch locks"}
+	wants := []string{"needs attention", "train-s1", "planner", "skillopt-generator", "failed", "branch locks"}
 	for i, want := range wants {
 		if i > 0 {
 			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
@@ -121,8 +125,11 @@ func TestLoadErrorKeepsStaleData(t *testing.T) {
 }
 
 func TestEmptyStatesRenderWithoutPanic(t *testing.T) {
-	m := sizedModel(Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }})
-	next, _ := m.Update(snapshotMsg{snap: Snapshot{}, at: time.Unix(3, 0)})
+	// Daemon running so the attention page shows the empty state rather than
+	// the (legitimate) daemon-stopped banner.
+	empty := Snapshot{Daemon: Daemon{Running: true}}
+	m := sizedModel(Deps{Load: func() (Snapshot, error) { return empty, nil }})
+	next, _ := m.Update(snapshotMsg{snap: empty, at: time.Unix(3, 0)})
 	m = next.(Model)
 	for range pages {
 		_ = m.View()

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -73,19 +73,28 @@ func (m Model) content() string {
 		b.WriteString(errorStyle.Render("refresh error: " + m.loadErr))
 		b.WriteString("\n\n")
 	}
-	switch pages[m.selected].page {
-	case pageAttention:
-		b.WriteString(m.attentionContent())
-	case pageTrains:
-		b.WriteString(m.trainsContent())
-	case pageAgents:
-		b.WriteString(m.agentsContent())
-	case pageSessions:
-		b.WriteString(m.sessionsContent())
-	case pageJobs:
-		b.WriteString(m.jobsContent())
-	case pageLocks:
-		b.WriteString(m.locksContent())
+	// Job overlays can be entered from more than one page (Jobs, Attention), so
+	// they are dispatched once here rather than inside each page renderer.
+	switch m.mode {
+	case modeJobDetail:
+		b.WriteString(m.jobDetailView())
+	case modeConfirmJobRetry, modeConfirmJobCancel:
+		b.WriteString(m.jobConfirmView())
+	default:
+		switch pages[m.selected].page {
+		case pageAttention:
+			b.WriteString(m.attentionContent())
+		case pageTrains:
+			b.WriteString(m.trainsContent())
+		case pageAgents:
+			b.WriteString(m.agentsContent())
+		case pageSessions:
+			b.WriteString(m.sessionsContent())
+		case pageJobs:
+			b.WriteString(m.jobsContentInteractive())
+		case pageLocks:
+			b.WriteString(m.locksContent())
+		}
 	}
 	b.WriteString("\n\n")
 	b.WriteString(mutedStyle.Render(m.footerHelp()))
@@ -99,12 +108,21 @@ func (m Model) helpContent() string {
 	b.WriteString("\n\n")
 	switch pages[m.selected].page {
 	case pageAttention:
-		b.WriteString("↑/↓  select a pending prompt\n")
+		b.WriteString("↑/↓  select a row (pending prompts, then blocked/failed jobs)\n")
 		b.WriteString("a    answer the selected prompt (choices or text)\n")
 		b.WriteString("d    dismiss (delete) the selected prompt\n")
+		b.WriteString("enter open the selected job's detail (events)\n")
+		b.WriteString("R    retry the selected job\n")
+		b.WriteString("s    start the daemon when it is stopped\n")
 	case pageTrains:
 		b.WriteString("↑/↓  select a train session\n")
 		b.WriteString("enter open the session (live phase view; esc returns)\n")
+	case pageJobs:
+		b.WriteString("↑/↓  select a job\n")
+		b.WriteString("enter open the job's detail (events)\n")
+		b.WriteString("R    retry the selected job (failed/blocked/cancelled)\n")
+		b.WriteString("c    cancel the selected job (queued/running)\n")
+		b.WriteString("pgup/pgdn  scroll a long list\n")
 	default:
 		b.WriteString("j/k or wheel  scroll\n")
 	}
@@ -127,12 +145,18 @@ func (m Model) footerHelp() string {
 		return "y delete  n/esc cancel"
 	case modeTrainDetail:
 		return "enter/esc back"
+	case modeJobDetail:
+		return "R retry  c cancel  esc back"
+	case modeConfirmJobRetry, modeConfirmJobCancel:
+		return "y confirm  n/esc cancel"
 	}
 	switch pages[m.selected].page {
 	case pageAttention:
-		return "tab/←→ page  ↑/↓ select  a answer  d dismiss  r refresh  q quit"
+		return "tab/←→ page  ↑/↓ select  a answer  d dismiss  enter/R jobs  ? help  q quit"
 	case pageTrains:
-		return "tab/←→ page  ↑/↓ select  enter detail  r refresh  q quit"
+		return "tab/←→ page  ↑/↓ select  enter open  r refresh  q quit"
+	case pageJobs:
+		return "tab/←→ page  ↑/↓ select  enter detail  R retry  c cancel  ? help  q quit"
 	}
 	return "tab/←→ page  j/k or wheel scroll  r refresh  q quit"
 }
@@ -164,20 +188,6 @@ func (m Model) sessionsContent() string {
 		b.WriteString(line)
 		b.WriteByte('\n')
 	}
-	return b.String()
-}
-
-func (m Model) jobsContent() string {
-	if m.snap.Jobs.Total == 0 {
-		return m.loadingOr("No jobs.", !m.loadedAt.IsZero())
-	}
-	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Total %d\n\n", m.snap.Jobs.Total))
-	rows := [][]string{{"STATE", "COUNT"}}
-	for _, state := range sortedKeys(m.snap.Jobs.ByState) {
-		rows = append(rows, []string{jobStateColor(state), fmt.Sprint(m.snap.Jobs.ByState[state])})
-	}
-	b.WriteString(renderRows(rows))
 	return b.String()
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -158,6 +158,9 @@ type Job struct {
 	Type    string
 	State   string
 	Payload string
+	// UpdatedAt is populated by ListJobs (for age display in the dashboard);
+	// other readers may leave it zero.
+	UpdatedAt string
 }
 
 type JobEvent struct {
@@ -1871,7 +1874,7 @@ func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
 }
 
 func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload FROM jobs ORDER BY id`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, updated_at FROM jobs ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}
@@ -1880,7 +1883,7 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.UpdatedAt); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2063,6 +2066,28 @@ func (s *Store) ListJobEvents(ctx context.Context, jobID string) ([]JobEvent, er
 			return nil, err
 		}
 		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+// LatestJobEvents returns the most recent event for every job that has one,
+// keyed by job id, in a single query (the dashboard refresh would otherwise
+// issue one ListJobEvents per job).
+func (s *Store) LatestJobEvents(ctx context.Context) (map[string]JobEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT job_id, kind, message FROM job_events
+		WHERE id IN (SELECT MAX(id) FROM job_events GROUP BY job_id)`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	events := map[string]JobEvent{}
+	for rows.Next() {
+		var event JobEvent
+		if err := rows.Scan(&event.JobID, &event.Kind, &event.Message); err != nil {
+			return nil, err
+		}
+		events[event.JobID] = event
 	}
 	return events, rows.Err()
 }

--- a/internal/db/store_cockpit_test.go
+++ b/internal/db/store_cockpit_test.go
@@ -206,3 +206,36 @@ func TestDeleteAgentChecked(t *testing.T) {
 		t.Fatalf("expected not-found on second delete, got %v", err)
 	}
 }
+
+func TestLatestJobEvents(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	if err := store.CreateJob(ctx, Job{ID: "job-a", Agent: "planner", Type: "ask", State: "failed"}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if err := store.CreateJob(ctx, Job{ID: "job-b", Agent: "planner", Type: "review", State: "queued"}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	for _, event := range []JobEvent{
+		{JobID: "job-a", Kind: "queued", Message: "created"},
+		{JobID: "job-a", Kind: "failed", Message: "boom"},
+		{JobID: "job-b", Kind: "queued", Message: "created"},
+	} {
+		if err := store.AddJobEvent(ctx, event); err != nil {
+			t.Fatalf("AddJobEvent: %v", err)
+		}
+	}
+	latest, err := store.LatestJobEvents(ctx)
+	if err != nil {
+		t.Fatalf("LatestJobEvents: %v", err)
+	}
+	if got := latest["job-a"]; got.Kind != "failed" || got.Message != "boom" {
+		t.Fatalf("job-a latest = %+v", got)
+	}
+	if got := latest["job-b"]; got.Kind != "queued" || got.Message != "created" {
+		t.Fatalf("job-b latest = %+v", got)
+	}
+	if _, ok := latest["job-missing"]; ok {
+		t.Fatal("jobs without events must be absent from the map")
+	}
+}


### PR DESCRIPTION
## WHAT
Task 5 of the dashboard-cockpit plan (#243): the Jobs page becomes an interactive list, the Attention page shows the real blocked/failed jobs, and a stopped daemon can be started with one key.

## WHY
The dashboard showed job counts but gave no way to see WHICH jobs were blocked/failed, why, or to act on them — every fix required hand-typed CLI commands.

## CHANGES
- **Jobs page**: state summary line + per-job rows with a cursor; `enter` opens a detail view with the job's event history (lazy-loaded, capped at the latest 20, "no events" distinguished from "loading"); `R` retries failed/blocked/cancelled jobs; `c` cancels queued/running jobs with a `cancelling…` label until the daemon settles them; y/N confirms that stay open while the action is in flight so errors are never silently dropped.
- **Retry goes through `workflow.RetryJob`** — the same path as `gitmoot job retry` — so the stale `payload.Result` is cleared and the `retry_queued` event the daemon's bookkeeping keys on is emitted (a hand-rolled state flip would have left the old result visible to reconcilers).
- **Attention page**: the "N blocked / N failed" counts become actual rows (id · type · state · latest event message) with the same enter/R keys; pending prompts keep a/d. A red "daemon stopped" banner appears when the daemon is down; `s` starts it via `runDaemonRestart`, restoring the previously persisted flags (workers/poll/watch) instead of silently reverting to defaults. Daemon start has its own busy/error state so its result cannot close an unrelated confirm.
- **Snapshot builder**: one batched `store.LatestJobEvents` query (latest event per job) replaces a per-blocked/failed-job `ListJobEvents` loop on every refresh tick.
- Plain and `--json` dashboard outputs stay byte-identical: job rows live in the unexported `jobRows` snapshot field.

## RESULTS
- `go test ./internal/cli/tui ./internal/db ./internal/cli` green; full `go test ./...` green except the known pre-existing flake `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` (fails on main too).
- New tests: detail load, retry/cancel confirm flows, cancelling label lifecycle, non-retryable no-op, attention job rows actionable, daemon start (guarded before first snapshot, no double-fire, result isolated from job confirms), zero-event detail, in-flight confirm stays open, batched latest-events query.

## REVIEW
High-effort multi-angle review run; fixed: hand-rolled retry bypassing `workflow.RetryJob` (stale payload.Result / wrong event kind), daemon-start result closing unrelated confirms via the shared message type, "loading…" shown forever for zero-event jobs, stale detail error leaking across jobs, missing in-flight guards on `s` and confirm dismissal, N+1 event queries per refresh, dead `Job.CreatedAt` plumbing, lost aggregate job counts, always-no-op "c cancel" hint on attention rows, stale `?` help, duplicated overlay dispatch/cursor-clamp/up-down blocks (consolidated via `content()` hoist, `clampCursor`, `pageCursor`). Known deferred: the `cancelling…` label only covers the window until the next refresh — a snapshot-level settle flag is noted for a later task.

## RISK
TUI-only interaction changes plus one additive store method; headless outputs unchanged (byte-stability tests untouched). Retry/cancel reuse the existing workflow functions the CLI already exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)