### PR TITLE
cli: fix post-promote keys and show the GitHub decision link

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -6976,6 +6976,12 @@ func buildSkillOptTrainStatusVerbose(ctx context.Context, store *db.Store, sessi
 		NoCandidateReason:  metadataString(candidateImport, "no_candidate_reason"),
 		NoCandidateDetails: decodedSkillOptMetadataValue(candidateImport["no_candidate_details"]),
 	}
+	if details.Candidate.PullRequestURL == "" {
+		// Issue-based candidate reviews never set iteration.PullRequestURL; the
+		// decision link lives in the candidate_review metadata instead.
+		review := decodedSkillOptMetadataValue(iterationMetadata["candidate_review"])
+		details.Candidate.PullRequestURL = skillOptCandidateReviewURLFromMetadata(review)
+	}
 	if optimizer := decodedSkillOptMetadataValue(iterationMetadata["optimizer"]); len(optimizer) > 0 {
 		candidateImport := decodedSkillOptMetadataValue(iterationMetadata["candidate_import"])
 		if attemptState := skillOptTrainOptimizerAttemptState(skillopt.NormalizeTrainState(iteration.State), optimizer, candidateImport); attemptState != "" {

--- a/internal/cli/skillopt_trainrun_tui.go
+++ b/internal/cli/skillopt_trainrun_tui.go
@@ -431,15 +431,33 @@ func toTrainRunSnapshot(s skillOptTrainStatusSnapshot) tui.TrainRunSnapshot {
 		FeedbackCount:     s.Counts.FeedbackEvents + s.Counts.RankedFeedbackEvents,
 		GeneratedOptions:  s.Progress.GeneratedOptions,
 		ETA:               s.Progress.ETA,
-		Terminal:          skillOptTrainRunTerminalPhase(s.StatusPhase),
+		// The iteration phase decides terminality: post-optimizer the display
+		// phase stays "optimizer_completed_candidate" even once the iteration
+		// is promoted/rejected (the #254 family of bugs). A lock-active display
+		// phase suppresses it: a session stopped while a detached worker still
+		// holds a lock is not actionable until the worker settles.
+		Terminal: skillOptTrainRunTerminalPhase(firstNonEmpty(s.CurrentPhase, s.StatusPhase)) &&
+			!skillOptTrainRunLockActivePhase(s.StatusPhase),
 	}
 	if s.Verbose != nil {
+		out.CandidateReviewURL = strings.TrimSpace(s.Verbose.Candidate.PullRequestURL)
 		out.Elapsed = s.Verbose.Elapsed
 		out.JobsRunning = s.Verbose.Jobs.Running
 		out.JobsSucceeded = s.Verbose.Jobs.Succeeded
 		out.JobsFailed = s.Verbose.Jobs.Failed
 	}
 	return out
+}
+
+// skillOptTrainRunLockActivePhase reports whether the display phase is derived
+// from a live resource lock (a detached worker is still running).
+func skillOptTrainRunLockActivePhase(phase string) bool {
+	switch phase {
+	case "generating_options", "generating_options_heartbeat_stale", "optimizer_running", "optimizer_heartbeat_stale":
+		return true
+	default:
+		return false
+	}
 }
 
 func skillOptTrainRunTerminalPhase(phase string) bool {

--- a/internal/cli/skillopt_trainrun_tui_test.go
+++ b/internal/cli/skillopt_trainrun_tui_test.go
@@ -236,6 +236,31 @@ func TestTailSkillOptTrainLog(t *testing.T) {
 	}
 }
 
+func TestToTrainRunSnapshotPostOptimizerTerminalAndDecisionURL(t *testing.T) {
+	// Post-optimizer the display phase stays "optimizer_completed_candidate";
+	// terminality and the decision link must follow the iteration phase.
+	snap := skillOptTrainStatusSnapshot{
+		SessionID:    "s1",
+		StatusPhase:  "optimizer_completed_candidate",
+		CurrentPhase: "candidate_promoted",
+		Verbose: &skillOptTrainStatusVerbose{
+			Candidate: skillOptTrainStatusCandidate{PullRequestURL: "https://github.com/o/r/issues/7#issuecomment-1"},
+		},
+	}
+	out := toTrainRunSnapshot(snap)
+	if !out.Terminal {
+		t.Fatalf("promoted iteration must be terminal: %+v", out)
+	}
+	if out.CandidateReviewURL != "https://github.com/o/r/issues/7#issuecomment-1" {
+		t.Fatalf("candidate review URL not mapped: %+v", out)
+	}
+	// Without verbose details the URL is simply absent.
+	snap.Verbose = nil
+	if out := toTrainRunSnapshot(snap); out.CandidateReviewURL != "" || !out.Terminal {
+		t.Fatalf("non-verbose mapping wrong: %+v", out)
+	}
+}
+
 func TestToTrainRunSnapshot(t *testing.T) {
 	snap := skillOptTrainStatusSnapshot{
 		SessionID:       "s1",

--- a/internal/cli/tui/trainrun.go
+++ b/internal/cli/tui/trainrun.go
@@ -11,26 +11,27 @@ import (
 // TrainRunSnapshot is the TUI-facing view of one train session's live state,
 // adapted by the cli from the skillopt status snapshot.
 type TrainRunSnapshot struct {
-	SessionID         string
-	IterationID       string
-	Template          string // "<id>@<version>"
-	ReviewRepo        string
-	WorkspaceRepo     string
-	Phase             string // lock-aware stable status phase (display)
-	ActionPhase       string // iteration phase gating the action keys; falls back to Phase when empty
-	NextAction        string
-	IssueURL          string // review issue (or candidate review issue) URL
-	CandidateVersion  string
-	NoCandidateReason string
-	FeedbackCount     int
-	ReviewItems       int
-	GeneratedOptions  int
-	JobsRunning       int
-	JobsSucceeded     int
-	JobsFailed        int
-	ETA               string
-	Elapsed           string
-	Terminal          bool
+	SessionID          string
+	IterationID        string
+	Template           string // "<id>@<version>"
+	ReviewRepo         string
+	WorkspaceRepo      string
+	Phase              string // lock-aware stable status phase (display)
+	ActionPhase        string // iteration phase gating the action keys; falls back to Phase when empty
+	NextAction         string
+	IssueURL           string // review issue (or candidate review issue) URL
+	CandidateVersion   string
+	CandidateReviewURL string // GitHub comment/issue where the promote/reject decision can also be made
+	NoCandidateReason  string
+	FeedbackCount      int
+	ReviewItems        int
+	GeneratedOptions   int
+	JobsRunning        int
+	JobsSucceeded      int
+	JobsFailed         int
+	ETA                string
+	Elapsed            string
+	Terminal           bool
 }
 
 // TrainRunActionResult carries the output lines from a short in-process phase

--- a/internal/cli/tui/trainrun_test.go
+++ b/internal/cli/tui/trainrun_test.go
@@ -225,6 +225,57 @@ func TestTrainRunActionsGateOnIterationPhase(t *testing.T) {
 	}
 }
 
+func TestTrainRunTerminalKeysAndDecisionLinkPostOptimizer(t *testing.T) {
+	// Display phase stuck at optimizer_completed_candidate, iteration promoted:
+	// the terminal screen must offer n and show the candidate review link.
+	snap := TrainRunSnapshot{
+		SessionID:          "s",
+		Phase:              "optimizer_completed_candidate",
+		ActionPhase:        "candidate_promoted",
+		Terminal:           true,
+		CandidateVersion:   "c@v2",
+		CandidateReviewURL: "https://github.com/o/r/issues/7#issuecomment-1",
+	}
+	started := false
+	deps := TrainRunDeps{
+		Load:      func() (TrainRunSnapshot, error) { return snap, nil },
+		StartNext: func() (TrainRunActionResult, error) { started = true; return TrainRunActionResult{}, nil },
+	}
+	m := trainRunModelWithDeps(t, deps, snap)
+	view := m.View()
+	for _, want := range []string{"n start next iteration", "candidate review: https://github.com/o/r/issues/7#issuecomment-1", "promoted"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("terminal view missing %q:\n%s", want, view)
+		}
+	}
+	next, cmd := m.Update(key("n"))
+	m = next.(TrainRunModel)
+	if cmd == nil {
+		t.Fatal("n should start the next iteration")
+	}
+	cmd()
+	if !started {
+		t.Fatal("StartNext should have been called")
+	}
+}
+
+func TestTrainRunPromoteScreenShowsDecisionLink(t *testing.T) {
+	snap := TrainRunSnapshot{
+		SessionID:          "s",
+		Phase:              "optimizer_completed_candidate",
+		ActionPhase:        "candidate_review_published",
+		CandidateVersion:   "c@v2",
+		CandidateReviewURL: "https://github.com/o/r/issues/7#issuecomment-1",
+	}
+	m := trainRunModelWithDeps(t, TrainRunDeps{Load: func() (TrainRunSnapshot, error) { return snap, nil }}, snap)
+	view := m.View()
+	for _, want := range []string{"candidate: c@v2", "candidate review: https://github.com/o/r/issues/7#issuecomment-1", "p promote"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("promote view missing %q:\n%s", want, view)
+		}
+	}
+}
+
 func TestTrainRunRejectRequiresReason(t *testing.T) {
 	var gotReason string
 	decided := false

--- a/internal/cli/tui/trainrun_view.go
+++ b/internal/cli/tui/trainrun_view.go
@@ -190,6 +190,23 @@ func (m TrainRunModel) body() string {
 		b.WriteString(fmt.Sprintf("candidate %s rejected\n", dash(s.CandidateVersion)))
 	}
 
+	// Post-optimizer the display phase can stay "optimizer_completed_candidate"
+	// while the iteration advances, so the switch above misses the decision and
+	// terminal lines; render them from the iteration phase too.
+	if s.Phase != m.actionPhase() {
+		switch m.actionPhase() {
+		case "candidate_created":
+			b.WriteString(fmt.Sprintf("candidate %s created — ready to publish the candidate review\n", dash(s.CandidateVersion)))
+		case "candidate_review_published":
+			b.WriteString(fmt.Sprintf("candidate: %s\n", dash(s.CandidateVersion)))
+		case "candidate_promoted":
+			b.WriteString(greenStyle.Render(fmt.Sprintf("candidate %s promoted", dash(s.CandidateVersion))) + "\n")
+		case "candidate_rejected":
+			b.WriteString(fmt.Sprintf("candidate %s rejected\n", dash(s.CandidateVersion)))
+		}
+	}
+	b.WriteString(m.candidateDecisionBlock())
+
 	if isLongTrainPhase(s.Phase) && len(m.logLines) > 0 {
 		b.WriteByte('\n')
 		for _, line := range m.logLines {
@@ -213,4 +230,21 @@ func (m TrainRunModel) issueBlock() string {
 	}
 	return selectedRowStyle.Render("review issue: "+m.snap.IssueURL) + "\n" +
 		mutedStyle.Render("comment on the issue — the review watcher picks it up") + "\n"
+}
+
+// candidateDecisionBlock renders the candidate review link when a promote or
+// reject decision is pending (or just made), so the user can decide from
+// GitHub instead of the keys.
+func (m TrainRunModel) candidateDecisionBlock() string {
+	if strings.TrimSpace(m.snap.CandidateReviewURL) == "" {
+		return ""
+	}
+	if m.actionPhase() != "candidate_review_published" && !m.snap.Terminal {
+		return ""
+	}
+	block := selectedRowStyle.Render("candidate review: "+m.snap.CandidateReviewURL) + "\n"
+	if m.actionPhase() == "candidate_review_published" {
+		block += mutedStyle.Render("decide here with p/x — or comment on GitHub, the review watcher picks it up") + "\n"
+	}
+	return block
 }


### PR DESCRIPTION
## WHAT
Task 1 of #255: post-promote `n` works again and the candidate decision link shows on the promote/terminal screens.

## WHY
Observed live: after promoting `gitmoot-plan-and-goal@v2` the terminal screen offered nothing — `Terminal` was computed from the display phase, which never becomes terminal post-optimizer (same class as #254). And there was no way to see the GitHub comment where the decision can also be made.

## CHANGES
- `Terminal` gates on the iteration phase (fallback to display), suppressed while a lock-active display phase shows a detached worker still running (a stopped-mid-run session must not offer `n` that would silently no-op).
- `CandidateReviewURL` in the snapshot; review found the obvious source (`iteration.PullRequestURL`) is never set by the issue-based flow, so the verbose status derives it from the `candidate_review` metadata via the existing `skillOptCandidateReviewURLFromMetadata`. Rendered as "candidate review: <url>" with a decide-on-GitHub hint (the review watcher honors comments).
- The display-vs-iteration fallback rendering covers `candidate_created` too — its body line was unreachable for real snapshots.

## RESULTS
tui + cli suites green (full cli run: only the known pre-existing flake). New tests: terminal keys + link with display/iteration divergence; promote screen rendering; mapping test incl. the no-verbose case.

## REVIEW
High-effort review run; all three findings fixed (URL never populated in real flows, missing candidate_created case, contradictory terminal state while a lock is live).

## RISK
TUI + one additive verbose-status value (`candidate.pull_request_url` now populated for issue-based reviews — previously omitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)