### PR TITLE
feat(cli): foreground agent ask dispatches to a managed agent type (#395)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -527,11 +527,51 @@ func resolveLocalDispatchAgent(ctx context.Context, store *db.Store, request loc
 			return db.Agent{}, noopAgentReservationRelease, err
 		}
 	}
-	if !request.Background && !request.AllowManagedSync {
-		return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("agent %q not found", request.Agent)
-	}
 	typeName := firstNonEmpty(forceType, request.Agent)
+	// A background dispatch (or a caller that explicitly opted in via
+	// AllowManagedSync, e.g. the skillopt path) always reaches the managed path.
+	// For a plain foreground dispatch, fall through to the managed path only for
+	// the `ask` action AND only when the resolved name maps to a configured
+	// managed agent type; otherwise preserve the historical "agent not found"
+	// error so a name that resolves to neither a single instance nor a type still
+	// fails as before. Scoped to `ask`: `implement` keeps its existing
+	// read-only/finalize semantics (readOnlyManagedImplementationBlock), and
+	// `review` carries required params (--pr / --head-sha) that the foreground
+	// path does not validate before this point — letting a heuristic-selected
+	// `run`->`review` reach the managed path would spin an instance and then fail
+	// downstream (#395).
+	if !request.Background && !request.AllowManagedSync {
+		allowSync := false
+		if strings.TrimSpace(request.Action) == "ask" {
+			ok, err := managedAgentTypeExists(request.Home, typeName)
+			if err != nil {
+				return db.Agent{}, noopAgentReservationRelease, err
+			}
+			allowSync = ok
+		}
+		if !allowSync {
+			return db.Agent{}, noopAgentReservationRelease, fmt.Errorf("agent %q not found", request.Agent)
+		}
+	}
 	return ensureManagedAgentInstance(ctx, store, request.Home, typeName, repo, record)
+}
+
+// managedAgentTypeExists reports whether typeName names a configured managed
+// agent type for the given home. It is used to decide whether a foreground
+// ask/run may dispatch synchronously to a managed type (#395) without changing
+// the historical "agent not found" behavior for names that match neither a
+// single instance nor a type.
+func managedAgentTypeExists(home string, typeName string) (bool, error) {
+	typeName = strings.TrimSpace(typeName)
+	if typeName == "" {
+		return false, nil
+	}
+	types, err := loadAgentTypeConfig(home)
+	if err != nil {
+		return false, err
+	}
+	_, ok := types[typeName]
+	return ok, nil
 }
 
 func readOnlyManagedImplementationBlock(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string) (runtime.Agent, bool, error) {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -1065,6 +1065,209 @@ func TestDispatchManagedSyncUsesJobTimeoutForRuntimeLock(t *testing.T) {
 	}
 }
 
