### PR TITLE
feat(workflow): integrate parallel implement legs before a dependent verify step (#332)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2490,6 +2490,15 @@ func (w jobWorker) defaultCommenter(_ string) github.Client {
 	return github.NewClient("")
 }
 
+// The checkout-bound git client backs every per-delegation worktree role; assert
+// at compile time so the engine's runtime type-assertions can never silently fall
+// back (which would skip read-only-fanout or #332 integration worktrees).
+var (
+	_ workflow.WorktreeManager            = gitutil.Client{}
+	_ workflow.ReadOnlyWorktreeManager    = gitutil.Client{}
+	_ workflow.IntegrationWorktreeManager = gitutil.Client{}
+)
+
 func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, home string) workflow.Engine {
 	engine := workflow.Engine{
 		Store:                   store,

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2497,6 +2497,7 @@ var (
 	_ workflow.WorktreeManager            = gitutil.Client{}
 	_ workflow.ReadOnlyWorktreeManager    = gitutil.Client{}
 	_ workflow.IntegrationWorktreeManager = gitutil.Client{}
+	_ workflow.WorktreeCommitter          = gitutil.Client{}
 )
 
 func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, home string) workflow.Engine {

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -99,6 +99,34 @@ func (c Client) RemoveWorktreeForce(ctx context.Context, path string) error {
 	return err
 }
 
+// MergeBranches sequentially merges each branch into the worktree at dir (its
+// current HEAD). It is used to integrate the per-delegation branches of parallel
+// implement legs into one tree before a dependent verify/review step runs
+// (issue #332). Sequential (not octopus) so a conflict pinpoints the offending
+// branch; on conflict the in-progress merge is aborted and an error naming the
+// branch is returned, so the caller can block rather than auto-resolve.
+func (c Client) MergeBranches(ctx context.Context, dir string, branches []string, message string) error {
+	dir, err := validateWorktreePath(dir)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(message) == "" {
+		message = "Gitmoot integration merge"
+	}
+	git := Client{Dir: dir, Runner: c.Runner}
+	for _, branch := range branches {
+		if err := validateBranch(branch); err != nil {
+			return err
+		}
+		if _, err := git.run(ctx, "merge", "--no-edit", "-m", message, branch); err != nil {
+			// Leave the worktree clean for disposal even on failure.
+			_, _ = git.run(ctx, "merge", "--abort")
+			return fmt.Errorf("merge branch %q: %w", branch, err)
+		}
+	}
+	return nil
+}
+
 func (c Client) CurrentBranch(ctx context.Context) (string, error) {
 	result, err := c.run(ctx, "branch", "--show-current")
 	if err != nil {

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -127,6 +127,35 @@ func (c Client) MergeBranches(ctx context.Context, dir string, branches []string
 	return nil
 }
 
+// CommitWorktree stages everything in the worktree at dir and commits it to that
+// worktree's current branch, returning whether a commit was made. It lets an
+// implement delegation leg persist its work to its own branch on success — even
+// in a PR-less local orchestrate where the task/PR finalizer never runs — so a
+// dependent integration step (#332) has committed branches to merge. A clean
+// worktree (nothing to commit) returns (false, nil). Unlike CommitAll it targets
+// an explicit dir and is a no-op (not an error) when there is nothing to commit.
+func (c Client) CommitWorktree(ctx context.Context, dir string, message string) (bool, error) {
+	dir, err := validateWorktreePath(dir)
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(message) == "" {
+		message = "Gitmoot delegation commit"
+	}
+	git := Client{Dir: dir, Runner: c.Runner}
+	if _, err := git.run(ctx, "add", "-A"); err != nil {
+		return false, err
+	}
+	// `git diff --cached --quiet` exits 0 when nothing is staged.
+	if _, err := git.run(ctx, "diff", "--cached", "--quiet"); err == nil {
+		return false, nil
+	}
+	if _, err := git.run(ctx, "commit", "-m", message); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (c Client) CurrentBranch(ctx context.Context) (string, error) {
 	result, err := c.run(ctx, "branch", "--show-current")
 	if err != nil {

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -184,6 +184,83 @@ func TestClientRemoveWorktreeForceSmoke(t *testing.T) {
 	}
 }
 
+func TestClientMergeBranchesCommandConstruction(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{}, {}}}
+	client := Client{Runner: runner, Dir: "/repo"}
+	if err := client.MergeBranches(context.Background(), "/wt/integration", []string{"legA", "legB"}, "integrate"); err != nil {
+		t.Fatalf("MergeBranches returned error: %v", err)
+	}
+	runner.wantArgs(t, 0, "git", "merge", "--no-edit", "-m", "integrate", "legA")
+	runner.wantArgs(t, 1, "git", "merge", "--no-edit", "-m", "integrate", "legB")
+}
+
+func TestClientMergeBranchesAbortsAndNamesConflictingBranch(t *testing.T) {
+	runner := &fakeRunner{errs: []error{nil, errors.New("CONFLICT")}}
+	client := Client{Runner: runner, Dir: "/repo"}
+	err := client.MergeBranches(context.Background(), "/wt/integration", []string{"legA", "legB"}, "integrate")
+	if err == nil {
+		t.Fatal("expected error when a leg merge conflicts")
+	}
+	if !strings.Contains(err.Error(), "legB") {
+		t.Fatalf("error must name the conflicting branch: %v", err)
+	}
+	last := runner.calls[len(runner.calls)-1]
+	if len(last) < 3 || last[1] != "merge" || last[2] != "--abort" {
+		t.Fatalf("expected a 'merge --abort' after conflict, got %v", last)
+	}
+	if err := (Client{}).MergeBranches(context.Background(), " ", []string{"legA"}, "m"); err == nil {
+		t.Fatal("MergeBranches accepted an empty dir")
+	}
+	if err := (Client{Runner: &fakeRunner{}}).MergeBranches(context.Background(), "/wt", []string{"bad branch"}, "m"); err == nil {
+		t.Fatal("MergeBranches accepted an unsafe branch name")
+	}
+}
+
+func TestClientMergeBranchesSmoke(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, dir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# base\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "base")
+	// Two file-disjoint legs off main.
+	runGit(t, dir, "checkout", "-b", "legA")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("A\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile a.txt returned error: %v", err)
+	}
+	runGit(t, dir, "add", "a.txt")
+	runGit(t, dir, "commit", "-m", "legA")
+	runGit(t, dir, "checkout", "main")
+	runGit(t, dir, "checkout", "-b", "legB")
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("B\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile b.txt returned error: %v", err)
+	}
+	runGit(t, dir, "add", "b.txt")
+	runGit(t, dir, "commit", "-m", "legB")
+	runGit(t, dir, "checkout", "main")
+
+	client := Client{Dir: dir}
+	wt := filepath.Join(t.TempDir(), "integration")
+	if err := client.AddDetachedWorktree(context.Background(), wt, "main"); err != nil {
+		t.Fatalf("AddDetachedWorktree returned error: %v", err)
+	}
+	if err := client.MergeBranches(context.Background(), wt, []string{"legA", "legB"}, "integrate"); err != nil {
+		t.Fatalf("MergeBranches returned error: %v", err)
+	}
+	// The integration worktree must now contain BOTH legs' files.
+	for _, f := range []string{"a.txt", "b.txt"} {
+		if _, err := os.Stat(filepath.Join(wt, f)); err != nil {
+			t.Fatalf("%s missing from integration worktree after merge: %v", f, err)
+		}
+	}
+}
+
 func TestClientBranchExistsReturnsFalseForMissingBranch(t *testing.T) {
 	runner := &fakeRunner{errs: []error{errors.New("exit status 1")}}
 	exists, err := (Client{Runner: runner, Dir: "/repo"}).BranchExists(context.Background(), "missing")

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -261,6 +261,52 @@ func TestClientMergeBranchesSmoke(t *testing.T) {
 	}
 }
 
+func TestClientCommitWorktreeSmoke(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, dir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# base\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "base")
+
+	client := Client{Dir: dir}
+	// Clean worktree -> no commit.
+	committed, err := client.CommitWorktree(context.Background(), dir, "noop")
+	if err != nil {
+		t.Fatalf("CommitWorktree(clean) returned error: %v", err)
+	}
+	if committed {
+		t.Fatal("CommitWorktree reported a commit for a clean worktree")
+	}
+	// Edit -> commit.
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("work\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile feature.txt returned error: %v", err)
+	}
+	committed, err = client.CommitWorktree(context.Background(), dir, "add feature")
+	if err != nil {
+		t.Fatalf("CommitWorktree(edit) returned error: %v", err)
+	}
+	if !committed {
+		t.Fatal("CommitWorktree did not commit a dirty worktree")
+	}
+	clean, err := client.WorktreeClean(context.Background())
+	if err != nil {
+		t.Fatalf("WorktreeClean returned error: %v", err)
+	}
+	if !clean {
+		t.Fatal("worktree should be clean after CommitWorktree")
+	}
+	if _, err := (Client{}).CommitWorktree(context.Background(), " ", "m"); err == nil {
+		t.Fatal("CommitWorktree accepted an empty dir")
+	}
+}
+
 func TestClientBranchExistsReturnsFalseForMissingBranch(t *testing.T) {
 	runner := &fakeRunner{errs: []error{errors.New("exit status 1")}}
 	exists, err := (Client{Runner: runner, Dir: "/repo"}).BranchExists(context.Background(), "missing")

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -875,6 +875,51 @@ func (e Engine) enqueueDelegation(ctx context.Context, job db.Job, payload JobPa
 	return e.allocateAndEnqueueDelegation(ctx, job, payload, d, request, ref)
 }
 
+// integrationDepBranches returns the per-delegation branches of delegation d's
+// succeeded implement-leg dependencies, so a dependent read-only step (e.g. a
+// decompose-and-verify verify gate) can run against a worktree with those legs
+// merged in rather than the base checkout (issue #332). It returns nil when d has
+// no such deps, in which case the normal read-only paths apply. Read-only deps
+// contribute no branch (they produce no implementation), and a leg that ran in
+// the shared checkout (branch == parent base) is skipped (its work is already on
+// the base).
+func (e Engine) integrationDepBranches(ctx context.Context, job db.Job, payload JobPayload, d Delegation) ([]string, error) {
+	deps := compactStrings(d.Deps)
+	if len(deps) == 0 || payload.Result == nil {
+		return nil, nil
+	}
+	byID := make(map[string]Delegation, len(payload.Result.Delegations))
+	for _, sib := range payload.Result.Delegations {
+		byID[strings.TrimSpace(sib.ID)] = sib
+	}
+	base := strings.TrimSpace(payload.Branch)
+	var branches []string
+	for _, dep := range deps {
+		sib, ok := byID[dep]
+		if !ok || readOnlyDelegationAction(sib.Action) {
+			continue
+		}
+		legJob, err := e.Store.GetJob(ctx, job.ID+"/delegation/"+dep)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return nil, err
+		}
+		if legJob.State != string(JobSucceeded) {
+			continue
+		}
+		legPayload, err := unmarshalPayload(legJob.Payload)
+		if err != nil {
+			return nil, err
+		}
+		if legBranch := strings.TrimSpace(legPayload.Branch); legBranch != "" && legBranch != base {
+			branches = append(branches, legBranch)
+		}
+	}
+	return branches, nil
+}
+
 // allocateAndEnqueueDelegation allocates the per-delegation worktree (or branch
 // lock) for implement delegations and enqueues the prepared request, recording a
 // delegation_enqueued event. It is shared by enqueueDelegation (initial/deferred
@@ -924,6 +969,46 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 			// inherited HeadSHA so the child validates against its own fresh
 			// worktree HEAD instead of a stale parent SHA.
 			request.HeadSHA = ""
+		}
+	} else if legBranches, err := e.integrationDepBranches(ctx, job, payload, d); err != nil {
+		return err
+	} else if len(legBranches) > 0 {
+		// This read-only delegation (e.g. a decompose-and-verify verify gate) depends
+		// on succeeded implement legs that each live on their own branch. Merge them
+		// into one detached worktree so the dependent sees the combined work instead
+		// of the base checkout (#332).
+		if manager, ok := e.DelegationWorktrees.(IntegrationWorktreeManager); !ok || strings.TrimSpace(e.Home) == "" {
+			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   job.ID,
+				Kind:    "delegation_worktree_skipped",
+				Message: fmt.Sprintf("delegation %q runs against the base checkout: integration worktree unavailable", request.DelegationID),
+			})
+		} else {
+			path, err := e.AllocateIntegrationWorktree(ctx, DelegationWorktreeRequest{
+				Home:         e.Home,
+				Repo:         request.Repo,
+				ParentJobID:  job.ID,
+				DelegationID: request.DelegationID,
+				BaseBranch:   payload.Branch,
+				Checkout:     e.DelegationCheckout,
+				RetryAttempt: request.RetryCount,
+			}, legBranches, manager)
+			if err != nil {
+				var blocked BlockedError
+				if errors.As(err, &blocked) {
+					return e.block(ctx, ref, blocked.Reason)
+				}
+				return err
+			}
+			request.WorktreePath = path
+			// Validate against the integration worktree's own HEAD, not the inherited
+			// parent HeadSHA (see isDelegationWorktreeChild).
+			request.HeadSHA = ""
+			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   job.ID,
+				Kind:    "delegation_integrated",
+				Message: fmt.Sprintf("delegation %q runs in an integration worktree merging %d implement leg(s)", request.DelegationID, len(legBranches)),
+			})
 		}
 	} else if readOnlyFanoutNeedsWorktree(payload, d) {
 		// Read-only fan-out: >=2 read-only siblings share the parent repo and would

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -892,6 +892,13 @@ func (e Engine) integrationDepBranches(ctx context.Context, job db.Job, payload 
 	for _, sib := range payload.Result.Delegations {
 		byID[strings.TrimSpace(sib.ID)] = sib
 	}
+	// Resolve each dep to its winning child job the same way advanceDelegations
+	// does (latest attempt per delegation id), so a leg that succeeded on a retry
+	// contributes its retry branch rather than the failed original.
+	children, err := e.childDelegationJobs(ctx, job.ID)
+	if err != nil {
+		return nil, err
+	}
 	base := strings.TrimSpace(payload.Branch)
 	var branches []string
 	for _, dep := range deps {
@@ -899,14 +906,8 @@ func (e Engine) integrationDepBranches(ctx context.Context, job db.Job, payload 
 		if !ok || readOnlyDelegationAction(sib.Action) {
 			continue
 		}
-		legJob, err := e.Store.GetJob(ctx, job.ID+"/delegation/"+dep)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				continue
-			}
-			return nil, err
-		}
-		if legJob.State != string(JobSucceeded) {
+		legJob, ok := children[dep]
+		if !ok || legJob.State != string(JobSucceeded) {
 			continue
 		}
 		legPayload, err := unmarshalPayload(legJob.Payload)

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -334,6 +334,18 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 	// pending retries). No-op for jobs that did not allocate a read-only worktree.
 	defer e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload)
 
+	// Commit a succeeded implement leg's work to its own branch BEFORE advancing
+	// the parent's delegation DAG. The parent advance below may enqueue a dependent
+	// that integrates this leg (#332); if the commit ran later (in the switch), the
+	// leg that *triggered* the integration would not yet be on its branch and its
+	// work would be missing from the merge. The task/PR finalizer path commits its
+	// own way, so this only covers PR-less delegation legs; it is a no-op otherwise.
+	if job.Type == "implement" && payload.Result.Decision == "implemented" && !e.implementationNeedsFinalizer(ctx, payload) {
+		if err := e.commitDelegationLeg(ctx, job, payload); err != nil {
+			return err
+		}
+	}
+
 	// When a delegated child job finishes, advance its parent's delegation DAG
 	// before running the child's own advancement: enqueue any now-ready
 	// dependent siblings, apply the failed delegation's failure_policy, and
@@ -424,8 +436,6 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 				return err
 			}
 			payload = finalized
-		} else if err := e.commitDelegationLeg(ctx, job, payload); err != nil {
-			return err
 		}
 		if payload.PullRequest <= 0 {
 			return e.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_skipped_no_pr", Message: "no pull request is attached; skipping PR advancement"})

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -424,6 +424,8 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 				return err
 			}
 			payload = finalized
