### PR TITLE
fix(workflow): parallelize read-only delegation fan-out with detached worktrees (#328)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2886,9 +2886,10 @@ func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload w
 }
 
 func (w jobWorker) taskWorktreeCheckout(ctx context.Context, payload workflow.JobPayload) (string, bool, error) {
-	// Delegated implement jobs carry their own per-delegation worktree path in
-	// the payload; prefer it over the task-table worktree so the child runs in
-	// its isolated checkout.
+	// Delegated jobs carry their own per-delegation worktree path in the payload
+	// (an implement child's branch worktree, or a read-only fan-out child's
+	// detached worktree); prefer it over the task-table worktree so the child runs
+	// in its isolated checkout.
 	if delegationPath := strings.TrimSpace(payload.WorktreePath); delegationPath != "" {
 		checkout, err := normalizeTaskWorktreePath(delegationPath)
 		if err != nil {
@@ -2937,6 +2938,23 @@ func normalizeTaskWorktreePath(path string) (string, error) {
 
 func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.JobPayload, checkout string) error {
 	git := gitutil.Client{Dir: checkout}
+	// A delegation worktree child runs in a gitmoot-managed worktree that is
+	// correct by construction: an implement child is on its delegation branch
+	// (created off the parent base, whose tip may have advanced past the inherited
+	// HeadSHA), while a read-only child uses a *detached* worktree with no branch
+	// at all (so CurrentBranch would error). Skip the branch and inherited-HeadSHA
+	// checks for these children, but still require the freshly allocated worktree
+	// to be clean before the job runs.
+	if isDelegationWorktreeChild(payload) {
+		clean, err := git.WorktreeClean(ctx)
+		if err != nil {
+			return err
+		}
+		if !clean {
+			return fmt.Errorf("checkout %s has uncommitted changes", checkout)
+		}
+		return nil
+	}
 	branch, err := git.CurrentBranch(ctx)
 	if err != nil {
 		return err
@@ -2950,15 +2968,6 @@ func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.
 	}
 	if !clean {
 		return fmt.Errorf("checkout %s has uncommitted changes", checkout)
-	}
-	// A delegated implement child runs in its own freshly-allocated worktree,
-	// created off the parent's base branch whose tip may have advanced past the
-	// HeadSHA the child inherited from the parent payload. The dispatcher clears
-	// the inherited HeadSHA for these children, so the worktree HEAD is correct
-	// by construction (it is the base-branch tip at allocation time) and there is
-	// nothing to compare against. Skip the HeadSHA equality check for them.
-	if isDelegationWorktreeChild(payload) {
-		return nil
 	}
 	expectedHead := strings.TrimSpace(payload.HeadSHA)
 	if expectedHead == "" {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2938,14 +2938,17 @@ func normalizeTaskWorktreePath(path string) (string, error) {
 
 func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.JobPayload, checkout string) error {
 	git := gitutil.Client{Dir: checkout}
-	// A delegation worktree child runs in a gitmoot-managed worktree that is
-	// correct by construction: an implement child is on its delegation branch
-	// (created off the parent base, whose tip may have advanced past the inherited
-	// HeadSHA), while a read-only child uses a *detached* worktree with no branch
-	// at all (so CurrentBranch would error). Skip the branch and inherited-HeadSHA
-	// checks for these children, but still require the freshly allocated worktree
-	// to be clean before the job runs.
+	// A delegation worktree child runs in a gitmoot-managed worktree. An implement
+	// child is on its delegation branch (created off the parent base, whose tip may
+	// have advanced past the inherited HeadSHA — so its HeadSHA check is skipped),
+	// while a read-only child uses a *detached* worktree with no branch at all (so
+	// CurrentBranch errors). Validate the branch when the worktree has one (the
+	// implement guard, preserved) and skip it for a detached read-only worktree;
+	// both still require the freshly allocated worktree to be clean.
 	if isDelegationWorktreeChild(payload) {
+		if branch, err := git.CurrentBranch(ctx); err == nil && branch != payload.Branch {
+			return fmt.Errorf("checkout branch is %s, not job branch %s", branch, payload.Branch)
+		}
 		clean, err := git.WorktreeClean(ctx)
 		if err != nil {
 			return err

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -2431,6 +2431,30 @@ func TestValidateTargetCheckoutSkipsHeadShaForDelegationWorktreeChild(t *testing
 	}
 }
 
+func TestValidateTargetCheckoutAcceptsDetachedReadOnlyWorktreeChild(t *testing.T) {
+	// A read-only delegation child runs in a *detached* worktree (no branch).
+	// CurrentBranch errors on a detached HEAD, so validateTargetCheckout must
+	// recognize the delegation worktree child and accept it on the clean-worktree
+	// check alone rather than rejecting it on the branch check.
+	ctx := context.Background()
+	checkout := createDaemonWorkerGitCheckout(t, "task-005")
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard)
+
+	detached := filepath.Join(t.TempDir(), "ro-worktree")
+	runDaemonWorkerGit(t, checkout, "worktree", "add", "--detach", detached, "HEAD")
+
+	payload := workflow.JobPayload{
+		Repo:         "owner/repo",
+		Branch:       "task-005",
+		DelegationID: "d1",
+		ParentJobID:  "parent-job",
+		WorktreePath: detached,
+	}
+	if err := worker.validateTargetCheckout(ctx, payload, detached); err != nil {
+		t.Fatalf("validateTargetCheckout rejected detached read-only worktree child: %v", err)
+	}
+}
+
 func TestRefreshDaemonJobPayloadPreservesTaskWorktreeHeadForFinalizer(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -86,6 +86,19 @@ func (c Client) RemoveWorktree(ctx context.Context, path string) error {
 	return err
 }
 
+// RemoveWorktreeForce removes a worktree even when it has uncommitted or
+// untracked changes. It is intended for throwaway worktrees (e.g. detached
+// read-only delegation fan-out worktrees) whose contents are never integrated,
+// so a runtime that left scratch files behind must not block disposal.
+func (c Client) RemoveWorktreeForce(ctx context.Context, path string) error {
+	path, err := validateWorktreePath(path)
+	if err != nil {
+		return err
+	}
+	_, err = c.run(ctx, "worktree", "remove", "--force", path)
+	return err
+}
+
 func (c Client) CurrentBranch(ctx context.Context) (string, error) {
 	result, err := c.run(ctx, "branch", "--show-current")
 	if err != nil {

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -122,6 +122,66 @@ func TestClientAddWorktreeRejectsInvalidInput(t *testing.T) {
 	if err := (Client{}).RemoveWorktree(context.Background(), " "); err == nil {
 		t.Fatal("RemoveWorktree accepted empty path")
 	}
+	if err := (Client{}).RemoveWorktreeForce(context.Background(), " "); err == nil {
+		t.Fatal("RemoveWorktreeForce accepted empty path")
+	}
+	if err := (Client{}).AddDetachedWorktree(context.Background(), "", "main"); err == nil {
+		t.Fatal("AddDetachedWorktree accepted empty path")
+	}
+	if err := (Client{}).AddDetachedWorktree(context.Background(), "/tmp/wt", " "); err == nil {
+		t.Fatal("AddDetachedWorktree accepted empty ref")
+	}
+	if err := (Client{}).AddDetachedWorktree(context.Background(), "/tmp/wt", "-bad"); err == nil {
+		t.Fatal("AddDetachedWorktree accepted ref starting with '-'")
+	}
+}
+
+func TestClientDetachedAndForceRemoveCommandConstruction(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{}, {}}}
+	client := Client{Runner: runner, Dir: "/repo"}
+	if err := client.AddDetachedWorktree(context.Background(), "/worktrees/d1", "main"); err != nil {
+		t.Fatalf("AddDetachedWorktree returned error: %v", err)
+	}
+	if err := client.RemoveWorktreeForce(context.Background(), "/worktrees/d1"); err != nil {
+		t.Fatalf("RemoveWorktreeForce returned error: %v", err)
+	}
+	runner.wantArgs(t, 0, "git", "worktree", "add", "--detach", "/worktrees/d1", "main")
+	runner.wantArgs(t, 1, "git", "worktree", "remove", "--force", "/worktrees/d1")
+}
+
+func TestClientRemoveWorktreeForceSmoke(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, dir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# smoke\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "init")
+
+	client := Client{Dir: dir}
+	wt := filepath.Join(t.TempDir(), "detached")
+	if err := client.AddDetachedWorktree(context.Background(), wt, "HEAD"); err != nil {
+		t.Fatalf("AddDetachedWorktree returned error: %v", err)
+	}
+	// A read-only runtime may leave untracked scratch files behind; plain remove
+	// refuses, force remove disposes the throwaway worktree anyway.
+	if err := os.WriteFile(filepath.Join(wt, "scratch.txt"), []byte("scratch\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile scratch returned error: %v", err)
+	}
+	if err := client.RemoveWorktree(context.Background(), wt); err == nil {
+		t.Fatal("RemoveWorktree unexpectedly removed a worktree with untracked files")
+	}
+	if err := client.RemoveWorktreeForce(context.Background(), wt); err != nil {
+		t.Fatalf("RemoveWorktreeForce returned error: %v", err)
+	}
+	if _, err := os.Stat(wt); !os.IsNotExist(err) {
+		t.Fatalf("worktree dir still present after force remove: stat err = %v", err)
+	}
 }
 
 func TestClientBranchExistsReturnsFalseForMissingBranch(t *testing.T) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -328,6 +328,12 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 	}
 	ref := taskRefFromPayload(payload)
 
+	// A read-only delegation child runs in a throwaway detached worktree; dispose
+	// it once the child is terminal. Deferred so it fires on every return path
+	// below (the delegation DAG early-returns for policy-handled failures and
+	// pending retries). No-op for jobs that did not allocate a read-only worktree.
+	defer e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload)
+
 	// When a delegated child job finishes, advance its parent's delegation DAG
 	// before running the child's own advancement: enqueue any now-ready
 	// dependent siblings, apply the failed delegation's failure_policy, and
@@ -917,6 +923,45 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 			// spuriously reject the child on a moving parent branch. Clear the
 			// inherited HeadSHA so the child validates against its own fresh
 			// worktree HEAD instead of a stale parent SHA.
+			request.HeadSHA = ""
+		}
+	} else if readOnlyFanoutNeedsWorktree(payload, d) {
+		// Read-only fan-out: >=2 read-only siblings share the parent repo and would
+		// otherwise serialize on the repo:<repo> checkout key (only one runs per
+		// daemon tick). Give this child its own detached, branch-lock-free worktree
+		// so its checkout key is worktree:<path> and the siblings run concurrently.
+		if manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager); !ok || strings.TrimSpace(e.Home) == "" {
+			// Isolation is unavailable (no Home/worktree manager, or the manager
+			// cannot create detached worktrees): the siblings fall back to the shared
+			// checkout and serialize. Emit a parent event so the loss of parallelism
+			// is observable rather than silent.
+			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   job.ID,
+				Kind:    "delegation_worktree_skipped",
+				Message: fmt.Sprintf("delegation %q read-only fan-out runs serialized in the shared checkout: detached worktree isolation unavailable", request.DelegationID),
+			})
+		} else {
+			path, err := e.AllocateReadOnlyDelegationWorktree(ctx, DelegationWorktreeRequest{
+				Home:         e.Home,
+				Repo:         request.Repo,
+				ParentJobID:  job.ID,
+				DelegationID: request.DelegationID,
+				Delegation:   d,
+				BaseBranch:   payload.Branch,
+				Checkout:     e.DelegationCheckout,
+				RetryAttempt: request.RetryCount,
+			}, manager)
+			if err != nil {
+				var blocked BlockedError
+				if errors.As(err, &blocked) {
+					return e.block(ctx, ref, blocked.Reason)
+				}
+				return err
+			}
+			request.WorktreePath = path
+			// The detached worktree is created at the parent base-branch tip, which
+			// may have advanced past the inherited HeadSHA. Clear it so the child
+			// validates against its own fresh worktree HEAD (see isDelegationWorktreeChild).
 			request.HeadSHA = ""
 		}
 	}

