### PR TITLE
docs(website): sync gitmoot.io with delegations, termination, durability, Kimi

### DIFF
--- a/website/docs/concepts/agents-templates-jobs-locks.md
+++ b/website/docs/concepts/agents-templates-jobs-locks.md
@@ -34,6 +34,17 @@ draft from visible context; `agent template add` installs the reviewed snapshot.
 Jobs are units of routed work. They can come from PR comments, local
 `agent ask`, task runs, retries, or merge actions.
 
+## Delegations
+
+An agent's result can return a validated `delegations[]` DAG, and Gitmoot
+dispatches each entry as a child job. Dependency-free delegations run in
+parallel, and once every top-level delegation is terminal Gitmoot enqueues a
+single coordinator continuation job back to the delegating agent to synthesize
+the results. Delegation trees are bounded by a depth cap, a per-root job budget,
+and loop detection, so offending delegations are dropped rather than retried
+forever. See the [Result Contract](../reference/result-contract.md) for the full
+field reference.
+
 ## Locks
 
 Gitmoot uses separate locks for separate resources:

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -105,6 +105,21 @@ To uninstall the CLI, remove the installed binary path returned by
 the runtime to stop finding Gitmoot guidance. Do not delete `~/.gitmoot` unless
 you intentionally want to remove local Gitmoot state, job history, and config.
 
+## Kimi Code Runtime
+
+To run agents on the Kimi Code runtime (`gitmoot agent start <name> --runtime
+kimi`), install the external `kimi` CLI, then authenticate so background jobs
+can reuse the session:
+
+```sh
+kimi login
+gitmoot update --restart-daemon
+```
+
+Restart the Gitmoot daemon after `kimi login` so it inherits the logged-in
+session. The Kimi runtime is a first-class adapter alongside Codex and Claude
+Code; it does not use the `gitmoot plugin install` discovery surface.
+
 ## SkillOpt Optimizer
 
 Gitmoot's SkillOpt train workflow invokes a separate Python optimizer only at

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -1,7 +1,7 @@
 # Quick Start
 
-Run from a project checkout. For Codex or Claude Code, start with the agent
-path:
+Run from a project checkout. For Codex, Claude Code, or Kimi Code, start with
+the agent path:
 
 ```text
 Install Gitmoot as a Codex or Claude skill/plugin in this repo, verify `gitmoot version`, run `gitmoot plugin doctor`, check `gh auth status`, and summarize the next Gitmoot workflow I can use.
@@ -40,6 +40,10 @@ gitmoot agent start project-planner \
   --template planner \
   --start-daemon
 ```
+
+The `--runtime` flag accepts `codex`, `claude`, or `kimi`. To use the Kimi Code
+runtime, run `kimi login` first, then restart the Gitmoot daemon so it inherits
+the session.
 
 For fast planning in the current Codex or Claude chat, ask the runtime:
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -11,7 +11,8 @@ hosted control plane in the current beta.
 ## What Gitmoot Is For
 
 - Route PR comments to named local agents.
-- Keep Codex, Claude Code, shell, and future runtimes behind one agent model.
+- Keep Codex, Claude Code, Kimi Code, shell, and future runtimes behind one
+  agent model.
 - Start or subscribe agents with explicit repo access and capabilities.
 - Use agent templates for reusable planner, review, or custom prompt agents.
 - Capture a successful current chat as a reviewed, reusable agent template
@@ -35,6 +36,7 @@ flowchart TD
   Daemon --> Runtime[Runtime adapter]
   Runtime --> Codex[Codex]
   Runtime --> Claude[Claude Code]
+  Runtime --> Kimi[Kimi Code]
   Runtime --> Shell[Shell]
   Daemon --> GitHub[GitHub issues and PRs]
   CLI --> SkillOpt[SkillOpt train workflow]

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -184,6 +184,27 @@ gitmoot agent start reviewer \
   --start-daemon
 ```
 
+`--runtime` accepts `codex`, `claude`, or `kimi`. Kimi Code is a first-class
+runtime adapter alongside Codex and Claude Code. Before starting a Kimi-backed
+agent, authenticate the Kimi CLI with `kimi login`, then restart the Gitmoot
+daemon so it inherits the logged-in session:
+
+```sh
+kimi login
+gitmoot daemon stop
+gitmoot daemon start --repo owner/repo
+gitmoot agent start reviewer \
+  --runtime kimi \
+  --repo owner/repo \
+  --path . \
+  --role reviewer \
+  --capability ask \
+  --capability review
+```
+
+A Kimi agent's runtime reference must be a Kimi session id (`session_<uuid>`)
+or empty; Gitmoot parses the session id from the Kimi CLI's stream-json output.
+
 Subscribe an existing runtime session:
 
 ```sh
@@ -418,6 +439,7 @@ gitmoot skillopt train start --template <id> --repo owner/repo --request <text> 
 gitmoot skillopt train status --session <id>
 gitmoot skillopt train run [--config path | --session <id>] [--plain]
 gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
