### PR TITLE
cli: hide and clean up training agents on the Agents page

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -6700,11 +6700,30 @@ func deleteSkillOptTrainSession(ctx context.Context, store *db.Store, sessionID 
 	if err := store.DeleteSkillOptTrainSession(ctx, sessionID); err != nil {
 		return nil, err
 	}
+	// Remove the per-option target agents this session scaffolded so they don't
+	// accumulate on the Agents page / agent list (best-effort — internal plumbing).
+	removeSkillOptTrainTargetAgents(ctx, store, sessionID)
 	repos := make([]string, 0, len(records))
 	for _, record := range records {
 		repos = append(repos, record.Repo)
 	}
 	return repos, nil
+}
+
+// removeSkillOptTrainTargetAgents deletes the `skillopt-target-<run>-…` agents a
+// training session scaffolded (one per generated option). The session id is
+// embedded in each name, so it only touches this session's plumbing. Best-effort.
+func removeSkillOptTrainTargetAgents(ctx context.Context, store *db.Store, sessionID string) {
+	agents, err := store.ListAgents(ctx)
+	if err != nil {
+		return
+	}
+	marker := skillOptSafeAgentName(strings.TrimSpace(sessionID))
+	for _, agent := range agents {
+		if strings.HasPrefix(agent.Name, "skillopt-target-") && marker != "" && strings.Contains(agent.Name, marker) {
+			_, _ = store.RemoveAgent(ctx, agent.Name)
+		}
+	}
 }
 
 // cleanupCreatedTrainRepo deletes a gitmoot-created GitHub repo and then its

--- a/internal/cli/skillopt_optimize_test.go
+++ b/internal/cli/skillopt_optimize_test.go
@@ -61,6 +61,51 @@ func TestBuildOptimizerCommandDefaultsCodexModel(t *testing.T) {
 	}
 }
 
