### PR TITLE
fix(cockpit): per-job log path for delegation IDs + close per-root workspace in job mode (#357)

### DIFF
--- a/internal/cli/cockpit_store.go
+++ b/internal/cli/cockpit_store.go
@@ -72,6 +72,14 @@ func (s cockpitPaneStore) GetOrCreateWorkspaceForRoot(ctx context.Context, rootJ
 	return s.store.GetOrCreateWorkspaceForRoot(ctx, rootJobID, create)
 }
 
+func (s cockpitPaneStore) GetWorkspaceForRoot(ctx context.Context, rootJobID string) (string, bool, error) {
+	return s.store.GetWorkspaceForRoot(ctx, rootJobID)
+}
+
+func (s cockpitPaneStore) DeleteWorkspaceForRoot(ctx context.Context, rootJobID string) error {
+	return s.store.DeleteWorkspaceForRoot(ctx, rootJobID)
+}
+
 func toDBCockpitPane(p cockpit.Pane) db.CockpitPane {
 	return db.CockpitPane{
 		ID:          p.ID,

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1798,12 +1798,16 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 				writeLine(w.Stdout, "job %s cockpit_unavailable event failed: %v", job.ID, eventErr)
 			}
 		}
-		// SEAT MODE ONLY: on the job's return, check whether the root coordination
-		// tree has now terminated and, if so, tear its panes / workspace / seat logs
-		// down once and surface the reconvene view (Task 7/8). Job mode is left
-		// byte-identical to P1 — its panes close per-Deliver and it never reaches
-		// here, so no extra herdr calls are made on the job-mode path.
-		if cp != nil && !userOptedOff && seatMode {
+		// On the job's return, check whether the root coordination tree has now
+		// terminated and, if so, tear its panes / workspace / seat logs down once and
+		// surface the reconvene view (Task 7/8). This runs in BOTH modes: seat mode
+		// closes the persisted seat panes + workspace here, and job mode (whose panes
+		// already close per-Deliver) still needs the per-root WORKSPACE closed at
+		// root-terminal — the cockpit_workspaces registry is the only remaining handle
+		// once the pane rows are gone. finalizeCockpitRootIfDone's cheap guard
+		// short-circuits when there is neither a pane row nor a registered workspace,
+		// so a non-cockpit tree makes no extra herdr calls.
+		if cp != nil && !userOptedOff {
 			defer w.finalizeCockpitRootIfDone(cp, job, payload, meta.RootJobID)
 		}
 	}
@@ -1943,7 +1947,12 @@ func (w jobWorker) cockpitTeeAdapter(agent runtime.Agent, checkout string, jobID
 		writeLine(w.Stdout, "job %s cockpit log dir create failed: %v", jobID, err)
 		return nil, "", nil
 	}
-	logPath := filepath.Join(dir, jobID+".log")
+	// Sanitize the job id into a flat, path-safe filename: delegation/continuation
+	// job ids contain '/' (e.g. "root/delegation/haiku-ocean", ".../continuation"),
+	// which would nest the log into dirs that are never created and fail os.Create →
+	// the live tail silently falls back to the P0 pane. A flat slug keeps it one
+	// file in this dir (no deep per-job dir trees).
+	logPath := filepath.Join(dir, cockpit.SafeLogName(jobID)+".log")
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		writeLine(w.Stdout, "job %s cockpit log create failed: %v", jobID, err)
@@ -2017,12 +2026,18 @@ func (w jobWorker) cockpitSeatLogAdapter(cp *cockpit.Cockpit, agent runtime.Agen
 // its per-Deliver teardown stays byte-identical.
 func (w jobWorker) finalizeCockpitRootIfDone(cp *cockpit.Cockpit, job db.Job, payload workflow.JobPayload, rootJobID string) {
 	ctx := context.Background()
-	// Cheap scoped guard before the full job-table scan: if the root has no live
-	// panes (none opened, or already finalized), there is nothing to do — this
-	// short-circuits the redundant rootTreeTerminal scans that would otherwise run
-	// on every in-tree job's completion once the root is already torn down.
+	// Cheap scoped guard before the full job-table scan: short-circuit only when the
+	// root has NEITHER a live pane row NOR a registered workspace (none opened, or
+	// already finalized) — there is then nothing to tear down, so the redundant
+	// rootTreeTerminal scans on every in-tree job's completion are skipped. Job mode
+	// deletes pane rows per-Deliver, so by root-terminal the pane list is empty while
+	// a cockpit_workspaces row still needs closing; gating on the pane list alone
+	// would skip that workspace teardown (the leftover-workspace bug). Any store error
+	// falls through to the (idempotent, best-effort) finalize rather than skipping.
 	if panes, perr := w.Store.ListCockpitPanesByRoot(ctx, rootJobID); perr == nil && len(panes) == 0 {
-		return
+		if _, found, wsErr := w.Store.GetWorkspaceForRoot(ctx, rootJobID); wsErr == nil && !found {
+			return
+		}
 	}
 	done, err := w.rootTreeTerminal(ctx, rootJobID)
 	if err != nil {

--- a/internal/cli/daemon_cockpit_test.go
+++ b/internal/cli/daemon_cockpit_test.go
@@ -331,6 +331,40 @@ func TestCockpitTeeAdapterTruncatesExistingLog(t *testing.T) {
 	}
 }
 
+// TestCockpitTeeAdapterDelegationJobIDFlatPath is the bug-1 case: a
+// delegation/continuation job id contains '/', which the per-job log path must
+// sanitize into a single flat, path-safe filename in <home>/logs/jobs/ — otherwise
+// os.Create nests into non-existent dirs, fails, and the live stream silently falls
+// back to the P0 pane. The log file must actually be created (a non-nil file).
+func TestCockpitTeeAdapterDelegationJobIDFlatPath(t *testing.T) {
+	home := t.TempDir()
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
+	agent := runtime.Agent{Name: "lead", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "true"}
+
+	jobID := "local-ask-conductor-1234/delegation/haiku-ocean"
+	adapter, logPath, logFile := worker.cockpitTeeAdapter(agent, t.TempDir(), jobID)
+	if logFile == nil || adapter == nil {
+		t.Fatalf("expected a non-nil adapter+log file for a slashed job id; adapter=%v file=%v", adapter, logFile)
+	}
+	defer logFile.Close()
+
+	jobsDir := filepath.Join(config.PathsForHome(home).Logs, "jobs")
+	// The log must be a single flat file directly in jobsDir (no nested dirs).
+	if got := filepath.Dir(logPath); got != jobsDir {
+		t.Fatalf("log dir = %q, want flat %q (slashed job id must not nest)", got, jobsDir)
+	}
+	wantPath := filepath.Join(jobsDir, cockpit.SafeLogName(jobID)+".log")
+	if logPath != wantPath {
+		t.Fatalf("logPath = %q, want %q", logPath, wantPath)
+	}
+	if strings.Contains(filepath.Base(logPath), "/") {
+		t.Fatalf("log filename %q still contains a path separator", filepath.Base(logPath))
+	}
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("log file not created for slashed job id: %v", err)
+	}
+}
+
 // TestCockpitTeeAdapterFailOpenUnsupportedRuntime: an unsupported runtime fails
 // the adapter rebuild, so the helper returns a nil file (no leaked log) and the
 // caller falls back to the P0 pane — fail-open, never failing the job.
@@ -439,6 +473,47 @@ func TestRootTreeTerminal(t *testing.T) {
 	if done, _ := worker.rootTreeTerminal(ctx, ""); done {
 		t.Fatal("rootTreeTerminal for an empty root id must be false")
 	}
+}
+
+// TestFinalizeCockpitRootIfDoneJobMode is the bug-2 daemon case: in JOB mode the
+// per-Deliver teardown deletes the pane rows, so at root-terminal no pane rows
+// remain — but the per-root workspace (recorded in cockpit_workspaces) must still
+// be torn down. finalizeCockpitRootIfDone must therefore run in job mode (not only
+// seat mode), its cheap guard must NOT short-circuit while a registry workspace
+// row exists, and FinalizeRoot must delete that registry row.
+func TestFinalizeCockpitRootIfDoneJobMode(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worker := defaultJobWorker(store, io.Discard)
+
+	// A terminal job-mode tree: the root coordinator succeeded and no pane rows
+	// remain (they were deleted per-Deliver), but a workspace was registered.
+	if err := store.CreateJob(ctx, db.Job{ID: "root-job", Agent: "a", Type: "implement", State: string(workflow.JobSucceeded), Payload: cockpitTestJobPayload(t, workflow.JobPayload{})}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-job", func() (string, error) {
+		return "w-job", nil
+	}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if rows, _ := store.ListCockpitPanesByRoot(ctx, "root-job"); len(rows) != 0 {
+		t.Fatalf("precondition: expected no pane rows, got %d", len(rows))
+	}
+
+	// A job-mode cockpit (herdr absent on CI, so the workspace-close call is a
+	// best-effort no-op); the load-bearing observable is that the registry row is
+	// deleted — proving the guard let job mode through and FinalizeRoot ran.
+	cp := cockpit.New(cockpit.Options{HerdrBin: "herdr-does-not-exist-for-tests", PaneKeyMode: config.CockpitPaneKeyJob}, cockpitPaneStore{store: store})
+
+	worker.finalizeCockpitRootIfDone(cp, db.Job{ID: "root-job"}, workflow.JobPayload{}, "root-job")
+
+	if ws, found, err := store.GetWorkspaceForRoot(ctx, "root-job"); err != nil || found || ws != "" {
+		t.Fatalf("workspace registry row after job-mode finalize = (%q,%v,%v), want (\"\",false,nil) — workspace not torn down", ws, found, err)
+	}
+
+	// Idempotent: a second finalize finds neither a pane row nor a workspace and
+	// short-circuits cleanly (no error, no panic).
+	worker.finalizeCockpitRootIfDone(cp, db.Job{ID: "root-job"}, workflow.JobPayload{}, "root-job")
 }
 
 func TestCockpitJobStateTerminal(t *testing.T) {

--- a/internal/cockpit/cockpit.go
+++ b/internal/cockpit/cockpit.go
@@ -89,6 +89,16 @@ type PaneStore interface {
 	// called only on first use for a given root and its workspace id is reused
 	// thereafter.
 	GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, err error)) (string, error)
+	// GetWorkspaceForRoot returns the registered workspace id for a root, if one
+	// exists. The bool reports found; a not-found root is ("", false, nil) — never a
+	// surfaced sql.ErrNoRows — so FinalizeRoot's fail-open path treats "no workspace"
+	// as a clean miss. It lets job-mode finalize close the per-root workspace from
+	// the registry even after every pane row has been deleted per-Deliver.
+	GetWorkspaceForRoot(ctx context.Context, rootJobID string) (workspaceID string, found bool, err error)
+	// DeleteWorkspaceForRoot removes the workspace registry row for a root so a
+	// second finalize finds nothing and no-ops (idempotent). Deleting a missing row
+	// is not an error.
+	DeleteWorkspaceForRoot(ctx context.Context, rootJobID string) error
 }
 
 // Options configures a Cockpit. The fields are frozen.
@@ -597,10 +607,28 @@ func (c *Cockpit) FinalizeRoot(ctx context.Context, rootJobID string) {
 			}
 		}
 	}
