### PR TITLE
fix(cli): claude agent doctor uses a live probe instead of false-failing on a missing env token (#414 PR1)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1797,15 +1797,40 @@ func runAgentDoctor(args []string, stdout, stderr io.Writer) int {
 		}
 		fmt.Fprintf(stdout, "claude-auth-env %s %s\n", status, detail)
 		if !auth.Ready() && !*live {
-			_ = persistAgentHealth(*home, name, "failed")
-			fmt.Fprintf(stderr, "agent %s health failed: %s\n", rtAgent.Name, runtime.ClaudeAuthSetupMessage)
-			return 1
+			// Env not Ready does not mean auth is broken: foreground Claude may
+			// authenticate fine via cached ~/.claude credentials. Probe the real
+			// dependency (claude -p) instead of false-failing on the env check.
+			// A probe failure escalates to failed/1; an OK or unavailable probe
+			// reports warn/0 (degraded-but-serving) with the background-token
+			// caveat — never a new false-fail.
+			if err := runtime.ClaudeLiveCheck(context.Background(), agentDoctorRunner, ""); err != nil {
+				if runtime.ClaudeProbeUnavailable(err) {
+					fmt.Fprintf(stdout, "claude-live warn probe unavailable: %s\n", err)
+					if perr := persistAgentHealth(*home, name, "warn"); perr != nil {
+						fmt.Fprintf(stderr, "update agent health: %v\n", perr)
+						return 1
+					}
+					fmt.Fprintf(stdout, "agent %s warn %s\n", rtAgent.Name, runtime.ClaudeBackgroundTokenMessage)
+					return 0
+				}
+				_ = persistAgentHealth(*home, name, "failed")
+				fmt.Fprintf(stdout, "claude-live fail %s\n", err)
+				fmt.Fprintf(stderr, "agent %s health failed: %s: %v\n", rtAgent.Name, runtime.ClaudeSessionAuthFailedMessage, err)
+				return 1
+			}
+			fmt.Fprintln(stdout, "claude-live ok live Claude print-mode check succeeded")
+			if perr := persistAgentHealth(*home, name, "warn"); perr != nil {
+				fmt.Fprintf(stderr, "update agent health: %v\n", perr)
+				return 1
+			}
+			fmt.Fprintf(stdout, "agent %s warn %s\n", rtAgent.Name, runtime.ClaudeBackgroundTokenMessage)
+			return 0
 		}
 		if *live {
 			if err := runtime.ClaudeLiveCheck(context.Background(), agentDoctorRunner, ""); err != nil {
 				_ = persistAgentHealth(*home, name, "failed")
 				fmt.Fprintf(stdout, "claude-live fail %s\n", err)
-				fmt.Fprintf(stderr, "agent %s health failed: %v\n", rtAgent.Name, err)
+				fmt.Fprintf(stderr, "agent %s health failed: %s: %v\n", rtAgent.Name, runtime.ClaudeSessionAuthFailedMessage, err)
 				return 1
 			}
 			fmt.Fprintln(stdout, "claude-live ok live Claude print-mode check succeeded")

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -2521,28 +2522,151 @@ func TestRunAgentDoctorClaudeReportsMaskedAuthEnv(t *testing.T) {
 	}
 }
 
