### PR TITLE
feat(skillopt): carry per-task_kind judge prompt + version in the contract (#345 Phase 2)

### DIFF
--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -77,6 +77,97 @@ type EvaluatorJudgeConfig struct {
 	Config json.RawMessage `json:"config,omitempty"`
 }
 
+// JudgePromptConfig is the additive, per-task_kind judge prompt payload carried
+// inside EvaluatorJudgeConfig.Config. It (un)marshals from the existing opaque
+// json.RawMessage passthrough, so it adds no new top-level contract fields and
+// does not bump ContractVersion. The Python judge reads
+// evaluator_profile.judge.config.judge_prompt_templates (keyed by task_kind) and
+// evaluator_profile.judge.config.judge_prompt_version.
+type JudgePromptConfig struct {
+	JudgePromptTemplates map[string]string `json:"judge_prompt_templates,omitempty"`
+	JudgePromptVersion   string            `json:"judge_prompt_version,omitempty"`
+}
+
+// JudgePromptConfig extracts the per-task_kind judge prompt templates and
+// version carried inside the judge Config passthrough, if present and
+// well-formed. It returns nil when neither field is present. Malformed shapes
+// (templates not an object of string→string, version not a string) are ignored,
+// consistent with the file's other best-effort metadata accessors, so a bad
+// payload never crashes export or import.
+func (c *EvaluatorJudgeConfig) JudgePromptConfig() *JudgePromptConfig {
+	if c == nil {
+		return nil
+	}
+	return parseJudgePromptConfig(c.Config)
+}
+
+func parseJudgePromptConfig(raw json.RawMessage) *JudgePromptConfig {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return nil
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil
+	}
+	out := &JudgePromptConfig{}
+	if rawTemplates, ok := decoded["judge_prompt_templates"]; ok {
+		var templates map[string]string
+		if err := json.Unmarshal(rawTemplates, &templates); err == nil && len(templates) > 0 {
+			out.JudgePromptTemplates = templates
+		}
+	}
+	if rawVersion, ok := decoded["judge_prompt_version"]; ok {
+		var version string
+		if err := json.Unmarshal(rawVersion, &version); err == nil {
+			out.JudgePromptVersion = strings.TrimSpace(version)
+		}
+	}
+	if len(out.JudgePromptTemplates) == 0 && out.JudgePromptVersion == "" {
+		return nil
+	}
+	return out
+}
+
+// mergeJudgePromptConfig folds the per-task_kind judge prompt templates and
+// version (parsed from the evaluator config) into the judge's opaque Config
+// passthrough without disturbing any other keys already present there. It is
+// additive: existing Config keys win on conflict only for non-judge-prompt
+// fields; the judge-prompt fields are (re)written from the parsed payload so the
+// validated shape is what survives export. A nil payload leaves Config
+// untouched.
+func mergeJudgePromptConfig(existing json.RawMessage, payload *JudgePromptConfig) (json.RawMessage, error) {
+	if payload == nil || (len(payload.JudgePromptTemplates) == 0 && payload.JudgePromptVersion == "") {
+		return existing, nil
+	}
+	merged := map[string]json.RawMessage{}
+	if trimmed := bytes.TrimSpace(existing); len(trimmed) > 0 {
+		if err := json.Unmarshal(trimmed, &merged); err != nil {
+			// Existing Config is not a JSON object we can extend; do not clobber it.
+			return existing, nil
+		}
+	}
+	if len(payload.JudgePromptTemplates) > 0 {
+		encoded, err := json.Marshal(payload.JudgePromptTemplates)
+		if err != nil {
+			return existing, err
+		}
+		merged["judge_prompt_templates"] = encoded
+	}
+	if payload.JudgePromptVersion != "" {
+		encoded, err := json.Marshal(payload.JudgePromptVersion)
+		if err != nil {
+			return existing, err
+		}
+		merged["judge_prompt_version"] = encoded
+	}
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return existing, err
+	}
+	return json.RawMessage(out), nil
+}
+
 type EvaluatorStageStatus struct {
 	Stage      string          `json:"stage,omitempty"`
 	Status     string          `json:"status,omitempty"`
@@ -490,6 +581,27 @@ func EvaluatorProfileFromConfig(config json.RawMessage) *EvaluatorProfile {
 	return BuildEvaluatorProfile(evaluatorID, evaluatorModel, config)
 }
 
+// judgePromptConfigFromConfig pulls the per-task_kind judge prompt templates and
+// version out of the evaluator config, accepting them either at the top level or
+// nested under "evaluation" (mirroring how evaluator_id/evaluator_model are
+// read). It is best-effort: malformed shapes yield nil rather than an error.
+func judgePromptConfigFromConfig(config json.RawMessage) *JudgePromptConfig {
+	if len(bytes.TrimSpace(config)) == 0 {
+		return nil
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(config, &decoded); err != nil {
+		return nil
+	}
+	if payload := parseJudgePromptConfig(config); payload != nil {
+		return payload
+	}
+	if nested, ok := decoded["evaluation"]; ok {
+		return parseJudgePromptConfig(nested)
+	}
+	return nil
+}
+
 func BuildEvaluatorProfile(evaluatorID string, evaluatorModel string, metadata json.RawMessage) *EvaluatorProfile {
 	profileID := strings.TrimSpace(evaluatorID)
 	evaluatorID = strings.ToLower(profileID)
@@ -499,6 +611,11 @@ func BuildEvaluatorProfile(evaluatorID string, evaluatorModel string, metadata j
 	judge := &EvaluatorJudgeConfig{Type: "llm_judge", When: "checks_pass"}
 	if model := strings.TrimSpace(evaluatorModel); model != "" {
 		judge.Model = model
+	}
+	if payload := judgePromptConfigFromConfig(metadata); payload != nil {
+		if merged, err := mergeJudgePromptConfig(judge.Config, payload); err == nil {
+			judge.Config = merged
+		}
 	}
 	switch evaluatorID {
 	case "landing_page_v1", "vue_landing_page_v1":

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -238,6 +238,163 @@ func TestExportTrainingPackagePreservesEvaluatorConfigNumberFidelity(t *testing.
 	}
 }
 
+func TestExportTrainingPackageCarriesJudgePromptTemplates(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("designer", "Design carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "designer")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "judge-prompt-run",
+		TemplateID:        "designer",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		MetadataJSON: `{"evaluation":{"evaluator_id":"landing_page_v1","evaluator_model":"gpt-evaluator",` +
+			`"judge_prompt_version":"jp-2",` +
+			`"judge_prompt_templates":{"vue_landing_page":"Judge the landing page.","generic":"Judge the artifact."}}}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+
+	pkg, err := ExportTrainingPackage(ctx, store, "judge-prompt-run")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	if pkg.EvaluatorProfile == nil || pkg.EvaluatorProfile.Judge == nil {
+		t.Fatalf("evaluator profile/judge missing: %+v", pkg.EvaluatorProfile)
+	}
+
+	assertJudgePrompt := func(t *testing.T, judge *EvaluatorJudgeConfig) {
+		t.Helper()
+		payload := judge.JudgePromptConfig()
+		if payload == nil {
+			t.Fatalf("judge prompt config missing; judge.Config = %s", string(judge.Config))
+		}
+		if payload.JudgePromptVersion != "jp-2" {
+			t.Fatalf("judge_prompt_version = %q, want jp-2", payload.JudgePromptVersion)
+		}
+		if len(payload.JudgePromptTemplates) != 2 ||
+			payload.JudgePromptTemplates["vue_landing_page"] != "Judge the landing page." ||
+			payload.JudgePromptTemplates["generic"] != "Judge the artifact." {
+			t.Fatalf("judge_prompt_templates = %+v", payload.JudgePromptTemplates)
+		}
+	}
+	assertJudgePrompt(t, pkg.EvaluatorProfile.Judge)
+
+	// The fields must survive a JSON round-trip (export → marshal → unmarshal),
+	// which is the boundary the Python judge reads across.
+	encoded, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatalf("marshal package: %v", err)
+	}
+	var decoded TrainingPackage
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal package: %v", err)
+	}
+	if decoded.EvaluatorProfile == nil || decoded.EvaluatorProfile.Judge == nil {
+		t.Fatalf("decoded evaluator profile/judge missing: %+v", decoded.EvaluatorProfile)
+	}
+	assertJudgePrompt(t, decoded.EvaluatorProfile.Judge)
+
+	// The Python side reads it at evaluator_profile.judge.config.* — verify the
+	// on-wire JSON path is exactly that.
+	if !strings.Contains(string(decoded.EvaluatorProfile.Judge.Config), `"judge_prompt_version":"jp-2"`) {
+		t.Fatalf("judge.config did not carry judge_prompt_version on the wire: %s", string(decoded.EvaluatorProfile.Judge.Config))
+	}
+
+	// The raw evaluator config also passes through unchanged.
+	if !strings.Contains(string(decoded.EvaluatorConfig), `"judge_prompt_version":"jp-2"`) ||
+		!strings.Contains(string(decoded.EvaluatorConfig), `"vue_landing_page":"Judge the landing page."`) {
+		t.Fatalf("evaluator_config did not carry judge prompt fields: %s", string(decoded.EvaluatorConfig))
+	}
+}
+
+func TestExportTrainingPackageJudgePromptTemplatesAbsentIsBackwardCompatible(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := testTemplate("designer", "Design carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "designer")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "no-judge-prompt-run",
+		TemplateID:        "designer",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "review",
+		MetadataJSON:      `{"evaluation":{"evaluator_id":"landing_page_v1","evaluator_model":"gpt-evaluator"}}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+
+	pkg, err := ExportTrainingPackage(ctx, store, "no-judge-prompt-run")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	if pkg.EvaluatorProfile == nil || pkg.EvaluatorProfile.Judge == nil {
+		t.Fatalf("evaluator profile/judge missing: %+v", pkg.EvaluatorProfile)
+	}
+	// Absent fields must not synthesize a judge prompt payload and must not add
+	// a judge config object to the wire format.
+	if payload := pkg.EvaluatorProfile.Judge.JudgePromptConfig(); payload != nil {
+		t.Fatalf("expected no judge prompt config, got %+v", payload)
+	}
+	if len(strings.TrimSpace(string(pkg.EvaluatorProfile.Judge.Config))) != 0 {
+		t.Fatalf("judge config should be empty when absent, got %s", string(pkg.EvaluatorProfile.Judge.Config))
+	}
+	encoded, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatalf("marshal package: %v", err)
+	}
+	if strings.Contains(string(encoded), "judge_prompt_templates") || strings.Contains(string(encoded), "judge_prompt_version") {
+		t.Fatalf("absent judge prompt fields leaked into package JSON: %s", string(encoded))
+	}
+}
+
+func TestEvaluatorJudgeConfigJudgePromptConfigIgnoresMalformedShapes(t *testing.T) {
+	tests := map[string]string{
+		"templates not an object":      `{"judge_prompt_templates":["a","b"]}`,
+		"templates values not strings": `{"judge_prompt_templates":{"vue":1}}`,
+		"version not a string":         `{"judge_prompt_version":42}`,
+		"config not an object":         `"just a string"`,
+		"empty templates object":       `{"judge_prompt_templates":{}}`,
+		"unrelated keys only":          `{"something_else":true}`,
+	}
+	for name, config := range tests {
+		t.Run(name, func(t *testing.T) {
+			judge := &EvaluatorJudgeConfig{Config: json.RawMessage(config)}
+			if payload := judge.JudgePromptConfig(); payload != nil {
+				t.Fatalf("malformed config %q should be ignored, got %+v", config, payload)
+			}
+		})
+	}
+	// A valid version alongside a malformed templates map still yields the
+	// version (the malformed half is dropped, not fatal).
+	judge := &EvaluatorJudgeConfig{Config: json.RawMessage(`{"judge_prompt_version":"jp-3","judge_prompt_templates":[1,2]}`)}
+	payload := judge.JudgePromptConfig()
+	if payload == nil || payload.JudgePromptVersion != "jp-3" || len(payload.JudgePromptTemplates) != 0 {
+		t.Fatalf("expected version-only payload, got %+v", payload)
+	}
+}
+
 func TestExportTrainingPackageBuildsEvaluatorProfileFromMetadata(t *testing.T) {
 	ctx := context.Background()
 	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
## What (Phase 2 of #345 — gitmoot Go scaffolding)
Additively carry a **per-`task_kind` judge prompt** map + a **`judge_prompt_version`** through the SkillOpt contract, so the gitmoot-skillopt optimizer can make the judge prompt a versioned, per-task-kind artifact and tune it. **No `contract_version` bump; no existing field changed.**

## How
- Carried via the existing opaque `EvaluatorJudgeConfig.Config` (`json.RawMessage`) — the judge's own passthrough. On-wire: `evaluator_profile.judge.config.judge_prompt_templates` (object: `task_kind` → system prompt) + `...judge_prompt_version` (string). The raw `evaluator_config` also passes through unchanged.
- New additive helpers: `JudgePromptConfig` + typed accessor `(*EvaluatorJudgeConfig).JudgePromptConfig()`; `parseJudgePromptConfig`/`judgePromptConfigFromConfig` (best-effort, reads fields at config top level or nested under `evaluation`, mirroring `evaluator_id`/`evaluator_model`); `mergeJudgePromptConfig` (folds into `judge.Config` without clobbering existing keys; injects nothing when absent). Wired into `EvaluatorProfileFromConfig`/`BuildEvaluatorProfile`/`ExportTrainingPackage`.
- **Malformed shapes are ignored, never fatal** (consistent with the file's other best-effort metadata accessors); a valid version survives a malformed templates map and vice versa.

## Verification
- `go build/vet`, `go test ./...`, `go test -race ./internal/workflow/` — all green.
- 3 round-trip tests: export carries the templates+version intact (via typed accessor and on-wire JSON path + raw `evaluator_config`); absence is backward-compatible (no empty `config` object); malformed shapes ignored.
- `/code-review`: no findings (purely additive within the opaque field).

The Python consumer (judge-prompt resolution + optimization) lands in a separate PR to `jerryfane/gitmoot-skillopt`. Part of #344 / #345 Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)