### PR TITLE
feat(tui): dashboard overhaul phase 1 — readable, grouped pages + full job request

### DIFF
--- a/internal/cli/dashboard_config.go
+++ b/internal/cli/dashboard_config.go
@@ -19,6 +19,13 @@ import (
 func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) tui.ConfigView {
 	view := tui.ConfigView{Path: paths.ConfigFile}
 
+	// Sections are appended in domain order so the page reads top-to-bottom as
+	// System (paths) → Agents (agent types) → Sessions (parallel sessions) →
+	// Feedback → Daemon. The first-row keys "paths"/"agent types"/"feedback"
+	// stay verbatim because the TUI render tests pin them; the parallel-sessions
+	// title is enriched to name its domain.
+
+	// System: filesystem paths.
 	view.Sections = append(view.Sections, tui.ConfigSection{
 		Title: "paths",
 		Rows: [][]string{
@@ -28,6 +35,7 @@ func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) 
 		},
 	})
 
+	// Agents: managed agent types.
 	if types, err := config.LoadAgentTypes(paths); err == nil && len(types) > 0 {
 		names := make([]string, 0, len(types))
 		for name := range types {
@@ -57,18 +65,32 @@ func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) 
 		view.Sections = append(view.Sections, tui.ConfigSection{Title: "agent types", Rows: rows, Editable: editable})
 	}
 
+	// Sessions: parallel-session policy. The scalar fields are inline-editable,
+	// mirroring feedback.repo / the agent timeouts; same_session and merge_back
+	// are short enums (ConfigText) and max_temp_sessions_per_agent is an int.
+	// eligible_actions is a string array: its editable Value is the bracketed
+	// TOML literal so configScalarForKind round-trips it back as a list and the
+	// re-parse in SetConfigScalar keeps accepting it.
 	if policy, err := config.LoadParallelSessionPolicy(paths); err == nil {
+		eligibleLiteral := configStringArrayLiteral(policy.EligibleActions)
 		view.Sections = append(view.Sections, tui.ConfigSection{
-			Title: "parallel sessions",
+			Title: "parallel sessions (session policy)",
 			Rows: [][]string{
 				{"same_session", policy.SameSession},
 				{"merge_back", policy.MergeBack},
 				{"max_temp_sessions_per_agent", strconv.Itoa(policy.MaxTempSessionsPerAgent)},
 				{"eligible_actions", strings.Join(policy.EligibleActions, ", ")},
 			},
+			Editable: []tui.ConfigField{
+				{Label: "parallel_sessions · same_session", KeyPath: []string{"parallel_sessions", "same_session"}, Kind: tui.ConfigText, Value: policy.SameSession},
+				{Label: "parallel_sessions · merge_back", KeyPath: []string{"parallel_sessions", "merge_back"}, Kind: tui.ConfigText, Value: policy.MergeBack},
+				{Label: "parallel_sessions · max_temp_sessions_per_agent", KeyPath: []string{"parallel_sessions", "max_temp_sessions_per_agent"}, Kind: tui.ConfigInt, Value: strconv.Itoa(policy.MaxTempSessionsPerAgent)},
+				{Label: "parallel_sessions · eligible_actions", KeyPath: []string{"parallel_sessions", "eligible_actions"}, Kind: tui.ConfigText, Value: eligibleLiteral},
+			},
 		})
 	}
 
+	// Feedback: default feedback repo.
 	if repo, err := config.LoadDefaultFeedbackRepo(paths); err == nil && strings.TrimSpace(repo) != "" {
 		view.Sections = append(view.Sections, tui.ConfigSection{
 			Title: "feedback",
@@ -79,6 +101,7 @@ func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) 
 		})
 	}
 
+	// Daemon: persisted daemon launch state.
 	daemonRows := [][]string{}
 	if len(daemon.Flags) > 0 {
 		daemonRows = append(daemonRows, []string{"flags", strings.Join(daemon.Flags, " ")})
@@ -96,13 +119,61 @@ func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) 
 // configScalarForKind types the value for the writer from the field's own
 // classification (the single source of truth), so a new int field cannot be
 // mis-written as a string. Durations and repos are stored as TOML strings.
+//
+// ConfigText covers both plain strings (repo, the session enums) and the
+// eligible_actions array. The TUI's edit overlay only carries a kind, not the
+// target's TOML shape, so a bracketed value ("[\"ask\", \"review\"]") is the
+// signal to write a string list; everything else is a plain string. None of the
+// scalar ConfigText values (owner/repo, queue/fork_temp_session, off/summary)
+// is ever bracketed, so this can't misclassify them.
 func configScalarForKind(kind tui.ConfigKind, value string) config.ConfigScalar {
 	if kind == tui.ConfigInt {
 		if n, err := strconv.Atoi(value); err == nil {
 			return config.IntScalar(n)
 		}
 	}
+	if items, ok := parseConfigStringArrayLiteral(value); ok {
+		return config.StringListScalar(items)
+	}
 	return config.StringScalar(value)
+}
+
+// configStringArrayLiteral renders a string slice as the bracketed TOML literal
+// the eligible_actions editor prefills (and round-trips back through
+// configScalarForKind). Empty slice → "[]".
+func configStringArrayLiteral(items []string) string {
+	quoted := make([]string, 0, len(items))
+	for _, item := range items {
+		quoted = append(quoted, strconv.Quote(item))
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
+
+// parseConfigStringArrayLiteral parses a bracketed, comma-separated list of
+// (optionally quoted) items, e.g. `["ask", "review"]` or `[ask, review]`. It
+// returns ok=false for any value that is not bracketed, so plain ConfigText
+// scalars fall through to a string write unchanged.
+func parseConfigStringArrayLiteral(value string) ([]string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if !strings.HasPrefix(trimmed, "[") || !strings.HasSuffix(trimmed, "]") {
+		return nil, false
+	}
+	inner := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+	if inner == "" {
+		return []string{}, true
+	}
+	items := make([]string, 0)
+	for _, part := range strings.Split(inner, ",") {
+		part = strings.TrimSpace(part)
+		if unquoted, err := strconv.Unquote(part); err == nil {
+			part = unquoted
+		}
+		part = strings.TrimSpace(part)
+		if part != "" {
+			items = append(items, part)
+		}
+	}
+	return items, true
 }
 
 func dashConfig(value string) string {

--- a/internal/cli/dashboard_config.go
+++ b/internal/cli/dashboard_config.go
@@ -67,13 +67,18 @@ func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) 
 
 	// Sessions: parallel-session policy. The scalar fields are inline-editable,
 	// mirroring feedback.repo / the agent timeouts; same_session and merge_back
-	// are short enums (ConfigText) and max_temp_sessions_per_agent is an int.
-	// eligible_actions is a string array: its editable Value is the bracketed
-	// TOML literal so configScalarForKind round-trips it back as a list and the
-	// re-parse in SetConfigScalar keeps accepting it.
+	// are short enums and max_temp_sessions_per_agent is an int. eligible_actions
+	// is a string list (ConfigStringList): its editable Value is the bracketed
+	// TOML literal so configScalarForKind round-trips it back as a list.
+	//
+	// LoadParallelSessionPolicy returns populated defaults (with a nil error) even
+	// when the file has no [parallel_sessions] section, so the read-only Rows
+	// always show the effective policy. But the inline-edit writer cannot create a
+	// missing key (section creation is reserved for the $EDITOR path), so the
+	// Editable affordance is only attached when the section actually exists —
+	// otherwise an edit would fail with a confusing "key not found".
 	if policy, err := config.LoadParallelSessionPolicy(paths); err == nil {
-		eligibleLiteral := configStringArrayLiteral(policy.EligibleActions)
-		view.Sections = append(view.Sections, tui.ConfigSection{
+		section := tui.ConfigSection{
 			Title: "parallel sessions (session policy)",
 			Rows: [][]string{
 				{"same_session", policy.SameSession},
@@ -81,13 +86,16 @@ func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) 
 				{"max_temp_sessions_per_agent", strconv.Itoa(policy.MaxTempSessionsPerAgent)},
 				{"eligible_actions", strings.Join(policy.EligibleActions, ", ")},
 			},
-			Editable: []tui.ConfigField{
-				{Label: "parallel_sessions · same_session", KeyPath: []string{"parallel_sessions", "same_session"}, Kind: tui.ConfigText, Value: policy.SameSession},
-				{Label: "parallel_sessions · merge_back", KeyPath: []string{"parallel_sessions", "merge_back"}, Kind: tui.ConfigText, Value: policy.MergeBack},
+		}
+		if configFileHasSection(paths, "parallel_sessions") {
+			section.Editable = []tui.ConfigField{
+				{Label: "parallel_sessions · same_session", KeyPath: []string{"parallel_sessions", "same_session"}, Kind: tui.ConfigText, Value: policy.SameSession, Allowed: []string{config.ParallelSessionQueue, config.ParallelSessionForkTempSession}},
+				{Label: "parallel_sessions · merge_back", KeyPath: []string{"parallel_sessions", "merge_back"}, Kind: tui.ConfigText, Value: policy.MergeBack, Allowed: []string{config.ParallelSessionMergeBackOff, config.ParallelSessionMergeBackSummary}},
 				{Label: "parallel_sessions · max_temp_sessions_per_agent", KeyPath: []string{"parallel_sessions", "max_temp_sessions_per_agent"}, Kind: tui.ConfigInt, Value: strconv.Itoa(policy.MaxTempSessionsPerAgent)},
-				{Label: "parallel_sessions · eligible_actions", KeyPath: []string{"parallel_sessions", "eligible_actions"}, Kind: tui.ConfigText, Value: eligibleLiteral},
-			},
-		})
+				{Label: "parallel_sessions · eligible_actions", KeyPath: []string{"parallel_sessions", "eligible_actions"}, Kind: tui.ConfigStringList, Value: configStringArrayLiteral(policy.EligibleActions), Allowed: []string{"ask", "review", "implement"}},
+			}
+		}
+		view.Sections = append(view.Sections, section)
 	}
 
 	// Feedback: default feedback repo.
@@ -116,26 +124,46 @@ func buildDashboardConfigView(paths config.Paths, daemon dashboardDaemonDetail) 
 	return view
 }
 
