### PR TITLE
cli: create, delete, and revert agents from the dashboard

### DIFF
--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -80,6 +80,9 @@ type dashboardAgent struct {
 	Runtime string `json:"runtime"`
 	Role    string `json:"role,omitempty"`
 	Health  string `json:"health,omitempty"`
+	// templateID feeds the TUI's agent detail; unexported so the --json output
+	// stays byte-identical.
+	templateID string
 }
 
 type dashboardSession struct {
@@ -298,7 +301,7 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 			return err
 		}
 		for _, agent := range agents {
-			snapshot.Agents = append(snapshot.Agents, dashboardAgent{Name: agent.Name, Runtime: agent.Runtime, Role: agent.Role, Health: agent.HealthStatus})
+			snapshot.Agents = append(snapshot.Agents, dashboardAgent{Name: agent.Name, Runtime: agent.Runtime, Role: agent.Role, Health: agent.HealthStatus, templateID: agent.TemplateID})
 		}
 		instances, err := store.ListAgentInstances(ctx)
 		if err != nil {

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/cli/tui"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -66,7 +67,17 @@ func runDashboardTUI(home string, interval time.Duration, stdout, stderr io.Writ
 		tea.WithAltScreen(),
 		tea.WithOutput(stdout),
 	)
-	if _, err := program.Run(); err != nil {
+	_, err := program.Run()
+	// Best-effort: a hard quit mid create-form leaves its prompt records
+	// pending; sweep them so they do not haunt the attention list (mirrors
+	// the standalone wizard's deferred cleanup).
+	_ = withStore(home, func(store *db.Store) error {
+		for _, id := range tui.AgentCreatePromptIDs() {
+			_ = store.DeleteInteractivePrompt(context.Background(), id)
+		}
+		return nil
+	})
+	if err != nil {
 		fmt.Fprintf(stderr, "dashboard: %v\n", err)
 		return 1
 	}
@@ -150,6 +161,81 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 				return cleanupCreatedTrainRepo(context.Background(), store, repo)
 			})
 		},
