### PR TITLE
Validate plugin hook manifests in doctor

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -78,9 +78,9 @@ gitmoot plugin doctor codex
 gitmoot plugin doctor claude
 ```
 
-Doctor checks the canonical skill, generated package, manifest JSON, copied
-skill, marketplace path, runtime CLI availability, and runtime validation where
-supported.
+Doctor checks the canonical skill, generated package, plugin manifest JSON,
+hook manifest JSON, copied skill, marketplace path, runtime CLI availability,
+and runtime validation where supported.
 
 ## Presence Hooks
 

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -379,6 +379,7 @@ func doctorRuntime(home string, provider pluginpack.Provider, explicitRuntime bo
 	runtime.Checks = append(runtime.Checks, checkCanonicalSkill())
 	runtime.Checks = append(runtime.Checks, checkPackage(packagePath))
 	runtime.Checks = append(runtime.Checks, checkManifest(packagePath, provider))
+	runtime.Checks = append(runtime.Checks, checkHookManifest(packagePath, provider))
 	runtime.Checks = append(runtime.Checks, checkCopiedSkill(packagePath))
 	runtime.Checks = append(runtime.Checks, checkMarketplacePath(home, provider))
 	runtime.Checks = append(runtime.Checks, checkRuntimeCLI(provider, explicitRuntime))
@@ -440,6 +441,13 @@ func checkManifest(packagePath string, provider pluginpack.Provider) pluginCheck
 		return failCheck("manifest", manifest+": "+err.Error(), true)
 	}
 	return okCheck("manifest", manifest, true)
+}
+
+func checkHookManifest(packagePath string, provider pluginpack.Provider) pluginCheck {
+	if err := pluginpack.ValidateHooksManifest(packagePath, provider); err != nil {
+		return failCheck("hook-manifest", err.Error(), true)
+	}
+	return okCheck("hook-manifest", pluginpack.HooksPath(packagePath), true)
 }
 
 func checkCopiedSkill(packagePath string) pluginCheck {

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -253,10 +253,51 @@ func TestRunPluginDoctorJSON(t *testing.T) {
 		t.Fatalf("codex runtime should be healthy: %+v", output.Runtimes[0])
 	}
 	assertDoctorCheck(t, output.Runtimes[0].Checks, "manifest", "ok")
+	assertDoctorCheck(t, output.Runtimes[0].Checks, "hook-manifest", "ok")
 	assertDoctorCheck(t, output.Runtimes[0].Checks, "copied-skill", "ok")
 	assertDoctorCheck(t, output.Runtimes[0].Checks, "marketplace-path", "ok")
 	assertDoctorCheck(t, output.Runtimes[0].Checks, "runtime-cli", "ok")
 	assertDoctorCheck(t, output.Runtimes[0].Checks, "validation-command", "warn")
+}
+
+func TestRunPluginDoctorFailsMissingHookManifest(t *testing.T) {
+	home := t.TempDir()
+	if _, err := pluginpack.Build(pluginpack.BuildOptions{
+		Provider: pluginpack.ProviderCodex,
+		Home:     filepath.Join(home, ".gitmoot"),
+	}); err != nil {
+		t.Fatalf("build package: %v", err)
+	}
+	packagePath := filepath.Join(home, ".gitmoot", "plugins", "build", "codex", "gitmoot")
+	if err := os.Remove(pluginpack.HooksPath(packagePath)); err != nil {
+		t.Fatalf("remove hooks manifest: %v", err)
+	}
+	restore := stubPluginLookPath(map[string]string{"codex": "/tmp/bin/codex"})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "doctor", "codex", "--home", home, "--json"}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("plugin doctor exit code = %d, want 1; stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "codex runtime is unhealthy") {
+		t.Fatalf("stderr missing unhealthy runtime:\n%s", stderr.String())
+	}
+	var output pluginDoctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("doctor JSON did not parse: %v\n%s", err, stdout.String())
+	}
+	if output.Runtimes[0].Healthy {
+		t.Fatalf("codex runtime should be unhealthy: %+v", output.Runtimes[0])
+	}
+	check := findDoctorCheck(t, output.Runtimes[0].Checks, "hook-manifest")
+	if check.Status != "fail" {
+		t.Fatalf("hook-manifest status = %q, want fail; checks=%+v", check.Status, output.Runtimes[0].Checks)
+	}
+	if !strings.Contains(check.Detail, filepath.Join("hooks", "hooks.json")) {
+		t.Fatalf("hook-manifest detail = %q, want hooks path", check.Detail)
+	}
 }
 
 func TestRunPluginDoctorClaudeReportsMaskedAuthEnv(t *testing.T) {

--- a/internal/pluginpack/pluginpack.go
+++ b/internal/pluginpack/pluginpack.go
@@ -87,6 +87,22 @@ func HooksPath(root string) string {
 	return filepath.Join(root, "hooks", "hooks.json")
 }
 
+func ValidateHooksManifest(root string, provider Provider) error {
+	if _, err := validateProvider(provider); err != nil {
+		return err
+	}
+	path := HooksPath(root)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	var hooks hooksFile
+	if err := json.Unmarshal(content, &hooks); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return validateHooksManifest(hooks, provider)
+}
+
 func IsGeneratedPackageDir(path string, provider Provider) bool {
 	return isGeneratedPackageDir(path, provider)
 }
@@ -378,6 +394,168 @@ func hooksManifest(provider Provider, gitmootBinary string, goos string) (hooksF
 			}},
 		},
 	}, nil
+}
+
+func validateHooksManifest(hooks hooksFile, provider Provider) error {
+	if len(hooks.Hooks) != 1 {
+		return fmt.Errorf("hook manifest has %d hook events, want exactly SessionStart", len(hooks.Hooks))
+	}
+	groups := hooks.Hooks["SessionStart"]
+	if len(groups) != 1 {
+		return fmt.Errorf("SessionStart hook groups = %d, want one", len(groups))
+	}
+	group := groups[0]
+	if group.Matcher != sessionStartMatcher {
+		return fmt.Errorf("SessionStart matcher = %q, want %q", group.Matcher, sessionStartMatcher)
+	}
+	if len(group.Hooks) != 1 {
+		return fmt.Errorf("SessionStart command hooks = %d, want one", len(group.Hooks))
+	}
+	return validateHookCommand(group.Hooks[0], provider)
+}
+
+func validateHookCommand(hook commandHook, provider Provider) error {
+	if hook.Type != "command" {
+		return fmt.Errorf("hook type = %q, want command", hook.Type)
+	}
+	if hook.Timeout != hookTimeoutSeconds {
+		return fmt.Errorf("hook timeout = %d, want %d", hook.Timeout, hookTimeoutSeconds)
+	}
+	if hook.StatusMessage != hookStatusMessage {
+		return fmt.Errorf("hook statusMessage = %q, want %q", hook.StatusMessage, hookStatusMessage)
+	}
+	switch provider {
+	case ProviderCodex:
+		if err := validatePOSIXHookCommand("command", hook.Command); err != nil {
+			return err
+		}
+		return validatePowerShellHookCommand("commandWindows", hook.CommandWindows)
+	case ProviderClaude:
+		if hook.Shell == "powershell" {
+			return validatePowerShellHookCommand("command", hook.Command)
+		}
+		if strings.TrimSpace(hook.Shell) != "" {
+			return fmt.Errorf("hook shell = %q, want empty or powershell", hook.Shell)
+		}
+		return validatePOSIXHookCommand("command", hook.Command)
+	default:
+		return fmt.Errorf("unknown plugin runtime %q", provider)
+	}
+}
+
+func validatePOSIXHookCommand(label string, command string) error {
+	command = strings.TrimSpace(command)
+	const suffix = " plugin hook-context || true"
+	if !strings.HasSuffix(command, suffix) {
+		return fmt.Errorf("%s has unexpected shape; want <gitmoot-binary> plugin hook-context || true", label)
+	}
+	binary, ok := parsePOSIXCommandWord(strings.TrimSuffix(command, suffix))
+	if !ok {
+		return fmt.Errorf("%s gitmoot binary is not a single POSIX shell word", label)
+	}
+	return validateHookBinary(label, binary)
+}
+
+func validatePowerShellHookCommand(label string, command string) error {
+	command = strings.TrimSpace(command)
+	const prefix = `& "`
+	if !strings.HasPrefix(command, prefix) {
+		return fmt.Errorf("%s has unexpected shape; want & \"<gitmoot-binary>\" plugin hook-context; exit 0", label)
+	}
+	end := len(prefix)
+	var binary strings.Builder
+	for end < len(command) {
+		switch command[end] {
+		case '`':
+			if end+1 >= len(command) {
+				return fmt.Errorf("%s has dangling PowerShell escape", label)
+			}
+			switch command[end+1] {
+			case '`', '"', '$':
+			default:
+				return fmt.Errorf("%s has unsupported PowerShell escape", label)
+			}
+			binary.WriteByte(command[end+1])
+			end += 2
+		case '$':
+			return fmt.Errorf("%s gitmoot binary contains unescaped PowerShell expansion", label)
+		case '"':
+			if end == len(prefix) {
+				return fmt.Errorf("%s gitmoot binary is empty", label)
+			}
+			const suffix = `" plugin hook-context; exit 0`
+			if command[end:] != suffix {
+				return fmt.Errorf("%s has unexpected shape; want & \"<gitmoot-binary>\" plugin hook-context; exit 0", label)
+			}
+			return validateHookBinary(label, binary.String())
+		default:
+			binary.WriteByte(command[end])
+			end++
+		}
+	}
+	return fmt.Errorf("%s has unterminated PowerShell string", label)
+}
+
+func parsePOSIXCommandWord(word string) (string, bool) {
+	if word == "" {
+		return "", false
+	}
+	var binary strings.Builder
+	for i := 0; i < len(word); {
+		switch word[i] {
+		case '\'':
+			i++
+			for i < len(word) && word[i] != '\'' {
+				binary.WriteByte(word[i])
+				i++
+			}
+			if i == len(word) {
+				return "", false
+			}
+			i++
+		case '"':
+			if i+3 > len(word) || word[i:i+3] != `"'"` {
+				return "", false
+			}
+			binary.WriteByte('\'')
+			i += 3
+		default:
+			if !isPOSIXShellSafe(rune(word[i])) {
+				return "", false
+			}
+			binary.WriteByte(word[i])
+			i++
+		}
+	}
+	return binary.String(), true
+}
+
+func validateHookBinary(label string, binary string) error {
+	binary = strings.TrimSpace(binary)
+	if !hookBinaryHasPath(binary) {
+		if binary != "gitmoot" && binary != "gitmoot.exe" {
+			return fmt.Errorf("%s gitmoot binary = %q, want gitmoot executable on PATH or a path to an existing executable", label, binary)
+		}
+		return nil
+	}
+	if !filepath.IsAbs(binary) {
+		return fmt.Errorf("%s gitmoot binary %q must be absolute", label, binary)
+	}
+	info, err := os.Stat(binary)
+	if err != nil {
+		return fmt.Errorf("%s gitmoot binary %q is unavailable: %w", label, binary, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s gitmoot binary %q is a directory", label, binary)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("%s gitmoot binary %q is not executable", label, binary)
+	}
+	return nil
+}
+
+func hookBinaryHasPath(binary string) bool {
+	return filepath.IsAbs(binary) || strings.ContainsAny(binary, `/\`)
 }
 
 func posixHookCommand(gitmootBinary string) string {

--- a/internal/pluginpack/pluginpack_test.go
+++ b/internal/pluginpack/pluginpack_test.go
@@ -127,6 +127,194 @@ func TestBuildClaudePackage(t *testing.T) {
 	}
 }
 
+func TestValidateHooksManifestAcceptsGeneratedPackage(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "gitmoot")
+	gitmootBinary := writeTempGitmootBinary(t)
+	if _, err := Build(BuildOptions{
+		Provider:      ProviderCodex,
+		OutDir:        out,
+		SourceFS:      validSkillFS(),
+		GitmootBinary: gitmootBinary,
+	}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if err := ValidateHooksManifest(out, ProviderCodex); err != nil {
+		t.Fatalf("ValidateHooksManifest() error = %v", err)
+	}
+}
+
+func TestValidateHooksManifestAcceptsRenamedExecutablePath(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "gitmoot")
+	gitmootBinary := writeTempExecutable(t, "gitmoot-current")
+	if _, err := Build(BuildOptions{
+		Provider:      ProviderCodex,
+		OutDir:        out,
+		SourceFS:      validSkillFS(),
+		GitmootBinary: gitmootBinary,
+	}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if err := ValidateHooksManifest(out, ProviderCodex); err != nil {
+		t.Fatalf("ValidateHooksManifest() error = %v", err)
+	}
+}
+
+func TestValidateHooksManifestRejectsMissingHookContextCommand(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "gitmoot")
+	if _, err := Build(BuildOptions{
+		Provider:      ProviderClaude,
+		OutDir:        out,
+		SourceFS:      validSkillFS(),
+		GitmootBinary: "/opt/gitmoot/bin/gitmoot",
+	}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	hooks := readHooksFile(t, HooksPath(out))
+	hooks.Hooks["SessionStart"][0].Hooks[0].Command = "echo ready || true"
+	if err := writeJSON(HooksPath(out), hooks); err != nil {
+		t.Fatalf("write hooks manifest: %v", err)
+	}
+
+	err := ValidateHooksManifest(out, ProviderClaude)
+	if err == nil {
+		t.Fatal("ValidateHooksManifest() error = nil, want malformed command error")
+	}
+	if !strings.Contains(err.Error(), "unexpected shape") {
+		t.Fatalf("ValidateHooksManifest() error = %v", err)
+	}
+}
+
+func TestValidateHooksManifestRejectsExtraSessionStartHook(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "gitmoot")
+	if _, err := Build(BuildOptions{
+		Provider:      ProviderCodex,
+		OutDir:        out,
+		SourceFS:      validSkillFS(),
+		GitmootBinary: "/opt/gitmoot/bin/gitmoot",
+	}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	hooks := readHooksFile(t, HooksPath(out))
+	hooks.Hooks["SessionStart"][0].Hooks = append(hooks.Hooks["SessionStart"][0].Hooks, commandHook{
+		Type:           "command",
+		Command:        "echo extra || true",
+		CommandWindows: `& "gitmoot" plugin hook-context; exit 0`,
+		Timeout:        hookTimeoutSeconds,
+		StatusMessage:  hookStatusMessage,
+	})
+	if err := writeJSON(HooksPath(out), hooks); err != nil {
+		t.Fatalf("write hooks manifest: %v", err)
+	}
+
+	err := ValidateHooksManifest(out, ProviderCodex)
+	if err == nil {
+		t.Fatal("ValidateHooksManifest() error = nil, want extra hook error")
+	}
+	if !strings.Contains(err.Error(), "command hooks = 2") {
+		t.Fatalf("ValidateHooksManifest() error = %v", err)
+	}
+}
+
+func TestValidateHooksManifestRejectsExtraShellOperation(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "gitmoot")
+	if _, err := Build(BuildOptions{
+		Provider:      ProviderCodex,
+		OutDir:        out,
+		SourceFS:      validSkillFS(),
+		GitmootBinary: "/opt/gitmoot/bin/gitmoot",
+	}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	hooks := readHooksFile(t, HooksPath(out))
+	hooks.Hooks["SessionStart"][0].Hooks[0].Command = "gitmoot plugin hook-context || true; echo extra"
+	if err := writeJSON(HooksPath(out), hooks); err != nil {
+		t.Fatalf("write hooks manifest: %v", err)
+	}
+
+	err := ValidateHooksManifest(out, ProviderCodex)
+	if err == nil {
+		t.Fatal("ValidateHooksManifest() error = nil, want extra shell operation error")
+	}
+	if !strings.Contains(err.Error(), "unexpected shape") {
+		t.Fatalf("ValidateHooksManifest() error = %v", err)
+	}
+}
+
+func TestValidateHooksManifestRejectsPowerShellExpansion(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "gitmoot")
+	gitmootBinary := writeTempGitmootBinary(t)
+	if _, err := Build(BuildOptions{
+		Provider:      ProviderCodex,
+		OutDir:        out,
+		SourceFS:      validSkillFS(),
+		GitmootBinary: gitmootBinary,
+	}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	hooks := readHooksFile(t, HooksPath(out))
+	hooks.Hooks["SessionStart"][0].Hooks[0].CommandWindows = `& "$(Write-Output gitmoot)" plugin hook-context; exit 0`
+	if err := writeJSON(HooksPath(out), hooks); err != nil {
+		t.Fatalf("write hooks manifest: %v", err)
+	}
+
+	err := ValidateHooksManifest(out, ProviderCodex)
+	if err == nil {
+		t.Fatal("ValidateHooksManifest() error = nil, want PowerShell expansion error")
+	}
+	if !strings.Contains(err.Error(), "PowerShell expansion") {
+		t.Fatalf("ValidateHooksManifest() error = %v", err)
+	}
+}
+
+func TestValidateHooksManifestRejectsNonGitmootBinary(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "gitmoot")
+	if _, err := Build(BuildOptions{
+		Provider:      ProviderClaude,
+		OutDir:        out,
+		SourceFS:      validSkillFS(),
+		GitmootBinary: "gitmoot",
+	}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	hooks := readHooksFile(t, HooksPath(out))
+	hooks.Hooks["SessionStart"][0].Hooks[0].Command = "true plugin hook-context || true"
+	hooks.Hooks["SessionStart"][0].Hooks[0].Shell = ""
+	if err := writeJSON(HooksPath(out), hooks); err != nil {
+		t.Fatalf("write hooks manifest: %v", err)
+	}
+
+	err := ValidateHooksManifest(out, ProviderClaude)
+	if err == nil {
+		t.Fatal("ValidateHooksManifest() error = nil, want non-gitmoot binary error")
+	}
+	if !strings.Contains(err.Error(), "want gitmoot executable") {
+		t.Fatalf("ValidateHooksManifest() error = %v", err)
+	}
+}
+
+func TestValidateHooksManifestRejectsUnavailableGitmootPath(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "gitmoot")
+	missingGitmoot := filepath.Join(t.TempDir(), "gitmoot")
+	if _, err := Build(BuildOptions{
+		Provider:      ProviderClaude,
+		OutDir:        out,
+		SourceFS:      validSkillFS(),
+		GitmootBinary: missingGitmoot,
+	}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	err := ValidateHooksManifest(out, ProviderClaude)
+	if err == nil {
+		t.Fatal("ValidateHooksManifest() error = nil, want missing binary error")
+	}
+	if !strings.Contains(err.Error(), "is unavailable") {
+		t.Fatalf("ValidateHooksManifest() error = %v", err)
+	}
+}
+
 func TestHookCommandsFallbackToGitmoot(t *testing.T) {
 	if got := posixHookCommand(""); got != "gitmoot plugin hook-context || true" {
 		t.Fatalf("posixHookCommand fallback = %q", got)
@@ -318,6 +506,20 @@ func validSkillFS() fstest.MapFS {
 		"gitmoot/references/SAFETY.md":    {Data: []byte("safety\n")},
 		"gitmoot/references/WORKFLOWS.md": {Data: []byte("workflow\n")},
 	}
+}
+
+func writeTempGitmootBinary(t *testing.T) string {
+	t.Helper()
+	return writeTempExecutable(t, "gitmoot")
+}
+
+func writeTempExecutable(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write temp gitmoot binary: %v", err)
+	}
+	return path
 }
 
 func assertFileContains(t *testing.T, path, want string) {

--- a/website/docs/plugins/codex-claude.md
+++ b/website/docs/plugins/codex-claude.md
@@ -78,9 +78,9 @@ gitmoot plugin doctor codex
 gitmoot plugin doctor claude
 ```
 
-Doctor checks the canonical skill, generated package, manifest JSON, copied
-skill, marketplace path, runtime CLI availability, and runtime validation where
-supported.
+Doctor checks the canonical skill, generated package, plugin manifest JSON,
+hook manifest JSON, copied skill, marketplace path, runtime CLI availability,
+and runtime validation where supported.
 
 ## Presence Hooks
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1316,9 +1316,9 @@ gitmoot plugin doctor codex
 gitmoot plugin doctor claude
 ```
 
-Doctor checks the canonical skill, generated package, manifest JSON, copied
-skill, marketplace path, runtime CLI availability, and runtime validation where
-supported.
+Doctor checks the canonical skill, generated package, plugin manifest JSON,
+hook manifest JSON, copied skill, marketplace path, runtime CLI availability,
+and runtime validation where supported.
 
 ## Presence Hooks
 


### PR DESCRIPTION
## Summary
- add `plugin doctor` validation for generated hook manifests
- validate the expected `SessionStart` event, matcher, command shape, timeout, and status message for Codex and Claude packages
- keep generated smoke binaries such as `/tmp/gitmoot-current` valid by accepting existing path-qualified executables while rejecting suspicious bare commands
- document that doctor now checks hook manifest JSON

Refs #294

## Checks
- `git diff --check`
- `env GOTOOLCHAIN=go1.26.0 go test ./internal/pluginpack ./internal/cli`
- `env GOTOOLCHAIN=go1.26.0 go test ./...`
- `cd website && npm run build:llms`
- `cd website && npm run build`

## Review
Raw final review output:

```text
No findings.
```
