### PR TITLE
feat(workflow): opt-in inline of child artifact_body in continuation (#368)

### DIFF
--- a/docs/cockpit-orchestrate.md
+++ b/docs/cockpit-orchestrate.md
@@ -73,6 +73,8 @@ cockpit_mode = "auto"      # on | off | auto (auto = on when launched in a Herdr
 cockpit_session = ""       # default Herdr session/workspace label ("" = per-run)
 cockpit_max_panes = 4      # cap on simultaneous panes per run
 cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
+inline_artifact_bodies = false   # inline each child's artifact_body into the coordinator continuation
+inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
 ```
 
 - `cockpit_mode = "off"` disables the cockpit even if `--cockpit` was passed;
@@ -83,6 +85,14 @@ cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per rol
 - `cockpit_pane_key = "job"` opens one pane per child job. `seat` mode reuses a
   single pane per logical role across phases (a later phase) so a long run does
   not accumulate panes.
+- `inline_artifact_bodies` (default `false`) inlines each child's `artifact_body`
+  into the coordinator continuation prompt as a fenced block, so the coordinator
+  reads the briefs without re-fetching them from disk. Off by default, the
+  continuation is byte-identical to before.
+- `inline_artifact_max_bytes` (default `32768`, i.e. 32 KiB per body) caps how
+  many bytes of each child's body are inlined; longer bodies are rune-safe
+  truncated with a marker pointing at the full on-disk brief. A per-continuation
+  aggregate cap also bounds the total inlined across all children.
 
 ## Constrained hosts
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -194,6 +194,9 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 			Store:     store,
 			MergeGate: newDaemonPolicyMergeGate(store, gh, checkout),
 		}
+		// Honor the opt-in [orchestrate] artifact-body inlining policy on this
+		// single-repo engine too; fail-safe to off if the policy cannot load.
+		defaultJobWorker(store, stdout, *home).applyInlineArtifactPolicy(&engine)
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
 		return runSingleRepoSupervisor(ctx, *home, daemon.Daemon{
 			Repo:         repo,
@@ -2953,7 +2956,21 @@ func (w jobWorker) defaultStartAdapter(runtimeName string, checkout string) (run
 }
 
 func (w jobWorker) defaultWorkflow(checkout string) workflow.Engine {
-	return daemonWorkflowEngine(w.Store, github.NewClient(checkout), checkout, w.workflowHome())
+	engine := daemonWorkflowEngine(w.Store, github.NewClient(checkout), checkout, w.workflowHome())
+	w.applyInlineArtifactPolicy(&engine)
+	return engine
+}
+
+// applyInlineArtifactPolicy sets the engine's opt-in artifact-body inlining fields
+// from the host [orchestrate] policy. It is fail-safe: any load error leaves the
+// engine with inlining off (the default) rather than failing engine construction.
+func (w jobWorker) applyInlineArtifactPolicy(engine *workflow.Engine) {
+	policy, err := w.orchestratePolicy()
+	if err != nil {
+		return
+	}
+	engine.InlineArtifactBodies = policy.InlineArtifactBodies
+	engine.MaxInlineArtifactBytes = policy.InlineArtifactMaxBytes
 }
 
 // workflowHome resolves the GITMOOT_HOME root used to place per-delegation

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -31,14 +31,23 @@ type OrchestratePolicy struct {
 	CockpitSession  string
 	CockpitMaxPanes int
 	CockpitPaneKey  string
+	// InlineArtifactBodies opts the coordinator continuation prompt into inlining
+	// each finished child's artifact_body as a fenced block (see issue #368). It is
+	// off by default because inlined briefs can be large.
+	InlineArtifactBodies bool
+	// InlineArtifactMaxBytes is the per-body byte cap applied when
+	// InlineArtifactBodies is set; 0 means the engine's built-in default.
+	InlineArtifactMaxBytes int
 }
 
 func DefaultOrchestratePolicy() OrchestratePolicy {
 	return OrchestratePolicy{
-		CockpitMode:     CockpitModeAuto,
-		CockpitSession:  "",
-		CockpitMaxPanes: 4,
-		CockpitPaneKey:  CockpitPaneKeyJob,
+		CockpitMode:            CockpitModeAuto,
+		CockpitSession:         "",
+		CockpitMaxPanes:        4,
+		CockpitPaneKey:         CockpitPaneKeyJob,
+		InlineArtifactBodies:   false,
+		InlineArtifactMaxBytes: 0,
 	}
 }
 
@@ -93,6 +102,14 @@ func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value st
 	case "cockpit_pane_key":
 		parsed, err := parseConfigString(value)
 		policy.CockpitPaneKey = strings.TrimSpace(parsed)
+		return err
+	case "inline_artifact_bodies":
+		parsed, err := strconv.ParseBool(value)
+		policy.InlineArtifactBodies = parsed
+		return err
+	case "inline_artifact_max_bytes":
+		parsed, err := strconv.Atoi(value)
+		policy.InlineArtifactMaxBytes = parsed
 		return err
 	default:
 		return nil

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -29,6 +29,54 @@ func TestLoadOrchestratePolicyDefaults(t *testing.T) {
 	if policy.CockpitPaneKey != CockpitPaneKeyJob {
 		t.Fatalf("CockpitPaneKey = %q, want %q", policy.CockpitPaneKey, CockpitPaneKeyJob)
 	}
+	if policy.InlineArtifactBodies {
+		t.Fatalf("InlineArtifactBodies = true, want false by default")
+	}
+	if policy.InlineArtifactMaxBytes != 0 {
+		t.Fatalf("InlineArtifactMaxBytes = %d, want 0 by default", policy.InlineArtifactMaxBytes)
+	}
+}
+
+// TestLoadOrchestratePolicyInlineArtifactKeys pins #368: both inline-artifact keys
+// parse from [orchestrate], and absent keys default off.
+func TestLoadOrchestratePolicyInlineArtifactKeys(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+inline_artifact_bodies = true
+inline_artifact_max_bytes = 4096
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	policy, err := LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if !policy.InlineArtifactBodies {
+		t.Fatalf("InlineArtifactBodies = false, want true")
+	}
+	if policy.InlineArtifactMaxBytes != 4096 {
+		t.Fatalf("InlineArtifactMaxBytes = %d, want 4096", policy.InlineArtifactMaxBytes)
+	}
+
+	// Absent keys keep the off default even when the section is otherwise present.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+cockpit_mode = "auto"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err = LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.InlineArtifactBodies || policy.InlineArtifactMaxBytes != 0 {
+		t.Fatalf("absent inline keys should default off, got %+v", policy)
+	}
 }
 
 func TestLoadOrchestratePolicyOverrides(t *testing.T) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1962,16 +1962,48 @@ func (e Engine) appendInlineArtifactBody(builder *strings.Builder, payload JobPa
 	}
 	truncated, omitted := truncateUTF8Bytes(body, limit)
 	*remaining -= len(truncated)
-	builder.WriteString("  artifact_body:\n")
-	builder.WriteString("```\n")
-	builder.WriteString(truncated)
+	// Assemble the inner block (body + optional truncation marker) first, then pick
+	// a fence longer than the longest backtick run inside it. A plain ``` fence is
+	// broken by a body that itself contains ``` (briefs/reviews routinely embed code
+	// fences), which would let an embedded gitmoot_result sentinel escape — exactly
+	// what fencing must prevent.
+	var inner strings.Builder
+	inner.WriteString(truncated)
 	if !strings.HasSuffix(truncated, "\n") {
-		builder.WriteString("\n")
+		inner.WriteString("\n")
 	}
 	if omitted > 0 {
-		fmt.Fprintf(builder, "... (%d bytes truncated; full brief at %s)\n", omitted, e.inlineBriefPath(childJobID))
+		fmt.Fprintf(&inner, "... (%d bytes truncated; full brief at %s)\n", omitted, e.inlineBriefPath(childJobID))
 	}
-	builder.WriteString("```\n")
+	fence := artifactBodyFence(inner.String())
+	builder.WriteString("  artifact_body:\n")
+	builder.WriteString(fence)
+	builder.WriteString("\n")
+	builder.WriteString(inner.String())
+	builder.WriteString(fence)
+	builder.WriteString("\n")
+}
+
+// artifactBodyFence returns a backtick fence guaranteed longer than the longest
+// run of backticks in content, so an embedded ``` (or a sentinel wrapped in one)
+// cannot terminate the fenced block early. Minimum three backticks.
+func artifactBodyFence(content string) string {
+	longest, run := 0, 0
+	for _, r := range content {
+		if r == '`' {
+			run++
+			if run > longest {
+				longest = run
+			}
+			continue
+		}
+		run = 0
+	}
+	n := longest + 1
+	if n < 3 {
+		n = 3
+	}
+	return strings.Repeat("`", n)
 }
 
 // inlineBriefPath renders the on-disk location of the parent's full brief.md, the

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -44,6 +44,18 @@ type Engine struct {
 	// optional and defaults to time.Now; tests inject it to drive the per-root
 	// wall-clock backstop (see MaxDelegationWallClock) deterministically.
 	Now func() time.Time
+	// InlineArtifactBodies, when true, makes buildContinuationPrompt append each
+	// finished child's payload.Result.ArtifactBody as a fenced block after the
+	// child's decision/summary/PR line, so a coordinator continuation can read the
+	// child briefs inline rather than re-opening every child job. It is opt-in
+	// (default false) because inlining bodies can be large; when false the
+	// continuation prompt is byte-identical to the legacy output.
+	InlineArtifactBodies bool
+	// MaxInlineArtifactBytes is the per-body cap (in bytes) applied to each child's
+	// inlined ArtifactBody when InlineArtifactBodies is true. A value <= 0 means
+	// defaultMaxInlineArtifactBytes. The total inlined across all children in one
+	// continuation is additionally bounded by maxInlineArtifactTotalBytes.
+	MaxInlineArtifactBytes int
 }
 
 // now returns the engine's current time, defaulting to time.Now when Now is unset.
