### PR TITLE
feat(orchestrate): Herdr cockpit — Phase 0 status panes (#357)

### DIFF
--- a/docs/cockpit-orchestrate.md
+++ b/docs/cockpit-orchestrate.md
@@ -1,0 +1,109 @@
+# Watching an orchestra: `gitmoot orchestrate --cockpit`
+
+`gitmoot orchestrate --cockpit` renders one live [Herdr](https://github.com/jerryfane/herdr)
+pane per delegation subagent so you can watch a fan-out as it runs — in the
+terminal, and (through [herdres](https://github.com/jerryfane/herdr)) mirrored to
+Telegram. It is **opt-in and fail-open**: with `--cockpit` off, or when Herdr is
+absent or unreachable, orchestration is byte-identical to today. Gitmoot imports
+no Herdr code; the cockpit is purely compositional, driving Herdr over its CLI
+only.
+
+## Turning it on
+
+`--cockpit` (alias `--herdr`) is a flag on `gitmoot orchestrate`:
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo --cockpit
+```
+
+When the flag is set, every child job in the delegation tree opens its own pane:
+the coordinator splits a workspace for the run, each delegation subagent gets a
+pane labeled `<agent> · d<depth> · <branch>`, and that pane streams the child's
+progress while the job runs. Children inherit the cockpit setting from their
+parent, so a single `--cockpit` on the root lights up the whole orchestra.
+
+Pick where the run lands with `--cockpit-session`:
+
+```sh
+gitmoot orchestrate decompose-and-verify "Implement the export feature." \
+  --repo owner/repo --cockpit --cockpit-session feature-export
+```
+
+### Terminal and Telegram
+
+The same panes are visible two ways:
+
+- **Terminal** — open the Herdr workspace to watch the panes split and update
+  live as each subagent works.
+- **Telegram** — with [herdres](https://github.com/jerryfane/herdr) bridging
+  Herdr to Telegram, each pane surfaces as a forum topic / agent status you can
+  read (and, in later phases, steer) from your phone. See the `herdres` skill for
+  bridge setup.
+
+## Close pane ≠ cancel job
+
+A cockpit pane is a **view**, not the job. Closing a pane (in the terminal or
+from Telegram) tears down the visible surface but does **not** cancel the
+underlying job — the child keeps running in the daemon and its result is still
+captured and synthesized. To actually stop work, cancel the job through the
+record path:
+
+```sh
+gitmoot job list --repo owner/repo     # find the child job id
+gitmoot job cancel <job-id>            # cancel via the record, pane teardown follows
+```
+
+This separation is deliberate: a herdr call must never fail or stall a job, so
+panes are best-effort and disposable while the job lifecycle stays owned by the
+engine.
+
+## Configuration: the `[orchestrate]` section
+
+Defaults live in `~/.gitmoot/config.toml` under `[orchestrate]` and can be
+overridden per run by the flags above:
+
+```toml
+[orchestrate]
+cockpit_mode = "auto"      # on | off | auto (auto = on iff herdr is reachable)
+cockpit_session = ""       # default Herdr session/workspace label ("" = per-run)
+cockpit_max_panes = 4      # cap on simultaneous panes per run
+cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
+```
+
+- `cockpit_mode = "off"` disables the cockpit even if `--cockpit` was passed by an
+  older script; `"on"` forces it (and emits a `cockpit_unavailable` job event if
+  Herdr is unreachable); `"auto"` (the default) turns it on only when `herdr
+  status` is ok.
+- `cockpit_pane_key = "job"` opens one pane per child job. `seat` mode reuses a
+  single pane per logical role across phases (a later phase) so a long run does
+  not accumulate panes.
+
+## Constrained hosts
+
+On a small box (few cores, limited terminal real estate, a shared daemon) the
+pane count is what bites, not the jobs. Keep it bounded:
+
+- **Lower `cockpit_max_panes`.** The default is `4`; set it to `2` (or `1`) on a
+  constrained host. Beyond the cap, extra subagents run **status-only** — they
+  still report state to Herdr but do not split a new pane, so the work fans out
+  exactly as without the cockpit while the visible surface stays small.
+- **Prefer `cockpit_pane_key = "seat"`** for long multi-phase runs so panes are
+  reused per role instead of accumulating one-per-job.
+- **The cockpit never changes the engine.** The delegation DAG, the result
+  contract, the runtime-session locks, and the checkout keys are all unchanged
+  whether the cockpit is on, off, or unavailable — so capping panes only changes
+  what you *see*, never how the orchestra runs.
+
+If Herdr is not installed or `herdr status` is not ok, `--cockpit` is a no-op
+beyond a single `cockpit_unavailable` event on the root job; the run proceeds
+unwrapped.
+
+## Smoke test
+
+An optional smoke script,
+[`scripts/cockpit-smoke.sh`](../scripts/cockpit-smoke.sh), confirms the cockpit
+is opt-in and fail-open. It runs against an isolated `--home`, exercises the
+`--cockpit` wrap path when `herdr` is reachable, and **skips cleanly** (exit 0)
+when `herdr` or `gitmoot` is unavailable, so it never fails a normal checkout
+that has no Herdr installed. Set `GITMOOT_COCKPIT_SMOKE_AGENT=<coordinator>` for
+a live end-to-end pane run.

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -254,18 +254,20 @@ func printAgentAskUsage(w io.Writer) {
 }
 
 type agentRunOptions struct {
-	home       string
-	repo       string
-	jsonOutput bool
-	background bool
-	typeName   string
-	model      string
-	taskID     string
-	prNumber   int
-	headSHA    string
-	branch     string
-	agent      string
-	message    string
+	home           string
+	repo           string
+	jsonOutput     bool
+	background     bool
+	typeName       string
+	model          string
+	taskID         string
+	prNumber       int
+	headSHA        string
+	branch         string
+	agent          string
+	message        string
+	cockpit        bool
+	cockpitSession string
 }
 
 func runAgentRun(args []string, stdout, stderr io.Writer) int {
@@ -334,7 +336,7 @@ func runOrchestrate(args []string, stdout, stderr io.Writer) int {
 
 func printOrchestrateUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--model model] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--model model] [--cockpit] [--cockpit-session name] [--home path] [--json]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Orchestrate work across agents (a coordinator that fans out delegations).")
 	fmt.Fprintln(w, "Sugar for `gitmoot agent run <agent> --background`: the named agent is the")
@@ -425,6 +427,8 @@ func dispatchAgentCommand(options agentRunOptions, action string, reason string,
 			PullRequest:          options.prNumber,
 			HeadSHA:              options.headSHA,
 			Branch:               options.branch,
+			Cockpit:              options.cockpit,
+			CockpitSession:       options.cockpitSession,
 			SelectedAction:       action,
 			SelectedActionReason: reason,
 			ExecutionPath:        executionPath,
@@ -474,7 +478,9 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 			options.background = true
 		case arg == "--json":
 			options.jsonOutput = true
-		case arg == "--type" || arg == "--model" || arg == "--repo" || arg == "--home" || arg == "--task" || arg == "--pr" || arg == "--head-sha" || arg == "--branch":
+		case arg == "--cockpit" || arg == "--herdr":
+			options.cockpit = true
+		case arg == "--type" || arg == "--model" || arg == "--repo" || arg == "--home" || arg == "--task" || arg == "--pr" || arg == "--head-sha" || arg == "--branch" || arg == "--cockpit-session":
 			if index+1 >= len(args) {
 				fmt.Fprintf(stderr, "%s requires a value for %s\n", label, arg)
 				return agentRunOptions{}, false
@@ -483,6 +489,8 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 			if !setAgentRunOption(&options, arg, args[index], stderr) {
 				return agentRunOptions{}, false
 			}
+		case strings.HasPrefix(arg, "--cockpit-session="):
+			options.cockpitSession = strings.TrimSpace(strings.TrimPrefix(arg, "--cockpit-session="))
 		case strings.HasPrefix(arg, "--type="):
 			options.typeName = strings.TrimPrefix(arg, "--type=")
 		case strings.HasPrefix(arg, "--model="):
@@ -538,6 +546,8 @@ func setAgentRunOption(options *agentRunOptions, flagName string, value string, 
 		options.headSHA = value
 	case "--branch":
 		options.branch = value
+	case "--cockpit-session":
+		options.cockpitSession = value
 	case "--pr":
 		parsed, err := strconv.Atoi(value)
 		if err != nil || parsed <= 0 {
@@ -553,7 +563,7 @@ func printAgentRunUsage(w io.Writer, command string) {
 	fmt.Fprintln(w, "Usage:")
 	switch command {
 	case "orchestrate":
-		fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--model model] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--model model] [--cockpit] [--cockpit-session name] [--home path] [--json]")
 	case "review":
 		fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--head-sha sha] [--branch branch] [--background] [--type type] [--model model] [--home path] [--json]")
 	case "implement":

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -526,6 +526,11 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 		fmt.Fprintf(stderr, "%s requires exactly one agent and one message\n", label)
 		return agentRunOptions{}, false
 	}
+	// --cockpit-session implies --cockpit so naming a session does not silently
+	// no-op when the bare --cockpit flag was omitted.
+	if strings.TrimSpace(options.cockpitSession) != "" {
+		options.cockpit = true
+	}
 	return options, true
 }
 

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -39,6 +39,8 @@ type localAgentDispatchRequest struct {
 	TaskTitle            string
 	LeadAgent            string
 	Reviewers            []string
+	Cockpit              bool
+	CockpitSession       string
 	SelectedAction       string
 	SelectedActionReason string
 	ExecutionPath        string
@@ -122,21 +124,23 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		}
 	}
 	job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
-		ID:           localAgentJobID(request.Action, agent.Name),
-		Agent:        agent.Name,
-		Action:       request.Action,
-		Repo:         repo.FullName(),
-		Branch:       firstNonEmpty(request.Branch, record.DefaultBranch),
-		PullRequest:  request.PullRequest,
-		HeadSHA:      request.HeadSHA,
-		GoalID:       request.GoalID,
-		TaskID:       request.TaskID,
-		TaskTitle:    request.TaskTitle,
-		LeadAgent:    firstNonEmpty(request.LeadAgent, agent.Name),
-		Reviewers:    request.Reviewers,
-		Sender:       "local",
-		Instructions: request.Instructions,
-		Model:        request.Model,
+		ID:             localAgentJobID(request.Action, agent.Name),
+		Agent:          agent.Name,
+		Action:         request.Action,
+		Repo:           repo.FullName(),
+		Branch:         firstNonEmpty(request.Branch, record.DefaultBranch),
+		PullRequest:    request.PullRequest,
+		HeadSHA:        request.HeadSHA,
+		GoalID:         request.GoalID,
+		TaskID:         request.TaskID,
+		TaskTitle:      request.TaskTitle,
+		LeadAgent:      firstNonEmpty(request.LeadAgent, agent.Name),
+		Reviewers:      request.Reviewers,
+		Sender:         "local",
+		Instructions:   request.Instructions,
+		Model:          request.Model,
+		Cockpit:        request.Cockpit,
+		CockpitSession: request.CockpitSession,
 	})
 	if err != nil {
 		return localAgentJobOutput{}, err

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -2643,6 +2643,36 @@ func TestParseAgentRunOptionsCapturesModel(t *testing.T) {
 	}
 }
 
+func TestParseAgentRunOptionsCapturesCockpit(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantCockpit bool
+		wantSession string
+	}{
+		{name: "absent leaves off", args: []string{"planner", "fan out fixes"}, wantCockpit: false, wantSession: ""},
+		{name: "--cockpit turns on", args: []string{"planner", "fan out fixes", "--cockpit"}, wantCockpit: true, wantSession: ""},
+		{name: "--herdr alias turns on", args: []string{"planner", "fan out fixes", "--herdr"}, wantCockpit: true, wantSession: ""},
+		{name: "session space form", args: []string{"planner", "fan out fixes", "--cockpit", "--cockpit-session", "review-room"}, wantCockpit: true, wantSession: "review-room"},
+		{name: "session inline form", args: []string{"planner", "fan out fixes", "--cockpit-session=review-room"}, wantCockpit: false, wantSession: "review-room"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			options, ok := parseAgentRunOptions("orchestrate", tt.args, &stderr)
+			if !ok {
+				t.Fatalf("parseAgentRunOptions failed: %q", stderr.String())
+			}
+			if options.cockpit != tt.wantCockpit {
+				t.Fatalf("cockpit = %v, want %v", options.cockpit, tt.wantCockpit)
+			}
+			if options.cockpitSession != tt.wantSession {
+				t.Fatalf("cockpitSession = %q, want %q", options.cockpitSession, tt.wantSession)
+			}
+		})
+	}
+}
+
 func TestParseAgentAskOptionsCapturesModel(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -2654,7 +2654,9 @@ func TestParseAgentRunOptionsCapturesCockpit(t *testing.T) {
 		{name: "--cockpit turns on", args: []string{"planner", "fan out fixes", "--cockpit"}, wantCockpit: true, wantSession: ""},
 		{name: "--herdr alias turns on", args: []string{"planner", "fan out fixes", "--herdr"}, wantCockpit: true, wantSession: ""},
 		{name: "session space form", args: []string{"planner", "fan out fixes", "--cockpit", "--cockpit-session", "review-room"}, wantCockpit: true, wantSession: "review-room"},
-		{name: "session inline form", args: []string{"planner", "fan out fixes", "--cockpit-session=review-room"}, wantCockpit: false, wantSession: "review-room"},
+		// --cockpit-session implies --cockpit, so the session is never silently ignored.
+		{name: "session space form implies cockpit", args: []string{"planner", "fan out fixes", "--cockpit-session", "review-room"}, wantCockpit: true, wantSession: "review-room"},
+		{name: "session inline form implies cockpit", args: []string{"planner", "fan out fixes", "--cockpit-session=review-room"}, wantCockpit: true, wantSession: "review-room"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/cli/cockpit_store.go
+++ b/internal/cli/cockpit_store.go
@@ -44,6 +44,10 @@ func (s cockpitPaneStore) DeleteCockpitPane(ctx context.Context, id string) erro
 	return s.store.DeleteCockpitPane(ctx, id)
 }
 
+func (s cockpitPaneStore) DeleteCockpitPaneByJob(ctx context.Context, jobID string) error {
+	return s.store.DeleteCockpitPaneByJob(ctx, jobID)
+}
+
 func (s cockpitPaneStore) GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, err error)) (string, error) {
 	return s.store.GetOrCreateWorkspaceForRoot(ctx, rootJobID, create)
 }

--- a/internal/cli/cockpit_store.go
+++ b/internal/cli/cockpit_store.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/jerryfane/gitmoot/internal/cockpit"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// cockpitPaneStore adapts a *db.Store to the cockpit.PaneStore interface. The
+// cockpit package keeps its own cockpit.Pane record (so it builds in isolation)
+// while the store persists field-identical db.CockpitPane rows; this shim
+// converts cockpit.Pane <-> db.CockpitPane field-for-field and passes the
+// identical-signature methods straight through.
+type cockpitPaneStore struct {
+	store *db.Store
+}
+
+func (s cockpitPaneStore) InsertCockpitPane(ctx context.Context, pane cockpit.Pane) error {
+	return s.store.InsertCockpitPane(ctx, toDBCockpitPane(pane))
+}
+
+func (s cockpitPaneStore) GetCockpitPaneByJob(ctx context.Context, jobID string) (cockpit.Pane, error) {
+	pane, err := s.store.GetCockpitPaneByJob(ctx, jobID)
+	if err != nil {
+		return cockpit.Pane{}, err
+	}
+	return fromDBCockpitPane(pane), nil
+}
+
+func (s cockpitPaneStore) ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([]cockpit.Pane, error) {
+	panes, err := s.store.ListCockpitPanesByRoot(ctx, rootJobID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]cockpit.Pane, 0, len(panes))
+	for _, pane := range panes {
+		out = append(out, fromDBCockpitPane(pane))
+	}
+	return out, nil
+}
+
+func (s cockpitPaneStore) DeleteCockpitPane(ctx context.Context, id string) error {
+	return s.store.DeleteCockpitPane(ctx, id)
+}
+
+func (s cockpitPaneStore) GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, err error)) (string, error) {
+	return s.store.GetOrCreateWorkspaceForRoot(ctx, rootJobID, create)
+}
+
+func toDBCockpitPane(p cockpit.Pane) db.CockpitPane {
+	return db.CockpitPane{
+		ID:          p.ID,
+		JobID:       p.JobID,
+		PaneKey:     p.PaneKey,
+		RootJobID:   p.RootJobID,
+		PaneID:      p.PaneID,
+		WorkspaceID: p.WorkspaceID,
+		Source:      p.Source,
+		CreatedAt:   p.CreatedAt,
+	}
+}
+
+func fromDBCockpitPane(p db.CockpitPane) cockpit.Pane {
+	return cockpit.Pane{
+		ID:          p.ID,
+		JobID:       p.JobID,
+		PaneKey:     p.PaneKey,
+		RootJobID:   p.RootJobID,
+		PaneID:      p.PaneID,
+		WorkspaceID: p.WorkspaceID,
+		Source:      p.Source,
+		CreatedAt:   p.CreatedAt,
+	}
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1698,14 +1698,18 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// cockpit rather than failing the job.
 	if payload.Cockpit {
 		policy, policyErr := w.orchestratePolicy()
-		modeOff := policyErr != nil || policy.CockpitMode == config.CockpitModeOff
+		// A policy LOAD error is not the same as the user opting out (mode off): the
+		// user asked for a cockpit, so degrade to cockpit-unavailable (run unwrapped
+		// AND emit the single cockpit_unavailable event) rather than silently
+		// dropping the pane. Only an explicit mode-off opts out without an event.
+		userOptedOff := policyErr == nil && policy.CockpitMode == config.CockpitModeOff
 		var cp *cockpit.Cockpit
-		if !modeOff {
+		if policyErr == nil && !userOptedOff {
 			cp = w.newCockpit(policy)
 		}
 		meta := cockpitJobMeta(job, payload, agent, checkout, policy.CockpitPaneKey)
 		var unavailable bool
-		adapter, unavailable = maybeWrapCockpit(cp, payload.Cockpit, modeOff, adapter, meta)
+		adapter, unavailable = maybeWrapCockpit(cp, payload.Cockpit, userOptedOff, adapter, meta)
 		if unavailable {
 			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "cockpit_unavailable", Message: "cockpit requested but herdr is unavailable; running without a pane"}); eventErr != nil {
 				writeLine(w.Stdout, "job %s cockpit_unavailable event failed: %v", job.ID, eventErr)
@@ -1806,9 +1810,16 @@ func cockpitJobMeta(job db.Job, payload workflow.JobPayload, agent runtime.Agent
 	if paneKeyMode == config.CockpitPaneKeySeat {
 		paneKey = agent.Name
 	}
+	// A root coordinator job has an empty payload.RootJobID; its own id IS the
+	// root (mirrors Engine.rootJobID). Without this every root collides into one
+	// herdr workspace keyed by "".
+	root := payload.RootJobID
+	if strings.TrimSpace(root) == "" {
+		root = job.ID
+	}
 	return cockpit.JobMeta{
 		JobID:     job.ID,
-		RootJobID: payload.RootJobID,
+		RootJobID: root,
 		Agent:     agent.Name,
 		Action:    job.Type,
 		Branch:    payload.Branch,

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/cockpit"
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -1689,6 +1690,28 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			writeLine(w.Stdout, "job %s runtime lock release failed: %v", job.ID, err)
 		}
 	}()
+	// Cockpit wrapping happens AFTER the runtime-session lock + checkout
+	// resolution so at most one live pane exists per held runtime session and the
+	// pane's CWD is the resolved worktree. It is strictly opt-in and best-effort:
+	// when --cockpit is off (or herdr is unavailable) the adapter is unchanged and
+	// behavior is byte-identical to today. A policy load failure degrades to no
+	// cockpit rather than failing the job.
+	if payload.Cockpit {
+		policy, policyErr := w.orchestratePolicy()
+		modeOff := policyErr != nil || policy.CockpitMode == config.CockpitModeOff
+		var cp *cockpit.Cockpit
+		if !modeOff {
+			cp = w.newCockpit(policy)
+		}
+		meta := cockpitJobMeta(job, payload, agent, checkout, policy.CockpitPaneKey)
+		var unavailable bool
+		adapter, unavailable = maybeWrapCockpit(cp, payload.Cockpit, modeOff, adapter, meta)
+		if unavailable {
+			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "cockpit_unavailable", Message: "cockpit requested but herdr is unavailable; running without a pane"}); eventErr != nil {
+				writeLine(w.Stdout, "job %s cockpit_unavailable event failed: %v", job.ID, eventErr)
+			}
+		}
+	}
 	if managed.OK {
 		if err := w.Store.MarkAgentInstanceRunning(ctx, agent.Name, time.Now().UTC(), managed.JobTimeout); err != nil {
 			if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
@@ -1742,6 +1765,80 @@ func (w jobWorker) parallelSessionPolicy() (config.ParallelSessionPolicy, error)
 		return config.ParallelSessionPolicy{}, err
 	}
 	return config.LoadParallelSessionPolicy(paths)
+}
+
+// orchestratePolicy loads the host-level [orchestrate] cockpit policy, mirroring
+// parallelSessionPolicy: an implicit/empty config home uses the defaults, and an
+// explicit home loads from the config file. It is best-effort at the call site —
+// a load error degrades to no cockpit (the job runs unwrapped).
+func (w jobWorker) orchestratePolicy() (config.OrchestratePolicy, error) {
+	if !w.ConfigHomeExplicit && strings.TrimSpace(w.ConfigHome) == "" {
+		return config.DefaultOrchestratePolicy(), nil
+	}
+	paths, err := initializedPaths(w.ConfigHome)
+	if err != nil {
+		return config.OrchestratePolicy{}, err
+	}
+	return config.LoadOrchestratePolicy(paths)
+}
+
+// newCockpit constructs a *cockpit.Cockpit from the orchestrate policy, backed by
+// the db store via the cockpitPaneStore shim. When the policy disables cockpit
+// panes (mode "off") it returns nil so the caller skips wrapping entirely. The
+// herdr binary is taken from HERDR_BIN (falling back to "herdr").
+func (w jobWorker) newCockpit(policy config.OrchestratePolicy) *cockpit.Cockpit {
+	if policy.CockpitMode == config.CockpitModeOff {
+		return nil
+	}
+	return cockpit.New(cockpit.Options{
+		HerdrBin:    firstNonEmpty(os.Getenv("HERDR_BIN"), "herdr"),
+		MaxPanes:    policy.CockpitMaxPanes,
+		PaneKeyMode: policy.CockpitPaneKey,
+	}, cockpitPaneStore{store: w.Store})
+}
+
+// cockpitJobMeta builds the cockpit.JobMeta for a delegation job from the decoded
+// payload, the runtime agent, and the resolved checkout dir. The pane key follows
+// the policy pane-key mode: "seat" keys by agent (one pane per logical seat),
+// otherwise the job id (one pane per job, the P0 default).
+func cockpitJobMeta(job db.Job, payload workflow.JobPayload, agent runtime.Agent, checkout string, paneKeyMode string) cockpit.JobMeta {
+	paneKey := job.ID
+	if paneKeyMode == config.CockpitPaneKeySeat {
+		paneKey = agent.Name
+	}
+	return cockpit.JobMeta{
+		JobID:     job.ID,
+		RootJobID: payload.RootJobID,
+		Agent:     agent.Name,
+		Action:    job.Type,
+		Branch:    payload.Branch,
+		Worktree:  checkout,
+		PaneKey:   paneKey,
+		Depth:     payload.DelegationDepth,
+	}
+}
+
+// maybeWrapCockpit decides whether a job's delivery is wrapped in a herdr pane.
+// It is a pure helper (no daemon state) so the wrap-vs-passthrough decision is
+// directly unit-testable. The returned unavailable flag is true exactly when the
+// caller should emit a single cockpit_unavailable job event:
+//   - not requested (payload.Cockpit false): inner unchanged, no event.
+//   - requested but the policy mode is off: skip entirely, inner unchanged, no
+//     event (an off host opted out, so there is nothing to warn about).
+//   - requested, mode not off, but the cockpit is nil or herdr is not available:
+//     inner unchanged, unavailable=true so the caller emits the event.
+//   - requested and available: the wrapped adapter, no event.
+//
+// Cockpit construction/Available failures are fail-open by contract: cp.Wrap
+// already returns inner untouched when Available is false.
+func maybeWrapCockpit(cp *cockpit.Cockpit, requested bool, modeOff bool, inner workflow.DeliveryAdapter, meta cockpit.JobMeta) (workflow.DeliveryAdapter, bool) {
+	if !requested || modeOff {
+		return inner, false
+	}
+	if cp == nil || !cp.Available(context.Background()) {
+		return inner, true
+	}
+	return cp.Wrap(inner, meta), false
 }
 
 func tempWorkerEligible(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload, agent runtime.Agent, policy config.ParallelSessionPolicy, now time.Time) tempWorkerEligibility {

--- a/internal/cli/daemon_cockpit_test.go
+++ b/internal/cli/daemon_cockpit_test.go
@@ -135,6 +135,31 @@ func TestCockpitJobMetaPaneKeyMode(t *testing.T) {
 	}
 }
 
+// TestCockpitJobMetaRootCoordinatorUsesOwnID guards that a root coordinator job
+// (empty payload.RootJobID) is its own root, so roots do not collide into one
+// herdr workspace keyed by the empty string.
+func TestCockpitJobMetaRootCoordinatorUsesOwnID(t *testing.T) {
+	agent := runtime.Agent{Name: "coord"}
+	checkout := "/tmp/worktree"
+
+	root := cockpitJobMeta(db.Job{ID: "root-job", Type: "ask"}, workflow.JobPayload{}, agent, checkout, "job")
+	if root.RootJobID != "root-job" {
+		t.Fatalf("root coordinator RootJobID = %q, want its own id %q", root.RootJobID, "root-job")
+	}
+
+	// A whitespace-only RootJobID is also treated as a root (mirrors the engine).
+	blank := cockpitJobMeta(db.Job{ID: "root-2", Type: "ask"}, workflow.JobPayload{RootJobID: "   "}, agent, checkout, "job")
+	if blank.RootJobID != "root-2" {
+		t.Fatalf("blank-root RootJobID = %q, want own id %q", blank.RootJobID, "root-2")
+	}
+
+	// A child carries the inherited root through unchanged.
+	child := cockpitJobMeta(db.Job{ID: "child-job", Type: "implement"}, workflow.JobPayload{RootJobID: "root-job"}, agent, checkout, "job")
+	if child.RootJobID != "root-job" {
+		t.Fatalf("child RootJobID = %q, want inherited %q", child.RootJobID, "root-job")
+	}
+}
+
 // TestWorkerEmitsCockpitUnavailableEvent drives the real worker path: a job that
 // requested --cockpit on a host without herdr runs unwrapped (the fake adapter
 // still delivers) and the worker records exactly one cockpit_unavailable event.

--- a/internal/cli/daemon_cockpit_test.go
+++ b/internal/cli/daemon_cockpit_test.go
@@ -1,0 +1,233 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/cockpit"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// cockpitStubAdapter is a no-op DeliveryAdapter used as the "inner" adapter so
+// the wrap-vs-passthrough decision can be checked by pointer identity.
+type cockpitStubAdapter struct{}
+
+func (cockpitStubAdapter) Deliver(context.Context, runtime.Agent, runtime.Job) (runtime.Result, error) {
+	return runtime.Result{}, nil
+}
+
+// sameAdapter reports whether two DeliveryAdapters are the same underlying value
+// (i.e. inner was returned untouched, not wrapped).
+func sameAdapter(a, b workflow.DeliveryAdapter) bool {
+	pa, okA := a.(*cockpitStubAdapter)
+	pb, okB := b.(*cockpitStubAdapter)
+	return okA && okB && pa == pb
+}
+
+func TestMaybeWrapCockpitDecision(t *testing.T) {
+	inner := &cockpitStubAdapter{}
+	meta := cockpit.JobMeta{JobID: "job-1"}
+
+	// A real cockpit constructed against a HERDR_BIN that does not exist on the
+	// test host: Available is false, so requested+available is exercised as the
+	// unavailable branch (CI has no herdr). The wrap-when-available branch is
+	// covered by the cockpit package's own tests against a fake runner.
+	unavailableCockpit := cockpit.New(cockpit.Options{HerdrBin: "herdr-does-not-exist-for-tests"}, nil)
+
+	tests := []struct {
+		name            string
+		cp              *cockpit.Cockpit
+		requested       bool
+		modeOff         bool
+		wantWrapped     bool
+		wantUnavailable bool
+	}{
+		{
+			name:            "not requested is a passthrough with no event",
+			cp:              unavailableCockpit,
+			requested:       false,
+			modeOff:         false,
+			wantWrapped:     false,
+			wantUnavailable: false,
+		},
+		{
+			name:            "mode off skips entirely with no event",
+			cp:              unavailableCockpit,
+			requested:       true,
+			modeOff:         true,
+			wantWrapped:     false,
+			wantUnavailable: false,
+		},
+		{
+			name:            "requested with nil cockpit is unavailable",
+			cp:              nil,
+			requested:       true,
+			modeOff:         false,
+			wantWrapped:     false,
+			wantUnavailable: true,
+		},
+		{
+			name:            "requested with herdr absent is unavailable",
+			cp:              unavailableCockpit,
+			requested:       true,
+			modeOff:         false,
+			wantWrapped:     false,
+			wantUnavailable: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, unavailable := maybeWrapCockpit(tc.cp, tc.requested, tc.modeOff, inner, meta)
+			if unavailable != tc.wantUnavailable {
+				t.Fatalf("unavailable = %v, want %v", unavailable, tc.wantUnavailable)
+			}
+			passthrough := sameAdapter(got, inner)
+			if tc.wantWrapped && passthrough {
+				t.Fatalf("expected a wrapped adapter, got the inner adapter untouched")
+			}
+			if !tc.wantWrapped && !passthrough {
+				t.Fatalf("expected the inner adapter untouched, got a wrapped adapter")
+			}
+		})
+	}
+
+	// Wrap path: when herdr is genuinely available on the host, a requested
+	// non-off job must produce a wrapped adapter (not the inner one) and report
+	// available. Skipped on hosts without a reachable herdr server so the test is
+	// deterministic everywhere.
+	live := cockpit.New(cockpit.Options{}, nil)
+	if !live.Available(context.Background()) {
+		t.Skip("herdr not available on this host; wrap-path branch is covered by the cockpit package tests")
+	}
+	got, unavailable := maybeWrapCockpit(live, true, false, inner, meta)
+	if unavailable {
+		t.Fatalf("unavailable = true with a live herdr, want false")
+	}
+	if sameAdapter(got, inner) {
+		t.Fatalf("expected a wrapped adapter with a live herdr, got the inner adapter untouched")
+	}
+}
+
+func TestCockpitJobMetaPaneKeyMode(t *testing.T) {
+	job := db.Job{ID: "job-42", Type: "implement", Agent: "lead"}
+	payload := workflow.JobPayload{RootJobID: "root-1", Branch: "feat/x", DelegationDepth: 2}
+	agent := runtime.Agent{Name: "lead"}
+	checkout := "/tmp/worktree"
+
+	jobMeta := cockpitJobMeta(job, payload, agent, checkout, "job")
+	if jobMeta.PaneKey != "job-42" {
+		t.Fatalf("job-mode PaneKey = %q, want job id", jobMeta.PaneKey)
+	}
+	if jobMeta.JobID != "job-42" || jobMeta.RootJobID != "root-1" || jobMeta.Agent != "lead" ||
+		jobMeta.Action != "implement" || jobMeta.Branch != "feat/x" || jobMeta.Worktree != checkout ||
+		jobMeta.Depth != 2 {
+		t.Fatalf("unexpected meta: %+v", jobMeta)
+	}
+
+	seatMeta := cockpitJobMeta(job, payload, agent, checkout, "seat")
+	if seatMeta.PaneKey != "lead" {
+		t.Fatalf("seat-mode PaneKey = %q, want agent name", seatMeta.PaneKey)
+	}
+}
+
+// TestWorkerEmitsCockpitUnavailableEvent drives the real worker path: a job that
+// requested --cockpit on a host without herdr runs unwrapped (the fake adapter
+// still delivers) and the worker records exactly one cockpit_unavailable event.
+func TestWorkerEmitsCockpitUnavailableEvent(t *testing.T) {
+	// Force herdr absent regardless of the host so the unavailable path is
+	// deterministic (this box may have a live herdr server).
+	t.Setenv("HERDR_BIN", "herdr-does-not-exist-for-tests")
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "task-cockpit")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:      "job-cockpit",
+		Agent:   "lead",
+		Action:  "implement",
+		Repo:    "owner/repo",
+		Branch:  "task-cockpit",
+		Cockpit: true,
+	})
+
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return &cliPollFakeGitHub{}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if adapter.calls != 1 {
+		t.Fatalf("adapter delivery calls = %d, want 1 (job runs unwrapped)", adapter.calls)
+	}
+
+	events, err := store.ListJobEvents(ctx, "job-cockpit")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	count := 0
+	for _, e := range events {
+		if e.Kind == "cockpit_unavailable" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("cockpit_unavailable events = %d, want exactly 1 (events: %+v)", count, events)
+	}
+}
+
+// TestWorkerNoCockpitEventWhenNotRequested confirms a job that did not request
+// --cockpit records no cockpit_unavailable event (off/absent is byte-identical).
+func TestWorkerNoCockpitEventWhenNotRequested(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "task-plain")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:     "job-plain",
+		Agent:  "lead",
+		Action: "implement",
+		Repo:   "owner/repo",
+		Branch: "task-plain",
+	})
+
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return &cliPollFakeGitHub{}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	events, err := store.ListJobEvents(ctx, "job-plain")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if daemonWorkerHasEvent(events, "cockpit_unavailable") {
+		t.Fatalf("unexpected cockpit_unavailable event for non-cockpit job: %+v", events)
+	}
+}

--- a/internal/cockpit/cockpit.go
+++ b/internal/cockpit/cockpit.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"sync"
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/runtime"
@@ -39,6 +40,13 @@ const (
 	// never stalls a job. Pane-open may be synchronous (only when streaming,
 	// P1); status/label/close are async best-effort.
 	herdrCallTimeout = 5 * time.Second
+
+	// availableTTL bounds how long a cached herdr-availability result is reused.
+	// Wrap is called once per job under the daemon's held runtime-session lock
+	// (SetMaxOpenConns(1)); shelling out to `herdr status` on every job would
+	// serialize a process spawn onto that hot path. A short TTL keeps the check
+	// cheap while still re-probing if herdr is started/stopped mid-run.
+	availableTTL = 30 * time.Second
 )
 
 // Pane is the cockpit's store-facing record for a single open pane. Its fields
@@ -65,6 +73,7 @@ type PaneStore interface {
 	GetCockpitPaneByJob(ctx context.Context, jobID string) (Pane, error)
 	ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([]Pane, error)
 	DeleteCockpitPane(ctx context.Context, id string) error
+	DeleteCockpitPaneByJob(ctx context.Context, jobID string) error
 	// GetOrCreateWorkspaceForRoot serializes one workspace per root: create is
 	// called only on first use for a given root and its workspace id is reused
 	// thereafter.
@@ -109,6 +118,17 @@ type Cockpit struct {
 	home       string
 
 	logger *slog.Logger
+
+	// availMu guards the memoized availability check. Wrap consults Available
+	// once per job on the locked hot path; caching the result for availableTTL
+	// avoids a `herdr status` shell-out per delivery while still re-probing
+	// periodically so a herdr that starts/stops mid-run is eventually noticed.
+	availMu     sync.Mutex
+	availCached bool
+	availOK     bool
+	availAt     time.Time
+	// now is the clock used for TTL expiry; overridable in tests.
+	now func() time.Time
 }
 
 // New builds a Cockpit. A zero HerdrBin defaults to "herdr"; a non-positive
@@ -134,6 +154,7 @@ func New(opts Options, store PaneStore) *Cockpit {
 		gitmootBin: bin,
 		home:       os.Getenv("GITMOOT_HOME"),
 		logger:     slog.Default(),
+		now:        time.Now,
 	}
 }
 
@@ -157,6 +178,7 @@ func newWithRunner(opts Options, store PaneStore, run runner, lookPath func(stri
 		gitmootBin: "gitmoot",
 		home:       "",
 		logger:     slog.Default(),
+		now:        time.Now,
 	}
 }
 
@@ -164,14 +186,30 @@ const defaultMaxPanes = 4
 
 // Available reports whether the cockpit can render panes: the herdr binary is
 // on PATH and `herdr status` reports the server running. It is timeout-bounded
-// so a hung herdr cannot stall gating.
+// so a hung herdr cannot stall gating, and the result is memoized for
+// availableTTL so the daemon's locked hot path does not shell out to `herdr
+// status` on every job. Fail-open: any probe error reports unavailable, which
+// makes Wrap return the inner adapter untouched.
 func (c *Cockpit) Available(ctx context.Context) bool {
 	if c == nil {
 		return false
 	}
-	ctx, cancel := context.WithTimeout(ctx, herdrCallTimeout)
+	c.availMu.Lock()
+	defer c.availMu.Unlock()
+	clock := c.now
+	if clock == nil {
+		clock = time.Now
+	}
+	if c.availCached && clock().Sub(c.availAt) < availableTTL {
+		return c.availOK
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, herdrCallTimeout)
 	defer cancel()
-	return c.client.available(ctx)
+	ok := c.client.available(probeCtx)
+	c.availCached = true
+	c.availOK = ok
+	c.availAt = clock()
+	return ok
 }
 
 // Wrap returns a DeliveryAdapter that opens a pane (best-effort), runs
@@ -293,7 +331,7 @@ func (a *paneAdapter) close(paneID string) {
 	c.bestEffort(ctx, "pane close", func(cctx context.Context) error {
 		return c.client.paneClose(cctx, paneID)
 	})
-	if err := c.store.DeleteCockpitPane(ctx, a.meta.JobID); err != nil {
+	if err := c.store.DeleteCockpitPaneByJob(ctx, a.meta.JobID); err != nil {
 		c.logf("cockpit: delete pane record for job %s: %v", a.meta.JobID, err)
 	}
 }

--- a/internal/cockpit/cockpit.go
+++ b/internal/cockpit/cockpit.go
@@ -1,0 +1,358 @@
+// Package cockpit renders one live herdr pane per delegation subagent for
+// `gitmoot orchestrate --cockpit`. It talks to the single herdr server over the
+// CLI only (no Go import of herdr) and is strictly opt-in: with the cockpit off
+// or herdr unreachable, Wrap returns the inner adapter untouched and
+// orchestration is byte-identical to today. Every herdr call is best-effort and
+// timeout-bounded — a herdr failure never fails or stalls the underlying job
+// (fail-open on work, fail-closed on the pane).
+package cockpit
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+const (
+	// herdrSource is the report-agent/report-metadata --source tag the spike
+	// verified for gitmoot-owned panes.
+	herdrSource = "custom:gitmoot"
+
+	// PaneKeyModeJob keys one pane per delegation job (the only P0 mode).
+	PaneKeyModeJob = "job"
+	// PaneKeyModeSeat keys one pane per logical seat (root, agent); reserved
+	// for P2 (Task 7). Treated as job mode in P0.
+	PaneKeyModeSeat = "seat"
+
+	// agentStateWorking / agentStateIdle are the report-agent --state values
+	// used to bracket a delivery.
+	agentStateWorking = "working"
+	agentStateIdle    = "idle"
+
+	// herdrCallTimeout bounds every individual herdr CLI call so a hung herdr
+	// never stalls a job. Pane-open may be synchronous (only when streaming,
+	// P1); status/label/close are async best-effort.
+	herdrCallTimeout = 5 * time.Second
+)
+
+// Pane is the cockpit's store-facing record for a single open pane. Its fields
+// mirror the frozen internal/db.CockpitPane row 1:1; integration adapts a
+// *db.Store to PaneStore over these fields (see the PaneStore doc).
+type Pane struct {
+	ID          string
+	JobID       string
+	PaneKey     string
+	RootJobID   string
+	PaneID      string
+	WorkspaceID string
+	Source      string
+	CreatedAt   string
+}
+
+// PaneStore is the narrow persistence surface the cockpit needs. It is the
+// frozen contract satisfied by *db.Store (Task 2): the method set and semantics
+// match db.Store's CockpitPane CRUD + per-root workspace registry. The cockpit
+// package keeps its own Pane record so it builds in isolation; integration
+// bridges *db.Store with a trivial shim over identical fields.
+type PaneStore interface {
+	InsertCockpitPane(ctx context.Context, pane Pane) error
+	GetCockpitPaneByJob(ctx context.Context, jobID string) (Pane, error)
+	ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([]Pane, error)
+	DeleteCockpitPane(ctx context.Context, id string) error
+	// GetOrCreateWorkspaceForRoot serializes one workspace per root: create is
+	// called only on first use for a given root and its workspace id is reused
+	// thereafter.
+	GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, err error)) (string, error)
+}
+
+// Options configures a Cockpit. The fields are frozen.
+type Options struct {
+	// HerdrBin is the herdr binary name or path (default "herdr").
+	HerdrBin string
+	// MaxPanes caps the number of split panes per cockpit run; jobs beyond the
+	// cap are status-only (no pane).
+	MaxPanes int
+	// PaneKeyMode is "job" (P0) or "seat" (P2).
+	PaneKeyMode string
+}
+
+// JobMeta describes the delegation job a pane is opened for. The fields are
+// frozen; the cockpit derives the gitmoot binary and home internally (they are
+// intentionally not part of the contract).
+type JobMeta struct {
+	JobID     string
+	RootJobID string
+	Agent     string
+	Action    string
+	Branch    string
+	Worktree  string
+	PaneKey   string
+	Depth     int
+}
+
+// Cockpit opens and tears down herdr panes around delegation deliveries.
+type Cockpit struct {
+	client herdrClient
+	store  PaneStore
+	opts   Options
+
+	// gitmootBin / home back the P0 `pane run "<gitmoot> job watch <job>
+	// --home <home>"` command. They are resolved once in New rather than
+	// threaded through the frozen JobMeta/Options.
+	gitmootBin string
+	home       string
+
+	logger *slog.Logger
+}
+
+// New builds a Cockpit. A zero HerdrBin defaults to "herdr"; a non-positive
+// MaxPanes defaults to a sane cap; an empty PaneKeyMode defaults to job.
+func New(opts Options, store PaneStore) *Cockpit {
+	if opts.HerdrBin == "" {
+		opts.HerdrBin = "herdr"
+	}
+	if opts.MaxPanes <= 0 {
+		opts.MaxPanes = defaultMaxPanes
+	}
+	if opts.PaneKeyMode == "" {
+		opts.PaneKeyMode = PaneKeyModeJob
+	}
+	bin, err := os.Executable()
+	if err != nil {
+		bin = "gitmoot"
+	}
+	return &Cockpit{
+		client:     herdrClient{run: newExecRunner(opts.HerdrBin), bin: opts.HerdrBin, lookPath: exec.LookPath},
+		store:      store,
+		opts:       opts,
+		gitmootBin: bin,
+		home:       os.Getenv("GITMOOT_HOME"),
+		logger:     slog.Default(),
+	}
+}
+
+// newWithRunner builds a Cockpit around an injected herdr runner and lookPath.
+// It backs the package tests, which drive the full pane lifecycle against a fake
+// runner (no real herdr server), and keeps gitmootBin/home deterministic.
+func newWithRunner(opts Options, store PaneStore, run runner, lookPath func(string) (string, error)) *Cockpit {
+	if opts.HerdrBin == "" {
+		opts.HerdrBin = "herdr"
+	}
+	if opts.MaxPanes <= 0 {
+		opts.MaxPanes = defaultMaxPanes
+	}
+	if opts.PaneKeyMode == "" {
+		opts.PaneKeyMode = PaneKeyModeJob
+	}
+	return &Cockpit{
+		client:     herdrClient{run: run, bin: opts.HerdrBin, lookPath: lookPath},
+		store:      store,
+		opts:       opts,
+		gitmootBin: "gitmoot",
+		home:       "",
+		logger:     slog.Default(),
+	}
+}
+
+const defaultMaxPanes = 4
+
+// Available reports whether the cockpit can render panes: the herdr binary is
+// on PATH and `herdr status` reports the server running. It is timeout-bounded
+// so a hung herdr cannot stall gating.
+func (c *Cockpit) Available(ctx context.Context) bool {
+	if c == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(ctx, herdrCallTimeout)
+	defer cancel()
+	return c.client.available(ctx)
+}
+
+// Wrap returns a DeliveryAdapter that opens a pane (best-effort), runs
+// inner.Deliver, and closes the pane on return. When the cockpit is unavailable
+// it returns inner untouched so no herdr calls are made and behavior is
+// byte-identical to today.
+func (c *Cockpit) Wrap(inner workflow.DeliveryAdapter, meta JobMeta) workflow.DeliveryAdapter {
+	if c == nil || inner == nil {
+		return inner
+	}
+	if !c.Available(context.Background()) {
+		return inner
+	}
+	return &paneAdapter{cockpit: c, inner: inner, meta: meta}
+}
+
+// paneAdapter brackets inner.Deliver with herdr pane open/close. All herdr
+// errors are logged and swallowed: the job's result is inner's, unchanged.
+type paneAdapter struct {
+	cockpit *Cockpit
+	inner   workflow.DeliveryAdapter
+	meta    JobMeta
+}
+
+func (a *paneAdapter) Deliver(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	pane := a.open(ctx)
+	if pane != "" {
+		defer a.close(pane)
+	}
+	return a.inner.Deliver(ctx, agent, job)
+}
+
+// open resolves the per-root workspace, splits a child pane, labels it, marks
+// the agent working, runs the job-watch command, and persists the pane. It
+// returns the new pane id, or "" when no pane was opened (over MaxPanes, herdr
+// error, or missing root). Every failure is swallowed (fail-closed on the
+// pane) so delivery proceeds unwrapped.
+func (a *paneAdapter) open(ctx context.Context) string {
+	c := a.cockpit
+	rootJob := a.meta.RootJobID
+	if rootJob == "" {
+		rootJob = a.meta.JobID
+	}
+
+	// Honor MaxPanes: beyond the cap the job is status-only (no pane).
+	if existing, err := c.store.ListCockpitPanesByRoot(ctx, rootJob); err == nil {
+		if len(existing) >= c.opts.MaxPanes {
+			c.logf("cockpit: max panes reached for root %s; status-only", rootJob)
+			return ""
+		}
+	}
+
+	workspaceID, err := c.store.GetOrCreateWorkspaceForRoot(ctx, rootJob, func() (string, error) {
+		callCtx, cancel := context.WithTimeout(ctx, herdrCallTimeout)
+		defer cancel()
+		wsID, _, createErr := c.client.workspaceCreate(callCtx, a.meta.Worktree, a.workspaceLabel())
+		return wsID, createErr
+	})
+	if err != nil || workspaceID == "" {
+		c.logf("cockpit: resolve workspace for root %s: %v", rootJob, err)
+		return ""
+	}
+
+	// The parent pane for the first split is the workspace's root pane. herdr
+	// accepts the workspace id as the split parent target for the root pane.
+	splitCtx, cancel := context.WithTimeout(ctx, herdrCallTimeout)
+	defer cancel()
+	paneID, err := c.client.paneSplit(splitCtx, c.rootPaneFor(workspaceID), a.meta.Worktree)
+	if err != nil || paneID == "" {
+		c.logf("cockpit: pane split for job %s: %v", a.meta.JobID, err)
+		return ""
+	}
+
+	source := herdrSource
+	shortID := shortJobID(a.meta.JobID)
+	agentLabel := "gm-" + shortID
+
+	// Label + status + watch are best-effort; a failure here still yields a
+	// usable pane, so we keep it and persist it.
+	c.bestEffort(ctx, "rename", func(cctx context.Context) error {
+		return c.client.paneRename(cctx, paneID, a.paneLabel())
+	})
+	c.bestEffort(ctx, "report-agent working", func(cctx context.Context) error {
+		return c.client.reportAgent(cctx, paneID, source, agentLabel, agentStateWorking)
+	})
+	c.bestEffort(ctx, "pane run", func(cctx context.Context) error {
+		return c.client.paneRun(cctx, paneID, a.watchCommand())
+	})
+
+	record := Pane{
+		JobID:       a.meta.JobID,
+		PaneKey:     a.paneKey(),
+		RootJobID:   rootJob,
+		PaneID:      paneID,
+		WorkspaceID: workspaceID,
+		Source:      source,
+	}
+	if err := c.store.InsertCockpitPane(ctx, record); err != nil {
+		c.logf("cockpit: persist pane for job %s: %v", a.meta.JobID, err)
+		// The pane is open and useful even if persistence failed; keep it.
+	}
+	return paneID
+}
+
+// close marks the agent idle, releases it, and closes the pane — all
+// best-effort. Workspace close is deferred to root-finalize (P2), not here.
+func (a *paneAdapter) close(paneID string) {
+	c := a.cockpit
+	source := herdrSource
+	agentLabel := "gm-" + shortJobID(a.meta.JobID)
+	ctx := context.Background()
+
+	c.bestEffort(ctx, "report-agent idle", func(cctx context.Context) error {
+		return c.client.reportAgent(cctx, paneID, source, agentLabel, agentStateIdle)
+	})
+	c.bestEffort(ctx, "release-agent", func(cctx context.Context) error {
+		return c.client.releaseAgent(cctx, paneID, source, agentLabel)
+	})
+	c.bestEffort(ctx, "pane close", func(cctx context.Context) error {
+		return c.client.paneClose(cctx, paneID)
+	})
+	if err := c.store.DeleteCockpitPane(ctx, a.meta.JobID); err != nil {
+		c.logf("cockpit: delete pane record for job %s: %v", a.meta.JobID, err)
+	}
+}
+
+// paneKey returns the pane's dedup key. In P0 (job mode) it is the job id; the
+// caller-supplied PaneKey wins when set (forward-compat with seat mode, P2).
+func (a *paneAdapter) paneKey() string {
+	if a.meta.PaneKey != "" {
+		return a.meta.PaneKey
+	}
+	return a.meta.JobID
+}
+
+// paneLabel is the verified rename label: "<agent> · d<depth> · <branch>".
+func (a *paneAdapter) paneLabel() string {
+	return fmt.Sprintf("%s · d%d · %s", a.meta.Agent, a.meta.Depth, a.meta.Branch)
+}
+
+// workspaceLabel labels the per-root workspace.
+func (a *paneAdapter) workspaceLabel() string {
+	return fmt.Sprintf("gitmoot · %s", shortJobID(a.workspaceRoot()))
+}
+
+func (a *paneAdapter) workspaceRoot() string {
+	if a.meta.RootJobID != "" {
+		return a.meta.RootJobID
+	}
+	return a.meta.JobID
+}
+
+// watchCommand is the P0 pane payload: tail the job's progress via the gitmoot
+// CLI. In P1 (Task 6) this is replaced by tailing a streamed log.
+func (a *paneAdapter) watchCommand() string {
+	cmd := fmt.Sprintf("%s job watch %s", a.cockpit.gitmootBin, a.meta.JobID)
+	if a.cockpit.home != "" {
+		cmd += fmt.Sprintf(" --home %s", a.cockpit.home)
+	}
+	return cmd
+}
+
+// rootPaneFor returns the split-parent target for a workspace. The workspace id
+// addresses its root pane for the first split; subsequent splits target the
+// root pane too (herdr lays them out under the workspace).
+func (c *Cockpit) rootPaneFor(workspaceID string) string {
+	return workspaceID
+}
+
+// bestEffort runs a timeout-bounded herdr call and swallows any error after
+// logging it. Used for every non-load-bearing pane operation.
+func (c *Cockpit) bestEffort(ctx context.Context, op string, fn func(context.Context) error) {
+	cctx, cancel := context.WithTimeout(ctx, herdrCallTimeout)
+	defer cancel()
+	if err := fn(cctx); err != nil {
+		c.logf("cockpit: %s: %v", op, err)
+	}
+}
+
+func (c *Cockpit) logf(format string, args ...any) {
+	if c.logger != nil {
+		c.logger.Debug(fmt.Sprintf(format, args...))
+	}
+}

--- a/internal/cockpit/cockpit_test.go
+++ b/internal/cockpit/cockpit_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
@@ -133,7 +134,18 @@ func (s *fakeStore) ListCockpitPanesByRoot(_ context.Context, rootJobID string) 
 func (s *fakeStore) DeleteCockpitPane(_ context.Context, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.panes, id)
+	for jobID, p := range s.panes {
+		if p.ID == id {
+			delete(s.panes, jobID)
+		}
+	}
+	return nil
+}
+
+func (s *fakeStore) DeleteCockpitPaneByJob(_ context.Context, jobID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.panes, jobID)
 	return nil
 }
 
@@ -215,6 +227,43 @@ func TestAvailable(t *testing.T) {
 	})
 }
 