+		} else if err := e.commitDelegationLeg(ctx, job, payload); err != nil {
+			return err
 		}
 		if payload.PullRequest <= 0 {
 			return e.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_skipped_no_pr", Message: "no pull request is attached; skipping PR advancement"})
@@ -919,6 +921,34 @@ func (e Engine) integrationDepBranches(ctx context.Context, job db.Job, payload 
 		}
 	}
 	return branches, nil
+}
+
+// commitDelegationLeg commits an implement delegation leg's worktree changes to
+// its own branch when the leg has its own per-delegation worktree but no task/PR
+// finalizer (a PR-less local orchestrate, where the finalizer never runs and the
+// edits would otherwise stay uncommitted). This makes the leg's work available on
+// its branch for a dependent integration step (#332). It is a no-op for jobs with
+// no delegation worktree, a clean worktree, or a manager that cannot commit.
+func (e Engine) commitDelegationLeg(ctx context.Context, job db.Job, payload JobPayload) error {
+	if strings.TrimSpace(payload.DelegationID) == "" || strings.TrimSpace(payload.WorktreePath) == "" {
+		return nil
+	}
+	committer, ok := e.DelegationWorktrees.(WorktreeCommitter)
+	if !ok {
+		return nil
+	}
+	committed, err := committer.CommitWorktree(ctx, payload.WorktreePath, fmt.Sprintf("Gitmoot delegation %s implementation", payload.DelegationID))
+	if err != nil {
+		return err
+	}
+	if committed {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_committed",
+			Message: fmt.Sprintf("delegation %q committed its implementation to branch %s", payload.DelegationID, payload.Branch),
+		})
+	}
+	return nil
 }
 
 // allocateAndEnqueueDelegation allocates the per-delegation worktree (or branch

