### PR TITLE
feat: SkillOpt generation durability — per-item persistence + idempotent resume (#303 core)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -31,9 +31,6 @@ type localAgentDispatchRequest struct {
 	AllowManagedSync     bool
 	JobTimeout           time.Duration
 	TaskID               string
-	ParentJobID          string
-	DelegationID         string
-	RootJobID            string
 	PullRequest          int
 	HeadSHA              string
 	Branch               string
@@ -136,9 +133,6 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		TaskTitle:    request.TaskTitle,
 		LeadAgent:    firstNonEmpty(request.LeadAgent, agent.Name),
 		Reviewers:    request.Reviewers,
-		ParentJobID:  request.ParentJobID,
-		DelegationID: request.DelegationID,
-		RootJobID:    request.RootJobID,
 		Sender:       "local",
 		Instructions: request.Instructions,
 	})

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -31,6 +31,9 @@ type localAgentDispatchRequest struct {
 	AllowManagedSync     bool
 	JobTimeout           time.Duration
 	TaskID               string
+	ParentJobID          string
+	DelegationID         string
+	RootJobID            string
 	PullRequest          int
 	HeadSHA              string
 	Branch               string
@@ -133,6 +136,9 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		TaskTitle:    request.TaskTitle,
 		LeadAgent:    firstNonEmpty(request.LeadAgent, agent.Name),
 		Reviewers:    request.Reviewers,
+		ParentJobID:  request.ParentJobID,
+		DelegationID: request.DelegationID,
+		RootJobID:    request.RootJobID,
 		Sender:       "local",
 		Instructions: request.Instructions,
 	})

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -5500,7 +5500,11 @@ func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store
 		return skillOptTrainGenerationResult{}, fmt.Errorf("eval run %s expects at least 2 options", run.ID)
 	}
 	existingGenerated := 0
-	completeExistingItems := 0
+	// toGenerate holds only the items that still need generation; complete items
+	// are skipped so resume regenerates nothing already persisted. A mix of
+	// complete and incomplete items is the normal resume state (per-item commits),
+	// so it is not an error — only a partially generated single item is.
+	toGenerate := make([]db.EvalReviewItem, 0, len(items))
 	for _, item := range items {
 		if rankedRun {
 			existing, err := store.ListEvalReviewOptions(ctx, run.ID, item.ItemID)
@@ -5510,11 +5514,11 @@ func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store
 			if len(existing) > 0 {
 				if len(existing) == len(roles) {
 					existingGenerated += len(existing)
-					completeExistingItems++
 					continue
 				}
 				return skillOptTrainGenerationResult{}, fmt.Errorf("item %s has partial generated options; inspect or clear review options before continuing", item.ItemID)
 			}
+			toGenerate = append(toGenerate, item)
 			continue
 		}
 		hasBaseline := strings.TrimSpace(item.BaselineArtifactID) != ""
@@ -5522,26 +5526,23 @@ func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store
 		if hasBaseline || hasCandidate {
 			if hasBaseline && hasCandidate {
 				existingGenerated += 2
-				completeExistingItems++
 				continue
 			}
 			return skillOptTrainGenerationResult{}, fmt.Errorf("item %s has partial generated A/B artifacts; inspect or clear review item artifacts before continuing", item.ItemID)
 		}
+		toGenerate = append(toGenerate, item)
 	}
