### PR TITLE
cli: preview an agent template version's prompt

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -207,6 +207,18 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 			})
 			return views, err
 		},
+		TemplateVersionContent: func(versionID string) (string, error) {
+			var content string
+			err := withStore(home, func(store *db.Store) error {
+				version, err := store.GetAgentTemplateVersionByID(context.Background(), versionID)
+				if err != nil {
+					return err
+				}
+				content = version.Content
+				return nil
+			})
+			return content, err
+		},
 		OpenAgentCreate: func() (tea.Model, error) {
 			// One store for the form's lifetime: its 200ms external-answer poll
 			// would otherwise open/migrate/close the database five times a

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -24,6 +24,7 @@ func (m *Model) openAgentDetail(agent Agent) tea.Cmd {
 	m.agentVersions = nil
 	m.agentVersionsLoaded = false
 	m.agentVersionsErr = ""
+	m.detailVersionCursor = 0
 	m.actionErr = ""
 	m.actionBusy = false
 	m.mode = modeAgentDetail
@@ -40,6 +41,50 @@ func (m *Model) openAgentDelete(agent Agent) {
 	m.actionErr = ""
 	m.actionBusy = false
 	m.mode = modeConfirmAgentDelete
+}
+
+// openVersionView opens the preview pager for a template version, reusing the
+// cache when it already holds this version's content (the train-run skill-pager
+// pattern, keyed by version id).
+func (m *Model) openVersionView(version TemplateVersion) tea.Cmd {
+	m.activeAgentVersion = version
+	m.mode = modeAgentVersionView
+	if m.versionViewLoaded && m.versionViewErr == "" && m.versionViewID == version.ID {
+		return nil
+	}
+	m.versionViewID = version.ID
+	m.versionViewLoaded = false
+	m.versionViewErr = ""
+	return versionContentCmd(m.deps, version.ID)
+}
+
+func versionContentCmd(deps Deps, versionID string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.TemplateVersionContent == nil {
+			return versionContentMsg{versionID: versionID}
+		}
+		content, err := deps.TemplateVersionContent(versionID)
+		return versionContentMsg{versionID: versionID, content: content, err: err}
+	}
+}
+
+// agentVersionView renders the version content pager.
+func (m Model) agentVersionView() string {
+	var b strings.Builder
+	v := m.activeAgentVersion
+	b.WriteString(headerStyle.Render("version v" + strconv.Itoa(v.Number) + "  " + dash(m.activeAgent.TemplateID)))
+	b.WriteString("\n\n")
+	switch {
+	case m.versionViewErr != "":
+		b.WriteString(errorStyle.Render(m.versionViewErr) + "\n")
+	case !m.versionViewLoaded:
+		b.WriteString(mutedStyle.Render("loading…") + "\n")
+	default:
+		b.WriteString(m.versionView.View())
+		b.WriteByte('\n')
+	}
+	b.WriteString("\n" + mutedStyle.Render("↑/↓ scroll  esc back"))
+	return b.String()
 }
 
 // revertableVersions are the superseded versions an agent's template can be
@@ -59,8 +104,21 @@ func (m Model) updateAgentOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.mode {
 	case modeAgentDetail:
 		switch msg.String() {
-		case "esc", "enter", "q":
+		case "esc", "q":
 			m.mode = modeNormal
+		case "up", "k":
+			if m.detailVersionCursor > 0 {
+				m.detailVersionCursor--
+			}
+		case "down", "j":
+			if m.detailVersionCursor < len(m.agentVersions)-1 {
+				m.detailVersionCursor++
+			}
+		case "enter":
+			// Open the selected version's prompt in the pager.
+			if m.detailVersionCursor < len(m.agentVersions) && m.deps.TemplateVersionContent != nil {
+				return m, m.openVersionView(m.agentVersions[m.detailVersionCursor])
+			}
 		case "v":
 			if len(m.revertableVersions()) > 0 {
 				m.versionCursor = 0
@@ -71,6 +129,21 @@ func (m Model) updateAgentOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.viewport.SetContent(m.content())
 		return m, nil
+	case modeAgentVersionView:
+		switch msg.String() {
+		case "esc", "q":
+			m.mode = modeAgentDetail
+			m.viewport.SetContent(m.content())
+			return m, nil
+		}
+		var cmd tea.Cmd
+		// Only steer the pager once its content is loaded — before that (or after
+		// a failed load) versionView is the zero viewport and scroll keys are noise.
+		if m.versionViewLoaded && m.versionViewErr == "" {
+			m.versionView, cmd = m.versionView.Update(msg)
+		}
+		m.viewport.SetContent(m.content())
+		return m, cmd
 	case modeAgentRevertPick:
 		versions := m.revertableVersions()
 		switch msg.String() {
@@ -366,8 +439,13 @@ func (m Model) agentDetailView() string {
 	case len(m.agentVersions) == 0:
 		b.WriteString(mutedStyle.Render("no versions") + "\n")
 	default:
-		for _, v := range m.agentVersions {
-			line := "v" + strconv.Itoa(v.Number) + "  " + versionStateColor(v.State)
+		for i, v := range m.agentVersions {
+			cursor := "  "
+			label := "v" + strconv.Itoa(v.Number)
+			if i == m.detailVersionCursor {
+				cursor, label = "▸ ", selectedRowStyle.Render(label)
+			}
+			line := cursor + label + "  " + versionStateColor(v.State)
 			if v.Name != "" {
 				line += "  " + truncate(v.Name, 48)
 			}
@@ -384,6 +462,9 @@ func (m Model) agentDetailView() string {
 	hint := "D delete  esc back"
 	if len(m.revertableVersions()) > 0 {
 		hint = "v revert  " + hint
+	}
+	if len(m.agentVersions) > 0 {
+		hint = "↑/↓ select  enter read version  " + hint
 	}
 	b.WriteString(mutedStyle.Render(hint))
 	return b.String()

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -72,6 +72,112 @@ func TestAgentDetailRendersVersionsAndJobs(t *testing.T) {
 	}
 }
 
+// openAgentVersionDetail opens the agent detail and loads its versions, leaving
+// the model on modeAgentDetail with the cursor on the first (current) version.
+func openAgentVersionDetail(t *testing.T, deps Deps) Model {
+	t.Helper()
+	if deps.TemplateVersions == nil {
+		deps.TemplateVersions = func(string) ([]TemplateVersion, error) {
+			return []TemplateVersion{
+				{ID: "v2-id", Number: 2, State: "current", Name: "improved"},
+				{ID: "v1-id", Number: 1, State: "superseded", Name: "initial"},
+			}, nil
+		}
+	}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd != nil {
+		next, _ = m.Update(cmd())
+		m = next.(Model)
+	}
+	if m.mode != modeAgentDetail {
+		t.Fatalf("expected modeAgentDetail, got %v", m.mode)
+	}
+	return m
+}
+
+func TestAgentVersionPreviewLoadsAndRenders(t *testing.T) {
+	var asked string
+	deps := Deps{TemplateVersionContent: func(versionID string) (string, error) {
+		asked = versionID
+		return "You are the planner.\nThink step by step.", nil
+	}}
+	m := openAgentVersionDetail(t, deps)
+	// enter opens the version under the cursor (the current one, v2).
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if m.mode != modeAgentVersionView || cmd == nil {
+		t.Fatalf("enter should open the version pager, mode=%v", m.mode)
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if asked != "v2-id" {
+		t.Fatalf("TemplateVersionContent asked for %q, want v2-id", asked)
+	}
+	view := m.View()
+	for _, want := range []string{"version v2", "planner-tpl", "You are the planner."} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("version view missing %q:\n%s", want, view)
+		}
+	}
+	// esc returns to the detail.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if m.mode != modeAgentDetail {
+		t.Fatalf("esc should return to the detail, got %v", m.mode)
+	}
+}
+
+func TestAgentVersionPreviewEmptyContent(t *testing.T) {
+	deps := Deps{TemplateVersionContent: func(string) (string, error) { return "   \n", nil }}
+	m := openAgentVersionDetail(t, deps)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if !strings.Contains(m.View(), "no content") {
+		t.Fatalf("blank version should show a no-content state:\n%s", m.View())
+	}
+}
+
+func TestAgentVersionPreviewCachesPerVersion(t *testing.T) {
+	calls := map[string]int{}
+	deps := Deps{TemplateVersionContent: func(versionID string) (string, error) {
+		calls[versionID]++
+		return "content of " + versionID, nil
+	}}
+	m := openAgentVersionDetail(t, deps)
+	// Open v2 (cursor 0), load, back out.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	// Re-open the same version: cache hit, no command, no second fetch.
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatal("re-opening the same version should hit the cache (no command)")
+	}
+	// Move the cursor to v1 and open: a different id must fetch.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	next, _ = m.Update(key("j"))
+	m = next.(Model)
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("a different version should fetch its content")
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if calls["v2-id"] != 1 || calls["v1-id"] != 1 {
+		t.Fatalf("expected one fetch per version, got %v", calls)
+	}
+}
+
 func TestAgentCreateFlowRunsCreateAgent(t *testing.T) {
 	var created []string
 	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -224,10 +224,13 @@ type Deps struct {
 	// collected answers. DeleteAgent refuses while jobs reference the agent.
 	// RevertTemplate makes a superseded template version current again.
 	TemplateVersions func(templateID string) ([]TemplateVersion, error)
-	OpenAgentCreate  func() (tea.Model, error)
-	CreateAgent      func(name, runtime, template string) error
-	DeleteAgent      func(name string) error
-	RevertTemplate   func(templateID, versionID string) error
+	// TemplateVersionContent loads a specific version's prompt content for the
+	// agent-detail preview pager.
+	TemplateVersionContent func(versionID string) (string, error)
+	OpenAgentCreate        func() (tea.Model, error)
+	CreateAgent            func(name, runtime, template string) error
+	DeleteAgent            func(name string) error
+	RevertTemplate         func(templateID, versionID string) error
 
 	// Optimize an agent: OpenAgentOptimize builds the pre-filled training form
 	// for the agent's template; StartOptimize scaffolds and starts the train
@@ -348,6 +351,13 @@ type agentVersionsMsg struct {
 	templateID string
 	versions   []TemplateVersion
 	err        error
+}
+
+// versionContentMsg carries a template version's content for the preview pager.
+type versionContentMsg struct {
+	versionID string
+	content   string
+	err       error
 }
 
 // agentActionMsg carries the outcome of an agent mutation.

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -62,6 +62,7 @@ const (
 	modeAgentRevertPick
 	modeConfirmAgentRevert
 	modeConfirmAgentDelete
+	modeAgentVersionView
 	modeConfigEdit
 )
 
@@ -131,6 +132,12 @@ type Model struct {
 	agentVersionsErr    string            // error from the version load
 	versionCursor       int               // selected row in the revert pick list
 	revertVersion       TemplateVersion   // version being confirmed for revert
+	detailVersionCursor int               // selected version row in the agent detail
+	activeAgentVersion  TemplateVersion   // version shown in the content pager
+	versionView         viewport.Model    // pager for a version's content
+	versionViewID       string            // version id the pager content belongs to
+	versionViewErr      string            //
+	versionViewLoaded   bool              //
 	agentErr            string            // inline error on the Agents page (e.g. create failed)
 	optimizeBusy        bool              // a train session is being scaffolded/started
 	formPending         bool              // a form push is in flight; suppress re-dispatch
@@ -173,6 +180,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.width = msg.Width
 			m.height = msg.Height
 			m.resizeViewport()
+			if m.versionViewLoaded {
+				m.versionView.Width = max(20, m.width-4)
+				m.versionView.Height = max(5, m.height-6)
+			}
 		}
 	case tea.KeyMsg:
 		// Modal overlays capture keys first; only ctrl+c stays global.
@@ -187,7 +198,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 			return m.updateTrainOverlay(msg)
-		case modeAgentDetail, modeAgentRevertPick, modeConfirmAgentRevert, modeConfirmAgentDelete:
+		case modeAgentDetail, modeAgentRevertPick, modeConfirmAgentRevert, modeConfirmAgentDelete, modeAgentVersionView:
 			if msg.String() == "ctrl+c" {
 				return m, tea.Quit
 			}
@@ -529,6 +540,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				m.agentVersionsErr = ""
 				m.agentVersions = msg.versions
+				m.detailVersionCursor = clampCursor(m.detailVersionCursor, len(msg.versions))
+			}
+		}
+	case versionContentMsg:
+		if msg.versionID == m.versionViewID {
+			m.versionViewLoaded = true
+			if msg.err != nil {
+				m.versionViewErr = msg.err.Error()
+			} else {
+				m.versionViewErr = ""
+				content := msg.content
+				if strings.TrimSpace(content) == "" {
+					content = mutedStyle.Render("(no content)")
+				}
+				m.versionView = viewport.New(max(20, m.width-4), max(5, m.height-6))
+				m.versionView.SetContent(content)
 			}
 		}
 	case agentFormResultMsg:

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -96,6 +96,8 @@ func (m Model) content() string {
 		b.WriteString(m.agentRevertConfirmView())
 	case modeConfirmAgentDelete:
 		b.WriteString(m.agentDeleteConfirmView())
+	case modeAgentVersionView:
+		b.WriteString(m.agentVersionView())
 	case modeConfigEdit:
 		b.WriteString(m.configEditView())
 	default:


### PR DESCRIPTION
## What

Round 4 / issue #266, task 3. The Agents detail listed every template version but you couldn't open one to read its prompt.

- Cursor over the version list (`↑/↓`); `enter` opens the selected version's prompt in a viewport pager (`modeAgentVersionView`), `esc`/`q` closes.
- Content loads lazily via new `Deps.TemplateVersionContent` → `store.GetAgentTemplateVersionByID().Content` — never on the 5s refresh tick.
- Single-slot cache keyed by version id (re-opening the same version is a cache hit; a different version refetches).
- Resize-aware; a blank version shows a `(no content)` state.

## Byte-stability

New data rides unexported `Model` fields and a TUI-only `Deps` callback; no json-tagged dashboard struct changes, so `--json`/`--plain` output is unchanged.

## Tests

`internal/cli/tui`: enter loads + renders content; esc returns; empty content shows the no-content state; cache hits per version id and refetches on a different id. Full `go test ./...` passes (only the known `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` daemon flake fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)