### PR TITLE
cli/runtime: fix generation-repo checkout path and surface real codex errors

### DIFF
--- a/internal/cli/skillopt_repocreate_test.go
+++ b/internal/cli/skillopt_repocreate_test.go
@@ -157,6 +157,41 @@ func TestSkillOptTrainRepoCheckerAndCreator(t *testing.T) {
 	}
 }
 
+func TestTrainGenerationCheckoutPath(t *testing.T) {
+	repo, err := daemon.ParseRepository("o/fresh")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// A non-empty home resolves under <home>/.gitmoot/checkouts/...
+	home := t.TempDir()
+	got, err := trainGenerationCheckoutPath(home, repo)
+	if err != nil {
+		t.Fatalf("explicit home: %v", err)
+	}
+	want := filepath.Join(config.PathsForHome(home).Home, "checkouts", "o", "fresh")
+	if got != want {
+		t.Fatalf("explicit-home path = %q, want %q", got, want)
+	}
+
+	// The default home (empty) must resolve to an ABSOLUTE path under the real
+	// gitmoot home — never a cwd-relative ".gitmoot/..." (the #278 regression).
+	def, err := trainGenerationCheckoutPath("", repo)
+	if err != nil {
+		t.Fatalf("default home: %v", err)
+	}
+	if !filepath.IsAbs(def) {
+		t.Fatalf("default-home checkout must be absolute, got %q", def)
+	}
+	defaults, err := config.DefaultPaths()
+	if err != nil {
+		t.Fatalf("DefaultPaths: %v", err)
+	}
+	if def != filepath.Join(defaults.Home, "checkouts", "o", "fresh") {
+		t.Fatalf("default-home path = %q, want under %q", def, defaults.Home)
+	}
+}
+
 func TestProvisionTrainGenerationRepo(t *testing.T) {
 	home := t.TempDir()
 	if err := config.Initialize(config.PathsForHome(home)); err != nil {

--- a/internal/cli/skillopt_tui.go
+++ b/internal/cli/skillopt_tui.go
@@ -15,7 +15,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/jerryfane/gitmoot/internal/cli/tui"
-	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
@@ -155,6 +154,19 @@ func skillOptTrainRepoCreator(home string) func(string) error {
 	}
 }
 
+// trainGenerationCheckoutPath is the gitmoot-managed checkout location for a
+// generation repo: <home>/checkouts/<owner>/<name>. It resolves the home the
+// same way the store does (pathsFromFlag → DefaultPaths when home is empty), so
+// the default-home case lands under the real ~/.gitmoot rather than a
+// cwd-relative ".gitmoot".
+func trainGenerationCheckoutPath(home string, repo github.Repository) (string, error) {
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(paths.Home, "checkouts", repo.Owner, repo.Name), nil
+}
+
 // provisionTrainGenerationRepo creates a missing generation repo with an initial
 // commit (so it has a default branch), clones it into a gitmoot-managed checkout
 // under <home>/checkouts/<owner>/<name>, registers that checkout, and records the
@@ -165,7 +177,10 @@ func provisionTrainGenerationRepo(ctx context.Context, home string, repo github.
 	if err := client.CreateRepository(ctx, repo, true); err != nil {
 		return err
 	}
-	checkout := filepath.Join(config.PathsForHome(home).Home, "checkouts", repo.Owner, repo.Name)
+	checkout, err := trainGenerationCheckoutPath(home, repo)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(checkout), 0o755); err != nil {
 		return err
 	}

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -195,7 +195,7 @@ func (a CodexAdapter) Start(ctx context.Context, request StartRequest) (StartRes
 	args = append(args, "--json", "--", request.Prompt)
 	result, err := a.runner().Run(ctx, a.Dir, "codex", args...)
 	if err != nil {
-		return StartResult{Raw: result.Stdout + result.Stderr}, commandError(result, err)
+		return StartResult{Raw: result.Stdout + result.Stderr}, codexCommandError(result, err)
 	}
 	threadID, err := parseCodexStartedThreadID(result.Stdout)
 	if err != nil {
@@ -225,7 +225,7 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 	args = append(args, "--", job.Prompt)
 	result, err := a.runner().Run(ctx, a.Dir, "codex", args...)
 	if err != nil {
-		return Result{Raw: result.Stdout + result.Stderr}, commandError(result, err)
+		return Result{Raw: result.Stdout + result.Stderr}, codexCommandError(result, err)
 	}
 	return Result{Raw: result.Stdout}, nil
 }
@@ -427,6 +427,54 @@ func commandError(result subprocess.Result, err error) error {
 		return err
 	}
 	return fmt.Errorf("%s: %w", detail, err)
+}
+
+// codexCommandError prefers the real failure message from codex's --json events
+// (on stdout) over the stderr-first commandError, which otherwise surfaces
+// codex's harmless "Reading additional input from stdin..." line instead of the
+// actual cause (usage limit, auth, etc.). Falls back to commandError when stdout
+// carries no parseable error event (e.g. the non-json Deliver path).
+func codexCommandError(result subprocess.Result, err error) error {
+	if detail := parseCodexErrorMessage(result.Stdout); detail != "" {
+		return fmt.Errorf("%s: %w", detail, err)
+	}
+	return commandError(result, err)
+}
+
+// parseCodexErrorMessage scans codex --json JSONL for the failure message in an
+// "error" ({"message":...}) or "turn.failed" ({"error":{"message":...}}) event,
+// returning the last non-empty one (turn.failed usually follows the error event).
+func parseCodexErrorMessage(output string) string {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	message := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var event struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+			Error   struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if json.Unmarshal([]byte(line), &event) != nil {
+			continue
+		}
+		switch event.Type {
+		case "error":
+			if m := strings.TrimSpace(event.Message); m != "" {
+				message = m
+			}
+		case "turn.failed":
+			if m := strings.TrimSpace(event.Error.Message); m != "" {
+				message = m
+			}
+		}
+	}
+	return message
 }
 
 func claudeCommandError(result subprocess.Result, err error) error {

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -625,3 +625,39 @@ func (f *fakeRunner) want(t *testing.T, index int, want ...string) {
 		t.Fatalf("call %d = %s\nwant %s", index, strings.Join(f.calls[index], " "), strings.Join(want, " "))
 	}
 }