+	// Also close the per-root workspace from the registry, even when no pane rows
+	// remain. In JOB mode the pane rows are deleted per-Deliver, so by the time the
+	// tree is terminal ListCockpitPanesByRoot is empty and the pane-row loop above
+	// closes nothing — the cockpit_workspaces registry (populated by
+	// GetOrCreateWorkspaceForRoot) is the only remaining handle on the workspace.
+	// Dedup against the pane-row workspaces so a workspace is never closed twice.
+	if registryWS, found, wsErr := c.store.GetWorkspaceForRoot(ctx, rootJobID); wsErr != nil {
+		c.logf("cockpit: finalize root %s get workspace: %v", rootJobID, wsErr)
+	} else if found && registryWS != "" {
+		// The set is keyed by workspace id, so adding one already closed via a pane
+		// row is a no-op — a workspace is never closed twice.
+		workspaces[registryWS] = struct{}{}
+	}
 	for workspaceID := range workspaces {
 		c.bestEffort(ctx, "workspace close", func(cctx context.Context) error {
 			return c.client.workspaceClose(cctx, workspaceID)
 		})
+	}
+	// Drop the workspace registry row so a second finalize finds nothing and
+	// no-ops (idempotent). Best-effort: a delete failure never blocks finalizing.
+	if err := c.store.DeleteWorkspaceForRoot(ctx, rootJobID); err != nil {
+		c.logf("cockpit: finalize root %s delete workspace: %v", rootJobID, err)
 	}
 	// Remove the root's seat-log directory: the accumulating per-seat logs only
 	// backed the live tails, which are now closed, so they persist no longer than
