### PR TITLE
feedback: lazy-first, self-documenting review reply template

### DIFF
--- a/internal/feedback/github.go
+++ b/internal/feedback/github.go
@@ -175,7 +175,8 @@ func (c GitHubCollector) rankedBody(ctx context.Context, store *db.Store, run db
 	}
 	builder.WriteString("- Compare each item across the option links or inline text below.\n")
 	builder.WriteString("- Rank every option from best to worst using the exact labels shown.\n")
-	builder.WriteString("- Reply by copying the fenced `yaml` block below into a new comment and filling every item.\n")
+	builder.WriteString("- Reply by copying the fenced `yaml` block below into a new comment.\n")
+	builder.WriteString("- If you only do one thing: rank each item's options best → worst (use `=` for ties). Everything else is optional.\n")
 	builder.WriteString("- Valid `quality` values: `poor`, `acceptable`, `strong`.\n")
 	builder.WriteString("- Valid `continue_mode` values: `explore`, `refine`, `distill`, `validate`.\n")
 	builder.WriteString("- Valid `promote` values: `yes`, `no`.\n\n")
@@ -345,28 +346,37 @@ func markdownTableCell(value string) string {
 	return value
 }
 
+// rankedReplyYAML builds the "Copy-Paste YAML Reply" the human posts back. It is
+// lazy-first and self-documenting: the only field you must set is `ranking` for
+// each item (winner + pairwise preferences are inferred from it); every other
+// field is an optional, commented-out hint showing its allowed values. The `#`
+// comments are ignored by the YAML parser, so the uncommented skeleton is a
+// complete, valid reply on its own.
 func rankedReplyYAML(runID string, items []db.EvalReviewItem, assignments map[string]githubAssignment) (string, error) {
-	type rankedReplyFile struct {
-		RunID string              `yaml:"run_id"`
-		Items []feedbackFileEntry `yaml:"items"`
-	}
-	packet := rankedReplyFile{RunID: runID}
+	var b strings.Builder
+	b.WriteString("# Minimum reply: set `ranking` for each item (best > worst; use = for ties).\n")
+	b.WriteString("# Everything else is optional — winner and pairwise preferences are inferred.\n")
+	fmt.Fprintf(&b, "run_id: %s\n", runID)
+	b.WriteString("items:\n")
 	for _, item := range items {
-		labels := displayOptionLabels(assignments[item.ItemID].Options)
-		packet.Items = append(packet.Items, feedbackFileEntry{
-			ItemID:       item.ItemID,
-			Ranking:      []string{fmt.Sprintf("<replace with ranked option labels, e.g. %s>", strings.Join(labels, " > "))},
-			Quality:      "",
-			ContinueMode: "",
-			Promote:      "",
-			Reasoning:    "",
-		})
+		example := strings.Join(displayOptionLabels(assignments[item.ItemID].Options), " > ")
+		if strings.TrimSpace(example) == "" {
+			example = "A > B > C"
+		}
+		fmt.Fprintf(&b, "  - item_id: %s\n", item.ItemID)
+		b.WriteString("    ranking:\n")
+		fmt.Fprintf(&b, "      - <rank best to worst, e.g. %s>\n", example)
+		b.WriteString("    # Optional — uncomment and fill any you care about:\n")
+		b.WriteString("    # quality: acceptable        # poor | acceptable | strong\n")
+		b.WriteString("    # continue_mode: refine      # explore | refine | distill | validate\n")
+		b.WriteString("    # promote: no                # yes | no\n")
+		b.WriteString("    # winner: A                  # defaults to the top-ranked option\n")
+		b.WriteString("    # required_improvements: [stronger hero copy, mobile layout]\n")
+		b.WriteString("    # useful_traits: { A: [clear value prop] }      # per-option strengths\n")
+		b.WriteString("    # rejected_traits: { B: [too generic] }         # per-option weaknesses\n")
+		b.WriteString("    # reasoning: why you ranked them this way\n")
 	}
-	content, err := yaml.Marshal(packet)
-	if err != nil {
-		return "", fmt.Errorf("encode ranked feedback reply: %w", err)
-	}
-	return string(content), nil
+	return b.String(), nil
 }
 
 func (c GitHubCollector) Sync(ctx context.Context, store *db.Store, runID string, repo github.Repository, issueNumber int64) (ImportResult, error) {

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -12,6 +12,65 @@ import (
 	"github.com/jerryfane/gitmoot/internal/github"
 )
 
+func TestRankedReplyYAMLRoundTrips(t *testing.T) {
+	items := []db.EvalReviewItem{{ItemID: "item-001"}}
+	assignments := map[string]githubAssignment{
+		"item-001": {blindAssignment: blindAssignment{ItemID: "item-001", Options: []blindOptionAssignment{
+			{Label: "a"}, {Label: "b"}, {Label: "c"},
+		}}},
+	}
+	tmpl, err := rankedReplyYAML("ranked-1", items, assignments)
+	if err != nil {
+		t.Fatalf("rankedReplyYAML: %v", err)
+	}
+	// The example ranking shows this item's actual labels.
+	if !strings.Contains(tmpl, "A > B > C") {
+		t.Fatalf("template missing the item's label example:\n%s", tmpl)
+	}
+
+	// A reviewer who only ranks (ties included) produces a complete, valid reply —
+	// the commented optional fields are ignored.
+	reply := strings.Replace(tmpl, "<rank best to worst, e.g. A > B > C>", "A > B = C", 1)
+	parsed, ok, err := ParseGitHubFeedbackComment("```yaml\n" + reply + "```\n")
+	if err != nil {
+		t.Fatalf("parse ranking-only reply: %v", err)
+	}
+	if !ok {
+		t.Fatalf("ranking-only reply should be accepted:\n%s", reply)
+	}
+	if parsed.RunID != "ranked-1" || len(parsed.Items) != 1 {
+		t.Fatalf("parsed = %+v", parsed)
+	}
+	entry := parsed.Items[0]
+	if entry.ItemID != "item-001" || strings.Join(entry.Ranking, ",") != "A,B,C" {
+		t.Fatalf("entry = %+v, want item-001 ranking [A B C]", entry)
+	}
+	if entry.Quality != "" || entry.ContinueMode != "" || entry.Promote != "" {
+		t.Fatalf("commented optional fields must not parse as values: %+v", entry)
+	}
+
+	// Uncommenting an optional field is honored (its trailing # hint is stripped).
+	filled := strings.Replace(reply, "    # quality: acceptable", "    quality: acceptable", 1)
+	parsedFull, ok, err := ParseGitHubFeedbackComment("```yaml\n" + filled + "```\n")
+	if err != nil || !ok {
+		t.Fatalf("filled reply parse: ok=%t err=%v", ok, err)
+	}
+	if parsedFull.Items[0].Quality != "acceptable" {
+		t.Fatalf("quality = %q, want acceptable", parsedFull.Items[0].Quality)
+	}
+
+	// Each optional is a single self-contained line, so uncommenting an inline
+	// trait map works on its own (no nested-indent footgun).
+	withTraits := strings.Replace(reply, "    # useful_traits: { A: [clear value prop] }", "    useful_traits: { A: [clear value prop] }", 1)
+	parsedTraits, ok, err := ParseGitHubFeedbackComment("```yaml\n" + withTraits + "```\n")
+	if err != nil || !ok {
+		t.Fatalf("inline traits parse: ok=%t err=%v", ok, err)
+	}
+	if got := parsedTraits.Items[0].UsefulTraits["A"]; len(got) != 1 || got[0] != "clear value prop" {
+		t.Fatalf("useful_traits = %v, want {A:[clear value prop]}", parsedTraits.Items[0].UsefulTraits)
+	}
+}
+
 func TestParseGitHubFeedbackComment(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -234,10 +293,12 @@ func TestGitHubCollectorPublishesRankedIssueBody(t *testing.T) {
 		"```yaml",
 		"run_id: ranked-1",
 		"item_id: item-001",
-		"<replace with ranked option labels, e.g. A > B > C > D>",
-		"quality: \"\"",
-		"continue_mode: \"\"",
-		"promote: \"\"",
+		"<rank best to worst, e.g. A > B > C > D>",
+		"# Minimum reply: set `ranking`",
+		"# quality: acceptable",
+		"poor | acceptable | strong",
+		"explore | refine | distill | validate",
+		"If you only do one thing: rank",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("ranked issue body missing %q:\n%s", want, body)


### PR DESCRIPTION
## What

The review issue's "Copy-Paste YAML Reply" was a bare skeleton of empty fields with no allowed-value hints, and the prose told reviewers to "fill every item" — even though the parser requires **only `ranking`** (winner + pairwise preferences are inferred from it).

Reworked `rankedReplyYAML` into a hand-built, **lazy-first, self-documenting** template:

```yaml
# Minimum reply: set `ranking` for each item (best > worst; use = for ties).
# Everything else is optional — winner and pairwise preferences are inferred.
run_id: ranked-1
items:
  - item_id: item-001
    ranking:
      - <rank best to worst, e.g. A > B > C>
    # Optional — uncomment and fill any you care about:
    # quality: acceptable        # poor | acceptable | strong
    # continue_mode: refine      # explore | refine | distill | validate
    # promote: no                # yes | no
    # winner: A                  # defaults to the top-ranked option
    # required_improvements: [stronger hero copy, mobile layout]
    # useful_traits: { A: [clear value prop] }      # per-option strengths
    # rejected_traits: { B: [too generic] }         # per-option weaknesses
    # reasoning: why you ranked them this way
```

- The `#` comments are ignored by the YAML parser, so the uncommented skeleton is a **complete, valid reply**.
- Every optional is a **single, self-contained line** — uncommenting one always yields valid YAML (no nested-indent footgun; inline maps/lists for traits & improvements).
- The prose now leads with "if you only do one thing: rank each item's options best → worst (use `=` for ties). Everything else is optional."
- No invented signals: empty optionals stay "no signal", which the optimizer already handles.

## Tests

`internal/feedback`: a **round-trip** test proves the emitted template parses via `ParseGitHubFeedbackComment` — ranking-only (with ties) is accepted and yields the ranking; uncommenting a scalar (`quality`) and an inline trait map are both honored. Updated the golden issue-body assertions. Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)