-func TestRunAgentDoctorClaudeFailsWhenAuthEnvMissing(t *testing.T) {
+// (A) env-missing but the live probe authenticates fine → the env check is not
+// a failure; report warn/0 with the background-token caveat (NOT failed, NOT a
+// dead-session message). This is the false-negative the live-probe fallback fixes.
+func TestRunAgentDoctorClaudeAuthEnvMissingProbeOKWarns(t *testing.T) {
 	withClaudeAuthEnv(t, nil)
 	home := t.TempDir()
-	subscribeClaudeAgent(t, home, "claude-missing")
+	subscribeClaudeAgent(t, home, "claude-probe-ok")
+	runner := &agentStartRunner{results: []subprocess.Result{{Stdout: `{"result":"OK"}`}}}
+	restoreRunner := replaceAgentDoctorRunner(runner)
+	defer restoreRunner()
 
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"agent", "doctor", "claude-missing", "--home", home}, &stdout, &stderr)
+	code := Run([]string{"agent", "doctor", "claude-probe-ok", "--home", home}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("doctor exit code = %d, want 0; stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "claude-auth-env warn") {
+		t.Fatalf("stdout missing claude-auth-env warn:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), runtime.ClaudeBackgroundTokenMessage) {
+		t.Fatalf("stdout missing background-token caveat:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), runtime.ClaudeSessionAuthFailedMessage) ||
+		strings.Contains(stderr.String(), runtime.ClaudeSessionAuthFailedMessage) {
+		t.Fatalf("output should NOT mention a dead-session message on probe-ok:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	// The probe must actually be invoked even without --live.
+	runner.want(t, 0, "", "claude", "-p", "--output-format", "json", "--", runtime.ClaudeLiveCheckPrompt)
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "claude-probe-ok")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.HealthStatus != "warn" {
+		t.Fatalf("health status = %q, want warn", agent.HealthStatus)
+	}
+}
+
+// (B) env-missing and the live probe returns an auth-classified failure → escalate
+// to failed/1 with the SESSION-failure message (refresh/rebind), not just "set up
+// a token".
+func TestRunAgentDoctorClaudeAuthEnvMissingProbeFailsSession(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	home := t.TempDir()
+	subscribeClaudeAgent(t, home, "claude-probe-fail")
+	runner := &agentStartRunner{
+		results: []subprocess.Result{{Stderr: "401 Invalid authentication credentials"}},
+		errs:    []error{errors.New("exit 1")},
+	}
+	restoreRunner := replaceAgentDoctorRunner(runner)
+	defer restoreRunner()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "doctor", "claude-probe-fail", "--home", home}, &stdout, &stderr)
 
 	if code != 1 {
 		t.Fatalf("doctor exit code = %d, want 1; stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "claude-auth-env warn") || !strings.Contains(stderr.String(), "claude setup-token") {
-		t.Fatalf("doctor output missing setup guidance:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	if !strings.Contains(stdout.String(), "claude-live fail") {
+		t.Fatalf("stdout missing classified probe failure:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), runtime.ClaudeSessionAuthFailedMessage) {
+		t.Fatalf("stderr missing session-failure message:\n%s", stderr.String())
 	}
 	store := openCLIJobStore(t, home)
 	defer store.Close()
-	agent, err := store.GetAgent(context.Background(), "claude-missing")
+	agent, err := store.GetAgent(context.Background(), "claude-probe-fail")
 	if err != nil {
 		t.Fatalf("GetAgent returned error: %v", err)
 	}
 	if agent.HealthStatus != "failed" {
 		t.Fatalf("health status = %q, want failed", agent.HealthStatus)
+	}
+}
+
+// (C) env-missing and the probe is unavailable (binary missing / exec error) →
+// warn/0 with the caveat; never a NEW false-fail just because the CLI is absent.
+func TestRunAgentDoctorClaudeAuthEnvMissingProbeUnavailableWarns(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	home := t.TempDir()
+	subscribeClaudeAgent(t, home, "claude-probe-unavail")
+	runner := &agentStartRunner{
+		errs: []error{&exec.Error{Name: "claude", Err: exec.ErrNotFound}},
+	}
+	restoreRunner := replaceAgentDoctorRunner(runner)
+	defer restoreRunner()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "doctor", "claude-probe-unavail", "--home", home}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("doctor exit code = %d, want 0; stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "claude-live warn probe unavailable") {
+		t.Fatalf("stdout missing probe-unavailable warn line:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), runtime.ClaudeBackgroundTokenMessage) {
+		t.Fatalf("stdout missing background-token caveat:\n%s", stdout.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "claude-probe-unavail")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.HealthStatus != "warn" {
+		t.Fatalf("health status = %q, want warn", agent.HealthStatus)
+	}
+}
+
+// (D) env token present → ok/0, the runner is NOT consulted (env-Ready boxes stay
+// instant; no probe).
+func TestRunAgentDoctorClaudeAuthEnvPresentSkipsProbe(t *testing.T) {
+	withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
+	home := t.TempDir()
+	subscribeClaudeAgent(t, home, "claude-env-ok")
+	runner := &agentStartRunner{}
+	restoreRunner := replaceAgentDoctorRunner(runner)
+	defer restoreRunner()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "doctor", "claude-env-ok", "--home", home}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("doctor exit code = %d, want 0; stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "claude-auth-env ok") {
+		t.Fatalf("stdout missing claude-auth-env ok:\n%s", stdout.String())
+	}
+	runner.mu.Lock()
+	calls := len(runner.calls)
+	runner.mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("runner consulted %d times, want 0 (env-Ready must not probe)", calls)
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), "claude-env-ok")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if agent.HealthStatus != "ok" {
+		t.Fatalf("health status = %q, want ok", agent.HealthStatus)
 	}
 }
 

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -477,8 +477,8 @@ func TestRunPluginDoctorClaudeLiveClassifiesAuthFailure(t *testing.T) {
 	if check.Status != "fail" {
 		t.Fatalf("runtime-live status = %q, want fail; checks=%+v", check.Status, output.Runtimes[0].Checks)
 	}
-	if !strings.Contains(check.Detail, "claude setup-token") || !strings.Contains(check.Detail, "restart the Gitmoot daemon") {
-		t.Fatalf("runtime-live detail = %q, want classified auth guidance", check.Detail)
+	if !strings.Contains(check.Detail, runtime.ClaudeSessionAuthFailedMessage) {
+		t.Fatalf("runtime-live detail = %q, want session-failure guidance", check.Detail)
 	}
 }
 

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -552,7 +552,7 @@ func ClassifyClaudeCommandError(result subprocess.Result, err error) error {
 	if !isClaudeAuthFailure(result) {
 		return base
 	}
-	return fmt.Errorf("Claude Code authentication failed. %s: %w", ClaudeAuthSetupMessage, base)
+	return fmt.Errorf("Claude Code authentication failed. %s: %w", ClaudeSessionAuthFailedMessage, base)
 }
 
 func isClaudeAuthFailure(result subprocess.Result) bool {

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -397,10 +397,13 @@ func TestClaudeStartClassifiesAuthFailure(t *testing.T) {
 		t.Fatal("Start accepted auth failure")
 	}
 	errText := err.Error()
-	for _, want := range []string{"Claude Code authentication failed", "claude setup-token", "restart the Gitmoot daemon", "401 Invalid authentication credentials"} {
+	for _, want := range []string{"Claude Code authentication failed", ClaudeSessionAuthFailedMessage, "401 Invalid authentication credentials"} {
 		if !strings.Contains(errText, want) {
 			t.Fatalf("error missing %q:\n%s", want, errText)
 		}
+	}
+	if strings.Contains(errText, ClaudeBackgroundTokenMessage) {
+		t.Fatalf("real subprocess auth failure must not reuse the background-token caveat:\n%s", errText)
 	}
 	if result.Raw != raw {
 		t.Fatalf("raw = %q, want %q", result.Raw, raw)
@@ -479,10 +482,13 @@ func TestClaudeDeliverClassifiesAuthFailure(t *testing.T) {
 		t.Fatal("Deliver accepted auth failure")
 	}
 	errText := err.Error()
-	for _, want := range []string{"Claude Code authentication failed", "claude setup-token", "restart the Gitmoot daemon", raw} {
+	for _, want := range []string{"Claude Code authentication failed", ClaudeSessionAuthFailedMessage, raw} {
 		if !strings.Contains(errText, want) {
 			t.Fatalf("error missing %q:\n%s", want, errText)
 		}
+	}
+	if strings.Contains(errText, ClaudeBackgroundTokenMessage) {
+		t.Fatalf("real subprocess auth failure must not reuse the background-token caveat:\n%s", errText)
 	}
 	if result.Raw != raw {
 		t.Fatalf("raw = %q, want %q", result.Raw, raw)
@@ -514,10 +520,13 @@ func TestClaudeHealthClassifiesAuthFailure(t *testing.T) {
 		t.Fatal("Health accepted auth failure")
 	}
 	errText := err.Error()
-	for _, want := range []string{"Claude Code authentication failed", "claude setup-token", "restart the Gitmoot daemon"} {
+	for _, want := range []string{"Claude Code authentication failed", ClaudeSessionAuthFailedMessage} {
 		if !strings.Contains(errText, want) {
 			t.Fatalf("error missing %q:\n%s", want, errText)
 		}
+	}
+	if strings.Contains(errText, ClaudeBackgroundTokenMessage) {
+		t.Fatalf("real subprocess auth failure must not reuse the background-token caveat:\n%s", errText)
 	}
 }
 

--- a/internal/runtime/claude_auth.go
+++ b/internal/runtime/claude_auth.go
@@ -3,18 +3,27 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
 const (
-	ClaudeOAuthTokenEnv    = "CLAUDE_CODE_OAUTH_TOKEN"
-	AnthropicAPIKeyEnv     = "ANTHROPIC_API_KEY"
-	AnthropicAuthTokenEnv  = "ANTHROPIC_AUTH_TOKEN"
-	ClaudeAuthSetupMessage = "Claude Code background jobs need non-interactive credentials. Run: claude setup-token; export CLAUDE_CODE_OAUTH_TOKEN=<token>; then restart the Gitmoot daemon so it inherits the token."
-	ClaudeLiveCheckPrompt  = "Gitmoot Claude live check. Return OK only."
+	ClaudeOAuthTokenEnv   = "CLAUDE_CODE_OAUTH_TOKEN"
+	AnthropicAPIKeyEnv    = "ANTHROPIC_API_KEY"
+	AnthropicAuthTokenEnv = "ANTHROPIC_AUTH_TOKEN"
+	// ClaudeBackgroundTokenMessage is the warn-path caveat: foreground Claude
+	// authenticates fine via cached credentials, but daemon background jobs run
+	// non-interactively and need an explicit token in the daemon env.
+	ClaudeBackgroundTokenMessage = "Foreground Claude works via cached credentials, but daemon background jobs run non-interactively and need a token in the daemon env. Run: claude setup-token; export CLAUDE_CODE_OAUTH_TOKEN=<token>; then restart the Gitmoot daemon so it inherits the token."
+	// ClaudeSessionAuthFailedMessage is the failure-path message: a genuine
+	// authentication/session failure (the cached session is expired or the
+	// --resume target is dead) that needs re-authentication and a fresh bind.
+	ClaudeSessionAuthFailedMessage = "Claude authentication/session failed; the cached session may be expired or the --resume target is dead. Re-authenticate (claude setup-token) and rebind the session."
+	ClaudeLiveCheckPrompt          = "Gitmoot Claude live check. Return OK only."
 )
 
 type ClaudeAuthEnv struct {
@@ -52,7 +61,7 @@ func (e ClaudeAuthEnv) MaskedDetail() string {
 func (e ClaudeAuthEnv) Warning() string {
 	switch {
 	case !e.Ready():
-		return ClaudeAuthSetupMessage
+		return ClaudeBackgroundTokenMessage
 	case e.AnthropicAPIKey:
 		return "ANTHROPIC_API_KEY is set; Claude Code may use API-key billing and this can override Claude OAuth behavior."
 	case e.AnthropicAuthToken:
@@ -78,6 +87,24 @@ func ClaudeLiveCheck(ctx context.Context, runner subprocess.Runner, dir string) 
 		return ClassifyClaudeCommandError(result, err)
 	}
 	return validateClaudeLiveJSON(result.Stdout)
+}
+
+// ClaudeProbeUnavailable reports whether a ClaudeLiveCheck error means the probe
+// could not run at all — the `claude` binary is missing or otherwise not
+// executable — as opposed to running and returning an auth/session failure. A
+// missing binary must never be classified as an auth failure: the operator may
+// simply lack the CLI on this box, which is not a new health regression. The
+// underlying exec error is wrapped with %w by commandError/ClassifyClaudeCommandError,
+// so errors.Is/As still reach it through the chain.
+func ClaudeProbeUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return true
+	}
+	var execErr *exec.Error
+	return errors.As(err, &execErr)
 }
 
 func validateClaudeLiveJSON(stdout string) error {

--- a/internal/runtime/claude_auth_test.go
+++ b/internal/runtime/claude_auth_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -79,10 +80,60 @@ func TestClaudeLiveCheckClassifiesAuthFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("ClaudeLiveCheck accepted auth failure")
 	}
-	for _, want := range []string{"Claude Code authentication failed", "claude setup-token", "restart the Gitmoot daemon"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error missing %q:\n%s", want, err)
-		}
+	// A real subprocess auth/session failure must surface the session-failure
+	// message (refresh + rebind), not the background-token caveat.
+	if !strings.Contains(err.Error(), ClaudeSessionAuthFailedMessage) {
+		t.Fatalf("error missing session-failure message:\n%s", err)
+	}
+	if strings.Contains(err.Error(), ClaudeBackgroundTokenMessage) {
+		t.Fatalf("error must not reuse the background-token caveat for a real auth failure:\n%s", err)
+	}
+}
+
+// (F) The two messages must be distinct, and a classified subprocess auth/session
+// failure (the path the adapter uses) must wrap the session message — never the
+// background-token caveat.
+func TestClaudeAuthMessagesAreDistinct(t *testing.T) {
+	if ClaudeBackgroundTokenMessage == ClaudeSessionAuthFailedMessage {
+		t.Fatal("background-token and session-failure messages must differ")
+	}
+	if !strings.Contains(ClaudeBackgroundTokenMessage, "background") {
+		t.Fatalf("background-token message lost its background-job framing:\n%s", ClaudeBackgroundTokenMessage)
+	}
+	if !strings.Contains(ClaudeSessionAuthFailedMessage, "session") {
+		t.Fatalf("session-failure message lost its session framing:\n%s", ClaudeSessionAuthFailedMessage)
+	}
+	err := ClassifyClaudeCommandError(
+		subprocess.Result{Stderr: "401 Invalid authentication credentials"},
+		errors.New("exit 1"),
+	)
+	if err == nil || !strings.Contains(err.Error(), ClaudeSessionAuthFailedMessage) {
+		t.Fatalf("ClassifyClaudeCommandError must wrap the session message:\n%v", err)
+	}
+}
+
+// A missing/unexecutable claude binary is "probe unavailable", not an auth
+// failure — ClaudeProbeUnavailable distinguishes it so doctor never false-fails.
+func TestClaudeProbeUnavailableClassifiesMissingBinary(t *testing.T) {
+	runner := &fakeRunner{
+		errs: []error{&exec.Error{Name: "claude", Err: exec.ErrNotFound}},
+	}
+	err := ClaudeLiveCheck(context.Background(), runner, "/repo")
+	if err == nil {
+		t.Fatal("ClaudeLiveCheck accepted a missing binary")
+	}
+	if !ClaudeProbeUnavailable(err) {
+		t.Fatalf("missing binary not classified as probe-unavailable:\n%v", err)
+	}
+	authErr := ClassifyClaudeCommandError(
+		subprocess.Result{Stderr: "401 authentication_error"},
+		errors.New("exit 1"),
+	)
+	if ClaudeProbeUnavailable(authErr) {
+		t.Fatalf("auth failure must NOT be classified as probe-unavailable:\n%v", authErr)
+	}
+	if ClaudeProbeUnavailable(nil) {
+		t.Fatal("nil error must not be probe-unavailable")
 	}
 }
 


### PR DESCRIPTION
Addresses #414 (PR1). The non-live `gitmoot agent doctor` marked a claude agent `failed` purely on an **env-var** check (`InspectClaudeAuthEnv`), ignoring valid cached `~/.claude/.credentials.json` — a false negative with a misleading "set up a token" message, even though foreground auth works fine (HealthStatus is cosmetic, never gates dispatch).

## Fix (PR1 scope)
- **Live-probe fallback** (probe the real dependency, not a proxy): in `runAgentDoctor`'s not-Ready claude branch, run `ClaudeLiveCheck` (`claude -p`) — only in this branch (env-Ready boxes stay instant; no double-probe with `--live`). **Status matrix:** env-Ready → `ok`/0; not-Ready + probe ok → **`warn`/0** + background-token caveat (was `failed`/1); + probe auth/session fail → `failed`/1 + session message; + probe unavailable (binary missing) → `warn`/0 (never a *new* false-fail). The persisted `HealthStatus` now matches the printed `claude-auth-env` line.
- **Message split** (`claude_auth.go`): `ClaudeBackgroundTokenMessage` (foreground OK; daemon *background* jobs need a token in the daemon env) vs `ClaudeSessionAuthFailedMessage` (auth/session failed — re-auth & rebind). Repointed `adapter.go` (which wrongly reused the background message for real subprocess failures) to the session message. New `ClaudeProbeUnavailable(err)` distinguishes a missing/unexecutable `claude` binary from a genuine auth failure.

Reading `~/.claude/.credentials.json` was deliberately **rejected** (fragile proxy: schema/keychain drift + expired-but-present false positives) — the live probe is the authoritative, portable signal. Researcher-designed (k8s readiness/liveness best-practices), decided spec on the issue.

## Deferred (separate follow-ups, per the decided scope)
- The in-place rebind verb (`agent restart` / `agent start --force` relaxing the "already exists" guard).
- Aligning `internal/doctor/checker.go` + `internal/cli/plugin.go` env-only checks to the live probe.

## Verification
- Gate green: `go build/vet/test ./...` + `-race ./internal/workflow/` + `-race ./internal/cli/`.
- `TestRunAgentDoctorClaudeFailsWhenAuthEnvMissing` split via the `replaceAgentDoctorRunner` seam: warn-when-probe-ok, failed-when-probe-fails (session message), warn-when-probe-unavailable, ok-when-env-token-present; + the two messages differ + adapter uses the session message.
- Adversarial 2-lens review (correctness + safety/regression): **clean**.
- Live before/after E2E (two binaries on this tokenless+cached-creds box) in progress — pre-fix `failed`/exit-1 vs fixed `warn`/exit-0 via a real `claude -p` probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)