### PR TITLE
cli: inline scalar config editing with comment-preserving writes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/creachadair/tomledit v0.0.29
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -22,10 +22,14 @@ github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfa
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
+github.com/creachadair/tomledit v0.0.29 h1:dB5CbdwJMpn/fmfAPTAAleXF/KJwY0Ggc1eL/zvZRgk=
+github.com/creachadair/tomledit v0.0.29/go.mod h1:4SoTXxzHgvzHRMIJPw+o6zK/yXii4VjLrb6/3gCQnyA=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/cli/dashboard_config.go
+++ b/internal/cli/dashboard_config.go
@@ -35,14 +35,26 @@ func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) 
 		}
 		sort.Strings(names)
 		rows := [][]string{{"NAME", "RUNTIME", "TEMPLATE", "ROLE", "MAX_BG", "IDLE", "JOB"}}
+		var editable []tui.ConfigField
 		for _, name := range names {
 			t := types[name]
 			rows = append(rows, []string{
 				name, t.Runtime, t.Template, dashConfig(t.Role),
 				strconv.Itoa(t.MaxBackground), dashConfig(t.IdleTimeout), dashConfig(t.JobTimeout),
 			})
+			// Scalar fields safe to edit inline; the rest (runtime, template,
+			// capabilities, adding/removing types) stay an $EDITOR job.
+			editable = append(editable,
+				tui.ConfigField{Label: name + " · max_background", KeyPath: []string{"agents", name, "max_background"}, Kind: tui.ConfigInt, Value: strconv.Itoa(t.MaxBackground)},
+			)
+			if strings.TrimSpace(t.IdleTimeout) != "" {
+				editable = append(editable, tui.ConfigField{Label: name + " · idle_timeout", KeyPath: []string{"agents", name, "idle_timeout"}, Kind: tui.ConfigDuration, Value: t.IdleTimeout})
+			}
+			if strings.TrimSpace(t.JobTimeout) != "" {
+				editable = append(editable, tui.ConfigField{Label: name + " · job_timeout", KeyPath: []string{"agents", name, "job_timeout"}, Kind: tui.ConfigDuration, Value: t.JobTimeout})
+			}
 		}
-		view.Sections = append(view.Sections, tui.ConfigSection{Title: "agent types", Rows: rows})
+		view.Sections = append(view.Sections, tui.ConfigSection{Title: "agent types", Rows: rows, Editable: editable})
 	}
 
 	if policy, err := config.LoadParallelSessionPolicy(paths); err == nil {
@@ -57,10 +69,13 @@ func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) 
 		})
 	}
 
-	if repo, err := config.LoadDefaultFeedbackRepo(paths); err == nil {
+	if repo, err := config.LoadDefaultFeedbackRepo(paths); err == nil && strings.TrimSpace(repo) != "" {
 		view.Sections = append(view.Sections, tui.ConfigSection{
 			Title: "feedback",
 			Rows:  [][]string{{"repo", dashConfig(repo)}},
+			Editable: []tui.ConfigField{
+				{Label: "feedback · repo", KeyPath: []string{"feedback", "repo"}, Kind: tui.ConfigText, Value: repo},
+			},
 		})
 	}
 
@@ -76,6 +91,18 @@ func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) 
 	}
 
 	return view