--- a/internal/workflow/integration_worktree_test.go
+++ b/internal/workflow/integration_worktree_test.go
@@ -1,0 +1,177 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestAllocateIntegrationWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	home := t.TempDir()
+	checkout := t.TempDir()
+	key, err := checkoutMutationLockKey(checkout)
+	if err != nil {
+		t.Fatalf("checkoutMutationLockKey returned error: %v", err)
+	}
+	manager := &fakeWorktreeManager{}
+
+	path, err := engine.AllocateIntegrationWorktree(ctx, DelegationWorktreeRequest{
+		Home:         home,
+		Repo:         "owner/repo",
+		ParentJobID:  "job-1",
+		DelegationID: "verify",
+		BaseBranch:   "main",
+		Checkout:     checkout,
+	}, []string{"branchA", "branchB"}, manager)
+	if err != nil {
+		t.Fatalf("AllocateIntegrationWorktree returned error: %v", err)
+	}
+	wantPath := filepath.Join(home, "worktrees", "owner--repo", "delegations", "job-1", "integration-verify")
+	if path != wantPath {
+		t.Fatalf("path = %q, want %q", path, wantPath)
+	}
+	if len(manager.detachedCalls) != 1 || manager.detachedCalls[0].path != wantPath || manager.detachedCalls[0].base != "main" {
+		t.Fatalf("detached calls = %+v, want one detached worktree at %q off main", manager.detachedCalls, wantPath)
+	}
+	if len(manager.mergeCalls) != 1 || manager.mergeCalls[0].dir != wantPath || !reflect.DeepEqual(manager.mergeCalls[0].branches, []string{"branchA", "branchB"}) {
+		t.Fatalf("merge calls = %+v, want one merge of [branchA branchB] in %q", manager.mergeCalls, wantPath)
+	}
+	// No branch lock is created (detached), and the checkout mutation lock is released.
+	if _, err := store.GetResourceLock(ctx, key); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("checkout lock after integration err = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestAllocateIntegrationWorktreeBlocksOnMergeConflict(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	manager := &fakeWorktreeManager{mergeErr: errors.New("CONFLICT (content): file.txt")}
+
+	_, err := engine.AllocateIntegrationWorktree(ctx, DelegationWorktreeRequest{
+		Home:         t.TempDir(),
+		Repo:         "owner/repo",
+		ParentJobID:  "job-1",
+		DelegationID: "verify",
+		BaseBranch:   "main",
+		Checkout:     t.TempDir(),
+	}, []string{"branchA", "branchB"}, manager)
+	if err == nil {
+		t.Fatal("AllocateIntegrationWorktree accepted a conflicting merge")
+	}
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("error = %v, want BlockedError so the parent blocks rather than auto-resolving", err)
+	}
+
+	// Empty leg branches is a programming error, not a block.
+	if _, err := engine.AllocateIntegrationWorktree(ctx, DelegationWorktreeRequest{
+		Home: t.TempDir(), Repo: "owner/repo", ParentJobID: "job-1", DelegationID: "verify", Checkout: t.TempDir(),
+	}, nil, manager); err == nil {
+		t.Fatal("AllocateIntegrationWorktree accepted zero leg branches")
+	}
+}
+
+func TestIntegrationDepBranches(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+
+	// Two succeeded implement legs (distinct branches), one succeeded read-only dep
+	// (no branch), and one implement leg that ran in the shared checkout (branch ==
+	// base, so it is already on base and skipped).
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legA", Agent: "builder", Type: "implement"},
+		JobPayload{Repo: "owner/repo", Branch: "branchA", DelegationID: "legA"})
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legB", Agent: "builder", Type: "implement"},
+		JobPayload{Repo: "owner/repo", Branch: "branchB", DelegationID: "legB"})
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/note", Agent: "noter", Type: "ask"},
+		JobPayload{Repo: "owner/repo", Branch: "task-x", DelegationID: "note"})
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legBase", Agent: "builder", Type: "implement"},
+		JobPayload{Repo: "owner/repo", Branch: "task-x", DelegationID: "legBase"})
+
+	parentJob := db.Job{ID: "p", Agent: "coord", Type: "ask"}
+	parentPayload := JobPayload{
+		Repo:   "owner/repo",
+		Branch: "task-x",
+		Result: &AgentResult{Delegations: []Delegation{
+			{ID: "legA", Action: "implement"},
+			{ID: "legB", Action: "implement"},
+			{ID: "note", Action: "ask"},
+			{ID: "legBase", Action: "implement"},
+		}},
+	}
+	verify := Delegation{ID: "verify", Action: "review", Deps: []string{"legA", "legB", "note", "legBase"}}
+
+	branches, err := engine.integrationDepBranches(ctx, parentJob, parentPayload, verify)
+	if err != nil {
+		t.Fatalf("integrationDepBranches returned error: %v", err)
+	}
+	if !reflect.DeepEqual(branches, []string{"branchA", "branchB"}) {
+		t.Fatalf("branches = %v, want [branchA branchB] (read-only and base-branch deps skipped)", branches)
+	}
+
+	// A delegation with no deps yields no integration.
+	none, err := engine.integrationDepBranches(ctx, parentJob, parentPayload, Delegation{ID: "x", Action: "review"})
+	if err != nil {
+		t.Fatalf("integrationDepBranches(no deps) returned error: %v", err)
+	}
+	if none != nil {
+		t.Fatalf("no-deps delegation = %v, want nil", none)
+	}
+}
+
+func TestAllocateAndEnqueueDelegationRoutesVerifyToIntegrationWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	home := t.TempDir()
+	manager := &fakeWorktreeManager{}
+	engine := testEngine(store)
+	engine.Home = home
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legA", Agent: "builder", Type: "implement"},
+		JobPayload{Repo: "owner/repo", Branch: "branchA", DelegationID: "legA"})
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legB", Agent: "builder", Type: "implement"},
+		JobPayload{Repo: "owner/repo", Branch: "branchB", DelegationID: "legB"})
+
+	parentJob := db.Job{ID: "p", Agent: "coord", Type: "ask"}
+	parentPayload := JobPayload{
+		Repo:   "owner/repo",
+		Branch: "task-x",
+		Result: &AgentResult{Delegations: []Delegation{
+			{ID: "legA", Action: "implement"},
+			{ID: "legB", Action: "implement"},
+			{ID: "verify", Action: "review", Deps: []string{"legA", "legB"}},
+		}},
+	}
+	verify := Delegation{ID: "verify", Agent: "checker", Action: "review", Prompt: "verify the combined work", Deps: []string{"legA", "legB"}}
+	request := engine.delegationRequest(parentJob, parentPayload, verify)
+
+	if err := engine.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, verify, request, taskRefFromPayload(parentPayload)); err != nil {
+		t.Fatalf("allocateAndEnqueueDelegation returned error: %v", err)
+	}
+
+	child, err := unmarshalPayload(mustJob(t, store, "p/delegation/verify").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	wantPath := filepath.Join(home, "worktrees", "owner--repo", "delegations", "p", "integration-verify")
+	if child.WorktreePath != wantPath {
+		t.Fatalf("verify worktree path = %q, want integration worktree %q", child.WorktreePath, wantPath)
+	}
+	if child.HeadSHA != "" {
+		t.Fatalf("verify HeadSHA = %q, want cleared", child.HeadSHA)
+	}
+	if len(manager.mergeCalls) != 1 || !reflect.DeepEqual(manager.mergeCalls[0].branches, []string{"branchA", "branchB"}) {
+		t.Fatalf("merge calls = %+v, want one merge of the two leg branches", manager.mergeCalls)
+	}
+}

