### PR TITLE
feat(dashboard): global + per-repo Health so the dashboard works anywhere (#267)

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -447,22 +447,47 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 			return config.SetConfigScalar(paths, keyPath, configScalarForKind(kind, value))
 		},
 		HealthChecks: func() ([]tui.HealthCheck, error) {
-			checks := doctor.Checker{Dir: "."}.Run(context.Background())
-			out := make([]tui.HealthCheck, 0, len(checks))
-			for _, c := range checks {
-				status := "ok"
-				if !c.OK {
-					if c.Required {
-						status = "fail"
-					} else {
-						status = "warn"
+			ctx := context.Background()
+			checker := doctor.Checker{}
+			out := []tui.HealthCheck{}
+			for _, c := range checker.GlobalChecks(ctx) {
+				out = append(out, toTUIHealthCheck(c, ""))
+			}
+			// Per-repo checks run against each tracked repo's recorded checkout,
+			// so the dashboard reports repo health from anywhere — not just the
+			// current directory (#267).
+			err := withStore(home, func(store *db.Store) error {
+				repos, err := store.ListRepos(ctx)
+				if err != nil {
+					return err
+				}
+				for _, r := range repos {
+					for _, c := range checker.RepoChecks(ctx, r.CheckoutPath) {
+						out = append(out, toTUIHealthCheck(c, r.FullName()))
 					}
 				}
-				out = append(out, tui.HealthCheck{Name: c.Name, Status: status, Detail: c.Detail, Required: c.Required})
+				return nil
+			})
+			if err != nil {
+				return nil, err
 			}
 			return out, nil
 		},
 	}
+}
+
+// toTUIHealthCheck maps a doctor.Check to a tui.HealthCheck, deriving the status
+// string and tagging it with scope ("" for global, "owner/repo" for per-repo).
+func toTUIHealthCheck(c doctor.Check, scope string) tui.HealthCheck {
+	status := "ok"
+	if !c.OK {
+		if c.Required {
+			status = "fail"
+		} else {
+			status = "warn"
+		}
+	}
+	return tui.HealthCheck{Name: c.Name, Status: status, Detail: c.Detail, Required: c.Required, Scope: scope}
 }
 
 // formPromptStore is the PromptStore for pushed forms: the hot 200ms answer

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -127,12 +127,16 @@ type configWriteMsg struct {
 	err error
 }
 
-// HealthCheck is one environment/runtime diagnostic for the Health page.
+// HealthCheck is one environment/runtime diagnostic for the Health page. Scope
+// is empty for global (cwd-independent) checks and the repo full name
+// ("owner/repo") for per-repo checks, so the Health page can render the global
+// block once and group the rest by repo.
 type HealthCheck struct {
 	Name     string
 	Status   string // "ok", "warn", or "fail"
 	Detail   string
 	Required bool
+	Scope    string
 }
 
 // Repo mirrors cli.dashboardRepo.

--- a/internal/cli/tui/health.go
+++ b/internal/cli/tui/health.go
@@ -63,16 +63,51 @@ func (m Model) healthContent() string {
 	case len(m.healthChecks) == 0:
 		b.WriteString(mutedStyle.Render("no checks") + "\n")
 	default:
-		checkRows := [][]string{{"CHECK", "STATUS", "DETAIL"}}
-		for _, check := range m.healthChecks {
-			checkRows = append(checkRows, []string{check.Name, healthStatusColor(check.Status), truncate(dash(check.Detail), 70)})
-		}
-		b.WriteString(renderRows(checkRows))
+		b.WriteString(renderHealthChecks(m.healthChecks))
 	}
 
 	b.WriteByte('\n')
 	b.WriteString(mutedStyle.Render("r re-run checks · s start daemon"))
 	b.WriteByte('\n')
+	return b.String()
+}
+
+// renderHealthChecks renders the global checks (Scope == "") as one table, then
+// a labelled table per repo scope, in first-seen order. This keeps the global
+// block visible once and groups the per-repo rows under each repo.
+func renderHealthChecks(checks []HealthCheck) string {
+	var b strings.Builder
+	global := make([]HealthCheck, 0, len(checks))
+	scopeOrder := []string{}
+	byScope := map[string][]HealthCheck{}
+	for _, c := range checks {
+		if c.Scope == "" {
+			global = append(global, c)
+			continue
+		}
+		if _, seen := byScope[c.Scope]; !seen {
+			scopeOrder = append(scopeOrder, c.Scope)
+		}
+		byScope[c.Scope] = append(byScope[c.Scope], c)
+	}
+
+	writeTable := func(group []HealthCheck) {
+		rows := [][]string{{"CHECK", "STATUS", "DETAIL"}}
+		for _, check := range group {
+			rows = append(rows, []string{check.Name, healthStatusColor(check.Status), truncate(dash(check.Detail), 70)})
+		}
+		b.WriteString(renderRows(rows))
+	}
+
+	if len(global) > 0 {
+		writeTable(global)
+	}
+	for _, scope := range scopeOrder {
+		b.WriteByte('\n')
+		b.WriteString(headerStyle.Render(scope))
+		b.WriteByte('\n')
+		writeTable(byScope[scope])
+	}
 	return b.String()
 }
 

