### PR TITLE
feat: structured job delegations — DAG, artifacts, continuation, lifecycle (#301 tasks 3054-3059)

### DIFF
--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -148,6 +148,89 @@ Expected signals:
    gitmoot daemon status
    ```
 
+## Delegation Smoke Test
+
+Goal: background coordinator job -> `delegations` in the coordinator result ->
+two child jobs fanned out to worker agents -> both children succeed -> coordinator
+continuation job enqueued. This exercises the structured delegation path end to
+end with local shell agents, so it needs no external runtime CLIs.
+
+The coordinator must run as background work so the daemon executes it through the
+engine and dispatches the delegations. A synchronous `gitmoot agent ask` without
+`--background` only returns the coordinator's own result and does not fan out, so
+the test would silently pass with zero child jobs.
+
+1. Register a coordinator shell agent whose result returns two delegations, and
+   two worker shell agents whose results return empty `delegations` (so the
+   fan-out terminates and does not recurse).
+
+   ```sh
+   gitmoot setup --repo owner/project --path . --agent coordinator --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"coordinator delegating ui and api\",\"findings\":[],\"changes_made\":[],\"tests_run\":[],\"needs\":[],\"delegations\":[{\"id\":\"ui\",\"agent\":\"ui-worker\",\"action\":\"ask\",\"prompt\":\"propose the ui changes\"},{\"id\":\"api\",\"agent\":\"api-worker\",\"action\":\"review\",\"prompt\":\"review the api contract\"}]}}'"
+   gitmoot agent subscribe ui-worker --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"ui worker done\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'" --role reviewer --repo owner/project --capability ask --capability review
+   gitmoot agent subscribe api-worker --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"api worker done\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'" --role reviewer --repo owner/project --capability ask --capability review
+   gitmoot agent repos coordinator
+   ```
+
+2. Start the background daemon so it executes the queued coordinator job and
+   fans out the delegations.
+
+   ```sh
+   gitmoot daemon start --repo owner/project --poll 30s
+   gitmoot daemon status
+   ```
+
+3. Queue the coordinator as background work.
+
+   ```sh
+   gitmoot agent ask coordinator --repo owner/project --background "coordinate the ui and api work"
+   ```
+
+4. Confirm the coordinator job, the two child jobs, and the continuation job.
+
+   ```sh
+   gitmoot job list --repo owner/project
+   gitmoot events --repo owner/project
+   ```
+
+Expected signals:
+
+- `gitmoot events --repo owner/project` shows two `delegation_enqueued` events
+  on the coordinator job, one for the `ui` delegation and one for the `api`
+  delegation.
+- `gitmoot job list --repo owner/project` shows two child jobs with composite
+  ids of the form `<coordinator-job-id>/delegation/ui` and
+  `<coordinator-job-id>/delegation/api`, each reaching `succeeded`.
+- After both children succeed, `gitmoot events --repo owner/project` shows a
+  `delegation_continuation_enqueued` event and `gitmoot job list` shows a
+  coordinator continuation job `<coordinator-job-id>/continuation` queued for
+  `coordinator`.
+
+5. (Optional) Verify dependency gating. Re-run with a coordinator whose result
+   adds a third delegation that depends on the first two; it must stay queued
+   until both deps succeed, then run.
+
+   ```json
+   {
+     "id": "integrate",
+     "agent": "api-worker",
+     "action": "ask",
+     "prompt": "integrate the ui and api work",
+     "deps": ["ui", "api"]
+   }
+   ```
+
+   Expected: `gitmoot events --repo owner/project` shows the
+   `<coordinator-job-id>/delegation/integrate` job enqueued only after the `ui`
+   and `api` children reach `succeeded`, and the continuation job is enqueued
+   once `integrate` also succeeds.
+
+6. Stop the daemon when finished.
+
+   ```sh
+   gitmoot daemon stop
+   gitmoot daemon status
+   ```
+
 ## Thermo Template Smoke Test
 
 Goal: PR comment -> queued review job -> Codex resume with cached thermo template

--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -165,7 +165,7 @@ the test would silently pass with zero child jobs.
    fan-out terminates and does not recurse).
 
    ```sh
-   gitmoot setup --repo owner/project --path . --agent coordinator --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"coordinator delegating ui and api\",\"findings\":[],\"changes_made\":[],\"tests_run\":[],\"needs\":[],\"delegations\":[{\"id\":\"ui\",\"agent\":\"ui-worker\",\"action\":\"ask\",\"prompt\":\"propose the ui changes\"},{\"id\":\"api\",\"agent\":\"api-worker\",\"action\":\"review\",\"prompt\":\"review the api contract\"}]}}'"
+   gitmoot setup --repo owner/project --path . --agent coordinator --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"coordinator delegating ui and api\",\"findings\":[],\"changes_made\":[],\"tests_run\":[],\"needs\":[],\"delegations\":[{\"id\":\"ui\",\"agent\":\"ui-worker\",\"action\":\"ask\",\"prompt\":\"propose the ui changes\"},{\"id\":\"api\",\"agent\":\"api-worker\",\"action\":\"ask\",\"prompt\":\"review the api contract\"}]}}'"
    gitmoot agent subscribe ui-worker --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"ui worker done\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'" --role reviewer --repo owner/project --capability ask --capability review
    gitmoot agent subscribe api-worker --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"api worker done\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'" --role reviewer --repo owner/project --capability ask --capability review
    gitmoot agent repos coordinator
@@ -204,6 +204,18 @@ Expected signals:
   `delegation_continuation_enqueued` event and `gitmoot job list` shows a
   coordinator continuation job `<coordinator-job-id>/continuation` queued for
   `coordinator`.
+
+> Note: the continuation job runs the **same** coordinator agent. A real LLM
+> coordinator ends the loop by returning no `delegations` on the continuation,
+> but a *static* shell agent returns the same delegations every time, so the
+> continuation re-delegates each generation. This is bounded by
+> `MaxDelegationDepth` (8): once a coordinator/continuation at that depth would
+> dispatch, Gitmoot refuses and records a `delegation_depth_exceeded` event
+> instead of spawning jobs forever. To keep this smoke test fast, run
+> `gitmoot daemon stop` once you have observed the first continuation rather than
+> waiting for the depth cap to halt the chain. Also note delegated `action:
+> review` requires a pull request / head SHA; use `action: ask` for PR-less
+> smoke agents (a no-PR review fails with "job for <branch> has no head SHA").
 
 5. (Optional) Verify dependency gating. Re-run with a coordinator whose result
    adds a third delegation that depends on the first two; it must stay queued

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -214,7 +214,11 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			return localAgentJobOutput{}, err
 		}
 	} else {
-		engine := daemonWorkflowEngine(store, github.NewClient(checkoutPath), checkoutPath)
+		workflowHome := ""
+		if paths, err := pathsFromFlag(request.Home); err == nil {
+			workflowHome = paths.Home
+		}
+		engine := daemonWorkflowEngine(store, github.NewClient(checkoutPath), checkoutPath, workflowHome)
 		if _, err := engine.RunJob(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {
 			return localAgentJobOutput{}, err
 		}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -808,7 +808,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			NextPoll:    map[string]time.Time{},
 			ErrorStreak: map[string]int{},
 		}
-		poller := defaultRegisteredRepoPoller(store, workers, dryRun, stdout)
+		poller := defaultRegisteredRepoPoller(store, workers, dryRun, stdout, paths.Home)
 		blobStore := artifact.NewStore(paths.ArtifactBlobs)
 		reviewGitHub := newSkillOptGitHubClient()
 		worker := defaultJobWorker(store, stdout, home)
@@ -958,7 +958,7 @@ func (l *repoCheckoutLocks) For(repo string) *sync.Mutex {
 }
 
 func pollRegisteredRepos(ctx context.Context, store *db.Store, workers int, dryRun bool, stdout io.Writer, nextPoll map[string]time.Time, now time.Time, fallbackPoll time.Duration) (time.Duration, error) {
-	return pollRegisteredReposWithPoller(ctx, defaultRegisteredRepoPoller(store, workers, dryRun, stdout), registeredRepoSchedule{NextPoll: nextPoll}, now, fallbackPoll)
+	return pollRegisteredReposWithPoller(ctx, defaultRegisteredRepoPoller(store, workers, dryRun, stdout, ""), registeredRepoSchedule{NextPoll: nextPoll}, now, fallbackPoll)
 }
 
 type registeredRepoSchedule struct {
@@ -987,7 +987,7 @@ type registeredRepoPoller struct {
 	WorkflowFactory func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
 }
 
-func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdout io.Writer) registeredRepoPoller {
+func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdout io.Writer, home string) registeredRepoPoller {
 	return registeredRepoPoller{
 		Store:        store,
 		Workers:      workers,
@@ -995,7 +995,7 @@ func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdo
 		Stdout:       stdout,
 		GitHubClient: func(checkout string) github.Client { return github.NewClient(checkout) },
 		WorkflowFactory: func(store *db.Store, gh github.Client, checkout string) *workflow.Engine {
-			engine := daemonWorkflowEngine(store, gh, checkout)
+			engine := daemonWorkflowEngine(store, gh, checkout, home)
 			return &engine
 		},
 	}
@@ -1536,6 +1536,13 @@ func queuedJobCheckoutKey(ctx context.Context, store *db.Store, job db.Job) stri
 }
 
 func queuedJobTaskWorktreePath(ctx context.Context, store *db.Store, payload workflow.JobPayload) (string, bool) {
+	// Sibling delegations share a task id but run in distinct per-delegation
+	// worktrees; key off the payload worktree path so they schedule as separate
+	// checkout keys and can run in parallel.
+	if delegationPath := strings.TrimSpace(payload.WorktreePath); delegationPath != "" {
+		path, err := normalizeTaskWorktreePath(delegationPath)
+		return path, err == nil && path != ""
+	}
 	if store == nil || strings.TrimSpace(payload.TaskID) == "" {
 		return "", false
 	}
@@ -2294,15 +2301,27 @@ func (w jobWorker) defaultStartAdapter(runtimeName string, checkout string) (run
 }
 
 func (w jobWorker) defaultWorkflow(checkout string) workflow.Engine {
-	return daemonWorkflowEngine(w.Store, github.NewClient(checkout), checkout)
+	return daemonWorkflowEngine(w.Store, github.NewClient(checkout), checkout, w.workflowHome())
+}
+
+// workflowHome resolves the GITMOOT_HOME root used to place per-delegation
+// worktrees, mirroring how the daemon resolves paths elsewhere. It returns an
+// empty string when resolution fails so the engine falls back to legacy
+// shared-checkout dispatch rather than failing the job.
+func (w jobWorker) workflowHome() string {
+	paths, err := pathsFromFlag(w.ConfigHome)
+	if err != nil {
+		return ""
+	}
+	return paths.Home
 }
 
 func (w jobWorker) defaultCommenter(_ string) github.Client {
 	return github.NewClient("")
 }
 
-func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string) workflow.Engine {
-	return workflow.Engine{
+func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, home string) workflow.Engine {
+	engine := workflow.Engine{
 		Store:                   store,
 		MergeGate:               daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout},
 		ImplementationFinalizer: daemonImplementationFinalizer{Store: store, GitHub: gh, FallbackCheckout: checkout},
@@ -2310,6 +2329,12 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string) wo
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},
 	}
+	if strings.TrimSpace(home) != "" && strings.TrimSpace(checkout) != "" {
+		engine.Home = home
+		engine.DelegationCheckout = checkout
+		engine.DelegationWorktrees = gitutil.Client{Dir: checkout}
+	}
+	return engine
 }
 
 type daemonImplementationFinalizer struct {
@@ -2685,6 +2710,16 @@ func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload w
 }
 
 func (w jobWorker) taskWorktreeCheckout(ctx context.Context, payload workflow.JobPayload) (string, bool, error) {
+	// Delegated implement jobs carry their own per-delegation worktree path in
+	// the payload; prefer it over the task-table worktree so the child runs in
+	// its isolated checkout.
+	if delegationPath := strings.TrimSpace(payload.WorktreePath); delegationPath != "" {
+		checkout, err := normalizeTaskWorktreePath(delegationPath)
+		if err != nil {
+			return "", false, err
+		}
+		return checkout, checkout != "", nil
+	}
 	if strings.TrimSpace(payload.TaskID) == "" {
 		return "", false, nil
 	}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2799,6 +2799,15 @@ func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.
 	if !clean {
 		return fmt.Errorf("checkout %s has uncommitted changes", checkout)
 	}
+	// A delegated implement child runs in its own freshly-allocated worktree,
+	// created off the parent's base branch whose tip may have advanced past the
+	// HeadSHA the child inherited from the parent payload. The dispatcher clears
+	// the inherited HeadSHA for these children, so the worktree HEAD is correct
+	// by construction (it is the base-branch tip at allocation time) and there is
+	// nothing to compare against. Skip the HeadSHA equality check for them.
+	if isDelegationWorktreeChild(payload) {
+		return nil
+	}
 	expectedHead := strings.TrimSpace(payload.HeadSHA)
 	if expectedHead == "" {
 		return fmt.Errorf("job for %s has no head SHA", payload.Branch)
@@ -2811,6 +2820,14 @@ func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.
 		return fmt.Errorf("checkout head is %s, not job head %s", head, expectedHead)
 	}
 	return nil
+}
+
+// isDelegationWorktreeChild reports whether the job is a delegated child running
+// in its own per-delegation worktree (it carries both a delegation id and an
+// allocated worktree path). Such children are validated against their isolated
+// worktree HEAD rather than the inherited parent HeadSHA.
+func isDelegationWorktreeChild(payload workflow.JobPayload) bool {
+	return strings.TrimSpace(payload.DelegationID) != "" && strings.TrimSpace(payload.WorktreePath) != ""
 }
 
 func (w jobWorker) validateReviewCheckout(ctx context.Context, payload workflow.JobPayload, checkout string) error {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2926,10 +2926,45 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause er
 		}
 		return nil
 	}
+	if payloadErr == nil && strings.TrimSpace(payload.ParentJobID) != "" {
+		// A delegation child killed by its per-delegation timeout (or any runtime
+		// failure that yields no parseable gitmoot_result) lands here still
+		// JobRunning, or JobFailed/JobBlocked WITHOUT a stored result: Mailbox.Run
+		// errored, so RunJob returned before AdvanceJob and the parent's
+		// advanceDelegations never ran. Finalize it as a terminal failed child and
+		// drive the parent DAG so the delegation's retry/failure_policy/continuation
+		// actually fire instead of the child stranding until the 30m stale-running
+		// recovery blindly re-queues it.
+		finalized, finalizeErr := w.finalizeTimedOutDelegationChild(ctx, latest, cause)
+		if finalizeErr != nil {
+			var blocked workflow.BlockedError
+			if errors.As(finalizeErr, &blocked) {
+				// block_parent failure_policy blocked the shared parent task; the
+				// child is finalized and the DAG advanced, so this is the expected
+				// terminal outcome rather than an error to propagate.
+				return nil
+			}
+			return finalizeErr
+		}
+		if finalized {
+			return nil
+		}
+	}
 	if latest.State == string(workflow.JobFailed) || latest.State == string(workflow.JobBlocked) {
 		return nil
 	}
 	return cause
+}
+
+// finalizeTimedOutDelegationChild bridges the daemon run-error path into the
+// engine's delegation DAG: it converts a timed-out/runtime-failed delegation
+// child with no stored result into a terminal failed child and advances the
+// parent. It builds a checkout-less engine because only DB/DAG operations run
+// here (no git/worktree work). Returns whether the child was finalized.
+func (w jobWorker) finalizeTimedOutDelegationChild(ctx context.Context, job db.Job, cause error) (bool, error) {
+	reason := fmt.Sprintf("delegation child %s ended without a result: %v", job.ID, cause)
+	engine := w.WorkflowFactory("")
+	return engine.FinalizeTimedOutDelegationChild(ctx, job.ID, reason)
 }
 
 func (w jobWorker) recordPostDeliveryWorkflowError(ctx context.Context, job db.Job, cause error) error {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2959,12 +2959,33 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause er
 // finalizeTimedOutDelegationChild bridges the daemon run-error path into the
 // engine's delegation DAG: it converts a timed-out/runtime-failed delegation
 // child with no stored result into a terminal failed child and advances the
-// parent. It builds a checkout-less engine because only DB/DAG operations run
-// here (no git/worktree work). Returns whether the child was finalized.
+// parent. Advancing the parent can trigger a retry of an *implement* delegation,
+// which must allocate a fresh per-delegation worktree; so it resolves the repo's
+// main checkout and builds a fully-wired engine instead of a checkout-less one.
+// A missing checkout degrades gracefully (the engine emits
+// delegation_worktree_skipped and falls back to a shared-checkout branch lock).
+// Returns whether the child was finalized.
 func (w jobWorker) finalizeTimedOutDelegationChild(ctx context.Context, job db.Job, cause error) (bool, error) {
 	reason := fmt.Sprintf("delegation child %s ended without a result: %v", job.ID, cause)
-	engine := w.WorkflowFactory("")
+	engine := w.WorkflowFactory(w.delegationParentCheckout(ctx, job))
 	return engine.FinalizeTimedOutDelegationChild(ctx, job.ID, reason)
+}
+
+// delegationParentCheckout returns the repo's main registered checkout for a
+// delegation child job (NOT the child's own worktree), so the engine can
+// `git worktree add` a retry's per-delegation worktree against it. It returns
+// "" on any lookup failure, leaving the engine to advance the DAG without
+// worktree isolation rather than blocking finalization.
+func (w jobWorker) delegationParentCheckout(ctx context.Context, job db.Job) string {
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return ""
+	}
+	repoRecord, err := w.Store.GetRepo(ctx, payload.Repo)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(repoRecord.CheckoutPath)
 }
 
 func (w jobWorker) recordPostDeliveryWorkflowError(ctx context.Context, job db.Job, cause error) error {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1625,9 +1625,10 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 		return nil
 	}
+	jobTimeout := effectiveJobTimeout(payload, managed)
 	lockTTL := daemonRunningJobStaleAfter
-	if managed.OK {
-		lockTTL = managed.JobTimeout
+	if jobTimeout > 0 {
+		lockTTL = jobTimeout
 	}
 	releaseLock, acquired, lockKey, err := acquireRuntimeSessionLock(ctx, w.Store, job.ID, agent, time.Now().UTC(), lockTTL)
 	if err != nil {
@@ -1686,9 +1687,9 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	engine := w.WorkflowFactory(checkout)
 	runCtx, stopRun := w.runningJobContext(ctx, job.ID)
 	defer stopRun()
-	if managed.OK {
+	if jobTimeout > 0 {
 		var cancel context.CancelFunc
-		runCtx, cancel = context.WithTimeout(runCtx, managed.JobTimeout)
+		runCtx, cancel = context.WithTimeout(runCtx, jobTimeout)
 		defer cancel()
 	}
 	_, err = engine.RunJob(runCtx, job.ID, agent, adapter)
@@ -1797,6 +1798,11 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		}
 		writeLine(w.Stdout, "job %s waiting: %s", job.ID, waitMessage)
 		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, waitMessage)
+	}
+	// A per-delegation timeout on the payload overrides the agent-type job
+	// timeout for both the lock TTL and the run deadline below.
+	if d, perr := time.ParseDuration(strings.TrimSpace(payload.JobTimeout)); perr == nil && d > 0 {
+		started.JobTimeout = d
 	}
 	payload.OriginalAgent = original.Name
 	payload.DelegatedAgent = started.Agent.Name
@@ -2136,6 +2142,18 @@ func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (mana
 		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s idle_timeout must be positive", configType)
 	}
 	return managedJobRuntimeConfig{OK: true, JobTimeout: jobTimeout, IdleTimeout: idleTimeout}, nil
+}
+
+// effectiveJobTimeout returns the timeout to enforce for a job: the
+// per-delegation payload.JobTimeout when it parses to a positive duration,
+// otherwise the agent-type managed.JobTimeout (which is zero when the agent is
+// not managed). The same value drives both the runtime-session lock TTL and the
+// run context deadline so the lock cannot expire before the job does.
+func effectiveJobTimeout(payload workflow.JobPayload, managed managedJobRuntimeConfig) time.Duration {
+	if d, err := time.ParseDuration(strings.TrimSpace(payload.JobTimeout)); err == nil && d > 0 {
+		return d
+	}
+	return managed.JobTimeout
 }
 
 func originalAgentForTempWorkerType(typ string) string {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2329,6 +2329,12 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},
 	}
+	if strings.TrimSpace(home) != "" {
+		// Root delegation artifacts under GITMOOT_HOME (alongside worktrees)
+		// rather than inside the repo checkout, so generated briefs stay out of
+		// the tracked tree and are never committed.
+		engine.ArtifactRoot = home
+	}
 	if strings.TrimSpace(home) != "" && strings.TrimSpace(checkout) != "" {
 		engine.Home = home
 		engine.DelegationCheckout = checkout

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -408,7 +408,7 @@ func TestPollRegisteredReposRoutesEachRepoWithOwnGitHubClient(t *testing.T) {
 			},
 		},
 	}
-	poller := defaultRegisteredRepoPoller(store, 2, false, io.Discard)
+	poller := defaultRegisteredRepoPoller(store, 2, false, io.Discard, "")
 	poller.GitHubClient = func(checkout string) github.Client { return clients[checkout] }
 	poller.WorkflowFactory = func(*db.Store, github.Client, string) *workflow.Engine { return nil }
 
@@ -478,7 +478,7 @@ func TestPollRegisteredReposBacksOffFailedRepoWithoutStoppingOthers(t *testing.T
 	}
 	failing := &cliPollFakeGitHub{listErr: errors.New("rate limited")}
 	healthy := &cliPollFakeGitHub{}
-	poller := defaultRegisteredRepoPoller(store, 1, false, io.Discard)
+	poller := defaultRegisteredRepoPoller(store, 1, false, io.Discard, "")
 	poller.GitHubClient = func(checkout string) github.Client {
 		if checkout == "/tmp/failing" {
 			return failing
@@ -1329,7 +1329,7 @@ func TestRunQueuedJobsRefreshesImplementedHeadBeforeReviewDispatch(t *testing.T)
 		return adapter, nil
 	}
 	worker.WorkflowFactory = func(checkout string) workflow.Engine {
-		return daemonWorkflowEngine(store, github.NoopClient{}, checkout)
+		return daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
 	}
 
 	if err := runQueuedJobs(ctx, worker, 1); err != nil {
@@ -3504,7 +3504,7 @@ func TestRetryPendingJobAdvancementsRefreshesImplementedHeadBeforePreflight(t *t
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.WorkflowFactory = func(checkout string) workflow.Engine {
-		return daemonWorkflowEngine(store, github.NoopClient{}, checkout)
+		return daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
 	}
 
 	if err := retryPendingJobAdvancements(ctx, worker, ""); err != nil {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -1408,6 +1408,15 @@ func TestRunQueuedJobsSerializesSameRepoCheckout(t *testing.T) {
 func TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	content := strings.Replace(config.DefaultConfig(paths), `same_session = "fork_temp_session"`, `same_session = "queue"`, 1)
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile config returned error: %v", err)
+	}
 	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
 	seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
 	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo-a")
@@ -1434,7 +1443,7 @@ func TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos(t *testing.T) {
 			mu.Unlock()
 		},
 	}
-	worker := defaultJobWorker(store, io.Discard)
+	worker := defaultJobWorker(store, io.Discard, home)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		return t.TempDir(), nil
 	}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -2248,6 +2248,49 @@ func TestRunQueuedJobsUsesTaskWorktreeForImplement(t *testing.T) {
 	}
 }
 
+func TestValidateTargetCheckoutSkipsHeadShaForDelegationWorktreeChild(t *testing.T) {
+	// A delegated implement child runs in its own freshly-allocated worktree whose
+	// HEAD is the base-branch tip at allocation time; the dispatcher clears the
+	// inherited parent HeadSHA. validateTargetCheckout must not reject such a child
+	// even when its payload HeadSHA is empty or stale, as long as the worktree is
+	// on the job branch and clean. A non-delegation job with a mismatched HeadSHA
+	// must still be rejected.
+	ctx := context.Background()
+	checkout := createDaemonWorkerGitCheckout(t, "task-005")
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard)
+
+	// Delegation child: empty HeadSHA + worktree path -> accepted.
+	delegationPayload := workflow.JobPayload{
+		Repo:         "owner/repo",
+		Branch:       "task-005",
+		DelegationID: "d1",
+		ParentJobID:  "parent-job",
+		WorktreePath: checkout,
+	}
+	if err := worker.validateTargetCheckout(ctx, delegationPayload, checkout); err != nil {
+		t.Fatalf("validateTargetCheckout rejected delegation worktree child: %v", err)
+	}
+
+	// Delegation child with a stale (non-matching) HeadSHA -> still accepted,
+	// because the equality check is skipped for delegation worktree children.
+	stalePayload := delegationPayload
+	stalePayload.HeadSHA = "0000000000000000000000000000000000000000"
+	if err := worker.validateTargetCheckout(ctx, stalePayload, checkout); err != nil {
+		t.Fatalf("validateTargetCheckout rejected delegation child with stale HeadSHA: %v", err)
+	}
+
+	// A non-delegation job with a mismatched HeadSHA must still be rejected so the
+	// HeadSHA guard is not weakened for ordinary jobs.
+	ordinaryPayload := workflow.JobPayload{
+		Repo:    "owner/repo",
+		Branch:  "task-005",
+		HeadSHA: "0000000000000000000000000000000000000000",
+	}
+	if err := worker.validateTargetCheckout(ctx, ordinaryPayload, checkout); err == nil {
+		t.Fatal("validateTargetCheckout accepted ordinary job with mismatched HeadSHA")
+	}
+}
+
 func TestRefreshDaemonJobPayloadPreservesTaskWorktreeHeadForFinalizer(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4132,3 +4132,334 @@ func TestEffectiveJobTimeout(t *testing.T) {
 		t.Fatalf("effectiveJobTimeout(unmanaged, payload) = %v, want 45s", got)
 	}
 }
