### PR TITLE
feat(workflow): per-root token budget for delegation trees (#338 Part B)

### DIFF
--- a/docs/cockpit-orchestrate.md
+++ b/docs/cockpit-orchestrate.md
@@ -75,6 +75,7 @@ cockpit_max_panes = 4      # cap on simultaneous panes per run
 cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
 inline_artifact_bodies = false   # inline each child's artifact_body into the coordinator continuation
 inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
+max_delegation_token_budget = 0  # per-root delegation token budget (input+output); 0 = unlimited (off)
 ```
 
 - `cockpit_mode = "off"` disables the cockpit even if `--cockpit` was passed;
@@ -93,6 +94,19 @@ inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
   many bytes of each child's body are inlined; longer bodies are rune-safe
   truncated with a marker pointing at the full on-disk brief. A per-continuation
   aggregate cap also bounds the total inlined across all children.
+- `max_delegation_token_budget` (default `0` = unlimited/off) bounds a delegation
+  tree by **cost** in addition to depth/width/total-jobs/wall-clock. When set to a
+  positive value, the whole tree under one root is capped at that many cumulative
+  tokens (input + output, summed across every job in the tree). A coordinator that
+  tries to fan out after the tree has already used at least the budget is refused
+  with a `delegation_cost_exceeded` event and routed to the graceful finalize
+  continuation (synthesize what completed, then stop). Token capture is
+  **best-effort per runtime**: Claude reports usage via its `--output-format json`
+  envelope, Kimi reports it when its stream emits a `usage` object, and Codex runs
+  delivery without `--json` so it contributes `0` (the budget under-counts Codex
+  rather than failing). Treat it as a coarse runaway-cost backstop, not a precise
+  spend limit; the budget is in raw tokens (no `$` price table yet). Leaving it at
+  `0` is byte-identical to before the knob existed.
 
 ## Constrained hosts
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -194,9 +194,10 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 			Store:     store,
 			MergeGate: newDaemonPolicyMergeGate(store, gh, checkout),
 		}
-		// Honor the opt-in [orchestrate] artifact-body inlining policy on this
-		// single-repo engine too; fail-safe to off if the policy cannot load.
-		defaultJobWorker(store, stdout, *home).applyInlineArtifactPolicy(&engine)
+		// Honor the opt-in [orchestrate] policy (artifact-body inlining + per-root
+		// delegation token budget) on this single-repo engine too; fail-safe to the
+		// defaults if the policy cannot load.
+		defaultJobWorker(store, stdout, *home).applyOrchestratePolicy(&engine)
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
 		return runSingleRepoSupervisor(ctx, *home, daemon.Daemon{
 			Repo:         repo,
@@ -3000,20 +3001,23 @@ func (w jobWorker) defaultStartAdapter(runtimeName string, checkout string) (run
 
 func (w jobWorker) defaultWorkflow(checkout string) workflow.Engine {
 	engine := daemonWorkflowEngine(w.Store, github.NewClient(checkout), checkout, w.workflowHome())
-	w.applyInlineArtifactPolicy(&engine)
+	w.applyOrchestratePolicy(&engine)
 	return engine
 }
 
-// applyInlineArtifactPolicy sets the engine's opt-in artifact-body inlining fields
-// from the host [orchestrate] policy. It is fail-safe: any load error leaves the
-// engine with inlining off (the default) rather than failing engine construction.
-func (w jobWorker) applyInlineArtifactPolicy(engine *workflow.Engine) {
+// applyOrchestratePolicy sets the engine's opt-in [orchestrate] fields — the
+// artifact-body inlining knobs and the per-root delegation token budget (#338
+// Part B) — from the host policy. It is fail-safe: any load error leaves the
+// engine with its defaults (inlining off, token budget 0 = unlimited) rather than
+// failing engine construction.
+func (w jobWorker) applyOrchestratePolicy(engine *workflow.Engine) {
 	policy, err := w.orchestratePolicy()
 	if err != nil {
 		return
 	}
 	engine.InlineArtifactBodies = policy.InlineArtifactBodies
 	engine.MaxInlineArtifactBytes = policy.InlineArtifactMaxBytes
+	engine.MaxDelegationTokenBudget = policy.MaxDelegationTokenBudget
 }
 
 // workflowHome resolves the GITMOOT_HOME root used to place per-delegation

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -38,16 +38,23 @@ type OrchestratePolicy struct {
 	// InlineArtifactMaxBytes is the per-body byte cap applied when
 	// InlineArtifactBodies is set; 0 means the engine's built-in default.
 	InlineArtifactMaxBytes int
+	// MaxDelegationTokenBudget is the cumulative per-root token budget (input +
+	// output, summed across a delegation tree) that bounds a tree by cost in
+	// addition to depth/width/total-jobs/wall-clock (#338 Part B). 0 (the default)
+	// means unlimited/off, so default behavior is unchanged. The daemon wires this
+	// into Engine.MaxDelegationTokenBudget at startup.
+	MaxDelegationTokenBudget int
 }
 
 func DefaultOrchestratePolicy() OrchestratePolicy {
 	return OrchestratePolicy{
-		CockpitMode:            CockpitModeAuto,
-		CockpitSession:         "",
-		CockpitMaxPanes:        4,
-		CockpitPaneKey:         CockpitPaneKeyJob,
-		InlineArtifactBodies:   false,
-		InlineArtifactMaxBytes: 0,
+		CockpitMode:              CockpitModeAuto,
+		CockpitSession:           "",
+		CockpitMaxPanes:          4,
+		CockpitPaneKey:           CockpitPaneKeyJob,
+		InlineArtifactBodies:     false,
+		InlineArtifactMaxBytes:   0,
+		MaxDelegationTokenBudget: 0,
 	}
 }
 
@@ -111,6 +118,10 @@ func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value st
 		parsed, err := strconv.Atoi(value)
 		policy.InlineArtifactMaxBytes = parsed
 		return err
+	case "max_delegation_token_budget":
+		parsed, err := strconv.Atoi(value)
+		policy.MaxDelegationTokenBudget = parsed
+		return err
 	default:
 		return nil
 	}
@@ -129,6 +140,9 @@ func validateOrchestratePolicy(policy OrchestratePolicy) error {
 	case CockpitPaneKeyJob, CockpitPaneKeySeat:
 	default:
 		return fmt.Errorf("unsupported orchestrate.cockpit_pane_key %q; use job or seat", policy.CockpitPaneKey)
+	}
+	if policy.MaxDelegationTokenBudget < 0 {
+		return fmt.Errorf("orchestrate.max_delegation_token_budget must be 0 (unlimited) or positive")
 	}
 	return nil
 }

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -35,6 +35,48 @@ func TestLoadOrchestratePolicyDefaults(t *testing.T) {
 	if policy.InlineArtifactMaxBytes != 0 {
 		t.Fatalf("InlineArtifactMaxBytes = %d, want 0 by default", policy.InlineArtifactMaxBytes)
 	}
+	if policy.MaxDelegationTokenBudget != 0 {
+		t.Fatalf("MaxDelegationTokenBudget = %d, want 0 (unlimited) by default", policy.MaxDelegationTokenBudget)
+	}
+}
+
+// TestLoadOrchestratePolicyMaxDelegationTokenBudget pins #338 Part B: the token
+// budget parses from [orchestrate] and an absent key keeps the 0 (unlimited)
+// default.
+func TestLoadOrchestratePolicyMaxDelegationTokenBudget(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+max_delegation_token_budget = 500000
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	policy, err := LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.MaxDelegationTokenBudget != 500000 {
+		t.Fatalf("MaxDelegationTokenBudget = %d, want 500000", policy.MaxDelegationTokenBudget)
+	}
+
+	// Absent key keeps the unlimited default even with the section present.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+cockpit_mode = "auto"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err = LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.MaxDelegationTokenBudget != 0 {
+		t.Fatalf("absent max_delegation_token_budget should default 0, got %d", policy.MaxDelegationTokenBudget)
+	}
 }
 
 // TestLoadOrchestratePolicyInlineArtifactKeys pins #368: both inline-artifact keys
@@ -133,6 +175,22 @@ cockpit_max_panes = 0
 cockpit_pane_key = "row"
 `,
 			wantErr: "unsupported orchestrate.cockpit_pane_key",
+		},
+		{
+			name: "max_delegation_token_budget_non_int",
+			body: `
+[orchestrate]
+max_delegation_token_budget = lots
+`,
+			wantErr: "parse [orchestrate].max_delegation_token_budget",
+		},
+		{
+			name: "max_delegation_token_budget_negative",
+			body: `
+[orchestrate]
+max_delegation_token_budget = -1
+`,
+			wantErr: "max_delegation_token_budget must be 0 (unlimited) or positive",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -1,0 +1,145 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// TestUpdateJobUsageRoundTrip pins the #338 Part B usage write path: a job starts
+// at 0/0 (the column default), UpdateJobUsage persists input/output counts, and
+// every jobs SELECT reads them back consistently.
+func TestUpdateJobUsageRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.CreateJob(ctx, Job{ID: "j1", Agent: "w", Type: "ask", State: "succeeded", Payload: "{}"}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+
+	// Default before any usage is recorded.
+	got, err := store.GetJob(ctx, "j1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if got.InputTokens != 0 || got.OutputTokens != 0 {
+		t.Fatalf("new job usage = (%d, %d), want (0, 0)", got.InputTokens, got.OutputTokens)
+	}
+
+	if err := store.UpdateJobUsage(ctx, "j1", 1500, 320); err != nil {
+		t.Fatalf("UpdateJobUsage returned error: %v", err)
+	}
+
+	got, err = store.GetJob(ctx, "j1")
+	if err != nil {
+		t.Fatalf("GetJob (after update) returned error: %v", err)
+	}
+	if got.InputTokens != 1500 || got.OutputTokens != 320 {
+		t.Fatalf("GetJob usage = (%d, %d), want (1500, 320)", got.InputTokens, got.OutputTokens)
+	}
+
+	// ListJobs must scan the same columns consistently.
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].InputTokens != 1500 || jobs[0].OutputTokens != 320 {
+		t.Fatalf("ListJobs usage = %+v, want one job with (1500, 320)", jobs)
+	}
+
+	// Negative values clamp to 0 so a malformed runtime report cannot drive a tree
+	// aggregate negative.
+	if err := store.UpdateJobUsage(ctx, "j1", -5, -7); err != nil {
+		t.Fatalf("UpdateJobUsage (negative) returned error: %v", err)
+	}
+	got, err = store.GetJob(ctx, "j1")
+	if err != nil {
+		t.Fatalf("GetJob (after negative) returned error: %v", err)
+	}
+	if got.InputTokens != 0 || got.OutputTokens != 0 {
+		t.Fatalf("clamped usage = (%d, %d), want (0, 0)", got.InputTokens, got.OutputTokens)
+	}
+
+	// Unknown job id is an error (mirrors UpdateJobPayload's requireAffected).
+	if err := store.UpdateJobUsage(ctx, "nope", 1, 1); err == nil {
+		t.Fatal("UpdateJobUsage on unknown job should error")
+	}
+}
+
+// TestJobTokenMigrationOnPreExistingDB pins that the input_tokens/output_tokens
+// migration applies to a database that already has a populated jobs table without
+// the token columns: existing rows gain the columns at their 0 default and remain
+// readable through the standard Job scans.
+func TestJobTokenMigrationOnPreExistingDB(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+
+	// Build an "old" database: a jobs table at the pre-#338B shape (no token
+	// columns) with one row, and a schema_migrations table marking every prior
+	// migration applied so Open()'s Migrate runs ONLY the new token-column ALTER.
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open returned error: %v", err)
+	}
+	if _, err := raw.ExecContext(ctx, `
+CREATE TABLE jobs (
+	id TEXT PRIMARY KEY,
+	agent TEXT NOT NULL,
+	type TEXT NOT NULL,
+	state TEXT NOT NULL,
+	payload TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	parent_job_id TEXT NOT NULL DEFAULT '',
+	delegation_id TEXT NOT NULL DEFAULT '',
+	delegation_depth INTEGER NOT NULL DEFAULT 0,
+	delegated_by TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
+INSERT INTO jobs(id, agent, type, state, payload) VALUES ('old', 'w', 'ask', 'succeeded', '{}');
+`); err != nil {
+		t.Fatalf("seed old schema returned error: %v", err)
+	}
+	// Mark every migration except the final token-column ALTER as already applied.
+	for v := 1; v < len(migrations); v++ {
+		if _, err := raw.ExecContext(ctx, `INSERT INTO schema_migrations(version, applied_at) VALUES (?, 'seed')`, v); err != nil {
+			t.Fatalf("seed schema_migrations v%d returned error: %v", v, err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw db returned error: %v", err)
+	}
+
+	// Re-open through the real Store: Migrate must apply the token-column ALTER to
+	// the pre-existing, populated jobs table without error.
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open (migrate) returned error: %v", err)
+	}
+	defer store.Close()
+
+	got, err := store.GetJob(ctx, "old")
+	if err != nil {
+		t.Fatalf("GetJob after migration returned error: %v", err)
+	}
+	if got.InputTokens != 0 || got.OutputTokens != 0 {
+		t.Fatalf("migrated existing row usage = (%d, %d), want (0, 0)", got.InputTokens, got.OutputTokens)
+	}
+
+	// The new columns are writable on the migrated row.
+	if err := store.UpdateJobUsage(ctx, "old", 42, 7); err != nil {
+		t.Fatalf("UpdateJobUsage on migrated row returned error: %v", err)
+	}
+	got, err = store.GetJob(ctx, "old")
+	if err != nil {
+		t.Fatalf("GetJob (post-write) returned error: %v", err)
+	}
+	if got.InputTokens != 42 || got.OutputTokens != 7 {
+		t.Fatalf("migrated row usage after write = (%d, %d), want (42, 7)", got.InputTokens, got.OutputTokens)
+	}
+}

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -52,8 +52,9 @@ func TestUpdateJobUsageRoundTrip(t *testing.T) {
 		t.Fatalf("ListJobs usage = %+v, want one job with (1500, 320)", jobs)
 	}
 