--- a/internal/cli/tui/health_test.go
+++ b/internal/cli/tui/health_test.go
@@ -191,3 +191,26 @@ func TestHealthStartDaemonShowsInFlightAndError(t *testing.T) {
 		t.Fatalf("a daemon start failure should render on Health:\n%s", m.View())
 	}
 }
+
+func TestRenderHealthChecksGroupsByScope(t *testing.T) {
+	out := renderHealthChecks([]HealthCheck{
+		{Name: "git", Status: "ok", Required: true},
+		{Name: "gh auth", Status: "ok", Required: true},
+		{Name: "repo remote", Status: "ok", Required: true, Scope: "owner/a"},
+		{Name: "base branch", Status: "ok", Required: true, Scope: "owner/a"},
+		{Name: "checkout", Status: "warn", Required: false, Scope: "owner/b"},
+	})
+	for _, want := range []string{"git", "gh auth", "owner/a", "repo remote", "base branch", "owner/b", "checkout"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("renderHealthChecks output missing %q:\n%s", want, out)
+		}
+	}
+	// The global block (git) must appear before the first repo scope header.
+	if strings.Index(out, "git") > strings.Index(out, "owner/a") {
+		t.Fatalf("global checks should render before repo scopes:\n%s", out)
+	}
+	// owner/a's checks render under its header, before owner/b's header.
+	if strings.Index(out, "owner/a") > strings.Index(out, "owner/b") {
+		t.Fatalf("repo scopes should render in first-seen order:\n%s", out)
+	}
+}

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -23,13 +23,20 @@ type Checker struct {
 	Runner subprocess.Runner
 }
 
+// Run returns the global (cwd-independent) checks followed by the per-repo
+// checks for the Checker's Dir, treated as a single checkout. This is the
+// `gitmoot doctor --repo <dir>` view.
 func (c Checker) Run(ctx context.Context) []Check {
-	runner := c.Runner
-	if runner == nil {
-		runner = subprocess.ExecRunner{}
-	}
+	checks := c.GlobalChecks(ctx)
+	return append(checks, c.RepoChecks(ctx, c.Dir)...)
+}
 
