### PR TITLE
feat(workflow): field-specific delegation validation errors (#309)

### DIFF
--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -85,13 +85,23 @@ const delegationSchemaHelp = "\nEach delegations[] entry is an object: " +
 	`{"id":"unique-id","agent":"gitmoot-agent-name","action":"ask|review|implement","prompt":"what the agent should do"}` +
 	"\n- id, agent, action, and prompt are ALL required. Use \"agent\" (the target Gitmoot agent's name), not \"to\".\n" +
 	"- Optional: \"deps\":[\"other-id\"] makes this delegation wait until those sibling delegations succeed.\n" +
-	"- Leave delegations empty ([]) when no follow-up agents are needed — that is how you signal the work is complete.\n"
+	"- Leave delegations empty ([]) when no follow-up agents are needed — that is how you signal the work is complete.\n" +
+	"- Validation errors name the offending entry as delegations[<index>] (id \"<id>\"); fix every listed field.\n"
 
 func RenderRepairPrompt(rawOutput string, parseError error) string {
 	var builder strings.Builder
 	builder.WriteString("Your previous response did not contain a valid gitmoot_result JSON object.\n")
 	if parseError != nil {
-		writeField(&builder, "Parse error", parseError.Error())
+		builder.WriteString("Validation errors (fix every line):\n")
+		for _, line := range strings.Split(parseError.Error(), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			builder.WriteString("- ")
+			builder.WriteString(line)
+			builder.WriteByte('\n')
+		}
 	}
 	builder.WriteString("\nReturn only one JSON object in this exact shape:\n")
 	builder.WriteString(`{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`)

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -79,12 +79,55 @@ func TestRenderRepairPromptIncludesErrorAndRawOutput(t *testing.T) {
 
 	for _, want := range []string{
 		"did not contain a valid gitmoot_result",
-		"Parse error: missing gitmoot_result",
+		"Validation errors (fix every line):",
+		"- missing gitmoot_result",
 		"Return only one JSON object",
 		"not json",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("repair prompt missing %q:\n%s", want, prompt)
 		}
+	}
+	if strings.Contains(prompt, "Parse error:") {
+		t.Fatalf("repair prompt unexpectedly includes the old Parse error label:\n%s", prompt)
+	}
+}
+
+func TestRenderRepairPromptSurfacesJoinedFieldErrors(t *testing.T) {
+	// Simulate an errors.Join'd validation failure against the frozen contract:
+	// each per-field error renders as one line, joined with newlines.
+	joined := errors.New(`delegations[0] (id "<missing>"): id is required
+delegations[1] (id "build-api"): action is required`)
+	prompt := RenderRepairPrompt("bad output", joined)
+
+	for _, want := range []string{
+		"Validation errors (fix every line):",
+		`- delegations[0] (id "<missing>"): id is required`,
+		`- delegations[1] (id "build-api"): action is required`,
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("repair prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestRenderRepairPromptIncludesSchemaHelpHint(t *testing.T) {
+	prompt := RenderRepairPrompt("bad output", errors.New("missing gitmoot_result"))
+	want := `delegations[<index>] (id "<id>")`
+	if !strings.Contains(prompt, want) {
+		t.Fatalf("repair prompt missing schema-help hint %q:\n%s", want, prompt)
+	}
+}
+
+func TestRenderJobIncludesDelegationValidationHint(t *testing.T) {
+	prompt := RenderJob(JobPrompt{
+		Repo:         "jerryfane/gitmoot",
+		Branch:       "task-005",
+		Action:       "implement",
+		Instructions: "build the api",
+	})
+	want := `delegations[<index>] (id "<id>")`
+	if !strings.Contains(prompt, want) {
+		t.Fatalf("job prompt missing delegation validation hint %q:\n%s", want, prompt)
 	}
 }

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -122,6 +122,32 @@ func validateAgentResultFields(raw json.RawMessage) error {
 	return nil
 }
 
+// DelegationValidationError is a per-field validation failure on a single
+// delegation. It carries the delegation's 0-based position and id so that, when
+// multiple field errors are aggregated with errors.Join, the coordinator can see
+// exactly which entry and which field each failure refers to and repair the whole
+// batch in one round.
+type DelegationValidationError struct {
+	Index int    // 0-based position in delegations[]
+	ID    string // delegation id; "" when missing/blank
+	Field string // "id" | "action" | "prompt"
+	Msg   string // e.g. "is required"
+}
+
+func (e DelegationValidationError) Error() string {
+	id := e.ID
+	if strings.TrimSpace(id) == "" {
+		id = "<missing>"
+	}
+	return fmt.Sprintf("delegations[%d] (id %q): %s %s", e.Index, id, e.Field, e.Msg)
+}
+
+// delegationFieldError builds a DelegationValidationError for the delegation at
+// index i, annotated with its id and the offending field/message.
+func delegationFieldError(i int, d Delegation, field, msg string) error {
+	return DelegationValidationError{Index: i, ID: d.ID, Field: field, Msg: msg}
+}
+
 func validateAgentResult(result AgentResult) error {
 	switch result.Decision {
 	case "approved", "changes_requested", "blocked", "implemented", "failed":
@@ -131,28 +157,33 @@ func validateAgentResult(result AgentResult) error {
 	if strings.TrimSpace(result.Summary) == "" {
 		return errors.New("gitmoot_result summary is required")
 	}
-	for _, d := range result.Delegations {
+	var errs []error
+	for i, d := range result.Delegations {
 		if strings.TrimSpace(d.ID) == "" {
-			return errors.New("delegation id is required")
-		}
-		// The engine keys child jobs, the dedup map, and the DAG on the raw id
-		// while deps are matched trimmed; a surrounding-whitespace id would make
-		// those disagree and silently drop the delegation. Require them equal.
-		if d.ID != strings.TrimSpace(d.ID) {
-			return fmt.Errorf("delegation id %q must not have leading or trailing whitespace", d.ID)
+			errs = append(errs, delegationFieldError(i, d, "id", "is required"))
+		} else if d.ID != strings.TrimSpace(d.ID) {
+			// The engine keys child jobs, the dedup map, and the DAG on the raw id
+			// while deps are matched trimmed; a surrounding-whitespace id would make
+			// those disagree and silently drop the delegation. Require them equal.
+			errs = append(errs, delegationFieldError(i, d, "id", "must not have leading or trailing whitespace"))
 		}
 		if err := validateDelegationTarget(d); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 		if strings.TrimSpace(d.Action) == "" {
-			return errors.New("delegation action is required")
+			errs = append(errs, delegationFieldError(i, d, "action", "is required"))
 		}
 		if strings.TrimSpace(d.Prompt) == "" {
-			return errors.New("delegation prompt is required")
+			errs = append(errs, delegationFieldError(i, d, "prompt", "is required"))
 		}
 		if err := validateDelegationLifecycle(d); err != nil {
-			return err
+			errs = append(errs, err)
 		}
+	}
+	// Aggregate every per-delegation field failure before the graph check, which
+	// assumes well-formed ids.
+	if joined := errors.Join(errs...); joined != nil {
+		return joined
 	}
 	if err := validateDelegationGraph(result.Delegations); err != nil {
 		return err

--- a/internal/workflow/result_test.go
+++ b/internal/workflow/result_test.go
@@ -117,10 +117,10 @@ func TestValidateAgentResultRejectsDelegationMissingFields(t *testing.T) {
 		del  Delegation
 		want string
 	}{
-		{"missing id", Delegation{Agent: "impl", Action: "implement", Prompt: "do"}, "delegation id is required"},
+		{"missing id", Delegation{Agent: "impl", Action: "implement", Prompt: "do"}, `delegations[0] (id "<missing>"): id is required`},
 		{"missing agent", Delegation{ID: "a", Action: "implement", Prompt: "do"}, `delegation "a" must set exactly one of agent or ephemeral`},
-		{"missing action", Delegation{ID: "a", Agent: "impl", Prompt: "do"}, "delegation action is required"},
-		{"missing prompt", Delegation{ID: "a", Agent: "impl", Action: "implement"}, "delegation prompt is required"},
+		{"missing action", Delegation{ID: "a", Agent: "impl", Prompt: "do"}, `delegations[0] (id "a"): action is required`},
+		{"missing prompt", Delegation{ID: "a", Agent: "impl", Action: "implement"}, `delegations[0] (id "a"): prompt is required`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -131,6 +131,60 @@ func TestValidateAgentResultRejectsDelegationMissingFields(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateAgentResultAggregatesDelegationFieldErrors(t *testing.T) {
+	// Two delegations, each missing a different field, must surface BOTH failures
+	// in a single error so the one repair retry can fix the whole batch.
+	result := AgentResult{
+		Decision: "implemented",
+		Summary:  "x",
+		Delegations: []Delegation{
+			{Agent: "impl", Action: "implement", Prompt: "do"}, // missing id
+			{ID: "build-api", Agent: "impl", Prompt: "do"},     // missing action
+		},
+	}
+	err := validateAgentResult(result)
+	if err == nil {
+		t.Fatal("validateAgentResult accepted two delegations missing fields")
+	}
+	if !strings.Contains(err.Error(), `delegations[0] (id "<missing>"): id is required`) {
+		t.Fatalf("error missing delegations[0] line: %v", err)
+	}
+	if !strings.Contains(err.Error(), `delegations[1] (id "build-api"): action is required`) {
+		t.Fatalf("error missing delegations[1] line: %v", err)
+	}
+}
+
+func TestDelegationValidationErrorFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		err  DelegationValidationError
+		want string
+	}{
+		{
+			name: "with id",
+			err:  DelegationValidationError{Index: 1, ID: "build-api", Field: "action", Msg: "is required"},
+			want: `delegations[1] (id "build-api"): action is required`,
+		},
+		{
+			name: "blank id renders as <missing>",
+			err:  DelegationValidationError{Index: 0, ID: "", Field: "id", Msg: "is required"},
+			want: `delegations[0] (id "<missing>"): id is required`,
+		},
+		{
+			name: "whitespace id renders as <missing>",
+			err:  DelegationValidationError{Index: 2, ID: "   ", Field: "id", Msg: "is required"},
+			want: `delegations[2] (id "<missing>"): id is required`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Fatalf("Error() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -109,6 +109,15 @@ Delegation fields:
   pre-registration and no cleanup (e.g. N workers each producing one result, or a
   cheap gate plus a strong verifier with per-worker models).
 
+### Validation errors
+
+Each required-field failure is reported per entry as
+`delegations[<index>] (id "<id>"): <field> is required`, where `<index>` is the
+0-based position in `delegations[]` and `<id>` is the delegation's id (or
+`<missing>` when blank). All offending fields across the batch are reported
+together — not just the first — and the coordinator gets one repair retry to fix
+them all in a single round.
+
 A delegation with no `deps` dispatches immediately and runs in parallel with
 other dep-free siblings. Once every top-level delegation reaches a terminal
 state, Gitmoot enqueues exactly one coordinator "continuation" job — back to

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -149,6 +149,15 @@ the same `delegations` field, `coordinator`, and `continuation` mechanics.
   For the longer comparison, including how temp workers fit in, see
   [Choosing a worker](../concepts/agents-templates-jobs-locks.md#choosing-a-worker-registered-agent-vs-ephemeral-worker).
 
+### Validation errors
+
+Each required-field failure is reported per entry as
+`delegations[<index>] (id "<id>"): <field> is required`, where `<index>` is the
+0-based position in `delegations[]` and `<id>` is the delegation's id (or
+`<missing>` when blank). All offending fields across the batch are reported
+together — not just the first — and the coordinator gets one repair retry to fix
+them all in a single round.
+
 ### How delegations run
 
 A delegation with no `deps` is dispatched immediately and runs in parallel with


### PR DESCRIPTION
Fixes #309.

## Problem
Delegation validation returned generic, first-error-only messages (`"delegation action is required"`) with no entry/field identification, so a coordinator emitting a malformed `delegations[]` couldn't tell which entry/field to fix, and the single repair retry could only address one problem at a time.

## Fix
Field- and index-specific, **aggregated** validation errors. A typed `DelegationValidationError{Index,ID,Field,Msg}` renders `delegations[<i>] (id "<id>"): <field> <msg>` (blank id → `<missing>`); `validateAgentResult` now collects **all** per-delegation field failures and returns them via `errors.Join` before the graph check. The repair prompt surfaces them as a `Validation errors (fix every line):` checklist, and `delegationSchemaHelp` names the positional format. The single repair retry is unchanged; already-id-bearing graph/cycle/dup/ephemeral messages are byte-identical.

## Changes
- `internal/workflow/result.go` (+test): typed error, index loop, `errors.Join` aggregation, the 3 generic errors upgraded.
- `internal/prompts/prompts.go` (+test): repair checklist + schema-help hint.
- `skills/gitmoot/references/RESULT_CONTRACT.md` + `website/docs/reference/result-contract.md`: documented.

## Verification
- `go build/vet`, `go test ./...`, `go test -race ./internal/workflow/` — all green.
- `/code-review high --fix` — clean (the `validateDelegationTarget`/`Lifecycle` errors stay in their existing id-bearing form by design; only the 3 generic errors changed).
- **Live codex E2E** (isolated `--home`): a coordinator emitting a malformed `delegations[]` (d1 missing `prompt`, d2 missing `action`) produced, through the real engine, one aggregated error — `delegations[0] (id "d1"): prompt is required` + `delegations[1] (id "d2"): action is required` — in the `malformed_output` event, and `repair_retry` fired. Codex's valid output still passes (proven by the #310 runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
