### PR TITLE
feat(workflow): add delegations schema and remove next_agents

### DIFF
--- a/GOALS/GOAL-issue-289-bug-report-flow.md
+++ b/GOALS/GOAL-issue-289-bug-report-flow.md
@@ -1,0 +1,416 @@
+# Implement Gitmoot Bug Report Flow
+
+Implement GitHub issue #289 task by task. Each task must be developed,
+reviewed, opened as its own pull request, merged, and verified before moving on,
+unless tasks are explicitly safe to run in parallel.
+
+Issue: https://github.com/jerryfane/gitmoot/issues/289
+
+The goal is to add a CLI-first Gitmoot bug-reporting system that can create
+high-quality GitHub issues from failed jobs, dashboard errors, daemon errors,
+and SkillOpt/train errors. The same underlying report builder should power both
+agent/CLI usage and the dashboard `B report bug` flow.
+
+## Core Rules
+
+- Target repository: `jerryfane/gitmoot`.
+- Target base branch: `main`.
+- Preserve existing unrelated uncommitted docs/logo changes. If those changes
+  make a task commit ambiguous, stop and ask before continuing.
+- Work one task at a time in the listed order by default.
+- Task 1 must merge first because it defines the shared report-builder
+  interface.
+- After Task 1 is merged, Tasks 2 and 3 may run in parallel on separate
+  branches/worktrees because they should touch mostly disjoint CLI/GitHub and
+  dashboard/TUI surfaces.
+- Task 4 must start only after Tasks 2 and 3 are merged.
+- Do not commit generated reports, caches, build artifacts, secrets,
+  credentials, session archives, cloned helper repos, local plugin build output,
+  or large outputs unless a task explicitly says they are intended tracked
+  fixtures/artifacts.
+- Preserve existing behavior unless the current task explicitly changes it.
+- Keep changes clean, scoped, and organized. Avoid broad rewrites.
+- Avoid code duplication. When repeated logic appears, extract small reusable
+  helpers that match existing repo patterns.
+- When delegating to Gitmoot agents, use `gitmoot agent run`,
+  `gitmoot agent implement`, `gitmoot agent review`, or `gitmoot task run`.
+  Do not put branch creation, commit, push, PR creation, or merge instructions
+  inside `gitmoot agent ask`; Gitmoot owns repository orchestration.
+- If implementation depends on external APIs, docs, CLIs, data formats,
+  generated scripts, installers, service launchers, subprocess calls, env vars,
+  config formats, or third-party libraries, verify the real contract with local
+  commands and/or official sources before editing.
+
+## Before Starting
+
+1. Inspect current repo state:
+   - `git status --short`
+   - `git branch --show-current`
+   - `git remote -v`
+2. Confirm the current checkout is `jerryfane/gitmoot` on `main`, or stop and
+   ask before continuing.
+3. If unrelated local changes overlap a task's files, stop and ask before
+   committing.
+4. Verify PR tooling before the first PR:
+   - `gh auth status`
+   - `gh repo view jerryfane/gitmoot`
+5. Pull/update `main` before creating each task branch.
+
+## Per-Task Branch Workflow
+
+1. Confirm the current task's scope.
+2. Create a task branch from latest `main`.
+3. Implement only that task.
+4. Add or update focused tests/checks appropriate to the task.
+5. Run focused tests for touched modules.
+6. Run broader checks when the task touches shared behavior, CLI/API surfaces,
+   GitHub integration, TUI workflows, docs build systems, or user-facing
+   behavior.
+7. For CLI, subprocess, GitHub, or dashboard changes, include an operational
+   smoke test or direct contract check. Syntax checks alone are not enough.
+8. Run `git diff --check`.
+9. Run `codex exec review --uncommitted` in every repo with uncommitted
+   changes.
+10. Preserve the exact raw final review output for the PR body.
+
+## Review-Fix Loop
+
+1. If review finds issues, do not only patch the literal line.
+2. Identify the underlying invariant/class of bug.
+3. Audit nearby and sibling paths for the same issue.
+4. Write a concise fix plan using:
+
+   ```text
+   Review found these issues: <<PASTE RAW REVIEW RESULTS BY REPO>>.
+   For each issue, identify the underlying invariant/class of bug, audit sibling
+   paths for the same issue, and plan the smallest safe fix. Verify external
+   assumptions with local commands and/or official sources. Preserve repo
+   patterns, avoid unnecessary refactors, and list tests/checks per repo.
+   ```
+
+5. Execute the fix plan.
+6. Re-run focused tests/checks and `codex exec review --uncommitted`.
+7. Repeat until the final raw review output contains no findings, or stop if
+   blocked or if a finding is incorrect after verification.
+
+## Commit Gate
+
+1. Inspect the final diff.
+2. Commit only the current task's intended tracked changes.
+3. Use the suggested commit message unless there is a clearer task-specific
+   alternative.
+4. Push the task branch.
+5. Verify the task branch worktree is clean after push, except for intentionally
+   ignored generated files.
+
+## Pull Request Gate
+
+1. Create one PR for the current task.
+2. The PR title must describe only the current task.
+3. The PR body must include:
+   - WHAT: what changed
+   - WHY: why the task was needed
+   - CHANGES: concrete implementation changes
+   - RESULTS: tests/checks/review results
+   - RISK: skipped checks, blockers, or residual risk
+4. Include the exact raw final `codex exec review --uncommitted` output in the
+   PR body.
+5. If CI or required checks exist, wait for them and fix failures before merge.
+6. Merge using the repository's configured/preferred merge method. If no
+   preference is discoverable, use squash merge for a clean task-level history.
+7. After merge, update local `main` and verify the worktree is clean except for
+   unrelated pre-existing changes.
+8. Record the PR number, PR URL, branch name, and merged commit hash.
+9. Delete the task branch after merge only if the repository normally does so or
+   the merge command supports safe branch deletion.
+
+## Parallel Task Rules
+
+- Parallelize only when tasks are independent, have disjoint file ownership, and
+  can be reviewed and merged without order-dependent assumptions.
+- Use one branch/worktree per task.
+- Clearly assign each branch a task number and file ownership.
+- Do not duplicate work across branches.
+- For Gitmoot-owned task PRs, let the merge gate update stale branches and
+  retry. If a real content conflict remains, resolve it in an explicit fix task
+  and re-run checks/review.
+- If Task 2 and Task 3 both need a shared interface adjustment after Task 1,
+  stop parallel work, make the shared adjustment in a small follow-up PR, merge
+  it, then rebase/update both task branches.
+
+## Final Response After All Tasks
+
+- List completed tasks.
+- For each task, list branch, PR URL, merge status, and merged commit hash.
+- List tests/checks run.
+- Include exact final raw `codex exec review --uncommitted` output for the last
+  task/repo.
+- Mention skipped checks, blockers, or residual risk.
+- Do not claim interactive `/review` is clean. Say:
+  `codex exec review is clean; ready for manual /review.`
+
+## Implementation Tasks
+
+### Task 1: Core Report Builder And Redaction
+
+Implement the shared report engine only. This task must merge before any CLI or
+dashboard integration work starts.
+
+Scope:
+
+- Add an internal report builder package that returns a structured bug report:
+  title, markdown body, labels, fingerprint, source metadata, and redaction
+  summary.
+- Support job-source reports first:
+  - load job by id
+  - parse payload
+  - include repo, agent, runtime if available, action, state, task, PR, result
+    summary, result decision, and recent events
+  - include enough request context to debug without exposing unnecessary raw
+    runtime output
+- Use the marker:
+
+  ```md
+  <!-- gitmoot:dashboard-report fingerprint:<hash> -->
+  ```
+
+- Reuse existing redaction behavior where possible:
+  - `workflow.RedactCommentText`
+  - comment truncation limits/patterns
+  - `/gitmoot` command neutralization
+- Omit raw runtime output by default. If any raw output excerpt is included, it
+  must be redacted and truncated.
+- Return labels `gitmoot-dashboard-report` and `bug` from the report builder.
+- Do not create GitHub issues in this task.
+
+Acceptance criteria:
+
+- A failed/blocked/cancelled job can produce a markdown report.
+- The report includes environment, selected error, job context, recent events,
+  and redaction notes.
+- Secrets such as GitHub tokens, API keys, passwords, Claude/OAuth/auth tokens,
+  and AWS credentials are redacted.
+- Fingerprint is stable for the same source/error and changes when the source
+  job/error changes materially.
+
+Tests/checks:
+
+- Focused tests for report builder formatting.
+- Redaction tests with GitHub token, API key, password, AWS key, and auth token
+  samples.
+- Truncation/omission test for long raw output.
+- `go test ./internal/...` or a narrower command if package boundaries make
+  that cheaper and sufficient.
+- `git diff --check`.
+- `codex exec review --uncommitted`.
+
+Suggested branch:
+
+```text
+issue-289-report-builder
+```
+
+Suggested commit:
+
+```text
+feat: add bug report builder
+```
+
+Dedicated task prompt:
+
+```text
+/goal Read /root/gitmoot/GOAL-issue-289-bug-report-flow.md. Execute Task 1 only: Core Report Builder And Redaction. Use a separate branch/worktree from latest main, preserve unrelated changes, implement only the shared builder/redaction layer, run focused tests, run codex exec review --uncommitted, open one PR, and stop after the PR is merged and verified.
+```
+
+### Task 2: CLI And GitHub Issue Creation
+
+Add the `gitmoot report bug` CLI using Task 1's report builder.
+
+Scope:
+
+- Add a top-level `report` CLI command with `bug` subcommand.
+- Implement:
+
+  ```sh
+  gitmoot report bug --job <job-id> --preview
+  gitmoot report bug --job <job-id> --create --yes
+  gitmoot report bug --source daemon --preview
+  gitmoot report bug --source dashboard --preview
+  gitmoot report bug --train <session-id> --create --yes
+  ```
+
+- For MVP, `--job` must be fully functional.
+- If daemon/dashboard/train report sources cannot be implemented safely in this
+  task, keep the CLI shape and return clear unsupported-source errors that name
+  the future source.
+- Default behavior is preview if neither `--preview` nor `--create` is given.
+- Non-interactive issue creation requires `--create --yes`.
+- Extend `github.CreateIssueInput` with `Labels []string`.
+- Apply labels from the report builder. Generated reports should use:
+  - `gitmoot-dashboard-report`
+  - `bug`
+- Best-effort label handling:
+  - try to create/apply `gitmoot-dashboard-report` if missing
+  - if label creation/application fails, still create the issue
+  - always include the marker in the body so reports remain searchable
+- Best-effort duplicate detection:
+  - search open `jerryfane/gitmoot` issues for the fingerprint marker
+  - if a match exists, print the existing issue URL instead of creating a
+    duplicate
+
+Acceptance criteria:
+
+- Preview prints redacted markdown and does not call GitHub issue creation.
+- Create creates an issue and prints the URL.
+- Missing/generated label failures do not block issue creation.
+- Duplicate fingerprint returns the existing issue URL.
+- CLI usage/help is clear enough for agents to call correctly.
+
+Tests/checks:
+
+- CLI preview test.
+- CLI create test using fake GitHub client/runner.
+- `--create` without `--yes` failure test.
+- label fallback test.
+- duplicate fingerprint test.
+- GitHub client label argument test.
+- `go test ./internal/cli ./internal/github ./internal/report` or equivalent.
+- `git diff --check`.
+- `codex exec review --uncommitted`.
+
+Suggested branch:
+
+```text
+issue-289-report-cli
+```
+
+Suggested commit:
+
+```text
+feat: add bug report CLI
+```
+
+Dedicated task prompt:
+
+```text
+/goal Read /root/gitmoot/GOAL-issue-289-bug-report-flow.md. Execute Task 2 only after Task 1 is merged: CLI And GitHub Issue Creation. Use a separate branch/worktree from latest main, implement the CLI and GitHub issue integration only, run focused and relevant broader tests, run codex exec review --uncommitted, open one PR, and stop after the PR is merged and verified.
+```
+
+### Task 3: Dashboard TUI Report Action
+
+Add the dashboard `B report bug` preview/create flow using the shared report
+builder.
+
+Scope:
+
+- Add a dashboard TUI mode such as `modeBugReportPreview`.
+- Add TUI deps for:
+  - building a bug report preview for a selected source
+  - creating a bug report issue for a selected source
+- Show `B report bug` only when the selected item is reportable:
+  - failed job
+  - blocked job
+  - cancelled job
+  - visible dashboard refresh/action error if already modeled as selectable
+- For MVP, failed/blocked/cancelled jobs must be fully functional.
+- Preview panel is read-only.
+- `g` creates the GitHub issue.
+- `esc` cancels and returns to the prior dashboard view.
+- Successful creation shows the issue URL.
+- Creation errors stay inline without closing the preview.
+- Reuse existing job detail/event loading and modal action patterns.
+- Do not duplicate report-building logic in the TUI layer.
+
+Acceptance criteria:
+
+- `B report bug` appears only for reportable selected items.
+- Pressing `B` opens a redacted preview for the selected job.
+- Pressing `g` creates an issue through the dep and shows the URL.
+- Failed creation keeps preview open with an inline error.
+- Existing retry/cancel/detail flows continue to work.
+
+Tests/checks:
+
+- TUI key hint visibility tests.
+- TUI preview render test.
+- TUI create-success test.
+- TUI create-error test.
+- Regression tests for retry/cancel overlays if touched.
+- `go test ./internal/cli/tui ./internal/cli` or equivalent.
+- `git diff --check`.
+- `codex exec review --uncommitted`.
+
+Suggested branch:
+
+```text
+issue-289-dashboard-report-action
+```
+
+Suggested commit:
+
+```text
+feat: add dashboard bug report action
+```
+
+Dedicated task prompt:
+
+```text
+/goal Read /root/gitmoot/GOAL-issue-289-bug-report-flow.md. Execute Task 3 only after Task 1 is merged: Dashboard TUI Report Action. Use a separate branch/worktree from latest main, avoid touching CLI code except shared interfaces, run TUI-focused tests, run codex exec review --uncommitted, open one PR, and stop after the PR is merged and verified.
+```
+
+### Task 4: Docs, Skill Guidance, Integration, Final Review
+
+Document the feature and verify the end-to-end behavior after Tasks 1-3 merge.
+
+Scope:
+
+- Update CLI reference docs with `gitmoot report bug`.
+- Update dashboard docs/release notes if appropriate.
+- Update Gitmoot skill guidance:
+  - agents preview by default
+  - agents create reports only when the user explicitly asks or policy allows
+  - agents report the issue URL back to the user after creation
+- Add integration smoke coverage around CLI preview/create with fake GitHub.
+- Verify the final behavior and issue #289 acceptance criteria.
+
+Acceptance criteria:
+
+- Docs clearly explain dashboard and CLI/agent flows.
+- Agents have explicit guidance for preview vs create.
+- Full expected command set is documented.
+- End-to-end tests demonstrate report preview and create behavior.
+- Issue #289 can be closed after final PR merge.
+
+Tests/checks:
+
+- Focused Go tests for report/CLI/TUI packages.
+- `go test ./...`.
+- `cd website && npm run build` if website docs changed.
+- `git diff --check`.
+- `codex exec review --uncommitted`.
+
+Suggested branch:
+
+```text
+issue-289-report-docs-integration
+```
+
+Suggested commit:
+
+```text
+docs: document bug report workflow
+```
+
+Dedicated task prompt:
+
+```text
+/goal Read /root/gitmoot/GOAL-issue-289-bug-report-flow.md. Execute Task 4 only after Tasks 2 and 3 are merged: Docs, Skill Guidance, Integration, Final Review. Update docs/skill guidance, run full relevant checks, run codex exec review --uncommitted, open the final PR, merge when clean, and summarize all task PRs.
+```
+
+## Coordinator Prompt
+
+Use this prompt to start the coordinator:
+
+```text
+/goal Read and execute /root/gitmoot/GOAL-issue-289-bug-report-flow.md for jerryfane/gitmoot issue #289. Coordinate the work task-by-task. Start Task 1 first. After Task 1 is merged, dispatch Tasks 2 and 3 concurrently on separate branches/worktrees. Start Task 4 only after Tasks 2 and 3 are merged. For every task, implement only that task, run focused tests and required broader checks, run codex exec review --uncommitted, fix until clean, open one PR, wait for checks, merge, update main, and record branch/PR/merge hash. Preserve existing unrelated uncommitted docs/logo changes and stop if they make task commits ambiguous.
+```

