### PR TITLE
feat(orchestrate): Herdr cockpit — Phase 1 live pane output (#357)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -26,6 +26,7 @@ import (
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -1708,6 +1709,23 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			cp = w.newCockpit(policy)
 		}
 		meta := cockpitJobMeta(job, payload, agent, checkout, policy.CockpitPaneKey)
+		// Only when the cockpit will actually wrap (herdr available) do we tee the
+		// child's live output into a per-job log the pane tails (Task 6). The tee
+		// rebuilds the inner adapter with a group-kill-preserving TeeRunner and sets
+		// meta.LogPath; on any log-setup failure it falls back to no LogPath (the P0
+		// `job watch` pane). The non-cockpit / unavailable paths never create a log
+		// file or tee — they stay byte-identical.
+		if maybeWrapCockpitAvailable(cp, payload.Cockpit, userOptedOff) {
+			if teeAdapter, logPath, logFile := w.cockpitTeeAdapter(agent, checkout, job.ID); logFile != nil {
+				defer func() {
+					if err := logFile.Close(); err != nil {
+						writeLine(w.Stdout, "job %s cockpit log close failed: %v", job.ID, err)
+					}
+				}()
+				adapter = teeAdapter
+				meta.LogPath = logPath
+			}
+		}
 		var unavailable bool
 		adapter, unavailable = maybeWrapCockpit(cp, payload.Cockpit, userOptedOff, adapter, meta)
 		if unavailable {
@@ -1829,6 +1847,46 @@ func cockpitJobMeta(job db.Job, payload workflow.JobPayload, agent runtime.Agent
 	}
 }
 
+// cockpitTeeAdapter creates the per-job log the cockpit pane tails and rebuilds
+// the runtime adapter to tee the child's live stdout/stderr into it. It is called
+// ONLY on the wrapping path (herdr available), so non-cockpit and cockpit-off
+// jobs never create a log file or tee and stay byte-identical. The log lives at
+// <home>/logs/jobs/<jobid>.log and is created+truncated so each run starts fresh.
+// The tee uses a TeeRunner whose inner is GroupRunner{}, so process-group kill is
+// preserved and the buffered Result the adapter consumes is unchanged.
+//
+// It is fail-open: any failure (paths unresolved, mkdir, create, or an
+// unsupported runtime) returns a nil *os.File so the caller skips teeing and the
+// pane falls back to the P0 `job watch` command. The returned *os.File is the
+// caller's to Close after the job runs; when nil the adapter/path are ignored.
+func (w jobWorker) cockpitTeeAdapter(agent runtime.Agent, checkout string, jobID string) (workflow.DeliveryAdapter, string, *os.File) {
+	paths, err := pathsFromFlag(w.ConfigHome)
+	if err != nil {
+		writeLine(w.Stdout, "job %s cockpit log path resolve failed: %v", jobID, err)
+		return nil, "", nil
+	}
+	dir := filepath.Join(paths.Logs, "jobs")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		writeLine(w.Stdout, "job %s cockpit log dir create failed: %v", jobID, err)
+		return nil, "", nil
+	}
+	logPath := filepath.Join(dir, jobID+".log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		writeLine(w.Stdout, "job %s cockpit log create failed: %v", jobID, err)
+		return nil, "", nil
+	}
+	adapter, err := buildRuntimeAdapter(agent, checkout, subprocess.TeeRunner{Inner: subprocess.GroupRunner{}, Out: logFile})
+	if err != nil {
+		// Unsupported runtime: this should never happen (AdapterFactory already
+		// built one above), but stay fail-open rather than leak the open file.
+		_ = logFile.Close()
+		writeLine(w.Stdout, "job %s cockpit tee adapter build failed: %v", jobID, err)
+		return nil, "", nil
+	}
+	return adapter, logPath, logFile
+}
+
 // maybeWrapCockpit decides whether a job's delivery is wrapped in a herdr pane.
 // It is a pure helper (no daemon state) so the wrap-vs-passthrough decision is
 // directly unit-testable. The returned unavailable flag is true exactly when the