-// configScalarForKind types the value for the writer from the field's own
-// classification (the single source of truth), so a new int field cannot be
-// mis-written as a string. Durations and repos are stored as TOML strings.
-//
-// ConfigText covers both plain strings (repo, the session enums) and the
-// eligible_actions array. The TUI's edit overlay only carries a kind, not the
-// target's TOML shape, so a bracketed value ("[\"ask\", \"review\"]") is the
-// signal to write a string list; everything else is a plain string. None of the
-// scalar ConfigText values (owner/repo, queue/fork_temp_session, off/summary)
-// is ever bracketed, so this can't misclassify them.
+// configScalarForKind types the value for the writer from the field's own kind
+// (the single source of truth), so the target's TOML shape never depends on the
+// value's syntax. Only ConfigStringList writes a TOML array; ConfigText (repo,
+// the session enums) always writes a plain string even if the user typed
+// brackets, and ConfigInt writes an int. This avoids mistyping a string field as
+// an array when its value happens to look bracketed.
 func configScalarForKind(kind tui.ConfigKind, value string) config.ConfigScalar {
-	if kind == tui.ConfigInt {
+	switch kind {
+	case tui.ConfigInt:
 		if n, err := strconv.Atoi(value); err == nil {
 			return config.IntScalar(n)
 		}
-	}
-	if items, ok := parseConfigStringArrayLiteral(value); ok {
-		return config.StringListScalar(items)
+	case tui.ConfigStringList:
+		if items, ok := parseConfigStringArrayLiteral(value); ok {
+			return config.StringListScalar(items)
+		}
 	}
 	return config.StringScalar(value)
+}
+
+// configFileHasSection reports whether the config file declares the given
+// [section] header. Inline edits cannot create a missing section (that is
+// reserved for the $EDITOR path), so the Config page only offers inline edits
+// for keys whose section already exists.
+func configFileHasSection(paths config.Paths, section string) bool {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return false
+	}
+	header := "[" + section + "]"
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(raw)
+		if i := strings.IndexByte(line, '#'); i >= 0 {
+			line = strings.TrimSpace(line[:i])
+		}
+		if line == header {
+			return true
+		}
+	}
+	return false
 }
 
 // configStringArrayLiteral renders a string slice as the bracketed TOML literal

--- a/internal/cli/dashboard_config_test.go
+++ b/internal/cli/dashboard_config_test.go
@@ -28,6 +28,12 @@ max_background = 4
 idle_timeout = "10m"
 job_timeout = "45m"
 
