### PR TITLE
cli: optimize an agent from the dashboard with backend choice

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -72,7 +72,8 @@ func runDashboardTUI(home string, interval time.Duration, stdout, stderr io.Writ
 	// pending; sweep them so they do not haunt the attention list (mirrors
 	// the standalone wizard's deferred cleanup).
 	_ = withStore(home, func(store *db.Store) error {
-		for _, id := range tui.AgentCreatePromptIDs() {
+		ids := append(tui.AgentCreatePromptIDs(), agentOptimizePromptIDs()...)
+		for _, id := range ids {
 			_ = store.DeleteInteractivePrompt(context.Background(), id)
 		}
 		return nil
@@ -212,7 +213,7 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 				store.Close()
 				return nil, fmt.Errorf("no agent templates installed; add one with `gitmoot agent template add`")
 			}
-			form := tui.NewAgentCreateForm(store, choices)
+			form := tui.NewAgentCreateForm(formPromptStore{home: home, store: store}, choices)
 			done := form.Done
 			form.Done = func(res tui.Result) tea.Cmd {
 				store.Close()
@@ -236,6 +237,30 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 				return err
 			})
 		},
+		OpenAgentOptimize: func(agent tui.Agent) (tea.Model, error) {
+			// Same lifetime pattern as the create form: one store for the
+			// form's 200ms poll, closed from the Done hook.
+			paths, err := initializedPaths(home)
+			if err != nil {
+				return nil, err
+			}
+			store, err := db.Open(paths.Database)
+			if err != nil {
+				return nil, err
+			}
+			form := tui.NewAgentOptimizeForm(formPromptStore{home: home, store: store},
+				agent.TemplateID, buildAgentOptimizeFields(),
+				agentOptimizeSummaryRows(agent.TemplateID), agentOptimizeInterpret)
+			done := form.Done
+			form.Done = func(res tui.Result) tea.Cmd {
+				store.Close()
+				return done(res)
+			}
+			return form, nil
+		},
+		StartOptimize: func(templateID string, values map[string]string) (string, error) {
+			return startAgentOptimizeSession(home, templateID, values)
+		},
 		StartDaemon: func() error {
 			// Restart rather than start: it tolerates a stopped daemon and
 			// restores the previously persisted flags (workers, poll, watch)
@@ -247,6 +272,31 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 			return nil
 		},
 	}
+}
+
+// formPromptStore is the PromptStore for pushed forms: the hot 200ms answer
+// poll reads through one held store, while the rare upserts/deletes go through
+// withStore so they still work after the held store is closed from the form's
+// Done hook (abort batches its prompt delete with the pop).
+type formPromptStore struct {
+	home  string
+	store *db.Store
+}
+
+func (s formPromptStore) UpsertInteractivePrompt(ctx context.Context, prompt db.InteractivePrompt) error {
+	return withStore(s.home, func(store *db.Store) error {
+		return store.UpsertInteractivePrompt(ctx, prompt)
+	})
+}
+
+func (s formPromptStore) GetInteractivePrompt(ctx context.Context, id string) (db.InteractivePrompt, error) {
+	return s.store.GetInteractivePrompt(ctx, id)
+}
+
+func (s formPromptStore) DeleteInteractivePrompt(ctx context.Context, id string) error {
+	return withStore(s.home, func(store *db.Store) error {
+		return store.DeleteInteractivePrompt(ctx, id)
+	})
 }
 
 // toTUISnapshot copies the cli dashboardSnapshot into the tui-facing Snapshot.

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1525,6 +1525,12 @@ func skillOptTrainOptimizerDefaultsFromInitConfig(config skillopt.TrainInitConfi
 		request.TargetBackend = skillOptTrainTargetBackendFromInitConfig(targetBackend, internalTargetAdapter)
 		request.EvaluatorBackend = evaluatorBackend
 	}
+	if value := strings.TrimSpace(config.Optimizer.OptimizerModel); value != "" {
+		request.OptimizerModel = value
+	}
+	if value := strings.TrimSpace(config.Optimizer.TargetModel); value != "" {
+		request.TargetModel = value
+	}
 	return request
 }
 
