### PR TITLE
Add read-only session hooks to Gitmoot plugins

### DIFF
--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/plugincontext"
 	"github.com/jerryfane/gitmoot/internal/plugininstall"
 	"github.com/jerryfane/gitmoot/internal/pluginpack"
 	"github.com/jerryfane/gitmoot/internal/runtime"
@@ -21,7 +22,9 @@ import (
 	"github.com/jerryfane/gitmoot/skills"
 )
 
+var pluginExecutable = os.Executable
 var pluginLookPath = exec.LookPath
+var pluginHookInput io.Reader = os.Stdin
 var pluginInstallRunner subprocess.Runner = subprocess.ExecRunner{}
 var pluginDoctorRunner subprocess.Runner = subprocess.ExecRunner{}
 
@@ -56,6 +59,8 @@ func runPlugin(args []string, stdout, stderr io.Writer) int {
 		return runPluginPath(args[1:], stdout, stderr)
 	case "doctor":
 		return runPluginDoctor(args[1:], stdout, stderr)
+	case "hook-context":
+		return runPluginHookContext(args[1:], stdout, stderr)
 	case "install":
 		return runPluginInstall(args[1:], stdout, stderr)
 	default:
@@ -71,6 +76,29 @@ func printPluginUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot plugin install codex|claude")
 	fmt.Fprintln(w, "  gitmoot plugin path codex|claude")
 	fmt.Fprintln(w, "  gitmoot plugin doctor [codex|claude] [--live]")
+}
+
+func runPluginHookContext(_ []string, stdout, stderr io.Writer) int {
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = ""
+	}
+	input := plugincontext.ReadHookInput(pluginHookInput, cwd)
+	contextText, err := plugincontext.Build(context.Background(), plugincontext.BuildOptions{
+		Input: input,
+	})
+	if err != nil {
+		if err := plugincontext.WriteOutput(stdout, ""); err != nil {
+			fmt.Fprintf(stderr, "plugin hook-context: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if err := plugincontext.WriteOutput(stdout, contextText); err != nil {
+		fmt.Fprintf(stderr, "plugin hook-context: %v\n", err)
+		return 1
+	}
+	return 0
 }
 
 func runPluginInstall(args []string, stdout, stderr io.Writer) int {
@@ -94,12 +122,13 @@ func runPluginInstall(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	result, err := plugininstall.Install(context.Background(), plugininstall.Options{
-		Provider: provider,
-		Home:     paths.Home,
-		Scope:    *scope,
-		Force:    *force,
-		Info:     buildinfo.Current(),
-		Runner:   pluginInstallRunner,
+		Provider:      provider,
+		Home:          paths.Home,
+		Scope:         *scope,
+		Force:         *force,
+		Info:          buildinfo.Current(),
+		Runner:        pluginInstallRunner,
+		GitmootBinary: resolveGitmootBinary(),
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "plugin install: %v\n", err)
@@ -164,11 +193,12 @@ func runPluginBuild(args []string, stdout, stderr io.Writer) int {
 		homePath = paths.Home
 	}
 	result, err := pluginpack.Build(pluginpack.BuildOptions{
-		Provider: provider,
-		Home:     homePath,
-		OutDir:   *outDir,
-		Force:    *force,
-		Info:     buildinfo.Current(),
+		Provider:      provider,
+		Home:          homePath,
+		OutDir:        *outDir,
+		Force:         *force,
+		Info:          buildinfo.Current(),
+		GitmootBinary: resolveGitmootBinary(),
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "plugin build: %v\n", err)
@@ -176,6 +206,24 @@ func runPluginBuild(args []string, stdout, stderr io.Writer) int {
 	}
 	writeLine(stdout, "%s", result.Path)
 	return 0
+}
+
+func resolveGitmootBinary() string {
+	if executable, err := pluginExecutable(); err == nil && filepath.IsAbs(executable) {
+		return executable
+	}
+	path, err := pluginLookPath("gitmoot")
+	if err != nil || strings.TrimSpace(path) == "" {
+		return ""
+	}
+	path = strings.TrimSpace(path)
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if absolute, err := filepath.Abs(path); err == nil {
+		return absolute
+	}
+	return ""
 }
 
 func runPluginPath(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,6 +46,7 @@ func TestRunPluginBuildPrintsPackagePath(t *testing.T) {
 	for _, path := range []string{
 		filepath.Join(packagePath, ".claude-plugin", "plugin.json"),
 		filepath.Join(packagePath, "skills", "gitmoot", "SKILL.md"),
+		filepath.Join(packagePath, "hooks", "hooks.json"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected generated file %s: %v", path, err)
@@ -66,6 +68,9 @@ func TestRunPluginBuildExplicitOutDoesNotNeedHome(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(out, ".codex-plugin", "plugin.json")); err != nil {
 		t.Fatalf("codex manifest missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "hooks", "hooks.json")); err != nil {
+		t.Fatalf("hook manifest missing: %v", err)
 	}
 }
 
@@ -105,6 +110,114 @@ func TestRunPluginPathHelpBeforeRuntime(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "-home") {
 		t.Fatalf("plugin path --help missing flag help:\n%s", stderr.String())
+	}
+}
+
+func TestResolveGitmootBinaryPrefersExecutable(t *testing.T) {
+	restoreExecutable := stubPluginExecutable(func() (string, error) {
+		return "/tmp/current/gitmoot", nil
+	})
+	defer restoreExecutable()
+	restorePath := stubPluginLookPath(map[string]string{"gitmoot": "/tmp/path/gitmoot"})
+	defer restorePath()
+
+	if got := resolveGitmootBinary(); got != "/tmp/current/gitmoot" {
+		t.Fatalf("resolveGitmootBinary() = %q, want current executable", got)
+	}
+}
+
+func TestResolveGitmootBinaryFallsBackToLookPath(t *testing.T) {
+	restoreExecutable := stubPluginExecutable(func() (string, error) {
+		return "", errors.New("not available")
+	})
+	defer restoreExecutable()
+	restorePath := stubPluginLookPath(map[string]string{"gitmoot": "/tmp/path/gitmoot"})
+	defer restorePath()
+
+	if got := resolveGitmootBinary(); got != "/tmp/path/gitmoot" {
+		t.Fatalf("resolveGitmootBinary() = %q, want PATH binary", got)
+	}
+}
+
+func TestRunPluginHookContextSuccessAndOutputShape(t *testing.T) {
+	cwd := t.TempDir()
+	input, err := json.Marshal(map[string]string{
+		"cwd":             cwd,
+		"hook_event_name": "SessionStart",
+	})
+	if err != nil {
+		t.Fatalf("marshal hook input: %v", err)
+	}
+	restore := replacePluginHookInput(bytes.NewReader(input))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "hook-context"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin hook-context exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("plugin hook-context stderr = %q, want empty", stderr.String())
+	}
+	var output struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("hook-context output did not parse: %v\n%s", err, stdout.String())
+	}
+	if output.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Fatalf("hook event = %q, want SessionStart", output.HookSpecificOutput.HookEventName)
+	}
+	contextText := output.HookSpecificOutput.AdditionalContext
+	for _, want := range []string{
+		"- cwd: \"" + cwd + "\"",
+		"- repo: not detected",
+		"`gitmoot dashboard`",
+		"answer directly",
+		"live monitoring follow-up",
+	} {
+		if !strings.Contains(contextText, want) {
+			t.Fatalf("additional context missing %q:\n%s", want, contextText)
+		}
+	}
+}
+
+func TestRunPluginHookContextMalformedInputStillSucceeds(t *testing.T) {
+	restore := replacePluginHookInput(strings.NewReader("{not json"))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "hook-context"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin hook-context exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("plugin hook-context stderr = %q, want empty", stderr.String())
+	}
+	var output map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("hook-context output did not parse: %v\n%s", err, stdout.String())
+	}
+	if _, ok := output["hookSpecificOutput"]; !ok {
+		t.Fatalf("hookSpecificOutput missing from malformed-input fallback: %s", stdout.String())
+	}
+}
+
+func TestRunPluginUsageDoesNotListHookContext(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	code := Run([]string{"plugin", "--help"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin --help exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "hook-context") {
+		t.Fatalf("plugin help should not list hidden hook-context:\n%s", stdout.String())
 	}
 }
 
@@ -334,6 +447,22 @@ func stubPluginLookPath(paths map[string]string) func() {
 	}
 	return func() {
 		pluginLookPath = original
+	}
+}
+
+func stubPluginExecutable(fn func() (string, error)) func() {
+	original := pluginExecutable
+	pluginExecutable = fn
+	return func() {
+		pluginExecutable = original
+	}
+}
+
+func replacePluginHookInput(r io.Reader) func() {
+	original := pluginHookInput
+	pluginHookInput = r
+	return func() {
+		pluginHookInput = original
 	}
 }
 

--- a/internal/plugincontext/plugincontext.go
+++ b/internal/plugincontext/plugincontext.go
@@ -1,0 +1,164 @@
+package plugincontext
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/config"
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+const DefaultHookEventName = "SessionStart"
+
+type HookInput struct {
+	CWD           string
+	HookEventName string
+}
+
+type BuildOptions struct {
+	Input  HookInput
+	Info   buildinfo.Info
+	Paths  config.Paths
+	Runner subprocess.Runner
+}
+
+type HookOutput struct {
+	HookSpecificOutput *HookSpecificOutput `json:"hookSpecificOutput,omitempty"`
+}
+
+type HookSpecificOutput struct {
+	HookEventName     string `json:"hookEventName"`
+	AdditionalContext string `json:"additionalContext"`
+}
+
+type repoInfo struct {
+	Root     string
+	Remote   string
+	Repo     string
+	Detected bool
+}
+
+func ReadHookInput(r io.Reader, fallbackCWD string) HookInput {
+	fallback := strings.TrimSpace(fallbackCWD)
+	input := HookInput{
+		CWD:           fallback,
+		HookEventName: DefaultHookEventName,
+	}
+	if r == nil {
+		return input
+	}
+	content, err := io.ReadAll(r)
+	if err != nil || len(bytes.TrimSpace(content)) == 0 {
+		return input
+	}
+
+	var raw struct {
+		CWD           string `json:"cwd"`
+		HookEventName string `json:"hook_event_name"`
+	}
+	if err := json.Unmarshal(content, &raw); err != nil {
+		return input
+	}
+	if cwd := strings.TrimSpace(raw.CWD); cwd != "" {
+		input.CWD = cwd
+	}
+	if event := strings.TrimSpace(raw.HookEventName); event != "" {
+		input.HookEventName = event
+	}
+	return input
+}
+
+func Build(ctx context.Context, opts BuildOptions) (string, error) {
+	cwd := strings.TrimSpace(opts.Input.CWD)
+	if cwd == "" {
+		return "", errors.New("cwd is required")
+	}
+
+	info := opts.Info
+	if info.Version == "" {
+		info = buildinfo.Current()
+	}
+	paths := opts.Paths
+	if strings.TrimSpace(paths.Home) == "" {
+		defaultPaths, err := config.DefaultPaths()
+		if err != nil {
+			return "", err
+		}
+		paths = defaultPaths
+	}
+
+	repo := detectRepo(ctx, cwd, opts.Runner)
+	var b strings.Builder
+	fmt.Fprintln(&b, "Gitmoot presence context")
+	fmt.Fprintf(&b, "- Gitmoot: %s (commit %s, built %s, %s)\n", info.Version, info.Commit, info.Date, info.Go)
+	fmt.Fprintf(&b, "- cwd: %s\n", quoteContextValue(cwd))
+	fmt.Fprintf(&b, "- Gitmoot home: %s\n", quoteContextValue(paths.Home))
+	if repo.Detected {
+		fmt.Fprintf(&b, "- repo: %s (root: %s)\n", quoteContextValue(repo.Repo), quoteContextValue(repo.Root))
+	} else if repo.Root != "" {
+		fmt.Fprintf(&b, "- repo: not detected (git root: %s)\n", quoteContextValue(repo.Root))
+	} else {
+		fmt.Fprintln(&b, "- repo: not detected")
+	}
+	fmt.Fprintln(&b, "- dashboard command: `gitmoot dashboard`")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Guidance")
+	fmt.Fprintln(&b, "- For Gitmoot health or status questions, run relevant read-only Gitmoot CLI checks and answer directly.")
+	fmt.Fprintln(&b, "- Mention `gitmoot dashboard` only as live monitoring follow-up after the direct answer.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Guardrails")
+	fmt.Fprintln(&b, "- This hook provides read-only startup context only.")
+	fmt.Fprintln(&b, "- Do not call GitHub, check `gh auth status`, start daemons, inspect remote PRs, poll jobs or locks automatically, create or subscribe agents, update templates, release locks, or mutate state unless the user explicitly asks.")
+	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+func OutputForContext(contextText string) HookOutput {
+	contextText = strings.TrimSpace(contextText)
+	if contextText == "" {
+		return HookOutput{}
+	}
+	return HookOutput{
+		HookSpecificOutput: &HookSpecificOutput{
+			HookEventName:     DefaultHookEventName,
+			AdditionalContext: contextText,
+		},
+	}
+}
+
+func WriteOutput(w io.Writer, contextText string) error {
+	return json.NewEncoder(w).Encode(OutputForContext(contextText))
+}
+
+func quoteContextValue(value string) string {
+	return strconv.Quote(strings.TrimSpace(value))
+}
+
+func detectRepo(ctx context.Context, cwd string, runner subprocess.Runner) repoInfo {
+	client := gitutil.Client{Dir: cwd, Runner: runner}
+	root, err := client.Root(ctx)
+	if err != nil {
+		return repoInfo{}
+	}
+	remote, err := client.OriginRemote(ctx)
+	if err != nil {
+		return repoInfo{Root: root}
+	}
+	repo, err := gitutil.ParseGitHubRemote(remote)
+	if err != nil {
+		return repoInfo{Root: root, Remote: remote}
+	}
+	return repoInfo{
+		Root:     root,
+		Remote:   remote,
+		Repo:     repo.String(),
+		Detected: true,
+	}
+}

--- a/internal/plugincontext/plugincontext_test.go
+++ b/internal/plugincontext/plugincontext_test.go
@@ -1,0 +1,262 @@
+package plugincontext
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+func TestReadHookInputEmptyFallsBack(t *testing.T) {
+	input := ReadHookInput(strings.NewReader(""), "/fallback")
+
+	if input.CWD != "/fallback" {
+		t.Fatalf("cwd = %q, want fallback", input.CWD)
+	}
+	if input.HookEventName != DefaultHookEventName {
+		t.Fatalf("hook event = %q, want %q", input.HookEventName, DefaultHookEventName)
+	}
+}
+
+func TestReadHookInputMalformedFallsBack(t *testing.T) {
+	input := ReadHookInput(strings.NewReader("{not json"), "/fallback")
+
+	if input.CWD != "/fallback" {
+		t.Fatalf("cwd = %q, want fallback", input.CWD)
+	}
+	if input.HookEventName != DefaultHookEventName {
+		t.Fatalf("hook event = %q, want %q", input.HookEventName, DefaultHookEventName)
+	}
+}
+
+func TestReadHookInputMissingCWDFallsBack(t *testing.T) {
+	input := ReadHookInput(strings.NewReader(`{"hook_event_name":"SessionStart"}`), "/fallback")
+
+	if input.CWD != "/fallback" {
+		t.Fatalf("cwd = %q, want fallback", input.CWD)
+	}
+	if input.HookEventName != "SessionStart" {
+		t.Fatalf("hook event = %q, want SessionStart", input.HookEventName)
+	}
+}
+
+func TestReadHookInputUsesProvidedCWD(t *testing.T) {
+	input := ReadHookInput(strings.NewReader(`{"cwd":"/provided","hook_event_name":"SessionStart"}`), "/fallback")
+
+	if input.CWD != "/provided" {
+		t.Fatalf("cwd = %q, want provided cwd", input.CWD)
+	}
+	if input.HookEventName != "SessionStart" {
+		t.Fatalf("hook event = %q, want SessionStart", input.HookEventName)
+	}
+}
+
+func TestBuildNoRepoContext(t *testing.T) {
+	contextText, err := Build(context.Background(), BuildOptions{
+		Input: HookInput{CWD: "/work"},
+		Info:  testInfo(),
+		Paths: config.Paths{Home: "/home/user/.gitmoot"},
+		Runner: fakeGitRunner{
+			rootErr: errors.New("not a git repo"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	for _, want := range []string{
+		"Gitmoot presence context",
+		"- Gitmoot: test-version",
+		"- cwd: \"/work\"",
+		"- Gitmoot home: \"/home/user/.gitmoot\"",
+		"- repo: not detected",
+		"`gitmoot dashboard`",
+		"answer directly",
+		"live monitoring follow-up",
+		"Do not call GitHub",
+		"mutate state",
+	} {
+		if !strings.Contains(contextText, want) {
+			t.Fatalf("context missing %q:\n%s", want, contextText)
+		}
+	}
+}
+
+func TestBuildDetectsGitHubRepo(t *testing.T) {
+	contextText, err := Build(context.Background(), BuildOptions{
+		Input: HookInput{CWD: "/work/subdir"},
+		Info:  testInfo(),
+		Paths: config.Paths{Home: "/home/user/.gitmoot"},
+		Runner: fakeGitRunner{
+			root:   "/work",
+			remote: "https://github.com/jerryfane/gitmoot.git",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	if !strings.Contains(contextText, "- repo: \"jerryfane/gitmoot\" (root: \"/work\")") {
+		t.Fatalf("context missing repo detection:\n%s", contextText)
+	}
+}
+
+func TestBuildTreatsRemoteErrorsAsNonFatal(t *testing.T) {
+	contextText, err := Build(context.Background(), BuildOptions{
+		Input: HookInput{CWD: "/work"},
+		Info:  testInfo(),
+		Paths: config.Paths{Home: "/home/user/.gitmoot"},
+		Runner: fakeGitRunner{
+			root:      "/work",
+			remoteErr: errors.New("no origin"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	if !strings.Contains(contextText, "- repo: not detected (git root: \"/work\")") {
+		t.Fatalf("context missing no-remote fallback:\n%s", contextText)
+	}
+}
+
+func TestBuildQuotesPathMetadata(t *testing.T) {
+	cwd := "/work\n- injected"
+	home := "/home/user\n- injected"
+	root := "/repo\n- injected"
+	contextText, err := Build(context.Background(), BuildOptions{
+		Input: HookInput{CWD: cwd},
+		Info:  testInfo(),
+		Paths: config.Paths{Home: home},
+		Runner: fakeGitRunner{
+			root:   root,
+			remote: "https://github.com/jerryfane/gitmoot.git",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	for _, rawBreakout := range []string{"\n- injected", "\n- cwd: /work"} {
+		if strings.Contains(contextText, rawBreakout) {
+			t.Fatalf("context contains raw breakout %q:\n%s", rawBreakout, contextText)
+		}
+	}
+	for _, want := range []string{
+		"- cwd: " + strconv.Quote(cwd),
+		"- Gitmoot home: " + strconv.Quote(home),
+		"root: " + strconv.Quote(root),
+	} {
+		if !strings.Contains(contextText, want) {
+			t.Fatalf("context missing quoted value %q:\n%s", want, contextText)
+		}
+	}
+}
+
+func TestBuildQuotesRepoMetadata(t *testing.T) {
+	remote := "https://github.com/good/repo\n- injected.git"
+	contextText, err := Build(context.Background(), BuildOptions{
+		Input: HookInput{CWD: "/work"},
+		Info:  testInfo(),
+		Paths: config.Paths{Home: "/home/user/.gitmoot"},
+		Runner: fakeGitRunner{
+			root:   "/work",
+			remote: remote,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	if strings.Contains(contextText, "\n- injected") {
+		t.Fatalf("context contains raw repo breakout:\n%s", contextText)
+	}
+	want := "- repo: " + strconv.Quote("good/repo\n- injected")
+	if !strings.Contains(contextText, want) {
+		t.Fatalf("context missing quoted repo %q:\n%s", want, contextText)
+	}
+}
+
+func TestWriteOutputWithContext(t *testing.T) {
+	var out bytes.Buffer
+	if err := WriteOutput(&out, "context text"); err != nil {
+		t.Fatalf("WriteOutput returned error: %v", err)
+	}
+
+	var decoded HookOutput
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("output did not parse: %v\n%s", err, out.String())
+	}
+	if decoded.HookSpecificOutput == nil {
+		t.Fatalf("hookSpecificOutput missing in %s", out.String())
+	}
+	if decoded.HookSpecificOutput.HookEventName != DefaultHookEventName {
+		t.Fatalf("hook event = %q, want %q", decoded.HookSpecificOutput.HookEventName, DefaultHookEventName)
+	}
+	if decoded.HookSpecificOutput.AdditionalContext != "context text" {
+		t.Fatalf("additional context = %q, want context text", decoded.HookSpecificOutput.AdditionalContext)
+	}
+}
+
+func TestWriteOutputWithoutContext(t *testing.T) {
+	var out bytes.Buffer
+	if err := WriteOutput(&out, "  \n  "); err != nil {
+		t.Fatalf("WriteOutput returned error: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("output did not parse: %v\n%s", err, out.String())
+	}
+	if len(decoded) != 0 {
+		t.Fatalf("empty context output = %#v, want empty object", decoded)
+	}
+}
+
+func testInfo() buildinfo.Info {
+	return buildinfo.Info{
+		Version: "test-version",
+		Commit:  "test-commit",
+		Date:    "test-date",
+		Go:      "test-go",
+	}
+}
+
+type fakeGitRunner struct {
+	root      string
+	rootErr   error
+	remote    string
+	remoteErr error
+}
+
+func (r fakeGitRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	if command != "git" {
+		return subprocess.Result{}, errors.New("unexpected command")
+	}
+	joined := strings.Join(args, " ")
+	switch joined {
+	case "rev-parse --show-toplevel":
+		if r.rootErr != nil {
+			return subprocess.Result{}, r.rootErr
+		}
+		return subprocess.Result{Stdout: r.root + "\n"}, nil
+	case "remote get-url origin":
+		if r.remoteErr != nil {
+			return subprocess.Result{}, r.remoteErr
+		}
+		return subprocess.Result{Stdout: r.remote + "\n"}, nil
+	default:
+		return subprocess.Result{}, errors.New("unexpected git args: " + joined)
+	}
+}
+
+func (r fakeGitRunner) LookPath(file string) (string, error) {
+	return file, nil
+}

--- a/internal/plugininstall/install.go
+++ b/internal/plugininstall/install.go
@@ -20,12 +20,13 @@ const (
 )
 
 type Options struct {
-	Provider pluginpack.Provider
-	Home     string
-	Scope    string
-	Force    bool
-	Info     buildinfo.Info
-	Runner   subprocess.Runner
+	Provider      pluginpack.Provider
+	Home          string
+	Scope         string
+	Force         bool
+	Info          buildinfo.Info
+	Runner        subprocess.Runner
+	GitmootBinary string
 }
 
 type Result struct {
@@ -62,11 +63,11 @@ func Install(ctx context.Context, opts Options) (Result, error) {
 	marketplaceRoot := pluginpack.DefaultMarketplaceDir(opts.Home, provider)
 	packagePath := pluginpack.DefaultPackageDir(opts.Home, provider)
 	marketplacePackagePath := filepath.Join(marketplaceRoot, "plugins", pluginpack.PluginName)
-	build, err := buildPackage(provider, opts.Home, packagePath, opts.Force, opts.Info)
+	build, err := buildPackage(provider, opts.Home, packagePath, opts.Force, opts.Info, opts.GitmootBinary)
 	if err != nil {
 		return Result{}, err
 	}
-	if _, err := buildPackage(provider, opts.Home, marketplacePackagePath, opts.Force, opts.Info); err != nil {
+	if _, err := buildPackage(provider, opts.Home, marketplacePackagePath, opts.Force, opts.Info, opts.GitmootBinary); err != nil {
 		return Result{}, err
 	}
 
@@ -113,7 +114,7 @@ func Install(ctx context.Context, opts Options) (Result, error) {
 	return result, nil
 }
 
-func buildPackage(provider pluginpack.Provider, home string, outDir string, force bool, info buildinfo.Info) (pluginpack.BuildResult, error) {
+func buildPackage(provider pluginpack.Provider, home string, outDir string, force bool, info buildinfo.Info, gitmootBinary string) (pluginpack.BuildResult, error) {
 	buildForce := force
 	if !buildForce {
 		if exists, err := pathExists(outDir); err != nil {
@@ -123,11 +124,12 @@ func buildPackage(provider pluginpack.Provider, home string, outDir string, forc
 		}
 	}
 	return pluginpack.Build(pluginpack.BuildOptions{
-		Provider: provider,
-		Home:     home,
-		OutDir:   outDir,
-		Force:    buildForce,
-		Info:     info,
+		Provider:      provider,
+		Home:          home,
+		OutDir:        outDir,
+		Force:         buildForce,
+		Info:          info,
+		GitmootBinary: gitmootBinary,
 	})
 }
 

--- a/internal/plugininstall/install_test.go
+++ b/internal/plugininstall/install_test.go
@@ -124,6 +124,28 @@ func TestInstallMissingRuntimeKeepsGeneratedFiles(t *testing.T) {
 	}
 }
 
+func TestInstallBuildsHookManifestsWithGitmootBinary(t *testing.T) {
+	home := filepath.Join(t.TempDir(), ".gitmoot")
+	result, err := Install(context.Background(), Options{
+		Provider:      pluginpack.ProviderCodex,
+		Home:          home,
+		Runner:        &fakeRunner{},
+		GitmootBinary: "/opt/Gitmoot App/gitmoot",
+	})
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(result.PackagePath, "hooks", "hooks.json"),
+		filepath.Join(result.MarketplaceRoot, "plugins", pluginpack.PluginName, "hooks", "hooks.json"),
+	} {
+		command := readSessionStartCommand(t, path)
+		if command != "'/opt/Gitmoot App/gitmoot' plugin hook-context || true" {
+			t.Fatalf("%s command = %q", path, command)
+		}
+	}
+}
+
 func TestInstallMarketplaceIsIdempotent(t *testing.T) {
 	home := filepath.Join(t.TempDir(), ".gitmoot")
 	runner := &fakeRunner{paths: map[string]string{"codex": "/bin/codex"}}
@@ -262,4 +284,21 @@ func readJSONFile(t *testing.T, path string, out any) {
 	if err := json.Unmarshal(content, out); err != nil {
 		t.Fatalf("unmarshal %s: %v\n%s", path, err, content)
 	}
+}
+
+func readSessionStartCommand(t *testing.T, path string) string {
+	t.Helper()
+	var payload struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	readJSONFile(t, path, &payload)
+	groups := payload.Hooks["SessionStart"]
+	if len(groups) != 1 || len(groups[0].Hooks) != 1 {
+		t.Fatalf("unexpected hook manifest %s: %+v", path, payload)
+	}
+	return groups[0].Hooks[0].Command
 }

--- a/internal/pluginpack/pluginpack.go
+++ b/internal/pluginpack/pluginpack.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/buildinfo"
@@ -36,12 +37,13 @@ const (
 )
 
 type BuildOptions struct {
-	Provider Provider
-	Home     string
-	OutDir   string
-	Force    bool
-	Info     buildinfo.Info
-	SourceFS fs.FS
+	Provider      Provider
+	Home          string
+	OutDir        string
+	Force         bool
+	Info          buildinfo.Info
+	SourceFS      fs.FS
+	GitmootBinary string
 }
 
 type BuildResult struct {
@@ -79,6 +81,10 @@ func ManifestPath(root string, provider Provider) string {
 	default:
 		return filepath.Join(root, "plugin.json")
 	}
+}
+
+func HooksPath(root string) string {
+	return filepath.Join(root, "hooks", "hooks.json")
 }
 
 func IsGeneratedPackageDir(path string, provider Provider) bool {
@@ -141,6 +147,18 @@ func Build(opts BuildOptions) (BuildResult, error) {
 		return BuildResult{}, err
 	}
 	if err := writeJSON(manifestPath, manifest); err != nil {
+		return BuildResult{}, err
+	}
+
+	hooksPath := HooksPath(outDir)
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+		return BuildResult{}, fmt.Errorf("create hooks dir: %w", err)
+	}
+	hooks, err := hooksManifest(provider, opts.GitmootBinary, runtime.GOOS)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	if err := writeJSON(hooksPath, hooks); err != nil {
 		return BuildResult{}, err
 	}
 
@@ -308,6 +326,112 @@ type claudeManifest struct {
 	Homepage    string `json:"homepage"`
 	Repository  string `json:"repository"`
 	License     string `json:"license"`
+}
+
+const (
+	sessionStartMatcher = "startup|resume|clear|compact"
+	hookStatusMessage   = "Loading Gitmoot context"
+	hookTimeoutSeconds  = 5
+)
+
+type hooksFile struct {
+	Hooks map[string][]hookMatcher `json:"hooks"`
+}
+
+type hookMatcher struct {
+	Matcher string        `json:"matcher"`
+	Hooks   []commandHook `json:"hooks"`
+}
+
+type commandHook struct {
+	Type           string `json:"type"`
+	Command        string `json:"command"`
+	CommandWindows string `json:"commandWindows,omitempty"`
+	Shell          string `json:"shell,omitempty"`
+	Timeout        int    `json:"timeout"`
+	StatusMessage  string `json:"statusMessage"`
+}
+
+func hooksManifest(provider Provider, gitmootBinary string, goos string) (hooksFile, error) {
+	handler := commandHook{
+		Type:          "command",
+		Command:       posixHookCommand(gitmootBinary),
+		Timeout:       hookTimeoutSeconds,
+		StatusMessage: hookStatusMessage,
+	}
+	switch provider {
+	case ProviderCodex:
+		handler.CommandWindows = powershellHookCommand(gitmootBinary)
+	case ProviderClaude:
+		if goos == "windows" {
+			handler.Command = powershellHookCommand(gitmootBinary)
+			handler.Shell = "powershell"
+		}
+	default:
+		return hooksFile{}, fmt.Errorf("unknown plugin runtime %q", provider)
+	}
+	return hooksFile{
+		Hooks: map[string][]hookMatcher{
+			"SessionStart": {{
+				Matcher: sessionStartMatcher,
+				Hooks:   []commandHook{handler},
+			}},
+		},
+	}, nil
+}
+
+func posixHookCommand(gitmootBinary string) string {
+	return posixShellQuote(hookBinary(gitmootBinary)) + " plugin hook-context || true"
+}
+
+func powershellHookCommand(gitmootBinary string) string {
+	return "& " + powershellDoubleQuote(hookBinary(gitmootBinary)) + " plugin hook-context; exit 0"
+}
+
+func hookBinary(gitmootBinary string) string {
+	if trimmed := strings.TrimSpace(gitmootBinary); trimmed != "" {
+		return trimmed
+	}
+	return "gitmoot"
+}
+
+func posixShellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	for _, r := range value {
+		if !isPOSIXShellSafe(r) {
+			return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+		}
+	}
+	return value
+}
+
+func isPOSIXShellSafe(r rune) bool {
+	if r >= 'a' && r <= 'z' {
+		return true
+	}
+	if r >= 'A' && r <= 'Z' {
+		return true
+	}
+	if r >= '0' && r <= '9' {
+		return true
+	}
+	switch r {
+	case '/', '.', '_', '-', '+', '=', ':', ',', '@', '%':
+		return true
+	default:
+		return false
+	}
+}
+
+func powershellDoubleQuote(value string) string {
+	escaped := strings.NewReplacer(
+		"`", "``",
+		`"`, "`\"",
+		"$", "`$",
+	).Replace(value)
+	return `"` + escaped + `"`
 }
 
 var semverish = regexp.MustCompile(`^\d+\.\d+\.\d+([-.+][0-9A-Za-z.-]+)?$`)

--- a/internal/pluginpack/pluginpack_test.go
+++ b/internal/pluginpack/pluginpack_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -14,10 +15,11 @@ import (
 func TestBuildCodexPackage(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "gitmoot")
 	result, err := Build(BuildOptions{
-		Provider: ProviderCodex,
-		OutDir:   out,
-		Info:     buildinfo.Info{Version: "v1.2.3"},
-		SourceFS: validSkillFS(),
+		Provider:      ProviderCodex,
+		OutDir:        out,
+		Info:          buildinfo.Info{Version: "v1.2.3"},
+		SourceFS:      validSkillFS(),
+		GitmootBinary: "/opt/Gitmoot App/gitmoot",
 	})
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -55,15 +57,34 @@ func TestBuildCodexPackage(t *testing.T) {
 	if !ok || len(defaultPrompt) != 1 || defaultPrompt[0] != "Use $gitmoot to check agent status." {
 		t.Fatalf("manifest defaultPrompt invalid: %#v", manifest["interface"])
 	}
+
+	hooks := readHooksFile(t, HooksPath(out))
+	handler := onlySessionStartHandler(t, hooks)
+	if handler.Type != "command" {
+		t.Fatalf("hook type = %q, want command", handler.Type)
+	}
+	if handler.Command != "'/opt/Gitmoot App/gitmoot' plugin hook-context || true" {
+		t.Fatalf("hook command = %q", handler.Command)
+	}
+	if handler.CommandWindows != `& "/opt/Gitmoot App/gitmoot" plugin hook-context; exit 0` {
+		t.Fatalf("hook commandWindows = %q", handler.CommandWindows)
+	}
+	if handler.Timeout != hookTimeoutSeconds {
+		t.Fatalf("hook timeout = %d, want %d", handler.Timeout, hookTimeoutSeconds)
+	}
+	if handler.StatusMessage != hookStatusMessage {
+		t.Fatalf("hook statusMessage = %q, want %q", handler.StatusMessage, hookStatusMessage)
+	}
 }
 
 func TestBuildClaudePackage(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "gitmoot")
 	_, err := Build(BuildOptions{
-		Provider: ProviderClaude,
-		OutDir:   out,
-		Info:     buildinfo.Info{Version: "dev"},
-		SourceFS: validSkillFS(),
+		Provider:      ProviderClaude,
+		OutDir:        out,
+		Info:          buildinfo.Info{Version: "dev"},
+		SourceFS:      validSkillFS(),
+		GitmootBinary: "/opt/gitmoot/bin/gitmoot",
 	})
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
@@ -82,6 +103,68 @@ func TestBuildClaudePackage(t *testing.T) {
 	}
 	if _, ok := manifest["skills"]; ok {
 		t.Fatalf("claude manifest should not include codex skills pointer: %#v", manifest)
+	}
+
+	hooks := readHooksFile(t, HooksPath(out))
+	handler := onlySessionStartHandler(t, hooks)
+	wantCommand := "/opt/gitmoot/bin/gitmoot plugin hook-context || true"
+	wantShell := ""
+	if runtime.GOOS == "windows" {
+		wantCommand = `& "/opt/gitmoot/bin/gitmoot" plugin hook-context; exit 0`
+		wantShell = "powershell"
+	}
+	if handler.Command != wantCommand {
+		t.Fatalf("hook command = %q", handler.Command)
+	}
+	if handler.CommandWindows != "" {
+		t.Fatalf("claude hook should not include Codex commandWindows: %+v", handler)
+	}
+	if handler.Shell != wantShell {
+		t.Fatalf("claude hook shell = %q, want %q", handler.Shell, wantShell)
+	}
+	if handler.Timeout != hookTimeoutSeconds || handler.StatusMessage != hookStatusMessage {
+		t.Fatalf("unexpected claude hook handler: %+v", handler)
+	}
+}
+
+func TestHookCommandsFallbackToGitmoot(t *testing.T) {
+	if got := posixHookCommand(""); got != "gitmoot plugin hook-context || true" {
+		t.Fatalf("posixHookCommand fallback = %q", got)
+	}
+	if got := powershellHookCommand(""); got != `& "gitmoot" plugin hook-context; exit 0` {
+		t.Fatalf("powershellHookCommand fallback = %q", got)
+	}
+}
+
+func TestHookCommandQuoting(t *testing.T) {
+	posixPath := "/tmp/git moot/it's/bin/gitmoot"
+	wantPOSIX := `'/tmp/git moot/it'"'"'s/bin/gitmoot' plugin hook-context || true`
+	if got := posixHookCommand(posixPath); got != wantPOSIX {
+		t.Fatalf("posixHookCommand() = %q, want %q", got, wantPOSIX)
+	}
+
+	powershellPath := "C:\\Program Files\\Git\"moot`\\git$moot.exe"
+	wantPowerShell := "& \"C:\\Program Files\\Git`\"moot``\\git`$moot.exe\" plugin hook-context; exit 0"
+	if got := powershellHookCommand(powershellPath); got != wantPowerShell {
+		t.Fatalf("powershellHookCommand() = %q, want %q", got, wantPowerShell)
+	}
+}
+
+func TestClaudeWindowsHookUsesPowerShell(t *testing.T) {
+	hooks, err := hooksManifest(ProviderClaude, `C:\Program Files\Gitmoot\git"moot.exe`, "windows")
+	if err != nil {
+		t.Fatalf("hooksManifest() error = %v", err)
+	}
+	handler := onlySessionStartHandler(t, hooks)
+	if handler.Shell != "powershell" {
+		t.Fatalf("claude Windows hook shell = %q, want powershell", handler.Shell)
+	}
+	wantCommand := "& \"C:\\Program Files\\Gitmoot\\git`\"moot.exe\" plugin hook-context; exit 0"
+	if handler.Command != wantCommand {
+		t.Fatalf("claude Windows hook command = %q, want %q", handler.Command, wantCommand)
+	}
+	if handler.CommandWindows != "" {
+		t.Fatalf("claude Windows hook should not use commandWindows: %+v", handler)
 	}
 }
 
@@ -259,4 +342,32 @@ func readJSON(t *testing.T, path string) map[string]any {
 		t.Fatalf("unmarshal %s: %v\n%s", path, err, content)
 	}
 	return value
+}
+
+func readHooksFile(t *testing.T, path string) hooksFile {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var value hooksFile
+	if err := json.Unmarshal(content, &value); err != nil {
+		t.Fatalf("unmarshal %s: %v\n%s", path, err, content)
+	}
+	return value
+}
+
+func onlySessionStartHandler(t *testing.T, hooks hooksFile) commandHook {
+	t.Helper()
+	groups := hooks.Hooks["SessionStart"]
+	if len(groups) != 1 {
+		t.Fatalf("SessionStart groups = %+v, want one", groups)
+	}
+	if groups[0].Matcher != sessionStartMatcher {
+		t.Fatalf("SessionStart matcher = %q, want %q", groups[0].Matcher, sessionStartMatcher)
+	}
+	if len(groups[0].Hooks) != 1 {
+		t.Fatalf("SessionStart handlers = %+v, want one", groups[0].Hooks)
+	}
+	return groups[0].Hooks[0]
 }


### PR DESCRIPTION
## Summary

Implements the core of issue #294 for the presence layer:

- adds hidden `gitmoot plugin hook-context` for read-only SessionStart context
- generates `hooks/hooks.json` in Codex and Claude plugin packages
- wires plugin build/install to call the installed Gitmoot binary from hooks
- quotes repo/path metadata in hidden context to avoid context injection

This combines task-2941 and task-2942 because the hook command and generated hook manifest are only review-clean together.

## Verification

- `env GOTOOLCHAIN=go1.26.0 go test ./internal/plugincontext ./internal/pluginpack ./internal/plugininstall ./internal/cli`
- `git diff --check`
- `codex exec review --uncommitted` after injection fix: no actionable findings
- `env GOTOOLCHAIN=go1.26.0 go test ./...`

## Notes

Docs and plugin doctor follow in separate branches after this core branch lands.

Fixes part of #294.