+[parallel_sessions]
+same_session = "fork_temp_session"
+merge_back = "summary"
+max_temp_sessions_per_agent = 4
+eligible_actions = ["ask", "review", "implement"]
+
 [feedback]
 repo = "owner/feedback"
 `
@@ -54,6 +60,15 @@ func sectionByTitle(view tui.ConfigView, title string) (tui.ConfigSection, bool)
 	return tui.ConfigSection{}, false
 }
 
+func editableByLabel(section tui.ConfigSection, label string) (tui.ConfigField, bool) {
+	for _, f := range section.Editable {
+		if f.Label == label {
+			return f, true
+		}
+	}
+	return tui.ConfigField{}, false
+}
+
 func TestBuildDashboardConfigView(t *testing.T) {
 	paths := writeConfig(t, sampleConfigTOML)
 	view := buildDashboardConfigView(paths, dashboardDaemonDetail{Flags: []string{"--workers", "4"}, WorkDir: "/work"})
@@ -67,6 +82,38 @@ func TestBuildDashboardConfigView(t *testing.T) {
 	agents, ok := sectionByTitle(view, "agent types")
 	if !ok || len(agents.Rows) != 2 || agents.Rows[1][0] != "planner" {
 		t.Fatalf("agent types section wrong: %+v", agents)
+	}
+	// Sessions: the title carries its domain and the scalars are inline-editable.
+	sessions, ok := sectionByTitle(view, "parallel sessions (session policy)")
+	if !ok || len(sessions.Rows) != 4 {
+		t.Fatalf("parallel sessions section wrong: %+v", sessions)
+	}
+	wantEditable := map[string]tui.ConfigKind{
+		"parallel_sessions · same_session":                tui.ConfigText,
+		"parallel_sessions · merge_back":                  tui.ConfigText,
+		"parallel_sessions · max_temp_sessions_per_agent": tui.ConfigInt,
+		"parallel_sessions · eligible_actions":            tui.ConfigText,
+	}
+	if len(sessions.Editable) != len(wantEditable) {
+		t.Fatalf("parallel sessions editable count = %d, want %d: %+v", len(sessions.Editable), len(wantEditable), sessions.Editable)
+	}
+	for _, f := range sessions.Editable {
+		kind, ok := wantEditable[f.Label]
+		if !ok {
+			t.Fatalf("unexpected editable field %q", f.Label)
+		}
+		if f.Kind != kind {
+			t.Fatalf("editable %q kind = %v, want %v", f.Label, f.Kind, kind)
+		}
+		if len(f.KeyPath) != 2 || f.KeyPath[0] != "parallel_sessions" {
+			t.Fatalf("editable %q keypath wrong: %v", f.Label, f.KeyPath)
+		}
+	}
+	// eligible_actions prefills the bracketed TOML literal so the writer can
+	// round-trip it back to a string array.
+	eligible, _ := editableByLabel(sessions, "parallel_sessions · eligible_actions")
+	if eligible.Value != `["ask", "review", "implement"]` {
+		t.Fatalf("eligible_actions value = %q", eligible.Value)
 	}
 	feedback, ok := sectionByTitle(view, "feedback")
 	if !ok || feedback.Rows[0][1] != "owner/feedback" {
@@ -114,6 +161,10 @@ func TestConfigScalarForKind(t *testing.T) {
 	intVal := configScalarForKind(tui.ConfigInt, "8")
 	strVal := configScalarForKind(tui.ConfigDuration, "15m")
 	repoVal := configScalarForKind(tui.ConfigText, "owner/x")
+	// A bracketed ConfigText value is written as a TOML string array, while a
+	// plain ConfigText scalar (the session enums) stays a string.
+	listVal := configScalarForKind(tui.ConfigText, `["ask", "review"]`)
+	sessionVal := configScalarForKind(tui.ConfigText, "queue")
 	// Apply each to a fixture and confirm the stored TOML type round-trips.
 	paths := writeConfig(t, sampleConfigTOML)
 	if err := config.SetConfigScalar(paths, []string{"agents", "planner", "max_background"}, intVal); err != nil {
@@ -125,11 +176,50 @@ func TestConfigScalarForKind(t *testing.T) {
 	if err := config.SetConfigScalar(paths, []string{"feedback", "repo"}, repoVal); err != nil {
 		t.Fatalf("repo write: %v", err)
 	}
+	if err := config.SetConfigScalar(paths, []string{"parallel_sessions", "eligible_actions"}, listVal); err != nil {
+		t.Fatalf("eligible_actions list write: %v", err)
+	}
+	if err := config.SetConfigScalar(paths, []string{"parallel_sessions", "same_session"}, sessionVal); err != nil {
+		t.Fatalf("same_session write: %v", err)
+	}
 	types, err := config.LoadAgentTypes(paths)
 	if err != nil {
 		t.Fatalf("reload: %v", err)
 	}
 	if types["planner"].MaxBackground != 8 || types["planner"].IdleTimeout != "15m" {
 		t.Fatalf("typed writes wrong: %+v", types["planner"])
+	}
+	policy, err := config.LoadParallelSessionPolicy(paths)
+	if err != nil {
+		t.Fatalf("reload policy: %v", err)
+	}
+	if strings.Join(policy.EligibleActions, ",") != "ask,review" {
+		t.Fatalf("eligible_actions list round-trip wrong: %+v", policy.EligibleActions)
+	}
+	if policy.SameSession != "queue" {
+		t.Fatalf("same_session scalar round-trip wrong: %q", policy.SameSession)
+	}
+}
+
+func TestParseConfigStringArrayLiteral(t *testing.T) {
+	cases := []struct {
+		in    string
+		items []string
+		ok    bool
+	}{
+		{`["ask", "review", "implement"]`, []string{"ask", "review", "implement"}, true},
+		{`[ask, review]`, []string{"ask", "review"}, true},
+		{`[]`, []string{}, true},
+		{"queue", nil, false},
+		{"owner/repo", nil, false},
+	}
+	for _, tc := range cases {
+		items, ok := parseConfigStringArrayLiteral(tc.in)
+		if ok != tc.ok {
+			t.Fatalf("%q: ok = %v, want %v", tc.in, ok, tc.ok)
+		}
+		if ok && strings.Join(items, ",") != strings.Join(tc.items, ",") {
+			t.Fatalf("%q: items = %v, want %v", tc.in, items, tc.items)
+		}
 	}
 }

--- a/internal/cli/dashboard_config_test.go
+++ b/internal/cli/dashboard_config_test.go
@@ -92,7 +92,7 @@ func TestBuildDashboardConfigView(t *testing.T) {
 		"parallel_sessions · same_session":                tui.ConfigText,
 		"parallel_sessions · merge_back":                  tui.ConfigText,
 		"parallel_sessions · max_temp_sessions_per_agent": tui.ConfigInt,
-		"parallel_sessions · eligible_actions":            tui.ConfigText,
+		"parallel_sessions · eligible_actions":            tui.ConfigStringList,
 	}
 	if len(sessions.Editable) != len(wantEditable) {
 		t.Fatalf("parallel sessions editable count = %d, want %d: %+v", len(sessions.Editable), len(wantEditable), sessions.Editable)
@@ -161,10 +161,16 @@ func TestConfigScalarForKind(t *testing.T) {
 	intVal := configScalarForKind(tui.ConfigInt, "8")
 	strVal := configScalarForKind(tui.ConfigDuration, "15m")
 	repoVal := configScalarForKind(tui.ConfigText, "owner/x")
-	// A bracketed ConfigText value is written as a TOML string array, while a
-	// plain ConfigText scalar (the session enums) stays a string.
-	listVal := configScalarForKind(tui.ConfigText, `["ask", "review"]`)
+	// A ConfigStringList value is written as a TOML string array; a ConfigText
+	// scalar (the session enums) stays a string.
+	listVal := configScalarForKind(tui.ConfigStringList, `["ask", "review"]`)
 	sessionVal := configScalarForKind(tui.ConfigText, "queue")
+	// Finding-10 guard: a ConfigText value that happens to look bracketed must
+	// still be written as a string, not silently promoted to an array.
+	bracketedText := configScalarForKind(tui.ConfigText, `["x"]`)
+	if err := config.SetConfigScalar(writeConfig(t, sampleConfigTOML), []string{"feedback", "repo"}, bracketedText); err != nil {
+		t.Fatalf("bracketed ConfigText should write as a string, got: %v", err)
+	}
 	// Apply each to a fixture and confirm the stored TOML type round-trips.
 	paths := writeConfig(t, sampleConfigTOML)
 	if err := config.SetConfigScalar(paths, []string{"agents", "planner", "max_background"}, intVal); err != nil {

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -549,15 +549,28 @@ func (m Model) agentsContentInteractive() string {
 		return b.String()
 	}
 	var b strings.Builder
-	rows := [][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH"}}
-	for i, a := range visible {
-		cursor, name := "  ", a.Name
-		if i == m.agentCursor {
-			cursor, name = "▸ ", selectedRowStyle.Render(a.Name)
+	// Group the visible agents by template for display only. The cursor still
+	// indexes visibleAgents() in its original order (agentUnderCursor and the
+	// shared pageCursor movement both rely on that), so each agent carries its
+	// original visible index and the cursor highlight is matched against that —
+	// regrouping the rows never shifts which agent the cursor selects.
+	for gi, g := range groupAgentsByTemplate(visible) {
+		if gi > 0 {
+			b.WriteByte('\n')
 		}
-		rows = append(rows, []string{cursor, name, a.Runtime, dash(a.Role), dash(a.Health)})
+		b.WriteString(headerStyle.Render(agentGroupLabel(g.templateID)))
+		b.WriteByte('\n')
+		rows := [][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH"}}
+		for _, it := range g.agents {
+			a := it.agent
+			cursor, name := "  ", a.Name
+			if it.index == m.agentCursor {
+				cursor, name = "▸ ", selectedRowStyle.Render(a.Name)
+			}
+			rows = append(rows, []string{cursor, name, a.Runtime, dash(a.Role), dash(a.Health)})
+		}
+		b.WriteString(renderRows(rows))
 	}
-	b.WriteString(renderRows(rows))
 	if m.agentErr != "" {
 		b.WriteString("\n" + errorStyle.Render(m.agentErr) + "\n")
 	}
@@ -571,6 +584,48 @@ func (m Model) agentsContentInteractive() string {
 	b.WriteString(mutedStyle.Render("enter detail  n new  o optimize  D delete"))
 	b.WriteByte('\n')
 	return b.String()
+}
+
+// agentGroupLabel is the section header for a template group; agents without a
+// template share the "(no template)" group.
+func agentGroupLabel(templateID string) string {
+	if strings.TrimSpace(templateID) == "" {
+		return "(no template)"
+	}
+	return templateID
+}
+
+// indexedAgent pairs a visible agent with its index in visibleAgents(), so the
+// grouped display can still match the (unreordered) agentCursor.
+type indexedAgent struct {
+	index int
+	agent Agent
+}
+
+// agentGroup is a template's agents in their original visible order.
+type agentGroup struct {
+	templateID string
+	agents     []indexedAgent
+}
+
+// groupAgentsByTemplate buckets visible agents by TemplateID for display.
+// Groups appear in first-appearance order and agents keep their visible order
+// within each group, so the flat selectable ordering is preserved — only the
+// rendering is regrouped. Each agent carries its original visible index for the
+// cursor match.
+func groupAgentsByTemplate(visible []Agent) []agentGroup {
+	groups := []agentGroup{}
+	at := map[string]int{} // templateID → index into groups
+	for i, a := range visible {
+		pos, ok := at[a.TemplateID]
+		if !ok {
+			pos = len(groups)
+			at[a.TemplateID] = pos
+			groups = append(groups, agentGroup{templateID: a.TemplateID})
+		}
+		groups[pos].agents = append(groups[pos].agents, indexedAgent{index: i, agent: a})
+	}
+	return groups
 }
 
 func (m Model) agentDetailView() string {

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -14,13 +14,27 @@ import (
 // template. The leading sentinel form keeps it from colliding with a real id.
 const agentCustomPromptValue = "__custom_prompt__"
 
-// agentUnderCursor returns the agent under the Agents cursor, if any.
+// agentUnderCursor returns the agent under the Agents cursor, if any. The cursor
+// indexes the display-ordered list (orderedAgents, grouped by template), so it
+// resolves to the row the user sees highlighted even when templates interleave.
 func (m Model) agentUnderCursor() (Agent, bool) {
-	visible := m.visibleAgents()
-	if pages[m.selected].page != pageAgents || m.agentCursor < 0 || m.agentCursor >= len(visible) {
+	ordered := m.orderedAgents()
+	if pages[m.selected].page != pageAgents || m.agentCursor < 0 || m.agentCursor >= len(ordered) {
 		return Agent{}, false
 	}
-	return visible[m.agentCursor], true
+	return ordered[m.agentCursor], true
+}
+
+// orderedAgents is the flat, display-ordered list of visible agents — the exact
+// top-to-bottom order rows render in (grouped by template, groups in
+// first-appearance order). The Agents cursor indexes into THIS slice so ↑/↓ steps
+// through the visible list in order.
+func (m Model) orderedAgents() []Agent {
+	var out []Agent
+	for _, g := range groupAgentsByTemplate(m.visibleAgents()) {
+		out = append(out, g.agents...)
+	}
+	return out
 }
 
 // isManagedTrainingAgent reports whether an agent name is internal skillopt
@@ -549,25 +563,24 @@ func (m Model) agentsContentInteractive() string {
 		return b.String()
 	}
 	var b strings.Builder
-	// Group the visible agents by template for display only. The cursor still
-	// indexes visibleAgents() in its original order (agentUnderCursor and the
-	// shared pageCursor movement both rely on that), so each agent carries its
-	// original visible index and the cursor highlight is matched against that —
-	// regrouping the rows never shifts which agent the cursor selects.
-	for gi, g := range groupAgentsByTemplate(visible) {
-		if gi > 0 {
-			b.WriteByte('\n')
-		}
+	// Render the visible agents grouped by template. The cursor indexes the
+	// display order (orderedAgents), so pos advances per agent row in lockstep
+	// and the highlight matches the visible position. The column header prints
+	// once at the top; template labels are display-only and consume no position.
+	b.WriteString(renderRows([][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH"}}))
+	pos := 0
+	for _, g := range groupAgentsByTemplate(visible) {
+		b.WriteByte('\n')
 		b.WriteString(headerStyle.Render(agentGroupLabel(g.templateID)))
 		b.WriteByte('\n')
-		rows := [][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH"}}
-		for _, it := range g.agents {
-			a := it.agent
+		rows := [][]string{}
+		for _, a := range g.agents {
 			cursor, name := "  ", a.Name
-			if it.index == m.agentCursor {
+			if pos == m.agentCursor {
 				cursor, name = "▸ ", selectedRowStyle.Render(a.Name)
 			}
 			rows = append(rows, []string{cursor, name, a.Runtime, dash(a.Role), dash(a.Health)})
+			pos++
 		}
 		b.WriteString(renderRows(rows))
 	}
@@ -595,35 +608,27 @@ func agentGroupLabel(templateID string) string {
 	return templateID
 }
 
-// indexedAgent pairs a visible agent with its index in visibleAgents(), so the
-// grouped display can still match the (unreordered) agentCursor.
-type indexedAgent struct {
-	index int
-	agent Agent
-}
-
 // agentGroup is a template's agents in their original visible order.
 type agentGroup struct {
 	templateID string
-	agents     []indexedAgent
+	agents     []Agent
 }
 
-// groupAgentsByTemplate buckets visible agents by TemplateID for display.
-// Groups appear in first-appearance order and agents keep their visible order
-// within each group, so the flat selectable ordering is preserved — only the
-// rendering is regrouped. Each agent carries its original visible index for the
-// cursor match.
+// groupAgentsByTemplate buckets visible agents by TemplateID for display. Groups
+// appear in first-appearance order and agents keep their visible order within
+// each group. orderedAgents flattens these groups to define the cursor's index
+// space, so the display order and the selectable order are one and the same.
 func groupAgentsByTemplate(visible []Agent) []agentGroup {
 	groups := []agentGroup{}
 	at := map[string]int{} // templateID → index into groups
-	for i, a := range visible {
+	for _, a := range visible {
 		pos, ok := at[a.TemplateID]
 		if !ok {
 			pos = len(groups)
 			at[a.TemplateID] = pos
 			groups = append(groups, agentGroup{templateID: a.TemplateID})
 		}
-		groups[pos].agents = append(groups[pos].agents, indexedAgent{index: i, agent: a})
+		groups[pos].agents = append(groups[pos].agents, a)
 	}
 	return groups
 }

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -52,14 +52,20 @@ func TestAgentsPageHidesTrainingAgents(t *testing.T) {
 	deps := Deps{}
 	m := agentsModel(t, deps, snap)
 	view := m.View()
-	// Real agents shown, training plumbing hidden + a count line.
-	for _, want := range []string{"planner", "reviewer", "3 training agents hidden"} {
+	// Real agents shown under their template-group headers, training plumbing
+	// hidden + a count line.
+	for _, want := range []string{"planner", "reviewer", "planner-tpl", "reviewer-tpl", "3 training agents hidden"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("agents view missing %q:\n%s", want, view)
 		}
 	}
 	if strings.Contains(view, "skillopt-target-") || strings.Contains(view, "skillopt-generator-bg") {
 		t.Fatalf("training agents must be hidden:\n%s", view)
+	}
+	// The hidden training agents have empty TemplateID, but they are filtered
+	// before grouping, so they must not surface a "(no template)" header.
+	if strings.Contains(view, "(no template)") {
+		t.Fatalf("hidden agents must not introduce a (no template) group:\n%s", view)
 	}
 	// The cursor + enter act on the VISIBLE list (planner is first visible).
 	if a, ok := m.agentUnderCursor(); !ok || a.Name != "planner" {
@@ -70,6 +76,49 @@ func TestAgentsPageHidesTrainingAgents(t *testing.T) {
 	m = next.(Model)
 	if a, _ := m.agentUnderCursor(); a.Name != "reviewer" {
 		t.Fatalf("down should move to the next visible agent, got %q", a.Name)
+	}
+}
+
+func TestAgentsPageGroupsByTemplate(t *testing.T) {
+	snap := agentsSnapshot()
+	// A second agent on planner-tpl (stays in the planner-tpl group) and one
+	// with no template (its own "(no template)" group).
+	snap.Agents = append(snap.Agents,
+		Agent{Name: "scout", Runtime: "claude", TemplateID: "planner-tpl"},
+		Agent{Name: "drifter", Runtime: "codex"},
+	)
+	m := agentsModel(t, Deps{}, snap)
+	view := m.View()
+	// Both template headers and the no-template header render.
+	for _, want := range []string{"planner-tpl", "reviewer-tpl", "(no template)"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("grouped view missing header %q:\n%s", want, view)
+		}
+	}
+	// Headers appear in first-appearance order: planner-tpl, then reviewer-tpl,
+	// then the (no template) group last.
+	pIdx := strings.Index(view, "planner-tpl")
+	rIdx := strings.Index(view, "reviewer-tpl")
+	nIdx := strings.Index(view, "(no template)")
+	if !(pIdx < rIdx && rIdx < nIdx) {
+		t.Fatalf("group headers out of order (planner=%d reviewer=%d none=%d):\n%s", pIdx, rIdx, nIdx, view)
+	}
+	// The (no template) header precedes its sole member.
+	if nIdx > strings.Index(view, "drifter") {
+		t.Fatalf("the (no template) header should precede its agent:\n%s", view)
+	}
+	// Cursor still indexes the flat visible order: planner, reviewer, scout,
+	// drifter. Grouping is display-only and must not reorder selection.
+	wants := []string{"planner", "reviewer", "scout", "drifter"}
+	for i, want := range wants {
+		a, ok := m.agentUnderCursor()
+		if !ok || a.Name != want {
+			t.Fatalf("cursor %d should select %q, got %q ok=%v", i, want, a.Name, ok)
+		}
+		if i < len(wants)-1 {
+			next, _ := m.Update(key("j"))
+			m = next.(Model)
+		}
 	}
 }
 

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -107,9 +107,10 @@ func TestAgentsPageGroupsByTemplate(t *testing.T) {
 	if nIdx > strings.Index(view, "drifter") {
 		t.Fatalf("the (no template) header should precede its agent:\n%s", view)
 	}
-	// Cursor still indexes the flat visible order: planner, reviewer, scout,
-	// drifter. Grouping is display-only and must not reorder selection.
-	wants := []string{"planner", "reviewer", "scout", "drifter"}
+	// Cursor follows the on-screen (grouped) order, so ↑/↓ step through rows in
+	// the order they render: the planner-tpl group (planner, scout) first, then
+	// reviewer-tpl (reviewer), then the (no template) group (drifter).
+	wants := []string{"planner", "scout", "reviewer", "drifter"}
 	for i, want := range wants {
 		a, ok := m.agentUnderCursor()
 		if !ok || a.Name != want {

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -178,8 +179,13 @@ func answerCmd(deps Deps, id, value string) tea.Cmd {
 	}
 }
 
-// attentionContent renders the Attention page: pending prompts (selectable),
-// then blocked/failed/cancelled jobs, stale resource locks, and branch locks.
+// attentionContent renders the Attention page. The daemon-down and
+// required-health-failed banners are pinned at the top, then the actionable
+// items are grouped under display-only section headers — "Prompts" (selectable),
+// "Blocked & failed jobs" (selectable) — followed by "Stale locks" and
+// "Branch locks". Section headers carry no cursor index: the selectable items
+// (prompts then reportable jobs) keep the exact flat ordering and indices of
+// attentionItems(), which m.promptCursor indexes into.
 func (m Model) attentionContent() string {
 	switch m.mode {
 	case modeAnswerChoice, modeAnswerText:
@@ -210,31 +216,62 @@ func (m Model) attentionContent() string {
 		wrote = true
 	}
 
+	// items is the flat, ordered selectable slice (prompts first, then
+	// reportable jobs). i is the global cursor index for every selectable row;
+	// section headers are display-only and never advance it.
 	items := m.attentionItems()
-	b.WriteString(headerStyle.Render("needs attention"))
-	b.WriteByte('\n')
+	renderRow := func(i int, item attnItem) {
+		cursor := "  "
+		var line string
+		switch {
+		case item.prompt != nil:
+			line = "prompt " + item.prompt.ID + "  " + truncate(item.prompt.Question, 56)
+		case item.job != nil:
+			line = "job " + item.job.ID + "  " + item.job.Type + "  " + jobStateColor(item.job.State)
+			if item.job.LatestEvent != "" {
+				line += "  " + mutedStyle.Render(truncate(item.job.LatestEvent, 48))
+			}
+		}
+		if i == m.promptCursor {
+			cursor = "▸ "
+			line = selectedRowStyle.Render("• ") + line
+		}
+		b.WriteString(cursor + line + "\n")
+	}
+
+	wrotePrompts := false
+	for i, item := range items {
+		if item.prompt == nil {
+			continue
+		}
+		if !wrotePrompts {
+			b.WriteString(headerStyle.Render("Prompts ("+strconv.Itoa(countPrompts(items))+")") + "\n")
+			wrotePrompts = true
+		}
+		renderRow(i, item)
+	}
+
+	wroteJobs := false
+	for i, item := range items {
+		if item.job == nil {
+			continue
+		}
+		if !wroteJobs {
+			if wrotePrompts {
+				b.WriteByte('\n')
+			}
+			b.WriteString(redStyle.Render("Blocked & failed jobs ("+strconv.Itoa(len(items)-countPrompts(items))+")") + "\n")
+			wroteJobs = true
+		}
+		renderRow(i, item)
+	}
+
 	if len(items) == 0 {
+		b.WriteString(headerStyle.Render("needs attention"))
+		b.WriteByte('\n')
 		b.WriteString(mutedStyle.Render("none"))
 		b.WriteByte('\n')
 	} else {
-		for i, item := range items {
-			cursor := "  "
-			var line string
-			switch {
-			case item.prompt != nil:
-				line = "prompt " + item.prompt.ID + "  " + truncate(item.prompt.Question, 56)
-			case item.job != nil:
-				line = "job " + item.job.ID + "  " + item.job.Type + "  " + jobStateColor(item.job.State)
-				if item.job.LatestEvent != "" {
-					line += "  " + mutedStyle.Render(truncate(item.job.LatestEvent, 48))
-				}
-			}
-			if i == m.promptCursor {
-				cursor = "▸ "
-				line = selectedRowStyle.Render("• ") + line
-			}
-			b.WriteString(cursor + line + "\n")
-		}
 		// Attention only lists reportable terminal jobs, so cancel never applies here.
 		help := "prompts: a answer · d dismiss   jobs: enter detail · R retry"
 		if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
@@ -252,7 +289,7 @@ func (m Model) attentionContent() string {
 	stale := staleLocks(m.snap.ResourceLocks)
 	if len(stale) > 0 {
 		b.WriteString("\n")
-		b.WriteString(headerStyle.Render("stale locks"))
+		b.WriteString(redStyle.Render("Stale locks (" + strconv.Itoa(len(stale)) + ")"))
 		b.WriteByte('\n')
 		for _, l := range stale {
 			b.WriteString(redStyle.Render(l.Key))
@@ -263,7 +300,7 @@ func (m Model) attentionContent() string {
 
 	if len(m.snap.BranchLocks) > 0 {
 		b.WriteString("\n")
-		b.WriteString(headerStyle.Render("branch locks"))
+		b.WriteString(headerStyle.Render("Branch locks (" + strconv.Itoa(len(m.snap.BranchLocks)) + ")"))
 		b.WriteByte('\n')
 		for _, l := range m.snap.BranchLocks {
 			b.WriteString(l.Repo + " " + l.Branch + " (" + dash(l.Owner) + ")")
@@ -276,6 +313,17 @@ func (m Model) attentionContent() string {
 		return "Nothing needs attention."
 	}
 	return b.String()
+}
+
+// countPrompts returns how many leading selectable rows are prompts.
+func countPrompts(items []attnItem) int {
+	n := 0
+	for _, item := range items {
+		if item.prompt != nil {
+			n++
+		}
+	}
+	return n
 }
 
 func (m Model) answerOverlay() string {

--- a/internal/cli/tui/attention_test.go
+++ b/internal/cli/tui/attention_test.go
@@ -170,6 +170,112 @@ func TestAnswerDoubleSubmitSuppressed(t *testing.T) {
 	}
 }
 
+func TestAttentionGroupsUnderSectionHeaders(t *testing.T) {
+	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
+	snap := Snapshot{
+		Daemon:  Daemon{Running: true},
+		Prompts: []db.InteractivePrompt{choicePrompt(), textPrompt()},
+		JobRows: []JobRow{
+			{ID: "j1", Type: "review", State: "failed", LatestEvent: "boom went wrong"},
+			{ID: "j2", Type: "merge", State: "succeeded"}, // not reportable, must be skipped
+			{ID: "j3", Type: "build", State: "blocked", LatestEvent: "stuck on dep"},
+		},
+		ResourceLocks: []ResourceLock{
+			{Key: "skillopt-train:abc", Stale: true},
+			{Key: "live-lock", Stale: false},
+		},
+		BranchLocks: []BranchLock{{Repo: "gitmoot", Branch: "main", Owner: "alice"}},
+	}
+	m := attentionModel(t, deps, snap)
+	view := m.View()
+
+	// Section headers carry the count of items in that section.
+	if !strings.Contains(view, "Prompts (2)") {
+		t.Fatalf("expected Prompts (2) header:\n%s", view)
+	}
+	if !strings.Contains(view, "Blocked & failed jobs (2)") {
+		t.Fatalf("expected Blocked & failed jobs (2) header (succeeded job excluded):\n%s", view)
+	}
+	if !strings.Contains(view, "Stale locks (1)") {
+		t.Fatalf("expected Stale locks (1) header:\n%s", view)
+	}
+	if !strings.Contains(view, "Branch locks (1)") {
+		t.Fatalf("expected Branch locks (1) header:\n%s", view)
+	}
+
+	// The reportable jobs' LatestEvent is shown as the one-line 'why'.
+	if !strings.Contains(view, "boom went wrong") {
+		t.Fatalf("expected failed job's LatestEvent in view:\n%s", view)
+	}
+
+	// The succeeded job must not be listed, and the non-stale lock must not
+	// appear under Stale locks.
+	if strings.Contains(view, "j2") {
+		t.Fatalf("succeeded job j2 should not be listed:\n%s", view)
+	}
+	if strings.Contains(view, "live-lock") {
+		t.Fatalf("non-stale lock should not appear:\n%s", view)
+	}
+
+	// Sections render in order: Prompts, then jobs, then stale locks, then
+	// branch locks.
+	pi := strings.Index(view, "Prompts (2)")
+	ji := strings.Index(view, "Blocked & failed jobs (2)")
+	si := strings.Index(view, "Stale locks (1)")
+	bi := strings.Index(view, "Branch locks (1)")
+	if !(pi < ji && ji < si && si < bi) {
+		t.Fatalf("sections out of order: prompts=%d jobs=%d stale=%d branch=%d\n%s", pi, ji, si, bi, view)
+	}
+}
+
+func TestAttentionHeadersDoNotShiftCursor(t *testing.T) {
+	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
+	snap := Snapshot{
+		Daemon:  Daemon{Running: true},
+		Prompts: []db.InteractivePrompt{choicePrompt(), textPrompt()},
+		JobRows: []JobRow{{ID: "j1", Type: "review", State: "failed"}},
+	}
+	m := attentionModel(t, deps, snap)
+
+	// Cursor starts on the first prompt (index 0); 'a' answers it.
+	if _, ok := m.attentionPrompt(); !ok {
+		t.Fatalf("cursor 0 should select the first prompt")
+	}
+
+	// Move down twice: index 1 is the second prompt, index 2 is the failed job.
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	if m.promptCursor != 2 {
+		t.Fatalf("cursor should be at the job (index 2), got %d", m.promptCursor)
+	}
+	job, ok := m.jobUnderCursor()
+	if !ok || job.ID != "j1" {
+		t.Fatalf("section headers must not shift cursor; expected job j1 under cursor, got ok=%v job=%+v", ok, job)
+	}
+	if _, ok := m.attentionPrompt(); ok {
+		t.Fatalf("a job row must not resolve to a prompt")
+	}
+}
+
+func TestAttentionLocksOnlyNoNeedsAttentionItems(t *testing.T) {
+	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
+	snap := Snapshot{
+		Daemon:        Daemon{Running: true},
+		ResourceLocks: []ResourceLock{{Key: "skillopt-train:abc", Stale: true}},
+	}
+	m := attentionModel(t, deps, snap)
+	view := m.View()
+	if !strings.Contains(view, "Stale locks (1)") {
+		t.Fatalf("expected Stale locks (1) header:\n%s", view)
+	}
+	// With no prompts or jobs, the "none" placeholder is shown.
+	if !strings.Contains(view, "none") {
+		t.Fatalf("expected 'none' placeholder when no prompts/jobs:\n%s", view)
+	}
+}
+
 func TestAttentionCursorClampedOnRefresh(t *testing.T) {
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	m := attentionModel(t, deps, promptSnap(choicePrompt(), textPrompt()))

--- a/internal/cli/tui/config.go
+++ b/internal/cli/tui/config.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -47,7 +48,7 @@ func (m Model) updateConfigOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		value := strings.TrimSpace(m.input.Value())
-		if problem := validateConfigValue(m.configField.Kind, value); problem != "" {
+		if problem := validateConfigValue(m.configField, value); problem != "" {
 			m.configActionErr = problem
 			m.viewport.SetContent(m.content())
 			return m, nil
@@ -63,10 +64,11 @@ func (m Model) updateConfigOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-// validateConfigValue checks a value's shape before the write attempt, so a
-// typo re-asks in the overlay instead of round-tripping through the writer.
-func validateConfigValue(kind ConfigKind, value string) string {
-	switch kind {
+// validateConfigValue checks a value's shape (and closed-set membership) before
+// the write attempt, so a typo re-asks in the overlay instead of round-tripping
+// through the writer and reverting with a generic error.
+func validateConfigValue(field ConfigField, value string) string {
+	switch field.Kind {
 	case ConfigInt:
 		if n, err := strconv.Atoi(value); err != nil || n < 1 {
 			return "must be an integer ≥ 1"
@@ -76,12 +78,51 @@ func validateConfigValue(kind ConfigKind, value string) string {
 		if err != nil || d <= 0 {
 			return "must be a positive duration like 10m or 45m"
 		}
+	case ConfigStringList:
+		items, ok := parseConfigListLiteral(value)
+		if !ok {
+			return `must be a list like ["ask", "review"]`
+		}
+		if len(items) == 0 {
+			return "value is required"
+		}
+		for _, it := range items {
+			if it == "" {
+				return "list items cannot be empty"
+			}
+			if len(field.Allowed) > 0 && !slices.Contains(field.Allowed, it) {
+				return "allowed: " + strings.Join(field.Allowed, ", ")
+			}
+		}
 	case ConfigText:
 		if value == "" {
 			return "value is required"
 		}
+		if len(field.Allowed) > 0 && !slices.Contains(field.Allowed, value) {
+			return "allowed: " + strings.Join(field.Allowed, ", ")
+		}
 	}
 	return ""
+}
+
+// parseConfigListLiteral parses a bracketed TOML-ish list literal into its
+// trimmed, unquoted tokens. It is the validation-side counterpart of the
+// writer's parser; the empty list "[]" parses to an empty slice.
+func parseConfigListLiteral(value string) ([]string, bool) {
+	s := strings.TrimSpace(value)
+	if !strings.HasPrefix(s, "[") || !strings.HasSuffix(s, "]") {
+		return nil, false
+	}
+	inner := strings.TrimSpace(s[1 : len(s)-1])
+	if inner == "" {
+		return []string{}, true
+	}
+	parts := strings.Split(inner, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, strings.TrimSpace(strings.Trim(strings.TrimSpace(p), `"'`)))
+	}
+	return out, true
 }
 
 func configWriteCmd(deps Deps, keyPath []string, value string, kind ConfigKind) tea.Cmd {

--- a/internal/cli/tui/config_test.go
+++ b/internal/cli/tui/config_test.go
@@ -229,13 +229,33 @@ func TestConfigInlineEditWriteErrorKeepsOverlay(t *testing.T) {
 }
 
 func TestConfigDurationFieldValidation(t *testing.T) {
-	if validateConfigValue(ConfigDuration, "10m") != "" {
+	if validateConfigValue(ConfigField{Kind: ConfigDuration}, "10m") != "" {
 		t.Fatal("10m should be a valid duration")
 	}
-	if validateConfigValue(ConfigDuration, "nope") == "" {
+	if validateConfigValue(ConfigField{Kind: ConfigDuration}, "nope") == "" {
 		t.Fatal("nope should be rejected as a duration")
 	}
-	if validateConfigValue(ConfigInt, "0") == "" {
+	if validateConfigValue(ConfigField{Kind: ConfigInt}, "0") == "" {
 		t.Fatal("0 should be rejected (must be >= 1)")
+	}
+}
+
+func TestConfigEnumAndListValidation(t *testing.T) {
+	enum := ConfigField{Kind: ConfigText, Allowed: []string{"queue", "fork_temp_session"}}
+	if validateConfigValue(enum, "queue") != "" {
+		t.Fatal("queue should be allowed")
+	}
+	if validateConfigValue(enum, "nonsense") == "" {
+		t.Fatal("a value outside the allowed set should be rejected")
+	}
+	list := ConfigField{Kind: ConfigStringList, Allowed: []string{"ask", "review", "implement"}}
+	if validateConfigValue(list, `["ask", "review"]`) != "" {
+		t.Fatal("a list of allowed actions should pass")
+	}
+	if validateConfigValue(list, `["ask", "deploy"]`) == "" {
+		t.Fatal("a list with a disallowed action should be rejected")
+	}
+	if validateConfigValue(list, "ask, review") == "" {
+		t.Fatal("a non-bracketed value should be rejected for a list field")
 	}
 }

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -69,9 +69,10 @@ type ConfigSection struct {
 type ConfigKind int
 
 const (
-	ConfigText     ConfigKind = iota // free text (e.g. owner/repo, checked by Validate)
-	ConfigInt                        // integer ≥ 1
-	ConfigDuration                   // Go duration string (10m, 45m)
+	ConfigText       ConfigKind = iota // free text (e.g. owner/repo, checked by Validate)
+	ConfigInt                          // integer ≥ 1
+	ConfigDuration                     // Go duration string (10m, 45m)
+	ConfigStringList                   // bracketed list literal, e.g. ["ask", "review"]
 )
 
 // ConfigField is one inline-editable scalar on the Config page.
@@ -80,6 +81,11 @@ type ConfigField struct {
 	KeyPath []string   // full dotted path for the writer, e.g. {agents, planner, max_background}
 	Kind    ConfigKind //
 	Value   string     // current value (prefilled in the editor)
+	// Allowed, when non-empty, is the closed set of permitted tokens. For
+	// ConfigText the whole value must be one of them; for ConfigStringList every
+	// list item must be. Validated inline so a bad value re-asks in the overlay
+	// instead of writing then reverting.
+	Allowed []string
 }
 
 // ConfigEditedMsg is delivered when the external editor (Deps.EditConfig) exits.

--- a/internal/cli/tui/dismiss_train_test.go
+++ b/internal/cli/tui/dismiss_train_test.go
@@ -183,3 +183,126 @@ func TestTrainCursorClampedOnRefresh(t *testing.T) {
 		t.Fatalf("train cursor should clamp to 0, got %d", m.trainCursor)
 	}
 }
+
+func TestTrainStatusCategory(t *testing.T) {
+	cases := map[string]int{
+		"request_confirmed":                trainCatActive,
+		"items_ready":                      trainCatActive,
+		"optimizer_completed":              trainCatActive,
+		"generating_options":               trainCatActive,
+		"optimizer_running":                trainCatActive,
+		"preflight_running":                trainCatActive,
+		"recovery_available":               trainCatActive,
+		"blocked_stale_lock":               trainCatBlocked,
+		"failed_unrecoverable":             trainCatBlocked,
+		"blocked_config":                   trainCatBlocked,
+		"optimizer_heartbeat_stale":        trainCatBlocked,
+		"candidate_promoted":               trainCatDone,
+		"candidate_rejected":               trainCatDone,
+		"run_abandoned":                    trainCatDone,
+		"optimizer_completed_no_candidate": trainCatDone,
+	}
+	for phase, want := range cases {
+		if got := trainStatusCategory(phase); got != want {
+			t.Errorf("trainStatusCategory(%q) = %d, want %d", phase, got, want)
+		}
+	}
+}
+
+func TestTrainLineageBase(t *testing.T) {
+	cases := []struct {
+		id       string
+		wantBase string
+		wantHas  bool
+	}{
+		{"officeqa-treasury-skillopt-v1", "officeqa-treasury-skillopt", true},
+		{"officeqa-treasury-skillopt-v8", "officeqa-treasury-skillopt", true},
+		{"run-12", "run", true},
+		{"plain-name", "plain-name", false},
+		{"train-aaa", "train-aaa", false},
+	}
+	for _, c := range cases {
+		base, has := trainLineageBase(c.id)
+		if base != c.wantBase || has != c.wantHas {
+			t.Errorf("trainLineageBase(%q) = (%q,%v), want (%q,%v)", c.id, base, has, c.wantBase, c.wantHas)
+		}
+	}
+}
+
+// TestTrainsListGroupsAndCollapses renders a mixed list and asserts the section
+// headers, the collapsed lineage parent line, and that flat sessions stay flat.
+func TestTrainsListGroupsAndCollapses(t *testing.T) {
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		Trains: []TrainSession{
+			{ID: "skillopt-v1", Phase: "items_ready", Repo: "o/r"},      // 0 Active, lineage
+			{ID: "lonely", Phase: "generating_options", Repo: "o/r"},    // 1 Active, flat
+			{ID: "skillopt-v2", Phase: "review_published", Repo: "o/r"}, // 2 Active, lineage
+			{ID: "stalled", Phase: "blocked_stale_lock", Repo: "o/r"},   // 3 Blocked
+			{ID: "gone", Phase: "run_abandoned", Repo: "o/r"},           // 4 Done
+		},
+	}
+	deps := Deps{Load: func() (Snapshot, error) { return snap, nil }}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // Attention → Trains
+	m = next.(Model)
+	if pages[m.selected].page != pageTrains {
+		t.Fatalf("expected Trains page")
+	}
+	view := m.View()
+	for _, want := range []string{"Active", "Blocked", "Done"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected section header %q:\n%s", want, view)
+		}
+	}
+	// Two skillopt-v* sessions collapse under one lineage parent line.
+	if !strings.Contains(view, "skillopt  ") || !strings.Contains(view, "×2") {
+		t.Fatalf("expected collapsed lineage parent 'skillopt ×2':\n%s", view)
+	}
+	// All individual session ids still render (children + flat rows).
+	for _, id := range []string{"skillopt-v1", "skillopt-v2", "lonely", "stalled", "gone"} {
+		if !strings.Contains(view, id) {
+			t.Fatalf("expected session %q in view:\n%s", id, view)
+		}
+	}
+	// Sections render in order: Active before Blocked before Done.
+	ai, bi, di := strings.Index(view, "Active"), strings.Index(view, "Blocked"), strings.Index(view, "Done")
+	if !(ai < bi && bi < di) {
+		t.Fatalf("sections out of order: Active=%d Blocked=%d Done=%d\n%s", ai, bi, di, view)
+	}
+}
+
+// TestTrainCursorSelectsSessionDespiteGrouping proves the cursor still indexes
+// into snap.Trains regardless of the grouped/collapsed visual layout: a session
+// that sorts late visually (Done) but sits at an early snap index is reachable
+// by its index, and the action overlay opens for the right session.
+func TestTrainCursorSelectsSessionDespiteGrouping(t *testing.T) {
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		Trains: []TrainSession{
+			{ID: "done-early", Phase: "run_abandoned", Repo: "o/r"}, // idx 0 → Done section
+			{ID: "live-late", Phase: "items_ready", Repo: "o/r"},    // idx 1 → Active section
+		},
+	}
+	deps := Deps{Load: func() (Snapshot, error) { return snap, nil }}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(Model)
+	// Cursor 0 selects snap.Trains[0] = done-early, even though it renders last.
+	if got, _ := m.trainUnderCursor(); got.ID != "done-early" {
+		t.Fatalf("cursor 0 should select snap index 0 (done-early), got %q", got.ID)
+	}
+	// Down moves to snap index 1 = live-late.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	if m.trainCursor != 1 {
+		t.Fatalf("down should move cursor to 1, got %d", m.trainCursor)
+	}
+	if got, _ := m.trainUnderCursor(); got.ID != "live-late" {
+		t.Fatalf("cursor 1 should select snap index 1 (live-late), got %q", got.ID)
+	}
+}

