### PR TITLE
feat(skillopt): recover --generation reclaims a stranded generation lock (#303)

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -304,10 +304,17 @@ persisted, `train continue` does not guess. It stops with a hard error such as
 before continuing`, so a partially generated item is inspected or cleared
 rather than silently completed or duplicated.
 
-This per-item generation durability is separate from `skillopt train recover`,
-which recovers the optimizer phase only (see "Optimizer And Candidate Gate").
-`train recover` does not release the generation lock or rebuild generation
-options.
+This per-item generation durability is complemented by `skillopt train recover
+--generation`. If a `train continue` is killed mid-generation, its generation
+lock is stranded (the deferred release never runs) and blocks re-entry until the
+~2h TTL expires. `skillopt train recover --session <id> --generation` reclaims
+that lock when its owner is provably dead and same-host (a live owner is refused;
+a cross-host owner waits for TTL), re-acquires it for the recover process, and
+salvages the persisted per-item options. It advances the iteration to
+`options_generated` only with `--advance-state` and only when every expected item
+is recovered; `--abort` reclaims the lock and leaves the phase at `items_ready`.
+By default `train recover` (without `--generation`) still recovers the optimizer
+phase only (see "Optimizer And Candidate Gate").
 
 Low-level `skillopt feedback github publish` and `sync` enforce
 `review.expected_repo` for train runs. If a preview train expects
@@ -599,16 +606,35 @@ gitmoot skillopt train recover --session planner-train --out-root .gitmoot/skill
 gitmoot skillopt train recover --session planner-train --out-root .gitmoot/skillopt/planner-train --json
 ```
 
-`train recover` is scoped to the optimizer phase only. It re-imports or repairs
-the optimizer candidate package and classifies the active iteration, for example
-`already_completed_candidate`, `already_completed_no_candidate`,
+By default `train recover` is scoped to the optimizer phase. It re-imports or
+repairs the optimizer candidate package and classifies the active iteration, for
+example `already_completed_candidate`, `already_completed_no_candidate`,
 `optimizer_active`, or `corrupted_unrecoverable`. Recovery validates the package
 state, imports a completed candidate through the normal candidate gate, or
 records `optimizer_completed_no_candidate` with the stored rejection reason.
-Incomplete or corrupted artifacts fail without modifying the train state. It does
-not recover the generation phase, release the generation lock, or rebuild
-generation options; per-item generation durability and idempotent resume handle
-that (see "Durable Generation And Idempotent Resume").
+Incomplete or corrupted artifacts fail without modifying the train state.
+
+Pass `--generation` to recover the generation phase instead: it reclaims a
+generation lock stranded by a crashed/killed `train continue` and salvages the
+persisted per-item options (see "Durable Generation And Idempotent Resume").
+
+```sh
+gitmoot skillopt train recover --session planner-train --generation
+gitmoot skillopt train recover --session planner-train --generation --advance-state
+gitmoot skillopt train recover --session planner-train --generation --abort
+```
+
+Reclamation is liveness-gated: the stranded lock is released only when its owner
+PID is provably dead AND it was held on this same host. A live owner is refused
+(`skillopt train generation is already running`) so you stop the running process
+first; a cross-host owner requires the lock TTL to expire. The recover process
+re-acquires the lock for itself so the salvage is crash-safe. Salvage is
+import-only — it reports `expected_items`, `recovered_items`, and `missing_items`
+and classifies the run as `generation_complete`, `generation_incomplete`, or
+`generation_active`. The iteration advances to `options_generated` only with
+`--advance-state` and only when every expected item is recovered (regenerating
+missing items remains `train continue`'s job). `--abort` reclaims the lock and
+leaves the phase at `items_ready`, keeping persisted items.
 
 ## Candidate Review And Next Iteration
 

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -8968,11 +8968,14 @@ func validateSkillOptTrainOptimizerRecoverableCompleteState(iteration db.SkillOp
 //
 // It is a liveness-gated steal-then-own: the stranded lock is reclaimed ONLY
 // when its owner PID is provably dead AND the lock was held on this same host
-// (owner_hostname == this host). A live owner is never stolen — recovery refuses
-// with the busy error so the operator stops the running process first. A
-// cross-host owner cannot be liveness-checked locally, so recovery requires the
-// lock's TTL to have expired before reclaiming it. The recover process then
-// re-acquires the lock for itself so the recovery is also crash-safe.
+// (owner_hostname == this host, OR owner_hostname is empty — a pre-#303 legacy
+// strand from a binary that did not record the host, treated as local since
+// skillopt train is local-first). A live owner is never stolen — recovery
+// refuses with the busy error so the operator stops the running process first. A
+// cross-host owner (a different, recorded host) cannot be liveness-checked
+// locally, so recovery requires the lock's TTL to have expired before reclaiming
+// it. The recover process then re-acquires the lock for itself so the recovery
+// is also crash-safe.
 //
 // Salvage is import-only: completed items are already durable (per-item commits
 // from #311), so recovery just classifies what is persisted vs. missing.
@@ -9018,25 +9021,39 @@ func recoverSkillOptTrainGenerationLock(ctx context.Context, paths config.Paths,
 		result.LockOwnerPID = lock.OwnerPID
 		result.LockOwnerHostname = strings.TrimSpace(lock.OwnerHostname)
 		ownerLive := skillOptOwnerPIDLive(lock.OwnerPID)
-		sameHost := strings.TrimSpace(lock.OwnerHostname) != "" && strings.EqualFold(strings.TrimSpace(lock.OwnerHostname), strings.TrimSpace(thisHost))
+		host := strings.TrimSpace(lock.OwnerHostname)
+		// Treat an empty/unrecorded owner_hostname as same-host-eligible: skillopt
+		// train is a local-first workflow (one local SQLite home), and an empty
+		// owner_hostname is the pre-#303 legacy case — the lock was written by a
+		// binary that didn't record the host. Those legacy strands are exactly the
+		// ones #303 exists to clear, so we treat an unknown host as this host. The
+		// PID-dead gate still applies: a LIVE owner is always refused (never steal a
+		// live owner); only a DEAD PID with an empty/this-host hostname is reclaimable.
+		sameHost := host == "" || strings.EqualFold(host, strings.TrimSpace(thisHost))
 		expired := !skillOptResourceLockActive(lock, now)
 		switch {
 		case ownerLive:
-			// Never steal a live owner — its deferred release will run.
+			// Never steal a live owner — its deferred release will run. When the
+			// host is unrecorded (legacy lock) the owner is, by the local-first
+			// invariant above, on this host, so say so rather than implying a
+			// foreign host we cannot verify.
 			result.Classification = "generation_active"
 			result.GenerationLockBlocked = true
 			result.NextAction = "stop the running generation process before recovering"
 			return result, fmt.Errorf("%w: %s (owner pid %d still running)", errSkillOptTrainGenerationBusy, lockKey, lock.OwnerPID)
 		case sameHost:
-			// Same-host dead owner: provably crashed, safe to reclaim.
+			// Same-host (or unrecorded/legacy host) dead owner: provably crashed,
+			// safe to reclaim.
 		case expired:
-			// Cross-host (or unknown-host) owner we cannot liveness-check: only
-			// reclaim once the lease has actually expired.
+			// Genuinely cross-host owner we cannot liveness-check: only reclaim
+			// once the lease has actually expired.
 		default:
+			// Genuinely cross-host (non-empty, different host) owner with an
+			// unexpired lease: cannot verify liveness, so refuse until TTL expiry.
 			result.Classification = "generation_active"
 			result.GenerationLockBlocked = true
 			result.NextAction = "owner is on another host; wait for the generation lock TTL to expire before recovering"
-			return result, fmt.Errorf("%w: %s (owner on host %q; cannot verify liveness, lease not expired)", errSkillOptTrainGenerationBusy, lockKey, strings.TrimSpace(lock.OwnerHostname))
+			return result, fmt.Errorf("%w: %s (owner on host %q; cannot verify liveness, lease not expired)", errSkillOptTrainGenerationBusy, lockKey, host)
 		}
 		// Reclaim by the stored owner job id (the deterministic identity of the
 		// crashed holder) and emit an audit event — there is no

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -108,7 +108,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train run [--config path | --session <id>] [--plain]")
 	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--export-only] [--promote version|--reject version --reason text] [--start-next]")
-	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
+	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path] [--generation [--abort | --advance-state]] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -148,7 +148,7 @@ func printSkillOptTrainUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt train status --session <id>")
 	fmt.Fprintln(w, "  gitmoot skillopt train run [--config path | --session <id>] [--plain]")
 	fmt.Fprintln(w, "  gitmoot skillopt train continue --session <id> [--backend codex] [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--model name] [--optimizer-model name] [--target-model name] [--optimizer-backend name] [--target-backend name] [--evaluator-id id] [--evaluator-model name] [--evaluator-backend name] [--skill-update-mode mode] [--num-epochs N] [--batch-size N] [--optimizer-views N] [--retry-optimizer-views auto|inherit|N] [--gate hard|soft|mixed] [--out-root path] [--timeout duration] [--dry-run] [--rerun-optimizer] [--export-only] [--promote version|--reject version --reason text] [--start-next]")
-	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path]")
+	fmt.Fprintln(w, "  gitmoot skillopt train recover --session <id> [--out-root path] [--generation [--abort | --advance-state]] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt train stop --session <id> --reason <text>")
 }
 
