### PR TITLE
feat: ephemeral agents — spawn throwaway workers from a delegation spec (#325 MVP)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1460,9 +1460,20 @@ func runAgentList(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	for _, agent := range agents {
+		if isEphemeralAgentName(agent.Name) {
+			continue // transient spawn-from-spec workers are not part of the registry
+		}
 		fmt.Fprintf(stdout, "%-16s %-8s %-12s %-20s %s\n", agent.Name, agent.Runtime, agent.Role, strings.Join(agentRepos[agent.Name], ","), strings.Join(agent.Capabilities, ","))
 	}
 	return 0
+}
+
+// isEphemeralAgentName reports whether an agent name is a transient ephemeral
+// worker materialized from a delegation spec (#325). Such workers are persisted
+// only for the duration of their job and auto-disposed; they are excluded from
+// the registry listings (mirroring the dashboard TUI's isEphemeralAgent filter).
+func isEphemeralAgentName(name string) bool {
+	return strings.Contains(name, "-ephemeral-")
 }
 
 type agentShowOutput struct {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2093,7 +2093,7 @@ func (w jobWorker) startTempWorker(ctx context.Context, job db.Job, payload work
 // already the engine-assigned "-ephemeral-" name; callers register a deferred
 // cleanupTempWorker to auto-dispose the worker on every exit path. The worker
 // runs read-only unless the spec opts into a writable autonomy policy.
-func (w jobWorker) startEphemeralWorker(ctx context.Context, job db.Job, payload workflow.JobPayload) error {
+func (w jobWorker) startEphemeralWorker(ctx context.Context, job db.Job, payload workflow.JobPayload) (err error) {
 	spec := payload.Ephemeral
 	if spec == nil {
 		return errors.New("ephemeral worker requires a spec")
@@ -2102,8 +2102,13 @@ func (w jobWorker) startEphemeralWorker(ctx context.Context, job db.Job, payload
 	if len(capabilities) == 0 {
 		capabilities = []string{job.Type}
 	}
-	// Default to read-only; the spec must opt into a writable policy.
-	policy := firstNonEmpty(strings.TrimSpace(spec.AutonomyPolicy), runtime.AutonomyPolicyReadOnly)
+	// Least privilege: default read-only, except an implement must be able to
+	// write. The spec may still opt into a different (validated) policy.
+	defaultPolicy := runtime.AutonomyPolicyReadOnly
+	if job.Type == "implement" {
+		defaultPolicy = runtime.AutonomyPolicyWorkspaceWrite
+	}
+	policy := firstNonEmpty(strings.TrimSpace(spec.AutonomyPolicy), defaultPolicy)
 	// Role is required by runtime.ValidateAgent but optional on the spec; fall
 	// back to the job action (e.g. "review"/"implement"), then a generic role.
 	role := firstNonEmpty(strings.TrimSpace(spec.Role), strings.TrimSpace(job.Type), "worker")
@@ -2122,6 +2127,16 @@ func (w jobWorker) startEphemeralWorker(ctx context.Context, job db.Job, payload
 	if err := w.Store.UpsertAgent(ctx, dbAgent(ephemeralAgent)); err != nil {
 		return err
 	}
+	// The agent row (and, below, its instance + a live runtime session) now
+	// exist. Dispose them if any later bring-up step fails so a partial
+	// materialization cannot leak an agent/instance/session — mirroring
+	// startTempWorker's cleanup-on-error. (The named return err is set by the
+	// `return err` paths below.)
+	defer func() {
+		if err != nil {
+			w.cleanupTempWorker(context.Background(), ephemeralAgent.Name)
+		}
+	}()
 	// Normalize the stored policy back onto the in-memory agent so the runtime
 	// session is started with the same sandbox the rest of run will use.
 	ephemeralAgent.AutonomyPolicy = runtime.NormalizeStoredAutonomyPolicy(ephemeralAgent.AutonomyPolicy)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1577,6 +1577,26 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	if err != nil {
 		return w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err)
 	}
+	// An ephemeral child carries an inline worker spec instead of a
+	// pre-registered agent. Materialize a throwaway agent + runtime session
+	// from the spec before the normal flow runs (which assumes the agent
+	// already exists via GetAgent below), and register a cleanup defer so the
+	// worker is auto-disposed on every exit path — success, failure, or block.
+	if payload.Ephemeral != nil {
+		if err := w.startEphemeralWorker(ctx, job, payload); err != nil {
+			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "ephemeral_worker_failed", Message: err.Error()}); eventErr != nil {
+				return eventErr
+			}
+			if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
+				return finishErr
+			}
+			_ = w.postJobResultComment(ctx, job.ID, runtime.Agent{Name: job.Agent}, "", err)
+			return nil
+		}
+		// Idempotent removal of the agent row + instance regardless of how run
+		// returns; uses a background context so cleanup survives ctx cancel.
+		defer w.cleanupTempWorker(context.Background(), job.Agent)
+	}
 	dbAgent, err := w.Store.GetAgent(ctx, job.Agent)
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
@@ -1725,6 +1745,11 @@ func (w jobWorker) parallelSessionPolicy() (config.ParallelSessionPolicy, error)
 }
 
 func tempWorkerEligible(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload, agent runtime.Agent, policy config.ParallelSessionPolicy, now time.Time) tempWorkerEligibility {
+	if payload.Ephemeral != nil {
+		// An ephemeral job already runs directly on its own throwaway worker;
+		// forking it into a second temp worker would double-spawn.
+		return tempWorkerEligibility{Reason: "ephemeral worker runs directly"}
+	}
 	if payload.DelegationReason == "temp_worker_merge_back" {
 		return tempWorkerEligibility{Reason: "merge-back waits for original runtime session"}
 	}
@@ -2058,6 +2083,116 @@ func (w jobWorker) startTempWorker(ctx context.Context, job db.Job, payload work
 	}
 	return tempWorkerStartResult{Agent: tempAgent, IdleTimeout: idleTimeout, JobTimeout: jobTimeout}, nil
 }
+
+// startEphemeralWorker materializes a throwaway agent for a job whose payload
+// carries an inline worker spec, generalizing the temp-worker machinery from
+// "fork an existing agent" to "spawn from a spec". It persists the agent (so the
+// rest of run's flow — GetAgent, the engine's executor checks — finds it),
+// associates payload.Repo via the agent's RepoScope, and reserves + starts a
+// runtime session (mirroring startTempWorker). The agent name on the job is
+// already the engine-assigned "-ephemeral-" name; callers register a deferred
+// cleanupTempWorker to auto-dispose the worker on every exit path. The worker
+// runs read-only unless the spec opts into a writable autonomy policy.
+func (w jobWorker) startEphemeralWorker(ctx context.Context, job db.Job, payload workflow.JobPayload) error {
+	spec := payload.Ephemeral
+	if spec == nil {
+		return errors.New("ephemeral worker requires a spec")
+	}
+	capabilities := spec.Capabilities
+	if len(capabilities) == 0 {
+		capabilities = []string{job.Type}
+	}
+	// Default to read-only; the spec must opt into a writable policy.
+	policy := firstNonEmpty(strings.TrimSpace(spec.AutonomyPolicy), runtime.AutonomyPolicyReadOnly)
+	// Role is required by runtime.ValidateAgent but optional on the spec; fall
+	// back to the job action (e.g. "review"/"implement"), then a generic role.
+	role := firstNonEmpty(strings.TrimSpace(spec.Role), strings.TrimSpace(job.Type), "worker")
+	ephemeralAgent := runtime.Agent{
+		Name:           job.Agent,
+		Role:           role,
+		Runtime:        spec.Runtime,
+		Model:          spec.Model,
+		TemplateID:     spec.Template,
+		Capabilities:   capabilities,
+		AutonomyPolicy: policy,
+		RepoScope:      payload.Repo,
+	}
+	// Persisting with RepoScope set associates the worker with payload.Repo
+	// (agent_repos), mirroring how a normal agent gains repo access.
+	if err := w.Store.UpsertAgent(ctx, dbAgent(ephemeralAgent)); err != nil {
+		return err
+	}
+	// Normalize the stored policy back onto the in-memory agent so the runtime
+	// session is started with the same sandbox the rest of run will use.
+	ephemeralAgent.AutonomyPolicy = runtime.NormalizeStoredAutonomyPolicy(ephemeralAgent.AutonomyPolicy)
+	checkout, err := w.CheckoutValidator(ctx, job, payload, ephemeralAgent)
+	if err != nil {
+		return err
+	}
+	var cachedTemplate db.AgentTemplate
+	if ephemeralAgent.TemplateID != "" {
+		cachedTemplate, err = loadInstalledTemplate(ctx, w.Store, ephemeralAgent.TemplateID)
+		if err != nil {
+			return err
+		}
+	}
+	now := time.Now().UTC()
+	reserved := db.AgentInstance{
+		Name:    ephemeralAgent.Name,
+		Type:    tempWorkerAgentType(ephemeralWorkerInstanceOrigin),
+		Runtime: ephemeralAgent.Runtime,
+		// "starting:" placeholder ref keeps the reserved row valid before the
+		// adapter returns the real runtime ref.
+		RuntimeRef:     "starting:" + ephemeralAgent.Name,
+		RepoFullName:   payload.Repo,
+		Role:           ephemeralAgent.Role,
+		TemplateID:     ephemeralAgent.TemplateID,
+		Model:          ephemeralAgent.Model,
+		Capabilities:   ephemeralAgent.Capabilities,
+		AutonomyPolicy: ephemeralAgent.AutonomyPolicy,
+		State:          "starting",
+		CreatedAt:      formatManagedAgentTime(now),
+		LastUsedAt:     formatManagedAgentTime(now),
+		ExpiresAt:      formatManagedAgentTime(now.Add(daemonRunningJobStaleAfter)),
+	}
+	if err := w.Store.UpsertAgentInstance(ctx, reserved); err != nil {
+		return err
+	}
+	adapter, err := w.StartAdapterFactory(ephemeralAgent.Runtime, checkout)
+	if err != nil {
+		return err
+	}
+	started, err := adapter.Start(ctx, runtime.StartRequest{Agent: ephemeralAgent, Prompt: agentStartupPrompt(ephemeralAgent, cachedTemplate)})
+	if err != nil {
+		return err
+	}
+	ephemeralAgent.RuntimeRef = strings.TrimSpace(started.RuntimeRef)
+	if err := runtime.ValidateAgent(ephemeralAgent); err != nil {
+		return err
+	}
+	// Persist the live runtime_ref on both the agent row (so GetAgent below
+	// resolves a runnable session) and the instance.
+	if err := w.Store.UpsertAgent(ctx, dbAgent(ephemeralAgent)); err != nil {
+		return err
+	}
+	instance := reserved
+	instance.RuntimeRef = ephemeralAgent.RuntimeRef
+	instance.State = "idle"
+	if err := w.Store.UpsertAgentInstance(ctx, instance); err != nil {
+		return err
+	}
+	if err := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "ephemeral_worker_started", Message: fmt.Sprintf("materialized %s worker %s", ephemeralAgent.Runtime, ephemeralAgent.Name)}); err != nil {
+		return err
+	}
+	writeLine(w.Stdout, "materialized ephemeral worker %s (%s) for job %s in %s", ephemeralAgent.Name, ephemeralAgent.Runtime, job.ID, payload.Repo)
+	return nil
+}
+
+// ephemeralWorkerInstanceOrigin is the synthetic "original" agent name used in an
+// ephemeral worker's instance type. It has no registered instance, so
+// managedJobConfig treats the worker as unmanaged (no agent-type config), which
+// is correct for a spec-spawned worker that does not belong to a managed pool.
+const ephemeralWorkerInstanceOrigin = "gitmoot-ephemeral-spec"
 
 func (w jobWorker) cleanupTempWorker(ctx context.Context, agentName string) {
 	if err := w.Store.DeleteAgentInstance(ctx, agentName); err != nil {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -1957,6 +1957,146 @@ func TestRunQueuedJobsCleansTempWorkerWhenDelegationRaceLoses(t *testing.T) {
 	}
 }
 
+// TestRunQueuedJobsMaterializesAndDisposesEphemeralWorker proves a queued child
+// carrying an inline EphemeralSpec (no pre-registered agent) gets a throwaway
+// agent materialized from the spec, runs the job (Start + Deliver invoked), and
+// is auto-disposed afterwards — both the agent row and its instance are gone.
+func TestRunQueuedJobsMaterializesAndDisposesEphemeralWorker(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	ephemeralName := "reviewer-ephemeral-abc1234567"
+	// No agent row is seeded: the worker must be materialized from the spec.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:        "job-eph",
+		Agent:     ephemeralName,
+		Action:    "ask",
+		Repo:      "owner/repo",
+		Branch:    "main",
+		Ephemeral: &workflow.EphemeralSpec{Runtime: runtime.CodexRuntime, Model: "gpt-5.4"},
+	})
+
+	startAdapter := &cliWorkerFakeAdapter{startRuntimeRef: "550e8400-e29b-41d4-a716-446655440555"}
+	deliveryAdapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}
+	var deliveredModel string
+	startCheckouts := []string{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.StartAdapterFactory = func(_ string, path string) (runtime.Adapter, error) {
+		startCheckouts = append(startCheckouts, path)
+		return startAdapter, nil
+	}
+	worker.AdapterFactory = func(agent runtime.Agent, _ string) (workflow.DeliveryAdapter, error) {
+		deliveredModel = agent.Model
+		return deliveryAdapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-eph")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded", job.State)
+	}
+	if startAdapter.startCalls != 1 || deliveryAdapter.calls != 1 {
+		t.Fatalf("start calls=%d delivery calls=%d, want 1 each", startAdapter.startCalls, deliveryAdapter.calls)
+	}
+	if deliveredModel != "gpt-5.4" {
+		t.Fatalf("delivered agent model = %q, want gpt-5.4", deliveredModel)
+	}
+	if len(startCheckouts) != 1 || startCheckouts[0] != checkout {
+		t.Fatalf("start checkouts = %+v, want %q", startCheckouts, checkout)
+	}
+	// The throwaway agent row and its instance must be gone after the run.
+	if _, err := store.GetAgentInstance(ctx, ephemeralName); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetAgentInstance after run error = %v, want no rows", err)
+	}
+	if _, err := store.GetAgent(ctx, ephemeralName); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetAgent after run error = %v, want no rows", err)
+	}
+	if !daemonWorkerHasEvent(mustListJobEvents(t, store, "job-eph"), "ephemeral_worker_started") {
+		t.Fatalf("missing ephemeral_worker_started event")
+	}
+}
+
+// TestRunQueuedJobsDisposesEphemeralWorkerOnFailure proves the throwaway agent
+// is auto-disposed even when delivery fails: the job reaches a terminal failed
+// state and neither the agent row nor its instance survives.
+func TestRunQueuedJobsDisposesEphemeralWorkerOnFailure(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	ephemeralName := "impl-ephemeral-def7654321"
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:        "job-eph-fail",
+		Agent:     ephemeralName,
+		Action:    "ask",
+		Repo:      "owner/repo",
+		Branch:    "main",
+		Ephemeral: &workflow.EphemeralSpec{Runtime: runtime.CodexRuntime, Model: "gpt-5.4"},
+	})
+
+	startAdapter := &cliWorkerFakeAdapter{startRuntimeRef: "550e8400-e29b-41d4-a716-446655440666"}
+	deliveryAdapter := &cliWorkerFakeAdapter{err: errors.New("delivery failed")}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.StartAdapterFactory = func(string, string) (runtime.Adapter, error) {
+		return startAdapter, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return deliveryAdapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-eph-fail")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+	if deliveryAdapter.calls != 1 {
+		t.Fatalf("delivery calls = %d, want 1", deliveryAdapter.calls)
+	}
+	// Cleanup must still run on the failure path.
+	if _, err := store.GetAgentInstance(ctx, ephemeralName); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetAgentInstance after failed run error = %v, want no rows", err)
+	}
+	if _, err := store.GetAgent(ctx, ephemeralName); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetAgent after failed run error = %v, want no rows", err)
+	}
+}
+
+func mustListJobEvents(t *testing.T, store *db.Store, jobID string) []db.JobEvent {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	return events
+}
+
 func TestRunQueuedJobsPreservesCreationOrderForSameRepo(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -394,6 +394,9 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 			return err
 		}
 		for _, agent := range agents {
+			if isEphemeralAgentName(agent.Name) {
+				continue // transient spawn-from-spec workers are not part of the registry
+			}
 			snapshot.Agents = append(snapshot.Agents, dashboardAgent{Name: agent.Name, Runtime: agent.Runtime, Role: agent.Role, Health: agent.HealthStatus, templateID: agent.TemplateID})
 		}
 		instances, err := store.ListAgentInstances(ctx)

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -45,6 +45,14 @@ func isManagedTrainingAgent(name string) bool {
 	return strings.HasPrefix(name, "skillopt-target-") || strings.HasPrefix(name, "skillopt-generator")
 }
 
