### PR TITLE
fix(workflow): keep terminal-success result on advance error + idempotent PR create (#387)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -454,6 +454,13 @@ func dispatchAgentCommand(options agentRunOptions, action string, reason string,
 		}
 		output.DaemonRunning = running
 	}
+	// The job + delivery succeeded terminally; only a benign post-success
+	// advance step errored (e.g. a merge-gate block on the freshly-opened PR, or
+	// a 422 "PR already exists" race). Per clig.dev, the result still goes to
+	// stdout with exit 0; the advance warning goes to stderr.
+	if output.AdvanceError != "" {
+		fmt.Fprintf(stderr, "%s: advance warning: %s\n", errLabel, output.AdvanceError)
+	}
 	return output, 0
 }
 

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -60,6 +60,12 @@ type localAgentJobOutput struct {
 	RawOutputCount       int                   `json:"raw_output_count"`
 	WatchCommand         string                `json:"watch_command,omitempty"`
 	DaemonRunning        bool                  `json:"daemon_running,omitempty"`
+	// AdvanceError is set only when the agent delivery + job succeeded
+	// terminally but a benign post-success advance step errored (e.g. a
+	// merge-gate block on a freshly-opened PR, or a 422 "PR already exists"
+	// race). The terminal-success result is still surfaced; this carries the
+	// advance warning so it is not silently lost.
+	AdvanceError string `json:"advance_error,omitempty"`
 }
 
 func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAgentDispatchRequest) (localAgentJobOutput, error) {
@@ -228,6 +234,22 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		}
 		engine := daemonWorkflowEngine(store, github.NewClient(checkoutPath), checkoutPath, workflowHome)
 		if _, err := engine.RunJob(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {
+			// A post-success advance step can error benignly (a merge-gate block
+			// on the freshly-opened PR, or a 422 "PR already exists" race) AFTER
+			// the agent delivery + job already succeeded terminally. In that case
+			// the persisted result is in hand: surface it (with the advance
+			// warning) instead of discarding it. Genuine delivery/run failures —
+			// where the re-fetched job is NOT terminally succeeded — stay raw.
+			var advErr workflow.AdvanceError
+			if errors.As(err, &advErr) {
+				if latest, gerr := store.GetJob(ctx, job.ID); gerr == nil && latest.State == string(workflow.JobSucceeded) {
+					out, perr := buildLocalAgentJobOutput(latest, request)
+					if perr == nil {
+						out.AdvanceError = advErr.Error()
+						return out, nil
+					}
+				}
+			}
 			return localAgentJobOutput{}, err
 		}
 	}
