### PR TITLE
fix(daemon): persist skip-native-review-fanout before opening the PR (#390)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3100,6 +3100,21 @@ func (f daemonImplementationFinalizer) FinalizeImplementation(ctx context.Contex
 	if branch != task.Branch {
 		return payload, workflow.BlockedError{Reason: fmt.Sprintf("implemented task worktree is on branch %s, not %s", branch, task.Branch)}
 	}
+	// Write-ahead the skip-native-review-fanout flag onto the branch lock as soon
+	// as the branch is confirmed — before EVERY downstream path that proceeds with
+	// a PR: the no-changes-but-PR-exists early return below, the adopt path, and
+	// the fresh EnsurePullRequest create. This closes the #390 TOCTOU: the daemon's
+	// PR-watcher (trigger 2) must never observe a PR for this branch with the flag
+	// still unpersisted. The branch lock already exists (acquired at job start);
+	// SetBranchLockReviewFanout is an idempotent UPDATE keyed by repo+branch and a
+	// no-op if the lock is somehow absent. Written only when set, mirroring the
+	// engine path's default-fast on the common (false) case; the engine's
+	// post-advance write now covers only the non-finalizer path (see engine.go).
+	if payload.SkipNativeReviewFanout {
+		if err := f.Store.SetBranchLockReviewFanout(ctx, payload.Repo, task.Branch, true); err != nil {
+			return payload, fmt.Errorf("persist skip-native-review-fanout before opening PR: %w", err)
+		}
+	}
 	status, err := git.StatusPorcelain(ctx)
 	if err != nil {
 		return payload, fmt.Errorf("inspect implementation diff: %w", err)

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -2953,6 +2953,176 @@ func TestDaemonImplementationFinalizerAdoptsExistingPullRequestViaEnsure(t *test
 	}
 }
 
+// stubSkipFlagAtOpenGitHub records whether the branch lock's skip flag was
+// already persisted at the moment the PR is opened — the #390 invariant: the
+// flag must be durable BEFORE the daemon-watched PR becomes observable, or the
+// PR-watcher can fan out native reviews in the gap.
+type stubSkipFlagAtOpenGitHub struct {
+	github.NoopClient
+	store      *db.Store
+	repo       string
+	branch     string
+	pr         github.PullRequest
+	opened     bool
+	skipAtOpen bool
+}
+
+func (s *stubSkipFlagAtOpenGitHub) EnsurePullRequest(ctx context.Context, _ github.CreatePullRequestInput) (github.PullRequest, error) {
+	s.opened = true
+	if lock, err := s.store.GetBranchLock(ctx, s.repo, s.branch); err == nil {
+		s.skipAtOpen = lock.SkipNativeReviewFanout
+	}
+	return s.pr, nil
+}
+
+// #390: with --skip-native-review-fanout, the finalizer must persist the skip
+// flag onto the branch lock BEFORE it opens the PR, so there is no TOCTOU window
+// in which the daemon's PR-watcher sees the fresh PR with the flag unset.
+func TestDaemonImplementationFinalizerPersistsSkipFanoutBeforeOpeningPR(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	runGit(t, repoDir, "switch", "-c", "task-1")
+	if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("new work\n"), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: repoDir}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	// The branch lock exists from job start; the finalizer flips its flag.
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	gh := &stubSkipFlagAtOpenGitHub{store: store, repo: "owner/repo", branch: "task-1", pr: github.PullRequest{
+		Number:  7,
+		URL:     "https://github.com/owner/repo/pull/7",
+		State:   "open",
+		HeadRef: "task-1",
+		BaseRef: "main",
+	}}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	payload := workflow.JobPayload{
+		Repo:                   "owner/repo",
+		Branch:                 "task-1",
+		GoalID:                 "goal-1",
+		TaskID:                 "task-1",
+		TaskTitle:              "Task 1",
+		LeadAgent:              "lead",
+		SkipNativeReviewFanout: true,
+		Result:                 &workflow.AgentResult{Decision: "implemented", Summary: "done"},
+	}
+
+	if _, err := finalizer.FinalizeImplementation(ctx, db.Job{ID: "job-1", Agent: "lead", Type: "implement"}, payload); err != nil {
+		t.Fatalf("FinalizeImplementation returned error: %v", err)
+	}
+	if !gh.opened {
+		t.Fatal("EnsurePullRequest was never called; cannot assert ordering")
+	}
+	if !gh.skipAtOpen {
+		t.Fatal("#390 regression: branch-lock skip flag was NOT persisted before the PR was opened")
+	}
+	// And the flag is durably set after finalize.
+	lock, err := store.GetBranchLock(ctx, "owner/repo", "task-1")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if !lock.SkipNativeReviewFanout {
+		t.Fatalf("expected lock.SkipNativeReviewFanout = true after finalize, got %+v", lock)
+	}
+}
+
+// #390 edge case: a re-finalize with no new changes and a PR already attached
+// takes the early "no changes" return BEFORE any PR-open path. The skip flag must
+// still be persisted on that path (it is written-ahead as soon as the branch is
+// confirmed), or a retry could leave the flag unset and reintroduce the TOCTOU.
+func TestDaemonImplementationFinalizerPersistsSkipFanoutOnNoChangeReFinalize(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	runGit(t, repoDir, "switch", "-c", "task-1")
+	if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("work\n"), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+	runGit(t, repoDir, "add", "feature.txt")
+	runGit(t, repoDir, "commit", "-m", "work")
+	head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: repoDir}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	// Clean worktree + PR already attached + head unchanged ⇒ the no-changes early
+	// return. NoopClient: no PR-open call is expected on this path.
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}
+	payload := workflow.JobPayload{
+		Repo:                   "owner/repo",
+		Branch:                 "task-1",
+		PullRequest:            7,
+		HeadSHA:                head,
+		GoalID:                 "goal-1",
+		TaskID:                 "task-1",
+		TaskTitle:              "Task 1",
+		LeadAgent:              "lead",
+		SkipNativeReviewFanout: true,
+		Result:                 &workflow.AgentResult{Decision: "implemented", Summary: "no new changes"},
+	}
+
+	finalized, err := finalizer.FinalizeImplementation(ctx, db.Job{ID: "job-1", Agent: "lead", Type: "implement"}, payload)
+	if err != nil {
+		t.Fatalf("FinalizeImplementation returned error: %v", err)
+	}
+	if finalized.PullRequest != 7 {
+		t.Fatalf("finalized.PullRequest = %d, want 7 (unchanged on no-change path)", finalized.PullRequest)
+	}
+	lock, err := store.GetBranchLock(ctx, "owner/repo", "task-1")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if !lock.SkipNativeReviewFanout {
+		t.Fatal("#390 regression: skip flag NOT persisted on the no-changes early-return path")
+	}
+}
+
 func TestDaemonImplementationFinalizerPushesAlreadyCommittedWork(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -494,7 +494,9 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 		if payload.Result.Decision != "implemented" {
 			return nil
 		}
+		finalizerRan := false
 		if e.implementationNeedsFinalizer(ctx, payload) {
+			finalizerRan = true
 			finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
 			if err != nil {
 				return err
@@ -535,12 +537,14 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			// skip_native_review_fanout straight onto the PR event.
 			SkipReviewFanout: payload.SkipNativeReviewFanout,
 		}
-		// Persist the flag onto the branch lock ONLY when set, so the daemon's
-		// PR-watcher path (trigger 2) can read it. Skipping the write on the common
-		// default (false) keeps that path free of an extra lock UPDATE and the new
-		// failure mode it would introduce — a freshly created lock already defaults
-		// to not-skip.
-		if payload.SkipNativeReviewFanout {
+		// Persist the flag onto the branch lock for the daemon's PR-watcher path
+		// (trigger 2). When the finalizer ran it already wrote the flag BEFORE
+		// opening the PR (closing the #390 TOCTOU), so this write would be
+		// redundant; only the non-finalizer path (PR pre-attached, no managed
+		// worktree) reaches the PR with the flag unpersisted. Skipping the write on
+		// the common default (false) keeps that path free of an extra lock UPDATE —
+		// a freshly created lock already defaults to not-skip.
+		if payload.SkipNativeReviewFanout && !finalizerRan {
 			if err := e.Store.SetBranchLockReviewFanout(ctx, payload.Repo, payload.Branch, true); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

Fixes #390 — a TOCTOU where `--skip-native-review-fanout` could be defeated. The skip flag was persisted onto the branch lock (`SetBranchLockReviewFanout`) only *after* `FinalizeImplementation` opened the PR, so the daemon's PR-watcher (trigger 2) could observe the freshly-opened PR with the flag still `false` and fan out native reviews anyway — stalling joe's unattended CI-merge flow.

## Fix (write-ahead ordering / transactional-outbox)

Persist the intent **before** the externally-observable action a separate consumer watches:

- **`internal/cli/daemon.go` `FinalizeImplementation`** — write-ahead `SetBranchLockReviewFanout(repo, branch, true)` (guarded by `SkipNativeReviewFanout`) **as soon as the branch is confirmed**, before *every* downstream path that proceeds with a PR: the no-changes-but-PR-exists early return, the adopt path, and the fresh `EnsurePullRequest` create. The branch lock already exists (acquired at job start); the setter is an idempotent UPDATE (no-op if the lock is absent).
- **`internal/workflow/engine.go`** — the existing post-advance write now runs only when the finalizer did **not** run (`!finalizerRan`), so it still covers the non-finalizer path (PR pre-attached, no managed worktree) without a redundant double-write on the finalizer path.

Trigger 1 (the in-process `SkipReviewFanout` carried on the PR event) is unchanged. Default behavior (flag `false`) is byte-identical — no extra lock UPDATE.

## Why this is complete

`FinalizeImplementation` (`daemon.go:3167`) is the **only** caller of `EnsurePullRequest`/`CreatePullRequest`, i.e. the sole opener of a daemon-watched PR — so write-ahead there closes the window entirely rather than narrowing it.

## Tests

- `TestDaemonImplementationFinalizerPersistsSkipFanoutBeforeOpeningPR` — a fake GitHub client asserts the branch-lock flag is already `true` **at the moment `EnsurePullRequest` is called** (the ordering invariant) on the fresh-create path.
- `TestDaemonImplementationFinalizerPersistsSkipFanoutOnNoChangeReFinalize` — covers the no-changes early-return path (caught in adversarial review): a re-finalize with a PR already attached still persists the flag.

A live E2E of the race is impractical (a timing window); the ordering regression tests are the verification.

`go build/vet/test ./...` + `go test -race ./internal/workflow/ ./internal/cli/` all green.

Closes #390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