--- a/GOALS/GOAL-structured-job-delegations.md
+++ b/GOALS/GOAL-structured-job-delegations.md
@@ -7,7 +7,7 @@ continuation jobs. This keeps multi-agent coordination entirely inside Gitmoot
 (no external tools) and uses the existing job system as the coordination
 substrate.
 
-This goal also removes `next_agents` cleanly, as agreed in
+This goal also removes the old agent-list result field cleanly, as agreed in
 https://github.com/jerryfane/gitmoot/issues/301#issuecomment-4717451503.
 
 ## Core Rules
@@ -181,7 +181,7 @@ worktree, runs tests/review, pushes, opens a PR, and reports back.
 
 ## Implementation Tasks
 
-### Task 3051: Schema migration — introduce delegations and remove next_agents
+### Task 3051: Schema migration — introduce structured delegations
 
 **Scope:**
 
@@ -204,7 +204,7 @@ worktree, runs tests/review, pushes, opens a PR, and reports back.
   }
   ```
 
-- Replace `NextAgents []string` in `AgentResult` with `Delegations []Delegation`.
+- Replace the old string-list handoff field in `AgentResult` with `Delegations []Delegation`.
 - Update `normalizeAgentResult` to default `Delegations` to `[]Delegation{}`.
 - Add job DAG fields to `JobRequest` and `JobPayload` in
   `internal/workflow/mailbox.go`:
@@ -219,18 +219,17 @@ worktree, runs tests/review, pushes, opens a PR, and reports back.
   - indexes on `(parent_job_id)` and `(delegation_id)`
 - Update `db.Job` struct and `Store.CreateJobWithEvent` / `GetJob` paths to
   persist the new fields.
-- Remove all `NextAgents`/`next_agents` references from the schema and data
-  model.
+- Remove the old agent-list field from the schema and data model.
 
 **Acceptance criteria:**
 
 - `go test ./internal/workflow ./internal/db` passes.
-- `grep -R "NextAgents\|next_agents" --include="*.go" internal/workflow internal/db` returns nothing.
+- a tracked-file grep for the old agent-list field returns nothing.
 
 **Suggested commit message:**
 
 ```text
-feat(workflow): add delegations schema and remove next_agents
+feat(workflow): add structured delegations schema
 ```
 
 ### Task 3052: Parse delegations and update the result contract
@@ -241,24 +240,23 @@ feat(workflow): add delegations schema and remove next_agents
   `delegations`.
 - Update `validateAgentResult` and `normalizeAgentResult` for the new field.
 - Update `internal/prompts/prompts.go` `RenderJob` and `RenderRepairPrompt` to
-  show a `delegations` example instead of `next_agents`:
+  show a `delegations` example:
 
   ```json
   {"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}
   ```
 
-- Update `skills/gitmoot/references/RESULT_CONTRACT.md` with the new field,
-  delegation example, and migration note for `next_agents` removal.
+- Update `skills/gitmoot/references/RESULT_CONTRACT.md` with the new field and
+  delegation example.
 - Update `internal/cli/agent_dispatch.go` `printLocalAgentJobOutput` to print
-  `delegations` instead of `next_agents`.
+  delegation agent names.
 - Update tests in `internal/workflow/result_test.go` and
-  `internal/cli/agent_test.go` that assert on `next_agents`.
+  `internal/cli/agent_test.go` that assert on result fields.
 
 **Acceptance criteria:**
 
 - `go test ./internal/workflow ./internal/cli ./internal/prompts` passes.
-- `grep -R "next_agents" --include="*.go" --include="*.md" internal skills docs`
-  returns only release notes if desired.
+- a tracked-file grep for the old result field returns no matches.
 
 **Suggested commit message:**
 
@@ -270,7 +268,7 @@ feat(workflow): parse delegations and update result contract
 
 **Scope:**
 
-- Delete `dispatchNextAgents` in `internal/workflow/engine.go`.
+- Delete the old string-list delegation dispatcher in `internal/workflow/engine.go`.
 - Add `dispatchDelegations(ctx, payload, result, ref) error` that:
   - Iterates over `result.Delegations`.
   - Builds a `JobRequest` for each delegation with inherited repo/branch/PR
@@ -417,14 +415,14 @@ feat(cli): render delegation DAG in dashboard
   - coordinator returns two delegations
   - workers return results
   - continuation job is enqueued
-- Update any remaining docs that mention `next_agents`.
+- Update any remaining docs that mention the old result field.
 
 **Acceptance criteria:**
 
 - Docs are consistent and link checks pass.
 - Smoke test runs manually and passes.
-- `grep -R "next_agents" --include="*.md" skills docs` returns nothing except
-  release notes.
+- a tracked-file grep for the old result field returns no matches except release
+  notes if deliberately retained.
 
 **Suggested commit message:**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -261,14 +261,15 @@ object:
     "changes_made": [],
     "tests_run": [],
     "needs": [],
-    "next_agents": []
+    "delegations": []
   }
 }
 ```
 
 Use `blocked` when work cannot continue without human input or external state.
 Use `failed` when the attempted action errored. Do not report tests, changes, or
-approvals that were not actually verified.
+approvals that were not actually verified. Use `delegations` to request follow-up
+work by named Gitmoot agents.
 
 ## Safety Rules
 

--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -100,7 +100,7 @@ the smoke test cannot approve or merge the PR.
 1. Register the repo and a shell smoke agent.
 
    ```sh
-   gitmoot setup --repo owner/project --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"shell ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"next_agents\":[]}}'"
+   gitmoot setup --repo owner/project --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"shell ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'"
    gitmoot agent repos shell-smoke
    ```
 
@@ -699,10 +699,10 @@ each repo -> no cross-routing. This intentionally avoids approving reviews.
 
    ```sh
    cd /path/to/project-a
-   gitmoot setup --repo owner/project-a --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"repo ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"next_agents\":[]}}'"
+   gitmoot setup --repo owner/project-a --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"repo ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'"
 
    cd /path/to/project-b
-   gitmoot setup --repo owner/project-b --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"repo ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"next_agents\":[]}}'"
+   gitmoot setup --repo owner/project-b --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"repo ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'"
 
    gitmoot agent repos shell-smoke
    ```

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -268,7 +268,7 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
 
    ```sh
    gitmoot agent subscribe audit --runtime claude --session <claude-session-id> --role reviewer --repo owner/project --capability review --capability ask
-   gitmoot agent subscribe shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"ok\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell\"],\"needs\":[],\"next_agents\":[]}}'" --role reviewer --repo owner/project --capability ask
+   gitmoot agent subscribe shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"ok\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell\"],\"needs\":[],\"delegations\":[]}}'" --role reviewer --repo owner/project --capability ask
    gitmoot agent list
    ```
 
@@ -448,7 +448,7 @@ Agents must return exactly one JSON object containing `gitmoot_result`:
     "changes_made": [],
     "tests_run": [],
     "needs": [],
-    "next_agents": []
+    "delegations": []
   }
 }
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -392,7 +392,7 @@ Required shape:
     "changes_made": [],
     "tests_run": [],
     "needs": [],