+		TemplateVersions: func(templateID string) ([]tui.TemplateVersion, error) {
+			var views []tui.TemplateVersion
+			err := withStore(home, func(store *db.Store) error {
+				versions, err := store.ListAgentTemplateVersions(context.Background(), templateID)
+				if err != nil {
+					return err
+				}
+				for _, v := range versions {
+					views = append(views, tui.TemplateVersion{
+						ID:      v.ID,
+						Number:  v.VersionNumber,
+						State:   v.State,
+						Name:    v.Name,
+						Created: v.CreatedAt,
+					})
+				}
+				return nil
+			})
+			return views, err
+		},
+		OpenAgentCreate: func() (tea.Model, error) {
+			// One store for the form's lifetime: its 200ms external-answer poll
+			// would otherwise open/migrate/close the database five times a
+			// second. Closed from the Done hook; on a hard quit the process
+			// exit releases it.
+			paths, err := initializedPaths(home)
+			if err != nil {
+				return nil, err
+			}
+			store, err := db.Open(paths.Database)
+			if err != nil {
+				return nil, err
+			}
+			templates, err := skillopt.ListTrainInitTemplateChoices(context.Background(), store)
+			if err != nil {
+				store.Close()
+				return nil, err
+			}
+			var choices []tui.Choice
+			for _, t := range templates {
+				// Only installed templates: registerAgentOnly persists the id
+				// verbatim, and an uninstalled one yields an agent whose jobs
+				// fail at delivery (the CLI register path gates the same way).
+				if t.Installed {
+					choices = append(choices, tui.Choice{Value: t.ID, Label: skillOptTrainInitTemplateChoiceLabel(t)})
+				}
+			}
+			if len(choices) == 0 {
+				store.Close()
+				return nil, fmt.Errorf("no agent templates installed; add one with `gitmoot agent template add`")
+			}
+			form := tui.NewAgentCreateForm(store, choices)
+			done := form.Done
+			form.Done = func(res tui.Result) tea.Cmd {
+				store.Close()
+				return done(res)
+			}
+			return form, nil
+		},
+		CreateAgent: func(name, runtimeName, templateID string) error {
+			return withStore(home, func(store *db.Store) error {
+				return registerAgentOnly(context.Background(), store, name, runtimeName, templateID, "")
+			})
+		},
+		DeleteAgent: func(name string) error {
+			return withStore(home, func(store *db.Store) error {
+				return store.DeleteAgentChecked(context.Background(), name)
+			})
+		},
+		RevertTemplate: func(templateID, versionID string) error {
+			return withStore(home, func(store *db.Store) error {
+				_, err := store.RevertAgentTemplateVersion(context.Background(), templateID, versionID)
+				return err
+			})
+		},
 		StartDaemon: func() error {
 			// Restart rather than start: it tolerates a stopped daemon and
 			// restores the previously persisted flags (workers, poll, watch)
@@ -176,7 +262,7 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 		out.Repos = append(out.Repos, tui.Repo{Name: r.Name, Enabled: r.Enabled})
 	}
 	for _, a := range s.Agents {
-		out.Agents = append(out.Agents, tui.Agent{Name: a.Name, Runtime: a.Runtime, Role: a.Role, Health: a.Health})
+		out.Agents = append(out.Agents, tui.Agent{Name: a.Name, Runtime: a.Runtime, Role: a.Role, Health: a.Health, TemplateID: a.templateID})
 	}
 	for _, sess := range s.RuntimeSessions {
 		out.Sessions = append(out.Sessions, tui.Session{Name: sess.Name, Runtime: sess.Runtime, Repo: sess.Repo, State: sess.State})

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -1,0 +1,440 @@
+package tui
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// agentUnderCursor returns the agent under the Agents cursor, if any.
+func (m Model) agentUnderCursor() (Agent, bool) {
+	if pages[m.selected].page != pageAgents || len(m.snap.Agents) == 0 {
+		return Agent{}, false
+	}
+	return m.snap.Agents[m.agentCursor], true
+}
+
+// openAgentDetail enters the detail view for an agent and lazily loads its
+// template's version history.
+func (m *Model) openAgentDetail(agent Agent) tea.Cmd {
+	m.activeAgent = agent
+	m.agentVersions = nil
+	m.agentVersionsLoaded = false
+	m.agentVersionsErr = ""
+	m.actionErr = ""
+	m.actionBusy = false
+	m.mode = modeAgentDetail
+	if agent.TemplateID == "" {
+		m.agentVersionsLoaded = true
+		return nil
+	}
+	return agentVersionsCmd(m.deps, agent.TemplateID)
+}
+
+// openAgentDelete enters the delete confirmation for an agent.
+func (m *Model) openAgentDelete(agent Agent) {
+	m.activeAgent = agent
+	m.actionErr = ""
+	m.actionBusy = false
+	m.mode = modeConfirmAgentDelete
+}
+
+// revertableVersions are the superseded versions an agent's template can be
+// reverted to.
+func (m Model) revertableVersions() []TemplateVersion {
+	out := []TemplateVersion{}
+	for _, v := range m.agentVersions {
+		if v.State == "superseded" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// updateAgentOverlay handles keys in the agent detail/revert/delete modes.
+func (m Model) updateAgentOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.mode {
+	case modeAgentDetail:
+		switch msg.String() {
+		case "esc", "enter", "q":
+			m.mode = modeNormal
+		case "v":
+			if len(m.revertableVersions()) > 0 {
+				m.versionCursor = 0
+				m.mode = modeAgentRevertPick
+			}
+		case "D":
+			m.openAgentDelete(m.activeAgent)
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case modeAgentRevertPick:
+		versions := m.revertableVersions()
+		switch msg.String() {
+		case "esc", "q":
+			m.mode = modeAgentDetail
+		case "up", "k":
+			if m.versionCursor > 0 {
+				m.versionCursor--
+			}
+		case "down", "j":
+			if m.versionCursor < len(versions)-1 {
+				m.versionCursor++
+			}
+		case "enter":
+			if m.versionCursor < len(versions) {
+				m.revertVersion = versions[m.versionCursor]
+				m.actionErr = ""
+				m.actionBusy = false
+				m.mode = modeConfirmAgentRevert
+			}
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case modeConfirmAgentRevert:
+		switch msg.String() {
+		case "y", "Y":
+			if m.actionBusy {
+				return m, nil
+			}
+			m.actionBusy = true
+			m.actionErr = ""
+			m.viewport.SetContent(m.content())
+			return m, agentRevertCmd(m.deps, m.activeAgent.TemplateID, m.revertVersion.ID)
+		default:
+			if m.actionBusy {
+				return m, nil
+			}
+			m.mode = modeAgentRevertPick
+			m.actionErr = ""
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case modeConfirmAgentDelete:
+		switch msg.String() {
+		case "y", "Y":
+			if m.actionBusy {
+				return m, nil
+			}
+			m.actionBusy = true
+			m.actionErr = ""
+			m.viewport.SetContent(m.content())
+			return m, agentDeleteCmd(m.deps, m.activeAgent.Name)
+		default:
+			if m.actionBusy {
+				return m, nil
+			}
+			m.mode = modeNormal
+			m.actionErr = ""
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	}
+	return m, nil
+}
+
+func agentVersionsCmd(deps Deps, templateID string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.TemplateVersions == nil {
+			return agentVersionsMsg{templateID: templateID}
+		}
+		versions, err := deps.TemplateVersions(templateID)
+		return agentVersionsMsg{templateID: templateID, versions: versions, err: err}
+	}
+}
+
+func agentDeleteCmd(deps Deps, name string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.DeleteAgent == nil {
+			return agentActionMsg{verb: "delete"}
+		}
+		return agentActionMsg{verb: "delete", err: deps.DeleteAgent(name)}
+	}
+}
+
+func agentRevertCmd(deps Deps, templateID, versionID string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.RevertTemplate == nil {
+			return agentActionMsg{verb: "revert"}
+		}
+		return agentActionMsg{verb: "revert", err: deps.RevertTemplate(templateID, versionID)}
+	}
+}
+
+// openAgentFormCmd builds the create form off the UI thread and pushes it; a
+// construction error renders inline on the Agents page instead.
+func openAgentFormCmd(deps Deps) tea.Cmd {
+	return func() tea.Msg {
+		form, err := deps.OpenAgentCreate()
+		if err != nil {
+			return agentActionMsg{verb: "form", err: err}
+		}
+		return PushModelMsg{Model: form}
+	}
+}
+
+func agentCreateCmd(deps Deps, values map[string]string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.CreateAgent == nil {
+			return agentActionMsg{verb: "create"}
+		}
+		return agentActionMsg{verb: "create", err: deps.CreateAgent(values["name"], values["runtime"], values["template"])}
+	}
+}
+
+// NewAgentCreateForm builds the create-agent form on the train-init field
+// widgets. On completion it pops itself off the Root stack and delivers the
+// answers to the dashboard, which runs Deps.CreateAgent.
+func NewAgentCreateForm(store PromptStore, templates []Choice) TrainInitModel {
+	fields := []Field{
+		{
+			Name:  "name",
+			Label: "Agent name",
+			Kind:  FieldText,
+			Prompt: db.InteractivePrompt{
+				ID:            "agent-create-name",
+				Question:      "Name for the new agent?",
+				Required:      true,
+				AnswerFormat:  "text",
+				SourceCommand: "dashboard agent create",
+				State:         db.InteractivePromptStatePending,
+			},
+		},
+		{
+			Name:    "runtime",
+			Label:   "Runtime",
+			Kind:    FieldChoice,
+			Choices: []Choice{{Value: "codex", Label: "codex"}, {Value: "claude", Label: "claude"}},
+			Default: "codex",
+			Prompt: db.InteractivePrompt{
+				ID:            "agent-create-runtime",
+				Question:      "Runtime for the new agent?",
+				Choices:       []string{"codex", "claude"},
+				Default:       "codex",
+				Required:      true,
+				AnswerFormat:  "choice",
+				SourceCommand: "dashboard agent create",
+				State:         db.InteractivePromptStatePending,
+			},
+		},
+		{
+			Name:    "template",
+			Label:   "Template",
+			Kind:    FieldChoice,
+			Choices: templates,
+			Prompt: db.InteractivePrompt{
+				ID:            "agent-create-template",
+				Question:      "Template for the new agent?",
+				Choices:       choiceValues(templates),
+				Required:      true,
+				AnswerFormat:  "choice",
+				SourceCommand: "dashboard agent create",
+				State:         db.InteractivePromptStatePending,
+			},
+		},
+	}
+	summary := func(answers map[string]string) [][]string {
+		return [][]string{
+			{"name", answers["name"]},
+			{"runtime", answers["runtime"]},
+			{"template", answers["template"]},
+		}
+	}
+	form := NewTrainInit(store, fields, summary, nil, 0)
+	form.Done = func(res Result) tea.Cmd {
+		return PopWith(agentFormResultMsg{result: res})
+	}
+	return form
+}
+
+func choiceValues(choices []Choice) []string {
+	values := make([]string, 0, len(choices))
+	for _, c := range choices {
+		values = append(values, c.Value)
+	}
+	return values
+}
+
+// agentsContentInteractive renders the Agents page as a selectable list. Agent
+// overlays are dispatched once in content(), not here.
+func (m Model) agentsContentInteractive() string {
+	if len(m.snap.Agents) == 0 {
+		var b strings.Builder
+		b.WriteString(m.loadingOr("No registered agents.", !m.loadedAt.IsZero()))
+		b.WriteByte('\n')
+		if m.agentErr != "" {
+			b.WriteString("\n" + errorStyle.Render(m.agentErr) + "\n")
+		}
+		b.WriteString("\n" + mutedStyle.Render("n new agent"))
+		return b.String()
+	}
+	var b strings.Builder
+	rows := [][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH"}}
+	for i, a := range m.snap.Agents {
+		cursor, name := "  ", a.Name
+		if i == m.agentCursor {
+			cursor, name = "▸ ", selectedRowStyle.Render(a.Name)
+		}
+		rows = append(rows, []string{cursor, name, a.Runtime, dash(a.Role), dash(a.Health)})
+	}
+	b.WriteString(renderRows(rows))
+	if m.agentErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.agentErr) + "\n")
+	}
+	b.WriteString(mutedStyle.Render("enter detail  n new  D delete"))
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func (m Model) agentDetailView() string {
+	a := m.activeAgent
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("agent " + a.Name))
+	b.WriteString("\n\n")
+	rows := [][]string{
+		{"runtime", dash(a.Runtime)},
+		{"role", dash(a.Role)},
+		{"health", dash(a.Health)},
+		{"template", dash(a.TemplateID)},
+	}
+	b.WriteString(renderRows(rows))
+	b.WriteByte('\n')
+
+	b.WriteString(headerStyle.Render("recent jobs"))
+	b.WriteByte('\n')
+	jobs := agentJobs(m.snap.JobRows, a.Name, 5)
+	if len(jobs) == 0 {
+		b.WriteString(mutedStyle.Render("none") + "\n")
+	} else {
+		for _, job := range jobs {
+			b.WriteString(job.ID + "  " + job.Type + "  " + jobStateColor(job.State) + "\n")
+		}
+	}
+	b.WriteByte('\n')
+
+	b.WriteString(headerStyle.Render("template versions"))
+	b.WriteByte('\n')
+	switch {
+	case a.TemplateID == "":
+		b.WriteString(mutedStyle.Render("no template") + "\n")
+	case m.agentVersionsErr != "":
+		b.WriteString(errorStyle.Render(m.agentVersionsErr) + "\n")
+	case !m.agentVersionsLoaded:
+		b.WriteString(mutedStyle.Render("loading…") + "\n")
+	case len(m.agentVersions) == 0:
+		b.WriteString(mutedStyle.Render("no versions") + "\n")
+	default:
+		for _, v := range m.agentVersions {
+			line := "v" + strconv.Itoa(v.Number) + "  " + versionStateColor(v.State)
+			if v.Name != "" {
+				line += "  " + truncate(v.Name, 48)
+			}
+			if v.Created != "" {
+				line += "  " + mutedStyle.Render(v.Created)
+			}
+			b.WriteString(line + "\n")
+		}
+	}
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	b.WriteString("\n")
+	hint := "D delete  esc back"
+	if len(m.revertableVersions()) > 0 {
+		hint = "v revert  " + hint
+	}
+	b.WriteString(mutedStyle.Render(hint))
+	return b.String()
+}
+
+func (m Model) agentRevertPickView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("revert " + m.activeAgent.TemplateID))
+	b.WriteString("\n\n")
+	b.WriteString("Pick the version to make current again:\n\n")
+	for i, v := range m.revertableVersions() {
+		cursor, label := "  ", "v"+strconv.Itoa(v.Number)
+		if v.Name != "" {
+			label += "  " + truncate(v.Name, 48)
+		}
+		if i == m.versionCursor {
+			cursor, label = "▸ ", selectedRowStyle.Render(label)
+		}
+		b.WriteString(cursor + label + "\n")
+	}
+	b.WriteString("\n" + mutedStyle.Render("enter pick  esc back"))
+	return b.String()
+}
+
+func (m Model) agentRevertConfirmView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("Revert " + m.activeAgent.TemplateID))
+	b.WriteString("\n\n")
+	b.WriteString("Make v" + strconv.Itoa(m.revertVersion.Number) + " the current version again? (y/n)\n")
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("reverting…"))
+	} else {
+		b.WriteString(mutedStyle.Render("y revert  n/esc cancel"))
+	}
+	return b.String()
+}
+
+func (m Model) agentDeleteConfirmView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("Delete agent " + m.activeAgent.Name))
+	b.WriteString("\n\n")
+	b.WriteString(dash(m.activeAgent.Runtime) + " · template " + dash(m.activeAgent.TemplateID) + "\n\n")
+	b.WriteString("Unregister this agent? (y/n)\n")
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("deleting…"))
+	} else {
+		b.WriteString(mutedStyle.Render("y delete  n/esc cancel"))
+	}
+	return b.String()
+}
+
+// agentJobs returns up to limit of the agent's most recent job rows, newest
+// first by UpdatedAt (job ids are semantic strings, so id order is not
+// recency).
+func agentJobs(rows []JobRow, agent string, limit int) []JobRow {
+	matched := []JobRow{}
+	for _, row := range rows {
+		if row.Agent == agent {
+			matched = append(matched, row)
+		}
+	}
+	sort.SliceStable(matched, func(i, j int) bool { return matched[i].UpdatedAt > matched[j].UpdatedAt })
+	if len(matched) > limit {
+		matched = matched[:limit]
+	}
+	return matched
+}
+
+// AgentCreatePromptIDs are the interactive-prompt records the create form
+// publishes; the dashboard deletes them on exit so a hard quit mid-form does
+// not leave phantom prompts behind.
+func AgentCreatePromptIDs() []string {
+	return []string{"agent-create-name", "agent-create-runtime", "agent-create-template"}
+}
+
+func versionStateColor(state string) string {
+	switch state {
+	case "current":
+		return greenStyle.Render(state)
+	case "rejected":
+		return redStyle.Render(state)
+	default:
+		return state
+	}
+}

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -1,0 +1,370 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func agentsSnapshot() Snapshot {
+	return Snapshot{
+		Daemon: Daemon{Running: true},
+		Agents: []Agent{
+			{Name: "planner", Runtime: "claude", Role: "plan", Health: "ok", TemplateID: "planner-tpl"},
+			{Name: "reviewer", Runtime: "codex", Health: "ok", TemplateID: "reviewer-tpl"},
+		},
+		JobRows: []JobRow{
+			{ID: "job-1", Agent: "planner", Type: "ask", State: "succeeded"},
+			{ID: "job-2", Agent: "reviewer", Type: "review", State: "failed"},
+		},
+	}
+}
+
+func agentsModel(t *testing.T, deps Deps, snap Snapshot) Model {
+	t.Helper()
+	if deps.Load == nil {
+		deps.Load = func() (Snapshot, error) { return snap, nil }
+	}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	for i := 0; i < 2; i++ { // Attention → Trains → Agents
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+	}
+	if pages[m.selected].page != pageAgents {
+		t.Fatalf("expected Agents page, got %v", pages[m.selected].page)
+	}
+	return m
+}
+
+func TestAgentDetailRendersVersionsAndJobs(t *testing.T) {
+	var asked string
+	deps := Deps{TemplateVersions: func(templateID string) ([]TemplateVersion, error) {
+		asked = templateID
+		return []TemplateVersion{
+			{ID: "v2-id", Number: 2, State: "current", Name: "improved"},
+			{ID: "v1-id", Number: 1, State: "superseded", Name: "initial"},
+		}, nil
+	}}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if m.mode != modeAgentDetail || cmd == nil {
+		t.Fatalf("enter should open the agent detail, mode=%v", m.mode)
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if asked != "planner-tpl" {
+		t.Fatalf("TemplateVersions asked for %q", asked)
+	}
+	view := m.View()
+	for _, want := range []string{"agent planner", "planner-tpl", "v2", "improved", "v1", "initial", "job-1"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("detail missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "job-2") {
+		t.Fatalf("detail must only list the agent's own jobs:\n%s", view)
+	}
+}
+
+func TestAgentCreateFlowRunsCreateAgent(t *testing.T) {
+	var created []string
+	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})
+	deps := Deps{
+		OpenAgentCreate: func() (tea.Model, error) { return form, nil },
+		CreateAgent: func(name, runtime, template string) error {
+			created = []string{name, runtime, template}
+			return nil
+		},
+	}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, cmd := m.Update(key("n"))
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("n should push the create form")
+	}
+	if _, ok := cmd().(PushModelMsg); !ok {
+		t.Fatal("n should produce a PushModelMsg")
+	}
+	// The popped form delivers its answers; the dashboard runs the create.
+	next, cmd = m.Update(agentFormResultMsg{result: Result{Values: map[string]string{
+		"name": "scout", "runtime": "claude", "template": "planner-tpl",
+	}}})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("a completed form should trigger the create")
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if len(created) != 3 || created[0] != "scout" || created[1] != "claude" || created[2] != "planner-tpl" {
+		t.Fatalf("CreateAgent called with %v", created)
+	}
+}
+
+func TestAgentCreateAbortedFormDoesNothing(t *testing.T) {
+	deps := Deps{CreateAgent: func(name, runtime, template string) error {
+		t.Fatal("aborted form must not create")
+		return nil
+	}}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, cmd := m.Update(agentFormResultMsg{result: Result{Aborted: true}})
+	m = next.(Model)
+	if cmd != nil {
+		// Drain: any returned cmd must not be a create.
+		if msg := cmd(); msg != nil {
+			if _, ok := msg.(agentActionMsg); ok {
+				t.Fatal("aborted form must not fire agentActionMsg")
+			}
+		}
+	}
+	_ = m
+}
+
+func TestAgentCreateErrorRendersInline(t *testing.T) {
+	deps := Deps{CreateAgent: func(name, runtime, template string) error {
+		return errors.New("agent name already registered")
+	}}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, cmd := m.Update(agentFormResultMsg{result: Result{Values: map[string]string{"name": "planner"}}})
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if !strings.Contains(m.View(), "agent name already registered") {
+		t.Fatalf("create error should render on the Agents page:\n%s", m.View())
+	}
+}
+
+func TestAgentDeleteGuardKeepsConfirmOpen(t *testing.T) {
+	deps := Deps{DeleteAgent: func(name string) error {
+		return errors.New("agent planner has queued or running jobs")
+	}}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, _ := m.Update(key("D"))
+	m = next.(Model)
+	if m.mode != modeConfirmAgentDelete {
+		t.Fatalf("D should open the delete confirm, mode=%v", m.mode)
+	}
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeConfirmAgentDelete {
+		t.Fatalf("refusal should keep the confirm open, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "queued or running jobs") {
+		t.Fatalf("refusal should render:\n%s", m.View())
+	}
+}
+
+func TestAgentDeleteSuccess(t *testing.T) {
+	var deleted string
+	deps := Deps{DeleteAgent: func(name string) error { deleted = name; return nil }}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown}) // → reviewer
+	m = next.(Model)
+	next, _ = m.Update(key("D"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if deleted != "reviewer" {
+		t.Fatalf("DeleteAgent called with %q", deleted)
+	}
+	if m.mode != modeNormal {
+		t.Fatalf("success should close the confirm, mode=%v", m.mode)
+	}
+}
+
+func TestAgentRevertPicksSupersededVersion(t *testing.T) {
+	var gotTemplate, gotVersion string
+	deps := Deps{
+		TemplateVersions: func(templateID string) ([]TemplateVersion, error) {
+			return []TemplateVersion{
+				{ID: "v3-id", Number: 3, State: "current"},
+				{ID: "v2-id", Number: 2, State: "superseded"},
+				{ID: "v1-id", Number: 1, State: "superseded"},
+			}, nil
+		},
+		RevertTemplate: func(templateID, versionID string) error {
+			gotTemplate, gotVersion = templateID, versionID
+			return nil
+		},
+	}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	next, _ = m.Update(cmd()) // versions load
+	m = next.(Model)
+	next, _ = m.Update(key("v"))
+	m = next.(Model)
+	if m.mode != modeAgentRevertPick {
+		t.Fatalf("v should open the revert pick, mode=%v", m.mode)
+	}
+	// Pick the second superseded version (v1).
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if m.mode != modeConfirmAgentRevert {
+		t.Fatalf("enter should confirm the pick, mode=%v", m.mode)
+	}
+	next, cmd = m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if gotTemplate != "planner-tpl" || gotVersion != "v1-id" {
+		t.Fatalf("RevertTemplate called with (%q, %q)", gotTemplate, gotVersion)
+	}
+	if m.mode != modeAgentDetail {
+		t.Fatalf("revert success should return to the detail, mode=%v", m.mode)
+	}
+}
+
+func TestAgentRevertUnavailableWithoutSuperseded(t *testing.T) {
+	deps := Deps{TemplateVersions: func(templateID string) ([]TemplateVersion, error) {
+		return []TemplateVersion{{ID: "v1-id", Number: 1, State: "current"}}, nil
+	}}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	next, _ = m.Update(key("v"))
+	m = next.(Model)
+	if m.mode != modeAgentDetail {
+		t.Fatalf("v with no superseded versions must be a no-op, mode=%v", m.mode)
+	}
+}
+
+func TestAgentCreateFormCompletionPopsWithResult(t *testing.T) {
+	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})
+	var model tea.Model = form
+	step := func(msg tea.Msg) tea.Cmd {
+		next, cmd := model.Update(msg)
+		model = next
+		return cmd
+	}
+	step(initMsg{})
+	// name
+	for _, r := range "scout" {
+		step(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	step(tea.KeyMsg{Type: tea.KeyEnter})
+	// runtime: codex default → enter
+	step(tea.KeyMsg{Type: tea.KeyEnter})
+	// template: first choice → enter
+	step(tea.KeyMsg{Type: tea.KeyEnter})
+	// confirm
+	cmd := step(key("y"))
+	if cmd == nil {
+		t.Fatal("confirm should produce the Done command")
+	}
+	pop, ok := cmd().(PopModelMsg)
+	if !ok {
+		t.Fatalf("Done must pop the form, got %T", cmd())
+	}
+	result, ok := pop.Deliver.(agentFormResultMsg)
+	if !ok {
+		t.Fatalf("the pop must deliver the form result, got %T", pop.Deliver)
+	}
+	if result.result.Aborted {
+		t.Fatal("completed form must not be aborted")
+	}
+	values := result.result.Values
+	if values["name"] != "scout" || values["runtime"] != "codex" || values["template"] != "planner-tpl" {
+		t.Fatalf("form values = %v", values)
+	}
+}
+
+func TestAgentCreateFormExternalFinishPopsNotQuits(t *testing.T) {
+	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})
+	var model tea.Model = form
+	step := func(msg tea.Msg) tea.Cmd {
+		next, cmd := model.Update(msg)
+		model = next
+		return cmd
+	}
+	step(initMsg{})
+	for _, r := range "scout" {
+		step(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	step(tea.KeyMsg{Type: tea.KeyEnter}) // name
+	step(tea.KeyMsg{Type: tea.KeyEnter}) // runtime
+	// As if an agent answered a field externally: the final commit then
+	// auto-accepts instead of showing the confirm — and must pop, not quit
+	// the whole dashboard.
+	ti := model.(TrainInitModel)
+	ti.external = true
+	model = ti
+	cmd := step(tea.KeyMsg{Type: tea.KeyEnter}) // template → final commit
+	if cmd == nil {
+		t.Fatal("the final commit should produce commands")
+	}
+	var sawPop, sawQuit bool
+	var walk func(tea.Cmd)
+	walk = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		switch msg := msg.(type) {
+		case tea.BatchMsg:
+			for _, sub := range msg {
+				walk(sub)
+			}
+		case PopModelMsg:
+			sawPop = true
+			if result, ok := msg.Deliver.(agentFormResultMsg); !ok || result.result.Aborted {
+				t.Fatalf("external finish must deliver a non-aborted result, got %+v", msg.Deliver)
+			}
+		case tea.QuitMsg:
+			sawQuit = true
+		}
+	}
+	walk(cmd)
+	if !sawPop || sawQuit {
+		t.Fatalf("external finish must pop (got pop=%v) and never quit (got quit=%v)", sawPop, sawQuit)
+	}
+}
+
+func TestAgentCreateFormAbortPopsAborted(t *testing.T) {
+	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})
+	next, _ := form.Update(initMsg{})
+	next, cmd := next.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	_ = next
+	if cmd == nil {
+		t.Fatal("esc should produce the abort command")
+	}
+	// abort batches the Done cmd with prompt cleanup; find the pop.
+	var pop *PopModelMsg
+	var walk func(tea.Cmd)
+	walk = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				walk(sub)
+			}
+			return
+		}
+		if p, ok := msg.(PopModelMsg); ok {
+			pop = &p
+		}
+	}
+	walk(cmd)
+	if pop == nil {
+		t.Fatal("abort must pop the form")
+	}
+	result, ok := pop.Deliver.(agentFormResultMsg)
+	if !ok || !result.result.Aborted {
+		t.Fatalf("abort must deliver an aborted result, got %+v", pop.Deliver)
+	}
+}

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -47,10 +47,11 @@ type Repo struct {
 
 // Agent mirrors cli.dashboardAgent.
 type Agent struct {
-	Name    string
-	Runtime string
-	Role    string
-	Health  string
+	Name       string
+	Runtime    string
+	Role       string
+	Health     string
+	TemplateID string
 }
 
 // Session mirrors cli.dashboardSession.
@@ -142,6 +143,26 @@ type Deps struct {
 	StopTrain       func(id, reason string) error
 	DeleteTrain     func(id string) ([]string, error)
 	DeleteTrainRepo func(repo string) error
+
+	// Agent actions. TemplateVersions lazily loads a template's version history
+	// for the agent detail view. OpenAgentCreate builds the create-agent form
+	// pushed onto the Root stack; the dashboard then runs CreateAgent with the
+	// collected answers. DeleteAgent refuses while jobs reference the agent.
+	// RevertTemplate makes a superseded template version current again.
+	TemplateVersions func(templateID string) ([]TemplateVersion, error)
+	OpenAgentCreate  func() (tea.Model, error)
+	CreateAgent      func(name, runtime, template string) error
+	DeleteAgent      func(name string) error
+	RevertTemplate   func(templateID, versionID string) error
+}
+
+// TemplateVersion is one row of a template's version history.
+type TemplateVersion struct {
+	ID      string
+	Number  int
+	State   string // pending | current | superseded | rejected
+	Name    string
+	Created string
 }
 
 // snapshotMsg carries the result of a Deps.Load call.
@@ -214,4 +235,23 @@ type trainDeleteMsg struct {
 type trainRepoCleanupMsg struct {
 	failed []string
 	errs   []string
+}
+
+// agentVersionsMsg carries a template's version history for the agent detail.
+type agentVersionsMsg struct {
+	templateID string
+	versions   []TemplateVersion
+	err        error
+}
+
+// agentActionMsg carries the outcome of an agent mutation.
+type agentActionMsg struct {
+	verb string // "create", "delete", "revert"
+	err  error
+}
+
+// agentFormResultMsg is delivered to the dashboard when the pushed
+// create-agent form pops (its Done callback is wired in NewAgentCreateForm).
+type agentFormResultMsg struct {
+	result Result
 }

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -51,6 +51,10 @@ const (
 	modeTrainStopReason
 	modeConfirmTrainDelete
 	modeConfirmTrainRepoCleanup
+	modeAgentDetail
+	modeAgentRevertPick
+	modeConfirmAgentRevert
+	modeConfirmAgentDelete
 )
 
 const defaultInterval = 5 * time.Second
@@ -94,6 +98,16 @@ type Model struct {
 
 	// Trains page action state.
 	pendingRepos []string // gitmoot-created repos offered for cleanup after a delete
+
+	// Agents page interaction state.
+	agentCursor         int               // selected row in snap.Agents
+	activeAgent         Agent             // agent shown in detail / being confirmed
+	agentVersions       []TemplateVersion // lazy-loaded template version history
+	agentVersionsLoaded bool              // the version load has returned (possibly empty)
+	agentVersionsErr    string            // error from the version load
+	versionCursor       int               // selected row in the revert pick list
+	revertVersion       TemplateVersion   // version being confirmed for revert
+	agentErr            string            // inline error on the Agents page (e.g. create failed)
 }
 
 // New returns a Model ready for tea.NewProgram. It starts in the loading state;
@@ -147,6 +161,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 			return m.updateTrainOverlay(msg)
+		case modeAgentDetail, modeAgentRevertPick, modeConfirmAgentRevert, modeConfirmAgentDelete:
+			if msg.String() == "ctrl+c" {
+				return m, tea.Quit
+			}
+			return m.updateAgentOverlay(msg)
 		}
 		if m.mode != modeNormal {
 			return m.updateOverlay(msg)
@@ -221,6 +240,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
+			if agent, ok := m.agentUnderCursor(); ok {
+				cmd := m.openAgentDetail(agent)
+				m.viewport.SetContent(m.content())
+				return m, cmd
+			}
 			if job, ok := m.jobUnderCursor(); ok {
 				cmd := m.openJobDetail(job)
 				m.viewport.SetContent(m.content())
@@ -254,6 +278,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmd := m.openTrainStop(t)
 				m.viewport.SetContent(m.content())
 				return m, cmd
+			}
+		case "n":
+			// Form construction touches the database, so it runs as a command
+			// (a synchronous call here would freeze the UI on a busy store).
+			if pages[m.selected].page == pageAgents && m.deps.OpenAgentCreate != nil {
+				m.agentErr = ""
+				return m, openAgentFormCmd(m.deps)
+			}
+		case "D":
+			if agent, ok := m.agentUnderCursor(); ok {
+				m.openAgentDelete(agent)
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
 			}
 		case "?":
 			m.showHelp = !m.showHelp
@@ -368,6 +405,65 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if cmd := m.queueLoad(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case agentVersionsMsg:
+		if m.activeAgent.TemplateID == msg.templateID {
+			m.agentVersionsLoaded = true
+			if msg.err != nil {
+				m.agentVersionsErr = msg.err.Error()
+			} else {
+				m.agentVersionsErr = ""
+				m.agentVersions = msg.versions
+			}
+		}
+	case agentFormResultMsg:
+		// The pushed create form popped itself; run the registration unless it
+		// was aborted.
+		if !msg.result.Aborted {
+			m.agentErr = ""
+			cmds = append(cmds, agentCreateCmd(m.deps, msg.result.Values))
+		}
+	case agentActionMsg:
+		switch msg.verb {
+		case "create", "form":
+			// No overlay is open by the time a create (or a failed form
+			// construction) settles; surface errors inline on the Agents page.
+			if msg.err != nil {
+				m.agentErr = msg.err.Error()
+			} else {
+				m.agentErr = ""
+			}
+		case "delete":
+			if m.mode == modeConfirmAgentDelete {
+				m.actionBusy = false
+				if msg.err != nil {
+					m.actionErr = msg.err.Error()
+				} else {
+					m.mode = modeNormal
+					m.actionErr = ""
+				}
+			}
+		case "revert":
+			if m.mode == modeConfirmAgentRevert {
+				m.actionBusy = false
+				if msg.err != nil {
+					m.actionErr = msg.err.Error()
+				} else {
+					// Back to the detail with a fresh version history.
+					m.mode = modeAgentDetail
+					m.actionErr = ""
+					m.agentVersionsLoaded = false
+					m.agentVersions = nil
+					if m.activeAgent.TemplateID != "" {
+						cmds = append(cmds, agentVersionsCmd(m.deps, m.activeAgent.TemplateID))
+					}
+				}
+			}
+		}
+		if msg.err == nil {
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
 	case daemonStartMsg:
 		// Daemon start has its own busy/error state so its result cannot close
 		// or pollute an unrelated job confirm that opened in the meantime.
@@ -409,6 +505,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampPromptCursor()
 			m.clampTrainCursor()
 			m.clampJobCursor()
+			m.agentCursor = clampCursor(m.agentCursor, len(m.snap.Agents))
 			// A cancel-requested job that has settled no longer needs the
 			// transitional "cancelling…" label.
 			for id := range m.cancelling {
@@ -483,6 +580,8 @@ func (m *Model) pageCursor() (*int, int) {
 		return &m.promptCursor, len(m.attentionItems())
 	case pageTrains:
 		return &m.trainCursor, len(m.snap.Trains)
+	case pageAgents:
+		return &m.agentCursor, len(m.snap.Agents)
 	case pageJobs:
 		return &m.jobCursor, len(m.snap.JobRows)
 	}

--- a/internal/cli/tui/root.go
+++ b/internal/cli/tui/root.go
@@ -9,7 +9,11 @@ type PushModelMsg struct {
 }
 
 // PopModelMsg asks the Root to pop the top model and return to the one below.
-type PopModelMsg struct{}
+// Deliver, when set, is forwarded to the resumed model right after the pop —
+// how a pushed form hands its result back to the model that pushed it.
+type PopModelMsg struct {
+	Deliver tea.Msg
+}
 
 // Push returns a command that pushes model onto the Root's stack.
 func Push(model tea.Model) tea.Cmd {
@@ -19,6 +23,12 @@ func Push(model tea.Model) tea.Cmd {
 // Pop returns a command that pops the Root's top model.
 func Pop() tea.Cmd {
 	return func() tea.Msg { return PopModelMsg{} }
+}
+
+// PopWith returns a command that pops the Root's top model and delivers msg
+// to the model below.
+func PopWith(msg tea.Msg) tea.Cmd {
+	return func() tea.Msg { return PopModelMsg{Deliver: msg} }
 }
 
 // Root is the navigation shell: a message router and screen compositor over a
@@ -76,7 +86,13 @@ func (r Root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// re-arm the tick, so pops cannot accumulate tick loops).
 			next, cmd := r.top().Update(refreshNudgeMsg{})
 			r.stack[len(r.stack)-1] = next
-			return r, cmd
+			cmds := []tea.Cmd{cmd}
+			if msg.Deliver != nil {
+				next, cmd = r.top().Update(msg.Deliver)
+				r.stack[len(r.stack)-1] = next
+				cmds = append(cmds, cmd)
+			}
+			return r, tea.Batch(cmds...)
 		}
 		return r, tea.Quit
 	}

--- a/internal/cli/tui/traininit.go
+++ b/internal/cli/tui/traininit.go
@@ -52,6 +52,11 @@ type TrainInitModel struct {
 	// pendingValue holds a validated free-text answer awaiting a repo
 	// existence check / creation decision (tiRepoCheck / tiRepoMissing).
 	pendingValue string
+
+	// Done, when set, replaces tea.Quit on completion/abort so the form can
+	// run embedded under the Root router (the cmd typically pops the form and
+	// delivers the Result to the model below).
+	Done func(Result) tea.Cmd
 }
 
 // NewTrainInit builds the form. summary renders the confirm-screen rows from the
@@ -196,6 +201,9 @@ func (m TrainInitModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "y", "Y", "enter":
 			m.state = tiDone
+			if m.Done != nil {
+				return m, m.Done(m.Result())
+			}
 			return m, tea.Quit
 		case "n", "N", "esc":
 			return m.abort()
@@ -297,7 +305,11 @@ func (m TrainInitModel) commit(value string) (tea.Model, tea.Cmd) {
 	m.pendingPromptID = ""
 	if m.external {
 		m.state = tiDone
-		cmds = append(cmds, tea.Quit)
+		exit := tea.Quit
+		if m.Done != nil {
+			exit = m.Done(m.Result())
+		}
+		cmds = append(cmds, exit)
 		return m, tea.Batch(cmds...)
 	}
 	m.state = tiConfirm
@@ -336,7 +348,11 @@ func (m *TrainInitModel) enterField(i int) tea.Cmd {
 func (m TrainInitModel) abort() (tea.Model, tea.Cmd) {
 	m.aborted = true
 	m.state = tiDone
-	cmds := []tea.Cmd{tea.Quit}
+	exit := tea.Quit
+	if m.Done != nil {
+		exit = m.Done(m.Result())
+	}
+	cmds := []tea.Cmd{exit}
 	if m.pendingPromptID != "" {
 		cmds = append(cmds, deletePromptCmd(m.store, m.pendingPromptID))
 	}

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -87,6 +87,14 @@ func (m Model) content() string {
 		b.WriteString(m.trainDeleteConfirmView())
 	case modeConfirmTrainRepoCleanup:
 		b.WriteString(m.trainRepoCleanupView())
+	case modeAgentDetail:
+		b.WriteString(m.agentDetailView())
+	case modeAgentRevertPick:
+		b.WriteString(m.agentRevertPickView())
+	case modeConfirmAgentRevert:
+		b.WriteString(m.agentRevertConfirmView())
+	case modeConfirmAgentDelete:
+		b.WriteString(m.agentDeleteConfirmView())
 	default:
 		switch pages[m.selected].page {
 		case pageAttention:
@@ -94,7 +102,7 @@ func (m Model) content() string {
 		case pageTrains:
 			b.WriteString(m.trainsContent())
 		case pageAgents:
-			b.WriteString(m.agentsContent())
+			b.WriteString(m.agentsContentInteractive())
 		case pageSessions:
 			b.WriteString(m.sessionsContent())
 		case pageJobs:
@@ -127,6 +135,12 @@ func (m Model) helpContent() string {
 		b.WriteString("s    stop a live session (asks for a reason)\n")
 		b.WriteString("d    delete a finished session and its history;\n")
 		b.WriteString("     repos gitmoot created for it can be deleted too\n")
+	case pageAgents:
+		b.WriteString("↑/↓  select an agent\n")
+		b.WriteString("enter open the agent (template, recent jobs, versions)\n")
+		b.WriteString("n    register a new agent (name, runtime, template)\n")
+		b.WriteString("D    delete the selected agent (refused while jobs reference it)\n")
+		b.WriteString("v    in the detail: revert the template to a previous version\n")
 	case pageJobs:
 		b.WriteString("↑/↓  select a job\n")
 		b.WriteString("enter open the job's detail (events)\n")
@@ -165,12 +179,20 @@ func (m Model) footerHelp() string {
 		return "y delete  n/esc cancel"
 	case modeConfirmTrainRepoCleanup:
 		return "y delete repos  n/esc keep them"
+	case modeAgentDetail:
+		return "v revert  D delete  esc back"
+	case modeAgentRevertPick:
+		return "↑/↓ pick  enter confirm  esc back"
+	case modeConfirmAgentRevert, modeConfirmAgentDelete:
+		return "y confirm  n/esc cancel"
 	}
 	switch pages[m.selected].page {
 	case pageAttention:
 		return "tab/←→ page  ↑/↓ select  a answer  d dismiss  enter/R jobs  ? help  q quit"
 	case pageTrains:
 		return "tab/←→ page  ↑/↓ select  enter open  s stop  d delete  ? help  q quit"
+	case pageAgents:
+		return "tab/←→ page  ↑/↓ select  enter detail  n new  D delete  ? help  q quit"
 	case pageJobs:
 		return "tab/←→ page  ↑/↓ select  enter detail  R retry  c cancel  ? help  q quit"
 	}
@@ -182,17 +204,6 @@ func (m Model) loadingOr(empty string, loaded bool) string {
 		return empty
 	}
 	return mutedStyle.Render("Loading…")
-}
-
-func (m Model) agentsContent() string {
-	if len(m.snap.Agents) == 0 {
-		return m.loadingOr("No registered agents.", !m.loadedAt.IsZero())
-	}
-	rows := [][]string{{"NAME", "RUNTIME", "ROLE", "HEALTH"}}
-	for _, a := range m.snap.Agents {
-		rows = append(rows, []string{a.Name, a.Runtime, dash(a.Role), dash(a.Health)})
-	}
-	return renderRows(rows)
 }
 
 func (m Model) sessionsContent() string {


### PR DESCRIPTION
## WHAT
Task 7 of the dashboard-cockpit plan (#243): the Agents page can now register a new agent, inspect one (template, recent jobs, version history), delete one, and revert its template to a previous version.

## WHY
Creating an agent required hand-typed CLI commands, there was no way to see an agent's template version history, and reverting a bad template promotion had no UI at all.

## CHANGES
- **Agents page**: aligned cursor table; `enter` opens a detail view showing runtime/role/health/template, the agent's 5 most recent jobs (sorted by UpdatedAt — job ids are semantic strings, so id order is not recency), and the template's version history (lazy-loaded, with created timestamps).
- **`n` create**: pushes a form built on the existing train-init Field widgets — name (text), runtime (codex/claude choice), template (choice, installed templates only: `registerAgentOnly` persists the id verbatim and an uninstalled one would yield an agent whose jobs fail at delivery). Registration runs through the same `registerAgentOnly` path as the CLI. Construction runs as a command so a busy store cannot freeze the UI; errors render inline.
- **`D` delete**: y/N confirm → `DeleteAgentChecked`; the queued/running-jobs refusal stays in the confirm.
- **`v` revert** (in the detail): pick from the superseded versions → y/N → `RevertAgentTemplateVersion`; success returns to the detail with a refreshed history.
- **Form embedding infrastructure**: `TrainInitModel` gains a `Done` hook replacing `tea.Quit` on completion, abort, AND the externally-answered auto-accept path (previously an agent answering the last field via `gitmoot interactive answer` would have killed the entire dashboard). `PopModelMsg` gains an optional `Deliver` payload (`PopWith`) so a popped form hands its result to the dashboard deterministically — this is the same mechanism Task 8's optimize form will use.
- The pushed form holds one store for its lifetime (its 200ms external-answer poll would otherwise run a full open/migrate/close cycle 5×/sec against the shared SQLite file, contending with the daemon), closed from the Done hook. The dashboard sweeps the form's three prompt records on exit so a ctrl+c mid-form leaves no phantom attention rows.
- `--json`/plain outputs untouched: the new `templateID` on `dashboardAgent` is unexported.

## RESULTS
- `go test ./internal/cli/tui ./internal/db` green; `./internal/cli` green except the known pre-existing flake `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos`. vet/gofmt clean.
- New tests: detail render (versions + only-own-jobs), create flow end-to-end (n → PushModelMsg → form result → CreateAgent with exact values), aborted form does nothing, create error inline, delete guard keeps confirm, delete success, revert picks the chosen superseded version id, v no-op without superseded versions, form completion pops with result, form abort pops aborted, external finish pops and never quits.

## REVIEW
High-effort multi-angle review run; fixed: external-answer path quitting the program, 5×/sec DB open/migrate poll churn, synchronous form construction freezing the UI, uninstalled templates offered, wrong recent-jobs ordering, prompt records leaking on hard quit, lost table alignment, dead Created field. Known accepted: fixed prompt ids collide if two dashboards run concurrently against the same home (same tradeoff as the existing train-init wizard); `versionStateColor` is a third state-color switch (consolidation queued for Task 9 polish).

## RISK
TUI + one Done-hook on the train-init model (standalone wizard behavior unchanged: Done nil → tea.Quit exactly as before, covered by existing traininit tests). Delete/revert are y/N-gated store calls that already have their own db-level tests from Task 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)