+func TestRemoveSkillOptTrainTargetAgents(t *testing.T) {
+	home := t.TempDir()
+	if err := config.Initialize(config.PathsForHome(home)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	sid := "train-plan-20260101-000000-111"
+	otherTarget := "skillopt-target-train-other-20260101-000000-222-item-001-generator-ccc"
+	for _, name := range []string{
+		"skillopt-target-" + sid + "-item-001-generator-aaa",
+		"skillopt-target-" + sid + "-item-002-generator-bbb",
+		"planner",   // a real user agent
+		otherTarget, // another session's plumbing
+	} {
+		if err := store.UpsertAgent(ctx, db.Agent{Name: name, Runtime: "codex"}); err != nil {
+			t.Fatalf("upsert %s: %v", name, err)
+		}
+	}
+
+	removeSkillOptTrainTargetAgents(ctx, store, sid)
+
+	got, err := store.ListAgents(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	names := map[string]bool{}
+	for _, a := range got {
+		names[a.Name] = true
+	}
+	// This session's target agents are gone; the user agent and the other
+	// session's plumbing remain.
+	if names["skillopt-target-"+sid+"-item-001-generator-aaa"] || names["skillopt-target-"+sid+"-item-002-generator-bbb"] {
+		t.Fatalf("session target agents should be removed: %v", names)
+	}
+	if !names["planner"] || !names[otherTarget] {
+		t.Fatalf("unrelated agents must remain: %v", names)
+	}
+}
+
 func TestBuildAgentOptimizeFieldsSkipsTemplate(t *testing.T) {
 	fields := buildAgentOptimizeFields("", nil)
 	names := make([]string, 0, len(fields))

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -16,10 +16,32 @@ const agentCustomPromptValue = "__custom_prompt__"
 
 // agentUnderCursor returns the agent under the Agents cursor, if any.
 func (m Model) agentUnderCursor() (Agent, bool) {
-	if pages[m.selected].page != pageAgents || len(m.snap.Agents) == 0 {
+	visible := m.visibleAgents()
+	if pages[m.selected].page != pageAgents || m.agentCursor < 0 || m.agentCursor >= len(visible) {
 		return Agent{}, false
 	}
-	return m.snap.Agents[m.agentCursor], true
+	return visible[m.agentCursor], true
+}
+
+// isManagedTrainingAgent reports whether an agent name is internal skillopt
+// training plumbing — the per-option target agents and the generator workers —
+// that the user never acts on, so the Agents page hides them.
+func isManagedTrainingAgent(name string) bool {
+	name = strings.TrimSpace(name)
+	return strings.HasPrefix(name, "skillopt-target-") || strings.HasPrefix(name, "skillopt-generator")
+}
+
+// visibleAgents are the user-facing agents (training plumbing filtered out). The
+// Agents page renders, cursors, and acts on this list; the serialized snapshot
+// keeps every agent, so --json/--plain are unaffected.
+func (m Model) visibleAgents() []Agent {
+	out := make([]Agent, 0, len(m.snap.Agents))
+	for _, a := range m.snap.Agents {
+		if !isManagedTrainingAgent(a.Name) {
+			out = append(out, a)
+		}
+	}
+	return out
 }
 
 // openAgentDetail enters the detail view for an agent and lazily loads its
@@ -501,7 +523,14 @@ func choiceValues(choices []Choice) []string {
 // agentsContentInteractive renders the Agents page as a selectable list. Agent
 // overlays are dispatched once in content(), not here.
 func (m Model) agentsContentInteractive() string {
-	if len(m.snap.Agents) == 0 {
+	visible := m.visibleAgents()
+	hidden := len(m.snap.Agents) - len(visible)
+	hiddenLine := func(b *strings.Builder) {
+		if hidden > 0 {
+			b.WriteString("\n" + mutedStyle.Render(strconv.Itoa(hidden)+" training agents hidden (skillopt-*)") + "\n")
+		}
+	}
+	if len(visible) == 0 {
 		var b strings.Builder
 		b.WriteString(m.loadingOr("No registered agents.", !m.loadedAt.IsZero()))
 		b.WriteByte('\n')
@@ -511,12 +540,13 @@ func (m Model) agentsContentInteractive() string {
 		if m.agentNotice != "" {
 			b.WriteString("\n" + mutedStyle.Render(m.agentNotice) + "\n")
 		}
+		hiddenLine(&b)
 		b.WriteString("\n" + mutedStyle.Render("n new agent"))
 		return b.String()
 	}
 	var b strings.Builder
 	rows := [][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH"}}
-	for i, a := range m.snap.Agents {
+	for i, a := range visible {
 		cursor, name := "  ", a.Name
 		if i == m.agentCursor {
 			cursor, name = "▸ ", selectedRowStyle.Render(a.Name)
@@ -530,6 +560,7 @@ func (m Model) agentsContentInteractive() string {
 	if m.agentNotice != "" {
 		b.WriteString("\n" + mutedStyle.Render(m.agentNotice) + "\n")
 	}
+	hiddenLine(&b)
 	if m.optimizeBusy {
 		b.WriteString("\n" + mutedStyle.Render("starting optimization…") + "\n")
 	}

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -41,6 +41,38 @@ func agentsModel(t *testing.T, deps Deps, snap Snapshot) Model {
 	return m
 }
 
+func TestAgentsPageHidesTrainingAgents(t *testing.T) {
+	snap := agentsSnapshot()
+	// Add internal training plumbing alongside the real agents.
+	snap.Agents = append(snap.Agents,
+		Agent{Name: "skillopt-target-train-s1-item-001-generator-abc", Runtime: "codex"},
+		Agent{Name: "skillopt-target-train-s1-item-002-generator-def", Runtime: "codex"},
+		Agent{Name: "skillopt-generator-bg-18b5", Runtime: "codex"},
+	)
+	deps := Deps{}
+	m := agentsModel(t, deps, snap)
+	view := m.View()
+	// Real agents shown, training plumbing hidden + a count line.
+	for _, want := range []string{"planner", "reviewer", "3 training agents hidden"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("agents view missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "skillopt-target-") || strings.Contains(view, "skillopt-generator-bg") {
+		t.Fatalf("training agents must be hidden:\n%s", view)
+	}
+	// The cursor + enter act on the VISIBLE list (planner is first visible).
+	if a, ok := m.agentUnderCursor(); !ok || a.Name != "planner" {
+		t.Fatalf("cursor should target the first visible agent, got %q ok=%v", a.Name, ok)
+	}
+	// Moving down lands on the next visible agent, never the hidden ones.
+	next, _ := m.Update(key("j"))
+	m = next.(Model)
+	if a, _ := m.agentUnderCursor(); a.Name != "reviewer" {
+		t.Fatalf("down should move to the next visible agent, got %q", a.Name)
+	}
+}
+
 func TestAgentDetailRendersVersionsAndJobs(t *testing.T) {
 	var asked string
 	deps := Deps{TemplateVersions: func(templateID string) ([]TemplateVersion, error) {

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -768,7 +768,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampPromptCursor()
 			m.clampTrainCursor()
 			m.clampJobCursor()
-			m.agentCursor = clampCursor(m.agentCursor, len(m.snap.Agents))
+			m.agentCursor = clampCursor(m.agentCursor, len(m.visibleAgents()))
 			m.sessionCursor = clampCursor(m.sessionCursor, len(m.sessionRows()))
 			m.configCursor = clampCursor(m.configCursor, len(m.configEditableFields()))
 			// A cancel-requested job that has settled no longer needs the
@@ -889,7 +889,7 @@ func (m *Model) pageCursor() (*int, int) {
 	case pageTrains:
 		return &m.trainCursor, len(m.snap.Trains)
 	case pageAgents:
-		return &m.agentCursor, len(m.snap.Agents)
+		return &m.agentCursor, len(m.visibleAgents())
 	case pageSessions:
 		return &m.sessionCursor, len(m.sessionRows())
 	case pageJobs:


### PR DESCRIPTION
## What

During a training run, each generated option registers a **full agent** named `skillopt-target-<run>-…` (plus `skillopt-generator-bg-*` workers). They were listed flat on the dashboard Agents page and **never cleaned up**, so they buried the real agents and accumulated across runs (you'd see plumbing from old sessions too).

- **Hide them on the Agents page:** `isManagedTrainingAgent` flags the `skillopt-target-`/`skillopt-generator` prefixes; `visibleAgents()` filters them out **everywhere the page acts on agents** (render, `pageCursor` bounds, `agentUnderCursor`, the cursor clamp), with a muted `N training agents hidden` line. The filter is **TUI-only** — `dashboardSnapshot.Agents` is untouched, so `--json`/`--plain` stay byte-stable.
- **Stop the pile-up:** `deleteSkillOptTrainSession` now removes the session's `skillopt-target-*` agents (matched by the session id embedded in the name) via the unchecked `store.RemoveAgent`, best-effort.

## Tests

`internal/cli/tui`: a snapshot mixing real + `skillopt-target-*`/`skillopt-generator-bg-*` shows only the real agents + the hidden-count line, and the cursor/`enter`/down act on the visible list (never a hidden agent). `internal/cli`: `removeSkillOptTrainTargetAgents` removes the session's target agents and leaves the user agent + another session's plumbing. Full `go test ./...` green.

Note: pre-existing accumulated agents aren't retroactively cleaned (only on the next session delete); the page filter hides them meanwhile. A `gitmoot agent gc` sweep is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)