### PR TITLE
github: treat gh's could-not-resolve as repository not found

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -358,9 +358,9 @@ func (c *GhClient) ListUserRepositories(ctx context.Context, limit int) ([]RepoS
 }
 
 // RepositoryExists reports whether the repo is visible to the authenticated gh
-// user. A 404 (or "not found") maps to (false, nil); any other error (auth,
-// network, rate limit) propagates so callers never offer to create a repo on an
-// ambiguous failure.
+// user. A 404, "not found", or the GraphQL "could not resolve to a repository"
+// phrasing maps to (false, nil); any other error (auth, network, rate limit)
+// propagates so callers never offer to create a repo on an ambiguous failure.
 func (c *GhClient) RepositoryExists(ctx context.Context, repo Repository) (bool, error) {
 	if strings.TrimSpace(repo.FullName()) == "" {
 		return false, fmt.Errorf("repository owner/name is required")
@@ -850,7 +850,15 @@ func isRateLimit(result subprocess.Result) bool {
 
 func isNotFound(result subprocess.Result) bool {
 	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
-	return strings.Contains(text, "http 404") || strings.Contains(text, "not found")
+	// `gh repo view` reports a missing repo via the GraphQL resolver phrasing
+	// rather than an HTTP 404 ("Could not resolve to a Repository with the
+	// name 'owner/name'"). gh uses the same phrasing for repos that exist but
+	// the token cannot see (private/org/EMU); treating those as "not found"
+	// is safe because the follow-up `gh repo create` then fails loudly with
+	// "name already exists" instead of leaving the caller dead-ended.
+	return strings.Contains(text, "http 404") ||
+		strings.Contains(text, "not found") ||
+		strings.Contains(text, "could not resolve to a repository")
 }
 
 func isNoChecks(result subprocess.Result) bool {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -36,6 +36,21 @@ func TestRepositoryExists(t *testing.T) {
 		}
 	})
 
+	t.Run("graphql could-not-resolve maps to not found", func(t *testing.T) {
+		// `gh repo view` reports a missing repo via the GraphQL resolver rather
+		// than HTTP 404; this is the phrasing that previously dead-ended the
+		// setup pickers' create offer.
+		runner := &fakeRunner{
+			results: []subprocess.Result{{Stderr: "GraphQL: Could not resolve to a Repository with the name 'o/r'. (repository)"}},
+			errs:    []error{errors.New("exit status 1")},
+		}
+		client := GhClient{Runner: runner}
+		ok, err := client.RepositoryExists(context.Background(), repo)
+		if err != nil || ok {
+			t.Fatalf("RepositoryExists = (%v, %v), want (false, nil) for could-not-resolve", ok, err)
+		}
+	})
+
 	t.Run("auth error propagates", func(t *testing.T) {
 		runner := &fakeRunner{
 			results: []subprocess.Result{{Stderr: "gh: To get started with GitHub CLI, please run: gh auth login"}},


### PR DESCRIPTION
## WHAT
Task 1 of #261: the repo existence check recognizes the GraphQL "could not resolve to a Repository" phrasing `gh repo view` uses for missing repos.

## WHY
Observed live in the train setup picker: typing a non-existent repo showed `repo check failed: GraphQL: Could not resolve to a Repository…` with no way forward, instead of the designed "repo does not exist — c create / e re-enter" offer. `isNotFound` only matched `http 404` / `not found`, so a plainly-missing repo became an *error* — which also made the headless `ensureSkillOptTrainRepo --create-repos` path silently skip creation (its ambiguous-error guard).

## CHANGES
`isNotFound` gains the `could not resolve to a repository` marker (input already lowercased). The two other callers (`GetUserPermission`, the file-contents check) hit REST endpoints that emit HTTP 404, so the marker is inert for them.

## RESULTS
`go test ./internal/github` green (new subtest feeds the real gh stderr through `RepositoryExists`, asserts `(false, nil)`; existing 404/not-found/auth cases unchanged); `go test ./internal/cli -run RepoCreate` green.

## RISK
Documented and accepted: gh emits the same phrasing for repos that exist but the token cannot see (private/org/EMU). Mapping those to "not found" can offer creation, and `gh repo create` then fails loudly with "name already exists" — a safe, self-explaining backstop vs. today's dead-end on every genuinely missing repo. Review (single-pass, focused) found no other risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)