### PR TITLE
feat(workflow): per-root cost ($) budget + circuit breaker for delegation trees (#380)

### DIFF
--- a/docs/cockpit-orchestrate.md
+++ b/docs/cockpit-orchestrate.md
@@ -76,6 +76,7 @@ cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per rol
 inline_artifact_bodies = false   # inline each child's artifact_body into the coordinator continuation
 inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
 max_delegation_token_budget = 0  # per-root delegation token budget (input+output); 0 = unlimited (off)
+max_delegation_cost_usd = 0      # per-root delegation dollar-cost budget (USD); 0 = unlimited (off)
 ```
 
 - `cockpit_mode = "off"` disables the cockpit even if `--cockpit` was passed;
@@ -105,8 +106,22 @@ max_delegation_token_budget = 0  # per-root delegation token budget (input+outpu
   envelope, Kimi reports it when its stream emits a `usage` object, and Codex runs
   delivery without `--json` so it contributes `0` (the budget under-counts Codex
   rather than failing). Treat it as a coarse runaway-cost backstop, not a precise
-  spend limit; the budget is in raw tokens (no `$` price table yet). Leaving it at
-  `0` is byte-identical to before the knob existed.
+  spend limit; the budget is in raw tokens. Leaving it at `0` is byte-identical to
+  before the knob existed.
+- `max_delegation_cost_usd` (default `0` = unlimited/off) is the **dollar-cost**
+  analogue of the token budget (#380): it bounds the same tree by its *measured
+  spend* rather than raw token count. Cost is derived from the same per-job token
+  usage the token budget already sums, priced through a small built-in per-model
+  price table (per-1M-token list prices — Haiku `0.25/1.25`, Sonnet `3/15`, Opus
+  `15/75` input/output USD — matched by substring against each job's model id;
+  an empty or unrecognized model id is priced at the mid-tier Sonnet default so it
+  is never free). When the tree's accumulated cost reaches the budget, the next
+  fan-out is refused with a `delegation_cost_usd_exceeded` event and routed to the
+  same graceful finalize continuation (synthesize what completed, then stop) — it
+  is **never hard-killed**. Because cost rides on the same best-effort token
+  capture and a hardcoded price table, it is a coarse runaway-cost backstop, not a
+  precise spend meter. Leaving it at `0` is byte-identical to before the knob
+  existed.
 
 ## Constrained hosts
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3311,10 +3311,10 @@ func (w jobWorker) defaultWorkflow(checkout string) workflow.Engine {
 }
 
 // applyOrchestratePolicy sets the engine's opt-in [orchestrate] fields — the
-// artifact-body inlining knobs and the per-root delegation token budget (#338
-// Part B) — from the host policy. It is fail-safe: any load error leaves the
-// engine with its defaults (inlining off, token budget 0 = unlimited) rather than
-// failing engine construction.
+// artifact-body inlining knobs and the per-root delegation token (#338 Part B)
+// and dollar-cost (#380) budgets — from the host policy. It is fail-safe: any
+// load error leaves the engine with its defaults (inlining off, both budgets 0 =
+// unlimited) rather than failing engine construction.
 func (w jobWorker) applyOrchestratePolicy(engine *workflow.Engine) {
 	policy, err := w.orchestratePolicy()
 	if err != nil {
@@ -3323,6 +3323,7 @@ func (w jobWorker) applyOrchestratePolicy(engine *workflow.Engine) {
 	engine.InlineArtifactBodies = policy.InlineArtifactBodies
 	engine.MaxInlineArtifactBytes = policy.InlineArtifactMaxBytes
 	engine.MaxDelegationTokenBudget = policy.MaxDelegationTokenBudget
+	engine.MaxDelegationCostUSD = policy.MaxDelegationCostUSD
 }
 
 // workflowHome resolves the GITMOOT_HOME root used to place per-delegation

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -44,6 +44,12 @@ type OrchestratePolicy struct {
 	// means unlimited/off, so default behavior is unchanged. The daemon wires this
 	// into Engine.MaxDelegationTokenBudget at startup.
 	MaxDelegationTokenBudget int
+	// MaxDelegationCostUSD is the cumulative per-root dollar-cost budget that bounds
+	// a delegation tree by its measured spend (token usage × a per-model price
+	// table), layered on top of the token budget (#380). 0 (the default) means
+	// unlimited/off, so default behavior is unchanged. The daemon wires this into
+	// Engine.MaxDelegationCostUSD at startup.
+	MaxDelegationCostUSD float64
 }
 
 func DefaultOrchestratePolicy() OrchestratePolicy {
@@ -55,6 +61,7 @@ func DefaultOrchestratePolicy() OrchestratePolicy {
 		InlineArtifactBodies:     false,
 		InlineArtifactMaxBytes:   0,
 		MaxDelegationTokenBudget: 0,
+		MaxDelegationCostUSD:     0,
 	}
 }
 
@@ -122,6 +129,10 @@ func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value st
 		parsed, err := strconv.Atoi(value)
 		policy.MaxDelegationTokenBudget = parsed
 		return err
+	case "max_delegation_cost_usd":
+		parsed, err := strconv.ParseFloat(value, 64)
+		policy.MaxDelegationCostUSD = parsed
+		return err
 	default:
 		return nil
 	}
@@ -143,6 +154,9 @@ func validateOrchestratePolicy(policy OrchestratePolicy) error {
 	}
 	if policy.MaxDelegationTokenBudget < 0 {
 		return fmt.Errorf("orchestrate.max_delegation_token_budget must be 0 (unlimited) or positive")
+	}
+	if policy.MaxDelegationCostUSD < 0 {
+		return fmt.Errorf("orchestrate.max_delegation_cost_usd must be 0 (unlimited) or positive")
 	}
 	return nil
 }

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -38,6 +38,48 @@ func TestLoadOrchestratePolicyDefaults(t *testing.T) {
 	if policy.MaxDelegationTokenBudget != 0 {
 		t.Fatalf("MaxDelegationTokenBudget = %d, want 0 (unlimited) by default", policy.MaxDelegationTokenBudget)
 	}
+	if policy.MaxDelegationCostUSD != 0 {
+		t.Fatalf("MaxDelegationCostUSD = %v, want 0 (unlimited) by default", policy.MaxDelegationCostUSD)
+	}
+}
+
+// TestLoadOrchestratePolicyMaxDelegationCostUSD pins #380: the dollar-cost budget
+// parses from [orchestrate] and an absent key keeps the 0 (unlimited) default,
+// mirroring the token-budget test above.
+func TestLoadOrchestratePolicyMaxDelegationCostUSD(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+max_delegation_cost_usd = 2.50
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	policy, err := LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.MaxDelegationCostUSD != 2.50 {
+		t.Fatalf("MaxDelegationCostUSD = %v, want 2.50", policy.MaxDelegationCostUSD)
+	}
+
+	// Absent key keeps the unlimited default even with the section present.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+cockpit_mode = "auto"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err = LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.MaxDelegationCostUSD != 0 {
+		t.Fatalf("absent max_delegation_cost_usd should default 0, got %v", policy.MaxDelegationCostUSD)
+	}
 }
 
 // TestLoadOrchestratePolicyMaxDelegationTokenBudget pins #338 Part B: the token
@@ -191,6 +233,22 @@ max_delegation_token_budget = lots
 max_delegation_token_budget = -1
 `,
 			wantErr: "max_delegation_token_budget must be 0 (unlimited) or positive",
+		},
+		{
+			name: "max_delegation_cost_usd_non_float",
+			body: `
+[orchestrate]
+max_delegation_cost_usd = cheap
+`,
+			wantErr: "parse [orchestrate].max_delegation_cost_usd",
+		},
+		{
+			name: "max_delegation_cost_usd_negative",
+			body: `
+[orchestrate]
+max_delegation_cost_usd = -0.5
+`,
+			wantErr: "max_delegation_cost_usd must be 0 (unlimited) or positive",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/workflow/cost.go
+++ b/internal/workflow/cost.go
@@ -1,0 +1,121 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+)
+
+// ModelPrice is a per-model price row in USD per single token (input and
+// output). The figures are derived from the published per-1M-token list prices
+// divided by 1e6, so the math below is a direct tokens × price multiply.
+//
+// We deliberately track only input and output here (not the cache-write /
+// cache-read classes ruflo's _prices.mjs carries) because gitmoot persists only
+// per-job InputTokens / OutputTokens (see db.Job and UpdateJobUsage); cached
+// token classes are not captured by any runtime adapter today, so a four-class
+// table would add columns that are always zero. When usage capture grows cache
+// classes, extend ModelPrice and priceForModel together.
+type ModelPrice struct {
+	// InputPerToken is the USD charged per input (prompt) token.
+	InputPerToken float64
+	// OutputPerToken is the USD charged per output (completion) token.
+	OutputPerToken float64
+}
+
+// modelPriceRow names a default price-table entry: a case-insensitive substring
+// that is matched against a job's model id (Tier, e.g. "haiku"/"sonnet"/"opus",
+// mirroring ruflo's modelTier()) and the price for that tier. The list is
+// ordered most-specific-first; priceForModel returns the first row whose Tier is
+// a substring of the model id.
+type modelPriceRow struct {
+	Tier  string
+	Price ModelPrice
+}
+
+// defaultModelPrices is the built-in price table: per-1M-token list prices
+// (Haiku 0.25/1.25, Sonnet 3/15, Opus 15/75 — input/output USD) expressed as USD
+// per single token. A model id that matches none of these tiers falls back to
+// defaultUnknownModelPrice. The table is intentionally tiny and hardcoded
+// (mirroring ruflo's _prices.mjs); it drifts from real provider pricing unless
+// maintained, so the cost budget is a coarse runaway-cost backstop, not a
+// precise spend meter.
+var defaultModelPrices = []modelPriceRow{
+	{Tier: "opus", Price: ModelPrice{InputPerToken: 15.0 / 1e6, OutputPerToken: 75.0 / 1e6}},
+	{Tier: "sonnet", Price: ModelPrice{InputPerToken: 3.0 / 1e6, OutputPerToken: 15.0 / 1e6}},
+	{Tier: "haiku", Price: ModelPrice{InputPerToken: 0.25 / 1e6, OutputPerToken: 1.25 / 1e6}},
+}
+
+// defaultUnknownModelPrice is the fallback applied to a job whose model id is
+// empty or matches no tier in defaultModelPrices. It uses the Sonnet row — a
+// mid-tier, non-zero price — so an unknown model still contributes a sensible
+// (rather than free) cost to the budget. Picking a non-zero default keeps the
+// budget conservative: an unpriced model cannot silently spend past the cap.
+var defaultUnknownModelPrice = ModelPrice{InputPerToken: 3.0 / 1e6, OutputPerToken: 15.0 / 1e6}
+
+// priceForModel maps a model id to a price row by case-insensitive substring,
+// most-specific-tier-first (opus → sonnet → haiku), mirroring ruflo's
+// modelTier(). An empty or unrecognized model id falls back to
+// defaultUnknownModelPrice rather than zero, so the budget never under-prices an
+// unknown model to free.
+func priceForModel(model string) ModelPrice {
+	id := strings.ToLower(strings.TrimSpace(model))
+	if id == "" {
+		return defaultUnknownModelPrice
+	}
+	for _, row := range defaultModelPrices {
+		if strings.Contains(id, row.Tier) {
+			return row.Price
+		}
+	}
+	return defaultUnknownModelPrice
+}
+
+// costFromTokens derives the USD cost of a single job's measured token usage:
+// input × input-price + output × output-price, using the price row for model.
+// It is post-call accounting over real token counts (mirroring ruflo's
+// costUsd() / costFromTokens()), never a pre-call estimate. Negative token
+// counts are clamped to 0 so a bad usage write cannot "refund" cost past the cap.
+func costFromTokens(model string, inputTokens, outputTokens int) float64 {
+	if inputTokens < 0 {
+		inputTokens = 0
+	}
+	if outputTokens < 0 {
+		outputTokens = 0
+	}
+	p := priceForModel(model)
+	return float64(inputTokens)*p.InputPerToken + float64(outputTokens)*p.OutputPerToken
+}
+
+// sumRootDelegationCost sums the USD cost across an entire coordination tree —
+// the originating coordinator (job.ID == rootID) plus every child or
+// continuation whose payload RootJobID points back at it — by pricing each job's
+// measured token usage through priceForModel(payload.Model). It is the cost
+// analogue of sumRootDelegationTokens (#338 Part B): there is no store query
+// keyed on root, so it lists all jobs and filters by RootJobID.
+//
+// Cost is measured accounting derived from the same per-job token counts the
+// token budget already sums (db.Job.InputTokens / OutputTokens) — a job whose
+// runtime did not report usage contributes 0, so the sum under-counts rather
+// than over-counts. A job whose model id is empty/unknown is priced at the
+// mid-tier fallback (defaultUnknownModelPrice) so it is never free.
+func (e Engine) sumRootDelegationCost(ctx context.Context, rootID string) (float64, error) {
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return 0, err
+	}
+	total := 0.0
+	for _, job := range jobs {
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return 0, err
+		}
+		if job.ID == rootID {
+			total += costFromTokens(payload.Model, job.InputTokens, job.OutputTokens)
+			continue
+		}
+		if payload.RootJobID == rootID {
+			total += costFromTokens(payload.Model, job.InputTokens, job.OutputTokens)
+		}
+	}
+	return total, nil
+}

