### PR TITLE
docs: add v0.3.0 beta 1 release notes

### DIFF
--- a/docs/release-notes/v0.3.0-beta.1.md
+++ b/docs/release-notes/v0.3.0-beta.1.md
@@ -1,0 +1,62 @@
+# Gitmoot v0.3.0-beta.1
+
+Gitmoot v0.3.0-beta.1 adds a full interactive **dashboard cockpit** and an
+end-to-end **train-run TUI** for the SkillOpt optimization loop, on top of the
+0.2.0 parallel-PR foundation.
+
+## Highlights
+
+### Interactive dashboard (`gitmoot dashboard`)
+
+- A bubbletea cockpit with pages for Attention, Trains, Agents, Sessions, Jobs,
+  Locks, Health, and Config. It launches automatically on a terminal and falls
+  back to the byte-stable `--plain` / `--json` snapshot everywhere else.
+- **Attention**: answer interactive prompts inline; retry or cancel
+  blocked/failed jobs; start the daemon when it is down.
+- **Agents**: create (pick a template or write a custom prompt in `$EDITOR`),
+  delete, revert a template version, switch runtime (codex/claude), optimize, and
+  read a version's prompt in a pager. Internal training agents are hidden.
+- **Jobs**: a scrollable list with timestamps, request/result detail, and
+  retry/cancel.
+- **Sessions**: per-session detail and a stop action. **Locks**: a "what to do"
+  guidance line.
+- **Health**: environment/daemon doctor checks. **Config**: inline scalar edits
+  (comment-preserving) plus an `$EDITOR` handoff with validation.
+
+### Train-run + train-init TUI (SkillOpt)
+
+- `gitmoot skillopt train init` interactive wizard (line and TUI) with template
+  resolution, optional GitHub repo creation, and a confirm summary.
+- A train-run view that drives **generate → review → optimize → promote** with a
+  live phase bar, streaming generation/optimizer progress, candidate preview, and
+  promote/reject — which now also posts the decision to the candidate-review
+  issue and closes it.
+- A lazy, self-documenting review-reply template: ranking is the only required
+  field; everything else is optional with inline allowed-values hints.
+
+### Reliability
+
+- Creating a generation repo now provisions a usable checkout (initial commit +
+  clone + register), so the optimizer can run in it.
+- The codex optimizer and target backends default to the codex CLI's configured
+  model instead of an unsupported `gpt-4o`.
+- Failed generate/continue steps surface the real runtime error (e.g. a codex
+  usage limit) instead of a cryptic stdin line.
+
+## Validation
+
+- `GOTOOLCHAIN=go1.26.0 go test ./...` — green except the known daemon flake
+  `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos`.
+- `go vet`, `gofmt`, and `git diff --check` clean.
+- High-effort code review on every change; live exercise of the dashboard and a
+  full train run end-to-end (generate → optimize → candidate promote) on a
+  disposable GitHub repo.
+
+## Known Beta Limits
+
+- The dashboard runs against the current checkout's home; running it from
+  anywhere to track every repo is tracked in #267.
+- Per-agent model selection is not wired yet (#268), and the dashboard does not
+  yet surface optimizer / `blocked_config` errors in the TUI (only generation
+  errors) — check the session log if an optimizer step stalls.
+- Release assets include `gitmoot_linux_amd64` only.


### PR DESCRIPTION
Release notes for v0.3.0-beta.1 (interactive dashboard cockpit + train-run TUI + reliability fixes since v0.2.0-beta.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)