### PR TITLE
docs: v0.4.1 release notes + version bump

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ version: 0.1.0
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.4.0"
+  gitmoot-version: "0.4.1"
   source: "jerryfane/gitmoot"
   openclaw:
     requires:

--- a/docs/release-notes/v0.4.1.md
+++ b/docs/release-notes/v0.4.1.md
@@ -1,0 +1,38 @@
+# Gitmoot v0.4.1
+
+Patch release: fixes a Herdr **cockpit** bug (#357) so `gitmoot orchestrate
+--cockpit` actually opens a live pane per delegation subagent. In v0.4.0 the
+cockpit only ever created an empty workspace.
+
+## Fix
+
+### Cockpit panes now open (#364)
+
+- herdr's `pane split` requires a **pane** id as the split parent, but the
+  cockpit passed the **workspace** id, so the very first split failed with
+  `pane_not_found` and no child pane was ever created — only an empty
+  `gitmoot ·` workspace that finalize then tore down.
+- The root pane id returned by `workspace create` is now captured, persisted in
+  the `cockpit_workspaces` registry (new `root_pane_id` column + an `ALTER TABLE`
+  migration), and used as the split parent; a `<ws>:p1` fallback covers legacy
+  registry rows.
+- The cockpit's test fake now rejects a workspace-id split parent (mirrors real
+  herdr's `pane_not_found`), so this cannot regress.
+
+## Validation
+
+- Verified live with real Codex: `orchestrate --cockpit` opens one pane per
+  delegation subagent — the `gitmoot · …` workspace's pane count grows as the
+  orchestra fans out and tears down per job.
+- `go build` / `go vet` / `go test ./...` and the `-race` workflow suite are
+  green; squash-merged via the CI gate.
+
+## Install / update
+
+```sh
+gitmoot update                                   # existing installs
+curl -fsSL https://gitmoot.io/install.sh | sh    # fresh install
+```
+
+Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
+`sha256sums.txt`.

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -4,7 +4,7 @@ description: Use Gitmoot for local-first AI agent coordination across repositori
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.4.0"
+  gitmoot-version: "0.4.1"
   source: "jerryfane/gitmoot"
 ---
 

--- a/website/docs/release-notes/v0.4.1.md
+++ b/website/docs/release-notes/v0.4.1.md
@@ -1,0 +1,38 @@
+# Gitmoot v0.4.1
+
+Patch release: fixes a Herdr **cockpit** bug (#357) so `gitmoot orchestrate
+--cockpit` actually opens a live pane per delegation subagent. In v0.4.0 the
+cockpit only ever created an empty workspace.
+
+## Fix
+
+### Cockpit panes now open (#364)
+
+- herdr's `pane split` requires a **pane** id as the split parent, but the
+  cockpit passed the **workspace** id, so the very first split failed with
+  `pane_not_found` and no child pane was ever created — only an empty
+  `gitmoot ·` workspace that finalize then tore down.
+- The root pane id returned by `workspace create` is now captured, persisted in
+  the `cockpit_workspaces` registry (new `root_pane_id` column + an `ALTER TABLE`
+  migration), and used as the split parent; a `<ws>:p1` fallback covers legacy
+  registry rows.
+- The cockpit's test fake now rejects a workspace-id split parent (mirrors real
+  herdr's `pane_not_found`), so this cannot regress.
+
+## Validation
+
+- Verified live with real Codex: `orchestrate --cockpit` opens one pane per
+  delegation subagent — the `gitmoot · …` workspace's pane count grows as the
+  orchestra fans out and tears down per job.
+- `go build` / `go vet` / `go test ./...` and the `-race` workflow suite are
+  green; squash-merged via the CI gate.
+
+## Install / update
+
+```sh
+gitmoot update                                   # existing installs
+curl -fsSL https://gitmoot.io/install.sh | sh    # fresh install
+```
+
+Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
+`sha256sums.txt`.

--- a/website/scripts/build-llms-full.mjs
+++ b/website/scripts/build-llms-full.mjs
@@ -24,6 +24,7 @@ const sources = [
   'docs/release-notes/v0.3.0-beta.1.md',
   'docs/release-notes/v0.3.1-beta.1.md',
   'docs/release-notes/v0.4.0.md',
+  'docs/release-notes/v0.4.1.md',
   'skills/gitmoot/SKILL.md',
   'skills/gitmoot/agent-templates/planner.md',
   'skills/gitmoot/references/CLI.md',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -62,6 +62,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Release Notes',
       items: [
+        'release-notes/v0.4.1',
         'release-notes/v0.4.0',
         'release-notes/v0.3.5-beta.1',
         'release-notes/v0.3.4-beta.1',

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -533,7 +533,7 @@ version: 0.1.0
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.4.0"
+  gitmoot-version: "0.4.1"
   source: "jerryfane/gitmoot"
   openclaw:
     requires:
@@ -4960,6 +4960,49 @@ Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
 
 ---
 
+# Source: docs/release-notes/v0.4.1.md
+
+# Gitmoot v0.4.1
+
+Patch release: fixes a Herdr **cockpit** bug (#357) so `gitmoot orchestrate
+--cockpit` actually opens a live pane per delegation subagent. In v0.4.0 the
+cockpit only ever created an empty workspace.
+
+## Fix
+
+### Cockpit panes now open (#364)
+
+- herdr's `pane split` requires a **pane** id as the split parent, but the
+  cockpit passed the **workspace** id, so the very first split failed with
+  `pane_not_found` and no child pane was ever created — only an empty
+  `gitmoot ·` workspace that finalize then tore down.
+- The root pane id returned by `workspace create` is now captured, persisted in
+  the `cockpit_workspaces` registry (new `root_pane_id` column + an `ALTER TABLE`
+  migration), and used as the split parent; a `<ws>:p1` fallback covers legacy
+  registry rows.
+- The cockpit's test fake now rejects a workspace-id split parent (mirrors real
+  herdr's `pane_not_found`), so this cannot regress.
+
+## Validation
+
+- Verified live with real Codex: `orchestrate --cockpit` opens one pane per
+  delegation subagent — the `gitmoot · …` workspace's pane count grows as the
+  orchestra fans out and tears down per job.
+- `go build` / `go vet` / `go test ./...` and the `-race` workflow suite are
+  green; squash-merged via the CI gate.
+
+## Install / update
+
+```sh
+gitmoot update                                   # existing installs
+curl -fsSL https://gitmoot.io/install.sh | sh    # fresh install
+```
+
+Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
+`sha256sums.txt`.
+
+---
+
 # Source: skills/gitmoot/SKILL.md
 
 ---
@@ -4968,7 +5011,7 @@ description: Use Gitmoot for local-first AI agent coordination across repositori
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.4.0"
+  gitmoot-version: "0.4.1"
   source: "jerryfane/gitmoot"
 ---
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -27,7 +27,7 @@ full expanded context.
 - [Codex And Claude Plugins](https://gitmoot.io/docs/plugins/codex-claude): Plugin discovery and runtime skill setup.
 - [SkillOpt Exchange Contract](https://gitmoot.io/docs/reference/skillopt-exchange-contract): Training and candidate package boundary for the external optimizer.
 - [Troubleshooting](https://gitmoot.io/docs/operations/troubleshooting): Diagnose GitHub auth, bug reports, runtimes, agent templates, remotes, permissions, and locks.
-- [Release Notes](https://gitmoot.io/docs/release-notes/v0.4.0): Latest release — SkillOpt judge↔human outcome capture, `judge-report`, per-task_kind judge prompt, judge-prompt optimization.
+- [Release Notes](https://gitmoot.io/docs/release-notes/v0.4.1): Latest release — fixes the Herdr cockpit so `orchestrate --cockpit` opens a live pane per delegation subagent (v0.4.0: SkillOpt judge↔human outcome capture, `judge-report`, per-task_kind judge prompt, judge-prompt optimization).
 - [Raw SKILL.md](https://gitmoot.io/SKILL.md): Agent skill entrypoint.
 - [Full LLM Context](https://gitmoot.io/llms-full.txt): Expanded Markdown context for agents.
 - [GitHub Repository](https://github.com/jerryfane/gitmoot): Source code and releases.


### PR DESCRIPTION
Docs for the **v0.4.1** release (the cockpit pane-split fix, #364 / #357).

## Changes
- **Release notes** added to both doc trees (they don't auto-sync): `docs/release-notes/v0.4.1.md` and `website/docs/release-notes/v0.4.1.md`.
- **Website wiring:** added `release-notes/v0.4.1` to `website/sidebars.ts`, added the file to the `build-llms-full.mjs` manifest, and pointed `llms.txt`'s "Latest release" line at v0.4.1.
- **Version bump:** `gitmoot-version` → `0.4.1` in `SKILL.md` and `skills/gitmoot/SKILL.md`.
- Regenerated `website/static/llms-full.txt` (`npm run build:llms`).

## Verification
- `cd website && npm run build` succeeds (Docusaurus `onBrokenLinks: throw` — so the new sidebar id resolved and there are no broken links); `build/release-notes/v0.4.1.html` is generated.
- `llms-full.txt` now carries the v0.4.1 notes + `gitmoot-version: "0.4.1"`.

The site is **not auto-deployed** — a manual `npm run build` + rsync to `/var/www/gitmoot-docs/` still publishes it to gitmoot.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)