### PR TITLE
feat(workflow): model-tier complexity-scoring helper + routing recommendation docs (#379)

### DIFF
--- a/internal/workflow/modeltier.go
+++ b/internal/workflow/modeltier.go
@@ -1,0 +1,252 @@
+package workflow
+
+import "strings"
+
+// Model-tier complexity scoring (issue #379).
+//
+// This file is a PURE, deterministic, side-effect-free primitive. It scores a
+// delegation's likely difficulty and maps that score to an abstract model Tier
+// so a future coordinator-policy step (or a CLI command, or a test) can decide
+// whether to downshift the per-delegation `model` to a cheaper runtime model,
+// leave it empty for the runtime default, or reserve a deep model for genuinely
+// hard work.
+//
+// CRITICAL: nothing in the engine, dispatcher, or scheduler calls into this
+// file. It is intentionally NOT wired into job dispatch — invoking it has zero
+// behavioral effect on how delegations run. Tiers are deliberately abstract:
+// there is no tier -> concrete vendor-model (codex/claude/kimi) map here, and
+// the `standard` tier maps to an empty `model` (the runtime default) by design.
+//
+// ALL of the weights, thresholds, and keyword lists below are HEURISTIC and
+// UNCALIBRATED. They encode a rough intuition ("longer + harder keywords +
+// multi-file implement == more complex"), not a measured model. Treat the exact
+// numbers as a starting point to be tuned, not as ground truth.
+
+// Tier is an abstract difficulty band for a delegation. It is intentionally not
+// bound to any concrete vendor model; mapping a Tier to a runtime model string
+// is a separate, deferred product decision.
+type Tier string
+
+const (
+	// TierMechanical is reserved for trivial, rote, deterministic edits (e.g. a
+	// rename or a codemod-style change). It is selected ONLY by an explicit intent
+	// match, never from the numeric complexity score.
+	TierMechanical Tier = "mechanical"
+	// TierCheap is for low-complexity work that a small/fast model can handle.
+	TierCheap Tier = "cheap"
+	// TierStandard is the default band; it maps to an empty `model` (runtime
+	// default) rather than to a specific model.
+	TierStandard Tier = "standard"
+	// TierDeep is for genuinely hard or quorum-critical work that warrants a
+	// strong, expensive model.
+	TierDeep Tier = "deep"
+)
+
+// Heuristic scoring weights and thresholds. Uncalibrated — see the file-level
+// doc comment. Each contribution is clamped so the total stays within [0, 1].
+const (
+	// promptLenFullScoreChars is the prompt length (in characters) at which the
+	// length signal reaches its full weight. Shorter prompts scale linearly below
+	// it.
+	promptLenFullScoreChars = 1200.0
+	// weightPromptLen is the maximum contribution of the prompt-length signal.
+	weightPromptLen = 0.30
+	// weightHardKeyword is the contribution of the FIRST matched hard keyword.
+	weightHardKeyword = 0.35
+	// weightHardKeywordEach is the additional contribution of each further hard
+	// keyword beyond the first, so several hard keywords push harder than one.
+	weightHardKeywordEach = 0.10
+	// maxHardKeywordScore caps the total hard-keyword contribution.
+	maxHardKeywordScore = 0.55
+	// weightImplementAction is the contribution of an implement-style action; an
+	// `ask` contributes nothing here (an ask is cheaper than a multi-file
+	// implement).
+	weightImplementAction = 0.20
+	// weightReviewAction is the (smaller) contribution of a review-style action.
+	weightReviewAction = 0.10
+	// weightScopeSignal is the contribution of the scope signal (a delegation
+	// that fans across many artifacts or carries a worktree is wider in scope).
+	weightScopeSignal = 0.15
+	// scopeArtifactThreshold is the artifact count at or above which the scope
+	// signal fires on artifact breadth alone.
+	scopeArtifactThreshold = 2
+	// weightQuorumCritical is the contribution of a quorum-critical leg; quorum
+	// legs gate the coordinator, so they lean toward a deeper model.
+	weightQuorumCritical = 0.20
+)
+
+// Tier thresholds over the complexity score. Fixed by design (issue #379):
+// `<0.3 -> cheap`, `<0.6 -> standard`, `>=0.6 -> deep`. `mechanical` is never
+// produced from the score — only from an explicit intent match.
+const (
+	tierCheapBelow    = 0.30
+	tierStandardBelow = 0.60
+)
+
+// hardKeywords are tokens whose presence in a delegation's prompt strongly
+// suggests genuinely hard work (architecture, security, data-shape, or
+// concurrency reasoning). Heuristic and non-exhaustive. Matched
+// case-insensitively as substrings.
+var hardKeywords = []string{
+	"architecture",
+	"oauth",
+	"schema",
+	"concurrency",
+	"migration",
+	"security",
+	"refactor",
+	"distributed",
+	"consensus",
+	"cryptograph",
+	"race condition",
+	"deadlock",
+	"transaction",
+	"performance",
+}
+
+// mechanicalKeywords are explicit intent tokens that mark a delegation as rote,
+// deterministic, mechanical work. A match selects TierMechanical directly,
+// independent of the numeric complexity score. Heuristic and non-exhaustive.
+var mechanicalKeywords = []string{
+	"rename",
+	"codemod",
+	"find and replace",
+	"find-and-replace",
+	"bump version",
+	"format the",
+	"run gofmt",
+	"fix typo",
+	"fix the typo",
+	"regenerate",
+}
+
+// implementActions are the action verbs that imply writing code (and so tend to
+// be more complex than a read-only ask/review). Matched against the
+// delegation's Action, case-insensitively.
+var implementActions = map[string]struct{}{
+	"implement": {},
+	"fix":       {},
+	"build":     {},
+	"write":     {},
+	"refactor":  {},
+	"migrate":   {},
+}
+
+// reviewActions are read-style action verbs that carry a small complexity
+// contribution (more than a bare ask, less than an implement).
+var reviewActions = map[string]struct{}{
+	"review": {},
+	"audit":  {},
+	"verify": {},
+}
+
+// ScoreComplexity returns a deterministic complexity estimate in [0, 1] for a
+// delegation, combining a prompt-length signal, a hard-keyword signal, the
+// action type (an ask is cheaper than a multi-file implement), a scope signal
+// (artifact breadth / worktree), and whether the leg is quorum-critical.
+//
+// It is pure and side-effect-free; it reads only the passed delegation and is
+// not called by the engine. All weights are heuristic — see the file-level doc
+// comment.
+func ScoreComplexity(d Delegation) float64 {
+	var score float64
+
+	// Length signal: longer prompts tend to describe more involved work. Scales
+	// linearly up to promptLenFullScoreChars, then saturates at weightPromptLen.
+	promptLen := float64(len(strings.TrimSpace(d.Prompt)))
+	lenFraction := promptLen / promptLenFullScoreChars
+	if lenFraction > 1 {
+		lenFraction = 1
+	}
+	score += lenFraction * weightPromptLen
+
+	// Hard-keyword signal: the first match contributes weightHardKeyword, each
+	// further distinct match adds weightHardKeywordEach, capped at
+	// maxHardKeywordScore.
+	if matches := countHardKeywords(d.Prompt); matches > 0 {
+		kw := weightHardKeyword + float64(matches-1)*weightHardKeywordEach
+		if kw > maxHardKeywordScore {
+			kw = maxHardKeywordScore
+		}
+		score += kw
+	}
+
+	// Action signal: implement-style actions imply writing (multi-file) code and
+	// score highest; review-style actions score a little; a bare ask scores zero.
+	action := strings.ToLower(strings.TrimSpace(d.Action))
+	if _, ok := implementActions[action]; ok {
+		score += weightImplementAction
+	} else if _, ok := reviewActions[action]; ok {
+		score += weightReviewAction
+	}
+
+	// Scope signal: a delegation that fans across multiple artifacts or carries a
+	// dedicated worktree is wider in scope than a single-target one.
+	if len(d.Artifacts) >= scopeArtifactThreshold || strings.TrimSpace(d.Worktree) != "" {
+		score += weightScopeSignal
+	}
+
+	// Quorum-critical legs gate the coordinator continuation, so bias them upward.
+	if d.Quorum > 0 {
+		score += weightQuorumCritical
+	}
+
+	if score > 1 {
+		score = 1
+	}
+	if score < 0 {
+		score = 0
+	}
+	return score
+}
+
+// countHardKeywords returns the number of distinct hard keywords present in the
+// prompt (case-insensitive substring match).
+func countHardKeywords(prompt string) int {
+	lower := strings.ToLower(prompt)
+	count := 0
+	for _, kw := range hardKeywords {
+		if strings.Contains(lower, kw) {
+			count++
+		}
+	}
+	return count
+}
+
+// TierFor maps a complexity score in [0, 1] to an abstract Tier using the fixed
+// thresholds from issue #379: `<0.3 -> cheap`, `<0.6 -> standard`,
+// `>=0.6 -> deep`. It never returns TierMechanical — that band is reachable only
+// through TierForDelegation's explicit intent match, not from the score.
+func TierFor(score float64) Tier {
+	switch {
+	case score < tierCheapBelow:
+		return TierCheap
+	case score < tierStandardBelow:
+		return TierStandard
+	default:
+		return TierDeep
+	}
+}
+
+// TierForDelegation is the convenience entry point: it returns TierMechanical
+// when the delegation's prompt carries an explicit mechanical-intent keyword,
+// and otherwise falls back to TierFor(ScoreComplexity(d)). Like everything in
+// this file, it is a pure helper and is not invoked by the engine.
+func TierForDelegation(d Delegation) Tier {
+	if hasMechanicalIntent(d.Prompt) {
+		return TierMechanical
+	}
+	return TierFor(ScoreComplexity(d))
+}
+
+// hasMechanicalIntent reports whether the prompt explicitly signals rote,
+// mechanical work via a mechanicalKeywords match (case-insensitive substring).
+func hasMechanicalIntent(prompt string) bool {
+	lower := strings.ToLower(prompt)
+	for _, kw := range mechanicalKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workflow/modeltier_test.go
+++ b/internal/workflow/modeltier_test.go
@@ -1,0 +1,235 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestScoreComplexityRange asserts the score always lands in [0, 1], including
+// for a maximally loaded delegation that would otherwise overflow the clamp.
+func TestScoreComplexityRange(t *testing.T) {
+	cases := []Delegation{
+		{Action: "ask", Prompt: "hi"},
+		{
+			Action:    "implement",
+			Prompt:    strings.Repeat("architecture oauth schema concurrency migration security refactor ", 50),
+			Artifacts: []string{"a", "b", "c"},
+			Worktree:  "wt",
+			Quorum:    2,
+		},
+	}
+	for i, d := range cases {
+		got := ScoreComplexity(d)
+		if got < 0 || got > 1 {
+			t.Fatalf("case %d: score %v out of [0,1]", i, got)
+		}
+	}
+}
+
+// TestScoreComplexityHardKeywords checks the hard-keyword signal: a single hard
+// keyword lifts the score, multiple keywords lift it further, and the keyword
+// contribution is capped.
+func TestScoreComplexityHardKeywords(t *testing.T) {
+	base := Delegation{ID: "x", Agent: "a", Action: "ask", Prompt: "do a small thing"}
+	one := Delegation{ID: "x", Agent: "a", Action: "ask", Prompt: "redesign the architecture"}
+	many := Delegation{ID: "x", Agent: "a", Action: "ask", Prompt: "architecture oauth schema concurrency migration security"}
+
+	baseScore := ScoreComplexity(base)
+	oneScore := ScoreComplexity(one)
+	manyScore := ScoreComplexity(many)
+
+	if !(baseScore < oneScore) {
+		t.Fatalf("one hard keyword should raise the score: base=%v one=%v", baseScore, oneScore)
+	}
+	if !(oneScore < manyScore) {
+		t.Fatalf("more hard keywords should raise the score: one=%v many=%v", oneScore, manyScore)
+	}
+	// The hard-keyword contribution is capped (maxHardKeywordScore = 0.55), so
+	// piling on keywords alone (with a cheap ask action) clears the cheap band
+	// but does not by itself reach the deep band — extra signals are needed.
+	if got := TierFor(manyScore); got == TierCheap {
+		t.Fatalf("six hard keywords should clear the cheap band, got %q (score=%v)", got, manyScore)
+	}
+	// Add an implement action to the same hard-keyword prompt and it should now
+	// clear the deep threshold.
+	deep := Delegation{ID: "x", Agent: "a", Action: "implement", Prompt: many.Prompt}
+	if got := TierFor(ScoreComplexity(deep)); got != TierDeep {
+		t.Fatalf("hard keywords plus an implement action should reach deep, got %q (score=%v)", got, ScoreComplexity(deep))
+	}
+}
+
+// TestScoreComplexityActionType checks that an implement-style action scores
+// higher than a review, which scores higher than a bare ask, holding the prompt
+// constant.
+func TestScoreComplexityActionType(t *testing.T) {
+	const prompt = "touch the handler"
+	ask := ScoreComplexity(Delegation{Action: "ask", Prompt: prompt})
+	review := ScoreComplexity(Delegation{Action: "review", Prompt: prompt})
+	implement := ScoreComplexity(Delegation{Action: "implement", Prompt: prompt})
+
+	if !(ask < review) {
+		t.Fatalf("review should score above ask: ask=%v review=%v", ask, review)
+	}
+	if !(review < implement) {
+		t.Fatalf("implement should score above review: review=%v implement=%v", review, implement)
+	}
+	// An ask contributes nothing from the action signal.
+	if ask != ScoreComplexity(Delegation{Action: "unknown-verb", Prompt: prompt}) {
+		t.Fatalf("ask and an unknown action should score equally on the action signal")
+	}
+}
+
+// TestScoreComplexityScopeSignal checks the scope signal fires on artifact
+// breadth or a worktree, and not for a single-target leg.
+func TestScoreComplexityScopeSignal(t *testing.T) {
+	const prompt = "edit one file"
+	narrow := ScoreComplexity(Delegation{Action: "ask", Prompt: prompt})
+	oneArtifact := ScoreComplexity(Delegation{Action: "ask", Prompt: prompt, Artifacts: []string{"a"}})
+	manyArtifacts := ScoreComplexity(Delegation{Action: "ask", Prompt: prompt, Artifacts: []string{"a", "b"}})
+	withWorktree := ScoreComplexity(Delegation{Action: "ask", Prompt: prompt, Worktree: "wt"})
+
+	if narrow != oneArtifact {
+		t.Fatalf("a single artifact should not fire the scope signal: narrow=%v one=%v", narrow, oneArtifact)
+	}
+	if !(narrow < manyArtifacts) {
+		t.Fatalf("multiple artifacts should fire the scope signal: narrow=%v many=%v", narrow, manyArtifacts)
+	}
+	if !(narrow < withWorktree) {
+		t.Fatalf("a worktree should fire the scope signal: narrow=%v worktree=%v", narrow, withWorktree)
+	}
+}
+
+// TestScoreComplexityQuorum checks a quorum-critical leg scores above an
+// otherwise identical non-quorum leg.
+func TestScoreComplexityQuorum(t *testing.T) {
+	const prompt = "review this"
+	plain := ScoreComplexity(Delegation{Action: "review", Prompt: prompt})
+	quorum := ScoreComplexity(Delegation{Action: "review", Prompt: prompt, Quorum: 2})
+	if !(plain < quorum) {
+		t.Fatalf("a quorum leg should score above a non-quorum leg: plain=%v quorum=%v", plain, quorum)
+	}
+}
+
+// TestScoreComplexityPromptLength checks that a longer prompt scores at least as
+// high as a short one, all else equal, and saturates at the configured cap.
+func TestScoreComplexityPromptLength(t *testing.T) {
+	short := ScoreComplexity(Delegation{Action: "ask", Prompt: "short"})
+	long := ScoreComplexity(Delegation{Action: "ask", Prompt: strings.Repeat("x", 600)})
+	saturated := ScoreComplexity(Delegation{Action: "ask", Prompt: strings.Repeat("x", 5000)})
+
+	if !(short < long) {
+		t.Fatalf("a longer prompt should score higher: short=%v long=%v", short, long)
+	}
+	if !(long < saturated) {
+		t.Fatalf("a much longer prompt should score higher up to saturation: long=%v saturated=%v", long, saturated)
+	}
+	// Beyond saturation, additional length adds nothing.
+	beyond := ScoreComplexity(Delegation{Action: "ask", Prompt: strings.Repeat("x", 50000)})
+	if saturated != beyond {
+		t.Fatalf("length signal should saturate: saturated=%v beyond=%v", saturated, beyond)
+	}
+}
+
+// TestTierForBoundaries pins the fixed thresholds from issue #379, including the
+// exact boundary values (the `<` comparisons mean 0.3 and 0.6 fall into the
+// upper band).
+func TestTierForBoundaries(t *testing.T) {
+	cases := []struct {
+		name  string
+		score float64
+		want  Tier
+	}{
+		{"zero", 0.0, TierCheap},
+		{"just below cheap cap", 0.299, TierCheap},
+		{"exactly 0.3 is standard", 0.30, TierStandard},
+		{"mid standard", 0.45, TierStandard},
+		{"just below deep cap", 0.599, TierStandard},
+		{"exactly 0.6 is deep", 0.60, TierDeep},
+		{"high", 0.95, TierDeep},
+		{"one", 1.0, TierDeep},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TierFor(tc.score); got != tc.want {
+				t.Fatalf("TierFor(%v) = %q, want %q", tc.score, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTierForNeverMechanical asserts TierFor never returns mechanical, no matter
+// the score — mechanical is reachable only via explicit intent.
+func TestTierForNeverMechanical(t *testing.T) {
+	for s := 0.0; s <= 1.0; s += 0.05 {
+		if got := TierFor(s); got == TierMechanical {
+			t.Fatalf("TierFor(%v) returned mechanical; it must come only from intent", s)
+		}
+	}
+}
+
+// TestTierForDelegationMechanicalIntent checks that an explicit mechanical
+// keyword selects TierMechanical even when the numeric score would otherwise be
+// high, and that without such a keyword the tier follows the score.
+func TestTierForDelegationMechanicalIntent(t *testing.T) {
+	cases := []struct {
+		name string
+		d    Delegation
+		want Tier
+	}{
+		{
+			name: "rename intent wins over a high score",
+			d: Delegation{
+				Action: "implement",
+				// Loaded with hard keywords so the score is high, but the explicit
+				// rename intent should still pin it to mechanical.
+				Prompt:    "rename the Foo symbol across the security and migration architecture",
+				Artifacts: []string{"a", "b"},
+			},
+			want: TierMechanical,
+		},
+		{
+			name: "codemod intent",
+			d:    Delegation{Action: "implement", Prompt: "run a codemod to update the import paths"},
+			want: TierMechanical,
+		},
+		{
+			name: "no intent, low score falls to cheap",
+			d:    Delegation{Action: "ask", Prompt: "what does this do"},
+			want: TierCheap,
+		},
+		{
+			name: "no intent, hard work falls to deep",
+			d: Delegation{
+				Action: "implement",
+				Prompt: "redesign the oauth and concurrency architecture with a schema migration",
+				Quorum: 2,
+			},
+			want: TierDeep,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TierForDelegation(tc.d); got != tc.want {
+				t.Fatalf("TierForDelegation(%q) = %q, want %q (score=%v)",
+					tc.d.Prompt, got, tc.want, ScoreComplexity(tc.d))
+			}
+		})
+	}
+}
+
+// TestScoreComplexityDeterministic checks the helper is pure: repeated calls on
+// the same input return the same score.
+func TestScoreComplexityDeterministic(t *testing.T) {
+	d := Delegation{
+		Action:    "implement",
+		Prompt:    "implement an oauth flow with a schema migration",
+		Artifacts: []string{"a", "b"},
+		Quorum:    3,
+	}
+	first := ScoreComplexity(d)
+	for i := 0; i < 5; i++ {
+		if got := ScoreComplexity(d); got != first {
+			t.Fatalf("ScoreComplexity not deterministic: first=%v call %d=%v", first, i, got)
+		}
+	}
+}

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -85,6 +85,44 @@ Delegation fields:
   job (for example a Codex, Claude Code, or Kimi Code model name). When omitted,
   the delegated agent's configured default model is used. There is no allow-list;
   Gitmoot passes the value through to the runtime as-is.
+
+  **Model-tier routing (recommendation).** Picking a per-delegation `model` is
+  the coordinator's call — Gitmoot does not choose or override it. As a costing
+  heuristic, think of each leg as falling into one of four abstract **tiers**,
+  then map the tier to a concrete model for whichever runtime the leg uses:
+
+  - **mechanical** — rote, deterministic edits (a rename, a codemod-style
+    find-and-replace, a version bump, regenerating a file). Use the smallest /
+    cheapest model.
+  - **cheap** — low-complexity legs (a short `ask`, a narrow single-file
+    lookup). A small, fast model is enough.
+  - **standard** — ordinary work with no strong hardness signal. **Leave
+    `model` empty** so the leg runs on the delegated agent's runtime default.
+  - **deep** — genuinely hard or quorum-critical legs. Reserve a strong,
+    expensive model.
+
+  Cheap **hardness signals** a coordinator can read off a leg before dispatch: a
+  long, detailed prompt; hard-topic keywords (`architecture`, `oauth`, `schema`,
+  `concurrency`, `migration`, `security`, `refactor`, …); a multi-file
+  `implement`/`fix` action versus a read-only `ask`; broad scope (several
+  `artifacts` or a dedicated `worktree`); and whether the leg is part of a
+  `quorum`. More of these lean **deep**; their absence leans **cheap**. Gitmoot
+  ships an uncalibrated helper for this — `workflow.ScoreComplexity` /
+  `workflow.TierFor` (`internal/workflow/modeltier.go`) — that turns a
+  delegation into a tier. It is a pure recommendation primitive: the engine
+  never calls it and never overrides a coordinator's chosen `model`.
+
+  **Cascade / escalate-in-continuation pattern.** Prefer to start a leg on the
+  cheapest plausible tier and **escalate in a continuation** only if it falls
+  short: run the first attempt on a cheap/standard model, and if the result is
+  `blocked`/`failed` (or a `quorum` vote is not met), have the coordinator
+  re-issue that leg in its next round on a deep model. This keeps the common
+  case cheap while still reaching a strong model for the legs that genuinely
+  need it.
+
+  **Rule of thumb:** downshift `model` for cheap/mechanical legs; leave `model`
+  empty for standard legs (so they take the runtime default); and reserve a deep
+  model for genuinely hard or quorum-critical legs.
 - `phase` (optional): a free-form per-delegation string. It is pass-through
   metadata — Gitmoot carries it through to the child job untouched and echoes it
   back in the coordinator continuation for each delegation that set a non-empty

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -118,6 +118,44 @@ the same `delegations` field, `coordinator`, and `continuation` mechanics.
   (for example a Codex, Claude Code, or Kimi Code model name). When omitted, the
   delegated agent's configured default model is used. There is no allow-list;
   Gitmoot passes the value through to the runtime as-is.
+
+  **Model-tier routing (recommendation).** Picking a per-delegation `model` is
+  the coordinator's call — Gitmoot does not choose or override it. As a costing
+  heuristic, think of each leg as falling into one of four abstract **tiers**,
+  then map the tier to a concrete model for whichever runtime the leg uses:
+
+  - **mechanical** — rote, deterministic edits (a rename, a codemod-style
+    find-and-replace, a version bump, regenerating a file). Use the smallest /
+    cheapest model.
+  - **cheap** — low-complexity legs (a short `ask`, a narrow single-file
+    lookup). A small, fast model is enough.
+  - **standard** — ordinary work with no strong hardness signal. **Leave
+    `model` empty** so the leg runs on the delegated agent's runtime default.
+  - **deep** — genuinely hard or quorum-critical legs. Reserve a strong,
+    expensive model.
+
+  Cheap **hardness signals** a coordinator can read off a leg before dispatch: a
+  long, detailed prompt; hard-topic keywords (`architecture`, `oauth`, `schema`,
+  `concurrency`, `migration`, `security`, `refactor`, …); a multi-file
+  `implement`/`fix` action versus a read-only `ask`; broad scope (several
+  `artifacts` or a dedicated `worktree`); and whether the leg is part of a
+  `quorum`. More of these lean **deep**; their absence leans **cheap**. Gitmoot
+  ships an uncalibrated helper for this — `workflow.ScoreComplexity` /
+  `workflow.TierFor` (`internal/workflow/modeltier.go`) — that turns a
+  delegation into a tier. It is a pure recommendation primitive: the engine
+  never calls it and never overrides a coordinator's chosen `model`.
+
+  **Cascade / escalate-in-continuation pattern.** Prefer to start a leg on the
+  cheapest plausible tier and **escalate in a continuation** only if it falls
+  short: run the first attempt on a cheap/standard model, and if the result is
+  `blocked`/`failed` (or a `quorum` vote is not met), have the coordinator
+  re-issue that leg in its next round on a deep model. This keeps the common
+  case cheap while still reaching a strong model for the legs that genuinely
+  need it.
+
+  **Rule of thumb:** downshift `model` for cheap/mechanical legs; leave `model`
+  empty for standard legs (so they take the runtime default); and reserve a deep
+  model for genuinely hard or quorum-critical legs.
 - `phase` (optional): a free-form per-delegation string. It is pass-through
   metadata — Gitmoot carries it through to the child job untouched and echoes it
   back in the coordinator continuation for each delegation that set a non-empty


### PR DESCRIPTION
## Summary
Closes #379 (scoped first slice). gitmoot already threads a per-delegation `model` (Delegation.Model → … → `--model` on codex/claude/kimi, no allow-list), so model-tier routing is a **selection heuristic, not an engine change**. This ships the safe, additive primitive + guidance; the risky parts are deferred to a human decision (below).

## What it does (pure, additive, default-off — nothing dispatches on it)
- `internal/workflow/modeltier.go` — `ScoreComplexity(Delegation) float64` (0–1, from prompt length, a hard-keyword list, action type, scope, quorum) + `TierFor(score)` → `Tier` (`mechanical`/`cheap`/`standard`/`deep`). All weights/thresholds are named constants documented as heuristic. **The engine never calls it** — it's a primitive a coordinator policy / test / future step can use.
- Docs (both trees): a "Model-tier routing (recommendation)" section in RESULT_CONTRACT.md — the tiers, cheap hardness signals, and the cascade/escalate-in-continuation pattern (gitmoot's coordinator+continuation loop is already a cascade engine).
- Tests: `ScoreComplexity`/`TierFor` table tests (boundaries, keyword cap, scope, quorum, determinism).

## Deferred to a human product decision (explicitly NOT implemented)
1. Concrete tier→vendor-model map (ships with NONE; tiers abstract, `standard` = empty/runtime-default).
2. A deterministic codemod / "do-it-inline" mechanical runtime.
3. Any engine-side override of the coordinator's chosen `model`.
See `GOALS/379-design-and-deferred.md` for the full design + rationale.

Full gate (`go build/vet/test`) green; adversarial review confirmed pure/additive with deferred items absent. (Pending separate deploy step: `website/static/llms-full.txt` regen.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