@@ -620,6 +632,16 @@ const MaxDelegationTotalJobs = 64
 // width of a single dispatch so a coordinator returning hundreds of delegations
 // at once is refused with a delegation_width_exceeded event.
 const MaxDelegationWidth = 16
+
+// defaultMaxInlineArtifactBytes is the per-body cap applied to each child's
+// inlined ArtifactBody in a coordinator continuation prompt when
+// Engine.MaxInlineArtifactBytes is unset (<= 0). See InlineArtifactBodies.
+const defaultMaxInlineArtifactBytes = 32 * 1024
+
+// maxInlineArtifactTotalBytes bounds the aggregate of all child ArtifactBodies
+// inlined into a single coordinator continuation prompt, independent of the
+// per-body cap, so a wide fan-out of briefs cannot balloon one continuation.
+const maxInlineArtifactTotalBytes = 128 * 1024
 
 // MaxDelegationWallClock bounds how long a single coordination tree (all children
 // and continuations sharing one root, see rootJobID) may run before a coordinator
@@ -1496,7 +1518,7 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		LeadAgent:    parentPayload.LeadAgent,
 		Reviewers:    parentPayload.Reviewers,
 		Sender:       parentJob.Agent,
-		Instructions: buildContinuationPrompt(parentResult, children, childPayloads),
+		Instructions: e.buildContinuationPrompt(parentResult, children, childPayloads),
 		Constraints:  parentPayload.Constraints,
 		ParentJobID:  parentJob.ID,
 		// Increment depth per continuation generation so a coordinator whose