-	if completeExistingItems > 0 {
-		if completeExistingItems == len(items) {
-			metadata := map[string]any{
-				"status":            "recovered",
-				"generated_options": existingGenerated,
-				"strategy":          skillOptTrainGenerationStrategy(run),
-				"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
-			}
-			return skillOptTrainGenerationResult{
-				GeneratedOptions: existingGenerated,
-				Metadata:         metadata,
-			}, nil
+	if len(toGenerate) == 0 {
+		metadata := map[string]any{
+			"status":            "recovered",
+			"generated_options": existingGenerated,
+			"strategy":          skillOptTrainGenerationStrategy(run),
+			"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
 		}
-		return skillOptTrainGenerationResult{}, fmt.Errorf("eval run %s has partial generated items; inspect or clear review artifacts before continuing", run.ID)
+		return skillOptTrainGenerationResult{
+			GeneratedOptions: existingGenerated,
+			Metadata:         metadata,
+		}, nil
 	}
 	dispatch, err := skillOptTrainGeneratorSelection(ctx, store, session, iteration, run, request)
 	if err != nil {
@@ -5555,13 +5556,15 @@ func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store
 	if err := ensureSkillOptTrainGenerationRepoReady(ctx, store, skillOptTrainGenerationRepo(session)); err != nil {
 		return skillOptTrainGenerationResult{}, err
 	}
-	progress := newSkillOptTrainGenerationProgress(request.Progress, len(items)*len(roles), request.GenerationLockExtend)
-	progress.start(len(items), len(roles), skillOptTrainGenerationRuntimeLabel(request))
-	generatedItems, err := generateSkillOptTrainItemOptions(ctx, store, blobStore, session, iteration, run, items, roles, rankedRun, request, dispatch, concurrency, progress)
+	progress := newSkillOptTrainGenerationProgress(request.Progress, len(toGenerate)*len(roles), request.GenerationLockExtend)
+	progress.start(len(toGenerate), len(roles), skillOptTrainGenerationRuntimeLabel(request))
+	generatedItems, err := generateSkillOptTrainItemOptions(ctx, store, blobStore, session, iteration, run, toGenerate, roles, rankedRun, request, dispatch, concurrency, progress)
 	if err != nil {
 		return skillOptTrainGenerationResult{}, err
 	}
-	writes := make([]db.EvalReviewGenerationWrite, 0, len(generatedItems))
+	// Each generated item was persisted atomically the moment it completed
+	// (see generateSkillOptTrainItemOptions), so there is no end-of-phase batch
+	// write here. This loop only aggregates metadata across the items.
 	generated := 0
 	jobIDs := []string{}
 	var generatorAgent string
@@ -5577,19 +5580,10 @@ func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store
 			generatorRuntime = item.Runtime
 		}
 		promptRecords = append(promptRecords, item.Prompts...)
-		writes = append(writes, db.EvalReviewGenerationWrite{
-			ItemID:     item.ItemID,
-			ReviewItem: item.ReviewItem,
-			Artifacts:  item.Artifacts,
-			Options:    item.Options,
-		})
-	}
-	if err := store.ReplaceGeneratedEvalReviewArtifacts(ctx, run.ID, writes); err != nil {
-		return skillOptTrainGenerationResult{}, err
 	}
 	metadata := map[string]any{
 		"status":              "succeeded",
-		"generated_options":   generated,
+		"generated_options":   existingGenerated + generated,
 		"jobs":                jobIDs,
 		"agent":               generatorAgent,
 		"runtime":             generatorRuntime,
@@ -5603,7 +5597,7 @@ func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store
 		"completed_at":        time.Now().UTC().Format(time.RFC3339Nano),
 	}
 	return skillOptTrainGenerationResult{
-		GeneratedOptions: generated,
+		GeneratedOptions: existingGenerated + generated,
 		JobIDs:           jobIDs,
 		AgentName:        generatorAgent,
 		Runtime:          generatorRuntime,
@@ -5620,6 +5614,17 @@ type skillOptTrainGeneratedItemOptions struct {
 	AgentName  string
 	Runtime    string
 	Prompts    []map[string]any
+}
+
+// skillOptTrainGenerationWriteForItem projects a generated item onto the store's
+// per-item write shape (artifacts + review item + options).
+func skillOptTrainGenerationWriteForItem(item skillOptTrainGeneratedItemOptions) db.EvalReviewGenerationWrite {
+	return db.EvalReviewGenerationWrite{
+		ItemID:     item.ItemID,
+		ReviewItem: item.ReviewItem,
+		Artifacts:  item.Artifacts,
+		Options:    item.Options,
+	}
 }
 
 type skillOptTrainGeneratedOption struct {
@@ -5665,6 +5670,13 @@ func generateSkillOptTrainItemOptions(ctx context.Context, store *db.Store, blob
 			}
 			result, err := generateSkillOptTrainSingleItemOptions(ctx, store, blobStore, session, iteration, run, item, roles, rankedRun, request, dispatch, progress)
 			if err != nil {
+				errs[index] = err
+				return
+			}
+			// Persist the completed item immediately so a later item's failure
+			// cannot lose it. Artifacts + item row + options commit in one
+			// transaction, so a partial item is never written.
+			if err := store.ReplaceGeneratedEvalReviewArtifactsForItem(ctx, run.ID, skillOptTrainGenerationWriteForItem(result)); err != nil {
 				errs[index] = err
 				return
 			}

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -5394,11 +5394,13 @@ func skillOptTrainGenerationLockKey(sessionID string, iterationID string) string
 	return "skillopt-train-generation:" + sessionID + ":" + iterationID
 }
 
-// skillOptTrainGenerationParentJobID is the stable correlation id stamped on
-// every generation child job for a run as both ParentJobID and RootJobID, so the
-// generation jobs can be found via ListJobsByParent. It is keyed on the eval run
-// (not the time-based lock owner id) so it stays stable across resumes.
-func skillOptTrainGenerationParentJobID(runID string) string {
+// skillOptTrainGenerationCorrelationPrefix is the stable TaskID prefix shared by
+// every generation child job for a run, so the jobs can be found by TaskID
+// prefix. It is NOT used as ParentJobID/RootJobID: those are delegation-engine
+// fields and AdvanceJob dereferences ParentJobID as a real job row, so stamping
+// a synthetic value there would make a requeued generation job fail advancement
+// permanently. Keyed on the eval run so it stays stable across resumes.
+func skillOptTrainGenerationCorrelationPrefix(runID string) string {
 	return "skillopt-train-generation:" + strings.TrimSpace(runID)
 }
 
@@ -5500,6 +5502,19 @@ func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store
 		return skillOptTrainGenerationResult{}, fmt.Errorf("eval run %s expects at least 2 options", run.ID)
 	}
 	existingGenerated := 0
+	// Count already-persisted options per item in ONE run-scoped query instead of
+	// one query per item (the single-conn store would otherwise serialize N
+	// round-trips on resume of a large run).
+	existingOptionCount := map[string]int{}
+	if rankedRun {
+		allOptions, err := store.ListEvalReviewOptions(ctx, run.ID, "")
+		if err != nil {
+			return skillOptTrainGenerationResult{}, err
+		}
+		for _, opt := range allOptions {
+			existingOptionCount[opt.ItemID]++
+		}
+	}
 	// toGenerate holds only the items that still need generation; complete items
 	// are skipped so resume regenerates nothing already persisted. A mix of
 	// complete and incomplete items is the normal resume state (per-item commits),
@@ -5507,13 +5522,10 @@ func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store
 	toGenerate := make([]db.EvalReviewItem, 0, len(items))
 	for _, item := range items {
 		if rankedRun {
-			existing, err := store.ListEvalReviewOptions(ctx, run.ID, item.ItemID)
-			if err != nil {
-				return skillOptTrainGenerationResult{}, err
-			}
-			if len(existing) > 0 {
-				if len(existing) == len(roles) {
-					existingGenerated += len(existing)
+			existing := existingOptionCount[item.ItemID]
+			if existing > 0 {
+				if existing == len(roles) {
+					existingGenerated += existing
 					continue
 				}
 				return skillOptTrainGenerationResult{}, fmt.Errorf("item %s has partial generated options; inspect or clear review options before continuing", item.ItemID)
@@ -5673,10 +5685,12 @@ func generateSkillOptTrainItemOptions(ctx context.Context, store *db.Store, blob
 				errs[index] = err
 				return
 			}
-			// Persist the completed item immediately so a later item's failure
-			// cannot lose it. Artifacts + item row + options commit in one
-			// transaction, so a partial item is never written.
-			if err := store.ReplaceGeneratedEvalReviewArtifactsForItem(ctx, run.ID, skillOptTrainGenerationWriteForItem(result)); err != nil {
+			// Persist the completed item immediately so neither a later item's
+			// failure nor a mid-run cancellation can lose it. Artifacts + item row
+			// + options commit in one transaction (a partial item is never
+			// written), using a non-cancellable context so a fully-generated item
+			// is durable even if ctx is cancelled at this instant.
+			if err := store.ReplaceGeneratedEvalReviewArtifactsForItem(context.WithoutCancel(ctx), run.ID, skillOptTrainGenerationWriteForItem(result)); err != nil {
 				errs[index] = err
 				return
 			}
@@ -5827,7 +5841,6 @@ func generateSkillOptTrainSingleOption(ctx context.Context, store *db.Store, ses
 }
 
 func dispatchSkillOptTrainGenerationJob(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, item db.EvalReviewItem, role string, attempt int, request skillOptTrainContinueRequest, dispatch skillOptTrainGenerationDispatch, prompt string) (localAgentJobOutput, error) {
-	parentJobID := skillOptTrainGenerationParentJobID(run.ID)
 	taskID := skillOptTrainGenerationTaskID(run.ID, item.ItemID, role, attempt)
 	if dispatch.Mode != skillOptTrainGenerationModeTargetSkill {
 		return dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
@@ -5839,8 +5852,6 @@ func dispatchSkillOptTrainGenerationJob(ctx context.Context, store *db.Store, se
 			Home:             request.Home,
 			AllowManagedSync: dispatch.Type != "",
 			TaskID:           taskID,
-			ParentJobID:      parentJobID,
-			RootJobID:        parentJobID,
 		})
 	}
 	agentName, err := startSkillOptTrainTargetSkillAgent(ctx, store, session, iteration, run, item, role, attempt, request, dispatch)
@@ -5855,8 +5866,6 @@ func dispatchSkillOptTrainGenerationJob(ctx context.Context, store *db.Store, se
 		Home:         request.Home,
 		JobTimeout:   skillOptTrainGenerationJobTimeoutHint(request, dispatch.Type),
 		TaskID:       taskID,
-		ParentJobID:  parentJobID,
-		RootJobID:    parentJobID,
 	})
 }
 

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -5394,6 +5394,21 @@ func skillOptTrainGenerationLockKey(sessionID string, iterationID string) string
 	return "skillopt-train-generation:" + sessionID + ":" + iterationID
 }
 
+// skillOptTrainGenerationParentJobID is the stable correlation id stamped on
+// every generation child job for a run as both ParentJobID and RootJobID, so the
+// generation jobs can be found via ListJobsByParent. It is keyed on the eval run
+// (not the time-based lock owner id) so it stays stable across resumes.
+func skillOptTrainGenerationParentJobID(runID string) string {
+	return "skillopt-train-generation:" + strings.TrimSpace(runID)
+}
+
+// skillOptTrainGenerationTaskID is the per-option TaskID stamped on each
+// generation child job, uniquely identifying the (run, item, label, attempt)
+// option it produced.
+func skillOptTrainGenerationTaskID(runID string, itemID string, label string, attempt int) string {
+	return fmt.Sprintf("skillopt-train-generation:%s:%s:%s:%d", strings.TrimSpace(runID), strings.TrimSpace(itemID), strings.TrimSpace(label), attempt)
+}
+
 // skillOptTrainGenerationProgress emits human-facing, one-line-per-option
 // progress to a writer (typically stderr) while option jobs run concurrently.
 // A nil receiver or nil writer is a no-op, so automated callers (the review
@@ -5800,6 +5815,8 @@ func generateSkillOptTrainSingleOption(ctx context.Context, store *db.Store, ses
 }
 
 func dispatchSkillOptTrainGenerationJob(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, run db.EvalRun, item db.EvalReviewItem, role string, attempt int, request skillOptTrainContinueRequest, dispatch skillOptTrainGenerationDispatch, prompt string) (localAgentJobOutput, error) {
+	parentJobID := skillOptTrainGenerationParentJobID(run.ID)
+	taskID := skillOptTrainGenerationTaskID(run.ID, item.ItemID, role, attempt)
 	if dispatch.Mode != skillOptTrainGenerationModeTargetSkill {
 		return dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
 			RepoFlag:         skillOptTrainGenerationRepo(session),
@@ -5809,6 +5826,9 @@ func dispatchSkillOptTrainGenerationJob(ctx context.Context, store *db.Store, se
 			Type:             dispatch.Type,
 			Home:             request.Home,
 			AllowManagedSync: dispatch.Type != "",
+			TaskID:           taskID,
+			ParentJobID:      parentJobID,
+			RootJobID:        parentJobID,
 		})
 	}
 	agentName, err := startSkillOptTrainTargetSkillAgent(ctx, store, session, iteration, run, item, role, attempt, request, dispatch)
@@ -5822,6 +5842,9 @@ func dispatchSkillOptTrainGenerationJob(ctx context.Context, store *db.Store, se
 		Instructions: prompt,
 		Home:         request.Home,
 		JobTimeout:   skillOptTrainGenerationJobTimeoutHint(request, dispatch.Type),
+		TaskID:       taskID,
+		ParentJobID:  parentJobID,
+		RootJobID:    parentJobID,
 	})
 }
 

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -3923,6 +3923,289 @@ func TestSkillOptTrainContinueRecoversCompleteGeneratedOptions(t *testing.T) {
 	}
 }
 
+// skillOptTrainItemAwareRunner answers generation jobs based on the item id
+// embedded in the delivered prompt rather than a fixed call sequence, so item
+// success/failure is deterministic regardless of goroutine scheduling. Start
+// calls return a thread, resume (delivery) calls return an implemented result
+// for any item id in failItems unless it is listed there, in which case they
+// return a non-implemented result that fails generation for that item.
+type skillOptTrainItemAwareRunner struct {
+	mu        sync.Mutex
+	failItems map[string]bool
+	threadSeq int
+	prompts   []string
+}
+
+func (r *skillOptTrainItemAwareRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	isResume := false
+	for _, arg := range args {
+		if arg == "resume" {
+			isResume = true
+			break
+		}
+	}
+	if !isResume {
+		r.threadSeq++
+		threadID := fmt.Sprintf("550e8400-e29b-41d4-a716-44665544%04d", 700+r.threadSeq)
+		return subprocess.Result{Command: command, Args: args, Stdout: `{"type":"thread.started","thread_id":"` + threadID + `"}` + "\n"}, nil
+	}
+	prompt := ""
+	if len(args) > 0 {
+		prompt = args[len(args)-1]
+	}
+	r.prompts = append(r.prompts, prompt)
+	for itemID := range r.failItems {
+		if strings.Contains(prompt, "Item id: "+itemID) {
+			return subprocess.Result{Command: command, Args: args, Stdout: `{"gitmoot_result":{"decision":"blocked","summary":"cannot generate","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"}, nil
+		}
+	}
+	return subprocess.Result{Command: command, Args: args, Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option\n\nGenerated content.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"}, nil
+}
+
+func (r *skillOptTrainItemAwareRunner) LookPath(file string) (string, error) {
+	if file == "" {
+		return "", errors.New("empty file")
+	}
+	return "/usr/bin/" + file, nil
+}
+
+func startSkillOptTrainGenerationForPersistTest(t *testing.T, home string) {
+	t.Helper()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train landing page plans.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+}
+
+// TestSkillOptTrainContinuePersistsCompletedItemBeforeLaterFailure proves the
+// core data-loss fix: a completed item is committed the moment it finishes, so a
+// later item's failure cannot lose it, and a resume completes without
+// regenerating the already-durable item.
+func TestSkillOptTrainContinuePersistsCompletedItemBeforeLaterFailure(t *testing.T) {
+	home := t.TempDir()
+	startSkillOptTrainGenerationForPersistTest(t, home)
+	const runID = "landing-train-review-001"
+
+	// hero-saas fails; ecommerce-proof succeeds and must survive.
+	failRunner := &skillOptTrainItemAwareRunner{failItems: map[string]bool{"hero-saas": true}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: failRunner})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	restoreFactory()
+	if code != 1 {
+		t.Fatalf("first continue exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateItemsReady || !strings.Contains(iteration.MetadataJSON, `"status":"failed"`) {
+		t.Fatalf("iteration after failure = %+v metadata=%s", iteration, iteration.MetadataJSON)
+	}
+	completedOptions, err := store.ListEvalReviewOptions(context.Background(), runID, "ecommerce-proof")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions ecommerce-proof returned error: %v", err)
+	}
+	if len(completedOptions) != 2 {
+		t.Fatalf("completed item not durable: ecommerce-proof options = %+v", completedOptions)
+	}
+	failedOptions, err := store.ListEvalReviewOptions(context.Background(), runID, "hero-saas")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions hero-saas returned error: %v", err)
+	}
+	if len(failedOptions) != 0 {
+		t.Fatalf("failed item persisted options: hero-saas options = %+v", failedOptions)
+	}
+	completedArtifactIDs := []string{completedOptions[0].ArtifactID, completedOptions[1].ArtifactID}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after first continue returned error: %v", err)
+	}
+
+	// Resume with everything succeeding: only hero-saas should be regenerated.
+	successRunner := &skillOptTrainItemAwareRunner{}
+	restoreFactory = replaceRuntimeFactory(runtime.Factory{Runner: successRunner})
+	defer restoreFactory()
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("resume continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "current_phase: options_generated") || !strings.Contains(stdout.String(), "generated_options: 4") {
+		t.Fatalf("resume continue stdout = %s", stdout.String())
+	}
+	// Only the incomplete item's two options were regenerated (1 start + 1
+	// delivery per option).
+	for _, prompt := range successRunner.prompts {
+		if strings.Contains(prompt, "Item id: ecommerce-proof") {
+			t.Fatalf("resume regenerated the already-complete item: %q", prompt)
+		}
+		if !strings.Contains(prompt, "Item id: hero-saas") {
+			t.Fatalf("resume delivery for unexpected item: %q", prompt)
+		}
+	}
+	if len(successRunner.prompts) != 2 {
+		t.Fatalf("resume option deliveries = %d, want 2 (only hero-saas)", len(successRunner.prompts))
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	for _, itemID := range []string{"ecommerce-proof", "hero-saas"} {
+		options, err := store.ListEvalReviewOptions(context.Background(), runID, itemID)
+		if err != nil {
+			t.Fatalf("ListEvalReviewOptions %s returned error: %v", itemID, err)
+		}
+		if len(options) != 2 || options[0].Label != "a" || options[1].Label != "b" {
+			t.Fatalf("options for %s after resume = %+v", itemID, options)
+		}
+	}
+	// The durable item's artifacts were not rewritten by the resume.
+	resumeOptions, err := store.ListEvalReviewOptions(context.Background(), runID, "ecommerce-proof")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions ecommerce-proof after resume returned error: %v", err)
+	}
+	if resumeOptions[0].ArtifactID != completedArtifactIDs[0] || resumeOptions[1].ArtifactID != completedArtifactIDs[1] {
+		t.Fatalf("resume rewrote durable item artifacts: before=%v after=%v", completedArtifactIDs, []string{resumeOptions[0].ArtifactID, resumeOptions[1].ArtifactID})
+	}
+}
+
+// TestSkillOptTrainContinueResumeRegeneratesOnlyIncompleteItems seeds one
+// complete item, then verifies resume regenerates only the missing item with
+// correct totals and no duplicate options.
+func TestSkillOptTrainContinueResumeRegeneratesOnlyIncompleteItems(t *testing.T) {
+	home := t.TempDir()
+	startSkillOptTrainGenerationForPersistTest(t, home)
+	const runID = "landing-train-review-001"
+	paths := config.PathsForHome(home)
+
+	// Seed ecommerce-proof as already complete (durable from a prior partial run).
+	store := openCLIJobStore(t, home)
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	var seededArtifactIDs []string
+	var artifacts []db.EvalArtifact
+	var options []db.EvalReviewOption
+	for _, label := range []string{"a", "b"} {
+		artifactRecord, err := prepareReviewItemContentArtifact(blobStore, runID, "ecommerce-proof", "option-"+label, []byte("seeded "+label), "text/markdown", "text")
+		if err != nil {
+			t.Fatalf("prepareReviewItemContentArtifact returned error: %v", err)
+		}
+		artifacts = append(artifacts, artifactRecord)
+		seededArtifactIDs = append(seededArtifactIDs, artifactRecord.ID)
+		options = append(options, db.EvalReviewOption{
+			RunID:      runID,
+			ItemID:     "ecommerce-proof",
+			Label:      label,
+			ArtifactID: artifactRecord.ID,
+			Role:       "option",
+		})
+	}
+	if err := store.ReplaceGeneratedEvalReviewArtifactsForItem(context.Background(), runID, db.EvalReviewGenerationWrite{
+		ItemID:    "ecommerce-proof",
+		Artifacts: artifacts,
+		Options:   options,
+	}); err != nil {
+		t.Fatalf("ReplaceGeneratedEvalReviewArtifactsForItem returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after seed returned error: %v", err)
+	}
+
+	runner := &skillOptTrainItemAwareRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("resume continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	// Progress total reflects only the incomplete item.
+	if !strings.Contains(stderr.String(), "generating 2 options (1 items x 2)") {
+		t.Fatalf("resume progress stderr = %s", stderr.String())
+	}
+	// existingGenerated (2) + generated (2) with no double-count.
+	if !strings.Contains(stdout.String(), "current_phase: options_generated") || !strings.Contains(stdout.String(), "generated_options: 4") {
+		t.Fatalf("resume continue stdout = %s", stdout.String())
+	}
+	for _, prompt := range runner.prompts {
+		if !strings.Contains(prompt, "Item id: hero-saas") {
+			t.Fatalf("resume delivered a prompt for an already-complete item: %q", prompt)
+		}
+	}
+	if len(runner.prompts) != 2 {
+		t.Fatalf("resume option deliveries = %d, want 2 (only hero-saas)", len(runner.prompts))
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	// hero-saas now generated, no duplicates.
+	heroOptions, err := store.ListEvalReviewOptions(context.Background(), runID, "hero-saas")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions hero-saas returned error: %v", err)
+	}
+	if len(heroOptions) != 2 || heroOptions[0].Label != "a" || heroOptions[1].Label != "b" {
+		t.Fatalf("hero-saas options after resume = %+v", heroOptions)
+	}
+	// Seeded item untouched: same artifact ids, still exactly two options.
+	ecommerceOptions, err := store.ListEvalReviewOptions(context.Background(), runID, "ecommerce-proof")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions ecommerce-proof returned error: %v", err)
+	}
+	if len(ecommerceOptions) != 2 || ecommerceOptions[0].ArtifactID != seededArtifactIDs[0] || ecommerceOptions[1].ArtifactID != seededArtifactIDs[1] {
+		t.Fatalf("seeded item changed after resume: %+v want artifacts %v", ecommerceOptions, seededArtifactIDs)
+	}
+}
+
 func TestSkillOptTrainContinueUsesManagedGeneratorConcurrency(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2919,22 +2919,33 @@ func TestSkillOptTrainGenerationStampsCorrelationIDs(t *testing.T) {
 	defer store.Close()
 
 	const runID = "landing-train-review-001"
-	parentJobID := skillOptTrainGenerationParentJobID(runID)
-	if parentJobID != "skillopt-train-generation:"+runID {
-		t.Fatalf("parent job id = %q", parentJobID)
+	prefix := skillOptTrainGenerationCorrelationPrefix(runID)
+	if prefix != "skillopt-train-generation:"+runID {
+		t.Fatalf("correlation prefix = %q", prefix)
 	}
 
-	children, err := store.ListJobsByParent(context.Background(), parentJobID)
+	allJobs, err := store.ListJobs(context.Background())
 	if err != nil {
-		t.Fatalf("ListJobsByParent returned error: %v", err)
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	var children []db.Job
+	for _, job := range allJobs {
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			t.Fatalf("daemonJobPayload returned error: %v", err)
+		}
+		if strings.HasPrefix(payload.TaskID, prefix+":") {
+			children = append(children, job)
+		}
 	}
 	if len(children) != 4 {
-		t.Fatalf("ListJobsByParent(%q) returned %d jobs, want 4: %+v", parentJobID, len(children), children)
+		t.Fatalf("generation jobs with TaskID prefix %q = %d, want 4: %+v", prefix, len(children), children)
 	}
 
-	// Every generation child must be discoverable via the run-scoped parent id and
-	// carry the structured correlation ids: parent and root both point at the run
-	// parent, and the per-option TaskID encodes (run, item, label, attempt).
+	// Each generation child carries the per-option TaskID encoding
+	// (run, item, label, attempt). It must NOT carry ParentJobID/RootJobID:
+	// those are delegation-engine fields, and a synthetic value would make
+	// AdvanceJob fail for a requeued generation job.
 	wantTaskIDs := map[string]bool{
 		skillOptTrainGenerationTaskID(runID, "hero-saas", "a", 0):       false,
 		skillOptTrainGenerationTaskID(runID, "hero-saas", "b", 0):       false,
@@ -2942,21 +2953,15 @@ func TestSkillOptTrainGenerationStampsCorrelationIDs(t *testing.T) {
 		skillOptTrainGenerationTaskID(runID, "ecommerce-proof", "b", 0): false,
 	}
 	for _, job := range children {
-		if job.ParentJobID != parentJobID {
-			t.Fatalf("job %s parent_job_id = %q, want %q", job.ID, job.ParentJobID, parentJobID)
+		if job.ParentJobID != "" {
+			t.Fatalf("job %s parent_job_id = %q, want empty (generation jobs are not delegations)", job.ID, job.ParentJobID)
 		}
 		payload, err := daemonJobPayload(job)
 		if err != nil {
 			t.Fatalf("daemonJobPayload returned error: %v", err)
 		}
-		if payload.ParentJobID != parentJobID {
-			t.Fatalf("job %s payload parent_job_id = %q, want %q", job.ID, payload.ParentJobID, parentJobID)
-		}
-		if payload.RootJobID != parentJobID {
-			t.Fatalf("job %s payload root_job_id = %q, want %q", job.ID, payload.RootJobID, parentJobID)
-		}
-		if payload.DelegationID != "" {
-			t.Fatalf("job %s payload delegation_id = %q, want empty", job.ID, payload.DelegationID)
+		if payload.ParentJobID != "" || payload.RootJobID != "" {
+			t.Fatalf("job %s payload parent/root = %q/%q, want empty", job.ID, payload.ParentJobID, payload.RootJobID)
 		}
 		seen, ok := wantTaskIDs[payload.TaskID]
 		if !ok {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2843,6 +2843,137 @@ items:
 	}
 }
 
+func TestSkillOptTrainGenerationStampsCorrelationIDs(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "type", "set", "skillopt-generator",
+		"--home", home,
+		"--runtime", "codex",
+		"--role", "generator",
+		"--max-background", "1",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train landing page plans.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440501"}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nHero with strong product narrative.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440502"}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nDashboard-led layout with proof metrics.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440503"}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option A\n\nCheckout analytics proof block.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+		{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440504"}` + "\n"},
+		{Stdout: `{"gitmoot_result":{"decision":"implemented","summary":"# Option B\n\nLifecycle commerce story with motion notes.","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "landing-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+
+	const runID = "landing-train-review-001"
+	parentJobID := skillOptTrainGenerationParentJobID(runID)
+	if parentJobID != "skillopt-train-generation:"+runID {
+		t.Fatalf("parent job id = %q", parentJobID)
+	}
+
+	children, err := store.ListJobsByParent(context.Background(), parentJobID)
+	if err != nil {
+		t.Fatalf("ListJobsByParent returned error: %v", err)
+	}
+	if len(children) != 4 {
+		t.Fatalf("ListJobsByParent(%q) returned %d jobs, want 4: %+v", parentJobID, len(children), children)
+	}
+
+	// Every generation child must be discoverable via the run-scoped parent id and
+	// carry the structured correlation ids: parent and root both point at the run
+	// parent, and the per-option TaskID encodes (run, item, label, attempt).
+	wantTaskIDs := map[string]bool{
+		skillOptTrainGenerationTaskID(runID, "hero-saas", "a", 0):       false,
+		skillOptTrainGenerationTaskID(runID, "hero-saas", "b", 0):       false,
+		skillOptTrainGenerationTaskID(runID, "ecommerce-proof", "a", 0): false,
+		skillOptTrainGenerationTaskID(runID, "ecommerce-proof", "b", 0): false,
+	}
+	for _, job := range children {
+		if job.ParentJobID != parentJobID {
+			t.Fatalf("job %s parent_job_id = %q, want %q", job.ID, job.ParentJobID, parentJobID)
+		}
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			t.Fatalf("daemonJobPayload returned error: %v", err)
+		}
+		if payload.ParentJobID != parentJobID {
+			t.Fatalf("job %s payload parent_job_id = %q, want %q", job.ID, payload.ParentJobID, parentJobID)
+		}
+		if payload.RootJobID != parentJobID {
+			t.Fatalf("job %s payload root_job_id = %q, want %q", job.ID, payload.RootJobID, parentJobID)
+		}
+		if payload.DelegationID != "" {
+			t.Fatalf("job %s payload delegation_id = %q, want empty", job.ID, payload.DelegationID)
+		}
+		seen, ok := wantTaskIDs[payload.TaskID]
+		if !ok {
+			t.Fatalf("job %s has unexpected task_id %q", job.ID, payload.TaskID)
+		}
+		if seen {
+			t.Fatalf("duplicate generation task_id %q", payload.TaskID)
+		}
+		wantTaskIDs[payload.TaskID] = true
+	}
+	for taskID, seen := range wantTaskIDs {
+		if !seen {
+			t.Fatalf("generation task_id %q was not stamped on any child job", taskID)
+		}
+	}
+}
+
 func TestSkillOptTrainContinueGeneratesRequiredVuePreviewBundles(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -454,11 +454,13 @@ func configureWritableSQLite(ctx context.Context, db *sql.DB) error {
 	}
 	// synchronous=NORMAL is the WAL-recommended setting: it fsyncs only at WAL
 	// checkpoints instead of on every commit (the FULL default), making the
-	// per-item generation commits cheap. The bounded tradeoff is that a power
-	// loss can lose at most the last in-flight commit (regenerated on resume);
-	// WAL still guarantees the database is never corrupted. The
-	// wal_autocheckpoint default (1000 pages) is left in place so long-lived
-	// read connections do not let the WAL grow unbounded.
+	// per-item generation commits cheap. The bounded tradeoff is that an OS
+	// crash or power loss can lose transactions committed since the last WAL
+	// checkpoint (not merely the last commit); WAL still guarantees the database
+	// is never corrupted. This is safe for generation because resume regenerates
+	// any item whose commit did not survive. The wal_autocheckpoint default
+	// (1000 pages) is left in place so long-lived read connections do not let the
+	// WAL grow unbounded.
 	if _, err := db.ExecContext(ctx, `PRAGMA synchronous=NORMAL`); err != nil {
 		return fmt.Errorf("configure sqlite synchronous: %w", err)
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -452,6 +452,16 @@ func configureWritableSQLite(ctx context.Context, db *sql.DB) error {
 	if _, err := db.ExecContext(ctx, `PRAGMA journal_mode=WAL`); err != nil {
 		return fmt.Errorf("configure sqlite WAL: %w", err)
 	}
+	// synchronous=NORMAL is the WAL-recommended setting: it fsyncs only at WAL
+	// checkpoints instead of on every commit (the FULL default), making the
+	// per-item generation commits cheap. The bounded tradeoff is that a power
+	// loss can lose at most the last in-flight commit (regenerated on resume);
+	// WAL still guarantees the database is never corrupted. The
+	// wal_autocheckpoint default (1000 pages) is left in place so long-lived
+	// read connections do not let the WAL grow unbounded.
+	if _, err := db.ExecContext(ctx, `PRAGMA synchronous=NORMAL`); err != nil {
+		return fmt.Errorf("configure sqlite synchronous: %w", err)
+	}
 	return nil
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -3184,6 +3184,108 @@ func upsertEvalReviewItemExec(ctx context.Context, exec sqlExecer, item EvalRevi
 	return err
 }
 
+// normalizeEvalReviewGenerationWrite validates and canonicalizes a single
+// generation write, scoping its review item and options to runID, normalizing
+// each artifact/option, and rejecting duplicate option labels for the item.
+func normalizeEvalReviewGenerationWrite(runID string, write EvalReviewGenerationWrite) (EvalReviewGenerationWrite, error) {
+	itemID := strings.TrimSpace(write.ItemID)
+	if itemID == "" && write.ReviewItem != nil {
+		itemID = strings.TrimSpace(write.ReviewItem.ItemID)
+	}
+	if itemID == "" {
+		return EvalReviewGenerationWrite{}, errors.New("eval review generation item id is required")
+	}
+	next := EvalReviewGenerationWrite{ItemID: itemID}
+	for _, artifact := range write.Artifacts {
+		artifact, err := normalizeEvalArtifact(artifact)
+		if err != nil {
+			return EvalReviewGenerationWrite{}, err
+		}
+		next.Artifacts = append(next.Artifacts, artifact)
+	}
+	if write.ReviewItem != nil {
+		item := *write.ReviewItem
+		item.RunID = runID
+		item.ItemID = itemID
+		if strings.TrimSpace(item.ID) == "" {
+			item.ID = item.RunID + "/" + item.ItemID
+		}
+		if strings.TrimSpace(item.RunID) == "" {
+			return EvalReviewGenerationWrite{}, errors.New("eval review item run id is required")
+		}
+		if strings.TrimSpace(item.ItemID) == "" {
+			return EvalReviewGenerationWrite{}, errors.New("eval review item id is required")
+		}
+		next.ReviewItem = &item
+	}
+	seen := map[string]struct{}{}
+	for _, option := range write.Options {
+		option.RunID = runID
+		option.ItemID = itemID
+		option, err := normalizeEvalReviewOption(option)
+		if err != nil {
+			return EvalReviewGenerationWrite{}, err
+		}
+		if _, ok := seen[option.Label]; ok {
+			return EvalReviewGenerationWrite{}, fmt.Errorf("eval review option label %q is duplicated for item %q", option.Label, itemID)
+		}
+		seen[option.Label] = struct{}{}
+		next.Options = append(next.Options, option)
+	}
+	return next, nil
+}
+
+// writeGeneratedEvalReviewArtifactsTx persists one normalized generation write
+// inside tx: upserts artifacts, upserts the review item, and replaces the item's
+// options (DELETE-then-INSERT scoped to run_id/item_id). The caller owns the
+// transaction lifecycle. The write must already be normalized.
+func writeGeneratedEvalReviewArtifactsTx(ctx context.Context, tx *sql.Tx, runID string, write EvalReviewGenerationWrite) error {
+	for _, artifact := range write.Artifacts {
+		if err := upsertEvalArtifactTx(ctx, tx, artifact); err != nil {
+			return err
+		}
+	}
+	if write.ReviewItem != nil {
+		item := *write.ReviewItem
+		if _, err := tx.ExecContext(ctx, `INSERT INTO eval_review_items(
+				id, run_id, item_id, title, source_artifact_id, baseline_artifact_id, candidate_artifact_id,
+				preview_artifact_id, diff_artifact_id, metadata_json, created_at, updated_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+			ON CONFLICT(id) DO UPDATE SET
+				run_id = excluded.run_id,
+				item_id = excluded.item_id,
+				title = excluded.title,
+				source_artifact_id = excluded.source_artifact_id,
+				baseline_artifact_id = excluded.baseline_artifact_id,
+				candidate_artifact_id = excluded.candidate_artifact_id,
+				preview_artifact_id = excluded.preview_artifact_id,
+				diff_artifact_id = excluded.diff_artifact_id,
+				metadata_json = excluded.metadata_json,
+				updated_at = CURRENT_TIMESTAMP`,
+			item.ID, item.RunID, item.ItemID, item.Title, item.SourceArtifactID, item.BaselineArtifactID, item.CandidateArtifactID,
+			item.PreviewArtifactID, item.DiffArtifactID, item.MetadataJSON); err != nil {
+			return err
+		}
+	}
+	if len(write.Options) == 0 {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM eval_review_options WHERE run_id = ? AND item_id = ?`, runID, write.ItemID); err != nil {
+		return err
+	}
+	for _, option := range write.Options {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO eval_review_options(
+				id, run_id, item_id, label, artifact_id, role, metadata_json, created_at, updated_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			option.ID, option.RunID, option.ItemID, option.Label, option.ArtifactID, option.Role, option.MetadataJSON); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Store) ReplaceGeneratedEvalReviewArtifacts(ctx context.Context, runID string, writes []EvalReviewGenerationWrite) error {
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
@@ -3191,49 +3293,9 @@ func (s *Store) ReplaceGeneratedEvalReviewArtifacts(ctx context.Context, runID s
 	}
 	normalized := make([]EvalReviewGenerationWrite, 0, len(writes))
 	for _, write := range writes {
-		itemID := strings.TrimSpace(write.ItemID)
-		if itemID == "" && write.ReviewItem != nil {
-			itemID = strings.TrimSpace(write.ReviewItem.ItemID)
-		}
-		if itemID == "" {
-			return errors.New("eval review generation item id is required")
-		}
-		next := EvalReviewGenerationWrite{ItemID: itemID}
-		for _, artifact := range write.Artifacts {
-			artifact, err := normalizeEvalArtifact(artifact)
-			if err != nil {
-				return err
-			}
-			next.Artifacts = append(next.Artifacts, artifact)
-		}
-		if write.ReviewItem != nil {
-			item := *write.ReviewItem
-			item.RunID = runID
-			item.ItemID = itemID
-			if strings.TrimSpace(item.ID) == "" {
-				item.ID = item.RunID + "/" + item.ItemID
-			}
-			if strings.TrimSpace(item.RunID) == "" {
-				return errors.New("eval review item run id is required")
-			}
-			if strings.TrimSpace(item.ItemID) == "" {
-				return errors.New("eval review item id is required")
-			}
-			next.ReviewItem = &item
-		}
-		seen := map[string]struct{}{}
-		for _, option := range write.Options {
-			option.RunID = runID
-			option.ItemID = itemID
-			option, err := normalizeEvalReviewOption(option)
-			if err != nil {
-				return err
-			}
-			if _, ok := seen[option.Label]; ok {
-				return fmt.Errorf("eval review option label %q is duplicated for item %q", option.Label, itemID)
-			}
-			seen[option.Label] = struct{}{}
-			next.Options = append(next.Options, option)
+		next, err := normalizeEvalReviewGenerationWrite(runID, write)
+		if err != nil {
+			return err
 		}
 		normalized = append(normalized, next)
 	}
@@ -3243,49 +3305,35 @@ func (s *Store) ReplaceGeneratedEvalReviewArtifacts(ctx context.Context, runID s
 	}
 	defer tx.Rollback()
 	for _, write := range normalized {
-		for _, artifact := range write.Artifacts {
-			if err := upsertEvalArtifactTx(ctx, tx, artifact); err != nil {
-				return err
-			}
-		}
-		if write.ReviewItem != nil {
-			item := *write.ReviewItem
-			if _, err := tx.ExecContext(ctx, `INSERT INTO eval_review_items(
-					id, run_id, item_id, title, source_artifact_id, baseline_artifact_id, candidate_artifact_id,
-					preview_artifact_id, diff_artifact_id, metadata_json, created_at, updated_at
-				)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-				ON CONFLICT(id) DO UPDATE SET
-					run_id = excluded.run_id,
-					item_id = excluded.item_id,
-					title = excluded.title,
-					source_artifact_id = excluded.source_artifact_id,
-					baseline_artifact_id = excluded.baseline_artifact_id,
-					candidate_artifact_id = excluded.candidate_artifact_id,
-					preview_artifact_id = excluded.preview_artifact_id,
-					diff_artifact_id = excluded.diff_artifact_id,
-					metadata_json = excluded.metadata_json,
-					updated_at = CURRENT_TIMESTAMP`,
-				item.ID, item.RunID, item.ItemID, item.Title, item.SourceArtifactID, item.BaselineArtifactID, item.CandidateArtifactID,
-				item.PreviewArtifactID, item.DiffArtifactID, item.MetadataJSON); err != nil {
-				return err
-			}
-		}
-		if len(write.Options) == 0 {
-			continue
-		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM eval_review_options WHERE run_id = ? AND item_id = ?`, runID, write.ItemID); err != nil {
+		if err := writeGeneratedEvalReviewArtifactsTx(ctx, tx, runID, write); err != nil {
 			return err
 		}
-		for _, option := range write.Options {
-			if _, err := tx.ExecContext(ctx, `INSERT INTO eval_review_options(
-					id, run_id, item_id, label, artifact_id, role, metadata_json, created_at, updated_at
-				)
-				VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
-				option.ID, option.RunID, option.ItemID, option.Label, option.ArtifactID, option.Role, option.MetadataJSON); err != nil {
-				return err
-			}
-		}
+	}
+	return tx.Commit()
+}
+
+// ReplaceGeneratedEvalReviewArtifactsForItem atomically persists the generated
+// artifacts, review item, and options for a single item in one transaction so a
+// completed item is durable on its own (artifacts + item row + options commit
+// together). Options are replaced DELETE-then-INSERT scoped to (run_id,item_id),
+// so re-writing the same item is idempotent and writing one item leaves others
+// untouched.
+func (s *Store) ReplaceGeneratedEvalReviewArtifactsForItem(ctx context.Context, runID string, write EvalReviewGenerationWrite) error {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return errors.New("eval review generation run id is required")
+	}
+	normalized, err := normalizeEvalReviewGenerationWrite(runID, write)
+	if err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := writeGeneratedEvalReviewArtifactsTx(ctx, tx, runID, normalized); err != nil {
+		return err
 	}
 	return tx.Commit()
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -98,6 +98,33 @@ func TestOpenConfiguresSQLiteContentionPragmas(t *testing.T) {
 	}
 }
 
+func TestOpenConfiguresSynchronousNormal(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	// synchronous=NORMAL reads back as 1 on the writable connection.
+	var synchronous int
+	if err := store.db.QueryRowContext(context.Background(), `PRAGMA synchronous`).Scan(&synchronous); err != nil {
+		t.Fatalf("PRAGMA synchronous returned error: %v", err)
+	}
+	if synchronous != 1 {
+		t.Fatalf("synchronous = %d, want 1 (NORMAL)", synchronous)
+	}
+
+	// wal_autocheckpoint stays at the sane SQLite default so long-lived read
+	// connections do not let the WAL grow unbounded.
+	var autocheckpoint int
+	if err := store.db.QueryRowContext(context.Background(), `PRAGMA wal_autocheckpoint`).Scan(&autocheckpoint); err != nil {
+		t.Fatalf("PRAGMA wal_autocheckpoint returned error: %v", err)
+	}
+	if autocheckpoint <= 0 {
+		t.Fatalf("wal_autocheckpoint = %d, want a positive default", autocheckpoint)
+	}
+}
+
 func TestInteractivePromptStorageAndAnswerValidation(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -995,6 +995,174 @@ func TestReplaceGeneratedEvalReviewArtifactsRollsBackBatch(t *testing.T) {
 	}
 }
 
+func TestReplaceGeneratedEvalReviewArtifactsForItemPersists(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	write := EvalReviewGenerationWrite{
+		ItemID:     "item-001",
+		ReviewItem: &EvalReviewItem{ItemID: "item-001", Title: "Item One"},
+		Artifacts: []EvalArtifact{{
+			ID:        "run-generated/item-001/option-a",
+			Hash:      "sha256:aaa",
+			MediaType: "text/markdown",
+			SizeBytes: 12,
+			Driver:    "text",
+		}},
+		Options: []EvalReviewOption{{
+			Label:      "a",
+			ArtifactID: "run-generated/item-001/option-a",
+			Role:       "option",
+		}},
+	}
+	if err := store.ReplaceGeneratedEvalReviewArtifactsForItem(ctx, "run-generated", write); err != nil {
+		t.Fatalf("ReplaceGeneratedEvalReviewArtifactsForItem error = %v", err)
+	}
+
+	if _, err := store.GetEvalArtifact(ctx, "run-generated/item-001/option-a"); err != nil {
+		t.Fatalf("GetEvalArtifact error = %v", err)
+	}
+	items, err := store.ListEvalReviewItems(ctx, "run-generated")
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	if len(items) != 1 || items[0].ItemID != "item-001" || items[0].Title != "Item One" {
+		t.Fatalf("items after persist = %+v", items)
+	}
+	options, err := store.ListEvalReviewOptions(ctx, "run-generated", "item-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 1 || options[0].Label != "a" {
+		t.Fatalf("options after persist = %+v", options)
+	}
+}
+
+func TestReplaceGeneratedEvalReviewArtifactsForItemRollsBack(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	// A valid artifact alongside an option missing its artifact id: the whole
+	// per-item write must fail and leave nothing persisted.
+	write := EvalReviewGenerationWrite{
+		ItemID:     "item-001",
+		ReviewItem: &EvalReviewItem{ItemID: "item-001"},
+		Artifacts: []EvalArtifact{{
+			ID:        "run-generated/item-001/option-a",
+			Hash:      "sha256:aaa",
+			MediaType: "text/markdown",
+			SizeBytes: 12,
+			Driver:    "text",
+		}},
+		Options: []EvalReviewOption{{
+			Label: "a",
+			Role:  "option",
+		}},
+	}
+	err = store.ReplaceGeneratedEvalReviewArtifactsForItem(ctx, "run-generated", write)
+	if err == nil || !strings.Contains(err.Error(), "artifact id is required") {
+		t.Fatalf("ReplaceGeneratedEvalReviewArtifactsForItem error = %v, want artifact id is required", err)
+	}
+	if _, err := store.GetEvalArtifact(ctx, "run-generated/item-001/option-a"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetEvalArtifact after rollback error = %v, want sql.ErrNoRows", err)
+	}
+	items, err := store.ListEvalReviewItems(ctx, "run-generated")
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("items after rollback = %+v", items)
+	}
+	options, err := store.ListEvalReviewOptions(ctx, "run-generated", "item-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 0 {
+		t.Fatalf("options after rollback = %+v", options)
+	}
+}
+
+func TestReplaceGeneratedEvalReviewArtifactsForItemNoClobber(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	writeItem := func(itemID, hash string) EvalReviewGenerationWrite {
+		artifactID := "run-generated/" + itemID + "/option-a"
+		return EvalReviewGenerationWrite{
+			ItemID:     itemID,
+			ReviewItem: &EvalReviewItem{ItemID: itemID},
+			Artifacts: []EvalArtifact{{
+				ID:        artifactID,
+				Hash:      hash,
+				MediaType: "text/markdown",
+				SizeBytes: 12,
+				Driver:    "text",
+			}},
+			Options: []EvalReviewOption{{
+				Label:      "a",
+				ArtifactID: artifactID,
+				Role:       "option",
+			}},
+		}
+	}
+
+	if err := store.ReplaceGeneratedEvalReviewArtifactsForItem(ctx, "run-generated", writeItem("item-001", "sha256:aaa")); err != nil {
+		t.Fatalf("ReplaceGeneratedEvalReviewArtifactsForItem item-001 error = %v", err)
+	}
+	// Writing item-002 must not clobber item-001.
+	if err := store.ReplaceGeneratedEvalReviewArtifactsForItem(ctx, "run-generated", writeItem("item-002", "sha256:bbb")); err != nil {
+		t.Fatalf("ReplaceGeneratedEvalReviewArtifactsForItem item-002 error = %v", err)
+	}
+
+	items, err := store.ListEvalReviewItems(ctx, "run-generated")
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items after writing two = %+v", items)
+	}
+	for _, itemID := range []string{"item-001", "item-002"} {
+		opts, err := store.ListEvalReviewOptions(ctx, "run-generated", itemID)
+		if err != nil {
+			t.Fatalf("ListEvalReviewOptions %s returned error: %v", itemID, err)
+		}
+		if len(opts) != 1 || opts[0].Label != "a" {
+			t.Fatalf("options for %s = %+v", itemID, opts)
+		}
+	}
+
+	// Re-writing item-001 is idempotent: no duplicate labels, item-002 intact.
+	if err := store.ReplaceGeneratedEvalReviewArtifactsForItem(ctx, "run-generated", writeItem("item-001", "sha256:ccc")); err != nil {
+		t.Fatalf("ReplaceGeneratedEvalReviewArtifactsForItem rewrite item-001 error = %v", err)
+	}
+	opts1, err := store.ListEvalReviewOptions(ctx, "run-generated", "item-001")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions item-001 returned error: %v", err)
+	}
+	if len(opts1) != 1 || opts1[0].Label != "a" {
+		t.Fatalf("options for item-001 after rewrite = %+v", opts1)
+	}
+	opts2, err := store.ListEvalReviewOptions(ctx, "run-generated", "item-002")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions item-002 returned error: %v", err)
+	}
+	if len(opts2) != 1 || opts2[0].Label != "a" {
+		t.Fatalf("options for item-002 after item-001 rewrite = %+v", opts2)
+	}
+}
+
 func TestFeedbackEventMethods(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
## Summary

Implements the **core data-loss fix** for #303: SkillOpt train option generation now persists **each review item the moment it completes** (its own atomic transaction) instead of one all-or-nothing batch at the very end, so an interruption no longer strands fully-succeeded child outputs. Resume is idempotent (regenerate only missing items), generation jobs carry a stable correlation `TaskID`, and the writable SQLite connection uses `synchronous=NORMAL` so per-item commits are cheap.

Scope = sections 1–3 of #303 (+ the SQLite tuning prereq). Deferred to #303 follow-ups: `recover --generation`, new status counters, bounded `--generation-concurrency`.

## Changes
- **db**: `synchronous=NORMAL` on the writable connection; refactor `ReplaceGeneratedEvalReviewArtifacts` into a shared per-item tx helper + normalizer; add atomic `ReplaceGeneratedEvalReviewArtifactsForItem` (artifacts + item + options in one tx). Batch path behavior unchanged.
- **skillopt**: persist each item immediately after its roles succeed (drop the end-of-phase batch write); idempotent resume generates only incomplete items, totals = existing + new; stamp a stable correlation `TaskID` (`skillopt-train-generation:<run>:<item>:<label>:<attempt>`) on generation jobs.

## Results
- `go build`, `go vet`, `go test ./...` (all packages), and `go test -race ./internal/workflow/` all pass on the pinned toolchain.
- New tests: per-item atomic persist / rollback / no-clobber (db); item-1 durable before item-2 fails + resume regenerates only incomplete (cli); generation-job correlation TaskID (cli); `synchronous=NORMAL` (db).

## Review
Ran `/code-review` (high). 10 findings → **fixed 4**: dropped a synthetic `ParentJobID`/`RootJobID` on generation jobs that would have made the delegation engine's `AdvanceJob` fail permanently for a requeued generation job (correlate via `TaskID` only); per-item commit now uses a non-cancellable context; resume detection uses one run-scoped query (was N+1); corrected the durability comment. **Skipped 6** (pre-existing patterns — pragma connection-scoping/`busy_timeout`, artifact GC, `GetAgent` error swallow — or subsumed by the major fix); details in the fix commit.

## Risk
Behavior-preserving for the happy path; the only removed behavior is the now-stale "partial generated items" hard error (a complete+incomplete mix is the normal resume state with per-item commits). Batch method retained as public API.

Implements #303 (core layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
