### PR TITLE
feat(cli): record OwnerPID+host on runtime-session locks so 'agent restart' refuses a live session (#425)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1811,14 +1811,21 @@ func runAgentRestart(args []string, stdout, stderr io.Writer) int {
 		if active > 0 {
 			return fmt.Errorf("agent %s has %d queued or running job(s); cancel them first: %w", name, active, db.ErrAgentHasActiveJobs)
 		}
-		// No runtime-session-lock guard here: the production runtime:<rt>:<ref>
-		// session lock never records an OwnerPID (see acquireRuntimeSessionLock),
-		// so a live foreground `agent ask` can't be distinguished from a stranded
-		// lock at this layer. Restart doesn't need to: it mints a NEW session (new
-		// runtime_ref → new lock key), so any old/stranded runtime:<rt>:<oldref>
-		// lock is simply left to self-clear on its TTL. A real session guard
-		// (record OwnerPID+host on acquisition, then a same-host liveness check) is
-		// a separate follow-up. The jobs-busy check above is the effective guard.
+		// Functional session-lock guard (#425): a live foreground `agent ask` holds
+		// the runtime:<rt>:<ref> session lock WITHOUT a DB job, so the jobs-busy
+		// check above can't see it. Refuse only a provably-LIVE same-host owner —
+		// restarting under a live session would clobber it. A stranded (dead-owner)
+		// or expired or absent lock does NOT block: restart is exactly the recovery
+		// for an abandoned session (and it mints a new runtime_ref → new lock key,
+		// so it never touches the old lock). This is the inverse of the #303
+		// generation-lock reclaim, which steals only a provably-dead/expired lock.
+		held, detail, err := runtimeSessionHeldByLiveOwner(context.Background(), store, runtimeAgent(existing))
+		if err != nil {
+			return err
+		}
+		if held {
+			return fmt.Errorf("a foreground runtime session for %s is in use (%s); finish or cancel it first", name, detail)
+		}
 		record, err = store.GetRepo(context.Background(), existing.RepoScope)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
@@ -1861,7 +1868,7 @@ func runAgentRestart(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	fmt.Fprintf(stdout, "restarted %s (%s); session: %s\n", existing.Name, existing.Runtime, existing.RuntimeRef)
-	fmt.Fprintf(stdout, "note: this abandons and replaces %s's current runtime session; finish any in-flight foreground `agent ask` first\n", existing.Name)
+	fmt.Fprintf(stdout, "note: this abandons and replaces %s's current runtime session; restart refuses while a live foreground `agent ask` holds it, but recovers a stranded one\n", existing.Name)
 	return 0
 }
 

--- a/internal/cli/agent_restart_test.go
+++ b/internal/cli/agent_restart_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
@@ -297,5 +299,172 @@ func TestRunAgentRestartStartFailsLeavesNoPartialWrite(t *testing.T) {
 	}
 	if got.HealthStatus != "failed" {
 		t.Fatalf("HealthStatus = %q, want unchanged failed (no partial write)", got.HealthStatus)
+	}
+}
+
+// runtimeAgentForRef builds the runtime.Agent whose runtime:<rt>:<ref> session
+// key a seeded "rebind-me" agent maps to — used to drive the REAL
+// acquireRuntimeSessionLock at the exact key the restart guard inspects.
+func runtimeAgentForRef(runtimeName, runtimeRef string) runtime.Agent {
+	return runtime.Agent{Name: "rebind-me", Runtime: runtimeName, RuntimeRef: runtimeRef}
+}
+
+// T7 (LOAD-BEARING) — a LIVE same-host owner holding the runtime-session lock
+// blocks the restart. The lock is acquired through the REAL
+// acquireRuntimeSessionLock, which now records this test process's os.Getpid()
+// (live) and os.Hostname() (this host). The guard must REJECT: exit non-zero,
+// runtime_ref UNCHANGED, adapter.Start NOT called.
+//
+// This is the test PR2's removed guard could not pass: that guard fired only on
+// lock.OwnerPID > 0, but acquireRuntimeSessionLock recorded no PID (OwnerPID=0),
+// so it never fired. Revert EITHER the OwnerPID recording in
+// acquireRuntimeSessionLock OR the runtimeSessionHeldByLiveOwner call in
+// runAgentRestart and this test fails (restart would proceed and rebind) —
+// proving both halves are load-bearing.
+func TestRunAgentRestartRejectsLiveSessionOwner(t *testing.T) {
+	home := t.TempDir()
+	const r1 = "550e8400-e29b-41d4-a716-446655440041"
+	agent, _ := seedRestartAgent(t, home, "codex", r1)
+
+	// Acquire the session lock for runtime:codex:<r1> via the real path.
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	release, acquired, key, err := acquireRuntimeSessionLock(
+		context.Background(), store, "live-ask-job",
+		runtimeAgentForRef(agent.Runtime, agent.RuntimeRef),
+		time.Now().UTC(), 30*time.Minute,
+	)
+	if err != nil || !acquired {
+		t.Fatalf("acquireRuntimeSessionLock: acquired=%v err=%v", acquired, err)
+	}
+	t.Cleanup(func() { _ = release(context.Background()) })
+	if key != "runtime:codex:"+r1 {
+		t.Fatalf("session key = %q, want runtime:codex:%s", key, r1)
+	}
+
+	fake := &agentRestartFakeAdapter{newRef: "550e8400-e29b-41d4-a716-446655440042"}
+	replaceRuntimeStartAdapter(t, fake)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "restart", "rebind-me", "--home", home}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("restart exit code = 0, want non-zero (live session must block); stdout=%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "foreground runtime session for rebind-me is in use") {
+		t.Fatalf("stderr = %q, want live-session refusal", stderr.String())
+	}
+	if fake.calls() != 0 {
+		t.Fatalf("adapter.Start calls = %d, want 0 (live session must not start a new one)", fake.calls())
+	}
+	if got := getRestartAgent(t, home, "rebind-me"); got.RuntimeRef != r1 {
+		t.Fatalf("RuntimeRef = %q, want unchanged %q", got.RuntimeRef, r1)
+	}
+}
+
+// seedRuntimeSessionLock writes a raw runtime:<rt>:<ref> resource lock with an
+// explicit owner PID / hostname / lease, bypassing acquireRuntimeSessionLock so
+// a test can model a stranded (dead-owner) or expired session precisely.
+func seedRuntimeSessionLock(t *testing.T, home, runtimeName, runtimeRef string, ownerPID int64, hostname string, expiresAt time.Time) {
+	t.Helper()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	key, ok := runtimeSessionResourceKey(runtimeAgentForRef(runtimeName, runtimeRef))
+	if !ok {
+		t.Fatalf("runtimeSessionResourceKey(%s,%s) not resumable", runtimeName, runtimeRef)
+	}
+	acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey:   key,
+		OwnerJobID:    "seed-session-owner",
+		OwnerToken:    "seed-token",
+		OwnerPID:      ownerPID,
+		OwnerHostname: hostname,
+		ExpiresAt:     expiresAt.UTC().Format(time.RFC3339Nano),
+	}, time.Now().UTC())
+	if err != nil || !acquired {
+		t.Fatalf("seed AcquireResourceLock: acquired=%v err=%v", acquired, err)
+	}
+}
+
+// T8 — a STRANDED (dead-owner) same-host session lock does NOT block the restart:
+// restart is exactly the recovery for an abandoned foreground ask. Dead PID
+// 2147480000 is far above any live PID; the lease is non-expired and the host is
+// this host, so only the PID-liveness gate decides — and a dead PID proceeds.
+func TestRunAgentRestartProceedsStrandedDeadOwner(t *testing.T) {
+	home := t.TempDir()
+	const r1 = "550e8400-e29b-41d4-a716-446655440051"
+	const r2 = "550e8400-e29b-41d4-a716-446655440052"
+	seedRestartAgent(t, home, "codex", r1)
+	thisHost, _ := os.Hostname()
+	seedRuntimeSessionLock(t, home, "codex", r1, 2147480000, thisHost, time.Now().UTC().Add(30*time.Minute))
+
+	fake := &agentRestartFakeAdapter{newRef: r2}
+	replaceRuntimeStartAdapter(t, fake)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"agent", "restart", "rebind-me", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("restart exit code = %d, want 0 (stranded session must be recoverable); stderr=%s", code, stderr.String())
+	}
+	if fake.calls() != 1 {
+		t.Fatalf("adapter.Start calls = %d, want 1", fake.calls())
+	}
+	if got := getRestartAgent(t, home, "rebind-me"); got.RuntimeRef != r2 {
+		t.Fatalf("RuntimeRef = %q, want rebound %q", got.RuntimeRef, r2)
+	}
+}
+
+// T9 — an EXPIRED lease does NOT block, even with a live owner PID: the lock is
+// stale and self-clears on the next acquire, so restart proceeds.
+func TestRunAgentRestartProceedsExpiredLease(t *testing.T) {
+	home := t.TempDir()
+	const r1 = "550e8400-e29b-41d4-a716-446655440061"
+	const r2 = "550e8400-e29b-41d4-a716-446655440062"
+	seedRestartAgent(t, home, "codex", r1)
+	thisHost, _ := os.Hostname()
+	// Live PID (this process) but a lease that expired in the past.
+	seedRuntimeSessionLock(t, home, "codex", r1, int64(os.Getpid()), thisHost, time.Now().UTC().Add(-time.Minute))
+
+	fake := &agentRestartFakeAdapter{newRef: r2}
+	replaceRuntimeStartAdapter(t, fake)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"agent", "restart", "rebind-me", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("restart exit code = %d, want 0 (expired lease must not block); stderr=%s", code, stderr.String())
+	}
+	if fake.calls() != 1 {
+		t.Fatalf("adapter.Start calls = %d, want 1", fake.calls())
+	}
+	if got := getRestartAgent(t, home, "rebind-me"); got.RuntimeRef != r2 {
+		t.Fatalf("RuntimeRef = %q, want rebound %q", got.RuntimeRef, r2)
+	}
+}
+
+// T10 — acquisition records identity: acquireRuntimeSessionLock then
+// GetResourceLock shows OwnerPID == os.Getpid() and OwnerHostname ==
+// os.Hostname() (trimmed). This is the additive metadata that makes the live
+// guard above functional at all.
+func TestAcquireRuntimeSessionLockRecordsOwnerIdentity(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	agent := runtimeAgentForRef("codex", "550e8400-e29b-41d4-a716-446655440071")
+	release, acquired, key, err := acquireRuntimeSessionLock(
+		context.Background(), store, "identity-job", agent, time.Now().UTC(), time.Minute,
+	)
+	if err != nil || !acquired {
+		t.Fatalf("acquireRuntimeSessionLock: acquired=%v err=%v", acquired, err)
+	}
+	defer func() { _ = release(context.Background()) }()
+
+	lock, err := store.GetResourceLock(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetResourceLock(%q) returned error: %v", key, err)
+	}
+	if lock.OwnerPID != int64(os.Getpid()) {
+		t.Fatalf("lock.OwnerPID = %d, want os.Getpid() = %d", lock.OwnerPID, os.Getpid())
+	}
+	wantHost, _ := os.Hostname()
+	if lock.OwnerHostname != strings.TrimSpace(wantHost) {
+		t.Fatalf("lock.OwnerHostname = %q, want os.Hostname() = %q", lock.OwnerHostname, strings.TrimSpace(wantHost))
 	}
 }

