### PR TITLE
feat(workflow): --skip-native-review-fanout — coordinator owns review (#371)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -254,20 +254,21 @@ func printAgentAskUsage(w io.Writer) {
 }
 
 type agentRunOptions struct {
-	home           string
-	repo           string
-	jsonOutput     bool
-	background     bool
-	typeName       string
-	model          string
-	taskID         string
-	prNumber       int
-	headSHA        string
-	branch         string
-	agent          string
-	message        string
-	cockpit        bool
-	cockpitSession string
+	home                   string
+	repo                   string
+	jsonOutput             bool
+	background             bool
+	typeName               string
+	model                  string
+	taskID                 string
+	prNumber               int
+	headSHA                string
+	branch                 string
+	agent                  string
+	message                string
+	cockpit                bool
+	cockpitSession         string
+	skipNativeReviewFanout bool
 }
 
 func runAgentRun(args []string, stdout, stderr io.Writer) int {
@@ -420,23 +421,24 @@ func dispatchAgentCommand(options agentRunOptions, action string, reason string,
 	if err := withStore(options.home, func(store *db.Store) error {
 		var err error
 		output, err = dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
-			RepoFlag:             options.repo,
-			Agent:                options.agent,
-			Action:               action,
-			Instructions:         options.message,
-			Background:           options.background,
-			Type:                 options.typeName,
-			Model:                options.model,
-			Home:                 options.home,
-			TaskID:               options.taskID,
-			PullRequest:          options.prNumber,
-			HeadSHA:              options.headSHA,
-			Branch:               options.branch,
-			Cockpit:              options.cockpit,
-			CockpitSession:       options.cockpitSession,
-			SelectedAction:       action,
-			SelectedActionReason: reason,
-			ExecutionPath:        executionPath,
+			RepoFlag:               options.repo,
+			Agent:                  options.agent,
+			Action:                 action,
+			Instructions:           options.message,
+			Background:             options.background,
+			Type:                   options.typeName,
+			Model:                  options.model,
+			Home:                   options.home,
+			TaskID:                 options.taskID,
+			PullRequest:            options.prNumber,
+			HeadSHA:                options.headSHA,
+			Branch:                 options.branch,
+			Cockpit:                options.cockpit,
+			CockpitSession:         options.cockpitSession,
+			SkipNativeReviewFanout: options.skipNativeReviewFanout,
+			SelectedAction:         action,
+			SelectedActionReason:   reason,
+			ExecutionPath:          executionPath,
 		})
 		return err
 	}); err != nil {
@@ -485,6 +487,8 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 			options.jsonOutput = true
 		case arg == "--cockpit" || arg == "--herdr":
 			options.cockpit = true
+		case arg == "--skip-native-review-fanout":
+			options.skipNativeReviewFanout = true
 		case arg == "--type" || arg == "--model" || arg == "--repo" || arg == "--home" || arg == "--task" || arg == "--pr" || arg == "--head-sha" || arg == "--branch" || arg == "--cockpit-session":
 			if index+1 >= len(args) {
 				fmt.Fprintf(stderr, "%s requires a value for %s\n", label, arg)
@@ -581,13 +585,13 @@ func printAgentRunUsage(w io.Writer, command string) {
 	fmt.Fprintln(w, "Usage:")
 	switch command {
 	case "orchestrate":
-		fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--model model] [--cockpit] [--cockpit-session name] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--model model] [--cockpit] [--cockpit-session name] [--skip-native-review-fanout] [--home path] [--json]")
 	case "review":
 		fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--head-sha sha] [--branch branch] [--background] [--type type] [--model model] [--home path] [--json]")
 	case "implement":
-		fmt.Fprintln(w, "  gitmoot agent implement <name> \"message\" [--repo owner/repo] [--task task-id] [--branch branch] [--background] [--type type] [--model model] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot agent implement <name> \"message\" [--repo owner/repo] [--task task-id] [--branch branch] [--background] [--type type] [--model model] [--skip-native-review-fanout] [--home path] [--json]")
 	default:
-		fmt.Fprintln(w, "  gitmoot agent run <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--background] [--type type] [--model model] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot agent run <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--background] [--type type] [--model model] [--skip-native-review-fanout] [--home path] [--json]")
 	}
 }
 

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -21,29 +21,30 @@ import (
 )
 
 type localAgentDispatchRequest struct {
-	RepoFlag             string
-	Agent                string
-	Action               string
-	Instructions         string
-	Background           bool
-	Type                 string
-	Model                string
-	Home                 string
-	AllowManagedSync     bool
-	JobTimeout           time.Duration
-	TaskID               string
-	PullRequest          int
-	HeadSHA              string
-	Branch               string
-	GoalID               string
-	TaskTitle            string
-	LeadAgent            string
-	Reviewers            []string
-	Cockpit              bool
-	CockpitSession       string
-	SelectedAction       string
-	SelectedActionReason string
-	ExecutionPath        string
+	RepoFlag               string
+	Agent                  string
+	Action                 string
+	Instructions           string
+	Background             bool
+	Type                   string
+	Model                  string
+	Home                   string
+	AllowManagedSync       bool
+	JobTimeout             time.Duration
+	TaskID                 string
+	PullRequest            int
+	HeadSHA                string
+	Branch                 string
+	GoalID                 string
+	TaskTitle              string
+	LeadAgent              string
+	Reviewers              []string
+	Cockpit                bool
+	CockpitSession         string
+	SkipNativeReviewFanout bool
+	SelectedAction         string
+	SelectedActionReason   string
+	ExecutionPath          string
 }
 
 type localAgentJobOutput struct {
@@ -124,23 +125,24 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		}
 	}
 	job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