+
+// seedDelegationCoordinator inserts a completed coordinator parent job whose
+// result carries the given delegations and advances it so the engine dispatches
+// the top-level delegation children. It returns the worker wired to the same
+// store. The coordinator runs an "ask" job; delegations use "review" so dispatch
+// stays on the shared-checkout path (no per-delegation worktree allocation).
+func seedDelegationCoordinator(t *testing.T, store *db.Store, parentID string, delegations []workflow.Delegation) jobWorker {
+	t.Helper()
+	ctx := context.Background()
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "coord", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	seenAgents := map[string]bool{"coord": true}
+	for _, d := range delegations {
+		if seenAgents[d.Agent] {
+			continue
+		}
+		seenAgents[d.Agent] = true
+		seedDaemonWorkerAgent(t, store, d.Agent, runtime.ShellRuntime, "unused", []string{d.Action}, "owner/repo")
+	}
+
+	if err := store.CreateJob(ctx, db.Job{ID: parentID, Agent: "coord", Type: "ask", State: string(workflow.JobRunning)}); err != nil {
+		t.Fatalf("CreateJob(parent) returned error: %v", err)
+	}
+	payload := workflow.JobPayload{
+		Repo:      "owner/repo",
+		Branch:    "task-1",
+		TaskID:    "task-1",
+		TaskTitle: "Coordinator",
+		Sender:    "coord",
+		Result: &workflow.AgentResult{
+			Decision:    "approved",
+			Summary:     "delegated",
+			Delegations: delegations,
+		},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal parent payload returned error: %v", err)
+	}
+	if err := store.UpdateJobPayload(ctx, parentID, string(encoded)); err != nil {
+		t.Fatalf("UpdateJobPayload(parent) returned error: %v", err)
+	}
+	if err := store.UpdateJobState(ctx, parentID, string(workflow.JobSucceeded)); err != nil {
+		t.Fatalf("UpdateJobState(parent) returned error: %v", err)
+	}
+
+	worker := defaultJobWorker(store, io.Discard)
+	worker.WorkflowFactory = func(checkout string) workflow.Engine {
+		return daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
+	}
+	engine := worker.WorkflowFactory("")
+	if err := engine.AdvanceJob(ctx, parentID); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	return worker
+}
+
+// markDelegationChildTimedOut simulates a per-delegation timeout kill: the child
+// is left JobRunning with no stored result, exactly as Mailbox.Run leaves it when
+// the run context deadline fires mid-delivery (the cancelled context aborts its
+// own fail write).
+func markDelegationChildTimedOut(t *testing.T, store *db.Store, childID string) {
+	t.Helper()
+	if err := store.UpdateJobState(context.Background(), childID, string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState(%s, running) returned error: %v", childID, err)
+	}
+}
+
+func TestHandleRunJobErrorTimedOutDelegationChildTriggersRetry(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worker := seedDelegationCoordinator(t, store, "parent-job", []workflow.Delegation{
+		{ID: "api", Agent: "api", Action: "review", Prompt: "build api", Retry: 1},
+	})
+
+	childID := "parent-job/delegation/api"
+	markDelegationChildTimedOut(t, store, childID)
+	child, err := store.GetJob(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetJob(child) returned error: %v", err)
+	}
+
+	// The daemon's run-error path must turn the timeout kill into a terminal
+	// failed child AND drive the parent DAG so the delegation's retry fires.
+	if err := worker.handleRunJobError(ctx, childID, context.DeadlineExceeded); err != nil {
+		t.Fatalf("handleRunJobError returned error: %v", err)
+	}
+
+	// The timed-out child is now terminal failed (not stranded in running).
+	finalized, err := store.GetJob(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetJob(child after) returned error: %v", err)
+	}
+	if finalized.State != string(workflow.JobFailed) {
+		t.Fatalf("timed-out child state = %q, want failed", finalized.State)
+	}
+
+	// Retry budget (Retry:1) is consumed by the timeout: a retry job is enqueued.
+	retry, err := store.GetJob(ctx, "parent-job/delegation/api/retry/1")
+	if err != nil {
+		t.Fatalf("retry job not enqueued after timeout: %v", err)
+	}
+	if retry.State != string(workflow.JobQueued) || retry.DelegationID != "api" {
+		t.Fatalf("retry job = %+v, want queued review of delegation api", retry)
+	}
+	events, err := store.ListJobEvents(ctx, "parent-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "delegation_retry") {
+		t.Fatalf("parent events = %+v, want delegation_retry", events)
+	}
+	_ = child
+}
+
+func TestHandleRunJobErrorTimedOutDelegationChildBlocksParentWhenNoRetry(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worker := seedDelegationCoordinator(t, store, "parent-job", []workflow.Delegation{
+		// Retry:0 + default block_parent failure_policy: a timeout must block the
+		// shared parent task, not strand the child.
+		{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
+	})
+
+	childID := "parent-job/delegation/api"
+	markDelegationChildTimedOut(t, store, childID)
+
+	// handleRunJobError swallows the BlockedError (the child is finalized and the
+	// DAG advanced), returning nil for a clean terminal outcome.
+	if err := worker.handleRunJobError(ctx, childID, context.DeadlineExceeded); err != nil {
+		t.Fatalf("handleRunJobError returned error: %v", err)
+	}
+
+	finalized, err := store.GetJob(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetJob(child) returned error: %v", err)
+	}
+	if finalized.State != string(workflow.JobFailed) {
+		t.Fatalf("timed-out child state = %q, want failed", finalized.State)
+	}
+	// No retry: the failure_policy (block_parent) fired on the shared task.
+	if _, err := store.GetJob(ctx, "parent-job/delegation/api/retry/1"); err == nil {
+		t.Fatal("no retry job should be enqueued when Retry=0")
+	}
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task state = %q, want blocked by block_parent failure_policy", task.State)
+	}
+}
+
+func TestHandleRunJobErrorTimedOutDelegationChildEnqueuesContinuationOnContinuePolicy(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worker := seedDelegationCoordinator(t, store, "parent-job", []workflow.Delegation{
+		// continue failure_policy: a timed-out child must resolve the delegation so
+		// the coordinator continuation is enqueued once every sibling is terminal.
+		{ID: "api", Agent: "api", Action: "review", Prompt: "build api", FailurePolicy: "continue"},
+	})
+
+	childID := "parent-job/delegation/api"
+	markDelegationChildTimedOut(t, store, childID)
+
+	if err := worker.handleRunJobError(ctx, childID, context.DeadlineExceeded); err != nil {
+		t.Fatalf("handleRunJobError returned error: %v", err)
+	}
+
+	// The coordinator continuation job is enqueued (the timeout failure resolved
+	// the only delegation under the continue policy).
+	if _, err := store.GetJob(ctx, "parent-job/continuation"); err != nil {
+		t.Fatalf("continuation job not enqueued after timed-out child under continue policy: %v", err)
+	}
+	events, err := store.ListJobEvents(ctx, "parent-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "delegation_continuation_enqueued") {
+		t.Fatalf("parent events = %+v, want delegation_continuation_enqueued", events)
+	}
+}
+
+func TestTaskWorktreeCheckoutPrefersDelegationPayloadWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worker := defaultJobWorker(store, io.Discard)
+
+	// The task table records a DIFFERENT worktree; a delegated implement child must
+	// run in its own payload.WorktreePath, never the shared task checkout.
+	taskCheckout := t.TempDir()
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", Branch: "task-1", WorktreePath: taskCheckout}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	delegationCheckout := t.TempDir()
+	payload := workflow.JobPayload{
+		Repo:         "owner/repo",
+		Branch:       "gitmoot-delegation-api",
+		TaskID:       "task-1",
+		DelegationID: "api",
+		ParentJobID:  "parent-job",
+		WorktreePath: delegationCheckout,
+	}
+
+	checkout, ok, err := worker.taskWorktreeCheckout(ctx, payload)
+	if err != nil {
+		t.Fatalf("taskWorktreeCheckout returned error: %v", err)
+	}
+	wantCheckout, err := normalizeTaskWorktreePath(delegationCheckout)
+	if err != nil {
+		t.Fatalf("normalizeTaskWorktreePath returned error: %v", err)
+	}
+	if !ok || checkout != wantCheckout {
+		t.Fatalf("taskWorktreeCheckout = (%q,%v), want (%q,true) from payload worktree, not task table", checkout, ok, wantCheckout)
+	}
+	if checkout == taskCheckout {
+		t.Fatal("checkout resolved to the shared task worktree instead of the delegation worktree")
+	}
+
+	// queuedJobTaskWorktreePath keys the scheduler off the same delegation path so
+	// siblings sharing a task id get distinct checkout keys and run in parallel.
+	path, keyed := queuedJobTaskWorktreePath(ctx, store, payload)
+	if !keyed || path != wantCheckout {
+		t.Fatalf("queuedJobTaskWorktreePath = (%q,%v), want (%q,true) from payload worktree", path, keyed, wantCheckout)
+	}
+}
+
+func TestRunQueuedJobsFansOutDelegationsAndEnqueuesContinuation(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "coord", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "api", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "ui", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:     "coordinator",
+		Agent:  "coord",
+		Action: "ask",
+		Repo:   "owner/repo",
+		Branch: "task-1",
+		TaskID: "task-1",
+		Sender: "coord",
+	})
+
+	// Acceptance criterion #1: a coordinator returning delegations fans out one
+	// child per delegation. Each subsequent reviewer approves, and the last sibling
+	// to finish triggers the auto-created continuation (acceptance criterion #4).
+	outputs := map[string]string{
+		"coordinator": `{"gitmoot_result":{"decision":"approved","summary":"split the work","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"api","agent":"api","action":"review","prompt":"review the api"},{"id":"ui","agent":"ui","action":"review","prompt":"review the ui"}]}}`,
+	}
+	defaultOutput := `{"gitmoot_result":{"decision":"approved","summary":"looks good","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+	adapter := &cliWorkerDelegationAdapter{outputs: outputs, defaultOutput: defaultOutput}
+
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(checkout string) workflow.Engine {
+		return daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
+	}
+
+	// Drain the DAG: coordinator -> two reviewer children -> continuation.
+	for range 5 {
+		if err := runQueuedJobs(ctx, worker, 2); err != nil {
+			t.Fatalf("runQueuedJobs returned error: %v", err)
+		}
+	}
+
+	// Both delegation children were fanned out and succeeded.
+	for _, id := range []string{"coordinator/delegation/api", "coordinator/delegation/ui"} {
+		child, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("delegation child %s not created: %v", id, err)
+		}
+		if child.State != string(workflow.JobSucceeded) {
+			t.Fatalf("child %s state = %q, want succeeded", id, child.State)
+		}
+		if child.ParentJobID != "coordinator" {
+			t.Fatalf("child %s parent = %q, want coordinator", id, child.ParentJobID)
+		}
+	}
+
+	// The continuation job was auto-created after the children finished.
+	cont, err := store.GetJob(ctx, "coordinator/continuation")
+	if err != nil {
+		t.Fatalf("continuation job not auto-created: %v", err)
+	}
+	if cont.ParentJobID != "coordinator" || strings.TrimSpace(cont.DelegationID) != "" {
+		t.Fatalf("continuation job = %+v, want parent=coordinator and empty delegation id", cont)
+	}
+	events, err := store.ListJobEvents(ctx, "coordinator")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "delegation_continuation_enqueued") {
+		t.Fatalf("coordinator events = %+v, want delegation_continuation_enqueued", events)
+	}
+}
+
+// cliWorkerDelegationAdapter returns a per-job-id canned gitmoot_result, so a
+// fan-out test can give the coordinator a delegating result and each child a
+// plain approval.
+type cliWorkerDelegationAdapter struct {
+	mu            sync.Mutex
+	outputs       map[string]string
+	defaultOutput string
+	delivered     []string
+}
+
+func (a *cliWorkerDelegationAdapter) Name() string { return "fake-delegation" }
+
+func (a *cliWorkerDelegationAdapter) Validate(context.Context, runtime.Agent) error { return nil }
+
+func (a *cliWorkerDelegationAdapter) Deliver(_ context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.delivered = append(a.delivered, job.ID)
+	if out, ok := a.outputs[job.ID]; ok {
+		return runtime.Result{Raw: out}, nil
+	}
+	return runtime.Result{Raw: a.defaultOutput}, nil
+}
+
+func (a *cliWorkerDelegationAdapter) Health(context.Context, runtime.Agent) error { return nil }
+
+func (a *cliWorkerDelegationAdapter) Capabilities(context.Context) ([]string, error) {
+	return nil, nil
+}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4055,3 +4055,37 @@ func daemonWorkerHasEvent(events []db.JobEvent, kind string) bool {
 	}
 	return false
 }
+
+func TestEffectiveJobTimeout(t *testing.T) {
+	managed := managedJobRuntimeConfig{OK: true, JobTimeout: 10 * time.Minute}
+
+	// A valid per-delegation timeout overrides the agent-type timeout.
+	if got := effectiveJobTimeout(workflow.JobPayload{JobTimeout: "30s"}, managed); got != 30*time.Second {
+		t.Fatalf("effectiveJobTimeout(payload override) = %v, want 30s", got)
+	}
+
+	// An empty payload timeout falls back to the managed timeout.
+	if got := effectiveJobTimeout(workflow.JobPayload{}, managed); got != 10*time.Minute {
+		t.Fatalf("effectiveJobTimeout(empty payload) = %v, want 10m", got)
+	}
+
+	// An unparseable payload timeout falls back to the managed timeout.
+	if got := effectiveJobTimeout(workflow.JobPayload{JobTimeout: "banana"}, managed); got != 10*time.Minute {
+		t.Fatalf("effectiveJobTimeout(invalid payload) = %v, want 10m", got)
+	}
+
+	// A non-positive payload timeout falls back to the managed timeout.
+	if got := effectiveJobTimeout(workflow.JobPayload{JobTimeout: "0s"}, managed); got != 10*time.Minute {
+		t.Fatalf("effectiveJobTimeout(zero payload) = %v, want 10m", got)
+	}
+
+	// With no managed config, an empty payload timeout yields zero (no deadline).
+	if got := effectiveJobTimeout(workflow.JobPayload{}, managedJobRuntimeConfig{}); got != 0 {
+		t.Fatalf("effectiveJobTimeout(unmanaged, empty) = %v, want 0", got)
+	}
+
+	// With no managed config, a valid payload timeout still applies.
+	if got := effectiveJobTimeout(workflow.JobPayload{JobTimeout: "45s"}, managedJobRuntimeConfig{}); got != 45*time.Second {
+		t.Fatalf("effectiveJobTimeout(unmanaged, payload) = %v, want 45s", got)
+	}
+}

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -149,6 +149,15 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 					detail.ResultDecision = payload.Result.Decision
 					detail.ResultSummary = payload.Result.Summary
 				}
+				// Lazily load the delegation tree: child jobs this coordinator
+				// spawned plus the continuation job, if any. Runs only for the
+				// one opened job, never on the refresh tick.
+				children, cerr := store.ListJobsByParent(context.Background(), id)
+				if cerr != nil {
+					return cerr
+				}
+				detail.Children, detail.ContinuationID, detail.ContinuationState =
+					buildDelegationTree(payload, children)
 				return nil
 			})
 			return detail, err
@@ -507,4 +516,74 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 		})
 	}
 	return out
+}
+
+// buildDelegationTree maps a coordinator's child jobs into the detail view's
+// delegation tree. Each child with a non-empty delegation id becomes a JobChild
+// (action and deps read from the parent's settled result, keyed by delegation
+// id); the lone child with an empty delegation id is the coordinator
+// continuation job. DepsSatisfied is true when every dep's sibling child has
+// reached a successful terminal state.
+func buildDelegationTree(parent workflow.JobPayload, children []db.Job) ([]tui.JobChild, string, string) {
+	// Delegation metadata (action, declared deps) lives on the parent result,
+	// always available once the coordinator settles, so we stay independent of
+	// the child payload shape.
+	type delegationMeta struct {
+		action string
+		deps   []string
+	}
+	meta := map[string]delegationMeta{}
+	if parent.Result != nil {
+		for _, d := range parent.Result.Delegations {
+			meta[d.ID] = delegationMeta{action: d.Action, deps: d.Deps}
+		}
+	}
+	// Child state by delegation id, for resolving DepsSatisfied.
+	stateByDelegation := map[string]string{}
+	for _, child := range children {
+		if id := strings.TrimSpace(child.DelegationID); id != "" {
+			stateByDelegation[id] = child.State
+		}
+	}
+
+	var (
+		out               []tui.JobChild
+		continuationID    string
+		continuationState string
+	)
+	for _, child := range children {
+		delegationID := strings.TrimSpace(child.DelegationID)
+		if delegationID == "" {
+			// The coordinator continuation job carries no delegation id.
+			continuationID = child.ID
+			continuationState = child.State
+			continue
+		}
+		m := meta[delegationID]
+		action := m.action
+		if strings.TrimSpace(action) == "" {
+			action = child.Type
+		}
+		out = append(out, tui.JobChild{
+			ID:            child.ID,
+			DelegationID:  delegationID,
+			Agent:         child.Agent,
+			Action:        action,
+			State:         child.State,
+			Deps:          m.deps,
+			DepsSatisfied: delegationDepsSatisfied(m.deps, stateByDelegation),
+		})
+	}
+	return out, continuationID, continuationState
+}
+
+// delegationDepsSatisfied reports whether every dep delegation has a sibling
+// child in a successful terminal state (the TUI's success notion).
+func delegationDepsSatisfied(deps []string, stateByDelegation map[string]string) bool {
+	for _, dep := range deps {
+		if stateByDelegation[strings.TrimSpace(dep)] != "succeeded" {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -538,16 +538,16 @@ func buildDelegationTree(parent workflow.JobPayload, children []db.Job) ([]tui.J
 			meta[d.ID] = delegationMeta{action: d.Action, deps: d.Deps}
 		}
 	}
-	// Child state by delegation id, for resolving DepsSatisfied.
-	stateByDelegation := map[string]string{}
-	for _, child := range children {
-		if id := strings.TrimSpace(child.DelegationID); id != "" {
-			stateByDelegation[id] = child.State
-		}
-	}
 
+	// Phase 2 retries create additional child rows that share a DelegationID
+	// (only the job ID differs, ".../retry/<n>"). Collapse them by delegation id
+	// keeping the latest attempt (highest RetryCount), mirroring the engine's
+	// childDelegationJobs/delegationJobRetryCount latest-attempt logic, so the
+	// DAG shows one node per delegation instead of a row per attempt.
 	var (
-		out               []tui.JobChild
+		order             []string
+		latest            = map[string]db.Job{}
+		latestRetry       = map[string]int{}
 		continuationID    string
 		continuationState string
 	)
@@ -559,6 +559,29 @@ func buildDelegationTree(parent workflow.JobPayload, children []db.Job) ([]tui.J
 			continuationState = child.State
 			continue
 		}
+		attempt := childRetryCount(child)
+		if _, ok := latest[delegationID]; ok {
+			if attempt < latestRetry[delegationID] {
+				continue
+			}
+		} else {
+			order = append(order, delegationID)
+		}
+		latest[delegationID] = child
+		latestRetry[delegationID] = attempt
+	}
+
+	// Child state by delegation id, resolved from the latest attempt only (not
+	// last-write-wins over ListJobsByParent's "delegation_id, id" ordering), so
+	// DepsSatisfied reflects the current attempt's outcome.
+	stateByDelegation := make(map[string]string, len(latest))
+	for id, child := range latest {
+		stateByDelegation[id] = child.State
+	}
+
+	out := make([]tui.JobChild, 0, len(order))
+	for _, delegationID := range order {
+		child := latest[delegationID]
 		m := meta[delegationID]
 		action := m.action
 		if strings.TrimSpace(action) == "" {
@@ -575,6 +598,17 @@ func buildDelegationTree(parent workflow.JobPayload, children []db.Job) ([]tui.J
 		})
 	}
 	return out, continuationID, continuationState
+}
+
+// childRetryCount reads a delegation child's RetryCount from its stored payload,
+// returning 0 when the payload is missing or cannot be parsed. Mirrors the
+// engine's delegationJobRetryCount so the dashboard dedups attempts identically.
+func childRetryCount(child db.Job) int {
+	payload, err := workflow.ParseJobPayload(child.Payload)
+	if err != nil {
+		return 0
+	}
+	return payload.RetryCount
 }
 
 // delegationDepsSatisfied reports whether every dep delegation has a sibling

--- a/internal/cli/dashboard_tui_test.go
+++ b/internal/cli/dashboard_tui_test.go
@@ -8,7 +8,87 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
+
+func TestBuildDelegationTree(t *testing.T) {
+	parent := workflow.JobPayload{
+		Result: &workflow.AgentResult{
+			Delegations: []workflow.Delegation{
+				{ID: "api", Agent: "coder", Action: "implement api"},
+				{ID: "ui", Agent: "coder", Action: "implement ui", Deps: []string{"api"}},
+			},
+		},
+	}
+	children := []db.Job{
+		{ID: "j-api", Agent: "coder", Type: "implement", State: "succeeded", ParentJobID: "p", DelegationID: "api"},
+		{ID: "j-ui", Agent: "coder", Type: "implement", State: "running", ParentJobID: "p", DelegationID: "ui"},
+		{ID: "j-cont", Agent: "planner", Type: "ask", State: "queued", ParentJobID: "p"},
+	}
+
+	got, contID, contState := buildDelegationTree(parent, children)
+	if contID != "j-cont" || contState != "queued" {
+		t.Fatalf("continuation = (%q,%q), want (j-cont,queued)", contID, contState)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d delegation children, want 2: %+v", len(got), got)
+	}
+	byDelegation := map[string]struct {
+		action    string
+		satisfied bool
+	}{}
+	for _, c := range got {
+		byDelegation[c.DelegationID] = struct {
+			action    string
+			satisfied bool
+		}{c.Action, c.DepsSatisfied}
+	}
+	if api := byDelegation["api"]; api.action != "implement api" {
+		t.Fatalf("api action = %q, want implement api", api.action)
+	}
+	// ui's only dep (api) succeeded, so its deps are satisfied.
+	if ui := byDelegation["ui"]; ui.action != "implement ui" || !ui.satisfied {
+		t.Fatalf("ui = %+v, want action=implement ui satisfied=true", ui)
+	}
+}
+
+func TestBuildDelegationTreeActionFallsBackToType(t *testing.T) {
+	// No parent result: action falls back to the child job type, deps unsatisfied
+	// when a dep's sibling has not succeeded.
+	children := []db.Job{
+		{ID: "j-api", Agent: "coder", Type: "implement", State: "running", ParentJobID: "p", DelegationID: "api"},
+		{ID: "j-ui", Agent: "coder", Type: "review", State: "running", ParentJobID: "p", DelegationID: "ui"},
+	}
+	parent := workflow.JobPayload{
+		Result: &workflow.AgentResult{
+			Delegations: []workflow.Delegation{{ID: "ui", Agent: "coder", Action: "", Deps: []string{"api"}}},
+		},
+	}
+	got, contID, _ := buildDelegationTree(parent, children)
+	if contID != "" {
+		t.Fatalf("no continuation child should leave continuation id empty, got %q", contID)
+	}
+	var apiAction, uiAction string
+	var uiSatisfied bool
+	for _, c := range got {
+		switch c.DelegationID {
+		case "api":
+			apiAction = c.Action
+		case "ui":
+			uiAction = c.Action
+			uiSatisfied = c.DepsSatisfied
+		}
+	}
+	if apiAction != "implement" {
+		t.Fatalf("api action fallback = %q, want job type implement", apiAction)
+	}
+	if uiAction != "review" {
+		t.Fatalf("ui action fallback = %q, want job type review", uiAction)
+	}
+	if uiSatisfied {
+		t.Fatalf("ui deps should be pending while api is still running")
+	}
+}
 
 func TestShouldLaunchTUI(t *testing.T) {
 	cases := []struct {

--- a/internal/cli/dashboard_tui_test.go
+++ b/internal/cli/dashboard_tui_test.go
@@ -3,9 +3,11 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/jerryfane/gitmoot/internal/cli/tui"
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/workflow"
@@ -87,6 +89,106 @@ func TestBuildDelegationTreeActionFallsBackToType(t *testing.T) {
 	}
 	if uiSatisfied {
 		t.Fatalf("ui deps should be pending while api is still running")
+	}
+}
+
+func TestBuildDelegationTreeCollapsesRetriedDelegation(t *testing.T) {
+	// A Phase 2 retry creates an additional child row sharing the DelegationID
+	// (only the job ID and RetryCount differ). The tree must show ONE node per
+	// delegation -- the latest attempt -- not a duplicate row per attempt.
+	parent := workflow.JobPayload{
+		Result: &workflow.AgentResult{
+			Delegations: []workflow.Delegation{
+				{ID: "api", Agent: "coder", Action: "implement api"},
+				{ID: "ui", Agent: "coder", Action: "implement ui", Deps: []string{"api"}},
+			},
+		},
+	}
+	mustPayload := func(p workflow.JobPayload) string {
+		t.Helper()
+		raw, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		return string(raw)
+	}
+	// api's first attempt failed; the retry (RetryCount=1) succeeded.
+	apiAttempt0 := workflow.JobPayload{ParentJobID: "p", DelegationID: "api", RetryCount: 0}
+	apiAttempt1 := workflow.JobPayload{ParentJobID: "p", DelegationID: "api", RetryCount: 1}
+	children := []db.Job{
+		{ID: "p/delegation/api", Agent: "coder", Type: "implement", State: "failed", ParentJobID: "p", DelegationID: "api", Payload: mustPayload(apiAttempt0)},
+		{ID: "p/delegation/api/retry/1", Agent: "coder", Type: "implement", State: "succeeded", ParentJobID: "p", DelegationID: "api", Payload: mustPayload(apiAttempt1)},
+		{ID: "p/delegation/ui", Agent: "coder", Type: "implement", State: "running", ParentJobID: "p", DelegationID: "ui", Payload: mustPayload(workflow.JobPayload{ParentJobID: "p", DelegationID: "ui"})},
+	}
+
+	got, _, _ := buildDelegationTree(parent, children)
+
+	byDelegation := map[string]tui.JobChild{}
+	for _, c := range got {
+		if _, dup := byDelegation[c.DelegationID]; dup {
+			t.Fatalf("delegation %q rendered as a duplicate row: %+v", c.DelegationID, got)
+		}
+		byDelegation[c.DelegationID] = c
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d delegation rows, want 2 (api collapsed, ui): %+v", len(got), got)
+	}
+	api := byDelegation["api"]
+	// Latest attempt (the retry) wins, so the node shows succeeded, not the
+	// stale failed first attempt.
+	if api.State != "succeeded" || api.ID != "p/delegation/api/retry/1" {
+		t.Fatalf("api node = (id=%q state=%q), want latest retry (p/delegation/api/retry/1, succeeded)", api.ID, api.State)
+	}
+	// ui depends on api; api's LATEST attempt succeeded, so deps are satisfied
+	// (computed from the latest attempt, not the stale failed first attempt).
+	ui := byDelegation["ui"]
+	if !ui.DepsSatisfied {
+		t.Fatalf("ui deps should be satisfied: api's latest attempt succeeded, got %+v", ui)
+	}
+}
+
+func TestBuildDelegationTreeRetryFailureLeavesDepsPending(t *testing.T) {
+	// The inverse: api's first attempt "succeeded" but a later retry attempt is
+	// still running. DepsSatisfied must reflect the LATEST attempt (running ->
+	// pending), not the stale first attempt, regardless of row ordering.
+	parent := workflow.JobPayload{
+		Result: &workflow.AgentResult{
+			Delegations: []workflow.Delegation{
+				{ID: "api", Agent: "coder", Action: "implement api"},
+				{ID: "ui", Agent: "coder", Action: "implement ui", Deps: []string{"api"}},
+			},
+		},
+	}
+	mustPayload := func(p workflow.JobPayload) string {
+		t.Helper()
+		raw, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		return string(raw)
+	}
+	children := []db.Job{
+		{ID: "p/delegation/api", Agent: "coder", Type: "implement", State: "succeeded", ParentJobID: "p", DelegationID: "api", Payload: mustPayload(workflow.JobPayload{ParentJobID: "p", DelegationID: "api", RetryCount: 0})},
+		{ID: "p/delegation/api/retry/1", Agent: "coder", Type: "implement", State: "running", ParentJobID: "p", DelegationID: "api", Payload: mustPayload(workflow.JobPayload{ParentJobID: "p", DelegationID: "api", RetryCount: 1})},
+		{ID: "p/delegation/ui", Agent: "coder", Type: "implement", State: "queued", ParentJobID: "p", DelegationID: "ui", Payload: mustPayload(workflow.JobPayload{ParentJobID: "p", DelegationID: "ui"})},
+	}
+
+	got, _, _ := buildDelegationTree(parent, children)
+	var ui tui.JobChild
+	apiCount := 0
+	for _, c := range got {
+		switch c.DelegationID {
+		case "api":
+			apiCount++
+		case "ui":
+			ui = c
+		}
+	}
+	if apiCount != 1 {
+		t.Fatalf("api should collapse to one node, got %d", apiCount)
+	}
+	if ui.DepsSatisfied {
+		t.Fatalf("ui deps should be PENDING: api's latest attempt is still running, got %+v", ui)
 	}
 }
 

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -162,6 +162,25 @@ type JobDetail struct {
 	Request        string // the human instructions that drove the job
 	ResultDecision string // gitmoot_result.decision, when the job has settled
 	ResultSummary  string // gitmoot_result.summary
+	// Children are the delegation child jobs this job spawned (empty for a
+	// non-coordinator job). They render as a "delegations" tree in the detail.
+	Children []JobChild
+	// ContinuationID/ContinuationState describe the coordinator continuation job
+	// enqueued once every delegation settled; ContinuationID is empty when none.
+	ContinuationID    string
+	ContinuationState string
+}
+
+// JobChild is one delegated child job in a coordinator's delegation tree, shown
+// in the job-detail "delegations" section.
+type JobChild struct {
+	ID            string
+	DelegationID  string
+	Agent         string
+	Action        string
+	State         string
+	Deps          []string
+	DepsSatisfied bool
 }
 
 // BugReportPreview is a redacted issue draft shown before creating a bug report.

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -244,6 +244,19 @@ func jobDecisionColor(decision string) string {
 	}
 }
 
+// depsLabel renders a delegation child's deps for the delegation tree: "-" when
+// it has none, else the comma-joined dep ids with a satisfied/pending suffix.
+func depsLabel(c JobChild) string {
+	if len(c.Deps) == 0 {
+		return "-"
+	}
+	suffix := " (pending)"
+	if c.DepsSatisfied {
+		suffix = " (satisfied)"
+	}
+	return strings.Join(c.Deps, ",") + suffix
+}
+
 // jobsContentInteractive renders the Jobs page as a selectable list. Job
 // overlays (detail/confirm) are dispatched once in content(), not here.
 func (m Model) jobsContentInteractive() string {
@@ -368,6 +381,38 @@ func (m Model) jobDetailView() string {
 		}
 		if d.ResultSummary != "" {
 			b.WriteString(clampLines(d.ResultSummary, 8) + "\n")
+		}
+		b.WriteByte('\n')
+	}
+
+	// Delegation tree (coordinator jobs): one row per delegated child plus the
+	// continuation job, if any.
+	if len(d.Children) > 0 {
+		b.WriteString(headerStyle.Render("delegations"))
+		b.WriteByte('\n')
+		rows := [][]string{{"DELEGATION", "AGENT", "ACTION", "DEPS", "STATE"}}
+		const maxChildren = 20
+		children := d.Children
+		omitted := 0
+		if len(children) > maxChildren {
+			omitted = len(children) - maxChildren
+			children = children[:maxChildren]
+		}
+		for _, c := range children {
+			rows = append(rows, []string{
+				dash(c.DelegationID),
+				dash(c.Agent),
+				truncate(c.Action, 30),
+				depsLabel(c),
+				jobStateColor(c.State),
+			})
+		}
+		b.WriteString(renderRows(rows))
+		if omitted > 0 {
+			b.WriteString(mutedStyle.Render(strconv.Itoa(omitted)+" more delegations omitted") + "\n")
+		}
+		if d.ContinuationID != "" {
+			b.WriteString("continuation  " + d.ContinuationID + "  " + jobStateColor(d.ContinuationState) + "\n")
 		}
 		b.WriteByte('\n')
 	}

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -665,6 +665,92 @@ func TestJobDetailOmitsBlocksWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestJobDetailShowsDelegationTree(t *testing.T) {
+	deps := Deps{
+		JobEvents: func(id string) ([]JobEventView, error) { return nil, nil },
+		JobDetail: func(id string) (JobDetail, error) {
+			return JobDetail{
+				Request: "Coordinate the auth refactor.",
+				Children: []JobChild{
+					{ID: "j-api", DelegationID: "api", Agent: "coder", Action: "implement api", State: "succeeded"},
+					{ID: "j-ui", DelegationID: "ui", Agent: "coder", Action: "implement ui", State: "running", Deps: []string{"api"}, DepsSatisfied: true},
+				},
+				ContinuationID:    "job-cont",
+				ContinuationState: "queued",
+			}, nil
+		},
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	m = drainBatch(t, m, cmd)
+	view := m.View()
+	for _, want := range []string{
+		"delegations", "api", "ui", "coder",
+		"implement api", "implement ui",
+		"succeeded", "running",
+		"(satisfied)",
+		"continuation", "job-cont",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("delegation tree missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestJobDetailOmitsDelegationsWhenNone(t *testing.T) {
+	deps := Deps{
+		JobEvents: func(id string) ([]JobEventView, error) { return nil, nil },
+		JobDetail: func(id string) (JobDetail, error) { return JobDetail{Request: "no children here"}, nil },
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	m = drainBatch(t, m, cmd)
+	if view := m.View(); strings.Contains(view, "delegations") || strings.Contains(view, "continuation") {
+		t.Fatalf("a job with no children should omit the delegations section:\n%s", view)
+	}
+}
+
+func TestJobDetailDelegationDepsPending(t *testing.T) {
+	deps := Deps{
+		JobEvents: func(id string) ([]JobEventView, error) { return nil, nil },
+		JobDetail: func(id string) (JobDetail, error) {
+			return JobDetail{
+				Children: []JobChild{
+					{ID: "j-ui", DelegationID: "ui", Agent: "coder", Action: "ship ui", State: "failed", Deps: []string{"api"}, DepsSatisfied: false},
+				},
+			}, nil
+		},
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	m = drainBatch(t, m, cmd)
+	view := m.View()
+	// State renders via jobStateColor; under termenv.Ascii the word is plain.
+	for _, want := range []string{"delegations", "failed", "(pending)"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("delegation tree missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "continuation") {
+		t.Fatalf("no continuation id should omit the continuation line:\n%s", view)
+	}
+}
+
+func TestDepsLabel(t *testing.T) {
+	if got := depsLabel(JobChild{}); got != "-" {
+		t.Fatalf("depsLabel(no deps) = %q, want -", got)
+	}
+	if got := depsLabel(JobChild{Deps: []string{"api", "db"}, DepsSatisfied: true}); got != "api,db (satisfied)" {
+		t.Fatalf("depsLabel(satisfied) = %q", got)
+	}
+	if got := depsLabel(JobChild{Deps: []string{"api"}, DepsSatisfied: false}); got != "api (pending)" {
+		t.Fatalf("depsLabel(pending) = %q", got)
+	}
+}
+
 func TestJobDetailClampLines(t *testing.T) {
 	got := clampLines("a\nb\nc\nd\ne", 3)
 	if !strings.Contains(got, "a\nb\nc") || !strings.Contains(got, "2 more lines") {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1941,6 +1941,29 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 	return jobs, rows.Err()
 }
 
+// ListJobsByParent returns the direct children of parentJobID (delegation
+// children and the coordinator continuation job), ordered by delegation_id then
+// id for a stable tree. It selects updated_at like ListJobs so callers can show
+// child age; the idx_jobs_parent_job_id index backs the filter.
+func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, updated_at
+		FROM jobs WHERE parent_job_id = ? ORDER BY delegation_id, id`, parentJobID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobs []Job
+	for rows.Next() {
+		var job Job
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.UpdatedAt); err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
 func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by
 		FROM jobs WHERE state = ? ORDER BY created_at, rowid`, "queued")

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -2491,3 +2491,56 @@ func TestMigrationCopiesPresetsToAgentTemplates(t *testing.T) {
 		t.Fatal("legacy presets table still exists")
 	}
 }
+
+func TestListJobsByParent(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.CreateJob(ctx, Job{ID: "parent", Agent: "planner", Type: "ask", State: "running"}); err != nil {
+		t.Fatalf("CreateJob parent returned error: %v", err)
+	}
+	// Two delegation children (inserted out of delegation_id order) plus the
+	// continuation child (empty delegation id) and one unrelated job.
+	if err := store.CreateJob(ctx, Job{ID: "child-ui", Agent: "coder", Type: "implement", State: "running", ParentJobID: "parent", DelegationID: "ui"}); err != nil {
+		t.Fatalf("CreateJob child-ui returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, Job{ID: "child-api", Agent: "coder", Type: "implement", State: "succeeded", ParentJobID: "parent", DelegationID: "api"}); err != nil {
+		t.Fatalf("CreateJob child-api returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, Job{ID: "child-cont", Agent: "planner", Type: "ask", State: "queued", ParentJobID: "parent"}); err != nil {
+		t.Fatalf("CreateJob child-cont returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, Job{ID: "unrelated", Agent: "planner", Type: "ask", State: "queued"}); err != nil {
+		t.Fatalf("CreateJob unrelated returned error: %v", err)
+	}
+
+	children, err := store.ListJobsByParent(ctx, "parent")
+	if err != nil {
+		t.Fatalf("ListJobsByParent returned error: %v", err)
+	}
+	// ORDER BY delegation_id, id: continuation (empty id) first, then api, ui.
+	wantIDs := []string{"child-cont", "child-api", "child-ui"}
+	if len(children) != len(wantIDs) {
+		t.Fatalf("ListJobsByParent returned %d children, want %d: %+v", len(children), len(wantIDs), children)
+	}
+	for i, want := range wantIDs {
+		if children[i].ID != want {
+			t.Fatalf("child[%d].ID = %q, want %q (order %+v)", i, children[i].ID, want, children)
+		}
+	}
+	if children[1].UpdatedAt == "" {
+		t.Fatalf("ListJobsByParent should populate UpdatedAt for child age: %+v", children[1])
+	}
+
+	empty, err := store.ListJobsByParent(ctx, "no-such-parent")
+	if err != nil {
+		t.Fatalf("ListJobsByParent unknown parent returned error: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("ListJobsByParent for unknown parent = %+v, want empty", empty)
+	}
+}

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -2,6 +2,7 @@ package prompts
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -14,6 +15,7 @@ type JobPrompt struct {
 	Action                 string
 	Instructions           string
 	Constraints            []string
+	DelegationArtifactDir  string
 	TemplateID             string
 	TemplateResolvedCommit string
 	TemplateInstructions   string
@@ -52,6 +54,18 @@ func RenderJob(prompt JobPrompt) string {
 				builder.WriteByte('\n')
 			}
 		}
+	}
+
+	if dir := strings.TrimSpace(prompt.DelegationArtifactDir); dir != "" {
+		builder.WriteString("\nDelegation artifacts:\n")
+		builder.WriteString("This job was delegated by a coordinator that shared context on disk.\n")
+		builder.WriteString("Read these files for the shared brief and the wider delegation batch before acting:\n")
+		builder.WriteString("- ")
+		builder.WriteString(filepath.Join(dir, "brief.md"))
+		builder.WriteByte('\n')
+		builder.WriteString("- ")
+		builder.WriteString(filepath.Join(dir, "context-manifest.json"))
+		builder.WriteByte('\n')
 	}
 
 	builder.WriteString("\nRequired output:\n")

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -42,6 +42,38 @@ func TestRenderJobIncludesContextAndContract(t *testing.T) {
 	}
 }
 
+func TestRenderJobIncludesDelegationArtifacts(t *testing.T) {
+	prompt := RenderJob(JobPrompt{
+		Repo:                  "jerryfane/gitmoot",
+		Branch:                "task-005",
+		Action:                "implement",
+		Instructions:          "build the api",
+		DelegationArtifactDir: "/home/user/.gitmoot/delegations/parent-job",
+	})
+
+	for _, want := range []string{
+		"Delegation artifacts:",
+		"/home/user/.gitmoot/delegations/parent-job/brief.md",
+		"/home/user/.gitmoot/delegations/parent-job/context-manifest.json",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestRenderJobOmitsDelegationArtifactsWhenUnset(t *testing.T) {
+	prompt := RenderJob(JobPrompt{
+		Repo:         "jerryfane/gitmoot",
+		Branch:       "task-005",
+		Action:       "implement",
+		Instructions: "build the api",
+	})
+	if strings.Contains(prompt, "Delegation artifacts:") {
+		t.Fatalf("prompt unexpectedly includes delegation artifacts section:\n%s", prompt)
+	}
+}
+
 func TestRenderRepairPromptIncludesErrorAndRawOutput(t *testing.T) {
 	prompt := RenderRepairPrompt("not json", errors.New("missing gitmoot_result"))
 

--- a/internal/workflow/artifacts.go
+++ b/internal/workflow/artifacts.go
@@ -1,0 +1,120 @@
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// delegationManifest is the on-disk context-manifest.json written for a parent
+// job that produced delegations carrying artifacts. It gives each child a
+// machine-readable view of its sibling delegations.
+type delegationManifest struct {
+	ParentJobID string                    `json:"parent_job_id"`
+	Delegations []delegationManifestEntry `json:"delegations"`
+}
+
+// delegationManifestEntry is the reduced view of a single delegation surfaced in
+// context-manifest.json. It intentionally exposes only the coordination fields
+// children need to reason about the wider batch.
+type delegationManifestEntry struct {
+	ID       string   `json:"id"`
+	Agent    string   `json:"agent"`
+	Action   string   `json:"action"`
+	Worktree string   `json:"worktree,omitempty"`
+	Deps     []string `json:"deps,omitempty"`
+}
+
+// writeDelegationArtifacts persists the coordinator brief and a context manifest
+// for a parent job when at least one of its delegations requests artifacts. It
+// mirrors writeAgentTemplateDraft's MkdirAll(0o755)+WriteFile(0o644) pattern and
+// returns the directory the artifacts were written to, or "" when nothing was
+// written (empty root or no delegation requested artifacts) so callers can skip
+// wiring the directory into child prompts. Artifacts live under
+// <root>/delegations/<parent-job-id>/, with the parent job id sanitized into a
+// single safe path segment because job ids may contain slashes.
+func writeDelegationArtifacts(root string, parentJobID string, result *AgentResult) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		return "", nil
+	}
+	if result == nil || !delegationsRequestArtifacts(result.Delegations) {
+		return "", nil
+	}
+	segment, err := safeDelegationPathSegment(parentJobID, "parent job id")
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(root, "delegations", segment)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create delegation artifact directory: %w", err)
+	}
+	briefPath := filepath.Join(dir, "brief.md")
+	if err := os.WriteFile(briefPath, []byte(result.ArtifactBody), 0o644); err != nil {
+		return "", fmt.Errorf("write delegation brief %s: %w", briefPath, err)
+	}
+	manifest := delegationManifest{
+		ParentJobID: parentJobID,
+		Delegations: make([]delegationManifestEntry, 0, len(result.Delegations)),
+	}
+	for _, d := range result.Delegations {
+		manifest.Delegations = append(manifest.Delegations, delegationManifestEntry{
+			ID:       d.ID,
+			Agent:    d.Agent,
+			Action:   d.Action,
+			Worktree: d.Worktree,
+			Deps:     d.Deps,
+		})
+	}
+	encoded, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode delegation manifest: %w", err)
+	}
+	manifestPath := filepath.Join(dir, "context-manifest.json")
+	if err := os.WriteFile(manifestPath, encoded, 0o644); err != nil {
+		return "", fmt.Errorf("write delegation manifest %s: %w", manifestPath, err)
+	}
+	return dir, nil
+}
+
+func delegationsRequestArtifacts(delegations []Delegation) bool {
+	for _, d := range delegations {
+		if len(d.Artifacts) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// safeDelegationPathSegment reduces a value (typically a parent job id, which may
+// contain slashes such as "parent-job/delegation/del-1") to a single path
+// segment that cannot escape its parent directory. Unsafe characters are
+// replaced with '-' rather than rejected so artifacts can always be written;
+// the only failure is an empty or wholly unsafe value.
+func safeDelegationPathSegment(value string, label string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s is required", label)
+	}
+	var builder strings.Builder
+	for _, char := range value {
+		switch {
+		case char >= 'a' && char <= 'z':
+			builder.WriteRune(char)
+		case char >= 'A' && char <= 'Z':
+			builder.WriteRune(char)
+		case char >= '0' && char <= '9':
+			builder.WriteRune(char)
+		case char == '-' || char == '_':
+			builder.WriteRune(char)
+		default:
+			builder.WriteByte('-')
+		}
+	}
+	segment := strings.Trim(builder.String(), "-")
+	if segment == "" || segment == "." || segment == ".." {
+		return "", fmt.Errorf("%s %q has no safe path representation", label, value)
+	}
+	return segment, nil
+}

--- a/internal/workflow/artifacts.go
+++ b/internal/workflow/artifacts.go
@@ -78,6 +78,25 @@ func writeDelegationArtifacts(root string, parentJobID string, result *AgentResu
 	return dir, nil
 }
 
+// delegationArtifactDir returns the directory writeDelegationArtifacts would
+// have written for this parent, without touching the filesystem. It lets the
+// deferred-enqueue path (advanceDelegations) point late-running children at the
+// same brief.md/context-manifest.json the ready children received, returning ""
+// when no artifacts were requested or the engine has no artifact root.
+func delegationArtifactDir(root string, parentJobID string, result *AgentResult) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		return "", nil
+	}
+	if result == nil || !delegationsRequestArtifacts(result.Delegations) {
+		return "", nil
+	}
+	segment, err := safeDelegationPathSegment(parentJobID, "parent job id")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "delegations", segment), nil
+}
+
 func delegationsRequestArtifacts(delegations []Delegation) bool {
 	for _, d := range delegations {
 		if len(d.Artifacts) > 0 {

--- a/internal/workflow/artifacts_test.go
+++ b/internal/workflow/artifacts_test.go
@@ -1,0 +1,178 @@
+package workflow
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteDelegationArtifactsWritesBriefAndManifest(t *testing.T) {
+	root := t.TempDir()
+	result := &AgentResult{
+		Decision:     "approved",
+		Summary:      "coordinated",
+		ArtifactBody: "# Brief\n\nShared context for the batch.\n",
+		Delegations: []Delegation{
+			{ID: "api", Agent: "builder-a", Action: "implement", Worktree: "api-work", Artifacts: []string{"brief.md"}},
+			{ID: "ui", Agent: "builder-b", Action: "implement"},
+		},
+	}
+
+	dir, err := writeDelegationArtifacts(root, "parent-job", result)
+	if err != nil {
+		t.Fatalf("writeDelegationArtifacts returned error: %v", err)
+	}
+	wantDir := filepath.Join(root, "delegations", "parent-job")
+	if dir != wantDir {
+		t.Fatalf("dir = %q, want %q", dir, wantDir)
+	}
+
+	brief, err := os.ReadFile(filepath.Join(dir, "brief.md"))
+	if err != nil {
+		t.Fatalf("read brief.md: %v", err)
+	}
+	if string(brief) != result.ArtifactBody {
+		t.Fatalf("brief.md = %q, want %q", string(brief), result.ArtifactBody)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "context-manifest.json"))
+	if err != nil {
+		t.Fatalf("read context-manifest.json: %v", err)
+	}
+	var manifest delegationManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	if manifest.ParentJobID != "parent-job" {
+		t.Fatalf("manifest parent_job_id = %q, want %q", manifest.ParentJobID, "parent-job")
+	}
+	if len(manifest.Delegations) != 2 {
+		t.Fatalf("manifest delegations = %d, want 2", len(manifest.Delegations))
+	}
+	first := manifest.Delegations[0]
+	if first.ID != "api" || first.Agent != "builder-a" || first.Action != "implement" || first.Worktree != "api-work" || len(first.Deps) != 0 {
+		t.Fatalf("manifest entry[0] = %+v", first)
+	}
+	second := manifest.Delegations[1]
+	if second.ID != "ui" || second.Agent != "builder-b" || second.Action != "implement" || second.Worktree != "" || len(second.Deps) != 0 {
+		t.Fatalf("manifest entry[1] = %+v", second)
+	}
+}
+
+func TestWriteDelegationArtifactsManifestOnlyHasReducedFields(t *testing.T) {
+	root := t.TempDir()
+	result := &AgentResult{
+		ArtifactBody: "brief",
+		Delegations: []Delegation{
+			{ID: "api", Agent: "builder", Action: "implement", Worktree: "w", Deps: []string{"x"},
+				Prompt: "secret prompt", Timeout: "5m", Retry: 3, FailurePolicy: "escalate", Artifacts: []string{"brief.md"}},
+		},
+	}
+
+	dir, err := writeDelegationArtifacts(root, "parent-job", result)
+	if err != nil {
+		t.Fatalf("writeDelegationArtifacts returned error: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "context-manifest.json"))
+	if err != nil {
+		t.Fatalf("read context-manifest.json: %v", err)
+	}
+	// The manifest must expose only the coordination fields, never the prompt
+	// or lifecycle controls.
+	var generic struct {
+		Delegations []map[string]json.RawMessage `json:"delegations"`
+	}
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	if len(generic.Delegations) != 1 {
+		t.Fatalf("manifest delegations = %d, want 1", len(generic.Delegations))
+	}
+	entry := generic.Delegations[0]
+	for _, want := range []string{"id", "agent", "action", "worktree", "deps"} {
+		if _, ok := entry[want]; !ok {
+			t.Fatalf("manifest entry missing %q: %v", want, entry)
+		}
+	}
+	for got := range entry {
+		switch got {
+		case "id", "agent", "action", "worktree", "deps":
+		default:
+			t.Fatalf("manifest entry leaked field %q: %v", got, entry)
+		}
+	}
+}
+
+func TestWriteDelegationArtifactsEmptyRootWritesNothing(t *testing.T) {
+	dir, err := writeDelegationArtifacts("", "parent-job", &AgentResult{
+		ArtifactBody: "brief",
+		Delegations:  []Delegation{{ID: "api", Agent: "a", Action: "implement", Artifacts: []string{"brief.md"}}},
+	})
+	if err != nil {
+		t.Fatalf("writeDelegationArtifacts returned error: %v", err)
+	}
+	if dir != "" {
+		t.Fatalf("dir = %q, want empty", dir)
+	}
+}
+
+func TestWriteDelegationArtifactsNoArtifactsWritesNothing(t *testing.T) {
+	root := t.TempDir()
+	dir, err := writeDelegationArtifacts(root, "parent-job", &AgentResult{
+		ArtifactBody: "brief",
+		Delegations: []Delegation{
+			{ID: "api", Agent: "a", Action: "implement"},
+			{ID: "ui", Agent: "b", Action: "review"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("writeDelegationArtifacts returned error: %v", err)
+	}
+	if dir != "" {
+		t.Fatalf("dir = %q, want empty", dir)
+	}
+	if entries, err := os.ReadDir(root); err != nil {
+		t.Fatalf("read root: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("root has %d entries, want none", len(entries))
+	}
+}
+
+func TestWriteDelegationArtifactsSanitizesUnsafeParentID(t *testing.T) {
+	root := t.TempDir()
+	result := &AgentResult{
+		ArtifactBody: "brief",
+		Delegations:  []Delegation{{ID: "api", Agent: "a", Action: "implement", Artifacts: []string{"brief.md"}}},
+	}
+
+	dir, err := writeDelegationArtifacts(root, "parent-job/delegation/del-1", result)
+	if err != nil {
+		t.Fatalf("writeDelegationArtifacts returned error: %v", err)
+	}
+
+	delegationsRoot := filepath.Join(root, "delegations")
+	rel, err := filepath.Rel(delegationsRoot, dir)
+	if err != nil {
+		t.Fatalf("filepath.Rel: %v", err)
+	}
+	if strings.Contains(rel, string(filepath.Separator)) || rel == ".." || strings.HasPrefix(rel, "..") {
+		t.Fatalf("sanitized dir %q escapes delegations root %q (rel=%q)", dir, delegationsRoot, rel)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "brief.md")); err != nil {
+		t.Fatalf("brief.md not written into sanitized dir: %v", err)
+	}
+	// The manifest must still carry the original (unsanitized) parent job id.
+	raw, err := os.ReadFile(filepath.Join(dir, "context-manifest.json"))
+	if err != nil {
+		t.Fatalf("read context-manifest.json: %v", err)
+	}
+	var manifest delegationManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	if manifest.ParentJobID != "parent-job/delegation/del-1" {
+		t.Fatalf("manifest parent_job_id = %q, want original id", manifest.ParentJobID)
+	}
+}

--- a/internal/workflow/branch.go
+++ b/internal/workflow/branch.go
@@ -110,15 +110,24 @@ func (e Engine) StartTaskBranch(ctx context.Context, request TaskBranchRequest, 
 	return task, nil
 }
 
-// delegationBranchName derives the git branch for a delegated implement job.
-// It prefers a slugged form of the delegation's requested worktree label and
-// otherwise falls back to a deterministic gitmoot-delegation-<parent-short>-<id>
-// name so sibling delegations from the same parent never collide.
-func delegationBranchName(d Delegation, parentJobID string, delegationID string) string {
+// delegationBranchName derives the git branch for a delegated implement job. The
+// branch is always namespaced with the parent-short and delegation id
+// (gitmoot-delegation-<parent-short>-<id>) so sibling delegations from the same
+// parent never collide, even when they share an identical or empty worktree
+// hint. A slugged form of the delegation's requested worktree label, when
+// present, is appended only as a human-readable suffix and never replaces the
+// namespacing. retryAttempt > 0 adds a -retry-<n> suffix so a retry of the same
+// delegation gets a fresh, isolated branch instead of reusing the failed
+// attempt's branch.
+func delegationBranchName(d Delegation, parentJobID string, delegationID string, retryAttempt int) string {
+	branch := fmt.Sprintf("gitmoot-delegation-%s-%s", parentShort(parentJobID), delegationID)
 	if hint := slug(d.Worktree); hint != "" {
-		return hint
+		branch += "-" + hint
 	}
-	return fmt.Sprintf("gitmoot-delegation-%s-%s", parentShort(parentJobID), delegationID)
+	if retryAttempt > 0 {
+		branch += fmt.Sprintf("-retry-%d", retryAttempt)
+	}
+	return branch
 }
 
 // slug normalizes an arbitrary label into a lowercase, dash-separated token

--- a/internal/workflow/branch.go
+++ b/internal/workflow/branch.go
@@ -2,10 +2,14 @@ package workflow
 
 import (
 	"context"
+	"crypto/sha1"
 	"database/sql"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 )
@@ -104,6 +108,44 @@ func (e Engine) StartTaskBranch(ctx context.Context, request TaskBranchRequest, 
 		return db.Task{}, err
 	}
 	return task, nil
+}
+
+// delegationBranchName derives the git branch for a delegated implement job.
+// It prefers a slugged form of the delegation's requested worktree label and
+// otherwise falls back to a deterministic gitmoot-delegation-<parent-short>-<id>
+// name so sibling delegations from the same parent never collide.
+func delegationBranchName(d Delegation, parentJobID string, delegationID string) string {
+	if hint := slug(d.Worktree); hint != "" {
+		return hint
+	}
+	return fmt.Sprintf("gitmoot-delegation-%s-%s", parentShort(parentJobID), delegationID)
+}
+
+// slug normalizes an arbitrary label into a lowercase, dash-separated token
+// safe for use in branch names. Mirrors internal/cli/workflow.go::slug.
+func slug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	lastDash := false
+	for _, char := range value {
+		if unicode.IsLetter(char) || unicode.IsDigit(char) {
+			builder.WriteRune(char)
+			lastDash = false
+			continue
+		}
+		if !lastDash && builder.Len() > 0 {
+			builder.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+// parentShort returns the first eight hex characters of the SHA-1 of the parent
+// job id, giving a stable short identifier for delegation branch names.
+func parentShort(parentJobID string) string {
+	sum := sha1.Sum([]byte(parentJobID))
+	return hex.EncodeToString(sum[:])[:8]
 }
 
 func validateTaskBranchRequest(request TaskBranchRequest) error {

--- a/internal/workflow/branch_test.go
+++ b/internal/workflow/branch_test.go
@@ -289,6 +289,54 @@ func TestEngineStartTaskBranchAllowsSameBranchInAnotherRepo(t *testing.T) {
 	}
 }
 
+func TestDelegationBranchNameAlwaysNamespaced(t *testing.T) {
+	short := parentShort("parent-job")
+	wantPrefix := "gitmoot-delegation-" + short + "-"
+
+	// No worktree hint: the branch is the bare namespaced form.
+	plain := delegationBranchName(Delegation{ID: "d1"}, "parent-job", "d1", 0)
+	if plain != wantPrefix+"d1" {
+		t.Fatalf("plain branch = %q, want %q", plain, wantPrefix+"d1")
+	}
+
+	// A worktree hint is appended only as a suffix, never replacing the namespace.
+	hinted := delegationBranchName(Delegation{ID: "d1", Worktree: "Feature Login"}, "parent-job", "d1", 0)
+	if hinted != wantPrefix+"d1-feature-login" {
+		t.Fatalf("hinted branch = %q, want %q", hinted, wantPrefix+"d1-feature-login")
+	}
+
+	// Two sibling delegations that share an identical worktree hint must still get
+	// distinct branches because each carries its own delegation id in the name.
+	siblingA := delegationBranchName(Delegation{ID: "api", Worktree: "shared"}, "parent-job", "api", 0)
+	siblingB := delegationBranchName(Delegation{ID: "ui", Worktree: "shared"}, "parent-job", "ui", 0)
+	if siblingA == siblingB {
+		t.Fatalf("siblings with identical worktree hint share branch %q", siblingA)
+	}
+
+	// Two siblings with empty worktree hints are likewise distinct.
+	emptyA := delegationBranchName(Delegation{ID: "api"}, "parent-job", "api", 0)
+	emptyB := delegationBranchName(Delegation{ID: "ui"}, "parent-job", "ui", 0)
+	if emptyA == emptyB {
+		t.Fatalf("siblings with empty worktree hint share branch %q", emptyA)
+	}
+
+	// A retry of the same delegation gets a distinct -retry-<n> branch so it never
+	// reuses the failed original attempt's still-checked-out branch.
+	original := delegationBranchName(Delegation{ID: "d1"}, "parent-job", "d1", 0)
+	retry := delegationBranchName(Delegation{ID: "d1"}, "parent-job", "d1", 2)
+	if retry != original+"-retry-2" {
+		t.Fatalf("retry branch = %q, want %q", retry, original+"-retry-2")
+	}
+	if retry == original {
+		t.Fatalf("retry branch %q collides with original attempt", retry)
+	}
+
+	// Determinism: the same inputs always produce the same branch.
+	if again := delegationBranchName(Delegation{ID: "d1", Worktree: "Feature Login"}, "parent-job", "d1", 0); again != hinted {
+		t.Fatalf("delegationBranchName not deterministic: %q != %q", again, hinted)
+	}
+}
+
 type fakeBranchCreator struct {
 	err      error
 	onCreate func()

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -20,6 +20,14 @@ type Engine struct {
 	JobID                   func(JobRequest) string
 	PayloadRefresher        func(context.Context, db.Job, JobPayload) (JobPayload, error)
 	ImplementationFinalizer ImplementationFinalizer
+	// Home is the resolved GITMOOT_HOME root used to place per-delegation
+	// worktrees. DelegationWorktrees is the checkout-bound git client that
+	// performs the worktree-add. Both are optional: when either is unset, the
+	// dispatcher enqueues implement delegations against the shared checkout
+	// (legacy behavior) rather than allocating isolated worktrees.
+	Home                string
+	DelegationWorktrees WorktreeManager
+	DelegationCheckout  string
 }
 
 type PullRequestEvent struct {
@@ -331,8 +339,9 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		return nil
 	}
 
-	requests := make([]JobRequest, 0, len(payload.Result.Delegations))
-	for _, d := range payload.Result.Delegations {
+	delegations := payload.Result.Delegations
+	requests := make([]JobRequest, 0, len(delegations))
+	for _, d := range delegations {
 		requests = append(requests, JobRequest{
 			ID:              job.ID + "/delegation/" + d.ID,
 			Agent:           d.Agent,
@@ -366,14 +375,41 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		}
 	}
 
-	// Acquire branch locks for all implement delegations before enqueueing any
-	// child job, so a later lock failure does not leave a half-dispatched batch.
-	for _, request := range requests {
-		if request.Action == "implement" {
-			if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, request.Agent, ref); err != nil {
+	// Allocate an isolated worktree (and branch lock) for every implement
+	// delegation before enqueueing any child job, so a later allocation failure
+	// does not leave a half-dispatched batch. Each sibling gets a distinct
+	// per-delegation branch and worktree path that overrides the parent's
+	// shared branch on the child request. When the engine has no worktree
+	// support wired, fall back to a bare branch lock on the parent branch.
+	for i := range requests {
+		if requests[i].Action != "implement" {
+			continue
+		}
+		if e.DelegationWorktrees == nil || strings.TrimSpace(e.Home) == "" {
+			if err := e.ensureBranchLock(ctx, requests[i].Repo, requests[i].Branch, requests[i].Agent, ref); err != nil {
 				return err
 			}
+			continue
 		}
+		result, err := e.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
+			Home:         e.Home,
+			Repo:         requests[i].Repo,
+			ParentJobID:  job.ID,
+			DelegationID: requests[i].DelegationID,
+			Delegation:   delegations[i],
+			BaseBranch:   payload.Branch,
+			Owner:        requests[i].Agent,
+			Checkout:     e.DelegationCheckout,
+		}, e.DelegationWorktrees)
+		if err != nil {
+			var blocked BlockedError
+			if errors.As(err, &blocked) {
+				return e.block(ctx, ref, blocked.Reason)
+			}
+			return err
+		}
+		requests[i].Branch = result.Branch
+		requests[i].WorktreePath = result.Path
 	}
 
 	for _, request := range requests {
@@ -716,6 +752,7 @@ func payloadMatchesRequest(payload JobPayload, request JobRequest) bool {
 		payload.ReviewRound == request.ReviewRound &&
 		payload.Sender == request.Sender &&
 		payload.Instructions == request.Instructions &&
+		payload.WorktreePath == request.WorktreePath &&
 		payloadDelegationMatchesRequest(payload, request) &&
 		equalStrings(payload.Reviewers, compactStrings(request.Reviewers)) &&
 		equalStrings(payload.Constraints, compactStrings(request.Constraints))

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -265,11 +265,12 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			if err := e.advanceDelegations(ctx, parentJob, parentPayload, parentPayload.Result, taskRefFromPayload(parentPayload)); err != nil {
 				return err
 			}
-			// A child that failed under a continue/escalate failure_policy, or one
-			// that was re-enqueued by the retry pass, is handled by the delegation
-			// graph (siblings keep running, the retry runs, or the coordinator
-			// continuation was enqueued); do not also block the shared parent task
-			// via the failed-decision path below.
+			// A child that failed under a continue/escalate failure_policy, one that
+			// was re-enqueued by the retry pass, or one whose parent already has a
+			// continuation in flight, is handled by the delegation graph (siblings
+			// keep running, the retry runs, or the coordinator continuation absorbs
+			// the failure); do not also block the shared parent task via the
+			// failed-decision path below.
 			if payload.Result.Decision == "blocked" || payload.Result.Decision == "failed" {
 				if delegationFailureHandledByPolicy(parentPayload.Result, payload.DelegationID) {
 					return nil
@@ -279,6 +280,17 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 					return err
 				}
 				if retrying {
+					return nil
+				}
+				// Once a continuation has been enqueued (e.g. an earlier escalate
+				// fired it), a later block_parent sibling failure must not block the
+				// shared parent task: that would contradict the in-flight
+				// continuation, which already carries every child outcome.
+				parentEvents, err := e.Store.ListJobEvents(ctx, parentJob.ID)
+				if err != nil {
+					return err
+				}
+				if continuationEnqueued(parentEvents) {
 					return nil
 				}
 			}
@@ -592,6 +604,17 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 		return err
 	}
 
+	// Parent job events drive two decisions below: which delegations dispatch
+	// skipped via fingerprint dedup (so they resolve against their winning
+	// sibling rather than stalling the continuation forever), and whether a
+	// continuation has already been enqueued (so a late block_parent failure does
+	// not contradict it).
+	parentEvents, err := e.Store.ListJobEvents(ctx, parentJob.ID)
+	if err != nil {
+		return err
+	}
+	dedupWinners := dedupedDelegationWinners(parentResult.Delegations, children, parentEvents)
+
 	// Resolve the shared artifact directory the same way dispatchDelegations did
 	// so late-running dependents reference the same brief.md/context-manifest.
 	artifactDir, err := delegationArtifactDir(e.ArtifactRoot, parentJob.ID, parentResult)
@@ -624,10 +647,18 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 		if err != nil {
 			return err
 		}
+		dedupWinners = dedupedDelegationWinners(parentResult.Delegations, children, parentEvents)
 	}
 
 	// Apply failure policies first so a failed dependency stops its dependents
-	// (or escalates/blocks) before we try to enqueue anything new.
+	// (or escalates/blocks) before we try to enqueue anything new. Once a
+	// continuation has already been enqueued (e.g. an earlier escalate fired it),
+	// a later block_parent sibling failure must not block the shared parent task:
+	// that would leave a blocked task AND an in-flight continuation, a
+	// contradictory end state the continuation prompt does not reflect. The
+	// continuation already carries every child outcome, so we fold the block into
+	// it by skipping the block here.
+	continuationAlreadyEnqueued := continuationEnqueued(parentEvents)
 	escalate := false
 	for _, d := range parentResult.Delegations {
 		child, ok := children[d.ID]
@@ -642,6 +673,9 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 		case "escalate":
 			escalate = true
 		default: // block_parent (also the empty default)
+			if continuationAlreadyEnqueued {
+				continue
+			}
 			return e.block(ctx, ref, fmt.Sprintf("delegation %q failed (failure_policy block_parent): %s", d.ID, childFailureReason(child)))
 		}
 	}
@@ -658,7 +692,12 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 			if _, exists := children[d.ID]; exists {
 				continue
 			}
-			if !depsSatisfied(d.Deps, children) {
+			// A deduped delegation folds into its winning sibling and must never
+			// get its own child, even if its deps are now satisfied.
+			if _, deduped := dedupWinners[d.ID]; deduped {
+				continue
+			}
+			if !depsSatisfied(d.Deps, children, dedupWinners) {
 				continue
 			}
 			if err := e.enqueueDelegation(ctx, parentJob, parentPayload, d, artifactDir, ref); err != nil {
@@ -670,13 +709,14 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 			if err != nil {
 				return err
 			}
+			dedupWinners = dedupedDelegationWinners(parentResult.Delegations, children, parentEvents)
 		}
 	}
 
 	// Enqueue the coordinator continuation job once every top-level delegation
 	// is resolved (terminal child, or permanently gated by a failed dependency
 	// under a continue policy), or immediately when a failure escalates.
-	if escalate || allDelegationsResolved(parentResult.Delegations, children) {
+	if escalate || allDelegationsResolved(parentResult.Delegations, children, dedupWinners) {
 		if err := e.maybeEnqueueContinuation(ctx, parentJob, parentPayload, parentResult, children, ref); err != nil {
 			return err
 		}
@@ -827,12 +867,98 @@ func delegationFingerprintKey(parentJobID, fingerprint string) string {
 	return "deleg-fp-" + strconv.FormatUint(hash.Sum64(), 36)
 }
 
+// dedupedDelegationWinners maps each fingerprint-deduped delegation id to the
+// winning sibling's child job: the same-fingerprint delegation that DID get a
+// child (and is therefore the canonical attempt the deduped node folds into). A
+// deduped delegation produces no child of its own (enqueueDelegation returns
+// early after a delegation_deduped event), so without this mapping
+// allDelegationsResolved/depsSatisfied would treat it as forever-active and stall
+// the coordinator continuation. The deduped set is taken from the parent's
+// recorded delegation_deduped events so it reflects exactly what dispatch skipped,
+// and each deduped id is resolved to its winner by fingerprint among siblings that
+// own a child.
+func dedupedDelegationWinners(delegations []Delegation, children map[string]db.Job, events []db.JobEvent) map[string]db.Job {
+	deduped := dedupedDelegationIDs(delegations, events)
+	if len(deduped) == 0 {
+		return nil
+	}
+	// Map each fingerprint to the winning sibling's child (the same-fingerprint
+	// delegation that owns a child). Delegation order is deterministic, so the
+	// first such sibling is a stable winner.
+	winnerByFingerprint := make(map[string]db.Job)
+	for _, d := range delegations {
+		fingerprint := strings.TrimSpace(d.Fingerprint)
+		if fingerprint == "" {
+			continue
+		}
+		if _, taken := winnerByFingerprint[fingerprint]; taken {
+			continue
+		}
+		if child, ok := children[d.ID]; ok {
+			winnerByFingerprint[fingerprint] = child
+		}
+	}
+	winners := make(map[string]db.Job)
+	for _, d := range delegations {
+		if !deduped[d.ID] {
+			continue
+		}
+		if winner, ok := winnerByFingerprint[strings.TrimSpace(d.Fingerprint)]; ok {
+			winners[d.ID] = winner
+		}
+	}
+	if len(winners) == 0 {
+		return nil
+	}
+	return winners
+}
+
+// dedupedDelegationIDs returns the set of delegation ids that dispatch skipped
+// via fingerprint dedup, by matching each known delegation against the parent's
+// recorded delegation_deduped event messages. enqueueDelegation formats those
+// messages as `delegation %q skipped: ...`, so a delegation is deduped when an
+// event message carries its %q-quoted id as the prefix. Reconstructing the
+// quoted prefix per delegation (rather than parsing the id out of the message)
+// keeps the match exact even for ids containing quotes or backslashes.
+func dedupedDelegationIDs(delegations []Delegation, events []db.JobEvent) map[string]bool {
+	var dedupedMessages []string
+	for _, event := range events {
+		if event.Kind == "delegation_deduped" {
+			dedupedMessages = append(dedupedMessages, event.Message)
+		}
+	}
+	if len(dedupedMessages) == 0 {
+		return nil
+	}
+	var ids map[string]bool
+	for _, d := range delegations {
+		prefix := fmt.Sprintf("delegation %q skipped:", d.ID)
+		for _, message := range dedupedMessages {
+			if strings.HasPrefix(message, prefix) {
+				if ids == nil {
+					ids = make(map[string]bool)
+				}
+				ids[d.ID] = true
+				break
+			}
+		}
+	}
+	return ids
+}
+
 // depsSatisfied reports whether every dependency id maps to a succeeded sibling.
 // An unknown dep id (not yet a child, or never created) is never satisfied, so a
 // failed or missing dependency keeps the dependent gated rather than enqueuing
-// it prematurely.
-func depsSatisfied(deps []string, children map[string]db.Job) bool {
+// it prematurely. A dep that points at a fingerprint-deduped delegation is
+// resolved against its winning sibling: satisfied iff that sibling succeeded.
+func depsSatisfied(deps []string, children map[string]db.Job, dedupWinners map[string]db.Job) bool {
 	for _, dep := range compactStrings(deps) {
+		if winner, ok := dedupWinners[dep]; ok {
+			if winner.State != string(JobSucceeded) {
+				return false
+			}
+			continue
+		}
 		child, ok := children[dep]
 		if !ok || child.State != string(JobSucceeded) {
 			return false
@@ -846,36 +972,50 @@ func depsSatisfied(deps []string, children map[string]db.Job) bool {
 // dependency failed under a continue policy and the delegation can never run.
 // queued/running children, or a not-yet-enqueued delegation whose deps are still
 // in flight, mean the batch is still active and no continuation is enqueued yet.
-func allDelegationsResolved(delegations []Delegation, children map[string]db.Job) bool {
+func allDelegationsResolved(delegations []Delegation, children map[string]db.Job, dedupWinners map[string]db.Job) bool {
 	byID := delegationsByID(delegations)
 	for _, d := range delegations {
-		if !delegationResolved(d, children, byID) {
+		if !delegationResolved(d, children, byID, dedupWinners) {
 			return false
 		}
 	}
 	return true
 }
 
-func delegationResolved(d Delegation, children map[string]db.Job, byID map[string]Delegation) bool {
+func delegationResolved(d Delegation, children map[string]db.Job, byID map[string]Delegation, dedupWinners map[string]db.Job) bool {
 	if child, ok := children[d.ID]; ok {
 		return isTerminalJobState(child.State)
 	}
+	// A fingerprint-deduped delegation never gets its own child; it is resolved
+	// when its winning sibling (the same-fingerprint delegation that did get a
+	// child) reaches a terminal state, so it cannot stall the continuation.
+	if winner, ok := dedupWinners[d.ID]; ok {
+		return isTerminalJobState(winner.State)
+	}
 	// No child job yet: the delegation is resolved only if it can never run
 	// because one of its dependencies is permanently unrunnable.
-	return delegationPermanentlyBlocked(d, children, byID, map[string]bool{})
+	return delegationPermanentlyBlocked(d, children, byID, dedupWinners, map[string]bool{})
 }
 
 // delegationPermanentlyBlocked reports whether a not-yet-enqueued delegation can
 // never run because a dependency terminally failed (or is itself permanently
 // blocked). It guards against cycles via the visiting set, treating a delegation
-// caught in a dependency cycle as blocked so the batch cannot deadlock.
-func delegationPermanentlyBlocked(d Delegation, children map[string]db.Job, byID map[string]Delegation, visiting map[string]bool) bool {
+// caught in a dependency cycle as blocked so the batch cannot deadlock. A dep
+// that points at a fingerprint-deduped delegation is resolved against its
+// winning sibling: a terminally-failed winner permanently blocks the dependent.
+func delegationPermanentlyBlocked(d Delegation, children map[string]db.Job, byID map[string]Delegation, dedupWinners map[string]db.Job, visiting map[string]bool) bool {
 	if visiting[d.ID] {
 		return true
 	}
 	visiting[d.ID] = true
 	defer delete(visiting, d.ID)
 	for _, dep := range compactStrings(d.Deps) {
+		if winner, ok := dedupWinners[dep]; ok {
+			if isTerminalJobState(winner.State) && winner.State != string(JobSucceeded) {
+				return true
+			}
+			continue
+		}
 		if child, ok := children[dep]; ok {
 			if isTerminalJobState(child.State) && child.State != string(JobSucceeded) {
 				return true
@@ -887,7 +1027,7 @@ func delegationPermanentlyBlocked(d Delegation, children map[string]db.Job, byID
 			// Unknown dependency id can never be satisfied.
 			return true
 		}
-		if delegationPermanentlyBlocked(depDel, children, byID, visiting) {
+		if delegationPermanentlyBlocked(depDel, children, byID, dedupWinners, visiting) {
 			return true
 		}
 	}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -500,8 +500,26 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 	}
 }
 
+// MaxDelegationDepth bounds how deep delegation nesting and coordinator
+// continuation chains may go. Each delegation child and each coordinator
+// continuation increments DelegationDepth; once a job at or beyond this depth
+// would dispatch, dispatchDelegations refuses and records a
+// delegation_depth_exceeded event. This is a safety net against runaway
+// recursion: a coordinator whose continuation re-delegates (e.g. a static or
+// looping agent) would otherwise spawn jobs forever.
+const MaxDelegationDepth = 8
+
 func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload JobPayload, ref taskRef) error {
 	if payload.Result == nil || len(payload.Result.Delegations) == 0 {
+		return nil
+	}
+
+	if payload.DelegationDepth >= MaxDelegationDepth {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_depth_exceeded",
+			Message: fmt.Sprintf("delegation depth %d reached the limit of %d; not dispatching %d delegation(s)", payload.DelegationDepth, MaxDelegationDepth, len(payload.Result.Delegations)),
+		})
 		return nil
 	}
 
@@ -879,7 +897,10 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		Instructions:    buildContinuationPrompt(parentResult, children, childPayloads),
 		Constraints:     parentPayload.Constraints,
 		ParentJobID:     parentJob.ID,
-		DelegationDepth: parentPayload.DelegationDepth,
+		// Increment depth per continuation generation so a coordinator whose
+		// continuation re-delegates is bounded by MaxDelegationDepth instead of
+		// looping forever (the continuation reused the parent's depth before).
+		DelegationDepth: parentPayload.DelegationDepth + 1,
 		DelegatedBy:     parentJob.Agent,
 	}
 	if err := e.enqueue(ctx, request); err != nil {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -518,6 +518,15 @@ func (e Engine) enqueueDelegation(ctx context.Context, job db.Job, payload JobPa
 func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, payload JobPayload, d Delegation, request JobRequest, ref taskRef) error {
 	if request.Action == "implement" {
 		if e.DelegationWorktrees == nil || strings.TrimSpace(e.Home) == "" {
+			// No per-delegation worktree isolation is available (the engine lacks a
+			// Home/DelegationWorktrees manager), so the child falls back to a
+			// shared-checkout branch lock. Emit a parent event so the loss of
+			// isolation is observable rather than silent.
+			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   job.ID,
+				Kind:    "delegation_worktree_skipped",
+				Message: fmt.Sprintf("delegation %q implement runs in the shared checkout on branch %s: per-delegation worktree isolation unavailable", request.DelegationID, request.Branch),
+			})
 			if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, request.Agent, ref); err != nil {
 				return err
 			}
@@ -531,6 +540,7 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 				BaseBranch:   payload.Branch,
 				Owner:        request.Agent,
 				Checkout:     e.DelegationCheckout,
+				RetryAttempt: request.RetryCount,
 			}, e.DelegationWorktrees)
 			if err != nil {
 				var blocked BlockedError
@@ -541,6 +551,14 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 			}
 			request.Branch = result.Branch
 			request.WorktreePath = result.Path
+			// The freshly-allocated worktree is created off the parent's base
+			// branch, whose tip may have advanced past the HeadSHA the child
+			// inherited from the parent payload. validateTargetCheckout (daemon)
+			// compares the worktree HEAD against payload.HeadSHA and would
+			// spuriously reject the child on a moving parent branch. Clear the
+			// inherited HeadSHA so the child validates against its own fresh
+			// worktree HEAD instead of a stale parent SHA.
+			request.HeadSHA = ""
 		}
 	}
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -28,6 +28,14 @@ type Engine struct {
 	Home                string
 	DelegationWorktrees WorktreeManager
 	DelegationCheckout  string
+	// ArtifactRoot is the filesystem root under which delegation artifacts
+	// (delegations/<parent-job-id>/brief.md and context-manifest.json) are
+	// written when a coordinator returns delegations that request artifacts.
+	// It is the resolved GITMOOT_HOME root (already ending in .gitmoot), kept
+	// outside any repo checkout so generated briefs are never committed. When
+	// empty, artifact writing is skipped (ask-path and tests that build an
+	// Engine without it keep their existing behavior).
+	ArtifactRoot string
 }
 
 type PullRequestEvent struct {
@@ -410,6 +418,27 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		}
 		requests[i].Branch = result.Branch
 		requests[i].WorktreePath = result.Path
+	}
+
+	// Write the shared coordinator brief and context manifest once, fully,
+	// before enqueueing any child job so a child that starts immediately reads a
+	// complete directory. Every child of a parent that produced artifacts is
+	// pointed at the same directory so its prompt can reference brief.md and
+	// context-manifest.json. Writing is skipped when the engine has no artifact
+	// root or no delegation requested artifacts.
+	artifactDir, err := writeDelegationArtifacts(e.ArtifactRoot, job.ID, payload.Result)
+	if err != nil {
+		return e.block(ctx, ref, fmt.Sprintf("write delegation artifacts: %v", err))
+	}
+	if artifactDir != "" {
+		for i := range requests {
+			requests[i].DelegationArtifactDir = artifactDir
+		}
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_artifacts_written",
+			Message: fmt.Sprintf("delegation artifacts written to %s", artifactDir),
+		})
 	}
 
 	for _, request := range requests {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -265,13 +265,22 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			if err := e.advanceDelegations(ctx, parentJob, parentPayload, parentPayload.Result, taskRefFromPayload(parentPayload)); err != nil {
 				return err
 			}
-			// A child that failed under a continue/escalate failure_policy is
-			// handled by the delegation graph (siblings keep running, or the
-			// coordinator continuation was enqueued); do not also block the
-			// shared parent task via the failed-decision path below.
-			if (payload.Result.Decision == "blocked" || payload.Result.Decision == "failed") &&
-				delegationFailureHandledByPolicy(parentPayload.Result, payload.DelegationID) {
-				return nil
+			// A child that failed under a continue/escalate failure_policy, or one
+			// that was re-enqueued by the retry pass, is handled by the delegation
+			// graph (siblings keep running, the retry runs, or the coordinator
+			// continuation was enqueued); do not also block the shared parent task
+			// via the failed-decision path below.
+			if payload.Result.Decision == "blocked" || payload.Result.Decision == "failed" {
+				if delegationFailureHandledByPolicy(parentPayload.Result, payload.DelegationID) {
+					return nil
+				}
+				retrying, err := e.delegationRetryPending(ctx, parentJob.ID, payload.DelegationID)
+				if err != nil {
+					return err
+				}
+				if retrying {
+					return nil
+				}
 			}
 		}
 	}
@@ -397,6 +406,10 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 		DelegationDepth: payload.DelegationDepth + 1,
 		DelegatedBy:     job.Agent,
 		Deps:            compactStrings(d.Deps),
+		JobTimeout:      strings.TrimSpace(d.Timeout),
+		Fingerprint:     strings.TrimSpace(d.Fingerprint),
+		FailurePolicy:   strings.TrimSpace(d.FailurePolicy),
+		SynthesisRule:   strings.TrimSpace(d.SynthesisRule),
 	}
 }
 
@@ -462,6 +475,35 @@ func (e Engine) enqueueDelegation(ctx context.Context, job db.Job, payload JobPa
 	request := e.delegationRequest(job, payload, d)
 	request.DelegationArtifactDir = artifactDir
 
+	// Fingerprint dedup: skip enqueueing a child whose fingerprint already
+	// appears among a sibling under the same parent. Scoped to this parent via
+	// the (parentJobID, fingerprint) key so identical fingerprints under
+	// different parents never collide. The delegation's own child is excluded so
+	// an idempotent re-enqueue of the same delegation is not treated as a dup.
+	if fingerprint := strings.TrimSpace(d.Fingerprint); fingerprint != "" {
+		seen, err := e.delegationFingerprintSeen(ctx, job.ID, d.ID, fingerprint)
+		if err != nil {
+			return err
+		}
+		if seen {
+			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   job.ID,
+				Kind:    "delegation_deduped",
+				Message: fmt.Sprintf("delegation %q skipped: fingerprint %q already enqueued (key %s)", d.ID, fingerprint, delegationFingerprintKey(job.ID, fingerprint)),
+			})
+			return nil
+		}
+	}
+
+	return e.allocateAndEnqueueDelegation(ctx, job, payload, d, request, ref)
+}
+
+// allocateAndEnqueueDelegation allocates the per-delegation worktree (or branch
+// lock) for implement delegations and enqueues the prepared request, recording a
+// delegation_enqueued event. It is shared by enqueueDelegation (initial/deferred
+// dispatch) and requeueDelegation (retry) so both go through identical worktree
+// allocation and idempotent enqueue.
+func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, payload JobPayload, d Delegation, request JobRequest, ref taskRef) error {
 	if request.Action == "implement" {
 		if e.DelegationWorktrees == nil || strings.TrimSpace(e.Home) == "" {
 			if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, request.Agent, ref); err != nil {
@@ -501,6 +543,38 @@ func (e Engine) enqueueDelegation(ctx context.Context, job db.Job, payload JobPa
 	return nil
 }
 
+// requeueDelegation re-enqueues a failed delegation child as a fresh job when
+// the delegation has retry budget left (failedChild's RetryCount < d.Retry). The
+// retry uses a distinct .../retry/<n> id so the enqueue idempotency path does not
+// mistake it for the already-failed original, carries RetryCount+1 in its
+// payload, and inherits the same DelegationID so it represents the same node in
+// the delegation graph. It returns whether a retry was enqueued.
+func (e Engine) requeueDelegation(ctx context.Context, parentJob db.Job, parentPayload JobPayload, d Delegation, failedChild db.Job, artifactDir string, ref taskRef) (bool, error) {
+	if d.Retry <= 0 {
+		return false, nil
+	}
+	attempt := delegationJobRetryCount(failedChild)
+	if attempt >= d.Retry {
+		return false, nil
+	}
+	next := attempt + 1
+
+	request := e.delegationRequest(parentJob, parentPayload, d)
+	request.ID = parentJob.ID + "/delegation/" + d.ID + "/retry/" + strconv.Itoa(next)
+	request.RetryCount = next
+	request.DelegationArtifactDir = artifactDir
+
+	if err := e.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, d, request, ref); err != nil {
+		return false, err
+	}
+	_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   parentJob.ID,
+		Kind:    "delegation_retry",
+		Message: fmt.Sprintf("delegation %q retry %d/%d enqueued as job %s after %s failed", d.ID, next, d.Retry, request.ID, failedChild.ID),
+	})
+	return true, nil
+}
+
 // advanceDelegations runs on a parent coordinator job each time one of its
 // delegated children finishes. It enqueues now-ready dependent siblings,
 // applies the failed delegation's failure_policy, and enqueues a single
@@ -523,6 +597,33 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 	artifactDir, err := delegationArtifactDir(e.ArtifactRoot, parentJob.ID, parentResult)
 	if err != nil {
 		return err
+	}
+
+	// Retry pass: a delegation that failed but has retry budget left is
+	// re-enqueued as a fresh child before any failure_policy is applied, so its
+	// failure is absorbed by the retry rather than blocking/escalating. A
+	// successful retry replaces the failed attempt in the children map (the retry
+	// id sorts after the original), so the delegation looks active again this
+	// pass and the failure switch below skips it.
+	retried := false
+	for _, d := range parentResult.Delegations {
+		child, ok := children[d.ID]
+		if !ok || !isTerminalJobState(child.State) || child.State == string(JobSucceeded) {
+			continue
+		}
+		didRetry, err := e.requeueDelegation(ctx, parentJob, parentPayload, d, child, artifactDir, ref)
+		if err != nil {
+			return err
+		}
+		if didRetry {
+			retried = true
+		}
+	}
+	if retried {
+		children, err = e.childDelegationJobs(ctx, parentJob.ID)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Apply failure policies first so a failed dependency stops its dependents
@@ -576,7 +677,7 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 	// is resolved (terminal child, or permanently gated by a failed dependency
 	// under a continue policy), or immediately when a failure escalates.
 	if escalate || allDelegationsResolved(parentResult.Delegations, children) {
-		if err := e.maybeEnqueueContinuation(ctx, parentJob, parentPayload, parentResult, children); err != nil {
+		if err := e.maybeEnqueueContinuation(ctx, parentJob, parentPayload, parentResult, children, ref); err != nil {
 			return err
 		}
 	}
@@ -587,7 +688,9 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 // a parent whose delegations have all finished. Idempotency is enforced by a
 // deterministic continuation id plus a one-shot delegation_continuation_enqueued
 // event on the parent, so concurrent child completions enqueue it at most once.
-func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, parentPayload JobPayload, parentResult *AgentResult, children map[string]db.Job) error {
+// When any delegation declares synthesis_rule "vote", the continuation is gated:
+// the parent task is blocked unless every child was approved/succeeded.
+func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, parentPayload JobPayload, parentResult *AgentResult, children map[string]db.Job, ref taskRef) error {
 	events, err := e.Store.ListJobEvents(ctx, parentJob.ID)
 	if err != nil {
 		return err
@@ -603,6 +706,13 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 			return err
 		}
 		childPayloads[id] = childPayload
+	}
+
+	// synthesis_rule "vote": block the parent unless every child approved or
+	// succeeded. The default ("" / "summary") concatenates child summaries into
+	// the continuation prompt below.
+	if delegationSynthesisRequiresVote(parentResult.Delegations) && !delegationVoteSatisfied(parentResult.Delegations, children, childPayloads) {
+		return e.block(ctx, ref, fmt.Sprintf("delegation synthesis_rule vote failed: not all delegated children for %s were approved/succeeded", parentJob.ID))
 	}
 
 	request := JobRequest{
@@ -645,13 +755,76 @@ func (e Engine) childDelegationJobs(ctx context.Context, parentJobID string) (ma
 		return nil, err
 	}
 	children := make(map[string]db.Job)
+	attempts := make(map[string]int)
 	for _, job := range jobs {
 		if job.ParentJobID != parentJobID || strings.TrimSpace(job.DelegationID) == "" {
 			continue
 		}
+		// A delegation may have several attempts after retries; keep the latest
+		// (highest RetryCount) so the failure/resolution logic always observes the
+		// current attempt regardless of ListJobs ordering.
+		attempt := delegationJobRetryCount(job)
+		if _, ok := children[job.DelegationID]; ok && attempt < attempts[job.DelegationID] {
+			continue
+		}
 		children[job.DelegationID] = job
+		attempts[job.DelegationID] = attempt
 	}
 	return children, nil
+}
+
+// delegationJobRetryCount reads a child job's RetryCount from its payload,
+// returning 0 when the payload is missing or cannot be parsed.
+func delegationJobRetryCount(job db.Job) int {
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		return 0
+	}
+	return payload.RetryCount
+}
+
+// delegationFingerprintSeen reports whether a sibling delegation under the same
+// parent (other than skipDelegationID) has already been enqueued with the given
+// fingerprint. It scans ListJobs filtered by ParentJobID, mirroring
+// childDelegationJobs, and compares each child's stored payload.Fingerprint so
+// dedup is scoped per the goal's (parentJobID, fingerprint) key.
+func (e Engine) delegationFingerprintSeen(ctx context.Context, parentJobID, skipDelegationID, fingerprint string) (bool, error) {
+	fingerprint = strings.TrimSpace(fingerprint)
+	if fingerprint == "" {
+		return false, nil
+	}
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, job := range jobs {
+		if job.ParentJobID != parentJobID || strings.TrimSpace(job.DelegationID) == "" {
+			continue
+		}
+		if job.DelegationID == skipDelegationID {
+			continue
+		}
+		childPayload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return false, err
+		}
+		if strings.TrimSpace(childPayload.Fingerprint) == fingerprint {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// delegationFingerprintKey hashes (parentJobID, fingerprint) into a stable,
+// parent-scoped dedup key, mirroring jobID's fnv hashing so identical
+// fingerprints under different parents never collide.
+func delegationFingerprintKey(parentJobID, fingerprint string) string {
+	hash := fnv.New64a()
+	for _, value := range []string{parentJobID, fingerprint} {
+		_, _ = hash.Write([]byte(value))
+		_, _ = hash.Write([]byte{0})
+	}
+	return "deleg-fp-" + strconv.FormatUint(hash.Sum64(), 36)
 }
 
 // depsSatisfied reports whether every dependency id maps to a succeeded sibling.
@@ -767,6 +940,25 @@ func delegationFailureHandledByPolicy(parentResult *AgentResult, delegationID st
 	return false
 }
 
+// delegationRetryPending reports whether the named delegation currently has a
+// non-terminal child, meaning the retry pass re-enqueued a fresh attempt and the
+// failed attempt's outcome is now superseded. childDelegationJobs already keeps
+// the latest attempt per delegation id, so a queued/running retry shows here.
+func (e Engine) delegationRetryPending(ctx context.Context, parentJobID, delegationID string) (bool, error) {
+	if strings.TrimSpace(delegationID) == "" {
+		return false, nil
+	}
+	children, err := e.childDelegationJobs(ctx, parentJobID)
+	if err != nil {
+		return false, err
+	}
+	child, ok := children[delegationID]
+	if !ok {
+		return false, nil
+	}
+	return !isTerminalJobState(child.State), nil
+}
+
 func childFailureReason(child db.Job) string {
 	payload, err := unmarshalPayload(child.Payload)
 	if err == nil && payload.Result != nil && strings.TrimSpace(payload.Result.Summary) != "" {
@@ -826,6 +1018,59 @@ func childPullRequestLink(payload JobPayload) string {
 		return ""
 	}
 	return fmt.Sprintf("https://github.com/%s/pull/%d", payload.Repo, payload.PullRequest)
+}
+
+func delegationSynthesisRule(d Delegation) string {
+	rule := strings.ToLower(strings.TrimSpace(d.SynthesisRule))
+	if rule == "" {
+		return "summary"
+	}
+	return rule
+}
+
+// delegationSynthesisRequiresVote reports whether any delegation in the batch
+// declares synthesis_rule "vote", which gates the coordinator continuation on
+// every child being approved/succeeded.
+func delegationSynthesisRequiresVote(delegations []Delegation) bool {
+	for _, d := range delegations {
+		if delegationSynthesisRule(d) == "vote" {
+			return true
+		}
+	}
+	return false
+}
+
+// delegationVoteSatisfied reports whether every delegation's child reached an
+// approving outcome: a succeeded job state, or a child result decision of
+// approved/succeeded/implemented. A missing or non-approving child fails the
+// vote.
+func delegationVoteSatisfied(delegations []Delegation, children map[string]db.Job, childPayloads map[string]JobPayload) bool {
+	for _, d := range delegations {
+		child, ok := children[d.ID]
+		if !ok {
+			return false
+		}
+		if child.State == string(JobSucceeded) {
+			continue
+		}
+		payload, ok := childPayloads[d.ID]
+		if !ok || payload.Result == nil {
+			return false
+		}
+		if !delegationDecisionApproves(payload.Result.Decision) {
+			return false
+		}
+	}
+	return true
+}
+
+func delegationDecisionApproves(decision string) bool {
+	switch strings.ToLower(strings.TrimSpace(decision)) {
+	case "approved", "succeeded", "implemented":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e Engine) preflightDelegation(ctx context.Context, request JobRequest) error {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -250,6 +250,32 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 	}
 	ref := taskRefFromPayload(payload)
 
+	// When a delegated child job finishes, advance its parent's delegation DAG
+	// before running the child's own advancement: enqueue any now-ready
+	// dependent siblings, apply the failed delegation's failure_policy, and
+	// enqueue the coordinator continuation job once every top-level sibling is
+	// terminal. This runs here (the child's AdvanceJob) because RunJob calls
+	// AdvanceJob per finishing child. A child with no parent is unaffected.
+	if strings.TrimSpace(payload.ParentJobID) != "" {
+		parentJob, parentPayload, err := e.jobPayload(ctx, payload.ParentJobID)
+		if err != nil {
+			return err
+		}
+		if parentPayload.Result != nil {
+			if err := e.advanceDelegations(ctx, parentJob, parentPayload, parentPayload.Result, taskRefFromPayload(parentPayload)); err != nil {
+				return err
+			}
+			// A child that failed under a continue/escalate failure_policy is
+			// handled by the delegation graph (siblings keep running, or the
+			// coordinator continuation was enqueued); do not also block the
+			// shared parent task via the failed-decision path below.
+			if (payload.Result.Decision == "blocked" || payload.Result.Decision == "failed") &&
+				delegationFailureHandledByPolicy(parentPayload.Result, payload.DelegationID) {
+				return nil
+			}
+		}
+	}
+
 	if job.Type == "review" {
 		latest, err := e.latestReviewRound(ctx, payload)
 		if err != nil {
@@ -342,82 +368,55 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 	return nil
 }
 
+// delegationRequest builds the canonical child JobRequest for a delegation,
+// inheriting the parent's repo/branch/PR context and stamping the DAG fields
+// (ParentJobID/DelegationID/DelegationDepth/DelegatedBy/Deps). It is shared by
+// dispatchDelegations (initial enqueue of ready delegations) and
+// advanceDelegations (deferred enqueue once deps clear) so both paths produce
+// identical, idempotent requests for the same delegation ID.
+func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) JobRequest {
+	return JobRequest{
+		ID:              job.ID + "/delegation/" + d.ID,
+		Agent:           d.Agent,
+		Action:          d.Action,
+		Repo:            payload.Repo,
+		Branch:          payload.Branch,
+		PullRequest:     payload.PullRequest,
+		HeadSHA:         payload.HeadSHA,
+		GoalID:          payload.GoalID,
+		TaskID:          payload.TaskID,
+		TaskTitle:       payload.TaskTitle,
+		LeadAgent:       payload.LeadAgent,
+		Reviewers:       payload.Reviewers,
+		ReviewRound:     payload.ReviewRound,
+		Sender:          job.Agent,
+		Instructions:    strings.TrimSpace(d.Prompt),
+		Constraints:     payload.Constraints,
+		ParentJobID:     job.ID,
+		DelegationID:    d.ID,
+		DelegationDepth: payload.DelegationDepth + 1,
+		DelegatedBy:     job.Agent,
+		Deps:            compactStrings(d.Deps),
+	}
+}
+
 func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload JobPayload, ref taskRef) error {
 	if payload.Result == nil || len(payload.Result.Delegations) == 0 {
 		return nil
 	}
 
 	delegations := payload.Result.Delegations
-	requests := make([]JobRequest, 0, len(delegations))
-	for _, d := range delegations {
-		requests = append(requests, JobRequest{
-			ID:              job.ID + "/delegation/" + d.ID,
-			Agent:           d.Agent,
-			Action:          d.Action,
-			Repo:            payload.Repo,
-			Branch:          payload.Branch,
-			PullRequest:     payload.PullRequest,
-			HeadSHA:         payload.HeadSHA,
-			GoalID:          payload.GoalID,
-			TaskID:          payload.TaskID,
-			TaskTitle:       payload.TaskTitle,
-			LeadAgent:       payload.LeadAgent,
-			Reviewers:       payload.Reviewers,
-			ReviewRound:     payload.ReviewRound,
-			Sender:          job.Agent,
-			Instructions:    strings.TrimSpace(d.Prompt),
-			Constraints:     payload.Constraints,
-			ParentJobID:     job.ID,
-			DelegationID:    d.ID,
-			DelegationDepth: payload.DelegationDepth + 1,
-			DelegatedBy:     job.Agent,
-		})
-	}
 
-	// Preflight all delegations before enqueueing any child job so that a
-	// partial failure does not leave the parent half-dispatched. Use a lightweight
-	// check that does not acquire branch locks or other execution side effects.
-	for _, request := range requests {
+	// Preflight every delegation (ready and deferred) before enqueueing any
+	// child job so a partial failure does not leave the parent half-dispatched
+	// and an unknown/uncapable agent on a deferred delegation blocks the parent
+	// immediately rather than only when its deps clear. Use a lightweight check
+	// that does not acquire branch locks or other execution side effects.
+	for _, d := range delegations {
+		request := e.delegationRequest(job, payload, d)
 		if err := e.preflightDelegation(ctx, request); err != nil {
 			return e.block(ctx, ref, fmt.Sprintf("delegation %q preflight failed: %v", request.DelegationID, err))
 		}
-	}
-
-	// Allocate an isolated worktree (and branch lock) for every implement
-	// delegation before enqueueing any child job, so a later allocation failure
-	// does not leave a half-dispatched batch. Each sibling gets a distinct
-	// per-delegation branch and worktree path that overrides the parent's
-	// shared branch on the child request. When the engine has no worktree
-	// support wired, fall back to a bare branch lock on the parent branch.
-	for i := range requests {
-		if requests[i].Action != "implement" {
-			continue
-		}
-		if e.DelegationWorktrees == nil || strings.TrimSpace(e.Home) == "" {
-			if err := e.ensureBranchLock(ctx, requests[i].Repo, requests[i].Branch, requests[i].Agent, ref); err != nil {
-				return err
-			}
-			continue
-		}
-		result, err := e.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
-			Home:         e.Home,
-			Repo:         requests[i].Repo,
-			ParentJobID:  job.ID,
-			DelegationID: requests[i].DelegationID,
-			Delegation:   delegations[i],
-			BaseBranch:   payload.Branch,
-			Owner:        requests[i].Agent,
-			Checkout:     e.DelegationCheckout,
-		}, e.DelegationWorktrees)
-		if err != nil {
-			var blocked BlockedError
-			if errors.As(err, &blocked) {
-				return e.block(ctx, ref, blocked.Reason)
-			}
-			return err
-		}
-		requests[i].Branch = result.Branch
-		requests[i].WorktreePath = result.Path
 	}
 
 	// Write the shared coordinator brief and context manifest once, fully,
@@ -431,9 +430,6 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		return e.block(ctx, ref, fmt.Sprintf("write delegation artifacts: %v", err))
 	}
 	if artifactDir != "" {
-		for i := range requests {
-			requests[i].DelegationArtifactDir = artifactDir
-		}
 		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
 			JobID:   job.ID,
 			Kind:    "delegation_artifacts_written",
@@ -441,17 +437,395 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		})
 	}
 
-	for _, request := range requests {
-		if err := e.enqueue(ctx, request); err != nil {
-			return fmt.Errorf("dispatch delegation %q: %w", request.DelegationID, err)
+	// Only delegations with no unmet deps are enqueued now; deferred ones are
+	// enqueued by advanceDelegations once every dep has succeeded. Allocate
+	// worktrees/branch locks only for the ready implement delegations so a
+	// deferred delegation does not hold a lock before it can run.
+	for _, d := range delegations {
+		if len(compactStrings(d.Deps)) > 0 {
+			continue
 		}
-		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
-			JobID:   job.ID,
-			Kind:    "delegation_enqueued",
-			Message: fmt.Sprintf("delegation %q enqueued as job %s", request.DelegationID, request.ID),
-		})
+		if err := e.enqueueDelegation(ctx, job, payload, d, artifactDir, ref); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// enqueueDelegation allocates the per-delegation worktree (or branch lock) for
+// implement delegations, then enqueues the child job and records a
+// delegation_enqueued event on the parent. It is idempotent: a duplicate
+// deterministic-ID insert is swallowed by e.enqueue when the existing job
+// matches the request, so it is safe to call from both dispatchDelegations and
+// advanceDelegations.
+func (e Engine) enqueueDelegation(ctx context.Context, job db.Job, payload JobPayload, d Delegation, artifactDir string, ref taskRef) error {
+	request := e.delegationRequest(job, payload, d)
+	request.DelegationArtifactDir = artifactDir
+
+	if request.Action == "implement" {
+		if e.DelegationWorktrees == nil || strings.TrimSpace(e.Home) == "" {
+			if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, request.Agent, ref); err != nil {
+				return err
+			}
+		} else {
+			result, err := e.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
+				Home:         e.Home,
+				Repo:         request.Repo,
+				ParentJobID:  job.ID,
+				DelegationID: request.DelegationID,
+				Delegation:   d,
+				BaseBranch:   payload.Branch,
+				Owner:        request.Agent,
+				Checkout:     e.DelegationCheckout,
+			}, e.DelegationWorktrees)
+			if err != nil {
+				var blocked BlockedError
+				if errors.As(err, &blocked) {
+					return e.block(ctx, ref, blocked.Reason)
+				}
+				return err
+			}
+			request.Branch = result.Branch
+			request.WorktreePath = result.Path
+		}
+	}
+
+	if err := e.enqueue(ctx, request); err != nil {
+		return fmt.Errorf("dispatch delegation %q: %w", request.DelegationID, err)
+	}
+	_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   job.ID,
+		Kind:    "delegation_enqueued",
+		Message: fmt.Sprintf("delegation %q enqueued as job %s", request.DelegationID, request.ID),
+	})
+	return nil
+}
+
+// advanceDelegations runs on a parent coordinator job each time one of its
+// delegated children finishes. It enqueues now-ready dependent siblings,
+// applies the failed delegation's failure_policy, and enqueues a single
+// coordinator continuation job once every top-level sibling has reached a
+// terminal state. It is idempotent: deferred dependents and the continuation
+// job use deterministic ids, so concurrent child completions cannot double
+// enqueue.
+func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parentPayload JobPayload, parentResult *AgentResult, ref taskRef) error {
+	if parentResult == nil || len(parentResult.Delegations) == 0 {
+		return nil
+	}
+
+	children, err := e.childDelegationJobs(ctx, parentJob.ID)
+	if err != nil {
+		return err
+	}
+
+	// Resolve the shared artifact directory the same way dispatchDelegations did
+	// so late-running dependents reference the same brief.md/context-manifest.
+	artifactDir, err := delegationArtifactDir(e.ArtifactRoot, parentJob.ID, parentResult)
+	if err != nil {
+		return err
+	}
+
+	// Apply failure policies first so a failed dependency stops its dependents
+	// (or escalates/blocks) before we try to enqueue anything new.
+	escalate := false
+	for _, d := range parentResult.Delegations {
+		child, ok := children[d.ID]
+		if !ok || !isTerminalJobState(child.State) || child.State == string(JobSucceeded) {
+			continue
+		}
+		switch delegationFailurePolicy(d) {
+		case "continue":
+			// Independent ready siblings still run; only this branch's
+			// dependents are skipped (handled by depsSatisfied below).
+			continue
+		case "escalate":
+			escalate = true
+		default: // block_parent (also the empty default)
+			return e.block(ctx, ref, fmt.Sprintf("delegation %q failed (failure_policy block_parent): %s", d.ID, childFailureReason(child)))
+		}
+	}
+
+	// Enqueue deferred dependents whose deps have all succeeded. Skip any whose
+	// dependency failed under a continue policy (depsSatisfied returns false
+	// unless every dep is succeeded). Already-enqueued children are skipped via
+	// the children map and e.enqueue's idempotency.
+	if !escalate {
+		for _, d := range parentResult.Delegations {
+			if len(compactStrings(d.Deps)) == 0 {
+				continue
+			}
+			if _, exists := children[d.ID]; exists {
+				continue
+			}
+			if !depsSatisfied(d.Deps, children) {
+				continue
+			}
+			if err := e.enqueueDelegation(ctx, parentJob, parentPayload, d, artifactDir, ref); err != nil {
+				return err
+			}
+			// Re-read children so a second satisfied dependent in the same pass
+			// is not mistaken for still-pending.
+			children, err = e.childDelegationJobs(ctx, parentJob.ID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Enqueue the coordinator continuation job once every top-level delegation
+	// is resolved (terminal child, or permanently gated by a failed dependency
+	// under a continue policy), or immediately when a failure escalates.
+	if escalate || allDelegationsResolved(parentResult.Delegations, children) {
+		if err := e.maybeEnqueueContinuation(ctx, parentJob, parentPayload, parentResult, children); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// maybeEnqueueContinuation enqueues exactly one coordinator continuation job for
+// a parent whose delegations have all finished. Idempotency is enforced by a
+// deterministic continuation id plus a one-shot delegation_continuation_enqueued
+// event on the parent, so concurrent child completions enqueue it at most once.
+func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, parentPayload JobPayload, parentResult *AgentResult, children map[string]db.Job) error {
+	events, err := e.Store.ListJobEvents(ctx, parentJob.ID)
+	if err != nil {
+		return err
+	}
+	if continuationEnqueued(events) {
+		return nil
+	}
+
+	childPayloads := make(map[string]JobPayload, len(children))
+	for id, child := range children {
+		childPayload, err := unmarshalPayload(child.Payload)
+		if err != nil {
+			return err
+		}
+		childPayloads[id] = childPayload
+	}
+
+	request := JobRequest{
+		ID:              delegationContinuationID(parentJob.ID),
+		Agent:           parentJob.Agent,
+		Action:          "ask",
+		Repo:            parentPayload.Repo,
+		Branch:          parentPayload.Branch,
+		PullRequest:     parentPayload.PullRequest,
+		HeadSHA:         parentPayload.HeadSHA,
+		GoalID:          parentPayload.GoalID,
+		TaskID:          parentPayload.TaskID,
+		TaskTitle:       parentPayload.TaskTitle,
+		LeadAgent:       parentPayload.LeadAgent,
+		Reviewers:       parentPayload.Reviewers,
+		Sender:          parentJob.Agent,
+		Instructions:    buildContinuationPrompt(parentResult, children, childPayloads),
+		Constraints:     parentPayload.Constraints,
+		ParentJobID:     parentJob.ID,
+		DelegationDepth: parentPayload.DelegationDepth,
+		DelegatedBy:     parentJob.Agent,
+	}
+	if err := e.enqueue(ctx, request); err != nil {
+		return fmt.Errorf("enqueue continuation for %q: %w", parentJob.ID, err)
+	}
+	_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   parentJob.ID,
+		Kind:    "delegation_continuation_enqueued",
+		Message: fmt.Sprintf("delegation continuation enqueued as job %s", request.ID),
+	})
+	return nil
+}
+
+// childDelegationJobs returns the direct delegation children of a parent job,
+// keyed by delegation id. There is no ListJobsByParent store query, so this
+// filters ListJobs on ParentJobID (mirroring latestReviewRound's list+filter).
+func (e Engine) childDelegationJobs(ctx context.Context, parentJobID string) (map[string]db.Job, error) {
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	children := make(map[string]db.Job)
+	for _, job := range jobs {
+		if job.ParentJobID != parentJobID || strings.TrimSpace(job.DelegationID) == "" {
+			continue
+		}
+		children[job.DelegationID] = job
+	}
+	return children, nil
+}
+
+// depsSatisfied reports whether every dependency id maps to a succeeded sibling.
+// An unknown dep id (not yet a child, or never created) is never satisfied, so a
+// failed or missing dependency keeps the dependent gated rather than enqueuing
+// it prematurely.
+func depsSatisfied(deps []string, children map[string]db.Job) bool {
+	for _, dep := range compactStrings(deps) {
+		child, ok := children[dep]
+		if !ok || child.State != string(JobSucceeded) {
+			return false
+		}
+	}
+	return true
+}
+
+// allDelegationsResolved reports whether every top-level delegation has reached
+// a final disposition: either a terminal child job, or no child at all because a
+// dependency failed under a continue policy and the delegation can never run.
+// queued/running children, or a not-yet-enqueued delegation whose deps are still
+// in flight, mean the batch is still active and no continuation is enqueued yet.
+func allDelegationsResolved(delegations []Delegation, children map[string]db.Job) bool {
+	byID := delegationsByID(delegations)
+	for _, d := range delegations {
+		if !delegationResolved(d, children, byID) {
+			return false
+		}
+	}
+	return true
+}
+
+func delegationResolved(d Delegation, children map[string]db.Job, byID map[string]Delegation) bool {
+	if child, ok := children[d.ID]; ok {
+		return isTerminalJobState(child.State)
+	}
+	// No child job yet: the delegation is resolved only if it can never run
+	// because one of its dependencies is permanently unrunnable.
+	return delegationPermanentlyBlocked(d, children, byID, map[string]bool{})
+}
+
+// delegationPermanentlyBlocked reports whether a not-yet-enqueued delegation can
+// never run because a dependency terminally failed (or is itself permanently
+// blocked). It guards against cycles via the visiting set, treating a delegation
+// caught in a dependency cycle as blocked so the batch cannot deadlock.
+func delegationPermanentlyBlocked(d Delegation, children map[string]db.Job, byID map[string]Delegation, visiting map[string]bool) bool {
+	if visiting[d.ID] {
+		return true
+	}
+	visiting[d.ID] = true
+	defer delete(visiting, d.ID)
+	for _, dep := range compactStrings(d.Deps) {
+		if child, ok := children[dep]; ok {
+			if isTerminalJobState(child.State) && child.State != string(JobSucceeded) {
+				return true
+			}
+			continue
+		}
+		depDel, ok := byID[dep]
+		if !ok {
+			// Unknown dependency id can never be satisfied.
+			return true
+		}
+		if delegationPermanentlyBlocked(depDel, children, byID, visiting) {
+			return true
+		}
+	}
+	return false
+}
+
+func delegationsByID(delegations []Delegation) map[string]Delegation {
+	byID := make(map[string]Delegation, len(delegations))
+	for _, d := range delegations {
+		byID[d.ID] = d
+	}
+	return byID
+}
+
+func isTerminalJobState(state string) bool {
+	switch state {
+	case string(JobSucceeded), string(JobFailed), string(JobBlocked), string(JobCancelled):
+		return true
+	default:
+		return false
+	}
+}
+
+func delegationFailurePolicy(d Delegation) string {
+	policy := strings.ToLower(strings.TrimSpace(d.FailurePolicy))
+	if policy == "" {
+		return "block_parent"
+	}
+	return policy
+}
+
+// delegationFailureHandledByPolicy reports whether the named delegation declares
+// a continue/escalate failure_policy, meaning a failure of its child is governed
+// by the delegation graph rather than blocking the shared parent task.
+func delegationFailureHandledByPolicy(parentResult *AgentResult, delegationID string) bool {
+	if parentResult == nil || strings.TrimSpace(delegationID) == "" {
+		return false
+	}
+	for _, d := range parentResult.Delegations {
+		if d.ID != delegationID {
+			continue
+		}
+		switch delegationFailurePolicy(d) {
+		case "continue", "escalate":
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func childFailureReason(child db.Job) string {
+	payload, err := unmarshalPayload(child.Payload)
+	if err == nil && payload.Result != nil && strings.TrimSpace(payload.Result.Summary) != "" {
+		return payload.Result.Summary
+	}
+	return child.State
+}
+
+func continuationEnqueued(events []db.JobEvent) bool {
+	for _, event := range events {
+		if event.Kind == "delegation_continuation_enqueued" {
+			return true
+		}
+	}
+	return false
+}
+
+func delegationContinuationID(parentJobID string) string {
+	return parentJobID + "/continuation"
+}
+
+// buildContinuationPrompt inlines each finished child's job id, agent, decision,
+// summary, and PR link into the coordinator continuation prompt so the
+// coordinator can synthesize the results without re-reading every child job.
+func buildContinuationPrompt(parentResult *AgentResult, children map[string]db.Job, childPayloads map[string]JobPayload) string {
+	var builder strings.Builder
+	builder.WriteString("All delegated jobs have finished. Review the results below and decide the next step.\n\n")
+	builder.WriteString("Delegation results:\n")
+	for _, d := range parentResult.Delegations {
+		child, ok := children[d.ID]
+		if !ok {
+			fmt.Fprintf(&builder, "- delegation %q (agent %s): not enqueued (dependencies unmet)\n", d.ID, d.Agent)
+			continue
+		}
+		decision := child.State
+		summary := ""
+		if payload, ok := childPayloads[d.ID]; ok && payload.Result != nil {
+			if strings.TrimSpace(payload.Result.Decision) != "" {
+				decision = payload.Result.Decision
+			}
+			summary = strings.TrimSpace(payload.Result.Summary)
+		}
+		fmt.Fprintf(&builder, "- delegation %q (job %s, agent %s): %s", d.ID, child.ID, child.Agent, decision)
+		if summary != "" {
+			fmt.Fprintf(&builder, " — %s", summary)
+		}
+		if link := childPullRequestLink(childPayloads[d.ID]); link != "" {
+			fmt.Fprintf(&builder, " (%s)", link)
+		}
+		builder.WriteString("\n")
+	}
+	return builder.String()
+}
+
+func childPullRequestLink(payload JobPayload) string {
+	if payload.PullRequest <= 0 || strings.TrimSpace(payload.Repo) == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/%s/pull/%d", payload.Repo, payload.PullRequest)
 }
 
 func (e Engine) preflightDelegation(ctx context.Context, request JobRequest) error {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -221,6 +221,81 @@ func (e Engine) RunJob(ctx context.Context, jobID string, agent runtime.Agent, a
 	return result, nil
 }
 
+// FinalizeTimedOutDelegationChild turns a delegation child that was killed by its
+// per-delegation timeout (or any runtime failure that left it JobRunning with no
+// parseable gitmoot_result) into a terminal FAILED child carrying a synthetic
+// failed result, then runs AdvanceJob so the parent's advanceDelegations applies
+// the delegation's retry/failure_policy/continuation. Without this a timeout kill
+// strands the child in JobRunning forever (Mailbox.Run errored, so RunJob returned
+// before AdvanceJob), and only the blind 30m stale-running recovery would re-queue
+// it, bypassing delegation.Retry and failure_policy.
+//
+// It is a no-op (returns false) for a non-delegation job, a job that already left
+// JobRunning, or a job that already stored a result, so it is safe to call from
+// the daemon's run-error handler and idempotent under concurrent recovery. When
+// the synthetic failure blocks the parent task under block_parent, AdvanceJob
+// returns a BlockedError, which is propagated like the result-bearing path.
+func (e Engine) FinalizeTimedOutDelegationChild(ctx context.Context, jobID string, reason string) (bool, error) {
+	if err := e.validate(); err != nil {
+		return false, err
+	}
+	job, payload, err := e.jobPayload(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(payload.ParentJobID) == "" {
+		return false, nil
+	}
+	// Already has a result -> the normal RunJob/AdvanceJob path handled it; nothing
+	// to recover. A deadline can leave the child either still JobRunning (the
+	// cancelled context aborted Mailbox.Run's own fail write) or already
+	// JobFailed/JobBlocked but WITHOUT a stored result (so the parent's
+	// advanceDelegations never ran). Recover both, but never touch a succeeded or
+	// cancelled child.
+	if payload.Result != nil {
+		return false, nil
+	}
+	switch job.State {
+	case string(JobRunning), string(JobFailed), string(JobBlocked):
+	default:
+		return false, nil
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "delegation child timed out before returning a result"
+	}
+	payload.Result = &AgentResult{
+		Decision: "failed",
+		Summary:  reason,
+	}
+	mailbox := Mailbox{Store: e.Store}
+	if job.State == string(JobRunning) {
+		if err := mailbox.finishWithPayload(ctx, jobID, JobFailed, reason, payload); err != nil {
+			return false, err
+		}
+	} else {
+		// Already terminal-failed/blocked: only attach the synthetic result so
+		// AdvanceJob (which requires a non-nil Result) can drive the parent DAG.
+		if err := mailbox.savePayload(ctx, jobID, payload); err != nil {
+			return false, err
+		}
+	}
+	if err := e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   jobID,
+		Kind:    "delegation_timeout_finalized",
+		Message: reason,
+	}); err != nil {
+		return false, err
+	}
+	if err := e.AdvanceJob(ctx, jobID); err != nil {
+		return true, err
+	}
+	if err := e.Store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: "advance_completed", Message: "workflow advancement completed"}); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
 func (e Engine) refreshJobPayload(ctx context.Context, jobID string) error {
 	job, payload, err := e.jobPayload(ctx, jobID)
 	if err != nil {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -740,6 +740,13 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 		if err != nil {
 			return err
 		}
+		// Re-read events too: a delegation deduped during this pass emits a new
+		// delegation_deduped event, and dedupedDelegationWinners derives the
+		// deduped set from events. Reusing the stale snapshot would hide it.
+		parentEvents, err = e.Store.ListJobEvents(ctx, parentJob.ID)
+		if err != nil {
+			return err
+		}
 		dedupWinners = dedupedDelegationWinners(parentResult.Delegations, children, parentEvents)
 	}
 
@@ -796,9 +803,16 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 			if err := e.enqueueDelegation(ctx, parentJob, parentPayload, d, artifactDir, ref); err != nil {
 				return err
 			}
-			// Re-read children so a second satisfied dependent in the same pass
-			// is not mistaken for still-pending.
+			// Re-read children AND events so a second satisfied dependent in the
+			// same pass is not mistaken for still-pending, and a delegation
+			// deduped by the enqueueDelegation call above (which emits a fresh
+			// delegation_deduped event) is observed by the final
+			// allDelegationsResolved check below rather than stalling forever.
 			children, err = e.childDelegationJobs(ctx, parentJob.ID)
+			if err != nil {
+				return err
+			}
+			parentEvents, err = e.Store.ListJobEvents(ctx, parentJob.ID)
 			if err != nil {
 				return err
 			}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2517,6 +2517,65 @@ func TestEngineDelegationDeferredDedupResolvesContinuation(t *testing.T) {
 	}
 }
 
+// TestEngineDelegationDepthCapStopsDispatch covers the runaway-recursion safety
+// net surfaced by the live E2E smoke: a coordinator whose continuation
+// re-delegates (e.g. a static shell agent) would otherwise spawn jobs forever
+// because the continuation reused the parent's depth. At/over MaxDelegationDepth
+// dispatch is refused with a delegation_depth_exceeded event; just under it,
+// dispatch still proceeds.
+func TestEngineDelegationDepthCapStopsDispatch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	result := func() *AgentResult {
+		return &AgentResult{
+			Decision:    "approved",
+			Summary:     "delegating",
+			Delegations: []Delegation{{ID: "w1", Agent: "w", Action: "ask", Prompt: "do work"}},
+		}
+	}
+
+	// At the cap: dispatch is refused and a delegation_depth_exceeded event fires.
+	insertCompletedJob(t, store, db.Job{ID: "deep-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", Sender: "coord",
+		DelegationDepth: MaxDelegationDepth, Result: result(),
+	})
+	if err := engine.AdvanceJob(ctx, "deep-job"); err != nil {
+		t.Fatalf("AdvanceJob(deep): %v", err)
+	}
+	if jobExists(t, store, "deep-job/delegation/w1") {
+		t.Fatal("delegation must NOT be dispatched at the depth cap")
+	}
+	events, err := store.ListJobEvents(ctx, "deep-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	capped := false
+	for _, ev := range events {
+		if ev.Kind == "delegation_depth_exceeded" {
+			capped = true
+		}
+	}
+	if !capped {
+		t.Fatal("expected a delegation_depth_exceeded event at the cap")
+	}
+
+	// Just under the cap: dispatch still proceeds.
+	insertCompletedJob(t, store, db.Job{ID: "shallow-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", Sender: "coord",
+		DelegationDepth: MaxDelegationDepth - 1, Result: result(),
+	})
+	if err := engine.AdvanceJob(ctx, "shallow-job"); err != nil {
+		t.Fatalf("AdvanceJob(shallow): %v", err)
+	}
+	if !jobExists(t, store, "shallow-job/delegation/w1") {
+		t.Fatal("delegation just under the depth cap must still dispatch")
+	}
+}
+
 // TestEngineDelegationEscalateThenBlockParentFoldsIntoContinuation pins the
 // contradictory-state fix: once an escalate failure has enqueued the
 // continuation, a later block_parent sibling failure must NOT also block the

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -218,6 +218,185 @@ func TestDispatchDelegationsTwoImplementSiblingsGetSeparateWorktrees(t *testing.
 	if len(manager.calls) != 2 {
 		t.Fatalf("AddWorktree calls = %+v, want two", manager.calls)
 	}
+	// Each child's HeadSHA is cleared so validateTargetCheckout validates the
+	// fresh worktree HEAD instead of the stale parent SHA.
+	if payloadOne.HeadSHA != "" || payloadTwo.HeadSHA != "" {
+		t.Fatalf("delegated implement children must not inherit parent HeadSHA: d1=%q d2=%q", payloadOne.HeadSHA, payloadTwo.HeadSHA)
+	}
+}
+
+func TestDispatchDelegationsSiblingsSharingWorktreeHintGetDistinctBranches(t *testing.T) {
+	// Two sibling implement delegations that share an identical worktree hint must
+	// still receive distinct, namespaced branches so the second AddWorktree does
+	// not collide on a branch already checked out by the first.
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "builder-a", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "builder-b", []string{"implement"}, "jerryfane/gitmoot")
+	home := t.TempDir()
+	manager := &fakeWorktreeManager{}
+	engine := testEngine(store)
+	engine.Home = home
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "audit", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "audit",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "d1", Agent: "builder-a", Action: "implement", Prompt: "build one", Worktree: "shared"},
+				{ID: "d2", Agent: "builder-b", Action: "implement", Prompt: "build two", Worktree: "shared"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	payloadOne, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/d1").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(d1) returned error: %v", err)
+	}
+	payloadTwo, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/d2").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(d2) returned error: %v", err)
+	}
+	if payloadOne.Branch == payloadTwo.Branch {
+		t.Fatalf("siblings sharing worktree hint share branch %q", payloadOne.Branch)
+	}
+	if len(manager.calls) != 2 {
+		t.Fatalf("AddWorktree calls = %+v, want two distinct allocations", manager.calls)
+	}
+	if manager.calls[0].branch == manager.calls[1].branch {
+		t.Fatalf("AddWorktree branches collide: %+v", manager.calls)
+	}
+}
+
+func TestDispatchDelegationsWithoutWorktreeManagerEmitsSkippedEvent(t *testing.T) {
+	// When the engine has no per-delegation worktree manager, an implement
+	// delegation falls back to a shared-checkout branch lock; the loss of
+	// isolation must be observable via a delegation_worktree_skipped event.
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "builder", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	// No engine.Home / engine.DelegationWorktrees: isolation unavailable.
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "audit", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "audit",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "d1", Agent: "builder", Action: "implement", Prompt: "build one"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	child := mustJob(t, store, "parent-job/delegation/d1")
+	payload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	// The fallback child runs in the shared checkout on the parent branch with no
+	// per-delegation worktree path.
+	if strings.TrimSpace(payload.WorktreePath) != "" {
+		t.Fatalf("fallback child unexpectedly got worktree path %q", payload.WorktreePath)
+	}
+	if payload.Branch != "task-005" {
+		t.Fatalf("fallback child branch = %q, want parent branch task-005", payload.Branch)
+	}
+	if got := countJobEvents(t, store, "parent-job", "delegation_worktree_skipped"); got != 1 {
+		t.Fatalf("delegation_worktree_skipped event count = %d, want 1", got)
+	}
+}
+
+func TestEngineDelegationRetryGetsIsolatedWorktreePathAndBranch(t *testing.T) {
+	// A retry of a failed implement delegation must allocate a fresh, isolated
+	// worktree path and branch (retry-suffixed) so it never collides with the
+	// failed original attempt's leftover worktree directory and checked-out branch.
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "builder", []string{"implement"}, "jerryfane/gitmoot")
+	home := t.TempDir()
+	manager := &fakeWorktreeManager{}
+	engine := testEngine(store)
+	engine.Home = home
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "build", Agent: "builder", Action: "implement", Prompt: "build it", Retry: 1},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	originalPayload, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/build").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(original) returned error: %v", err)
+	}
+
+	// Fail the original attempt and advance the parent so a retry is enqueued.
+	completeDelegationChild(t, store, "parent-job/delegation/build", JobFailed, AgentResult{Decision: "failed", Summary: "broke"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/build"); err != nil {
+		t.Fatalf("AdvanceJob(build) returned error: %v", err)
+	}
+
+	retry := mustJob(t, store, "parent-job/delegation/build/retry/1")
+	retryPayload, err := unmarshalPayload(retry.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(retry) returned error: %v", err)
+	}
+	if retryPayload.WorktreePath == originalPayload.WorktreePath {
+		t.Fatalf("retry reuses original worktree path %q", retryPayload.WorktreePath)
+	}
+	if retryPayload.Branch == originalPayload.Branch {
+		t.Fatalf("retry reuses original branch %q", retryPayload.Branch)
+	}
+	wantRetryPath := filepath.Join(home, "worktrees", "jerryfane--gitmoot", "delegations", "parent-job", "build", "retry", "1")
+	if retryPayload.WorktreePath != wantRetryPath {
+		t.Fatalf("retry worktree path = %q, want %q", retryPayload.WorktreePath, wantRetryPath)
+	}
+	if !strings.HasSuffix(retryPayload.Branch, "-retry-1") {
+		t.Fatalf("retry branch = %q, want -retry-1 suffix", retryPayload.Branch)
+	}
+	// Two distinct git worktrees were added: the original and the isolated retry.
+	if len(manager.calls) != 2 {
+		t.Fatalf("AddWorktree calls = %+v, want two (original + retry)", manager.calls)
+	}
+	if manager.calls[0].path == manager.calls[1].path || manager.calls[0].branch == manager.calls[1].branch {
+		t.Fatalf("retry allocation collides with original: %+v", manager.calls)
+	}
 }
 
 func TestEngineHandlePullRequestOpenedDispatchesReviewers(t *testing.T) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -1888,6 +1889,12 @@ func TestEngineDelegationFailurePolicyContinue(t *testing.T) {
 	if jobExists(t, store, "parent-job/delegation/integrate") {
 		t.Fatalf("integrate must remain gated out after dep failure under continue")
 	}
+	// Once the continue-gated batch resolves (api failed under continue, ui
+	// succeeded, integrate permanently gated), the coordinator continuation must
+	// be enqueued so the batch does not stall.
+	if !jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatalf("continuation must be enqueued once the continue-gated batch resolves")
+	}
 }
 
 func TestEngineDelegationFailurePolicyEscalate(t *testing.T) {
@@ -2187,6 +2194,283 @@ func TestEngineDelegationFingerprintScopedPerParent(t *testing.T) {
 	}
 	if delegationFingerprintKey("parent-a", "shared-fp") == delegationFingerprintKey("parent-b", "shared-fp") {
 		t.Fatal("fingerprint key must differ per parent")
+	}
+}
+
+// TestEngineDelegationDedupedResolvesContinuationAndDependent pins the critical
+// liveness fix: a fingerprint-deduped delegation has no child of its own, yet it
+// must resolve against its winning sibling so the coordinator continuation is
+// enqueued and a dependent of the deduped node still runs once the winner
+// succeeds. Before the fix the deduped node was treated as forever-active and the
+// continuation never fired.
+func TestEngineDelegationDedupedResolvesContinuationAndDependent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "synth", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", Fingerprint: "shared-fp"},
+				{ID: "dup", Agent: "ui", Action: "review", Prompt: "build api again", Fingerprint: "shared-fp"},
+				{ID: "synth", Agent: "synth", Action: "review", Prompt: "synthesize", Deps: []string{"dup"}},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	// api wins the fingerprint; dup is deduped (no child) and synth is gated.
+	if !jobExists(t, store, "parent-job/delegation/api") {
+		t.Fatal("api child should be enqueued")
+	}
+	if jobExists(t, store, "parent-job/delegation/dup") {
+		t.Fatal("dup must be deduped and never get a child")
+	}
+	if jobExists(t, store, "parent-job/delegation/synth") {
+		t.Fatal("synth depends on the deduped dup and must wait for the winner")
+	}
+
+	// The winning sibling succeeds: the deduped dup resolves against it, so the
+	// dependent of the deduped node enqueues and the continuation fires.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobSucceeded, AgentResult{Decision: "approved", Summary: "api ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	if !jobExists(t, store, "parent-job/delegation/synth") {
+		t.Fatal("dependent of the deduped node must enqueue once the winner succeeds")
+	}
+	// synth has not finished, so the continuation is still gated on it.
+	if jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("continuation must wait for the dependent of the deduped node")
+	}
+
+	completeDelegationChild(t, store, "parent-job/delegation/synth", JobSucceeded, AgentResult{Decision: "approved", Summary: "synth ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/synth"); err != nil {
+		t.Fatalf("AdvanceJob(synth) returned error: %v", err)
+	}
+	if !jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("continuation must be enqueued once the deduped node and its dependent resolve")
+	}
+}
+
+// TestEngineDelegationEscalateThenBlockParentFoldsIntoContinuation pins the
+// contradictory-state fix: once an escalate failure has enqueued the
+// continuation, a later block_parent sibling failure must NOT also block the
+// shared parent task; the block folds into the already-enqueued continuation.
+func TestEngineDelegationEscalateThenBlockParentFoldsIntoContinuation(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", FailurePolicy: "escalate"},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui", FailurePolicy: "block_parent"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	// api fails under escalate: the continuation is enqueued immediately.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobFailed, AgentResult{Decision: "failed", Summary: "api broke"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	if !jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("escalate must enqueue the continuation immediately")
+	}
+
+	// ui then fails under block_parent: because a continuation is already in
+	// flight, the parent task must NOT be blocked (that would contradict the
+	// continuation). AdvanceJob must not return a BlockedError.
+	completeDelegationChild(t, store, "parent-job/delegation/ui", JobFailed, AgentResult{Decision: "failed", Summary: "ui broke"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/ui"); err != nil {
+		var blocked BlockedError
+		if errors.As(err, &blocked) {
+			t.Fatalf("block_parent must not block the parent after a continuation was enqueued: %v", err)
+		}
+		t.Fatalf("AdvanceJob(ui) returned error: %v", err)
+	}
+	if state, _ := store.GetTask(ctx, "task-5"); state.State == string(TaskBlocked) {
+		t.Fatal("parent task must not be blocked once a continuation has been enqueued")
+	}
+}
+
+// TestEngineDelegationTransitiveChainGatesAndContinues exercises a 3-level
+// transitive dependency chain a -> b(deps a) -> c(deps b): b gates until a
+// succeeds, c gates until b succeeds, and the continuation fires only after c
+// terminates. This is the most fragile gating path (a deferred dependent that is
+// itself the dep of another deferred dependent) and was previously untested.
+func TestEngineDelegationTransitiveChainGatesAndContinues(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "wa", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "wb", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "wc", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "a", Agent: "wa", Action: "review", Prompt: "step a"},
+				{ID: "b", Agent: "wb", Action: "review", Prompt: "step b", Deps: []string{"a"}},
+				{ID: "c", Agent: "wc", Action: "review", Prompt: "step c", Deps: []string{"b"}},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	// Only a is enqueued; b and c are both gated.
+	if !jobExists(t, store, "parent-job/delegation/a") {
+		t.Fatal("a should be enqueued immediately")
+	}
+	if jobExists(t, store, "parent-job/delegation/b") {
+		t.Fatal("b must gate until a succeeds")
+	}
+	if jobExists(t, store, "parent-job/delegation/c") {
+		t.Fatal("c must gate until b succeeds")
+	}
+
+	// a succeeds: b enqueues, c is still gated on b.
+	completeDelegationChild(t, store, "parent-job/delegation/a", JobSucceeded, AgentResult{Decision: "approved", Summary: "a ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/a"); err != nil {
+		t.Fatalf("AdvanceJob(a) returned error: %v", err)
+	}
+	if !jobExists(t, store, "parent-job/delegation/b") {
+		t.Fatal("b must enqueue once a succeeds")
+	}
+	if jobExists(t, store, "parent-job/delegation/c") {
+		t.Fatal("c must still gate until b succeeds")
+	}
+	if jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("continuation must not fire while the chain is in flight")
+	}
+
+	// b succeeds: c enqueues, continuation still gated on c.
+	completeDelegationChild(t, store, "parent-job/delegation/b", JobSucceeded, AgentResult{Decision: "approved", Summary: "b ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/b"); err != nil {
+		t.Fatalf("AdvanceJob(b) returned error: %v", err)
+	}
+	if !jobExists(t, store, "parent-job/delegation/c") {
+		t.Fatal("c must enqueue once b succeeds")
+	}
+	if jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("continuation must not fire until c terminates")
+	}
+
+	// c terminates: continuation fires.
+	completeDelegationChild(t, store, "parent-job/delegation/c", JobSucceeded, AgentResult{Decision: "approved", Summary: "c ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/c"); err != nil {
+		t.Fatalf("AdvanceJob(c) returned error: %v", err)
+	}
+	if !jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("continuation must fire after the full chain terminates")
+	}
+}
+
+// TestEngineAdvanceDelegationsConcurrentContinuationExactlyOnce drives the real
+// concurrency the daemon exposes with --workers>1: both leaf children finish and
+// AdvanceJob is called for each in parallel goroutines. Exactly one continuation
+// job must exist and neither AdvanceJob may error. Run with -race.
+func TestEngineAdvanceDelegationsConcurrentContinuationExactlyOnce(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	// Both leaf children finish before either is advanced, so both parallel
+	// AdvanceJob passes observe an all-terminal batch and race to enqueue.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobSucceeded, AgentResult{Decision: "approved", Summary: "api ok"})
+	completeDelegationChild(t, store, "parent-job/delegation/ui", JobSucceeded, AgentResult{Decision: "approved", Summary: "ui ok"})
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i, childID := range []string{"parent-job/delegation/api", "parent-job/delegation/ui"} {
+		wg.Add(1)
+		go func(idx int, id string) {
+			defer wg.Done()
+			errs[idx] = engine.AdvanceJob(ctx, id)
+		}(i, childID)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent AdvanceJob[%d] returned error: %v", i, err)
+		}
+	}
+
+	continuationCount := 0
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.ID == delegationContinuationID("parent-job") {
+			continuationCount++
+		}
+	}
+	if continuationCount != 1 {
+		t.Fatalf("continuation job count = %d, want exactly 1", continuationCount)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -63,6 +63,72 @@ func TestEngineAdvanceJobDispatchesDelegations(t *testing.T) {
 	}
 }
 
+func TestDispatchDelegationsTwoImplementSiblingsGetSeparateWorktrees(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "builder-a", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "builder-b", []string{"implement"}, "jerryfane/gitmoot")
+	home := t.TempDir()
+	manager := &fakeWorktreeManager{}
+	engine := testEngine(store)
+	engine.Home = home
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "audit", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "audit",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "d1", Agent: "builder-a", Action: "implement", Prompt: "build one"},
+				{ID: "d2", Agent: "builder-b", Action: "implement", Prompt: "build two"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	childOne := mustJob(t, store, "parent-job/delegation/d1")
+	childTwo := mustJob(t, store, "parent-job/delegation/d2")
+	payloadOne, err := unmarshalPayload(childOne.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(d1) returned error: %v", err)
+	}
+	payloadTwo, err := unmarshalPayload(childTwo.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(d2) returned error: %v", err)
+	}
+
+	wantPathOne := filepath.Join(home, "worktrees", "jerryfane--gitmoot", "delegations", "parent-job", "d1")
+	wantPathTwo := filepath.Join(home, "worktrees", "jerryfane--gitmoot", "delegations", "parent-job", "d2")
+	if payloadOne.WorktreePath != wantPathOne {
+		t.Fatalf("d1 worktree path = %q, want %q", payloadOne.WorktreePath, wantPathOne)
+	}
+	if payloadTwo.WorktreePath != wantPathTwo {
+		t.Fatalf("d2 worktree path = %q, want %q", payloadTwo.WorktreePath, wantPathTwo)
+	}
+	if payloadOne.WorktreePath == payloadTwo.WorktreePath {
+		t.Fatalf("siblings share worktree path %q", payloadOne.WorktreePath)
+	}
+	if payloadOne.Branch == payloadTwo.Branch {
+		t.Fatalf("siblings share branch %q", payloadOne.Branch)
+	}
+	if payloadOne.Branch == "task-005" || payloadTwo.Branch == "task-005" {
+		t.Fatalf("delegation branch not overridden: d1=%q d2=%q", payloadOne.Branch, payloadTwo.Branch)
+	}
+	if len(manager.calls) != 2 {
+		t.Fatalf("AddWorktree calls = %+v, want two", manager.calls)
+	}
+}
+
 func TestEngineHandlePullRequestOpenedDispatchesReviewers(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -1348,9 +1414,6 @@ func TestEngineAdvanceBlocksOnAgentBlockedResult(t *testing.T) {
 	}
 	assertTaskState(t, store, "task-7", TaskBlocked)
 }
-
-
-
 
 func TestEngineSetTaskStatePreservesExistingMetadata(t *testing.T) {
 	ctx := context.Background()

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
@@ -1605,6 +1606,359 @@ func mustJob(t *testing.T, store *db.Store, jobID string) db.Job {
 		t.Fatalf("GetJob(%s) returned error: %v", jobID, err)
 	}
 	return job
+}
+
+// completeDelegationChild transitions a queued delegation child to a terminal
+// state and stamps a Result into its payload, mirroring what Mailbox.Run does
+// when a child finishes, so the engine's advanceDelegations can observe it.
+func completeDelegationChild(t *testing.T, store *db.Store, childID string, state JobState, result AgentResult) {
+	t.Helper()
+	ctx := context.Background()
+	job, err := store.GetJob(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetJob(%s) returned error: %v", childID, err)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(%s) returned error: %v", childID, err)
+	}
+	payload.Result = &result
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload(%s) returned error: %v", childID, err)
+	}
+	if err := store.UpdateJobPayload(ctx, childID, encoded); err != nil {
+		t.Fatalf("UpdateJobPayload(%s) returned error: %v", childID, err)
+	}
+	if err := store.UpdateJobState(ctx, childID, string(state)); err != nil {
+		t.Fatalf("UpdateJobState(%s) returned error: %v", childID, err)
+	}
+}
+
+func jobExists(t *testing.T, store *db.Store, jobID string) bool {
+	t.Helper()
+	_, err := store.GetJob(context.Background(), jobID)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false
+	}
+	t.Fatalf("GetJob(%s) returned error: %v", jobID, err)
+	return false
+}
+
+func TestEngineAdvanceDelegationsGatesOnDeps(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "integ", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
+				{ID: "integrate", Agent: "integ", Action: "review", Prompt: "integrate", Deps: []string{"api", "ui"}},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	// Only the dependency-free delegations are enqueued initially.
+	if !jobExists(t, store, "parent-job/delegation/api") {
+		t.Fatalf("api child should be enqueued")
+	}
+	if !jobExists(t, store, "parent-job/delegation/ui") {
+		t.Fatalf("ui child should be enqueued")
+	}
+	if jobExists(t, store, "parent-job/delegation/integrate") {
+		t.Fatalf("integrate child must not be enqueued before deps succeed")
+	}
+
+	// First dep succeeds: integrate is still gated on ui.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobSucceeded, AgentResult{Decision: "approved", Summary: "api ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	if jobExists(t, store, "parent-job/delegation/integrate") {
+		t.Fatalf("integrate child must not be enqueued until all deps succeed")
+	}
+
+	// Second dep succeeds: integrate is now enqueued with correct metadata.
+	completeDelegationChild(t, store, "parent-job/delegation/ui", JobSucceeded, AgentResult{Decision: "approved", Summary: "ui ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/ui"); err != nil {
+		t.Fatalf("AdvanceJob(ui) returned error: %v", err)
+	}
+	integrate := mustJob(t, store, "parent-job/delegation/integrate")
+	if integrate.Agent != "integ" || integrate.Type != "review" || integrate.State != string(JobQueued) {
+		t.Fatalf("integrate child = %+v", integrate)
+	}
+	if integrate.ParentJobID != "parent-job" || integrate.DelegationID != "integrate" || integrate.DelegationDepth != 1 {
+		t.Fatalf("integrate child metadata = %+v", integrate)
+	}
+	payload, err := unmarshalPayload(integrate.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(integrate) returned error: %v", err)
+	}
+	if len(payload.Deps) != 2 || payload.Deps[0] != "api" || payload.Deps[1] != "ui" {
+		t.Fatalf("integrate child deps = %v", payload.Deps)
+	}
+}
+
+func TestEngineAdvanceDelegationsEnqueuesContinuationOnce(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	// First child finishes: not all siblings terminal, so no continuation yet.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobSucceeded, AgentResult{Decision: "approved", Summary: "api ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	if jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatalf("continuation must not be enqueued before all siblings finish")
+	}
+
+	// Second child finishes: continuation enqueued exactly once.
+	completeDelegationChild(t, store, "parent-job/delegation/ui", JobSucceeded, AgentResult{Decision: "approved", Summary: "ui ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/ui"); err != nil {
+		t.Fatalf("AdvanceJob(ui) returned error: %v", err)
+	}
+	continuation := mustJob(t, store, delegationContinuationID("parent-job"))
+	if continuation.Agent != "coord" || continuation.Type != "ask" || continuation.ParentJobID != "parent-job" {
+		t.Fatalf("continuation job = %+v", continuation)
+	}
+	if continuation.State != string(JobQueued) {
+		t.Fatalf("continuation state = %q", continuation.State)
+	}
+
+	// Re-advancing another finished child must not create a duplicate.
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("second AdvanceJob(api) returned error: %v", err)
+	}
+	children, err := engine.childDelegationJobs(ctx, "parent-job")
+	if err != nil {
+		t.Fatalf("childDelegationJobs returned error: %v", err)
+	}
+	if _, ok := children[""]; ok {
+		t.Fatalf("continuation should not appear as a delegation child")
+	}
+	continuationCount := 0
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.ID == delegationContinuationID("parent-job") {
+			continuationCount++
+		}
+	}
+	if continuationCount != 1 {
+		t.Fatalf("continuation job count = %d, want 1", continuationCount)
+	}
+}
+
+func TestEngineDelegationFailurePolicyBlockParent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "integ", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
+				{ID: "integrate", Agent: "integ", Action: "review", Prompt: "integrate", Deps: []string{"api"}},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobFailed, AgentResult{Decision: "failed", Summary: "api broke"})
+	err := engine.AdvanceJob(ctx, "parent-job/delegation/api")
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("AdvanceJob(api) error = %v, want BlockedError", err)
+	}
+	assertTaskState(t, store, "task-5", TaskBlocked)
+	if jobExists(t, store, "parent-job/delegation/integrate") {
+		t.Fatalf("dependent integrate child must not be enqueued after dep failed")
+	}
+}
+
+func TestEngineDelegationFailurePolicyContinue(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "integ", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", FailurePolicy: "continue"},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
+				{ID: "integrate", Agent: "integ", Action: "review", Prompt: "integrate", Deps: []string{"api"}},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	// api fails under a continue policy: the parent is not blocked and the
+	// independent ui sibling keeps running.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobFailed, AgentResult{Decision: "failed", Summary: "api broke"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	if state, _ := store.GetTask(ctx, "task-5"); state.State == string(TaskBlocked) {
+		t.Fatalf("continue policy must not block the parent task")
+	}
+	// integrate depends on the failed api and must never enqueue.
+	if jobExists(t, store, "parent-job/delegation/integrate") {
+		t.Fatalf("integrate depends on failed api and must not enqueue under continue")
+	}
+
+	// ui still completes; with api terminal-failed and ui succeeded and
+	// integrate gated out, all top-level dels are terminal -> continuation.
+	completeDelegationChild(t, store, "parent-job/delegation/ui", JobSucceeded, AgentResult{Decision: "approved", Summary: "ui ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/ui"); err != nil {
+		t.Fatalf("AdvanceJob(ui) returned error: %v", err)
+	}
+	if jobExists(t, store, "parent-job/delegation/integrate") {
+		t.Fatalf("integrate must remain gated out after dep failure under continue")
+	}
+}
+
+func TestEngineDelegationFailurePolicyEscalate(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", FailurePolicy: "escalate"},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	// api fails under escalate: a continuation job is enqueued immediately,
+	// without waiting for the ui sibling, and the parent is not blocked.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobFailed, AgentResult{Decision: "failed", Summary: "api broke"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	if !jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatalf("escalate must enqueue the continuation immediately")
+	}
+	if state, _ := store.GetTask(ctx, "task-5"); state.State == string(TaskBlocked) {
+		t.Fatalf("escalate policy must not block the parent task")
+	}
+}
+
+func TestContinuationPromptInlinesChildResults(t *testing.T) {
+	dels := []Delegation{
+		{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
+		{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
+	}
+	children := map[string]db.Job{
+		"api": {ID: "parent-job/delegation/api", Agent: "api", State: string(JobSucceeded)},
+		"ui":  {ID: "parent-job/delegation/ui", Agent: "ui", State: string(JobSucceeded)},
+	}
+	childPayloads := map[string]JobPayload{
+		"api": {Repo: "jerryfane/gitmoot", PullRequest: 12, Result: &AgentResult{Decision: "implemented", Summary: "api built"}},
+		"ui":  {Result: &AgentResult{Decision: "approved", Summary: "ui built"}},
+	}
+	prompt := buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	for _, want := range []string{
+		"parent-job/delegation/api",
+		"parent-job/delegation/ui",
+		"api built",
+		"ui built",
+		"implemented",
+		"approved",
+		"https://github.com/jerryfane/gitmoot/pull/12",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("continuation prompt missing %q\n%s", want, prompt)
+		}
+	}
 }
 
 type fakeImplementationFinalizer struct {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2445,6 +2445,78 @@ func TestEngineDelegationDedupedResolvesContinuationAndDependent(t *testing.T) {
 	}
 }
 
+// TestEngineDelegationDeferredDedupResolvesContinuation covers the narrower
+// deferred-dedup ordering: two same-fingerprint delegations are BOTH deferred
+// behind different deps, so the loser is deduped lazily inside the same
+// advanceDelegations pass that clears its dep. Before re-reading events at the
+// recompute points, the just-deduped delegation was invisible to
+// allDelegationsResolved and the coordinator continuation stalled forever (no
+// child ever re-triggers the parent). This asserts it now resolves in that pass.
+func TestEngineDelegationDeferredDedupResolvesContinuation(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "g1", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "g2", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "a", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "b", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "g1", Agent: "g1", Action: "review", Prompt: "gate 1"},
+				{ID: "g2", Agent: "g2", Action: "review", Prompt: "gate 2"},
+				{ID: "a", Agent: "a", Action: "review", Prompt: "shared work", Deps: []string{"g1"}, Fingerprint: "shared-fp"},
+				{ID: "b", Agent: "b", Action: "review", Prompt: "shared work dup", Deps: []string{"g2"}, Fingerprint: "shared-fp"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent): %v", err)
+	}
+	if !jobExists(t, store, "parent-job/delegation/g1") || !jobExists(t, store, "parent-job/delegation/g2") {
+		t.Fatal("both dep-free gates should be enqueued")
+	}
+	if jobExists(t, store, "parent-job/delegation/a") || jobExists(t, store, "parent-job/delegation/b") {
+		t.Fatal("a and b are deferred behind their deps and must not enqueue yet")
+	}
+
+	// g1 succeeds first: a (the fingerprint winner) enqueues and succeeds.
+	completeDelegationChild(t, store, "parent-job/delegation/g1", JobSucceeded, AgentResult{Decision: "approved", Summary: "g1 ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/g1"); err != nil {
+		t.Fatalf("AdvanceJob(g1): %v", err)
+	}
+	if !jobExists(t, store, "parent-job/delegation/a") {
+		t.Fatal("a should enqueue once g1 succeeds")
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/a", JobSucceeded, AgentResult{Decision: "approved", Summary: "a ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/a"); err != nil {
+		t.Fatalf("AdvanceJob(a): %v", err)
+	}
+
+	// g2 succeeds LAST: b's dep clears and b is deduped against a in this same
+	// pass. The continuation must still fire.
+	completeDelegationChild(t, store, "parent-job/delegation/g2", JobSucceeded, AgentResult{Decision: "approved", Summary: "g2 ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/g2"); err != nil {
+		t.Fatalf("AdvanceJob(g2): %v", err)
+	}
+	if jobExists(t, store, "parent-job/delegation/b") {
+		t.Fatal("b shares a's fingerprint and must be deduped (no child)")
+	}
+	if !jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("continuation must enqueue in the same pass that deferred-dedups b against its winner")
+	}
+}
+
 // TestEngineDelegationEscalateThenBlockParentFoldsIntoContinuation pins the
 // contradictory-state fix: once an escalate failure has enqueued the
 // continuation, a later block_parent sibling failure must NOT also block the

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1961,6 +1961,325 @@ func TestContinuationPromptInlinesChildResults(t *testing.T) {
 	}
 }
 
+func countJobEvents(t *testing.T, store *db.Store, jobID, kind string) int {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s) returned error: %v", jobID, err)
+	}
+	count := 0
+	for _, event := range events {
+		if event.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func TestEngineDelegationTimeoutPlumbedToChildPayload(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "helper", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "audit", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "audit",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "del-1", Agent: "helper", Action: "review", Prompt: "review this", Timeout: "30s"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	child := mustJob(t, store, "parent-job/delegation/del-1")
+	payload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.JobTimeout != "30s" {
+		t.Fatalf("child JobTimeout = %q, want %q", payload.JobTimeout, "30s")
+	}
+}
+
+func TestEngineDelegationInvalidLifecycleRejectedAtExtraction(t *testing.T) {
+	// Each invalid lifecycle control must be rejected when the agent result is
+	// extracted, so a malformed delegation never reaches the dispatcher.
+	cases := map[string]string{
+		"timeout":        `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"d","agent":"a","action":"review","prompt":"go","timeout":"banana"}]}}`,
+		"negative retry": `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"d","agent":"a","action":"review","prompt":"go","retry":-1}]}}`,
+		"failure_policy": `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"d","agent":"a","action":"review","prompt":"go","failure_policy":"explode"}]}}`,
+		"synthesis_rule": `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"d","agent":"a","action":"review","prompt":"go","synthesis_rule":"coinflip"}]}}`,
+	}
+	for name, output := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ExtractAgentResult(output); err == nil {
+				t.Fatalf("ExtractAgentResult accepted invalid %s", name)
+			}
+		})
+	}
+
+	// Valid lifecycle controls pass validation.
+	if err := validateDelegationLifecycle(Delegation{ID: "d", Timeout: "30s", Retry: 2, FailurePolicy: "continue", SynthesisRule: "vote"}); err != nil {
+		t.Fatalf("validateDelegationLifecycle rejected valid controls: %v", err)
+	}
+}
+
+func TestEngineDelegationRetryReenqueuesUntilExhausted(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", Retry: 2},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	// First failure: retry 1 is enqueued; the parent is not blocked.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobFailed, AgentResult{Decision: "failed", Summary: "api broke"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	retry1 := mustJob(t, store, "parent-job/delegation/api/retry/1")
+	if retry1.State != string(JobQueued) || retry1.DelegationID != "api" {
+		t.Fatalf("retry/1 = %+v", retry1)
+	}
+	retry1Payload, err := unmarshalPayload(retry1.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(retry/1) returned error: %v", err)
+	}
+	if retry1Payload.RetryCount != 1 {
+		t.Fatalf("retry/1 RetryCount = %d, want 1", retry1Payload.RetryCount)
+	}
+	if state, _ := store.GetTask(ctx, "task-5"); state.State == string(TaskBlocked) {
+		t.Fatalf("parent must not be blocked while retries remain")
+	}
+
+	// Second failure: retry 2 is enqueued.
+	completeDelegationChild(t, store, "parent-job/delegation/api/retry/1", JobFailed, AgentResult{Decision: "failed", Summary: "still broke"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api/retry/1"); err != nil {
+		t.Fatalf("AdvanceJob(retry/1) returned error: %v", err)
+	}
+	retry2 := mustJob(t, store, "parent-job/delegation/api/retry/2")
+	retry2Payload, err := unmarshalPayload(retry2.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(retry/2) returned error: %v", err)
+	}
+	if retry2Payload.RetryCount != 2 {
+		t.Fatalf("retry/2 RetryCount = %d, want 2", retry2Payload.RetryCount)
+	}
+
+	// Third failure: retry budget exhausted (RetryCount 2 == Retry 2). No retry/3
+	// is enqueued and the default block_parent policy blocks the parent.
+	completeDelegationChild(t, store, "parent-job/delegation/api/retry/2", JobFailed, AgentResult{Decision: "failed", Summary: "broke again"})
+	err = engine.AdvanceJob(ctx, "parent-job/delegation/api/retry/2")
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("AdvanceJob(retry/2) error = %v, want BlockedError after retries exhausted", err)
+	}
+	if jobExists(t, store, "parent-job/delegation/api/retry/3") {
+		t.Fatal("retry/3 must not be enqueued after the retry budget is exhausted")
+	}
+	if got := countJobEvents(t, store, "parent-job", "delegation_retry"); got != 2 {
+		t.Fatalf("delegation_retry event count = %d, want 2", got)
+	}
+	assertTaskState(t, store, "task-5", TaskBlocked)
+}
+
+func TestEngineDelegationFingerprintDedup(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", Fingerprint: "shared-fp"},
+				{ID: "dup", Agent: "ui", Action: "review", Prompt: "build api again", Fingerprint: "shared-fp"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	if !jobExists(t, store, "parent-job/delegation/api") {
+		t.Fatal("first delegation with the fingerprint must be enqueued")
+	}
+	if jobExists(t, store, "parent-job/delegation/dup") {
+		t.Fatal("second delegation with the same fingerprint must be deduped")
+	}
+	if got := countJobEvents(t, store, "parent-job", "delegation_deduped"); got != 1 {
+		t.Fatalf("delegation_deduped event count = %d, want 1", got)
+	}
+}
+
+func TestEngineDelegationFingerprintScopedPerParent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	for _, parent := range []string{"parent-a", "parent-b"} {
+		insertCompletedJob(t, store, db.Job{ID: parent, Agent: "coord", Type: "ask"}, JobPayload{
+			Repo:      "jerryfane/gitmoot",
+			Branch:    "task-005",
+			TaskID:    "task-5",
+			TaskTitle: "Parent",
+			Sender:    "coord",
+			Result: &AgentResult{
+				Decision: "approved",
+				Summary:  "done",
+				Delegations: []Delegation{
+					{ID: "api", Agent: "api", Action: "review", Prompt: "build api", Fingerprint: "shared-fp"},
+				},
+			},
+		})
+		if err := engine.AdvanceJob(ctx, parent); err != nil {
+			t.Fatalf("AdvanceJob(%s) returned error: %v", parent, err)
+		}
+	}
+
+	// The same fingerprint under a different parent must NOT be deduped.
+	if !jobExists(t, store, "parent-a/delegation/api") {
+		t.Fatal("parent-a child must be enqueued")
+	}
+	if !jobExists(t, store, "parent-b/delegation/api") {
+		t.Fatal("parent-b child must be enqueued; fingerprint dedup is scoped per parent")
+	}
+	if delegationFingerprintKey("parent-a", "shared-fp") == delegationFingerprintKey("parent-b", "shared-fp") {
+		t.Fatal("fingerprint key must differ per parent")
+	}
+}
+
+func TestEngineDelegationSynthesisRuleVoteBlocksOnFailure(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", FailurePolicy: "continue", SynthesisRule: "vote"},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui", FailurePolicy: "continue", SynthesisRule: "vote"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	// api succeeds, ui fails: the vote is not unanimous, so the continuation is
+	// gated and the parent task is blocked instead of being enqueued.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobSucceeded, AgentResult{Decision: "approved", Summary: "api ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/ui", JobFailed, AgentResult{Decision: "failed", Summary: "ui broke"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/ui"); err != nil {
+		var blocked BlockedError
+		if !errors.As(err, &blocked) {
+			t.Fatalf("AdvanceJob(ui) error = %v, want BlockedError from vote", err)
+		}
+	}
+	if jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("vote failure must not enqueue the continuation")
+	}
+	assertTaskState(t, store, "task-5", TaskBlocked)
+}
+
+func TestEngineDelegationSynthesisRuleVotePassesWhenAllApproved(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", SynthesisRule: "vote"},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui", SynthesisRule: "vote"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobSucceeded, AgentResult{Decision: "approved", Summary: "api ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/ui", JobSucceeded, AgentResult{Decision: "approved", Summary: "ui ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/ui"); err != nil {
+		t.Fatalf("AdvanceJob(ui) returned error: %v", err)
+	}
+	if !jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("a unanimous vote must enqueue the continuation")
+	}
+	if state, _ := store.GetTask(ctx, "task-5"); state.State == string(TaskBlocked) {
+		t.Fatal("a unanimous vote must not block the parent")
+	}
+}
+
 type fakeImplementationFinalizer struct {
 	payload JobPayload
 	err     error

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -60,6 +61,94 @@ func TestEngineAdvanceJobDispatchesDelegations(t *testing.T) {
 	// Idempotent: advancing the same parent again must not duplicate the child.
 	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
 		t.Fatalf("second AdvanceJob returned error: %v", err)
+	}
+}
+
+func TestEngineAdvanceJobWritesDelegationArtifacts(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "helper", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	root := t.TempDir()
+	engine.ArtifactRoot = root
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "audit", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "audit",
+		Result: &AgentResult{
+			Decision:     "approved",
+			Summary:      "done",
+			ArtifactBody: "# Shared brief\n\nDo the work.\n",
+			Delegations: []Delegation{
+				{ID: "del-1", Agent: "helper", Action: "review", Prompt: "review this", Artifacts: []string{"brief.md"}},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	wantDir := filepath.Join(root, "delegations", "parent-job")
+	briefBytes, err := os.ReadFile(filepath.Join(wantDir, "brief.md"))
+	if err != nil {
+		t.Fatalf("read brief.md: %v", err)
+	}
+	if string(briefBytes) != "# Shared brief\n\nDo the work.\n" {
+		t.Fatalf("brief.md = %q", string(briefBytes))
+	}
+	if _, err := os.Stat(filepath.Join(wantDir, "context-manifest.json")); err != nil {
+		t.Fatalf("context-manifest.json missing: %v", err)
+	}
+
+	child := mustJob(t, store, "parent-job/delegation/del-1")
+	payload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.DelegationArtifactDir != wantDir {
+		t.Fatalf("child DelegationArtifactDir = %q, want %q", payload.DelegationArtifactDir, wantDir)
+	}
+}
+
+func TestEngineAdvanceJobSkipsArtifactsWithoutRoot(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "helper", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "audit", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "audit",
+		Result: &AgentResult{
+			Decision:     "approved",
+			Summary:      "done",
+			ArtifactBody: "brief",
+			Delegations: []Delegation{
+				{ID: "del-1", Agent: "helper", Action: "review", Prompt: "review this", Artifacts: []string{"brief.md"}},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	child := mustJob(t, store, "parent-job/delegation/del-1")
+	payload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.DelegationArtifactDir != "" {
+		t.Fatalf("child DelegationArtifactDir = %q, want empty when no artifact root", payload.DelegationArtifactDir)
 	}
 }
 

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -39,6 +39,7 @@ type JobRequest struct {
 	DelegationID     string
 	DelegationDepth  int
 	DelegatedBy      string
+	WorktreePath     string
 	OriginalAgent    string
 	DelegatedAgent   string
 	DelegationReason string
@@ -62,6 +63,7 @@ type JobPayload struct {
 	DelegationID           string       `json:"delegation_id,omitempty"`
 	DelegationDepth        int          `json:"delegation_depth,omitempty"`
 	DelegatedBy            string       `json:"delegated_by,omitempty"`
+	WorktreePath           string       `json:"worktree_path,omitempty"`
 	TemplateID             string       `json:"template_id,omitempty"`
 	TemplateResolvedCommit string       `json:"template_resolved_commit,omitempty"`
 	TemplateContent        string       `json:"template_content,omitempty"`
@@ -107,6 +109,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		DelegationID:           request.DelegationID,
 		DelegationDepth:        request.DelegationDepth,
 		DelegatedBy:            request.DelegatedBy,
+		WorktreePath:           request.WorktreePath,
 		TemplateID:             snapshot.ID,
 		TemplateResolvedCommit: snapshot.ResolvedCommit,
 		TemplateContent:        snapshot.Content,

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -40,6 +40,11 @@ type JobRequest struct {
 	DelegationDepth       int
 	DelegatedBy           string
 	Deps                  []string
+	JobTimeout            string
+	RetryCount            int
+	Fingerprint           string
+	FailurePolicy         string
+	SynthesisRule         string
 	DelegationArtifactDir string
 	WorktreePath          string
 	OriginalAgent         string
@@ -66,6 +71,11 @@ type JobPayload struct {
 	DelegationDepth        int          `json:"delegation_depth,omitempty"`
 	DelegatedBy            string       `json:"delegated_by,omitempty"`
 	Deps                   []string     `json:"deps,omitempty"`
+	JobTimeout             string       `json:"job_timeout,omitempty"`
+	RetryCount             int          `json:"retry_count,omitempty"`
+	Fingerprint            string       `json:"fingerprint,omitempty"`
+	FailurePolicy          string       `json:"failure_policy,omitempty"`
+	SynthesisRule          string       `json:"synthesis_rule,omitempty"`
 	DelegationArtifactDir  string       `json:"delegation_artifact_dir,omitempty"`
 	WorktreePath           string       `json:"worktree_path,omitempty"`
 	TemplateID             string       `json:"template_id,omitempty"`
@@ -114,6 +124,11 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		DelegationDepth:        request.DelegationDepth,
 		DelegatedBy:            request.DelegatedBy,
 		Deps:                   compactStrings(request.Deps),
+		JobTimeout:             strings.TrimSpace(request.JobTimeout),
+		RetryCount:             request.RetryCount,
+		Fingerprint:            strings.TrimSpace(request.Fingerprint),
+		FailurePolicy:          strings.TrimSpace(request.FailurePolicy),
+		SynthesisRule:          strings.TrimSpace(request.SynthesisRule),
 		DelegationArtifactDir:  request.DelegationArtifactDir,
 		WorktreePath:           request.WorktreePath,
 		TemplateID:             snapshot.ID,

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -19,30 +19,31 @@ type Mailbox struct {
 }
 
 type JobRequest struct {
-	ID               string
-	Agent            string
-	Action           string
-	Repo             string
-	Branch           string
-	PullRequest      int
-	HeadSHA          string
-	GoalID           string
-	TaskID           string
-	TaskTitle        string
-	LeadAgent        string
-	Reviewers        []string
-	ReviewRound      string
-	Sender           string
-	Instructions     string
-	Constraints      []string
-	ParentJobID      string
-	DelegationID     string
-	DelegationDepth  int
-	DelegatedBy      string
-	WorktreePath     string
-	OriginalAgent    string
-	DelegatedAgent   string
-	DelegationReason string
+	ID                    string
+	Agent                 string
+	Action                string
+	Repo                  string
+	Branch                string
+	PullRequest           int
+	HeadSHA               string
+	GoalID                string
+	TaskID                string
+	TaskTitle             string
+	LeadAgent             string
+	Reviewers             []string
+	ReviewRound           string
+	Sender                string
+	Instructions          string
+	Constraints           []string
+	ParentJobID           string
+	DelegationID          string
+	DelegationDepth       int
+	DelegatedBy           string
+	DelegationArtifactDir string
+	WorktreePath          string
+	OriginalAgent         string
+	DelegatedAgent        string
+	DelegationReason      string
 }
 
 type JobPayload struct {
@@ -63,6 +64,7 @@ type JobPayload struct {
 	DelegationID           string       `json:"delegation_id,omitempty"`
 	DelegationDepth        int          `json:"delegation_depth,omitempty"`
 	DelegatedBy            string       `json:"delegated_by,omitempty"`
+	DelegationArtifactDir  string       `json:"delegation_artifact_dir,omitempty"`
 	WorktreePath           string       `json:"worktree_path,omitempty"`
 	TemplateID             string       `json:"template_id,omitempty"`
 	TemplateResolvedCommit string       `json:"template_resolved_commit,omitempty"`
@@ -109,6 +111,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		DelegationID:           request.DelegationID,
 		DelegationDepth:        request.DelegationDepth,
 		DelegatedBy:            request.DelegatedBy,
+		DelegationArtifactDir:  request.DelegationArtifactDir,
 		WorktreePath:           request.WorktreePath,
 		TemplateID:             snapshot.ID,
 		TemplateResolvedCommit: snapshot.ResolvedCommit,
@@ -357,6 +360,7 @@ func (p JobPayload) prompt(action string) prompts.JobPrompt {
 		Action:                 action,
 		Instructions:           p.Instructions,
 		Constraints:            p.Constraints,
+		DelegationArtifactDir:  p.DelegationArtifactDir,
 		TemplateID:             p.TemplateID,
 		TemplateResolvedCommit: p.TemplateResolvedCommit,
 		TemplateInstructions:   agenttemplate.InstructionsForContent(p.TemplateContent),

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -39,6 +39,7 @@ type JobRequest struct {
 	DelegationID          string
 	DelegationDepth       int
 	DelegatedBy           string
+	Deps                  []string
 	DelegationArtifactDir string
 	WorktreePath          string
 	OriginalAgent         string
@@ -64,6 +65,7 @@ type JobPayload struct {
 	DelegationID           string       `json:"delegation_id,omitempty"`
 	DelegationDepth        int          `json:"delegation_depth,omitempty"`
 	DelegatedBy            string       `json:"delegated_by,omitempty"`
+	Deps                   []string     `json:"deps,omitempty"`
 	DelegationArtifactDir  string       `json:"delegation_artifact_dir,omitempty"`
 	WorktreePath           string       `json:"worktree_path,omitempty"`
 	TemplateID             string       `json:"template_id,omitempty"`
@@ -111,6 +113,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		DelegationID:           request.DelegationID,
 		DelegationDepth:        request.DelegationDepth,
 		DelegatedBy:            request.DelegatedBy,
+		Deps:                   compactStrings(request.Deps),
 		DelegationArtifactDir:  request.DelegationArtifactDir,
 		WorktreePath:           request.WorktreePath,
 		TemplateID:             snapshot.ID,

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -126,7 +126,113 @@ func validateAgentResult(result AgentResult) error {
 			return err
 		}
 	}
+	if err := validateDelegationGraph(result.Delegations); err != nil {
+		return err
+	}
+	if delegationsRequestArtifacts(result.Delegations) && strings.TrimSpace(result.ArtifactBody) == "" {
+		return errors.New("artifact_body is required when delegations request artifacts")
+	}
 	return nil
+}
+
+// validateDelegationGraph enforces the structural invariants of the delegation
+// dependency DAG: every id is unique, every declared dep references a known
+// sibling id (and never the delegation itself), and the deps form no cycle. A
+// coordinator that violates any of these would otherwise crash mid-dispatch
+// (duplicate ids collide on the deterministic child job id) or silently drop a
+// delegation while falsely signalling the batch is complete (unknown deps and
+// cycles are treated as permanently blocked by the engine). Validating here
+// turns those into clean errors at result-parse time, before any side effects.
+func validateDelegationGraph(delegations []Delegation) error {
+	known := make(map[string]struct{}, len(delegations))
+	for _, d := range delegations {
+		id := strings.TrimSpace(d.ID)
+		if _, ok := known[id]; ok {
+			return fmt.Errorf("delegation id %q is not unique", id)
+		}
+		known[id] = struct{}{}
+	}
+	for _, d := range delegations {
+		id := strings.TrimSpace(d.ID)
+		for _, dep := range d.Deps {
+			dep = strings.TrimSpace(dep)
+			if dep == "" {
+				continue
+			}
+			if dep == id {
+				return fmt.Errorf("delegation %q depends on itself", id)
+			}
+			if _, ok := known[dep]; !ok {
+				return fmt.Errorf("delegation %q references unknown dep %q", id, dep)
+			}
+		}
+	}
+	return detectDelegationCycle(delegations)
+}
+
+// detectDelegationCycle runs a depth-first search over the delegation deps and
+// reports the first cycle it finds, naming the delegations involved. Deps that
+// reference unknown ids are ignored here because validateDelegationGraph has
+// already rejected those; this keeps the traversal focused on real edges.
+func detectDelegationCycle(delegations []Delegation) error {
+	edges := make(map[string][]string, len(delegations))
+	for _, d := range delegations {
+		id := strings.TrimSpace(d.ID)
+		for _, dep := range d.Deps {
+			dep = strings.TrimSpace(dep)
+			if dep != "" {
+				edges[id] = append(edges[id], dep)
+			}
+		}
+	}
+
+	const (
+		unvisited = 0
+		visiting  = 1
+		done      = 2
+	)
+	state := make(map[string]int, len(delegations))
+	var stack []string
+
+	var visit func(id string) []string
+	visit = func(id string) []string {
+		state[id] = visiting
+		stack = append(stack, id)
+		for _, dep := range edges[id] {
+			switch state[dep] {
+			case visiting:
+				// Found a back-edge; slice the stack from dep to close the cycle.
+				cycle := append([]string{}, stack[indexOf(stack, dep):]...)
+				return append(cycle, dep)
+			case unvisited:
+				if cycle := visit(dep); cycle != nil {
+					return cycle
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[id] = done
+		return nil
+	}
+
+	for _, d := range delegations {
+		id := strings.TrimSpace(d.ID)
+		if state[id] == unvisited {
+			if cycle := visit(id); cycle != nil {
+				return fmt.Errorf("delegations form a dependency cycle: %s", strings.Join(cycle, " -> "))
+			}
+		}
+	}
+	return nil
+}
+
+func indexOf(values []string, target string) int {
+	for i, v := range values {
+		if v == target {
+			return i
+		}
+	}
+	return 0
 }
 
 // validateDelegationLifecycle validates the Phase 2 lifecycle controls on a

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -113,6 +113,12 @@ func validateAgentResult(result AgentResult) error {
 		if strings.TrimSpace(d.ID) == "" {
 			return errors.New("delegation id is required")
 		}
+		// The engine keys child jobs, the dedup map, and the DAG on the raw id
+		// while deps are matched trimmed; a surrounding-whitespace id would make
+		// those disagree and silently drop the delegation. Require them equal.
+		if d.ID != strings.TrimSpace(d.ID) {
+			return fmt.Errorf("delegation id %q must not have leading or trailing whitespace", d.ID)
+		}
 		if strings.TrimSpace(d.Agent) == "" {
 			return errors.New("delegation agent is required")
 		}

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -121,9 +121,6 @@ func validateAgentResult(result AgentResult) error {
 		if strings.TrimSpace(d.Prompt) == "" {
 			return errors.New("delegation prompt is required")
 		}
-		if len(d.Deps) > 0 {
-			return fmt.Errorf("delegation %q uses dependencies, which are not yet supported", d.ID)
-		}
 	}
 	return nil
 }

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 const resultKey = `"gitmoot_result"`
@@ -121,6 +122,39 @@ func validateAgentResult(result AgentResult) error {
 		if strings.TrimSpace(d.Prompt) == "" {
 			return errors.New("delegation prompt is required")
 		}
+		if err := validateDelegationLifecycle(d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateDelegationLifecycle validates the Phase 2 lifecycle controls on a
+// delegation: timeout must parse as a positive duration, retry must be
+// non-negative, and failure_policy/synthesis_rule must be drawn from their
+// allowed sets. Empty values are accepted and fall back to defaults.
+func validateDelegationLifecycle(d Delegation) error {
+	if timeout := strings.TrimSpace(d.Timeout); timeout != "" {
+		parsed, err := time.ParseDuration(timeout)
+		if err != nil {
+			return fmt.Errorf("delegation %q timeout %q is invalid: %w", d.ID, timeout, err)
+		}
+		if parsed <= 0 {
+			return fmt.Errorf("delegation %q timeout %q must be positive", d.ID, timeout)
+		}
+	}
+	if d.Retry < 0 {
+		return fmt.Errorf("delegation %q retry must be >= 0", d.ID)
+	}
+	switch strings.ToLower(strings.TrimSpace(d.FailurePolicy)) {
+	case "", "block_parent", "continue", "escalate":
+	default:
+		return fmt.Errorf("delegation %q failure_policy %q is invalid", d.ID, d.FailurePolicy)
+	}
+	switch strings.ToLower(strings.TrimSpace(d.SynthesisRule)) {
+	case "", "summary", "vote":
+	default:
+		return fmt.Errorf("delegation %q synthesis_rule %q is invalid", d.ID, d.SynthesisRule)
 	}
 	return nil
 }

--- a/internal/workflow/result_test.go
+++ b/internal/workflow/result_test.go
@@ -76,3 +76,159 @@ func TestExtractAgentResultRejectsUnsupportedField(t *testing.T) {
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestExtractAgentResultAcceptsDelegationDeps(t *testing.T) {
+	output := `{"gitmoot_result":{"decision":"implemented","summary":"fan out",` +
+		`"delegations":[` +
+		`{"id":"api","agent":"impl","action":"implement","prompt":"build api"},` +
+		`{"id":"ui","agent":"impl","action":"implement","prompt":"build ui"},` +
+		`{"id":"integrate","agent":"impl","action":"implement","prompt":"wire up","deps":["api","ui"]}` +
+		`]}}`
+
+	result, err := ExtractAgentResult(output)
+
+	if err != nil {
+		t.Fatalf("ExtractAgentResult returned error: %v", err)
+	}
+	if len(result.Delegations) != 3 {
+		t.Fatalf("delegations = %+v", result.Delegations)
+	}
+	if got := result.Delegations[2].Deps; len(got) != 2 || got[0] != "api" || got[1] != "ui" {
+		t.Fatalf("deps = %+v", got)
+	}
+}
+
+func TestExtractAgentResultRejectsNextAgentsField(t *testing.T) {
+	output := `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[],"next_agents":["impl"]}}`
+
+	_, err := ExtractAgentResult(output)
+
+	if err == nil {
+		t.Fatal("ExtractAgentResult accepted next_agents field")
+	}
+	if !strings.Contains(err.Error(), `unsupported gitmoot_result field "next_agents"`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestValidateAgentResultRejectsDelegationMissingFields(t *testing.T) {
+	cases := []struct {
+		name string
+		del  Delegation
+		want string
+	}{
+		{"missing id", Delegation{Agent: "impl", Action: "implement", Prompt: "do"}, "delegation id is required"},
+		{"missing agent", Delegation{ID: "a", Action: "implement", Prompt: "do"}, "delegation agent is required"},
+		{"missing action", Delegation{ID: "a", Agent: "impl", Prompt: "do"}, "delegation action is required"},
+		{"missing prompt", Delegation{ID: "a", Agent: "impl", Action: "implement"}, "delegation prompt is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := AgentResult{Decision: "implemented", Summary: "x", Delegations: []Delegation{tc.del}}
+			err := validateAgentResult(result)
+			if err == nil {
+				t.Fatalf("validateAgentResult accepted %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateAgentResultRejectsDuplicateDelegationID(t *testing.T) {
+	result := AgentResult{
+		Decision: "implemented",
+		Summary:  "x",
+		Delegations: []Delegation{
+			{ID: "dup", Agent: "impl", Action: "implement", Prompt: "first"},
+			{ID: "dup", Agent: "other", Action: "implement", Prompt: "second"},
+		},
+	}
+	err := validateAgentResult(result)
+	if err == nil {
+		t.Fatal("validateAgentResult accepted duplicate delegation id")
+	}
+	if !strings.Contains(err.Error(), `delegation id "dup" is not unique`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestValidateAgentResultRejectsUnknownDep(t *testing.T) {
+	result := AgentResult{
+		Decision: "implemented",
+		Summary:  "x",
+		Delegations: []Delegation{
+			{ID: "a", Agent: "impl", Action: "implement", Prompt: "do", Deps: []string{"nonexistent"}},
+		},
+	}
+	err := validateAgentResult(result)
+	if err == nil {
+		t.Fatal("validateAgentResult accepted unknown dep")
+	}
+	if !strings.Contains(err.Error(), `delegation "a" references unknown dep "nonexistent"`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestValidateAgentResultRejectsSelfDep(t *testing.T) {
+	result := AgentResult{
+		Decision: "implemented",
+		Summary:  "x",
+		Delegations: []Delegation{
+			{ID: "a", Agent: "impl", Action: "implement", Prompt: "do", Deps: []string{"a"}},
+		},
+	}
+	err := validateAgentResult(result)
+	if err == nil {
+		t.Fatal("validateAgentResult accepted self-dep")
+	}
+	if !strings.Contains(err.Error(), `delegation "a" depends on itself`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestValidateAgentResultRejectsDependencyCycle(t *testing.T) {
+	result := AgentResult{
+		Decision: "implemented",
+		Summary:  "x",
+		Delegations: []Delegation{
+			{ID: "a", Agent: "impl", Action: "implement", Prompt: "do", Deps: []string{"b"}},
+			{ID: "b", Agent: "impl", Action: "implement", Prompt: "do", Deps: []string{"a"}},
+		},
+	}
+	err := validateAgentResult(result)
+	if err == nil {
+		t.Fatal("validateAgentResult accepted dependency cycle")
+	}
+	if !strings.Contains(err.Error(), "dependency cycle") {
+		t.Fatalf("error = %v", err)
+	}
+	// The error must name both delegations in the cycle.
+	if !strings.Contains(err.Error(), "a") || !strings.Contains(err.Error(), "b") {
+		t.Fatalf("cycle error does not name the delegations: %v", err)
+	}
+}
+
+func TestValidateAgentResultRejectsArtifactsWithoutBody(t *testing.T) {
+	result := AgentResult{
+		Decision: "implemented",
+		Summary:  "x",
+		Delegations: []Delegation{
+			{ID: "a", Agent: "impl", Action: "implement", Prompt: "do", Artifacts: []string{"brief.md"}},
+		},
+	}
+	err := validateAgentResult(result)
+	if err == nil {
+		t.Fatal("validateAgentResult accepted delegation requesting artifacts with empty body")
+	}
+	if !strings.Contains(err.Error(), "artifact_body is required when delegations request artifacts") {
+		t.Fatalf("error = %v", err)
+	}
+
+	// With a brief written, the same delegations are valid.
+	result.ArtifactBody = "shared brief"
+	if err := validateAgentResult(result); err != nil {
+		t.Fatalf("validateAgentResult rejected delegations with a written brief: %v", err)
+	}
+}

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -154,6 +155,11 @@ type DelegationWorktreeRequest struct {
 	BaseBranch   string
 	Owner        string
 	Checkout     string
+	// RetryAttempt is the 1-based retry number for a re-enqueued delegation. It
+	// is 0 for the original attempt. A non-zero value gives the retry an isolated
+	// worktree path and branch so it never collides with the failed attempt's
+	// still-present worktree directory and checked-out branch.
+	RetryAttempt int
 }
 
 // DelegationWorktreeResult is the allocated worktree path and branch for a
@@ -185,11 +191,11 @@ func (e Engine) AllocateDelegationWorktree(ctx context.Context, request Delegati
 	if strings.TrimSpace(request.Owner) == "" {
 		return DelegationWorktreeResult{}, errors.New("delegation worktree owner is required")
 	}
-	path, err := DelegationWorktreePath(request.Home, request.Repo, request.ParentJobID, request.DelegationID)
+	path, err := DelegationWorktreePath(request.Home, request.Repo, request.ParentJobID, request.DelegationID, request.RetryAttempt)
 	if err != nil {
 		return DelegationWorktreeResult{}, err
 	}
-	branch := delegationBranchName(request.Delegation, request.ParentJobID, request.DelegationID)
+	branch := delegationBranchName(request.Delegation, request.ParentJobID, request.DelegationID, request.RetryAttempt)
 	if strings.TrimSpace(branch) == "" {
 		return DelegationWorktreeResult{}, errors.New("delegation worktree branch could not be derived")
 	}
@@ -264,8 +270,10 @@ func TaskWorktreePath(home string, repo string, taskID string) (string, error) {
 // DelegationWorktreePath builds the deterministic on-disk worktree path for a
 // delegated implement job:
 // $GITMOOT_HOME/worktrees/<owner>--<repo>/delegations/<parent-job-id>/<delegation-id>/.
+// A retryAttempt > 0 appends /retry/<n> so a re-enqueued delegation gets a fresh
+// isolated directory rather than colliding with the failed attempt's worktree.
 // It reuses the same repo/segment sanitization as TaskWorktreePath.
-func DelegationWorktreePath(home string, repo string, parentJobID string, delegationID string) (string, error) {
+func DelegationWorktreePath(home string, repo string, parentJobID string, delegationID string, retryAttempt int) (string, error) {
 	home = strings.TrimSpace(home)
 	if home == "" {
 		return "", errors.New("delegation worktree home is required")
@@ -282,7 +290,11 @@ func DelegationWorktreePath(home string, repo string, parentJobID string, delega
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, "worktrees", repoSegment, "delegations", parentSegment, delegationSegment), nil
+	base := filepath.Join(home, "worktrees", repoSegment, "delegations", parentSegment, delegationSegment)
+	if retryAttempt > 0 {
+		base = filepath.Join(base, "retry", strconv.Itoa(retryAttempt))
+	}
+	return base, nil
 }
 
 func taskWorktreeRepoSegment(repo string) (string, error) {

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -141,6 +141,93 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 	return task, nil
 }
 
+// DelegationWorktreeRequest carries the inputs needed to allocate a git
+// worktree for a delegated implement job. Unlike TaskWorktreeRequest it does not
+// touch the tasks table; the resulting path and branch are returned to the
+// dispatcher for storage in the child JobPayload.
+type DelegationWorktreeRequest struct {
+	Home         string
+	Repo         string
+	ParentJobID  string
+	DelegationID string
+	Delegation   Delegation
+	BaseBranch   string
+	Owner        string
+	Checkout     string
+}
+
+// DelegationWorktreeResult is the allocated worktree path and branch for a
+// delegated implement job.
+type DelegationWorktreeResult struct {
+	Path   string
+	Branch string
+}
+
+// AllocateDelegationWorktree creates an isolated git worktree for a delegated
+// implement job. It mirrors AllocateTaskWorktree's lock ordering (branch lock,
+// then checkout mutation lock, then the git worktree add) but writes nothing to
+// the tasks table: the deterministic path and computed branch are returned so
+// the dispatcher can store them in the child JobPayload. Two delegations from
+// the same parent get distinct paths and branches.
+func (e Engine) AllocateDelegationWorktree(ctx context.Context, request DelegationWorktreeRequest, manager WorktreeManager) (DelegationWorktreeResult, error) {
+	if err := e.validate(); err != nil {
+		return DelegationWorktreeResult{}, err
+	}
+	if manager == nil {
+		return DelegationWorktreeResult{}, errors.New("worktree manager is required")
+	}
+	if strings.TrimSpace(request.ParentJobID) == "" {
+		return DelegationWorktreeResult{}, errors.New("delegation worktree parent job id is required")
+	}
+	if strings.TrimSpace(request.DelegationID) == "" {
+		return DelegationWorktreeResult{}, errors.New("delegation worktree delegation id is required")
+	}
+	if strings.TrimSpace(request.Owner) == "" {
+		return DelegationWorktreeResult{}, errors.New("delegation worktree owner is required")
+	}
+	path, err := DelegationWorktreePath(request.Home, request.Repo, request.ParentJobID, request.DelegationID)
+	if err != nil {
+		return DelegationWorktreeResult{}, err
+	}
+	branch := delegationBranchName(request.Delegation, request.ParentJobID, request.DelegationID)
+	if strings.TrimSpace(branch) == "" {
+		return DelegationWorktreeResult{}, errors.New("delegation worktree branch could not be derived")
+	}
+	lock := db.BranchLock{RepoFullName: request.Repo, Branch: branch, Owner: request.Owner}
+	createdLock, err := e.Store.CreateLock(ctx, lock)
+	if err != nil {
+		return DelegationWorktreeResult{}, err
+	}
+	if !createdLock {
+		existingLock, err := e.Store.GetBranchLock(ctx, request.Repo, branch)
+		if err != nil {
+			return DelegationWorktreeResult{}, err
+		}
+		if existingLock.Owner != request.Owner {
+			return DelegationWorktreeResult{}, BlockedError{Reason: "branch lock rejected action for " + branch}
+		}
+	}
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(ctx, e.Store, request.Checkout, "worktree:"+request.ParentJobID+"/"+request.DelegationID, time.Now().UTC())
+	if err != nil {
+		if createdLock {
+			_, _ = e.Store.ReleaseLock(ctx, lock)
+		}
+		return DelegationWorktreeResult{}, err
+	}
+	defer func() {
+		if releaseCheckoutLock != nil {
+			_ = releaseCheckoutLock(context.Background())
+		}
+	}()
+	if err := addTaskWorktree(ctx, manager, branch, path, request.BaseBranch); err != nil {
+		if createdLock {
+			_, _ = e.Store.ReleaseLock(ctx, lock)
+		}
+		return DelegationWorktreeResult{}, err
+	}
+	return DelegationWorktreeResult{Path: path, Branch: branch}, nil
+}
+
 func addTaskWorktree(ctx context.Context, manager WorktreeManager, branch string, path string, base string) error {
 	if checker, ok := manager.(BranchExistenceChecker); ok {
 		exists, err := checker.BranchExists(ctx, branch)
@@ -172,6 +259,30 @@ func TaskWorktreePath(home string, repo string, taskID string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, "worktrees", repoSegment, taskSegment), nil
+}
+
+// DelegationWorktreePath builds the deterministic on-disk worktree path for a
+// delegated implement job:
+// $GITMOOT_HOME/worktrees/<owner>--<repo>/delegations/<parent-job-id>/<delegation-id>/.
+// It reuses the same repo/segment sanitization as TaskWorktreePath.
+func DelegationWorktreePath(home string, repo string, parentJobID string, delegationID string) (string, error) {
+	home = strings.TrimSpace(home)
+	if home == "" {
+		return "", errors.New("delegation worktree home is required")
+	}
+	repoSegment, err := taskWorktreeRepoSegment(repo)
+	if err != nil {
+		return "", err
+	}
+	parentSegment, err := taskWorktreePathSegment(parentJobID, "parent job id")
+	if err != nil {
+		return "", err
+	}
+	delegationSegment, err := taskWorktreePathSegment(delegationID, "delegation id")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "worktrees", repoSegment, "delegations", parentSegment, delegationSegment), nil
 }
 
 func taskWorktreeRepoSegment(repo string) (string, error) {

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -365,6 +365,238 @@ func TestEngineAllocateTaskWorktreeUsesExistingBranchWhenBranchAlreadyExists(t *
 	}
 }
 
+func TestDelegationWorktreePath(t *testing.T) {
+	path, err := DelegationWorktreePath("/home/gitmoot", "owner/repo", "job-1", "d1")
+	if err != nil {
+		t.Fatalf("DelegationWorktreePath returned error: %v", err)
+	}
+	want := filepath.Join("/home/gitmoot", "worktrees", "owner--repo", "delegations", "job-1", "d1")
+	if path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+	for _, tc := range []struct {
+		name       string
+		home       string
+		repo       string
+		parentJob  string
+		delegation string
+	}{
+		{name: "empty home", home: "", repo: "owner/repo", parentJob: "job-1", delegation: "d1"},
+		{name: "empty repo", home: "/home/gitmoot", repo: "", parentJob: "job-1", delegation: "d1"},
+		{name: "nested repo", home: "/home/gitmoot", repo: "owner/repo/extra", parentJob: "job-1", delegation: "d1"},
+		{name: "unsafe parent", home: "/home/gitmoot", repo: "owner/repo", parentJob: "../job", delegation: "d1"},
+		{name: "unsafe delegation", home: "/home/gitmoot", repo: "owner/repo", parentJob: "job-1", delegation: "../d"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := DelegationWorktreePath(tc.home, tc.repo, tc.parentJob, tc.delegation); err == nil {
+				t.Fatal("DelegationWorktreePath accepted invalid input")
+			}
+		})
+	}
+}
+
+func TestAllocateDelegationWorktreeAddsGitWorktreeAndReturnsPathBranch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	home := t.TempDir()
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	manager := &fakeWorktreeManager{onAdd: func() {
+		lock, err := store.GetResourceLock(ctx, key)
+		if err != nil {
+			t.Fatalf("GetResourceLock during AddWorktree returned error: %v", err)
+		}
+		if lock.OwnerJobID != "worktree:job-1/d1" {
+			t.Fatalf("checkout lock owner = %q, want worktree:job-1/d1", lock.OwnerJobID)
+		}
+	}}
+
+	result, err := engine.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
+		Home:         home,
+		Repo:         "owner/repo",
+		ParentJobID:  "job-1",
+		DelegationID: "d1",
+		Delegation:   Delegation{ID: "d1", Agent: "helper", Action: "implement"},
+		BaseBranch:   "main",
+		Owner:        "helper",
+		Checkout:     checkout,
+	}, manager)
+	if err != nil {
+		t.Fatalf("AllocateDelegationWorktree returned error: %v", err)
+	}
+	wantPath := filepath.Join(home, "worktrees", "owner--repo", "delegations", "job-1", "d1")
+	if result.Path != wantPath {
+		t.Fatalf("path = %q, want %q", result.Path, wantPath)
+	}
+	wantBranch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1")
+	if result.Branch != wantBranch {
+		t.Fatalf("branch = %q, want %q", result.Branch, wantBranch)
+	}
+	if len(manager.calls) != 1 || manager.calls[0].branch != wantBranch || manager.calls[0].path != wantPath || manager.calls[0].base != "main" {
+		t.Fatalf("worktree calls = %+v", manager.calls)
+	}
+	// The tasks table must not be touched by delegation allocation.
+	if _, err := store.GetTask(ctx, "d1"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetTask after delegation allocation error = %v, want sql.ErrNoRows", err)
+	}
+	lock, err := store.GetBranchLock(ctx, "owner/repo", wantBranch)
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.Owner != "helper" {
+		t.Fatalf("lock owner = %q, want helper", lock.Owner)
+	}
+	if _, err := store.GetResourceLock(ctx, key); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("checkout lock after AddWorktree error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestAllocateDelegationWorktreeUsesCheckoutMutationLock(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	home := t.TempDir()
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: key,
+		OwnerJobID:  "task:other",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	manager := &fakeWorktreeManager{}
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		time.Sleep(20 * time.Millisecond)
+		_, _ = store.ReleaseResourceLock(context.Background(), key, "task:other", "other-token")
+	}()
+
+	result, err := engine.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
+		Home:         home,
+		Repo:         "owner/repo",
+		ParentJobID:  "job-1",
+		DelegationID: "d1",
+		Owner:        "helper",
+		Checkout:     checkout,
+	}, manager)
+	if err != nil {
+		t.Fatalf("AllocateDelegationWorktree returned error: %v", err)
+	}
+	<-released
+	if result.Path == "" {
+		t.Fatalf("delegation worktree path is empty: %+v", result)
+	}
+	if len(manager.calls) != 1 {
+		t.Fatalf("AddWorktree calls = %+v, want one call after checkout lock release", manager.calls)
+	}
+	if _, err := store.GetResourceLock(ctx, key); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("checkout lock after AddWorktree error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestAllocateDelegationWorktreeBranchNaming(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+
+	hinted, err := engine.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
+		Home:         t.TempDir(),
+		Repo:         "owner/repo",
+		ParentJobID:  "job-1",
+		DelegationID: "d1",
+		Delegation:   Delegation{ID: "d1", Worktree: "Feature Login"},
+		Owner:        "helper",
+		Checkout:     t.TempDir(),
+	}, &fakeWorktreeManager{})
+	if err != nil {
+		t.Fatalf("AllocateDelegationWorktree (hinted) returned error: %v", err)
+	}
+	if hinted.Branch != "feature-login" {
+		t.Fatalf("hinted branch = %q, want feature-login", hinted.Branch)
+	}
+
+	fallback, err := engine.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
+		Home:         t.TempDir(),
+		Repo:         "owner/repo",
+		ParentJobID:  "job-1",
+		DelegationID: "d2",
+		Delegation:   Delegation{ID: "d2"},
+		Owner:        "helper",
+		Checkout:     t.TempDir(),
+	}, &fakeWorktreeManager{})
+	if err != nil {
+		t.Fatalf("AllocateDelegationWorktree (fallback) returned error: %v", err)
+	}
+	want := "gitmoot-delegation-" + parentShort("job-1") + "-d2"
+	if fallback.Branch != want {
+		t.Fatalf("fallback branch = %q, want %q", fallback.Branch, want)
+	}
+}
+
+func TestAllocateDelegationWorktreeReusesExistingBranch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	home := t.TempDir()
+	branch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1")
+	manager := &fakeWorktreeManager{existingBranches: map[string]bool{branch: true}}
+
+	result, err := engine.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
+		Home:         home,
+		Repo:         "owner/repo",
+		ParentJobID:  "job-1",
+		DelegationID: "d1",
+		Owner:        "helper",
+		Checkout:     t.TempDir(),
+	}, manager)
+	if err != nil {
+		t.Fatalf("AllocateDelegationWorktree returned error: %v", err)
+	}
+	wantPath := filepath.Join(home, "worktrees", "owner--repo", "delegations", "job-1", "d1")
+	if result.Path != wantPath || result.Branch != branch {
+		t.Fatalf("result = %+v, want path %q branch %q", result, wantPath, branch)
+	}
+	if len(manager.calls) != 0 {
+		t.Fatalf("AddWorktree ran for existing branch: %+v", manager.calls)
+	}
+	if len(manager.existingCalls) != 1 || manager.existingCalls[0].branch != branch || manager.existingCalls[0].path != wantPath {
+		t.Fatalf("existing branch worktree calls = %+v", manager.existingCalls)
+	}
+}
+
+func TestAllocateDelegationWorktreeReleasesBranchLockOnFailure(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	manager := &fakeWorktreeManager{err: errors.New("git failed")}
+	branch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1")
+
+	_, err := engine.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
+		Home:         t.TempDir(),
+		Repo:         "owner/repo",
+		ParentJobID:  "job-1",
+		DelegationID: "d1",
+		Owner:        "helper",
+		Checkout:     t.TempDir(),
+	}, manager)
+	if err == nil {
+		t.Fatal("AllocateDelegationWorktree succeeded despite worktree failure")
+	}
+	if _, lockErr := store.GetBranchLock(ctx, "owner/repo", branch); !errors.Is(lockErr, sql.ErrNoRows) {
+		t.Fatalf("branch lock after failure error = %v, want sql.ErrNoRows", lockErr)
+	}
+}
+
 type fakeWorktreeManager struct {
 	err              error
 	onAdd            func()

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -366,13 +366,26 @@ func TestEngineAllocateTaskWorktreeUsesExistingBranchWhenBranchAlreadyExists(t *
 }
 
 func TestDelegationWorktreePath(t *testing.T) {
-	path, err := DelegationWorktreePath("/home/gitmoot", "owner/repo", "job-1", "d1")
+	path, err := DelegationWorktreePath("/home/gitmoot", "owner/repo", "job-1", "d1", 0)
 	if err != nil {
 		t.Fatalf("DelegationWorktreePath returned error: %v", err)
 	}
 	want := filepath.Join("/home/gitmoot", "worktrees", "owner--repo", "delegations", "job-1", "d1")
 	if path != want {
 		t.Fatalf("path = %q, want %q", path, want)
+	}
+	// A retry attempt gets an isolated /retry/<n> subdirectory so it never
+	// collides with the failed original attempt's worktree.
+	retryPath, err := DelegationWorktreePath("/home/gitmoot", "owner/repo", "job-1", "d1", 2)
+	if err != nil {
+		t.Fatalf("DelegationWorktreePath (retry) returned error: %v", err)
+	}
+	wantRetry := filepath.Join("/home/gitmoot", "worktrees", "owner--repo", "delegations", "job-1", "d1", "retry", "2")
+	if retryPath != wantRetry {
+		t.Fatalf("retry path = %q, want %q", retryPath, wantRetry)
+	}
+	if retryPath == want {
+		t.Fatalf("retry path %q collides with original attempt path", retryPath)
 	}
 	for _, tc := range []struct {
 		name       string
@@ -388,7 +401,7 @@ func TestDelegationWorktreePath(t *testing.T) {
 		{name: "unsafe delegation", home: "/home/gitmoot", repo: "owner/repo", parentJob: "job-1", delegation: "../d"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := DelegationWorktreePath(tc.home, tc.repo, tc.parentJob, tc.delegation); err == nil {
+			if _, err := DelegationWorktreePath(tc.home, tc.repo, tc.parentJob, tc.delegation, 0); err == nil {
 				t.Fatal("DelegationWorktreePath accepted invalid input")
 			}
 		})
@@ -432,7 +445,7 @@ func TestAllocateDelegationWorktreeAddsGitWorktreeAndReturnsPathBranch(t *testin
 	if result.Path != wantPath {
 		t.Fatalf("path = %q, want %q", result.Path, wantPath)
 	}
-	wantBranch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1")
+	wantBranch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1", 0)
 	if result.Branch != wantBranch {
 		t.Fatalf("branch = %q, want %q", result.Branch, wantBranch)
 	}
@@ -521,8 +534,12 @@ func TestAllocateDelegationWorktreeBranchNaming(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AllocateDelegationWorktree (hinted) returned error: %v", err)
 	}
-	if hinted.Branch != "feature-login" {
-		t.Fatalf("hinted branch = %q, want feature-login", hinted.Branch)
+	// The worktree hint is appended only as a human-readable suffix; the branch is
+	// always namespaced with the parent-short and delegation id so it stays unique
+	// across siblings regardless of the hint.
+	wantHinted := "gitmoot-delegation-" + parentShort("job-1") + "-d1-feature-login"
+	if hinted.Branch != wantHinted {
+		t.Fatalf("hinted branch = %q, want %q", hinted.Branch, wantHinted)
 	}
 
 	fallback, err := engine.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
@@ -548,7 +565,7 @@ func TestAllocateDelegationWorktreeReusesExistingBranch(t *testing.T) {
 	store := openEngineStore(t)
 	engine := testEngine(store)
 	home := t.TempDir()
-	branch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1")
+	branch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1", 0)
 	manager := &fakeWorktreeManager{existingBranches: map[string]bool{branch: true}}
 
 	result, err := engine.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
@@ -579,7 +596,7 @@ func TestAllocateDelegationWorktreeReleasesBranchLockOnFailure(t *testing.T) {
 	store := openEngineStore(t)
 	engine := testEngine(store)
 	manager := &fakeWorktreeManager{err: errors.New("git failed")}
-	branch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1")
+	branch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1", 0)
 
 	_, err := engine.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
 		Home:         t.TempDir(),

--- a/skills/gitmoot/agent-templates/planner.md
+++ b/skills/gitmoot/agent-templates/planner.md
@@ -79,6 +79,57 @@ When asked to write the goal file:
 Do not implement the planned feature unless the user explicitly asks after the
 plan and goal file are complete.
 
+## Coordinator Delegations
+
+When you run as a managed coordinator agent and want Gitmoot to fan work out to
+other named agents, return a top-level `delegations` array in your
+`gitmoot_result`. Gitmoot enqueues one child job per delegation and records a
+`delegation_enqueued` event on your job for each one.
+
+Each delegation requires four fields:
+
+- `id`: stable identifier for the delegation within this result.
+- `agent`: name of the Gitmoot agent to run.
+- `action`: job action, e.g. `ask`, `review`, or `implement`.
+- `prompt`: instructions for the delegated job.
+
+Optional advanced controls are also supported: `worktree`, `artifacts`, `deps`,
+`timeout`, `retry`, `failure_policy`, `fingerprint`, and `synthesis_rule`. A
+delegation with no `deps` is dispatched immediately and runs in parallel with
+its siblings; a delegation with `deps` runs only after every listed sibling has
+succeeded. Once all top-level delegations reach a terminal state, Gitmoot
+enqueues one coordinator continuation job so you can synthesize the results.
+
+See `references/RESULT_CONTRACT.md` for the full field reference. Example
+coordinator result that delegates two flat parallel jobs to different agents:
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "Plan ready; delegating implementation and review.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "delegations": [
+      {
+        "id": "build-api",
+        "agent": "backend-coder",
+        "action": "implement",
+        "prompt": "Implement the REST API described in the plan."
+      },
+      {
+        "id": "review-plan",
+        "agent": "reviewer",
+        "action": "review",
+        "prompt": "Review the implementation plan for correctness and risk."
+      }
+    ]
+  }
+}
+```
+
 ## Current-Chat Use
 
 When the user says "use the Gitmoot planner here", apply these same planner

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -389,3 +389,64 @@ gitmoot agent allow reviewer --repo owner/project-b
 gitmoot status --repo owner/project-a
 gitmoot status --repo owner/project-b
 ```
+
+## Multi-Model Delegation
+
+A coordinator agent can fan work out to other agents running on different
+runtimes by returning a `delegations` array in its `gitmoot_result`. Gitmoot
+enqueues one child job per delegation, records a `delegation_enqueued` event on
+the coordinator job, and runs the children in the daemon. Start a coordinator
+and two workers on different runtimes so each delegation lands on the best model
+for the job:
+
+```sh
+gitmoot agent start coordinator --runtime codex --repo owner/repo --role planner --capability ask --start-daemon
+gitmoot agent start ui-worker --runtime claude --repo owner/repo --role reviewer --capability ask --capability review
+gitmoot agent start api-worker --runtime kimi --repo owner/repo --role reviewer --capability ask --capability review
+```
+
+Queue the coordinator as background work so the daemon runs it and dispatches
+its delegations (a synchronous `gitmoot agent ask` without `--background` only
+returns the coordinator's own answer and does not fan out):
+
+```sh
+gitmoot agent ask coordinator --repo owner/repo --background "Coordinate the redesign across the API and UI teams."
+```
+
+The coordinator returns two delegations to the workers on different runtimes:
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "Delegating UI review and API review to the workers.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "delegations": [
+      {
+        "id": "ui",
+        "agent": "ui-worker",
+        "action": "ask",
+        "prompt": "Propose the component changes for the new dashboard layout."
+      },
+      {
+        "id": "api",
+        "agent": "api-worker",
+        "action": "review",
+        "prompt": "Review the API contract for the dashboard endpoints."
+      }
+    ]
+  }
+}
+```
+
+Gitmoot enqueues each delegation as a flat parallel child job
+(`<parent-job-id>/delegation/<id>`) with a `delegation_enqueued` event on the
+parent. Delegations that declare `deps` run only after the named siblings
+succeed, and once every top-level delegation is terminal Gitmoot enqueues one
+coordinator continuation job so the coordinator can synthesize the results.
+Inspect the fan-out with `gitmoot job list --repo owner/repo` (one row per child
+job) and `gitmoot events --repo owner/repo` (the `delegation_enqueued` events).
+See `RESULT_CONTRACT.md` for the full delegation field reference.


