### PR TITLE
feat(tui): live Activity dashboard page

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -611,62 +611,75 @@ func activityJobActive(state string) bool {
 	return state == "queued" || state == "running"
 }
 
-// buildDashboardActivity groups jobs into delegation trees keyed by root job and
-// returns the roots that have any queued/running work, newest first — the
-// Activity page's live "what are agents working on" view. Each job's root is read
-// from its payload RootJobID (falling back to its own id for an originating
-// coordinator); the root's direct delegation children come from the same
+// buildDashboardActivity groups jobs into delegation trees and returns the
+// originating roots that have queued/running work, newest first — the Activity
+// page's live "what are agents working on" view. A root is an originating job
+// (empty ParentJobID); its direct delegation children come from the same
 // buildDelegationTree used by the job-detail view.
+//
+// Two invariants keep this cheap and consistent: (1) the active decision and the
+// progress counts use the SAME scope — the root plus its direct delegation
+// children (incl. the continuation) — so a surfaced tree always shows visible
+// live work rather than a settled coordinator with "0 running" driven by a
+// deeper descendant; (2) job payloads are parsed only for the few live roots and
+// their direct children, never for every job on the refresh tick (matching the
+// cheap-tick design of the Attention path).
+//
+// Scope is intentionally one level deep: the page renders direct delegations, so
+// a tree whose root and direct children have all settled is not surfaced even if
+// a deeper grandchild (a sub-coordinator's own delegation) is still running.
+// Surfacing such a tree would show an all-settled, "0 running" coordinator with
+// the live grandchild invisible. Rendering the full recursive tree is a separate,
+// larger change.
 func buildDashboardActivity(jobs []db.Job) []tui.ActivityRoot {
 	jobByID := make(map[string]db.Job, len(jobs))
-	payloadOf := make(map[string]workflow.JobPayload, len(jobs))
-	rootOf := make(map[string]string, len(jobs))
 	childrenByParent := map[string][]db.Job{}
+	var rootIDs []string
 	for _, j := range jobs {
 		jobByID[j.ID] = j
-		payload, err := workflow.ParseJobPayload(j.Payload)
-		if err != nil {
-			payload = workflow.JobPayload{}
-		}
-		payloadOf[j.ID] = payload
-		root := strings.TrimSpace(payload.RootJobID)
-		if root == "" {
-			root = j.ID
-		}
-		rootOf[j.ID] = root
 		if parent := strings.TrimSpace(j.ParentJobID); parent != "" {
 			childrenByParent[parent] = append(childrenByParent[parent], j)
+		} else {
+			// An originating job (user-launched coordinator or standalone agent)
+			// roots its own delegation tree.
+			rootIDs = append(rootIDs, j.ID)
 		}
-	}
-
-	membersByRoot := map[string][]db.Job{}
-	for _, j := range jobs {
-		membersByRoot[rootOf[j.ID]] = append(membersByRoot[rootOf[j.ID]], j)
 	}
 
 	var roots []tui.ActivityRoot
-	for rootID, members := range membersByRoot {
-		active := false
-		for _, m := range members {
-			if activityJobActive(m.State) {
-				active = true
+	// Sort key per root: the most recent update across the tree (root + direct
+	// children + continuation). A coordinator freezes its own UpdatedAt once it
+	// fans out, so its actively-running children must drive "newest first".
+	latestByRoot := map[string]string{}
+	for _, rootID := range rootIDs {
+		rootJob := jobByID[rootID]
+		directChildren := childrenByParent[rootID]
+		// Decide activeness from raw job states (no payload parse) so a fully
+		// settled tree costs nothing on the tick. Scope = root + direct children
+		// (the continuation is a direct child), matching what the page renders.
+		active := activityJobActive(rootJob.State)
+		for _, c := range directChildren {
+			if active {
 				break
 			}
+			active = activityJobActive(c.State)
 		}
 		if !active {
 			continue
 		}
-		rootJob, ok := jobByID[rootID]
-		if !ok {
-			continue
+		// Only for the few live roots: parse the root payload (Repo + delegation
+		// metadata) and, via buildDelegationTree, the direct children.
+		payload, err := workflow.ParseJobPayload(rootJob.Payload)
+		if err != nil {
+			payload = workflow.JobPayload{}
 		}
-		children, contID, contState := buildDelegationTree(payloadOf[rootID], childrenByParent[rootID])
+		children, contID, contState := buildDelegationTree(payload, directChildren)
 		root := tui.ActivityRoot{
 			JobID:             rootJob.ID,
 			Agent:             rootJob.Agent,
 			Action:            rootJob.Type,
 			State:             rootJob.State,
-			Repo:              strings.TrimSpace(payloadOf[rootID].Repo),
+			Repo:              strings.TrimSpace(payload.Repo),
 			UpdatedAt:         rootJob.UpdatedAt,
 			Children:          children,
 			ContinuationID:    contID,
@@ -685,11 +698,19 @@ func buildDashboardActivity(jobs []db.Job) []tui.ActivityRoot {
 				root.Done++
 			}
 		}
+		latest := rootJob.UpdatedAt
+		for _, c := range directChildren {
+			if c.UpdatedAt > latest {
+				latest = c.UpdatedAt
+			}
+		}
+		latestByRoot[rootJob.ID] = latest
 		roots = append(roots, root)
 	}
 	sort.SliceStable(roots, func(i, j int) bool {
-		if roots[i].UpdatedAt != roots[j].UpdatedAt {
-			return roots[i].UpdatedAt > roots[j].UpdatedAt // newest activity first (ISO lexical)
+		li, lj := latestByRoot[roots[i].JobID], latestByRoot[roots[j].JobID]
+		if li != lj {
+			return li > lj // newest activity first (ISO lexical)
 		}
 		return roots[i].JobID < roots[j].JobID
 	})

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -674,12 +674,14 @@ func buildDashboardActivity(jobs []db.Job) []tui.ActivityRoot {
 			Total:             len(children),
 		}
 		for _, c := range children {
-			switch {
-			case activityJobActive(c.State):
+			switch c.State {
+			case "running":
 				root.Running++
-			case c.State == "blocked":
+			case "queued":
+				root.Queued++
+			case "blocked":
 				root.Blocked++
-			case c.State == "succeeded" || c.State == "failed" || c.State == "cancelled":
+			case "succeeded", "failed", "cancelled":
 				root.Done++
 			}
 		}

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -506,6 +507,7 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 		out.ResourceLocks = append(out.ResourceLocks, tui.ResourceLock{Key: l.Key, Owner: l.Owner, Stale: l.Stale})
 	}
 	out.Config = s.configView
+	jobs := make([]db.Job, 0, len(s.jobRows))
 	for _, row := range s.jobRows {
 		out.JobRows = append(out.JobRows, tui.JobRow{
 			ID:          row.ID,
@@ -516,7 +518,9 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 			LatestEvent: row.LatestEvent,
 			Repo:        row.Repo,
 		})
+		jobs = append(jobs, row.Job)
 	}
+	out.Activity = buildDashboardActivity(jobs)
 	return out
 }
 
@@ -600,6 +604,94 @@ func buildDelegationTree(parent workflow.JobPayload, children []db.Job) ([]tui.J
 		})
 	}
 	return out, continuationID, continuationState
+}
+
+// activityJobActive reports whether a job state counts as live (in-progress) work.
+func activityJobActive(state string) bool {
+	return state == "queued" || state == "running"
+}
+
+// buildDashboardActivity groups jobs into delegation trees keyed by root job and
+// returns the roots that have any queued/running work, newest first — the
+// Activity page's live "what are agents working on" view. Each job's root is read
+// from its payload RootJobID (falling back to its own id for an originating
+// coordinator); the root's direct delegation children come from the same
+// buildDelegationTree used by the job-detail view.
+func buildDashboardActivity(jobs []db.Job) []tui.ActivityRoot {
+	jobByID := make(map[string]db.Job, len(jobs))
+	payloadOf := make(map[string]workflow.JobPayload, len(jobs))
+	rootOf := make(map[string]string, len(jobs))
+	childrenByParent := map[string][]db.Job{}
+	for _, j := range jobs {
+		jobByID[j.ID] = j
+		payload, err := workflow.ParseJobPayload(j.Payload)
+		if err != nil {
+			payload = workflow.JobPayload{}
+		}
+		payloadOf[j.ID] = payload
+		root := strings.TrimSpace(payload.RootJobID)
+		if root == "" {
+			root = j.ID
+		}
+		rootOf[j.ID] = root
+		if parent := strings.TrimSpace(j.ParentJobID); parent != "" {
+			childrenByParent[parent] = append(childrenByParent[parent], j)
+		}
+	}
+
+	membersByRoot := map[string][]db.Job{}
+	for _, j := range jobs {
+		membersByRoot[rootOf[j.ID]] = append(membersByRoot[rootOf[j.ID]], j)
+	}
+
+	var roots []tui.ActivityRoot
+	for rootID, members := range membersByRoot {
+		active := false
+		for _, m := range members {
+			if activityJobActive(m.State) {
+				active = true
+				break
+			}
+		}
+		if !active {
+			continue
+		}
+		rootJob, ok := jobByID[rootID]
+		if !ok {
+			continue
+		}
+		children, contID, contState := buildDelegationTree(payloadOf[rootID], childrenByParent[rootID])
+		root := tui.ActivityRoot{
+			JobID:             rootJob.ID,
+			Agent:             rootJob.Agent,
+			Action:            rootJob.Type,
+			State:             rootJob.State,
+			Repo:              strings.TrimSpace(payloadOf[rootID].Repo),
+			UpdatedAt:         rootJob.UpdatedAt,
+			Children:          children,
+			ContinuationID:    contID,
+			ContinuationState: contState,
+			Total:             len(children),
+		}
+		for _, c := range children {
+			switch {
+			case activityJobActive(c.State):
+				root.Running++
+			case c.State == "blocked":
+				root.Blocked++
+			case c.State == "succeeded" || c.State == "failed" || c.State == "cancelled":
+				root.Done++
+			}
+		}
+		roots = append(roots, root)
+	}
+	sort.SliceStable(roots, func(i, j int) bool {
+		if roots[i].UpdatedAt != roots[j].UpdatedAt {
+			return roots[i].UpdatedAt > roots[j].UpdatedAt // newest activity first (ISO lexical)
+		}
+		return roots[i].JobID < roots[j].JobID
+	})
+	return roots
 }
 
 // childRetryCount reads a delegation child's RetryCount from its stored payload,

--- a/internal/cli/dashboard_tui_test.go
+++ b/internal/cli/dashboard_tui_test.go
@@ -371,3 +371,93 @@ func TestBuildDashboardActivity(t *testing.T) {
 		t.Fatalf("expected 2 delegation children, got %d", len(r.Children))
 	}
 }
+
+// TestBuildDashboardActivityScopesActiveToDirectTree guards the consistency
+// invariant: a root's activeness is decided over the same scope the page renders
+// (root + direct children + continuation), so a surfaced tree always has visible
+// live work. A root whose only live work is a deeper grandchild (its direct
+// children all settled) is NOT surfaced — it would otherwise render a settled
+// coordinator with "0 running", which is what the page promises never to show.
+func TestBuildDashboardActivityScopesActiveToDirectTree(t *testing.T) {
+	mustPayload := func(p workflow.JobPayload) string {
+		t.Helper()
+		raw, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		return string(raw)
+	}
+	jobs := []db.Job{
+		// Tree A: a live continuation (a direct child) keeps the root surfaced even
+		// though the delegation child itself settled.
+		{ID: "a-root", Agent: "planner", Type: "implement", State: "succeeded", UpdatedAt: "2026-01-02T00:00:00Z",
+			Payload: mustPayload(workflow.JobPayload{Result: &workflow.AgentResult{
+				Delegations: []workflow.Delegation{{ID: "d1", Action: "build"}},
+			}})},
+		{ID: "a-root/delegation/d1", Agent: "impl", Type: "implement", State: "succeeded", ParentJobID: "a-root", DelegationID: "d1",
+			Payload: mustPayload(workflow.JobPayload{RootJobID: "a-root", ParentJobID: "a-root", DelegationID: "d1"})},
+		{ID: "a-root/continuation", Agent: "planner", Type: "ask", State: "running", ParentJobID: "a-root",
+			Payload: mustPayload(workflow.JobPayload{RootJobID: "a-root", ParentJobID: "a-root"})},
+
+		// Tree B: root + direct child both settled, but a grandchild (child of the
+		// sub-coordinator b-sub) is still running. The grandchild is not a direct
+		// child of b-root, so b-root must NOT be surfaced as live work.
+		{ID: "b-root", Agent: "planner", Type: "implement", State: "succeeded", UpdatedAt: "2026-01-03T00:00:00Z",
+			Payload: mustPayload(workflow.JobPayload{Result: &workflow.AgentResult{
+				Delegations: []workflow.Delegation{{ID: "s1", Action: "sub"}},
+			}})},
+		{ID: "b-sub", Agent: "coord", Type: "implement", State: "succeeded", ParentJobID: "b-root", DelegationID: "s1",
+			Payload: mustPayload(workflow.JobPayload{RootJobID: "b-root", ParentJobID: "b-root", DelegationID: "s1"})},
+		{ID: "b-grandchild", Agent: "impl", Type: "implement", State: "running", ParentJobID: "b-sub", DelegationID: "g1",
+			Payload: mustPayload(workflow.JobPayload{RootJobID: "b-root", ParentJobID: "b-sub", DelegationID: "g1"})},
+	}
+	roots := buildDashboardActivity(jobs)
+	if len(roots) != 1 {
+		t.Fatalf("expected only the continuation-live root, got %d: %+v", len(roots), roots)
+	}
+	r := roots[0]
+	if r.JobID != "a-root" {
+		t.Fatalf("surfaced root = %q, want a-root (b-root has no live direct child)", r.JobID)
+	}
+	if r.ContinuationID != "a-root/continuation" || r.ContinuationState != "running" {
+		t.Fatalf("continuation = (%q,%q), want (a-root/continuation, running)", r.ContinuationID, r.ContinuationState)
+	}
+}
+
+// TestBuildDashboardActivitySortsByTreeWideActivity guards that roots sort by the
+// freshest update anywhere in the tree, not the coordinator's own (frozen)
+// timestamp: a coordinator that settled earlier but has a child running right now
+// must rank above one that settled later with only stale children.
+func TestBuildDashboardActivitySortsByTreeWideActivity(t *testing.T) {
+	mustPayload := func(p workflow.JobPayload) string {
+		t.Helper()
+		raw, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		return string(raw)
+	}
+	jobs := []db.Job{
+		// coord-A settled at 09:00 but its child is running and was updated at 14:00.
+		{ID: "coord-A", Agent: "planner", Type: "implement", State: "succeeded", UpdatedAt: "2026-01-01T09:00:00Z",
+			Payload: mustPayload(workflow.JobPayload{Result: &workflow.AgentResult{
+				Delegations: []workflow.Delegation{{ID: "a1", Action: "x"}},
+			}})},
+		{ID: "coord-A/delegation/a1", Agent: "impl", Type: "implement", State: "running", UpdatedAt: "2026-01-01T14:00:00Z", ParentJobID: "coord-A", DelegationID: "a1",
+			Payload: mustPayload(workflow.JobPayload{ParentJobID: "coord-A", DelegationID: "a1"})},
+		// coord-B settled later (10:00) but its child only sits queued (10:30).
+		{ID: "coord-B", Agent: "planner", Type: "implement", State: "succeeded", UpdatedAt: "2026-01-01T10:00:00Z",
+			Payload: mustPayload(workflow.JobPayload{Result: &workflow.AgentResult{
+				Delegations: []workflow.Delegation{{ID: "b1", Action: "y"}},
+			}})},
+		{ID: "coord-B/delegation/b1", Agent: "impl", Type: "implement", State: "queued", UpdatedAt: "2026-01-01T10:30:00Z", ParentJobID: "coord-B", DelegationID: "b1",
+			Payload: mustPayload(workflow.JobPayload{ParentJobID: "coord-B", DelegationID: "b1"})},
+	}
+	roots := buildDashboardActivity(jobs)
+	if len(roots) != 2 {
+		t.Fatalf("want 2 active roots, got %d: %+v", len(roots), roots)
+	}
+	if roots[0].JobID != "coord-A" {
+		t.Fatalf("want coord-A first (freshest activity is its running child), got %q then %q", roots[0].JobID, roots[1].JobID)
+	}
+}

--- a/internal/cli/dashboard_tui_test.go
+++ b/internal/cli/dashboard_tui_test.go
@@ -331,3 +331,43 @@ func TestDashboardCreateAgentWithPrompt(t *testing.T) {
 		t.Fatalf("template content = %q, want the edited prompt", tpl.Content)
 	}
 }