+gitmoot skillopt train recover --session <id> [--out-root path] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
 ```
 
@@ -440,6 +462,35 @@ context, and starts follow-up iterations only after a promoted/rejected/abandone
 decision. Use `skillopt review`, `feedback`, `export`, `import`, and
 `candidate` directly only for advanced debugging, custom research runs, or
 recovering one step of a train session.
+
+Option generation in `skillopt train continue` is durable and idempotent on
+resume. Each review item's artifacts, item row, and options commit in a single
+transaction the moment that item finishes, so an interrupted generation phase
+keeps every item that already completed instead of losing the whole batch.
+Re-running `skillopt train continue` regenerates only the incomplete items:
+completed items are skipped, no duplicate options are written, and finished work
+is never rewritten. If an item has some but not all of its options persisted,
+resume hard-errors with `item <id> has partial generated options; inspect or
+clear review options before continuing` so you can inspect or clear that item
+before retrying.
+
+`skillopt train recover` repairs the optimizer phase of a session — it
+re-imports or repairs the optimizer candidate package and classifies the
+iteration as `already_completed_candidate`, `already_completed_no_candidate`,
+`optimizer_active`, or `corrupted_unrecoverable`:
+
+```sh
+gitmoot skillopt train recover --session <id>
+gitmoot skillopt train recover --session <id> --out-root .gitmoot/skillopt/<run-id>
+gitmoot skillopt train recover --session <id> --json
+```
+
+`--out-root` overrides the optimizer output directory (it defaults to the
+session's persisted optimizer path), and `--json` prints the recovery result as
+JSON. Recovery scope is the optimizer phase only: it does not release the
+generation lock and does not rebuild generation options. To recover an
+interrupted generation phase, simply re-run `skillopt train continue`, which
+resumes the incomplete items as described above.
 
 `skillopt review create` starts a review run for a template and target repo.
 Use the default A/B shape for validation, or pass `--mode explore|refine|distill`

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -1,0 +1,163 @@
+# Agent Result Contract
+
+Every Gitmoot agent job ends by returning a single `gitmoot_result` JSON object.
+The result is how an agent reports its outcome, records what it actually did, and
+optionally requests follow-up work from other agents. Gitmoot parses this object
+after the runtime delivers the agent's output and uses it to drive the rest of
+the workflow, so it should be concise, truthful, and tied to work that really
+happened.
+
+## The `gitmoot_result` Shape
+
+At a high level the result captures a decision, a short summary, and several
+arrays that describe the work:
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved|changes_requested|blocked|implemented|failed",
+    "summary": "Brief outcome.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "delegations": []
+  }
+}
+```
+
+The `decision` field reports the outcome of the job:
+
+- `approved`: a review found no blocking issues.
+- `changes_requested`: a review found issues that should be fixed before merge.
+- `blocked`: work cannot continue without human input or an external state
+  change.
+- `implemented`: the requested implementation work was completed.
+- `failed`: the attempted action errored or could not complete.
+
+The narrative and evidence fields are reporting-only. Do not claim tests were run
+in `tests_run` unless they were actually run, and do not list files in
+`changes_made` unless they were actually changed. Use `needs` for missing
+credentials, unclear scope, unavailable tools, failing external services, or
+required human decisions. Always redact secrets from summaries, findings, raw
+command output, and examples.
+
+## Delegations
+
+The `delegations` array is how an agent asks named Gitmoot agents to do
+follow-up work. Each entry describes a child job that Gitmoot spawns and tracks.
+This is the mechanism that replaced the legacy `next_agents` field: rather than
+naming a single hand-off, an agent can request a structured set of child jobs
+with dependencies, failure handling, and synthesis rules.
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "Plan ready for review.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "delegations": [
+      {
+        "id": "review-plan",
+        "agent": "thermo-review",
+        "action": "review",
+        "prompt": "Review the implementation plan for correctness."
+      }
+    ]
+  }
+}
+```
+
+### Delegation fields
+
+- `id` (required): a stable identifier for this delegation, unique within the
+  result. Sibling delegations reference it through `deps`.
+- `agent` (required): the name of the Gitmoot agent to run for the child job.
+- `action` (required): the job action — one of `ask`, `review`, or `implement`.
+- `prompt` (required): the instructions handed to the delegated job.
+- `deps` (optional): an array of sibling delegation `id`s. The delegation runs
+  only after every listed sibling job succeeds. Each entry must reference a
+  known sibling in the same result, may not be self-referential, and may not
+  form a cycle. Delegations form a directed acyclic graph (DAG), and cycles are
+  rejected at validation time.
+- `failure_policy` (optional): one of `block_parent`, `continue`, or `escalate`.
+  Defaults to `block_parent` when omitted.
+- `synthesis_rule` (optional): one of `summary` or `vote`. It tells the
+  coordinator how to combine the children's results.
+- `timeout` (optional): a Go duration string that must be positive (for example,
+  `10m`).
+- `retry` (optional): an integer that must be `>= 0`.
+- `worktree` (optional): the worktree path for the child job.
+- `artifacts` (optional): named artifact handles passed to the child. When any
+  delegation requests `artifacts`, the parent result must also set the top-level
+  `artifact_body` field; validation rejects the result otherwise. See
+  [Top-level fields](#top-level-fields).
+- `fingerprint` (optional): a dedup key. Delegations with identical fingerprints
+  are de-duplicated, so the same delegation is not dispatched twice.
+
+### How delegations run
+
+A delegation with no `deps` is dispatched immediately and runs in parallel with
+its other dep-free siblings. A delegation that lists `deps` waits until every
+sibling it depends on has succeeded before it dispatches. Because the dependency
+graph is a DAG, Gitmoot can resolve a clear order without ever looping.
+
+Once every top-level delegation reaches a terminal state, Gitmoot enqueues
+exactly one coordinator "continuation" job, sent back to the delegating agent, to
+synthesize the children's results according to the `synthesis_rule`. There is
+always exactly one continuation per batch of top-level delegations, not one per
+child, so the delegating agent gets a single opportunity to consolidate the
+outcome.
+
+### Job-tree linkage
+
+Each child job carries linkage fields so any job can be traced through the tree:
+
+- `parent_job_id`: the job that delegated this child.
+- `delegation_id`: the `id` of the delegation that produced this child.
+- `root_job_id`: the root of the entire delegation tree.
+- `delegation_depth`: how deep this job sits below the root.
+- `task_id`: the task the tree belongs to.
+
+These fields let Gitmoot connect a child back to its parent, to the specific
+delegation that spawned it, and to the root of the job tree, and they are what
+the termination bounds below are measured against.
+
+## Top-level fields
+
+- `artifact_body` (optional): the artifact payload made available to delegated
+  children. It is required whenever any delegation sets `artifacts`. The two
+  fields are coupled: child-facing `artifacts` handles describe what a child can
+  reference, and `artifact_body` carries the actual payload at the top level of
+  the parent result. Setting `artifacts` without `artifact_body` is rejected by
+  validation.
+
+## Termination bounds
+
+Delegation and coordinator-continuation chains are bounded so they cannot recurse
+or fan out forever. The bounds are enforced by the workflow engine, and when one
+trips, the offending delegations are dropped rather than dispatched.
+
+- **Depth cap (`MaxDelegationDepth = 8`)**: each delegation child and each
+  coordinator continuation increments `delegation_depth`. A job at or beyond this
+  depth may not delegate further.
+- **Per-root job budget (`MaxDelegationTotalJobs = 64`)**: the whole delegation
+  tree under one root — all children and continuations sharing that root — is
+  capped at this many jobs. When a batch of delegations would exceed the budget,
+  it is dropped, and the parent receives a lifecycle event such as "delegation
+  tree for root &lt;id&gt; reached the job budget of 64".
+- **Loop detection**: a canonical windowed signature over recent delegation
+  activity halts repeated or cyclic delegation chains — for example an
+  oscillating A→B→A loop — well before the depth cap is reached.
+
+When any bound trips, the offending delegations are dropped (not dispatched) and
+the parent receives a lifecycle/mailbox event explaining why. Work is bounded,
+not silently retried forever.
+
+For the in-repo source of truth, see
+[`skills/gitmoot/references/RESULT_CONTRACT.md`](https://github.com/jerryfane/gitmoot/blob/main/skills/gitmoot/references/RESULT_CONTRACT.md)
+and the safety notes in
+[`skills/gitmoot/references/SAFETY.md`](https://github.com/jerryfane/gitmoot/blob/main/skills/gitmoot/references/SAFETY.md).

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -1,8 +1,8 @@
 # Runtime Adapters
 
 Runtime adapters keep Gitmoot workflow logic independent from Codex, Claude
-Code, shell commands, and future runtimes. Gitmoot snapshots the agent template
-and rendered job prompt before handing work to an adapter.
+Code, Kimi Code, shell commands, and future runtimes. Gitmoot snapshots the
+agent template and rendered job prompt before handing work to an adapter.
 
 ## Current Runtimes
 
@@ -10,6 +10,12 @@ and rendered job prompt before handing work to an adapter.
   commands. Prefer explicit session ids for long-running agents.
 - **Claude Code** uses Claude CLI print/resume style commands when available.
   Restart the daemon or runtime session after changing token environment.
+- **Kimi Code** starts a session with `kimi -p '<prompt>' --output-format
+  stream-json` and resumes or delivers follow-up work with `kimi -S <session-id>
+  -p '<prompt>' --output-format stream-json`, parsing the session id from the
+  stream-json output. Select it with `gitmoot agent start <name> --runtime
+  kimi`. Authenticate once with `kimi login`, then restart the Gitmoot daemon so
+  it inherits the session.
 - **Shell** invokes a configured shell command and is mainly for smoke tests,
   demos, and adapter contract checks.
 
@@ -19,6 +25,7 @@ and rendered job prompt before handing work to an adapter.
 
 - Codex accepts a session UUID, thread name, or `last`.
 - Claude accepts a UUID or `last`.
+- Kimi accepts a session id of the form `session_<uuid>` or an empty value.
 - Shell uses the configured command.
 
 Prefer explicit runtime session ids over `last` for durable agents. Use

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -374,6 +374,29 @@ Use `quality: poor` or `continue_mode: explore` when all options are weak and a
 stable winner should not narrow the search yet. Gitmoot keeps feedback parsing
 deterministic and stores imported events as canonical feedback for export.
 
+## Option Generation Durability
+
+Option generation is durable per item. As each review item finishes, its
+artifacts, item row, and options are committed together in one transaction, so
+finished work survives an interrupted run instead of being held until the whole
+generation phase completes.
+
+Resume is idempotent. Rerunning `gitmoot skillopt train continue` regenerates
+only the incomplete items: completed items are skipped, no duplicate options are
+created, and completed work is never rewritten. You can safely rerun `continue`
+after a crash, a kill, or a stopped run to finish only what is left.
+
+A partially generated item is a hard error rather than something Gitmoot
+silently repairs. If an item has some but not all of its options persisted,
+resume stops with:
+
+```text
+item <id> has partial generated options; inspect or clear review options before continuing
+```
+
+Inspect that item or clear its review options, then rerun `train continue` to
+regenerate it cleanly.
+
 ## Optimizer And Candidate Gate
 
 After feedback sync, `train continue` exports the training package, invokes the
@@ -572,10 +595,19 @@ instead of re-running blindly:
 gitmoot skillopt train recover --session planner-train --out-root .gitmoot/skillopt/planner-train
 ```
 