-    "next_agents": []
+    "delegations": []
   }
 }
 ```

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -839,7 +839,18 @@ func printLocalAgentJobOutput(stdout io.Writer, output localAgentJobOutput) {
 	printRawMessages(stdout, "findings", output.Result.Findings)
 	printStringList(stdout, "needs", output.Result.Needs)
 	printStringList(stdout, "tests_run", output.Result.TestsRun)
-	printStringList(stdout, "next_agents", output.Result.NextAgents)
+	printStringList(stdout, "delegations", delegationAgentNames(output.Result.Delegations))
+}
+
+func delegationAgentNames(delegations []workflow.Delegation) []string {
+	names := make([]string, 0, len(delegations))
+	for _, d := range delegations {
+		name := strings.TrimSpace(d.Agent)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 func printRawMessages(stdout io.Writer, label string, values []json.RawMessage) {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -497,8 +497,8 @@ func TestRunAgentAskDispatchesAndStoresResult(t *testing.T) {
 	}
 
 	runner := &agentStartRunner{results: []subprocess.Result{
-		{Stdout: `{"gitmoot_result":{"decision":"approved","summary":"plan ready","findings":[{"title":"clear"}],"changes_made":[],"tests_run":["go test ./internal/cli"],"needs":["ship it"],"next_agents":["thermo-review"]}}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"approved","summary":"json ready","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"approved","summary":"plan ready","findings":[{"title":"clear"}],"changes_made":[],"tests_run":["go test ./internal/cli"],"needs":["ship it"],"delegations":[{"id":"review","agent":"thermo-review","action":"review","prompt":"review the plan"}]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"approved","summary":"json ready","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
 	}}
 	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
 	defer restoreFactory()