+
+func TestBuildDashboardActivity(t *testing.T) {
+	mustPayload := func(p workflow.JobPayload) string {
+		t.Helper()
+		raw, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		return string(raw)
+	}
+	jobs := []db.Job{
+		// Active root coordinator (no RootJobID → its own id is the root); its
+		// result names the two delegations.
+		{ID: "root-1", Agent: "planner", Type: "implement", State: "running", UpdatedAt: "2026-01-02T00:00:00Z",
+			Payload: mustPayload(workflow.JobPayload{Repo: "o/r", Result: &workflow.AgentResult{
+				Delegations: []workflow.Delegation{{ID: "d1", Action: "build"}, {ID: "d2", Action: "test"}},
+			}})},
+		{ID: "root-1/delegation/d1", Agent: "impl-a", Type: "implement", State: "running", ParentJobID: "root-1", DelegationID: "d1",
+			Payload: mustPayload(workflow.JobPayload{RootJobID: "root-1", ParentJobID: "root-1", DelegationID: "d1"})},
+		{ID: "root-1/delegation/d2", Agent: "impl-b", Type: "implement", State: "succeeded", ParentJobID: "root-1", DelegationID: "d2",
+			Payload: mustPayload(workflow.JobPayload{RootJobID: "root-1", ParentJobID: "root-1", DelegationID: "d2"})},
+		// A fully-settled tree (no active member) must be excluded.
+		{ID: "root-2", Agent: "planner", Type: "ask", State: "succeeded", UpdatedAt: "2026-01-01T00:00:00Z",
+			Payload: mustPayload(workflow.JobPayload{Repo: "o/x"})},
+	}
+	roots := buildDashboardActivity(jobs)
+	if len(roots) != 1 {
+		t.Fatalf("expected 1 active root, got %d: %+v", len(roots), roots)
+	}
+	r := roots[0]
+	if r.JobID != "root-1" || r.Repo != "o/r" || r.State != "running" {
+		t.Fatalf("root fields wrong: %+v", r)
+	}
+	if r.Total != 2 || r.Running != 1 || r.Blocked != 0 || r.Done != 1 {
+		t.Fatalf("progress counts wrong: total=%d running=%d blocked=%d done=%d", r.Total, r.Running, r.Blocked, r.Done)
+	}
+	if len(r.Children) != 2 {
+		t.Fatalf("expected 2 delegation children, got %d", len(r.Children))
+	}
+}