-Recovery validates the package state, imports a completed candidate through the
-normal candidate gate, or records `optimizer_completed_no_candidate` with the
-stored rejection reason. Incomplete or corrupted artifacts fail without
-modifying the train state.
+`train recover` accepts `--session <id>`, an optional `--out-root <path>`, and
+`--json`. Its scope is the optimizer phase only: it re-imports and repairs the
+optimizer candidate package and classifies the iteration as
+`already_completed_candidate`, `already_completed_no_candidate`,
+`optimizer_active`, or `corrupted_unrecoverable`. It re-imports a completed
+candidate through the normal candidate gate, or records
+`optimizer_completed_no_candidate` with the stored rejection reason. Incomplete
+or corrupted artifacts fail without modifying the train state.
+
+`train recover` does not touch option generation: it does not release the
+generation lock and does not rebuild generation options. To resume interrupted
+option generation, rerun `gitmoot skillopt train continue` (see
+[Option Generation Durability](#option-generation-durability)).
 
 ## Candidate Review And Next Iteration
 
@@ -729,7 +761,14 @@ Manual smoke scenarios for review operations:
   and next action options.
 - Optimizer wrapper failed after artifacts: if `status_phase` is
   `recovery_available`, run `gitmoot skillopt train recover --session <id>
-  --out-root <optimizer-output-root>`.
+  --out-root <optimizer-output-root>`. `train recover` repairs the optimizer
+  candidate package only; it does not release the generation lock or rebuild
+  generation options.
+- Interrupted option generation: rerun `gitmoot skillopt train continue
+  --session <id>`. It regenerates only incomplete items and never rewrites
+  completed work. If it reports that an item "has partial generated options",
+  inspect or clear that item's review options before continuing. Do not use
+  `train recover` for this; recover is optimizer-phase only.
 - Stale optimizer lock: if `status_phase` is `blocked_stale_lock`, inspect
   `active_lock` owner, pid, host, heartbeat, and expiry in verbose status before
   clearing stale state or retrying the optimizer.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -43,6 +43,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'reference/cli',
         'reference/runtime-adapters',
+        'reference/result-contract',
         'reference/skillopt-exchange-contract',
       ],
     },

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -19,6 +19,7 @@ Local-first multi-agent coordination for GitHub pull request workflows.
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-black.svg)](./LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/jerryfane/gitmoot?include_prereleases&color=black)](https://github.com/jerryfane/gitmoot/releases)
 [![Go module](https://img.shields.io/badge/go-module-black.svg)](./go.mod)
+[![CI](https://github.com/jerryfane/gitmoot/actions/workflows/ci.yml/badge.svg)](https://github.com/jerryfane/gitmoot/actions/workflows/ci.yml)
 
 Gitmoot lets humans and AI agents collaborate through the place software teams
 already audit work: GitHub pull requests. It runs on the user's machine, keeps
@@ -36,8 +37,13 @@ trail. Gitmoot makes the repository and its pull requests the shared surface:
 
 - PR comments become agent tasks, review requests, retries, and merge signals.
 - Local SQLite records agents, repos, jobs, goals, tasks, PRs, and branch locks.
-- Runtime adapters keep Codex, Claude Code, and future runtimes behind the same
-  Gitmoot agent model.
+- Runtime adapters keep Codex, Claude Code, Kimi Code, and future runtimes
+  behind the same Gitmoot agent model.
+- Agents can return a validated `delegations[]` DAG that Gitmoot dispatches as
+  child jobs, then enqueues one continuation job to synthesize their results
+  (replacing the old `next_agents` mechanism).
+- Delegation trees are bounded by a depth cap, a per-root job budget, and loop
+  detection, so coordination halts instead of recursing forever.
 - Agent Templates and job snapshots make agent instructions explicit and reproducible.
 - Humans can follow progress from GitHub while agents keep working locally.
 
@@ -48,13 +54,13 @@ GitHub PR comments/state
   -> local gitmoot daemon
   -> local SQLite state machine and job mailbox
   -> registered runtime adapter
-  -> Codex, Claude Code, shell, or another agent runtime
+  -> Codex, Claude Code, Kimi Code, shell, or another agent runtime
   -> GitHub PR comments, statuses, branches, PRs, and merges
 ```
 
 The core primitive is a runtime-neutral Gitmoot agent, not a Codex-specific
-session. Codex and Claude Code are adapters behind the same internal runtime
-contract.
+session. Codex, Claude Code, and Kimi Code are adapters behind the same internal
+runtime contract.
 
 ## Install
 
@@ -103,6 +109,10 @@ gitmoot agent start project-planner \
   --template planner \
   --start-daemon
 ```
+
+`--runtime` accepts `codex`, `claude`, or `kimi`. For Kimi Code, run
+`kimi login` and restart the Gitmoot daemon so it inherits the session, then
+start the agent with `--runtime kimi`.
 
 For fast planning in the current Codex or Claude chat, ask the runtime:
 
@@ -154,7 +164,7 @@ For the full walkthrough, see [docs/local-workflow.md](docs/local-workflow.md).
 - **Agent**: a named Gitmoot identity with repo access, role, capabilities, and
   a runtime adapter.
 - **Runtime adapter**: the bridge from Gitmoot jobs to Codex, Claude Code,
-  shell commands, or future runtimes.
+  Kimi Code, shell commands, or future runtimes.
 - **Template**: cached prompt content attached to an agent and snapshotted into
   each job.
 - **Job**: a routed unit of work created from a PR comment, local ask, task run,
@@ -485,16 +495,19 @@ go test ./...
 go vet ./...
 ```
 
+GitHub Actions enforces the same gate on every push to `main` and every pull
+request: build, vet, and test, plus the race detector on `internal/workflow`.
+
 ---
 
 # Source: SKILL.md
 
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, PR comments, daemon jobs, branch locks, agent templates, template capture, custom prompt agents, and Codex or Claude Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, PR comments, daemon jobs, branch locks, agent templates, template capture, custom prompt agents, and Codex, Claude Code, or Kimi Code runtime workflows.
 version: 0.1.0
 license: Apache-2.0
-compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
+compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
   gitmoot-version: "0.1.0"
   source: "jerryfane/gitmoot"
@@ -519,9 +532,9 @@ This root `SKILL.md` is kept as a raw compatibility entrypoint for agents and
 Gitmoot is a local-first coordinator for AI agents working across repositories,
 goals, reviews, PR comments, and runtime workflows. Use this skill when the
 user wants PR-comment agent workflows, repo-scoped agent subscriptions,
-background daemon checks, Codex or Claude Code agent startup, structured
-implementation plans, standard goal files, agent template workflows, template
-capture, custom prompt agents, job status, or branch lock inspection.
+background daemon checks, Codex, Claude Code, or Kimi Code agent startup,
+structured implementation plans, standard goal files, agent template workflows,
+template capture, custom prompt agents, job status, or branch lock inspection.
 
 For current-chat prompt import, "use <agent> here" means run
 `gitmoot agent prompt <agent>` and apply the returned prompt content in this
@@ -548,9 +561,15 @@ Use `gitmoot agent template draft <id>` for a blank scaffold,
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
-same Codex or Claude session, and branch locks protect implementation ownership.
+same Codex, Claude, or Kimi session, and branch locks protect implementation
+ownership.
 The daemon default is `--workers 1`; raise it only for independent runtime
 sessions or managed agent types with `max_background` greater than one.
+
+For runtime selection, `gitmoot agent start <name> --runtime <runtime>` accepts
+`codex`, `claude`, or `kimi`. Kimi Code is a first-class runtime adapter
+alongside Codex and Claude Code. To use it, run `kimi login`, then restart the
+Gitmoot daemon so it inherits the session.
 
 For Gitmoot health or status questions, run the relevant read-only Gitmoot CLI
 checks and answer directly from the results. Mention `gitmoot dashboard` only
@@ -663,6 +682,24 @@ default. Create with `--create --yes` only when the user explicitly asks or the
 active workflow policy permits filing reports, then report the created or
 existing GitHub issue URL back to the user.
 
+SkillOpt train generation is durable and idempotent on resume. Each review
+item's artifacts, item row, and options commit in one transaction the moment
+that item finishes, so an interrupted generate phase loses only the item that
+was in flight. Re-running `gitmoot skillopt train continue` regenerates ONLY the
+items that are not yet complete; fully-generated items are skipped, so no
+duplicate options are produced and completed work is never rewritten. If a single
+item has some but not all of its options/artifacts persisted, resume returns a
+hard error (`item <id> has partial generated options; inspect or clear review
+options before continuing`) rather than guessing.
+
+Use `gitmoot skillopt train recover --session <id> [--out-root path] [--json]`
+to recover the OPTIMIZER phase only. It re-imports or repairs the optimizer
+candidate package and classifies the iteration (for example
+`already_completed_candidate`, `already_completed_no_candidate`,
+`optimizer_active`, or `corrupted_unrecoverable`). It does NOT release the
+generation-phase lock or rebuild generation options; use `train continue` for
+generation resume.
+
 ## PR Comment Commands
 
 Use GitHub PR comments as the public audit trail:
@@ -759,7 +796,8 @@ object:
 
 Use `blocked` when work cannot continue without human input or external state.
 Use `failed` when the attempted action errored. Do not report tests, changes, or
-approvals that were not actually verified.
+approvals that were not actually verified. Use `delegations` to request follow-up
+work by named Gitmoot agents.
 
 ## Safety Rules
 
@@ -807,8 +845,8 @@ gitmoot plugin doctor
 gitmoot agent template list
 gitmoot agent template add frontend-reviewer --file agents/frontend-reviewer.md
 gitmoot agent template update thermo-nuclear-code-quality-review
-gitmoot agent start <name> --runtime codex|claude --repo owner/repo --path . --template thermo-nuclear-code-quality-review --start-daemon
-gitmoot agent subscribe <name> --runtime codex|claude|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
+gitmoot agent start <name> --runtime codex|claude|kimi --repo owner/repo --path . --template thermo-nuclear-code-quality-review --start-daemon
+gitmoot agent subscribe <name> --runtime codex|claude|kimi|shell --session <id|name|last|command> --role <role> --repo owner/repo --capability <capability>
 gitmoot agent run <name> "message" --repo owner/repo [--task task-id] [--pr number] [--background]
 gitmoot agent review <name> "message" --repo owner/repo --pr number [--background]
 gitmoot agent implement <name> "message" --repo owner/repo [--task task-id] [--background]
@@ -890,8 +928,8 @@ Background execution uses separate resource categories:
   ticks from mutating the same checkout at once.
 - **Runtime session locks**: SQLite resource locks keyed as
   `runtime:<runtime>:<runtime_ref>`, shared by daemon jobs, `job run`, and
-  synchronous `agent ask`, so one Codex or Claude session is never resumed by
-  two jobs at the same time.
+  synchronous `agent ask`, so one Codex, Claude, or Kimi session is never resumed
+  by two jobs at the same time.
 - **Branch locks**: workflow ownership records used for implementation and
   merge safety.
 
@@ -913,8 +951,8 @@ max_temp_sessions_per_agent = 4
 eligible_actions = ["ask", "review", "implement"]
 ```
 
-When a Codex or Claude runtime session is busy, Gitmoot can start a bounded
-temporary worker with the same template and repo scope. Implementation jobs only
+When a Codex, Claude, or Kimi runtime session is busy, Gitmoot can start a
+bounded temporary worker with the same template and repo scope. Implementation jobs only
 fork when the task has a recorded worktree and the original agent is writable.
 If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
 
@@ -945,7 +983,9 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    reference, grants the repo, and can start the background daemon. For Codex it
    runs `codex exec --json -- <startup-prompt>` and records the emitted
    `thread.started.thread_id`. For Claude Code it creates a session id and uses
-   the installed Claude CLI's non-interactive print mode.
+   the installed Claude CLI's non-interactive print mode. For Kimi Code it runs
+   `kimi -p '<startup-prompt>' --output-format stream-json` and records the
+   `session_<uuid>` session id parsed from the stream-json output.
 
    ```sh
    gitmoot init
@@ -1540,8 +1580,9 @@ Then confirm the runtime uses the same home directory as the shell where
 
 # Runtime Adapter Authoring
 
-Gitmoot treats Codex, Claude Code, and shell commands as runtime adapters behind
-one interface. Workflow, daemon, and GitHub code should stay runtime-neutral.
+Gitmoot treats Codex, Claude Code, Kimi Code, and shell commands as runtime
+adapters behind one interface. Workflow, daemon, and GitHub code should stay
+runtime-neutral.
 
 ## Adapter Contract
 
@@ -1590,7 +1631,8 @@ type Agent struct {
 ```
 
 `RuntimeRef` is runtime-specific. Codex accepts a session UUID, thread name, or
-`last`. Claude accepts a UUID or `last`. Shell uses the configured command.
+`last`. Claude accepts a UUID or `last`. Kimi accepts a Kimi session id of the
+form `session_<uuid>` or empty. Shell uses the configured command.
 `TemplateID` is Gitmoot-owned metadata. Adapters do not fetch or interpret template
 content; Gitmoot snapshots cached template instructions into the rendered prompt
 before delivery.
@@ -1625,6 +1667,22 @@ The UUID is stored only after the command succeeds. Future jobs use the Claude
 adapter's resume path. This depends on the installed Claude Code CLI supporting
 the documented `--session-id`, `-p`, `--output-format json`, and `--resume`
 contract.
+
+Kimi startup runs in the repo checkout path:
+
+```sh
+kimi -p '<startup-prompt>' --output-format stream-json
+```
+
+The adapter parses the stream-json output and stores the reported session id.
+Future jobs resume that session with:
+
+```sh
+kimi -S <session-id> -p '<job-prompt>' --output-format stream-json
+```
+
+Kimi runs against a logged-in Kimi CLI. Run `kimi login`, then restart the
+Gitmoot daemon so it inherits the session.
 
 Shell adapters do not support `agent start`; register shell commands with
 `agent subscribe`.
@@ -2475,6 +2533,29 @@ gitmoot skillopt train continue --session landing-page-train
 gitmoot skillopt train continue --session landing-page-train
 ```
 
+### Durable Generation And Idempotent Resume
+
+Option generation is durable per item. As soon as a single review item's
+options finish, that item's artifacts, item row, and options commit in one
+transaction, instead of a single end-of-phase batch write. A later item's
+failure or a mid-run cancellation cannot lose an item that already finished.
+
+Resume is idempotent. Re-running `train continue` regenerates only the items
+that are not yet complete; fully-generated items are skipped, so no duplicate
+options are produced and completed work is never rewritten. A mix of complete
+and incomplete items is the normal resume state.
+
+If a single item has some but not all of its options or A/B artifacts
+persisted, `train continue` does not guess. It stops with a hard error such as
+`item <id> has partial generated options; inspect or clear review options
+before continuing`, so a partially generated item is inspected or cleared
+rather than silently completed or duplicated.
+
+This per-item generation durability is separate from `skillopt train recover`,
+which recovers the optimizer phase only (see "Optimizer And Candidate Gate").
+`train recover` does not release the generation lock or rebuild generation
+options.
+
 Low-level `skillopt feedback github publish` and `sync` enforce
 `review.expected_repo` for train runs. If a preview train expects
 `owner/previews`, publishing or syncing against `owner/product` fails instead of
@@ -2761,10 +2842,20 @@ instead of re-running blindly:
 gitmoot skillopt train recover --session planner-train --out-root .gitmoot/skillopt/planner-train
 ```
 
-Recovery validates the package state, imports a completed candidate through the
-normal candidate gate, or records `optimizer_completed_no_candidate` with the
-stored rejection reason. Incomplete or corrupted artifacts fail without
-modifying the train state.
+```sh
+gitmoot skillopt train recover --session planner-train --out-root .gitmoot/skillopt/planner-train --json
+```
+
+`train recover` is scoped to the optimizer phase only. It re-imports or repairs
+the optimizer candidate package and classifies the active iteration, for example
+`already_completed_candidate`, `already_completed_no_candidate`,
+`optimizer_active`, or `corrupted_unrecoverable`. Recovery validates the package
+state, imports a completed candidate through the normal candidate gate, or
+records `optimizer_completed_no_candidate` with the stored rejection reason.
+Incomplete or corrupted artifacts fail without modifying the train state. It does
+not recover the generation phase, release the generation lock, or rebuild
+generation options; per-item generation durability and idempotent resume handle
+that (see "Durable Generation And Idempotent Resume").
 
 ## Candidate Review And Next Iteration
 
@@ -3673,6 +3764,101 @@ Expected signals:
   job events.
 
 5. Stop the daemon when finished.
+
+   ```sh
+   gitmoot daemon stop
+   gitmoot daemon status
+   ```
+
+## Delegation Smoke Test
+
+Goal: background coordinator job -> `delegations` in the coordinator result ->
+two child jobs fanned out to worker agents -> both children succeed -> coordinator
+continuation job enqueued. This exercises the structured delegation path end to
+end with local shell agents, so it needs no external runtime CLIs.
+
+The coordinator must run as background work so the daemon executes it through the
+engine and dispatches the delegations. A synchronous `gitmoot agent ask` without
+`--background` only returns the coordinator's own result and does not fan out, so
+the test would silently pass with zero child jobs.
+
+1. Register a coordinator shell agent whose result returns two delegations, and
+   two worker shell agents whose results return empty `delegations` (so the
+   fan-out terminates and does not recurse).
+
+   ```sh
+   gitmoot setup --repo owner/project --path . --agent coordinator --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"coordinator delegating ui and api\",\"findings\":[],\"changes_made\":[],\"tests_run\":[],\"needs\":[],\"delegations\":[{\"id\":\"ui\",\"agent\":\"ui-worker\",\"action\":\"ask\",\"prompt\":\"propose the ui changes\"},{\"id\":\"api\",\"agent\":\"api-worker\",\"action\":\"ask\",\"prompt\":\"review the api contract\"}]}}'"
+   gitmoot agent subscribe ui-worker --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"ui worker done\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'" --role reviewer --repo owner/project --capability ask --capability review
+   gitmoot agent subscribe api-worker --runtime shell --session "printf '%s\n' '{\"gitmoot_result\":{\"decision\":\"approved\",\"summary\":\"api worker done\",\"findings\":[],\"changes_made\":[],\"tests_run\":[\"shell smoke\"],\"needs\":[],\"delegations\":[]}}'" --role reviewer --repo owner/project --capability ask --capability review
+   gitmoot agent repos coordinator
+   ```
+
+2. Start the background daemon so it executes the queued coordinator job and
+   fans out the delegations.
+
+   ```sh
+   gitmoot daemon start --repo owner/project --poll 30s
+   gitmoot daemon status
+   ```
+
+3. Queue the coordinator as background work.
+
+   ```sh
+   gitmoot agent ask coordinator --repo owner/project --background "coordinate the ui and api work"
+   ```
+
+4. Confirm the coordinator job, the two child jobs, and the continuation job.
+
+   ```sh
+   gitmoot job list --repo owner/project
+   gitmoot events --repo owner/project
+   ```
+
+Expected signals:
+
+- `gitmoot events --repo owner/project` shows two `delegation_enqueued` events
+  on the coordinator job, one for the `ui` delegation and one for the `api`
+  delegation.
+- `gitmoot job list --repo owner/project` shows two child jobs with composite
+  ids of the form `<coordinator-job-id>/delegation/ui` and
+  `<coordinator-job-id>/delegation/api`, each reaching `succeeded`.
+- After both children succeed, `gitmoot events --repo owner/project` shows a
+  `delegation_continuation_enqueued` event and `gitmoot job list` shows a
+  coordinator continuation job `<coordinator-job-id>/continuation` queued for
+  `coordinator`.
+
+> Note: the continuation job runs the **same** coordinator agent. A real LLM
+> coordinator ends the loop by returning no `delegations` on the continuation,
+> but a *static* shell agent returns the same delegations every time, so the
+> continuation re-delegates each generation. This is bounded by
+> `MaxDelegationDepth` (8): once a coordinator/continuation at that depth would
+> dispatch, Gitmoot refuses and records a `delegation_depth_exceeded` event
+> instead of spawning jobs forever. To keep this smoke test fast, run
+> `gitmoot daemon stop` once you have observed the first continuation rather than
+> waiting for the depth cap to halt the chain. Also note delegated `action:
+> review` requires a pull request / head SHA; use `action: ask` for PR-less
+> smoke agents (a no-PR review fails with "job for <branch> has no head SHA").
+
+5. (Optional) Verify dependency gating. Re-run with a coordinator whose result
+   adds a third delegation that depends on the first two; it must stay queued
+   until both deps succeed, then run.
+
+   ```json
+   {
+     "id": "integrate",
+     "agent": "api-worker",
+     "action": "ask",
+     "prompt": "integrate the ui and api work",
+     "deps": ["ui", "api"]
+   }
+   ```
+
+   Expected: `gitmoot events --repo owner/project` shows the
+   `<coordinator-job-id>/delegation/integrate` job enqueued only after the `ui`
+   and `api` children reach `succeeded`, and the continuation job is enqueued
+   once `integrate` also succeeds.
+
+6. Stop the daemon when finished.
 
    ```sh
    gitmoot daemon stop
@@ -4665,9 +4851,9 @@ bug-report workflow added after the v0.3.0 dashboard beta.
 
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, jobs, branch locks, agent-templates, template capture, custom prompt agents, and Codex or Claude Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, jobs, branch locks, agent-templates, template capture, custom prompt agents, and Codex, Claude Code, or Kimi Code runtime workflows.
 license: Apache-2.0
-compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex or Claude Code.
+compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
   gitmoot-version: "0.1.0"
   source: "jerryfane/gitmoot"
@@ -4678,7 +4864,7 @@ metadata:
 Gitmoot is a local-first coordinator for AI agents working across repositories,
 goals, reviews, PR comments, and runtime workflows. Use this skill when the
 user wants PR-comment agent workflows, repo-scoped agent subscriptions,
-background daemon checks, Codex or Claude Code agent startup, structured
+background daemon checks, Codex, Claude Code, or Kimi Code agent startup, structured
 implementation plans, standard goal files, agent template workflows, custom
 prompt agents, template capture, job status, or branch lock inspection.
 
@@ -4705,7 +4891,8 @@ Use `gitmoot agent template draft <id>` for a blank scaffold,
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
-same Codex or Claude session, and branch locks protect implementation ownership.
+same Codex, Claude, or Kimi session, and branch locks protect implementation
+ownership.
 The daemon default is `--workers 1`; raise it only for independent runtime
 sessions or managed agent types with `max_background` greater than one.
 
@@ -4750,8 +4937,8 @@ analysis, planning, or questions. Use `gitmoot agent review <agent> --repo
 owner/repo --pr <number> "..."` for PR review decisions and `gitmoot agent
 implement <agent> --repo owner/repo --task <task-id> "..."` for file changes.
 Add `--background` only when the user wants a queued background job. Use
-`gitmoot plugin doctor` when checking whether Codex or Claude Code can discover
-Gitmoot through an installed runtime plugin. Use
+`gitmoot plugin doctor` when checking whether Codex, Claude Code, or Kimi Code
+can discover Gitmoot through an installed runtime plugin. Use
 `gitmoot plugin codex-launch --repo <path>` to print a Codex launch command that
 adds the resolved `.gitmoot` home to the sandbox on Linux, macOS, and Windows.
 Use `gitmoot goal template` when
@@ -4781,7 +4968,16 @@ specific step. In train mode, collect enough ranked feedback and trait notes
 before optimizer handoff, check `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help` when optimizer-backed continue is needed,
 keep promotion decisions explicit, and start follow-up iterations only through
-`train continue --start-next`.
+`train continue --start-next`. Generation is durable: each review item's
+artifacts and options commit in one transaction the moment that item finishes,
+so an interrupted phase resumes idempotently when you re-run `train continue` —
+already-complete items are skipped and never duplicated, while an item with some
+but not all options persisted returns a hard error to inspect or clear before
+continuing. For optimizer-phase recovery, use
+`gitmoot skillopt train recover --session <id> [--out-root path] [--json]`,
+which re-imports or repairs the optimizer candidate package and classifies the
+iteration; it does not release the generation lock or rebuild generation
+options.
 
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).
@@ -4829,6 +5025,7 @@ capabilities:
 runtime_compatibility:
   - codex
   - claude
+  - kimi
 tags:
   - planning
   - goals
@@ -4897,6 +5094,57 @@ When asked to write the goal file:
 
 Do not implement the planned feature unless the user explicitly asks after the
 plan and goal file are complete.
+
+## Coordinator Delegations
+
+When you run as a managed coordinator agent and want Gitmoot to fan work out to
+other named agents, return a top-level `delegations` array in your
+`gitmoot_result`. Gitmoot enqueues one child job per delegation and records a
+`delegation_enqueued` event on your job for each one.
+
+Each delegation requires four fields:
+
+- `id`: stable identifier for the delegation within this result.
+- `agent`: name of the Gitmoot agent to run.
+- `action`: job action, e.g. `ask`, `review`, or `implement`.
+- `prompt`: instructions for the delegated job.
+
+Optional advanced controls are also supported: `worktree`, `artifacts`, `deps`,
+`timeout`, `retry`, `failure_policy`, `fingerprint`, and `synthesis_rule`. A
+delegation with no `deps` is dispatched immediately and runs in parallel with
+its siblings; a delegation with `deps` runs only after every listed sibling has
+succeeded. Once all top-level delegations reach a terminal state, Gitmoot
+enqueues one coordinator continuation job so you can synthesize the results.
+
+See `references/RESULT_CONTRACT.md` for the full field reference. Example
+coordinator result that delegates two flat parallel jobs to different agents:
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "Plan ready; delegating implementation and review.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "delegations": [
+      {
+        "id": "build-api",
+        "agent": "backend-coder",
+        "action": "implement",
+        "prompt": "Implement the REST API described in the plan."
+      },
+      {
+        "id": "review-plan",
+        "agent": "reviewer",
+        "action": "review",
+        "prompt": "Review the implementation plan for correctness and risk."
+      }
+    ]
+  }
+}
+```
 
 ## Current-Chat Use
 
@@ -5005,7 +5253,7 @@ equivalent:
   remedy and can be retried in place).
 - **Agents** lists registered agents: `enter` opens a detail with the template,
   recent jobs, and the template's version history; `n` registers a new agent
-  (name, codex/claude runtime, installed template); `o` starts a training
+  (name, codex/claude/kimi runtime, installed template); `o` starts a training
   session for the agent's template via a pre-filled form (review/workspace
   repos, request, codex/claude backend, optional model — the backend/model are
   stored in the session's optimizer defaults so `train continue` inherits
@@ -5094,6 +5342,9 @@ gitmoot agent start reviewer \
   --capability review \
   --start-daemon
 ```
