### PR TITLE
feat: layered termination — loop detection + budgets for delegation recursion (#305 Now tier)

### DIFF
--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -73,8 +73,19 @@ func RenderJob(prompt JobPrompt) string {
 	builder.WriteString("Use this shape:\n")
 	builder.WriteString(`{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`)
 	builder.WriteByte('\n')
+	builder.WriteString(delegationSchemaHelp)
 	return builder.String()
 }
+
+// delegationSchemaHelp documents the delegations[] object shape inside the
+// rendered prompt itself. Runtime agents (codex/claude/kimi) only receive this
+// prompt, not the gitmoot skill docs, so without this they guess field names
+// (e.g. "to" instead of "agent") and the result fails validation.
+const delegationSchemaHelp = "\nEach delegations[] entry is an object: " +
+	`{"id":"unique-id","agent":"gitmoot-agent-name","action":"ask|review|implement","prompt":"what the agent should do"}` +
+	"\n- id, agent, action, and prompt are ALL required. Use \"agent\" (the target Gitmoot agent's name), not \"to\".\n" +
+	"- Optional: \"deps\":[\"other-id\"] makes this delegation wait until those sibling delegations succeed.\n" +
+	"- Leave delegations empty ([]) when no follow-up agents are needed — that is how you signal the work is complete.\n"
 
 func RenderRepairPrompt(rawOutput string, parseError error) string {
 	var builder strings.Builder
@@ -84,7 +95,9 @@ func RenderRepairPrompt(rawOutput string, parseError error) string {
 	}
 	builder.WriteString("\nReturn only one JSON object in this exact shape:\n")
 	builder.WriteString(`{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`)
-	builder.WriteString("\n\nPrevious raw output:\n")
+	builder.WriteString("\n")
+	builder.WriteString(delegationSchemaHelp)
+	builder.WriteString("\nPrevious raw output:\n")
 	builder.WriteString(trimRawOutput(rawOutput, 12000))
 	builder.WriteByte('\n')
 	return builder.String()

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -2,10 +2,13 @@ package workflow
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -530,6 +533,60 @@ const MaxDelegationDepth = 8
 // refuses further children and records a delegation_budget_exceeded event.
 const MaxDelegationTotalJobs = 64
 
+// delegationHashWindowSize is how many recent delegation-set hashes a coordinator
+// continuation chain remembers (threaded via the payload, not scanned across
+// jobs). A repeat within this sliding window is what the loop detector treats as
+// non-progress: a coordinator re-issuing a delegation set it already issued.
+const delegationHashWindowSize = 3
+
+// canonicalDelegationSetHash hashes a delegation set into a stable, order-
+// independent fingerprint so two continuations that re-issue "the same work"
+// produce the same hash even if the delegations are listed in a different order.
+// Delegations are sorted by ID; for each, the ID, Agent, Action, trimmed Prompt,
+// and sorted/compacted Deps are emitted with a separator that cannot appear in a
+// normal field, then the whole thing is SHA-256 hashed. Any change to a prompt,
+// agent, action, dep, or the set of ids changes the hash; pure reordering does
+// not.
+func canonicalDelegationSetHash(dels []Delegation) string {
+	sorted := make([]Delegation, len(dels))
+	copy(sorted, dels)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+
+	var builder strings.Builder
+	for _, d := range sorted {
+		deps := compactStrings(d.Deps)
+		sort.Strings(deps)
+		fields := []string{d.ID, d.Agent, d.Action, strings.TrimSpace(d.Prompt), strings.Join(deps, ",")}
+		builder.WriteString(strings.Join(fields, "\x1f"))
+		builder.WriteString("\x1e")
+	}
+	sum := sha256.Sum256([]byte(builder.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+// appendDelegationHashWindow appends h to the sliding window, keeping only the
+// most recent delegationHashWindowSize entries so the loop detector reasons over
+// a bounded history threaded through the payload.
+func appendDelegationHashWindow(window []string, h string) []string {
+	window = append(window, h)
+	if len(window) > delegationHashWindowSize {
+		window = window[len(window)-delegationHashWindowSize:]
+	}
+	return window
+}
+
+// windowContainsHash reports whether the sliding window already holds h, i.e. the
+// coordinator is re-issuing a delegation set it issued within the last few
+// generations.
+func windowContainsHash(window []string, h string) bool {
+	for _, existing := range window {
+		if existing == h {
+			return true
+		}
+	}
+	return false
+}
+
 // countRootDelegationJobs counts every job belonging to a coordination tree: the
 // originating coordinator itself (job.ID == rootID) plus every child or
 // continuation whose payload RootJobID points back at it. There is no store query
@@ -584,6 +641,16 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		return nil
 	}
 
+	// Windowed non-progress detection. The depth/budget caps above are blunt
+	// safety nets; this catches the common loop sooner: a coordinator whose
+	// continuation re-issues a delegation set it already issued within the last
+	// few generations (the window threaded through the payload). A real,
+	// progressing coordinator emits a different set each round, so its hash is
+	// never in the window and dispatch proceeds untouched.
+	if stopped, err := e.handleDelegationLoop(ctx, job, payload, ref); err != nil || stopped {
+		return err
+	}
+
 	delegations := payload.Result.Delegations
 
 	// Preflight every delegation (ready and deferred) before enqueueing any
@@ -629,6 +696,76 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		}
 	}
 	return nil
+}
+
+// handleDelegationLoop implements the windowed non-progress check. It compares
+// the current delegation set's canonical hash against the sliding window
+// threaded through the payload and decides whether dispatch should be halted:
+//
+//   - the hash is NOT in the window: not a repeat. Returns (false, nil); the
+//     caller dispatches normally and maybeEnqueueContinuation records this hash
+//     in the window for the next generation.
+//   - the hash IS in the window and the coordinator was already nudged once
+//     (DelegationRepeatCount >= 1): a confirmed loop. Records a
+//     delegation_loop_detected event and returns (true, nil) so dispatch is
+//     skipped — the coordinator got a corrective continuation and repeated anyway.
+//   - the hash IS in the window for the first time: records a
+//     delegation_loop_warning and, instead of dispatching, enqueues one
+//     corrective continuation that tells the coordinator to change its approach
+//     or finish. Returns (true, nil) so the repeat is not dispatched.
+//
+// Returning (true, ...) means "do not dispatch"; (false, nil) means "proceed".
+func (e Engine) handleDelegationLoop(ctx context.Context, job db.Job, payload JobPayload, ref taskRef) (bool, error) {
+	currentHash := canonicalDelegationSetHash(payload.Result.Delegations)
+	if !windowContainsHash(payload.RecentDelegationHashes, currentHash) {
+		return false, nil
+	}
+
+	if payload.DelegationRepeatCount >= 1 {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_loop_detected",
+			Message: fmt.Sprintf("delegation set %s repeated after a corrective nudge (repeat count %d); not dispatching %d delegation(s)", currentHash, payload.DelegationRepeatCount, len(payload.Result.Delegations)),
+		})
+		return true, nil
+	}
+
+	_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   job.ID,
+		Kind:    "delegation_loop_warning",
+		Message: fmt.Sprintf("delegation set %s repeats a recent round; sending a corrective continuation instead of dispatching %d delegation(s)", currentHash, len(payload.Result.Delegations)),
+	})
+
+	request := JobRequest{
+		ID:              delegationContinuationID(job.ID),
+		Agent:           job.Agent,
+		Action:          "ask",
+		Repo:            payload.Repo,
+		Branch:          payload.Branch,
+		PullRequest:     payload.PullRequest,
+		HeadSHA:         payload.HeadSHA,
+		GoalID:          payload.GoalID,
+		TaskID:          payload.TaskID,
+		TaskTitle:       payload.TaskTitle,
+		LeadAgent:       payload.LeadAgent,
+		Reviewers:       payload.Reviewers,
+		Sender:          job.Agent,
+		Instructions:    buildCorrectiveContinuationPrompt(payload.Result),
+		Constraints:     payload.Constraints,
+		ParentJobID:     job.ID,
+		DelegationDepth: payload.DelegationDepth + 1,
+		DelegatedBy:     job.Agent,
+		RootJobID:       e.rootJobID(job, payload),
+		// Carry the window forward (now including this repeat) and mark that a
+		// corrective nudge has fired, so if the next generation repeats again the
+		// detector escalates to delegation_loop_detected.
+		RecentDelegationHashes: appendDelegationHashWindow(payload.RecentDelegationHashes, currentHash),
+		DelegationRepeatCount:  payload.DelegationRepeatCount + 1,
+	}
+	if err := e.enqueue(ctx, request); err != nil {
+		return true, fmt.Errorf("enqueue corrective continuation for %q: %w", job.ID, err)
+	}
+	return true, nil
 }
 
 // enqueueDelegation allocates the per-delegation worktree (or branch lock) for