@@ -7845,6 +7851,12 @@ func skillOptTrainOptimizerDefaultsMetadata(request skillOptTrainOptimizerReques
 	if value := strings.TrimSpace(request.TargetBackend); value != "" {
 		metadata["target_backend"] = value
 	}
+	if value := strings.TrimSpace(request.OptimizerModel); value != "" {
+		metadata["optimizer_model"] = value
+	}
+	if value := strings.TrimSpace(request.TargetModel); value != "" {
+		metadata["target_model"] = value
+	}
 	if value := strings.TrimSpace(request.EvaluatorID); value != "" {
 		metadata["evaluator_id"] = value
 	}
@@ -7889,6 +7901,10 @@ func applySkillOptTrainOptimizerDefaultsFromMetadata(metadataJSON string, reques
 	if len(metadata) == 0 {
 		return
 	}
+	// Captured before backend inheritance below: stored model names are
+	// backend-specific, so they are only inherited when the backends are too.
+	backendOverridden := request.Backend != "" || request.OptimizerBackend != "" ||
+		request.TargetBackend != "" || request.EvaluatorBackend != ""
 	if request.Backend == "" && request.OptimizerBackend == "" && request.TargetBackend == "" && request.EvaluatorBackend == "" {
 		request.Backend = metadataString(metadata, "backend")
 	}
@@ -7901,6 +7917,14 @@ func applySkillOptTrainOptimizerDefaultsFromMetadata(metadataJSON string, reques
 		}
 		if request.EvaluatorBackend == "" {
 			request.EvaluatorBackend = metadataString(metadata, "evaluator_backend")
+		}
+	}
+	if !backendOverridden && request.Model == "" {
+		if request.OptimizerModel == "" {
+			request.OptimizerModel = metadataString(metadata, "optimizer_model")
+		}
+		if request.TargetModel == "" {
+			request.TargetModel = metadataString(metadata, "target_model")
 		}
 	}
 	if request.EvaluatorID == "" {

--- a/internal/cli/skillopt_optimize_test.go
+++ b/internal/cli/skillopt_optimize_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestBuildAgentOptimizeFieldsSkipsTemplate(t *testing.T) {
+	fields := buildAgentOptimizeFields()
+	names := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f.Name == "template" {
+			t.Fatal("the optimize form must not ask for the template (pre-filled from the agent)")
+		}
+		names = append(names, f.Name)
+	}
+	want := []string{"name", "review_repo", "workspace_repo", "artifact_kind", "preview", "request", "backend", "model"}
+	if len(names) != len(want) {
+		t.Fatalf("fields = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("fields = %v, want %v", names, want)
+		}
+	}
+}
+
+func TestAgentOptimizeInterpretModelOptional(t *testing.T) {
+	if value, status := agentOptimizeInterpret("model", "  "); status != "ok" || value != "" {
+		t.Fatalf("empty model = (%q, %q), want optional ok", value, status)
+	}
+	if _, status := agentOptimizeInterpret("name", " "); status != "reask" {
+		t.Fatalf("empty name should reask, got %q", status)
+	}
+	if _, status := agentOptimizeInterpret("workspace_repo", "not-a-repo"); status != "reask" {
+		t.Fatalf("malformed workspace repo should reask, got %q", status)
+	}
+}
+
+func TestStartAgentOptimizeSessionPersistsBackendAndModel(t *testing.T) {
+	home := t.TempDir()
+	_ = chdirTemp(t)
+	restoreFetcher := replaceAgentTemplateFetcher(fakeAgentTemplateFetcher{
+		commit:  "abc123",
+		content: "# Gitmoot Planner\n\nPlan work.",
+	})
+	defer restoreFetcher()
+	fakeGH := &repoCreateFakeGitHub{}
+	restoreGH := replaceSkillOptGitHubClient(fakeGH)
+	defer restoreGH()
+
+	sessionID, err := startAgentOptimizeSession(home, "planner", map[string]string{
+		"name":           "opt-planner",
+		"review_repo":    "owner/review",
+		"workspace_repo": "owner/workspace",
+		"artifact_kind":  "text",
+		"preview":        "none",
+		"request":        "Make plans sharper.",
+		"backend":        "claude",
+		"model":          "claude-opus-4-8",
+	})
+	if err != nil {
+		t.Fatalf("startAgentOptimizeSession: %v", err)
+	}
+	if sessionID == "" {
+		t.Fatal("expected a session id")
+	}
+
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	session, err := store.GetSkillOptTrainSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession: %v", err)
+	}
+	if session.TemplateID != "planner" || session.TargetRepo != "owner/review" {
+		t.Fatalf("session = %+v", session)
+	}
+	for key, want := range map[string]string{
+		"optimizer_backend": "claude",
+		"target_backend":    "claude",
+		"evaluator_backend": "claude",
+		"optimizer_model":   "claude-opus-4-8",
+		"target_model":      "claude-opus-4-8",
+	} {
+		if got := skillOptMetadataString(session.MetadataJSON, "optimizer_defaults", key); got != want {
+			t.Fatalf("optimizer_defaults.%s = %q, want %q (metadata=%s)", key, got, want, session.MetadataJSON)
+		}
+	}
+
+	// The continue path picks the choices up when flags are absent…
+	var request skillOptTrainOptimizerRequest
+	applySkillOptTrainOptimizerDefaultsFromMetadata(session.MetadataJSON, &request)
+	if request.OptimizerBackend != "claude" || request.TargetBackend != "claude" {
+		t.Fatalf("applied backends = %+v", request)
+	}
+	if request.OptimizerModel != "claude-opus-4-8" || request.TargetModel != "claude-opus-4-8" {
+		t.Fatalf("applied models = %+v", request)
+	}
+	// …and explicit flags still win.
+	explicit := skillOptTrainOptimizerRequest{Backend: "codex", Model: "gpt-5"}
+	applySkillOptTrainOptimizerDefaultsFromMetadata(session.MetadataJSON, &explicit)
+	if explicit.Backend != "codex" || explicit.OptimizerBackend != "" {
+		t.Fatalf("explicit backend overridden: %+v", explicit)
+	}
+	if explicit.Model != "gpt-5" || explicit.OptimizerModel != "" || explicit.TargetModel != "" {
+		t.Fatalf("explicit model overridden: %+v", explicit)
+	}
+
+	// --create-repos records the repos against the session, so deleting the
+	// session later offers their cleanup.
+	records, err := store.ListCreatedReposForSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("ListCreatedReposForSession: %v", err)
+	}
+	repos := map[string]bool{}
+	for _, record := range records {
+		repos[record.Repo] = true
+	}
+	if !repos["owner/review"] || !repos["owner/workspace"] {
+		t.Fatalf("created repo records = %v", records)
+	}
+}