--- a/internal/cli/tui/activity.go
+++ b/internal/cli/tui/activity.go
@@ -42,6 +42,7 @@ func (m Model) activityContent() string {
 			b.WriteString("    " + mutedStyle.Render(
 				strconv.Itoa(r.Total)+" delegations · "+
 					strconv.Itoa(r.Running)+" running · "+
+					strconv.Itoa(r.Queued)+" queued · "+
 					strconv.Itoa(r.Blocked)+" blocked · "+
 					strconv.Itoa(r.Done)+" done") + "\n")
 			for _, c := range r.Children {

--- a/internal/cli/tui/activity.go
+++ b/internal/cli/tui/activity.go
@@ -11,12 +11,23 @@ import (
 func (m Model) activitySelectable() []JobRow {
 	var out []JobRow
 	for _, r := range m.snap.Activity {
-		out = append(out, JobRow{ID: r.JobID, Agent: r.Agent, Type: r.Action, State: r.State})
+		out = append(out, JobRow{ID: r.JobID, Agent: r.Agent, Type: r.Action, State: r.State, UpdatedAt: r.UpdatedAt})
 		for _, c := range r.Children {
 			out = append(out, JobRow{ID: c.ID, Agent: c.Agent, Type: c.Action, State: c.State})
 		}
 	}
 	return out
+}
+
+// activitySelectableLen counts the selectable rows (root + children per tree)
+// without materializing the []JobRow — the cursor length needed on every
+// up/down keystroke and refresh clamp.
+func (m Model) activitySelectableLen() int {
+	n := 0
+	for _, r := range m.snap.Activity {
+		n += 1 + len(r.Children)
+	}
+	return n
 }
 
 // activityUnderCursor returns the job (root or delegate) under the Activity
@@ -32,109 +43,152 @@ func (m Model) activityUnderCursor() (JobRow, bool) {
 	return sel[m.activityCursor], true
 }
 
-// activityTreeCap is how many delegation trees fit the Activity page, leaving
-// room for the title/intro, the more/earlier markers, and the footer. A tree is
-// roughly a root line + progress + up to ~5 children + spacing.
-func activityTreeCap(height int) int {
-	if n := (height - 7) / 8; n >= 1 {
-		return n
+// activityWindowCap is how many display rows fit the Activity page, leaving room
+// for the title/intro, the above/below markers, and the footer. Mirrors
+// jobsWindowCap so a wide fan-out (or a short terminal) never pushes the cursor
+// off-screen.
+func activityWindowCap(height int) int {
+	if height-9 < 3 {
+		return 3
 	}
-	return 1
+	return height - 9
+}
+
+// activityRow is one rendered line of the Activity page. Selectable rows (a root
+// or a delegation child) carry the cursor marker and map to an activitySelectable
+// index; adornment rows (the progress summary, the continuation, blank
+// separators) are static.
+type activityRow struct {
+	selectable bool
+	sel        int    // activitySelectable index, when selectable
+	indent     string // spaces before the marker
+	target     string // text highlighted when this row is selected
+	rest       string // text after the target
+	static     string // full text for non-selectable rows
+}
+
+// activityRows flattens the delegation trees into display rows, assigning each
+// selectable row the same index activitySelectable() produces (root, then its
+// children, per tree) so the cursor and the rendered marker stay in lockstep.
+func (m Model) activityRows() []activityRow {
+	var rows []activityRow
+	sel := 0
+	for ri, r := range m.snap.Activity {
+		if ri > 0 {
+			rows = append(rows, activityRow{static: ""}) // blank separator between trees
+		}
+		rootRest := "  " + r.Agent + "  " + r.Action + "  " + jobStateColor(r.State)
+		if r.Repo != "" {
+			rootRest += "  " + mutedStyle.Render(r.Repo)
+		}
+		rows = append(rows, activityRow{selectable: true, sel: sel, target: r.JobID, rest: rootRest})
+		sel++
+		if r.Total > 0 {
+			rows = append(rows, activityRow{static: "    " + mutedStyle.Render(
+				strconv.Itoa(r.Total)+" delegations · "+
+					strconv.Itoa(r.Running)+" running · "+
+					strconv.Itoa(r.Queued)+" queued · "+
+					strconv.Itoa(r.Blocked)+" blocked · "+
+					strconv.Itoa(r.Done)+" done")})
+		}
+		for _, c := range r.Children {
+			rows = append(rows, activityRow{
+				selectable: true,
+				sel:        sel,
+				indent:     "    ",
+				target:     dash(c.Agent),
+				rest:       "  " + truncate(c.Action, 24) + "  " + jobStateColor(c.State),
+			})
+			sel++
+		}
+		// Show the continuation whenever one exists — including the corrective
+		// path where the coordinator re-enqueues a continuation with no fresh
+		// delegations (Total == 0), so its live work is never hidden.
+		if r.ContinuationID != "" {
+			rows = append(rows, activityRow{static: "      " + mutedStyle.Render("continuation") + "  " + jobStateColor(r.ContinuationState)})
+		}
+	}
+	return rows
 }
 
 // activityContent renders the Activity page: delegation trees with
 // queued/running work, newest first. Each root shows the coordinator line, a
 // progress summary, and the delegation children (which agent is doing what, and
 // its state) plus the continuation job. The cursor walks roots AND children;
-// enter opens the selected job's detail (its request + result). Trees are
-// windowed around the cursor so the page always fits and the cursor stays
-// visible; "↑/↓ N more trees" markers show what is scrolled off.
+// enter opens the selected job's detail (its request + result). Display rows are
+// windowed around the cursor so the page always fits and the selected row stays
+// visible — even for a single wide fan-out — with "↑/↓ N more rows" markers for
+// what is scrolled off.
 func (m Model) activityContent() string {
-	roots := m.snap.Activity
-	if len(roots) == 0 {
+	if len(m.snap.Activity) == 0 {
 		return m.loadingOr("No active jobs — nothing is running right now.", !m.loadedAt.IsZero())
 	}
 
-	// counts[i] = selectable rows in tree i (root + its children); find which
-	// tree the flat cursor falls in so we can window around it.
-	counts := make([]int, len(roots))
-	cursorTree := 0
-	cum := 0
-	for i, r := range roots {
-		counts[i] = 1 + len(r.Children)
-		if m.activityCursor >= cum && m.activityCursor < cum+counts[i] {
-			cursorTree = i
+	rows := m.activityRows()
+	capacity := activityWindowCap(m.height)
+
+	// Clamp the effective cursor into the selectable range so the row search
+	// below always matches — even if a future code path mutates m.snap.Activity
+	// without re-clamping m.activityCursor.
+	selCount := 0
+	for _, row := range rows {
+		if row.selectable {
+			selCount++
 		}
-		cum += counts[i]
+	}
+	cursor := m.activityCursor
+	if cursor < 0 {
+		cursor = 0
+	}
+	if selCount > 0 && cursor > selCount-1 {
+		cursor = selCount - 1
 	}
 
-	capacity := activityTreeCap(m.height)
+	// Locate the selected display row, then window around it (mirrors the Jobs
+	// page) so the cursor is always within the rendered slice.
+	cursorRow := 0
+	for i, row := range rows {
+		if row.selectable && row.sel == cursor {
+			cursorRow = i
+			break
+		}
+	}
 	start := 0
-	if len(roots) > capacity {
-		start = cursorTree - capacity/2
+	if len(rows) > capacity {
+		start = cursorRow - capacity/2
 		if start < 0 {
 			start = 0
 		}
-		if start > len(roots)-capacity {
-			start = len(roots) - capacity
+		if start > len(rows)-capacity {
+			start = len(rows) - capacity
 		}
 	}
 	end := start + capacity
-	if end > len(roots) {
-		end = len(roots)
-	}
-
-	// pos = flat selectable position of the first row in the window.
-	pos := 0
-	for i := 0; i < start; i++ {
-		pos += counts[i]
+	if end > len(rows) {
+		end = len(rows)
 	}
 
 	var b strings.Builder
 	b.WriteString(mutedStyle.Render("Delegation trees with queued/running work (live, refreshes every 5s).") + "\n\n")
 	if start > 0 {
-		b.WriteString(mutedStyle.Render("  ↑ "+strconv.Itoa(start)+" more trees") + "\n")
+		b.WriteString(mutedStyle.Render("  ↑ "+strconv.Itoa(start)+" more rows above") + "\n")
 	}
-	for ti := start; ti < end; ti++ {
-		r := roots[ti]
+	for i := start; i < end; i++ {
+		row := rows[i]
+		if !row.selectable {
+			b.WriteString(row.static + "\n")
+			continue
+		}
 		marker := "  "
-		id := r.JobID
-		if pos == m.activityCursor {
+		target := row.target
+		if row.sel == cursor {
 			marker = "▸ "
-			id = selectedRowStyle.Render(id)
+			target = selectedRowStyle.Render(target)
 		}
-		line := marker + id + "  " + r.Agent + "  " + r.Action + "  " + jobStateColor(r.State)
-		if r.Repo != "" {
-			line += "  " + mutedStyle.Render(r.Repo)
-		}
-		b.WriteString(line + "\n")
-		pos++
-
-		if r.Total > 0 {
-			b.WriteString("    " + mutedStyle.Render(
-				strconv.Itoa(r.Total)+" delegations · "+
-					strconv.Itoa(r.Running)+" running · "+
-					strconv.Itoa(r.Queued)+" queued · "+
-					strconv.Itoa(r.Blocked)+" blocked · "+
-					strconv.Itoa(r.Done)+" done") + "\n")
-			for _, c := range r.Children {
-				cm := "  "
-				agent := dash(c.Agent)
-				if pos == m.activityCursor {
-					cm = "▸ "
-					agent = selectedRowStyle.Render(agent)
-				}
-				b.WriteString("    " + cm + agent + "  " + truncate(c.Action, 24) + "  " + jobStateColor(c.State) + "\n")
-				pos++
-			}
-			if r.ContinuationID != "" {
-				b.WriteString("      " + mutedStyle.Render("continuation") + "  " + jobStateColor(r.ContinuationState) + "\n")
-			}
-		}
-		b.WriteByte('\n')
+		b.WriteString(row.indent + marker + target + row.rest + "\n")
 	}
-	if end < len(roots) {
-		b.WriteString(mutedStyle.Render("  ↓ "+strconv.Itoa(len(roots)-end)+" more trees") + "\n")
+	if end < len(rows) {
+		b.WriteString(mutedStyle.Render("  ↓ "+strconv.Itoa(len(rows)-end)+" more rows below") + "\n")
 	}
 	b.WriteString(mutedStyle.Render("↑/↓ select root or delegate · enter open its detail (request + result)"))
 	b.WriteByte('\n')

--- a/internal/cli/tui/activity.go
+++ b/internal/cli/tui/activity.go
@@ -5,19 +5,38 @@ import (
 	"strings"
 )
 
-// activityUnderCursor returns the active delegation root under the Activity
-// cursor, if any.
-func (m Model) activityUnderCursor() (ActivityRoot, bool) {
-	if pages[m.selected].page != pageActivity || m.activityCursor < 0 || m.activityCursor >= len(m.snap.Activity) {
-		return ActivityRoot{}, false
+// activitySelectable is the flat list of jobs the Activity cursor can land on —
+// each active root followed by its delegation children — so enter can open the
+// detail (request + result) of a root OR a specific delegate.
+func (m Model) activitySelectable() []JobRow {
+	var out []JobRow
+	for _, r := range m.snap.Activity {
+		out = append(out, JobRow{ID: r.JobID, Agent: r.Agent, Type: r.Action, State: r.State})
+		for _, c := range r.Children {
+			out = append(out, JobRow{ID: c.ID, Agent: c.Agent, Type: c.Action, State: c.State})
+		}
 	}
-	return m.snap.Activity[m.activityCursor], true
+	return out
+}
+
+// activityUnderCursor returns the job (root or delegate) under the Activity
+// cursor, if any.
+func (m Model) activityUnderCursor() (JobRow, bool) {
+	if pages[m.selected].page != pageActivity {
+		return JobRow{}, false
+	}
+	sel := m.activitySelectable()
+	if m.activityCursor < 0 || m.activityCursor >= len(sel) {
+		return JobRow{}, false
+	}
+	return sel[m.activityCursor], true
 }
 
 // activityContent renders the Activity page: every delegation tree with
 // queued/running work, newest first. Each root shows the coordinator line, a
 // progress summary, and the delegation children (which agent is doing what, and
-// its state) plus the continuation job. enter opens the root's full detail.
+// its state) plus the continuation job. The cursor walks roots AND children;
+// enter opens the selected job's detail (its request + result).
 func (m Model) activityContent() string {
 	roots := m.snap.Activity
 	if len(roots) == 0 {
@@ -25,18 +44,20 @@ func (m Model) activityContent() string {
 	}
 	var b strings.Builder
 	b.WriteString(mutedStyle.Render("Delegation trees with queued/running work (live, refreshes every 5s).") + "\n\n")
-	for i, r := range roots {
-		cursor := "  "
+	pos := 0 // flat selectable position; advances for the root then each child
+	for _, r := range roots {
+		marker := "  "
 		id := r.JobID
-		if i == m.activityCursor {
-			cursor = "▸ "
+		if pos == m.activityCursor {
+			marker = "▸ "
 			id = selectedRowStyle.Render(id)
 		}
-		line := cursor + id + "  " + r.Agent + "  " + r.Action + "  " + jobStateColor(r.State)
+		line := marker + id + "  " + r.Agent + "  " + r.Action + "  " + jobStateColor(r.State)
 		if r.Repo != "" {
 			line += "  " + mutedStyle.Render(r.Repo)
 		}
 		b.WriteString(line + "\n")
+		pos++
 
 		if r.Total > 0 {
 			b.WriteString("    " + mutedStyle.Render(
@@ -46,7 +67,14 @@ func (m Model) activityContent() string {
 					strconv.Itoa(r.Blocked)+" blocked · "+
 					strconv.Itoa(r.Done)+" done") + "\n")
 			for _, c := range r.Children {
-				b.WriteString("      " + dash(c.Agent) + "  " + truncate(c.Action, 30) + "  " + jobStateColor(c.State) + "\n")
+				cm := "  "
+				agent := dash(c.Agent)
+				if pos == m.activityCursor {
+					cm = "▸ "
+					agent = selectedRowStyle.Render(agent)
+				}
+				b.WriteString("    " + cm + agent + "  " + truncate(c.Action, 24) + "  " + jobStateColor(c.State) + "\n")
+				pos++
 			}
 			if r.ContinuationID != "" {
 				b.WriteString("      " + mutedStyle.Render("continuation") + "  " + jobStateColor(r.ContinuationState) + "\n")
@@ -54,7 +82,7 @@ func (m Model) activityContent() string {
 		}
 		b.WriteByte('\n')
 	}
-	b.WriteString(mutedStyle.Render("↑/↓ select · enter open root detail"))
+	b.WriteString(mutedStyle.Render("↑/↓ select root or delegate · enter open its detail (request + result)"))
 	b.WriteByte('\n')
 	return b.String()
 }

--- a/internal/cli/tui/activity.go
+++ b/internal/cli/tui/activity.go
@@ -1,0 +1,59 @@
+package tui
+
+import (
+	"strconv"
+	"strings"
+)
+
+// activityUnderCursor returns the active delegation root under the Activity
+// cursor, if any.
+func (m Model) activityUnderCursor() (ActivityRoot, bool) {
+	if pages[m.selected].page != pageActivity || m.activityCursor < 0 || m.activityCursor >= len(m.snap.Activity) {
+		return ActivityRoot{}, false
+	}
+	return m.snap.Activity[m.activityCursor], true
+}
+
+// activityContent renders the Activity page: every delegation tree with
+// queued/running work, newest first. Each root shows the coordinator line, a
+// progress summary, and the delegation children (which agent is doing what, and
+// its state) plus the continuation job. enter opens the root's full detail.
+func (m Model) activityContent() string {
+	roots := m.snap.Activity
+	if len(roots) == 0 {
+		return m.loadingOr("No active jobs — nothing is running right now.", !m.loadedAt.IsZero())
+	}
+	var b strings.Builder
+	b.WriteString(mutedStyle.Render("Delegation trees with queued/running work (live, refreshes every 5s).") + "\n\n")
+	for i, r := range roots {
+		cursor := "  "
+		id := r.JobID
+		if i == m.activityCursor {
+			cursor = "▸ "
+			id = selectedRowStyle.Render(id)
+		}
+		line := cursor + id + "  " + r.Agent + "  " + r.Action + "  " + jobStateColor(r.State)
+		if r.Repo != "" {
+			line += "  " + mutedStyle.Render(r.Repo)
+		}
+		b.WriteString(line + "\n")
+
+		if r.Total > 0 {
+			b.WriteString("    " + mutedStyle.Render(
+				strconv.Itoa(r.Total)+" delegations · "+
+					strconv.Itoa(r.Running)+" running · "+
+					strconv.Itoa(r.Blocked)+" blocked · "+
+					strconv.Itoa(r.Done)+" done") + "\n")
+			for _, c := range r.Children {
+				b.WriteString("      " + dash(c.Agent) + "  " + truncate(c.Action, 30) + "  " + jobStateColor(c.State) + "\n")
+			}
+			if r.ContinuationID != "" {
+				b.WriteString("      " + mutedStyle.Render("continuation") + "  " + jobStateColor(r.ContinuationState) + "\n")
+			}
+		}
+		b.WriteByte('\n')
+	}
+	b.WriteString(mutedStyle.Render("↑/↓ select · enter open root detail"))
+	b.WriteByte('\n')
+	return b.String()
+}

--- a/internal/cli/tui/activity.go
+++ b/internal/cli/tui/activity.go
@@ -32,20 +32,71 @@ func (m Model) activityUnderCursor() (JobRow, bool) {
 	return sel[m.activityCursor], true
 }
 
-// activityContent renders the Activity page: every delegation tree with
+// activityTreeCap is how many delegation trees fit the Activity page, leaving
+// room for the title/intro, the more/earlier markers, and the footer. A tree is
+// roughly a root line + progress + up to ~5 children + spacing.
+func activityTreeCap(height int) int {
+	if n := (height - 7) / 8; n >= 1 {
+		return n
+	}
+	return 1
+}
+
+// activityContent renders the Activity page: delegation trees with
 // queued/running work, newest first. Each root shows the coordinator line, a
 // progress summary, and the delegation children (which agent is doing what, and
 // its state) plus the continuation job. The cursor walks roots AND children;
-// enter opens the selected job's detail (its request + result).
+// enter opens the selected job's detail (its request + result). Trees are
+// windowed around the cursor so the page always fits and the cursor stays
+// visible; "↑/↓ N more trees" markers show what is scrolled off.
 func (m Model) activityContent() string {
 	roots := m.snap.Activity
 	if len(roots) == 0 {
 		return m.loadingOr("No active jobs — nothing is running right now.", !m.loadedAt.IsZero())
 	}
+
+	// counts[i] = selectable rows in tree i (root + its children); find which
+	// tree the flat cursor falls in so we can window around it.
+	counts := make([]int, len(roots))
+	cursorTree := 0
+	cum := 0
+	for i, r := range roots {
+		counts[i] = 1 + len(r.Children)
+		if m.activityCursor >= cum && m.activityCursor < cum+counts[i] {
+			cursorTree = i
+		}
+		cum += counts[i]
+	}
+
+	capacity := activityTreeCap(m.height)
+	start := 0
+	if len(roots) > capacity {
+		start = cursorTree - capacity/2
+		if start < 0 {
+			start = 0
+		}
+		if start > len(roots)-capacity {
+			start = len(roots) - capacity
+		}
+	}
+	end := start + capacity
+	if end > len(roots) {
+		end = len(roots)
+	}
+
+	// pos = flat selectable position of the first row in the window.
+	pos := 0
+	for i := 0; i < start; i++ {
+		pos += counts[i]
+	}
+
 	var b strings.Builder
 	b.WriteString(mutedStyle.Render("Delegation trees with queued/running work (live, refreshes every 5s).") + "\n\n")
-	pos := 0 // flat selectable position; advances for the root then each child
-	for _, r := range roots {
+	if start > 0 {
+		b.WriteString(mutedStyle.Render("  ↑ "+strconv.Itoa(start)+" more trees") + "\n")
+	}
+	for ti := start; ti < end; ti++ {
+		r := roots[ti]
 		marker := "  "
 		id := r.JobID
 		if pos == m.activityCursor {
@@ -81,6 +132,9 @@ func (m Model) activityContent() string {
 			}
 		}
 		b.WriteByte('\n')
+	}
+	if end < len(roots) {
+		b.WriteString(mutedStyle.Render("  ↓ "+strconv.Itoa(len(roots)-end)+" more trees") + "\n")
 	}
 	b.WriteString(mutedStyle.Render("↑/↓ select root or delegate · enter open its detail (request + result)"))
 	b.WriteByte('\n')

--- a/internal/cli/tui/activity_test.go
+++ b/internal/cli/tui/activity_test.go
@@ -22,8 +22,8 @@ func TestActivityPageRendersActiveTrees(t *testing.T) {
 		Activity: []ActivityRoot{{
 			JobID: "root-1", Agent: "planner", Action: "implement", State: "running", Repo: "o/r",
 			Children: []JobChild{
-				{DelegationID: "d1", Agent: "impl-a", Action: "build the API", State: "running"},
-				{DelegationID: "d2", Agent: "impl-b", Action: "write tests", State: "blocked"},
+				{ID: "c1", DelegationID: "d1", Agent: "impl-a", Action: "build the API", State: "running"},
+				{ID: "c2", DelegationID: "d2", Agent: "impl-b", Action: "write tests", State: "blocked"},
 			},
 			ContinuationID: "cont-1", ContinuationState: "queued",
 			Total: 2, Running: 1, Blocked: 1, Done: 0,
@@ -36,14 +36,21 @@ func TestActivityPageRendersActiveTrees(t *testing.T) {
 			t.Fatalf("activity view missing %q:\n%s", want, view)
 		}
 	}
-	// The cursor selects the root; enter opens its detail.
-	if r, ok := m.activityUnderCursor(); !ok || r.JobID != "root-1" {
-		t.Fatalf("cursor should select root-1, got %+v ok=%v", r, ok)
+	// Cursor 0 = the root; enter opens its detail.
+	if r, ok := m.activityUnderCursor(); !ok || r.ID != "root-1" {
+		t.Fatalf("cursor 0 should select root-1, got %+v ok=%v", r, ok)
+	}
+	// Cursor 1 = the first delegate; the cursor walks into the tree, and enter
+	// opens that delegate's detail (its request/result), not the root's.
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(Model)
+	if r, ok := m.activityUnderCursor(); !ok || r.ID != "c1" {
+		t.Fatalf("cursor 1 should select delegate c1, got %+v ok=%v", r, ok)
 	}
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = next.(Model)
-	if m.mode != modeJobDetail || m.activeJob.ID != "root-1" {
-		t.Fatalf("enter should open the root's job detail, mode=%v job=%q", m.mode, m.activeJob.ID)
+	if m.mode != modeJobDetail || m.activeJob.ID != "c1" {
+		t.Fatalf("enter on a delegate should open ITS detail, mode=%v job=%q", m.mode, m.activeJob.ID)
 	}
 	_ = cmd
 }

--- a/internal/cli/tui/activity_test.go
+++ b/internal/cli/tui/activity_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -59,5 +60,76 @@ func TestActivityPageEmpty(t *testing.T) {
 	m := activityPageModel(t, Snapshot{Daemon: Daemon{Running: true}})
 	if !strings.Contains(m.View(), "No active jobs") {
 		t.Fatalf("empty activity page should say so:\n%s", m.View())
+	}
+}
+
+// TestActivityPageShowsCorrectiveContinuation guards that a live continuation is
+// rendered even when the root has no fresh delegation children (Total == 0) — the
+// engine's corrective-continuation path, where the continuation is the only live
+// work and must not be hidden.
+func TestActivityPageShowsCorrectiveContinuation(t *testing.T) {
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		Activity: []ActivityRoot{{
+			JobID: "root-1", Agent: "planner", Action: "implement", State: "succeeded",
+			ContinuationID: "root-1/continuation", ContinuationState: "running",
+		}},
+	}
+	m := activityPageModel(t, snap)
+	if view := m.View(); !strings.Contains(view, "continuation") {
+		t.Fatalf("a live continuation with no fresh delegations must still render:\n%s", view)
+	}
+}
+
+// TestActivityPageWindowsWideFanout guards that a single root with many
+// delegation children windows its rows around the cursor: a short terminal must
+// keep the selected delegate visible (not rendered below the viewport) and show
+// the scrolled-off markers.
+func TestActivityPageWindowsWideFanout(t *testing.T) {
+	children := make([]JobChild, 0, 30)
+	for i := 0; i < 30; i++ {
+		children = append(children, JobChild{
+			ID:    "c" + strconv.Itoa(i),
+			Agent: "impl-" + strconv.Itoa(i),
+			// A distinctive action token so we can assert the selected row renders.
+			Action: "task-" + strconv.Itoa(i),
+			State:  "running",
+		})
+	}
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		Activity: []ActivityRoot{{
+			JobID: "root-1", Agent: "planner", Action: "implement", State: "running",
+			Children: children, Total: 30, Running: 30,
+		}},
+	}
+	m := sizedModel(Deps{Load: func() (Snapshot, error) { return snap, nil }})
+	// A short terminal: far fewer rows than the 30+ the tree wants to draw.
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 18})
+	m = next.(Model)
+	next, _ = m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	m = tabToPage(t, m, pageActivity)
+
+	// Walk the cursor down to a deep delegate (root + child index 25 = 26 downs).
+	for i := 0; i < 26; i++ {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = next.(Model)
+	}
+	if r, ok := m.activityUnderCursor(); !ok || r.ID != "c25" {
+		t.Fatalf("cursor should be on c25, got %+v ok=%v", r, ok)
+	}
+	view := m.View()
+	// The selected delegate's row must be in the rendered window...
+	if !strings.Contains(view, "task-25") {
+		t.Fatalf("selected delegate task-25 should be visible:\n%s", view)
+	}
+	// ...and the window must have scrolled (rows above are hidden behind a marker).
+	if !strings.Contains(view, "more rows above") {
+		t.Fatalf("a deep cursor should scroll the window and show an above marker:\n%s", view)
+	}
+	// The very first delegate is far above the window and must be hidden.
+	if strings.Contains(view, "task-0  ") {
+		t.Fatalf("task-0 should be scrolled out of the window:\n%s", view)
 	}
 }

--- a/internal/cli/tui/activity_test.go
+++ b/internal/cli/tui/activity_test.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func activityPageModel(t *testing.T, snap Snapshot) Model {
+	t.Helper()
+	m := sizedModel(Deps{Load: func() (Snapshot, error) { return snap, nil }})
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	return tabToPage(t, m, pageActivity)
+}
+
+func TestActivityPageRendersActiveTrees(t *testing.T) {
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		Activity: []ActivityRoot{{
+			JobID: "root-1", Agent: "planner", Action: "implement", State: "running", Repo: "o/r",
+			Children: []JobChild{
+				{DelegationID: "d1", Agent: "impl-a", Action: "build the API", State: "running"},
+				{DelegationID: "d2", Agent: "impl-b", Action: "write tests", State: "blocked"},
+			},
+			ContinuationID: "cont-1", ContinuationState: "queued",
+			Total: 2, Running: 1, Blocked: 1, Done: 0,
+		}},
+	}
+	m := activityPageModel(t, snap)
+	view := m.View()
+	for _, want := range []string{"root-1", "o/r", "impl-a", "build the API", "impl-b", "2 delegations", "continuation"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("activity view missing %q:\n%s", want, view)
+		}
+	}
+	// The cursor selects the root; enter opens its detail.
+	if r, ok := m.activityUnderCursor(); !ok || r.JobID != "root-1" {
+		t.Fatalf("cursor should select root-1, got %+v ok=%v", r, ok)
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if m.mode != modeJobDetail || m.activeJob.ID != "root-1" {
+		t.Fatalf("enter should open the root's job detail, mode=%v job=%q", m.mode, m.activeJob.ID)
+	}
+	_ = cmd
+}
+
+func TestActivityPageEmpty(t *testing.T) {
+	m := activityPageModel(t, Snapshot{Daemon: Daemon{Running: true}})
+	if !strings.Contains(m.View(), "No active jobs") {
+		t.Fatalf("empty activity page should say so:\n%s", m.View())
+	}
+}

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -31,13 +31,7 @@ func agentsModel(t *testing.T, deps Deps, snap Snapshot) Model {
 	m := sizedModel(deps)
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
 	m = next.(Model)
-	for i := 0; i < 2; i++ { // Attention → Trains → Agents
-		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = next.(Model)
-	}
-	if pages[m.selected].page != pageAgents {
-		t.Fatalf("expected Agents page, got %v", pages[m.selected].page)
-	}
+	m = tabToPage(t, m, pageAgents)
 	return m
 }
 

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -49,7 +49,8 @@ type ActivityRoot struct {
 	ContinuationID    string
 	ContinuationState string
 	Total             int // direct delegation children
-	Running           int // queued/running children
+	Running           int // children actively running
+	Queued            int // children waiting to start
 	Blocked           int
 	Done              int // terminal children (succeeded/failed/cancelled)
 }

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -30,7 +30,28 @@ type Snapshot struct {
 	ResourceLocks  []ResourceLock
 	Prompts        []db.InteractivePrompt
 	JobRows        []JobRow
+	Activity       []ActivityRoot
 	Config         ConfigView
+}
+
+// ActivityRoot is one live delegation tree on the Activity page: a root
+// coordinator job that has queued/running work somewhere in its tree, its direct
+// delegation children (which agent is doing what, and their state), the
+// coordinator continuation job, and a progress summary.
+type ActivityRoot struct {
+	JobID             string
+	Agent             string
+	Action            string
+	State             string
+	Repo              string
+	UpdatedAt         string
+	Children          []JobChild
+	ContinuationID    string
+	ContinuationState string
+	Total             int // direct delegation children
+	Running           int // queued/running children
+	Blocked           int
+	Done              int // terminal children (succeeded/failed/cancelled)
 }
 
 // Daemon mirrors cli.dashboardDaemon.

--- a/internal/cli/tui/dismiss_train_test.go
+++ b/internal/cli/tui/dismiss_train_test.go
@@ -122,9 +122,7 @@ func trainsModel(t *testing.T) Model {
 	m := sizedModel(deps)
 	next, _ := m.Update(snapshotMsg{snap: trainSnapshot(), at: time.Unix(1, 0)})
 	m = next.(Model)
-	// Tab from Attention to Trains.
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	return next.(Model)
+	return tabToPage(t, m, pageTrains)
 }
 
 func TestTrainDetailShowsSessionLocksOnly(t *testing.T) {
@@ -248,11 +246,7 @@ func TestTrainsListGroupsAndCollapses(t *testing.T) {
 	m := sizedModel(deps)
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
 	m = next.(Model)
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // Attention → Trains
-	m = next.(Model)
-	if pages[m.selected].page != pageTrains {
-		t.Fatalf("expected Trains page")
-	}
+	m = tabToPage(t, m, pageTrains)
 	view := m.View()
 	for _, want := range []string{"Active", "Blocked", "Done"} {
 		if !strings.Contains(view, want) {
@@ -303,8 +297,7 @@ func TestTrainCursorFollowsDisplayOrder(t *testing.T) {
 	m := sizedModel(deps)
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
 	m = next.(Model)
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = next.(Model)
+	m = tabToPage(t, m, pageTrains)
 	// Cursor 0 selects the first VISIBLE row = live-late (Active renders before Done).
 	if got, _ := m.trainUnderCursor(); got.ID != "live-late" {
 		t.Fatalf("cursor 0 should select the first visible row (live-late), got %q", got.ID)
@@ -336,8 +329,7 @@ func TestTrainsGroupByRepoWithinSection(t *testing.T) {
 	m := sizedModel(deps)
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
 	m = next.(Model)
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // Attention → Trains
-	m = next.(Model)
+	m = tabToPage(t, m, pageTrains)
 	view := m.View()
 	for _, want := range []string{"Active", "o/alpha", "o/beta", "a-v1", "a-v2", "b1"} {
 		if !strings.Contains(view, want) {
@@ -374,8 +366,7 @@ func TestTrainsCollapseRepoFoldsSessions(t *testing.T) {
 	m := sizedModel(deps)
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
 	m = next.(Model)
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // → Trains
-	m = next.(Model)
+	m = tabToPage(t, m, pageTrains)
 	// Cursor 0 = a1 (o/alpha). Space folds o/alpha.
 	next, _ = m.Update(key(" "))
 	m = next.(Model)
@@ -408,8 +399,7 @@ func TestTrainsCollapsedByDefault(t *testing.T) {
 	m := sizedModel(deps)
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
 	m = next.(Model)
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // → Trains
-	m = next.(Model)
+	m = tabToPage(t, m, pageTrains)
 	view := m.View()
 	if strings.Contains(view, "s1") {
 		t.Fatalf("sessions should be folded by default:\n%s", view)

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -30,15 +30,7 @@ func jobsModel(t *testing.T, deps Deps, snap Snapshot) Model {
 	m := sizedModel(deps)
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
 	m = next.(Model)
-	// Tab to the Jobs page (Attention → Trains → Agents → Sessions → Jobs).
-	for i := 0; i < 4; i++ {
-		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = next.(Model)
-	}
-	if pages[m.selected].page != pageJobs {
-		t.Fatalf("expected Jobs page, got %v", pages[m.selected].page)
-	}
-	return m
+	return tabToPage(t, m, pageJobs)
 }
 
 func TestFormatJobTime(t *testing.T) {

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -373,8 +373,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 			}
 			if r, ok := m.activityUnderCursor(); ok {
-				// Open the root coordinator's job detail (full request + tree).
-				cmd := m.openJobDetail(JobRow{ID: r.JobID, Agent: r.Agent, Type: r.Action, State: r.State})
+				// Open the selected job's detail — a root coordinator (full request
+				// + delegation tree) or a delegate (the prompt it received + result).
+				cmd := m.openJobDetail(r)
 				m.viewport.SetContent(m.content())
 				return m, cmd
 			}
@@ -837,7 +838,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampPromptCursor()
 			m.clampTrainCursor()
 			m.clampJobCursor()
-			m.activityCursor = clampCursor(m.activityCursor, len(m.snap.Activity))
+			m.activityCursor = clampCursor(m.activityCursor, len(m.activitySelectable()))
 			m.agentCursor = clampCursor(m.agentCursor, len(m.visibleAgents()))
 			m.sessionCursor = clampCursor(m.sessionCursor, len(m.sessionRows()))
 			m.configCursor = clampCursor(m.configCursor, len(m.configEditableFields()))
@@ -964,7 +965,7 @@ func (m *Model) pageCursor() (*int, int) {
 	case pageAttention:
 		return &m.promptCursor, selectableCount(m.attentionVisibleRows())
 	case pageActivity:
-		return &m.activityCursor, len(m.snap.Activity)
+		return &m.activityCursor, len(m.activitySelectable())
 	case pageTrains:
 		return &m.trainCursor, selectableCount(m.trainVisibleRows())
 	case pageAgents:

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -838,7 +838,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampPromptCursor()
 			m.clampTrainCursor()
 			m.clampJobCursor()
-			m.activityCursor = clampCursor(m.activityCursor, len(m.activitySelectable()))
+			m.activityCursor = clampCursor(m.activityCursor, m.activitySelectableLen())
 			m.agentCursor = clampCursor(m.agentCursor, len(m.visibleAgents()))
 			m.sessionCursor = clampCursor(m.sessionCursor, len(m.sessionRows()))
 			m.configCursor = clampCursor(m.configCursor, len(m.configEditableFields()))
@@ -965,7 +965,7 @@ func (m *Model) pageCursor() (*int, int) {
 	case pageAttention:
 		return &m.promptCursor, selectableCount(m.attentionVisibleRows())
 	case pageActivity:
-		return &m.activityCursor, len(m.activitySelectable())
+		return &m.activityCursor, m.activitySelectableLen()
 	case pageTrains:
 		return &m.trainCursor, selectableCount(m.trainVisibleRows())
 	case pageAgents:

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -16,6 +16,7 @@ type page int
 
 const (
 	pageAttention page = iota
+	pageActivity
 	pageTrains
 	pageAgents
 	pageSessions
@@ -33,6 +34,7 @@ var pages = []struct {
 	title string
 }{
 	{pageAttention, "Attention", "Attention"},
+	{pageActivity, "Activity", "Activity — live agent work"},
 	{pageTrains, "Trains", "Trains"},
 	{pageAgents, "Agents", "Agents"},
 	{pageSessions, "Workers", "Runtime workers (agent sessions)"},
@@ -96,18 +98,19 @@ type Model struct {
 	expanded          map[string]bool
 	collapseByDefault bool
 
-	// Attention / Trains page interaction state.
-	mode         mode
-	promptCursor int                  // selected row in snap.Prompts on the Attention page
-	trainCursor  int                  // selected row in snap.Trains on the Trains page
-	active       db.InteractivePrompt // prompt being answered/dismissed in an overlay
-	activeTrain  TrainSession         // train shown in modeTrainDetail
-	choiceIdx    int                  // selected choice in modeAnswerChoice
-	input        textinput.Model      // free-text answer in modeAnswerText
-	actionErr    string               // inline error from the last Answer/Dismiss attempt
-	actionBusy   bool                 // an action is in flight; suppress re-submit
-	showHelp     bool                 // '?' help overlay
-	tickGen      int                  // current tick chain; stale generations are dropped
+	// Attention / Activity / Trains page interaction state.
+	mode           mode
+	promptCursor   int                  // selected row in snap.Prompts on the Attention page
+	activityCursor int                  // selected active root on the Activity page
+	trainCursor    int                  // selected row in snap.Trains on the Trains page
+	active         db.InteractivePrompt // prompt being answered/dismissed in an overlay
+	activeTrain    TrainSession         // train shown in modeTrainDetail
+	choiceIdx      int                  // selected choice in modeAnswerChoice
+	input          textinput.Model      // free-text answer in modeAnswerText
+	actionErr      string               // inline error from the last Answer/Dismiss attempt
+	actionBusy     bool                 // an action is in flight; suppress re-submit
+	showHelp       bool                 // '?' help overlay
+	tickGen        int                  // current tick chain; stale generations are dropped
 
 	// Sessions page interaction state.
 	sessionCursor      int     // selected row in sessionRows()
@@ -368,6 +371,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.openSessionDetail()
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
+			}
+			if r, ok := m.activityUnderCursor(); ok {
+				// Open the root coordinator's job detail (full request + tree).
+				cmd := m.openJobDetail(JobRow{ID: r.JobID, Agent: r.Agent, Type: r.Action, State: r.State})
+				m.viewport.SetContent(m.content())
+				return m, cmd
 			}
 			if agent, ok := m.agentUnderCursor(); ok {
 				cmd := m.openAgentDetail(agent)
@@ -828,6 +837,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampPromptCursor()
 			m.clampTrainCursor()
 			m.clampJobCursor()
+			m.activityCursor = clampCursor(m.activityCursor, len(m.snap.Activity))
 			m.agentCursor = clampCursor(m.agentCursor, len(m.visibleAgents()))
 			m.sessionCursor = clampCursor(m.sessionCursor, len(m.sessionRows()))
 			m.configCursor = clampCursor(m.configCursor, len(m.configEditableFields()))
@@ -953,6 +963,8 @@ func (m *Model) pageCursor() (*int, int) {
 	switch pages[m.selected].page {
 	case pageAttention:
 		return &m.promptCursor, selectableCount(m.attentionVisibleRows())
+	case pageActivity:
+		return &m.activityCursor, len(m.snap.Activity)
 	case pageTrains:
 		return &m.trainCursor, selectableCount(m.trainVisibleRows())
 	case pageAgents:

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -57,10 +57,27 @@ func loadedModel(t *testing.T) Model {
 	return next.(Model)
 }
 
+// tabToPage tabs forward until the given page is selected, running any cmd a
+// landing dispatches (e.g. Health's lazy load). Robust to page-order changes.
+func tabToPage(t *testing.T, m Model, p page) Model {
+	t.Helper()
+	for i := 0; i < len(pages) && pages[m.selected].page != p; i++ {
+		next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+		if cmd != nil {
+			cmd()
+		}
+	}
+	if pages[m.selected].page != p {
+		t.Fatalf("could not reach page %v", p)
+	}
+	return m
+}
+
 func TestPagesRenderExpectedContent(t *testing.T) {
 	m := loadedModel(t)
-	// Page order: Attention, Trains, Agents, Sessions, Jobs, Locks, Health, Config.
-	wants := []string{"Prompts (1)", "train-s1", "planner", "skillopt-generator", "failed", "branch locks", "environment", "edit in $EDITOR"}
+	// Page order: Attention, Activity, Trains, Agents, Workers, Jobs, Locks, Health, Config.
+	wants := []string{"Prompts (1)", "No active jobs", "train-s1", "planner", "skillopt-generator", "failed", "branch locks", "environment", "edit in $EDITOR"}
 	for i, want := range wants {
 		if i > 0 {
 			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
@@ -109,12 +126,8 @@ func TestLoadErrorKeepsStaleData(t *testing.T) {
 	m := loadedModel(t)
 	next, _ := m.Update(snapshotMsg{err: errors.New("db locked"), at: time.Unix(2, 0)})
 	m = next.(Model)
-	// Move to the Agents page (Attention → Trains → Agents) where the stale
-	// data is visible.
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = next.(Model)
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = next.(Model)
+	// Move to the Agents page where the stale data is visible.
+	m = tabToPage(t, m, pageAgents)
 	view := m.View()
 	if !strings.Contains(view, "refresh error: db locked") {
 		t.Fatalf("expected error banner, got:\n%s", view)

--- a/internal/cli/tui/root_test.go
+++ b/internal/cli/tui/root_test.go
@@ -53,7 +53,8 @@ func driveRoot(t *testing.T, root Root, msg tea.Msg) Root {
 func TestRootPushesTrainViewOnTrainsEnter(t *testing.T) {
 	root := rootWithDashboard(t)
 	// Tab to Trains, then enter.
-	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab})
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab}) // Attention → Activity
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab}) // Activity → Trains
 	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyEnter})
 	if len(root.stack) != 2 {
 		t.Fatalf("enter on Trains should push the train view, stack=%d", len(root.stack))
@@ -65,7 +66,8 @@ func TestRootPushesTrainViewOnTrainsEnter(t *testing.T) {
 
 func TestRootPopsBackToDashboard(t *testing.T) {
 	root := rootWithDashboard(t)
-	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab})
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab}) // Attention → Activity
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab}) // Activity → Trains
 	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyEnter})
 	if len(root.stack) != 2 {
 		t.Fatalf("setup: stack=%d", len(root.stack))
@@ -82,7 +84,8 @@ func TestRootPopsBackToDashboard(t *testing.T) {
 
 func TestRootCtrlCQuitsFromChild(t *testing.T) {
 	root := rootWithDashboard(t)
-	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab})
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab}) // Attention → Activity
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab}) // Activity → Trains
 	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyEnter})
 	_, cmd := root.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	if cmd == nil {
@@ -95,7 +98,8 @@ func TestRootCtrlCQuitsFromChild(t *testing.T) {
 
 func TestRootBroadcastsWindowSize(t *testing.T) {
 	root := rootWithDashboard(t)
-	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab})
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab}) // Attention → Activity
+	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyTab}) // Activity → Trains
 	root = driveRoot(t, root, tea.KeyMsg{Type: tea.KeyEnter})
 	next, _ := root.Update(tea.WindowSizeMsg{Width: 60, Height: 20})
 	root = next.(Root)

--- a/internal/cli/tui/sessions_test.go
+++ b/internal/cli/tui/sessions_test.go
@@ -16,14 +16,7 @@ func sessionsPageModel(t *testing.T, snap Snapshot) Model {
 	m := sizedModel(Deps{Load: func() (Snapshot, error) { return snap, nil }})
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1_700_000_000, 0)})
 	m = next.(Model)
-	for i := 0; i < 3; i++ {
-		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = next.(Model)
-	}
-	if pages[m.selected].page != pageSessions {
-		t.Fatalf("expected Sessions page, got %v", pages[m.selected].page)
-	}
-	return m
+	return tabToPage(t, m, pageSessions)
 }
 
 func sessionDetailSnapshot() Snapshot {
@@ -108,14 +101,7 @@ func sessionsPageModelWithDeps(t *testing.T, snap Snapshot, deps Deps) Model {
 	m := sizedModel(deps)
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1_700_000_000, 0)})
 	m = next.(Model)
-	for i := 0; i < 3; i++ {
-		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = next.(Model)
-	}
-	if pages[m.selected].page != pageSessions {
-		t.Fatalf("expected Sessions page, got %v", pages[m.selected].page)
-	}
-	return m
+	return tabToPage(t, m, pageSessions)
 }
 
 func TestSessionStopSingleConfirms(t *testing.T) {
@@ -192,13 +178,7 @@ func TestLocksPageShowsGuidance(t *testing.T) {
 	m := sizedModel(Deps{Load: func() (Snapshot, error) { return snap, nil }})
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1_700_000_000, 0)})
 	m = next.(Model)
-	for i := 0; i < 5; i++ { // Attention → … → Locks (6th page)
-		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = next.(Model)
-	}
-	if pages[m.selected].page != pageLocks {
-		t.Fatalf("expected Locks page, got %v", pages[m.selected].page)
-	}
+	m = tabToPage(t, m, pageLocks)
 	view := m.View()
 	for _, want := range []string{"what to do: usually nothing", "gitmoot lock release"} {
 		if !strings.Contains(view, want) {

--- a/internal/cli/tui/trains_action_test.go
+++ b/internal/cli/tui/trains_action_test.go
@@ -27,12 +27,7 @@ func trainsActionModel(t *testing.T, deps Deps, snap Snapshot) Model {
 	m := sizedModel(deps)
 	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
 	m = next.(Model)
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // Attention → Trains
-	m = next.(Model)
-	if pages[m.selected].page != pageTrains {
-		t.Fatalf("expected Trains page, got %v", pages[m.selected].page)
-	}
-	return m
+	return tabToPage(t, m, pageTrains)
 }
 
 func typeText(t *testing.T, m Model, text string) Model {

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -110,6 +110,8 @@ func (m Model) content() string {
 		switch pages[m.selected].page {
 		case pageAttention:
 			b.WriteString(m.attentionContent())
+		case pageActivity:
+			b.WriteString(m.activityContent())
 		case pageTrains:
 			b.WriteString(m.trainsContent())
 		case pageAgents:
@@ -145,6 +147,12 @@ func (m Model) helpContent() string {
 			b.WriteString("B    report bug for the selected job\n")
 		}
 		b.WriteString("s    start the daemon when it is stopped\n")
+	case pageActivity:
+		b.WriteString("live delegation trees with queued/running work (newest first)\n")
+		b.WriteString("each root shows the coordinator, a progress summary, and the\n")
+		b.WriteString("delegation children (which agent is doing what, and its state)\n")
+		b.WriteString("↑/↓  select an active root\n")
+		b.WriteString("enter open the root's full detail (request + delegation tree)\n")
 	case pageTrains:
 		b.WriteString("↑/↓  select a train session\n")
 		b.WriteString("enter open the session (live phase view; esc returns)\n")
@@ -246,6 +254,8 @@ func (m Model) footerHelp() string {
 			help += "  B report bug"
 		}
 		return help + "  ? help  q quit"
+	case pageActivity:
+		return "tab/←→ page  ↑/↓ select  enter open root  ? help  q quit"
 	case pageTrains:
 		return "tab/←→ page  ↑/↓ select  enter open  s stop  d delete  ? help  q quit"
 	case pageAgents:

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -255,7 +255,7 @@ func (m Model) footerHelp() string {
 		}
 		return help + "  ? help  q quit"
 	case pageActivity:
-		return "tab/←→ page  ↑/↓ select  enter open root  ? help  q quit"
+		return "tab/←→ page  ↑/↓ select root or delegate  enter open detail  ? help  q quit"
 	case pageTrains:
 		return "tab/←→ page  ↑/↓ select  enter open  s stop  d delete  ? help  q quit"
 	case pageAgents:


### PR DESCRIPTION
## What

Adds a dedicated **Activity** page to the `gitmoot dashboard` TUI: a live, refresh-every-5s view of the delegation trees that have queued/running work — *what are agents working on right now*. Each tree shows the coordinator line, a progress summary (`N delegations · running · queued · blocked · done`), the delegation children (which agent is doing what, and its state), and the continuation job. The cursor walks roots **and** delegates; `enter` opens the selected job's detail (its full request + result).

Built on the existing `buildDelegationTree` used by the job-detail view — no schema change (the originating root is found via empty `ParentJobID`).

## Commits

- Live Activity page (delegation trees of active jobs)
- Split queued from running in the progress summary
- Make delegates selectable + drill-in to a delegate's own detail
- Window the page so it scrolls with the cursor
- **Harden after `/code-review`** (this PR's final commit) — see below

## Review fixes (high-effort `/code-review`, 14 finder angles across two passes)

- **Cheap refresh tick restored** — payloads are parsed only for the few *live* roots and their direct children, not every job on every tick (the prior version full-scanned `ListJobs` and unmarshalled each payload, defeating the documented cheap-tick design of the Attention path).
- **Consistent active scope** — a root is surfaced iff the root, a direct delegation child, or the continuation is live, and the counts use that same scope; no more "active" trees rendering a settled coordinator with `0 running`.
- **Wide fan-out windowing** — the page windows flat display rows around the cursor (mirroring the Jobs page), so a 20-child fan-out or a short terminal always keeps the selected delegate on-screen.
- **Correct ordering** — roots sort by the freshest update *across the tree*, not the coordinator's frozen timestamp (a coordinator stops updating once it fans out), so "newest activity first" holds.
- **Corrective continuation visible** — a live continuation renders even when the root has no fresh delegations.
- Root `UpdatedAt` propagated into the detail view; defensive cursor clamp in the renderer; no per-keystroke allocation of the selectable slice.

## Known limitation (documented in code)

Scope is intentionally **one level deep**: the page renders direct delegations, so a tree whose root and direct children have all settled is not surfaced even if a deeper *grandchild* (a sub-coordinator's own delegation) is still running — surfacing it would show an all-settled coordinator with the live grandchild invisible. Full recursive-tree rendering is a separate, larger change.

## Tests / gate

`go build`, `go vet`, `go test ./...`, and `go test -race ./internal/workflow/` all green. New tests cover the active-scope consistency, tree-wide sort, wide-fan-out windowing, and corrective-continuation visibility.

## Verification

Verified end-to-end against a real coordinator → 5 kimi delegates fan-out (each wrote a joke; continuation collected them) with the live dashboard open on the Activity tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)