@@ -942,22 +1079,22 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 	}
 
 	request := JobRequest{
-		ID:              delegationContinuationID(parentJob.ID),
-		Agent:           parentJob.Agent,
-		Action:          "ask",
-		Repo:            parentPayload.Repo,
-		Branch:          parentPayload.Branch,
-		PullRequest:     parentPayload.PullRequest,
-		HeadSHA:         parentPayload.HeadSHA,
-		GoalID:          parentPayload.GoalID,
-		TaskID:          parentPayload.TaskID,
-		TaskTitle:       parentPayload.TaskTitle,
-		LeadAgent:       parentPayload.LeadAgent,
-		Reviewers:       parentPayload.Reviewers,
-		Sender:          parentJob.Agent,
-		Instructions:    buildContinuationPrompt(parentResult, children, childPayloads),
-		Constraints:     parentPayload.Constraints,
-		ParentJobID:     parentJob.ID,
+		ID:           delegationContinuationID(parentJob.ID),
+		Agent:        parentJob.Agent,
+		Action:       "ask",
+		Repo:         parentPayload.Repo,
+		Branch:       parentPayload.Branch,
+		PullRequest:  parentPayload.PullRequest,
+		HeadSHA:      parentPayload.HeadSHA,
+		GoalID:       parentPayload.GoalID,
+		TaskID:       parentPayload.TaskID,
+		TaskTitle:    parentPayload.TaskTitle,
+		LeadAgent:    parentPayload.LeadAgent,
+		Reviewers:    parentPayload.Reviewers,
+		Sender:       parentJob.Agent,
+		Instructions: buildContinuationPrompt(parentResult, children, childPayloads),
+		Constraints:  parentPayload.Constraints,
+		ParentJobID:  parentJob.ID,
 		// Increment depth per continuation generation so a coordinator whose
 		// continuation re-delegates is bounded by MaxDelegationDepth instead of
 		// looping forever (the continuation reused the parent's depth before).
@@ -966,6 +1103,12 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		// Share the originating coordinator's root so the whole continuation
 		// chain counts against one per-root budget and is visible to loop detection.
 		RootJobID: e.rootJobID(parentJob, parentPayload),
+		// Record the delegation set that was actually dispatched in the sliding
+		// window so the next generation can detect a non-progress repeat. A real
+		// dispatch happened => progress, so reset the repeat counter; the
+		// corrective-nudge counter only climbs while the coordinator loops.
+		RecentDelegationHashes: appendDelegationHashWindow(parentPayload.RecentDelegationHashes, canonicalDelegationSetHash(parentResult.Delegations)),
+		DelegationRepeatCount:  0,
 	}
 	if err := e.enqueue(ctx, request); err != nil {
 		return fmt.Errorf("enqueue continuation for %q: %w", parentJob.ID, err)
@@ -1345,6 +1488,23 @@ func buildContinuationPrompt(parentResult *AgentResult, children map[string]db.J
 	// Completion contract: make termination directed. The engine already treats
 	// an empty delegations list as terminal, so spell it out for the agent.
 	builder.WriteString("\n\nIf the goal is now complete, return your result with an EMPTY delegations list to finish. Only return new delegations if more work is genuinely required.")
+	return builder.String()
+}
+
+// buildCorrectiveContinuationPrompt is the one-shot nudge sent when a
+// coordinator re-issues a delegation set it already issued. It tells the
+// coordinator the repeat changed nothing and asks it to change approach or
+// finish, then lists the repeated delegations for context. If it repeats again,
+// handleDelegationLoop escalates to delegation_loop_detected and stops.
+func buildCorrectiveContinuationPrompt(parentResult *AgentResult) string {
+	var builder strings.Builder
+	builder.WriteString("You delegated the same set as a previous round; it did not change the outcome. Change your approach or return an EMPTY delegations list to finish.\n\n")
+	if parentResult != nil && len(parentResult.Delegations) > 0 {
+		builder.WriteString("Repeated delegation set:\n")
+		for _, d := range parentResult.Delegations {
+			fmt.Fprintf(&builder, "- delegation %q (agent %s, action %s)\n", d.ID, d.Agent, d.Action)
+		}
+	}
 	return builder.String()
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -464,10 +464,22 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 	return nil
 }
 
+// rootJobID returns the id of the coordinator that originated a coordination
+// tree. A child or continuation inherits its parent's RootJobID via the payload;
+// the originating coordinator has no RootJobID, so its own job id is the root.
+// Every job in one tree therefore shares a single root, which lets the loop
+// detector and per-root budget reason about the whole tree at once.
+func (e Engine) rootJobID(job db.Job, payload JobPayload) string {
+	if strings.TrimSpace(payload.RootJobID) != "" {
+		return payload.RootJobID
+	}
+	return job.ID
+}
+
 // delegationRequest builds the canonical child JobRequest for a delegation,
 // inheriting the parent's repo/branch/PR context and stamping the DAG fields
-// (ParentJobID/DelegationID/DelegationDepth/DelegatedBy/Deps). It is shared by
-// dispatchDelegations (initial enqueue of ready delegations) and
+// (ParentJobID/DelegationID/DelegationDepth/DelegatedBy/RootJobID/Deps). It is
+// shared by dispatchDelegations (initial enqueue of ready delegations) and
 // advanceDelegations (deferred enqueue once deps clear) so both paths produce
 // identical, idempotent requests for the same delegation ID.
 func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) JobRequest {
@@ -492,6 +504,7 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 		DelegationID:    d.ID,
 		DelegationDepth: payload.DelegationDepth + 1,
 		DelegatedBy:     job.Agent,
+		RootJobID:       e.rootJobID(job, payload),
 		Deps:            compactStrings(d.Deps),
 		JobTimeout:      strings.TrimSpace(d.Timeout),
 		Fingerprint:     strings.TrimSpace(d.Fingerprint),
@@ -509,6 +522,40 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 // looping agent) would otherwise spawn jobs forever.
 const MaxDelegationDepth = 8
 
+// MaxDelegationTotalJobs bounds how many jobs a single coordination tree (all
+// children and continuations sharing one root, see rootJobID) may produce. Where
+// MaxDelegationDepth caps nesting in one branch, this caps the total fan-out so a
+// coordinator that re-delegates wide (rather than deep) on every continuation is
+// still halted. Once a root's tree reaches this many jobs, dispatchDelegations
+// refuses further children and records a delegation_budget_exceeded event.
+const MaxDelegationTotalJobs = 64
+
+// countRootDelegationJobs counts every job belonging to a coordination tree: the
+// originating coordinator itself (job.ID == rootID) plus every child or
+// continuation whose payload RootJobID points back at it. There is no store query
+// keyed on root, so it lists all jobs and filters (mirroring childDelegationJobs).
+func (e Engine) countRootDelegationJobs(ctx context.Context, rootID string) (int, error) {
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, job := range jobs {
+		if job.ID == rootID {
+			count++
+			continue
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return 0, err
+		}
+		if payload.RootJobID == rootID {
+			count++
+		}
+	}
+	return count, nil
+}
+
 func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload JobPayload, ref taskRef) error {
 	if payload.Result == nil || len(payload.Result.Delegations) == 0 {
 		return nil
@@ -519,6 +566,20 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 			JobID:   job.ID,
 			Kind:    "delegation_depth_exceeded",
 			Message: fmt.Sprintf("delegation depth %d reached the limit of %d; not dispatching %d delegation(s)", payload.DelegationDepth, MaxDelegationDepth, len(payload.Result.Delegations)),
+		})
+		return nil
+	}
+
+	rootID := e.rootJobID(job, payload)
+	total, err := e.countRootDelegationJobs(ctx, rootID)
+	if err != nil {
+		return err
+	}
+	if total >= MaxDelegationTotalJobs {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_budget_exceeded",
+			Message: fmt.Sprintf("delegation tree for root %s reached the job budget of %d (%d jobs); not dispatching %d delegation(s)", rootID, MaxDelegationTotalJobs, total, len(payload.Result.Delegations)),
 		})
 		return nil
 	}
