### PR TITLE
fix: hide inactive bug-report busy shortcut

### DIFF
--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -245,6 +245,9 @@ func TestJobsBugReportPreviewCreateFlow(t *testing.T) {
 	if cmd == nil || !m.actionBusy {
 		t.Fatalf("g should start issue creation, busy=%v cmd=%v", m.actionBusy, cmd)
 	}
+	if got := m.footerHelp(); strings.Contains(got, "esc back") || !strings.Contains(got, "creating issue") {
+		t.Fatalf("busy footer help = %q, want creating state without esc back", got)
+	}
 	next, _ = m.Update(cmd())
 	m = next.(Model)
 	if created != "j-failed" {

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -214,7 +214,7 @@ func (m Model) footerHelp() string {
 			return "esc back"
 		}
 		if m.actionBusy {
-			return "creating issue…  esc back"
+			return "creating issue…"
 		}
 		if m.bugReportLoaded && m.bugReportErr == "" && m.deps.CreateBugReport != nil {
 			return "g create issue  esc back"


### PR DESCRIPTION
## Summary
- Hide the inactive `esc back` hint while bug-report issue creation is busy in the TUI.
- Add a focused regression assertion for the busy footer state.

Refs #289.

## Validation
- `git diff --check`
- `/tmp/go1.26.4/bin/go test ./internal/cli/tui`
- `/tmp/go1.26.4/bin/go test ./internal/cli ./internal/cli/tui`

## Final Raw Review Output
```text
codex
No correctness issues were found in the current changes. I could not run the Go test due to the environment's read-only Go toolchain cache, but the diff itself is consistent with the existing busy-state input handling.
No correctness issues were found in the current changes. I could not run the Go test due to the environment's read-only Go toolchain cache, but the diff itself is consistent with the existing busy-state input handling.
```
