### PR TITLE
cli: runtime-session detail and locks guidance

### DIFF
--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -107,6 +107,15 @@ type dashboardSession struct {
 	Runtime string `json:"runtime"`
 	Repo    string `json:"repo,omitempty"`
 	State   string `json:"state,omitempty"`
+
+	// Detail fields shown only in the interactive session detail view. They are
+	// unexported so the --json/--plain output stays byte-stable (mirrors how
+	// dashboardAgent.templateID is carried).
+	sessionType string
+	role        string
+	templateID  string
+	lastUsedAt  string
+	expiresAt   string
 }
 
 type dashboardJobs struct {
@@ -390,7 +399,17 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 			return err
 		}
 		for _, instance := range instances {
-			snapshot.RuntimeSessions = append(snapshot.RuntimeSessions, dashboardSession{Name: instance.Name, Runtime: instance.Runtime, Repo: instance.RepoFullName, State: instance.State})
+			snapshot.RuntimeSessions = append(snapshot.RuntimeSessions, dashboardSession{
+				Name:        instance.Name,
+				Runtime:     instance.Runtime,
+				Repo:        instance.RepoFullName,
+				State:       instance.State,
+				sessionType: instance.Type,
+				role:        instance.Role,
+				templateID:  instance.TemplateID,
+				lastUsedAt:  instance.LastUsedAt,
+				expiresAt:   instance.ExpiresAt,
+			})
 		}
 		jobs, err := store.ListJobs(ctx)
 		if err != nil {

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -398,7 +398,17 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 		out.Agents = append(out.Agents, tui.Agent{Name: a.Name, Runtime: a.Runtime, Role: a.Role, Health: a.Health, TemplateID: a.templateID})
 	}
 	for _, sess := range s.RuntimeSessions {
-		out.Sessions = append(out.Sessions, tui.Session{Name: sess.Name, Runtime: sess.Runtime, Repo: sess.Repo, State: sess.State})
+		out.Sessions = append(out.Sessions, tui.Session{
+			Name:     sess.Name,
+			Runtime:  sess.Runtime,
+			Repo:     sess.Repo,
+			State:    sess.State,
+			Type:     sess.sessionType,
+			Role:     sess.role,
+			Template: sess.templateID,
+			LastUsed: sess.lastUsedAt,
+			Expires:  sess.expiresAt,
+		})
 	}
 	for _, w := range s.Worktrees {
 		out.Worktrees = append(out.Worktrees, tui.Worktree{Task: w.Task, Repo: w.Repo, Path: w.Path})

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -129,6 +129,12 @@ func (m Model) updateOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.viewport.SetContent(m.content())
 		}
 		return m, nil