@@ -746,6 +774,17 @@ func (c *Cockpit) seatLogRootDir(rootJobID string) string {
 		return ""
 	}
 	return filepath.Join(c.home, "logs", "seats", shortJobID(rootJobID))
+}
+
+// SafeLogName maps a job id to a flat, filesystem-safe filename component for the
+// per-job log. Delegation/continuation job ids contain '/' (e.g.
+// "root/delegation/haiku-ocean", ".../continuation"), which would otherwise nest
+// the per-job log into directories that are never created and fail os.Create →
+// the live tail silently falls back to the P0 pane. Slugifying to a single
+// path-safe token keeps it one file in <home>/logs/jobs/. It reuses seatSlug so
+// the per-job and per-seat sanitizers stay in lockstep.
+func SafeLogName(jobID string) string {
+	return seatSlug(jobID)
 }
 
 // seatSlug maps a pane key (e.g. an agent name) to a filesystem-safe slug for the

--- a/internal/cockpit/cockpit_test.go
+++ b/internal/cockpit/cockpit_test.go
@@ -212,6 +212,23 @@ func (s *fakeStore) GetOrCreateWorkspaceForRoot(_ context.Context, rootJobID str
 	return ws, nil
 }
 
+func (s *fakeStore) GetWorkspaceForRoot(_ context.Context, rootJobID string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ws, ok := s.workspaces[rootJobID]
+	if !ok || ws == "" {
+		return "", false, nil
+	}
+	return ws, true, nil
+}
+
+func (s *fakeStore) DeleteWorkspaceForRoot(_ context.Context, rootJobID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.workspaces, rootJobID)
+	return nil
+}
+
 // fakeInner is the wrapped DeliveryAdapter. It records that it ran and returns a
 // fixed result so the pane wrapper's pass-through can be asserted.
 type fakeInner struct {
@@ -843,14 +860,81 @@ func TestFinalizeRootClosesDeletesAndRemovesSeatLogs(t *testing.T) {
 	}
 }
 