+}
+
+// configScalarForKind types the value for the writer from the field's own
+// classification (the single source of truth), so a new int field cannot be
+// mis-written as a string. Durations and repos are stored as TOML strings.
+func configScalarForKind(kind tui.ConfigKind, value string) config.ConfigScalar {
+	if kind == tui.ConfigInt {
+		if n, err := strconv.Atoi(value); err == nil {
+			return config.IntScalar(n)
+		}
+	}
+	return config.StringScalar(value)
 }
 
 func dashConfig(value string) string {

--- a/internal/cli/dashboard_config_test.go
+++ b/internal/cli/dashboard_config_test.go
@@ -109,3 +109,27 @@ func TestEditConfigCmdHonorsEditorEnv(t *testing.T) {
 	// cmd must be non-nil and the env path is exercised in the hand test.
 	_ = tea.Cmd(cmd)
 }
+
+func TestConfigScalarForKind(t *testing.T) {
+	intVal := configScalarForKind(tui.ConfigInt, "8")
+	strVal := configScalarForKind(tui.ConfigDuration, "15m")
+	repoVal := configScalarForKind(tui.ConfigText, "owner/x")
+	// Apply each to a fixture and confirm the stored TOML type round-trips.
+	paths := writeConfig(t, sampleConfigTOML)
+	if err := config.SetConfigScalar(paths, []string{"agents", "planner", "max_background"}, intVal); err != nil {
+		t.Fatalf("int write: %v", err)
+	}
+	if err := config.SetConfigScalar(paths, []string{"agents", "planner", "idle_timeout"}, strVal); err != nil {
+		t.Fatalf("duration write: %v", err)
+	}
+	if err := config.SetConfigScalar(paths, []string{"feedback", "repo"}, repoVal); err != nil {
+		t.Fatalf("repo write: %v", err)
+	}
+	types, err := config.LoadAgentTypes(paths)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if types["planner"].MaxBackground != 8 || types["planner"].IdleTimeout != "15m" {
+		t.Fatalf("typed writes wrong: %+v", types["planner"])
+	}
+}

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/jerryfane/gitmoot/internal/cli/tui"
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/doctor"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
@@ -286,6 +287,13 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 				return []string{err.Error()}
 			}
 			return validateDashboardConfig(paths)
+		},
+		SetConfigScalar: func(keyPath []string, value string, kind tui.ConfigKind) error {
+			paths, err := initializedPaths(home)
+			if err != nil {
+				return err
+			}
+			return config.SetConfigScalar(paths, keyPath, configScalarForKind(kind, value))
 		},
 		HealthChecks: func() ([]tui.HealthCheck, error) {
 			checks := doctor.Checker{Dir: "."}.Run(context.Background())

--- a/internal/cli/tui/config.go
+++ b/internal/cli/tui/config.go
@@ -1,6 +1,117 @@
 package tui
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// configEditableFields flattens the inline-editable fields across all config
+// sections, in render order — the Config page's cursor indexes into this.
+func (m Model) configEditableFields() []ConfigField {
+	var fields []ConfigField
+	for _, section := range m.snap.Config.Sections {
+		fields = append(fields, section.Editable...)
+	}
+	return fields
+}
+
+// openConfigEdit enters the inline edit overlay for a scalar field.
+func (m *Model) openConfigEdit(field ConfigField) tea.Cmd {
+	m.configField = field
+	m.configActionErr = ""
+	m.mode = modeConfigEdit
+	ti := textinput.New()
+	ti.SetValue(field.Value)
+	ti.CursorEnd()
+	m.input = ti
+	return m.input.Focus()
+}
+
+// updateConfigOverlay handles keys while editing a scalar config field.
+func (m Model) updateConfigOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		if m.actionBusy {
+			return m, nil
+		}
+		m.mode = modeNormal
+		m.configActionErr = ""
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case "enter":
+		if m.actionBusy {
+			return m, nil
+		}
+		value := strings.TrimSpace(m.input.Value())
+		if problem := validateConfigValue(m.configField.Kind, value); problem != "" {
+			m.configActionErr = problem
+			m.viewport.SetContent(m.content())
+			return m, nil
+		}
+		m.actionBusy = true
+		m.configActionErr = ""
+		m.viewport.SetContent(m.content())
+		return m, configWriteCmd(m.deps, m.configField.KeyPath, value, m.configField.Kind)
+	}
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	m.viewport.SetContent(m.content())
+	return m, cmd
+}
+
+// validateConfigValue checks a value's shape before the write attempt, so a
+// typo re-asks in the overlay instead of round-tripping through the writer.
+func validateConfigValue(kind ConfigKind, value string) string {
+	switch kind {
+	case ConfigInt:
+		if n, err := strconv.Atoi(value); err != nil || n < 1 {
+			return "must be an integer ≥ 1"
+		}
+	case ConfigDuration:
+		d, err := time.ParseDuration(value)
+		if err != nil || d <= 0 {
+			return "must be a positive duration like 10m or 45m"
+		}
+	case ConfigText:
+		if value == "" {
+			return "value is required"
+		}
+	}
+	return ""
+}
+
+func configWriteCmd(deps Deps, keyPath []string, value string, kind ConfigKind) tea.Cmd {
+	return func() tea.Msg {
+		if deps.SetConfigScalar == nil {
+			return configWriteMsg{}
+		}
+		return configWriteMsg{err: deps.SetConfigScalar(keyPath, value, kind)}
+	}
+}
+
+// configEditView renders the inline edit overlay.
+func (m Model) configEditView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("edit " + m.configField.Label))
+	b.WriteString("\n\n")
+	b.WriteString(strings.Join(m.configField.KeyPath, ".") + "\n\n")
+	b.WriteString(m.input.View())
+	b.WriteByte('\n')
+	if m.configActionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.configActionErr) + "\n")
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("writing…"))
+	} else {
+		b.WriteString(mutedStyle.Render("enter save  esc cancel"))
+	}
+	return b.String()
+}
 
 // configContent renders the Config page: each parsed section as a key/value
 // table, the config file path, and any validation problems from the last edit.
