### PR TITLE
docs: v0.4.0 release notes + judge-prompt optimization + skillopt v0.3.0 (#345)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ version: 0.1.0
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.1.0"
+  gitmoot-version: "0.4.0"
   source: "jerryfane/gitmoot"
   openclaw:
     requires:
@@ -107,7 +107,7 @@ continues:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/docs/release-notes/v0.4.0.md
+++ b/docs/release-notes/v0.4.0.md
@@ -1,0 +1,55 @@
+# Gitmoot v0.4.0
+
+First official (non-beta) release. Headlines the **SkillOpt evaluator-hardening**
+work (#345): Gitmoot now records how the LLM judge's accept/reject verdicts
+compare to the human's decision at the manual gate, reports calibration, and
+carries per-`task_kind` judge prompts in the contract — the substrate for tuning
+the judge against real human agreement.
+
+## Highlights
+
+### Judge↔human outcome capture + `judge-report`
+
+- Every candidate promote/reject at the manual gate records all four judge↔human
+  directions (`agree_accept`, `agree_reject`, `judge_accept_human_reject`,
+  `judge_reject_human_accept`) into a local `skillopt_judge_outcomes` table,
+  tagged with the judge prompt version, evaluator id, and prompt hash. Capture is
+  measurement-only and never overrides a decision; reports with no judge signal
+  are skipped.
+- `gitmoot skillopt judge-report [--template <id>]` renders a confusion matrix,
+  agreement rate, Cohen's κ, soft-score calibration bands, and per-dimension
+  disagreement.
+
+### Per-`task_kind` judge prompt in the contract
+
+- The exchange contract additively carries
+  `evaluator_profile.judge.config.judge_prompt_templates[task_kind]` and
+  `judge_prompt_version`, so a tuned judge prompt can be selected per task kind
+  (no `contract_version` bump).
+
+### Judge-prompt optimization (companion: gitmoot-skillopt v0.3.0)
+
+- The captured outcomes feed an **offline, frozen-and-alternated, per-`task_kind`
+  judge-prompt optimization** loop in
+  [gitmoot-skillopt v0.3.0](https://github.com/jerryfane/gitmoot-skillopt/releases/tag/v0.3.0)
+  (`optimize --judge-prompt-optimization`), gated on held-out human agreement.
+  On a real held-out set it lifted judge↔human agreement on the correctness task
+  kind from 0.33 → 0.67 (gate-accepted), with non-improving variants correctly
+  rejected. See the
+  [judge-prompt optimization guide](https://github.com/jerryfane/gitmoot-skillopt/blob/main/docs/guide/judge-prompt-optimization.md).
+
+## Validation
+
+- `go build` / `go vet` / `go test ./...` and the `-race` workflow suite are
+  green; the judge-outcome capture was validated end-to-end on a live Codex run
+  across all four directions.
+
+## Install / update
+
+```sh
+gitmoot update                                   # existing installs
+curl -fsSL https://gitmoot.io/install.sh | sh    # fresh install
+```
+
+Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
+`sha256sums.txt`.

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -47,7 +47,11 @@ The exported package has:
 - `evaluator_config`: evaluator and run metadata used by the external
   optimizer. Top-level workflow mode is exported as `training_mode`, not as
   `evaluator_config.mode`; `evaluator_config.mode` is reserved for evaluator
-  implementation ids or drivers.
+  implementation ids or drivers. The judge config additively carries
+  per-`task_kind` judge prompts under `judge.config.judge_prompt_templates`
+  (with a `judge_prompt_version`), so a judge prompt tuned by gitmoot-skillopt's
+  judge-prompt optimization can be selected per task kind without a
+  `contract_version` bump.
 
 Artifact package entries reference local SHA256 blobs stored under Gitmoot home.
 The export does not copy blobs into the repository by default.

--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -421,7 +421,7 @@ recommended install path is:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -4,7 +4,7 @@ description: Use Gitmoot for local-first AI agent coordination across repositori
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.1.0"
+  gitmoot-version: "0.4.0"
   source: "jerryfane/gitmoot"
 ---
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -540,7 +540,7 @@ training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
 to validate the contract without model calls.
 Before real model-backed optimization, check `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help`, or install it with
-`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl`.
+`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl`.
 Verify required model/backend environment variables for the installed optimizer
 version. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -294,6 +294,15 @@ soft-score versus the human decision), and per-dimension disagreement — useful
 to tell whether the LLM judge is well-calibrated against human verdicts before
 you trust it to gate candidates.
 
+Those captured outcomes feed judge-prompt optimization. The contract carries a
+per-`task_kind` judge prompt
+(`evaluator_profile.judge.config.judge_prompt_templates[task_kind]` +
+`judge_prompt_version`), and gitmoot-skillopt v0.3.0 can tune it offline against
+held-out human verdicts with `gitmoot-skillopt optimize
+--judge-prompt-optimization --judge-human-labeled-path <labels.json>` — the
+freeze-and-alternate counterpart to skill optimization, accepting a candidate
+judge prompt only when it raises held-out human agreement.
+
 Run the deterministic smoke before changing train behavior:
 
 ```sh

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -129,7 +129,7 @@ training:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -281,7 +281,7 @@ Fix:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -549,7 +549,7 @@ training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
 to validate the contract without model calls.
 Before real model-backed optimization, check `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help`, or install it with
-`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl`.
+`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl`.
 Verify required model/backend environment variables for the installed optimizer
 version. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -61,7 +61,12 @@ The exported package has:
   `checks` (an ordered list of cheap artifact/render checks, each with `id`,
   `type`, `when`, `required`, and an optional `config`), `judge` (the LLM judge
   config: `type`, `when`, optional `model`, and optional `config`), and
-  `metadata` (the raw evaluator config the profile was derived from).
+  `metadata` (the raw evaluator config the profile was derived from). The
+  judge's `config` additively carries per-`task_kind` judge prompts under
+  `judge_prompt_templates[task_kind]` plus a `judge_prompt_version`, so a judge
+  prompt tuned by [judge-prompt
+  optimization](https://github.com/jerryfane/gitmoot-skillopt/blob/main/docs/guide/judge-prompt-optimization.md)
+  can be selected per task kind (no `contract_version` bump).
 
 Artifact package entries reference local SHA256 blobs stored under Gitmoot home.
 The export does not copy blobs into the repository by default.

--- a/website/docs/release-notes/v0.4.0.md
+++ b/website/docs/release-notes/v0.4.0.md
@@ -1,0 +1,55 @@
+# Gitmoot v0.4.0
+
+First official (non-beta) release. Headlines the **SkillOpt evaluator-hardening**
+work (#345): Gitmoot now records how the LLM judge's accept/reject verdicts
+compare to the human's decision at the manual gate, reports calibration, and
+carries per-`task_kind` judge prompts in the contract — the substrate for tuning
+the judge against real human agreement.
+
+## Highlights
+
+### Judge↔human outcome capture + `judge-report`
+
+- Every candidate promote/reject at the manual gate records all four judge↔human
+  directions (`agree_accept`, `agree_reject`, `judge_accept_human_reject`,
+  `judge_reject_human_accept`) into a local `skillopt_judge_outcomes` table,
+  tagged with the judge prompt version, evaluator id, and prompt hash. Capture is
+  measurement-only and never overrides a decision; reports with no judge signal
+  are skipped.
+- `gitmoot skillopt judge-report [--template <id>]` renders a confusion matrix,
+  agreement rate, Cohen's κ, soft-score calibration bands, and per-dimension
+  disagreement.
+
+### Per-`task_kind` judge prompt in the contract
+
+- The exchange contract additively carries
+  `evaluator_profile.judge.config.judge_prompt_templates[task_kind]` and
+  `judge_prompt_version`, so a tuned judge prompt can be selected per task kind
+  (no `contract_version` bump).
+
+### Judge-prompt optimization (companion: gitmoot-skillopt v0.3.0)
+
+- The captured outcomes feed an **offline, frozen-and-alternated, per-`task_kind`
+  judge-prompt optimization** loop in
+  [gitmoot-skillopt v0.3.0](https://github.com/jerryfane/gitmoot-skillopt/releases/tag/v0.3.0)
+  (`optimize --judge-prompt-optimization`), gated on held-out human agreement.
+  On a real held-out set it lifted judge↔human agreement on the correctness task
+  kind from 0.33 → 0.67 (gate-accepted), with non-improving variants correctly
+  rejected. See the
+  [judge-prompt optimization guide](https://github.com/jerryfane/gitmoot-skillopt/blob/main/docs/guide/judge-prompt-optimization.md).
+
+## Validation
+
+- `go build` / `go vet` / `go test ./...` and the `-race` workflow suite are
+  green; the judge-outcome capture was validated end-to-end on a live Codex run
+  across all four directions.
+
+## Install / update
+
+```sh
+gitmoot update                                   # existing installs
+curl -fsSL https://gitmoot.io/install.sh | sh    # fresh install
+```
+
+Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
+`sha256sums.txt`.

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -421,7 +421,7 @@ recommended install path is:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```
@@ -711,6 +711,30 @@ soft-score versus the human decision), and per-dimension disagreement. `--templa
 scopes the report to one template, and `--home` reads from a non-default Gitmoot
 home. Use it to decide whether the judge is well-calibrated enough to trust at
 the gate before relying on it for candidate decisions.
+
+### Optimizing the judge prompt
+
+The captured outcomes are the substrate for tuning the judge itself. The
+contract carries a per-`task_kind` judge prompt
+(`evaluator_profile.judge.config.judge_prompt_templates[task_kind]` +
+`judge_prompt_version`), and [gitmoot-skillopt
+v0.3.0](https://github.com/jerryfane/gitmoot-skillopt/releases/tag/v0.3.0) can
+optimize it offline against held-out human verdicts:
+
+```sh
+gitmoot-skillopt optimize \
+  --training-package training.json --artifact-root ~/.gitmoot/evals/blobs \
+  --out-root out/judge --candidate-output out/judge/judge_candidate.json \
+  --judge-prompt-optimization --judge-human-labeled-path held-out-labels.json \
+  --evaluator-backend codex --optimizer-backend codex
+```
+
+This is the freeze-and-alternate counterpart to skill optimization: it tunes the
+judge prompt (frozen skill) per `task_kind`, accepting a candidate only when it
+raises agreement with the held-out human-labeled set (the `human_agreement`
+gate). See the [judge-prompt optimization
+guide](https://github.com/jerryfane/gitmoot-skillopt/blob/main/docs/guide/judge-prompt-optimization.md)
+for the guardrails and cost/cadence discipline.
 
 ## Deterministic Smoke
 

--- a/website/scripts/build-llms-full.mjs
+++ b/website/scripts/build-llms-full.mjs
@@ -23,6 +23,7 @@ const sources = [
   'docs/release-notes/v0.2.0-beta.2.md',
   'docs/release-notes/v0.3.0-beta.1.md',
   'docs/release-notes/v0.3.1-beta.1.md',
+  'docs/release-notes/v0.4.0.md',
   'skills/gitmoot/SKILL.md',
   'skills/gitmoot/agent-templates/planner.md',
   'skills/gitmoot/references/CLI.md',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -61,6 +61,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Release Notes',
       items: [
+        'release-notes/v0.4.0',
         'release-notes/v0.3.5-beta.1',
         'release-notes/v0.3.4-beta.1',
         'release-notes/v0.3.3-beta.1',

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -533,7 +533,7 @@ version: 0.1.0
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.1.0"
+  gitmoot-version: "0.4.0"
   source: "jerryfane/gitmoot"
   openclaw:
     requires:
@@ -635,7 +635,7 @@ continues:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```
@@ -2710,7 +2710,7 @@ recommended install path is:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```
@@ -3129,7 +3129,11 @@ The exported package has:
 - `evaluator_config`: evaluator and run metadata used by the external
   optimizer. Top-level workflow mode is exported as `training_mode`, not as
   `evaluator_config.mode`; `evaluator_config.mode` is reserved for evaluator
-  implementation ids or drivers.
+  implementation ids or drivers. The judge config additively carries
+  per-`task_kind` judge prompts under `judge.config.judge_prompt_templates`
+  (with a `judge_prompt_version`), so a judge prompt tuned by gitmoot-skillopt's
+  judge-prompt optimization can be selected per task kind without a
+  `contract_version` bump.
 
 Artifact package entries reference local SHA256 blobs stored under Gitmoot home.
 The export does not copy blobs into the repository by default.
@@ -4896,6 +4900,66 @@ bug-report workflow added after the v0.3.0 dashboard beta.
 
 ---
 
+# Source: docs/release-notes/v0.4.0.md
+
+# Gitmoot v0.4.0
+
+First official (non-beta) release. Headlines the **SkillOpt evaluator-hardening**
+work (#345): Gitmoot now records how the LLM judge's accept/reject verdicts
+compare to the human's decision at the manual gate, reports calibration, and
+carries per-`task_kind` judge prompts in the contract — the substrate for tuning
+the judge against real human agreement.
+
+## Highlights
+
+### Judge↔human outcome capture + `judge-report`
+
+- Every candidate promote/reject at the manual gate records all four judge↔human
+  directions (`agree_accept`, `agree_reject`, `judge_accept_human_reject`,
+  `judge_reject_human_accept`) into a local `skillopt_judge_outcomes` table,
+  tagged with the judge prompt version, evaluator id, and prompt hash. Capture is
+  measurement-only and never overrides a decision; reports with no judge signal
+  are skipped.
+- `gitmoot skillopt judge-report [--template <id>]` renders a confusion matrix,
+  agreement rate, Cohen's κ, soft-score calibration bands, and per-dimension
+  disagreement.
+
+### Per-`task_kind` judge prompt in the contract
+
+- The exchange contract additively carries
+  `evaluator_profile.judge.config.judge_prompt_templates[task_kind]` and
+  `judge_prompt_version`, so a tuned judge prompt can be selected per task kind
+  (no `contract_version` bump).
+
+### Judge-prompt optimization (companion: gitmoot-skillopt v0.3.0)
+
+- The captured outcomes feed an **offline, frozen-and-alternated, per-`task_kind`
+  judge-prompt optimization** loop in
+  [gitmoot-skillopt v0.3.0](https://github.com/jerryfane/gitmoot-skillopt/releases/tag/v0.3.0)
+  (`optimize --judge-prompt-optimization`), gated on held-out human agreement.
+  On a real held-out set it lifted judge↔human agreement on the correctness task
+  kind from 0.33 → 0.67 (gate-accepted), with non-improving variants correctly
+  rejected. See the
+  [judge-prompt optimization guide](https://github.com/jerryfane/gitmoot-skillopt/blob/main/docs/guide/judge-prompt-optimization.md).
+
+## Validation
+
+- `go build` / `go vet` / `go test ./...` and the `-race` workflow suite are
+  green; the judge-outcome capture was validated end-to-end on a live Codex run
+  across all four directions.
+
+## Install / update
+
+```sh
+gitmoot update                                   # existing installs
+curl -fsSL https://gitmoot.io/install.sh | sh    # fresh install
+```
+
+Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
+`sha256sums.txt`.
+
+---
+
 # Source: skills/gitmoot/SKILL.md
 
 ---
@@ -4904,7 +4968,7 @@ description: Use Gitmoot for local-first AI agent coordination across repositori
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.1.0"
+  gitmoot-version: "0.4.0"
   source: "jerryfane/gitmoot"
 ---
 
@@ -5768,7 +5832,7 @@ training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
 to validate the contract without model calls.
 Before real model-backed optimization, check `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help`, or install it with
-`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl`.
+`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl`.
 Verify required model/backend environment variables for the installed optimizer
 version. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate
@@ -6118,6 +6182,15 @@ directions, the agreement rate and Cohen's κ, calibration buckets (judge
 soft-score versus the human decision), and per-dimension disagreement — useful
 to tell whether the LLM judge is well-calibrated against human verdicts before
 you trust it to gate candidates.
+
+Those captured outcomes feed judge-prompt optimization. The contract carries a
+per-`task_kind` judge prompt
+(`evaluator_profile.judge.config.judge_prompt_templates[task_kind]` +
+`judge_prompt_version`), and gitmoot-skillopt v0.3.0 can tune it offline against
+held-out human verdicts with `gitmoot-skillopt optimize
+--judge-prompt-optimization --judge-human-labeled-path <labels.json>` — the
+freeze-and-alternate counterpart to skill optimization, accepting a candidate
+judge prompt only when it raises held-out human agreement.
 
 Run the deterministic smoke before changing train behavior:
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -23,7 +23,7 @@ workflows.
 - [Codex And Claude Plugins](https://gitmoot.io/docs/plugins/codex-claude): Plugin discovery and runtime skill setup.
 - [SkillOpt Exchange Contract](https://gitmoot.io/docs/reference/skillopt-exchange-contract): Training and candidate package boundary for the external optimizer.
 - [Troubleshooting](https://gitmoot.io/docs/operations/troubleshooting): Diagnose GitHub auth, bug reports, runtimes, agent templates, remotes, permissions, and locks.
-- [Release Notes](https://gitmoot.io/docs/release-notes/v0.3.5-beta.1): Latest beta notes — delegation termination model, coordinator recipes, daemon/dashboard from anywhere.
+- [Release Notes](https://gitmoot.io/docs/release-notes/v0.4.0): Latest release — SkillOpt judge↔human outcome capture, `judge-report`, per-task_kind judge prompt, judge-prompt optimization.
 - [Raw SKILL.md](https://gitmoot.io/SKILL.md): Agent skill entrypoint.
 - [Full LLM Context](https://gitmoot.io/llms-full.txt): Expanded Markdown context for agents.
 - [GitHub Repository](https://github.com/jerryfane/gitmoot): Source code and releases.


### PR DESCRIPTION
Updates both doc trees (in-repo + website, which don't auto-sync) for the **v0.4.0** release and the companion **gitmoot-skillopt v0.3.0**.

## Changes
- **v0.4.0 release notes** — `docs/release-notes/v0.4.0.md` + `website/docs/release-notes/v0.4.0.md`; registered in `sidebars.ts`, `static/llms.txt`, and the `build-llms-full.mjs` source list (`llms-full.txt` regenerated).
- **Judge-prompt optimization docs** — a concise section in the SkillOpt train workflow (website) + the skill `WORKFLOWS.md` (in-repo), and a contract note for `evaluator_profile.judge.config.judge_prompt_templates` / `judge_prompt_version` in both `skillopt-exchange-contract.md`, linking gitmoot-skillopt's guide.
- **Version bumps** — stale gitmoot-skillopt wheel URL `v0.2.0b1` → `v0.3.0` across 7 docs; `SKILL.md` `gitmoot-version` metadata `0.1.0` → `0.4.0`.

## Build
`cd website && npm run build` succeeds with `onBrokenLinks: throw`; the v0.4.0 page builds and `llms-full.txt` carries the v0.3.0 wheel URL (no stale `v0.2.0b1` refs). Deploy to gitmoot.io follows after merge.

Refs #345