### PR TITLE
cli: switch an agent's runtime from the dashboard

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -274,6 +274,11 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 				return err
 			})
 		},
+		SetAgentRuntime: func(name, runtimeName string) error {
+			return withStore(home, func(store *db.Store) error {
+				return store.UpdateAgentRuntime(context.Background(), name, runtimeName)
+			})
+		},
 		OpenAgentOptimize: func(agent tui.Agent) (tea.Model, error) {
 			// Same lifetime pattern as the create form: one store for the
 			// form's 200ms poll, closed from the Done hook.

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -43,6 +43,63 @@ func (m *Model) openAgentDelete(agent Agent) {
 	m.mode = modeConfirmAgentDelete
 }
 
+// agentRuntimeOptions are the runtimes an agent can be switched between.
+var agentRuntimeOptions = []string{"codex", "claude"}
+
+// openAgentRuntimePick enters the switch-runtime overlay, preselecting the
+// agent's current runtime.
+func (m *Model) openAgentRuntimePick(agent Agent) {
+	m.activeAgent = agent
+	m.actionErr = ""
+	m.actionBusy = false
+	m.runtimePickCursor = 0
+	for i, rt := range agentRuntimeOptions {
+		if rt == agent.Runtime {
+			m.runtimePickCursor = i
+			break
+		}
+	}
+	m.mode = modeAgentRuntimePick
+}
+
+func agentSetRuntimeCmd(deps Deps, name, runtime string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.SetAgentRuntime == nil {
+			return agentActionMsg{verb: "runtime"}
+		}
+		return agentActionMsg{verb: "runtime", err: deps.SetAgentRuntime(name, runtime)}
+	}
+}
+
+// agentRuntimePickView renders the switch-runtime choice overlay.
+func (m Model) agentRuntimePickView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("switch runtime · " + m.activeAgent.Name))
+	b.WriteString("\n\n")
+	b.WriteString(mutedStyle.Render("Pick the runtime this agent runs on. The warm session resets; the next job starts fresh."))
+	b.WriteString("\n\n")
+	for i, rt := range agentRuntimeOptions {
+		cursor, label := "  ", rt
+		if i == m.runtimePickCursor {
+			cursor, label = "▸ ", selectedRowStyle.Render(rt)
+		}
+		if rt == m.activeAgent.Runtime {
+			label += "  " + mutedStyle.Render("(current)")
+		}
+		b.WriteString(cursor + label + "\n")
+	}
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("switching…"))
+	} else {
+		b.WriteString(mutedStyle.Render("↑/↓ pick  enter apply  esc cancel"))
+	}
+	return b.String()
+}
+
 // openVersionView opens the preview pager for a template version, reusing the
 // cache when it already holds this version's content (the train-run skill-pager
 // pattern, keyed by version id).
@@ -144,6 +201,40 @@ func (m Model) updateAgentOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.viewport.SetContent(m.content())
 		return m, cmd
