### PR TITLE
docs: make llms.txt discoverable + surface judge-prompt optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ for install details and troubleshooting.
 ## Documentation
 
 - [Hosted docs](https://gitmoot.io/docs/intro)
-- [LLM index](https://gitmoot.io/llms.txt)
+- [LLM index](https://gitmoot.io/llms.txt) — machine-readable docs index; agents start here (full context: [llms-full.txt](https://gitmoot.io/llms-full.txt))
 - [Agent Skills package](skills/gitmoot/SKILL.md)
 - [CLI reference](skills/gitmoot/references/CLI.md)
 - [Codex and Claude plugins](docs/plugins.md)

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -8,6 +8,14 @@ GitHub pull request comments, routes jobs to registered agent runtimes, and
 writes attributed results back to the pull request discussion. There is no
 hosted control plane in the current beta.
 
+:::tip For agents
+New here? Open **[`llms.txt`](https://gitmoot.io/llms.txt)** — the
+machine-readable index of these docs — and the agent skill
+**[`SKILL.md`](https://gitmoot.io/SKILL.md)**.
+**[`llms-full.txt`](https://gitmoot.io/llms-full.txt)** has the full expanded
+context in one file.
+:::
+
 ## What Gitmoot Is For
 
 - Route PR comments to named local agents.
@@ -49,9 +57,7 @@ flowchart TD
 Codex, Claude Code, and Kimi Code are the runtimes Gitmoot can start or
 subscribe; shell is subscribe-only.
 
-Use the docs here for the human workflow. Agents should also read
-[`SKILL.md`](https://gitmoot.io/SKILL.md) and
-[`llms.txt`](https://gitmoot.io/llms.txt).
+Use the docs here for the human workflow; agents have the index callout above.
 
 ## Docs Map
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -87,6 +87,11 @@ const config: Config = {
           position: 'right',
         },
         {
+          href: 'https://gitmoot.io/llms.txt',
+          label: 'llms.txt',
+          position: 'right',
+        },
+        {
           href: 'https://github.com/jerryfane/gitmoot',
           label: 'GitHub',
           position: 'right',
@@ -110,6 +115,7 @@ const config: Config = {
       links: [
         {label: 'Install script', href: 'https://gitmoot.io/install.sh'},
         {label: 'SKILL.md', href: 'https://gitmoot.io/SKILL.md'},
+        {label: 'llms.txt', href: 'https://gitmoot.io/llms.txt'},
         {label: 'Website', href: 'https://gitmoot.io'},
         {label: 'GitHub', href: 'https://github.com/jerryfane/gitmoot'},
         {label: 'Discord', href: 'https://discord.gg/TTFRHFyDXf'},

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -483,7 +483,7 @@ for install details and troubleshooting.
 ## Documentation
 
 - [Hosted docs](https://gitmoot.io/docs/intro)
-- [LLM index](https://gitmoot.io/llms.txt)
+- [LLM index](https://gitmoot.io/llms.txt) — machine-readable docs index; agents start here (full context: [llms-full.txt](https://gitmoot.io/llms-full.txt))
 - [Agent Skills package](skills/gitmoot/SKILL.md)
 - [CLI reference](skills/gitmoot/references/CLI.md)
 - [Codex and Claude plugins](docs/plugins.md)

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -5,6 +5,10 @@ goals, reviews, pull request comments, daemon jobs, branch locks, agent
 templates, current-chat prompt import, and Codex or Claude Code runtime
 workflows.
 
+This file is the machine-readable index of the Gitmoot docs — agents should
+start here, then open [`llms-full.txt`](https://gitmoot.io/llms-full.txt) for the
+full expanded context.
+
 ## Start Here
 
 - [Introduction](https://gitmoot.io/docs/intro): What Gitmoot is and when to use it.
@@ -13,7 +17,7 @@ workflows.
 - [PR Comment Workflow](https://gitmoot.io/docs/workflows/pr-comment-workflow): Route auditable work from GitHub comments.
 - [Planner And Goal Workflow](https://gitmoot.io/docs/workflows/planner-goal-workflow): Create structured plans and goal files.
 - [Template Capture Workflow](https://gitmoot.io/docs/workflows/template-capture-workflow): Turn a current chat workflow into a reviewed reusable template.
-- [SkillOpt Train Workflow](https://gitmoot.io/docs/workflows/skillopt-train-workflow): Run the full feedback, optimizer, candidate-review, and promotion loop.
+- [SkillOpt Train Workflow](https://gitmoot.io/docs/workflows/skillopt-train-workflow): Run the full feedback, optimizer, candidate-review, and promotion loop, including judge↔human outcome capture, `judge-report`, and judge-prompt optimization.
 
 ## References
 


### PR DESCRIPTION
Makes `llms.txt` (the machine-readable docs index at gitmoot.io/llms.txt) discoverable to an agent that lands on the docs, and surfaces judge-prompt optimization as a first-class topic in it.

## Changes
- **`website/static/llms.txt`** — header hint ("this is the machine-readable index — start here"); the SkillOpt Train Workflow entry now names judge↔human capture, `judge-report`, and judge-prompt optimization (previously only in the release-notes line).
- **`website/docusaurus.config.ts`** — add an `llms.txt` link to the **navbar** (right cluster) and **footer**; the custom `Footer` component renders from `footer.links`, so the config edit suffices. Site-wide on every docs page.
- **`website/docs/intro.md`** — the site root redirects here, so it's the landing page; promote the buried `llms.txt`/`SKILL.md` mention into a prominent `:::tip For agents` admonition near the top.
- **`README.md`** — clarify the existing "LLM index" label (machine-readable index; agents start here) for the GitHub-landing case.

## Build
`npm run build` succeeds (`onBrokenLinks: throw`); the `llms.txt` link is in the built navbar/footer, the admonition renders, and `llms.txt` carries the enriched SkillOpt line. `llms-full.txt` regenerated (README change). Deploy to gitmoot.io follows after merge.