### PR TITLE
feat(daemon): opt-in continuous worker-pool scheduler (#394, part 1 of 2)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -108,7 +108,7 @@ func runDaemonStartWithWorkDir(args []string, workDir string, stdout, stderr io.
 		}
 	}
 
-	started, err := startDaemonChild(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir)
+	started, err := startDaemonChild(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.Scheduler, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir)
 	if err != nil {
 		fmt.Fprintf(stderr, "daemon start: %v\n", err)
 		return 1
@@ -123,6 +123,18 @@ func runDaemonStartWithWorkDir(args []string, workDir string, stdout, stderr io.
 	return 0
 }
 
+// parseSchedulerMode maps the --scheduler flag to the worker-pool toggle (#394).
+func parseSchedulerMode(mode string) (bool, error) {
+	switch strings.TrimSpace(mode) {
+	case "", "barrier":
+		return false, nil
+	case "pool":
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid --scheduler %q: want \"barrier\" or \"pool\"", mode)
+	}
+}
+
 func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("daemon run", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -135,6 +147,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	workers := fs.Int("workers", 1, "worker count")
 	dryRun := fs.Bool("dry-run", false, "run without mutating external systems")
 	watchSkillOptReviews := fs.Bool("watch-skillopt-reviews", false, "poll watched SkillOpt review issue comments and import valid feedback")
+	scheduler := fs.String("scheduler", "barrier", "queued-job scheduler: barrier (default) or pool (#394 opt-in continuous worker pool)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -153,6 +166,11 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "workers must be positive")
 		return 2
 	}
+	usePool, schedErr := parseSchedulerMode(*scheduler)
+	if schedErr != nil {
+		fmt.Fprintln(stderr, schedErr.Error())
+		return 2
+	}
 	if *repoFlag != "" && *dryRun {
 		fmt.Fprintln(stderr, "daemon run --dry-run is only supported without --repo")
 		return 2
@@ -162,7 +180,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	defer stop()
 
 	if *repoFlag == "" {
-		err := runRegisteredRepoSupervisor(ctx, *home, *poll, *workers, *dryRun, *watchSkillOptReviews, session, stdout)
+		err := runRegisteredRepoSupervisor(ctx, *home, *poll, *workers, *dryRun, *watchSkillOptReviews, usePool, session, stdout)
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return 0
 		}
@@ -205,7 +223,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 			Store:        store,
 			GitHub:       gh,
 			Workflow:     &engine,
-		}, store, *workers, session, stdout)
+		}, store, *workers, usePool, session, stdout)
 	})
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return 0
@@ -418,6 +436,8 @@ type daemonStartConfig struct {
 	ExplicitWorkers              bool
 	WatchSkillOptReviews         bool
 	ExplicitWatchSkillOptReviews bool
+	Scheduler                    string
+	ExplicitScheduler            bool
 }
 
 const daemonHelp = -1
@@ -433,6 +453,7 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 	poll := fs.Duration("poll", 30*time.Second, "poll interval")
 	workers := fs.Int("workers", 1, "worker count")
 	watchSkillOptReviews := fs.Bool("watch-skillopt-reviews", false, "poll watched SkillOpt review issue comments and import valid feedback")
+	scheduler := fs.String("scheduler", "barrier", "queued-job scheduler: barrier (default) or pool (#394 opt-in continuous worker pool)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return daemonStartConfig{}, daemonHelp
@@ -450,6 +471,7 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 		Poll:                 *poll,
 		Workers:              *workers,
 		WatchSkillOptReviews: *watchSkillOptReviews,
+		Scheduler:            *scheduler,
 	}
 	fs.Visit(func(f *flag.Flag) {
 		switch f.Name {
@@ -467,6 +489,9 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 			cfg.ExplicitStartConfig = true
 		case "watch-skillopt-reviews":
 			cfg.ExplicitWatchSkillOptReviews = true
+			cfg.ExplicitStartConfig = true
+		case "scheduler":
+			cfg.ExplicitScheduler = true
 			cfg.ExplicitStartConfig = true
 		}
 	})
@@ -488,6 +513,10 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 	}
 	if cfg.Workers <= 0 {
 		fmt.Fprintln(stderr, "workers must be positive")
+		return daemonStartConfig{}, 2
+	}
+	if _, err := parseSchedulerMode(cfg.Scheduler); err != nil {
+		fmt.Fprintln(stderr, err.Error())
 		return daemonStartConfig{}, 2
 	}
 	return cfg, 0
