### PR TITLE
feat(tui): repo grouping + collapsible groups on Attention & Trains

### DIFF
--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -73,6 +74,7 @@ type dashboardDaemonDetail struct {
 type dashboardJobRow struct {
 	db.Job
 	LatestEvent string
+	Repo        string // parsed from the payload for reportable jobs (attention grouping)
 }
 
 type dashboardResourceLock struct {
@@ -431,6 +433,17 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 			row := dashboardJobRow{Job: job}
 			if job.State == "blocked" || job.State == "failed" {
 				row.LatestEvent = latestEvents[job.ID].Message
+			}
+			// Reportable jobs surface on the Attention page grouped by repo; the
+			// repo lives in the payload, so parse it only for that small subset to
+			// keep the refresh tick cheap.
+			if job.State == "blocked" || job.State == "failed" || job.State == "cancelled" {
+				var p struct {
+					Repo string `json:"repo"`
+				}
+				if err := json.Unmarshal([]byte(job.Payload), &p); err == nil {
+					row.Repo = strings.TrimSpace(p.Repo)
+				}
 			}
 			snapshot.jobRows = append(snapshot.jobRows, row)
 		}

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -93,7 +93,8 @@ func runDashboardTUI(home string, interval time.Duration, stdout, stderr io.Writ
 // DB) so the TUI always reflects current state, including live train phases.
 func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 	return tui.Deps{
-		Interval: interval,
+		Interval:                interval,
+		CollapseGroupsByDefault: true,
 		Load: func() (tui.Snapshot, error) {
 			paths, err := initializedPaths(home)
 			if err != nil {

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -513,6 +513,7 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 			State:       row.State,
 			UpdatedAt:   row.UpdatedAt,
 			LatestEvent: row.LatestEvent,
+			Repo:        row.Repo,
 		})
 	}
 	return out

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -67,9 +67,13 @@ func orderJobsByRepo(jobs []*JobRow) []*JobRow {
 // attentionPrompt returns the prompt under the attention cursor, if the
 // selected item is a prompt.
 func (m Model) attentionPrompt() (db.InteractivePrompt, bool) {
+	idx := selectedItemIndex(m.attentionVisibleRows(), m.promptCursor)
+	if idx < 0 {
+		return db.InteractivePrompt{}, false
+	}
 	items := m.attentionItems()
-	if m.promptCursor < len(items) && items[m.promptCursor].prompt != nil {
-		return *items[m.promptCursor].prompt, true
+	if idx < len(items) && items[idx].prompt != nil {
+		return *items[idx].prompt, true
 	}
 	return db.InteractivePrompt{}, false
 }
@@ -219,6 +223,68 @@ func answerCmd(deps Deps, id, value string) tea.Cmd {
 // "Branch locks". Section headers carry no cursor index: the selectable items
 // (prompts then reportable jobs) keep the exact flat ordering and indices of
 // attentionItems(), which m.promptCursor indexes into.
+// attentionListRows builds the Attention page's collapsible row tree: a
+// "Prompts" section, a "Blocked & failed jobs" section grouped by repo, and the
+// "Stale locks" / "Branch locks" sections. Leaf itemIdx indexes attentionItems()
+// (prompts then repo-ordered jobs); lock rows are display-only leaves (itemIdx
+// -1, no action).
+func (m Model) attentionListRows() []listRow {
+	items := m.attentionItems()
+	promptN := countPrompts(items)
+	var rows []listRow
+
+	// Prompts: critical and few, so they are plain leaves under a static header —
+	// the cursor lands on the first prompt, ready to answer (no collapse).
+	if promptN > 0 {
+		rows = append(rows, staticRow(0, "Prompts ("+strconv.Itoa(promptN)+")"))
+		for i := 0; i < promptN; i++ {
+			p := items[i].prompt
+			rows = append(rows, leafRow(1, "prompt "+p.ID+"  "+truncate(p.Question, 56), i, ""))
+		}
+	}
+
+	// Blocked & failed jobs: a static section title with collapsible repo groups.
+	if jobN := len(items) - promptN; jobN > 0 {
+		rows = append(rows, staticRow(0, "Blocked & failed jobs ("+strconv.Itoa(jobN)+")"))
+		curRepo := "\x00" // sentinel so the first repo header always prints
+		repoKey := ""
+		for i := promptN; i < len(items); i++ {
+			j := items[i].job
+			if label := attentionRepoLabel(j.Repo); label != curRepo {
+				curRepo = label
+				repoKey = "attn:jobrepo:" + label
+				rows = append(rows, headerRow(repoKey, 1, label))
+			}
+			line := "job " + j.ID + "  " + j.Type + "  " + jobStateColor(j.State)
+			if j.LatestEvent != "" {
+				line += "  " + mutedStyle.Render(truncate(j.LatestEvent, 48))
+			}
+			rows = append(rows, leafRow(2, line, i, repoKey))
+		}
+	}
+
+	// Locks are display-only context (no actions), shown as static lines.
+	if stale := staleLocks(m.snap.ResourceLocks); len(stale) > 0 {
+		rows = append(rows, staticRow(0, "Stale locks ("+strconv.Itoa(len(stale))+")"))
+		for _, l := range stale {
+			rows = append(rows, staticRow(1, redStyle.Render(l.Key)))
+		}
+	}
+	if len(m.snap.BranchLocks) > 0 {
+		rows = append(rows, staticRow(0, "Branch locks ("+strconv.Itoa(len(m.snap.BranchLocks))+")"))
+		for _, l := range m.snap.BranchLocks {
+			rows = append(rows, staticRow(1, l.Repo+" "+l.Branch+" ("+dash(l.Owner)+")"))
+		}
+	}
+	return rows
+}
+
+// attentionVisibleRows is the Attention tree filtered by the collapse state — the
+// exact rows rendered, and the index space m.promptCursor walks.
+func (m Model) attentionVisibleRows() []listRow {
+	return visibleListRows(m.attentionListRows(), m.collapsed)
+}
+
 func (m Model) attentionContent() string {
 	switch m.mode {
 	case modeAnswerChoice, modeAnswerText:
@@ -249,106 +315,28 @@ func (m Model) attentionContent() string {
 		wrote = true
 	}
 
-	// items is the flat, ordered selectable slice (prompts first, then
-	// reportable jobs). i is the global cursor index for every selectable row;
-	// section headers are display-only and never advance it.
-	items := m.attentionItems()
-	renderRow := func(i int, item attnItem, indent string) {
-		marker := "  "
-		var line string
-		switch {
-		case item.prompt != nil:
-			line = "prompt " + item.prompt.ID + "  " + truncate(item.prompt.Question, 56)
-		case item.job != nil:
-			line = "job " + item.job.ID + "  " + item.job.Type + "  " + jobStateColor(item.job.State)
-			if item.job.LatestEvent != "" {
-				line += "  " + mutedStyle.Render(truncate(item.job.LatestEvent, 48))
+	// When only non-actionable context (locks) is present, say so explicitly so
+	// the page does not read as if those locks need an answer.
+	actionable := len(m.attentionItems())
+	rows := m.attentionVisibleRows()
+	if actionable == 0 && len(rows) > 0 {
+		b.WriteString(headerStyle.Render("Needs attention") + "\n" + mutedStyle.Render("none") + "\n\n")
+		wrote = true
+	}
+	if len(rows) > 0 {
+		renderListRows(&b, rows, m.promptCursor)
+		if actionable > 0 {
+			help := "↑/↓ move · space fold repo   prompts: a answer · d dismiss   jobs: enter detail · R retry"
+			if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
+				help += " · B report bug"
 			}
+			b.WriteString("\n" + mutedStyle.Render(help) + "\n")
 		}
-		if i == m.promptCursor {
-			marker = "▸ "
-			line = selectedRowStyle.Render("• ") + line
-		}
-		b.WriteString(indent + marker + line + "\n")
-	}
-
-	wrotePrompts := false
-	for i, item := range items {
-		if item.prompt == nil {
-			continue
-		}
-		if !wrotePrompts {
-			b.WriteString(headerStyle.Render("Prompts ("+strconv.Itoa(countPrompts(items))+")") + "\n")
-			wrotePrompts = true
-		}
-		renderRow(i, item, "")
-	}
-
-	// Blocked & failed jobs, grouped under repo sub-headers (display-only). The
-	// jobs are already repo-ordered in attentionItems, so a repo header is
-	// emitted whenever the repo changes; rows indent under their repo.
-	wroteJobs := false
-	curRepo := ""
-	for i, item := range items {
-		if item.job == nil {
-			continue
-		}
-		if !wroteJobs {
-			if wrotePrompts {
-				b.WriteByte('\n')
-			}
-			b.WriteString(redStyle.Render("Blocked & failed jobs ("+strconv.Itoa(len(items)-countPrompts(items))+")") + "\n")
-			wroteJobs = true
-			curRepo = "\x00" // sentinel so the first repo header always prints
-		}
-		if label := attentionRepoLabel(item.job.Repo); label != curRepo {
-			curRepo = label
-			b.WriteString("  " + mutedStyle.Render(label) + "\n")
-		}
-		renderRow(i, item, "  ")
-	}
-
-	if len(items) == 0 {
-		b.WriteString(headerStyle.Render("needs attention"))
-		b.WriteByte('\n')
-		b.WriteString(mutedStyle.Render("none"))
-		b.WriteByte('\n')
-	} else {
-		// Attention only lists reportable terminal jobs, so cancel never applies here.
-		help := "prompts: a answer · d dismiss   jobs: enter detail · R retry"
-		if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
-			help += " · B report bug"
-		}
-		b.WriteString(mutedStyle.Render(help))
-		b.WriteByte('\n')
 		wrote = true
 	}
 
 	if m.actionErr != "" {
 		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
-	}
-
-	stale := staleLocks(m.snap.ResourceLocks)
-	if len(stale) > 0 {
-		b.WriteString("\n")
-		b.WriteString(redStyle.Render("Stale locks (" + strconv.Itoa(len(stale)) + ")"))
-		b.WriteByte('\n')
-		for _, l := range stale {
-			b.WriteString(redStyle.Render(l.Key))
-			b.WriteByte('\n')
-		}
-		wrote = true
-	}
-
-	if len(m.snap.BranchLocks) > 0 {
-		b.WriteString("\n")
-		b.WriteString(headerStyle.Render("Branch locks (" + strconv.Itoa(len(m.snap.BranchLocks)) + ")"))
-		b.WriteByte('\n')
-		for _, l := range m.snap.BranchLocks {
-			b.WriteString(l.Repo + " " + l.Branch + " (" + dash(l.Owner) + ")")
-			b.WriteByte('\n')
-		}
-		wrote = true
 	}
 
 	if !wrote {

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -17,18 +17,51 @@ type attnItem struct {
 }
 
 // attentionItems lists the actionable attention rows: pending prompts first,
-// then blocked/failed/cancelled jobs.
+// then blocked/failed/cancelled jobs ordered by repo (so the render can group
+// them under repo sub-headers while the cursor still walks them in view order).
 func (m Model) attentionItems() []attnItem {
 	items := make([]attnItem, 0, len(m.snap.Prompts))
 	for i := range m.snap.Prompts {
 		items = append(items, attnItem{prompt: &m.snap.Prompts[i]})
 	}
+	var jobs []*JobRow
 	for i := range m.snap.JobRows {
 		if jobReportable(m.snap.JobRows[i].State) {
-			items = append(items, attnItem{job: &m.snap.JobRows[i]})
+			jobs = append(jobs, &m.snap.JobRows[i])
 		}
 	}
+	for _, j := range orderJobsByRepo(jobs) {
+		items = append(items, attnItem{job: j})
+	}
 	return items
+}
+
+// attentionRepoLabel is the repo a reportable job belongs to, or "(no repo)" for
+// jobs whose payload carried none.
+func attentionRepoLabel(repo string) string {
+	if strings.TrimSpace(repo) == "" {
+		return "(no repo)"
+	}
+	return repo
+}
+
+// orderJobsByRepo groups jobs by repo in first-appearance order (preserving each
+// job's order within its repo), so same-repo jobs are contiguous.
+func orderJobsByRepo(jobs []*JobRow) []*JobRow {
+	order := []string{}
+	buckets := map[string][]*JobRow{}
+	for _, j := range jobs {
+		label := attentionRepoLabel(j.Repo)
+		if _, ok := buckets[label]; !ok {
+			order = append(order, label)
+		}
+		buckets[label] = append(buckets[label], j)
+	}
+	out := make([]*JobRow, 0, len(jobs))
+	for _, label := range order {
+		out = append(out, buckets[label]...)
+	}
+	return out
 }
 
 // attentionPrompt returns the prompt under the attention cursor, if the
@@ -220,8 +253,8 @@ func (m Model) attentionContent() string {
 	// reportable jobs). i is the global cursor index for every selectable row;
 	// section headers are display-only and never advance it.
 	items := m.attentionItems()
-	renderRow := func(i int, item attnItem) {
-		cursor := "  "
+	renderRow := func(i int, item attnItem, indent string) {
+		marker := "  "
 		var line string
 		switch {
 		case item.prompt != nil:
@@ -233,10 +266,10 @@ func (m Model) attentionContent() string {
 			}
 		}
 		if i == m.promptCursor {
-			cursor = "▸ "
+			marker = "▸ "
 			line = selectedRowStyle.Render("• ") + line
 		}
-		b.WriteString(cursor + line + "\n")
+		b.WriteString(indent + marker + line + "\n")
 	}
 
 	wrotePrompts := false
@@ -248,10 +281,14 @@ func (m Model) attentionContent() string {
 			b.WriteString(headerStyle.Render("Prompts ("+strconv.Itoa(countPrompts(items))+")") + "\n")
 			wrotePrompts = true
 		}
-		renderRow(i, item)
+		renderRow(i, item, "")
 	}
 
+	// Blocked & failed jobs, grouped under repo sub-headers (display-only). The
+	// jobs are already repo-ordered in attentionItems, so a repo header is
+	// emitted whenever the repo changes; rows indent under their repo.
 	wroteJobs := false
+	curRepo := ""
 	for i, item := range items {
 		if item.job == nil {
 			continue
@@ -262,8 +299,13 @@ func (m Model) attentionContent() string {
 			}
 			b.WriteString(redStyle.Render("Blocked & failed jobs ("+strconv.Itoa(len(items)-countPrompts(items))+")") + "\n")
 			wroteJobs = true
+			curRepo = "\x00" // sentinel so the first repo header always prints
 		}
-		renderRow(i, item)
+		if label := attentionRepoLabel(item.job.Repo); label != curRepo {
+			curRepo = label
+			b.WriteString("  " + mutedStyle.Render(label) + "\n")
+		}
+		renderRow(i, item, "  ")
 	}
 
 	if len(items) == 0 {

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -282,7 +282,7 @@ func (m Model) attentionListRows() []listRow {
 // attentionVisibleRows is the Attention tree filtered by the collapse state — the
 // exact rows rendered, and the index space m.promptCursor walks.
 func (m Model) attentionVisibleRows() []listRow {
-	return visibleListRows(m.attentionListRows(), m.collapsed)
+	return visibleListRows(m.attentionListRows(), m.groupCollapsed)
 }
 
 func (m Model) attentionContent() string {
@@ -326,7 +326,7 @@ func (m Model) attentionContent() string {
 	if len(rows) > 0 {
 		renderListRows(&b, rows, m.promptCursor)
 		if actionable > 0 {
-			help := "↑/↓ move · space fold repo   prompts: a answer · d dismiss   jobs: enter detail · R retry"
+			help := "↑/↓ move · space open/close repo   prompts: a answer · d dismiss   jobs: enter detail · R retry"
 			if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
 				help += " · B report bug"
 			}

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -216,13 +216,6 @@ func answerCmd(deps Deps, id, value string) tea.Cmd {
 	}
 }
 
-// attentionContent renders the Attention page. The daemon-down and
-// required-health-failed banners are pinned at the top, then the actionable
-// items are grouped under display-only section headers — "Prompts" (selectable),
-// "Blocked & failed jobs" (selectable) — followed by "Stale locks" and
-// "Branch locks". Section headers carry no cursor index: the selectable items
-// (prompts then reportable jobs) keep the exact flat ordering and indices of
-// attentionItems(), which m.promptCursor indexes into.
 // attentionListRows builds the Attention page's collapsible row tree: a
 // "Prompts" section, a "Blocked & failed jobs" section grouped by repo, and the
 // "Stale locks" / "Branch locks" sections. Leaf itemIdx indexes attentionItems()
@@ -246,6 +239,10 @@ func (m Model) attentionListRows() []listRow {
 	// Blocked & failed jobs: a static section title with collapsible repo groups.
 	if jobN := len(items) - promptN; jobN > 0 {
 		rows = append(rows, staticRow(0, "Blocked & failed jobs ("+strconv.Itoa(jobN)+")"))
+		repoCount := map[string]int{} // per-repo job count for the header ("×N")
+		for i := promptN; i < len(items); i++ {
+			repoCount[attentionRepoLabel(items[i].job.Repo)]++
+		}
 		curRepo := "\x00" // sentinel so the first repo header always prints
 		repoKey := ""
 		for i := promptN; i < len(items); i++ {
@@ -253,7 +250,7 @@ func (m Model) attentionListRows() []listRow {
 			if label := attentionRepoLabel(j.Repo); label != curRepo {
 				curRepo = label
 				repoKey = "attn:jobrepo:" + label
-				rows = append(rows, headerRow(repoKey, 1, label))
+				rows = append(rows, headerRow(repoKey, 1, label+"  ×"+strconv.Itoa(repoCount[label])))
 			}
 			line := "job " + j.ID + "  " + j.Type + "  " + jobStateColor(j.State)
 			if j.LatestEvent != "" {
@@ -317,7 +314,9 @@ func (m Model) attentionContent() string {
 
 	// When only non-actionable context (locks) is present, say so explicitly so
 	// the page does not read as if those locks need an answer.
-	actionable := len(m.attentionItems())
+	items := m.attentionItems()
+	actionable := len(items)
+	hasJobs := actionable-countPrompts(items) > 0 // every attention job is reportable
 	rows := m.attentionVisibleRows()
 	if actionable == 0 && len(rows) > 0 {
 		b.WriteString(headerStyle.Render("Needs attention") + "\n" + mutedStyle.Render("none") + "\n\n")
@@ -326,9 +325,11 @@ func (m Model) attentionContent() string {
 	if len(rows) > 0 {
 		renderListRows(&b, rows, m.promptCursor)
 		if actionable > 0 {
-			help := "↑/↓ move · space open/close repo   prompts: a answer · d dismiss   jobs: enter detail · R retry"
-			if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
-				help += " · B report bug"
+			// Job actions are shown whenever jobs exist (not only when the cursor is
+			// on one), since groups start folded and the cursor may rest on a header.
+			help := "↑/↓ move · space open/close repo   prompts: a answer · d dismiss"
+			if hasJobs {
+				help += "   jobs: enter detail · R retry · B report bug"
 			}
 			b.WriteString("\n" + mutedStyle.Render(help) + "\n")
 		}

--- a/internal/cli/tui/attention_test.go
+++ b/internal/cli/tui/attention_test.go
@@ -334,3 +334,36 @@ func TestAttentionGroupsJobsByRepo(t *testing.T) {
 		}
 	}
 }
+
+// TestAttentionCollapseJobRepo verifies a job repo group folds with space and
+// re-expands, while prompts and other repos stay put.
+func TestAttentionCollapseJobRepo(t *testing.T) {
+	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		JobRows: []JobRow{
+			{ID: "j1", Type: "ask", State: "failed", Repo: "o/alpha"},
+			{ID: "j2", Type: "ask", State: "blocked", Repo: "o/beta"},
+		},
+	}
+	m := attentionModel(t, deps, snap)
+	// Cursor 0 = j1 (o/alpha). Space folds o/alpha.
+	next, _ := m.Update(key(" "))
+	m = next.(Model)
+	view := m.View()
+	if strings.Contains(view, "j1") {
+		t.Fatalf("j1 should be hidden after folding o/alpha:\n%s", view)
+	}
+	if !strings.Contains(view, "[+]") {
+		t.Fatalf("folded repo should show a [+] marker:\n%s", view)
+	}
+	if !strings.Contains(view, "j2") {
+		t.Fatalf("o/beta job should still be visible:\n%s", view)
+	}
+	// Space on the collapsed header re-expands it.
+	next, _ = m.Update(key(" "))
+	m = next.(Model)
+	if !strings.Contains(m.View(), "j1") {
+		t.Fatalf("expanding o/alpha should restore j1:\n%s", m.View())
+	}
+}

--- a/internal/cli/tui/attention_test.go
+++ b/internal/cli/tui/attention_test.go
@@ -295,3 +295,42 @@ func TestAttentionCursorClampedOnRefresh(t *testing.T) {
 		t.Fatalf("empty attention page expected:\n%s", m.View())
 	}
 }
+
+// TestAttentionGroupsJobsByRepo verifies the blocked/failed jobs render under
+// repo sub-headers, with same-repo jobs contiguous, and the cursor walking them
+// in that display order.
+func TestAttentionGroupsJobsByRepo(t *testing.T) {
+	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		JobRows: []JobRow{
+			{ID: "j1", Type: "ask", State: "failed", Repo: "o/alpha"},
+			{ID: "j2", Type: "ask", State: "blocked", Repo: "o/beta"},
+			{ID: "j3", Type: "ask", State: "failed", Repo: "o/alpha"},
+		},
+	}
+	m := attentionModel(t, deps, snap)
+	view := m.View()
+	for _, want := range []string{"Blocked & failed jobs (3)", "o/alpha", "o/beta", "j1", "j2", "j3"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("attention view missing %q:\n%s", want, view)
+		}
+	}
+	// alpha is first-seen so its jobs (j1, j3) are contiguous and precede beta's j2.
+	i1, i3, i2 := strings.Index(view, "j1"), strings.Index(view, "j3"), strings.Index(view, "j2")
+	if !(i1 < i3 && i3 < i2) {
+		t.Fatalf("jobs not grouped by repo (want j1<j3<j2): j1=%d j3=%d j2=%d\n%s", i1, i3, i2, view)
+	}
+	// Cursor walks the repo-grouped order: 0=j1, 1=j3, 2=j2.
+	wants := []string{"j1", "j3", "j2"}
+	for i, want := range wants {
+		got, ok := m.jobUnderCursor()
+		if !ok || got.ID != want {
+			t.Fatalf("cursor %d should select %q, got %q ok=%v", i, want, got.ID, ok)
+		}
+		if i < len(wants)-1 {
+			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+			m = next.(Model)
+		}
+	}
+}

--- a/internal/cli/tui/collapse.go
+++ b/internal/cli/tui/collapse.go
@@ -1,0 +1,158 @@
+package tui
+
+import "strings"
+
+// listRow is one row of a collapsible grouped list (Attention, Trains). Rows
+// come in three kinds:
+//
+//   - leaf: a selectable item. itemIdx indexes the page's ordered-items slice so
+//     actions resolve to the right item; groupKey names the collapsible group it
+//     belongs to (empty if none), so collapsing from a leaf knows what to fold.
+//   - header: a collapsible group title (e.g. a repo). It is a cursor stop ONLY
+//     when collapsed (so it can be re-expanded); when expanded it is display-only
+//     and the cursor flows straight to its items.
+//   - static: a display-only line (a section title, a lineage parent, a lock).
+//     Never a cursor stop.
+//
+// Keeping the cursor on items (plus collapsed headers) means the common,
+// all-expanded view navigates item→item exactly as an ungrouped list would.
+type listRow struct {
+	header   bool
+	static   bool
+	key      string // header: stable collapse key
+	groupKey string // leaf: the collapse key of its group (space folds it)
+	depth    int
+	text     string // rendered content (no indent / cursor marker)
+	itemIdx  int    // leaf: index into the page's ordered items; -1 otherwise
+
+	collapsed bool // header: current collapse state, stamped by visibleListRows
+}
+
+func staticRow(depth int, text string) listRow {
+	return listRow{static: true, depth: depth, text: text, itemIdx: -1}
+}
+
+func headerRow(key string, depth int, text string) listRow {
+	return listRow{header: true, key: key, depth: depth, text: text, itemIdx: -1}
+}
+
+func leafRow(depth int, text string, itemIdx int, groupKey string) listRow {
+	return listRow{depth: depth, text: text, itemIdx: itemIdx, groupKey: groupKey}
+}
+
+// selectable reports whether the cursor can land on this row: leaves always, and
+// headers only while collapsed (so a folded group can be reopened). Static rows
+// and expanded headers are display-only.
+func (r listRow) selectable() bool {
+	if r.header {
+		return r.collapsed
+	}
+	return !r.static
+}
+
+// visibleListRows returns the rows visible given the collapsed set: a row is
+// hidden when an ancestor header (a shallower header before it) is collapsed.
+// Header rows stay visible and are stamped with their collapse state.
+func visibleListRows(rows []listRow, collapsed map[string]bool) []listRow {
+	out := make([]listRow, 0, len(rows))
+	hideDepth := -1 // when >=0, hide rows deeper than this until we return to it
+	for _, r := range rows {
+		if hideDepth >= 0 {
+			if r.depth > hideDepth {
+				continue
+			}
+			hideDepth = -1
+		}
+		if r.header {
+			r.collapsed = collapsed[r.key]
+		}
+		out = append(out, r)
+		if r.header && collapsed[r.key] {
+			hideDepth = r.depth
+		}
+	}
+	return out
+}
+
+// selectableCount is how many of the visible rows the cursor can land on.
+func selectableCount(rows []listRow) int {
+	n := 0
+	for _, r := range rows {
+		if r.selectable() {
+			n++
+		}
+	}
+	return n
+}
+
+// selectableRowAt returns the cursor-th selectable row among the visible rows.
+func selectableRowAt(rows []listRow, cursor int) (listRow, bool) {
+	if cursor < 0 {
+		return listRow{}, false
+	}
+	n := 0
+	for _, r := range rows {
+		if !r.selectable() {
+			continue
+		}
+		if n == cursor {
+			return r, true
+		}
+		n++
+	}
+	return listRow{}, false
+}
+
+// selectedItemIndex returns the page-items index of the leaf under the cursor,
+// or -1 when the cursor is on a (collapsed) header or out of range.
+func selectedItemIndex(rows []listRow, cursor int) int {
+	r, ok := selectableRowAt(rows, cursor)
+	if !ok || r.header {
+		return -1
+	}
+	return r.itemIdx
+}
+
+// renderListRows writes the visible rows into b. cursor is the index among the
+// SELECTABLE rows of the highlighted row. Headers show a [-]/[+] collapse marker;
+// the selected row gets the "▸ " cursor marker. Indent follows depth.
+func renderListRows(b *strings.Builder, rows []listRow, cursor int) {
+	sel := 0
+	for _, r := range rows {
+		indent := strings.Repeat("  ", r.depth)
+		selected := r.selectable() && sel == cursor
+		marker := "  "
+		if selected {
+			marker = "▸ "
+		}
+		switch {
+		case r.header:
+			collapseMark := "[-] "
+			if r.collapsed {
+				collapseMark = "[+] "
+			}
+			label := r.text
+			if !selected {
+				if r.depth == 0 {
+					label = headerStyle.Render(label)
+				} else {
+					label = mutedStyle.Render(label)
+				}
+			}
+			b.WriteString(indent + marker + collapseMark + label + "\n")
+		case r.static:
+			label := r.text
+			if r.depth == 0 {
+				label = headerStyle.Render(label)
+			} else {
+				label = mutedStyle.Render(label)
+			}
+			b.WriteString(indent + "  " + label + "\n")
+		default:
+			b.WriteString(indent + marker + r.text + "\n")
+		}
+		if r.selectable() {
+			sel++
+		}
+	}
+}

--- a/internal/cli/tui/collapse.go
+++ b/internal/cli/tui/collapse.go
@@ -136,12 +136,13 @@ func renderListRows(b *strings.Builder, rows []listRow, cursor int) {
 				collapseMark = "[+] "
 			}
 			label := r.text
-			if !selected {
-				if r.depth == 0 {
-					label = headerStyle.Render(label)
-				} else {
-					label = mutedStyle.Render(label)
-				}
+			switch {
+			case selected:
+				label = selectedRowStyle.Render(label)
+			case r.depth == 0:
+				label = headerStyle.Render(label)
+			default:
+				label = mutedStyle.Render(label)
 			}
 			b.WriteString(indent + marker + collapseMark + label + "\n")
 		case r.static:
@@ -153,7 +154,11 @@ func renderListRows(b *strings.Builder, rows []listRow, cursor int) {
 			}
 			b.WriteString(indent + "  " + label + "\n")
 		default:
-			b.WriteString(indent + marker + r.text + "\n")
+			text := r.text
+			if selected {
+				text = selectedRowStyle.Render(text)
+			}
+			b.WriteString(indent + marker + text + "\n")
 		}
 		if r.selectable() {
 			sel++

--- a/internal/cli/tui/collapse.go
+++ b/internal/cli/tui/collapse.go
@@ -50,10 +50,12 @@ func (r listRow) selectable() bool {
 	return !r.static
 }
 
-// visibleListRows returns the rows visible given the collapsed set: a row is
-// hidden when an ancestor header (a shallower header before it) is collapsed.
+// visibleListRows returns the rows visible given the collapse predicate: a row
+// is hidden when an ancestor header (a shallower header before it) is collapsed.
 // Header rows stay visible and are stamped with their collapse state.
-func visibleListRows(rows []listRow, collapsed map[string]bool) []listRow {
+// isCollapsed(key) decides each header's state — groups are collapsed by default,
+// so it returns true unless the user has explicitly expanded the group.
+func visibleListRows(rows []listRow, isCollapsed func(key string) bool) []listRow {
 	out := make([]listRow, 0, len(rows))
 	hideDepth := -1 // when >=0, hide rows deeper than this until we return to it
 	for _, r := range rows {
@@ -63,11 +65,13 @@ func visibleListRows(rows []listRow, collapsed map[string]bool) []listRow {
 			}
 			hideDepth = -1
 		}
+		collapsed := false
 		if r.header {
-			r.collapsed = collapsed[r.key]
+			collapsed = isCollapsed(r.key)
+			r.collapsed = collapsed
 		}
 		out = append(out, r)
-		if r.header && collapsed[r.key] {
+		if collapsed {
 			hideDepth = r.depth
 		}
 	}

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -149,7 +149,9 @@ type Jobs struct {
 }
 
 // JobRow is one job the Jobs page can act on. LatestEvent is filled for
-// blocked/failed jobs (the "why" shown in the attention list).
+// blocked/failed jobs (the "why" shown in the attention list). Repo is filled
+// for reportable (blocked/failed/cancelled) jobs so the Attention page can group
+// them by repository.
 type JobRow struct {
 	ID          string
 	Agent       string
@@ -157,6 +159,7 @@ type JobRow struct {
 	State       string
 	UpdatedAt   string
 	LatestEvent string
+	Repo        string
 }
 
 // JobDetail is the job's parsed payload, loaded lazily when its detail opens

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -248,6 +248,11 @@ type Deps struct {
 	Dismiss  func(id string) error
 	Interval time.Duration
 
+	// CollapseGroupsByDefault folds collapsible repo groups (Attention / Trains)
+	// on first show, so the live dashboard opens uncluttered; the user expands
+	// what they want with space. Tests leave it false (groups start expanded).
+	CollapseGroupsByDefault bool
+
 	// OpenTrain, when set, builds the embedded train-run model for a session;
 	// the Trains page pushes it onto the Root stack instead of the inline
 	// detail view.

--- a/internal/cli/tui/dismiss_train_test.go
+++ b/internal/cli/tui/dismiss_train_test.go
@@ -354,3 +354,41 @@ func TestTrainsGroupByRepoWithinSection(t *testing.T) {
 		t.Fatalf("cursor 0 should select a-v1, got %q", got.ID)
 	}
 }
+
+// TestTrainsCollapseRepoFoldsSessions verifies space folds the cursor's repo
+// group (hiding its sessions and showing a [+] header) and that the collapsed
+// header is selectable so space re-expands it.
+func TestTrainsCollapseRepoFoldsSessions(t *testing.T) {
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		Trains: []TrainSession{
+			{ID: "a1", Phase: "items_ready", Repo: "o/alpha"},
+			{ID: "b1", Phase: "items_ready", Repo: "o/beta"},
+		},
+	}
+	deps := Deps{Load: func() (Snapshot, error) { return snap, nil }}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // → Trains
+	m = next.(Model)
+	// Cursor 0 = a1 (o/alpha). Space folds o/alpha.
+	next, _ = m.Update(key(" "))
+	m = next.(Model)
+	view := m.View()
+	if strings.Contains(view, "a1") {
+		t.Fatalf("a1 should be hidden after folding o/alpha:\n%s", view)
+	}
+	if !strings.Contains(view, "[+]") {
+		t.Fatalf("folded repo should show a [+] marker:\n%s", view)
+	}
+	if !strings.Contains(view, "b1") {
+		t.Fatalf("o/beta should still be visible:\n%s", view)
+	}
+	// Cursor now sits on the collapsed o/alpha header; space re-expands it.
+	next, _ = m.Update(key(" "))
+	m = next.(Model)
+	if !strings.Contains(m.View(), "a1") {
+		t.Fatalf("expanding o/alpha should restore a1:\n%s", m.View())
+	}
+}

--- a/internal/cli/tui/dismiss_train_test.go
+++ b/internal/cli/tui/dismiss_train_test.go
@@ -218,7 +218,7 @@ func TestTrainLineageBase(t *testing.T) {
 		{"officeqa-treasury-skillopt-v1", "officeqa-treasury-skillopt", true},
 		{"officeqa-treasury-skillopt-v8", "officeqa-treasury-skillopt", true},
 		{"run-v12", "run", true},
-		{"run-12", "run-12", false},     // bare numeric is NOT a version lineage
+		{"run-12", "run-12", false},                         // bare numeric is NOT a version lineage
 		{"train-x-20260611-1", "train-x-20260611-1", false}, // timestamp tail, not a version
 		{"plain-name", "plain-name", false},
 		{"train-aaa", "train-aaa", false},
@@ -327,9 +327,9 @@ func TestTrainsGroupByRepoWithinSection(t *testing.T) {
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
 		Trains: []TrainSession{
-			{ID: "a-v1", Phase: "items_ready", Repo: "o/alpha"},        // Active, alpha, lineage
-			{ID: "b1", Phase: "generating_options", Repo: "o/beta"},    // Active, beta, lone
-			{ID: "a-v2", Phase: "review_published", Repo: "o/alpha"},   // Active, alpha, lineage
+			{ID: "a-v1", Phase: "items_ready", Repo: "o/alpha"},      // Active, alpha, lineage
+			{ID: "b1", Phase: "generating_options", Repo: "o/beta"},  // Active, beta, lone
+			{ID: "a-v2", Phase: "review_published", Repo: "o/alpha"}, // Active, alpha, lineage
 		},
 	}
 	deps := Deps{Load: func() (Snapshot, error) { return snap, nil }}

--- a/internal/cli/tui/dismiss_train_test.go
+++ b/internal/cli/tui/dismiss_train_test.go
@@ -315,3 +315,42 @@ func TestTrainCursorFollowsDisplayOrder(t *testing.T) {
 		t.Fatalf("cursor 1 should select the next visible row (done-early), got %q", got.ID)
 	}
 }
+
+// TestTrainsGroupByRepoWithinSection verifies that within a status section,
+// sessions are sub-grouped by repo (first-appearance order) with lineage
+// collapse inside each repo, and the cursor follows that display order.
+func TestTrainsGroupByRepoWithinSection(t *testing.T) {
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		Trains: []TrainSession{
+			{ID: "a-v1", Phase: "items_ready", Repo: "o/alpha"},        // Active, alpha, lineage
+			{ID: "b1", Phase: "generating_options", Repo: "o/beta"},    // Active, beta, lone
+			{ID: "a-v2", Phase: "review_published", Repo: "o/alpha"},   // Active, alpha, lineage
+		},
+	}
+	deps := Deps{Load: func() (Snapshot, error) { return snap, nil }}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // Attention → Trains
+	m = next.(Model)
+	view := m.View()
+	for _, want := range []string{"Active", "o/alpha", "o/beta", "a-v1", "a-v2", "b1"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("trains view missing %q:\n%s", want, view)
+		}
+	}
+	// Repos in first-appearance order: alpha before beta.
+	if strings.Index(view, "o/alpha") > strings.Index(view, "o/beta") {
+		t.Fatalf("repos out of order (alpha before beta):\n%s", view)
+	}
+	// alpha's lineage collapses; its members precede beta's session.
+	v1, v2, b := strings.Index(view, "a-v1"), strings.Index(view, "a-v2"), strings.Index(view, "b1")
+	if !(v1 < v2 && v2 < b) {
+		t.Fatalf("repo/lineage order wrong (want a-v1<a-v2<b1): %d %d %d\n%s", v1, v2, b, view)
+	}
+	// Cursor 0 selects the first display row (a-v1 under alpha).
+	if got, _ := m.trainUnderCursor(); got.ID != "a-v1" {
+		t.Fatalf("cursor 0 should select a-v1, got %q", got.ID)
+	}
+}

--- a/internal/cli/tui/dismiss_train_test.go
+++ b/internal/cli/tui/dismiss_train_test.go
@@ -392,3 +392,31 @@ func TestTrainsCollapseRepoFoldsSessions(t *testing.T) {
 		t.Fatalf("expanding o/alpha should restore a1:\n%s", m.View())
 	}
 }
+
+// TestTrainsCollapsedByDefault verifies the live default (CollapseGroupsByDefault)
+// folds repo groups on first show, and space on a [+] header expands one.
+func TestTrainsCollapsedByDefault(t *testing.T) {
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		Trains: []TrainSession{{ID: "s1", Phase: "items_ready", Repo: "o/alpha"}},
+	}
+	deps := Deps{Load: func() (Snapshot, error) { return snap, nil }, CollapseGroupsByDefault: true}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // → Trains
+	m = next.(Model)
+	view := m.View()
+	if strings.Contains(view, "s1") {
+		t.Fatalf("sessions should be folded by default:\n%s", view)
+	}
+	if !strings.Contains(view, "[+]") {
+		t.Fatalf("collapsed repo should show a [+] marker:\n%s", view)
+	}
+	// Space on the collapsed repo header expands it.
+	next, _ = m.Update(key(" "))
+	m = next.(Model)
+	if !strings.Contains(m.View(), "s1") {
+		t.Fatalf("space should expand the repo and reveal s1:\n%s", m.View())
+	}
+}

--- a/internal/cli/tui/dismiss_train_test.go
+++ b/internal/cli/tui/dismiss_train_test.go
@@ -259,11 +259,15 @@ func TestTrainsListGroupsAndCollapses(t *testing.T) {
 			t.Fatalf("expected section header %q:\n%s", want, view)
 		}
 	}
-	// Two skillopt-v* sessions collapse under one lineage parent line.
-	if !strings.Contains(view, "skillopt  ") || !strings.Contains(view, "×2") {
-		t.Fatalf("expected collapsed lineage parent 'skillopt ×2':\n%s", view)
+	// Repo is the only group: the repo header carries the count, and there is NO
+	// separate lineage sub-group line (e.g. "skillopt  ×2") inside it.
+	if !strings.Contains(view, "o/r") {
+		t.Fatalf("expected the repo group header:\n%s", view)
 	}
-	// All individual session ids still render (children + flat rows).
+	if strings.Contains(view, "skillopt  ×") {
+		t.Fatalf("lineage sub-group line should be gone (only the repo group remains):\n%s", view)
+	}
+	// All individual session ids still render directly under the repo.
 	for _, id := range []string{"skillopt-v1", "skillopt-v2", "lonely", "stalled", "gone"} {
 		if !strings.Contains(view, id) {
 			t.Fatalf("expected session %q in view:\n%s", id, view)

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -60,9 +60,13 @@ func (m Model) jobUnderCursor() (JobRow, bool) {
 		}
 		return m.snap.JobRows[m.jobCursor], true
 	case pageAttention:
+		idx := selectedItemIndex(m.attentionVisibleRows(), m.promptCursor)
+		if idx < 0 {
+			return JobRow{}, false
+		}
 		items := m.attentionItems()
-		if m.promptCursor < len(items) && items[m.promptCursor].job != nil {
-			return *items[m.promptCursor].job, true
+		if idx < len(items) && items[idx].job != nil {
+			return *items[idx].job, true
 		}
 	}
 	return JobRow{}, false

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -86,6 +86,11 @@ type Model struct {
 	loadErr  string
 	inFlight bool
 
+	// collapsed tracks which collapsible group headers (Attention / Trains /
+	// Jobs) are collapsed, keyed by a stable page-qualified group key. An absent
+	// key means expanded. It persists across refresh ticks for the session.
+	collapsed map[string]bool
+
 	// Attention / Trains page interaction state.
 	mode         mode
 	promptCursor int                  // selected row in snap.Prompts on the Attention page
@@ -175,6 +180,7 @@ func New(deps Deps) Model {
 		viewport:   viewport.New(80, 20),
 		inFlight:   true,
 		cancelling: map[string]struct{}{},
+		collapsed:  map[string]bool{},
 	}
 	m.resizeViewport()
 	m.viewport.SetContent(m.content())
@@ -294,6 +300,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
+		case " ":
+			// Toggle a collapsible group header (Attention / Trains).
+			if m.toggleCurrentGroup() {
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
 		case "a":
 			if pages[m.selected].page == pageAttention {
 				if cmd := m.openAnswer(); cmd != nil {
@@ -314,6 +326,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 			}
 		case "enter":
+			// On a collapsible page, enter on a group header toggles it (so the
+			// header is a usable target without leaving the keyboard home keys).
+			if m.cursorOnHeader() {
+				m.toggleCurrentGroup()
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
 			if pages[m.selected].page == pageConfig {
 				fields := m.configEditableFields()
 				if m.deps.SetConfigScalar != nil && m.configCursor < len(fields) {
@@ -328,12 +347,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// inline detail (keeps the model usable standalone and old tests
 				// green). Pushing is suppressed while an optimize start is in
 				// flight: its result message routes to the top of the stack, so a
-				// covering view would swallow it.
-				if m.deps.OpenTrain != nil && len(m.snap.Trains) > 0 && !m.optimizeBusy {
-					session := m.snap.Trains[m.trainCursor].ID
-					return m, Push(m.deps.OpenTrain(session))
+				// covering view would swallow it. Resolve the session through the
+				// cursor (display order), not raw snapshot order.
+				if t, ok := m.trainUnderCursor(); ok {
+					if m.deps.OpenTrain != nil && !m.optimizeBusy {
+						return m, Push(m.deps.OpenTrain(t.ID))
+					}
+					m.openTrainDetail()
 				}
-				m.openTrainDetail()
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}
@@ -925,9 +946,9 @@ func (m Model) healthRequiredFailed() bool {
 func (m *Model) pageCursor() (*int, int) {
 	switch pages[m.selected].page {
 	case pageAttention:
-		return &m.promptCursor, len(m.attentionItems())
+		return &m.promptCursor, selectableCount(m.attentionVisibleRows())
 	case pageTrains:
-		return &m.trainCursor, len(m.snap.Trains)
+		return &m.trainCursor, selectableCount(m.trainVisibleRows())
 	case pageAgents:
 		return &m.agentCursor, len(m.visibleAgents())
 	case pageSessions:
@@ -951,15 +972,72 @@ func clampCursor(cursor, n int) int {
 	return cursor
 }
 
-// clampPromptCursor keeps the Attention cursor within the current item list
-// (prompts plus blocked/failed jobs) after a refresh removes rows.
+// clampPromptCursor keeps the Attention cursor within the current selectable
+// rows (prompt/job leaves plus collapsed repo headers) after a refresh/collapse.
 func (m *Model) clampPromptCursor() {
-	m.promptCursor = clampCursor(m.promptCursor, len(m.attentionItems()))
+	m.promptCursor = clampCursor(m.promptCursor, selectableCount(m.attentionVisibleRows()))
 }
 
-// clampTrainCursor keeps the Trains cursor within the current session list.
+// clampTrainCursor keeps the Trains cursor within the current selectable rows.
 func (m *Model) clampTrainCursor() {
-	m.trainCursor = clampCursor(m.trainCursor, len(m.snap.Trains))
+	m.trainCursor = clampCursor(m.trainCursor, selectableCount(m.trainVisibleRows()))
+}
+
+// currentListRows returns the visible collapsible rows for the current page, if
+// it is a collapsible-list page (Attention or Trains).
+func (m Model) currentListRows() ([]listRow, bool) {
+	switch pages[m.selected].page {
+	case pageAttention:
+		return m.attentionVisibleRows(), true
+	case pageTrains:
+		return m.trainVisibleRows(), true
+	}
+	return nil, false
+}
+
+// selectedListRow returns the row under the current page's cursor (among the
+// selectable rows), if the page is a collapsible list.
+func (m Model) selectedListRow() (listRow, bool) {
+	rows, ok := m.currentListRows()
+	if !ok {
+		return listRow{}, false
+	}
+	cursor, _ := m.pageCursor()
+	if cursor == nil {
+		return listRow{}, false
+	}
+	return selectableRowAt(rows, *cursor)
+}
+
+// cursorOnHeader reports whether the cursor sits on a collapsed group header
+// (the only kind of header the cursor can land on).
+func (m Model) cursorOnHeader() bool {
+	r, ok := m.selectedListRow()
+	return ok && r.header
+}
+
+// toggleCurrentGroup folds or unfolds a repo group: on a collapsed header it
+// expands; on a leaf it collapses that leaf's group. Returns true when it
+// changed something (the caller re-renders and suppresses any leaf action).
+func (m *Model) toggleCurrentGroup() bool {
+	r, ok := m.selectedListRow()
+	if !ok {
+		return false
+	}
+	if m.collapsed == nil {
+		m.collapsed = map[string]bool{}
+	}
+	switch {
+	case r.header && r.collapsed:
+		m.collapsed[r.key] = false
+	case !r.header && r.groupKey != "":
+		m.collapsed[r.groupKey] = true
+	default:
+		return false
+	}
+	m.clampPromptCursor()
+	m.clampTrainCursor()
+	return true
 }
 
 // clampJobCursor keeps the Jobs cursor within the current job list.

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -86,10 +86,13 @@ type Model struct {
 	loadErr  string
 	inFlight bool
 
-	// collapsed tracks which collapsible group headers (Attention / Trains /
-	// Jobs) are collapsed, keyed by a stable page-qualified group key. An absent
-	// key means expanded. It persists across refresh ticks for the session.
-	collapsed map[string]bool
+	// expanded records explicit user open(true)/close(false) decisions for
+	// collapsible group headers (Attention / Trains), keyed by a stable
+	// page-qualified group key; it overrides collapseByDefault and persists across
+	// refresh ticks. collapseByDefault is the state for groups the user has not
+	// touched — the live dashboard sets it true so groups start folded.
+	expanded         map[string]bool
+	collapseByDefault bool
 
 	// Attention / Trains page interaction state.
 	mode         mode
@@ -179,8 +182,9 @@ func New(deps Deps) Model {
 		height:     30,
 		viewport:   viewport.New(80, 20),
 		inFlight:   true,
-		cancelling: map[string]struct{}{},
-		collapsed:  map[string]bool{},
+		cancelling:        map[string]struct{}{},
+		expanded:          map[string]bool{},
+		collapseByDefault: deps.CollapseGroupsByDefault,
 	}
 	m.resizeViewport()
 	m.viewport.SetContent(m.content())
@@ -1016,22 +1020,35 @@ func (m Model) cursorOnHeader() bool {
 	return ok && r.header
 }
 
-// toggleCurrentGroup folds or unfolds a repo group: on a collapsed header it
-// expands; on a leaf it collapses that leaf's group. Returns true when it
-// changed something (the caller re-renders and suppresses any leaf action).
+// groupCollapsed reports whether a group is collapsed. An explicit user
+// open/close (stored in m.expanded) wins; otherwise the page default applies
+// (collapseByDefault — the live dashboard starts groups folded to reduce
+// clutter, while tests default to expanded).
+func (m Model) groupCollapsed(key string) bool {
+	if v, ok := m.expanded[key]; ok {
+		return !v
+	}
+	return m.collapseByDefault
+}
+
+// toggleCurrentGroup opens or closes a repo group: on a collapsed header it
+// expands; on a leaf it collapses that leaf's group. The state is stored
+// explicitly (not as a delete), so it holds regardless of the default. Since the
+// cursor stays in place, pressing space on a just-opened group's first row
+// closes it again. Returns true when it changed something.
 func (m *Model) toggleCurrentGroup() bool {
 	r, ok := m.selectedListRow()
 	if !ok {
 		return false
 	}
-	if m.collapsed == nil {
-		m.collapsed = map[string]bool{}
+	if m.expanded == nil {
+		m.expanded = map[string]bool{}
 	}
 	switch {
 	case r.header && r.collapsed:
-		m.collapsed[r.key] = false
+		m.expanded[r.key] = true
 	case !r.header && r.groupKey != "":
-		m.collapsed[r.groupKey] = true
+		m.expanded[r.groupKey] = false
 	default:
 		return false
 	}

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -87,11 +87,13 @@ type Model struct {
 	inFlight bool
 
 	// expanded records explicit user open(true)/close(false) decisions for
-	// collapsible group headers (Attention / Trains), keyed by a stable
-	// page-qualified group key; it overrides collapseByDefault and persists across
-	// refresh ticks. collapseByDefault is the state for groups the user has not
-	// touched — the live dashboard sets it true so groups start folded.
-	expanded         map[string]bool
+	// collapsible group headers (Attention / Trains), keyed by a page-qualified
+	// group key; it overrides collapseByDefault and persists across refresh ticks
+	// while the key is stable (a Trains group's key includes its status section,
+	// so a session changing section moves to that section's group). collapseByDefault
+	// is the state for groups the user has not touched — the live dashboard sets it
+	// true so groups start folded.
+	expanded          map[string]bool
 	collapseByDefault bool
 
 	// Attention / Trains page interaction state.
@@ -177,11 +179,11 @@ type Model struct {
 // Init issues the first Load and arms the refresh tick.
 func New(deps Deps) Model {
 	m := Model{
-		deps:       deps,
-		width:      100,
-		height:     30,
-		viewport:   viewport.New(80, 20),
-		inFlight:   true,
+		deps:              deps,
+		width:             100,
+		height:            30,
+		viewport:          viewport.New(80, 20),
+		inFlight:          true,
 		cancelling:        map[string]struct{}{},
 		expanded:          map[string]bool{},
 		collapseByDefault: deps.CollapseGroupsByDefault,
@@ -1049,12 +1051,40 @@ func (m *Model) toggleCurrentGroup() bool {
 		m.expanded[r.key] = true
 	case !r.header && r.groupKey != "":
 		m.expanded[r.groupKey] = false
+		// Folding from a leaf removes that leaf (and its siblings) from the
+		// selectable set; move the cursor onto the now-collapsed header so the
+		// highlight follows the group instead of clamping onto an unrelated row.
+		m.focusHeader(r.groupKey)
 	default:
 		return false
 	}
 	m.clampPromptCursor()
 	m.clampTrainCursor()
 	return true
+}
+
+// focusHeader points the current page's cursor at the selectable header whose
+// group key matches, after that group was just collapsed.
+func (m *Model) focusHeader(key string) {
+	rows, ok := m.currentListRows()
+	if !ok {
+		return
+	}
+	cursor, _ := m.pageCursor()
+	if cursor == nil {
+		return
+	}
+	sel := 0
+	for _, row := range rows {
+		if !row.selectable() {
+			continue
+		}
+		if row.header && row.key == key {
+			*cursor = sel
+			return
+		}
+		sel++
+	}
 }
 
 // clampJobCursor keeps the Jobs cursor within the current job list.

--- a/internal/cli/tui/trains.go
+++ b/internal/cli/tui/trains.go
@@ -18,18 +18,19 @@ func (m *Model) openTrainDetail() {
 	}
 }
 
-// trainUnderCursor returns the session under the Trains cursor, if any. The
-// cursor indexes the display-ordered list (orderedTrains), not raw snapshot
-// order, so it resolves to the row the user sees highlighted.
+// trainUnderCursor returns the session under the Trains cursor, if the cursor is
+// on a session row (not a collapsible header). The cursor indexes the visible
+// rows; a leaf resolves through its itemIdx into orderedTrains().
 func (m Model) trainUnderCursor() (TrainSession, bool) {
 	if pages[m.selected].page != pageTrains {
 		return TrainSession{}, false
 	}
+	idx := selectedItemIndex(m.trainVisibleRows(), m.trainCursor)
 	ordered := m.orderedTrains()
-	if m.trainCursor < 0 || m.trainCursor >= len(ordered) {
+	if idx < 0 || idx >= len(ordered) {
 		return TrainSession{}, false
 	}
-	return ordered[m.trainCursor], true
+	return ordered[idx], true
 }
 
 // openTrainStop enters the stop-reason overlay for a live session.
@@ -391,6 +392,56 @@ func (m Model) orderedTrains() []TrainSession {
 	return out
 }
 
+// trainRowContent is the per-session row text (id + phase, dimmed when the run
+// is terminal) used as the leaf content in the collapsible Trains list.
+func trainRowContent(t TrainSession) string {
+	phase := t.Phase
+	if deadTrainPhase(t.Phase) {
+		phase = mutedStyle.Render(t.Phase)
+	}
+	return t.ID + "  " + phase
+}
+
+// trainListRows builds the Trains page's collapsible row tree:
+// status section (Active/Blocked/Done) → repo → lineage → session. Leaf itemIdx
+// indexes orderedTrains() (built in the same order), so the cursor resolves to
+// the right session.
+func (m Model) trainListRows() []listRow {
+	var rows []listRow
+	idx := 0
+	for _, cat := range []int{trainCatActive, trainCatBlocked, trainCatDone} {
+		repos := m.trainSectionRepos(cat)
+		if len(repos) == 0 {
+			continue
+		}
+		title := trainSectionTitles[cat]
+		rows = append(rows, staticRow(0, title)) // status section: display-only
+		for _, rb := range repos {
+			repoKey := "trains:" + title + ":" + rb.repo
+			rows = append(rows, headerRow(repoKey, 1, rb.repo+"  ×"+strconv.Itoa(bucketMemberCount(rb))))
+			for _, g := range rb.groups {
+				if len(g.members) > 1 {
+					rows = append(rows, staticRow(2, g.base+"  ×"+strconv.Itoa(len(g.members)))) // lineage: display-only
+					for _, t := range g.members {
+						rows = append(rows, leafRow(3, trainRowContent(t), idx, repoKey))
+						idx++
+					}
+					continue
+				}
+				rows = append(rows, leafRow(2, trainRowContent(g.members[0]), idx, repoKey))
+				idx++
+			}
+		}
+	}
+	return rows
+}
+
+// trainVisibleRows is the Trains tree filtered by the collapse state — the rows
+// rendered, and the index space m.trainCursor walks.
+func (m Model) trainVisibleRows() []listRow {
+	return visibleListRows(m.trainListRows(), m.collapsed)
+}
+
 func (m Model) trainsContent() string {
 	if m.mode == modeTrainDetail {
 		return m.trainDetail()
@@ -399,62 +450,9 @@ func (m Model) trainsContent() string {
 		return m.loadingOr("No train sessions.", !m.loadedAt.IsZero())
 	}
 	var b strings.Builder
-
-	// pos is the display position of the next selectable session row; it must
-	// advance in lockstep with orderedTrains() so the cursor highlights and
-	// selects the same row. Section headers and lineage parents are display-only
-	// and consume no position.
-	pos := 0
-	first := true
-	for _, cat := range []int{trainCatActive, trainCatBlocked, trainCatDone} {
-		repos := m.trainSectionRepos(cat)
-		if len(repos) == 0 {
-			continue
-		}
-		if !first {
-			b.WriteByte('\n')
-		}
-		first = false
-		b.WriteString(headerStyle.Render(trainSectionTitles[cat]))
-		b.WriteByte('\n')
-		for _, rb := range repos {
-			// Repo sub-header (display-only); sessions of this repo follow, with
-			// lineages collapsed beneath it.
-			b.WriteString("  " + rb.repo + "  " + mutedStyle.Render("×"+strconv.Itoa(bucketMemberCount(rb))) + "\n")
-			for _, g := range rb.groups {
-				if len(g.members) > 1 {
-					b.WriteString("    " + g.base + "  " + mutedStyle.Render("×"+strconv.Itoa(len(g.members))) + "\n")
-					for _, t := range g.members {
-						m.writeTrainRow(&b, t, pos == m.trainCursor, "      ")
-						pos++
-					}
-					continue
-				}
-				m.writeTrainRow(&b, g.members[0], pos == m.trainCursor, "    ")
-				pos++
-			}
-		}
-	}
-
-	b.WriteString(mutedStyle.Render("enter open  s stop  d delete"))
-	b.WriteByte('\n')
+	renderListRows(&b, m.trainVisibleRows(), m.trainCursor)
+	b.WriteString("\n" + mutedStyle.Render("↑/↓ move · space fold repo · enter open · s stop · d delete") + "\n")
 	return b.String()
-}
-
-// writeTrainRow renders a single selectable session row at the given indent.
-// selected is true when this row's display position is under the cursor; the
-// cursor row replaces the trailing two spaces of indent with the "▸ " marker so
-// columns stay aligned.
-func (m Model) writeTrainRow(b *strings.Builder, t TrainSession, selected bool, indent string) {
-	phase := t.Phase
-	if deadTrainPhase(t.Phase) {
-		phase = mutedStyle.Render(t.Phase)
-	}
-	if selected {
-		b.WriteString(indent[:len(indent)-2] + "▸ " + selectedRowStyle.Render(t.ID) + "  " + phase + "\n")
-		return
-	}
-	b.WriteString(indent + t.ID + "  " + phase + "\n")
 }
 
 func (m Model) trainDetail() string {

--- a/internal/cli/tui/trains.go
+++ b/internal/cli/tui/trains.go
@@ -439,7 +439,7 @@ func (m Model) trainListRows() []listRow {
 // trainVisibleRows is the Trains tree filtered by the collapse state — the rows
 // rendered, and the index space m.trainCursor walks.
 func (m Model) trainVisibleRows() []listRow {
-	return visibleListRows(m.trainListRows(), m.collapsed)
+	return visibleListRows(m.trainListRows(), m.groupCollapsed)
 }
 
 func (m Model) trainsContent() string {
@@ -451,7 +451,7 @@ func (m Model) trainsContent() string {
 	}
 	var b strings.Builder
 	renderListRows(&b, m.trainVisibleRows(), m.trainCursor)
-	b.WriteString("\n" + mutedStyle.Render("↑/↓ move · space fold repo · enter open · s stop · d delete") + "\n")
+	b.WriteString("\n" + mutedStyle.Render("↑/↓ move · space open/close repo · enter open · s stop · d delete") + "\n")
 	return b.String()
 }
 

--- a/internal/cli/tui/trains.go
+++ b/internal/cli/tui/trains.go
@@ -418,6 +418,10 @@ func (m Model) trainListRows() []listRow {
 		title := trainSectionTitles[cat]
 		rows = append(rows, staticRow(0, title)) // status section: display-only
 		for _, rb := range repos {
+			// Key by (section, repo) so the same repo in two sections folds
+			// independently (matching the two visually separate groups). The fold
+			// state holds while a session's section is stable; if a session changes
+			// section its row moves to that section's group (collapsed by default).
 			repoKey := "trains:" + title + ":" + rb.repo
 			rows = append(rows, headerRow(repoKey, 1, rb.repo+"  ×"+strconv.Itoa(bucketMemberCount(rb))))
 			for _, g := range rb.groups {

--- a/internal/cli/tui/trains.go
+++ b/internal/cli/tui/trains.go
@@ -403,9 +403,10 @@ func trainRowContent(t TrainSession) string {
 }
 
 // trainListRows builds the Trains page's collapsible row tree:
-// status section (Active/Blocked/Done) → repo → lineage → session. Leaf itemIdx
-// indexes orderedTrains() (built in the same order), so the cursor resolves to
-// the right session.
+// status section (Active/Blocked/Done) → repo → session. The repo is the only
+// collapsible group; sessions list directly under it (lineage versions stay
+// contiguous via rb.groups ordering, but without a separate sub-group line).
+// Leaf itemIdx indexes orderedTrains() (built in the same order).
 func (m Model) trainListRows() []listRow {
 	var rows []listRow
 	idx := 0
@@ -420,16 +421,10 @@ func (m Model) trainListRows() []listRow {
 			repoKey := "trains:" + title + ":" + rb.repo
 			rows = append(rows, headerRow(repoKey, 1, rb.repo+"  ×"+strconv.Itoa(bucketMemberCount(rb))))
 			for _, g := range rb.groups {
-				if len(g.members) > 1 {
-					rows = append(rows, staticRow(2, g.base+"  ×"+strconv.Itoa(len(g.members)))) // lineage: display-only
-					for _, t := range g.members {
-						rows = append(rows, leafRow(3, trainRowContent(t), idx, repoKey))
-						idx++
-					}
-					continue
+				for _, t := range g.members {
+					rows = append(rows, leafRow(2, trainRowContent(t), idx, repoKey))
+					idx++
 				}
-				rows = append(rows, leafRow(2, trainRowContent(g.members[0]), idx, repoKey))
-				idx++
 			}
 		}
 	}

--- a/internal/cli/tui/trains.go
+++ b/internal/cli/tui/trains.go
@@ -291,19 +291,26 @@ type trainGroup struct {
 	members []TrainSession
 }
 
-// trainSectionGroups returns the display-ordered groups for one status category.
-// Sessions are taken in snapshot order; a base shared by more than one session
-// in the category collapses into a single group whose members stay contiguous
-// (in snapshot order), emitted at the position of its first member. This keeps
-// every lineage child under its own parent even when members are not adjacent
-// in the snapshot.
-func (m Model) trainSectionGroups(cat int) []trainGroup {
-	var rows []TrainSession
-	for _, t := range m.snap.Trains {
-		if trainStatusCategory(t.Phase) == cat {
-			rows = append(rows, t)
-		}
+// trainRepoBucket is one repository's lineage groups within a status section.
+type trainRepoBucket struct {
+	repo   string
+	groups []trainGroup
+}
+
+// trainRepoLabel is a session's target repo, or "(no repo)" when it has none.
+func trainRepoLabel(repo string) string {
+	if strings.TrimSpace(repo) == "" {
+		return "(no repo)"
 	}
+	return repo
+}
+
+// lineageGroups buckets sessions into display groups: a base shared by more than
+// one session collapses into a single group whose members stay contiguous (in
+// the given order, emitted at the first member's position); everything else is a
+// lone group in place. This keeps every lineage child under its own parent even
+// when members are not adjacent.
+func lineageGroups(rows []TrainSession) []trainGroup {
 	counts := map[string]int{}
 	for _, t := range rows {
 		if base, ok := trainLineageBase(t.ID); ok {
@@ -333,15 +340,52 @@ func (m Model) trainSectionGroups(cat int) []trainGroup {
 	return groups
 }
 
+// trainSectionRepos returns the display-ordered repo buckets for one status
+// category: the category's sessions (snapshot order) bucketed by repo in
+// first-appearance order, each with its lineage groups.
+func (m Model) trainSectionRepos(cat int) []trainRepoBucket {
+	var rows []TrainSession
+	for _, t := range m.snap.Trains {
+		if trainStatusCategory(t.Phase) == cat {
+			rows = append(rows, t)
+		}
+	}
+	order := []string{}
+	byRepo := map[string][]TrainSession{}
+	for _, t := range rows {
+		label := trainRepoLabel(t.Repo)
+		if _, ok := byRepo[label]; !ok {
+			order = append(order, label)
+		}
+		byRepo[label] = append(byRepo[label], t)
+	}
+	out := make([]trainRepoBucket, 0, len(order))
+	for _, label := range order {
+		out = append(out, trainRepoBucket{repo: label, groups: lineageGroups(byRepo[label])})
+	}
+	return out
+}
+
+// bucketMemberCount is the total sessions across a repo bucket's lineage groups.
+func bucketMemberCount(rb trainRepoBucket) int {
+	n := 0
+	for _, g := range rb.groups {
+		n += len(g.members)
+	}
+	return n
+}
+
 // orderedTrains is the flat, display-ordered list of sessions — the exact
-// top-to-bottom order rows render in (sections Active→Blocked→Done, lineages
-// contiguous). The Trains cursor indexes into THIS slice, so ↑/↓ steps through
-// the visible list in order and selection matches the highlighted row.
+// top-to-bottom order rows render in (sections Active→Blocked→Done, then by repo,
+// then lineages contiguous). The Trains cursor indexes into THIS slice, so ↑/↓
+// steps through the visible list in order and selection matches the highlight.
 func (m Model) orderedTrains() []TrainSession {
 	var out []TrainSession
 	for _, cat := range []int{trainCatActive, trainCatBlocked, trainCatDone} {
-		for _, g := range m.trainSectionGroups(cat) {
-			out = append(out, g.members...)
+		for _, rb := range m.trainSectionRepos(cat) {
+			for _, g := range rb.groups {
+				out = append(out, g.members...)
+			}
 		}
 	}
 	return out
@@ -363,8 +407,8 @@ func (m Model) trainsContent() string {
 	pos := 0
 	first := true
 	for _, cat := range []int{trainCatActive, trainCatBlocked, trainCatDone} {
-		groups := m.trainSectionGroups(cat)
-		if len(groups) == 0 {
+		repos := m.trainSectionRepos(cat)
+		if len(repos) == 0 {
 			continue
 		}
 		if !first {
@@ -373,17 +417,22 @@ func (m Model) trainsContent() string {
 		first = false
 		b.WriteString(headerStyle.Render(trainSectionTitles[cat]))
 		b.WriteByte('\n')
-		for _, g := range groups {
-			if len(g.members) > 1 {
-				b.WriteString("  " + g.base + "  " + mutedStyle.Render("×"+strconv.Itoa(len(g.members))) + "\n")
-				for _, t := range g.members {
-					m.writeTrainRow(&b, t, pos == m.trainCursor, "    ")
-					pos++
+		for _, rb := range repos {
+			// Repo sub-header (display-only); sessions of this repo follow, with
+			// lineages collapsed beneath it.
+			b.WriteString("  " + rb.repo + "  " + mutedStyle.Render("×"+strconv.Itoa(bucketMemberCount(rb))) + "\n")
+			for _, g := range rb.groups {
+				if len(g.members) > 1 {
+					b.WriteString("    " + g.base + "  " + mutedStyle.Render("×"+strconv.Itoa(len(g.members))) + "\n")
+					for _, t := range g.members {
+						m.writeTrainRow(&b, t, pos == m.trainCursor, "      ")
+						pos++
+					}
+					continue
 				}
-				continue
+				m.writeTrainRow(&b, g.members[0], pos == m.trainCursor, "    ")
+				pos++
 			}
-			m.writeTrainRow(&b, g.members[0], pos == m.trainCursor, "  ")
-			pos++
 		}
 	}
 


### PR DESCRIPTION
## Summary
Builds on the Phase-1 dashboard overhaul (#315): organizes the Attention and Trains pages **by repository** and makes the groups **collapsible**, defaulting to folded on the live dashboard so it opens uncluttered.

## What changed
- **Repo grouping**: Attention's blocked/failed jobs and Trains' sessions are grouped under their repository (jobs' repo is parsed from the payload for reportable jobs). Trains keeps the Active/Blocked/Done status sections; repo is the single group inside them (the redundant lineage sub-group was removed).
- **Collapsible groups** via a shared primitive (`internal/cli/tui/collapse.go`): the cursor stays on items (and on *collapsed* headers to reopen them), so normal navigation is unchanged. `space` opens/closes the repo group under the cursor; folded groups show `[+] owner/repo ×N`.
- **Collapsed by default** on the live dashboard (`Deps.CollapseGroupsByDefault`); the model still defaults to expanded in tests, and explicit user open/close persists per group.
- **Bug fix**: the Trains `enter` handler resolved the session by raw snapshot order — it now goes through the display-ordered cursor (`trainUnderCursor`).

## Code review (high, --fix)
A multi-agent review (39 candidates → 10 confirmed) drove fixes in this branch: restored the `selectedRowStyle` highlight on the selected row; reposition the cursor onto a group's header when folding from a leaf; show "B report bug" whenever reportable jobs exist (groups start folded); add `×N` counts to Attention repo headers; keep Trains fold-state independent per status section; remove a stale doc comment; gofmt. One finding (single-session repos remaining collapsible) was intentionally kept for uniformity.

## Verification
`go build/vet/test ./...` + `go test -race ./internal/workflow/` all green; tests added for repo grouping, collapse behavior, and collapsed-by-default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)