### PR TITLE
feat: built-in coordinator recipe templates — review-panel & decompose-and-verify (#310)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,20 @@ Ask it from a PR comment:
 /gitmoot thermo-review review
 ```
 
+### Coordinator Recipes
+
+Coordinator recipes are built-in templates that turn the Orchestra pattern into
+one command. Each runs a coordinator that fans work out to ephemeral workers (no
+pre-registration) and reconvenes them in a single continuation. `review-panel`
+convenes a panel of diverse-lens reviewers over a PR and synthesizes one verdict;
+`decompose-and-verify` splits an implementation task into parallel, file-disjoint
+legs and runs a verify step that depends on all of them.
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
+```
+
 ### Custom Prompt Agents
 
 Custom agent templates let you keep a local template file and bind its

--- a/SKILL.md
+++ b/SKILL.md
@@ -226,6 +226,19 @@ gitmoot agent start thermo-review \
   --start-daemon
 ```
 
+Coordinator recipes are built-in templates for the Orchestra pattern: a
+coordinator that fans work out to ephemeral workers (no pre-registration) and
+reconvenes them in one continuation. `review-panel` convenes a panel of
+diverse-lens reviewers over a PR and synthesizes their verdict;
+`decompose-and-verify` splits an implementation task into parallel file-disjoint
+legs and runs a verify step that depends on all of them. Run them with
+`gitmoot orchestrate`:
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
+```
+
 Create a local custom prompt template:
 
 ```sh

--- a/internal/agenttemplate/agenttemplate.go
+++ b/internal/agenttemplate/agenttemplate.go
@@ -20,6 +20,8 @@ import (
 
 const ThermoNuclearCodeQualityReviewID = "thermo-nuclear-code-quality-review"
 const PlannerTemplateID = "planner"
+const ReviewPanelTemplateID = "review-panel"
+const DecomposeAndVerifyTemplateID = "decompose-and-verify"
 const LocalSourceRepo = "local"
 const LocalSourceRef = "file"
 const DefaultLocalDescription = "Local custom prompt agent template."
@@ -83,6 +85,14 @@ var builtins = []Definition{
 		SourceRef:           "main",
 		SourcePath:          "skills/gitmoot/agent-templates/planner.md",
 	},
+	{ID: ReviewPanelTemplateID, Name: "Review Panel Coordinator",
+		Description:         "Coordinator recipe that fans a PR or change out to a panel of ephemeral reviewers with diverse lenses, then synthesizes their findings.",
+		DefaultRole:         "coordinator", DefaultCapabilities: []string{"ask", "review"}, Mutation: false,
+		SourceRepo: "jerryfane/gitmoot", SourceRef: "main", SourcePath: "skills/gitmoot/agent-templates/review-panel.md"},
+	{ID: DecomposeAndVerifyTemplateID, Name: "Decompose and Verify Coordinator",
+		Description:         "Coordinator recipe that decomposes a task into parallel ephemeral implementation subtasks, then runs a verify step that depends on all of them.",
+		DefaultRole:         "coordinator", DefaultCapabilities: []string{"ask", "review", "implement"}, Mutation: true,
+		SourceRepo: "jerryfane/gitmoot", SourceRef: "main", SourcePath: "skills/gitmoot/agent-templates/decompose-and-verify.md"},
 }
 
 var retiredIDs = map[string]struct{}{
@@ -463,6 +473,14 @@ func MetadataForDefinition(definition Definition) Metadata {
 			"driver":         "code-review",
 			"preferred_gate": "human-review",
 		}
+	case ReviewPanelTemplateID:
+		metadata.Tags = []string{"coordinator", "review", "orchestra"}
+		metadata.Inputs = []string{"repo", "pull_request", "task"}
+		metadata.Outputs = []string{"delegations", "review_synthesis"}
+	case DecomposeAndVerifyTemplateID:
+		metadata.Tags = []string{"coordinator", "implement", "orchestra"}
+		metadata.Inputs = []string{"repo", "task"}
+		metadata.Outputs = []string{"delegations", "verification_report"}
 	}
 	return metadata
 }

--- a/internal/agenttemplate/agenttemplate_test.go
+++ b/internal/agenttemplate/agenttemplate_test.go
@@ -80,6 +80,19 @@ func TestEmbeddedBuiltinTemplatesParseAndValidate(t *testing.T) {
 		if !reflect.DeepEqual(parsed.Metadata.Capabilities, def.DefaultCapabilities) {
 			t.Fatalf("template %s capabilities = %v, want %v", def.ID, parsed.Metadata.Capabilities, def.DefaultCapabilities)
 		}
+		// The MetadataForDefinition fallback (used when a fetched file lacks
+		// frontmatter) must agree with the embedded file's frontmatter for the
+		// coordinator recipes, or a no-frontmatter fetch would report different
+		// tags/inputs/outputs than the template actually declares.
+		if def.ID == ReviewPanelTemplateID || def.ID == DecomposeAndVerifyTemplateID {
+			fallback := MetadataForDefinition(def)
+			if !reflect.DeepEqual(fallback.Tags, parsed.Metadata.Tags) ||
+				!reflect.DeepEqual(fallback.Inputs, parsed.Metadata.Inputs) ||
+				!reflect.DeepEqual(fallback.Outputs, parsed.Metadata.Outputs) {
+				t.Fatalf("template %s: MetadataForDefinition fallback diverges from frontmatter (tags %v/%v inputs %v/%v outputs %v/%v)",
+					def.ID, fallback.Tags, parsed.Metadata.Tags, fallback.Inputs, parsed.Metadata.Inputs, fallback.Outputs, parsed.Metadata.Outputs)
+			}
+		}
 	}
 }
 

--- a/internal/agenttemplate/agenttemplate_test.go
+++ b/internal/agenttemplate/agenttemplate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -12,12 +13,13 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/skills"
 )
 
 func TestBuiltinsIncludesPlannerAndThermoTemplates(t *testing.T) {
 	definitions := Builtins()
-	if len(definitions) != 2 {
-		t.Fatalf("builtin count = %d, want 2", len(definitions))
+	if len(definitions) != 4 {
+		t.Fatalf("builtin count = %d, want 4", len(definitions))
 	}
 	thermo, ok := Lookup(ThermoNuclearCodeQualityReviewID)
 	if !ok {
@@ -35,6 +37,49 @@ func TestBuiltinsIncludesPlannerAndThermoTemplates(t *testing.T) {
 	}
 	if planner.SourceRepo != "jerryfane/gitmoot" || planner.SourcePath != "skills/gitmoot/agent-templates/planner.md" {
 		t.Fatalf("planner source = %+v", planner)
+	}
+	reviewPanel, ok := Lookup(ReviewPanelTemplateID)
+	if !ok {
+		t.Fatal("review-panel template missing")
+	}
+	if reviewPanel.Mutation || reviewPanel.DefaultRole != "coordinator" || !reflect.DeepEqual(reviewPanel.DefaultCapabilities, []string{"ask", "review"}) {
+		t.Fatalf("review-panel definition = %+v", reviewPanel)
+	}
+	if reviewPanel.SourceRepo != "jerryfane/gitmoot" || reviewPanel.SourcePath != "skills/gitmoot/agent-templates/review-panel.md" {
+		t.Fatalf("review-panel source = %+v", reviewPanel)
+	}
+	decompose, ok := Lookup(DecomposeAndVerifyTemplateID)
+	if !ok {
+		t.Fatal("decompose-and-verify template missing")
+	}
+	if !decompose.Mutation || decompose.DefaultRole != "coordinator" || !reflect.DeepEqual(decompose.DefaultCapabilities, []string{"ask", "review", "implement"}) {
+		t.Fatalf("decompose-and-verify definition = %+v", decompose)
+	}
+	if decompose.SourceRepo != "jerryfane/gitmoot" || decompose.SourcePath != "skills/gitmoot/agent-templates/decompose-and-verify.md" {
+		t.Fatalf("decompose-and-verify source = %+v", decompose)
+	}
+}
+
+func TestEmbeddedBuiltinTemplatesParseAndValidate(t *testing.T) {
+	for _, def := range Builtins() {
+		if def.SourceRepo != "jerryfane/gitmoot" {
+			continue
+		}
+		path := strings.TrimPrefix(def.SourcePath, "skills/")
+		data, err := fs.ReadFile(skills.FS, path)
+		if err != nil {
+			t.Fatalf("read embedded template %s: %v", def.ID, err)
+		}
+		parsed, err := ParseTemplateContent(string(data))
+		if err != nil {
+			t.Fatalf("template %s did not validate: %v", def.ID, err)
+		}
+		if parsed.Metadata.ID != def.ID {
+			t.Fatalf("template %s metadata id = %q", def.ID, parsed.Metadata.ID)
+		}
+		if !reflect.DeepEqual(parsed.Metadata.Capabilities, def.DefaultCapabilities) {
+			t.Fatalf("template %s capabilities = %v, want %v", def.ID, parsed.Metadata.Capabilities, def.DefaultCapabilities)
+		}
 	}
 }
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2974,6 +2974,17 @@ func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.
 	}
 	expectedHead := strings.TrimSpace(payload.HeadSHA)
 	if expectedHead == "" {
+		// A delegation child can inherit an empty HeadSHA from a coordinator that
+		// has no PR context (a local `gitmoot orchestrate`). It is gitmoot-dispatched
+		// against the registered checkout, so run it against the current HEAD rather
+		// than failing — e.g. a decompose-and-verify verify step, or any read-only
+		// follow-up delegation. Implement children always run in a per-delegation
+		// worktree (handled above), so only non-mutating shared-checkout delegation
+		// children reach here. Non-delegation jobs (PR comments) still require a
+		// HeadSHA.
+		if strings.TrimSpace(payload.DelegationID) != "" {
+			return nil
+		}
 		return fmt.Errorf("job for %s has no head SHA", payload.Branch)
 	}
 	head, err := git.HeadSHA(ctx)

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -2455,6 +2455,32 @@ func TestValidateTargetCheckoutAcceptsDetachedReadOnlyWorktreeChild(t *testing.T
 	}
 }
 
+func TestValidateTargetCheckoutAllowsSharedCheckoutDelegationChildWithoutHeadSHA(t *testing.T) {
+	// A read-only delegation child from a local orchestrate (no PR) inherits an
+	// empty HeadSHA and runs in the shared checkout (no per-delegation worktree).
+	// It must be accepted and run against the current HEAD, not rejected for a
+	// missing HeadSHA. A non-delegation job with no HeadSHA is still rejected.
+	ctx := context.Background()
+	checkout := createDaemonWorkerGitCheckout(t, "task-005")
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard)
+
+	delegationChild := workflow.JobPayload{
+		Repo:         "owner/repo",
+		Branch:       "task-005",
+		DelegationID: "verify-1",
+		ParentJobID:  "parent-job",
+		// no WorktreePath (shared checkout), no HeadSHA (PR-less local orchestrate)
+	}
+	if err := worker.validateTargetCheckout(ctx, delegationChild, checkout); err != nil {
+		t.Fatalf("validateTargetCheckout rejected shared-checkout delegation child without HeadSHA: %v", err)
+	}
+
+	nonDelegation := workflow.JobPayload{Repo: "owner/repo", Branch: "task-005"}
+	if err := worker.validateTargetCheckout(ctx, nonDelegation, checkout); err == nil {
+		t.Fatal("validateTargetCheckout accepted a non-delegation job with no HeadSHA")
+	}
+}
+
 func TestRefreshDaemonJobPayloadPreservesTaskWorktreeHeadForFinalizer(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/skills/gitmoot/agent-templates/decompose-and-verify.md
+++ b/skills/gitmoot/agent-templates/decompose-and-verify.md
@@ -52,7 +52,11 @@ gitmoot orchestrate decompose-and-verify "Implement the export feature described
    deps so they build in parallel in their own branch worktrees. Give each a
    precise prompt naming the files it owns and its acceptance.
 3. Create one verify step as a review-action ephemeral worker whose deps list
-   every implementation delegation id. Set synthesis_rule summary on it.
+   every implementation delegation id. Set synthesis_rule summary on it. Each
+   implementation leg lands on its own branch/worktree, so the verify step reads
+   the shared checkout, not an auto-merged combination of the legs; if it reports
+   the legs' work as missing, that is the cue for the continuation to integrate or
+   re-delegate (handled below), not a leg failure.
 4. Pick runtimes per leg; a stronger model for the verify gate is reasonable.
    Ephemeral workers are leaf-only.
 5. Every leg here is ephemeral. On each delegation set the `ephemeral` object

--- a/skills/gitmoot/agent-templates/decompose-and-verify.md
+++ b/skills/gitmoot/agent-templates/decompose-and-verify.md
@@ -1,0 +1,116 @@
+---
+id: decompose-and-verify
+name: Decompose and Verify Coordinator
+description: Coordinator recipe that decomposes a task into parallel ephemeral implementation subtasks, then runs a verify step that depends on all of them.
+kind: agent-template
+version: 1
+capabilities:
+  - ask
+  - review
+  - implement
+runtime_compatibility:
+  - codex
+  - claude
+  - kimi
+tags:
+  - coordinator
+  - implement
+  - orchestra
+inputs:
+  - repo
+  - task
+outputs:
+  - delegations
+  - verification_report
+---
+
+# Decompose and Verify Coordinator
+
+You are the Gitmoot decompose-and-verify coordinator, a conductor in Gitmoot's
+Orchestra model. You take one implementation task, split it into independent
+subtasks that build in parallel, fan them out to ephemeral implementation
+workers, then run a single verify step that depends on all of them before
+reporting back. You orchestrate; you do not write the code yourself in the first
+pass.
+
+## When To Use
+
+Use this recipe when a task splits into pieces that do not block each other and
+you want a final correctness gate over the combined result. Start it as
+background work:
+
+```sh
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
+```
+
+## Decompose Workflow
+
+1. Read the task and current repo state. Identify the smallest set of independent
+   subtasks — each owning a disjoint set of files so workers never collide on the
+   checkout.
+2. Create one implement delegation per subtask as an ephemeral worker, with no
+   deps so they build in parallel in their own branch worktrees. Give each a
+   precise prompt naming the files it owns and its acceptance.
+3. Create one verify step as a review-action ephemeral worker whose deps list
+   every implementation delegation id. Set synthesis_rule summary on it.
+4. Pick runtimes per leg; a stronger model for the verify gate is reasonable.
+   Ephemeral workers are leaf-only.
+5. Do not set agent on these delegations — agent and ephemeral are mutually
+   exclusive, and every leg here is ephemeral.
+
+## Coordinator Result
+
+The implementation legs are dep-free (parallel); the verify step depends on all
+of them, forming a small DAG. Gitmoot enqueues one continuation after verify
+finishes.
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "Decomposing the task into two parallel implementation legs plus a verify gate.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "delegations": [
+      {
+        "id": "impl-api",
+        "action": "implement",
+        "prompt": "Implement the export HTTP API in internal/api/export.go and its handler wiring only. Add unit tests in internal/api/export_test.go. Do not touch storage or UI files. Acceptance: the new endpoint returns the export payload and tests pass.",
+        "ephemeral": { "runtime": "codex", "role": "implementer", "capabilities": ["ask", "implement"] }
+      },
+      {
+        "id": "impl-storage",
+        "action": "implement",
+        "prompt": "Implement the export query in internal/store/export_query.go only. Add unit tests in internal/store/export_query_test.go. Do not touch API or UI files. Acceptance: the query returns the rows the export needs and tests pass.",
+        "ephemeral": { "runtime": "claude", "role": "implementer", "capabilities": ["ask", "implement"] }
+      },
+      {
+        "id": "verify",
+        "action": "review",
+        "prompt": "Verify the combined export feature: run the build and full test suite, confirm the API and storage legs integrate, and report any failure with file and line. Decision changes_requested if anything fails to build, test, or integrate; otherwise approved.",
+        "deps": ["impl-api", "impl-storage"],
+        "synthesis_rule": "summary",
+        "ephemeral": { "runtime": "claude", "role": "verifier", "capabilities": ["ask", "review"] }
+      }
+    ]
+  }
+}
+```
+
+## Synthesis (Continuation)
+
+After verify finishes, Gitmoot enqueues one continuation back to you with all
+results. Read the verify result first — it is the gate. If verify reported
+changes_requested, summarize what failed and which leg owns the fix, and
+optionally re-delegate a single targeted implement leg plus a fresh verify that
+deps on it. If verify passed, return a final gitmoot_result with decision
+implemented, the merged changes_made, the tests_run from verify, and no
+delegations.
+
+## Safety Rules
+
+- Keep subtasks file-disjoint so parallel legs never edit the same file.
+- The verify step must always deps on every implementation leg; never skip it.
+- Redact secrets from prompts, findings, and summaries.

--- a/skills/gitmoot/agent-templates/decompose-and-verify.md
+++ b/skills/gitmoot/agent-templates/decompose-and-verify.md
@@ -55,8 +55,12 @@ gitmoot orchestrate decompose-and-verify "Implement the export feature described
    every implementation delegation id. Set synthesis_rule summary on it.
 4. Pick runtimes per leg; a stronger model for the verify gate is reasonable.
    Ephemeral workers are leaf-only.
-5. Do not set agent on these delegations — agent and ephemeral are mutually
-   exclusive, and every leg here is ephemeral.
+5. Every leg here is ephemeral. On each delegation set the `ephemeral` object
+   (`{"runtime": ..., "role": ..., "capabilities": [...]}`) and the `action`.
+   NEVER set the `agent` field and NEVER invent an agent name (do not put a name
+   like "ephemeral-codex-worker" in `agent`) — `agent` and `ephemeral` are
+   mutually exclusive, and there are no pre-registered agents to name. The `id`
+   is just the delegation label; it is not an agent.
 
 ## Coordinator Result
 

--- a/skills/gitmoot/agent-templates/review-panel.md
+++ b/skills/gitmoot/agent-templates/review-panel.md
@@ -1,0 +1,132 @@
+---
+id: review-panel
+name: Review Panel Coordinator
+description: Coordinator recipe that fans a PR or change out to a panel of ephemeral reviewers with diverse lenses, then synthesizes their findings.
+kind: agent-template
+version: 1
+capabilities:
+  - ask
+  - review
+runtime_compatibility:
+  - codex
+  - claude
+  - kimi
+tags:
+  - coordinator
+  - review
+  - orchestra
+inputs:
+  - repo
+  - pull_request
+  - task
+outputs:
+  - delegations
+  - review_synthesis
+---
+
+# Review Panel Coordinator
+
+You are the Gitmoot review-panel coordinator, a conductor in Gitmoot's Orchestra
+model. Your job is to review a pull request or proposed change by convening a
+panel of independent reviewers, each looking through a different lens, then
+synthesizing their findings into one verdict. You do not review the code
+yourself in the first pass; you delegate, then reconcile.
+
+## When To Use
+
+Use this recipe when one review pass is not enough and the change benefits from
+several independent perspectives at once. Start it as background work:
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+```
+
+## Fan-Out Workflow
+
+1. Read the PR or change: the diff, the linked task or issue, and the files it
+   touches. Identify the riskiest surfaces.
+2. Fan out a panel of reviewers as ephemeral workers — one delegation per lens,
+   with no deps so they run in parallel. Default to three lenses; adapt to the
+   change: correctness and security; performance and maintainability; tests and
+   edge cases.
+3. Each reviewer is a throwaway worker spawned from the
+   thermo-nuclear-code-quality-review template, seeded with one lens in its
+   prompt. Mix runtimes so the panel does not share one model's blind spots.
+   Ephemeral workers are leaf-only: they return findings, never their own
+   delegations.
+4. Set synthesis_rule summary on each delegation.
+5. Do not set agent on these delegations — agent and ephemeral are mutually
+   exclusive, and the panel is ephemeral.
+
+## Coordinator Result
+
+Return one gitmoot_result whose delegations array is the panel. All panelists are
+dep-free, so they run in parallel; Gitmoot enqueues one continuation once they
+all finish.
+
+```json
+{
+  "gitmoot_result": {
+    "decision": "approved",
+    "summary": "Convening a three-reviewer panel on the PR with diverse lenses.",
+    "findings": [],
+    "changes_made": [],
+    "tests_run": [],
+    "needs": [],
+    "delegations": [
+      {
+        "id": "lens-correctness-security",
+        "action": "review",
+        "prompt": "Review this PR strictly for correctness and security: logic errors, unhandled errors, injection, authz and authn gaps, unsafe input handling. Report blocking issues with file and line. Ignore performance and style.",
+        "synthesis_rule": "summary",
+        "ephemeral": {
+          "runtime": "claude",
+          "template": "thermo-nuclear-code-quality-review",
+          "role": "reviewer",
+          "capabilities": ["ask", "review"]
+        }
+      },
+      {
+        "id": "lens-performance-maintainability",
+        "action": "review",
+        "prompt": "Review this PR strictly for performance and maintainability: hot-path allocations, N+1 patterns, complexity, duplication, naming, and abstractions worth extracting. Report blocking issues with file and line. Ignore security and test coverage.",
+        "synthesis_rule": "summary",
+        "ephemeral": {
+          "runtime": "codex",
+          "template": "thermo-nuclear-code-quality-review",
+          "role": "reviewer",
+          "capabilities": ["ask", "review"]
+        }
+      },
+      {
+        "id": "lens-tests-edge-cases",
+        "action": "review",
+        "prompt": "Review this PR strictly for tests and edge cases: missing coverage, untested branches, boundary and error-path gaps, and flaky or non-deterministic tests. Report blocking issues with file and line. Ignore performance and style.",
+        "synthesis_rule": "summary",
+        "ephemeral": {
+          "runtime": "claude",
+          "template": "thermo-nuclear-code-quality-review",
+          "role": "reviewer",
+          "capabilities": ["ask", "review"]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Synthesis (Continuation)
+
+Gitmoot runs every panelist, then enqueues one continuation job back to you with
+the panel's results. In that continuation: read each reviewer's findings;
+de-duplicate and group by severity; decide the verdict (changes_requested if any
+reviewer raised a blocking issue, else approved); return a final gitmoot_result
+with no delegations, findings holding the merged issues, and summary stating the
+verdict and which lenses drove it. Do not re-delegate unless a reviewer surfaced
+a new high-risk area the panel did not cover.
+
+## Safety Rules
+
+- This recipe is review-only. Do not request implement work or mutate files.
+- Keep each lens prompt narrow so panelists stay independent.
+- Redact secrets from prompts, findings, and summaries.

--- a/skills/gitmoot/agent-templates/review-panel.md
+++ b/skills/gitmoot/agent-templates/review-panel.md
@@ -49,11 +49,13 @@ gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/rep
    with no deps so they run in parallel. Default to three lenses; adapt to the
    change: correctness and security; performance and maintainability; tests and
    edge cases.
-3. Each reviewer is a throwaway worker spawned from the
-   thermo-nuclear-code-quality-review template, seeded with one lens in its
+3. Each reviewer is a throwaway ephemeral worker seeded with one lens in its
    prompt. Mix runtimes so the panel does not share one model's blind spots.
    Ephemeral workers are leaf-only: they return findings, never their own
-   delegations.
+   delegations. The lens prompt is self-contained — do not set an ephemeral
+   template unless that template is already installed in this Gitmoot home (for
+   example, set "template": "thermo-nuclear-code-quality-review" only when you
+   have run gitmoot agent template update for it).
 4. Set synthesis_rule summary on each delegation.
 5. Do not set agent on these delegations — agent and ephemeral are mutually
    exclusive, and the panel is ephemeral.
@@ -81,7 +83,6 @@ all finish.
         "synthesis_rule": "summary",
         "ephemeral": {
           "runtime": "claude",
-          "template": "thermo-nuclear-code-quality-review",
           "role": "reviewer",
           "capabilities": ["ask", "review"]
         }
@@ -93,7 +94,6 @@ all finish.
         "synthesis_rule": "summary",
         "ephemeral": {
           "runtime": "codex",
-          "template": "thermo-nuclear-code-quality-review",
           "role": "reviewer",
           "capabilities": ["ask", "review"]
         }
@@ -105,7 +105,6 @@ all finish.
         "synthesis_rule": "summary",
         "ephemeral": {
           "runtime": "claude",
-          "template": "thermo-nuclear-code-quality-review",
           "role": "reviewer",
           "capabilities": ["ask", "review"]
         }

--- a/skills/gitmoot/agent-templates/review-panel.md
+++ b/skills/gitmoot/agent-templates/review-panel.md
@@ -57,8 +57,12 @@ gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/rep
    example, set "template": "thermo-nuclear-code-quality-review" only when you
    have run gitmoot agent template update for it).
 4. Set synthesis_rule summary on each delegation.
-5. Do not set agent on these delegations — agent and ephemeral are mutually
-   exclusive, and the panel is ephemeral.
+5. Every panelist is ephemeral. On each delegation set the `ephemeral` object
+   (`{"runtime": ..., "role": ..., "capabilities": [...]}`) and the `action`.
+   NEVER set the `agent` field and NEVER invent an agent name (do not put a name
+   like "ephemeral-codex-reviewer" in `agent`) — `agent` and `ephemeral` are
+   mutually exclusive, and there are no pre-registered agents to name. The `id`
+   is just the delegation label; it is not an agent.
 
 ## Coordinator Result
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -250,6 +250,15 @@ gitmoot orchestrate project-planner "Plan and split this work across agents." --
 gitmoot orchestrate project-planner "Plan and split this work." --repo owner/repo --model gpt-5-codex
 ```
 
+The built-in coordinator recipes `review-panel` and `decompose-and-verify` are
+orchestrate-ready: each runs a coordinator that fans work out to ephemeral
+workers and reconvenes them in a continuation, with no agent pre-registration:
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
+```
+
 `gitmoot orchestrate <agent> "..." [--repo R]` is sugar for
 `gitmoot agent run <agent> --background "..."`. It starts a conductor
 (coordinator) that returns a `delegations[]` score; the players (child agents)
@@ -303,6 +312,18 @@ gitmoot agent start project-planner \
   --path . \
   --template planner \
   --start-daemon
+```
+
+Install or refresh the built-in coordinator recipe templates. These are
+coordinator prompts for the Orchestra pattern, run with `gitmoot orchestrate`
+rather than started as long-lived agents:
+
+```sh
+gitmoot agent template update review-panel
+gitmoot agent template update decompose-and-verify
+gitmoot agent template show review-panel
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
 ```
 
 For fast current-chat planning, use the Gitmoot skill with the same packaged

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -474,9 +474,10 @@ Two recipes ship built in:
 - **`review-panel`** — fans a PR or change out to a panel of ephemeral reviewers,
   each with a different lens (correctness and security; performance and
   maintainability; tests and edge cases), then synthesizes their findings into
-  one verdict. The panelists are dep-free, so they review in parallel, and they
-  are seeded from the `thermo-nuclear-code-quality-review` template across mixed
-  runtimes so the panel does not share one model's blind spots.
+  one verdict. The panelists are dep-free, so they review in parallel, each with
+  a self-contained lens prompt across mixed runtimes so the panel does not share
+  one model's blind spots (point a panelist at an installed review template such
+  as `thermo-nuclear-code-quality-review` only if you want).
 - **`decompose-and-verify`** — decomposes one implementation task into
   file-disjoint subtasks, fans them out to ephemeral implementation workers that
   build in parallel in their own branch worktrees, then runs a single `review`

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -459,3 +459,43 @@ Each child job carries job-tree linkage fields — `parent_job_id`,
 `delegation_id`, `root_job_id`, `delegation_depth`, and `task_id` — so a child
 can be traced back to its parent, its originating delegation, and the root of the
 tree. See `RESULT_CONTRACT.md` for the full delegation field reference.
+
+## Coordinator Recipes
+
+Coordinator recipes are built-in agent templates that turn the Orchestra pattern
+into one-command workflows. Each recipe is a coordinator prompt that emits a
+`delegations[]` of **ephemeral** workers (no pre-registration), runs them in the
+daemon, then reconvenes their results in a single continuation. Start one with
+`gitmoot orchestrate <recipe-id> "..." --repo owner/repo`; the daemon runs the
+coordinator in the background and dispatches its delegations.
+
+Two recipes ship built in:
+
+- **`review-panel`** — fans a PR or change out to a panel of ephemeral reviewers,
+  each with a different lens (correctness and security; performance and
+  maintainability; tests and edge cases), then synthesizes their findings into
+  one verdict. The panelists are dep-free, so they review in parallel, and they
+  are seeded from the `thermo-nuclear-code-quality-review` template across mixed
+  runtimes so the panel does not share one model's blind spots.
+- **`decompose-and-verify`** — decomposes one implementation task into
+  file-disjoint subtasks, fans them out to ephemeral implementation workers that
+  build in parallel in their own branch worktrees, then runs a single `review`
+  verify step that `deps` on every implementation leg before reporting back.
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
+```
+
+The panelists in `review-panel` and every implementation and verify leg in
+`decompose-and-verify` are **ephemeral** workers: Gitmoot creates each from the
+delegation's `ephemeral` spec, runs it, and disposes of it once the child job
+finishes. Ephemeral workers are leaf-only — they return findings, never their own
+delegations — so a recipe's fan-out is exactly one level deep. In both recipes the
+delegations never set `agent`, because `agent` and `ephemeral` are mutually
+exclusive. Once every leg is terminal, Gitmoot enqueues one continuation back to
+the coordinator to merge the results (the panel verdict, or the verify gate plus
+the merged changes). Inspect the run under `gitmoot job list --repo owner/repo`
+and the `delegation_enqueued` events in `gitmoot events --repo owner/repo`. See
+`RESULT_CONTRACT.md` for the `ephemeral` field reference and the termination
+bounds these recipes run inside.

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -158,6 +158,16 @@ Each required-field failure is reported per entry as
 together — not just the first — and the coordinator gets one repair retry to fix
 them all in a single round.
 
+:::tip Built-in coordinator recipes
+You do not have to author the `ephemeral` fan-out by hand. The built-in
+**coordinator recipes** `review-panel` and `decompose-and-verify` are templates
+that emit a ready-made ephemeral `delegations[]` for you — a diverse-lens review
+panel, or parallel implementation legs plus a verify gate. Run them with
+`gitmoot orchestrate review-panel "..."` /
+`gitmoot orchestrate decompose-and-verify "..."`. See the
+[Coordinator Recipes Workflow](../workflows/coordinator-recipes-workflow.md).
+:::
+
 ### How delegations run
 
 A delegation with no `deps` is dispatched immediately and runs in parallel with

--- a/website/docs/workflows/coordinator-recipes-workflow.md
+++ b/website/docs/workflows/coordinator-recipes-workflow.md
@@ -31,9 +31,10 @@ gitmoot agent template show review-panel
 independent reviewers, each looking through a different lens, then synthesizing
 their findings into one verdict. It fans out three dep-free reviewers by default —
 correctness and security; performance and maintainability; tests and edge cases —
-so they review in parallel. Each panelist is an ephemeral worker seeded from the
-`thermo-nuclear-code-quality-review` template, and the recipe mixes runtimes so
-the panel does not share one model's blind spots.
+so they review in parallel. Each panelist is an ephemeral worker with a
+self-contained lens prompt, and the recipe mixes runtimes so the panel does not
+share one model's blind spots (point a panelist at an installed review template
+such as `thermo-nuclear-code-quality-review` only if you want).
 
 ```sh
 gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo

--- a/website/docs/workflows/coordinator-recipes-workflow.md
+++ b/website/docs/workflows/coordinator-recipes-workflow.md
@@ -1,0 +1,82 @@
+# Coordinator Recipes Workflow
+
+Coordinator recipes are built-in agent templates that turn the
+[Orchestra pattern](../reference/result-contract.md#delegations-orchestration)
+into one-command workflows. Each recipe is a coordinator prompt that emits a
+`delegations[]` of **ephemeral** workers — created on demand from an inline spec,
+run once, then auto-disposed — so you do not pre-register any agents. Gitmoot runs
+the panelists or legs in the daemon, then reconvenes their results in a single
+continuation back to the coordinator.
+
+Start a recipe with `gitmoot orchestrate <recipe-id> "..." --repo owner/repo`,
+which is sugar for a background `gitmoot agent run`:
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
+```
+
+Two recipes ship built in. Install or refresh either template the same way as any
+built-in template:
+
+```sh
+gitmoot agent template update review-panel
+gitmoot agent template update decompose-and-verify
+gitmoot agent template show review-panel
+```
+
+## Review Panel
+
+`review-panel` reviews a pull request or change by convening a panel of
+independent reviewers, each looking through a different lens, then synthesizing
+their findings into one verdict. It fans out three dep-free reviewers by default —
+correctness and security; performance and maintainability; tests and edge cases —
+so they review in parallel. Each panelist is an ephemeral worker seeded from the
+`thermo-nuclear-code-quality-review` template, and the recipe mixes runtimes so
+the panel does not share one model's blind spots.
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+```
+
+Once every panelist is terminal, Gitmoot enqueues one continuation that
+de-duplicates the findings, decides the verdict (`changes_requested` if any
+reviewer raised a blocking issue, else `approved`), and reports which lenses drove
+it.
+
+## Decompose and Verify
+
+`decompose-and-verify` takes one implementation task, splits it into independent
+file-disjoint subtasks, and fans them out to ephemeral implementation workers that
+build in parallel in their own branch worktrees. It then adds one `review`-action
+verify step whose `deps` list every implementation leg, forming a small DAG, so
+the gate runs only after all the legs finish.
+
+```sh
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
+```
+
+After verify finishes, Gitmoot enqueues one continuation. The coordinator reads
+the verify result first — it is the gate — and either reports the merged changes
+when verify passed, or summarizes what failed and which leg owns the fix.
+
+## Ephemeral, leaf-only, bounded
+
+In both recipes the delegations never set `agent`: `agent` and `ephemeral` are
+mutually exclusive, and every panelist or leg here is ephemeral. Ephemeral workers
+are **leaf-only** — they return findings, never their own delegations — so a
+recipe's fan-out is exactly one level deep. The recipes run inside the same
+delegation [termination bounds](../reference/result-contract.md#termination-bounds)
+as any orchestra: a depth cap, a per-root job budget, and loop detection.
+
+Inspect a run with the usual job and event commands:
+
+```sh
+gitmoot job list --repo owner/repo
+gitmoot events --repo owner/repo
+```
+
+See the [Result Contract](../reference/result-contract.md) for the `ephemeral`
+field reference and the
+[registered agent vs. ephemeral worker](../concepts/agents-templates-jobs-locks.md#choosing-a-worker-registered-agent-vs-ephemeral-worker)
+comparison.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -27,6 +27,7 @@ const sidebars: SidebarsConfig = {
         'workflows/planner-goal-workflow',
         'workflows/template-capture-workflow',
         'workflows/review-agent-workflow',
+        'workflows/coordinator-recipes-workflow',
         'workflows/skillopt-train-workflow',
       ],
     },

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -218,6 +218,20 @@ Ask it from a PR comment:
 /gitmoot thermo-review review
 ```
 
+### Coordinator Recipes
+
+Coordinator recipes are built-in templates that turn the Orchestra pattern into
+one command. Each runs a coordinator that fans work out to ephemeral workers (no
+pre-registration) and reconvenes them in a single continuation. `review-panel`
+convenes a panel of diverse-lens reviewers over a PR and synthesizes one verdict;
+`decompose-and-verify` splits an implementation task into parallel, file-disjoint
+legs and runs a verify step that depends on all of them.
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
+```
+
 ### Custom Prompt Agents
 
 Custom agent templates let you keep a local template file and bind its
@@ -735,6 +749,19 @@ gitmoot agent start thermo-review \
   --repo owner/repo \
   --template thermo-nuclear-code-quality-review \
   --start-daemon
+```
+
+Coordinator recipes are built-in templates for the Orchestra pattern: a
+coordinator that fans work out to ephemeral workers (no pre-registration) and
+reconvenes them in one continuation. `review-panel` convenes a panel of
+diverse-lens reviewers over a PR and synthesizes their verdict;
+`decompose-and-verify` splits an implementation task into parallel file-disjoint
+legs and runs a verify step that depends on all of them. Run them with
+`gitmoot orchestrate`:
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
 ```
 
 Create a local custom prompt template:
@@ -5443,6 +5470,15 @@ gitmoot orchestrate project-planner "Plan and split this work across agents." --
 gitmoot orchestrate project-planner "Plan and split this work." --repo owner/repo --model gpt-5-codex
 ```
 
+The built-in coordinator recipes `review-panel` and `decompose-and-verify` are
+orchestrate-ready: each runs a coordinator that fans work out to ephemeral
+workers and reconvenes them in a continuation, with no agent pre-registration:
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
+```
+
 `gitmoot orchestrate <agent> "..." [--repo R]` is sugar for
 `gitmoot agent run <agent> --background "..."`. It starts a conductor
 (coordinator) that returns a `delegations[]` score; the players (child agents)
@@ -5496,6 +5532,18 @@ gitmoot agent start project-planner \
   --path . \
   --template planner \
   --start-daemon
+```
+
+Install or refresh the built-in coordinator recipe templates. These are
+coordinator prompts for the Orchestra pattern, run with `gitmoot orchestrate`
+rather than started as long-lived agents:
+
+```sh
+gitmoot agent template update review-panel
+gitmoot agent template update decompose-and-verify
+gitmoot agent template show review-panel
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
 ```
 
 For fast current-chat planning, use the Gitmoot skill with the same packaged
@@ -6212,6 +6260,46 @@ Each child job carries job-tree linkage fields — `parent_job_id`,
 can be traced back to its parent, its originating delegation, and the root of the
 tree. See `RESULT_CONTRACT.md` for the full delegation field reference.
 
+## Coordinator Recipes
+
+Coordinator recipes are built-in agent templates that turn the Orchestra pattern
+into one-command workflows. Each recipe is a coordinator prompt that emits a
+`delegations[]` of **ephemeral** workers (no pre-registration), runs them in the
+daemon, then reconvenes their results in a single continuation. Start one with
+`gitmoot orchestrate <recipe-id> "..." --repo owner/repo`; the daemon runs the
+coordinator in the background and dispatches its delegations.
+
+Two recipes ship built in:
+
+- **`review-panel`** — fans a PR or change out to a panel of ephemeral reviewers,
+  each with a different lens (correctness and security; performance and
+  maintainability; tests and edge cases), then synthesizes their findings into
+  one verdict. The panelists are dep-free, so they review in parallel, and they
+  are seeded from the `thermo-nuclear-code-quality-review` template across mixed
+  runtimes so the panel does not share one model's blind spots.
+- **`decompose-and-verify`** — decomposes one implementation task into
+  file-disjoint subtasks, fans them out to ephemeral implementation workers that
+  build in parallel in their own branch worktrees, then runs a single `review`
+  verify step that `deps` on every implementation leg before reporting back.
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo
+```
+
+The panelists in `review-panel` and every implementation and verify leg in
+`decompose-and-verify` are **ephemeral** workers: Gitmoot creates each from the
+delegation's `ephemeral` spec, runs it, and disposes of it once the child job
+finishes. Ephemeral workers are leaf-only — they return findings, never their own
+delegations — so a recipe's fan-out is exactly one level deep. In both recipes the
+delegations never set `agent`, because `agent` and `ephemeral` are mutually
+exclusive. Once every leg is terminal, Gitmoot enqueues one continuation back to
+the coordinator to merge the results (the panel verdict, or the verify gate plus
+the merged changes). Inspect the run under `gitmoot job list --repo owner/repo`
+and the `delegation_enqueued` events in `gitmoot events --repo owner/repo`. See
+`RESULT_CONTRACT.md` for the `ephemeral` field reference and the termination
+bounds these recipes run inside.
+
 ---
 
 # Source: skills/gitmoot/references/TEMPLATE_CAPTURE.md
@@ -6523,6 +6611,13 @@ A delegation with no `deps` dispatches immediately and runs in parallel with
 other dep-free siblings. Once every top-level delegation reaches a terminal
 state, Gitmoot enqueues exactly one coordinator "continuation" job — back to
 the delegating agent — to synthesize the children's results.
+
+Sibling children that share the repo run in isolated git worktrees so they do
+not serialize on the shared checkout: `implement` children each get their own
+branch worktree, and when a coordinator fans out **two or more read-only**
+(`ask`/`review`) children, each gets a throwaway detached worktree (no branch).
+The worktrees are disposed automatically when each child finishes. This is
+internal scheduling — coordinators do not request it.
 
 Each child job carries `parent_job_id`, `delegation_id`, `root_job_id`,
 `delegation_depth`, and `task_id`, so a child can be traced to its parent, its

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6274,9 +6274,10 @@ Two recipes ship built in:
 - **`review-panel`** — fans a PR or change out to a panel of ephemeral reviewers,
   each with a different lens (correctness and security; performance and
   maintainability; tests and edge cases), then synthesizes their findings into
-  one verdict. The panelists are dep-free, so they review in parallel, and they
-  are seeded from the `thermo-nuclear-code-quality-review` template across mixed
-  runtimes so the panel does not share one model's blind spots.
+  one verdict. The panelists are dep-free, so they review in parallel, each with
+  a self-contained lens prompt across mixed runtimes so the panel does not share
+  one model's blind spots (point a panelist at an installed review template such
+  as `thermo-nuclear-code-quality-review` only if you want).
 - **`decompose-and-verify`** — decomposes one implementation task into
   file-disjoint subtasks, fans them out to ephemeral implementation workers that
   build in parallel in their own branch worktrees, then runs a single `review`

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6608,6 +6608,15 @@ Delegation fields:
   pre-registration and no cleanup (e.g. N workers each producing one result, or a
   cheap gate plus a strong verifier with per-worker models).
 
+### Validation errors
+
+Each required-field failure is reported per entry as
+`delegations[<index>] (id "<id>"): <field> is required`, where `<index>` is the
+0-based position in `delegations[]` and `<id>` is the delegation's id (or
+`<missing>` when blank). All offending fields across the batch are reported
+together — not just the first — and the coordinator gets one repair retry to fix
+them all in a single round.
+
 A delegation with no `deps` dispatches immediately and runs in parallel with
 other dep-free siblings. Once every top-level delegation reaches a terminal
 state, Gitmoot enqueues exactly one coordinator "continuation" job — back to


### PR DESCRIPTION
Fixes #310.

## Summary
Two built-in **coordinator recipe templates** — `review-panel` and `decompose-and-verify` — plus a small engine fix that makes a recipe's read-only verify/follow-up step runnable from a local `orchestrate`. Recipes are pure prompt-templates: the coordinator emits a `delegations[]` of **ephemeral** workers (no pre-registration), and Gitmoot runs the DAG + continuation.

- **`review-panel`** — fans a PR/change out to a panel of ephemeral reviewers with diverse lenses (no deps → parallel), then synthesizes one verdict. Self-contained (no pre-installed template required).
- **`decompose-and-verify`** — decomposes a task into file-disjoint parallel `implement` legs + a `deps`-gated `verify` step; the continuation gates on verify.

## Changes
- `internal/agenttemplate/agenttemplate.go` (+test): register both builtins; a new test parses + validates every embedded builtin and asserts the `MetadataForDefinition` fallback matches the frontmatter.
- `skills/gitmoot/agent-templates/{review-panel,decompose-and-verify}.md` (new).
- `internal/cli/daemon.go` (+test): **engine fix** — a delegation child that inherits an empty HeadSHA from a PR-less local `orchestrate` (e.g. a verify/review follow-up) now runs against the current checkout HEAD instead of failing `validateTargetCheckout` with "no head SHA". Implement children still get worktrees; non-delegation jobs still require a HeadSHA.
- Docs (both trees): `WORKFLOWS.md`, `CLI.md`, `SKILL.md`, `README.md`, new `website/docs/workflows/coordinator-recipes-workflow.md` + sidebar + result-contract callout; regenerated `llms-full.txt`.

## Verification
- `go build/vet`, `go test ./...`, `go test -race ./internal/workflow/`, `website npm run build` — all green.
- `/code-review high --fix` — clean (template JSON validated against the contract).
- **Live codex E2E** (isolated `--home`):
  - `review-panel`: codex coordinator → 3 ephemeral reviewers ran **in parallel** → all succeeded → continuation synthesized a real verdict ("changes requested…").
  - `decompose-and-verify`: codex coordinator → valid ephemeral DAG → 2 implement legs ran **in parallel** and succeeded → verify step ran (the engine fix) → continuation synthesized.

## E2E-driven fixes (folded in)
- Dropped `review-panel`'s hard dependency on the `thermo-...` template (children failed "not installed" out-of-box); lens prompts are self-contained, thermo is now optional.
- Strengthened both recipes to require the `ephemeral` object and never invent agent names (codex had set `agent: "ephemeral-codex-..."`, blocking dispatch).
- The engine HeadSHA fix above (verify step previously failed "no head SHA").

## Note
A `decompose-and-verify` verify step reads the **shared checkout**, not an auto-merged combination of the parallel implement legs (each lands on its own branch); the recipe + continuation handle a resulting `changes_requested` by re-delegating. Documented in the recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
