### PR TITLE
feat(cli): add 'agent restart' to rebind a dead runtime session in place (#414 PR2)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -101,7 +101,7 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent show <name> [--json]")
 	fmt.Fprintln(w, "  gitmoot agent list")
 	fmt.Fprintln(w, "  gitmoot agent remove <name>")
-	fmt.Fprintln(w, "  gitmoot agent restart <name>")
+	fmt.Fprintln(w, "  gitmoot agent restart <name>      # abandon + replace the runtime session (finish in-flight asks first)")
 	fmt.Fprintln(w, "  gitmoot agent doctor <name>")
 }
 
@@ -1784,9 +1784,14 @@ func runAgentRestart(args []string, stdout, stderr io.Writer) int {
 		record   db.Repo
 		cached   db.AgentTemplate
 	)
-	// Load + guards: resolve the existing agent and its checkout, and refuse a
-	// busy / live-session agent BEFORE calling adapter.Start. A guard failure
-	// must leave runtime_ref untouched and never start a session.
+	// Load + busy pre-flight: resolve the existing agent and its checkout, and
+	// refuse an agent with queued/running jobs BEFORE calling adapter.Start so a
+	// refusal leaves runtime_ref untouched and never starts a session. This is a
+	// best-effort pre-flight guard, NOT atomic with the rebind: the count and the
+	// later runtime_ref write happen in separate store sessions with adapter.Start
+	// between them, so a job enqueued in that window isn't re-checked. That is
+	// benign for this manual recovery verb — restart abandons and replaces the
+	// session rather than orphaning work.
 	if err := withStore(*home, func(store *db.Store) error {
 		var err error
 		existing, err = store.GetAgent(context.Background(), name)
@@ -1806,9 +1811,14 @@ func runAgentRestart(args []string, stdout, stderr io.Writer) int {
 		if active > 0 {
 			return fmt.Errorf("agent %s has %d queued or running job(s); cancel them first: %w", name, active, db.ErrAgentHasActiveJobs)
 		}
-		if err := runtimeSessionLockHeldByLivePID(context.Background(), store, runtimeAgent(existing)); err != nil {
-			return err
-		}
+		// No runtime-session-lock guard here: the production runtime:<rt>:<ref>
+		// session lock never records an OwnerPID (see acquireRuntimeSessionLock),
+		// so a live foreground `agent ask` can't be distinguished from a stranded
+		// lock at this layer. Restart doesn't need to: it mints a NEW session (new
+		// runtime_ref → new lock key), so any old/stranded runtime:<rt>:<oldref>
+		// lock is simply left to self-clear on its TTL. A real session guard
+		// (record OwnerPID+host on acquisition, then a same-host liveness check) is
+		// a separate follow-up. The jobs-busy check above is the effective guard.
 		record, err = store.GetRepo(context.Background(), existing.RepoScope)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
@@ -1851,30 +1861,8 @@ func runAgentRestart(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	fmt.Fprintf(stdout, "restarted %s (%s); session: %s\n", existing.Name, existing.Runtime, existing.RuntimeRef)
+	fmt.Fprintf(stdout, "note: this abandons and replaces %s's current runtime session; finish any in-flight foreground `agent ask` first\n", existing.Name)
 	return 0
-}
-
-// runtimeSessionLockHeldByLivePID refuses a restart when the foreground
-// runtime-session lock runtime:<rt>:<ref> is held by a live process — a
-// concurrent `agent ask` holds it without a DB job, so the jobs-busy check
-// alone would miss it. A held-but-dead lock (stranded PID) does NOT block:
-// restart is exactly the recovery for an abandoned session.
-func runtimeSessionLockHeldByLivePID(ctx context.Context, store *db.Store, agent runtime.Agent) error {
-	key, ok := runtimeSessionResourceKey(agent)
-	if !ok {
-		return nil
-	}
-	lock, err := store.GetResourceLock(ctx, key)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	if lock.OwnerPID > 0 && skillOptOwnerPIDLive(lock.OwnerPID) {
-		return fmt.Errorf("agent %s session %s is busy (held by live pid %d); wait for it to finish, then restart", agent.Name, agent.RuntimeRef, lock.OwnerPID)
-	}
-	return nil
 }
 
 func runAgentDoctor(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -27,6 +27,12 @@ var newRuntimeFactory = func() runtime.Factory {
 
 var agentDoctorRunner subprocess.Runner = subprocess.ExecRunner{}
 
+// runtimeStartAdapterFor builds the runtime adapter `agent restart` re-runs
+// Start on. It is a package var so tests can inject a fake adapter (the start
+// path's own seams generate runtime-specific refs that are hard to assert on);
+// production wires it straight to runtimeStartAdapter.
+var runtimeStartAdapterFor = runtimeStartAdapter
+
 func runAgent(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		printAgentUsage(stdout)
@@ -59,6 +65,8 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 		return runAgentList(args[1:], stdout, stderr)
 	case "remove":
 		return runAgentRemove(args[1:], stdout, stderr)
+	case "restart":
+		return runAgentRestart(args[1:], stdout, stderr)
 	case "doctor":
 		return runAgentDoctor(args[1:], stdout, stderr)
 	case "allow":
@@ -93,6 +101,7 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent show <name> [--json]")
 	fmt.Fprintln(w, "  gitmoot agent list")
 	fmt.Fprintln(w, "  gitmoot agent remove <name>")
+	fmt.Fprintln(w, "  gitmoot agent restart <name>")
 	fmt.Fprintln(w, "  gitmoot agent doctor <name>")
 }
 
@@ -1737,6 +1746,135 @@ func runAgentRemove(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "removed %s\n", name)
 	return 0
+}
+
+// runAgentRestart rebinds a registered agent to a fresh runtime session in
+// place: it re-runs adapter.Start for a new runtime_ref and persists ONLY that
+// ref plus health="unknown", preserving every other field by reading the
+// existing record, mutating two fields, and writing it back (UpsertAgent's
+// ON CONFLICT is a full-row PUT). Pure preservation — no override flags, no
+// rebuild-from-flags. The old session is abandoned, not torn down (the
+// runtime_ref is a local resume handle).
+func runAgentRestart(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent restart", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent restart requires exactly one name")
+			return 2
+		}
+		return 0
+	}
+	name := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent restart requires exactly one name")
+		return 2
+	}
+
+	var (
+		existing db.Agent
+		record   db.Repo
+		cached   db.AgentTemplate
+	)
+	// Load + guards: resolve the existing agent and its checkout, and refuse a
+	// busy / live-session agent BEFORE calling adapter.Start. A guard failure
+	// must leave runtime_ref untouched and never start a session.
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		existing, err = store.GetAgent(context.Background(), name)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("agent %q not found; use agent start to create it", name)
+		}
+		if err != nil {
+			return err
+		}
+		if existing.Runtime == runtime.ShellRuntime {
+			return fmt.Errorf("agent %q uses the shell runtime, which has no startable session", name)
+		}
+		active, err := store.AgentActiveJobCount(context.Background(), name)
+		if err != nil {
+			return err
+		}
+		if active > 0 {
+			return fmt.Errorf("agent %s has %d queued or running job(s); cancel them first: %w", name, active, db.ErrAgentHasActiveJobs)
+		}
+		if err := runtimeSessionLockHeldByLivePID(context.Background(), store, runtimeAgent(existing)); err != nil {
+			return err
+		}
+		record, err = store.GetRepo(context.Background(), existing.RepoScope)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if existing.TemplateID != "" {
+			cached, err = loadInstalledTemplate(context.Background(), store, existing.TemplateID)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent restart: %v\n", err)
+		return 1
+	}
+
+	adapter, err := runtimeStartAdapterFor(newRuntimeFactory(), existing.Runtime, record.CheckoutPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "load adapter: %v\n", err)
+		return 1
+	}
+	started, err := adapter.Start(context.Background(), runtime.StartRequest{
+		Agent:  runtimeAgent(existing),
+		Prompt: agentStartupPrompt(runtimeAgent(existing), cached),
+	})
+	if err != nil {
+		// adapter.Start failed: write NOTHING — runtime_ref + metadata stay as loaded.
+		fmt.Fprintf(stderr, "start runtime: %v\n", err)
+		return 1
+	}
+
+	// Rebind by read-modify-write: mutate ONLY runtime_ref + health on the
+	// already-loaded record so the full-row upsert preserves everything else.
+	existing.RuntimeRef = strings.TrimSpace(started.RuntimeRef)
+	existing.HealthStatus = "unknown"
+	if err := withStore(*home, func(store *db.Store) error {
+		return store.UpsertAgent(context.Background(), existing)
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent restart: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "restarted %s (%s); session: %s\n", existing.Name, existing.Runtime, existing.RuntimeRef)
+	return 0
+}
+
+// runtimeSessionLockHeldByLivePID refuses a restart when the foreground
+// runtime-session lock runtime:<rt>:<ref> is held by a live process — a
+// concurrent `agent ask` holds it without a DB job, so the jobs-busy check
+// alone would miss it. A held-but-dead lock (stranded PID) does NOT block:
+// restart is exactly the recovery for an abandoned session.
+func runtimeSessionLockHeldByLivePID(ctx context.Context, store *db.Store, agent runtime.Agent) error {
+	key, ok := runtimeSessionResourceKey(agent)
+	if !ok {
+		return nil
+	}
+	lock, err := store.GetResourceLock(ctx, key)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if lock.OwnerPID > 0 && skillOptOwnerPIDLive(lock.OwnerPID) {
+		return fmt.Errorf("agent %s session %s is busy (held by live pid %d); wait for it to finish, then restart", agent.Name, agent.RuntimeRef, lock.OwnerPID)
+	}
+	return nil
 }
 
 func runAgentDoctor(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/agent_restart_test.go
+++ b/internal/cli/agent_restart_test.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"os"
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
@@ -299,45 +297,5 @@ func TestRunAgentRestartStartFailsLeavesNoPartialWrite(t *testing.T) {
 	}
 	if got.HealthStatus != "failed" {
 		t.Fatalf("HealthStatus = %q, want unchanged failed (no partial write)", got.HealthStatus)
-	}
-}
-
-// T7 — the runtime-session lock runtime:<rt>:<ref> held by a LIVE pid blocks the
-// restart (a concurrent foreground `agent ask` with no DB job). We use the test
-// process's own pid as the guaranteed-live owner.
-func TestRunAgentRestartRejectsLiveSessionLock(t *testing.T) {
-	home := t.TempDir()
-	const r1 = "550e8400-e29b-41d4-a716-446655440041"
-	seedRestartAgent(t, home, "codex", r1)
-	func() {
-		store := openCLIJobStore(t, home)
-		defer store.Close()
-		acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
-			ResourceKey: "runtime:codex:" + r1,
-			OwnerJobID:  "foreground-ask",
-			OwnerToken:  "tok",
-			OwnerPID:    int64(os.Getpid()),
-			ExpiresAt:   time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
-		}, time.Now().UTC())
-		if err != nil || !acquired {
-			t.Fatalf("AcquireResourceLock acquired=%v err=%v", acquired, err)
-		}
-	}()
-
-	fake := &agentRestartFakeAdapter{newRef: "550e8400-e29b-41d4-a716-446655440042"}
-	replaceRuntimeStartAdapter(t, fake)
-
-	var stdout, stderr bytes.Buffer
-	if code := Run([]string{"agent", "restart", "rebind-me", "--home", home}, &stdout, &stderr); code != 1 {
-		t.Fatalf("restart exit code = %d, want 1; stderr=%s", code, stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "busy") {
-		t.Fatalf("stderr = %q, want live-session busy rejection", stderr.String())
-	}
-	if fake.calls() != 0 {
-		t.Fatalf("adapter.Start calls = %d, want 0 (live session must not be replaced)", fake.calls())
-	}
-	if got := getRestartAgent(t, home, "rebind-me"); got.RuntimeRef != r1 {
-		t.Fatalf("RuntimeRef = %q, want unchanged %q", got.RuntimeRef, r1)
 	}
 }

