### PR TITLE
fix(workflow): release the cancelled job's runtime-session lock on cancel (#391)

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4338,6 +4338,21 @@ func (s *Store) ReleaseResourceLock(ctx context.Context, resourceKey string, own
 	return affected == 1, nil
 }
 
+// DeleteResourceLocksByOwner releases every resource lock held by ownerJobID,
+// regardless of token/expiry — used when a job is cancelled and can no longer
+// renew its locks. Returns the number released.
+func (s *Store) DeleteResourceLocksByOwner(ctx context.Context, ownerJobID string) (int64, error) {
+	ownerJobID = strings.TrimSpace(ownerJobID)
+	if ownerJobID == "" {
+		return 0, nil
+	}
+	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks WHERE owner_job_id = ?`, ownerJobID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 func (s *Store) DeleteExpiredResourceLocks(ctx context.Context, now time.Time) (int64, error) {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks
 		WHERE expires_at <= ?

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1375,6 +1375,54 @@ func TestResourceLockMethods(t *testing.T) {
 	}
 }
 
+func TestDeleteResourceLocksByOwner(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	for _, lock := range []ResourceLock{
+		{ResourceKey: "runtime:codex:session-1", OwnerJobID: "job-a", OwnerToken: "token-a1", ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano)},
+		{ResourceKey: "runtime:codex:session-2", OwnerJobID: "job-a", OwnerToken: "token-a2", ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano)},
+		{ResourceKey: "runtime:codex:session-3", OwnerJobID: "job-b", OwnerToken: "token-b1", ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano)},
+	} {
+		acquired, err := store.AcquireResourceLock(ctx, lock, now)
+		if err != nil {
+			t.Fatalf("AcquireResourceLock(%s) returned error: %v", lock.ResourceKey, err)
+		}
+		if !acquired {
+			t.Fatalf("AcquireResourceLock(%s) did not acquire", lock.ResourceKey)
+		}
+	}
+
+	// Empty owner id is a no-op.
+	if released, err := store.DeleteResourceLocksByOwner(ctx, "  "); err != nil || released != 0 {
+		t.Fatalf("DeleteResourceLocksByOwner(empty) released=%d err=%v, want 0/nil", released, err)
+	}
+
+	released, err := store.DeleteResourceLocksByOwner(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("DeleteResourceLocksByOwner(job-a) returned error: %v", err)
+	}
+	if released != 2 {
+		t.Fatalf("DeleteResourceLocksByOwner(job-a) released=%d, want 2", released)
+	}
+
+	// job-a's locks are gone.
+	for _, key := range []string{"runtime:codex:session-1", "runtime:codex:session-2"} {
+		if _, err := store.GetResourceLock(ctx, key); !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("GetResourceLock(%s) error = %v, want sql.ErrNoRows", key, err)
+		}
+	}
+	// job-b's lock survives.
+	if _, err := store.GetResourceLock(ctx, "runtime:codex:session-3"); err != nil {
+		t.Fatalf("GetResourceLock(session-3) returned error: %v, want surviving lock", err)
+	}
+}
+
 func TestResourceLockRecoversExpiredLock(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -129,11 +129,16 @@ func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, erro
 		}
 		return db.Job{}, fmt.Errorf("job %s is %s; cancel requires queued or running", latest.ID, latest.State)
 	}
-	// Best-effort: release any resource locks the cancelled job still owns
-	// (e.g. a stranded runtime-session lock whose deferred release never ran
-	// because the job was killed). The job is already terminally cancelled, so
-	// no live owner is dispossessed. We swallow the error on purpose: lock
-	// cleanup is incidental and must never make a successful cancel fail.
+	// Best-effort: release any resource locks the cancelled job still owns (e.g. a
+	// stranded runtime-session lock whose deferred release never ran because the
+	// job was killed) so the next job on that runtime session does not wait out
+	// the full lock TTL. This only makes the existing TTL-based reaper release
+	// happen sooner for a cancelled job — the same brief same-session window
+	// already exists when a long-running job's lock TTL lapses while its runtime
+	// is still in flight; cancelling signals intent to abandon the job. A fully
+	// race-free release would have to reap the runtime process first (separate,
+	// larger change). We swallow the error on purpose: lock cleanup is incidental
+	// and must never make a successful cancel fail.
 	_, _ = store.DeleteResourceLocksByOwner(ctx, job.ID)
 	return store.GetJob(ctx, job.ID)
 }

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -129,6 +129,12 @@ func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, erro
 		}
 		return db.Job{}, fmt.Errorf("job %s is %s; cancel requires queued or running", latest.ID, latest.State)
 	}
+	// Best-effort: release any resource locks the cancelled job still owns
+	// (e.g. a stranded runtime-session lock whose deferred release never ran
+	// because the job was killed). The job is already terminally cancelled, so
+	// no live owner is dispossessed. We swallow the error on purpose: lock
+	// cleanup is incidental and must never make a successful cancel fail.
+	_, _ = store.DeleteResourceLocksByOwner(ctx, job.ID)
 	return store.GetJob(ctx, job.ID)
 }
 

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -2,8 +2,11 @@ package workflow
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 )
@@ -147,6 +150,55 @@ func TestCancelJobCancelsQueuedOrRunningJob(t *testing.T) {
 	}
 	if len(events) != 2 || events[1].Kind != string(JobCancelled) {
 		t.Fatalf("events = %+v, want cancellation event", events)
+	}
+}
+
+func TestCancelJobReleasesRuntimeSessionLock(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "ask", State: string(JobRunning)}, db.JobEvent{Kind: string(JobRunning), Message: "running"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	const lockKey = "runtime:codex:session-1"
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: lockKey,
+		OwnerJobID:  "job-1",
+		OwnerToken:  "token-1",
+		ExpiresAt:   now.Add(30 * time.Minute).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		t.Fatalf("AcquireResourceLock returned error: %v", err)
+	}
+	if !acquired {
+		t.Fatal("AcquireResourceLock did not acquire the runtime-session lock")
+	}
+
+	job, err := CancelJob(ctx, store, "job-1")
+	if err != nil {
+		t.Fatalf("CancelJob returned error: %v", err)
+	}
+	if job.State != string(JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+
+	if _, err := store.GetResourceLock(ctx, lockKey); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetResourceLock after cancel error = %v, want sql.ErrNoRows (lock should be released)", err)
+	}
+
+	// A different job must be able to re-acquire the freed key immediately.
+	reacquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: lockKey,
+		OwnerJobID:  "job-2",
+		OwnerToken:  "token-2",
+		ExpiresAt:   now.Add(30 * time.Minute).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		t.Fatalf("second AcquireResourceLock returned error: %v", err)
+	}
+	if !reacquired {
+		t.Fatal("second job could not re-acquire the freed runtime-session lock")
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -486,6 +486,11 @@ is routed through the graceful finalize path (synthesize what completed → stop
 and the daemon stops starting queued children of that root. See
 `references/SAFETY.md` for how it relates to the other termination bounds.
 
+`gitmoot job cancel <job-id>` also releases any resource locks the cancelled job
+still owned — including a stranded `runtime:<rt>:<session>` lock left behind when
+a foreground `gitmoot agent ask` was killed — so the next ask on that agent does
+not wait out the lock TTL before it can run.
+
 Merge-gate retries are automatic while the daemon is running. Retryable states,
 such as a busy base-branch merge queue or a GitHub branch update in progress,
 are retried on the next daemon poll tick. The default poll interval is `30s`

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -484,6 +484,11 @@ and the daemon stops starting queued children of that root. See the
 [termination bounds](result-contract.md#termination-bounds) for how it relates
 to the other delegation backstops.
 
+`gitmoot job cancel <job-id>` also releases any resource locks the cancelled job
+still owned — including a stranded `runtime:<rt>:<session>` lock left behind when
+a foreground `gitmoot agent ask` was killed — so the next ask on that agent does
+not wait out the lock TTL before it can run.
+
 Merge-gate retries are automatic while the daemon is running. Retryable states,
 such as a busy base-branch merge queue or a GitHub branch update in progress,
 are retried on the next daemon poll tick. The default poll interval is `30s`

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5905,6 +5905,11 @@ is routed through the graceful finalize path (synthesize what completed → stop
 and the daemon stops starting queued children of that root. See
 `references/SAFETY.md` for how it relates to the other termination bounds.
 
+`gitmoot job cancel <job-id>` also releases any resource locks the cancelled job
+still owned — including a stranded `runtime:<rt>:<session>` lock left behind when
+a foreground `gitmoot agent ask` was killed — so the next ask on that agent does
+not wait out the lock TTL before it can run.
+
 Merge-gate retries are automatic while the daemon is running. Retryable states,
 such as a busy base-branch merge queue or a GitHub branch update in progress,
 are retried on the next daemon poll tick. The default poll interval is `30s`


### PR DESCRIPTION
Closes #391.

`gitmoot job cancel` now releases the cancelled job's stranded **runtime-session lock**. Killing a foreground `gitmoot agent ask` left its `resource_locks` row (`runtime:<rt>:<session>`, 30-min TTL) stranded — the `defer releaseLock` never ran — so the next ask on that agent failed `runtime session … is busy` until the TTL. `job cancel`/`--force` didn't release it.

## What
- **`store.DeleteResourceLocksByOwner(ctx, ownerJobID)`** — `DELETE FROM resource_locks WHERE owner_job_id = ?` (trim, no-op on empty, returns count).
- **`workflow.CancelJob`** calls it best-effort right after the queued/running→cancelled transition (swallows the error so cancel never fails on lock cleanup).

## Honest scope note (from review)
The release is unconditional, so it makes the **existing TTL-based reaper release happen sooner** for a cancelled job. The same brief same-session window already exists when a long-running job's lock TTL lapses while its runtime is still in flight — this isn't a new failure class, and cancelling signals intent to abandon the job. A fully race-free release would have to reap the runtime process first (a separate, larger change). The comment documents this honestly.

## Verification
- Full Go gate green: `build`/`vet`/`test ./...` / `-race ./internal/workflow/` (160s); gofmt clean.
- Tests: `TestCancelJobReleasesRuntimeSessionLock` (cancel a job owning a `runtime:codex:session-1` lock → lock gone → a different job re-acquires the same key); `TestDeleteResourceLocksByOwner` (deletes only the owner's rows; no-op on blank id); existing `CancelJob` tests stay green.
- Binary E2E: compiled `job cancel` released a seeded `runtime:claude:e2e-session` lock (0 owned after), and a different job re-acquired the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