-// TestFinalizeRootNoPanesIsNoop: finalizing a root with no panes (job mode, or
-// already finalized) is a cheap no-op with no herdr calls beyond the list.
+// TestFinalizeRootNoPanesIsNoop: finalizing a root with no panes AND no registered
+// workspace (already finalized, or never opened) is a cheap no-op with no herdr
+// close calls beyond the list.
 func TestFinalizeRootNoPanesIsNoop(t *testing.T) {
 	fr := newFakeRunner()
 	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, newFakeStore(), fr.run, okLookPath)
 	c.FinalizeRoot(context.Background(), "root-empty")
 	if countVerb(fr, "pane close") != 0 || countVerb(fr, "workspace close") != 0 {
 		t.Fatalf("finalize of an empty root must make no close calls; calls: %v", fr.calls)
+	}
+}
+
+// TestFinalizeRootClosesRegistryWorkspaceWithoutPaneRows is the job-mode bug-2
+// case: by the time the root tree is terminal the pane rows have been deleted
+// per-Deliver, so ListCockpitPanesByRoot is empty — but the per-root workspace
+// (recorded in the cockpit_workspaces registry) must still be closed and its
+// registry row deleted. A second finalize then finds nothing and no-ops.
+func TestFinalizeRootClosesRegistryWorkspaceWithoutPaneRows(t *testing.T) {
+	fr := newFakeRunner()
+	store := newFakeStore()
+	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeJob}, store, fr.run, okLookPath)
+
+	// Simulate a finished job-mode run: a workspace was registered for the root, but
+	// the pane row was already deleted on the per-Deliver grace close, so no rows
+	// remain under the root.
+	if _, err := store.GetOrCreateWorkspaceForRoot(context.Background(), "root-job", func() (string, error) {
+		return "w-job", nil
+	}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if rows, _ := store.ListCockpitPanesByRoot(context.Background(), "root-job"); len(rows) != 0 {
+		t.Fatalf("precondition: expected no pane rows, got %d", len(rows))
+	}
+
+	c.FinalizeRoot(context.Background(), "root-job")
+
+	if got := countVerb(fr, "pane close"); got != 0 {
+		t.Fatalf("pane close count = %d, want 0 (no pane rows in job mode)", got)
+	}
+	if got := countVerb(fr, "workspace close"); got != 1 {
+		t.Fatalf("workspace close count = %d, want 1 (registry workspace closed without pane rows)", got)
+	}
+	if ws, found, _ := store.GetWorkspaceForRoot(context.Background(), "root-job"); found || ws != "" {
+		t.Fatalf("workspace registry row still present after finalize: ws=%q found=%v", ws, found)
+	}
+
+	// Idempotent: a second finalize finds neither a pane row nor a workspace, so it
+	// makes no further close calls.
+	c.FinalizeRoot(context.Background(), "root-job")
+	if got := countVerb(fr, "workspace close"); got != 1 {
+		t.Fatalf("workspace close count after second finalize = %d, want 1 (idempotent)", got)
+	}
+}
+
+// TestFinalizeRootDedupsPaneAndRegistryWorkspace: seat mode has both pane rows AND
+// a registry row pointing at the SAME workspace; finalize must close that
+// workspace exactly once (no double close).
+func TestFinalizeRootDedupsPaneAndRegistryWorkspace(t *testing.T) {
+	fr := newFakeRunner()
+	store := newFakeStore()
+	c := newWithRunner(Options{PaneKeyMode: PaneKeyModeSeat}, store, fr.run, okLookPath)
+
+	adapter := c.Wrap(&fakeInner{}, seatMeta("job-a", "builder"))
+	if _, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatal(err)
+	}
+	// The open path recorded both a pane row (workspace w1) and the registry row.
+	if ws, found, _ := store.GetWorkspaceForRoot(context.Background(), "root-seat"); !found || ws == "" {
+		t.Fatalf("precondition: expected a registered workspace, got found=%v ws=%q", found, ws)
+	}
+
+	c.FinalizeRoot(context.Background(), "root-seat")
+
+	if got := countVerb(fr, "workspace close"); got != 1 {
+		t.Fatalf("workspace close count = %d, want 1 (pane-row + registry workspace deduped)", got)
 	}
 }
 
