### PR TITLE
fix(cockpit): split panes off the workspace root pane, not its id (#357)

### DIFF
--- a/internal/cli/cockpit_store.go
+++ b/internal/cli/cockpit_store.go
@@ -68,7 +68,7 @@ func (s cockpitPaneStore) DeleteCockpitPaneByJob(ctx context.Context, jobID stri
 	return s.store.DeleteCockpitPaneByJob(ctx, jobID)
 }
 
-func (s cockpitPaneStore) GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, err error)) (string, error) {
+func (s cockpitPaneStore) GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, rootPaneID string, err error)) (string, string, error) {
 	return s.store.GetOrCreateWorkspaceForRoot(ctx, rootJobID, create)
 }
 

--- a/internal/cli/daemon_cockpit_test.go
+++ b/internal/cli/daemon_cockpit_test.go
@@ -491,8 +491,8 @@ func TestFinalizeCockpitRootIfDoneJobMode(t *testing.T) {
 	if err := store.CreateJob(ctx, db.Job{ID: "root-job", Agent: "a", Type: "implement", State: string(workflow.JobSucceeded), Payload: cockpitTestJobPayload(t, workflow.JobPayload{})}); err != nil {
 		t.Fatalf("CreateJob: %v", err)
 	}
-	if _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-job", func() (string, error) {
-		return "w-job", nil
+	if _, _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-job", func() (string, string, error) {
+		return "w-job", "w-job:p1", nil
 	}); err != nil {
 		t.Fatalf("seed workspace: %v", err)
 	}

--- a/internal/cockpit/cockpit.go
+++ b/internal/cockpit/cockpit.go
@@ -87,8 +87,10 @@ type PaneStore interface {
 	DeleteCockpitPaneByJob(ctx context.Context, jobID string) error
 	// GetOrCreateWorkspaceForRoot serializes one workspace per root: create is
 	// called only on first use for a given root and its workspace id is reused
-	// thereafter.
-	GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, err error)) (string, error)
+	// thereafter. create returns both the workspace id and its root pane id; the
+	// root pane id is persisted and returned on every reuse so subsequent children
+	// can split off it (herdr's pane split needs a PANE id, not a workspace id).
+	GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, rootPaneID string, err error)) (workspaceID string, rootPaneID string, err error)
 	// GetWorkspaceForRoot returns the registered workspace id for a root, if one
 	// exists. The bool reports found; a not-found root is ("", false, nil) — never a
 	// surfaced sql.ErrNoRows — so FinalizeRoot's fail-open path treats "no workspace"
@@ -367,22 +369,29 @@ func (a *paneAdapter) open(ctx context.Context) string {
 		return ""
 	}
 