+
+`--runtime` accepts `codex`, `claude`, or `kimi`. For `kimi`, run `kimi login`
+first and restart the Gitmoot daemon so it inherits the session.
 
 Subscribe an existing runtime session:
 
@@ -5329,6 +5580,7 @@ gitmoot skillopt train start --template <id> --repo owner/repo --request <text> 
 gitmoot skillopt train status --session <id>
 gitmoot skillopt train run [--config path | --session <id>] [--plain]
 gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
+gitmoot skillopt train recover --session <id> [--out-root path] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
 ```
 
@@ -5351,6 +5603,23 @@ context, and starts follow-up iterations only after a promoted/rejected/abandone
 decision. Use `skillopt review`, `feedback`, `export`, `import`, and
 `candidate` directly only for advanced debugging, custom research runs, or
 recovering one step of a train session.
+
+`skillopt train continue` generation is durable and idempotent on resume. Each
+review item's artifacts, item row, and options commit in one transaction the
+moment that item finishes, so an interrupted generate phase loses only the item
+that was in flight. Re-running `train continue` regenerates ONLY the items that
+are not yet complete; fully-generated items are skipped, so no duplicate options
+are produced and completed work is never rewritten. If a single item has some
+but not all of its options/artifacts persisted, resume returns a hard error
+(`item <id> has partial generated options; inspect or clear review options
+before continuing`) rather than guessing.
+
+`skillopt train recover --session <id>` recovers the OPTIMIZER phase only. It
+re-imports or repairs the optimizer candidate package and classifies the
+iteration (for example `already_completed_candidate`,
+`already_completed_no_candidate`, `optimizer_active`, or
+`corrupted_unrecoverable`). It does NOT release the generation-phase lock or
+rebuild generation options; use `train continue` for generation resume.
 
 `skillopt review create` starts a review run for a template and target repo.
 Use the default A/B shape for validation, or pass `--mode explore|refine|distill`
@@ -5775,8 +6044,8 @@ through a runtime adapter.
 Background jobs are scheduled against three distinct resources:
 
 - repo checkout mutexes for daemon ticks that use the same local checkout;
-- runtime session locks keyed as `runtime:<runtime>:<runtime_ref>` for Codex
-  and Claude delivery;
+- runtime session locks keyed as `runtime:<runtime>:<runtime_ref>` for Codex,
+  Claude, and Kimi delivery;
 - branch locks for implementation ownership and merge safety.
 
 The daemon default is `--workers 1`. Users can raise it when jobs target
@@ -5800,6 +6069,70 @@ gitmoot agent allow reviewer --repo owner/project-b
 gitmoot status --repo owner/project-a
 gitmoot status --repo owner/project-b
 ```
