### PR TITLE
cli: stop a runtime session from the dashboard

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -279,6 +279,11 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 				return store.UpdateAgentRuntime(context.Background(), name, runtimeName)
 			})
 		},
+		StopSession: func(name string) error {
+			return withStore(home, func(store *db.Store) error {
+				return store.StopAgentInstance(context.Background(), name)
+			})
+		},
 		EditAgentPrompt: func(seedTemplateID string) tea.Cmd {
 			seed := agentPromptScaffold
 			if strings.TrimSpace(seedTemplateID) != "" {

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -129,12 +129,6 @@ func (m Model) updateOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.viewport.SetContent(m.content())
 		}
 		return m, nil
-	case modeSessionDetail:
-		if s := msg.String(); s == "enter" || s == "q" {
-			m.mode = modeNormal
-			m.viewport.SetContent(m.content())
-		}
-		return m, nil
 	case modeAnswerChoice:
 		switch msg.String() {
 		case "up", "k":

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -248,6 +248,10 @@ type Deps struct {
 	// preserving its role/capabilities/repos and clearing the warm session.
 	SetAgentRuntime func(name, runtime string) error
 
+	// StopSession removes a runtime session (warm agent_instance) by name,
+	// refusing one that is mid-job. Wired to store.StopAgentInstance.
+	StopSession func(name string) error
+
 	// EditAgentPrompt opens $EDITOR seeded from the given base template (empty =
 	// a minimal scaffold) and returns a command whose completion delivers an
 	// AgentPromptEditedMsg with the saved content (it is a tea.ExecProcess that
@@ -335,6 +339,11 @@ type jobDetailMsg struct {
 	id     string
 	detail JobDetail
 	err    error
+}
+
+// sessionActionMsg carries the outcome of a Deps.StopSession call.
+type sessionActionMsg struct {
+	err error
 }
 
 // jobActionMsg carries the outcome of a retry/cancel action.

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -54,6 +54,7 @@ const (
 	modeTrainDetail
 	modeJobDetail
 	modeSessionDetail
+	modeConfirmSessionStop
 	modeConfirmJobRetry
 	modeConfirmJobCancel
 	modeTrainStopReason
@@ -99,8 +100,9 @@ type Model struct {
 
 	// Sessions page interaction state.
 	sessionCursor      int     // selected row in sessionRows()
-	activeSession      Session // session shown in modeSessionDetail
+	activeSession      Session // session shown in modeSessionDetail / being stopped
 	activeSessionCount int     // members collapsed into the selected row (>1 for a bg group)
+	sessionNotice      string  // muted note on the Sessions page (e.g. group not stoppable)
 
 	// Jobs page interaction state.
 	jobCursor       int                 // selected row in snap.JobRows
@@ -222,6 +224,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 			return m.updateConfigOverlay(msg)
+		case modeSessionDetail, modeConfirmSessionStop:
+			if msg.String() == "ctrl+c" {
+				return m, tea.Quit
+			}
+			return m.updateSessionOverlay(msg)
 		}
 		if m.mode != modeNormal {
 			return m.updateOverlay(msg)
@@ -231,6 +238,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "tab", "right":
 			m.selected = (m.selected + 1) % len(pages)
+			m.sessionNotice = ""
 			m.viewport.GotoTop()
 			if cmd := m.maybeLoadHealth(); cmd != nil {
 				cmds = append(cmds, cmd)
@@ -242,6 +250,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.selected < 0 {
 				m.selected = len(pages) - 1
 			}
+			m.sessionNotice = ""
 			m.viewport.GotoTop()
 			if cmd := m.maybeLoadHealth(); cmd != nil {
 				cmds = append(cmds, cmd)
@@ -266,6 +275,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if *cursor > 0 {
 					*cursor--
 				}
+				m.sessionNotice = ""
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
@@ -274,6 +284,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if *cursor < n-1 {
 					*cursor++
 				}
+				m.sessionNotice = ""
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
@@ -363,6 +374,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmd := m.openTrainStop(t)
 				m.viewport.SetContent(m.content())
 				return m, cmd
+			}
+			if pages[m.selected].page == pageSessions && m.deps.StopSession != nil {
+				rows := m.sessionRows()
+				if m.sessionCursor < len(rows) {
+					m.openSessionStop(rows[m.sessionCursor])
+				}
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
 			}
 		case "n":
 			// Form construction touches the database, so it runs as a command
@@ -519,6 +538,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.agentNotice = "note: prompt has no gitmoot_result contract; created anyway"
 			}
 			cmds = append(cmds, agentCreateWithPromptCmd(m.deps, name, runtime, msg.Content))
+		}
+	case sessionActionMsg:
+		if m.mode == modeConfirmSessionStop {
+			m.actionBusy = false
+			if msg.err != nil {
+				m.actionErr = msg.err.Error()
+			} else {
+				m.mode = modeNormal
+				m.actionErr = ""
+			}
+		}
+		if msg.err == nil {
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 		}
 	case trainStopMsg:
 		if m.mode == modeTrainStopReason {

--- a/internal/cli/tui/sessions.go
+++ b/internal/cli/tui/sessions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jerryfane/gitmoot/internal/cli/style"
 )
 
@@ -56,6 +57,87 @@ func (m Model) sessionRows() []sessionRow {
 	return rows
 }
 
+// updateSessionOverlay handles keys in the session detail and stop-confirm
+// modes. Like the job overlay it guards esc/keys while a stop is in flight so
+// the result (especially a refusal) is never dropped.
+func (m Model) updateSessionOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.mode {
+	case modeSessionDetail:
+		if s := msg.String(); s == "enter" || s == "q" || s == "esc" {
+			m.mode = modeNormal
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case modeConfirmSessionStop:
+		switch msg.String() {
+		case "y", "Y":
+			if m.actionBusy {
+				return m, nil
+			}
+			m.actionBusy = true
+			m.actionErr = ""
+			cmd := sessionStopCmd(m.deps, m.activeSession.Name)
+			m.viewport.SetContent(m.content())
+			return m, cmd
+		default:
+			// While the stop is in flight, keep the confirm open so its result
+			// (especially an error like "running a job") is not dropped — this is
+			// why the overlay has its own handler rather than the shared esc path.
+			if m.actionBusy {
+				return m, nil
+			}
+			m.mode = modeNormal
+			m.actionErr = ""
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	}
+	return m, nil
+}
+
+// openSessionStop opens the stop confirmation for a single session. Collapsed
+// background groups aren't individually addressable, so a group row instead
+// sets a muted hint pointing at `gitmoot agent gc`.
+func (m *Model) openSessionStop(row sessionRow) {
+	m.actionErr = ""
+	m.actionBusy = false
+	if row.count > 1 {
+		m.sessionNotice = "background workers expire on their own — clear them with `gitmoot agent gc`"
+		return
+	}
+	m.sessionNotice = ""
+	m.activeSession = row.session
+	m.activeSessionCount = row.count
+	m.mode = modeConfirmSessionStop
+}
+
+func sessionStopCmd(deps Deps, name string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.StopSession == nil {
+			return sessionActionMsg{}
+		}
+		return sessionActionMsg{err: deps.StopSession(name)}
+	}
+}
+
+func (m Model) sessionStopConfirmView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("Stop session " + m.activeSession.Name))
+	b.WriteString("\n\n")
+	b.WriteString(dash(m.activeSession.Type) + " · " + dash(m.activeSession.Runtime) + " · " + dash(m.activeSession.State) + "\n\n")
+	b.WriteString("Stop this runtime session? The next job starts a fresh one. (y/n)\n")
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	b.WriteString("\n")
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("stopping…"))
+	} else {
+		b.WriteString(mutedStyle.Render("y confirm  n/esc cancel"))
+	}
+	return b.String()
+}
+
 // openSessionDetail enters the detail view for the session under the cursor.
 func (m *Model) openSessionDetail() {
 	rows := m.sessionRows()
@@ -84,7 +166,14 @@ func (m Model) sessionsContent() string {
 		b.WriteString(cursor + label + "\n")
 	}
 	b.WriteByte('\n')
-	b.WriteString(mutedStyle.Render("enter detail"))
+	hint := "enter detail"
+	if m.deps.StopSession != nil {
+		hint += "  s stop"
+	}
+	b.WriteString(mutedStyle.Render(hint))
+	if m.sessionNotice != "" {
+		b.WriteString("\n" + mutedStyle.Render(m.sessionNotice))
+	}
 	return b.String()
 }
 