--- a/internal/cli/tui/dismiss_train_test.go
+++ b/internal/cli/tui/dismiss_train_test.go
@@ -217,7 +217,9 @@ func TestTrainLineageBase(t *testing.T) {
 	}{
 		{"officeqa-treasury-skillopt-v1", "officeqa-treasury-skillopt", true},
 		{"officeqa-treasury-skillopt-v8", "officeqa-treasury-skillopt", true},
-		{"run-12", "run", true},
+		{"run-v12", "run", true},
+		{"run-12", "run-12", false},     // bare numeric is NOT a version lineage
+		{"train-x-20260611-1", "train-x-20260611-1", false}, // timestamp tail, not a version
 		{"plain-name", "plain-name", false},
 		{"train-aaa", "train-aaa", false},
 	}
@@ -267,6 +269,13 @@ func TestTrainsListGroupsAndCollapses(t *testing.T) {
 			t.Fatalf("expected session %q in view:\n%s", id, view)
 		}
 	}
+	// Lineage children are contiguous under their parent: v2 follows v1, and both
+	// come before the unrelated flat 'lonely' row (snapshot order is v1, lonely,
+	// v2 — grouping must keep the lineage together regardless).
+	v1i, v2i, lonelyi := strings.Index(view, "skillopt-v1"), strings.Index(view, "skillopt-v2"), strings.Index(view, "lonely")
+	if !(v1i < v2i && v2i < lonelyi) {
+		t.Fatalf("lineage children must be contiguous (v1 < v2 < lonely): v1=%d v2=%d lonely=%d\n%s", v1i, v2i, lonelyi, view)
+	}
 	// Sections render in order: Active before Blocked before Done.
 	ai, bi, di := strings.Index(view, "Active"), strings.Index(view, "Blocked"), strings.Index(view, "Done")
 	if !(ai < bi && bi < di) {
@@ -274,16 +283,16 @@ func TestTrainsListGroupsAndCollapses(t *testing.T) {
 	}
 }
 
