### PR TITLE
cli: show the request and result in the job detail

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -129,6 +129,29 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 			})
 			return views, err
 		},
+		JobDetail: func(id string) (tui.JobDetail, error) {
+			// Lazy: parse the one opened job's payload, not every job per tick.
+			var detail tui.JobDetail
+			err := withStore(home, func(store *db.Store) error {
+				job, err := store.GetJob(context.Background(), id)
+				if err != nil {
+					return err
+				}
+				payload, err := workflow.ParseJobPayload(job.Payload)
+				if err != nil {
+					return nil // malformed/absent payload → empty detail, no error
+				}
+				detail.Repo = payload.Repo
+				detail.PullRequest = payload.PullRequest
+				detail.Request = payload.Instructions
+				if payload.Result != nil {
+					detail.ResultDecision = payload.Result.Decision
+					detail.ResultSummary = payload.Result.Summary
+				}
+				return nil
+			})
+			return detail, err
+		},
 		RetryJob: func(id string) error {
 			// workflow.RetryJob is the same path `gitmoot job retry` takes: it
 			// clears the stale payload.Result and emits the retry_queued event

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -140,6 +140,17 @@ type JobRow struct {
 	LatestEvent string
 }
 
+// JobDetail is the job's parsed payload, loaded lazily when its detail opens
+// (the request/result is only ever shown for one job, so it is not parsed for
+// the whole list on every refresh tick).
+type JobDetail struct {
+	Repo           string
+	PullRequest    int
+	Request        string // the human instructions that drove the job
+	ResultDecision string // gitmoot_result.decision, when the job has settled
+	ResultSummary  string // gitmoot_result.summary
+}
+
 // JobEventView is one entry of a job's event history shown in the detail view.
 type JobEventView struct {
 	Kind    string
@@ -187,9 +198,11 @@ type Deps struct {
 	// detail view.
 	OpenTrain func(sessionID string) tea.Model
 
-	// Job actions: event history (detail view), retry a failed/blocked job,
-	// cancel a queued/running one (cooperative — the daemon settles it).
+	// Job actions: event history + parsed payload (detail view), retry a
+	// failed/blocked job, cancel a queued/running one (cooperative — the
+	// daemon settles it).
 	JobEvents func(id string) ([]JobEventView, error)
+	JobDetail func(id string) (JobDetail, error)
 	RetryJob  func(id string) error
 	CancelJob func(id string) error
 
@@ -287,6 +300,13 @@ type dismissResultMsg struct {
 type jobEventsMsg struct {
 	id     string
 	events []JobEventView
+	err    error
+}
+
+// jobDetailMsg carries a job's parsed payload for the detail view.
+type jobDetailMsg struct {
+	id     string
+	detail JobDetail
 	err    error
 }
 

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -8,16 +8,18 @@ import (
 )
 
 // openJobDetail enters the job detail view for the job under the Jobs cursor
-// and lazily loads its event history.
+// and lazily loads its event history and parsed payload (request/result).
 func (m *Model) openJobDetail(job JobRow) tea.Cmd {
 	m.activeJob = job
 	m.jobEvents = nil
 	m.jobEventsLoaded = false
 	m.jobEventsErr = ""
+	m.activeJobDetail = JobDetail{}
+	m.jobDetailLoaded = false
 	m.actionErr = ""
 	m.actionBusy = false
 	m.mode = modeJobDetail
-	return jobEventsCmd(m.deps, job.ID)
+	return tea.Batch(jobEventsCmd(m.deps, job.ID), jobDetailCmd(m.deps, job.ID))
 }
 
 // openJobConfirm enters the retry or cancel confirmation for the given job.
@@ -119,6 +121,16 @@ func jobEventsCmd(deps Deps, id string) tea.Cmd {
 	}
 }
 
+func jobDetailCmd(deps Deps, id string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.JobDetail == nil {
+			return jobDetailMsg{id: id}
+		}
+		detail, err := deps.JobDetail(id)
+		return jobDetailMsg{id: id, detail: detail, err: err}
+	}
+}
+
 func jobActionCmd(action func(string) error, verb, id string) tea.Cmd {
 	return func() tea.Msg {
 		if action == nil {
@@ -134,6 +146,30 @@ func daemonStartCmd(deps Deps) tea.Cmd {
 			return daemonStartMsg{}
 		}
 		return daemonStartMsg{err: deps.StartDaemon()}
+	}
+}
+
+// clampLines preserves newlines (unlike truncate, which collapses whitespace)
+// but caps the block to maxLines, appending an elision marker when it overflows.
+func clampLines(value string, maxLines int) string {
+	lines := strings.Split(strings.TrimRight(value, "\n"), "\n")
+	if len(lines) <= maxLines {
+		return strings.Join(lines, "\n")
+	}
+	kept := lines[:maxLines]
+	return strings.Join(kept, "\n") + "\n" + mutedStyle.Render("… "+strconv.Itoa(len(lines)-maxLines)+" more lines")
+}
+
+// jobDecisionColor colors a gitmoot_result decision: blocked/failed red,
+// changes_requested neutral, everything else (approved/implemented) green.
+func jobDecisionColor(decision string) string {
+	switch decision {
+	case "blocked", "failed":
+		return redStyle.Render(decision)
+	case "approved", "implemented":
+		return greenStyle.Render(decision)
+	default:
+		return decision
 	}
 }
 
@@ -176,8 +212,36 @@ func (m Model) jobDetailView() string {
 		{"state", m.activeJob.State},
 		{"updated", dash(m.activeJob.UpdatedAt)},
 	}
+	d := m.activeJobDetail
+	if d.Repo != "" {
+		repo := d.Repo
+		if d.PullRequest > 0 {
+			repo += "  #" + strconv.Itoa(d.PullRequest)
+		}
+		rows = append(rows, []string{"repo", repo})
+	}
 	b.WriteString(renderRows(rows))
 	b.WriteByte('\n')
+
+	// What was asked (newlines preserved, capped to a few lines).
+	if d.Request != "" {
+		b.WriteString(headerStyle.Render("request"))
+		b.WriteByte('\n')
+		b.WriteString(clampLines(d.Request, 8) + "\n\n")
+	}
+	// What came back (settled jobs).
+	if d.ResultDecision != "" || d.ResultSummary != "" {
+		b.WriteString(headerStyle.Render("result"))
+		b.WriteByte('\n')
+		if d.ResultDecision != "" {
+			b.WriteString("decision  " + jobDecisionColor(d.ResultDecision) + "\n")
+		}
+		if d.ResultSummary != "" {
+			b.WriteString(clampLines(d.ResultSummary, 8) + "\n")
+		}
+		b.WriteByte('\n')
+	}
+
 	b.WriteString(headerStyle.Render("events"))
 	b.WriteByte('\n')
 	switch {

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -51,8 +51,7 @@ func TestJobsPageDetailLoadsEvents(t *testing.T) {
 	if m.mode != modeJobDetail || cmd == nil {
 		t.Fatalf("enter should open the job detail, mode=%v", m.mode)
 	}
-	next, _ = m.Update(cmd()) // jobEventsMsg
-	m = next.(Model)
+	m = drainBatch(t, m, cmd) // events + detail load
 	if asked != "j-failed" {
 		t.Fatalf("JobEvents asked for %q", asked)
 	}
@@ -245,8 +244,7 @@ func TestJobDetailZeroEventsShowsNoEvents(t *testing.T) {
 	if !strings.Contains(m.View(), "loading…") {
 		t.Fatalf("detail should show loading before the events arrive:\n%s", m.View())
 	}
-	next, _ = m.Update(cmd())
-	m = next.(Model)
+	m = drainBatch(t, m, cmd)
 	if !strings.Contains(m.View(), "no events") {
 		t.Fatalf("an empty (loaded) history should say so, not keep loading:\n%s", m.View())
 	}
@@ -287,5 +285,74 @@ func TestJobActionErrorKeepsConfirm(t *testing.T) {
 	}
 	if !strings.Contains(m.View(), "db locked") {
 		t.Fatalf("error should render:\n%s", m.View())
+	}
+}
+
+func drainBatch(t *testing.T, m Model, cmd tea.Cmd) Model {
+	t.Helper()
+	if cmd == nil {
+		return m
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, sub := range batch {
+			if sub != nil {
+				next, _ := m.Update(sub())
+				m = next.(Model)
+			}
+		}
+		return m
+	}
+	next, _ := m.Update(msg)
+	return next.(Model)
+}
+
+func TestJobDetailShowsRequestAndResult(t *testing.T) {
+	deps := Deps{
+		JobEvents: func(id string) ([]JobEventView, error) {
+			return []JobEventView{{Kind: "failed", Message: "boom"}}, nil
+		},
+		JobDetail: func(id string) (JobDetail, error) {
+			return JobDetail{Repo: "o/r", PullRequest: 7, Request: "Plan the auth refactor.",
+				ResultDecision: "failed", ResultSummary: "the checkout is read-only"}, nil
+		},
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	m = drainBatch(t, m, cmd)
+	view := m.View()
+	for _, want := range []string{"repo", "o/r", "#7", "request", "Plan the auth refactor", "result", "decision", "failed", "read-only", "events"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("job detail missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestJobDetailOmitsBlocksWhenAbsent(t *testing.T) {
+	deps := Deps{
+		JobEvents: func(id string) ([]JobEventView, error) { return nil, nil },
+		JobDetail: func(id string) (JobDetail, error) { return JobDetail{}, nil },
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	m = drainBatch(t, m, cmd)
+	view := m.View()
+	if strings.Contains(view, "request") || strings.Contains(view, "result") {
+		t.Fatalf("a job without payload content should omit request/result blocks:\n%s", view)
+	}
+}
+
+func TestJobDetailClampLines(t *testing.T) {
+	got := clampLines("a\nb\nc\nd\ne", 3)
+	if !strings.Contains(got, "a\nb\nc") || !strings.Contains(got, "2 more lines") {
+		t.Fatalf("clampLines = %q", got)
+	}
+	// Within the cap, newlines are preserved verbatim (not collapsed).
+	if clampLines("one\ntwo", 5) != "one\ntwo" {
+		t.Fatalf("clampLines should preserve newlines under the cap")
 	}
 }

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -100,6 +100,8 @@ type Model struct {
 	jobEvents       []JobEventView      // lazy-loaded event history for the detail view
 	jobEventsLoaded bool                // the detail's event load has returned (possibly empty)
 	jobEventsErr    string              // error from the detail's event load
+	activeJobDetail JobDetail           // lazy-loaded parsed payload (request/result)
+	jobDetailLoaded bool                // the detail's payload load has returned
 	cancelling      map[string]struct{} // jobs with a cancel requested, until settled
 	daemonBusy      bool                // a daemon start is in flight; suppress re-submit
 	daemonErr       string              // error from the last daemon start attempt
@@ -420,6 +422,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.jobEventsErr = ""
 				m.jobEvents = msg.events
 			}
+		}
+	case jobDetailMsg:
+		// A malformed/absent payload yields a zero JobDetail and no error; the
+		// detail simply omits the request/result blocks.
+		if msg.id == m.activeJob.ID {
+			m.jobDetailLoaded = true
+			m.activeJobDetail = msg.detail
 		}
 	case healthChecksMsg:
 		m.healthLoading = false

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -366,6 +366,13 @@ func marshalPayload(payload JobPayload) (string, error) {
 	return string(encoded), nil
 }
 
+// ParseJobPayload decodes a stored job payload (the same form the mailbox
+// writes), tolerating the legacy preset_* keys. Read-only callers — e.g. the
+// dashboard's job detail — use this to surface the request and result.
+func ParseJobPayload(value string) (JobPayload, error) {
+	return unmarshalPayload(value)
+}
+
 func unmarshalPayload(value string) (JobPayload, error) {
 	var payload JobPayload
 	if err := json.Unmarshal([]byte(value), &payload); err != nil {

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -468,3 +468,21 @@ func (f *fakeDelivery) Deliver(_ context.Context, _ runtime.Agent, job runtime.J
 	}
 	return result, nil
 }
+
+func TestParseJobPayloadExported(t *testing.T) {
+	encoded, err := marshalPayload(JobPayload{Repo: "o/r", PullRequest: 7, Instructions: "do it", Result: &AgentResult{Decision: "approved", Summary: "done"}})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	got, err := ParseJobPayload(encoded)
+	if err != nil {
+		t.Fatalf("ParseJobPayload: %v", err)
+	}
+	if got.Repo != "o/r" || got.PullRequest != 7 || got.Result == nil || got.Result.Decision != "approved" {
+		t.Fatalf("round-trip wrong: %+v", got)
+	}
+	// Empty/malformed input errors (caller treats as no detail).
+	if _, err := ParseJobPayload(""); err == nil {
+		t.Fatal("empty payload should error")
+	}
+}


### PR DESCRIPTION
## WHAT
Task 2 of #266: the dashboard job detail now shows the request and result, not just the event log.

## WHY
"When I enter a job's details it's not very clear what I'm looking at" — the detail showed agent/type/state + events but never the job's actual content (the request, the repo/PR, or the `gitmoot_result` decision/summary), all of which live in the job payload, unrendered.

## CHANGES
- Job detail renders: **repo** (+ `#PR`), a **request** block (the human instructions), and — for settled jobs — a **result** block (decision, colored; summary).
- **Lazy** parse: a new `Deps.JobDetail(id)` fetches+parses only the opened job's payload (alongside the existing `JobEvents` lazy load), not every job on every 5s tick — review caught that the first cut parsed all N payloads (×2 unmarshals) per refresh over the whole unbounded job history.
- Request/summary **preserve newlines** (`clampLines`, capped to 8 lines + "… N more") instead of being flattened to one line (the other review finding).
- `workflow.ParseJobPayload` exposes the existing payload decoder for read-only use; malformed/absent payloads (older jobs) yield an empty detail, never an error.

## RESULTS
Full `go test ./...` green except the known pre-existing daemon flake. New tests: detail shows request+result; omits the blocks when absent; `clampLines` caps + preserves newlines; `ParseJobPayload` round-trip + empty-input error. `--json`/plain byte-stable (parsed fields live on the non-serialized `tui.JobDetail`).

## REVIEW
High-effort review run; both findings fixed by the lazy refactor: per-tick N-payload parse → lazy single-job parse; newline-collapsing `truncate` → newline-preserving `clampLines`.

## RISK
One additive `Deps` callback (full suite run). TUI + one exported workflow helper; headless outputs untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)