### PR DESCRIPTION
## Summary

Implements the remaining work for **#301 — structured job delegations** (tasks **3054–3059**), on top of the delegations schema merged in #302. A coordinator job can now fan out parallel child jobs to other agents, share a focused brief via durable artifacts, gate work on a dependency DAG, and resume through an automatic continuation job — entirely inside Gitmoot's job system.

Built per `GOALS/GOAL-structured-job-delegations.md`. 13 commits, **62 new tests**, full module green (`go test ./...` + `-race`) on the pinned go1.26.4 toolchain.

## What's implemented

| Task | What |
|---|---|
| **3054** | Per-delegation worktree allocation — each `implement` delegation gets an isolated, deterministic worktree + branch (`AllocateDelegationWorktree`) |
| **3055** | Artifact writer + child-prompt reader — coordinator writes `brief.md` + `context-manifest.json` once (under `$GITMOOT_HOME`, kept out of the tracked tree); children's prompts point at them |
| **3056** | Dependency graph + continuation jobs — `deps` gating, `advanceDelegations`, idempotent coordinator continuation, `failure_policy` (block_parent/continue/escalate) |
| **3059** | Phase-2 lifecycle controls — `timeout`, `retry`, `fingerprint` dedup, `synthesis_rule` vote |
| **3057** | Dashboard DAG — delegation tree (parent → children → continuation) in the job-detail view |
| **3058** | Docs, planner template, WORKFLOWS.md, beta smoke test |

