### PR TITLE
cli: reset the in-flight load latch when the dashboard resumes from a pop

### DIFF
--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -566,8 +566,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Resumed after a pop: the old tick chain died unhandled under the child
 		// view, so refresh now and start a NEW chain. Bumping the generation also
 		// kills a stale pre-push tick that would otherwise re-arm a second chain.
-		// A pop also means any pushed form is gone.
+		// A pop also means any pushed form is gone — and any snapshot load that
+		// was in flight when the push happened had its result routed to the
+		// covering view and dropped, so the in-flight latch must reset or
+		// queueLoad would suppress every future refresh.
 		m.formPending = false
+		m.inFlight = false
 		m.tickGen++
 		if cmd := m.queueLoad(); cmd != nil {
 			cmds = append(cmds, cmd)

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -161,6 +161,23 @@ func TestTickRearmsAndRefreshes(t *testing.T) {
 	}
 }
 
+func TestPopNudgeResetsInFlightLoad(t *testing.T) {
+	m := loadedModel(t)
+	// A load dispatched just before a push has its snapshotMsg routed to the
+	// covering view and dropped; the latch must not survive the pop.
+	if cmd := m.queueLoad(); cmd == nil {
+		t.Fatal("first queueLoad should start a load")
+	}
+	next, cmd := m.Update(refreshNudgeMsg{})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("the pop nudge should refresh despite the swallowed in-flight load")
+	}
+	if m.inFlight != true {
+		t.Fatal("the nudge's own load should now be in flight")
+	}
+}
+
 func TestStaleTickGenerationDropped(t *testing.T) {
 	m := loadedModel(t)
 	// A pop-nudge starts a new tick generation…


### PR DESCRIPTION
## WHAT
Task 10 hand-testing fix: the dashboard could freeze permanently after pushing a child view.

## WHY
A snapshot load dispatched just before a push (e.g. the optimize flow opening the new session's phase view while a refresh tick's load was in flight) had its `snapshotMsg` routed to the covering view and dropped. The `inFlight` latch never cleared, so every later tick and manual `r` was suppressed — observed live: the Trains list froze at a stale timestamp and never showed the just-created session.

## CHANGES
The pop nudge (`refreshNudgeMsg`) now resets `inFlight` alongside the tick generation, so the resumed dashboard always reloads. Regression test: queueLoad latched + nudge → the nudge's reload fires.

## RESULTS
`go test ./internal/cli/tui` green; verified live in the herdr hand test (restarted dashboard refreshes correctly through the full optimize→phase-view→pop cycle).

## RISK
One-line state reset on a path that already restarts the tick chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)