### PR TITLE
cli: map stable train phases to the right phase-bar segment

### DIFF
--- a/internal/cli/tui/trainrun_test.go
+++ b/internal/cli/tui/trainrun_test.go
@@ -29,7 +29,13 @@ func TestTrainPhaseSegment(t *testing.T) {
 		"candidate_created":          2,
 		"candidate_review_published": 3,
 		"candidate_promoted":         3,
-		"something_unknown":          0,
+		// Stable display phases the view actually receives from the CLI.
+		"preflight_running":             2,
+		"blocked_config":                2,
+		"recovery_available":            2,
+		"failed_unrecoverable":          2,
+		"optimizer_completed_candidate": 3,
+		"something_unknown":             0,
 	}
 	for phase, want := range cases {
 		if got := trainPhaseSegment(phase); got != want {

--- a/internal/cli/tui/trainrun_view.go
+++ b/internal/cli/tui/trainrun_view.go
@@ -19,9 +19,13 @@ func trainPhaseSegment(phase string) int {
 	case "review_published", "feedback_synced":
 		return 1
 	case "training_package_created", "optimizer_running", "optimizer_heartbeat_stale",
-		"optimizer_completed", "optimizer_completed_no_candidate", "candidate_created":
+		"optimizer_completed", "optimizer_completed_no_candidate", "candidate_created",
+		// Stable optimizer-stage phases the CLI emits (no candidate yet).
+		"preflight_running", "blocked_config", "recovery_available", "failed_unrecoverable":
 		return 2
-	case "candidate_review_published", "candidate_promoted", "candidate_rejected":
+	case "candidate_review_published", "candidate_promoted", "candidate_rejected",
+		// The CLI collapses the candidate states into this stable display phase.
+		"optimizer_completed_candidate":
 		return 3
 	default:
 		return 0


### PR DESCRIPTION
## What

The train-run phase bar highlighted **generate** even when the run was at optimize/promote. `trainPhaseSegment` listed the *raw* iteration phases, but the view receives the CLI's *stable* display phase — which collapses the candidate states into `optimizer_completed_candidate` (skillopt.go) and emits `blocked_config` / `preflight_running` / `recovery_available` / `failed_unrecoverable`. None were in the switch → `default: 0` → "generate" stayed blue.

Map the stable phases: `optimizer_completed_candidate` → **promote (3)**; the optimizer-stage stable phases → **optimize (2)**. `blocked_stale_lock` correctly stays at generate (0).

## Tests

`internal/cli/tui`: `TestTrainPhaseSegment` extended to assert the stable strings the view actually receives (`optimizer_completed_candidate`→3, `blocked_config`/`preflight_running`/`recovery_available`/`failed_unrecoverable`→2). Full tui package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)