--- a/internal/cli/skillopt_tui.go
+++ b/internal/cli/skillopt_tui.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -195,4 +199,231 @@ func cleanupSkillOptTrainInitTUIPrompts(store *db.Store, scope string, fields []
 			_ = store.DeleteInteractivePrompt(ctx, id)
 		}
 	}
+}
+
+// agentOptimizePromptScope namespaces the prompt records the dashboard's
+// optimize form publishes (one form per dashboard process).
+const agentOptimizePromptScope = "dashboard-optimize"
+
+// agentOptimizePromptIDs returns the prompt record ids the optimize form
+// publishes (derived from the field definitions, so a new field cannot be
+// missed), letting the dashboard sweep them on exit.
+func agentOptimizePromptIDs() []string {
+	fields := buildAgentOptimizeFields()
+	ids := make([]string, 0, len(fields))
+	for _, field := range fields {
+		ids = append(ids, field.Prompt.ID)
+	}
+	return ids
+}
+
+// buildAgentOptimizeFields builds the optimize-form fields: the standard
+// train-init questions (minus the pre-filled template), plus the workspace
+// repo, a codex/claude backend pick, and an optional model override.
+func buildAgentOptimizeFields() []tui.Field {
+	standard := func(field string) tui.Field {
+		descriptor := buildSkillOptTrainInitPrompt(agentOptimizePromptScope, field, skillOptTrainInitInputs{})
+		entry := tui.Field{
+			Name:    field,
+			Label:   skillOptTrainInitWizardLabel(field),
+			Prompt:  descriptor.Prompt,
+			Default: descriptor.Prompt.Default,
+		}
+		if len(descriptor.Prompt.Choices) > 0 {
+			entry.Kind = tui.FieldChoice
+			for _, choice := range descriptor.Prompt.Choices {
+				entry.Choices = append(entry.Choices, tui.Choice{Value: choice, Label: choice})
+			}
+		} else {
+			entry.Kind = tui.FieldText
+		}
+		return entry
+	}
+	custom := func(field, label, question string, choices []string, def string, required bool) tui.Field {
+		format := "text"
+		if len(choices) > 0 {
+			format = "choice"
+		}
+		entry := tui.Field{
+			Name:    field,
+			Label:   label,
+			Kind:    tui.FieldText,
+			Default: def,
+			Prompt: db.InteractivePrompt{
+				ID:            skillOptTrainInitPromptID(agentOptimizePromptScope, field),
+				Question:      question,
+				Choices:       choices,
+				Default:       def,
+				Required:      required,
+				AnswerFormat:  format,
+				SourceCommand: "gitmoot dashboard agent optimize",
+				State:         db.InteractivePromptStatePending,
+			},
+		}
+		if len(choices) > 0 {
+			entry.Kind = tui.FieldChoice
+			for _, choice := range choices {
+				entry.Choices = append(entry.Choices, tui.Choice{Value: choice, Label: choice})
+			}
+		}
+		return entry
+	}
+	return []tui.Field{
+		standard("name"),
+		standard("review_repo"),
+		custom("workspace_repo", "Workspace repo", "Workspace repository in owner/repo form? (options are generated there)", nil, "", true),
+		standard("artifact_kind"),
+		standard("preview"),
+		standard("request"),
+		custom("backend", "Optimizer backend", "Backend for the optimizer and target runs?", []string{"codex", "claude"}, "codex", true),
+		custom("model", "Model (optional)", "Model override for the optimizer and target runs? (empty = backend default)", nil, "", false),
+	}
+}
+
+// agentOptimizeInterpret validates the optimize-form free-text answers with
+// the same core the train-init wizard uses; the model is the one optional
+// field, and the workspace repo borrows the review-repo format check.
+func agentOptimizeInterpret(field, text string) (string, string) {
+	switch field {
+	case "model":
+		return strings.TrimSpace(text), "ok"
+	case "name":
+		value := strings.TrimSpace(text)
+		if err := skillopt.ValidateTrainInitName(value); err != nil {
+			return "", "reask"
+		}
+		return value, "ok"
+	case "review_repo", "workspace_repo":
+		// Validate the owner/repo shape in the form, so a typo re-asks here
+		// instead of failing the whole pipeline after the form closed.
+		value := strings.TrimSpace(text)
+		if _, err := daemon.ParseRepository(value); err != nil {
+			return "", "reask"
+		}
+		return value, "ok"
+	default:
+		return skillOptTrainInitInterpretCore(field, text, db.InteractivePrompt{}, nil)
+	}
+}
+
+// agentOptimizeSummaryRows renders the optimize confirm screen.
+func agentOptimizeSummaryRows(template string) func(map[string]string) [][]string {
+	return func(answers map[string]string) [][]string {
+		model := strings.TrimSpace(answers["model"])
+		if model == "" {
+			model = "backend default"
+		}
+		return [][]string{
+			{"template", template},
+			{"name", answers["name"]},
+			{"review repo", answers["review_repo"]},
+			{"workspace repo", answers["workspace_repo"]},
+			{"artifact kind", answers["artifact_kind"]},
+			{"preview", answers["preview"]},
+			{"backend", answers["backend"]},
+			{"model", model},
+			{"request", firstLine(answers["request"])},
+		}
+	}
+}
+
+// startAgentOptimizeSession runs the full optimize pipeline headlessly: write
+// the train-init scaffold (with the backend/model choices in its [optimizer]
+// section, which train start persists into the session's optimizer_defaults
+// metadata), then run `skillopt train start --config --yes` with a
+// pre-generated session id so the caller can open its phase view.
+func startAgentOptimizeSession(home, templateID string, answers map[string]string) (string, error) {
+	name := strings.TrimSpace(answers["name"])
+	if err := skillopt.ValidateTrainInitName(name); err != nil {
+		return "", err
+	}
+	reviewRepo, err := daemon.ParseRepository(strings.TrimSpace(answers["review_repo"]))
+	if err != nil {
+		return "", fmt.Errorf("review repo: %w", err)
+	}
+	workspaceRepo, err := daemon.ParseRepository(strings.TrimSpace(answers["workspace_repo"]))
+	if err != nil {
+		return "", fmt.Errorf("workspace repo: %w", err)
+	}
+	preview, err := normalizeSkillOptTrainInitPreview(strings.TrimSpace(answers["preview"]))
+	if err != nil {
+		return "", err
+	}
+	var template db.AgentTemplate
+	if err := withStore(home, func(store *db.Store) error {
+		var err error
+		template, err = skillopt.ResolveTrainInitTemplateChoice(context.Background(), store, newAgentTemplateFetcher(), templateID)
+		return err
+	}); err != nil {
+		return "", err
+	}
+	values := skillOptTrainInitInputs{
+		Name:         name,
+		Template:     template.ID,
+		ReviewRepo:   reviewRepo.FullName(),
+		TaskKind:     "custom",
+		ArtifactKind: strings.TrimSpace(answers["artifact_kind"]),
+		Preview:      preview,
+		Mode:         db.EvalRunModeExplore,
+		Request:      strings.TrimSpace(answers["request"]),
+	}
+	// DefaultTrainInitConfig already carries the explore mode and its
+	// exploration level; only the per-run fields are overlaid here.
+	config := skillopt.DefaultTrainInitConfig()
+	config.Name = values.Name
+	config.Template = template.ID
+	config.TemplateVersion = template.VersionID
+	config.ReviewRepo = values.ReviewRepo
+	config.TaskKind = values.TaskKind
+	config.ArtifactKind = values.ArtifactKind
+	config.Preview = values.Preview
+	config.Options = skillOptTrainInitDefaultOptions(config.Mode)
+	if backend := strings.TrimSpace(answers["backend"]); backend != "" {
+		config.Optimizer.OptimizerBackend = backend
+		config.Optimizer.TargetBackend = backend
+		config.Optimizer.EvaluatorBackend = backend
+		if !strings.EqualFold(backend, "codex") {
+			// The codex_exec adapter default only applies to codex targets;
+			// leaving it in the scaffold would contradict the chosen backend.
+			config.Optimizer.InternalTargetAdapter = ""
+		}
+	}
+	if model := strings.TrimSpace(answers["model"]); model != "" {
+		config.Optimizer.OptimizerModel = model
+		config.Optimizer.TargetModel = model
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	scaffoldRoot := filepath.Join(cwd, ".gitmoot", skillopt.TrainInitScaffoldDirName, values.Name)
+	if _, err := os.Stat(scaffoldRoot); err == nil {
+		return "", fmt.Errorf("a train scaffold named %q already exists at %s; pick a different name", values.Name, scaffoldRoot)
+	}
+	paths, err := skillopt.WriteTrainInitScaffold(cwd, skillopt.TrainInitScaffold{
+		Config:          config,
+		TaskMarkdown:    values.Request,
+		ReviewItemsYAML: skillOptTrainInitStarterReviewItemsYAML(values),
+	})
+	if err != nil {
+		return "", err
+	}
+	sessionID := generatedSkillOptTrainSessionID(template.ID)
+	var stdout, stderr bytes.Buffer
+	args := []string{
+		"--home", home,
+		"--config", paths.ConfigPath,
+		"--session", sessionID,
+		"--workspace-repo", workspaceRepo.FullName(),
+		"--create-repos",
+		"--yes",
+	}
+	if code := runSkillOptTrainStart(args, &stdout, &stderr); code != 0 {
+		reason := strings.TrimSpace(stderr.String())
+		if reason == "" {
+			reason = strings.TrimSpace(stdout.String())
+		}
+		return "", fmt.Errorf("train start failed: %s", reason)
+	}
+	return sessionID, nil
 }

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -176,6 +176,42 @@ func openAgentFormCmd(deps Deps) tea.Cmd {
 	}
 }
 
