### PR TITLE
feat(workflow): operator kill switch for delegation trees (#341)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -44,6 +44,7 @@ gitmoot job show <job-id>
 gitmoot job watch <job-id>
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>
+gitmoot job kill <root-job-id>            # operator kill switch for a runaway delegation tree
 gitmoot status --repo owner/repo
 gitmoot version --json
 gitmoot update --check

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1628,12 +1628,18 @@ func queuedJobMatchesSession(job db.Job, rootFilter string) bool {
 	return err == nil && payload.RootJobID == rootFilter
 }
 
-// queuedChildOfKilledRoot reports whether a queued job is a child of a delegation
-// tree whose root has been killed by an operator (#341). Only children are
-// matched: the root coordinator itself (payload.RootJobID == "" or == job.ID) is
-// never skipped, so its next continuation can run and route the engine through
-// the graceful finalize path. A payload-parse miss or store error fails open
-// (returns false) so a hiccup never silently strands a normal job.
+// queuedChildOfKilledRoot reports whether a queued job is a delegation child leg
+// of a tree whose root has been killed by an operator (#341). Only child legs are
+// matched and skipped. Two classes are deliberately exempted so the graceful
+// finalize can still run:
+//   - the root coordinator itself (payload.RootJobID == "" or == job.ID); and
+//   - any continuation (coordinator reconvene or the #305 graceful finalize),
+//     which carries no DelegationID — it MUST run so the engine routes the killed
+//     tree through enqueueFinalizeContinuation and emits a terminal result.
+//
+// Delegation child legs set DelegationID (delegationRequest), so a non-empty
+// DelegationID is what marks a job as skippable work. A payload-parse miss or
+// store error fails open (returns false) so a hiccup never silently strands a job.
 func queuedChildOfKilledRoot(ctx context.Context, store *db.Store, job db.Job) bool {
 	if store == nil {
 		return false
@@ -1644,6 +1650,12 @@ func queuedChildOfKilledRoot(ctx context.Context, store *db.Store, job db.Job) b
 	}
 	rootJobID := strings.TrimSpace(payload.RootJobID)
 	if rootJobID == "" || rootJobID == job.ID {
+		return false
+	}
+	// Continuations (DelegationID == "") reconvene the coordinator / finalize the
+	// tree and must always run, even for a killed root. Only actual child legs are
+	// skipped.
+	if strings.TrimSpace(payload.DelegationID) == "" {
 		return false
 	}
 	killed, err := store.IsRootJobKilled(ctx, rootJobID)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1461,9 +1461,18 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 	}
 	pending := make([]db.Job, 0, len(jobs))
 	for _, job := range jobs {
-		if queuedJobMatchesRepo(job, repoFilter) && queuedJobMatchesSession(job, rootFilter) {
-			pending = append(pending, job)
+		if !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
+			continue
 		}
+		// Operator kill switch (#341): once a tree's root is killed, do not start
+		// any of its queued children. The coordinator's own continuation still runs
+		// so the engine can route through the graceful finalize path; in-flight
+		// children finish normally. Only children (payload.RootJobID points at
+		// another root) are skipped here — the root job itself is never skipped.
+		if queuedChildOfKilledRoot(ctx, worker.Store, job) {
+			continue
+		}
+		pending = append(pending, job)
 	}
 	for len(pending) > 0 {
 		policy, err := worker.parallelSessionPolicy()
@@ -1617,6 +1626,28 @@ func queuedJobMatchesSession(job db.Job, rootFilter string) bool {
 	}
 	payload, err := daemonJobPayload(job)
 	return err == nil && payload.RootJobID == rootFilter
+}
+
+// queuedChildOfKilledRoot reports whether a queued job is a child of a delegation
+// tree whose root has been killed by an operator (#341). Only children are
+// matched: the root coordinator itself (payload.RootJobID == "" or == job.ID) is
+// never skipped, so its next continuation can run and route the engine through
+// the graceful finalize path. A payload-parse miss or store error fails open
+// (returns false) so a hiccup never silently strands a normal job.
+func queuedChildOfKilledRoot(ctx context.Context, store *db.Store, job db.Job) bool {
+	if store == nil {
+		return false
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return false
+	}
+	rootJobID := strings.TrimSpace(payload.RootJobID)
+	if rootJobID == "" || rootJobID == job.ID {
+		return false
+	}
+	killed, err := store.IsRootJobKilled(ctx, rootJobID)
+	return err == nil && killed
 }
 
 func queuedJobCheckoutKey(ctx context.Context, store *db.Store, job db.Job) string {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4515,12 +4515,16 @@ func TestRunQueuedJobsForRepoSkipsChildrenOfKilledRoot(t *testing.T) {
 	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
 	seedDaemonWorkerAgent(t, store, "w", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
 
-	killedChildPayload := mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", Sender: "w", RootJobID: "killed-root"})
-	liveChildPayload := mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", Sender: "w", RootJobID: "live-root"})
+	killedChildPayload := mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", Sender: "w", RootJobID: "killed-root", DelegationID: "d1"})
+	liveChildPayload := mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", Sender: "w", RootJobID: "live-root", DelegationID: "d2"})
+	// A continuation of the killed root carries NO DelegationID and MUST still run
+	// so the engine routes the tree through the graceful #305 finalize.
+	killedContinuationPayload := mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", Sender: "w", RootJobID: "killed-root", DelegationFinalize: true})
 	for _, j := range []db.Job{
 		{ID: "killed-root", Agent: "w", Type: "ask", State: string(workflow.JobSucceeded), Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Sender: "w"})},
 		{ID: "live-root", Agent: "w", Type: "ask", State: string(workflow.JobSucceeded), Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Sender: "w"})},
 		{ID: "killed-child", Agent: "w", Type: "ask", State: string(workflow.JobQueued), Payload: killedChildPayload},
+		{ID: "killed-root/continuation", Agent: "w", Type: "ask", State: string(workflow.JobQueued), Payload: killedContinuationPayload},
 		{ID: "live-child", Agent: "w", Type: "ask", State: string(workflow.JobQueued), Payload: liveChildPayload},
 	} {
 		if err := store.CreateJobWithEvent(ctx, j, db.JobEvent{Kind: j.State, Message: "seed"}); err != nil {
@@ -4561,6 +4565,15 @@ func TestRunQueuedJobsForRepoSkipsChildrenOfKilledRoot(t *testing.T) {
 	}
 	if !liveDelivered {
 		t.Fatalf("a queued child of an un-killed root must still run; delivered=%v", adapter.delivered)
+	}
+	continuationDelivered := false
+	for _, id := range adapter.delivered {
+		if id == "killed-root/continuation" {
+			continuationDelivered = true
+		}
+	}
+	if !continuationDelivered {
+		t.Fatalf("the continuation of a killed root must run so the graceful finalize executes; delivered=%v", adapter.delivered)
 	}
 
 	killedChild, err := store.GetJob(ctx, "killed-child")

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4505,6 +4505,73 @@ func enqueueDaemonWorkerJob(t *testing.T, store *db.Store, request workflow.JobR
 	}
 }
 
+// TestRunQueuedJobsForRepoSkipsChildrenOfKilledRoot pins the #341 daemon half of
+// the operator kill switch: once a tree's root is marked killed, a queued CHILD
+// of that root is skipped by runQueuedJobsForRepo (never delivered, stays
+// queued), while a queued child of an un-killed root still runs.
+func TestRunQueuedJobsForRepoSkipsChildrenOfKilledRoot(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "w", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+
+	killedChildPayload := mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", Sender: "w", RootJobID: "killed-root"})
+	liveChildPayload := mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", Sender: "w", RootJobID: "live-root"})
+	for _, j := range []db.Job{
+		{ID: "killed-root", Agent: "w", Type: "ask", State: string(workflow.JobSucceeded), Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Sender: "w"})},
+		{ID: "live-root", Agent: "w", Type: "ask", State: string(workflow.JobSucceeded), Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Sender: "w"})},
+		{ID: "killed-child", Agent: "w", Type: "ask", State: string(workflow.JobQueued), Payload: killedChildPayload},
+		{ID: "live-child", Agent: "w", Type: "ask", State: string(workflow.JobQueued), Payload: liveChildPayload},
+	} {
+		if err := store.CreateJobWithEvent(ctx, j, db.JobEvent{Kind: j.State, Message: "seed"}); err != nil {
+			t.Fatalf("CreateJobWithEvent(%s) returned error: %v", j.ID, err)
+		}
+	}
+
+	// Operator kills only the first tree.
+	if err := store.SetRootJobKilled(ctx, "killed-root"); err != nil {
+		t.Fatalf("SetRootJobKilled returned error: %v", err)
+	}
+
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	if err := runQueuedJobsForRepo(ctx, worker, 4, "", ""); err != nil {
+		t.Fatalf("runQueuedJobsForRepo returned error: %v", err)
+	}
+
+	for _, id := range adapter.delivered {
+		if id == "killed-child" {
+			t.Fatalf("a queued child of a killed root must not be delivered; delivered=%v", adapter.delivered)
+		}
+	}
+	liveDelivered := false
+	for _, id := range adapter.delivered {
+		if id == "live-child" {
+			liveDelivered = true
+		}
+	}
+	if !liveDelivered {
+		t.Fatalf("a queued child of an un-killed root must still run; delivered=%v", adapter.delivered)
+	}
+
+	killedChild, err := store.GetJob(ctx, "killed-child")
+	if err != nil {
+		t.Fatalf("GetJob(killed-child) returned error: %v", err)
+	}
+	if killedChild.State != string(workflow.JobQueued) {
+		t.Fatalf("killed-child state = %q, want still queued", killedChild.State)
+	}
+}
+
 func daemonWorkerHasEvent(events []db.JobEvent, kind string) bool {
 	for _, event := range events {
 		if event.Kind == kind {

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -36,6 +36,8 @@ func runJob(args []string, stdout, stderr io.Writer) int {
 		return runJobRetry(args[1:], stdout, stderr)
 	case "cancel":
 		return runJobCancel(args[1:], stdout, stderr)
+	case "kill":
+		return runJobKill(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown job command %q\n\n", args[0])
 		printJobUsage(stderr)
@@ -52,6 +54,7 @@ func printJobUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot job run <id>")
 	fmt.Fprintln(w, "  gitmoot job retry <id>")
 	fmt.Fprintln(w, "  gitmoot job cancel <id>")
+	fmt.Fprintln(w, "  gitmoot job kill <root-job-id>")
 }
 
 func runJobList(args []string, stdout, stderr io.Writer) int {
@@ -262,6 +265,31 @@ func runJobCancel(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	fmt.Fprintf(stdout, "cancelled job %s\n", job.ID)
+	return 0
+}
+
+// runJobKill is the operator kill switch (#341): it marks a runaway delegation
+// tree (identified by its root job id) as killed so the engine routes the
+// coordinator's next continuation through the graceful finalize path and the
+// daemon stops starting queued children. In-flight jobs finish normally.
+func runJobKill(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job kill", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	rootJobID, ok := parseSingleJobID(fs, args, stderr, "job kill")
+	if !ok {
+		return parseSingleJobIDExitCode(args)
+	}
+	var job db.Job
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		job, err = workflow.KillDelegationTree(context.Background(), store, rootJobID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "job kill: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "killed delegation tree rooted at %s\n", job.ID)
 	return 0
 }
 

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -171,6 +171,47 @@ func TestRunJobRunUsesDaemonWorkerInternals(t *testing.T) {
 	}
 }
 
+// TestRunJobKill covers the #341 operator kill switch CLI: `job kill <root>`
+// marks the root as killed and reports it, and errors on a missing root id.
+func TestRunJobKill(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedCLIJob(t, store, db.Job{
+		ID:      "root-job",
+		Agent:   "coord",
+		Type:    "ask",
+		State:   string(workflow.JobRunning),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main"}),
+	}, "running")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "kill", "root-job", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job kill exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "killed delegation tree rooted at root-job") {
+		t.Fatalf("job kill output = %q", stdout.String())
+	}
+	killed, err := store.IsRootJobKilled(context.Background(), "root-job")
+	if err != nil {
+		t.Fatalf("IsRootJobKilled returned error: %v", err)
+	}
+	if !killed {
+		t.Fatal("job kill should mark the root as killed")
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "kill", "no-such-root", "--home", home}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("job kill on missing root exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "job kill:") {
+		t.Fatalf("job kill missing-root stderr = %q", stderr.String())
+	}
+}
+
 func openCLIJobStore(t *testing.T, home string) *db.Store {
 	t.Helper()
 	paths := config.PathsForHome(home)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -201,6 +201,11 @@ type Job struct {
 	DelegationID    string
 	DelegationDepth int
 	DelegatedBy     string
+	// RootKilled is the operator kill-switch flag (#341). When true, the
+	// delegation tree rooted at this job has been killed: the engine's next
+	// dispatch routes through the graceful finalize continuation instead of
+	// dispatching new delegations, and the daemon skips queued children.
+	RootKilled bool
 	// UpdatedAt is populated by ListJobs (for age display in the dashboard);
 	// other readers may leave it zero.
 	UpdatedAt string
@@ -2050,17 +2055,42 @@ func (s *Store) JobCreatedAt(ctx context.Context, id string) (string, error) {
 	return createdAt, nil
 }
 
+// SetRootJobKilled marks a delegation tree's root job as killed by an operator
+// (#341). Only the root row carries the flag; the engine and daemon scope to a
+// tree by joining children's payload RootJobID back to this id. No-op-safe: an
+// unknown id simply affects zero rows (the caller verifies existence).
+func (s *Store) SetRootJobKilled(ctx context.Context, rootID string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE jobs SET root_killed = 1, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, rootID)
+	return err
+}
+
+// IsRootJobKilled reports whether the root job rootID has been killed by an
+// operator (#341). An unknown id reads as not killed (COALESCE over no rows
+// yields zero rows, so the scan defaults to false), so the backstop fails open
+// and never blocks dispatch on a lookup miss.
+func (s *Store) IsRootJobKilled(ctx context.Context, rootID string) (bool, error) {
+	var killed bool
+	row := s.db.QueryRowContext(ctx, `SELECT COALESCE(root_killed, 0) FROM jobs WHERE id = ?`, rootID)
+	if err := row.Scan(&killed); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return killed, nil
+}
+
 func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by FROM jobs WHERE id = ?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed FROM jobs WHERE id = ?`, id)
 	var job Job
-	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy); err != nil {
+	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled); err != nil {
 		return Job{}, err
 	}
 	return job, nil
 }
 
 func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, updated_at FROM jobs ORDER BY id`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, updated_at FROM jobs ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}
@@ -2069,7 +2099,7 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.UpdatedAt); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.UpdatedAt); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2082,7 +2112,7 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 // id for a stable tree. It selects updated_at like ListJobs so callers can show
 // child age; the idx_jobs_parent_job_id index backs the filter.
 func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, updated_at
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, updated_at
 		FROM jobs WHERE parent_job_id = ? ORDER BY delegation_id, id`, parentJobID)
 	if err != nil {
 		return nil, err
@@ -2092,7 +2122,7 @@ func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.UpdatedAt); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.UpdatedAt); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2101,7 +2131,7 @@ func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job
 }
 
 func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed
 		FROM jobs WHERE state = ? ORDER BY created_at, rowid`, "queued")
 	if err != nil {
 		return nil, err
@@ -2111,7 +2141,7 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2120,7 +2150,7 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 }
 
 func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Time) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed
 		FROM jobs WHERE state = ? AND updated_at < ? ORDER BY id`, "running", before.UTC().Format("2006-01-02 15:04:05"))
 	if err != nil {
 		return nil, err
@@ -2130,7 +2160,7 @@ func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Ti
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -5732,5 +5762,8 @@ ALTER TABLE cockpit_workspaces ADD COLUMN root_pane_id TEXT NOT NULL DEFAULT '';
 	`,
 	`
 ALTER TABLE branch_locks ADD COLUMN skip_native_review_fanout INTEGER NOT NULL DEFAULT 0;
+	`,
+	`
+ALTER TABLE jobs ADD COLUMN root_killed INTEGER NOT NULL DEFAULT 0;
 	`,
 }