+// TestDispatchForegroundAskToManagedTypeSpinsInstance covers #395: a plain
+// foreground ask whose name resolves to a configured managed agent type (no
+// --type, no AllowManagedSync) must dispatch synchronously to the managed type
+// instead of erroring "agent not found".
+func TestDispatchForegroundAskToManagedTypeSpinsInstance(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--max-background", "1",
+		"--idle-timeout", "20m",
+		"--job-timeout", "45m",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	runner := &managedSyncLockRunner{
+		t:          t,
+		store:      store,
+		runtimeKey: "runtime:codex:550e8400-e29b-41d4-a716-446655440222",
+		minTTL:     44 * time.Minute,
+	}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	// No Type, no AllowManagedSync: this is the plain foreground ask the issue
+	// targets. Before #395 this returned `agent "planner" not found`.
+	output, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		RepoFlag:     "owner/repo",
+		Agent:        "planner",
+		Action:       "ask",
+		Instructions: "Plan the work foreground.",
+		Home:         home,
+	})
+	if err != nil {
+		t.Fatalf("dispatchLocalAgentJob returned error: %v", err)
+	}
+	if output.Result == nil || output.Result.Decision != "implemented" {
+		t.Fatalf("dispatch output = %+v", output)
+	}
+	// Reaching ensureManagedAgentInstance must have spun a managed instance of
+	// the type, proving the synchronous managed path was taken.
+	instances, err := store.ListAgentInstances(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgentInstances returned error: %v", err)
+	}
+	if len(instances) != 1 || instances[0].Type != "planner" {
+		t.Fatalf("instances = %+v, want one planner managed instance", instances)
+	}
+	if output.Agent != instances[0].Name {
+		t.Fatalf("job agent = %q, want managed instance %q", output.Agent, instances[0].Name)
+	}
+}
+
+// TestDispatchForegroundReviewToManagedTypeStillErrors pins the #395 scoping
+// decision: the foreground managed-type fall-through is limited to the `ask`
+// action. A foreground `review` whose name resolves to a configured managed
+// type must NOT spin a managed instance (review carries required params the
+// foreground path has not validated here) — it stays the historical not-found
+// error, so a heuristic-selected `run`->`review` can't spin-then-fail downstream.
+func TestDispatchForegroundReviewToManagedTypeStillErrors(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "type", "set", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--max-background", "1",
+		"--idle-timeout", "20m",
+		"--job-timeout", "45m",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent type set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	_, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		RepoFlag:     "owner/repo",
+		Agent:        "planner",
+		Action:       "review",
+		PullRequest:  7,
+		Instructions: "Review the PR foreground.",
+		Home:         home,
+	})
+	if err == nil || !strings.Contains(err.Error(), `agent "planner" not found`) {
+		t.Fatalf("review-to-type dispatch err = %v, want \"agent not found\"", err)
+	}
+	instances, err := store.ListAgentInstances(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgentInstances returned error: %v", err)
+	}
+	if len(instances) != 0 {
+		t.Fatalf("instances = %+v, want zero (review must not spin a managed instance)", instances)
+	}
+}
+
+// TestDispatchForegroundAskSingleInstanceUnchanged confirms a name that
+// resolves to a registered single agent still dispatches to that instance and
+// does not spin a managed instance, preserving single-instance-shadows-type.
+func TestDispatchForegroundAskSingleInstanceUnchanged(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(context.Background(), db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:           "solo",
+		Role:           "planner",
+		Runtime:        runtime.ShellRuntime,
+		RuntimeRef:     "echo",
+		RepoScope:      "owner/repo",
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: runtime.AutonomyPolicyReadOnly,
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	runner := &agentStartRunner{results: []subprocess.Result{
+		{Stdout: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}` + "\n"},
+	}}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	output, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		RepoFlag:     "owner/repo",
+		Agent:        "solo",
+		Action:       "ask",
+		Instructions: "Use the single instance.",
+		Home:         home,
+	})
+	if err != nil {
+		t.Fatalf("dispatchLocalAgentJob returned error: %v", err)
+	}
+	if output.Agent != "solo" {
+		t.Fatalf("job agent = %q, want solo", output.Agent)
+	}
+	instances, err := store.ListAgentInstances(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgentInstances returned error: %v", err)
+	}
+	if len(instances) != 0 {
+		t.Fatalf("instances = %+v, want no managed instances for a single agent", instances)
+	}
+}
+
+// TestDispatchForegroundAskUnknownNameStillErrors confirms requirement #3: a
+// name resolving to neither a single agent nor a managed type still returns the
+// historical `agent "<name>" not found` error in the foreground.
+func TestDispatchForegroundAskUnknownNameStillErrors(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(context.Background(), db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+
+	_, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		RepoFlag:     "owner/repo",
+		Agent:        "ghost",
+		Action:       "ask",
+		Instructions: "Should not resolve.",
+		Home:         home,
+	})
+	if err == nil {
+		t.Fatal("dispatchLocalAgentJob returned nil error, want not found")
+	}
+	if !strings.Contains(err.Error(), `agent "ghost" not found`) {
+		t.Fatalf("error = %q, want agent not found", err.Error())
+	}
+}
+
 func TestDispatchManagedAgentStartsFreshInstanceWhenPolicyChanges(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()


### PR DESCRIPTION
## Summary
Closes #395. Foreground `gitmoot agent ask`/`agent run` (the `ask` action) now dispatches synchronously to a managed agent **type** — spinning/reusing a managed instance up to `max_background` — instead of erroring `agent "<name>" not found`. Previously only background dispatch reached the managed-instance path.

## Change
`resolveLocalDispatchAgent` (`internal/cli/agent_dispatch.go`): when a foreground dispatch resolves to neither a single registered agent nor `--type`, and the **`ask`** action's name maps to a configured managed agent type (`managedAgentTypeExists`), fall through to `ensureManagedAgentInstance` (which keeps all `max_background` semantics) instead of returning not-found.

Preserved exactly:
- **Single-instance-shadows-type** precedence (`GetAgent` tried first).
- `--type` still forces the type.
- Unknown name (neither instance nor type) → still `agent "<name>" not found`.
- **`implement` unchanged**; **`review` scoped out** — a heuristic-selected `run`→`review` must not spin an instance and then fail downstream on a missing `--pr`, so the fall-through is limited to `ask` (found in adversarial review).

## Tests
- `TestDispatchForegroundAskToManagedTypeSpinsInstance` — foreground ask to a type spins a managed instance (fails without the fix).
- `TestDispatchForegroundReviewToManagedTypeStillErrors` — review-to-type does NOT spin an instance (ask-only scoping).
- `TestDispatchForegroundAskSingleInstanceUnchanged` / `…UnknownNameStillErrors` — precedence + not-found preserved.

## Verification
- `go build/vet/test ./...` + `go test -race ./internal/cli/` green.
- **Live E2E** (codex, isolated home): a foreground `agent ask <type>` (no `--type`, no `--background`) on a managed type spun a managed instance and returned a real `gitmoot_result` (`approved`/"ok") — vs. the prior `agent not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
