### PR TITLE
feat(orchestrate): Herdr cockpit — Phase 3 auto-detect (#357)

### DIFF
--- a/docs/cockpit-orchestrate.md
+++ b/docs/cockpit-orchestrate.md
@@ -22,6 +22,11 @@ pane labeled `<agent> · d<depth> · <branch>`, and that pane streams the child'
 progress while the job runs. Children inherit the cockpit setting from their
 parent, so a single `--cockpit` on the root lights up the whole orchestra.
 
+**Auto-detect:** running `gitmoot orchestrate` from inside a Herdr session
+(`HERDR_ENV` set) turns the cockpit on automatically — no `--cockpit` needed. An
+explicit flag works anywhere; `[orchestrate] cockpit_mode = off` is the host-level
+veto; outside a Herdr session it stays off unless you pass the flag.
+
 Pick where the run lands with `--cockpit-session`:
 
 ```sh
@@ -64,16 +69,17 @@ overridden per run by the flags above:
 
 ```toml
 [orchestrate]
-cockpit_mode = "auto"      # on | off | auto (auto = on iff herdr is reachable)
+cockpit_mode = "auto"      # on | off | auto (auto = on when launched in a Herdr session)
 cockpit_session = ""       # default Herdr session/workspace label ("" = per-run)
 cockpit_max_panes = 4      # cap on simultaneous panes per run
 cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
 ```
 
-- `cockpit_mode = "off"` disables the cockpit even if `--cockpit` was passed by an
-  older script; `"on"` forces it (and emits a `cockpit_unavailable` job event if
-  Herdr is unreachable); `"auto"` (the default) turns it on only when `herdr
-  status` is ok.
+- `cockpit_mode = "off"` disables the cockpit even if `--cockpit` was passed;
+  `"auto"` (the default) auto-enables it when `orchestrate` runs from inside a
+  Herdr session and honors an explicit `--cockpit` anywhere. A pane is only opened
+  when `herdr status` is ok; otherwise a requested run emits one
+  `cockpit_unavailable` job event and proceeds without panes.
 - `cockpit_pane_key = "job"` opens one pane per child job. `seat` mode reuses a
   single pane per logical role across phases (a later phase) so a long run does
   not accumulate panes.

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -317,6 +317,11 @@ func runOrchestrate(args []string, stdout, stderr io.Writer) int {
 	}
 	// Force the background run path: orchestrate always fans out delegations.
 	options.background = true
+	// Auto-detect: when orchestrate is launched from inside a Herdr session, default
+	// the cockpit on so panes "just appear" without an explicit --cockpit. An
+	// explicit --cockpit/--herdr/--cockpit-session already set it; outside Herdr it
+	// stays off; and the daemon's [orchestrate] cockpit_mode = off still vetoes.
+	options.cockpit = cockpitAutoEnabled(options.cockpit, os.Getenv("HERDR_ENV"))
 	selected, reason := selectOrchestrateAction(options)
 	output, exit := dispatchAgentCommand(options, selected, reason, "orchestrate", stdout, stderr)
 	if exit != 0 {
@@ -532,6 +537,14 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 		options.cockpit = true
 	}
 	return options, true
+}
+
+// cockpitAutoEnabled implements the cockpit "auto" default: it stays whatever the
+// user explicitly chose, otherwise turns on when launched from inside a Herdr
+// session (a non-empty HERDR_ENV). The daemon's [orchestrate] cockpit_mode = off
+// is the host-level veto applied later.
+func cockpitAutoEnabled(explicit bool, herdrEnv string) bool {
+	return explicit || strings.TrimSpace(herdrEnv) != ""
 }
 
 func setAgentRunOption(options *agentRunOptions, flagName string, value string, stderr io.Writer) bool {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -2741,3 +2741,22 @@ func TestAgentModelRoundTripsThroughStorageMapping(t *testing.T) {
 		t.Fatalf("runtimeAgent model = %q, want %q", roundTripped.Model, "opus")
 	}
 }
+
+func TestCockpitAutoEnabled(t *testing.T) {
+	cases := []struct {
+		explicit bool
+		env      string
+		want     bool
+	}{
+		{false, "", false},     // outside Herdr, no flag -> off
+		{false, "1", true},     // inside a Herdr session -> auto on
+		{false, "  ", false},   // whitespace HERDR_ENV -> off
+		{true, "", true},       // explicit --cockpit -> on even outside Herdr
+		{true, "1", true},      // explicit + in Herdr -> on
+	}
+	for _, c := range cases {
+		if got := cockpitAutoEnabled(c.explicit, c.env); got != c.want {
+			t.Errorf("cockpitAutoEnabled(%v, %q) = %v, want %v", c.explicit, c.env, got, c.want)
+		}
+	}
+}

--- a/website/docs/workflows/cockpit-orchestrate-workflow.md
+++ b/website/docs/workflows/cockpit-orchestrate-workflow.md
@@ -22,6 +22,11 @@ the coordinator splits a workspace for the run, each subagent gets a pane labele
 the job runs. Children inherit the cockpit setting from their parent, so a single
 `--cockpit` on the root lights up the whole orchestra.
 
+**Auto-detect:** if you run `gitmoot orchestrate` from inside a Herdr session
+(`HERDR_ENV` set), the cockpit turns on automatically — no `--cockpit` needed. An
+explicit flag still works anywhere; `cockpit_mode = off` (below) is the host-level
+veto; outside a Herdr session it stays off unless you pass the flag.
+
 Pick where the run lands with `--cockpit-session`:
 
 ```sh
@@ -62,15 +67,17 @@ overridden per run by the flags above:
 
 ```toml
 [orchestrate]
-cockpit_mode = "auto"      # on | off | auto (auto = on iff herdr is reachable)
+cockpit_mode = "auto"      # on | off | auto (auto = on when launched in a Herdr session)
 cockpit_session = ""       # default Herdr session/workspace label ("" = per-run)
 cockpit_max_panes = 4      # cap on simultaneous panes per run
 cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
 ```
 
 - `cockpit_mode = "off"` disables the cockpit even if `--cockpit` was passed;
-  `"on"` forces it (and emits a `cockpit_unavailable` job event if Herdr is
-  unreachable); `"auto"` (the default) turns it on only when `herdr status` is ok.
+  `"auto"` (the default) auto-enables it when you run `orchestrate` from inside a
+  Herdr session (and honors an explicit `--cockpit` anywhere). Either way a pane
+  is only actually opened when `herdr status` is ok; otherwise the requested run
+  emits a single `cockpit_unavailable` job event and proceeds without panes.
 - `cockpit_pane_key = "job"` opens one pane per child job. `seat` mode reuses a
   single pane per logical role across phases so a long run does not accumulate
   panes.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6414,6 +6414,65 @@ and the `delegation_enqueued` events in `gitmoot events --repo owner/repo`. See
 `RESULT_CONTRACT.md` for the `ephemeral` field reference and the termination
 bounds these recipes run inside.
 
+## Cockpit: Live Panes For An Orchestra
+
+Add `--cockpit` (alias `--herdr`) to `gitmoot orchestrate` to render one live
+[Herdr](https://github.com/jerryfane/herdr) pane per delegation subagent so a
+fan-out is watchable as it runs — in the terminal, and (through herdres) mirrored
+to Telegram. The cockpit is **opt-in and fail-open**: with `--cockpit` off, or
+when Herdr is absent or `herdr status` is not ok, orchestration is byte-identical
+to today. Gitmoot imports no Herdr code; it drives Herdr over its CLI only, and a
+herdr call never fails or stalls a job.
+
+```sh
+gitmoot orchestrate review-panel "Review PR #123 in this repo." --repo owner/repo --cockpit
+gitmoot orchestrate decompose-and-verify "Implement the export feature." \
+  --repo owner/repo --cockpit --cockpit-session feature-export
+```
+
+Each child job opens a pane labeled `<agent> · d<depth> · <branch>` and streams
+its progress; children inherit the cockpit setting from their parent, so one
+`--cockpit` on the root lights up the whole orchestra. The same panes are visible
+in the terminal (open the Herdr workspace) and on Telegram via the herdres bridge.
+
+A cockpit pane is a **view, not the job**: closing a pane (in the terminal or
+from Telegram) tears down the visible surface but does NOT cancel the underlying
+job — the child keeps running and its result is still synthesized. To stop work,
+cancel through the record path, not by closing the pane:
+
+```sh
+gitmoot job list --repo owner/repo     # find the child job id
+gitmoot job cancel <job-id>            # cancel via the record; pane teardown follows
+```
+
+Defaults live in `~/.gitmoot/config.toml` under `[orchestrate]` and are
+overridable per run by the flags above:
+
+```toml
+[orchestrate]
+cockpit_mode = "auto"      # on | off | auto (auto = on iff herdr is reachable)
+cockpit_session = ""       # default Herdr session/workspace label ("" = per-run)
+cockpit_max_panes = 4      # cap on simultaneous panes per run
+cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
+```
+
+On a constrained host the pane count is what bites, not the jobs. Lower
+`cockpit_max_panes` (the default is `4`; use `2` or `1` on a small box) — beyond
+the cap, extra subagents run **status-only**: they still report state to Herdr
+but do not split a new pane, so the work fans out exactly as without the cockpit
+while the visible surface stays small. Prefer `cockpit_pane_key = "seat"` for
+long multi-phase runs so panes are reused per role instead of accumulating one
+per job. The cockpit never changes the engine — the DAG, the result contract,
+the runtime-session locks, and the checkout keys are unchanged whether it is on,
+off, or unavailable — so capping panes only changes what you see, never how the
+orchestra runs. If `--cockpit` is asked for but Herdr is unreachable, gitmoot
+emits one `cockpit_unavailable` job event on the root and runs unwrapped.
+
+The optional `scripts/cockpit-smoke.sh` confirms the cockpit is opt-in and
+fail-open: it runs against an isolated `--home`, exercises the `--cockpit` wrap
+path when `herdr` is reachable, and skips cleanly when `herdr` or `gitmoot` is
+unavailable. See `../../../docs/cockpit-orchestrate.md` for the full reference.
+
 ---
 
 # Source: skills/gitmoot/references/TEMPLATE_CAPTURE.md


### PR DESCRIPTION
**Phase 3 of #357** (final cockpit phase; builds on #358/#359/#360). Makes the cockpit **auto-enable when you run `gitmoot orchestrate` from inside a Herdr session** — panes "just appear," no `--cockpit` needed.

## What's included
- **Auto-detect**: a small pure helper `cockpitAutoEnabled(explicit, herdrEnv)` — keeps the user's explicit choice, else turns the cockpit on when `HERDR_ENV` is set. Wired in `runOrchestrate` (so `parseAgentRunOptions` stays env-free; existing tests unaffected). `[orchestrate] cockpit_mode = off` is still the host veto; outside a Herdr session it stays off unless `--cockpit` is passed; a requested-but-unreachable run still emits the single `cockpit_unavailable` event.
- Docs updated in **both trees** (the stale `auto = on iff herdr reachable` line → `auto = on when launched in a Herdr session`).
- Unit test for the helper (explicit / in-session / whitespace-env / outside-session).

## Verification
- Full gate green: `go build/vet/test ./...`; website builds clean (`onBrokenLinks: throw`).
- Review: given the ~3-line pure-helper surface, this was a focused self-review (the multi-agent `/code-review` fleet was applied to the larger P0–P2 diffs); the helper is total + table-tested and the wiring keeps the off/explicit/outside-session paths intact.

## Scope note (planned split)
Phase 3 also proposed **attach-and-type ("Model A")** panes. As flagged in the plan + #357's open-questions, that part has real open design (it changes result capture and can orphan a runtime), so it's **split to a tracked follow-up: #361** rather than forced here. This PR ships the safe, high-value half (auto-detect), completing the cockpit's "it just works" UX.

Closes the #357 phased rollout (P0–P3); #361 tracks the optional Model-A extension.