@@ -595,6 +624,9 @@ func overlayDaemonStartArgs(args []string, cfg daemonStartConfig) []string {
 	if cfg.ExplicitWatchSkillOptReviews {
 		args = withDaemonBoolFlagArg(args, "watch-skillopt-reviews", cfg.WatchSkillOptReviews)
 	}
+	if cfg.ExplicitScheduler {
+		args = withDaemonFlagArg(args, "scheduler", cfg.Scheduler)
+	}
 	return args
 }
 
@@ -656,7 +688,7 @@ func currentDaemonPID(state daemonState) (pid int, stale bool, err error) {
 	return pid, false, nil
 }
 
-func startDaemonChild(home string, poll string, workers int, watchSkillOptReviews bool, repo string, session string, state daemonState, workDir string) (daemonMeta, error) {
+func startDaemonChild(home string, poll string, workers int, watchSkillOptReviews bool, scheduler string, repo string, session string, state daemonState, workDir string) (daemonMeta, error) {
 	executable, err := os.Executable()
 	if err != nil {
 		return daemonMeta{}, err
@@ -666,7 +698,7 @@ func startDaemonChild(home string, poll string, workers int, watchSkillOptReview
 		return daemonMeta{}, err
 	}
 	defer logFile.Close()
-	args := daemonChildArgs(home, poll, workers, watchSkillOptReviews, repo, session)
+	args := daemonChildArgs(home, poll, workers, watchSkillOptReviews, scheduler, repo, session)
 	cmd := exec.Command(executable, args...)
 	cmd.Dir = workDir
 	cmd.Stdout = logFile
@@ -689,7 +721,7 @@ func startDaemonChild(home string, poll string, workers int, watchSkillOptReview
 	}, nil
 }
 
-func daemonChildArgs(home string, poll string, workers int, watchSkillOptReviews bool, repo string, session string) []string {
+func daemonChildArgs(home string, poll string, workers int, watchSkillOptReviews bool, scheduler string, repo string, session string) []string {
 	args := []string{"daemon", "run", "--poll", poll, "--workers", strconv.Itoa(workers)}
 	if home != "" {
 		args = append(args, "--home", home)
@@ -702,6 +734,9 @@ func daemonChildArgs(home string, poll string, workers int, watchSkillOptReviews
 	}
 	if watchSkillOptReviews {
 		args = append(args, "--watch-skillopt-reviews")
+	}
+	if usePool, _ := parseSchedulerMode(scheduler); usePool {
+		args = append(args, "--scheduler", "pool")
 	}
 	return args
 }
@@ -829,7 +864,7 @@ func hasWhitespace(value string) bool {
 	return strings.ContainsAny(value, " \t\r\n")
 }
 
-func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Duration, workers int, dryRun bool, watchSkillOptReviews bool, rootFilter string, stdout io.Writer) error {
+func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Duration, workers int, dryRun bool, watchSkillOptReviews bool, usePool bool, rootFilter string, stdout io.Writer) error {
 	return withStoreAndPaths(home, func(paths config.Paths, store *db.Store) error {
 		schedule := registeredRepoSchedule{
 			NextPoll:    map[string]time.Time{},
@@ -840,6 +875,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 		reviewGitHub := newSkillOptGitHubClient()
 		worker := defaultJobWorker(store, stdout, home)
 		worker.CommenterFactory = worker.defaultCommenter
+		worker.UsePool = usePool
 		checkoutLocks := &repoCheckoutLocks{}
 		poller.CheckoutLocks = checkoutLocks
 		var workerErr <-chan error
@@ -884,7 +920,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 	})
 }
 
-func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, store *db.Store, workers int, rootFilter string, stdout io.Writer) error {
+func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, store *db.Store, workers int, usePool bool, rootFilter string, stdout io.Writer) error {
 	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, time.Now().UTC()); err != nil {
 		return err
 	}
@@ -900,6 +936,7 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 	}
 	worker := defaultJobWorker(store, stdout, home)
 	worker.CommenterFactory = worker.defaultCommenter
+	worker.UsePool = usePool
 	var checkoutLock sync.Mutex
 	workerErr := startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
 		checkoutLock.Lock()
@@ -1214,6 +1251,9 @@ type jobWorker struct {
 	CheckoutValidator   func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error)
 	WorkflowFactory     func(string) workflow.Engine
 	CommenterFactory    func(string) github.Client
+	// UsePool selects the opt-in continuous worker-pool scheduler (#394,
+	// --scheduler=pool) over the default per-tick wg.Wait() barrier.
+	UsePool bool
 }
 
 const daemonRunningJobStaleAfter = 30 * time.Minute
@@ -1456,24 +1496,12 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 	if limit <= 0 {
 		return nil
 	}
-	jobs, err := worker.Store.ListQueuedJobs(ctx)
+	if worker.UsePool {
+		return runQueuedJobsForRepoPool(ctx, worker, limit, repoFilter, rootFilter)
+	}
+	pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter)
 	if err != nil {
 		return err
-	}
-	pending := make([]db.Job, 0, len(jobs))
-	for _, job := range jobs {
-		if !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
-			continue
-		}
-		// Operator kill switch (#341): once a tree's root is killed, do not start
-		// any of its queued children. The coordinator's own continuation still runs
-		// so the engine can route through the graceful finalize path; in-flight
-		// children finish normally. Only children (payload.RootJobID points at
-		// another root) are skipped here — the root job itself is never skipped.
-		if queuedChildOfKilledRoot(ctx, worker.Store, job) {
-			continue
-		}
-		pending = append(pending, job)
 	}
 	for len(pending) > 0 {
 		policy, err := worker.parallelSessionPolicy()
@@ -1507,6 +1535,139 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 	return nil
 }
 