--- a/internal/workflow/readonly_worktree_test.go
+++ b/internal/workflow/readonly_worktree_test.go
@@ -147,10 +147,23 @@ func TestCleanupReadOnlyDelegationWorktreeForceRemoves(t *testing.T) {
 	engine.DelegationCheckout = t.TempDir()
 	engine.DelegationWorktrees = manager
 
-	payload := JobPayload{DelegationID: "d1", WorktreePath: "/wt/d1"}
+	// The worktree path must exist on disk; cleanup skips an already-gone path.
+	wt := t.TempDir()
+	payload := JobPayload{DelegationID: "d1", WorktreePath: wt}
 	engine.cleanupReadOnlyDelegationWorktree(ctx, "job-1/delegation/d1", "ask", payload)
-	if len(manager.removedForce) != 1 || manager.removedForce[0] != "/wt/d1" {
-		t.Fatalf("removedForce = %+v, want one force-remove of /wt/d1", manager.removedForce)
+	if len(manager.removedForce) != 1 || manager.removedForce[0] != wt {
+		t.Fatalf("removedForce = %+v, want one force-remove of %q", manager.removedForce, wt)
+	}
+
+	// Idempotent: a second cleanup for an already-removed (non-existent) worktree
+	// is a silent no-op (no re-lock, no spurious cleanup-failed event).
+	gone := filepath.Join(t.TempDir(), "already-removed")
+	engine.cleanupReadOnlyDelegationWorktree(ctx, "job-1/delegation/d1", "ask", JobPayload{DelegationID: "d1", WorktreePath: gone})
+	if len(manager.removedForce) != 1 {
+		t.Fatalf("cleanup of a missing worktree must be a no-op: %+v", manager.removedForce)
+	}
+	if got := countJobEvents(t, store, "job-1/delegation/d1", "delegation_worktree_cleanup_failed"); got != 0 {
+		t.Fatalf("missing-worktree cleanup must not emit cleanup_failed events, got %d", got)
 	}
 	if got := countJobEvents(t, store, "job-1/delegation/d1", "delegation_worktree_removed"); got != 1 {
 		t.Fatalf("delegation_worktree_removed event count = %d, want 1", got)

--- a/internal/workflow/readonly_worktree_test.go
+++ b/internal/workflow/readonly_worktree_test.go
@@ -1,0 +1,330 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"database/sql"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestReadOnlyFanoutNeedsWorktree(t *testing.T) {
+	ask := Delegation{ID: "a", Action: "ask", Prompt: "p"}
+	ask2 := Delegation{ID: "b", Action: "ask", Prompt: "p"}
+	review := Delegation{ID: "c", Action: "review", Prompt: "p"}
+	impl := Delegation{ID: "d", Action: "implement", Prompt: "p"}
+
+	cases := []struct {
+		name        string
+		delegations []Delegation
+		target      Delegation
+		want        bool
+	}{
+		{"two ask siblings", []Delegation{ask, ask2}, ask, true},
+		{"ask + review (both read-only)", []Delegation{ask, review}, review, true},
+		{"single ask", []Delegation{ask}, ask, false},
+		{"implement target never isolated", []Delegation{impl, ask, ask2}, impl, false},
+		{"one ask among implements", []Delegation{impl, ask}, ask, false},
+		{"two ask plus implement", []Delegation{ask, ask2, impl}, ask, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := JobPayload{Result: &AgentResult{Delegations: tc.delegations}}
+			if got := readOnlyFanoutNeedsWorktree(payload, tc.target); got != tc.want {
+				t.Fatalf("readOnlyFanoutNeedsWorktree = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// Nil result must not panic and must report no fan-out.
+	if readOnlyFanoutNeedsWorktree(JobPayload{}, ask) {
+		t.Fatal("readOnlyFanoutNeedsWorktree with nil result = true, want false")
+	}
+}
+
+func TestIsReadOnlyDelegationWorktree(t *testing.T) {
+	base := JobPayload{DelegationID: "d1", WorktreePath: "/wt/d1"}
+	if !isReadOnlyDelegationWorktree("ask", base) {
+		t.Fatal("ask delegation worktree child not detected")
+	}
+	if !isReadOnlyDelegationWorktree("review", base) {
+		t.Fatal("review delegation worktree child not detected")
+	}
+	if isReadOnlyDelegationWorktree("implement", base) {
+		t.Fatal("implement child must not be treated as a read-only worktree")
+	}
+	if isReadOnlyDelegationWorktree("ask", JobPayload{WorktreePath: "/wt/d1"}) {
+		t.Fatal("non-delegation job (no delegation id) must not match")
+	}
+	if isReadOnlyDelegationWorktree("ask", JobPayload{DelegationID: "d1"}) {
+		t.Fatal("delegation child without a worktree path must not match")
+	}
+}
+
+func TestAllocateReadOnlyDelegationWorktreeDetachedNoBranchLock(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	home := t.TempDir()
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	manager := &fakeWorktreeManager{onAdd: func() {
+		lock, err := store.GetResourceLock(ctx, key)
+		if err != nil {
+			t.Fatalf("GetResourceLock during AddDetachedWorktree returned error: %v", err)
+		}
+		if lock.OwnerJobID != "worktree:job-1/d1" {
+			t.Fatalf("checkout lock owner = %q, want worktree:job-1/d1", lock.OwnerJobID)
+		}
+	}}
+
+	path, err := engine.AllocateReadOnlyDelegationWorktree(ctx, DelegationWorktreeRequest{
+		Home:         home,
+		Repo:         "owner/repo",
+		ParentJobID:  "job-1",
+		DelegationID: "d1",
+		Delegation:   Delegation{ID: "d1", Agent: "audit", Action: "ask"},
+		BaseBranch:   "main",
+		Checkout:     checkout,
+	}, manager)
+	if err != nil {
+		t.Fatalf("AllocateReadOnlyDelegationWorktree returned error: %v", err)
+	}
+	wantPath := filepath.Join(home, "worktrees", "owner--repo", "delegations", "job-1", "d1")
+	if path != wantPath {
+		t.Fatalf("path = %q, want %q", path, wantPath)
+	}
+	if len(manager.detachedCalls) != 1 || manager.detachedCalls[0].path != wantPath || manager.detachedCalls[0].base != "main" {
+		t.Fatalf("detached calls = %+v, want one at %q ref main", manager.detachedCalls, wantPath)
+	}
+	// A read-only worktree must create no branch and take no branch lock.
+	if len(manager.calls) != 0 {
+		t.Fatalf("read-only allocation must not call AddWorktree (branch path): %+v", manager.calls)
+	}
+	wantBranch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1", 0)
+	if _, err := store.GetBranchLock(ctx, "owner/repo", wantBranch); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("read-only allocation must not create a branch lock; GetBranchLock err = %v", err)
+	}
+	// The checkout mutation lock must be released after allocation.
+	if _, err := store.GetResourceLock(ctx, key); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("checkout lock after AddDetachedWorktree err = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestAllocateReadOnlyDelegationWorktreeDefaultsRefToHEAD(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	manager := &fakeWorktreeManager{}
+	if _, err := engine.AllocateReadOnlyDelegationWorktree(ctx, DelegationWorktreeRequest{
+		Home:         t.TempDir(),
+		Repo:         "owner/repo",
+		ParentJobID:  "job-1",
+		DelegationID: "d1",
+		Delegation:   Delegation{ID: "d1", Agent: "audit", Action: "ask"},
+		BaseBranch:   "",
+		Checkout:     t.TempDir(),
+	}, manager); err != nil {
+		t.Fatalf("AllocateReadOnlyDelegationWorktree returned error: %v", err)
+	}
+	if len(manager.detachedCalls) != 1 || manager.detachedCalls[0].base != "HEAD" {
+		t.Fatalf("detached calls = %+v, want ref HEAD when base empty", manager.detachedCalls)
+	}
+}
+
+func TestCleanupReadOnlyDelegationWorktreeForceRemoves(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	manager := &fakeWorktreeManager{}
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	payload := JobPayload{DelegationID: "d1", WorktreePath: "/wt/d1"}
+	engine.cleanupReadOnlyDelegationWorktree(ctx, "job-1/delegation/d1", "ask", payload)
+	if len(manager.removedForce) != 1 || manager.removedForce[0] != "/wt/d1" {
+		t.Fatalf("removedForce = %+v, want one force-remove of /wt/d1", manager.removedForce)
+	}
+	if got := countJobEvents(t, store, "job-1/delegation/d1", "delegation_worktree_removed"); got != 1 {
+		t.Fatalf("delegation_worktree_removed event count = %d, want 1", got)
+	}
+
+	// No-op for an implement child (cleaned via the merge gate, not here).
+	manager.removedForce = nil
+	engine.cleanupReadOnlyDelegationWorktree(ctx, "job-2", "implement", payload)
+	// No-op for a non-delegation job and for a child without a worktree path.
+	engine.cleanupReadOnlyDelegationWorktree(ctx, "job-3", "ask", JobPayload{WorktreePath: "/wt/x"})
+	engine.cleanupReadOnlyDelegationWorktree(ctx, "job-4", "ask", JobPayload{DelegationID: "d2"})
+	if len(manager.removedForce) != 0 {
+		t.Fatalf("cleanup must be a no-op for non read-only worktree children: %+v", manager.removedForce)
+	}
+}
+
+func TestDispatchDelegationsTwoReadOnlySiblingsGetSeparateDetachedWorktrees(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit-a", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit-b", []string{"ask"}, "jerryfane/gitmoot")
+	home := t.TempDir()
+	manager := &fakeWorktreeManager{}
+	engine := testEngine(store)
+	engine.Home = home
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "d1", Agent: "audit-a", Action: "ask", Prompt: "audit one"},
+				{ID: "d2", Agent: "audit-b", Action: "ask", Prompt: "audit two"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	payloadOne, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/d1").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(d1) returned error: %v", err)
+	}
+	payloadTwo, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/d2").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(d2) returned error: %v", err)
+	}
+
+	wantPathOne := filepath.Join(home, "worktrees", "jerryfane--gitmoot", "delegations", "parent-job", "d1")
+	wantPathTwo := filepath.Join(home, "worktrees", "jerryfane--gitmoot", "delegations", "parent-job", "d2")
+	if payloadOne.WorktreePath != wantPathOne {
+		t.Fatalf("d1 worktree path = %q, want %q", payloadOne.WorktreePath, wantPathOne)
+	}
+	if payloadTwo.WorktreePath != wantPathTwo {
+		t.Fatalf("d2 worktree path = %q, want %q", payloadTwo.WorktreePath, wantPathTwo)
+	}
+	if payloadOne.WorktreePath == payloadTwo.WorktreePath {
+		t.Fatalf("read-only siblings share worktree path %q -> would serialize on the same checkout key", payloadOne.WorktreePath)
+	}
+	// Read-only children are detached: no branch is created, so they keep the
+	// inherited parent branch (unlike implement children, which are rebranded).
+	if payloadOne.Branch != "task-005" || payloadTwo.Branch != "task-005" {
+		t.Fatalf("read-only children must keep the parent branch: d1=%q d2=%q", payloadOne.Branch, payloadTwo.Branch)
+	}
+	// HeadSHA cleared so validateTargetCheckout validates the fresh worktree HEAD.
+	if payloadOne.HeadSHA != "" || payloadTwo.HeadSHA != "" {
+		t.Fatalf("read-only worktree children must not inherit parent HeadSHA: d1=%q d2=%q", payloadOne.HeadSHA, payloadTwo.HeadSHA)
+	}
+	// Two detached worktrees, no branch-creating AddWorktree calls.
+	if len(manager.detachedCalls) != 2 {
+		t.Fatalf("detached worktree calls = %+v, want two", manager.detachedCalls)
+	}
+	if len(manager.calls) != 0 {
+		t.Fatalf("read-only fan-out must not call AddWorktree (branch path): %+v", manager.calls)
+	}
+	for _, c := range manager.detachedCalls {
+		if c.base != "task-005" {
+			t.Fatalf("detached worktree ref = %q, want parent branch task-005", c.base)
+		}
+	}
+}
+
+func TestDispatchDelegationsSingleReadOnlyDelegationStaysInSharedCheckout(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"ask"}, "jerryfane/gitmoot")
+	home := t.TempDir()
+	manager := &fakeWorktreeManager{}
+	engine := testEngine(store)
+	engine.Home = home
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "d1", Agent: "audit", Action: "ask", Prompt: "audit one"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	payload, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/d1").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if strings.TrimSpace(payload.WorktreePath) != "" {
+		t.Fatalf("single read-only delegation must stay in the shared checkout, got worktree %q", payload.WorktreePath)
+	}
+	if len(manager.detachedCalls) != 0 {
+		t.Fatalf("single read-only delegation must not allocate a worktree: %+v", manager.detachedCalls)
+	}
+}
+
+func TestDispatchDelegationsReadOnlyFanoutWithoutManagerEmitsSkippedEvent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit-a", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit-b", []string{"ask"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	// No engine.Home / engine.DelegationWorktrees: detached isolation unavailable.
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "d1", Agent: "audit-a", Action: "ask", Prompt: "audit one"},
+				{ID: "d2", Agent: "audit-b", Action: "ask", Prompt: "audit two"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	for _, id := range []string{"parent-job/delegation/d1", "parent-job/delegation/d2"} {
+		payload, err := unmarshalPayload(mustJob(t, store, id).Payload)
+		if err != nil {
+			t.Fatalf("unmarshalPayload(%s) returned error: %v", id, err)
+		}
+		if strings.TrimSpace(payload.WorktreePath) != "" {
+			t.Fatalf("fallback child %s unexpectedly got worktree path %q", id, payload.WorktreePath)
+		}
+	}
+	if got := countJobEvents(t, store, "parent-job", "delegation_worktree_skipped"); got != 2 {
+		t.Fatalf("delegation_worktree_skipped event count = %d, want 2", got)
+	}
+}

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -25,6 +25,17 @@ type BranchExistenceChecker interface {
 	BranchExists(ctx context.Context, branch string) (bool, error)
 }
 
