### PR TITLE
feat(tui): bulk-delete a template group of agents from the Agents page

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -315,24 +316,34 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 		},
 		DeleteAgents: func(names []string) (int, []string, error) {
 			deleted := 0
-			var skipped []string
-			err := withStore(home, func(store *db.Store) error {
+			var skipped, failed []string
+			var firstErr error
+			openErr := withStore(home, func(store *db.Store) error {
 				for _, n := range names {
-					e := store.DeleteAgentChecked(context.Background(), n)
-					if e == nil {
+					switch e := store.DeleteAgentChecked(context.Background(), n); {
+					case e == nil:
 						deleted++
-						continue
-					}
-					// Skip agents still referenced by active jobs; surface anything else.
-					if strings.Contains(e.Error(), "queued or running") {
+					case errors.Is(e, db.ErrAgentHasActiveJobs):
+						// Still referenced by active jobs — skip, don't abort the batch.
 						skipped = append(skipped, n)
-						continue
+					default:
+						// Unexpected: record and keep going so the caller learns the full
+						// outcome (each delete already committed in its own tx).
+						failed = append(failed, n)
+						if firstErr == nil {
+							firstErr = e
+						}
 					}
-					return e
 				}
 				return nil
 			})
-			return deleted, skipped, err
+			if openErr != nil {
+				return deleted, skipped, openErr
+			}
+			if len(failed) > 0 {
+				return deleted, skipped, fmt.Errorf("%d agent(s) could not be deleted (e.g. %s: %v)", len(failed), failed[0], firstErr)
+			}
+			return deleted, skipped, nil
 		},
 		RevertTemplate: func(templateID, versionID string) error {
 			return withStore(home, func(store *db.Store) error {

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -313,6 +313,27 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 				return store.DeleteAgentChecked(context.Background(), name)
 			})
 		},
+		DeleteAgents: func(names []string) (int, []string, error) {
+			deleted := 0
+			var skipped []string
+			err := withStore(home, func(store *db.Store) error {
+				for _, n := range names {
+					e := store.DeleteAgentChecked(context.Background(), n)
+					if e == nil {
+						deleted++
+						continue
+					}
+					// Skip agents still referenced by active jobs; surface anything else.
+					if strings.Contains(e.Error(), "queued or running") {
+						skipped = append(skipped, n)
+						continue
+					}
+					return e
+				}
+				return nil
+			})
+			return deleted, skipped, err
+		},
 		RevertTemplate: func(templateID, versionID string) error {
 			return withStore(home, func(store *db.Store) error {
 				_, err := store.RevertAgentTemplateVersion(context.Background(), templateID, versionID)

--- a/internal/cli/dashboard_tui_test.go
+++ b/internal/cli/dashboard_tui_test.go
@@ -332,6 +332,48 @@ func TestDashboardCreateAgentWithPrompt(t *testing.T) {
 	}
 }
 
+// TestDashboardTUIDeleteAgentsSkipsActive exercises the bulk-delete dep: it
+// deletes the agents it can and skips any with a queued/running job.
+func TestDashboardTUIDeleteAgentsSkipsActive(t *testing.T) {
+	home := dashboardTestHome(t)
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	ctx := context.Background()
+	for _, n := range []string{"a1", "a2"} {
+		if err := store.UpsertAgent(ctx, db.Agent{Name: n, Runtime: "codex"}); err != nil {
+			t.Fatalf("upsert %s: %v", n, err)
+		}
+	}
+	// a2 has a running job → must be skipped, not deleted.
+	if err := store.CreateJob(ctx, db.Job{ID: "j1", Agent: "a2", Type: "ask", State: "running"}); err != nil {
+		t.Fatalf("job: %v", err)
+	}
+	store.Close()
+
+	deps := dashboardTUIDeps(home, 0)
+	deleted, skipped, err := deps.DeleteAgents([]string{"a1", "a2"})
+	if err != nil {
+		t.Fatalf("DeleteAgents: %v", err)
+	}
+	if deleted != 1 || len(skipped) != 1 || skipped[0] != "a2" {
+		t.Fatalf("deleted=%d skipped=%v, want 1 / [a2]", deleted, skipped)
+	}
+
+	store2, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer store2.Close()
+	if _, err := store2.GetAgent(ctx, "a1"); err == nil {
+		t.Fatalf("a1 should be deleted")
+	}
+	if _, err := store2.GetAgent(ctx, "a2"); err != nil {
+		t.Fatalf("a2 should remain (had an active job): %v", err)
+	}
+}
+
 func TestBuildDashboardActivity(t *testing.T) {
 	mustPayload := func(p workflow.JobPayload) string {
 		t.Helper()

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -420,7 +420,7 @@ func (m Model) agentGroupDeleteConfirmView() string {
 	}
 	b.WriteByte('\n')
 	if k := m.agentsWithActiveJobs(m.groupDeleteNames); k > 0 {
-		b.WriteString(mutedStyle.Render(strconv.Itoa(k)+" have active jobs and will be skipped.") + "\n")
+		b.WriteString(mutedStyle.Render(strconv.Itoa(k)+" currently have active jobs and will be skipped.") + "\n")
 	}
 	b.WriteString("Unregister the whole group? (y/n)\n")
 	if m.actionErr != "" {

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -340,8 +340,109 @@ func (m Model) updateAgentOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.viewport.SetContent(m.content())
 		return m, nil
+	case modeConfirmAgentGroupDelete:
+		switch msg.String() {
+		case "y", "Y":
+			if m.actionBusy {
+				return m, nil
+			}
+			m.actionBusy = true
+			m.actionErr = ""
+			m.viewport.SetContent(m.content())
+			return m, agentGroupDeleteCmd(m.deps, m.groupDeleteNames)
+		default:
+			if m.actionBusy {
+				return m, nil
+			}
+			m.mode = modeNormal
+			m.actionErr = ""
+		}
+		m.viewport.SetContent(m.content())
+		return m, nil
 	}
 	return m, nil
+}
+
+// openAgentGroupDelete opens the bulk-delete confirm for the template group of
+// the agent under the cursor.
+func (m *Model) openAgentGroupDelete() {
+	a, ok := m.agentUnderCursor()
+	if !ok {
+		return
+	}
+	var names []string
+	for _, g := range groupAgentsByTemplate(m.visibleAgents()) {
+		if g.templateID == a.TemplateID {
+			for _, ga := range g.agents {
+				names = append(names, ga.Name)
+			}
+			break
+		}
+	}
+	m.groupDeleteLabel = agentGroupLabel(a.TemplateID)
+	m.groupDeleteNames = names
+	m.actionErr = ""
+	m.actionBusy = false
+	m.mode = modeConfirmAgentGroupDelete
+}
+
+// agentsWithActiveJobs counts how many of the named agents currently have a
+// queued/running job in the snapshot — a best-effort heads-up before a bulk
+// delete (the store is authoritative and skips them).
+func (m Model) agentsWithActiveJobs(names []string) int {
+	active := map[string]bool{}
+	for _, j := range m.snap.JobRows {
+		if j.State == "queued" || j.State == "running" {
+			active[j.Agent] = true
+		}
+	}
+	n := 0
+	for _, name := range names {
+		if active[name] {
+			n++
+		}
+	}
+	return n
+}
+
+func (m Model) agentGroupDeleteConfirmView() string {
+	var b strings.Builder
+	n := len(m.groupDeleteNames)
+	b.WriteString(headerStyle.Render("Delete " + strconv.Itoa(n) + " agents in group \"" + m.groupDeleteLabel + "\""))
+	b.WriteString("\n\n")
+	const showMax = 8
+	for i, name := range m.groupDeleteNames {
+		if i >= showMax {
+			b.WriteString(mutedStyle.Render("… and "+strconv.Itoa(n-showMax)+" more") + "\n")
+			break
+		}
+		b.WriteString("  " + name + "\n")
+	}
+	b.WriteByte('\n')
+	if k := m.agentsWithActiveJobs(m.groupDeleteNames); k > 0 {
+		b.WriteString(mutedStyle.Render(strconv.Itoa(k)+" have active jobs and will be skipped.") + "\n")
+	}
+	b.WriteString("Unregister the whole group? (y/n)\n")
+	if m.actionErr != "" {
+		b.WriteString("\n" + errorStyle.Render(m.actionErr) + "\n")
+	}
+	b.WriteByte('\n')
+	if m.actionBusy {
+		b.WriteString(mutedStyle.Render("deleting…"))
+	} else {
+		b.WriteString(mutedStyle.Render("y delete all  n/esc cancel"))
+	}
+	return b.String()
+}
+
+func agentGroupDeleteCmd(deps Deps, names []string) tea.Cmd {
+	return func() tea.Msg {
+		if deps.DeleteAgents == nil {
+			return agentGroupDeleteMsg{}
+		}
+		deleted, skipped, err := deps.DeleteAgents(names)
+		return agentGroupDeleteMsg{deleted: deleted, skipped: skipped, err: err}
+	}
 }
 
 func agentVersionsCmd(deps Deps, templateID string) tea.Cmd {
@@ -659,7 +760,7 @@ func (m Model) agentsContentInteractive() string {
 	if m.optimizeBusy {
 		b.WriteString("\n" + mutedStyle.Render("starting optimization…") + "\n")
 	}
-	b.WriteString(mutedStyle.Render("enter detail  n new  o optimize  D delete  a show all/hide"))
+	b.WriteString(mutedStyle.Render("enter detail  n new  o optimize  D delete  X delete group  a show all/hide"))
 	b.WriteByte('\n')
 	return b.String()
 }

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -80,6 +80,59 @@ func TestAgentGroupDeleteFlow(t *testing.T) {
 	}
 }
 
+// TestAgentGroupDeleteStandaloneFallsBackToSingle guards the safety rule: X on a
+// template-less agent opens the single-agent delete (not a bulk delete of the
+// whole heterogeneous "Standalone agents" catch-all).
+func TestAgentGroupDeleteStandaloneFallsBackToSingle(t *testing.T) {
+	snap := agentsSnapshot()
+	snap.Agents = append(snap.Agents, Agent{Name: "drifter", Runtime: "codex"}) // TemplateID ""
+	called := false
+	deps := Deps{DeleteAgents: func(names []string) (int, []string, error) { called = true; return 0, nil, nil }}
+	m := agentsModel(t, deps, snap)
+	for i := 0; i < 6; i++ {
+		if a, ok := m.agentUnderCursor(); ok && a.Name == "drifter" {
+			break
+		}
+		next, _ := m.Update(key("j"))
+		m = next.(Model)
+	}
+	next, _ := m.Update(key("X"))
+	m = next.(Model)
+	if m.mode != modeConfirmAgentDelete {
+		t.Fatalf("X on a standalone agent should open single delete, mode=%v", m.mode)
+	}
+	if called {
+		t.Fatal("standalone X must not bulk-delete the catch-all group")
+	}
+}
+
+// TestAgentGroupDeletePartialErrorReported guards that a partial-error bulk delete
+// still closes the overlay, reports the committed deletes, and surfaces the error
+// (so the stale list/retry-wedge can't happen).
+func TestAgentGroupDeletePartialErrorReported(t *testing.T) {
+	snap := agentsSnapshot()
+	snap.Agents = append(snap.Agents, Agent{Name: "planner-2", Runtime: "claude", TemplateID: "planner-tpl"})
+	deps := Deps{DeleteAgents: func(names []string) (int, []string, error) {
+		return 1, nil, errors.New("db locked") // one committed, then failed
+	}}
+	m := agentsModel(t, deps, snap)
+	next, _ := m.Update(key("X"))
+	m = next.(Model)
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("a partial-error delete should still close the overlay, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.agentNotice, "deleted 1") {
+		t.Fatalf("should still report the committed deletes: %q", m.agentNotice)
+	}
+	if !strings.Contains(m.agentErr, "db locked") {
+		t.Fatalf("should surface the error: %q", m.agentErr)
+	}
+}
+
 // TestAgentGroupDeleteNoDepInert verifies X is inert without a DeleteAgents dep.
 func TestAgentGroupDeleteNoDepInert(t *testing.T) {
 	m := agentsModel(t, Deps{}, agentsSnapshot())

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -36,6 +36,60 @@ func agentsModel(t *testing.T, deps Deps, snap Snapshot) Model {
 	return m
 }
 
+// TestAgentGroupDeleteFlow exercises X → confirm → y: it bulk-deletes the cursor
+// agent's whole template group, surfaces the active-job skip heads-up, calls
+// DeleteAgents with the group's names, and reports the deleted/skipped result.
+func TestAgentGroupDeleteFlow(t *testing.T) {
+	snap := agentsSnapshot()
+	snap.Agents = append(snap.Agents, Agent{Name: "planner-2", Runtime: "claude", TemplateID: "planner-tpl"})
+	snap.JobRows = append(snap.JobRows, JobRow{ID: "jx", Agent: "planner", Type: "ask", State: "running"})
+	var got []string
+	deps := Deps{DeleteAgents: func(names []string) (int, []string, error) {
+		got = names
+		return len(names) - 1, []string{"planner"}, nil // planner skipped (active job)
+	}}
+	m := agentsModel(t, deps, snap)
+	// Cursor 0 = planner (planner-tpl group). X opens the group-delete confirm.
+	next, _ := m.Update(key("X"))
+	m = next.(Model)
+	if m.mode != modeConfirmAgentGroupDelete {
+		t.Fatalf("X should open the group-delete confirm, mode=%v", m.mode)
+	}
+	view := m.View()
+	for _, want := range []string{"planner-tpl", "planner-2", "have active jobs"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("confirm missing %q:\n%s", want, view)
+		}
+	}
+	// y runs the bulk delete with the whole group's names.
+	next, cmd := m.Update(key("y"))
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("y should dispatch the bulk delete")
+	}
+	next, _ = m.Update(cmd())
+	m = next.(Model)
+	if len(got) != 2 || got[0] != "planner" || got[1] != "planner-2" {
+		t.Fatalf("DeleteAgents called with %v, want [planner planner-2]", got)
+	}
+	if m.mode != modeNormal {
+		t.Fatalf("success should close the confirm, mode=%v", m.mode)
+	}
+	if !strings.Contains(m.agentNotice, "deleted 1") || !strings.Contains(m.agentNotice, "1 skipped") {
+		t.Fatalf("notice should report deleted/skipped: %q", m.agentNotice)
+	}
+}
+
+// TestAgentGroupDeleteNoDepInert verifies X is inert without a DeleteAgents dep.
+func TestAgentGroupDeleteNoDepInert(t *testing.T) {
+	m := agentsModel(t, Deps{}, agentsSnapshot())
+	next, _ := m.Update(key("X"))
+	m = next.(Model)
+	if m.mode != modeNormal {
+		t.Fatalf("X without a DeleteAgents dep should be a no-op, mode=%v", m.mode)
+	}
+}
+
 // TestAgentsListWindowsLongList guards that a long agent list (e.g. with 'a'
 // showing many training agents) windows around the cursor so the selection stays
 // visible and the scroll markers appear — rather than overflowing unscrollably.

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -316,7 +316,11 @@ type Deps struct {
 	OpenAgentCreate        func() (tea.Model, error)
 	CreateAgent            func(name, runtime, template string) error
 	DeleteAgent            func(name string) error
-	RevertTemplate         func(templateID, versionID string) error
+	// DeleteAgents bulk-unregisters a set of agents (a template group). It deletes
+	// what it can and returns the names it skipped because they still have
+	// queued/running jobs, plus any unexpected error.
+	DeleteAgents   func(names []string) (deleted int, skipped []string, err error)
+	RevertTemplate func(templateID, versionID string) error
 	// SetAgentRuntime switches a registered agent's runtime (codex/claude/kimi),
 	// preserving its role/capabilities/repos and clearing the warm session.
 	SetAgentRuntime func(name, runtime string) error
@@ -485,6 +489,13 @@ type versionContentMsg struct {
 type agentActionMsg struct {
 	verb string // "create", "delete", "revert"
 	err  error
+}
+
+// agentGroupDeleteMsg carries the outcome of a bulk template-group delete.
+type agentGroupDeleteMsg struct {
+	deleted int
+	skipped []string
+	err     error
 }
 
 // agentFormResultMsg is delivered to the dashboard when the pushed

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -464,11 +464,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 			}
 		case "X":
-			if pages[m.selected].page == pageAgents && m.deps.DeleteAgents != nil {
-				if _, ok := m.agentUnderCursor(); ok {
-					m.openAgentGroupDelete()
-					m.viewport.SetContent(m.content())
-					return m, tea.Batch(cmds...)
+			if pages[m.selected].page == pageAgents {
+				if agent, ok := m.agentUnderCursor(); ok {
+					// The "Standalone agents" bucket is a heterogeneous catch-all
+					// (every template-less agent), not a coherent set — bulk-deleting
+					// it would be a footgun, so fall back to single-agent delete.
+					if agent.TemplateID == "" {
+						m.openAgentDelete(agent)
+						m.viewport.SetContent(m.content())
+						return m, tea.Batch(cmds...)
+					}
+					if m.deps.DeleteAgents != nil {
+						m.openAgentGroupDelete()
+						m.viewport.SetContent(m.content())
+						return m, tea.Batch(cmds...)
+					}
 				}
 			}
 		case "o":
@@ -812,21 +822,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case agentGroupDeleteMsg:
 		if m.mode == modeConfirmAgentGroupDelete {
+			// The deletes are already committed (each is its own tx), so always
+			// close the overlay, report what actually happened, and refresh — even
+			// on a partial error — so the list never shows already-deleted agents
+			// and a retry can't wedge re-deleting them.
 			m.actionBusy = false
+			m.mode = modeNormal
+			note := "deleted " + strconv.Itoa(msg.deleted) + " agent(s)"
+			if len(msg.skipped) > 0 {
+				note += " · " + strconv.Itoa(len(msg.skipped)) + " skipped (active jobs)"
+			}
+			m.agentNotice = note
 			if msg.err != nil {
-				m.actionErr = msg.err.Error()
+				m.agentErr = msg.err.Error()
 			} else {
-				m.mode = modeNormal
-				m.actionErr = ""
-				note := "deleted " + strconv.Itoa(msg.deleted) + " agent(s)"
-				if len(msg.skipped) > 0 {
-					note += " · " + strconv.Itoa(len(msg.skipped)) + " skipped (active jobs)"
-				}
-				m.agentNotice = note
-				m.agentCursor = clampCursor(m.agentCursor, len(m.visibleAgents()))
-				if cmd := m.queueLoad(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.agentErr = ""
+			}
+			m.agentCursor = clampCursor(m.agentCursor, len(m.visibleAgents()))
+			if cmd := m.queueLoad(); cmd != nil {
+				cmds = append(cmds, cmd)
 			}
 		}
 	case daemonStartMsg:

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,6 +68,7 @@ const (
 	modeAgentRevertPick
 	modeConfirmAgentRevert
 	modeConfirmAgentDelete
+	modeConfirmAgentGroupDelete
 	modeAgentVersionView
 	modeAgentRuntimePick
 	modeConfigEdit
@@ -158,6 +160,8 @@ type Model struct {
 	// Agents page interaction state.
 	agentCursor         int               // selected row in snap.Agents
 	showAllAgents       bool              // Agents page: include hidden skillopt-* training agents
+	groupDeleteLabel    string            // template-group label being bulk-deleted (confirm)
+	groupDeleteNames    []string          // agent names in the group being bulk-deleted
 	activeAgent         Agent             // agent shown in detail / being confirmed
 	agentVersions       []TemplateVersion // lazy-loaded template version history
 	agentVersionsLoaded bool              // the version load has returned (possibly empty)
@@ -239,7 +243,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 			return m.updateTrainOverlay(msg)
-		case modeAgentDetail, modeAgentRevertPick, modeConfirmAgentRevert, modeConfirmAgentDelete, modeAgentVersionView, modeAgentRuntimePick:
+		case modeAgentDetail, modeAgentRevertPick, modeConfirmAgentRevert, modeConfirmAgentDelete, modeConfirmAgentGroupDelete, modeAgentVersionView, modeAgentRuntimePick:
 			if msg.String() == "ctrl+c" {
 				return m, tea.Quit
 			}
@@ -458,6 +462,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.openAgentDelete(agent)
 				m.viewport.SetContent(m.content())
 				return m, tea.Batch(cmds...)
+			}
+		case "X":
+			if pages[m.selected].page == pageAgents && m.deps.DeleteAgents != nil {
+				if _, ok := m.agentUnderCursor(); ok {
+					m.openAgentGroupDelete()
+					m.viewport.SetContent(m.content())
+					return m, tea.Batch(cmds...)
+				}
 			}
 		case "o":
 			if agent, ok := m.agentUnderCursor(); ok && agent.TemplateID != "" &&
@@ -796,6 +808,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err == nil {
 			if cmd := m.queueLoad(); cmd != nil {
 				cmds = append(cmds, cmd)
+			}
+		}
+	case agentGroupDeleteMsg:
+		if m.mode == modeConfirmAgentGroupDelete {
+			m.actionBusy = false
+			if msg.err != nil {
+				m.actionErr = msg.err.Error()
+			} else {
+				m.mode = modeNormal
+				m.actionErr = ""
+				note := "deleted " + strconv.Itoa(msg.deleted) + " agent(s)"
+				if len(msg.skipped) > 0 {
+					note += " · " + strconv.Itoa(len(msg.skipped)) + " skipped (active jobs)"
+				}
+				m.agentNotice = note
+				m.agentCursor = clampCursor(m.agentCursor, len(m.visibleAgents()))
+				if cmd := m.queueLoad(); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
 			}
 		}
 	case daemonStartMsg:

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -100,6 +100,8 @@ func (m Model) content() string {
 		b.WriteString(m.agentRevertConfirmView())
 	case modeConfirmAgentDelete:
 		b.WriteString(m.agentDeleteConfirmView())
+	case modeConfirmAgentGroupDelete:
+		b.WriteString(m.agentGroupDeleteConfirmView())
 	case modeAgentVersionView:
 		b.WriteString(m.agentVersionView())
 	case modeAgentRuntimePick:
@@ -238,7 +240,7 @@ func (m Model) footerHelp() string {
 		return "↑/↓ pick  enter confirm  esc back"
 	case modeAgentRuntimePick:
 		return "↑/↓ pick  enter apply  esc cancel"
-	case modeConfirmAgentRevert, modeConfirmAgentDelete:
+	case modeConfirmAgentRevert, modeConfirmAgentDelete, modeConfirmAgentGroupDelete:
 		return "y confirm  n/esc cancel"
 	case modeConfigEdit:
 		return "type value  enter save  esc cancel"
@@ -259,7 +261,7 @@ func (m Model) footerHelp() string {
 	case pageTrains:
 		return "tab/←→ page  ↑/↓ select  enter open  s stop  d delete  ? help  q quit"
 	case pageAgents:
-		return "tab/←→ page  ↑/↓ select  enter detail  n new  o optimize  e runtime  D delete  a show all/hide  ? help  q quit"
+		return "tab/←→ page  ↑/↓ select  enter detail  n new  o optimize  e runtime  D delete  X delete group  a show all/hide  ? help  q quit"
 	case pageSessions:
 		return "tab/←→ page  ↑/↓ select  enter detail  s stop  ? help  q quit"
 	case pageJobs:

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -742,9 +742,15 @@ func (s *Store) RemoveAgent(ctx context.Context, name string) (bool, error) {
 	return affected > 0, tx.Commit()
 }
 
+// ErrAgentHasActiveJobs is the sentinel DeleteAgentChecked wraps when it refuses
+// an agent that still has queued/running jobs. Callers (e.g. the dashboard's
+// bulk delete) classify "skip vs hard error" with errors.Is rather than matching
+// the message text.
+var ErrAgentHasActiveJobs = errors.New("agent has queued or running jobs")
+
 // DeleteAgentChecked removes an agent (and its instances) unless queued or
-// running jobs still reference it, in which case it refuses so in-flight work is
-// never orphaned.
+// running jobs still reference it, in which case it refuses (wrapping
+// ErrAgentHasActiveJobs) so in-flight work is never orphaned.
 func (s *Store) DeleteAgentChecked(ctx context.Context, name string) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -760,7 +766,7 @@ func (s *Store) DeleteAgentChecked(ctx context.Context, name string) error {
 		return err
 	}
 	if active > 0 {
-		return fmt.Errorf("agent %s has %d queued or running job(s); cancel them first", name, active)
+		return fmt.Errorf("agent %s has %d queued or running job(s); cancel them first: %w", name, active, ErrAgentHasActiveJobs)
 	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM agent_repos WHERE agent_name = ?`, name); err != nil {
 		return err

--- a/internal/db/store_cockpit_test.go
+++ b/internal/db/store_cockpit_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -192,9 +193,10 @@ func TestDeleteAgentChecked(t *testing.T) {
 	if err := store.CreateJob(ctx, Job{ID: "j1", Agent: "worker", Type: "ask", State: "queued"}); err != nil {
 		t.Fatalf("job: %v", err)
 	}
-	// Refused while a queued job references the agent.
-	if err := store.DeleteAgentChecked(ctx, "worker"); err == nil || !strings.Contains(err.Error(), "queued or running") {
-		t.Fatalf("expected job-reference refusal, got %v", err)
+	// Refused while a queued job references the agent — wraps the sentinel so
+	// callers can classify with errors.Is, not message text.
+	if err := store.DeleteAgentChecked(ctx, "worker"); err == nil || !errors.Is(err, ErrAgentHasActiveJobs) {
+		t.Fatalf("expected job-reference refusal (ErrAgentHasActiveJobs), got %v", err)
 	}
 	if err := store.UpdateJobState(ctx, "j1", "succeeded"); err != nil {
 		t.Fatalf("settle job: %v", err)


### PR DESCRIPTION
Adds a way to delete a whole **set** of agents at once from the dashboard Agents page — the cleanup the training/skillopt sets need.

## What
- **`X`** on an agent opens a confirm for that agent's whole **template group**: lists the members (capped) + count, plus a heads-up of how many currently have active jobs and will be skipped.
- **`y`** bulk-unregisters the group via a new `DeleteAgents` dep that loops `DeleteAgentChecked`, deleting what it can and **skipping any agent with a queued/running job** (in-flight work is never orphaned). The result reports `deleted N · M skipped (active jobs)`.

This pairs with the `a` show-all toggle: reveal the training agents, put the cursor on a training group, `X` to clear it.

## Safety (driven by a focused code review)
A multi-agent review of this destructive path (3 angles, 18 candidates, 0 refuted) drove a hardening commit:
- **No catch-all footgun** — every template-less agent shares `TemplateID ""`, so `X` on one would have bulk-deleted *all* unrelated standalone agents. `X` on a template-less agent now **falls back to single-agent delete**.
- **Partial deletes never silently dropped** — each delete commits in its own tx, so the dep now continues past unexpected errors and returns the full counts; the handler always closes the overlay, reports deleted/skipped, surfaces the error, and refreshes the list — so it can't show already-deleted agents or wedge a retry on "not found".
- **No fragile string-match** — `DeleteAgentChecked` now wraps a sentinel `db.ErrAgentHasActiveJobs`, classified via `errors.Is` instead of the message text.
- Softened the confirm heads-up wording (the store is authoritative at delete time).
- Accepted as-is (noted): the heads-up is best-effort/snapshot-based but the store gates the actual deletion and the post-delete notice is authoritative.

## Tests / gate
New tests: the `X→confirm→y` flow (names, active-job heads-up, result note), standalone→single-delete fallback, partial-error still reports + closes, the no-dep no-op guard, the real-store dep skipping an active-job agent, and the store sentinel via `errors.Is`. `go build`/`vet`/`test ./...` + `-race ./internal/workflow/` all green; changed files gofmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)