### PR TITLE
cli: scrollable jobs list with a datetime column

### DIFF
--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -434,6 +434,16 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 			}
 			snapshot.jobRows = append(snapshot.jobRows, row)
 		}
+		// Newest-first for the interactive Jobs list (ISO timestamps sort
+		// lexically; id breaks ties deterministically). jobRows is unexported and
+		// feeds only the TUI, so the --json/--plain aggregate stays byte-stable.
+		sort.SliceStable(snapshot.jobRows, func(i, j int) bool {
+			a, b := snapshot.jobRows[i], snapshot.jobRows[j]
+			if a.UpdatedAt != b.UpdatedAt {
+				return a.UpdatedAt > b.UpdatedAt
+			}
+			return a.ID > b.ID
+		})
 		tasks, err := store.ListTasks(ctx)
 		if err != nil {
 			return err

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -186,7 +187,30 @@ func (m Model) jobsContentInteractive() string {
 	}
 	b.WriteString(mutedStyle.Render(strconv.Itoa(m.snap.Jobs.Total)+" total") + "  " + strings.Join(summary, "  "))
 	b.WriteString("\n\n")
-	for i, job := range m.snap.JobRows {
+	// Window the list so the cursor stays on-screen even with hundreds of jobs;
+	// the cursor is kept roughly centered (stateless — derived from jobCursor).
+	rows := m.snap.JobRows
+	n := len(rows)
+	capacity := jobsWindowCap(m.height)
+	start := 0
+	if n > capacity {
+		start = m.jobCursor - capacity/2
+		if start < 0 {
+			start = 0
+		}
+		if start > n-capacity {
+			start = n - capacity
+		}
+	}
+	end := start + capacity
+	if end > n {
+		end = n
+	}
+	if start > 0 {
+		b.WriteString(mutedStyle.Render("↑ "+strconv.Itoa(start)+" earlier") + "\n")
+	}
+	for i := start; i < end; i++ {
+		job := rows[i]
 		cursor, id := "  ", job.ID
 		state := job.State
 		if _, pending := m.cancelling[job.ID]; pending && jobCancelable(job.State) {
@@ -195,11 +219,43 @@ func (m Model) jobsContentInteractive() string {
 		if i == m.jobCursor {
 			cursor, id = "▸ ", selectedRowStyle.Render(job.ID)
 		}
-		b.WriteString(cursor + id + "  " + job.Agent + "  " + job.Type + "  " + jobStateColor(state) + "\n")
+		b.WriteString(cursor + id + "  " + job.Agent + "  " + job.Type + "  " + jobStateColor(state) +
+			"  " + mutedStyle.Render(formatJobTime(job.UpdatedAt)) + "\n")
+	}
+	if end < n {
+		b.WriteString(mutedStyle.Render("↓ "+strconv.Itoa(n-end)+" more") + "\n")
 	}
 	b.WriteString(mutedStyle.Render("enter detail  R retry  c cancel"))
 	b.WriteByte('\n')
 	return b.String()
+}
+
+// jobsWindowCap is how many job rows fit the Jobs page, leaving room for the
+// title, summary, more/earlier markers, and footer.
+func jobsWindowCap(height int) int {
+	if height-9 < 3 {
+		return 3
+	}
+	return height - 9
+}
+
+// formatJobTime renders a stored ISO timestamp ("2006-01-02 15:04:05", UTC from
+// SQLite) as a compact "MM-DD HH:MM". A value it can't parse is trimmed to its
+// first 16 chars so the column never balloons.
+func formatJobTime(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02T15:04:05Z07:00", "2006-01-02 15:04:05.999999999"} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.Format("01-02 15:04")
+		}
+	}
+	if r := []rune(value); len(r) > 16 {
+		return string(r[:16])
+	}
+	return value
 }
 
 func (m Model) jobDetailView() string {
@@ -210,7 +266,7 @@ func (m Model) jobDetailView() string {
 		{"agent", dash(m.activeJob.Agent)},
 		{"type", dash(m.activeJob.Type)},
 		{"state", m.activeJob.State},
-		{"updated", dash(m.activeJob.UpdatedAt)},
+		{"updated", formatJobTime(m.activeJob.UpdatedAt)},
 	}
 	d := m.activeJobDetail
 	if d.Repo != "" {

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +38,67 @@ func jobsModel(t *testing.T, deps Deps, snap Snapshot) Model {
 		t.Fatalf("expected Jobs page, got %v", pages[m.selected].page)
 	}
 	return m
+}
+
+func TestFormatJobTime(t *testing.T) {
+	cases := map[string]string{
+		"2026-06-11 14:30:05":  "06-11 14:30",
+		"2026-01-02T15:04:05Z": "01-02 15:04",
+		"":                     "-",
+		"not a date":           "not a date",
+	}
+	for in, want := range cases {
+		if got := formatJobTime(in); got != want {
+			t.Fatalf("formatJobTime(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// An unparseable but long value is trimmed, not echoed whole.
+	if got := formatJobTime("2026-06-11-garbage-tail-xxxxxxxx"); len(got) != 16 {
+		t.Fatalf("long unparseable value should trim to 16 chars, got %q", got)
+	}
+}
+
+func TestJobsRowShowsTime(t *testing.T) {
+	snap := jobsSnapshot()
+	snap.JobRows[0].UpdatedAt = "2026-06-11 14:30:05"
+	m := jobsModel(t, Deps{}, snap)
+	if !strings.Contains(m.View(), "06-11 14:30") {
+		t.Fatalf("jobs row should show the formatted time:\n%s", m.View())
+	}
+}
+
+func TestJobsListWindowsLongList(t *testing.T) {
+	snap := Snapshot{Daemon: Daemon{Running: true}}
+	for i := 0; i < 100; i++ {
+		snap.JobRows = append(snap.JobRows, JobRow{
+			ID: "job-" + strconv.Itoa(i), Agent: "planner", Type: "ask", State: "succeeded",
+		})
+	}
+	m := jobsModel(t, Deps{}, snap)
+	cap := jobsWindowCap(m.height)
+	if cap >= 100 {
+		t.Fatalf("test needs a window smaller than the list; cap=%d", cap)
+	}
+	// Cursor at top: a "more" marker, no "earlier", and the last row is hidden.
+	view := m.View()
+	if !strings.Contains(view, "more") || strings.Contains(view, "earlier") {
+		t.Fatalf("top of a long list should show only a 'more' marker:\n%s", view)
+	}
+	if strings.Contains(view, "job-99 ") {
+		t.Fatalf("the far end should not render while the cursor is at the top")
+	}
+	// Drive the cursor to the last job; it must stay visible (window follows).
+	for i := 0; i < 99; i++ {
+		next, _ := m.Update(key("j"))
+		m = next.(Model)
+	}
+	view = m.View()
+	if !strings.Contains(view, "job-99") {
+		t.Fatalf("the selected last job must be visible after scrolling:\n%s", view)
+	}
+	if !strings.Contains(view, "earlier") {
+		t.Fatalf("the bottom of a long list should show an 'earlier' marker:\n%s", view)
+	}
 }
 
 func TestJobsPageDetailLoadsEvents(t *testing.T) {


### PR DESCRIPTION
## What

Round 5 / point 4. With 260+ jobs the Jobs page dumped every row into a fixed viewport with no keep-cursor-visible logic (you couldn't reach most of them), and rows showed no time.

- **Windowed list**: render only a window of rows around the cursor (kept roughly centered, derived statelessly from `jobCursor`) with muted `↑ N earlier` / `↓ N more` markers, so the selected row is always on-screen however long the list. Matches the codebase's windowed-list precedent (`maxEvents` in the detail view).
- **Datetime column**: a compact `MM-DD HH:MM` via a new `formatJobTime` helper (parses the SQLite ISO timestamp; rune-safe fallback for anything unparseable), appended to each row and used in the detail's `updated` row.
- **Newest-first**: `jobRows` is sorted by `updated_at` desc (tie-break id) when building the snapshot.

## Byte-stability

`jobRows` is unexported and consumed only by `toTUISnapshot`; the `--json`/`--plain` jobs output is the `{total, by_state}` aggregate, unaffected by the reorder. No json-tagged struct changes.

## Tests

`internal/cli/tui`: `formatJobTime` parses the ISO layouts and falls back safely; a row shows the formatted time; a 100-job list renders only a window with the right markers and keeps the selected last job visible after scrolling to it. Full `go test ./...` green except the known daemon flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)