@@ -902,6 +963,9 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		// looping forever (the continuation reused the parent's depth before).
 		DelegationDepth: parentPayload.DelegationDepth + 1,
 		DelegatedBy:     parentJob.Agent,
+		// Share the originating coordinator's root so the whole continuation
+		// chain counts against one per-root budget and is visible to loop detection.
+		RootJobID: e.rootJobID(parentJob, parentPayload),
 	}
 	if err := e.enqueue(ctx, request); err != nil {
 		return fmt.Errorf("enqueue continuation for %q: %w", parentJob.ID, err)
@@ -1278,6 +1342,9 @@ func buildContinuationPrompt(parentResult *AgentResult, children map[string]db.J
 		}
 		builder.WriteString("\n")
 	}
+	// Completion contract: make termination directed. The engine already treats
+	// an empty delegations list as terminal, so spell it out for the agent.
+	builder.WriteString("\n\nIf the goal is now complete, return your result with an EMPTY delegations list to finish. Only return new delegations if more work is genuinely required.")
 	return builder.String()
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -533,7 +533,20 @@ const MaxDelegationDepth = 8
 // refuses further children and records a delegation_budget_exceeded event.
 const MaxDelegationTotalJobs = 64
 
+// MaxDelegationWidth bounds how many delegations a single coordinator result may
+// fan out in one generation. The total-jobs budget is checked before a batch is
+// dispatched, so it cannot stop one enormous fan-out on its own; this caps the
+// width of a single dispatch so a coordinator returning hundreds of delegations
+// at once is refused with a delegation_width_exceeded event.
+const MaxDelegationWidth = 16
+
 // delegationHashWindowSize is how many recent delegation-set hashes a coordinator