-	// Negative values clamp to 0 so a malformed runtime report cannot drive a tree
-	// aggregate negative.
+	// Negative deltas clamp to 0 so a malformed runtime report cannot drive a tree
+	// aggregate negative; usage accumulates, so a clamped delta preserves the prior
+	// total rather than resetting it.
 	if err := store.UpdateJobUsage(ctx, "j1", -5, -7); err != nil {
 		t.Fatalf("UpdateJobUsage (negative) returned error: %v", err)
 	}
@@ -61,8 +62,21 @@ func TestUpdateJobUsageRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetJob (after negative) returned error: %v", err)
 	}
-	if got.InputTokens != 0 || got.OutputTokens != 0 {
-		t.Fatalf("clamped usage = (%d, %d), want (0, 0)", got.InputTokens, got.OutputTokens)
+	if got.InputTokens != 1500 || got.OutputTokens != 320 {
+		t.Fatalf("after a clamped-negative delta usage = (%d, %d), want (1500, 320) preserved", got.InputTokens, got.OutputTokens)
+	}
+
+	// A second positive delivery ACCUMULATES (a malformed-output repair re-delivers
+	// the same job id) instead of overwriting the first write.
+	if err := store.UpdateJobUsage(ctx, "j1", 100, 80); err != nil {
+		t.Fatalf("UpdateJobUsage (accumulate) returned error: %v", err)
+	}
+	got, err = store.GetJob(ctx, "j1")
+	if err != nil {
+		t.Fatalf("GetJob (after accumulate) returned error: %v", err)
+	}
+	if got.InputTokens != 1600 || got.OutputTokens != 400 {
+		t.Fatalf("accumulated usage = (%d, %d), want (1600, 400)", got.InputTokens, got.OutputTokens)
 	}
 
 	// Unknown job id is an error (mirrors UpdateJobPayload's requireAffected).

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -112,7 +112,8 @@ CREATE TABLE jobs (
 	parent_job_id TEXT NOT NULL DEFAULT '',
 	delegation_id TEXT NOT NULL DEFAULT '',
 	delegation_depth INTEGER NOT NULL DEFAULT 0,
-	delegated_by TEXT NOT NULL DEFAULT ''
+	delegated_by TEXT NOT NULL DEFAULT '',
+	root_killed INTEGER NOT NULL DEFAULT 0
 );
 CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
 INSERT INTO jobs(id, agent, type, state, payload) VALUES ('old', 'w', 'ask', 'succeeded', '{}');

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -206,6 +206,13 @@ type Job struct {
 	// dispatch routes through the graceful finalize continuation instead of
 	// dispatching new delegations, and the daemon skips queued children.
 	RootKilled bool
+	// InputTokens and OutputTokens record the runtime token usage captured for
+	// this job (best-effort per runtime; see UpdateJobUsage). They default to 0
+	// and are populated by every jobs SELECT so the per-root delegation token
+	// budget (#338 Part B) can sum a tree's usage. A job whose runtime does not
+	// report usage contributes 0 — the budget still works, it just under-counts.
+	InputTokens  int
+	OutputTokens int
 	// UpdatedAt is populated by ListJobs (for age display in the dashboard);
 	// other readers may leave it zero.
 	UpdatedAt string
@@ -2081,16 +2088,16 @@ func (s *Store) IsRootJobKilled(ctx context.Context, rootID string) (bool, error
 }
 
 func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed FROM jobs WHERE id = ?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens FROM jobs WHERE id = ?`, id)
 	var job Job
-	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled); err != nil {
+	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens); err != nil {
 		return Job{}, err
 	}
 	return job, nil
 }
 
 func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, updated_at FROM jobs ORDER BY id`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at FROM jobs ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}
@@ -2099,7 +2106,7 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.UpdatedAt); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2112,7 +2119,7 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 // id for a stable tree. It selects updated_at like ListJobs so callers can show
 // child age; the idx_jobs_parent_job_id index backs the filter.
 func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, updated_at
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at
 		FROM jobs WHERE parent_job_id = ? ORDER BY delegation_id, id`, parentJobID)
 	if err != nil {
 		return nil, err
@@ -2122,7 +2129,7 @@ func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.UpdatedAt); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2131,7 +2138,7 @@ func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job
 }
 
 func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
 		FROM jobs WHERE state = ? ORDER BY created_at, rowid`, "queued")
 	if err != nil {
 		return nil, err
@@ -2141,7 +2148,7 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2150,7 +2157,7 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 }
 
 func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Time) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
 		FROM jobs WHERE state = ? AND updated_at < ? ORDER BY id`, "running", before.UTC().Format("2006-01-02 15:04:05"))
 	if err != nil {
 		return nil, err
@@ -2160,7 +2167,7 @@ func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Ti
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2280,6 +2287,26 @@ func (s *Store) DelegateQueuedJob(ctx context.Context, id string, fromAgent stri
 
 func (s *Store) UpdateJobPayload(ctx context.Context, id string, payload string) error {
 	result, err := s.db.ExecContext(ctx, `UPDATE jobs SET payload = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, payload, id)