-// TestTrainCursorSelectsSessionDespiteGrouping proves the cursor still indexes
-// into snap.Trains regardless of the grouped/collapsed visual layout: a session
-// that sorts late visually (Done) but sits at an early snap index is reachable
-// by its index, and the action overlay opens for the right session.
-func TestTrainCursorSelectsSessionDespiteGrouping(t *testing.T) {
+// TestTrainCursorFollowsDisplayOrder proves the cursor steps through the visible
+// (grouped) order, not raw snapshot order: an Active session at a late snap index
+// is selected first because the Active section renders before Done, so ↑/↓ always
+// move the highlight to the visually adjacent row.
+func TestTrainCursorFollowsDisplayOrder(t *testing.T) {
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
 		Trains: []TrainSession{
-			{ID: "done-early", Phase: "run_abandoned", Repo: "o/r"}, // idx 0 → Done section
-			{ID: "live-late", Phase: "items_ready", Repo: "o/r"},    // idx 1 → Active section
+			{ID: "done-early", Phase: "run_abandoned", Repo: "o/r"}, // idx 0 → Done section (renders last)
+			{ID: "live-late", Phase: "items_ready", Repo: "o/r"},    // idx 1 → Active section (renders first)
 		},
 	}
 	deps := Deps{Load: func() (Snapshot, error) { return snap, nil }}
@@ -292,17 +301,17 @@ func TestTrainCursorSelectsSessionDespiteGrouping(t *testing.T) {
 	m = next.(Model)
 	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = next.(Model)
-	// Cursor 0 selects snap.Trains[0] = done-early, even though it renders last.
-	if got, _ := m.trainUnderCursor(); got.ID != "done-early" {
-		t.Fatalf("cursor 0 should select snap index 0 (done-early), got %q", got.ID)
+	// Cursor 0 selects the first VISIBLE row = live-late (Active renders before Done).
+	if got, _ := m.trainUnderCursor(); got.ID != "live-late" {
+		t.Fatalf("cursor 0 should select the first visible row (live-late), got %q", got.ID)
 	}
-	// Down moves to snap index 1 = live-late.
+	// Down moves to the next visible row = done-early (Done section).
 	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	m = next.(Model)
 	if m.trainCursor != 1 {
 		t.Fatalf("down should move cursor to 1, got %d", m.trainCursor)
 	}
-	if got, _ := m.trainUnderCursor(); got.ID != "live-late" {
-		t.Fatalf("cursor 1 should select snap index 1 (live-late), got %q", got.ID)
+	if got, _ := m.trainUnderCursor(); got.ID != "done-early" {
+		t.Fatalf("cursor 1 should select the next visible row (done-early), got %q", got.ID)
 	}
 }

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -103,6 +103,13 @@ func (m Model) updateJobOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if jobCancelable(m.activeJob.State) {
 				m.mode = modeConfirmJobCancel
 			}
+		default:
+			// Forward unmapped keys (↑/↓, pgup/pgdn, space, u/d) to the viewport
+			// so a long request/result/delegation list can be scrolled.
+			var cmd tea.Cmd
+			m.viewport, cmd = m.viewport.Update(msg)
+			m.viewport.SetContent(m.content())
+			return m, cmd
 		}
 		m.viewport.SetContent(m.content())
 		return m, nil
@@ -366,13 +373,14 @@ func (m Model) jobDetailView() string {
 	b.WriteString(renderRows(rows))
 	b.WriteByte('\n')
 
-	// What was asked (newlines preserved, capped to a few lines).
+	// What was asked. Shown in full (newlines preserved) — the detail viewport
+	// scrolls, so the whole request is readable, not just the first lines.
 	if d.Request != "" {
 		b.WriteString(headerStyle.Render("request"))
 		b.WriteByte('\n')
-		b.WriteString(clampLines(d.Request, 8) + "\n\n")
+		b.WriteString(strings.TrimRight(d.Request, "\n") + "\n\n")
 	}
-	// What came back (settled jobs).
+	// What came back (settled jobs). Shown in full; the viewport scrolls.
 	if d.ResultDecision != "" || d.ResultSummary != "" {
 		b.WriteString(headerStyle.Render("result"))
 		b.WriteByte('\n')
@@ -380,7 +388,7 @@ func (m Model) jobDetailView() string {
 			b.WriteString("decision  " + jobDecisionColor(d.ResultDecision) + "\n")
 		}
 		if d.ResultSummary != "" {
-			b.WriteString(clampLines(d.ResultSummary, 8) + "\n")
+			b.WriteString(strings.TrimRight(d.ResultSummary, "\n") + "\n")
 		}
 		b.WriteByte('\n')
 	}

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -227,17 +227,6 @@ func daemonStartCmd(deps Deps) tea.Cmd {
 	}
 }
 
-// clampLines preserves newlines (unlike truncate, which collapses whitespace)
-// but caps the block to maxLines, appending an elision marker when it overflows.
-func clampLines(value string, maxLines int) string {
-	lines := strings.Split(strings.TrimRight(value, "\n"), "\n")
-	if len(lines) <= maxLines {
-		return strings.Join(lines, "\n")
-	}
-	kept := lines[:maxLines]
-	return strings.Join(kept, "\n") + "\n" + mutedStyle.Render("… "+strconv.Itoa(len(lines)-maxLines)+" more lines")
-}
-
 // jobDecisionColor colors a gitmoot_result decision: blocked/failed red,
 // changes_requested neutral, everything else (approved/implemented) green.
 func jobDecisionColor(decision string) string {

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -750,14 +750,3 @@ func TestDepsLabel(t *testing.T) {
 		t.Fatalf("depsLabel(pending) = %q", got)
 	}
 }
-
-func TestJobDetailClampLines(t *testing.T) {
-	got := clampLines("a\nb\nc\nd\ne", 3)
-	if !strings.Contains(got, "a\nb\nc") || !strings.Contains(got, "2 more lines") {
-		t.Fatalf("clampLines = %q", got)
-	}
-	// Within the cap, newlines are preserved verbatim (not collapsed).
-	if clampLines("one\ntwo", 5) != "one\ntwo" {
-		t.Fatalf("clampLines should preserve newlines under the cap")
-	}
-}

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -35,7 +35,7 @@ var pages = []struct {
 	{pageAttention, "Attention", "Attention"},
 	{pageTrains, "Trains", "Trains"},
 	{pageAgents, "Agents", "Agents"},
-	{pageSessions, "Sessions", "Runtime sessions"},
+	{pageSessions, "Workers", "Runtime workers (agent sessions)"},
 	{pageJobs, "Jobs", "Jobs"},
 	{pageLocks, "Locks", "Locks"},
 	{pageHealth, "Health", "Health"},

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -60,7 +60,7 @@ func loadedModel(t *testing.T) Model {
 func TestPagesRenderExpectedContent(t *testing.T) {
 	m := loadedModel(t)
 	// Page order: Attention, Trains, Agents, Sessions, Jobs, Locks, Health, Config.
-	wants := []string{"needs attention", "train-s1", "planner", "skillopt-generator", "failed", "branch locks", "environment", "edit in $EDITOR"}
+	wants := []string{"Prompts (1)", "train-s1", "planner", "skillopt-generator", "failed", "branch locks", "environment", "edit in $EDITOR"}
 	for i, want := range wants {
 		if i > 0 {
 			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})

--- a/internal/cli/tui/sessions.go
+++ b/internal/cli/tui/sessions.go
@@ -49,7 +49,7 @@ func (m Model) sessionRows() []sessionRow {
 	}
 	for _, s := range singles {
 		rows = append(rows, sessionRow{
-			label:   fmt.Sprintf("%s [%s] %s %s", s.Name, s.Runtime, dash(s.Repo), s.State),
+			label:   fmt.Sprintf("%s (%s) [%s] %s %s", s.Name, dash(s.Type), s.Runtime, dash(s.Repo), s.State),
 			session: s,
 			count:   1,
 		})
@@ -151,8 +151,12 @@ func (m *Model) openSessionDetail() {
 
 func (m Model) sessionsContent() string {
 	var b strings.Builder
-	b.WriteString(mutedStyle.Render("The live codex/claude/kimi processes backing your Agents — one warm session per delivered job (up to max_background); idle ones expire on their own."))
-	b.WriteString("\n\n")
+	// Kept as short lines so the key phrases survive viewport wrapping.
+	b.WriteString(mutedStyle.Render("Live runtime processes (codex/claude/kimi) that execute jobs for your agents.") + "\n")
+	b.WriteString(mutedStyle.Render("Each row shows its owning agent type.") + "\n")
+	b.WriteString(mutedStyle.Render("Stopping one frees the warm process; it does NOT cancel a running job.") + "\n")
+	b.WriteString(mutedStyle.Render("Idle sessions expire on their own.") + "\n")
+	b.WriteString("\n")
 	rows := m.sessionRows()
 	if len(rows) == 0 {
 		b.WriteString(m.loadingOr("No runtime sessions.", !m.loadedAt.IsZero()))

--- a/internal/cli/tui/sessions_test.go
+++ b/internal/cli/tui/sessions_test.go
@@ -39,6 +39,28 @@ func sessionDetailSnapshot() Snapshot {
 	}
 }
 
+func TestSessionsIntroExplainsRuntimeProcesses(t *testing.T) {
+	m := sessionsPageModel(t, sessionDetailSnapshot())
+	view := m.View()
+	// The intro must plainly frame sessions as live runtime processes that run
+	// jobs for agents, and that stopping one frees the process (not a job).
+	for _, want := range []string{"runtime processes", "execute jobs for your agents", "does NOT cancel a running job"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("sessions intro missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestSessionRowShowsOwningAgentType(t *testing.T) {
+	m := sessionsPageModel(t, sessionDetailSnapshot())
+	view := m.View()
+	// The single "planner" session row must surface its owning agent type so a
+	// name like "planner" reads as belonging to the "planner" type.
+	if !strings.Contains(view, "planner (planner)") {
+		t.Fatalf("session row should show the owning agent type:\n%s", view)
+	}
+}
+
 func TestSessionDetailRendersInstanceFields(t *testing.T) {
 	m := sessionsPageModel(t, sessionDetailSnapshot())
 	// The grouped bg rows sort first, then the single "planner". Move to it.

--- a/internal/cli/tui/trains.go
+++ b/internal/cli/tui/trains.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -220,6 +222,67 @@ func (m Model) trainRepoCleanupView() string {
 	return b.String()
 }
 
+// Train status categories. A session lands in exactly one section; the ordering
+// of the constants is also the top-to-bottom render order of the sections.
+const (
+	trainCatActive = iota
+	trainCatBlocked
+	trainCatDone
+)
+
+var trainSectionTitles = map[int]string{
+	trainCatActive:  "Active",
+	trainCatBlocked: "Blocked",
+	trainCatDone:    "Done",
+}
+
+// trainStatusCategory buckets a phase into Active/Blocked/Done for the grouped
+// list. Blocked is checked before the broad Active default so a stalled
+// heartbeat or stale lock surfaces under Blocked rather than masquerading as
+// live work. Done covers the terminal states.
+func trainStatusCategory(phase string) int {
+	p := skillopt.NormalizeTrainState(phase)
+	switch p {
+	case skillopt.TrainStateRunAbandoned,
+		skillopt.TrainStateCandidatePromoted,
+		skillopt.TrainStateCandidateRejected,
+		skillopt.TrainStateOptimizerCompletedNoCandidate:
+		return trainCatDone
+	}
+	switch p {
+	case "blocked_stale_lock", "failed_unrecoverable", "blocked_config":
+		return trainCatBlocked
+	}
+	if strings.HasSuffix(p, "_heartbeat_stale") {
+		return trainCatBlocked
+	}
+	// Everything else — the ordered in-progress phases plus the live lock
+	// phases (generating_options/optimizer_running/preflight_running/
+	// recovery_available) — is Active.
+	return trainCatActive
+}
+
+var trainLineageSuffix = regexp.MustCompile(`-(v?\d+)$`)
+
+// trainLineageBase strips a trailing version suffix ("-v3", "-12") from a
+// session id, returning the shared base name and whether a suffix was present.
+// Sessions that share a base collapse under one lineage parent line.
+func trainLineageBase(id string) (string, bool) {
+	loc := trainLineageSuffix.FindStringIndex(id)
+	if loc == nil {
+		return id, false
+	}
+	return id[:loc[0]], true
+}
+
+// trainRow is one displayed session paired with its index into snap.Trains. The
+// index — not the visual position — is what the cursor selects, so grouping and
+// lineage collapsing only reorder rows visually; selection stays index-based.
+type trainRow struct {
+	idx int
+	t   TrainSession
+}
+
 func (m Model) trainsContent() string {
 	if m.mode == modeTrainDetail {
 		return m.trainDetail()
@@ -228,22 +291,80 @@ func (m Model) trainsContent() string {
 		return m.loadingOr("No train sessions.", !m.loadedAt.IsZero())
 	}
 	var b strings.Builder
+
+	// Bucket sessions into the three sections, preserving original index so the
+	// cursor (an index into snap.Trains) still highlights the right row.
+	sections := map[int][]trainRow{}
 	for i, t := range m.snap.Trains {
-		cursor := "  "
-		phase := t.Phase
-		if deadTrainPhase(t.Phase) {
-			phase = mutedStyle.Render(t.Phase)
-		}
-		line := t.ID + "  " + phase
-		if i == m.trainCursor {
-			cursor = "▸ "
-			line = selectedRowStyle.Render(t.ID) + "  " + phase
-		}
-		b.WriteString(cursor + line + "\n")
+		cat := trainStatusCategory(t.Phase)
+		sections[cat] = append(sections[cat], trainRow{idx: i, t: t})
 	}
+
+	first := true
+	for _, cat := range []int{trainCatActive, trainCatBlocked, trainCatDone} {
+		rows := sections[cat]
+		if len(rows) == 0 {
+			continue
+		}
+		if !first {
+			b.WriteByte('\n')
+		}
+		first = false
+		// Section header is display-only: it consumes no cursor position.
+		b.WriteString(headerStyle.Render(trainSectionTitles[cat]))
+		b.WriteByte('\n')
+		m.writeTrainSection(&b, rows)
+	}
+
 	b.WriteString(mutedStyle.Render("enter open  s stop  d delete"))
 	b.WriteByte('\n')
 	return b.String()
+}
+
+// writeTrainSection renders one section's rows, collapsing lineages (same base
+// name with a trailing version suffix) under a single display-only parent line
+// with the children indented beneath it. Lone sessions render flat. The lineage
+// parent line is non-selectable; only the underlying sessions are, and each is
+// highlighted by its original snap.Trains index so the cursor maps correctly.
+func (m Model) writeTrainSection(b *strings.Builder, rows []trainRow) {
+	// Count how many rows in this section share each lineage base. A base seen
+	// more than once becomes a collapsed group; everything else stays flat.
+	counts := map[string]int{}
+	for _, r := range rows {
+		if base, ok := trainLineageBase(r.t.ID); ok {
+			counts[base]++
+		}
+	}
+	rendered := map[string]bool{}
+	for _, r := range rows {
+		base, hasSuffix := trainLineageBase(r.t.ID)
+		if hasSuffix && counts[base] > 1 {
+			// Emit the lineage parent once, at the position of its first child.
+			if !rendered[base] {
+				rendered[base] = true
+				parent := base + "  " + mutedStyle.Render("×"+strconv.Itoa(counts[base]))
+				b.WriteString("  " + parent + "\n")
+			}
+			m.writeTrainRow(b, r, "    ")
+			continue
+		}
+		m.writeTrainRow(b, r, "  ")
+	}
+}
+
+// writeTrainRow renders a single selectable session row at the given indent.
+// indent is the text written for a non-cursor row; the cursor row replaces the
+// trailing two spaces with the "▸ " marker so columns stay aligned.
+func (m Model) writeTrainRow(b *strings.Builder, r trainRow, indent string) {
+	phase := r.t.Phase
+	if deadTrainPhase(r.t.Phase) {
+		phase = mutedStyle.Render(r.t.Phase)
+	}
+	if r.idx == m.trainCursor {
+		b.WriteString(indent[:len(indent)-2] + "▸ " + selectedRowStyle.Render(r.t.ID) + "  " + phase + "\n")
+		return
+	}
+	b.WriteString(indent + r.t.ID + "  " + phase + "\n")
 }
 
 func (m Model) trainDetail() string {

--- a/internal/cli/tui/trains.go
+++ b/internal/cli/tui/trains.go
@@ -18,12 +18,18 @@ func (m *Model) openTrainDetail() {
 	}
 }
 
-// trainUnderCursor returns the session under the Trains cursor, if any.
+// trainUnderCursor returns the session under the Trains cursor, if any. The
+// cursor indexes the display-ordered list (orderedTrains), not raw snapshot
+// order, so it resolves to the row the user sees highlighted.
 func (m Model) trainUnderCursor() (TrainSession, bool) {
-	if pages[m.selected].page != pageTrains || len(m.snap.Trains) == 0 {
+	if pages[m.selected].page != pageTrains {
 		return TrainSession{}, false
 	}
-	return m.snap.Trains[m.trainCursor], true
+	ordered := m.orderedTrains()
+	if m.trainCursor < 0 || m.trainCursor >= len(ordered) {
+		return TrainSession{}, false
+	}
+	return ordered[m.trainCursor], true
 }
 
 // openTrainStop enters the stop-reason overlay for a live session.
@@ -262,11 +268,14 @@ func trainStatusCategory(phase string) int {
 	return trainCatActive
 }
 
-var trainLineageSuffix = regexp.MustCompile(`-(v?\d+)$`)
+// Only an explicit "-vN" suffix marks a version lineage. A bare "-N" (e.g. a
+// timestamp tail or an independently named run) is NOT treated as a version, so
+// unrelated sessions like nightly-1/nightly-2 do not collapse together.
+var trainLineageSuffix = regexp.MustCompile(`-v\d+$`)
 
-// trainLineageBase strips a trailing version suffix ("-v3", "-12") from a
-// session id, returning the shared base name and whether a suffix was present.
-// Sessions that share a base collapse under one lineage parent line.
+// trainLineageBase strips an explicit version suffix ("-v3") from a session id,
+// returning the shared base name and whether a suffix was present. Sessions in
+// the same status section that share a base collapse under one lineage line.
 func trainLineageBase(id string) (string, bool) {
 	loc := trainLineageSuffix.FindStringIndex(id)
 	if loc == nil {
@@ -275,12 +284,67 @@ func trainLineageBase(id string) (string, bool) {
 	return id[:loc[0]], true
 }
 
-// trainRow is one displayed session paired with its index into snap.Trains. The
-// index — not the visual position — is what the cursor selects, so grouping and
-// lineage collapsing only reorder rows visually; selection stays index-based.
-type trainRow struct {
-	idx int
-	t   TrainSession
+// trainGroup is one unit of the Trains display: either a lone session
+// (len(members)==1, base "") or a collapsed lineage (members share base).
+type trainGroup struct {
+	base    string
+	members []TrainSession
+}
+
+// trainSectionGroups returns the display-ordered groups for one status category.
+// Sessions are taken in snapshot order; a base shared by more than one session
+// in the category collapses into a single group whose members stay contiguous
+// (in snapshot order), emitted at the position of its first member. This keeps
+// every lineage child under its own parent even when members are not adjacent
+// in the snapshot.
+func (m Model) trainSectionGroups(cat int) []trainGroup {
+	var rows []TrainSession
+	for _, t := range m.snap.Trains {
+		if trainStatusCategory(t.Phase) == cat {
+			rows = append(rows, t)
+		}
+	}
+	counts := map[string]int{}
+	for _, t := range rows {
+		if base, ok := trainLineageBase(t.ID); ok {
+			counts[base]++
+		}
+	}
+	emitted := map[string]bool{}
+	var groups []trainGroup
+	for _, t := range rows {
+		base, ok := trainLineageBase(t.ID)
+		if ok && counts[base] > 1 {
+			if emitted[base] {
+				continue
+			}
+			emitted[base] = true
+			g := trainGroup{base: base}
+			for _, u := range rows {
+				if b, o := trainLineageBase(u.ID); o && b == base {
+					g.members = append(g.members, u)
+				}
+			}
+			groups = append(groups, g)
+			continue
+		}
+		groups = append(groups, trainGroup{members: []TrainSession{t}})
+	}
+	return groups
+}
+
+// orderedTrains is the flat, display-ordered list of sessions — the exact
+// top-to-bottom order rows render in (sections Active→Blocked→Done, lineages
+// contiguous). The Trains cursor indexes into THIS slice, so ↑/↓ steps through
+// the visible list in order and selection matches the highlighted row.
+func (m Model) orderedTrains() []TrainSession {
+	var out []TrainSession
+	for _, cat := range []int{trainCatActive, trainCatBlocked, trainCatDone} {
+		for _, g := range m.trainSectionGroups(cat) {
+			out = append(out, g.members...)
+		}
+	}
+	return out
 }
 
 func (m Model) trainsContent() string {
@@ -292,28 +356,35 @@ func (m Model) trainsContent() string {
 	}
 	var b strings.Builder
 
-	// Bucket sessions into the three sections, preserving original index so the
-	// cursor (an index into snap.Trains) still highlights the right row.
-	sections := map[int][]trainRow{}
-	for i, t := range m.snap.Trains {
-		cat := trainStatusCategory(t.Phase)
-		sections[cat] = append(sections[cat], trainRow{idx: i, t: t})
-	}
-
+	// pos is the display position of the next selectable session row; it must
+	// advance in lockstep with orderedTrains() so the cursor highlights and
+	// selects the same row. Section headers and lineage parents are display-only
+	// and consume no position.
+	pos := 0
 	first := true
 	for _, cat := range []int{trainCatActive, trainCatBlocked, trainCatDone} {
-		rows := sections[cat]
-		if len(rows) == 0 {
+		groups := m.trainSectionGroups(cat)
+		if len(groups) == 0 {
 			continue
 		}
 		if !first {
 			b.WriteByte('\n')
 		}
 		first = false
-		// Section header is display-only: it consumes no cursor position.
 		b.WriteString(headerStyle.Render(trainSectionTitles[cat]))
 		b.WriteByte('\n')
-		m.writeTrainSection(&b, rows)
+		for _, g := range groups {
+			if len(g.members) > 1 {
+				b.WriteString("  " + g.base + "  " + mutedStyle.Render("×"+strconv.Itoa(len(g.members))) + "\n")
+				for _, t := range g.members {
+					m.writeTrainRow(&b, t, pos == m.trainCursor, "    ")
+					pos++
+				}
+				continue
+			}
+			m.writeTrainRow(&b, g.members[0], pos == m.trainCursor, "  ")
+			pos++
+		}
 	}
 
 	b.WriteString(mutedStyle.Render("enter open  s stop  d delete"))
@@ -321,50 +392,20 @@ func (m Model) trainsContent() string {
 	return b.String()
 }
 
-// writeTrainSection renders one section's rows, collapsing lineages (same base
-// name with a trailing version suffix) under a single display-only parent line
-// with the children indented beneath it. Lone sessions render flat. The lineage
-// parent line is non-selectable; only the underlying sessions are, and each is
-// highlighted by its original snap.Trains index so the cursor maps correctly.
-func (m Model) writeTrainSection(b *strings.Builder, rows []trainRow) {
-	// Count how many rows in this section share each lineage base. A base seen
-	// more than once becomes a collapsed group; everything else stays flat.
-	counts := map[string]int{}
-	for _, r := range rows {
-		if base, ok := trainLineageBase(r.t.ID); ok {
-			counts[base]++
-		}
-	}
-	rendered := map[string]bool{}
-	for _, r := range rows {
-		base, hasSuffix := trainLineageBase(r.t.ID)
-		if hasSuffix && counts[base] > 1 {
-			// Emit the lineage parent once, at the position of its first child.
-			if !rendered[base] {
-				rendered[base] = true
-				parent := base + "  " + mutedStyle.Render("×"+strconv.Itoa(counts[base]))
-				b.WriteString("  " + parent + "\n")
-			}
-			m.writeTrainRow(b, r, "    ")
-			continue
-		}
-		m.writeTrainRow(b, r, "  ")
-	}
-}
-
 // writeTrainRow renders a single selectable session row at the given indent.
-// indent is the text written for a non-cursor row; the cursor row replaces the
-// trailing two spaces with the "▸ " marker so columns stay aligned.
-func (m Model) writeTrainRow(b *strings.Builder, r trainRow, indent string) {
-	phase := r.t.Phase
-	if deadTrainPhase(r.t.Phase) {
-		phase = mutedStyle.Render(r.t.Phase)
+// selected is true when this row's display position is under the cursor; the
+// cursor row replaces the trailing two spaces of indent with the "▸ " marker so
+// columns stay aligned.
+func (m Model) writeTrainRow(b *strings.Builder, t TrainSession, selected bool, indent string) {
+	phase := t.Phase
+	if deadTrainPhase(t.Phase) {
+		phase = mutedStyle.Render(t.Phase)
 	}
-	if r.idx == m.trainCursor {
-		b.WriteString(indent[:len(indent)-2] + "▸ " + selectedRowStyle.Render(r.t.ID) + "  " + phase + "\n")
+	if selected {
+		b.WriteString(indent[:len(indent)-2] + "▸ " + selectedRowStyle.Render(t.ID) + "  " + phase + "\n")
 		return
 	}
-	b.WriteString(indent + r.t.ID + "  " + phase + "\n")
+	b.WriteString(indent + t.ID + "  " + phase + "\n")
 }
 
 func (m Model) trainDetail() string {


### PR DESCRIPTION
## Summary
Phase 1 of the dashboard TUI overhaul (issue discussion). Makes the dense flat pages readable using **existing snapshot data only — no schema changes**. Phase 2 (live Activity page + `root_job_id` denormalization + Jobs grouping) lands separately.

## What changed
- **Jobs detail** — the request and result now render **in full and scroll** (the overlay viewport receives keys); previously capped at 8 lines with no scroll, so only the start of a request was visible.
- **Attention** — grouped into **Prompts / Blocked & failed jobs / Stale locks / Branch locks** with counts, severity color, and the "why" line.
- **Trains** — bucketed by status **Active / Blocked / Done**, and an explicit `-vN` **lineage collapses** under one base row (so `…-v1..v8` fold together).
- **Agents** — grouped by **template**.
- **Workers** (renamed from "Sessions") — clarified intro (these are runtime processes that run jobs for agents; stopping one ≠ cancelling a job) + an owning-agent-type column.
- **Config** — `parallel_sessions` scalars are **inline-editable** (offered only when the section exists), with allowed-value validation.

## Correctness (from `/code-review`)
The review caught that grouping changed visual order while the cursor still indexed snapshot order — fixed so **↑/↓ follow the on-screen order** on Trains and Agents (single ordering source drives both render and cursor; lineage children stay contiguous). Also tightened the lineage regex to explicit `-vN`, made config edits robust (section-presence guard, enum validation, explicit list kind), and removed dead code.

## Verification
`go build/vet/test ./...` + `go test -race ./internal/workflow/` all green. Page tests updated for the new grouped rendering and cursor-follows-display-order behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)