### PR TITLE
feat(skillopt): apply accepted judge prompt to production (#354)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -1590,7 +1590,7 @@ func buildSkillOptTrainStartPlan(template db.AgentTemplate, repo string, workspa
 	if workspaceRepo != "" {
 		state = skillopt.TrainStateItemsReady
 	}
-	metadata := skillOptTrainStartMetadata(request, mode, explorationLevel, optionsCount, preferredGate, itemPlans, warnings, previewPolicy, configDefaults)
+	metadata := skillOptTrainStartMetadata(request, mode, explorationLevel, optionsCount, preferredGate, itemPlans, warnings, previewPolicy, configDefaults, skillOptTemplateJudgeEvaluation(template))
 	session := db.SkillOptTrainSession{
 		ID:                sessionID,
 		TemplateID:        template.ID,
@@ -8091,10 +8091,44 @@ func generatedSkillOptTrainSessionID(templateID string) string {
 	return "train-" + strings.Trim(b.String(), "-_") + "-" + now.Format("20060102-150405") + fmt.Sprintf("-%09d", now.Nanosecond())
 }
 
-func skillOptTrainStartMetadata(request string, mode string, explorationLevel string, optionsCount int, preferredGate string, items []skillOptTrainItemPlan, warnings []string, previewPolicy skillopt.TrainPreviewPolicy, configDefaults skillOptTrainStartConfigDefaults) string {
+// skillOptTemplateJudgeEvaluation extracts a template's promoted judge prompt
+// fields (written by `skillopt judge promote`, #354) into the shape the
+// evaluator reader consumes: judge_prompt_templates as a real object and
+// judge_prompt_version as a string. Returns nil when the template carries none,
+// so train-start metadata stays byte-identical for templates without a promoted
+// judge prompt. This is the consumption half of #354: the promoted prompt is
+// folded into the eval-run's evaluation config so a subsequent run resolves it.
+func skillOptTemplateJudgeEvaluation(template db.AgentTemplate) map[string]any {
+	metadata, err := agenttemplate.UnmarshalMetadata(template.MetadataJSON)
+	if err != nil {
+		return nil
+	}
+	out := map[string]any{}
+	if raw := strings.TrimSpace(metadata.Evaluation["judge_prompt_templates"]); raw != "" {
+		templates := map[string]string{}
+		if err := json.Unmarshal([]byte(raw), &templates); err == nil && len(templates) > 0 {
+			out["judge_prompt_templates"] = templates
+		}
+	}
+	if version := strings.TrimSpace(metadata.Evaluation["judge_prompt_version"]); version != "" {
+		out["judge_prompt_version"] = version
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func skillOptTrainStartMetadata(request string, mode string, explorationLevel string, optionsCount int, preferredGate string, items []skillOptTrainItemPlan, warnings []string, previewPolicy skillopt.TrainPreviewPolicy, configDefaults skillOptTrainStartConfigDefaults, judgeEvaluation map[string]any) string {
 	lines := strings.Count(request, "\n") + 1
 	words := len(strings.Fields(request))
 	previewMetadata, reviewMetadata := previewPolicy.Metadata()
+	evaluation := map[string]any{
+		"preferred_gate": preferredGate,
+	}
+	for key, value := range judgeEvaluation {
+		evaluation[key] = value
+	}
 	metadata := map[string]any{
 		"request":           request,
 		"request_lines":     lines,
@@ -8105,12 +8139,10 @@ func skillOptTrainStartMetadata(request string, mode string, explorationLevel st
 		"options_count":     optionsCount,
 		"items_count":       len(items),
 		"item_warnings":     warnings,
-		"evaluation": map[string]any{
-			"preferred_gate": preferredGate,
-		},
-		"preview": previewMetadata,
-		"review":  reviewMetadata,
-		"source":  "gitmoot skillopt train start",
+		"evaluation":        evaluation,
+		"preview":           previewMetadata,
+		"review":            reviewMetadata,
+		"source":            "gitmoot skillopt train start",
 	}
 	if optimizerDefaults := skillOptTrainOptimizerDefaultsMetadata(configDefaults.Optimizer); len(optimizerDefaults) > 0 {
 		metadata["optimizer_defaults"] = optimizerDefaults

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -22,6 +22,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/jerryfane/gitmoot/internal/agenttemplate"
 	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/cli/style"
 	"github.com/jerryfane/gitmoot/internal/config"
@@ -71,6 +72,8 @@ func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptFeedback(args[1:], stdout, stderr)
 	case "judge-report":
 		return runSkillOptJudgeReport(args[1:], stdout, stderr)
+	case "judge":
+		return runSkillOptJudge(args[1:], stdout, stderr)
 	case "train":
 		return runSkillOptTrain(args[1:], stdout, stderr)
 	default:
@@ -97,6 +100,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
 	fmt.Fprintln(w, "  gitmoot skillopt judge-report [--template id]")
+	fmt.Fprintln(w, "  gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <h>] [--yes] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt train init --name <name> --template <id> --review-repo owner/repo --artifact-kind kind --preview kind (--request text|--request-file path)")
 	fmt.Fprintln(w, "  gitmoot skillopt train init templates --json")
 	fmt.Fprintln(w, "  gitmoot skillopt train start --config .gitmoot/skillopt/<name>/config.toml [--yes]")
@@ -11452,6 +11456,258 @@ func runSkillOptCandidatePromote(args []string, stdout, stderr io.Writer) int {
 	}
 	writeLine(stdout, "promoted candidate %s", promoted.ID)
 	return 0
+}
+
+func runSkillOptJudge(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSkillOptJudgeUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "promote":
+		return runSkillOptJudgePromote(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skillopt judge command %q\n\n", args[0])
+		printSkillOptJudgeUsage(stderr)
+		return 2
+	}
+}
+
+func printSkillOptJudgeUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <h>] [--yes] [--json]")
+}
+
+// skillOptJudgePromoteResult is the machine-readable preview/apply summary for
+// `skillopt judge promote`. Applied is false in preview mode (no --yes).
+type skillOptJudgePromoteResult struct {
+	TemplateID            string  `json:"template_id"`
+	TaskKind              string  `json:"task_kind"`
+	Applied               bool    `json:"applied"`
+	Accepted              bool    `json:"accepted"`
+	BaselineAgreement     float64 `json:"baseline_agreement"`
+	BestAgreement         float64 `json:"best_agreement"`
+	AgreementDelta        float64 `json:"agreement_delta"`
+	BestOrigin            string  `json:"best_origin,omitempty"`
+	PreviousPromptVersion string  `json:"previous_judge_prompt_version,omitempty"`
+	NewPromptVersion      string  `json:"new_judge_prompt_version,omitempty"`
+	PromptBytes           int     `json:"prompt_bytes"`
+	PromptPreview         string  `json:"prompt_preview,omitempty"`
+}
+
+const skillOptJudgePromptPreviewLimit = 800
+
+func runSkillOptJudgePromote(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt judge promote", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	templateID := fs.String("template", "", "agent template id to promote the judge prompt into")
+	taskKind := fs.String("task-kind", "", "task kind variant to promote (use _global for the all-items pass)")
+	file := fs.String("file", "", "judge candidate package JSON file")
+	yes := fs.Bool("yes", false, "apply the promotion; without it the command previews and writes nothing")
+	jsonOutput := fs.Bool("json", false, "print the result as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt judge promote does not accept positional arguments")
+		return 2
+	}
+	templateRef := strings.TrimSpace(*templateID)
+	if templateRef == "" {
+		fmt.Fprintln(stderr, "skillopt judge promote requires --template")
+		return 2
+	}
+	kind := strings.TrimSpace(*taskKind)
+	if kind == "" {
+		fmt.Fprintln(stderr, "skillopt judge promote requires --task-kind")
+		return 2
+	}
+	packagePath := strings.TrimSpace(*file)
+	if packagePath == "" {
+		fmt.Fprintln(stderr, "skillopt judge promote requires --file")
+		return 2
+	}
+	data, err := os.ReadFile(packagePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt judge promote: read package: %v\n", err)
+		return 2
+	}
+	pkg, err := skillopt.ParseJudgeCandidatePackage(data)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt judge promote: %v\n", err)
+		return 2
+	}
+	variant, ok := pkg.Variants[kind]
+	if !ok {
+		fmt.Fprintf(stderr, "skillopt judge promote: task-kind %q not found in package variants\n", kind)
+		return 2
+	}
+	if !variant.Accepted {
+		fmt.Fprintf(stderr, "skillopt judge promote: variant %q was not accepted by the judge optimizer (best_origin=%q); refusing to promote\n", kind, variant.BestOrigin)
+		return 1
+	}
+	if strings.TrimSpace(variant.BestPrompt) == "" {
+		fmt.Fprintf(stderr, "skillopt judge promote: variant %q has an empty best_prompt; nothing to promote\n", kind)
+		return 1
+	}
+
+	result := skillOptJudgePromoteResult{
+		TemplateID:        templateRef,
+		TaskKind:          kind,
+		Accepted:          variant.Accepted,
+		BaselineAgreement: variant.BaselineAgreement,
+		BestAgreement:     variant.BestAgreement,
+		AgreementDelta:    variant.BestAgreement - variant.BaselineAgreement,
+		BestOrigin:        variant.BestOrigin,
+		NewPromptVersion:  strings.TrimSpace(variant.JudgePromptVersion),
+		PromptBytes:       len(variant.BestPrompt),
+		PromptPreview:     truncateSkillOptJudgePrompt(variant.BestPrompt),
+	}
+
+	// Preview by default; only --yes writes.
+	openStore := withReadOnlyStore
+	if *yes {
+		openStore = withStore
+	}
+	if err := openStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		template, err := loadInstalledTemplate(ctx, store, templateRef)
+		if err != nil {
+			return err
+		}
+		metadata, err := agenttemplate.UnmarshalMetadata(template.MetadataJSON)
+		if err != nil {
+			return fmt.Errorf("decode template metadata: %w", err)
+		}
+		result.PreviousPromptVersion = strings.TrimSpace(metadata.Evaluation["judge_prompt_version"])
+		updatedMetadata, err := applyJudgePromptToMetadata(metadata, kind, variant)
+		if err != nil {
+			return err
+		}
+		if !*yes {
+			return nil
+		}
+		metadataJSON, err := agenttemplate.MarshalMetadata(updatedMetadata)
+		if err != nil {
+			return fmt.Errorf("encode template metadata: %w", err)
+		}
+		if _, err := store.UpdateAgentTemplateMetadata(ctx, template.ID, metadataJSON); err != nil {
+			return err
+		}
+		result.Applied = true
+		reason := fmt.Sprintf("judge prompt promoted for task_kind=%s: agreement %.3f→%.3f (delta %+.3f), origin=%s, version %s→%s",
+			kind, variant.BaselineAgreement, variant.BestAgreement, result.AgreementDelta, variant.BestOrigin,
+			emptyToDash(result.PreviousPromptVersion), emptyToDash(result.NewPromptVersion))
+		outcome := db.SkillOptJudgeOutcome{
+			CandidateVersionID: judgeOutcomeCandidateVersionID(template),
+			TemplateID:         template.ID,
+			JudgePromptVersion: result.NewPromptVersion,
+			HumanDecision:      "promoted",
+			// The human promoted and the judge optimizer already accepted this
+			// variant (the accepted-gate above), so the decision agrees with the
+			// judge's signal.
+			Direction: db.SkillOptJudgeDirectionAgreeAccept,
+			Reason:    reason,
+		}
+		if err := store.InsertSkillOptJudgeOutcome(ctx, outcome); err != nil {
+			return fmt.Errorf("record judge outcome: %w", err)
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt judge promote: %v\n", err)
+		return 1
+	}
+
+	if *jsonOutput {
+		if err := writeJSON(stdout, result); err != nil {
+			fmt.Fprintf(stderr, "skillopt judge promote: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printSkillOptJudgePromoteResult(stdout, result)
+	return 0
+}
+
+// applyJudgePromptToMetadata folds an accepted judge variant into a template's
+// flat Evaluation map: judge_prompt_templates is stored as a JSON-encoded
+// map[task_kind]string (merging so sibling task kinds are preserved), and
+// judge_prompt_version records the variant's version. The encoding round-trips
+// through EvaluationConfigForReader → judgePromptConfigFromConfig.
+func applyJudgePromptToMetadata(metadata agenttemplate.Metadata, taskKind string, variant skillopt.JudgeCandidateVariant) (agenttemplate.Metadata, error) {
+	templates := map[string]string{}
+	if existing := strings.TrimSpace(metadata.Evaluation["judge_prompt_templates"]); existing != "" {
+		if err := json.Unmarshal([]byte(existing), &templates); err != nil {
+			// Existing value is not a JSON object map; start fresh rather than
+			// silently dropping the new prompt.
+			templates = map[string]string{}
+		}
+	}
+	templates[taskKind] = variant.BestPrompt
+	encoded, err := json.Marshal(templates)
+	if err != nil {
+		return agenttemplate.Metadata{}, fmt.Errorf("encode judge prompt templates: %w", err)
+	}
+	if metadata.Evaluation == nil {
+		metadata.Evaluation = map[string]string{}
+	}
+	metadata.Evaluation["judge_prompt_templates"] = string(encoded)
+	if version := strings.TrimSpace(variant.JudgePromptVersion); version != "" {
+		metadata.Evaluation["judge_prompt_version"] = version
+	}
+	return metadata, nil
+}
+
+// judgeOutcomeCandidateVersionID picks a non-empty candidate_version_id for the
+// audit row (the column is NOT NULL): the template's current version when known,
+// otherwise the template id itself, since judge-prompt promotion targets the
+// template rather than a specific candidate version.
+func judgeOutcomeCandidateVersionID(template db.AgentTemplate) string {
+	if id := strings.TrimSpace(template.VersionID); id != "" {
+		return id
+	}
+	return template.ID
+}
+
+func truncateSkillOptJudgePrompt(prompt string) string {
+	prompt = strings.TrimSpace(prompt)
+	if utf8.RuneCountInString(prompt) <= skillOptJudgePromptPreviewLimit {
+		return prompt
+	}
+	runes := []rune(prompt)
+	return string(runes[:skillOptJudgePromptPreviewLimit]) + "…"
+}
+
+func emptyToDash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
+}
+
+func printSkillOptJudgePromoteResult(w io.Writer, result skillOptJudgePromoteResult) {
+	writeLine(w, "template: %s", result.TemplateID)
+	writeLine(w, "task_kind: %s", result.TaskKind)
+	writeLine(w, "accepted: %t", result.Accepted)
+	writeLine(w, "agreement: %.3f → %.3f (delta %+.3f)", result.BaselineAgreement, result.BestAgreement, result.AgreementDelta)
+	if result.BestOrigin != "" {
+		writeLine(w, "best_origin: %s", result.BestOrigin)
+	}
+	writeLine(w, "judge_prompt_version: %s → %s", emptyToDash(result.PreviousPromptVersion), emptyToDash(result.NewPromptVersion))
+	writeLine(w, "prompt_bytes: %d", result.PromptBytes)
+	if result.PromptPreview != "" {
+		writeLine(w, "prompt_preview:")
+		writeLine(w, "%s", result.PromptPreview)
+	}
+	if result.Applied {
+		writeLine(w, "applied: wrote judge prompt into template %s", result.TemplateID)
+	} else {
+		writeLine(w, "preview only: nothing was written. Re-run with --yes to apply.")
+	}
 }
 
 func runSkillOptCandidateReject(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/skillopt_judge_test.go
+++ b/internal/cli/skillopt_judge_test.go
@@ -1,0 +1,310 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// cliJudgeTemplate installs a planner template with an existing Evaluation map,
+// including a pre-existing judge_prompt_templates sibling so promotion-merge can
+// be asserted to preserve other task kinds.
+func cliJudgeTemplate(id string) db.AgentTemplate {
+	content := agenttemplate.FormatTemplateContent(agenttemplate.Metadata{
+		ID:                   id,
+		Name:                 "Planner",
+		Description:          "Plans implementation work.",
+		Kind:                 agenttemplate.TemplateKind,
+		Version:              agenttemplate.TemplateVersion,
+		Capabilities:         []string{"ask"},
+		RuntimeCompatibility: []string{"codex"},
+		Tags:                 []string{"planning"},
+		Inputs:               []string{"task"},
+		Outputs:              []string{"plan"},
+		Evaluation: map[string]string{
+			"evaluator_id":           "landing_page_v1",
+			"evaluator_model":        "gpt-evaluator",
+			"preferred_gate":         "pairwise",
+			"judge_prompt_templates": `{"generic":"Existing generic prompt."}`,
+			"judge_prompt_version":   "v0",
+		},
+	}, "# Planner\n\nPlan the work.\n")
+	parsed, err := agenttemplate.ParseTemplateContent(content)
+	if err != nil {
+		panic(err)
+	}
+	metadataJSON, err := agenttemplate.MarshalMetadata(parsed.Metadata)
+	if err != nil {
+		panic(err)
+	}
+	return db.AgentTemplate{
+		ID:             id,
+		Name:           parsed.Metadata.Name,
+		Description:    parsed.Metadata.Description,
+		SourceRepo:     agenttemplate.LocalSourceRepo,
+		SourceRef:      agenttemplate.LocalSourceRef,
+		SourcePath:     id + ".md",
+		ResolvedCommit: agenttemplate.HashContent(content),
+		Content:        content,
+		MetadataJSON:   metadataJSON,
+	}
+}
+
+func writeJudgePackage(t *testing.T, dir string) string {
+	t.Helper()
+	pkg := map[string]any{
+		"kind":                      skillopt.JudgeCandidatePackageKind,
+		"contract_version":          skillopt.ContractVersion,
+		"judge_prompt_version_base": "v0",
+		"n_labeled":                 6,
+		"variants": map[string]any{
+			"vue_landing_page": map[string]any{
+				"task_kind":            "vue_landing_page",
+				"n_items":              6,
+				"baseline_agreement":   0.5,
+				"best_agreement":       0.83,
+				"best_origin":          "judge_reflect_vue_landing_page",
+				"judge_prompt_version": "v0+judge2",
+				"accepted":             true,
+				"best_prompt":          "Judge the landing page strictly.",
+			},
+			"refused_kind": map[string]any{
+				"task_kind":            "refused_kind",
+				"n_items":              4,
+				"baseline_agreement":   0.6,
+				"best_agreement":       0.6,
+				"best_origin":          "baseline_judge",
+				"judge_prompt_version": "v0",
+				"accepted":             false,
+				"best_prompt":          "Should not be promoted.",
+			},
+		},
+	}
+	encoded, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatalf("marshal judge package: %v", err)
+	}
+	path := filepath.Join(dir, "judge-candidate.json")
+	if err := os.WriteFile(path, encoded, 0o644); err != nil {
+		t.Fatalf("write judge package: %v", err)
+	}
+	return path
+}
+
+func newJudgeTestHome(t *testing.T) (string, config.Paths) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliJudgeTemplate("planner")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	return home, paths
+}
+
+func TestSkillOptJudgePromotePreviewWritesNothing(t *testing.T) {
+	home, paths := newJudgeTestHome(t)
+	pkgPath := writeJudgePackage(t, t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "judge", "promote", "--home", home, "--template", "planner", "--task-kind", "vue_landing_page", "--file", pkgPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("preview exit code = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "preview only") {
+		t.Fatalf("preview stdout missing preview notice: %q", out)
+	}
+	if !strings.Contains(out, "0.500 → 0.830") {
+		t.Fatalf("preview stdout missing agreement delta: %q", out)
+	}
+	if !strings.Contains(out, "Judge the landing page strictly.") {
+		t.Fatalf("preview stdout missing prompt preview: %q", out)
+	}
+
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	metadata, err := agenttemplate.UnmarshalMetadata(template.MetadataJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalMetadata returned error: %v", err)
+	}
+	if got := metadata.Evaluation["judge_prompt_version"]; got != "v0" {
+		t.Fatalf("preview must not change metadata; judge_prompt_version = %q, want v0", got)
+	}
+	if strings.Contains(metadata.Evaluation["judge_prompt_templates"], "vue_landing_page") {
+		t.Fatalf("preview must not write the new template: %q", metadata.Evaluation["judge_prompt_templates"])
+	}
+	outcomes, err := store.ListSkillOptJudgeOutcomes(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("ListSkillOptJudgeOutcomes returned error: %v", err)
+	}
+	if len(outcomes) != 0 {
+		t.Fatalf("preview must not write an audit row; got %d", len(outcomes))
+	}
+}
+
+func TestSkillOptJudgePromoteRefusesNotAccepted(t *testing.T) {
+	home, paths := newJudgeTestHome(t)
+	pkgPath := writeJudgePackage(t, t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "judge", "promote", "--home", home, "--template", "planner", "--task-kind", "refused_kind", "--file", pkgPath, "--yes"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for non-accepted variant, got %d (stderr=%s)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not accepted") {
+		t.Fatalf("stderr missing accepted-gate message: %q", stderr.String())
+	}
+
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	metadata, err := agenttemplate.UnmarshalMetadata(template.MetadataJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalMetadata returned error: %v", err)
+	}
+	if strings.Contains(metadata.Evaluation["judge_prompt_templates"], "refused_kind") {
+		t.Fatalf("refused variant must not be written: %q", metadata.Evaluation["judge_prompt_templates"])
+	}
+}
+
+func TestSkillOptJudgePromoteMissingTaskKind(t *testing.T) {
+	home, _ := newJudgeTestHome(t)
+	pkgPath := writeJudgePackage(t, t.TempDir())
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "judge", "promote", "--home", home, "--template", "planner", "--task-kind", "nonexistent", "--file", pkgPath, "--yes"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for missing task-kind, got 0 (stdout=%s)", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "not found in package variants") {
+		t.Fatalf("stderr missing not-found message: %q", stderr.String())
+	}
+}
+
+// TestSkillOptJudgePromoteApplyRoundTrip is the load-bearing acceptance test:
+// promote --yes, then read the persisted metadata back through the production
+// reader and assert judge_prompt_templates[task_kind] == best_prompt with the
+// version bumped, while preserving the sibling task kind.
+func TestSkillOptJudgePromoteApplyRoundTrip(t *testing.T) {
+	home, paths := newJudgeTestHome(t)
+	pkgPath := writeJudgePackage(t, t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "judge", "promote", "--home", home, "--template", "planner", "--task-kind", "vue_landing_page", "--file", pkgPath, "--yes", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("apply exit code = %d, stderr=%s", code, stderr.String())
+	}
+	var result struct {
+		Applied               bool    `json:"applied"`
+		TaskKind              string  `json:"task_kind"`
+		PreviousPromptVersion string  `json:"previous_judge_prompt_version"`
+		NewPromptVersion      string  `json:"new_judge_prompt_version"`
+		AgreementDelta        float64 `json:"agreement_delta"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode result JSON: %v\n%s", err, stdout.String())
+	}
+	if !result.Applied {
+		t.Fatalf("result.Applied = false, want true: %+v", result)
+	}
+	if result.PreviousPromptVersion != "v0" || result.NewPromptVersion != "v0+judge2" {
+		t.Fatalf("version bump = %q→%q", result.PreviousPromptVersion, result.NewPromptVersion)
+	}
+
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	metadata, err := agenttemplate.UnmarshalMetadata(template.MetadataJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalMetadata returned error: %v", err)
+	}
+
+	// Version was bumped in the durable home.
+	if got := metadata.Evaluation["judge_prompt_version"]; got != "v0+judge2" {
+		t.Fatalf("judge_prompt_version = %q, want v0+judge2", got)
+	}
+
+	// Round-trip through the production reader: the persisted flat Evaluation map
+	// expands into the nested config judgePromptConfigFromConfig consumes.
+	config := skillopt.EvaluationConfigForReader(metadata.Evaluation)
+	profile := skillopt.EvaluatorProfileFromConfig(config)
+	if profile == nil || profile.Judge == nil {
+		t.Fatalf("EvaluatorProfileFromConfig returned nil judge: %+v", profile)
+	}
+	payload := profile.Judge.JudgePromptConfig()
+	if payload == nil {
+		t.Fatal("JudgePromptConfig is nil; promoted prompt did not round-trip")
+	}
+	if got := payload.JudgePromptTemplates["vue_landing_page"]; got != "Judge the landing page strictly." {
+		t.Fatalf("round-trip judge_prompt_templates[vue_landing_page] = %q", got)
+	}
+	// Sibling task kind preserved.
+	if got := payload.JudgePromptTemplates["generic"]; got != "Existing generic prompt." {
+		t.Fatalf("sibling task kind not preserved: generic = %q", got)
+	}
+	if payload.JudgePromptVersion != "v0+judge2" {
+		t.Fatalf("round-trip judge_prompt_version = %q", payload.JudgePromptVersion)
+	}
+
+	// Audit row written.
+	outcomes, err := store.ListSkillOptJudgeOutcomes(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("ListSkillOptJudgeOutcomes returned error: %v", err)
+	}
+	if len(outcomes) != 1 {
+		t.Fatalf("expected 1 judge outcome row, got %d", len(outcomes))
+	}
+	outcome := outcomes[0]
+	if outcome.HumanDecision != "promoted" {
+		t.Fatalf("human_decision = %q, want promoted", outcome.HumanDecision)
+	}
+	if outcome.JudgePromptVersion != "v0+judge2" {
+		t.Fatalf("audit judge_prompt_version = %q", outcome.JudgePromptVersion)
+	}
+	if outcome.Direction != db.SkillOptJudgeDirectionAgreeAccept {
+		t.Fatalf("audit direction = %q, want %q", outcome.Direction, db.SkillOptJudgeDirectionAgreeAccept)
+	}
+	if !strings.Contains(outcome.Reason, "v0") || !strings.Contains(outcome.Reason, "v0+judge2") {
+		t.Fatalf("audit reason missing version delta: %q", outcome.Reason)
+	}
+	if !strings.Contains(outcome.Reason, "0.500") || !strings.Contains(outcome.Reason, "0.830") {
+		t.Fatalf("audit reason missing agreement delta: %q", outcome.Reason)
+	}
+}

--- a/internal/cli/skillopt_judge_test.go
+++ b/internal/cli/skillopt_judge_test.go
@@ -308,3 +308,88 @@ func TestSkillOptJudgePromoteApplyRoundTrip(t *testing.T) {
 		t.Fatalf("audit reason missing agreement delta: %q", outcome.Reason)
 	}
 }
+
+// TestSkillOptTrainStartFoldsPromotedJudgePrompt closes the #354 loop: a
+// template carrying a promoted judge prompt must have it folded into the
+// eval-run's evaluation config at train start, so the training-package export
+// reader (BuildEvaluatorProfile -> judgePromptConfigFromConfig) resolves it on a
+// subsequent run — not merely a unit round-trip of the template metadata.
+func TestSkillOptTrainStartFoldsPromotedJudgePrompt(t *testing.T) {
+	template := cliJudgeTemplate("planner-loop-354")
+
+	judgeEval := skillOptTemplateJudgeEvaluation(template)
+	if judgeEval == nil {
+		t.Fatal("skillOptTemplateJudgeEvaluation returned nil for a template with a promoted judge prompt")
+	}
+
+	metadata := skillOptTrainStartMetadata(
+		"Train planner outputs.",
+		db.EvalRunModeExplore, db.ExplorationLevelHigh, 4, "soft",
+		nil, nil, skillopt.TrainPreviewPolicy{}, skillOptTrainStartConfigDefaults{}, judgeEval,
+	)
+
+	profile := skillopt.BuildEvaluatorProfile("landing_page_v1", "gpt-evaluator", json.RawMessage(metadata))
+	if profile == nil || profile.Judge == nil {
+		t.Fatalf("BuildEvaluatorProfile returned nil judge: %+v", profile)
+	}
+	payload := profile.Judge.JudgePromptConfig()
+	if payload == nil {
+		t.Fatal("JudgePromptConfig is nil; promoted prompt was not folded into eval-run metadata")
+	}
+	if got := payload.JudgePromptTemplates["generic"]; got != "Existing generic prompt." {
+		t.Fatalf("eval-run judge_prompt_templates[generic] = %q, want %q", got, "Existing generic prompt.")
+	}
+	if payload.JudgePromptVersion != "v0" {
+		t.Fatalf("eval-run judge_prompt_version = %q, want v0", payload.JudgePromptVersion)
+	}
+}
+
+// TestSkillOptTrainStartOmitsJudgePromptWhenAbsent pins the no-op path: a
+// template with no promoted judge prompt yields a train-start evaluation block
+// carrying only preferred_gate (behavior unchanged).
+func TestSkillOptTrainStartOmitsJudgePromptWhenAbsent(t *testing.T) {
+	content := agenttemplate.FormatTemplateContent(agenttemplate.Metadata{
+		ID:                   "plain-354",
+		Name:                 "Plain",
+		Description:          "No judge prompt.",
+		Kind:                 agenttemplate.TemplateKind,
+		Version:              agenttemplate.TemplateVersion,
+		Capabilities:         []string{"ask"},
+		RuntimeCompatibility: []string{"codex"},
+		Tags:                 []string{"planning"},
+		Inputs:               []string{"task"},
+		Outputs:              []string{"plan"},
+	}, "# Plain\n\nDo the work.\n")
+	parsed, err := agenttemplate.ParseTemplateContent(content)
+	if err != nil {
+		t.Fatalf("ParseTemplateContent: %v", err)
+	}
+	metadataJSON, err := agenttemplate.MarshalMetadata(parsed.Metadata)
+	if err != nil {
+		t.Fatalf("MarshalMetadata: %v", err)
+	}
+	template := db.AgentTemplate{ID: "plain-354", MetadataJSON: metadataJSON}
+
+	if judgeEval := skillOptTemplateJudgeEvaluation(template); judgeEval != nil {
+		t.Fatalf("expected nil judge evaluation for a template without a promoted prompt, got %+v", judgeEval)
+	}
+
+	metadata := skillOptTrainStartMetadata(
+		"Train.", db.EvalRunModeExplore, db.ExplorationLevelHigh, 1, "soft",
+		nil, nil, skillopt.TrainPreviewPolicy{}, skillOptTrainStartConfigDefaults{}, nil,
+	)
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(metadata), &decoded); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	evaluation, _ := decoded["evaluation"].(map[string]any)
+	if evaluation == nil {
+		t.Fatal("evaluation block missing")
+	}
+	if _, ok := evaluation["judge_prompt_templates"]; ok {
+		t.Fatal("evaluation should not carry judge_prompt_templates when the template has none")
+	}
+	if _, ok := evaluation["preferred_gate"]; !ok {
+		t.Fatal("evaluation should still carry preferred_gate")
+	}
+}

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -3805,7 +3805,7 @@ func TestSkillOptTrainGenerationLockTTLScalesWithWorkload(t *testing.T) {
 		PreviewRepo:  "owner/previews",
 		TaskKind:     "design",
 		State:        skillopt.TrainStateItemsReady,
-		MetadataJSON: skillOptTrainStartMetadata("Train landing page previews.", db.EvalRunModeExplore, db.ExplorationLevelHigh, 4, "soft", nil, nil, previewPolicy, skillOptTrainStartConfigDefaults{}),
+		MetadataJSON: skillOptTrainStartMetadata("Train landing page previews.", db.EvalRunModeExplore, db.ExplorationLevelHigh, 4, "soft", nil, nil, previewPolicy, skillOptTrainStartConfigDefaults{}, nil),
 	}); err != nil {
 		t.Fatalf("UpsertSkillOptTrainSession returned error: %v", err)
 	}
@@ -6701,7 +6701,7 @@ func TestSkillOptTrainCandidateReviewBodyShowsTextSamplePreview(t *testing.T) {
 		t.Fatalf("BuildTrainPreviewPolicy optional returned error: %v", err)
 	}
 	optionalSession := session
-	optionalSession.MetadataJSON = skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil, optionalPolicy, skillOptTrainStartConfigDefaults{})
+	optionalSession.MetadataJSON = skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil, optionalPolicy, skillOptTrainStartConfigDefaults{}, nil)
 	for _, tt := range []struct {
 		name    string
 		session db.SkillOptTrainSession
@@ -6796,7 +6796,7 @@ func TestSkillOptTrainCandidateReviewRequiredPreviewKeepsBundleFailure(t *testin
 	if err != nil {
 		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
 	}
-	session.MetadataJSON = skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil, requiredPolicy, skillOptTrainStartConfigDefaults{})
+	session.MetadataJSON = skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil, requiredPolicy, skillOptTrainStartConfigDefaults{}, nil)
 	previews := publishSkillOptTrainCandidateSamplePreviews(context.Background(), paths, store, session, db.SkillOptTrainIteration{
 		ID:                    "optimizer-train-001",
 		CandidateVersionID:    version.ID,
@@ -9318,7 +9318,7 @@ func TestSkillOptFeedbackGitHubCommandsEnforceTrainReviewRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildTrainPreviewPolicy returned error: %v", err)
 	}
-	metadata := skillOptTrainStartMetadata("Train landing page reviews.", db.EvalRunModeExplore, db.ExplorationLevelHigh, 4, "soft", nil, nil, previewPolicy, skillOptTrainStartConfigDefaults{})
+	metadata := skillOptTrainStartMetadata("Train landing page reviews.", db.EvalRunModeExplore, db.ExplorationLevelHigh, 4, "soft", nil, nil, previewPolicy, skillOptTrainStartConfigDefaults{}, nil)
 	session := db.SkillOptTrainSession{
 		ID:           "preview-train",
 		TemplateID:   "planner",
@@ -11399,7 +11399,7 @@ func seedSkillOptTrainFeedbackSynced(t *testing.T) (string, string) {
 	if err != nil {
 		t.Fatalf("BuildTrainPreviewPolicy returned error: %v", err)
 	}
-	metadata := skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil, previewPolicy, skillOptTrainStartConfigDefaults{})
+	metadata := skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil, previewPolicy, skillOptTrainStartConfigDefaults{}, nil)
 	session := db.SkillOptTrainSession{
 		ID:                "optimizer-train",
 		TemplateID:        "planner",

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1273,6 +1273,46 @@ func (s *Store) PromoteAgentTemplateVersion(ctx context.Context, versionID strin
 	return s.GetAgentTemplateVersionByID(ctx, target.ID)
 }
 
+// UpdateAgentTemplateMetadata replaces the stored metadata_json for an installed
+// template (the agent_templates row) and, when present, its current version row,
+// so both the template-level read path and version-referenced exports observe the
+// change. Content, name, description, and version identity are untouched: this is
+// a focused metadata write used by `skillopt judge promote` to fold an accepted
+// judge prompt into the template's Evaluation map without minting a new version.
+func (s *Store) UpdateAgentTemplateMetadata(ctx context.Context, templateID string, metadataJSON string) (AgentTemplate, error) {
+	templateID = strings.TrimSpace(templateID)
+	metadataJSON = strings.TrimSpace(metadataJSON)
+	if templateID == "" {
+		return AgentTemplate{}, errors.New("template id is required")
+	}
+	if metadataJSON == "" {
+		return AgentTemplate{}, errors.New("metadata_json is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AgentTemplate{}, err
+	}
+	defer tx.Rollback()
+	result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET metadata_json = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, metadataJSON, templateID)
+	if err != nil {
+		return AgentTemplate{}, err
+	}
+	if err := requireAffected(result, "agent template", templateID); err != nil {
+		return AgentTemplate{}, err
+	}
+	if current, hasCurrent, err := getCurrentAgentTemplateVersion(ctx, tx, templateID); err != nil {
+		return AgentTemplate{}, err
+	} else if hasCurrent {
+		if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET metadata_json = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, metadataJSON, current.ID); err != nil {
+			return AgentTemplate{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return AgentTemplate{}, err
+	}
+	return s.GetAgentTemplate(ctx, templateID)
+}
+
 func (s *Store) RejectAgentTemplateVersion(ctx context.Context, versionID string, reason string) (AgentTemplateVersion, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -21,8 +21,9 @@ import (
 const (
 	ContractVersion = 1
 
-	TrainingPackageKind  = "gitmoot-skillopt-training-package"
-	CandidatePackageKind = "gitmoot-skillopt-candidate-package"
+	TrainingPackageKind       = "gitmoot-skillopt-training-package"
+	CandidatePackageKind      = "gitmoot-skillopt-candidate-package"
+	JudgeCandidatePackageKind = "gitmoot-skillopt-judge-candidate"
 
 	CandidateSourceRepo = "gitmoot-skillopt"
 	CandidateSourceRef  = "candidate"
@@ -166,6 +167,113 @@ func mergeJudgePromptConfig(existing json.RawMessage, payload *JudgePromptConfig
 		return existing, err
 	}
 	return json.RawMessage(out), nil
+}
+
+// JudgeCandidateVariant is one per-task_kind result emitted by the judge-prompt
+// optimizer (#345 Phase 2). The "_global" key in JudgeCandidatePackage.Variants
+// carries the all-items pass (TaskKind is empty there). A variant is only
+// eligible for promotion when Accepted is true and BestPrompt is non-empty.
+type JudgeCandidateVariant struct {
+	TaskKind           string  `json:"task_kind"`
+	NItems             int     `json:"n_items"`
+	BaselineAgreement  float64 `json:"baseline_agreement"`
+	BestAgreement      float64 `json:"best_agreement"`
+	BestOrigin         string  `json:"best_origin"`
+	JudgePromptVersion string  `json:"judge_prompt_version"`
+	Accepted           bool    `json:"accepted"`
+	BestPrompt         string  `json:"best_prompt"`
+}
+
+// JudgeCandidatePackage is the structured output of the judge-prompt optimizer,
+// emitted by the Python side as kind=JudgeCandidatePackageKind. It carries one
+// JudgeCandidateVariant per task_kind keyed in Variants (plus a "_global" pass).
+// `gitmoot skillopt judge promote` reads an accepted variant out of this package
+// and writes it into a template so the next skill-opt run judges with it.
+type JudgeCandidatePackage struct {
+	Kind                   string                           `json:"kind"`
+	ContractVersion        int                              `json:"contract_version"`
+	JudgePromptVersionBase string                           `json:"judge_prompt_version_base,omitempty"`
+	NLabeled               int                              `json:"n_labeled,omitempty"`
+	Variants               map[string]JudgeCandidateVariant `json:"variants"`
+}
+
+// ParseJudgeCandidatePackage decodes and validates a judge-candidate package
+// blob, enforcing the kind tag and ContractVersion so a stale or foreign payload
+// is rejected before any promotion is attempted.
+func ParseJudgeCandidatePackage(data []byte) (JudgeCandidatePackage, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return JudgeCandidatePackage{}, errors.New("judge candidate package is empty")
+	}
+	var pkg JudgeCandidatePackage
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return JudgeCandidatePackage{}, fmt.Errorf("decode judge candidate package: %w", err)
+	}
+	if pkg.Kind != JudgeCandidatePackageKind {
+		return JudgeCandidatePackage{}, fmt.Errorf("judge candidate package kind must be %q, got %q", JudgeCandidatePackageKind, pkg.Kind)
+	}
+	if pkg.ContractVersion != ContractVersion {
+		return JudgeCandidatePackage{}, fmt.Errorf("judge candidate package contract_version must be %d, got %d", ContractVersion, pkg.ContractVersion)
+	}
+	if len(pkg.Variants) == 0 {
+		return JudgeCandidatePackage{}, errors.New("judge candidate package has no variants")
+	}
+	return pkg, nil
+}
+
+// EvaluationConfigForReader expands a template's flat Evaluation map
+// (map[string]string, where judge_prompt_templates is stored as a JSON-encoded
+// object string per the write contract of `judge promote`) into the nested
+// evaluator config that judgePromptConfigFromConfig / EvaluatorProfileFromConfig
+// consume. It mirrors how the eval-run start path nests an "evaluation" object:
+// the JSON-string value of judge_prompt_templates is re-inlined as a real object
+// so the reader's map[string]string decode succeeds. This is the bridge that
+// proves the round-trip without changing the reader's contract. It returns nil
+// for an empty map so callers can fall back to existing config sources.
+func EvaluationConfigForReader(evaluation map[string]string) json.RawMessage {
+	if len(evaluation) == 0 {
+		return nil
+	}
+	nested := make(map[string]json.RawMessage, len(evaluation))
+	for key, value := range evaluation {
+		switch key {
+		case "judge_prompt_templates":
+			trimmed := strings.TrimSpace(value)
+			if trimmed == "" {
+				continue
+			}
+			// Stored as a JSON-encoded object string; re-inline as raw JSON when
+			// it parses as the map[string]string the reader expects, otherwise
+			// fall back to a JSON string so the value is never silently dropped.
+			var probe map[string]string
+			if err := json.Unmarshal([]byte(trimmed), &probe); err == nil {
+				nested[key] = json.RawMessage(trimmed)
+				continue
+			}
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				continue
+			}
+			nested[key] = encoded
+		default:
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				continue
+			}
+			nested[key] = encoded
+		}
+	}
+	if len(nested) == 0 {
+		return nil
+	}
+	nestedRaw, err := json.Marshal(nested)
+	if err != nil {
+		return nil
+	}
+	wrapper, err := json.Marshal(map[string]json.RawMessage{"evaluation": nestedRaw})
+	if err != nil {
+		return nil
+	}
+	return json.RawMessage(wrapper)
 }
 
 type EvaluatorStageStatus struct {

--- a/internal/skillopt/contract_judge_test.go
+++ b/internal/skillopt/contract_judge_test.go
@@ -1,0 +1,160 @@
+package skillopt
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func validJudgeCandidatePackageJSON() string {
+	return `{
+		"kind": "gitmoot-skillopt-judge-candidate",
+		"contract_version": 1,
+		"judge_prompt_version_base": "v0",
+		"n_labeled": 6,
+		"variants": {
+			"vue_landing_page": {
+				"task_kind": "vue_landing_page",
+				"n_items": 6,
+				"baseline_agreement": 0.5,
+				"best_agreement": 0.83,
+				"best_origin": "judge_reflect_vue_landing_page",
+				"judge_prompt_version": "v0+judge2",
+				"accepted": true,
+				"best_prompt": "Judge the landing page strictly.",
+				"history": [{"agreement": 0.5}, {"agreement": 0.83}]
+			},
+			"_global": {
+				"task_kind": "",
+				"n_items": 6,
+				"baseline_agreement": 0.5,
+				"best_agreement": 0.5,
+				"best_origin": "baseline_judge",
+				"judge_prompt_version": "v0",
+				"accepted": false,
+				"best_prompt": "Judge the artifact."
+			}
+		}
+	}`
+}
+
+func TestParseJudgeCandidatePackage(t *testing.T) {
+	pkg, err := ParseJudgeCandidatePackage([]byte(validJudgeCandidatePackageJSON()))
+	if err != nil {
+		t.Fatalf("ParseJudgeCandidatePackage returned error: %v", err)
+	}
+	if pkg.Kind != JudgeCandidatePackageKind {
+		t.Fatalf("kind = %q, want %q", pkg.Kind, JudgeCandidatePackageKind)
+	}
+	if pkg.ContractVersion != ContractVersion {
+		t.Fatalf("contract_version = %d, want %d", pkg.ContractVersion, ContractVersion)
+	}
+	if pkg.JudgePromptVersionBase != "v0" || pkg.NLabeled != 6 {
+		t.Fatalf("base/n_labeled = %q/%d", pkg.JudgePromptVersionBase, pkg.NLabeled)
+	}
+	variant, ok := pkg.Variants["vue_landing_page"]
+	if !ok {
+		t.Fatalf("missing vue_landing_page variant: %+v", pkg.Variants)
+	}
+	if !variant.Accepted || variant.BestPrompt != "Judge the landing page strictly." {
+		t.Fatalf("variant = %+v", variant)
+	}
+	if variant.JudgePromptVersion != "v0+judge2" {
+		t.Fatalf("judge_prompt_version = %q", variant.JudgePromptVersion)
+	}
+	if variant.BaselineAgreement != 0.5 || variant.BestAgreement != 0.83 {
+		t.Fatalf("agreement = %v→%v", variant.BaselineAgreement, variant.BestAgreement)
+	}
+	if global := pkg.Variants["_global"]; global.Accepted {
+		t.Fatalf("_global should not be accepted: %+v", global)
+	}
+}
+
+func TestParseJudgeCandidatePackageRejectsWrongKind(t *testing.T) {
+	data := strings.Replace(validJudgeCandidatePackageJSON(), "gitmoot-skillopt-judge-candidate", "gitmoot-skillopt-candidate-package", 1)
+	if _, err := ParseJudgeCandidatePackage([]byte(data)); err == nil {
+		t.Fatal("expected error for wrong kind")
+	}
+}
+
+func TestParseJudgeCandidatePackageRejectsWrongContractVersion(t *testing.T) {
+	data := strings.Replace(validJudgeCandidatePackageJSON(), `"contract_version": 1`, `"contract_version": 2`, 1)
+	if _, err := ParseJudgeCandidatePackage([]byte(data)); err == nil {
+		t.Fatal("expected error for contract_version mismatch")
+	}
+}
+
+func TestParseJudgeCandidatePackageRejectsEmpty(t *testing.T) {
+	if _, err := ParseJudgeCandidatePackage([]byte("  ")); err == nil {
+		t.Fatal("expected error for empty package")
+	}
+}
+
+func TestParseJudgeCandidatePackageRejectsNoVariants(t *testing.T) {
+	data := `{"kind":"gitmoot-skillopt-judge-candidate","contract_version":1,"variants":{}}`
+	if _, err := ParseJudgeCandidatePackage([]byte(data)); err == nil {
+		t.Fatal("expected error for empty variants")
+	}
+}
+
+// TestEvaluationConfigForReaderRoundTrip proves the write encoding used by
+// `skillopt judge promote` (a flat Evaluation map[string]string where
+// judge_prompt_templates is a JSON-encoded object string) is readable back by
+// the production judge-prompt reader. EvaluationConfigForReader expands the flat
+// map into the nested evaluator config that judgePromptConfigFromConfig /
+// EvaluatorProfileFromConfig consume, mirroring the eval-run start nesting.
+func TestEvaluationConfigForReaderRoundTrip(t *testing.T) {
+	// Encode the templates exactly as the write path does.
+	templates := map[string]string{
+		"vue_landing_page": "Judge the landing page strictly.",
+		"generic":          "Judge the artifact.",
+	}
+	encoded, err := json.Marshal(templates)
+	if err != nil {
+		t.Fatalf("marshal templates: %v", err)
+	}
+	evaluation := map[string]string{
+		"driver":                 "code-review",
+		"preferred_gate":         "pairwise",
+		"evaluator_id":           "landing_page_v1",
+		"evaluator_model":        "gpt-evaluator",
+		"judge_prompt_templates": string(encoded),
+		"judge_prompt_version":   "v0+judge2",
+	}
+
+	config := EvaluationConfigForReader(evaluation)
+	if len(config) == 0 {
+		t.Fatal("EvaluationConfigForReader returned empty config")
+	}
+
+	// Read back through the production path.
+	profile := EvaluatorProfileFromConfig(config)
+	if profile == nil {
+		t.Fatal("EvaluatorProfileFromConfig returned nil")
+	}
+	if profile.Judge == nil {
+		t.Fatal("profile.Judge is nil")
+	}
+	payload := profile.Judge.JudgePromptConfig()
+	if payload == nil {
+		t.Fatal("JudgePromptConfig is nil; templates did not round-trip")
+	}
+	if got := payload.JudgePromptTemplates["vue_landing_page"]; got != "Judge the landing page strictly." {
+		t.Fatalf("judge_prompt_templates[vue_landing_page] = %q", got)
+	}
+	if got := payload.JudgePromptTemplates["generic"]; got != "Judge the artifact." {
+		t.Fatalf("judge_prompt_templates[generic] = %q", got)
+	}
+	if payload.JudgePromptVersion != "v0+judge2" {
+		t.Fatalf("judge_prompt_version = %q, want v0+judge2", payload.JudgePromptVersion)
+	}
+}
+
+func TestEvaluationConfigForReaderEmpty(t *testing.T) {
+	if config := EvaluationConfigForReader(nil); config != nil {
+		t.Fatalf("expected nil for empty map, got %q", string(config))
+	}
+	if config := EvaluationConfigForReader(map[string]string{}); config != nil {
+		t.Fatalf("expected nil for empty map, got %q", string(config))
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -508,6 +508,7 @@ gitmoot skillopt train continue --session <id> [--generator-type skillopt-genera
 gitmoot skillopt train recover --session <id> [--out-root path] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
 gitmoot skillopt judge-report [--template <id>] [--home <path>]
+gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <path>] [--yes] [--json]
 ```
 
 On a real terminal, `skillopt train run` opens an interactive view of one session
@@ -592,6 +593,22 @@ LLM judge is calibrated against human verdicts. It prints a confusion matrix
 buckets (judge soft-score versus the human decision), and per-dimension
 disagreement. Pass `--template <id>` to scope the report to one template, and
 `--home <path>` to read from a non-default Gitmoot home. It is read-only.
+
+`skillopt judge promote` closes the judge-prompt optimization loop: it applies an
+**accepted** judge-prompt variant (from the judge-prompt optimizer's
+`gitmoot-skillopt-judge-candidate` package) into a template, so the next
+skill-opt run judges with the improved prompt. Select the variant with
+`--task-kind <kind>` (use `_global` for the all-items pass). It **previews by
+default** — printing the template id, task kind, the `baseline→best` agreement
+delta, and a truncated prompt preview, and writing nothing — and requires
+`--yes` to apply. It refuses (hard error) any variant whose `accepted` is not
+true or whose `best_prompt` is empty, and any task kind missing from the package.
+On apply it writes the prompt into the template's `evaluation` metadata
+(`judge_prompt_templates` keyed by task kind, **merging** so other task kinds are
+preserved, plus a bumped `judge_prompt_version`) and records a
+`skillopt_judge_outcomes` audit row (`human_decision=promoted`, the old→new
+version, and the agreement delta in `reason`). `--json` emits the machine-readable
+preview/apply summary.
 
 The Markdown feedback collector writes blind A/B review packets with `index.md`,
 per-item Markdown files, editable `feedback.yml`, and hidden assignment metadata

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -505,6 +505,7 @@ gitmoot skillopt train continue --session <id> [--generator-type skillopt-genera
 gitmoot skillopt train recover --session <id> [--out-root path] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
 gitmoot skillopt judge-report [--template <id>] [--home <path>]
+gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <path>] [--yes] [--json]
 ```
 
 On a real terminal, `skillopt train run` opens an interactive view of one session
@@ -601,6 +602,22 @@ LLM judge is calibrated against human verdicts. It prints a confusion matrix
 buckets (judge soft-score versus the human decision), and per-dimension
 disagreement. Pass `--template <id>` to scope the report to one template, and
 `--home <path>` to read from a non-default Gitmoot home. It is read-only.
+
+`skillopt judge promote` closes the judge-prompt optimization loop: it applies an
+**accepted** judge-prompt variant (from the judge-prompt optimizer's
+`gitmoot-skillopt-judge-candidate` package) into a template, so the next
+skill-opt run judges with the improved prompt. Select the variant with
+`--task-kind <kind>` (use `_global` for the all-items pass). It **previews by
+default** — printing the template id, task kind, the `baseline→best` agreement
+delta, and a truncated prompt preview, and writing nothing — and requires
+`--yes` to apply. It refuses (hard error) any variant whose `accepted` is not
+true or whose `best_prompt` is empty, and any task kind missing from the package.
+On apply it writes the prompt into the template's `evaluation` metadata
+(`judge_prompt_templates` keyed by task kind, **merging** so other task kinds are
+preserved, plus a bumped `judge_prompt_version`) and records a
+`skillopt_judge_outcomes` audit row (`human_decision=promoted`, the old→new
+version, and the agreement delta in `reason`). `--json` emits the machine-readable
+preview/apply summary.
 
 The Markdown feedback collector writes blind A/B review packets with `index.md`,
 per-item Markdown files, editable `feedback.yml`, and hidden assignment metadata

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5926,6 +5926,7 @@ gitmoot skillopt train continue --session <id> [--generator-type skillopt-genera
 gitmoot skillopt train recover --session <id> [--out-root path] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
 gitmoot skillopt judge-report [--template <id>] [--home <path>]
+gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <path>] [--yes] [--json]
 ```
 
 On a real terminal, `skillopt train run` opens an interactive view of one session
@@ -6010,6 +6011,22 @@ LLM judge is calibrated against human verdicts. It prints a confusion matrix
 buckets (judge soft-score versus the human decision), and per-dimension
 disagreement. Pass `--template <id>` to scope the report to one template, and
 `--home <path>` to read from a non-default Gitmoot home. It is read-only.
+
+`skillopt judge promote` closes the judge-prompt optimization loop: it applies an
+**accepted** judge-prompt variant (from the judge-prompt optimizer's
+`gitmoot-skillopt-judge-candidate` package) into a template, so the next
+skill-opt run judges with the improved prompt. Select the variant with
+`--task-kind <kind>` (use `_global` for the all-items pass). It **previews by
+default** — printing the template id, task kind, the `baseline→best` agreement
+delta, and a truncated prompt preview, and writing nothing — and requires
+`--yes` to apply. It refuses (hard error) any variant whose `accepted` is not
+true or whose `best_prompt` is empty, and any task kind missing from the package.
+On apply it writes the prompt into the template's `evaluation` metadata
+(`judge_prompt_templates` keyed by task kind, **merging** so other task kinds are
+preserved, plus a bumped `judge_prompt_version`) and records a
+`skillopt_judge_outcomes` audit row (`human_decision=promoted`, the old→new
+version, and the agreement delta in `reason`). `--json` emits the machine-readable
+preview/apply summary.
 
 The Markdown feedback collector writes blind A/B review packets with `index.md`,
 per-item Markdown files, editable `feedback.yml`, and hidden assignment metadata


### PR DESCRIPTION
Closes #354.

Closes the SkillOpt judge-prompt loop: an **accepted** judge-candidate variant from the optimizer (#345 Phase 2) can now be promoted into a template and is actually resolved by a subsequent run.

## What
- `gitmoot skillopt judge promote --template <id> --task-kind <k> --file <pkg.json> [--yes]` — **preview by default** (shows baseline→best agreement + the prompt), `--yes` applies. Refuses non-`accepted` variants, empty prompts, and missing task kinds.
- New contract type `JudgeCandidatePackage` + `ParseJudgeCandidatePackage` (validates `kind` + `contract_version==1`).
- Promotion writes the accepted `best_prompt` into the template's `Metadata.Evaluation["judge_prompt_templates"]` (merging — sibling task kinds preserved) and bumps `judge_prompt_version`; records a `skillopt_judge_outcomes` audit row.
- **Consumption (the loop):** `train start` now folds the template's promoted judge fields into the eval-run's `evaluation` config, so the export reader (`BuildEvaluatorProfile` → `judgePromptConfigFromConfig`) resolves the new prompt on the next run. Byte-identical when a template carries no promoted prompt.

## Verification
- Full Go gate green: `build` / `vet` / `test ./...` (28 pkgs) / `-race ./internal/workflow/`.
- Tests: package parse/validate, preview-vs-apply, accepted-gate refusal, per-task_kind merge preservation, audit row, **round-trip through the production reader**, and **loop-closure** (train-start fold → reader resolves) + no-op preservation.
- Binary E2E (isolated on-disk store): `judge promote` preview wrote nothing, refused a non-accepted variant, and `--yes` persisted `judge_prompt_templates`/`judge_prompt_version` for only the accepted task kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
