### PR TITLE
feat(workflow): per-root wall-clock budget for delegation trees (#338)

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1937,6 +1937,18 @@ func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent)
 	return tx.Commit()
 }
 
+// JobCreatedAt returns a job's created_at timestamp string (SQLite UTC format,
+// "2006-01-02 15:04:05"). Used by the delegation wall-clock backstop to measure a
+// tree's age from its root job. Returns sql.ErrNoRows if the job is unknown.
+func (s *Store) JobCreatedAt(ctx context.Context, id string) (string, error) {
+	var createdAt string
+	row := s.db.QueryRowContext(ctx, `SELECT created_at FROM jobs WHERE id = ?`, id)
+	if err := row.Scan(&createdAt); err != nil {
+		return "", err
+	}
+	return createdAt, nil
+}
+
 func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by FROM jobs WHERE id = ?`, id)
 	var job Job

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
@@ -39,6 +40,18 @@ type Engine struct {
 	// empty, artifact writing is skipped (ask-path and tests that build an
 	// Engine without it keep their existing behavior).
 	ArtifactRoot string
+	// Now returns the current time and is the engine's only clock source. It is
+	// optional and defaults to time.Now; tests inject it to drive the per-root
+	// wall-clock backstop (see MaxDelegationWallClock) deterministically.
+	Now func() time.Time
+}
+
+// now returns the engine's current time, defaulting to time.Now when Now is unset.
+func (e Engine) now() time.Time {
+	if e.Now != nil {
+		return e.Now()
+	}
+	return time.Now()
 }
 
 type PullRequestEvent struct {
@@ -497,6 +510,37 @@ func (e Engine) rootJobID(job db.Job, payload JobPayload) string {
 	return job.ID
 }
 
+// rootWallClockExceeded reports whether the coordination tree rooted at rootID has
+// been running longer than MaxDelegationWallClock, measured from the root job's
+// created_at, and the elapsed duration. It fails open: any lookup/parse problem
+// returns (false, 0) so a clock or timestamp hiccup never blocks dispatch.
+func (e Engine) rootWallClockExceeded(ctx context.Context, rootID string) (bool, time.Duration) {
+	createdAt, err := e.Store.JobCreatedAt(ctx, rootID)
+	if err != nil {
+		return false, 0
+	}
+	start, err := parseJobTimestamp(createdAt)
+	if err != nil {
+		return false, 0
+	}
+	elapsed := e.now().UTC().Sub(start)
+	return elapsed > MaxDelegationWallClock, elapsed
+}
+
+// parseJobTimestamp parses a jobs.created_at value. SQLite's CURRENT_TIMESTAMP
+// default is UTC in "2006-01-02 15:04:05" form; RFC3339 is also accepted
+// defensively in case a timestamp was written explicitly.
+func parseJobTimestamp(s string) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("unrecognized job timestamp %q", s)
+}
+
 // delegationRequest builds the canonical child JobRequest for a delegation,
 // inheriting the parent's repo/branch/PR context and stamping the DAG fields
 // (ParentJobID/DelegationID/DelegationDepth/DelegatedBy/RootJobID/Deps). It is
@@ -570,6 +614,16 @@ const MaxDelegationTotalJobs = 64
 // width of a single dispatch so a coordinator returning hundreds of delegations
 // at once is refused with a delegation_width_exceeded event.
 const MaxDelegationWidth = 16
+
+// MaxDelegationWallClock bounds how long a single coordination tree (all children
+// and continuations sharing one root, see rootJobID) may run before a coordinator
+// is refused further fan-out. Where the depth/job-count caps bound the shape of
+// the tree, this bounds its duration so an expensive-but-not-numerous tree (slow
+// agents, long per-job work) cannot run unbounded. Measured from the root job's
+// created_at; once exceeded, dispatchDelegations refuses further children and
+// records a delegation_walltime_exceeded event. It is a generous runaway backstop,
+// not a tight SLA. (A future enhancement could make it configurable — see #338.)
+const MaxDelegationWallClock = 2 * time.Hour
 
 // delegationHashWindowSize is how many recent delegation-set hashes a coordinator
 // continuation chain remembers (threaded via the payload, not scanned across
@@ -714,6 +768,15 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 			Message: fmt.Sprintf("delegation tree for root %s reached the job budget of %d (%d jobs); not dispatching %d delegation(s)", rootID, MaxDelegationTotalJobs, total, len(payload.Result.Delegations)),
 		})
 		return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("per-root job budget of %d reached", MaxDelegationTotalJobs))
+	}
+
+	if exceeded, elapsed := e.rootWallClockExceeded(ctx, rootID); exceeded {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_walltime_exceeded",
+			Message: fmt.Sprintf("delegation tree for root %s ran %s, exceeding the wall-clock limit of %s; not dispatching %d delegation(s)", rootID, elapsed.Round(time.Second), MaxDelegationWallClock, len(payload.Result.Delegations)),
+		})
+		return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("wall-clock limit of %s reached", MaxDelegationWallClock))
 	}
 
 	if width := len(payload.Result.Delegations); width > MaxDelegationWidth {

--- a/internal/workflow/walltime_test.go
+++ b/internal/workflow/walltime_test.go
@@ -1,0 +1,105 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// TestEngineWallClockBudgetTripEnqueuesFinalize pins the #338 wall-clock backstop:
+// a coordination tree that has run longer than MaxDelegationWallClock does not
+// dispatch its next generation; instead it gets one graceful finalize continuation.
+func TestEngineWallClockBudgetTripEnqueuesFinalize(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+
+	engine := testEngine(store)
+	// Drive the clock MaxDelegationWallClock + 1h past the root's created_at so the
+	// tree is over its wall-clock budget while everything else is in bounds.
+	engine.Now = func() time.Time { return time.Now().Add(MaxDelegationWallClock + time.Hour) }
+
+	insertCompletedJob(t, store, db.Job{ID: "slow", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-009", TaskID: "task-9", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "slow tree", Delegations: []Delegation{
+			{ID: "d0", Agent: "w", Action: "ask", Prompt: "work"},
+			{ID: "d1", Agent: "w", Action: "ask", Prompt: "work"},
+		}},
+	})
+	if err := engine.AdvanceJob(ctx, "slow"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if jobExists(t, store, "slow/delegation/d0") {
+		t.Fatal("over-walltime delegations must not be dispatched")
+	}
+	if got := countJobEvents(t, store, "slow", "delegation_walltime_exceeded"); got != 1 {
+		t.Fatalf("delegation_walltime_exceeded events = %d, want 1", got)
+	}
+	cont, err := unmarshalPayload(mustJob(t, store, "slow/continuation").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if !cont.DelegationFinalize {
+		t.Fatalf("finalize continuation must carry DelegationFinalize: %+v", cont)
+	}
+	if got := countJobEvents(t, store, "slow", "delegation_finalize_enqueued"); got != 1 {
+		t.Fatalf("delegation_finalize_enqueued events = %d, want 1", got)
+	}
+}
+
+// TestEngineWithinWallClockBudgetDispatches is the control: a fresh tree (default
+// clock, ~0 elapsed) does not trip the wall-clock backstop and dispatches normally.
+func TestEngineWithinWallClockBudgetDispatches(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+	engine := testEngine(store) // default clock => elapsed ~0
+
+	insertCompletedJob(t, store, db.Job{ID: "fresh", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-009", TaskID: "task-9", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "fresh tree", Delegations: []Delegation{
+			{ID: "d0", Agent: "w", Action: "ask", Prompt: "work"},
+		}},
+	})
+	if err := engine.AdvanceJob(ctx, "fresh"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if !jobExists(t, store, "fresh/delegation/d0") {
+		t.Fatal("in-budget delegations must be dispatched")
+	}
+	if got := countJobEvents(t, store, "fresh", "delegation_walltime_exceeded"); got != 0 {
+		t.Fatalf("delegation_walltime_exceeded events = %d, want 0", got)
+	}
+}
+
+func TestParseJobTimestamp(t *testing.T) {
+	want := time.Date(2026, 6, 19, 15, 1, 11, 0, time.UTC)
+	for _, in := range []string{"2026-06-19 15:01:11", "2026-06-19T15:01:11Z"} {
+		got, err := parseJobTimestamp(in)
+		if err != nil {
+			t.Fatalf("parseJobTimestamp(%q) returned error: %v", in, err)
+		}
+		if !got.Equal(want) {
+			t.Fatalf("parseJobTimestamp(%q) = %v, want %v", in, got, want)
+		}
+	}
+	if _, err := parseJobTimestamp("not-a-timestamp"); err == nil {
+		t.Fatal("parseJobTimestamp on garbage should error")
+	}
+}
+
+// TestRootWallClockExceededFailsOpen pins that a missing root timestamp never
+// blocks dispatch (the backstop fails open).
+func TestRootWallClockExceededFailsOpen(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	engine.Now = func() time.Time { return time.Now().Add(100 * time.Hour) }
+	if exceeded, _ := engine.rootWallClockExceeded(ctx, "no-such-root"); exceeded {
+		t.Fatal("unknown root must not be reported as over wall-clock budget")
+	}
+}

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -147,6 +147,11 @@ Delegation trees are bounded so they cannot run forever:
   this depth may not delegate further.
 - Per-root job budget: `MaxDelegationTotalJobs = 64`. The whole delegation tree
   under one root is capped at this many jobs.
+- Per-root wall-clock budget: `MaxDelegationWallClock = 2h`. The whole tree under
+  one root is bounded in duration (measured from the root job's creation); a
+  coordinator that tries to fan out after the tree has run this long is refused
+  with a `delegation_walltime_exceeded` event. A generous runaway backstop, not a
+  tight deadline.
 - Loop detection: a windowed signature over recent delegation activity halts
   repeated or cyclic delegation chains (e.g. oscillating A→B→A) well before the
   depth cap is reached.

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -230,6 +230,13 @@ trips, the offending delegations are dropped rather than dispatched.
   capped at this many jobs. When a batch of delegations would exceed the budget,
   it is dropped, and the parent receives a lifecycle event such as "delegation
   tree for root &lt;id&gt; reached the job budget of 64".
+- **Wall-clock budget (`MaxDelegationWallClock = 2h`)**: the whole delegation
+  tree under one root is bounded in duration, measured from the root job's
+  creation. When a coordinator tries to fan out after the tree has run longer
+  than this, the new delegations are dropped and the parent receives a
+  `delegation_walltime_exceeded` event. This bounds an expensive-but-not-numerous
+  tree (slow agents, long per-job work) that the depth/job-count caps miss. It is
+  a generous runaway backstop, not a tight deadline.
 - **Loop detection**: a canonical windowed signature over recent delegation
   activity halts repeated or cyclic delegation chains — for example an
   oscillating A→B→A loop — well before the depth cap is reached.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1157,11 +1157,14 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    gitmoot daemon start --repo owner/project --poll 30s
    ```
 