+
+func TestCodexCommandError(t *testing.T) {
+	runErr := errors.New("exit status 1")
+
+	t.Run("surfaces the --json error event over stderr noise", func(t *testing.T) {
+		result := subprocess.Result{
+			Stderr: "Reading additional input from stdin...",
+			Stdout: `{"type":"thread.started","thread_id":"t1"}` + "\n" +
+				`{"type":"turn.started"}` + "\n" +
+				`{"type":"error","message":"You've hit your usage limit. try again at Jun 14th"}` + "\n",
+		}
+		got := codexCommandError(result, runErr).Error()
+		if !strings.Contains(got, "You've hit your usage limit") {
+			t.Fatalf("want the usage-limit message, got %q", got)
+		}
+		if strings.Contains(got, "Reading additional input from stdin") {
+			t.Fatalf("must not surface the stdin noise line, got %q", got)
+		}
+	})
+
+	t.Run("uses a turn.failed error.message", func(t *testing.T) {
+		result := subprocess.Result{
+			Stdout: `{"type":"turn.failed","error":{"message":"sandbox denied write"}}` + "\n",
+		}
+		if got := codexCommandError(result, runErr).Error(); !strings.Contains(got, "sandbox denied write") {
+			t.Fatalf("want the turn.failed message, got %q", got)
+		}
+	})
+
+	t.Run("falls back to stderr when stdout has no json error", func(t *testing.T) {
+		result := subprocess.Result{Stderr: "boom on stderr", Stdout: "plain non-json output"}
+		if got := codexCommandError(result, runErr).Error(); !strings.Contains(got, "boom on stderr") {
+			t.Fatalf("want the stderr fallback, got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
## What

Two bugs found while debugging a stalled train run (the run's actual failure — codex hitting its usage limit — is not a gitmoot bug).

### A. Generation-repo checkout resolves the default home (regression from #278)
`provisionTrainGenerationRepo` computed the managed checkout with `config.PathsForHome(home)`. With the dashboard's default `home == ""`, `PathsForHome("").Home` is the **relative** `.gitmoot`, which got absolutized against the cwd — so the clone landed in `<cwd>/.gitmoot/checkouts/...` (inside the source repo) instead of `~/.gitmoot/checkouts/...`.

Fix: resolve the home the way `withStore` does, via a new testable `trainGenerationCheckoutPath` helper (`pathsFromFlag(home)` → `DefaultPaths()` when empty). Dropped the now-unused `config` import.

### B. Surface the real codex error
`commandError` is stderr-first, so a failed codex job showed codex's harmless leading line *"Reading additional input from stdin…: exit status 1"* instead of the real cause, which codex emits as a `--json` event on **stdout** (e.g. *"You've hit your usage limit…"*).

Fix: `parseCodexErrorMessage` scans the JSONL for an `error`/`turn.failed` message; `codexCommandError` prefers it and falls back to `commandError`. Used in `CodexAdapter.Start` (the `--json` path) and `Deliver` (falls back — no `--json`, left as-is to avoid reshaping result parsing). This makes the real reason legible everywhere the error bubbles up — job events and the train-run view (#279).

## Tests

`internal/cli`: `trainGenerationCheckoutPath("")` returns an **absolute** path under `DefaultPaths().Home` (not cwd-relative); a non-empty home resolves under `PathsForHome(home)`. `internal/runtime`: a `--json` stdout with a usage-limit `error` event surfaces that message (not the stdin line); a `turn.failed` `error.message` is surfaced; no-JSON falls back to stderr. Full `go test ./...` green except the known daemon flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)