### PR TITLE
cli: default the codex model for the codex_exec target backend too

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -8736,6 +8736,18 @@ func printSkillOptTrainRecoverResult(stdout io.Writer, result skillOptTrainRecov
 	writeLine(stdout, "next: %s", emptyText(result.NextAction))
 }
 
+// isCodexFamilyBackend reports whether a gitmoot-skillopt backend runs through
+// the codex CLI and would otherwise default to gpt-4o: the "codex" chat backend
+// (optimizer/evaluator) and the "codex_exec" target backend.
+func isCodexFamilyBackend(backend string) bool {
+	switch strings.TrimSpace(backend) {
+	case runtime.CodexRuntime, "codex_exec":
+		return true
+	default:
+		return false
+	}
+}
+
 func buildSkillOptTrainOptimizerCommand(iteration db.SkillOptTrainIteration, request skillOptTrainOptimizerRequest, paths skillOptTrainOptimizerPaths) (string, []string, error) {
 	resolvedRequest, _, err := resolveSkillOptTrainBackendRequest(request)
 	if err != nil {
@@ -8779,13 +8791,17 @@ func buildSkillOptTrainOptimizerCommand(iteration db.SkillOptTrainIteration, req
 			targetModel = model
 		}
 	}
-	// When a role runs on the codex backend with no model set, default to the
+	// When a role runs on a codex-family backend with no model set, default to the
 	// model the codex CLI is configured with. gitmoot-skillopt would otherwise
-	// fall back to gpt-4o, which a ChatGPT-account codex login rejects.
+	// fall back to gpt-4o (its OPTIMIZER/TARGET_DEPLOYMENT default), which a
+	// ChatGPT-account codex login rejects. The codex preset resolves the optimizer
+	// to "codex" and the target to "codex_exec" — both pass an explicit model to
+	// codex, so both need the override. The evaluator is left alone: it inherits
+	// the optimizer model in gitmoot-skillopt when --evaluator-model is omitted.
 	optimizerBackend := firstNonEmpty(strings.TrimSpace(request.OptimizerBackend), strings.TrimSpace(request.Backend))
 	targetBackend := firstNonEmpty(strings.TrimSpace(request.TargetBackend), strings.TrimSpace(request.Backend))
-	wantOptimizerCodexModel := optimizerModel == "" && optimizerBackend == runtime.CodexRuntime
-	wantTargetCodexModel := targetModel == "" && targetBackend == runtime.CodexRuntime
+	wantOptimizerCodexModel := optimizerModel == "" && isCodexFamilyBackend(optimizerBackend)
+	wantTargetCodexModel := targetModel == "" && isCodexFamilyBackend(targetBackend)
 	if wantOptimizerCodexModel || wantTargetCodexModel {
 		if codexModel, _ := runtime.ConfiguredCodexModel(); codexModel != "" {
 			if wantOptimizerCodexModel {

--- a/internal/cli/skillopt_optimize_test.go
+++ b/internal/cli/skillopt_optimize_test.go
@@ -32,18 +32,26 @@ func TestBuildOptimizerCommandDefaultsCodexModel(t *testing.T) {
 		return args
 	}
 
-	// codex backend, empty model → optimizer model defaults to the codex model.
-	// (Target resolves to codex_exec, which uses codex's model natively, so no
-	// --target-model is injected.)
+	// codex preset, empty model → optimizer AND target default to the codex model.
+	// The preset resolves the optimizer to "codex" and the target to "codex_exec";
+	// both pass an explicit model to codex, so both need the override. The
+	// evaluator inherits the optimizer model in gitmoot-skillopt (no flag emitted).
 	args := build(skillOptTrainOptimizerRequest{Backend: "codex"})
-	if got := argValue(args, "--optimizer-model"); got != "gpt-5.5" {
-		t.Fatalf("codex+empty: --optimizer-model = %q, want gpt-5.5 (args=%v)", got, args)
+	for _, flag := range []string{"--optimizer-model", "--target-model"} {
+		if got := argValue(args, flag); got != "gpt-5.5" {
+			t.Fatalf("codex+empty: %s = %q, want gpt-5.5 (args=%v)", flag, got, args)
+		}
+	}
+	if got := argValue(args, "--evaluator-model"); got != "" {
+		t.Fatalf("evaluator should inherit the optimizer model, not get an explicit flag: %q", got)
 	}
 
-	// An explicit model still wins.
+	// An explicit model still wins for optimizer + target.
 	args = build(skillOptTrainOptimizerRequest{Backend: "codex", Model: "o3"})
-	if got := argValue(args, "--optimizer-model"); got != "o3" {
-		t.Fatalf("explicit model overridden: --optimizer-model = %q, want o3", got)
+	for _, flag := range []string{"--optimizer-model", "--target-model"} {
+		if got := argValue(args, flag); got != "o3" {
+			t.Fatalf("explicit model overridden: %s = %q, want o3", flag, got)
+		}
 	}
 
 	// A non-codex backend gets no codex-derived default.


### PR DESCRIPTION
## What

Follow-up to #281. That PR defaulted the codex **optimizer** model but only matched the exact backend `codex`. The `codex` preset resolves the **target** to `codex_exec`, which the check missed — so no `--target-model` was passed and the **target canary** ran with `gitmoot-skillopt`'s hardcoded `gpt-4o`, rejected by a ChatGPT-account codex (HTTP 400) and blocking the optimizer at `blocked_config`:

```
--optimizer-model gpt-5.5 --optimizer-backend codex --target-backend codex_exec   (no --target-model!)
ERROR {"status":400,"message":"The 'gpt-4o' model is not supported when using Codex with a ChatGPT account."}
```

Fix: add `isCodexFamilyBackend` (matches `codex` + `codex_exec`) and use it for the optimizer **and** target model defaults, so the codex preset now emits both `--optimizer-model <m>` and `--target-model <m>`.

**Evaluator left intentionally alone** (deviation from the original plan, caught during review): gitmoot-skillopt's evaluator inherits the optimizer model when `--evaluator-model` is omitted (its canary uses the inherited `gpt-5.5`), so defaulting it would wrongly override an explicit `--model`. Verified against `gitmoot-skillopt/preflight.py`.

## Tests

`internal/cli`: the codex preset with an empty model now emits `--optimizer-model` **and** `--target-model` = `gpt-5.5`, and **no** `--evaluator-model` (it inherits); an explicit `--model` still wins for both; a non-codex backend gets no codex default. Full `go test ./...` green.

Note: a separate, non-fatal `SKILL.md missing frontmatter` log line (external `gitmoot-skillopt` packaging) and the dashboard's optimizer-error *surfacing* gap remain as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)