### PR TITLE
fix(doctor): live-probe claude auth in gitmoot/plugin doctor instead of env-only false-warn (#414 PR3)

### DIFF
--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -435,7 +435,9 @@ func doctorRuntime(home string, provider pluginpack.Provider, explicitRuntime bo
 	runtime.Checks = append(runtime.Checks, checkMarketplacePath(home, provider))
 	runtime.Checks = append(runtime.Checks, checkRuntimeCLI(provider, explicitRuntime))
 	if provider == pluginpack.ProviderClaude {
-		runtime.Checks = append(runtime.Checks, checkClaudeAuthEnv())
+		// When --live is set, checkClaudeLive already runs the authoritative
+		// claude -p probe, so the auth-env check stays env-only (no second probe).
+		runtime.Checks = append(runtime.Checks, checkClaudeAuthEnv(live))
 		if live {
 			runtime.Checks = append(runtime.Checks, checkClaudeLive())
 		}
@@ -530,16 +532,39 @@ func checkRuntimeCLI(provider pluginpack.Provider, explicitRuntime bool) pluginC
 	return okCheck("runtime-cli", path, true)
 }
 
-func checkClaudeAuthEnv() pluginCheck {
+func checkClaudeAuthEnv(live bool) pluginCheck {
 	auth := gitmootruntime.InspectClaudeAuthEnv(os.LookupEnv)
-	detail := auth.MaskedDetail()
-	if warning := auth.Warning(); warning != "" {
-		detail += "; " + warning
+	masked := auth.MaskedDetail()
+	if auth.Ready() {
+		detail := masked
+		if warning := auth.Warning(); warning != "" {
+			detail += "; " + warning
+		}
+		if auth.Warning() == "" {
+			return okCheck("runtime-auth-env", detail, false)
+		}
+		return warnCheck("runtime-auth-env", detail, false)
 	}
-	if auth.Ready() && auth.Warning() == "" {
-		return okCheck("runtime-auth-env", detail, false)
+	if live {
+		// checkClaudeLive runs the authoritative probe in the --live path; keep
+		// the auth-env check env-only here so we don't spawn claude twice.
+		return warnCheck("runtime-auth-env", masked+"; "+gitmootruntime.ClaudeBackgroundTokenMessage, false)
 	}
-	return warnCheck("runtime-auth-env", detail, false)
+	// Env not Ready does not mean auth is broken: foreground Claude may
+	// authenticate fine via cached ~/.claude credentials. `plugin doctor` is an
+	// operator one-shot (infrequent), so probe the real dependency (claude -p)
+	// instead of false-warning on the env check. A successful probe reports ok
+	// with the background-token caveat; a missing binary stays warn (the runtime
+	// CLI presence check already covers absence); a genuine auth/session failure
+	// stays warn (this is a non-required runtime-auth check) with the session
+	// message. The `--live` checkClaudeLive path is unchanged.
+	if err := gitmootruntime.ClaudeLiveCheck(context.Background(), pluginDoctorRunner, ""); err != nil {
+		if gitmootruntime.ClaudeProbeUnavailable(err) {
+			return warnCheck("runtime-auth-env", masked+"; "+gitmootruntime.ClaudeBackgroundTokenMessage+" (probe unavailable)", false)
+		}
+		return warnCheck("runtime-auth-env", masked+"; "+gitmootruntime.ClaudeSessionAuthFailedMessage, false)
+	}
+	return okCheck("runtime-auth-env", masked+"; "+gitmootruntime.ClaudeBackgroundTokenMessage, false)
 }
 
 func formatCodexLaunchCommand(cli string, repo string, gitmootHome string, shell string) string {

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -382,7 +383,12 @@ func TestRunPluginDoctorClaudeReportsMaskedAuthEnv(t *testing.T) {
 	}
 }
 
-func TestRunPluginDoctorClaudeWarnsWhenAuthEnvMissing(t *testing.T) {
+// TestRunPluginDoctorClaudeProbesOKWhenAuthEnvMissing is the load-bearing PR3
+// flip: with no env token but a successful live `claude -p` probe, the
+// runtime-auth-env check reports OK (was a false-negative "warn" under the
+// env-only InspectClaudeAuthEnv behavior). Reverting checkClaudeAuthEnv to the
+// env-only check makes this assert ok->fail.
+func TestRunPluginDoctorClaudeProbesOKWhenAuthEnvMissing(t *testing.T) {
 	withClaudeAuthEnv(t, nil)
 	home := t.TempDir()
 	if _, err := pluginpack.Build(pluginpack.BuildOptions{
@@ -393,6 +399,9 @@ func TestRunPluginDoctorClaudeWarnsWhenAuthEnvMissing(t *testing.T) {
 	}
 	restore := stubPluginLookPath(map[string]string{"claude": "/tmp/bin/claude"})
 	defer restore()
+	runner := &agentStartRunner{results: []subprocess.Result{{Stdout: `{"result":"OK"}`}}}
+	restoreRunner := replacePluginDoctorRunner(runner)
+	defer restoreRunner()
 
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{"plugin", "doctor", "claude", "--home", home, "--json"}, &stdout, &stderr)
@@ -405,11 +414,126 @@ func TestRunPluginDoctorClaudeWarnsWhenAuthEnvMissing(t *testing.T) {
 		t.Fatalf("doctor JSON did not parse: %v\n%s", err, stdout.String())
 	}
 	check := findDoctorCheck(t, output.Runtimes[0].Checks, "runtime-auth-env")
+	if check.Status != "ok" {
+		t.Fatalf("runtime-auth-env status = %q, want ok; checks=%+v", check.Status, output.Runtimes[0].Checks)
+	}
+	if !strings.Contains(check.Detail, runtime.ClaudeBackgroundTokenMessage) {
+		t.Fatalf("runtime-auth-env detail = %q, want background-token caveat", check.Detail)
+	}
+	// The default (no --live) check live-probes via claude -p in the not-Ready branch.
+	runner.want(t, 0, "", "claude", "-p", "--output-format", "json", "--", runtime.ClaudeLiveCheckPrompt)
+}
+
+func TestRunPluginDoctorClaudeWarnsWhenAuthEnvMissingAndProbeFails(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	home := t.TempDir()
+	if _, err := pluginpack.Build(pluginpack.BuildOptions{
+		Provider: pluginpack.ProviderClaude,
+		Home:     filepath.Join(home, ".gitmoot"),
+	}); err != nil {
+		t.Fatalf("build claude package: %v", err)
+	}
+	restore := stubPluginLookPath(map[string]string{"claude": "/tmp/bin/claude"})
+	defer restore()
+	runner := &agentStartRunner{
+		results: []subprocess.Result{{Stderr: "401 Invalid authentication credentials"}},
+		errs:    []error{errors.New("exit 1")},
+	}
+	restoreRunner := replacePluginDoctorRunner(runner)
+	defer restoreRunner()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "doctor", "claude", "--home", home, "--json"}, &stdout, &stderr)
+
+	// runtime-auth-env is non-required, so a failed probe is still a warn (exit 0),
+	// but with the session-failure message, not the background-token caveat.
+	if code != 0 {
+		t.Fatalf("plugin doctor exit code = %d, stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	var output pluginDoctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("doctor JSON did not parse: %v\n%s", err, stdout.String())
+	}
+	check := findDoctorCheck(t, output.Runtimes[0].Checks, "runtime-auth-env")
 	if check.Status != "warn" {
 		t.Fatalf("runtime-auth-env status = %q, want warn; checks=%+v", check.Status, output.Runtimes[0].Checks)
 	}
-	if !strings.Contains(check.Detail, "claude setup-token") {
-		t.Fatalf("runtime-auth-env detail = %q, want setup-token guidance", check.Detail)
+	if !strings.Contains(check.Detail, runtime.ClaudeSessionAuthFailedMessage) {
+		t.Fatalf("runtime-auth-env detail = %q, want session-failure message", check.Detail)
+	}
+}
+
+func TestRunPluginDoctorClaudeWarnsWhenAuthEnvMissingAndProbeUnavailable(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	home := t.TempDir()
+	if _, err := pluginpack.Build(pluginpack.BuildOptions{
+		Provider: pluginpack.ProviderClaude,
+		Home:     filepath.Join(home, ".gitmoot"),
+	}); err != nil {
+		t.Fatalf("build claude package: %v", err)
+	}
+	restore := stubPluginLookPath(map[string]string{"claude": "/tmp/bin/claude"})
+	defer restore()
+	runner := &agentStartRunner{
+		errs: []error{&exec.Error{Name: "claude", Err: exec.ErrNotFound}},
+	}
+	restoreRunner := replacePluginDoctorRunner(runner)
+	defer restoreRunner()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "doctor", "claude", "--home", home, "--json"}, &stdout, &stderr)
+
+	// A missing/unrunnable binary is never a new false-fail: it stays a warn
+	// (the runtime-cli presence check already covers absence).
+	if code != 0 {
+		t.Fatalf("plugin doctor exit code = %d, stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	var output pluginDoctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("doctor JSON did not parse: %v\n%s", err, stdout.String())
+	}
+	check := findDoctorCheck(t, output.Runtimes[0].Checks, "runtime-auth-env")
+	if check.Status != "warn" {
+		t.Fatalf("runtime-auth-env status = %q, want warn; checks=%+v", check.Status, output.Runtimes[0].Checks)
+	}
+	if !strings.Contains(check.Detail, "probe unavailable") {
+		t.Fatalf("runtime-auth-env detail = %q, want probe-unavailable caveat", check.Detail)
+	}
+}
+
+// TestRunPluginDoctorClaudeOKWhenAuthEnvSetSkipsProbe asserts the env-Ready
+// fast path stays instant: the runner is never consulted.
+func TestRunPluginDoctorClaudeOKWhenAuthEnvSetSkipsProbe(t *testing.T) {
+	withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
+	home := t.TempDir()
+	if _, err := pluginpack.Build(pluginpack.BuildOptions{
+		Provider: pluginpack.ProviderClaude,
+		Home:     filepath.Join(home, ".gitmoot"),
+	}); err != nil {
+		t.Fatalf("build claude package: %v", err)
+	}
+	restore := stubPluginLookPath(map[string]string{"claude": "/tmp/bin/claude"})
+	defer restore()
+	runner := &agentStartRunner{}
+	restoreRunner := replacePluginDoctorRunner(runner)
+	defer restoreRunner()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"plugin", "doctor", "claude", "--home", home, "--json"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("plugin doctor exit code = %d, stderr=%s\nstdout=%s", code, stderr.String(), stdout.String())
+	}
+	var output pluginDoctorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("doctor JSON did not parse: %v\n%s", err, stdout.String())
+	}
+	check := findDoctorCheck(t, output.Runtimes[0].Checks, "runtime-auth-env")
+	if check.Status != "ok" {
+		t.Fatalf("runtime-auth-env status = %q, want ok; checks=%+v", check.Status, output.Runtimes[0].Checks)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("env-Ready path consulted the runner (%d calls), want no probe", len(runner.calls))
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -125,7 +125,11 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	checks := doctor.Checker{Dir: *repoDir}.Run(context.Background())
+	// The one-shot `gitmoot doctor` opts into the live claude probe (LiveProbe)
+	// so a cached-creds box is reported accurately rather than false-warned. The
+	// dashboard (dashboard_tui.go) leaves LiveProbe false so its refresh loop
+	// never spawns claude.
+	checks := doctor.Checker{Dir: *repoDir, LiveProbe: true}.Run(context.Background())
 	for _, check := range checks {
 		status := "ok"
 		if !check.OK {

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -21,6 +21,13 @@ type Check struct {
 type Checker struct {
 	Dir    string
 	Runner subprocess.Runner
+	// LiveProbe opts the claude auth check into a live `claude -p` probe when the
+	// auth env is not Ready, instead of false-reporting OK:false on a cached-creds
+	// box. It is opt-in because GlobalChecks is re-run on every dashboard refresh
+	// (dashboard_tui.go) and an unconditional probe would spawn claude each time.
+	// The one-shot `gitmoot doctor` (root.go) sets this true; the dashboard leaves
+	// it false so a refresh never spawns claude.
+	LiveProbe bool
 }
 
 // Run returns the global (cwd-independent) checks followed by the per-repo
@@ -42,7 +49,7 @@ func (c Checker) GlobalChecks(ctx context.Context) []Check {
 		c.command(ctx, runner, "codex", true, "--version"),
 		c.command(ctx, runner, "claude", false, "--help"),
 		c.command(ctx, runner, "kimi", false, "--version"),
-		c.claudeAuthEnv(),
+		c.claudeAuthEnv(ctx),
 		c.ghAuth(ctx, runner),
 	}
 }
@@ -118,13 +125,38 @@ func (c Checker) baseBranch(ctx context.Context, runner subprocess.Runner, dir s
 	return Check{Name: "base branch", OK: true, Required: true, Detail: branch}
 }
 
-func (c Checker) claudeAuthEnv() Check {
+func (c Checker) claudeAuthEnv(ctx context.Context) Check {
 	auth := runtime.InspectClaudeAuthEnv(os.LookupEnv)
-	detail := auth.MaskedDetail()
-	if warning := auth.Warning(); warning != "" {
-		detail += "; " + warning
+	masked := auth.MaskedDetail()
+	if auth.Ready() {
+		detail := masked
+		if warning := auth.Warning(); warning != "" {
+			detail += "; " + warning
+		}
+		return Check{Name: "claude auth", OK: true, Required: false, Detail: detail}
 	}
-	return Check{Name: "claude auth", OK: auth.Ready(), Required: false, Detail: detail}
+	// Env not Ready does not mean auth is broken: foreground Claude may
+	// authenticate fine via cached ~/.claude credentials. The dashboard path
+	// (LiveProbe false) keeps the env-only warn — it must never spawn claude per
+	// refresh. The one-shot `gitmoot doctor` (LiveProbe true) probes the real
+	// dependency (claude -p) so a cached-creds box reports OK instead of a
+	// false-negative warn.
+	if !c.LiveProbe {
+		detail := masked
+		if warning := auth.Warning(); warning != "" {
+			detail += "; " + warning
+		}
+		return Check{Name: "claude auth", OK: false, Required: false, Detail: detail}
+	}
+	if err := runtime.ClaudeLiveCheck(ctx, c.runner(), ""); err != nil {
+		if runtime.ClaudeProbeUnavailable(err) {
+			// Missing/unrunnable binary is not an auth regression; the claude CLI
+			// presence check already covers it. Keep it a non-required warn.
+			return Check{Name: "claude auth", OK: false, Required: false, Detail: masked + "; " + runtime.ClaudeBackgroundTokenMessage + " (probe unavailable)"}
+		}
+		return Check{Name: "claude auth", OK: false, Required: false, Detail: masked + "; " + runtime.ClaudeSessionAuthFailedMessage}
+	}
+	return Check{Name: "claude auth", OK: true, Required: false, Detail: masked + "; " + runtime.ClaudeBackgroundTokenMessage}
 }
 
 func FailedRequired(checks []Check) error {

--- a/internal/doctor/checker_test.go
+++ b/internal/doctor/checker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -89,6 +90,125 @@ func TestCheckerWarnsWhenClaudeAuthEnvMissing(t *testing.T) {
 		}
 	}
 	t.Fatalf("checks missing claude auth: %+v", checks)
+}
+
+// claudeProbeKey is the fakeRunner key for the live claude -p JSON probe that
+// ClaudeLiveCheck issues.
+var claudeProbeKey = "claude -p --output-format json -- " + runtime.ClaudeLiveCheckPrompt
+
+// countingRunner wraps fakeRunner and records every Run invocation so a test can
+// assert the probe never fired (the dashboard / env-Ready paths).
+type countingRunner struct {
+	fakeRunner
+	runs *int
+}
+
+func (r countingRunner) Run(ctx context.Context, dir, command string, args ...string) (subprocess.Result, error) {
+	*r.runs++
+	return r.fakeRunner.Run(ctx, dir, command, args...)
+}
+
+// TestClaudeAuthEnvLiveProbeOKFlipsWarnToOK is the load-bearing PR3 flip: with
+// no env token but a successful live probe, LiveProbe reports OK:true (the
+// env-only behavior returned OK:false). Reverting claudeAuthEnv to env-only
+// makes this assert OK:true -> false.
+func TestClaudeAuthEnvLiveProbeOKFlipsWarnToOK(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	runs := 0
+	runner := countingRunner{
+		fakeRunner: fakeRunner{
+			runs: map[string]subprocess.Result{claudeProbeKey: {Stdout: `{"result":"OK"}`}},
+		},
+		runs: &runs,
+	}
+	check := Checker{Runner: runner, LiveProbe: true}.claudeAuthEnv(context.Background())
+	if !check.OK || check.Required {
+		t.Fatalf("claude auth check = %+v, want OK:true non-required", check)
+	}
+	if !strings.Contains(check.Detail, runtime.ClaudeBackgroundTokenMessage) {
+		t.Fatalf("claude auth detail = %q, want background-token caveat", check.Detail)
+	}
+	if runs != 1 {
+		t.Fatalf("probe ran %d times, want exactly 1", runs)
+	}
+}
+
+func TestClaudeAuthEnvLiveProbeFailIsNotOK(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	runner := fakeRunner{
+		runs: map[string]subprocess.Result{claudeProbeKey: {Stderr: "401 Invalid authentication credentials"}},
+		errs: map[string]error{claudeProbeKey: fmt.Errorf("exit 1")},
+	}
+	check := Checker{Runner: runner, LiveProbe: true}.claudeAuthEnv(context.Background())
+	if check.OK {
+		t.Fatalf("claude auth check = %+v, want OK:false on probe failure", check)
+	}
+	if !strings.Contains(check.Detail, runtime.ClaudeSessionAuthFailedMessage) {
+		t.Fatalf("claude auth detail = %q, want session-failure message", check.Detail)
+	}
+}
+
+func TestClaudeAuthEnvLiveProbeUnavailableWarns(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	runner := fakeRunner{
+		errs: map[string]error{claudeProbeKey: &exec.Error{Name: "claude", Err: exec.ErrNotFound}},
+	}
+	check := Checker{Runner: runner, LiveProbe: true}.claudeAuthEnv(context.Background())
+	if check.OK || check.Required {
+		t.Fatalf("claude auth check = %+v, want OK:false non-required (probe unavailable)", check)
+	}
+	if !strings.Contains(check.Detail, "probe unavailable") {
+		t.Fatalf("claude auth detail = %q, want probe-unavailable caveat", check.Detail)
+	}
+	if !strings.Contains(check.Detail, runtime.ClaudeBackgroundTokenMessage) {
+		t.Fatalf("claude auth detail = %q, want background-token caveat", check.Detail)
+	}
+}
+
+// TestClaudeAuthEnvDashboardNeverProbes guards the critical invariant: the
+// dashboard path (LiveProbe false) reports the env-only warn WITHOUT consulting
+// the runner — so a dashboard refresh never spawns claude.
+func TestClaudeAuthEnvDashboardNeverProbes(t *testing.T) {
+	withClaudeAuthEnv(t, nil)
+	runs := 0
+	// A runner that returns success if ever called for the probe — proving the
+	// dashboard path does not run it (otherwise OK would flip to true).
+	runner := countingRunner{
+		fakeRunner: fakeRunner{
+			runs: map[string]subprocess.Result{claudeProbeKey: {Stdout: `{"result":"OK"}`}},
+		},
+		runs: &runs,
+	}
+	check := Checker{Runner: runner, LiveProbe: false}.claudeAuthEnv(context.Background())
+	if check.OK {
+		t.Fatalf("claude auth check = %+v, want OK:false (env-only warn, no probe)", check)
+	}
+	if runs != 0 {
+		t.Fatalf("dashboard path ran the runner %d times, want 0 (must never spawn claude)", runs)
+	}
+	if !strings.Contains(check.Detail, runtime.ClaudeBackgroundTokenMessage) {
+		t.Fatalf("claude auth detail = %q, want background-token caveat", check.Detail)
+	}
+}
+
+func TestClaudeAuthEnvReadySkipsProbe(t *testing.T) {
+	withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
+	runs := 0
+	runner := countingRunner{
+		fakeRunner: fakeRunner{
+			runs: map[string]subprocess.Result{claudeProbeKey: {Stderr: "should not run"}},
+			errs: map[string]error{claudeProbeKey: fmt.Errorf("should not run")},
+		},
+		runs: &runs,
+	}
+	// Even with LiveProbe true, an env token present takes the instant path.
+	check := Checker{Runner: runner, LiveProbe: true}.claudeAuthEnv(context.Background())
+	if !check.OK {
+		t.Fatalf("claude auth check = %+v, want OK:true when env token present", check)
+	}
+	if runs != 0 {
+		t.Fatalf("env-Ready path ran the runner %d times, want 0", runs)
+	}
 }
 
 func TestCheckerRunsGlobalChecksOutsideRepoDir(t *testing.T) {


### PR DESCRIPTION
Closes #414 (PR3 — the last piece). PR1 fixed `agent doctor`; this aligns the two remaining env-only claude-auth checks to the same live-probe pattern, **cost-aware** so the dashboard never spawns claude.

## What
- **`internal/cli/plugin.go` `checkClaudeAuthEnv`** (`gitmoot plugin doctor`, operator one-shot): when env is not-Ready, live-probe via the existing `pluginDoctorRunner` seam → `ok`+caveat (probe ok) / `warn`+"(probe unavailable)" / `warn`+session-message (probe fail). The env-Ready fast path and the `--live`/`checkClaudeLive` path are unchanged (a new `live bool` param keeps `plugin doctor --live` from double-spawning claude — the authoritative probe stays in `checkClaudeLive`).
- **`internal/doctor/checker.go`**: added **opt-in `Checker.LiveProbe bool`**. `claudeAuthEnv(ctx)` probes **only** when `LiveProbe` is set: probe ok → `OK:true`+`ClaudeBackgroundTokenMessage`; probe fail → `OK:false`+`ClaudeSessionAuthFailedMessage`; probe unavailable → `OK:false`+caveat. The one-shot `gitmoot doctor` (`root.go:128`) sets `LiveProbe:true`; **the dashboard (`dashboard_tui.go:451`) is unchanged** (`LiveProbe` defaults false) so its per-refresh `HealthChecks` never spawns claude — proven by `TestClaudeAuthEnvDashboardNeverProbes` (a counting runner asserts 0 invocations).

Reuses PR1's `ClaudeLiveCheck` / `ClaudeProbeUnavailable` / `ClaudeBackgroundTokenMessage` / `ClaudeSessionAuthFailedMessage` (unmodified). An env-Ready box never probes (no latency regression).

## Verification
- Gate green: `go build/vet/test ./...` + `-race ./internal/workflow/` + `-race ./internal/cli/` + `./internal/doctor/`.
- 9 tests (checker + plugin), several load-bearing (probe-ok flips `OK` false→true; messages asserted; the dashboard-never-probes counting-runner test).
- 2-lens adversarial review (correctness + safety/dashboard-cost): **clean** on the first pass.
- **Live smoke:** the fixed `gitmoot doctor` on a tokenless+cached-creds box now reports `claude auth  ok` (the real `claude -p` probe succeeded) with the background-token caveat — where pre-fix it was an env-only warn.

## Closes out #414
PR1 (live-probe `agent doctor`) + PR2 (`agent restart`) + PR3 (this) resolve the issue. One minor, code-grounded follow-up was noted on the issue during PR2 (a *functional* session-lock guard for `agent restart`, which needs `OwnerPID`/host recorded on runtime-session-lock acquisition) — tracked separately as a small enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)