-		ID:             localAgentJobID(request.Action, agent.Name),
-		Agent:          agent.Name,
-		Action:         request.Action,
-		Repo:           repo.FullName(),
-		Branch:         firstNonEmpty(request.Branch, record.DefaultBranch),
-		PullRequest:    request.PullRequest,
-		HeadSHA:        request.HeadSHA,
-		GoalID:         request.GoalID,
-		TaskID:         request.TaskID,
-		TaskTitle:      request.TaskTitle,
-		LeadAgent:      firstNonEmpty(request.LeadAgent, agent.Name),
-		Reviewers:      request.Reviewers,
-		Sender:         "local",
-		Instructions:   request.Instructions,
-		Model:          request.Model,
-		Cockpit:        request.Cockpit,
-		CockpitSession: request.CockpitSession,
+		ID:                     localAgentJobID(request.Action, agent.Name),
+		Agent:                  agent.Name,
+		Action:                 request.Action,
+		Repo:                   repo.FullName(),
+		Branch:                 firstNonEmpty(request.Branch, record.DefaultBranch),
+		PullRequest:            request.PullRequest,
+		HeadSHA:                request.HeadSHA,
+		GoalID:                 request.GoalID,
+		TaskID:                 request.TaskID,
+		TaskTitle:              request.TaskTitle,
+		LeadAgent:              firstNonEmpty(request.LeadAgent, agent.Name),
+		Reviewers:              request.Reviewers,
+		Sender:                 "local",
+		Instructions:           request.Instructions,
+		Model:                  request.Model,
+		Cockpit:                request.Cockpit,
+		CockpitSession:         request.CockpitSession,
+		SkipNativeReviewFanout: request.SkipNativeReviewFanout,
 	})
 	if err != nil {
 		return localAgentJobOutput{}, err

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -266,6 +266,10 @@ func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullR
 		LeadAgent:         lock.Owner,
 		Sender:            "github",
 		RequiredReviewers: reviewers,
+		// Trigger 2 (daemon path): the implement-job advancement persisted the
+		// skip flag onto the branch lock; honor it so the PR-watcher path skips
+		// the native review fanout too.
+		SkipReviewFanout: lock.SkipNativeReviewFanout,
 	})
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -220,6 +220,162 @@ func TestPollOnceRoutesPullRequestUpdatesToWorkflow(t *testing.T) {
 	}
 }
 