--- a/internal/workflow/integration_worktree_test.go
+++ b/internal/workflow/integration_worktree_test.go
@@ -88,13 +88,13 @@ func TestIntegrationDepBranches(t *testing.T) {
 	// Two succeeded implement legs (distinct branches), one succeeded read-only dep
 	// (no branch), and one implement leg that ran in the shared checkout (branch ==
 	// base, so it is already on base and skipped).
-	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legA", Agent: "builder", Type: "implement"},
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legA", Agent: "builder", Type: "implement", ParentJobID: "p", DelegationID: "legA"},
 		JobPayload{Repo: "owner/repo", Branch: "branchA", DelegationID: "legA"})
-	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legB", Agent: "builder", Type: "implement"},
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legB", Agent: "builder", Type: "implement", ParentJobID: "p", DelegationID: "legB"},
 		JobPayload{Repo: "owner/repo", Branch: "branchB", DelegationID: "legB"})
-	insertCompletedJob(t, store, db.Job{ID: "p/delegation/note", Agent: "noter", Type: "ask"},
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/note", Agent: "noter", Type: "ask", ParentJobID: "p", DelegationID: "note"},
 		JobPayload{Repo: "owner/repo", Branch: "task-x", DelegationID: "note"})
-	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legBase", Agent: "builder", Type: "implement"},
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legBase", Agent: "builder", Type: "implement", ParentJobID: "p", DelegationID: "legBase"},
 		JobPayload{Repo: "owner/repo", Branch: "task-x", DelegationID: "legBase"})
 
 	parentJob := db.Job{ID: "p", Agent: "coord", Type: "ask"}
