### PR TITLE
cli: stop, delete, and clean up train sessions from the dashboard

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -130,6 +130,26 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 				return err
 			})
 		},
+		StopTrain: func(id, reason string) error {
+			return withStore(home, func(store *db.Store) error {
+				_, err := stopSkillOptTrainSession(context.Background(), store, id, reason)
+				return err
+			})
+		},
+		DeleteTrain: func(id string) ([]string, error) {
+			var repos []string
+			err := withStore(home, func(store *db.Store) error {
+				var err error
+				repos, err = deleteSkillOptTrainSession(context.Background(), store, id)
+				return err
+			})
+			return repos, err
+		},
+		DeleteTrainRepo: func(repo string) error {
+			return withStore(home, func(store *db.Store) error {
+				return cleanupCreatedTrainRepo(context.Background(), store, repo)
+			})
+		},
 		StartDaemon: func() error {
 			// Restart rather than start: it tolerates a stopped daemon and
 			// restores the previously persisted flags (workers, poll, watch)

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -6662,6 +6662,39 @@ func stopSkillOptTrainSession(ctx context.Context, store *db.Store, sessionID st
 	return iteration, nil
 }
 
+// deleteSkillOptTrainSession removes a train session and its history, and
+// returns the GitHub repos gitmoot recorded as created for it. The records
+// deliberately survive the cascade so a caller can offer their cleanup; any
+// future delete surface must list them BEFORE the delete or they orphan.
+func deleteSkillOptTrainSession(ctx context.Context, store *db.Store, sessionID string) ([]string, error) {
+	records, err := store.ListCreatedReposForSession(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if err := store.DeleteSkillOptTrainSession(ctx, sessionID); err != nil {
+		return nil, err
+	}
+	repos := make([]string, 0, len(records))
+	for _, record := range records {
+		repos = append(repos, record.Repo)
+	}
+	return repos, nil
+}
+
+// cleanupCreatedTrainRepo deletes a gitmoot-created GitHub repo and then its
+// created_repos record — in that order, so a failed GitHub delete keeps the
+// repo on offer for a retry.
+func cleanupCreatedTrainRepo(ctx context.Context, store *db.Store, repo string) error {
+	parsed, err := daemon.ParseRepository(repo)
+	if err != nil {
+		return err
+	}
+	if err := newSkillOptGitHubClient().DeleteRepository(ctx, parsed); err != nil {
+		return err
+	}
+	return store.DeleteCreatedRepoRecord(ctx, repo)
+}
+
 func loadSkillOptTrainStatus(ctx context.Context, store *db.Store, sessionID string) (db.SkillOptTrainSession, *db.SkillOptTrainIteration, skillopt.TrainStatusCounts, error) {
 	session, err := store.GetSkillOptTrainSession(ctx, strings.TrimSpace(sessionID))
 	if err != nil {

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -134,6 +134,14 @@ type Deps struct {
 	// StartDaemon starts the background daemon when the attention list shows it
 	// stopped.
 	StartDaemon func() error
+
+	// Train session actions. StopTrain abandons a live session's current run
+	// with a reason. DeleteTrain removes a terminal session and its history,
+	// returning the GitHub repos gitmoot recorded as created for it (still
+	// pending cleanup). DeleteTrainRepo deletes one such repo and its record.
+	StopTrain       func(id, reason string) error
+	DeleteTrain     func(id string) ([]string, error)
+	DeleteTrainRepo func(repo string) error
 }
 
 // snapshotMsg carries the result of a Deps.Load call.
@@ -186,4 +194,24 @@ type jobActionMsg struct {
 // jobActionMsg so it cannot close or pollute an open job confirm.
 type daemonStartMsg struct {
 	err error
+}
+
+// trainStopMsg carries the outcome of a Deps.StopTrain call.
+type trainStopMsg struct {
+	err error
+}
+
+// trainDeleteMsg carries the outcome of a Deps.DeleteTrain call; repos are the
+// recorded gitmoot-created repos now eligible for cleanup.
+type trainDeleteMsg struct {
+	repos []string
+	err   error
+}
+
+// trainRepoCleanupMsg carries the outcome of a cleanup pass: the repos that
+// failed (so a retry only replays those) and their errors. Both empty on full
+// success.
+type trainRepoCleanupMsg struct {
+	failed []string
+	errs   []string
 }

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -47,6 +48,9 @@ const (
 	modeJobDetail
 	modeConfirmJobRetry
 	modeConfirmJobCancel
+	modeTrainStopReason
+	modeConfirmTrainDelete
+	modeConfirmTrainRepoCleanup
 )
 
 const defaultInterval = 5 * time.Second
@@ -87,6 +91,9 @@ type Model struct {
 	cancelling      map[string]struct{} // jobs with a cancel requested, until settled
 	daemonBusy      bool                // a daemon start is in flight; suppress re-submit
 	daemonErr       string              // error from the last daemon start attempt
+
+	// Trains page action state.
+	pendingRepos []string // gitmoot-created repos offered for cleanup after a delete
 }
 
 // New returns a Model ready for tea.NewProgram. It starts in the loading state;
@@ -129,11 +136,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case tea.KeyMsg:
 		// Modal overlays capture keys first; only ctrl+c stays global.
-		if m.mode == modeJobDetail || m.mode == modeConfirmJobRetry || m.mode == modeConfirmJobCancel {
+		switch m.mode {
+		case modeJobDetail, modeConfirmJobRetry, modeConfirmJobCancel:
 			if msg.String() == "ctrl+c" {
 				return m, tea.Quit
 			}
 			return m.updateJobOverlay(msg)
+		case modeTrainStopReason, modeConfirmTrainDelete, modeConfirmTrainRepoCleanup:
+			if msg.String() == "ctrl+c" {
+				return m, tea.Quit
+			}
+			return m.updateTrainOverlay(msg)
 		}
 		if m.mode != modeNormal {
 			return m.updateOverlay(msg)
@@ -190,6 +203,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
+			if t, ok := m.trainUnderCursor(); ok && deadTrainPhase(t.Phase) {
+				m.openTrainDelete(t)
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
 		case "enter":
 			if pages[m.selected].page == pageTrains {
 				// With a Root router, open the full train-run view; otherwise the
@@ -232,6 +250,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
+			if t, ok := m.trainUnderCursor(); ok && !deadTrainPhase(t.Phase) {
+				cmd := m.openTrainStop(t)
+				m.viewport.SetContent(m.content())
+				return m, cmd
+			}
 		case "?":
 			m.showHelp = !m.showHelp
 			m.viewport.SetContent(m.content())
@@ -245,25 +268,37 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.viewport, cmd = m.viewport.Update(msg)
 		cmds = append(cmds, cmd)
 	case answerResultMsg:
-		m.actionBusy = false
-		if msg.err != nil {
-			m.actionErr = msg.err.Error()
-		} else {
-			m.mode = modeNormal
-			m.actionErr = ""
+		// Apply only while the answer overlay is still open: the prompt
+		// overlays allow esc while busy, so a stale result must not close or
+		// pollute whatever overlay the user opened since. Refresh regardless.
+		if m.mode == modeAnswerChoice || m.mode == modeAnswerText {
+			m.actionBusy = false
+			if msg.err != nil {
+				m.actionErr = msg.err.Error()
+			} else {
+				m.mode = modeNormal
+				m.actionErr = ""
+			}
+		}
+		if msg.err == nil {
 			if cmd := m.queueLoad(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
 		}
 	case dismissResultMsg:
-		m.actionBusy = false
 		// A prompt already gone (removed by another terminal or a prior refresh)
 		// is treated as success, since the goal was to remove it.
-		if msg.err != nil && !errors.Is(msg.err, db.ErrInteractivePromptNotFound) {
-			m.actionErr = msg.err.Error()
-		} else {
-			m.mode = modeNormal
-			m.actionErr = ""
+		dismissed := msg.err == nil || errors.Is(msg.err, db.ErrInteractivePromptNotFound)
+		if m.mode == modeConfirmDismiss {
+			m.actionBusy = false
+			if dismissed {
+				m.mode = modeNormal
+				m.actionErr = ""
+			} else {
+				m.actionErr = msg.err.Error()
+			}
+		}
+		if dismissed {
 			if cmd := m.queueLoad(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
@@ -278,6 +313,61 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.jobEvents = msg.events
 			}
 		}
+	case trainStopMsg:
+		if m.mode == modeTrainStopReason {
+			m.actionBusy = false
+			if msg.err != nil {
+				m.actionErr = msg.err.Error()
+			} else {
+				m.mode = modeNormal
+				m.actionErr = ""
+			}
+		}
+		if msg.err == nil {
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+	case trainDeleteMsg:
+		if m.mode == modeConfirmTrainDelete {
+			m.actionBusy = false
+			if msg.err != nil {
+				// e.g. the lock-refusal from DeleteSkillOptTrainSession; stays
+				// in the confirm so the user reads it.
+				m.actionErr = msg.err.Error()
+			} else {
+				m.actionErr = ""
+				if len(msg.repos) > 0 {
+					m.pendingRepos = msg.repos
+					m.mode = modeConfirmTrainRepoCleanup
+				} else {
+					m.mode = modeNormal
+				}
+			}
+		}
+		if msg.err == nil {
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+	case trainRepoCleanupMsg:
+		if m.mode == modeConfirmTrainRepoCleanup {
+			m.actionBusy = false
+			if len(msg.errs) > 0 {
+				// Scope errors carry their remedy verbatim; keep the confirm
+				// open with only the still-failing repos on offer, so a retry
+				// does not replay repos that were already deleted.
+				m.actionErr = strings.Join(msg.errs, "\n")
+				m.pendingRepos = msg.failed
+			} else {
+				m.mode = modeNormal
+				m.actionErr = ""
+				m.pendingRepos = nil
+			}
+		}
+		if cmd := m.queueLoad(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case daemonStartMsg:
 		// Daemon start has its own busy/error state so its result cannot close
 		// or pollute an unrelated job confirm that opened in the meantime.
@@ -291,17 +381,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case jobActionMsg:
-		m.actionBusy = false
-		if msg.err != nil {
-			m.actionErr = msg.err.Error()
-		} else {
-			if msg.verb == "cancel" && msg.id != "" {
-				m.cancelling[msg.id] = struct{}{}
-			}
-			if m.mode == modeConfirmJobRetry || m.mode == modeConfirmJobCancel {
+		if msg.err == nil && msg.verb == "cancel" && msg.id != "" {
+			m.cancelling[msg.id] = struct{}{}
+		}
+		if m.mode == modeConfirmJobRetry || m.mode == modeConfirmJobCancel {
+			m.actionBusy = false
+			if msg.err != nil {
+				m.actionErr = msg.err.Error()
+			} else {
 				m.mode = modeNormal
+				m.actionErr = ""
 			}
-			m.actionErr = ""
+		}
+		if msg.err == nil {
 			if cmd := m.queueLoad(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}

--- a/internal/cli/tui/trains.go
+++ b/internal/cli/tui/trains.go
@@ -1,14 +1,223 @@
 package tui
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
 
 // openTrainDetail shows the detail view for the train under the cursor.
 func (m *Model) openTrainDetail() {
-	if pages[m.selected].page != pageTrains || len(m.snap.Trains) == 0 {
-		return
+	if t, ok := m.trainUnderCursor(); ok {
+		m.activeTrain = t
+		m.mode = modeTrainDetail
 	}
-	m.activeTrain = m.snap.Trains[m.trainCursor]
-	m.mode = modeTrainDetail
+}
+
+// trainUnderCursor returns the session under the Trains cursor, if any.
+func (m Model) trainUnderCursor() (TrainSession, bool) {
+	if pages[m.selected].page != pageTrains || len(m.snap.Trains) == 0 {
+		return TrainSession{}, false
+	}
+	return m.snap.Trains[m.trainCursor], true
+}
+
+// openTrainStop enters the stop-reason overlay for a live session.
+func (m *Model) openTrainStop(t TrainSession) tea.Cmd {
+	m.activeTrain = t
+	m.actionErr = ""
+	m.actionBusy = false
+	m.mode = modeTrainStopReason
+	ti := textinput.New()
+	ti.Placeholder = "why is this run being abandoned?"
+	m.input = ti
+	return m.input.Focus()
+}
+
+// openTrainDelete enters the delete confirmation for a terminal session.
+func (m *Model) openTrainDelete(t TrainSession) {
+	m.activeTrain = t
+	m.actionErr = ""
+	m.actionBusy = false
+	m.mode = modeConfirmTrainDelete
+}
+
+// updateTrainOverlay handles keys in the stop/delete/repo-cleanup modes. Like
+// the job confirms, an overlay stays open while its action is in flight so the
+// eventual error is never dropped silently.
+func (m Model) updateTrainOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.mode {
+	case modeTrainStopReason:
+		switch msg.String() {
+		case "esc":
+			if m.actionBusy {
+				return m, nil
+			}
+			m.mode = modeNormal
+			m.actionErr = ""
+		case "enter":
+			if m.actionBusy {
+				return m, nil
+			}
+			reason := strings.TrimSpace(m.input.Value())
+			if reason == "" {
+				m.actionErr = "a reason is required"
+			} else {
+				m.actionBusy = true
+				m.actionErr = ""
+				m.viewport.SetContent(m.content())
+				return m, trainStopCmd(m.deps, m.activeTrain.ID, reason)
+			}
+		default:
+			// Freeze the reason while the stop is in flight so a retry after an
+			// error submits exactly what is rendered.
+			if m.actionBusy {
+				return m, nil
+			}
+			var cmd tea.Cmd
+			m.input, cmd = m.input.Update(msg)
+			m.viewport.SetContent(m.content())
+			return m, cmd
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case modeConfirmTrainDelete:
+		switch msg.String() {
+		case "y", "Y":
+			if m.actionBusy {
+				return m, nil
+			}
+			m.actionBusy = true
+			m.actionErr = ""
+			m.viewport.SetContent(m.content())
+			return m, trainDeleteCmd(m.deps, m.activeTrain.ID)
+		default:
+			if m.actionBusy {
+				return m, nil
+			}
+			m.mode = modeNormal
+			m.actionErr = ""
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case modeConfirmTrainRepoCleanup:
+		switch msg.String() {
+		case "y", "Y":
+			if m.actionBusy {
+				return m, nil
+			}
+			m.actionBusy = true
+			m.actionErr = ""
+			m.viewport.SetContent(m.content())
+			return m, trainRepoCleanupCmd(m.deps, m.pendingRepos)
+		default:
+			if m.actionBusy {
+				return m, nil
+			}
+			// The session is already gone; declining just keeps the repos.
+			m.mode = modeNormal
+			m.actionErr = ""
+			m.pendingRepos = nil
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	}
+	return m, nil
+}
+
+func trainStopCmd(deps Deps, id, reason string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.StopTrain == nil {
+			return trainStopMsg{}
+		}
+		return trainStopMsg{err: deps.StopTrain(id, reason)}
+	}
+}
+
+func trainDeleteCmd(deps Deps, id string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.DeleteTrain == nil {
+			return trainDeleteMsg{}
+		}
+		repos, err := deps.DeleteTrain(id)
+		return trainDeleteMsg{repos: repos, err: err}
+	}
+}
+
+func trainRepoCleanupCmd(deps Deps, repos []string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.DeleteTrainRepo == nil {
+			return trainRepoCleanupMsg{}
+		}
+		var failed, errs []string
+		for _, repo := range repos {
+			if err := deps.DeleteTrainRepo(repo); err != nil {
+				failed = append(failed, repo)
+				errs = append(errs, err.Error())
+			}
+		}
+		return trainRepoCleanupMsg{failed: failed, errs: errs}
+	}
+}
+
+func (m Model) trainStopView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("stop " + m.activeTrain.ID))
+	b.WriteString("\n\n")
+	b.WriteString("Stopping abandons the current run (phase " + dash(m.activeTrain.Phase) + ").\n\n")
+	b.WriteString("reason: " + m.input.View())
+	b.WriteByte('\n')
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("stopping…"))
+	} else {
+		b.WriteString(mutedStyle.Render("enter stop  esc cancel"))
+	}
+	return b.String()
+}
+
+func (m Model) trainDeleteConfirmView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("Delete train " + m.activeTrain.ID))
+	b.WriteString("\n\n")
+	b.WriteString("phase " + dash(m.activeTrain.Phase) + " · " + dash(m.activeTrain.Repo) + "\n\n")
+	b.WriteString("Delete this session and all its history? (y/n)\n")
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("deleting…"))
+	} else {
+		b.WriteString(mutedStyle.Render("y delete  n/esc cancel"))
+	}
+	return b.String()
+}
+
+func (m Model) trainRepoCleanupView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("session deleted"))
+	b.WriteString("\n\n")
+	b.WriteString("gitmoot created these GitHub repos for it:\n")
+	for _, repo := range m.pendingRepos {
+		b.WriteString("  " + repo + "\n")
+	}
+	b.WriteString("\nAlso delete them from GitHub? (y/n)\n")
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("deleting repos…"))
+	} else {
+		b.WriteString(mutedStyle.Render("y delete repos  n/esc keep them"))
+	}
+	return b.String()
 }
 
 func (m Model) trainsContent() string {
@@ -32,7 +241,7 @@ func (m Model) trainsContent() string {
 		}
 		b.WriteString(cursor + line + "\n")
 	}
-	b.WriteString(mutedStyle.Render("enter detail"))
+	b.WriteString(mutedStyle.Render("enter open  s stop  d delete"))
 	b.WriteByte('\n')
 	return b.String()
 }
@@ -84,11 +293,9 @@ func trainLocks(locks []ResourceLock, sessionID string) []ResourceLock {
 	return out
 }
 
+// deadTrainPhase reports whether a session is in a terminal state (the
+// canonical list lives in skillopt, so new terminal states gate correctly
+// here without a second hand-kept copy).
 func deadTrainPhase(phase string) bool {
-	switch phase {
-	case "run_abandoned", "candidate_rejected", "candidate_promoted":
-		return true
-	default:
-		return false
-	}
+	return skillopt.IsTerminalTrainState(phase)
 }

--- a/internal/cli/tui/trains_action_test.go
+++ b/internal/cli/tui/trains_action_test.go
@@ -1,0 +1,272 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func trainsSnapshot() Snapshot {
+	return Snapshot{
+		Daemon: Daemon{Running: true},
+		Trains: []TrainSession{
+			{ID: "train-live", Phase: "items_ready", Repo: "o/r"},
+			{ID: "train-done", Phase: "run_abandoned", Repo: "o/r"},
+		},
+	}
+}
+
+func trainsActionModel(t *testing.T, deps Deps, snap Snapshot) Model {
+	t.Helper()
+	if deps.Load == nil {
+		deps.Load = func() (Snapshot, error) { return snap, nil }
+	}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // Attention → Trains
+	m = next.(Model)
+	if pages[m.selected].page != pageTrains {
+		t.Fatalf("expected Trains page, got %v", pages[m.selected].page)
+	}
+	return m
+}
+
+func typeText(t *testing.T, m Model, text string) Model {
+	t.Helper()
+	for _, r := range text {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(Model)
+	}
+	return m
+}
+
+func TestTrainStopReasonFlow(t *testing.T) {
+	var gotID, gotReason string
+	deps := Deps{StopTrain: func(id, reason string) error {
+		gotID, gotReason = id, reason
+		return nil
+	}}
+	m := trainsActionModel(t, deps, trainsSnapshot())
+	// Cursor on train-live (first row); s opens the reason input.
+	next, _ := m.Update(key("s"))
+	m = next.(Model)
+	if m.mode != modeTrainStopReason {
+		t.Fatalf("s on a live session should ask for a reason, mode=%v", m.mode)
+	}
+	// Empty reason is refused inline.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if m.mode != modeTrainStopReason || !strings.Contains(m.View(), "a reason is required") {
+		t.Fatalf("empty reason must be refused:\n%s", m.View())
+	}
+	m = typeText(t, m, "wrong template")
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("enter with a reason should run the stop")
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if gotID != "train-live" || gotReason != "wrong template" {
+		t.Fatalf("StopTrain called with (%q, %q)", gotID, gotReason)
+	}
+	if m.mode != modeNormal {
+		t.Fatalf("success should close the overlay, mode=%v", m.mode)
+	}
+}
+
+func TestTrainStopOnTerminalIgnored(t *testing.T) {
+	deps := Deps{StopTrain: func(id, reason string) error { t.Fatal("must not stop"); return nil }}
+	m := trainsActionModel(t, deps, trainsSnapshot())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown}) // → train-done
+	m = next.(Model)
+	next, _ = m.Update(key("s"))
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("s on a terminal session must be a no-op, mode=%v", m.mode)
+	}
+}
+
+func TestTrainDeleteOnLiveIgnored(t *testing.T) {
+	deps := Deps{DeleteTrain: func(id string) ([]string, error) { t.Fatal("must not delete"); return nil, nil }}
+	m := trainsActionModel(t, deps, trainsSnapshot())
+	next, _ := m.Update(key("d"))
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("d on a live session must be a no-op, mode=%v", m.mode)
+	}
+}
+
+func TestTrainDeleteWithoutReposClosesAfterConfirm(t *testing.T) {
+	var deleted string
+	deps := Deps{DeleteTrain: func(id string) ([]string, error) { deleted = id; return nil, nil }}
+	m := trainsActionModel(t, deps, trainsSnapshot())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown}) // → train-done
+	m = next.(Model)
+	next, _ = m.Update(key("d"))
+	m = next.(Model)
+	if m.mode != modeConfirmTrainDelete {
+		t.Fatalf("d on a terminal session should confirm, mode=%v", m.mode)
+	}
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if deleted != "train-done" {
+		t.Fatalf("DeleteTrain called with %q", deleted)
+	}
+	if m.mode != modeNormal {
+		t.Fatalf("no recorded repos → straight back to the list, mode=%v", m.mode)
+	}
+}
+
+func TestTrainDeleteRefusalStaysInConfirm(t *testing.T) {
+	deps := Deps{DeleteTrain: func(id string) ([]string, error) {
+		return nil, errors.New("session train-done still holds an active resource lock")
+	}}
+	m := trainsActionModel(t, deps, trainsSnapshot())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, _ = m.Update(key("d"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeConfirmTrainDelete {
+		t.Fatalf("refusal should keep the confirm open, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "active resource lock") {
+		t.Fatalf("refusal should render:\n%s", m.View())
+	}
+}
+
+func TestTrainDeleteOffersRepoCleanupOnlyWhenRecorded(t *testing.T) {
+	var deletedRepos []string
+	deps := Deps{
+		DeleteTrain:     func(id string) ([]string, error) { return []string{"o/eval-repo-1", "o/eval-repo-2"}, nil },
+		DeleteTrainRepo: func(repo string) error { deletedRepos = append(deletedRepos, repo); return nil },
+	}
+	m := trainsActionModel(t, deps, trainsSnapshot())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, _ = m.Update(key("d"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeConfirmTrainRepoCleanup {
+		t.Fatalf("recorded repos should trigger the second confirm, mode=%v", m.mode)
+	}
+	view := m.View()
+	if !strings.Contains(view, "o/eval-repo-1") || !strings.Contains(view, "o/eval-repo-2") {
+		t.Fatalf("the repos on offer must be listed:\n%s", view)
+	}
+	next, cmd = m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if len(deletedRepos) != 2 || deletedRepos[0] != "o/eval-repo-1" || deletedRepos[1] != "o/eval-repo-2" {
+		t.Fatalf("DeleteTrainRepo calls = %v", deletedRepos)
+	}
+	if m.mode != modeNormal {
+		t.Fatalf("cleanup success should close the overlay, mode=%v", m.mode)
+	}
+}
+
+func TestTrainRepoCleanupDeclinedKeepsRepos(t *testing.T) {
+	deps := Deps{
+		DeleteTrain:     func(id string) ([]string, error) { return []string{"o/eval-repo-1"}, nil },
+		DeleteTrainRepo: func(repo string) error { t.Fatal("declining must not delete repos"); return nil },
+	}
+	m := trainsActionModel(t, deps, trainsSnapshot())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, _ = m.Update(key("d"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	next, _ = m.Update(key("n"))
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("declining should close the overlay, mode=%v", m.mode)
+	}
+}
+
+func TestTrainRepoCleanupRetryOnlyReplaysFailedRepos(t *testing.T) {
+	var calls []string
+	deps := Deps{
+		DeleteTrain: func(id string) ([]string, error) { return []string{"o/repo-ok", "o/repo-bad"}, nil },
+		DeleteTrainRepo: func(repo string) error {
+			calls = append(calls, repo)
+			if repo == "o/repo-bad" {
+				return errors.New("transient network error")
+			}
+			return nil
+		},
+	}
+	m := trainsActionModel(t, deps, trainsSnapshot())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, _ = m.Update(key("d"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	next, cmd = m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeConfirmTrainRepoCleanup {
+		t.Fatalf("partial failure should keep the confirm open, mode=%v", m.mode)
+	}
+	// Retry: only the failed repo may be replayed; the deleted one is gone.
+	next, cmd = m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	want := []string{"o/repo-ok", "o/repo-bad", "o/repo-bad"}
+	if len(calls) != len(want) {
+		t.Fatalf("DeleteTrainRepo calls = %v, want %v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("DeleteTrainRepo calls = %v, want %v", calls, want)
+		}
+	}
+}
+
+func TestTrainRepoCleanupScopeErrorRendered(t *testing.T) {
+	scopeErr := "deleting o/eval-repo-1 requires the delete_repo token scope; run `gh auth refresh -h github.com -s delete_repo` and retry"
+	deps := Deps{
+		DeleteTrain:     func(id string) ([]string, error) { return []string{"o/eval-repo-1"}, nil },
+		DeleteTrainRepo: func(repo string) error { return errors.New(scopeErr) },
+	}
+	m := trainsActionModel(t, deps, trainsSnapshot())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, _ = m.Update(key("d"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	next, cmd = m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeConfirmTrainRepoCleanup {
+		t.Fatalf("repo errors should keep the confirm open, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "delete_repo token scope") {
+		t.Fatalf("the scope remedy must render verbatim:\n%s", m.View())
+	}
+}

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -74,12 +74,19 @@ func (m Model) content() string {
 		b.WriteString("\n\n")
 	}
 	// Job overlays can be entered from more than one page (Jobs, Attention), so
-	// they are dispatched once here rather than inside each page renderer.
+	// they are dispatched once here rather than inside each page renderer; the
+	// train action overlays follow the same pattern.
 	switch m.mode {
 	case modeJobDetail:
 		b.WriteString(m.jobDetailView())
 	case modeConfirmJobRetry, modeConfirmJobCancel:
 		b.WriteString(m.jobConfirmView())
+	case modeTrainStopReason:
+		b.WriteString(m.trainStopView())
+	case modeConfirmTrainDelete:
+		b.WriteString(m.trainDeleteConfirmView())
+	case modeConfirmTrainRepoCleanup:
+		b.WriteString(m.trainRepoCleanupView())
 	default:
 		switch pages[m.selected].page {
 		case pageAttention:
@@ -117,6 +124,9 @@ func (m Model) helpContent() string {
 	case pageTrains:
 		b.WriteString("↑/↓  select a train session\n")
 		b.WriteString("enter open the session (live phase view; esc returns)\n")
+		b.WriteString("s    stop a live session (asks for a reason)\n")
+		b.WriteString("d    delete a finished session and its history;\n")
+		b.WriteString("     repos gitmoot created for it can be deleted too\n")
 	case pageJobs:
 		b.WriteString("↑/↓  select a job\n")
 		b.WriteString("enter open the job's detail (events)\n")
@@ -149,12 +159,18 @@ func (m Model) footerHelp() string {
 		return "R retry  c cancel  esc back"
 	case modeConfirmJobRetry, modeConfirmJobCancel:
 		return "y confirm  n/esc cancel"
+	case modeTrainStopReason:
+		return "type reason  enter stop  esc cancel"
+	case modeConfirmTrainDelete:
+		return "y delete  n/esc cancel"
+	case modeConfirmTrainRepoCleanup:
+		return "y delete repos  n/esc keep them"
 	}
 	switch pages[m.selected].page {
 	case pageAttention:
 		return "tab/←→ page  ↑/↓ select  a answer  d dismiss  enter/R jobs  ? help  q quit"
 	case pageTrains:
-		return "tab/←→ page  ↑/↓ select  enter open  r refresh  q quit"
+		return "tab/←→ page  ↑/↓ select  enter open  s stop  d delete  ? help  q quit"
 	case pageJobs:
 		return "tab/←→ page  ↑/↓ select  enter detail  R retry  c cancel  ? help  q quit"
 	}


### PR DESCRIPTION
## WHAT
Task 6 of the dashboard-cockpit plan (#243): stop a live train session, delete a finished one, and optionally clean up the GitHub repos gitmoot created for it — all from the Trains page.

## WHY
Stopping or removing a train session required hand-typed `skillopt train stop` commands, deletion did not exist at all, and temporary eval repos gitmoot created lingered on GitHub forever.

## CHANGES
- **`s` stop**: on a live session, a reason input opens (reason is required; the field freezes while the stop is in flight so a retry submits exactly what is rendered). Runs the same `stopSkillOptTrainSession` helper as `gitmoot skillopt train stop`.
- **`d` delete**: only on terminal sessions; y/N confirm; runs `DeleteSkillOptTrainSession` (single-tx cascade). The active-lock refusal renders inline and keeps the confirm open.
- **Repo cleanup**: after a successful delete, if `created_repos` has rows for the session, a second y/N lists them and offers GitHub deletion. Never offered for unrecorded repos. A missing `delete_repo` scope error shows its remedy (`gh auth refresh -h github.com -s delete_repo`) verbatim and keeps the confirm open, so the user can refresh the token in another terminal and press y again; a retry only replays the repos that failed — succeeded ones are pruned from the offer.
- **Terminal-state gating fixed**: `deadTrainPhase` now delegates to `skillopt.IsTerminalTrainState`. The hand-kept list omitted `optimizer_completed_no_candidate`, leaving such sessions both unstoppable and undeletable from the TUI.
- **Stale-result hardening (all overlays)**: every action-result handler (answer, dismiss, job retry/cancel, train stop/delete/cleanup) now applies only while its own overlay is open. Previously a prompt answer escaped while in flight could close or pollute a train/job overlay the user opened afterwards.
- The compound delete+list-repos and parse→GitHub-delete→record-delete policies live in cli helpers (`deleteSkillOptTrainSession`, `cleanupCreatedTrainRepo`, using the `newSkillOptGitHubClient` test seam) so a future `skillopt train delete` command reuses them instead of rediscovering the ordering.

## RESULTS
- `go test ./internal/cli/tui` green (9 new train-action tests: stop reason flow incl. empty-reason refusal, stop/delete gating no-ops, delete confirm/refusal, cleanup offered only when recorded, decline keeps repos, scope-error rendering, retry-prunes-succeeded-repos).
- `go test ./internal/cli` green except the known pre-existing flake `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` (fails on main too). vet/gofmt clean.

## REVIEW
High-effort multi-angle review run; fixed: the `optimizer_completed_no_candidate` gating gap, retry replaying already-deleted repos, stale results crossing overlays, reason input editable while busy, in-loop nil-dep check, duplicated cursor guard in `openTrainDetail`, compound ops inlined in TUI wiring. Known accepted: stop has no lock guard (same semantics as the existing `skillopt train stop` CLI); list-then-delete is two store calls, so a repo recorded in the microseconds between them would miss the offer (records orphan harmlessly); declining cleanup permanently keeps the repos (by design — the overlay stays open on errors, so the in-flow retry path covers the scope-refresh case). Overlay confirm/settle/view consolidation deferred to Task 9 polish.

## RISK
TUI-only plus two additive unexported cli helpers; headless outputs untouched. Deletion is double-gated (terminal-only + y/N) and repo cleanup is triple-gated (recorded-only + second y/N + ordered delete-then-forget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)