@@ -235,6 +257,13 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
+	return buildLocalAgentJobOutput(latest, request)
+}
+
+// buildLocalAgentJobOutput renders the terminal job into the success-path
+// localAgentJobOutput. It is shared by the normal success return and the
+// post-success advance-error recovery so both surface the identical result.
+func buildLocalAgentJobOutput(latest db.Job, request localAgentDispatchRequest) (localAgentJobOutput, error) {
 	payload, err := daemonJobPayload(latest)
 	if err != nil {
 		return localAgentJobOutput{}, err
@@ -843,6 +872,9 @@ func printLocalAgentJobOutput(stdout io.Writer, output localAgentJobOutput) {
 	writeLine(stdout, "repo: %s", output.Repo)
 	writeLine(stdout, "agent: %s", output.Agent)
 	writeLine(stdout, "action: %s", output.Action)
+	if output.AdvanceError != "" {
+		writeLine(stdout, "advance_error: %s", output.AdvanceError)
+	}
 	if output.WatchCommand != "" {
 		writeLine(stdout, "next: %s", output.WatchCommand)
 	}

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -234,21 +234,8 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		}
 		engine := daemonWorkflowEngine(store, github.NewClient(checkoutPath), checkoutPath, workflowHome)
 		if _, err := engine.RunJob(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {
-			// A post-success advance step can error benignly (a merge-gate block
-			// on the freshly-opened PR, or a 422 "PR already exists" race) AFTER
-			// the agent delivery + job already succeeded terminally. In that case
-			// the persisted result is in hand: surface it (with the advance
-			// warning) instead of discarding it. Genuine delivery/run failures —
-			// where the re-fetched job is NOT terminally succeeded — stay raw.
-			var advErr workflow.AdvanceError
-			if errors.As(err, &advErr) {
-				if latest, gerr := store.GetJob(ctx, job.ID); gerr == nil && latest.State == string(workflow.JobSucceeded) {
-					out, perr := buildLocalAgentJobOutput(latest, request)
-					if perr == nil {
-						out.AdvanceError = advErr.Error()
-						return out, nil
-					}
-				}
+			if out, ok, _ := recoverAdvanceErrorOutput(ctx, store, job.ID, request, err); ok {
+				return out, nil
 			}
 			return localAgentJobOutput{}, err
 		}
@@ -258,6 +245,35 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		return localAgentJobOutput{}, err
 	}
 	return buildLocalAgentJobOutput(latest, request)
+}
+
+// recoverAdvanceErrorOutput salvages the persisted result when a post-success
+// advance step errors benignly (a merge-gate block on the freshly-opened PR, or
+// a 422 "PR already exists" race) AFTER the agent delivery + job already
+// succeeded terminally. It returns (output, true, nil) — output carrying the
+// advance warning — only when runErr is a workflow.AdvanceError AND the
+// re-fetched job is terminally succeeded AND the result renders. Otherwise it
+// returns recovered=false so the caller surfaces the raw run error; genuine
+// delivery/run failures (where the re-fetched job is NOT terminally succeeded)
+// never recover.
+func recoverAdvanceErrorOutput(ctx context.Context, store *db.Store, jobID string, request localAgentDispatchRequest, runErr error) (localAgentJobOutput, bool, error) {
+	var advErr workflow.AdvanceError
+	if !errors.As(runErr, &advErr) {
+		return localAgentJobOutput{}, false, nil
+	}
+	latest, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		return localAgentJobOutput{}, false, err
+	}
+	if latest.State != string(workflow.JobSucceeded) {
+		return localAgentJobOutput{}, false, nil
+	}
+	out, err := buildLocalAgentJobOutput(latest, request)
+	if err != nil {
+		return localAgentJobOutput{}, false, err
+	}
+	out.AdvanceError = advErr.Error()
+	return out, true, nil
 }
 
 // buildLocalAgentJobOutput renders the terminal job into the success-path

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// buildLocalAgentJobOutput must render a terminally-succeeded implement job into
+// the same populated output the success path returns, so the advance-error
+// recovery branch can surface the persisted result instead of discarding it.
+func TestBuildLocalAgentJobOutputRendersSucceededJob(t *testing.T) {
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        "owner/repo",
+		PullRequest: 7,
+		Result:      &workflow.AgentResult{Decision: "implemented", Summary: "opened PR"},
+		RawOutputs:  []string{`{"gitmoot_result":{}}`},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	job := db.Job{
+		ID:      "local-implement-lead-abc",
+		Agent:   "lead",
+		Type:    "implement",
+		State:   string(workflow.JobSucceeded),
+		Payload: string(payload),
+	}
+	out, err := buildLocalAgentJobOutput(job, localAgentDispatchRequest{
+		SelectedAction:       "implement",
+		SelectedActionReason: "explicit agent implement",
+		ExecutionPath:        "agent_implement",
+	})
+	if err != nil {
+		t.Fatalf("buildLocalAgentJobOutput returned error: %v", err)
+	}
+	if out.JobID != job.ID || out.State != string(workflow.JobSucceeded) || out.Repo != "owner/repo" {
+		t.Fatalf("output = %+v", out)
+	}
+	if out.Result == nil || out.Result.Summary != "opened PR" || out.RawOutputCount != 1 {
+		t.Fatalf("output result = %+v (raw=%d)", out.Result, out.RawOutputCount)
+	}
+	if out.AdvanceError != "" {
+		t.Fatalf("AdvanceError = %q, want empty by default", out.AdvanceError)
+	}
+}
+
+// The terminal-success output, when an advance error is attached, must serialize
+// the result AND the advance_error in --json mode, and render an advance_error
+// line in human mode. This is the #387 surface: exit 0 with the result on
+// stdout and the advance warning carried alongside.
+func TestLocalAgentJobOutputSurfacesAdvanceError(t *testing.T) {
+	out := localAgentJobOutput{
+		JobID:        "local-implement-lead-abc",
+		State:        string(workflow.JobSucceeded),
+		Repo:         "owner/repo",
+		Agent:        "lead",
+		Action:       "implement",
+		Result:       &workflow.AgentResult{Decision: "implemented", Summary: "opened PR"},
+		AdvanceError: "workflow advance failed: workflow blocked: ci is pending",
+	}
+
+	t.Run("json includes advance_error and result", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := writeJSON(&buf, out); err != nil {
+			t.Fatalf("writeJSON returned error: %v", err)
+		}
+		var decoded localAgentJobOutput
+		if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+			t.Fatalf("decode: %v\n%s", err, buf.String())
+		}
+		if decoded.AdvanceError != out.AdvanceError {
+			t.Fatalf("decoded advance_error = %q", decoded.AdvanceError)
+		}
+		if decoded.Result == nil || decoded.Result.Summary != "opened PR" {
+			t.Fatalf("decoded result = %+v", decoded.Result)
+		}
+		if !strings.Contains(buf.String(), `"advance_error"`) {
+			t.Fatalf("json missing advance_error key:\n%s", buf.String())
+		}
+	})
+
+	t.Run("human mode prints advance_error line", func(t *testing.T) {
+		var buf bytes.Buffer
+		printLocalAgentJobOutput(&buf, out)
+		if !strings.Contains(buf.String(), "advance_error: workflow advance failed: workflow blocked: ci is pending") {
+			t.Fatalf("human output missing advance_error line:\n%s", buf.String())
+		}
+		// The result still renders.
+		if !strings.Contains(buf.String(), "summary: opened PR") {
+			t.Fatalf("human output missing result summary:\n%s", buf.String())
+		}
+	})
+}
+
+// By default (no advance error) the JSON output must NOT carry an advance_error
+// key — the field is omitempty, so the normal success path stays byte-identical.
+func TestLocalAgentJobOutputOmitsAdvanceErrorByDefault(t *testing.T) {
+	out := localAgentJobOutput{
+		JobID:  "local-implement-lead-abc",
+		State:  string(workflow.JobSucceeded),
+		Repo:   "owner/repo",
+		Agent:  "lead",
+		Action: "implement",
+		Result: &workflow.AgentResult{Decision: "implemented", Summary: "opened PR"},
+	}
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, out); err != nil {
+		t.Fatalf("writeJSON returned error: %v", err)
+	}
+	if strings.Contains(buf.String(), "advance_error") {
+		t.Fatalf("default json should omit advance_error:\n%s", buf.String())
+	}
+	var human bytes.Buffer
+	printLocalAgentJobOutput(&human, out)
+	if strings.Contains(human.String(), "advance_error") {
+		t.Fatalf("default human output should omit advance_error:\n%s", human.String())
+	}
+}

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -120,4 +122,90 @@ func TestLocalAgentJobOutputOmitsAdvanceErrorByDefault(t *testing.T) {
 	if strings.Contains(human.String(), "advance_error") {
 		t.Fatalf("default human output should omit advance_error:\n%s", human.String())
 	}
+}
+
+// recoverAdvanceErrorOutput is the post-success advance-recovery glue extracted
+// from dispatchLocalAgentJob: it recovers the persisted result ONLY when the run
+// error is a workflow.AdvanceError AND the re-fetched job is terminally
+// succeeded. It seeds a real db.Store job (mirroring the success-path payload)
+// and asserts the three branches.
+func TestRecoverAdvanceErrorOutput(t *testing.T) {
+	ctx := context.Background()
+	request := localAgentDispatchRequest{
+		SelectedAction:       "implement",
+		SelectedActionReason: "explicit agent implement",
+		ExecutionPath:        "agent_implement",
+	}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        "owner/repo",
+		PullRequest: 7,
+		Result:      &workflow.AgentResult{Decision: "implemented", Summary: "opened PR"},
+		RawOutputs:  []string{`{"gitmoot_result":{}}`},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	seedJob := func(t *testing.T, store *db.Store, id string, state string) {
+		t.Helper()
+		if err := store.CreateJob(ctx, db.Job{
+			ID:      id,
+			Agent:   "lead",
+			Type:    "implement",
+			State:   state,
+			Payload: string(payload),
+		}); err != nil {
+			t.Fatalf("CreateJob returned error: %v", err)
+		}
+	}
+
+	t.Run("succeeded job + AdvanceError recovers with result and warning", func(t *testing.T) {
+		store := daemonWorkerStore(t)
+		seedJob(t, store, "local-implement-lead-ok", string(workflow.JobSucceeded))
+		runErr := workflow.AdvanceError{Err: errors.New("workflow blocked: ci is pending")}
+
+		out, recovered, err := recoverAdvanceErrorOutput(ctx, store, "local-implement-lead-ok", request, runErr)
+		if err != nil {
+			t.Fatalf("recoverAdvanceErrorOutput returned error: %v", err)
+		}
+		if !recovered {
+			t.Fatal("recovered = false, want true for a succeeded job with an AdvanceError")
+		}
+		if out.Result == nil || out.Result.Summary != "opened PR" {
+			t.Fatalf("output result = %+v", out.Result)
+		}
+		if out.AdvanceError == "" {
+			t.Fatalf("AdvanceError = %q, want the advance warning attached", out.AdvanceError)
+		}
+		if out.AdvanceError != runErr.Error() {
+			t.Fatalf("AdvanceError = %q, want %q", out.AdvanceError, runErr.Error())
+		}
+	})
+
+	t.Run("plain (non-AdvanceError) error does not recover", func(t *testing.T) {
+		store := daemonWorkerStore(t)
+		seedJob(t, store, "local-implement-lead-plain", string(workflow.JobSucceeded))
+
+		out, recovered, err := recoverAdvanceErrorOutput(ctx, store, "local-implement-lead-plain", request, errors.New("delivery failed"))
+		if err != nil {
+			t.Fatalf("recoverAdvanceErrorOutput returned error: %v", err)
+		}
+		if recovered {
+			t.Fatalf("recovered = true, want false for a non-AdvanceError; out=%+v", out)
+		}
+	})
+
+	t.Run("AdvanceError but job not succeeded does not recover", func(t *testing.T) {
+		store := daemonWorkerStore(t)
+		seedJob(t, store, "local-implement-lead-blocked", string(workflow.JobBlocked))
+		runErr := workflow.AdvanceError{Err: errors.New("workflow blocked: ci is pending")}
+
+		out, recovered, err := recoverAdvanceErrorOutput(ctx, store, "local-implement-lead-blocked", request, runErr)
+		if err != nil {
+			t.Fatalf("recoverAdvanceErrorOutput returned error: %v", err)
+		}
+		if recovered {
+			t.Fatalf("recovered = true, want false when the re-fetched job is not succeeded; out=%+v", out)
+		}
+	})
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3160,7 +3160,11 @@ func (f daemonImplementationFinalizer) FinalizeImplementation(ctx context.Contex
 		}
 		return payload, nil
 	}