+	case modeAgentRuntimePick:
+		switch msg.String() {
+		case "esc", "q":
+			if m.actionBusy {
+				return m, nil
+			}
+			m.mode = modeNormal
+			m.actionErr = ""
+		case "up", "k":
+			if m.runtimePickCursor > 0 {
+				m.runtimePickCursor--
+			}
+		case "down", "j":
+			if m.runtimePickCursor < len(agentRuntimeOptions)-1 {
+				m.runtimePickCursor++
+			}
+		case "enter":
+			if m.actionBusy {
+				return m, nil
+			}
+			runtime := agentRuntimeOptions[m.runtimePickCursor]
+			if runtime == m.activeAgent.Runtime {
+				// Nothing to change; just close.
+				m.mode = modeNormal
+				m.actionErr = ""
+				break
+			}
+			m.actionBusy = true
+			m.actionErr = ""
+			m.viewport.SetContent(m.content())
+			return m, agentSetRuntimeCmd(m.deps, m.activeAgent.Name, runtime)
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
 	case modeAgentRevertPick:
 		versions := m.revertableVersions()
 		switch msg.String() {

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -178,6 +178,80 @@ func TestAgentVersionPreviewCachesPerVersion(t *testing.T) {
 	}
 }
 
+func TestAgentSwitchRuntimeFlow(t *testing.T) {
+	var got []string
+	deps := Deps{SetAgentRuntime: func(name, runtime string) error {
+		got = []string{name, runtime}
+		return nil
+	}}
+	m := agentsModel(t, deps, agentsSnapshot())
+	// planner (claude) is under the cursor; e opens the runtime picker.
+	next, _ := m.Update(key("e"))
+	m = next.(Model)
+	if m.mode != modeAgentRuntimePick {
+		t.Fatalf("e should open the runtime picker, mode=%v", m.mode)
+	}
+	// Cursor preselects the current runtime (claude, index 1). Move up to codex.
+	if m.runtimePickCursor != 1 {
+		t.Fatalf("picker should preselect the current runtime, cursor=%d", m.runtimePickCursor)
+	}
+	next, _ = m.Update(key("k"))
+	m = next.(Model)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("enter on a different runtime should apply it")
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if len(got) != 2 || got[0] != "planner" || got[1] != "codex" {
+		t.Fatalf("SetAgentRuntime called with %v, want [planner codex]", got)
+	}
+	if m.mode != modeNormal {
+		t.Fatalf("a successful switch should close the overlay, mode=%v", m.mode)
+	}
+}
+
+func TestAgentSwitchRuntimeNoChangeCloses(t *testing.T) {
+	deps := Deps{SetAgentRuntime: func(string, string) error {
+		t.Fatal("picking the current runtime must not call SetAgentRuntime")
+		return nil
+	}}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, _ := m.Update(key("e"))
+	m = next.(Model)
+	// Enter on the preselected (current) runtime is a no-op close.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatal("re-picking the current runtime should not issue a command")
+	}
+	if m.mode != modeNormal {
+		t.Fatalf("no-op pick should close the overlay, mode=%v", m.mode)
+	}
+}
+
+func TestAgentSwitchRuntimeErrorStaysOpen(t *testing.T) {
+	deps := Deps{SetAgentRuntime: func(string, string) error {
+		return errors.New("unknown runtime")
+	}}
+	m := agentsModel(t, deps, agentsSnapshot())
+	next, _ := m.Update(key("e"))
+	m = next.(Model)
+	next, _ = m.Update(key("k")) // claude → codex
+	m = next.(Model)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeAgentRuntimePick {
+		t.Fatalf("a failed switch should keep the overlay open, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "unknown runtime") {
+		t.Fatalf("the error should render in the overlay:\n%s", m.View())
+	}
+}
+
 func TestAgentCreateFlowRunsCreateAgent(t *testing.T) {
 	var created []string
 	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -237,6 +237,9 @@ type Deps struct {
 	CreateAgent            func(name, runtime, template string) error
 	DeleteAgent            func(name string) error
 	RevertTemplate         func(templateID, versionID string) error
+	// SetAgentRuntime switches a registered agent's runtime (codex/claude),
+	// preserving its role/capabilities/repos and clearing the warm session.
+	SetAgentRuntime func(name, runtime string) error
 
 	// Optimize an agent: OpenAgentOptimize builds the pre-filled training form
 	// for the agent's template; StartOptimize scaffolds and starts the train

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -64,6 +64,7 @@ const (
 	modeConfirmAgentRevert
 	modeConfirmAgentDelete
 	modeAgentVersionView
+	modeAgentRuntimePick
 	modeConfigEdit
 )
 
@@ -139,6 +140,7 @@ type Model struct {
 	versionCursor       int               // selected row in the revert pick list
 	revertVersion       TemplateVersion   // version being confirmed for revert
 	detailVersionCursor int               // selected version row in the agent detail
+	runtimePickCursor   int               // selected runtime in the switch-runtime overlay
 	activeAgentVersion  TemplateVersion   // version shown in the content pager
 	versionView         viewport.Model    // pager for a version's content
 	versionViewID       string            // version id the pager content belongs to
@@ -204,7 +206,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 			return m.updateTrainOverlay(msg)
-		case modeAgentDetail, modeAgentRevertPick, modeConfirmAgentRevert, modeConfirmAgentDelete, modeAgentVersionView:
+		case modeAgentDetail, modeAgentRevertPick, modeConfirmAgentRevert, modeConfirmAgentDelete, modeAgentVersionView, modeAgentRuntimePick:
 			if msg.String() == "ctrl+c" {
 				return m, tea.Quit
 			}
@@ -380,6 +382,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, openAgentOptimizeCmd(m.deps, agent)
 			}
 		case "e":
+			if agent, ok := m.agentUnderCursor(); ok && m.deps.SetAgentRuntime != nil {
+				m.openAgentRuntimePick(agent)
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
 			if pages[m.selected].page == pageConfig && m.deps.EditConfig != nil {
 				m.configEditErr = ""
 				m.configProblems = nil
@@ -612,6 +619,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "delete":
 			if m.mode == modeConfirmAgentDelete {
+				m.actionBusy = false
+				if msg.err != nil {
+					m.actionErr = msg.err.Error()
+				} else {
+					m.mode = modeNormal
+					m.actionErr = ""
+				}
+			}
+		case "runtime":
+			if m.mode == modeAgentRuntimePick {
 				m.actionBusy = false
 				if msg.err != nil {
 					m.actionErr = msg.err.Error()

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -98,6 +98,8 @@ func (m Model) content() string {
 		b.WriteString(m.agentDeleteConfirmView())
 	case modeAgentVersionView:
 		b.WriteString(m.agentVersionView())
+	case modeAgentRuntimePick:
+		b.WriteString(m.agentRuntimePickView())
 	case modeConfigEdit:
 		b.WriteString(m.configEditView())
 	default:
@@ -204,6 +206,8 @@ func (m Model) footerHelp() string {
 		return "v revert  D delete  esc back"
 	case modeAgentRevertPick:
 		return "↑/↓ pick  enter confirm  esc back"
+	case modeAgentRuntimePick:
+		return "↑/↓ pick  enter apply  esc cancel"
 	case modeConfirmAgentRevert, modeConfirmAgentDelete:
 		return "y confirm  n/esc cancel"
 	case modeConfigEdit:
@@ -217,7 +221,7 @@ func (m Model) footerHelp() string {
 	case pageTrains:
 		return "tab/←→ page  ↑/↓ select  enter open  s stop  d delete  ? help  q quit"
 	case pageAgents:
-		return "tab/←→ page  ↑/↓ select  enter detail  n new  o optimize  D delete  ? help  q quit"
+		return "tab/←→ page  ↑/↓ select  enter detail  n new  o optimize  e runtime  D delete  ? help  q quit"
 	case pageSessions:
 		return "tab/←→ page  ↑/↓ select  enter detail  ? help  q quit"
 	case pageJobs:

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -632,6 +632,30 @@ func (s *Store) UpsertAgent(ctx context.Context, agent Agent) error {
 	return tx.Commit()
 }
 
+// UpdateAgentRuntime switches a registered agent's runtime (codex or claude),
+// preserving its role, capabilities, repo scope, template, and policy. The warm
+// runtime_ref is cleared because it is bound to the old runtime — the next job
+// starts a fresh session for the new runtime. The old agent_instance, if any,
+// idle-expires on its own.
+func (s *Store) UpdateAgentRuntime(ctx context.Context, name, runtime string) error {
+	runtime = strings.TrimSpace(runtime)
+	if runtime != "codex" && runtime != "claude" {
+		return fmt.Errorf("unknown runtime %q (want codex or claude)", runtime)
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, template_id, capabilities_json, autonomy_policy, health_status
+		FROM agents WHERE name = ?`, name)
+	agent, err := scanAgent(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("agent %q is not registered", name)
+	}
+	if err != nil {
+		return err
+	}
+	agent.Runtime = runtime
+	agent.RuntimeRef = ""
+	return s.UpsertAgent(ctx, agent)
+}
+
 func (s *Store) GetAgent(ctx context.Context, name string) (Agent, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, template_id, capabilities_json, autonomy_policy, health_status
 		FROM agents WHERE name = ?`, name)

--- a/internal/db/store_cockpit_test.go
+++ b/internal/db/store_cockpit_test.go
@@ -207,6 +207,53 @@ func TestDeleteAgentChecked(t *testing.T) {
 	}
 }
 
+func TestUpdateAgentRuntime(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	original := Agent{
+		Name:           "worker",
+		Role:           "implement",
+		Runtime:        "codex",
+		RuntimeRef:     "sess-abc",
+		RepoScope:      "owner/repo",
+		TemplateID:     "worker-tpl",
+		Capabilities:   []string{"implement", "review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}
+	if err := store.UpsertAgent(ctx, original); err != nil {
+		t.Fatalf("upsert agent: %v", err)
+	}
+
+	// Unknown runtime is rejected, leaving the row untouched.
+	if err := store.UpdateAgentRuntime(ctx, "worker", "gpt"); err == nil || !strings.Contains(err.Error(), "unknown runtime") {
+		t.Fatalf("expected unknown-runtime error, got %v", err)
+	}
+	// Missing agent errors.
+	if err := store.UpdateAgentRuntime(ctx, "ghost", "claude"); err == nil || !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("expected not-registered error, got %v", err)
+	}
+
+	if err := store.UpdateAgentRuntime(ctx, "worker", "claude"); err != nil {
+		t.Fatalf("switch runtime: %v", err)
+	}
+	got, err := store.GetAgent(ctx, "worker")
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if got.Runtime != "claude" {
+		t.Fatalf("runtime = %q, want claude", got.Runtime)
+	}
+	if got.RuntimeRef != "" {
+		t.Fatalf("runtime_ref = %q, want cleared", got.RuntimeRef)
+	}
+	// Everything else preserved.
+	if got.Role != "implement" || got.RepoScope != "owner/repo" || got.TemplateID != "worker-tpl" ||
+		got.AutonomyPolicy != "auto" || strings.Join(got.Capabilities, ",") != "implement,review" {
+		t.Fatalf("switch runtime altered preserved fields: %+v", got)
+	}
+}
+
 func TestLatestJobEvents(t *testing.T) {
 	store := openCockpitStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## What

Round 4 / issue #266, task 6 (runtime half only; the model half is deferred to #268). There was no dashboard path to move an agent between the codex and claude runtimes.

- Agents page: `e` opens a runtime picker (`↑/↓`, `enter` apply, `esc` cancel), preselecting the agent's current runtime.
- Picking the current runtime is a no-op that just closes; a failed switch keeps the picker open with an inline error.

## Store

New `store.UpdateAgentRuntime(name, runtime)`:
- Rejects an unknown runtime (only `codex`/`claude`) and a missing/unregistered agent.
- Sets the runtime and **clears `runtime_ref`** — the warm session is bound to the old runtime, so the next job starts a fresh one; the old `agent_instance` idle-expires.
- Re-writes via `UpsertAgent`, preserving role, capabilities, repo scope, template, and policy (a focused method, not `registerAgentOnly`, which would drop role/caps).

## Tests

`internal/db`: switch flips runtime + clears runtime_ref + preserves the other fields; rejects unknown runtime; errors on a missing agent. `internal/cli/tui`: `e` → pick → `SetAgentRuntime` called with the new runtime and overlay closes; no-op pick issues no command; a failed switch stays open with the error rendered. Full `go test ./...` green except the known `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` daemon flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)