+func TestHandlePullRequestWorkflowSkipsReviewFanoutWhenLockSet(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Role:           "lead",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-007", GoalID: "goal-1", Title: "Task 7", State: string(workflow.TaskPlanned), Branch: "task-7"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	// The implement-job advancement would persist this flag onto the lock; set it
+	// directly here to exercise the daemon's trigger-2 read.
+	if err := store.SetBranchLockReviewFanout(ctx, repo.FullName(), "task-7", true); err != nil {
+		t.Fatalf("SetBranchLockReviewFanout returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls:    []github.PullRequest{},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true}}
+	engine := workflow.Engine{
+		Store:     store,
+		MergeGate: gate,
+		JobID: func(request workflow.JobRequest) string {
+			parts := []string{request.Action, request.Agent, request.TaskID}
+			if request.ReviewRound != "" {
+				parts = append(parts, request.ReviewRound)
+			}
+			return strings.Join(parts, "-")
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	pull := github.PullRequest{
+		Number:  7,
+		Title:   "Task 7",
+		State:   "open",
+		URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+		HeadRef: "task-7",
+		BaseRef: "main",
+		HeadSHA: "abc123",
+	}
+	if err := daemon.handlePullRequestWorkflow(ctx, pull); err != nil {
+		t.Fatalf("handlePullRequestWorkflow returned error: %v", err)
+	}
+
+	// Zero review jobs were enqueued even though a review-capable agent exists.
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "review" {
+			t.Fatalf("expected no review jobs with skip set, found %+v", job)
+		}
+	}
+	// The no-reviewers tail still ran (merge gate evaluated, baseline recorded).
+	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+	if _, err := store.GetPullRequest(ctx, repo.FullName(), 7); err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+}
+
+func TestHandlePullRequestWorkflowFansOutWhenLockUnset(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Role:           "lead",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "audit",
+		Role:           "reviewer",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"review"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-007", GoalID: "goal-1", Title: "Task 7", State: string(workflow.TaskPlanned), Branch: "task-7"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls:    []github.PullRequest{},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	engine := workflow.Engine{
+		Store: store,
+		JobID: func(request workflow.JobRequest) string {
+			parts := []string{request.Action, request.Agent, request.TaskID}
+			if request.ReviewRound != "" {
+				parts = append(parts, request.ReviewRound)
+			}
+			return strings.Join(parts, "-")
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	pull := github.PullRequest{
+		Number:  7,
+		Title:   "Task 7",
+		State:   "open",
+		URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+		HeadRef: "task-7",
+		BaseRef: "main",
+		HeadSHA: "abc123",
+	}
+	if err := daemon.handlePullRequestWorkflow(ctx, pull); err != nil {
+		t.Fatalf("handlePullRequestWorkflow returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "review-audit-task-007-review-1"); err != nil {
+		t.Fatalf("expected review job to be enqueued (default fanout): %v", err)
+	}
+}
+
 func TestPollOnceRetriesPullRequestWorkflowAfterRoutingFailure(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -402,9 +402,10 @@ type PairwisePreference struct {
 }
 
 type BranchLock struct {
-	RepoFullName string
-	Branch       string
-	Owner        string
+	RepoFullName           string
+	Branch                 string
+	Owner                  string
+	SkipNativeReviewFanout bool
 }
 
 type BranchLockEvent struct {
@@ -4294,16 +4295,16 @@ func (s *Store) CreateLock(ctx context.Context, lock BranchLock) (bool, error) {
 }
 
 func (s *Store) GetBranchLock(ctx context.Context, repoFullName string, branch string) (BranchLock, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, branch, owner FROM branch_locks WHERE repo_full_name = ? AND branch = ?`, repoFullName, branch)
+	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, branch, owner, skip_native_review_fanout FROM branch_locks WHERE repo_full_name = ? AND branch = ?`, repoFullName, branch)
 	var lock BranchLock
-	if err := row.Scan(&lock.RepoFullName, &lock.Branch, &lock.Owner); err != nil {
+	if err := row.Scan(&lock.RepoFullName, &lock.Branch, &lock.Owner, &lock.SkipNativeReviewFanout); err != nil {
 		return BranchLock{}, err
 	}
 	return lock, nil
 }
 
 func (s *Store) ListBranchLocks(ctx context.Context, repoFullName string) ([]BranchLock, error) {
-	query := `SELECT repo_full_name, branch, owner FROM branch_locks`
+	query := `SELECT repo_full_name, branch, owner, skip_native_review_fanout FROM branch_locks`
 	args := []any{}
 	if strings.TrimSpace(repoFullName) != "" {
 		query += ` WHERE repo_full_name = ?`
@@ -4319,12 +4320,22 @@ func (s *Store) ListBranchLocks(ctx context.Context, repoFullName string) ([]Bra
 	var locks []BranchLock
 	for rows.Next() {
 		var lock BranchLock
-		if err := rows.Scan(&lock.RepoFullName, &lock.Branch, &lock.Owner); err != nil {
+		if err := rows.Scan(&lock.RepoFullName, &lock.Branch, &lock.Owner, &lock.SkipNativeReviewFanout); err != nil {
 			return nil, err
 		}
 		locks = append(locks, lock)
 	}
 	return locks, rows.Err()
+}
+
+// SetBranchLockReviewFanout persists the skip_native_review_fanout flag onto the
+// branch lock for (repoFullName, branch). It is a no-op when no lock exists for
+// the pair. The flag is never written at lock creation (CreateLock defaults it to
+// 0); only the implement-job advancement path sets it so the daemon's PR-watcher
+// can read whether the native review fanout should be skipped.
+func (s *Store) SetBranchLockReviewFanout(ctx context.Context, repoFullName string, branch string, skip bool) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE branch_locks SET skip_native_review_fanout = ?, updated_at = CURRENT_TIMESTAMP WHERE repo_full_name = ? AND branch = ?`, skip, repoFullName, branch)
+	return err
 }
 
 func (s *Store) ReleaseLock(ctx context.Context, lock BranchLock) (bool, error) {
@@ -5678,5 +5689,8 @@ CREATE TABLE cockpit_workspaces (
 	`,
 	`
 ALTER TABLE cockpit_workspaces ADD COLUMN root_pane_id TEXT NOT NULL DEFAULT '';
+	`,
+	`
+ALTER TABLE branch_locks ADD COLUMN skip_native_review_fanout INTEGER NOT NULL DEFAULT 0;
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -2278,6 +2278,61 @@ func TestRepositoryMethods(t *testing.T) {
 	}
 }
 
+func TestBranchLockSkipNativeReviewFanout(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if created, err := store.CreateLock(ctx, BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-7", Owner: "lead"}); err != nil || !created {
+		t.Fatalf("CreateLock returned created=%v err=%v", created, err)
+	}
+
+	// CreateLock defaults the flag to false.
+	lock, err := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-7")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.SkipNativeReviewFanout {
+		t.Fatalf("expected default SkipNativeReviewFanout=false, got %+v", lock)
+	}
+
+	// SetBranchLockReviewFanout flips it; GetBranchLock returns it.
+	if err := store.SetBranchLockReviewFanout(ctx, "jerryfane/gitmoot", "task-7", true); err != nil {
+		t.Fatalf("SetBranchLockReviewFanout returned error: %v", err)
+	}
+	lock, err = store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-7")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if !lock.SkipNativeReviewFanout {
+		t.Fatalf("expected SkipNativeReviewFanout=true after set, got %+v", lock)
+	}
+
+	// ListBranchLocks round-trips the column.
+	locks, err := store.ListBranchLocks(ctx, "jerryfane/gitmoot")
+	if err != nil {
+		t.Fatalf("ListBranchLocks returned error: %v", err)
+	}
+	if len(locks) != 1 || !locks[0].SkipNativeReviewFanout {
+		t.Fatalf("ListBranchLocks = %+v", locks)
+	}
+
+	// Flipping back to false round-trips too.
+	if err := store.SetBranchLockReviewFanout(ctx, "jerryfane/gitmoot", "task-7", false); err != nil {
+		t.Fatalf("SetBranchLockReviewFanout(false) returned error: %v", err)
+	}
+	lock, err = store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-7")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.SkipNativeReviewFanout {
+		t.Fatalf("expected SkipNativeReviewFanout=false after reset, got %+v", lock)
+	}
+}
+
 func TestAddPendingAgentTemplateCandidateRollsBackArtifacts(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -497,10 +497,15 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			// skip_native_review_fanout straight onto the PR event.
 			SkipReviewFanout: payload.SkipNativeReviewFanout,
 		}
-		// Persist the flag onto the branch lock so the daemon's PR-watcher path
-		// (trigger 2) can read it when it independently opens the PR workflow.
-		if err := e.Store.SetBranchLockReviewFanout(ctx, payload.Repo, payload.Branch, payload.SkipNativeReviewFanout); err != nil {
-			return err
+		// Persist the flag onto the branch lock ONLY when set, so the daemon's
+		// PR-watcher path (trigger 2) can read it. Skipping the write on the common
+		// default (false) keeps that path free of an extra lock UPDATE and the new
+		// failure mode it would introduce — a freshly created lock already defaults
+		// to not-skip.
+		if payload.SkipNativeReviewFanout {
+			if err := e.Store.SetBranchLockReviewFanout(ctx, payload.Repo, payload.Branch, true); err != nil {
+				return err
+			}
 		}
 		return e.HandlePullRequestOpened(ctx, event)
 	case "review":

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -77,6 +77,11 @@ type PullRequestEvent struct {
 	LeadAgent         string
 	Sender            string
 	RequiredReviewers []string
+	// SkipReviewFanout, when true, suppresses the native review-fanout loop in
+	// HandlePullRequestOpened: zero review jobs are enqueued and the PR runs the
+	// same no-reviewers tail (record baseline + merge gate) the zero-reviewers
+	// case already runs, so the PR still advances. Defaults false => full fanout.
+	SkipReviewFanout bool
 }
 
 type MergeRequest struct {
@@ -135,7 +140,10 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 	if len(reviewers) == 0 {
 		reviewers = compactStrings(append([]string{}, e.RequiredReviewers...))
 	}
-	if len(reviewers) == 0 {
+	// When the caller asked to skip the native review fanout, run the exact same
+	// no-reviewers tail the zero-reviewers case runs (merge gate + baseline) so the
+	// PR still advances, but enqueue ZERO review jobs.
+	if len(reviewers) == 0 || event.SkipReviewFanout {
 		decision, err := e.runMergeGate(ctx, "", JobPayload{
 			Repo:        event.Repo,
 			Branch:      event.Branch,
@@ -485,6 +493,14 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			LeadAgent:         leadAgent,
 			Sender:            job.Agent,
 			RequiredReviewers: e.requiredReviewers(payload),
+			// Trigger 1 (in-process path): carry the implement job's
+			// skip_native_review_fanout straight onto the PR event.
+			SkipReviewFanout: payload.SkipNativeReviewFanout,
+		}
+		// Persist the flag onto the branch lock so the daemon's PR-watcher path
+		// (trigger 2) can read it when it independently opens the PR workflow.
+		if err := e.Store.SetBranchLockReviewFanout(ctx, payload.Repo, payload.Branch, payload.SkipNativeReviewFanout); err != nil {
+			return err
 		}
 		return e.HandlePullRequestOpened(ctx, event)
 	case "review":

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -591,6 +591,112 @@ func TestEngineHandlePullRequestOpenedDoesNotOverwriteNoReviewerMerge(t *testing
 	}
 }
 
+func TestEngineHandlePullRequestOpenedSkipsReviewFanout(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	// A ready-but-not-merged gate so the no-reviewers tail runs to completion and
+	// records the baseline (the same tail the zero-reviewers path runs).
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:              "jerryfane/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		HeadSHA:           "head123",
+		GoalID:            "goal-1",
+		TaskID:            "task-7",
+		TaskTitle:         "Workflow Engine",
+		LeadAgent:         "lead",
+		Sender:            "lead",
+		RequiredReviewers: []string{"audit"},
+		SkipReviewFanout:  true,
+	})
+
+	if err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+	// Zero review jobs enqueued despite a required reviewer being present.
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "review" {
+			t.Fatalf("expected no review jobs, found %+v", job)
+		}
+	}
+	// The merge gate (no-reviewers tail) still ran.
+	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 || !gate.requests[0].ReviewOptional {
+		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+	// Baseline still recorded so the PR advances.
+	pr, err := store.GetPullRequest(ctx, "jerryfane/gitmoot", 7)
+	if err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+	if pr.HeadBranch != "task-7" || pr.HeadSHA != "head123" {
+		t.Fatalf("pull request baseline = %+v", pr)
+	}
+}
+
+func TestEngineAdvanceImplementPersistsSkipReviewFanoutOntoLock(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Reason: "ci is pending"}}
+	engine.MergeGate = gate
+	// A branch lock owned by the lead must exist for the setter to flip.
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/gitmoot", Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-job",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:                   "jerryfane/gitmoot",
+		Branch:                 "task-7",
+		PullRequest:            7,
+		HeadSHA:                "head123",
+		TaskID:                 "task-7",
+		TaskTitle:              "Workflow Engine",
+		LeadAgent:              "lead",
+		SkipNativeReviewFanout: true,
+		Result:                 &AgentResult{Decision: "implemented", Summary: "opened PR"},
+	})
+
+	err := engine.AdvanceJob(ctx, "implement-job")
+
+	// The no-reviewers tail blocks on the pending gate; trigger 1 must have fired
+	// (no review jobs) and the flag must be persisted onto the lock (trigger 2).
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || blocked.Reason != "ci is pending" {
+		t.Fatalf("error = %v, want merge gate BlockedError", err)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "review" {
+			t.Fatalf("expected no review jobs, found %+v", job)
+		}
+	}
+	lock, err := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-7")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if !lock.SkipNativeReviewFanout {
+		t.Fatalf("expected lock.SkipNativeReviewFanout = true, got %+v", lock)
+	}
+}
+
 func TestEngineAdvanceImplementDispatchesReviewers(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -59,6 +59,7 @@ type JobRequest struct {
 	Cockpit                bool
 	CockpitSession         string
 	CockpitPaneKey         string
+	SkipNativeReviewFanout bool
 	Ephemeral              *EphemeralSpec
 }
 
@@ -103,6 +104,7 @@ type JobPayload struct {
 	Cockpit                bool           `json:"cockpit,omitempty"`
 	CockpitSession         string         `json:"cockpit_session,omitempty"`
 	CockpitPaneKey         string         `json:"cockpit_pane_key,omitempty"`
+	SkipNativeReviewFanout bool           `json:"skip_native_review_fanout,omitempty"`
 	Ephemeral              *EphemeralSpec `json:"ephemeral,omitempty"`
 	RawOutputs             []string       `json:"raw_outputs,omitempty"`
 	Result                 *AgentResult   `json:"result,omitempty"`
@@ -166,6 +168,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		Cockpit:                request.Cockpit,
 		CockpitSession:         strings.TrimSpace(request.CockpitSession),
 		CockpitPaneKey:         strings.TrimSpace(request.CockpitPaneKey),
+		SkipNativeReviewFanout: request.SkipNativeReviewFanout,
 		Ephemeral:              request.Ephemeral,
 	})
 	if err != nil {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -256,6 +256,18 @@ string (a Codex, Claude Code, or Kimi Code model name) with no allow-list; an
 omitted `--model` leaves the agent's default model in effect. Both `--model X`
 and `--model=X` are accepted.
 
+`gitmoot orchestrate`, `agent run`, and `agent implement` also accept an optional
+`--skip-native-review-fanout` flag. By default an `implement` job that opens a
+pull request fans the PR out to Gitmoot's native reviewers (the configured
+required reviewers, or the ones passed for the task). With
+`--skip-native-review-fanout` set, the coordinator owns review orchestration
+instead: the implement→PR step still records the PR baseline, runs the merge
+gate, and records the `implemented` decision, but it enqueues **no** native
+review jobs. The skip is honored on both PR-open paths — the engine's
+implement-advance and the daemon's GitHub PR-watcher — so a PR opened either way
+stays free of native review fan-out. The flag defaults off; leave it off for the
+full native review fan-out, which is byte-identical to prior behavior.
+
 Start an orchestra of agents with `gitmoot orchestrate`:
 
 ```sh

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -484,6 +484,29 @@ Each child job carries job-tree linkage fields — `parent_job_id`,
 can be traced back to its parent, its originating delegation, and the root of the
 tree. See `RESULT_CONTRACT.md` for the full delegation field reference.
 
+## Coordinator-Owned Review
+
+By default an `implement` job that opens a pull request fans the PR out to
+Gitmoot's native reviewers — the configured required reviewers, or the ones
+passed for the task — so each reviewer runs as its own review job before the
+merge gate. When a coordinator already plans review itself (for example a
+`review-panel` leg, or a custom continuation that reconvenes its own reviewers),
+that native fan-out duplicates work. Pass `--skip-native-review-fanout` on
+`gitmoot orchestrate`, `gitmoot agent run`, or `gitmoot agent implement` to hand
+review orchestration to the coordinator:
+
+```sh
+gitmoot agent implement lead --repo owner/repo --task task-001 --skip-native-review-fanout "Implement this task."
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo --skip-native-review-fanout
+```
+
+With the flag set, the implement→PR step still records the PR baseline, runs the
+merge gate, and records the `implemented` decision — it simply enqueues **no**
+native review jobs. The skip is honored on both PR-open paths: the engine's
+implement-advance and the daemon's GitHub PR-watcher, so a PR opened either way
+stays free of native review fan-out. The flag defaults off; leaving it off keeps
+the full native review fan-out, byte-identical to prior behavior.
+
 ## Coordinator Recipes
 
 Coordinator recipes are built-in agent templates that turn the Orchestra pattern

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -274,6 +274,18 @@ string (a Codex, Claude Code, or Kimi Code model name) with no allow-list; an
 omitted `--model` leaves the agent's default model in effect. Both `--model X`
 and `--model=X` are accepted.
 
+`gitmoot orchestrate`, `agent run`, and `agent implement` also accept an optional
+`--skip-native-review-fanout` flag. By default an `implement` job that opens a
+pull request fans the PR out to Gitmoot's native reviewers (the configured
+required reviewers, or the ones passed for the task). With
+`--skip-native-review-fanout` set, the coordinator owns review orchestration
+instead: the implement→PR step still records the PR baseline, runs the merge
+gate, and records the `implemented` decision, but it enqueues **no** native
+review jobs. The skip is honored on both PR-open paths — the engine's
+implement-advance and the daemon's GitHub PR-watcher — so a PR opened either way
+stays free of native review fan-out. The flag defaults off; leave it off for the
+full native review fan-out, which is byte-identical to prior behavior.
+
 Start an orchestra of agents with `gitmoot orchestrate`:
 
 ```sh

--- a/website/docs/workflows/coordinator-recipes-workflow.md
+++ b/website/docs/workflows/coordinator-recipes-workflow.md
@@ -61,6 +61,29 @@ After verify finishes, Gitmoot enqueues one continuation. The coordinator reads
 the verify result first — it is the gate — and either reports the merged changes
 when verify passed, or summarizes what failed and which leg owns the fix.
 
+## Coordinator-owned review
+
+By default an `implement` job that opens a pull request fans the PR out to
+Gitmoot's native reviewers — the configured required reviewers, or the ones
+passed for the task — so each reviewer runs as its own review job before the
+merge gate. When a coordinator already plans review itself (for example a
+`review-panel` leg, or a custom continuation that reconvenes its own reviewers),
+that native fan-out duplicates work. Pass `--skip-native-review-fanout` on
+`gitmoot orchestrate`, `gitmoot agent run`, or `gitmoot agent implement` to hand
+review orchestration to the coordinator:
+
+```sh
+gitmoot agent implement lead --repo owner/repo --task task-001 --skip-native-review-fanout "Implement this task."
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo --skip-native-review-fanout
+```
+
+With the flag set, the implement→PR step still records the PR baseline, runs the
+merge gate, and records the `implemented` decision — it simply enqueues **no**
+native review jobs. The skip is honored on both PR-open paths: the engine's
+implement-advance and the daemon's GitHub PR-watcher, so a PR opened either way
+stays free of native review fan-out. The flag defaults off; leaving it off keeps
+the full native review fan-out, byte-identical to prior behavior.
+
 ## Ephemeral, leaf-only, bounded
 
 In both recipes the delegations never set `agent`: `agent` and `ephemeral` are

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5629,6 +5629,18 @@ string (a Codex, Claude Code, or Kimi Code model name) with no allow-list; an
 omitted `--model` leaves the agent's default model in effect. Both `--model X`
 and `--model=X` are accepted.
 
+`gitmoot orchestrate`, `agent run`, and `agent implement` also accept an optional
+`--skip-native-review-fanout` flag. By default an `implement` job that opens a
+pull request fans the PR out to Gitmoot's native reviewers (the configured
+required reviewers, or the ones passed for the task). With
+`--skip-native-review-fanout` set, the coordinator owns review orchestration
+instead: the implement→PR step still records the PR baseline, runs the merge
+gate, and records the `implemented` decision, but it enqueues **no** native
+review jobs. The skip is honored on both PR-open paths — the engine's
+implement-advance and the daemon's GitHub PR-watcher — so a PR opened either way
+stays free of native review fan-out. The flag defaults off; leave it off for the
+full native review fan-out, which is byte-identical to prior behavior.
+
 Start an orchestra of agents with `gitmoot orchestrate`:
 
 ```sh
@@ -6466,6 +6478,29 @@ Each child job carries job-tree linkage fields — `parent_job_id`,
 `delegation_id`, `root_job_id`, `delegation_depth`, and `task_id` — so a child
 can be traced back to its parent, its originating delegation, and the root of the
 tree. See `RESULT_CONTRACT.md` for the full delegation field reference.
+
+## Coordinator-Owned Review
+
+By default an `implement` job that opens a pull request fans the PR out to
+Gitmoot's native reviewers — the configured required reviewers, or the ones
+passed for the task — so each reviewer runs as its own review job before the
+merge gate. When a coordinator already plans review itself (for example a
+`review-panel` leg, or a custom continuation that reconvenes its own reviewers),
+that native fan-out duplicates work. Pass `--skip-native-review-fanout` on
+`gitmoot orchestrate`, `gitmoot agent run`, or `gitmoot agent implement` to hand
+review orchestration to the coordinator:
+
+```sh
+gitmoot agent implement lead --repo owner/repo --task task-001 --skip-native-review-fanout "Implement this task."
+gitmoot orchestrate decompose-and-verify "Implement the export feature described in the task." --repo owner/repo --skip-native-review-fanout
+```
+
+With the flag set, the implement→PR step still records the PR baseline, runs the
+merge gate, and records the `implemented` decision — it simply enqueues **no**
+native review jobs. The skip is honored on both PR-open paths: the engine's
+implement-advance and the daemon's GitHub PR-watcher, so a PR opened either way
+stays free of native review fan-out. The flag defaults off; leaving it off keeps
+the full native review fan-out, byte-identical to prior behavior.
 
 ## Coordinator Recipes
 


### PR DESCRIPTION
Implements #371.

## WHAT
Add `--skip-native-review-fanout` so a coordinator owns review orchestration: an implement→PR records the baseline + `implemented` decision and runs the merge gate, but enqueues **zero** native review jobs — honored by **both** triggers (the engine implement-advance AND the daemon GitHub PR-watcher). **Default off ⇒ full fanout, byte-identical to today.**

## WHY
When an implement job opens a PR, gitmoot auto-fans-out review jobs. A council reviews via its own delegations, so the native fanout is a redundant second round. The daemon PR-watcher rebuilds the PR event without the implement payload, so the flag is persisted on the branch lock for that path to read.

## CHANGES
- `internal/workflow/engine.go`: `PullRequestEvent.SkipReviewFanout`; `HandlePullRequestOpened` runs the existing no-reviewers tail (merge gate + baseline) when `len(reviewers)==0 || SkipReviewFanout` → 0 review jobs. `AdvanceJob` implement sets `event.SkipReviewFanout` from the payload (trigger 1) and — **only when set** — persists it onto the branch lock for the daemon path (review fix: avoids an extra UPDATE/failure-mode on the default path).
- `internal/workflow/mailbox.go`: `JobRequest`/`JobPayload.SkipNativeReviewFanout` + `Enqueue` copy.
- `internal/cli/agent.go` + `agent_dispatch.go`: `--skip-native-review-fanout` bool flag (orchestrate/agent run/agent implement), mirrors `--cockpit`.
- `internal/db/store.go`: `branch_locks` ALTER `ADD COLUMN skip_native_review_fanout INTEGER NOT NULL DEFAULT 0`; `BranchLock` field; `GetBranchLock`/`ListBranchLocks` scan it; new `SetBranchLockReviewFanout` UPDATE (`CreateLock` unchanged → defaults 0).
- `internal/daemon/daemon.go`: `handlePullRequestWorkflow` sets `event.SkipReviewFanout = lock.SkipNativeReviewFanout` (trigger 2).
- Docs: CLI flag + a "coordinator-owned review" section in both doc trees; `llms-full.txt` regenerated.

## RESULTS
- `go build/vet/test ./...` + `go test -race ./internal/workflow/` green; website build clean.
- Tests: engine (skip ⇒ 0 reviews, merge gate runs, baseline recorded, task ReadyToMerge; implement-advance persists the flag onto the lock); daemon (`handlePullRequestWorkflow` with the lock flag set ⇒ 0 reviews; unset ⇒ fans out); store (`branch_locks` round-trip, `SetBranchLockReviewFanout`, `CreateLock` defaults false).
- `/code-review` (high): fixed the default-path extra-write/failure-mode (guard the persist on the flag). INTEGER→bool scan verified by the store round-trip test.

## RISK / E2E note
- **E2E = engine + daemon + store integration tests** (both triggers ⇒ 0 reviews). A true live GitHub PR-watcher run needs a real PR, so this is integration-tested, not a live orchestra (as agreed).
- **Known narrow race:** the implement runtime opens the PR slightly before `AdvanceJob` persists the flag onto the lock; if the daemon PR-watcher polls in that window it reads `skip=false` and fans out once (degrades to prior behavior — extra reviews, never fewer). The engine trigger always honors the flag (reads the payload directly). Closing the race fully would mean persisting at lock-creation (broader change); deferred per the issue's accepted advance-time design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
