### PR TITLE
feat(tui): show an agent's live runtime sessions in its detail (gap 6)

### DIFF
--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -49,6 +49,9 @@ func isManagedTrainingAgent(name string) bool {
 // Agents page renders, cursors, and acts on this list; the serialized snapshot
 // keeps every agent, so --json/--plain are unaffected.
 func (m Model) visibleAgents() []Agent {
+	if m.showAllAgents {
+		return m.snap.Agents
+	}
 	out := make([]Agent, 0, len(m.snap.Agents))
 	for _, a := range m.snap.Agents {
 		if !isManagedTrainingAgent(a.Name) {
@@ -543,9 +546,39 @@ func choiceValues(choices []Choice) []string {
 func (m Model) agentsContentInteractive() string {
 	visible := m.visibleAgents()
 	hidden := len(m.snap.Agents) - len(visible)
+	// LIVE = warm runtime sessions per agent. Count once over all sessions (keyed
+	// by owning agent) so the render stays O(agents + sessions); also tally the
+	// sessions owned by hidden training agents to annotate the hidden line.
+	liveByAgent := map[string]int{}
+	hiddenLive, hiddenRunning := 0, 0
+	for _, s := range m.snap.Sessions {
+		name := sessionAgentName(s)
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		liveByAgent[name]++
+		if isManagedTrainingAgent(name) {
+			hiddenLive++
+			if s.State == "running" {
+				hiddenRunning++
+			}
+		}
+	}
 	hiddenLine := func(b *strings.Builder) {
+		if m.showAllAgents {
+			b.WriteString("\n" + mutedStyle.Render("showing all agents · a hide training") + "\n")
+			return
+		}
 		if hidden > 0 {
-			b.WriteString("\n" + mutedStyle.Render(strconv.Itoa(hidden)+" training agents hidden (skillopt-*)") + "\n")
+			line := strconv.Itoa(hidden) + " training agents hidden (skillopt-*)"
+			if hiddenLive > 0 {
+				line += " · " + strconv.Itoa(hiddenLive) + " live"
+				if hiddenRunning > 0 {
+					line += " (" + strconv.Itoa(hiddenRunning) + " running)"
+				}
+			}
+			line += " · a show all"
+			b.WriteString("\n" + mutedStyle.Render(line) + "\n")
 		}
 	}
 	if len(visible) == 0 {
@@ -567,15 +600,6 @@ func (m Model) agentsContentInteractive() string {
 	// display order (orderedAgents), so pos advances per agent row in lockstep
 	// and the highlight matches the visible position. The column header prints
 	// once at the top; template labels are display-only and consume no position.
-	// LIVE = warm runtime sessions per agent. Count once over all sessions
-	// (keyed by owning agent) so the render stays O(agents + sessions), mirroring
-	// sessionRows' single-pass grouping rather than scanning per row.
-	liveByAgent := map[string]int{}
-	for _, s := range m.snap.Sessions {
-		if name := sessionAgentName(s); strings.TrimSpace(name) != "" {
-			liveByAgent[name]++
-		}
-	}
 	b.WriteString(renderRows([][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH", "LIVE"}}))
 	pos := 0
 	for _, g := range groupAgentsByTemplate(visible) {
@@ -607,7 +631,7 @@ func (m Model) agentsContentInteractive() string {
 	if m.optimizeBusy {
 		b.WriteString("\n" + mutedStyle.Render("starting optimization…") + "\n")
 	}
-	b.WriteString(mutedStyle.Render("enter detail  n new  o optimize  D delete"))
+	b.WriteString(mutedStyle.Render("enter detail  n new  o optimize  D delete  a show all/hide"))
 	b.WriteByte('\n')
 	return b.String()
 }

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -567,6 +567,15 @@ func (m Model) agentsContentInteractive() string {
 	// display order (orderedAgents), so pos advances per agent row in lockstep
 	// and the highlight matches the visible position. The column header prints
 	// once at the top; template labels are display-only and consume no position.
+	// LIVE = warm runtime sessions per agent. Count once over all sessions
+	// (keyed by owning agent) so the render stays O(agents + sessions), mirroring
+	// sessionRows' single-pass grouping rather than scanning per row.
+	liveByAgent := map[string]int{}
+	for _, s := range m.snap.Sessions {
+		if name := sessionAgentName(s); strings.TrimSpace(name) != "" {
+			liveByAgent[name]++
+		}
+	}
 	b.WriteString(renderRows([][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH", "LIVE"}}))
 	pos := 0
 	for _, g := range groupAgentsByTemplate(visible) {
@@ -579,9 +588,8 @@ func (m Model) agentsContentInteractive() string {
 			if pos == m.agentCursor {
 				cursor, name = "▸ ", selectedRowStyle.Render(a.Name)
 			}
-			// LIVE = warm runtime sessions for this agent (drill in for detail).
 			live := "-"
-			if n := len(agentSessions(m.snap.Sessions, a.Name)); n > 0 {
+			if n := liveByAgent[a.Name]; n > 0 {
 				live = strconv.Itoa(n)
 			}
 			rows = append(rows, []string{cursor, name, a.Runtime, dash(a.Role), dash(a.Health), live})
@@ -620,17 +628,32 @@ type agentGroup struct {
 	agents     []Agent
 }
 
-// agentSessions returns the live runtime sessions belonging to an agent. A
-// session's Type is its agent-type name, which equals the registered agent's
-// Name, so that is the join key (the same warm process can serve any agent of
-// that type). Order is preserved from the snapshot.
+// tempWorkerTypePrefix is the prefix the daemon stamps on a temp worker's agent
+// type ("temp:<agent>", see tempWorkerAgentType). Stripping it rolls the temp
+// worker's session up under the agent it serves.
+const tempWorkerTypePrefix = "temp:"
+
+// sessionAgentName is the registered-agent name a runtime session belongs to: its
+// Type is the agent-type name (== the agent's Name), with the temp-worker
+// "temp:" prefix stripped so a parallel temp worker counts toward the agent it
+// serves rather than disappearing from the Agents view.
+func sessionAgentName(s Session) string {
+	if rest, ok := strings.CutPrefix(s.Type, tempWorkerTypePrefix); ok {
+		return rest
+	}
+	return s.Type
+}
+
+// agentSessions returns the live runtime sessions belonging to an agent (the same
+// warm process can serve any agent of that type, including its temp workers).
+// Order is preserved from the snapshot.
 func agentSessions(sessions []Session, agentName string) []Session {
 	if strings.TrimSpace(agentName) == "" {
 		return nil
 	}
 	var out []Session
 	for _, s := range sessions {
-		if s.Type == agentName {
+		if sessionAgentName(s) == agentName {
 			out = append(out, s)
 		}
 	}

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -567,7 +567,7 @@ func (m Model) agentsContentInteractive() string {
 	// display order (orderedAgents), so pos advances per agent row in lockstep
 	// and the highlight matches the visible position. The column header prints
 	// once at the top; template labels are display-only and consume no position.
-	b.WriteString(renderRows([][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH"}}))
+	b.WriteString(renderRows([][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH", "LIVE"}}))
 	pos := 0
 	for _, g := range groupAgentsByTemplate(visible) {
 		b.WriteByte('\n')
@@ -579,7 +579,12 @@ func (m Model) agentsContentInteractive() string {
 			if pos == m.agentCursor {
 				cursor, name = "▸ ", selectedRowStyle.Render(a.Name)
 			}
-			rows = append(rows, []string{cursor, name, a.Runtime, dash(a.Role), dash(a.Health)})
+			// LIVE = warm runtime sessions for this agent (drill in for detail).
+			live := "-"
+			if n := len(agentSessions(m.snap.Sessions, a.Name)); n > 0 {
+				live = strconv.Itoa(n)
+			}
+			rows = append(rows, []string{cursor, name, a.Runtime, dash(a.Role), dash(a.Health), live})
 			pos++
 		}
 		b.WriteString(renderRows(rows))
@@ -613,6 +618,23 @@ func agentGroupLabel(templateID string) string {
 type agentGroup struct {
 	templateID string
 	agents     []Agent
+}
+
+// agentSessions returns the live runtime sessions belonging to an agent. A
+// session's Type is its agent-type name, which equals the registered agent's
+// Name, so that is the join key (the same warm process can serve any agent of
+// that type). Order is preserved from the snapshot.
+func agentSessions(sessions []Session, agentName string) []Session {
+	if strings.TrimSpace(agentName) == "" {
+		return nil
+	}
+	var out []Session
+	for _, s := range sessions {
+		if s.Type == agentName {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // groupAgentsByTemplate buckets visible agents by TemplateID for display. Groups
@@ -656,6 +678,27 @@ func (m Model) agentDetailView() string {
 	} else {
 		for _, job := range jobs {
 			b.WriteString(job.ID + "  " + job.Type + "  " + jobStateColor(job.State) + "\n")
+		}
+	}
+	b.WriteByte('\n')
+
+	// Live runtime sessions (warm processes) serving this agent. Ephemeral — they
+	// expire on idle — so they live here as a drill-in snapshot, not in the list.
+	b.WriteString(headerStyle.Render("live sessions"))
+	b.WriteByte('\n')
+	sessions := agentSessions(m.snap.Sessions, a.Name)
+	if len(sessions) == 0 {
+		b.WriteString(mutedStyle.Render("none") + "\n")
+	} else {
+		for _, s := range sessions {
+			line := s.Name + "  " + s.State
+			if s.Repo != "" {
+				line += "  " + s.Repo
+			}
+			if s.Expires != "" {
+				line += "  " + mutedStyle.Render("expires "+formatJobTime(s.Expires))
+			}
+			b.WriteString(line + "\n")
 		}
 	}
 	b.WriteByte('\n')

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -601,16 +601,22 @@ func (m Model) agentsContentInteractive() string {
 	// and the highlight matches the visible position. The column header prints
 	// once at the top; template labels are display-only and consume no position.
 	b.WriteString(renderRows([][]string{{"", "NAME", "RUNTIME", "ROLE", "HEALTH", "LIVE"}}))
+
+	// Build the group + agent lines once, then window them around the cursor so a
+	// long list (e.g. 'a' showing the training agents) stays scrollable with the
+	// selection on-screen. The column header above is always shown; agentCursor
+	// indexes the flat agent order.
+	var lines []string
+	cursorLine := 0
 	pos := 0
 	for _, g := range groupAgentsByTemplate(visible) {
-		b.WriteByte('\n')
-		b.WriteString(headerStyle.Render(agentGroupLabel(g.templateID)))
-		b.WriteByte('\n')
+		lines = append(lines, "", headerStyle.Render(agentGroupLabel(g.templateID)))
 		rows := [][]string{}
 		for _, a := range g.agents {
 			cursor, name := "  ", a.Name
 			if pos == m.agentCursor {
 				cursor, name = "▸ ", selectedRowStyle.Render(a.Name)
+				cursorLine = len(lines) + len(rows)
 			}
 			live := "-"
 			if n := liveByAgent[a.Name]; n > 0 {
@@ -619,7 +625,29 @@ func (m Model) agentsContentInteractive() string {
 			rows = append(rows, []string{cursor, name, a.Runtime, dash(a.Role), dash(a.Health), live})
 			pos++
 		}
-		b.WriteString(renderRows(rows))
+		lines = append(lines, strings.Split(strings.TrimRight(renderRows(rows), "\n"), "\n")...)
+	}
+
+	capacity := agentsWindowCap(m.height)
+	start, end := 0, len(lines)
+	if len(lines) > capacity {
+		start = cursorLine - capacity/2
+		if start < 0 {
+			start = 0
+		}
+		if start > len(lines)-capacity {
+			start = len(lines) - capacity
+		}
+		end = start + capacity
+	}
+	if start > 0 {
+		b.WriteString(mutedStyle.Render("  ↑ "+strconv.Itoa(start)+" more above") + "\n")
+	}
+	for i := start; i < end; i++ {
+		b.WriteString(lines[i] + "\n")
+	}
+	if end < len(lines) {
+		b.WriteString(mutedStyle.Render("  ↓ "+strconv.Itoa(len(lines)-end)+" more below") + "\n")
 	}
 	if m.agentErr != "" {
 		b.WriteString("\n" + errorStyle.Render(m.agentErr) + "\n")
@@ -634,6 +662,16 @@ func (m Model) agentsContentInteractive() string {
 	b.WriteString(mutedStyle.Render("enter detail  n new  o optimize  D delete  a show all/hide"))
 	b.WriteByte('\n')
 	return b.String()
+}
+
+// agentsWindowCap is how many group/agent lines fit the Agents page, leaving
+// room for the viewport chrome (title, column header, scroll markers, the
+// hidden/all line, and the footer) so the windowed body stays on-screen.
+func agentsWindowCap(height int) int {
+	if height-12 < 3 {
+		return 3
+	}
+	return height - 12
 }
 
 // agentGroupLabel is the section header for a template group; agents without a

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -118,13 +118,17 @@ func TestAgentsPageGroupsByTemplate(t *testing.T) {
 }
 
 // TestAgentDetailShowsLiveSessions verifies an agent's detail lists its live
-// runtime sessions (matched by session.Type == agent.Name) and that the agent
-// list shows the per-agent live count, while another agent's sessions don't leak.
+// runtime sessions (matched by owning agent — including temp workers, whose Type
+// carries a "temp:" prefix) and that the agent list shows the per-agent live
+// count, while another agent's sessions don't leak.
 func TestAgentDetailShowsLiveSessions(t *testing.T) {
 	snap := agentsSnapshot()
 	snap.Sessions = []Session{
 		{Name: "claude-bg-9f2", Type: "planner", Runtime: "claude", Repo: "o/r", State: "running", Expires: "2026-06-18T10:09:00Z"},
 		{Name: "claude-bg-1a7", Type: "planner", Runtime: "claude", Repo: "o/r", State: "idle", Expires: "2026-06-18T10:04:00Z"},
+		// A temp worker for planner: its Type carries the daemon's "temp:" prefix
+		// and must still roll up under planner.
+		{Name: "planner-temp-job9", Type: "temp:planner", Runtime: "claude", Repo: "o/r", State: "running"},
 		{Name: "codex-bg-77", Type: "reviewer", Runtime: "codex", Repo: "o/x", State: "running"},
 	}
 	m := agentsModel(t, Deps{}, snap)
@@ -140,7 +144,7 @@ func TestAgentDetailShowsLiveSessions(t *testing.T) {
 		m = next.(Model)
 	}
 	view := m.View()
-	for _, want := range []string{"live sessions", "claude-bg-9f2", "running", "claude-bg-1a7", "idle"} {
+	for _, want := range []string{"live sessions", "claude-bg-9f2", "running", "claude-bg-1a7", "idle", "planner-temp-job9"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("planner detail missing %q:\n%s", want, view)
 		}

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -35,6 +35,56 @@ func agentsModel(t *testing.T, deps Deps, snap Snapshot) Model {
 	return m
 }
 
+// TestAgentsHiddenLineShowsLiveCount verifies the hidden-agents line annotates how
+// many live sessions belong to hidden training agents (so the LIVE column isn't
+// silently empty when all live work is under hidden agents).
+func TestAgentsHiddenLineShowsLiveCount(t *testing.T) {
+	snap := agentsSnapshot()
+	snap.Agents = append(snap.Agents, Agent{Name: "skillopt-generator", Runtime: "codex"})
+	snap.Sessions = []Session{
+		{Name: "skillopt-generator-bg-1", Type: "skillopt-generator", Runtime: "codex", State: "running"},
+		{Name: "skillopt-generator-bg-2", Type: "skillopt-generator", Runtime: "codex", State: "idle"},
+	}
+	m := agentsModel(t, Deps{}, snap)
+	view := m.View()
+	if !strings.Contains(view, "1 training agents hidden") {
+		t.Fatalf("expected a hidden count:\n%s", view)
+	}
+	if !strings.Contains(view, "2 live") || !strings.Contains(view, "1 running") {
+		t.Fatalf("hidden line should annotate live/running session counts:\n%s", view)
+	}
+}
+
+// TestAgentsShowAllToggle verifies the 'a' key un-hides the training agents (and
+// hides them again), and that their LIVE counts then appear.
+func TestAgentsShowAllToggle(t *testing.T) {
+	snap := agentsSnapshot()
+	snap.Agents = append(snap.Agents, Agent{Name: "skillopt-generator", Runtime: "codex"})
+	snap.Sessions = []Session{
+		{Name: "skillopt-generator-bg-1", Type: "skillopt-generator", Runtime: "codex", State: "running"},
+	}
+	m := agentsModel(t, Deps{}, snap)
+	if strings.Contains(m.View(), "skillopt-generator") {
+		t.Fatalf("training agent should be hidden by default:\n%s", m.View())
+	}
+	// 'a' shows all.
+	next, _ := m.Update(key("a"))
+	m = next.(Model)
+	view := m.View()
+	if !strings.Contains(view, "skillopt-generator") {
+		t.Fatalf("'a' should reveal the hidden training agent:\n%s", view)
+	}
+	if !strings.Contains(view, "showing all agents") {
+		t.Fatalf("show-all mode should be indicated:\n%s", view)
+	}
+	// 'a' again hides them.
+	next, _ = m.Update(key("a"))
+	m = next.(Model)
+	if strings.Contains(m.View(), "skillopt-generator") {
+		t.Fatalf("'a' again should re-hide the training agent:\n%s", m.View())
+	}
+}
+
 func TestAgentsPageHidesTrainingAgents(t *testing.T) {
 	snap := agentsSnapshot()
 	// Add internal training plumbing alongside the real agents.

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -117,6 +117,59 @@ func TestAgentsPageGroupsByTemplate(t *testing.T) {
 	}
 }
 
+// TestAgentDetailShowsLiveSessions verifies an agent's detail lists its live
+// runtime sessions (matched by session.Type == agent.Name) and that the agent
+// list shows the per-agent live count, while another agent's sessions don't leak.
+func TestAgentDetailShowsLiveSessions(t *testing.T) {
+	snap := agentsSnapshot()
+	snap.Sessions = []Session{
+		{Name: "claude-bg-9f2", Type: "planner", Runtime: "claude", Repo: "o/r", State: "running", Expires: "2026-06-18T10:09:00Z"},
+		{Name: "claude-bg-1a7", Type: "planner", Runtime: "claude", Repo: "o/r", State: "idle", Expires: "2026-06-18T10:04:00Z"},
+		{Name: "codex-bg-77", Type: "reviewer", Runtime: "codex", Repo: "o/x", State: "running"},
+	}
+	m := agentsModel(t, Deps{}, snap)
+	// The list shows the per-agent live count column.
+	if !strings.Contains(m.View(), "LIVE") {
+		t.Fatalf("agent list should have a LIVE column:\n%s", m.View())
+	}
+	// Open planner's detail (cursor 0).
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd != nil {
+		next, _ = m.Update(cmd())
+		m = next.(Model)
+	}
+	view := m.View()
+	for _, want := range []string{"live sessions", "claude-bg-9f2", "running", "claude-bg-1a7", "idle"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("planner detail missing %q:\n%s", want, view)
+		}
+	}
+	// reviewer's session must not appear under planner.
+	if strings.Contains(view, "codex-bg-77") {
+		t.Fatalf("another agent's session leaked into planner's detail:\n%s", view)
+	}
+}
+
+// TestAgentDetailNoLiveSessions shows the empty state when an agent has none.
+func TestAgentDetailNoLiveSessions(t *testing.T) {
+	m := agentsModel(t, Deps{}, agentsSnapshot()) // snapshot has no Sessions
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd != nil {
+		next, _ = m.Update(cmd())
+		m = next.(Model)
+	}
+	view := m.View()
+	idx := strings.Index(view, "live sessions")
+	if idx < 0 {
+		t.Fatalf("detail should have a live sessions section:\n%s", view)
+	}
+	if !strings.Contains(view[idx:], "none") {
+		t.Fatalf("an agent with no sessions should show none:\n%s", view[idx:])
+	}
+}
+
 func TestAgentDetailRendersVersionsAndJobs(t *testing.T) {
 	var asked string
 	deps := Deps{TemplateVersions: func(templateID string) ([]TemplateVersion, error) {

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -33,6 +34,49 @@ func agentsModel(t *testing.T, deps Deps, snap Snapshot) Model {
 	m = next.(Model)
 	m = tabToPage(t, m, pageAgents)
 	return m
+}
+
+// TestAgentsListWindowsLongList guards that a long agent list (e.g. with 'a'
+// showing many training agents) windows around the cursor so the selection stays
+// visible and the scroll markers appear — rather than overflowing unscrollably.
+func TestAgentsListWindowsLongList(t *testing.T) {
+	snap := Snapshot{Daemon: Daemon{Running: true}}
+	for i := 0; i < 80; i++ {
+		snap.Agents = append(snap.Agents, Agent{
+			Name: "agent-" + strconv.Itoa(i), Runtime: "codex", Role: "impl", Health: "ok", TemplateID: "tpl",
+		})
+	}
+	m := sizedModel(Deps{Load: func() (Snapshot, error) { return snap, nil }})
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = next.(Model)
+	next, _ = m.Update(snapshotMsg{snap: snap, at: time.Unix(1, 0)})
+	m = next.(Model)
+	m = tabToPage(t, m, pageAgents)
+
+	cap := agentsWindowCap(m.height)
+	if cap >= 80 {
+		t.Fatalf("test needs a window smaller than the list; cap=%d", cap)
+	}
+	// At the top: a "below" marker, no "above", and the far end hidden.
+	view := m.View()
+	if !strings.Contains(view, "more below") || strings.Contains(view, "more above") {
+		t.Fatalf("top of a long list should show only a 'below' marker:\n%s", view)
+	}
+	if strings.Contains(view, "agent-79 ") {
+		t.Fatalf("the far end should not render while the cursor is at the top:\n%s", view)
+	}
+	// Drive the cursor to the last agent; it must stay visible (window follows).
+	for i := 0; i < 79; i++ {
+		next, _ := m.Update(key("j"))
+		m = next.(Model)
+	}
+	view = m.View()
+	if !strings.Contains(view, "agent-79") {
+		t.Fatalf("the selected last agent must be visible after scrolling:\n%s", view)
+	}
+	if !strings.Contains(view, "more above") {
+		t.Fatalf("the bottom of a long list should show an 'above' marker:\n%s", view)
+	}
 }
 
 // TestAgentsHiddenLineShowsLiveCount verifies the hidden-agents line annotates how

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -157,6 +157,7 @@ type Model struct {
 
 	// Agents page interaction state.
 	agentCursor         int               // selected row in snap.Agents
+	showAllAgents       bool              // Agents page: include hidden skillopt-* training agents
 	activeAgent         Agent             // agent shown in detail / being confirmed
 	agentVersions       []TemplateVersion // lazy-loaded template version history
 	agentVersionsLoaded bool              // the version load has returned (possibly empty)
@@ -323,6 +324,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if cmd := m.openAnswer(); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
+				m.viewport.SetContent(m.content())
+				return m, tea.Batch(cmds...)
+			}
+			if pages[m.selected].page == pageAgents {
+				// Toggle the hidden skillopt-* training agents in/out of the list.
+				m.showAllAgents = !m.showAllAgents
+				m.agentCursor = clampCursor(m.agentCursor, len(m.visibleAgents()))
+				m.viewport.GotoTop()
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
 			}

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -259,7 +259,7 @@ func (m Model) footerHelp() string {
 	case pageTrains:
 		return "tab/←→ page  ↑/↓ select  enter open  s stop  d delete  ? help  q quit"
 	case pageAgents:
-		return "tab/←→ page  ↑/↓ select  enter detail  n new  o optimize  e runtime  D delete  ? help  q quit"
+		return "tab/←→ page  ↑/↓ select  enter detail  n new  o optimize  e runtime  D delete  a show all/hide  ? help  q quit"
 	case pageSessions:
 		return "tab/←→ page  ↑/↓ select  enter detail  s stop  ? help  q quit"
 	case pageJobs:


### PR DESCRIPTION
Closes the last dashboard-overhaul gap (gap 6). Surfaces the warm runtime sessions serving each agent **without duplicating the Sessions tab** (Option 1 from the design discussion).

## What
- **Agents list** gains a `LIVE` column = the count of warm runtime sessions for each agent.
- **Agent detail** gains a `live sessions` section listing each session (name, state, repo, expiry). It's a drill-in snapshot, so the ephemeral, expiring session rows don't clutter the live list.
- Sessions join to an agent by owning agent-type name; **temp workers** (whose type is `temp:<agent>`) roll up under the agent they serve.

## Why this shape
Runtime sessions are ephemeral (expire on idle) and already have their own Sessions tab. Nesting them as live rows in the Agents list would duplicate that tab and need a 3-level collapsible primitive. A per-agent count + a detail drill-in gives "what's live for this agent" cheaply, with one source of truth.

## Code review (focused, --fix)
A multi-agent review (3 angles, 14 candidates) caught one real bug, fixed here:
- **Temp-worker sessions were missed** — they store `Type = "temp:<agent>"`, so the original exact `Type == Name` join skipped them, making the *busiest* agents show `LIVE -`/none while running. Now normalized via `sessionAgentName` (strips the `temp:` prefix) so they roll up correctly.
- **Counted once per render** (a map keyed by owning agent) instead of scanning all sessions per row — O(agents+sessions), mirroring `sessionRows`.
- Skipped (noted in commit): empty-`Type` sessions (unreachable — every instance write sets a type) and header/data column alignment (pre-existing for the whole Agents table, cosmetic).

## Tests / gate
New tests: detail lists the agent's sessions (incl. a `temp:`-prefixed one rolling up) and excludes other agents'; empty state; the list `LIVE` column. `go build`/`vet`/`test ./...` + `-race ./internal/workflow/` all green; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)