### PR TITLE
cli: stream optimizer output live with spinner, elapsed, and run header

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -4537,9 +4537,13 @@ func continueSkillOptTrainOptimizer(ctx context.Context, paths config.Paths, sto
 		}
 		result.Command = command
 		result.Args = args
-		announceSkillOptTrainOptimizerLaunch(progress, request)
-		stopHeartbeat := startSkillOptTrainOptimizerHeartbeat(progress)
-		runResult, err := runSkillOptTrainOptimizer(ctx, optimizerPaths, request, command, args)
+		// One serialized writer shared by the launch banner, the heartbeat
+		// ticker, and the optimizer's streamed output: they write concurrently
+		// and the destination is not necessarily concurrency-safe.
+		sharedProgress := subprocess.SyncWriter(progress)
+		announceSkillOptTrainOptimizerLaunch(sharedProgress, request)
+		stopHeartbeat := startSkillOptTrainOptimizerHeartbeat(sharedProgress)
+		runResult, err := runSkillOptTrainOptimizer(ctx, sharedProgress, optimizerPaths, request, command, args)
 		stopHeartbeat()
 		result.RecoveryAvailable = skillOptTrainOptimizerRecoveryAvailable(optimizerPaths)
 		if err != nil {
@@ -8887,7 +8891,7 @@ func startSkillOptTrainOptimizerHeartbeat(progress io.Writer) func() {
 	}
 }
 