+
+## Multi-Model Delegation
+
+A coordinator agent can fan work out to other agents running on different
+runtimes by returning a `delegations` array in its `gitmoot_result`. Gitmoot
+enqueues one child job per delegation, records a `delegation_enqueued` event on
+the coordinator job, and runs the children in the daemon. Start a coordinator
+and two workers on different runtimes so each delegation lands on the best model
+for the job:
+
+```sh
+gitmoot agent start coordinator --runtime codex --repo owner/repo --role planner --capability ask --start-daemon
+gitmoot agent start ui-worker --runtime claude --repo owner/repo --role reviewer --capability ask --capability review
+gitmoot agent start api-worker --runtime kimi --repo owner/repo --role reviewer --capability ask --capability review
+```
+
+Queue the coordinator as background work so the daemon runs it and dispatches
+its delegations (a synchronous `gitmoot agent ask` without `--background` only
+returns the coordinator's own answer and does not fan out):
+
+```sh
+gitmoot agent ask coordinator --repo owner/repo --background "Coordinate the redesign across the API and UI teams."
+```
+
+The coordinator returns two delegations to the workers on different runtimes:
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "Delegating UI review and API review to the workers.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "delegations": [
+      {
+        "id": "ui",
+        "agent": "ui-worker",
+        "action": "ask",
+        "prompt": "Propose the component changes for the new dashboard layout."
+      },
+      {
+        "id": "api",
+        "agent": "api-worker",
+        "action": "review",
+        "prompt": "Review the API contract for the dashboard endpoints."
+      }
+    ]
+  }
+}
+```
+
+Gitmoot enqueues each delegation as a flat parallel child job
+(`<parent-job-id>/delegation/<id>`) with a `delegation_enqueued` event on the
+parent. Delegations that declare `deps` run only after the named siblings
+succeed, and once every top-level delegation is terminal Gitmoot enqueues one
+coordinator continuation job so the coordinator can synthesize the results.
+Inspect the fan-out with `gitmoot job list --repo owner/repo` (one row per child
+job) and `gitmoot events --repo owner/repo` (the `delegation_enqueued` events).
+Each child job carries job-tree linkage fields — `parent_job_id`,
+`delegation_id`, `root_job_id`, `delegation_depth`, and `task_id` — so a child
+can be traced back to its parent, its originating delegation, and the root of the
+tree. See `RESULT_CONTRACT.md` for the full delegation field reference.
 
 ---
 
@@ -5964,6 +6297,26 @@ If the work depends on external APIs, CLIs, env vars, generated scripts, service
 launchers, installers, deployment behavior, or third-party libraries, verify the
 real contract with local commands and/or official documentation before editing.
 
+## Delegation Termination Bounds
+
+Delegation and coordinator-continuation chains are bounded so they cannot recurse
+or fan out forever:
+
+- Depth cap `MaxDelegationDepth = 8`: each delegation child and each coordinator
+  continuation increments `delegation_depth`. A job at or beyond this depth may
+  not delegate further.
+- Per-root job budget `MaxDelegationTotalJobs = 64`: the whole delegation tree
+  under one root (all children and continuations sharing that root) is capped.
+  When a batch would exceed it, the delegations are not dispatched.
+- Loop detection: a canonical windowed signature hash over recent delegation
+  activity halts repeated or cyclic delegation chains well before the depth cap
+  is reached, preventing oscillating A→B→A loops.
+
+When a bound trips, the offending delegations are dropped (not dispatched) and
+the parent receives a lifecycle/mailbox event explaining why (for example, the
+delegation tree for a root reached the job budget of 64). Work is bounded, not
+silently retried forever.
+
 ## When To Stop
 
 Stop and report `blocked` when the target repo is unclear, GitHub auth is
@@ -5994,6 +6347,86 @@ truthful, and tied to work that actually happened.
 }
 ```
 
