### PR TITLE
docs: v0.5.0 + v0.5.1 release notes + foreground managed-type / daemon-flag updates

### DIFF
--- a/docs/release-notes/v0.5.0.md
+++ b/docs/release-notes/v0.5.0.md
@@ -1,0 +1,37 @@
+# Gitmoot v0.5.0
+
+Headline: an opt-in **continuous worker-pool scheduler** (`--scheduler pool`)
+plus a batch of workflow/daemon fixes. The new scheduler is opt-in and the
+default per-tick scheduler is unchanged, so upgrading is safe.
+
+## What's new since v0.4.2
+
+- **feat(daemon): opt-in continuous worker-pool scheduler** (#394) —
+  `gitmoot daemon run|start --scheduler pool` keeps up to `--workers` jobs busy
+  and re-queries the queue as workers free (so a job queued *after* dispatch
+  began is picked up without waiting for the in-flight batch), with live
+  in-flight checkout accounting for working-tree safety. A read-only follow-up
+  (`ask`/`review`) blocked only by a contended same-repo checkout is auto-isolated
+  into an ephemeral detached worktree so it runs beside the holder instead of
+  deadlocking. Default stays the existing barrier.
+- **fix(daemon): `--skip-native-review-fanout` TOCTOU** (#390) — the skip flag is
+  now persisted onto the branch lock *before* the PR is opened, so the daemon's
+  PR-watcher never fans out native reviews in the gap.
+- **fix(workflow): keep the terminal-success result on a post-advance error +
+  idempotent PR create** (#387) — `agent implement --json` no longer drops the
+  result envelope when the post-implement PR advance errors; PR creation adopts a
+  concurrent/out-of-band PR instead of erroring.
+- **fix(workflow): release the cancelled job's runtime-session lock on cancel**
+  (#391) — cancelling a job no longer strands its runtime-session lock for the TTL.
+- **fix(workflow): sanitize unsafe worktree path segments** (#384) — multi-round
+  coordinators can dispatch implement again. Thanks @gaijinjoe.
+- **feat(workflow): operator kill switch for delegation trees** (#341) — stop a
+  runaway tree; the coordinator still finalizes gracefully.
+- **feat(workflow): per-root token budget for delegation trees** (#338).
+- **feat(skillopt): apply the accepted judge prompt to production** (#354).
+- **docs: running one agent's jobs concurrently** (#396); **pin the SkillOpt
+  install wheel to gitmoot-skillopt v0.3.1** (#346).
+
+All additive / opt-in (default behavior byte-identical), shipped via squash-merge
+with the CI gate green and adversarial `/code-review`. The pool scheduler and the
+#390 fix were validated end-to-end with live Codex against a real daemon.

--- a/docs/release-notes/v0.5.1.md
+++ b/docs/release-notes/v0.5.1.md
@@ -1,0 +1,42 @@
+# Gitmoot v0.5.1
+
+Five issues from the orchestration / @gaijinjoe backlog: a daemon issue-mention
+watcher, foreground managed-type dispatch, a merge-gate deadlock fix, a per-root
+cost budget, and a model-tier scoring helper. All additive / opt-in or bug fixes
+— default behavior unchanged.
+
+## What's new since v0.5.0
+
+- **feat(daemon): watch open issues for `@<agent>` mentions** (#389) — opt-in
+  `gitmoot daemon run|start --watch-issues` watches open **issues** for
+  `@<agent> ask …` mentions and routes them to jobs (mirroring the PR-comment
+  watcher), posting the result back as an issue comment. Default off. It also
+  fixed the bare `@<agent>` mention form — the documented way to summon an agent
+  — which now parses on **PR** comments too (it previously required a `/gitmoot`
+  prefix and silently did nothing).
+- **feat(cli): foreground `agent ask` dispatches to a managed agent type** (#395)
+  — a foreground `gitmoot agent ask <type>` (the `ask` action) now spins or
+  reuses a managed instance up to `max_background` instead of erroring
+  `agent not found`, so you no longer hand-clone agents for inline parallel use.
+  Single-instance-shadows-type precedence is preserved; `review`/`implement` to a
+  type still use `--background`.
+- **fix(workflow): advance integration-worktree reviews instead of deadlocking**
+  (#388) — the merge gate no longer deadlocks on a #332 decompose-and-verify
+  review whose HeadSHA was intentionally cleared. A narrow carve-out accepts the
+  empty SHA only for integration-worktree reviews; normal head-match safety is
+  intact (a mismatched head is still rejected).
+- **feat(workflow): per-root cost ($) budget + circuit breaker** (#380) — opt-in
+  `[orchestrate] max_delegation_cost_usd` trips a delegation tree to graceful
+  finalize when accumulated cost (priced from token usage via a built-in model
+  price table) exceeds the bound — the dollar parallel of the #338 token budget.
+  Default off; fail-open.
+- **feat(workflow): model-tier complexity-scoring helper + routing guidance**
+  (#379) — a pure `ScoreComplexity`/`TierFor` primitive (mechanical / cheap /
+  standard / deep) plus result-contract guidance a coordinator can use to pick a
+  `model` per delegation. Additive and inert (the engine never calls it); the
+  concrete tier→model map is deliberately left to operators.
+
+All shipped via squash-merge with the CI gate green and adversarial `/code-review`.
+#395 and #389 were verified end-to-end with live Codex (including a real GitHub
+repo for the issue watcher — which caught two live bugs the unit tests missed);
+#388 and #380 were validated by unit + `-race` + review.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -82,6 +82,14 @@ coordinator job itself, and ignores every other queued job. `--session` composes
 with `--repo` (AND): a job must match both filters to run. Leaving both empty
 keeps the default behavior of matching all enabled repos and all jobs.
 
+Both `daemon run` and `daemon start` also accept two opt-in flags (both off by
+default, so leaving them unset is byte-identical to before): `--watch-issues`
+watches open **issues** for `@<agent> ask …` mentions and routes them to jobs,
+mirroring the PR-comment watcher; `--scheduler pool` selects the continuous
+worker-pool scheduler that re-queries the queue as workers free and auto-isolates
+a contended same-repo read job into an ephemeral worktree (fixing a same-repo
+dependent-job deadlock), versus the default `--scheduler barrier`.
+
 `gitmoot dashboard` shows local state — daemon health, repos, agents and runtime
 sessions, jobs by state, worktrees, branch locks, SkillOpt train phase/candidate,
 and pending interactive prompts.
@@ -328,10 +336,10 @@ default runtime model for that managed agent type.
 A registered single instance **shadows** a managed type of the same name:
 dispatch resolves `gitmoot agent <name>` to a registered single instance before a
 type, so force the type with `--type <name>` (or do not register a single
-instance of that name). Managed-type auto-spin and `[parallel_sessions]`
-temp-session forking happen on the **background** path only — a foreground
-`gitmoot agent ask <type> --type <type>` returns `agent not found`; use
-`--background`. See WORKFLOWS.md → "Running one agent's jobs in parallel".
+instance of that name). Since **v0.5.1** a foreground `gitmoot agent ask <type>`
+(the `ask` action) dispatches to the managed type synchronously; background
+`run`/`review`/`implement` to a type and `[parallel_sessions]` temp-session
+forking use the **background** path. See WORKFLOWS.md → "Running one agent's jobs in parallel".
 
 ## Agent Templates
 

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -430,9 +430,10 @@ instances / temp sessions actually run concurrently.
 registered agent by name **first**, so if you `gitmoot agent start researcher`
 *and* `gitmoot agent type set researcher`, plain `researcher` always uses the
 single instance. Force the managed type with `--type researcher` (or don't
-register a single instance of that name). A **foreground** ask cannot route to a
-type today — `gitmoot agent ask <type> --type <type>` errors `agent not found`;
-use `--background`.
+register a single instance of that name). Since **v0.5.1** a **foreground**
+`gitmoot agent ask <type>` (the `ask` action) dispatches to the managed type
+synchronously — it spins or reuses a managed instance up to `max_background`.
+`review`/`implement` to a type still use `--background`.
 
 ## Multi-Repo Work
 

--- a/website/docs/concepts/agents-templates-jobs-locks.md
+++ b/website/docs/concepts/agents-templates-jobs-locks.md
@@ -126,8 +126,10 @@ jobs at once (default `1`; raise it, e.g. `--workers 6`).
 
 **Precedence:** dispatch resolves a registered single instance by name *before* a
 managed type, so a single agent named `researcher` shadows a `researcher` type —
-force the type with `--type researcher`. Foreground `gitmoot agent ask <type>`
-cannot route to a type today (it returns `agent not found`); use `--background`.
+force the type with `--type researcher`. Since **v0.5.1** a foreground `gitmoot
+agent ask <type>` (the `ask` action) routes to the managed type synchronously
+(spins/reuses an instance up to `max_background`); `review`/`implement` to a type
+still use `--background`.
 
 ## Locks
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -82,6 +82,14 @@ coordinator job itself, and ignores every other queued job. `--session` composes
 with `--repo` (AND): a job must match both filters to run. Leaving both empty
 keeps the default behavior of matching all enabled repos and all jobs.
 
+Both `daemon run` and `daemon start` also accept two opt-in flags (both off by
+default, so leaving them unset is byte-identical to before): `--watch-issues`
+watches open **issues** for `@<agent> ask …` mentions and routes them to jobs,
+mirroring the PR-comment watcher; `--scheduler pool` selects the continuous
+worker-pool scheduler that re-queries the queue as workers free and auto-isolates
+a contended same-repo read job into an ephemeral worktree (fixing a same-repo
+dependent-job deadlock), versus the default `--scheduler barrier`.
+
 `gitmoot dashboard` shows local state — daemon health, repos, agents and runtime
 sessions, jobs by state, worktrees, branch locks, SkillOpt train phase/candidate,
 and pending interactive prompts.
@@ -337,10 +345,10 @@ default runtime model for that managed agent type.
 A registered single instance **shadows** a managed type of the same name:
 dispatch resolves `gitmoot agent <name>` to a registered single instance before a
 type, so force the type with `--type <name>` (or do not register a single
-instance of that name). Managed-type auto-spin and `[parallel_sessions]`
-temp-session forking happen on the **background** path only — a foreground
-`gitmoot agent ask <type> --type <type>` returns `agent not found`; use
-`--background`. See [Running one agent's jobs
+instance of that name). Since **v0.5.1** a foreground `gitmoot agent ask <type>`
+(the `ask` action) dispatches to the managed type synchronously; background
+`run`/`review`/`implement` to a type and `[parallel_sessions]` temp-session
+forking use the **background** path. See [Running one agent's jobs
 concurrently](../concepts/agents-templates-jobs-locks.md#running-one-agents-jobs-concurrently).
 
 ## Agent Templates

--- a/website/docs/release-notes/v0.5.0.md
+++ b/website/docs/release-notes/v0.5.0.md
@@ -1,0 +1,37 @@
+# Gitmoot v0.5.0
+
+Headline: an opt-in **continuous worker-pool scheduler** (`--scheduler pool`)
+plus a batch of workflow/daemon fixes. The new scheduler is opt-in and the
+default per-tick scheduler is unchanged, so upgrading is safe.
+
+## What's new since v0.4.2
+
+- **feat(daemon): opt-in continuous worker-pool scheduler** (#394) —
+  `gitmoot daemon run|start --scheduler pool` keeps up to `--workers` jobs busy
+  and re-queries the queue as workers free (so a job queued *after* dispatch
+  began is picked up without waiting for the in-flight batch), with live
+  in-flight checkout accounting for working-tree safety. A read-only follow-up
+  (`ask`/`review`) blocked only by a contended same-repo checkout is auto-isolated
+  into an ephemeral detached worktree so it runs beside the holder instead of
+  deadlocking. Default stays the existing barrier.
+- **fix(daemon): `--skip-native-review-fanout` TOCTOU** (#390) — the skip flag is
+  now persisted onto the branch lock *before* the PR is opened, so the daemon's
+  PR-watcher never fans out native reviews in the gap.
+- **fix(workflow): keep the terminal-success result on a post-advance error +
+  idempotent PR create** (#387) — `agent implement --json` no longer drops the
+  result envelope when the post-implement PR advance errors; PR creation adopts a
+  concurrent/out-of-band PR instead of erroring.
+- **fix(workflow): release the cancelled job's runtime-session lock on cancel**
+  (#391) — cancelling a job no longer strands its runtime-session lock for the TTL.
+- **fix(workflow): sanitize unsafe worktree path segments** (#384) — multi-round
+  coordinators can dispatch implement again. Thanks @gaijinjoe.
+- **feat(workflow): operator kill switch for delegation trees** (#341) — stop a
+  runaway tree; the coordinator still finalizes gracefully.
+- **feat(workflow): per-root token budget for delegation trees** (#338).
+- **feat(skillopt): apply the accepted judge prompt to production** (#354).
+- **docs: running one agent's jobs concurrently** (#396); **pin the SkillOpt
+  install wheel to gitmoot-skillopt v0.3.1** (#346).
+
+All additive / opt-in (default behavior byte-identical), shipped via squash-merge
+with the CI gate green and adversarial `/code-review`. The pool scheduler and the
+#390 fix were validated end-to-end with live Codex against a real daemon.

--- a/website/docs/release-notes/v0.5.1.md
+++ b/website/docs/release-notes/v0.5.1.md
@@ -1,0 +1,42 @@
+# Gitmoot v0.5.1
+
+Five issues from the orchestration / @gaijinjoe backlog: a daemon issue-mention
+watcher, foreground managed-type dispatch, a merge-gate deadlock fix, a per-root
+cost budget, and a model-tier scoring helper. All additive / opt-in or bug fixes
+— default behavior unchanged.
+
+## What's new since v0.5.0
+
+- **feat(daemon): watch open issues for `@<agent>` mentions** (#389) — opt-in
+  `gitmoot daemon run|start --watch-issues` watches open **issues** for
+  `@<agent> ask …` mentions and routes them to jobs (mirroring the PR-comment
+  watcher), posting the result back as an issue comment. Default off. It also
+  fixed the bare `@<agent>` mention form — the documented way to summon an agent
+  — which now parses on **PR** comments too (it previously required a `/gitmoot`
+  prefix and silently did nothing).
+- **feat(cli): foreground `agent ask` dispatches to a managed agent type** (#395)
+  — a foreground `gitmoot agent ask <type>` (the `ask` action) now spins or
+  reuses a managed instance up to `max_background` instead of erroring
+  `agent not found`, so you no longer hand-clone agents for inline parallel use.
+  Single-instance-shadows-type precedence is preserved; `review`/`implement` to a
+  type still use `--background`.
+- **fix(workflow): advance integration-worktree reviews instead of deadlocking**
+  (#388) — the merge gate no longer deadlocks on a #332 decompose-and-verify
+  review whose HeadSHA was intentionally cleared. A narrow carve-out accepts the
+  empty SHA only for integration-worktree reviews; normal head-match safety is
+  intact (a mismatched head is still rejected).
+- **feat(workflow): per-root cost ($) budget + circuit breaker** (#380) — opt-in
+  `[orchestrate] max_delegation_cost_usd` trips a delegation tree to graceful
+  finalize when accumulated cost (priced from token usage via a built-in model
+  price table) exceeds the bound — the dollar parallel of the #338 token budget.
+  Default off; fail-open.
+- **feat(workflow): model-tier complexity-scoring helper + routing guidance**
+  (#379) — a pure `ScoreComplexity`/`TierFor` primitive (mechanical / cheap /
+  standard / deep) plus result-contract guidance a coordinator can use to pick a
+  `model` per delegation. Additive and inert (the engine never calls it); the
+  concrete tier→model map is deliberately left to operators.
+
+All shipped via squash-merge with the CI gate green and adversarial `/code-review`.
+#395 and #389 were verified end-to-end with live Codex (including a real GitHub
+repo for the issue watcher — which caught two live bugs the unit tests missed);
+#388 and #380 were validated by unit + `-race` + review.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -62,6 +62,8 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Release Notes',
       items: [
+        'release-notes/v0.5.1',
+        'release-notes/v0.5.0',
         'release-notes/v0.4.2',
         'release-notes/v0.4.1',
         'release-notes/v0.4.0',

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5501,6 +5501,14 @@ coordinator job itself, and ignores every other queued job. `--session` composes
 with `--repo` (AND): a job must match both filters to run. Leaving both empty
 keeps the default behavior of matching all enabled repos and all jobs.
 
+Both `daemon run` and `daemon start` also accept two opt-in flags (both off by
+default, so leaving them unset is byte-identical to before): `--watch-issues`
+watches open **issues** for `@<agent> ask …` mentions and routes them to jobs,
+mirroring the PR-comment watcher; `--scheduler pool` selects the continuous
+worker-pool scheduler that re-queries the queue as workers free and auto-isolates
+a contended same-repo read job into an ephemeral worktree (fixing a same-repo
+dependent-job deadlock), versus the default `--scheduler barrier`.
+
 `gitmoot dashboard` shows local state — daemon health, repos, agents and runtime
 sessions, jobs by state, worktrees, branch locks, SkillOpt train phase/candidate,
 and pending interactive prompts.
@@ -5747,10 +5755,10 @@ default runtime model for that managed agent type.
 A registered single instance **shadows** a managed type of the same name:
 dispatch resolves `gitmoot agent <name>` to a registered single instance before a
 type, so force the type with `--type <name>` (or do not register a single
-instance of that name). Managed-type auto-spin and `[parallel_sessions]`
-temp-session forking happen on the **background** path only — a foreground
-`gitmoot agent ask <type> --type <type>` returns `agent not found`; use
-`--background`. See WORKFLOWS.md → "Running one agent's jobs in parallel".
+instance of that name). Since **v0.5.1** a foreground `gitmoot agent ask <type>`
+(the `ask` action) dispatches to the managed type synchronously; background
+`run`/`review`/`implement` to a type and `[parallel_sessions]` temp-session
+forking use the **background** path. See WORKFLOWS.md → "Running one agent's jobs in parallel".
 
 ## Agent Templates
 
@@ -6520,9 +6528,10 @@ instances / temp sessions actually run concurrently.
 registered agent by name **first**, so if you `gitmoot agent start researcher`
 *and* `gitmoot agent type set researcher`, plain `researcher` always uses the
 single instance. Force the managed type with `--type researcher` (or don't
-register a single instance of that name). A **foreground** ask cannot route to a
-type today — `gitmoot agent ask <type> --type <type>` errors `agent not found`;
-use `--background`.
+register a single instance of that name). Since **v0.5.1** a **foreground**
+`gitmoot agent ask <type>` (the `ask` action) dispatches to the managed type
+synchronously — it spins or reuses a managed instance up to `max_background`.
+`review`/`implement` to a type still use `--background`.
 
 ## Multi-Repo Work
 
@@ -6920,6 +6929,15 @@ cannot recurse or fan out forever:
   reports it if its stream emits it; Codex `Deliver` runs without `--json` and so
   contributes `0`), so the budget can under-count but never over-counts. Leaving
   the knob at `0` skips the check entirely.
+- Per-root **dollar-cost** budget `[orchestrate].max_delegation_cost_usd`,
+  **off by default** (`0` = unlimited): the cost analogue of the token budget
+  (#380). It bounds the same tree by *measured spend* — the same per-job token
+  usage priced through a built-in per-model price table (Haiku/Sonnet/Opus list
+  prices, matched by substring; unknown models priced at the mid-tier Sonnet
+  default so they are never free). When the tree's accumulated cost reaches the
+  budget, the next fan-out is refused with a `delegation_cost_usd_exceeded` event
+  and routed to the finalize continuation — never hard-killed. Coarse backstop,
+  not a precise spend meter; leaving the knob at `0` skips the check entirely.
 - Per-coordinator width `MaxDelegationWidth = 16`: a single coordinator result
   may not fan out more than this many delegations in one generation; an over-wide
   set is refused with a `delegation_width_exceeded` event.
@@ -7042,6 +7060,44 @@ Delegation fields:
   job (for example a Codex, Claude Code, or Kimi Code model name). When omitted,
   the delegated agent's configured default model is used. There is no allow-list;
   Gitmoot passes the value through to the runtime as-is.
+
+  **Model-tier routing (recommendation).** Picking a per-delegation `model` is
+  the coordinator's call — Gitmoot does not choose or override it. As a costing
+  heuristic, think of each leg as falling into one of four abstract **tiers**,
+  then map the tier to a concrete model for whichever runtime the leg uses:
+
+  - **mechanical** — rote, deterministic edits (a rename, a codemod-style
+    find-and-replace, a version bump, regenerating a file). Use the smallest /
+    cheapest model.
+  - **cheap** — low-complexity legs (a short `ask`, a narrow single-file
+    lookup). A small, fast model is enough.
+  - **standard** — ordinary work with no strong hardness signal. **Leave
+    `model` empty** so the leg runs on the delegated agent's runtime default.
+  - **deep** — genuinely hard or quorum-critical legs. Reserve a strong,
+    expensive model.
+
+  Cheap **hardness signals** a coordinator can read off a leg before dispatch: a
+  long, detailed prompt; hard-topic keywords (`architecture`, `oauth`, `schema`,
+  `concurrency`, `migration`, `security`, `refactor`, …); a multi-file
+  `implement`/`fix` action versus a read-only `ask`; broad scope (several
+  `artifacts` or a dedicated `worktree`); and whether the leg is part of a
+  `quorum`. More of these lean **deep**; their absence leans **cheap**. Gitmoot
+  ships an uncalibrated helper for this — `workflow.ScoreComplexity` /
+  `workflow.TierFor` (`internal/workflow/modeltier.go`) — that turns a
+  delegation into a tier. It is a pure recommendation primitive: the engine
+  never calls it and never overrides a coordinator's chosen `model`.
+
+  **Cascade / escalate-in-continuation pattern.** Prefer to start a leg on the
+  cheapest plausible tier and **escalate in a continuation** only if it falls
+  short: run the first attempt on a cheap/standard model, and if the result is
+  `blocked`/`failed` (or a `quorum` vote is not met), have the coordinator
+  re-issue that leg in its next round on a deep model. This keeps the common
+  case cheap while still reaching a strong model for the legs that genuinely
+  need it.
+
+  **Rule of thumb:** downshift `model` for cheap/mechanical legs; leave `model`
+  empty for standard legs (so they take the runtime default); and reserve a deep
+  model for genuinely hard or quorum-critical legs.
 - `phase` (optional): a free-form per-delegation string. It is pass-through
   metadata — Gitmoot carries it through to the child job untouched and echoes it
   back in the coordinator continuation for each delegation that set a non-empty
@@ -7133,6 +7189,16 @@ Delegation trees are bounded so they cannot run forever:
   below — so the budget can under-count a runtime that does not report usage; it
   never over-counts. Leaving the knob at `0` skips the check entirely (behavior is
   byte-identical to before the knob existed).
+- Per-root **dollar-cost** budget (#380): `[orchestrate].max_delegation_cost_usd`,
+  **off by default** (`0` = unlimited). The cost analogue of the token budget: it
+  bounds the same tree by *measured spend*, derived from the same per-job token
+  usage priced through a built-in per-model price table (Haiku/Sonnet/Opus list
+  prices matched by substring; unknown/empty models priced at the mid-tier Sonnet
+  default so they are never free). When the tree's accumulated cost reaches the
+  budget, the next fan-out is refused with a `delegation_cost_usd_exceeded` event
+  and routes through the finalize continuation — never hard-killed. Coarse
+  runaway-cost backstop, not a precise spend meter; leaving the knob at `0` is
+  byte-identical to before the knob existed.
 - Per-coordinator width: `MaxDelegationWidth = 16`. A single coordinator result
   may not fan out more than this many delegations in one generation; an over-wide
   set is refused with a `delegation_width_exceeded` event and routes through the


### PR DESCRIPTION
Release-notes pages for v0.5.0 and v0.5.1 (both trees + sidebar); corrects the stale 'foreground ask can't route to a type' note (#395 fixed it); documents `--watch-issues` (#389) and `--scheduler pool` (#394); regenerates llms-full.txt. Website build passes (`onBrokenLinks: throw`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)