-	checks := []Check{
+// GlobalChecks returns the diagnostics that do not depend on any repo checkout:
+// required/optional runtime binaries and the auth checks. They can run from
+// anywhere, so the dashboard renders them once.
+func (c Checker) GlobalChecks(ctx context.Context) []Check {
+	runner := c.runner()
+	return []Check{
 		c.command(ctx, runner, "git", true, "--version"),
 		c.command(ctx, runner, "gh", true, "--version"),
 		c.command(ctx, runner, "codex", true, "--version"),
@@ -37,10 +44,29 @@ func (c Checker) Run(ctx context.Context) []Check {
 		c.command(ctx, runner, "kimi", false, "--version"),
 		c.claudeAuthEnv(),
 		c.ghAuth(ctx, runner),
-		c.repoRemote(ctx, runner),
-		c.baseBranch(ctx, runner),
 	}
-	return checks
+}
+
+// RepoChecks returns the per-repo diagnostics (origin remote resolves, base
+// branch present) run against checkoutPath. A repo that has no checkout path yet
+// (subscribed but never delivered to) reports a single non-required "no checkout"
+// check rather than failing the git-dependent checks.
+func (c Checker) RepoChecks(ctx context.Context, checkoutPath string) []Check {
+	if strings.TrimSpace(checkoutPath) == "" {
+		return []Check{{Name: "checkout", OK: false, Required: false, Detail: "no checkout yet"}}
+	}
+	runner := c.runner()
+	return []Check{
+		c.repoRemote(ctx, runner, checkoutPath),
+		c.baseBranch(ctx, runner, checkoutPath),
+	}
+}
+
+func (c Checker) runner() subprocess.Runner {
+	if c.Runner != nil {
+		return c.Runner
+	}
+	return subprocess.ExecRunner{}
 }
 
 func (c Checker) command(ctx context.Context, runner subprocess.Runner, name string, required bool, args ...string) Check {
@@ -62,8 +88,8 @@ func (c Checker) ghAuth(ctx context.Context, runner subprocess.Runner) Check {
 	return Check{Name: "gh auth", OK: true, Required: true, Detail: firstLine(result.Stdout, result.Stderr)}
 }
 
-func (c Checker) repoRemote(ctx context.Context, runner subprocess.Runner) Check {
-	result, err := runner.Run(ctx, c.Dir, "git", "remote", "get-url", "origin")
+func (c Checker) repoRemote(ctx context.Context, runner subprocess.Runner, dir string) Check {
+	result, err := runner.Run(ctx, dir, "git", "remote", "get-url", "origin")
 	if err != nil {
 		return Check{Name: "repo remote", Required: true, Detail: strings.TrimSpace(result.Stderr)}
 	}
@@ -73,15 +99,15 @@ func (c Checker) repoRemote(ctx context.Context, runner subprocess.Runner) Check
 		return Check{Name: "repo remote", Required: true, Detail: err.Error()}
 	}
 
-	view, err := runner.Run(ctx, c.Dir, "gh", "repo", "view", repo.String(), "--json", "nameWithOwner")
+	view, err := runner.Run(ctx, dir, "gh", "repo", "view", repo.String(), "--json", "nameWithOwner")
 	if err != nil {
 		return Check{Name: "repo remote", Required: true, Detail: strings.TrimSpace(view.Stderr)}
 	}
 	return Check{Name: "repo remote", OK: true, Required: true, Detail: repo.String()}
 }
 
-func (c Checker) baseBranch(ctx context.Context, runner subprocess.Runner) Check {
-	result, err := runner.Run(ctx, c.Dir, "git", "branch", "--show-current")
+func (c Checker) baseBranch(ctx context.Context, runner subprocess.Runner, dir string) Check {
+	result, err := runner.Run(ctx, dir, "git", "branch", "--show-current")
 	if err != nil {
 		return Check{Name: "base branch", Required: true, Detail: strings.TrimSpace(result.Stderr)}
 	}

--- a/internal/doctor/checker_test.go
+++ b/internal/doctor/checker_test.go
@@ -173,3 +173,66 @@ func withClaudeAuthEnv(t *testing.T, values map[string]string) {
 		}
 	})
 }
+
+func TestRepoChecksNoCheckoutWarns(t *testing.T) {
+	checks := Checker{Runner: fakeRunner{paths: map[string]bool{}}}.RepoChecks(context.Background(), "")
+	if len(checks) != 1 {
+		t.Fatalf("RepoChecks(\"\") = %+v, want a single check", checks)
+	}
+	c := checks[0]
+	if c.Name != "checkout" || c.OK || c.Required {
+		t.Fatalf("no-checkout check = %+v, want non-required, not-ok 'checkout'", c)
+	}
+	if !strings.Contains(c.Detail, "no checkout") {
+		t.Fatalf("no-checkout detail = %q", c.Detail)
+	}
+}
+
+func TestGlobalChecksHaveNoRepoChecks(t *testing.T) {
+	runner := fakeRunner{
+		paths: map[string]bool{"git": true, "gh": true, "codex": true},
+		runs: map[string]subprocess.Result{
+			"git --version":   {Stdout: "git version 2\n"},
+			"gh --version":    {Stdout: "gh version 2\n"},
+			"codex --version": {Stdout: "codex 1\n"},
+			"gh auth status":  {Stdout: "Logged in\n"},
+		},
+	}
+	for _, c := range (Checker{Runner: runner}).GlobalChecks(context.Background()) {
+		if c.Name == "repo remote" || c.Name == "base branch" || c.Name == "checkout" {
+			t.Fatalf("GlobalChecks unexpectedly included per-repo check %q", c.Name)
+		}
+	}
+}
+
+func TestRepoChecksAgainstCheckoutPath(t *testing.T) {
+	runner := pathSensitiveRunner{
+		want: "/checkout",
+		fakeRunner: fakeRunner{
+			runs: map[string]subprocess.Result{
+				"git remote get-url origin":                           {Stdout: "https://github.com/jerryfane/gitmoot.git\n"},
+				"gh repo view jerryfane/gitmoot --json nameWithOwner": {Stdout: `{"nameWithOwner":"jerryfane/gitmoot"}`},
+				"git branch --show-current":                           {Stdout: "main\n"},
+			},
+		},
+	}
+	checks := Checker{Runner: runner}.RepoChecks(context.Background(), "/checkout")
+	for _, c := range checks {
+		if !c.OK {
+			t.Fatalf("repo check %q ran against wrong dir or failed: %+v", c.Name, c)
+		}
+	}
+}
+
+// pathSensitiveRunner asserts that git/gh repo commands run in the expected dir.
+type pathSensitiveRunner struct {
+	fakeRunner
+	want string
+}
+
+func (r pathSensitiveRunner) Run(ctx context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
+	if dir != r.want {
+		return subprocess.Result{}, fmt.Errorf("ran in %q, want %q", dir, r.want)
+	}
+	return r.fakeRunner.Run(ctx, dir, command, args...)
+}


### PR DESCRIPTION
## Problem
The dashboard's Health page ran the repo-specific doctor checks against the **current directory** (`doctor.Checker{Dir: "."}`), so running `gitmoot dashboard` from outside a git repo showed spurious failures:
```
repo remote  fail  fatal: not a git repository (or any of the parent directories): .git
base branch  fail  fatal: not a git repository …
```
The dashboard is a global cockpit — it should report the health of every tracked repo, not the cwd.

## Change
Split `doctor.Checker` into two tiers:
- **`GlobalChecks`** — cwd-independent: git/gh/codex/claude/kimi binaries, gh auth, claude auth. Rendered once.
- **`RepoChecks(checkoutPath)`** — per-repo: origin remote resolves, base branch present. Run against **each repo's recorded checkout** (`db.Repo.CheckoutPath`). A repo with no checkout path yet reports a non-required `no checkout` check rather than failing.

`Checker.Run` still returns global + the cwd's repo checks, so `gitmoot doctor --repo <dir>` is unchanged. The dashboard renders the global block once plus a per-repo section for each repo from `store.ListRepos`, tagged via a new `HealthCheck.Scope`, on the existing **lazy** HealthChecks path (never the 5s tick). The `Dir: "."` dependency is gone.

## Verification
- `go build/vet`, full `go test ./...` green.
- New doctor tests: `GlobalChecks` excludes per-repo checks; `RepoChecks("")` → non-required "no checkout"; `RepoChecks(path)` runs against that path. New tui test: `renderHealthChecks` groups global-first then per-repo in first-seen order.
- Review pass found no functional regressions; HealthChecks confirmed lazy-only.

Fixes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)