-	workspaceID, err := c.store.GetOrCreateWorkspaceForRoot(ctx, rootJob, func() (string, error) {
+	workspaceID, rootPaneID, err := c.store.GetOrCreateWorkspaceForRoot(ctx, rootJob, func() (string, string, error) {
 		callCtx, cancel := context.WithTimeout(ctx, herdrCallTimeout)
 		defer cancel()
-		wsID, _, createErr := c.client.workspaceCreate(callCtx, a.meta.Worktree, a.workspaceLabel())
-		return wsID, createErr
+		wsID, rootPane, createErr := c.client.workspaceCreate(callCtx, a.meta.Worktree, a.workspaceLabel())
+		return wsID, rootPane, createErr
 	})
 	if err != nil || workspaceID == "" {
 		c.logf("cockpit: resolve workspace for root %s: %v", rootJob, err)
 		return ""
 	}
 
-	// The parent pane for the first split is the workspace's root pane. herdr
-	// accepts the workspace id as the split parent target for the root pane.
+	// The parent of every split is the workspace's ROOT PANE. herdr's `pane split`
+	// requires a pane id as the parent target — passing the workspace id fails with
+	// pane_not_found — so we split off the root pane captured at workspace create
+	// (persisted in the registry and returned on reuse). rootPaneFor is a defensive
+	// fallback for legacy registry rows whose root pane id predates this capture.
 	splitCtx, cancel := context.WithTimeout(ctx, herdrCallTimeout)
 	defer cancel()
-	paneID, err := c.client.paneSplit(splitCtx, c.rootPaneFor(workspaceID), a.meta.Worktree)
+	splitParent := rootPaneID
+	if splitParent == "" {
+		splitParent = c.rootPaneFor(workspaceID)
+	}
+	paneID, err := c.client.paneSplit(splitCtx, splitParent, a.meta.Worktree)
 	if err != nil || paneID == "" {
 		c.logf("cockpit: pane split for job %s: %v", a.meta.JobID, err)
 		return ""
@@ -537,11 +546,17 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-// rootPaneFor returns the split-parent target for a workspace. The workspace id
-// addresses its root pane for the first split; subsequent splits target the
-// root pane too (herdr lays them out under the workspace).
+// rootPaneFor derives a best-effort split-parent for a workspace whose root pane
+// id was not captured at create time (legacy registry rows predating that
+// capture). herdr names a workspace's root pane "<workspaceID>:p1", so we target
+// that; the workspace id alone is NOT a valid split parent (pane_not_found).
+// Freshly created workspaces pass the real root pane id from workspaceCreate and
+// never reach this fallback.
 func (c *Cockpit) rootPaneFor(workspaceID string) string {
-	return workspaceID
+	if workspaceID == "" {
+		return ""
+	}
+	return workspaceID + ":p1"
 }
 
 // bestEffort runs a timeout-bounded herdr call and swallows any error after

--- a/internal/cockpit/cockpit_test.go
+++ b/internal/cockpit/cockpit_test.go
@@ -31,7 +31,7 @@ type reply struct {
 func newFakeRunner() *fakeRunner {
 	return &fakeRunner{replies: map[string]reply{
 		"status":             {stdout: `{"server":{"running":true}}`},
-		"workspace create":   {stdout: `{"result":{"workspace":{"workspace_id":"w1"},"root_pane":{"pane_id":"w1:p1"}}}`},
+		"workspace create":   {stdout: `{"result":{"workspace":{"workspace_id":"w1"},"root_pane":{"pane_id":"w1:proot"}}}`},
 		"pane split":         {stdout: `{"result":{"pane":{"pane_id":"w1:p2"}}}`},
 		"pane rename":        {stdout: `{}`},
 		"pane report-agent":  {stdout: `{}`},
@@ -235,7 +235,10 @@ func (s *fakeStore) GetWorkspaceForRoot(_ context.Context, rootJobID string) (st
 func (s *fakeStore) DeleteWorkspaceForRoot(_ context.Context, rootJobID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Mirror the real store, which deletes the whole cockpit_workspaces row
+	// (workspace_id AND root_pane_id) so a later create rebinds from scratch.
 	delete(s.workspaces, rootJobID)
+	delete(s.rootPanes, rootJobID)
 	return nil
 }
 
@@ -456,9 +459,10 @@ func TestWrapDeliverArgsCarryVerifiedFields(t *testing.T) {
 	// workspace create uses the worktree cwd and --no-focus.
 	assertContains("workspace create --cwd /tmp/wt --label")
 	assertContains("--no-focus")
-	// pane split targets the workspace's ROOT PANE id (w1:p1, captured at create),
-	// not the bare workspace id — herdr's pane split needs a pane parent.
-	assertContains("pane split w1:p1 --direction down --cwd /tmp/wt --no-focus")
+	// pane split targets the workspace's ROOT PANE id captured at create (w1:proot,
+	// deliberately distinct from rootPaneFor's derived "w1:p1"), proving open() uses
+	// the persisted root pane id — not the bare workspace id, and not the fallback.
+	assertContains("pane split w1:proot --direction down --cwd /tmp/wt --no-focus")
 	// rename uses "<agent> · d<depth> · <branch>".
 	assertContains("pane rename w1:p2 builder · d1 · feat/x")
 	// report-agent uses the verified source + gm-<jobid8> agent + working.
@@ -469,6 +473,30 @@ func TestWrapDeliverArgsCarryVerifiedFields(t *testing.T) {
 	// teardown releases then closes.
 	assertContains("pane release-agent w1:p2 --source custom:gitmoot --agent gm-abcdef01")
 	assertContains("pane close w1:p2")
+}
+
+// TestWrapDeliverFallsBackToDerivedRootPaneWhenEmpty covers the defensive path:
+// a LEGACY registry row bound a workspace to the root before root_pane_id existed,
+// so the migration defaulted its root_pane_id to ''. open() must then split off the
+// DERIVED root pane "<ws>:p1" (rootPaneFor) — never the bare workspace id, which
+// herdr rejects with pane_not_found (the fake runner enforces that) — and must NOT
+// re-create the already-bound workspace.
+func TestWrapDeliverFallsBackToDerivedRootPaneWhenEmpty(t *testing.T) {
+	fr := newFakeRunner()
+	store := newFakeStore()
+	// Seed a legacy row: workspace bound, root pane id absent (migration default '').
+	store.workspaces[sampleMeta().RootJobID] = "w1"
+	c := newWithRunner(Options{}, store, fr.run, okLookPath)
+	if _, err := c.Wrap(&fakeInner{}, sampleMeta()).Deliver(context.Background(), runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(fr.calls, "\n")
+	if !strings.Contains(joined, "pane split w1:p1 --direction down") {
+		t.Fatalf("expected fallback split off derived root pane w1:p1; calls:\n%s", joined)
+	}
+	if got := countVerb(fr, "workspace create"); got != 0 {
+		t.Fatalf("legacy row must be reused, not re-created; workspace create count = %d", got)
+	}
 }
 
 func TestWatchCommandTailsLogWhenLogPathSet(t *testing.T) {

--- a/internal/cockpit/cockpit_test.go
+++ b/internal/cockpit/cockpit_test.go
@@ -48,6 +48,13 @@ func (f *fakeRunner) run(_ context.Context, args ...string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls = append(f.calls, strings.Join(args, " "))
+	// Mirror real herdr: `pane split <parent>` requires a PANE id (form "ws:pN"),
+	// not a workspace id ("ws"). A workspace-id parent fails with pane_not_found.
+	// This guards the root-pane-id split fix from regressing: passing the bare
+	// workspace id (as the old rootPaneFor did) would silently create no pane.
+	if len(args) >= 3 && args[0] == "pane" && args[1] == "split" && !strings.Contains(args[2], ":") {
+		return `{"error":{"code":"pane_not_found","message":"pane not found"}}`, errors.New("pane_not_found: " + args[2])
+	}
 	r, ok := f.replies[replyKey(args)]
 	if !ok {
 		return "{}", nil
@@ -99,6 +106,7 @@ type fakeStore struct {
 	mu         sync.Mutex
 	panes      map[string]Pane // keyed by job id
 	workspaces map[string]string
+	rootPanes  map[string]string // root job id -> workspace root pane id
 	createN    int
 	insertErr  error
 	byKeyErr   error
@@ -106,7 +114,7 @@ type fakeStore struct {
 }
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{panes: map[string]Pane{}, workspaces: map[string]string{}}
+	return &fakeStore{panes: map[string]Pane{}, workspaces: map[string]string{}, rootPanes: map[string]string{}}
 }
 
 func (s *fakeStore) InsertCockpitPane(_ context.Context, pane Pane) error {
@@ -194,22 +202,24 @@ func (s *fakeStore) DeleteCockpitPaneByJob(_ context.Context, jobID string) erro
 	return nil
 }
 
-func (s *fakeStore) GetOrCreateWorkspaceForRoot(_ context.Context, rootJobID string, create func() (string, error)) (string, error) {
+func (s *fakeStore) GetOrCreateWorkspaceForRoot(_ context.Context, rootJobID string, create func() (string, string, error)) (string, string, error) {
 	s.mu.Lock()
 	if ws, ok := s.workspaces[rootJobID]; ok {
+		rp := s.rootPanes[rootJobID]
 		s.mu.Unlock()
-		return ws, nil
+		return ws, rp, nil
 	}
 	s.mu.Unlock()
-	ws, err := create()
+	ws, rp, err := create()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	s.mu.Lock()
 	s.createN++
 	s.workspaces[rootJobID] = ws
+	s.rootPanes[rootJobID] = rp
 	s.mu.Unlock()
-	return ws, nil
+	return ws, rp, nil
 }
 
 func (s *fakeStore) GetWorkspaceForRoot(_ context.Context, rootJobID string) (string, bool, error) {
@@ -446,8 +456,9 @@ func TestWrapDeliverArgsCarryVerifiedFields(t *testing.T) {
 	// workspace create uses the worktree cwd and --no-focus.
 	assertContains("workspace create --cwd /tmp/wt --label")
 	assertContains("--no-focus")
-	// pane split targets the workspace root pane parent and the worktree cwd.
-	assertContains("pane split w1 --direction down --cwd /tmp/wt --no-focus")
+	// pane split targets the workspace's ROOT PANE id (w1:p1, captured at create),
+	// not the bare workspace id — herdr's pane split needs a pane parent.
+	assertContains("pane split w1:p1 --direction down --cwd /tmp/wt --no-focus")
 	// rename uses "<agent> · d<depth> · <branch>".
 	assertContains("pane rename w1:p2 builder · d1 · feat/x")
 	// report-agent uses the verified source + gm-<jobid8> agent + working.
@@ -885,8 +896,8 @@ func TestFinalizeRootClosesRegistryWorkspaceWithoutPaneRows(t *testing.T) {
 	// Simulate a finished job-mode run: a workspace was registered for the root, but
 	// the pane row was already deleted on the per-Deliver grace close, so no rows
 	// remain under the root.
-	if _, err := store.GetOrCreateWorkspaceForRoot(context.Background(), "root-job", func() (string, error) {
-		return "w-job", nil
+	if _, _, err := store.GetOrCreateWorkspaceForRoot(context.Background(), "root-job", func() (string, string, error) {
+		return "w-job", "w-job:p1", nil
 	}); err != nil {
 		t.Fatalf("seed workspace: %v", err)
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4767,56 +4767,60 @@ func (s *Store) DeleteCockpitPaneByJob(ctx context.Context, jobID string) error 
 // inserter wins and create runs once; losers read the winner's id back without
 // calling create. create is invoked outside the row insert (it shells out to
 // herdr), and a racing insert that loses simply re-reads the committed id.
-func (s *Store) GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, err error)) (string, error) {
+// create returns BOTH the new workspace id and the id of its root pane: herdr's
+// `pane split` requires a PANE id as the split parent (the workspace id is not a
+// valid target), so the root pane id is persisted alongside the workspace and
+// returned on every reuse so subsequent children split off it.
+func (s *Store) GetOrCreateWorkspaceForRoot(ctx context.Context, rootJobID string, create func() (workspaceID string, rootPaneID string, err error)) (workspaceID string, rootPaneID string, err error) {
 	rootJobID = strings.TrimSpace(rootJobID)
 	if rootJobID == "" {
-		return "", errors.New("cockpit workspace root_job_id is required")
+		return "", "", errors.New("cockpit workspace root_job_id is required")
 	}
 	if create == nil {
-		return "", errors.New("cockpit workspace create func is required")
+		return "", "", errors.New("cockpit workspace create func is required")
 	}
 	// Fast path: an existing registration short-circuits without calling create.
-	if existing, err := s.lookupWorkspaceForRoot(ctx, rootJobID); err != nil {
-		return "", err
-	} else if existing != "" {
-		return existing, nil
+	if existingWS, existingRP, err := s.lookupWorkspaceForRoot(ctx, rootJobID); err != nil {
+		return "", "", err
+	} else if existingWS != "" {
+		return existingWS, existingRP, nil
 	}
-	workspaceID, err := create()
+	workspaceID, rootPaneID, err = create()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	workspaceID = strings.TrimSpace(workspaceID)
+	rootPaneID = strings.TrimSpace(rootPaneID)
 	if workspaceID == "" {
-		return "", errors.New("cockpit workspace create returned an empty workspace id")
+		return "", "", errors.New("cockpit workspace create returned an empty workspace id")
 	}
 	// INSERT OR IGNORE: if a concurrent caller already bound this root, our row
 	// is dropped and we fall through to re-read the winning id (our freshly
 	// created workspace is then orphaned, which the cockpit reaper handles).
-	if _, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO cockpit_workspaces(root_job_id, workspace_id) VALUES (?, ?)`,
-		rootJobID, workspaceID); err != nil {
-		return "", err
+	if _, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO cockpit_workspaces(root_job_id, workspace_id, root_pane_id) VALUES (?, ?, ?)`,
+		rootJobID, workspaceID, rootPaneID); err != nil {
+		return "", "", err
 	}
-	stored, err := s.lookupWorkspaceForRoot(ctx, rootJobID)
+	storedWS, storedRP, err := s.lookupWorkspaceForRoot(ctx, rootJobID)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	if stored == "" {
-		// Should not happen: we just inserted-or-ignored. Treat as our id.
-		return workspaceID, nil
+	if storedWS == "" {
+		// Should not happen: we just inserted-or-ignored. Treat as our ids.
+		return workspaceID, rootPaneID, nil
 	}
-	return stored, nil
+	return storedWS, storedRP, nil
 }
 
-func (s *Store) lookupWorkspaceForRoot(ctx context.Context, rootJobID string) (string, error) {
-	var workspaceID string
-	err := s.db.QueryRowContext(ctx, `SELECT workspace_id FROM cockpit_workspaces WHERE root_job_id = ?`, rootJobID).Scan(&workspaceID)
+func (s *Store) lookupWorkspaceForRoot(ctx context.Context, rootJobID string) (workspaceID string, rootPaneID string, err error) {
+	err = s.db.QueryRowContext(ctx, `SELECT workspace_id, root_pane_id FROM cockpit_workspaces WHERE root_job_id = ?`, rootJobID).Scan(&workspaceID, &rootPaneID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", nil
+		return "", "", nil
 	}
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return strings.TrimSpace(workspaceID), nil
+	return strings.TrimSpace(workspaceID), strings.TrimSpace(rootPaneID), nil
 }
 
 // GetWorkspaceForRoot returns the Herdr workspace id registered for an
@@ -4831,7 +4835,7 @@ func (s *Store) GetWorkspaceForRoot(ctx context.Context, rootJobID string) (stri
 	if rootJobID == "" {
 		return "", false, nil
 	}
-	workspaceID, err := s.lookupWorkspaceForRoot(ctx, rootJobID)
+	workspaceID, _, err := s.lookupWorkspaceForRoot(ctx, rootJobID)
 	if err != nil {
 		return "", false, err
 	}
@@ -5671,5 +5675,8 @@ CREATE TABLE cockpit_workspaces (
 	workspace_id TEXT NOT NULL,
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+	`,
+	`
+ALTER TABLE cockpit_workspaces ADD COLUMN root_pane_id TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3397,28 +3397,34 @@ func TestGetOrCreateWorkspaceForRoot(t *testing.T) {
 	defer store.Close()
 
 	var calls atomic.Int64
-	create := func() (string, error) {
+	create := func() (string, string, error) {
 		calls.Add(1)
-		return "ws-created", nil
+		return "ws-created", "ws-created:p1", nil
 	}
 
-	// First call creates and binds the workspace.
-	ws, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-1", create)
+	// First call creates and binds the workspace AND its root pane id.
+	ws, rp, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-1", create)
 	if err != nil {
 		t.Fatalf("GetOrCreateWorkspaceForRoot returned error: %v", err)
 	}
 	if ws != "ws-created" {
 		t.Fatalf("workspace id = %q, want ws-created", ws)
 	}
+	if rp != "ws-created:p1" {
+		t.Fatalf("root pane id = %q, want ws-created:p1", rp)
+	}
 
-	// Repeated calls for the same root return the bound id without calling create.
+	// Repeated calls for the same root return the bound ids without calling create.
 	for i := 0; i < 3; i++ {
-		ws, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-1", create)
+		ws, rp, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-1", create)
 		if err != nil {
 			t.Fatalf("GetOrCreateWorkspaceForRoot (repeat) returned error: %v", err)
 		}
 		if ws != "ws-created" {
 			t.Fatalf("workspace id (repeat) = %q, want ws-created", ws)
+		}
+		if rp != "ws-created:p1" {
+			t.Fatalf("root pane id (repeat) = %q, want ws-created:p1", rp)
 		}
 	}
 	if got := calls.Load(); got != 1 {
@@ -3426,21 +3432,21 @@ func TestGetOrCreateWorkspaceForRoot(t *testing.T) {
 	}
 
 	// A different root creates its own workspace.
-	ws2, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-2", func() (string, error) {
-		return "ws-other", nil
+	ws2, rp2, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-2", func() (string, string, error) {
+		return "ws-other", "ws-other:p1", nil
 	})
 	if err != nil {
 		t.Fatalf("GetOrCreateWorkspaceForRoot(root-2) returned error: %v", err)
 	}
-	if ws2 != "ws-other" {
-		t.Fatalf("workspace id (root-2) = %q, want ws-other", ws2)
+	if ws2 != "ws-other" || rp2 != "ws-other:p1" {
+		t.Fatalf("root-2 = (%q,%q), want (ws-other,ws-other:p1)", ws2, rp2)
 	}
 
 	// Validation: empty root and nil create are rejected.
-	if _, err := store.GetOrCreateWorkspaceForRoot(ctx, "  ", create); err == nil {
+	if _, _, err := store.GetOrCreateWorkspaceForRoot(ctx, "  ", create); err == nil {
 		t.Fatal("GetOrCreateWorkspaceForRoot with empty root returned nil error")
 	}
-	if _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-3", nil); err == nil {
+	if _, _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-3", nil); err == nil {
 		t.Fatal("GetOrCreateWorkspaceForRoot with nil create returned nil error")
 	}
 }
@@ -3466,8 +3472,8 @@ func TestGetAndDeleteWorkspaceForRoot(t *testing.T) {
 		t.Fatalf("GetWorkspaceForRoot(empty) = (found=%v,err=%v), want (false,nil)", found, err)
 	}
 
-	if _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-1", func() (string, error) {
-		return "ws-1", nil
+	if _, _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-1", func() (string, string, error) {
+		return "ws-1", "ws-1:p1", nil
 	}); err != nil {
 		t.Fatalf("seed workspace: %v", err)
 	}
@@ -3500,10 +3506,11 @@ func TestGetOrCreateWorkspaceForRootConcurrent(t *testing.T) {
 
 	const goroutines = 16
 	var calls atomic.Int64
-	create := func() (string, error) {
+	create := func() (string, string, error) {
 		// Each create returns a distinct id so we can verify exactly one wins.
 		n := calls.Add(1)
-		return "ws-" + string(rune('a'+int(n-1))), nil
+		id := "ws-" + string(rune('a'+int(n-1)))
+		return id, id + ":p1", nil
 	}
 
 	var wg sync.WaitGroup
@@ -3514,7 +3521,7 @@ func TestGetOrCreateWorkspaceForRootConcurrent(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 			<-start
-			ws, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-race", create)
+			ws, _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-race", create)
 			if err != nil {
 				t.Errorf("GetOrCreateWorkspaceForRoot(concurrent) returned error: %v", err)
 				return
@@ -3537,9 +3544,9 @@ func TestGetOrCreateWorkspaceForRootConcurrent(t *testing.T) {
 	}
 	// create may run more than once under contention (it shells out before the
 	// insert), but the bound id is stable and matches what every caller sees.
-	final, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-race", func() (string, error) {
+	final, _, err := store.GetOrCreateWorkspaceForRoot(ctx, "root-race", func() (string, string, error) {
 		t.Fatal("create must not run once the root is bound")
-		return "", nil
+		return "", "", nil
 	})
 	if err != nil {
 		t.Fatalf("GetOrCreateWorkspaceForRoot(after race) returned error: %v", err)


### PR DESCRIPTION
## What

The cockpit (`gitmoot orchestrate --cockpit`, #357) **never actually opened a child pane** — it only created an empty `gitmoot ·` workspace that finalize then tore down.

Root cause: herdr's `pane split` requires a **pane id** as the split parent, but `rootPaneFor` returned the **workspace id** (`return workspaceID`). So the very first split always failed with `pane_not_found` and `open()` bailed before persisting any pane.

It was invisible because:
- cockpit errors log at **Debug** (suppressed under the daemon's default slog level), and
- the **fake herdr runner accepted any split parent**, so every unit test passed.

## Fix

- Capture the **root pane id** returned by `workspace create` (it was being discarded), persist it in the `cockpit_workspaces` registry (new `root_pane_id` column + `ALTER TABLE` migration), and return it from `GetOrCreateWorkspaceForRoot` so every child splits off it.
- `rootPaneFor` becomes a defensive `"<ws>:p1"` fallback for **legacy registry rows** whose `root_pane_id` predates the column (it's only reached when the persisted id is empty).
- The fake runner now **rejects a workspace-id split parent** (mirrors real herdr's `pane_not_found`), and the assertions use a root pane id (`w1:proot`) deliberately distinct from the derived fallback — so a revert of `open()` now fails. Added a test for the legacy-row fallback path.

## Verification

- **Live, with real codex**: `orchestrate --cockpit` now opens one pane per delegation subagent — the `gitmoot · …` workspace's `pane_count` grows `2 → 4` as the orchestra fans out (conductor + 2 children) and tears down per job.
- **Mutation-tested** the regression guard: reverting `open()` to use `rootPaneFor` / the bare workspace id now makes the cockpit tests fail (they previously passed).
- Full Go gate green: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./internal/workflow/`.

## Migration

Index-versioned `ALTER TABLE cockpit_workspaces ADD COLUMN root_pane_id TEXT NOT NULL DEFAULT ''` — runs once on existing v0.4.0 DBs (existing rows default to `''` → handled by the fallback) and on fresh DBs after the table CREATE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)