+	case modeSessionDetail:
+		if s := msg.String(); s == "enter" || s == "q" {
+			m.mode = modeNormal
+			m.viewport.SetContent(m.content())
+		}
+		return m, nil
 	case modeAnswerChoice:
 		switch msg.String() {
 		case "up", "k":

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -115,12 +115,18 @@ type Agent struct {
 	TemplateID string
 }
 
-// Session mirrors cli.dashboardSession.
+// Session mirrors cli.dashboardSession. Type/Role/Template/LastUsed/Expires
+// back the interactive session detail view only (never serialized).
 type Session struct {
-	Name    string
-	Runtime string
-	Repo    string
-	State   string
+	Name     string
+	Runtime  string
+	Repo     string
+	State    string
+	Type     string
+	Role     string
+	Template string
+	LastUsed string
+	Expires  string
 }
 
 // Jobs mirrors cli.dashboardJobs.

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -53,6 +53,7 @@ const (
 	modeConfirmDismiss
 	modeTrainDetail
 	modeJobDetail
+	modeSessionDetail
 	modeConfirmJobRetry
 	modeConfirmJobCancel
 	modeTrainStopReason
@@ -94,6 +95,11 @@ type Model struct {
 	actionBusy   bool                 // an action is in flight; suppress re-submit
 	showHelp     bool                 // '?' help overlay
 	tickGen      int                  // current tick chain; stale generations are dropped
+
+	// Sessions page interaction state.
+	sessionCursor      int     // selected row in sessionRows()
+	activeSession      Session // session shown in modeSessionDetail
+	activeSessionCount int     // members collapsed into the selected row (>1 for a bg group)
 
 	// Jobs page interaction state.
 	jobCursor       int                 // selected row in snap.JobRows
@@ -303,6 +309,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, Push(m.deps.OpenTrain(session))
 				}
 				m.openTrainDetail()
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
+			if pages[m.selected].page == pageSessions {
+				m.openSessionDetail()
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
@@ -673,6 +684,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampTrainCursor()
 			m.clampJobCursor()
 			m.agentCursor = clampCursor(m.agentCursor, len(m.snap.Agents))
+			m.sessionCursor = clampCursor(m.sessionCursor, len(m.sessionRows()))
 			m.configCursor = clampCursor(m.configCursor, len(m.configEditableFields()))
 			// A cancel-requested job that has settled no longer needs the
 			// transitional "cancelling…" label.
@@ -793,6 +805,8 @@ func (m *Model) pageCursor() (*int, int) {
 		return &m.trainCursor, len(m.snap.Trains)
 	case pageAgents:
 		return &m.agentCursor, len(m.snap.Agents)
+	case pageSessions:
+		return &m.sessionCursor, len(m.sessionRows())
 	case pageJobs:
 		return &m.jobCursor, len(m.snap.JobRows)
 	case pageConfig:

--- a/internal/cli/tui/sessions.go
+++ b/internal/cli/tui/sessions.go
@@ -1,0 +1,117 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/cli/style"
+)
+
+// sessionRow is one rendered line on the Sessions page. Generated background
+// sessions sharing a type/runtime/state collapse into one counted group; named
+// sessions stand alone. session is the row's representative instance (the first
+// member of a group), used by the detail view.
+type sessionRow struct {
+	label   string
+	session Session
+	count   int // >1 means a collapsed background group
+}
+
+// sessionRows collapses generated "<type>-bg-<hex>" sessions sharing a
+// type/runtime/state into one counted line (mirroring cli.groupedRuntimeSessions)
+// while keeping each row's representative session for the detail view.
+func (m Model) sessionRows() []sessionRow {
+	type groupKey struct{ prefix, runtime, state string }
+	order := []groupKey{}
+	counts := map[groupKey]int{}
+	rep := map[groupKey]Session{}
+	singles := []Session{}
+	for _, s := range m.snap.Sessions {
+		if prefix, ok := style.GroupSuffix(s.Name); ok {
+			key := groupKey{prefix: prefix, runtime: s.Runtime, state: s.State}
+			if counts[key] == 0 {
+				order = append(order, key)
+				rep[key] = s
+			}
+			counts[key]++
+		} else {
+			singles = append(singles, s)
+		}
+	}
+	rows := make([]sessionRow, 0, len(order)+len(singles))
+	for _, key := range order {
+		rows = append(rows, sessionRow{
+			label:   fmt.Sprintf("%s [%s] ×%d %s", key.prefix, key.runtime, counts[key], key.state),
+			session: rep[key],
+			count:   counts[key],
+		})
+	}
+	for _, s := range singles {
+		rows = append(rows, sessionRow{
+			label:   fmt.Sprintf("%s [%s] %s %s", s.Name, s.Runtime, dash(s.Repo), s.State),
+			session: s,
+			count:   1,
+		})
+	}
+	return rows
+}
+
+// openSessionDetail enters the detail view for the session under the cursor.
+func (m *Model) openSessionDetail() {
+	rows := m.sessionRows()
+	if m.sessionCursor >= len(rows) || m.sessionCursor < 0 {
+		return
+	}
+	m.activeSession = rows[m.sessionCursor].session
+	m.activeSessionCount = rows[m.sessionCursor].count
+	m.mode = modeSessionDetail
+}
+
+func (m Model) sessionsContent() string {
+	var b strings.Builder
+	b.WriteString(mutedStyle.Render("The live codex/claude processes backing your Agents — one warm session per delivered job (up to max_background); idle ones expire on their own."))
+	b.WriteString("\n\n")
+	rows := m.sessionRows()
+	if len(rows) == 0 {
+		b.WriteString(m.loadingOr("No runtime sessions.", !m.loadedAt.IsZero()))
+		return b.String()
+	}
+	for i, row := range rows {
+		cursor, label := "  ", row.label
+		if i == m.sessionCursor {
+			cursor, label = "▸ ", selectedRowStyle.Render(row.label)
+		}
+		b.WriteString(cursor + label + "\n")
+	}
+	b.WriteByte('\n')
+	b.WriteString(mutedStyle.Render("enter detail"))
+	return b.String()
+}
+
+func (m Model) sessionDetailView() string {
+	var b strings.Builder
+	s := m.activeSession
+	if m.activeSessionCount > 1 {
+		b.WriteString(headerStyle.Render(fmt.Sprintf("runtime sessions  %s ×%d", dash(s.Type), m.activeSessionCount)))
+	} else {
+		b.WriteString(headerStyle.Render("runtime session " + s.Name))
+	}
+	b.WriteString("\n\n")
+	rows := [][]string{
+		{"type", dash(s.Type)},
+		{"runtime", dash(s.Runtime)},
+		{"role", dash(s.Role)},
+		{"repo", dash(s.Repo)},
+		{"state", dash(s.State)},
+		{"template", dash(s.Template)},
+		{"last used", dash(s.LastUsed)},
+		{"expires", dash(s.Expires)},
+	}
+	b.WriteString(renderRows(rows))
+	b.WriteByte('\n')
+	if m.activeSessionCount > 1 {
+		b.WriteString("\n" + mutedStyle.Render(fmt.Sprintf("%d ephemeral background workers share this type/runtime/state; the fields above are the first one's.", m.activeSessionCount)) + "\n")
+	}
+	b.WriteString("\n" + mutedStyle.Render("esc back"))
+	return b.String()
+}

--- a/internal/cli/tui/sessions_test.go
+++ b/internal/cli/tui/sessions_test.go
@@ -1,0 +1,102 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// sessionsPageModel loads a snapshot and tabs to the Sessions page (the 4th
+// page: Attention → Trains → Agents → Sessions).
+func sessionsPageModel(t *testing.T, snap Snapshot) Model {
+	t.Helper()
+	m := sizedModel(Deps{Load: func() (Snapshot, error) { return snap, nil }})
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1_700_000_000, 0)})
+	m = next.(Model)
+	for i := 0; i < 3; i++ {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+	}
+	if pages[m.selected].page != pageSessions {
+		t.Fatalf("expected Sessions page, got %v", pages[m.selected].page)
+	}
+	return m
+}
+
+func sessionDetailSnapshot() Snapshot {
+	return Snapshot{
+		DatabaseExists: true,
+		Sessions: []Session{
+			{Name: "planner", Runtime: "claude", Repo: "owner/repo", State: "idle",
+				Type: "planner", Role: "plan", Template: "planner-tpl",
+				LastUsed: "2026-06-10T12:00:00Z", Expires: "2026-06-10T12:30:00Z"},
+			{Name: "skillopt-generator-bg-aa11", Runtime: "claude", State: "idle", Type: "skillopt-generator"},
+			{Name: "skillopt-generator-bg-bb22", Runtime: "claude", State: "idle", Type: "skillopt-generator"},
+		},
+	}
+}
+
+func TestSessionDetailRendersInstanceFields(t *testing.T) {
+	m := sessionsPageModel(t, sessionDetailSnapshot())
+	// The grouped bg rows sort first, then the single "planner". Move to it.
+	// rows: [generator group, planner]. Cursor down to planner (index 1).
+	next, _ := m.Update(key("j"))
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if m.mode != modeSessionDetail {
+		t.Fatalf("enter should open the session detail, mode=%v", m.mode)
+	}
+	view := m.View()
+	for _, want := range []string{"runtime session planner", "plan", "owner/repo", "planner-tpl", "2026-06-10T12:30:00Z"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("session detail missing %q:\n%s", want, view)
+		}
+	}
+	// esc returns to the list.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("esc should return to the list, got %v", m.mode)
+	}
+}
+
+func TestSessionDetailGroupShowsCount(t *testing.T) {
+	m := sessionsPageModel(t, sessionDetailSnapshot())
+	// Cursor starts on the collapsed generator group (row 0).
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	view := m.View()
+	if !strings.Contains(view, "×2") {
+		t.Fatalf("group detail should note the member count:\n%s", view)
+	}
+	if !strings.Contains(view, "background workers") {
+		t.Fatalf("group detail should explain the collapse:\n%s", view)
+	}
+}
+
+func TestLocksPageShowsGuidance(t *testing.T) {
+	snap := Snapshot{
+		DatabaseExists: true,
+		BranchLocks:    []BranchLock{{Repo: "owner/repo", Branch: "feature", Owner: "agent"}},
+		ResourceLocks:  []ResourceLock{{Key: "generation:s1", Owner: "pid:1"}},
+	}
+	m := sizedModel(Deps{Load: func() (Snapshot, error) { return snap, nil }})
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1_700_000_000, 0)})
+	m = next.(Model)
+	for i := 0; i < 5; i++ { // Attention → … → Locks (6th page)
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+	}
+	if pages[m.selected].page != pageLocks {
+		t.Fatalf("expected Locks page, got %v", pages[m.selected].page)
+	}
+	view := m.View()
+	for _, want := range []string{"what to do: usually nothing", "gitmoot lock release"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("locks page missing guidance %q:\n%s", want, view)
+		}
+	}
+}

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -1,14 +1,12 @@
 package tui
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/jerryfane/gitmoot/internal/cli/style"
 )
 
 var (
@@ -80,6 +78,8 @@ func (m Model) content() string {
 	switch m.mode {
 	case modeJobDetail:
 		b.WriteString(m.jobDetailView())
+	case modeSessionDetail:
+		b.WriteString(m.sessionDetailView())
 	case modeConfirmJobRetry, modeConfirmJobCancel:
 		b.WriteString(m.jobConfirmView())
 	case modeTrainStopReason:
@@ -208,6 +208,8 @@ func (m Model) footerHelp() string {
 		return "y confirm  n/esc cancel"
 	case modeConfigEdit:
 		return "type value  enter save  esc cancel"
+	case modeSessionDetail:
+		return "enter/esc back"
 	}
 	switch pages[m.selected].page {
 	case pageAttention:
@@ -216,6 +218,8 @@ func (m Model) footerHelp() string {
 		return "tab/←→ page  ↑/↓ select  enter open  s stop  d delete  ? help  q quit"
 	case pageAgents:
 		return "tab/←→ page  ↑/↓ select  enter detail  n new  o optimize  D delete  ? help  q quit"
+	case pageSessions:
+		return "tab/←→ page  ↑/↓ select  enter detail  ? help  q quit"
 	case pageJobs:
 		return "tab/←→ page  ↑/↓ select  enter detail  R retry  c cancel  ? help  q quit"
 	case pageHealth:
@@ -231,21 +235,6 @@ func (m Model) loadingOr(empty string, loaded bool) string {
 		return empty
 	}
 	return mutedStyle.Render("Loading…")
-}
-
-func (m Model) sessionsContent() string {
-	var b strings.Builder
-	b.WriteString(mutedStyle.Render("Long-lived codex/claude processes gitmoot keeps warm to run jobs; idle ones expire on their own."))
-	b.WriteString("\n\n")
-	if len(m.snap.Sessions) == 0 {
-		b.WriteString(m.loadingOr("No runtime sessions.", !m.loadedAt.IsZero()))
-		return b.String()
-	}
-	for _, line := range groupedSessions(m.snap.Sessions) {
-		b.WriteString(line)
-		b.WriteByte('\n')
-	}
-	return b.String()
 }
 
 func (m Model) locksContent() string {
@@ -292,35 +281,16 @@ func (m Model) locksContent() string {
 		}
 		b.WriteString(renderRows(rows))
 	}
-	return b.String()
-}
 
-// groupedSessions collapses generated "<type>-bg-<hex>" sessions sharing a
-// type/runtime/state into one counted line, mirroring cli.groupedRuntimeSessions.
-func groupedSessions(sessions []Session) []string {
-	type groupKey struct{ prefix, runtime, state string }
-	order := []groupKey{}
-	counts := map[groupKey]int{}
-	singles := []Session{}
-	for _, s := range sessions {
-		if prefix, ok := style.GroupSuffix(s.Name); ok {
-			key := groupKey{prefix: prefix, runtime: s.Runtime, state: s.State}
-			if counts[key] == 0 {
-				order = append(order, key)
-			}
-			counts[key]++
-		} else {
-			singles = append(singles, s)
-		}
-	}
-	lines := make([]string, 0, len(order)+len(singles))
-	for _, key := range order {
-		lines = append(lines, fmt.Sprintf("%s [%s] ×%d %s", key.prefix, key.runtime, counts[key], key.state))
-	}
-	for _, s := range singles {
-		lines = append(lines, fmt.Sprintf("%s [%s] %s %s", s.Name, s.Runtime, dash(s.Repo), s.State))
-	}
-	return lines
+	// What to do: usually nothing — locks clear themselves.
+	b.WriteByte('\n')
+	b.WriteString(mutedStyle.Render("what to do: usually nothing. Stale resource locks clear once the daemon runs (Health → s);"))
+	b.WriteByte('\n')
+	b.WriteString(mutedStyle.Render("branch locks release when their work finishes, or free one with"))
+	b.WriteByte('\n')
+	b.WriteString(mutedStyle.Render("  gitmoot lock release owner/repo <branch> --owner <agent>"))
+	b.WriteByte('\n')
+	return b.String()
 }
 
 func jobStateColor(state string) string {


### PR DESCRIPTION
## What

Round 4 / issue #266, task 4. Two clarity fixes the user hit in live use.

**Runtime sessions** — the page was an opaque grouped list. Now:
- A cursor list (`↑/↓`); `enter` opens a detail view for the selected session.
- Detail shows type, runtime, role, repo, state, template, last-used, expiry — pulled from the `agent_instance` row.
- A sharper one-liner explains what these are (the live codex/claude processes backing your Agents; one warm session per delivered job, up to `max_background`; idle ones expire).
- Collapsed background groups (`<type>-bg-<hex>`) open a group detail noting the member count.

**Locks** — added a "what to do" hint after the lock tables: usually nothing — stale resource locks clear once the daemon runs (Health → s); branch locks release when work finishes, or `gitmoot lock release owner/repo <branch> --owner <agent>`.

## Byte-stability

Detail fields ride **unexported** `dashboardSession` fields (mirrors the existing `dashboardAgent.templateID`) and non-serialized `tui.Session` fields, so `--json`/`--plain` output is unchanged. The grouping logic is preserved identically (same key, order, and label format) — just refactored to carry each row's representative session.

## Tests

`internal/cli/tui`: session detail renders the instance fields; a collapsed group shows its `×N` count + explainer; esc returns; locks page shows the guidance line. Full `go test ./...` green except the known `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` daemon flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)