### PR TITLE
feat(orchestrate): Herdr cockpit — Phase 2 seat mode + steer/reconvene (#357)

### DIFF
--- a/internal/cli/cockpit_store.go
+++ b/internal/cli/cockpit_store.go
@@ -28,8 +28,28 @@ func (s cockpitPaneStore) GetCockpitPaneByJob(ctx context.Context, jobID string)
 	return fromDBCockpitPane(pane), nil
 }
 
+func (s cockpitPaneStore) GetCockpitPaneByKey(ctx context.Context, workspaceID, paneKey string) (cockpit.Pane, bool, error) {
+	pane, found, err := s.store.GetCockpitPaneByKey(ctx, workspaceID, paneKey)
+	if err != nil || !found {
+		return cockpit.Pane{}, found, err
+	}
+	return fromDBCockpitPane(pane), true, nil
+}
+
 func (s cockpitPaneStore) ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([]cockpit.Pane, error) {
 	panes, err := s.store.ListCockpitPanesByRoot(ctx, rootJobID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]cockpit.Pane, 0, len(panes))
+	for _, pane := range panes {
+		out = append(out, fromDBCockpitPane(pane))
+	}
+	return out, nil
+}
+
+func (s cockpitPaneStore) ListAllCockpitPanes(ctx context.Context) ([]cockpit.Pane, error) {
+	panes, err := s.store.ListAllCockpitPanes(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2017,6 +2017,13 @@ func (w jobWorker) cockpitSeatLogAdapter(cp *cockpit.Cockpit, agent runtime.Agen
 // its per-Deliver teardown stays byte-identical.
 func (w jobWorker) finalizeCockpitRootIfDone(cp *cockpit.Cockpit, job db.Job, payload workflow.JobPayload, rootJobID string) {
 	ctx := context.Background()
+	// Cheap scoped guard before the full job-table scan: if the root has no live
+	// panes (none opened, or already finalized), there is nothing to do — this
+	// short-circuits the redundant rootTreeTerminal scans that would otherwise run
+	// on every in-tree job's completion once the root is already torn down.
+	if panes, perr := w.Store.ListCockpitPanesByRoot(ctx, rootJobID); perr == nil && len(panes) == 0 {
+		return
+	}
 	done, err := w.rootTreeTerminal(ctx, rootJobID)
 	if err != nil {
 		writeLine(w.Stdout, "job %s cockpit root-finalize check failed: %v", job.ID, err)
@@ -2037,8 +2044,8 @@ func (w jobWorker) finalizeCockpitRootIfDone(cp *cockpit.Cockpit, job db.Job, pa
 }
 
 // rootTreeTerminal reports whether every job in the coordination tree rooted at
-// rootJobID is terminal (succeeded/failed/blocked/cancelled) — i.e. nothing is
-// still queued or running. It lists jobs and matches the root id against each
+// rootJobID is terminal (succeeded/failed/cancelled) — i.e. nothing is still
+// queued, running, or blocked (a blocked job can resume, so it is not terminal). It lists jobs and matches the root id against each
 // job's own id (the root coordinator) or its payload RootJobID (children +
 // continuations), mirroring the engine's per-root reasoning. It fails closed
 // (returns false) on any unparseable payload so a transient hiccup never triggers
@@ -2106,9 +2113,14 @@ func (w jobWorker) isReconveneContinuation(ctx context.Context, job db.Job, payl
 func cockpitJobStateTerminal(state string) bool {
 	switch state {
 	case string(workflow.JobSucceeded), string(workflow.JobFailed),
-		string(workflow.JobBlocked), string(workflow.JobCancelled):
+		string(workflow.JobCancelled):
 		return true
 	default:
+		// JobBlocked is deliberately NOT terminal: a blocked job (e.g. awaiting a
+		// permission/approval or interactive answer) can resume, and finalizing the
+		// root then would tear down a pane + seat log the job still needs. The
+		// engine's graceful-finalize continuation provides the real terminal signal
+		// for a stuck tree.
 		return false
 	}
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -828,6 +828,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			workerErr = startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
 				return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, stdout, now, checkoutLocks)
 			})
+			startCockpitReconcileLoop(ctx, store, paths.Home, stdout)
 		}
 		for {
 			if err := receiveSupervisorWorkerError(workerErr); err != nil {
@@ -880,6 +881,7 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 		defer checkoutLock.Unlock()
 		return runDaemonWorkerTick(ctx, store, worker, workers, false, d.Repo.FullName(), stdout, now)
 	})
+	startCockpitReconcileLoop(ctx, store, home, stdout)
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -945,6 +947,49 @@ func receiveSupervisorWorkerError(errCh <-chan error) error {
 	default:
 		return nil
 	}
+}
+
+// startCockpitReconcileLoop runs the low-frequency cockpit reconcile GC in the
+// background until ctx is cancelled (Task 7). Each tick drops cockpit_pane rows
+// whose herdr pane is gone AND whose owning root is terminal, complementing the
+// per-Deliver / root-finalize teardown and report-metadata --ttl-ms self-expiry.
+// It is entirely best-effort: it is gated on herdr availability (so a host without
+// herdr never sweeps), uses the auto-policy cockpit, and swallows every error. It
+// never blocks the supervisor's poll/worker loops. A policy load failure or a
+// disabled cockpit simply skips the sweep.
+func startCockpitReconcileLoop(ctx context.Context, store *db.Store, home string, stdout io.Writer) {
+	worker := defaultJobWorker(store, stdout, home)
+	go func() {
+		ticker := time.NewTicker(cockpitReconcileInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				reconcileCockpitPanesOnce(ctx, worker)
+			}
+		}
+	}()
+}
+
+// reconcileCockpitPanesOnce performs one best-effort cockpit reconcile sweep. It
+// builds the cockpit from the host orchestrate policy, skips when the cockpit is
+// disabled or herdr is unreachable, and otherwise asks cockpit.Reconcile to drop
+// orphaned rows (pane gone + root terminal). All errors are swallowed.
+func reconcileCockpitPanesOnce(ctx context.Context, worker jobWorker) {
+	policy, err := worker.orchestratePolicy()
+	if err != nil || policy.CockpitMode == config.CockpitModeOff {
+		return
+	}
+	cp := worker.newCockpit(policy)
+	if cp == nil || !cp.Available(ctx) {
+		return
+	}
+	cp.Reconcile(ctx, func(rootJobID string) bool {
+		terminal, terr := worker.rootTreeTerminal(ctx, rootJobID)
+		return terr == nil && terminal
+	})
 }
 
 type repoCheckoutLocks struct {
@@ -1149,6 +1194,12 @@ type jobWorker struct {
 const daemonRunningJobStaleAfter = 30 * time.Minute
 const daemonJobCancelPollInterval = 250 * time.Millisecond
 const daemonWorkerLoopInterval = 1 * time.Second
+
+// cockpitReconcileInterval is the low-frequency cadence of the cockpit reconcile
+// GC sweep (Task 7): it drops cockpit_pane rows whose herdr pane is gone and whose
+// owning root is terminal. It runs rarely because it is a backstop for the
+// per-Deliver / root-finalize teardown plus report-metadata --ttl-ms self-expiry.
+const cockpitReconcileInterval = 5 * time.Minute
 
 var errRuntimeSessionBusy = errors.New("runtime session is busy")
 
@@ -1709,22 +1760,32 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			cp = w.newCockpit(policy)
 		}
 		meta := cockpitJobMeta(job, payload, agent, checkout, policy.CockpitPaneKey)
+		seatMode := policy.CockpitPaneKey == config.CockpitPaneKeySeat
 		// Only when the cockpit will actually wrap (herdr available) do we tee the
-		// child's live output into a per-job log the pane tails (Task 6). The tee
-		// rebuilds the inner adapter with a group-kill-preserving TeeRunner and sets
+		// child's live output into a log the pane tails (Task 6). The tee rebuilds
+		// the inner adapter with a group-kill-preserving TeeRunner and sets
 		// meta.LogPath; on any log-setup failure it falls back to no LogPath (the P0
 		// `job watch` pane). The non-cockpit / unavailable paths never create a log
 		// file or tee — they stay byte-identical.
+		//
+		// Job mode uses a per-job truncate log removed when the job finishes. Seat
+		// mode (Task 7) uses a STABLE per-seat append log so the one seat pane tails
+		// one file that accumulates the seat's history across delegation rounds — it
+		// is opened O_APPEND and is NOT removed per job (it persists for the root's
+		// life and is torn down by FinalizeRoot).
 		if maybeWrapCockpitAvailable(cp, payload.Cockpit, userOptedOff) {
-			if teeAdapter, logPath, logFile := w.cockpitTeeAdapter(agent, checkout, job.ID); logFile != nil {
+			teeAdapter, logPath, logFile := w.cockpitLogAdapter(cp, agent, checkout, job.ID, meta.RootJobID, meta.PaneKey, seatMode)
+			if logFile != nil {
 				defer func() {
 					if err := logFile.Close(); err != nil {
 						writeLine(w.Stdout, "job %s cockpit log close failed: %v", job.ID, err)
 					}
-					// The per-job log only backs the live pane tail, which is torn
-					// down with the job; remove it so cockpit logs don't accumulate
-					// one-file-per-job. Best-effort: a leftover log never matters.
-					_ = os.Remove(logPath)
+					// Job mode: the per-job log only backs a per-job pane torn down with
+					// the job, so remove it. Seat mode: keep the append log — it backs the
+					// persisted seat pane and is removed on root finalize.
+					if !seatMode {
+						_ = os.Remove(logPath)
+					}
 				}()
 				adapter = teeAdapter
 				meta.LogPath = logPath
@@ -1736,6 +1797,14 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "cockpit_unavailable", Message: "cockpit requested but herdr is unavailable; running without a pane"}); eventErr != nil {
 				writeLine(w.Stdout, "job %s cockpit_unavailable event failed: %v", job.ID, eventErr)
 			}
+		}
+		// SEAT MODE ONLY: on the job's return, check whether the root coordination
+		// tree has now terminated and, if so, tear its panes / workspace / seat logs
+		// down once and surface the reconvene view (Task 7/8). Job mode is left
+		// byte-identical to P1 — its panes close per-Deliver and it never reaches
+		// here, so no extra herdr calls are made on the job-mode path.
+		if cp != nil && !userOptedOff && seatMode {
+			defer w.finalizeCockpitRootIfDone(cp, job, payload, meta.RootJobID)
 		}
 	}
 	if managed.OK {
@@ -1880,6 +1949,14 @@ func (w jobWorker) cockpitTeeAdapter(agent runtime.Agent, checkout string, jobID
 		writeLine(w.Stdout, "job %s cockpit log create failed: %v", jobID, err)
 		return nil, "", nil
 	}
+	return w.cockpitTeeOnFile(agent, checkout, jobID, logPath, logFile)
+}
+
+// cockpitTeeOnFile rebuilds the runtime adapter to tee the child's live
+// stdout/stderr into an already-open log file, shared by the per-job (truncate)
+// and per-seat (append) log paths. It is fail-open: an unsupported runtime closes
+// the file and returns nils so the caller falls back to the P0 pane.
+func (w jobWorker) cockpitTeeOnFile(agent runtime.Agent, checkout, jobID, logPath string, logFile *os.File) (workflow.DeliveryAdapter, string, *os.File) {
 	adapter, err := buildRuntimeAdapter(agent, checkout, subprocess.TeeRunner{Inner: subprocess.GroupRunner{}, Out: logFile})
 	if err != nil {
 		// Unsupported runtime: this should never happen (AdapterFactory already
@@ -1889,6 +1966,151 @@ func (w jobWorker) cockpitTeeAdapter(agent runtime.Agent, checkout string, jobID
 		return nil, "", nil
 	}
 	return adapter, logPath, logFile
+}
+
+// cockpitLogAdapter picks the live-output log per PaneKeyMode (Task 7): seat mode
+// uses the stable per-seat append log so the one seat pane tails one accumulating
+// file across rounds; job mode keeps the per-job truncate log (byte-identical to
+// P1). It is called only on the wrapping path (herdr available); a nil *os.File
+// means fall back to the P0 pane.
+func (w jobWorker) cockpitLogAdapter(cp *cockpit.Cockpit, agent runtime.Agent, checkout, jobID, rootJobID, paneKey string, seatMode bool) (workflow.DeliveryAdapter, string, *os.File) {
+	if seatMode {
+		return w.cockpitSeatLogAdapter(cp, agent, checkout, jobID, rootJobID, paneKey)
+	}
+	return w.cockpitTeeAdapter(agent, checkout, jobID)
+}
+
+// cockpitSeatLogAdapter opens the stable per-seat append log the seat's one pane
+// tails across delegation rounds (Task 7) and tees the child's stdout/stderr into
+// it. The path is <home>/logs/seats/<rootShort>/<seatSlug>.log, opened O_APPEND so
+// each round's output accumulates rather than truncating the prior round's — no
+// tail re-pointing needed. The log is NOT removed per job; it persists for the
+// root's life and is removed by FinalizeRoot. It is fail-open: any failure
+// (unresolved path, mkdir, create, unsupported runtime) returns nils so the caller
+// falls back to the P0 pane.
+func (w jobWorker) cockpitSeatLogAdapter(cp *cockpit.Cockpit, agent runtime.Agent, checkout, jobID, rootJobID, paneKey string) (workflow.DeliveryAdapter, string, *os.File) {
+	logPath := cp.SeatLogPath(rootJobID, paneKey)
+	if logPath == "" {
+		// Home unset (cockpit could not resolve GITMOOT_HOME): fall back to the P0
+		// pane rather than an unstable seat log.
+		return nil, "", nil
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		writeLine(w.Stdout, "job %s cockpit seat log dir create failed: %v", jobID, err)
+		return nil, "", nil
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		writeLine(w.Stdout, "job %s cockpit seat log open failed: %v", jobID, err)
+		return nil, "", nil
+	}
+	return w.cockpitTeeOnFile(agent, checkout, jobID, logPath, logFile)
+}
+
+// finalizeCockpitRootIfDone tears the root's cockpit down once the coordination
+// tree it belongs to has terminated (Task 7/8, seat mode only). It runs on a
+// wrapped seat-mode job's return: if every job sharing the root is terminal, it
+// calls FinalizeRoot (close panes / workspace, delete rows, remove seat logs) and,
+// when this job is the terminal coordinator continuation, FocusRoot to surface the
+// reconvene view. Everything is best-effort: it is deferred on a detached context
+// so a cockpit/herdr problem never affects the job. Job mode never reaches here, so
+// its per-Deliver teardown stays byte-identical.
+func (w jobWorker) finalizeCockpitRootIfDone(cp *cockpit.Cockpit, job db.Job, payload workflow.JobPayload, rootJobID string) {
+	ctx := context.Background()
+	done, err := w.rootTreeTerminal(ctx, rootJobID)
+	if err != nil {
+		writeLine(w.Stdout, "job %s cockpit root-finalize check failed: %v", job.ID, err)
+		return
+	}
+	if !done {
+		return
+	}
+	// A terminal continuation that absorbed the children (a finalize continuation,
+	// or a coordinator continuation that returned no further delegations) is the
+	// reconvene point: surface the root workspace so the synthesized verdict —
+	// which lands in the coordinator's own pane (its continuation shares the
+	// coordinator seat in seat mode) — is brought forward.
+	if w.isReconveneContinuation(ctx, job, payload) {
+		cp.FocusRoot(ctx, rootJobID)
+	}
+	cp.FinalizeRoot(ctx, rootJobID)
+}
+
+// rootTreeTerminal reports whether every job in the coordination tree rooted at
+// rootJobID is terminal (succeeded/failed/blocked/cancelled) — i.e. nothing is
+// still queued or running. It lists jobs and matches the root id against each
+// job's own id (the root coordinator) or its payload RootJobID (children +
+// continuations), mirroring the engine's per-root reasoning. It fails closed
+// (returns false) on any unparseable payload so a transient hiccup never triggers
+// a premature teardown.
+func (w jobWorker) rootTreeTerminal(ctx context.Context, rootJobID string) (bool, error) {
+	rootJobID = strings.TrimSpace(rootJobID)
+	if rootJobID == "" {
+		return false, nil
+	}
+	jobs, err := w.Store.ListJobs(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, j := range jobs {
+		inTree := j.ID == rootJobID
+		if !inTree {
+			p, perr := daemonJobPayload(j)
+			if perr != nil {
+				// An unparseable job payload could belong to the tree; do not finalize
+				// while its membership/state is unknown.
+				return false, nil
+			}
+			inTree = strings.TrimSpace(p.RootJobID) == rootJobID
+		}
+		if !inTree {
+			continue
+		}
+		if !cockpitJobStateTerminal(j.State) {
+			return false, nil
+		}
+	}
+	// Every in-tree job (if any) is terminal — the tree is done. An already-pruned
+	// root (no jobs found) is also terminal: a late finalize is a harmless no-op.
+	return true, nil
+}
+
+// isReconveneContinuation reports whether this job is the coordinator's terminal
+// reconvene point: a finalize continuation, or any coordinator continuation that
+// returned no further delegations (so the tree stops here). It is the signal to
+// refocus the root workspace on the synthesized verdict (Task 8).
+func (w jobWorker) isReconveneContinuation(ctx context.Context, job db.Job, payload workflow.JobPayload) bool {
+	if payload.DelegationFinalize {
+		return true
+	}
+	// A continuation job carries a parent (the prior coordinator job in the chain).
+	// When such a continuation returns no delegations, the coordination tree has
+	// reconvened on it.
+	if strings.TrimSpace(payload.ParentJobID) == "" {
+		// The root coordinator itself: a reconvene point only if it spawned no
+		// children (it ran to completion without delegating).
+		children, err := w.Store.ListJobsByParent(ctx, job.ID)
+		if err != nil {
+			return false
+		}
+		return len(children) == 0
+	}
+	if payload.Result != nil && len(payload.Result.Delegations) > 0 {
+		return false
+	}
+	return true
+}
+
+// cockpitJobStateTerminal reports whether a job state is terminal for the purpose
+// of root-tree finalization: nothing more will run for it.
+func cockpitJobStateTerminal(state string) bool {
+	switch state {
+	case string(workflow.JobSucceeded), string(workflow.JobFailed),
+		string(workflow.JobBlocked), string(workflow.JobCancelled):
+		return true
+	default:
+		return false
+	}
 }
 
 // maybeWrapCockpit decides whether a job's delivery is wrapped in a herdr pane.

--- a/internal/cli/daemon_cockpit_test.go
+++ b/internal/cli/daemon_cockpit_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -381,5 +382,232 @@ func TestWorkerNoCockpitEventWhenNotRequested(t *testing.T) {
 	}
 	if daemonWorkerHasEvent(events, "cockpit_unavailable") {
 		t.Fatalf("unexpected cockpit_unavailable event for non-cockpit job: %+v", events)
+	}
+}
+
+func cockpitTestJobPayload(t *testing.T, p workflow.JobPayload) string {
+	t.Helper()
+	encoded, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return string(encoded)
+}
+
+// TestRootTreeTerminal: a root coordination tree is terminal only when every job
+// sharing the root (the root coordinator + every child/continuation by payload
+// RootJobID) is in a terminal state.
+func TestRootTreeTerminal(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worker := defaultJobWorker(store, io.Discard)
+
+	// Root coordinator (its own id is the root) + two children carrying RootJobID.
+	mustCreate := func(id, state string, payload workflow.JobPayload) {
+		if err := store.CreateJob(ctx, db.Job{ID: id, Agent: "a", Type: "implement", State: state, Payload: cockpitTestJobPayload(t, payload)}); err != nil {
+			t.Fatalf("CreateJob %s: %v", id, err)
+		}
+	}
+	mustCreate("root-1", string(workflow.JobSucceeded), workflow.JobPayload{})
+	mustCreate("child-a", string(workflow.JobSucceeded), workflow.JobPayload{RootJobID: "root-1"})
+	mustCreate("child-b", string(workflow.JobRunning), workflow.JobPayload{RootJobID: "root-1"})
+
+	// child-b still running -> not terminal.
+	if done, err := worker.rootTreeTerminal(ctx, "root-1"); err != nil || done {
+		t.Fatalf("rootTreeTerminal with a running child = (%v, %v), want (false, nil)", done, err)
+	}
+
+	// Finish child-b -> terminal.
+	if _, err := store.TransitionJobState(ctx, "child-b", string(workflow.JobRunning), string(workflow.JobFailed)); err != nil {
+		t.Fatalf("transition child-b: %v", err)
+	}
+	if done, err := worker.rootTreeTerminal(ctx, "root-1"); err != nil || !done {
+		t.Fatalf("rootTreeTerminal with all children terminal = (%v, %v), want (true, nil)", done, err)
+	}
+
+	// A cancelled job counts as terminal.
+	mustCreate("child-c", string(workflow.JobCancelled), workflow.JobPayload{RootJobID: "root-1"})
+	if done, err := worker.rootTreeTerminal(ctx, "root-1"); err != nil || !done {
+		t.Fatalf("rootTreeTerminal with a cancelled child = (%v, %v), want (true, nil)", done, err)
+	}
+
+	// An unknown root with no jobs is treated as terminal (already pruned).
+	if done, err := worker.rootTreeTerminal(ctx, "root-none"); err != nil || !done {
+		t.Fatalf("rootTreeTerminal for an empty root = (%v, %v), want (true, nil)", done, err)
+	}
+	// An empty root id is never terminal.
+	if done, _ := worker.rootTreeTerminal(ctx, ""); done {
+		t.Fatal("rootTreeTerminal for an empty root id must be false")
+	}
+}
+
+func TestCockpitJobStateTerminal(t *testing.T) {
+	terminal := []string{
+		string(workflow.JobSucceeded), string(workflow.JobFailed),
+		string(workflow.JobBlocked), string(workflow.JobCancelled),
+	}
+	for _, s := range terminal {
+		if !cockpitJobStateTerminal(s) {
+			t.Errorf("cockpitJobStateTerminal(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{string(workflow.JobQueued), string(workflow.JobRunning), "", "weird"} {
+		if cockpitJobStateTerminal(s) {
+			t.Errorf("cockpitJobStateTerminal(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestIsReconveneContinuation: a finalize continuation, a continuation that
+// returned no delegations, and a root coordinator with no children are reconvene
+// points; a coordinator that returned delegations is not.
+func TestIsReconveneContinuation(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worker := defaultJobWorker(store, io.Discard)
+
+	// finalize continuation -> reconvene.
+	if !worker.isReconveneContinuation(ctx, db.Job{ID: "fin"}, workflow.JobPayload{DelegationFinalize: true}) {
+		t.Fatal("finalize continuation must be a reconvene point")
+	}
+	// continuation (has parent) with no delegations -> reconvene.
+	if !worker.isReconveneContinuation(ctx, db.Job{ID: "cont"}, workflow.JobPayload{ParentJobID: "coord", Result: &workflow.AgentResult{}}) {
+		t.Fatal("a childless continuation must be a reconvene point")
+	}
+	// continuation that returned delegations -> NOT reconvene.
+	withDel := workflow.JobPayload{ParentJobID: "coord", Result: &workflow.AgentResult{Delegations: []workflow.Delegation{{ID: "d1", Agent: "x", Action: "implement", Prompt: "go"}}}}
+	if worker.isReconveneContinuation(ctx, db.Job{ID: "cont2"}, withDel) {
+		t.Fatal("a continuation that returned delegations is not a reconvene point")
+	}
+	// root coordinator with NO children -> reconvene.
+	if err := store.CreateJob(ctx, db.Job{ID: "root-solo", Agent: "a", Type: "ask", State: string(workflow.JobSucceeded), Payload: cockpitTestJobPayload(t, workflow.JobPayload{})}); err != nil {
+		t.Fatal(err)
+	}
+	if !worker.isReconveneContinuation(ctx, db.Job{ID: "root-solo"}, workflow.JobPayload{}) {
+		t.Fatal("a childless root coordinator must be a reconvene point")
+	}
+	// root coordinator WITH a child -> not reconvene (the children, not this job,
+	// carry the work; the terminal continuation is the reconvene point).
+	if err := store.CreateJob(ctx, db.Job{ID: "root-par", Agent: "a", Type: "ask", State: string(workflow.JobSucceeded), Payload: cockpitTestJobPayload(t, workflow.JobPayload{})}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: "child-1", Agent: "a", Type: "implement", State: string(workflow.JobSucceeded), ParentJobID: "root-par", Payload: cockpitTestJobPayload(t, workflow.JobPayload{RootJobID: "root-par", ParentJobID: "root-par"})}); err != nil {
+		t.Fatal(err)
+	}
+	if worker.isReconveneContinuation(ctx, db.Job{ID: "root-par"}, workflow.JobPayload{}) {
+		t.Fatal("a root coordinator with children is not itself the reconvene point")
+	}
+}
+
+// TestCockpitSeatLogAdapterAppends: seat mode uses a STABLE per-seat append log so
+// the seat's pane tails one accumulating file across rounds. The path is
+// <home>/logs/seats/<rootShort>/<seatSlug>.log, opened O_APPEND (prior output is
+// preserved, not truncated), and the adapter tees the child's stdout into it.
+func TestCockpitSeatLogAdapterAppends(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GITMOOT_HOME", home)
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
+	cp := cockpit.New(cockpit.Options{HerdrBin: "herdr-does-not-exist-for-tests", PaneKeyMode: config.CockpitPaneKeySeat}, nil)
+
+	wantPath := cp.SeatLogPath("root-seat", "builder")
+	if wantPath == "" {
+		t.Fatal("expected a non-empty seat-log path with GITMOOT_HOME set")
+	}
+	// Pre-seed prior-round history that the append log must preserve.
+	if err := os.MkdirAll(filepath.Dir(wantPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wantPath, []byte("ROUND1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := runtime.Agent{Name: "builder", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "echo ROUND2"}
+	adapter, logPath, logFile := worker.cockpitSeatLogAdapter(cp, agent, t.TempDir(), "job-r2", "root-seat", "builder")
+	if logFile == nil {
+		t.Fatal("expected a non-nil seat log file")
+	}
+	defer logFile.Close()
+	if logPath != wantPath {
+		t.Fatalf("seat logPath = %q, want %q", logPath, wantPath)
+	}
+
+	if _, err := adapter.Deliver(context.Background(), agent, runtime.Job{Prompt: "go"}); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	logged, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read seat log: %v", err)
+	}
+	got := string(logged)
+	if !strings.Contains(got, "ROUND1") {
+		t.Fatalf("seat log must preserve prior-round history (append, not truncate); got: %q", got)
+	}
+	if !strings.Contains(got, "ROUND2") {
+		t.Fatalf("seat log must contain this round's teed output; got: %q", got)
+	}
+
+	// The seat-log adapter carries a group-kill-preserving TeeRunner (result capture
+	// unchanged).
+	shell, ok := adapter.(runtime.ShellAdapter)
+	if !ok {
+		t.Fatalf("adapter type = %T, want runtime.ShellAdapter", adapter)
+	}
+	tee, ok := shell.Runner.(subprocess.TeeRunner)
+	if !ok {
+		t.Fatalf("adapter Runner = %T, want subprocess.TeeRunner", shell.Runner)
+	}
+	if _, ok := tee.Inner.(subprocess.GroupRunner); !ok {
+		t.Fatalf("tee inner = %T, want subprocess.GroupRunner", tee.Inner)
+	}
+}
+
+// TestCockpitSeatLogAdapterFailOpenNoHome: with no resolvable home, the seat-log
+// path is empty and the adapter falls back to the P0 pane (nil file) — fail-open.
+func TestCockpitSeatLogAdapterFailOpenNoHome(t *testing.T) {
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard)
+	// An empty GITMOOT_HOME makes the cockpit's home empty, so SeatLogPath returns "".
+	t.Setenv("GITMOOT_HOME", "")
+	cp := cockpit.New(cockpit.Options{HerdrBin: "herdr-does-not-exist-for-tests", PaneKeyMode: config.CockpitPaneKeySeat}, nil)
+	agent := runtime.Agent{Name: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "true"}
+	adapter, logPath, logFile := worker.cockpitSeatLogAdapter(cp, agent, t.TempDir(), "job-x", "root-seat", "builder")
+	if adapter != nil || logPath != "" || logFile != nil {
+		t.Fatalf("expected fail-open nils with no home, got adapter=%v path=%q file=%v", adapter, logPath, logFile)
+	}
+}
+
+// TestCockpitLogAdapterPicksLogPerMode: job mode uses the per-job truncate log
+// (<home>/logs/jobs/<jobid>.log); seat mode uses the stable per-seat append log
+// (<home>/logs/seats/<rootShort>/<seatSlug>.log). The dispatch is what keeps job
+// mode byte-identical to P1.
+func TestCockpitLogAdapterPicksLogPerMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GITMOOT_HOME", home)
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
+	cp := cockpit.New(cockpit.Options{HerdrBin: "herdr-does-not-exist-for-tests", PaneKeyMode: config.CockpitPaneKeySeat}, nil)
+	agent := runtime.Agent{Name: "builder", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "true"}
+
+	// Job mode -> per-job log under logs/jobs.
+	_, jobLog, jobFile := worker.cockpitLogAdapter(cp, agent, t.TempDir(), "job-1", "root-1", "builder", false)
+	if jobFile == nil {
+		t.Fatal("job-mode log file is nil")
+	}
+	jobFile.Close()
+	wantJob := filepath.Join(config.PathsForHome(home).Logs, "jobs", "job-1.log")
+	if jobLog != wantJob {
+		t.Fatalf("job-mode log = %q, want %q", jobLog, wantJob)
+	}
+
+	// Seat mode -> stable per-seat log under logs/seats/<rootShort>.
+	_, seatLog, seatFile := worker.cockpitLogAdapter(cp, agent, t.TempDir(), "job-1", "root-1", "builder", true)
+	if seatFile == nil {
+		t.Fatal("seat-mode log file is nil")
+	}
+	seatFile.Close()
+	wantSeat := cp.SeatLogPath("root-1", "builder")
+	if seatLog != wantSeat {
+		t.Fatalf("seat-mode log = %q, want %q", seatLog, wantSeat)
+	}
+	if !strings.Contains(seatLog, filepath.Join("logs", "seats")) {
+		t.Fatalf("seat-mode log %q is not under logs/seats", seatLog)
 	}
 }

--- a/internal/cli/daemon_cockpit_test.go
+++ b/internal/cli/daemon_cockpit_test.go
@@ -444,14 +444,16 @@ func TestRootTreeTerminal(t *testing.T) {
 func TestCockpitJobStateTerminal(t *testing.T) {
 	terminal := []string{
 		string(workflow.JobSucceeded), string(workflow.JobFailed),
-		string(workflow.JobBlocked), string(workflow.JobCancelled),
+		string(workflow.JobCancelled),
 	}
 	for _, s := range terminal {
 		if !cockpitJobStateTerminal(s) {
 			t.Errorf("cockpitJobStateTerminal(%q) = false, want true", s)
 		}
 	}
-	for _, s := range []string{string(workflow.JobQueued), string(workflow.JobRunning), "", "weird"} {
+	// JobBlocked is NOT terminal: a blocked job can resume, so finalizing the root
+	// (closing panes + removing seat logs) while blocked would be premature.
+	for _, s := range []string{string(workflow.JobQueued), string(workflow.JobRunning), string(workflow.JobBlocked), "", "weird"} {
 		if cockpitJobStateTerminal(s) {
 			t.Errorf("cockpitJobStateTerminal(%q) = true, want false", s)
 		}

--- a/internal/cockpit/cockpit.go
+++ b/internal/cockpit/cockpit.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -72,7 +73,16 @@ type Pane struct {
 type PaneStore interface {
 	InsertCockpitPane(ctx context.Context, pane Pane) error
 	GetCockpitPaneByJob(ctx context.Context, jobID string) (Pane, error)
+	// GetCockpitPaneByKey returns the live pane for a (workspaceID, paneKey) seat,
+	// if one exists. The bool reports found; a not-found row is (Pane{}, false, nil)
+	// — never a surfaced sql.ErrNoRows — so the seat-reuse fail-open path can treat
+	// "no pane yet" as a clean miss rather than an error. (Task 7, seat mode.)
+	GetCockpitPaneByKey(ctx context.Context, workspaceID, paneKey string) (Pane, bool, error)
 	ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([]Pane, error)
+	// ListAllCockpitPanes returns every recorded pane across all roots. The
+	// reconcile GC uses it to find orphaned rows (pane gone from herdr + owning
+	// root terminal). (Task 7, reconcile.)
+	ListAllCockpitPanes(ctx context.Context) ([]Pane, error)
 	DeleteCockpitPane(ctx context.Context, id string) error
 	DeleteCockpitPaneByJob(ctx context.Context, jobID string) error
 	// GetOrCreateWorkspaceForRoot serializes one workspace per root: create is
@@ -90,6 +100,13 @@ type Options struct {
 	MaxPanes int
 	// PaneKeyMode is "job" (P0) or "seat" (P2).
 	PaneKeyMode string
+	// GraceClose delays the per-Deliver pane teardown in JOB mode so the last
+	// output stays readable instead of vanishing the instant a child finishes
+	// (Task 8). It is non-blocking: the close fires from a detached goroutine after
+	// the grace, so the job never waits on it. A non-positive value defaults to
+	// defaultGraceClose; seat mode ignores it (those panes persist until root
+	// finalize).
+	GraceClose time.Duration
 }
 
 // JobMeta describes the delegation job a pane is opened for. The fields are
@@ -136,6 +153,12 @@ type Cockpit struct {
 	availAt     time.Time
 	// now is the clock used for TTL expiry; overridable in tests.
 	now func() time.Time
+
+	// removeAll / sleepAfter back the seat-log teardown and grace-close timing;
+	// they default to os.RemoveAll / time.AfterFunc and are overridable in tests so
+	// the filesystem and timer behavior can be asserted deterministically.
+	removeAll  func(string) error
+	sleepAfter func(time.Duration, func()) *time.Timer
 }
 
 // New builds a Cockpit. A zero HerdrBin defaults to "herdr"; a non-positive
@@ -162,6 +185,8 @@ func New(opts Options, store PaneStore) *Cockpit {
 		home:       os.Getenv("GITMOOT_HOME"),
 		logger:     slog.Default(),
 		now:        time.Now,
+		removeAll:  os.RemoveAll,
+		sleepAfter: time.AfterFunc,
 	}
 }
 
@@ -186,10 +211,30 @@ func newWithRunner(opts Options, store PaneStore, run runner, lookPath func(stri
 		home:       "",
 		logger:     slog.Default(),
 		now:        time.Now,
+		removeAll:  os.RemoveAll,
+		// Tests run the grace-close synchronously so the job-mode teardown sequence
+		// is observable inline (production uses the real time.AfterFunc timer).
+		sleepAfter: syncAfterFunc,
 	}
 }
 
+// syncAfterFunc runs fn immediately and returns a stopped timer. It is the
+// test-constructor's sleepAfter so the grace-close teardown is deterministic and
+// inline rather than firing on a real timer.
+func syncAfterFunc(_ time.Duration, fn func()) *time.Timer {
+	fn()
+	t := time.NewTimer(0)
+	t.Stop()
+	return t
+}
+
 const defaultMaxPanes = 4
+
+// defaultGraceClose is the default delay before a JOB-mode pane is torn down on
+// Deliver return (Task 8). It keeps the child's last output readable for a beat
+// rather than vanishing the instant the job finishes. The close runs detached so
+// the job never blocks on the grace.
+const defaultGraceClose = 8 * time.Second
 
 // Available reports whether the cockpit can render panes: the herdr binary is
 // on PATH and `herdr status` reports the server running. It is timeout-bounded
@@ -244,16 +289,26 @@ type paneAdapter struct {
 func (a *paneAdapter) Deliver(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
 	pane := a.open(ctx)
 	if pane != "" {
-		defer a.close(pane)
+		// Seat mode: the pane persists for reuse across the seat's rounds — the
+		// delivery only marks the agent idle on return; the pane (and its row,
+		// workspace, seat log) is torn down on ROOT FINALIZE, not here (Task 7).
+		// Job mode: tear the pane down per delivery as in P0/P1, but after a short
+		// grace so the last output stays readable (Task 8).
+		if a.cockpit.seatMode() {
+			defer a.markIdle(pane)
+		} else {
+			defer a.cockpit.graceClose(pane, a.meta.JobID)
+		}
 	}
 	return a.inner.Deliver(ctx, agent, job)
 }
 
-// open resolves the per-root workspace, splits a child pane, labels it, marks
-// the agent working, runs the job-watch command, and persists the pane. It
-// returns the new pane id, or "" when no pane was opened (over MaxPanes, herdr
-// error, or missing root). Every failure is swallowed (fail-closed on the
-// pane) so delivery proceeds unwrapped.
+// open resolves the per-root workspace and either reuses the seat's existing pane
+// (seat mode) or splits a fresh child pane (job mode / first seat open), labels
+// it, marks the agent working, runs the watch command, and persists the pane. It
+// returns the pane id, or "" when no pane was opened (over MaxPanes, herdr error,
+// or missing root). Every failure is swallowed (fail-closed on the pane) so
+// delivery proceeds unwrapped.
 func (a *paneAdapter) open(ctx context.Context) string {
 	c := a.cockpit
 	rootJob := a.meta.RootJobID
@@ -261,12 +316,45 @@ func (a *paneAdapter) open(ctx context.Context) string {
 		rootJob = a.meta.JobID
 	}
 
-	// Honor MaxPanes: beyond the cap the job is status-only (no pane).
-	if existing, err := c.store.ListCockpitPanesByRoot(ctx, rootJob); err == nil {
-		if len(existing) >= c.opts.MaxPanes {
-			c.logf("cockpit: max panes reached for root %s; status-only", rootJob)
-			return ""
+	source := herdrSource
+	agentLabel := "gm-" + shortJobID(a.meta.JobID)
+
+	// List the root's panes once: seat mode uses it to find a seat to reuse, and
+	// both modes use it for the MaxPanes cap. Doing this BEFORE resolving the
+	// workspace keeps job mode byte-identical to P0/P1 (the cap is checked before
+	// any `workspace create`).
+	existing, listErr := c.store.ListCockpitPanesByRoot(ctx, rootJob)
+	if listErr != nil {
+		c.logf("cockpit: list panes for root %s: %v", rootJob, listErr)
+	}
+
+	// Seat mode: reuse an existing live pane for this seat (pane_key) instead of
+	// splitting a new one. The same agent across delegation rounds shares one pane
+	// that tails one accumulating seat log, so there is no second split and no
+	// second row. A reuse is NOT a new pane, so it bypasses the MaxPanes cap (the
+	// cap bounds distinct seats, enforced on the split path below).
+	if c.seatMode() {
+		for _, p := range existing {
+			if p.PaneKey == a.paneKey() && p.PaneID != "" {
+				c.bestEffort(ctx, "report-agent working", func(cctx context.Context) error {
+					return c.client.reportAgent(cctx, p.PaneID, source, agentLabel, agentStateWorking)
+				})
+				// Ensure the seat's pane is tailing its accumulating log. The seat log
+				// is the same file across rounds (O_APPEND, daemon-managed), so
+				// re-running the tail is idempotent and survives a pane that was
+				// started before the log existed.
+				c.bestEffort(ctx, "pane run", func(cctx context.Context) error {
+					return c.client.paneRun(cctx, p.PaneID, a.watchCommand())
+				})
+				return p.PaneID
+			}
 		}
+	}
+
+	// Honor MaxPanes: a fresh split beyond the cap is status-only (no pane).
+	if len(existing) >= c.opts.MaxPanes {
+		c.logf("cockpit: max panes reached for root %s; status-only", rootJob)
+		return ""
 	}
 
 	workspaceID, err := c.store.GetOrCreateWorkspaceForRoot(ctx, rootJob, func() (string, error) {
@@ -290,10 +378,6 @@ func (a *paneAdapter) open(ctx context.Context) string {
 		return ""
 	}
 
-	source := herdrSource
-	shortID := shortJobID(a.meta.JobID)
-	agentLabel := "gm-" + shortID
-
 	// Label + status + watch are best-effort; a failure here still yields a
 	// usable pane, so we keep it and persist it.
 	c.bestEffort(ctx, "rename", func(cctx context.Context) error {
@@ -315,32 +399,79 @@ func (a *paneAdapter) open(ctx context.Context) string {
 		Source:      source,
 	}
 	if err := c.store.InsertCockpitPane(ctx, record); err != nil {
+		// A UNIQUE(workspace_id, pane_key) violation means a concurrent same-seat
+		// open already persisted the seat's pane (the get-or-create convergence the
+		// frozen contract guarantees). In seat mode that is the expected race: the
+		// pane we just split is the redundant loser, so close it and reuse the
+		// winner's pane so the seat stays a single pane. In job mode the key is the
+		// (unique) job id, so this only fires on a genuine re-run and is harmless.
 		c.logf("cockpit: persist pane for job %s: %v", a.meta.JobID, err)
+		if c.seatMode() {
+			if winner, found, lookErr := c.store.GetCockpitPaneByKey(ctx, workspaceID, a.paneKey()); lookErr == nil && found && winner.PaneID != "" && winner.PaneID != paneID {
+				c.bestEffort(ctx, "pane close", func(cctx context.Context) error {
+					return c.client.paneClose(cctx, paneID)
+				})
+				return winner.PaneID
+			}
+		}
 		// The pane is open and useful even if persistence failed; keep it.
 	}
 	return paneID
 }
 
-// close marks the agent idle, releases it, and closes the pane — all
-// best-effort. Workspace close is deferred to root-finalize (P2), not here.
-func (a *paneAdapter) close(paneID string) {
+// markIdle reports the agent idle on a seat pane without closing it (seat mode):
+// the pane persists for reuse and is torn down only on root finalize. It is the
+// seat-mode analogue of close()'s first step.
+func (a *paneAdapter) markIdle(paneID string) {
 	c := a.cockpit
-	source := herdrSource
-	agentLabel := "gm-" + shortJobID(a.meta.JobID)
-	ctx := context.Background()
-
-	c.bestEffort(ctx, "report-agent idle", func(cctx context.Context) error {
-		return c.client.reportAgent(cctx, paneID, source, agentLabel, agentStateIdle)
+	c.bestEffort(context.Background(), "report-agent idle", func(cctx context.Context) error {
+		return c.client.reportAgent(cctx, paneID, herdrSource, "gm-"+shortJobID(a.meta.JobID), agentStateIdle)
 	})
+}
+
+// graceClose schedules a JOB-mode pane teardown after the configured grace so the
+// child's last output stays readable, then marks idle, releases, closes, and
+// deletes the row — all best-effort. The agent is marked idle immediately (so a
+// finished job never reads as "working" during the grace) and the actual close
+// fires from a detached timer, so the job never blocks on the grace window. The
+// per-job log only backs the live tail and is the daemon's to remove.
+func (c *Cockpit) graceClose(paneID, jobID string) {
+	// Mark idle now: a finished child must not read as "working" while its pane
+	// lingers during the grace window.
+	c.bestEffort(context.Background(), "report-agent idle", func(cctx context.Context) error {
+		return c.client.reportAgent(cctx, paneID, herdrSource, "gm-"+shortJobID(jobID), agentStateIdle)
+	})
+	grace := c.opts.GraceClose
+	if grace <= 0 {
+		grace = defaultGraceClose
+	}
+	after := c.sleepAfter
+	if after == nil {
+		after = time.AfterFunc
+	}
+	after(grace, func() { c.teardownJobPane(paneID, jobID) })
+}
+
+// teardownJobPane releases the agent, closes the pane, and deletes its row by job
+// id — the JOB-mode teardown body, run after the grace. All steps best-effort.
+func (c *Cockpit) teardownJobPane(paneID, jobID string) {
+	ctx := context.Background()
 	c.bestEffort(ctx, "release-agent", func(cctx context.Context) error {
-		return c.client.releaseAgent(cctx, paneID, source, agentLabel)
+		return c.client.releaseAgent(cctx, paneID, herdrSource, "gm-"+shortJobID(jobID))
 	})
 	c.bestEffort(ctx, "pane close", func(cctx context.Context) error {
 		return c.client.paneClose(cctx, paneID)
 	})
-	if err := c.store.DeleteCockpitPaneByJob(ctx, a.meta.JobID); err != nil {
-		c.logf("cockpit: delete pane record for job %s: %v", a.meta.JobID, err)
+	if err := c.store.DeleteCockpitPaneByJob(ctx, jobID); err != nil {
+		c.logf("cockpit: delete pane record for job %s: %v", jobID, err)
 	}
+}
+
+// seatMode reports whether the cockpit keys panes by logical seat (Task 7) rather
+// than by job (P0). It centralizes the mode check so the open/Deliver/finalize
+// paths stay in lockstep.
+func (c *Cockpit) seatMode() bool {
+	return c != nil && c.opts.PaneKeyMode == PaneKeyModeSeat
 }
 
 // paneKey returns the pane's dedup key. In P0 (job mode) it is the job id; the
@@ -417,4 +548,226 @@ func (c *Cockpit) logf(format string, args ...any) {
 	if c.logger != nil {
 		c.logger.Debug(fmt.Sprintf(format, args...))
 	}
+}
+
+// FinalizeRoot tears down every pane opened under one orchestration root when its
+// coordination tree terminates (Task 7, seat mode): it closes each pane (and its
+// workspace), deletes the rows, and removes the root's seat-log directory. It is
+// the seat-mode teardown — job-mode panes already close per-Deliver — and is
+// idempotent and entirely best-effort: a finalize on a root with no panes (job
+// mode, or already finalized) is a cheap no-op, and a herdr/store failure on one
+// pane never blocks finalizing the rest. The daemon calls it once when the root's
+// tree reaches a terminal state.
+func (c *Cockpit) FinalizeRoot(ctx context.Context, rootJobID string) {
+	if c == nil {
+		return
+	}
+	rootJobID = strings.TrimSpace(rootJobID)
+	if rootJobID == "" {
+		return
+	}
+	panes, err := c.store.ListCockpitPanesByRoot(ctx, rootJobID)
+	if err != nil {
+		c.logf("cockpit: finalize root %s list panes: %v", rootJobID, err)
+		return
+	}
+	workspaces := map[string]struct{}{}
+	for _, pane := range panes {
+		if pane.PaneID != "" {
+			c.bestEffort(ctx, "report-agent idle", func(cctx context.Context) error {
+				return c.client.reportAgent(cctx, pane.PaneID, herdrSource, "gm-"+shortJobID(pane.JobID), agentStateIdle)
+			})
+			c.bestEffort(ctx, "release-agent", func(cctx context.Context) error {
+				return c.client.releaseAgent(cctx, pane.PaneID, herdrSource, "gm-"+shortJobID(pane.JobID))
+			})
+			c.bestEffort(ctx, "pane close", func(cctx context.Context) error {
+				return c.client.paneClose(cctx, pane.PaneID)
+			})
+		}
+		if pane.WorkspaceID != "" {
+			workspaces[pane.WorkspaceID] = struct{}{}
+		}
+		if pane.ID != "" {
+			if err := c.store.DeleteCockpitPane(ctx, pane.ID); err != nil {
+				c.logf("cockpit: finalize root %s delete pane %s: %v", rootJobID, pane.ID, err)
+			}
+		} else if pane.JobID != "" {
+			if err := c.store.DeleteCockpitPaneByJob(ctx, pane.JobID); err != nil {
+				c.logf("cockpit: finalize root %s delete pane for job %s: %v", rootJobID, pane.JobID, err)
+			}
+		}
+	}
+	for workspaceID := range workspaces {
+		c.bestEffort(ctx, "workspace close", func(cctx context.Context) error {
+			return c.client.workspaceClose(cctx, workspaceID)
+		})
+	}
+	// Remove the root's seat-log directory: the accumulating per-seat logs only
+	// backed the live tails, which are now closed, so they persist no longer than
+	// the root's life.
+	if dir := c.seatLogRootDir(rootJobID); dir != "" {
+		remove := c.removeAll
+		if remove == nil {
+			remove = os.RemoveAll
+		}
+		if err := remove(dir); err != nil {
+			c.logf("cockpit: finalize root %s remove seat logs %s: %v", rootJobID, dir, err)
+		}
+	}
+}
+
+// FocusRoot surfaces the orchestration root's workspace (Task 8, coordinator
+// reconvene): on the coordinator's terminal continuation the daemon calls this so
+// the reconvene view — where the coordinator pane already shows the synthesized
+// verdict, since its continuation shares the coordinator seat — is brought
+// forward. It uses `herdr workspace focus <workspace_id>` (herdr has no
+// focus-pane-by-id verb, only the directional `pane focus`, so workspace focus is
+// the closest supported reconvene gesture). Best-effort: any failure (no live
+// workspace, herdr down) is swallowed.
+func (c *Cockpit) FocusRoot(ctx context.Context, rootJobID string) {
+	if c == nil {
+		return
+	}
+	rootJobID = strings.TrimSpace(rootJobID)
+	if rootJobID == "" {
+		return
+	}
+	panes, err := c.store.ListCockpitPanesByRoot(ctx, rootJobID)
+	if err != nil || len(panes) == 0 {
+		if err != nil {
+			c.logf("cockpit: focus root %s list panes: %v", rootJobID, err)
+		}
+		return
+	}
+	workspaceID := ""
+	for _, pane := range panes {
+		if pane.WorkspaceID != "" {
+			workspaceID = pane.WorkspaceID
+			break
+		}
+	}
+	if workspaceID == "" {
+		return
+	}
+	c.bestEffort(ctx, "workspace focus", func(cctx context.Context) error {
+		return c.client.workspaceFocus(cctx, workspaceID)
+	})
+}
+
+// Reconcile is the low-frequency GC sweep (Task 7): it drops cockpit_pane rows
+// whose herdr pane is gone AND whose owning root job is terminal, so orphaned
+// rows (a daemon crash before teardown, a pane the user closed) do not accumulate.
+// It pairs with report-metadata --ttl-ms self-expiry on the herdr side. It is
+// cheap and entirely best-effort — every error is swallowed and the sweep simply
+// skips that row. rootTerminal reports whether a root's coordination tree has
+// fully terminated (the daemon supplies it from job state); a nil rootTerminal
+// treats every root as non-terminal, so nothing is dropped.
+func (c *Cockpit) Reconcile(ctx context.Context, rootTerminal func(rootJobID string) bool) {
+	if c == nil || rootTerminal == nil {
+		return
+	}
+	panes, err := c.store.ListAllCockpitPanes(ctx)
+	if err != nil {
+		c.logf("cockpit: reconcile list panes: %v", err)
+		return
+	}
+	if len(panes) == 0 {
+		return
+	}
+	live, ok := c.livePaneIDs(ctx)
+	if !ok {
+		// Could not enumerate live panes (herdr down / parse error): do nothing
+		// rather than risk dropping rows for panes that are actually alive.
+		return
+	}
+	terminalCache := map[string]bool{}
+	for _, pane := range panes {
+		if _, alive := live[pane.PaneID]; alive && pane.PaneID != "" {
+			continue
+		}
+		terminal, cached := terminalCache[pane.RootJobID]
+		if !cached {
+			terminal = rootTerminal(pane.RootJobID)
+			terminalCache[pane.RootJobID] = terminal
+		}
+		if !terminal {
+			continue
+		}
+		if pane.ID != "" {
+			if err := c.store.DeleteCockpitPane(ctx, pane.ID); err != nil {
+				c.logf("cockpit: reconcile delete pane %s: %v", pane.ID, err)
+			}
+		} else if pane.JobID != "" {
+			if err := c.store.DeleteCockpitPaneByJob(ctx, pane.JobID); err != nil {
+				c.logf("cockpit: reconcile delete pane for job %s: %v", pane.JobID, err)
+			}
+		}
+	}
+}
+
+// livePaneIDs returns the set of pane ids herdr currently reports (`herdr pane
+// list`). The bool is false when the list could not be obtained (herdr down /
+// parse error), so the reconcile caller can skip dropping rows rather than risk
+// removing live panes.
+func (c *Cockpit) livePaneIDs(ctx context.Context) (map[string]struct{}, bool) {
+	cctx, cancel := context.WithTimeout(ctx, herdrCallTimeout)
+	defer cancel()
+	ids, err := c.client.paneList(cctx)
+	if err != nil {
+		c.logf("cockpit: reconcile pane list: %v", err)
+		return nil, false
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set, true
+}
+
+// SeatLogPath returns the stable per-seat append-log path for a (root, paneKey)
+// seat: <home>/logs/seats/<rootShort>/<seatSlug>.log. In seat mode the daemon
+// opens this O_APPEND (not per-job O_TRUNC) so the seat's one pane tails one file
+// that accumulates the seat's output across delegation rounds — no tail
+// re-pointing needed. It returns "" when home is unset so the caller falls back
+// to the P0 pane. paneKey is slugified so an agent name with path-unsafe
+// characters cannot escape the seat-log directory.
+func (c *Cockpit) SeatLogPath(rootJobID, paneKey string) string {
+	dir := c.seatLogRootDir(rootJobID)
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, seatSlug(paneKey)+".log")
+}
+
+// seatLogRootDir is the per-root seat-log directory removed on finalize:
+// <home>/logs/seats/<rootShort>. It returns "" when home is unset.
+func (c *Cockpit) seatLogRootDir(rootJobID string) string {
+	if c == nil || c.home == "" {
+		return ""
+	}
+	return filepath.Join(c.home, "logs", "seats", shortJobID(rootJobID))
+}
+
+// seatSlug maps a pane key (e.g. an agent name) to a filesystem-safe slug for the
+// seat-log filename. Any character outside [A-Za-z0-9._-] becomes '_', so a key
+// like "owner/repo" or "" cannot traverse out of the seat-log directory.
+func seatSlug(key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "seat"
+	}
+	var b strings.Builder
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "seat"
+	}
+	return out
 }

--- a/internal/cockpit/cockpit_test.go
+++ b/internal/cockpit/cockpit_test.go
@@ -3,6 +3,9 @@ package cockpit
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -35,7 +38,9 @@ func newFakeRunner() *fakeRunner {
 		"pane run":           {stdout: `{}`},
 		"pane release-agent": {stdout: `{}`},
 		"pane close":         {stdout: `{}`},
+		"pane list":          {stdout: `{"result":{"panes":[]}}`},
 		"workspace close":    {stdout: `{}`},
+		"workspace focus":    {stdout: `{}`},
 	}}
 }
 
@@ -86,13 +91,18 @@ func okLookPath(string) (string, error) { return "/usr/bin/herdr", nil }
 
 func failLookPath(string) (string, error) { return "", errors.New("not found") }
 
-// fakeStore is an in-memory PaneStore with a one-workspace-per-root registry.
+// fakeStore is an in-memory PaneStore with a one-workspace-per-root registry. It
+// enforces UNIQUE(workspace_id, pane_key) on insert (like the real store) so the
+// seat-reuse convergence can be asserted, and assigns a generated ID to each row
+// so reconcile/finalize (which address panes by ID) round-trip.
 type fakeStore struct {
 	mu         sync.Mutex
 	panes      map[string]Pane // keyed by job id
 	workspaces map[string]string
 	createN    int
 	insertErr  error
+	byKeyErr   error
+	nextID     int
 }
 
 func newFakeStore() *fakeStore {
@@ -105,6 +115,17 @@ func (s *fakeStore) InsertCockpitPane(_ context.Context, pane Pane) error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Enforce UNIQUE(workspace_id, pane_key): a second open for the same seat is a
+	// duplicate the cockpit treats as "pane already exists, reuse it".
+	for _, p := range s.panes {
+		if p.WorkspaceID == pane.WorkspaceID && p.PaneKey == pane.PaneKey {
+			return errors.New("UNIQUE constraint failed: cockpit_panes.workspace_id, cockpit_panes.pane_key")
+		}
+	}
+	if pane.ID == "" {
+		s.nextID++
+		pane.ID = "pane-id-" + strconv.Itoa(s.nextID)
+	}
 	s.panes[pane.JobID] = pane
 	return nil
 }
@@ -119,6 +140,20 @@ func (s *fakeStore) GetCockpitPaneByJob(_ context.Context, jobID string) (Pane, 
 	return p, nil
 }
 
+func (s *fakeStore) GetCockpitPaneByKey(_ context.Context, workspaceID, paneKey string) (Pane, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.byKeyErr != nil {
+		return Pane{}, false, s.byKeyErr
+	}
+	for _, p := range s.panes {
+		if p.WorkspaceID == workspaceID && p.PaneKey == paneKey {
+			return p, true, nil
+		}
+	}
+	return Pane{}, false, nil
+}
+
 func (s *fakeStore) ListCockpitPanesByRoot(_ context.Context, rootJobID string) ([]Pane, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -127,6 +162,16 @@ func (s *fakeStore) ListCockpitPanesByRoot(_ context.Context, rootJobID string) 
 		if p.RootJobID == rootJobID {
 			out = append(out, p)
 		}
+	}
+	return out, nil
+}
+
+func (s *fakeStore) ListAllCockpitPanes(_ context.Context) ([]Pane, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Pane, 0, len(s.panes))
+	for _, p := range s.panes {
+		out = append(out, p)
 	}
 	return out, nil
 }
@@ -596,6 +641,343 @@ func TestShortJobID(t *testing.T) {
 	for in, want := range cases {
 		if got := shortJobID(in); got != want {
 			t.Errorf("shortJobID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// countVerb counts how many times a verb key appears in the runner's call log.
+func countVerb(fr *fakeRunner, verb string) int {
+	n := 0
+	for _, v := range fr.verbs() {
+		if v == verb {
+			n++
+		}
+	}
+	return n
+}
+
+// seatMeta is a seat-mode JobMeta: the same seat (pane_key) shared across rounds
+// by distinct jobs under one root.
+func seatMeta(jobID, paneKey string) JobMeta {
+	return JobMeta{
+		JobID:     jobID,
+		RootJobID: "root-seat",
+		Agent:     "builder",
+		Action:    "implement",
+		Branch:    "feat/x",
+		Worktree:  "/tmp/wt",
+		PaneKey:   paneKey,
+		Depth:     1,
+	}
+}
+
+// TestSeatModeReusesPaneAcrossRounds: in seat mode, two deliveries on the SAME
+// seat (pane_key) under one root split exactly one pane (the first), then reuse
+// it — no second `pane split`, no second `workspace create`, and the seat row
+// persists (it is NOT deleted per-Deliver as job mode does).
+func TestSeatModeReusesPaneAcrossRounds(t *testing.T) {
+	fr := newFakeRunner()
+	store := newFakeStore()
+	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, store, fr.run, okLookPath)
+
+	round1 := c.Wrap(&fakeInner{}, seatMeta("job-r1", "builder"))
+	if _, err := round1.Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatalf("round 1: %v", err)
+	}
+	round2 := c.Wrap(&fakeInner{}, seatMeta("job-r2", "builder"))
+	if _, err := round2.Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatalf("round 2: %v", err)
+	}
+
+	if got := countVerb(fr, "pane split"); got != 1 {
+		t.Fatalf("pane split count = %d, want 1 (seat reuse must not re-split); calls: %v", got, fr.calls)
+	}
+	if store.createN != 1 {
+		t.Fatalf("workspace created %d times, want 1 (one workspace per root)", store.createN)
+	}
+	if got := countVerb(fr, "pane close"); got != 0 {
+		t.Fatalf("pane close count = %d, want 0 (seat panes persist until root finalize)", got)
+	}
+	// The seat pane row persists for reuse (keyed by its first job's id here).
+	panes, _ := store.ListCockpitPanesByRoot(context.Background(), "root-seat")
+	if len(panes) != 1 {
+		t.Fatalf("seat rows = %d, want 1 (one row per seat); rows: %+v", len(panes), panes)
+	}
+	// On reuse the pane is re-marked working and the tail is (idempotently) re-run.
+	if got := countVerb(fr, "pane run"); got < 2 {
+		t.Fatalf("pane run count = %d, want >= 2 (reuse ensures the tail is running)", got)
+	}
+}
+
+// TestSeatModeDistinctSeatsSplitDistinctPanes: two different seats under one root
+// each get their own pane (one split each).
+func TestSeatModeDistinctSeatsSplitDistinctPanes(t *testing.T) {
+	fr := newFakeRunner()
+	fr.replies["pane split"] = reply{stdout: `{"result":{"pane":{"pane_id":"w1:pX"}}}`}
+	store := newFakeStore()
+	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, store, fr.run, okLookPath)
+
+	a := c.Wrap(&fakeInner{}, seatMeta("job-a", "builder"))
+	if _, err := a.Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatal(err)
+	}
+	b := c.Wrap(&fakeInner{}, seatMeta("job-b", "reviewer"))
+	if _, err := b.Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := countVerb(fr, "pane split"); got != 2 {
+		t.Fatalf("pane split count = %d, want 2 (distinct seats)", got)
+	}
+	panes, _ := store.ListCockpitPanesByRoot(context.Background(), "root-seat")
+	if len(panes) != 2 {
+		t.Fatalf("seat rows = %d, want 2", len(panes))
+	}
+}
+
+// TestSeatModeDeliverMarksIdleNotClosed: a seat-mode Deliver, on return, reports
+// the agent idle but never releases/closes the pane (that is root-finalize's job).
+func TestSeatModeDeliverMarksIdleNotClosed(t *testing.T) {
+	fr := newFakeRunner()
+	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, newFakeStore(), fr.run, okLookPath)
+	adapter := c.Wrap(&fakeInner{}, seatMeta("job-1", "builder"))
+	if _, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(fr.calls, "\n")
+	if !strings.Contains(joined, "--state idle") {
+		t.Fatalf("expected report-agent idle on seat-mode return; calls:\n%s", joined)
+	}
+	if countVerb(fr, "pane release-agent") != 0 || countVerb(fr, "pane close") != 0 {
+		t.Fatalf("seat-mode Deliver must not release/close the pane; calls: %v", fr.calls)
+	}
+}
+
+// TestSeatModeConvergesOnUniqueViolation: when the open-time root list misses the
+// seat (a racing open) but the insert then hits the UNIQUE(workspace_id,pane_key)
+// constraint, the loser closes the pane it split and converges on the winner's
+// pane (found via GetCockpitPaneByKey) — the seat stays one pane.
+func TestSeatModeConvergesOnUniqueViolation(t *testing.T) {
+	fr := newFakeRunner()
+	base := newFakeStore()
+	// Pre-seed the winning seat pane row (the race winner already persisted it).
+	base.workspaces["root-seat"] = "w1"
+	base.panes["winner-job"] = Pane{ID: "pane-id-win", JobID: "winner-job", PaneKey: "builder", RootJobID: "root-seat", PaneID: "w1:pWIN", WorkspaceID: "w1"}
+	// The wrapper hides the winner from the open-time root list (one-shot) so the
+	// loser proceeds to split + insert and hits the UNIQUE constraint; the row is
+	// still present for the insert constraint + the post-violation by-key lookup.
+	hiding := &hideThenShowStore{fakeStore: base}
+	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, hiding, fr.run, okLookPath)
+
+	adapter := c.Wrap(&fakeInner{}, seatMeta("loser-job", "builder"))
+	paneID := adapter.(*paneAdapter).open(context.Background())
+	if paneID != "w1:pWIN" {
+		t.Fatalf("loser must converge on the winner's pane, got %q", paneID)
+	}
+	// Still exactly one seat row (the loser's split pane was not persisted).
+	rows, _ := base.ListCockpitPanesByRoot(context.Background(), "root-seat")
+	if len(rows) != 1 {
+		t.Fatalf("seat rows after convergence = %d, want 1; rows: %+v", len(rows), rows)
+	}
+	if countVerb(fr, "pane close") == 0 {
+		t.Fatalf("loser must close its redundant pane on the UNIQUE violation; calls: %v", fr.calls)
+	}
+}
+
+// hideThenShowStore hides the seat row from the open-time root list (one-shot) but
+// still enforces UNIQUE on insert and reveals the row on the post-violation by-key
+// lookup, exercising the convergence-on-violation path.
+type hideThenShowStore struct {
+	*fakeStore
+	lists int
+}
+
+func (s *hideThenShowStore) ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([]Pane, error) {
+	s.lists++
+	if s.lists == 1 {
+		return nil, nil // hide the seat from the open-time reuse scan
+	}
+	return s.fakeStore.ListCockpitPanesByRoot(ctx, rootJobID)
+}
+
+// TestFinalizeRootClosesDeletesAndRemovesSeatLogs: FinalizeRoot closes every
+// pane under a root, closes the workspace, deletes the rows, and removes the
+// root's seat-log directory.
+func TestFinalizeRootClosesDeletesAndRemovesSeatLogs(t *testing.T) {
+	fr := newFakeRunner()
+	store := newFakeStore()
+	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, store, fr.run, okLookPath)
+	home := t.TempDir()
+	c.home = home
+
+	// Open two seats under the root.
+	for _, seat := range []struct{ job, key string }{{"job-a", "builder"}, {"job-b", "reviewer"}} {
+		fr.replies["pane split"] = reply{stdout: `{"result":{"pane":{"pane_id":"w1:` + seat.key + `"}}}`}
+		adapter := c.Wrap(&fakeInner{}, seatMeta(seat.job, seat.key))
+		if _, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Create the seat-log directory + files that finalize must remove.
+	seatDir := c.seatLogRootDir("root-seat")
+	if err := os.MkdirAll(seatDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(seatDir, "builder.log"), []byte("history"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c.FinalizeRoot(context.Background(), "root-seat")
+
+	if got := countVerb(fr, "pane close"); got != 2 {
+		t.Fatalf("pane close count = %d, want 2 (one per seat)", got)
+	}
+	if got := countVerb(fr, "workspace close"); got != 1 {
+		t.Fatalf("workspace close count = %d, want 1 (one per root workspace)", got)
+	}
+	rows, _ := store.ListCockpitPanesByRoot(context.Background(), "root-seat")
+	if len(rows) != 0 {
+		t.Fatalf("rows after finalize = %d, want 0; rows: %+v", len(rows), rows)
+	}
+	if _, err := os.Stat(seatDir); !os.IsNotExist(err) {
+		t.Fatalf("seat-log dir still exists after finalize: %v", err)
+	}
+}
+
+// TestFinalizeRootNoPanesIsNoop: finalizing a root with no panes (job mode, or
+// already finalized) is a cheap no-op with no herdr calls beyond the list.
+func TestFinalizeRootNoPanesIsNoop(t *testing.T) {
+	fr := newFakeRunner()
+	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, newFakeStore(), fr.run, okLookPath)
+	c.FinalizeRoot(context.Background(), "root-empty")
+	if countVerb(fr, "pane close") != 0 || countVerb(fr, "workspace close") != 0 {
+		t.Fatalf("finalize of an empty root must make no close calls; calls: %v", fr.calls)
+	}
+}
+
+// TestReconcileDropsOrphans: reconcile drops rows whose pane is gone from herdr
+// AND whose root is terminal; it keeps rows that are still live, and keeps rows
+// whose root is not terminal even if the pane is gone.
+func TestReconcileDropsOrphans(t *testing.T) {
+	fr := newFakeRunner()
+	// herdr reports only "w1:live" as a live pane.
+	fr.replies["pane list"] = reply{stdout: `{"result":{"panes":[{"pane_id":"w1:live"}]}}`}
+	store := newFakeStore()
+	// orphan-terminal: pane gone + root terminal -> dropped
+	store.panes["job-orphan"] = Pane{ID: "id-orphan", JobID: "job-orphan", PaneID: "w1:gone", RootJobID: "root-done", WorkspaceID: "w1"}
+	// live: pane present -> kept regardless of root state
+	store.panes["job-live"] = Pane{ID: "id-live", JobID: "job-live", PaneID: "w1:live", RootJobID: "root-done", WorkspaceID: "w1"}
+	// orphan-active: pane gone but root NOT terminal -> kept
+	store.panes["job-active"] = Pane{ID: "id-active", JobID: "job-active", PaneID: "w1:gone2", RootJobID: "root-busy", WorkspaceID: "w1"}
+
+	c := newWithRunner(Options{}, store, fr.run, okLookPath)
+	terminal := func(root string) bool { return root == "root-done" }
+	c.Reconcile(context.Background(), terminal)
+
+	all, _ := store.ListAllCockpitPanes(context.Background())
+	got := map[string]bool{}
+	for _, p := range all {
+		got[p.JobID] = true
+	}
+	if got["job-orphan"] {
+		t.Fatalf("orphan-terminal row should be dropped; remaining: %+v", all)
+	}
+	if !got["job-live"] {
+		t.Fatalf("live row should be kept; remaining: %+v", all)
+	}
+	if !got["job-active"] {
+		t.Fatalf("orphan under a non-terminal root should be kept; remaining: %+v", all)
+	}
+}
+
+// TestReconcileSkipsWhenPaneListUnavailable: if `herdr pane list` errors, reconcile
+// drops nothing (it must not remove rows for panes that may be alive).
+func TestReconcileSkipsWhenPaneListUnavailable(t *testing.T) {
+	fr := newFakeRunner()
+	fr.replies["pane list"] = reply{err: errors.New("herdr down")}
+	store := newFakeStore()
+	store.panes["job-orphan"] = Pane{ID: "id-orphan", JobID: "job-orphan", PaneID: "w1:gone", RootJobID: "root-done", WorkspaceID: "w1"}
+	c := newWithRunner(Options{}, store, fr.run, okLookPath)
+	c.Reconcile(context.Background(), func(string) bool { return true })
+	all, _ := store.ListAllCockpitPanes(context.Background())
+	if len(all) != 1 {
+		t.Fatalf("reconcile must not drop rows when pane list is unavailable; rows: %+v", all)
+	}
+}
+
+// TestFocusRootFocusesWorkspace: FocusRoot focuses the root's workspace (Task 8
+// reconvene). With no panes it is a no-op.
+func TestFocusRootFocusesWorkspace(t *testing.T) {
+	fr := newFakeRunner()
+	store := newFakeStore()
+	store.panes["coord"] = Pane{ID: "id-c", JobID: "coord", PaneID: "w7:pC", RootJobID: "root-x", WorkspaceID: "w7"}
+	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, store, fr.run, okLookPath)
+	c.FocusRoot(context.Background(), "root-x")
+	joined := strings.Join(fr.calls, "\n")
+	if !strings.Contains(joined, "workspace focus w7") {
+		t.Fatalf("expected `workspace focus w7`; calls:\n%s", joined)
+	}
+
+	fr2 := newFakeRunner()
+	c2 := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, newFakeStore(), fr2.run, okLookPath)
+	c2.FocusRoot(context.Background(), "root-none")
+	if countVerb(fr2, "workspace focus") != 0 {
+		t.Fatalf("focus with no panes must be a no-op; calls: %v", fr2.calls)
+	}
+}
+
+// TestJobModeGraceCloseStillTearsDown: job mode is unchanged — a Deliver opens,
+// runs, and tears the pane down (release + close + row delete) after the grace
+// (synchronous in tests). The seat-only behaviors do not leak into job mode.
+func TestJobModeGraceCloseStillTearsDown(t *testing.T) {
+	fr := newFakeRunner()
+	store := newFakeStore()
+	c := newWithRunner(Options{}, store, fr.run, okLookPath) // default = job mode
+	adapter := c.Wrap(&fakeInner{}, sampleMeta())
+	if _, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{ID: "abcdef0123456789"}); err != nil {
+		t.Fatal(err)
+	}
+	if countVerb(fr, "pane close") != 1 || countVerb(fr, "pane release-agent") != 1 {
+		t.Fatalf("job mode must release + close the pane per Deliver; calls: %v", fr.calls)
+	}
+	// Idle is reported before the close (so a finished job never reads as working).
+	joined := strings.Join(fr.calls, "\n")
+	if !strings.Contains(joined, "--state idle") {
+		t.Fatalf("job mode must report idle on teardown; calls:\n%s", joined)
+	}
+	if _, err := store.GetCockpitPaneByJob(context.Background(), "abcdef0123456789"); err == nil {
+		t.Fatal("job-mode row must be deleted on teardown")
+	}
+}
+
+// TestSeatLogPath builds the stable per-seat append-log path and slugs unsafe keys.
+func TestSeatLogPath(t *testing.T) {
+	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, newFakeStore(), newFakeRunner().run, okLookPath)
+	if got := c.SeatLogPath("root-x", "builder"); got != "" {
+		t.Fatalf("empty home must yield empty seat-log path, got %q", got)
+	}
+	c.home = "/home/g"
+	want := filepath.Join("/home/g", "logs", "seats", "root-x", "builder.log")
+	if got := c.SeatLogPath("root-x", "builder"); got != want {
+		t.Fatalf("SeatLogPath = %q, want %q", got, want)
+	}
+	// A path-unsafe key is slugified so it cannot escape the seat-log dir.
+	wantSlug := filepath.Join("/home/g", "logs", "seats", "root-x", "owner_repo.log")
+	if got := c.SeatLogPath("root-x", "owner/repo"); got != wantSlug {
+		t.Fatalf("SeatLogPath(unsafe) = %q, want %q", got, wantSlug)
+	}
+}
+
+func TestSeatSlug(t *testing.T) {
+	cases := map[string]string{
+		"builder":    "builder",
+		"owner/repo": "owner_repo",
+		"":           "seat",
+		"a.b-c_d":    "a.b-c_d",
+		"../escape":  ".._escape",
+	}
+	for in, want := range cases {
+		if got := seatSlug(in); got != want {
+			t.Errorf("seatSlug(%q) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/internal/cockpit/herdr.go
+++ b/internal/cockpit/herdr.go
@@ -181,6 +181,44 @@ func (c herdrClient) workspaceClose(ctx context.Context, workspace string) error
 	return err
 }
 
+// workspaceFocus runs `herdr workspace focus <workspace>` to bring a workspace
+// forward (Task 8 reconvene). herdr has no focus-pane-by-id verb (only the
+// directional `pane focus`), so workspace focus is the closest supported gesture.
+func (c herdrClient) workspaceFocus(ctx context.Context, workspace string) error {
+	_, err := c.run(ctx, "workspace", "focus", workspace)
+	return err
+}
+
+// paneListResult mirrors `herdr pane list`: only each pane's id is load-bearing
+// for the reconcile GC (which pane rows still have a live herdr pane).
+type paneListResult struct {
+	Result struct {
+		Panes []struct {
+			PaneID string `json:"pane_id"`
+		} `json:"panes"`
+	} `json:"result"`
+}
+
+// paneList runs `herdr pane list` and returns every live pane id. It backs the
+// reconcile sweep, which drops cockpit_pane rows whose pane is no longer present.
+func (c herdrClient) paneList(ctx context.Context) ([]string, error) {
+	out, err := c.run(ctx, "pane", "list")
+	if err != nil {
+		return nil, err
+	}
+	var pl paneListResult
+	if err := json.Unmarshal([]byte(out), &pl); err != nil {
+		return nil, fmt.Errorf("parse pane list: %w", err)
+	}
+	ids := make([]string, 0, len(pl.Result.Panes))
+	for _, p := range pl.Result.Panes {
+		if p.PaneID != "" {
+			ids = append(ids, p.PaneID)
+		}
+	}
+	return ids, nil
+}
+
 // shortJobID trims a job id to the 8-char form used in the gm-<jobid8> agent
 // label (the spike's verified report-agent --agent convention).
 func shortJobID(jobID string) string {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4707,7 +4707,7 @@ func (s *Store) GetCockpitPaneByKey(ctx context.Context, workspaceID, paneKey st
 // oldest first, so the cockpit can tear them all down on root finalize.
 func (s *Store) ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([]CockpitPane, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, job_id, pane_key, root_job_id, pane_id, workspace_id, source, created_at
-		FROM cockpit_panes WHERE root_job_id = ? ORDER BY created_at, id`, strings.TrimSpace(rootJobID))
+		FROM cockpit_panes WHERE root_job_id = ? ORDER BY created_at, rowid`, strings.TrimSpace(rootJobID))
 	if err != nil {
 		return nil, err
 	}
@@ -4728,7 +4728,7 @@ func (s *Store) ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([
 // root terminal) without scanning per-root.
 func (s *Store) ListAllCockpitPanes(ctx context.Context) ([]CockpitPane, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, job_id, pane_key, root_job_id, pane_id, workspace_id, source, created_at
-		FROM cockpit_panes ORDER BY created_at, id`)
+		FROM cockpit_panes ORDER BY created_at, rowid`)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4684,11 +4684,51 @@ func (s *Store) GetCockpitPaneByJob(ctx context.Context, jobID string) (CockpitP
 	return scanCockpitPane(row)
 }
 
+// GetCockpitPaneByKey returns the live pane for a (workspace_id, pane_key) seat,
+// if one exists (issue #357, seat mode). The bool reports found; a not-found row
+// is (CockpitPane{}, false, nil) — sql.ErrNoRows is never surfaced — so the
+// seat-reuse fail-open path can treat "no pane yet" as a clean miss rather than an
+// error. The (workspace_id, pane_key) pair is UNIQUE, so at most one row matches.
+func (s *Store) GetCockpitPaneByKey(ctx context.Context, workspaceID, paneKey string) (CockpitPane, bool, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, job_id, pane_key, root_job_id, pane_id, workspace_id, source, created_at
+		FROM cockpit_panes WHERE workspace_id = ? AND pane_key = ?`,
+		strings.TrimSpace(workspaceID), strings.TrimSpace(paneKey))
+	pane, err := scanCockpitPane(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return CockpitPane{}, false, nil
+	}
+	if err != nil {
+		return CockpitPane{}, false, err
+	}
+	return pane, true, nil
+}
+
 // ListCockpitPanesByRoot returns every pane opened under one orchestration root,
 // oldest first, so the cockpit can tear them all down on root finalize.
 func (s *Store) ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([]CockpitPane, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, job_id, pane_key, root_job_id, pane_id, workspace_id, source, created_at
 		FROM cockpit_panes WHERE root_job_id = ? ORDER BY created_at, id`, strings.TrimSpace(rootJobID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var panes []CockpitPane
+	for rows.Next() {
+		pane, err := scanCockpitPane(rows)
+		if err != nil {
+			return nil, err
+		}
+		panes = append(panes, pane)
+	}
+	return panes, rows.Err()
+}
+
+// ListAllCockpitPanes returns every recorded pane across all roots, oldest first.
+// The reconcile GC uses it to find orphaned rows (pane gone from herdr + owning
+// root terminal) without scanning per-root.
+func (s *Store) ListAllCockpitPanes(ctx context.Context) ([]CockpitPane, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, job_id, pane_key, root_job_id, pane_id, workspace_id, source, created_at
+		FROM cockpit_panes ORDER BY created_at, id`)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3298,6 +3298,96 @@ func TestDeleteCockpitPaneByJob(t *testing.T) {
 	}
 }
 
+// TestGetCockpitPaneByKey: the seat-reuse lookup finds the pane for a
+// (workspace_id, pane_key) seat and reports a clean miss (false, nil) — never
+// sql.ErrNoRows — when none exists.
+func TestGetCockpitPaneByKey(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	pane := CockpitPane{
+		JobID:       "job-seat",
+		PaneKey:     "seat:builder",
+		RootJobID:   "root",
+		PaneID:      "pane-seat",
+		WorkspaceID: "ws-1",
+		Source:      "custom:gitmoot",
+	}
+	if err := store.InsertCockpitPane(ctx, pane); err != nil {
+		t.Fatalf("InsertCockpitPane returned error: %v", err)
+	}
+
+	got, found, err := store.GetCockpitPaneByKey(ctx, "ws-1", "seat:builder")
+	if err != nil {
+		t.Fatalf("GetCockpitPaneByKey returned error: %v", err)
+	}
+	if !found {
+		t.Fatal("GetCockpitPaneByKey did not find the seat pane")
+	}
+	if got.PaneID != "pane-seat" || got.JobID != "job-seat" {
+		t.Fatalf("GetCockpitPaneByKey = %+v, want pane-seat/job-seat", got)
+	}
+
+	// A miss is a clean (false, nil), not sql.ErrNoRows.
+	_, found, err = store.GetCockpitPaneByKey(ctx, "ws-1", "seat:nobody")
+	if err != nil {
+		t.Fatalf("GetCockpitPaneByKey(miss) returned error: %v", err)
+	}
+	if found {
+		t.Fatal("GetCockpitPaneByKey(miss) reported found")
+	}
+	_, found, err = store.GetCockpitPaneByKey(ctx, "ws-other", "seat:builder")
+	if err != nil || found {
+		t.Fatalf("GetCockpitPaneByKey(other workspace) = (found=%v, err=%v), want (false, nil)", found, err)
+	}
+}
+
+// TestListAllCockpitPanes: the reconcile sweep can enumerate every pane across all
+// roots, oldest first.
+func TestListAllCockpitPanes(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if all, err := store.ListAllCockpitPanes(ctx); err != nil || len(all) != 0 {
+		t.Fatalf("ListAllCockpitPanes(empty) = (%d rows, %v), want (0, nil)", len(all), err)
+	}
+
+	panes := []CockpitPane{
+		{JobID: "job-1", PaneKey: "seat:a", RootJobID: "root-1", PaneID: "p1", WorkspaceID: "ws-1"},
+		{JobID: "job-2", PaneKey: "seat:b", RootJobID: "root-1", PaneID: "p2", WorkspaceID: "ws-1"},
+		{JobID: "job-3", PaneKey: "seat:c", RootJobID: "root-2", PaneID: "p3", WorkspaceID: "ws-2"},
+	}
+	for _, p := range panes {
+		if err := store.InsertCockpitPane(ctx, p); err != nil {
+			t.Fatalf("InsertCockpitPane(%s) returned error: %v", p.JobID, err)
+		}
+	}
+	all, err := store.ListAllCockpitPanes(ctx)
+	if err != nil {
+		t.Fatalf("ListAllCockpitPanes returned error: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("ListAllCockpitPanes = %d rows, want 3", len(all))
+	}
+	seen := map[string]bool{}
+	for _, p := range all {
+		seen[p.JobID] = true
+	}
+	for _, want := range []string{"job-1", "job-2", "job-3"} {
+		if !seen[want] {
+			t.Fatalf("ListAllCockpitPanes missing %s; got %+v", want, all)
+		}
+	}
+}
+
 func TestGetOrCreateWorkspaceForRoot(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
**Phase 2 of #357** (builds on #358, #359). Adds the recurring-council ergonomics: seat-keyed panes that persist per model across rounds, root-finalize teardown, reconcile GC, and coordinator reconvene. Default (`cockpit_pane_key = job`) is **unchanged from P0/P1**; seat behavior is opt-in.

## What's included
- **Seat-keyed panes** (`cockpit_pane_key = seat`): pane keyed by an opaque seat (`(root, agent)`), reused across rounds via `GetCockpitPaneByKey` (concurrent same-seat opens converge on one pane via `UNIQUE(workspace_id,pane_key)`). 
- **Per-seat append log** `<home>/logs/seats/<root>/<seat>.log` (O_APPEND) so the persistent pane's `tail` accumulates the seat's history across rounds — no re-pointing. (Job mode keeps the P1 per-job truncate+remove log.)
- **`Cockpit.FinalizeRoot`** — on root-tree-terminal, close panes + workspace, delete rows, remove seat logs. **Reconcile GC** ticker drops orphaned rows (pane gone from `herdr pane list` **and** root terminal); `report-metadata --ttl-ms` self-expiry.
- **Steer + reconvene** — `gitmoot job cancel` tears the pane down via the existing path; grace-close (job mode) keeps last output readable; coordinator continuation reuses the coordinator seat so the verdict lands there, and `workspace focus` surfaces it. (Note: herdr has no `pane focus <id>` — only directional — so `workspace focus` is the reconvene gesture.)

## Verification
- Full gate + `-race` (workflow + cockpit + db) green; tests for seat reuse, append log, FinalizeRoot teardown, reconcile orphan-drop, job-mode-unchanged.
- `/code-review high` → fixed: a **flaky** test from non-deterministic pane ordering (`ORDER BY created_at, rowid`); **`blocked` jobs are no longer treated as terminal** (a blocked job resumes — finalizing would prematurely tear down its pane); a cheap pane-existence guard before the root-terminal `ListJobs` scan (avoids redundant hot-path scans post-finalize).
- E2E: `cockpit-smoke.sh` passes with herdr reachable.

Known follow-ups (noted, non-blocking): the daemon infers root-tree-terminal by a job scan — the cleaner design is an **engine-emitted root-finalized signal** (would also fully close a small premature-finalize race when a child is enqueued exactly as the last sibling completes; today it self-heals via workspace re-create + reconcile). Part of #357 (Phase 3 auto-detect + attach-and-type follows).