### PR TITLE
feat(workflow): escalate_human failure_policy — durable human-in-the-loop pause + /gitmoot resume (#340)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3500,12 +3500,21 @@ func (n *daemonEscalationNotifier) NotifyEscalation(ctx context.Context, request
 }
 
 // buildEscalationComment renders the @-tag escalation comment body (#340).
+//
+// The body must never begin a line with "@<handle>" or a bare "/gitmoot": the
+// daemon ingests comments on its own PRs, and ParseCommand treats a line whose
+// first token is "@<agent>" as a "@<agent> <action>" command — so a leading
+// "@<handle> Gitmoot paused…" would make the daemon post a spurious "unsupported
+// command action" ack on its own escalation notification. The human is mentioned
+// mid-line ("cc @<handle>"), which still notifies them on GitHub but is not
+// parsed as a command.
 func buildEscalationComment(handle string, request workflow.EscalationRequest) string {
 	var b strings.Builder
-	if strings.TrimSpace(handle) != "" {
-		b.WriteString("@" + strings.TrimPrefix(handle, "@") + " ")
+	b.WriteString("Gitmoot paused a delegation tree awaiting your decision (escalate_human).\n")
+	if h := strings.TrimPrefix(strings.TrimSpace(handle), "@"); h != "" {
+		b.WriteString("cc @" + h + "\n")
 	}
-	b.WriteString("Gitmoot paused a delegation tree awaiting your decision (escalate_human).\n\n")
+	b.WriteString("\n")
 	if d := strings.TrimSpace(request.DelegationID); d != "" {
 		b.WriteString(fmt.Sprintf("- failing leg: `%s`\n", d))
 	}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -219,12 +219,13 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		defaultJobWorker(store, stdout, *home).applyOrchestratePolicy(&engine)
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
 		return runSingleRepoSupervisor(ctx, *home, daemon.Daemon{
-			Repo:         repo,
-			PollInterval: *poll,
-			Store:        store,
-			GitHub:       gh,
-			Workflow:     &engine,
-			WatchIssues:  *watchIssues,
+			Repo:          repo,
+			PollInterval:  *poll,
+			Store:         store,
+			GitHub:        gh,
+			Workflow:      &engine,
+			WatchIssues:   *watchIssues,
+			EscalationTTL: resolveEscalationTTL(*home),
 		}, store, *workers, usePool, session, stdout)
 	})
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -1108,6 +1109,7 @@ type registeredRepoPoller struct {
 	Stdout          io.Writer
 	RecoveryOnly    bool
 	WatchIssues     bool
+	EscalationTTL   time.Duration
 	CheckoutLocks   *repoCheckoutLocks
 	GitHubClient    func(checkout string) github.Client
 	WorkflowFactory func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
@@ -1115,16 +1117,49 @@ type registeredRepoPoller struct {
 
 func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdout io.Writer, home string) registeredRepoPoller {
 	return registeredRepoPoller{
-		Store:        store,
-		Workers:      workers,
-		DryRun:       dryRun,
-		Stdout:       stdout,
-		GitHubClient: func(checkout string) github.Client { return github.NewClient(checkout) },
+		Store:         store,
+		Workers:       workers,
+		DryRun:        dryRun,
+		Stdout:        stdout,
+		EscalationTTL: resolveEscalationTTL(home),
+		GitHubClient:  func(checkout string) github.Client { return github.NewClient(checkout) },
 		WorkflowFactory: func(store *db.Store, gh github.Client, checkout string) *workflow.Engine {
 			engine := daemonWorkflowEngine(store, gh, checkout, home)
+			// Apply only the escalate_human notifier handle from policy (#340),
+			// keeping the budget/inlining knobs out of this path so its existing
+			// behavior is unchanged. The notifier itself is already wired by
+			// daemonWorkflowEngine; this just sets the configured @-handle.
+			if notifier, ok := engine.EscalationNotifier.(*daemonEscalationNotifier); ok && notifier != nil {
+				if policy, err := defaultJobWorker(store, stdout, home).orchestratePolicy(); err == nil {
+					notifier.Handle = policy.EscalationHandle
+				}
+			}
 			return &engine
 		},
 	}
+}
+
+// resolveEscalationTTL reads the [orchestrate].escalation_ttl policy (#340),
+// falling back to DefaultEscalationTTL when unset and to 0 (scan disabled) only
+// on a hard parse failure, so the auto-finalize backstop is on by default.
+func resolveEscalationTTL(home string) time.Duration {
+	policy := config.DefaultOrchestratePolicy()
+	if strings.TrimSpace(home) != "" {
+		if paths, err := initializedPaths(home); err == nil {
+			if loaded, err := config.LoadOrchestratePolicy(paths); err == nil {
+				policy = loaded
+			}
+		}
+	}
+	raw := strings.TrimSpace(policy.EscalationTTL)
+	if raw == "" {
+		raw = config.DefaultEscalationTTL
+	}
+	ttl, err := time.ParseDuration(raw)
+	if err != nil || ttl <= 0 {
+		return 0
+	}
+	return ttl
 }
 
 func pollRegisteredReposWithPoller(ctx context.Context, poller registeredRepoPoller, schedule registeredRepoSchedule, now time.Time, fallbackPoll time.Duration) (time.Duration, error) {
@@ -1200,11 +1235,12 @@ func (p registeredRepoPoller) pollRepo(ctx context.Context, repoRecord db.Repo, 
 		}
 	}
 	d := daemon.Daemon{
-		Repo:        repo,
-		Store:       store,
-		GitHub:      gh,
-		Workflow:    engine,
-		WatchIssues: p.WatchIssues,
+		Repo:          repo,
+		Store:         store,
+		GitHub:        gh,
+		Workflow:      engine,
+		WatchIssues:   p.WatchIssues,
+		EscalationTTL: p.EscalationTTL,
 	}
 	if recoveryOnly {
 		err = d.PollRecoveryCommandsOnce(ctx)
@@ -3260,6 +3296,10 @@ func (w jobWorker) advanceJob(ctx context.Context, job db.Job) error {
 	}
 	engine := w.WorkflowFactory(checkout)
 	if err := engine.AdvanceJob(ctx, job.ID); err != nil {
+		var awaiting workflow.AwaitingHumanError
+		if errors.As(err, &awaiting) {
+			return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_awaiting_human", Message: err.Error()})
+		}
 		var blocked workflow.BlockedError
 		if errors.As(err, &blocked) {
 			return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_blocked", Message: err.Error()})
@@ -3342,6 +3382,9 @@ func (w jobWorker) applyOrchestratePolicy(engine *workflow.Engine) {
 	engine.MaxInlineArtifactBytes = policy.InlineArtifactMaxBytes
 	engine.MaxDelegationTokenBudget = policy.MaxDelegationTokenBudget
 	engine.MaxDelegationCostUSD = policy.MaxDelegationCostUSD
+	if notifier, ok := engine.EscalationNotifier.(*daemonEscalationNotifier); ok && notifier != nil {
+		notifier.Handle = policy.EscalationHandle
+	}
 }
 
 // workflowHome resolves the GITMOOT_HOME root used to place per-delegation
@@ -3375,6 +3418,10 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		Store:                   store,
 		MergeGate:               daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout},
 		ImplementationFinalizer: daemonImplementationFinalizer{Store: store, GitHub: gh, FallbackCheckout: checkout},
+		// escalate_human (#340): @-tag the human on the tree's PR/issue when a leg
+		// pauses awaiting a decision. Best-effort and nil-safe in the engine; the
+		// handle is filled in from policy by applyOrchestratePolicy.
+		EscalationNotifier: &daemonEscalationNotifier{Store: store, GitHub: gh},
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},
@@ -3391,6 +3438,88 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		engine.DelegationWorktrees = gitutil.Client{Dir: checkout}
 	}
 	return engine
+}
+
+// daemonEscalationNotifier implements workflow.EscalationNotifier (#340): when a
+// delegation tree pauses awaiting a human, it @-tags that human in a GitHub
+// comment on the tree's PR (or the issue carrying the coordinator) with the
+// resume instructions. Best-effort: any lookup/post failure is returned to the
+// engine, which already treats notifier errors as non-fatal (the pause itself is
+// durable via the task state + recorded event + dashboard Attention).
+type daemonEscalationNotifier struct {
+	Store  *db.Store
+	GitHub github.Client
+	// Handle is the configured escalation_handle (a GitHub login without the @).
+	// Empty falls back to the PR author, then the repo owner.
+	Handle string
+}
+
+func (n *daemonEscalationNotifier) NotifyEscalation(ctx context.Context, request workflow.EscalationRequest) error {
+	if n == nil || n.Store == nil || n.GitHub == nil {
+		return nil
+	}
+	repoFull := strings.TrimSpace(request.Repo)
+	pull := request.PullRequest
+	owner := ""
+	// The engine seam leaves PR/repo best-effort; the coordinator job's payload is
+	// the source of truth for both, so load it when either is missing.
+	if repoFull == "" || pull <= 0 {
+		if job, err := n.Store.GetJob(ctx, request.CoordinatorJobID); err == nil {
+			if payload, perr := daemonJobPayload(job); perr == nil {
+				if repoFull == "" {
+					repoFull = strings.TrimSpace(payload.Repo)
+				}
+				if pull <= 0 {
+					pull = payload.PullRequest
+				}
+			}
+		}
+	}
+	if repoFull == "" || pull <= 0 {
+		// No issue/PR to post on; the durable pause (state + event + Attention)
+		// still stands. Nothing to notify.
+		return nil
+	}
+	repo, err := daemon.ParseRepository(repoFull)
+	if err != nil {
+		return err
+	}
+	owner = repo.Owner
+
+	// Default @-handle: the configured escalation_handle, else the repo owner (the
+	// human who owns the tree). The PullRequest type carries no author field, so
+	// the owner is the available, always-present human to tag.
+	handle := strings.TrimPrefix(strings.TrimSpace(n.Handle), "@")
+	if handle == "" {
+		handle = owner
+	}
+
+	body := buildEscalationComment(handle, request)
+	_, err = n.GitHub.PostIssueComment(ctx, repo, int64(pull), body)
+	return err
+}
+
+// buildEscalationComment renders the @-tag escalation comment body (#340).
+func buildEscalationComment(handle string, request workflow.EscalationRequest) string {
+	var b strings.Builder
+	if strings.TrimSpace(handle) != "" {
+		b.WriteString("@" + strings.TrimPrefix(handle, "@") + " ")
+	}
+	b.WriteString("Gitmoot paused a delegation tree awaiting your decision (escalate_human).\n\n")
+	if d := strings.TrimSpace(request.DelegationID); d != "" {
+		b.WriteString(fmt.Sprintf("- failing leg: `%s`\n", d))
+	}
+	if r := strings.TrimSpace(request.Reason); r != "" {
+		b.WriteString(fmt.Sprintf("- reason: %s\n", r))
+	}
+	if q := strings.TrimSpace(request.Question); q != "" {
+		b.WriteString(fmt.Sprintf("- question: %s\n", q))
+	}
+	b.WriteString("\nResume with one of:\n")
+	b.WriteString(fmt.Sprintf("- `/gitmoot resume %s retry <instructions>` — re-run the failing leg with your guidance\n", request.CoordinatorJobID))
+	b.WriteString(fmt.Sprintf("- `/gitmoot resume %s continue` — proceed the coordinator with what completed\n", request.CoordinatorJobID))
+	b.WriteString(fmt.Sprintf("- `/gitmoot resume %s abort` — stop and synthesize a best-effort final result\n", request.CoordinatorJobID))
+	return b.String()
 }
 
 type daemonImplementationFinalizer struct {
@@ -4000,6 +4129,14 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause er
 	}
 	payload, payloadErr := daemonJobPayload(latest)
 	if payloadErr == nil && payload.Result != nil {
+		var awaiting workflow.AwaitingHumanError
+		if errors.As(cause, &awaiting) {
+			// escalate_human (#340): the parent tree paused durably awaiting a human;
+			// the child delivered a result and the pause (task state + event +
+			// notification) is already recorded. Treat this as the expected terminal
+			// outcome, not a failure to propagate.
+			return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: latest.ID, Kind: "advance_awaiting_human", Message: cause.Error()})
+		}
 		var blocked workflow.BlockedError
 		if errors.As(cause, &blocked) {
 			return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: latest.ID, Kind: "advance_blocked", Message: cause.Error()})
@@ -4020,6 +4157,13 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause er
 		// recovery blindly re-queues it.
 		finalized, finalizeErr := w.finalizeTimedOutDelegationChild(ctx, latest, cause)
 		if finalizeErr != nil {
+			var awaiting workflow.AwaitingHumanError
+			if errors.As(finalizeErr, &awaiting) {
+				// escalate_human failure_policy paused the shared parent task awaiting
+				// a human (#340); the child is finalized and the DAG advanced, so this
+				// is the expected durable-pause outcome, not an error to propagate.
+				return nil
+			}
 			var blocked workflow.BlockedError
 			if errors.As(finalizeErr, &blocked) {
 				// block_parent failure_policy blocked the shared parent task; the

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -5693,3 +5693,45 @@ func TestResolveDaemonStartRepoBootstrapsUnregistered(t *testing.T) {
 		t.Fatal("expected origin mismatch error for unregistered repo from non-matching cwd")
 	}
 }
+
+// TestBuildEscalationCommentIsNotParsedAsCommand pins the #340 regression where
+// the escalation notification, posted by the daemon on its own PR, led a line
+// with "@<handle> Gitmoot paused…" and so was parsed by ParseCommand as a
+// "@<agent> <action=Gitmoot>" command — making the daemon reply with a spurious
+// "unsupported command action 'Gitmoot'" ack. The body must @-mention the human
+// (so GitHub still notifies) without any line that ParseCommand treats as a
+// command.
+func TestBuildEscalationCommentIsNotParsedAsCommand(t *testing.T) {
+	req := workflow.EscalationRequest{
+		CoordinatorJobID: "coord-123",
+		DelegationID:     "failing-leg",
+		Reason:           "child returned failed",
+		Question:         "how should we proceed?",
+	}
+	body := buildEscalationComment("jerryfane", req)
+
+	// The human is still mentioned (GitHub notification preserved)...
+	if !strings.Contains(body, "@jerryfane") {
+		t.Fatalf("escalation comment dropped the @-mention; body:\n%s", body)
+	}
+	// ...but never as the first token of a line (which ParseCommand would treat
+	// as a `@<agent> <action>` command), and no line starts with a bare /gitmoot.
+	for _, line := range strings.Split(body, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) == 0 {
+			continue
+		}
+		if strings.HasPrefix(fields[0], "@") {
+			t.Fatalf("escalation comment line starts with an @-mention (parses as a command): %q", line)
+		}
+		if fields[0] == "/gitmoot" {
+			t.Fatalf("escalation comment line starts with a bare /gitmoot (parses as a command): %q", line)
+		}
+	}
+
+	// And end-to-end: the daemon's own parser yields no command at all for the
+	// notification body, so the daemon never acks it as an (un)routable command.
+	if cmds := daemon.ParseCommands(body); len(cmds) != 0 {
+		t.Fatalf("escalation comment parsed into %d command(s); want 0: %+v\nbody:\n%s", len(cmds), cmds, body)
+	}
+}

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
 // dashboardListCap is how many entries each list shows in styled mode before