--- a/internal/db/store_root_killed_test.go
+++ b/internal/db/store_root_killed_test.go
@@ -1,0 +1,111 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// TestRootKilledRoundTrip pins the #341 store contract: a fresh job reads as not
+// killed; SetRootJobKilled flips it; IsRootJobKilled and GetJob both observe the
+// flag; and an unknown id reads as not killed (fails open) rather than erroring.
+func TestRootKilledRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.CreateJobWithEvent(ctx, Job{ID: "root", Agent: "coord", Type: "ask", State: "succeeded"}, JobEvent{Kind: "succeeded", Message: "done"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	killed, err := store.IsRootJobKilled(ctx, "root")
+	if err != nil {
+		t.Fatalf("IsRootJobKilled returned error: %v", err)
+	}
+	if killed {
+		t.Fatal("a fresh job must read as not killed")
+	}
+	if job, err := store.GetJob(ctx, "root"); err != nil || job.RootKilled {
+		t.Fatalf("GetJob fresh RootKilled = %v (err %v), want false", job.RootKilled, err)
+	}
+
+	if err := store.SetRootJobKilled(ctx, "root"); err != nil {
+		t.Fatalf("SetRootJobKilled returned error: %v", err)
+	}
+
+	killed, err = store.IsRootJobKilled(ctx, "root")
+	if err != nil {
+		t.Fatalf("IsRootJobKilled (after set) returned error: %v", err)
+	}
+	if !killed {
+		t.Fatal("IsRootJobKilled should report true after SetRootJobKilled")
+	}
+	job, err := store.GetJob(ctx, "root")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if !job.RootKilled {
+		t.Fatalf("GetJob RootKilled = false after kill, want true: %+v", job)
+	}
+
+	// Unknown ids fail open: not killed, no error.
+	missing, err := store.IsRootJobKilled(ctx, "no-such-root")
+	if err != nil {
+		t.Fatalf("IsRootJobKilled(missing) returned error: %v", err)
+	}
+	if missing {
+		t.Fatal("an unknown root id must read as not killed")
+	}
+}
+
+// TestMigrateAppendsRootKilled pins that the root_killed ALTER applies on a
+// pre-existing DB that predates the column, defaulting existing jobs to not
+// killed, and that existing job scans keep working after the upgrade.
+func TestMigrateAppendsRootKilled(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open returned error: %v", err)
+	}
+	store := &Store{db: raw}
+	// Apply every migration EXCEPT the last (the root_killed ALTER), reproducing a
+	// DB whose jobs table has no root_killed column.
+	for version, migration := range migrations[:len(migrations)-1] {
+		if err := store.applyMigration(ctx, version+1, migration); err != nil {
+			t.Fatalf("applyMigration(%d) returned error: %v", version+1, err)
+		}
+	}
+	if _, err := raw.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload) VALUES ('legacy', 'coord', 'ask', 'succeeded', '{}')`); err != nil {
+		t.Fatalf("insert legacy job returned error: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw Close returned error: %v", err)
+	}
+
+	upgraded, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open upgraded DB returned error: %v", err)
+	}
+	defer upgraded.Close()
+
+	job, err := upgraded.GetJob(ctx, "legacy")
+	if err != nil {
+		t.Fatalf("GetJob legacy returned error: %v", err)
+	}
+	if job.RootKilled {
+		t.Fatalf("legacy job RootKilled = true, want false default")
+	}
+	// Existing scans still work end to end after the upgrade.
+	jobs, err := upgraded.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ID != "legacy" || jobs[0].RootKilled {
+		t.Fatalf("ListJobs after upgrade = %+v, want one un-killed legacy job", jobs)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -796,6 +796,22 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		return nil
 	}
 
+	rootID := e.rootJobID(job, payload)
+
+	// Operator kill switch (#341): an operator can terminate a runaway tree by
+	// root id (gitmoot job kill). This is the FIRST backstop so operator action
+	// wins over every budget cap: rather than dispatching the next generation,
+	// route through the same #305 graceful finalize continuation (synthesize what
+	// completed → stop). Fails open: a lookup error never blocks dispatch.
+	if killed, _ := e.Store.IsRootJobKilled(ctx, rootID); killed {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_killed",
+			Message: fmt.Sprintf("root delegation tree %s killed by operator; not dispatching %d delegation(s)", rootID, len(payload.Result.Delegations)),
+		})
+		return e.enqueueFinalizeContinuation(ctx, job, payload, "delegation tree killed by operator")
+	}
+
 	if payload.DelegationDepth >= MaxDelegationDepth {
 		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
 			JobID:   job.ID,
@@ -805,7 +821,6 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("delegation depth limit of %d reached", MaxDelegationDepth))
 	}
 
-	rootID := e.rootJobID(job, payload)
 	total, err := e.countRootDelegationJobs(ctx, rootID)
 	if err != nil {
 		return err

--- a/internal/workflow/job_kill.go
+++ b/internal/workflow/job_kill.go
@@ -9,8 +9,14 @@ import (
 )
 
 // KillDelegationTree is the operator kill switch (#341). It marks the delegation
-// tree rooted at rootJobID as killed so the engine and daemon stop expanding it,
-// then returns the root job.
+// tree as killed so the engine and daemon stop expanding it, then returns the
+// killed root job.
+//
+// jobID may be ANY job in the tree — the root coordinator or any child/
+// continuation. A child carries payload.RootJobID; the kill is always applied to
+// that real root, since the engine and daemon only ever consult the root's flag.
+// Passing a child id therefore kills the whole tree rather than silently marking a
+// row nothing reads.
 //
 // The kill is graceful, not a hard stop: it does NOT cancel in-flight jobs. The
 // flag takes effect at the two expansion points:
@@ -19,21 +25,33 @@ import (
 //     and, on the coordinator's next continuation, routes through the #305 graceful
 //     finalize continuation (synthesize what completed → stop) instead of
 //     dispatching the next generation; and
-//   - the daemon skips queued children of a killed root, so no new child starts.
+//   - the daemon skips queued child legs of a killed root (continuations still run).
 //
-// In-flight children run to completion normally. The root job must exist; an
-// unknown id is an error so an operator typo does not silently no-op.
-func KillDelegationTree(ctx context.Context, store *db.Store, rootJobID string) (db.Job, error) {
+// In-flight children run to completion normally. The job must exist; an unknown id
+// is an error so an operator typo does not silently no-op.
+func KillDelegationTree(ctx context.Context, store *db.Store, jobID string) (db.Job, error) {
 	if store == nil {
 		return db.Job{}, fmt.Errorf("store is required")
 	}
-	rootJobID = strings.TrimSpace(rootJobID)
-	if rootJobID == "" {
-		return db.Job{}, fmt.Errorf("root job id is required")
+	jobID = strings.TrimSpace(jobID)
+	if jobID == "" {
+		return db.Job{}, fmt.Errorf("job id is required")
 	}
-	root, err := store.GetJob(ctx, rootJobID)
+	target, err := store.GetJob(ctx, jobID)
 	if err != nil {
-		return db.Job{}, fmt.Errorf("kill delegation tree %s: %w", rootJobID, err)
+		return db.Job{}, fmt.Errorf("kill delegation tree %s: %w", jobID, err)
+	}
+	// Resolve to the real root: a child/continuation carries RootJobID, the root
+	// coordinator does not. The engine/daemon only consult the root's flag, so we
+	// must mark the root even when the operator passes a descendant id.
+	root := target
+	if payload, perr := unmarshalPayload(target.Payload); perr == nil {
+		if r := strings.TrimSpace(payload.RootJobID); r != "" && r != target.ID {
+			root, err = store.GetJob(ctx, r)
+			if err != nil {
+				return db.Job{}, fmt.Errorf("kill delegation tree: resolve root %s of %s: %w", r, jobID, err)
+			}
+		}
 	}
 	if err := store.SetRootJobKilled(ctx, root.ID); err != nil {
 		return db.Job{}, err
@@ -41,9 +59,10 @@ func KillDelegationTree(ctx context.Context, store *db.Store, rootJobID string) 
 	if err := store.AddJobEvent(ctx, db.JobEvent{
 		JobID:   root.ID,
 		Kind:    "delegation_killed",
-		Message: fmt.Sprintf("operator killed delegation tree rooted at %s; new delegations and queued children stop, in-flight jobs finish", root.ID),
+		Message: fmt.Sprintf("operator killed delegation tree rooted at %s; new delegations and queued child legs stop, in-flight jobs finish", root.ID),
 	}); err != nil {
 		return db.Job{}, err
 	}
-	return store.GetJob(ctx, root.ID)
+	root.RootKilled = true
+	return root, nil
 }

--- a/internal/workflow/job_kill.go
+++ b/internal/workflow/job_kill.go
@@ -1,0 +1,49 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// KillDelegationTree is the operator kill switch (#341). It marks the delegation
+// tree rooted at rootJobID as killed so the engine and daemon stop expanding it,
+// then returns the root job.
+//
+// The kill is graceful, not a hard stop: it does NOT cancel in-flight jobs. The
+// flag takes effect at the two expansion points:
+//
+//   - the engine's dispatchDelegations sees IsRootJobKilled as its first backstop
+//     and, on the coordinator's next continuation, routes through the #305 graceful
+//     finalize continuation (synthesize what completed → stop) instead of
+//     dispatching the next generation; and
+//   - the daemon skips queued children of a killed root, so no new child starts.
+//
+// In-flight children run to completion normally. The root job must exist; an
+// unknown id is an error so an operator typo does not silently no-op.
+func KillDelegationTree(ctx context.Context, store *db.Store, rootJobID string) (db.Job, error) {
+	if store == nil {
+		return db.Job{}, fmt.Errorf("store is required")
+	}
+	rootJobID = strings.TrimSpace(rootJobID)
+	if rootJobID == "" {
+		return db.Job{}, fmt.Errorf("root job id is required")
+	}
+	root, err := store.GetJob(ctx, rootJobID)
+	if err != nil {
+		return db.Job{}, fmt.Errorf("kill delegation tree %s: %w", rootJobID, err)
+	}
+	if err := store.SetRootJobKilled(ctx, root.ID); err != nil {
+		return db.Job{}, err
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   root.ID,
+		Kind:    "delegation_killed",
+		Message: fmt.Sprintf("operator killed delegation tree rooted at %s; new delegations and queued children stop, in-flight jobs finish", root.ID),
+	}); err != nil {
+		return db.Job{}, err
+	}
+	return store.GetJob(ctx, root.ID)
+}

--- a/internal/workflow/job_kill_test.go
+++ b/internal/workflow/job_kill_test.go
@@ -113,3 +113,38 @@ func TestKillDelegationTreeMarksRootAndErrorsOnMissing(t *testing.T) {
 		t.Fatal("KillDelegationTree on a missing root must error")
 	}
 }
+
+// TestKillDelegationTreeResolvesChildToRoot pins that passing ANY tree member's
+// id (a child/continuation, not just the root) kills the whole tree — the engine
+// and daemon only consult the root's flag, so a child id must resolve to it.
+func TestKillDelegationTreeResolvesChildToRoot(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	insertCompletedJob(t, store, db.Job{ID: "root", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", TaskID: "task-9", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "tree"},
+	})
+	insertCompletedJob(t, store, db.Job{ID: "root/delegation/c1", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Sender: "coord", RootJobID: "root", DelegationID: "d1",
+		Result: &AgentResult{Decision: "approved", Summary: "child"},
+	})
+
+	// Operator passes a CHILD id; the whole tree (its root) must be killed.
+	root, err := KillDelegationTree(ctx, store, "root/delegation/c1")
+	if err != nil {
+		t.Fatalf("KillDelegationTree(child) returned error: %v", err)
+	}
+	if root.ID != "root" {
+		t.Fatalf("kill should resolve a child id to the root; got %q", root.ID)
+	}
+	if killed, _ := store.IsRootJobKilled(ctx, "root"); !killed {
+		t.Fatal("the ROOT must be marked killed when an operator passes a child id")
+	}
+	if killed, _ := store.IsRootJobKilled(ctx, "root/delegation/c1"); killed {
+		t.Fatal("the child row itself should not carry the kill flag")
+	}
+	if got := countJobEvents(t, store, "root", "delegation_killed"); got != 1 {
+		t.Fatalf("delegation_killed events on root = %d, want 1", got)
+	}
+}

--- a/internal/workflow/job_kill_test.go
+++ b/internal/workflow/job_kill_test.go
@@ -1,0 +1,115 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// TestEngineKilledRootEnqueuesFinalizeAndDispatchesZero pins the #341 operator
+// kill switch: once a tree's root is marked killed, the coordinator's next
+// dispatchDelegations does not dispatch any new delegations; instead it gets one
+// graceful finalize continuation and emits delegation_killed.
+func TestEngineKilledRootEnqueuesFinalizeAndDispatchesZero(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "root", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-009", TaskID: "task-9", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "killed tree", Delegations: []Delegation{
+			{ID: "d0", Agent: "w", Action: "ask", Prompt: "work"},
+			{ID: "d1", Agent: "w", Action: "ask", Prompt: "work"},
+		}},
+	})
+
+	// Operator kills the tree before the coordinator's next dispatch.
+	if err := store.SetRootJobKilled(ctx, "root"); err != nil {
+		t.Fatalf("SetRootJobKilled returned error: %v", err)
+	}
+
+	if err := engine.AdvanceJob(ctx, "root"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if jobExists(t, store, "root/delegation/d0") || jobExists(t, store, "root/delegation/d1") {
+		t.Fatal("a killed root must not dispatch any new delegations")
+	}
+	if got := countJobEvents(t, store, "root", "delegation_killed"); got != 1 {
+		t.Fatalf("delegation_killed events = %d, want 1", got)
+	}
+	cont, err := unmarshalPayload(mustJob(t, store, "root/continuation").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if !cont.DelegationFinalize {
+		t.Fatalf("kill finalize continuation must carry DelegationFinalize: %+v", cont)
+	}
+	if got := countJobEvents(t, store, "root", "delegation_finalize_enqueued"); got != 1 {
+		t.Fatalf("delegation_finalize_enqueued events = %d, want 1", got)
+	}
+}
+
+// TestEngineUnkilledRootDispatches is the control: a tree whose root was never
+// killed dispatches its delegations normally and emits no delegation_killed.
+func TestEngineUnkilledRootDispatches(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "live", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-009", TaskID: "task-9", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "live tree", Delegations: []Delegation{
+			{ID: "d0", Agent: "w", Action: "ask", Prompt: "work"},
+		}},
+	})
+	if err := engine.AdvanceJob(ctx, "live"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if !jobExists(t, store, "live/delegation/d0") {
+		t.Fatal("an un-killed root must dispatch its delegations")
+	}
+	if got := countJobEvents(t, store, "live", "delegation_killed"); got != 0 {
+		t.Fatalf("delegation_killed events = %d, want 0", got)
+	}
+}
+
+// TestKillDelegationTreeMarksRootAndErrorsOnMissing covers the workflow entry
+// point used by the CLI: it marks an existing root, emits the event, and errors
+// on an unknown root id.
+func TestKillDelegationTreeMarksRootAndErrorsOnMissing(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	insertCompletedJob(t, store, db.Job{ID: "root", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", TaskID: "task-9", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "tree"},
+	})
+
+	root, err := KillDelegationTree(ctx, store, "root")
+	if err != nil {
+		t.Fatalf("KillDelegationTree returned error: %v", err)
+	}
+	if !root.RootKilled {
+		t.Fatalf("returned root job should report RootKilled=true: %+v", root)
+	}
+	killed, err := store.IsRootJobKilled(ctx, "root")
+	if err != nil {
+		t.Fatalf("IsRootJobKilled returned error: %v", err)
+	}
+	if !killed {
+		t.Fatal("root should be marked killed after KillDelegationTree")
+	}
+	if got := countJobEvents(t, store, "root", "delegation_killed"); got != 1 {
+		t.Fatalf("delegation_killed events = %d, want 1", got)
+	}
+
+	if _, err := KillDelegationTree(ctx, store, "no-such-root"); err == nil {
+		t.Fatal("KillDelegationTree on a missing root must error")
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -474,9 +474,17 @@ gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>
+gitmoot job kill <root-job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+`gitmoot job kill <root-job-id>` is the operator kill switch for a runaway
+delegation tree: it terminates the tree identified by its **root** job id
+gracefully. In-flight jobs finish normally; the coordinator's next continuation
+is routed through the graceful finalize path (synthesize what completed → stop)
+and the daemon stops starting queued children of that root. See
+`references/SAFETY.md` for how it relates to the other termination bounds.
 
 Merge-gate retries are automatic while the daemon is running. Retryable states,
 such as a busy base-branch merge queue or a GitHub branch update in progress,

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -173,6 +173,11 @@ Delegation trees are bounded so they cannot run forever:
 - Loop detection: a windowed signature over recent delegation activity halts
   repeated or cyclic delegation chains (e.g. oscillating A→B→A) well before the
   depth cap is reached.
+- Operator kill switch: `gitmoot job kill <root-job-id>` terminates a runaway
+  tree by its root id from outside. It is the **first** backstop (operator action
+  wins over every budget cap) and is graceful — in-flight jobs finish, the
+  coordinator's next continuation routes through the finalize path below (a
+  `delegation_killed` event is emitted), and the daemon stops new children.
 
 When a bound trips (a budget cap or confirmed loop), the offending delegations
 are not dispatched and the parent receives a typed lifecycle event explaining why

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -67,6 +67,13 @@ cannot recurse or fan out forever:
 - Loop detection: a canonical windowed signature hash over recent delegation
   activity halts repeated or cyclic delegation chains well before the depth cap
   is reached, preventing oscillating A→B→A loops.
+- Operator kill switch: `gitmoot job kill <root-job-id>` lets an operator
+  terminate a runaway tree by its root id from outside. It is the **first**
+  backstop, so operator action wins over every budget cap. The kill is graceful,
+  not a hard stop — in-flight jobs finish normally, the coordinator's next
+  continuation routes through the same finalize path below (a
+  `delegation_killed` event is emitted), and the daemon stops starting queued
+  children of the killed root.
 
 When a bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why (for example, the delegation tree

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -471,9 +471,18 @@ gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>
+gitmoot job kill <root-job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+`gitmoot job kill <root-job-id>` is the operator kill switch for a runaway
+delegation tree: it terminates the tree identified by its **root** job id
+gracefully. In-flight jobs finish normally; the coordinator's next continuation
+is routed through the graceful finalize path (synthesize what completed → stop)
+and the daemon stops starting queued children of that root. See the
+[termination bounds](result-contract.md#termination-bounds) for how it relates
+to the other delegation backstops.
 
 Merge-gate retries are automatic while the daemon is running. Retryable states,
 such as a busy base-branch merge queue or a GitHub branch update in progress,

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -265,6 +265,12 @@ trips, the offending delegations are dropped rather than dispatched.
 - **Loop detection**: a canonical windowed signature over recent delegation
   activity halts repeated or cyclic delegation chains — for example an
   oscillating A→B→A loop — well before the depth cap is reached.
+- **Operator kill switch**: `gitmoot job kill <root-job-id>` lets an operator
+  terminate a runaway tree by its root id from outside. It is the **first**
+  backstop, so operator action wins over every budget cap. The kill is graceful —
+  in-flight jobs finish normally, the coordinator's next continuation routes
+  through the same finalize path below (a `delegation_killed` event is emitted),
+  and the daemon stops starting queued children of the killed root.
 
 When any bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why. Rather than stopping silently,

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -928,6 +928,7 @@ gitmoot job show <job-id>
 gitmoot job watch <job-id>
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>
+gitmoot job kill <root-job-id>            # operator kill switch for a runaway delegation tree
 gitmoot status --repo owner/repo
 gitmoot version --json
 gitmoot update --check
@@ -5892,9 +5893,17 @@ gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>
+gitmoot job kill <root-job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+`gitmoot job kill <root-job-id>` is the operator kill switch for a runaway
+delegation tree: it terminates the tree identified by its **root** job id
+gracefully. In-flight jobs finish normally; the coordinator's next continuation
+is routed through the graceful finalize path (synthesize what completed → stop)
+and the daemon stops starting queued children of that root. See
+`references/SAFETY.md` for how it relates to the other termination bounds.
 
 Merge-gate retries are automatic while the daemon is running. Retryable states,
 such as a busy base-branch merge queue or a GitHub branch update in progress,
@@ -6851,6 +6860,13 @@ cannot recurse or fan out forever:
 - Loop detection: a canonical windowed signature hash over recent delegation
   activity halts repeated or cyclic delegation chains well before the depth cap
   is reached, preventing oscillating A→B→A loops.
+- Operator kill switch: `gitmoot job kill <root-job-id>` lets an operator
+  terminate a runaway tree by its root id from outside. It is the **first**
+  backstop, so operator action wins over every budget cap. The kill is graceful,
+  not a hard stop — in-flight jobs finish normally, the coordinator's next
+  continuation routes through the same finalize path below (a
+  `delegation_killed` event is emitted), and the daemon stops starting queued
+  children of the killed root.
 
 When a bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why (for example, the delegation tree
@@ -7048,6 +7064,11 @@ Delegation trees are bounded so they cannot run forever:
 - Loop detection: a windowed signature over recent delegation activity halts
   repeated or cyclic delegation chains (e.g. oscillating A→B→A) well before the
   depth cap is reached.
+- Operator kill switch: `gitmoot job kill <root-job-id>` terminates a runaway
+  tree by its root id from outside. It is the **first** backstop (operator action
+  wins over every budget cap) and is graceful — in-flight jobs finish, the
+  coordinator's next continuation routes through the finalize path below (a
+  `delegation_killed` event is emitted), and the daemon stops new children.
 
 When a bound trips (a budget cap or confirmed loop), the offending delegations
 are not dispatched and the parent receives a typed lifecycle event explaining why


### PR DESCRIPTION
Closes #341.

An operator kill switch for runaway delegation trees: `gitmoot job kill <job-id>` terminates a tree **gracefully** — it routes through the #305 finalize continuation (synthesize what completed → stop) rather than a hard kill that loses partial work.

## What
- **CLI** `gitmoot job kill <job-id>` (mirrors `job cancel`). Accepts ANY job in the tree (root or a child/continuation) and resolves to the real root.
- **DB**: `root_killed` ALTER-ADD-COLUMN migration + `Job.RootKilled` + `SetRootJobKilled`/`IsRootJobKilled` (added to all 5 job SELECT scans).
- **Engine**: `IsRootJobKilled` is the **first** backstop in `dispatchDelegations` (before depth) → emits `delegation_killed` + routes to `enqueueFinalizeContinuation`; no new delegations dispatched.
- **Daemon**: skips queued **child legs** of a killed root (`DelegationID != ""`) — but **continuations run** so the graceful finalize actually executes. In-flight children finish normally.

## Review fixes (8-finder review → 3 real bugs, all fixed)
- **Daemon no longer strands the finalize continuation** — it was skipping ALL jobs of a killed root (including the continuation), so the graceful finalize never ran. Now only true child legs are skipped.
- **`KillDelegationTree` resolves any tree-member id → the real root** (so `job kill <child-id>` kills the tree, not a row nothing reads) + dropped a redundant `GetJob`.
- Tests extended: continuation-of-killed-root IS delivered; child id resolves to root.

## Verification
- Full Go gate green: `build`/`vet`/`test ./...` (28 pkgs) / `-race ./internal/workflow/` (140s); gofmt clean.
- Tests: engine (kill→finalize+zero-dispatch+`delegation_killed`), store (round-trip + migration-on-existing-DB), daemon (child legs skipped, continuation delivered), CLI, child→root resolution.
- Binary E2E (compiled CLI + on-disk store): `job kill <child-id>` marked the **root** killed (`root_killed=1`), left the child row unflagged, one `delegation_killed` event.

(codex-crazyj is not intrinsic to the operator-kill path; the engine-finalize + daemon-skip mechanics are covered by the integration tests above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
