### PR TITLE
docs: document running one agent's jobs concurrently (managed types vs single instances)

### DIFF
--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -325,6 +325,14 @@ gitmoot agent gc
 `agent type set --model <name>` (or `[agents.<type>].model` in config) sets the
 default runtime model for that managed agent type.
 
+A registered single instance **shadows** a managed type of the same name:
+dispatch resolves `gitmoot agent <name>` to a registered single instance before a
+type, so force the type with `--type <name>` (or do not register a single
+instance of that name). Managed-type auto-spin and `[parallel_sessions]`
+temp-session forking happen on the **background** path only — a foreground
+`gitmoot agent ask <type> --type <type>` returns `agent not found`; use
+`--background`. See WORKFLOWS.md → "Running one agent's jobs in parallel".
+
 ## Agent Templates
 
 Install or refresh the built-in thermo review template:

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -401,6 +401,39 @@ than one, or forkable temporary workers. By default `[parallel_sessions]` uses
 serialized; same-runtime Codex/Claude jobs can fork only when the action is
 eligible and implementation jobs have a safe task worktree.
 
+### Running one agent's jobs in parallel
+
+One registered agent serves one **foreground** ask at a time: `gitmoot agent ask
+<name>` pins a single resumable runtime session, serialized by the
+`runtime:<runtime>:<runtime_ref>` lock. Foreground asks do not auto-fork — to run
+the *same* agent on several questions at once, dispatch them as **background**
+jobs, where two mechanisms spin extra sessions for you:
+
+1. **Temp-session forking (default, zero-config).** `[parallel_sessions]` ships
+   with `same_session = "fork_temp_session"` and `max_temp_sessions_per_agent =
+   4`: when a registered agent's session is busy and another **eligible**
+   background job (`ask`/`review`/`implement`) is queued for it, the daemon forks
+   a throwaway temp worker from that agent so the jobs run in parallel. Same
+   runtime only (Codex/Claude/Kimi); same-checkout work stays serialized; an
+   `implement` fork needs a safe task worktree. Nothing to configure.
+2. **Managed agent types (`max_background`).** `gitmoot agent type set <type>
+   --max-background N` defines a *pool* of named, reusable managed instances.
+   Dispatch to the type with `gitmoot agent run <type> --type <type>
+   --background …` and the daemon reuses an idle instance or spins a new one, up
+   to `N`.
+
+Both only deliver real parallelism when the daemon has job slots: raise
+`--workers` above the default `1` (e.g. `--workers 6`) so `max_background`
+instances / temp sessions actually run concurrently.
+
+**Precedence — a single instance shadows a same-named type.** Dispatch resolves a
+registered agent by name **first**, so if you `gitmoot agent start researcher`
+*and* `gitmoot agent type set researcher`, plain `researcher` always uses the
+single instance. Force the managed type with `--type researcher` (or don't
+register a single instance of that name). A **foreground** ask cannot route to a
+type today — `gitmoot agent ask <type> --type <type>` errors `agent not found`;
+use `--background`.
+
 ## Multi-Repo Work
 
 Agents are global identities with explicit per-repo access. When working across

--- a/website/docs/concepts/agents-templates-jobs-locks.md
+++ b/website/docs/concepts/agents-templates-jobs-locks.md
@@ -102,6 +102,33 @@ reusable, addressable, trainable, and resume a warm session; ephemeral workers
 are zero-setup and self-cleaning but cold-spawn each time and carry no
 accumulated identity.
 
+## Running one agent's jobs concurrently
+
+A single registered agent answers one **foreground** ask at a time —
+`gitmoot agent ask <name>` pins one resumable runtime session, serialized by the
+runtime session lock. To run the *same* agent on several tasks at once, dispatch
+**background** jobs; the daemon spins extra sessions two ways:
+
+- **Temp-session forking** — the default. `[parallel_sessions]` ships with
+  `same_session = "fork_temp_session"` and `max_temp_sessions_per_agent = 4`, so a
+  busy registered agent's extra eligible background jobs (`ask` / `review` /
+  `implement`) fork throwaway **temp workers** that run in parallel (same runtime
+  only; same-checkout work stays serialized; `implement` needs a task worktree).
+  Zero configuration — this is the "temp worker" column in the table above.
+- **Managed agent types** — `gitmoot agent type set <type> --max-background N`
+  defines a reusable, addressable pool. Dispatch with
+  `gitmoot agent run <type> --type <type> --background …` and the daemon reuses an
+  idle instance or spins a new one, up to `N`.
+
+Both need daemon **job slots** to run at the same time: `max_background` and temp
+sessions are session slots, but the daemon still executes at most `--workers`
+jobs at once (default `1`; raise it, e.g. `--workers 6`).
+
+**Precedence:** dispatch resolves a registered single instance by name *before* a
+managed type, so a single agent named `researcher` shadows a `researcher` type —
+force the type with `--type researcher`. Foreground `gitmoot agent ask <type>`
+cannot route to a type today (it returns `agent not found`); use `--background`.
+
 ## Locks
 
 Gitmoot uses separate locks for separate resources:

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -334,6 +334,15 @@ gitmoot agent gc
 `agent type set --model <name>` (or `[agents.<type>].model` in config) sets the
 default runtime model for that managed agent type.
 