@@ -1846,10 +1904,23 @@ func maybeWrapCockpit(cp *cockpit.Cockpit, requested bool, modeOff bool, inner w
 	if !requested || modeOff {
 		return inner, false
 	}
-	if cp == nil || !cp.Available(context.Background()) {
+	if !maybeWrapCockpitAvailable(cp, requested, modeOff) {
 		return inner, true
 	}
 	return cp.Wrap(inner, meta), false
+}
+
+// maybeWrapCockpitAvailable reports whether the cockpit will actually wrap this
+// job's delivery in a pane: requested, the host did not opt out (mode off), and
+// herdr is reachable. It is the single source of truth the daemon uses BOTH to
+// decide whether to set up the per-job tee log (so logs/tees are created only on
+// the wrapping path) and inside maybeWrapCockpit's final decision, so the two can
+// never drift. Availability is cached (availableTTL) so the extra call is cheap.
+func maybeWrapCockpitAvailable(cp *cockpit.Cockpit, requested bool, modeOff bool) bool {
+	if !requested || modeOff || cp == nil {
+		return false
+	}
+	return cp.Available(context.Background())
 }
 
 func tempWorkerEligible(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload, agent runtime.Agent, policy config.ParallelSessionPolicy, now time.Time) tempWorkerEligibility {
@@ -2560,15 +2631,26 @@ func (w jobWorker) refreshImplementedPayloadForRetry(ctx context.Context, job db
 }
 
 func (w jobWorker) defaultAdapter(agent runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
+	return buildRuntimeAdapter(agent, checkout, nil)
+}
+
+// buildRuntimeAdapter constructs the concrete runtime adapter for a job. A nil
+// runner leaves the adapter's Runner unset, so it falls through to the
+// process-group GroupRunner{} via the adapter's runner() — byte-identical to the
+// non-cockpit path. The cockpit path (Task 6) passes a non-nil tee runner so the
+// child's stdout/stderr is also streamed live into the per-job log the pane
+// tails; the tee preserves group-kill (its inner is GroupRunner{}) and returns
+// the same buffered Result, so result capture, locks, and signals are unchanged.
+func buildRuntimeAdapter(agent runtime.Agent, checkout string, runner subprocess.Runner) (workflow.DeliveryAdapter, error) {
 	switch agent.Runtime {
 	case runtime.CodexRuntime:
-		return runtime.CodexAdapter{Dir: checkout}, nil
+		return runtime.CodexAdapter{Dir: checkout, Runner: runner}, nil
 	case runtime.ClaudeRuntime:
-		return runtime.ClaudeAdapter{Dir: checkout}, nil
+		return runtime.ClaudeAdapter{Dir: checkout, Runner: runner}, nil
 	case runtime.KimiRuntime:
-		return runtime.KimiAdapter{Dir: checkout}, nil
+		return runtime.KimiAdapter{Dir: checkout, Runner: runner}, nil
 	case runtime.ShellRuntime:
-		return runtime.ShellAdapter{Dir: checkout}, nil
+		return runtime.ShellAdapter{Dir: checkout, Runner: runner}, nil
 	default:
 		return nil, fmt.Errorf("unsupported runtime: %s", agent.Runtime)
 	}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1721,6 +1721,10 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 					if err := logFile.Close(); err != nil {
 						writeLine(w.Stdout, "job %s cockpit log close failed: %v", job.ID, err)
 					}
+					// The per-job log only backs the live pane tail, which is torn
+					// down with the job; remove it so cockpit logs don't accumulate
+					// one-file-per-job. Best-effort: a leftover log never matters.
+					_ = os.Remove(logPath)
 				}()
 				adapter = teeAdapter
 				meta.LogPath = logPath

--- a/internal/cli/daemon_cockpit_test.go
+++ b/internal/cli/daemon_cockpit_test.go
@@ -3,12 +3,17 @@ package cli
 import (
 	"context"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/cockpit"
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -213,6 +218,128 @@ func TestWorkerEmitsCockpitUnavailableEvent(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("cockpit_unavailable events = %d, want exactly 1 (events: %+v)", count, events)
+	}
+}
+
+// TestMaybeWrapCockpitAvailable checks the single source of truth the daemon uses
+// to decide whether to set up the per-job tee log: it is true only when requested,
+// not opted-off, the cockpit is non-nil, AND herdr is reachable. CI has no herdr
+// so every here-listed case is false; the available branch is covered by the
+// cockpit package's fake-runner tests + the live skip in TestMaybeWrapCockpitDecision.
+func TestMaybeWrapCockpitAvailable(t *testing.T) {
+	unavailableCockpit := cockpit.New(cockpit.Options{HerdrBin: "herdr-does-not-exist-for-tests"}, nil)
+	cases := []struct {
+		name      string
+		cp        *cockpit.Cockpit
+		requested bool
+		modeOff   bool
+	}{
+		{"not requested", unavailableCockpit, false, false},
+		{"mode off", unavailableCockpit, true, true},
+		{"nil cockpit", nil, true, false},
+		{"herdr absent", unavailableCockpit, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if maybeWrapCockpitAvailable(tc.cp, tc.requested, tc.modeOff) {
+				t.Fatalf("maybeWrapCockpitAvailable = true, want false")
+			}
+		})
+	}
+}
+
+// TestCockpitTeeAdapterCreatesLogAndTees proves the wrapping-path log setup: it
+// creates+truncates <home>/logs/jobs/<jobid>.log, returns the path + an open file
+// + a tee-instrumented adapter, and the adapter's Deliver streams the child's
+// stdout into that log (the file a pane tails). Result capture is unchanged.
+func TestCockpitTeeAdapterCreatesLogAndTees(t *testing.T) {
+	home := t.TempDir()
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
+	agent := runtime.Agent{Name: "lead", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "echo streamed-line"}
+
+	adapter, logPath, logFile := worker.cockpitTeeAdapter(agent, t.TempDir(), "job-tee")
+	if logFile == nil {
+		t.Fatal("expected a non-nil log file on the wrapping path")
+	}
+	defer logFile.Close()
+
+	wantPath := filepath.Join(config.PathsForHome(home).Logs, "jobs", "job-tee.log")
+	if logPath != wantPath {
+		t.Fatalf("logPath = %q, want %q", logPath, wantPath)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("log file not created: %v", err)
+	}
+
+	// The adapter must carry a TeeRunner whose Out is the log file (the seam that
+	// streams live with zero adapter change) and whose inner preserves group-kill.
+	shell, ok := adapter.(runtime.ShellAdapter)
+	if !ok {
+		t.Fatalf("adapter type = %T, want runtime.ShellAdapter", adapter)
+	}
+	tee, ok := shell.Runner.(subprocess.TeeRunner)
+	if !ok {
+		t.Fatalf("adapter Runner = %T, want subprocess.TeeRunner", shell.Runner)
+	}
+	if _, ok := tee.Inner.(subprocess.GroupRunner); !ok {
+		t.Fatalf("tee inner = %T, want subprocess.GroupRunner (group-kill preserved)", tee.Inner)
+	}
+
+	// Delivering tees the child's stdout into the log; the buffered Result is intact.
+	res, err := adapter.Deliver(context.Background(), agent, runtime.Job{Prompt: "go"})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if !strings.Contains(res.Raw, "streamed-line") {
+		t.Fatalf("result raw missing output: %q", res.Raw)
+	}
+	logged, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logged), "streamed-line") {
+		t.Fatalf("log missing teed output: %q", string(logged))
+	}
+}
+
+// TestCockpitTeeAdapterTruncatesExistingLog: each run starts fresh, so stale
+// output from a prior run of the same job id is not shown in the pane.
+func TestCockpitTeeAdapterTruncatesExistingLog(t *testing.T) {
+	home := t.TempDir()
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
+	logPath := filepath.Join(config.PathsForHome(home).Logs, "jobs", "job-trunc.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath, []byte("STALE OUTPUT\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := runtime.Agent{Name: "lead", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "true"}
+	_, _, logFile := worker.cockpitTeeAdapter(agent, t.TempDir(), "job-trunc")
+	if logFile == nil {
+		t.Fatal("expected a non-nil log file")
+	}
+	defer logFile.Close()
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if strings.Contains(string(logged), "STALE") {
+		t.Fatalf("log was not truncated: %q", string(logged))
+	}
+}
+
+// TestCockpitTeeAdapterFailOpenUnsupportedRuntime: an unsupported runtime fails
+// the adapter rebuild, so the helper returns a nil file (no leaked log) and the
+// caller falls back to the P0 pane — fail-open, never failing the job.
+func TestCockpitTeeAdapterFailOpenUnsupportedRuntime(t *testing.T) {
+	home := t.TempDir()
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
+	agent := runtime.Agent{Name: "x", Runtime: "nope-not-a-runtime"}
+	adapter, logPath, logFile := worker.cockpitTeeAdapter(agent, t.TempDir(), "job-bad")
+	if adapter != nil || logPath != "" || logFile != nil {
+		t.Fatalf("expected fail-open nils, got adapter=%v path=%q file=%v", adapter, logPath, logFile)
 	}
 }
 

--- a/internal/cockpit/cockpit.go
+++ b/internal/cockpit/cockpit.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -103,6 +104,12 @@ type JobMeta struct {
 	Worktree  string
 	PaneKey   string
 	Depth     int
+	// LogPath is the per-job log file the daemon tees the child's live
+	// stdout/stderr into (P1, Task 6). When set, the pane tails it for live
+	// output; when empty the pane falls back to the P0 `gitmoot job watch`
+	// command. It is optional and best-effort: an empty LogPath leaves the pane
+	// behaving exactly as P0.
+	LogPath string
 }
 
 // Cockpit opens and tears down herdr panes around delegation deliveries.
@@ -362,14 +369,31 @@ func (a *paneAdapter) workspaceRoot() string {
 	return a.meta.JobID
 }
 
-// watchCommand is the P0 pane payload: tail the job's progress via the gitmoot
-// CLI. In P1 (Task 6) this is replaced by tailing a streamed log.
+// watchCommand is the pane payload. In P1 (Task 6), when the daemon tees the
+// child's live stdout/stderr into a per-job log (meta.LogPath set), the pane
+// tails that file so real output appears live: `tail -n +1 -F <log>` (-n +1
+// replays from the start so output written before the pane attached is not lost;
+// -F keeps following across the truncate-on-start and any rotation). With no log
+// (LogPath empty — herdr unavailable on the wrapping path, or a log that could
+// not be created) it falls back to the P0 `gitmoot job watch` command, so
+// behavior is unchanged.
 func (a *paneAdapter) watchCommand() string {
+	if a.meta.LogPath != "" {
+		return fmt.Sprintf("tail -n +1 -F %s", shellQuote(a.meta.LogPath))
+	}
 	cmd := fmt.Sprintf("%s job watch %s", a.cockpit.gitmootBin, a.meta.JobID)
 	if a.cockpit.home != "" {
 		cmd += fmt.Sprintf(" --home %s", a.cockpit.home)
 	}
 	return cmd
+}
+
+// shellQuote single-quotes s for safe interpolation into the single shell-string
+// command the pane runs, so a log path with spaces or shell metacharacters is
+// passed as one literal argument. Single quotes preserve everything except a
+// single quote, which is closed, escaped, and reopened.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // rootPaneFor returns the split-parent target for a workspace. The workspace id

--- a/internal/cockpit/cockpit_test.go
+++ b/internal/cockpit/cockpit_test.go
@@ -398,6 +398,67 @@ func TestWrapDeliverArgsCarryVerifiedFields(t *testing.T) {
 	assertContains("pane close w1:p2")
 }
 
+func TestWatchCommandTailsLogWhenLogPathSet(t *testing.T) {
+	// With a per-job LogPath (P1, Task 6) the pane tails the streamed log instead
+	// of running `gitmoot job watch`. -n +1 replays from the start; -F follows
+	// across the truncate-on-start and rotation.
+	a := &paneAdapter{
+		cockpit: &Cockpit{gitmootBin: "gitmoot", home: "/home/g"},
+		meta:    JobMeta{JobID: "abcdef0123456789", LogPath: "/home/g/logs/jobs/abcdef0123456789.log"},
+	}
+	got := a.watchCommand()
+	want := "tail -n +1 -F '/home/g/logs/jobs/abcdef0123456789.log'"
+	if got != want {
+		t.Fatalf("watchCommand = %q, want %q", got, want)
+	}
+}
+
+func TestWatchCommandFallsBackToJobWatchWhenNoLogPath(t *testing.T) {
+	// No LogPath (herdr unavailable on the wrapping path, or the log could not be
+	// created) ⇒ the P0 `gitmoot job watch` command, byte-identical to before.
+	a := &paneAdapter{
+		cockpit: &Cockpit{gitmootBin: "gitmoot", home: "/home/g"},
+		meta:    JobMeta{JobID: "abcdef0123456789"},
+	}
+	got := a.watchCommand()
+	want := "gitmoot job watch abcdef0123456789 --home /home/g"
+	if got != want {
+		t.Fatalf("watchCommand = %q, want %q", got, want)
+	}
+}
+
+func TestWatchCommandShellQuotesLogPathWithSpaces(t *testing.T) {
+	// A log path with a space (or shell metacharacter) is passed as a single
+	// literal argument so tail receives the whole path.
+	a := &paneAdapter{
+		cockpit: &Cockpit{gitmootBin: "gitmoot"},
+		meta:    JobMeta{JobID: "x", LogPath: "/home/my logs/jobs/x.log"},
+	}
+	if got, want := a.watchCommand(), "tail -n +1 -F '/home/my logs/jobs/x.log'"; got != want {
+		t.Fatalf("watchCommand = %q, want %q", got, want)
+	}
+}
+
+func TestWrapDeliverPaneRunTailsLogPath(t *testing.T) {
+	// End-to-end through Wrap/Deliver: a meta carrying LogPath makes the pane-run
+	// command tail the streamed log rather than run job-watch.
+	fr := newFakeRunner()
+	c := newWithRunner(Options{}, newFakeStore(), fr.run, okLookPath)
+	meta := sampleMeta()
+	meta.LogPath = "/tmp/logs/jobs/abcdef0123456789.log"
+	adapter := c.Wrap(&fakeInner{}, meta)
+	if _, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(fr.calls, "\n")
+	if want := "pane run w1:p2 tail -n +1 -F '/tmp/logs/jobs/abcdef0123456789.log'"; !strings.Contains(joined, want) {
+		t.Fatalf("expected pane run to tail the log; want %q; calls:\n%s", want, joined)
+	}
+	if strings.Contains(joined, "job watch") {
+		t.Fatalf("pane should tail the log, not run job watch; calls:\n%s", joined)
+	}
+}
+
 func TestWrapSwallowsHerdrErrors(t *testing.T) {
 	// pane split fails ⇒ no pane opened, but delivery still proceeds and the
 	// result is unchanged.

--- a/internal/subprocess/group.go
+++ b/internal/subprocess/group.go
@@ -3,6 +3,7 @@ package subprocess
 import (
 	"bytes"
 	"context"
+	"io"
 	"os/exec"
 	"syscall"
 	"time"
@@ -24,6 +25,15 @@ func (GroupRunner) Run(ctx context.Context, dir string, command string, args ...
 	return RunGroup(ctx, dir, command, args...)
 }
 
+// RunStream gives GroupRunner the StreamRunner contract: process-group kill
+// semantics PLUS a live line-tee of the child's stdout/stderr to out. It is what
+// TeeRunner{} defaults to, so teeing a runtime adapter's output into a per-job
+// log keeps the same whole-group cancellation the adapters rely on. A nil out
+// degrades to RunGroup.
+func (GroupRunner) RunStream(ctx context.Context, dir string, out io.Writer, command string, args ...string) (Result, error) {
+	return RunGroupStream(ctx, dir, out, command, args...)
+}
+
 func (GroupRunner) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
@@ -33,18 +43,49 @@ func (GroupRunner) LookPath(file string) (string, error) {
 // group, Go's WaitDelay reaps a stuck main child after the grace period, and a
 // final best-effort SIGKILL sweeps any group members that ignored SIGTERM.
 func RunGroup(ctx context.Context, dir string, command string, args ...string) (Result, error) {
-	cmd := exec.CommandContext(ctx, command, args...)
-	cmd.Dir = dir
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd, sweep := newGroupCmd(ctx, dir, command, args)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	// On ctx cancel, signal the whole group. The pgid is resolved HERE, while
-	// the process is alive, and remembered for the final sweep — re-resolving
-	// after the child is reaped could chase a reused pid into an unrelated
-	// process group. syscall.Kill takes the pgid negated (golang/go#53199).
+	err := cmd.Run()
+	sweep()
+	return Result{
+		Command: command,
+		Args:    args,
+		Stdout:  stdout.String(),
+		Stderr:  stderr.String(),
+	}, err
+}
+
+// RunGroupStream is RunGroup that additionally streams the child's stdout and
+// stderr to out, line by line, as they are produced — the buffered Result is
+// byte-identical to RunGroup's, so the tee is purely additive. A nil out
+// degrades to RunGroup. The whole-group cancellation/sweep is identical.
+func RunGroupStream(ctx context.Context, dir string, out io.Writer, command string, args ...string) (Result, error) {
+	if out == nil {
+		return RunGroup(ctx, dir, command, args...)
+	}
+	cmd, sweep := newGroupCmd(ctx, dir, command, args)
+	result, err := runStreamingCmd(cmd, out, command, args)
+	sweep()
+	return result, err
+}
+
+// newGroupCmd builds an *exec.Cmd wired for process-group semantics and returns
+// it alongside a sweep closure to call after cmd.Run() returns. The child gets
+// its own pgid (Setpgid) so the daemon never signals itself; on ctx cancel the
+// whole group is SIGTERMed (pgid resolved while alive, then remembered for the
+// sweep — re-resolving after the child is reaped could chase a reused pid into
+// an unrelated group; syscall.Kill takes the pgid negated, golang/go#53199);
+// WaitDelay reaps a stuck main child after the grace; sweep SIGKILLs any group
+// members that survived (orphaned grandchildren) when the run was cancelled.
+func newGroupCmd(ctx context.Context, dir string, command string, args []string) (*exec.Cmd, func()) {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Dir = dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
 	var pgid int
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
@@ -59,17 +100,13 @@ func RunGroup(ctx context.Context, dir string, command string, args ...string) (
 	// If the main child ignores SIGTERM, Wait force-kills it after the grace.
 	cmd.WaitDelay = groupKillGrace
 
-	err := cmd.Run()
-	if ctx.Err() != nil && pgid > 0 {
-		// The run was cancelled: sweep group members that survived SIGTERM and
-		// the main child's kill (orphaned grandchildren). A fully-dead group
-		// makes this a harmless ESRCH.
-		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	sweep := func() {
+		if ctx.Err() != nil && pgid > 0 {
+			// The run was cancelled: sweep group members that survived SIGTERM and
+			// the main child's kill (orphaned grandchildren). A fully-dead group
+			// makes this a harmless ESRCH.
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		}
 	}
-	return Result{
-		Command: command,
-		Args:    args,
-		Stdout:  stdout.String(),
-		Stderr:  stderr.String(),
-	}, err
+	return cmd, sweep
 }

--- a/internal/subprocess/group_test.go
+++ b/internal/subprocess/group_test.go
@@ -1,6 +1,7 @@
 package subprocess
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -72,4 +73,69 @@ func TestRunGroupNormalCompletionUnaffected(t *testing.T) {
 	if strings.TrimSpace(result.Stdout) != "hello" {
 		t.Fatalf("stdout = %q", result.Stdout)
 	}
+}
+
+// TestRunGroupStreamTeesAndBuffers: the streaming group runner tees live to out
+// while returning the same buffered Result as RunGroup — the tee is additive.
+func TestRunGroupStreamTeesAndBuffers(t *testing.T) {
+	var tee bytes.Buffer
+	result, err := RunGroupStream(context.Background(), "", &tee, "sh", "-c", "echo out; echo err >&2")
+	if err != nil {
+		t.Fatalf("RunGroupStream: %v", err)
+	}
+	if result.Stdout != "out\n" || result.Stderr != "err\n" {
+		t.Fatalf("buffered result = %+v", result)
+	}
+	if got := tee.String(); !strings.Contains(got, "out\n") || !strings.Contains(got, "err\n") {
+		t.Fatalf("tee missing streams: %q", got)
+	}
+}
+
+// TestRunGroupStreamKillsGrandchildrenOnCancel: streaming must NOT weaken the
+// whole-group kill — cancelling still terminates the background grandchild, the
+// failure mode plain exec.CommandContext (and the non-group RunStream) leaves
+// behind. This is the load-bearing guarantee for teeing runtime adapter output.
+func TestRunGroupStreamKillsGrandchildrenOnCancel(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var tee bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		_, err := RunGroupStream(ctx, "", &tee, "sh", "-c", "sleep 300 & echo $! > "+pidFile+"; wait")
+		done <- err
+	}()
+
+	var grandchild int
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(pidFile); err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid > 0 {
+				grandchild = pid
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if grandchild == 0 {
+		t.Fatal("grandchild pid never appeared")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("RunGroupStream did not return after cancellation")
+	}
+
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(grandchild, 0); err != nil {
+			return // dead — success
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("grandchild %d survived group cancellation", grandchild)
 }

--- a/internal/subprocess/runner.go
+++ b/internal/subprocess/runner.go
@@ -43,6 +43,34 @@ func (ExecRunner) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
 
+// TeeRunner adapts a stream-capable runner into a plain Runner that always tees
+// the child's stdout/stderr live to Out. Adapters call only .Run(); wrapping
+// the inner runner in a TeeRunner makes those same .Run() calls stream their
+// output into Out (a per-job log a pane tails) with ZERO adapter change. Inner
+// defaults to GroupRunner{}, so the process-group kill semantics the runtime
+// adapters rely on are preserved. A nil Out degrades to the inner's plain Run,
+// and the buffered Result returned is exactly the one RunStream produces — so
+// result capture, locks, and signals are unchanged. The tee is purely additive.
+type TeeRunner struct {
+	Inner StreamRunner
+	Out   io.Writer
+}
+
+func (t TeeRunner) inner() StreamRunner {
+	if t.Inner != nil {
+		return t.Inner
+	}
+	return GroupRunner{}
+}
+
+func (t TeeRunner) Run(ctx context.Context, dir string, command string, args ...string) (Result, error) {
+	return t.inner().RunStream(ctx, dir, t.Out, command, args...)
+}
+
+func (t TeeRunner) LookPath(file string) (string, error) {
+	return t.inner().LookPath(file)
+}
+
 // SyncWriter serializes writes to w. Stream tees and any sibling writers
 // (e.g. a heartbeat ticker) sharing one destination should share one
 // SyncWriter, since destinations like bytes.Buffer are not safe for
@@ -108,7 +136,17 @@ func RunStream(ctx context.Context, dir string, out io.Writer, command string, a
 	}
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Dir = dir
+	return runStreamingCmd(cmd, out, command, args)
+}
 
+// runStreamingCmd wires line-teeing tee writers (sharing one SyncWriter so the
+// two pipes interleave safely) plus the buffered captures onto cmd, runs it, and
+// returns the same buffered Result Run/RunGroup produce. The cmd's run strategy
+// (plain context-cancel vs process-group) is the caller's choice: RunStream
+// passes a plain cmd; RunGroupStream wires the group cancel/sweep first. The
+// returned Result is byte-identical to the non-streaming runners' Result, so the
+// tee never changes result capture.
+func runStreamingCmd(cmd *exec.Cmd, out io.Writer, command string, args []string) (Result, error) {
 	tee := SyncWriter(out)
 	outLines := &lineWriter{out: tee}
 	errLines := &lineWriter{out: tee}

--- a/internal/subprocess/runner_test.go
+++ b/internal/subprocess/runner_test.go
@@ -57,3 +57,79 @@ func TestRunStreamInterleavesAtLineBoundaries(t *testing.T) {
 		t.Fatalf("line not assembled before forwarding: %q", got)
 	}
 }
+
+// TestTeeRunnerTeesAndReturnsResult: a TeeRunner's plain Run tees the child's
+// output to Out while returning the same buffered Result — so an adapter that
+// only calls .Run() streams live into the log with no change to result capture.
+func TestTeeRunnerTeesAndReturnsResult(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command differs on windows")
+	}
+	var tee bytes.Buffer
+	runner := TeeRunner{Inner: GroupRunner{}, Out: &tee}
+	result, err := runner.Run(context.Background(), "", "sh", "-c", "echo out; echo err >&2")
+	if err != nil {
+		t.Fatalf("TeeRunner.Run: %v", err)
+	}
+	if result.Stdout != "out\n" || result.Stderr != "err\n" {
+		t.Fatalf("buffered result = %+v", result)
+	}
+	teed := tee.String()
+	if !strings.Contains(teed, "out\n") || !strings.Contains(teed, "err\n") {
+		t.Fatalf("tee missing streams: %q", teed)
+	}
+}
+
+// TestTeeRunnerNilOutDegradesToRun: a nil Out leaves behavior byte-identical to
+// the inner runner's plain Run — the tee is opt-in via a non-nil writer.
+func TestTeeRunnerNilOutDegradesToRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command differs on windows")
+	}
+	runner := TeeRunner{Inner: GroupRunner{}}
+	result, err := runner.Run(context.Background(), "", "sh", "-c", "echo ok")
+	if err != nil {
+		t.Fatalf("TeeRunner.Run nil out: %v", err)
+	}
+	if result.Stdout != "ok\n" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+// TestTeeRunnerDefaultsToGroupRunner: a zero Inner defaults to GroupRunner{}, so
+// the tee keeps the process-group kill semantics — proven by a nil-inner runner
+// streaming output correctly via the group stream path.
+func TestTeeRunnerDefaultsToGroupRunner(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command differs on windows")
+	}
+	var tee bytes.Buffer
+	runner := TeeRunner{Out: &tee} // Inner nil -> GroupRunner{}
+	result, err := runner.Run(context.Background(), "", "sh", "-c", "echo grouped")
+	if err != nil {
+		t.Fatalf("TeeRunner.Run default inner: %v", err)
+	}
+	if strings.TrimSpace(result.Stdout) != "grouped" {
+		t.Fatalf("result = %+v", result)
+	}
+	if !strings.Contains(tee.String(), "grouped") {
+		t.Fatalf("tee missing output: %q", tee.String())
+	}
+}
+
+// TestTeeRunnerLookPathDelegates: LookPath passes through to the inner runner so
+// runtime resolution (and the GroupRunner default) behaves identically.
+func TestTeeRunnerLookPathDelegates(t *testing.T) {
+	runner := TeeRunner{Inner: GroupRunner{}}
+	got, err := runner.LookPath("sh")
+	if err != nil {
+		t.Fatalf("LookPath: %v", err)
+	}
+	want, err := GroupRunner{}.LookPath("sh")
+	if err != nil {
+		t.Fatalf("GroupRunner.LookPath: %v", err)
+	}
+	if got != want {
+		t.Fatalf("LookPath = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
**Phase 1 of #357** (builds on #358). Each cockpit child's **real stdout/stderr now streams live into its pane**, replacing the Phase-0 `gitmoot job watch` placeholder.

## How
- **`subprocess.TeeRunner`** — wraps a stream-capable runner (default `GroupRunner{}`); its `Run` calls `RunStream` teeing the child's output to a writer. Adapters call `.Run()` unchanged, so injecting a `TeeRunner` tees live with **zero adapter change**.
- **`GroupRunner.RunStream` / `RunGroupStream`** — added so streaming **preserves process-group kill** (plain `ExecRunner.RunStream` would orphan grandchildren). `RunGroup`/`RunGroupStream` share `newGroupCmd` (group cancel/sweep); `RunStream`/`RunGroupStream` share `runStreamingCmd` (tee+capture). The buffered `Result` is byte-identical → result capture / locks / SIGTERM-group-kill / `raw_outputs` unchanged.
- **daemon** — for a cockpit-wrapped job only, creates `<home>/logs/jobs/<jobid>.log`, injects `TeeRunner{Inner: GroupRunner{}, Out: logFile}`, sets `JobMeta.LogPath`, and **removes the log on completion** (it only backs the ephemeral pane → no accumulation). Fail-open: any log-setup error falls back to the Phase-0 `job watch` pane; **non-cockpit jobs byte-identical** (`Runner` nil → `GroupRunner`).
- **cockpit** — `JobMeta.LogPath`; `watchCommand()` → `tail -n +1 -F <log>` (shell-quoted) when set, else the Phase-0 fallback.

## Verification
- Full gate + `-race ./internal/workflow/` green; added: TeeRunner tee/Result/group-default, group-stream tees + kills grandchildren on cancel, cockpit tail command, daemon tee-adapter creates/streams/cleans the log + fail-open.
- `/code-review high` → correctness clean (the `pgid` post-`Run` read is the pre-existing pattern; line writes reach `tail` via OS cache); fixed the per-job-log accumulation (remove on completion).
- E2E: binary builds; `cockpit-smoke.sh` passes with herdr reachable.

Part of #357 (Phase 2 seat mode + steer/reconvene, Phase 3 auto-detect + attach-and-type follow).