+// openAgentOptimizeCmd builds the pre-filled optimize form off the UI thread
+// and pushes it.
+func openAgentOptimizeCmd(deps Deps, agent Agent) tea.Cmd {
+	return func() tea.Msg {
+		form, err := deps.OpenAgentOptimize(agent)
+		if err != nil {
+			return agentActionMsg{verb: "form", err: err}
+		}
+		return PushModelMsg{Model: form}
+	}
+}
+
+// startOptimizeCmd scaffolds and starts the train session from the form's
+// answers.
+func startOptimizeCmd(deps Deps, templateID string, values map[string]string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.StartOptimize == nil {
+			return optimizeStartedMsg{}
+		}
+		sessionID, err := deps.StartOptimize(templateID, values)
+		return optimizeStartedMsg{sessionID: sessionID, err: err}
+	}
+}
+
+// NewAgentOptimizeForm wraps the train-init form for the optimize flow: on
+// completion it pops itself and delivers the answers (bound to the template it
+// was opened for) to the dashboard, which starts the session and opens its
+// phase view.
+func NewAgentOptimizeForm(store PromptStore, templateID string, fields []Field, summary func(map[string]string) [][]string, interpret Interpret) TrainInitModel {
+	form := NewTrainInit(store, fields, summary, interpret, 0)
+	form.Done = func(res Result) tea.Cmd {
+		return PopWith(agentOptimizeFormResultMsg{templateID: templateID, result: res})
+	}
+	return form
+}
+
 func agentCreateCmd(deps Deps, values map[string]string) tea.Cmd {
 	return func() tea.Msg {
 		if deps.CreateAgent == nil {
@@ -284,7 +320,10 @@ func (m Model) agentsContentInteractive() string {
 	if m.agentErr != "" {
 		b.WriteString("\n" + errorStyle.Render(m.agentErr) + "\n")
 	}
-	b.WriteString(mutedStyle.Render("enter detail  n new  D delete"))
+	if m.optimizeBusy {
+		b.WriteString("\n" + mutedStyle.Render("starting optimization…") + "\n")
+	}
+	b.WriteString(mutedStyle.Render("enter detail  n new  o optimize  D delete"))
 	b.WriteByte('\n')
 	return b.String()
 }

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -242,6 +242,110 @@ func TestAgentRevertUnavailableWithoutSuperseded(t *testing.T) {
 	}
 }
 
+func TestAgentOptimizeFlowOpensPhaseView(t *testing.T) {
+	var startedTemplate string
+	var startedValues map[string]string
+	pushedTrain := ""
+	form := NewAgentOptimizeForm(newFakeStore(), "planner-tpl", []Field{{Name: "name", Kind: FieldText}}, nil, nil)
+	deps := Deps{
+		OpenAgentOptimize: func(agent Agent) (tea.Model, error) { return form, nil },
+		StartOptimize: func(templateID string, values map[string]string) (string, error) {
+			startedTemplate = templateID
+			startedValues = values
+			return "train-planner-1", nil
+		},
+		OpenTrain: func(sessionID string) tea.Model {
+			pushedTrain = sessionID
+			return New(Deps{})
+		},
+	}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, cmd := m.Update(key("o"))
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("o should build the optimize form")
+	}
+	if _, ok := cmd().(PushModelMsg); !ok {
+		t.Fatalf("o should push the form, got %T", cmd())
+	}
+	// The popped form delivers its answers; the dashboard starts the session.
+	next, cmd = m.Update(agentOptimizeFormResultMsg{templateID: "planner-tpl", result: Result{Values: map[string]string{
+		"name": "opt-planner", "backend": "claude", "model": "claude-opus-4-8",
+	}}})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("a completed optimize form should start the session")
+	}
+	if !strings.Contains(m.View(), "starting optimization…") {
+		t.Fatalf("the in-flight state should render:\n%s", m.View())
+	}
+	started := cmd()
+	if startedTemplate != "planner-tpl" || startedValues["backend"] != "claude" {
+		t.Fatalf("StartOptimize called with (%q, %v)", startedTemplate, startedValues)
+	}
+	// Success pushes the new session's phase view.
+	next, cmd = m.Update(started)
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("a started session should open its phase view")
+	}
+	var sawPush bool
+	var walk func(tea.Cmd)
+	walk = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				walk(sub)
+			}
+			return
+		}
+		if _, ok := msg.(PushModelMsg); ok {
+			sawPush = true
+		}
+	}
+	walk(cmd)
+	if !sawPush || pushedTrain != "train-planner-1" {
+		t.Fatalf("expected the phase view push for train-planner-1; push=%v opened=%q", sawPush, pushedTrain)
+	}
+	if m.optimizeBusy {
+		t.Fatal("the in-flight flag should clear once the session started")
+	}
+}
+
+func TestAgentOptimizeErrorRendersInline(t *testing.T) {
+	deps := Deps{
+		StartOptimize: func(templateID string, values map[string]string) (string, error) {
+			return "", errors.New("train start failed: no items")
+		},
+	}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, cmd := m.Update(agentOptimizeFormResultMsg{templateID: "planner-tpl", result: Result{Values: map[string]string{"name": "x"}}})
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if !strings.Contains(m.View(), "train start failed: no items") {
+		t.Fatalf("the start error should render on the Agents page:\n%s", m.View())
+	}
+}
+
+func TestAgentOptimizeAbortedFormDoesNothing(t *testing.T) {
+	deps := Deps{
+		StartOptimize: func(templateID string, values map[string]string) (string, error) {
+			t.Fatal("aborted form must not start a session")
+			return "", nil
+		},
+	}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, cmd := m.Update(agentOptimizeFormResultMsg{templateID: "planner-tpl", result: Result{Aborted: true}})
+	_ = next
+	if cmd != nil {
+		t.Fatal("an aborted optimize form must produce no commands")
+	}
+}
+
 func TestAgentCreateFormCompletionPopsWithResult(t *testing.T) {
 	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})
 	var model tea.Model = form

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -154,6 +154,13 @@ type Deps struct {
 	CreateAgent      func(name, runtime, template string) error
 	DeleteAgent      func(name string) error
 	RevertTemplate   func(templateID, versionID string) error
+
+	// Optimize an agent: OpenAgentOptimize builds the pre-filled training form
+	// for the agent's template; StartOptimize scaffolds and starts the train
+	// session from the collected answers and returns its id, which the
+	// dashboard opens via OpenTrain.
+	OpenAgentOptimize func(agent Agent) (tea.Model, error)
+	StartOptimize     func(templateID string, values map[string]string) (string, error)
 }
 
 // TemplateVersion is one row of a template's version history.
