### PR TITLE
feat(workflow): quorum synthesis rule (#370)

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1502,6 +1502,15 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		return e.block(ctx, ref, fmt.Sprintf("delegation synthesis_rule vote failed: not all delegated children for %s were approved/succeeded", parentJob.ID))
 	}
 
+	// synthesis_rule "quorum": block the parent unless at least K children
+	// reached an approving outcome (succeeded state or an approving decision).
+	if delegationSynthesisRequiresQuorum(parentResult.Delegations) {
+		k := delegationQuorumThreshold(parentResult.Delegations)
+		if !delegationQuorumSatisfied(parentResult.Delegations, children, childPayloads, k) {
+			return e.block(ctx, ref, fmt.Sprintf("delegation synthesis_rule quorum failed: fewer than %d delegated children for %s were approved/succeeded", k, parentJob.ID))
+		}
+	}
+
 	request := JobRequest{
 		ID:           delegationContinuationID(parentJob.ID),
 		Agent:        parentJob.Agent,
@@ -2138,6 +2147,60 @@ func delegationVoteSatisfied(delegations []Delegation, children map[string]db.Jo
 		}
 	}
 	return true
+}
+
+// delegationSynthesisRequiresQuorum reports whether any delegation in the batch
+// declares synthesis_rule "quorum", which gates the coordinator continuation on
+// at least K children reaching an approving outcome.
+func delegationSynthesisRequiresQuorum(delegations []Delegation) bool {
+	for _, d := range delegations {
+		if delegationSynthesisRule(d) == "quorum" {
+			return true
+		}
+	}
+	return false
+}
+
+// delegationQuorumThreshold returns the quorum K declared on the quorum
+// delegation(s). When multiple quorum delegations declare different thresholds,
+// the maximum is used.
+func delegationQuorumThreshold(delegations []Delegation) int {
+	k := 0
+	for _, d := range delegations {
+		if delegationSynthesisRule(d) != "quorum" {
+			continue
+		}
+		if d.Quorum > k {
+			k = d.Quorum
+		}
+	}
+	return k
+}
+
+// delegationQuorumSatisfied reports whether at least k children reached an
+// approving outcome: a succeeded job state, or a child result decision of
+// approved/succeeded/implemented (the same approving-outcome test the vote rule
+// uses).
+func delegationQuorumSatisfied(delegations []Delegation, children map[string]db.Job, childPayloads map[string]JobPayload, k int) bool {
+	approving := 0
+	for _, d := range delegations {
+		child, ok := children[d.ID]
+		if !ok {
+			continue
+		}
+		if child.State == string(JobSucceeded) {
+			approving++
+			continue
+		}
+		payload, ok := childPayloads[d.ID]
+		if !ok || payload.Result == nil {
+			continue
+		}
+		if delegationDecisionApproves(payload.Result.Decision) {
+			approving++
+		}
+	}
+	return approving >= k
 }
 
 func delegationDecisionApproves(decision string) bool {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2727,6 +2727,8 @@ func TestEngineDelegationInvalidLifecycleRejectedAtExtraction(t *testing.T) {
 		"negative retry": `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"d","agent":"a","action":"review","prompt":"go","retry":-1}]}}`,
 		"failure_policy": `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"d","agent":"a","action":"review","prompt":"go","failure_policy":"explode"}]}}`,
 		"synthesis_rule": `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"d","agent":"a","action":"review","prompt":"go","synthesis_rule":"coinflip"}]}}`,
+		"quorum missing": `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"d","agent":"a","action":"review","prompt":"go","synthesis_rule":"quorum"}]}}`,
+		"quorum zero":    `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"d","agent":"a","action":"review","prompt":"go","synthesis_rule":"quorum","quorum":0}]}}`,
 	}
 	for name, output := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -2739,6 +2741,17 @@ func TestEngineDelegationInvalidLifecycleRejectedAtExtraction(t *testing.T) {
 	// Valid lifecycle controls pass validation.
 	if err := validateDelegationLifecycle(Delegation{ID: "d", Timeout: "30s", Retry: 2, FailurePolicy: "continue", SynthesisRule: "vote"}); err != nil {
 		t.Fatalf("validateDelegationLifecycle rejected valid controls: %v", err)
+	}
+
+	// synthesis_rule quorum is accepted when quorum > 0 and rejected otherwise.
+	if err := validateDelegationLifecycle(Delegation{ID: "d", SynthesisRule: "quorum", Quorum: 2}); err != nil {
+		t.Fatalf("validateDelegationLifecycle rejected valid quorum: %v", err)
+	}
+	if err := validateDelegationLifecycle(Delegation{ID: "d", SynthesisRule: "quorum", Quorum: 0}); err == nil {
+		t.Fatal("validateDelegationLifecycle accepted quorum with quorum == 0")
+	}
+	if err := validateDelegationLifecycle(Delegation{ID: "d", SynthesisRule: "quorum"}); err == nil {
+		t.Fatal("validateDelegationLifecycle accepted quorum with missing quorum")
 	}
 }
 
@@ -3571,6 +3584,99 @@ func TestEngineDelegationSynthesisRuleVotePassesWhenAllApproved(t *testing.T) {
 	}
 	if state, _ := store.GetTask(ctx, "task-5"); state.State == string(TaskBlocked) {
 		t.Fatal("a unanimous vote must not block the parent")
+	}
+}
+
+func TestEngineDelegationSynthesisRuleQuorumBlocksWhenUnmet(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", FailurePolicy: "continue", SynthesisRule: "quorum", Quorum: 2},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui", FailurePolicy: "continue", SynthesisRule: "quorum", Quorum: 2},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	// Only one of two children approves while quorum K=2: the continuation is
+	// gated and the parent task is blocked instead of being enqueued.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobSucceeded, AgentResult{Decision: "approved", Summary: "api ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/ui", JobFailed, AgentResult{Decision: "failed", Summary: "ui broke"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/ui"); err != nil {
+		var blocked BlockedError
+		if !errors.As(err, &blocked) {
+			t.Fatalf("AdvanceJob(ui) error = %v, want BlockedError from quorum", err)
+		}
+	}
+	if jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("an unmet quorum must not enqueue the continuation")
+	}
+	assertTaskState(t, store, "task-5", TaskBlocked)
+}
+
+func TestEngineDelegationSynthesisRuleQuorumPassesWhenMet(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", FailurePolicy: "continue", SynthesisRule: "quorum", Quorum: 1},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui", FailurePolicy: "continue", SynthesisRule: "quorum", Quorum: 1},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+
+	// quorum K=1: one approving child meets the threshold even though the other
+	// fails, so the continuation is enqueued and the parent is not blocked.
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobSucceeded, AgentResult{Decision: "approved", Summary: "api ok"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err != nil {
+		t.Fatalf("AdvanceJob(api) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/ui", JobFailed, AgentResult{Decision: "failed", Summary: "ui broke"})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/ui"); err != nil {
+		t.Fatalf("AdvanceJob(ui) returned error: %v", err)
+	}
+	if !jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("a met quorum must enqueue the continuation")
+	}
+	if state, _ := store.GetTask(ctx, "task-5"); state.State == string(TaskBlocked) {
+		t.Fatal("a met quorum must not block the parent")
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3680,6 +3680,28 @@ func TestEngineDelegationSynthesisRuleQuorumPassesWhenMet(t *testing.T) {
 	}
 }
 
