### PR TITLE
ci: add GitHub Actions build/vet/test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+# Runs the build/vet/test gate on every push to main and every pull request, so
+# "the tests pass" is enforced on a clean checkout rather than trusted from a
+# local run. Does NOT run the live multi-runtime (codex/claude/kimi) E2E — that
+# needs runtime auth and stays a manual step.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: build / vet / test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Test (race detector, workflow engine)
+        run: go test -race ./internal/workflow/

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -1408,6 +1408,15 @@ func TestRunQueuedJobsSerializesSameRepoCheckout(t *testing.T) {
 func TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	content := strings.Replace(config.DefaultConfig(paths), `same_session = "fork_temp_session"`, `same_session = "queue"`, 1)
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile config returned error: %v", err)
+	}
 	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
 	seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
 	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo-a")
@@ -1434,7 +1443,7 @@ func TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos(t *testing.T) {
 			mu.Unlock()
 		},
 	}
-	worker := defaultJobWorker(store, io.Discard)
+	worker := defaultJobWorker(store, io.Discard, home)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		return t.TempDir(), nil
 	}


### PR DESCRIPTION
## Summary

Adds the repo's first **CI gate**. There was no `.github/workflows`, so the test suite was never enforced on PRs (`checks: 0` on every PR) — which is how a broken test (`TestRunQueuedJobsSerializesSameRuntimeSessionAcrossRepos`) had silently sat on `main`.

This PR is **independent of #304/#306** and should merge **first** so the big delegation changes land on a repo that actually gates tests.

## What the workflow runs (on every push to `main` and every PR)

- `go build ./...`
- `go vet ./...`
- `go test ./...` (all packages)
- `go test -race ./internal/workflow/` (concurrency/exactly-once paths)

Go version comes from `go.mod` (`go-version-file`). It does **not** run the live multi-runtime (codex/claude/kimi) E2E — that needs runtime auth and stays a manual step.

## Also included

The one-line fix for the pre-existing failing test (`f2908ae`, cherry-picked) so the suite is green — that commit is also in PR #304, so it'll deduplicate on merge.

## Follow-ups (not in this PR)
- A `gofmt -l` check is intentionally omitted for now: `internal/runtime/adapter_test.go` and `internal/workflow/engine_test.go` are currently unformatted on `main`, which would make this PR red. Worth adding once the tree is `gofmt`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
