### PR TITLE
cli: auto-select a repo created in the optimize form

### DIFF
--- a/internal/cli/tui/traininit.go
+++ b/internal/cli/tui/traininit.go
@@ -144,6 +144,9 @@ func (m TrainInitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.inlineErr = "create failed: " + msg.err.Error()
 			return m, nil
 		}
+		// Make the just-created repo a selectable, pre-selected choice on every
+		// repo field so it is auto-selected here and reusable for the other one.
+		m.registerCreatedRepo(msg.value)
 		return m.commit(msg.value)
 	}
 	return m, nil
@@ -420,6 +423,45 @@ func newPathInput() textinput.Model {
 	ti := textinput.New()
 	ti.Placeholder = "template id, version, or file path"
 	return ti
+}
+
+// registerCreatedRepo records a newly-created repo on every repo field (those
+// with a CreateRepo callback): it inserts the repo as a selectable choice and
+// makes it the field's default, so the field it was created on shows it selected
+// on re-entry and the other repo field pre-selects it too.
+func (m *TrainInitModel) registerCreatedRepo(repo string) {
+	for i := range m.fields {
+		if m.fields[i].CreateRepo == nil {
+			continue
+		}
+		if m.fields[i].Kind == FieldChoice || m.fields[i].Kind == FieldTemplate {
+			m.fields[i].Choices = ensureRepoChoice(m.fields[i].Choices, repo)
+		}
+		m.fields[i].Default = repo
+	}
+}
+
+// ensureRepoChoice returns choices with repo present as a normal entry, inserted
+// before the first Custom ("another repo…") entry so it stays last. A repo
+// already in the list is left untouched (no duplicate).
+func ensureRepoChoice(choices []Choice, repo string) []Choice {
+	for _, c := range choices {
+		if c.Value == repo {
+			return choices
+		}
+	}
+	insertAt := len(choices)
+	for i, c := range choices {
+		if c.Custom {
+			insertAt = i
+			break
+		}
+	}
+	out := make([]Choice, 0, len(choices)+1)
+	out = append(out, choices[:insertAt]...)
+	out = append(out, Choice{Value: repo, Label: repo})
+	out = append(out, choices[insertAt:]...)
+	return out
 }
 
 func choiceIndex(choices []Choice, value string) int {

--- a/internal/cli/tui/traininit_picker_test.go
+++ b/internal/cli/tui/traininit_picker_test.go
@@ -23,6 +23,88 @@ func pickerField(checkRepo func(string) (bool, error), createRepo func(string) e
 	}
 }
 
+// repoFieldNamed is pickerField with a chosen name (for multi-field forms).
+func repoFieldNamed(name string, checkRepo func(string) (bool, error), createRepo func(string) error) Field {
+	f := pickerField(checkRepo, createRepo)
+	f.Name = name
+	f.Prompt = db.InteractivePrompt{ID: "picker-" + name}
+	return f
+}
+
+func TestRepoPickerCreatedRepoAutoSelectedAcrossFields(t *testing.T) {
+	createOne := func(string) error { return nil }
+	missing := func(string) (bool, error) { return true, nil }
+	interpret := func(_, text string) (string, string) {
+		if !strings.Contains(text, "/") {
+			return "", "reask"
+		}
+		return strings.TrimSpace(text), "ok"
+	}
+	review := repoFieldNamed("review_repo", missing, createOne)
+	workspace := repoFieldNamed("workspace_repo", missing, createOne)
+	// A non-repo field (no CreateRepo) must be left untouched.
+	plain := Field{Name: "items", Label: "Items", Kind: FieldChoice,
+		Choices: []Choice{{Value: "2", Label: "2"}}, Prompt: db.InteractivePrompt{ID: "items"}}
+
+	form := NewTrainInit(newFakeStore(), []Field{review, workspace, plain}, nil, interpret, 0)
+	var model tea.Model = form
+	var lastCmd tea.Cmd
+	step := func(msg tea.Msg) { next, cmd := model.Update(msg); model, lastCmd = next, cmd }
+
+	step(initMsg{})
+	step(tea.KeyMsg{Type: tea.KeyDown})  // → custom entry on review_repo
+	step(tea.KeyMsg{Type: tea.KeyEnter}) // open text sub-state
+	for _, r := range "o/fresh" {
+		step(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	step(tea.KeyMsg{Type: tea.KeyEnter}) // repo check
+	step(lastCmd())                      // repoCheckMsg → missing
+	step(key("c"))                       // create
+	step(lastCmd())                      // repoCreatedMsg → registerCreatedRepo + commit → enters workspace_repo
+
+	m := model.(TrainInitModel)
+	if m.answers["review_repo"] != "o/fresh" {
+		t.Fatalf("review_repo answer = %q, want o/fresh", m.answers["review_repo"])
+	}
+	// Both repo fields now carry the created repo as a choice and as their default.
+	for _, name := range []string{"review_repo", "workspace_repo"} {
+		f := fieldByName(m.fields, name)
+		if f.Default != "o/fresh" {
+			t.Fatalf("%s default = %q, want o/fresh", name, f.Default)
+		}
+		if countChoice(f.Choices, "o/fresh") != 1 {
+			t.Fatalf("%s should list o/fresh exactly once: %+v", name, f.Choices)
+		}
+	}
+	// The non-repo field is untouched.
+	if plain := fieldByName(m.fields, "items"); plain.Default == "o/fresh" || countChoice(plain.Choices, "o/fresh") != 0 {
+		t.Fatalf("non-repo field was polluted: %+v", plain)
+	}
+	// The form advanced to workspace_repo with the created repo pre-selected.
+	if m.idx != 1 || m.choiceIdx != choiceIndex(m.fields[1].Choices, "o/fresh") {
+		t.Fatalf("workspace_repo not pre-selected: idx=%d choiceIdx=%d", m.idx, m.choiceIdx)
+	}
+}
+
+func fieldByName(fields []Field, name string) Field {
+	for _, f := range fields {
+		if f.Name == name {
+			return f
+		}
+	}
+	return Field{}
+}
+
+func countChoice(choices []Choice, value string) int {
+	n := 0
+	for _, c := range choices {
+		if c.Value == value {
+			n++
+		}
+	}
+	return n
+}
+
 func TestRepoPickerSelectsKnownRepoDirectly(t *testing.T) {
 	form := NewTrainInit(newFakeStore(), []Field{pickerField(nil, nil)}, nil, nil, 0)
 	var model tea.Model = form


### PR DESCRIPTION
## What

Round 5 / point 1. The optimize form's two repo pickers (`review_repo`, `workspace_repo`) built their choice lists once at construction. A repo created through the "another repo…" path committed as that field's answer but was never injected into the choice lists, so it wasn't shown as selected and the other repo field couldn't reuse it.

On a successful create (`repoCreatedMsg`), `registerCreatedRepo` now:
- inserts the repo into every repo field's `Choices` (deduped, placed before the "another repo…" custom entry so it stays last), and
- sets it as those fields' `Default`,

so the created repo is auto-selected where it was made and pre-selected for the other repo field. Repo fields are identified by their `CreateRepo` callback, so non-repo fields are left untouched.

## Tests

`internal/cli/tui`: creating a repo via the custom path makes it appear once in both repo fields' choices and as their default, advances to the next repo field pre-selected, and leaves a non-repo field untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)