### PR TITLE
cli: default the codex optimizer model to the codex CLI's model

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -8779,6 +8779,23 @@ func buildSkillOptTrainOptimizerCommand(iteration db.SkillOptTrainIteration, req
 			targetModel = model
 		}
 	}
+	// When a role runs on the codex backend with no model set, default to the
+	// model the codex CLI is configured with. gitmoot-skillopt would otherwise
+	// fall back to gpt-4o, which a ChatGPT-account codex login rejects.
+	optimizerBackend := firstNonEmpty(strings.TrimSpace(request.OptimizerBackend), strings.TrimSpace(request.Backend))
+	targetBackend := firstNonEmpty(strings.TrimSpace(request.TargetBackend), strings.TrimSpace(request.Backend))
+	wantOptimizerCodexModel := optimizerModel == "" && optimizerBackend == runtime.CodexRuntime
+	wantTargetCodexModel := targetModel == "" && targetBackend == runtime.CodexRuntime
+	if wantOptimizerCodexModel || wantTargetCodexModel {
+		if codexModel, _ := runtime.ConfiguredCodexModel(); codexModel != "" {
+			if wantOptimizerCodexModel {
+				optimizerModel = codexModel
+			}
+			if wantTargetCodexModel {
+				targetModel = codexModel
+			}
+		}
+	}
 	if optimizerModel != "" {
 		args = append(args, "--optimizer-model", optimizerModel)
 	}

--- a/internal/cli/skillopt_optimize_test.go
+++ b/internal/cli/skillopt_optimize_test.go
@@ -2,12 +2,56 @@ package cli
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 )
+
+func TestBuildOptimizerCommandDefaultsCodexModel(t *testing.T) {
+	prev := skillOptTrainOptimizerRunner
+	skillOptTrainOptimizerRunner = &skillOptTrainFakeOptimizerRunner{}
+	defer func() { skillOptTrainOptimizerRunner = prev }()
+
+	// A configured codex model the default should pick up.
+	codexHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte("model = \"gpt-5.5\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", codexHome)
+
+	build := func(req skillOptTrainOptimizerRequest) []string {
+		req.SkillOptBin = "gitmoot-skillopt"
+		_, args, err := buildSkillOptTrainOptimizerCommand(db.SkillOptTrainIteration{}, req, skillOptTrainOptimizerPaths{})
+		if err != nil {
+			t.Fatalf("buildSkillOptTrainOptimizerCommand: %v", err)
+		}
+		return args
+	}
+
+	// codex backend, empty model → optimizer model defaults to the codex model.
+	// (Target resolves to codex_exec, which uses codex's model natively, so no
+	// --target-model is injected.)
+	args := build(skillOptTrainOptimizerRequest{Backend: "codex"})
+	if got := argValue(args, "--optimizer-model"); got != "gpt-5.5" {
+		t.Fatalf("codex+empty: --optimizer-model = %q, want gpt-5.5 (args=%v)", got, args)
+	}
+
+	// An explicit model still wins.
+	args = build(skillOptTrainOptimizerRequest{Backend: "codex", Model: "o3"})
+	if got := argValue(args, "--optimizer-model"); got != "o3" {
+		t.Fatalf("explicit model overridden: --optimizer-model = %q, want o3", got)
+	}
+
+	// A non-codex backend gets no codex-derived default.
+	args = build(skillOptTrainOptimizerRequest{OptimizerBackend: "openai_chat"})
+	if got := argValue(args, "--optimizer-model"); got == "gpt-5.5" {
+		t.Fatalf("non-codex backend must not pick up the codex model: args=%v", args)
+	}
+}
 
 func TestBuildAgentOptimizeFieldsSkipsTemplate(t *testing.T) {
 	fields := buildAgentOptimizeFields("", nil)

--- a/internal/cli/skillopt_tui.go
+++ b/internal/cli/skillopt_tui.go
@@ -411,7 +411,7 @@ func buildAgentOptimizeFields(home string, repoChoices []tui.Choice) []tui.Field
 		standard("preview"),
 		standard("request"),
 		custom("backend", "Optimizer backend", "Backend for the optimizer and target runs?", []string{"codex", "claude"}, "codex", true),
-		custom("model", "Model (optional)", "Model override for the optimizer and target runs? (empty = backend default)", nil, "", false),
+		custom("model", "Model (optional)", "Model override for the optimizer and target runs? (empty = your codex model on the codex backend, else the backend default)", nil, "", false),
 	}
 }
 