--- a/internal/cli/tui/sessions_test.go
+++ b/internal/cli/tui/sessions_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -74,6 +75,89 @@ func TestSessionDetailGroupShowsCount(t *testing.T) {
 	}
 	if !strings.Contains(view, "background workers") {
 		t.Fatalf("group detail should explain the collapse:\n%s", view)
+	}
+}
+
+func sessionsPageModelWithDeps(t *testing.T, snap Snapshot, deps Deps) Model {
+	t.Helper()
+	if deps.Load == nil {
+		deps.Load = func() (Snapshot, error) { return snap, nil }
+	}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1_700_000_000, 0)})
+	m = next.(Model)
+	for i := 0; i < 3; i++ {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+	}
+	if pages[m.selected].page != pageSessions {
+		t.Fatalf("expected Sessions page, got %v", pages[m.selected].page)
+	}
+	return m
+}
+
+func TestSessionStopSingleConfirms(t *testing.T) {
+	var stopped string
+	deps := Deps{StopSession: func(name string) error { stopped = name; return nil }}
+	m := sessionsPageModelWithDeps(t, sessionDetailSnapshot(), deps)
+	// Cursor down to the single "planner" session (row 1; row 0 is the bg group).
+	next, _ := m.Update(key("j"))
+	m = next.(Model)
+	next, _ = m.Update(key("s"))
+	m = next.(Model)
+	if m.mode != modeConfirmSessionStop {
+		t.Fatalf("s on a single session should open the stop confirm, mode=%v", m.mode)
+	}
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("y should dispatch the stop")
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if stopped != "planner" {
+		t.Fatalf("StopSession called with %q, want planner", stopped)
+	}
+	if m.mode != modeNormal {
+		t.Fatalf("a successful stop should close the confirm, mode=%v", m.mode)
+	}
+}
+
+func TestSessionStopGroupShowsHint(t *testing.T) {
+	deps := Deps{StopSession: func(string) error {
+		t.Fatal("a group row must not call StopSession")
+		return nil
+	}}
+	m := sessionsPageModelWithDeps(t, sessionDetailSnapshot(), deps)
+	// Cursor starts on the collapsed generator group (row 0).
+	next, _ := m.Update(key("s"))
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("s on a group must not open a confirm, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "agent gc") {
+		t.Fatalf("group stop should hint at gc:\n%s", m.View())
+	}
+}
+
+func TestSessionStopRefusalRendersInline(t *testing.T) {
+	deps := Deps{StopSession: func(string) error {
+		return errors.New("session \"planner\" is running a job; cancel it from Jobs first")
+	}}
+	m := sessionsPageModelWithDeps(t, sessionDetailSnapshot(), deps)
+	next, _ := m.Update(key("j"))
+	m = next.(Model)
+	next, _ = m.Update(key("s"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeConfirmSessionStop {
+		t.Fatalf("a refused stop should keep the confirm open, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "running a job") {
+		t.Fatalf("refusal should render inline:\n%s", m.View())
 	}
 }
 

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -80,6 +80,8 @@ func (m Model) content() string {
 		b.WriteString(m.jobDetailView())
 	case modeSessionDetail:
 		b.WriteString(m.sessionDetailView())
+	case modeConfirmSessionStop:
+		b.WriteString(m.sessionStopConfirmView())
 	case modeConfirmJobRetry, modeConfirmJobCancel:
 		b.WriteString(m.jobConfirmView())
 	case modeTrainStopReason:
@@ -214,6 +216,8 @@ func (m Model) footerHelp() string {
 		return "type value  enter save  esc cancel"
 	case modeSessionDetail:
 		return "enter/esc back"
+	case modeConfirmSessionStop:
+		return "y confirm  n/esc cancel"
 	}
 	switch pages[m.selected].page {
 	case pageAttention:
@@ -223,7 +227,7 @@ func (m Model) footerHelp() string {
 	case pageAgents:
 		return "tab/←→ page  ↑/↓ select  enter detail  n new  o optimize  e runtime  D delete  ? help  q quit"
 	case pageSessions:
-		return "tab/←→ page  ↑/↓ select  enter detail  ? help  q quit"
+		return "tab/←→ page  ↑/↓ select  enter detail  s stop  ? help  q quit"
 	case pageJobs:
 		return "tab/←→ page  ↑/↓ select  enter detail  R retry  c cancel  ? help  q quit"
 	case pageHealth:

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1556,6 +1556,24 @@ func (s *Store) DeleteAgentInstance(ctx context.Context, name string) error {
 	return requireAffected(result, "agent instance", name)
 }
 
+// StopAgentInstance removes a runtime session (warm agent_instance) by name. It
+// refuses a session that is mid-job (state "running") so an in-flight job is
+// never orphaned — the caller cancels the job first. A missing session errors.
+func (s *Store) StopAgentInstance(ctx context.Context, name string) error {
+	name = strings.TrimSpace(name)
+	instance, err := s.GetAgentInstance(ctx, name)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("session %q not found", name)
+	}
+	if err != nil {
+		return err
+	}
+	if instance.State == "running" {
+		return fmt.Errorf("session %q is running a job; cancel it from Jobs first", name)
+	}
+	return s.DeleteAgentInstance(ctx, name)
+}
+
 func (s *Store) DeleteExpiredAgentInstances(ctx context.Context, now time.Time) (int64, error) {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM agent_instances
 		WHERE state = 'idle'

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1309,6 +1309,50 @@ func TestResourceLockDoesNotRecoverExpiredRunningOwner(t *testing.T) {
 	}
 }
 
+func TestStopAgentInstance(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+
+	mk := func(name, state string) AgentInstance {
+		return AgentInstance{
+			Name: name, Type: "planner", Runtime: "codex", RuntimeRef: "ref-" + name,
+			RepoFullName: "owner/repo", Role: "planner", State: state,
+			CreatedAt: formatResourceLockTime(now), LastUsedAt: formatResourceLockTime(now),
+			ExpiresAt: formatResourceLockTime(now.Add(time.Minute)),
+		}
+	}
+	if err := store.UpsertAgentInstance(ctx, mk("idle-1", "idle")); err != nil {
+		t.Fatalf("seed idle: %v", err)
+	}
+	if err := store.UpsertAgentInstance(ctx, mk("busy-1", "running")); err != nil {
+		t.Fatalf("seed running: %v", err)
+	}
+
+	// Idle session stops (row removed).
+	if err := store.StopAgentInstance(ctx, "idle-1"); err != nil {
+		t.Fatalf("stop idle: %v", err)
+	}
+	if _, err := store.GetAgentInstance(ctx, "idle-1"); err == nil {
+		t.Fatal("idle session should be gone after stop")
+	}
+	// Running session is refused and left in place.
+	if err := store.StopAgentInstance(ctx, "busy-1"); err == nil || !strings.Contains(err.Error(), "running a job") {
+		t.Fatalf("expected running-refusal, got %v", err)
+	}
+	if _, err := store.GetAgentInstance(ctx, "busy-1"); err != nil {
+		t.Fatalf("running session must survive a refused stop: %v", err)
+	}
+	// Missing session errors.
+	if err := store.StopAgentInstance(ctx, "ghost"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found, got %v", err)
+	}
+}
+
 func TestAgentInstanceMethods(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
## What

Round 5 / point 3. The Sessions page was read-only — no way to stop a runtime session you no longer want warm.

- `s` on a single session opens a stop confirmation; confirming removes the `agent_instance` row (the next job for that agent starts a fresh session — a session is just metadata + a `runtime_ref`, no live process).
- New `store.StopAgentInstance` **refuses a session that is mid-job** (`state == "running"`) with "cancel it from Jobs first", so an in-flight job is never orphaned; a missing session errors.
- Collapsed background-worker **group** rows aren't individually addressable, so `s` there shows a muted hint to clear them with `gitmoot agent gc` instead of a confirm.

## Robustness

Session overlays (detail + stop-confirm) move to a dedicated `updateSessionOverlay` so the stop-confirm guards keys — including `esc` — while the stop is in flight (mirrors the job-cancel confirm), rather than the shared overlay path whose `esc` is unconditional. The group hint clears on cursor move and page change.

## Byte-stability

TUI/store-only: a new `Deps.StopSession`, a `tui`-only `sessionActionMsg`, and the new store method. No json-tagged dashboard struct changes.

## Tests

`internal/db`: `StopAgentInstance` deletes an idle session, refuses a running one (left in place), errors on missing. `internal/cli/tui`: `s` on a single session → confirm → `StopSession` called → closes; `s` on a group shows the gc hint and no confirm; a refusal renders inline and keeps the confirm open. Full `go test ./...` green except the known daemon flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)