### PR TITLE
cli: preview the candidate skill from the train phase view

### DIFF
--- a/internal/cli/skillopt_trainrun_tui.go
+++ b/internal/cli/skillopt_trainrun_tui.go
@@ -257,6 +257,18 @@ func skillOptTrainRunDeps(home string, sessionID func() string) tui.TrainRunDeps
 		TailLog: func(offset int64) ([]string, int64, error) {
 			return tailSkillOptTrainLog(home, sessionID(), offset)
 		},
+		TemplateVersionContent: func(versionRef string) (string, error) {
+			var content string
+			err := withStore(home, func(store *db.Store) error {
+				template, err := store.GetAgentTemplateReference(context.Background(), versionRef)
+				if err != nil {
+					return err
+				}
+				content = template.Content
+				return nil
+			})
+			return content, err
+		},
 	}
 }
 

--- a/internal/cli/tui/trainrun.go
+++ b/internal/cli/tui/trainrun.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -80,6 +81,10 @@ type TrainRunDeps struct {
 	// during the long generate/optimizer phases.
 	TailLog func(offset int64) (lines []string, next int64, err error)
 
+	// TemplateVersionContent loads a template version's content (e.g. the
+	// promoted candidate) for the v preview pager.
+	TemplateVersionContent func(versionRef string) (string, error)
+
 	// Embedded marks the model as a child of the Root router: q/esc pop back to
 	// the dashboard instead of quitting the program.
 	Embedded bool
@@ -90,7 +95,14 @@ type trainRunMode int
 const (
 	trainModeNormal trainRunMode = iota
 	trainModeReject
+	trainModeSkillView
 )
+
+type trainSkillContentMsg struct {
+	versionRef string
+	content    string
+	err        error
+}
 
 type trainSnapshotMsg struct {
 	snap TrainRunSnapshot
@@ -153,6 +165,13 @@ type TrainRunModel struct {
 	// also redraw the live elapsed time. Armed only while a long phase shows.
 	spin     spinner.Model
 	spinning bool
+
+	// v skill preview pager state, keyed by the version it holds so a new
+	// candidate (start-next) invalidates the cache.
+	skillView    viewport.Model
+	skillVersion string // version the pager content belongs to / was requested for
+	skillErr     string
+	skillLoaded  bool
 }
 
 const trainLogTailLines = 8
@@ -212,9 +231,26 @@ func (m TrainRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		if msg.Width > 0 && msg.Height > 0 {
 			m.width, m.height = msg.Width, msg.Height
+			if m.skillLoaded {
+				m.skillView.Width = max(20, m.width-4)
+				m.skillView.Height = max(5, m.height-6)
+			}
 		}
 	case tea.KeyMsg:
 		return m.updateKey(msg)
+	case trainSkillContentMsg:
+		// Match the version that was REQUESTED (not the live snapshot, which a
+		// refresh may have advanced) so the pager cannot wedge on loading.
+		if msg.versionRef == m.skillVersion {
+			m.skillLoaded = true
+			if msg.err != nil {
+				m.skillErr = msg.err.Error()
+			} else {
+				m.skillErr = ""
+				m.skillView = viewport.New(max(20, m.width-4), max(5, m.height-6))
+				m.skillView.SetContent(msg.content)
+			}
+		}
 	case trainActionMsg:
 		m.actionBusy = false
 		if msg.err != nil {
@@ -342,6 +378,16 @@ func (m TrainRunModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
+	if m.mode == trainModeSkillView {
+		switch msg.String() {
+		case "esc", "q", "v":
+			m.mode = trainModeNormal
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.skillView, cmd = m.skillView.Update(msg)
+		return m, cmd
+	}
 	if m.mode == trainModeReject {
 		switch msg.String() {
 		case "esc":
@@ -405,8 +451,28 @@ func (m TrainRunModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.actionBusy, m.actionErr = true, ""
 			return m, startNextCmd(m.deps)
 		}
+	case "v":
+		if m.snap.CandidateVersion != "" && m.deps.TemplateVersionContent != nil &&
+			(m.snap.Terminal || m.actionPhase() == "candidate_review_published") {
+			m.mode = trainModeSkillView
+			// Reuse only content cached for THIS candidate version.
+			if m.skillLoaded && m.skillErr == "" && m.skillVersion == m.snap.CandidateVersion {
+				return m, nil
+			}
+			m.skillVersion = m.snap.CandidateVersion
+			m.skillLoaded = false
+			m.skillErr = ""
+			return m, skillContentCmd(m.deps, m.snap.CandidateVersion)
+		}
 	}
 	return m, nil
+}
+
+func skillContentCmd(d TrainRunDeps, versionRef string) tea.Cmd {
+	return func() tea.Msg {
+		content, err := d.TemplateVersionContent(versionRef)
+		return trainSkillContentMsg{versionRef: versionRef, content: content, err: err}
+	}
 }
 
 // actionPhase is the phase the action keys gate on: the iteration phase when

--- a/internal/cli/tui/trainrun_progress_test.go
+++ b/internal/cli/tui/trainrun_progress_test.go
@@ -52,3 +52,98 @@ func TestTrainRunLiveElapsedFallsBackToSnapshotText(t *testing.T) {
 		t.Fatalf("fallback elapsed = %q", got)
 	}
 }
+
+func TestTrainRunSkillPreview(t *testing.T) {
+	snap := TrainRunSnapshot{
+		SessionID:        "s",
+		Phase:            "optimizer_completed_candidate",
+		ActionPhase:      "candidate_promoted",
+		Terminal:         true,
+		CandidateVersion: "tpl@v2",
+	}
+	asked := ""
+	deps := TrainRunDeps{
+		Load: func() (TrainRunSnapshot, error) { return snap, nil },
+		TemplateVersionContent: func(versionRef string) (string, error) {
+			asked = versionRef
+			return "---\nid: tpl\n---\n\n# The Skill\n\nBody.", nil
+		},
+	}
+	m := trainRunModelWithDeps(t, deps, snap)
+	if !strings.Contains(m.View(), "v view skill") {
+		t.Fatalf("footer should offer the preview:\n%s", m.View())
+	}
+	next, cmd := m.Update(key("v"))
+	m = next.(TrainRunModel)
+	if cmd == nil {
+		t.Fatal("v should load the skill content")
+	}
+	if !strings.Contains(m.View(), "loading…") {
+		t.Fatalf("pager should show loading first:\n%s", m.View())
+	}
+	next, _ = m.Update(cmd())
+	m = next.(TrainRunModel)
+	if asked != "tpl@v2" {
+		t.Fatalf("TemplateVersionContent asked for %q", asked)
+	}
+	if !strings.Contains(m.View(), "# The Skill") || !strings.Contains(m.View(), "skill — tpl@v2") {
+		t.Fatalf("pager missing content:\n%s", m.View())
+	}
+	// esc returns to the normal terminal screen.
+	next, _ = m.Update(key("v"))
+	m = next.(TrainRunModel)
+	if m.mode != trainModeNormal || !strings.Contains(m.View(), "n start next iteration") {
+		t.Fatalf("v again should close the pager, mode=%v", m.mode)
+	}
+}
+
+func TestTrainRunSkillPreviewInvalidatesOnNewCandidate(t *testing.T) {
+	snap := TrainRunSnapshot{
+		SessionID: "s", Phase: "optimizer_completed_candidate",
+		ActionPhase: "candidate_promoted", Terminal: true, CandidateVersion: "tpl@v2",
+	}
+	contents := map[string]string{"tpl@v2": "old body v2", "tpl@v3": "new body v3"}
+	deps := TrainRunDeps{
+		Load:                   func() (TrainRunSnapshot, error) { return snap, nil },
+		TemplateVersionContent: func(ref string) (string, error) { return contents[ref], nil },
+	}
+	m := trainRunModelWithDeps(t, deps, snap)
+	next, cmd := m.Update(key("v"))
+	m = next.(TrainRunModel)
+	next, _ = m.Update(cmd())
+	m = next.(TrainRunModel)
+	if !strings.Contains(m.View(), "old body v2") {
+		t.Fatalf("v2 content missing:\n%s", m.View())
+	}
+	next, _ = m.Update(key("v")) // close
+	m = next.(TrainRunModel)
+	// A new candidate arrives; v must fetch the NEW content, not reuse v2's.
+	fresh := snap
+	fresh.CandidateVersion = "tpl@v3"
+	next, _ = m.Update(trainSnapshotMsg{snap: fresh, at: time.Unix(2, 0)})
+	m = next.(TrainRunModel)
+	next, cmd = m.Update(key("v"))
+	m = next.(TrainRunModel)
+	if cmd == nil {
+		t.Fatal("a new candidate must re-fetch")
+	}
+	next, _ = m.Update(cmd())
+	m = next.(TrainRunModel)
+	if !strings.Contains(m.View(), "new body v3") || strings.Contains(m.View(), "old body v2") {
+		t.Fatalf("stale cache shown for the new candidate:\n%s", m.View())
+	}
+}
+
+func TestTrainRunSkillPreviewUnavailableWithoutCandidate(t *testing.T) {
+	snap := TrainRunSnapshot{SessionID: "s", Phase: "review_published", ActionPhase: "review_published"}
+	deps := TrainRunDeps{
+		Load:                   func() (TrainRunSnapshot, error) { return snap, nil },
+		TemplateVersionContent: func(string) (string, error) { t.Fatal("must not load"); return "", nil },
+	}
+	m := trainRunModelWithDeps(t, deps, snap)
+	next, cmd := m.Update(key("v"))
+	m = next.(TrainRunModel)
+	if cmd != nil || m.mode != trainModeNormal {
+		t.Fatal("v without a candidate must be a no-op")
+	}
+}

--- a/internal/cli/tui/trainrun_view.go
+++ b/internal/cli/tui/trainrun_view.go
@@ -59,6 +59,13 @@ func (m TrainRunModel) View() string {
 		b.WriteString("\n\n")
 	}
 
+	if m.mode == trainModeSkillView {
+		b.WriteString(m.skillViewBody())
+		b.WriteString("\n")
+		b.WriteString(mutedStyle.Render("↑/↓ scroll  esc back"))
+		return b.String()
+	}
+
 	b.WriteString(m.body())
 
 	if m.mode == trainModeReject {
@@ -99,6 +106,9 @@ func (m TrainRunModel) footer() string {
 	}
 	if m.snap.Terminal {
 		action = "n start next iteration  "
+	}
+	if m.snap.CandidateVersion != "" && (m.snap.Terminal || m.actionPhase() == "candidate_review_published") {
+		action += "v view skill  "
 	}
 	return action + "r refresh  q quit"
 }
@@ -231,6 +241,23 @@ func (m TrainRunModel) body() string {
 
 	if s.NextAction != "" {
 		b.WriteString(mutedStyle.Render("next: " + s.NextAction))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// skillViewBody renders the candidate skill content in a scrollable pager.
+func (m TrainRunModel) skillViewBody() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("skill — " + dash(m.snap.CandidateVersion)))
+	b.WriteString("\n\n")
+	switch {
+	case m.skillErr != "":
+		b.WriteString(errorStyle.Render(m.skillErr) + "\n")
+	case !m.skillLoaded:
+		b.WriteString(mutedStyle.Render("loading…") + "\n")
+	default:
+		b.WriteString(m.skillView.View())
 		b.WriteByte('\n')
 	}
 	return b.String()


### PR DESCRIPTION
## WHAT
Task 6 of #255 (item 9b): `v` on the promote/terminal screens opens the candidate skill's content in a scrollable pager.

## WHY
After promotion (or while deciding) there was no way to read the actual skill text without leaving the TUI and digging up the template version by hand.

## CHANGES
`TrainRunDeps.TemplateVersionContent` (wired to `store.GetAgentTemplateReference`); a `trainModeSkillView` viewport pager with lazy load, loading/error states, and `esc`/`q`/`v` to close; footer offers `v view skill` whenever a candidate version exists on the decision or terminal screens.

Review fixes baked in: the content cache is keyed by version (start-next's new candidate re-fetches instead of showing the previous iteration's text under the new header); the arriving content matches the *requested* version rather than the live snapshot (a refresh advancing the candidate mid-load can no longer wedge the pager on "loading…"); window resizes re-dimension the pager; the write-only content field was removed.

## RESULTS
tui + cli TrainRun suites green. New tests: full v→load→render→close cycle, no-op without a candidate, and the stale-cache invalidation regression.

## RISK
TUI-only; one additive dep backed by an existing store read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)