### PR TITLE
cli: post the promote/reject decision to the candidate-review issue

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -2652,7 +2652,69 @@ func continueSkillOptTrainCandidateDecision(ctx context.Context, store *db.Store
 		output.Lines = lines
 		return output, nil
 	}
-	return continueSkillOptTrainAfterCandidateDecision(ctx, store, session.ID, request, result)
+	// Reflect the decision on the candidate-review issue so it doesn't sit open
+	// with no record of the choice (works for a TUI p/x or the --promote/--reject
+	// flags). Best-effort: a GitHub failure never undoes the recorded decision.
+	decisionNotice := postSkillOptTrainCandidateDecisionComment(ctx, iteration, result, request)
+	out, err := continueSkillOptTrainAfterCandidateDecision(ctx, store, session.ID, request, result)
+	// Surface the GitHub notice whether or not the follow-up (e.g. --start-next)
+	// succeeded — the decision was made and posted regardless.
+	if decisionNotice != "" {
+		out.Lines = append(out.Lines, decisionNotice)
+	}
+	return out, err
+}
+
+// postSkillOptTrainCandidateDecisionComment posts a promote/reject decision to the
+// candidate-review issue (or PR) and closes the issue. It is best-effort and
+// returns a one-line notice (or a warning) for the continue output; the recorded
+// decision stands regardless. The comment carries a gitmoot marker so the review
+// watcher skips it.
+func postSkillOptTrainCandidateDecisionComment(ctx context.Context, iteration db.SkillOptTrainIteration, result skillOptTrainCandidateDecisionResult, request skillOptTrainContinueRequest) string {
+	repoName := strings.TrimSpace(iteration.IssueRepo)
+	number := iteration.IssueNumber
+	onIssue := repoName != "" && number > 0
+	if !onIssue {
+		repoName = strings.TrimSpace(iteration.PullRequestRepo)
+		number = iteration.PullRequestNumber
+	}
+	if repoName == "" || number <= 0 {
+		return ""
+	}
+	repo, err := daemon.ParseRepository(repoName)
+	if err != nil {
+		return fmt.Sprintf("warning: candidate-review repo %q is unparseable; decision not posted: %v", repoName, err)
+	}
+	version := strings.TrimSpace(result.CandidateVersionID)
+	if version == "" {
+		version = strings.TrimSpace(firstNonEmpty(request.PromoteCandidate, request.RejectCandidate))
+	}
+	var body strings.Builder
+	body.WriteString(skillOptTrainDecisionMarker + "\n")
+	switch {
+	case strings.Contains(result.Decision, "promot"):
+		fmt.Fprintf(&body, "✅ Promoted `%s` from gitmoot.", version)
+	case strings.Contains(result.Decision, "reject"):
+		fmt.Fprintf(&body, "❌ Rejected `%s` from gitmoot.", version)
+		if reason := strings.TrimSpace(request.DecisionReason); reason != "" {
+			fmt.Fprintf(&body, "\n\nReason: %s", reason)
+		}
+	default:
+		fmt.Fprintf(&body, "Decision recorded for `%s`: %s", version, result.Decision)
+	}
+	client := newSkillOptGitHubClient()
+	if _, err := client.PostIssueComment(ctx, repo, number, body.String()); err != nil {
+		return fmt.Sprintf("warning: could not post the decision to %s#%d: %v", repo.FullName(), number, err)
+	}
+	notice := fmt.Sprintf("candidate_review: posted the decision to %s#%d", repo.FullName(), number)
+	// Only close a dedicated review issue; never close a user's pull request.
+	if onIssue {
+		if _, err := client.CloseIssue(ctx, repo, number); err != nil {
+			return notice + fmt.Sprintf(" (could not close it: %v)", err)
+		}
+		notice += " and closed it"
+	}
+	return notice
 }
 
 func continueSkillOptTrainAfterCandidateDecision(ctx context.Context, store *db.Store, sessionID string, request skillOptTrainContinueRequest, result skillOptTrainCandidateDecisionResult) (skillOptTrainContinueOutput, error) {

--- a/internal/cli/skillopt_decision_test.go
+++ b/internal/cli/skillopt_decision_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+type decisionFakeGitHub struct {
+	github.NoopClient
+	postedRepo string
+	postedNum  int64
+	postedBody string
+	closedNum  int64
+	postErr    error
+}
+
+func (f *decisionFakeGitHub) PostIssueComment(_ context.Context, repo github.Repository, n int64, body string) (github.IssueComment, error) {
+	if f.postErr != nil {
+		return github.IssueComment{}, f.postErr
+	}
+	f.postedRepo, f.postedNum, f.postedBody = repo.FullName(), n, body
+	return github.IssueComment{URL: "https://github.com/o/r/issues/2#issuecomment-1"}, nil
+}
+
+func (f *decisionFakeGitHub) CloseIssue(_ context.Context, _ github.Repository, n int64) (github.Issue, error) {
+	f.closedNum = n
+	return github.Issue{}, nil
+}
+
+func TestPostSkillOptTrainCandidateDecisionComment(t *testing.T) {
+	iter := db.SkillOptTrainIteration{IssueRepo: "o/r", IssueNumber: 2}
+
+	t.Run("promote comments and closes the issue", func(t *testing.T) {
+		fake := &decisionFakeGitHub{}
+		restore := replaceSkillOptGitHubClient(fake)
+		defer restore()
+		result := skillOptTrainCandidateDecisionResult{Decided: true, Decision: "promoted", CandidateVersionID: "agent@v4"}
+		notice := postSkillOptTrainCandidateDecisionComment(context.Background(), iter, result, skillOptTrainOptimizerContinueRequestForTest("promote"))
+		if fake.postedNum != 2 || fake.postedRepo != "o/r" {
+			t.Fatalf("comment posted to %s#%d, want o/r#2", fake.postedRepo, fake.postedNum)
+		}
+		if !strings.Contains(fake.postedBody, skillOptTrainDecisionMarker) || !strings.Contains(fake.postedBody, "Promoted `agent@v4`") {
+			t.Fatalf("body = %q", fake.postedBody)
+		}
+		if fake.closedNum != 2 {
+			t.Fatalf("issue should be closed, closedNum=%d", fake.closedNum)
+		}
+		if !strings.Contains(notice, "closed it") {
+			t.Fatalf("notice = %q", notice)
+		}
+	})
+
+	t.Run("reject includes the reason", func(t *testing.T) {
+		fake := &decisionFakeGitHub{}
+		restore := replaceSkillOptGitHubClient(fake)
+		defer restore()
+		req := skillOptTrainContinueRequest{RejectCandidate: "agent@v4", DecisionReason: "weak hero copy"}
+		result := skillOptTrainCandidateDecisionResult{Decided: true, Decision: "rejected", CandidateVersionID: "agent@v4"}
+		postSkillOptTrainCandidateDecisionComment(context.Background(), iter, result, req)
+		if !strings.Contains(fake.postedBody, "Rejected `agent@v4`") || !strings.Contains(fake.postedBody, "Reason: weak hero copy") {
+			t.Fatalf("body = %q", fake.postedBody)
+		}
+	})
+
+	t.Run("post error yields a warning, no panic", func(t *testing.T) {
+		fake := &decisionFakeGitHub{postErr: errors.New("rate limited")}
+		restore := replaceSkillOptGitHubClient(fake)
+		defer restore()
+		result := skillOptTrainCandidateDecisionResult{Decided: true, Decision: "promoted", CandidateVersionID: "agent@v4"}
+		notice := postSkillOptTrainCandidateDecisionComment(context.Background(), iter, result, skillOptTrainOptimizerContinueRequestForTest("promote"))
+		if !strings.Contains(notice, "warning") {
+			t.Fatalf("notice = %q, want a warning", notice)
+		}
+		if fake.closedNum != 0 {
+			t.Fatal("a failed comment must not close the issue")
+		}
+	})
+
+	t.Run("no issue or PR → no post", func(t *testing.T) {
+		fake := &decisionFakeGitHub{}
+		restore := replaceSkillOptGitHubClient(fake)
+		defer restore()
+		result := skillOptTrainCandidateDecisionResult{Decided: true, Decision: "promoted", CandidateVersionID: "agent@v4"}
+		notice := postSkillOptTrainCandidateDecisionComment(context.Background(), db.SkillOptTrainIteration{}, result, skillOptTrainOptimizerContinueRequestForTest("promote"))
+		if notice != "" || fake.postedNum != 0 {
+			t.Fatalf("no issue should mean no post: notice=%q postedNum=%d", notice, fake.postedNum)
+		}
+	})
+}
+
+func skillOptTrainOptimizerContinueRequestForTest(kind string) skillOptTrainContinueRequest {
+	if kind == "promote" {
+		return skillOptTrainContinueRequest{PromoteCandidate: "agent@v4"}
+	}
+	return skillOptTrainContinueRequest{RejectCandidate: "agent@v4"}
+}
+
+func TestReviewWatcherSkipsDecisionComment(t *testing.T) {
+	body := skillOptTrainDecisionMarker + "\n✅ Promoted `agent@v4` from gitmoot."
+	if !isGitmootSkillOptReviewWatchComment(body) {
+		t.Fatal("the decision comment must be skipped by the review watcher (no re-import loop)")
+	}
+}

--- a/internal/cli/skillopt_review_watcher.go
+++ b/internal/cli/skillopt_review_watcher.go
@@ -24,6 +24,7 @@ import (
 const skillOptReviewWatchErrorMarker = "<!-- gitmoot:skillopt-review-watch-error -->"
 const skillOptReviewWatchSuccessMarker = "<!-- gitmoot:skillopt-review-watch-success -->"
 const skillOptReviewWatchStaleMarker = "<!-- gitmoot:skillopt-review-watch-stale -->"
+const skillOptTrainDecisionMarker = "<!-- gitmoot:skillopt-candidate-decision -->"
 
 func pollSkillOptReviewWatches(ctx context.Context, paths config.Paths, store *db.Store, blobStore artifact.Store, gh github.Client, stdout io.Writer, dryRun bool, home string) (int, error) {
 	if store == nil {
@@ -242,6 +243,7 @@ func isGitmootSkillOptReviewWatchComment(body string) bool {
 	return strings.Contains(body, skillOptReviewWatchErrorMarker) ||
 		strings.Contains(body, skillOptReviewWatchSuccessMarker) ||
 		strings.Contains(body, skillOptReviewWatchStaleMarker) ||
+		strings.Contains(body, skillOptTrainDecisionMarker) ||
 		strings.Contains(body, "<!-- gitmoot:skillopt-feedback-packet -->") ||
 		strings.HasPrefix(body, "# Gitmoot SkillOpt Feedback:")
 }

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -6854,8 +6854,16 @@ func TestSkillOptTrainContinueRecoversCandidateReviewFromSidecar(t *testing.T) {
 	if !strings.Contains(stdout.String(), "current_phase: candidate_promoted") || !strings.Contains(stdout.String(), "promoted_candidate: planner@v2") {
 		t.Fatalf("sidecar recovery stdout = %s", stdout.String())
 	}
-	if fakeGitHub.createdIssue.Repo.FullName() != "" || len(fakeGitHub.postedComments) != 0 {
-		t.Fatalf("sidecar recovery reposted github state: issue=%+v comments=%+v", fakeGitHub.createdIssue, fakeGitHub.postedComments)
+	// The recovery must not re-create the issue, but the promote now posts the
+	// decision to the recovered issue (#8) so it reflects the choice.
+	if fakeGitHub.createdIssue.Repo.FullName() != "" {
+		t.Fatalf("sidecar recovery must not re-create the issue: %+v", fakeGitHub.createdIssue)
+	}
+	if len(fakeGitHub.postedComments) != 1 {
+		t.Fatalf("expected one decision comment on the recovered issue, got %+v", fakeGitHub.postedComments)
+	}
+	if c := fakeGitHub.postedComments[0]; c.IssueNumber != 8 || !strings.Contains(c.Body, skillOptTrainDecisionMarker) || !strings.Contains(c.Body, "Promoted") {
+		t.Fatalf("decision comment = %+v", fakeGitHub.postedComments[0])
 	}
 	if _, err := os.Stat(sidecarPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("sidecar still exists err=%v", err)


### PR DESCRIPTION
## What

A promote/reject made from the TUI (`p`/`x`) or the CLI `--promote`/`--reject` flags recorded the decision **in the DB only** — the candidate-review issue stayed open with no record of the choice.

After the decision is persisted, `continueSkillOptTrainCandidateDecision` now posts a comment to the candidate-review issue (or PR) and closes the issue:
- `✅ Promoted \`<ver>\` from gitmoot.` / `❌ Rejected \`<ver>\` from gitmoot.` + `Reason: <reason>`.
- The comment carries a new `<!-- gitmoot:skillopt-candidate-decision -->` marker, added to the review watcher's skip set, so it is **never re-imported** (no loop).
- **Best-effort:** a GitHub failure surfaces a warning but never undoes the recorded decision; the notice is appended even if a follow-up (`--start-next`) errors. A user **PR** is commented but **not** closed (only a dedicated review issue is closed).

Covers both entry points since they share the decision path.

## Tests

`internal/cli`: `postSkillOptTrainCandidateDecisionComment` — promote comments + closes issue #N with the marker + `Promoted <ver>`; reject includes the reason; a post error yields a warning and doesn't close; no issue/PR → no post. The review watcher skips the decision marker. Updated `TestSkillOptTrainContinueRecoversCandidateReviewFromSidecar` to expect the one decision comment on the recovered issue (no issue re-creation). Full `go test ./...` green.

Note: re-running `--promote` on an already-decided candidate could post a duplicate (cosmetic, marker-tagged, watcher-skipped) comment — an accepted edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)