@@ -523,7 +523,7 @@ func TestRunAgentAskDispatchesAndStoresResult(t *testing.T) {
 		"- ship it",
 		"tests_run:",
 		"- go test ./internal/cli",
-		"next_agents:",
+		"delegations:",
 		"- thermo-review",
 	} {
 		if !strings.Contains(stdout.String(), want) {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -2525,7 +2525,7 @@ func (r *managedSyncLockRunner) Run(ctx context.Context, _ string, command strin
 		r.t.Fatalf("runtime lock ttl = %s, want at least %s", ttl, r.minTTL)
 	}
 	r.checked = true
-	return subprocess.Result{Command: command, Args: args, Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"}, nil
+	return subprocess.Result{Command: command, Args: args, Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"}, nil
 }
 
 func (r *managedSyncLockRunner) LookPath(file string) (string, error) {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -934,7 +934,7 @@ func TestRunQueuedJobsPostsAttributedResultComment(t *testing.T) {
 	}
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
 		return &cliWorkerFakeAdapter{
-			output: `{"gitmoot_result":{"decision":"approved","summary":"done with token=ghp_abcdefghijklmnopqrstuvwxyz123456","findings":[{"severity":"low","body":"ok"}],"changes_made":["commented"],"tests_run":["go test ./..."],"needs":["none"],"next_agents":["lead"]}}`,
+			output: `{"gitmoot_result":{"decision":"approved","summary":"done with token=ghp_abcdefghijklmnopqrstuvwxyz123456","findings":[{"severity":"low","body":"ok"}],"changes_made":["commented"],"tests_run":["go test ./..."],"needs":["none"],"delegations":[{"id":"follow-up","agent":"lead","action":"ask","prompt":"coordinate next steps"}]}}`,
 		}, nil
 	}
 	worker.CommenterFactory = func(string) github.Client {
@@ -959,7 +959,8 @@ func TestRunQueuedJobsPostsAttributedResultComment(t *testing.T) {
 		"**Changes Made**",
 		"**Tests Run**",
 		"**Needs**",
-		"**Next Agents**",
+		"**Delegations**",
+		"- lead",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("comment body missing %q:\n%s", want, body)

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -536,7 +536,7 @@ func TestRunQueuedJobsExecutesShellAdapterSuccess(t *testing.T) {
 	store := daemonWorkerStore(t)
 	checkout := t.TempDir()
 	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
-	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, `printf '%s\n' '{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}'`, []string{"ask"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, `printf '%s\n' '{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}'`, []string{"ask"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-success", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -593,7 +593,7 @@ func TestRunQueuedJobsBlocksReadOnlyImplementBeforeRuntime(t *testing.T) {
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-readonly-implement", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
 	comments := &cliPollFakeGitHub{}
 	checkoutCalls := 0
-	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"should not run","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"should not run","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		checkoutCalls++
@@ -710,7 +710,7 @@ func TestRunQueuedJobsAllowsReadOnlyAsk(t *testing.T) {
 	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
 	seedDaemonWorkerAgentWithPolicy(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-readonly-ask", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
-	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"approved","summary":"ask ran","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"approved","summary":"ask ran","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		return checkout, nil
@@ -848,7 +848,7 @@ func TestRunQueuedJobsPreservesAdvanceRetryForPostDeliveryPermissionError(t *tes
 	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
 	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-advance-permission", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7})
-	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"implemented","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"implemented","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		return checkout, nil
@@ -893,7 +893,7 @@ func TestRunQueuedJobsUsesMailboxRepairForMalformedOutput(t *testing.T) {
 	store := daemonWorkerStore(t)
 	checkout := t.TempDir()
 	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
-	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, `if printf '%s' "$1" | grep -q 'Previous raw output'; then printf '%s\n' '{"gitmoot_result":{"decision":"approved","summary":"repaired","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}'; else printf '%s\n' 'not json'; fi`, []string{"ask"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, `if printf '%s' "$1" | grep -q 'Previous raw output'; then printf '%s\n' '{"gitmoot_result":{"decision":"approved","summary":"repaired","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}'; else printf '%s\n' 'not json'; fi`, []string{"ask"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-repair", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -1063,7 +1063,7 @@ func TestDaemonWorkerTickRetriesFailedResultCommentPost(t *testing.T) {
 	}
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
 		return &cliWorkerFakeAdapter{
-			output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+			output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		}, nil
 	}
 	worker.CommenterFactory = func(string) github.Client {
@@ -1171,7 +1171,7 @@ func TestRunQueuedJobsPostsCommentAfterRetryDespitePriorComment(t *testing.T) {
 	}
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
 		return &cliWorkerFakeAdapter{
-			output: `{"gitmoot_result":{"decision":"approved","summary":"retried","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+			output: `{"gitmoot_result":{"decision":"approved","summary":"retried","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		}, nil
 	}
 	worker.CommenterFactory = func(string) github.Client {
@@ -1199,7 +1199,7 @@ func TestRunQueuedJobsDrainsBeyondWorkerLimit(t *testing.T) {
 		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
 	}
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -1249,7 +1249,7 @@ func TestRunQueuedJobsDefersJobsEnqueuedByCurrentSnapshot(t *testing.T) {
 		HeadSHA:     strings.Repeat("a", 40),
 	})
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"implemented","summary":"opened","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"implemented","summary":"opened","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -1315,7 +1315,7 @@ func TestRunQueuedJobsRefreshesImplementedHeadBeforeReviewDispatch(t *testing.T)
 		HeadSHA:     oldHead,
 	})
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"implemented","summary":"opened","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"implemented","summary":"opened","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		onDeliver: func() {
 			if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("implemented\n"), 0o644); err != nil {
 				t.Fatalf("WriteFile returned error: %v", err)
@@ -1371,7 +1371,7 @@ func TestRunQueuedJobsSerializesSameRepoCheckout(t *testing.T) {
 	active := 0
 	maxActive := 0
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		onDeliver: func() {
 			mu.Lock()
 			active++
@@ -1420,7 +1420,7 @@ func TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos(t *testing.T) {
 	active := 0
 	maxActive := 0
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		onDeliver: func() {
 			mu.Lock()
 			active++
@@ -1467,7 +1467,7 @@ func TestRunQueuedJobsAllowsDifferentRuntimeSessionsAcrossRepos(t *testing.T) {
 	active := 0
 	maxActive := 0
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		onDeliver: func() {
 			mu.Lock()
 			active++
@@ -1525,7 +1525,7 @@ func TestRunQueuedJobsLeavesBusyRuntimeSessionQueued(t *testing.T) {
 		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
 	}
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard, home)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -1592,7 +1592,7 @@ func TestRunQueuedJobsDelegatesBusyRuntimeToTempWorker(t *testing.T) {
 	var lockObservedMu sync.Mutex
 	lockObserved := false
 	deliveryAdapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		onDeliver: func() {
 			if _, err := store.GetResourceLock(ctx, tempRuntimeLockKey); err != nil {
 				t.Errorf("GetResourceLock during temp delivery returned error: %v", err)
@@ -1808,7 +1808,7 @@ func TestRunQueuedJobsResumesDelegatedTempWorkerAfterRestart(t *testing.T) {
 		t.Fatalf("CreateJobWithEvent returned error: %v", err)
 	}
 	deliveryAdapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"resumed","findings":[],"changes_made":[],"tests_run":["go test"],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"resumed","findings":[],"changes_made":[],"tests_run":["go test"],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard, home)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -1916,7 +1916,7 @@ func TestRunQueuedJobsCleansTempWorkerWhenDelegationRaceLoses(t *testing.T) {
 		},
 	}
 	deliveryAdapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -1957,7 +1957,7 @@ func TestRunQueuedJobsPreservesCreationOrderForSameRepo(t *testing.T) {
 		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
 	}
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -1984,7 +1984,7 @@ func TestRunQueuedJobsPreservesCancellationRace(t *testing.T) {
 	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-cancel", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"late","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"late","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		onDeliver: func() {
 			if _, err := workflow.CancelJob(ctx, store, "job-cancel"); err != nil {
 				t.Fatalf("CancelJob returned error: %v", err)
@@ -2121,7 +2121,7 @@ func TestRunQueuedJobsUsesConfiguredMergeGate(t *testing.T) {
 	})
 	gate := &cliWorkerFakeMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true}}
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -2161,7 +2161,7 @@ func TestRunQueuedJobsFailsImplementWithoutBranchLockBeforeDelivery(t *testing.T
 	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-implement", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 1, TaskID: "task-1"})
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
@@ -2206,7 +2206,7 @@ func TestRunQueuedJobsUsesTaskWorktreeForImplement(t *testing.T) {
 		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
 	}
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-implement-worktree", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, HeadSHA: head, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
-	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"implemented","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"implemented","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
 	worker := defaultJobWorker(store, io.Discard)
 	adapterCheckout := ""
 	worker.AdapterFactory = func(_ runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
@@ -2342,7 +2342,7 @@ func TestRunQueuedJobsResumesDelegatedImplementWithOriginalBranchLock(t *testing
 		DelegatedAgent:   "lead-temp-job-implement",
 		DelegationReason: "runtime_session_busy",
 	})
-	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"implemented","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"implemented","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
 	worker := defaultJobWorker(store, io.Discard)
 	adapterCheckout := ""
 	worker.AdapterFactory = func(_ runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
@@ -2394,7 +2394,7 @@ func TestRunQueuedJobsUsesTaskWorktreeForReview(t *testing.T) {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-review-worktree", Agent: "reviewer", Action: "review", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, HeadSHA: head, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
-	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
 	worker := defaultJobWorker(store, io.Discard)
 	adapterCheckout := ""
 	worker.AdapterFactory = func(_ runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
@@ -2675,7 +2675,7 @@ func TestRunQueuedJobsKeepsReviewOnRegisteredCheckoutWithoutTaskWorktree(t *test
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-review-main-checkout", Agent: "reviewer", Action: "review", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, HeadSHA: head, GoalID: "goal-1", TaskID: "task-1", TaskTitle: "Task 1"})
-	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`}
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
 	worker := defaultJobWorker(store, io.Discard)
 	adapterCheckout := ""
 	worker.AdapterFactory = func(_ runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
@@ -3032,7 +3032,7 @@ func TestRunQueuedJobsFailsReviewOnWrongCheckoutBranchBeforeDelivery(t *testing.
 	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-review", Agent: "reviewer", Action: "review", Repo: "owner/repo", Branch: "task-1", PullRequest: 1, HeadSHA: head})
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
@@ -3073,7 +3073,7 @@ func TestRunQueuedJobsFailsReviewOnWrongCheckoutHeadBeforeDelivery(t *testing.T)
 	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-review", Agent: "reviewer", Action: "review", Repo: "owner/repo", Branch: "task-1", PullRequest: 1, HeadSHA: strings.Repeat("0", 40), TaskID: "task-1"})
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
@@ -3114,7 +3114,7 @@ func TestRunQueuedJobsFailsPRScopedAskOnWrongCheckoutHeadBeforeDelivery(t *testi
 	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-ask", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "task-1", PullRequest: 1, HeadSHA: strings.Repeat("0", 40)})
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
@@ -3149,7 +3149,7 @@ func TestRunQueuedJobsForRepoSkipsOtherRepos(t *testing.T) {
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2})
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -3197,7 +3197,7 @@ func TestRunEnabledRepoWorkerTicksSkipsDisabledRepos(t *testing.T) {
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-enabled", Agent: "audit", Action: "ask", Repo: "owner/enabled", Branch: "main", PullRequest: 1})
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-disabled", Agent: "audit", Action: "ask", Repo: "owner/disabled", Branch: "main", PullRequest: 2})
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -3247,7 +3247,7 @@ func TestRunQueuedJobsRecordsPostDeliveryWorkflowErrorForRetry(t *testing.T) {
 	})
 	gate := &cliWorkerFakeMergeGate{err: errors.New("github unavailable")}
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -3546,7 +3546,7 @@ func TestRunQueuedJobsSwallowsPostDeliveryBlockedWorkflow(t *testing.T) {
 	})
 	gate := &cliWorkerFakeMergeGate{decision: workflow.MergeDecision{Ready: false, Reason: "ci pending"}}
 	adapter := &cliWorkerFakeAdapter{
-		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -145,7 +145,7 @@ func TestRunJobRunUsesDaemonWorkerInternals(t *testing.T) {
 	runGit(t, checkout, "branch", "-m", "main")
 	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
 	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
-	seedDaemonWorkerAgent(t, store, "audit", "shell", `printf '%s\n' '{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}'`, []string{"ask"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "audit", "shell", `printf '%s\n' '{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}'`, []string{"ask"}, "owner/repo")
 	seedCLIJob(t, store, db.Job{
 		ID:      "job-run",
 		Agent:   "audit",

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2649,13 +2649,13 @@ func TestSkillOptTrainContinueGeneratesOptionsWithCurrentSkill(t *testing.T) {
 
 	runner := &agentStartRunner{results: []subprocess.Result{
 		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440201"}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nHero with strong product narrative.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nHero with strong product narrative.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
 		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440202"}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nDashboard-led layout with proof metrics.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nDashboard-led layout with proof metrics.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
 		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440203"}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nCheckout analytics proof block.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nCheckout analytics proof block.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
 		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440204"}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nLifecycle commerce story with motion notes.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nLifecycle commerce story with motion notes.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
 	}}
 	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
 	defer restoreFactory()
@@ -3477,8 +3477,8 @@ func TestSkillOptTrainContinueRejectsNonImplementedGenerationResult(t *testing.T
 
 	runner := &agentStartRunner{results: []subprocess.Result{
 		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440401"}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"changes_requested","summary":"This is a review finding, not generated content.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"changes_requested","summary":"This is still a review finding, not generated content.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"changes_requested","summary":"This is a review finding, not generated content.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"changes_requested","summary":"This is still a review finding, not generated content.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
 	}}
 	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
 	defer restoreFactory()
@@ -3940,10 +3940,10 @@ func TestSkillOptTrainContinueUsesRegisteredWorkspaceRepoCheckout(t *testing.T) 
 	}
 	runner := &agentStartRunner{results: []subprocess.Result{
 		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440401"}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nWorkspace hero A.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nWorkspace hero B.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nWorkspace proof A.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nWorkspace proof B.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nWorkspace hero A.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nWorkspace hero B.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nWorkspace proof A.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nWorkspace proof B.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
 	}}
 	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
 	defer restoreFactory()
@@ -4041,10 +4041,10 @@ func TestSkillOptTrainContinueGeneratesValidateArtifacts(t *testing.T) {
 
 	runner := &agentStartRunner{results: []subprocess.Result{
 		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440301"}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Baseline\n\nConventional hero.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Candidate\n\nImproved hero.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Baseline\n\nConventional proof.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
-		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Candidate\n\nImproved proof.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Baseline\n\nConventional hero.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Candidate\n\nImproved hero.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Baseline\n\nConventional proof.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Candidate\n\nImproved proof.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
 	}}
 	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
 	defer restoreFactory()
@@ -8269,7 +8269,7 @@ func (r *skillOptConcurrentGenerationRunner) Run(_ context.Context, dir string, 
 			prompt = args[len(args)-1]
 		}
 		summary := "# Generated option\n\n" + strings.Split(prompt, "\n")[0]
-		return subprocess.Result{Command: command, Args: args, Stdout: fmt.Sprintf(`{"gitmoot_result":{"decision":"implemented","summary":%q,"findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`+"\n", summary)}, nil
+		return subprocess.Result{Command: command, Args: args, Stdout: fmt.Sprintf(`{"gitmoot_result":{"decision":"implemented","summary":%q,"findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`+"\n", summary)}, nil
 	}
 	r.mu.Unlock()
 	return subprocess.Result{Command: command, Args: args}, nil
@@ -8314,7 +8314,7 @@ func cliImplementedSummaryResult(t *testing.T, summary string) subprocess.Result
 			"changes_made": []any{},
 			"tests_run":    []any{},
 			"needs":        []any{},
-			"next_agents":  []any{},
+			"delegations":  []any{},
 		},
 	})
 	if err != nil {

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -733,7 +733,7 @@ func subscribeShellImplementAgent(t *testing.T, home string, name string, repo s
 		"agent", "subscribe", name,
 		"--home", home,
 		"--runtime", "shell",
-		"--session", `printf '%s\n' '{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}'`,
+		"--session", `printf '%s\n' '{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}'`,
 		"--role", "lead",
 		"--repo", repo,
 		"--capability", "implement",

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -153,11 +153,15 @@ type Comment struct {
 }
 
 type Job struct {
-	ID      string
-	Agent   string
-	Type    string
-	State   string
-	Payload string
+	ID              string
+	Agent           string
+	Type            string
+	State           string
+	Payload         string
+	ParentJobID     string
+	DelegationID    string
+	DelegationDepth int
+	DelegatedBy     string
 	// UpdatedAt is populated by ListJobs (for age display in the dashboard);
 	// other readers may leave it zero.
 	UpdatedAt string
@@ -1881,8 +1885,10 @@ func (s *Store) MarkCommentSeenIfNew(ctx context.Context, comment Comment) (bool
 }
 
 func (s *Store) CreateJob(ctx context.Context, job Job) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, updated_at)
-		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`, job.ID, job.Agent, job.Type, job.State, job.Payload)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		job.ID, job.Agent, job.Type, job.State, job.Payload,
+		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy)
 	return err
 }
 
@@ -1893,8 +1899,10 @@ func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent)
 	}
 	defer tx.Rollback()
 
-	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, updated_at)
-		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`, job.ID, job.Agent, job.Type, job.State, job.Payload); err != nil {
+	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		job.ID, job.Agent, job.Type, job.State, job.Payload,
+		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy); err != nil {
 		return err
 	}
 	if event.JobID == "" {
@@ -1907,16 +1915,16 @@ func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent)
 }
 
 func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload FROM jobs WHERE id = ?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by FROM jobs WHERE id = ?`, id)
 	var job Job
-	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload); err != nil {
+	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy); err != nil {
 		return Job{}, err
 	}
 	return job, nil
 }
 
 func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, updated_at FROM jobs ORDER BY id`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, updated_at FROM jobs ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}
@@ -1925,7 +1933,7 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.UpdatedAt); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.UpdatedAt); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -1934,7 +1942,7 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 }
 
 func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by
 		FROM jobs WHERE state = ? ORDER BY created_at, rowid`, "queued")
 	if err != nil {
 		return nil, err
@@ -1944,7 +1952,7 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -1953,7 +1961,7 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 }
 
 func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Time) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by
 		FROM jobs WHERE state = ? AND updated_at < ? ORDER BY id`, "running", before.UTC().Format("2006-01-02 15:04:05"))
 	if err != nil {
 		return nil, err
@@ -1963,7 +1971,7 @@ func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Ti
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -4952,5 +4960,14 @@ CREATE TABLE created_repos (
 );
 
 CREATE INDEX idx_created_repos_session ON created_repos(session_id);
+	`,
+	`
+ALTER TABLE jobs ADD COLUMN parent_job_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE jobs ADD COLUMN delegation_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE jobs ADD COLUMN delegation_depth INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE jobs ADD COLUMN delegated_by TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX idx_jobs_parent_job_id ON jobs(parent_job_id);
+CREATE INDEX idx_jobs_delegation_id ON jobs(delegation_id);
 	`,
 }

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -57,7 +57,7 @@ func RenderJob(prompt JobPrompt) string {
 	builder.WriteString("\nRequired output:\n")
 	builder.WriteString("Return exactly one JSON object containing a top-level gitmoot_result field.\n")
 	builder.WriteString("Use this shape:\n")
-	builder.WriteString(`{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`)
+	builder.WriteString(`{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`)
 	builder.WriteByte('\n')
 	return builder.String()
 }
@@ -69,7 +69,7 @@ func RenderRepairPrompt(rawOutput string, parseError error) string {
 		writeField(&builder, "Parse error", parseError.Error())
 	}
 	builder.WriteString("\nReturn only one JSON object in this exact shape:\n")
-	builder.WriteString(`{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`)
+	builder.WriteString(`{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`)
 	builder.WriteString("\n\nPrevious raw output:\n")
 	builder.WriteString(trimRawOutput(rawOutput, 12000))
 	builder.WriteByte('\n')

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -243,7 +243,7 @@ func renderMarkdown(report Report, data jobReportData) string {
 		writeList(&builder, "Changes made", data.payload.Result.ChangesMade)
 		writeList(&builder, "Tests run", data.payload.Result.TestsRun)
 		writeList(&builder, "Needs", data.payload.Result.Needs)
-		writeList(&builder, "Next agents", data.payload.Result.NextAgents)
+		writeList(&builder, "Delegations", delegationAgentNames(data.payload.Result.Delegations))
 	}
 
 	writeDetails(&builder, "Selected error details", func(details *strings.Builder) {
@@ -287,6 +287,17 @@ func renderMarkdown(report Report, data jobReportData) string {
 	})
 
 	return workflow.LimitCommentBody(builder.String())
+}
+
+func delegationAgentNames(delegations []workflow.Delegation) []string {
+	names := make([]string, 0, len(delegations))
+	for _, d := range delegations {
+		name := strings.TrimSpace(d.Agent)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 func jobSummary(source SourceMetadata) string {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -255,7 +255,7 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			return nil
 		}
 	}
-	if err := e.dispatchNextAgents(ctx, payload, *payload.Result, ref); err != nil {
+	if err := e.dispatchDelegations(ctx, job, payload, ref); err != nil {
 		return err
 	}
 
@@ -322,6 +322,90 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			_, err = e.runMergeGate(ctx, reviewer, payload, ref)
 			return err
 		}
+	}
+	return nil
+}
+
+func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload JobPayload, ref taskRef) error {
+	if payload.Result == nil || len(payload.Result.Delegations) == 0 {
+		return nil
+	}
+
+	requests := make([]JobRequest, 0, len(payload.Result.Delegations))
+	for _, d := range payload.Result.Delegations {
+		requests = append(requests, JobRequest{
+			ID:              job.ID + "/delegation/" + d.ID,
+			Agent:           d.Agent,
+			Action:          d.Action,
+			Repo:            payload.Repo,
+			Branch:          payload.Branch,
+			PullRequest:     payload.PullRequest,
+			HeadSHA:         payload.HeadSHA,
+			GoalID:          payload.GoalID,
+			TaskID:          payload.TaskID,
+			TaskTitle:       payload.TaskTitle,
+			LeadAgent:       payload.LeadAgent,
+			Reviewers:       payload.Reviewers,
+			ReviewRound:     payload.ReviewRound,
+			Sender:          job.Agent,
+			Instructions:    strings.TrimSpace(d.Prompt),
+			Constraints:     payload.Constraints,
+			ParentJobID:     job.ID,
+			DelegationID:    d.ID,
+			DelegationDepth: payload.DelegationDepth + 1,
+			DelegatedBy:     job.Agent,
+		})
+	}
+
+	// Preflight all delegations before enqueueing any child job so that a
+	// partial failure does not leave the parent half-dispatched. Use a lightweight
+	// check that does not acquire branch locks or other execution side effects.
+	for _, request := range requests {
+		if err := e.preflightDelegation(ctx, request); err != nil {
+			return e.block(ctx, ref, fmt.Sprintf("delegation %q preflight failed: %v", request.DelegationID, err))
+		}
+	}
+
+	// Acquire branch locks for all implement delegations before enqueueing any
+	// child job, so a later lock failure does not leave a half-dispatched batch.
+	for _, request := range requests {
+		if request.Action == "implement" {
+			if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, request.Agent, ref); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, request := range requests {
+		if err := e.enqueue(ctx, request); err != nil {
+			return fmt.Errorf("dispatch delegation %q: %w", request.DelegationID, err)
+		}
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_enqueued",
+			Message: fmt.Sprintf("delegation %q enqueued as job %s", request.DelegationID, request.ID),
+		})
+	}
+	return nil
+}
+
+func (e Engine) preflightDelegation(ctx context.Context, request JobRequest) error {
+	agent, err := e.Store.GetAgent(ctx, request.Agent)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("agent %q is not subscribed", request.Agent)
+		}
+		return err
+	}
+	allowed, err := e.Store.AgentCanAccessRepo(ctx, agent.Name, request.Repo)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return fmt.Errorf("agent %q is not allowed on %q", agent.Name, request.Repo)
+	}
+	if !contains(agent.Capabilities, request.Action) {
+		return fmt.Errorf("agent %q lacks %q capability", agent.Name, request.Action)
 	}
 	return nil
 }
@@ -430,40 +514,6 @@ func (e Engine) leadAgent(ctx context.Context, payload JobPayload) (string, erro
 		return "", errors.New("lead agent is required")
 	}
 	return "", err
-}
-
-func (e Engine) dispatchNextAgents(ctx context.Context, payload JobPayload, result AgentResult, ref taskRef) error {
-	requests := []JobRequest{}
-	for _, agent := range compactStrings(result.NextAgents) {
-		request := JobRequest{
-			Agent:        agent,
-			Action:       "ask",
-			Repo:         payload.Repo,
-			Branch:       payload.Branch,
-			PullRequest:  payload.PullRequest,
-			HeadSHA:      payload.HeadSHA,
-			GoalID:       payload.GoalID,
-			TaskID:       payload.TaskID,
-			TaskTitle:    payload.TaskTitle,
-			LeadAgent:    payload.LeadAgent,
-			Reviewers:    e.requiredReviewers(payload),
-			ReviewRound:  payload.ReviewRound,
-			Sender:       payload.Sender,
-			Instructions: "Another agent requested your input: " + result.Summary,
-		}
-		requests = append(requests, request)
-	}
-	for _, request := range requests {
-		if err := e.ensureAgentAllowed(ctx, request, ref); err != nil {
-			return err
-		}
-	}
-	for _, request := range requests {
-		if err := e.enqueue(ctx, request); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (e Engine) allRequiredReviewersApproved(ctx context.Context, currentReviewer string, payload JobPayload) (bool, error) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -11,6 +11,58 @@ import (
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
+func TestEngineAdvanceJobDispatchesDelegations(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "helper", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "audit", Type: "ask"}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-005",
+		PullRequest: 5,
+		TaskID:      "task-5",
+		TaskTitle:   "Parent",
+		Sender:      "audit",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "del-1", Agent: "helper", Action: "review", Prompt: "review this"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	child := mustJob(t, store, "parent-job/delegation/del-1")
+	if child.Agent != "helper" || child.Type != "review" || child.State != string(JobQueued) {
+		t.Fatalf("child job = %+v", child)
+	}
+	if child.ParentJobID != "parent-job" || child.DelegationID != "del-1" || child.DelegationDepth != 1 || child.DelegatedBy != "audit" {
+		t.Fatalf("child metadata = %+v", child)
+	}
+
+	payload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.ParentJobID != "parent-job" || payload.DelegationID != "del-1" || payload.DelegationDepth != 1 || payload.DelegatedBy != "audit" {
+		t.Fatalf("child payload metadata = %+v", payload)
+	}
+	if payload.Sender != "audit" || payload.Instructions != "review this" {
+		t.Fatalf("child payload context = %+v", payload)
+	}
+
+	// Idempotent: advancing the same parent again must not duplicate the child.
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("second AdvanceJob returned error: %v", err)
+	}
+}
+
 func TestEngineHandlePullRequestOpenedDispatchesReviewers(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -433,7 +485,7 @@ func TestEngineRunJobAdvancesCompletedResult(t *testing.T) {
 	engine.RequiredReviewers = []string{"audit"}
 	agent := runtime.Agent{Name: "lead", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "lead"}
 	adapter := &fakeDelivery{outputs: []string{
-		`{"gitmoot_result":{"decision":"implemented","summary":"opened PR","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		`{"gitmoot_result":{"decision":"implemented","summary":"opened PR","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
 	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
 		ID:          "implement-job",
@@ -489,7 +541,7 @@ func TestEngineRunJobAllowsDelegatedImplementWithOriginalBranchLock(t *testing.T
 	engine := testEngine(store)
 	agent := runtime.Agent{Name: "lead-temp-job-1", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "lead"}
 	adapter := &fakeDelivery{outputs: []string{
-		`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
 
 	if _, err := engine.RunJob(ctx, "job-1", agent, adapter); err != nil {
@@ -532,7 +584,7 @@ func TestEngineRunJobAllowsMergeBackAskForImplementOnlyOriginal(t *testing.T) {
 	engine := testEngine(store)
 	agent := runtime.Agent{Name: "lead", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "lead"}
 	adapter := &fakeDelivery{outputs: []string{
-		`{"gitmoot_result":{"decision":"approved","summary":"ack","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		`{"gitmoot_result":{"decision":"approved","summary":"ack","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
 
 	if _, err := engine.RunJob(ctx, "job-merge-back", agent, adapter); err != nil {
@@ -557,7 +609,7 @@ func TestEngineRunJobPreflightsPolicyBeforeDelivery(t *testing.T) {
 	delivered := false
 	adapter := &fakeDelivery{
 		outputs: []string{
-			`{"gitmoot_result":{"decision":"implemented","summary":"opened PR","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+			`{"gitmoot_result":{"decision":"implemented","summary":"opened PR","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		},
 		onDeliver: func() {
 			delivered = true
@@ -1155,71 +1207,6 @@ func TestEngineAdvanceReviewApprovalIgnoresStaleRoundWhenNewerRoundExists(t *tes
 	}
 }
 
-func TestEngineAdvanceStaleReviewDoesNotDispatchNextAgents(t *testing.T) {
-	ctx := context.Background()
-	store := openEngineStore(t)
-	engine := testEngine(store)
-	seedAgent(t, store, "planner", []string{"ask"}, "jerryfane/gitmoot")
-	if err := store.UpsertTask(ctx, db.Task{
-		ID:     "task-7",
-		GoalID: "goal-1",
-		Title:  "Workflow Engine",
-		State:  string(TaskReviewing),
-		Branch: "task-7",
-	}); err != nil {
-		t.Fatalf("UpsertTask returned error: %v", err)
-	}
-	insertCompletedJob(t, store, db.Job{
-		ID:    "audit-review-round-1",
-		Agent: "audit",
-		Type:  "review",
-	}, JobPayload{
-		Repo:        "jerryfane/gitmoot",
-		Branch:      "task-7",
-		PullRequest: 7,
-		TaskID:      "task-7",
-		TaskTitle:   "Workflow Engine",
-		Reviewers:   []string{"audit"},
-		ReviewRound: "review-1",
-		Result:      &AgentResult{Decision: "approved", Summary: "old approval", NextAgents: []string{"planner"}},
-	})
-	encoded, err := marshalPayload(JobPayload{
-		Repo:        "jerryfane/gitmoot",
-		Branch:      "task-7",
-		PullRequest: 7,
-		TaskID:      "task-7",
-		TaskTitle:   "Workflow Engine",
-		Reviewers:   []string{"audit"},
-		ReviewRound: "review-2",
-	})
-	if err != nil {
-		t.Fatalf("marshalPayload returned error: %v", err)
-	}
-	if err := store.CreateJobWithEvent(ctx, db.Job{
-		ID:      "audit-review-round-2",
-		Agent:   "audit",
-		Type:    "review",
-		State:   string(JobQueued),
-		Payload: encoded,
-	}, db.JobEvent{Kind: string(JobQueued), Message: "newer round queued"}); err != nil {
-		t.Fatalf("CreateJobWithEvent returned error: %v", err)
-	}
-
-	if err := engine.AdvanceJob(ctx, "audit-review-round-1"); err != nil {
-		t.Fatalf("AdvanceJob returned error: %v", err)
-	}
-	jobs, err := store.ListJobs(ctx)
-	if err != nil {
-		t.Fatalf("ListJobs returned error: %v", err)
-	}
-	for _, job := range jobs {
-		if job.Type == "ask" {
-			t.Fatalf("stale review dispatched next-agent job: %+v", job)
-		}
-	}
-	assertTaskState(t, store, "task-7", TaskReviewing)
-}
-
 func TestEngineAdvanceStaleReviewDoesNotRegressReadyState(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -1362,91 +1349,8 @@ func TestEngineAdvanceBlocksOnAgentBlockedResult(t *testing.T) {
 	assertTaskState(t, store, "task-7", TaskBlocked)
 }
 
-func TestEngineAdvanceDispatchesNextAgents(t *testing.T) {
-	ctx := context.Background()
-	store := openEngineStore(t)
-	seedAgent(t, store, "planner", []string{"ask"}, "jerryfane/gitmoot")
-	engine := testEngine(store)
-	insertCompletedJob(t, store, db.Job{
-		ID:    "review-job",
-		Agent: "audit",
-		Type:  "review",
-	}, JobPayload{
-		Repo:      "jerryfane/gitmoot",
-		Branch:    "task-7",
-		TaskID:    "task-7",
-		TaskTitle: "Workflow Engine",
-		Result:    &AgentResult{Decision: "approved", Summary: "ask planner", NextAgents: []string{"planner"}},
-	})
 
-	err := engine.AdvanceJob(ctx, "review-job")
 
-	if err != nil {
-		t.Fatalf("AdvanceJob returned error: %v", err)
-	}
-	mustJob(t, store, "ask-planner-task-7")
-}
-
-func TestEngineAdvanceBlocksWhenNextAgentScopeRejected(t *testing.T) {
-	ctx := context.Background()
-	store := openEngineStore(t)
-	seedAgent(t, store, "planner", []string{"ask"}, "other/repo")
-	engine := testEngine(store)
-	insertCompletedJob(t, store, db.Job{
-		ID:    "review-job",
-		Agent: "audit",
-		Type:  "review",
-	}, JobPayload{
-		Repo:      "jerryfane/gitmoot",
-		Branch:    "task-7",
-		TaskID:    "task-7",
-		TaskTitle: "Workflow Engine",
-		Result:    &AgentResult{Decision: "approved", Summary: "ask planner", NextAgents: []string{"planner"}},
-	})
-
-	err := engine.AdvanceJob(ctx, "review-job")
-
-	var blocked BlockedError
-	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "not allowed") {
-		t.Fatalf("error = %v, want scope BlockedError", err)
-	}
-	assertTaskState(t, store, "task-7", TaskBlocked)
-}
-
-func TestEngineAdvancePreflightsNextAgentsBeforeEnqueue(t *testing.T) {
-	ctx := context.Background()
-	store := openEngineStore(t)
-	seedAgent(t, store, "planner", []string{"ask"}, "jerryfane/gitmoot")
-	engine := testEngine(store)
-	insertCompletedJob(t, store, db.Job{
-		ID:    "review-job",
-		Agent: "audit",
-		Type:  "review",
-	}, JobPayload{
-		Repo:      "jerryfane/gitmoot",
-		Branch:    "task-7",
-		TaskID:    "task-7",
-		TaskTitle: "Workflow Engine",
-		Result:    &AgentResult{Decision: "approved", Summary: "ask planner", NextAgents: []string{"planner", "missing"}},
-	})
-
-	err := engine.AdvanceJob(ctx, "review-job")
-
-	var blocked BlockedError
-	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "not subscribed") {
-		t.Fatalf("error = %v, want missing next-agent BlockedError", err)
-	}
-	jobs, listErr := store.ListJobs(ctx)
-	if listErr != nil {
-		t.Fatalf("ListJobs returned error: %v", listErr)
-	}
-	for _, job := range jobs {
-		if job.Type == "ask" {
-			t.Fatalf("ask job was enqueued before next-agent preflight completed: %+v", job)
-		}
-	}
-	assertTaskState(t, store, "task-7", TaskBlocked)
-}
 
 func TestEngineSetTaskStatePreservesExistingMetadata(t *testing.T) {
 	ctx := context.Background()

--- a/internal/workflow/job_comment.go
+++ b/internal/workflow/job_comment.go
@@ -57,7 +57,7 @@ func RenderJobResultComment(comment JobResultComment) string {
 		writeList(&builder, "Changes Made", comment.Result.ChangesMade)
 		writeList(&builder, "Tests Run", comment.Result.TestsRun)
 		writeList(&builder, "Needs", comment.Result.Needs)
-		writeList(&builder, "Next Agents", comment.Result.NextAgents)
+		writeList(&builder, "Delegations", delegationAgentNames(comment.Result.Delegations))
 	}
 	if strings.TrimSpace(comment.Diagnostic) != "" && (comment.Result == nil || strings.TrimSpace(comment.Diagnostic) != strings.TrimSpace(comment.Result.Summary)) {
 		writeScalar(&builder, "Diagnostics", limitCommentText(comment.Diagnostic))
@@ -66,6 +66,17 @@ func RenderJobResultComment(comment JobResultComment) string {
 		builder.WriteString("\nRaw runtime output was retained in local Gitmoot state and is not posted here.\n")
 	}
 	return limitCommentBody(builder.String())
+}
+
+func delegationAgentNames(delegations []Delegation) []string {
+	names := make([]string, 0, len(delegations))
+	for _, d := range delegations {
+		name := strings.TrimSpace(d.Agent)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 func writeScalar(builder *strings.Builder, label string, value string) {

--- a/internal/workflow/job_comment_test.go
+++ b/internal/workflow/job_comment_test.go
@@ -20,7 +20,7 @@ func TestRenderJobResultCommentIncludesAttributionAndResult(t *testing.T) {
 			ChangesMade: []string{"reviewed workflow"},
 			TestsRun:    []string{"go test ./..."},
 			Needs:       []string{"rerun review"},
-			NextAgents:  []string{"lead"},
+			Delegations: []Delegation{{ID: "plan", Agent: "lead", Action: "ask", Prompt: "plan next steps"}},
 		},
 	})
 
@@ -36,7 +36,8 @@ func TestRenderJobResultCommentIncludesAttributionAndResult(t *testing.T) {
 		"**Changes Made**",
 		"**Tests Run**",
 		"**Needs**",
-		"**Next Agents**",
+		"**Delegations**",
+		"- lead",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("comment body missing %q:\n%s", want, body)

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -35,6 +35,10 @@ type JobRequest struct {
 	Sender           string
 	Instructions     string
 	Constraints      []string
+	ParentJobID      string
+	DelegationID     string
+	DelegationDepth  int
+	DelegatedBy      string
 	OriginalAgent    string
 	DelegatedAgent   string
 	DelegationReason string
@@ -54,6 +58,10 @@ type JobPayload struct {
 	Sender                 string       `json:"sender"`
 	Instructions           string       `json:"instructions"`
 	Constraints            []string     `json:"constraints"`
+	ParentJobID            string       `json:"parent_job_id,omitempty"`
+	DelegationID           string       `json:"delegation_id,omitempty"`
+	DelegationDepth        int          `json:"delegation_depth,omitempty"`
+	DelegatedBy            string       `json:"delegated_by,omitempty"`
 	TemplateID             string       `json:"template_id,omitempty"`
 	TemplateResolvedCommit string       `json:"template_resolved_commit,omitempty"`
 	TemplateContent        string       `json:"template_content,omitempty"`
@@ -95,6 +103,10 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		Sender:                 request.Sender,
 		Instructions:           request.Instructions,
 		Constraints:            compactStrings(request.Constraints),
+		ParentJobID:            request.ParentJobID,
+		DelegationID:           request.DelegationID,
+		DelegationDepth:        request.DelegationDepth,
+		DelegatedBy:            request.DelegatedBy,
 		TemplateID:             snapshot.ID,
 		TemplateResolvedCommit: snapshot.ResolvedCommit,
 		TemplateContent:        snapshot.Content,
@@ -107,11 +119,15 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 	}
 
 	job := db.Job{
-		ID:      request.ID,
-		Agent:   request.Agent,
-		Type:    request.Action,
-		State:   string(JobQueued),
-		Payload: payload,
+		ID:              request.ID,
+		Agent:           request.Agent,
+		Type:            request.Action,
+		State:           string(JobQueued),
+		Payload:         payload,
+		ParentJobID:     request.ParentJobID,
+		DelegationID:    request.DelegationID,
+		DelegationDepth: request.DelegationDepth,
+		DelegatedBy:     request.DelegatedBy,
 	}
 	if err := m.Store.CreateJobWithEvent(ctx, job, db.JobEvent{JobID: job.ID, Kind: string(JobQueued), Message: "job queued"}); err != nil {
 		return db.Job{}, err

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -51,6 +51,45 @@ func TestMailboxEnqueueCreatesQueuedJobAndEvent(t *testing.T) {
 	}
 }
 
+func TestMailboxEnqueuePersistsDelegationMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+
+	job, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:              "job-child",
+		Agent:           "audit",
+		Action:          "ask",
+		Repo:            "jerryfane/gitmoot",
+		Branch:          "task-005",
+		ParentJobID:     "job-parent",
+		DelegationID:    "delegation-1",
+		DelegationDepth: 2,
+		DelegatedBy:     "lead",
+	})
+	if err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if job.ParentJobID != "job-parent" || job.DelegationID != "delegation-1" || job.DelegationDepth != 2 || job.DelegatedBy != "lead" {
+		t.Fatalf("returned job metadata = %+v", job)
+	}
+
+	stored, err := store.GetJob(ctx, "job-child")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.ParentJobID != "job-parent" || stored.DelegationID != "delegation-1" || stored.DelegationDepth != 2 || stored.DelegatedBy != "lead" {
+		t.Fatalf("stored job metadata = %+v", stored)
+	}
+	payload, err := unmarshalPayload(stored.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.ParentJobID != "job-parent" || payload.DelegationID != "delegation-1" || payload.DelegationDepth != 2 || payload.DelegatedBy != "lead" {
+		t.Fatalf("payload metadata = %+v", payload)
+	}
+}
+
 func TestMailboxEnqueueSnapshotsAgentTemplate(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -187,7 +187,7 @@ func TestMailboxRunIncludesTemplateSnapshotInPrompt(t *testing.T) {
 	mailbox := Mailbox{Store: store}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
-		`{"gitmoot_result":{"decision":"approved","summary":"clean","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		`{"gitmoot_result":{"decision":"approved","summary":"clean","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
 	templateContent := agenttemplate.FormatTemplateContent(agenttemplate.Metadata{
 		ID:                   "thermo",
@@ -248,7 +248,7 @@ func TestMailboxRunStoresResultAndSucceeds(t *testing.T) {
 	mailbox := Mailbox{Store: store}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
-		`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["mailbox"],"tests_run":["go test ./..."],"needs":[],"next_agents":[]}}`,
+		`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["mailbox"],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`,
 	}}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "implement", Repo: "jerryfane/gitmoot", Branch: "task-005", PullRequest: 5}); err != nil {
@@ -285,7 +285,7 @@ func TestMailboxRunUsesAdapterSummaryWhenAvailable(t *testing.T) {
 	adapter := &fakeDelivery{
 		outputs: []string{`{"result":"wrapped by runtime"}`},
 		summaries: []string{
-			`{"gitmoot_result":{"decision":"approved","summary":"parsed from summary","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+			`{"gitmoot_result":{"decision":"approved","summary":"parsed from summary","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		},
 	}
 
@@ -312,7 +312,7 @@ func TestMailboxRunRetriesMalformedOutputOnce(t *testing.T) {
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		"review complete, no json",
-		`{"gitmoot_result":{"decision":"approved","summary":"clean after repair","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		`{"gitmoot_result":{"decision":"approved","summary":"clean after repair","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
@@ -347,7 +347,7 @@ func TestMailboxRunMarksBlockedDecision(t *testing.T) {
 	mailbox := Mailbox{Store: store}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
-		`{"gitmoot_result":{"decision":"blocked","summary":"needs credentials","findings":[],"changes_made":[],"tests_run":[],"needs":["GITHUB_TOKEN"],"next_agents":[]}}`,
+		`{"gitmoot_result":{"decision":"blocked","summary":"needs credentials","findings":[],"changes_made":[],"tests_run":[],"needs":["GITHUB_TOKEN"],"delegations":[]}}`,
 	}}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
@@ -371,7 +371,7 @@ func TestMailboxRunRejectsNonQueuedJob(t *testing.T) {
 	mailbox := Mailbox{Store: store}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
-		`{"gitmoot_result":{"decision":"approved","summary":"should not run","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+		`{"gitmoot_result":{"decision":"approved","summary":"should not run","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
@@ -405,7 +405,7 @@ func TestMailboxRunPreservesCancellationDuringDelivery(t *testing.T) {
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{
 		outputs: []string{
-			`{"gitmoot_result":{"decision":"approved","summary":"completed after cancellation","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`,
+			`{"gitmoot_result":{"decision":"approved","summary":"completed after cancellation","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 		},
 		onDeliver: func() {
 			if err := store.UpdateJobState(ctx, "job-1", string(JobCancelled)); err != nil {

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -9,14 +9,32 @@ import (
 
 const resultKey = `"gitmoot_result"`
 
+// Delegation describes a child job that an agent wants Gitmoot to enqueue on
+// its behalf. It is the richer replacement for the legacy next_agents list.
+type Delegation struct {
+	ID            string   `json:"id"`
+	Agent         string   `json:"agent"`
+	Action        string   `json:"action"`
+	Worktree      string   `json:"worktree,omitempty"`
+	Prompt        string   `json:"prompt"`
+	Artifacts     []string `json:"artifacts,omitempty"`
+	Deps          []string `json:"deps,omitempty"`
+	Timeout       string   `json:"timeout,omitempty"`
+	Retry         int      `json:"retry,omitempty"`
+	FailurePolicy string   `json:"failure_policy,omitempty"`
+	Fingerprint   string   `json:"fingerprint,omitempty"`
+	SynthesisRule string   `json:"synthesis_rule,omitempty"`
+}
+
 type AgentResult struct {
-	Decision    string            `json:"decision"`
-	Summary     string            `json:"summary"`
-	Findings    []json.RawMessage `json:"findings"`
-	ChangesMade []string          `json:"changes_made"`
-	TestsRun    []string          `json:"tests_run"`
-	Needs       []string          `json:"needs"`
-	NextAgents  []string          `json:"next_agents"`
+	Decision     string            `json:"decision"`
+	Summary      string            `json:"summary"`
+	Findings     []json.RawMessage `json:"findings"`
+	ChangesMade  []string          `json:"changes_made"`
+	TestsRun     []string          `json:"tests_run"`
+	Needs        []string          `json:"needs"`
+	Delegations  []Delegation      `json:"delegations"`
+	ArtifactBody string            `json:"artifact_body,omitempty"`
 }
 
 func ExtractAgentResult(output string) (AgentResult, error) {
@@ -34,6 +52,16 @@ func ExtractAgentResult(output string) (AgentResult, error) {
 		if err := json.Unmarshal(raw, &result); err != nil {
 			if validationErr == nil {
 				validationErr = err
+			}
+			continue
+		}
+		var legacy struct {
+			NextAgents []string `json:"next_agents"`
+		}
+		_ = json.Unmarshal(raw, &legacy)
+		if len(legacy.NextAgents) > 0 {
+			if validationErr == nil {
+				validationErr = fmt.Errorf("legacy next_agents is no longer supported; use delegations")
 			}
 			continue
 		}
@@ -61,6 +89,23 @@ func validateAgentResult(result AgentResult) error {
 	if strings.TrimSpace(result.Summary) == "" {
 		return errors.New("gitmoot_result summary is required")
 	}
+	for _, d := range result.Delegations {
+		if strings.TrimSpace(d.ID) == "" {
+			return errors.New("delegation id is required")
+		}
+		if strings.TrimSpace(d.Agent) == "" {
+			return errors.New("delegation agent is required")
+		}
+		if strings.TrimSpace(d.Action) == "" {
+			return errors.New("delegation action is required")
+		}
+		if strings.TrimSpace(d.Prompt) == "" {
+			return errors.New("delegation prompt is required")
+		}
+		if len(d.Deps) > 0 {
+			return fmt.Errorf("delegation %q uses dependencies, which are not yet supported", d.ID)
+		}
+	}
 	return nil
 }
 
@@ -77,8 +122,8 @@ func normalizeAgentResult(result *AgentResult) {
 	if result.Needs == nil {
 		result.Needs = []string{}
 	}
-	if result.NextAgents == nil {
-		result.NextAgents = []string{}
+	if result.Delegations == nil {
+		result.Delegations = []Delegation{}
 	}
 }
 

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -10,7 +10,7 @@ import (
 const resultKey = `"gitmoot_result"`
 
 // Delegation describes a child job that an agent wants Gitmoot to enqueue on
-// its behalf. It is the richer replacement for the legacy next_agents list.
+// its behalf.
 type Delegation struct {
 	ID            string   `json:"id"`
 	Agent         string   `json:"agent"`
@@ -48,20 +48,16 @@ func ExtractAgentResult(output string) (AgentResult, error) {
 		if !ok {
 			continue
 		}
-		var result AgentResult
-		if err := json.Unmarshal(raw, &result); err != nil {
+		if err := validateAgentResultFields(raw); err != nil {
 			if validationErr == nil {
 				validationErr = err
 			}
 			continue
 		}
-		var legacy struct {
-			NextAgents []string `json:"next_agents"`
-		}
-		_ = json.Unmarshal(raw, &legacy)
-		if len(legacy.NextAgents) > 0 {
+		var result AgentResult
+		if err := json.Unmarshal(raw, &result); err != nil {
 			if validationErr == nil {
-				validationErr = fmt.Errorf("legacy next_agents is no longer supported; use delegations")
+				validationErr = err
 			}
 			continue
 		}
@@ -78,6 +74,29 @@ func ExtractAgentResult(output string) (AgentResult, error) {
 		return AgentResult{}, validationErr
 	}
 	return AgentResult{}, errors.New("missing valid gitmoot_result JSON object")
+}
+
+func validateAgentResultFields(raw json.RawMessage) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	allowed := map[string]struct{}{
+		"decision":      {},
+		"summary":       {},
+		"findings":      {},
+		"changes_made":  {},
+		"tests_run":     {},
+		"needs":         {},
+		"delegations":   {},
+		"artifact_body": {},
+	}
+	for field := range fields {
+		if _, ok := allowed[field]; !ok {
+			return fmt.Errorf("unsupported gitmoot_result field %q", field)
+		}
+	}
+	return nil
 }
 
 func validateAgentResult(result AgentResult) error {

--- a/internal/workflow/result_test.go
+++ b/internal/workflow/result_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestExtractAgentResultFromFencedOutput(t *testing.T) {
 	output := "done\n```json\n" +
-		`{"gitmoot_result":{"decision":"approved","summary":"looks good","findings":[],"changes_made":[],"tests_run":["go test ./..."],"needs":[],"next_agents":[]}}` +
+		`{"gitmoot_result":{"decision":"approved","summary":"looks good","findings":[],"changes_made":[],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}` +
 		"\n```"
 
 	result, err := ExtractAgentResult(output)
@@ -34,14 +34,14 @@ func TestExtractAgentResultNormalizesMissingArrays(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExtractAgentResult returned error: %v", err)
 	}
-	if result.Findings == nil || result.ChangesMade == nil || result.TestsRun == nil || result.Needs == nil || result.NextAgents == nil {
+	if result.Findings == nil || result.ChangesMade == nil || result.TestsRun == nil || result.Needs == nil || result.Delegations == nil {
 		t.Fatalf("result arrays were not normalized: %+v", result)
 	}
 }
 
 func TestExtractAgentResultSkipsDecoyJSONCandidate(t *testing.T) {
 	output := `{"note":"mentions gitmoot_result but is not the envelope"}` + "\n" +
-		`{"gitmoot_result":{"decision":"approved","summary":"real result","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`
+		`{"gitmoot_result":{"decision":"approved","summary":"real result","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
 
 	result, err := ExtractAgentResult(output)
 
@@ -54,7 +54,7 @@ func TestExtractAgentResultSkipsDecoyJSONCandidate(t *testing.T) {
 }
 
 func TestExtractAgentResultRejectsUnsupportedDecision(t *testing.T) {
-	output := `{"gitmoot_result":{"decision":"maybe","summary":"unclear","findings":[],"changes_made":[],"tests_run":[],"needs":[],"next_agents":[]}}`
+	output := `{"gitmoot_result":{"decision":"maybe","summary":"unclear","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
 
 	if _, err := ExtractAgentResult(output); err == nil {
 		t.Fatal("ExtractAgentResult accepted unsupported decision")

--- a/internal/workflow/result_test.go
+++ b/internal/workflow/result_test.go
@@ -1,6 +1,9 @@
 package workflow
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestExtractAgentResultFromFencedOutput(t *testing.T) {
 	output := "done\n```json\n" +
@@ -58,5 +61,18 @@ func TestExtractAgentResultRejectsUnsupportedDecision(t *testing.T) {
 
 	if _, err := ExtractAgentResult(output); err == nil {
 		t.Fatal("ExtractAgentResult accepted unsupported decision")
+	}
+}
+
+func TestExtractAgentResultRejectsUnsupportedField(t *testing.T) {
+	output := `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[],"unexpected_field":[]}}`
+
+	_, err := ExtractAgentResult(output)
+
+	if err == nil {
+		t.Fatal("ExtractAgentResult accepted unsupported field")
+	}
+	if !strings.Contains(err.Error(), `unsupported gitmoot_result field "unexpected_field"`) {
+		t.Fatalf("error = %v", err)
 	}
 }

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -12,10 +12,45 @@ truthful, and tied to work that actually happened.
     "changes_made": [],
     "tests_run": [],
     "needs": [],
-    "next_agents": []
+    "delegations": []
   }
 }
 ```
+
+## Delegations
+
+Use `delegations` to request follow-up work by named Gitmoot agents. Each
+delegation describes a child job:
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "Plan ready for review.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "delegations": [
+      {
+        "id": "review-plan",
+        "agent": "thermo-review",
+        "action": "review",
+        "prompt": "Review the implementation plan for correctness."
+      }
+    ]
+  }
+}
+```
+
+Delegation fields:
+
+- `id` (required): stable identifier for this delegation within the result.
+- `agent` (required): name of the Gitmoot agent to run.
+- `action` (required): job action, e.g. `ask`, `review`, or `implement`.
+- `prompt` (required): instructions for the delegated job.
+- `worktree`, `artifacts`, `deps`, `timeout`, `retry`, `failure_policy`,
+  `fingerprint`, `synthesis_rule`: optional controls for advanced dispatchers.
 
 ## Decisions
 
@@ -31,5 +66,5 @@ truthful, and tied to work that actually happened.
 - Do not claim files were changed unless they were actually changed.
 - Use `needs` for missing credentials, unclear scope, unavailable tools, failing
   external services, or required human decisions.
-- Use `next_agents` only when another named Gitmoot agent should be invoked.
+- Use `delegations` when another named Gitmoot agent should be invoked.
 - Redact secrets from summaries, findings, raw command output, and examples.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -752,7 +752,7 @@ object:
     "changes_made": [],
     "tests_run": [],
     "needs": [],
-    "next_agents": []
+    "delegations": []
   }
 }
 ```
@@ -1055,7 +1055,7 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
 
    ```sh
    gitmoot agent subscribe audit --runtime claude --session <claude-session-id> --role reviewer --repo owner/project --capability review --capability ask
-   gitmoot agent subscribe shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"ok\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell\"],\"needs\":[],\"next_agents\":[]}}'" --role reviewer --repo owner/project --capability ask
+   gitmoot agent subscribe shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"ok\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell\"],\"needs\":[],\"delegations\":[]}}'" --role reviewer --repo owner/project --capability ask
    gitmoot agent list
    ```
 
@@ -1235,7 +1235,7 @@ Agents must return exactly one JSON object containing `gitmoot_result`:
     "changes_made": [],
     "tests_run": [],
     "needs": [],
-    "next_agents": []
+    "delegations": []
   }
 }
 ```
@@ -2124,7 +2124,7 @@ Required shape:
     "changes_made": [],
     "tests_run": [],
     "needs": [],
-    "next_agents": []
+    "delegations": []
   }
 }
 ```
@@ -3631,7 +3631,7 @@ the smoke test cannot approve or merge the PR.
 1. Register the repo and a shell smoke agent.
 
    ```sh
-   gitmoot setup --repo owner/project --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"shell ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"next_agents\":[]}}'"
+   gitmoot setup --repo owner/project --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"shell ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'"
    gitmoot agent repos shell-smoke
    ```
 
@@ -4230,10 +4230,10 @@ each repo -> no cross-routing. This intentionally avoids approving reviews.
 
    ```sh
    cd /path/to/project-a
-   gitmoot setup --repo owner/project-a --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"repo ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"next_agents\":[]}}'"
+   gitmoot setup --repo owner/project-a --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"repo ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'"
 
    cd /path/to/project-b
-   gitmoot setup --repo owner/project-b --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"repo ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"next_agents\":[]}}'"
+   gitmoot setup --repo owner/project-b --path . --agent shell-smoke --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"repo ask smoke passed\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'"
 
    gitmoot agent repos shell-smoke
    ```
@@ -5989,7 +5989,7 @@ truthful, and tied to work that actually happened.
     "changes_made": [],
     "tests_run": [],
     "needs": [],
-    "next_agents": []
+    "delegations": []
   }
 }
 ```
@@ -6008,7 +6008,7 @@ truthful, and tied to work that actually happened.
 - Do not claim files were changed unless they were actually changed.
 - Use `needs` for missing credentials, unclear scope, unavailable tools, failing
   external services, or required human decisions.
-- Use `next_agents` only when another named Gitmoot agent should be invoked.
+- Use `delegations` only when another named Gitmoot agent should be invoked.
 - Redact secrets from summaries, findings, raw command output, and examples.
 
 ---


### PR DESCRIPTION
Implements Task 3051 from GOALS/GOAL-structured-job-delegations.md.

### What changed
- Added a new `Delegation` struct and replaced `AgentResult.NextAgents` with `AgentResult.Delegations`.
- Added job DAG columns to `db.Job` and the SQLite migration (`parent_job_id`, `delegation_id`, `delegation_depth`, `delegated_by`).
- Persisted DAG metadata through `Mailbox.Enqueue`, `Store.CreateJob`, and `Store.CreateJobWithEvent`.
- Added a minimal delegation dispatcher in `Engine.AdvanceJob` with validation, lightweight preflight, branch-lock acquisition for implement actions, and task blocking on policy failures.
- Updated prompts, report rendering, job comments, `SKILL.md`, and `skills/gitmoot/references/RESULT_CONTRACT.md` to use `delegations`.
- Rejected legacy non-empty `next_agents` output and unsupported delegation `deps` during result validation.

### Verification
- `go test ./internal/workflow ./internal/db ./internal/prompts ./internal/report` passes.
- `go vet ./...` and `git diff --check` are clean.
- `codex-face exec review --uncommitted` was iterated until no further actionable findings remained; the final run was interrupted by model capacity, not by a code issue.

### Scope note
Raw `next_agents` strings in some CLI test fixtures and docs are intentionally left unchanged where they are empty/ignored, to be migrated in Task 3052.