@@ -1873,6 +1873,9 @@ func runSkillOptTrainRecover(args []string, stdout, stderr io.Writer) int {
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	sessionID := fs.String("session", "", "train session id")
 	outRoot := fs.String("out-root", "", "optimizer output directory; defaults to the persisted train optimizer path")
+	generation := fs.Bool("generation", false, "recover the option-generation phase: reclaim a stranded generation lock and salvage persisted options instead of the optimizer phase")
+	abort := fs.Bool("abort", false, "with --generation, reclaim the stranded generation lock and leave the iteration at items_ready (does not advance state)")
+	advanceState := fs.Bool("advance-state", false, "with --generation, advance the iteration to options_generated when every expected item is recovered")
 	jsonOutput := fs.Bool("json", false, "print recovery result as JSON")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -1888,9 +1891,21 @@ func runSkillOptTrainRecover(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "skillopt train recover requires --session")
 		return 2
 	}
+	if !*generation && (*abort || *advanceState) {
+		fmt.Fprintln(stderr, "skillopt train recover --abort and --advance-state require --generation")
+		return 2
+	}
+	if *abort && *advanceState {
+		fmt.Fprintln(stderr, "skillopt train recover --abort and --advance-state are mutually exclusive")
+		return 2
+	}
 	var result skillOptTrainRecoverResult
 	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
 		var recoverErr error
