### PR TITLE
fix(skillopt): band landing-page reports in judge-report calibration (#345)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -11297,10 +11297,20 @@ func skillOptJudgeReportRoot(judgeScoreJSON string) []map[string]any {
 	return sources
 }
 
+// skillOptJudgeSoftScore extracts the continuous judge score used for the
+// calibration curve. It mirrors the soft-score fallback chain of the verdict
+// heuristic (skillOptJudgeAcceptFromReport in internal/db/store.go): "soft",
+// then the landing-page profile's "best_selection_soft"/"best_selection_hard".
+// Keeping the two in lockstep means every report that produced an accept/reject
+// verdict is also banded in calibration — otherwise landing-page reports (which
+// carry best_selection_soft, not a top-level "soft") would be silently dropped
+// into "no soft score", blinding calibration to the dominant real report shape.
 func skillOptJudgeSoftScore(judgeScoreJSON string) (float64, bool) {
 	for _, source := range skillOptJudgeReportRoot(judgeScoreJSON) {
-		if value, ok := skillOptJudgeFloatValue(source["soft"]); ok {
-			return value, true
+		for _, key := range []string{"soft", "best_selection_soft", "best_selection_hard"} {
+			if value, ok := skillOptJudgeFloatValue(source[key]); ok {
+				return value, true
+			}
 		}
 	}
 	return 0, false

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -11749,6 +11749,32 @@ func TestSkillOptJudgeReportRendersMatrixAndAgreement(t *testing.T) {
 	}
 }
 
+func TestSkillOptJudgeSoftScoreFallsBackToSelectionScore(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		report string
+		want   float64
+		wantOK bool
+	}{
+		{name: "top-level soft wins", report: `{"soft":0.42,"best_selection_soft":0.9}`, want: 0.42, wantOK: true},
+		{name: "nested evaluator_score soft", report: `{"evaluator_score":{"soft":0.55}}`, want: 0.55, wantOK: true},
+		{name: "landing-page best_selection_soft", report: `{"best_selection_hard":0.0,"best_selection_soft":0.76,"promotable":true}`, want: 0.76, wantOK: true},
+		{name: "best_selection_hard last resort", report: `{"best_selection_hard":0.5}`, want: 0.5, wantOK: true},
+		{name: "no continuous score", report: `{"quality_status":"fail"}`, wantOK: false},
+		{name: "empty report", report: ``, wantOK: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := skillOptJudgeSoftScore(tc.report)
+			if ok != tc.wantOK {
+				t.Fatalf("skillOptJudgeSoftScore ok = %v, want %v", ok, tc.wantOK)
+			}
+			if tc.wantOK && got != tc.want {
+				t.Fatalf("skillOptJudgeSoftScore = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func cliSkillOptTemplate(id string, body string) db.AgentTemplate {
 	content := cliSkillOptTemplateContent(id, body)
 	parsed, err := agenttemplate.ParseTemplateContent(content)


### PR DESCRIPTION
## Problem

The `gitmoot skillopt judge-report` calibration curve ("judge soft-score band vs human promote rate") extracted **only** a top-level `soft` score via `skillOptJudgeSoftScore`. But the verdict heuristic that decides judge accept/reject (`skillOptJudgeAcceptFromReport`, `internal/db/store.go`) falls back to the landing-page profile's `best_selection_soft` / `best_selection_hard`.

Result: a **landing-page eval report** — the dominant real evaluator shape (it carries `best_selection_soft`, not a top-level `soft`) — produced a correct accept/reject verdict and showed up in the confusion matrix, but was silently dropped into the calibration "no soft score" bucket. Calibration was blind to exactly the reports it most needs to characterize.

## Fix

Mirror the verdict heuristic's soft-score fallback chain (`soft` → `best_selection_soft` → `best_selection_hard`) in `skillOptJudgeSoftScore`, so every report that yields a verdict is also banded. Additive, no behavior change for reports that already carried a top-level `soft`.

## Validation

Surfaced by the **full live codex judge-capture E2E** (#345). With real captured outcomes, two landing-page reports (`best_selection_soft=0.76`) moved from `no soft score` into the `[0.75,1.00]` band:

```
before:  [0.75,1.00]  0   -        ... no soft score  2  -
after:   [0.75,1.00]  2   0.500 (1/2)
```

- New unit test `TestSkillOptJudgeSoftScoreFallsBackToSelectionScore` (top-level soft precedence, nested `evaluator_score.soft`, landing-page `best_selection_soft`, `best_selection_hard` last resort, no-signal, empty).
- Existing `TestSkillOptJudgeReportRendersMatrixAndAgreement` still green.
- Full gate: `go build ./... && go vet ./... && go test ./...` + `go test -race ./internal/workflow/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)