### PR TITLE
cli: gate train-run action keys on the iteration phase

### DIFF
--- a/internal/cli/skillopt_trainrun_tui.go
+++ b/internal/cli/skillopt_trainrun_tui.go
@@ -422,6 +422,7 @@ func toTrainRunSnapshot(s skillOptTrainStatusSnapshot) tui.TrainRunSnapshot {
 		ReviewRepo:        strings.TrimSpace(s.TargetRepo),
 		WorkspaceRepo:     strings.TrimSpace(s.WorkspaceRepo),
 		Phase:             s.StatusPhase,
+		ActionPhase:       s.CurrentPhase,
 		NextAction:        s.NextAction,
 		IssueURL:          skillOptTrainContinueFromGitHubURL(s.CurrentPhase, s.IssueURL),
 		CandidateVersion:  s.CandidateVersion,

--- a/internal/cli/tui/trainrun.go
+++ b/internal/cli/tui/trainrun.go
@@ -16,7 +16,8 @@ type TrainRunSnapshot struct {
 	Template          string // "<id>@<version>"
 	ReviewRepo        string
 	WorkspaceRepo     string
-	Phase             string // lock-aware stable status phase
+	Phase             string // lock-aware stable status phase (display)
+	ActionPhase       string // iteration phase gating the action keys; falls back to Phase when empty
 	NextAction        string
 	IssueURL          string // review issue (or candidate review issue) URL
 	CandidateVersion  string
@@ -350,7 +351,7 @@ func (m TrainRunModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	switch msg.String() {
 	case "enter":
-		switch m.snap.Phase {
+		switch m.actionPhase() {
 		case "items_ready", "feedback_synced", "training_package_created":
 			m.actionBusy, m.actionErr = true, ""
 			return m, spawnCmd(m.deps)
@@ -359,12 +360,12 @@ func (m TrainRunModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, continueCmd(m.deps)
 		}
 	case "p":
-		if m.snap.Phase == "candidate_review_published" {
+		if m.actionPhase() == "candidate_review_published" {
 			m.actionBusy, m.actionErr = true, ""
 			return m, decideCmd(m.deps, true, m.snap.CandidateVersion, "")
 		}
 	case "x":
-		if m.snap.Phase == "candidate_review_published" {
+		if m.actionPhase() == "candidate_review_published" {
 			m.mode = trainModeReject
 			m.actionErr = ""
 			ti := textinput.New()
@@ -379,6 +380,17 @@ func (m TrainRunModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+// actionPhase is the phase the action keys gate on: the iteration phase when
+// the snapshot carries it, else the display phase (they coincide outside the
+// post-optimizer stretch, where the display phase stays
+// "optimizer_completed_candidate" while the iteration advances).
+func (m TrainRunModel) actionPhase() string {
+	if strings.TrimSpace(m.snap.ActionPhase) != "" {
+		return m.snap.ActionPhase
+	}
+	return m.snap.Phase
 }
 
 func continueCmd(d TrainRunDeps) tea.Cmd {

--- a/internal/cli/tui/trainrun_test.go
+++ b/internal/cli/tui/trainrun_test.go
@@ -192,6 +192,39 @@ func TestTrainRunPromote(t *testing.T) {
 	}
 }
 
+func TestTrainRunActionsGateOnIterationPhase(t *testing.T) {
+	// Post-optimizer, the display phase stays "optimizer_completed_candidate"
+	// while the iteration phase advances; the action keys must follow the
+	// iteration phase or p/x/enter go dead exactly when a human is needed.
+	snap := TrainRunSnapshot{
+		SessionID:        "s",
+		Phase:            "optimizer_completed_candidate",
+		ActionPhase:      "candidate_review_published",
+		CandidateVersion: "c@v2",
+	}
+	var gotPromote bool
+	deps := TrainRunDeps{
+		Load: func() (TrainRunSnapshot, error) { return snap, nil },
+		Decide: func(promote bool, candidate, reason string) (TrainRunActionResult, error) {
+			gotPromote = promote
+			return TrainRunActionResult{}, nil
+		},
+	}
+	m := trainRunModelWithDeps(t, deps, snap)
+	if !strings.Contains(m.View(), "p promote") {
+		t.Fatalf("footer should offer promote/reject:\n%s", m.View())
+	}
+	next, cmd := m.Update(key("p"))
+	m = next.(TrainRunModel)
+	if cmd == nil {
+		t.Fatal("p should promote when the iteration phase is candidate_review_published")
+	}
+	cmd()
+	if !gotPromote {
+		t.Fatal("Decide(promote) should have been called")
+	}
+}
+
 func TestTrainRunRejectRequiresReason(t *testing.T) {
 	var gotReason string
 	decided := false

--- a/internal/cli/tui/trainrun_view.go
+++ b/internal/cli/tui/trainrun_view.go
@@ -84,7 +84,7 @@ func (m TrainRunModel) footer() string {
 		return "working…  q quit"
 	}
 	action := ""
-	switch m.snap.Phase {
+	switch m.actionPhase() {
 	case "items_ready", "feedback_synced", "training_package_created":
 		action = "enter generate  "
 	case "options_generated":


### PR DESCRIPTION
## WHAT
Fixes the train-run phase view's action keys (enter/p/x) going dead after the optimizer completes.

## WHY
Observed live: a session reached `candidate_review_published` but the phase view footer only offered `r refresh  q quit` — no promote/reject. The keys were gated on the *display* phase (`StatusPhase`), which stays `optimizer_completed_candidate` post-optimizer while the *iteration* phase advances. Every post-optimizer human action was unreachable from the TUI.

## CHANGES
`TrainRunSnapshot` gains `ActionPhase` (mapped from `CurrentPhase`); the key gating and footer hints use it, falling back to the display phase when empty (standalone use and existing fixtures unchanged).

## RESULTS
`go test ./internal/cli/tui ./internal/cli -run TrainRun` green. New regression test: display phase `optimizer_completed_candidate` + iteration phase `candidate_review_published` → footer offers promote and `p` fires Decide.

## RISK
One additive snapshot field; gating falls back to the previous behavior when the field is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)