+// listPendingQueuedJobs returns the queued jobs eligible to run for this
+// repo/session filter, dropping children of a killed root.
+//
+// Operator kill switch (#341): once a tree's root is killed, do not start any of
+// its queued children. The coordinator's own continuation still runs so the
+// engine can route through the graceful finalize path; in-flight children finish
+// normally. Only children (payload.RootJobID points at another root) are skipped
+// here — the root job itself is never skipped.
+func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string) ([]db.Job, error) {
+	jobs, err := worker.Store.ListQueuedJobs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	pending := make([]db.Job, 0, len(jobs))
+	for _, job := range jobs {
+		if !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
+			continue
+		}
+		if queuedChildOfKilledRoot(ctx, worker.Store, job) {
+			continue
+		}
+		pending = append(pending, job)
+	}
+	return pending, nil
+}
+
+// runQueuedJobsForRepoPool is the opt-in (--scheduler=pool) continuous scheduler
+// for #394. Unlike the per-tick barrier it never blocks the tick on a whole
+// batch: it keeps up to `limit` workers busy and RE-QUERIES the queue as each
+// worker frees, so a job queued *after* dispatch began (e.g. a running job that
+// kicks off a follow-up same-repo job and polls it) is picked up without waiting
+// for the in-flight batch to drain (layer 1).
+//
+// Working-tree safety is preserved by live in-flight checkout accounting: a job
+// whose checkout key is already held by a running job is never dispatched
+// concurrently (layer 2). Same-repo no-worktree jobs therefore still serialize;
+// only distinct checkout keys (e.g. isolated worktrees) run in parallel — a
+// follow-up PR makes the awaited follow-up carry one so the chain can complete.
+//
+// inflightCheckouts/inflightRuntimes/running/firstErr are owned solely by this
+// dispatcher goroutine; worker goroutines communicate only via the done channel,
+// so no lock is required.
+func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, repoFilter string, rootFilter string) error {
+	if limit <= 0 {
+		return nil
+	}
+	policy, perr := worker.parallelSessionPolicy()
+	if perr != nil {
+		policy = config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue}
+	}
+
+	type finished struct {
+		checkoutKey string
+		runtimeKey  string
+		err         error
+	}
+	inflightCheckouts := map[string]bool{}
+	inflightRuntimes := map[string]bool{}
+	running := 0
+	done := make(chan finished, limit)
+	var firstErr error
+
+	reap := func(f finished) {
+		delete(inflightCheckouts, f.checkoutKey)
+		if f.runtimeKey != "" {
+			delete(inflightRuntimes, f.runtimeKey)
+		}
+		running--
+		if f.err != nil && firstErr == nil && !errors.Is(f.err, errRuntimeSessionBusy) {
+			firstErr = f.err
+		}
+	}
+
+	for {
+		// Reap finished workers (non-blocking) so freed checkout keys and slots are
+		// visible to this dispatch pass.
+		for reaping := true; reaping; {
+			select {
+			case f := <-done:
+				reap(f)
+			default:
+				reaping = false
+			}
+		}
+
+		// Stop dispatching promptly on cancellation rather than relying on the next
+		// store query to observe it; in-flight workers return as their own ctx is
+		// cancelled (parity with the barrier's wg.Wait()), then we drain and exit.
+		if firstErr == nil && ctx.Err() != nil {
+			firstErr = ctx.Err()
+		}
+
+		dispatched := 0
+		if firstErr == nil {
+			pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter)
+			if err != nil {
+				firstErr = err
+			} else if slots := limit - running; slots > 0 {
+				queued, _ := selectRunnableQueuedJobsSeeded(ctx, worker.Store, pending, slots, policy, inflightCheckouts, inflightRuntimes)
+				for _, job := range queued {
+					job := job
+					checkoutKey := queuedJobCheckoutKey(ctx, worker.Store, job)
+					runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
+					inflightCheckouts[checkoutKey] = true
+					if runtimeKey != "" {
+						inflightRuntimes[runtimeKey] = true
+					}
+					running++
+					dispatched++
+					go func() {
+						done <- finished{checkoutKey: checkoutKey, runtimeKey: runtimeKey, err: worker.run(ctx, job)}
+					}()
+				}
+			}
+		}
+
+		if running == 0 {
+			// Nothing running: if we also dispatched nothing this pass the queue is
+			// drained (or everything left is un-runnable for now) — return, surfacing
+			// any worker error. On firstErr we reach here once inflight has drained.
+			if dispatched == 0 {
+				return firstErr
+			}
+			continue
+		}
+		if dispatched == 0 {
+			// No progress is possible until a running worker frees a resource; block
+			// for one, then re-query (which may now include newly-queued jobs).
+			reap(<-done)
+		}
+	}
+}
+
 type queuedJobResourceSelector struct {
 	limit            int
 	policy           config.ParallelSessionPolicy
@@ -1520,14 +1681,23 @@ func selectRunnableQueuedJobs(ctx context.Context, store *db.Store, pending []db
 }
 
 func selectRunnableQueuedJobsWithPolicy(ctx context.Context, store *db.Store, pending []db.Job, limit int, policy config.ParallelSessionPolicy) ([]db.Job, []db.Job) {
+	return selectRunnableQueuedJobsSeeded(ctx, store, pending, limit, policy, nil, nil)
+}
+
+// selectRunnableQueuedJobsSeeded is selectRunnableQueuedJobsWithPolicy with the
+// checkout/runtime resource sets pre-seeded from already-running jobs. The
+// barrier path passes nil seeds (empty, == the original behavior); the pool path
+// (#394) seeds the live in-flight keys so a job whose checkout key is already
+// held by a running job is not selected. The seed maps are copied, never mutated.
+func selectRunnableQueuedJobsSeeded(ctx context.Context, store *db.Store, pending []db.Job, limit int, policy config.ParallelSessionPolicy, seedCheckouts map[string]bool, seedRuntimes map[string]bool) ([]db.Job, []db.Job) {
 	if limit <= 0 {
 		return nil, pending
 	}
 	selector := queuedJobResourceSelector{
 		limit:            limit,
 		policy:           policy,
-		checkouts:        map[string]bool{},
-		runtimes:         map[string]bool{},
+		checkouts:        copyStringSet(seedCheckouts),
+		runtimes:         copyStringSet(seedRuntimes),
 		tempReservations: map[string]int{},
 	}
 	queued := make([]db.Job, 0, min(limit, len(pending)))
@@ -1540,6 +1710,16 @@ func selectRunnableQueuedJobsWithPolicy(ctx context.Context, store *db.Store, pe
 		remaining = append(remaining, job)
 	}
 	return queued, remaining
+}
+
+func copyStringSet(src map[string]bool) map[string]bool {
+	dst := make(map[string]bool, len(src))
+	for k, v := range src {
+		if v {
+			dst[k] = true
+		}
+	}
+	return dst
 }
 
 func (s queuedJobResourceSelector) selects(ctx context.Context, store *db.Store, job db.Job, selected int) bool {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -214,7 +214,7 @@ func TestDaemonRestartOverlayPreservesSavedArgs(t *testing.T) {
 func TestDaemonStartForwardsRepoAndSessionThroughRestart(t *testing.T) {
 	// The detached child argv carries both filters (this is exactly what
 	// daemonMeta.Args records).
-	childArgs := daemonChildArgs("/tmp/gitmoot-home", "30s", 1, false, "owner/project", "root-coordinator")
+	childArgs := daemonChildArgs("/tmp/gitmoot-home", "30s", 1, false, "barrier", "owner/project", "root-coordinator")
 	if !daemonArgsContainFlag(childArgs, "repo", "owner/project") {
 		t.Fatalf("child argv missing --repo: %v", childArgs)
 	}
@@ -274,7 +274,7 @@ func TestDaemonStartConfigSessionRootAlias(t *testing.T) {
 }
 
 func TestDaemonChildArgsRunAllRepoSupervisor(t *testing.T) {
-	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 2, true, "", "")
+	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 2, true, "barrier", "", "")
 
 	for i, arg := range args {
 		if arg == "--repo" || strings.HasPrefix(arg, "--repo=") {
@@ -300,7 +300,7 @@ func TestDaemonChildArgsRunAllRepoSupervisor(t *testing.T) {
 }
 
 func TestDaemonChildArgsForwardsRepo(t *testing.T) {
-	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 1, false, "owner/project", "")
+	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 1, false, "barrier", "owner/project", "")
 
 	if !daemonArgsContainFlag(args, "repo", "owner/project") {
 		t.Fatalf("daemon child args missing --repo owner/project: %v", args)
@@ -318,7 +318,7 @@ func TestDaemonChildArgsForwardsRepo(t *testing.T) {
 }
 
 func TestDaemonChildArgsForwardsSession(t *testing.T) {
-	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 1, false, "owner/project", "root-coordinator")
+	args := daemonChildArgs("/tmp/gitmoot-home", "30s", 1, false, "barrier", "owner/project", "root-coordinator")
 
 	if !daemonArgsContainFlag(args, "repo", "owner/project") {
 		t.Fatalf("daemon child args missing --repo owner/project: %v", args)
@@ -3810,6 +3810,238 @@ func TestRunQueuedJobsForRepoSkipsOtherRepos(t *testing.T) {
 	}
 	if adapter.calls != 1 {
 		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+}
+
+// --- #394 PR1: opt-in continuous worker-pool scheduler (--scheduler=pool) ---
+
+const poolSchedulerAskResult = `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+
+func TestParseSchedulerMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    bool
+		wantErr bool
+	}{
+		{"", false, false},
+		{"barrier", false, false},
+		{"pool", true, false},
+		{"  pool  ", true, false},
+		{"bogus", false, true},
+	}
+	for _, tc := range cases {
+		got, err := parseSchedulerMode(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseSchedulerMode(%q) err = nil, want error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseSchedulerMode(%q) err = %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("parseSchedulerMode(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDaemonChildArgsForwardsPoolScheduler(t *testing.T) {
+	pool := daemonChildArgs("/tmp/home", "30s", 1, false, "pool", "", "")
+	if !daemonArgsContainFlag(pool, "scheduler", "pool") {
+		t.Fatalf("pool child args missing --scheduler pool: %v", pool)
+	}
+	parsed, code := parseDaemonStartConfig("daemon restart", pool[2:], io.Discard)
+	if code != 0 {
+		t.Fatalf("parse pool child args code = %d: %v", code, pool)
+	}
+	if parsed.Scheduler != "pool" || !parsed.ExplicitScheduler {
+		t.Fatalf("parsed pool scheduler = %q explicit=%v", parsed.Scheduler, parsed.ExplicitScheduler)
+	}
+	// barrier (the default) appends no --scheduler flag, keeping the child argv
+	// byte-identical to before this change.
+	barrier := daemonChildArgs("/tmp/home", "30s", 1, false, "barrier", "", "")
+	for _, a := range barrier {
+		if a == "--scheduler" {
+			t.Fatalf("barrier child args should not carry --scheduler: %v", barrier)
+		}
+	}
+	if _, code := parseDaemonStartConfig("daemon start", []string{"--scheduler", "bogus"}, io.Discard); code != 2 {
+		t.Fatalf("invalid --scheduler code = %d, want 2", code)
+	}
+}
+
+func poolSchedulerWorker(t *testing.T, store *db.Store, adapter workflow.DeliveryAdapter, usePool bool) jobWorker {
+	t.Helper()
+	worker := defaultJobWorker(store, io.Discard)
+	worker.UsePool = usePool
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	return worker
+}
+
+func TestRunQueuedJobsPoolDrainsIndependentJobs(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo-a")
+	if err := store.AllowAgentRepo(ctx, "audit", "owner/repo-b"); err != nil {
+		t.Fatalf("AllowAgentRepo: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2})
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
+	worker := poolSchedulerWorker(t, store, adapter, true)
+
+	if err := runQueuedJobsForRepo(ctx, worker, 2, "", ""); err != nil {
+		t.Fatalf("pool runQueuedJobsForRepo: %v", err)
+	}
+	for _, id := range []string{"job-a", "job-b"} {
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob %s: %v", id, err)
+		}
+		if job.State != string(workflow.JobSucceeded) {
+			t.Fatalf("%s state = %q, want succeeded", id, job.State)
+		}
+	}
+}
+
+// runMidFlightEnqueueScenario runs job-a, which enqueues job-b (a different repo,
+// so a distinct checkout key) once dispatch has begun, then returns job-b's final
+// state. The pool re-queries and runs it; the barrier never re-queries, so it
+// stays queued — the #394 layer-1 behavior the pool fixes.
+func runMidFlightEnqueueScenario(t *testing.T, usePool bool) string {
+	t.Helper()
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo-a")
+	if err := store.AllowAgentRepo(ctx, "audit", "owner/repo-b"); err != nil {
+		t.Fatalf("AllowAgentRepo: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+
+	var once sync.Once
+	var enqErr error
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
+	adapter.onDeliver = func() {
+		once.Do(func() {
+			_, enqErr = (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2})
+		})
+	}
+	worker := poolSchedulerWorker(t, store, adapter, usePool)
+
+	if err := runQueuedJobsForRepo(ctx, worker, 2, "", ""); err != nil {
+		t.Fatalf("runQueuedJobsForRepo(usePool=%v): %v", usePool, err)
+	}
+	if enqErr != nil {
+		t.Fatalf("mid-flight enqueue of job-b failed: %v", enqErr)
+	}
+	job, err := store.GetJob(ctx, "job-b")
+	if err != nil {
+		t.Fatalf("GetJob job-b: %v", err)
+	}
+	return job.State
+}
+
+func TestRunQueuedJobsPoolPicksUpMidFlightJob(t *testing.T) {
+	if got := runMidFlightEnqueueScenario(t, true); got != string(workflow.JobSucceeded) {
+		t.Fatalf("pool: job-b state = %q, want succeeded (mid-flight job not picked up)", got)
+	}
+	if got := runMidFlightEnqueueScenario(t, false); got != string(workflow.JobQueued) {
+		t.Fatalf("barrier: job-b state = %q, want queued (barrier must not re-query mid-tick)", got)
+	}
+}
+
+func TestRunQueuedJobsPoolStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo-a")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	// The worker blocks until its context is cancelled; the pool must drain it and
+	// return rather than hang.
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult, waitForContextCancel: true}
+	worker := poolSchedulerWorker(t, store, adapter, true)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- runQueuedJobsForRepo(ctx, worker, 2, "", "") }()
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pool did not return after context cancellation (hang)")
+	}
+}
+
+type poolConcurrencyTracker struct {
+	mu     sync.Mutex
+	active int
+	max    int
+}
+
+func (c *poolConcurrencyTracker) span() {
+	c.mu.Lock()
+	c.active++
+	if c.active > c.max {
+		c.max = c.active
+	}
+	c.mu.Unlock()
+	time.Sleep(25 * time.Millisecond)
+	c.mu.Lock()
+	c.active--
+	c.mu.Unlock()
+}
+
+func (c *poolConcurrencyTracker) peak() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.max
+}
+
+func runPoolConcurrencyScenario(t *testing.T, repoB string) int {
+	t.Helper()
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo-a")
+	if repoB != "owner/repo-a" {
+		seedDaemonWorkerRepo(t, store, repoB, t.TempDir())
+		if err := store.AllowAgentRepo(ctx, "audit", repoB); err != nil {
+			t.Fatalf("AllowAgentRepo: %v", err)
+		}
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-1", Agent: "audit", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-2", Agent: "audit", Action: "ask", Repo: repoB, Branch: "main", PullRequest: 2})
+
+	tracker := &poolConcurrencyTracker{}
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
+	adapter.onDeliver = tracker.span
+	worker := poolSchedulerWorker(t, store, adapter, true)
+
+	if err := runQueuedJobsForRepo(ctx, worker, 2, "", ""); err != nil {
+		t.Fatalf("runQueuedJobsForRepo: %v", err)
+	}
+	return tracker.peak()
+}
+
+func TestRunQueuedJobsPoolHonorsCheckoutSafety(t *testing.T) {
+	// Same repo, no worktree ⇒ same checkout key ⇒ live accounting must serialize
+	// them even at --workers 2 (working-tree safety, #394 layer 2).
+	if peak := runPoolConcurrencyScenario(t, "owner/repo-a"); peak != 1 {
+		t.Fatalf("same-repo peak concurrency = %d, want 1 (must serialize same checkout key)", peak)
+	}
+	// Distinct repos ⇒ distinct checkout keys ⇒ the pool runs them in parallel.
+	if peak := runPoolConcurrencyScenario(t, "owner/repo-b"); peak != 2 {
+		t.Fatalf("distinct-repo peak concurrency = %d, want 2 (distinct keys must parallelize)", peak)
 	}
 }
 


### PR DESCRIPTION
## Summary

Part 1 of 2 for #394 (same-repo dependent-job deadlock). Adds an **opt-in** continuous worker-pool scheduler behind `--scheduler=pool`; the default stays the existing per-tick barrier, **byte-identical when the flag is off**.

## The problem (two layers)

- **L1 — tick barrier:** `runQueuedJobsForRepo` selects a batch then blocks the whole tick on `wg.Wait()`, and never re-queries. A job queued *after* the batch was selected isn't picked up until the next tick.
- **L2 — checkout mutex:** the same-repo checkout key `repo:<repo>` is a working-tree-safety mutex.

A running job that dispatches and polls another same-repo job deadlocks: the awaited job can't be scheduled while the tick is barriered (L1), and even unbarriered it's refused while the poller holds the repo checkout (L2).

## What this PR does (L1 + the safety foundation)

`runQueuedJobsForRepoPool` — a continuous dispatcher that:
- keeps up to `--workers` jobs busy and **re-queries the queue as each worker frees**, so a job queued mid-flight is picked up without waiting for the in-flight batch to drain;
- enforces **live in-flight checkout accounting** (via a seedable `selectRunnableQueuedJobsSeeded`): a job whose checkout key is already held by a running job is never dispatched concurrently. Same-repo no-worktree jobs therefore still serialize (working-tree safety); only distinct checkout keys run in parallel.

Single-dispatcher-goroutine ownership of all mutable state (workers communicate only via a buffered `done` channel), so no locks. Stops dispatching promptly on context cancel.

## What's deferred to PR2

This PR does **not** by itself fix the opaque same-repo deadlock: an awaited no-worktree follow-up still (correctly) serializes on `repo:<repo>`. **PR2 gives the awaited follow-up an auto-created isolated worktree** → a distinct `worktree:<path>` key → schedulable beside the poller, completing the chain. This PR is the continuous-pool + safe-accounting foundation PR2 builds on.

## Flag plumbing

`--scheduler=barrier|pool` on `daemon run` and `daemon start`, threaded through both supervisors and forwarded on the `daemon start` → `daemon run` child spawn (and restart-arg preservation). Invalid values rejected.

## Tests

- `TestParseSchedulerMode`, `TestDaemonChildArgsForwardsPoolScheduler` — flag parse + forwarding; barrier appends no flag.
- `TestRunQueuedJobsPoolDrainsIndependentJobs` — drain parity.
- `TestRunQueuedJobsPoolPicksUpMidFlightJob` — the L1 fix: the pool runs a job enqueued after dispatch began; the **barrier leaves it queued** (explicit contrast).
- `TestRunQueuedJobsPoolHonorsCheckoutSafety` — same-repo peak concurrency = 1 (serialized), distinct-repo = 2 (parallel).
- `TestRunQueuedJobsPoolStopsOnContextCancel` — liveness: returns on cancel, no hang.

`go build/vet/test ./...` + `go test -race ./internal/cli/ ./internal/workflow/` all green. Reviewed adversarially for liveness, channel-buffer leaks, seed-map mutation, and the safety invariant.

Part 1 of #394 (not a full fix on its own — see "deferred to PR2").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