--- a/internal/workflow/cost_test.go
+++ b/internal/workflow/cost_test.go
@@ -1,0 +1,224 @@
+package workflow
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// floatNear reports whether got is within eps of want; the price math is in
+// floating dollars so equality checks must tolerate representation error.
+func floatNear(got, want, eps float64) bool {
+	return math.Abs(got-want) <= eps
+}
+
+// TestPriceForModelTiers pins the substring tiering (mirroring ruflo's
+// modelTier()): a model id is matched case-insensitively against opus → sonnet →
+// haiku (most-specific first), and anything unrecognized — including empty —
+// falls back to the mid-tier (Sonnet) default rather than zero.
+func TestPriceForModelTiers(t *testing.T) {
+	cases := []struct {
+		model string
+		want  ModelPrice
+	}{
+		{"claude-opus-4-8", ModelPrice{InputPerToken: 15.0 / 1e6, OutputPerToken: 75.0 / 1e6}},
+		{"claude-sonnet-4-5", ModelPrice{InputPerToken: 3.0 / 1e6, OutputPerToken: 15.0 / 1e6}},
+		{"claude-3-5-HAIKU", ModelPrice{InputPerToken: 0.25 / 1e6, OutputPerToken: 1.25 / 1e6}},
+		{"", defaultUnknownModelPrice},
+		{"gpt-5.5", defaultUnknownModelPrice},
+		{"  Opus  ", ModelPrice{InputPerToken: 15.0 / 1e6, OutputPerToken: 75.0 / 1e6}},
+	}
+	for _, tc := range cases {
+		got := priceForModel(tc.model)
+		if !floatNear(got.InputPerToken, tc.want.InputPerToken, 1e-12) ||
+			!floatNear(got.OutputPerToken, tc.want.OutputPerToken, 1e-12) {
+			t.Fatalf("priceForModel(%q) = %+v, want %+v", tc.model, got, tc.want)
+		}
+	}
+}
+
+// TestCostFromTokens pins the post-call accounting formula
+// (input × input_price + output × output_price) and the negative-spend clamp:
+// negative token counts contribute 0, so a bad usage write cannot refund cost.
+func TestCostFromTokens(t *testing.T) {
+	// 1,000,000 input + 1,000,000 output on Opus => $15 + $75 = $90.
+	if got := costFromTokens("claude-opus-4-8", 1_000_000, 1_000_000); !floatNear(got, 90.0, 1e-9) {
+		t.Fatalf("costFromTokens(opus, 1e6, 1e6) = %v, want 90.0", got)
+	}
+	// Sonnet: 1,000,000 input + 1,000,000 output => $3 + $15 = $18.
+	if got := costFromTokens("claude-sonnet-4-5", 1_000_000, 1_000_000); !floatNear(got, 18.0, 1e-9) {
+		t.Fatalf("costFromTokens(sonnet, 1e6, 1e6) = %v, want 18.0", got)
+	}
+	// Negative counts clamp to 0 — no refund past the cap.
+	if got := costFromTokens("claude-opus-4-8", -5, -7); got != 0 {
+		t.Fatalf("costFromTokens(opus, -5, -7) = %v, want 0 (clamped)", got)
+	}
+	// Unknown model is priced at the mid-tier fallback, never free.
+	if got := costFromTokens("some-unknown-model", 1_000_000, 0); !floatNear(got, 3.0, 1e-9) {
+		t.Fatalf("costFromTokens(unknown, 1e6, 0) = %v, want 3.0 (Sonnet fallback)", got)
+	}
+}
+
+// seedCostTree builds a coordination tree rooted at rootID whose children carry a
+// known model id and output token count, so the per-root dollar cost is
+// deterministic. It mirrors seedTreeWithUsage but threads a Model through each
+// child's payload so priceForModel resolves to a real tier rather than the
+// unknown fallback.
+func seedCostTree(t *testing.T, store *db.Store, rootID, model string, n, perChildTokens int, rootDelegations []Delegation) {
+	t.Helper()
+	ctx := context.Background()
+	insertCompletedJob(t, store, db.Job{ID: rootID, Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-380", TaskID: "task-380", Sender: "coord", Model: model,
+		Result: &AgentResult{Decision: "approved", Summary: "tree", Delegations: rootDelegations},
+	})
+	for i := 0; i < n; i++ {
+		childID := rootID + "/child" + string(rune('a'+i))
+		insertCompletedJob(t, store, db.Job{ID: childID, Agent: "w", Type: "ask"}, JobPayload{
+			Repo: "jerryfane/gitmoot", Branch: "task-380", TaskID: "task-380", Sender: "w",
+			RootJobID: rootID, Model: model,
+			Result: &AgentResult{Decision: "approved", Summary: "child"},
+		})
+		if err := store.UpdateJobUsage(ctx, childID, 0, perChildTokens); err != nil {
+			t.Fatalf("UpdateJobUsage(%s) returned error: %v", childID, err)
+		}
+	}
+}
+
+// TestSumRootDelegationCost pins the per-root cost aggregation: it prices each
+// job's measured token usage through its model and sums the root coordinator plus
+// every job pointing back at it, ignoring jobs from other roots.
+func TestSumRootDelegationCost(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+
+	// Root R on Opus: coordinator (1e6 in / 1e6 out => $90) + one Opus child
+	// (1e6 out => $75) => $165 total.
+	insertCompletedJob(t, store, db.Job{ID: "R", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", TaskID: "task-380", Sender: "coord", Model: "claude-opus-4-8",
+		Result: &AgentResult{Decision: "approved", Summary: "root"},
+	})
+	if err := store.UpdateJobUsage(ctx, "R", 1_000_000, 1_000_000); err != nil {
+		t.Fatalf("UpdateJobUsage(R) returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "R/c1", Agent: "w", Type: "ask"}, JobPayload{
+		RootJobID: "R", Model: "claude-opus-4-8", Result: &AgentResult{Decision: "approved", Summary: "c1"},
+	})
+	if err := store.UpdateJobUsage(ctx, "R/c1", 0, 1_000_000); err != nil {
+		t.Fatalf("UpdateJobUsage(R/c1) returned error: %v", err)
+	}
+	// Unrelated root S with usage that must NOT be counted toward R.
+	insertCompletedJob(t, store, db.Job{ID: "S", Agent: "coord", Type: "ask"}, JobPayload{
+		Model: "claude-opus-4-8", Result: &AgentResult{Decision: "approved", Summary: "other root"},
+	})
+	if err := store.UpdateJobUsage(ctx, "S", 1_000_000, 1_000_000); err != nil {
+		t.Fatalf("UpdateJobUsage(S) returned error: %v", err)
+	}
+
+	got, err := engine.sumRootDelegationCost(ctx, "R")
+	if err != nil {
+		t.Fatalf("sumRootDelegationCost returned error: %v", err)
+	}
+	if want := 90.0 + 75.0; !floatNear(got, want, 1e-9) {
+		t.Fatalf("sumRootDelegationCost(R) = %v, want %v", got, want)
+	}
+}
+
+// TestEngineCostBudgetTripEnqueuesFinalize pins #380: a coordination tree whose
+// measured cost has reached the dollar budget does not dispatch its next
+// generation; instead it gets one graceful finalize continuation and emits
+// delegation_cost_usd_exceeded — exactly mirroring the token-budget trip.
+func TestEngineCostBudgetTripEnqueuesFinalize(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+
+	engine := testEngine(store)
+	engine.MaxDelegationCostUSD = 100.0
+
+	// Two Opus children of 1,000,000 output tokens each => $75 + $75 = $150 spent
+	// >= $100 budget.
+	seedCostTree(t, store, "over", "claude-opus-4-8", 2, 1_000_000, []Delegation{
+		{ID: "d0", Agent: "w", Action: "ask", Prompt: "work"},
+		{ID: "d1", Agent: "w", Action: "ask", Prompt: "work"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "over"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if jobExists(t, store, "over/delegation/d0") || jobExists(t, store, "over/delegation/d1") {
+		t.Fatal("over-budget delegations must not be dispatched")
+	}
+	if got := countJobEvents(t, store, "over", "delegation_cost_usd_exceeded"); got != 1 {
+		t.Fatalf("delegation_cost_usd_exceeded events = %d, want 1", got)
+	}
+	cont, err := unmarshalPayload(mustJob(t, store, "over/continuation").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if !cont.DelegationFinalize {
+		t.Fatalf("finalize continuation must carry DelegationFinalize: %+v", cont)
+	}
+	if got := countJobEvents(t, store, "over", "delegation_finalize_enqueued"); got != 1 {
+		t.Fatalf("delegation_finalize_enqueued events = %d, want 1", got)
+	}
+}
+
+// TestEngineWithinCostBudgetDispatches is the control: a tree whose measured cost
+// is strictly under the dollar budget dispatches its next generation normally and
+// emits no cost-exceeded event.
+func TestEngineWithinCostBudgetDispatches(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+
+	engine := testEngine(store)
+	engine.MaxDelegationCostUSD = 100.0
+
+	// One Opus child of 1,000,000 output tokens => $75 spent < $100 budget.
+	seedCostTree(t, store, "under", "claude-opus-4-8", 1, 1_000_000, []Delegation{
+		{ID: "d0", Agent: "w", Action: "ask", Prompt: "work"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "under"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if !jobExists(t, store, "under/delegation/d0") {
+		t.Fatal("in-budget delegations must be dispatched")
+	}
+	if got := countJobEvents(t, store, "under", "delegation_cost_usd_exceeded"); got != 0 {
+		t.Fatalf("delegation_cost_usd_exceeded events = %d, want 0", got)
+	}
+}
+
+// TestEngineZeroCostBudgetIsUnlimited is the byte-identical-default control: with
+// the cost budget left at 0 (the default), a tree that has spent a large amount
+// still dispatches and never trips the cost backstop, proving the check is fully
+// skipped when unset.
+func TestEngineZeroCostBudgetIsUnlimited(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+
+	engine := testEngine(store) // MaxDelegationCostUSD defaults to 0 => unlimited
+
+	// A child with a huge Opus token count; with the budget 0 it must be ignored.
+	seedCostTree(t, store, "unbounded", "claude-opus-4-8", 1, 100_000_000, []Delegation{
+		{ID: "d0", Agent: "w", Action: "ask", Prompt: "work"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "unbounded"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if !jobExists(t, store, "unbounded/delegation/d0") {
+		t.Fatal("with budget 0 (unlimited), delegations must still be dispatched")
+	}
+	if got := countJobEvents(t, store, "unbounded", "delegation_cost_usd_exceeded"); got != 0 {
+		t.Fatalf("delegation_cost_usd_exceeded events = %d, want 0 with unlimited budget", got)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -69,6 +69,21 @@ type Engine struct {
 	// runtime that does not report usage contributes 0 to the sum, so the budget
 	// under-counts that runtime rather than failing.
 	MaxDelegationTokenBudget int
+	// MaxDelegationCostUSD is the cumulative per-root dollar-cost budget that bounds
+	// a delegation tree by its measured spend, layered on top of the token budget
+	// (#380). Cost is derived from the same per-job token usage the token budget
+	// already sums, priced through a small per-model price table (see cost.go):
+	// cost = Σ (input × input_price + output × output_price) over every job in the
+	// tree. When a coordinator is about to dispatch a new generation and the tree
+	// has already spent at least this many dollars, dispatchDelegations refuses
+	// further fan-out and routes to the #305 finalize continuation
+	// (delegation_cost_usd_exceeded). 0 (the default) means unlimited: the check is
+	// skipped entirely so default behavior is byte-identical to before this knob
+	// existed. It is sourced from the host [orchestrate].max_delegation_cost_usd
+	// config at daemon startup. Because cost is derived from best-effort token
+	// capture and a hardcoded price table, treat it as a coarse runaway-cost
+	// backstop, not a precise spend meter.
+	MaxDelegationCostUSD float64
 }
 
 // now returns the engine's current time, defaulting to time.Now when Now is unset.
@@ -933,6 +948,27 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 				Message: fmt.Sprintf("delegation tree %s reached token budget %d (used %d); not dispatching %d delegation(s)", rootID, e.MaxDelegationTokenBudget, used, len(payload.Result.Delegations)),
 			})
 			return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("token budget %d reached", e.MaxDelegationTokenBudget))
+		}
+	}
+
+	// Per-root dollar-cost budget (#380). This is the cost analogue of the token
+	// budget above: where the token budget bounds raw token count, this bounds the
+	// measured spend derived from those same tokens × a per-model price table (see
+	// cost.go). A tree that has already spent at least MaxDelegationCostUSD dollars
+	// is refused further fan-out and routed to the same #305 finalize continuation,
+	// exactly like every backstop above — never hard-killed. It is opt-in: when the
+	// budget is 0 (the default) the check is skipped entirely, so default behavior
+	// is byte-identical. The sum fails open (a lookup/parse hiccup yields 0 and does
+	// not block dispatch) and is best-effort per runtime: a runtime that reports no
+	// usage contributes $0, so the budget under-counts that runtime.
+	if e.MaxDelegationCostUSD > 0 {
+		if spent, _ := e.sumRootDelegationCost(ctx, rootID); spent >= e.MaxDelegationCostUSD {
+			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   job.ID,
+				Kind:    "delegation_cost_usd_exceeded",
+				Message: fmt.Sprintf("delegation tree %s reached cost budget $%.4f (spent $%.4f); not dispatching %d delegation(s)", rootID, e.MaxDelegationCostUSD, spent, len(payload.Result.Delegations)),
+			})
+			return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("cost budget $%.4f reached", e.MaxDelegationCostUSD))
 		}
 	}
 

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -176,6 +176,16 @@ Delegation trees are bounded so they cannot run forever:
   below — so the budget can under-count a runtime that does not report usage; it
   never over-counts. Leaving the knob at `0` skips the check entirely (behavior is
   byte-identical to before the knob existed).
+- Per-root **dollar-cost** budget (#380): `[orchestrate].max_delegation_cost_usd`,
+  **off by default** (`0` = unlimited). The cost analogue of the token budget: it
+  bounds the same tree by *measured spend*, derived from the same per-job token
+  usage priced through a built-in per-model price table (Haiku/Sonnet/Opus list
+  prices matched by substring; unknown/empty models priced at the mid-tier Sonnet
+  default so they are never free). When the tree's accumulated cost reaches the
+  budget, the next fan-out is refused with a `delegation_cost_usd_exceeded` event
+  and routes through the finalize continuation — never hard-killed. Coarse
+  runaway-cost backstop, not a precise spend meter; leaving the knob at `0` is
+  byte-identical to before the knob existed.
 - Per-coordinator width: `MaxDelegationWidth = 16`. A single coordinator result
   may not fan out more than this many delegations in one generation; an over-wide
   set is refused with a `delegation_width_exceeded` event and routes through the

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -70,6 +70,15 @@ cannot recurse or fan out forever:
   reports it if its stream emits it; Codex `Deliver` runs without `--json` and so
   contributes `0`), so the budget can under-count but never over-counts. Leaving
   the knob at `0` skips the check entirely.
+- Per-root **dollar-cost** budget `[orchestrate].max_delegation_cost_usd`,
+  **off by default** (`0` = unlimited): the cost analogue of the token budget
+  (#380). It bounds the same tree by *measured spend* — the same per-job token
+  usage priced through a built-in per-model price table (Haiku/Sonnet/Opus list
+  prices, matched by substring; unknown models priced at the mid-tier Sonnet
+  default so they are never free). When the tree's accumulated cost reaches the
+  budget, the next fan-out is refused with a `delegation_cost_usd_exceeded` event
+  and routed to the finalize continuation — never hard-killed. Coarse backstop,
+  not a precise spend meter; leaving the knob at `0` skips the check entirely.
 - Per-coordinator width `MaxDelegationWidth = 16`: a single coordinator result
   may not fan out more than this many delegations in one generation; an over-wide
   set is refused with a `delegation_width_exceeded` event.


### PR DESCRIPTION
## Summary
Closes #380. Per-root **dollar-cost** budget + circuit breaker for delegation trees, mirroring the per-root **token** budget (#338). Additive, default-OFF — no behavior change unless `max_delegation_cost_usd` is set.

## What it does
- `internal/workflow/cost.go` — a per-model **price table** (opus $15/$75, sonnet $3/$15, haiku $0.25/$1.25 per 1M in/out; unknown → mid-tier Sonnet, never $0), `costFromTokens` (negative-clamped), and `sumRootDelegationCost` (prices every job in the root's tree from its measured input/output tokens).
- `Engine.MaxDelegationCostUSD` + a breaker in `dispatchDelegations`, placed right after the token-budget check and reusing the SAME trip path (`enqueueFinalizeContinuation` — the #305 graceful finalize, never a hard kill).
- Config `[orchestrate].max_delegation_cost_usd` (float, default 0 = off, rejects negative), wired via `applyOrchestratePolicy`.

## Safety
- Default-off (`if MaxDelegationCostUSD > 0`) → byte-identical when unset.
- Fail-open: a price/aggregation error yields $0, never blocks dispatch.
- Coarse backstop (documented): cost rides on best-effort token capture (same caveat as #338); under-counts rather than over-counts.

## Tests
Price tiering, cost formula + clamp, per-root accumulation, breaker → graceful finalize, in-budget control, zero-budget default unchanged, config parse/invalid. Full gate (`go build/vet/test` + `go test -race ./internal/workflow/`) green; adversarial review clean.

Note: like the #338 token budget it mirrors, the breaker is validated at the engine/unit level — a live over-budget delegation-tree E2E needs the full Orchestra flow with real runtimes (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
