### PR TITLE
feat(workflow): result-aware non-progress loop detection for delegation trees (#339)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3329,10 +3329,11 @@ func (w jobWorker) defaultWorkflow(checkout string) workflow.Engine {
 }
 
 // applyOrchestratePolicy sets the engine's opt-in [orchestrate] fields — the
-// artifact-body inlining knobs and the per-root delegation token (#338 Part B)
-// and dollar-cost (#380) budgets — from the host policy. It is fail-safe: any
-// load error leaves the engine with its defaults (inlining off, both budgets 0 =
-// unlimited) rather than failing engine construction.
+// artifact-body inlining knobs, the per-root delegation token (#338 Part B) and
+// dollar-cost (#380) budgets, and the result-aware non-progress streak threshold
+// (#339) — from the host policy. It is fail-safe: any load error leaves the
+// engine with its defaults (inlining off, both budgets 0 = unlimited, streak
+// threshold 0 = engine default) rather than failing engine construction.
 func (w jobWorker) applyOrchestratePolicy(engine *workflow.Engine) {
 	policy, err := w.orchestratePolicy()
 	if err != nil {
@@ -3342,6 +3343,7 @@ func (w jobWorker) applyOrchestratePolicy(engine *workflow.Engine) {
 	engine.MaxInlineArtifactBytes = policy.InlineArtifactMaxBytes
 	engine.MaxDelegationTokenBudget = policy.MaxDelegationTokenBudget
 	engine.MaxDelegationCostUSD = policy.MaxDelegationCostUSD
+	engine.MaxDelegationNonProgressStreak = policy.MaxDelegationNonProgressStreak
 }
 
 // workflowHome resolves the GITMOOT_HOME root used to place per-delegation

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -50,18 +50,26 @@ type OrchestratePolicy struct {
 	// unlimited/off, so default behavior is unchanged. The daemon wires this into
 	// Engine.MaxDelegationCostUSD at startup.
 	MaxDelegationCostUSD float64
+	// MaxDelegationNonProgressStreak is the per-root threshold for the result-aware
+	// non-progress loop detector (#339): how many consecutive continuation
+	// generations a delegation tree may produce with no new durable side effect
+	// before the loop ladder trips. 0 (the default) means use the engine's built-in
+	// default (2), so default behavior is unchanged. The daemon wires this into
+	// Engine.MaxDelegationNonProgressStreak at startup.
+	MaxDelegationNonProgressStreak int
 }
 
 func DefaultOrchestratePolicy() OrchestratePolicy {
 	return OrchestratePolicy{
-		CockpitMode:              CockpitModeAuto,
-		CockpitSession:           "",
-		CockpitMaxPanes:          4,
-		CockpitPaneKey:           CockpitPaneKeyJob,
-		InlineArtifactBodies:     false,
-		InlineArtifactMaxBytes:   0,
-		MaxDelegationTokenBudget: 0,
-		MaxDelegationCostUSD:     0,
+		CockpitMode:                    CockpitModeAuto,
+		CockpitSession:                 "",
+		CockpitMaxPanes:                4,
+		CockpitPaneKey:                 CockpitPaneKeyJob,
+		InlineArtifactBodies:           false,
+		InlineArtifactMaxBytes:         0,
+		MaxDelegationTokenBudget:       0,
+		MaxDelegationCostUSD:           0,
+		MaxDelegationNonProgressStreak: 0,
 	}
 }
 
@@ -133,6 +141,10 @@ func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value st
 		parsed, err := strconv.ParseFloat(value, 64)
 		policy.MaxDelegationCostUSD = parsed
 		return err
+	case "max_delegation_non_progress_streak":
+		parsed, err := strconv.Atoi(value)
+		policy.MaxDelegationNonProgressStreak = parsed
+		return err
 	default:
 		return nil
 	}
@@ -157,6 +169,9 @@ func validateOrchestratePolicy(policy OrchestratePolicy) error {
 	}
 	if policy.MaxDelegationCostUSD < 0 {
 		return fmt.Errorf("orchestrate.max_delegation_cost_usd must be 0 (unlimited) or positive")
+	}
+	if policy.MaxDelegationNonProgressStreak < 0 {
+		return fmt.Errorf("orchestrate.max_delegation_non_progress_streak must be 0 (engine default) or positive")
 	}
 	return nil
 }

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -41,6 +41,48 @@ func TestLoadOrchestratePolicyDefaults(t *testing.T) {
 	if policy.MaxDelegationCostUSD != 0 {
 		t.Fatalf("MaxDelegationCostUSD = %v, want 0 (unlimited) by default", policy.MaxDelegationCostUSD)
 	}
+	if policy.MaxDelegationNonProgressStreak != 0 {
+		t.Fatalf("MaxDelegationNonProgressStreak = %d, want 0 (engine default) by default", policy.MaxDelegationNonProgressStreak)
+	}
+}
+
+// TestLoadOrchestratePolicyMaxDelegationNonProgressStreak pins #339: the
+// result-aware non-progress streak threshold parses from [orchestrate] and an
+// absent key keeps the 0 (engine default) value.
+func TestLoadOrchestratePolicyMaxDelegationNonProgressStreak(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+max_delegation_non_progress_streak = 3
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	policy, err := LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.MaxDelegationNonProgressStreak != 3 {
+		t.Fatalf("MaxDelegationNonProgressStreak = %d, want 3", policy.MaxDelegationNonProgressStreak)
+	}
+
+	// Absent key keeps the engine-default (0) even with the section present.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+cockpit_mode = "auto"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err = LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.MaxDelegationNonProgressStreak != 0 {
+		t.Fatalf("absent max_delegation_non_progress_streak should default 0, got %d", policy.MaxDelegationNonProgressStreak)
+	}
 }
 
 // TestLoadOrchestratePolicyMaxDelegationCostUSD pins #380: the dollar-cost budget