@@ -978,6 +1062,27 @@ func TestSeatSlug(t *testing.T) {
 	for in, want := range cases {
 		if got := seatSlug(in); got != want {
 			t.Errorf("seatSlug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestSafeLogName: a delegation/continuation job id (which contains '/') is
+// flattened into a single path-safe filename component with no separators, so the
+// per-job log is one file rather than nesting into non-existent dirs (bug 1).
+func TestSafeLogName(t *testing.T) {
+	cases := map[string]string{
+		"plain-job-1234":                            "plain-job-1234",
+		"local-ask-conductor-1234/delegation/haiku": "local-ask-conductor-1234_delegation_haiku",
+		"root/continuation":                         "root_continuation",
+		"":                                          "seat",
+	}
+	for in, want := range cases {
+		got := SafeLogName(in)
+		if got != want {
+			t.Errorf("SafeLogName(%q) = %q, want %q", in, got, want)
+		}
+		if strings.ContainsAny(got, `/\`) {
+			t.Errorf("SafeLogName(%q) = %q still contains a path separator", in, got)
 		}
 	}
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4819,6 +4819,36 @@ func (s *Store) lookupWorkspaceForRoot(ctx context.Context, rootJobID string) (s
 	return strings.TrimSpace(workspaceID), nil
 }
 
+// GetWorkspaceForRoot returns the Herdr workspace id registered for an
+// orchestration root, if one exists. The bool reports found; a not-found root is
+// ("", false, nil) — never a surfaced sql.ErrNoRows — so the cockpit's fail-open
+// finalize path can treat "no workspace" as a clean miss rather than an error.
+// FinalizeRoot uses it to close the per-root workspace even when no pane rows
+// remain (job mode deletes pane rows per-Deliver, so the registry is the only
+// remaining handle on the workspace at root-terminal).
+func (s *Store) GetWorkspaceForRoot(ctx context.Context, rootJobID string) (string, bool, error) {
+	rootJobID = strings.TrimSpace(rootJobID)
+	if rootJobID == "" {
+		return "", false, nil
+	}
+	workspaceID, err := s.lookupWorkspaceForRoot(ctx, rootJobID)
+	if err != nil {
+		return "", false, err
+	}
+	if workspaceID == "" {
+		return "", false, nil
+	}
+	return workspaceID, true, nil
+}
+
+// DeleteWorkspaceForRoot removes the cockpit_workspaces registry row for a root.
+// FinalizeRoot calls it after closing the workspace so a second finalize finds
+// nothing and no-ops (idempotent). Deleting a missing row is a no-op, not an error.
+func (s *Store) DeleteWorkspaceForRoot(ctx context.Context, rootJobID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM cockpit_workspaces WHERE root_job_id = ?`, strings.TrimSpace(rootJobID))
+	return err
+}
+
 func scanCockpitPane(row interface{ Scan(dest ...any) error }) (CockpitPane, error) {
 	var pane CockpitPane
 	if err := row.Scan(&pane.ID, &pane.JobID, &pane.PaneKey, &pane.RootJobID,

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3445,6 +3445,51 @@ func TestGetOrCreateWorkspaceForRoot(t *testing.T) {
 	}
 }
 
+// TestGetAndDeleteWorkspaceForRoot covers the registry lookup + delete the
+// job-mode finalize relies on to close the per-root workspace once the pane rows
+// are gone: a registered root reports found; an unknown/empty root reports a clean
+// miss (never sql.ErrNoRows); delete drops the row and is idempotent.
+func TestGetAndDeleteWorkspaceForRoot(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	// Unknown root is a clean miss, not an error.
+	if ws, found, err := store.GetWorkspaceForRoot(ctx, "root-x"); err != nil || found || ws != "" {
+		t.Fatalf("GetWorkspaceForRoot(unknown) = (%q,%v,%v), want (\"\",false,nil)", ws, found, err)
+	}
+	// An empty root id is also a clean miss.
+	if _, found, err := store.GetWorkspaceForRoot(ctx, "  "); err != nil || found {
+		t.Fatalf("GetWorkspaceForRoot(empty) = (found=%v,err=%v), want (false,nil)", found, err)
+	}
+
+	if _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-1", func() (string, error) {
+		return "ws-1", nil
+	}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+
+	ws, found, err := store.GetWorkspaceForRoot(ctx, "root-1")
+	if err != nil || !found || ws != "ws-1" {
+		t.Fatalf("GetWorkspaceForRoot(root-1) = (%q,%v,%v), want (ws-1,true,nil)", ws, found, err)
+	}
+
+	// Delete drops the row; a subsequent lookup is a clean miss.
+	if err := store.DeleteWorkspaceForRoot(ctx, "root-1"); err != nil {
+		t.Fatalf("DeleteWorkspaceForRoot returned error: %v", err)
+	}
+	if _, found, err := store.GetWorkspaceForRoot(ctx, "root-1"); err != nil || found {
+		t.Fatalf("GetWorkspaceForRoot after delete = (found=%v,err=%v), want (false,nil)", found, err)
+	}
+	// Idempotent: deleting a missing row is a no-op, not an error.
+	if err := store.DeleteWorkspaceForRoot(ctx, "root-1"); err != nil {
+		t.Fatalf("DeleteWorkspaceForRoot (repeat) returned error: %v", err)
+	}
+}
+
 func TestGetOrCreateWorkspaceForRootConcurrent(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
Two real bugs caught by a **live codex `orchestrate --cockpit` run** (the unit/seam tests + smoke missed both — they used slash-free job ids and seat mode):

**Bug 1 — live stream silently fell back for delegation children.** The per-job log was `filepath.Join(<home>/logs/jobs, jobID+".log")`, but delegation/continuation job IDs contain `/` (e.g. `…/delegation/haiku-ocean`), so `os.Create` nested into non-existent dirs and failed → fail-open to the Phase-0 `job watch` pane. So P1 live streaming never worked for real delegation children. **Fix:** sanitize the job id to a flat, path-safe filename (`cockpit.SafeLogName`, shares the seat-slug sanitizer).

**Bug 2 — per-root workspace leaked in job mode.** `FinalizeRoot` derived the workspace to close from pane rows, but job mode deletes those per-Deliver, so the workspace (tracked in `cockpit_workspaces`) was never closed; the finalize hook was also seat-only. → empty `gitmoot · …` workspaces accumulated. **Fix:** added `GetWorkspaceForRoot`/`DeleteWorkspaceForRoot`; `FinalizeRoot` now also closes the registry workspace (works when no pane rows remain), the finalize hook runs in both modes, and the cheap guard only short-circuits when there is neither a pane row nor a registered workspace.

## Verification (live, real codex)
Re-ran `gitmoot orchestrate conductor(claude) → player-1/player-2(codex) → continuation --cockpit` after the fix:
- `cockpit log create failed` count: **0** (was one per child) → live stream wired.
- leftover `gitmoot ·` workspaces after the run: **0** → workspace torn down.
- orchestra succeeded end-to-end; `--cockpit` off / job-mode panes-close-per-Deliver behavior unchanged.

Tests added: `SafeLogName`, delegation-job-id flat path, `FinalizeRoot` registry-workspace teardown (no pane rows) + dedup, job-mode finalize, `Get/DeleteWorkspaceForRoot`. Full gate + `-race ./internal/workflow/` green.