### PR TITLE
feat: add bug report builder

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,0 +1,554 @@
+package report
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+const (
+	SourceKindJob          = "job"
+	LabelDashboardReport   = "gitmoot-dashboard-report"
+	LabelBug               = "bug"
+	defaultRecentEventSize = 8
+)
+
+// Report is a redacted GitHub-ready issue draft produced from a local Gitmoot
+// error source.
+type Report struct {
+	Title             string
+	Body              string
+	Labels            []string
+	Fingerprint       string
+	Source            SourceMetadata
+	RedactionSummary  RedactionSummary
+	SelectedErrorText string
+}
+
+type SourceMetadata struct {
+	Kind        string
+	ID          string
+	Repo        string
+	Agent       string
+	Runtime     string
+	Action      string
+	State       string
+	TaskID      string
+	TaskTitle   string
+	Branch      string
+	HeadSHA     string
+	PullRequest int
+}
+
+type RedactionSummary struct {
+	Notes              []string
+	RawOutputCount     int
+	RawOutputsOmitted  bool
+	RecentEventCount   int
+	IncludedEventCount int
+}
+
+type JobOptions struct {
+	RecentEventLimit int
+}
+
+type jobReportData struct {
+	job           db.Job
+	payload       workflow.JobPayload
+	agent         db.Agent
+	agentLoaded   bool
+	events        []db.JobEvent
+	recentEvents  []db.JobEvent
+	selectedError string
+}
+
+// BuildJobReport loads a job and returns a redacted, structured issue draft.
+func BuildJobReport(ctx context.Context, store *db.Store, jobID string, opts JobOptions) (Report, error) {
+	if store == nil {
+		return Report{}, errors.New("store is required")
+	}
+	jobID = strings.TrimSpace(jobID)
+	if jobID == "" {
+		return Report{}, errors.New("job id is required")
+	}
+
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Report{}, fmt.Errorf("job %q not found", jobID)
+		}
+		return Report{}, err
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		return Report{}, err
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		return Report{}, err
+	}
+	agent, agentLoaded, err := loadAgentBestEffort(ctx, store, job.Agent)
+	if err != nil {
+		return Report{}, err
+	}
+
+	limit := opts.RecentEventLimit
+	if limit <= 0 {
+		limit = defaultRecentEventSize
+	}
+	data := jobReportData{
+		job:           job,
+		payload:       payload,
+		agent:         agent,
+		agentLoaded:   agentLoaded,
+		events:        events,
+		recentEvents:  tailEvents(events, limit),
+		selectedError: selectJobError(job, payload, events),
+	}
+	return renderJobReport(data), nil
+}
+
+func loadAgentBestEffort(ctx context.Context, store *db.Store, name string) (db.Agent, bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return db.Agent{}, false, nil
+	}
+	agent, err := store.GetAgent(ctx, name)
+	if err == nil {
+		return agent, true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.Agent{}, false, nil
+	}
+	return db.Agent{}, false, err
+}
+
+func renderJobReport(data jobReportData) Report {
+	source := SourceMetadata{
+		Kind:        SourceKindJob,
+		ID:          data.job.ID,
+		Repo:        data.payload.Repo,
+		Agent:       data.job.Agent,
+		Action:      data.job.Type,
+		State:       data.job.State,
+		TaskID:      data.payload.TaskID,
+		TaskTitle:   data.payload.TaskTitle,
+		Branch:      data.payload.Branch,
+		HeadSHA:     data.payload.HeadSHA,
+		PullRequest: data.payload.PullRequest,
+	}
+	if data.agentLoaded {
+		source.Runtime = data.agent.Runtime
+	}
+	source = sanitizeSourceMetadata(source)
+
+	fingerprint := jobFingerprint(data.job, data.payload, data.selectedError)
+	redaction := RedactionSummary{
+		RawOutputCount:     len(data.payload.RawOutputs),
+		RawOutputsOmitted:  len(data.payload.RawOutputs) > 0,
+		RecentEventCount:   len(data.events),
+		IncludedEventCount: len(data.recentEvents),
+		Notes: []string{
+			"Applied Gitmoot comment redaction to all rendered fields.",
+			"Neutralized /gitmoot command-looking lines in rendered text.",
+		},
+	}
+	if redaction.RawOutputsOmitted {
+		redaction.Notes = append(redaction.Notes, "Omitted raw runtime output from the report body.")
+	}
+
+	report := Report{
+		Title:             reportTitle(data.job, data.payload),
+		Labels:            []string{LabelDashboardReport, LabelBug},
+		Fingerprint:       fingerprint,
+		Source:            source,
+		RedactionSummary:  redaction,
+		SelectedErrorText: sanitizeField(data.selectedError),
+	}
+	report.Body = renderMarkdown(report, data)
+	return report
+}
+
+func sanitizeSourceMetadata(source SourceMetadata) SourceMetadata {
+	source.Kind = sanitizeField(source.Kind)
+	source.ID = sanitizeField(source.ID)
+	source.Repo = sanitizeField(source.Repo)
+	source.Agent = sanitizeField(source.Agent)
+	source.Runtime = sanitizeField(source.Runtime)
+	source.Action = sanitizeField(source.Action)
+	source.State = sanitizeField(source.State)
+	source.TaskID = sanitizeField(source.TaskID)
+	source.TaskTitle = sanitizeField(source.TaskTitle)
+	source.Branch = sanitizeField(source.Branch)
+	source.HeadSHA = sanitizeField(source.HeadSHA)
+	return source
+}
+
+func reportTitle(job db.Job, payload workflow.JobPayload) string {
+	parts := []string{"Gitmoot"}
+	if state := strings.TrimSpace(job.State); state != "" {
+		parts = append(parts, state)
+	} else {
+		parts = append(parts, "error")
+	}
+	parts = append(parts, "job")
+	if action := strings.TrimSpace(job.Type); action != "" {
+		parts = append(parts, action)
+	}
+	if agent := strings.TrimSpace(job.Agent); agent != "" {
+		parts = append(parts, "for", agent)
+	}
+	if repo := strings.TrimSpace(payload.Repo); repo != "" {
+		parts = append(parts, "in", repo)
+	}
+	return workflow.LimitCommentText(strings.Join(parts, " "))
+}
+
+func renderMarkdown(report Report, data jobReportData) string {
+	var builder strings.Builder
+	builder.WriteString("<!-- gitmoot:dashboard-report fingerprint:")
+	builder.WriteString(report.Fingerprint)
+	builder.WriteString(" -->\n\n")
+
+	builder.WriteString("## Summary\n\n")
+	writeBullet(&builder, "Source", report.Source.Kind+" "+report.Source.ID)
+	writeBullet(&builder, "State", report.Source.State)
+	writeBullet(&builder, "Selected error", report.SelectedErrorText)
+
+	builder.WriteString("\n## Environment\n\n")
+	writeBullet(&builder, "Repository", report.Source.Repo)
+	writeBullet(&builder, "Agent", report.Source.Agent)
+	writeBullet(&builder, "Runtime", report.Source.Runtime)
+	writeBullet(&builder, "Action", report.Source.Action)
+	writeBullet(&builder, "Branch", report.Source.Branch)
+	if report.Source.PullRequest > 0 {
+		writeBullet(&builder, "Pull request", "#"+strconv.Itoa(report.Source.PullRequest))
+	}
+	writeBullet(&builder, "Head SHA", report.Source.HeadSHA)
+
+	builder.WriteString("\n## Job Context\n\n")
+	writeBullet(&builder, "Job ID", report.Source.ID)
+	writeBullet(&builder, "Task", taskLabel(report.Source.TaskID, report.Source.TaskTitle))
+	writeBullet(&builder, "Sender", data.payload.Sender)
+	writeBullet(&builder, "Lead agent", data.payload.LeadAgent)
+	writeBullet(&builder, "Review round", data.payload.ReviewRound)
+	writeBullet(&builder, "Template", data.payload.TemplateID)
+	if len(data.payload.Reviewers) > 0 {
+		writeBullet(&builder, "Reviewers", strings.Join(data.payload.Reviewers, ", "))
+	}
+	if len(data.payload.Constraints) > 0 {
+		writeList(&builder, "Constraints", data.payload.Constraints)
+	}
+	if strings.TrimSpace(data.payload.Instructions) != "" {
+		builder.WriteString("\n### Request Instructions\n\n")
+		builder.WriteString(sanitizeBlock(data.payload.Instructions))
+		builder.WriteString("\n")
+	}
+
+	if data.payload.Result != nil {
+		builder.WriteString("\n## Agent Result\n\n")
+		writeBullet(&builder, "Decision", data.payload.Result.Decision)
+		writeBullet(&builder, "Summary", data.payload.Result.Summary)
+		writeJSONList(&builder, "Findings", data.payload.Result.Findings)
+		writeList(&builder, "Changes made", data.payload.Result.ChangesMade)
+		writeList(&builder, "Tests run", data.payload.Result.TestsRun)
+		writeList(&builder, "Needs", data.payload.Result.Needs)
+		writeList(&builder, "Next agents", data.payload.Result.NextAgents)
+	}
+
+	builder.WriteString("\n## Recent Events\n\n")
+	if len(data.recentEvents) == 0 {
+		builder.WriteString("- No job events recorded.\n")
+	} else {
+		for _, event := range data.recentEvents {
+			builder.WriteString("- `")
+			builder.WriteString(sanitizeInline(event.Kind))
+			builder.WriteString("`: ")
+			builder.WriteString(sanitizeField(event.Message))
+			builder.WriteString("\n")
+		}
+	}
+
+	builder.WriteString("\n## Redaction Notes\n\n")
+	for _, note := range report.RedactionSummary.Notes {
+		builder.WriteString("- ")
+		builder.WriteString(sanitizeField(note))
+		builder.WriteString("\n")
+	}
+	if report.RedactionSummary.RawOutputsOmitted {
+		builder.WriteString("- Raw runtime outputs omitted: ")
+		builder.WriteString(strconv.Itoa(report.RedactionSummary.RawOutputCount))
+		builder.WriteString(" retained locally.\n")
+	}
+	if report.RedactionSummary.RecentEventCount > report.RedactionSummary.IncludedEventCount {
+		builder.WriteString("- Recent events truncated to the latest ")
+		builder.WriteString(strconv.Itoa(report.RedactionSummary.IncludedEventCount))
+		builder.WriteString(" of ")
+		builder.WriteString(strconv.Itoa(report.RedactionSummary.RecentEventCount))
+		builder.WriteString(".\n")
+	}
+
+	builder.WriteString("\n## Fingerprint\n\n")
+	builder.WriteString("`")
+	builder.WriteString(report.Fingerprint)
+	builder.WriteString("`\n")
+
+	return workflow.LimitCommentBody(builder.String())
+}
+
+func writeBullet(builder *strings.Builder, label string, value string) {
+	value = sanitizeField(value)
+	if value == "" {
+		return
+	}
+	builder.WriteString("- **")
+	builder.WriteString(label)
+	builder.WriteString(":** ")
+	builder.WriteString(value)
+	builder.WriteString("\n")
+}
+
+func writeList(builder *strings.Builder, title string, values []string) {
+	items := compactStrings(values)
+	if len(items) == 0 {
+		return
+	}
+	builder.WriteString("\n### ")
+	builder.WriteString(title)
+	builder.WriteString("\n\n")
+	for _, item := range items {
+		builder.WriteString("- ")
+		builder.WriteString(sanitizeField(item))
+		builder.WriteString("\n")
+	}
+}
+
+func writeJSONList(builder *strings.Builder, title string, values []json.RawMessage) {
+	if len(values) == 0 {
+		return
+	}
+	builder.WriteString("\n### ")
+	builder.WriteString(title)
+	builder.WriteString("\n\n")
+	for _, value := range values {
+		text := sanitizeField(formatRawJSON(value))
+		if text == "" {
+			continue
+		}
+		builder.WriteString("- ")
+		builder.WriteString(text)
+		builder.WriteString("\n")
+	}
+}
+
+func formatRawJSON(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err == nil {
+		return compact.String()
+	}
+	return string(raw)
+}
+
+func taskLabel(id string, title string) string {
+	id = strings.TrimSpace(id)
+	title = strings.TrimSpace(title)
+	switch {
+	case id != "" && title != "":
+		return id + " - " + title
+	case id != "":
+		return id
+	default:
+		return title
+	}
+}
+
+func selectJobError(job db.Job, payload workflow.JobPayload, events []db.JobEvent) string {
+	terminalIndex := latestTerminalJobEventIndex(events)
+	if terminalIndex >= 0 {
+		if message := latestPriorityDiagnosticMessage(events[terminalIndex+1:]); message != "" {
+			return message
+		}
+	} else if payload.Result == nil || strings.TrimSpace(payload.Result.Summary) == "" {
+		if message := latestPriorityDiagnosticMessage(events); message != "" {
+			return message
+		}
+	}
+	if payload.Result != nil && strings.TrimSpace(payload.Result.Summary) != "" {
+		return payload.Result.Summary
+	}
+	if terminalIndex >= 0 && strings.TrimSpace(events[terminalIndex].Message) != "" {
+		return events[terminalIndex].Message
+	}
+	if message := latestPriorityDiagnosticMessage(events); message != "" {
+		return message
+	}
+	for i := len(events) - 1; i >= 0; i-- {
+		if strings.TrimSpace(events[i].Message) == "" {
+			continue
+		}
+		if isDiagnosticEvent(events[i].Kind) {
+			return events[i].Message
+		}
+	}
+	for i := len(events) - 1; i >= 0; i-- {
+		if strings.TrimSpace(events[i].Message) != "" {
+			return events[i].Message
+		}
+	}
+	if strings.TrimSpace(job.State) != "" {
+		return "job " + job.State
+	}
+	return "No error summary recorded."
+}
+
+func latestPriorityDiagnosticMessage(events []db.JobEvent) string {
+	commentPostResolved := false
+	advanceRetryResolved := false
+	for i := len(events) - 1; i >= 0; i-- {
+		kind := strings.TrimSpace(events[i].Kind)
+		switch kind {
+		case "comment_posted":
+			commentPostResolved = true
+		case "advance_completed", "advance_retried":
+			advanceRetryResolved = true
+		case "retry_queued":
+			commentPostResolved = true
+			advanceRetryResolved = true
+		}
+		if strings.TrimSpace(events[i].Message) == "" {
+			continue
+		}
+		if kind == "comment_post_failed" && commentPostResolved {
+			continue
+		}
+		if kind == "advance_retry" && advanceRetryResolved {
+			continue
+		}
+		if isPriorityDiagnosticEvent(kind) {
+			return events[i].Message
+		}
+	}
+	return ""
+}
+
+func latestTerminalJobEventIndex(events []db.JobEvent) int {
+	for i := len(events) - 1; i >= 0; i-- {
+		if isTerminalJobEvent(events[i].Kind) {
+			return i
+		}
+	}
+	return -1
+}
+
+func isTerminalJobEvent(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case string(workflow.JobSucceeded), string(workflow.JobFailed), string(workflow.JobBlocked), string(workflow.JobCancelled):
+		return true
+	default:
+		return false
+	}
+}
+
+func isPriorityDiagnosticEvent(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case "malformed_output", "repair_retry", "permission_blocked", "comment_post_failed",
+		"advance_blocked", "advance_retry", "runtime_lock_wait", "cancel_settled":
+		return true
+	default:
+		return false
+	}
+}
+
+func isDiagnosticEvent(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case string(workflow.JobFailed), string(workflow.JobBlocked), string(workflow.JobCancelled),
+		"malformed_output", "repair_retry", "permission_blocked", "comment_post_failed",
+		"advance_blocked", "advance_retry", "runtime_lock_wait", "cancel_settled":
+		return true
+	default:
+		return strings.Contains(kind, "fail") || strings.Contains(kind, "error") || strings.Contains(kind, "blocked")
+	}
+}
+
+func jobFingerprint(job db.Job, payload workflow.JobPayload, selectedError string) string {
+	values := []string{
+		SourceKindJob,
+		job.ID,
+		job.State,
+		job.Type,
+		job.Agent,
+		payload.Repo,
+		payload.TaskID,
+		strconv.Itoa(payload.PullRequest),
+		resultDecision(payload),
+		normalizeFingerprintText(selectedError),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(values, "\x00")))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func resultDecision(payload workflow.JobPayload) string {
+	if payload.Result == nil {
+		return ""
+	}
+	return payload.Result.Decision
+}
+
+func normalizeFingerprintText(value string) string {
+	value = workflow.RedactCommentText(value)
+	value = strings.TrimSpace(value)
+	value = strings.Join(strings.Fields(value), " ")
+	runes := []rune(value)
+	if len(runes) > 500 {
+		value = string(runes[:500])
+	}
+	return value
+}
+
+func tailEvents(events []db.JobEvent, limit int) []db.JobEvent {
+	if limit <= 0 || len(events) <= limit {
+		return append([]db.JobEvent(nil), events...)
+	}
+	return append([]db.JobEvent(nil), events[len(events)-limit:]...)
+}
+
+func compactStrings(values []string) []string {
+	output := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			output = append(output, value)
+		}
+	}
+	return output
+}
+
+func sanitizeField(value string) string {
+	return workflow.LimitCommentText(value)
+}
+
+func sanitizeBlock(value string) string {
+	return workflow.LimitCommentText(value)
+}
+
+func sanitizeInline(value string) string {
+	return strings.ReplaceAll(sanitizeField(value), "`", "'")
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,0 +1,467 @@
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func TestBuildJobReportFormatsRedactedJobReport(t *testing.T) {
+	ctx := context.Background()
+	store := openReportStore(t)
+	defer store.Close()
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "audit", Runtime: "codex", RepoScope: "owner/repo"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	payload := workflow.JobPayload{
+		Repo:         "owner/repo",
+		Branch:       "task-1-password=plain-branch-password",
+		HeadSHA:      "abc123",
+		PullRequest:  7,
+		TaskID:       "task-1",
+		TaskTitle:    "Fix report bug token=plain-task-token",
+		Sender:       "planner",
+		LeadAgent:    "lead",
+		Reviewers:    []string{"audit"},
+		Constraints:  []string{"do not leak token=ghp_abcdefghijklmnopqrstuvwxyz123456"},
+		Instructions: "Reproduce the failure.\n/gitmoot merge\napi_key=plain-api-key-value",
+		Result: &workflow.AgentResult{
+			Decision: "failed",
+			Summary:  "delivery failed password=plain-password-value oauth_token=plain-oauth-value",
+			Findings: []json.RawMessage{
+				json.RawMessage(`{"body":"AWS_SECRET_ACCESS_KEY=plain-aws-secret"}`),
+			},
+			Needs: []string{"rerun with auth_token=plain-auth-value"},
+		},
+		RawOutputs: []string{"raw token ghp_abcdefghijklmnopqrstuvwxyz123456 password=raw-secret"},
+	}
+	seedReportJob(t, store, db.Job{
+		ID:      "job-failed",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobFailed),
+		Payload: mustReportPayload(t, payload),
+	}, "failed with ghp_abcdefghijklmnopqrstuvwxyz123456")
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-failed", Kind: "malformed_output", Message: "bad output with AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+
+	report, err := BuildJobReport(ctx, store, "job-failed", JobOptions{})
+	if err != nil {
+		t.Fatalf("BuildJobReport returned error: %v", err)
+	}
+
+	for _, want := range []string{
+		"<!-- gitmoot:dashboard-report fingerprint:",
+		"## Summary",
+		"- **Repository:** owner/repo",
+		"- **Agent:** audit",
+		"- **Runtime:** codex",
+		"- **Action:** ask",
+		"- **Pull request:** #7",
+		"- **Task:** task-1 - Fix report bug token=[REDACTED]",
+		"## Agent Result",
+		"- **Decision:** failed",
+		"## Recent Events",
+		"Raw runtime outputs omitted: 1 retained locally.",
+		`\/gitmoot merge`,
+	} {
+		if !strings.Contains(report.Body, want) {
+			t.Fatalf("report body missing %q:\n%s", want, report.Body)
+		}
+	}
+	for _, leaked := range []string{
+		"ghp_abcdefghijklmnopqrstuvwxyz123456",
+		"plain-api-key-value",
+		"plain-password-value",
+		"plain-oauth-value",
+		"plain-auth-value",
+		"plain-branch-password",
+		"plain-task-token",
+		"plain-aws-secret",
+		"AKIAIOSFODNN7EXAMPLE",
+		"raw token",
+		"raw-secret",
+	} {
+		if strings.Contains(report.Body, leaked) {
+			t.Fatalf("report leaked %q:\n%s", leaked, report.Body)
+		}
+	}
+	if report.Title != "Gitmoot failed job ask for audit in owner/repo" {
+		t.Fatalf("title = %q", report.Title)
+	}
+	if report.Fingerprint == "" || !strings.Contains(report.Body, report.Fingerprint) {
+		t.Fatalf("fingerprint missing from report: %+v\n%s", report, report.Body)
+	}
+	if got := strings.Join(report.Labels, ","); got != "gitmoot-dashboard-report,bug" {
+		t.Fatalf("labels = %q", got)
+	}
+	if !report.RedactionSummary.RawOutputsOmitted || report.RedactionSummary.RawOutputCount != 1 {
+		t.Fatalf("redaction summary = %+v", report.RedactionSummary)
+	}
+	if strings.Contains(report.Source.TaskTitle, "plain-task-token") || strings.Contains(report.Source.Branch, "plain-branch-password") {
+		t.Fatalf("source metadata leaked secrets: %+v", report.Source)
+	}
+	if !strings.Contains(report.Source.TaskTitle, "[REDACTED]") || !strings.Contains(report.Source.Branch, "[REDACTED]") {
+		t.Fatalf("source metadata was not redacted: %+v", report.Source)
+	}
+}
+
+func TestBuildJobReportTruncatesLongRenderedFieldsAndOmitsRawOutput(t *testing.T) {
+	ctx := context.Background()
+	store := openReportStore(t)
+	defer store.Close()
+	longSummary := strings.Repeat("x", 2500)
+	payload := workflow.JobPayload{
+		Repo: "owner/repo",
+		Result: &workflow.AgentResult{
+			Decision: "blocked",
+			Summary:  longSummary,
+		},
+		RawOutputs: []string{strings.Repeat("raw output ", 400)},
+	}
+	seedReportJob(t, store, db.Job{
+		ID:      "job-blocked",
+		Agent:   "planner",
+		Type:    "ask",
+		State:   string(workflow.JobBlocked),
+		Payload: mustReportPayload(t, payload),
+	}, "blocked")
+
+	report, err := BuildJobReport(ctx, store, "job-blocked", JobOptions{})
+	if err != nil {
+		t.Fatalf("BuildJobReport returned error: %v", err)
+	}
+	if !strings.Contains(report.Body, "[truncated]") {
+		t.Fatalf("report did not truncate long summary:\n%s", report.Body)
+	}
+	if strings.Contains(report.Body, "raw output raw output") {
+		t.Fatalf("report included raw output:\n%s", report.Body)
+	}
+	if !strings.Contains(report.Body, "Raw runtime outputs omitted: 1 retained locally.") {
+		t.Fatalf("report missing raw-output omission note:\n%s", report.Body)
+	}
+}
+
+func TestBuildJobReportCapsTotalBody(t *testing.T) {
+	ctx := context.Background()
+	store := openReportStore(t)
+	defer store.Close()
+	findings := make([]json.RawMessage, 50)
+	for i := range findings {
+		findings[i] = json.RawMessage(`"` + strings.Repeat("finding text ", 250) + `"`)
+	}
+	payload := workflow.JobPayload{
+		Repo: "owner/repo",
+		Result: &workflow.AgentResult{
+			Decision: "failed",
+			Summary:  "large result",
+			Findings: findings,
+		},
+	}
+	seedReportJob(t, store, db.Job{
+		ID:      "job-large",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(workflow.JobFailed),
+		Payload: mustReportPayload(t, payload),
+	}, "failed")
+
+	report, err := BuildJobReport(ctx, store, "job-large", JobOptions{})
+	if err != nil {
+		t.Fatalf("BuildJobReport returned error: %v", err)
+	}
+	if len([]rune(report.Body)) > 60000 {
+		t.Fatalf("report body length = %d, want <= 60000", len([]rune(report.Body)))
+	}
+	if !strings.Contains(report.Body, "comment truncated") {
+		t.Fatalf("report did not include total-body truncation notice")
+	}
+	if !strings.Contains(report.Body, "<!-- gitmoot:dashboard-report fingerprint:") {
+		t.Fatalf("truncated report lost fingerprint marker:\n%s", report.Body)
+	}
+}
+
+func TestBuildJobReportFingerprintStableAndMateriallyChanges(t *testing.T) {
+	ctx := context.Background()
+	store := openReportStore(t)
+	defer store.Close()
+	payload := workflow.JobPayload{
+		Repo: "owner/repo",
+		Result: &workflow.AgentResult{
+			Decision: "failed",
+			Summary:  "first failure",
+		},
+	}
+	seedReportJob(t, store, db.Job{
+		ID:      "job-fingerprint",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(workflow.JobFailed),
+		Payload: mustReportPayload(t, payload),
+	}, "failed")
+
+	first, err := BuildJobReport(ctx, store, "job-fingerprint", JobOptions{})
+	if err != nil {
+		t.Fatalf("BuildJobReport first returned error: %v", err)
+	}
+	second, err := BuildJobReport(ctx, store, "job-fingerprint", JobOptions{})
+	if err != nil {
+		t.Fatalf("BuildJobReport second returned error: %v", err)
+	}
+	if first.Fingerprint != second.Fingerprint {
+		t.Fatalf("fingerprint unstable: %q != %q", first.Fingerprint, second.Fingerprint)
+	}
+
+	payload.Result.Summary = "second failure"
+	if err := store.UpdateJobPayload(ctx, "job-fingerprint", mustReportPayload(t, payload)); err != nil {
+		t.Fatalf("UpdateJobPayload returned error: %v", err)
+	}
+	changed, err := BuildJobReport(ctx, store, "job-fingerprint", JobOptions{})
+	if err != nil {
+		t.Fatalf("BuildJobReport changed returned error: %v", err)
+	}
+	if changed.Fingerprint == first.Fingerprint {
+		t.Fatalf("fingerprint did not change for material error change: %q", changed.Fingerprint)
+	}
+}
+
+func TestBuildJobReportPrefersInfrastructureDiagnosticOverResultSummary(t *testing.T) {
+	ctx := context.Background()
+	store := openReportStore(t)
+	defer store.Close()
+	payload := workflow.JobPayload{
+		Repo: "owner/repo",
+		Result: &workflow.AgentResult{
+			Decision: "approved",
+			Summary:  "agent completed successfully",
+		},
+	}
+	seedReportJob(t, store, db.Job{
+		ID:      "job-comment-failed",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobFailed),
+		Payload: mustReportPayload(t, payload),
+	}, "job failed")
+
+	before, err := BuildJobReport(ctx, store, "job-comment-failed", JobOptions{})
+	if err != nil {
+		t.Fatalf("BuildJobReport before returned error: %v", err)
+	}
+	if before.SelectedErrorText != "agent completed successfully" {
+		t.Fatalf("selected error before infra event = %q", before.SelectedErrorText)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-comment-failed", Kind: "comment_post_failed", Message: "temporary github error"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+
+	after, err := BuildJobReport(ctx, store, "job-comment-failed", JobOptions{})
+	if err != nil {
+		t.Fatalf("BuildJobReport after returned error: %v", err)
+	}
+	if after.SelectedErrorText != "temporary github error" {
+		t.Fatalf("selected error after infra event = %q", after.SelectedErrorText)
+	}
+	if after.Fingerprint == before.Fingerprint {
+		t.Fatalf("fingerprint did not change after priority diagnostic event: %q", after.Fingerprint)
+	}
+}
+
+func TestBuildJobReportDoesNotLetStaleTransientDiagnosticMaskFinalFailure(t *testing.T) {
+	ctx := context.Background()
+	store := openReportStore(t)
+	defer store.Close()
+
+	tests := []struct {
+		name         string
+		jobID        string
+		finalPayload workflow.JobPayload
+		finalMessage string
+		want         string
+	}{
+		{
+			name:  "result summary wins after stale wait",
+			jobID: "job-stale-wait-summary",
+			finalPayload: workflow.JobPayload{
+				Repo: "owner/repo",
+				Result: &workflow.AgentResult{
+					Decision: "failed",
+					Summary:  "final optimizer failed",
+				},
+			},
+			finalMessage: "job failed",
+			want:         "final optimizer failed",
+		},
+		{
+			name:         "terminal message wins after stale retry",
+			jobID:        "job-stale-retry-terminal",
+			finalPayload: workflow.JobPayload{Repo: "owner/repo"},
+			finalMessage: "adapter exited with status 2",
+			want:         "adapter exited with status 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := store.CreateJobWithEvent(ctx, db.Job{
+				ID:      tt.jobID,
+				Agent:   "audit",
+				Type:    "ask",
+				State:   string(workflow.JobQueued),
+				Payload: mustReportPayload(t, workflow.JobPayload{Repo: "owner/repo"}),
+			}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "queued"}); err != nil {
+				t.Fatalf("CreateJobWithEvent returned error: %v", err)
+			}
+			if err := store.AddJobEvent(ctx, db.JobEvent{JobID: tt.jobID, Kind: "runtime_lock_wait", Message: "runtime session busy"}); err != nil {
+				t.Fatalf("AddJobEvent returned error: %v", err)
+			}
+			transitioned, err := store.TransitionJobStatePayloadWithEvent(ctx, tt.jobID, string(workflow.JobQueued), string(workflow.JobFailed), mustReportPayload(t, tt.finalPayload), db.JobEvent{
+				Kind:    string(workflow.JobFailed),
+				Message: tt.finalMessage,
+			})
+			if err != nil {
+				t.Fatalf("TransitionJobStatePayloadWithEvent returned error: %v", err)
+			}
+			if !transitioned {
+				t.Fatal("TransitionJobStatePayloadWithEvent did not transition")
+			}
+
+			report, err := BuildJobReport(ctx, store, tt.jobID, JobOptions{})
+			if err != nil {
+				t.Fatalf("BuildJobReport returned error: %v", err)
+			}
+			if report.SelectedErrorText != tt.want {
+				t.Fatalf("selected error = %q, want %q", report.SelectedErrorText, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildJobReportIgnoresResolvedPostTerminalDiagnostics(t *testing.T) {
+	ctx := context.Background()
+	store := openReportStore(t)
+	defer store.Close()
+
+	tests := []struct {
+		name   string
+		jobID  string
+		events []db.JobEvent
+	}{
+		{
+			name:  "comment post recovered",
+			jobID: "job-comment-recovered",
+			events: []db.JobEvent{
+				{Kind: "comment_post_failed", Message: "temporary github error"},
+				{Kind: "comment_posted", Message: "posted attributed PR result comment"},
+			},
+		},
+		{
+			name:  "advance retry recovered",
+			jobID: "job-advance-recovered",
+			events: []db.JobEvent{
+				{Kind: "advance_retry", Message: "post-delivery workflow retry failed"},
+				{Kind: "advance_retried", Message: "post-delivery workflow retry completed"},
+				{Kind: "advance_completed", Message: "workflow advancement completed"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := workflow.JobPayload{
+				Repo: "owner/repo",
+				Result: &workflow.AgentResult{
+					Decision: "approved",
+					Summary:  "agent completed successfully",
+				},
+			}
+			seedReportJob(t, store, db.Job{
+				ID:      tt.jobID,
+				Agent:   "audit",
+				Type:    "ask",
+				State:   string(workflow.JobSucceeded),
+				Payload: mustReportPayload(t, payload),
+			}, "job succeeded")
+			for _, event := range tt.events {
+				event.JobID = tt.jobID
+				if err := store.AddJobEvent(ctx, event); err != nil {
+					t.Fatalf("AddJobEvent returned error: %v", err)
+				}
+			}
+
+			report, err := BuildJobReport(ctx, store, tt.jobID, JobOptions{})
+			if err != nil {
+				t.Fatalf("BuildJobReport returned error: %v", err)
+			}
+			if report.SelectedErrorText != "agent completed successfully" {
+				t.Fatalf("selected error = %q, want result summary", report.SelectedErrorText)
+			}
+		})
+	}
+}
+
+func TestBuildJobReportUsesRecentEventsLimit(t *testing.T) {
+	ctx := context.Background()
+	store := openReportStore(t)
+	defer store.Close()
+	seedReportJob(t, store, db.Job{
+		ID:      "job-events",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobCancelled),
+		Payload: mustReportPayload(t, workflow.JobPayload{Repo: "owner/repo"}),
+	}, "queued")
+	for _, event := range []db.JobEvent{
+		{JobID: "job-events", Kind: "one", Message: "first"},
+		{JobID: "job-events", Kind: "two", Message: "second"},
+		{JobID: "job-events", Kind: "cancelled", Message: "third"},
+	} {
+		if err := store.AddJobEvent(ctx, event); err != nil {
+			t.Fatalf("AddJobEvent returned error: %v", err)
+		}
+	}
+
+	report, err := BuildJobReport(ctx, store, "job-events", JobOptions{RecentEventLimit: 2})
+	if err != nil {
+		t.Fatalf("BuildJobReport returned error: %v", err)
+	}
+	if strings.Contains(report.Body, "`queued`: queued") || strings.Contains(report.Body, "`one`: first") {
+		t.Fatalf("report included events outside limit:\n%s", report.Body)
+	}
+	for _, want := range []string{"`two`: second", "`cancelled`: third", "Recent events truncated to the latest 2 of 4."} {
+		if !strings.Contains(report.Body, want) {
+			t.Fatalf("report missing %q:\n%s", want, report.Body)
+		}
+	}
+}
+
+func openReportStore(t *testing.T) *db.Store {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	return store
+}
+
+func seedReportJob(t *testing.T, store *db.Store, job db.Job, message string) {
+	t.Helper()
+	if err := store.CreateJobWithEvent(context.Background(), job, db.JobEvent{Kind: job.State, Message: message}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+}
+
+func mustReportPayload(t *testing.T, payload workflow.JobPayload) string {
+	t.Helper()
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	return string(encoded)
+}

--- a/internal/workflow/job_comment.go
+++ b/internal/workflow/job_comment.go
@@ -127,6 +127,18 @@ func formatFinding(raw json.RawMessage) string {
 	return string(raw)
 }
 
+// LimitCommentText applies the same redaction, truncation, and command
+// neutralization used for GitHub job result comments.
+func LimitCommentText(value string) string {
+	return limitCommentText(value)
+}
+
+// LimitCommentBody applies the same total body cap used for GitHub job result
+// comments, including redaction and command neutralization.
+func LimitCommentBody(value string) string {
+	return limitCommentBody(value)
+}
+
 func limitCommentText(value string) string {
 	value = RedactCommentText(value)
 	value = strings.TrimSpace(value)


### PR DESCRIPTION
## WHAT

Adds the shared bug-report builder for Gitmoot job failures and dashboard/CLI bug-report flows.

## WHY

Issue #289 needs a common redacted issue-draft surface before the dashboard button and CLI command can create reports consistently.

## CHANGES

- Added `internal/report` with `BuildJobReport`, report metadata, labels, stable fingerprints, markdown rendering, recent-event truncation, and raw-output omission.
- Reused workflow GitHub-comment redaction by exporting `workflow.LimitCommentText` and `workflow.LimitCommentBody`.
- Added tests covering redaction, metadata sanitization, raw-output omission, body caps, command neutralization, fingerprint stability, transient diagnostic ordering, and recovered diagnostic events.

## RESULTS

- `/tmp/go1.26.4/bin/go test ./internal/report ./internal/workflow` passed.
- `/tmp/go1.26.4/bin/go test ./internal/...` passed.
- `git diff --check` passed.
- `codex exec review --uncommitted` final raw output:

```text
I found no discrete correctness issues in the reviewed staged, unstaged, or untracked changes. Test execution was blocked by the sandbox because Go tried to download the 1.26 toolchain into a read-only module cache, so this verdict is based on static review.
I found no discrete correctness issues in the reviewed staged, unstaged, or untracked changes. Test execution was blocked by the sandbox because Go tried to download the 1.26 toolchain into a read-only module cache, so this verdict is based on static review.
```

## RISK

Local default `go` is 1.22.2 while this repo declares `go 1.26`, so verification used the local Go 1.26.4 binary at `/tmp/go1.26.4/bin/go`. The new report package is not wired into user-facing commands yet; Tasks 2 and 3 will consume it.

Part of #289.