+		if *generation {
+			result, recoverErr = recoverSkillOptTrainGenerationLock(context.Background(), paths, store, *sessionID, *abort, *advanceState)
+			return recoverErr
+		}
 		result, recoverErr = recoverSkillOptTrainOptimizerArtifacts(context.Background(), paths, store, *sessionID, *outRoot)
 		return recoverErr
 	}); err != nil {
@@ -2884,6 +2899,23 @@ type skillOptTrainRecoverResult struct {
 	CandidatePackagePath string   `json:"candidate_package,omitempty"`
 	ArtifactDir          string   `json:"artifact_dir,omitempty"`
 	Artifacts            []string `json:"artifacts,omitempty"`
+
+	// Generation-recovery fields (populated by recover --generation). They
+	// describe the stranded generation lock that was classified/reclaimed and
+	// the per-item salvage outcome.
+	Mode                  string   `json:"mode,omitempty"`
+	LockState             string   `json:"lock_state,omitempty"`
+	LockOwnerJobID        string   `json:"lock_owner_job_id,omitempty"`
+	LockOwnerPID          int64    `json:"lock_owner_pid,omitempty"`
+	LockOwnerHostname     string   `json:"lock_owner_hostname,omitempty"`
+	LockReclaimed         bool     `json:"lock_reclaimed,omitempty"`
+	ExpectedItems         int      `json:"expected_items,omitempty"`
+	RecoveredItems        int      `json:"recovered_items,omitempty"`
+	MissingItems          int      `json:"missing_items,omitempty"`
+	PersistedOptions      int      `json:"persisted_options,omitempty"`
+	MissingItemIDs        []string `json:"missing_item_ids,omitempty"`
+	StateAdvanced         bool     `json:"state_advanced,omitempty"`
+	GenerationLockBlocked bool     `json:"generation_lock_blocked,omitempty"`
 }
 
 type skillOptTrainBackendResolution struct {
@@ -5266,12 +5298,14 @@ func acquireSkillOptTrainGenerationLock(ctx context.Context, store *db.Store, se
 	}
 	now := time.Now().UTC()
 	ownerJobID := localAgentJobID("skillopt-train-generation", strings.TrimSpace(sessionID))
+	hostname, _ := os.Hostname()
 	ok, err := store.AcquireResourceLock(ctx, db.ResourceLock{
-		ResourceKey: key,
-		OwnerJobID:  ownerJobID,
-		OwnerToken:  token,
-		OwnerPID:    int64(os.Getpid()),
-		ExpiresAt:   now.Add(ttl).Format(time.RFC3339Nano),
+		ResourceKey:   key,
+		OwnerJobID:    ownerJobID,
+		OwnerToken:    token,
+		OwnerPID:      int64(os.Getpid()),
+		OwnerHostname: hostname,
+		ExpiresAt:     now.Add(ttl).Format(time.RFC3339Nano),
 	}, now)
 	if err != nil {
 		return noopAgentReservationRelease, skillOptTrainNoopExtend, false, err
@@ -5485,6 +5519,73 @@ func skillOptTrainGenerationRuntimeLabel(request skillOptTrainContinueRequest) s
 	return strings.TrimSpace(request.Optimizer.Backend)
 }
 
+// skillOptTrainGenerationPlan classifies a run's review items against what is
+// already persisted: which items are complete (and how many options that adds),
+// and which items still need generation. It is the shared detection used by both
+// the continue/resume path and generation-lock recovery, so "skip complete,
+// regenerate missing" behaves identically in both.
+type skillOptTrainGenerationPlan struct {
+	ExistingGenerated int
+	ToGenerate        []db.EvalReviewItem
+	CompleteItemIDs   []string
+	MissingItemIDs    []string
+}
+
+// classifySkillOptTrainGenerationItems partitions items into already-persisted
+// (complete) and still-missing. A complete item contributes its persisted
+// options to ExistingGenerated and is skipped; a partially persisted single item
+// is an error (per-item commits are atomic, so a half-written item is corruption,
+// not a normal resume state).
+func classifySkillOptTrainGenerationItems(ctx context.Context, store *db.Store, run db.EvalRun, items []db.EvalReviewItem, roles []string, rankedRun bool) (skillOptTrainGenerationPlan, error) {
+	plan := skillOptTrainGenerationPlan{
+		ToGenerate: make([]db.EvalReviewItem, 0, len(items)),
+	}
+	// Count already-persisted options per item in ONE run-scoped query instead of
+	// one query per item (the single-conn store would otherwise serialize N
+	// round-trips on resume of a large run).
+	existingOptionCount := map[string]int{}
+	if rankedRun {
+		allOptions, err := store.ListEvalReviewOptions(ctx, run.ID, "")
+		if err != nil {
+			return skillOptTrainGenerationPlan{}, err
+		}
+		for _, opt := range allOptions {
+			existingOptionCount[opt.ItemID]++
+		}
+	}
+	// A mix of complete and incomplete items is the normal resume state (per-item
+	// commits), so it is not an error — only a partially generated single item is.
+	for _, item := range items {
+		if rankedRun {
+			existing := existingOptionCount[item.ItemID]
+			if existing > 0 {
+				if existing == len(roles) {
+					plan.ExistingGenerated += existing
+					plan.CompleteItemIDs = append(plan.CompleteItemIDs, item.ItemID)
+					continue
+				}
+				return skillOptTrainGenerationPlan{}, fmt.Errorf("item %s has partial generated options; inspect or clear review options before continuing", item.ItemID)
+			}
+			plan.ToGenerate = append(plan.ToGenerate, item)
+			plan.MissingItemIDs = append(plan.MissingItemIDs, item.ItemID)
+			continue
+		}
+		hasBaseline := strings.TrimSpace(item.BaselineArtifactID) != ""
+		hasCandidate := strings.TrimSpace(item.CandidateArtifactID) != ""
+		if hasBaseline || hasCandidate {
+			if hasBaseline && hasCandidate {
+				plan.ExistingGenerated += 2
+				plan.CompleteItemIDs = append(plan.CompleteItemIDs, item.ItemID)
+				continue
+			}
+			return skillOptTrainGenerationPlan{}, fmt.Errorf("item %s has partial generated A/B artifacts; inspect or clear review item artifacts before continuing", item.ItemID)
+		}
+		plan.ToGenerate = append(plan.ToGenerate, item)
+		plan.MissingItemIDs = append(plan.MissingItemIDs, item.ItemID)
+	}
+	return plan, nil
+}
+
 func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainContinueRequest) (skillOptTrainGenerationResult, error) {
 	if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateOptionsGenerated); err != nil {
 		return skillOptTrainGenerationResult{}, err
@@ -5508,49 +5609,12 @@ func generateSkillOptTrainOptions(ctx context.Context, paths config.Paths, store
 	if len(roles) < 2 {
 		return skillOptTrainGenerationResult{}, fmt.Errorf("eval run %s expects at least 2 options", run.ID)
 	}
-	existingGenerated := 0
-	// Count already-persisted options per item in ONE run-scoped query instead of
-	// one query per item (the single-conn store would otherwise serialize N
-	// round-trips on resume of a large run).
-	existingOptionCount := map[string]int{}
-	if rankedRun {
-		allOptions, err := store.ListEvalReviewOptions(ctx, run.ID, "")
-		if err != nil {
-			return skillOptTrainGenerationResult{}, err
-		}
-		for _, opt := range allOptions {
-			existingOptionCount[opt.ItemID]++
-		}
+	plan, err := classifySkillOptTrainGenerationItems(ctx, store, run, items, roles, rankedRun)
+	if err != nil {
+		return skillOptTrainGenerationResult{}, err
 	}
-	// toGenerate holds only the items that still need generation; complete items
-	// are skipped so resume regenerates nothing already persisted. A mix of
-	// complete and incomplete items is the normal resume state (per-item commits),
-	// so it is not an error — only a partially generated single item is.
-	toGenerate := make([]db.EvalReviewItem, 0, len(items))
-	for _, item := range items {
-		if rankedRun {
-			existing := existingOptionCount[item.ItemID]
-			if existing > 0 {
-				if existing == len(roles) {
-					existingGenerated += existing
-					continue
-				}
-				return skillOptTrainGenerationResult{}, fmt.Errorf("item %s has partial generated options; inspect or clear review options before continuing", item.ItemID)
-			}
-			toGenerate = append(toGenerate, item)
-			continue
-		}
-		hasBaseline := strings.TrimSpace(item.BaselineArtifactID) != ""
-		hasCandidate := strings.TrimSpace(item.CandidateArtifactID) != ""
-		if hasBaseline || hasCandidate {
-			if hasBaseline && hasCandidate {
-				existingGenerated += 2
-				continue
-			}
-			return skillOptTrainGenerationResult{}, fmt.Errorf("item %s has partial generated A/B artifacts; inspect or clear review item artifacts before continuing", item.ItemID)
-		}
-		toGenerate = append(toGenerate, item)
-	}
+	existingGenerated := plan.ExistingGenerated
+	toGenerate := plan.ToGenerate
 	if len(toGenerate) == 0 {
 		metadata := map[string]any{
 			"status":            "recovered",
@@ -8897,6 +8961,229 @@ func validateSkillOptTrainOptimizerRecoverableCompleteState(iteration db.SkillOp
 	}
 }
 
+// recoverSkillOptTrainGenerationLock reclaims a generation lock stranded by a
+// crashed/killed train continue (the lock's deferred release never ran) and
+// salvages the already-persisted per-item options, optionally advancing the
+// iteration to options_generated.
+//
+// It is a liveness-gated steal-then-own: the stranded lock is reclaimed ONLY
+// when its owner PID is provably dead AND the lock was held on this same host
+// (owner_hostname == this host). A live owner is never stolen — recovery refuses
+// with the busy error so the operator stops the running process first. A
+// cross-host owner cannot be liveness-checked locally, so recovery requires the
+// lock's TTL to have expired before reclaiming it. The recover process then
+// re-acquires the lock for itself so the recovery is also crash-safe.
+//
+// Salvage is import-only: completed items are already durable (per-item commits
+// from #311), so recovery just classifies what is persisted vs. missing.
+// Regenerating missing items is deferred to a future --regenerate. The iteration
+// advances to options_generated only when advanceState is set and every expected
+// item is recovered. With abort set, the lock is reclaimed and the phase is left
+// at items_ready (persisted items are kept).
+func recoverSkillOptTrainGenerationLock(ctx context.Context, paths config.Paths, store *db.Store, sessionID string, abort bool, advanceState bool) (skillOptTrainRecoverResult, error) {
+	session, iteration, _, err := loadSkillOptTrainStatus(ctx, store, sessionID)
+	if err != nil {
+		return skillOptTrainRecoverResult{}, err
+	}
+	result := skillOptTrainRecoverResult{
+		SessionID: strings.TrimSpace(session.ID),
+		Mode:      "generation",
+	}
+	if iteration == nil {
+		result.Classification = "unrecoverable"
+		return result, errors.New("train session has no iteration to recover")
+	}
+	result.IterationID = strings.TrimSpace(iteration.ID)
+	result.CurrentPhase = skillopt.NormalizeTrainState(iteration.State)
+
+	// Classify the stranded generation lock (if any) and decide whether it is
+	// safe to reclaim. A live owner is refused; a cross-host owner needs TTL
+	// expiry; a same-host dead owner is reclaimable.
+	lockKey := skillOptTrainGenerationLockKey(session.ID, iteration.ID)
+	now := time.Now().UTC()
+	thisHost, _ := os.Hostname()
+	lock, lockErr := store.GetResourceLock(ctx, lockKey)
+	hasLock := false
+	switch {
+	case lockErr == nil:
+		hasLock = true
+	case errors.Is(lockErr, sql.ErrNoRows):
+		hasLock = false
+	default:
+		return result, lockErr
+	}
+	if hasLock {
+		result.LockState = skillOptTrainOptimizerLockStatus(lock, now)
+		result.LockOwnerJobID = strings.TrimSpace(lock.OwnerJobID)
+		result.LockOwnerPID = lock.OwnerPID
+		result.LockOwnerHostname = strings.TrimSpace(lock.OwnerHostname)
+		ownerLive := skillOptOwnerPIDLive(lock.OwnerPID)
+		sameHost := strings.TrimSpace(lock.OwnerHostname) != "" && strings.EqualFold(strings.TrimSpace(lock.OwnerHostname), strings.TrimSpace(thisHost))
+		expired := !skillOptResourceLockActive(lock, now)
+		switch {
+		case ownerLive:
+			// Never steal a live owner — its deferred release will run.
+			result.Classification = "generation_active"
+			result.GenerationLockBlocked = true
+			result.NextAction = "stop the running generation process before recovering"
+			return result, fmt.Errorf("%w: %s (owner pid %d still running)", errSkillOptTrainGenerationBusy, lockKey, lock.OwnerPID)
+		case sameHost:
+			// Same-host dead owner: provably crashed, safe to reclaim.
+		case expired:
+			// Cross-host (or unknown-host) owner we cannot liveness-check: only
+			// reclaim once the lease has actually expired.
+		default:
+			result.Classification = "generation_active"
+			result.GenerationLockBlocked = true
+			result.NextAction = "owner is on another host; wait for the generation lock TTL to expire before recovering"
+			return result, fmt.Errorf("%w: %s (owner on host %q; cannot verify liveness, lease not expired)", errSkillOptTrainGenerationBusy, lockKey, strings.TrimSpace(lock.OwnerHostname))
+		}
+		// Reclaim by the stored owner job id (the deterministic identity of the
+		// crashed holder) and emit an audit event — there is no
+		// ForceReleaseLockWithEvent for resource locks, so the event is emitted
+		// manually.
+		released, err := store.DeleteResourceLocksByOwner(ctx, strings.TrimSpace(lock.OwnerJobID))
+		if err != nil {
+			return result, err
+		}
+		if released > 0 {
+			result.LockReclaimed = true
+			auditMessage := fmt.Sprintf("reclaimed stranded skillopt generation lock %s (owner pid %d, host %q, state %s) during recover --generation", lockKey, lock.OwnerPID, strings.TrimSpace(lock.OwnerHostname), result.LockState)
+			if eventErr := store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   strings.TrimSpace(lock.OwnerJobID),
+				Kind:    "lock_reclaimed",
+				Message: auditMessage,
+			}); eventErr != nil {
+				return result, eventErr
+			}
+		}
+	}
+
+	if abort {
+		// --abort: reclaim only, keep persisted items, leave phase at items_ready.
+		if result.LockReclaimed {
+			result.Classification = "generation_lock_reclaimed"
+		} else {
+			result.Classification = "generation_no_lock"
+		}
+		result.CurrentPhase = skillopt.NormalizeTrainState(iteration.State)
+		result.NextAction = "rerun train continue to regenerate the remaining items"
+		return result, nil
+	}
+
+	// Steal-then-own: re-acquire the generation lock for THIS recover process so
+	// the salvage itself is crash-safe (a crash here strands our own lock, which a
+	// subsequent recover reclaims the same way).
+	releaseGenerationLock, _, acquired, err := acquireSkillOptTrainGenerationLock(ctx, store, session.ID, iteration.ID, skillOptTrainGenerationLockTTL)
+	if err != nil {
+		return result, err
+	}
+	if !acquired {
+		result.Classification = "generation_active"
+		result.GenerationLockBlocked = true
+		result.NextAction = "another process re-acquired the generation lock; retry recovery"
+		return result, fmt.Errorf("%w: %s", errSkillOptTrainGenerationBusy, lockKey)
+	}
+	defer func() {
+		_ = releaseGenerationLock(context.Background())
+	}()
+
+	// Reload after taking ownership so we classify against the freshest state.
+	session, reloaded, _, err := loadSkillOptTrainStatus(ctx, store, session.ID)
+	if err != nil {
+		return result, err
+	}
+	if reloaded == nil {
+		result.Classification = "unrecoverable"
+		return result, errors.New("train session has no iteration to recover")
+	}
+	iteration = reloaded
+	result.CurrentPhase = skillopt.NormalizeTrainState(iteration.State)
+
+	run, err := store.GetEvalRun(ctx, iteration.EvalRunID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			result.Classification = "unrecoverable"
+			return result, fmt.Errorf("eval run %s not found", iteration.EvalRunID)
+		}
+		return result, err
+	}
+	rankedRun := skillOptRunUsesRankedOptions(run)
+	items, err := store.ListEvalReviewItems(ctx, run.ID)
+	if err != nil {
+		return result, err
+	}
+	if len(items) == 0 {
+		result.Classification = "unrecoverable"
+		return result, fmt.Errorf("eval run %s has no review items to recover", run.ID)
+	}
+	roles := skillOptTrainGenerationRoles(run)
+	if len(roles) < 2 {
+		result.Classification = "unrecoverable"
+		return result, fmt.Errorf("eval run %s expects at least 2 options", run.ID)
+	}
+	plan, err := classifySkillOptTrainGenerationItems(ctx, store, run, items, roles, rankedRun)
+	if err != nil {
+		// A partially persisted single item is corruption, not a normal resume
+		// state — surface it without advancing.
+		result.Classification = "generation_partial"
+		result.ExpectedItems = len(items)
+		result.NextAction = "inspect or clear the partially persisted item before recovering"
+		return result, err
+	}
+	result.ExpectedItems = len(items)
+	result.RecoveredItems = len(plan.CompleteItemIDs)
+	result.MissingItems = len(plan.ToGenerate)
+	result.MissingItemIDs = plan.MissingItemIDs
+	result.PersistedOptions = plan.ExistingGenerated
+
+	if len(plan.ToGenerate) == 0 {
+		// Every expected item is persisted — recovery imported nothing new (the
+		// per-item commits already did the work) but the run is salvageable.
+		result.Classification = "generation_complete"
+		if advanceState {
+			if err := advanceSkillOptTrainToOptionsGenerated(ctx, store, session, *iteration, plan.ExistingGenerated); err != nil {
+				return result, err
+			}
+			result.StateAdvanced = true
+			result.CurrentPhase = skillopt.TrainStateOptionsGenerated
+			result.NextAction = "publish the human review packet"
+			return result, nil
+		}
+		result.NextAction = "rerun with --advance-state to advance the iteration to options_generated"
+		return result, nil
+	}
+
+	// Some items are still missing. Import-only recovery does not regenerate them
+	// (deferred to a future --regenerate), so it never advances state.
+	result.Classification = "generation_incomplete"
+	result.NextAction = "rerun train continue to regenerate the missing items"
+	return result, nil
+}
+
+// advanceSkillOptTrainToOptionsGenerated moves an iteration whose options are all
+// persisted to options_generated, recording recovered generation metadata. It is
+// used by recover --generation --advance-state.
+func advanceSkillOptTrainToOptionsGenerated(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, generatedOptions int) error {
+	if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateOptionsGenerated); err != nil {
+		return err
+	}
+	metadata := map[string]any{
+		"status":            "recovered",
+		"generated_options": generatedOptions,
+		"recovered_via":     "recover --generation --advance-state",
+		"completed_at":      time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	session.State = skillopt.TrainStateOptionsGenerated
+	iteration.State = skillopt.TrainStateOptionsGenerated
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "generation", metadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "generation", metadata)
+	if err := store.UpsertSkillOptTrainSession(ctx, session); err != nil {
+		return err
+	}
+	return store.UpsertSkillOptTrainIteration(ctx, iteration)
+}
+
 func markSkillOptTrainOptimizerRecoveredComplete(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, paths skillOptTrainOptimizerPaths) (db.SkillOptTrainSession, *db.SkillOptTrainIteration, error) {
 	if err := validateSkillOptTrainOptimizerRecoverableCompleteState(iteration); err != nil {
 		return db.SkillOptTrainSession{}, nil, err
@@ -9002,6 +9289,10 @@ func printSkillOptTrainRecoverResult(stdout io.Writer, result skillOptTrainRecov
 	writeLine(stdout, "iteration: %s", emptyText(result.IterationID))
 	writeLine(stdout, "recovery_state: %s", emptyText(result.Classification))
 	writeLine(stdout, "current_phase: %s", emptyText(result.CurrentPhase))
+	if result.Mode == "generation" {
+		printSkillOptTrainGenerationRecoverResult(stdout, result)
+		return
+	}
 	writeLine(stdout, "recovery_available: %t", result.RecoveryAvailable)
 	writeLine(stdout, "optimizer_out_root: %s", emptyText(result.OutRoot))
 	writeLine(stdout, "optimizer_root: %s", emptyText(result.OptimizerRoot))
@@ -9015,6 +9306,30 @@ func printSkillOptTrainRecoverResult(stdout io.Writer, result skillOptTrainRecov
 	}
 	if len(result.Artifacts) > 0 {
 		writeLine(stdout, "artifacts: %s", strings.Join(result.Artifacts, ","))
+	}
+	writeLine(stdout, "next: %s", emptyText(result.NextAction))
+}
+
+func printSkillOptTrainGenerationRecoverResult(stdout io.Writer, result skillOptTrainRecoverResult) {
+	writeLine(stdout, "mode: generation")
+	writeLine(stdout, "lock_state: %s", emptyText(result.LockState))
+	writeLine(stdout, "lock_reclaimed: %t", result.LockReclaimed)
+	if result.LockOwnerJobID != "" {
+		writeLine(stdout, "lock_owner_job_id: %s", result.LockOwnerJobID)
+	}
+	if result.LockOwnerPID > 0 {
+		writeLine(stdout, "lock_owner_pid: %d", result.LockOwnerPID)
+	}
+	if result.LockOwnerHostname != "" {
+		writeLine(stdout, "lock_owner_hostname: %s", result.LockOwnerHostname)
+	}
+	writeLine(stdout, "expected_items: %d", result.ExpectedItems)
+	writeLine(stdout, "recovered_items: %d", result.RecoveredItems)
+	writeLine(stdout, "missing_items: %d", result.MissingItems)
+	writeLine(stdout, "persisted_options: %d", result.PersistedOptions)
+	writeLine(stdout, "state_advanced: %t", result.StateAdvanced)
+	if len(result.MissingItemIDs) > 0 {
+		writeLine(stdout, "missing_item_ids: %s", strings.Join(result.MissingItemIDs, ","))
 	}
 	writeLine(stdout, "next: %s", emptyText(result.NextAction))
 }

--- a/internal/cli/skillopt_recover_generation_test.go
+++ b/internal/cli/skillopt_recover_generation_test.go
@@ -225,6 +225,169 @@ func TestSkillOptTrainRecoverGenerationRefusesLiveOwner(t *testing.T) {
 	}
 }
 
+func TestSkillOptTrainRecoverGenerationReclaimsDeadEmptyHostLock(t *testing.T) {
+	// Legacy strand (pre-#303): the lock was written by a binary that did not
+	// record owner_hostname, so it is empty. A local-first workflow treats an
+	// unrecorded host as this host, so a dead PID with an unexpired lease must be
+	// reclaimable — exactly the motivating case #303 exists to clear.
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	seedStrandedGenerationLock(t, home, deadPID(t), "", time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover empty-host exit code = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"mode: generation",
+		"lock_reclaimed: true",
+		"recovery_state: generation_complete",
+		"expected_items: 2",
+		"recovered_items: 2",
+		"missing_items: 0",
+		"persisted_options: 4",
+		"state_advanced: false",
+		"current_phase: items_ready",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("recover empty-host stdout missing %q:\n%s", want, out)
+		}
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	// The stranded lock must be gone.
+	if _, err := store.GetResourceLock(context.Background(), skillOptTrainGenerationLockKey("landing-train", "landing-train-001")); err == nil {
+		t.Fatalf("generation lock still held after empty-host reclaim")
+	}
+	// An audit event for the reclaim must exist.
+	events, err := store.ListJobEvents(context.Background(), "local-skillopt-train-generation-landing-train-deadbeef")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	foundReclaim := false
+	for _, event := range events {
+		if event.Kind == "lock_reclaimed" {
+			foundReclaim = true
+		}
+	}
+	if !foundReclaim {
+		t.Fatalf("no lock_reclaimed audit event recorded: %+v", events)
+	}
+	// State must NOT have advanced without --advance-state.
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateItemsReady {
+		t.Fatalf("iteration state = %s, want items_ready", iteration.State)
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationEmptyHostAdvanceState(t *testing.T) {
+	// Legacy empty-host strand with a dead owner: --advance-state must advance the
+	// complete run to options_generated, mirroring the same-host advance test.
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	seedStrandedGenerationLock(t, home, deadPID(t), "", time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation", "--advance-state"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("recover empty-host --advance-state exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"state_advanced: true",
+		"current_phase: options_generated",
+		"recovery_state: generation_complete",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("recover empty-host --advance-state stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateOptionsGenerated {
+		t.Fatalf("iteration state after empty-host --advance-state = %s, want options_generated", iteration.State)
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationEmptyHostAbortReclaims(t *testing.T) {
+	// --abort must reach the reclaim path for a legacy empty-host dead-owner lock
+	// (the host gate must not short-circuit before abort). Persisted items survive.
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	seedStrandedGenerationLock(t, home, deadPID(t), "", time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation", "--abort"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover empty-host --abort exit code = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"recovery_state: generation_lock_reclaimed",
+		"lock_reclaimed: true",
+		"current_phase: items_ready",
+		"state_advanced: false",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("recover empty-host --abort stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if _, err := store.GetResourceLock(context.Background(), skillOptTrainGenerationLockKey("landing-train", "landing-train-001")); err == nil {
+		t.Fatalf("generation lock still held after empty-host --abort reclaim")
+	}
+	options, err := store.ListEvalReviewOptions(context.Background(), "landing-train-review-001", "")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 4 {
+		t.Fatalf("abort dropped persisted options: got %d, want 4", len(options))
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationEmptyHostRefusesLiveOwner(t *testing.T) {
+	// A LIVE owner with an empty (legacy) hostname must still be refused — never
+	// steal a live owner — and the message must NOT claim the owner is on another
+	// host (the host is simply unrecorded, and the workflow is local-first).
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	seedStrandedGenerationLock(t, home, int64(os.Getpid()), "", time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("recover empty-host live owner exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "recovery_state: generation_active") {
+		t.Fatalf("recover empty-host live owner stdout = %s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "skillopt train generation is already running") {
+		t.Fatalf("recover empty-host live owner stderr = %s", stderr.String())
+	}
+	// The message must report the running PID, not claim a foreign host.
+	if !strings.Contains(stderr.String(), "still running") {
+		t.Fatalf("recover empty-host live owner stderr missing 'still running': %s", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "another host") || strings.Contains(stderr.String(), "owner on host") {
+		t.Fatalf("recover empty-host live owner stderr wrongly claims another host: %s", stderr.String())
+	}
+
+	// The live owner's lock must NOT have been stolen.
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	lock, err := store.GetResourceLock(context.Background(), skillOptTrainGenerationLockKey("landing-train", "landing-train-001"))
+	if err != nil {
+		t.Fatalf("live owner lock missing after refused recover: %v", err)
+	}
+	if lock.OwnerPID != int64(os.Getpid()) {
+		t.Fatalf("live owner lock owner pid = %d, want %d", lock.OwnerPID, os.Getpid())
+	}
+}
+
 func TestSkillOptTrainRecoverGenerationRequiresTTLForCrossHost(t *testing.T) {
 	home, _ := seedSkillOptTrainItemsReady(t, 2)
 	// Cross-host dead owner, lease NOT yet expired -> must refuse (cannot verify

--- a/internal/cli/skillopt_recover_generation_test.go
+++ b/internal/cli/skillopt_recover_generation_test.go
@@ -1,0 +1,490 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// seedSkillOptTrainItemsReady starts a 2-item, 2-option train session that lands
+// at items_ready, then persists generated options for persistItems items (in the
+// order returned by ListEvalReviewItems). It returns the home dir and the run id.
+// With persistItems == 2 the run is fully recoverable; with 1 it is partial.
+func seedSkillOptTrainItemsReady(t *testing.T, persistItems int) (string, string) {
+	t.Helper()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/workspace.git")
+	t.Chdir(repoDir)
+	itemsPath := writeSkillOptTrainItemsFile(t)
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close after template seed returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"skillopt", "train", "start",
+		"--home", home,
+		"--template", "planner",
+		"--repo", "owner/product",
+		"--session", "landing-train",
+		"--workspace-repo", "owner/workspace",
+		"--request", "Train landing page plans.",
+		"--task-kind", "design",
+		"--mode", "explore",
+		"--options", "2",
+		"--items-file", itemsPath,
+		"--yes",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("train start exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	runID := "landing-train-review-001"
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	items, err := store.ListEvalReviewItems(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	writes := make([]db.EvalReviewGenerationWrite, 0, persistItems)
+	for i, item := range items {
+		if i >= persistItems {
+			break
+		}
+		var artifacts []db.EvalArtifact
+		var options []db.EvalReviewOption
+		for _, label := range []string{"a", "b"} {
+			artifactRecord, err := prepareReviewItemContentArtifact(blobStore, runID, item.ItemID, "option-"+label, []byte("existing option "+label), "text/markdown", "text")
+			if err != nil {
+				t.Fatalf("prepareReviewItemContentArtifact returned error: %v", err)
+			}
+			artifacts = append(artifacts, artifactRecord)
+			options = append(options, db.EvalReviewOption{
+				RunID:      runID,
+				ItemID:     item.ItemID,
+				Label:      label,
+				ArtifactID: artifactRecord.ID,
+				Role:       "option",
+			})
+		}
+		writes = append(writes, db.EvalReviewGenerationWrite{
+			ItemID:    item.ItemID,
+			Artifacts: artifacts,
+			Options:   options,
+		})
+	}
+	if len(writes) > 0 {
+		if err := store.ReplaceGeneratedEvalReviewArtifacts(context.Background(), runID, writes); err != nil {
+			t.Fatalf("ReplaceGeneratedEvalReviewArtifacts returned error: %v", err)
+		}
+	}
+	return home, runID
+}
+
+// seedStrandedGenerationLock writes a generation lock owned by a dead PID, on the
+// given host, expiring at expiresAt — emulating a crashed train continue whose
+// deferred release never ran.
+func seedStrandedGenerationLock(t *testing.T, home string, ownerPID int64, ownerHost string, expiresAt time.Time) {
+	t.Helper()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey:   skillOptTrainGenerationLockKey("landing-train", "landing-train-001"),
+		OwnerJobID:    "local-skillopt-train-generation-landing-train-deadbeef",
+		OwnerToken:    "stranded-token",
+		OwnerPID:      ownerPID,
+		OwnerHostname: ownerHost,
+		ExpiresAt:     expiresAt.Format(time.RFC3339Nano),
+	}, time.Now().UTC())
+	if err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock stranded returned acquired=%v err=%v", acquired, err)
+	}
+}
+
+// deadPID returns a PID that is (almost certainly) not a running process.
+func deadPID(t *testing.T) int64 {
+	t.Helper()
+	// A very high PID that no process should occupy in the test environment.
+	return 2147480000
+}
+
+func thisHostname(t *testing.T) string {
+	t.Helper()
+	host, err := os.Hostname()
+	if err != nil {
+		t.Fatalf("os.Hostname returned error: %v", err)
+	}
+	return host
+}
+
+func TestSkillOptTrainRecoverGenerationReclaimsDeadSameHostLock(t *testing.T) {
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	// Stale lock: dead owner on this host, lease still in the future.
+	seedStrandedGenerationLock(t, home, deadPID(t), thisHostname(t), time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover --generation exit code = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"mode: generation",
+		"lock_reclaimed: true",
+		"recovery_state: generation_complete",
+		"expected_items: 2",
+		"recovered_items: 2",
+		"missing_items: 0",
+		"persisted_options: 4",
+		"state_advanced: false",
+		"current_phase: items_ready",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("recover stdout missing %q:\n%s", want, out)
+		}
+	}
+
+	// The stranded lock must be gone; a subsequent acquire must succeed.
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if _, err := store.GetResourceLock(context.Background(), skillOptTrainGenerationLockKey("landing-train", "landing-train-001")); err == nil {
+		t.Fatalf("generation lock still held after reclaim")
+	}
+	// An audit event for the reclaim must exist.
+	events, err := store.ListJobEvents(context.Background(), "local-skillopt-train-generation-landing-train-deadbeef")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	foundReclaim := false
+	for _, event := range events {
+		if event.Kind == "lock_reclaimed" {
+			foundReclaim = true
+		}
+	}
+	if !foundReclaim {
+		t.Fatalf("no lock_reclaimed audit event recorded: %+v", events)
+	}
+	// State must NOT have advanced without --advance-state.
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateItemsReady {
+		t.Fatalf("iteration state = %s, want items_ready", iteration.State)
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationRefusesLiveOwner(t *testing.T) {
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	// Live owner: use this test process's own PID so it is provably alive.
+	seedStrandedGenerationLock(t, home, int64(os.Getpid()), thisHostname(t), time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("recover live owner exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "recovery_state: generation_active") {
+		t.Fatalf("recover live owner stdout = %s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "skillopt train generation is already running") {
+		t.Fatalf("recover live owner stderr = %s", stderr.String())
+	}
+
+	// The live owner's lock must NOT have been stolen.
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	lock, err := store.GetResourceLock(context.Background(), skillOptTrainGenerationLockKey("landing-train", "landing-train-001"))
+	if err != nil {
+		t.Fatalf("live owner lock missing after refused recover: %v", err)
+	}
+	if lock.OwnerPID != int64(os.Getpid()) {
+		t.Fatalf("live owner lock owner pid = %d, want %d", lock.OwnerPID, os.Getpid())
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationRequiresTTLForCrossHost(t *testing.T) {
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	// Cross-host dead owner, lease NOT yet expired -> must refuse (cannot verify
+	// liveness across hosts).
+	seedStrandedGenerationLock(t, home, deadPID(t), "some-other-host.example", time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("recover cross-host unexpired exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "recovery_state: generation_active") ||
+		!strings.Contains(stderr.String(), "skillopt train generation is already running") {
+		t.Fatalf("recover cross-host unexpired stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if _, err := store.GetResourceLock(context.Background(), skillOptTrainGenerationLockKey("landing-train", "landing-train-001")); err != nil {
+		t.Fatalf("cross-host lock removed despite unexpired lease: %v", err)
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationReclaimsExpiredCrossHostLock(t *testing.T) {
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	// Cross-host owner with an EXPIRED lease -> reclaimable on TTL expiry.
+	seedStrandedGenerationLock(t, home, deadPID(t), "some-other-host.example", time.Now().UTC().Add(-time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover expired cross-host exit code = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "lock_reclaimed: true") ||
+		!strings.Contains(stdout.String(), "recovery_state: generation_complete") {
+		t.Fatalf("recover expired cross-host stdout = %s", stdout.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if _, err := store.GetResourceLock(context.Background(), skillOptTrainGenerationLockKey("landing-train", "landing-train-001")); err == nil {
+		t.Fatalf("expired cross-host lock still held after reclaim")
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationAdvanceStateGate(t *testing.T) {
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	seedStrandedGenerationLock(t, home, deadPID(t), thisHostname(t), time.Now().UTC().Add(time.Hour))
+
+	// Without --advance-state, state stays items_ready.
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("recover without advance exit code = %d; stderr=%s", code, stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateItemsReady {
+		t.Fatalf("iteration state after recover (no advance) = %s, want items_ready", iteration.State)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	// With --advance-state, the complete run advances to options_generated.
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation", "--advance-state"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("recover with advance exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"state_advanced: true",
+		"current_phase: options_generated",
+		"recovery_state: generation_complete",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("recover --advance-state stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err = store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateOptionsGenerated {
+		t.Fatalf("iteration state after --advance-state = %s, want options_generated", iteration.State)
+	}
+	if !strings.Contains(iteration.MetadataJSON, `"status":"recovered"`) {
+		t.Fatalf("iteration metadata after advance = %s", iteration.MetadataJSON)
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationIncompleteDoesNotAdvance(t *testing.T) {
+	// Only 1 of 2 items persisted -> import-only recovery reports the missing
+	// item and refuses to advance even with --advance-state.
+	home, _ := seedSkillOptTrainItemsReady(t, 1)
+	seedStrandedGenerationLock(t, home, deadPID(t), thisHostname(t), time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation", "--advance-state"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover incomplete exit code = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"recovery_state: generation_incomplete",
+		"expected_items: 2",
+		"recovered_items: 1",
+		"missing_items: 1",
+		"persisted_options: 2",
+		"state_advanced: false",
+		"missing_item_ids:",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("recover incomplete stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateItemsReady {
+		t.Fatalf("incomplete recover advanced state to %s", iteration.State)
+	}
+	// The lock must still have been reclaimed.
+	if _, err := store.GetResourceLock(context.Background(), skillOptTrainGenerationLockKey("landing-train", "landing-train-001")); err == nil {
+		t.Fatalf("generation lock still held after incomplete reclaim")
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationAbortReclaimsAndKeepsItemsReady(t *testing.T) {
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	seedStrandedGenerationLock(t, home, deadPID(t), thisHostname(t), time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation", "--abort"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover --abort exit code = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"recovery_state: generation_lock_reclaimed",
+		"lock_reclaimed: true",
+		"current_phase: items_ready",
+		"state_advanced: false",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("recover --abort stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if _, err := store.GetResourceLock(context.Background(), skillOptTrainGenerationLockKey("landing-train", "landing-train-001")); err == nil {
+		t.Fatalf("generation lock still held after --abort reclaim")
+	}
+	// Persisted items must survive an abort.
+	options, err := store.ListEvalReviewOptions(context.Background(), "landing-train-review-001", "")
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions returned error: %v", err)
+	}
+	if len(options) != 4 {
+		t.Fatalf("abort dropped persisted options: got %d, want 4", len(options))
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "landing-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateItemsReady {
+		t.Fatalf("abort changed state to %s", iteration.State)
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationNoLock(t *testing.T) {
+	// No stranded lock present: recovery still classifies the persisted state.
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover no-lock exit code = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"lock_reclaimed: false",
+		"recovery_state: generation_complete",
+		"recovered_items: 2",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("recover no-lock stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationFlagsRequireGeneration(t *testing.T) {
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--advance-state"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("recover --advance-state without --generation exit code = %d, want 2; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "require --generation") {
+		t.Fatalf("recover flag-guard stderr = %s", stderr.String())
+	}
+}
+
+func TestSkillOptTrainStatusSurfacesStaleGenerationLock(t *testing.T) {
+	home, _ := seedSkillOptTrainItemsReady(t, 1)
+	// Dead owner + expired lease => classified "stale" (not active), surfaced
+	// separately from the true items_ready phase. (A future-lease dead-owner lock
+	// is deliberately still "active" to avoid flapping a legitimate long run; the
+	// status "stale" label needs the lease to have expired.)
+	seedStrandedGenerationLock(t, home, deadPID(t), thisHostname(t), time.Now().UTC().Add(-time.Hour))
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	snapshot, err := loadSkillOptTrainStatusSnapshot(context.Background(), store, "landing-train", true)
+	if err != nil {
+		t.Fatalf("loadSkillOptTrainStatusSnapshot returned error: %v", err)
+	}
+	if snapshot.Verbose == nil {
+		t.Fatalf("status snapshot verbose nil")
+	}
+	var genLock *skillOptTrainStatusLock
+	for i := range snapshot.Verbose.ActiveLocks {
+		if snapshot.Verbose.ActiveLocks[i].Name == "generation" {
+			genLock = &snapshot.Verbose.ActiveLocks[i]
+		}
+	}
+	if genLock == nil {
+		t.Fatalf("generation lock not surfaced in status: %+v", snapshot.Verbose.ActiveLocks)
+	}
+	if genLock.Status != "stale" {
+		t.Fatalf("generation lock status = %q, want stale", genLock.Status)
+	}
+	// The true phase must not be hidden by the stale lock.
+	if snapshot.CurrentPhase != skillopt.TrainStateItemsReady {
+		t.Fatalf("status current_phase = %s, want items_ready", snapshot.CurrentPhase)
+	}
+}
+
+func TestSkillOptTrainRecoverGenerationJSON(t *testing.T) {
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	seedStrandedGenerationLock(t, home, deadPID(t), thisHostname(t), time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation", "--advance-state", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover --json exit code = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		`"mode": "generation"`,
+		`"classification": "generation_complete"`,
+		`"lock_reclaimed": true`,
+		`"state_advanced": true`,
+		`"recovered_items": 2`,
+		`"persisted_options": 4`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("recover --json missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -545,7 +545,7 @@ gitmoot skillopt train start --template <id> --repo owner/repo --request <text> 
 gitmoot skillopt train status --session <id>
 gitmoot skillopt train run [--config path | --session <id>] [--plain]
 gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
-gitmoot skillopt train recover --session <id> [--out-root path] [--json]
+gitmoot skillopt train recover --session <id> [--out-root path] [--generation [--abort | --advance-state]] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
 gitmoot skillopt judge-report [--template <id>] [--home <path>]
 gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <path>] [--yes] [--json]
@@ -581,12 +581,29 @@ but not all of its options/artifacts persisted, resume returns a hard error
 (`item <id> has partial generated options; inspect or clear review options
 before continuing`) rather than guessing.
 
-`skillopt train recover --session <id>` recovers the OPTIMIZER phase only. It
-re-imports or repairs the optimizer candidate package and classifies the
+`skillopt train recover --session <id>` recovers the OPTIMIZER phase by default.
+It re-imports or repairs the optimizer candidate package and classifies the
 iteration (for example `already_completed_candidate`,
 `already_completed_no_candidate`, `optimizer_active`, or
-`corrupted_unrecoverable`). It does NOT release the generation-phase lock or
-rebuild generation options; use `train continue` for generation resume.
+`corrupted_unrecoverable`).
+
+`skillopt train recover --session <id> --generation` recovers the GENERATION
+phase: it reclaims a generation lock stranded by a crashed/killed `train
+continue` (whose deferred lock release never ran) and salvages the already
+persisted per-item options. Reclamation is liveness-gated — the stranded lock is
+released ONLY when its owner PID is provably dead AND it was held on this same
+host; a live owner is refused (`skillopt train generation is already running`) so
+you stop the running process first, and a cross-host owner requires the lock's
+TTL to have expired. The recover process re-acquires the lock for itself so the
+salvage is also crash-safe. Salvage is import-only: completed items are already
+durable, so recovery classifies them as `expected_items`/`recovered_items`/
+`missing_items` and reports `recovery_state: generation_complete`,
+`generation_incomplete`, or `generation_active`. The iteration advances to
+`options_generated` only with `--advance-state` and only when every expected item
+is recovered (regenerating missing items remains `train continue`'s job). Use
+`--abort` to reclaim the lock and leave the iteration at `items_ready` (persisted
+items are kept). A stale generation lock is also surfaced in `train status` (as a
+`stale` active lock, separate from the true current phase).
 
 `skillopt review create` starts a review run for a template and target repo.
 Use the default A/B shape for validation, or pass `--mode explore|refine|distill`

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -544,7 +544,7 @@ gitmoot skillopt train start --template <id> --repo owner/repo --request <text> 
 gitmoot skillopt train status --session <id>
 gitmoot skillopt train run [--config path | --session <id>] [--plain]
 gitmoot skillopt train continue --session <id> [--generator-type skillopt-generator | --generator-agent name] [--skillopt-bin path] [--dry-run] [--promote version|--reject version --reason text] [--start-next]
-gitmoot skillopt train recover --session <id> [--out-root path] [--json]
+gitmoot skillopt train recover --session <id> [--out-root path] [--generation [--abort | --advance-state]] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
 gitmoot skillopt judge-report [--template <id>] [--home <path>]
 gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <path>] [--yes] [--json]
@@ -581,7 +581,7 @@ resume hard-errors with `item <id> has partial generated options; inspect or
 clear review options before continuing` so you can inspect or clear that item
 before retrying.
 
-`skillopt train recover` repairs the optimizer phase of a session — it
+`skillopt train recover` repairs the optimizer phase of a session by default — it
 re-imports or repairs the optimizer candidate package and classifies the
 iteration as `already_completed_candidate`, `already_completed_no_candidate`,
 `optimizer_active`, or `corrupted_unrecoverable`:
@@ -594,10 +594,31 @@ gitmoot skillopt train recover --session <id> --json
 
 `--out-root` overrides the optimizer output directory (it defaults to the
 session's persisted optimizer path), and `--json` prints the recovery result as
-JSON. Recovery scope is the optimizer phase only: it does not release the
-generation lock and does not rebuild generation options. To recover an
-interrupted generation phase, simply re-run `skillopt train continue`, which
-resumes the incomplete items as described above.
+JSON.
+
+Pass `--generation` to recover the generation phase instead:
+
+```sh
+gitmoot skillopt train recover --session <id> --generation
+gitmoot skillopt train recover --session <id> --generation --advance-state
+gitmoot skillopt train recover --session <id> --generation --abort
+```
+
+This reclaims a generation lock stranded by a crashed/killed `train continue`
+(whose deferred lock release never ran) and salvages the persisted per-item
+options. Reclamation is liveness-gated: the lock is released only when its owner
+PID is provably dead AND it was held on this same host. A live owner is refused
+(`skillopt train generation is already running`) so you stop the running process
+first; a cross-host owner requires the lock TTL to expire. The recover process
+re-acquires the lock for itself so the salvage is crash-safe. Salvage is
+import-only — it reports `expected_items`, `recovered_items`, and `missing_items`
+and classifies the run as `generation_complete`, `generation_incomplete`, or
+`generation_active`. The iteration advances to `options_generated` only with
+`--advance-state` and only when every expected item is recovered (regenerating
+missing items remains `train continue`'s job). `--abort` reclaims the lock and
+leaves the phase at `items_ready`, keeping persisted items. A stale generation
+lock also surfaces in `train status` as a `stale` active lock, separate from the
+true current phase.
 
 `skillopt review create` starts a review run for a template and target repo.
 Use the default A/B shape for validation, or pass `--mode explore|refine|distill`

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -621,18 +621,35 @@ gitmoot skillopt train recover --session planner-train --out-root .gitmoot/skill
 ```
 
 `train recover` accepts `--session <id>`, an optional `--out-root <path>`, and
-`--json`. Its scope is the optimizer phase only: it re-imports and repairs the
-optimizer candidate package and classifies the iteration as
+`--json`. By default its scope is the optimizer phase: it re-imports and repairs
+the optimizer candidate package and classifies the iteration as
 `already_completed_candidate`, `already_completed_no_candidate`,
 `optimizer_active`, or `corrupted_unrecoverable`. It re-imports a completed
 candidate through the normal candidate gate, or records
 `optimizer_completed_no_candidate` with the stored rejection reason. Incomplete
 or corrupted artifacts fail without modifying the train state.
 
-`train recover` does not touch option generation: it does not release the
-generation lock and does not rebuild generation options. To resume interrupted
-option generation, rerun `gitmoot skillopt train continue` (see
-[Option Generation Durability](#option-generation-durability)).
+Pass `--generation` to recover the generation phase instead:
+
+```sh
+gitmoot skillopt train recover --session planner-train --generation
+gitmoot skillopt train recover --session planner-train --generation --advance-state
+gitmoot skillopt train recover --session planner-train --generation --abort
+```
+
+This reclaims a generation lock stranded by a crashed/killed `train continue`
+(whose deferred lock release never ran) and salvages the persisted per-item
+options. Reclamation is liveness-gated: the lock is released only when its owner
+PID is provably dead AND it was held on this same host. A live owner is refused
+(`skillopt train generation is already running`) so you stop the running process
+first; a cross-host owner requires the lock TTL to expire. The recover process
+re-acquires the lock for itself so the salvage is crash-safe. Salvage is
+import-only — it reports `expected_items`, `recovered_items`, and `missing_items`
+and classifies the run as `generation_complete`, `generation_incomplete`, or
+`generation_active`. The iteration advances to `options_generated` only with
+`--advance-state` and only when every expected item is recovered (regenerating
+missing items remains `train continue`'s job). `--abort` reclaims the lock and
+leaves the phase at `items_ready`, keeping persisted items.
 
 ## Candidate Review And Next Iteration
 
@@ -842,14 +859,21 @@ Manual smoke scenarios for review operations:
   and next action options.
 - Optimizer wrapper failed after artifacts: if `status_phase` is
   `recovery_available`, run `gitmoot skillopt train recover --session <id>
-  --out-root <optimizer-output-root>`. `train recover` repairs the optimizer
-  candidate package only; it does not release the generation lock or rebuild
-  generation options.
+  --out-root <optimizer-output-root>`. By default `train recover` repairs the
+  optimizer candidate package only.
 - Interrupted option generation: rerun `gitmoot skillopt train continue
   --session <id>`. It regenerates only incomplete items and never rewrites
   completed work. If it reports that an item "has partial generated options",
-  inspect or clear that item's review options before continuing. Do not use
-  `train recover` for this; recover is optimizer-phase only.
+  inspect or clear that item's review options before continuing.
+- Stale generation lock blocking re-entry: if a `train continue` was killed
+  mid-generation, its generation lock is stranded and `train continue` reports
+  `skillopt train generation is already running` until the lock TTL expires.
+  Run `gitmoot skillopt train recover --session <id> --generation` to reclaim
+  the lock (when its owner is provably dead and same-host) and salvage persisted
+  options; add `--advance-state` to advance a fully recovered run to
+  `options_generated`, or `--abort` to reclaim and stay at `items_ready`. A stale
+  generation lock also surfaces in verbose `train status` as a `stale`
+  `active_lock`, separate from the true current phase.
 - Stale optimizer lock: if `status_phase` is `blocked_stale_lock`, inspect
   `active_lock` owner, pid, host, heartbeat, and expiry in verbose status before
   clearing stale state or retrying the optimizer.


### PR DESCRIPTION
Closes #303.

Adds `gitmoot skillopt train recover --generation` to reclaim a **stranded** `skillopt-train-generation:*` resource lock (left when a `train continue` generation process is SIGKILLed and its deferred lock-release never runs), salvage the already-persisted per-item options (import-only), and — with `--advance-state` and all items recovered — advance the iteration to `options_generated`.

## What it does
- **Liveness-gated steal-then-own** (no locking-core change): reclaim ONLY when the owner PID is provably dead AND same-host (`owner_hostname == this host`, or **empty** — a pre-#303 legacy strand from a binary that did not record the host, treated as local since skillopt train is local-first). A live owner is never stolen (refused with the busy error). A genuine cross-host owner (different recorded host) requires TTL expiry.
- Records the previously-missing `OwnerHostname` on `acquireSkillOptTrainGenerationLock` (matching the optimizer lock).
- Reclaim via `DeleteResourceLocksByOwner(lock.OwnerJobID)` + a manual `lock_reclaimed` audit event; re-acquires for the recover process (crash-safe).
- Import-only salvage (regenerating missing items stays `train continue`'s job, deferred to a future `--regenerate`). `--abort` reclaims and keeps `items_ready` with persisted options intact. `train status` surfaces the stale lock.

## Decisions (from the issue's decided-spec comment)
Import-only; `--advance-state` required to advance; record `OwnerHostname`.

## Verification
- Gate green: `go build/vet/test ./...` + `go test -race ./internal/workflow/`.
- 15 unit tests (dead-same-host reclaim, refuse-live-owner, cross-host TTL gate, expired-cross-host reclaim, advance-state gating, incomplete-no-advance, abort, no-lock, flag guards, JSON, stale-lock-in-status, empty-host reclaim/advance/abort/refuse-live).
- Adversarial review: clean (after a fix-round for legacy empty-hostname strands).
- **Live codex E2E PASS**: real generation → SIGKILL strands the lock → fresh `train continue` blocked → `recover --generation` reclaims + imports + audit event → `train continue` reaches `options_generated`.

Docs updated in both trees (in-repo + website).

🤖 Generated with [Claude Code](https://claude.com/claude-code)