### PR TITLE
ci(release): publish linux/arm64 + automate release builds, fix installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+# Builds the release binaries for every supported OS/arch and attaches them to
+# the GitHub Release that triggered the run. Fires when a release is *published*
+# (the existing manual flow: cut the tag + release notes in the UI, this then
+# builds and uploads the assets). Re-running re-uploads with --clobber.
+#
+# Pure-Go build (sqlite via modernc, no cgo) so every target cross-compiles from
+# one ubuntu runner with CGO_ENABLED=0 → static, portable binaries.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-upload:
+    name: build + upload release assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the released tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build all targets (static, version-stamped)
+        env:
+          CGO_ENABLED: "0"
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          COMMIT="$(git rev-parse HEAD)"
+          DATE="$(git show -s --format=%cI HEAD)"
+          PKG=github.com/jerryfane/gitmoot/internal/buildinfo
+          LDFLAGS="-s -w -X ${PKG}.Version=${VERSION} -X ${PKG}.Commit=${COMMIT} -X ${PKG}.Date=${DATE}"
+          for t in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            os="${t%/*}"; arch="${t#*/}"
+            echo "building gitmoot_${os}_${arch}"
+            GOOS="$os" GOARCH="$arch" go build -trimpath -ldflags "$LDFLAGS" \
+              -o "dist/gitmoot_${os}_${arch}" ./cmd/gitmoot
+          done
+
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum gitmoot_* > sha256sums.txt
+          cat sha256sums.txt
+
+      - name: Upload assets to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            dist/gitmoot_linux_amd64 \
+            dist/gitmoot_linux_arm64 \
+            dist/gitmoot_darwin_amd64 \
+            dist/gitmoot_darwin_arm64 \
+            dist/sha256sums.txt \
+            --repo "${{ github.repository }}" --clobber

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+set -eu
+
+repo="jerryfane/gitmoot"
+api_url="https://api.github.com/repos/${repo}/releases?per_page=20"
+install_dir="${GITMOOT_INSTALL_DIR:-"$HOME/.local/bin"}"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "gitmoot install: missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need curl
+need sed
+need uname
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+
+case "$os" in
+  linux) os="linux" ;;
+  darwin) os="darwin" ;;
+  *)
+    echo "gitmoot install: unsupported OS: $os" >&2
+    exit 1
+    ;;
+esac
+
+case "$arch" in
+  x86_64|amd64) arch="amd64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *)
+    echo "gitmoot install: unsupported architecture: $arch" >&2
+    exit 1
+    ;;
+esac
+
+asset="gitmoot_${os}_${arch}"
+case "$asset" in
+  gitmoot_linux_amd64|gitmoot_linux_arm64|gitmoot_darwin_amd64|gitmoot_darwin_arm64) ;;
+  *)
+    echo "gitmoot install: no published beta asset for ${os}/${arch}" >&2
+    echo "See https://github.com/${repo}/releases" >&2
+    exit 1
+    ;;
+esac
+
+tag="${GITMOOT_VERSION:-}"
+if [ -z "$tag" ]; then
+  tag="$(curl -fsSL "$api_url" | sed -n 's/.*"tag_name": "\([^"]*\)".*/\1/p' | head -n 1)"
+fi
+
+if [ -z "$tag" ]; then
+  echo "gitmoot install: could not find a GitHub release for ${repo}" >&2
+  exit 1
+fi
+
+base_url="https://github.com/${repo}/releases/download/${tag}"
+tmp_dir="$(mktemp -d 2>/dev/null || mktemp -d -t gitmoot-install)"
+trap 'rm -rf "$tmp_dir"' EXIT INT TERM
+
+echo "Installing Gitmoot ${tag} for ${os}/${arch}"
+curl -fL "${base_url}/${asset}" -o "${tmp_dir}/gitmoot"
+curl -fL "${base_url}/sha256sums.txt" -o "${tmp_dir}/sha256sums.txt"
+
+expected="$(sed -n "s/  ${asset}$//p" "${tmp_dir}/sha256sums.txt" | head -n 1)"
+if [ -z "$expected" ]; then
+  echo "gitmoot install: checksum for ${asset} was not found" >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "${tmp_dir}/gitmoot" | sed 's/ .*//')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "${tmp_dir}/gitmoot" | sed 's/ .*//')"
+else
+  echo "gitmoot install: missing sha256sum or shasum for checksum verification" >&2
+  exit 1
+fi
+
+if [ "$actual" != "$expected" ]; then
+  echo "gitmoot install: checksum mismatch for ${asset}" >&2
+  exit 1
+fi
+
+mkdir -p "$install_dir"
+chmod 755 "${tmp_dir}/gitmoot"
+cp "${tmp_dir}/gitmoot" "${install_dir}/gitmoot"
+chmod 755 "${install_dir}/gitmoot"
+
+echo "Gitmoot installed to ${install_dir}/gitmoot"
+case ":$PATH:" in
+  *":$install_dir:"*) ;;
+  *) echo "Add ${install_dir} to PATH to run gitmoot from any shell." ;;
+esac
+"${install_dir}/gitmoot" version

--- a/website/docs/operations/deployment.md
+++ b/website/docs/operations/deployment.md
@@ -47,3 +47,29 @@ flowchart LR
 `docs.gitmoot.io` currently resolves to this server but should only be enabled
 after the origin TLS certificate and nginx server block explicitly cover that
 host.