Also bundles a small **pre-existing-test fix**: `TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos` was red on `main` (it built the worker with no home → defaulted to `fork_temp_session` → shelled out to a real `codex` CLI absent in CI). Made deterministic with a `same_session="queue"` home. Test-only.

## Acceptance criteria (#301)

- ✅ Coordinator returns `delegations` that spawn workers in parallel
- ✅ Workers receive a focused brief (artifact dir referenced in their prompt)
- ✅ Dashboard shows the delegation tree/DAG
- ✅ Continuation job created automatically when all deps finish (exactly once; `-race` tested)
- ✅ `next_agents` removed cleanly (no tracked references; back-compat verified)

## Quality process

This branch went through **three adversarial review rounds** (multi-agent), each fixing what the prior surfaced:

1. **8-way verification** → found 1 critical + 11 major. Fixed: deps-graph validation (duplicate ids / unknown deps / cycles), the **critical** fingerprint-dedup continuation deadlock, worktree/branch/retry collisions, dashboard retry-row duplication, and timeout→DAG integration.
2. **6-way re-verification** → found 2 residual majors: a *deferred-dedup* variant of the liveness stall (stale events snapshot) and timed-out implement-retries losing worktree isolation. Both fixed with regression tests.

Each fix ships a test that fails before / passes after.

## Test plan

```
GOTOOLCHAIN=local go build ./...      # ok
GOTOOLCHAIN=local go vet ./...        # ok
GOTOOLCHAIN=local go test ./...       # ok (all 30 packages)
GOTOOLCHAIN=local go test -race ./internal/workflow/   # ok (concurrency exactly-once)
```

## Known follow-ups (minor/nit — intentionally out of scope)

- Failed-attempt retry worktrees are not GC'd (each retry gets a fresh dir; cleanup is a lifecycle concern).
- A few test-rigor gaps (dashboard `JobDetail` seam integration test; dashboard dedup tests don't independently distinguish from the old code path).
- Cosmetic: timeout-finalize event asymmetry; duplicate `delegation_retry` event under concurrent retry; manifest surfaces the declared logical worktree name rather than the allocated branch.
- `escalate` failure_policy is all-or-nothing for deferred dependents (documented behavior).
- Acceptance criterion "workers don't re-explore the repo" is a prompt-level hint, not enforceable at the runtime boundary.

Implements #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
