### PR TITLE
cli: provision a usable generation repo when creating one for train

### DIFF
--- a/internal/cli/skillopt_repocreate_test.go
+++ b/internal/cli/skillopt_repocreate_test.go
@@ -3,19 +3,26 @@ package cli
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
 )
 
 // repoCreateFakeGitHub reports configured repos as missing and records creates.
+// CloneRepository lays down a real local git checkout (origin + an initial commit
+// on a branch) so repoRecordForCheckout validates the provisioned repo.
 type repoCreateFakeGitHub struct {
 	github.NoopClient
 	existing map[string]bool
 	created  []string
+	cloned   []string
 	existErr error
 }
 
@@ -33,6 +40,27 @@ func (f *repoCreateFakeGitHub) CreateRepository(_ context.Context, repo github.R
 	}
 	f.existing[repo.FullName()] = true
 	return nil
+}
+
+func (f *repoCreateFakeGitHub) CloneRepository(_ context.Context, repo github.Repository, dir string) error {
+	f.cloned = append(f.cloned, repo.FullName()+" -> "+dir)
+	run := func(args ...string) error {
+		cmd := exec.Command("git", args...)
+		cmd.Env = append(cmd.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git %s: %v: %s", strings.Join(args, " "), err, out)
+		}
+		return nil
+	}
+	if err := run("init", "-b", "main", dir); err != nil {
+		return err
+	}
+	if err := run("-C", dir, "remote", "add", "origin", "https://github.com/"+repo.FullName()+".git"); err != nil {
+		return err
+	}
+	return run("-C", dir, "commit", "--allow-empty", "-m", "init")
 }
 
 func replaceSkillOptGitHubClient(client github.Client) func() {
@@ -116,11 +144,75 @@ func TestSkillOptTrainRepoCheckerAndCreator(t *testing.T) {
 		t.Fatal("unparseable repo should error")
 	}
 
-	create := skillOptTrainRepoCreator()
+	home := t.TempDir()
+	if err := config.Initialize(config.PathsForHome(home)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	create := skillOptTrainRepoCreator(home)
 	if err := create("o/new"); err != nil {
 		t.Fatalf("create: %v", err)
 	}
 	if len(fake.created) != 1 || fake.created[0] != "o/new" {
 		t.Fatalf("created = %v", fake.created)
+	}
+}
+
+func TestProvisionTrainGenerationRepo(t *testing.T) {
+	home := t.TempDir()
+	if err := config.Initialize(config.PathsForHome(home)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	fake := &repoCreateFakeGitHub{}
+	restore := replaceSkillOptGitHubClient(fake)
+	defer restore()
+
+	repo, err := daemon.ParseRepository("o/fresh")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := provisionTrainGenerationRepo(context.Background(), home, repo); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	if len(fake.created) != 1 || len(fake.cloned) != 1 {
+		t.Fatalf("expected one create + one clone, got created=%v cloned=%v", fake.created, fake.cloned)
+	}
+
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	// Registered with a checkout under the gitmoot-managed checkouts dir.
+	got, err := store.GetRepo(ctx, "o/fresh")
+	if err != nil {
+		t.Fatalf("get repo: %v", err)
+	}
+	wantPrefix := filepath.Join(config.PathsForHome(home).Home, "checkouts", "o", "fresh")
+	if got.CheckoutPath != wantPrefix {
+		t.Fatalf("checkout path = %q, want %q", got.CheckoutPath, wantPrefix)
+	}
+	// Recorded for cleanup.
+	records, err := store.ListCreatedReposForSession(ctx, "")
+	if err != nil {
+		t.Fatalf("list created: %v", err)
+	}
+	found := false
+	for _, r := range records {
+		if r.Repo == "o/fresh" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("o/fresh should be recorded as created: %+v", records)
+	}
+
+	// Idempotent: a second provision reuses the existing checkout (no second clone).
+	if err := provisionTrainGenerationRepo(ctx, home, repo); err != nil {
+		t.Fatalf("re-provision: %v", err)
+	}
+	if len(fake.cloned) != 1 {
+		t.Fatalf("re-provision should not clone again: %v", fake.cloned)
 	}
 }

--- a/internal/cli/skillopt_tui.go
+++ b/internal/cli/skillopt_tui.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,8 +15,10 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/jerryfane/gitmoot/internal/cli/tui"
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
 )
 
@@ -39,7 +42,7 @@ var runSkillOptTrainInitTUI = runSkillOptTrainInitTUIImpl
 
 func runSkillOptTrainInitTUIImpl(home, scope string, stdout io.Writer, values *skillOptTrainInitInputs, missing []string) error {
 	return withStore(home, func(store *db.Store) error {
-		fields, err := buildSkillOptTrainInitTUIFields(store, scope, *values, missing)
+		fields, err := buildSkillOptTrainInitTUIFields(store, home, scope, *values, missing)
 		if err != nil {
 			return err
 		}
@@ -71,7 +74,7 @@ func runSkillOptTrainInitTUIImpl(home, scope string, stdout io.Writer, values *s
 
 // buildSkillOptTrainInitTUIFields builds the form fields for the missing inputs,
 // in the same stable order as the line wizard.
-func buildSkillOptTrainInitTUIFields(store *db.Store, scope string, values skillOptTrainInitInputs, missing []string) ([]tui.Field, error) {
+func buildSkillOptTrainInitTUIFields(store *db.Store, home, scope string, values skillOptTrainInitInputs, missing []string) ([]tui.Field, error) {
 	missingSet := make(map[string]struct{}, len(missing))
 	for _, field := range missing {
 		missingSet[field] = struct{}{}
@@ -108,7 +111,7 @@ func buildSkillOptTrainInitTUIFields(store *db.Store, scope string, values skill
 		case field == "review_repo":
 			entry.Kind = tui.FieldText
 			entry.CheckRepo = skillOptTrainRepoChecker()
-			entry.CreateRepo = skillOptTrainRepoCreator()
+			entry.CreateRepo = skillOptTrainRepoCreator(home)
 			if choices := skillOptRepoPickerChoices(skillOptKnownRepoNames(context.Background(), store)); len(choices) > 0 {
 				entry.Kind = tui.FieldChoice
 				entry.Choices = choices
@@ -138,14 +141,63 @@ func skillOptTrainRepoChecker() func(string) (bool, error) {
 	}
 }
 
-func skillOptTrainRepoCreator() func(string) error {
+// skillOptTrainRepoCreator returns a form CreateRepo callback that provisions a
+// missing repo into a *usable* generation repo (created with an initial commit,
+// cloned to a gitmoot-managed checkout, and registered) so train generate can
+// run in it. home is the gitmoot home the checkout and store live under.
+func skillOptTrainRepoCreator(home string) func(string) error {
 	return func(value string) error {
 		repo, err := daemon.ParseRepository(value)
 		if err != nil {
 			return err
 		}
-		return newSkillOptGitHubClient().CreateRepository(context.Background(), repo, true)
+		return provisionTrainGenerationRepo(context.Background(), home, repo)
 	}
+}
+
+// provisionTrainGenerationRepo creates a missing generation repo with an initial
+// commit (so it has a default branch), clones it into a gitmoot-managed checkout
+// under <home>/checkouts/<owner>/<name>, registers that checkout, and records the
+// repo for later cleanup. It is idempotent: a pre-existing valid checkout of the
+// same repo is reused rather than re-cloned.
+func provisionTrainGenerationRepo(ctx context.Context, home string, repo github.Repository) error {
+	client := newSkillOptGitHubClient()
+	if err := client.CreateRepository(ctx, repo, true); err != nil {
+		return err
+	}
+	checkout := filepath.Join(config.PathsForHome(home).Home, "checkouts", repo.Owner, repo.Name)
+	if err := os.MkdirAll(filepath.Dir(checkout), 0o755); err != nil {
+		return err
+	}
+	switch _, statErr := os.Stat(checkout); {
+	case statErr == nil:
+		// A checkout dir already exists (e.g. a prior attempt) — reuse it only if
+		// it is genuinely this repo's checkout; otherwise refuse rather than clone
+		// into a non-empty/foreign directory.
+		if _, err := repoRecordFromPath(ctx, repo, checkout); err != nil {
+			return fmt.Errorf("checkout path %s already exists but is not a checkout of %s: %w", checkout, repo.FullName(), err)
+		}
+	case errors.Is(statErr, os.ErrNotExist):
+		if err := client.CloneRepository(ctx, repo, checkout); err != nil {
+			// Remove any partial clone so a retry isn't blocked by a stale dir; the
+			// repo now exists on GitHub, so recovery is `gitmoot repo add` (or a
+			// later train continue once the checkout is registered).
+			_ = os.RemoveAll(checkout)
+			return fmt.Errorf("created %s but cloning it to %s failed (register a checkout with `gitmoot repo add %s --path <dir>`): %w", repo.FullName(), checkout, repo.FullName(), err)
+		}
+	default:
+		return statErr
+	}
+	record, err := repoRecordFromPath(ctx, repo, checkout)
+	if err != nil {
+		return err
+	}
+	return withStore(home, func(store *db.Store) error {
+		if err := store.UpsertRepo(ctx, record); err != nil {
+			return err
+		}
+		return store.RecordCreatedRepo(ctx, db.CreatedRepo{Repo: repo.FullName(), Purpose: "train"})
+	})
 }
 
 // skillOptTrainInitTUISummaryRows renders the confirm-screen rows: each field's
@@ -329,7 +381,7 @@ func buildAgentOptimizeFields(home string, repoChoices []tui.Choice) []tui.Field
 	workspace := custom("workspace_repo", "Workspace repo", "Workspace repository in owner/repo form? (options are generated there)", nil, "", true)
 	for _, field := range []*tui.Field{&review, &workspace} {
 		field.CheckRepo = skillOptTrainRepoChecker()
-		field.CreateRepo = skillOptTrainRepoCreatorRecording(home)
+		field.CreateRepo = skillOptTrainRepoCreator(home)
 		if len(repoChoices) > 0 {
 			field.Kind = tui.FieldChoice
 			field.Choices = repoChoices
@@ -345,24 +397,6 @@ func buildAgentOptimizeFields(home string, repoChoices []tui.Choice) []tui.Field
 		standard("request"),
 		custom("backend", "Optimizer backend", "Backend for the optimizer and target runs?", []string{"codex", "claude"}, "codex", true),
 		custom("model", "Model (optional)", "Model override for the optimizer and target runs? (empty = backend default)", nil, "", false),
-	}
-}
-
-// skillOptTrainRepoCreatorRecording creates a missing repo AND records it as
-// gitmoot-created with an empty session id; startAgentOptimizeSession adopts
-// the record into the new session so the delete-time cleanup offer covers it.
-func skillOptTrainRepoCreatorRecording(home string) func(string) error {
-	return func(value string) error {
-		repo, err := daemon.ParseRepository(value)
-		if err != nil {
-			return err
-		}
-		if err := newSkillOptGitHubClient().CreateRepository(context.Background(), repo, true); err != nil {
-			return err
-		}
-		return withStore(home, func(store *db.Store) error {
-			return store.RecordCreatedRepo(context.Background(), db.CreatedRepo{Repo: repo.FullName(), Purpose: "train"})
-		})
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1964,6 +1964,10 @@ func (f *fakeGitHub) CreateRepository(context.Context, github.Repository, bool) 
 	return nil
 }
 
+func (f *fakeGitHub) CloneRepository(context.Context, github.Repository, string) error {
+	return nil
+}
+
 func (f *fakeGitHub) ListUserRepositories(context.Context, int) ([]github.RepoSummary, error) {
 	return nil, nil
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -22,6 +22,7 @@ type Client interface {
 	Preflight(ctx context.Context, repo Repository) error
 	RepositoryExists(ctx context.Context, repo Repository) (bool, error)
 	CreateRepository(ctx context.Context, repo Repository, private bool) error
+	CloneRepository(ctx context.Context, repo Repository, dir string) error
 	DeleteRepository(ctx context.Context, repo Repository) error
 	ListUserRepositories(ctx context.Context, limit int) ([]RepoSummary, error)
 	ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error)
@@ -385,7 +386,23 @@ func (c *GhClient) CreateRepository(ctx context.Context, repo Repository, privat
 	if private {
 		visibility = "--private"
 	}
-	_, err := c.run(ctx, true, "repo", "create", repo.FullName(), visibility)
+	// --add-readme gives the new repo an initial commit and a default branch, so
+	// it is immediately clonable into a usable checkout (gitmoot only creates
+	// repos for its own workflows, where an empty repo is never useful).
+	_, err := c.run(ctx, true, "repo", "create", repo.FullName(), visibility, "--add-readme")
+	return err
+}
+
+// CloneRepository clones repo into dir via `gh repo clone`. dir must not already
+// exist (gh refuses to clone into a non-empty target).
+func (c *GhClient) CloneRepository(ctx context.Context, repo Repository, dir string) error {
+	if strings.TrimSpace(repo.FullName()) == "" {
+		return fmt.Errorf("repository owner/name is required")
+	}
+	if strings.TrimSpace(dir) == "" {
+		return fmt.Errorf("clone destination is required")
+	}
+	_, err := c.run(ctx, false, "repo", "clone", repo.FullName(), dir)
 	return err
 }
 
@@ -950,6 +967,10 @@ func (NoopClient) RepositoryExists(context.Context, Repository) (bool, error) {
 }
 
 func (NoopClient) CreateRepository(context.Context, Repository, bool) error {
+	return nil
+}
+
+func (NoopClient) CloneRepository(context.Context, Repository, string) error {
 	return nil
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -80,7 +80,7 @@ func TestCreateRepository(t *testing.T) {
 		if err := client.CreateRepository(context.Background(), repo, true); err != nil {
 			t.Fatalf("CreateRepository: %v", err)
 		}
-		runner.wantArgs(t, 0, "repo", "create", "o/r", "--private")
+		runner.wantArgs(t, 0, "repo", "create", "o/r", "--private", "--add-readme")
 	})
 
 	t.Run("public", func(t *testing.T) {
@@ -89,7 +89,7 @@ func TestCreateRepository(t *testing.T) {
 		if err := client.CreateRepository(context.Background(), repo, false); err != nil {
 			t.Fatalf("CreateRepository: %v", err)
 		}
-		runner.wantArgs(t, 0, "repo", "create", "o/r", "--public")
+		runner.wantArgs(t, 0, "repo", "create", "o/r", "--public", "--add-readme")
 	})
 
 	t.Run("error propagates", func(t *testing.T) {
@@ -100,6 +100,26 @@ func TestCreateRepository(t *testing.T) {
 		client := GhClient{Runner: runner}
 		if err := client.CreateRepository(context.Background(), repo, true); err == nil {
 			t.Fatal("expected error to propagate")
+		}
+	})
+}
+
+func TestCloneRepository(t *testing.T) {
+	repo := Repository{Owner: "o", Name: "r"}
+
+	t.Run("clones to dir", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{}}}
+		client := GhClient{Runner: runner}
+		if err := client.CloneRepository(context.Background(), repo, "/tmp/o-r"); err != nil {
+			t.Fatalf("CloneRepository: %v", err)
+		}
+		runner.wantArgs(t, 0, "repo", "clone", "o/r", "/tmp/o-r")
+	})
+
+	t.Run("requires a destination", func(t *testing.T) {
+		client := GhClient{Runner: &fakeRunner{results: []subprocess.Result{{}}}}
+		if err := client.CloneRepository(context.Background(), repo, ""); err == nil {
+			t.Fatal("expected an error for an empty destination")
 		}
 	})
 }


### PR DESCRIPTION
## What

Fixes a train/optimize stall: creating a repo via the "another repo…" path made an **empty** GitHub repo and only recorded it, so the later generate step aborted every retry with *"generation repo … is not registered with a checkout path"* and the run sat at `items_ready` (the dashboard kept showing "started in the background").

The create callback now **provisions a usable generation repo**:
1. Create it with an initial commit — `gh repo create --add-readme` (gives it a default branch so it's clonable).
2. Clone it into a gitmoot-managed checkout: `<home>/checkouts/<owner>/<name>`.
3. Register that checkout (`repoRecordFromPath` + `store.UpsertRepo`) and record it for cleanup.

Idempotent: a valid existing checkout of the same repo is reused (no re-clone); a failed clone removes the partial dir and returns an actionable error (`gitmoot repo add …`).

Adds `github.Client.CloneRepository` (`gh repo clone`), implemented on `GhClient`/`NoopClient`/the daemon test fake. Threads the gitmoot `home` into `buildSkillOptTrainInitTUIFields` so **both** the optimize form and the train-init wizard provision the same way (the two create callbacks are unified into `skillOptTrainRepoCreator(home)`).

## Notes / follow-up

- Partial-failure recovery (create succeeds, clone fails) currently needs a manual `gitmoot repo add` or the deferred **generate self-heal** (auto-clone a registered-but-missing checkout in `ensureSkillOptTrainGenerationRepoReady`). That self-heal would also rescue repos created before this change — filed mentally as the natural next step if desired.

## Tests

`internal/github`: `CreateRepository` includes `--add-readme`; `CloneRepository` runs `gh repo clone <full> <dir>` and rejects an empty destination. `internal/cli`: `provisionTrainGenerationRepo` creates + clones (fake lays down a real local git checkout) + registers the managed checkout + records it, and is idempotent on a second run. Full `go test ./...` green except the known daemon flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)