--- a/internal/runtime/codex_config.go
+++ b/internal/runtime/codex_config.go
@@ -1,0 +1,55 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/creachadair/tomledit"
+)
+
+// ConfiguredCodexModel returns the model the codex CLI is configured to use: the
+// top-level `model` key in <codex-home>/config.toml, resolving the codex home the
+// same way the adapter does (CODEX_HOME, else ~/.codex). It returns "" with no
+// error when the config file or the key is absent, so callers treat an empty
+// result as "no override".
+func ConfiguredCodexModel() (string, error) {
+	path, err := codexConfigPath()
+	if err != nil || path == "" {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	doc, err := tomledit.Parse(strings.NewReader(string(data)))
+	if err != nil {
+		return "", err
+	}
+	entry := doc.First("model")
+	if entry == nil || entry.KeyValue == nil {
+		return "", nil
+	}
+	raw := strings.TrimSpace(entry.KeyValue.Value.String())
+	// The value is the TOML source form (e.g. `"gpt-5.5"`); unquote a basic
+	// string, falling back to trimming quotes for a literal string.
+	if unq, err := strconv.Unquote(raw); err == nil {
+		return strings.TrimSpace(unq), nil
+	}
+	return strings.TrimSpace(strings.Trim(raw, "\"'")), nil
+}
+
+func codexConfigPath() (string, error) {
+	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
+		return filepath.Join(home, "config.toml"), nil
+	}
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(userHome, ".codex", "config.toml"), nil
+}

--- a/internal/runtime/codex_config_test.go
+++ b/internal/runtime/codex_config_test.go
@@ -1,0 +1,45 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfiguredCodexModel(t *testing.T) {
+	t.Run("reads the top-level model key", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "config.toml"),
+			[]byte("model = \"gpt-5.5\"\nmodel_reasoning_effort = \"high\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("CODEX_HOME", dir)
+		got, err := ConfiguredCodexModel()
+		if err != nil {
+			t.Fatalf("ConfiguredCodexModel: %v", err)
+		}
+		if got != "gpt-5.5" {
+			t.Fatalf("model = %q, want gpt-5.5", got)
+		}
+	})
+
+	t.Run("empty when the file is missing", func(t *testing.T) {
+		t.Setenv("CODEX_HOME", t.TempDir()) // no config.toml inside
+		got, err := ConfiguredCodexModel()
+		if err != nil || got != "" {
+			t.Fatalf("missing config: got (%q, %v), want (\"\", nil)", got, err)
+		}
+	})
+
+	t.Run("empty when the model key is absent", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte("model_reasoning_effort = \"high\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("CODEX_HOME", dir)
+		got, err := ConfiguredCodexModel()
+		if err != nil || got != "" {
+			t.Fatalf("no model key: got (%q, %v), want (\"\", nil)", got, err)
+		}
+	})
+}


### PR DESCRIPTION
## What

When the optimize backend is codex and the model field is left empty, gitmoot passed **no** `--optimizer-model` flag, so the external `gitmoot-skillopt` fell back to a hardcoded `gpt-4o` (`codex_backend.py`). A **ChatGPT-account codex login rejects `gpt-4o`** (HTTP 400), blocking the optimizer at `blocked_config` — even though the codex CLI is configured with a working model (`~/.codex/config.toml` `model = "gpt-5.5"`).

Now:
- New `runtime.ConfiguredCodexModel()` reads the top-level `model` from `<codex-home>/config.toml` (honoring `CODEX_HOME`, else `~/.codex`) via the existing `creachadair/tomledit`. Returns `""` (no error) when the file/key is absent.
- In `buildSkillOptTrainOptimizerCommand`, when a role's resolved backend is `codex` and its model is empty, the model defaults to the codex CLI's configured model before `--optimizer-model`/`--target-model` are emitted. Explicit models and non-codex backends are untouched; the `codex_exec` target uses codex's model natively, so it's left alone.

Plus a small help-text tweak on the optimize form's model field.

## Tests

`internal/runtime`: `ConfiguredCodexModel` reads `model` from a temp `CODEX_HOME/config.toml`; empty when the file or key is missing. `internal/cli`: the optimizer command, with backend=codex + empty model + a configured codex model, emits `--optimizer-model gpt-5.5`; an explicit model still wins; a non-codex backend gets no codex-derived default. Full `go test ./...` green.

Note: the `gpt-4o` fallback lives in the external `gitmoot-skillopt`; this overrides it by passing the model explicitly rather than patching that tool. If codex has no configured `model`, behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)