@@ -52,6 +53,9 @@ type dashboardSnapshot struct {
 	// jobRows carries per-job rows (and, for blocked/failed jobs, the latest
 	// event message) for the TUI's Jobs page. Unexported for the same reason.
 	jobRows []dashboardJobRow
+	// awaitingHuman carries the tasks paused at awaiting_human (#340) for the
+	// TUI's Attention page. Unexported so --json/--plain stay byte-stable.
+	awaitingHuman []dashboardAwaitingHuman
 	// daemonDetail carries the persisted daemon flags/workdir and a tail of
 	// recent log errors for the TUI's Health page. Unexported so --json and
 	// the plain renderer stay byte-stable.
@@ -75,6 +79,14 @@ type dashboardJobRow struct {
 	db.Job
 	LatestEvent string
 	Repo        string // parsed from the payload for reportable jobs (attention grouping)
+}
+
+// dashboardAwaitingHuman is one task paused at awaiting_human (#340), shown in the
+// TUI's Attention page with the resume hint.
+type dashboardAwaitingHuman struct {
+	TaskID string
+	Repo   string
+	Title  string
 }
 
 type dashboardResourceLock struct {
@@ -467,6 +479,9 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 		for _, task := range tasks {
 			if strings.TrimSpace(task.WorktreePath) != "" {
 				snapshot.Worktrees = append(snapshot.Worktrees, dashboardWorktree{Task: task.ID, Repo: task.RepoFullName, Path: task.WorktreePath})
+			}
+			if task.State == string(workflow.TaskAwaitingHuman) {
+				snapshot.awaitingHuman = append(snapshot.awaitingHuman, dashboardAwaitingHuman{TaskID: task.ID, Repo: task.RepoFullName, Title: task.Title})
 			}
 		}
 		locks, err := store.ListBranchLocks(ctx, "")

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -577,6 +577,9 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 		})
 		jobs = append(jobs, row.Job)
 	}
+	for _, t := range s.awaitingHuman {
+		out.AwaitingHuman = append(out.AwaitingHuman, tui.AwaitingHumanTask{TaskID: t.TaskID, Repo: t.Repo, Title: t.Title})
+	}
 	out.Activity = buildDashboardActivity(jobs)
 	return out
 }

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -260,6 +260,21 @@ func (m Model) attentionListRows() []listRow {
 		}
 	}
 
+	// Awaiting human (#340): trees paused for a human decision. Display-only (the
+	// resume verb lives on the tree's PR/issue or `gitmoot resume`), so these are
+	// static rows that do not consume the selectable itemIdx space.
+	if n := len(m.snap.AwaitingHuman); n > 0 {
+		rows = append(rows, staticRow(0, "Awaiting human ("+strconv.Itoa(n)+")"))
+		for _, t := range m.snap.AwaitingHuman {
+			line := attentionRepoLabel(t.Repo) + "  task " + t.TaskID
+			if strings.TrimSpace(t.Title) != "" {
+				line += "  " + mutedStyle.Render(truncate(t.Title, 40))
+			}
+			rows = append(rows, staticRow(1, line))
+			rows = append(rows, staticRow(2, mutedStyle.Render("resume: /gitmoot resume <jobID> retry|continue|abort")))
+		}
+	}
+
 	// Locks are display-only context (no actions), shown as static lines.
 	if stale := staleLocks(m.snap.ResourceLocks); len(stale) > 0 {
 		rows = append(rows, staticRow(0, "Stale locks ("+strconv.Itoa(len(stale))+")"))

--- a/internal/cli/tui/attention_test.go
+++ b/internal/cli/tui/attention_test.go
@@ -276,6 +276,28 @@ func TestAttentionLocksOnlyNoNeedsAttentionItems(t *testing.T) {
 	}
 }
 
