### PR TITLE
feat: add dashboard bug report action

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/doctor"
+	"github.com/jerryfane/gitmoot/internal/report"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -166,6 +167,39 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 				_, err := workflow.CancelJob(context.Background(), store, id)
 				return err
 			})
+		},
+		BugReportPreview: func(id string) (tui.BugReportPreview, error) {
+			var preview tui.BugReportPreview
+			err := withStore(home, func(store *db.Store) error {
+				draft, err := report.BuildJobReport(context.Background(), store, id, report.JobOptions{})
+				if err != nil {
+					return err
+				}
+				preview = tui.BugReportPreview{
+					Title:       draft.Title,
+					Body:        draft.Body,
+					Labels:      draft.Labels,
+					Fingerprint: draft.Fingerprint,
+				}
+				return nil
+			})
+			return preview, err
+		},
+		CreateBugReport: func(id string, preview tui.BugReportPreview) (tui.BugReportCreateResult, error) {
+			if strings.TrimSpace(id) == "" {
+				return tui.BugReportCreateResult{}, fmt.Errorf("job id is required")
+			}
+			draft := report.Report{
+				Title:       preview.Title,
+				Body:        preview.Body,
+				Labels:      append([]string(nil), preview.Labels...),
+				Fingerprint: preview.Fingerprint,
+			}
+			result, err := createBugReportIssueResult(context.Background(), newReportGitHubClient(), draft, nil)
+			if err != nil {
+				return tui.BugReportCreateResult{}, err
+			}
+			return tui.BugReportCreateResult{URL: result.URL, Existing: result.Existing}, nil
 		},
 		StopTrain: func(id, reason string) error {
 			return withStore(home, func(store *db.Store) error {

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -162,18 +162,47 @@ func printReportPreview(w io.Writer, draft report.Report) {
 }
 
 func createBugReportIssue(ctx context.Context, stdout, stderr io.Writer, draft report.Report) int {
-	gh := newReportGitHubClient()
-	if err := gh.Preflight(ctx, reportIssueRepo); err != nil {
+	result, err := createBugReportIssueResult(ctx, newReportGitHubClient(), draft, stderr)
+	if err != nil {
 		fmt.Fprintf(stderr, "report bug: %v\n", err)
 		return 1
+	}
+	if result.Existing {
+		fmt.Fprintf(stdout, "existing issue: %s\n", result.URL)
+	} else {
+		fmt.Fprintf(stdout, "created issue: %s\n", result.URL)
+	}
+	return 0
+}
+
+type bugReportIssueResult struct {
+	URL      string
+	Existing bool
+}
+
+func createBugReportIssueResult(ctx context.Context, gh reportGitHubClient, draft report.Report, warnings io.Writer) (bugReportIssueResult, error) {
+	if gh == nil {
+		return bugReportIssueResult{}, errors.New("github client is required")
+	}
+	if strings.TrimSpace(draft.Fingerprint) == "" {
+		return bugReportIssueResult{}, errors.New("bug report fingerprint is required")
+	}
+	if strings.TrimSpace(draft.Body) == "" {
+		return bugReportIssueResult{}, errors.New("bug report body is required")
+	}
+	if err := gh.Preflight(ctx, reportIssueRepo); err != nil {
+		return bugReportIssueResult{}, err
 	}
 	marker := report.FingerprintMarker(draft.Fingerprint)
 	matches, err := gh.SearchOpenIssues(ctx, reportIssueRepo, marker)
 	if err != nil {
-		fmt.Fprintf(stderr, "warning: duplicate search failed: %v\n", err)
+		if warnings != nil {
+			fmt.Fprintf(warnings, "warning: duplicate search failed: %v\n", err)
+		} else {
+			return bugReportIssueResult{}, fmt.Errorf("duplicate search failed: %w", err)
+		}
 	} else if existing, ok := matchingIssueByMarker(matches, marker); ok {
-		fmt.Fprintf(stdout, "existing issue: %s\n", existing.URL)
-		return 0
+		return bugReportIssueResult{URL: existing.URL, Existing: true}, nil
 	}
 	issue, err := gh.CreateIssue(ctx, github.CreateIssueInput{
 		Repo:   reportIssueRepo,
@@ -182,11 +211,9 @@ func createBugReportIssue(ctx context.Context, stdout, stderr io.Writer, draft r
 		Labels: draft.Labels,
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "report bug: create issue: %v\n", err)
-		return 1
+		return bugReportIssueResult{}, fmt.Errorf("create issue: %w", err)
 	}
-	fmt.Fprintf(stdout, "created issue: %s\n", issue.URL)
-	return 0
+	return bugReportIssueResult{URL: issue.URL}, nil
 }
 
 func matchingIssueByMarker(issues []github.Issue, marker string) (github.Issue, bool) {

--- a/internal/cli/report_test.go
+++ b/internal/cli/report_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/report"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -240,5 +241,26 @@ func TestReportBugContinuesWhenDuplicateSearchFails(t *testing.T) {
 	}
 	if stdout.String() != "created issue: https://github.com/jerryfane/gitmoot/issues/290\n" {
 		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestCreateBugReportIssueResultRequiresVisibleDuplicateSearchWarning(t *testing.T) {
+	fake := &reportFakeGitHub{
+		searchErr: errors.New("search unavailable"),
+	}
+	draft := report.Report{
+		Title:       "Gitmoot failed job ask for planner",
+		Body:        "<!-- gitmoot:dashboard-report fingerprint:abc123 -->\n\nbody",
+		Labels:      []string{"gitmoot-dashboard-report", "bug"},
+		Fingerprint: "abc123",
+	}
+
+	_, err := createBugReportIssueResult(context.Background(), fake, draft, nil)
+
+	if err == nil || !strings.Contains(err.Error(), "duplicate search failed: search unavailable") {
+		t.Fatalf("expected duplicate search error, got %v", err)
+	}
+	if fake.createCalled {
+		t.Fatal("must not create an issue when duplicate search failed without a warning sink")
 	}
 }

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -9,21 +9,21 @@ import (
 )
 
 // attnItem is one selectable row on the Attention page: a pending prompt or a
-// blocked/failed job.
+// blocked/failed/cancelled job.
 type attnItem struct {
 	prompt *db.InteractivePrompt
 	job    *JobRow
 }
 
 // attentionItems lists the actionable attention rows: pending prompts first,
-// then blocked/failed jobs.
+// then blocked/failed/cancelled jobs.
 func (m Model) attentionItems() []attnItem {
 	items := make([]attnItem, 0, len(m.snap.Prompts))
 	for i := range m.snap.Prompts {
 		items = append(items, attnItem{prompt: &m.snap.Prompts[i]})
 	}
 	for i := range m.snap.JobRows {
-		if m.snap.JobRows[i].State == "blocked" || m.snap.JobRows[i].State == "failed" {
+		if jobReportable(m.snap.JobRows[i].State) {
 			items = append(items, attnItem{job: &m.snap.JobRows[i]})
 		}
 	}
@@ -179,7 +179,7 @@ func answerCmd(deps Deps, id, value string) tea.Cmd {
 }
 
 // attentionContent renders the Attention page: pending prompts (selectable),
-// then blocked/failed job counts, stale resource locks, and branch locks.
+// then blocked/failed/cancelled jobs, stale resource locks, and branch locks.
 func (m Model) attentionContent() string {
 	switch m.mode {
 	case modeAnswerChoice, modeAnswerText:
@@ -235,8 +235,12 @@ func (m Model) attentionContent() string {
 			}
 			b.WriteString(cursor + line + "\n")
 		}
-		// Attention only lists blocked/failed jobs, so cancel never applies here.
-		b.WriteString(mutedStyle.Render("prompts: a answer · d dismiss   jobs: enter detail · R retry"))
+		// Attention only lists reportable terminal jobs, so cancel never applies here.
+		help := "prompts: a answer · d dismiss   jobs: enter detail · R retry"
+		if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
+			help += " · B report bug"
+		}
+		b.WriteString(mutedStyle.Render(help))
 		b.WriteByte('\n')
 		wrote = true
 	}

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -164,6 +164,20 @@ type JobDetail struct {
 	ResultSummary  string // gitmoot_result.summary
 }
 
+// BugReportPreview is a redacted issue draft shown before creating a bug report.
+type BugReportPreview struct {
+	Title       string
+	Body        string
+	Labels      []string
+	Fingerprint string
+}
+
+// BugReportCreateResult is the GitHub issue selected by create action.
+type BugReportCreateResult struct {
+	URL      string
+	Existing bool
+}
+
 // JobEventView is one entry of a job's event history shown in the detail view.
 type JobEventView struct {
 	Kind    string
@@ -218,6 +232,10 @@ type Deps struct {
 	JobDetail func(id string) (JobDetail, error)
 	RetryJob  func(id string) error
 	CancelJob func(id string) error
+	// BugReportPreview builds the redacted report preview. CreateBugReport posts
+	// the exact loaded preview draft and returns the selected issue URL.
+	BugReportPreview func(id string) (BugReportPreview, error)
+	CreateBugReport  func(id string, preview BugReportPreview) (BugReportCreateResult, error)
 
 	// StartDaemon starts the background daemon when the attention list shows it
 	// stopped.
@@ -339,6 +357,21 @@ type jobDetailMsg struct {
 	id     string
 	detail JobDetail
 	err    error
+}
+
+// bugReportPreviewMsg carries a redacted report draft for the preview overlay.
+type bugReportPreviewMsg struct {
+	id      string
+	preview BugReportPreview
+	err     error
+}
+
+// bugReportCreateMsg carries the result of creating a bug report issue.
+type bugReportCreateMsg struct {
+	id       string
+	url      string
+	existing bool
+	err      error
 }
 
 // sessionActionMsg carries the outcome of a Deps.StopSession call.

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,20 @@ func (m *Model) openJobDetail(job JobRow) tea.Cmd {
 	m.actionBusy = false
 	m.mode = modeJobDetail
 	return tea.Batch(jobEventsCmd(m.deps, job.ID), jobDetailCmd(m.deps, job.ID))
+}
+
+// openBugReportPreview enters the redacted report preview for a reportable job.
+func (m *Model) openBugReportPreview(job JobRow) tea.Cmd {
+	m.activeJob = job
+	m.bugReport = BugReportPreview{}
+	m.bugReportLoaded = false
+	m.bugReportErr = ""
+	m.bugReportURL = ""
+	m.bugReportExisting = false
+	m.actionErr = ""
+	m.actionBusy = false
+	m.mode = modeBugReportPreview
+	return bugReportPreviewCmd(m.deps, job.ID)
 }
 
 // openJobConfirm enters the retry or cancel confirmation for the given job.
@@ -59,6 +74,10 @@ func jobRetryable(state string) bool {
 	return state == "failed" || state == "blocked" || state == "cancelled"
 }
 
+func jobReportable(state string) bool {
+	return state == "failed" || state == "blocked" || state == "cancelled"
+}
+
 func jobCancelable(state string) bool {
 	return state == "queued" || state == "running"
 }
@@ -74,10 +93,41 @@ func (m Model) updateJobOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if jobRetryable(m.activeJob.State) {
 				m.mode = modeConfirmJobRetry
 			}
+		case "B":
+			if jobReportable(m.activeJob.State) {
+				cmd := m.openBugReportPreview(m.activeJob)
+				m.viewport.SetContent(m.content())
+				return m, cmd
+			}
 		case "c":
 			if jobCancelable(m.activeJob.State) {
 				m.mode = modeConfirmJobCancel
 			}
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
+	case modeBugReportPreview:
+		switch msg.String() {
+		case "esc", "q":
+			if m.actionBusy {
+				return m, nil
+			}
+			m.mode = modeNormal
+			m.actionErr = ""
+			m.actionBusy = false
+		case "g":
+			if m.deps.CreateBugReport == nil || m.actionBusy || !m.bugReportLoaded || m.bugReportErr != "" || m.bugReportURL != "" {
+				return m, nil
+			}
+			m.actionBusy = true
+			m.actionErr = ""
+			m.viewport.SetContent(m.content())
+			return m, bugReportCreateCmd(m.deps, m.activeJob.ID, m.bugReport)
+		default:
+			var cmd tea.Cmd
+			m.viewport, cmd = m.viewport.Update(msg)
+			m.viewport.SetContent(m.content())
+			return m, cmd
 		}
 		m.viewport.SetContent(m.content())
 		return m, nil
@@ -129,6 +179,26 @@ func jobDetailCmd(deps Deps, id string) tea.Cmd {
 		}
 		detail, err := deps.JobDetail(id)
 		return jobDetailMsg{id: id, detail: detail, err: err}
+	}
+}
+
+func bugReportPreviewCmd(deps Deps, id string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.BugReportPreview == nil {
+			return bugReportPreviewMsg{id: id, err: errors.New("bug report preview is not available")}
+		}
+		preview, err := deps.BugReportPreview(id)
+		return bugReportPreviewMsg{id: id, preview: preview, err: err}
+	}
+}
+
+func bugReportCreateCmd(deps Deps, id string, preview BugReportPreview) tea.Cmd {
+	return func() tea.Msg {
+		if deps.CreateBugReport == nil {
+			return bugReportCreateMsg{id: id, err: errors.New("bug report issue creation is not available in this build")}
+		}
+		result, err := deps.CreateBugReport(id, preview)
+		return bugReportCreateMsg{id: id, url: result.URL, existing: result.Existing, err: err}
 	}
 }
 
@@ -225,7 +295,11 @@ func (m Model) jobsContentInteractive() string {
 	if end < n {
 		b.WriteString(mutedStyle.Render("↓ "+strconv.Itoa(n-end)+" more") + "\n")
 	}
-	b.WriteString(mutedStyle.Render("enter detail  R retry  c cancel"))
+	help := "enter detail  R retry  c cancel"
+	if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
+		help += "  B report bug"
+	}
+	b.WriteString(mutedStyle.Render(help))
 	b.WriteByte('\n')
 	return b.String()
 }
@@ -346,6 +420,52 @@ func (m Model) jobConfirmView() string {
 		b.WriteString(mutedStyle.Render("working…"))
 	} else {
 		b.WriteString(mutedStyle.Render("y confirm  n/esc cancel"))
+	}
+	return b.String()
+}
+
+func (m Model) bugReportPreviewView() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("bug report preview for job " + m.activeJob.ID))
+	b.WriteString("\n\n")
+	switch {
+	case m.bugReportErr != "":
+		b.WriteString(errorStyle.Render(m.bugReportErr))
+		b.WriteByte('\n')
+	case !m.bugReportLoaded:
+		b.WriteString(mutedStyle.Render("building redacted preview…"))
+		b.WriteByte('\n')
+	default:
+		if m.bugReport.Title != "" {
+			b.WriteString(headerStyle.Render(m.bugReport.Title))
+			b.WriteString("\n\n")
+		}
+		if len(m.bugReport.Labels) > 0 {
+			b.WriteString("labels  " + strings.Join(m.bugReport.Labels, ", ") + "\n")
+		}
+		if m.bugReport.Fingerprint != "" {
+			b.WriteString("fingerprint  " + m.bugReport.Fingerprint + "\n")
+		}
+		if m.bugReportURL != "" {
+			label := "created: "
+			if m.bugReportExisting {
+				label = "existing: "
+			}
+			b.WriteString("\n" + greenStyle.Render(label+m.bugReportURL) + "\n")
+		}
+		if m.actionErr != "" {
+			b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+		}
+		if m.actionBusy {
+			b.WriteString("\n" + mutedStyle.Render("creating issue…") + "\n")
+		}
+		if m.bugReport.Body != "" {
+			b.WriteString("\n")
+			b.WriteString(m.bugReport.Body)
+			if !strings.HasSuffix(m.bugReport.Body, "\n") {
+				b.WriteByte('\n')
+			}
+		}
 	}
 	return b.String()
 }

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -17,6 +17,7 @@ func jobsSnapshot() Snapshot {
 			{ID: "j-failed", Agent: "planner", Type: "ask", State: "failed", LatestEvent: "boom"},
 			{ID: "j-running", Agent: "planner", Type: "implement", State: "running"},
 			{ID: "j-done", Agent: "planner", Type: "review", State: "succeeded"},
+			{ID: "j-cancelled", Agent: "planner", Type: "ask", State: "cancelled", LatestEvent: "user cancelled"},
 		},
 	}
 }