+// isEphemeralAgent reports whether an agent name belongs to an ephemeral worker
+// materialized for a single delegation (#325). Ephemeral names carry the
+// "-ephemeral-" infix (see workflow.ephemeralAgentName); they expire with the
+// delegation, so the persistent Agents registry hides them.
+func isEphemeralAgent(name string) bool {
+	return strings.Contains(name, "-ephemeral-")
+}
+
 // visibleAgents are the user-facing agents (training plumbing filtered out). The
 // Agents page renders, cursors, and acts on this list; the serialized snapshot
 // keeps every agent, so --json/--plain are unaffected.
@@ -54,7 +62,7 @@ func (m Model) visibleAgents() []Agent {
 	}
 	out := make([]Agent, 0, len(m.snap.Agents))
 	for _, a := range m.snap.Agents {
-		if !isManagedTrainingAgent(a.Name) {
+		if !isManagedTrainingAgent(a.Name) && !isEphemeralAgent(a.Name) {
 			out = append(out, a)
 		}
 	}
@@ -666,7 +674,16 @@ func choiceValues(choices []Choice) []string {
 // overlays are dispatched once in content(), not here.
 func (m Model) agentsContentInteractive() string {
 	visible := m.visibleAgents()
-	hidden := len(m.snap.Agents) - len(visible)
+	// hidden counts only the managed training agents the hidden line describes
+	// ("… training agents hidden (skillopt-*)"). Ephemeral agents (#325) are
+	// filtered from the registry too, but they are not training plumbing, so they
+	// are dropped silently rather than mislabeled here.
+	hidden := 0
+	for _, a := range m.snap.Agents {
+		if isManagedTrainingAgent(a.Name) {
+			hidden++
+		}
+	}
 	// LIVE = warm runtime sessions per agent. Count once over all sessions (keyed
 	// by owning agent) so the render stays O(agents + sessions); also tally the
 	// sessions owned by hidden training agents to annotate the hidden line.

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -274,6 +274,53 @@ func TestAgentsPageHidesTrainingAgents(t *testing.T) {
 	}
 }
 
+// TestAgentsPageHidesEphemeralAgents guards #325: an ephemeral worker (its name
+// carries the "-ephemeral-" infix) is dropped from the persistent Agents
+// registry grouping, while a normal agent on the same template still renders.
+// Ephemeral agents are not training plumbing, so they must not be folded into
+// the "training agents hidden (skillopt-*)" count line.
+func TestAgentsPageHidesEphemeralAgents(t *testing.T) {
+	snap := agentsSnapshot()
+	snap.Agents = append(snap.Agents,
+		Agent{Name: "fixit-ephemeral-abc", Runtime: "claude", TemplateID: "planner-tpl"},
+	)
+	m := agentsModel(t, Deps{}, snap)
+
+	// The visible/registry list excludes the ephemeral agent but keeps the normal ones.
+	for _, a := range m.visibleAgents() {
+		if a.Name == "fixit-ephemeral-abc" {
+			t.Fatalf("ephemeral agent must be excluded from the registry list:\n%v", m.visibleAgents())
+		}
+	}
+	var sawPlanner, sawReviewer bool
+	for _, a := range m.visibleAgents() {
+		switch a.Name {
+		case "planner":
+			sawPlanner = true
+		case "reviewer":
+			sawReviewer = true
+		}
+	}
+	if !sawPlanner || !sawReviewer {
+		t.Fatalf("normal agents must remain in the registry list, got %v", m.visibleAgents())
+	}
+
+	view := m.View()
+	if strings.Contains(view, "fixit-ephemeral-abc") {
+		t.Fatalf("ephemeral agent must not render in the Agents registry:\n%s", view)
+	}
+	for _, want := range []string{"planner", "reviewer"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("agents view missing normal agent %q:\n%s", want, view)
+		}
+	}
+	// The ephemeral agent is not training plumbing: with no skillopt-* agents
+	// present, the "training agents hidden" line must not appear.
+	if strings.Contains(view, "training agents hidden") {
+		t.Fatalf("ephemeral agents must not be counted as hidden training agents:\n%s", view)
+	}
+}
+
 func TestAgentsPageGroupsByTemplate(t *testing.T) {
 	snap := agentsSnapshot()
 	// A second agent on planner-tpl (stays in the planner-tpl group) and one

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -486,9 +486,21 @@ func (e Engine) rootJobID(job db.Job, payload JobPayload) string {
 // advanceDelegations (deferred enqueue once deps clear) so both paths produce
 // identical, idempotent requests for the same delegation ID.
 func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) JobRequest {
+	// An ephemeral delegation has no pre-registered agent: synthesize a stable
+	// agent name (carrying the "-ephemeral-" infix the TUI filters on) and thread
+	// the worker spec through so the daemon can materialize the worker and the
+	// engine can skip the registered-agent checks. A non-ephemeral delegation
+	// keeps routing to its named agent unchanged.
+	agent := d.Agent
+	var ephemeral *EphemeralSpec
+	if d.Ephemeral != nil {
+		agent = ephemeralAgentName(d.ID, job.ID)
+		ephemeral = d.Ephemeral
+	}
 	return JobRequest{
 		ID:              job.ID + "/delegation/" + d.ID,
-		Agent:           d.Agent,
+		Agent:           agent,
+		Ephemeral:       ephemeral,
 		Action:          d.Action,
 		Repo:            payload.Repo,
 		Branch:          payload.Branch,
@@ -1607,6 +1619,14 @@ func delegationDecisionApproves(decision string) bool {
 }
 
 func (e Engine) preflightDelegation(ctx context.Context, request JobRequest) error {
+	// An ephemeral delegation routes to an on-demand worker that no agent row
+	// backs, so the registered-agent existence, repo-access, and capability checks
+	// do not apply: the ephemeral child inherits the coordinator's allowed repo
+	// scope. Only validate that the spec runtime is a real agent runtime (never
+	// shell); the daemon materializes the worker from the spec.
+	if request.Ephemeral != nil {
+		return validateEphemeralSpec(request.DelegationID, request.Ephemeral)
+	}
 	agent, err := e.Store.GetAgent(ctx, request.Agent)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1981,14 +2001,33 @@ func (e Engine) ensureJobExecutorAllowed(ctx context.Context, job db.Job, payloa
 		payload.DelegationReason == "temp_worker_merge_back" &&
 		payload.OriginalAgent == job.Agent
 	return e.ensureAgentAllowedWithBranchOwner(ctx, JobRequest{
-		Agent:  authorizationAgent,
-		Action: job.Type,
-		Repo:   payload.Repo,
-		Branch: payload.Branch,
+		Agent:        authorizationAgent,
+		Action:       job.Type,
+		Repo:         payload.Repo,
+		Branch:       payload.Branch,
+		DelegationID: payload.DelegationID,
+		// Carry the worker spec so an ephemeral child's executor check inherits the
+		// coordinator's repo scope (skip the registered-agent checks) instead of
+		// blocking on a synthetic agent name that no agent row backs.
+		Ephemeral: payload.Ephemeral,
 	}, branchOwner, ref, allowMissingCapability)
 }
 
 func (e Engine) ensureAgentAllowedWithBranchOwner(ctx context.Context, request JobRequest, branchOwner string, ref taskRef, allowMissingCapability bool) error {
+	// An ephemeral worker has no registered agent row: it inherits the
+	// coordinator's allowed repo scope, so the existence, repo-access, and
+	// capability checks are skipped. Validate only that the spec runtime is a real
+	// agent runtime (never shell), then fall through to the shared branch-lock path
+	// so an ephemeral implement still serializes on its branch like any other.
+	if request.Ephemeral != nil {
+		if err := validateEphemeralSpec(request.DelegationID, request.Ephemeral); err != nil {
+			return e.block(ctx, ref, err.Error())
+		}
+		if request.Action == "implement" {
+			return e.ensureBranchLock(ctx, request.Repo, request.Branch, branchOwner, ref)
+		}
+		return nil
+	}
 	agent, err := e.Store.GetAgent(ctx, request.Agent)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -582,7 +582,14 @@ func canonicalDelegationSetHash(dels []Delegation) string {
 	for _, d := range sorted {
 		deps := compactStrings(d.Deps)
 		sort.Strings(deps)
-		fields := []string{d.ID, d.Agent, d.Action, strings.TrimSpace(d.Prompt), strings.Join(deps, ",")}
+		// For an ephemeral delegation, d.Agent is empty; fold the spec identity
+		// (runtime/model/template/role) into the hash so two distinct ephemeral
+		// specs are not mistaken for the same work by loop detection / dedup.
+		eph := ""
+		if d.Ephemeral != nil {
+			eph = strings.Join([]string{d.Ephemeral.Runtime, d.Ephemeral.Model, d.Ephemeral.Template, d.Ephemeral.Role}, "|")
+		}
+		fields := []string{d.ID, d.Agent, eph, d.Action, strings.TrimSpace(d.Prompt), strings.Join(deps, ",")}
 		builder.WriteString(strings.Join(fields, "\x1f"))
 		builder.WriteString("\x1e")
 	}
@@ -641,6 +648,18 @@ func (e Engine) countRootDelegationJobs(ctx context.Context, rootID string) (int
 
 func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload JobPayload, ref taskRef) error {
 	if payload.Result == nil || len(payload.Result.Delegations) == 0 {
+		return nil
+	}
+
+	// Ephemeral workers are leaf executors: they are auto-disposed when their job
+	// completes, so a continuation enqueued to their (now-deleted) synthetic agent
+	// would strand. Do not dispatch delegations returned by an ephemeral worker.
+	if payload.Ephemeral != nil {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_ignored_ephemeral",
+			Message: fmt.Sprintf("ephemeral workers cannot delegate; ignoring %d delegation(s)", len(payload.Result.Delegations)),
+		})
 		return nil
 	}
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2287,6 +2287,89 @@ func TestEngineDelegationRequestCopiesModel(t *testing.T) {
 	}
 }
 
+func TestEngineDelegationRequestThreadsEphemeralSpec(t *testing.T) {
+	engine := Engine{}
+	spec := &EphemeralSpec{Runtime: runtime.CodexRuntime, Model: "gpt-5.4"}
+	request := engine.delegationRequest(
+		db.Job{ID: "parent-job", Agent: "audit"},
+		JobPayload{Repo: "jerryfane/gitmoot"},
+		Delegation{ID: "worker", Ephemeral: spec, Action: "implement", Prompt: "hi"},
+	)
+	if request.Ephemeral != spec {
+		t.Fatalf("request.Ephemeral = %+v, want the delegation spec", request.Ephemeral)
+	}
+	// The synthetic agent name replaces the (empty) delegation agent and carries
+	// the TUI filter infix.
+	if !strings.Contains(request.Agent, "-ephemeral-") {
+		t.Fatalf("request.Agent = %q, want it to contain %q", request.Agent, "-ephemeral-")
+	}
+	if request.Agent != ephemeralAgentName("worker", "parent-job") {
+		t.Fatalf("request.Agent = %q, want the deterministic ephemeral name", request.Agent)
+	}
+
+	// A non-ephemeral delegation keeps routing to its named agent unchanged.
+	plain := engine.delegationRequest(
+		db.Job{ID: "parent-job", Agent: "audit"},
+		JobPayload{Repo: "jerryfane/gitmoot"},
+		Delegation{ID: "del-1", Agent: "helper", Action: "review", Prompt: "go"},
+	)
+	if plain.Ephemeral != nil {
+		t.Fatalf("non-ephemeral request carried a spec: %+v", plain.Ephemeral)
+	}
+	if plain.Agent != "helper" {
+		t.Fatalf("non-ephemeral request.Agent = %q, want %q", plain.Agent, "helper")
+	}
+}
+
+func TestEngineDispatchesEphemeralDelegationWithoutRegisteredAgent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	// The coordinator is registered; the ephemeral worker deliberately is NOT, so
+	// this exercises the engine's bypass of the registered-agent existence,
+	// repo-access, and capability checks for an ephemeral delegation.
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "worker", Ephemeral: &EphemeralSpec{Runtime: runtime.CodexRuntime, Model: "gpt-5.4"}, Action: "review", Prompt: "hi"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	child := mustJob(t, store, "parent-job/delegation/worker")
+	if !strings.Contains(child.Agent, "-ephemeral-") {
+		t.Fatalf("child agent = %q, want it to contain %q", child.Agent, "-ephemeral-")
+	}
+	payload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.Ephemeral == nil {
+		t.Fatalf("child payload missing ephemeral spec: %+v", payload)
+	}
+	if payload.Ephemeral.Runtime != runtime.CodexRuntime || payload.Ephemeral.Model != "gpt-5.4" {
+		t.Fatalf("child payload ephemeral spec = %+v", payload.Ephemeral)
+	}
+	// The stored payload JSON must carry the ephemeral key so downstream consumers
+	// (daemon worker materialization, dashboard) can read it back.
+	if !strings.Contains(child.Payload, `"ephemeral"`) {
+		t.Fatalf("stored payload missing ephemeral key: %s", child.Payload)
+	}
+}
+
 func TestEngineDelegationInvalidLifecycleRejectedAtExtraction(t *testing.T) {
 	// Each invalid lifecycle control must be rejected when the agent result is
 	// extracted, so a malformed delegation never reaches the dispatcher.

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -67,6 +67,36 @@ func TestEngineAdvanceJobDispatchesDelegations(t *testing.T) {
 	}
 }
 
+func TestEngineEphemeralWorkerCannotDelegate(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "helper", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	// A job that is itself an ephemeral worker (payload.Ephemeral set) returns a
+	// delegation. The engine must NOT dispatch it (an ephemeral worker is a leaf
+	// that is auto-disposed; a continuation to its synthetic agent would strand).
+	insertCompletedJob(t, store, db.Job{ID: "eph-job", Agent: "x-ephemeral-abc", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		Sender:    "x-ephemeral-abc",
+		Ephemeral: &EphemeralSpec{Runtime: "codex"},
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "del-1", Agent: "helper", Action: "review", Prompt: "review this"},
+			},
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "eph-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if jobExists(t, store, "eph-job/delegation/del-1") {
+		t.Fatalf("ephemeral worker's delegation must not be dispatched")
+	}
+}
+
 func TestEngineAdvanceJobWritesDelegationArtifacts(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -54,46 +54,48 @@ type JobRequest struct {
 	RecentDelegationHashes []string
 	DelegationRepeatCount  int
 	Model                  string
+	Ephemeral              *EphemeralSpec
 }
 
 type JobPayload struct {
-	Repo                   string       `json:"repo"`
-	Branch                 string       `json:"branch"`
-	PullRequest            int          `json:"pull_request"`
-	HeadSHA                string       `json:"head_sha,omitempty"`
-	GoalID                 string       `json:"goal_id,omitempty"`
-	TaskID                 string       `json:"task_id"`
-	TaskTitle              string       `json:"task_title"`
-	LeadAgent              string       `json:"lead_agent,omitempty"`
-	Reviewers              []string     `json:"reviewers,omitempty"`
-	ReviewRound            string       `json:"review_round,omitempty"`
-	Sender                 string       `json:"sender"`
-	Instructions           string       `json:"instructions"`
-	Constraints            []string     `json:"constraints"`
-	ParentJobID            string       `json:"parent_job_id,omitempty"`
-	DelegationID           string       `json:"delegation_id,omitempty"`
-	DelegationDepth        int          `json:"delegation_depth,omitempty"`
-	DelegatedBy            string       `json:"delegated_by,omitempty"`
-	RootJobID              string       `json:"root_job_id,omitempty"`
-	Deps                   []string     `json:"deps,omitempty"`
-	JobTimeout             string       `json:"job_timeout,omitempty"`
-	RetryCount             int          `json:"retry_count,omitempty"`
-	Fingerprint            string       `json:"fingerprint,omitempty"`
-	FailurePolicy          string       `json:"failure_policy,omitempty"`
-	SynthesisRule          string       `json:"synthesis_rule,omitempty"`
-	DelegationArtifactDir  string       `json:"delegation_artifact_dir,omitempty"`
-	WorktreePath           string       `json:"worktree_path,omitempty"`
-	TemplateID             string       `json:"template_id,omitempty"`
-	TemplateResolvedCommit string       `json:"template_resolved_commit,omitempty"`
-	TemplateContent        string       `json:"template_content,omitempty"`
-	OriginalAgent          string       `json:"original_agent,omitempty"`
-	DelegatedAgent         string       `json:"delegated_agent,omitempty"`
-	DelegationReason       string       `json:"delegation_reason,omitempty"`
-	RecentDelegationHashes []string     `json:"recent_delegation_hashes,omitempty"`
-	DelegationRepeatCount  int          `json:"delegation_repeat_count,omitempty"`
-	Model                  string       `json:"model,omitempty"`
-	RawOutputs             []string     `json:"raw_outputs,omitempty"`
-	Result                 *AgentResult `json:"result,omitempty"`
+	Repo                   string         `json:"repo"`
+	Branch                 string         `json:"branch"`
+	PullRequest            int            `json:"pull_request"`
+	HeadSHA                string         `json:"head_sha,omitempty"`
+	GoalID                 string         `json:"goal_id,omitempty"`
+	TaskID                 string         `json:"task_id"`
+	TaskTitle              string         `json:"task_title"`
+	LeadAgent              string         `json:"lead_agent,omitempty"`
+	Reviewers              []string       `json:"reviewers,omitempty"`
+	ReviewRound            string         `json:"review_round,omitempty"`
+	Sender                 string         `json:"sender"`
+	Instructions           string         `json:"instructions"`
+	Constraints            []string       `json:"constraints"`
+	ParentJobID            string         `json:"parent_job_id,omitempty"`
+	DelegationID           string         `json:"delegation_id,omitempty"`
+	DelegationDepth        int            `json:"delegation_depth,omitempty"`
+	DelegatedBy            string         `json:"delegated_by,omitempty"`
+	RootJobID              string         `json:"root_job_id,omitempty"`
+	Deps                   []string       `json:"deps,omitempty"`
+	JobTimeout             string         `json:"job_timeout,omitempty"`
+	RetryCount             int            `json:"retry_count,omitempty"`
+	Fingerprint            string         `json:"fingerprint,omitempty"`
+	FailurePolicy          string         `json:"failure_policy,omitempty"`
+	SynthesisRule          string         `json:"synthesis_rule,omitempty"`
+	DelegationArtifactDir  string         `json:"delegation_artifact_dir,omitempty"`
+	WorktreePath           string         `json:"worktree_path,omitempty"`
+	TemplateID             string         `json:"template_id,omitempty"`
+	TemplateResolvedCommit string         `json:"template_resolved_commit,omitempty"`
+	TemplateContent        string         `json:"template_content,omitempty"`
+	OriginalAgent          string         `json:"original_agent,omitempty"`
+	DelegatedAgent         string         `json:"delegated_agent,omitempty"`
+	DelegationReason       string         `json:"delegation_reason,omitempty"`
+	RecentDelegationHashes []string       `json:"recent_delegation_hashes,omitempty"`
+	DelegationRepeatCount  int            `json:"delegation_repeat_count,omitempty"`
+	Model                  string         `json:"model,omitempty"`
+	Ephemeral              *EphemeralSpec `json:"ephemeral,omitempty"`
+	RawOutputs             []string       `json:"raw_outputs,omitempty"`
+	Result                 *AgentResult   `json:"result,omitempty"`
 }
 
 type DeliveryAdapter interface {
@@ -149,6 +151,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		RecentDelegationHashes: request.RecentDelegationHashes,
 		DelegationRepeatCount:  request.DelegationRepeatCount,
 		Model:                  request.Model,
+		Ephemeral:              request.Ephemeral,
 	})
 	if err != nil {
 		return db.Job{}, err

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -90,6 +90,43 @@ func TestMailboxEnqueuePersistsDelegationMetadata(t *testing.T) {
 	}
 }
 
+func TestMailboxEnqueuePersistsEphemeralSpec(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:           "job-ephemeral",
+		Agent:        "worker-ephemeral-abc123",
+		Action:       "review",
+		Repo:         "jerryfane/gitmoot",
+		ParentJobID:  "job-parent",
+		DelegationID: "worker",
+		Ephemeral:    &EphemeralSpec{Runtime: "codex", Model: "gpt-5.4"},
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	stored, err := store.GetJob(ctx, "job-ephemeral")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	// The marshalled payload must carry the ephemeral key for downstream consumers.
+	if !strings.Contains(stored.Payload, `"ephemeral"`) {
+		t.Fatalf("payload = %q, want it to contain the ephemeral spec", stored.Payload)
+	}
+	payload, err := unmarshalPayload(stored.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.Ephemeral == nil {
+		t.Fatalf("payload missing ephemeral spec: %+v", payload)
+	}
+	if payload.Ephemeral.Runtime != "codex" || payload.Ephemeral.Model != "gpt-5.4" {
+		t.Fatalf("payload ephemeral spec = %+v", payload.Ephemeral)
+	}
+}
+
 func TestMailboxEnqueuePersistsModel(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -1,31 +1,52 @@
 package workflow
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
 const resultKey = `"gitmoot_result"`
 
+// EphemeralSpec describes an on-demand worker that Gitmoot should materialize
+// for a delegation instead of routing it to a pre-registered agent. The daemon
+// builds the worker from this spec (default sandbox read-only); the workflow
+// engine treats a delegation carrying a spec as inheriting the coordinator's
+// allowed repo scope, so it bypasses the registered-agent existence, repo-access,
+// and capability checks. Runtime is REQUIRED and must be one of codex/claude/kimi
+// — never shell.
+type EphemeralSpec struct {
+	Runtime        string   `json:"runtime"`
+	Model          string   `json:"model,omitempty"`
+	Template       string   `json:"template,omitempty"`
+	Role           string   `json:"role,omitempty"`
+	Capabilities   []string `json:"capabilities,omitempty"`
+	AutonomyPolicy string   `json:"autonomy_policy,omitempty"`
+}
+
 // Delegation describes a child job that an agent wants Gitmoot to enqueue on
 // its behalf.
 type Delegation struct {
-	ID            string   `json:"id"`
-	Agent         string   `json:"agent"`
-	Action        string   `json:"action"`
-	Worktree      string   `json:"worktree,omitempty"`
-	Prompt        string   `json:"prompt"`
-	Artifacts     []string `json:"artifacts,omitempty"`
-	Deps          []string `json:"deps,omitempty"`
-	Timeout       string   `json:"timeout,omitempty"`
-	Retry         int      `json:"retry,omitempty"`
-	FailurePolicy string   `json:"failure_policy,omitempty"`
-	Fingerprint   string   `json:"fingerprint,omitempty"`
-	SynthesisRule string   `json:"synthesis_rule,omitempty"`
-	Model         string   `json:"model,omitempty"`
+	ID            string         `json:"id"`
+	Agent         string         `json:"agent"`
+	Ephemeral     *EphemeralSpec `json:"ephemeral,omitempty"`
+	Action        string         `json:"action"`
+	Worktree      string         `json:"worktree,omitempty"`
+	Prompt        string         `json:"prompt"`
+	Artifacts     []string       `json:"artifacts,omitempty"`
+	Deps          []string       `json:"deps,omitempty"`
+	Timeout       string         `json:"timeout,omitempty"`
+	Retry         int            `json:"retry,omitempty"`
+	FailurePolicy string         `json:"failure_policy,omitempty"`
+	Fingerprint   string         `json:"fingerprint,omitempty"`
+	SynthesisRule string         `json:"synthesis_rule,omitempty"`
+	Model         string         `json:"model,omitempty"`
 }
 
 type AgentResult struct {
@@ -120,8 +141,8 @@ func validateAgentResult(result AgentResult) error {
 		if d.ID != strings.TrimSpace(d.ID) {
 			return fmt.Errorf("delegation id %q must not have leading or trailing whitespace", d.ID)
 		}
-		if strings.TrimSpace(d.Agent) == "" {
-			return errors.New("delegation agent is required")
+		if err := validateDelegationTarget(d); err != nil {
+			return err
 		}
 		if strings.TrimSpace(d.Action) == "" {
 			return errors.New("delegation action is required")
@@ -270,6 +291,92 @@ func validateDelegationLifecycle(d Delegation) error {
 		return fmt.Errorf("delegation %q synthesis_rule %q is invalid", d.ID, d.SynthesisRule)
 	}
 	return nil
+}
+
+// validateDelegationTarget enforces that a delegation routes to EXACTLY ONE of a
+// pre-registered agent or an inline ephemeral worker spec. A delegation with both
+// is ambiguous (which identity owns the branch lock and repo scope?), and one with
+// neither has no executor at all; both are rejected at result-parse time before any
+// side effects. When an ephemeral spec is present, its runtime must be one of
+// codex/claude/kimi (never shell or empty) because the daemon materializes a real
+// runtime worker from it.
+func validateDelegationTarget(d Delegation) error {
+	hasAgent := strings.TrimSpace(d.Agent) != ""
+	hasEphemeral := d.Ephemeral != nil
+	switch {
+	case hasAgent && hasEphemeral:
+		return fmt.Errorf("delegation %q sets both agent and ephemeral; exactly one is allowed", d.ID)
+	case !hasAgent && !hasEphemeral:
+		return fmt.Errorf("delegation %q must set exactly one of agent or ephemeral", d.ID)
+	}
+	if hasEphemeral {
+		if err := validateEphemeralSpec(d.ID, d.Ephemeral); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateEphemeralSpec validates the inline worker spec on a delegation: the
+// runtime is required and must be a real agent runtime (codex/claude/kimi); shell
+// and unknown runtimes are rejected so an ephemeral worker is never a raw shell.
+func validateEphemeralSpec(delegationID string, spec *EphemeralSpec) error {
+	if spec == nil {
+		return nil
+	}
+	switch strings.TrimSpace(spec.Runtime) {
+	case runtime.CodexRuntime, runtime.ClaudeRuntime, runtime.KimiRuntime:
+		return nil
+	case "":
+		return fmt.Errorf("delegation %q ephemeral runtime is required", delegationID)
+	default:
+		return fmt.Errorf("delegation %q ephemeral runtime %q is invalid; expected one of codex/claude/kimi", delegationID, spec.Runtime)
+	}
+}
+
+// ephemeralAgentName derives the synthetic agent name for an ephemeral delegation
+// child from the delegation id and parent job id. The name always contains the
+// literal infix "-ephemeral-" so the TUI can filter ephemeral workers off that
+// marker, and the trailing short hash of (parentJobID+delegationID) keeps the name
+// stable and unique per (parent, delegation) pair.
+func ephemeralAgentName(delegationID, parentJobID string) string {
+	return slugForName(delegationID) + "-ephemeral-" + shortHash(parentJobID+delegationID)
+}
+
+// slugForName lowercases an id and reduces it to a short, name-safe slug
+// (alphanumerics and dashes), so the ephemeral agent name stays readable while
+// the trailing hash guarantees uniqueness.
+func slugForName(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range value {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			builder.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash && builder.Len() > 0 {
+				builder.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	slug := strings.Trim(builder.String(), "-")
+	if slug == "" {
+		return "ephem"
+	}
+	if len(slug) > 32 {
+		slug = strings.Trim(slug[:32], "-")
+	}
+	return slug
+}
+
+// shortHash returns a short, stable hex fingerprint of value used as the unique
+// suffix on an ephemeral agent name.
+func shortHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])[:10]
 }
 
 func normalizeAgentResult(result *AgentResult) {

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -326,12 +326,20 @@ func validateEphemeralSpec(delegationID string, spec *EphemeralSpec) error {
 	}
 	switch strings.TrimSpace(spec.Runtime) {
 	case runtime.CodexRuntime, runtime.ClaudeRuntime, runtime.KimiRuntime:
-		return nil
 	case "":
 		return fmt.Errorf("delegation %q ephemeral runtime is required", delegationID)
 	default:
 		return fmt.Errorf("delegation %q ephemeral runtime %q is invalid; expected one of codex/claude/kimi", delegationID, spec.Runtime)
 	}
+	// Reject an unknown autonomy_policy at parse time: an unrecognized value
+	// would otherwise normalize to "auto" (writable) downstream and silently
+	// defeat the least-privilege read-only default.
+	if policy := strings.TrimSpace(spec.AutonomyPolicy); policy != "" {
+		if _, err := runtime.NormalizeAutonomyPolicy(policy); err != nil {
+			return fmt.Errorf("delegation %q ephemeral autonomy_policy %q is invalid", delegationID, spec.AutonomyPolicy)
+		}
+	}
+	return nil
 }
 
 // ephemeralAgentName derives the synthetic agent name for an ephemeral delegation

--- a/internal/workflow/result_test.go
+++ b/internal/workflow/result_test.go
@@ -118,7 +118,7 @@ func TestValidateAgentResultRejectsDelegationMissingFields(t *testing.T) {
 		want string
 	}{
 		{"missing id", Delegation{Agent: "impl", Action: "implement", Prompt: "do"}, "delegation id is required"},
-		{"missing agent", Delegation{ID: "a", Action: "implement", Prompt: "do"}, "delegation agent is required"},
+		{"missing agent", Delegation{ID: "a", Action: "implement", Prompt: "do"}, `delegation "a" must set exactly one of agent or ephemeral`},
 		{"missing action", Delegation{ID: "a", Agent: "impl", Prompt: "do"}, "delegation action is required"},
 		{"missing prompt", Delegation{ID: "a", Agent: "impl", Action: "implement"}, "delegation prompt is required"},
 	}
@@ -230,5 +230,105 @@ func TestValidateAgentResultRejectsArtifactsWithoutBody(t *testing.T) {
 	result.ArtifactBody = "shared brief"
 	if err := validateAgentResult(result); err != nil {
 		t.Fatalf("validateAgentResult rejected delegations with a written brief: %v", err)
+	}
+}
+
+func TestValidateAgentResultAcceptsEphemeralDelegation(t *testing.T) {
+	output := `{"gitmoot_result":{"decision":"implemented","summary":"fan out",` +
+		`"delegations":[` +
+		`{"id":"worker","ephemeral":{"runtime":"codex","model":"gpt-5.4"},"action":"implement","prompt":"hi"}` +
+		`]}}`
+
+	result, err := ExtractAgentResult(output)
+	if err != nil {
+		t.Fatalf("ExtractAgentResult rejected a valid ephemeral delegation: %v", err)
+	}
+	if len(result.Delegations) != 1 {
+		t.Fatalf("delegations = %+v", result.Delegations)
+	}
+	spec := result.Delegations[0].Ephemeral
+	if spec == nil {
+		t.Fatalf("ephemeral spec was not parsed: %+v", result.Delegations[0])
+	}
+	if spec.Runtime != "codex" || spec.Model != "gpt-5.4" {
+		t.Fatalf("ephemeral spec = %+v", spec)
+	}
+	if strings.TrimSpace(result.Delegations[0].Agent) != "" {
+		t.Fatalf("ephemeral delegation should not carry an agent: %q", result.Delegations[0].Agent)
+	}
+}
+
+func TestValidateAgentResultRejectsBothAgentAndEphemeral(t *testing.T) {
+	result := AgentResult{
+		Decision: "implemented",
+		Summary:  "x",
+		Delegations: []Delegation{
+			{ID: "d", Agent: "impl", Ephemeral: &EphemeralSpec{Runtime: "codex"}, Action: "implement", Prompt: "go"},
+		},
+	}
+	err := validateAgentResult(result)
+	if err == nil {
+		t.Fatal("validateAgentResult accepted a delegation with both agent and ephemeral")
+	}
+	if !strings.Contains(err.Error(), "sets both agent and ephemeral") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestValidateAgentResultRejectsNeitherAgentNorEphemeral(t *testing.T) {
+	result := AgentResult{
+		Decision: "implemented",
+		Summary:  "x",
+		Delegations: []Delegation{
+			{ID: "d", Action: "implement", Prompt: "go"},
+		},
+	}
+	err := validateAgentResult(result)
+	if err == nil {
+		t.Fatal("validateAgentResult accepted a delegation with neither agent nor ephemeral")
+	}
+	if !strings.Contains(err.Error(), "must set exactly one of agent or ephemeral") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestValidateAgentResultRejectsShellEphemeralRuntime(t *testing.T) {
+	cases := map[string]string{
+		"shell":   "shell",
+		"empty":   "",
+		"unknown": "bash",
+	}
+	for name, rt := range cases {
+		t.Run(name, func(t *testing.T) {
+			result := AgentResult{
+				Decision: "implemented",
+				Summary:  "x",
+				Delegations: []Delegation{
+					{ID: "d", Ephemeral: &EphemeralSpec{Runtime: rt}, Action: "implement", Prompt: "go"},
+				},
+			}
+			err := validateAgentResult(result)
+			if err == nil {
+				t.Fatalf("validateAgentResult accepted ephemeral runtime %q", rt)
+			}
+			if !strings.Contains(err.Error(), "ephemeral runtime") {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestEphemeralAgentNameContainsInfix(t *testing.T) {
+	name := ephemeralAgentName("worker-1", "parent-job")
+	if !strings.Contains(name, "-ephemeral-") {
+		t.Fatalf("ephemeral agent name %q does not contain the %q infix", name, "-ephemeral-")
+	}
+	// The name is stable for the same (delegation, parent) pair and distinct for
+	// different parents, so the TUI filter and idempotent enqueue agree.
+	if again := ephemeralAgentName("worker-1", "parent-job"); again != name {
+		t.Fatalf("ephemeralAgentName not stable: %q vs %q", name, again)
+	}
+	if other := ephemeralAgentName("worker-1", "other-parent"); other == name {
+		t.Fatalf("ephemeralAgentName collided across parents: %q", name)
 	}
 }

--- a/internal/workflow/result_test.go
+++ b/internal/workflow/result_test.go
@@ -318,6 +318,27 @@ func TestValidateAgentResultRejectsShellEphemeralRuntime(t *testing.T) {
 	}
 }
 
+func TestValidateAgentResultRejectsInvalidEphemeralAutonomyPolicy(t *testing.T) {
+	// An unknown policy must be rejected at parse time so it cannot normalize to
+	// a writable "auto" downstream and defeat the read-only default.
+	result := AgentResult{
+		Decision: "implemented",
+		Summary:  "x",
+		Delegations: []Delegation{
+			{ID: "d", Ephemeral: &EphemeralSpec{Runtime: "codex", AutonomyPolicy: "writable"}, Action: "ask", Prompt: "go"},
+		},
+	}
+	err := validateAgentResult(result)
+	if err == nil || !strings.Contains(err.Error(), "autonomy_policy") {
+		t.Fatalf("expected an autonomy_policy validation error, got %v", err)
+	}
+	// A valid policy passes.
+	result.Delegations[0].Ephemeral.AutonomyPolicy = "read-only"
+	if err := validateAgentResult(result); err != nil {
+		t.Fatalf("valid read-only policy rejected: %v", err)
+	}
+}
+
 func TestEphemeralAgentNameContainsInfix(t *testing.T) {
 	name := ephemeralAgentName("worker-1", "parent-job")
 	if !strings.Contains(name, "-ephemeral-") {

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -93,7 +93,9 @@ score so the players (child agents) run and a finale (continuation) reconvenes
 and synthesizes. `gitmoot orchestrate <agent> "..." [--repo R]` is sugar for
 `gitmoot agent run <agent> --background "..."`. See
 [RESULT_CONTRACT.md](references/RESULT_CONTRACT.md) for the delegation fields and
-termination bounds. An agent (via `--model` on start/subscribe/type set) and an
+termination bounds. A coordinator can also spawn throwaway, auto-disposed
+ephemeral workers on demand via a delegation's `ephemeral` spec (no
+pre-registration; mutually exclusive with `agent`). An agent (via `--model` on start/subscribe/type set) and an
 individual job or delegation (via `--model` on run/ask/review/implement or the
 delegation `model` field) can pin a runtime model, with the per-job/delegation
 value overriding the agent default. Use

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -100,6 +100,15 @@ Delegation fields:
   delegation (see [Termination bounds](#termination-bounds)); they do not relax
   the depth cap, per-root job budget, or loop detection.
 
+  **`agent` vs `ephemeral` — which to use:** delegate to a registered `agent`
+  when the work needs a specific, durable, addressable worker (a tuned/trained
+  template, a resumable session, accountable history) or when the worker must
+  itself delegate — **ephemeral workers are leaf-only and cannot return their own
+  delegations**. Use `ephemeral` for one-off, disposable, dynamically-sized
+  fan-out where you just need "a runtime + model + prompt" with no
+  pre-registration and no cleanup (e.g. N workers each producing one result, or a
+  cheap gate plus a strong verifier with per-worker models).
+
 A delegation with no `deps` dispatches immediately and runs in parallel with
 other dep-free siblings. Once every top-level delegation reaches a terminal
 state, Gitmoot enqueues exactly one coordinator "continuation" job — back to

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -78,6 +78,27 @@ Delegation fields:
   job (for example a Codex, Claude Code, or Kimi Code model name). When omitted,
   the delegated agent's configured default model is used. There is no allow-list;
   Gitmoot passes the value through to the runtime as-is.
+- `ephemeral` (optional): an inline worker spec that spawns a throwaway child
+  agent on demand instead of routing to a pre-registered one. It is **mutually
+  exclusive** with `agent`: a delegation must set exactly one of `agent` or
+  `ephemeral`. When `ephemeral` is set, no agent needs to be registered first —
+  Gitmoot materializes a worker from the spec, runs the child job, and disposes
+  of the worker once the job finishes. The ephemeral child inherits the
+  coordinator's allowed repo scope. Fields:
+  - `runtime` (required): the runtime that backs the worker, one of `codex`,
+    `claude`, or `kimi`. It is never `shell`.
+  - `model` (optional): a runtime-scoped model string, as for the delegation
+    `model` field above.
+  - `template` (optional): an agent-template id to seed the worker's prompt.
+  - `role` (optional): a human-readable role label for the worker.
+  - `capabilities` (optional): an array of capability strings advertised by the
+    worker.
+  - `autonomy_policy` (optional): the worker's sandbox autonomy. Defaults to
+    `read-only`.
+
+  Ephemeral delegations are bounded by the same delegation limits as any other
+  delegation (see [Termination bounds](#termination-bounds)); they do not relax
+  the depth cap, per-root job budget, or loop detection.
 
 A delegation with no `deps` dispatches immediately and runs in parallel with
 other dep-free siblings. Once every top-level delegation reaches a terminal

--- a/website/docs/concepts/agents-templates-jobs-locks.md
+++ b/website/docs/concepts/agents-templates-jobs-locks.md
@@ -51,6 +51,55 @@ agents) run in parallel or in dependency order, and a finale (continuation)
 reconvenes and synthesizes the results. It is a naming layer on top of the same
 `delegations` mechanics described above.
 
+## Choosing a worker: registered agent vs. ephemeral worker
+
+There are only **two** kinds of worker you deliberately create — a **registered
+agent** and an **ephemeral worker**. A third, the **temp worker**, is created
+*automatically* by the daemon and is never something you make by hand.
+
+| | Registered agent | Ephemeral worker | Temp worker |
+|---|---|---|---|
+| Who creates it | You (`gitmoot agent start` / `subscribe` / `type set`) | A coordinator (a `delegations[]` entry with an `ephemeral` spec) | The daemon, automatically |
+| Persists | Yes — lives in the registry | No — auto-disposed after its job | No — auto-disposed after its job |
+| Identity / name | Stable, addressable | Synthetic, hidden from the registry | Synthetic, hidden from the registry |
+| Reusable | Across many jobs and PR subscriptions | One job, then gone | One job, then gone |
+| Built from | Your config (runtime / model / template / capabilities) | An inline spec on the delegation | A **fork of an existing registered agent** |
+| Purpose | A durable role | A one-off delegated task | **Concurrency** — run a registered agent's jobs in parallel |
+
+A temp worker is just *"this registered agent is busy; clone it to run another
+job in parallel, then drop the clone."* You influence it only through a managed
+agent type's `max_background` — you never create one directly.
+
+**Create a registered agent when the role is durable and addressable:**
+
+- You will reuse it (a repo's `reviewer`, a `planner` you invoke repeatedly).
+- It needs a stable name — PR-comment subscriptions, `gitmoot agent ask <name>`,
+  the dashboard, job history and accountability.
+- It carries managed state: a versioned, SkillOpt-trained template, a resumable
+  runtime session, repo scope / capabilities / autonomy you tune.
+- You want a pool that auto-scales under load — a managed *agent type* with
+  `max_background` (the daemon forks temp workers from it).
+- It needs to **itself delegate** — ephemeral workers are leaf-only and cannot
+  return their own delegations.
+
+**Spawn an ephemeral worker (via a coordinator's delegation) when the work is
+one-off and disposable:**
+
+- Dynamic fan-out you do not know ahead of time ("three workers each draft an
+  option", "a cheap gate plus a strong verifier").
+- No reuse, no identity, no subscription — it exists only for that delegation.
+- The coordinator wants to choose the runtime and model *per task* (model
+  tiering).
+- You want zero setup and zero cleanup — no pre-registration, auto-disposed,
+  never clutters the registry.
+
+**Rule of thumb:** *durable and named → register an agent; one-off and
+coordinator-spawned → ephemeral; concurrency of a registered agent → temp
+workers happen for you.* The trade-off: registered agents have setup cost but are
+reusable, addressable, trainable, and resume a warm session; ephemeral workers
+are zero-setup and self-cleaning but cold-spawn each time and carry no
+accumulated identity.
+
 ## Locks
 
 Gitmoot uses separate locks for separate resources:

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -111,6 +111,27 @@ the same `delegations` field, `coordinator`, and `continuation` mechanics.
   (for example a Codex, Claude Code, or Kimi Code model name). When omitted, the
   delegated agent's configured default model is used. There is no allow-list;
   Gitmoot passes the value through to the runtime as-is.
+- `ephemeral` (optional): an inline worker spec that spawns a throwaway child
+  agent on demand instead of routing to a pre-registered one. It is **mutually
+  exclusive** with `agent` — a delegation must set exactly one of `agent` or
+  `ephemeral`. When `ephemeral` is set, the coordinator does not need to register
+  an agent first: Gitmoot creates a worker from the spec, runs the child job, and
+  auto-disposes of the worker once the job finishes. The ephemeral child inherits
+  the coordinator's allowed repo scope. The spec has these fields:
+  - `runtime` (required): the runtime that backs the worker — one of `codex`,
+    `claude`, or `kimi`. It is never `shell`.
+  - `model` (optional): a runtime-scoped model string, exactly like the
+    delegation `model` field above.
+  - `template` (optional): an agent-template id used to seed the worker's prompt.
+  - `role` (optional): a human-readable role label for the worker.
+  - `capabilities` (optional): an array of capability strings the worker
+    advertises.
+  - `autonomy_policy` (optional): the worker's sandbox autonomy. Defaults to
+    `read-only`.
+
+  Ephemeral delegations are bounded by the same delegation limits as every other
+  delegation (see [Termination bounds](#termination-bounds)): they do not relax
+  the depth cap, the per-root job budget, or loop detection.
 
 ### How delegations run
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6510,6 +6510,15 @@ Delegation fields:
   delegation (see [Termination bounds](#termination-bounds)); they do not relax
   the depth cap, per-root job budget, or loop detection.
 
+  **`agent` vs `ephemeral` — which to use:** delegate to a registered `agent`
+  when the work needs a specific, durable, addressable worker (a tuned/trained
+  template, a resumable session, accountable history) or when the worker must
+  itself delegate — **ephemeral workers are leaf-only and cannot return their own
+  delegations**. Use `ephemeral` for one-off, disposable, dynamically-sized
+  fan-out where you just need "a runtime + model + prompt" with no
+  pre-registration and no cleanup (e.g. N workers each producing one result, or a
+  cheap gate plus a strong verifier with per-worker models).
+
 A delegation with no `deps` dispatches immediately and runs in parallel with
 other dep-free siblings. Once every top-level delegation reaches a terminal
 state, Gitmoot enqueues exactly one coordinator "continuation" job — back to

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -4958,7 +4958,9 @@ score so the players (child agents) run and a finale (continuation) reconvenes
 and synthesizes. `gitmoot orchestrate <agent> "..." [--repo R]` is sugar for
 `gitmoot agent run <agent> --background "..."`. See
 [RESULT_CONTRACT.md](references/RESULT_CONTRACT.md) for the delegation fields and
-termination bounds. An agent (via `--model` on start/subscribe/type set) and an
+termination bounds. A coordinator can also spawn throwaway, auto-disposed
+ephemeral workers on demand via a delegation's `ephemeral` spec (no
+pre-registration; mutually exclusive with `agent`). An agent (via `--model` on start/subscribe/type set) and an
 individual job or delegation (via `--model` on run/ask/review/implement or the
 delegation `model` field) can pin a runtime model, with the per-job/delegation
 value overriding the agent default. Use
@@ -6486,6 +6488,27 @@ Delegation fields:
   job (for example a Codex, Claude Code, or Kimi Code model name). When omitted,
   the delegated agent's configured default model is used. There is no allow-list;
   Gitmoot passes the value through to the runtime as-is.
+- `ephemeral` (optional): an inline worker spec that spawns a throwaway child
+  agent on demand instead of routing to a pre-registered one. It is **mutually
+  exclusive** with `agent`: a delegation must set exactly one of `agent` or
+  `ephemeral`. When `ephemeral` is set, no agent needs to be registered first —
+  Gitmoot materializes a worker from the spec, runs the child job, and disposes
+  of the worker once the job finishes. The ephemeral child inherits the
+  coordinator's allowed repo scope. Fields:
+  - `runtime` (required): the runtime that backs the worker, one of `codex`,
+    `claude`, or `kimi`. It is never `shell`.
+  - `model` (optional): a runtime-scoped model string, as for the delegation
+    `model` field above.
+  - `template` (optional): an agent-template id to seed the worker's prompt.
+  - `role` (optional): a human-readable role label for the worker.
+  - `capabilities` (optional): an array of capability strings advertised by the
+    worker.
+  - `autonomy_policy` (optional): the worker's sandbox autonomy. Defaults to
+    `read-only`.
+
+  Ephemeral delegations are bounded by the same delegation limits as any other
+  delegation (see [Termination bounds](#termination-bounds)); they do not relax
+  the depth cap, per-root job budget, or loop detection.
 
 A delegation with no `deps` dispatches immediately and runs in parallel with
 other dep-free siblings. Once every top-level delegation reaches a terminal


### PR DESCRIPTION
Implements the **MVP** of #325: a coordinator can delegate to a **throwaway agent created from an inline spec** (runtime + model + prompt) instead of only pre-registered agents. Builds on #268 (per-delegation `model`), bounded by #305.

## WHAT
A `delegations[]` entry gains an optional **`ephemeral`** object (mutually exclusive with `agent`):
```json
{"id":"joke-1","action":"ask","prompt":"write a joke",
 "ephemeral":{"runtime":"codex","model":"gpt-5.4","autonomy_policy":"read-only"}}
```
The engine allows the spec-based delegation (no "agent not subscribed"); the daemon **materializes** a throwaway agent when it runs the child job, runs it, and **auto-disposes** it. No registry entry.

## WHY
Lets a coordinator "spawn codex gpt-5.4 agents to do X" with **zero pre-registration**, and stops one-off agents from cluttering the registry. It's the primitive that makes #310 (Orchestra recipes) turnkey.

## CHANGES
| Layer | Change |
|---|---|
| `internal/workflow/result.go` | `EphemeralSpec` + `Delegation.Ephemeral`; exactly-one-of `agent`/`ephemeral`; runtime ∈ codex/claude/kimi; `ephemeralAgentName` (`-ephemeral-` infix); reject unknown `autonomy_policy` |
| `internal/workflow/mailbox.go`, `engine.go` | thread `Ephemeral` through `JobRequest`/`JobPayload`; `delegationRequest` synthesizes the name; engine **bypasses** GetAgent/ACL/capability for spec jobs; loop-hash folds in the spec; **ephemeral workers are leaf-only** (their delegations are ignored) |
| `internal/cli/daemon.go` | `startEphemeralWorker` materializes from the spec at the `run` seam (reusing temp-worker machinery), `defer cleanupTempWorker` disposes on success **and** failure, **rollback** on partial bring-up, read-only default (workspace-write for `implement`), double-spawn guard |
| `internal/cli/tui/agents.go`, `agent.go`, `dashboard.go` | hide transient ephemeral agents from the registry / `agent list` / `dashboard --json` |
| docs | `RESULT_CONTRACT.md` + website mirror + `SKILL.md`; `llms-full.txt` regenerated |

**Design:** least-privilege (read-only default; reuse the runtime's `--sandbox`); additive (a delegation with no `ephemeral` behaves exactly as today); never touches the `delegations` key or `coordinator`/`continuation`. Spec shape follows the 2026 SOTA `(instruction, context, tools, model)` tuple per the #325 research.

## RESULTS
- `go build/vet/test ./...` green; `go test -race ./internal/workflow/` green; `gofmt` clean.
- Built via a wave-based workflow (3 parallel worktree tasks → integrate → 1 daemon task), then a `/code-review high` pass: **6 fixes applied** (partial-materialization leak/rollback, autonomy-policy escalation, leaf-only guard, loop-hash spec, action-aware sandbox default, CLI/dashboard hiding) + regression tests.

## RISK / deferred (tracked in #325, NOT in this PR)
- **`gitmoot orchestrate --spawn` CLI convenience** — deferred; coordinators use `delegations[].ephemeral` directly.
- **Crash-time dead-owner reclamation** — MVP relies on the `defer` (success+failure) + instance TTL; a daemon **crash mid-job** can leave a transient agent row until reclaimed. A daemon-side sweep is the follow-up.
- **Quality follow-ups** noted by review: `startEphemeralWorker`/`startTempWorker` share a near-duplicate bring-up (parameterize), and ephemerality is a name-infix convention rather than a typed column.
- Website docs deploy is a separate manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)