+// continuation chain remembers (threaded via the payload, not scanned across
+// jobs). A repeat within this sliding window is what the loop detector treats as
+// non-progress: a coordinator re-issuing a delegation set it already issued.
+// NOTE (follow-up, issue #305 "Later"): detection is set-only (not result-aware)
+// and only catches cycles of period <= delegationHashWindowSize; longer cycles
+// fall back to the depth/total-job/width backstops.
 // continuation chain remembers (threaded via the payload, not scanned across
 // jobs). A repeat within this sliding window is what the loop detector treats as
 // non-progress: a coordinator re-issuing a delegation set it already issued.
@@ -641,6 +654,15 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		return nil
 	}
 
+	if width := len(payload.Result.Delegations); width > MaxDelegationWidth {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_width_exceeded",
+			Message: fmt.Sprintf("delegation set width %d exceeds the per-coordinator limit of %d; not dispatching", width, MaxDelegationWidth),
+		})
+		return nil
+	}
+
 	// Windowed non-progress detection. The depth/budget caps above are blunt
 	// safety nets; this catches the common loop sooner: a coordinator whose
 	// continuation re-issues a delegation set it already issued within the last
@@ -719,6 +741,19 @@ func (e Engine) handleDelegationLoop(ctx context.Context, job db.Job, payload Jo
 	currentHash := canonicalDelegationSetHash(payload.Result.Delegations)
 	if !windowContainsHash(payload.RecentDelegationHashes, currentHash) {
 		return false, nil
+	}
+
+	// Idempotent on re-advance: if this job already emitted a loop event it has
+	// already enqueued its corrective continuation (deterministic id), so do not
+	// re-emit the event or double-count it.
+	events, err := e.Store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		return true, err
+	}
+	for _, ev := range events {
+		if ev.Kind == "delegation_loop_warning" || ev.Kind == "delegation_loop_detected" {
+			return true, nil
+		}
 	}
 
 	if payload.DelegationRepeatCount >= 1 {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3040,3 +3040,231 @@ func (f *fakeMergeGate) Evaluate(_ context.Context, request MergeRequest) (Merge
 	}
 	return f.decision, nil
 }
