### PR TITLE
skillopt: synthesize template metadata on export for legacy rows

### DIFF
--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -847,7 +847,7 @@ func storeCandidateArtifactBlobs(blobStore artifact.Store, preparedArtifacts []p
 }
 
 func templateSnapshot(template db.AgentTemplate) (TemplateSnapshot, error) {
-	metadata, err := agenttemplate.UnmarshalMetadata(template.MetadataJSON)
+	metadata, err := templateMetadataOrSynthesized(template)
 	if err != nil {
 		return TemplateSnapshot{}, err
 	}
@@ -864,6 +864,50 @@ func templateSnapshot(template db.AgentTemplate) (TemplateSnapshot, error) {
 		Metadata:       metadata,
 		Content:        template.Content,
 	}, nil
+}
+
+// templateMetadataOrSynthesized parses the template's stored metadata, or —
+// for legacy rows installed before frontmatter became mandatory at install
+// time and therefore carrying an empty metadata_json — synthesizes a minimal
+// valid record from the row itself so training does not dead-end. Non-empty
+// but invalid metadata still fails loudly.
+func templateMetadataOrSynthesized(template db.AgentTemplate) (agenttemplate.Metadata, error) {
+	if strings.TrimSpace(template.MetadataJSON) != "" {
+		return agenttemplate.UnmarshalMetadata(template.MetadataJSON)
+	}
+	// Prefer frontmatter embedded in the content (mirrors the cached-template
+	// fallbacks in agent_template.go and train_init_templates.go), so the
+	// exported metadata cannot contradict the content's own frontmatter.
+	if parsed, err := agenttemplate.ParseTemplateContent(template.Content); err == nil {
+		return parsed.Metadata, nil
+	}
+	name := strings.TrimSpace(template.Name)
+	if name == "" {
+		name = template.ID
+	}
+	description := strings.TrimSpace(template.Description)
+	if description == "" {
+		description = "Agent template " + template.ID
+	}
+	minimal := agenttemplate.Metadata{
+		ID:                   template.ID,
+		Name:                 name,
+		Description:          description,
+		Kind:                 agenttemplate.TemplateKind,
+		Version:              agenttemplate.TemplateVersion,
+		Capabilities:         []string{"ask"},
+		RuntimeCompatibility: []string{"codex", "claude"},
+		Tags:                 []string{"agent-template"},
+		Inputs:               []string{"repo", "task"},
+		Outputs:              []string{"response"},
+	}
+	// Round-trip through the canonical encoder so the synthesized record is
+	// validated and normalized exactly like stored metadata.
+	encoded, err := agenttemplate.MarshalMetadata(minimal)
+	if err != nil {
+		return agenttemplate.Metadata{}, fmt.Errorf("synthesize metadata for template %s: %w", template.ID, err)
+	}
+	return agenttemplate.UnmarshalMetadata(encoded)
 }
 
 func evalItem(item db.EvalReviewItem, options []EvalReviewOption) (EvalItem, error) {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1127,4 +1128,66 @@ func testTemplateContent(id string, body string) string {
 		Inputs:               []string{"task"},
 		Outputs:              []string{"plan"},
 	}, "# Planner\n\n"+body+"\n")