@@ -1867,10 +1889,13 @@ func delegationContinuationID(parentJobID string) string {
 // buildContinuationPrompt inlines each finished child's job id, agent, decision,
 // summary, and PR link into the coordinator continuation prompt so the
 // coordinator can synthesize the results without re-reading every child job.
-func buildContinuationPrompt(parentResult *AgentResult, children map[string]db.Job, childPayloads map[string]JobPayload) string {
+func (e Engine) buildContinuationPrompt(parentResult *AgentResult, children map[string]db.Job, childPayloads map[string]JobPayload) string {
 	var builder strings.Builder
 	builder.WriteString("All delegated jobs have finished. Review the results below and decide the next step.\n\n")
 	builder.WriteString("Delegation results:\n")
+	// remainingInline tracks the aggregate ArtifactBody budget across all children
+	// for this continuation; only consulted when InlineArtifactBodies is set.
+	remainingInline := maxInlineArtifactTotalBytes
 	for _, d := range parentResult.Delegations {
 		child, ok := children[d.ID]
 		if !ok {
@@ -1896,11 +1921,104 @@ func buildContinuationPrompt(parentResult *AgentResult, children map[string]db.J
 			fmt.Fprintf(&builder, " (%s)", link)
 		}
 		builder.WriteString("\n")
+		// Opt-in: inline the child's brief body as a fenced block so a downstream
+		// model reads it inline. Guarded entirely behind the flag so the disabled
+		// output is byte-identical to the legacy prompt.
+		if e.InlineArtifactBodies {
+			e.appendInlineArtifactBody(&builder, childPayloads[d.ID], child.ID, &remainingInline)
+		}
 	}
 	// Completion contract: make termination directed. The engine already treats
 	// an empty delegations list as terminal, so spell it out for the agent.
 	builder.WriteString("\n\nIf the goal is now complete, return your result with an EMPTY delegations list to finish. Only return new delegations if more work is genuinely required.")
 	return builder.String()
+}
+
+// appendInlineArtifactBody writes a fenced block containing the child's
+// payload.Result.ArtifactBody, rune-safe truncated to the per-body cap
+// (e.MaxInlineArtifactBytes or defaultMaxInlineArtifactBytes) and further bounded
+// by the per-continuation aggregate budget (*remaining). The block is fenced so an
+// embedded gitmoot_result sentinel inside a body cannot confuse a downstream
+// model. When truncation occurs a trailing marker points at the full brief on
+// disk. It is only called when Engine.InlineArtifactBodies is true.
+func (e Engine) appendInlineArtifactBody(builder *strings.Builder, payload JobPayload, childJobID string, remaining *int) {
+	if payload.Result == nil {
+		return
+	}
+	body := payload.Result.ArtifactBody
+	if body == "" {
+		return
+	}
+	perBody := e.MaxInlineArtifactBytes
+	if perBody <= 0 {
+		perBody = defaultMaxInlineArtifactBytes
+	}
+	limit := perBody
+	if *remaining < limit {
+		limit = *remaining
+	}
+	if limit <= 0 {
+		return
+	}
+	truncated, omitted := truncateUTF8Bytes(body, limit)
+	*remaining -= len(truncated)
+	builder.WriteString("  artifact_body:\n")
+	builder.WriteString("```\n")
+	builder.WriteString(truncated)
+	if !strings.HasSuffix(truncated, "\n") {
+		builder.WriteString("\n")
+	}
+	if omitted > 0 {
+		fmt.Fprintf(builder, "... (%d bytes truncated; full brief at %s)\n", omitted, e.inlineBriefPath(childJobID))
+	}
+	builder.WriteString("```\n")
+}
+
+// inlineBriefPath renders the on-disk location of the parent's full brief.md, the
+// same path writeDelegationArtifacts uses (ArtifactRoot/delegations/<sanitized
+// parent job id>/brief.md). The parent job id is recovered from a child job id by
+// stripping the trailing "/delegation/<child>" suffix; on any failure it falls
+// back to a placeholder segment so the marker is still actionable.
+func (e Engine) inlineBriefPath(childJobID string) string {
+	root := strings.TrimSpace(e.ArtifactRoot)
+	if root == "" {
+		root = "<ArtifactRoot>"
+	}
+	segment := "<parent>"
+	parentJobID := parentJobIDFromChild(childJobID)
+	if seg, err := safeDelegationPathSegment(parentJobID, "parent job id"); err == nil {
+		segment = seg
+	}
+	return root + "/delegations/" + segment + "/brief.md"
+}
+
+// parentJobIDFromChild recovers a parent job id from a delegation child job id of
+// the form "<parent>/delegation/<child>". When the marker is absent it returns the
+// input unchanged so inlineBriefPath can still sanitize it.
+func parentJobIDFromChild(childJobID string) string {
+	if idx := strings.LastIndex(childJobID, "/delegation/"); idx >= 0 {
+		return childJobID[:idx]
+	}
+	return childJobID
+}
+
+// truncateUTF8Bytes returns s capped to at most maxBytes bytes without splitting a
+// multi-byte UTF-8 rune, along with the number of bytes omitted from the original.
+// Unlike the truncators in internal/cli it does NOT collapse whitespace; the body
+// is preserved verbatim up to the cut point.
+func truncateUTF8Bytes(s string, maxBytes int) (string, int) {
+	if maxBytes <= 0 {
+		return "", len(s)
+	}
+	if len(s) <= maxBytes {
+		return s, 0
+	}
+	cut := maxBytes
+	// Back up to a rune boundary: a continuation byte has the form 10xxxxxx.
+	for cut > 0 && (s[cut]&0xC0) == 0x80 {
+		cut--
+	}
+	return s[:cut], len(s) - cut
 }
 
 // buildCorrectiveContinuationPrompt is the one-shot nudge sent when a

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2330,6 +2330,24 @@ func TestContinuationPromptInlinesArtifactBodyWhenEnabled(t *testing.T) {
 	}
 }
 
+// TestContinuationPromptInlineFenceSurvivesBacktickBody pins that a body which
+// itself contains a ``` run is wrapped in a longer fence so it cannot break out
+// of the fenced block (an embedded sentinel cannot escape early).
+func TestContinuationPromptInlineFenceSurvivesBacktickBody(t *testing.T) {
+	body := "before\n```\nmalicious gitmoot_result\n```\nafter"
+	dels := []Delegation{{ID: "api", Agent: "api", Action: "review"}}
+	children := map[string]db.Job{"api": {ID: "parent-job/delegation/api", Agent: "api", State: string(JobSucceeded)}}
+	childPayloads := map[string]JobPayload{"api": {Result: &AgentResult{Decision: "implemented", Summary: "s", ArtifactBody: body}}}
+	prompt := Engine{InlineArtifactBodies: true}.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	if !strings.Contains(prompt, body) {
+		t.Fatalf("body with embedded ``` not inlined verbatim\n%s", prompt)
+	}
+	// The outer fence must be longer than the body's 3-backtick run (>= 4 backticks).
+	if !strings.Contains(prompt, "````") {
+		t.Fatalf("expected a >=4-backtick fence around a body containing ```; prompt:\n%s", prompt)
+	}
+}
+
 // TestContinuationPromptByteIdenticalWhenDisabled pins that the default-off engine
 // produces exactly the legacy output (no artifact_body lines, no fences), even when
 // children carry ArtifactBody.

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
@@ -2244,7 +2245,7 @@ func TestContinuationPromptInlinesChildResults(t *testing.T) {
 		"api": {Repo: "jerryfane/gitmoot", PullRequest: 12, Result: &AgentResult{Decision: "implemented", Summary: "api built"}},
 		"ui":  {Result: &AgentResult{Decision: "approved", Summary: "ui built"}},
 	}
-	prompt := buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	prompt := Engine{}.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
 	for _, want := range []string{
 		"parent-job/delegation/api",
 		"parent-job/delegation/ui",
@@ -2273,7 +2274,7 @@ func TestContinuationPromptIncludesPhase(t *testing.T) {
 		"api": {Result: &AgentResult{Decision: "implemented", Summary: "api built"}},
 		"ui":  {Result: &AgentResult{Decision: "approved", Summary: "ui built"}},
 	}
-	withPhase := buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	withPhase := Engine{}.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
 	if !strings.Contains(withPhase, "[phase: design]") {
 		t.Fatalf("continuation prompt missing phase label\n%s", withPhase)
 	}
@@ -2284,7 +2285,7 @@ func TestContinuationPromptIncludesPhase(t *testing.T) {
 		{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
 		{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
 	}
-	noPhase := buildContinuationPrompt(&AgentResult{Delegations: noPhaseDels}, children, childPayloads)
+	noPhase := Engine{}.buildContinuationPrompt(&AgentResult{Delegations: noPhaseDels}, children, childPayloads)
 	if strings.Contains(noPhase, "phase") {
 		t.Fatalf("continuation prompt must not mention phase when none set\n%s", noPhase)
 	}
@@ -2295,8 +2296,150 @@ func TestContinuationPromptIncludesPhase(t *testing.T) {
 		{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
 		{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
 	}
-	if got := buildContinuationPrompt(&AgentResult{Delegations: cleared}, children, childPayloads); got != noPhase {
+	if got := (Engine{}).buildContinuationPrompt(&AgentResult{Delegations: cleared}, children, childPayloads); got != noPhase {
 		t.Fatalf("clearing phase changed the prompt:\n--- got ---\n%s\n--- want ---\n%s", got, noPhase)
+	}
+}
+
+// TestContinuationPromptInlinesArtifactBodyWhenEnabled pins #368: with the opt-in
+// toggle on, each finished child's ArtifactBody is appended as a fenced block after
+// its result line.
+func TestContinuationPromptInlinesArtifactBodyWhenEnabled(t *testing.T) {
+	dels := []Delegation{
+		{ID: "api", Agent: "api", Action: "review"},
+		{ID: "ui", Agent: "ui", Action: "review"},
+	}
+	children := map[string]db.Job{
+		"api": {ID: "parent-job/delegation/api", Agent: "api", State: string(JobSucceeded)},
+		"ui":  {ID: "parent-job/delegation/ui", Agent: "ui", State: string(JobSucceeded)},
+	}
+	childPayloads := map[string]JobPayload{
+		"api": {Result: &AgentResult{Decision: "implemented", Summary: "api built", ArtifactBody: "API BRIEF BODY"}},
+		"ui":  {Result: &AgentResult{Decision: "approved", Summary: "ui built", ArtifactBody: "UI BRIEF BODY"}},
+	}
+	engine := Engine{InlineArtifactBodies: true}
+	prompt := engine.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	for _, want := range []string{"API BRIEF BODY", "UI BRIEF BODY", "artifact_body:", "```"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("inline-enabled continuation prompt missing %q\n%s", want, prompt)
+		}
+	}
+	// The body must be fenced (a ``` opens before each body).
+	if strings.Count(prompt, "```") < 4 {
+		t.Fatalf("expected each inlined body fenced (>=4 ``` markers), got %d\n%s", strings.Count(prompt, "```"), prompt)
+	}
+}
+
+// TestContinuationPromptByteIdenticalWhenDisabled pins that the default-off engine
+// produces exactly the legacy output (no artifact_body lines, no fences), even when
+// children carry ArtifactBody.
+func TestContinuationPromptByteIdenticalWhenDisabled(t *testing.T) {
+	dels := []Delegation{
+		{ID: "api", Agent: "api", Action: "review"},
+		{ID: "ui", Agent: "ui", Action: "review"},
+	}
+	children := map[string]db.Job{
+		"api": {ID: "parent-job/delegation/api", Agent: "api", State: string(JobSucceeded)},
+		"ui":  {ID: "parent-job/delegation/ui", Agent: "ui", State: string(JobSucceeded)},
+	}
+	withBody := map[string]JobPayload{
+		"api": {Result: &AgentResult{Decision: "implemented", Summary: "api built", ArtifactBody: "API BRIEF BODY"}},
+		"ui":  {Result: &AgentResult{Decision: "approved", Summary: "ui built", ArtifactBody: "UI BRIEF BODY"}},
+	}
+	noBody := map[string]JobPayload{
+		"api": {Result: &AgentResult{Decision: "implemented", Summary: "api built"}},
+		"ui":  {Result: &AgentResult{Decision: "approved", Summary: "ui built"}},
+	}
+	// Default-off engine ignores ArtifactBody entirely: output equals the legacy
+	// rendering produced for the same children without any body present.
+	got := Engine{}.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, withBody)
+	want := Engine{}.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, noBody)
+	if got != want {
+		t.Fatalf("default-off prompt not byte-identical to legacy:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	if strings.Contains(got, "artifact_body") || strings.Contains(got, "```") {
+		t.Fatalf("default-off prompt must not inline bodies\n%s", got)
+	}
+}
+
+// TestContinuationPromptInlineOverCapTruncatedWithMarker pins per-body truncation:
+// a body larger than the per-body cap is cut and a marker pointing at the on-disk
+// brief is appended.
+func TestContinuationPromptInlineOverCapTruncatedWithMarker(t *testing.T) {
+	body := strings.Repeat("x", 100)
+	dels := []Delegation{{ID: "api", Agent: "api", Action: "review"}}
+	children := map[string]db.Job{
+		"api": {ID: "parent-job/delegation/api", Agent: "api", State: string(JobSucceeded)},
+	}
+	childPayloads := map[string]JobPayload{
+		"api": {Result: &AgentResult{Decision: "implemented", ArtifactBody: body}},
+	}
+	engine := Engine{InlineArtifactBodies: true, MaxInlineArtifactBytes: 10, ArtifactRoot: "/home/.gitmoot"}
+	prompt := engine.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	if !strings.Contains(prompt, strings.Repeat("x", 10)) {
+		t.Fatalf("expected the first 10 bytes inlined\n%s", prompt)
+	}
+	if strings.Contains(prompt, strings.Repeat("x", 11)) {
+		t.Fatalf("body not truncated to the per-body cap\n%s", prompt)
+	}
+	wantMarker := "... (90 bytes truncated; full brief at /home/.gitmoot/delegations/parent-job/brief.md)"
+	if !strings.Contains(prompt, wantMarker) {
+		t.Fatalf("expected truncation marker %q\n%s", wantMarker, prompt)
+	}
+}
+
+// TestContinuationPromptInlineRuneSafe pins that truncation at the byte cap does not
+// split a multi-byte UTF-8 rune.
+func TestContinuationPromptInlineRuneSafe(t *testing.T) {
+	// Each "世" is 3 bytes. A cap of 10 lands mid-rune (3*3=9 < 10 < 12); the helper
+	// must back up to 9 bytes (three full runes) rather than emit a broken rune.
+	body := strings.Repeat("世", 10)
+	dels := []Delegation{{ID: "api", Agent: "api", Action: "review"}}
+	children := map[string]db.Job{
+		"api": {ID: "parent-job/delegation/api", Agent: "api", State: string(JobSucceeded)},
+	}
+	childPayloads := map[string]JobPayload{
+		"api": {Result: &AgentResult{Decision: "implemented", ArtifactBody: body}},
+	}
+	engine := Engine{InlineArtifactBodies: true, MaxInlineArtifactBytes: 10}
+	prompt := engine.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	if !utf8.ValidString(prompt) {
+		t.Fatalf("inlined prompt contains an invalid (split) UTF-8 rune\n%q", prompt)
+	}
+	if !strings.Contains(prompt, strings.Repeat("世", 3)) {
+		t.Fatalf("expected three full runes inlined\n%s", prompt)
+	}
+	if strings.Contains(prompt, strings.Repeat("世", 4)) {
+		t.Fatalf("expected at most three full runes under a 10-byte cap\n%s", prompt)
+	}
+}
+
+// TestContinuationPromptInlineAggregateCapHonored pins the per-continuation
+// aggregate budget across multiple children: once the total budget is spent, later
+// children's bodies are not inlined.
+func TestContinuationPromptInlineAggregateCapHonored(t *testing.T) {
+	big := strings.Repeat("a", maxInlineArtifactTotalBytes)
+	dels := []Delegation{
+		{ID: "first", Agent: "a", Action: "review"},
+		{ID: "second", Agent: "b", Action: "review"},
+	}
+	children := map[string]db.Job{
+		"first":  {ID: "parent-job/delegation/first", Agent: "a", State: string(JobSucceeded)},
+		"second": {ID: "parent-job/delegation/second", Agent: "b", State: string(JobSucceeded)},
+	}
+	childPayloads := map[string]JobPayload{
+		"first":  {Result: &AgentResult{Decision: "implemented", ArtifactBody: big}},
+		"second": {Result: &AgentResult{Decision: "implemented", ArtifactBody: "SECOND_BODY_MARKER"}},
+	}
+	// Per-body cap is large enough to admit the whole first body, exhausting the
+	// aggregate budget so the second body is dropped entirely.
+	engine := Engine{InlineArtifactBodies: true, MaxInlineArtifactBytes: maxInlineArtifactTotalBytes}
+	prompt := engine.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	if strings.Contains(prompt, "SECOND_BODY_MARKER") {
+		t.Fatalf("aggregate cap not honored: second body inlined despite exhausted budget")
+	}
+	if !strings.Contains(prompt, "a") {
+		t.Fatalf("expected first body inlined\n")
 	}
 }
 
@@ -2995,7 +3138,7 @@ func TestEngineDelegationRootJobIDPropagates(t *testing.T) {
 // contract: the continuation prompt must explicitly tell the coordinator to
 // finish by returning an EMPTY delegations list when the goal is complete.
 func TestContinuationPromptIncludesCompletionContract(t *testing.T) {
-	prompt := buildContinuationPrompt(
+	prompt := Engine{}.buildContinuationPrompt(
 		&AgentResult{Delegations: []Delegation{{ID: "w1", Agent: "w"}}},
 		map[string]db.Job{},
 		map[string]JobPayload{},

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -180,7 +180,15 @@ stops with a clean synthesis instead of a dead end.
 ### Top-level fields
 
 - `artifact_body` (optional): the artifact payload made available to delegated
-  children. Required whenever any delegation sets `artifacts`.
+  children. Required whenever any delegation sets `artifacts`. When the
+  orchestrate policy enables it, a child's `artifact_body` can also be **inlined**
+  into the coordinator continuation prompt — appended as a fenced block after each
+  child's decision/summary/PR line, size-capped (per body and per continuation)
+  and rune-safe truncated, with a marker pointing at the full on-disk brief at
+  `<ArtifactRoot>/delegations/<parent>/brief.md`. Inlining is **off by default**;
+  see `inline_artifact_bodies` in the orchestrate config docs
+  (`docs/cockpit-orchestrate.md`). With it off, the continuation prompt is
+  byte-identical to before.
 
 ## Decisions
 

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -221,7 +221,14 @@ the termination bounds below are measured against.
   fields are coupled: child-facing `artifacts` handles describe what a child can
   reference, and `artifact_body` carries the actual payload at the top level of
   the parent result. Setting `artifacts` without `artifact_body` is rejected by
-  validation.
+  validation. When the orchestrate policy enables it, a child's `artifact_body`
+  can also be **inlined** into the coordinator continuation prompt — appended as a
+  fenced block after each child's decision/summary/PR line, size-capped (per body
+  and per continuation) and rune-safe truncated, with a marker pointing at the
+  full on-disk brief at `<ArtifactRoot>/delegations/<parent>/brief.md`. Inlining
+  is **off by default**; see `inline_artifact_bodies` in the
+  [cockpit/orchestrate config](../workflows/cockpit-orchestrate-workflow.md#configuration-the-orchestrate-section).
+  With it off, the continuation prompt is byte-identical to before.
 
 ## Termination bounds
 

--- a/website/docs/workflows/cockpit-orchestrate-workflow.md
+++ b/website/docs/workflows/cockpit-orchestrate-workflow.md
@@ -71,6 +71,8 @@ cockpit_mode = "auto"      # on | off | auto (auto = on when launched in a Herdr
 cockpit_session = ""       # default Herdr session/workspace label ("" = per-run)
 cockpit_max_panes = 4      # cap on simultaneous panes per run
 cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
+inline_artifact_bodies = false   # inline each child's artifact_body into the coordinator continuation
+inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
 ```
 
 - `cockpit_mode = "off"` disables the cockpit even if `--cockpit` was passed;
@@ -81,6 +83,14 @@ cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per rol
 - `cockpit_pane_key = "job"` opens one pane per child job. `seat` mode reuses a
   single pane per logical role across phases so a long run does not accumulate
   panes.
+- `inline_artifact_bodies` (default `false`) inlines each child's `artifact_body`
+  into the coordinator continuation prompt as a fenced block, so the coordinator
+  reads the briefs without re-fetching them from disk. Off by default, the
+  continuation is byte-identical to before.
+- `inline_artifact_max_bytes` (default `32768`, i.e. 32 KiB per body) caps how
+  many bytes of each child's body are inlined; longer bodies are rune-safe
+  truncated with a marker pointing at the full on-disk brief. A per-continuation
+  aggregate cap also bounds the total inlined across all children.
 
 ## Constrained hosts
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6958,7 +6958,15 @@ stops with a clean synthesis instead of a dead end.
 ### Top-level fields
 
 - `artifact_body` (optional): the artifact payload made available to delegated
-  children. Required whenever any delegation sets `artifacts`.
+  children. Required whenever any delegation sets `artifacts`. When the
+  orchestrate policy enables it, a child's `artifact_body` can also be **inlined**
+  into the coordinator continuation prompt — appended as a fenced block after each
+  child's decision/summary/PR line, size-capped (per body and per continuation)
+  and rune-safe truncated, with a marker pointing at the full on-disk brief at
+  `<ArtifactRoot>/delegations/<parent>/brief.md`. Inlining is **off by default**;
+  see `inline_artifact_bodies` in the orchestrate config docs
+  (`docs/cockpit-orchestrate.md`). With it off, the continuation prompt is
+  byte-identical to before.
 
 ## Decisions
 


### PR DESCRIPTION
Implements #368.

## WHAT
Opt-in inlining of each finished child's `artifact_body` into the coordinator continuation prompt, so a conciliator can reconcile plans/reviews in-band instead of re-opening every child job. **Off by default → continuation byte-identical to today.**

## CHANGES
- `internal/workflow/engine.go`: `buildContinuationPrompt` is now an `Engine` method. When `Engine.InlineArtifactBodies` is set, each child line is followed by a **fenced** block with the child's `artifact_body`, **rune-safe truncated** to a per-body cap (`MaxInlineArtifactBytes`, default 32 KiB) and bounded by a per-continuation aggregate cap (128 KiB), with a truncation marker pointing at the on-disk brief (`<ArtifactRoot>/delegations/<parent>/brief.md`). New helpers `appendInlineArtifactBody`/`truncateUTF8Bytes` (rune-safe, no whitespace collapse)/`inlineBriefPath`/`parentJobIDFromChild`, all in the workflow package.
- **Dynamic fence** (review fix): the fence is chosen longer than the longest backtick run in the block, so a body that itself contains ``` cannot break out and let an embedded sentinel escape.
- `internal/config/orchestrate.go`: `[orchestrate] inline_artifact_bodies` (bool, default false) + `inline_artifact_max_bytes` (int, default 32768) on `OrchestratePolicy`.
- `internal/cli/daemon.go`: the daemon workflow factory sets the Engine fields from the loaded policy (fail-safe to off). Continuations run through `defaultWorkflow` (which sets `ArtifactRoot` + applies the policy).
- Docs: result-contract (both trees) + the `[orchestrate]` config docs; regenerated `llms-full.txt`.

## RESULTS
- `go build/vet/test ./...` + `go test -race ./internal/workflow/` green; website build clean.
- Tests: body present + fenced (enabled); **byte-identical when disabled**; over-cap truncated with marker; rune-safe (multi-byte body not split); aggregate cap across children; **fence survives a body containing ```** (review-fix regression); config keys parse + default off.
- `/code-review` (high) found the fence-injection bug → fixed. The "minimal-engine missing ArtifactRoot" candidate was refuted — coordinator continuations run through `defaultWorkflow`, which sets `ArtifactRoot` and applies the policy.

## RISK / E2E note
Low — fully additive/opt-in; disabled path proven byte-identical by test. **E2E = the engine integration suite** (it exercises the real `buildContinuationPrompt` path end-to-end). A live codex orchestra was not run for this one: observing inlined bodies requires the artifact-request delegation path (children forced to return `artifact_body`), which isn't reliably driveable via a prompt and would burn quota for marginal gain over the deterministic integration tests — the approved plan allowed this fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
