### PR TITLE
fix(workflow): advance integration-worktree reviews instead of deadlocking on a cleared HeadSHA (#388)

### DIFF
--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -440,7 +440,28 @@ func (g PolicyMergeGate) ensureReviewMatchesHead(payload JobPayload, headSHA str
 	if reviewHead != "" {
 		return fmt.Errorf("latest review from %s is for a different head SHA", agent)
 	}
+	// A review that ran in an integration worktree (#332 decompose-and-verify)
+	// has its inherited HeadSHA deliberately cleared by the engine
+	// (allocateAndEnqueueDelegation in engine.go): the worktree carries no
+	// branch and is validated against its own fresh HEAD, not the parent PR
+	// head. Such a review legitimately records no head SHA, so accepting it here
+	// is what lets a gate-required integration review advance instead of
+	// deadlocking. This is narrow: a normal review with a mismatched non-empty
+	// head still fails above, and a normal review missing a head SHA but lacking
+	// the integration-worktree markers still fails below.
+	if isIntegrationWorktreeReview(payload) {
+		return nil
+	}
 	return fmt.Errorf("latest review from %s does not record a head SHA; rerun review", agent)
+}
+
+// isIntegrationWorktreeReview reports whether the review job ran in a
+// gitmoot-managed delegation worktree (it carries both a delegation id and an
+// allocated worktree path). The engine clears the inherited HeadSHA for exactly
+// these children so they validate against their isolated worktree HEAD, mirroring
+// isDelegationWorktreeChild in the daemon's checkout validation.
+func isIntegrationWorktreeReview(payload JobPayload) bool {
+	return strings.TrimSpace(payload.DelegationID) != "" && strings.TrimSpace(payload.WorktreePath) != ""
 }
 
 func (g PolicyMergeGate) ensureStatuses(ctx context.Context, repo github.Repository, pullRequest int64, headSHA string) error {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -925,6 +925,90 @@ func TestPolicyMergeGateBlocksLegacyReviewWithoutHeadSHA(t *testing.T) {
 	}
 }
 
+// TestPolicyMergeGateAdvancesIntegrationWorktreeReviewWithoutHeadSHA is the #388
+// regression: a gate-required review that ran on a #332 integration worktree has
+// its inherited HeadSHA cleared by design (the worktree carries no branch and is
+// validated against its own fresh HEAD). The gate must not treat that empty SHA
+// as a stale/unverifiable review — otherwise the merge deadlocks because the
+// required review can never be satisfied. With the fix the PR advances and merges.
+func TestPolicyMergeGateAdvancesIntegrationWorktreeReviewWithoutHeadSHA(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "jerryfane/gitmoot",
+		Number:       9,
+		URL:          "https://github.com/jerryfane/gitmoot/pull/9",
+		HeadBranch:   "task-9",
+		BaseBranch:   "main",
+		HeadSHA:      "head123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	// An integration-worktree review: a delegation child (DelegationID +
+	// WorktreePath set) whose HeadSHA the engine intentionally cleared.
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review", DelegationID: "verify-gate"}, JobPayload{
+		Repo:         "jerryfane/gitmoot",
+		PullRequest:  9,
+		TaskID:       "task-9",
+		ReviewRound:  "review-1",
+		DelegationID: "verify-gate",
+		WorktreePath: "/tmp/gitmoot/integration-verify-gate",
+		Result:       &AgentResult{Decision: "approved", Summary: "integration verified"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("integration-worktree review did not advance to merge: decision = %+v", decision)
+	}
+}
+
+// TestPolicyMergeGateBlocksDelegationReviewForMismatchedHead is the safety guard:
+// the #388 exception applies only to an empty HeadSHA. A delegation review that
+// DID record a head SHA which does not match the PR head is still a real mismatch
+// and must STILL be rejected — the integration-worktree carve-out must not weaken
+// the head-match check for any review that carries a concrete (wrong) SHA.
+func TestPolicyMergeGateBlocksDelegationReviewForMismatchedHead(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review", DelegationID: "verify-gate"}, JobPayload{
+		Repo:         "jerryfane/gitmoot",
+		PullRequest:  9,
+		HeadSHA:      "stale999",
+		TaskID:       "task-9",
+		ReviewRound:  "review-1",
+		DelegationID: "verify-gate",
+		WorktreePath: "/tmp/gitmoot/integration-verify-gate",
+		Result:       &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:     github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status: github.CombinedStatus{State: "success"},
+	}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "jerryfane/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready || !strings.Contains(decision.Reason, "different head SHA") {
+		t.Fatalf("delegation review with mismatched head was not rejected: decision = %+v", decision)
+	}
+}
+
 func TestPolicyMergeGateBlocksMissingFinalReview(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)


### PR DESCRIPTION
## Summary
Closes #388. Fixes a merge-gate deadlock on integration-worktree reviews (the #332 decompose-and-verify path).

## Root cause
The engine deliberately clears `HeadSHA=""` for a review dispatched onto an integration worktree (keyed `integration-<delegation-id>`, no branch) so it validates against the worktree's own fresh HEAD rather than a stale parent SHA. But the merge gate's `ensureReviewMatchesHead` then rejects the empty SHA (`does not record a head SHA; rerun review`) — and if that review is a gate requirement, it can never be satisfied → the gate deadlocks.

## Fix
A narrow carve-out in `ensureReviewMatchesHead` (`internal/workflow/merge_gate.go`): when a review records NO head SHA **and** carries the integration/delegation-worktree markers (`DelegationID != "" && WorktreePath != ""`, via `isIntegrationWorktreeReview`, mirroring the daemon's `isDelegationWorktreeChild` discriminator), accept it — exactly the case where the engine intentionally cleared the SHA (the review *was* validated against its own worktree HEAD at dispatch).

Normal review safety preserved: the carve-out is reached only when `reviewHead == ""`; a review with a non-empty **mismatched** head is still rejected (`different head SHA`), and a normal/legacy empty-SHA review (without the markers) is still rejected.

## Tests
- `TestPolicyMergeGateAdvancesIntegrationWorktreeReviewWithoutHeadSHA` — regression: the integration-worktree review now advances to merge.
- `TestPolicyMergeGateBlocksDelegationReviewForMismatchedHead` — guard: a concrete-but-wrong head is still rejected.
- Existing guards (`…BlocksReviewForStaleHead`, `…BlocksLegacyReviewWithoutHeadSHA`) still pass.

Full gate (`go build/vet/test ./...` + `go test -race ./internal/workflow/`) green; adversarial review confirmed safe + unspoofable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