+
+// TestCanonicalDelegationSetHashStableUnderReorder pins the order-independence and
+// change-sensitivity contract the loop detector relies on: reordering the same
+// delegation set yields the same hash, while changing any field (prompt, agent,
+// or a dep) yields a different one.
+func TestCanonicalDelegationSetHashStableUnderReorder(t *testing.T) {
+	base := []Delegation{
+		{ID: "a", Agent: "wa", Action: "review", Prompt: "step a", Deps: []string{"x", "y"}},
+		{ID: "b", Agent: "wb", Action: "review", Prompt: "step b"},
+	}
+	reordered := []Delegation{
+		{ID: "b", Agent: "wb", Action: "review", Prompt: "step b"},
+		{ID: "a", Agent: "wa", Action: "review", Prompt: "step a", Deps: []string{"y", "x"}},
+	}
+	if canonicalDelegationSetHash(base) != canonicalDelegationSetHash(reordered) {
+		t.Fatal("hash must be stable under delegation and dep reordering")
+	}
+	// Whitespace-only prompt differences are normalized away.
+	trimmed := []Delegation{
+		{ID: "a", Agent: "wa", Action: "review", Prompt: "  step a  ", Deps: []string{"x", "y"}},
+		{ID: "b", Agent: "wb", Action: "review", Prompt: "step b"},
+	}
+	if canonicalDelegationSetHash(base) != canonicalDelegationSetHash(trimmed) {
+		t.Fatal("hash must ignore surrounding prompt whitespace")
+	}
+
+	promptChanged := []Delegation{
+		{ID: "a", Agent: "wa", Action: "review", Prompt: "DIFFERENT", Deps: []string{"x", "y"}},
+		{ID: "b", Agent: "wb", Action: "review", Prompt: "step b"},
+	}
+	agentChanged := []Delegation{
+		{ID: "a", Agent: "OTHER", Action: "review", Prompt: "step a", Deps: []string{"x", "y"}},
+		{ID: "b", Agent: "wb", Action: "review", Prompt: "step b"},
+	}
+	depChanged := []Delegation{
+		{ID: "a", Agent: "wa", Action: "review", Prompt: "step a", Deps: []string{"x", "z"}},
+		{ID: "b", Agent: "wb", Action: "review", Prompt: "step b"},
+	}
+	baseHash := canonicalDelegationSetHash(base)
+	for name, changed := range map[string][]Delegation{
+		"prompt": promptChanged,
+		"agent":  agentChanged,
+		"dep":    depChanged,
+	} {
+		if canonicalDelegationSetHash(changed) == baseHash {
+			t.Fatalf("hash must change when the %s changes", name)
+		}
+	}
+}
+
+// TestAppendDelegationHashWindowKeepsLastThree pins the sliding-window bound: only
+// the most recent delegationHashWindowSize hashes are retained.
+func TestAppendDelegationHashWindowKeepsLastThree(t *testing.T) {
+	var window []string
+	for _, h := range []string{"h1", "h2", "h3", "h4"} {
+		window = appendDelegationHashWindow(window, h)
+	}
+	if len(window) != delegationHashWindowSize {
+		t.Fatalf("window length = %d, want %d", len(window), delegationHashWindowSize)
+	}
+	want := []string{"h2", "h3", "h4"}
+	if !equalStrings(window, want) {
+		t.Fatalf("window = %v, want %v", window, want)
+	}
+}
+
+// driveStaticGeneration simulates one coordinator continuation generation: it
+// stamps the already-enqueued continuation job with a delegation result (the
+// same set every time, modeling a static coordinator) and advances it, which is
+// exactly what the daemon does when the continuation runs and re-delegates.
+func driveStaticGeneration(t *testing.T, store *db.Store, engine Engine, continuationID string, dels []Delegation) error {
+	t.Helper()
+	completeDelegationChild(t, store, continuationID, JobSucceeded, AgentResult{
+		Decision:    "approved",
+		Summary:     "still working",
+		Delegations: dels,
+	})
+	return engine.AdvanceJob(context.Background(), continuationID)
+}
+
+// TestEngineStaticCoordinatorHaltedByLoopDetection is the core regression: a
+// coordinator whose continuation re-issues the SAME delegation set every round is
+// stopped by windowed non-progress detection (a warning + corrective nudge, then
+// a delegation_loop_detected halt) well before MaxDelegationDepth — not left to
+// the blunt depth cap.
+func TestEngineStaticCoordinatorHaltedByLoopDetection(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	dels := []Delegation{{ID: "w1", Agent: "w", Action: "review", Prompt: "do work"}}
+
+	// Generation 0: the originating coordinator dispatches the set for real.
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result:    &AgentResult{Decision: "approved", Summary: "round 0", Delegations: dels},
+	})
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root) returned error: %v", err)
+	}
+	if !jobExists(t, store, "root-job/delegation/w1") {
+		t.Fatal("generation 0 must dispatch the delegation for real")
+	}
+
+	// Child finishes -> continuation (generation 1) is enqueued carrying the
+	// window with generation 0's hash.
+	completeDelegationChild(t, store, "root-job/delegation/w1", JobSucceeded, AgentResult{Decision: "approved", Summary: "w1 ok"})
+	if err := engine.AdvanceJob(ctx, "root-job/delegation/w1"); err != nil {
+		t.Fatalf("AdvanceJob(child) returned error: %v", err)
+	}
+	continuationID := delegationContinuationID("root-job")
+	if !jobExists(t, store, continuationID) {
+		t.Fatal("a continuation must be enqueued after the child finishes")
+	}
+
+	// Generation 1: the continuation re-issues the SAME set. This is the first
+	// repeat -> a warning fires and a corrective continuation is enqueued INSTEAD
+	// of dispatching. The corrective continuation reuses the continuation id.
+	if err := driveStaticGeneration(t, store, engine, continuationID, dels); err != nil {
+		t.Fatalf("driveStaticGeneration(gen1) returned error: %v", err)
+	}
+	if countJobEvents(t, store, continuationID, "delegation_loop_warning") != 1 {
+		t.Fatal("first repeat must record exactly one delegation_loop_warning")
+	}
+	correctiveID := delegationContinuationID(continuationID)
+	if !jobExists(t, store, correctiveID) {
+		t.Fatal("first repeat must enqueue a corrective continuation instead of dispatching")
+	}
+	correctivePayload, err := unmarshalPayload(mustJob(t, store, correctiveID).Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(corrective) returned error: %v", err)
+	}
+	if correctivePayload.DelegationRepeatCount != 1 {
+		t.Fatalf("corrective DelegationRepeatCount = %d, want 1", correctivePayload.DelegationRepeatCount)
+	}
+	if !strings.Contains(correctivePayload.Instructions, "EMPTY delegations list") {
+		t.Fatalf("corrective prompt missing the change-or-finish nudge: %q", correctivePayload.Instructions)
+	}
+
+	// Generation 2: the coordinator repeats AGAIN after the corrective nudge ->
+	// delegation_loop_detected halts it with no further dispatch.
+	if err := driveStaticGeneration(t, store, engine, correctiveID, dels); err != nil {
+		t.Fatalf("driveStaticGeneration(gen2) returned error: %v", err)
+	}
+	if countJobEvents(t, store, correctiveID, "delegation_loop_detected") != 1 {
+		t.Fatal("second repeat after a nudge must record delegation_loop_detected")
+	}
+	// No further child or continuation may be created off the halted generation.
+	if jobExists(t, store, delegationContinuationID(correctiveID)) {
+		t.Fatal("delegation_loop_detected must not enqueue another continuation")
+	}
+
+	// It stopped well before the blunt depth cap: the deepest job created carries
+	// a DelegationDepth far below MaxDelegationDepth.
+	if correctivePayload.DelegationDepth >= MaxDelegationDepth {
+		t.Fatalf("loop detection must halt well before MaxDelegationDepth=%d (depth=%d)", MaxDelegationDepth, correctivePayload.DelegationDepth)
+	}
+}
+
+// TestEngineProgressingCoordinatorNotFalselyFlagged pins the false-positive guard:
+// a coordinator that issues a DIFFERENT delegation set each continuation keeps
+// dispatching for real and is never flagged as a loop.
+func TestEngineProgressingCoordinatorNotFalselyFlagged(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	// Generation 0: dispatch the first distinct set for real.
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision:    "approved",
+			Summary:     "round 0",
+			Delegations: []Delegation{{ID: "w1", Agent: "w", Action: "review", Prompt: "round 0 work"}},
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root) returned error: %v", err)
+	}
+
+	completeDelegationChild(t, store, "root-job/delegation/w1", JobSucceeded, AgentResult{Decision: "approved", Summary: "w1 ok"})
+	if err := engine.AdvanceJob(ctx, "root-job/delegation/w1"); err != nil {
+		t.Fatalf("AdvanceJob(child) returned error: %v", err)
+	}
+
+	// Walk several generations, each issuing a DISTINCT delegation set. Every
+	// generation must dispatch a real child and never warn or halt.
+	parentID := "root-job"
+	for round := 1; round <= 4; round++ {
+		continuationID := delegationContinuationID(parentID)
+		if !jobExists(t, store, continuationID) {
+			t.Fatalf("round %d: continuation must be enqueued", round)
+		}
+		delID := fmt.Sprintf("w%d", round+1)
+		dels := []Delegation{{ID: delID, Agent: "w", Action: "review", Prompt: fmt.Sprintf("round %d work", round)}}
+		if err := driveStaticGeneration(t, store, engine, continuationID, dels); err != nil {
+			t.Fatalf("round %d: generation returned error: %v", round, err)
+		}
+		if countJobEvents(t, store, continuationID, "delegation_loop_warning") != 0 {
+			t.Fatalf("round %d: a progressing coordinator must not warn", round)
+		}
+		if countJobEvents(t, store, continuationID, "delegation_loop_detected") != 0 {
+			t.Fatalf("round %d: a progressing coordinator must not be halted", round)
+		}
+		childID := continuationID + "/delegation/" + delID
+		if !jobExists(t, store, childID) {
+			t.Fatalf("round %d: a distinct set must dispatch a real child %s", round, childID)
+		}
+		// Finish the round's child so the next continuation is enqueued.
+		completeDelegationChild(t, store, childID, JobSucceeded, AgentResult{Decision: "approved", Summary: "ok"})
+		if err := engine.AdvanceJob(ctx, childID); err != nil {
+			t.Fatalf("round %d: AdvanceJob(child) returned error: %v", round, err)
+		}
+		parentID = continuationID
+	}
+}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2717,6 +2717,45 @@ func TestEngineDelegationBudgetCapStopsDispatch(t *testing.T) {
 	}
 }
 
