### PR TITLE
feat(skillopt): capture judge↔human outcomes + judge-report (#345 Phase 1)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -11125,19 +11125,23 @@ func renderSkillOptJudgeReport(stdout io.Writer, outcomes []db.SkillOptJudgeOutc
 
 	// Cohen's kappa for the 2x2 judge-vs-human table:
 	//   po = observed agreement; pe = chance agreement from the marginals.
-	//   kappa = (po - pe) / (1 - pe). Reported as 1.0 when pe == 1 (every
-	//   rater always picked the same label, so there is no chance disagreement).
+	//   kappa = (po - pe) / (1 - pe). When pe == 1 (a rater used a single label
+	//   for every row) kappa is undefined: report 1.000 only when observed
+	//   agreement is also perfect, otherwise "n/a" rather than a misleading 1.0.
 	po := float64(agreements) / float64(total)
 	judgeAcceptTotal := agreeAccept + judgeAcceptHumanReject
 	humanAcceptTotal := agreeAccept + judgeRejectHumanAccept
 	judgeRejectTotal := total - judgeAcceptTotal
 	humanRejectTotal := total - humanAcceptTotal
 	pe := (float64(judgeAcceptTotal)*float64(humanAcceptTotal) + float64(judgeRejectTotal)*float64(humanRejectTotal)) / (float64(total) * float64(total))
-	kappa := 1.0
-	if pe < 1 {
-		kappa = (po - pe) / (1 - pe)
+	switch {
+	case pe < 1:
+		fmt.Fprintf(stdout, "cohen's kappa: %.3f\n", (po-pe)/(1-pe))
+	case po >= 1:
+		writeLine(stdout, "cohen's kappa: 1.000")
+	default:
+		writeLine(stdout, "cohen's kappa: n/a (degenerate: a rater used a single label)")
 	}
-	fmt.Fprintf(stdout, "cohen's kappa: %.3f\n", kappa)
 	writeLine(stdout, "")
 
 	renderSkillOptJudgeCalibration(stdout, outcomes)
@@ -11173,6 +11177,14 @@ func renderSkillOptJudgeCalibration(stdout io.Writer, outcomes []db.SkillOptJudg
 			continue
 		}
 		humanPromoted := outcome.HumanDecision == "promoted"
+		// Clamp out-of-range soft scores into [0,1] so a malformed value lands in
+		// an edge band rather than being silently dropped from the calibration.
+		if soft < 0 {
+			soft = 0
+		}
+		if soft > 1 {
+			soft = 1
+		}
 		for index, band := range skillOptJudgeBands {
 			if soft >= band.low && soft < band.high {
 				stats[index].count++

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -69,6 +69,8 @@ func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptCandidate(args[1:], stdout, stderr)
 	case "feedback":
 		return runSkillOptFeedback(args[1:], stdout, stderr)
+	case "judge-report":
+		return runSkillOptJudgeReport(args[1:], stdout, stderr)
 	case "train":
 		return runSkillOptTrain(args[1:], stdout, stderr)
 	default:
@@ -94,6 +96,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
+	fmt.Fprintln(w, "  gitmoot skillopt judge-report [--template id]")
 	fmt.Fprintln(w, "  gitmoot skillopt train init --name <name> --template <id> --review-repo owner/repo --artifact-kind kind --preview kind (--request text|--request-file path)")
 	fmt.Fprintln(w, "  gitmoot skillopt train init templates --json")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --config .gitmoot/skillopt/<name>/config.toml [--yes]")
@@ -11052,6 +11055,277 @@ func runSkillOptCandidateList(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "%-18s %-14s %-9s %-8s %s\n", version.ID, version.TemplateID, version.State, scoreText(review.Score), firstLine(review.PreferenceSummary))
 	}
 	return 0
+}
+
+// runSkillOptJudgeReport renders an offline calibration report comparing the
+// LLM judge's accept/reject signal against the human promote/reject decision
+// captured at decision time (#345). It is read-only: it lists the stored
+// judge-outcome rows and computes a confusion matrix, overall agreement,
+// Cohen's kappa, soft-score calibration bands, and per-dimension disagreement.
+func runSkillOptJudgeReport(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt judge-report", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	templateID := fs.String("template", "", "template id to filter")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt judge-report does not accept positional arguments")
+		return 2
+	}
+	var outcomes []db.SkillOptJudgeOutcome
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		outcomes, err = store.ListSkillOptJudgeOutcomes(context.Background(), *templateID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt judge-report: %v\n", err)
+		return 1
+	}
+	renderSkillOptJudgeReport(stdout, outcomes)
+	return 0
+}
+
+func renderSkillOptJudgeReport(stdout io.Writer, outcomes []db.SkillOptJudgeOutcome) {
+	if len(outcomes) == 0 {
+		writeLine(stdout, "no judge outcomes captured")
+		return
+	}
+	// Confusion matrix: count each of the four direction buckets.
+	counts := map[string]int{
+		db.SkillOptJudgeDirectionAgreeAccept:            0,
+		db.SkillOptJudgeDirectionAgreeReject:            0,
+		db.SkillOptJudgeDirectionJudgeAcceptHumanReject: 0,
+		db.SkillOptJudgeDirectionJudgeRejectHumanAccept: 0,
+	}
+	for _, outcome := range outcomes {
+		counts[outcome.Direction]++
+	}
+	total := len(outcomes)
+	agreeAccept := counts[db.SkillOptJudgeDirectionAgreeAccept]
+	agreeReject := counts[db.SkillOptJudgeDirectionAgreeReject]
+	judgeAcceptHumanReject := counts[db.SkillOptJudgeDirectionJudgeAcceptHumanReject]
+	judgeRejectHumanAccept := counts[db.SkillOptJudgeDirectionJudgeRejectHumanAccept]
+
+	fmt.Fprintf(stdout, "judge outcomes: %d\n", total)
+	writeLine(stdout, "")
+	writeLine(stdout, "confusion matrix (judge vs human)")
+	fmt.Fprintf(stdout, "  %-22s %-14s %-14s\n", "", "human promote", "human reject")
+	fmt.Fprintf(stdout, "  %-22s %-14d %-14d\n", "judge accept", agreeAccept, judgeAcceptHumanReject)
+	fmt.Fprintf(stdout, "  %-22s %-14d %-14d\n", "judge reject", judgeRejectHumanAccept, agreeReject)
+	writeLine(stdout, "")
+
+	// Overall agreement = (agree_accept + agree_reject) / total.
+	agreements := agreeAccept + agreeReject
+	fmt.Fprintf(stdout, "agreement rate: %.3f (%d/%d)\n", float64(agreements)/float64(total), agreements, total)
+
+	// Cohen's kappa for the 2x2 judge-vs-human table:
+	//   po = observed agreement; pe = chance agreement from the marginals.
+	//   kappa = (po - pe) / (1 - pe). Reported as 1.0 when pe == 1 (every
+	//   rater always picked the same label, so there is no chance disagreement).
+	po := float64(agreements) / float64(total)
+	judgeAcceptTotal := agreeAccept + judgeAcceptHumanReject
+	humanAcceptTotal := agreeAccept + judgeRejectHumanAccept
+	judgeRejectTotal := total - judgeAcceptTotal
+	humanRejectTotal := total - humanAcceptTotal
+	pe := (float64(judgeAcceptTotal)*float64(humanAcceptTotal) + float64(judgeRejectTotal)*float64(humanRejectTotal)) / (float64(total) * float64(total))
+	kappa := 1.0
+	if pe < 1 {
+		kappa = (po - pe) / (1 - pe)
+	}
+	fmt.Fprintf(stdout, "cohen's kappa: %.3f\n", kappa)
+	writeLine(stdout, "")
+
+	renderSkillOptJudgeCalibration(stdout, outcomes)
+	renderSkillOptJudgeDimensionDisagreement(stdout, outcomes)
+}
+
+// skillOptJudgeBands are the soft-score calibration bands, low edge inclusive.
+var skillOptJudgeBands = []struct {
+	label string
+	low   float64
+	high  float64
+}{
+	{"[0.00,0.25)", 0.00, 0.25},
+	{"[0.25,0.50)", 0.25, 0.50},
+	{"[0.50,0.75)", 0.50, 0.75},
+	{"[0.75,1.00]", 0.75, 1.01},
+}
+
+// renderSkillOptJudgeCalibration buckets outcomes by the judge's soft score and
+// reports the human promote rate within each band — a calibration curve showing
+// whether higher judge confidence tracks more human promotions.
+func renderSkillOptJudgeCalibration(stdout io.Writer, outcomes []db.SkillOptJudgeOutcome) {
+	type bandStat struct {
+		count    int
+		promoted int
+	}
+	stats := make([]bandStat, len(skillOptJudgeBands))
+	unscored := 0
+	for _, outcome := range outcomes {
+		soft, ok := skillOptJudgeSoftScore(outcome.JudgeScoreJSON)
+		if !ok {
+			unscored++
+			continue
+		}
+		humanPromoted := outcome.HumanDecision == "promoted"
+		for index, band := range skillOptJudgeBands {
+			if soft >= band.low && soft < band.high {
+				stats[index].count++
+				if humanPromoted {
+					stats[index].promoted++
+				}
+				break
+			}
+		}
+	}
+	writeLine(stdout, "calibration (judge soft-score band vs human promote rate)")
+	fmt.Fprintf(stdout, "  %-14s %-8s %s\n", "BAND", "N", "HUMAN PROMOTE RATE")
+	for index, band := range skillOptJudgeBands {
+		stat := stats[index]
+		rate := "-"
+		if stat.count > 0 {
+			rate = fmt.Sprintf("%.3f (%d/%d)", float64(stat.promoted)/float64(stat.count), stat.promoted, stat.count)
+		}
+		fmt.Fprintf(stdout, "  %-14s %-8d %s\n", band.label, stat.count, rate)
+	}
+	if unscored > 0 {
+		fmt.Fprintf(stdout, "  %-14s %-8d %s\n", "no soft score", unscored, "-")
+	}
+	writeLine(stdout, "")
+}
+
+// renderSkillOptJudgeDimensionDisagreement, when dimension_scores are present in
+// the captured eval reports, reports each dimension's mean score split by human
+// promote vs reject, plus the gap between them — surfacing dimensions where the
+// judge's per-dimension score diverges from the human decision.
+func renderSkillOptJudgeDimensionDisagreement(stdout io.Writer, outcomes []db.SkillOptJudgeOutcome) {
+	type dimStat struct {
+		promoteSum   float64
+		promoteCount int
+		rejectSum    float64
+		rejectCount  int
+	}
+	stats := map[string]*dimStat{}
+	for _, outcome := range outcomes {
+		dimensions := skillOptJudgeDimensionScores(outcome.JudgeScoreJSON)
+		humanPromoted := outcome.HumanDecision == "promoted"
+		for name, score := range dimensions {
+			stat := stats[name]
+			if stat == nil {
+				stat = &dimStat{}
+				stats[name] = stat
+			}
+			if humanPromoted {
+				stat.promoteSum += score
+				stat.promoteCount++
+			} else {
+				stat.rejectSum += score
+				stat.rejectCount++
+			}
+		}
+	}
+	if len(stats) == 0 {
+		return
+	}
+	names := make([]string, 0, len(stats))
+	for name := range stats {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	writeLine(stdout, "per-dimension disagreement (mean judge dimension score by human decision)")
+	fmt.Fprintf(stdout, "  %-22s %-16s %-16s %s\n", "DIMENSION", "PROMOTE MEAN", "REJECT MEAN", "GAP")
+	for _, name := range names {
+		stat := stats[name]
+		promoteMean, promoteOK := skillOptJudgeMean(stat.promoteSum, stat.promoteCount)
+		rejectMean, rejectOK := skillOptJudgeMean(stat.rejectSum, stat.rejectCount)
+		gap := "-"
+		if promoteOK && rejectOK {
+			gap = fmt.Sprintf("%+.3f", promoteMean-rejectMean)
+		}
+		fmt.Fprintf(stdout, "  %-22s %-16s %-16s %s\n", name, skillOptJudgeMeanText(promoteMean, promoteOK, stat.promoteCount), skillOptJudgeMeanText(rejectMean, rejectOK, stat.rejectCount), gap)
+	}
+	writeLine(stdout, "")
+}
+
+func skillOptJudgeMean(sum float64, count int) (float64, bool) {
+	if count == 0 {
+		return 0, false
+	}
+	return sum / float64(count), true
+}
+
+func skillOptJudgeMeanText(mean float64, ok bool, count int) string {
+	if !ok {
+		return "-"
+	}
+	return fmt.Sprintf("%.3f (n=%d)", mean, count)
+}
+
+// skillOptJudgeReportRoot decodes a captured judge eval report and returns the
+// candidate sources to inspect: the report root plus any nested evaluator_score
+// object (mirroring how the report is read at capture time).
+func skillOptJudgeReportRoot(judgeScoreJSON string) []map[string]any {
+	judgeScoreJSON = strings.TrimSpace(judgeScoreJSON)
+	if judgeScoreJSON == "" {
+		return nil
+	}
+	var report map[string]any
+	if err := json.Unmarshal([]byte(judgeScoreJSON), &report); err != nil {
+		return nil
+	}
+	sources := []map[string]any{report}
+	if nested := decodedSkillOptMetadataValue(report["evaluator_score"]); len(nested) > 0 {
+		sources = append(sources, nested)
+	}
+	return sources
+}
+
+func skillOptJudgeSoftScore(judgeScoreJSON string) (float64, bool) {
+	for _, source := range skillOptJudgeReportRoot(judgeScoreJSON) {
+		if value, ok := skillOptJudgeFloatValue(source["soft"]); ok {
+			return value, true
+		}
+	}
+	return 0, false
+}
+
+func skillOptJudgeDimensionScores(judgeScoreJSON string) map[string]float64 {
+	for _, source := range skillOptJudgeReportRoot(judgeScoreJSON) {
+		raw := decodedSkillOptMetadataValue(source["dimension_scores"])
+		if len(raw) == 0 {
+			continue
+		}
+		scores := make(map[string]float64, len(raw))
+		for name, value := range raw {
+			if score, ok := skillOptJudgeFloatValue(value); ok {
+				scores[name] = score
+			}
+		}
+		if len(scores) > 0 {
+			return scores
+		}
+	}
+	return nil
+}
+
+func skillOptJudgeFloatValue(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case json.Number:
+		parsed, err := typed.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
 }
 
 func runSkillOptCandidateShow(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -11701,6 +11701,54 @@ func containsString(values []string, want string) bool {
 	return false
 }
 
+func TestSkillOptJudgeReportRendersMatrixAndAgreement(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	for index, outcome := range []db.SkillOptJudgeOutcome{
+		{ID: "judge-outcome-1", CandidateVersionID: "planner@v2", TemplateID: "planner", JudgeScoreJSON: `{"soft":0.9,"dimension_scores":{"clarity":0.9,"safety":0.8}}`, HumanDecision: "promoted", Direction: db.SkillOptJudgeDirectionAgreeAccept},
+		{ID: "judge-outcome-2", CandidateVersionID: "planner@v3", TemplateID: "planner", JudgeScoreJSON: `{"soft":0.1,"dimension_scores":{"clarity":0.2,"safety":0.3}}`, HumanDecision: "rejected", Direction: db.SkillOptJudgeDirectionAgreeReject},
+		{ID: "judge-outcome-3", CandidateVersionID: "planner@v4", TemplateID: "planner", JudgeScoreJSON: `{"soft":0.8,"dimension_scores":{"clarity":0.85,"safety":0.7}}`, HumanDecision: "rejected", Direction: db.SkillOptJudgeDirectionJudgeAcceptHumanReject},
+	} {
+		if err := store.InsertSkillOptJudgeOutcome(context.Background(), outcome); err != nil {
+			t.Fatalf("InsertSkillOptJudgeOutcome %d returned error: %v", index, err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "judge-report", "--home", home, "--template", "planner"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt judge-report exit code = %d, stderr=%q", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"judge outcomes: 3",
+		"confusion matrix (judge vs human)",
+		"judge accept",
+		"judge reject",
+		// agreement = (agree_accept + agree_reject) / total = 2/3.
+		"agreement rate: 0.667 (2/3)",
+		"cohen's kappa:",
+		"calibration (judge soft-score band vs human promote rate)",
+		"per-dimension disagreement",
+		"clarity",
+		"safety",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("skillopt judge-report output missing %q\n%s", want, output)
+		}
+	}
+}
+
 func cliSkillOptTemplate(id string, body string) db.AgentTemplate {
 	content := cliSkillOptTemplateContent(id, body)
 	parsed, err := agenttemplate.ParseTemplateContent(content)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4645,7 +4645,14 @@ func captureSkillOptJudgeOutcome(ctx context.Context, execer sqlExecer, version 
 	if err != nil {
 		return err
 	}
-	judgeAccept, promptVersion, evaluatorID, promptHash := skillOptJudgeAcceptFromReport(evalReportJSON)
+	judgeAccept, hasSignal, promptVersion, evaluatorID, promptHash := skillOptJudgeAcceptFromReport(evalReportJSON)
+	if !hasSignal {
+		// No recognizable judge signal in the eval report (missing/empty/
+		// unrecognized): skip rather than record a misleading "judge rejected"
+		// outcome that would pollute the agreement dataset. Calibration excludes
+		// no-data decisions.
+		return nil
+	}
 	humanPromoted := strings.TrimSpace(humanDecision) == "promoted"
 	direction := skillOptJudgeDirection(humanPromoted, judgeAccept)
 	_, err = execer.ExecContext(ctx, `INSERT INTO skillopt_judge_outcomes(
@@ -4689,23 +4696,27 @@ func skillOptJudgeDirection(humanPromoted bool, judgeAccept bool) string {
 //
 // Judge-accept heuristic (most authoritative field wins):
 //  1. explicit boolean "promotable" — true => accept, false => reject;
-//  2. an explicit recommendation string ("recommendation"/"recommended_action"):
-//     "promote"/"accept" => accept, "reject" => reject;
+//  2. a recommendation string ("recommendation"/"recommended_action"):
+//     "promote"/"accept"/"approve"/"pass" => accept, "reject"/"decline"/"fail"
+//     => reject;
 //  3. a quality/contract status string ("quality_status"/"contract_status"):
-//     "pass"/"promote"/"ok"/"accept" => accept, an explicit "fail"/"reject" =>
-//     reject (statuses like "not_run" are inconclusive and skipped);
+//     "pass"/"passed"/"promote"/"ok"/"accept"/"approved" => accept,
+//     "fail"/"failed"/"reject"/"rejected" => reject (other statuses like
+//     "not_run" are inconclusive and skipped);
 //  4. fall back to the soft score: soft >= 0.5 => accept.
 //
-// If no signal at all is present the judge defaults to reject (a missing or
-// empty report is not evidence the judge endorsed the candidate).
-func skillOptJudgeAcceptFromReport(evalReportJSON string) (accept bool, promptVersion string, evaluatorID string, promptHash string) {
+// hasSignal reports whether any of the above produced a verdict. When it is
+// false (missing/empty/unrecognized report), callers should SKIP recording the
+// outcome rather than treat the absence of data as a "judge rejected" verdict,
+// which would pollute the calibration dataset.
+func skillOptJudgeAcceptFromReport(evalReportJSON string) (accept bool, hasSignal bool, promptVersion string, evaluatorID string, promptHash string) {
 	evalReportJSON = strings.TrimSpace(evalReportJSON)
 	if evalReportJSON == "" {
-		return false, "", "", ""
+		return false, false, "", "", ""
 	}
 	var report map[string]any
 	if err := json.Unmarshal([]byte(evalReportJSON), &report); err != nil {
-		return false, "", "", ""
+		return false, false, "", "", ""
 	}
 	// Search the report root and the nested evaluator_score object, preferring
 	// whichever supplies the most authoritative signal.
@@ -4721,34 +4732,34 @@ func skillOptJudgeAcceptFromReport(evalReportJSON string) (accept bool, promptVe
 	// 1) explicit promotable boolean.
 	for _, source := range sources {
 		if value, ok := source["promotable"].(bool); ok {
-			return value, promptVersion, evaluatorID, promptHash
+			return value, true, promptVersion, evaluatorID, promptHash
 		}
 	}
 	// 2) explicit recommendation.
 	if recommendation := firstSkillOptJudgeString(sources, "recommendation", "recommended_action"); recommendation != "" {
 		switch strings.ToLower(recommendation) {
 		case "promote", "accept", "approve", "pass":
-			return true, promptVersion, evaluatorID, promptHash
+			return true, true, promptVersion, evaluatorID, promptHash
 		case "reject", "decline", "fail":
-			return false, promptVersion, evaluatorID, promptHash
+			return false, true, promptVersion, evaluatorID, promptHash
 		}
 	}
 	// 3) quality / contract status.
 	if status := firstSkillOptJudgeString(sources, "quality_status", "contract_status"); status != "" {
 		switch strings.ToLower(status) {
 		case "pass", "passed", "promote", "ok", "accept", "approved":
-			return true, promptVersion, evaluatorID, promptHash
+			return true, true, promptVersion, evaluatorID, promptHash
 		case "fail", "failed", "reject", "rejected":
-			return false, promptVersion, evaluatorID, promptHash
+			return false, true, promptVersion, evaluatorID, promptHash
 		}
 	}
 	// 4) soft-score fallback.
 	for _, source := range sources {
 		if soft, ok := skillOptJudgeFloat(source["soft"]); ok {
-			return soft >= 0.5, promptVersion, evaluatorID, promptHash
+			return soft >= 0.5, true, promptVersion, evaluatorID, promptHash
 		}
 	}
-	return false, promptVersion, evaluatorID, promptHash
+	return false, false, promptVersion, evaluatorID, promptHash
 }
 
 func firstSkillOptJudgeString(sources []map[string]any, keys ...string) string {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2,12 +2,14 @@ package db
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 	"time"
@@ -95,6 +97,25 @@ type AgentTemplateCandidateReview struct {
 	CreatedAt           string
 	UpdatedAt           string
 	DecidedAt           string
+}
+
+// SkillOptJudgeOutcome records a single human promote/reject decision on a
+// SkillOpt candidate alongside the LLM judge's signal for the same candidate,
+// so judge calibration (agreement, Cohen's kappa, per-dimension drift) can be
+// computed offline. The raw judge eval report is stored in JudgeScoreJSON so
+// the derived Direction can always be recomputed from source.
+type SkillOptJudgeOutcome struct {
+	ID                 string
+	CandidateVersionID string
+	TemplateID         string
+	JudgeScoreJSON     string
+	JudgePromptVersion string
+	JudgeEvaluatorID   string
+	JudgePromptHash    string
+	HumanDecision      string
+	Direction          string
+	Reason             string
+	CreatedAt          string
 }
 
 type AgentRepo struct {
@@ -1346,7 +1367,16 @@ func (s *Store) DecideSkillOptTrainCandidate(ctx context.Context, session SkillO
 	if target.State != "pending" {
 		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not pending", target.ID, target.State)
 	}
-	switch strings.TrimSpace(decision) {
+	// Snapshot the candidate's eval report inside the transaction so the
+	// judge-outcome captured after commit reflects the report the decision was
+	// made against. Best-effort: capture must never fail the decision.
+	normalizedDecision := strings.TrimSpace(decision)
+	var captureReason string
+	if normalizedDecision == "rejected" {
+		captureReason = iteration.DecisionReason
+	}
+	capturedEvalReport := candidateEvalReportJSONTx(ctx, tx, target.ID)
+	switch normalizedDecision {
 	case "promoted":
 		current, hasCurrent, err := getCurrentAgentTemplateVersion(ctx, tx, target.TemplateID)
 		if err != nil {
@@ -1417,7 +1447,21 @@ func (s *Store) DecideSkillOptTrainCandidate(ctx context.Context, session SkillO
 	if err := tx.Commit(); err != nil {
 		return AgentTemplateVersion{}, err
 	}
+	// Capture the judge-vs-human outcome only after the decision is durably
+	// committed, and never let a capture failure surface to the caller — the
+	// human's promote/reject must stand regardless. (#345)
+	if err := captureSkillOptJudgeOutcome(ctx, s.db, target, capturedEvalReport, normalizedDecision, captureReason); err != nil {
+		log.Printf("skillopt: capture judge outcome for candidate %s failed: %v", target.ID, err)
+	}
 	return s.GetAgentTemplateVersionByID(ctx, target.ID)
+}
+
+func candidateEvalReportJSONTx(ctx context.Context, tx *sql.Tx, versionID string) string {
+	var report string
+	if err := tx.QueryRowContext(ctx, `SELECT eval_report_json FROM agent_template_candidate_reviews WHERE version_id = ?`, strings.TrimSpace(versionID)).Scan(&report); err != nil {
+		return ""
+	}
+	return report
 }
 
 func (s *Store) AgentCanAccessRepo(ctx context.Context, agentName string, repoFullName string) (bool, error) {
@@ -4481,6 +4525,260 @@ func scanAgentTemplateCandidateReview(scanner agentTemplateScanner) (AgentTempla
 	return review, nil
 }
 
+// SkillOpt judge-outcome direction buckets. The four directions are the cells
+// of the human-vs-judge confusion matrix.
+const (
+	// SkillOptJudgeDirectionAgreeAccept: human promoted and judge accepted.
+	SkillOptJudgeDirectionAgreeAccept = "agree_accept"
+	// SkillOptJudgeDirectionAgreeReject: human rejected and judge rejected.
+	SkillOptJudgeDirectionAgreeReject = "agree_reject"
+	// SkillOptJudgeDirectionJudgeAcceptHumanReject: judge accepted but the human
+	// rejected (a judge false positive relative to the human).
+	SkillOptJudgeDirectionJudgeAcceptHumanReject = "judge_accept_human_reject"
+	// SkillOptJudgeDirectionJudgeRejectHumanAccept: judge rejected but the human
+	// promoted (a judge false negative relative to the human).
+	SkillOptJudgeDirectionJudgeRejectHumanAccept = "judge_reject_human_accept"
+)
+
+func (s *Store) InsertSkillOptJudgeOutcome(ctx context.Context, outcome SkillOptJudgeOutcome) error {
+	id := strings.TrimSpace(outcome.ID)
+	if id == "" {
+		generated, err := newSkillOptJudgeOutcomeID()
+		if err != nil {
+			return err
+		}
+		id = generated
+	}
+	if strings.TrimSpace(outcome.CandidateVersionID) == "" {
+		return errors.New("judge outcome candidate_version_id is required")
+	}
+	if strings.TrimSpace(outcome.HumanDecision) == "" {
+		return errors.New("judge outcome human_decision is required")
+	}
+	if strings.TrimSpace(outcome.Direction) == "" {
+		return errors.New("judge outcome direction is required")
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO skillopt_judge_outcomes(
+			id, candidate_version_id, template_id, judge_score_json, judge_prompt_version,
+			judge_evaluator_id, judge_prompt_hash, human_decision, direction, reason
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id,
+		strings.TrimSpace(outcome.CandidateVersionID),
+		strings.TrimSpace(outcome.TemplateID),
+		strings.TrimSpace(outcome.JudgeScoreJSON),
+		strings.TrimSpace(outcome.JudgePromptVersion),
+		strings.TrimSpace(outcome.JudgeEvaluatorID),
+		strings.TrimSpace(outcome.JudgePromptHash),
+		strings.TrimSpace(outcome.HumanDecision),
+		strings.TrimSpace(outcome.Direction),
+		strings.TrimSpace(outcome.Reason))
+	return err
+}
+
+func (s *Store) ListSkillOptJudgeOutcomes(ctx context.Context, templateID string) ([]SkillOptJudgeOutcome, error) {
+	query := `SELECT id, candidate_version_id, template_id, judge_score_json, judge_prompt_version,
+			judge_evaluator_id, judge_prompt_hash, human_decision, direction, reason, created_at
+		FROM skillopt_judge_outcomes`
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if templateID = strings.TrimSpace(templateID); templateID != "" {
+		query += ` WHERE template_id = ? ORDER BY created_at, id`
+		rows, err = s.db.QueryContext(ctx, query, templateID)
+	} else {
+		query += ` ORDER BY created_at, id`
+		rows, err = s.db.QueryContext(ctx, query)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var outcomes []SkillOptJudgeOutcome
+	for rows.Next() {
+		outcome, err := scanSkillOptJudgeOutcome(rows)
+		if err != nil {
+			return nil, err
+		}
+		outcomes = append(outcomes, outcome)
+	}
+	return outcomes, rows.Err()
+}
+
+func (s *Store) GetSkillOptJudgeOutcome(ctx context.Context, id string) (SkillOptJudgeOutcome, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, candidate_version_id, template_id, judge_score_json, judge_prompt_version,
+			judge_evaluator_id, judge_prompt_hash, human_decision, direction, reason, created_at
+		FROM skillopt_judge_outcomes WHERE id = ?`, strings.TrimSpace(id))
+	return scanSkillOptJudgeOutcome(row)
+}
+
+func scanSkillOptJudgeOutcome(row interface{ Scan(dest ...any) error }) (SkillOptJudgeOutcome, error) {
+	var outcome SkillOptJudgeOutcome
+	if err := row.Scan(&outcome.ID, &outcome.CandidateVersionID, &outcome.TemplateID, &outcome.JudgeScoreJSON,
+		&outcome.JudgePromptVersion, &outcome.JudgeEvaluatorID, &outcome.JudgePromptHash, &outcome.HumanDecision,
+		&outcome.Direction, &outcome.Reason, &outcome.CreatedAt); err != nil {
+		return SkillOptJudgeOutcome{}, err
+	}
+	return outcome, nil
+}
+
+func newSkillOptJudgeOutcomeID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return "judge-outcome-" + hex.EncodeToString(raw[:]), nil
+}
+
+// captureSkillOptJudgeOutcome records one judge-vs-human outcome row for a
+// candidate decision. It is best-effort: capture must never fail the decision,
+// so callers log and continue on error.
+//
+// The judge accept/reject signal is read generically from the candidate
+// review's eval_report_json (never from new typed struct fields) using
+// skillOptJudgeAcceptFromReport, and the four-way Direction is derived from the
+// human decision crossed with that signal. The raw eval report is persisted in
+// JudgeScoreJSON so Direction can be recomputed later if the heuristic evolves.
+func captureSkillOptJudgeOutcome(ctx context.Context, execer sqlExecer, version AgentTemplateVersion, evalReportJSON string, humanDecision string, reason string) error {
+	id, err := newSkillOptJudgeOutcomeID()
+	if err != nil {
+		return err
+	}
+	judgeAccept, promptVersion, evaluatorID, promptHash := skillOptJudgeAcceptFromReport(evalReportJSON)
+	humanPromoted := strings.TrimSpace(humanDecision) == "promoted"
+	direction := skillOptJudgeDirection(humanPromoted, judgeAccept)
+	_, err = execer.ExecContext(ctx, `INSERT INTO skillopt_judge_outcomes(
+			id, candidate_version_id, template_id, judge_score_json, judge_prompt_version,
+			judge_evaluator_id, judge_prompt_hash, human_decision, direction, reason
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id,
+		strings.TrimSpace(version.ID),
+		strings.TrimSpace(version.TemplateID),
+		strings.TrimSpace(evalReportJSON),
+		promptVersion,
+		evaluatorID,
+		promptHash,
+		strings.TrimSpace(humanDecision),
+		direction,
+		strings.TrimSpace(reason))
+	return err
+}
+
+func skillOptJudgeDirection(humanPromoted bool, judgeAccept bool) string {
+	switch {
+	case humanPromoted && judgeAccept:
+		return SkillOptJudgeDirectionAgreeAccept
+	case !humanPromoted && !judgeAccept:
+		return SkillOptJudgeDirectionAgreeReject
+	case !humanPromoted && judgeAccept:
+		return SkillOptJudgeDirectionJudgeAcceptHumanReject
+	default: // humanPromoted && !judgeAccept
+		return SkillOptJudgeDirectionJudgeRejectHumanAccept
+	}
+}
+
+// skillOptJudgeAcceptFromReport derives a judge accept/reject signal plus the
+// judge prompt/evaluator identity from a candidate's eval report JSON, reading
+// everything generically (map[string]any) so it does not depend on any typed
+// struct fields that may be absent on older reports. The eval report may carry
+// the judge fields at the top level or nested under "evaluator_score" (the
+// EvaluatorScore object in internal/skillopt/contract.go), so both locations
+// are inspected.
+//
+// Judge-accept heuristic (most authoritative field wins):
+//  1. explicit boolean "promotable" — true => accept, false => reject;
+//  2. an explicit recommendation string ("recommendation"/"recommended_action"):
+//     "promote"/"accept" => accept, "reject" => reject;
+//  3. a quality/contract status string ("quality_status"/"contract_status"):
+//     "pass"/"promote"/"ok"/"accept" => accept, an explicit "fail"/"reject" =>
+//     reject (statuses like "not_run" are inconclusive and skipped);
+//  4. fall back to the soft score: soft >= 0.5 => accept.
+//
+// If no signal at all is present the judge defaults to reject (a missing or
+// empty report is not evidence the judge endorsed the candidate).
+func skillOptJudgeAcceptFromReport(evalReportJSON string) (accept bool, promptVersion string, evaluatorID string, promptHash string) {
+	evalReportJSON = strings.TrimSpace(evalReportJSON)
+	if evalReportJSON == "" {
+		return false, "", "", ""
+	}
+	var report map[string]any
+	if err := json.Unmarshal([]byte(evalReportJSON), &report); err != nil {
+		return false, "", "", ""
+	}
+	// Search the report root and the nested evaluator_score object, preferring
+	// whichever supplies the most authoritative signal.
+	sources := []map[string]any{report}
+	if nested, ok := report["evaluator_score"].(map[string]any); ok {
+		sources = append(sources, nested)
+	}
+
+	promptVersion = firstSkillOptJudgeString(sources, "judge_prompt_version", "prompt_version")
+	evaluatorID = firstSkillOptJudgeString(sources, "judge_evaluator_id", "evaluator_id", "profile_id")
+	promptHash = firstSkillOptJudgeString(sources, "judge_prompt_hash", "prompt_hash")
+
+	// 1) explicit promotable boolean.
+	for _, source := range sources {
+		if value, ok := source["promotable"].(bool); ok {
+			return value, promptVersion, evaluatorID, promptHash
+		}
+	}
+	// 2) explicit recommendation.
+	if recommendation := firstSkillOptJudgeString(sources, "recommendation", "recommended_action"); recommendation != "" {
+		switch strings.ToLower(recommendation) {
+		case "promote", "accept", "approve", "pass":
+			return true, promptVersion, evaluatorID, promptHash
+		case "reject", "decline", "fail":
+			return false, promptVersion, evaluatorID, promptHash
+		}
+	}
+	// 3) quality / contract status.
+	if status := firstSkillOptJudgeString(sources, "quality_status", "contract_status"); status != "" {
+		switch strings.ToLower(status) {
+		case "pass", "passed", "promote", "ok", "accept", "approved":
+			return true, promptVersion, evaluatorID, promptHash
+		case "fail", "failed", "reject", "rejected":
+			return false, promptVersion, evaluatorID, promptHash
+		}
+	}
+	// 4) soft-score fallback.
+	for _, source := range sources {
+		if soft, ok := skillOptJudgeFloat(source["soft"]); ok {
+			return soft >= 0.5, promptVersion, evaluatorID, promptHash
+		}
+	}
+	return false, promptVersion, evaluatorID, promptHash
+}
+
+func firstSkillOptJudgeString(sources []map[string]any, keys ...string) string {
+	for _, source := range sources {
+		for _, key := range keys {
+			if value, ok := source[key].(string); ok {
+				if trimmed := strings.TrimSpace(value); trimmed != "" {
+					return trimmed
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func skillOptJudgeFloat(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case json.Number:
+		parsed, err := typed.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
+}
+
 func agentTemplateFromVersion(version AgentTemplateVersion) AgentTemplate {
 	return AgentTemplate{
 		ID:             version.TemplateID,
@@ -5079,5 +5377,23 @@ CREATE INDEX idx_jobs_delegation_id ON jobs(delegation_id);
 	`
 ALTER TABLE agents ADD COLUMN model TEXT NOT NULL DEFAULT '';
 ALTER TABLE agent_instances ADD COLUMN model TEXT NOT NULL DEFAULT '';
+	`,
+	`
+CREATE TABLE skillopt_judge_outcomes (
+	id TEXT PRIMARY KEY,
+	candidate_version_id TEXT NOT NULL,
+	template_id TEXT NOT NULL DEFAULT '',
+	judge_score_json TEXT NOT NULL DEFAULT '',
+	judge_prompt_version TEXT NOT NULL DEFAULT '',
+	judge_evaluator_id TEXT NOT NULL DEFAULT '',
+	judge_prompt_hash TEXT NOT NULL DEFAULT '',
+	human_decision TEXT NOT NULL,
+	direction TEXT NOT NULL,
+	reason TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_skillopt_judge_outcomes_template ON skillopt_judge_outcomes(template_id);
+CREATE INDEX idx_skillopt_judge_outcomes_candidate ON skillopt_judge_outcomes(candidate_version_id);
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -2993,6 +2993,32 @@ func TestDecideSkillOptTrainCandidateCapturesJudgeOutcome(t *testing.T) {
 	}
 }
 
+func TestDecideSkillOptTrainCandidateSkipsCaptureWithoutJudgeSignal(t *testing.T) {
+	// A decision whose eval report carries no recognizable judge signal must not
+	// record a misleading "judge rejected" outcome — it is skipped entirely.
+	for _, report := range []string{"", "{}", `{"summary":"no judge fields here"}`} {
+		ctx := context.Background()
+		store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+		if err != nil {
+			t.Fatalf("Open returned error: %v", err)
+		}
+		candidate := seedSkillOptJudgeCandidate(t, store, report)
+		session := SkillOptTrainSession{ID: "session-1", TemplateID: "planner", State: "review_published"}
+		iteration := SkillOptTrainIteration{ID: "session-1-001", SessionID: "session-1", State: "review_published"}
+		if _, err := store.DecideSkillOptTrainCandidate(ctx, session, iteration, candidate.ID, "promoted"); err != nil {
+			t.Fatalf("DecideSkillOptTrainCandidate returned error: %v", err)
+		}
+		outcomes, err := store.ListSkillOptJudgeOutcomes(ctx, "planner")
+		if err != nil {
+			t.Fatalf("ListSkillOptJudgeOutcomes returned error: %v", err)
+		}
+		if len(outcomes) != 0 {
+			t.Fatalf("report %q: captured %d outcomes, want 0 (no judge signal)", report, len(outcomes))
+		}
+		store.Close()
+	}
+}
+
 func seedSkillOptJudgeCandidate(t *testing.T, store *Store, evalReportJSON string) AgentTemplateVersion {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -44,6 +44,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"skillopt_train_sessions",
 		"skillopt_train_iterations",
 		"skillopt_review_watches",
+		"skillopt_judge_outcomes",
 		"interactive_prompts",
 	} {
 		ok, err := store.HasTable(ctx, table)
@@ -2835,4 +2836,202 @@ func TestUpsertAgentInstancePersistsModel(t *testing.T) {
 	if agent.Model != "claude-sonnet-4-5" {
 		t.Fatalf("GetAgent (instance fallback) model = %q, want %q", agent.Model, "claude-sonnet-4-5")
 	}
+}
+
+func TestSkillOptJudgeOutcomeCRUDRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	outcome := SkillOptJudgeOutcome{
+		ID:                 "judge-outcome-1",
+		CandidateVersionID: "planner@v2",
+		TemplateID:         "planner",
+		JudgeScoreJSON:     `{"soft":0.81,"quality_status":"pass"}`,
+		JudgePromptVersion: "jp-2026-01",
+		JudgeEvaluatorID:   "landing_page_v1",
+		JudgePromptHash:    "deadbeef",
+		HumanDecision:      "promoted",
+		Direction:          SkillOptJudgeDirectionAgreeAccept,
+		Reason:             "looks good",
+	}
+	if err := store.InsertSkillOptJudgeOutcome(ctx, outcome); err != nil {
+		t.Fatalf("InsertSkillOptJudgeOutcome returned error: %v", err)
+	}
+
+	got, err := store.GetSkillOptJudgeOutcome(ctx, "judge-outcome-1")
+	if err != nil {
+		t.Fatalf("GetSkillOptJudgeOutcome returned error: %v", err)
+	}
+	if got.CandidateVersionID != outcome.CandidateVersionID ||
+		got.TemplateID != outcome.TemplateID ||
+		got.JudgeScoreJSON != outcome.JudgeScoreJSON ||
+		got.JudgePromptVersion != outcome.JudgePromptVersion ||
+		got.JudgeEvaluatorID != outcome.JudgeEvaluatorID ||
+		got.JudgePromptHash != outcome.JudgePromptHash ||
+		got.HumanDecision != outcome.HumanDecision ||
+		got.Direction != outcome.Direction ||
+		got.Reason != outcome.Reason {
+		t.Fatalf("GetSkillOptJudgeOutcome = %+v, want %+v", got, outcome)
+	}
+	if strings.TrimSpace(got.CreatedAt) == "" {
+		t.Fatalf("expected created_at to be populated, got %+v", got)
+	}
+
+	// A second outcome on a different template, plus an auto-generated id.
+	other := SkillOptJudgeOutcome{
+		CandidateVersionID: "reviewer@v3",
+		TemplateID:         "reviewer",
+		HumanDecision:      "rejected",
+		Direction:          SkillOptJudgeDirectionAgreeReject,
+	}
+	if err := store.InsertSkillOptJudgeOutcome(ctx, other); err != nil {
+		t.Fatalf("InsertSkillOptJudgeOutcome (auto id) returned error: %v", err)
+	}
+
+	all, err := store.ListSkillOptJudgeOutcomes(ctx, "")
+	if err != nil {
+		t.Fatalf("ListSkillOptJudgeOutcomes(all) returned error: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("ListSkillOptJudgeOutcomes(all) = %d rows, want 2", len(all))
+	}
+
+	plannerOnly, err := store.ListSkillOptJudgeOutcomes(ctx, "planner")
+	if err != nil {
+		t.Fatalf("ListSkillOptJudgeOutcomes(planner) returned error: %v", err)
+	}
+	if len(plannerOnly) != 1 || plannerOnly[0].ID != "judge-outcome-1" {
+		t.Fatalf("ListSkillOptJudgeOutcomes(planner) = %+v, want only judge-outcome-1", plannerOnly)
+	}
+
+	// Required fields are validated.
+	if err := store.InsertSkillOptJudgeOutcome(ctx, SkillOptJudgeOutcome{HumanDecision: "promoted", Direction: SkillOptJudgeDirectionAgreeAccept}); err == nil {
+		t.Fatal("InsertSkillOptJudgeOutcome with empty candidate_version_id returned nil error")
+	}
+}
+
+func TestDecideSkillOptTrainCandidateCapturesJudgeOutcome(t *testing.T) {
+	tests := []struct {
+		name          string
+		evalReport    string
+		decision      string
+		reason        string
+		wantDirection string
+	}{
+		{
+			name:          "promote with judge accept agrees",
+			evalReport:    `{"evaluator_score":{"soft":0.9,"quality_status":"pass","judge_prompt_version":"jp-1","evaluator_id":"landing_page_v1","judge_prompt_hash":"abc123"}}`,
+			decision:      "promoted",
+			wantDirection: SkillOptJudgeDirectionAgreeAccept,
+		},
+		{
+			name:          "promote with judge reject is judge_reject_human_accept",
+			evalReport:    `{"soft":0.2,"quality_status":"fail"}`,
+			decision:      "promoted",
+			wantDirection: SkillOptJudgeDirectionJudgeRejectHumanAccept,
+		},
+		{
+			name:          "reject with judge reject agrees",
+			evalReport:    `{"promotable":false,"soft":0.1}`,
+			decision:      "rejected",
+			reason:        "not actionable",
+			wantDirection: SkillOptJudgeDirectionAgreeReject,
+		},
+		{
+			name:          "reject with judge accept is judge_accept_human_reject",
+			evalReport:    `{"promotable":true,"soft":0.95}`,
+			decision:      "rejected",
+			reason:        "style mismatch",
+			wantDirection: SkillOptJudgeDirectionJudgeAcceptHumanReject,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+			if err != nil {
+				t.Fatalf("Open returned error: %v", err)
+			}
+			defer store.Close()
+
+			candidate := seedSkillOptJudgeCandidate(t, store, tc.evalReport)
+			session := SkillOptTrainSession{ID: "session-1", TemplateID: "planner", State: "review_published"}
+			iteration := SkillOptTrainIteration{ID: "session-1-001", SessionID: "session-1", State: "review_published", DecisionReason: tc.reason}
+
+			if _, err := store.DecideSkillOptTrainCandidate(ctx, session, iteration, candidate.ID, tc.decision); err != nil {
+				t.Fatalf("DecideSkillOptTrainCandidate returned error: %v", err)
+			}
+
+			outcomes, err := store.ListSkillOptJudgeOutcomes(ctx, "planner")
+			if err != nil {
+				t.Fatalf("ListSkillOptJudgeOutcomes returned error: %v", err)
+			}
+			if len(outcomes) != 1 {
+				t.Fatalf("captured %d outcomes, want 1", len(outcomes))
+			}
+			outcome := outcomes[0]
+			if outcome.CandidateVersionID != candidate.ID {
+				t.Fatalf("captured candidate_version_id = %q, want %q", outcome.CandidateVersionID, candidate.ID)
+			}
+			if outcome.Direction != tc.wantDirection {
+				t.Fatalf("captured direction = %q, want %q", outcome.Direction, tc.wantDirection)
+			}
+			if outcome.HumanDecision != tc.decision {
+				t.Fatalf("captured human_decision = %q, want %q", outcome.HumanDecision, tc.decision)
+			}
+			if outcome.JudgeScoreJSON != tc.evalReport {
+				t.Fatalf("captured judge_score_json = %q, want raw eval report %q", outcome.JudgeScoreJSON, tc.evalReport)
+			}
+			if tc.reason != "" && outcome.Reason != tc.reason {
+				t.Fatalf("captured reason = %q, want %q", outcome.Reason, tc.reason)
+			}
+		})
+	}
+}
+
+func seedSkillOptJudgeCandidate(t *testing.T, store *Store, evalReportJSON string) AgentTemplateVersion {
+	t.Helper()
+	ctx := context.Background()
+	template := AgentTemplate{
+		ID:             "planner",
+		Name:           "Planner",
+		Description:    "Plans work",
+		SourceRepo:     "local",
+		SourceRef:      "current",
+		SourcePath:     "planner.md",
+		ResolvedCommit: "abc123",
+		Content:        "Plan carefully.",
+		MetadataJSON:   `{"id":"planner","name":"Planner","description":"Plans work","kind":"agent-template","version":1,"capabilities":["ask"],"runtime_compatibility":["codex"],"tags":["planning"],"inputs":["task"],"outputs":["plan"]}`,
+	}
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	current, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	candidate, err := store.AddPendingAgentTemplateCandidate(ctx, AgentTemplate{
+		ID:             "planner",
+		Name:           "Planner Candidate",
+		Description:    "Plans work",
+		SourceRepo:     "gitmoot-skillopt",
+		SourceRef:      "candidate",
+		SourcePath:     "candidate.json",
+		ResolvedCommit: "def456",
+		Content:        "Plan carefully with risks.",
+		MetadataJSON:   template.MetadataJSON,
+	}, AgentTemplateCandidateReview{
+		TemplateID:     "planner",
+		BaseVersionID:  current.VersionID,
+		EvalReportJSON: evalReportJSON,
+		State:          "pending",
+	}, nil)
+	if err != nil {
+		t.Fatalf("AddPendingAgentTemplateCandidate returned error: %v", err)
+	}
+	return candidate
 }

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -139,6 +139,9 @@ type EvaluatorScore struct {
 	GateRejection          *GateRejectionPacket    `json:"gate_rejection,omitempty"`
 	StageStatus            []EvaluatorStageStatus  `json:"stage_status,omitempty"`
 	Metadata               json.RawMessage         `json:"metadata,omitempty"`
+	JudgePromptVersion     string                  `json:"judge_prompt_version,omitempty"`
+	JudgeEvaluatorID       string                  `json:"judge_evaluator_id,omitempty"`
+	JudgePromptHash        string                  `json:"judge_prompt_hash,omitempty"`
 }
 
 type EvalRun struct {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -1191,3 +1191,41 @@ func TestTemplateMetadataSynthesizedForLegacyEmptyRows(t *testing.T) {
 		t.Fatal("corrupt metadata must still error")
 	}
 }
+
+func TestEvaluatorScoreJudgePromptFieldsRoundTrip(t *testing.T) {
+	score := EvaluatorScore{
+		ProfileID:          "judge-default",
+		JudgePromptVersion: "2026-06-19.1",
+		JudgeEvaluatorID:   "evaluator-abc",
+		JudgePromptHash:    "sha256:deadbeef",
+	}
+	encoded, err := json.Marshal(score)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	var decoded EvaluatorScore
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if decoded.JudgePromptVersion != score.JudgePromptVersion {
+		t.Errorf("JudgePromptVersion = %q, want %q", decoded.JudgePromptVersion, score.JudgePromptVersion)
+	}
+	if decoded.JudgeEvaluatorID != score.JudgeEvaluatorID {
+		t.Errorf("JudgeEvaluatorID = %q, want %q", decoded.JudgeEvaluatorID, score.JudgeEvaluatorID)
+	}
+	if decoded.JudgePromptHash != score.JudgePromptHash {
+		t.Errorf("JudgePromptHash = %q, want %q", decoded.JudgePromptHash, score.JudgePromptHash)
+	}
+}
+
+func TestEvaluatorScoreJudgePromptFieldsOmitEmpty(t *testing.T) {
+	encoded, err := json.Marshal(EvaluatorScore{ProfileID: "judge-default"})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	for _, field := range []string{"judge_prompt_version", "judge_evaluator_id", "judge_prompt_hash"} {
+		if strings.Contains(string(encoded), field) {
+			t.Errorf("empty EvaluatorScore must omit %q, got %s", field, encoded)
+		}
+	}
+}

--- a/scripts/skillopt-train-smoke.sh
+++ b/scripts/skillopt-train-smoke.sh
@@ -9,6 +9,14 @@ CONTRACT_TESTS=(
   TestEvaluatorProfileAndFailurePacketContractsRoundTrip
   TestImportCandidatePackageRejectsNoCandidateMetadata
   TestImportCandidatePackageRejectsUnchangedContent
+  TestEvaluatorScoreJudgePromptFieldsRoundTrip
+  TestEvaluatorScoreJudgePromptFieldsOmitEmpty
+)
+
+DB_TESTS=(
+  TestSkillOptJudgeOutcomeCRUDRoundTrip
+  TestDecideSkillOptTrainCandidateCapturesJudgeOutcome
+  TestDecideSkillOptTrainCandidateSkipsCaptureWithoutJudgeSignal
 )
 
 CLI_TESTS=(
@@ -21,6 +29,7 @@ CLI_TESTS=(
   TestSkillOptPreviewRouteSlugsUnsafeSegments
   TestTrustedVueViteScaffoldUsesRelativeBase
   TestSkillOptGitHubPagesURLHandlesProjectAndUserPages
+  TestSkillOptJudgeReportRendersMatrixAndAgreement
   TestSkillOptTrainContinueRecordsNoCandidateResult
   TestSkillOptTrainContinueRerunsOptimizerAfterNoCandidate
   TestSkillOptTrainContinuePublishesCandidateReviewPromotesAndStartsNext
@@ -49,9 +58,11 @@ cd "$ROOT_DIR"
 IFS='|'
 CONTRACT_TEST_PATTERN="${CONTRACT_TESTS[*]}"
 CLI_TEST_PATTERN="${CLI_TESTS[*]}"
+DB_TEST_PATTERN="${DB_TESTS[*]}"
 unset IFS
 
 GOTOOLCHAIN="$GO_TOOLCHAIN" "$GO_BIN" test ./internal/skillopt -run "$CONTRACT_TEST_PATTERN"
+GOTOOLCHAIN="$GO_TOOLCHAIN" "$GO_BIN" test ./internal/db -run "$DB_TEST_PATTERN"
 GOTOOLCHAIN="$GO_TOOLCHAIN" "$GO_BIN" test ./internal/cli -run "$CLI_TEST_PATTERN"
 
 echo "skillopt train smoke passed"

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -482,6 +482,7 @@ gitmoot skillopt train run [--config path | --session <id>] [--plain]
 gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
 gitmoot skillopt train recover --session <id> [--out-root path] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
+gitmoot skillopt judge-report [--template <id>] [--home <path>]
 ```
 
 On a real terminal, `skillopt train run` opens an interactive view of one session
@@ -550,6 +551,22 @@ report JSON, preference summary, and a content diff against the base/current
 version. `skillopt candidate promote` makes a pending candidate current, while
 `skillopt candidate reject` records an auditable rejection and prevents that
 version from being selected by `@latest`.
+
+At the manual promote/reject gate, Gitmoot records every judge↔human outcome
+into a local store — all four directions: `agree_accept`, `agree_reject`,
+`judge_accept_human_reject` (judge accepts, human rejects — a false positive),
+and `judge_reject_human_accept` (judge rejects, human accepts — a false
+negative). Each outcome is tagged with the judge prompt version, evaluator id,
+and prompt hash that produced the score, so later analysis can compare judges by
+prompt revision. This capture is measurement only: it never changes the judge,
+overrides a decision, or bumps the result contract.
+
+`skillopt judge-report` reads those captured outcomes and reports how well the
+LLM judge is calibrated against human verdicts. It prints a confusion matrix
+(the four `direction` buckets), the agreement rate and Cohen's κ, calibration
+buckets (judge soft-score versus the human decision), and per-dimension
+disagreement. Pass `--template <id>` to scope the report to one template, and
+`--home <path>` to read from a non-default Gitmoot home. It is read-only.
 
 The Markdown feedback collector writes blind A/B review packets with `index.md`,
 per-item Markdown files, editable `feedback.yml`, and hidden assignment metadata

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -279,6 +279,21 @@ wait, or reject and `--start-next` to keep improving. LaTeX/PDF, Storybook,
 notebook, image, and other preview types are future adapters, not current
 renderer/publisher pairs.
 
+At each manual promote/reject decision, Gitmoot records the judge↔human outcome
+into a local store, tagged with the judge prompt version/id/hash that produced
+the score. All four directions are captured — `agree_accept`, `agree_reject`,
+`judge_accept_human_reject` (false positive), `judge_reject_human_accept` (false
+negative) — so you can measure agreements as well as disagreements. Capture is
+measurement only: it never alters the judge, overrides the decision, or bumps
+the result contract, and a capture error never fails the decision.
+
+Inspect calibration with `gitmoot skillopt judge-report [--template <id>]
+[--home <path>]`. It is read-only and prints a confusion matrix over the four
+directions, the agreement rate and Cohen's κ, calibration buckets (judge
+soft-score versus the human decision), and per-dimension disagreement — useful
+to tell whether the LLM judge is well-calibrated against human verdicts before
+you trust it to gate candidates.
+
 Run the deterministic smoke before changing train behavior:
 
 ```sh

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -479,6 +479,7 @@ gitmoot skillopt train run [--config path | --session <id>] [--plain]
 gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
 gitmoot skillopt train recover --session <id> [--out-root path] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
+gitmoot skillopt judge-report [--template <id>] [--home <path>]
 ```
 
 On a real terminal, `skillopt train run` opens an interactive view of one session
@@ -559,6 +560,22 @@ report JSON, preference summary, and a content diff against the base/current
 version. `skillopt candidate promote` makes a pending candidate current, while
 `skillopt candidate reject` records an auditable rejection and prevents that
 version from being selected by `@latest`.
+
+At the manual promote/reject gate, Gitmoot records every judge↔human outcome
+into a local store — all four directions: `agree_accept`, `agree_reject`,
+`judge_accept_human_reject` (judge accepts, human rejects — a false positive),
+and `judge_reject_human_accept` (judge rejects, human accepts — a false
+negative). Each outcome is tagged with the judge prompt version, evaluator id,
+and prompt hash that produced the score, so later analysis can compare judges by
+prompt revision. This capture is measurement only: it never changes the judge,
+overrides a decision, or bumps the result contract.
+
+`skillopt judge-report` reads those captured outcomes and reports how well the
+LLM judge is calibrated against human verdicts. It prints a confusion matrix
+(the four `direction` buckets), the agreement rate and Cohen's κ, calibration
+buckets (judge soft-score versus the human decision), and per-dimension
+disagreement. Pass `--template <id>` to scope the report to one template, and
+`--home <path>` to read from a non-default Gitmoot home. It is read-only.
 
 The Markdown feedback collector writes blind A/B review packets with `index.md`,
 per-item Markdown files, editable `feedback.yml`, and hidden assignment metadata

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -680,6 +680,38 @@ Manual append-style next iterations are not supported. The train state machine
 creates the next iteration atomically from the resolved previous decision, its
 eval run, and copied item plan.
 
+## Judge↔Human Outcome Capture
+
+At each manual promote/reject decision, Gitmoot records the judge↔human outcome
+into a local store, tagged with the judge prompt version, evaluator id, and
+prompt hash that produced the candidate's score. All four directions are
+captured:
+
+- `agree_accept`: the judge accepted the candidate and the human promoted it;
+- `agree_reject`: the judge rejected the candidate and the human rejected it;
+- `judge_accept_human_reject`: the judge accepted but the human rejected (a
+  false positive);
+- `judge_reject_human_accept`: the judge rejected but the human promoted (a
+  false negative).
+
+Capture is measurement only. It never changes the judge, overrides the human
+decision, or bumps the result contract, and a capture error never fails the
+decision.
+
+Inspect how well the LLM judge tracks human verdicts:
+
+```sh
+gitmoot skillopt judge-report --template planner
+gitmoot skillopt judge-report --template planner --home /path/to/home
+```
+
+`judge-report` is read-only. It prints a confusion matrix over the four
+directions, the agreement rate and Cohen's κ, calibration buckets (judge
+soft-score versus the human decision), and per-dimension disagreement. `--template`
+scopes the report to one template, and `--home` reads from a non-default Gitmoot
+home. Use it to decide whether the judge is well-calibrated enough to trust at
+the gate before relying on it for candidate decisions.
+
 ## Deterministic Smoke
 
 Run the local train smoke script before shipping train-mode changes:

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5710,6 +5710,7 @@ gitmoot skillopt train run [--config path | --session <id>] [--plain]
 gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
 gitmoot skillopt train recover --session <id> [--out-root path] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
+gitmoot skillopt judge-report [--template <id>] [--home <path>]
 ```
 
 On a real terminal, `skillopt train run` opens an interactive view of one session
@@ -5778,6 +5779,22 @@ report JSON, preference summary, and a content diff against the base/current
 version. `skillopt candidate promote` makes a pending candidate current, while
 `skillopt candidate reject` records an auditable rejection and prevents that
 version from being selected by `@latest`.
+
+At the manual promote/reject gate, Gitmoot records every judge↔human outcome
+into a local store — all four directions: `agree_accept`, `agree_reject`,
+`judge_accept_human_reject` (judge accepts, human rejects — a false positive),
+and `judge_reject_human_accept` (judge rejects, human accepts — a false
+negative). Each outcome is tagged with the judge prompt version, evaluator id,
+and prompt hash that produced the score, so later analysis can compare judges by
+prompt revision. This capture is measurement only: it never changes the judge,
+overrides a decision, or bumps the result contract.
+
+`skillopt judge-report` reads those captured outcomes and reports how well the
+LLM judge is calibrated against human verdicts. It prints a confusion matrix
+(the four `direction` buckets), the agreement rate and Cohen's κ, calibration
+buckets (judge soft-score versus the human decision), and per-dimension
+disagreement. Pass `--template <id>` to scope the report to one template, and
+`--home <path>` to read from a non-default Gitmoot home. It is read-only.
 
 The Markdown feedback collector writes blind A/B review packets with `index.md`,
 per-item Markdown files, editable `feedback.yml`, and hidden assignment metadata
@@ -6086,6 +6103,21 @@ review repo. Candidate decisions are explicit: promote, reject with a reason,
 wait, or reject and `--start-next` to keep improving. LaTeX/PDF, Storybook,
 notebook, image, and other preview types are future adapters, not current
 renderer/publisher pairs.
+
+At each manual promote/reject decision, Gitmoot records the judge↔human outcome
+into a local store, tagged with the judge prompt version/id/hash that produced
+the score. All four directions are captured — `agree_accept`, `agree_reject`,
+`judge_accept_human_reject` (false positive), `judge_reject_human_accept` (false
+negative) — so you can measure agreements as well as disagreements. Capture is
+measurement only: it never alters the judge, overrides the decision, or bumps
+the result contract, and a capture error never fails the decision.
+
+Inspect calibration with `gitmoot skillopt judge-report [--template <id>]
+[--home <path>]`. It is read-only and prints a confusion matrix over the four
+directions, the agreement rate and Cohen's κ, calibration buckets (judge
+soft-score versus the human decision), and per-dimension disagreement — useful
+to tell whether the LLM judge is well-calibrated against human verdicts before
+you trust it to gate candidates.
 
 Run the deterministic smoke before changing train behavior:
 


### PR DESCRIPTION
## What (Phase 1 of #345)
At the manual promote/reject gate, record **every** judge↔human outcome (agreements *and* disagreements) into a local `skillopt_judge_outcomes` table — tagged with which judge prompt produced the score — and add `gitmoot skillopt judge-report` to view calibration. This is the measurement substrate Phase 2 (judge-prompt optimization) builds on. **No judge change, no `contract_version` bump** — additive only.

## How
- **DB** (`internal/db/store.go`): migration + `skillopt_judge_outcomes` table; `SkillOptJudgeOutcome` CRUD; capture inside `DecideSkillOptTrainCandidate` (best-effort — never fails the human decision), recording all four `direction` buckets (`agree_accept`/`agree_reject`/`judge_accept_human_reject`/`judge_reject_human_accept`). The judge-accept signal is read **generically** from the eval-report JSON (promotable → recommendation → quality/contract status → soft-score fallback); the raw report is stored so direction is recomputable.
- **Contract** (`internal/skillopt/contract.go`): additive `EvaluatorScore` fields `judge_prompt_version` / `judge_evaluator_id` / `judge_prompt_hash` (`omitempty`).
- **CLI** (`internal/cli/skillopt.go`): `gitmoot skillopt judge-report [--template <id>]` — confusion matrix, agreement rate + Cohen's κ, soft-score calibration bands, per-dimension disagreement.
- **Docs** both trees + `llms-full.txt` regenerated; smoke suite extended.

## Review (`/code-review high --fix`)
Applied: **skip capture when the report has no judge signal** (don't pollute the dataset with a phantom "reject"; regression test added); κ reports `n/a` for a degenerate table instead of a misleading `1.0`; calibration clamps out-of-range soft scores; heuristic doc aligned. Deferred (noted): factoring the report-signal parser into a shared `internal/skillopt` helper → Step 2's contract work.

## Verification
- `go build/vet`, `go test ./...`, `go test -race ./internal/workflow/` — all green.
- `scripts/skillopt-train-smoke.sh` extended + green (CRUD round-trip, all four directions via the real `DecideSkillOptTrainCandidate`, no-signal skip, report rendering).
- Live isolated-`--home`: migration creates `skillopt_judge_outcomes`; `judge-report` renders.

Part of #344. Phase 1 of #345 (Phase 2 = judge-prompt optimization, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)