+// TestAttentionShowsAwaitingHuman pins the #340 Attention surface: a tree paused
+// at awaiting_human renders under an "Awaiting human" section with the resume
+// hint, even when there are no actionable prompts/jobs.
+func TestAttentionShowsAwaitingHuman(t *testing.T) {
+	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
+	snap := Snapshot{
+		Daemon:        Daemon{Running: true},
+		AwaitingHuman: []AwaitingHumanTask{{TaskID: "task-5", Repo: "jerryfane/gitmoot", Title: "Parent"}},
+	}
+	m := attentionModel(t, deps, snap)
+	view := m.View()
+	if !strings.Contains(view, "Awaiting human (1)") {
+		t.Fatalf("expected Awaiting human (1) header:\n%s", view)
+	}
+	if !strings.Contains(view, "task-5") {
+		t.Fatalf("expected the paused task id:\n%s", view)
+	}
+	if !strings.Contains(view, "/gitmoot resume") {
+		t.Fatalf("expected the resume hint:\n%s", view)
+	}
+}
+
 func TestAttentionCursorClampedOnRefresh(t *testing.T) {
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	m := attentionModel(t, deps, promptSnap(choicePrompt(), textPrompt()))

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -30,8 +30,17 @@ type Snapshot struct {
 	ResourceLocks  []ResourceLock
 	Prompts        []db.InteractivePrompt
 	JobRows        []JobRow
+	AwaitingHuman  []AwaitingHumanTask
 	Activity       []ActivityRoot
 	Config         ConfigView
+}
+
+// AwaitingHumanTask is one delegation tree paused at awaiting_human (#340), shown
+// in the Attention page so an operator knows a `/gitmoot resume` is needed.
+type AwaitingHumanTask struct {
+	TaskID string
+	Repo   string
+	Title  string
 }
 
 // ActivityRoot is one live delegation tree on the Activity page: a root

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -53,5 +53,11 @@ cockpit_mode = "auto"
 cockpit_session = ""
 cockpit_max_panes = 4
 cockpit_pane_key = "job"
+# escalate_human failure_policy (#340): when a delegation pauses awaiting a human,
+# the daemon @-tags escalation_handle (default: the repo owner) in a comment with
+# the resume instructions. escalation_ttl auto-finalizes a never-answered pause
+# (Go duration; default 24h). Both optional.
+escalation_handle = ""
+escalation_ttl = ""
 `, paths.Database, paths.Logs, paths.Workspaces, paths.Evals, paths.ArtifactBlobs)
 }

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -50,7 +51,19 @@ type OrchestratePolicy struct {
 	// unlimited/off, so default behavior is unchanged. The daemon wires this into
 	// Engine.MaxDelegationCostUSD at startup.
 	MaxDelegationCostUSD float64
+	// EscalationHandle is the GitHub login the escalate_human notifier @-tags when
+	// a tree pauses awaiting a human (#340). Empty (the default) falls back to the
+	// PR author, then the repo owner, so a notification always names someone.
+	EscalationHandle string
+	// EscalationTTL is how long a tree may sit paused awaiting a human before the
+	// daemon's background scan auto-finalizes it (#340), as a Go duration string.
+	// Empty (the default) uses DefaultEscalationTTL (24h); the daemon parses it.
+	EscalationTTL string
 }
+
+// DefaultEscalationTTL is the fallback time a paused-for-human tree may sit
+// before the daemon auto-finalizes it gracefully (#340).
+const DefaultEscalationTTL = "24h"
 
 func DefaultOrchestratePolicy() OrchestratePolicy {
 	return OrchestratePolicy{
@@ -62,6 +75,8 @@ func DefaultOrchestratePolicy() OrchestratePolicy {
 		InlineArtifactMaxBytes:   0,
 		MaxDelegationTokenBudget: 0,
 		MaxDelegationCostUSD:     0,
+		EscalationHandle:         "",
+		EscalationTTL:            "",
 	}
 }
 
@@ -133,6 +148,14 @@ func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value st
 		parsed, err := strconv.ParseFloat(value, 64)
 		policy.MaxDelegationCostUSD = parsed
 		return err
+	case "escalation_handle":
+		parsed, err := parseConfigString(value)
+		policy.EscalationHandle = strings.TrimPrefix(strings.TrimSpace(parsed), "@")
+		return err
+	case "escalation_ttl":
+		parsed, err := parseConfigString(value)
+		policy.EscalationTTL = strings.TrimSpace(parsed)
+		return err
 	default:
 		return nil
 	}
@@ -157,6 +180,15 @@ func validateOrchestratePolicy(policy OrchestratePolicy) error {
 	}
 	if policy.MaxDelegationCostUSD < 0 {
 		return fmt.Errorf("orchestrate.max_delegation_cost_usd must be 0 (unlimited) or positive")
+	}
+	if ttl := strings.TrimSpace(policy.EscalationTTL); ttl != "" {
+		parsed, err := time.ParseDuration(ttl)
+		if err != nil {
+			return fmt.Errorf("orchestrate.escalation_ttl %q is invalid: %w", ttl, err)
+		}
+		if parsed <= 0 {
+			return fmt.Errorf("orchestrate.escalation_ttl must be positive")
+		}
 	}
 	return nil
 }

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -121,6 +121,59 @@ cockpit_mode = "auto"
 	}
 }
 
+// TestLoadOrchestratePolicyEscalationKeys pins #340: escalation_handle and
+// escalation_ttl parse from [orchestrate]; absent keys keep the empty defaults;
+// the handle drops a leading @; and a non-duration ttl is rejected.
+func TestLoadOrchestratePolicyEscalationKeys(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+escalation_handle = "@octocat"
+escalation_ttl = "36h"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.EscalationHandle != "octocat" {
+		t.Fatalf("EscalationHandle = %q, want octocat (leading @ stripped)", policy.EscalationHandle)
+	}
+	if policy.EscalationTTL != "36h" {
+		t.Fatalf("EscalationTTL = %q, want 36h", policy.EscalationTTL)
+	}
+
+	// Absent keys keep the empty defaults even with the section present.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+cockpit_mode = "auto"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err = LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.EscalationHandle != "" || policy.EscalationTTL != "" {
+		t.Fatalf("absent escalation keys should default empty, got handle=%q ttl=%q", policy.EscalationHandle, policy.EscalationTTL)
+	}
+
+	// A non-duration ttl is rejected.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+escalation_ttl = "soon"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadOrchestratePolicy(paths); err == nil {
+		t.Fatal("LoadOrchestratePolicy accepted an invalid escalation_ttl")
+	}
+}
+
 // TestLoadOrchestratePolicyInlineArtifactKeys pins #368: both inline-artifact keys
 // parse from [orchestrate], and absent keys default off.
 func TestLoadOrchestratePolicyInlineArtifactKeys(t *testing.T) {

--- a/internal/daemon/command.go
+++ b/internal/daemon/command.go
@@ -10,6 +10,9 @@ type Command struct {
 	Agent        string
 	JobID        string
 	Instructions string
+	// Decision is the resume verb (retry|continue|abort) for the `resume` action
+	// (#340); empty for every other action.
+	Decision string
 }
 
 func ParseCommands(body string) []Command {
@@ -53,6 +56,12 @@ func ParseCommand(line string) (Command, bool) {
 			return Command{}, false
 		}
 		return Command{Action: fields[1], JobID: fields[2], Instructions: trailing(fields, 3)}, true
+	case "resume":
+		// `/gitmoot resume <jobID> <retry|continue|abort> [instructions]` (#340).
+		if len(fields) < 4 {
+			return Command{}, false
+		}
+		return Command{Action: "resume", JobID: fields[2], Decision: strings.ToLower(fields[3]), Instructions: trailing(fields, 4)}, true
 	case "ask":
 		if len(fields) < 3 {
 			return Command{}, false
@@ -68,14 +77,21 @@ func ParseCommand(line string) (Command, bool) {
 
 func (c Command) Validate() error {
 	switch c.Action {
-	case "review", "implement", "ask", "status", "merge", "retry", "cancel", "help":
+	case "review", "implement", "ask", "status", "merge", "retry", "cancel", "help", "resume":
 	default:
 		return fmt.Errorf("unsupported command action %q", c.Action)
 	}
-	if (c.Action == "retry" || c.Action == "cancel") && c.JobID == "" {
+	if (c.Action == "retry" || c.Action == "cancel" || c.Action == "resume") && c.JobID == "" {
 		return fmt.Errorf("command %q requires a job id", c.Action)
 	}
-	if c.Action != "status" && c.Action != "merge" && c.Action != "retry" && c.Action != "cancel" && c.Action != "help" && c.Agent == "" {
+	if c.Action == "resume" {
+		switch c.Decision {
+		case "retry", "continue", "abort":
+		default:
+			return fmt.Errorf("command resume requires a decision of retry, continue, or abort")
+		}
+	}
+	if c.Action != "status" && c.Action != "merge" && c.Action != "retry" && c.Action != "cancel" && c.Action != "help" && c.Action != "resume" && c.Agent == "" {
 		return fmt.Errorf("command %q requires an agent", c.Action)
 	}
 	return nil

--- a/internal/daemon/command_test.go
+++ b/internal/daemon/command_test.go
@@ -115,3 +115,44 @@ func TestValidateRejectsUnsupportedCommand(t *testing.T) {
 		t.Fatal("Validate accepted unsupported action")
 	}
 }
+
+// TestParseCommandResume pins the #340 resume grammar:
+// `/gitmoot resume <jobID> <retry|continue|abort> [instructions]`.
+func TestParseCommandResume(t *testing.T) {
+	command, ok := ParseCommand("/gitmoot resume job-1 retry use the staging endpoint")
+	if !ok {
+		t.Fatal("ParseCommand did not parse resume command")
+	}
+	if command.Action != "resume" || command.JobID != "job-1" || command.Decision != "retry" || command.Instructions != "use the staging endpoint" {
+		t.Fatalf("command = %+v", command)
+	}
+
+	// Decision normalizes case; instructions are optional.
+	command, ok = ParseCommand("/gitmoot resume job-2 CONTINUE")
+	if !ok {
+		t.Fatal("ParseCommand did not parse resume continue command")
+	}
+	if command.Decision != "continue" || command.Instructions != "" {
+		t.Fatalf("command = %+v", command)
+	}
+
+	// Missing the decision verb is not a valid resume command.
+	if _, ok := ParseCommand("/gitmoot resume job-3"); ok {
+		t.Fatal("ParseCommand accepted resume without a decision")
+	}
+}
+
+func TestValidateResume(t *testing.T) {
+	if err := (Command{Action: "resume", JobID: "job-1", Decision: "retry"}).Validate(); err != nil {
+		t.Fatalf("Validate rejected a valid resume: %v", err)
+	}
+	if err := (Command{Action: "resume", Decision: "retry"}).Validate(); err == nil {
+		t.Fatal("Validate accepted resume without a job id")
+	}
+	if err := (Command{Action: "resume", JobID: "job-1", Decision: "bogus"}).Validate(); err == nil {
+		t.Fatal("Validate accepted resume with an invalid decision")
+	}
+	if err := (Command{Action: "resume", JobID: "job-1"}).Validate(); err == nil {
+		t.Fatal("Validate accepted resume without a decision")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -29,6 +29,10 @@ type Daemon struct {
 	// PollOnce also polls open non-PR issues and routes `@<agent> ask …`
 	// comments to jobs. Default false keeps the PR-only behavior unchanged.
 	WatchIssues bool
+	// EscalationTTL bounds how long a tree may sit paused awaiting a human before
+	// PollOnce auto-finalizes it gracefully (#340). 0 disables the scan, keeping
+	// behavior unchanged for trees that never use escalate_human.
+	EscalationTTL time.Duration
 }
 
 func (d Daemon) Run(ctx context.Context) error {
@@ -120,6 +124,14 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 	}
 	if d.WatchIssues {
 		if err := d.PollIssuesOnce(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	// escalate_human TTL scan (#340): auto-finalize trees that have sat paused
+	// awaiting a human past the configured TTL. No-op when the engine is unset or
+	// EscalationTTL is 0, so default behavior is unchanged.
+	if d.Workflow != nil && d.EscalationTTL > 0 {
+		if _, err := d.Workflow.AutoFinalizeExpiredEscalations(ctx, d.EscalationTTL); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -729,7 +741,7 @@ func (d Daemon) handleRecoveryComment(ctx context.Context, pull github.PullReque
 
 func onlyJobRecoveryCommands(commands []Command) bool {
 	for _, command := range commands {
-		if command.Action != "retry" && command.Action != "cancel" && command.Action != "help" {
+		if command.Action != "retry" && command.Action != "cancel" && command.Action != "help" && command.Action != "resume" {
 			return false
 		}
 	}
@@ -751,6 +763,8 @@ func (d Daemon) handleCommand(ctx context.Context, pull github.PullRequest, comm
 		return d.handleRetryCommand(ctx, pull, command)
 	case "cancel":
 		return d.handleCancelCommand(ctx, pull, command)
+	case "resume":
+		return d.handleResumeCommand(ctx, pull, command)
 	}
 
 	agent, err := d.Store.GetAgent(ctx, command.Agent)
@@ -825,6 +839,7 @@ func (d Daemon) handleHelpCommand(ctx context.Context, pull github.PullRequest) 
 		"- `/gitmoot status`",
 		"- `/gitmoot retry <job-id>`",
 		"- `/gitmoot cancel <job-id>`",
+		"- `/gitmoot resume <job-id> <retry|continue|abort> [instructions]`",
 		"- `/gitmoot merge`",
 	}
 	agents, err := d.Store.ListAgents(ctx)
@@ -876,6 +891,29 @@ func (d Daemon) handleCancelCommand(ctx context.Context, pull github.PullRequest
 		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not cancel job `%s`: %v.", command.JobID, err))
 	}
 	return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot cancelled job `%s`.", job.ID))
+}
+
+// handleResumeCommand resolves a tree paused at awaiting_human (#340) via
+// `/gitmoot resume <jobID> retry|continue|abort [instructions]`. It is
+// authorize-commenter gated by the caller (handleComment / handleRecoveryComment)
+// and job-scope gated here, exactly like retry/cancel. retry re-enqueues the
+// failed leg with the human's instructions; continue proceeds the coordinator
+// continuation; abort routes to the #305 graceful finalize.
+func (d Daemon) handleResumeCommand(ctx context.Context, pull github.PullRequest, command Command) error {
+	if d.Workflow == nil {
+		return d.ack(ctx, pull.Number, "Gitmoot cannot resume this tree because the workflow engine is not configured.")
+	}
+	if err := d.validateJobCommandScope(ctx, pull, command.JobID); err != nil {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not resume job `%s`: %v.", command.JobID, err))
+	}
+	decision, ok := workflow.ParseResumeDecision(command.Decision)
+	if !ok {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not resume job `%s`: decision must be retry, continue, or abort.", command.JobID))
+	}
+	if err := d.Workflow.ResolveEscalation(ctx, command.JobID, decision, command.Instructions); err != nil {
+		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot could not resume job `%s`: %v.", command.JobID, err))
+	}
+	return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot resumed job `%s` with `%s`.", command.JobID, decision))
 }
 
 func (d Daemon) validateJobCommandScope(ctx context.Context, pull github.PullRequest, jobID string) error {

--- a/internal/daemon/resume_test.go
+++ b/internal/daemon/resume_test.go
@@ -1,0 +1,251 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// resumeFixture seeds a coordinator whose single escalate_human delegation failed
+// and drives the engine to the durable awaiting_human pause, returning the engine
+// (wired into a Daemon) and the PR the coordinator belongs to. The coordinator id
+// is "coord" with PR #7.
+func resumeFixture(t *testing.T, store *db.Store) (*workflow.Engine, github.PullRequest) {
+	t.Helper()
+	ctx := context.Background()
+	repo := "jerryfane/gitmoot"
+	seedResumeAgent(t, store, "coord", []string{"ask"}, repo)
+	seedResumeAgent(t, store, "api", []string{"review"}, repo)
+
+	engine := &workflow.Engine{
+		Store: store,
+		JobID: func(request workflow.JobRequest) string { return request.ID },
+	}
+
+	coordPayload := workflow.JobPayload{
+		Repo:        repo,
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Parent",
+		Sender:      "coord",
+		Result: &workflow.AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []workflow.Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", FailurePolicy: "escalate_human"},
+			},
+		},
+	}
+	createResumeJob(t, store, db.Job{ID: "coord", Agent: "coord", Type: "ask"}, coordPayload)
+	if err := engine.AdvanceJob(ctx, "coord"); err != nil {
+		t.Fatalf("AdvanceJob(coord) returned error: %v", err)
+	}
+
+	// The dispatched child exists; mark it failed and advance to pause.
+	childID := "coord/delegation/api"
+	childPayload := workflow.JobPayload{
+		Repo:         repo,
+		Branch:       "task-7",
+		PullRequest:  7,
+		TaskID:       "task-7",
+		ParentJobID:  "coord",
+		DelegationID: "api",
+		RootJobID:    "coord",
+		Result:       &workflow.AgentResult{Decision: "failed", Summary: "api broke"},
+	}
+	setResumeJobResult(t, store, childID, childPayload)
+	if err := engine.AdvanceJob(ctx, childID); err == nil {
+		t.Fatal("AdvanceJob(child) should return AwaitingHumanError")
+	}
+
+	task, err := store.GetTask(ctx, "task-7")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskAwaitingHuman) {
+		t.Fatalf("task state = %q, want awaiting_human", task.State)
+	}
+
+	return engine, github.PullRequest{Number: 7, HeadRef: "task-7", HeadSHA: "abc"}
+}
+
+func seedResumeAgent(t *testing.T, store *db.Store, name string, caps []string, repo string) {
+	t.Helper()
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:           name,
+		Role:           "agent",
+		Runtime:        "shell",
+		RuntimeRef:     "printf ok",
+		RepoScope:      repo,
+		Capabilities:   caps,
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent(%s) returned error: %v", name, err)
+	}
+}
+
+func createResumeJob(t *testing.T, store *db.Store, job db.Job, payload workflow.JobPayload) {
+	t.Helper()
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	job.State = string(workflow.JobSucceeded)
+	job.Payload = string(encoded)
+	job.ParentJobID = payload.ParentJobID
+	job.DelegationID = payload.DelegationID
+	if err := store.CreateJobWithEvent(context.Background(), job, db.JobEvent{Kind: string(workflow.JobSucceeded), Message: "done"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(%s) returned error: %v", job.ID, err)
+	}
+}
+
+func setResumeJobResult(t *testing.T, store *db.Store, jobID string, payload workflow.JobPayload) {
+	t.Helper()
+	ctx := context.Background()
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.UpdateJobPayload(ctx, jobID, string(encoded)); err != nil {
+		t.Fatalf("UpdateJobPayload(%s) returned error: %v", jobID, err)
+	}
+	if err := store.UpdateJobState(ctx, jobID, string(workflow.JobFailed)); err != nil {
+		t.Fatalf("UpdateJobState(%s) returned error: %v", jobID, err)
+	}
+}
+
+func TestHandleResumeRetryReenqueuesLeg(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	engine, pull := resumeFixture(t, store)
+	client := &fakeGitHub{}
+	d := Daemon{Repo: github.Repository{Owner: "jerryfane", Name: "gitmoot"}, Store: store, GitHub: client, Workflow: engine}
+
+	if err := d.handleResumeCommand(ctx, pull, Command{Action: "resume", JobID: "coord", Decision: "retry", Instructions: "use staging"}); err != nil {
+		t.Fatalf("handleResumeCommand(retry) returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "coord/delegation/api/resume"); err != nil {
+		t.Fatalf("retry must re-enqueue the failing leg: %v", err)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "resumed job `coord` with `retry`") {
+		t.Fatalf("ack = %+v", client.posted)
+	}
+}
+
+func TestHandleResumeContinueEnqueuesContinuation(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	engine, pull := resumeFixture(t, store)
+	client := &fakeGitHub{}
+	d := Daemon{Repo: github.Repository{Owner: "jerryfane", Name: "gitmoot"}, Store: store, GitHub: client, Workflow: engine}
+
+	if err := d.handleResumeCommand(ctx, pull, Command{Action: "resume", JobID: "coord", Decision: "continue"}); err != nil {
+		t.Fatalf("handleResumeCommand(continue) returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "coord/continuation"); err != nil {
+		t.Fatalf("continue must enqueue the coordinator continuation: %v", err)
+	}
+}
+
+func TestHandleResumeAbortFinalizes(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	engine, pull := resumeFixture(t, store)
+	client := &fakeGitHub{}
+	d := Daemon{Repo: github.Repository{Owner: "jerryfane", Name: "gitmoot"}, Store: store, GitHub: client, Workflow: engine}
+
+	if err := d.handleResumeCommand(ctx, pull, Command{Action: "resume", JobID: "coord", Decision: "abort"}); err != nil {
+		t.Fatalf("handleResumeCommand(abort) returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "coord/continuation")
+	if err != nil {
+		t.Fatalf("abort must enqueue a finalize continuation: %v", err)
+	}
+	var payload workflow.JobPayload
+	if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
+		t.Fatalf("unmarshal continuation payload: %v", err)
+	}
+	if !payload.DelegationFinalize {
+		t.Fatalf("abort continuation must carry DelegationFinalize: %+v", payload)
+	}
+}
+
+func TestHandleResumeRejectsOutOfScopeJob(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	engine, _ := resumeFixture(t, store)
+	client := &fakeGitHub{}
+	d := Daemon{Repo: github.Repository{Owner: "jerryfane", Name: "gitmoot"}, Store: store, GitHub: client, Workflow: engine}
+
+	// A PR that does not own the coordinator job (#999) must be rejected without
+	// re-enqueueing anything.
+	otherPull := github.PullRequest{Number: 999, HeadRef: "other"}
+	if err := d.handleResumeCommand(ctx, otherPull, Command{Action: "resume", JobID: "coord", Decision: "retry"}); err != nil {
+		t.Fatalf("handleResumeCommand returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "coord/delegation/api/resume"); err == nil {
+		t.Fatal("an out-of-scope resume must not re-enqueue the leg")
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "could not resume") {
+		t.Fatalf("expected a scope-rejection ack, got %+v", client.posted)
+	}
+}
+
+// TestPollOnceResumeIsAuthorizeGated proves the resume verb runs through the same
+// authorize-commenter gate as retry/cancel: an unauthorized commenter's resume is
+// ignored and never re-enqueues the failing leg.
+func TestPollOnceResumeIsAuthorizeGated(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	engine, _ := resumeFixture(t, store)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	client := &fakeGitHub{
+		permissions: map[string]string{"mallory": "read"},
+		pulls:       []github.PullRequest{{Number: 7, Title: "Task 7", State: "open", HeadRef: "task-7", BaseRef: "main", HeadSHA: "abc"}},
+		comments: map[int64][]github.IssueComment{
+			7: {{ID: 707, Body: "/gitmoot resume coord retry", Author: "mallory"}},
+		},
+	}
+	d := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: engine}
+	pull := github.PullRequest{Number: 7, HeadRef: "task-7", HeadSHA: "abc"}
+	comment := github.IssueComment{ID: 707, Body: "/gitmoot resume coord retry", Author: "mallory"}
+	if err := d.handleComment(ctx, pull, comment); err != nil {
+		t.Fatalf("handleComment returned error: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "coord/delegation/api/resume"); err == nil {
+		t.Fatal("an unauthorized resume must not re-enqueue the failing leg")
+	}
+	if _, err := store.GetJob(ctx, "coord/continuation"); err == nil {
+		t.Fatal("an unauthorized resume must not enqueue a continuation")
+	}
+	found := false
+	for _, p := range client.posted {
+		if strings.Contains(p.body, "ignored comment 707") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an authorize-rejection ack, got %+v", client.posted)
+	}
+}
+
+func TestHandleResumeRequiresWorkflowEngine(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	client := &fakeGitHub{}
+	d := Daemon{Repo: github.Repository{Owner: "jerryfane", Name: "gitmoot"}, Store: store, GitHub: client}
+	pull := github.PullRequest{Number: 7, HeadRef: "task-7"}
+	if err := d.handleResumeCommand(ctx, pull, Command{Action: "resume", JobID: "coord", Decision: "retry"}); err != nil {
+		t.Fatalf("handleResumeCommand returned error: %v", err)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "workflow engine is not configured") {
+		t.Fatalf("expected a not-configured ack, got %+v", client.posted)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -3092,10 +3092,13 @@ func (e Engine) reviewApprovalAlreadyAdvanced(ctx context.Context, ref taskRef) 
 	return task.State == string(TaskReadyToMerge) || task.State == string(TaskMerged), nil
 }
 
-// Escalation event kinds (#340). The requested event is the one-shot pause
-// marker (idempotent: a second escalate_human pass observing it re-notifies
-// nothing and re-records nothing); the resolved event is recorded by the resume
-// path when an operator answers.
+// Escalation event kinds (#340). Escalation is round-based: a coordinator/leg can
+// pause more than once over its lifetime (a retried leg that fails again opens a
+// NEW round). The pause is OPEN while requested > resolved, and CLOSED (resolved
+// or finalizable) while requested == resolved. So a second escalate_human pass
+// during an OPEN round re-notifies nothing and re-records nothing (idempotent),
+// but the first failure of a round whose every prior escalation was resolved
+// opens a fresh round: a new requested event, a re-notify, and a re-pause.
 const (
 	escalationRequestedEvent = "delegation_escalation_requested"
 	escalationResolvedEvent  = "delegation_escalation_resolved"
@@ -3115,9 +3118,10 @@ type EscalationRecord struct {
 }
 
 // pauseAwaitingHuman is the escalate_human analogue of block (#340): it sets the
-// shared parent task to TaskAwaitingHuman, records a one-shot
-// delegation_escalation_requested event (idempotent via the ListJobEvents
-// once-guard), notifies the human best-effort through the injected
+// shared parent task to TaskAwaitingHuman, records a per-round
+// delegation_escalation_requested event (idempotent WITHIN an open round via the
+// requested>resolved guard, but a retried leg that fails again opens a fresh
+// round and re-pauses), notifies the human best-effort through the injected
 // EscalationNotifier, and returns an AwaitingHumanError so the caller enqueues NO
 // continuation. The tree therefore consumes zero compute until an operator
 // resumes it with `/gitmoot resume <coordinator> retry|continue|abort`.
@@ -3125,18 +3129,20 @@ func (e Engine) pauseAwaitingHuman(ctx context.Context, parentJob db.Job, parent
 	reason := childFailureReason(child)
 	awaitErr := AwaitingHumanError{Reason: fmt.Sprintf("delegation %q failed (failure_policy escalate_human): %s", d.ID, reason)}
 
-	// Once the pause marker exists, this is an idempotent re-advance (a concurrent
-	// child completion, or the same child's AdvanceJob re-running): keep the task
-	// in awaiting_human and return the same pause error, but re-record nothing and
-	// re-notify nobody.
-	events, err := e.Store.ListJobEvents(ctx, parentJob.ID)
+	// While an escalation round is OPEN (requested > resolved), this is an
+	// idempotent re-advance (a concurrent child completion, or the same child's
+	// AdvanceJob re-running): keep the task in awaiting_human and return the same
+	// pause error, but re-record nothing and re-notify nobody. When the round is
+	// CLOSED (requested == resolved: a prior escalation was resolved, e.g. a retry
+	// that has now failed AGAIN) we fall through to open a FRESH round below — a
+	// new requested event, a re-pause, and a re-notify — so the tree never strands
+	// permanently in planned with nothing in flight (#340).
+	open, err := e.escalationOpen(ctx, parentJob.ID)
 	if err != nil {
 		return err
 	}
-	for _, ev := range events {
-		if ev.Kind == escalationRequestedEvent {
-			return awaitErr
-		}
+	if open {
+		return awaitErr
 	}
 
 	if err := e.setTaskState(ctx, ref, TaskAwaitingHuman); err != nil {
@@ -3220,20 +3226,52 @@ func (e Engine) loadEscalation(ctx context.Context, coordinatorJobID string) (Es
 	return rec, true, nil
 }
 
-// escalationResolved reports whether a paused coordinator already had its
-// escalation resolved (a resume verb ran). The resume path is authorize-gated
-// and idempotency-guarded by this check.
-func (e Engine) escalationResolved(ctx context.Context, coordinatorJobID string) (bool, error) {
+// escalationRoundCounts returns how many escalation rounds were requested vs
+// resolved for a coordinator (#340). Escalation is round-based: a retried leg
+// that fails again opens a fresh round, so a coordinator can accumulate several
+// requested/resolved pairs over its lifetime. The pause is OPEN (resolvable /
+// finalizable) while requested > resolved, and CLOSED while requested ==
+// resolved.
+func (e Engine) escalationRoundCounts(ctx context.Context, coordinatorJobID string) (requested, resolved int, err error) {
 	events, err := e.Store.ListJobEvents(ctx, coordinatorJobID)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, ev := range events {
+		switch ev.Kind {
+		case escalationRequestedEvent:
+			requested++
+		case escalationResolvedEvent:
+			resolved++
+		}
+	}
+	return requested, resolved, nil
+}
+
+// escalationOpen reports whether a coordinator currently has an UNRESOLVED
+// escalation round (requested > resolved): the tree is paused awaiting a human
+// right now. When false, either no escalation ever opened, or every round that
+// opened has been resolved (the leg may then fail AGAIN to open a new round).
+func (e Engine) escalationOpen(ctx context.Context, coordinatorJobID string) (bool, error) {
+	requested, resolved, err := e.escalationRoundCounts(ctx, coordinatorJobID)
 	if err != nil {
 		return false, err
 	}
-	for _, ev := range events {
-		if ev.Kind == escalationResolvedEvent {
-			return true, nil
-		}
+	return requested > resolved, nil
+}
+
+// escalationResolved reports whether the coordinator has no OPEN escalation round
+// to act on — i.e. every requested escalation has been resolved (requested ==
+// resolved). The resume path and the TTL backstop are idempotency-guarded by
+// this check: an OPEN round (requested > resolved) is resolvable/finalizable, a
+// CLOSED one is a no-op. Round-based so a re-pause after a failed retry is again
+// resolvable, never permanently stranded (#340).
+func (e Engine) escalationResolved(ctx context.Context, coordinatorJobID string) (bool, error) {
+	open, err := e.escalationOpen(ctx, coordinatorJobID)
+	if err != nil {
+		return false, err
 	}
-	return false, nil
+	return !open, nil
 }
 
 // ResumeDecision is one of the three human resume verbs for a paused tree (#340).

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -24,6 +25,14 @@ type Engine struct {
 	JobID                   func(JobRequest) string
 	PayloadRefresher        func(context.Context, db.Job, JobPayload) (JobPayload, error)
 	ImplementationFinalizer ImplementationFinalizer
+	// EscalationNotifier is the injected, best-effort seam (mirroring
+	// ImplementationFinalizer) the engine calls when a delegation fails under the
+	// escalate_human failure_policy and the tree pauses awaiting a human (#340).
+	// The daemon implements it to @-tag the human in a PR/issue comment with the
+	// resume instructions. It is optional: when nil the pause still happens (the
+	// dashboard "Attention" section and the recorded event remain), only the
+	// GitHub notification is skipped. A notifier error never fails the pause.
+	EscalationNotifier EscalationNotifier
 	// Home is the resolved GITMOOT_HOME root used to place per-delegation
 	// worktrees. DelegationWorktrees is the checkout-bound git client that
 	// performs the worktree-add. Both are optional: when either is unset, the
@@ -137,12 +146,58 @@ type ImplementationFinalizer interface {
 	FinalizeImplementation(ctx context.Context, job db.Job, payload JobPayload) (JobPayload, error)
 }
 
+// EscalationRequest carries the context the EscalationNotifier needs to notify a
+// human that a delegation tree has paused awaiting their decision (#340).
+type EscalationRequest struct {
+	// CoordinatorJobID is the paused coordinator job; the human resumes the tree
+	// with `/gitmoot resume <CoordinatorJobID> retry|continue|abort`.
+	CoordinatorJobID string
+	// DelegationID is the failing leg that triggered the escalation.
+	DelegationID string
+	// ChildJobID is the failed child job id for that leg (best-effort; may be
+	// empty if the child could not be resolved).
+	ChildJobID string
+	// Reason is the child's failure summary (why the leg failed).
+	Reason string
+	// Question is the human-facing escalation question (the delegation's prompt),
+	// so the notification can quote what is being asked of the human.
+	Question string
+	// Repo/PullRequest/Branch/TaskID/TaskTitle locate the tree's PR or issue so
+	// the notifier can post the @-tag comment in the right place.
+	Repo        string
+	PullRequest int
+	Branch      string
+	TaskID      string
+	TaskTitle   string
+}
+
+// EscalationNotifier is the injected seam the engine calls (best-effort) when a
+// tree pauses awaiting a human (#340). The daemon implements it to post a GitHub
+// comment that @-tags the human with the resume instructions.
+type EscalationNotifier interface {
+	NotifyEscalation(ctx context.Context, request EscalationRequest) error
+}
+
 type BlockedError struct {
 	Reason string
 }
 
 func (e BlockedError) Error() string {
 	return "workflow blocked: " + e.Reason
+}
+
+// AwaitingHumanError is returned by pauseAwaitingHuman when a delegation fails
+// under the escalate_human failure_policy (#340). It is distinct from
+// BlockedError so the engine and daemon can tell a durable human-in-the-loop
+// pause (resumable via `/gitmoot resume`) apart from a terminal block. Like
+// BlockedError it propagates up through AdvanceJob as an AdvanceError, so the
+// agent's already-delivered result is preserved while the tree waits.
+type AwaitingHumanError struct {
+	Reason string
+}
+
+func (e AwaitingHumanError) Error() string {
+	return "workflow awaiting human: " + e.Reason
 }
 
 // AdvanceError wraps an error that occurred while advancing a job *after* the
@@ -602,8 +657,11 @@ func (e Engine) rootJobID(job db.Job, payload JobPayload) string {
 
 // rootWallClockExceeded reports whether the coordination tree rooted at rootID has
 // been running longer than MaxDelegationWallClock, measured from the root job's
-// created_at, and the elapsed duration. It fails open: any lookup/parse problem
-// returns (false, 0) so a clock or timestamp hiccup never blocks dispatch.
+// created_at MINUS any time the tree spent paused awaiting a human (#340), and the
+// adjusted elapsed duration. Excluding paused time means a tree a human took hours
+// to answer is not punished as a runaway: only active wall-clock counts. It fails
+// open: any lookup/parse problem returns (false, 0) so a clock or timestamp hiccup
+// never blocks dispatch.
 func (e Engine) rootWallClockExceeded(ctx context.Context, rootID string) (bool, time.Duration) {
 	createdAt, err := e.Store.JobCreatedAt(ctx, rootID)
 	if err != nil {
@@ -613,8 +671,85 @@ func (e Engine) rootWallClockExceeded(ctx context.Context, rootID string) (bool,
 	if err != nil {
 		return false, 0
 	}
-	elapsed := e.now().UTC().Sub(start)
+	now := e.now().UTC()
+	elapsed := now.Sub(start) - e.rootPausedDuration(ctx, rootID, now)
+	if elapsed < 0 {
+		elapsed = 0
+	}
 	return elapsed > MaxDelegationWallClock, elapsed
+}
+
+// rootPausedDuration sums the wall-clock time the coordination tree rooted at
+// rootID spent paused awaiting a human across every job in the tree (#340). For
+// each job that recorded a delegation_escalation_requested event, the pause runs
+// from its paused_at until the matching delegation_escalation_resolved event's
+// resolved_at (or until now if still paused). It fails open: any lookup/parse
+// hiccup contributes 0 to the sum, so the wall-clock backstop never blocks
+// dispatch on a bad timestamp. A tree with no escalation contributes 0, keeping
+// default behavior byte-identical.
+func (e Engine) rootPausedDuration(ctx context.Context, rootID string, now time.Time) time.Duration {
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return 0
+	}
+	var total time.Duration
+	for _, job := range jobs {
+		inTree := job.ID == rootID
+		if !inTree {
+			payload, err := unmarshalPayload(job.Payload)
+			if err != nil {
+				continue
+			}
+			inTree = payload.RootJobID == rootID
+		}
+		if !inTree {
+			continue
+		}
+		total += e.jobPausedDuration(ctx, job.ID, now)
+	}
+	return total
+}
+
+// jobPausedDuration returns how long a single coordinator job spent (or has been)
+// paused awaiting a human, derived from its escalation events. A job with no
+// escalation contributes 0.
+func (e Engine) jobPausedDuration(ctx context.Context, jobID string, now time.Time) time.Duration {
+	events, err := e.Store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return 0
+	}
+	var pausedAt, resolvedAt time.Time
+	havePaused, haveResolved := false, false
+	for _, ev := range events {
+		switch ev.Kind {
+		case escalationRequestedEvent:
+			var rec EscalationRecord
+			if json.Unmarshal([]byte(ev.Message), &rec) == nil && strings.TrimSpace(rec.PausedAt) != "" {
+				if t, err := parseJobTimestamp(rec.PausedAt); err == nil {
+					pausedAt, havePaused = t, true
+				}
+			}
+		case escalationResolvedEvent:
+			var rec EscalationRecord
+			if json.Unmarshal([]byte(ev.Message), &rec) == nil && strings.TrimSpace(rec.PausedAt) != "" {
+				// Resolved events reuse the PausedAt field to carry resolved_at.
+				if t, err := parseJobTimestamp(rec.PausedAt); err == nil {
+					resolvedAt, haveResolved = t, true
+				}
+			}
+		}
+	}
+	if !havePaused {
+		return 0
+	}
+	end := now
+	if haveResolved {
+		end = resolvedAt
+	}
+	if dur := end.Sub(pausedAt); dur > 0 {
+		return dur
+	}
+	return 0
 }
 
 // parseJobTimestamp parses a jobs.created_at value. SQLite's CURRENT_TIMESTAMP
@@ -1577,6 +1712,18 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 			continue
 		case "escalate":
 			escalate = true
+		case "escalate_human":
+			// Durable human-in-the-loop pause (#340): set TaskAwaitingHuman,
+			// record the one-shot escalation event, notify the human best-effort,
+			// and return an AwaitingHumanError so NO continuation is enqueued and
+			// the tree consumes zero compute until an operator resumes it. As with
+			// block_parent, once a continuation is already in flight (an earlier
+			// escalate sibling fired it) the tree is already proceeding
+			// autonomously, so fold this leg in rather than contradict it.
+			if continuationAlreadyEnqueued {
+				continue
+			}
+			return e.pauseAwaitingHuman(ctx, parentJob, parentPayload, ref, d, child)
 		default: // block_parent (also the empty default)
 			if continuationAlreadyEnqueued {
 				continue
@@ -2000,8 +2147,10 @@ func delegationFailurePolicy(d Delegation) string {
 }
 
 // delegationFailureHandledByPolicy reports whether the named delegation declares
-// a continue/escalate failure_policy, meaning a failure of its child is governed
-// by the delegation graph rather than blocking the shared parent task.
+// a continue/escalate/escalate_human failure_policy, meaning a failure of its
+// child is governed by the delegation graph (siblings keep running, the
+// coordinator continuation absorbs it, or the tree pauses awaiting a human)
+// rather than blocking the shared parent task.
 func delegationFailureHandledByPolicy(parentResult *AgentResult, delegationID string) bool {
 	if parentResult == nil || strings.TrimSpace(delegationID) == "" {
 		return false
@@ -2011,7 +2160,7 @@ func delegationFailureHandledByPolicy(parentResult *AgentResult, delegationID st
 			continue
 		}
 		switch delegationFailurePolicy(d) {
-		case "continue", "escalate":
+		case "continue", "escalate", "escalate_human":
 			return true
 		default:
 			return false
@@ -2941,6 +3090,400 @@ func (e Engine) reviewApprovalAlreadyAdvanced(ctx context.Context, ref taskRef) 
 		return false, err
 	}
 	return task.State == string(TaskReadyToMerge) || task.State == string(TaskMerged), nil
+}
+
+// Escalation event kinds (#340). The requested event is the one-shot pause
+// marker (idempotent: a second escalate_human pass observing it re-notifies
+// nothing and re-records nothing); the resolved event is recorded by the resume
+// path when an operator answers.
+const (
+	escalationRequestedEvent = "delegation_escalation_requested"
+	escalationResolvedEvent  = "delegation_escalation_resolved"
+)
+
+// EscalationRecord is the structured payload stored in a
+// delegation_escalation_requested event message, so the resume path can resolve
+// the failing leg and child job, and the wall-clock backstop can exclude the
+// paused duration. It is JSON-encoded into the event message (job_events has no
+// dedicated columns); PausedAt is RFC3339-UTC.
+type EscalationRecord struct {
+	DelegationID string `json:"delegation_id"`
+	ChildJobID   string `json:"child_job_id,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+	Question     string `json:"question,omitempty"`
+	PausedAt     string `json:"paused_at,omitempty"`
+}
+
+// pauseAwaitingHuman is the escalate_human analogue of block (#340): it sets the
+// shared parent task to TaskAwaitingHuman, records a one-shot
+// delegation_escalation_requested event (idempotent via the ListJobEvents
+// once-guard), notifies the human best-effort through the injected
+// EscalationNotifier, and returns an AwaitingHumanError so the caller enqueues NO
+// continuation. The tree therefore consumes zero compute until an operator
+// resumes it with `/gitmoot resume <coordinator> retry|continue|abort`.
+func (e Engine) pauseAwaitingHuman(ctx context.Context, parentJob db.Job, parentPayload JobPayload, ref taskRef, d Delegation, child db.Job) error {
+	reason := childFailureReason(child)
+	awaitErr := AwaitingHumanError{Reason: fmt.Sprintf("delegation %q failed (failure_policy escalate_human): %s", d.ID, reason)}
+
+	// Once the pause marker exists, this is an idempotent re-advance (a concurrent
+	// child completion, or the same child's AdvanceJob re-running): keep the task
+	// in awaiting_human and return the same pause error, but re-record nothing and
+	// re-notify nobody.
+	events, err := e.Store.ListJobEvents(ctx, parentJob.ID)
+	if err != nil {
+		return err
+	}
+	for _, ev := range events {
+		if ev.Kind == escalationRequestedEvent {
+			return awaitErr
+		}
+	}
+
+	if err := e.setTaskState(ctx, ref, TaskAwaitingHuman); err != nil {
+		return err
+	}
+
+	record := EscalationRecord{
+		DelegationID: d.ID,
+		ChildJobID:   child.ID,
+		Reason:       reason,
+		Question:     strings.TrimSpace(d.Prompt),
+		PausedAt:     e.now().UTC().Format(time.RFC3339),
+	}
+	encoded, marshalErr := json.Marshal(record)
+	message := awaitErr.Reason
+	if marshalErr == nil {
+		message = string(encoded)
+	}
+	if err := e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   parentJob.ID,
+		Kind:    escalationRequestedEvent,
+		Message: message,
+	}); err != nil {
+		return err
+	}
+
+	// Notify the human best-effort: a nil notifier (ask-path/tests) or a notifier
+	// error never fails the pause — the dashboard "Attention" section and the
+	// recorded event are the durable source of truth; the comment is a courtesy.
+	if e.EscalationNotifier != nil {
+		_ = e.EscalationNotifier.NotifyEscalation(ctx, EscalationRequest{
+			CoordinatorJobID: parentJob.ID,
+			DelegationID:     d.ID,
+			ChildJobID:       child.ID,
+			Reason:           reason,
+			Question:         strings.TrimSpace(d.Prompt),
+			Repo:             firstNonEmptyString(ref.Repo, parentPayload.Repo),
+			PullRequest:      parentPayload.PullRequest,
+			Branch:           firstNonEmptyString(ref.Branch, parentPayload.Branch),
+			TaskID:           ref.ID,
+			TaskTitle:        ref.Title,
+		})
+	}
+
+	return awaitErr
+}
+
+// firstNonEmptyString returns the first non-blank value, or "".
+func firstNonEmptyString(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// loadEscalation returns the structured escalation record recorded on a paused
+// coordinator job, and whether one exists. It tolerates a legacy/plain-text
+// message (pre-JSON) by returning a record with only the raw reason, so a resume
+// still routes.
+func (e Engine) loadEscalation(ctx context.Context, coordinatorJobID string) (EscalationRecord, bool, error) {
+	events, err := e.Store.ListJobEvents(ctx, coordinatorJobID)
+	if err != nil {
+		return EscalationRecord{}, false, err
+	}
+	var rec EscalationRecord
+	found := false
+	for _, ev := range events {
+		if ev.Kind != escalationRequestedEvent {
+			continue
+		}
+		found = true
+		if json.Unmarshal([]byte(ev.Message), &rec) != nil {
+			rec = EscalationRecord{Reason: ev.Message}
+		}
+	}
+	if !found {
+		return EscalationRecord{}, false, nil
+	}
+	return rec, true, nil
+}
+
+// escalationResolved reports whether a paused coordinator already had its
+// escalation resolved (a resume verb ran). The resume path is authorize-gated
+// and idempotency-guarded by this check.
+func (e Engine) escalationResolved(ctx context.Context, coordinatorJobID string) (bool, error) {
+	events, err := e.Store.ListJobEvents(ctx, coordinatorJobID)
+	if err != nil {
+		return false, err
+	}
+	for _, ev := range events {
+		if ev.Kind == escalationResolvedEvent {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ResumeDecision is one of the three human resume verbs for a paused tree (#340).
+type ResumeDecision string
+
+const (
+	// ResumeRetry re-enqueues the failing delegation leg with the human's
+	// instructions folded into its prompt.
+	ResumeRetry ResumeDecision = "retry"
+	// ResumeContinue proceeds the coordinator continuation (today's escalate path,
+	// now human-approved): the coordinator synthesizes every child outcome.
+	ResumeContinue ResumeDecision = "continue"
+	// ResumeAbort routes to the #305 graceful finalize continuation for a terminal
+	// best-effort synthesis of whatever completed.
+	ResumeAbort ResumeDecision = "abort"
+)
+
+// validResumeDecision normalizes and validates a resume verb.
+func validResumeDecision(decision string) (ResumeDecision, bool) {
+	switch ResumeDecision(strings.ToLower(strings.TrimSpace(decision))) {
+	case ResumeRetry:
+		return ResumeRetry, true
+	case ResumeContinue:
+		return ResumeContinue, true
+	case ResumeAbort:
+		return ResumeAbort, true
+	default:
+		return "", false
+	}
+}
+
+// ParseResumeDecision is the exported normalizer the daemon uses to validate the
+// human's resume verb before calling ResolveEscalation (#340).
+func ParseResumeDecision(decision string) (ResumeDecision, bool) {
+	return validResumeDecision(decision)
+}
+
+// ResolveEscalation resumes a tree paused at TaskAwaitingHuman (#340). The
+// coordinatorJobID is the job that recorded the escalation (the resume target the
+// notification quoted). decision selects the verb; instructions is the human's
+// optional guidance, folded into the retried leg's prompt (retry) and recorded on
+// the resolution event (all verbs). It is idempotent: a second resume on an
+// already-resolved coordinator is a no-op. It clears TaskAwaitingHuman and records
+// a delegation_escalation_resolved event carrying resolved_at so the wall-clock
+// backstop can close the pause window. The caller (daemon handleResumeCommand) is
+// authorize-commenter gated.
+func (e Engine) ResolveEscalation(ctx context.Context, coordinatorJobID string, decision ResumeDecision, instructions string) error {
+	if err := e.validate(); err != nil {
+		return err
+	}
+	verb, ok := validResumeDecision(string(decision))
+	if !ok {
+		return fmt.Errorf("invalid resume decision %q; want retry|continue|abort", decision)
+	}
+
+	rec, exists, err := e.loadEscalation(ctx, coordinatorJobID)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("job %s has no pending human escalation", coordinatorJobID)
+	}
+	resolved, err := e.escalationResolved(ctx, coordinatorJobID)
+	if err != nil {
+		return err
+	}
+	if resolved {
+		// Already answered: idempotent no-op so a duplicate comment poll cannot
+		// re-run the verb (which could double-enqueue a leg or continuation).
+		return nil
+	}
+
+	parentJob, parentPayload, err := e.jobPayload(ctx, coordinatorJobID)
+	if err != nil {
+		return err
+	}
+	if parentPayload.Result == nil {
+		return fmt.Errorf("job %s has no result to resume", coordinatorJobID)
+	}
+	ref := taskRefFromPayload(parentPayload)
+
+	switch verb {
+	case ResumeRetry:
+		if err := e.resumeRetryLeg(ctx, parentJob, parentPayload, rec, instructions); err != nil {
+			return err
+		}
+	case ResumeContinue:
+		children, err := e.childDelegationJobs(ctx, parentJob.ID)
+		if err != nil {
+			return err
+		}
+		if err := e.maybeEnqueueContinuation(ctx, parentJob, parentPayload, parentPayload.Result, children, ref); err != nil {
+			return err
+		}
+	case ResumeAbort:
+		reason := "human aborted the escalation"
+		if strings.TrimSpace(instructions) != "" {
+			reason = "human aborted the escalation: " + strings.TrimSpace(instructions)
+		}
+		if err := e.enqueueFinalizeContinuation(ctx, parentJob, parentPayload, reason); err != nil {
+			return err
+		}
+	}
+
+	// Clear the pause: move the task out of awaiting_human. retry/continue re-arm
+	// the delegation machinery (the next child completion advances the DAG, or the
+	// continuation runs), so move to reviewing-ish "implementing" intent; abort's
+	// finalize continuation will settle the task itself. We use planned as a
+	// neutral non-terminal state so the dashboard stops listing it under Attention.
+	if err := e.setTaskState(ctx, ref, TaskPlanned); err != nil {
+		return err
+	}
+
+	resolution := EscalationRecord{
+		DelegationID: rec.DelegationID,
+		ChildJobID:   rec.ChildJobID,
+		Reason:       string(verb),
+		Question:     strings.TrimSpace(instructions),
+		PausedAt:     e.now().UTC().Format(time.RFC3339), // reused as resolved_at
+	}
+	message := string(verb)
+	if encoded, marshalErr := json.Marshal(resolution); marshalErr == nil {
+		message = string(encoded)
+	}
+	return e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   coordinatorJobID,
+		Kind:    escalationResolvedEvent,
+		Message: message,
+	})
+}
+
+// resumeRetryLeg re-enqueues the failing delegation leg of a paused tree with the
+// human's instructions folded into its prompt, under a deterministic resume id so
+// a duplicate resume cannot double-enqueue it. It is the retry verb's worker.
+func (e Engine) resumeRetryLeg(ctx context.Context, parentJob db.Job, parentPayload JobPayload, rec EscalationRecord, instructions string) error {
+	d, ok := findDelegation(parentPayload.Result.Delegations, rec.DelegationID)
+	if !ok {
+		return fmt.Errorf("escalated delegation %q not found on job %s", rec.DelegationID, parentJob.ID)
+	}
+	if instr := strings.TrimSpace(instructions); instr != "" {
+		d.Prompt = strings.TrimSpace(d.Prompt) + "\n\nHuman guidance on resume: " + instr
+	}
+	artifactDir, err := delegationArtifactDir(e.ArtifactRoot, parentJob.ID, parentPayload.Result)
+	if err != nil {
+		return err
+	}
+	request := e.delegationRequest(parentJob, parentPayload, d)
+	request.ID = parentJob.ID + "/delegation/" + d.ID + "/resume"
+	request.Instructions = strings.TrimSpace(d.Prompt)
+	request.DelegationArtifactDir = artifactDir
+	if err := e.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, d, request, taskRefFromPayload(parentPayload)); err != nil {
+		return err
+	}
+	return e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   parentJob.ID,
+		Kind:    "delegation_escalation_retry",
+		Message: fmt.Sprintf("human resume retry re-enqueued delegation %q as job %s", d.ID, request.ID),
+	})
+}
+
+// findDelegation returns the delegation with the given id from a result's set.
+func findDelegation(delegations []Delegation, id string) (Delegation, bool) {
+	for _, d := range delegations {
+		if d.ID == id {
+			return d, true
+		}
+	}
+	return Delegation{}, false
+}
+
+// AutoFinalizeExpiredEscalations scans for trees paused awaiting a human past the
+// TTL and gracefully finalizes them (#340): a never-answered escalation must not
+// strand a tree forever. For each coordinator with an unresolved
+// delegation_escalation_requested whose paused_at is older than ttl, it routes to
+// the #305 finalize continuation (synthesize what completed), clears
+// TaskAwaitingHuman, and records a delegation_escalation_resolved event tagged
+// "ttl" (so wall-clock pause accounting closes too). ttl <= 0 disables the scan.
+// It returns the number of trees finalized. Idempotent: an already-resolved
+// escalation is skipped, and the finalize continuation has a deterministic id.
+func (e Engine) AutoFinalizeExpiredEscalations(ctx context.Context, ttl time.Duration) (int, error) {
+	if err := e.validate(); err != nil {
+		return 0, err
+	}
+	if ttl <= 0 {
+		return 0, nil
+	}
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return 0, err
+	}
+	now := e.now().UTC()
+	finalized := 0
+	for _, job := range jobs {
+		rec, exists, err := e.loadEscalation(ctx, job.ID)
+		if err != nil {
+			return finalized, err
+		}
+		if !exists {
+			continue
+		}
+		resolved, err := e.escalationResolved(ctx, job.ID)
+		if err != nil {
+			return finalized, err
+		}
+		if resolved {
+			continue
+		}
+		pausedAt, perr := parseJobTimestamp(rec.PausedAt)
+		if perr != nil {
+			// Without a parseable paused_at we cannot age the pause; skip rather than
+			// finalize prematurely.
+			continue
+		}
+		if now.Sub(pausedAt) < ttl {
+			continue
+		}
+		coordinatorJob, payload, err := e.jobPayload(ctx, job.ID)
+		if err != nil {
+			return finalized, err
+		}
+		if payload.Result == nil {
+			continue
+		}
+		reason := fmt.Sprintf("escalation TTL of %s elapsed with no human response", ttl)
+		if err := e.enqueueFinalizeContinuation(ctx, coordinatorJob, payload, reason); err != nil {
+			return finalized, err
+		}
+		if err := e.setTaskState(ctx, taskRefFromPayload(payload), TaskPlanned); err != nil {
+			return finalized, err
+		}
+		resolution := EscalationRecord{
+			DelegationID: rec.DelegationID,
+			ChildJobID:   rec.ChildJobID,
+			Reason:       "ttl",
+			PausedAt:     now.Format(time.RFC3339), // reused as resolved_at
+		}
+		message := "ttl"
+		if encoded, marshalErr := json.Marshal(resolution); marshalErr == nil {
+			message = string(encoded)
+		}
+		if err := e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    escalationResolvedEvent,
+			Message: message,
+		}); err != nil {
+			return finalized, err
+		}
+		finalized++
+	}
+	return finalized, nil
 }
 
 func (e Engine) block(ctx context.Context, ref taskRef, reason string) error {

--- a/internal/workflow/escalate_human_test.go
+++ b/internal/workflow/escalate_human_test.go
@@ -285,6 +285,150 @@ func TestResolveEscalationRetryReenqueuesLeg(t *testing.T) {
 	}
 }
 
