### PR TITLE
cli: surface a failed generate/continue in the train-run view

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1721,6 +1721,7 @@ type skillOptTrainStatusVerbose struct {
 	ReviewIssue           skillOptTrainStatusReviewIssue `json:"review_issue,omitempty"`
 	Candidate             skillOptTrainStatusCandidate   `json:"candidate,omitempty"`
 	Optimizer             map[string]any                 `json:"optimizer,omitempty"`
+	Generation            map[string]any                 `json:"generation,omitempty"`
 	Jobs                  skillOptTrainStatusJobs        `json:"jobs"`
 	ActiveLocks           []skillOptTrainStatusLock      `json:"active_locks,omitempty"`
 	Items                 []skillOptTrainStatusItem      `json:"items,omitempty"`
@@ -6972,6 +6973,11 @@ func buildSkillOptTrainStatusVerbose(ctx context.Context, store *db.Store, sessi
 	addStatus("candidate_decision", decodedSkillOptMetadataValue(statusMetadata["candidate_decision"]))
 	if len(statuses) > 0 {
 		details.MetadataStatus = statuses
+	}
+	// Carry the full generation metadata (status + error) so a failed background
+	// generate can be surfaced in the train-run view rather than silently stalling.
+	if generation := decodedSkillOptMetadataValue(statusMetadata["generation"]); len(generation) > 0 {
+		details.Generation = generation
 	}
 	if iteration == nil {
 		return details, nil

--- a/internal/cli/skillopt_trainrun_tui.go
+++ b/internal/cli/skillopt_trainrun_tui.go
@@ -464,6 +464,11 @@ func toTrainRunSnapshot(s skillOptTrainStatusSnapshot) tui.TrainRunSnapshot {
 		out.OptimizerBackend = metadataString(s.Verbose.Optimizer, "run_optimizer_backend")
 		out.OptimizerModel = metadataString(s.Verbose.Optimizer, "run_optimizer_model")
 		out.OptimizerAttempt = metadataString(s.Verbose.Optimizer, "optimizer_attempt")
+		// Surface only a *failed* generation; a succeeded/retried attempt overwrites
+		// the metadata, so this clears itself once generate advances.
+		if metadataString(s.Verbose.Generation, "status") == "failed" {
+			out.GenerationError = strings.TrimSpace(metadataString(s.Verbose.Generation, "error"))
+		}
 	}
 	return out
 }

--- a/internal/cli/skillopt_trainrun_tui_test.go
+++ b/internal/cli/skillopt_trainrun_tui_test.go
@@ -310,3 +310,23 @@ func TestToTrainRunSnapshot(t *testing.T) {
 		t.Fatalf("verbose mapping wrong: %+v", out)
 	}
 }
+
+func TestToTrainRunSnapshotMapsGenerationError(t *testing.T) {
+	// A failed generation surfaces its error.
+	failed := skillOptTrainStatusSnapshot{
+		SessionID:   "s1",
+		StatusPhase: "items_ready",
+		Verbose: &skillOptTrainStatusVerbose{
+			Generation: map[string]any{"status": "failed", "error": "generation repo o/r is not registered with a checkout path"},
+		},
+	}
+	if out := toTrainRunSnapshot(failed); out.GenerationError != "generation repo o/r is not registered with a checkout path" {
+		t.Fatalf("generation error not mapped: %q", out.GenerationError)
+	}
+	// A succeeded/absent generation status carries no error.
+	ok := failed
+	ok.Verbose = &skillOptTrainStatusVerbose{Generation: map[string]any{"status": "succeeded", "error": "stale"}}
+	if out := toTrainRunSnapshot(ok); out.GenerationError != "" {
+		t.Fatalf("a non-failed generation must not surface an error: %q", out.GenerationError)
+	}
+}

--- a/internal/cli/tui/trainrun.go
+++ b/internal/cli/tui/trainrun.go
@@ -25,6 +25,7 @@ type TrainRunSnapshot struct {
 	CandidateVersion   string
 	CandidateReviewURL string // GitHub comment/issue where the promote/reject decision can also be made
 	NoCandidateReason  string
+	GenerationError    string // non-empty when the last generate attempt failed (surface + offer retry)
 	FeedbackCount      int
 	ReviewItems        int
 	GeneratedOptions   int
@@ -299,6 +300,11 @@ func (m TrainRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.loadErr = ""
 			m.snap = msg.snap
 			m.loadedAt = msg.at
+			// A surfaced generation failure overrides the optimistic "started in
+			// the background" note — the background step did not succeed.
+			if strings.TrimSpace(msg.snap.GenerationError) != "" {
+				m.resultLines = nil
+			}
 			if long := isLongTrainPhase(msg.snap.Phase); long && !m.spinning {
 				m.spinning = true
 				cmds = append(cmds, m.spin.Tick)

--- a/internal/cli/tui/trainrun_test.go
+++ b/internal/cli/tui/trainrun_test.go
@@ -79,6 +79,47 @@ func TestTrainRunGeneratingShowsJobCounts(t *testing.T) {
 	}
 }
 
+func TestTrainRunSurfacesGenerationError(t *testing.T) {
+	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Template: "t@v1", Phase: "items_ready"})
+	// A spawn first reports the optimistic "started in the background" note…
+	next, _ := m.Update(trainSpawnMsg{logPath: "/tmp/x.log"})
+	m = next.(TrainRunModel)
+	if !strings.Contains(m.View(), "started in the background") {
+		t.Fatalf("expected the optimistic note first:\n%s", m.View())
+	}
+	// …then a refresh shows the generation failed: surface it, drop the note.
+	failed := TrainRunSnapshot{SessionID: "s", Template: "t@v1", Phase: "items_ready",
+		GenerationError: "generation repo o/r is not registered with a checkout path"}
+	next, _ = m.Update(trainSnapshotMsg{snap: failed, at: time.Unix(3, 0)})
+	m = next.(TrainRunModel)
+	view := m.View()
+	if !strings.Contains(view, "generation failed: generation repo o/r is not registered") {
+		t.Fatalf("expected the generation error surfaced:\n%s", view)
+	}
+	if !strings.Contains(view, "press enter to retry") {
+		t.Fatalf("expected a retry hint:\n%s", view)
+	}
+	if strings.Contains(view, "started in the background") {
+		t.Fatalf("the optimistic note should be cleared on a failure:\n%s", view)
+	}
+}
+
+func TestTrainRunNoGenerationErrorKeepsNote(t *testing.T) {
+	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Phase: "items_ready"})
+	next, _ := m.Update(trainSpawnMsg{logPath: "/tmp/x.log"})
+	m = next.(TrainRunModel)
+	// A clean refresh (no generation error) keeps the optimistic note.
+	next, _ = m.Update(trainSnapshotMsg{snap: TrainRunSnapshot{SessionID: "s", Phase: "items_ready"}, at: time.Unix(3, 0)})
+	m = next.(TrainRunModel)
+	view := m.View()
+	if strings.Contains(view, "generation failed") {
+		t.Fatalf("no error should render without a GenerationError:\n%s", view)
+	}
+	if !strings.Contains(view, "started in the background") {
+		t.Fatalf("the note should remain without a failure:\n%s", view)
+	}
+}
+
 func TestTrainRunLoadErrorKeepsStaleData(t *testing.T) {
 	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Template: "t@v1", Phase: "items_ready"})
 	next, _ := m.Update(trainSnapshotMsg{err: errors.New("db locked"), at: time.Unix(2, 0)})