--- a/internal/cli/runtime_lock.go
+++ b/internal/cli/runtime_lock.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -24,11 +27,20 @@ func acquireRuntimeSessionLock(ctx context.Context, store *db.Store, jobID strin
 	if err != nil {
 		return nil, false, key, err
 	}
+	// Record the acquiring process's identity (additive metadata) so a later
+	// liveness check — e.g. `agent restart`'s session-lock guard (#425) — can tell
+	// a LIVE same-host foreground session from a STRANDED (dead-owner) one. This is
+	// purely additive: AcquireResourceLock does not gate on OwnerPID, so the locking
+	// semantics are unchanged. hostname is best-effort: an empty host is treated as
+	// this/local host by the consumer (local-first, mirroring the #303 recovery).
+	hostname, _ := os.Hostname()
 	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
-		ResourceKey: key,
-		OwnerJobID:  jobID,
-		OwnerToken:  ownerToken,
-		ExpiresAt:   now.UTC().Add(ttl).Format(time.RFC3339Nano),
+		ResourceKey:   key,
+		OwnerJobID:    jobID,
+		OwnerToken:    ownerToken,
+		OwnerPID:      int64(os.Getpid()),
+		OwnerHostname: strings.TrimSpace(hostname),
+		ExpiresAt:     now.UTC().Add(ttl).Format(time.RFC3339Nano),
 	}, now)
 	if err != nil || !acquired {
 		return func(context.Context) error { return nil }, acquired, key, err
@@ -51,6 +63,62 @@ func runtimeSessionResourceKey(agent runtime.Agent) (string, bool) {
 		return "", false
 	}
 	return "runtime:" + runtimeName + ":" + runtimeRef, true
+}
+
+// runtimeSessionHeldByLiveOwner reports whether the agent's runtime:<rt>:<ref>
+// session lock is currently held by a provably-LIVE, same-host owner. It is the
+// guard `agent restart` uses to refuse clobbering a live foreground `agent ask`
+// while still PROCEEDING on a stranded/expired/absent lock (the recovery story).
+//
+// Classification (mirrors the #303 generation-lock recovery, inverted — there we
+// reclaim only a provably-dead lock, here we BLOCK only a provably-live one):
+//   - no resource key (non-resumable runtime / empty ref) → not held.
+//   - no lock (ErrNoRows) → not held (proceed).
+//   - lease expired (ExpiresAt < now) → not held (stale/self-clearing → proceed).
+//   - active lease, same host (empty host = legacy/local, treated as this host),
+//     OwnerPID > 0, and the PID is live → HELD (reject).
+//   - active lease, same host, PID dead or ≤0 (legacy) → not held (stranded → proceed).
+//   - active lease, genuinely cross-host (non-empty, different host — liveness not
+//     locally verifiable) → HELD (conservative: a cross-host runtime-session lock
+//     is not a local-first scenario, so refuse rather than risk abandoning a
+//     possibly-live session).
+//
+// A GetResourceLock error other than not-found is returned (never silently proceed).
+func runtimeSessionHeldByLiveOwner(ctx context.Context, store *db.Store, agent runtime.Agent) (bool, string, error) {
+	key, ok := runtimeSessionResourceKey(agent)
+	if !ok {
+		return false, "", nil
+	}
+	lock, err := store.GetResourceLock(ctx, key)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	now := time.Now().UTC()
+	if expiresAt, parsed := parseSkillOptStatusTime(lock.ExpiresAt); parsed && !expiresAt.After(now) {
+		// Lease expired: stale and self-clearing on the next acquire — proceed.
+		return false, "", nil
+	}
+	host := strings.TrimSpace(lock.OwnerHostname)
+	thisHost, _ := os.Hostname()
+	sameHost := host == "" || strings.EqualFold(host, strings.TrimSpace(thisHost))
+	hostText := host
+	if hostText == "" {
+		hostText = "this host"
+	}
+	switch {
+	case sameHost && lock.OwnerPID > 0 && skillOptOwnerPIDLive(lock.OwnerPID):
+		// Live same-host owner: refuse — restarting would clobber a live session.
+		return true, fmt.Sprintf("held by pid %d on %s", lock.OwnerPID, hostText), nil
+	case sameHost:
+		// Same-host dead/legacy owner: stranded session — restart recovers it.
+		return false, "", nil
+	default:
+		// Cross-host owner we cannot liveness-check locally: refuse conservatively.
+		return true, fmt.Sprintf("held by pid %d on %s (cross-host; liveness unverifiable)", lock.OwnerPID, hostText), nil
+	}
 }
 
 func newRuntimeLockOwnerToken() (string, error) {


### PR DESCRIPTION
Closes #425. Follow-up to #414 PR2 (#417), which removed a non-functional `agent restart` session-lock guard (it gated on `lock.OwnerPID > 0`, but runtime-session locks never recorded a PID). This makes it functional.

## What
1. **`internal/cli/runtime_lock.go`** — `acquireRuntimeSessionLock` now records `OwnerPID = int64(os.Getpid())` and `OwnerHostname = os.Hostname()` on the `runtime:<rt>:<ref>` `db.ResourceLock`. Purely **additive** metadata (the DB already persists/scans these fields; `AcquireResourceLock` doesn't gate on `OwnerPID`), so locking/serialization semantics are unchanged.
2. **`internal/cli/agent.go`** — `runAgentRestart` gains a **functional** session-lock guard (after the jobs-busy guard, before `adapter.Start`), via `runtimeSessionHeldByLiveOwner`. Classification (reusing the #303 lease-liveness pattern + `skillOptOwnerPIDLive`):
   - no lock / **expired lease** / dead-owner → **proceed** (the stranded-session recovery `restart` exists for — preserved).
   - active lease + **same-host** (empty host = local, per #303) + `OwnerPID > 0` + **live** → **reject** (a foreground `agent ask` holds the session): exit 1, `runtime_ref` unchanged, `adapter.Start` not called.
   - genuinely **cross-host** active lease → conservatively **reject** (can't verify a foreign PID's liveness; refusing beats abandoning a possibly-live session — not a local-first scenario).

The success-path note is updated (restart now refuses a live ask but still recovers a stranded one). The out-of-scope acquire-path auto-reclaim (the broader "session is busy" recovery) is **not** included — recording `OwnerPID` here merely enables it later.

## Verification
- Gate green: `go build/vet/test ./...` + `-race ./internal/workflow/` + `-race ./internal/cli/`.
- Tests: **T7** live-owner-blocks (LOAD-BEARING — acquires via the *real* `acquireRuntimeSessionLock` with a live `os.Getpid()`; reverting either the OwnerPID recording or the guard makes it fail), **T8** stranded-dead-owner-proceeds, **T9** expired-lease-proceeds, **T10** acquisition-records-identity. Existing runtime-session-lock + `agent restart` tests stay green.
- 2-lens adversarial review (correctness + safety/recovery-preserved): **clean** on the first pass.
- No live E2E: a live foreground `agent ask` blocks the operator's shell, so "restart while an ask is live" is impractical to stage; T7's use of the real acquire path is the integration test. Unit + `-race` + review is the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)