### PR TITLE
docs(skillopt): pin install wheel to v0.3.1 (#346)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -107,7 +107,7 @@ continues:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -421,7 +421,7 @@ recommended install path is:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -2188,7 +2188,7 @@ type skillOptTrainOptimizerRequest struct {
 	OptimizerLockState           string
 }
 
-const skillOptTrainSkillOptWheelURL = "https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.2.0b1/gitmoot_skillopt-0.2.0b1-py3-none-any.whl"
+const skillOptTrainSkillOptWheelURL = "https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl"
 
 type skillOptTrainOptimizerPreflightError struct {
 	Executable string

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -566,7 +566,7 @@ training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
 to validate the contract without model calls.
 Before real model-backed optimization, check `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help`, or install it with
-`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl`.
+`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl`.
 Verify required model/backend environment variables for the installed optimizer
 version. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -129,7 +129,7 @@ training:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -290,7 +290,7 @@ Fix:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -575,7 +575,7 @@ training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
 to validate the contract without model calls.
 Before real model-backed optimization, check `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help`, or install it with
-`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl`.
+`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl`.
 Verify required model/backend environment variables for the installed optimizer
 version. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -421,7 +421,7 @@ recommended install path is:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -647,7 +647,7 @@ continues:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```
@@ -2748,7 +2748,7 @@ recommended install path is:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```
@@ -5984,7 +5984,7 @@ training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
 to validate the contract without model calls.
 Before real model-backed optimization, check `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help`, or install it with
-`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.0/gitmoot_skillopt-0.3.0-py3-none-any.whl`.
+`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.3.1/gitmoot_skillopt-0.3.1-py3-none-any.whl`.
 Verify required model/backend environment variables for the installed optimizer
 version. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate


### PR DESCRIPTION
Bumps the hardcoded `gitmoot-skillopt` install wheel URL to **v0.3.1** (ships the default-on hard verifiers, #346) across both doc trees, regenerates `llms-full.txt`, and fixes the **doubly-stale** CLI install-hint const in `internal/cli/skillopt.go` (was `v0.2.0b1` — the v0.3.0 release missed it).

The 'gitmoot-skillopt v0.3.0 can optimize the judge prompt' attribution at the workflow doc is left as-is (the feature genuinely landed in v0.3.0).

Gate: `go build`/`vet` + `internal/cli` tests green locally. Site redeploy follows on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)