+// ReadOnlyWorktreeManager allocates and disposes throwaway detached worktrees
+// for read-only (ask/review) delegation fan-out. Unlike implement worktrees
+// these carry no branch and no branch lock: the worker only reads the checkout,
+// so the worktree exists solely to give concurrent same-repo read-only siblings
+// distinct checkout keys (otherwise they serialize on the shared repo checkout).
+// The checkout-bound gitutil.Client satisfies this interface.
+type ReadOnlyWorktreeManager interface {
+	AddDetachedWorktree(ctx context.Context, path string, ref string) error
+	RemoveWorktreeForce(ctx context.Context, path string) error
+}
+
 type TaskWorktreeRequest struct {
 	Home       string
 	Repo       string
@@ -232,6 +243,130 @@ func (e Engine) AllocateDelegationWorktree(ctx context.Context, request Delegati
 		return DelegationWorktreeResult{}, err
 	}
 	return DelegationWorktreeResult{Path: path, Branch: branch}, nil
+}
+
+// AllocateReadOnlyDelegationWorktree creates a detached, branch-lock-free git
+// worktree for a read-only (ask/review) delegation child so it does not
+// serialize with its same-repo siblings on the shared repo checkout key. It
+// reuses the deterministic DelegationWorktreePath and the checkout mutation lock
+// (a detached `git worktree add` mutates the shared .git) but takes no branch
+// lock and creates no branch: a read-only child owns nothing to merge. The
+// worktree is disposed by cleanupReadOnlyDelegationWorktree once the child job
+// reaches a terminal state.
+func (e Engine) AllocateReadOnlyDelegationWorktree(ctx context.Context, request DelegationWorktreeRequest, manager ReadOnlyWorktreeManager) (string, error) {
+	if err := e.validate(); err != nil {
+		return "", err
+	}
+	if manager == nil {
+		return "", errors.New("read-only worktree manager is required")
+	}
+	if strings.TrimSpace(request.ParentJobID) == "" {
+		return "", errors.New("delegation worktree parent job id is required")
+	}
+	if strings.TrimSpace(request.DelegationID) == "" {
+		return "", errors.New("delegation worktree delegation id is required")
+	}
+	path, err := DelegationWorktreePath(request.Home, request.Repo, request.ParentJobID, request.DelegationID, request.RetryAttempt)
+	if err != nil {
+		return "", err
+	}
+	ref := strings.TrimSpace(request.BaseBranch)
+	if ref == "" {
+		ref = "HEAD"
+	}
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(ctx, e.Store, request.Checkout, "worktree:"+request.ParentJobID+"/"+request.DelegationID, time.Now().UTC())
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if releaseCheckoutLock != nil {
+			_ = releaseCheckoutLock(context.Background())
+		}
+	}()
+	if err := manager.AddDetachedWorktree(ctx, path, ref); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// readOnlyDelegationAction reports whether a delegation action runs read-only.
+// implement is the only write action (it mutates a branch and merges); every
+// other action (ask, review) only reads the checkout.
+func readOnlyDelegationAction(action string) bool {
+	a := strings.ToLower(strings.TrimSpace(action))
+	return a != "" && a != "implement"
+}
+
+// readOnlyFanoutNeedsWorktree reports whether read-only delegation d should run
+// in its own detached worktree to avoid serializing with its siblings. It is
+// true only when d is read-only and the coordinator emitted >=2 read-only
+// delegations: all delegation children inherit the parent repo, so >=2 read-only
+// siblings otherwise collapse to the same repo:<repo> checkout key and run
+// one-at-a-time. A single read-only delegation stays in the shared checkout (a
+// worktree would be pure overhead with no parallelism to gain).
+func readOnlyFanoutNeedsWorktree(payload JobPayload, d Delegation) bool {
+	if !readOnlyDelegationAction(d.Action) {
+		return false
+	}
+	if payload.Result == nil {
+		return false
+	}
+	count := 0
+	for _, sib := range payload.Result.Delegations {
+		if readOnlyDelegationAction(sib.Action) {
+			count++
+			if count >= 2 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isReadOnlyDelegationWorktree reports whether a job ran in a detached read-only
+// delegation worktree that must be disposed. Only read-only delegation children
+// allocate one; implement children carry a branch and are cleaned through the
+// merge gate, so they are excluded.
+func isReadOnlyDelegationWorktree(jobType string, payload JobPayload) bool {
+	return strings.TrimSpace(payload.DelegationID) != "" &&
+		strings.TrimSpace(payload.WorktreePath) != "" &&
+		readOnlyDelegationAction(jobType)
+}
+
+// cleanupReadOnlyDelegationWorktree disposes the detached worktree allocated for
+// a read-only delegation child once the child job is terminal. It is best-effort
+// and idempotent: a missing worktree (already removed on a prior advance, or
+// never allocated) is logged, not fatal. Removal mutates the shared .git, so it
+// holds the checkout mutation lock like allocation does.
+func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID string, jobType string, payload JobPayload) {
+	if !isReadOnlyDelegationWorktree(jobType, payload) {
+		return
+	}
+	manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager)
+	if !ok || manager == nil {
+		return
+	}
+	// Detach from the caller's cancellation: this runs on the child's terminal
+	// AdvanceJob, which may carry a job context already cancelled by a run timeout.
+	// The worktree must still be disposed, so keep context values but drop the
+	// deadline/cancel.
+	opCtx := context.WithoutCancel(ctx)
+	path := strings.TrimSpace(payload.WorktreePath)
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(opCtx, e.Store, e.DelegationCheckout, "worktree-cleanup:"+jobID, time.Now().UTC())
+	if err != nil {
+		_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("read-only worktree %s cleanup could not lock checkout: %v", path, err)})
+		return
+	}
+	defer func() {
+		if releaseCheckoutLock != nil {
+			_ = releaseCheckoutLock(context.Background())
+		}
+	}()
+	if err := manager.RemoveWorktreeForce(opCtx, path); err != nil {
+		_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("read-only worktree %s force-remove failed: %v", path, err)})
+		return
+	}
+	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: fmt.Sprintf("read-only worktree %s removed", path)})
 }
 
 func addTaskWorktree(ctx context.Context, manager WorktreeManager, branch string, path string, base string) error {

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -352,6 +353,12 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 	// deadline/cancel.
 	opCtx := context.WithoutCancel(ctx)
 	path := strings.TrimSpace(payload.WorktreePath)
+	// Idempotent: AdvanceJob can run more than once for a job (re-advance / retry
+	// passes). If the worktree directory is already gone, do not re-lock or emit a
+	// spurious cleanup-failed event.
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		return
+	}
 	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(opCtx, e.Store, e.DelegationCheckout, "worktree-cleanup:"+jobID, time.Now().UTC())
 	if err != nil {
 		_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("read-only worktree %s cleanup could not lock checkout: %v", path, err)})

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -620,6 +620,9 @@ type fakeWorktreeManager struct {
 	existingBranches map[string]bool
 	calls            []worktreeCall
 	existingCalls    []worktreeCall
+	detachedCalls    []worktreeCall // AddDetachedWorktree: path in .path, ref in .base
+	removedForce     []string       // RemoveWorktreeForce paths
+	removeErr        error
 }
 
 type worktreeCall struct {
@@ -646,4 +649,17 @@ func (f *fakeWorktreeManager) AddExistingBranchWorktree(_ context.Context, branc
 
 func (f *fakeWorktreeManager) BranchExists(_ context.Context, branch string) (bool, error) {
 	return f.existingBranches[branch], nil
+}
+
+func (f *fakeWorktreeManager) AddDetachedWorktree(_ context.Context, path string, ref string) error {
+	if f.onAdd != nil {
+		f.onAdd()
+	}
+	f.detachedCalls = append(f.detachedCalls, worktreeCall{path: path, base: ref})
+	return f.err
+}
+
+func (f *fakeWorktreeManager) RemoveWorktreeForce(_ context.Context, path string) error {
+	f.removedForce = append(f.removedForce, path)
+	return f.removeErr
 }

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -114,6 +114,13 @@ other dep-free siblings. Once every top-level delegation reaches a terminal
 state, Gitmoot enqueues exactly one coordinator "continuation" job — back to
 the delegating agent — to synthesize the children's results.
 
+Sibling children that share the repo run in isolated git worktrees so they do
+not serialize on the shared checkout: `implement` children each get their own
+branch worktree, and when a coordinator fans out **two or more read-only**
+(`ask`/`review`) children, each gets a throwaway detached worktree (no branch).
+The worktrees are disposed automatically when each child finishes. This is
+internal scheduling — coordinators do not request it.
+
 Each child job carries `parent_job_id`, `delegation_id`, `root_job_id`,
 `delegation_depth`, and `task_id`, so a child can be traced to its parent, its
 originating delegation, and the root of the job tree.

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -156,6 +156,13 @@ its other dep-free siblings. A delegation that lists `deps` waits until every
 sibling it depends on has succeeded before it dispatches. Because the dependency
 graph is a DAG, Gitmoot can resolve a clear order without ever looping.
 
+Sibling children that share the repo run in isolated git worktrees so they do
+not serialize on the shared checkout: `implement` children each get their own
+branch worktree, and when a coordinator fans out two or more read-only
+(`ask`/`review`) children, each gets a throwaway detached worktree (no branch),
+disposed automatically when the child finishes. This is internal scheduling —
+coordinators do not request it.
+
 Once every top-level delegation reaches a terminal state, Gitmoot enqueues
 exactly one coordinator "continuation" job, sent back to the delegating agent, to
 synthesize the children's results according to the `synthesis_rule`. There is


### PR DESCRIPTION
Fixes #328.

## Problem
Read-only (`ask`/`review`) delegation fan-out against the same repo ran **serially**, not in parallel, even with `daemon --workers > 1`. The daemon's runnable-job selector admits **one job per checkout key per tick**, and read-only delegation children all collapse to the same key `repo:<repo>` because per-delegation worktrees were allocated **only for `implement`** actions. This serialized the headline ephemeral/orchestra case — *"spawn N codex workers, each does an independent read-only audit"* — despite being expressed as a parallel `delegations[]` set.

## Fix
Give a read-only delegation that is part of a **≥2-read-only-sibling** fan-out its own **detached, branch-lock-free** worktree, so each child gets a distinct `worktree:<path>` checkout key and the siblings run concurrently. A single read-only delegation stays in the shared checkout (no overhead). The throwaway worktree is **force-removed** when the child reaches a terminal state.

Generalizes the implement-path worktree mechanism from #176; additive — `implement` delegation behavior and the `delegations`/`coordinator`/`continuation` contract are unchanged, and fan-out stays bounded by the existing #305 caps.

## Changes
- `internal/workflow/worktree.go`: `AllocateReadOnlyDelegationWorktree` (detached, no branch lock), `readOnlyFanoutNeedsWorktree` (≥2 read-only siblings → isolate; counts all read-only deps so diamond concurrency is covered), `cleanupReadOnlyDelegationWorktree` (idempotent, cancellation-detached, holds the checkout mutation lock), `ReadOnlyWorktreeManager` interface.
- `internal/workflow/engine.go`: read-only branch in `allocateAndEnqueueDelegation`; deferred cleanup in `AdvanceJob` (fires on every terminal path).
- `internal/cli/daemon.go`: `validateTargetCheckout` accepts a detached delegation worktree (no branch) while **still** validating the branch for implement worktree children.
- `internal/git/client.go`: `RemoveWorktreeForce` (throwaway worktrees may carry untracked scratch files).
- Docs: read-only fan-out worktree isolation noted in the in-repo and website result-contract references.

## Tests
- Engine dispatch: 2 read-only siblings → distinct detached worktrees, parent branch kept, HeadSHA cleared, no branch-creating calls; single read-only → shared checkout; no manager → `delegation_worktree_skipped`.
- `readOnlyFanoutNeedsWorktree` / `isReadOnlyDelegationWorktree` tables; allocator (detached add, no branch lock, lock released, `HEAD` default); cleanup (force-remove + idempotent no-op on a missing path).
- Daemon: `validateTargetCheckout` accepts a real detached worktree.
- gitutil: `AddDetachedWorktree`/`RemoveWorktreeForce` command construction + a force-remove smoke test over a dirty worktree.
- Full gate green: `go build/vet`, `go test ./...`, `go test -race ./internal/workflow/`.

## Reviewed
Ran `/code-review high --fix`. Applied: restored the implement-child branch guard (the restructure had dropped it); made cleanup idempotent (no spurious `cleanup_failed` event on a re-run `AdvanceJob`); synced docs. Considered and rejected narrowing the trigger to dependency-free siblings — it would reintroduce serialization for diamond deps (siblings that become ready together after a shared parent).

## Known limitation (future, tracked with #328)
A read-only child that dies with no result *and* never hits the timeout-finalizer path (hard daemon kill mid-run) can orphan its worktree — the same class as existing implement-delegation worktrees; a daemon reclamation sweep is the follow-up (cf. #303).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