@@ -254,4 +261,18 @@ type agentActionMsg struct {
 // create-agent form pops (its Done callback is wired in NewAgentCreateForm).
 type agentFormResultMsg struct {
 	result Result
+}
+
+// agentOptimizeFormResultMsg is delivered when the pushed optimize form pops.
+// It carries the template the form was opened for, so a cursor move between
+// opening and completing the form cannot retarget the session.
+type agentOptimizeFormResultMsg struct {
+	templateID string
+	result     Result
+}
+
+// optimizeStartedMsg carries the outcome of Deps.StartOptimize.
+type optimizeStartedMsg struct {
+	sessionID string
+	err       error
 }

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -108,6 +108,8 @@ type Model struct {
 	versionCursor       int               // selected row in the revert pick list
 	revertVersion       TemplateVersion   // version being confirmed for revert
 	agentErr            string            // inline error on the Agents page (e.g. create failed)
+	optimizeBusy        bool              // a train session is being scaffolded/started
+	formPending         bool              // a form push is in flight; suppress re-dispatch
 }
 
 // New returns a Model ready for tea.NewProgram. It starts in the loading state;
@@ -231,8 +233,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if pages[m.selected].page == pageTrains {
 				// With a Root router, open the full train-run view; otherwise the
 				// inline detail (keeps the model usable standalone and old tests
-				// green).
-				if m.deps.OpenTrain != nil && len(m.snap.Trains) > 0 {
+				// green). Pushing is suppressed while an optimize start is in
+				// flight: its result message routes to the top of the stack, so a
+				// covering view would swallow it.
+				if m.deps.OpenTrain != nil && len(m.snap.Trains) > 0 && !m.optimizeBusy {
 					session := m.snap.Trains[m.trainCursor].ID
 					return m, Push(m.deps.OpenTrain(session))
 				}
@@ -282,7 +286,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "n":
 			// Form construction touches the database, so it runs as a command
 			// (a synchronous call here would freeze the UI on a busy store).
-			if pages[m.selected].page == pageAgents && m.deps.OpenAgentCreate != nil {
+			if pages[m.selected].page == pageAgents && m.deps.OpenAgentCreate != nil &&
+				!m.formPending && !m.optimizeBusy {
+				m.formPending = true
 				m.agentErr = ""
 				return m, openAgentFormCmd(m.deps)
 			}
@@ -291,6 +297,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.openAgentDelete(agent)
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
+			}
+		case "o":
+			if agent, ok := m.agentUnderCursor(); ok && agent.TemplateID != "" &&
+				m.deps.OpenAgentOptimize != nil && !m.formPending && !m.optimizeBusy {
+				m.formPending = true
+				m.activeAgent = agent
+				m.agentErr = ""
+				return m, openAgentOptimizeCmd(m.deps, agent)
 			}
 		case "?":
 			m.showHelp = !m.showHelp
@@ -422,11 +436,35 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.agentErr = ""
 			cmds = append(cmds, agentCreateCmd(m.deps, msg.result.Values))
 		}
+	case agentOptimizeFormResultMsg:
+		m.formPending = false
+		if !msg.result.Aborted {
+			m.agentErr = ""
+			m.optimizeBusy = true
+			cmds = append(cmds, startOptimizeCmd(m.deps, msg.templateID, msg.result.Values))
+		}
+	case optimizeStartedMsg:
+		m.optimizeBusy = false
+		if msg.err != nil {
+			m.agentErr = msg.err.Error()
+		} else {
+			m.agentErr = ""
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			// Straight into the new session's live phase view.
+			if m.deps.OpenTrain != nil && msg.sessionID != "" {
+				cmds = append(cmds, Push(m.deps.OpenTrain(msg.sessionID)))
+			}
+		}
 	case agentActionMsg:
 		switch msg.verb {
 		case "create", "form":
 			// No overlay is open by the time a create (or a failed form
 			// construction) settles; surface errors inline on the Agents page.
+			if msg.verb == "form" {
+				m.formPending = false
+			}
 			if msg.err != nil {
 				m.agentErr = msg.err.Error()
 			} else {
@@ -525,6 +563,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Resumed after a pop: the old tick chain died unhandled under the child
 		// view, so refresh now and start a NEW chain. Bumping the generation also
 		// kills a stale pre-push tick that would otherwise re-arm a second chain.
+		// A pop also means any pushed form is gone.
+		m.formPending = false
 		m.tickGen++
 		if cmd := m.queueLoad(); cmd != nil {
 			cmds = append(cmds, cmd)

--- a/internal/cli/tui/traininit.go
+++ b/internal/cli/tui/traininit.go
@@ -222,7 +222,11 @@ func (m TrainInitModel) updateFieldKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if msg.String() == "enter" {
 			value, status := m.validate(field.Name, m.input.Value())
 			if status != "ok" {
-				m.inlineErr = "value required"
+				if strings.TrimSpace(m.input.Value()) != "" {
+					m.inlineErr = "invalid value — check the expected format"
+				} else {
+					m.inlineErr = "value required"
+				}
 				return m, nil
 			}
 			if field.CheckRepo != nil {

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -139,6 +139,8 @@ func (m Model) helpContent() string {
 		b.WriteString("↑/↓  select an agent\n")
 		b.WriteString("enter open the agent (template, recent jobs, versions)\n")
 		b.WriteString("n    register a new agent (name, runtime, template)\n")
+		b.WriteString("o    optimize: start a training session for the agent's template\n")
+		b.WriteString("     (asks repos, request, codex/claude backend, optional model)\n")
 		b.WriteString("D    delete the selected agent (refused while jobs reference it)\n")
 		b.WriteString("v    in the detail: revert the template to a previous version\n")
 	case pageJobs:
@@ -192,7 +194,7 @@ func (m Model) footerHelp() string {
 	case pageTrains:
 		return "tab/←→ page  ↑/↓ select  enter open  s stop  d delete  ? help  q quit"
 	case pageAgents:
-		return "tab/←→ page  ↑/↓ select  enter detail  n new  D delete  ? help  q quit"
+		return "tab/←→ page  ↑/↓ select  enter detail  n new  o optimize  D delete  ? help  q quit"
 	case pageJobs:
 		return "tab/←→ page  ↑/↓ select  enter detail  R retry  c cancel  ? help  q quit"
 	}

--- a/internal/skillopt/train_init.go
+++ b/internal/skillopt/train_init.go
@@ -68,6 +68,8 @@ type TrainInitOptimizerConfig struct {
 	OptimizerBackend          string
 	TargetBackend             string
 	EvaluatorBackend          string
+	OptimizerModel            string
+	TargetModel               string
 	InternalTargetAdapter     string
 }
 
@@ -194,6 +196,8 @@ func RenderTrainInitConfig(config TrainInitConfig) ([]byte, error) {
 	writeTrainInitString(&b, "optimizer_backend", config.Optimizer.OptimizerBackend)
 	writeTrainInitString(&b, "target_backend", config.Optimizer.TargetBackend)
 	writeTrainInitString(&b, "evaluator_backend", config.Optimizer.EvaluatorBackend)
+	writeTrainInitString(&b, "optimizer_model", config.Optimizer.OptimizerModel)
+	writeTrainInitString(&b, "target_model", config.Optimizer.TargetModel)
 	writeTrainInitString(&b, "internal_target_adapter", config.Optimizer.InternalTargetAdapter)
 	b.WriteString("\n[final_evaluator]\n")
 	writeTrainInitBool(&b, "enabled", config.FinalEvaluatorEnabled)
@@ -300,6 +304,12 @@ func ParseTrainInitConfig(content []byte) (TrainInitConfig, error) {
 	}
 	if value := getString("optimizer.evaluator_backend", false); value != "" {
 		config.Optimizer.EvaluatorBackend = value
+	}
+	if value := getString("optimizer.optimizer_model", false); value != "" {
+		config.Optimizer.OptimizerModel = value
+	}
+	if value := getString("optimizer.target_model", false); value != "" {
+		config.Optimizer.TargetModel = value
 	}
 	if value := getString("optimizer.internal_target_adapter", false); value != "" {
 		config.Optimizer.InternalTargetAdapter = value


### PR DESCRIPTION
## WHAT
Task 8 of the dashboard-cockpit plan (#243): `o` on an agent starts a full training session for its template — pre-filled form, codex/claude backend pick, optional model override — and drops straight into the live phase view.

## WHY
Starting a training run required hand-assembling `skillopt train init` + `skillopt train start` commands; there was no way to choose the optimizer backend/model without memorizing flags, and the choices were not persisted for `train continue`.

## CHANGES
- **`o` on the Agents page** pushes a train-init form pre-filled with the agent's template (template question skipped). Fields: name, review repo, workspace repo, artifact kind, preview, request, backend (codex/claude choice), model (optional text). Name validity and owner/repo shape are validated inside the form, so a typo re-asks instead of failing the whole pipeline after the form closed.
- **On confirm** the dashboard scaffolds the train-init config — the backend lands in the scaffold's `[optimizer]` section (a claude pick also drops the contradictory `codex_exec` adapter default), the model in the new `optimizer_model`/`target_model` keys — and runs the existing `skillopt train start --config --session --workspace-repo --create-repos --yes` pipeline headlessly with a pre-generated session id, then pushes that session's phase view. An existing scaffold with the same name is refused, never clobbered. Repos created via `--create-repos` are recorded against the session, so Task 6's delete flow offers their cleanup later.
- **Persistence round-trip**: the `optimizer_defaults` metadata writer/reader gain `optimizer_model`/`target_model`. `train continue` inherits them when flags are absent — but only when the backends are inherited too, since model names are backend-specific (an explicit `--backend codex` no longer pairs with a stored claude model).
- **Hardening**: the form result carries the template it was opened for (cursor moves can't retarget the session); `n`/`o` are double-dispatch-guarded; stack pushes are suppressed while a start is in flight (the result message routes to the stack top); the form prompt store routes upserts/deletes through per-call opens so abort-time prompt cleanup can't race the held store's close; only train start's stderr becomes the inline error; the form's generic "value required" now distinguishes invalid-format input.

## RESULTS
- `go test ./internal/cli/tui ./internal/skillopt` green; cli suites green (full run: only the known pre-existing flake `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos`). vet/gofmt clean.
- New tests: the form skips the template question; model optional / name+repo validated in interpret; **end-to-end with a real store + fake GitHub**: `startAgentOptimizeSession` persists `optimizer_backend/target_backend/evaluator_backend/optimizer_model/target_model` in the session's `optimizer_defaults`, the continue path picks them up when flags are absent AND explicit flags win, and both created repos are recorded against the session; full o→push→result→StartOptimize→phase-view navigation with fake deps; in-flight state renders; error renders inline; aborted form produces no commands.

## REVIEW
High-effort multi-angle review run; fixed (this PR): model-inherited-despite-backend-override, scaffold clobbering, activeAgent retargeting, double-push, swallowed in-flight result, prompt-delete/store-close race, stale codex_exec adapter in claude scaffolds, transcript-as-error, parallel field-name list, derivable format param, dead normalize call, weak abort test. Known accepted: `startAgentOptimizeSession` mirrors `runSkillOptTrainInitCreate`'s config-assembly tail (consolidation queued with the overlay-helper unification for Task 9); fixed prompt-id scope collides across concurrent dashboards (same tradeoff as the create form and the standalone wizard); scaffolds are written under the dashboard's CWD like the CLI's.

## RISK
The metadata reader change is guarded additively (new keys only inherited when no backend was given); the TOML writer adds two keys that old parsers ignore. The headless pipeline is the same code path the CLI exercises, driven with explicit flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)