-	pr, err := f.githubClient(task.WorktreePath).CreatePullRequest(ctx, github.CreatePullRequestInput{
+	// No local record yet: ensure the PR on GitHub idempotently. EnsurePullRequest
+	// adopts an out-of-band/concurrent open PR for this head (and survives the 422
+	// "already exists" create race) instead of erroring, so a benign race no longer
+	// blocks the implementation after the work already landed.
+	pr, err := f.githubClient(task.WorktreePath).EnsurePullRequest(ctx, github.CreatePullRequestInput{
 		Repo:  repo,
 		Title: finalizerPullRequestTitle(task),
 		Body:  finalizerPullRequestBody(job, payload, task),

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -2850,6 +2850,109 @@ func TestDaemonImplementationFinalizerCommitsBeforeReusingExistingPullRequest(t 
 	}
 }
 
+// stubEnsureGitHub adopts a pre-existing open PR via EnsurePullRequest, the way
+// the real GhClient does when GetOpenPullRequestByHead finds one. It records
+// whether CreatePullRequest was called so the test can prove the finalizer took
+// the idempotent adopt path instead of erroring on a 422 race.
+type stubEnsureGitHub struct {
+	github.NoopClient
+	existing    github.PullRequest
+	ensureCalls int
+	createCalls int
+	ensureErr   error
+}
+
+func (s *stubEnsureGitHub) EnsurePullRequest(context.Context, github.CreatePullRequestInput) (github.PullRequest, error) {
+	s.ensureCalls++
+	if s.ensureErr != nil {
+		return github.PullRequest{}, s.ensureErr
+	}
+	return s.existing, nil
+}
+
+func (s *stubEnsureGitHub) CreatePullRequest(context.Context, github.CreatePullRequestInput) (github.PullRequest, error) {
+	s.createCalls++
+	return github.PullRequest{}, errors.New("CreatePullRequest should not be called when EnsurePullRequest adopts")
+}
+
+// With no local PR record, the finalizer must adopt an out-of-band/concurrent
+// open PR via EnsurePullRequest instead of erroring with a BlockedError — the
+// #387 idempotency fix.
+func TestDaemonImplementationFinalizerAdoptsExistingPullRequestViaEnsure(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	runGit(t, repoDir, "switch", "-c", "task-1")
+	if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("new work\n"), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: repoDir}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	// No local PR record: the local fast-path misses, so the github-side ensure runs.
+	gh := &stubEnsureGitHub{existing: github.PullRequest{
+		Number:  99,
+		URL:     "https://github.com/owner/repo/pull/99",
+		State:   "open",
+		HeadRef: "task-1",
+		BaseRef: "main",
+	}}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	payload := workflow.JobPayload{
+		Repo:      "owner/repo",
+		Branch:    "task-1",
+		GoalID:    "goal-1",
+		TaskID:    "task-1",
+		TaskTitle: "Task 1",
+		LeadAgent: "lead",
+		Result:    &workflow.AgentResult{Decision: "implemented", Summary: "done"},
+	}
+
+	finalized, err := finalizer.FinalizeImplementation(ctx, db.Job{ID: "job-1", Agent: "lead", Type: "implement"}, payload)
+	if err != nil {
+		t.Fatalf("FinalizeImplementation returned error: %v", err)
+	}
+	var blocked workflow.BlockedError
+	if errors.As(err, &blocked) {
+		t.Fatalf("FinalizeImplementation returned BlockedError on an existing PR: %v", err)
+	}
+	if finalized.PullRequest != 99 {
+		t.Fatalf("finalized pull request = %d, want 99 (adopted)", finalized.PullRequest)
+	}
+	if gh.ensureCalls != 1 {
+		t.Fatalf("EnsurePullRequest calls = %d, want 1", gh.ensureCalls)
+	}
+	if gh.createCalls != 0 {
+		t.Fatalf("CreatePullRequest calls = %d, want 0 (adopt, not create)", gh.createCalls)
+	}
+	// The adopted PR is persisted locally.
+	stored, err := store.GetPullRequest(ctx, "owner/repo", 99)
+	if err != nil {
+		t.Fatalf("GetPullRequest(99) returned error: %v", err)
+	}
+	if stored.HeadBranch != "task-1" || !strings.EqualFold(stored.State, "open") {
+		t.Fatalf("stored PR = %+v", stored)
+	}
+}
+
 func TestDaemonImplementationFinalizerPushesAlreadyCommittedWork(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2151,6 +2151,14 @@ func (f *fakeGitHub) CreatePullRequest(context.Context, github.CreatePullRequest
 	return github.PullRequest{}, errors.New("not implemented")
 }
 
+func (f *fakeGitHub) GetOpenPullRequestByHead(context.Context, github.Repository, string) (github.PullRequest, bool, error) {
+	return github.PullRequest{}, false, errors.New("not implemented")
+}
+
+func (f *fakeGitHub) EnsurePullRequest(context.Context, github.CreatePullRequestInput) (github.PullRequest, error) {
+	return github.PullRequest{}, errors.New("not implemented")
+}
+
 func (f *fakeGitHub) CreateIssue(context.Context, github.CreateIssueInput) (github.Issue, error) {
 	return github.Issue{}, errors.New("not implemented")
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2151,7 +2151,7 @@ func (f *fakeGitHub) CreatePullRequest(context.Context, github.CreatePullRequest
 	return github.PullRequest{}, errors.New("not implemented")
 }
 
-func (f *fakeGitHub) GetOpenPullRequestByHead(context.Context, github.Repository, string) (github.PullRequest, bool, error) {
+func (f *fakeGitHub) GetOpenPullRequestByHead(context.Context, github.Repository, string, string) (github.PullRequest, bool, error) {
 	return github.PullRequest{}, false, errors.New("not implemented")
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -27,7 +27,9 @@ type Client interface {
 	ListUserRepositories(ctx context.Context, limit int) ([]RepoSummary, error)
 	ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error)
 	GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error)
+	GetOpenPullRequestByHead(ctx context.Context, repo Repository, head string) (PullRequest, bool, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
+	EnsurePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
 	CreateIssue(ctx context.Context, input CreateIssueInput) (Issue, error)
 	CloseIssue(ctx context.Context, repo Repository, issueNumber int64) (Issue, error)
 	ListIssueComments(ctx context.Context, repo Repository, issueNumber int64) ([]IssueComment, error)
@@ -457,6 +459,92 @@ func (c *GhClient) CreatePullRequest(ctx context.Context, input CreatePullReques
 		return PullRequest{}, err
 	}
 	return pr, nil
+}
+
+// GetOpenPullRequestByHead returns the open PR whose head branch is `head`, if
+// one exists, via `gh pr list`. The boolean is false (with a nil error) when no
+// open PR is found. `gh pr list --json` field names differ from the REST API
+// (url/headRefOid/baseRefName), so the response is decoded through a dedicated
+// wire shape and mapped onto PullRequest.
+func (c *GhClient) GetOpenPullRequestByHead(ctx context.Context, repo Repository, head string) (PullRequest, bool, error) {
+	if strings.TrimSpace(repo.FullName()) == "" {
+		return PullRequest{}, false, fmt.Errorf("repository owner/name is required")
+	}
+	if strings.TrimSpace(head) == "" {
+		return PullRequest{}, false, fmt.Errorf("head branch is required")
+	}
+	result, err := c.run(ctx, false,
+		"pr", "list",
+		"--repo", repo.FullName(),
+		"--head", head,
+		"--state", "open",
+		"--json", "number,url,headRefOid,baseRefName,state",
+	)
+	if err != nil {
+		return PullRequest{}, false, err
+	}
+	var wire []struct {
+		Number      int64  `json:"number"`
+		URL         string `json:"url"`
+		HeadRefOid  string `json:"headRefOid"`
+		BaseRefName string `json:"baseRefName"`
+		State       string `json:"state"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &wire); err != nil {
+		return PullRequest{}, false, fmt.Errorf("decode gh pr list response: %w", err)
+	}
+	if len(wire) == 0 {
+		return PullRequest{}, false, nil
+	}
+	w := wire[0]
+	return PullRequest{
+		Number:  w.Number,
+		URL:     w.URL,
+		State:   strings.ToLower(strings.TrimSpace(w.State)),
+		HeadRef: head,
+		HeadSHA: w.HeadRefOid,
+		BaseRef: w.BaseRefName,
+	}, true, nil
+}
+
+// EnsurePullRequest returns the open PR for input.Head idempotently: it adopts
+// an existing open head PR (query-first, no create), otherwise creates one, and
+// if create races a concurrent open (a 422 "a pull request already exists") it
+// re-queries by head and adopts the winner. This removes the TOCTOU window
+// where two finalizers (or an out-of-band PR) turn a benign "already exists"
+// into a hard error.
+func (c *GhClient) EnsurePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error) {
+	if existing, ok, err := c.GetOpenPullRequestByHead(ctx, input.Repo, input.Head); err != nil {
+		return PullRequest{}, err
+	} else if ok {
+		return existing, nil
+	}
+	pr, err := c.CreatePullRequest(ctx, input)
+	if err == nil {
+		return pr, nil
+	}
+	if !isPullRequestAlreadyExists(err) {
+		return PullRequest{}, err
+	}
+	// A concurrent create won the race; adopt the now-existing open PR.
+	if existing, ok, qerr := c.GetOpenPullRequestByHead(ctx, input.Repo, input.Head); qerr != nil {
+		return PullRequest{}, qerr
+	} else if ok {
+		return existing, nil
+	}
+	return PullRequest{}, err
+}
+
+// isPullRequestAlreadyExists detects the gh/GitHub 422 raised when a PR already
+// exists for the head branch. gh surfaces it in the error text, so match on the
+// "already exists" phrasing (and the 422 status) robustly.
+func isPullRequestAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "already exists") ||
+		(strings.Contains(text, "422") && strings.Contains(text, "pull request"))
 }
 
 func (c *GhClient) ListIssueComments(ctx context.Context, repo Repository, issueNumber int64) ([]IssueComment, error) {
@@ -1066,7 +1154,15 @@ func (NoopClient) GetPullRequest(context.Context, Repository, int64) (PullReques
 	return PullRequest{}, errors.ErrUnsupported
 }
 
+func (NoopClient) GetOpenPullRequestByHead(context.Context, Repository, string) (PullRequest, bool, error) {
+	return PullRequest{}, false, errors.ErrUnsupported
+}
+
 func (NoopClient) CreatePullRequest(context.Context, CreatePullRequestInput) (PullRequest, error) {
+	return PullRequest{}, errors.ErrUnsupported
+}
+
+func (NoopClient) EnsurePullRequest(context.Context, CreatePullRequestInput) (PullRequest, error) {
 	return PullRequest{}, errors.ErrUnsupported
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -27,7 +27,7 @@ type Client interface {
 	ListUserRepositories(ctx context.Context, limit int) ([]RepoSummary, error)
 	ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error)
 	GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error)
-	GetOpenPullRequestByHead(ctx context.Context, repo Repository, head string) (PullRequest, bool, error)
+	GetOpenPullRequestByHead(ctx context.Context, repo Repository, head string, base string) (PullRequest, bool, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
 	EnsurePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error)
 	CreateIssue(ctx context.Context, input CreateIssueInput) (Issue, error)
@@ -461,22 +461,29 @@ func (c *GhClient) CreatePullRequest(ctx context.Context, input CreatePullReques
 	return pr, nil
 }
 
-// GetOpenPullRequestByHead returns the open PR whose head branch is `head`, if
-// one exists, via `gh pr list`. The boolean is false (with a nil error) when no
+// GetOpenPullRequestByHead returns the open PR whose head branch is `head` and
+// whose base branch is `base`, if one exists, via `gh pr list`. Filtering by
+// both head and base makes the match exact: GitHub guarantees a single open PR
+// per (head, same-base) pair — that uniqueness is exactly the 422 "a pull
+// request already exists" case. The boolean is false (with a nil error) when no
 // open PR is found. `gh pr list --json` field names differ from the REST API
 // (url/headRefOid/baseRefName), so the response is decoded through a dedicated
 // wire shape and mapped onto PullRequest.
-func (c *GhClient) GetOpenPullRequestByHead(ctx context.Context, repo Repository, head string) (PullRequest, bool, error) {
+func (c *GhClient) GetOpenPullRequestByHead(ctx context.Context, repo Repository, head string, base string) (PullRequest, bool, error) {
 	if strings.TrimSpace(repo.FullName()) == "" {
 		return PullRequest{}, false, fmt.Errorf("repository owner/name is required")
 	}
 	if strings.TrimSpace(head) == "" {
 		return PullRequest{}, false, fmt.Errorf("head branch is required")
 	}
+	if strings.TrimSpace(base) == "" {
+		return PullRequest{}, false, fmt.Errorf("base branch is required")
+	}
 	result, err := c.run(ctx, false,
 		"pr", "list",
 		"--repo", repo.FullName(),
 		"--head", head,
+		"--base", base,
 		"--state", "open",
 		"--json", "number,url,headRefOid,baseRefName,state",
 	)
@@ -514,7 +521,7 @@ func (c *GhClient) GetOpenPullRequestByHead(ctx context.Context, repo Repository
 // where two finalizers (or an out-of-band PR) turn a benign "already exists"
 // into a hard error.
 func (c *GhClient) EnsurePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error) {
-	if existing, ok, err := c.GetOpenPullRequestByHead(ctx, input.Repo, input.Head); err != nil {
+	if existing, ok, err := c.GetOpenPullRequestByHead(ctx, input.Repo, input.Head, input.Base); err != nil {
 		return PullRequest{}, err
 	} else if ok {
 		return existing, nil
@@ -527,7 +534,7 @@ func (c *GhClient) EnsurePullRequest(ctx context.Context, input CreatePullReques
 		return PullRequest{}, err
 	}
 	// A concurrent create won the race; adopt the now-existing open PR.
-	if existing, ok, qerr := c.GetOpenPullRequestByHead(ctx, input.Repo, input.Head); qerr != nil {
+	if existing, ok, qerr := c.GetOpenPullRequestByHead(ctx, input.Repo, input.Head, input.Base); qerr != nil {
 		return PullRequest{}, qerr
 	} else if ok {
 		return existing, nil
@@ -1154,7 +1161,7 @@ func (NoopClient) GetPullRequest(context.Context, Repository, int64) (PullReques
 	return PullRequest{}, errors.ErrUnsupported
 }
 
-func (NoopClient) GetOpenPullRequestByHead(context.Context, Repository, string) (PullRequest, bool, error) {
+func (NoopClient) GetOpenPullRequestByHead(context.Context, Repository, string, string) (PullRequest, bool, error) {
 	return PullRequest{}, false, errors.ErrUnsupported
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -810,6 +810,126 @@ func TestCreatePullRequestFetchesCreatedPR(t *testing.T) {
 	runner.wantArgs(t, 1, "api", "repos/jerryfane/gitmoot/pulls/7")
 }
 
+func TestGetOpenPullRequestByHead(t *testing.T) {
+	repo := Repository{Owner: "jerryfane", Name: "gitmoot"}
+
+	t.Run("found", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{
+			{Stdout: `[{"number":7,"url":"https://github.com/jerryfane/gitmoot/pull/7","headRefOid":"abc123","baseRefName":"main","state":"OPEN"}]`},
+		}}
+		client := GhClient{Runner: runner}
+		pr, ok, err := client.GetOpenPullRequestByHead(context.Background(), repo, "task-7")
+		if err != nil || !ok {
+			t.Fatalf("GetOpenPullRequestByHead = (%+v, %v, %v), want found", pr, ok, err)
+		}
+		if pr.Number != 7 || pr.HeadSHA != "abc123" || pr.BaseRef != "main" || pr.HeadRef != "task-7" || pr.State != "open" {
+			t.Fatalf("pr = %+v", pr)
+		}
+		runner.wantArgs(t, 0,
+			"pr", "list",
+			"--repo", "jerryfane/gitmoot",
+			"--head", "task-7",
+			"--state", "open",
+			"--json", "number,url,headRefOid,baseRefName,state",
+		)
+	})
+
+	t.Run("none", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{Stdout: `[]`}}}
+		client := GhClient{Runner: runner}
+		_, ok, err := client.GetOpenPullRequestByHead(context.Background(), repo, "task-7")
+		if err != nil || ok {
+			t.Fatalf("GetOpenPullRequestByHead = (ok=%v, err=%v), want (false, nil)", ok, err)
+		}
+	})
+}
+
+func TestEnsurePullRequest(t *testing.T) {
+	repo := Repository{Owner: "jerryfane", Name: "gitmoot"}
+	input := CreatePullRequestInput{Repo: repo, Title: "Task 7", Body: "body", Head: "task-7", Base: "main"}
+
+	t.Run("adopts existing open head PR without creating", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{
+			{Stdout: `[{"number":9,"url":"https://github.com/jerryfane/gitmoot/pull/9","headRefOid":"def456","baseRefName":"main","state":"OPEN"}]`},
+		}}
+		client := GhClient{Runner: runner}
+		pr, err := client.EnsurePullRequest(context.Background(), input)
+		if err != nil {
+			t.Fatalf("EnsurePullRequest returned error: %v", err)
+		}
+		if pr.Number != 9 || pr.HeadSHA != "def456" {
+			t.Fatalf("pr = %+v", pr)
+		}
+		// Only the query ran; no create.
+		if len(runner.calls) != 1 {
+			t.Fatalf("calls = %v, want exactly the query call", runner.calls)
+		}
+		runner.wantArgs(t, 0, "pr", "list", "--repo", "jerryfane/gitmoot", "--head", "task-7", "--state", "open", "--json", "number,url,headRefOid,baseRefName,state")
+	})
+
+	t.Run("creates when absent", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{
+			{Stdout: `[]`}, // query: none
+			{Stdout: "https://github.com/jerryfane/gitmoot/pull/11\n"}, // create
+			{Stdout: `{"number":11,"title":"Task 7","state":"open","html_url":"https://github.com/jerryfane/gitmoot/pull/11","head":{"ref":"task-7","sha":"sha11"},"base":{"ref":"main"}}`}, // getPullRequest
+		}}
+		client := GhClient{Runner: runner}
+		pr, err := client.EnsurePullRequest(context.Background(), input)
+		if err != nil {
+			t.Fatalf("EnsurePullRequest returned error: %v", err)
+		}
+		if pr.Number != 11 || pr.HeadSHA != "sha11" {
+			t.Fatalf("pr = %+v", pr)
+		}
+		runner.wantArgs(t, 0, "pr", "list", "--repo", "jerryfane/gitmoot", "--head", "task-7", "--state", "open", "--json", "number,url,headRefOid,baseRefName,state")
+		runner.wantArgs(t, 1, "pr", "create", "--repo", "jerryfane/gitmoot", "--title", "Task 7", "--body", "body", "--head", "task-7", "--base", "main")
+	})
+
+	t.Run("re-queries and adopts on 422 already exists race", func(t *testing.T) {
+		runner := &fakeRunner{
+			results: []subprocess.Result{
+				{Stdout: `[]`}, // query: none (TOCTOU window)
+				{Stderr: "pull request create failed: GraphQL: A pull request already exists for jerryfane:task-7. (createPullRequest)"},                  // create: 422
+				{Stdout: `[{"number":13,"url":"https://github.com/jerryfane/gitmoot/pull/13","headRefOid":"sha13","baseRefName":"main","state":"OPEN"}]`}, // re-query: winner
+			},
+			errs: []error{
+				nil,
+				errors.New("exit status 1"),
+				nil,
+			},
+		}
+		client := GhClient{Runner: runner}
+		pr, err := client.EnsurePullRequest(context.Background(), input)
+		if err != nil {
+			t.Fatalf("EnsurePullRequest returned error: %v", err)
+		}
+		if pr.Number != 13 || pr.HeadSHA != "sha13" {
+			t.Fatalf("pr = %+v", pr)
+		}
+		// query, create (422), re-query.
+		if len(runner.calls) != 3 {
+			t.Fatalf("calls = %v, want query+create+requery", runner.calls)
+		}
+	})
+
+	t.Run("propagates a non-422 create error", func(t *testing.T) {
+		runner := &fakeRunner{
+			results: []subprocess.Result{
+				{Stdout: `[]`},
+				{Stderr: "HTTP 403: forbidden"},
+			},
+			errs: []error{nil, errors.New("exit status 1")},
+		}
+		client := GhClient{Runner: runner}
+		if _, err := client.EnsurePullRequest(context.Background(), input); err == nil {
+			t.Fatal("expected a non-422 create error to propagate")
+		}
+		if len(runner.calls) != 2 {
+			t.Fatalf("calls = %v, want query+create only (no re-query on a hard error)", runner.calls)
+		}
+	})
+}
+
 type fakeRunner struct {
 	results []subprocess.Result
 	errs    []error

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -818,7 +818,7 @@ func TestGetOpenPullRequestByHead(t *testing.T) {
 			{Stdout: `[{"number":7,"url":"https://github.com/jerryfane/gitmoot/pull/7","headRefOid":"abc123","baseRefName":"main","state":"OPEN"}]`},
 		}}
 		client := GhClient{Runner: runner}
-		pr, ok, err := client.GetOpenPullRequestByHead(context.Background(), repo, "task-7")
+		pr, ok, err := client.GetOpenPullRequestByHead(context.Background(), repo, "task-7", "main")
 		if err != nil || !ok {
 			t.Fatalf("GetOpenPullRequestByHead = (%+v, %v, %v), want found", pr, ok, err)
 		}
@@ -829,6 +829,7 @@ func TestGetOpenPullRequestByHead(t *testing.T) {
 			"pr", "list",
 			"--repo", "jerryfane/gitmoot",
 			"--head", "task-7",
+			"--base", "main",
 			"--state", "open",
 			"--json", "number,url,headRefOid,baseRefName,state",
 		)
@@ -837,7 +838,7 @@ func TestGetOpenPullRequestByHead(t *testing.T) {
 	t.Run("none", func(t *testing.T) {
 		runner := &fakeRunner{results: []subprocess.Result{{Stdout: `[]`}}}
 		client := GhClient{Runner: runner}
-		_, ok, err := client.GetOpenPullRequestByHead(context.Background(), repo, "task-7")
+		_, ok, err := client.GetOpenPullRequestByHead(context.Background(), repo, "task-7", "main")
 		if err != nil || ok {
 			t.Fatalf("GetOpenPullRequestByHead = (ok=%v, err=%v), want (false, nil)", ok, err)
 		}
@@ -864,7 +865,7 @@ func TestEnsurePullRequest(t *testing.T) {
 		if len(runner.calls) != 1 {
 			t.Fatalf("calls = %v, want exactly the query call", runner.calls)
 		}
-		runner.wantArgs(t, 0, "pr", "list", "--repo", "jerryfane/gitmoot", "--head", "task-7", "--state", "open", "--json", "number,url,headRefOid,baseRefName,state")
+		runner.wantArgs(t, 0, "pr", "list", "--repo", "jerryfane/gitmoot", "--head", "task-7", "--base", "main", "--state", "open", "--json", "number,url,headRefOid,baseRefName,state")
 	})
 
 	t.Run("creates when absent", func(t *testing.T) {
@@ -881,7 +882,7 @@ func TestEnsurePullRequest(t *testing.T) {
 		if pr.Number != 11 || pr.HeadSHA != "sha11" {
 			t.Fatalf("pr = %+v", pr)
 		}
-		runner.wantArgs(t, 0, "pr", "list", "--repo", "jerryfane/gitmoot", "--head", "task-7", "--state", "open", "--json", "number,url,headRefOid,baseRefName,state")
+		runner.wantArgs(t, 0, "pr", "list", "--repo", "jerryfane/gitmoot", "--head", "task-7", "--base", "main", "--state", "open", "--json", "number,url,headRefOid,baseRefName,state")
 		runner.wantArgs(t, 1, "pr", "create", "--repo", "jerryfane/gitmoot", "--title", "Task 7", "--body", "body", "--head", "task-7", "--base", "main")
 	})
 
@@ -926,6 +927,34 @@ func TestEnsurePullRequest(t *testing.T) {
 		}
 		if len(runner.calls) != 2 {
 			t.Fatalf("calls = %v, want query+create only (no re-query on a hard error)", runner.calls)
+		}
+	})
+
+	t.Run("returns the 422 error when the re-query still finds nothing", func(t *testing.T) {
+		createErr := errors.New("pull request create failed: GraphQL: A pull request already exists for jerryfane:task-7. (createPullRequest)")
+		runner := &fakeRunner{
+			results: []subprocess.Result{
+				{Stdout: `[]`}, // query: none
+				{Stderr: "pull request create failed: A pull request already exists"}, // create: 422
+				{Stdout: `[]`}, // re-query: still none (e.g. the existing PR targets a different base)
+			},
+			errs: []error{
+				nil,
+				createErr,
+				nil,
+			},
+		}
+		client := GhClient{Runner: runner}
+		_, err := client.EnsurePullRequest(context.Background(), input)
+		if err == nil {
+			t.Fatal("expected the original 422 error when the re-query finds no adoptable PR")
+		}
+		if !errors.Is(err, createErr) {
+			t.Fatalf("err = %v, want the original create (422) error", err)
+		}
+		// query, create (422), re-query — then surface the original error.
+		if len(runner.calls) != 3 {
+			t.Fatalf("calls = %v, want query+create+requery", runner.calls)
 		}
 	})
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -130,6 +130,27 @@ func (e BlockedError) Error() string {
 	return "workflow blocked: " + e.Reason
 }
 
+// AdvanceError wraps an error that occurred while advancing a job *after* the
+// agent delivery + job already succeeded terminally. RunJob returns the
+// agent's result alongside it, so callers can distinguish a benign
+// post-success advance condition (e.g. a merge-gate block on a freshly-opened
+// PR, or a 422 "PR already exists" race) from a genuine delivery/run failure
+// and surface the persisted terminal-success result instead of discarding it.
+type AdvanceError struct {
+	Err error
+}
+
+func (e AdvanceError) Error() string {
+	if e.Err == nil {
+		return "workflow advance failed"
+	}
+	return "workflow advance failed: " + e.Err.Error()
+}
+
+func (e AdvanceError) Unwrap() error {
+	return e.Err
+}
+
 func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEvent) error {
 	if err := e.validate(); err != nil {
 		return err
@@ -262,7 +283,11 @@ func (e Engine) RunJob(ctx context.Context, jobID string, agent runtime.Agent, a
 		}
 	}
 	if err := e.AdvanceJob(ctx, jobID); err != nil {
-		return result, err
+		// The agent delivery and the job itself already succeeded; only this
+		// post-success advance step errored. Wrap it so callers can recover the
+		// persisted terminal-success result (the result is in hand) instead of
+		// discarding it. Delivery/run failures above stay raw.
+		return result, AdvanceError{Err: err}
 	}
 	if err := e.Store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: "advance_completed", Message: "workflow advancement completed"}); err != nil {
 		return result, err

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -987,6 +987,97 @@ func TestEngineRunJobAdvancesCompletedResult(t *testing.T) {
 	mustJob(t, store, "review-audit-task-7-review-1")
 }
 
+// A benign post-success advance condition (here: a merge-gate block on the
+// freshly-"opened" PR) makes AdvanceJob return after the agent delivery + job
+// already succeeded terminally. RunJob must wrap that error in AdvanceError
+// (so callers can recover the persisted result) while still returning the
+// result; the job stays JobSucceeded.
+func TestEngineRunJobWrapsPostSuccessAdvanceError(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	// A pending (not-ready) merge gate blocks the no-reviewers tail -> AdvanceJob
+	// returns a BlockedError AFTER the result is stored.
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Reason: "ci is pending"}}
+	agent := runtime.Agent{Name: "lead", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "lead"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"implemented","summary":"opened PR","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:          "implement-job",
+		Agent:       "lead",
+		Action:      "implement",
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		HeadSHA:     "head123",
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	result, err := engine.RunJob(ctx, "implement-job", agent, adapter)
+
+	var advErr AdvanceError
+	if !errors.As(err, &advErr) {
+		t.Fatalf("RunJob error = %v, want AdvanceError", err)
+	}
+	// The wrapped cause is still reachable; the result is in hand.
+	var blocked BlockedError
+	if !errors.As(advErr, &blocked) || blocked.Reason != "ci is pending" {
+		t.Fatalf("AdvanceError did not wrap the merge-gate BlockedError: %v", advErr)
+	}
+	if result.Decision != "implemented" || result.Summary != "opened PR" {
+		t.Fatalf("result = %+v, want the delivered implemented result", result)
+	}
+	// The job is terminally succeeded despite the post-success advance error.
+	job := mustJob(t, store, "implement-job")
+	if job.State != string(JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded", job.State)
+	}
+}
+
+// A delivery/run failure (here: a non-existent runtime command) errors BEFORE
+// AdvanceJob, so RunJob must return that error raw, NOT wrapped in AdvanceError,
+// and the job must not be JobSucceeded.
+func TestEngineRunJobDeliveryFailureStaysRaw(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	agent := runtime.Agent{Name: "lead", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "lead"}
+	// A delivery error before the result is stored.
+	adapter := &fakeDelivery{err: errors.New("runtime exploded")}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:        "implement-job",
+		Agent:     "lead",
+		Action:    "implement",
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-7",
+		TaskID:    "task-7",
+		LeadAgent: "lead",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	_, err := engine.RunJob(ctx, "implement-job", agent, adapter)
+
+	if err == nil {
+		t.Fatal("RunJob returned nil error, want delivery failure")
+	}
+	var advErr AdvanceError
+	if errors.As(err, &advErr) {
+		t.Fatalf("delivery failure wrapped as AdvanceError: %v", err)
+	}
+	job := mustJob(t, store, "implement-job")
+	if job.State == string(JobSucceeded) {
+		t.Fatalf("job state = %q, want non-succeeded after delivery failure", job.State)
+	}
+}
+
 func TestEngineRunJobAllowsDelegatedImplementWithOriginalBranchLock(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -684,6 +684,7 @@ type fakeDelivery struct {
 	prompts   []string
 	models    []string
 	onDeliver func()
+	err       error
 }
 
 func (f *fakeDelivery) Deliver(_ context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
@@ -691,6 +692,9 @@ func (f *fakeDelivery) Deliver(_ context.Context, _ runtime.Agent, job runtime.J
 	f.models = append(f.models, job.Model)
 	if f.onDeliver != nil {
 		f.onDeliver()
+	}
+	if f.err != nil {
+		return runtime.Result{}, f.err
 	}
 	index := len(f.prompts) - 1
 	result := runtime.Result{}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -268,6 +268,17 @@ implement-advance and the daemon's GitHub PR-watcher — so a PR opened either w
 stays free of native review fan-out. The flag defaults off; leave it off for the
 full native review fan-out, which is byte-identical to prior behavior.
 
+When a synchronous `agent implement`/`run`/`ask`/`review`/`orchestrate` job
+delivers and **succeeds terminally** but a benign *post-success* advancement step
+errors — for example a merge-gate block on the freshly-opened PR, or a 422
+"a pull request already exists" race — the command no longer discards the result.
+It **exits 0** with the agent result on stdout (in JSON mode this includes an
+additive `advance_error` field carrying the advance warning, omitted when there
+is none), prints `advance warning: …` to stderr, and shows an `advance_error:`
+line in human output. Genuine non-terminal failures (the job did not reach
+`succeeded`) still exit non-zero as before. A normal success with no advance error
+is byte-identical to prior behavior — no `advance_error` field is emitted.
+
 Start an orchestra of agents with `gitmoot orchestrate`:
 
 ```sh

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -286,6 +286,17 @@ implement-advance and the daemon's GitHub PR-watcher — so a PR opened either w
 stays free of native review fan-out. The flag defaults off; leave it off for the
 full native review fan-out, which is byte-identical to prior behavior.
 
+When a synchronous `agent implement`/`run`/`ask`/`review`/`orchestrate` job
+delivers and **succeeds terminally** but a benign *post-success* advancement step
+errors — for example a merge-gate block on the freshly-opened PR, or a 422
+"a pull request already exists" race — the command no longer discards the result.
+It **exits 0** with the agent result on stdout (in JSON mode this includes an
+additive `advance_error` field carrying the advance warning, omitted when there
+is none), prints `advance warning: …` to stderr, and shows an `advance_error:`
+line in human output. Genuine non-terminal failures (the job did not reach
+`succeeded`) still exit non-zero as before. A normal success with no advance error
+is byte-identical to prior behavior — no `advance_error` field is emitted.
+
 Start an orchestra of agents with `gitmoot orchestrate`:
 
 ```sh

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5687,6 +5687,17 @@ implement-advance and the daemon's GitHub PR-watcher — so a PR opened either w
 stays free of native review fan-out. The flag defaults off; leave it off for the
 full native review fan-out, which is byte-identical to prior behavior.
 
+When a synchronous `agent implement`/`run`/`ask`/`review`/`orchestrate` job
+delivers and **succeeds terminally** but a benign *post-success* advancement step
+errors — for example a merge-gate block on the freshly-opened PR, or a 422
+"a pull request already exists" race — the command no longer discards the result.
+It **exits 0** with the agent result on stdout (in JSON mode this includes an
+additive `advance_error` field carrying the advance warning, omitted when there
+is none), prints `advance warning: …` to stderr, and shows an `advance_error:`
+line in human output. Genuine non-terminal failures (the job did not reach
+`succeeded`) still exit non-zero as before. A normal success with no advance error
+is byte-identical to prior behavior — no `advance_error` field is emitted.
+
 Start an orchestra of agents with `gitmoot orchestrate`:
 
 ```sh


### PR DESCRIPTION
Closes #387.

`gitmoot agent implement … --json` could print **nothing** + exit non-zero even though the implement + PR genuinely succeeded, because a benign **post-success** advance condition (a merge-gate block on the freshly-opened PR, or a 422 "PR already exists" race) made the in-process advance return an error and the persisted result was discarded. Fixed in two parts.

## Part A — never lose a terminal-success result
- New typed **`workflow.AdvanceError{Err}`** (mirrors `BlockedError`, with `Unwrap`); `engine.RunJob` wraps **only** the post-delivery `AdvanceJob` error (delivery/run failures stay raw).
- `localAgentJobOutput` gains an additive **`advance_error`** field. `dispatchLocalAgentJob`, on a `RunJob` error, recovers via `recoverAdvanceErrorOutput`: `errors.As(AdvanceError)` + re-fetch the job + only when it reached **`JobSucceeded`** → build the normal success output, set `advance_error`, and return **nil**. Genuine non-terminal failures still error.
- CLI: the result JSON goes to **stdout**, the advance warning to **stderr**, **exit 0** on terminal success (per [clig.dev](https://clig.dev/)). Fixes implement/ask/run/review/orchestrate at once (shared `dispatchAgentCommand`).

## Part B — idempotent PR create-or-get
- New **`github.EnsurePullRequest`**: query the open PR for `head`→`base` (`GetOpenPullRequestByHead`, **base-filtered** so it's unique) → adopt; else create; on a 422 "already exists", re-query + adopt. `FinalizeImplementation` now calls it instead of `CreatePullRequest`, so the 422 race resolves to the same PR instead of a `BlockedError`. Genuine create failures still surface as `BlockedError`.

## Review fixes (3-finder review → 3 PLAUSIBLE, all addressed)
- base-filter the PR query (no `wire[0]` ambiguity across two bases);
- extracted the recovery glue into `recoverAdvanceErrorOutput` + a direct unit test (the previously-untested wiring);
- added the create-422-then-empty-requery fallback test.

## Verification
- Full Go gate green: `build`/`vet`/`test ./...` (28 pkgs) / `-race ./internal/workflow/` (153s); gofmt clean. Rebased clean onto `main` (disjoint from #391).
- Tests: `AdvanceError` wrap-vs-raw; **`TestRecoverAdvanceErrorOutput`** (real store + `AdvanceError` on a `succeeded` job → recovered output with `advance_error`; plain error / non-succeeded → not recovered) — the integration heart of the fix; `EnsurePullRequest` adopt/create/422-requery/hard-error; `FinalizeImplementation` adopts without creating.
- A *live* advance-error/422 reproduction needs real GitHub PR + merge-gate state that isn't cheaply triggerable; the recovery-glue + EnsurePullRequest integration tests above cover the logic end-to-end. Default success path (no advance error) is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