+}
+
+func TestTemplateMetadataSynthesizedForLegacyEmptyRows(t *testing.T) {
+	// Templates installed before frontmatter became mandatory carry an empty
+	// metadata_json; export must synthesize a valid record instead of
+	// dead-ending the training run.
+	template := db.AgentTemplate{
+		ID:          "legacy-template",
+		Name:        "Legacy Template",
+		Description: "Installed before metadata was mandatory.",
+		Content:     "# Legacy Template\n\nDo the work.",
+	}
+	snapshot, err := templateSnapshot(template)
+	if err != nil {
+		t.Fatalf("templateSnapshot: %v", err)
+	}
+	meta := snapshot.Metadata
+	if meta.ID != "legacy-template" || meta.Name != "Legacy Template" {
+		t.Fatalf("synthesized identity wrong: %+v", meta)
+	}
+	// Pin the exact synthesized values: the Python-side candidate validation
+	// compares these against the candidate frontmatter, so drift breaks the
+	// cross-repo contract.
+	if len(meta.Capabilities) != 1 || meta.Capabilities[0] != "ask" {
+		t.Fatalf("capabilities = %v, want [ask]", meta.Capabilities)
+	}
+	if len(meta.RuntimeCompatibility) != 2 || meta.RuntimeCompatibility[0] != "codex" || meta.RuntimeCompatibility[1] != "claude" {
+		t.Fatalf("runtime_compatibility = %v", meta.RuntimeCompatibility)
+	}
+	if meta.Kind != agenttemplate.TemplateKind || meta.Version != agenttemplate.TemplateVersion {
+		t.Fatalf("kind/version = %q/%d", meta.Kind, meta.Version)
+	}
+	if len(meta.Tags) == 0 || len(meta.Inputs) == 0 || len(meta.Outputs) == 0 {
+		t.Fatalf("synthesized metadata incomplete: %+v", meta)
+	}
+	// Content frontmatter beats synthesis: a legacy row whose CONTENT carries
+	// frontmatter must export that, never the generic defaults.
+	withFM := testTemplate("with-fm", "Body.")
+	withFM.MetadataJSON = ""
+	fmSnapshot, err := templateSnapshot(withFM)
+	if err != nil {
+		t.Fatalf("templateSnapshot with frontmatter content: %v", err)
+	}
+	parsed, err := agenttemplate.ParseTemplateContent(withFM.Content)
+	if err != nil {
+		t.Fatalf("ParseTemplateContent: %v", err)
+	}
+	if !reflect.DeepEqual(fmSnapshot.Metadata, parsed.Metadata) {
+		t.Fatalf("content frontmatter not preferred:\ngot  %+v\nwant %+v", fmSnapshot.Metadata, parsed.Metadata)
+	}
+	// Name/description fall back when the row is bare.
+	bare, err := templateSnapshot(db.AgentTemplate{ID: "bare"})
+	if err != nil {
+		t.Fatalf("templateSnapshot bare: %v", err)
+	}
+	if bare.Metadata.Name != "bare" || bare.Metadata.Description == "" {
+		t.Fatalf("bare fallbacks wrong: %+v", bare.Metadata)
+	}
+	// Non-empty but corrupt metadata still fails loudly.
+	if _, err := templateSnapshot(db.AgentTemplate{ID: "corrupt", MetadataJSON: "{not json"}); err == nil {
+		t.Fatal("corrupt metadata must still error")
+	}
 }


### PR DESCRIPTION
## WHAT
Task 2 of #255 (gitmoot half of the frontmatter self-healing): export no longer dead-ends on templates with empty `metadata_json`.

## WHY
Hit live: the first real training run blocked at "training export failed: template metadata is empty" because `gitmoot-plan-and-goal@v1` was installed (by an older gitmoot) without frontmatter. Install-time and train-time requirements disagreed.

## CHANGES
`templateSnapshot` resolves metadata in priority order: stored `metadata_json` → frontmatter parsed from the content (review finding: the generic defaults must never contradict frontmatter embedded in the content; this mirrors the existing cached-template fallbacks) → synthesized minimal record from the row, round-tripped through the canonical encoder so it is validated/normalized exactly like stored metadata. Non-empty invalid metadata still errors. All current install paths (AddLocal/UpdateLocal/builtin Update/candidate import) already marshal metadata, so only legacy rows are affected.

## RESULTS
`go test ./internal/skillopt` green. New test pins the exact synthesized values (the Python-side candidate validation compares them against candidate frontmatter — drift breaks the cross-repo contract), covers content-frontmatter priority via DeepEqual, bare-row fallbacks, and corrupt-metadata still erroring.

## REVIEW
High-effort review run; fixed: content-frontmatter priority missing, redundant self-confirming test block. Known sequencing note (accepted): for a frontmatter-less legacy template the failure now moves from export to candidate packaging until the gitmoot-skillopt packager half (next task) lands — the two halves together close the loop.

## RISK
Export-only behavior change for rows no current code path can produce; exported content and content hashes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)