### PR TITLE
feat: add bug report CLI

### DIFF
--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -1,0 +1,202 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/report"
+)
+
+type reportGitHubClient interface {
+	Preflight(ctx context.Context, repo github.Repository) error
+	SearchOpenIssues(ctx context.Context, repo github.Repository, text string) ([]github.Issue, error)
+	CreateIssue(ctx context.Context, input github.CreateIssueInput) (github.Issue, error)
+}
+
+var newReportGitHubClient = func() reportGitHubClient {
+	return github.NewClient("")
+}
+
+var reportIssueRepo = github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+
+func runReport(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printReportUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "bug":
+		return runReportBug(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown report command %q\n\n", args[0])
+		printReportUsage(stderr)
+		return 2
+	}
+}
+
+func printReportUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot report bug --job <job-id> [--preview]")
+	fmt.Fprintln(w, "  gitmoot report bug --job <job-id> --create --yes")
+	fmt.Fprintln(w, "  gitmoot report bug --source daemon --preview")
+	fmt.Fprintln(w, "  gitmoot report bug --source dashboard --preview")
+	fmt.Fprintln(w, "  gitmoot report bug --train <session-id> --create --yes")
+}
+
+type reportBugOptions struct {
+	home    string
+	jobID   string
+	source  string
+	trainID string
+	preview bool
+	create  bool
+	yes     bool
+}
+
+func runReportBug(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("report bug", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	options := reportBugOptions{}
+	fs.StringVar(&options.home, "home", "", "home directory to use instead of the current user's home")
+	fs.StringVar(&options.jobID, "job", "", "job id to build a report from")
+	fs.StringVar(&options.source, "source", "", "future report source: daemon or dashboard")
+	fs.StringVar(&options.trainID, "train", "", "future SkillOpt train session id to build a report from")
+	fs.BoolVar(&options.preview, "preview", false, "print the report without creating a GitHub issue")
+	fs.BoolVar(&options.create, "create", false, "create a GitHub issue")
+	fs.BoolVar(&options.yes, "yes", false, "confirm non-interactive issue creation")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "report bug does not accept positional arguments")
+		return 2
+	}
+	if err := validateReportBugOptions(options); err != nil {
+		fmt.Fprintf(stderr, "report bug: %v\n", err)
+		return 2
+	}
+	if !options.create {
+		options.preview = true
+	}
+
+	draft, err := buildBugReport(context.Background(), options)
+	if err != nil {
+		fmt.Fprintf(stderr, "report bug: %v\n", err)
+		return 1
+	}
+	if options.preview {
+		printReportPreview(stdout, draft)
+		return 0
+	}
+	return createBugReportIssue(context.Background(), stdout, stderr, draft)
+}
+
+func validateReportBugOptions(options reportBugOptions) error {
+	if options.preview && options.create {
+		return errors.New("--preview and --create are mutually exclusive")
+	}
+	if options.create && !options.yes {
+		return errors.New("--create requires --yes")
+	}
+	sourceCount := 0
+	if strings.TrimSpace(options.jobID) != "" {
+		sourceCount++
+	}
+	if strings.TrimSpace(options.source) != "" {
+		sourceCount++
+	}
+	if strings.TrimSpace(options.trainID) != "" {
+		sourceCount++
+	}
+	if sourceCount == 0 {
+		return errors.New("a source is required (--job, --source daemon, --source dashboard, or --train)")
+	}
+	if sourceCount > 1 {
+		return errors.New("only one source may be specified")
+	}
+	return nil
+}
+
+func buildBugReport(ctx context.Context, options reportBugOptions) (report.Report, error) {
+	if jobID := strings.TrimSpace(options.jobID); jobID != "" {
+		var draft report.Report
+		err := withStore(options.home, func(store *db.Store) error {
+			var err error
+			draft, err = report.BuildJobReport(ctx, store, jobID, report.JobOptions{})
+			return err
+		})
+		return draft, err
+	}
+	if source := strings.TrimSpace(options.source); source != "" {
+		switch source {
+		case "daemon", "dashboard":
+			return report.Report{}, fmt.Errorf("source %s is not supported yet", source)
+		default:
+			return report.Report{}, fmt.Errorf("source %s is not supported", source)
+		}
+	}
+	if trainID := strings.TrimSpace(options.trainID); trainID != "" {
+		return report.Report{}, fmt.Errorf("source train is not supported yet for session %s", trainID)
+	}
+	return report.Report{}, errors.New("source is required")
+}
+
+func printReportPreview(w io.Writer, draft report.Report) {
+	fmt.Fprintf(w, "Title: %s\n", draft.Title)
+	fmt.Fprintf(w, "Labels: %s\n", strings.Join(draft.Labels, ", "))
+	fmt.Fprintf(w, "Fingerprint: %s\n\n", draft.Fingerprint)
+	fmt.Fprintln(w, "Body:")
+	fmt.Fprint(w, draft.Body)
+	if !strings.HasSuffix(draft.Body, "\n") {
+		fmt.Fprintln(w)
+	}
+}
+
+func createBugReportIssue(ctx context.Context, stdout, stderr io.Writer, draft report.Report) int {
+	gh := newReportGitHubClient()
+	if err := gh.Preflight(ctx, reportIssueRepo); err != nil {
+		fmt.Fprintf(stderr, "report bug: %v\n", err)
+		return 1
+	}
+	marker := report.FingerprintMarker(draft.Fingerprint)
+	matches, err := gh.SearchOpenIssues(ctx, reportIssueRepo, marker)
+	if err != nil {
+		fmt.Fprintf(stderr, "warning: duplicate search failed: %v\n", err)
+	} else if existing, ok := matchingIssueByMarker(matches, marker); ok {
+		fmt.Fprintf(stdout, "existing issue: %s\n", existing.URL)
+		return 0
+	}
+	issue, err := gh.CreateIssue(ctx, github.CreateIssueInput{
+		Repo:   reportIssueRepo,
+		Title:  draft.Title,
+		Body:   draft.Body,
+		Labels: draft.Labels,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "report bug: create issue: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "created issue: %s\n", issue.URL)
+	return 0
+}
+
+func matchingIssueByMarker(issues []github.Issue, marker string) (github.Issue, bool) {
+	for _, issue := range issues {
+		if strings.TrimSpace(issue.URL) == "" {
+			continue
+		}
+		if issue.Body == "" || strings.Contains(issue.Body, marker) {
+			return issue, true
+		}
+	}
+	return github.Issue{}, false
+}

--- a/internal/cli/report_test.go
+++ b/internal/cli/report_test.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func TestReportBugJobPreviewDefaultsToPreview(t *testing.T) {
+	home := seedCLIReportJob(t)
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"report", "bug", "--home", home, "--job", "job-failed"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("report bug preview exit code = %d, stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"Title: Gitmoot failed job ask for audit in owner/repo",
+		"Labels: gitmoot-dashboard-report, bug",
+		"Fingerprint: ",
+		"<!-- gitmoot:dashboard-report fingerprint:",
+		"## Recent Events",
+		"failed during delivery",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("preview output missing %q:\n%s", want, output)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestReportBugCreateRequiresYes(t *testing.T) {
+	home := seedCLIReportJob(t)
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"report", "bug", "--home", home, "--job", "job-failed", "--create"}, &stdout, &stderr)
+
+	if code != 2 {
+		t.Fatalf("report bug --create exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "--create requires --yes") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestReportBugUnsupportedSourcesNameSource(t *testing.T) {
+	for _, args := range [][]string{
+		{"report", "bug", "--source", "daemon", "--preview"},
+		{"report", "bug", "--source", "dashboard", "--preview"},
+		{"report", "bug", "--train", "train-1", "--preview"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			code := Run(args, &stdout, &stderr)
+
+			if code != 1 {
+				t.Fatalf("exit code = %d, stderr=%s", code, stderr.String())
+			}
+			output := stderr.String()
+			if !strings.Contains(output, "source daemon") && !strings.Contains(output, "source dashboard") && !strings.Contains(output, "source train") {
+				t.Fatalf("stderr does not name source: %q", output)
+			}
+		})
+	}
+}
+
+func TestReportBugJobCreateCreatesIssueWithLabels(t *testing.T) {
+	home := seedCLIReportJob(t)
+	fake := &reportFakeGitHub{
+		createdIssue: github.Issue{Number: 289, URL: "https://github.com/jerryfane/gitmoot/issues/289"},
+	}
+	restore := replaceReportGitHubClient(fake)
+	defer restore()
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"report", "bug", "--home", home, "--job", "job-failed", "--create", "--yes"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("report bug create exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if stdout.String() != "created issue: https://github.com/jerryfane/gitmoot/issues/289\n" {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if len(fake.preflightRepos) != 1 || fake.preflightRepos[0].FullName() != "jerryfane/gitmoot" {
+		t.Fatalf("preflight repos = %+v", fake.preflightRepos)
+	}
+	if len(fake.searches) != 1 || !strings.Contains(fake.searches[0], "gitmoot:dashboard-report fingerprint:") {
+		t.Fatalf("searches = %+v", fake.searches)
+	}
+	if fake.createInput.Repo.FullName() != "jerryfane/gitmoot" ||
+		!strings.Contains(fake.createInput.Body, "<!-- gitmoot:dashboard-report fingerprint:") ||
+		strings.Join(fake.createInput.Labels, ",") != "gitmoot-dashboard-report,bug" {
+		t.Fatalf("create input = %+v", fake.createInput)
+	}
+}
+
+func TestReportBugJobCreateReturnsExistingIssueForDuplicate(t *testing.T) {
+	home := seedCLIReportJob(t)
+	fake := &reportFakeGitHub{
+		searchIssues: []github.Issue{{
+			Number: 289,
+			URL:    "https://github.com/jerryfane/gitmoot/issues/289",
+		}},
+	}
+	restore := replaceReportGitHubClient(fake)
+	defer restore()
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"report", "bug", "--home", home, "--job", "job-failed", "--create", "--yes"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("report bug duplicate exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if stdout.String() != "existing issue: https://github.com/jerryfane/gitmoot/issues/289\n" {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if fake.createCalled {
+		t.Fatal("duplicate report should not create a new issue")
+	}
+}
+
+func seedCLIReportJob(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 7,
+		TaskID:      "task-1",
+		TaskTitle:   "Fix bug reporting",
+		Result: &workflow.AgentResult{
+			Decision: "failed",
+			Summary:  "failed during delivery",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(context.Background(), db.Job{
+		ID:      "job-failed",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobFailed),
+		Payload: string(payload),
+	}, db.JobEvent{Kind: string(workflow.JobFailed), Message: "failed during delivery"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	return home
+}
+
+func replaceReportGitHubClient(client reportGitHubClient) func() {
+	prev := newReportGitHubClient
+	newReportGitHubClient = func() reportGitHubClient { return client }
+	return func() { newReportGitHubClient = prev }
+}
+
+type reportFakeGitHub struct {
+	github.NoopClient
+
+	preflightRepos []github.Repository
+	searches       []string
+	searchIssues   []github.Issue
+	searchErr      error
+	createInput    github.CreateIssueInput
+	createdIssue   github.Issue
+	createErr      error
+	createCalled   bool
+}
+
+func (f *reportFakeGitHub) Preflight(_ context.Context, repo github.Repository) error {
+	f.preflightRepos = append(f.preflightRepos, repo)
+	return nil
+}
+
+func (f *reportFakeGitHub) SearchOpenIssues(_ context.Context, _ github.Repository, text string) ([]github.Issue, error) {
+	f.searches = append(f.searches, text)
+	if f.searchErr != nil {
+		return nil, f.searchErr
+	}
+	return append([]github.Issue(nil), f.searchIssues...), nil
+}
+
+func (f *reportFakeGitHub) CreateIssue(_ context.Context, input github.CreateIssueInput) (github.Issue, error) {
+	f.createCalled = true
+	f.createInput = input
+	if f.createErr != nil {
+		return github.Issue{}, f.createErr
+	}
+	if f.createdIssue.URL == "" {
+		return github.Issue{Number: 1, URL: "https://github.com/jerryfane/gitmoot/issues/1"}, nil
+	}
+	return f.createdIssue, nil
+}
+
+var _ reportGitHubClient = (*reportFakeGitHub)(nil)
+
+func TestReportBugContinuesWhenDuplicateSearchFails(t *testing.T) {
+	home := seedCLIReportJob(t)
+	fake := &reportFakeGitHub{
+		searchErr:    errors.New("search unavailable"),
+		createdIssue: github.Issue{Number: 290, URL: "https://github.com/jerryfane/gitmoot/issues/290"},
+	}
+	restore := replaceReportGitHubClient(fake)
+	defer restore()
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"report", "bug", "--home", home, "--job", "job-failed", "--create", "--yes"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("report bug search failure exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "warning: duplicate search failed: search unavailable") {
+		t.Fatalf("stderr missing warning: %q", stderr.String())
+	}
+	if stdout.String() != "created issue: https://github.com/jerryfane/gitmoot/issues/290\n" {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -35,6 +35,7 @@ var rootCommands = []command{
 	{name: "goal", summary: "import or inspect goals", run: runGoal},
 	{name: "task", summary: "run or inspect tasks", run: runTask},
 	{name: "job", summary: "inspect and recover jobs", run: runJob},
+	{name: "report", summary: "build and file bug reports", run: runReport},
 	{name: "lock", summary: "inspect and release branch locks", run: runLock},
 	{name: "interactive", summary: "inspect and answer interactive prompts", run: runInteractive},
 	{name: "dashboard", summary: "show a snapshot of local Gitmoot state", run: runDashboard},

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -53,7 +53,7 @@ func TestRunInitCreatesState(t *testing.T) {
 }
 
 func TestRunSubcommandHelpSucceeds(t *testing.T) {
-	for _, command := range []string{"init", "doctor", "version", "config", "update", "setup", "repo", "agent", "plugin", "events", "job", "lock", "skillopt"} {
+	for _, command := range []string{"init", "doctor", "version", "config", "update", "setup", "repo", "agent", "plugin", "events", "job", "report", "lock", "skillopt"} {
 		t.Run(command, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -149,12 +149,14 @@ type Issue struct {
 	Title  string `json:"title"`
 	State  string `json:"state"`
 	URL    string `json:"html_url"`
+	Body   string `json:"body"`
 }
 
 type CreateIssueInput struct {
-	Repo  Repository
-	Title string
-	Body  string
+	Repo   Repository
+	Title  string
+	Body   string
+	Labels []string
 }
 
 type CreatePullRequestInput struct {
@@ -468,13 +470,83 @@ func (c *GhClient) PostIssueComment(ctx context.Context, repo Repository, issueN
 	return comment, err
 }
 
+func (c *GhClient) SearchOpenIssues(ctx context.Context, repo Repository, text string) ([]Issue, error) {
+	if strings.TrimSpace(repo.FullName()) == "" {
+		return nil, fmt.Errorf("repository owner/name is required")
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil, fmt.Errorf("issue search text is required")
+	}
+	var response struct {
+		Items []Issue `json:"items"`
+	}
+	query := fmt.Sprintf("repo:%s is:issue is:open in:body %q", repo.FullName(), text)
+	err := c.apiJSON(ctx, false, &response, "-X", "GET", "search/issues", "-f", "q="+query)
+	return response.Items, err
+}
+
 func (c *GhClient) CreateIssue(ctx context.Context, input CreateIssueInput) (Issue, error) {
 	var issue Issue
 	err := c.apiJSON(ctx, true, &issue,
 		endpoint(input.Repo, "issues"),
 		"-f", "title="+input.Title,
 		"-f", "body="+input.Body)
-	return issue, err
+	if err != nil {
+		return Issue{}, err
+	}
+	c.applyIssueLabelsBestEffort(ctx, input.Repo, issue.Number, input.Labels)
+	return issue, nil
+}
+
+func (c *GhClient) applyIssueLabelsBestEffort(ctx context.Context, repo Repository, issueNumber int64, labels []string) {
+	labels = compactUniqueStrings(labels)
+	if strings.TrimSpace(repo.FullName()) == "" || issueNumber <= 0 || len(labels) == 0 {
+		return
+	}
+	for _, label := range labels {
+		color, description := issueLabelMetadata(label)
+		args := []string{
+			"api",
+			endpoint(repo, "labels"),
+			"-f", "name=" + label,
+			"-f", "color=" + color,
+		}
+		if description != "" {
+			args = append(args, "-f", "description="+description)
+		}
+		_, _ = c.run(ctx, true, args...)
+	}
+	args := []string{"api", endpoint(repo, "issues", issueNumber, "labels")}
+	for _, label := range labels {
+		args = append(args, "-f", "labels[]="+label)
+	}
+	_, _ = c.run(ctx, true, args...)
+}
+
+func issueLabelMetadata(label string) (string, string) {
+	switch label {
+	case "gitmoot-dashboard-report":
+		return "5319e7", "Gitmoot-generated bug report"
+	case "bug":
+		return "d73a4a", "Something is not working"
+	default:
+		return "ededed", ""
+	}
+}
+
+func compactUniqueStrings(values []string) []string {
+	seen := map[string]bool{}
+	var compacted []string
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		compacted = append(compacted, value)
+	}
+	return compacted
 }
 
 func (c *GhClient) CloseIssue(ctx context.Context, repo Repository, issueNumber int64) (Issue, error) {
@@ -996,6 +1068,10 @@ func (NoopClient) GetPullRequest(context.Context, Repository, int64) (PullReques
 
 func (NoopClient) CreatePullRequest(context.Context, CreatePullRequestInput) (PullRequest, error) {
 	return PullRequest{}, errors.ErrUnsupported
+}
+
+func (NoopClient) SearchOpenIssues(context.Context, Repository, string) ([]Issue, error) {
+	return nil, errors.ErrUnsupported
 }
 
 func (NoopClient) CreateIssue(context.Context, CreateIssueInput) (Issue, error) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -238,6 +238,61 @@ func TestCreateIssueUsesIssuesEndpoint(t *testing.T) {
 	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/issues", "-f", "title=Review run-1", "-f", "body=body")
 }
 
+func TestCreateIssueAppliesLabelsBestEffort(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stdout: `{"number": 8, "title": "Bug", "state": "open", "html_url": "https://github.com/jerryfane/gitmoot/issues/8"}`},
+			{Stderr: "HTTP 422: Validation Failed"},
+			{Stderr: "HTTP 422: Validation Failed"},
+			{Stderr: "HTTP 422: Validation Failed"},
+		},
+		errs: []error{
+			nil,
+			errors.New("exit status 1"),
+			errors.New("exit status 1"),
+			errors.New("exit status 1"),
+		},
+	}
+	client := GhClient{Runner: runner}
+
+	issue, err := client.CreateIssue(context.Background(), CreateIssueInput{
+		Repo:   Repository{Owner: "jerryfane", Name: "gitmoot"},
+		Title:  "Bug",
+		Body:   "body",
+		Labels: []string{"gitmoot-dashboard-report", "bug"},
+	})
+
+	if err != nil {
+		t.Fatalf("CreateIssue returned error: %v", err)
+	}
+	if issue.Number != 8 {
+		t.Fatalf("issue = %+v", issue)
+	}
+	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/issues", "-f", "title=Bug", "-f", "body=body")
+	runner.wantArgs(t, 1, "api", "repos/jerryfane/gitmoot/labels", "-f", "name=gitmoot-dashboard-report", "-f", "color=5319e7", "-f", "description=Gitmoot-generated bug report")
+	runner.wantArgs(t, 2, "api", "repos/jerryfane/gitmoot/labels", "-f", "name=bug", "-f", "color=d73a4a", "-f", "description=Something is not working")
+	runner.wantArgs(t, 3, "api", "repos/jerryfane/gitmoot/issues/8/labels", "-f", "labels[]=gitmoot-dashboard-report", "-f", "labels[]=bug")
+}
+
+func TestSearchOpenIssuesUsesIssueSearchEndpoint(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"items":[{"number":8,"title":"Bug","state":"open","html_url":"https://github.com/jerryfane/gitmoot/issues/8","body":"<!-- gitmoot:dashboard-report fingerprint:abc -->"}]}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	issues, err := client.SearchOpenIssues(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, "<!-- gitmoot:dashboard-report fingerprint:abc -->")
+
+	if err != nil {
+		t.Fatalf("SearchOpenIssues returned error: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 8 || !strings.Contains(issues[0].Body, "fingerprint:abc") {
+		t.Fatalf("issues = %+v", issues)
+	}
+	runner.wantArgs(t, 0, "api", "-X", "GET", "search/issues", "-f", `q=repo:jerryfane/gitmoot is:issue is:open in:body "<!-- gitmoot:dashboard-report fingerprint:abc -->"`)
+}
+
 func TestPreflightChecksGhAuthAndRepoAccess(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -20,6 +20,8 @@ const (
 	SourceKindJob          = "job"
 	LabelDashboardReport   = "gitmoot-dashboard-report"
 	LabelBug               = "bug"
+	fingerprintMarkerStart = "<!-- gitmoot:dashboard-report fingerprint:"
+	fingerprintMarkerEnd   = " -->"
 	defaultRecentEventSize = 8
 )
 
@@ -60,6 +62,12 @@ type RedactionSummary struct {
 
 type JobOptions struct {
 	RecentEventLimit int
+}
+
+// FingerprintMarker returns the stable markdown marker used for duplicate
+// detection in GitHub issue bodies.
+func FingerprintMarker(fingerprint string) string {
+	return fingerprintMarkerStart + strings.TrimSpace(fingerprint) + fingerprintMarkerEnd
 }
 
 type jobReportData struct {
@@ -216,9 +224,8 @@ func reportTitle(job db.Job, payload workflow.JobPayload) string {
 
 func renderMarkdown(report Report, data jobReportData) string {
 	var builder strings.Builder
-	builder.WriteString("<!-- gitmoot:dashboard-report fingerprint:")
-	builder.WriteString(report.Fingerprint)
-	builder.WriteString(" -->\n\n")
+	builder.WriteString(FingerprintMarker(report.Fingerprint))
+	builder.WriteString("\n\n")
 
 	builder.WriteString("## Summary\n\n")
 	writeBullet(&builder, "Source", report.Source.Kind+" "+report.Source.ID)


### PR DESCRIPTION
## Summary
- add `gitmoot report bug` with job preview and guarded issue creation
- add duplicate detection through the report fingerprint marker
- apply `gitmoot-dashboard-report` and `bug` labels best-effort when creating reports

Part of #289.

## Verification
- `/tmp/go1.26.4/bin/go test ./internal/cli ./internal/github ./internal/report`
- `/tmp/go1.26.4/bin/go test ./internal/daemon ./internal/feedback`
- `git diff --check`
- `codex exec review --uncommitted` (clean; review could not run default Go tests because sandbox Go is 1.22 and the repo requires Go 1.26)

## Final Raw Review Output (post-merge audit reconstruction)
Reconstructed from merge commit `f0b56c902104efd37617bf7723eb71211e3fa14f` applied with `--no-commit` on parent `a8c3b744f1373893e575ad13991e699141412d20`.

```text
codex
No discrete correctness issues were identified in the staged changes.
No discrete correctness issues were identified in the staged changes.
```