@@ -26,6 +137,21 @@ func (m Model) configContent() string {
 		b.WriteByte('\n')
 	}
 
+	// Inline-editable scalars as a cursor list (enter to change one).
+	fields := m.configEditableFields()
+	if len(fields) > 0 {
+		b.WriteString(headerStyle.Render("editable settings"))
+		b.WriteByte('\n')
+		for i, field := range fields {
+			cursor, label := "  ", field.Label
+			if i == m.configCursor {
+				cursor, label = "▸ ", selectedRowStyle.Render(field.Label)
+			}
+			b.WriteString(cursor + label + "  " + mutedStyle.Render(dash(field.Value)) + "\n")
+		}
+		b.WriteByte('\n')
+	}
+
 	if m.configEditErr != "" {
 		b.WriteString(errorStyle.Render("editor: "+m.configEditErr) + "\n")
 	}
@@ -37,7 +163,11 @@ func (m Model) configContent() string {
 		b.WriteString(mutedStyle.Render("e to fix") + "\n")
 	}
 
-	b.WriteString("\n" + mutedStyle.Render("e edit in $EDITOR · structural edits stay in the editor"))
+	hint := "e edit in $EDITOR · structural edits stay in the editor"
+	if len(fields) > 0 {
+		hint = "↑/↓ select · enter change · " + hint
+	}
+	b.WriteString("\n" + mutedStyle.Render(hint))
 	b.WriteByte('\n')
 	return b.String()
 }

--- a/internal/cli/tui/config_test.go
+++ b/internal/cli/tui/config_test.go
@@ -117,3 +117,125 @@ func TestConfigEditNoOpWithoutDep(t *testing.T) {
 		t.Fatal("e without an EditConfig dep must be a no-op")
 	}
 }