--- a/internal/cli/agent_restart_test.go
+++ b/internal/cli/agent_restart_test.go
@@ -1,0 +1,343 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// agentRestartFakeAdapter is a runtime.Adapter test double for `agent restart`:
+// it records whether Start was called and returns a deterministic, configurable
+// new runtime_ref (or an error). Runtime-agnostic — the adapter the restart path
+// builds is replaced wholesale via runtimeStartAdapterFor so codex/claude/kimi
+// all funnel through this one fake without depending on each adapter's
+// runtime-specific ref generation.
+type agentRestartFakeAdapter struct {
+	mu           sync.Mutex
+	name         string
+	newRef       string
+	startErr     error
+	startCalls   int
+	lastRequest  runtime.StartRequest
+	lastCheckout string
+}
+
+func (a *agentRestartFakeAdapter) Name() string {
+	if a.name != "" {
+		return a.name
+	}
+	return "fake"
+}
+
+func (a *agentRestartFakeAdapter) Start(_ context.Context, request runtime.StartRequest) (runtime.StartResult, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.startCalls++
+	a.lastRequest = request
+	if a.startErr != nil {
+		return runtime.StartResult{}, a.startErr
+	}
+	return runtime.StartResult{RuntimeRef: a.newRef}, nil
+}
+
+func (a *agentRestartFakeAdapter) calls() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.startCalls
+}
+
+func (a *agentRestartFakeAdapter) Validate(context.Context, runtime.Agent) error { return nil }
+
+func (a *agentRestartFakeAdapter) Deliver(context.Context, runtime.Agent, runtime.Job) (runtime.Result, error) {
+	return runtime.Result{}, nil
+}
+
+func (a *agentRestartFakeAdapter) Health(context.Context, runtime.Agent) error { return nil }
+
+func (a *agentRestartFakeAdapter) Capabilities(context.Context) ([]string, error) {
+	return []string{"ask", "review", "implement"}, nil
+}
+
+// replaceRuntimeStartAdapter swaps the restart path's adapter builder for one
+// that hands back the supplied fake and records the checkout it was asked for.
+func replaceRuntimeStartAdapter(t *testing.T, fake *agentRestartFakeAdapter) {
+	t.Helper()
+	previous := runtimeStartAdapterFor
+	runtimeStartAdapterFor = func(_ runtime.Factory, runtimeName string, checkout string) (runtime.Adapter, error) {
+		fake.mu.Lock()
+		fake.name = runtimeName
+		fake.lastCheckout = checkout
+		fake.mu.Unlock()
+		return fake, nil
+	}
+	t.Cleanup(func() { runtimeStartAdapterFor = previous })
+}
+
+// seedRestartAgent registers a fully-populated agent (every preserved field set
+// to a distinctive value) plus its repo, so a restart can resolve the checkout
+// and we can assert nothing but runtime_ref + health changes.
+func seedRestartAgent(t *testing.T, home, runtimeName, runtimeRef string) (db.Agent, string) {
+	t.Helper()
+	repoDir := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(context.Background(), db.Repo{
+		Owner:         "owner",
+		Name:          "repo",
+		DefaultBranch: "main",
+		CheckoutPath:  repoDir,
+		PollInterval:  "30s",
+	}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	agent := db.Agent{
+		Name:           "rebind-me",
+		Role:           "reviewer",
+		Runtime:        runtimeName,
+		RuntimeRef:     runtimeRef,
+		RepoScope:      "owner/repo",
+		Model:          "gpt-5.5",
+		Capabilities:   []string{"ask", "review"},
+		AutonomyPolicy: "workspace-write",
+		HealthStatus:   "failed",
+	}
+	if err := store.UpsertAgent(context.Background(), agent); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	return agent, repoDir
+}
+
+func getRestartAgent(t *testing.T, home, name string) db.Agent {
+	t.Helper()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	agent, err := store.GetAgent(context.Background(), name)
+	if err != nil {
+		t.Fatalf("GetAgent(%q) returned error: %v", name, err)
+	}
+	return agent
+}
+
+// T1 (LOAD-BEARING) — restart rebinds runtime_ref + resets health to "unknown"
+// while preserving role/repo_scope/model/capabilities/autonomy verbatim. This
+// fails against an implementation that rebuilds the agent from flags (it would
+// blank the metadata) or that skips the rebind (ref would stay R1).
+func TestRunAgentRestartPreservesMetadataAndRebindsSession(t *testing.T) {
+	home := t.TempDir()
+	const r1 = "550e8400-e29b-41d4-a716-446655440001"
+	const r2 = "550e8400-e29b-41d4-a716-446655440002"
+	seedRestartAgent(t, home, "codex", r1)
+
+	fake := &agentRestartFakeAdapter{newRef: r2}
+	replaceRuntimeStartAdapter(t, fake)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"agent", "restart", "rebind-me", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("restart exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if fake.calls() != 1 {
+		t.Fatalf("adapter.Start calls = %d, want 1", fake.calls())
+	}
+	if !strings.Contains(stdout.String(), "restarted rebind-me (codex); session: "+r2) {
+		t.Fatalf("restart output = %q", stdout.String())
+	}
+
+	got := getRestartAgent(t, home, "rebind-me")
+	if got.RuntimeRef != r2 {
+		t.Fatalf("RuntimeRef = %q, want %q (not rebound)", got.RuntimeRef, r2)
+	}
+	if got.HealthStatus != "unknown" {
+		t.Fatalf("HealthStatus = %q, want unknown", got.HealthStatus)
+	}
+	if got.Role != "reviewer" || got.RepoScope != "owner/repo" || got.Model != "gpt-5.5" ||
+		got.AutonomyPolicy != "workspace-write" || strings.Join(got.Capabilities, ",") != "ask,review" {
+		t.Fatalf("preserved metadata changed: %+v", got)
+	}
+}
+
+// T2 — a queued/running job blocks the restart: exit non-zero, the busy message
+// (ErrAgentHasActiveJobs), runtime_ref UNCHANGED, adapter.Start NOT called. This
+// is load-bearing for the busy guard: an implementation that skips it would
+// start a session and rebind.
+func TestRunAgentRestartRejectsBusyAgent(t *testing.T) {
+	home := t.TempDir()
+	const r1 = "550e8400-e29b-41d4-a716-446655440011"
+	seedRestartAgent(t, home, "codex", r1)
+	func() {
+		store := openCLIJobStore(t, home)
+		defer store.Close()
+		if err := store.CreateJob(context.Background(), db.Job{ID: "busy-job", Agent: "rebind-me", Type: "ask", State: "running", Payload: "{}"}); err != nil {
+			t.Fatalf("CreateJob returned error: %v", err)
+		}
+	}()
+
+	fake := &agentRestartFakeAdapter{newRef: "550e8400-e29b-41d4-a716-446655440012"}
+	replaceRuntimeStartAdapter(t, fake)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "restart", "rebind-me", "--home", home}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("restart exit code = 0, want non-zero; stdout=%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "cancel them first") {
+		t.Fatalf("stderr = %q, want busy message", stderr.String())
+	}
+	if fake.calls() != 0 {
+		t.Fatalf("adapter.Start calls = %d, want 0 (busy agent must not start a session)", fake.calls())
+	}
+	if got := getRestartAgent(t, home, "rebind-me"); got.RuntimeRef != r1 {
+		t.Fatalf("RuntimeRef = %q, want unchanged %q", got.RuntimeRef, r1)
+	}
+}
+
+// T3 — restarting a missing agent fails with the start-to-create hint.
+func TestRunAgentRestartRejectsMissingAgent(t *testing.T) {
+	home := t.TempDir()
+	fake := &agentRestartFakeAdapter{newRef: "x"}
+	replaceRuntimeStartAdapter(t, fake)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"agent", "restart", "ghost", "--home", home}, &stdout, &stderr); code != 1 {
+		t.Fatalf("restart exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not found; use agent start to create it") {
+		t.Fatalf("stderr = %q, want not-found hint", stderr.String())
+	}
+	if fake.calls() != 0 {
+		t.Fatalf("adapter.Start calls = %d, want 0", fake.calls())
+	}
+}
+
+// T4 — a shell-runtime agent has no startable session and is rejected.
+func TestRunAgentRestartRejectsShellRuntime(t *testing.T) {
+	home := t.TempDir()
+	func() {
+		store := openCLIJobStore(t, home)
+		defer store.Close()
+		if err := store.UpsertAgent(context.Background(), db.Agent{
+			Name:       "sheller",
+			Runtime:    runtime.ShellRuntime,
+			RuntimeRef: "echo hi",
+		}); err != nil {
+			t.Fatalf("UpsertAgent returned error: %v", err)
+		}
+	}()
+	fake := &agentRestartFakeAdapter{newRef: "x"}
+	replaceRuntimeStartAdapter(t, fake)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"agent", "restart", "sheller", "--home", home}, &stdout, &stderr); code != 1 {
+		t.Fatalf("restart exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "shell runtime") {
+		t.Fatalf("stderr = %q, want shell rejection", stderr.String())
+	}
+	if fake.calls() != 0 {
+		t.Fatalf("adapter.Start calls = %d, want 0", fake.calls())
+	}
+}
+
+// T5 — runtime-agnostic: T1's preserve+rebind holds for claude and kimi too.
+func TestRunAgentRestartRuntimeAgnostic(t *testing.T) {
+	for _, runtimeName := range []string{runtime.ClaudeRuntime, runtime.KimiRuntime} {
+		t.Run(runtimeName, func(t *testing.T) {
+			home := t.TempDir()
+			const r1 = "550e8400-e29b-41d4-a716-446655440021"
+			const r2 = "550e8400-e29b-41d4-a716-446655440022"
+			seedRestartAgent(t, home, runtimeName, r1)
+
+			fake := &agentRestartFakeAdapter{newRef: r2}
+			replaceRuntimeStartAdapter(t, fake)
+
+			var stdout, stderr bytes.Buffer
+			if code := Run([]string{"agent", "restart", "rebind-me", "--home", home}, &stdout, &stderr); code != 0 {
+				t.Fatalf("restart %s exit code = %d, stderr=%s", runtimeName, code, stderr.String())
+			}
+			if fake.calls() != 1 {
+				t.Fatalf("adapter.Start calls = %d, want 1", fake.calls())
+			}
+			got := getRestartAgent(t, home, "rebind-me")
+			if got.RuntimeRef != r2 || got.Runtime != runtimeName || got.HealthStatus != "unknown" {
+				t.Fatalf("agent = %+v, want runtime=%s ref=%s health=unknown", got, runtimeName, r2)
+			}
+			if got.Role != "reviewer" || got.Model != "gpt-5.5" || strings.Join(got.Capabilities, ",") != "ask,review" {
+				t.Fatalf("preserved metadata changed: %+v", got)
+			}
+		})
+	}
+}
+
+// T6 — adapter.Start failing writes NOTHING: runtime_ref AND health stay exactly
+// as loaded (no partial update). Load-bearing for the "write nothing on error"
+// invariant.
+func TestRunAgentRestartStartFailsLeavesNoPartialWrite(t *testing.T) {
+	home := t.TempDir()
+	const r1 = "550e8400-e29b-41d4-a716-446655440031"
+	seedRestartAgent(t, home, "codex", r1)
+
+	fake := &agentRestartFakeAdapter{startErr: errors.New("session backend exploded")}
+	replaceRuntimeStartAdapter(t, fake)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"agent", "restart", "rebind-me", "--home", home}, &stdout, &stderr); code != 1 {
+		t.Fatalf("restart exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if fake.calls() != 1 {
+		t.Fatalf("adapter.Start calls = %d, want 1", fake.calls())
+	}
+	got := getRestartAgent(t, home, "rebind-me")
+	if got.RuntimeRef != r1 {
+		t.Fatalf("RuntimeRef = %q, want unchanged %q (no partial write)", got.RuntimeRef, r1)
+	}
+	if got.HealthStatus != "failed" {
+		t.Fatalf("HealthStatus = %q, want unchanged failed (no partial write)", got.HealthStatus)
+	}
+}
+
+// T7 — the runtime-session lock runtime:<rt>:<ref> held by a LIVE pid blocks the
+// restart (a concurrent foreground `agent ask` with no DB job). We use the test
+// process's own pid as the guaranteed-live owner.
+func TestRunAgentRestartRejectsLiveSessionLock(t *testing.T) {
+	home := t.TempDir()
+	const r1 = "550e8400-e29b-41d4-a716-446655440041"
+	seedRestartAgent(t, home, "codex", r1)
+	func() {
+		store := openCLIJobStore(t, home)
+		defer store.Close()
+		acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+			ResourceKey: "runtime:codex:" + r1,
+			OwnerJobID:  "foreground-ask",
+			OwnerToken:  "tok",
+			OwnerPID:    int64(os.Getpid()),
+			ExpiresAt:   time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+		}, time.Now().UTC())
+		if err != nil || !acquired {
+			t.Fatalf("AcquireResourceLock acquired=%v err=%v", acquired, err)
+		}
+	}()
+
+	fake := &agentRestartFakeAdapter{newRef: "550e8400-e29b-41d4-a716-446655440042"}
+	replaceRuntimeStartAdapter(t, fake)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"agent", "restart", "rebind-me", "--home", home}, &stdout, &stderr); code != 1 {
+		t.Fatalf("restart exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "busy") {
+		t.Fatalf("stderr = %q, want live-session busy rejection", stderr.String())
+	}
+	if fake.calls() != 0 {
+		t.Fatalf("adapter.Start calls = %d, want 0 (live session must not be replaced)", fake.calls())
+	}
+	if got := getRestartAgent(t, home, "rebind-me"); got.RuntimeRef != r1 {
+		t.Fatalf("RuntimeRef = %q, want unchanged %q", got.RuntimeRef, r1)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -802,6 +802,18 @@ func (s *Store) RemoveAgent(ctx context.Context, name string) (bool, error) {
 // the message text.
 var ErrAgentHasActiveJobs = errors.New("agent has queued or running jobs")
 
+// AgentActiveJobCount returns how many queued or running jobs reference the
+// named agent. It is the shared busy check behind DeleteAgentChecked and the
+// `agent restart` rebind, so both refuse an agent with in-flight work using the
+// same query (callers wrap ErrAgentHasActiveJobs to classify the refusal).
+func (s *Store) AgentActiveJobCount(ctx context.Context, name string) (int, error) {
+	var active int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs WHERE agent = ? AND state IN ('queued', 'running')`, name).Scan(&active); err != nil {
+		return 0, err
+	}
+	return active, nil
+}
+
 // DeleteAgentChecked removes an agent (and its instances) unless queued or
 // running jobs still reference it, in which case it refuses (wrapping
 // ErrAgentHasActiveJobs) so in-flight work is never orphaned.

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -802,16 +802,31 @@ func (s *Store) RemoveAgent(ctx context.Context, name string) (bool, error) {
 // the message text.
 var ErrAgentHasActiveJobs = errors.New("agent has queued or running jobs")
 
-// AgentActiveJobCount returns how many queued or running jobs reference the
-// named agent. It is the shared busy check behind DeleteAgentChecked and the
-// `agent restart` rebind, so both refuse an agent with in-flight work using the
-// same query (callers wrap ErrAgentHasActiveJobs to classify the refusal).
-func (s *Store) AgentActiveJobCount(ctx context.Context, name string) (int, error) {
+// rowQuerier is the QueryRowContext shape shared by *sql.DB and *sql.Tx, so
+// countActiveJobsTx can run on either a plain connection or inside a transaction.
+type rowQuerier interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// countActiveJobsTx is the single source of the queued/running busy count for an
+// agent. Both AgentActiveJobCount (own connection) and DeleteAgentChecked (inside
+// its delete transaction) call it, so the SQL and the ('queued','running') state
+// list live in exactly one place and can't drift.
+func countActiveJobsTx(ctx context.Context, q rowQuerier, name string) (int, error) {
 	var active int
-	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs WHERE agent = ? AND state IN ('queued', 'running')`, name).Scan(&active); err != nil {
+	if err := q.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs WHERE agent = ? AND state IN ('queued', 'running')`, name).Scan(&active); err != nil {
 		return 0, err
 	}
 	return active, nil
+}
+
+// AgentActiveJobCount returns how many queued or running jobs reference the
+// named agent. It is the restart rebind's busy pre-flight; it shares its query
+// with DeleteAgentChecked via countActiveJobsTx so both refuse an agent with
+// in-flight work identically (callers wrap ErrAgentHasActiveJobs to classify the
+// refusal).
+func (s *Store) AgentActiveJobCount(ctx context.Context, name string) (int, error) {
+	return countActiveJobsTx(ctx, s.db, name)
 }
 
 // DeleteAgentChecked removes an agent (and its instances) unless queued or
@@ -827,8 +842,11 @@ func (s *Store) DeleteAgentChecked(ctx context.Context, name string) error {
 		return err
 	}
 	defer tx.Rollback()
-	var active int
-	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs WHERE agent = ? AND state IN ('queued', 'running')`, name).Scan(&active); err != nil {
+	// Same query as AgentActiveJobCount, but run on tx so the check + the deletes
+	// below stay in one transaction (atomic). countActiveJobsTx is the shared
+	// source of the SQL/state-list.
+	active, err := countActiveJobsTx(ctx, tx, name)
+	if err != nil {
 		return err
 	}
 	if active > 0 {


### PR DESCRIPTION
Part of #414 (PR2). Adds **`gitmoot agent restart <name>`** so an operator can rebind a registered agent to a **fresh runtime session** (new `runtime_ref`) without losing its metadata — instead of today's only recovery (`agent remove` + recreate, which loses role/repo/template/capabilities/model/autonomy).

## What it does
- New name-only verb (in the `remove`/`doctor` family), **not** `start --force` (which builds the agent from flags — the create path that would overwrite metadata).
- **Read-modify-write** (because `UpsertAgent` ON CONFLICT is a full-row PUT): loads the existing agent, re-runs `adapter.Start` for a fresh `runtime_ref`, then persists with **only** `RuntimeRef` + `HealthStatus("unknown")` changed — all other metadata preserved verbatim.
- **Guards:** not-found (`use agent start to create it`), shell runtime (no startable session), and **busy** (queued/running jobs → `ErrAgentHasActiveJobs`, "cancel them first"). On `adapter.Start` error → exit 1, **writes nothing** (no partial update).
- **Runtime-agnostic** (claude/codex/kimi). **Abandon-and-replace** the old session (the `runtime_ref` is a local resume handle — no teardown; any old/stranded `runtime:<rt>:<ref>` lock self-clears on its TTL since restart mints a new session/lock key). `adapter.Start` runs foreground, so **cached creds suffice** — `restart` works on a tokenless box where daemon background dispatch can't.

Researcher-designed (systemd/kubectl `restart` semantics; RFC 5789 PATCH-via-read-modify-write), decided spec on the issue.

## Scope / deferred
- Busy-count SQL is factored into one tx-aware helper (`countActiveJobsTx`) shared by `restart` and `DeleteAgentChecked` (its atomicity unchanged).
- **Pure preservation** — no override flags. Help + success output note that restart abandons the current session (finish in-flight foreground `agent ask`s first); the busy guard is a best-effort pre-flight check for a manual verb (not atomic with the rebind).
- **Deliberately NOT included** (left for review): a *functional* session-lock guard that refuses while a live foreground `agent ask` holds the session — it requires recording `OwnerPID`+host on runtime-session-lock acquisition + a same-host liveness check; tracked as a follow-up. (A first attempt at this guard was non-functional — runtime-session locks don't record `OwnerPID` — so it was removed rather than shipped as dead code.)
- **PR3 (separate, #414 stays open):** align `internal/doctor/checker.go` + `internal/cli/plugin.go` env-only auth checks to the live probe (as PR1 did for `agent doctor`).

## Verification
- Gate green: `go build/vet/test ./...` + `-race ./internal/workflow/` + `-race ./internal/cli/`.
- Tests (fake-adapter + temp-store seams): preserve-metadata + rebind (load-bearing), reject-busy (load-bearing), not-found, shell-rejected, runtime-agnostic (claude/kimi), start-fails-no-partial-write. `DeleteAgentChecked` stays green/byte-identical.
- 2-lens adversarial review → **clean** after a fix round (removed a non-functional session-lock guard the first pass shipped; genuinely shared the busy-count SQL).
- Live E2E in progress: real `adapter.Start` rebind on a throwaway home → fresh `runtime_ref` + preserved metadata + a working `agent ask` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)