+A registered single instance **shadows** a managed type of the same name:
+dispatch resolves `gitmoot agent <name>` to a registered single instance before a
+type, so force the type with `--type <name>` (or do not register a single
+instance of that name). Managed-type auto-spin and `[parallel_sessions]`
+temp-session forking happen on the **background** path only — a foreground
+`gitmoot agent ask <type> --type <type>` returns `agent not found`; use
+`--background`. See [Running one agent's jobs
+concurrently](../concepts/agents-templates-jobs-locks.md#running-one-agents-jobs-concurrently).
+
 ## Agent Templates
 
 Install or refresh the built-in thermo review template:

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5744,6 +5744,14 @@ gitmoot agent gc
 `agent type set --model <name>` (or `[agents.<type>].model` in config) sets the
 default runtime model for that managed agent type.
 
+A registered single instance **shadows** a managed type of the same name:
+dispatch resolves `gitmoot agent <name>` to a registered single instance before a
+type, so force the type with `--type <name>` (or do not register a single
+instance of that name). Managed-type auto-spin and `[parallel_sessions]`
+temp-session forking happen on the **background** path only — a foreground
+`gitmoot agent ask <type> --type <type>` returns `agent not found`; use
+`--background`. See WORKFLOWS.md → "Running one agent's jobs in parallel".
+
 ## Agent Templates
 
 Install or refresh the built-in thermo review template:
@@ -6482,6 +6490,39 @@ than one, or forkable temporary workers. By default `[parallel_sessions]` uses
 `eligible_actions = ["ask", "review", "implement"]`. Same-checkout work remains
 serialized; same-runtime Codex/Claude jobs can fork only when the action is
 eligible and implementation jobs have a safe task worktree.
+
+### Running one agent's jobs in parallel
+
+One registered agent serves one **foreground** ask at a time: `gitmoot agent ask
+<name>` pins a single resumable runtime session, serialized by the
+`runtime:<runtime>:<runtime_ref>` lock. Foreground asks do not auto-fork — to run
+the *same* agent on several questions at once, dispatch them as **background**
+jobs, where two mechanisms spin extra sessions for you:
+
+1. **Temp-session forking (default, zero-config).** `[parallel_sessions]` ships
+   with `same_session = "fork_temp_session"` and `max_temp_sessions_per_agent =
+   4`: when a registered agent's session is busy and another **eligible**
+   background job (`ask`/`review`/`implement`) is queued for it, the daemon forks
+   a throwaway temp worker from that agent so the jobs run in parallel. Same
+   runtime only (Codex/Claude/Kimi); same-checkout work stays serialized; an
+   `implement` fork needs a safe task worktree. Nothing to configure.
+2. **Managed agent types (`max_background`).** `gitmoot agent type set <type>
+   --max-background N` defines a *pool* of named, reusable managed instances.
+   Dispatch to the type with `gitmoot agent run <type> --type <type>
+   --background …` and the daemon reuses an idle instance or spins a new one, up
+   to `N`.
+
+Both only deliver real parallelism when the daemon has job slots: raise
+`--workers` above the default `1` (e.g. `--workers 6`) so `max_background`
+instances / temp sessions actually run concurrently.
+
+**Precedence — a single instance shadows a same-named type.** Dispatch resolves a
+registered agent by name **first**, so if you `gitmoot agent start researcher`
+*and* `gitmoot agent type set researcher`, plain `researcher` always uses the
+single instance. Force the managed type with `--type researcher` (or don't
+register a single instance of that name). A **foreground** ask cannot route to a
+type today — `gitmoot agent ask <type> --type <type>` errors `agent not found`;
+use `--background`.
 
 ## Multi-Repo Work
 


### PR DESCRIPTION
## Summary

Documents how to run **one agent on several jobs concurrently** — previously only one-line mentions of `max_background` / managed agent types existed, with nothing explaining the foreground-vs-background split that makes this confusing (and that led to hand-cloning agents to get parallelism).

Surfaced while converting the `researcher` agent to a managed type: foreground `agent ask` pins one session and serializes, so I'd cloned the instance to run two asks at once. The native mechanisms (temp-session forking + managed types) are background-only and were undocumented.

## What's added

A focused **"Running one agent's jobs concurrently"** section explaining:
- **Foreground** `agent ask <name>` pins one resumable session (serialized by the runtime-session lock); **background** dispatch auto-spins extra sessions.
- **Temp-session forking** (`[parallel_sessions]`, default `same_session = fork_temp_session`, `max_temp_sessions_per_agent = 4`) — zero-config; a busy registered agent's extra eligible background jobs fork throwaway temp workers.
- **Managed agent types** (`agent type set <type> --max-background N`) — an addressable, reusable pool; dispatch via `--type <type> --background`.
- **Single-instance-shadows-type** precedence (`GetAgent` resolves first) + the `--type` flag to force the type.
- Both need daemon `--workers > 1` for real concurrency (`max_background`/temp = session slots; `--workers` = job slots).

## Both doc trees (per AGENTS.md two-tree rule)

| In-repo | Website |
|---|---|
| `skills/gitmoot/references/WORKFLOWS.md` (new section) | `website/docs/concepts/agents-templates-jobs-locks.md` (new section) |
| `skills/gitmoot/references/CLI.md` (precedence note) | `website/docs/reference/cli.md` (precedence note) |

`website/static/llms-full.txt` regenerated via `npm run build:llms`.

## Verification
- `cd website && npm run build` passes (`onBrokenLinks: throw` — validates the new cross-page anchor link from `reference/cli.md` → the concepts section).
- `go build ./...` passes (docs-only; no Go change).

Docs-only. Relates to #395 (the foreground-`ask`-to-type product gap this documents as a current limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