-   The daemon validates that the current checkout's `origin` remote matches
-   `--repo`. `agent start --start-daemon` runs this same background start path
-   for the selected checkout. Use `gitmoot daemon start` without `--repo` after
-   registering all intended repos if one daemon should supervise the whole
-   Gitmoot home.
+   When `--repo` names a repo that is already registered, the daemon resolves
+   its registered checkout, so `gitmoot daemon start --repo owner/project` works
+   from any directory. For a repo that is not yet registered, run the command
+   from the matching checkout (the daemon validates the current checkout's
+   `origin` remote against `--repo` to bootstrap it). `agent start
+   --start-daemon` runs this same background start path for the selected
+   checkout. Use `gitmoot daemon start` without `--repo` after registering all
+   intended repos if one daemon should supervise the whole Gitmoot home.
 
    Gitmoot records agent autonomy policy as `read-only`, `workspace-write`,
    `danger-full-access`, or `auto`. For Codex these map to Codex sandbox
@@ -6646,6 +6649,11 @@ Delegation trees are bounded so they cannot run forever:
   this depth may not delegate further.
 - Per-root job budget: `MaxDelegationTotalJobs = 64`. The whole delegation tree
   under one root is capped at this many jobs.
+- Per-root wall-clock budget: `MaxDelegationWallClock = 2h`. The whole tree under
+  one root is bounded in duration (measured from the root job's creation); a
+  coordinator that tries to fan out after the tree has run this long is refused
+  with a `delegation_walltime_exceeded` event. A generous runaway backstop, not a
+  tight deadline.
 - Loop detection: a windowed signature over recent delegation activity halts
   repeated or cyclic delegation chains (e.g. oscillating A→B→A) well before the
   depth cap is reached.


### PR DESCRIPTION
## What
Adds a **per-root wall-clock budget** — the wall-clock half of #338 — as a fourth termination backstop next to depth (8), per-root job count (64), and width (16).

When a coordinator tries to fan out after its tree (all jobs sharing one `root_job_id`) has been running longer than `MaxDelegationWallClock = 2h` — measured from the **root job's `created_at`** — the new delegations are dropped and the engine enqueues the #305 **graceful finalize continuation**, recording a typed `delegation_walltime_exceeded` event. This bounds an expensive-but-not-numerous tree (slow agents, long per-job work) that the shape-based caps can't catch.

## How
- New `MaxDelegationWallClock` constant + a check in `dispatchDelegations` (after the per-root job-budget block, reusing `rootID`), routing to `enqueueFinalizeContinuation`.
- `Engine.Now func() time.Time` — an optional injectable clock (defaults to `time.Now`) so the backstop is deterministically testable.
- `Store.JobCreatedAt` reads the root's timestamp; `parseJobTimestamp` handles SQLite's UTC `CURRENT_TIMESTAMP` format (and RFC3339 defensively).
- **Fails open:** any timestamp lookup/parse problem skips the check rather than blocking dispatch.

## Tests / verification
- `go build/vet`, `go test ./...`, `go test -race ./internal/workflow/` — all green.
- New `walltime_test.go`: over-budget tree → no dispatch + `delegation_walltime_exceeded` + a terminal `DelegationFinalize` continuation; in-budget control still dispatches; `parseJobTimestamp` (both formats + garbage); fail-open on a missing root.
- Review pass: no functional issues (timezone math is UTC-correct; t=0 root never false-trips; negative clock skew can't trip; one backstop fires per advance).
- Docs updated in both trees (`skills/.../RESULT_CONTRACT.md` + `website/docs/reference/result-contract.md`, `llms-full.txt` regenerated).

## Scope note
This is the **wall-clock** half of #338. The **cost/token** half needs a per-job token-capture pipeline that doesn't exist yet (gitmoot captures no per-job token usage today, and codex is invoked without `--json`), so it's tracked separately in #338.

Part of #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)