+
+func configEditSnapshot() Snapshot {
+	return Snapshot{
+		Daemon: Daemon{Running: true},
+		Config: ConfigView{
+			Path: "/home/.gitmoot/config.toml",
+			Sections: []ConfigSection{
+				{Title: "agent types", Rows: [][]string{{"NAME"}, {"planner"}}, Editable: []ConfigField{
+					{Label: "planner · max_background", KeyPath: []string{"agents", "planner", "max_background"}, Kind: ConfigInt, Value: "4"},
+					{Label: "planner · idle_timeout", KeyPath: []string{"agents", "planner", "idle_timeout"}, Kind: ConfigDuration, Value: "10m"},
+				}},
+				{Title: "feedback", Rows: [][]string{{"repo", "owner/feedback"}}, Editable: []ConfigField{
+					{Label: "feedback · repo", KeyPath: []string{"feedback", "repo"}, Kind: ConfigText, Value: "owner/feedback"},
+				}},
+			},
+		},
+	}
+}
+
+func configEditModel(t *testing.T, deps Deps) Model {
+	t.Helper()
+	snap := configEditSnapshot()
+	if deps.Load == nil {
+		deps.Load = func() (Snapshot, error) { return snap, nil }
+	}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	for pages[m.selected].page != pageConfig {
+		next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+		if cmd != nil {
+			cmd()
+		}
+	}
+	return m
+}
+
+func TestConfigInlineEditWritesScalar(t *testing.T) {
+	var gotPath []string
+	var gotValue string
+	deps := Deps{SetConfigScalar: func(keyPath []string, value string, kind ConfigKind) error {
+		gotPath, gotValue = keyPath, value
+		return nil
+	}}
+	m := configEditModel(t, deps)
+	// Cursor on the first editable field (planner · max_background).
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if m.mode != modeConfigEdit || cmd == nil {
+		t.Fatalf("enter should open the inline editor, mode=%v", m.mode)
+	}
+	// Clear "4", type "8".
+	for range "4" {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+		m = next.(Model)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("8")})
+	m = next.(Model)
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if len(gotPath) != 3 || gotPath[2] != "max_background" || gotValue != "8" {
+		t.Fatalf("SetConfigScalar called with (%v, %q)", gotPath, gotValue)
+	}
+	if m.mode != modeNormal {
+		t.Fatalf("a successful write should close the editor, mode=%v", m.mode)
+	}
+}
+
+func TestConfigInlineEditValidatesBeforeWrite(t *testing.T) {
+	deps := Deps{SetConfigScalar: func(keyPath []string, value string, kind ConfigKind) error {
+		t.Fatal("must not write an invalid value")
+		return nil
+	}}
+	m := configEditModel(t, deps)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter}) // open editor on max_background (int)
+	m = next.(Model)
+	for range "4" {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+		m = next.(Model)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("abc")})
+	m = next.(Model)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatal("an invalid int must not dispatch a write")
+	}
+	if m.mode != modeConfigEdit || !strings.Contains(m.View(), "integer ≥ 1") {
+		t.Fatalf("invalid value should re-ask in the overlay:\n%s", m.View())
+	}
+}
+
+func TestConfigInlineEditWriteErrorKeepsOverlay(t *testing.T) {
+	deps := Deps{SetConfigScalar: func(keyPath []string, value string, kind ConfigKind) error {
+		return errors.New("config invalid after edit (reverted)")
+	}}
+	m := configEditModel(t, deps)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter}) // submit unchanged value
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeConfigEdit || !strings.Contains(m.View(), "reverted") {
+		t.Fatalf("a write error should keep the overlay with the message:\n%s", m.View())
+	}
+}
+
+func TestConfigDurationFieldValidation(t *testing.T) {
+	if validateConfigValue(ConfigDuration, "10m") != "" {
+		t.Fatal("10m should be a valid duration")
+	}
+	if validateConfigValue(ConfigDuration, "nope") == "" {
+		t.Fatal("nope should be rejected as a duration")
+	}
+	if validateConfigValue(ConfigInt, "0") == "" {
+		t.Fatal("0 should be rejected (must be >= 1)")
+	}
+}

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -57,12 +57,39 @@ type ConfigView struct {
 // ConfigSection is one titled group of key/value rows on the Config page.
 type ConfigSection struct {
 	Title string
-	Rows  [][]string // each row is {key, value}
+	Rows  [][]string // each row is {key, value}; for tables, the first row is a header
+
+	// Editable lists the inline-editable scalar fields in this section, in the
+	// order they should be cycled. Sections without editable fields (paths,
+	// daemon) omit it; structural edits stay in $EDITOR.
+	Editable []ConfigField
+}
+
+// ConfigKind classifies how an inline config edit is validated.
+type ConfigKind int
+
+const (
+	ConfigText     ConfigKind = iota // free text (e.g. owner/repo, checked by Validate)
+	ConfigInt                        // integer ≥ 1
+	ConfigDuration                   // Go duration string (10m, 45m)
+)
+
+// ConfigField is one inline-editable scalar on the Config page.
+type ConfigField struct {
+	Label   string     // human label, e.g. "planner · max_background"
+	KeyPath []string   // full dotted path for the writer, e.g. {agents, planner, max_background}
+	Kind    ConfigKind //
+	Value   string     // current value (prefilled in the editor)
 }
 
 // ConfigEditedMsg is delivered when the external editor (Deps.EditConfig) exits.
 type ConfigEditedMsg struct {
 	Err error
+}
+
+// configWriteMsg carries the outcome of an inline Deps.SetConfigScalar write.
+type configWriteMsg struct {
+	err error
 }
 
 // HealthCheck is one environment/runtime diagnostic for the Health page.
@@ -207,6 +234,12 @@ type Deps struct {
 	// and returns human-readable problems (empty when valid).
 	EditConfig     func() tea.Cmd
 	ValidateConfig func() []string
+
+	// SetConfigScalar writes one scalar config field (comment-preserving) and
+	// returns an error on an invalid value or a write that fails to re-parse.
+	// The kind tells the writer how to type the TOML value (int vs string),
+	// so the field's classification is the single source of truth.
+	SetConfigScalar func(keyPath []string, value string, kind ConfigKind) error
 }
 
 // TemplateVersion is one row of a template's version history.

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -62,6 +62,7 @@ const (
 	modeAgentRevertPick
 	modeConfirmAgentRevert
 	modeConfirmAgentDelete
+	modeConfigEdit
 )
 
 const defaultInterval = 5 * time.Second
@@ -111,8 +112,11 @@ type Model struct {
 	healthErr     string
 
 	// Config page state.
-	configProblems []string // validation problems after an edit (empty = valid)
-	configEditErr  string   // the editor itself failed to launch/run
+	configProblems  []string    // validation problems after an $EDITOR edit (empty = valid)
+	configEditErr   string      // the editor itself failed to launch/run
+	configCursor    int         // selected editable field on the Config page
+	configField     ConfigField // field being edited inline
+	configActionErr string      // inline write error in the edit overlay
 
 	// Trains page action state.
 	pendingRepos []string // gitmoot-created repos offered for cleanup after a delete
@@ -186,6 +190,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 			return m.updateAgentOverlay(msg)
+		case modeConfigEdit:
+			if msg.String() == "ctrl+c" {
+				return m, tea.Quit
+			}
+			return m.updateConfigOverlay(msg)
 		}
 		if m.mode != modeNormal {
 			return m.updateOverlay(msg)
@@ -261,6 +270,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 			}
 		case "enter":
+			if pages[m.selected].page == pageConfig {
+				fields := m.configEditableFields()
+				if m.deps.SetConfigScalar != nil && m.configCursor < len(fields) {
+					cmd := m.openConfigEdit(fields[m.configCursor])
+					m.viewport.SetContent(m.content())
+					return m, cmd
+				}
+				return m, tea.Batch(cmds...)
+			}
 			if pages[m.selected].page == pageTrains {
 				// With a Root router, open the full train-run view; otherwise the
 				// inline detail (keeps the model usable standalone and old tests
@@ -411,6 +429,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.healthErr = ""
 			m.healthChecks = msg.checks
+		}
+	case configWriteMsg:
+		if m.mode == modeConfigEdit {
+			m.actionBusy = false
+			if msg.err != nil {
+				m.configActionErr = msg.err.Error()
+			} else {
+				m.mode = modeNormal
+				m.configActionErr = ""
+				if cmd := m.queueLoad(); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+			}
 		}
 	case ConfigEditedMsg:
 		if msg.Err != nil {
@@ -606,6 +637,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampTrainCursor()
 			m.clampJobCursor()
 			m.agentCursor = clampCursor(m.agentCursor, len(m.snap.Agents))
+			m.configCursor = clampCursor(m.configCursor, len(m.configEditableFields()))
 			// A cancel-requested job that has settled no longer needs the
 			// transitional "cancelling…" label.
 			for id := range m.cancelling {
@@ -727,6 +759,8 @@ func (m *Model) pageCursor() (*int, int) {
 		return &m.agentCursor, len(m.snap.Agents)
 	case pageJobs:
 		return &m.jobCursor, len(m.snap.JobRows)
+	case pageConfig:
+		return &m.configCursor, len(m.configEditableFields())
 	}
 	return nil, 0
 }

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -96,6 +96,8 @@ func (m Model) content() string {
 		b.WriteString(m.agentRevertConfirmView())
 	case modeConfirmAgentDelete:
 		b.WriteString(m.agentDeleteConfirmView())
+	case modeConfigEdit:
+		b.WriteString(m.configEditView())
 	default:
 		switch pages[m.selected].page {
 		case pageAttention:
@@ -159,7 +161,9 @@ func (m Model) helpContent() string {
 		b.WriteString("r    re-run the environment checks\n")
 		b.WriteString("s    start the daemon when it is stopped\n")
 	case pageConfig:
-		b.WriteString("the parsed config sections (read-only here)\n")
+		b.WriteString("the parsed config sections + inline-editable settings\n")
+		b.WriteString("↑/↓  select an editable setting\n")
+		b.WriteString("enter change the selected setting (validated, comment-preserving)\n")
 		b.WriteString("e    edit config.toml in $EDITOR; re-validated on return\n")
 		b.WriteString("     structural edits (add/remove agent types) stay in the editor\n")
 	default:
@@ -200,6 +204,8 @@ func (m Model) footerHelp() string {
 		return "↑/↓ pick  enter confirm  esc back"
 	case modeConfirmAgentRevert, modeConfirmAgentDelete:
 		return "y confirm  n/esc cancel"
+	case modeConfigEdit:
+		return "type value  enter save  esc cancel"
 	}
 	switch pages[m.selected].page {
 	case pageAttention:
@@ -213,7 +219,7 @@ func (m Model) footerHelp() string {
 	case pageHealth:
 		return "tab/←→ page  r re-run checks  s start daemon  ? help  q quit"
 	case pageConfig:
-		return "tab/←→ page  e edit in $EDITOR  ? help  q quit"
+		return "tab/←→ page  ↑/↓ select  enter change  e editor  ? help  q quit"
 	}
 	return "tab/←→ page  j/k or wheel scroll  r refresh  q quit"
 }

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/creachadair/tomledit"
+	"github.com/creachadair/tomledit/parser"
+)
+
+// SetConfigScalar replaces the value of an existing scalar key in the config
+// file, preserving comments, key order, and formatting (tomledit edits the
+// lossless AST). keyPath is the full dotted path, e.g.
+// {"agents", "planner", "max_background"} or {"feedback", "repo"}. The key must
+// already exist — adding/removing keys or whole sections stays an $EDITOR job.
+//
+// The write is atomic (temp file + rename) and validated: if the resulting
+// file fails to re-parse through the Load* parsers, the original is restored
+// and the validation error is returned.
+func SetConfigScalar(paths Paths, keyPath []string, value ConfigScalar) error {
+	if len(keyPath) < 2 {
+		return fmt.Errorf("config key path must include a section and a key")
+	}
+	original, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return err
+	}
+	doc, err := tomledit.Parse(strings.NewReader(string(original)))
+	if err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+	entry := doc.First(keyPath...)
+	if entry == nil || entry.KeyValue == nil {
+		return fmt.Errorf("config key %q not found", strings.Join(keyPath, "."))
+	}
+	parsed, err := parser.ParseValue(value.toml())
+	if err != nil {
+		return fmt.Errorf("invalid config value %q: %w", value.toml(), err)
+	}
+	// Preserve any trailing line-comment on the edited key (ParseValue of the
+	// bare new value carries none); block comments live on the KeyValue and
+	// are untouched.
+	parsed.Trailer = entry.Value.Trailer
+	entry.Value = parsed
+
+	var buf strings.Builder
+	if err := tomledit.Format(&buf, doc); err != nil {
+		return fmt.Errorf("format config: %w", err)
+	}
+
+	if err := writeConfigAtomic(paths.ConfigFile, []byte(buf.String())); err != nil {
+		return err
+	}
+	// Validate through the real parsers; restore the original on any failure so
+	// a bad write can never wedge the daemon.
+	if err := validateConfigFile(paths); err != nil {
+		if restoreErr := writeConfigAtomic(paths.ConfigFile, original); restoreErr != nil {
+			return fmt.Errorf("config invalid after edit AND restore failed (file left broken: %v): %w", restoreErr, err)
+		}
+		return fmt.Errorf("config invalid after edit (reverted): %w", err)
+	}
+	return nil
+}
+
+// ConfigScalar is a typed scalar value to write, so the caller need not build
+// TOML literals (and get quoting wrong).
+type ConfigScalar struct {
+	str  *string
+	num  *int
+	list []string
+}
+
+// StringScalar / IntScalar / StringListScalar construct a ConfigScalar.
+func StringScalar(v string) ConfigScalar       { return ConfigScalar{str: &v} }
+func IntScalar(v int) ConfigScalar             { return ConfigScalar{num: &v} }
+func StringListScalar(v []string) ConfigScalar { return ConfigScalar{list: v} }
+
+func (c ConfigScalar) toml() string {
+	switch {
+	case c.num != nil:
+		return strconv.Itoa(*c.num)
+	case c.list != nil:
+		quoted := make([]string, len(c.list))
+		for i, item := range c.list {
+			quoted[i] = strconv.Quote(item)
+		}
+		return "[" + strings.Join(quoted, ", ") + "]"
+	case c.str != nil:
+		return strconv.Quote(*c.str)
+	default:
+		return `""`
+	}
+}
+
+// validateConfigFile re-runs every config parser, returning the first error.
+func validateConfigFile(paths Paths) error {
+	if _, err := LoadAgentTypes(paths); err != nil {
+		return err
+	}
+	if _, err := LoadParallelSessionPolicy(paths); err != nil {
+		return err
+	}
+	if _, err := LoadDefaultFeedbackRepo(paths); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeConfigAtomic(path string, contents []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".config-*.toml")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(contents); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const editFixture = `# Gitmoot local configuration.
+
+[paths]
+database = "/home/.gitmoot/gitmoot.db"
+
+[agents.planner]
+# the planner runs ask jobs
+runtime = "codex"
+template = "gitmoot-plan-and-goal"
+max_background = 4
+idle_timeout = "10m"
+
+[feedback]
+repo = "owner/feedback"
+`
+
+func editTestPaths(t *testing.T, contents string) Paths {
+	t.Helper()
+	home := t.TempDir()
+	paths := PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return paths
+}
+
+func TestSetConfigScalarPreservesCommentsAndOtherKeys(t *testing.T) {
+	paths := editTestPaths(t, editFixture)
+	if err := SetConfigScalar(paths, []string{"agents", "planner", "max_background"}, IntScalar(8)); err != nil {
+		t.Fatalf("SetConfigScalar: %v", err)
+	}
+	out, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "max_background = 8") {
+		t.Fatalf("value not updated:\n%s", got)
+	}
+	// Comments and untouched keys survive.
+	for _, want := range []string{
+		"# Gitmoot local configuration.",
+		"# the planner runs ask jobs",
+		`template = "gitmoot-plan-and-goal"`,
+		`idle_timeout = "10m"`,
+		`repo = "owner/feedback"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("lost %q after edit:\n%s", want, got)
+		}
+	}
+	// The change re-parses through the real loaders.
+	types, err := LoadAgentTypes(paths)
+	if err != nil {
+		t.Fatalf("LoadAgentTypes after edit: %v", err)
+	}
+	if types["planner"].MaxBackground != 8 {
+		t.Fatalf("max_background = %d, want 8", types["planner"].MaxBackground)
+	}
+}
+
+func TestSetConfigScalarStringValue(t *testing.T) {
+	paths := editTestPaths(t, editFixture)
+	if err := SetConfigScalar(paths, []string{"feedback", "repo"}, StringScalar("owner/other")); err != nil {
+		t.Fatalf("SetConfigScalar: %v", err)
+	}
+	repo, err := LoadDefaultFeedbackRepo(paths)
+	if err != nil || repo != "owner/other" {
+		t.Fatalf("feedback repo = %q (err %v)", repo, err)
+	}
+}
+
+func TestSetConfigScalarMissingKeyErrors(t *testing.T) {
+	paths := editTestPaths(t, editFixture)
+	if err := SetConfigScalar(paths, []string{"agents", "planner", "nonexistent"}, IntScalar(1)); err == nil {
+		t.Fatal("expected error for a missing key")
+	}
+	// Adding new keys is not allowed here (stays an $EDITOR job).
+	if err := SetConfigScalar(paths, []string{"agents", "ghost", "max_background"}, IntScalar(1)); err == nil {
+		t.Fatal("expected error for a missing section")
+	}
+}
+
+func TestSetConfigScalarRevertsOnInvalidResult(t *testing.T) {
+	paths := editTestPaths(t, editFixture)
+	original, _ := os.ReadFile(paths.ConfigFile)
+	// max_background must be an integer; writing a non-int string makes the
+	// re-parse fail, so the write must be reverted.
+	err := SetConfigScalar(paths, []string{"agents", "planner", "max_background"}, StringScalar("not-an-int"))
+	if err == nil {
+		t.Fatal("expected validation failure")
+	}
+	after, _ := os.ReadFile(paths.ConfigFile)
+	if string(after) != string(original) {
+		t.Fatalf("file not reverted after invalid edit:\n%s", string(after))
+	}
+}
+
+func TestSetConfigScalarPreservesTrailingComment(t *testing.T) {
+	fixture := "[agents.planner]\nmax_background = 4 # ops cap, do not exceed\n"
+	paths := editTestPaths(t, fixture)
+	if err := SetConfigScalar(paths, []string{"agents", "planner", "max_background"}, IntScalar(8)); err != nil {
+		t.Fatalf("SetConfigScalar: %v", err)
+	}
+	out, _ := os.ReadFile(paths.ConfigFile)
+	got := string(out)
+	if !strings.Contains(got, "max_background = 8") {
+		t.Fatalf("value not updated:\n%s", got)
+	}
+	if !strings.Contains(got, "ops cap, do not exceed") {
+		t.Fatalf("trailing comment on the edited line was dropped:\n%s", got)
+	}
+}


### PR DESCRIPTION
## WHAT
Task 4 of #261: edit safe scalar config fields inline on the Config page, with a comment-preserving TOML writer.

## WHY
Task 3 gave the Config page read-only views + `$EDITOR`. This adds quick inline edits for the common scalars without opening an editor — and does it without the comment loss that `go-toml v2` (which dropped document editing) would cause.

## CHANGES
- **`config.SetConfigScalar`** (new `internal/config/edit.go`) on `creachadair/tomledit`: parse the lossless AST, set an *existing* key's value, format back. Comments (block AND the edited line's trailing comment), key order, and formatting are preserved. The write is atomic (temp + rename) and re-validated through the existing `config.Load*` parsers; an invalid result is reverted to the original (and if even the revert fails, the error says so loudly). Adding/removing keys or sections is refused — that stays an `$EDITOR` job.
- **Config page**: an "editable settings" cursor list (agent-type `max_background`/`idle_timeout`/`job_timeout`, feedback `repo`); `enter` opens a text overlay that validates the value's shape (int ≥1, **positive** duration, non-empty repo) before writing via `Deps.SetConfigScalar`.
- The TOML type is taken from the field's own `ConfigKind` (single source of truth), not re-derived from the key name, so a future int field can't be mis-written as a string.
- `ConfigScalar` typed value (`IntScalar`/`StringScalar`/`StringListScalar`) keeps quoting correct.

## RESULTS
Full `go test ./...` green except the known pre-existing daemon flake. New tests: comment + other-key preservation, **trailing-comment-on-the-edited-line** preservation, string write, missing-key/section refusal, revert-on-invalid-result, inline-edit write/validate/error overlay flows, duration/int shape validation, kind-driven typing round-trip. `--json` byte-stable (config rides unexported snapshot fields). `go mod tidy` adds tomledit (+ its test dep go-cmp in go.sum).

## REVIEW
High-effort review run; all five findings fixed: revert-error swallowed, edited-line trailing comment dropped (the original test only covered a block comment on a *different* key), `0s`/negative durations accepted, type re-derived from key name instead of `ConfigKind`, `configCursor` not clamped on refresh.

## RISK
New external dependency (`tomledit`, lossless TOML editor) scoped to one writer; all writes are validated + atomic + revert-on-failure. TUI + config-package only; headless outputs untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)