### PR TITLE
feat(tui): close the dashboard-overhaul gaps — Jobs grouping, Config sections, Standalone-agents label

### DIFF
--- a/internal/cli/tui/activity.go
+++ b/internal/cli/tui/activity.go
@@ -43,15 +43,15 @@ func (m Model) activityUnderCursor() (JobRow, bool) {
 	return sel[m.activityCursor], true
 }
 
-// activityWindowCap is how many display rows fit the Activity page, leaving room
-// for the title/intro, the above/below markers, and the footer. Mirrors
-// jobsWindowCap so a wide fan-out (or a short terminal) never pushes the cursor
-// off-screen.
+// activityWindowCap is how many display rows fit the Activity page. The viewport
+// is height-4; the page also renders the title block (2), the intro (2), both
+// scroll markers (2), and the footer (1) = 7 lines of chrome, so the window keeps
+// to height-11 to stay inside the viewport even when both markers show.
 func activityWindowCap(height int) int {
-	if height-9 < 3 {
+	if height-11 < 3 {
 		return 3
 	}
-	return height - 9
+	return height - 11
 }
 
 // activityRow is one rendered line of the Activity page. Selectable rows (a root

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -600,10 +600,11 @@ func (m Model) agentsContentInteractive() string {
 }
 
 // agentGroupLabel is the section header for a template group; agents without a
-// template share the "(no template)" group.
+// template — they run a custom prompt rather than a reusable template — share
+// the "Standalone agents" group.
 func agentGroupLabel(templateID string) string {
 	if strings.TrimSpace(templateID) == "" {
-		return "(no template)"
+		return "Standalone agents (custom prompt)"
 	}
 	return templateID
 }
@@ -663,7 +664,7 @@ func (m Model) agentDetailView() string {
 	b.WriteByte('\n')
 	switch {
 	case a.TemplateID == "":
-		b.WriteString(mutedStyle.Render("no template") + "\n")
+		b.WriteString(mutedStyle.Render("none — standalone agent, runs a custom prompt") + "\n")
 	case m.agentVersionsErr != "":
 		b.WriteString(errorStyle.Render(m.agentVersionsErr) + "\n")
 	case !m.agentVersionsLoaded:

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -57,9 +57,9 @@ func TestAgentsPageHidesTrainingAgents(t *testing.T) {
 		t.Fatalf("training agents must be hidden:\n%s", view)
 	}
 	// The hidden training agents have empty TemplateID, but they are filtered
-	// before grouping, so they must not surface a "(no template)" header.
-	if strings.Contains(view, "(no template)") {
-		t.Fatalf("hidden agents must not introduce a (no template) group:\n%s", view)
+	// before grouping, so they must not surface a "Standalone agents (custom prompt)" header.
+	if strings.Contains(view, "Standalone agents (custom prompt)") {
+		t.Fatalf("hidden agents must not introduce a Standalone agents (custom prompt) group:\n%s", view)
 	}
 	// The cursor + enter act on the VISIBLE list (planner is first visible).
 	if a, ok := m.agentUnderCursor(); !ok || a.Name != "planner" {
@@ -76,7 +76,7 @@ func TestAgentsPageHidesTrainingAgents(t *testing.T) {
 func TestAgentsPageGroupsByTemplate(t *testing.T) {
 	snap := agentsSnapshot()
 	// A second agent on planner-tpl (stays in the planner-tpl group) and one
-	// with no template (its own "(no template)" group).
+	// with no template (its own "Standalone agents (custom prompt)" group).
 	snap.Agents = append(snap.Agents,
 		Agent{Name: "scout", Runtime: "claude", TemplateID: "planner-tpl"},
 		Agent{Name: "drifter", Runtime: "codex"},
@@ -84,26 +84,26 @@ func TestAgentsPageGroupsByTemplate(t *testing.T) {
 	m := agentsModel(t, Deps{}, snap)
 	view := m.View()
 	// Both template headers and the no-template header render.
-	for _, want := range []string{"planner-tpl", "reviewer-tpl", "(no template)"} {
+	for _, want := range []string{"planner-tpl", "reviewer-tpl", "Standalone agents (custom prompt)"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("grouped view missing header %q:\n%s", want, view)
 		}
 	}
 	// Headers appear in first-appearance order: planner-tpl, then reviewer-tpl,
-	// then the (no template) group last.
+	// then the Standalone agents (custom prompt) group last.
 	pIdx := strings.Index(view, "planner-tpl")
 	rIdx := strings.Index(view, "reviewer-tpl")
-	nIdx := strings.Index(view, "(no template)")
+	nIdx := strings.Index(view, "Standalone agents (custom prompt)")
 	if !(pIdx < rIdx && rIdx < nIdx) {
 		t.Fatalf("group headers out of order (planner=%d reviewer=%d none=%d):\n%s", pIdx, rIdx, nIdx, view)
 	}
-	// The (no template) header precedes its sole member.
+	// The Standalone agents (custom prompt) header precedes its sole member.
 	if nIdx > strings.Index(view, "drifter") {
-		t.Fatalf("the (no template) header should precede its agent:\n%s", view)
+		t.Fatalf("the Standalone agents (custom prompt) header should precede its agent:\n%s", view)
 	}
 	// Cursor follows the on-screen (grouped) order, so ↑/↓ step through rows in
 	// the order they render: the planner-tpl group (planner, scout) first, then
-	// reviewer-tpl (reviewer), then the (no template) group (drifter).
+	// reviewer-tpl (reviewer), then the Standalone agents (custom prompt) group (drifter).
 	wants := []string{"planner", "scout", "reviewer", "drifter"}
 	for i, want := range wants {
 		a, ok := m.agentUnderCursor()

--- a/internal/cli/tui/collapse.go
+++ b/internal/cli/tui/collapse.go
@@ -117,6 +117,49 @@ func selectedItemIndex(rows []listRow, cursor int) int {
 	return r.itemIdx
 }
 
+// windowListRows keeps the page within `capacity` rendered rows by returning the
+// slice around the cursor's selected row, the cursor re-based to that slice, and
+// the count of rows hidden above/below. When the rows already fit it returns them
+// unchanged. This lets a collapsible list whose expanded groups can overflow the
+// viewport (e.g. Jobs) stay scrollable with the selection always visible, the
+// same window-around-cursor pattern the flat lists use.
+func windowListRows(rows []listRow, cursor, capacity int) (windowed []listRow, relCursor, above, below int) {
+	if capacity < 1 {
+		capacity = 1
+	}
+	if len(rows) <= capacity {
+		return rows, cursor, 0, 0
+	}
+	// Absolute index of the cursor-th selectable row.
+	selIdx, n := 0, 0
+	for i, r := range rows {
+		if !r.selectable() {
+			continue
+		}
+		if n == cursor {
+			selIdx = i
+			break
+		}
+		n++
+	}
+	start := selIdx - capacity/2
+	if start < 0 {
+		start = 0
+	}
+	if start > len(rows)-capacity {
+		start = len(rows) - capacity
+	}
+	end := start + capacity
+	// Re-base the cursor: subtract the selectable rows hidden before the window.
+	hidden := 0
+	for _, r := range rows[:start] {
+		if r.selectable() {
+			hidden++
+		}
+	}
+	return rows[start:end], cursor - hidden, start, len(rows) - end
+}
+
 // renderListRows writes the visible rows into b. cursor is the index among the
 // SELECTABLE rows of the highlighted row. Headers show a [-]/[+] collapse marker;
 // the selected row gets the "▸ " cursor marker. Indent follows depth.

--- a/internal/cli/tui/config.go
+++ b/internal/cli/tui/config.go
@@ -20,6 +20,18 @@ func (m Model) configEditableFields() []ConfigField {
 	return fields
 }
 
+// configFieldEntity splits a 3+-part config KeyPath (e.g. [agents, <name>,
+// <setting>]) into the middle entity it belongs to and the leaf setting, so the
+// Config page can sub-group a section's editable fields under that entity (one
+// heading per agent instead of a flat "<agent> · <setting>" list). Shorter
+// KeyPaths return empty strings and render flat under their section.
+func configFieldEntity(f ConfigField) (entity, setting string) {
+	if len(f.KeyPath) >= 3 {
+		return f.KeyPath[1], f.KeyPath[len(f.KeyPath)-1]
+	}
+	return "", ""
+}
+
 // openConfigEdit enters the inline edit overlay for a scalar field.
 func (m *Model) openConfigEdit(field ConfigField) tea.Cmd {
 	m.configField = field
@@ -192,12 +204,25 @@ func (m Model) configContent() string {
 				continue
 			}
 			b.WriteString("  " + mutedStyle.Render(section.Title) + "\n")
+			curEntity := ""
 			for _, field := range section.Editable {
-				cursor, label := "  ", field.Label
-				if idx == m.configCursor {
-					cursor, label = "▸ ", selectedRowStyle.Render(field.Label)
+				// Fields with an entity (e.g. each agent type) get a sub-heading so
+				// their settings group together; the redundant entity prefix is then
+				// dropped from the label.
+				entity, setting := configFieldEntity(field)
+				label, indent := field.Label, "    "
+				if entity != "" {
+					if entity != curEntity {
+						curEntity = entity
+						b.WriteString("    " + mutedStyle.Render(entity) + "\n")
+					}
+					label, indent = setting, "      "
 				}
-				b.WriteString("    " + cursor + label + "  " + mutedStyle.Render(dash(field.Value)) + "\n")
+				cursor, shown := "  ", label
+				if idx == m.configCursor {
+					cursor, shown = "▸ ", selectedRowStyle.Render(label)
+				}
+				b.WriteString(indent + cursor + shown + "  " + mutedStyle.Render(dash(field.Value)) + "\n")
 				idx++
 			}
 		}

--- a/internal/cli/tui/config.go
+++ b/internal/cli/tui/config.go
@@ -178,17 +178,28 @@ func (m Model) configContent() string {
 		b.WriteByte('\n')
 	}
 
-	// Inline-editable scalars as a cursor list (enter to change one).
-	fields := m.configEditableFields()
-	if len(fields) > 0 {
+	// Inline-editable scalars as a cursor list (enter to change one), grouped
+	// under their config section so related settings stay together. m.configCursor
+	// still indexes the flat configEditableFields() order — these same sections
+	// concatenated — so the running index stays in lockstep while the per-section
+	// sub-headers are display-only.
+	if len(m.configEditableFields()) > 0 {
 		b.WriteString(headerStyle.Render("editable settings"))
 		b.WriteByte('\n')
-		for i, field := range fields {
-			cursor, label := "  ", field.Label
-			if i == m.configCursor {
-				cursor, label = "▸ ", selectedRowStyle.Render(field.Label)
+		idx := 0
+		for _, section := range cv.Sections {
+			if len(section.Editable) == 0 {
+				continue
 			}
-			b.WriteString(cursor + label + "  " + mutedStyle.Render(dash(field.Value)) + "\n")
+			b.WriteString("  " + mutedStyle.Render(section.Title) + "\n")
+			for _, field := range section.Editable {
+				cursor, label := "  ", field.Label
+				if idx == m.configCursor {
+					cursor, label = "▸ ", selectedRowStyle.Render(field.Label)
+				}
+				b.WriteString("    " + cursor + label + "  " + mutedStyle.Render(dash(field.Value)) + "\n")
+				idx++
+			}
 		}
 		b.WriteByte('\n')
 	}
@@ -205,7 +216,7 @@ func (m Model) configContent() string {
 	}
 
 	hint := "e edit in $EDITOR · structural edits stay in the editor"
-	if len(fields) > 0 {
+	if len(m.configEditableFields()) > 0 {
 		hint = "↑/↓ select · enter change · " + hint
 	}
 	b.WriteString("\n" + mutedStyle.Render(hint))

--- a/internal/cli/tui/config_test.go
+++ b/internal/cli/tui/config_test.go
@@ -114,6 +114,48 @@ func TestConfigEditableSettingsGroupedBySection(t *testing.T) {
 	}
 }
 
+// TestConfigEditableSettingsSubgroupedByEntity verifies that editable fields with
+// a 3-part KeyPath (e.g. per agent type) sub-group under the entity name, with the
+// redundant "<entity> · " prefix dropped from the field label.
+func TestConfigEditableSettingsSubgroupedByEntity(t *testing.T) {
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		Config: ConfigView{
+			Path: "/c.toml",
+			Sections: []ConfigSection{{
+				Title: "agent types",
+				Editable: []ConfigField{
+					{Label: "planner · max_background", KeyPath: []string{"agents", "planner", "max_background"}, Value: "4"},
+					{Label: "planner · idle_timeout", KeyPath: []string{"agents", "planner", "idle_timeout"}, Value: "10m"},
+					{Label: "reviewer · max_background", KeyPath: []string{"agents", "reviewer", "max_background"}, Value: "2"},
+				},
+			}},
+		},
+	}
+	m := configModel(t, Deps{}, snap)
+	view := m.View()
+	eb := strings.Index(view, "editable settings")
+	if eb < 0 {
+		t.Fatalf("missing editable settings block:\n%s", view)
+	}
+	sub := view[eb:]
+	// The flat "<entity> · <setting>" label is gone; entity is a sub-heading.
+	if strings.Contains(sub, "planner · max_background") {
+		t.Fatalf("entity prefix should be dropped from the field label:\n%s", sub)
+	}
+	last := -1
+	for _, s := range []string{"agent types", "planner", "max_background", "idle_timeout", "reviewer"} {
+		i := strings.Index(sub, s)
+		if i < 0 {
+			t.Fatalf("editable block missing %q:\n%s", s, sub)
+		}
+		if i < last {
+			t.Fatalf("editable block out of order at %q:\n%s", s, sub)
+		}
+		last = i
+	}
+}
+
 func TestConfigEditDispatchesEditorCmd(t *testing.T) {
 	edited := false
 	deps := Deps{

--- a/internal/cli/tui/config_test.go
+++ b/internal/cli/tui/config_test.go
@@ -61,6 +61,59 @@ func TestConfigPageRendersSections(t *testing.T) {
 	}
 }
 
+// TestConfigEditableSettingsGroupedBySection verifies the editable settings
+// render grouped under their section sub-headers (in section order) while the
+// cursor still indexes the flat field order across sections.
+func TestConfigEditableSettingsGroupedBySection(t *testing.T) {
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		Config: ConfigView{
+			Path: "/c.toml",
+			Sections: []ConfigSection{
+				{Title: "daemon", Editable: []ConfigField{{Label: "workers", Value: "1"}}},
+				{Title: "delegation", Editable: []ConfigField{
+					{Label: "max depth", Value: "8"},
+					{Label: "budget", Value: "40"},
+				}},
+			},
+		},
+	}
+	m := configModel(t, Deps{}, snap)
+	view := m.View()
+
+	// Within the editable block, each section sub-header precedes its fields, in
+	// section order (slice the view from "editable settings" so the read-only
+	// overview above it can't satisfy the assertion).
+	eb := strings.Index(view, "editable settings")
+	if eb < 0 {
+		t.Fatalf("missing editable settings block:\n%s", view)
+	}
+	sub := view[eb:]
+	last := -1
+	for _, s := range []string{"daemon", "workers", "delegation", "max depth", "budget"} {
+		i := strings.Index(sub, s)
+		if i < 0 {
+			t.Fatalf("editable block missing %q:\n%s", s, sub)
+		}
+		if i < last {
+			t.Fatalf("editable block out of order at %q:\n%s", s, sub)
+		}
+		last = i
+	}
+
+	// The cursor indexes the flat field order across sections.
+	if f := m.configEditableFields(); len(f) != 3 || f[0].Label != "workers" || f[2].Label != "budget" {
+		t.Fatalf("flat field order wrong: %+v", f)
+	}
+	for i := 0; i < 2; i++ {
+		next, _ := m.Update(key("j"))
+		m = next.(Model)
+	}
+	if m.configCursor != 2 {
+		t.Fatalf("cursor should be 2 (budget) after two downs, got %d", m.configCursor)
+	}
+}
+
 func TestConfigEditDispatchesEditorCmd(t *testing.T) {
 	edited := false
 	deps := Deps{

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -275,12 +275,12 @@ type jobStatusGroup struct {
 	jobs  []JobRow
 }
 
-// jobsByStatusGroup buckets the snapshot jobs by state into display-ordered
-// groups (active first). Both jobsOrdered and jobsListRows derive from this, so
-// the cursor's item index and the rendered rows can never drift apart.
-func (m Model) jobsByStatusGroup() []jobStatusGroup {
+// computeJobsByStatusGroup buckets job rows by state into display-ordered groups
+// (active first, then any unknown states sorted). Pure over its input so the
+// result can be memoized per snapshot.
+func computeJobsByStatusGroup(jobRows []JobRow) []jobStatusGroup {
 	byState := map[string][]JobRow{}
-	for _, j := range m.snap.JobRows {
+	for _, j := range jobRows {
 		byState[j.State] = append(byState[j.State], j)
 	}
 	var groups []jobStatusGroup
@@ -302,6 +302,40 @@ func (m Model) jobsByStatusGroup() []jobStatusGroup {
 		groups = append(groups, jobStatusGroup{st, byState[st]})
 	}
 	return groups
+}
+
+// jobsByStatusGroup returns the status groups, reusing the per-snapshot cache
+// (m.jobGroups, set when the snapshot is applied) so jobsVisibleRows/jobsOrdered/
+// jobUnderCursor don't each re-bucket every job on every keystroke. Falls back to
+// computing on the fly when the cache is unset, so correctness never depends on
+// it. Both jobsOrdered and jobsListRows derive from this, so the cursor's item
+// index and the rendered rows can never drift apart.
+func (m Model) jobsByStatusGroup() []jobStatusGroup {
+	if m.jobGroups != nil {
+		return m.jobGroups
+	}
+	return computeJobsByStatusGroup(m.snap.JobRows)
+}
+
+// jobsSummaryOrder lists the states present in byState in the same active-first
+// order as the status groups, so the top summary line mirrors the sections.
+func jobsSummaryOrder(byState map[string]int) []string {
+	var out []string
+	used := map[string]bool{}
+	for _, st := range jobStatusGroupOrder {
+		if byState[st] > 0 {
+			out = append(out, st)
+			used[st] = true
+		}
+	}
+	var rest []string
+	for st, n := range byState {
+		if n > 0 && !used[st] {
+			rest = append(rest, st)
+		}
+	}
+	sort.Strings(rest)
+	return append(out, rest...)
 }
 
 // jobsOrdered is the jobs flattened in status-group order — the index space the
@@ -350,37 +384,58 @@ func (m Model) jobsContentInteractive() string {
 	}
 	var b strings.Builder
 	summary := []string{}
-	for _, state := range sortedKeys(m.snap.Jobs.ByState) {
+	for _, state := range jobsSummaryOrder(m.snap.Jobs.ByState) {
 		summary = append(summary, jobStateColor(state)+" "+strconv.Itoa(m.snap.Jobs.ByState[state]))
 	}
 	b.WriteString(mutedStyle.Render(strconv.Itoa(m.snap.Jobs.Total)+" total") + "  " + strings.Join(summary, "  "))
 	b.WriteString("\n\n")
 
-	windowed, rel, above, below := windowListRows(m.jobsVisibleRows(), m.jobCursor, jobsWindowCap(m.height))
+	rows := m.jobsVisibleRows()
+	windowed, rel, above, below := windowListRows(rows, m.jobCursor, jobsWindowCap(m.height))
 	if above > 0 {
-		b.WriteString(mutedStyle.Render("↑ "+strconv.Itoa(above)+" more rows above") + "\n")
+		// above == the window start index; keep the status-group context when the
+		// window opens mid-group (the group's header scrolled off).
+		marker := "↑ " + strconv.Itoa(above) + " more rows above"
+		if above < len(rows) && !rows[above].header {
+			for i := above - 1; i >= 0; i-- {
+				if rows[i].header {
+					marker += " · " + rows[i].text + " (continued)"
+					break
+				}
+			}
+		}
+		b.WriteString(mutedStyle.Render(marker) + "\n")
 	}
 	renderListRows(&b, windowed, rel)
 	if below > 0 {
 		b.WriteString(mutedStyle.Render("↓ "+strconv.Itoa(below)+" more rows below") + "\n")
 	}
 
-	help := "↑/↓ select · space open/close · enter detail · R retry · c cancel"
-	if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
-		help += " · B report bug"
+	// enter toggles a collapsed group header; it only opens a detail on a job leaf.
+	help := "↑/↓ select · space open/close"
+	if m.cursorOnHeader() {
+		help += " · enter open/close"
+	} else {
+		help += " · enter detail · R retry · c cancel"
+		if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
+			help += " · B report bug"
+		}
 	}
 	b.WriteString("\n" + mutedStyle.Render(help))
 	b.WriteByte('\n')
 	return b.String()
 }
 
-// jobsWindowCap is how many job rows fit the Jobs page, leaving room for the
-// title, summary, more/earlier markers, and footer.
+// jobsWindowCap is how many list rows fit the Jobs page. The viewport is
+// height-4; the page also renders the title block (2), the summary (2), both
+// scroll markers (2), and the blank-line+help footer (2) = 8 lines of chrome, so
+// the window keeps to height-12 to stay inside the viewport even when both
+// markers show.
 func jobsWindowCap(height int) int {
-	if height-9 < 3 {
+	if height-12 < 3 {
 		return 3
 	}
-	return height - 9
+	return height - 12
 }
 
 // formatJobTime renders a stored ISO timestamp ("2006-01-02 15:04:05", UTC from

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -478,14 +478,15 @@ func (m Model) jobDetailView() string {
 	b.WriteString(renderRows(rows))
 	b.WriteByte('\n')
 
-	// What was asked. Shown in full (newlines preserved) — the detail viewport
-	// scrolls, so the whole request is readable, not just the first lines.
+	// What was asked. Shown in full, soft-wrapped to the viewport width so long
+	// lines aren't clipped at the right edge; the viewport scrolls vertically.
+	width := m.viewport.Width
 	if d.Request != "" {
 		b.WriteString(headerStyle.Render("request"))
 		b.WriteByte('\n')
-		b.WriteString(strings.TrimRight(d.Request, "\n") + "\n\n")
+		b.WriteString(wrapText(strings.TrimRight(d.Request, "\n"), width) + "\n\n")
 	}
-	// What came back (settled jobs). Shown in full; the viewport scrolls.
+	// What came back (settled jobs). Shown in full, wrapped the same way.
 	if d.ResultDecision != "" || d.ResultSummary != "" {
 		b.WriteString(headerStyle.Render("result"))
 		b.WriteByte('\n')
@@ -493,7 +494,7 @@ func (m Model) jobDetailView() string {
 			b.WriteString("decision  " + jobDecisionColor(d.ResultDecision) + "\n")
 		}
 		if d.ResultSummary != "" {
-			b.WriteString(strings.TrimRight(d.ResultSummary, "\n") + "\n")
+			b.WriteString(wrapText(strings.TrimRight(d.ResultSummary, "\n"), width) + "\n")
 		}
 		b.WriteByte('\n')
 	}

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -55,10 +56,15 @@ func (m *Model) openJobConfirm(job JobRow, cancel bool) {
 func (m Model) jobUnderCursor() (JobRow, bool) {
 	switch pages[m.selected].page {
 	case pageJobs:
-		if len(m.snap.JobRows) == 0 {
+		idx := selectedItemIndex(m.jobsVisibleRows(), m.jobCursor)
+		if idx < 0 {
 			return JobRow{}, false
 		}
-		return m.snap.JobRows[m.jobCursor], true
+		ordered := m.jobsOrdered()
+		if idx < len(ordered) {
+			return ordered[idx], true
+		}
+		return JobRow{}, false
 	case pageAttention:
 		idx := selectedItemIndex(m.attentionVisibleRows(), m.promptCursor)
 		if idx < 0 {
@@ -257,8 +263,87 @@ func depsLabel(c JobChild) string {
 	return strings.Join(c.Deps, ",") + suffix
 }
 
-// jobsContentInteractive renders the Jobs page as a selectable list. Job
-// overlays (detail/confirm) are dispatched once in content(), not here.
+// jobStatusGroupOrder lists job states in the order the Jobs page groups them —
+// active work first, the settled pile last. States outside this list (defensive)
+// are appended in sorted order.
+var jobStatusGroupOrder = []string{"running", "queued", "blocked", "failed", "succeeded", "cancelled"}
+
+// jobStatusGroup is one status section of the Jobs page: a state and its jobs in
+// snapshot order.
+type jobStatusGroup struct {
+	state string
+	jobs  []JobRow
+}
+
+// jobsByStatusGroup buckets the snapshot jobs by state into display-ordered
+// groups (active first). Both jobsOrdered and jobsListRows derive from this, so
+// the cursor's item index and the rendered rows can never drift apart.
+func (m Model) jobsByStatusGroup() []jobStatusGroup {
+	byState := map[string][]JobRow{}
+	for _, j := range m.snap.JobRows {
+		byState[j.State] = append(byState[j.State], j)
+	}
+	var groups []jobStatusGroup
+	used := map[string]bool{}
+	for _, st := range jobStatusGroupOrder {
+		if jobs := byState[st]; len(jobs) > 0 {
+			groups = append(groups, jobStatusGroup{st, jobs})
+			used[st] = true
+		}
+	}
+	var rest []string
+	for st := range byState {
+		if !used[st] {
+			rest = append(rest, st)
+		}
+	}
+	sort.Strings(rest)
+	for _, st := range rest {
+		groups = append(groups, jobStatusGroup{st, byState[st]})
+	}
+	return groups
+}
+
+// jobsOrdered is the jobs flattened in status-group order — the index space the
+// Jobs cursor resolves through (leaf itemIdx in jobsListRows points here).
+func (m Model) jobsOrdered() []JobRow {
+	var out []JobRow
+	for _, g := range m.jobsByStatusGroup() {
+		out = append(out, g.jobs...)
+	}
+	return out
+}
+
+// jobsListRows builds the collapsible Jobs tree: one header per status group
+// (×count) with its jobs as leaves. The state lives in the header, so leaves omit
+// it — except a job being cancelled, which shows a transient inline label.
+func (m Model) jobsListRows() []listRow {
+	var rows []listRow
+	idx := 0
+	for _, g := range m.jobsByStatusGroup() {
+		key := "jobs:status:" + g.state
+		rows = append(rows, headerRow(key, 0, g.state+"  ×"+strconv.Itoa(len(g.jobs))))
+		for _, j := range g.jobs {
+			line := j.ID + "  " + j.Agent + "  " + j.Type + "  " + mutedStyle.Render(formatJobTime(j.UpdatedAt))
+			if _, pending := m.cancelling[j.ID]; pending && jobCancelable(j.State) {
+				line += "  " + "cancelling…"
+			}
+			rows = append(rows, leafRow(1, line, idx, key))
+			idx++
+		}
+	}
+	return rows
+}
+
+// jobsVisibleRows is the Jobs tree filtered by collapse state — the rows rendered
+// and the index space m.jobCursor walks.
+func (m Model) jobsVisibleRows() []listRow {
+	return visibleListRows(m.jobsListRows(), m.groupCollapsed)
+}
+
+// jobsContentInteractive renders the Jobs page as a collapsible list grouped by
+// status, windowed so the selection stays visible even when a status group has
+// hundreds of jobs. Job overlays (detail/confirm) are dispatched in content().
 func (m Model) jobsContentInteractive() string {
 	if len(m.snap.JobRows) == 0 {
 		return m.loadingOr("No jobs.", !m.loadedAt.IsZero())
@@ -270,49 +355,21 @@ func (m Model) jobsContentInteractive() string {
 	}
 	b.WriteString(mutedStyle.Render(strconv.Itoa(m.snap.Jobs.Total)+" total") + "  " + strings.Join(summary, "  "))
 	b.WriteString("\n\n")
-	// Window the list so the cursor stays on-screen even with hundreds of jobs;
-	// the cursor is kept roughly centered (stateless — derived from jobCursor).
-	rows := m.snap.JobRows
-	n := len(rows)
-	capacity := jobsWindowCap(m.height)
-	start := 0
-	if n > capacity {
-		start = m.jobCursor - capacity/2
-		if start < 0 {
-			start = 0
-		}
-		if start > n-capacity {
-			start = n - capacity
-		}
+
+	windowed, rel, above, below := windowListRows(m.jobsVisibleRows(), m.jobCursor, jobsWindowCap(m.height))
+	if above > 0 {
+		b.WriteString(mutedStyle.Render("↑ "+strconv.Itoa(above)+" more rows above") + "\n")
 	}
-	end := start + capacity
-	if end > n {
-		end = n
+	renderListRows(&b, windowed, rel)
+	if below > 0 {
+		b.WriteString(mutedStyle.Render("↓ "+strconv.Itoa(below)+" more rows below") + "\n")
 	}
-	if start > 0 {
-		b.WriteString(mutedStyle.Render("↑ "+strconv.Itoa(start)+" earlier") + "\n")
-	}
-	for i := start; i < end; i++ {
-		job := rows[i]
-		cursor, id := "  ", job.ID
-		state := job.State
-		if _, pending := m.cancelling[job.ID]; pending && jobCancelable(job.State) {
-			state = "cancelling…"
-		}
-		if i == m.jobCursor {
-			cursor, id = "▸ ", selectedRowStyle.Render(job.ID)
-		}
-		b.WriteString(cursor + id + "  " + job.Agent + "  " + job.Type + "  " + jobStateColor(state) +
-			"  " + mutedStyle.Render(formatJobTime(job.UpdatedAt)) + "\n")
-	}
-	if end < n {
-		b.WriteString(mutedStyle.Render("↓ "+strconv.Itoa(n-end)+" more") + "\n")
-	}
-	help := "enter detail  R retry  c cancel"
+
+	help := "↑/↓ select · space open/close · enter detail · R retry · c cancel"
 	if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
-		help += "  B report bug"
+		help += " · B report bug"
 	}
-	b.WriteString(mutedStyle.Render(help))
+	b.WriteString("\n" + mutedStyle.Render(help))
 	b.WriteByte('\n')
 	return b.String()
 }

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 func jobsSnapshot() Snapshot {
@@ -766,6 +767,33 @@ func TestJobDetailShowsRequestAndResult(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("job detail missing %q:\n%s", want, view)
 		}
+	}
+}
+
+// TestJobDetailWrapsLongResult guards that a long single-line result summary is
+// soft-wrapped to the viewport width instead of being clipped at the right edge.
+func TestJobDetailWrapsLongResult(t *testing.T) {
+	long := "Implementation blocked because the workspace is mounted read-only. " +
+		strings.Repeat("decrypt-failure replay-poisoning regression coverage ", 12) + "END_TOKEN"
+	deps := Deps{
+		JobEvents: func(id string) ([]JobEventView, error) { return nil, nil },
+		JobDetail: func(id string) (JobDetail, error) {
+			return JobDetail{ResultDecision: "blocked", ResultSummary: long}, nil
+		},
+	}
+	m := jobsModel(t, deps, jobsSnapshot())
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	m = drainBatch(t, m, cmd)
+	detail := m.jobDetailView()
+	for _, ln := range strings.Split(detail, "\n") {
+		if w := lipgloss.Width(ln); w > m.viewport.Width {
+			t.Fatalf("detail line width %d exceeds viewport %d (would clip): %q", w, m.viewport.Width, ln)
+		}
+	}
+	// The tail of the summary survives the wrap (it was clipped before the fix).
+	if !strings.Contains(detail, "END_TOKEN") {
+		t.Fatalf("wrapped summary should include its tail:\n%s", detail)
 	}
 }
 

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -168,6 +168,58 @@ func TestJobsCollapsedByDefault(t *testing.T) {
 	}
 }
 
+// TestJobsWindowFitsViewport guards that, when both scroll markers show (cursor
+// mid-list), the windowed content fits inside the viewport so the "more rows
+// below" marker and the footer help are not clipped off the bottom.
+func TestJobsWindowFitsViewport(t *testing.T) {
+	snap := Snapshot{Daemon: Daemon{Running: true}}
+	for i := 0; i < 100; i++ {
+		snap.JobRows = append(snap.JobRows, JobRow{ID: "job-" + strconv.Itoa(i), Agent: "planner", Type: "ask", State: "succeeded"})
+	}
+	m := jobsModel(t, Deps{}, snap)
+	for i := 0; i < 50; i++ { // scroll into the middle → both markers present
+		next, _ := m.Update(key("j"))
+		m = next.(Model)
+	}
+	content := m.content()
+	if !strings.Contains(content, "more rows above") || !strings.Contains(content, "more rows below") {
+		t.Fatalf("mid-scroll should show both markers:\n%s", content)
+	}
+	lines := strings.Split(content, "\n")
+	idxOf := func(sub string) int {
+		for i, ln := range lines {
+			if strings.Contains(ln, sub) {
+				return i
+			}
+		}
+		return -1
+	}
+	// The below-marker and the footer help must land within the visible viewport.
+	for _, sub := range []string{"more rows below", "enter detail"} {
+		i := idxOf(sub)
+		if i < 0 || i >= m.viewport.Height {
+			t.Fatalf("%q at line %d is outside the %d-line viewport (would clip):\n%s", sub, i, m.viewport.Height, content)
+		}
+	}
+}
+
+// TestJobsWindowKeepsGroupContext guards that scrolling deep into a status group
+// (so its header scrolls off) keeps the group context on the "above" marker.
+func TestJobsWindowKeepsGroupContext(t *testing.T) {
+	snap := Snapshot{Daemon: Daemon{Running: true}}
+	for i := 0; i < 100; i++ {
+		snap.JobRows = append(snap.JobRows, JobRow{ID: "job-" + strconv.Itoa(i), Agent: "planner", Type: "ask", State: "succeeded"})
+	}
+	m := jobsModel(t, Deps{}, snap)
+	for i := 0; i < 60; i++ {
+		next, _ := m.Update(key("j"))
+		m = next.(Model)
+	}
+	if view := m.View(); !strings.Contains(view, "(continued)") {
+		t.Fatalf("deep cursor should keep the status-group context on the marker:\n%s", view)
+	}
+}
+
 func TestJobsPageDetailLoadsEvents(t *testing.T) {
 	var asked string
 	deps := Deps{JobEvents: func(id string) ([]JobEventView, error) {

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -33,6 +33,22 @@ func jobsModel(t *testing.T, deps Deps, snap Snapshot) Model {
 	return tabToPage(t, m, pageJobs)
 }
 
+// selectJob walks the Jobs cursor down to the row for the given job id (the page
+// now groups jobs by status, so the cursor order is not snapshot order). Test
+// groups default to expanded, so every job is a reachable leaf.
+func selectJob(t *testing.T, m Model, id string) Model {
+	t.Helper()
+	for i := 0; i < 500; i++ {
+		if j, ok := m.jobUnderCursor(); ok && j.ID == id {
+			return m
+		}
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = next.(Model)
+	}
+	t.Fatalf("could not move the Jobs cursor to %q", id)
+	return m
+}
+
 func TestFormatJobTime(t *testing.T) {
 	cases := map[string]string{
 		"2026-06-11 14:30:05":  "06-11 14:30",
@@ -72,10 +88,14 @@ func TestJobsListWindowsLongList(t *testing.T) {
 	if cap >= 100 {
 		t.Fatalf("test needs a window smaller than the list; cap=%d", cap)
 	}
-	// Cursor at top: a "more" marker, no "earlier", and the last row is hidden.
+	// All 100 jobs are succeeded, so they fall under one status group (expanded in
+	// tests). Cursor at top: a "below" marker, no "above", and the last row hidden.
 	view := m.View()
-	if !strings.Contains(view, "more") || strings.Contains(view, "earlier") {
-		t.Fatalf("top of a long list should show only a 'more' marker:\n%s", view)
+	if !strings.Contains(view, "succeeded  ×100") {
+		t.Fatalf("jobs should group under a status header with a count:\n%s", view)
+	}
+	if !strings.Contains(view, "more rows below") || strings.Contains(view, "more rows above") {
+		t.Fatalf("top of a long list should show only a 'below' marker:\n%s", view)
 	}
 	if strings.Contains(view, "job-99 ") {
 		t.Fatalf("the far end should not render while the cursor is at the top")
@@ -89,8 +109,62 @@ func TestJobsListWindowsLongList(t *testing.T) {
 	if !strings.Contains(view, "job-99") {
 		t.Fatalf("the selected last job must be visible after scrolling:\n%s", view)
 	}
-	if !strings.Contains(view, "earlier") {
-		t.Fatalf("the bottom of a long list should show an 'earlier' marker:\n%s", view)
+	if !strings.Contains(view, "more rows above") {
+		t.Fatalf("the bottom of a long list should show an 'above' marker:\n%s", view)
+	}
+}
+
+// TestJobsGroupedByStatus verifies the Jobs list groups under status headers
+// (with ×counts) in active-first order, and that the cursor resolves through the
+// grouped order rather than snapshot order.
+func TestJobsGroupedByStatus(t *testing.T) {
+	m := jobsModel(t, Deps{}, jobsSnapshot())
+	view := m.View()
+	for _, want := range []string{"running  ×1", "failed  ×1", "succeeded  ×1", "cancelled  ×1"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("missing status header %q:\n%s", want, view)
+		}
+	}
+	// Active-first order: running before failed before succeeded before cancelled.
+	last := -1
+	for _, h := range []string{"running  ×1", "failed  ×1", "succeeded  ×1", "cancelled  ×1"} {
+		i := strings.Index(view, h)
+		if i < last {
+			t.Fatalf("status groups out of order at %q:\n%s", h, view)
+		}
+		last = i
+	}
+	// Cursor 0 is the first job in grouped order (running), not snapshot order.
+	if j, ok := m.jobUnderCursor(); !ok || j.ID != "j-running" {
+		t.Fatalf("cursor 0 should resolve to j-running (grouped order), got %+v ok=%v", j, ok)
+	}
+}
+
+// TestJobsCollapsedByDefault verifies the live default folds the status groups so
+// the page opens as status headers, and space expands one.
+func TestJobsCollapsedByDefault(t *testing.T) {
+	snap := jobsSnapshot()
+	deps := Deps{Load: func() (Snapshot, error) { return snap, nil }, CollapseGroupsByDefault: true}
+	m := sizedModel(deps)
+	next, _ := m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	m = tabToPage(t, m, pageJobs)
+	view := m.View()
+	if strings.Contains(view, "j-running") {
+		t.Fatalf("jobs should be folded under status headers by default:\n%s", view)
+	}
+	if !strings.Contains(view, "[+]") {
+		t.Fatalf("collapsed status group should show a [+] marker:\n%s", view)
+	}
+	// The cursor rests on a collapsed header, not a job.
+	if _, ok := m.jobUnderCursor(); ok {
+		t.Fatalf("cursor should be on a collapsed header, not a job")
+	}
+	// Space on the first collapsed header (running) expands it.
+	next, _ = m.Update(key(" "))
+	m = next.(Model)
+	if !strings.Contains(m.View(), "j-running") {
+		t.Fatalf("space should expand the running group and reveal j-running:\n%s", m.View())
 	}
 }
 
@@ -101,6 +175,7 @@ func TestJobsPageDetailLoadsEvents(t *testing.T) {
 		return []JobEventView{{Kind: "failed", Message: "boom"}}, nil
 	}}
 	m := jobsModel(t, deps, jobsSnapshot())
+	m = selectJob(t, m, "j-failed")
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = next.(Model)
 	if m.mode != modeJobDetail || cmd == nil {
@@ -119,7 +194,7 @@ func TestJobsRetryConfirmFlow(t *testing.T) {
 	var retried string
 	deps := Deps{RetryJob: func(id string) error { retried = id; return nil }}
 	m := jobsModel(t, deps, jobsSnapshot())
-	// Cursor on j-failed (first row); R opens the confirm.
+	m = selectJob(t, m, "j-failed")
 	next, _ := m.Update(key("R"))
 	m = next.(Model)
 	if m.mode != modeConfirmJobRetry {
@@ -148,10 +223,8 @@ func TestJobsCancelRunningShowsCancelling(t *testing.T) {
 		CancelJob: func(id string) error { cancelled = id; return nil },
 	}
 	m := jobsModel(t, deps, snap)
-	// Move to the running job (row 2).
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
-	m = next.(Model)
-	next, _ = m.Update(key("c"))
+	m = selectJob(t, m, "j-running")
+	next, _ := m.Update(key("c"))
 	m = next.(Model)
 	if m.mode != modeConfirmJobCancel {
 		t.Fatalf("c should confirm cancel, mode=%v", m.mode)
@@ -179,12 +252,8 @@ func TestJobsCancelRunningShowsCancelling(t *testing.T) {
 func TestJobsRetryOnNonRetryableIgnored(t *testing.T) {
 	deps := Deps{RetryJob: func(id string) error { t.Fatal("must not retry"); return nil }}
 	m := jobsModel(t, deps, jobsSnapshot())
-	// Move to the succeeded job (row 3).
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
-	m = next.(Model)
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
-	m = next.(Model)
-	next, _ = m.Update(key("R"))
+	m = selectJob(t, m, "j-done")
+	next, _ := m.Update(key("R"))
 	m = next.(Model)
 	if m.mode != modeNormal {
 		t.Fatalf("R on a succeeded job must be a no-op, mode=%v", m.mode)
@@ -212,6 +281,7 @@ func TestJobsBugReportPreviewCreateFlow(t *testing.T) {
 		},
 	}
 	m := jobsModel(t, deps, jobsSnapshot())
+	m = selectJob(t, m, "j-failed")
 	if !strings.Contains(m.View(), "B report bug") {
 		t.Fatalf("failed selected job should advertise report action:\n%s", m.View())
 	}
@@ -270,6 +340,7 @@ func TestJobsBugReportPreviewKeepsFooterVisibleForLongBody(t *testing.T) {
 		},
 	}
 	m := jobsModel(t, deps, jobsSnapshot())
+	m = selectJob(t, m, "j-failed")
 	next, cmd := m.Update(key("B"))
 	m = next.(Model)
 	next, _ = m.Update(cmd())
@@ -291,6 +362,7 @@ func TestJobsBugReportCreateErrorKeepsPreview(t *testing.T) {
 		},
 	}
 	m := jobsModel(t, deps, jobsSnapshot())
+	m = selectJob(t, m, "j-failed")
 	next, cmd := m.Update(key("B"))
 	m = next.(Model)
 	next, _ = m.Update(cmd())
@@ -317,6 +389,7 @@ func TestJobsBugReportExistingIssueLabel(t *testing.T) {
 		},
 	}
 	m := jobsModel(t, deps, jobsSnapshot())
+	m = selectJob(t, m, "j-failed")
 	next, cmd := m.Update(key("B"))
 	m = next.(Model)
 	next, _ = m.Update(cmd())
@@ -344,6 +417,7 @@ func TestJobsBugReportCreateResultNotDroppedAfterEsc(t *testing.T) {
 		},
 	}
 	m := jobsModel(t, deps, jobsSnapshot())
+	m = selectJob(t, m, "j-failed")
 	next, cmd := m.Update(key("B"))
 	m = next.(Model)
 	next, _ = m.Update(cmd())
@@ -367,6 +441,7 @@ func TestJobsBugReportBuildErrorKeepsPreview(t *testing.T) {
 		return BugReportPreview{}, errors.New("payload malformed")
 	}}
 	m := jobsModel(t, deps, jobsSnapshot())
+	m = selectJob(t, m, "j-failed")
 	next, cmd := m.Update(key("B"))
 	m = next.(Model)
 	next, _ = m.Update(cmd())
@@ -385,6 +460,7 @@ func TestJobsBugReportPreviewWithoutCreateDepDoesNotAdvertiseCreate(t *testing.T
 		return BugReportPreview{Title: "draft", Body: "body"}, nil
 	}}
 	m := jobsModel(t, deps, jobsSnapshot())
+	m = selectJob(t, m, "j-failed")
 	next, cmd := m.Update(key("B"))
 	m = next.(Model)
 	next, _ = m.Update(cmd())
@@ -407,8 +483,7 @@ func TestJobsBugReportIgnoredForNonReportableJob(t *testing.T) {
 		},
 	}
 	m := jobsModel(t, deps, jobsSnapshot())
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
-	m = next.(Model)
+	m = selectJob(t, m, "j-running")
 	if strings.Contains(m.View(), "B report bug") {
 		t.Fatalf("running selected job must not advertise report action:\n%s", m.View())
 	}
@@ -564,6 +639,7 @@ func TestJobDetailZeroEventsShowsNoEvents(t *testing.T) {
 func TestJobConfirmStaysOpenWhileActionInFlight(t *testing.T) {
 	deps := Deps{RetryJob: func(id string) error { return nil }}
 	m := jobsModel(t, deps, jobsSnapshot())
+	m = selectJob(t, m, "j-failed")
 	next, _ := m.Update(key("R"))
 	m = next.(Model)
 	next, cmd := m.Update(key("y"))
@@ -585,6 +661,7 @@ func TestJobConfirmStaysOpenWhileActionInFlight(t *testing.T) {
 func TestJobActionErrorKeepsConfirm(t *testing.T) {
 	deps := Deps{RetryJob: func(id string) error { return errors.New("db locked") }}
 	m := jobsModel(t, deps, jobsSnapshot())
+	m = selectJob(t, m, "j-failed")
 	next, _ := m.Update(key("R"))
 	m = next.(Model)
 	next, cmd := m.Update(key("y"))

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -119,7 +119,10 @@ type Model struct {
 	sessionNotice      string  // muted note on the Sessions page (e.g. group not stoppable)
 
 	// Jobs page interaction state.
-	jobCursor         int                 // selected row in snap.JobRows
+	jobCursor int // selected row in jobsVisibleRows(); resolve to a job via
+	// selectedItemIndex(jobsVisibleRows(), jobCursor) -> jobsOrdered(), NOT
+	// snap.JobRows (grouping reorders by status and collapsed headers take slots).
+	jobGroups         []jobStatusGroup    // per-snapshot status grouping cache (see jobsByStatusGroup)
 	activeJob         JobRow              // job shown in detail / being confirmed
 	jobEvents         []JobEventView      // lazy-loaded event history for the detail view
 	jobEventsLoaded   bool                // the detail's event load has returned (possibly empty)
@@ -835,6 +838,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.loadErr = ""
 			m.snap = msg.snap
 			m.loadedAt = msg.at
+			m.jobGroups = computeJobsByStatusGroup(m.snap.JobRows)
 			m.clampPromptCursor()
 			m.clampTrainCursor()
 			m.clampJobCursor()
@@ -1075,6 +1079,7 @@ func (m *Model) toggleCurrentGroup() bool {
 	}
 	m.clampPromptCursor()
 	m.clampTrainCursor()
+	m.clampJobCursor()
 	return true
 }
 

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -973,7 +973,7 @@ func (m *Model) pageCursor() (*int, int) {
 	case pageSessions:
 		return &m.sessionCursor, len(m.sessionRows())
 	case pageJobs:
-		return &m.jobCursor, len(m.snap.JobRows)
+		return &m.jobCursor, selectableCount(m.jobsVisibleRows())
 	case pageConfig:
 		return &m.configCursor, len(m.configEditableFields())
 	}
@@ -1010,6 +1010,8 @@ func (m Model) currentListRows() ([]listRow, bool) {
 		return m.attentionVisibleRows(), true
 	case pageTrains:
 		return m.trainVisibleRows(), true
+	case pageJobs:
+		return m.jobsVisibleRows(), true
 	}
 	return nil, false
 }
@@ -1100,9 +1102,9 @@ func (m *Model) focusHeader(key string) {
 	}
 }
 
-// clampJobCursor keeps the Jobs cursor within the current job list.
+// clampJobCursor keeps the Jobs cursor within the current selectable rows.
 func (m *Model) clampJobCursor() {
-	m.jobCursor = clampCursor(m.jobCursor, len(m.snap.JobRows))
+	m.jobCursor = clampCursor(m.jobCursor, selectableCount(m.jobsVisibleRows()))
 }
 
 func loadSnapshot(deps Deps) tea.Cmd {

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -427,6 +427,16 @@ func dash(value string) string {
 	return value
 }
 
+// wrapText soft-wraps s to width columns (word-wrap, preserving existing
+// newlines) so long single-line content isn't clipped by the viewport's right
+// edge. A width <= 0 returns s unchanged.
+func wrapText(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	return lipgloss.NewStyle().Width(width).Render(s)
+}
+
 // truncate collapses internal whitespace and shortens value to limit runes with
 // a trailing ellipsis.
 func truncate(value string, limit int) string {

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -263,9 +263,14 @@ func (m Model) footerHelp() string {
 	case pageSessions:
 		return "tab/←→ page  ↑/↓ select  enter detail  s stop  ? help  q quit"
 	case pageJobs:
-		help := "tab/←→ page  ↑/↓ select  space open/close  enter detail  R retry  c cancel"
-		if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
-			help += "  B report bug"
+		help := "tab/←→ page  ↑/↓ select  space open/close"
+		if m.cursorOnHeader() {
+			help += "  enter open/close"
+		} else {
+			help += "  enter detail  R retry  c cancel"
+			if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
+				help += "  B report bug"
+			}
 		}
 		return help + "  ? help  q quit"
 	case pageHealth:

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -263,7 +263,7 @@ func (m Model) footerHelp() string {
 	case pageSessions:
 		return "tab/←→ page  ↑/↓ select  enter detail  s stop  ? help  q quit"
 	case pageJobs:
-		help := "tab/←→ page  ↑/↓ select  enter detail  R retry  c cancel"
+		help := "tab/←→ page  ↑/↓ select  space open/close  enter detail  R retry  c cancel"
 		if job, ok := m.jobUnderCursor(); ok && jobReportable(job.State) {
 			help += "  B report bug"
 		}


### PR DESCRIPTION
Closes the remaining gaps from the dashboard-overhaul requirements (the live Activity page shipped in #317). Three independent improvements, all in `internal/cli/tui/`, reusing existing primitives — no schema change.

## What

**Jobs page — grouped by status (the "too confusionary" page).** Was a flat windowed list with only a state-count summary; grouping was explicitly deferred in #315. Now grouped with the same collapse primitive as Attention/Trains:
- `jobsByStatusGroup`/`jobsOrdered`/`jobsListRows` build collapsible `status ×N` sections — **active first** (running, queued, blocked, failed), then succeeded/cancelled. The cursor resolves through the grouped order.
- Honors `CollapseGroupsByDefault`, so the live page opens as status headers and expands on demand; `space`/`enter` toggle a group.
- New `windowListRows` keeps an expanded status with hundreds of jobs scrollable with the selection always visible.

**Config page — editable settings grouped by section.** The read-only rows were already sectioned; the *editable* block was one flat list. Now rendered under each `ConfigSection` sub-header (the cursor still indexes the flat field order).

**Agents page — "(no template)" → "Standalone agents (custom prompt)".** Answers "what are agents without templates?" with a meaningful label and a detail-view explanation.

## Code review (high, --fix)

A multi-agent review (8 finder angles, 42 candidates → 10 confirmed) drove a hardening commit:
- **Viewport fit** — sized `jobsWindowCap` (and the same latent defect in `activityWindowCap`) to the real chrome so the footer help and "more rows below" marker never clip off the bottom when both scroll markers show.
- **Group context on scroll** — the "above" marker carries `<state> ×N (continued)` once a tall group's header scrolls off.
- **Summary order** aligned active-first with the sections.
- **Context-sensitive `enter`** help (a collapsed header toggles; a leaf opens detail) in both the in-content help and the footer.
- **Cursor clamp** added to `toggleCurrentGroup` (Jobs joined the collapsible pages).
- **Per-snapshot grouping memoized** so navigation doesn't re-bucket every job each keystroke.
- Stale `jobCursor` comment fixed.

One finding skipped (noted in the commit): re-coloring the status word *inside* the group header — `renderListRows` re-wraps headers in `headerStyle`/`mutedStyle`/`selectedRowStyle`, which would clobber the inner color; the state is named in the header text and the summary keeps its colors.

## Tests / gate

New tests: status grouping + active-first order, collapsed-by-default, windowing, viewport-fit (no footer clip), group-context-on-scroll, config section grouping. Existing Jobs action tests now select their target job by id (`selectJob`) instead of relying on cursor order. `go build`/`vet`/`test ./...` and `-race ./internal/workflow/` all green; gofmt clean.

## Not included (by design)

Gap 6 (nesting runtime sessions under agent templates) — deferred pending a product decision, since runtime sessions now have their own tab and nesting needs a 3-level collapsible primitive. See the discussion thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)