@@ -138,9 +138,9 @@ func TestAllocateAndEnqueueDelegationRoutesVerifyToIntegrationWorktree(t *testin
 	engine.DelegationCheckout = t.TempDir()
 	engine.DelegationWorktrees = manager
 
-	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legA", Agent: "builder", Type: "implement"},
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legA", Agent: "builder", Type: "implement", ParentJobID: "p", DelegationID: "legA"},
 		JobPayload{Repo: "owner/repo", Branch: "branchA", DelegationID: "legA"})
-	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legB", Agent: "builder", Type: "implement"},
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legB", Agent: "builder", Type: "implement", ParentJobID: "p", DelegationID: "legB"},
 		JobPayload{Repo: "owner/repo", Branch: "branchB", DelegationID: "legB"})
 
 	parentJob := db.Job{ID: "p", Agent: "coord", Type: "ask"}

--- a/internal/workflow/integration_worktree_test.go
+++ b/internal/workflow/integration_worktree_test.go
@@ -128,6 +128,44 @@ func TestIntegrationDepBranches(t *testing.T) {
 	}
 }
 
+func TestCommitDelegationLeg(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	manager := &fakeWorktreeManager{commitMade: true}
+	engine.DelegationWorktrees = manager
+
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legA", ParentJobID: "p", DelegationID: "legA", Type: "implement"},
+		JobPayload{Repo: "owner/repo", Branch: "branchA", DelegationID: "legA", WorktreePath: "/wt/legA"})
+	job := mustJob(t, store, "p/delegation/legA")
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+
+	if err := engine.commitDelegationLeg(ctx, job, payload); err != nil {
+		t.Fatalf("commitDelegationLeg returned error: %v", err)
+	}
+	if len(manager.committedDirs) != 1 || manager.committedDirs[0] != "/wt/legA" {
+		t.Fatalf("committedDirs = %v, want [/wt/legA]", manager.committedDirs)
+	}
+	if got := countJobEvents(t, store, "p/delegation/legA", "delegation_committed"); got != 1 {
+		t.Fatalf("delegation_committed events = %d, want 1", got)
+	}
+
+	// No-op for a job without a delegation worktree.
+	manager.committedDirs = nil
+	if err := engine.commitDelegationLeg(ctx, db.Job{ID: "x"}, JobPayload{WorktreePath: "/wt/x"}); err != nil {
+		t.Fatalf("commitDelegationLeg(non-delegation) returned error: %v", err)
+	}
+	if err := engine.commitDelegationLeg(ctx, db.Job{ID: "y", DelegationID: "y"}, JobPayload{DelegationID: "y"}); err != nil {
+		t.Fatalf("commitDelegationLeg(no worktree) returned error: %v", err)
+	}
+	if len(manager.committedDirs) != 0 {
+		t.Fatalf("commit must be a no-op without a delegation worktree: %v", manager.committedDirs)
+	}
+}
+
 func TestAllocateAndEnqueueDelegationRoutesVerifyToIntegrationWorktree(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -308,9 +308,7 @@ func (e Engine) AllocateReadOnlyDelegationWorktree(ctx context.Context, request 
 // the dependent's own id, carries no branch/branch lock, and is disposed by the
 // same read-only cleanup as fan-out worktrees. A merge conflict means the
 // decomposition was not actually file-disjoint: it is returned as a BlockedError
-// so the caller blocks the parent rather than auto-resolving. It is idempotent —
-// an existing worktree is reused and the (already-merged) branches re-merge as
-// no-ops.
+// so the caller blocks the parent rather than auto-resolving.
 func (e Engine) AllocateIntegrationWorktree(ctx context.Context, request DelegationWorktreeRequest, legBranches []string, manager IntegrationWorktreeManager) (string, error) {
 	if err := e.validate(); err != nil {
 		return "", err
@@ -345,12 +343,11 @@ func (e Engine) AllocateIntegrationWorktree(ctx context.Context, request Delegat
 			_ = releaseCheckoutLock(context.Background())
 		}
 	}()
-	// Idempotent: reuse an existing integration worktree (e.g. a re-run of the same
-	// dispatch attempt); the merge below re-runs as a no-op for already-merged legs.
-	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-		if err := manager.AddDetachedWorktree(ctx, path, ref); err != nil {
-			return "", err
-		}
+	// A delegation is dispatched once (advanceDelegations skips already-enqueued
+	// dependents; retries use a retry-suffixed path), so allocate a fresh detached
+	// worktree like the implement and read-only paths rather than reusing one.
+	if err := manager.AddDetachedWorktree(ctx, path, ref); err != nil {
+		return "", err
 	}
 	msg := "Gitmoot integration merge for delegation " + request.DelegationID
 	if err := manager.MergeBranches(ctx, path, legBranches, msg); err != nil {

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -37,6 +37,16 @@ type ReadOnlyWorktreeManager interface {
 	RemoveWorktreeForce(ctx context.Context, path string) error
 }
 
+// IntegrationWorktreeManager builds a detached worktree off the parent base and
+// merges the per-delegation branches of succeeded implement legs into it, so a
+// dependent verify/review step sees the legs' combined work instead of the base
+// checkout (issue #332). The detached worktree carries no branch and no branch
+// lock, so it is disposed by the same read-only cleanup as fan-out worktrees.
+type IntegrationWorktreeManager interface {
+	AddDetachedWorktree(ctx context.Context, path string, ref string) error
+	MergeBranches(ctx context.Context, dir string, branches []string, message string) error
+}
+
 type TaskWorktreeRequest struct {
 	Home       string
 	Repo       string
@@ -286,6 +296,65 @@ func (e Engine) AllocateReadOnlyDelegationWorktree(ctx context.Context, request 
 	}()
 	if err := manager.AddDetachedWorktree(ctx, path, ref); err != nil {
 		return "", err
+	}
+	return path, nil
+}
+
+// AllocateIntegrationWorktree creates a detached worktree off the parent base
+// branch and sequentially merges the given succeeded implement-leg branches into
+// it, so a dependent read-only step (a decompose-and-verify verify gate) sees the
+// legs' combined work rather than the base checkout (issue #332). The worktree is
+// keyed on a synthetic "integration-<delegation-id>" so it never collides with
+// the dependent's own id, carries no branch/branch lock, and is disposed by the
+// same read-only cleanup as fan-out worktrees. A merge conflict means the
+// decomposition was not actually file-disjoint: it is returned as a BlockedError
+// so the caller blocks the parent rather than auto-resolving. It is idempotent —
+// an existing worktree is reused and the (already-merged) branches re-merge as
+// no-ops.
+func (e Engine) AllocateIntegrationWorktree(ctx context.Context, request DelegationWorktreeRequest, legBranches []string, manager IntegrationWorktreeManager) (string, error) {
+	if err := e.validate(); err != nil {
+		return "", err
+	}
+	if manager == nil {
+		return "", errors.New("integration worktree manager is required")
+	}
+	if strings.TrimSpace(request.ParentJobID) == "" {
+		return "", errors.New("delegation worktree parent job id is required")
+	}
+	if strings.TrimSpace(request.DelegationID) == "" {
+		return "", errors.New("delegation worktree delegation id is required")
+	}
+	if len(legBranches) == 0 {
+		return "", errors.New("integration worktree requires at least one leg branch")
+	}
+	integrationID := "integration-" + request.DelegationID
+	path, err := DelegationWorktreePath(request.Home, request.Repo, request.ParentJobID, integrationID, request.RetryAttempt)
+	if err != nil {
+		return "", err
+	}
+	ref := strings.TrimSpace(request.BaseBranch)
+	if ref == "" {
+		ref = "HEAD"
+	}
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(ctx, e.Store, request.Checkout, "worktree:"+request.ParentJobID+"/"+integrationID, time.Now().UTC())
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if releaseCheckoutLock != nil {
+			_ = releaseCheckoutLock(context.Background())
+		}
+	}()
+	// Idempotent: reuse an existing integration worktree (e.g. a re-run of the same
+	// dispatch attempt); the merge below re-runs as a no-op for already-merged legs.
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		if err := manager.AddDetachedWorktree(ctx, path, ref); err != nil {
+			return "", err
+		}
+	}
+	msg := "Gitmoot integration merge for delegation " + request.DelegationID
+	if err := manager.MergeBranches(ctx, path, legBranches, msg); err != nil {
+		return "", BlockedError{Reason: fmt.Sprintf("integration merge for delegation %q failed (decomposition is not file-disjoint): %v", request.DelegationID, err)}
 	}
 	return path, nil
 }

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -47,6 +47,14 @@ type IntegrationWorktreeManager interface {
 	MergeBranches(ctx context.Context, dir string, branches []string, message string) error
 }
 
+// WorktreeCommitter commits an implement delegation leg's work to its own branch
+// on success, so the leg's changes are available on its branch for a dependent
+// integration step (#332) even in a PR-less local orchestrate where the task/PR
+// finalizer never runs. The checkout-bound gitutil.Client satisfies it.
+type WorktreeCommitter interface {
+	CommitWorktree(ctx context.Context, dir string, message string) (bool, error)
+}
+
 type TaskWorktreeRequest struct {
 	Home       string
 	Repo       string

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -623,6 +623,13 @@ type fakeWorktreeManager struct {
 	detachedCalls    []worktreeCall // AddDetachedWorktree: path in .path, ref in .base
 	removedForce     []string       // RemoveWorktreeForce paths
 	removeErr        error
+	mergeCalls       []mergeCall // MergeBranches calls
+	mergeErr         error
+}
+
+type mergeCall struct {
+	dir      string
+	branches []string
 }
 
 type worktreeCall struct {
@@ -657,6 +664,11 @@ func (f *fakeWorktreeManager) AddDetachedWorktree(_ context.Context, path string
 	}
 	f.detachedCalls = append(f.detachedCalls, worktreeCall{path: path, base: ref})
 	return f.err
+}
+
+func (f *fakeWorktreeManager) MergeBranches(_ context.Context, dir string, branches []string, _ string) error {
+	f.mergeCalls = append(f.mergeCalls, mergeCall{dir: dir, branches: branches})
+	return f.mergeErr
 }
 
 func (f *fakeWorktreeManager) RemoveWorktreeForce(_ context.Context, path string) error {

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -625,6 +625,9 @@ type fakeWorktreeManager struct {
 	removeErr        error
 	mergeCalls       []mergeCall // MergeBranches calls
 	mergeErr         error
+	committedDirs    []string // CommitWorktree dirs
+	commitMade       bool     // value CommitWorktree returns for "committed"
+	commitErr        error
 }
 
 type mergeCall struct {
@@ -669,6 +672,11 @@ func (f *fakeWorktreeManager) AddDetachedWorktree(_ context.Context, path string
 func (f *fakeWorktreeManager) MergeBranches(_ context.Context, dir string, branches []string, _ string) error {
 	f.mergeCalls = append(f.mergeCalls, mergeCall{dir: dir, branches: branches})
 	return f.mergeErr
+}
+
+func (f *fakeWorktreeManager) CommitWorktree(_ context.Context, dir string, _ string) (bool, error) {
+	f.committedDirs = append(f.committedDirs, dir)
+	return f.commitMade, f.commitErr
 }
 
 func (f *fakeWorktreeManager) RemoveWorktreeForce(_ context.Context, path string) error {

--- a/skills/gitmoot/agent-templates/decompose-and-verify.md
+++ b/skills/gitmoot/agent-templates/decompose-and-verify.md
@@ -53,10 +53,12 @@ gitmoot orchestrate decompose-and-verify "Implement the export feature described
    precise prompt naming the files it owns and its acceptance.
 3. Create one verify step as a review-action ephemeral worker whose deps list
    every implementation delegation id. Set synthesis_rule summary on it. Each
-   implementation leg lands on its own branch/worktree, so the verify step reads
-   the shared checkout, not an auto-merged combination of the legs; if it reports
-   the legs' work as missing, that is the cue for the continuation to integrate or
-   re-delegate (handled below), not a leg failure.
+   implementation leg lands on its own branch; Gitmoot automatically merges the
+   succeeded legs into one integration worktree before this verify step runs, so
+   the verify sees the legs' combined work. If two legs touched the same files the
+   merge conflicts (the decomposition was not file-disjoint) and the parent is
+   blocked with the offending leg named, rather than running verify on a partial
+   tree.
 4. Pick runtimes per leg; a stronger model for the verify gate is reasonable.
    Ephemeral workers are leaf-only.
 5. Every leg here is ephemeral. On each delegation set the `ephemeral` object

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -127,8 +127,12 @@ Sibling children that share the repo run in isolated git worktrees so they do
 not serialize on the shared checkout: `implement` children each get their own
 branch worktree, and when a coordinator fans out **two or more read-only**
 (`ask`/`review`) children, each gets a throwaway detached worktree (no branch).
-The worktrees are disposed automatically when each child finishes. This is
-internal scheduling — coordinators do not request it.
+A read-only child that **`deps` on `implement` legs** (e.g. a decompose-and-verify
+verify gate) runs in a detached worktree with those legs' branches **merged in**,
+so it sees their combined work rather than the base checkout; if the legs are not
+file-disjoint the merge conflicts and the parent is blocked. The worktrees are
+disposed automatically when each child finishes. This is internal scheduling —
+coordinators do not request it.
 
 Each child job carries `parent_job_id`, `delegation_id`, `root_job_id`,
 `delegation_depth`, and `task_id`, so a child can be traced to its parent, its

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -179,8 +179,12 @@ Sibling children that share the repo run in isolated git worktrees so they do
 not serialize on the shared checkout: `implement` children each get their own
 branch worktree, and when a coordinator fans out two or more read-only
 (`ask`/`review`) children, each gets a throwaway detached worktree (no branch),
-disposed automatically when the child finishes. This is internal scheduling —
-coordinators do not request it.
+disposed automatically when the child finishes. A read-only child that `deps` on
+`implement` legs (e.g. a decompose-and-verify verify gate) runs in a detached
+worktree with those legs' branches merged in, so it sees their combined work
+rather than the base checkout; if the legs are not file-disjoint the merge
+conflicts and the parent is blocked. This is internal scheduling — coordinators
+do not request it.
 
 Once every top-level delegation reaches a terminal state, Gitmoot enqueues
 exactly one coordinator "continuation" job, sent back to the delegating agent, to

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6626,8 +6626,12 @@ Sibling children that share the repo run in isolated git worktrees so they do
 not serialize on the shared checkout: `implement` children each get their own
 branch worktree, and when a coordinator fans out **two or more read-only**
 (`ask`/`review`) children, each gets a throwaway detached worktree (no branch).
-The worktrees are disposed automatically when each child finishes. This is
-internal scheduling — coordinators do not request it.
+A read-only child that **`deps` on `implement` legs** (e.g. a decompose-and-verify
+verify gate) runs in a detached worktree with those legs' branches **merged in**,
+so it sees their combined work rather than the base checkout; if the legs are not
+file-disjoint the merge conflicts and the parent is blocked. The worktrees are
+disposed automatically when each child finishes. This is internal scheduling —
+coordinators do not request it.
 
 Each child job carries `parent_job_id`, `delegation_id`, `root_job_id`,
 `delegation_depth`, and `task_id`, so a child can be traced to its parent, its


### PR DESCRIPTION
Fixes #332.

## Summary
Make a dependent verify/review step see the **combined** work of parallel implement legs. Three coordinated changes (all additive):

1. **Integrate before verify** — when a read-only delegation `deps` on succeeded `implement` legs, the engine builds a **detached integration worktree** off the parent base, **sequentially merges** the leg branches into it (conflict → `BlockedError` naming the leg → parent blocks; never auto-resolves), and points the dependent there. Reuses the #328/#329 detached-worktree machinery (no branch/lock; same read-only cleanup) and the #310 HeadSHA handling.
2. **Legs commit their work** — in a PR-less local `orchestrate` the task/PR finalizer never runs (`advance_skipped_no_pr`), so an implement leg's edits stayed uncommitted and its branch was empty. An implement delegation leg with its own worktree but no finalizer now commits to its branch on success (`gitutil.CommitWorktree`).
3. **Commit ordering** — the leg commit runs **before** `advanceDelegations`, so the leg whose completion *triggers* the integration is already on its branch when the merge runs.

## Changes
- `internal/git/client.go`: `MergeBranches` (sequential, abort+name on conflict), `CommitWorktree` (stage+commit a worktree dir, no-op when clean).
- `internal/workflow/worktree.go`: `IntegrationWorktreeManager` + `AllocateIntegrationWorktree`; `WorktreeCommitter`.
- `internal/workflow/engine.go`: `integrationDepBranches` (retry-aware via `childDelegationJobs`), the integration branch in `allocateAndEnqueueDelegation`, `commitDelegationLeg`, and the pre-advance leg commit in `AdvanceJob`.
- `internal/cli/daemon.go`: compile-time interface assertions for `gitutil.Client`.
- docs (both trees): decompose-and-verify recipe + RESULT_CONTRACT now describe the integration worktree.

## Verification
- `go build/vet`, `go test ./...`, `go test -race ./internal/workflow/`, `website npm run build` — all green.
- `/code-review high --fix` — applied (retry-aware leg resolution; dropped a redundant idempotency guard; docs sync).
- **Live codex E2E** (isolated `--home`): `gitmoot orchestrate decompose-and-verify` → 2 implement legs ran in parallel, **committed** to their branches → integration worktree **merged both** (`delegation_integrated`) → verify ran there and returned **approved** ("README.md has the comment at line 5 AND AGENTS.md at line 2; working tree clean") → continuation **implemented**. The earlier runs (pre-fix) reproduced each gap in turn ("no head SHA" → fixed; legs uncommitted → fixed; last-leg-not-committed-at-integration → fixed by the ordering change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