+	if err != nil {
+		return err
+	}
+	return requireAffected(result, "job", id)
+}
+
+// UpdateJobUsage records the runtime token usage for a job (best-effort capture
+// from the runtime adapters; see internal/runtime). Negative values are clamped
+// to 0 so a malformed runtime usage report can never push a tree's aggregate
+// below zero (#338 Part B / ruflo design reference #380). It does not touch
+// updated_at: usage is captured at delivery time alongside the existing payload
+// write and is purely additive accounting, not a state transition.
+func (s *Store) UpdateJobUsage(ctx context.Context, id string, inputTokens int, outputTokens int) error {
+	if inputTokens < 0 {
+		inputTokens = 0
+	}
+	if outputTokens < 0 {
+		outputTokens = 0
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE jobs SET input_tokens = ?, output_tokens = ? WHERE id = ?`, inputTokens, outputTokens, id)
 	if err != nil {
 		return err
 	}
@@ -5765,5 +5792,9 @@ ALTER TABLE branch_locks ADD COLUMN skip_native_review_fanout INTEGER NOT NULL D
 	`,
 	`
 ALTER TABLE jobs ADD COLUMN root_killed INTEGER NOT NULL DEFAULT 0;
+	`,
+	`
+ALTER TABLE jobs ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE jobs ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0;
 	`,
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2306,7 +2306,11 @@ func (s *Store) UpdateJobUsage(ctx context.Context, id string, inputTokens int, 
 	if outputTokens < 0 {
 		outputTokens = 0
 	}
-	result, err := s.db.ExecContext(ctx, `UPDATE jobs SET input_tokens = ?, output_tokens = ? WHERE id = ?`, inputTokens, outputTokens, id)
+	// Accumulate rather than overwrite: a job can be delivered more than once (a
+	// malformed-output repair retry re-delivers the same job.ID), so each delivery
+	// adds its usage instead of clobbering the prior write. The per-delta clamp to
+	// 0 above keeps the running total monotonic.
+	result, err := s.db.ExecContext(ctx, `UPDATE jobs SET input_tokens = input_tokens + ?, output_tokens = output_tokens + ? WHERE id = ?`, inputTokens, outputTokens, id)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -57,6 +57,15 @@ type Result struct {
 	Decision string
 	Summary  string
 	Raw      string
+	// InputTokens and OutputTokens are best-effort runtime token usage captured
+	// from the CLI's structured output where it exposes one (#338 Part B). They
+	// default to 0. Per-runtime status today: claude reports usage via its
+	// --output-format json envelope; kimi reports usage if its stream-json emits a
+	// usage/result event; codex Deliver runs without --json (plain text) so it
+	// contributes 0. A 0 here means "not captured", and the per-root delegation
+	// token budget simply under-counts that job rather than failing.
+	InputTokens  int
+	OutputTokens int
 }
 
 type StartRequest struct {
@@ -356,15 +365,42 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 		return Result{Raw: result.Stdout + result.Stderr}, claudeCommandError(result, err)
 	}
 	parsed := Result{Raw: result.Stdout}
-	var payload struct {
-		Result string `json:"result"`
-	}
-	if json.Unmarshal([]byte(result.Stdout), &payload) == nil && payload.Result != "" {
-		parsed.Summary = payload.Result
+	summary, inTok, outTok := parseClaudeJSONResult(result.Stdout)
+	if summary != "" {
+		parsed.Summary = summary
 	} else {
 		parsed.Summary = strings.TrimSpace(result.Stdout)
 	}
+	parsed.InputTokens = inTok
+	parsed.OutputTokens = outTok
 	return parsed, nil
+}
+
+// claudeJSONResult mirrors the relevant fields of the Claude Code
+// --output-format json result envelope. The CLI emits a single JSON object whose
+// "result" holds the assistant's final text and whose "usage" object carries the
+// token counts. We read only what the budget and summary need and ignore the rest
+// (cost, session id, tool stats, …) so unrelated schema additions are harmless.
+type claudeJSONResult struct {
+	Result string `json:"result"`
+	Usage  struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+// parseClaudeJSONResult extracts the assistant summary and best-effort token
+// usage from a Claude Code --output-format json envelope. It returns ("", 0, 0)
+// when stdout is not the JSON envelope (e.g. the --output-format json fallback to
+// plain text), so the caller can fall back to the raw text and contribute 0 to
+// the token budget. Usage capture is best-effort: a missing "usage" object leaves
+// the counts at 0 rather than erroring.
+func parseClaudeJSONResult(stdout string) (summary string, inputTokens int, outputTokens int) {
+	var payload claudeJSONResult
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		return "", 0, 0
+	}
+	return payload.Result, payload.Usage.InputTokens, payload.Usage.OutputTokens
 }
 
 func (a ClaudeAdapter) Health(ctx context.Context, agent Agent) error {

--- a/internal/runtime/kimi.go
+++ b/internal/runtime/kimi.go
@@ -45,7 +45,7 @@ func (a KimiAdapter) Start(ctx context.Context, request StartRequest) (StartResu
 	if err != nil {
 		return StartResult{Raw: result.Stdout + result.Stderr}, kimiCommandError(result, err)
 	}
-	content, sessionID, parseErr := parseKimiStreamJSON(result.Stdout)
+	content, sessionID, _, parseErr := parseKimiStreamJSON(result.Stdout)
 	if parseErr != nil {
 		return StartResult{Raw: result.Stdout}, fmt.Errorf("parse kimi stream-json output: %w", parseErr)
 	}
@@ -79,11 +79,11 @@ func (a KimiAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result,
 	if err != nil {
 		return Result{Raw: result.Stdout + result.Stderr}, kimiCommandError(result, err)
 	}
-	content, _, parseErr := parseKimiStreamJSON(result.Stdout)
+	content, _, usage, parseErr := parseKimiStreamJSON(result.Stdout)
 	if parseErr != nil {
 		return Result{Raw: result.Stdout}, fmt.Errorf("parse kimi stream-json output: %w", parseErr)
 	}
-	return Result{Raw: content, Summary: strings.TrimSpace(content)}, nil
+	return Result{Raw: content, Summary: strings.TrimSpace(content), InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens}, nil
 }
 
 func (a KimiAdapter) Health(ctx context.Context, agent Agent) error {
@@ -126,16 +126,32 @@ type kimiStreamEvent struct {
 	Type      string `json:"type"`
 	Content   string `json:"content"`
 	SessionID string `json:"session_id"`
+	// Usage carries best-effort token counts when Kimi's stream emits a usage or
+	// result event (#338 Part B). The field set mirrors the common LLM-CLI shape
+	// (input_tokens/output_tokens). It is nil/zero on events that carry no usage,
+	// so a runtime that never reports usage simply contributes 0 to the budget.
+	Usage *kimiUsage `json:"usage"`
+}
+
+// kimiUsage holds the best-effort token counts extracted from a Kimi stream-json
+// usage/result event. Counts default to 0 when the stream omits usage.
+type kimiUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
 }
 
 // parseKimiStreamJSON reads Kimi's --output-format stream-json JSONL output and
-// returns the concatenated assistant content plus the session id from the resume
-// hint meta event, if present.
-func parseKimiStreamJSON(output string) (string, string, error) {
+// returns the concatenated assistant content, the session id from the resume hint
+// meta event (if present), and the best-effort token usage from the last event
+// that carried a usage object (if any). Usage capture is best-effort: when no
+// event reports usage the returned kimiUsage is zero-valued and the job
+// contributes 0 to the per-root token budget.
+func parseKimiStreamJSON(output string) (string, string, kimiUsage, error) {
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var contentParts []string
 	var sessionID string
+	var usage kimiUsage
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -144,6 +160,9 @@ func parseKimiStreamJSON(output string) (string, string, error) {
 		var event kimiStreamEvent
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			continue
+		}
+		if event.Usage != nil {
+			usage = *event.Usage
 		}
 		switch event.Role {
 		case "assistant":
@@ -155,9 +174,9 @@ func parseKimiStreamJSON(output string) (string, string, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return "", "", err
+		return "", "", kimiUsage{}, err
 	}
-	return strings.Join(contentParts, ""), sessionID, nil
+	return strings.Join(contentParts, ""), sessionID, usage, nil
 }
 
 func isKimiSessionID(ref string) bool {

--- a/internal/runtime/usage_test.go
+++ b/internal/runtime/usage_test.go
@@ -1,0 +1,128 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+// TestClaudeDeliverCapturesUsage pins the best-effort #338 Part B token capture
+// for the claude runtime: when the --output-format json envelope carries a usage
+// object, Deliver surfaces input_tokens/output_tokens on the Result.
+func TestClaudeDeliverCapturesUsage(t *testing.T) {
+	// A representative Claude Code --output-format json envelope. We read only
+	// "result" and "usage.{input,output}_tokens"; the rest is ignored.
+	stdout := `{"type":"result","subtype":"success","result":"done","session_id":"abc",` +
+		`"usage":{"input_tokens":1234,"output_tokens":567,"cache_read_input_tokens":10}}`
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
+	adapter := ClaudeAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "done" {
+		t.Fatalf("summary = %q, want %q", result.Summary, "done")
+	}
+	if result.InputTokens != 1234 || result.OutputTokens != 567 {
+		t.Fatalf("claude usage = (%d, %d), want (1234, 567)", result.InputTokens, result.OutputTokens)
+	}
+}
+
+// TestClaudeDeliverNoUsageStaysZero pins that a claude response without a usage
+// object (or that falls back to plain text) contributes 0 to the budget.
+func TestClaudeDeliverNoUsageStaysZero(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		stdout string
+	}{
+		{name: "json_without_usage", stdout: `{"result":"done"}`},
+		{name: "plain_text_fallback", stdout: "just some text, not json"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: tt.stdout}}}
+			adapter := ClaudeAdapter{Runner: runner}
+			agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+			result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+			if err != nil {
+				t.Fatalf("Deliver returned error: %v", err)
+			}
+			if result.InputTokens != 0 || result.OutputTokens != 0 {
+				t.Fatalf("usage = (%d, %d), want (0, 0)", result.InputTokens, result.OutputTokens)
+			}
+		})
+	}
+}
+
+// TestParseClaudeJSONResult unit-tests the envelope parser directly.
+func TestParseClaudeJSONResult(t *testing.T) {
+	summary, in, out := parseClaudeJSONResult(`{"result":"hi","usage":{"input_tokens":7,"output_tokens":3}}`)
+	if summary != "hi" || in != 7 || out != 3 {
+		t.Fatalf("parseClaudeJSONResult = (%q, %d, %d), want (\"hi\", 7, 3)", summary, in, out)
+	}
+	// Non-JSON returns the zero contribution so the caller falls back to raw text.
+	if summary, in, out := parseClaudeJSONResult("not json"); summary != "" || in != 0 || out != 0 {
+		t.Fatalf("parseClaudeJSONResult(non-json) = (%q, %d, %d), want (\"\", 0, 0)", summary, in, out)
+	}
+}
+
+// TestKimiDeliverCapturesUsage pins the best-effort #338 Part B token capture for
+// the kimi runtime: when the stream-json output emits an event carrying a usage
+// object, Deliver surfaces the counts on the Result.
+func TestKimiDeliverCapturesUsage(t *testing.T) {
+	stdout := `{"role":"assistant","content":"answer"}` + "\n" +
+		`{"role":"meta","type":"result","usage":{"input_tokens":800,"output_tokens":200}}` + "\n"
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
+	adapter := KimiAdapter{Runner: runner, Dir: "/repo"}
+	agent := Agent{Name: "audit", Role: "reviewer", Runtime: KimiRuntime, RuntimeRef: "session_550e8400-e29b-41d4-a716-446655440000", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "answer" {
+		t.Fatalf("summary = %q, want %q", result.Summary, "answer")
+	}
+	if result.InputTokens != 800 || result.OutputTokens != 200 {
+		t.Fatalf("kimi usage = (%d, %d), want (800, 200)", result.InputTokens, result.OutputTokens)
+	}
+}
+
+// TestKimiDeliverNoUsageStaysZero pins that a kimi stream without any usage event
+// contributes 0 to the budget.
+func TestKimiDeliverNoUsageStaysZero(t *testing.T) {
+	stdout := `{"role":"assistant","content":"answer"}` + "\n"
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
+	adapter := KimiAdapter{Runner: runner, Dir: "/repo"}
+	agent := Agent{Name: "audit", Role: "reviewer", Runtime: KimiRuntime, RuntimeRef: "session_550e8400-e29b-41d4-a716-446655440000", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.InputTokens != 0 || result.OutputTokens != 0 {
+		t.Fatalf("kimi usage = (%d, %d), want (0, 0)", result.InputTokens, result.OutputTokens)
+	}
+}
+
+// TestCodexDeliverDoesNotCaptureUsage documents the honest per-runtime status:
+// codex Deliver runs `codex exec resume … -- <prompt>` WITHOUT --json (plain
+// text), so it exposes no machine-readable usage and contributes 0 to the per-root
+// token budget. This is intentional (see Result doc + RESULT_CONTRACT.md); the
+// budget under-counts codex rather than failing.
+func TestCodexDeliverDoesNotCaptureUsage(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "codex finished the task. plenty of tokens used but none reported."}}}
+	adapter := CodexAdapter{Runner: runner}
+	agent := Agent{Name: "impl", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "last", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "implement"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.InputTokens != 0 || result.OutputTokens != 0 {
+		t.Fatalf("codex usage = (%d, %d), want (0, 0) — codex Deliver reports no usage", result.InputTokens, result.OutputTokens)
+	}
+}

--- a/internal/workflow/costbudget_test.go
+++ b/internal/workflow/costbudget_test.go
@@ -1,0 +1,175 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// seedTreeWithUsage builds a small coordination tree rooted at rootID: the root
+// coordinator plus n already-completed children (each pointing back at the root
+// via RootJobID) carrying perChildTokens output tokens. It returns nothing; the
+// caller asserts via engine.AdvanceJob(rootID).
+func seedTreeWithUsage(t *testing.T, store *db.Store, rootID string, n int, perChildTokens int, rootDelegations []Delegation) {
+	t.Helper()
+	ctx := context.Background()
+	insertCompletedJob(t, store, db.Job{ID: rootID, Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-009", TaskID: "task-9", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "tree", Delegations: rootDelegations},
+	})
+	for i := 0; i < n; i++ {
+		childID := rootID + "/child" + string(rune('a'+i))
+		insertCompletedJob(t, store, db.Job{ID: childID, Agent: "w", Type: "ask"}, JobPayload{
+			Repo: "jerryfane/gitmoot", Branch: "task-009", TaskID: "task-9", Sender: "w",
+			RootJobID: rootID,
+			Result:    &AgentResult{Decision: "approved", Summary: "child"},
+		})
+		// Seed the child's runtime token usage (input 0, output perChildTokens) so
+		// the per-root sum is deterministic and independent of any live runtime.
+		if err := store.UpdateJobUsage(ctx, childID, 0, perChildTokens); err != nil {
+			t.Fatalf("UpdateJobUsage(%s) returned error: %v", childID, err)
+		}
+	}
+}
+
+// TestEngineTokenBudgetTripEnqueuesFinalize pins the #338 Part B per-root token
+// budget: a coordination tree whose children have already used at least the
+// budget does not dispatch its next generation; instead it gets one graceful
+// finalize continuation and emits delegation_cost_exceeded.
+func TestEngineTokenBudgetTripEnqueuesFinalize(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+
+	engine := testEngine(store)
+	engine.MaxDelegationTokenBudget = 1000
+
+	// Two children of 600 tokens each => 1200 used >= 1000 budget.
+	seedTreeWithUsage(t, store, "over", 2, 600, []Delegation{
+		{ID: "d0", Agent: "w", Action: "ask", Prompt: "work"},
+		{ID: "d1", Agent: "w", Action: "ask", Prompt: "work"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "over"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if jobExists(t, store, "over/delegation/d0") || jobExists(t, store, "over/delegation/d1") {
+		t.Fatal("over-budget delegations must not be dispatched")
+	}
+	if got := countJobEvents(t, store, "over", "delegation_cost_exceeded"); got != 1 {
+		t.Fatalf("delegation_cost_exceeded events = %d, want 1", got)
+	}
+	cont, err := unmarshalPayload(mustJob(t, store, "over/continuation").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if !cont.DelegationFinalize {
+		t.Fatalf("finalize continuation must carry DelegationFinalize: %+v", cont)
+	}
+	if got := countJobEvents(t, store, "over", "delegation_finalize_enqueued"); got != 1 {
+		t.Fatalf("delegation_finalize_enqueued events = %d, want 1", got)
+	}
+}
+
+// TestEngineWithinTokenBudgetDispatches is the control: a tree whose usage is
+// strictly under the budget dispatches its next generation normally and emits no
+// cost-exceeded event.
+func TestEngineWithinTokenBudgetDispatches(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+
+	engine := testEngine(store)
+	engine.MaxDelegationTokenBudget = 1000
+
+	// One child of 300 tokens => 300 used < 1000 budget.
+	seedTreeWithUsage(t, store, "under", 1, 300, []Delegation{
+		{ID: "d0", Agent: "w", Action: "ask", Prompt: "work"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "under"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if !jobExists(t, store, "under/delegation/d0") {
+		t.Fatal("in-budget delegations must be dispatched")
+	}
+	if got := countJobEvents(t, store, "under", "delegation_cost_exceeded"); got != 0 {
+		t.Fatalf("delegation_cost_exceeded events = %d, want 0", got)
+	}
+}
+
+// TestEngineZeroTokenBudgetIsUnlimited is the byte-identical-default control:
+// with the budget left at 0 (the default), a tree that has used a large number of
+// tokens still dispatches and never trips the cost backstop, proving the check is
+// fully skipped when unset.
+func TestEngineZeroTokenBudgetIsUnlimited(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+
+	engine := testEngine(store) // MaxDelegationTokenBudget defaults to 0 => unlimited
+
+	// A child with a huge token count; with budget 0 it must be ignored entirely.
+	seedTreeWithUsage(t, store, "unbounded", 1, 1_000_000, []Delegation{
+		{ID: "d0", Agent: "w", Action: "ask", Prompt: "work"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "unbounded"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if !jobExists(t, store, "unbounded/delegation/d0") {
+		t.Fatal("with budget 0 (unlimited), delegations must still be dispatched")
+	}
+	if got := countJobEvents(t, store, "unbounded", "delegation_cost_exceeded"); got != 0 {
+		t.Fatalf("delegation_cost_exceeded events = %d, want 0 with unlimited budget", got)
+	}
+}
+
+// TestSumRootDelegationTokens pins the per-root aggregation: it sums input +
+// output across the root coordinator and every job pointing back at it, and
+// ignores jobs belonging to other roots.
+func TestSumRootDelegationTokens(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+
+	// Root R: coordinator (10 in / 20 out) + two children (100 out, 250 out).
+	insertCompletedJob(t, store, db.Job{ID: "R", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", TaskID: "task-9", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "root"},
+	})
+	if err := store.UpdateJobUsage(ctx, "R", 10, 20); err != nil {
+		t.Fatalf("UpdateJobUsage(R) returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "R/c1", Agent: "w", Type: "ask"}, JobPayload{
+		RootJobID: "R", Result: &AgentResult{Decision: "approved", Summary: "c1"},
+	})
+	if err := store.UpdateJobUsage(ctx, "R/c1", 0, 100); err != nil {
+		t.Fatalf("UpdateJobUsage(R/c1) returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "R/c2", Agent: "w", Type: "ask"}, JobPayload{
+		RootJobID: "R", Result: &AgentResult{Decision: "approved", Summary: "c2"},
+	})
+	if err := store.UpdateJobUsage(ctx, "R/c2", 0, 250); err != nil {
+		t.Fatalf("UpdateJobUsage(R/c2) returned error: %v", err)
+	}
+	// An unrelated root S with usage that must NOT be counted toward R.
+	insertCompletedJob(t, store, db.Job{ID: "S", Agent: "coord", Type: "ask"}, JobPayload{
+		Result: &AgentResult{Decision: "approved", Summary: "other root"},
+	})
+	if err := store.UpdateJobUsage(ctx, "S", 999, 999); err != nil {
+		t.Fatalf("UpdateJobUsage(S) returned error: %v", err)
+	}
+
+	got, err := engine.sumRootDelegationTokens(ctx, "R")
+	if err != nil {
+		t.Fatalf("sumRootDelegationTokens returned error: %v", err)
+	}
+	if want := 10 + 20 + 100 + 250; got != want {
+		t.Fatalf("sumRootDelegationTokens(R) = %d, want %d", got, want)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -56,6 +56,19 @@ type Engine struct {
 	// defaultMaxInlineArtifactBytes. The total inlined across all children in one
 	// continuation is additionally bounded by maxInlineArtifactTotalBytes.
 	MaxInlineArtifactBytes int
+	// MaxDelegationTokenBudget is the cumulative per-root token budget (input +
+	// output, summed across a coordination tree) that bounds a delegation tree by
+	// cost in addition to depth/width/total-jobs/wall-clock (#338 Part B). When a
+	// coordinator is about to dispatch a new generation and the tree has already
+	// used at least this many tokens, dispatchDelegations refuses further fan-out
+	// and routes to the #305 finalize continuation (delegation_cost_exceeded).
+	// 0 (the default) means unlimited: the check is skipped entirely so default
+	// behavior is byte-identical to before this knob existed. It is sourced from
+	// the host [orchestrate].max_delegation_token_budget config at daemon startup.
+	// NOTE: token capture is best-effort per runtime (see internal/runtime); a
+	// runtime that does not report usage contributes 0 to the sum, so the budget
+	// under-counts that runtime rather than failing.
+	MaxDelegationTokenBudget int
 }
 
 // now returns the engine's current time, defaulting to time.Now when Now is unset.
@@ -765,6 +778,37 @@ func (e Engine) countRootDelegationJobs(ctx context.Context, rootID string) (int
 	return count, nil
 }
 
+// sumRootDelegationTokens sums the runtime token usage (input + output) across an
+// entire coordination tree: the originating coordinator itself (job.ID == rootID)
+// plus every child or continuation whose payload RootJobID points back at it. It
+// mirrors countRootDelegationJobs (there is no store query keyed on root, so it
+// lists all jobs and filters). Used by the per-root token budget (#338 Part B) to
+// decide, before dispatching a new generation, whether the tree has already spent
+// its budget. Token capture is best-effort per runtime (see internal/runtime); a
+// job whose runtime did not report usage contributes 0, so the sum under-counts
+// rather than over-counts.
+func (e Engine) sumRootDelegationTokens(ctx context.Context, rootID string) (int, error) {
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return 0, err
+	}
+	total := 0
+	for _, job := range jobs {
+		if job.ID == rootID {
+			total += job.InputTokens + job.OutputTokens
+			continue
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return 0, err
+		}
+		if payload.RootJobID == rootID {
+			total += job.InputTokens + job.OutputTokens
+		}
+	}
+	return total, nil
+}
+
 func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload JobPayload, ref taskRef) error {
 	if payload.Result == nil || len(payload.Result.Delegations) == 0 {
 		return nil
@@ -841,6 +885,26 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 			Message: fmt.Sprintf("delegation tree for root %s ran %s, exceeding the wall-clock limit of %s; not dispatching %d delegation(s)", rootID, elapsed.Round(time.Second), MaxDelegationWallClock, len(payload.Result.Delegations)),
 		})
 		return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("wall-clock limit of %s reached", MaxDelegationWallClock))
+	}
+
+	// Per-root token budget (#338 Part B). Where the depth/total-jobs/wall-clock
+	// backstops bound the shape and duration of a tree, this bounds its cost: a
+	// coordination tree that has already used at least MaxDelegationTokenBudget
+	// tokens (input + output, summed across the whole tree) is refused further
+	// fan-out and routed to the #305 finalize continuation. It is opt-in: when the
+	// budget is 0 (the default) the check is skipped entirely, so default behavior
+	// is byte-identical. The sum fails open — a lookup/parse hiccup yields 0 and
+	// does not block dispatch — and is best-effort per runtime (a runtime that
+	// reports no usage contributes 0, so the budget under-counts that runtime).
+	if e.MaxDelegationTokenBudget > 0 {
+		if used, _ := e.sumRootDelegationTokens(ctx, rootID); used >= e.MaxDelegationTokenBudget {
+			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   job.ID,
+				Kind:    "delegation_cost_exceeded",
+				Message: fmt.Sprintf("delegation tree %s reached token budget %d (used %d); not dispatching %d delegation(s)", rootID, e.MaxDelegationTokenBudget, used, len(payload.Result.Delegations)),
+			})
+			return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("token budget %d reached", e.MaxDelegationTokenBudget))
+		}
 	}
 
 	if width := len(payload.Result.Delegations); width > MaxDelegationWidth {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -301,6 +301,15 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		PullRequest: payload.PullRequest,
 		Model:       payload.Model,
 	})
+	// Record best-effort runtime token usage so the per-root delegation token
+	// budget (#338 Part B) can sum a tree's cost. Only persist when the runtime
+	// actually reported usage (a positive count) so runtimes that report nothing
+	// (e.g. codex Deliver, which runs without --json) leave the columns at their 0
+	// default rather than taking a no-op write. Usage accounting must never fail a
+	// delivery, so a write error is swallowed.
+	if err == nil && (result.InputTokens > 0 || result.OutputTokens > 0) {
+		_ = m.Store.UpdateJobUsage(ctx, job.ID, result.InputTokens, result.OutputTokens)
+	}
 	if strings.TrimSpace(result.Summary) != "" {
 		return result.Summary, err
 	}

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -166,6 +166,16 @@ Delegation trees are bounded so they cannot run forever:
   coordinator that tries to fan out after the tree has run this long is refused
   with a `delegation_walltime_exceeded` event. A generous runaway backstop, not a
   tight deadline.
+- Per-root token budget (cost): `[orchestrate].max_delegation_token_budget`,
+  **off by default** (`0` = unlimited). When set to a positive value, the whole
+  tree under one root is bounded by cumulative token usage (input + output,
+  summed across every job in the tree). A coordinator that tries to fan out after
+  the tree has already used at least the budget is refused with a
+  `delegation_cost_exceeded` event and routes through the finalize continuation.
+  Token capture is **best-effort per runtime** — see the capture-status note
+  below — so the budget can under-count a runtime that does not report usage; it
+  never over-counts. Leaving the knob at `0` skips the check entirely (behavior is
+  byte-identical to before the knob existed).
 - Per-coordinator width: `MaxDelegationWidth = 16`. A single coordinator result
   may not fan out more than this many delegations in one generation; an over-wide
   set is refused with a `delegation_width_exceeded` event and routes through the
@@ -188,6 +198,24 @@ told it cannot delegate further and asked to synthesize a best-effort final
 result and return empty delegations. That continuation is terminal — any
 delegations it returns are ignored (`delegation_finalized`) — so the chain always
 stops with a clean synthesis instead of a dead end.
+
+#### Token-capture status (per runtime)
+
+The per-root **token budget** sums whatever token usage each job's runtime
+reports at delivery time. Capture is **best-effort and uneven across runtimes**;
+a job whose runtime reports no usage contributes `0` to the sum, so the budget
+**under-counts** that runtime rather than failing. Current status:
+
+| Runtime | Reports token usage? | How |
+| --- | --- | --- |
+| **Claude Code** | Yes | Parsed from the `usage.{input,output}_tokens` of the `--output-format json` envelope on delivery. |
+| **Kimi Code** | Best-effort | Captured if the `--output-format stream-json` stream emits a `usage` object; otherwise `0`. |
+| **Codex** | No (contributes `0`) | `codex exec resume … -- <prompt>` runs without `--json` (plain text), so delivery exposes no machine-readable usage. |
+
+Because of this, a tree made up mostly of Codex jobs will accumulate little or no
+counted usage — set the budget with that in mind, and prefer it as a coarse
+runaway-cost backstop rather than a precise spend limit. A `$`-denominated price
+table is intentionally **not** implemented yet; the budget is in raw tokens.
 
 ### Top-level fields
 

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -61,6 +61,15 @@ cannot recurse or fan out forever:
   coordinator that tries to fan out after the tree has run this long is refused
   with a `delegation_walltime_exceeded` event. A generous runaway backstop, not a
   tight deadline.
+- Per-root token budget (cost) `[orchestrate].max_delegation_token_budget`,
+  **off by default** (`0` = unlimited): when set to a positive value, the whole
+  tree under one root is bounded by cumulative token usage (input + output across
+  every job in the tree). A coordinator that tries to fan out after the tree has
+  already used at least the budget is refused with a `delegation_cost_exceeded`
+  event. Token capture is **best-effort per runtime** (Claude reports usage; Kimi
+  reports it if its stream emits it; Codex `Deliver` runs without `--json` and so
+  contributes `0`), so the budget can under-count but never over-counts. Leaving
+  the knob at `0` skips the check entirely.
 - Per-coordinator width `MaxDelegationWidth = 16`: a single coordinator result
   may not fan out more than this many delegations in one generation; an over-wide
   set is refused with a `delegation_width_exceeded` event.

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -258,6 +258,16 @@ trips, the offending delegations are dropped rather than dispatched.
   `delegation_walltime_exceeded` event. This bounds an expensive-but-not-numerous
   tree (slow agents, long per-job work) that the depth/job-count caps miss. It is
   a generous runaway backstop, not a tight deadline.
+- **Per-root token budget / cost (`[orchestrate].max_delegation_token_budget`, off
+  by default — `0` = unlimited)**: when set to a positive value, the whole
+  delegation tree under one root is bounded by cumulative token usage (input +
+  output, summed across every job in the tree). A coordinator that tries to fan
+  out after the tree has already used at least the budget is refused with a
+  `delegation_cost_exceeded` event and routed through the graceful finalize
+  continuation. Token capture is **best-effort per runtime** (see the table
+  below), so the budget can under-count a runtime that does not report usage — it
+  never over-counts. Leaving the knob at `0` skips the check entirely (behavior is
+  byte-identical to before the knob existed).
 - **Per-coordinator width (`MaxDelegationWidth = 16`)**: a single coordinator
   result may request at most this many delegations in one generation; a wider set
   is refused with a `delegation_width_exceeded` event and routed through the same
@@ -280,6 +290,24 @@ further and asked to synthesize a best-effort final result and return empty
 delegations. That continuation is terminal — any delegations it returns are
 ignored (`delegation_finalized`). Work is bounded and always ends with a clean
 synthesis, not a silent dead end.
+
+### Token-capture status (per runtime)
+
+The per-root **token budget** sums whatever usage each job's runtime reports at
+delivery time. Capture is best-effort and uneven across runtimes; a job whose
+runtime reports no usage contributes `0`, so the budget **under-counts** rather
+than failing:
+
+| Runtime | Reports token usage? | How |
+| --- | --- | --- |
+| **Claude Code** | Yes | Parsed from `usage.{input,output}_tokens` of the `--output-format json` envelope. |
+| **Kimi Code** | Best-effort | Captured if the `--output-format stream-json` stream emits a `usage` object; otherwise `0`. |
+| **Codex** | No (contributes `0`) | Delivery runs `codex exec resume … -- <prompt>` without `--json` (plain text), so no machine-readable usage is exposed. |
+
+Because of this, a tree made up mostly of Codex jobs accumulates little or no
+counted usage — set the budget accordingly and treat it as a coarse runaway-cost
+backstop, not a precise spend limit. A `$`-denominated price table is not
+implemented yet; the budget is in raw tokens.
 
 For the in-repo source of truth, see
 [`skills/gitmoot/references/RESULT_CONTRACT.md`](https://github.com/jerryfane/gitmoot/blob/main/skills/gitmoot/references/RESULT_CONTRACT.md)

--- a/website/docs/workflows/cockpit-orchestrate-workflow.md
+++ b/website/docs/workflows/cockpit-orchestrate-workflow.md
@@ -73,6 +73,7 @@ cockpit_max_panes = 4      # cap on simultaneous panes per run
 cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
 inline_artifact_bodies = false   # inline each child's artifact_body into the coordinator continuation
 inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
+max_delegation_token_budget = 0  # per-root delegation token budget (input+output); 0 = unlimited (off)
 ```
 
 - `cockpit_mode = "off"` disables the cockpit even if `--cockpit` was passed;
@@ -91,6 +92,18 @@ inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
   many bytes of each child's body are inlined; longer bodies are rune-safe
   truncated with a marker pointing at the full on-disk brief. A per-continuation
   aggregate cap also bounds the total inlined across all children.
+- `max_delegation_token_budget` (default `0` = unlimited/off) bounds a delegation
+  tree by **cost** in addition to depth/width/total-jobs/wall-clock. When set to a
+  positive value, the whole tree under one root is capped at that many cumulative
+  tokens (input + output across every job in the tree); a coordinator that tries
+  to fan out after the tree has already used at least the budget is refused with a
+  `delegation_cost_exceeded` event and routed to the graceful finalize
+  continuation. Token capture is **best-effort per runtime** — Claude reports
+  usage via `--output-format json`, Kimi reports it when its stream emits a
+  `usage` object, and Codex runs delivery without `--json` so it contributes `0`
+  (the budget under-counts Codex rather than failing). Treat it as a coarse
+  runaway-cost backstop, not a precise spend limit (raw tokens, no `$` price table
+  yet). Leaving it at `0` is byte-identical to before the knob existed.
 
 ## Constrained hosts
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6854,6 +6854,15 @@ cannot recurse or fan out forever:
   coordinator that tries to fan out after the tree has run this long is refused
   with a `delegation_walltime_exceeded` event. A generous runaway backstop, not a
   tight deadline.
+- Per-root token budget (cost) `[orchestrate].max_delegation_token_budget`,
+  **off by default** (`0` = unlimited): when set to a positive value, the whole
+  tree under one root is bounded by cumulative token usage (input + output across
+  every job in the tree). A coordinator that tries to fan out after the tree has
+  already used at least the budget is refused with a `delegation_cost_exceeded`
+  event. Token capture is **best-effort per runtime** (Claude reports usage; Kimi
+  reports it if its stream emits it; Codex `Deliver` runs without `--json` and so
+  contributes `0`), so the budget can under-count but never over-counts. Leaving
+  the knob at `0` skips the check entirely.
 - Per-coordinator width `MaxDelegationWidth = 16`: a single coordinator result
   may not fan out more than this many delegations in one generation; an over-wide
   set is refused with a `delegation_width_exceeded` event.
@@ -7057,6 +7066,16 @@ Delegation trees are bounded so they cannot run forever:
   coordinator that tries to fan out after the tree has run this long is refused
   with a `delegation_walltime_exceeded` event. A generous runaway backstop, not a
   tight deadline.
+- Per-root token budget (cost): `[orchestrate].max_delegation_token_budget`,
+  **off by default** (`0` = unlimited). When set to a positive value, the whole
+  tree under one root is bounded by cumulative token usage (input + output,
+  summed across every job in the tree). A coordinator that tries to fan out after
+  the tree has already used at least the budget is refused with a
+  `delegation_cost_exceeded` event and routes through the finalize continuation.
+  Token capture is **best-effort per runtime** — see the capture-status note
+  below — so the budget can under-count a runtime that does not report usage; it
+  never over-counts. Leaving the knob at `0` skips the check entirely (behavior is
+  byte-identical to before the knob existed).
 - Per-coordinator width: `MaxDelegationWidth = 16`. A single coordinator result
   may not fan out more than this many delegations in one generation; an over-wide
   set is refused with a `delegation_width_exceeded` event and routes through the
@@ -7079,6 +7098,24 @@ told it cannot delegate further and asked to synthesize a best-effort final
 result and return empty delegations. That continuation is terminal — any
 delegations it returns are ignored (`delegation_finalized`) — so the chain always
 stops with a clean synthesis instead of a dead end.
+
+#### Token-capture status (per runtime)
+
+The per-root **token budget** sums whatever token usage each job's runtime
+reports at delivery time. Capture is **best-effort and uneven across runtimes**;
+a job whose runtime reports no usage contributes `0` to the sum, so the budget
+**under-counts** that runtime rather than failing. Current status:
+
+| Runtime | Reports token usage? | How |
+| --- | --- | --- |
+| **Claude Code** | Yes | Parsed from the `usage.{input,output}_tokens` of the `--output-format json` envelope on delivery. |
+| **Kimi Code** | Best-effort | Captured if the `--output-format stream-json` stream emits a `usage` object; otherwise `0`. |
+| **Codex** | No (contributes `0`) | `codex exec resume … -- <prompt>` runs without `--json` (plain text), so delivery exposes no machine-readable usage. |
+
+Because of this, a tree made up mostly of Codex jobs will accumulate little or no
+counted usage — set the budget with that in mind, and prefer it as a coarse
+runaway-cost backstop rather than a precise spend limit. A `$`-denominated price
+table is intentionally **not** implemented yet; the budget is in raw tokens.
 
 ### Top-level fields
 


### PR DESCRIPTION
Closes #338. (Part A — wall-clock budget — shipped in #342; this is **Part B**.)

A cumulative **per-root token budget** for delegation trees: when a coordinator is about to dispatch a new generation and the tree's captured token usage has reached the budget, it routes through the #305 graceful finalize continuation (synthesize what completed → stop) instead. Design reference: #380 (ruflo).

## What
- **DB**: `input_tokens`/`output_tokens` columns + `Job` fields + `UpdateJobUsage` (added to all 5 job SELECT scans).
- **Engine**: `Engine.MaxDelegationTokenBudget` (0 = unlimited, default) + `sumRootDelegationTokens` + a `delegation_cost_exceeded` backstop in `dispatchDelegations` (after wall-clock) → `enqueueFinalizeContinuation`.
- **Config**: `[orchestrate] max_delegation_token_budget` knob, wired to the engine at daemon startup.
- **Best-effort per-runtime capture** (recorded at delivery): **claude** reports usage via `--output-format json`; **kimi** best-effort from stream-json; **codex contributes 0** (`codex exec resume` has no `--json` — documented). A runtime that reports no usage contributes 0, so the budget under-counts rather than fails. Token-count budget only ($ price table deferred).

## Review fix
- `UpdateJobUsage` now **accumulates** (`col = col + ?`) instead of overwriting, so a malformed-output repair re-delivery doesn't under-count (per-delta negative clamp keeps the total monotonic). Test updated + explicit accumulation assertion.

## Verification
- Full Go gate green (rebased onto #341): `build`/`vet`/`test ./...` (28 pkgs) / `-race ./internal/workflow/` (150s); gofmt clean.
- Tests: engine (≥budget → finalize + zero-dispatch + `delegation_cost_exceeded`; under-budget dispatches; **budget 0 = unchanged** control), store (round-trip + accumulation + migration-on-existing-DB), config (parse + negative rejection), runtime (claude/kimi usage parsed, codex stays 0).
- Binary smoke: the compiled binary reads jobs with the combined columns, a seeded tree sums to 125 ≥ budget 100, and the config knob is accepted.

Default behavior is byte-identical (budget defaults to 0/unlimited). The live trip is integration-tested; a codex orchestra can't trip a token budget (codex reports 0), and claude usage capture is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