@@ -195,6 +196,233 @@ func TestJobsRetryOnNonRetryableIgnored(t *testing.T) {
 	m = next.(Model)
 	if m.mode != modeNormal {
 		t.Fatalf("R on a succeeded job must be a no-op, mode=%v", m.mode)
+	}
+}
+
+func TestJobsBugReportPreviewCreateFlow(t *testing.T) {
+	var previewed, created string
+	deps := Deps{
+		BugReportPreview: func(id string) (BugReportPreview, error) {
+			previewed = id
+			return BugReportPreview{
+				Title:       "Gitmoot failed job ask for planner",
+				Body:        "<!-- gitmoot:dashboard-report fingerprint:abc123 -->\n\nredacted body",
+				Labels:      []string{"gitmoot-dashboard-report", "bug"},
+				Fingerprint: "abc123",
+			}, nil
+		},
+		CreateBugReport: func(id string, preview BugReportPreview) (BugReportCreateResult, error) {
+			created = id
+			if preview.Fingerprint != "abc123" || !strings.Contains(preview.Body, "redacted body") {
+				t.Fatalf("CreateBugReport received preview = %+v", preview)
+			}
+			return BugReportCreateResult{URL: "https://github.com/jerryfane/gitmoot/issues/777"}, nil
+		},
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	if !strings.Contains(m.View(), "B report bug") {
+		t.Fatalf("failed selected job should advertise report action:\n%s", m.View())
+	}
+	next, cmd := m.Update(key("B"))
+	m = next.(Model)
+	if m.mode != modeBugReportPreview || cmd == nil {
+		t.Fatalf("B should open bug report preview, mode=%v", m.mode)
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if previewed != "j-failed" {
+		t.Fatalf("BugReportPreview called with %q", previewed)
+	}
+	view := m.View()
+	for _, want := range []string{"bug report preview", "Gitmoot failed job", "gitmoot-dashboard-report, bug", "abc123", "redacted body"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("preview missing %q:\n%s", want, view)
+		}
+	}
+
+	next, cmd = m.Update(key("g"))
+	m = next.(Model)
+	if cmd == nil || !m.actionBusy {
+		t.Fatalf("g should start issue creation, busy=%v cmd=%v", m.actionBusy, cmd)
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if created != "j-failed" {
+		t.Fatalf("CreateBugReport called with %q", created)
+	}
+	if m.mode != modeBugReportPreview || !strings.Contains(m.View(), "https://github.com/jerryfane/gitmoot/issues/777") {
+		t.Fatalf("success should keep preview open with URL:\n%s", m.View())
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("esc should return to dashboard, mode=%v", m.mode)
+	}
+}
+
+func TestJobsBugReportCreateErrorKeepsPreview(t *testing.T) {
+	deps := Deps{
+		BugReportPreview: func(id string) (BugReportPreview, error) {
+			return BugReportPreview{Title: "draft", Body: "body"}, nil
+		},
+		CreateBugReport: func(id string, preview BugReportPreview) (BugReportCreateResult, error) {
+			return BugReportCreateResult{}, errors.New("github unavailable")
+		},
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(key("B"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	next, cmd = m.Update(key("g"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeBugReportPreview {
+		t.Fatalf("creation error should keep preview open, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.View(), "github unavailable") {
+		t.Fatalf("creation error should render inline:\n%s", m.View())
+	}
+}
+
+func TestJobsBugReportExistingIssueLabel(t *testing.T) {
+	deps := Deps{
+		BugReportPreview: func(id string) (BugReportPreview, error) {
+			return BugReportPreview{Title: "draft", Body: "body", Fingerprint: "abc123"}, nil
+		},
+		CreateBugReport: func(id string, preview BugReportPreview) (BugReportCreateResult, error) {
+			return BugReportCreateResult{URL: "https://github.com/jerryfane/gitmoot/issues/777", Existing: true}, nil
+		},
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(key("B"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	next, cmd = m.Update(key("g"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	view := m.View()
+	if !strings.Contains(view, "existing: https://github.com/jerryfane/gitmoot/issues/777") {
+		t.Fatalf("existing issue should be labeled distinctly:\n%s", view)
+	}
+	if strings.Contains(view, "created: https://github.com/jerryfane/gitmoot/issues/777") {
+		t.Fatalf("existing issue must not be labeled created:\n%s", view)
+	}
+}
+
+func TestJobsBugReportCreateResultNotDroppedAfterEsc(t *testing.T) {
+	deps := Deps{
+		BugReportPreview: func(id string) (BugReportPreview, error) {
+			return BugReportPreview{Title: "draft", Body: "body", Fingerprint: "abc123"}, nil
+		},
+		CreateBugReport: func(id string, preview BugReportPreview) (BugReportCreateResult, error) {
+			return BugReportCreateResult{URL: "https://github.com/jerryfane/gitmoot/issues/778"}, nil
+		},
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(key("B"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	next, cmd = m.Update(key("g"))
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if m.mode != modeBugReportPreview {
+		t.Fatalf("esc while create is in flight must keep preview open, mode=%v", m.mode)
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if !strings.Contains(m.View(), "created: https://github.com/jerryfane/gitmoot/issues/778") {
+		t.Fatalf("create result should still render after esc:\n%s", m.View())
+	}
+}
+
+func TestJobsBugReportBuildErrorKeepsPreview(t *testing.T) {
+	deps := Deps{BugReportPreview: func(id string) (BugReportPreview, error) {
+		return BugReportPreview{}, errors.New("payload malformed")
+	}}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(key("B"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeBugReportPreview || !strings.Contains(m.View(), "payload malformed") {
+		t.Fatalf("build error should render in preview mode:\n%s", m.View())
+	}
+	next, cmd = m.Update(key("g"))
+	if cmd != nil {
+		t.Fatal("g must not create when preview build failed")
+	}
+}
+
+func TestJobsBugReportPreviewWithoutCreateDepDoesNotAdvertiseCreate(t *testing.T) {
+	deps := Deps{BugReportPreview: func(id string) (BugReportPreview, error) {
+		return BugReportPreview{Title: "draft", Body: "body"}, nil
+	}}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(key("B"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if strings.Contains(m.footerHelp(), "g create issue") {
+		t.Fatalf("missing create dep must not advertise g create issue: %q", m.footerHelp())
+	}
+	next, cmd = m.Update(key("g"))
+	m = next.(Model)
+	if cmd != nil || m.actionBusy || m.actionErr != "" {
+		t.Fatalf("g without create dep should be inert, busy=%v err=%q cmd=%v", m.actionBusy, m.actionErr, cmd)
+	}
+}
+
+func TestJobsBugReportIgnoredForNonReportableJob(t *testing.T) {
+	deps := Deps{
+		BugReportPreview: func(id string) (BugReportPreview, error) {
+			t.Fatalf("must not build report for non-reportable job %s", id)
+			return BugReportPreview{}, nil
+		},
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	if strings.Contains(m.View(), "B report bug") {
+		t.Fatalf("running selected job must not advertise report action:\n%s", m.View())
+	}
+	next, cmd := m.Update(key("B"))
+	m = next.(Model)
+	if cmd != nil || m.mode != modeNormal {
+		t.Fatalf("B on running job should be a no-op, mode=%v cmd=%v", m.mode, cmd)
+	}
+}
+
+func TestAttentionCancelledJobReportable(t *testing.T) {
+	var previewed string
+	snap := Snapshot{
+		Daemon:  Daemon{Running: true},
+		JobRows: []JobRow{{ID: "j-cancelled", Agent: "planner", Type: "ask", State: "cancelled", LatestEvent: "user cancelled"}},
+	}
+	deps := Deps{
+		Load: func() (Snapshot, error) { return snap, nil },
+		BugReportPreview: func(id string) (BugReportPreview, error) {
+			previewed = id
+			return BugReportPreview{Title: "cancelled draft", Body: "body"}, nil
+		},
+	}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	if !strings.Contains(m.View(), "job j-cancelled") || !strings.Contains(m.View(), "B report bug") {
+		t.Fatalf("cancelled attention job should be visible and reportable:\n%s", m.View())
+	}
+	next, cmd := m.Update(key("B"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if previewed != "j-cancelled" || m.mode != modeBugReportPreview {
+		t.Fatalf("cancelled job previewed=%q mode=%v", previewed, m.mode)
 	}
 }
 

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -57,6 +57,7 @@ const (
 	modeConfirmSessionStop
 	modeConfirmJobRetry
 	modeConfirmJobCancel
+	modeBugReportPreview
 	modeTrainStopReason
 	modeConfirmTrainDelete
 	modeConfirmTrainRepoCleanup
@@ -105,16 +106,21 @@ type Model struct {
 	sessionNotice      string  // muted note on the Sessions page (e.g. group not stoppable)
 
 	// Jobs page interaction state.
-	jobCursor       int                 // selected row in snap.JobRows
-	activeJob       JobRow              // job shown in detail / being confirmed
-	jobEvents       []JobEventView      // lazy-loaded event history for the detail view
-	jobEventsLoaded bool                // the detail's event load has returned (possibly empty)
-	jobEventsErr    string              // error from the detail's event load
-	activeJobDetail JobDetail           // lazy-loaded parsed payload (request/result)
-	jobDetailLoaded bool                // the detail's payload load has returned
-	cancelling      map[string]struct{} // jobs with a cancel requested, until settled
-	daemonBusy      bool                // a daemon start is in flight; suppress re-submit
-	daemonErr       string              // error from the last daemon start attempt
+	jobCursor         int                 // selected row in snap.JobRows
+	activeJob         JobRow              // job shown in detail / being confirmed
+	jobEvents         []JobEventView      // lazy-loaded event history for the detail view
+	jobEventsLoaded   bool                // the detail's event load has returned (possibly empty)
+	jobEventsErr      string              // error from the detail's event load
+	activeJobDetail   JobDetail           // lazy-loaded parsed payload (request/result)
+	jobDetailLoaded   bool                // the detail's payload load has returned
+	bugReport         BugReportPreview    // redacted issue draft for modeBugReportPreview
+	bugReportLoaded   bool                // the preview build has returned
+	bugReportErr      string              // error from building the preview
+	bugReportURL      string              // created issue URL
+	bugReportExisting bool                // bugReportURL points to an existing duplicate
+	cancelling        map[string]struct{} // jobs with a cancel requested, until settled
+	daemonBusy        bool                // a daemon start is in flight; suppress re-submit
+	daemonErr         string              // error from the last daemon start attempt
 
 	// Health page state (lazy: the checks shell out, so they load on first
 	// open and on r, not on the refresh tick).
@@ -204,7 +210,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		// Modal overlays capture keys first; only ctrl+c stays global.
 		switch m.mode {
-		case modeJobDetail, modeConfirmJobRetry, modeConfirmJobCancel:
+		case modeJobDetail, modeConfirmJobRetry, modeConfirmJobCancel, modeBugReportPreview:
 			if msg.String() == "ctrl+c" {
 				return m, tea.Quit
 			}
@@ -352,6 +358,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
+		case "B":
+			if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
+				cmd := m.openBugReportPreview(job)
+				m.viewport.SetContent(m.content())
+				return m, cmd
+			}
 		case "c":
 			if job, ok := m.jobUnderCursor(); ok && jobCancelable(job.State) {
 				m.openJobConfirm(job, true)
@@ -483,6 +495,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.id == m.activeJob.ID {
 			m.jobDetailLoaded = true
 			m.activeJobDetail = msg.detail
+		}
+	case bugReportPreviewMsg:
+		if msg.id == m.activeJob.ID {
+			m.bugReportLoaded = true
+			if msg.err != nil {
+				m.bugReportErr = msg.err.Error()
+			} else {
+				m.bugReportErr = ""
+				m.bugReport = msg.preview
+			}
 		}
 	case healthChecksMsg:
 		m.healthLoading = false
@@ -755,6 +777,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err == nil {
 			if cmd := m.queueLoad(); cmd != nil {
 				cmds = append(cmds, cmd)
+			}
+		}
+	case bugReportCreateMsg:
+		if m.mode == modeBugReportPreview && msg.id == m.activeJob.ID {
+			m.actionBusy = false
+			if msg.err != nil {
+				m.actionErr = msg.err.Error()
+			} else {
+				m.actionErr = ""
+				m.bugReportURL = msg.url
+				m.bugReportExisting = msg.existing
 			}
 		}
 	case snapshotMsg:

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -84,6 +84,8 @@ func (m Model) content() string {
 		b.WriteString(m.sessionStopConfirmView())
 	case modeConfirmJobRetry, modeConfirmJobCancel:
 		b.WriteString(m.jobConfirmView())
+	case modeBugReportPreview:
+		b.WriteString(m.bugReportPreviewView())
 	case modeTrainStopReason:
 		b.WriteString(m.trainStopView())
 	case modeConfirmTrainDelete:
@@ -136,11 +138,14 @@ func (m Model) helpContent() string {
 	b.WriteString("\n\n")
 	switch pages[m.selected].page {
 	case pageAttention:
-		b.WriteString("↑/↓  select a row (pending prompts, then blocked/failed jobs)\n")
+		b.WriteString("↑/↓  select a row (pending prompts, then blocked/failed/cancelled jobs)\n")
 		b.WriteString("a    answer the selected prompt (choices or text)\n")
 		b.WriteString("d    dismiss (delete) the selected prompt\n")
 		b.WriteString("enter open the selected job's detail (events)\n")
 		b.WriteString("R    retry the selected job\n")
+		if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
+			b.WriteString("B    report bug for the selected job\n")
+		}
 		b.WriteString("s    start the daemon when it is stopped\n")
 	case pageTrains:
 		b.WriteString("↑/↓  select a train session\n")
@@ -161,6 +166,9 @@ func (m Model) helpContent() string {
 		b.WriteString("enter open the job's detail (events)\n")
 		b.WriteString("R    retry the selected job (failed/blocked/cancelled)\n")
 		b.WriteString("c    cancel the selected job (queued/running)\n")
+		if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
+			b.WriteString("B    report bug for the selected job\n")
+		}
 		b.WriteString("pgup/pgdn  scroll a long list\n")
 	case pageHealth:
 		b.WriteString("daemon state + flags, then environment checks\n")
@@ -195,9 +203,23 @@ func (m Model) footerHelp() string {
 	case modeTrainDetail:
 		return "enter/esc back"
 	case modeJobDetail:
+		if jobReportable(m.activeJob.State) {
+			return "R retry  B report bug  c cancel  esc back"
+		}
 		return "R retry  c cancel  esc back"
 	case modeConfirmJobRetry, modeConfirmJobCancel:
 		return "y confirm  n/esc cancel"
+	case modeBugReportPreview:
+		if m.bugReportURL != "" {
+			return "esc back"
+		}
+		if m.actionBusy {
+			return "creating issue…  esc back"
+		}
+		if m.bugReportLoaded && m.bugReportErr == "" && m.deps.CreateBugReport != nil {
+			return "g create issue  esc back"
+		}
+		return "esc back"
 	case modeTrainStopReason:
 		return "type reason  enter stop  esc cancel"
 	case modeConfirmTrainDelete:
@@ -221,7 +243,11 @@ func (m Model) footerHelp() string {
 	}
 	switch pages[m.selected].page {
 	case pageAttention:
-		return "tab/←→ page  ↑/↓ select  a answer  d dismiss  enter/R jobs  ? help  q quit"
+		help := "tab/←→ page  ↑/↓ select  a answer  d dismiss  enter/R jobs"
+		if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
+			help += "  B report bug"
+		}
+		return help + "  ? help  q quit"
 	case pageTrains:
 		return "tab/←→ page  ↑/↓ select  enter open  s stop  d delete  ? help  q quit"
 	case pageAgents:
@@ -229,7 +255,11 @@ func (m Model) footerHelp() string {
 	case pageSessions:
 		return "tab/←→ page  ↑/↓ select  enter detail  s stop  ? help  q quit"
 	case pageJobs:
-		return "tab/←→ page  ↑/↓ select  enter detail  R retry  c cancel  ? help  q quit"
+		help := "tab/←→ page  ↑/↓ select  enter detail  R retry  c cancel"
+		if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
+			help += "  B report bug"
+		}
+		return help + "  ? help  q quit"
 	case pageHealth:
 		return "tab/←→ page  r re-run checks  s start daemon  ? help  q quit"
 	case pageConfig:
@@ -303,7 +333,7 @@ func (m Model) locksContent() string {
 
 func jobStateColor(state string) string {
 	switch state {
-	case "failed", "blocked":
+	case "failed", "blocked", "cancelled":
 		return redStyle.Render(state)
 	case "succeeded":
 		return greenStyle.Render(state)


### PR DESCRIPTION
## Summary
- Add `B report bug` from dashboard Jobs and Attention views for failed, blocked, and cancelled jobs.
- Show a redacted bug report preview before issue creation, with `g create issue` only after the preview loads.
- Reuse the report issue creation helper, preserve duplicate detection, and distinguish created vs existing issues in the TUI.
- Keep create results in the preview while issue creation is in flight and surface duplicate-search failures instead of silently creating from the dashboard.

Part of #289.

## Verification
- `/tmp/go1.26.4/bin/go test ./internal/cli/tui`
- `/tmp/go1.26.4/bin/go test ./internal/cli -run 'TestReportBug|TestCreateBugReportIssueResult|TestJobs'`
- `/tmp/go1.26.4/bin/go test ./internal/cli/tui ./internal/cli`
- `git diff --check`
- `codex exec review --uncommitted` found one P3 footer-hint issue during post-merge audit; fixed by #295 (`f4c43595db8a5e8eec0672819bd9394dd43e9166`).

## Final Raw Review Output (post-merge audit reconstruction)
Reconstructed from merge commit `998c63de872e45f7b48855f1c73fec509f356a45` applied with `--no-commit` on parent `f0b56c902104efd37617bf7723eb71211e3fa14f`.

```text
codex
The new bug-report flow has a user-facing key-hint bug during issue creation; otherwise the changes appear coherent from static review.

Review comment:

- [P3] Fix the busy bug-report footer hint — /tmp/gitmoot-pr292-review/internal/cli/tui/view.go:217-217
  When issue creation is in flight, `updateJobOverlay` deliberately ignores `esc`/`q` while `m.actionBusy` is true, but this footer still advertises `esc back`. In a slow GitHub create, the user is told Esc will leave the preview even though it is a no-op until the command returns, so the TUI presents a broken key binding.
The new bug-report flow has a user-facing key-hint bug during issue creation; otherwise the changes appear coherent from static review.

Review comment:

- [P3] Fix the busy bug-report footer hint — /tmp/gitmoot-pr292-review/internal/cli/tui/view.go:217-217
  When issue creation is in flight, `updateJobOverlay` deliberately ignores `esc`/`q` while `m.actionBusy` is true, but this footer still advertises `esc back`. In a slow GitHub create, the user is told Esc will leave the preview even though it is a no-op until the command returns, so the TUI presents a broken key binding.
```
