### PR TITLE
fix(cli): resolve registered checkout for daemon start --repo (#202)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -296,11 +296,14 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    gitmoot daemon start --repo owner/project --poll 30s
    ```
 
-   The daemon validates that the current checkout's `origin` remote matches
-   `--repo`. `agent start --start-daemon` runs this same background start path
-   for the selected checkout. Use `gitmoot daemon start` without `--repo` after
-   registering all intended repos if one daemon should supervise the whole
-   Gitmoot home.
+   When `--repo` names a repo that is already registered, the daemon resolves
+   its registered checkout, so `gitmoot daemon start --repo owner/project` works
+   from any directory. For a repo that is not yet registered, run the command
+   from the matching checkout (the daemon validates the current checkout's
+   `origin` remote against `--repo` to bootstrap it). `agent start
+   --start-daemon` runs this same background start path for the selected
+   checkout. Use `gitmoot daemon start` without `--repo` after registering all
+   intended repos if one daemon should supervise the whole Gitmoot home.
 
    Gitmoot records agent autonomy policy as `read-only`, `workspace-write`,
    `danger-full-access`, or `auto`. For Codex these map to Codex sandbox

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -175,7 +175,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	}
 
 	err = withStore(*home, func(store *db.Store) error {
-		repoRecord, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: "."})
+		repoRecord, err := resolveDaemonStartRepo(ctx, store, repo, ".")
 		if err != nil {
 			return err
 		}
@@ -503,7 +503,7 @@ func daemonWorkDir(workDir string) (string, error) {
 
 func preflightDaemonRepoStart(ctx context.Context, home string, repo github.Repository, pollInterval string, workDir string) error {
 	return withStore(home, func(store *db.Store) error {
-		repoRecord, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: workDir})
+		repoRecord, err := resolveDaemonStartRepo(ctx, store, repo, workDir)
 		if err != nil {
 			return err
 		}
@@ -3312,6 +3312,28 @@ func resolveDaemonCheckout(ctx context.Context, repo github.Repository, client g
 		return "", err
 	}
 	return record.CheckoutPath, nil
+}
+
+// resolveDaemonStartRepo resolves the repo record that `daemon start/run --repo
+// owner/repo` should run against. When the repo is already registered with a
+// checkout path, it resolves against that REGISTERED checkout so the command
+// works from any working directory (#202) — origin protection is still enforced,
+// just against the registered checkout rather than the cwd. When the repo is not
+// yet registered (or has no checkout path), it bootstraps from workDir (the
+// current checkout), preserving the original behavior for first-time setup.
+func resolveDaemonStartRepo(ctx context.Context, store *db.Store, repo github.Repository, workDir string) (db.Repo, error) {
+	existing, err := store.GetRepo(ctx, repo.FullName())
+	switch {
+	case err == nil && strings.TrimSpace(existing.CheckoutPath) != "":
+		record, rerr := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: existing.CheckoutPath})
+		if rerr != nil {
+			return db.Repo{}, fmt.Errorf("registered checkout for %s at %s is unusable (re-register with `gitmoot repo add`): %w", repo.FullName(), existing.CheckoutPath, rerr)
+		}
+		return record, nil
+	case err != nil && !errors.Is(err, sql.ErrNoRows):
+		return db.Repo{}, err
+	}
+	return repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: workDir})
 }
 
 func repoRecordForCheckout(ctx context.Context, repo github.Repository, client gitutil.Client) (db.Repo, error) {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4653,3 +4653,95 @@ func (a *cliWorkerDelegationAdapter) Health(context.Context, runtime.Agent) erro
 func (a *cliWorkerDelegationAdapter) Capabilities(context.Context) ([]string, error) {
 	return nil, nil
 }
+
+// TestResolveDaemonStartRepoUsesRegisteredCheckout is the #202 regression: when
+// the target repo is already registered with a checkout, `daemon start --repo
+// owner/repo` resolves against the REGISTERED checkout regardless of the current
+// working directory, instead of failing because cwd's origin does not match.
+func TestResolveDaemonStartRepoUsesRegisteredCheckout(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+
+	// The registered checkout for owner/repo.
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	// A non-matching working directory: a different git repo whose origin points
+	// at some other repo. Resolving from here previously errored with
+	// "current checkout origin is owner/other, not owner/repo".
+	otherDir := t.TempDir()
+	runGit(t, otherDir, "init")
+	runGit(t, otherDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, otherDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(otherDir, "f.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, otherDir, "add", "f.txt")
+	runGit(t, otherDir, "commit", "-m", "init")
+	runGit(t, otherDir, "remote", "add", "origin", "https://github.com/owner/other.git")
+
+	repo, err := daemon.ParseRepository("owner/repo")
+	if err != nil {
+		t.Fatalf("ParseRepository returned error: %v", err)
+	}
+	record, err := resolveDaemonStartRepo(ctx, store, repo, otherDir)
+	if err != nil {
+		t.Fatalf("resolveDaemonStartRepo from non-matching cwd returned error: %v", err)
+	}
+	wantRoot := strings.TrimSpace(runGitOutput(t, checkout, "rev-parse", "--show-toplevel"))
+	if record.CheckoutPath != wantRoot {
+		t.Fatalf("resolved checkout = %q, want registered checkout %q", record.CheckoutPath, wantRoot)
+	}
+	if record.Owner != "owner" || record.Name != "repo" {
+		t.Fatalf("resolved repo = %s/%s, want owner/repo", record.Owner, record.Name)
+	}
+}
+
+// TestResolveDaemonStartRepoBootstrapsUnregistered pins that an unregistered repo
+// still resolves from the current checkout (first-time setup path), and that an
+// origin mismatch there still fails (origin protection intact).
+func TestResolveDaemonStartRepoBootstrapsUnregistered(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	repo, err := daemon.ParseRepository("owner/repo")
+	if err != nil {
+		t.Fatalf("ParseRepository returned error: %v", err)
+	}
+	// Bootstraps from the matching cwd.
+	record, err := resolveDaemonStartRepo(ctx, store, repo, checkout)
+	if err != nil {
+		t.Fatalf("resolveDaemonStartRepo bootstrap returned error: %v", err)
+	}
+	if record.Owner != "owner" || record.Name != "repo" {
+		t.Fatalf("bootstrapped repo = %s/%s, want owner/repo", record.Owner, record.Name)
+	}
+	// Origin protection: a non-matching cwd for an unregistered repo still fails.
+	other, err := daemon.ParseRepository("owner/elsewhere")
+	if err != nil {
+		t.Fatalf("ParseRepository returned error: %v", err)
+	}
+	if _, err := resolveDaemonStartRepo(ctx, store, other, checkout); err == nil {
+		t.Fatal("expected origin mismatch error for unregistered repo from non-matching cwd")
+	}
+}


### PR DESCRIPTION
## Problem
`gitmoot daemon start --repo owner/repo` failed when run from a directory whose checkout origin was a different repo:
```
daemon start: current checkout origin is jerryfane/gitmoot-live-test, not jerryfane/gitmoot-parallel-…
```
`--repo` looks like an explicit selector, so requiring cwd to be the matching checkout is surprising (esp. for daemon startup / scripted smoke tests).

## Fix
New `resolveDaemonStartRepo`: when the target repo is **already registered** with a checkout path, resolve against that **registered** checkout so the command works from any directory. For a not-yet-registered repo, bootstrap from the cwd as before. Origin protection is preserved — it is enforced against the registered checkout rather than the cwd. Wired into both the `daemon start` preflight and the `daemon run` worker path.

## Verification
- `go build/vet`, full `internal/cli` tests green.
- New regression tests: resolving `--repo` from a **non-matching cwd** returns the registered checkout; the unregistered path still bootstraps from cwd and still rejects an origin mismatch (protection intact).
- Live: `daemon start --repo e2e/finalize` from an unrelated checkout (`/root/gitmoot`, origin `jerryfane/gitmoot`) — the exact failing scenario — now starts cleanly.
- Doc updated (`docs/local-workflow.md`).

Fixes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)