+
+## Install script (`gitmoot.io/install.sh`)
+
+The one-liner installer (`curl -fsSL https://gitmoot.io/install.sh | sh`) is
+served from the nginx web root at the site root — **separate** from the
+Docusaurus docs build (`baseUrl` is `/docs/`, so `website/static/` files would
+land under `/docs/`, not `/`). The source of truth is tracked at
+**`scripts/install.sh`**; deploy it by copying that file to the path the
+`gitmoot.io` server block serves `/install.sh` from (confirm against the live
+nginx config), e.g.:
+
+```sh
+# from the repo root, on the server (adjust the destination to the real root):
+install -m 0644 scripts/install.sh /var/www/gitmoot-docs/install.sh
+```
+
+Smoke check after deploy:
+
+```sh
+curl -fsSL https://gitmoot.io/install.sh | sh -n -   # downloads + shell-parses
+```
+
+The installer downloads the per-OS/arch binary plus `sha256sums.txt` from the
+matching GitHub release and verifies the checksum. The release assets
+(including `gitmoot_linux_arm64`) and `sha256sums.txt` are produced by
+`.github/workflows/release.yml` on release publish.

--- a/website/docs/operations/deployment.md
+++ b/website/docs/operations/deployment.md
@@ -51,16 +51,17 @@ host.
 ## Install script (`gitmoot.io/install.sh`)
 
 The one-liner installer (`curl -fsSL https://gitmoot.io/install.sh | sh`) is
-served from the nginx web root at the site root — **separate** from the
-Docusaurus docs build (`baseUrl` is `/docs/`, so `website/static/` files would
-land under `/docs/`, not `/`). The source of truth is tracked at
-**`scripts/install.sh`**; deploy it by copying that file to the path the
-`gitmoot.io` server block serves `/install.sh` from (confirm against the live
-nginx config), e.g.:
+served from the **`gitmoot.io` site root**, which on the live server is
+**`/var/www/gitmoot.io/`** (`root /var/www/gitmoot.io;` with `location =
+/install.sh` in `/etc/nginx/sites-available/gitmoot.io`) — **separate** from the
+Docusaurus docs build, which is served under `/docs/` from
+`/var/www/gitmoot-docs/` (`baseUrl` is `/docs/`, so `website/static/` files land
+under `/docs/`, not `/`). The source of truth is tracked at
+**`scripts/install.sh`**; deploy it by copying that file to the site root:
 
 ```sh
-# from the repo root, on the server (adjust the destination to the real root):
-install -m 0644 scripts/install.sh /var/www/gitmoot-docs/install.sh
+# from the repo root, on the server:
+install -m 0644 scripts/install.sh /var/www/gitmoot.io/install.sh
 ```
 
 Smoke check after deploy:


### PR DESCRIPTION
## Why
`curl -fsSL https://gitmoot.io/install.sh | sh` cannot install on Raspberry Pi / any `linux/arm64` host: **no `gitmoot_linux_arm64` asset has ever been published**, and the installer rejects that arch. While investigating I also found the installer is broken on *every* platform (it fetches `SHA256SUMS`, but releases ship `sha256sums.txt`). This PR adds an arm64 release path, automates release artifact builds, and brings the installer under version control.

> Context: the missing `gitmoot_linux_arm64` binary has already been uploaded **manually** to the existing **v0.5.1** release (built from the `v0.5.1` tag, static `CGO_ENABLED=0`, checksum added to `sha256sums.txt`). This PR makes that repeatable and fixes the installer so the binary is actually usable.

## What
- **`.github/workflows/release.yml`** (new) — on `release: published`, cross-compile `linux,darwin × amd64,arm64` with `CGO_ENABLED=0` (static), version-stamp via `internal/buildinfo.{Version,Commit,Date}` from the tag, generate `sha256sums.txt`, and upload all assets with `--clobber`. Pure-Go build (sqlite via `modernc`), so all four targets cross-compile from one ubuntu runner.
- **`scripts/install.sh`** (new, tracked) — the previously server-only installer, now in-repo, with two fixes:
  - add `gitmoot_linux_arm64` to the published-asset allowlist
  - fetch `sha256sums.txt` instead of `SHA256SUMS` (3 occurrences)
- **`website/docs/operations/deployment.md`** — document how `gitmoot.io/install.sh` is served (nginx web root, separate from the `/docs/` Docusaurus build, since `baseUrl` is `/docs/`).

## Verification
- `sh -n scripts/install.sh` → syntax OK
- `release.yml` parses as valid YAML
- Proved both relevant builds on an arm64 host: `GOOS=linux GOARCH=arm64` and `GOOS=darwin GOARCH=arm64` with `CGO_ENABLED=0` → static ELF / Mach-O binaries; the linux/arm64 build reports `gitmoot v0.5.1` and runs.

## Open question for the reviewer
The exact nginx web-root path for deploying `install.sh` is a **placeholder** (`/var/www/gitmoot-docs/install.sh`) in `deployment.md` — please confirm/correct against the live server config. (`install.sh` deployment was previously undocumented.)

## Notes
- The release workflow only affects **future** releases; v0.5.1's arm64 asset was added manually.
- Triggering on `release: published` matches the current manual flow (cut the tag + notes in the UI, workflow then builds & attaches assets). Switch to `on: push: tags` if you'd rather it create the release itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)