### PR TITLE
fix(skillopt): recognize real landing-page eval-report shape in judge capture (#345)

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4703,7 +4703,9 @@ func skillOptJudgeDirection(humanPromoted bool, judgeAccept bool) string {
 //     "pass"/"passed"/"promote"/"ok"/"accept"/"approved" => accept,
 //     "fail"/"failed"/"reject"/"rejected" => reject (other statuses like
 //     "not_run" are inconclusive and skipped);
-//  4. fall back to the soft score: soft >= 0.5 => accept.
+//  4. fall back to a soft/selection score — "soft", or the landing-page
+//     profile's "best_selection_soft"/"best_selection_hard" — first present
+//     wins: score >= 0.5 => accept.
 //
 // hasSignal reports whether any of the above produced a verdict. When it is
 // false (missing/empty/unrecognized report), callers should SKIP recording the
@@ -4753,10 +4755,16 @@ func skillOptJudgeAcceptFromReport(evalReportJSON string) (accept bool, hasSigna
 			return false, true, promptVersion, evaluatorID, promptHash
 		}
 	}
-	// 4) soft-score fallback.
+	// 4) soft/selection-score fallback. Real optimizer reports vary by evaluator
+	// profile: the generic profile sets a top-level "promotable" (handled above);
+	// the landing-page profile instead reports the best candidate's selection-gate
+	// scores ("best_selection_soft"/"best_selection_hard") with no "promotable".
+	// Treat the first such score present as the judge's confidence: >= 0.5 => accept.
 	for _, source := range sources {
-		if soft, ok := skillOptJudgeFloat(source["soft"]); ok {
-			return soft >= 0.5, true, promptVersion, evaluatorID, promptHash
+		for _, key := range []string{"soft", "best_selection_soft", "best_selection_hard"} {
+			if score, ok := skillOptJudgeFloat(source[key]); ok {
+				return score >= 0.5, true, promptVersion, evaluatorID, promptHash
+			}
 		}
 	}
 	return false, false, promptVersion, evaluatorID, promptHash

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -2948,6 +2948,23 @@ func TestDecideSkillOptTrainCandidateCapturesJudgeOutcome(t *testing.T) {
 			reason:        "style mismatch",
 			wantDirection: SkillOptJudgeDirectionJudgeAcceptHumanReject,
 		},
+		{
+			// Real landing-page profile shape (no "promotable"): judge-accept is
+			// derived from best_selection_soft. Promote => agree.
+			name:          "landing-page promote agrees via best_selection_soft",
+			evalReport:    `{"best_selection_hard":1.0,"best_selection_soft":0.88,"best_step":1,"dry_run":false}`,
+			decision:      "promoted",
+			wantDirection: SkillOptJudgeDirectionAgreeAccept,
+		},
+		{
+			// Real landing-page shape the gate scored well but the human rejected:
+			// the false-positive calibration signal we most want to capture.
+			name:          "landing-page reject captures judge over-score",
+			evalReport:    `{"best_selection_hard":0.9,"best_selection_soft":0.86,"best_step":2}`,
+			decision:      "rejected",
+			reason:        "off-brand",
+			wantDirection: SkillOptJudgeDirectionJudgeAcceptHumanReject,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -3016,6 +3033,35 @@ func TestDecideSkillOptTrainCandidateSkipsCaptureWithoutJudgeSignal(t *testing.T
 			t.Fatalf("report %q: captured %d outcomes, want 0 (no judge signal)", report, len(outcomes))
 		}
 		store.Close()
+	}
+}
+
+func TestSkillOptJudgeAcceptFromRealReportShapes(t *testing.T) {
+	// Shapes taken from real optimizer eval reports in the wild (not synthetic):
+	// the generic profile sets top-level "promotable"; the landing-page profile
+	// instead reports "best_selection_soft"/"best_selection_hard" with no
+	// "promotable". Both must yield a signal so the decision is captured.
+	cases := []struct {
+		name       string
+		report     string
+		wantAccept bool
+		wantSignal bool
+	}{
+		{"generic promotable true", `{"promotable":true,"best_selection_soft":0.88}`, true, true},
+		{"generic promotable false", `{"promotable":false,"best_selection_soft":0.88}`, false, true},
+		{"landing-page best_selection_soft high", `{"best_selection_hard":1.0,"best_selection_soft":0.88,"best_step":1,"dry_run":false}`, true, true},
+		{"landing-page best_selection_soft low", `{"best_selection_hard":0.0,"best_selection_soft":0.2,"best_step":0}`, false, true},
+		{"landing-page hard only", `{"best_selection_hard":0.9,"best_step":1}`, true, true},
+		{"no signal", `{"best_step":0,"dry_run":true}`, false, false},
+	}
+	for _, tc := range cases {
+		accept, hasSignal, _, _, _ := skillOptJudgeAcceptFromReport(tc.report)
+		if hasSignal != tc.wantSignal {
+			t.Fatalf("%s: hasSignal=%v want %v (report=%s)", tc.name, hasSignal, tc.wantSignal, tc.report)
+		}
+		if hasSignal && accept != tc.wantAccept {
+			t.Fatalf("%s: accept=%v want %v", tc.name, accept, tc.wantAccept)
+		}
 	}
 }
 


### PR DESCRIPTION
## Why (found by validating against real data)
Answering "did we E2E this against real output?", I checked the **actual** optimizer eval reports captured in a live home (codex-produced) against the Phase-1 judge-capture heuristic. Result: the heuristic recognized the **generic** profile's top-level `promotable` (23/31 reports) but **not** the **landing-page** profile's shape, which uses `best_selection_soft`/`best_selection_hard` with **no `promotable`**. So landing-page candidate decisions — including real promoted/rejected ones — were silently **skipped** (safe, but inert). The synthetic tests never caught this because they assumed `quality_status`/`evaluator_score` shapes that **zero** real reports use.

## Fix
`skillOptJudgeAcceptFromReport`'s soft-score fallback now also reads `best_selection_soft` / `best_selection_hard` (first present wins, `>= 0.5` ⇒ accept). `promotable` still short-circuits first, so it's never overridden. A `null`-scored `dry_run` report still yields no signal (correctly skipped).

## Real-data impact
On the 31 real captured reports: recognized coverage **23/31 → 30/31**. The 1 remaining is a `dry_run` report with `null` scores — correctly skipped (no verdict).

## Tests
- `TestSkillOptJudgeAcceptFromRealReportShapes` — unit cases copied verbatim from real report shapes (generic `promotable`, landing-page `best_selection_*`, null/no-signal).
- Landing-page promote/reject cases added to `TestDecideSkillOptTrainCandidateCapturesJudgeOutcome` — exercised through the **production** `DecideSkillOptTrainCandidate` path (promote ⇒ agree_accept; reject of a high-scored candidate ⇒ judge_accept_human_reject — the false-positive calibration signal).
- `go build/vet`, `go test ./...`, `go test -race ./internal/workflow/` green; `/code-review` clean.

Follow-up to #350 (Phase 1 capture). Part of #345 / #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)