@@ -249,6 +291,22 @@ max_delegation_cost_usd = cheap
 max_delegation_cost_usd = -0.5
 `,
 			wantErr: "max_delegation_cost_usd must be 0 (unlimited) or positive",
+		},
+		{
+			name: "max_delegation_non_progress_streak_non_int",
+			body: `
+[orchestrate]
+max_delegation_non_progress_streak = many
+`,
+			wantErr: "parse [orchestrate].max_delegation_non_progress_streak",
+		},
+		{
+			name: "max_delegation_non_progress_streak_negative",
+			body: `
+[orchestrate]
+max_delegation_non_progress_streak = -1
+`,
+			wantErr: "max_delegation_non_progress_streak must be 0 (engine default) or positive",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -84,6 +84,37 @@ type Engine struct {
 	// capture and a hardcoded price table, treat it as a coarse runaway-cost
 	// backstop, not a precise spend meter.
 	MaxDelegationCostUSD float64
+	// MaxDelegationNonProgressStreak bounds how many consecutive continuation
+	// generations a coordination tree may produce with NO new durable side effect
+	// before the result-aware loop detector trips (#339). Where the structural
+	// fast-path (handleDelegationLoop / canonicalDelegationSetHash) only catches a
+	// coordinator literally re-issuing the same delegation SET, this catches a
+	// coordinator that perturbs the set each round (evading the set hash) yet whose
+	// children keep returning nothing new — comparing a mechanical progressDigest of
+	// each generation's verifiable child side effects (decision, changes_made,
+	// tests_run, PR/HeadSHA, artifact body) against the previous digest threaded
+	// through the payload. A streak of unchanged digests at or above this threshold
+	// trips the SAME ladder as the structural check (delegation_loop_warning +
+	// corrective continuation, then delegation_loop_detected + graceful finalize).
+	// Any new durable side effect resets the streak to 0 even if the self-reported
+	// summary repeats. <= 0 means use defaultMaxDelegationNonProgressStreak (2); it
+	// is configurable per-root alongside the depth/width/budget bounds.
+	MaxDelegationNonProgressStreak int
+}
+
+// defaultMaxDelegationNonProgressStreak is the streak threshold used when the
+// engine's MaxDelegationNonProgressStreak is unset (<= 0): two consecutive
+// non-progress generations trip the result-aware loop detector (#339).
+const defaultMaxDelegationNonProgressStreak = 2
+
+// nonProgressStreakThreshold returns the configured result-aware non-progress
+// streak threshold, falling back to defaultMaxDelegationNonProgressStreak when
+// unset so a zero-valued Engine keeps the documented default.
+func (e Engine) nonProgressStreakThreshold() int {
+	if e.MaxDelegationNonProgressStreak > 0 {
+		return e.MaxDelegationNonProgressStreak
+	}
+	return defaultMaxDelegationNonProgressStreak
 }
 
 // now returns the engine's current time, defaulting to time.Now when Now is unset.
@@ -794,6 +825,65 @@ func windowContainsHash(window []string, h string) bool {
 		}
 	}
 	return false
+}
+
+// progressDigest fingerprints the VERIFIABLE side effects a finished generation
+// of delegated children produced, so the result-aware loop detector (#339) can
+// tell "a coordinator that keeps producing the same results" (no progress) from
+// "genuinely new results" (progress). Two generations whose children advanced
+// nothing externally observable hash identically EVEN IF the coordinator
+// perturbed the delegation set (different ids/agents/prompts) or the children
+// rewrote their self-reported prose; any new durable side effect — a different
+// decision, a new commit/change, a test run, a new PR/HeadSHA, or a changed
+// artifact body — changes the digest.
+//
+// Only externally-verifiable fields are folded in, per child: Result.Decision,
+// Result.ChangesMade, Result.TestsRun, the child payload's PullRequest + HeadSHA
+// (where a real PR advance lands), and Result.ArtifactBody. The self-reported
+// Summary/Findings TEXT is deliberately excluded (weight 0) so a coordinator
+// cannot defeat the detector by churning prose, and a repeated summary over a
+// real new side effect is still correctly read as progress.
+//
+// Crucially the per-child side-effect tuple is hashed WITHOUT the delegation id,
+// then the tuples are SORTED, so the digest depends only on the multiset of side
+// effects the generation produced — not on the labels the coordinator chose.
+// That is what closes the evasion hole: a coordinator that trivially perturbs the
+// delegation set each round but whose children keep returning nothing new yields
+// the same (empty-result) multiset every round, so the digest repeats and the
+// streak climbs. A child whose Result did not parse contributes the same empty
+// tuple as a child that ran but produced no durable effect. The separators (\x1f
+// between fields, \x1e between children, \x1d between list items) keep field
+// boundaries unambiguous.
+func progressDigest(dels []Delegation, childPayloads map[string]JobPayload) string {
+	tuples := make([]string, 0, len(dels))
+	for _, d := range dels {
+		fields := []string{"", "", "", "0", "", ""}
+		if payload, ok := childPayloads[d.ID]; ok && payload.Result != nil {
+			r := payload.Result
+			changes := append([]string(nil), r.ChangesMade...)
+			sort.Strings(changes)
+			tests := append([]string(nil), r.TestsRun...)
+			sort.Strings(tests)
+			fields = []string{
+				strings.TrimSpace(r.Decision),
+				strings.Join(changes, "\x1d"),
+				strings.Join(tests, "\x1d"),
+				strconv.Itoa(payload.PullRequest),
+				strings.TrimSpace(payload.HeadSHA),
+				strings.TrimSpace(r.ArtifactBody),
+			}
+		}
+		tuples = append(tuples, strings.Join(fields, "\x1f"))
+	}
+	sort.Strings(tuples)
+
+	var builder strings.Builder
+	for _, t := range tuples {
+		builder.WriteString(t)
+		builder.WriteString("\x1e")
+	}
+	sum := sha256.Sum256([]byte(builder.String()))
+	return hex.EncodeToString(sum[:])
 }
 
 // countRootDelegationJobs counts every job belonging to a coordination tree: the
@@ -1676,6 +1766,97 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		}
 	}
 
+	// Result-aware non-progress detection (#339). The structural fast-path
+	// (handleDelegationLoop) only catches a coordinator literally re-issuing the
+	// same delegation SET; a coordinator that perturbs the set each round to evade
+	// the set hash, yet whose children keep returning nothing new, slips past it.
+	// Here — after every child has finished and childPayloads carry full results —
+	// fold the generation's verifiable side effects into a progressDigest and
+	// compare it to the previous generation's digest threaded through the payload.
+	// No new durable side effect + an unchanged digest => the streak climbs; any
+	// new side effect (a different decision, a new commit/change, a test run, a new
+	// PR/HeadSHA, a changed artifact body) resets it to 0 even when the summary
+	// text repeats. At the threshold the result-aware path trips the SAME ladder as
+	// the structural check: a first trip emits delegation_loop_warning and a
+	// corrective continuation; a trip after a corrective nudge has already fired
+	// (DelegationRepeatCount >= 1) emits delegation_loop_detected and routes to the
+	// #305 graceful finalize continuation. Both reuse the existing once-guards
+	// (the continuationEnqueued top-guard above + enqueueFinalizeContinuation's own
+	// guard) so re-advance never double-fires.
+	digest := progressDigest(parentResult.Delegations, childPayloads)
+	nonProgressStreak := 0
+	if digest == parentPayload.LastProgressDigest {
+		// The previous generation recorded this exact digest and this generation
+		// reproduced it: no new durable side effect => the streak climbs.
+		nonProgressStreak = parentPayload.NonProgressStreak + 1
+	}
+	if nonProgressStreak >= e.nonProgressStreakThreshold() {
+		if parentPayload.DelegationRepeatCount >= 1 {
+			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   parentJob.ID,
+				Kind:    "delegation_loop_detected",
+				Message: fmt.Sprintf("delegation tree made no new durable side effect for %d consecutive generations after a corrective nudge (digest %s); finalizing instead of continuing", nonProgressStreak, digest),
+			})
+			// Graceful finalize (#305): give the coordinator one terminal continuation
+			// to synthesize a best-effort result rather than stopping silently.
+			return e.enqueueFinalizeContinuation(ctx, parentJob, parentPayload, "delegation tree made no progress after a corrective nudge")
+		}
+
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   parentJob.ID,
+			Kind:    "delegation_loop_warning",
+			Message: fmt.Sprintf("delegation tree made no new durable side effect for %d consecutive generations (digest %s); sending a corrective continuation instead of continuing", nonProgressStreak, digest),
+		})
+		correctiveRequest := JobRequest{
+			ID:              delegationContinuationID(parentJob.ID),
+			Agent:           parentJob.Agent,
+			Action:          "ask",
+			Model:           parentPayload.Model,
+			Phase:           parentPayload.Phase,
+			Repo:            parentPayload.Repo,
+			Branch:          parentPayload.Branch,
+			PullRequest:     parentPayload.PullRequest,
+			HeadSHA:         parentPayload.HeadSHA,
+			GoalID:          parentPayload.GoalID,
+			TaskID:          parentPayload.TaskID,
+			TaskTitle:       parentPayload.TaskTitle,
+			LeadAgent:       parentPayload.LeadAgent,
+			Reviewers:       parentPayload.Reviewers,
+			Sender:          parentJob.Agent,
+			Instructions:    buildCorrectiveContinuationPrompt(parentResult),
+			Constraints:     parentPayload.Constraints,
+			ParentJobID:     parentJob.ID,
+			DelegationDepth: parentPayload.DelegationDepth + 1,
+			DelegatedBy:     parentJob.Agent,
+			RootJobID:       e.rootJobID(parentJob, parentPayload),
+			// Carry the window forward and mark that a corrective nudge has fired so a
+			// further non-progress generation escalates to delegation_loop_detected.
+			RecentDelegationHashes: appendDelegationHashWindow(parentPayload.RecentDelegationHashes, canonicalDelegationSetHash(parentResult.Delegations)),
+			DelegationRepeatCount:  parentPayload.DelegationRepeatCount + 1,
+			// Thread the non-progress streak forward: if the coordinator's corrective
+			// continuation still produces no new side effect, the streak stays at or
+			// above the threshold and the next generation escalates.
+			NonProgressStreak:  nonProgressStreak,
+			LastProgressDigest: digest,
+			Cockpit:            parentPayload.Cockpit,
+			CockpitSession:     parentPayload.CockpitSession,
+			CockpitPaneKey:     parentPayload.CockpitPaneKey,
+		}
+		if err := e.enqueue(ctx, correctiveRequest); err != nil {
+			return fmt.Errorf("enqueue corrective continuation for %q: %w", parentJob.ID, err)
+		}
+		// The corrective continuation IS the coordinator's single continuation, so it
+		// occupies the continuation slot: emit delegation_continuation_enqueued so a
+		// re-advance hits the continuationEnqueued top-guard rather than re-running
+		// the streak logic.
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   parentJob.ID,
+			Kind:    "delegation_continuation_enqueued",
+			Message: fmt.Sprintf("corrective continuation occupies the continuation slot for job %s", correctiveRequest.ID),
+		})
+		return nil
+	}
+
 	request := JobRequest{
 		ID:           delegationContinuationID(parentJob.ID),
 		Agent:        parentJob.Agent,
@@ -1709,6 +1890,13 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		// corrective-nudge counter only climbs while the coordinator loops.
 		RecentDelegationHashes: appendDelegationHashWindow(parentPayload.RecentDelegationHashes, canonicalDelegationSetHash(parentResult.Delegations)),
 		DelegationRepeatCount:  0,
+		// Result-aware non-progress carry-forward (#339): record this generation's
+		// progressDigest so the next generation can detect a non-progress repeat, and
+		// thread the (sub-threshold) streak forward. nonProgressStreak is 0 whenever
+		// this generation produced a new durable side effect, so genuine progress
+		// always resets the streak even when the self-reported summary repeats.
+		NonProgressStreak:  nonProgressStreak,
+		LastProgressDigest: digest,
 		// Inherit the coordinator's cockpit settings so the continuation renders
 		// its pane under the same workspace/session as the rest of the tree.
 		Cockpit:        parentPayload.Cockpit,

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2673,6 +2673,23 @@ func countJobEvents(t *testing.T, store *db.Store, jobID, kind string) int {
 	return count
 }
 
+// jobEventMessage returns the message of the first event of kind on jobID, or ""
+// when none exists. Used to attribute a delegation_loop_* event to the structural
+// vs result-aware path (both emit the same kind, distinguished by message).
+func jobEventMessage(t *testing.T, store *db.Store, jobID, kind string) string {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s) returned error: %v", jobID, err)
+	}
+	for _, event := range events {
+		if event.Kind == kind {
+			return event.Message
+		}
+	}
+	return ""
+}
+
 func TestEngineDelegationTimeoutPlumbedToChildPayload(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -4128,8 +4145,10 @@ func TestEngineStaticCoordinatorHaltedByLoopDetection(t *testing.T) {
 }
 
 // TestEngineProgressingCoordinatorNotFalselyFlagged pins the false-positive guard:
-// a coordinator that issues a DIFFERENT delegation set each continuation keeps
-// dispatching for real and is never flagged as a loop.
+// a coordinator that issues a DIFFERENT delegation set each continuation AND whose
+// children land a genuinely new durable side effect each round keeps dispatching
+// for real and is never flagged as a loop — by either the structural fast-path or
+// the result-aware non-progress streak (#339).
 func TestEngineProgressingCoordinatorNotFalselyFlagged(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -4182,11 +4201,336 @@ func TestEngineProgressingCoordinatorNotFalselyFlagged(t *testing.T) {
 		if !jobExists(t, store, childID) {
 			t.Fatalf("round %d: a distinct set must dispatch a real child %s", round, childID)
 		}
-		// Finish the round's child so the next continuation is enqueued.
-		completeDelegationChild(t, store, childID, JobSucceeded, AgentResult{Decision: "approved", Summary: "ok"})
+		// Finish the round's child with a genuinely NEW durable side effect (a
+		// distinct ChangesMade) so the result-aware progressDigest differs every
+		// round and the non-progress streak stays reset — real progress, never
+		// flagged.
+		completeDelegationChild(t, store, childID, JobSucceeded, AgentResult{
+			Decision:    "approved",
+			Summary:     "ok",
+			ChangesMade: []string{fmt.Sprintf("change %d", round)},
+		})
 		if err := engine.AdvanceJob(ctx, childID); err != nil {
 			t.Fatalf("round %d: AdvanceJob(child) returned error: %v", round, err)
 		}
 		parentID = continuationID
+	}
+}
+
+// driveResultAwareGeneration runs one full coordinator continuation generation
+// for the result-aware (#339) tests: it stamps the already-enqueued continuation
+// job `parentID` with the delegation set `dels`, advances it (dispatching the
+// children), then completes each child with the matching result from
+// `childResults` (keyed by delegation id) and advances one child so
+// advanceDelegations -> maybeEnqueueContinuation runs the non-progress check. It
+// returns the id of the next continuation (delegationContinuationID(parentID)),
+// which is the same id whether the generation continued normally, tripped a
+// corrective continuation, or tripped a finalize continuation.
+func driveResultAwareGeneration(t *testing.T, store *db.Store, engine Engine, parentID string, dels []Delegation, childResults map[string]AgentResult) string {
+	t.Helper()
+	ctx := context.Background()
+	// Stamp the continuation job with this generation's delegation set and advance
+	// it so the children are dispatched (modeling the coordinator re-delegating).
+	completeDelegationChild(t, store, parentID, JobSucceeded, AgentResult{
+		Decision:    "approved",
+		Summary:     "coordinating",
+		Delegations: dels,
+	})
+	if err := engine.AdvanceJob(ctx, parentID); err != nil {
+		t.Fatalf("driveResultAwareGeneration: AdvanceJob(parent %s) returned error: %v", parentID, err)
+	}
+	// Complete every dispatched child with its chosen result, then advance one so
+	// the parent's continuation decision runs once all children are terminal.
+	var lastChildID string
+	for _, d := range dels {
+		childID := parentID + "/delegation/" + d.ID
+		if !jobExists(t, store, childID) {
+			// The generation was halted before dispatch (e.g. a finalize trip from a
+			// prior corrective nudge): no children to complete.
+			continue
+		}
+		result := childResults[d.ID]
+		completeDelegationChild(t, store, childID, JobSucceeded, result)
+		lastChildID = childID
+	}
+	if lastChildID != "" {
+		if err := engine.AdvanceJob(ctx, lastChildID); err != nil {
+			t.Fatalf("driveResultAwareGeneration: AdvanceJob(child %s) returned error: %v", lastChildID, err)
+		}
+	}
+	return delegationContinuationID(parentID)
+}
+
+// TestProgressDigestIgnoresDelegationIdentityAndText pins the two properties the
+// result-aware loop detector relies on: the digest is independent of the
+// delegation labels (so a perturbed set with the same empty results matches) and
+// independent of self-reported Summary/Findings text, while ANY new durable side
+// effect changes it.
+func TestProgressDigestIgnoresDelegationIdentityAndText(t *testing.T) {
+	noEffect := func(summary string) *AgentResult {
+		return &AgentResult{Decision: "approved", Summary: summary}
+	}
+	genA := []Delegation{{ID: "w1", Agent: "wa", Action: "review"}}
+	payA := map[string]JobPayload{"w1": {Result: noEffect("first wording")}}
+	// Perturbed set (different id/agent) + different summary text, same empty side
+	// effects: must hash identically.
+	genB := []Delegation{{ID: "x9", Agent: "wb", Action: "review"}}
+	payB := map[string]JobPayload{"x9": {Result: noEffect("totally different wording")}}
+	if progressDigest(genA, payA) != progressDigest(genB, payB) {
+		t.Fatal("digest must ignore delegation identity and self-reported text when side effects are unchanged")
+	}
+
+	// A new durable side effect (ChangesMade) must change the digest.
+	payChanged := map[string]JobPayload{"w1": {Result: &AgentResult{Decision: "approved", ChangesMade: []string{"edited file"}}}}
+	if progressDigest(genA, payA) == progressDigest(genA, payChanged) {
+		t.Fatal("a new ChangesMade must change the digest")
+	}
+	// A new PR/HeadSHA must change the digest.
+	payPR := map[string]JobPayload{"w1": {PullRequest: 7, HeadSHA: "abc123", Result: noEffect("first wording")}}
+	if progressDigest(genA, payA) == progressDigest(genA, payPR) {
+		t.Fatal("a new PR/HeadSHA must change the digest")
+	}
+}
+
+// TestEngineResultAwareNonProgressStreakTripsLadder is the core #339 regression:
+// a coordinator that PERTURBS the delegation set every round (evading the
+// structural set-hash fast-path) but whose children keep returning NO new durable
+// side effect is caught by the result-aware non-progress streak. It trips the SAME
+// ladder as the structural check: delegation_loop_warning + a corrective
+// continuation, then delegation_loop_detected + a graceful finalize continuation.
+func TestEngineResultAwareNonProgressStreakTripsLadder(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	// Each round the child returns the same trivial approval with NO durable side
+	// effect, regardless of the (perturbed) delegation id.
+	noProgress := AgentResult{Decision: "approved", Summary: "still investigating"}
+	perturbed := func(round int) ([]Delegation, map[string]AgentResult) {
+		id := fmt.Sprintf("w%d", round)
+		return []Delegation{{ID: id, Agent: "w", Action: "review", Prompt: fmt.Sprintf("attempt %d", round)}},
+			map[string]AgentResult{id: noProgress}
+	}
+
+	// Generation 0: the originating coordinator dispatches a real set; its child
+	// returns no durable effect, establishing the baseline digest.
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result:    &AgentResult{Decision: "approved", Summary: "round 0", Delegations: []Delegation{{ID: "w0", Agent: "w", Action: "review", Prompt: "attempt 0"}}},
+	})
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "root-job/delegation/w0", JobSucceeded, noProgress)
+	if err := engine.AdvanceJob(ctx, "root-job/delegation/w0"); err != nil {
+		t.Fatalf("AdvanceJob(root child) returned error: %v", err)
+	}
+
+	// Generation 1 runs the continuation root-job/continuation: its (perturbed-set)
+	// children again make no progress, so the digest repeats and the streak climbs
+	// to 1. Still a normal continuation, no warning. The set is perturbed each round
+	// so the STRUCTURAL fast-path never fires — only the RESULT-aware path can.
+	gen1Cont := delegationContinuationID("root-job")
+	dels1, res1 := perturbed(1)
+	gen2Cont := driveResultAwareGeneration(t, store, engine, gen1Cont, dels1, res1)
+	if countJobEvents(t, store, gen1Cont, "delegation_loop_warning") != 0 {
+		t.Fatal("generation 1 must not warn: streak only reached 1")
+	}
+	if countJobEvents(t, store, gen1Cont, "delegation_loop_detected") != 0 {
+		t.Fatal("generation 1 must not be halted")
+	}
+	gen2Payload, err := unmarshalPayload(mustJob(t, store, gen2Cont).Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(gen2) returned error: %v", err)
+	}
+	if gen2Payload.NonProgressStreak != 1 {
+		t.Fatalf("gen2 NonProgressStreak = %d, want 1", gen2Payload.NonProgressStreak)
+	}
+
+	// Generation 2: streak reaches the threshold (2) -> delegation_loop_warning and a
+	// corrective continuation INSTEAD of a normal one. Structural detection never
+	// fired (the set hashes differ each round), proving the RESULT-aware path tripped.
+	dels2, res2 := perturbed(2)
+	gen3Cont := driveResultAwareGeneration(t, store, engine, gen2Cont, dels2, res2)
+	if countJobEvents(t, store, gen2Cont, "delegation_loop_warning") != 1 {
+		t.Fatal("generation 2 must record exactly one delegation_loop_warning (result-aware trip)")
+	}
+	// Attribute the trip to the RESULT-aware path, not the structural set-hash path:
+	// both emit delegation_loop_warning, distinguished by message.
+	if msg := jobEventMessage(t, store, gen2Cont, "delegation_loop_warning"); !strings.Contains(msg, "no new durable side effect") {
+		t.Fatalf("warning must come from the result-aware path, got message: %q", msg)
+	}
+	correctivePayload, err := unmarshalPayload(mustJob(t, store, gen3Cont).Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(corrective) returned error: %v", err)
+	}
+	if correctivePayload.DelegationRepeatCount != 1 {
+		t.Fatalf("corrective DelegationRepeatCount = %d, want 1", correctivePayload.DelegationRepeatCount)
+	}
+	if correctivePayload.NonProgressStreak < 2 {
+		t.Fatalf("corrective NonProgressStreak = %d, want >= 2 (carried forward)", correctivePayload.NonProgressStreak)
+	}
+	if !strings.Contains(correctivePayload.Instructions, "EMPTY delegations list") {
+		t.Fatalf("corrective prompt missing the change-or-finish nudge: %q", correctivePayload.Instructions)
+	}
+
+	// Generation 3: the coordinator STILL makes no progress after the corrective
+	// nudge -> delegation_loop_detected + a terminal finalize continuation.
+	dels3, res3 := perturbed(3)
+	gen4Cont := driveResultAwareGeneration(t, store, engine, gen3Cont, dels3, res3)
+	if countJobEvents(t, store, gen3Cont, "delegation_loop_detected") != 1 {
+		t.Fatal("generation 3 must record delegation_loop_detected after the corrective nudge")
+	}
+	if countJobEvents(t, store, gen3Cont, "delegation_finalize_enqueued") != 1 {
+		t.Fatal("delegation_loop_detected must enqueue a graceful finalize continuation")
+	}
+	finalizePayload, err := unmarshalPayload(mustJob(t, store, gen4Cont).Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(finalize) returned error: %v", err)
+	}
+	if !finalizePayload.DelegationFinalize {
+		t.Fatalf("loop_detected continuation must be a terminal finalize: %+v", finalizePayload)
+	}
+	// It halted well before the blunt depth cap.
+	if finalizePayload.DelegationDepth >= MaxDelegationDepth {
+		t.Fatalf("result-aware loop detection must halt well before MaxDelegationDepth=%d (depth=%d)", MaxDelegationDepth, finalizePayload.DelegationDepth)
+	}
+}
+
+// TestEngineResultAwareProgressResetsStreak pins the progress boundary from the
+// other side: a coordinator whose children land a genuinely new durable side
+// effect each round (a fresh ChangesMade, then a fresh TestsRun, …) is NEVER
+// flagged by the result-aware streak, because each new side effect resets the
+// streak even though the self-reported summary text repeats verbatim. The
+// delegation set is perturbed each round so the STRUCTURAL fast-path stays silent
+// and the test isolates the result-aware decision: the only reason it does not
+// trip is that the digest changes every round.
+func TestEngineResultAwareProgressResetsStreak(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	// Each round perturbs the delegation id (silencing the structural set-hash path)
+	// and lands a NEW durable side effect, while the Summary text repeats verbatim.
+	progressing := func(round int) ([]Delegation, map[string]AgentResult) {
+		id := fmt.Sprintf("w%d", round)
+		r := AgentResult{Decision: "approved", Summary: "still working"}
+		if round%2 == 1 {
+			r.ChangesMade = []string{fmt.Sprintf("edit-%d", round)}
+		} else {
+			r.TestsRun = []string{fmt.Sprintf("go test ./pkg%d", round)}
+		}
+		return []Delegation{{ID: id, Agent: "w", Action: "review", Prompt: fmt.Sprintf("round %d", round)}},
+			map[string]AgentResult{id: r}
+	}
+
+	// Generation 0: dispatch the first set for real with a first durable effect.
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result:    &AgentResult{Decision: "approved", Summary: "still working", Delegations: []Delegation{{ID: "w0", Agent: "w", Action: "review", Prompt: "round 0"}}},
+	})
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "root-job/delegation/w0", JobSucceeded, AgentResult{Decision: "approved", Summary: "still working", ChangesMade: []string{"edit-0"}})
+	if err := engine.AdvanceJob(ctx, "root-job/delegation/w0"); err != nil {
+		t.Fatalf("AdvanceJob(root child) returned error: %v", err)
+	}
+
+	parentID := delegationContinuationID("root-job")
+	for round := 1; round <= 4; round++ {
+		dels, res := progressing(round)
+		next := driveResultAwareGeneration(t, store, engine, parentID, dels, res)
+		if countJobEvents(t, store, parentID, "delegation_loop_warning") != 0 {
+			t.Fatalf("round %d: a progressing coordinator must not warn", round)
+		}
+		if countJobEvents(t, store, parentID, "delegation_loop_detected") != 0 {
+			t.Fatalf("round %d: a progressing coordinator must not be halted", round)
+		}
+		nextPayload, err := unmarshalPayload(mustJob(t, store, next).Payload)
+		if err != nil {
+			t.Fatalf("round %d: unmarshalPayload(next) returned error: %v", round, err)
+		}
+		if nextPayload.NonProgressStreak != 0 {
+			t.Fatalf("round %d: a progressing coordinator must keep NonProgressStreak at 0, got %d", round, nextPayload.NonProgressStreak)
+		}
+		parentID = next
+	}
+}
+
+// TestEngineResultAwareStreakIdempotentOnReadvance pins that re-advancing a
+// coordinator whose result-aware streak already tripped does not double-fire: the
+// once-guards (continuationEnqueued + the finalize guard) make a second
+// advanceDelegations a no-op, so the warning/finalize events and the corrective
+// continuation are emitted exactly once.
+func TestEngineResultAwareStreakIdempotentOnReadvance(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	noProgress := AgentResult{Decision: "approved", Summary: "stuck"}
+	perturbed := func(round int) ([]Delegation, map[string]AgentResult) {
+		id := fmt.Sprintf("w%d", round)
+		return []Delegation{{ID: id, Agent: "w", Action: "review", Prompt: fmt.Sprintf("attempt %d", round)}},
+			map[string]AgentResult{id: noProgress}
+	}
+
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result:    &AgentResult{Decision: "approved", Summary: "round 0", Delegations: []Delegation{{ID: "w0", Agent: "w", Action: "review", Prompt: "attempt 0"}}},
+	})
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "root-job/delegation/w0", JobSucceeded, noProgress)
+	if err := engine.AdvanceJob(ctx, "root-job/delegation/w0"); err != nil {
+		t.Fatalf("AdvanceJob(root child) returned error: %v", err)
+	}
+
+	// Drive to the first trip: generation 1 climbs the streak to 1, generation 2
+	// reaches the threshold and the warning + corrective continuation fire on the
+	// generation-2 continuation job (gen2Cont).
+	gen1Cont := delegationContinuationID("root-job")
+	dels1, res1 := perturbed(1)
+	gen2Cont := driveResultAwareGeneration(t, store, engine, gen1Cont, dels1, res1)
+	dels2, res2 := perturbed(2)
+	_ = driveResultAwareGeneration(t, store, engine, gen2Cont, dels2, res2)
+	if countJobEvents(t, store, gen2Cont, "delegation_loop_warning") != 1 {
+		t.Fatal("warning must fire exactly once on the first result-aware trip")
+	}
+
+	// Re-advance the tripped coordinator and its already-completed child several
+	// times: the once-guards must keep every count at exactly one.
+	for i := 0; i < 3; i++ {
+		if err := engine.AdvanceJob(ctx, gen2Cont); err != nil {
+			t.Fatalf("re-advance %d AdvanceJob(parent) returned error: %v", i, err)
+		}
+		if err := engine.AdvanceJob(ctx, gen2Cont+"/delegation/w2"); err != nil {
+			t.Fatalf("re-advance %d AdvanceJob(child) returned error: %v", i, err)
+		}
+	}
+	if got := countJobEvents(t, store, gen2Cont, "delegation_loop_warning"); got != 1 {
+		t.Fatalf("delegation_loop_warning fired %d times under re-advance, want 1", got)
+	}
+	if got := countJobEvents(t, store, gen2Cont, "delegation_continuation_enqueued"); got != 1 {
+		t.Fatalf("delegation_continuation_enqueued fired %d times under re-advance, want 1", got)
 	}
 }

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -53,6 +53,8 @@ type JobRequest struct {
 	DelegationReason       string
 	RecentDelegationHashes []string
 	DelegationRepeatCount  int
+	NonProgressStreak      int
+	LastProgressDigest     string
 	DelegationFinalize     bool
 	Model                  string
 	Phase                  string
@@ -98,6 +100,8 @@ type JobPayload struct {
 	DelegationReason       string         `json:"delegation_reason,omitempty"`
 	RecentDelegationHashes []string       `json:"recent_delegation_hashes,omitempty"`
 	DelegationRepeatCount  int            `json:"delegation_repeat_count,omitempty"`
+	NonProgressStreak      int            `json:"non_progress_streak,omitempty"`
+	LastProgressDigest     string         `json:"last_progress_digest,omitempty"`
 	DelegationFinalize     bool           `json:"delegation_finalize,omitempty"`
 	Model                  string         `json:"model,omitempty"`
 	Phase                  string         `json:"phase,omitempty"`
@@ -162,6 +166,8 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		DelegationReason:       request.DelegationReason,
 		RecentDelegationHashes: request.RecentDelegationHashes,
 		DelegationRepeatCount:  request.DelegationRepeatCount,
+		NonProgressStreak:      request.NonProgressStreak,
+		LastProgressDigest:     request.LastProgressDigest,
 		DelegationFinalize:     request.DelegationFinalize,
 		Model:                  request.Model,
 		Phase:                  request.Phase,

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -228,9 +228,19 @@ Delegation trees are bounded so they cannot run forever:
   may not fan out more than this many delegations in one generation; an over-wide
   set is refused with a `delegation_width_exceeded` event and routes through the
   finalize continuation.
-- Loop detection: a windowed signature over recent delegation activity halts
-  repeated or cyclic delegation chains (e.g. oscillating A→B→A) well before the
-  depth cap is reached.
+- Loop detection (two signals): a **structural** windowed signature over recent
+  delegation sets halts a coordinator re-issuing the same set (e.g. oscillating
+  A→B→A) well before the depth cap; a **result-aware non-progress streak** (#339)
+  additionally catches a coordinator that perturbs the set each round to dodge the
+  structural hash but whose children keep returning nothing new — it fingerprints
+  the children's verifiable side effects (`decision`, `changes_made`, `tests_run`,
+  PR/HeadSHA, `artifact_body`; self-reported summary/findings text is excluded) and
+  trips after `MaxDelegationNonProgressStreak` consecutive generations with no new
+  durable side effect (default `2`, configurable per-host via
+  `[orchestrate].max_delegation_non_progress_streak`). Any new durable side effect
+  resets the streak even if the summary repeats. Both share the same ladder
+  (`delegation_loop_warning` → corrective continuation → `delegation_loop_detected`
+  → finalize).
 - Operator kill switch: `gitmoot job kill <root-job-id>` terminates a runaway
   tree by its root id from outside. It is the **first** backstop (operator action
   wins over every budget cap) and is graceful — in-flight jobs finish, the

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -82,9 +82,20 @@ cannot recurse or fan out forever:
 - Per-coordinator width `MaxDelegationWidth = 16`: a single coordinator result
   may not fan out more than this many delegations in one generation; an over-wide
   set is refused with a `delegation_width_exceeded` event.
-- Loop detection: a canonical windowed signature hash over recent delegation
-  activity halts repeated or cyclic delegation chains well before the depth cap
-  is reached, preventing oscillating A→B→A loops.
+- Loop detection (two signals): a cheap **structural** signature hash over recent
+  delegation sets halts a coordinator that literally re-issues the same set,
+  preventing oscillating A→B→A loops well before the depth cap. Layered on top, a
+  **result-aware non-progress streak** (#339) catches a coordinator that perturbs
+  the set each round to evade the structural hash but whose children keep
+  returning nothing new: after every generation finishes, the engine fingerprints
+  the children's *verifiable* side effects (decision, `changes_made`, `tests_run`,
+  PR/HeadSHA, `artifact_body` — self-reported summary/findings text is excluded).
+  When that digest repeats for `MaxDelegationNonProgressStreak` consecutive
+  generations (default `2`, set per-host via
+  `[orchestrate].max_delegation_non_progress_streak`), the tree trips the same loop
+  ladder; any new durable side effect resets the streak even if the summary text
+  repeats. Both signals share one ladder: `delegation_loop_warning` + a corrective
+  continuation, then `delegation_loop_detected` + the graceful finalize below.
 - Operator kill switch: `gitmoot job kill <root-job-id>` lets an operator
   terminate a runaway tree by its root id from outside. It is the **first**
   backstop, so operator action wins over every budget cap. The kill is graceful,

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -310,9 +310,21 @@ trips, the offending delegations are dropped rather than dispatched.
   result may request at most this many delegations in one generation; a wider set
   is refused with a `delegation_width_exceeded` event and routed through the same
   graceful finalize continuation.
-- **Loop detection**: a canonical windowed signature over recent delegation
-  activity halts repeated or cyclic delegation chains — for example an
-  oscillating A→B→A loop — well before the depth cap is reached.
+- **Loop detection (two signals)**: a **structural** windowed signature over
+  recent delegation sets halts a coordinator that re-issues the same set — for
+  example an oscillating A→B→A loop — well before the depth cap is reached. A
+  **result-aware non-progress streak** (#339) layers on top to catch a coordinator
+  that perturbs the set each round to dodge the structural hash but whose children
+  keep returning nothing new: after every generation finishes, the engine
+  fingerprints the children's *verifiable* side effects (`decision`,
+  `changes_made`, `tests_run`, PR/HeadSHA, `artifact_body` — self-reported
+  summary/findings text is deliberately excluded) and trips the loop ladder once
+  that digest repeats for `MaxDelegationNonProgressStreak` consecutive generations
+  (default `2`, configurable per-host via
+  `[orchestrate].max_delegation_non_progress_streak`). Any new durable side effect
+  resets the streak even when the summary text repeats. Both signals share one
+  ladder: a `delegation_loop_warning` plus a corrective continuation, then
+  `delegation_loop_detected` plus the graceful finalize continuation.
 - **Operator kill switch**: `gitmoot job kill <root-job-id>` lets an operator
   terminate a runaway tree by its root id from outside. It is the **first**
   backstop, so operator action wins over every budget cap. The kill is graceful —


### PR DESCRIPTION
Closes #339.

Layers a **result-aware non-progress** detector on top of the existing **structural** loop fast-path (which is unchanged). A coordinator that fans out trivially-different work each round but whose children produce no new verifiable side effects now trips after a configurable number of generations instead of relying on the blunt depth cap.

## How it works
- `progressDigest(dels, childPayloads)` hashes each child's **verifiable side effects** — `Result.Decision`, `ChangesMade`, `TestsRun`, `payload.PullRequest`+`HeadSHA`, `Result.ArtifactBody` — and **excludes** self-reported `Summary`/`Findings` text. The per-child tuple is hashed without the delegation id and the tuples are sorted, so the digest is a **label-independent multiset** — a perturbed delegation set with the same (empty) results hashes identically, closing the evasion hole.
- New payload fields `NonProgressStreak` + `LastProgressDigest` (mirroring `DelegationRepeatCount`/`RecentDelegationHashes`), threaded through continuations. Unchanged digest ⇒ `streak++`; **any** new durable side effect ⇒ `streak` resets to 0 (even if summary text repeats).
- At `streak >= threshold` it trips the **same ladder** as the structural check (`delegation_loop_warning` → corrective continuation → `delegation_loop_detected` → graceful `enqueueFinalizeContinuation`), reusing the existing once-guards.
- Threshold default **2**, configurable per host via `[orchestrate].max_delegation_non_progress_streak` (0 = engine default).

## Decisions (from the issue's decided-spec comment)
Threshold 2 (configurable); progress = any new durable side effect; the optional LM progress-judge is deferred.

## Verification
- Gate green: `go build/vet/test ./...` + `go test -race ./internal/workflow/` (165s).
- Tests: digest label/text independence + changes-on-side-effect; perturbed-set-no-progress trips warning→corrective→detected→finalize; perturbed-set-with-real-side-effect never trips; idempotent once-guards on re-advance; config default + negative-validation cases. (Existing `TestEngineProgressingCoordinatorNotFalselyFlagged` updated — its old "progress = a different delegation set each round" was exactly the evasion case #339 targets, so it now lands a genuinely new side effect per round.)
- Adversarial review: **clean**.
- Live loop is impractical to stage (a real non-progressing tree), so validation is unit + `-race` + review, consistent with the issue's decided spec.

Docs updated in both trees (RESULT_CONTRACT/SAFETY + website twin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)