--- a/internal/cli/tui/trainrun_view.go
+++ b/internal/cli/tui/trainrun_view.go
@@ -74,6 +74,10 @@ func (m TrainRunModel) View() string {
 	if m.actionErr != "" {
 		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
 	}
+	if ge := strings.TrimSpace(m.snap.GenerationError); ge != "" {
+		b.WriteString("\n" + errorStyle.Render("generation failed: "+ge) + "\n")
+		b.WriteString(mutedStyle.Render("press enter to retry once the cause is fixed") + "\n")
+	}
 	for _, line := range m.resultLines {
 		b.WriteString(mutedStyle.Render(line) + "\n")
 	}


### PR DESCRIPTION
## What

Companion to #278. When a backgrounded generate/continue step fails (e.g. the generation repo isn't registered with a checkout), the error was persisted to session metadata + the log file, but the train-run view kept showing the optimistic *"started in the background — watch the phase above"* — so the run looked stuck at `items_ready` with no visible reason. (This is exactly what the user hit.)

Now:
- `buildSkillOptTrainStatusVerbose` carries the full generation metadata (`status` + `error`) into the verbose status snapshot.
- `toTrainRunSnapshot` maps a **failed** generation onto a new `TrainRunSnapshot.GenerationError` (TUI-only field).
- The view renders `generation failed: <err>` (red) + "press enter to retry once the cause is fixed", and the stale "started in the background" note is cleared once the failure is observed.
- It self-clears: a successful retry overwrites the generation status away from `failed`, so the error disappears.

## Byte-stability

The new `generation` field lives only on the `verbose` status struct (affects `skillopt train status --verbose --json`, a debug surface). The dashboard `--json`/`--plain` and the non-verbose `train status --json` are unchanged; `TrainRunSnapshot.GenerationError` is not serialized.

## Tests

`internal/cli`: a failed generation maps to `GenerationError`; a succeeded/absent status maps to empty. `internal/cli/tui`: a failed-generation snapshot renders the error + retry hint and drops the "started in the background" note; a clean snapshot keeps the note. Full `go test ./...` green except the known daemon flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)