### PR TITLE
docs: v0.4.2 release notes + version bump

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ version: 0.1.0
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.4.1"
+  gitmoot-version: "0.4.2"
   source: "jerryfane/gitmoot"
   openclaw:
     requires:

--- a/docs/release-notes/v0.4.2.md
+++ b/docs/release-notes/v0.4.2.md
@@ -1,0 +1,40 @@
+# Gitmoot v0.4.2
+
+Orchestration release: five additive, opt-in primitives that make multi-agent
+"council" coordination more controllable — all from the #357 review thread
+(thanks @gaijinjoe). Default behavior is unchanged.
+
+## What's new since v0.4.1
+
+- **fix(daemon): scope the backgrounded daemon to `--repo` (+ new `--session`)** (#367, #372) —
+  `gitmoot daemon start --repo X` now forwards `--repo` into its detached child, so the
+  background daemon scopes to that repo instead of polling every enabled repo. A new
+  `--session <root-job-id>` (alias `--root`) pins a daemon to one orchestration run.
+- **feat(workflow): `phase` pass-through on delegations** (#369, #373) — tag each delegation
+  with a free-form `phase` (e.g. plan / review / reconcile) that round-trips through the job
+  payload and is echoed back in the coordinator continuation. Metadata only — excluded from
+  loop detection.
+- **feat(workflow): inline child `artifact_body` in the continuation** (#368, #374) — opt-in
+  (`[orchestrate] inline_artifact_bodies`) inlining of each finished child's full brief into the
+  coordinator continuation prompt, fenced and size-capped (per body + per continuation).
+- **feat(workflow): `quorum` synthesis rule** (#370, #375) — `synthesis_rule: "quorum"` with
+  `quorum: K`: the continuation proceeds iff at least K children approve. `vote` is the special
+  case `K = number of delegations`; integer K only, and `K` must not exceed the delegation count.
+- **feat(workflow): `--skip-native-review-fanout`** (#371, #376) — let a coordinator own review
+  orchestration: the implement→PR still records the PR baseline + runs the merge gate, but
+  enqueues **no** native review jobs — honored by both the engine implement-advance and the
+  daemon GitHub PR-watcher (persisted on the branch lock).
+
+All five are additive / opt-in (default behavior byte-identical), shipped via squash-merge with
+the CI gate green and `/code-review`. Verified end-to-end with live Codex orchestras; #371
+verified live on a real GitHub PR (no flag → review fan-out; `--skip-native-review-fanout` → zero).
+
+## Install / update
+
+```sh
+gitmoot update                                   # existing installs
+curl -fsSL https://gitmoot.io/install.sh | sh    # fresh install
+```
+
+Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
+`sha256sums.txt`.

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -4,7 +4,7 @@ description: Use Gitmoot for local-first AI agent coordination across repositori
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.4.1"
+  gitmoot-version: "0.4.2"
   source: "jerryfane/gitmoot"
 ---
 

--- a/website/docs/release-notes/v0.4.2.md
+++ b/website/docs/release-notes/v0.4.2.md
@@ -1,0 +1,40 @@
+# Gitmoot v0.4.2
+
+Orchestration release: five additive, opt-in primitives that make multi-agent
+"council" coordination more controllable — all from the #357 review thread
+(thanks @gaijinjoe). Default behavior is unchanged.
+
+## What's new since v0.4.1
+
+- **fix(daemon): scope the backgrounded daemon to `--repo` (+ new `--session`)** (#367, #372) —
+  `gitmoot daemon start --repo X` now forwards `--repo` into its detached child, so the
+  background daemon scopes to that repo instead of polling every enabled repo. A new
+  `--session <root-job-id>` (alias `--root`) pins a daemon to one orchestration run.
+- **feat(workflow): `phase` pass-through on delegations** (#369, #373) — tag each delegation
+  with a free-form `phase` (e.g. plan / review / reconcile) that round-trips through the job
+  payload and is echoed back in the coordinator continuation. Metadata only — excluded from
+  loop detection.
+- **feat(workflow): inline child `artifact_body` in the continuation** (#368, #374) — opt-in
+  (`[orchestrate] inline_artifact_bodies`) inlining of each finished child's full brief into the
+  coordinator continuation prompt, fenced and size-capped (per body + per continuation).
+- **feat(workflow): `quorum` synthesis rule** (#370, #375) — `synthesis_rule: "quorum"` with
+  `quorum: K`: the continuation proceeds iff at least K children approve. `vote` is the special
+  case `K = number of delegations`; integer K only, and `K` must not exceed the delegation count.
+- **feat(workflow): `--skip-native-review-fanout`** (#371, #376) — let a coordinator own review
+  orchestration: the implement→PR still records the PR baseline + runs the merge gate, but
+  enqueues **no** native review jobs — honored by both the engine implement-advance and the
+  daemon GitHub PR-watcher (persisted on the branch lock).
+
+All five are additive / opt-in (default behavior byte-identical), shipped via squash-merge with
+the CI gate green and `/code-review`. Verified end-to-end with live Codex orchestras; #371
+verified live on a real GitHub PR (no flag → review fan-out; `--skip-native-review-fanout` → zero).
+
+## Install / update
+
+```sh
+gitmoot update                                   # existing installs
+curl -fsSL https://gitmoot.io/install.sh | sh    # fresh install
+```
+
+Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
+`sha256sums.txt`.

--- a/website/scripts/build-llms-full.mjs
+++ b/website/scripts/build-llms-full.mjs
@@ -25,6 +25,7 @@ const sources = [
   'docs/release-notes/v0.3.1-beta.1.md',
   'docs/release-notes/v0.4.0.md',
   'docs/release-notes/v0.4.1.md',
+  'docs/release-notes/v0.4.2.md',
   'skills/gitmoot/SKILL.md',
   'skills/gitmoot/agent-templates/planner.md',
   'skills/gitmoot/references/CLI.md',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -62,6 +62,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Release Notes',
       items: [
+        'release-notes/v0.4.2',
         'release-notes/v0.4.1',
         'release-notes/v0.4.0',
         'release-notes/v0.3.5-beta.1',

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -545,7 +545,7 @@ version: 0.1.0
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.4.1"
+  gitmoot-version: "0.4.2"
   source: "jerryfane/gitmoot"
   openclaw:
     requires:
@@ -5041,6 +5041,51 @@ Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
 
 ---
 
+# Source: docs/release-notes/v0.4.2.md
+
+# Gitmoot v0.4.2
+
+Orchestration release: five additive, opt-in primitives that make multi-agent
+"council" coordination more controllable — all from the #357 review thread
+(thanks @gaijinjoe). Default behavior is unchanged.
+
+## What's new since v0.4.1
+
+- **fix(daemon): scope the backgrounded daemon to `--repo` (+ new `--session`)** (#367, #372) —
+  `gitmoot daemon start --repo X` now forwards `--repo` into its detached child, so the
+  background daemon scopes to that repo instead of polling every enabled repo. A new
+  `--session <root-job-id>` (alias `--root`) pins a daemon to one orchestration run.
+- **feat(workflow): `phase` pass-through on delegations** (#369, #373) — tag each delegation
+  with a free-form `phase` (e.g. plan / review / reconcile) that round-trips through the job
+  payload and is echoed back in the coordinator continuation. Metadata only — excluded from
+  loop detection.
+- **feat(workflow): inline child `artifact_body` in the continuation** (#368, #374) — opt-in
+  (`[orchestrate] inline_artifact_bodies`) inlining of each finished child's full brief into the
+  coordinator continuation prompt, fenced and size-capped (per body + per continuation).
+- **feat(workflow): `quorum` synthesis rule** (#370, #375) — `synthesis_rule: "quorum"` with
+  `quorum: K`: the continuation proceeds iff at least K children approve. `vote` is the special
+  case `K = number of delegations`; integer K only, and `K` must not exceed the delegation count.
+- **feat(workflow): `--skip-native-review-fanout`** (#371, #376) — let a coordinator own review
+  orchestration: the implement→PR still records the PR baseline + runs the merge gate, but
+  enqueues **no** native review jobs — honored by both the engine implement-advance and the
+  daemon GitHub PR-watcher (persisted on the branch lock).
+
+All five are additive / opt-in (default behavior byte-identical), shipped via squash-merge with
+the CI gate green and `/code-review`. Verified end-to-end with live Codex orchestras; #371
+verified live on a real GitHub PR (no flag → review fan-out; `--skip-native-review-fanout` → zero).
+
+## Install / update
+
+```sh
+gitmoot update                                   # existing installs
+curl -fsSL https://gitmoot.io/install.sh | sh    # fresh install
+```
+
+Assets: `gitmoot_linux_amd64`, `gitmoot_darwin_amd64`, `gitmoot_darwin_arm64`,
+`sha256sums.txt`.
+
+---
+
 # Source: skills/gitmoot/SKILL.md
 
 ---
@@ -5049,7 +5094,7 @@ description: Use Gitmoot for local-first AI agent coordination across repositori
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
-  gitmoot-version: "0.4.1"
+  gitmoot-version: "0.4.2"
   source: "jerryfane/gitmoot"
 ---
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -27,7 +27,7 @@ full expanded context.
 - [Codex And Claude Plugins](https://gitmoot.io/docs/plugins/codex-claude): Plugin discovery and runtime skill setup.
 - [SkillOpt Exchange Contract](https://gitmoot.io/docs/reference/skillopt-exchange-contract): Training and candidate package boundary for the external optimizer.
 - [Troubleshooting](https://gitmoot.io/docs/operations/troubleshooting): Diagnose GitHub auth, bug reports, runtimes, agent templates, remotes, permissions, and locks.
-- [Release Notes](https://gitmoot.io/docs/release-notes/v0.4.1): Latest release — fixes the Herdr cockpit so `orchestrate --cockpit` opens a live pane per delegation subagent (v0.4.0: SkillOpt judge↔human outcome capture, `judge-report`, per-task_kind judge prompt, judge-prompt optimization).
+- [Release Notes](https://gitmoot.io/docs/release-notes/v0.4.2): Latest release — five opt-in orchestration primitives: daemon `--repo`/`--session` scoping, delegation `phase`, inline `artifact_body`, `quorum` synthesis rule, and `--skip-native-review-fanout` (v0.4.1 fixed the Herdr cockpit panes).
 - [Raw SKILL.md](https://gitmoot.io/SKILL.md): Agent skill entrypoint.
 - [Full LLM Context](https://gitmoot.io/llms-full.txt): Expanded Markdown context for agents.
 - [GitHub Repository](https://github.com/jerryfane/gitmoot): Source code and releases.


### PR DESCRIPTION
Docs for the **v0.4.2** orchestration release (ships #367–#371).

## Changes
- Release notes in both trees: `docs/release-notes/v0.4.2.md` + `website/docs/release-notes/v0.4.2.md` (the five opt-in primitives).
- Website wiring: `sidebars.ts` (+ `release-notes/v0.4.2`), `build-llms-full.mjs` manifest, `llms.txt` "Latest release" line.
- `gitmoot-version` → `0.4.2` in `SKILL.md` + `skills/gitmoot/SKILL.md`.
- Regenerated `website/static/llms-full.txt`.

## Verification
- `cd website && npm run build` succeeds (Docusaurus `onBrokenLinks: throw`); `llms-full.txt` carries the v0.4.2 notes.

The site is **not auto-deployed** — manual `npm run build` + rsync to `/var/www/gitmoot-docs/` publishes it (done after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)