+// TestEngineDelegationWidthCapStopsDispatch covers the per-coordinator fan-out
+// width cap: the total-jobs budget is checked before a batch is dispatched, so
+// it cannot stop one enormous single fan-out; the width cap does.
+func TestEngineDelegationWidthCapStopsDispatch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	dels := make([]Delegation, 0, MaxDelegationWidth+1)
+	for i := 0; i <= MaxDelegationWidth; i++ {
+		dels = append(dels, Delegation{ID: fmt.Sprintf("d%d", i), Agent: "w", Action: "ask", Prompt: "work"})
+	}
+	insertCompletedJob(t, store, db.Job{ID: "wide-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "too wide", Delegations: dels},
+	})
+	if err := engine.AdvanceJob(ctx, "wide-job"); err != nil {
+		t.Fatalf("AdvanceJob(wide): %v", err)
+	}
+	if jobExists(t, store, "wide-job/delegation/d0") {
+		t.Fatal("a delegation set wider than MaxDelegationWidth must not be dispatched")
+	}
+	events, err := store.ListJobEvents(ctx, "wide-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	widened := false
+	for _, ev := range events {
+		if ev.Kind == "delegation_width_exceeded" {
+			widened = true
+		}
+	}
+	if !widened {
+		t.Fatal("expected a delegation_width_exceeded event")
+	}
+}
+
 // TestEngineDelegationEscalateThenBlockParentFoldsIntoContinuation pins the
 // contradictory-state fix: once an escalate failure has enqueued the
 // continuation, a later block_parent sibling failure must NOT also block the

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2573,6 +2574,146 @@ func TestEngineDelegationDepthCapStopsDispatch(t *testing.T) {
 	}
 	if !jobExists(t, store, "shallow-job/delegation/w1") {
 		t.Fatal("delegation just under the depth cap must still dispatch")
+	}
+}
+
+// TestEngineDelegationRootJobIDPropagates pins the lineage scaffolding the loop
+// detector relies on: an originating coordinator has no RootJobID, so its own id
+// is the root; both its delegation children and its continuation inherit that
+// same root so the whole coordination tree shares one originating id.
+func TestEngineDelegationRootJobIDPropagates(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "w1", Agent: "w", Action: "review", Prompt: "do work"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root) returned error: %v", err)
+	}
+
+	// The child inherits the originating coordinator's id as its root.
+	child := mustJob(t, store, "root-job/delegation/w1")
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(child) returned error: %v", err)
+	}
+	if childPayload.RootJobID != "root-job" {
+		t.Fatalf("child RootJobID = %q, want %q", childPayload.RootJobID, "root-job")
+	}
+
+	// Once the child finishes, the continuation must share the same root.
+	completeDelegationChild(t, store, "root-job/delegation/w1", JobSucceeded, AgentResult{Decision: "approved", Summary: "w1 ok"})
+	if err := engine.AdvanceJob(ctx, "root-job/delegation/w1"); err != nil {
+		t.Fatalf("AdvanceJob(child) returned error: %v", err)
+	}
+	continuation := mustJob(t, store, delegationContinuationID("root-job"))
+	continuationPayload, err := unmarshalPayload(continuation.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(continuation) returned error: %v", err)
+	}
+	if continuationPayload.RootJobID != "root-job" {
+		t.Fatalf("continuation RootJobID = %q, want %q", continuationPayload.RootJobID, "root-job")
+	}
+}
+
+// TestContinuationPromptIncludesCompletionContract pins the L1 completion
+// contract: the continuation prompt must explicitly tell the coordinator to
+// finish by returning an EMPTY delegations list when the goal is complete.
+func TestContinuationPromptIncludesCompletionContract(t *testing.T) {
+	prompt := buildContinuationPrompt(
+		&AgentResult{Delegations: []Delegation{{ID: "w1", Agent: "w"}}},
+		map[string]db.Job{},
+		map[string]JobPayload{},
+	)
+	if !strings.Contains(prompt, "EMPTY delegations list") {
+		t.Fatalf("continuation prompt missing completion contract: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Only return new delegations if more work is genuinely required") {
+		t.Fatalf("continuation prompt missing completion-contract guidance: %q", prompt)
+	}
+}
+
+// TestEngineDelegationBudgetCapStopsDispatch pins the L3 per-root job budget: a
+// coordinator tree that re-delegates wide is halted once it has produced
+// MaxDelegationTotalJobs jobs. Dispatch is refused with a
+// delegation_budget_exceeded event and no further children are created.
+func TestEngineDelegationBudgetCapStopsDispatch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	// Seed MaxDelegationTotalJobs jobs already belonging to the root's tree: the
+	// originating coordinator itself plus enough children stamped with its root.
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "w1", Agent: "w", Action: "review", Prompt: "do work"},
+			},
+		},
+	})
+	for i := 1; i < MaxDelegationTotalJobs; i++ {
+		insertCompletedJob(t, store, db.Job{ID: fmt.Sprintf("root-job/filler/%d", i), Agent: "w", Type: "review"}, JobPayload{
+			Repo:      "jerryfane/gitmoot",
+			Branch:    "task-005",
+			TaskID:    "task-5",
+			Sender:    "coord",
+			RootJobID: "root-job",
+		})
+	}
+
+	count, err := engine.countRootDelegationJobs(ctx, "root-job")
+	if err != nil {
+		t.Fatalf("countRootDelegationJobs returned error: %v", err)
+	}
+	if count != MaxDelegationTotalJobs {
+		t.Fatalf("countRootDelegationJobs = %d, want %d", count, MaxDelegationTotalJobs)
+	}
+
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root) returned error: %v", err)
+	}
+
+	// At the budget: dispatch is refused and no child is created.
+	if jobExists(t, store, "root-job/delegation/w1") {
+		t.Fatal("delegation must NOT be dispatched once the per-root budget is reached")
+	}
+	events, err := store.ListJobEvents(ctx, "root-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	budgeted := false
+	for _, ev := range events {
+		if ev.Kind == "delegation_budget_exceeded" {
+			budgeted = true
+		}
+	}
+	if !budgeted {
+		t.Fatal("expected a delegation_budget_exceeded event at the per-root budget")
 	}
 }
 

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -39,6 +39,7 @@ type JobRequest struct {
 	DelegationID          string
 	DelegationDepth       int
 	DelegatedBy           string
+	RootJobID             string
 	Deps                  []string
 	JobTimeout            string
 	RetryCount            int
@@ -70,6 +71,7 @@ type JobPayload struct {
 	DelegationID           string       `json:"delegation_id,omitempty"`
 	DelegationDepth        int          `json:"delegation_depth,omitempty"`
 	DelegatedBy            string       `json:"delegated_by,omitempty"`
+	RootJobID              string       `json:"root_job_id,omitempty"`
 	Deps                   []string     `json:"deps,omitempty"`
 	JobTimeout             string       `json:"job_timeout,omitempty"`
 	RetryCount             int          `json:"retry_count,omitempty"`
@@ -123,6 +125,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		DelegationID:           request.DelegationID,
 		DelegationDepth:        request.DelegationDepth,
 		DelegatedBy:            request.DelegatedBy,
+		RootJobID:              request.RootJobID,
 		Deps:                   compactStrings(request.Deps),
 		JobTimeout:             strings.TrimSpace(request.JobTimeout),
 		RetryCount:             request.RetryCount,

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -19,38 +19,40 @@ type Mailbox struct {
 }
 
 type JobRequest struct {
-	ID                    string
-	Agent                 string
-	Action                string
-	Repo                  string
-	Branch                string
-	PullRequest           int
-	HeadSHA               string
-	GoalID                string
-	TaskID                string
-	TaskTitle             string
-	LeadAgent             string
-	Reviewers             []string
-	ReviewRound           string
-	Sender                string
-	Instructions          string
-	Constraints           []string
-	ParentJobID           string
-	DelegationID          string
-	DelegationDepth       int
-	DelegatedBy           string
-	RootJobID             string
-	Deps                  []string
-	JobTimeout            string
-	RetryCount            int
-	Fingerprint           string
-	FailurePolicy         string
-	SynthesisRule         string
-	DelegationArtifactDir string
-	WorktreePath          string
-	OriginalAgent         string
-	DelegatedAgent        string
-	DelegationReason      string
+	ID                     string
+	Agent                  string
+	Action                 string
+	Repo                   string
+	Branch                 string
+	PullRequest            int
+	HeadSHA                string
+	GoalID                 string
+	TaskID                 string
+	TaskTitle              string
+	LeadAgent              string
+	Reviewers              []string
+	ReviewRound            string
+	Sender                 string
+	Instructions           string
+	Constraints            []string
+	ParentJobID            string
+	DelegationID           string
+	DelegationDepth        int
+	DelegatedBy            string
+	RootJobID              string
+	Deps                   []string
+	JobTimeout             string
+	RetryCount             int
+	Fingerprint            string
+	FailurePolicy          string
+	SynthesisRule          string
+	DelegationArtifactDir  string
+	WorktreePath           string
+	OriginalAgent          string
+	DelegatedAgent         string
+	DelegationReason       string
+	RecentDelegationHashes []string
+	DelegationRepeatCount  int
 }
 
 type JobPayload struct {
@@ -86,6 +88,8 @@ type JobPayload struct {
 	OriginalAgent          string       `json:"original_agent,omitempty"`
 	DelegatedAgent         string       `json:"delegated_agent,omitempty"`
 	DelegationReason       string       `json:"delegation_reason,omitempty"`
+	RecentDelegationHashes []string     `json:"recent_delegation_hashes,omitempty"`
+	DelegationRepeatCount  int          `json:"delegation_repeat_count,omitempty"`
 	RawOutputs             []string     `json:"raw_outputs,omitempty"`
 	Result                 *AgentResult `json:"result,omitempty"`
 }
@@ -140,6 +144,8 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		OriginalAgent:          request.OriginalAgent,
 		DelegatedAgent:         request.DelegatedAgent,
 		DelegationReason:       request.DelegationReason,
+		RecentDelegationHashes: request.RecentDelegationHashes,
+		DelegationRepeatCount:  request.DelegationRepeatCount,
 	})
 	if err != nil {
 		return db.Job{}, err

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -90,6 +90,35 @@ func TestMailboxEnqueuePersistsDelegationMetadata(t *testing.T) {
 	}
 }
 
+func TestMailboxEnqueuePersistsRootJobID(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:        "job-child",
+		Agent:     "audit",
+		Action:    "ask",
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		RootJobID: "root-coordinator",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	stored, err := store.GetJob(ctx, "job-child")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := unmarshalPayload(stored.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.RootJobID != "root-coordinator" {
+		t.Fatalf("payload RootJobID = %q, want %q", payload.RootJobID, "root-coordinator")
+	}
+}
+
 func TestMailboxEnqueueSnapshotsAgentTemplate(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)


### PR DESCRIPTION
## Summary

Implements the "Now" tier of the layered termination model in #305: replaces "depth-cap-only" runaway protection with **engine-enforced loop detection**, so a coordinator whose continuation re-delegates is stopped by a principled non-progress check — not by grinding to the blunt depth cap.

Follow-up to #301 / PR #304. **Stacked on `feat/delegations-impl-3054-3059`** (PR #304); retarget the base to `main` once #304 merges.

## Why

PR #304 added `MaxDelegationDepth=8` after a live E2E showed a coordinator continuation recursing forever. That's a backstop, not a fix — the **root cause** is that termination was implicit (the continuation prompt never told the agent how to finish) and unconditional (the engine re-invokes the coordinator after every batch). Validated against LangGraph, AutoGen, OpenAI/Anthropic, CrewAI, and Temporal/Step Functions, whose consensus is: termination must be engine-enforced, bound *total work* not just depth, and use windowed non-progress detection (see #305 for citations).

## What ships (Now tier)

| Layer | Mechanism |
|---|---|
| Lineage | `RootJobID` threaded through every child/continuation for per-root scoping |
| L1 contract | continuation prompt now explicitly states "return empty `delegations` to finish" |
| **L2 loop detection** | canonical, order-independent hash of each delegation set; sliding window (last 3); **two-tier** — 1st repeat → `delegation_loop_warning` + corrective continuation; 2nd → `delegation_loop_detected` + halt. Idempotent on re-advance. |
| L3 budget | per-root **total-job** cap (64) + per-coordinator **fan-out width** cap (16), alongside depth (8) |

## Proven live (E2E)

Built a local release and ran a **static shell coordinator** (always returns the same 2 delegations) against a real daemon in an isolated `GITMOOT_HOME`:

| | Original | PR #304 (depth cap) | This PR (loop detection) |
|---|---|---|---|
| Outcome | unbounded (killed at 67 jobs) | halted at depth 8 | **halted at 5 jobs** |
| How | — | `delegation_depth_exceeded` | `delegation_loop_warning` → `delegation_loop_detected` (depth cap never touched) |

## Verification
- 4-way adversarial re-verify: loop-detection, budget-lineage, and interactions all **confirmed** (high confidence).
- `go build` / `vet` / `test ./...` (30 pkgs) / `-race ./internal/workflow` all green on the pinned toolchain.
- 8 new tests (canonical-hash stability/sensitivity, window bound, static-coordinator-halts-via-L2, progressing-coordinator-not-flagged, RootJobID propagation, completion contract, per-root budget cap, fan-out width cap).

## Deferred to #305 "Later" (documented in code + issue)
- **Graceful finalize**: a best-effort "synthesize and finish" continuation on a backstop trip (today a trip stops with a typed event).
- **Result-aware hashing**: fold child results into the loop signature (today set-only; catches cycles of period ≤ window, longer cycles fall back to the depth/total-job/width backstops).

Implements #305 (Now tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