+// TestEscalateHumanRetryFailingAgainRePausesAndRemainsResolvable is the
+// regression for the round-based escalation fix (#340): a `retry` resume that
+// itself fails again must open a FRESH escalation round (re-pause the tree,
+// re-notify the human, enqueue no continuation) and remain resolvable/finalizable
+// — never stranded in planned with nothing in flight.
+func TestEscalateHumanRetryFailingAgainRePausesAndRemainsResolvable(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	notifier := &recordingNotifier{}
+	engine := testEngine(store)
+	engine.EscalationNotifier = notifier
+
+	// Round 1: the leg fails and the tree pauses awaiting a human.
+	seedEscalateHumanCoordinator(t, store, engine)
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err == nil {
+		t.Fatal("expected AwaitingHumanError on the first failure")
+	}
+	assertTaskState(t, store, "task-5", TaskAwaitingHuman)
+	if got := countJobEvents(t, store, "parent-job", escalationRequestedEvent); got != 1 {
+		t.Fatalf("%s events after round 1 = %d, want 1", escalationRequestedEvent, got)
+	}
+	if len(notifier.calls) != 1 {
+		t.Fatalf("notifier calls after round 1 = %d, want 1", len(notifier.calls))
+	}
+
+	// The human resumes with `retry`: the failing leg is re-enqueued and round 1
+	// is resolved (the task leaves awaiting_human, planned for now).
+	if err := engine.ResolveEscalation(ctx, "parent-job", ResumeRetry, "try the staging endpoint"); err != nil {
+		t.Fatalf("ResolveEscalation(retry) returned error: %v", err)
+	}
+	resumeJobID := "parent-job/delegation/api/resume"
+	if !jobExists(t, store, resumeJobID) {
+		t.Fatal("retry must re-enqueue the failing leg")
+	}
+	if got := countJobEvents(t, store, "parent-job", escalationResolvedEvent); got != 1 {
+		t.Fatalf("%s events after retry resume = %d, want 1", escalationResolvedEvent, got)
+	}
+	if state, _ := store.GetTask(ctx, "task-5"); state.State == string(TaskAwaitingHuman) {
+		t.Fatal("retry resume must clear awaiting_human")
+	}
+
+	// The re-run ALSO fails — a normal, expected outcome (the leg already failed
+	// once). Advancing it must open a FRESH escalation round, not silently strand.
+	completeDelegationChild(t, store, resumeJobID, JobFailed, AgentResult{Decision: "failed", Summary: "api still broken"})
+	err := engine.AdvanceJob(ctx, resumeJobID)
+	var awaiting AwaitingHumanError
+	if !errors.As(err, &awaiting) {
+		t.Fatalf("AdvanceJob(resume) error = %v, want AwaitingHumanError (re-pause)", err)
+	}
+
+	// Re-pause: the task is awaiting_human again so the dashboard Attention section
+	// re-shows it.
+	assertTaskState(t, store, "task-5", TaskAwaitingHuman)
+
+	// A SECOND requested event exists (a fresh round), and the human was re-notified.
+	if got := countJobEvents(t, store, "parent-job", escalationRequestedEvent); got != 2 {
+		t.Fatalf("%s events after re-pause = %d, want 2 (a new round)", escalationRequestedEvent, got)
+	}
+	if len(notifier.calls) != 2 {
+		t.Fatalf("notifier calls after re-pause = %d, want 2 (re-notified)", len(notifier.calls))
+	}
+
+	// Still zero compute: no continuation was enqueued by the re-pause.
+	if jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("a re-pause must NOT enqueue a continuation")
+	}
+
+	// The fresh round is OPEN again, so a follow-up `/gitmoot resume ... abort`
+	// resolves and finalizes it — proving the tree is not permanently stranded.
+	if err := engine.ResolveEscalation(ctx, "parent-job", ResumeAbort, "give up"); err != nil {
+		t.Fatalf("ResolveEscalation(abort) on the re-pause returned error: %v", err)
+	}
+	if got := countJobEvents(t, store, "parent-job", escalationResolvedEvent); got != 2 {
+		t.Fatalf("%s events after abort = %d, want 2 (both rounds resolved)", escalationResolvedEvent, got)
+	}
+	cont, err := unmarshalPayload(mustJob(t, store, delegationContinuationID("parent-job")).Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if !cont.DelegationFinalize {
+		t.Fatalf("abort on the re-pause must route to the graceful finalize continuation: %+v", cont)
+	}
+	if got := countJobEvents(t, store, "parent-job", "delegation_finalize_enqueued"); got != 1 {
+		t.Fatalf("delegation_finalize_enqueued events = %d, want 1", got)
+	}
+}
+
+// TestAutoFinalizeExpiredEscalationsCatchesRePause pins that a re-paused tree (a
+// retried leg that failed again, opening a new round) that nobody answers is
+// still caught by the wall-clock TTL backstop — the anti-stranding guarantee
+// holds across rounds (#340).
+func TestAutoFinalizeExpiredEscalationsCatchesRePause(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.EscalationNotifier = &recordingNotifier{}
+
+	base := time.Now().UTC()
+	engine.Now = func() time.Time { return base }
+
+	// Round 1 pause → retry → re-run fails again → re-pause (round 2 open).
+	seedEscalateHumanCoordinator(t, store, engine)
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err == nil {
+		t.Fatal("expected AwaitingHumanError on the first failure")
+	}
+	if err := engine.ResolveEscalation(ctx, "parent-job", ResumeRetry, ""); err != nil {
+		t.Fatalf("ResolveEscalation(retry) returned error: %v", err)
+	}
+	resumeJobID := "parent-job/delegation/api/resume"
+	completeDelegationChild(t, store, resumeJobID, JobFailed, AgentResult{Decision: "failed", Summary: "still broken"})
+	if err := engine.AdvanceJob(ctx, resumeJobID); err == nil {
+		t.Fatal("expected AwaitingHumanError on the re-pause")
+	}
+	assertTaskState(t, store, "task-5", TaskAwaitingHuman)
+
+	// Within TTL: the OPEN re-pause is not finalized.
+	if finalized, err := engine.AutoFinalizeExpiredEscalations(ctx, 48*time.Hour); err != nil || finalized != 0 {
+		t.Fatalf("within-TTL re-pause finalized = %d (err %v), want 0", finalized, err)
+	}
+
+	// Past TTL: the never-answered re-pause auto-finalizes gracefully.
+	engine.Now = func() time.Time { return base.Add(49 * time.Hour) }
+	finalized, err := engine.AutoFinalizeExpiredEscalations(ctx, 48*time.Hour)
+	if err != nil {
+		t.Fatalf("AutoFinalizeExpiredEscalations returned error: %v", err)
+	}
+	if finalized != 1 {
+		t.Fatalf("past-TTL re-pause finalized = %d, want 1", finalized)
+	}
+	cont, err := unmarshalPayload(mustJob(t, store, delegationContinuationID("parent-job")).Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if !cont.DelegationFinalize {
+		t.Fatalf("TTL auto-finalize of a re-pause must enqueue a finalize continuation: %+v", cont)
+	}
+}
+
 func TestResolveEscalationContinueEnqueuesContinuation(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/escalate_human_test.go
+++ b/internal/workflow/escalate_human_test.go
@@ -1,0 +1,453 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// recordingNotifier captures EscalationNotifier calls for the best-effort
+// notification assertions. errOnNotify makes NotifyEscalation fail so the test
+// can prove the pause still succeeds when the notifier errors.
+type recordingNotifier struct {
+	calls       []EscalationRequest
+	errOnNotify bool
+}
+
+func (n *recordingNotifier) NotifyEscalation(_ context.Context, request EscalationRequest) error {
+	n.calls = append(n.calls, request)
+	if n.errOnNotify {
+		return errors.New("notify failed")
+	}
+	return nil
+}
+
+// seedEscalateHumanCoordinator inserts a coordinator with a single escalate_human
+// delegation plus an independent sibling, advances it once to dispatch the
+// children, then completes the escalate_human leg as failed. It returns the
+// engine so the test can assert on the resulting pause.
+func seedEscalateHumanCoordinator(t *testing.T, store *db.Store, engine Engine) {
+	t.Helper()
+	ctx := context.Background()
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-005",
+		TaskID:    "task-5",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "api", Agent: "api", Action: "review", Prompt: "build api", FailurePolicy: "escalate_human"},
+				{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
+			},
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/api", JobFailed, AgentResult{Decision: "failed", Summary: "api broke"})
+}
+
+func TestEscalateHumanPausesAndEnqueuesNoContinuation(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	notifier := &recordingNotifier{}
+	engine := testEngine(store)
+	engine.EscalationNotifier = notifier
+
+	seedEscalateHumanCoordinator(t, store, engine)
+
+	err := engine.AdvanceJob(ctx, "parent-job/delegation/api")
+	var awaiting AwaitingHumanError
+	if !errors.As(err, &awaiting) {
+		t.Fatalf("AdvanceJob(api) error = %v, want AwaitingHumanError", err)
+	}
+
+	// The shared parent task is paused, NOT blocked.
+	assertTaskState(t, store, "task-5", TaskAwaitingHuman)
+
+	// No continuation is enqueued: the tree consumes zero compute while waiting.
+	if jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("escalate_human must NOT enqueue a continuation while awaiting a human")
+	}
+	if got := countJobEvents(t, store, "parent-job", "delegation_continuation_enqueued"); got != 0 {
+		t.Fatalf("delegation_continuation_enqueued events = %d, want 0", got)
+	}
+
+	// Exactly one one-shot escalation event, carrying the failing leg + reason.
+	if got := countJobEvents(t, store, "parent-job", escalationRequestedEvent); got != 1 {
+		t.Fatalf("%s events = %d, want 1", escalationRequestedEvent, got)
+	}
+	rec, exists, err := engine.loadEscalation(ctx, "parent-job")
+	if err != nil || !exists {
+		t.Fatalf("loadEscalation = (%+v, %v, %v), want a record", rec, exists, err)
+	}
+	if rec.DelegationID != "api" || rec.ChildJobID != "parent-job/delegation/api" || rec.Reason != "api broke" {
+		t.Fatalf("escalation record = %+v, want delegation api / child / reason", rec)
+	}
+
+	// Notifier invoked once, best-effort, with the resume context.
+	if len(notifier.calls) != 1 {
+		t.Fatalf("notifier calls = %d, want 1", len(notifier.calls))
+	}
+	if c := notifier.calls[0]; c.CoordinatorJobID != "parent-job" || c.DelegationID != "api" {
+		t.Fatalf("notifier request = %+v, want coordinator parent-job / delegation api", c)
+	}
+}
+
+func TestEscalateHumanRequestedEventIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	notifier := &recordingNotifier{}
+	engine := testEngine(store)
+	engine.EscalationNotifier = notifier
+
+	seedEscalateHumanCoordinator(t, store, engine)
+
+	// Advance the failing leg twice (mirrors a concurrent / repeated child advance).
+	for i := 0; i < 2; i++ {
+		err := engine.AdvanceJob(ctx, "parent-job/delegation/api")
+		var awaiting AwaitingHumanError
+		if !errors.As(err, &awaiting) {
+			t.Fatalf("AdvanceJob(api) iteration %d error = %v, want AwaitingHumanError", i, err)
+		}
+	}
+	if got := countJobEvents(t, store, "parent-job", escalationRequestedEvent); got != 1 {
+		t.Fatalf("%s events after re-advance = %d, want 1 (one-shot)", escalationRequestedEvent, got)
+	}
+	// The notifier must not re-fire on the idempotent re-advance.
+	if len(notifier.calls) != 1 {
+		t.Fatalf("notifier calls after re-advance = %d, want 1", len(notifier.calls))
+	}
+}
+
+func TestEscalateHumanPausesEvenWhenNotifierErrors(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.EscalationNotifier = &recordingNotifier{errOnNotify: true}
+
+	seedEscalateHumanCoordinator(t, store, engine)
+
+	err := engine.AdvanceJob(ctx, "parent-job/delegation/api")
+	var awaiting AwaitingHumanError
+	if !errors.As(err, &awaiting) {
+		t.Fatalf("AdvanceJob(api) error = %v, want AwaitingHumanError even when notifier errors", err)
+	}
+	// The pause is durable regardless of the notifier failure.
+	assertTaskState(t, store, "task-5", TaskAwaitingHuman)
+	if got := countJobEvents(t, store, "parent-job", escalationRequestedEvent); got != 1 {
+		t.Fatalf("%s events = %d, want 1 despite notifier error", escalationRequestedEvent, got)
+	}
+}
+
+func TestEscalateHumanPausedTreeIsNotABudgetFailure(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.EscalationNotifier = &recordingNotifier{}
+
+	seedEscalateHumanCoordinator(t, store, engine)
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err == nil {
+		t.Fatal("expected AwaitingHumanError")
+	}
+
+	// A paused tree must not be a block, a finalize, or a budget-trip event.
+	for _, kind := range []string{
+		"delegation_finalize_enqueued",
+		"delegation_walltime_exceeded",
+		"delegation_budget_exceeded",
+		"delegation_cost_exceeded",
+	} {
+		if got := countJobEvents(t, store, "parent-job", kind); got != 0 {
+			t.Fatalf("%s events = %d, want 0 for a paused tree", kind, got)
+		}
+	}
+	if state, _ := store.GetTask(ctx, "task-5"); state.State == string(TaskBlocked) {
+		t.Fatal("a paused-for-human tree must not be blocked")
+	}
+}
+
+// TestRootWallClockExcludesPausedTime pins that the wall-clock backstop subtracts
+// time the tree spent paused awaiting a human. A tree whose raw age exceeds the
+// budget only because of a long pause is NOT reported as over budget.
+func TestRootWallClockExcludesPausedTime(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+
+	base := time.Now().UTC()
+	// "Now" is MaxDelegationWallClock + 5h past the root creation: raw elapsed is
+	// over budget.
+	now := base.Add(MaxDelegationWallClock + 5*time.Hour)
+	engine.Now = func() time.Time { return now }
+
+	// Seed a root coordinator job.
+	insertCompletedJob(t, store, db.Job{ID: "root", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "b", TaskID: "task-5", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "x"},
+	})
+
+	// Record a 6h pause window on the root via the escalation events, so excluding
+	// it brings active elapsed back under budget.
+	pausedAt := base.Add(MaxDelegationWallClock - time.Hour)
+	resolvedAt := pausedAt.Add(6 * time.Hour)
+	addEscalationEvent(t, store, "root", escalationRequestedEvent, EscalationRecord{DelegationID: "api", PausedAt: pausedAt.Format(time.RFC3339)})
+	addEscalationEvent(t, store, "root", escalationResolvedEvent, EscalationRecord{DelegationID: "api", PausedAt: resolvedAt.Format(time.RFC3339)})
+
+	exceeded, elapsed := engine.rootWallClockExceeded(ctx, "root")
+	if exceeded {
+		t.Fatalf("wall-clock should exclude the 6h pause; got exceeded with elapsed %s", elapsed)
+	}
+
+	// Control: with no pause recorded, the same clock IS over budget.
+	insertCompletedJob(t, store, db.Job{ID: "root2", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "b", TaskID: "task-6", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "x"},
+	})
+	if exceeded, _ := engine.rootWallClockExceeded(ctx, "root2"); !exceeded {
+		t.Fatal("a tree with no pause and the same clock must be over wall-clock budget")
+	}
+}
+
+func addEscalationEvent(t *testing.T, store *db.Store, jobID, kind string, rec EscalationRecord) {
+	t.Helper()
+	encoded, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal escalation record: %v", err)
+	}
+	if err := store.AddJobEvent(context.Background(), db.JobEvent{JobID: jobID, Kind: kind, Message: string(encoded)}); err != nil {
+		t.Fatalf("AddJobEvent: %v", err)
+	}
+}
+
+func TestResolveEscalationRetryReenqueuesLeg(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.EscalationNotifier = &recordingNotifier{}
+
+	seedEscalateHumanCoordinator(t, store, engine)
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err == nil {
+		t.Fatal("expected AwaitingHumanError")
+	}
+
+	if err := engine.ResolveEscalation(ctx, "parent-job", ResumeRetry, "use the staging endpoint"); err != nil {
+		t.Fatalf("ResolveEscalation(retry) returned error: %v", err)
+	}
+	resumeJobID := "parent-job/delegation/api/resume"
+	if !jobExists(t, store, resumeJobID) {
+		t.Fatal("retry must re-enqueue the failing leg")
+	}
+	// The human's guidance is folded into the re-run leg's prompt.
+	payload, err := unmarshalPayload(mustJob(t, store, resumeJobID).Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if want := "use the staging endpoint"; !containsSubstr(payload.Instructions, want) {
+		t.Fatalf("retry leg instructions = %q, want it to fold in %q", payload.Instructions, want)
+	}
+	// The task leaves awaiting_human and the resolution is recorded once.
+	if state, _ := store.GetTask(ctx, "task-5"); state.State == string(TaskAwaitingHuman) {
+		t.Fatal("resume must clear awaiting_human")
+	}
+	if got := countJobEvents(t, store, "parent-job", escalationResolvedEvent); got != 1 {
+		t.Fatalf("%s events = %d, want 1", escalationResolvedEvent, got)
+	}
+
+	// Idempotent: a second resume is a no-op (no duplicate resolution event).
+	if err := engine.ResolveEscalation(ctx, "parent-job", ResumeContinue, ""); err != nil {
+		t.Fatalf("second ResolveEscalation returned error: %v", err)
+	}
+	if got := countJobEvents(t, store, "parent-job", escalationResolvedEvent); got != 1 {
+		t.Fatalf("%s events after second resume = %d, want 1 (idempotent)", escalationResolvedEvent, got)
+	}
+}
+
+func TestResolveEscalationContinueEnqueuesContinuation(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.EscalationNotifier = &recordingNotifier{}
+
+	seedEscalateHumanCoordinator(t, store, engine)
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err == nil {
+		t.Fatal("expected AwaitingHumanError")
+	}
+	// The independent sibling also finishes so the continuation has all outcomes.
+	completeDelegationChild(t, store, "parent-job/delegation/ui", JobSucceeded, AgentResult{Decision: "approved", Summary: "ui ok"})
+
+	if err := engine.ResolveEscalation(ctx, "parent-job", ResumeContinue, ""); err != nil {
+		t.Fatalf("ResolveEscalation(continue) returned error: %v", err)
+	}
+	if !jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("continue must enqueue the coordinator continuation")
+	}
+	if got := countJobEvents(t, store, "parent-job", escalationResolvedEvent); got != 1 {
+		t.Fatalf("%s events = %d, want 1", escalationResolvedEvent, got)
+	}
+}
+
+func TestResolveEscalationAbortFinalizes(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.EscalationNotifier = &recordingNotifier{}
+
+	seedEscalateHumanCoordinator(t, store, engine)
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err == nil {
+		t.Fatal("expected AwaitingHumanError")
+	}
+
+	if err := engine.ResolveEscalation(ctx, "parent-job", ResumeAbort, "not worth it"); err != nil {
+		t.Fatalf("ResolveEscalation(abort) returned error: %v", err)
+	}
+	cont, err := unmarshalPayload(mustJob(t, store, delegationContinuationID("parent-job")).Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if !cont.DelegationFinalize {
+		t.Fatalf("abort must route to the graceful finalize continuation: %+v", cont)
+	}
+	if got := countJobEvents(t, store, "parent-job", "delegation_finalize_enqueued"); got != 1 {
+		t.Fatalf("delegation_finalize_enqueued events = %d, want 1", got)
+	}
+}
+
+func TestResolveEscalationRejectsUnknownAndUnpaused(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.EscalationNotifier = &recordingNotifier{}
+
+	seedEscalateHumanCoordinator(t, store, engine)
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err == nil {
+		t.Fatal("expected AwaitingHumanError")
+	}
+
+	// Unknown verb is rejected before any side effect.
+	if err := engine.ResolveEscalation(ctx, "parent-job", ResumeDecision("frobnicate"), ""); err == nil {
+		t.Fatal("ResolveEscalation must reject an unknown decision")
+	}
+	// A coordinator with no pending escalation is rejected.
+	insertCompletedJob(t, store, db.Job{ID: "no-escalation", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", TaskID: "task-7", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "x"},
+	})
+	if err := engine.ResolveEscalation(ctx, "no-escalation", ResumeRetry, ""); err == nil {
+		t.Fatal("ResolveEscalation must reject a coordinator with no pending escalation")
+	}
+}
+
+func TestAutoFinalizeExpiredEscalations(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.EscalationNotifier = &recordingNotifier{}
+
+	base := time.Now().UTC()
+	engine.Now = func() time.Time { return base }
+	seedEscalateHumanCoordinator(t, store, engine)
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err == nil {
+		t.Fatal("expected AwaitingHumanError")
+	}
+
+	// Within TTL: no finalize.
+	finalized, err := engine.AutoFinalizeExpiredEscalations(ctx, 48*time.Hour)
+	if err != nil {
+		t.Fatalf("AutoFinalizeExpiredEscalations returned error: %v", err)
+	}
+	if finalized != 0 {
+		t.Fatalf("finalized = %d within TTL, want 0", finalized)
+	}
+	if jobExists(t, store, delegationContinuationID("parent-job")) {
+		t.Fatal("within-TTL pause must not finalize")
+	}
+
+	// Advance the clock past the TTL: the paused tree auto-finalizes gracefully.
+	engine.Now = func() time.Time { return base.Add(49 * time.Hour) }
+	finalized, err = engine.AutoFinalizeExpiredEscalations(ctx, 48*time.Hour)
+	if err != nil {
+		t.Fatalf("AutoFinalizeExpiredEscalations returned error: %v", err)
+	}
+	if finalized != 1 {
+		t.Fatalf("finalized = %d past TTL, want 1", finalized)
+	}
+	cont, err := unmarshalPayload(mustJob(t, store, delegationContinuationID("parent-job")).Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if !cont.DelegationFinalize {
+		t.Fatalf("TTL auto-finalize must enqueue a finalize continuation: %+v", cont)
+	}
+	if got := countJobEvents(t, store, "parent-job", escalationResolvedEvent); got != 1 {
+		t.Fatalf("%s events = %d, want 1 after TTL finalize", escalationResolvedEvent, got)
+	}
+
+	// Idempotent: a second scan does nothing (already resolved).
+	finalized, err = engine.AutoFinalizeExpiredEscalations(ctx, 48*time.Hour)
+	if err != nil {
+		t.Fatalf("second AutoFinalizeExpiredEscalations returned error: %v", err)
+	}
+	if finalized != 0 {
+		t.Fatalf("second scan finalized = %d, want 0 (idempotent)", finalized)
+	}
+}
+
+func TestParseResumeDecision(t *testing.T) {
+	for _, in := range []string{"retry", "RETRY", " continue ", "abort"} {
+		if _, ok := ParseResumeDecision(in); !ok {
+			t.Fatalf("ParseResumeDecision(%q) ok = false, want true", in)
+		}
+	}
+	if _, ok := ParseResumeDecision("nope"); ok {
+		t.Fatal("ParseResumeDecision(nope) ok = true, want false")
+	}
+}
+
+// containsSubstr is a tiny local helper to avoid importing strings just for one
+// assertion (the test file already pulls its other deps).
+func containsSubstr(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -324,7 +324,7 @@ func validateDelegationLifecycle(d Delegation) error {
 		return fmt.Errorf("delegation %q retry must be >= 0", d.ID)
 	}
 	switch strings.ToLower(strings.TrimSpace(d.FailurePolicy)) {
-	case "", "block_parent", "continue", "escalate":
+	case "", "block_parent", "continue", "escalate", "escalate_human":
 	default:
 		return fmt.Errorf("delegation %q failure_policy %q is invalid", d.ID, d.FailurePolicy)
 	}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -11,6 +11,12 @@ const (
 	TaskReadyToMerge     TaskState = "ready_to_merge"
 	TaskMerged           TaskState = "merged"
 	TaskBlocked          TaskState = "blocked"
+	// TaskAwaitingHuman is the resumable pause state a task enters when a
+	// delegation fails under the escalate_human failure_policy (#340). Unlike
+	// TaskBlocked (terminal), it is a durable human-in-the-loop pause: the tree
+	// enqueues no continuation and consumes no compute until an operator resumes
+	// it via `/gitmoot resume <jobID> retry|continue|abort`.
+	TaskAwaitingHuman TaskState = "awaiting_human"
 )
 
 type JobState string

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -82,7 +82,10 @@ Delegation fields:
     routes to the graceful finalize continuation. A never-answered escalation is
     auto-finalized after `[orchestrate].escalation_ttl` (default 24h); paused
     time is excluded from the per-root wall-clock budget, and a paused tree is
-    never counted as a budget failure.
+    never counted as a budget failure. The daemon routes `/gitmoot resume`
+    comments on the tree's **open** PR or issue (it watches open PRs/issues); the
+    dashboard **Attention** section and the `escalation_ttl` backstop cover a tree
+    whose PR/issue is no longer open.
 - `synthesis_rule` (optional): one of `summary`, `vote`, or `quorum`.
 - `quorum` (optional): an integer `K` (`> 0`), required when `synthesis_rule`
   is `quorum`. The coordinator continuation proceeds only if at least `K`

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -63,8 +63,26 @@ Delegation fields:
   only after every listed sibling succeeds. Each entry must reference a known
   sibling in the same result, may not be self-referential, and may not form a
   cycle — delegations form a DAG, and cycles are rejected.
-- `failure_policy` (optional): one of `block_parent`, `continue`, or
-  `escalate`. Defaults to `block_parent` when omitted.
+- `failure_policy` (optional): one of `block_parent`, `continue`, `escalate`, or
+  `escalate_human`. Defaults to `block_parent` when omitted.
+  - `block_parent` — a failed child blocks the shared parent task (terminal).
+  - `continue` — independent siblings keep running; only this branch's dependents
+    are skipped.
+  - `escalate` — hand every child outcome to the **coordinator** continuation to
+    decide autonomously (no human).
+  - `escalate_human` — a **durable human-in-the-loop pause** (#340). On a child
+    failure the parent task enters the resumable `awaiting_human` state, **no
+    continuation is enqueued, and the tree consumes zero tokens/compute** until a
+    human resumes it. The daemon @-tags the human in a GitHub comment (default
+    handle: the repo owner, or `[orchestrate].escalation_handle`) and the
+    dashboard lists the tree under **Attention**. A human resumes with
+    `/gitmoot resume <coordinatorJobID> retry|continue|abort [instructions]`:
+    `retry` re-runs the failing leg with the instructions folded in, `continue`
+    proceeds the coordinator continuation (now human-approved), and `abort`
+    routes to the graceful finalize continuation. A never-answered escalation is
+    auto-finalized after `[orchestrate].escalation_ttl` (default 24h); paused
+    time is excluded from the per-root wall-clock budget, and a paused tree is
+    never counted as a budget failure.
 - `synthesis_rule` (optional): one of `summary`, `vote`, or `quorum`.
 - `quorum` (optional): an integer `K` (`> 0`), required when `synthesis_rule`
   is `quorum`. The coordinator continuation proceeds only if at least `K`

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -103,7 +103,10 @@ cannot recurse or fan out forever:
   `/gitmoot resume <coordinatorJobID> retry|continue|abort [instructions]`
   (authorize-commenter gated, exactly like `/gitmoot retry`/`cancel`); a
   never-answered escalation is auto-finalized through the graceful finalize path
-  below after `[orchestrate].escalation_ttl` (default 24h).
+  below after `[orchestrate].escalation_ttl` (default 24h). The daemon ingests
+  `/gitmoot resume` comments on the tree's **open** PR or issue; the dashboard
+  **Attention** section and the TTL backstop cover a tree whose PR/issue is no
+  longer open.
 
 When a bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why (for example, the delegation tree

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -60,7 +60,9 @@ cannot recurse or fan out forever:
   one root is bounded in duration (measured from the root job's creation); a
   coordinator that tries to fan out after the tree has run this long is refused
   with a `delegation_walltime_exceeded` event. A generous runaway backstop, not a
-  tight deadline.
+  tight deadline. **Time a tree spends paused awaiting a human** (the
+  `escalate_human` failure_policy, below) **is excluded** from this measurement, so
+  a slow human response is never punished as a runaway.
 - Per-root token budget (cost) `[orchestrate].max_delegation_token_budget`,
   **off by default** (`0` = unlimited): when set to a positive value, the whole
   tree under one root is bounded by cumulative token usage (input + output across
@@ -92,6 +94,16 @@ cannot recurse or fan out forever:
   continuation routes through the same finalize path below (a
   `delegation_killed` event is emitted), and the daemon stops starting queued
   children of the killed root.
+- Human-in-the-loop pause (`escalate_human` failure_policy, #340): when a child
+  fails under `escalate_human`, the parent task enters the resumable
+  `awaiting_human` state, a one-shot `delegation_escalation_requested` event is
+  recorded, the human is @-tagged in a GitHub comment, and **no continuation is
+  enqueued** — the tree consumes zero tokens/compute while it waits. A paused tree
+  is **not** a budget failure. A human resumes with
+  `/gitmoot resume <coordinatorJobID> retry|continue|abort [instructions]`
+  (authorize-commenter gated, exactly like `/gitmoot retry`/`cancel`); a
+  never-answered escalation is auto-finalized through the graceful finalize path
+  below after `[orchestrate].escalation_ttl` (default 24h).
 
 When a bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why (for example, the delegation tree

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -112,7 +112,10 @@ the same `delegations` field, `coordinator`, and `continuation` mechanics.
     routes to the graceful finalize continuation. A never-answered escalation is
     auto-finalized after `[orchestrate].escalation_ttl` (default 24h); paused
     time is excluded from the per-root wall-clock budget, and a paused tree is
-    never counted as a budget failure.
+    never counted as a budget failure. The daemon routes `/gitmoot resume`
+    comments on the tree's **open** PR or issue (it watches open PRs/issues); the
+    dashboard **Attention** section and the `escalation_ttl` backstop cover a tree
+    whose PR/issue is no longer open.
 - `synthesis_rule` (optional): one of `summary`, `vote`, or `quorum`. It tells
   the coordinator how to combine the children's results.
 - `quorum` (optional): an integer `K` (`> 0`), required when `synthesis_rule` is

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -93,8 +93,26 @@ the same `delegations` field, `coordinator`, and `continuation` mechanics.
   known sibling in the same result, may not be self-referential, and may not
   form a cycle. Delegations form a directed acyclic graph (DAG), and cycles are
   rejected at validation time.
-- `failure_policy` (optional): one of `block_parent`, `continue`, or `escalate`.
-  Defaults to `block_parent` when omitted.
+- `failure_policy` (optional): one of `block_parent`, `continue`, `escalate`, or
+  `escalate_human`. Defaults to `block_parent` when omitted.
+  - `block_parent` — a failed child blocks the shared parent task (terminal).
+  - `continue` — independent siblings keep running; only this branch's dependents
+    are skipped.
+  - `escalate` — hand every child outcome to the **coordinator** continuation to
+    decide autonomously (no human).
+  - `escalate_human` — a **durable human-in-the-loop pause** (#340). On a child
+    failure the parent task enters the resumable `awaiting_human` state, **no
+    continuation is enqueued, and the tree consumes zero tokens/compute** until a
+    human resumes it. The daemon @-tags the human in a GitHub comment (default
+    handle: the repo owner, or `[orchestrate].escalation_handle`) and the
+    dashboard lists the tree under **Attention**. A human resumes with
+    `/gitmoot resume <coordinatorJobID> retry|continue|abort [instructions]`:
+    `retry` re-runs the failing leg with the instructions folded in, `continue`
+    proceeds the coordinator continuation (now human-approved), and `abort`
+    routes to the graceful finalize continuation. A never-answered escalation is
+    auto-finalized after `[orchestrate].escalation_ttl` (default 24h); paused
+    time is excluded from the per-root wall-clock budget, and a paused tree is
+    never counted as a budget failure.
 - `synthesis_rule` (optional): one of `summary`, `vote`, or `quorum`. It tells
   the coordinator how to combine the children's results.
 - `quorum` (optional): an integer `K` (`> 0`), required when `synthesis_rule` is


### PR DESCRIPTION
Closes #340.

Adds the additive `escalate_human` failure_policy: when a delegated **child** fails under it, the workflow engine **pauses the tree** durably (task state `awaiting_human`), enqueues **no continuation** (zero tokens/compute while waiting), records a one-shot `delegation_escalation_requested` event, and the daemon @-tags the human in a GitHub comment. The human resolves it with `/gitmoot resume <coordinatorJobID> retry|continue|abort [instructions]`. A TTL auto-finalizes a never-answered escalation gracefully. All additive and default-off-safe: a tree with no `escalate_human` delegation is byte-identical.

## What it does
- **Policy/state**: `escalate_human` added to validation + the failure-policy switch → `pauseAwaitingHuman` (mirrors `block_parent`'s mechanics) → new resumable `TaskAwaitingHuman` state (SQLite `state` is TEXT — no schema change). Escalation is **round-based** (open = `requested > resolved` events): a `retry` whose re-run fails again **re-pauses** (re-notifies, stays resolvable + TTL-finalizable) instead of stranding the tree.
- **Notify (both surfaces)**: an injected, nil-safe, best-effort `EscalationNotifier` posts the @-tag GitHub comment (handle = `[orchestrate].escalation_handle`, else repo owner); the dashboard **Attention** section lists `awaiting_human` trees.
- **Resume verb**: `/gitmoot resume <jobID> retry|continue|abort` (authorize-commenter gated, like `retry`/`cancel`): `retry` re-enqueues the failing leg with the human's instructions, `continue` proceeds the coordinator continuation, `abort` → graceful finalize (#305).
- **TTL + budget**: `AutoFinalizeExpiredEscalations` finalizes a tree paused past `[orchestrate].escalation_ttl` (default 24h); `rootWallClockExceeded` subtracts paused time (a slow human is not a runaway); a paused tree enqueues nothing, so token/cost budgets are untouched.

## Decisions (from the issue's decided-spec comment)
New `escalate_human` value (`escalate` stays coordinator-only); BOTH @-tag comment + dashboard Attention; retry/continue/abort; TTL → graceful finalize; paused time excluded from wall-clock; zero tokens while waiting.

## Verification
- Gate green on the merged tree (this branch merges current main): `go build/vet/test ./...` + `go test -race ./internal/workflow/` (198s).
- Unit tests: pause→awaiting_human + no continuation + one-shot idempotent event; notifier best-effort; paused ≠ budget failure; wall-clock excludes paused time; ResolveEscalation retry/continue/abort + idempotent + rejects unknown verb/unpaused; AutoFinalize TTL; round-based re-pause (load-bearing); handleResumeCommand routing + authorize-gate; ParseCommand/Validate; Attention TUI; escalation comment is not self-parsed as a command.
- Adversarial review: **clean** (after fixing a HIGH retry-restrand finding → round-based escalation).
- **Live codex E2E PASS**: all three seams (pause / GitHub @-comment / resume routing) + round-based re-pause + TTL validated live on the real binary + daemon + GitHub (pause-origination via the real `FinalizeTimedOutDelegationChild` recovery path).

### E2E follow-ups folded in
- Fixed: the notifier comment self-parsing as a command (it led with `@handle`); now mentions mid-line so GitHub still notifies but the daemon doesn't ack it (regression test added).
- Documented: the daemon routes `/gitmoot resume` comments only on the tree's **open** PR/issue; the dashboard Attention section + TTL backstop cover a closed PR/issue.

Merge order: this is the third of #303 → #339 → #340 (merged main in to absorb #339's additive `[orchestrate]` config wiring). Docs updated in both trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)