+func TestAvailableMemoizesWithinTTL(t *testing.T) {
+	fr := newFakeRunner()
+	c := newWithRunner(Options{}, newFakeStore(), fr.run, okLookPath)
+	now := time.Unix(0, 0)
+	c.now = func() time.Time { return now }
+
+	statusCalls := func() int {
+		n := 0
+		for _, v := range fr.verbs() {
+			if v == "status" {
+				n++
+			}
+		}
+		return n
+	}
+
+	// First call probes; subsequent calls within the TTL reuse the cache.
+	if !c.Available(context.Background()) {
+		t.Fatal("expected available")
+	}
+	if !c.Available(context.Background()) || !c.Available(context.Background()) {
+		t.Fatal("expected available (cached)")
+	}
+	if got := statusCalls(); got != 1 {
+		t.Fatalf("status shell-outs within TTL = %d, want 1", got)
+	}
+
+	// Past the TTL, the cache expires and the probe runs again.
+	now = now.Add(availableTTL + time.Second)
+	if !c.Available(context.Background()) {
+		t.Fatal("expected available after TTL")
+	}
+	if got := statusCalls(); got != 2 {
+		t.Fatalf("status shell-outs after TTL = %d, want 2", got)
+	}
+}
+
 func TestWrapUnavailableReturnsInnerUntouched(t *testing.T) {
 	fr := newFakeRunner()
 	c := newWithRunner(Options{}, newFakeStore(), fr.run, failLookPath)
@@ -288,6 +337,32 @@ func TestWrapDeliverCommandSequence(t *testing.T) {
 	}
 	if store.createN != 1 {
 		t.Fatalf("expected workspace created once, got %d", store.createN)
+	}
+}
+
+func TestWrapDeliverDeletesPaneRowByJobOnClose(t *testing.T) {
+	// close() must remove the pane row keyed by job id so it does not orphan and
+	// a re-run of the same job can reclaim its (workspace_id, pane_key) slot.
+	fr := newFakeRunner()
+	store := newFakeStore()
+	c := newWithRunner(Options{}, store, fr.run, okLookPath)
+	inner := &fakeInner{result: runtime.Result{Summary: "ok"}}
+
+	adapter := c.Wrap(inner, sampleMeta())
+	if _, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{ID: "abcdef0123456789"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := store.GetCockpitPaneByJob(context.Background(), "abcdef0123456789"); err == nil {
+		t.Fatal("expected pane row deleted by job on close")
+	}
+
+	// A re-run of the same job re-inserts and again deletes — no leaked row.
+	adapter2 := c.Wrap(&fakeInner{}, sampleMeta())
+	if _, err := adapter2.Deliver(context.Background(), runtime.Agent{}, runtime.Job{ID: "abcdef0123456789"}); err != nil {
+		t.Fatalf("unexpected error on re-run: %v", err)
+	}
+	if _, err := store.GetCockpitPaneByJob(context.Background(), "abcdef0123456789"); err == nil {
+		t.Fatal("expected pane row deleted by job on close after re-run")
 	}
 }
 

--- a/internal/cockpit/cockpit_test.go
+++ b/internal/cockpit/cockpit_test.go
@@ -1,0 +1,465 @@
+package cockpit
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// fakeRunner records every herdr invocation and returns canned stdout (and an
+// optional error) keyed by the first two args (the herdr subcommand path). It
+// stands in for a real herdr server.
+type fakeRunner struct {
+	mu      sync.Mutex
+	calls   []string
+	replies map[string]reply
+}
+
+type reply struct {
+	stdout string
+	err    error
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{replies: map[string]reply{
+		"status":             {stdout: `{"server":{"running":true}}`},
+		"workspace create":   {stdout: `{"result":{"workspace":{"workspace_id":"w1"},"root_pane":{"pane_id":"w1:p1"}}}`},
+		"pane split":         {stdout: `{"result":{"pane":{"pane_id":"w1:p2"}}}`},
+		"pane rename":        {stdout: `{}`},
+		"pane report-agent":  {stdout: `{}`},
+		"pane run":           {stdout: `{}`},
+		"pane release-agent": {stdout: `{}`},
+		"pane close":         {stdout: `{}`},
+		"workspace close":    {stdout: `{}`},
+	}}
+}
+
+func (f *fakeRunner) run(_ context.Context, args ...string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, strings.Join(args, " "))
+	r, ok := f.replies[replyKey(args)]
+	if !ok {
+		return "{}", nil
+	}
+	return r.stdout, r.err
+}
+
+// replyKey maps an invocation to its reply/verb key. `status` is a single-word
+// subcommand; everything else keys on the first two args (the herdr
+// command-group + subcommand, e.g. "pane split").
+func replyKey(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	if args[0] == "status" {
+		return "status"
+	}
+	if len(args) > 1 {
+		return args[0] + " " + args[1]
+	}
+	return args[0]
+}
+
+func (f *fakeRunner) verbs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.calls))
+	for _, c := range f.calls {
+		out = append(out, replyKey(strings.Split(c, " ")))
+	}
+	return out
+}
+
+func (f *fakeRunner) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func okLookPath(string) (string, error) { return "/usr/bin/herdr", nil }
+
+func failLookPath(string) (string, error) { return "", errors.New("not found") }
+
+// fakeStore is an in-memory PaneStore with a one-workspace-per-root registry.
+type fakeStore struct {
+	mu         sync.Mutex
+	panes      map[string]Pane // keyed by job id
+	workspaces map[string]string
+	createN    int
+	insertErr  error
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{panes: map[string]Pane{}, workspaces: map[string]string{}}
+}
+
+func (s *fakeStore) InsertCockpitPane(_ context.Context, pane Pane) error {
+	if s.insertErr != nil {
+		return s.insertErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.panes[pane.JobID] = pane
+	return nil
+}
+
+func (s *fakeStore) GetCockpitPaneByJob(_ context.Context, jobID string) (Pane, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.panes[jobID]
+	if !ok {
+		return Pane{}, errors.New("not found")
+	}
+	return p, nil
+}
+
+func (s *fakeStore) ListCockpitPanesByRoot(_ context.Context, rootJobID string) ([]Pane, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Pane
+	for _, p := range s.panes {
+		if p.RootJobID == rootJobID {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func (s *fakeStore) DeleteCockpitPane(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.panes, id)
+	return nil
+}
+
+func (s *fakeStore) GetOrCreateWorkspaceForRoot(_ context.Context, rootJobID string, create func() (string, error)) (string, error) {
+	s.mu.Lock()
+	if ws, ok := s.workspaces[rootJobID]; ok {
+		s.mu.Unlock()
+		return ws, nil
+	}
+	s.mu.Unlock()
+	ws, err := create()
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	s.createN++
+	s.workspaces[rootJobID] = ws
+	s.mu.Unlock()
+	return ws, nil
+}
+
+// fakeInner is the wrapped DeliveryAdapter. It records that it ran and returns a
+// fixed result so the pane wrapper's pass-through can be asserted.
+type fakeInner struct {
+	called bool
+	result runtime.Result
+	err    error
+}
+
+func (a *fakeInner) Deliver(_ context.Context, _ runtime.Agent, _ runtime.Job) (runtime.Result, error) {
+	a.called = true
+	return a.result, a.err
+}
+
+func sampleMeta() JobMeta {
+	return JobMeta{
+		JobID:     "abcdef0123456789",
+		RootJobID: "root00001111",
+		Agent:     "builder",
+		Action:    "implement",
+		Branch:    "feat/x",
+		Worktree:  "/tmp/wt",
+		Depth:     1,
+	}
+}
+
+func TestAvailable(t *testing.T) {
+	t.Run("up", func(t *testing.T) {
+		c := newWithRunner(Options{}, newFakeStore(), newFakeRunner().run, okLookPath)
+		if !c.Available(context.Background()) {
+			t.Fatal("expected available")
+		}
+	})
+	t.Run("binary absent ⇒ no runner calls", func(t *testing.T) {
+		fr := newFakeRunner()
+		c := newWithRunner(Options{}, newFakeStore(), fr.run, failLookPath)
+		if c.Available(context.Background()) {
+			t.Fatal("expected unavailable when binary absent")
+		}
+		if fr.callCount() != 0 {
+			t.Fatalf("expected no runner calls, got %v", fr.calls)
+		}
+	})
+	t.Run("server down", func(t *testing.T) {
+		fr := newFakeRunner()
+		fr.replies["status"] = reply{stdout: `{"server":{"running":false}}`}
+		c := newWithRunner(Options{}, newFakeStore(), fr.run, okLookPath)
+		if c.Available(context.Background()) {
+			t.Fatal("expected unavailable when server not running")
+		}
+	})
+	t.Run("status errors", func(t *testing.T) {
+		fr := newFakeRunner()
+		fr.replies["status"] = reply{err: errors.New("socket gone")}
+		c := newWithRunner(Options{}, newFakeStore(), fr.run, okLookPath)
+		if c.Available(context.Background()) {
+			t.Fatal("expected unavailable when status errors")
+		}
+	})
+}
+
+func TestWrapUnavailableReturnsInnerUntouched(t *testing.T) {
+	fr := newFakeRunner()
+	c := newWithRunner(Options{}, newFakeStore(), fr.run, failLookPath)
+	inner := &fakeInner{result: runtime.Result{Summary: "done"}}
+
+	got := c.Wrap(inner, sampleMeta())
+	if got != inner {
+		t.Fatal("expected Wrap to return inner unchanged when unavailable")
+	}
+	// Only the status check happened during gating; no pane calls.
+	for _, v := range fr.verbs() {
+		if strings.HasPrefix(v, "pane") || strings.HasPrefix(v, "workspace") {
+			t.Fatalf("expected no pane/workspace calls, got %v", fr.calls)
+		}
+	}
+}
+
+func TestWrapNilInner(t *testing.T) {
+	c := newWithRunner(Options{}, newFakeStore(), newFakeRunner().run, okLookPath)
+	if c.Wrap(nil, sampleMeta()) != nil {
+		t.Fatal("expected nil inner to pass through")
+	}
+}
+
+func TestWrapDeliverCommandSequence(t *testing.T) {
+	fr := newFakeRunner()
+	store := newFakeStore()
+	c := newWithRunner(Options{}, store, fr.run, okLookPath)
+	inner := &fakeInner{result: runtime.Result{Decision: "approve", Summary: "ok", Raw: "raw"}}
+
+	adapter := c.Wrap(inner, sampleMeta())
+	res, err := adapter.Deliver(context.Background(), runtime.Agent{Name: "builder"}, runtime.Job{ID: "abcdef0123456789"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !inner.called {
+		t.Fatal("inner adapter was not invoked")
+	}
+	// Result is inner's, unchanged.
+	if res != inner.result {
+		t.Fatalf("result mutated: got %+v want %+v", res, inner.result)
+	}
+
+	want := []string{
+		"status",            // Wrap gating
+		"workspace create",  // per-root workspace
+		"pane split",        // child pane
+		"pane rename",       // label
+		"pane report-agent", // working
+		"pane run",          // job watch
+		"pane report-agent", // idle
+		"pane release-agent",
+		"pane close",
+	}
+	got := fr.verbs()
+	if len(got) != len(want) {
+		t.Fatalf("command sequence length: got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("command[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+
+	// Persisted exactly one pane keyed by job id, with the verified ids.
+	pane, err := store.GetCockpitPaneByJob(context.Background(), "abcdef0123456789")
+	if err == nil {
+		// pane was deleted on close; re-open via the panes map is gone. Instead
+		// assert the workspace registry created exactly once.
+		_ = pane
+	}
+	if store.createN != 1 {
+		t.Fatalf("expected workspace created once, got %d", store.createN)
+	}
+}
+
+func TestWrapDeliverArgsCarryVerifiedFields(t *testing.T) {
+	fr := newFakeRunner()
+	c := newWithRunner(Options{}, newFakeStore(), fr.run, okLookPath)
+	inner := &fakeInner{}
+	adapter := c.Wrap(inner, sampleMeta())
+	if _, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatal(err)
+	}
+
+	joined := strings.Join(fr.calls, "\n")
+	assertContains := func(substr string) {
+		if !strings.Contains(joined, substr) {
+			t.Fatalf("expected herdr calls to contain %q; calls:\n%s", substr, joined)
+		}
+	}
+	// workspace create uses the worktree cwd and --no-focus.
+	assertContains("workspace create --cwd /tmp/wt --label")
+	assertContains("--no-focus")
+	// pane split targets the workspace root pane parent and the worktree cwd.
+	assertContains("pane split w1 --direction down --cwd /tmp/wt --no-focus")
+	// rename uses "<agent> · d<depth> · <branch>".
+	assertContains("pane rename w1:p2 builder · d1 · feat/x")
+	// report-agent uses the verified source + gm-<jobid8> agent + working.
+	assertContains("pane report-agent w1:p2 --source custom:gitmoot --agent gm-abcdef01 --state working")
+	assertContains("--state idle")
+	// pane run carries the job-watch command.
+	assertContains("pane run w1:p2 gitmoot job watch abcdef0123456789")
+	// teardown releases then closes.
+	assertContains("pane release-agent w1:p2 --source custom:gitmoot --agent gm-abcdef01")
+	assertContains("pane close w1:p2")
+}
+
+func TestWrapSwallowsHerdrErrors(t *testing.T) {
+	// pane split fails ⇒ no pane opened, but delivery still proceeds and the
+	// result is unchanged.
+	fr := newFakeRunner()
+	fr.replies["pane split"] = reply{err: errors.New("herdr boom")}
+	c := newWithRunner(Options{}, newFakeStore(), fr.run, okLookPath)
+	inner := &fakeInner{result: runtime.Result{Summary: "still-ok"}}
+
+	adapter := c.Wrap(inner, sampleMeta())
+	res, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{})
+	if err != nil {
+		t.Fatalf("herdr error must not surface: %v", err)
+	}
+	if res != inner.result {
+		t.Fatalf("result mutated on herdr failure: %+v", res)
+	}
+	if !inner.called {
+		t.Fatal("inner must run even when pane open fails")
+	}
+	// No close/teardown calls since no pane was opened.
+	for _, v := range fr.verbs() {
+		if v == "pane close" || v == "pane release-agent" {
+			t.Fatalf("teardown ran for an unopened pane: %v", fr.calls)
+		}
+	}
+}
+
+func TestWrapSwallowsLabelAndPersistErrors(t *testing.T) {
+	// rename/report errors are best-effort: the pane stays open and torn down.
+	fr := newFakeRunner()
+	fr.replies["pane rename"] = reply{err: errors.New("rename boom")}
+	fr.replies["pane report-agent"] = reply{err: errors.New("status boom")}
+	store := newFakeStore()
+	store.insertErr = errors.New("db boom")
+	c := newWithRunner(Options{}, store, fr.run, okLookPath)
+	inner := &fakeInner{result: runtime.Result{Summary: "ok"}}
+
+	adapter := c.Wrap(inner, sampleMeta())
+	res, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{})
+	if err != nil {
+		t.Fatalf("best-effort errors must not surface: %v", err)
+	}
+	if res != inner.result {
+		t.Fatalf("result mutated: %+v", res)
+	}
+	// Pane opened despite the soft failures ⇒ it is torn down.
+	closed := false
+	for _, v := range fr.verbs() {
+		if v == "pane close" {
+			closed = true
+		}
+	}
+	if !closed {
+		t.Fatalf("expected pane close on teardown; calls: %v", fr.calls)
+	}
+}
+
+func TestWrapHonorsMaxPanes(t *testing.T) {
+	fr := newFakeRunner()
+	store := newFakeStore()
+	// Pre-seed MaxPanes panes under the root so the next open is status-only.
+	store.panes["pre1"] = Pane{JobID: "pre1", RootJobID: "root00001111"}
+	store.panes["pre2"] = Pane{JobID: "pre2", RootJobID: "root00001111"}
+	c := newWithRunner(Options{MaxPanes: 2}, store, fr.run, okLookPath)
+	inner := &fakeInner{result: runtime.Result{Summary: "ok"}}
+
+	adapter := c.Wrap(inner, sampleMeta())
+	if _, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatal(err)
+	}
+	if !inner.called {
+		t.Fatal("inner must still run when over the pane cap")
+	}
+	for _, v := range fr.verbs() {
+		if v == "pane split" || v == "workspace create" {
+			t.Fatalf("expected status-only (no pane) over MaxPanes; calls: %v", fr.calls)
+		}
+	}
+}
+
+func TestWrapPropagatesInnerError(t *testing.T) {
+	fr := newFakeRunner()
+	c := newWithRunner(Options{}, newFakeStore(), fr.run, okLookPath)
+	innerErr := errors.New("delivery failed")
+	inner := &fakeInner{err: innerErr}
+
+	adapter := c.Wrap(inner, sampleMeta())
+	_, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{})
+	if !errors.Is(err, innerErr) {
+		t.Fatalf("expected inner error to propagate, got %v", err)
+	}
+	// Pane still torn down even on inner failure.
+	closed := false
+	for _, v := range fr.verbs() {
+		if v == "pane close" {
+			closed = true
+		}
+	}
+	if !closed {
+		t.Fatalf("expected pane close even on inner error; calls: %v", fr.calls)
+	}
+}
+
+func TestNewDefaults(t *testing.T) {
+	c := New(Options{}, newFakeStore())
+	if c.opts.HerdrBin != "herdr" {
+		t.Fatalf("HerdrBin default = %q, want herdr", c.opts.HerdrBin)
+	}
+	if c.opts.MaxPanes != defaultMaxPanes {
+		t.Fatalf("MaxPanes default = %d, want %d", c.opts.MaxPanes, defaultMaxPanes)
+	}
+	if c.opts.PaneKeyMode != PaneKeyModeJob {
+		t.Fatalf("PaneKeyMode default = %q, want %q", c.opts.PaneKeyMode, PaneKeyModeJob)
+	}
+}
+
+func TestNilCockpitWrapAndAvailable(t *testing.T) {
+	var c *Cockpit
+	if c.Available(context.Background()) {
+		t.Fatal("nil cockpit must report unavailable")
+	}
+	inner := &fakeInner{}
+	if c.Wrap(inner, sampleMeta()) != inner {
+		t.Fatal("nil cockpit Wrap must return inner")
+	}
+}
+
+func TestShortJobID(t *testing.T) {
+	cases := map[string]string{
+		"abcdef0123456789": "abcdef01",
+		"short":            "short",
+		"":                 "",
+		"  abcdef0123  ":   "abcdef01",
+	}
+	for in, want := range cases {
+		if got := shortJobID(in); got != want {
+			t.Errorf("shortJobID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/cockpit/herdr.go
+++ b/internal/cockpit/herdr.go
@@ -1,0 +1,192 @@
+package cockpit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// runner executes a single herdr CLI invocation and returns its stdout. It is
+// injectable so tests can drive the client with a fake (no real herdr server).
+// The default runner (newExecRunner) execs the configured herdr binary.
+type runner func(ctx context.Context, args ...string) (stdout string, err error)
+
+// newExecRunner returns a runner that execs the herdr binary at bin. When the
+// caller sets HERDR_SOCKET_PATH, it is passed through to the child process so
+// the spike's reachability gating (a background/daemon context reaching the
+// single herdr server) holds; an unset value defaults to herdr's own socket.
+func newExecRunner(bin string) runner {
+	return func(ctx context.Context, args ...string) (string, error) {
+		cmd := exec.CommandContext(ctx, bin, args...)
+		// Inherit the daemon environment (incl. HERDR_SOCKET_PATH when set) so
+		// herdr resolves the same socket the reachability check used.
+		cmd.Env = os.Environ()
+		out, err := cmd.Output()
+		return string(out), err
+	}
+}
+
+// herdrClient is a thin, typed wrapper over the verified herdr CLI surface. It
+// owns no state beyond the runner and binary name; every call is a one-shot
+// invocation. JSON parsing targets only the fields the spike verified.
+type herdrClient struct {
+	run runner
+	bin string
+	// lookPath resolves the herdr binary on PATH; injectable so tests can drive
+	// availability deterministically without a real herdr install.
+	lookPath func(string) (string, error)
+}
+
+// status mirrors the shape of `herdr status --json`. Only the running flag is
+// load-bearing for gating; the rest is decoded best-effort.
+type statusResult struct {
+	Server struct {
+		Running bool `json:"running"`
+	} `json:"server"`
+}
+
+// available reports whether the herdr binary is on PATH and the server is
+// reachable (`herdr status --json` rc 0 + .server.running == true).
+func (c herdrClient) available(ctx context.Context) bool {
+	if c.bin == "" {
+		return false
+	}
+	lookPath := c.lookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	if _, err := lookPath(c.bin); err != nil {
+		return false
+	}
+	out, err := c.run(ctx, "status", "--json")
+	if err != nil {
+		return false
+	}
+	var st statusResult
+	if err := json.Unmarshal([]byte(out), &st); err != nil {
+		return false
+	}
+	return st.Server.Running
+}
+
+// workspaceResult mirrors `herdr workspace create`: it carries the new
+// workspace id and the id of its root pane (the parent for the first split).
+type workspaceResult struct {
+	Result struct {
+		Workspace struct {
+			WorkspaceID string `json:"workspace_id"`
+		} `json:"workspace"`
+		RootPane struct {
+			PaneID string `json:"pane_id"`
+		} `json:"root_pane"`
+	} `json:"result"`
+}
+
+// workspaceCreate runs `herdr workspace create --cwd <dir> --label <label>
+// --no-focus` and returns (workspaceID, rootPaneID).
+func (c herdrClient) workspaceCreate(ctx context.Context, cwd, label string) (workspaceID string, rootPaneID string, err error) {
+	out, err := c.run(ctx, "workspace", "create", "--cwd", cwd, "--label", label, "--no-focus")
+	if err != nil {
+		return "", "", err
+	}
+	var ws workspaceResult
+	if err := json.Unmarshal([]byte(out), &ws); err != nil {
+		return "", "", fmt.Errorf("parse workspace create: %w", err)
+	}
+	id := ws.Result.Workspace.WorkspaceID
+	root := ws.Result.RootPane.PaneID
+	if id == "" || root == "" {
+		return "", "", fmt.Errorf("workspace create returned empty ids")
+	}
+	return id, root, nil
+}
+
+// paneResult mirrors `herdr pane split`: the new pane's id.
+type paneResult struct {
+	Result struct {
+		Pane struct {
+			PaneID string `json:"pane_id"`
+		} `json:"pane"`
+	} `json:"result"`
+}
+
+// paneSplit runs `herdr pane split <parent> --direction down --cwd <worktree>
+// --no-focus` and returns the new child pane id.
+func (c herdrClient) paneSplit(ctx context.Context, parentPane, cwd string) (paneID string, err error) {
+	out, err := c.run(ctx, "pane", "split", parentPane, "--direction", "down", "--cwd", cwd, "--no-focus")
+	if err != nil {
+		return "", err
+	}
+	var p paneResult
+	if err := json.Unmarshal([]byte(out), &p); err != nil {
+		return "", fmt.Errorf("parse pane split: %w", err)
+	}
+	if p.Result.Pane.PaneID == "" {
+		return "", fmt.Errorf("pane split returned empty pane id")
+	}
+	return p.Result.Pane.PaneID, nil
+}
+
+// paneRename runs `herdr pane rename <pane> "<label>"`.
+func (c herdrClient) paneRename(ctx context.Context, pane, label string) error {
+	_, err := c.run(ctx, "pane", "rename", pane, label)
+	return err
+}
+
+// reportAgent runs `herdr pane report-agent <pane> --source <source> --agent
+// <agent> --state <state>`.
+func (c herdrClient) reportAgent(ctx context.Context, pane, source, agent, state string) error {
+	_, err := c.run(ctx, "pane", "report-agent", pane, "--source", source, "--agent", agent, "--state", state)
+	return err
+}
+
+// reportMetadata runs `herdr pane report-metadata <pane> --source <source>
+// --title "<title>" --ttl-ms <n>`.
+func (c herdrClient) reportMetadata(ctx context.Context, pane, source, title string, ttlMS int) error {
+	args := []string{"pane", "report-metadata", pane, "--source", source, "--title", title}
+	if ttlMS > 0 {
+		args = append(args, "--ttl-ms", strconv.Itoa(ttlMS))
+	}
+	_, err := c.run(ctx, args...)
+	return err
+}
+
+// paneRun runs `herdr pane run <pane> "<command>"`. The command is a single
+// shell string (e.g. the gitmoot job-watch invocation) handed to the pane.
+func (c herdrClient) paneRun(ctx context.Context, pane, command string) error {
+	_, err := c.run(ctx, "pane", "run", pane, command)
+	return err
+}
+
+// releaseAgent runs `herdr pane release-agent <pane> --source <source> --agent
+// <agent>`.
+func (c herdrClient) releaseAgent(ctx context.Context, pane, source, agent string) error {
+	_, err := c.run(ctx, "pane", "release-agent", pane, "--source", source, "--agent", agent)
+	return err
+}
+
+// paneClose runs `herdr pane close <pane>`.
+func (c herdrClient) paneClose(ctx context.Context, pane string) error {
+	_, err := c.run(ctx, "pane", "close", pane)
+	return err
+}
+
+// workspaceClose runs `herdr workspace close <workspace>`.
+func (c herdrClient) workspaceClose(ctx context.Context, workspace string) error {
+	_, err := c.run(ctx, "workspace", "close", workspace)
+	return err
+}
+
+// shortJobID trims a job id to the 8-char form used in the gm-<jobid8> agent
+// label (the spike's verified report-agent --agent convention).
+func shortJobID(jobID string) string {
+	jobID = strings.TrimSpace(jobID)
+	if len(jobID) > 8 {
+		return jobID[:8]
+	}
+	return jobID
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -42,5 +42,16 @@ same_session = "fork_temp_session"
 merge_back = "summary"
 max_temp_sessions_per_agent = 4
 eligible_actions = ["ask", "review", "implement"]
+
+[orchestrate]
+# Render one live herdr pane per delegation subagent when a job opts in with
+# --cockpit. cockpit_mode: on | off | auto (auto gates on herdr reachability).
+# cockpit_max_panes caps concurrent panes (constrained hosts ~4); beyond the cap
+# a job runs status-only with no pane. cockpit_pane_key: job (one pane per job)
+# or seat (reuse one pane per seat). cockpit_session is an optional named session.
+cockpit_mode = "auto"
+cockpit_session = ""
+cockpit_max_panes = 4
+cockpit_pane_key = "job"
 `, paths.Database, paths.Logs, paths.Workspaces, paths.Evals, paths.ArtifactBlobs)
 }

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	// CockpitMode values for [orchestrate].cockpit_mode. "auto" lets the daemon
+	// decide per job (gated on herdr reachability), "on" forces panes when herdr
+	// is reachable, and "off" disables cockpit panes entirely regardless of the
+	// per-job --cockpit flag.
+	CockpitModeAuto = "auto"
+	CockpitModeOn   = "on"
+	CockpitModeOff  = "off"
+
+	// CockpitPaneKey values for [orchestrate].cockpit_pane_key. "job" gives each
+	// job its own pane (P0); "seat" reuses one pane per opaque seat key (P2).
+	CockpitPaneKeyJob  = "job"
+	CockpitPaneKeySeat = "seat"
+)
+
+// OrchestratePolicy is the host-level cockpit policy read from the
+// [orchestrate] section of the gitmoot config. The daemon combines it with the
+// per-job JobPayload.Cockpit flag to decide whether to wrap a job's delivery in
+// a herdr pane (see issue #357). It never affects engine/DAG behavior.
+type OrchestratePolicy struct {
+	CockpitMode     string
+	CockpitSession  string
+	CockpitMaxPanes int
+	CockpitPaneKey  string
+}
+
+func DefaultOrchestratePolicy() OrchestratePolicy {
+	return OrchestratePolicy{
+		CockpitMode:     CockpitModeAuto,
+		CockpitSession:  "",
+		CockpitMaxPanes: 4,
+		CockpitPaneKey:  CockpitPaneKeyJob,
+	}
+}
+
+func LoadOrchestratePolicy(paths Paths) (OrchestratePolicy, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return OrchestratePolicy{}, err
+	}
+	policy := DefaultOrchestratePolicy()
+	current := false
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			current = strings.TrimSpace(section) == "orchestrate"
+			continue
+		}
+		if !current {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if err := applyOrchestratePolicyField(&policy, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
+			return OrchestratePolicy{}, fmt.Errorf("parse [orchestrate].%s: %w", strings.TrimSpace(key), err)
+		}
+	}
+	if err := validateOrchestratePolicy(policy); err != nil {
+		return OrchestratePolicy{}, err
+	}
+	return policy, nil
+}
+
+func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value string) error {
+	switch key {
+	case "cockpit_mode":
+		parsed, err := parseConfigString(value)
+		policy.CockpitMode = strings.TrimSpace(parsed)
+		return err
+	case "cockpit_session":
+		parsed, err := parseConfigString(value)
+		policy.CockpitSession = strings.TrimSpace(parsed)
+		return err
+	case "cockpit_max_panes":
+		parsed, err := strconv.Atoi(value)
+		policy.CockpitMaxPanes = parsed
+		return err
+	case "cockpit_pane_key":
+		parsed, err := parseConfigString(value)
+		policy.CockpitPaneKey = strings.TrimSpace(parsed)
+		return err
+	default:
+		return nil
+	}
+}
+
+func validateOrchestratePolicy(policy OrchestratePolicy) error {
+	switch policy.CockpitMode {
+	case CockpitModeAuto, CockpitModeOn, CockpitModeOff:
+	default:
+		return fmt.Errorf("unsupported orchestrate.cockpit_mode %q; use on, off, or auto", policy.CockpitMode)
+	}
+	if policy.CockpitMaxPanes < 1 {
+		return fmt.Errorf("orchestrate.cockpit_max_panes must be positive")
+	}
+	switch policy.CockpitPaneKey {
+	case CockpitPaneKeyJob, CockpitPaneKeySeat:
+	default:
+		return fmt.Errorf("unsupported orchestrate.cockpit_pane_key %q; use job or seat", policy.CockpitPaneKey)
+	}
+	return nil
+}

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoadOrchestratePolicyDefaults(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+
+	policy, err := LoadOrchestratePolicy(paths)
+
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.CockpitMode != CockpitModeAuto {
+		t.Fatalf("CockpitMode = %q, want %q", policy.CockpitMode, CockpitModeAuto)
+	}
+	if policy.CockpitSession != "" {
+		t.Fatalf("CockpitSession = %q, want empty", policy.CockpitSession)
+	}
+	if policy.CockpitMaxPanes != 4 {
+		t.Fatalf("CockpitMaxPanes = %d, want 4", policy.CockpitMaxPanes)
+	}
+	if policy.CockpitPaneKey != CockpitPaneKeyJob {
+		t.Fatalf("CockpitPaneKey = %q, want %q", policy.CockpitPaneKey, CockpitPaneKeyJob)
+	}
+}
+
+func TestLoadOrchestratePolicyOverrides(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+cockpit_mode = "on"
+cockpit_session = "review-room"
+cockpit_max_panes = 8
+cockpit_pane_key = "seat"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	policy, err := LoadOrchestratePolicy(paths)
+
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.CockpitMode != CockpitModeOn || policy.CockpitSession != "review-room" || policy.CockpitMaxPanes != 8 || policy.CockpitPaneKey != CockpitPaneKeySeat {
+		t.Fatalf("policy = %+v", policy)
+	}
+}
+
+func TestLoadOrchestratePolicyRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "cockpit_mode",
+			body: `
+[orchestrate]
+cockpit_mode = "maybe"
+`,
+			wantErr: "unsupported orchestrate.cockpit_mode",
+		},
+		{
+			name: "cockpit_max_panes",
+			body: `
+[orchestrate]
+cockpit_max_panes = 0
+`,
+			wantErr: "cockpit_max_panes must be positive",
+		},
+		{
+			name: "cockpit_pane_key",
+			body: `
+[orchestrate]
+cockpit_pane_key = "row"
+`,
+			wantErr: "unsupported orchestrate.cockpit_pane_key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if err := Initialize(paths); err != nil {
+				t.Fatalf("Initialize returned error: %v", err)
+			}
+			if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+tt.body), 0o600); err != nil {
+				t.Fatalf("write config returned error: %v", err)
+			}
+
+			_, err := LoadOrchestratePolicy(paths)
+
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("LoadOrchestratePolicy error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDefaultConfigIncludesOrchestrateSection(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	content := DefaultConfig(paths)
+	if !strings.Contains(content, "[orchestrate]") {
+		t.Fatalf("DefaultConfig missing [orchestrate] section:\n%s", content)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4705,9 +4705,19 @@ func (s *Store) ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([
 }
 
 // DeleteCockpitPane removes a pane record by ID. Deleting a missing row is a
-// no-op (best-effort teardown should not fail on a stale record).
+// no-op (best-effort teardown should not fail on a stale record). It stays
+// available for reconcile/GC, which addresses panes by their generated id.
 func (s *Store) DeleteCockpitPane(ctx context.Context, id string) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM cockpit_panes WHERE id = ?`, strings.TrimSpace(id))
+	return err
+}
+
+// DeleteCockpitPaneByJob removes the pane record for a job. The cockpit opens a
+// pane without knowing its generated primary key, so teardown deletes by job_id;
+// this also lets a re-run of the same job reclaim its (workspace_id, pane_key)
+// slot. Deleting a missing row is a no-op.
+func (s *Store) DeleteCockpitPaneByJob(ctx context.Context, jobID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM cockpit_panes WHERE job_id = ?`, strings.TrimSpace(jobID))
 	return err
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -118,6 +118,22 @@ type SkillOptJudgeOutcome struct {
 	CreatedAt          string
 }
 
+// CockpitPane records one live Herdr pane opened for a delegation subagent's
+// job (issue #357). Panes are keyed by (workspace_id, pane_key) so the cockpit
+// can find/reuse a pane for a seat without splitting duplicates; root_job_id is
+// derived from the job payload (not a jobs column) so all panes of one
+// orchestration root can be listed and torn down together.
+type CockpitPane struct {
+	ID          string
+	JobID       string
+	PaneKey     string
+	RootJobID   string
+	PaneID      string
+	WorkspaceID string
+	Source      string
+	CreatedAt   string
+}
+
 type AgentRepo struct {
 	AgentName    string
 	RepoFullName string
@@ -4631,6 +4647,145 @@ func newSkillOptJudgeOutcomeID() (string, error) {
 	return "judge-outcome-" + hex.EncodeToString(raw[:]), nil
 }
 
+// InsertCockpitPane records a live Herdr pane for a delegation subagent's job
+// (issue #357). An empty ID is auto-generated. The (workspace_id, pane_key)
+// pair is UNIQUE, so a duplicate open for the same seat surfaces as an error the
+// cockpit can treat as "pane already exists, reuse it".
+func (s *Store) InsertCockpitPane(ctx context.Context, pane CockpitPane) error {
+	id := strings.TrimSpace(pane.ID)
+	if id == "" {
+		generated, err := newCockpitPaneID()
+		if err != nil {
+			return err
+		}
+		id = generated
+	}
+	if strings.TrimSpace(pane.JobID) == "" {
+		return errors.New("cockpit pane job_id is required")
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO cockpit_panes(
+			id, job_id, pane_key, root_job_id, pane_id, workspace_id, source
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id,
+		strings.TrimSpace(pane.JobID),
+		strings.TrimSpace(pane.PaneKey),
+		strings.TrimSpace(pane.RootJobID),
+		strings.TrimSpace(pane.PaneID),
+		strings.TrimSpace(pane.WorkspaceID),
+		strings.TrimSpace(pane.Source))
+	return err
+}
+
+// GetCockpitPaneByJob returns the pane recorded for a job, if any.
+func (s *Store) GetCockpitPaneByJob(ctx context.Context, jobID string) (CockpitPane, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, job_id, pane_key, root_job_id, pane_id, workspace_id, source, created_at
+		FROM cockpit_panes WHERE job_id = ?`, strings.TrimSpace(jobID))
+	return scanCockpitPane(row)
+}
+
+// ListCockpitPanesByRoot returns every pane opened under one orchestration root,
+// oldest first, so the cockpit can tear them all down on root finalize.
+func (s *Store) ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([]CockpitPane, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, job_id, pane_key, root_job_id, pane_id, workspace_id, source, created_at
+		FROM cockpit_panes WHERE root_job_id = ? ORDER BY created_at, id`, strings.TrimSpace(rootJobID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var panes []CockpitPane
+	for rows.Next() {
+		pane, err := scanCockpitPane(rows)
+		if err != nil {
+			return nil, err
+		}
+		panes = append(panes, pane)
+	}
+	return panes, rows.Err()
+}
+
+// DeleteCockpitPane removes a pane record by ID. Deleting a missing row is a
+// no-op (best-effort teardown should not fail on a stale record).
+func (s *Store) DeleteCockpitPane(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM cockpit_panes WHERE id = ?`, strings.TrimSpace(id))
+	return err
+}
+
+// GetOrCreateWorkspaceForRoot returns the single Herdr workspace id bound to an
+// orchestration root, creating it via create exactly once. Concurrent callers
+// for the same root serialize on the cockpit_workspaces primary key: the first
+// inserter wins and create runs once; losers read the winner's id back without
+// calling create. create is invoked outside the row insert (it shells out to
+// herdr), and a racing insert that loses simply re-reads the committed id.
+func (s *Store) GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, err error)) (string, error) {
+	rootJobID = strings.TrimSpace(rootJobID)
+	if rootJobID == "" {
+		return "", errors.New("cockpit workspace root_job_id is required")
+	}
+	if create == nil {
+		return "", errors.New("cockpit workspace create func is required")
+	}
+	// Fast path: an existing registration short-circuits without calling create.
+	if existing, err := s.lookupWorkspaceForRoot(ctx, rootJobID); err != nil {
+		return "", err
+	} else if existing != "" {
+		return existing, nil
+	}
+	workspaceID, err := create()
+	if err != nil {
+		return "", err
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return "", errors.New("cockpit workspace create returned an empty workspace id")
+	}
+	// INSERT OR IGNORE: if a concurrent caller already bound this root, our row
+	// is dropped and we fall through to re-read the winning id (our freshly
+	// created workspace is then orphaned, which the cockpit reaper handles).
+	if _, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO cockpit_workspaces(root_job_id, workspace_id) VALUES (?, ?)`,
+		rootJobID, workspaceID); err != nil {
+		return "", err
+	}
+	stored, err := s.lookupWorkspaceForRoot(ctx, rootJobID)
+	if err != nil {
+		return "", err
+	}
+	if stored == "" {
+		// Should not happen: we just inserted-or-ignored. Treat as our id.
+		return workspaceID, nil
+	}
+	return stored, nil
+}
+
+func (s *Store) lookupWorkspaceForRoot(ctx context.Context, rootJobID string) (string, error) {
+	var workspaceID string
+	err := s.db.QueryRowContext(ctx, `SELECT workspace_id FROM cockpit_workspaces WHERE root_job_id = ?`, rootJobID).Scan(&workspaceID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(workspaceID), nil
+}
+
+func scanCockpitPane(row interface{ Scan(dest ...any) error }) (CockpitPane, error) {
+	var pane CockpitPane
+	if err := row.Scan(&pane.ID, &pane.JobID, &pane.PaneKey, &pane.RootJobID,
+		&pane.PaneID, &pane.WorkspaceID, &pane.Source, &pane.CreatedAt); err != nil {
+		return CockpitPane{}, err
+	}
+	return pane, nil
+}
+
+func newCockpitPaneID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return "cockpit-pane-" + hex.EncodeToString(raw[:]), nil
+}
+
 // captureSkillOptJudgeOutcome records one judge-vs-human outcome row for a
 // candidate decision. It is best-effort: capture must never fail the decision,
 // so callers log and continue on error.
@@ -5414,5 +5569,27 @@ CREATE TABLE skillopt_judge_outcomes (
 
 CREATE INDEX idx_skillopt_judge_outcomes_template ON skillopt_judge_outcomes(template_id);
 CREATE INDEX idx_skillopt_judge_outcomes_candidate ON skillopt_judge_outcomes(candidate_version_id);
+	`,
+	`
+CREATE TABLE cockpit_panes (
+	id TEXT PRIMARY KEY,
+	job_id TEXT NOT NULL DEFAULT '',
+	pane_key TEXT NOT NULL DEFAULT '',
+	root_job_id TEXT NOT NULL DEFAULT '',
+	pane_id TEXT NOT NULL DEFAULT '',
+	workspace_id TEXT NOT NULL DEFAULT '',
+	source TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	UNIQUE(workspace_id, pane_key)
+);
+
+CREATE INDEX idx_cockpit_panes_job ON cockpit_panes(job_id);
+CREATE INDEX idx_cockpit_panes_root ON cockpit_panes(root_job_id);
+
+CREATE TABLE cockpit_workspaces (
+	root_job_id TEXT PRIMARY KEY,
+	workspace_id TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -3106,4 +3108,267 @@ func seedSkillOptJudgeCandidate(t *testing.T, store *Store, evalReportJSON strin
 		t.Fatalf("AddPendingAgentTemplateCandidate returned error: %v", err)
 	}
 	return candidate
+}
+
+func TestCockpitPaneCRUDRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	pane := CockpitPane{
+		ID:          "cockpit-pane-1",
+		JobID:       "job-child-1",
+		PaneKey:     "job:job-child-1",
+		RootJobID:   "job-root",
+		PaneID:      "pane-aaa",
+		WorkspaceID: "ws-1",
+		Source:      "custom:gitmoot",
+	}
+	if err := store.InsertCockpitPane(ctx, pane); err != nil {
+		t.Fatalf("InsertCockpitPane returned error: %v", err)
+	}
+
+	got, err := store.GetCockpitPaneByJob(ctx, "job-child-1")
+	if err != nil {
+		t.Fatalf("GetCockpitPaneByJob returned error: %v", err)
+	}
+	if got.ID != pane.ID ||
+		got.JobID != pane.JobID ||
+		got.PaneKey != pane.PaneKey ||
+		got.RootJobID != pane.RootJobID ||
+		got.PaneID != pane.PaneID ||
+		got.WorkspaceID != pane.WorkspaceID ||
+		got.Source != pane.Source {
+		t.Fatalf("GetCockpitPaneByJob = %+v, want %+v", got, pane)
+	}
+	if strings.TrimSpace(got.CreatedAt) == "" {
+		t.Fatalf("expected created_at to be populated, got %+v", got)
+	}
+
+	// A second pane under the same root, with an auto-generated id and a
+	// distinct pane_key (so the UNIQUE(workspace_id, pane_key) holds).
+	second := CockpitPane{
+		JobID:       "job-child-2",
+		PaneKey:     "job:job-child-2",
+		RootJobID:   "job-root",
+		PaneID:      "pane-bbb",
+		WorkspaceID: "ws-1",
+		Source:      "custom:gitmoot",
+	}
+	if err := store.InsertCockpitPane(ctx, second); err != nil {
+		t.Fatalf("InsertCockpitPane (auto id) returned error: %v", err)
+	}
+
+	// A pane under a different root must not leak into the root listing.
+	other := CockpitPane{
+		JobID:       "job-other",
+		PaneKey:     "job:job-other",
+		RootJobID:   "job-root-2",
+		PaneID:      "pane-ccc",
+		WorkspaceID: "ws-2",
+		Source:      "custom:gitmoot",
+	}
+	if err := store.InsertCockpitPane(ctx, other); err != nil {
+		t.Fatalf("InsertCockpitPane (other root) returned error: %v", err)
+	}
+
+	rootPanes, err := store.ListCockpitPanesByRoot(ctx, "job-root")
+	if err != nil {
+		t.Fatalf("ListCockpitPanesByRoot returned error: %v", err)
+	}
+	if len(rootPanes) != 2 {
+		t.Fatalf("ListCockpitPanesByRoot(job-root) = %d rows, want 2", len(rootPanes))
+	}
+	if rootPanes[0].JobID != "job-child-1" || rootPanes[1].JobID != "job-child-2" {
+		t.Fatalf("ListCockpitPanesByRoot ordering = %s, %s; want job-child-1, job-child-2",
+			rootPanes[0].JobID, rootPanes[1].JobID)
+	}
+
+	// Delete the first pane; the listing shrinks and the by-job lookup misses.
+	if err := store.DeleteCockpitPane(ctx, "cockpit-pane-1"); err != nil {
+		t.Fatalf("DeleteCockpitPane returned error: %v", err)
+	}
+	if _, err := store.GetCockpitPaneByJob(ctx, "job-child-1"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetCockpitPaneByJob after delete = %v, want sql.ErrNoRows", err)
+	}
+	rootPanes, err = store.ListCockpitPanesByRoot(ctx, "job-root")
+	if err != nil {
+		t.Fatalf("ListCockpitPanesByRoot after delete returned error: %v", err)
+	}
+	if len(rootPanes) != 1 || rootPanes[0].JobID != "job-child-2" {
+		t.Fatalf("ListCockpitPanesByRoot after delete = %+v, want only job-child-2", rootPanes)
+	}
+
+	// Deleting a missing row is a no-op, not an error.
+	if err := store.DeleteCockpitPane(ctx, "cockpit-pane-missing"); err != nil {
+		t.Fatalf("DeleteCockpitPane(missing) returned error: %v", err)
+	}
+
+	// job_id is required.
+	if err := store.InsertCockpitPane(ctx, CockpitPane{PaneKey: "k", WorkspaceID: "ws-x"}); err == nil {
+		t.Fatal("InsertCockpitPane with empty job_id returned nil error")
+	}
+}
+
+func TestCockpitPaneUniquePerWorkspaceSeat(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	first := CockpitPane{
+		JobID:       "job-a",
+		PaneKey:     "seat:planner",
+		RootJobID:   "root",
+		PaneID:      "pane-1",
+		WorkspaceID: "ws-1",
+	}
+	if err := store.InsertCockpitPane(ctx, first); err != nil {
+		t.Fatalf("InsertCockpitPane(first) returned error: %v", err)
+	}
+
+	// Same (workspace_id, pane_key) for a different job must be rejected.
+	dup := CockpitPane{
+		JobID:       "job-b",
+		PaneKey:     "seat:planner",
+		RootJobID:   "root",
+		PaneID:      "pane-2",
+		WorkspaceID: "ws-1",
+	}
+	if err := store.InsertCockpitPane(ctx, dup); err == nil {
+		t.Fatal("InsertCockpitPane with duplicate (workspace_id, pane_key) returned nil error")
+	}
+
+	// The same pane_key in a different workspace is allowed.
+	otherWS := CockpitPane{
+		JobID:       "job-c",
+		PaneKey:     "seat:planner",
+		RootJobID:   "root",
+		PaneID:      "pane-3",
+		WorkspaceID: "ws-2",
+	}
+	if err := store.InsertCockpitPane(ctx, otherWS); err != nil {
+		t.Fatalf("InsertCockpitPane(other workspace) returned error: %v", err)
+	}
+}
+
+func TestGetOrCreateWorkspaceForRoot(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	var calls atomic.Int64
+	create := func() (string, error) {
+		calls.Add(1)
+		return "ws-created", nil
+	}
+
+	// First call creates and binds the workspace.
+	ws, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-1", create)
+	if err != nil {
+		t.Fatalf("GetOrCreateWorkspaceForRoot returned error: %v", err)
+	}
+	if ws != "ws-created" {
+		t.Fatalf("workspace id = %q, want ws-created", ws)
+	}
+
+	// Repeated calls for the same root return the bound id without calling create.
+	for i := 0; i < 3; i++ {
+		ws, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-1", create)
+		if err != nil {
+			t.Fatalf("GetOrCreateWorkspaceForRoot (repeat) returned error: %v", err)
+		}
+		if ws != "ws-created" {
+			t.Fatalf("workspace id (repeat) = %q, want ws-created", ws)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("create called %d times, want exactly 1", got)
+	}
+
+	// A different root creates its own workspace.
+	ws2, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-2", func() (string, error) {
+		return "ws-other", nil
+	})
+	if err != nil {
+		t.Fatalf("GetOrCreateWorkspaceForRoot(root-2) returned error: %v", err)
+	}
+	if ws2 != "ws-other" {
+		t.Fatalf("workspace id (root-2) = %q, want ws-other", ws2)
+	}
+
+	// Validation: empty root and nil create are rejected.
+	if _, err := store.GetOrCreateWorkspaceForRoot(ctx, "  ", create); err == nil {
+		t.Fatal("GetOrCreateWorkspaceForRoot with empty root returned nil error")
+	}
+	if _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-3", nil); err == nil {
+		t.Fatal("GetOrCreateWorkspaceForRoot with nil create returned nil error")
+	}
+}
+
+func TestGetOrCreateWorkspaceForRootConcurrent(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	const goroutines = 16
+	var calls atomic.Int64
+	create := func() (string, error) {
+		// Each create returns a distinct id so we can verify exactly one wins.
+		n := calls.Add(1)
+		return "ws-" + string(rune('a'+int(n-1))), nil
+	}
+
+	var wg sync.WaitGroup
+	results := make([]string, goroutines)
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			ws, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-race", create)
+			if err != nil {
+				t.Errorf("GetOrCreateWorkspaceForRoot(concurrent) returned error: %v", err)
+				return
+			}
+			results[idx] = ws
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	// All callers must observe the same single bound workspace id.
+	winner := results[0]
+	if winner == "" {
+		t.Fatal("first concurrent caller got an empty workspace id")
+	}
+	for i, got := range results {
+		if got != winner {
+			t.Fatalf("concurrent caller %d got %q, want the single winner %q", i, got, winner)
+		}
+	}
+	// create may run more than once under contention (it shells out before the
+	// insert), but the bound id is stable and matches what every caller sees.
+	final, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-race", func() (string, error) {
+		t.Fatal("create must not run once the root is bound")
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("GetOrCreateWorkspaceForRoot(after race) returned error: %v", err)
+	}
+	if final != winner {
+		t.Fatalf("post-race bound id = %q, want %q", final, winner)
+	}
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3257,6 +3257,47 @@ func TestCockpitPaneUniquePerWorkspaceSeat(t *testing.T) {
 	}
 }
 
+func TestDeleteCockpitPaneByJob(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	pane := CockpitPane{
+		JobID:       "job-x",
+		PaneKey:     "job:job-x",
+		RootJobID:   "root",
+		PaneID:      "pane-1",
+		WorkspaceID: "ws-1",
+		Source:      "custom:gitmoot",
+	}
+	if err := store.InsertCockpitPane(ctx, pane); err != nil {
+		t.Fatalf("InsertCockpitPane returned error: %v", err)
+	}
+
+	// Delete by job id (the cockpit teardown path) removes the row without
+	// knowing its generated primary key.
+	if err := store.DeleteCockpitPaneByJob(ctx, "job-x"); err != nil {
+		t.Fatalf("DeleteCockpitPaneByJob returned error: %v", err)
+	}
+	if _, err := store.GetCockpitPaneByJob(ctx, "job-x"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetCockpitPaneByJob after delete-by-job = %v, want sql.ErrNoRows", err)
+	}
+
+	// The slot is reclaimable: re-inserting the same (workspace_id, pane_key)
+	// after a delete-by-job must not hit the UNIQUE constraint.
+	if err := store.InsertCockpitPane(ctx, pane); err != nil {
+		t.Fatalf("re-insert after DeleteCockpitPaneByJob returned error: %v", err)
+	}
+
+	// Deleting a missing job is a no-op, not an error.
+	if err := store.DeleteCockpitPaneByJob(ctx, "job-missing"); err != nil {
+		t.Fatalf("DeleteCockpitPaneByJob(missing) returned error: %v", err)
+	}
+}
+
 func TestGetOrCreateWorkspaceForRoot(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -588,6 +588,11 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 		FailurePolicy:   strings.TrimSpace(d.FailurePolicy),
 		SynthesisRule:   strings.TrimSpace(d.SynthesisRule),
 		Model:           strings.TrimSpace(d.Model),
+		// Cockpit settings are inherited from the coordinator so every delegation
+		// subagent in one tree renders a pane under the same workspace/session.
+		Cockpit:        payload.Cockpit,
+		CockpitSession: payload.CockpitSession,
+		CockpitPaneKey: payload.CockpitPaneKey,
 	}
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -932,6 +932,11 @@ func (e Engine) handleDelegationLoop(ctx context.Context, job db.Job, payload Jo
 		// detector escalates to delegation_loop_detected.
 		RecentDelegationHashes: appendDelegationHashWindow(payload.RecentDelegationHashes, currentHash),
 		DelegationRepeatCount:  payload.DelegationRepeatCount + 1,
+		// Inherit the coordinator's cockpit settings so the continuation renders
+		// its pane under the same workspace/session as the rest of the tree.
+		Cockpit:        payload.Cockpit,
+		CockpitSession: payload.CockpitSession,
+		CockpitPaneKey: payload.CockpitPaneKey,
 	}
 	if err := e.enqueue(ctx, request); err != nil {
 		return true, fmt.Errorf("enqueue corrective continuation for %q: %w", job.ID, err)
@@ -980,6 +985,11 @@ func (e Engine) enqueueFinalizeContinuation(ctx context.Context, job db.Job, pay
 		DelegatedBy:        job.Agent,
 		RootJobID:          e.rootJobID(job, payload),
 		DelegationFinalize: true,
+		// Inherit the coordinator's cockpit settings so the finalize continuation
+		// renders its pane under the same workspace/session as the rest of the tree.
+		Cockpit:        payload.Cockpit,
+		CockpitSession: payload.CockpitSession,
+		CockpitPaneKey: payload.CockpitPaneKey,
 	}
 	if err := e.enqueue(ctx, request); err != nil {
 		return fmt.Errorf("enqueue finalize continuation for %q: %w", job.ID, err)
@@ -1499,6 +1509,11 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		// corrective-nudge counter only climbs while the coordinator loops.
 		RecentDelegationHashes: appendDelegationHashWindow(parentPayload.RecentDelegationHashes, canonicalDelegationSetHash(parentResult.Delegations)),
 		DelegationRepeatCount:  0,
+		// Inherit the coordinator's cockpit settings so the continuation renders
+		// its pane under the same workspace/session as the rest of the tree.
+		Cockpit:        parentPayload.Cockpit,
+		CockpitSession: parentPayload.CockpitSession,
+		CockpitPaneKey: parentPayload.CockpitPaneKey,
 	}
 	if err := e.enqueue(ctx, request); err != nil {
 		return fmt.Errorf("enqueue continuation for %q: %w", parentJob.ID, err)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2317,6 +2317,34 @@ func TestEngineDelegationRequestCopiesModel(t *testing.T) {
 	}
 }
 
+func TestEngineDelegationRequestInheritsCockpit(t *testing.T) {
+	engine := Engine{}
+	request := engine.delegationRequest(
+		db.Job{ID: "parent-job", Agent: "audit"},
+		JobPayload{Repo: "jerryfane/gitmoot", Cockpit: true, CockpitSession: "room", CockpitPaneKey: "seat"},
+		Delegation{ID: "del-1", Agent: "helper", Action: "review", Prompt: "go"},
+	)
+	if !request.Cockpit {
+		t.Fatalf("request.Cockpit = false, want true (inherited from coordinator)")
+	}
+	if request.CockpitSession != "room" {
+		t.Fatalf("request.CockpitSession = %q, want %q", request.CockpitSession, "room")
+	}
+	if request.CockpitPaneKey != "seat" {
+		t.Fatalf("request.CockpitPaneKey = %q, want %q", request.CockpitPaneKey, "seat")
+	}
+
+	// A coordinator that did not opt in produces children with cockpit off.
+	off := engine.delegationRequest(
+		db.Job{ID: "parent-job", Agent: "audit"},
+		JobPayload{Repo: "jerryfane/gitmoot"},
+		Delegation{ID: "del-2", Agent: "helper", Action: "review", Prompt: "go"},
+	)
+	if off.Cockpit {
+		t.Fatalf("request.Cockpit = true, want false when coordinator did not opt in")
+	}
+}
+
 func TestEngineDelegationRequestThreadsEphemeralSpec(t *testing.T) {
 	engine := Engine{}
 	spec := &EphemeralSpec{Runtime: runtime.CodexRuntime, Model: "gpt-5.4"}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2046,6 +2046,48 @@ func TestEngineContinuationCarriesParentModel(t *testing.T) {
 	}
 }
 
+// TestEngineContinuationInheritsCockpit guards that a coordinator's cockpit
+// settings carry into the post-synthesis continuation so the continuation
+// renders its pane under the same workspace/session as the rest of the tree.
+func TestEngineContinuationInheritsCockpit(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:           "jerryfane/gitmoot",
+		Branch:         "task-005",
+		Sender:         "coord",
+		Cockpit:        true,
+		CockpitSession: "room",
+		CockpitPaneKey: "seat",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
+			},
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent): %v", err)
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobSucceeded, AgentResult{Decision: "approved", Summary: "api ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api): %v", err)
+	}
+	continuation := mustJob(t, store, delegationContinuationID("parent-job"))
+	cp, err := unmarshalPayload(continuation.Payload)
+	if err != nil {
+		t.Fatalf("unmarshal continuation payload: %v", err)
+	}
+	if !cp.Cockpit || cp.CockpitSession != "room" || cp.CockpitPaneKey != "seat" {
+		t.Fatalf("continuation cockpit fields = (%t, %q, %q), want (true, room, seat)", cp.Cockpit, cp.CockpitSession, cp.CockpitPaneKey)
+	}
+}
+
 func TestEngineDelegationFailurePolicyBlockParent(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -55,6 +55,9 @@ type JobRequest struct {
 	DelegationRepeatCount  int
 	DelegationFinalize     bool
 	Model                  string
+	Cockpit                bool
+	CockpitSession         string
+	CockpitPaneKey         string
 	Ephemeral              *EphemeralSpec
 }
 
@@ -95,6 +98,9 @@ type JobPayload struct {
 	DelegationRepeatCount  int            `json:"delegation_repeat_count,omitempty"`
 	DelegationFinalize     bool           `json:"delegation_finalize,omitempty"`
 	Model                  string         `json:"model,omitempty"`
+	Cockpit                bool           `json:"cockpit,omitempty"`
+	CockpitSession         string         `json:"cockpit_session,omitempty"`
+	CockpitPaneKey         string         `json:"cockpit_pane_key,omitempty"`
 	Ephemeral              *EphemeralSpec `json:"ephemeral,omitempty"`
 	RawOutputs             []string       `json:"raw_outputs,omitempty"`
 	Result                 *AgentResult   `json:"result,omitempty"`
@@ -154,6 +160,9 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		DelegationRepeatCount:  request.DelegationRepeatCount,
 		DelegationFinalize:     request.DelegationFinalize,
 		Model:                  request.Model,
+		Cockpit:                request.Cockpit,
+		CockpitSession:         strings.TrimSpace(request.CockpitSession),
+		CockpitPaneKey:         strings.TrimSpace(request.CockpitPaneKey),
 		Ephemeral:              request.Ephemeral,
 	})
 	if err != nil {

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -650,6 +650,66 @@ func (f *fakeDelivery) Deliver(_ context.Context, _ runtime.Agent, job runtime.J
 	return result, nil
 }
 
+func TestMailboxEnqueuePersistsCockpitFields(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:             "job-cockpit",
+		Agent:          "audit",
+		Action:         "ask",
+		Repo:           "jerryfane/gitmoot",
+		Branch:         "task-005",
+		Sender:         "local",
+		Cockpit:        true,
+		CockpitSession: "  review-room  ",
+		CockpitPaneKey: "  seat-1  ",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	stored, err := store.GetJob(ctx, "job-cockpit")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := unmarshalPayload(stored.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if !payload.Cockpit {
+		t.Fatalf("payload.Cockpit = false, want true")
+	}
+	// CockpitSession/CockpitPaneKey are trimmed on enqueue.
+	if payload.CockpitSession != "review-room" {
+		t.Fatalf("payload.CockpitSession = %q, want %q", payload.CockpitSession, "review-room")
+	}
+	if payload.CockpitPaneKey != "seat-1" {
+		t.Fatalf("payload.CockpitPaneKey = %q, want %q", payload.CockpitPaneKey, "seat-1")
+	}
+}
+
+func TestJobPayloadCockpitRoundTrip(t *testing.T) {
+	encoded, err := marshalPayload(JobPayload{Cockpit: true, CockpitSession: "room", CockpitPaneKey: "job"})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	got, err := unmarshalPayload(encoded)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if !got.Cockpit || got.CockpitSession != "room" || got.CockpitPaneKey != "job" {
+		t.Fatalf("round-trip wrong: %+v", got)
+	}
+	// Cockpit defaults are omitempty: a zero payload encodes without the keys.
+	zero, err := marshalPayload(JobPayload{})
+	if err != nil {
+		t.Fatalf("marshalPayload zero: %v", err)
+	}
+	if strings.Contains(zero, "cockpit") {
+		t.Fatalf("zero payload should omit cockpit keys: %s", zero)
+	}
+}
+
 func TestParseJobPayloadExported(t *testing.T) {
 	encoded, err := marshalPayload(JobPayload{Repo: "o/r", PullRequest: 7, Instructions: "do it", Result: &AgentResult{Decision: "approved", Summary: "done"}})
 	if err != nil {

--- a/scripts/cockpit-smoke.sh
+++ b/scripts/cockpit-smoke.sh
@@ -19,6 +19,11 @@ command -v herdr >/dev/null 2>&1 || skip "herdr is not on PATH"
 # honor HERDR_SOCKET_PATH if the caller set one). No --session is needed.
 herdr status >/dev/null 2>&1 || skip "herdr status is not ok (server not running / not reachable)"
 
+# Gate the pane surface here too (matching herdr-train-init-smoke.sh) so we skip
+# BEFORE doing any home/repo init when panes are unavailable. These are the exact
+# reachability + pane primitives the cockpit adapter uses.
+herdr pane list >/dev/null 2>&1 || skip "herdr pane list failed — cockpit pane surface not available"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK="$(mktemp -d)"
 
@@ -54,10 +59,6 @@ gm init >/dev/null
   && git config user.name "cockpit smoke" \
   && git commit -q --allow-empty -m "init" )
 
-echo "cockpit-smoke: confirming the herdr reachability + pane surface"
-# These are the exact reachability + pane primitives the cockpit adapter uses;
-# `herdr status` already passed above, list confirms the pane surface is live.
-herdr pane list >/dev/null 2>&1 || skip "herdr pane list failed — cockpit pane surface not available"
 echo "cockpit-smoke: herdr is reachable; exercising the --cockpit wrap path"
 
 # Drive a tiny background orchestrate with --cockpit. We do not require a real

--- a/scripts/cockpit-smoke.sh
+++ b/scripts/cockpit-smoke.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Optional smoke for the Herdr cockpit (`gitmoot orchestrate --cockpit`).
+#
+# It verifies that the cockpit is opt-in and fail-open: with `--cockpit` set but
+# Herdr unreachable, orchestration must still enqueue normally (no pane, just one
+# `cockpit_unavailable` job event), and when Herdr IS reachable it exercises the
+# wrap path against the live single-server socket. It SKIPS cleanly (exit 0) when
+# Herdr or gitmoot is unavailable so it never fails a normal checkout.
+set -euo pipefail
+
+skip() {
+  echo "cockpit-smoke: SKIP — $1"
+  exit 0
+}
+
+command -v herdr >/dev/null 2>&1 || skip "herdr is not on PATH"
+
+# Reachability is gated on `herdr status` (single server, default socket;
+# honor HERDR_SOCKET_PATH if the caller set one). No --session is needed.
+herdr status >/dev/null 2>&1 || skip "herdr status is not ok (server not running / not reachable)"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+
+# Use an explicit GITMOOT_BIN if provided, otherwise build a current binary from
+# this checkout so the smoke always matches the code under review.
+if [ -n "${GITMOOT_BIN:-}" ]; then
+  command -v "$GITMOOT_BIN" >/dev/null 2>&1 || skip "GITMOOT_BIN=$GITMOOT_BIN is not executable"
+else
+  command -v go >/dev/null 2>&1 || skip "go is not on PATH to build gitmoot (or set GITMOOT_BIN)"
+  GITMOOT_BIN="$WORK/gitmoot"
+  echo "cockpit-smoke: building gitmoot from $ROOT_DIR"
+  ( cd "$ROOT_DIR" && GOTOOLCHAIN="${GOTOOLCHAIN:-go1.26.0}" go build -o "$GITMOOT_BIN" ./cmd/gitmoot ) \
+    || skip "could not build gitmoot from this checkout"
+fi
+
+HOME_DIR="$WORK/home"
+REPO_DIR="$WORK/repo"
+mkdir -p "$HOME_DIR" "$REPO_DIR"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# Everything runs against an isolated --home so the smoke never touches the
+# user's real gitmoot state or daemon.
+gm() { "$GITMOOT_BIN" "$@" --home "$HOME_DIR"; }
+
+echo "cockpit-smoke: initializing an isolated gitmoot home"
+gm init >/dev/null
+
+# A throwaway git repo so orchestrate has a checkout to point at.
+( cd "$REPO_DIR" \
+  && git init -q \
+  && git config user.email smoke@example.com \
+  && git config user.name "cockpit smoke" \
+  && git commit -q --allow-empty -m "init" )
+
+echo "cockpit-smoke: confirming the herdr reachability + pane surface"
+# These are the exact reachability + pane primitives the cockpit adapter uses;
+# `herdr status` already passed above, list confirms the pane surface is live.
+herdr pane list >/dev/null 2>&1 || skip "herdr pane list failed — cockpit pane surface not available"
+echo "cockpit-smoke: herdr is reachable; exercising the --cockpit wrap path"
+
+# Drive a tiny background orchestrate with --cockpit. We do not require a real
+# coordinator template or runtime auth here by default; we only assert that
+# --cockpit is accepted and that orchestration proceeds (a pane is best-effort
+# and never blocks or fails the job). Set GITMOOT_COCKPIT_SMOKE_AGENT to a real,
+# runnable coordinator for a live end-to-end pane demo.
+AGENT="${GITMOOT_COCKPIT_SMOKE_AGENT:-}"
+if [ -z "$AGENT" ]; then
+  gm orchestrate --help 2>&1 | grep -q -- "--cockpit" \
+    || { echo "cockpit-smoke: FAIL — orchestrate is missing the --cockpit flag"; exit 1; }
+  echo "cockpit-smoke: OK — orchestrate exposes --cockpit and herdr is reachable"
+  echo "cockpit-smoke: set GITMOOT_COCKPIT_SMOKE_AGENT=<coordinator> for a live pane run"
+  exit 0
+fi
+
+echo "cockpit-smoke: launching '$AGENT' under --cockpit (isolated home: $HOME_DIR)"
+gm orchestrate "$AGENT" "Cockpit smoke: confirm the pane wrap path." \
+  --repo "file://$REPO_DIR" --cockpit >/dev/null \
+  || { echo "cockpit-smoke: FAIL — orchestrate --cockpit returned non-zero"; exit 1; }
+
+echo "cockpit-smoke: orchestrate --cockpit launched; inspect panes with 'herdr pane list'"
+echo "cockpit-smoke: OK"

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -524,3 +524,62 @@ the merged changes). Inspect the run under `gitmoot job list --repo owner/repo`
 and the `delegation_enqueued` events in `gitmoot events --repo owner/repo`. See
 `RESULT_CONTRACT.md` for the `ephemeral` field reference and the termination
 bounds these recipes run inside.
+
+## Cockpit: Live Panes For An Orchestra
+
+Add `--cockpit` (alias `--herdr`) to `gitmoot orchestrate` to render one live
+[Herdr](https://github.com/jerryfane/herdr) pane per delegation subagent so a
+fan-out is watchable as it runs — in the terminal, and (through herdres) mirrored
+to Telegram. The cockpit is **opt-in and fail-open**: with `--cockpit` off, or
+when Herdr is absent or `herdr status` is not ok, orchestration is byte-identical
+to today. Gitmoot imports no Herdr code; it drives Herdr over its CLI only, and a
+herdr call never fails or stalls a job.
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo --cockpit
+gitmoot orchestrate decompose-and-verify "Implement the export feature." \
+  --repo owner/repo --cockpit --cockpit-session feature-export
+```
+
+Each child job opens a pane labeled `<agent> · d<depth> · <branch>` and streams
+its progress; children inherit the cockpit setting from their parent, so one
+`--cockpit` on the root lights up the whole orchestra. The same panes are visible
+in the terminal (open the Herdr workspace) and on Telegram via the herdres bridge.
+
+A cockpit pane is a **view, not the job**: closing a pane (in the terminal or
+from Telegram) tears down the visible surface but does NOT cancel the underlying
+job — the child keeps running and its result is still synthesized. To stop work,
+cancel through the record path, not by closing the pane:
+
+```sh
+gitmoot job list --repo owner/repo     # find the child job id
+gitmoot job cancel <job-id>            # cancel via the record; pane teardown follows
+```
+
+Defaults live in `~/.gitmoot/config.toml` under `[orchestrate]` and are
+overridable per run by the flags above:
+
+```toml
+[orchestrate]
+cockpit_mode = "auto"      # on | off | auto (auto = on iff herdr is reachable)
+cockpit_session = ""       # default Herdr session/workspace label ("" = per-run)
+cockpit_max_panes = 4      # cap on simultaneous panes per run
+cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
+```
+
+On a constrained host the pane count is what bites, not the jobs. Lower
+`cockpit_max_panes` (the default is `4`; use `2` or `1` on a small box) — beyond
+the cap, extra subagents run **status-only**: they still report state to Herdr
+but do not split a new pane, so the work fans out exactly as without the cockpit
+while the visible surface stays small. Prefer `cockpit_pane_key = "seat"` for
+long multi-phase runs so panes are reused per role instead of accumulating one
+per job. The cockpit never changes the engine — the DAG, the result contract,
+the runtime-session locks, and the checkout keys are unchanged whether it is on,
+off, or unavailable — so capping panes only changes what you see, never how the
+orchestra runs. If `--cockpit` is asked for but Herdr is unreachable, gitmoot
+emits one `cockpit_unavailable` job event on the root and runs unwrapped.
+
+The optional `scripts/cockpit-smoke.sh` confirms the cockpit is opt-in and
+fail-open: it runs against an isolated `--home`, exercises the `--cockpit` wrap
+path when `herdr` is reachable, and skips cleanly when `herdr` or `gitmoot` is
+unavailable. See `../../../docs/cockpit-orchestrate.md` for the full reference.

--- a/website/docs/workflows/cockpit-orchestrate-workflow.md
+++ b/website/docs/workflows/cockpit-orchestrate-workflow.md
@@ -1,0 +1,110 @@
+# Cockpit Orchestrate Workflow
+
+`gitmoot orchestrate --cockpit` renders one live
+[Herdr](https://github.com/jerryfane/herdr) pane per delegation subagent so you
+can watch an [orchestra](../reference/result-contract.md#delegations-orchestration)
+fan out as it runs — in the terminal, and (through herdres) mirrored to Telegram.
+It is **opt-in and fail-open**: with `--cockpit` off, or when Herdr is absent or
+unreachable, orchestration is byte-identical to today. Gitmoot imports no Herdr
+code; the cockpit drives Herdr over its CLI only.
+
+## Turning it on
+
+`--cockpit` (alias `--herdr`) is a flag on `gitmoot orchestrate`:
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo --cockpit
+```
+
+When the flag is set, every child job in the delegation tree opens its own pane:
+the coordinator splits a workspace for the run, each subagent gets a pane labeled
+`<agent> · d<depth> · <branch>`, and that pane streams the child's progress while
+the job runs. Children inherit the cockpit setting from their parent, so a single
+`--cockpit` on the root lights up the whole orchestra.
+
+Pick where the run lands with `--cockpit-session`:
+
+```sh
+gitmoot orchestrate decompose-and-verify "Implement the export feature." \
+  --repo owner/repo --cockpit --cockpit-session feature-export
+```
+
+### Terminal and Telegram
+
+The same panes are visible two ways:
+
+- **Terminal** — open the Herdr workspace to watch the panes split and update
+  live as each subagent works.
+- **Telegram** — with the herdres bridge connecting Herdr to Telegram, each pane
+  surfaces as a forum topic / agent status you can read (and, in later phases,
+  steer) from your phone.
+
+## Close pane ≠ cancel job
+
+A cockpit pane is a **view**, not the job. Closing a pane (in the terminal or from
+Telegram) tears down the visible surface but does **not** cancel the underlying
+job — the child keeps running in the daemon and its result is still captured and
+synthesized. To stop work, cancel the job through the record path:
+
+```sh
+gitmoot job list --repo owner/repo     # find the child job id
+gitmoot job cancel <job-id>            # cancel via the record; pane teardown follows
+```
+
+This separation is deliberate: a Herdr call must never fail or stall a job, so
+panes are best-effort and disposable while the job lifecycle stays owned by the
+[engine](../concepts/agents-templates-jobs-locks.md).
+
+## Configuration: the `[orchestrate]` section
+
+Defaults live in `~/.gitmoot/config.toml` under `[orchestrate]` and can be
+overridden per run by the flags above:
+
+```toml
+[orchestrate]
+cockpit_mode = "auto"      # on | off | auto (auto = on iff herdr is reachable)
+cockpit_session = ""       # default Herdr session/workspace label ("" = per-run)
+cockpit_max_panes = 4      # cap on simultaneous panes per run
+cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
+```
+
+- `cockpit_mode = "off"` disables the cockpit even if `--cockpit` was passed;
+  `"on"` forces it (and emits a `cockpit_unavailable` job event if Herdr is
+  unreachable); `"auto"` (the default) turns it on only when `herdr status` is ok.
+- `cockpit_pane_key = "job"` opens one pane per child job. `seat` mode reuses a
+  single pane per logical role across phases so a long run does not accumulate
+  panes.
+
+## Constrained hosts
+
+On a small box (few cores, limited terminal real estate, a shared daemon) the
+pane count is what bites, not the jobs. Keep it bounded:
+
+- **Lower `cockpit_max_panes`.** The default is `4`; set it to `2` (or `1`) on a
+  constrained host. Beyond the cap, extra subagents run **status-only** — they
+  still report state to Herdr but do not split a new pane, so the work fans out
+  exactly as without the cockpit while the visible surface stays small.
+- **Prefer `cockpit_pane_key = "seat"`** for long multi-phase runs so panes are
+  reused per role instead of accumulating one per job.
+- **The cockpit never changes the engine.** The delegation DAG, the
+  [result contract](../reference/result-contract.md), the runtime-session locks,
+  and the checkout keys are all unchanged whether the cockpit is on, off, or
+  unavailable — so capping panes only changes what you *see*, never how the
+  orchestra runs.
+
+If Herdr is not installed or `herdr status` is not ok, `--cockpit` is a no-op
+beyond a single `cockpit_unavailable` event on the root job; the run proceeds
+unwrapped.
+
+## Smoke test
+
+The optional `scripts/cockpit-smoke.sh` script in the repository confirms the
+cockpit is opt-in and fail-open. It runs against an isolated `--home`, exercises
+the `--cockpit` wrap path when `herdr` is reachable, and **skips cleanly** when
+`herdr` or `gitmoot` is unavailable, so it never fails a normal checkout that has
+no Herdr installed.
+
+See the [Coordinator Recipes Workflow](./coordinator-recipes-workflow.md) for the
+recipes you will most often watch in the cockpit, and the
+[Result Contract](../reference/result-contract.md) for the delegation fields and
+termination bounds an orchestra runs inside.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -28,6 +28,7 @@ const sidebars: SidebarsConfig = {
         'workflows/template-capture-workflow',
         'workflows/review-agent-workflow',
         'workflows/coordinator-recipes-workflow',
+        'workflows/cockpit-orchestrate-workflow',
         'workflows/skillopt-train-workflow',
       ],
     },


### PR DESCRIPTION
**Phase 0 of #357** — the first shippable slice of Herdr-aware orchestration: an opt-in `--cockpit` that renders one labeled, status-colored Herdr pane per delegation subagent (watchable in the terminal and, via herdres, on Telegram). No Go import of herdr (CLI over socket only); **byte-identical when off or herdr absent**.

## What's included
- **`internal/cockpit`** — herdr CLI client (injectable runner for tests) + a wrapping `DeliveryAdapter` (status-only: per-root workspace → pane split → `report-agent` status → pane runs `gitmoot job watch` → teardown on `Deliver` return). All herdr calls best-effort + timeout-bounded; `Available()` memoized.
- **`internal/db`** — `cockpit_panes` + `cockpit_workspaces` (one workspace per root) + CRUD + `DeleteCockpitPaneByJob`.
- **`--cockpit`/`--herdr`/`--cockpit-session`** flag + `JobPayload` fields + delegation **and continuation** inheritance + `[orchestrate]` config policy (`cockpit_mode` auto/on/off, `cockpit_max_panes` 4, `cockpit_pane_key` job/seat).
- **daemon wiring** — wraps the delivery adapter after the runtime-session lock + checkout resolution, gated on `payload.Cockpit` + policy + `herdr status`; emits one `cockpit_unavailable` event on the fallback path (incl. policy-load error).
- docs (both trees) + `scripts/cockpit-smoke.sh` (skip-if-absent).

## Verification
- Reachability spike (daemon-context → herdr via default socket) confirmed; exact command cycle locked.
- Full gate green: `go build/vet/test ./...` + `go test -race ./internal/workflow/`.
- `/code-review high` run → fixed: root-coordinator workspace collision (empty `RootJobID`), pane rows never deleted (delete-by-job + UNIQUE-slot reclaim), continuations not inheriting cockpit fields, per-Deliver `Available()` shell-out (now cached), policy-load error now emits the event, `--cockpit-session` implies `--cockpit`.
- E2E: binary exposes `--cockpit`; `cockpit-smoke.sh` passes with herdr reachable.

Part of #357 (Phases 1–3 — live stdout streaming, seat mode + steer/reconvene, auto-detect + attach-and-type — follow as their own PRs).