### PR TITLE
cli: dashboard cockpit polish and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,22 @@ gitmoot agent prompt release-planner
 Installed custom templates are snapshots. After editing the source file, run
 `gitmoot agent template diff <id>` and `gitmoot agent template update <id>`.
 
+### Dashboard Cockpit
+
+On a terminal, `gitmoot dashboard` opens an interactive TUI that can act on
+everything it shows: answer prompts and retry blocked/failed jobs from the
+Attention page (plus `s` to restart a stopped daemon), open/stop/delete train
+sessions (with optional cleanup of GitHub repos gitmoot created for them),
+create/delete agents, revert a template to a previous version, start a training
+run for an agent with a codex/claude backend pick (`o`), and cancel queued or
+running jobs. Press `?` on any page for its keys. Piped/`--plain`/`--json`
+output is unchanged and script-stable.
+
+```sh
+gitmoot dashboard           # interactive cockpit
+gitmoot dashboard --json    # one-shot snapshot for scripts
+```
+
 ### Jobs, Locks, And Recovery
 
 ```sh
@@ -275,6 +291,8 @@ gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
 gitmoot job list --repo owner/repo
 gitmoot job show <job-id>
+gitmoot job retry <job-id>
+gitmoot job cancel <job-id>
 gitmoot daemon logs
 gitmoot lock list --repo owner/repo
 gitmoot lock release owner/repo <branch> --owner <agent>

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -23,16 +23,19 @@ const (
 	pageLocks
 )
 
+// label is the (short) sidebar entry; title is the page heading. The sidebar
+// is 10-14 columns wide, so labels must stay short or they wrap.
 var pages = []struct {
 	page  page
 	label string
+	title string
 }{
-	{pageAttention, "Attention"},
-	{pageTrains, "Trains"},
-	{pageAgents, "Agents"},
-	{pageSessions, "Sessions"},
-	{pageJobs, "Jobs"},
-	{pageLocks, "Locks"},
+	{pageAttention, "Attention", "Attention"},
+	{pageTrains, "Trains", "Trains"},
+	{pageAgents, "Agents", "Agents"},
+	{pageSessions, "Sessions", "Runtime sessions"},
+	{pageJobs, "Jobs", "Jobs"},
+	{pageLocks, "Locks", "Locks"},
 }
 
 // mode is the interaction mode; modeNormal navigates pages, the others are

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -63,7 +64,7 @@ func (m Model) content() string {
 		return m.helpContent()
 	}
 	var b strings.Builder
-	b.WriteString(titleStyle.Render(pages[m.selected].label))
+	b.WriteString(titleStyle.Render(pages[m.selected].title))
 	if !m.loadedAt.IsZero() {
 		b.WriteString("  ")
 		b.WriteString(mutedStyle.Render("updated " + m.loadedAt.Format("15:04:05")))
@@ -119,7 +120,7 @@ func (m Model) content() string {
 // helpContent is the '?' overlay: every key for the current page plus globals.
 func (m Model) helpContent() string {
 	var b strings.Builder
-	b.WriteString(titleStyle.Render("Help — " + pages[m.selected].label))
+	b.WriteString(titleStyle.Render("Help — " + pages[m.selected].title))
 	b.WriteString("\n\n")
 	switch pages[m.selected].page {
 	case pageAttention:
@@ -209,10 +210,13 @@ func (m Model) loadingOr(empty string, loaded bool) string {
 }
 
 func (m Model) sessionsContent() string {
-	if len(m.snap.Sessions) == 0 {
-		return m.loadingOr("No runtime sessions.", !m.loadedAt.IsZero())
-	}
 	var b strings.Builder
+	b.WriteString(mutedStyle.Render("Long-lived codex/claude processes gitmoot keeps warm to run jobs; idle ones expire on their own."))
+	b.WriteString("\n\n")
+	if len(m.snap.Sessions) == 0 {
+		b.WriteString(m.loadingOr("No runtime sessions.", !m.loadedAt.IsZero()))
+		return b.String()
+	}
 	for _, line := range groupedSessions(m.snap.Sessions) {
 		b.WriteString(line)
 		b.WriteByte('\n')
@@ -221,10 +225,37 @@ func (m Model) sessionsContent() string {
 }
 
 func (m Model) locksContent() string {
-	if len(m.snap.BranchLocks) == 0 && len(m.snap.ResourceLocks) == 0 {
-		return m.loadingOr("No active locks.", !m.loadedAt.IsZero())
-	}
 	var b strings.Builder
+	b.WriteString(mutedStyle.Render("Locks serialize work: branch locks guard implementation branches, resource locks guard checkouts/sessions/train steps."))
+	b.WriteString("\n\n")
+	if len(m.snap.BranchLocks) == 0 && len(m.snap.ResourceLocks) == 0 {
+		b.WriteString(m.loadingOr("No active locks.", !m.loadedAt.IsZero()))
+		return b.String()
+	}
+
+	// Stale resource locks first — they explain stalled work.
+	stale := staleLocks(m.snap.ResourceLocks)
+	active := len(m.snap.ResourceLocks) - len(stale)
+	b.WriteString(headerStyle.Render("resource locks"))
+	b.WriteByte('\n')
+	if len(stale) > 0 {
+		for _, l := range stale {
+			b.WriteString(redStyle.Render("stale  "+l.Key) + "  " + mutedStyle.Render(dash(l.Owner)))
+			b.WriteByte('\n')
+		}
+		b.WriteString(mutedStyle.Render("stale = the owning process died; the daemon reclaims these on its own once it runs"))
+		b.WriteByte('\n')
+	}
+	switch {
+	case active == 0 && len(stale) == 0:
+		b.WriteString(mutedStyle.Render("none"))
+		b.WriteByte('\n')
+	case active > 0:
+		b.WriteString(mutedStyle.Render(strconv.Itoa(active) + " active (held by running work; they release on their own)"))
+		b.WriteByte('\n')
+	}
+
+	b.WriteByte('\n')
 	b.WriteString(headerStyle.Render("branch locks"))
 	b.WriteByte('\n')
 	if len(m.snap.BranchLocks) == 0 {
@@ -234,23 +265,6 @@ func (m Model) locksContent() string {
 		rows := [][]string{{"REPO", "BRANCH", "OWNER"}}
 		for _, l := range m.snap.BranchLocks {
 			rows = append(rows, []string{l.Repo, l.Branch, dash(l.Owner)})
-		}
-		b.WriteString(renderRows(rows))
-	}
-	b.WriteByte('\n')
-	b.WriteString(headerStyle.Render("resource locks"))
-	b.WriteByte('\n')
-	if len(m.snap.ResourceLocks) == 0 {
-		b.WriteString(mutedStyle.Render("none"))
-		b.WriteByte('\n')
-	} else {
-		rows := [][]string{{"KEY", "OWNER", "STATE"}}
-		for _, l := range m.snap.ResourceLocks {
-			state := "active"
-			if l.Stale {
-				state = redStyle.Render("stale")
-			}
-			rows = append(rows, []string{l.Key, dash(l.Owner), state})
 		}
 		b.WriteString(renderRows(rows))
 	}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -65,12 +65,46 @@ and pending interactive prompts.
 
 On a real terminal (stdin and stdout both a TTY) and with no other output/mutation
 flag, `gitmoot dashboard` launches an **interactive TUI**: a sidebar of pages
-(Attention, Trains, Agents, Sessions, Jobs, Locks) that auto-refreshes. Navigate
-with `tab`/`shift+tab` or `←/→`; on the Attention page select a pending prompt
-with `↑/↓` and `a` to answer it inline (a choice list or a text field) or `d` to
-dismiss it; on the Trains page `enter` opens a per-session detail with its locks;
-`r` refreshes, `q` quits. Inline answers/dismissals use the same store APIs as
-`gitmoot interactive answer` / `clear`.
+(Attention, Trains, Agents, Runtime sessions, Jobs, Locks) that auto-refreshes.
+Navigate with `tab`/`shift+tab` or `←/→`; `↑/↓` selects a row; `?` opens a
+per-page key reference; `r` refreshes, `q` quits. The TUI is the cockpit — every
+page can act, and each action runs the same store/workflow code as its CLI
+equivalent:
+
+- **Attention** lists pending prompts (`a` answer inline, `d` dismiss) and the
+  actual blocked/failed jobs with their latest event message (`enter` detail,
+  `R` retry). A red banner appears when the daemon is stopped; `s` restarts it
+  with its previously persisted flags.
+- **Trains** lists every train session: `enter` opens ANY session's live phase
+  view (not just the newest), `s` stops a live session (a reason is required;
+  same path as `skillopt train stop`), `d` deletes a finished session and its
+  history — and, if gitmoot created GitHub repos for that session, a second
+  confirm offers to delete those too (never offered for repos gitmoot did not
+  create; a missing `delete_repo` token scope shows its `gh auth refresh`
+  remedy and can be retried in place).
+- **Agents** lists registered agents: `enter` opens a detail with the template,
+  recent jobs, and the template's version history; `n` registers a new agent
+  (name, codex/claude runtime, installed template); `o` starts a training
+  session for the agent's template via a pre-filled form (review/workspace
+  repos, request, codex/claude backend, optional model — the backend/model are
+  stored in the session's optimizer defaults so `train continue` inherits
+  them), then drops into the live phase view; `D` deletes the agent (refused
+  while jobs reference it); `v` in the detail reverts the template to a
+  previous version (same as `gitmoot agent template revert`).
+- **Jobs** lists every job with a state summary: `enter` shows the event
+  history, `R` retries failed/blocked/cancelled jobs (same path as
+  `gitmoot job retry`), `c` cancels queued AND running jobs (same as
+  `gitmoot job cancel`; running ones show `cancelling…` until the daemon
+  settles them).
+- **Locks** explains and lists locks, stale resource locks first in red (the
+  owning process died; a running daemon reclaims them automatically); active
+  locks collapse to a count. Branch locks are released with
+  `gitmoot lock release owner/repo <branch> --owner <agent>`.
+
+Form questions are also published as interactive prompt records, so an agent can
+answer them with `gitmoot interactive answer` while the form is open. Inline
+answers/dismissals use the same store APIs as `gitmoot interactive answer` /
+`clear`.
 
 Everywhere else — pipes, redirects, CI, `--plain`, `--json`, `--all`, `--watch`,
 `--answer`, `--dismiss` — it prints the one-shot snapshot instead, unchanged. Set
@@ -246,6 +280,10 @@ Template updates are versioned locally. `gitmoot agent template show <id>`
 prints the current version, content hash, source commit, and promotion state.
 Agents use the current promoted version by default, or a pinned version when
 configured with a reference such as `--template frontend-reviewer@v1`.
+
+A bad promotion can be undone: `gitmoot agent template revert <template-id>
+--version <version-id>` makes a superseded version current again (the dashboard's
+Agents page does the same with `v` in the agent detail).
 Queued jobs keep the exact template content snapshot they were created with.
 
 Discover templates by metadata:


### PR DESCRIPTION
## WHAT
Task 9 of the dashboard-cockpit plan (#243): naming/explanations polish and the documentation pass.

## WHY
"Sessions" and "Locks" confused the operator (the original complaint behind #243); the cockpit's new actions were undocumented.

## CHANGES
- Sessions page titled "Runtime sessions" with a one-line explainer (sidebar keeps the short label — the long one word-wraps the 10–14 column sidebar).
- Locks page: explainer line, stale resource locks first in red, active collapsed to a count, branch locks after. Review caught that the drafted "recover with `gitmoot lock release <key>`" hint documented a nonexistent command (resource locks have no release-by-key CLI; the daemon auto-reclaims expired ones) — the shipped note says that instead.
- README: Dashboard Cockpit section; `job retry`/`job cancel` added to the jobs block.
- skills/gitmoot/references/CLI.md: the TUI section documents every page's actions (attention rows + daemon `s`, train stop/delete + recorded-repo cleanup with the `delete_repo` scope remedy, agent create/optimize/delete/revert, job retry/cancel incl. running-job cancellation), plus `agent template revert`.

## RESULTS
`go test ./internal/cli/tui` green; vet/gofmt clean. Plain/`--json` outputs untouched (changes are TUI strings + docs).

## REVIEW
Focused review run; fixed: the nonexistent lock-release hint (TUI + doc), the sidebar wrap, and the Locks explainer being skipped on the empty page.

## RISK
Strings and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)