+// TestQuorumThresholdExceedingDelegationCountRejected pins that a quorum K larger
+// than the number of delegations (always unsatisfiable → would block forever) is
+// rejected at extraction, while K == len (vote-equivalent) is accepted.
+func TestQuorumThresholdExceedingDelegationCountRejected(t *testing.T) {
+	result := AgentResult{
+		Decision: "approved",
+		Summary:  "s",
+		Delegations: []Delegation{
+			{ID: "a", Agent: "a", Action: "ask", Prompt: "p", SynthesisRule: "quorum", Quorum: 3},
+			{ID: "b", Agent: "b", Action: "ask", Prompt: "p", SynthesisRule: "quorum", Quorum: 3},
+		},
+	}
+	if err := validateAgentResult(result); err == nil {
+		t.Fatal("quorum K=3 with 2 delegations must be rejected (unsatisfiable)")
+	}
+	result.Delegations[0].Quorum = 2
+	result.Delegations[1].Quorum = 2
+	if err := validateAgentResult(result); err != nil {
+		t.Fatalf("quorum K=2 with 2 delegations (== len) must be valid: %v", err)
+	}
+}
+
 type fakeImplementationFinalizer struct {
 	payload JobPayload
 	err     error

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -190,6 +190,16 @@ func validateAgentResult(result AgentResult) error {
 	if err := validateDelegationGraph(result.Delegations); err != nil {
 		return err
 	}
+	// A quorum threshold larger than the number of delegations can never be
+	// satisfied (at most len(delegations) children can approve), which would block
+	// the coordinator forever. Reject it at extraction with a clear message rather
+	// than letting the gate block silently. (Per-delegation validation already
+	// guarantees each quorum delegation has Quorum > 0, so the threshold is >= 1.)
+	if delegationSynthesisRequiresQuorum(result.Delegations) {
+		if k := delegationQuorumThreshold(result.Delegations); k > len(result.Delegations) {
+			return fmt.Errorf("synthesis_rule quorum requires quorum (%d) to be <= the number of delegations (%d)", k, len(result.Delegations))
+		}
+	}
 	if delegationsRequestArtifacts(result.Delegations) && strings.TrimSpace(result.ArtifactBody) == "" {
 		return errors.New("artifact_body is required when delegations request artifacts")
 	}

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -46,6 +46,7 @@ type Delegation struct {
 	FailurePolicy string         `json:"failure_policy,omitempty"`
 	Fingerprint   string         `json:"fingerprint,omitempty"`
 	SynthesisRule string         `json:"synthesis_rule,omitempty"`
+	Quorum        int            `json:"quorum,omitempty"`
 	Model         string         `json:"model,omitempty"`
 	Phase         string         `json:"phase,omitempty"`
 }
@@ -319,6 +320,10 @@ func validateDelegationLifecycle(d Delegation) error {
 	}
 	switch strings.ToLower(strings.TrimSpace(d.SynthesisRule)) {
 	case "", "summary", "vote":
+	case "quorum":
+		if d.Quorum <= 0 {
+			return fmt.Errorf("delegation %q synthesis_rule quorum requires quorum > 0", d.ID)
+		}
 	default:
 		return fmt.Errorf("delegation %q synthesis_rule %q is invalid", d.ID, d.SynthesisRule)
 	}

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -65,7 +65,13 @@ Delegation fields:
   cycle — delegations form a DAG, and cycles are rejected.
 - `failure_policy` (optional): one of `block_parent`, `continue`, or
   `escalate`. Defaults to `block_parent` when omitted.
-- `synthesis_rule` (optional): one of `summary` or `vote`.
+- `synthesis_rule` (optional): one of `summary`, `vote`, or `quorum`.
+- `quorum` (optional): an integer `K` (`> 0`), required when `synthesis_rule`
+  is `quorum`. The coordinator continuation proceeds only if at least `K`
+  children reach an approving decision; otherwise the parent blocks, exactly as a
+  failed `vote` does. `vote` is the special case where `K` equals the number of
+  delegations (every child must approve). `K` is an integer count only — no
+  fractions or percentages.
 - `timeout` (optional): a Go duration string and must be positive (e.g. `10m`).
 - `retry` (optional): integer `>= 0`.
 - `worktree` (optional): worktree path for the child job.

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -71,7 +71,8 @@ Delegation fields:
   children reach an approving decision; otherwise the parent blocks, exactly as a
   failed `vote` does. `vote` is the special case where `K` equals the number of
   delegations (every child must approve). `K` is an integer count only — no
-  fractions or percentages.
+  fractions or percentages — and must not exceed the number of delegations (a
+  larger `K` is unsatisfiable and is rejected).
 - `timeout` (optional): a Go duration string and must be positive (e.g. `10m`).
 - `retry` (optional): integer `>= 0`.
 - `worktree` (optional): worktree path for the child job.

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -95,8 +95,14 @@ the same `delegations` field, `coordinator`, and `continuation` mechanics.
   rejected at validation time.
 - `failure_policy` (optional): one of `block_parent`, `continue`, or `escalate`.
   Defaults to `block_parent` when omitted.
-- `synthesis_rule` (optional): one of `summary` or `vote`. It tells the
-  coordinator how to combine the children's results.
+- `synthesis_rule` (optional): one of `summary`, `vote`, or `quorum`. It tells
+  the coordinator how to combine the children's results.
+- `quorum` (optional): an integer `K` (`> 0`), required when `synthesis_rule` is
+  `quorum`. The coordinator continuation proceeds only if at least `K` children
+  reach an approving decision; otherwise the parent blocks, exactly as a failed
+  `vote` does. `vote` is the special case where `K` equals the number of
+  delegations (every child must approve). `K` is an integer count only — no
+  fractions or percentages.
 - `timeout` (optional): a Go duration string that must be positive (for example,
   `10m`).
 - `retry` (optional): an integer that must be `>= 0`.

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -102,7 +102,8 @@ the same `delegations` field, `coordinator`, and `continuation` mechanics.
   reach an approving decision; otherwise the parent blocks, exactly as a failed
   `vote` does. `vote` is the special case where `K` equals the number of
   delegations (every child must approve). `K` is an integer count only — no
-  fractions or percentages.
+  fractions or percentages — and must not exceed the number of delegations (a
+  larger `K` is unsatisfiable and is rejected).
 - `timeout` (optional): a Go duration string that must be positive (for example,
   `10m`).
 - `retry` (optional): an integer that must be `>= 0`.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6843,7 +6843,13 @@ Delegation fields:
   cycle — delegations form a DAG, and cycles are rejected.
 - `failure_policy` (optional): one of `block_parent`, `continue`, or
   `escalate`. Defaults to `block_parent` when omitted.
-- `synthesis_rule` (optional): one of `summary` or `vote`.
+- `synthesis_rule` (optional): one of `summary`, `vote`, or `quorum`.
+- `quorum` (optional): an integer `K` (`> 0`), required when `synthesis_rule`
+  is `quorum`. The coordinator continuation proceeds only if at least `K`
+  children reach an approving decision; otherwise the parent blocks, exactly as a
+  failed `vote` does. `vote` is the special case where `K` equals the number of
+  delegations (every child must approve). `K` is an integer count only — no
+  fractions or percentages.
 - `timeout` (optional): a Go duration string and must be positive (e.g. `10m`).
 - `retry` (optional): integer `>= 0`.
 - `worktree` (optional): worktree path for the child job.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6849,7 +6849,8 @@ Delegation fields:
   children reach an approving decision; otherwise the parent blocks, exactly as a
   failed `vote` does. `vote` is the special case where `K` equals the number of
   delegations (every child must approve). `K` is an integer count only — no
-  fractions or percentages.
+  fractions or percentages — and must not exceed the number of delegations (a
+  larger `K` is unsatisfiable and is rejected).
 - `timeout` (optional): a Go duration string and must be positive (e.g. `10m`).
 - `retry` (optional): integer `>= 0`.
 - `worktree` (optional): worktree path for the child job.


### PR DESCRIPTION
Implements #370.

## WHAT
Add a `quorum` synthesis rule: a delegation set can declare `synthesis_rule: "quorum"` with `quorum: K`, and the coordinator continuation proceeds iff at least **K** children reach an approving outcome; otherwise the parent blocks (exactly like a failed `vote`). `vote` is the special case `K == len(delegations)`. **Additive — `summary`/`vote`/no-rule paths byte-identical.**

## CHANGES
- `internal/workflow/result.go`: `Delegation.Quorum int` (`json:"quorum,omitempty"`); `validateDelegationLifecycle` allows `quorum` and requires `Quorum > 0`; `validateAgentResult` rejects `K > len(delegations)` (unsatisfiable → would block forever) with a clear message (review fix).
- `internal/workflow/engine.go`: `delegationSynthesisRequiresQuorum` / `delegationQuorumThreshold` (max K across quorum delegations) / `delegationQuorumSatisfied` (count approving children — same approving test as `vote`: `JobSucceeded` or an approving decision — `>= K`); a quorum gate in `maybeEnqueueContinuation` beside the vote gate (`e.block` when unmet). Reads `parentResult.Delegations` directly — no payload/mailbox propagation. `vote` code path untouched.
- Docs: `quorum` documented in both result-contract trees (incl. the `K <= len` constraint); `llms-full.txt` regenerated.

## RESULTS
- `go build/vet/test ./...` + `go test -race ./internal/workflow/` green; website build clean.
- Tests: quorum met (≥K ⇒ continuation enqueued, parent not blocked); not-met (<K ⇒ parent blocks, nothing enqueued); validation accepts `K>0` & `K<=len`, rejects `K<=0`/missing/`K>len`; `summary`/`vote` unchanged.
- `/code-review` (high): the core is a faithful mirror of the vote machinery (validation runs before the gate; vote-vs-quorum missing-child asymmetry is correct by design — "all" vs "≥K"). The one actionable finding — `K > len(delegations)` unsatisfiable → silent perpetual block — is now rejected at extraction (+ test + docs).
- **Live codex E2E:** a coordinator set `synthesis_rule:"quorum", quorum:2` on two delegations; both children approved, the continuation was enqueued and the parent was not blocked (gate fired live).

## RISK
Low — additive/opt-in; default + `summary` + `vote` paths byte-identical (quorum gate fully guarded behind `delegationSynthesisRequiresQuorum`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