-func runSkillOptTrainOptimizer(ctx context.Context, paths skillOptTrainOptimizerPaths, request skillOptTrainOptimizerRequest, command string, args []string) (subprocess.Result, error) {
+func runSkillOptTrainOptimizer(ctx context.Context, progress io.Writer, paths skillOptTrainOptimizerPaths, request skillOptTrainOptimizerRequest, command string, args []string) (subprocess.Result, error) {
 	timeout := strings.TrimSpace(request.Timeout)
 	if timeout != "" {
 		duration, err := time.ParseDuration(timeout)
@@ -8904,7 +8908,17 @@ func runSkillOptTrainOptimizer(ctx context.Context, paths skillOptTrainOptimizer
 	if err := os.MkdirAll(paths.OutRoot, 0o755); err != nil {
 		return subprocess.Result{}, fmt.Errorf("create optimizer out-root: %w", err)
 	}
-	result, err := skillOptTrainOptimizerRunner.Run(ctx, paths.OutRoot, command, args...)
+	// Stream the optimizer's progress lines live when the runner supports it:
+	// in the detached phase-view child, progress IS the tailed session log, so
+	// the minibatch/analyst/accept lines appear as they happen instead of only
+	// after exit. The buffered Result is unchanged either way.
+	var result subprocess.Result
+	var err error
+	if streamer, ok := skillOptTrainOptimizerRunner.(subprocess.StreamRunner); ok && progress != nil {
+		result, err = streamer.RunStream(ctx, paths.OutRoot, progress, command, args...)
+	} else {
+		result, err = skillOptTrainOptimizerRunner.Run(ctx, paths.OutRoot, command, args...)
+	}
 	if err != nil {
 		return result, fmt.Errorf("optimizer failed: %w%s", err, subprocessDiagnostics(result))
 	}
@@ -8957,6 +8971,14 @@ func addSkillOptTrainOptimizerConfigMetadata(metadata map[string]any, request sk
 	}
 	if mode := strings.TrimSpace(request.FeedbackDirectMode); mode != "" {
 		metadata["feedback_direct_mode"] = mode
+	}
+	// Resolved backend/model identify WHAT is running; the phase view shows
+	// them in its header.
+	if value := firstNonEmpty(strings.TrimSpace(request.OptimizerBackend), strings.TrimSpace(request.Backend)); value != "" {
+		metadata["run_optimizer_backend"] = value
+	}
+	if value := firstNonEmpty(strings.TrimSpace(request.OptimizerModel), strings.TrimSpace(request.Model)); value != "" {
+		metadata["run_optimizer_model"] = value
 	}
 	if request.FinalEvalSet {
 		metadata["final_eval"] = request.FinalEval

--- a/internal/cli/skillopt_stream_test.go
+++ b/internal/cli/skillopt_stream_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+// streamRecordingRunner implements subprocess.StreamRunner and records which
+// entry point the optimizer launch used.
+type streamRecordingRunner struct {
+	streamed bool
+	ran      bool
+	wroteTo  io.Writer
+	result   subprocess.Result
+}
+
+func (r *streamRecordingRunner) Run(ctx context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
+	r.ran = true
+	return r.result, nil
+}
+
+func (r *streamRecordingRunner) RunStream(ctx context.Context, dir string, out io.Writer, command string, args ...string) (subprocess.Result, error) {
+	r.streamed = true
+	r.wroteTo = out
+	if out != nil {
+		_, _ = out.Write([]byte("[1/6 FEEDBACK-DIRECT] live line\n"))
+	}
+	return r.result, nil
+}
+
+func (r *streamRecordingRunner) LookPath(file string) (string, error) { return file, nil }
+
+func TestRunSkillOptTrainOptimizerStreamsWhenSupported(t *testing.T) {
+	previous := skillOptTrainOptimizerRunner
+	runner := &streamRecordingRunner{result: subprocess.Result{Stdout: "done"}}
+	skillOptTrainOptimizerRunner = runner
+	defer func() { skillOptTrainOptimizerRunner = previous }()
+
+	var progress bytes.Buffer
+	paths := skillOptTrainOptimizerPaths{OutRoot: t.TempDir()}
+	result, err := runSkillOptTrainOptimizer(context.Background(), &progress, paths, skillOptTrainOptimizerRequest{}, "gitmoot-skillopt", []string{"optimize"})
+	if err != nil {
+		t.Fatalf("runSkillOptTrainOptimizer: %v", err)
+	}
+	if !runner.streamed || runner.ran {
+		t.Fatalf("expected the streaming entry point; streamed=%v ran=%v", runner.streamed, runner.ran)
+	}
+	if !strings.Contains(progress.String(), "live line") {
+		t.Fatalf("progress writer did not receive the stream: %q", progress.String())
+	}
+	if result.Stdout != "done" {
+		t.Fatalf("buffered result lost: %+v", result)
+	}
+
+	// A nil progress writer (or a Runner without streaming) uses Run.
+	runner.streamed, runner.ran = false, false
+	if _, err := runSkillOptTrainOptimizer(context.Background(), nil, paths, skillOptTrainOptimizerRequest{}, "gitmoot-skillopt", []string{"optimize"}); err != nil {
+		t.Fatalf("nil-progress run: %v", err)
+	}
+	if runner.streamed || !runner.ran {
+		t.Fatalf("nil progress must use Run; streamed=%v ran=%v", runner.streamed, runner.ran)
+	}
+}
+
+func TestOptimizerMetadataRecordsBackendAndModel(t *testing.T) {
+	metadata := map[string]any{}
+	addSkillOptTrainOptimizerConfigMetadata(metadata, skillOptTrainOptimizerRequest{
+		OptimizerBackend: "claude",
+		OptimizerModel:   "claude-sonnet-4-6",
+	})
+	if metadata["run_optimizer_backend"] != "claude" || metadata["run_optimizer_model"] != "claude-sonnet-4-6" {
+		t.Fatalf("metadata = %v", metadata)
+	}
+	// The combined Backend/Model fields are the fallback identity.
+	metadata = map[string]any{}
+	addSkillOptTrainOptimizerConfigMetadata(metadata, skillOptTrainOptimizerRequest{Backend: "codex", Model: "gpt-4o"})
+	if metadata["run_optimizer_backend"] != "codex" || metadata["run_optimizer_model"] != "gpt-4o" {
+		t.Fatalf("fallback metadata = %v", metadata)
+	}
+}

--- a/internal/cli/skillopt_trainrun_tui.go
+++ b/internal/cli/skillopt_trainrun_tui.go
@@ -445,8 +445,42 @@ func toTrainRunSnapshot(s skillOptTrainStatusSnapshot) tui.TrainRunSnapshot {
 		out.JobsRunning = s.Verbose.Jobs.Running
 		out.JobsSucceeded = s.Verbose.Jobs.Succeeded
 		out.JobsFailed = s.Verbose.Jobs.Failed
+		// The phase-matching lock's acquisition time is the phase start: a
+		// leftover lock from an earlier killed step (e.g. a review lock with a
+		// long TTL) can sort first, so the lock NAME must match the phase.
+		out.PhaseStartedAt = trainPhaseLockStart(s.StatusPhase, s.Verbose.ActiveLocks)
+		out.OptimizerBackend = metadataString(s.Verbose.Optimizer, "run_optimizer_backend")
+		out.OptimizerModel = metadataString(s.Verbose.Optimizer, "run_optimizer_model")
+		out.OptimizerAttempt = metadataString(s.Verbose.Optimizer, "optimizer_attempt")
 	}
 	return out
+}
+
+// trainPhaseLockStart returns the acquisition time of the active lock whose
+// name matches the displayed long phase (generation locks for generating
+// phases, optimizer locks for optimizer phases); zero when none matches.
+func trainPhaseLockStart(statusPhase string, locks []skillOptTrainStatusLock) time.Time {
+	var wanted map[string]bool
+	switch statusPhase {
+	case "generating_options", "generating_options_heartbeat_stale":
+		wanted = map[string]bool{"generation": true}
+	case "optimizer_running", "optimizer_heartbeat_stale":
+		wanted = map[string]bool{"optimizer": true, "optimizer_legacy": true}
+	default:
+		return time.Time{}
+	}
+	for _, lock := range locks {
+		if !wanted[lock.Name] {
+			continue
+		}
+		if lock.Status != "active" && lock.Status != "active_expired_heartbeat" {
+			continue
+		}
+		if acquired, ok := parseSkillOptStatusTime(lock.AcquiredAt); ok {
+			return acquired
+		}
+	}
+	return time.Time{}
 }
 
 // skillOptTrainRunLockActivePhase reports whether the display phase is derived

--- a/internal/cli/skillopt_trainrun_tui_test.go
+++ b/internal/cli/skillopt_trainrun_tui_test.go
@@ -261,6 +261,27 @@ func TestToTrainRunSnapshotPostOptimizerTerminalAndDecisionURL(t *testing.T) {
 	}
 }
 
+func TestTrainPhaseLockStartMatchesPhaseFamily(t *testing.T) {
+	optimizerAcquired := "2026-06-11T10:00:00Z"
+	locks := []skillOptTrainStatusLock{
+		// A leftover review lock from a killed step sorts first; it must NOT
+		// provide the optimizer phase's start time.
+		{Name: "review", Status: "active", AcquiredAt: "2026-06-11T08:00:00Z"},
+		{Name: "optimizer", Status: "active", AcquiredAt: optimizerAcquired},
+	}
+	got := trainPhaseLockStart("optimizer_running", locks)
+	want, _ := parseSkillOptStatusTime(optimizerAcquired)
+	if !got.Equal(want) {
+		t.Fatalf("optimizer phase start = %v, want %v", got, want)
+	}
+	if !trainPhaseLockStart("generating_options", locks).IsZero() {
+		t.Fatal("no generation lock → zero start")
+	}
+	if !trainPhaseLockStart("review_published", locks).IsZero() {
+		t.Fatal("non-long phases have no lock-derived start")
+	}
+}
+
 func TestToTrainRunSnapshot(t *testing.T) {
 	snap := skillOptTrainStatusSnapshot{
 		SessionID:       "s1",

--- a/internal/cli/tui/trainrun.go
+++ b/internal/cli/tui/trainrun.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -32,6 +33,12 @@ type TrainRunSnapshot struct {
 	ETA                string
 	Elapsed            string
 	Terminal           bool
+
+	// Live-progress detail for the long phases.
+	PhaseStartedAt   time.Time // active generation/optimizer lock acquisition; zero when unknown
+	OptimizerBackend string    // e.g. "claude"
+	OptimizerModel   string    // e.g. "claude-sonnet-4-6"; empty = backend default
+	OptimizerAttempt string    // e.g. "attempt-001"
 }
 
 // TrainRunActionResult carries the output lines from a short in-process phase
@@ -141,6 +148,11 @@ type TrainRunModel struct {
 	// and the last few complete lines to show.
 	logOffset int64
 	logLines  []string
+
+	// Long-phase liveness: a spinner whose ticks (10 fps for spinner.Dot)
+	// also redraw the live elapsed time. Armed only while a long phase shows.
+	spin     spinner.Model
+	spinning bool
 }
 
 const trainLogTailLines = 8
@@ -160,6 +172,7 @@ func isLongTrainPhase(phase string) bool {
 // NewTrainRun returns a model ready for tea.NewProgram.
 func NewTrainRun(deps TrainRunDeps) TrainRunModel {
 	m := TrainRunModel{deps: deps, width: 100, height: 30, inFlight: true}
+	m.spin = spinner.New(spinner.WithSpinner(spinner.Dot))
 	if deps.Plan != nil {
 		m.confirming = true
 		m.inFlight = false
@@ -235,6 +248,13 @@ func (m TrainRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, cmd)
 			}
 		}
+	case spinner.TickMsg:
+		if !m.spinning {
+			break // disarmed: drop the stale tick instead of re-arming
+		}
+		var cmd tea.Cmd
+		m.spin, cmd = m.spin.Update(msg)
+		cmds = append(cmds, cmd)
 	case trainSnapshotMsg:
 		m.inFlight = false
 		if msg.err != nil {
@@ -243,6 +263,12 @@ func (m TrainRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.loadErr = ""
 			m.snap = msg.snap
 			m.loadedAt = msg.at
+			if long := isLongTrainPhase(msg.snap.Phase); long && !m.spinning {
+				m.spinning = true
+				cmds = append(cmds, m.spin.Tick)
+			} else if !long {
+				m.spinning = false
+			}
 			// Clear the displayed lines when not in a long phase so stale output
 			// does not linger; the byte offset stays monotonic (one per-session
 			// log spans generation and optimizer).

--- a/internal/cli/tui/trainrun_progress_test.go
+++ b/internal/cli/tui/trainrun_progress_test.go
@@ -1,0 +1,54 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+)
+
+func TestTrainRunLongPhaseShowsSpinnerElapsedAndHeader(t *testing.T) {
+	snap := TrainRunSnapshot{
+		SessionID:        "s",
+		Phase:            "optimizer_running",
+		PhaseStartedAt:   time.Now().Add(-5 * time.Minute),
+		OptimizerBackend: "claude",
+		OptimizerModel:   "claude-sonnet-4-6",
+		OptimizerAttempt: "attempt-001",
+	}
+	m := trainRunModelWithDeps(t, TrainRunDeps{Load: func() (TrainRunSnapshot, error) { return snap, nil }}, snap)
+	if !m.spinning {
+		t.Fatal("a long-phase snapshot should arm the spinner")
+	}
+	view := m.View()
+	for _, want := range []string{"optimizing", "elapsed 5m0s", "optimizer: claude · claude-sonnet-4-6 · attempt-001"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("long-phase view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestTrainRunSpinnerDisarmsOutsideLongPhases(t *testing.T) {
+	long := TrainRunSnapshot{SessionID: "s", Phase: "optimizer_running"}
+	m := trainRunModelWithDeps(t, TrainRunDeps{Load: func() (TrainRunSnapshot, error) { return long, nil }}, long)
+	if !m.spinning {
+		t.Fatal("long phase should arm the spinner")
+	}
+	next, _ := m.Update(trainSnapshotMsg{snap: TrainRunSnapshot{SessionID: "s", Phase: "candidate_created"}, at: time.Unix(2, 0)})
+	m = next.(TrainRunModel)
+	if m.spinning {
+		t.Fatal("leaving the long phase should disarm the spinner")
+	}
+	// A stale spinner tick must not re-arm a dead chain.
+	if _, cmd := m.Update(spinner.TickMsg{ID: m.spin.ID()}); cmd != nil {
+		t.Fatal("stale spinner tick must be dropped")
+	}
+}
+
+func TestTrainRunLiveElapsedFallsBackToSnapshotText(t *testing.T) {
+	m := TrainRunModel{snap: TrainRunSnapshot{Elapsed: "2m"}}
+	if got := m.liveElapsed(); got != "2m" {
+		t.Fatalf("fallback elapsed = %q", got)
+	}
+}

--- a/internal/cli/tui/trainrun_view.go
+++ b/internal/cli/tui/trainrun_view.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // trainPhaseSegments are the four coarse stages shown in the phase bar.
@@ -157,7 +158,11 @@ func (m TrainRunModel) body() string {
 	case "items_ready", "request_confirmed", "workspace_ready":
 		b.WriteString(fmt.Sprintf("%d review items ready to generate options\n", s.ReviewItems))
 	case "generating_options", "generating_options_heartbeat_stale":
+		b.WriteString(m.spin.View())
 		b.WriteString(fmt.Sprintf("generating options — %d running · %d done · %d failed", s.JobsRunning, s.JobsSucceeded, s.JobsFailed))
+		if elapsed := m.liveElapsed(); elapsed != "" {
+			b.WriteString(" · elapsed " + elapsed)
+		}
 		if s.ETA != "" && s.ETA != "unknown" {
 			b.WriteString("  (eta " + s.ETA + ")")
 		}
@@ -168,11 +173,20 @@ func (m TrainRunModel) body() string {
 		b.WriteString(m.issueBlock())
 		b.WriteString(fmt.Sprintf("feedback so far: %d\n", s.FeedbackCount))
 	case "optimizer_running", "optimizer_heartbeat_stale", "training_package_created":
-		b.WriteString("optimizer running")
-		if s.Elapsed != "" {
-			b.WriteString(" · " + s.Elapsed)
+		if s.Phase == "training_package_created" {
+			b.WriteString("optimizer ready to run")
+		} else {
+			b.WriteString(m.spin.View())
+			b.WriteString("optimizing")
+			if elapsed := m.liveElapsed(); elapsed != "" {
+				b.WriteString(" — elapsed " + elapsed)
+			}
 		}
 		b.WriteByte('\n')
+		if header := m.optimizerHeader(); header != "" {
+			b.WriteString(mutedStyle.Render(header))
+			b.WriteByte('\n')
+		}
 	case "candidate_created":
 		b.WriteString(fmt.Sprintf("candidate %s created — ready to publish the candidate review\n", dash(s.CandidateVersion)))
 	case "candidate_review_published":
@@ -220,6 +234,42 @@ func (m TrainRunModel) body() string {
 		b.WriteByte('\n')
 	}
 	return b.String()
+}
+
+// liveElapsed renders the time since the phase's lock was acquired, ticking
+// with the spinner redraws; without a lock timestamp it falls back to the
+// snapshot's coarse elapsed text.
+func (m TrainRunModel) liveElapsed() string {
+	if !m.snap.PhaseStartedAt.IsZero() {
+		elapsed := time.Since(m.snap.PhaseStartedAt)
+		if elapsed >= 0 {
+			return elapsed.Round(time.Second).String()
+		}
+	}
+	return m.snap.Elapsed
+}
+
+// optimizerHeader identifies what the optimizer run is: backend, model, and
+// attempt, from the metadata recorded at launch.
+func (m TrainRunModel) optimizerHeader() string {
+	parts := []string{}
+	if m.snap.OptimizerBackend != "" {
+		parts = append(parts, m.snap.OptimizerBackend)
+	}
+	model := m.snap.OptimizerModel
+	if model == "" && m.snap.OptimizerBackend != "" {
+		model = "backend default model"
+	}
+	if model != "" {
+		parts = append(parts, model)
+	}
+	if m.snap.OptimizerAttempt != "" {
+		parts = append(parts, m.snap.OptimizerAttempt)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "optimizer: " + strings.Join(parts, " · ")
 }
 
 // issueBlock renders the GitHub issue URL prominently with the continue-from-

--- a/internal/subprocess/runner.go
+++ b/internal/subprocess/runner.go
@@ -3,7 +3,9 @@ package subprocess
 import (
 	"bytes"
 	"context"
+	"io"
 	"os/exec"
+	"sync"
 )
 
 type Result struct {
@@ -18,14 +20,111 @@ type Runner interface {
 	LookPath(file string) (string, error)
 }
 
+// StreamRunner additionally tees the child's stdout and stderr to a writer as
+// they are produced, while still returning the buffered Result — for
+// long-lived subprocesses whose progress should appear live (e.g. in a log a
+// TUI tails) instead of only after exit.
+type StreamRunner interface {
+	Runner
+	RunStream(ctx context.Context, dir string, out io.Writer, command string, args ...string) (Result, error)
+}
+
 type ExecRunner struct{}
 
 func (ExecRunner) Run(ctx context.Context, dir string, command string, args ...string) (Result, error) {
 	return Run(ctx, dir, command, args...)
 }
 
+func (ExecRunner) RunStream(ctx context.Context, dir string, out io.Writer, command string, args ...string) (Result, error) {
+	return RunStream(ctx, dir, out, command, args...)
+}
+
 func (ExecRunner) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
+}
+
+// SyncWriter serializes writes to w. Stream tees and any sibling writers
+// (e.g. a heartbeat ticker) sharing one destination should share one
+// SyncWriter, since destinations like bytes.Buffer are not safe for
+// concurrent writes.
+func SyncWriter(w io.Writer) io.Writer {
+	if w == nil {
+		return nil
+	}
+	if _, ok := w.(*syncWriter); ok {
+		return w
+	}
+	return &syncWriter{w: w}
+}
+
+type syncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
+}
+
+// lineWriter buffers partial writes and forwards only complete lines, so two
+// pipes teeing into one destination interleave at line boundaries instead of
+// arbitrary io.Copy chunk boundaries.
+type lineWriter struct {
+	out io.Writer
+	buf bytes.Buffer
+}
+
+func (l *lineWriter) Write(p []byte) (int, error) {
+	l.buf.Write(p)
+	for {
+		line, err := l.buf.ReadString('\n')
+		if err != nil {
+			// Incomplete line: keep it buffered for the next write.
+			l.buf.WriteString(line)
+			return len(p), nil
+		}
+		if _, err := io.WriteString(l.out, line); err != nil {
+			return len(p), err
+		}
+	}
+}
+
+func (l *lineWriter) flush() {
+	if l.buf.Len() > 0 {
+		_, _ = io.WriteString(l.out, l.buf.String()+"\n")
+		l.buf.Reset()
+	}
+}
+
+// RunStream runs like Run but additionally streams the child's stdout and
+// stderr to out, line by line, as they are produced. A nil out degrades to
+// Run. out is wrapped in a SyncWriter; callers writing to the same
+// destination concurrently should pass the same SyncWriter-wrapped value.
+func RunStream(ctx context.Context, dir string, out io.Writer, command string, args ...string) (Result, error) {
+	if out == nil {
+		return Run(ctx, dir, command, args...)
+	}
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Dir = dir
+
+	tee := SyncWriter(out)
+	outLines := &lineWriter{out: tee}
+	errLines := &lineWriter{out: tee}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = io.MultiWriter(&stdout, outLines)
+	cmd.Stderr = io.MultiWriter(&stderr, errLines)
+
+	err := cmd.Run()
+	outLines.flush()
+	errLines.flush()
+	return Result{
+		Command: command,
+		Args:    args,
+		Stdout:  stdout.String(),
+		Stderr:  stderr.String(),
+	}, err
 }
 
 func Run(ctx context.Context, dir string, command string, args ...string) (Result, error) {

--- a/internal/subprocess/runner_test.go
+++ b/internal/subprocess/runner_test.go
@@ -1,6 +1,7 @@
 package subprocess
 
 import (
+	"bytes"
 	"context"
 	"runtime"
 	"strings"
@@ -18,5 +19,41 @@ func TestRunCapturesStdout(t *testing.T) {
 	}
 	if strings.TrimSpace(result.Stdout) != "gitmoot" {
 		t.Fatalf("stdout = %q", result.Stdout)
+	}
+}
+
+func TestRunStreamTeesAndBuffers(t *testing.T) {
+	var tee bytes.Buffer
+	result, err := RunStream(context.Background(), "", &tee, "sh", "-c", "echo out; echo err >&2")
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+	if result.Stdout != "out\n" || result.Stderr != "err\n" {
+		t.Fatalf("buffered result = %+v", result)
+	}
+	teed := tee.String()
+	if !strings.Contains(teed, "out\n") || !strings.Contains(teed, "err\n") {
+		t.Fatalf("tee missing streams: %q", teed)
+	}
+}
+
+func TestRunStreamNilWriterDegradesToRun(t *testing.T) {
+	result, err := RunStream(context.Background(), "", nil, "sh", "-c", "echo ok")
+	if err != nil {
+		t.Fatalf("RunStream nil: %v", err)
+	}
+	if result.Stdout != "ok\n" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestRunStreamInterleavesAtLineBoundaries(t *testing.T) {
+	var tee bytes.Buffer
+	_, err := RunStream(context.Background(), "", &tee, "sh", "-c", "printf 'partial'; sleep 0.05; printf ' line\\n'")
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+	if got := tee.String(); got != "partial line\n" {
+		t.Fatalf("line not assembled before forwarding: %q", got)
 	}
 }


### PR DESCRIPTION
## WHAT
Task 4 of #255 (items 1, 5, 6): the generate and optimize phases show a spinner + live elapsed time, the optimizer's progress lines stream into the phase view as they happen, and a header identifies the run (backend · model · attempt).

## WHY
A real optimizer run is minutes of silence today: its rich progress output is buffered until exit, there's no animation, and "elapsed" only updates on refresh ticks. You couldn't even tell which backend/model was running.

## CHANGES
- **`subprocess.RunStream`** (+ `StreamRunner` interface, additive — the existing `Runner` and all its fakes are untouched; the optimizer seam type-asserts and falls back to `Run`): tees the child's stdout/stderr to a writer line-by-line (partial chunks assembled, so the two pipes interleave at line boundaries) while the buffered `Result` is preserved. Review hardening: the launch banner, heartbeat ticker, and stream share one `subprocess.SyncWriter` — the destination (a log file today, possibly a buffer tomorrow) is not necessarily concurrency-safe.
- In the detached phase-view child, the progress writer IS the tailed session log, so the minibatch/analyst/accept lines appear live in the existing log tail with zero new plumbing.
- **Spinner + live elapsed**: `bubbles/spinner` armed only during long phases (stale ticks dropped; ticks double as the elapsed redraw). Elapsed counts from the phase's own lock acquisition — review caught that taking the *first* active lock could pick a leftover review lock from a killed step, so the lock name must match the phase family — with fallback to the coarse status text.
- **Run header**: `optimizer: claude · claude-sonnet-4-6 · attempt-001` from `run_optimizer_backend`/`run_optimizer_model` recorded in the launch metadata (mirrors the exact CLI-arg resolution; no log parsing). `training_package_created` now reads "optimizer ready to run" (the lock-derived display phase takes over once it actually runs).

## RESULTS
Full `go test ./...` green except the known pre-existing daemon flake; `-race` on the stream tests green. New tests: tee+buffer round-trip, nil-writer degradation, line-boundary assembly, streaming-vs-Run seam selection with a fake StreamRunner, metadata backend/model recording (incl. combined-field fallback), long-phase view (spinner+elapsed+header), spinner disarm + stale-tick drop, elapsed fallback, phase-family lock matching (wrong-lock-first scenario).

## REVIEW
High-effort review run; fixed: heartbeat/tee shared-writer race (latent) + mid-line interleaving, first-lock-wins elapsed bug, 10fps comment accuracy. Known accepted: default-backend runs (no flags, no optimizer_defaults) record no backend, so the header hides — the attempt still shows; all of this user's presets set a backend.

## RISK
Additive interface; streaming only activates for the real ExecRunner with a non-nil progress writer. Optimizer metadata gains two additive keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)