+## Delegations
+
+Use `delegations` to request follow-up work by named Gitmoot agents. Each
+delegation describes a child job:
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "Plan ready for review.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "delegations": [
+      {
+        "id": "review-plan",
+        "agent": "thermo-review",
+        "action": "review",
+        "prompt": "Review the implementation plan for correctness."
+      }
+    ]
+  }
+}
+```
+
+Delegation fields:
+
+- `id` (required): stable identifier for this delegation, unique within the
+  result. Sibling delegations reference it through `deps`.
+- `agent` (required): name of the Gitmoot agent to run.
+- `action` (required): job action, e.g. `ask`, `review`, or `implement`.
+- `prompt` (required): instructions for the delegated job.
+- `deps` (optional): array of sibling delegation `id`s. This delegation runs
+  only after every listed sibling succeeds. Each entry must reference a known
+  sibling in the same result, may not be self-referential, and may not form a
+  cycle — delegations form a DAG, and cycles are rejected.
+- `failure_policy` (optional): one of `block_parent`, `continue`, or
+  `escalate`. Defaults to `block_parent` when omitted.
+- `synthesis_rule` (optional): one of `summary` or `vote`.
+- `timeout` (optional): a Go duration string and must be positive (e.g. `10m`).
+- `retry` (optional): integer `>= 0`.
+- `worktree` (optional): worktree path for the child job.
+- `artifacts` (optional): named artifact handles passed to the child. When any
+  delegation requests artifacts, the parent result must also set the top-level
+  `artifact_body` field; validation rejects the result otherwise.
+- `fingerprint` (optional): dedup key. Identical fingerprints are
+  de-duplicated, so the same delegation is not dispatched twice.
+
+A delegation with no `deps` dispatches immediately and runs in parallel with
+other dep-free siblings. Once every top-level delegation reaches a terminal
+state, Gitmoot enqueues exactly one coordinator "continuation" job — back to
+the delegating agent — to synthesize the children's results.
+
+Each child job carries `parent_job_id`, `delegation_id`, `root_job_id`,
+`delegation_depth`, and `task_id`, so a child can be traced to its parent, its
+originating delegation, and the root of the job tree.
+
+### Termination bounds
+
+Delegation trees are bounded so they cannot run forever:
+
+- Depth cap: `MaxDelegationDepth = 8`. Each delegation child and each
+  coordinator continuation increments `delegation_depth`; a job at or beyond
+  this depth may not delegate further.
+- Per-root job budget: `MaxDelegationTotalJobs = 64`. The whole delegation tree
+  under one root is capped at this many jobs.
+- Loop detection: a windowed signature over recent delegation activity halts
+  repeated or cyclic delegation chains (e.g. oscillating A→B→A) well before the
+  depth cap is reached.
+
+When a bound trips, the offending delegations are dropped rather than
+dispatched, and the parent receives a lifecycle/mailbox event explaining why
+(for example, "delegation tree for root <id> reached the job budget of 64").
+
+### Top-level fields
+
+- `artifact_body` (optional): the artifact payload made available to delegated
+  children. Required whenever any delegation sets `artifacts`.
+
 ## Decisions
 
 - `approved`: review found no blocking issues.
@@ -6008,7 +6441,7 @@ truthful, and tied to work that actually happened.
 - Do not claim files were changed unless they were actually changed.
 - Use `needs` for missing credentials, unclear scope, unavailable tools, failing
   external services, or required human decisions.
-- Use `delegations` only when another named Gitmoot agent should be invoked.
+- Use `delegations` when another named Gitmoot agent should be invoked.
 - Redact secrets from summaries, findings, raw command output, and examples.
 
 ---

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -18,7 +18,8 @@ workflows.
 ## References
 
 - [CLI Reference](https://gitmoot.io/docs/reference/cli): Commands for install, dashboard/TUI, agents, jobs, bug reports, locks, goals, and SkillOpt.
-- [Runtime Adapters](https://gitmoot.io/docs/reference/runtime-adapters): Codex, Claude Code, shell, and future runtimes.
+- [Runtime Adapters](https://gitmoot.io/docs/reference/runtime-adapters): Codex, Claude Code, Kimi Code, shell, and future runtimes.
+- [Result Contract](https://gitmoot.io/docs/reference/result-contract): gitmoot_result shape, the delegations DAG, continuation, and termination bounds.
 - [Codex And Claude Plugins](https://gitmoot.io/docs/plugins/codex-claude): Plugin discovery and runtime skill setup.
 - [SkillOpt Exchange Contract](https://gitmoot.io/docs/reference/skillopt-exchange-contract): Training and candidate package boundary for the external optimizer.
 - [Troubleshooting](https://gitmoot.io/docs/operations/troubleshooting): Diagnose GitHub auth, bug reports, runtimes, agent templates, remotes, permissions, and locks.


### PR DESCRIPTION
## Summary
Companion to #312. That PR updated the in-repo reference docs + Agent Skill files; this one updates the **gitmoot.io Docusaurus site** (`website/docs`), which is maintained separately and had the same gaps. Now the new sections actually reach the live site.

## Changes
- **New page `reference/result-contract.md`** (added to the Reference sidebar): `gitmoot_result` shape, the `delegations[]` DAG (deps rules, `failure_policy`/`synthesis_rule` enums, `artifacts`↔`artifact_body`, fingerprint), the coordinator continuation job, job-tree linkage fields, and a Termination bounds section (`MaxDelegationDepth=8`, `MaxDelegationTotalJobs=64`, loop detection).
- **Kimi Code runtime**: `intro`, `getting-started/install` + `quick-start`, `reference/runtime-adapters`, `reference/cli` — runtime enumerations + `agent start --runtime kimi` (with `kimi login`).
- **SkillOpt durability**: per-item persistence + idempotent resume + partial-item guard, and the optimizer-phase-only `train recover`, in `workflows/skillopt-train-workflow` and `reference/cli`.
- `concepts/agents-templates-jobs-locks` links to the new Result Contract page.
- Regenerated `static/llms-full.txt`; updated curated `static/llms.txt`.

## Verification
- `npm run build` (build:llms + docusaurus build) passes with **no broken links** — the new page, sidebar id, internal links, and the updated mermaid diagram all validate.
- Constants/enums checked against `engine.go`/`result.go`; Kimi commands against `kimi.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)