### PR TITLE
fix(daemon): scope backgrounded daemon to --repo + add --session filter (#367)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ ownership, and busy Codex/Claude runtime sessions can fork bounded temporary
 workers when `[parallel_sessions]` allows it. Temp workers still require
 checkout/worktree safety and write-capable agents for implementation jobs.
 
+`gitmoot daemon start --repo owner/repo` scopes the background daemon to that one
+repo; `gitmoot daemon start` with no `--repo` supervises every enabled repo. Both
+`daemon run` and `daemon start` accept `--session <root-job-id>` (alias `--root`)
+to pin the worker to a single orchestration run — it then runs only jobs whose
+`root_job_id` matches that value plus the root coordinator job itself, AND-combined
+with any `--repo` filter:
+
+```sh
+gitmoot daemon start --repo owner/repo --session <root-job-id>
+```
+
 Route work through PR comments:
 
 ```text
@@ -160,7 +171,8 @@ For the full walkthrough, see [docs/local-workflow.md](docs/local-workflow.md).
 - **Repo**: a GitHub repository plus local checkout path that Gitmoot is allowed
   to monitor and mutate.
 - **Daemon**: the local background process that polls GitHub PRs and routes
-  queued jobs.
+  queued jobs. By default it supervises every enabled repo; `--repo` scopes it to
+  one repo and `--session <root-job-id>` scopes it to one orchestration run.
 - **Agent**: a named Gitmoot identity with repo access, role, capabilities, and
   a runtime adapter.
 - **Runtime adapter**: the bridge from Gitmoot jobs to Codex, Claude Code,

--- a/SKILL.md
+++ b/SKILL.md
@@ -131,6 +131,8 @@ gitmoot plugin doctor
 gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
 gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon start --repo owner/repo --session <root-job-id>
+gitmoot daemon start
 gitmoot daemon status
 gitmoot plugin doctor
 gitmoot agent list
@@ -160,7 +162,13 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 ```
 
 Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`
-only when the user explicitly wants a foreground process.
+only when the user explicitly wants a foreground process. `gitmoot daemon start
+--repo owner/repo` scopes the background daemon to that one repo; `gitmoot daemon
+start` with no `--repo` supervises every enabled repo. Both `daemon run` and
+`daemon start` accept `--session <root-job-id>` (alias `--root`) to pin the
+worker to one orchestration run: it then runs only jobs whose `root_job_id`
+matches that value plus the root coordinator job itself, AND-combined with any
+`--repo` filter.
 
 Use `gitmoot agent prompt <agent-or-template>` when the user wants to reuse a
 Gitmoot agent prompt in the current chat. Use `gitmoot agent run` for

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -302,8 +302,26 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    from the matching checkout (the daemon validates the current checkout's
    `origin` remote against `--repo` to bootstrap it). `agent start
    --start-daemon` runs this same background start path for the selected
-   checkout. Use `gitmoot daemon start` without `--repo` after registering all
-   intended repos if one daemon should supervise the whole Gitmoot home.
+   checkout.
+
+   `gitmoot daemon start --repo owner/project` also scopes the background daemon
+   to that one repo: it only polls and runs jobs for `owner/project`. Use
+   `gitmoot daemon start` without `--repo` after registering all intended repos
+   if one daemon should supervise the whole Gitmoot home; that supervises every
+   enabled repo.
+
+   To pin a worker to a single orchestration run, pass `--session <root-job-id>`
+   (alias `--root`) to `daemon run` or `daemon start`:
+
+   ```sh
+   gitmoot daemon start --repo owner/project --session <root-job-id>
+   ```
+
+   With `--session` set, the worker runs only jobs whose `root_job_id` matches
+   that value, plus the root coordinator job itself, and ignores every other
+   queued job. `--session` composes with `--repo` (AND): a job must match both
+   filters to run. Leaving both empty keeps the default of matching all enabled
+   repos and all jobs.
 
    Gitmoot records agent autonomy policy as `read-only`, `workspace-write`,
    `danger-full-access`, or `auto`. For Codex these map to Codex sandbox

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -843,7 +843,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, time.Now().UTC()); err != nil {
 				return err
 			}
-			if err := recoverCancelledRunningJobsForEnabledRepos(ctx, store, stdout); err != nil {
+			if err := recoverCancelledRunningJobsForEnabledRepos(ctx, store, rootFilter, stdout); err != nil {
 				return err
 			}
 			workerErr = startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
@@ -1267,7 +1267,7 @@ func recoverRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.W
 	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, time.Now().UTC().Add(-daemonRunningJobStaleAfter), repoFilter, rootFilter)
 }
 
-func recoverCancelledRunningJobsForEnabledRepos(ctx context.Context, store *db.Store, stdout io.Writer) error {
+func recoverCancelledRunningJobsForEnabledRepos(ctx context.Context, store *db.Store, rootFilter string, stdout io.Writer) error {
 	repos, err := store.ListRepos(ctx)
 	if err != nil {
 		return err
@@ -1276,7 +1276,7 @@ func recoverCancelledRunningJobsForEnabledRepos(ctx context.Context, store *db.S
 		if !repo.Enabled {
 			continue
 		}
-		if err := recoverCancelledRunningJobsForRepo(ctx, store, stdout, repo.FullName(), ""); err != nil {
+		if err := recoverCancelledRunningJobsForRepo(ctx, store, stdout, repo.FullName(), rootFilter); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -108,7 +108,7 @@ func runDaemonStartWithWorkDir(args []string, workDir string, stdout, stderr io.
 		}
 	}
 
-	started, err := startDaemonChild(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, state, resolvedWorkDir)
+	started, err := startDaemonChild(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir)
 	if err != nil {
 		fmt.Fprintf(stderr, "daemon start: %v\n", err)
 		return 1
@@ -128,6 +128,9 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	repoFlag := fs.String("repo", "", "GitHub repository as owner/repo")
+	var session string
+	fs.StringVar(&session, "session", "", "scope the daemon worker to a delegation root job id")
+	fs.StringVar(&session, "root", "", "alias for --session")
 	poll := fs.Duration("poll", 30*time.Second, "poll interval")
 	workers := fs.Int("workers", 1, "worker count")
 	dryRun := fs.Bool("dry-run", false, "run without mutating external systems")
@@ -159,7 +162,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	defer stop()
 
 	if *repoFlag == "" {
-		err := runRegisteredRepoSupervisor(ctx, *home, *poll, *workers, *dryRun, *watchSkillOptReviews, stdout)
+		err := runRegisteredRepoSupervisor(ctx, *home, *poll, *workers, *dryRun, *watchSkillOptReviews, session, stdout)
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return 0
 		}
@@ -198,7 +201,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 			Store:        store,
 			GitHub:       gh,
 			Workflow:     &engine,
-		}, store, *workers, stdout)
+		}, store, *workers, session, stdout)
 	})
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return 0
@@ -401,6 +404,8 @@ type daemonStartConfig struct {
 	RepoFlag                     string
 	Repo                         github.Repository
 	RepoSet                      bool
+	Session                      string
+	ExplicitSession              bool
 	Poll                         time.Duration
 	Workers                      int
 	ExplicitStartConfig          bool
@@ -418,6 +423,9 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	repoFlag := fs.String("repo", "", "GitHub repository as owner/repo")
+	var session string
+	fs.StringVar(&session, "session", "", "scope the daemon worker to a delegation root job id")
+	fs.StringVar(&session, "root", "", "alias for --session")
 	poll := fs.Duration("poll", 30*time.Second, "poll interval")
 	workers := fs.Int("workers", 1, "worker count")
 	watchSkillOptReviews := fs.Bool("watch-skillopt-reviews", false, "poll watched SkillOpt review issue comments and import valid feedback")
@@ -434,6 +442,7 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 	cfg := daemonStartConfig{
 		Home:                 *home,
 		RepoFlag:             *repoFlag,
+		Session:              session,
 		Poll:                 *poll,
 		Workers:              *workers,
 		WatchSkillOptReviews: *watchSkillOptReviews,
@@ -442,6 +451,9 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 		switch f.Name {
 		case "repo":
 			cfg.ExplicitRepo = true
+			cfg.ExplicitStartConfig = true
+		case "session", "root":
+			cfg.ExplicitSession = true
 			cfg.ExplicitStartConfig = true
 		case "poll":
 			cfg.ExplicitPoll = true
@@ -567,6 +579,9 @@ func overlayDaemonStartArgs(args []string, cfg daemonStartConfig) []string {
 	if cfg.ExplicitRepo {
 		args = withDaemonFlagArg(args, "repo", cfg.RepoFlag)
 	}
+	if cfg.ExplicitSession {
+		args = withDaemonFlagArg(args, "session", cfg.Session)
+	}
 	if cfg.ExplicitPoll {
 		args = withDaemonFlagArg(args, "poll", cfg.Poll.String())
 	}
@@ -637,7 +652,7 @@ func currentDaemonPID(state daemonState) (pid int, stale bool, err error) {
 	return pid, false, nil
 }
 
-func startDaemonChild(home string, poll string, workers int, watchSkillOptReviews bool, state daemonState, workDir string) (daemonMeta, error) {
+func startDaemonChild(home string, poll string, workers int, watchSkillOptReviews bool, repo string, session string, state daemonState, workDir string) (daemonMeta, error) {
 	executable, err := os.Executable()
 	if err != nil {
 		return daemonMeta{}, err
@@ -647,7 +662,7 @@ func startDaemonChild(home string, poll string, workers int, watchSkillOptReview
 		return daemonMeta{}, err
 	}
 	defer logFile.Close()
-	args := daemonChildArgs(home, poll, workers, watchSkillOptReviews)
+	args := daemonChildArgs(home, poll, workers, watchSkillOptReviews, repo, session)
 	cmd := exec.Command(executable, args...)
 	cmd.Dir = workDir
 	cmd.Stdout = logFile
@@ -670,10 +685,16 @@ func startDaemonChild(home string, poll string, workers int, watchSkillOptReview
 	}, nil
 }
 
-func daemonChildArgs(home string, poll string, workers int, watchSkillOptReviews bool) []string {
+func daemonChildArgs(home string, poll string, workers int, watchSkillOptReviews bool, repo string, session string) []string {
 	args := []string{"daemon", "run", "--poll", poll, "--workers", strconv.Itoa(workers)}
 	if home != "" {
 		args = append(args, "--home", home)
+	}
+	if repo != "" {
+		args = append(args, "--repo", repo)
+	}
+	if session != "" {
+		args = append(args, "--session", session)
 	}
 	if watchSkillOptReviews {
 		args = append(args, "--watch-skillopt-reviews")
@@ -804,7 +825,7 @@ func hasWhitespace(value string) bool {
 	return strings.ContainsAny(value, " \t\r\n")
 }
 
-func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Duration, workers int, dryRun bool, watchSkillOptReviews bool, stdout io.Writer) error {
+func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Duration, workers int, dryRun bool, watchSkillOptReviews bool, rootFilter string, stdout io.Writer) error {
 	return withStoreAndPaths(home, func(paths config.Paths, store *db.Store) error {
 		schedule := registeredRepoSchedule{
 			NextPoll:    map[string]time.Time{},
@@ -826,7 +847,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 				return err
 			}
 			workerErr = startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
-				return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, stdout, now, checkoutLocks)
+				return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, rootFilter, stdout, now, checkoutLocks)
 			})
 			startCockpitReconcileLoop(ctx, store, paths.Home, stdout)
 		}
@@ -859,14 +880,14 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 	})
 }
 
-func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, store *db.Store, workers int, stdout io.Writer) error {
+func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, store *db.Store, workers int, rootFilter string, stdout io.Writer) error {
 	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, time.Now().UTC()); err != nil {
 		return err
 	}
-	if err := recoverRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName()); err != nil {
+	if err := recoverRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName(), rootFilter); err != nil {
 		return err
 	}
-	if err := recoverCancelledRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName()); err != nil {
+	if err := recoverCancelledRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName(), rootFilter); err != nil {
 		return err
 	}
 	interval := d.PollInterval
@@ -879,7 +900,7 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 	workerErr := startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
 		checkoutLock.Lock()
 		defer checkoutLock.Unlock()
-		return runDaemonWorkerTick(ctx, store, worker, workers, false, d.Repo.FullName(), stdout, now)
+		return runDaemonWorkerTick(ctx, store, worker, workers, false, d.Repo.FullName(), rootFilter, stdout, now)
 	})
 	startCockpitReconcileLoop(ctx, store, home, stdout)
 	for {
@@ -1224,7 +1245,7 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 }
 
 func recoverRunningJobs(ctx context.Context, store *db.Store, stdout io.Writer) error {
-	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, time.Now().UTC().Add(-daemonRunningJobStaleAfter), "")
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, time.Now().UTC().Add(-daemonRunningJobStaleAfter), "", "")
 }
 
 func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time) error {
@@ -1239,11 +1260,11 @@ func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, std
 }
 
 func recoverRunningJobsBefore(ctx context.Context, store *db.Store, stdout io.Writer, before time.Time) error {
-	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, before, "")
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, before, "", "")
 }
 
-func recoverRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.Writer, repoFilter string) error {
-	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, time.Now().UTC().Add(-daemonRunningJobStaleAfter), repoFilter)
+func recoverRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.Writer, repoFilter string, rootFilter string) error {
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, time.Now().UTC().Add(-daemonRunningJobStaleAfter), repoFilter, rootFilter)
 }
 
 func recoverCancelledRunningJobsForEnabledRepos(ctx context.Context, store *db.Store, stdout io.Writer) error {
@@ -1255,20 +1276,20 @@ func recoverCancelledRunningJobsForEnabledRepos(ctx context.Context, store *db.S
 		if !repo.Enabled {
 			continue
 		}
-		if err := recoverCancelledRunningJobsForRepo(ctx, store, stdout, repo.FullName()); err != nil {
+		if err := recoverCancelledRunningJobsForRepo(ctx, store, stdout, repo.FullName(), ""); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func recoverCancelledRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.Writer, repoFilter string) error {
+func recoverCancelledRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.Writer, repoFilter string, rootFilter string) error {
 	jobs, err := store.ListJobs(ctx)
 	if err != nil {
 		return err
 	}
 	for _, job := range jobs {
-		if job.State != string(workflow.JobCancelled) || !queuedJobMatchesRepo(job, repoFilter) {
+		if job.State != string(workflow.JobCancelled) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}
 		settled, err := workflow.SettleCancelledRunningJob(ctx, store, job.ID, "cancelled job recovered after daemon restart")
@@ -1282,13 +1303,13 @@ func recoverCancelledRunningJobsForRepo(ctx context.Context, store *db.Store, st
 	return nil
 }
 
-func recoverRunningJobsBeforeForRepo(ctx context.Context, store *db.Store, stdout io.Writer, before time.Time, repoFilter string) error {
+func recoverRunningJobsBeforeForRepo(ctx context.Context, store *db.Store, stdout io.Writer, before time.Time, repoFilter string, rootFilter string) error {
 	jobs, err := store.ListRunningJobsUpdatedBefore(ctx, before)
 	if err != nil {
 		return err
 	}
 	for _, job := range jobs {
-		if !queuedJobMatchesRepo(job, repoFilter) {
+		if !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}
 		recovered, err := store.TransitionJobStateWithEvent(ctx, job.ID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
@@ -1307,16 +1328,16 @@ func recoverRunningJobsBeforeForRepo(ctx context.Context, store *db.Store, stdou
 }
 
 func runQueuedJobs(ctx context.Context, worker jobWorker, limit int) error {
-	return runQueuedJobsForRepo(ctx, worker, limit, "")
+	return runQueuedJobsForRepo(ctx, worker, limit, "", "")
 }
 
-func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilter string) error {
+func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string) error {
 	jobs, err := worker.Store.ListJobs(ctx)
 	if err != nil {
 		return err
 	}
 	for _, job := range jobs {
-		if !jobStateCanRetryAdvancement(job.State) || !queuedJobMatchesRepo(job, repoFilter) {
+		if !jobStateCanRetryAdvancement(job.State) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}
 		needsRetry, err := worker.jobNeedsAdvanceRetry(ctx, job.ID)
@@ -1333,30 +1354,30 @@ func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilt
 	return nil
 }
 
-func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker, workers int, dryRun bool, repoFilter string, stdout io.Writer, now time.Time) error {
+func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker, workers int, dryRun bool, repoFilter string, rootFilter string, stdout io.Writer, now time.Time) error {
 	if dryRun {
 		return nil
 	}
-	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now.Add(-daemonRunningJobStaleAfter), repoFilter); err != nil {
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now.Add(-daemonRunningJobStaleAfter), repoFilter, rootFilter); err != nil {
 		return err
 	}
 	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, now); err != nil {
 		return err
 	}
-	if err := retryPendingJobAdvancements(ctx, worker, repoFilter); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, repoFilter, rootFilter); err != nil {
 		return err
 	}
-	if err := retryPendingJobComments(ctx, worker, repoFilter); err != nil {
+	if err := retryPendingJobComments(ctx, worker, repoFilter, rootFilter); err != nil {
 		return err
 	}
-	return runQueuedJobsForRepo(ctx, worker, workers, repoFilter)
+	return runQueuedJobsForRepo(ctx, worker, workers, repoFilter, rootFilter)
 }
 
 func runEnabledRepoWorkerTicks(ctx context.Context, store *db.Store, worker jobWorker, workers int, stdout io.Writer, now time.Time) error {
-	return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, stdout, now, nil)
+	return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, "", stdout, now, nil)
 }
 
-func runEnabledRepoWorkerTicksWithLocks(ctx context.Context, store *db.Store, worker jobWorker, workers int, stdout io.Writer, now time.Time, locks *repoCheckoutLocks) error {
+func runEnabledRepoWorkerTicksWithLocks(ctx context.Context, store *db.Store, worker jobWorker, workers int, rootFilter string, stdout io.Writer, now time.Time, locks *repoCheckoutLocks) error {
 	repos, err := store.ListRepos(ctx)
 	if err != nil {
 		return err
@@ -1369,7 +1390,7 @@ func runEnabledRepoWorkerTicksWithLocks(ctx context.Context, store *db.Store, wo
 		if lock != nil {
 			lock.Lock()
 		}
-		if err := runDaemonWorkerTick(ctx, store, worker, workers, false, repo.FullName(), stdout, now); err != nil {
+		if err := runDaemonWorkerTick(ctx, store, worker, workers, false, repo.FullName(), rootFilter, stdout, now); err != nil {
 			if lock != nil {
 				lock.Unlock()
 			}
@@ -1391,13 +1412,13 @@ func jobStateCanRetryAdvancement(state string) bool {
 	}
 }
 
-func retryPendingJobComments(ctx context.Context, worker jobWorker, repoFilter string) error {
+func retryPendingJobComments(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string) error {
 	jobs, err := worker.Store.ListJobs(ctx)
 	if err != nil {
 		return err
 	}
 	for _, job := range jobs {
-		if !jobStateCanRetryComment(job.State) || !queuedJobMatchesRepo(job, repoFilter) {
+		if !jobStateCanRetryComment(job.State) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}
 		needsRetry, err := worker.jobNeedsCommentRetry(ctx, job.ID)
@@ -1427,7 +1448,7 @@ func jobStateCanRetryComment(state string) bool {
 	}
 }
 
-func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repoFilter string) error {
+func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repoFilter string, rootFilter string) error {
 	if limit <= 0 {
 		return nil
 	}
@@ -1437,7 +1458,7 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 	}
 	pending := make([]db.Job, 0, len(jobs))
 	for _, job := range jobs {
-		if queuedJobMatchesRepo(job, repoFilter) {
+		if queuedJobMatchesRepo(job, repoFilter) && queuedJobMatchesSession(job, rootFilter) {
 			pending = append(pending, job)
 		}
 	}
@@ -1575,6 +1596,24 @@ func queuedJobMatchesRepo(job db.Job, repoFilter string) bool {
 	}
 	payload, err := daemonJobPayload(job)
 	return err == nil && payload.Repo == repoFilter
+}
+
+// queuedJobMatchesSession reports whether a job belongs to the delegation tree
+// rooted at rootFilter. An empty filter matches everything (the default daemon
+// behavior). Otherwise a job matches iff it is the root coordinator job itself
+// (job.ID == rootFilter) or carries the root id in its payload
+// (payload.RootJobID == rootFilter); children and continuations inherit the
+// root id via the payload.
+func queuedJobMatchesSession(job db.Job, rootFilter string) bool {
+	rootFilter = strings.TrimSpace(rootFilter)
+	if rootFilter == "" {
+		return true
+	}
+	if job.ID == rootFilter {
+		return true
+	}
+	payload, err := daemonJobPayload(job)
+	return err == nil && payload.RootJobID == rootFilter
 }
 
 func queuedJobCheckoutKey(ctx context.Context, store *db.Store, job db.Job) string {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -211,12 +211,77 @@ func TestDaemonRestartOverlayPreservesSavedArgs(t *testing.T) {
 	}
 }
 
+func TestDaemonStartForwardsRepoAndSessionThroughRestart(t *testing.T) {
+	// The detached child argv carries both filters (this is exactly what
+	// daemonMeta.Args records).
+	childArgs := daemonChildArgs("/tmp/gitmoot-home", "30s", 1, false, "owner/project", "root-coordinator")
+	if !daemonArgsContainFlag(childArgs, "repo", "owner/project") {
+		t.Fatalf("child argv missing --repo: %v", childArgs)
+	}
+	if !daemonArgsContainFlag(childArgs, "session", "root-coordinator") {
+		t.Fatalf("child argv missing --session: %v", childArgs)
+	}
+
+	meta := daemonMeta{Args: childArgs}
+
+	// A restart with no explicit start flags rebuilds the start args from the
+	// saved run args and must preserve both filters.
+	restartCfg, code := parseDaemonStartConfig("daemon restart", nil, io.Discard)
+	if code != 0 {
+		t.Fatalf("parseDaemonStartConfig(restart) code = %d", code)
+	}
+	targetArgs := overlayDaemonStartArgs(daemonStartArgsFromRunArgs(meta.Args), restartCfg)
+	parsed, code := parseDaemonStartConfig("daemon restart", targetArgs, io.Discard)
+	if code != 0 {
+		t.Fatalf("parse restored restart args code = %d, args=%v", code, targetArgs)
+	}
+	if parsed.RepoFlag != "owner/project" {
+		t.Fatalf("restart repo flag = %q, want owner/project; args=%v", parsed.RepoFlag, targetArgs)
+	}
+	if parsed.Session != "root-coordinator" {
+		t.Fatalf("restart session = %q, want root-coordinator; args=%v", parsed.Session, targetArgs)
+	}
+
+	// An explicit --session on restart overlays the saved value.
+	overrideCfg, code := parseDaemonStartConfig("daemon restart", []string{"--session", "other-root"}, io.Discard)
+	if code != 0 {
+		t.Fatalf("parseDaemonStartConfig(override) code = %d", code)
+	}
+	overlaid := overlayDaemonStartArgs(daemonStartArgsFromRunArgs(meta.Args), overrideCfg)
+	parsedOverride, code := parseDaemonStartConfig("daemon restart", overlaid, io.Discard)
+	if code != 0 {
+		t.Fatalf("parse overlaid restart args code = %d, args=%v", code, overlaid)
+	}
+	if parsedOverride.RepoFlag != "owner/project" {
+		t.Fatalf("override repo flag = %q, want owner/project; args=%v", parsedOverride.RepoFlag, overlaid)
+	}
+	if parsedOverride.Session != "other-root" {
+		t.Fatalf("override session = %q, want other-root; args=%v", parsedOverride.Session, overlaid)
+	}
+}
+
+func TestDaemonStartConfigSessionRootAlias(t *testing.T) {
+	parsed, code := parseDaemonStartConfig("daemon start", []string{"--root", "root-coordinator"}, io.Discard)
+	if code != 0 {
+		t.Fatalf("parseDaemonStartConfig(--root) code = %d", code)
+	}
+	if parsed.Session != "root-coordinator" {
+		t.Fatalf("--root session = %q, want root-coordinator", parsed.Session)
+	}
+	if !parsed.ExplicitSession {
+		t.Fatalf("--root did not mark the session as explicit")
+	}
+}
+
 func TestDaemonChildArgsRunAllRepoSupervisor(t *testing.T) {
-	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 2, true)
+	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 2, true, "", "")
 
 	for i, arg := range args {
 		if arg == "--repo" || strings.HasPrefix(arg, "--repo=") {
 			t.Fatalf("daemon child args include repo at index %d: %v", i, args)
+		}
+		if arg == "--session" || strings.HasPrefix(arg, "--session=") {
+			t.Fatalf("daemon child args include session at index %d: %v", i, args)
 		}
 	}
 	parsed, code := parseDaemonStartConfig("daemon restart", args[2:], io.Discard)
@@ -226,9 +291,60 @@ func TestDaemonChildArgsRunAllRepoSupervisor(t *testing.T) {
 	if parsed.RepoSet {
 		t.Fatalf("daemon child args selected single-repo mode: %v", args)
 	}
+	if parsed.Session != "" {
+		t.Fatalf("daemon child args carried a session filter: %v", args)
+	}
 	if parsed.Workers != 2 || parsed.Poll != 30*time.Second || !parsed.WatchSkillOptReviews {
 		t.Fatalf("parsed child args = %+v", parsed)
 	}
+}
+
+func TestDaemonChildArgsForwardsRepo(t *testing.T) {
+	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 1, false, "owner/project", "")
+
+	if !daemonArgsContainFlag(args, "repo", "owner/project") {
+		t.Fatalf("daemon child args missing --repo owner/project: %v", args)
+	}
+	parsed, code := parseDaemonStartConfig("daemon restart", args[2:], io.Discard)
+	if code != 0 {
+		t.Fatalf("parse child args code = %d, args=%v", code, args)
+	}
+	if !parsed.RepoSet || parsed.RepoFlag != "owner/project" {
+		t.Fatalf("parsed child args did not select single-repo mode: %+v args=%v", parsed, args)
+	}
+	if parsed.Session != "" {
+		t.Fatalf("parsed child args carried a session filter: %+v", parsed)
+	}
+}
+
+func TestDaemonChildArgsForwardsSession(t *testing.T) {
+	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 1, false, "owner/project", "root-coordinator")
+
+	if !daemonArgsContainFlag(args, "repo", "owner/project") {
+		t.Fatalf("daemon child args missing --repo owner/project: %v", args)
+	}
+	if !daemonArgsContainFlag(args, "session", "root-coordinator") {
+		t.Fatalf("daemon child args missing --session root-coordinator: %v", args)
+	}
+	parsed, code := parseDaemonStartConfig("daemon restart", args[2:], io.Discard)
+	if code != 0 {
+		t.Fatalf("parse child args code = %d, args=%v", code, args)
+	}
+	if parsed.Session != "root-coordinator" {
+		t.Fatalf("parsed child args session = %q, want root-coordinator; args=%v", parsed.Session, args)
+	}
+}
+
+// daemonArgsContainFlag reports whether argv carries `--name value` as a
+// separate flag/value pair.
+func daemonArgsContainFlag(args []string, name string, value string) bool {
+	flagName := "--" + name
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flagName && args[i+1] == value {
+			return true
+		}
+	}
+	return false
 }
 
 func TestDaemonProcessArgsMatchRequiresSavedArgs(t *testing.T) {
@@ -1085,7 +1201,7 @@ func TestDaemonWorkerTickRetriesFailedResultCommentPost(t *testing.T) {
 	}
 
 	comments.postErr = nil
-	if err := retryPendingJobComments(ctx, worker, "owner/repo"); err != nil {
+	if err := retryPendingJobComments(ctx, worker, "owner/repo", ""); err != nil {
 		t.Fatalf("retryPendingJobComments returned error: %v", err)
 	}
 	if len(comments.posted) != 1 {
@@ -1127,7 +1243,7 @@ func TestRetryPendingJobCommentsPreservesStoredFailureDiagnostic(t *testing.T) {
 		return comments
 	}
 
-	if err := retryPendingJobComments(ctx, worker, "owner/repo"); err != nil {
+	if err := retryPendingJobComments(ctx, worker, "owner/repo", ""); err != nil {
 		t.Fatalf("retryPendingJobComments returned error: %v", err)
 	}
 
@@ -3401,7 +3517,7 @@ func TestRunQueuedJobsForRepoSkipsOtherRepos(t *testing.T) {
 		return adapter, nil
 	}
 
-	if err := runQueuedJobsForRepo(ctx, worker, 2, "owner/repo-a"); err != nil {
+	if err := runQueuedJobsForRepo(ctx, worker, 2, "owner/repo-a", ""); err != nil {
 		t.Fatalf("runQueuedJobsForRepo returned error: %v", err)
 	}
 
@@ -3418,6 +3534,115 @@ func TestRunQueuedJobsForRepoSkipsOtherRepos(t *testing.T) {
 	}
 	if jobB.State != string(workflow.JobQueued) {
 		t.Fatalf("job-b state = %q, want queued", jobB.State)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+}
+
+func TestRunQueuedJobsForRepoSkipsOtherSessions(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo-a")
+	// The root coordinator job (its own id is the root) and a child carrying the
+	// root id both belong to session "root-coordinator"; a job from a different
+	// root does not.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "root-coordinator", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "child-of-root", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 2, RootJobID: "root-coordinator"})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "other-root-job", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 3, RootJobID: "other-root"})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobsForRepo(ctx, worker, 3, "", "root-coordinator"); err != nil {
+		t.Fatalf("runQueuedJobsForRepo returned error: %v", err)
+	}
+
+	root, err := store.GetJob(ctx, "root-coordinator")
+	if err != nil {
+		t.Fatalf("GetJob root-coordinator returned error: %v", err)
+	}
+	child, err := store.GetJob(ctx, "child-of-root")
+	if err != nil {
+		t.Fatalf("GetJob child-of-root returned error: %v", err)
+	}
+	other, err := store.GetJob(ctx, "other-root-job")
+	if err != nil {
+		t.Fatalf("GetJob other-root-job returned error: %v", err)
+	}
+	// The root coordinator (job.ID == session) ran.
+	if root.State != string(workflow.JobSucceeded) {
+		t.Fatalf("root-coordinator state = %q, want succeeded", root.State)
+	}
+	// The child (payload.RootJobID == session) ran.
+	if child.State != string(workflow.JobSucceeded) {
+		t.Fatalf("child-of-root state = %q, want succeeded", child.State)
+	}
+	// The non-matching root stayed queued.
+	if other.State != string(workflow.JobQueued) {
+		t.Fatalf("other-root-job state = %q, want queued", other.State)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+}
+
+func TestRunQueuedJobsForRepoAppliesRepoAndSessionAndMatch(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo-a")
+	if err := store.AllowAgentRepo(ctx, "audit", "owner/repo-b"); err != nil {
+		t.Fatalf("AllowAgentRepo returned error: %v", err)
+	}
+	// Only the job matching BOTH repo AND session should run.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "match", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1, RootJobID: "root-coordinator"})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "wrong-repo", Agent: "audit", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2, RootJobID: "root-coordinator"})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "wrong-session", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 3, RootJobID: "other-root"})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobsForRepo(ctx, worker, 3, "owner/repo-a", "root-coordinator"); err != nil {
+		t.Fatalf("runQueuedJobsForRepo returned error: %v", err)
+	}
+
+	match, err := store.GetJob(ctx, "match")
+	if err != nil {
+		t.Fatalf("GetJob match returned error: %v", err)
+	}
+	wrongRepo, err := store.GetJob(ctx, "wrong-repo")
+	if err != nil {
+		t.Fatalf("GetJob wrong-repo returned error: %v", err)
+	}
+	wrongSession, err := store.GetJob(ctx, "wrong-session")
+	if err != nil {
+		t.Fatalf("GetJob wrong-session returned error: %v", err)
+	}
+	if match.State != string(workflow.JobSucceeded) {
+		t.Fatalf("match state = %q, want succeeded", match.State)
+	}
+	if wrongRepo.State != string(workflow.JobQueued) {
+		t.Fatalf("wrong-repo state = %q, want queued", wrongRepo.State)
+	}
+	if wrongSession.State != string(workflow.JobQueued) {
+		t.Fatalf("wrong-session state = %q, want queued", wrongSession.State)
 	}
 	if adapter.calls != 1 {
 		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
@@ -3521,7 +3746,7 @@ func TestRunQueuedJobsRecordsPostDeliveryWorkflowErrorForRetry(t *testing.T) {
 	}
 	gate.err = nil
 	gate.decision = workflow.MergeDecision{Ready: true}
-	if err := retryPendingJobAdvancements(ctx, worker, ""); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", ""); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 	if adapter.calls != 1 {
@@ -3578,7 +3803,7 @@ func TestRetryPendingJobAdvancementsRecoversStartedAdvancement(t *testing.T) {
 		return workflow.Engine{Store: store, MergeGate: gate}
 	}
 
-	if err := retryPendingJobAdvancements(ctx, worker, ""); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", ""); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 
@@ -3632,7 +3857,7 @@ func TestRetryPendingJobAdvancementsAdvancesFailedStoredResult(t *testing.T) {
 		return workflow.Engine{Store: store}
 	}
 
-	if err := retryPendingJobAdvancements(ctx, worker, ""); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", ""); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 
@@ -3740,7 +3965,7 @@ func TestRetryPendingJobAdvancementsRefreshesImplementedHeadBeforePreflight(t *t
 		return daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
 	}
 
-	if err := retryPendingJobAdvancements(ctx, worker, ""); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", ""); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 
@@ -3880,7 +4105,7 @@ func TestRecoverCancelledRunningJobsSettlesAbandonedCancellation(t *testing.T) {
 		t.Fatalf("CancelJob returned error: %v", err)
 	}
 
-	if err := recoverCancelledRunningJobsForRepo(ctx, store, io.Discard, "owner/repo"); err != nil {
+	if err := recoverCancelledRunningJobsForRepo(ctx, store, io.Discard, "owner/repo", ""); err != nil {
 		t.Fatalf("recoverCancelledRunningJobsForRepo returned error: %v", err)
 	}
 
@@ -3910,7 +4135,7 @@ func TestRecoverCancelledRunningJobsForRepoSkipsOtherRepos(t *testing.T) {
 		}
 	}
 
-	if err := recoverCancelledRunningJobsForRepo(ctx, store, io.Discard, "owner/repo-a"); err != nil {
+	if err := recoverCancelledRunningJobsForRepo(ctx, store, io.Discard, "owner/repo-a", ""); err != nil {
 		t.Fatalf("recoverCancelledRunningJobsForRepo returned error: %v", err)
 	}
 
@@ -3940,7 +4165,7 @@ func TestDaemonWorkerTickRechecksStaleRunningJobs(t *testing.T) {
 	worker := defaultJobWorker(store, io.Discard)
 	now := time.Now().UTC().Add(daemonRunningJobStaleAfter + time.Second)
 
-	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "", io.Discard, now); err != nil {
+	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "", "", io.Discard, now); err != nil {
 		t.Fatalf("runDaemonWorkerTick returned error: %v", err)
 	}
 
@@ -3964,7 +4189,7 @@ func TestRecoverRunningJobsForRepoSkipsOtherRepos(t *testing.T) {
 		}
 	}
 
-	if err := recoverRunningJobsBeforeForRepo(ctx, store, io.Discard, time.Now().UTC().Add(time.Second), "owner/repo-a"); err != nil {
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, io.Discard, time.Now().UTC().Add(time.Second), "owner/repo-a", ""); err != nil {
 		t.Fatalf("recoverRunningJobsBeforeForRepo returned error: %v", err)
 	}
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -55,6 +55,8 @@ snippet with `--config-snippet`.
 gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
 gitmoot daemon start --repo owner/repo --poll 30s --workers 1
+gitmoot daemon start --repo owner/repo --session <root-job-id>
+gitmoot daemon start
 gitmoot daemon status
 gitmoot daemon logs
 gitmoot daemon stop
@@ -68,6 +70,17 @@ Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`
 unless the Gitmoot home has multiple independent runtime sessions or managed
 agent types with `max_background` greater than one.
+
+`daemon start --repo owner/repo` scopes the background daemon to a single repo:
+it only polls and runs jobs for that repo. `daemon start` with no `--repo` still
+supervises every enabled repo in the Gitmoot home.
+
+Both `daemon run` and `daemon start` accept `--session <root-job-id>` (alias
+`--root`) to pin the worker to one orchestration run. With `--session` set, the
+worker runs only jobs whose `root_job_id` matches that value plus the root
+coordinator job itself, and ignores every other queued job. `--session` composes
+with `--repo` (AND): a job must match both filters to run. Leaving both empty
+keeps the default behavior of matching all enabled repos and all jobs.
 
 `gitmoot dashboard` shows local state — daemon health, repos, agents and runtime
 sessions, jobs by state, worktrees, branch locks, SkillOpt train phase/candidate,

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -193,6 +193,15 @@ gitmoot daemon start --repo owner/repo --poll 30s --workers 1
 
 Use `gitmoot daemon run` only when you intentionally want a foreground process.
 
+If queued jobs for one repo never move while another repo's jobs do, check
+whether the daemon was started with `--repo`: `gitmoot daemon start --repo
+owner/repo` scopes the background daemon to that one repo and skips jobs for
+every other repo. Start it without `--repo` to supervise all enabled repos, or
+start a daemon per repo. Likewise, a daemon started with `--session <root-job-id>`
+(alias `--root`) runs only jobs whose `root_job_id` matches that orchestration
+run plus the root coordinator job itself, AND-combined with any `--repo` filter;
+restart it without `--session` to drain unrelated jobs.
+
 ## Job Stuck Or Failed
 
 Symptom: a job is queued, blocked, failed, or no longer changing state.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -55,6 +55,8 @@ snippet with `--config-snippet`.
 gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
 gitmoot daemon start --repo owner/repo --poll 30s --workers 1
+gitmoot daemon start --repo owner/repo --session <root-job-id>
+gitmoot daemon start
 gitmoot daemon status
 gitmoot daemon logs
 gitmoot daemon stop
@@ -68,6 +70,17 @@ Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`
 unless the Gitmoot home has multiple independent runtime sessions or managed
 agent types with `max_background` greater than one.
+
+`daemon start --repo owner/repo` scopes the background daemon to a single repo:
+it only polls and runs jobs for that repo. `daemon start` with no `--repo` still
+supervises every enabled repo in the Gitmoot home.
+
+Both `daemon run` and `daemon start` accept `--session <root-job-id>` (alias
+`--root`) to pin the worker to one orchestration run. With `--session` set, the
+worker runs only jobs whose `root_job_id` matches that value plus the root
+coordinator job itself, and ignores every other queued job. `--session` composes
+with `--repo` (AND): a job must match both filters to run. Leaving both empty
+keeps the default behavior of matching all enabled repos and all jobs.
 
 `gitmoot dashboard` shows local state — daemon health, repos, agents and runtime
 sessions, jobs by state, worktrees, branch locks, SkillOpt train phase/candidate,

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -155,6 +155,17 @@ ownership, and busy Codex/Claude runtime sessions can fork bounded temporary
 workers when `[parallel_sessions]` allows it. Temp workers still require
 checkout/worktree safety and write-capable agents for implementation jobs.
 
+`gitmoot daemon start --repo owner/repo` scopes the background daemon to that one
+repo; `gitmoot daemon start` with no `--repo` supervises every enabled repo. Both
+`daemon run` and `daemon start` accept `--session <root-job-id>` (alias `--root`)
+to pin the worker to a single orchestration run — it then runs only jobs whose
+`root_job_id` matches that value plus the root coordinator job itself, AND-combined
+with any `--repo` filter:
+
+```sh
+gitmoot daemon start --repo owner/repo --session <root-job-id>
+```
+
 Route work through PR comments:
 
 ```text
@@ -170,7 +181,8 @@ For the full walkthrough, see [docs/local-workflow.md](docs/local-workflow.md).
 - **Repo**: a GitHub repository plus local checkout path that Gitmoot is allowed
   to monitor and mutate.
 - **Daemon**: the local background process that polls GitHub PRs and routes
-  queued jobs.
+  queued jobs. By default it supervises every enabled repo; `--repo` scopes it to
+  one repo and `--session <root-job-id>` scopes it to one orchestration run.
 - **Agent**: a named Gitmoot identity with repo access, role, capabilities, and
   a runtime adapter.
 - **Runtime adapter**: the bridge from Gitmoot jobs to Codex, Claude Code,
@@ -659,6 +671,8 @@ gitmoot plugin doctor
 gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
 gitmoot daemon start --repo owner/repo --poll 30s
+gitmoot daemon start --repo owner/repo --session <root-job-id>
+gitmoot daemon start
 gitmoot daemon status
 gitmoot plugin doctor
 gitmoot agent list
@@ -688,7 +702,13 @@ gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issu
 ```
 
 Use `gitmoot daemon start` for the background daemon. Use `gitmoot daemon run`
-only when the user explicitly wants a foreground process.
+only when the user explicitly wants a foreground process. `gitmoot daemon start
+--repo owner/repo` scopes the background daemon to that one repo; `gitmoot daemon
+start` with no `--repo` supervises every enabled repo. Both `daemon run` and
+`daemon start` accept `--session <root-job-id>` (alias `--root`) to pin the
+worker to one orchestration run: it then runs only jobs whose `root_job_id`
+matches that value plus the root coordinator job itself, AND-combined with any
+`--repo` filter.
 
 Use `gitmoot agent prompt <agent-or-template>` when the user wants to reuse a
 Gitmoot agent prompt in the current chat. Use `gitmoot agent run` for
@@ -1166,8 +1186,26 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    from the matching checkout (the daemon validates the current checkout's
    `origin` remote against `--repo` to bootstrap it). `agent start
    --start-daemon` runs this same background start path for the selected
-   checkout. Use `gitmoot daemon start` without `--repo` after registering all
-   intended repos if one daemon should supervise the whole Gitmoot home.
+   checkout.
+
+   `gitmoot daemon start --repo owner/project` also scopes the background daemon
+   to that one repo: it only polls and runs jobs for `owner/project`. Use
+   `gitmoot daemon start` without `--repo` after registering all intended repos
+   if one daemon should supervise the whole Gitmoot home; that supervises every
+   enabled repo.
+
+   To pin a worker to a single orchestration run, pass `--session <root-job-id>`
+   (alias `--root`) to `daemon run` or `daemon start`:
+
+   ```sh
+   gitmoot daemon start --repo owner/project --session <root-job-id>
+   ```
+
+   With `--session` set, the worker runs only jobs whose `root_job_id` matches
+   that value, plus the root coordinator job itself, and ignores every other
+   queued job. `--session` composes with `--repo` (AND): a job must match both
+   filters to run. Leaving both empty keeps the default of matching all enabled
+   repos and all jobs.
 
    Gitmoot records agent autonomy policy as `read-only`, `workspace-write`,
    `danger-full-access`, or `auto`. For Codex these map to Codex sandbox
@@ -5390,6 +5428,8 @@ snippet with `--config-snippet`.
 gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
 gitmoot daemon start --repo owner/repo --poll 30s --workers 1
+gitmoot daemon start --repo owner/repo --session <root-job-id>
+gitmoot daemon start
 gitmoot daemon status
 gitmoot daemon logs
 gitmoot daemon stop
@@ -5403,6 +5443,17 @@ Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`
 unless the Gitmoot home has multiple independent runtime sessions or managed
 agent types with `max_background` greater than one.
+
+`daemon start --repo owner/repo` scopes the background daemon to a single repo:
+it only polls and runs jobs for that repo. `daemon start` with no `--repo` still
+supervises every enabled repo in the Gitmoot home.
+
+Both `daemon run` and `daemon start` accept `--session <root-job-id>` (alias
+`--root`) to pin the worker to one orchestration run. With `--session` set, the
+worker runs only jobs whose `root_job_id` matches that value plus the root
+coordinator job itself, and ignores every other queued job. `--session` composes
+with `--repo` (AND): a job must match both filters to run. Leaving both empty
+keeps the default behavior of matching all enabled repos and all jobs.
 
 `gitmoot dashboard` shows local state — daemon health, repos, agents and runtime
 sessions, jobs by state, worktrees, branch locks, SkillOpt train phase/candidate,


### PR DESCRIPTION
Implements #367.

## WHAT
- **Fix the #367 bug:** `gitmoot daemon start --repo X` (backgrounded) now forwards `--repo` into its detached child, so the daemon actually scopes to repo X instead of falling into the all-repos supervisor and polling every enabled repo.
- **New `--session <rootJobID>` (alias `--root`)** on both `daemon run` and `daemon start`: pins the worker to one orchestration run.

## WHY
The backgrounded path dropped `--repo` in `daemonChildArgs`, so a council run on a throwaway repo fired ~120 stray jobs on unrelated repos. The foreground `daemon run --repo X` was already correctly scoped; this brings the managed background path to parity and adds finer session scoping.

## CHANGES
- `internal/cli/daemon.go`:
  - `daemonChildArgs` / `startDaemonChild` gain `repo` + `session` params and forward `--repo`/`--session` to the child argv (only when non-empty); `runDaemonStartWithWorkDir` passes `cfg.RepoFlag` + `cfg.Session`.
  - Register `--session` (alias `--root`) on `daemon run` and `daemon start`; `daemonStartConfig` gains `Session`/`ExplicitSession`; `overlayDaemonStartArgs` preserves it across restart.
  - New `queuedJobMatchesSession` (empty ⇒ match all; else `job.ID == S` **or** `payload.RootJobID == S`), AND-combined with `queuedJobMatchesRepo` at **every** job-selection gate (`runQueuedJobsForRepo`, retry/advance/comment, running + cancelled recovery, single- and multi-repo supervisors). An optional `rootFilter` is threaded alongside the existing `repoFilter`.
  - Default path (no `--repo`, no `--session`) is byte-identical: the empty-filter check returns before any payload parse.
- Docs (both trees, no auto-sync): `docs/local-workflow.md`, `README.md`, `SKILL.md`, `skills/gitmoot/references/CLI.md` + mirror `website/docs/reference/cli.md`, `website/docs/operations/troubleshooting.md`; regenerated `website/static/llms-full.txt`.

## RESULTS
- `go build ./... && go vet ./... && go test ./...` and `go test -race ./internal/workflow/` green; `go test ./internal/cli/ ./internal/daemon/` green. Website build clean (`onBrokenLinks: throw`).
- New unit tests: child-arg forwarding (`--repo`/`--session`), restart/overlay preservation, `--root` alias, and session-skip filter cases (root via `job.ID==S`, child via `payload.RootJobID==S`, repo+session AND-match).
- **Live E2E** (isolated `--home`, two fake repos): `daemon start --repo A --session S` → spawned child argv carries `--repo A --session S` and the daemon polls **only** repo A (repo B: 0); `daemon start` (no flags) → child argv has **no** `--repo` and supervises **both** repos.
- `/code-review` (high) found one real issue — the multi-repo cancelled-job startup recovery ignored the session filter — now fixed (it threads `rootFilter` like the single-repo path).

## RISK
- Low. Default (unfiltered) behavior is unchanged and unit-covered. The `--session`-without-`--repo` (multi-repo) variant still polls all repos but only *runs* the pinned session's jobs (intended). Deliberately **out of scope** (per #367): full per-session isolation (scoped lock namespaces, per-space pidfile). A `jobFilter{repo,root}` struct (vs. two parallel params) was considered and deferred — correctness verified, refactor would be broader than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
