### PR TITLE
feat(workflow): goal-anchored finale continuations (#418)

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -686,6 +686,84 @@ func (e Engine) rootJobID(job db.Job, payload JobPayload) string {
 	return job.ID
 }
 
+// originalGoal resolves the goal text that a coordinator continuation prompt is
+// anchored to (#418). It reads the ROOT coordinator's own Instructions — the
+// user's original prompt — via rootJobID, which is depth-stable: a NESTED
+// continuation's parentPayload.Instructions holds the parent continuation's built
+// prompt (not the user's goal), so resolving from the root keeps every generation
+// of the chain anchored to the same intent. The caller passes fallback (the
+// immediate parentPayload.Instructions) for two cases: the root was pruned (lookup
+// fails) or the root carries no instructions; in both the continuation must never
+// error, so it falls back rather than failing. The result is whitespace-trimmed;
+// empty/whitespace yields "" so the builders omit the Original goal header.
+func (e Engine) originalGoal(ctx context.Context, rootJobID, fallback string) string {
+	if root, err := e.Store.GetJob(ctx, rootJobID); err == nil {
+		if payload, err := unmarshalPayload(root.Payload); err == nil {
+			if goal := strings.TrimSpace(payload.Instructions); goal != "" {
+				return goal
+			}
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+// goalAnchorHeader renders the "Original goal:" section prepended to a coordinator
+// continuation prompt (#418). An empty/whitespace goal yields "" so the prompt
+// never prints an empty header (the closing instruction degrades to generic
+// synthesis framing — see goalSynthesisClosing). The goal is the user's own prompt,
+// so it is emitted as plain labeled text without fencing.
+func goalAnchorHeader(goal string) string {
+	goal = strings.TrimSpace(goal)
+	if goal == "" {
+		return ""
+	}
+	return "Original goal:\n" + goal + "\n\n"
+}
+
+// goalSynthesisClosing returns the goal-anchored synthesis instruction that
+// replaces the legacy "decide the next step" framing (#418). When a goal is
+// present it asks the coordinator to synthesize an answer to THAT goal; when the
+// goal is empty it degrades to generic synthesis framing. Both spell out the
+// unchanged termination contract: an empty delegations list finishes, and new
+// delegations are only for a genuine remaining gap.
+func goalSynthesisClosing(goal string) string {
+	if strings.TrimSpace(goal) != "" {
+		return "Synthesize these results into an answer to the ORIGINAL GOAL above. " +
+			"Reconcile any conflicts between children and flag any gaps. " +
+			"Only return new delegations if a genuine gap remains; " +
+			"otherwise return an EMPTY delegations list to finish."
+	}
+	return "Synthesize these results into a single coherent answer. " +
+		"Reconcile any conflicts between children and flag any gaps. " +
+		"Only return new delegations if a genuine gap remains; " +
+		"otherwise return an EMPTY delegations list to finish."
+}
+
+// budgetPressureLine returns a one-line nudge to bias the coordinator toward
+// synthesizing rather than re-delegating when the coordination tree is near a
+// termination bound (#418). depth is the depth the NEXT generation would occupy
+// (parentPayload.DelegationDepth+1) and jobs is the current per-root job count.
+// It fires only within budgetPressureSlack of a bound; otherwise it returns "" so
+// a tree with plenty of headroom prints no line (keeping the prompt clean). A
+// non-positive jobs (the count was unavailable) suppresses the job clause.
+func budgetPressureLine(depth, jobs int) string {
+	nearDepth := depth >= MaxDelegationDepth-budgetPressureSlack
+	nearJobs := jobs > 0 && jobs >= MaxDelegationTotalJobs-budgetPressureSlack
+	if !nearDepth && !nearJobs {
+		return ""
+	}
+	if jobs > 0 {
+		return fmt.Sprintf("You are at depth %d/%d and %d/%d jobs — prefer finishing (synthesize now) over re-delegating.\n\n",
+			depth, MaxDelegationDepth, jobs, MaxDelegationTotalJobs)
+	}
+	return fmt.Sprintf("You are at depth %d/%d — prefer finishing (synthesize now) over re-delegating.\n\n",
+		depth, MaxDelegationDepth)
+}
+
+// budgetPressureSlack is how close to a termination bound (depth or per-root job
+// count) the tree must be before budgetPressureLine injects its nudge (#418).
+const budgetPressureSlack = 2
+
 // rootWallClockExceeded reports whether the coordination tree rooted at rootID has
 // been running longer than MaxDelegationWallClock, measured from the root job's
 // created_at MINUS any time the tree spent paused awaiting a human (#340), and the
@@ -1047,6 +1125,18 @@ func (e Engine) countRootDelegationJobs(ctx context.Context, rootID string) (int
 	return count, nil
 }
 
+// rootJobCountForPressure returns the per-root job count for the budget-pressure
+// nudge (#418), failing open to 0 on any lookup error. A 0 makes budgetPressureLine
+// drop only the job clause (depth pressure still fires); it must never error the
+// continuation, which is why this swallows the error rather than propagating it.
+func (e Engine) rootJobCountForPressure(ctx context.Context, rootID string) int {
+	count, err := e.countRootDelegationJobs(ctx, rootID)
+	if err != nil {
+		return 0
+	}
+	return count
+}
+
 // sumRootDelegationTokens sums the runtime token usage (input + output) across an
 // entire coordination tree: the originating coordinator itself (job.ID == rootID)
 // plus every child or continuation whose payload RootJobID points back at it. It
@@ -1335,7 +1425,7 @@ func (e Engine) handleDelegationLoop(ctx context.Context, job db.Job, payload Jo
 		LeadAgent:       payload.LeadAgent,
 		Reviewers:       payload.Reviewers,
 		Sender:          job.Agent,
-		Instructions:    buildCorrectiveContinuationPrompt(payload.Result),
+		Instructions:    buildCorrectiveContinuationPrompt(e.originalGoal(ctx, e.rootJobID(job, payload), payload.Instructions), payload.Result),
 		Constraints:     payload.Constraints,
 		ParentJobID:     job.ID,
 		DelegationDepth: payload.DelegationDepth + 1,
@@ -1393,7 +1483,7 @@ func (e Engine) enqueueFinalizeContinuation(ctx context.Context, job db.Job, pay
 		LeadAgent:          payload.LeadAgent,
 		Reviewers:          payload.Reviewers,
 		Sender:             job.Agent,
-		Instructions:       buildFinalizeContinuationPrompt(payload.Result, reason),
+		Instructions:       buildFinalizeContinuationPrompt(e.originalGoal(ctx, e.rootJobID(job, payload), payload.Instructions), payload.Result, reason),
 		Constraints:        payload.Constraints,
 		ParentJobID:        job.ID,
 		DelegationDepth:    payload.DelegationDepth + 1,
@@ -1897,6 +1987,13 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		childPayloads[id] = childPayload
 	}
 
+	// Goal-anchor the continuation (#418): resolve the user's ORIGINAL goal from
+	// the ROOT coordinator (depth-stable; parentPayload.Instructions is the parent
+	// continuation's built prompt for a nested generation) so every variant below
+	// restates the same intent. A pruned/empty root falls back to the parent's
+	// instructions and, ultimately, an empty goal that omits the header.
+	goal := e.originalGoal(ctx, e.rootJobID(parentJob, parentPayload), parentPayload.Instructions)
+
 	// synthesis_rule "vote": block the parent unless every child approved or
 	// succeeded. The default ("" / "summary") concatenates child summaries into
 	// the continuation prompt below.
@@ -1970,7 +2067,7 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 			LeadAgent:       parentPayload.LeadAgent,
 			Reviewers:       parentPayload.Reviewers,
 			Sender:          parentJob.Agent,
-			Instructions:    buildCorrectiveContinuationPrompt(parentResult),
+			Instructions:    buildCorrectiveContinuationPrompt(goal, parentResult),
 			Constraints:     parentPayload.Constraints,
 			ParentJobID:     parentJob.ID,
 			DelegationDepth: parentPayload.DelegationDepth + 1,
@@ -2005,22 +2102,26 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 	}
 
 	request := JobRequest{
-		ID:           delegationContinuationID(parentJob.ID),
-		Agent:        parentJob.Agent,
-		Action:       "ask",
-		Model:        parentPayload.Model,
-		Phase:        parentPayload.Phase,
-		Repo:         parentPayload.Repo,
-		Branch:       parentPayload.Branch,
-		PullRequest:  parentPayload.PullRequest,
-		HeadSHA:      parentPayload.HeadSHA,
-		GoalID:       parentPayload.GoalID,
-		TaskID:       parentPayload.TaskID,
-		TaskTitle:    parentPayload.TaskTitle,
-		LeadAgent:    parentPayload.LeadAgent,
-		Reviewers:    parentPayload.Reviewers,
-		Sender:       parentJob.Agent,
-		Instructions: e.buildContinuationPrompt(parentResult, children, childPayloads),
+		ID:          delegationContinuationID(parentJob.ID),
+		Agent:       parentJob.Agent,
+		Action:      "ask",
+		Model:       parentPayload.Model,
+		Phase:       parentPayload.Phase,
+		Repo:        parentPayload.Repo,
+		Branch:      parentPayload.Branch,
+		PullRequest: parentPayload.PullRequest,
+		HeadSHA:     parentPayload.HeadSHA,
+		GoalID:      parentPayload.GoalID,
+		TaskID:      parentPayload.TaskID,
+		TaskTitle:   parentPayload.TaskTitle,
+		LeadAgent:   parentPayload.LeadAgent,
+		Reviewers:   parentPayload.Reviewers,
+		Sender:      parentJob.Agent,
+		// Budget-pressure nudge (#418): when the tree is near a depth/job bound, bias
+		// the coordinator toward synthesizing now over more fan-out. The job count is
+		// best-effort — a lookup error yields 0, which suppresses only the job clause,
+		// never the continuation.
+		Instructions: e.buildContinuationPrompt(goal, budgetPressureLine(parentPayload.DelegationDepth+1, e.rootJobCountForPressure(ctx, e.rootJobID(parentJob, parentPayload))), parentResult, children, childPayloads),
 		Constraints:  parentPayload.Constraints,
 		ParentJobID:  parentJob.ID,
 		// Increment depth per continuation generation so a coordinator whose
@@ -2400,9 +2501,11 @@ func delegationContinuationID(parentJobID string) string {
 // buildContinuationPrompt inlines each finished child's job id, agent, decision,
 // summary, and PR link into the coordinator continuation prompt so the
 // coordinator can synthesize the results without re-reading every child job.
-func (e Engine) buildContinuationPrompt(parentResult *AgentResult, children map[string]db.Job, childPayloads map[string]JobPayload) string {
+func (e Engine) buildContinuationPrompt(goal, budgetLine string, parentResult *AgentResult, children map[string]db.Job, childPayloads map[string]JobPayload) string {
 	var builder strings.Builder
-	builder.WriteString("All delegated jobs have finished. Review the results below and decide the next step.\n\n")
+	builder.WriteString(goalAnchorHeader(goal))
+	builder.WriteString("All delegated jobs have finished. Review the results below.\n\n")
+	builder.WriteString(budgetLine)
 	builder.WriteString("Delegation results:\n")
 	// remainingInline tracks the aggregate ArtifactBody budget across all children
 	// for this continuation; only consulted when InlineArtifactBodies is set.
@@ -2440,8 +2543,12 @@ func (e Engine) buildContinuationPrompt(parentResult *AgentResult, children map[
 		}
 	}
 	// Completion contract: make termination directed. The engine already treats
-	// an empty delegations list as terminal, so spell it out for the agent.
-	builder.WriteString("\n\nIf the goal is now complete, return your result with an EMPTY delegations list to finish. Only return new delegations if more work is genuinely required.")
+	// an empty delegations list as terminal, so spell it out for the agent. The
+	// closing is reframed (#418) from "decide the next step" to goal-anchored
+	// synthesis — but the termination semantics (empty delegations = done) are
+	// unchanged.
+	builder.WriteString("\n\n")
+	builder.WriteString(goalSynthesisClosing(goal))
 	return builder.String()
 }
 
@@ -2569,15 +2676,18 @@ func truncateUTF8Bytes(s string, maxBytes int) (string, int) {
 // coordinator the repeat changed nothing and asks it to change approach or
 // finish, then lists the repeated delegations for context. If it repeats again,
 // handleDelegationLoop escalates to delegation_loop_detected and stops.
-func buildCorrectiveContinuationPrompt(parentResult *AgentResult) string {
+func buildCorrectiveContinuationPrompt(goal string, parentResult *AgentResult) string {
 	var builder strings.Builder
+	builder.WriteString(goalAnchorHeader(goal))
 	builder.WriteString("You delegated the same set as a previous round; it did not change the outcome. Change your approach or return an EMPTY delegations list to finish.\n\n")
 	if parentResult != nil && len(parentResult.Delegations) > 0 {
 		builder.WriteString("Repeated delegation set:\n")
 		for _, d := range parentResult.Delegations {
 			fmt.Fprintf(&builder, "- delegation %q (agent %s, action %s)\n", d.ID, d.Agent, d.Action)
 		}
+		builder.WriteString("\n")
 	}
+	builder.WriteString(goalSynthesisClosing(goal))
 	return builder.String()
 }
 
@@ -2587,10 +2697,19 @@ func buildCorrectiveContinuationPrompt(parentResult *AgentResult) string {
 // the completed work, and states that any delegations it returns now are ignored
 // (the engine enforces this via DelegationFinalize). It lists the delegations that
 // were not dispatched for context.
-func buildFinalizeContinuationPrompt(parentResult *AgentResult, reason string) string {
+func buildFinalizeContinuationPrompt(goal string, parentResult *AgentResult, reason string) string {
 	var builder strings.Builder
+	builder.WriteString(goalAnchorHeader(goal))
 	fmt.Fprintf(&builder, "A termination backstop was reached (%s). You cannot delegate any more work.\n\n", reason)
-	builder.WriteString("Synthesize a best-effort FINAL result from what has already completed, and return an EMPTY delegations list. Any delegations you return now will be ignored.\n")
+	// Goal-anchored synthesis (#418): the finalize continuation is already
+	// terminal (any delegations are ignored — DelegationFinalize), so it restates
+	// the goal and asks for a best-effort answer to it, reconciling child conflicts
+	// and flagging gaps, rather than a raw stitch of child outputs.
+	if strings.TrimSpace(goal) != "" {
+		builder.WriteString("Synthesize a best-effort FINAL answer to the ORIGINAL GOAL above from what has already completed — reconcile any conflicts between children and flag any gaps — and return an EMPTY delegations list. Any delegations you return now will be ignored.\n")
+	} else {
+		builder.WriteString("Synthesize a best-effort FINAL result from what has already completed — reconcile any conflicts between children and flag any gaps — and return an EMPTY delegations list. Any delegations you return now will be ignored.\n")
+	}
 	if parentResult != nil && len(parentResult.Delegations) > 0 {
 		builder.WriteString("\nDelegations that were NOT dispatched:\n")
 		for _, d := range parentResult.Delegations {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2442,7 +2442,7 @@ func TestContinuationPromptInlinesChildResults(t *testing.T) {
 		"api": {Repo: "jerryfane/gitmoot", PullRequest: 12, Result: &AgentResult{Decision: "implemented", Summary: "api built"}},
 		"ui":  {Result: &AgentResult{Decision: "approved", Summary: "ui built"}},
 	}
-	prompt := Engine{}.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	prompt := Engine{}.buildContinuationPrompt("", "", &AgentResult{Delegations: dels}, children, childPayloads)
 	for _, want := range []string{
 		"parent-job/delegation/api",
 		"parent-job/delegation/ui",
@@ -2471,7 +2471,7 @@ func TestContinuationPromptIncludesPhase(t *testing.T) {
 		"api": {Result: &AgentResult{Decision: "implemented", Summary: "api built"}},
 		"ui":  {Result: &AgentResult{Decision: "approved", Summary: "ui built"}},
 	}
-	withPhase := Engine{}.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	withPhase := Engine{}.buildContinuationPrompt("", "", &AgentResult{Delegations: dels}, children, childPayloads)
 	if !strings.Contains(withPhase, "[phase: design]") {
 		t.Fatalf("continuation prompt missing phase label\n%s", withPhase)
 	}
@@ -2482,7 +2482,7 @@ func TestContinuationPromptIncludesPhase(t *testing.T) {
 		{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
 		{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
 	}
-	noPhase := Engine{}.buildContinuationPrompt(&AgentResult{Delegations: noPhaseDels}, children, childPayloads)
+	noPhase := Engine{}.buildContinuationPrompt("", "", &AgentResult{Delegations: noPhaseDels}, children, childPayloads)
 	if strings.Contains(noPhase, "phase") {
 		t.Fatalf("continuation prompt must not mention phase when none set\n%s", noPhase)
 	}
@@ -2493,7 +2493,7 @@ func TestContinuationPromptIncludesPhase(t *testing.T) {
 		{ID: "api", Agent: "api", Action: "review", Prompt: "build api"},
 		{ID: "ui", Agent: "ui", Action: "review", Prompt: "build ui"},
 	}
-	if got := (Engine{}).buildContinuationPrompt(&AgentResult{Delegations: cleared}, children, childPayloads); got != noPhase {
+	if got := (Engine{}).buildContinuationPrompt("", "", &AgentResult{Delegations: cleared}, children, childPayloads); got != noPhase {
 		t.Fatalf("clearing phase changed the prompt:\n--- got ---\n%s\n--- want ---\n%s", got, noPhase)
 	}
 }
@@ -2515,7 +2515,7 @@ func TestContinuationPromptInlinesArtifactBodyWhenEnabled(t *testing.T) {
 		"ui":  {Result: &AgentResult{Decision: "approved", Summary: "ui built", ArtifactBody: "UI BRIEF BODY"}},
 	}
 	engine := Engine{InlineArtifactBodies: true}
-	prompt := engine.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	prompt := engine.buildContinuationPrompt("", "", &AgentResult{Delegations: dels}, children, childPayloads)
 	for _, want := range []string{"API BRIEF BODY", "UI BRIEF BODY", "artifact_body:", "```"} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("inline-enabled continuation prompt missing %q\n%s", want, prompt)
@@ -2535,7 +2535,7 @@ func TestContinuationPromptInlineFenceSurvivesBacktickBody(t *testing.T) {
 	dels := []Delegation{{ID: "api", Agent: "api", Action: "review"}}
 	children := map[string]db.Job{"api": {ID: "parent-job/delegation/api", Agent: "api", State: string(JobSucceeded)}}
 	childPayloads := map[string]JobPayload{"api": {Result: &AgentResult{Decision: "implemented", Summary: "s", ArtifactBody: body}}}
-	prompt := Engine{InlineArtifactBodies: true}.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	prompt := Engine{InlineArtifactBodies: true}.buildContinuationPrompt("", "", &AgentResult{Delegations: dels}, children, childPayloads)
 	if !strings.Contains(prompt, body) {
 		t.Fatalf("body with embedded ``` not inlined verbatim\n%s", prompt)
 	}
@@ -2567,8 +2567,8 @@ func TestContinuationPromptByteIdenticalWhenDisabled(t *testing.T) {
 	}
 	// Default-off engine ignores ArtifactBody entirely: output equals the legacy
 	// rendering produced for the same children without any body present.
-	got := Engine{}.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, withBody)
-	want := Engine{}.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, noBody)
+	got := Engine{}.buildContinuationPrompt("", "", &AgentResult{Delegations: dels}, children, withBody)
+	want := Engine{}.buildContinuationPrompt("", "", &AgentResult{Delegations: dels}, children, noBody)
 	if got != want {
 		t.Fatalf("default-off prompt not byte-identical to legacy:\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
@@ -2590,7 +2590,7 @@ func TestContinuationPromptInlineOverCapTruncatedWithMarker(t *testing.T) {
 		"api": {Result: &AgentResult{Decision: "implemented", ArtifactBody: body}},
 	}
 	engine := Engine{InlineArtifactBodies: true, MaxInlineArtifactBytes: 10, ArtifactRoot: "/home/.gitmoot"}
-	prompt := engine.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	prompt := engine.buildContinuationPrompt("", "", &AgentResult{Delegations: dels}, children, childPayloads)
 	if !strings.Contains(prompt, strings.Repeat("x", 10)) {
 		t.Fatalf("expected the first 10 bytes inlined\n%s", prompt)
 	}
@@ -2617,7 +2617,7 @@ func TestContinuationPromptInlineRuneSafe(t *testing.T) {
 		"api": {Result: &AgentResult{Decision: "implemented", ArtifactBody: body}},
 	}
 	engine := Engine{InlineArtifactBodies: true, MaxInlineArtifactBytes: 10}
-	prompt := engine.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	prompt := engine.buildContinuationPrompt("", "", &AgentResult{Delegations: dels}, children, childPayloads)
 	if !utf8.ValidString(prompt) {
 		t.Fatalf("inlined prompt contains an invalid (split) UTF-8 rune\n%q", prompt)
 	}
@@ -2649,7 +2649,7 @@ func TestContinuationPromptInlineAggregateCapHonored(t *testing.T) {
 	// Per-body cap is large enough to admit the whole first body, exhausting the
 	// aggregate budget so the second body is dropped entirely.
 	engine := Engine{InlineArtifactBodies: true, MaxInlineArtifactBytes: maxInlineArtifactTotalBytes}
-	prompt := engine.buildContinuationPrompt(&AgentResult{Delegations: dels}, children, childPayloads)
+	prompt := engine.buildContinuationPrompt("", "", &AgentResult{Delegations: dels}, children, childPayloads)
 	if strings.Contains(prompt, "SECOND_BODY_MARKER") {
 		t.Fatalf("aggregate cap not honored: second body inlined despite exhausted budget")
 	}
@@ -3384,14 +3384,18 @@ func TestEngineDelegationRootJobIDPropagates(t *testing.T) {
 // finish by returning an EMPTY delegations list when the goal is complete.
 func TestContinuationPromptIncludesCompletionContract(t *testing.T) {
 	prompt := Engine{}.buildContinuationPrompt(
+		"",
+		"",
 		&AgentResult{Delegations: []Delegation{{ID: "w1", Agent: "w"}}},
 		map[string]db.Job{},
 		map[string]JobPayload{},
 	)
+	// Termination contract unchanged (#418): an empty delegations list finishes,
+	// and new delegations are only for a genuine remaining gap.
 	if !strings.Contains(prompt, "EMPTY delegations list") {
 		t.Fatalf("continuation prompt missing completion contract: %q", prompt)
 	}
-	if !strings.Contains(prompt, "Only return new delegations if more work is genuinely required") {
+	if !strings.Contains(prompt, "Only return new delegations if a genuine gap remains") {
 		t.Fatalf("continuation prompt missing completion-contract guidance: %q", prompt)
 	}
 }

--- a/internal/workflow/finalize_test.go
+++ b/internal/workflow/finalize_test.go
@@ -90,6 +90,7 @@ func TestEngineFinalizeContinuationIsTerminal(t *testing.T) {
 
 func TestBuildFinalizeContinuationPrompt(t *testing.T) {
 	prompt := buildFinalizeContinuationPrompt(
+		"",
 		&AgentResult{Delegations: []Delegation{{ID: "x", Agent: "w", Action: "ask"}}},
 		"per-root job budget of 64 reached",
 	)

--- a/internal/workflow/goal_anchored_finale_test.go
+++ b/internal/workflow/goal_anchored_finale_test.go
@@ -1,0 +1,252 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// TestContinuationPromptAnchorsGoalAndReconcileFraming pins the #418 core: a
+// non-empty goal is restated under an "Original goal:" header, the closing is
+// reframed to goal-anchored synthesis (reconcile conflicts + flag gaps), and the
+// unchanged EMPTY-delegations termination contract is still spelled out.
+func TestContinuationPromptAnchorsGoalAndReconcileFraming(t *testing.T) {
+	goal := "Compare three sort algorithms and recommend one"
+	dels := []Delegation{{ID: "a", Agent: "a", Action: "review"}}
+	children := map[string]db.Job{"a": {ID: "p/delegation/a", Agent: "a", State: string(JobSucceeded)}}
+	childPayloads := map[string]JobPayload{"a": {Result: &AgentResult{Decision: "done", Summary: "quicksort fastest"}}}
+
+	prompt := Engine{}.buildContinuationPrompt(goal, "", &AgentResult{Delegations: dels}, children, childPayloads)
+
+	if !strings.Contains(prompt, "Original goal:\n"+goal) {
+		t.Fatalf("continuation prompt missing the Original goal header for %q:\n%s", goal, prompt)
+	}
+	for _, want := range []string{
+		"ORIGINAL GOAL", // goal-anchored synthesis framing
+		"Reconcile any conflicts between children",
+		"flag any gaps",
+		"EMPTY delegations list to finish", // termination contract unchanged
+		"Only return new delegations if a genuine gap remains",
+		"quicksort fastest", // child results still inlined
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("continuation prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	// The legacy "decide the next step" framing is gone.
+	if strings.Contains(prompt, "decide the next step") {
+		t.Fatalf("continuation prompt must not retain the legacy 'decide the next step' framing:\n%s", prompt)
+	}
+}
+
+// TestContinuationPromptOmitsEmptyGoalHeader pins the decided default: an
+// empty/whitespace goal omits the "Original goal:" header entirely (never an empty
+// header) and degrades to generic synthesis framing while keeping the termination
+// contract.
+func TestContinuationPromptOmitsEmptyGoalHeader(t *testing.T) {
+	dels := []Delegation{{ID: "a", Agent: "a", Action: "review"}}
+	children := map[string]db.Job{"a": {ID: "p/delegation/a", Agent: "a", State: string(JobSucceeded)}}
+	childPayloads := map[string]JobPayload{"a": {Result: &AgentResult{Decision: "done", Summary: "s"}}}
+
+	for _, goal := range []string{"", "   \n\t  "} {
+		prompt := Engine{}.buildContinuationPrompt(goal, "", &AgentResult{Delegations: dels}, children, childPayloads)
+		if strings.Contains(prompt, "Original goal:") {
+			t.Fatalf("empty goal %q must omit the Original goal header:\n%s", goal, prompt)
+		}
+		// Generic synthesis framing still asks for reconcile/gap + termination.
+		for _, want := range []string{
+			"Reconcile any conflicts between children",
+			"flag any gaps",
+			"EMPTY delegations list to finish",
+		} {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("empty-goal prompt missing %q:\n%s", want, prompt)
+			}
+		}
+		if strings.Contains(prompt, "ORIGINAL GOAL") {
+			t.Fatalf("empty-goal prompt must not reference an ORIGINAL GOAL:\n%s", prompt)
+		}
+	}
+}
+
+// TestCorrectiveContinuationPromptAnchorsGoal pins that the corrective nudge also
+// restates the goal and carries the goal-anchored synthesis closing.
+func TestCorrectiveContinuationPromptAnchorsGoal(t *testing.T) {
+	goal := "Find and fix the flaky test"
+	prompt := buildCorrectiveContinuationPrompt(goal, &AgentResult{Delegations: []Delegation{{ID: "x", Agent: "w", Action: "ask"}}})
+	for _, want := range []string{
+		"Original goal:\n" + goal,
+		"did not change the outcome", // existing corrective nudge preserved
+		"ORIGINAL GOAL",
+		"Reconcile any conflicts between children",
+		"EMPTY delegations list to finish",
+		`delegation "x"`,
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("corrective prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	// Empty goal: no header, generic framing, nudge preserved.
+	empty := buildCorrectiveContinuationPrompt("", &AgentResult{})
+	if strings.Contains(empty, "Original goal:") {
+		t.Fatalf("empty-goal corrective prompt must omit the header:\n%s", empty)
+	}
+	if !strings.Contains(empty, "did not change the outcome") {
+		t.Fatalf("empty-goal corrective prompt dropped the nudge:\n%s", empty)
+	}
+}
+
+// TestFinalizeContinuationPromptAnchorsGoal pins that the terminal finalize prompt
+// restates the goal and asks for a best-effort answer to it, while preserving its
+// terminal semantics (any delegations are ignored).
+func TestFinalizeContinuationPromptAnchorsGoal(t *testing.T) {
+	goal := "Ship the release notes"
+	prompt := buildFinalizeContinuationPrompt(goal, &AgentResult{Delegations: []Delegation{{ID: "x", Agent: "w", Action: "ask"}}}, "per-root job budget of 64 reached")
+	for _, want := range []string{
+		"Original goal:\n" + goal,
+		"ORIGINAL GOAL",
+		"termination backstop",
+		"per-root job budget of 64 reached",
+		"reconcile any conflicts between children",
+		"EMPTY delegations",
+		"ignored", // terminal semantics preserved
+		`delegation "x"`,
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("finalize prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+// TestBudgetPressureLine pins the optional near-bound nudge: it fires within the
+// slack of a depth/job bound and stays silent with headroom; an unavailable job
+// count (0) suppresses only the job clause.
+func TestBudgetPressureLine(t *testing.T) {
+	// Plenty of headroom on both axes: silent.
+	if got := budgetPressureLine(1, 2); got != "" {
+		t.Fatalf("expected no budget-pressure line with headroom, got %q", got)
+	}
+	// Near the depth bound (depth = MaxDelegationDepth - slack): fires.
+	near := budgetPressureLine(MaxDelegationDepth-budgetPressureSlack, 3)
+	if !strings.Contains(near, "prefer finishing") {
+		t.Fatalf("expected a budget-pressure nudge near the depth bound, got %q", near)
+	}
+	// Near the job bound only: fires and names the job count.
+	jobs := budgetPressureLine(1, MaxDelegationTotalJobs-budgetPressureSlack)
+	if !strings.Contains(jobs, "jobs") || !strings.Contains(jobs, "prefer finishing") {
+		t.Fatalf("expected a job-count budget-pressure nudge, got %q", jobs)
+	}
+	// Unavailable job count (0) near depth: depth clause only, no job clause.
+	depthOnly := budgetPressureLine(MaxDelegationDepth, 0)
+	if !strings.Contains(depthOnly, "depth") || strings.Contains(depthOnly, "jobs") {
+		t.Fatalf("expected depth-only nudge with unavailable job count, got %q", depthOnly)
+	}
+}
+
+// TestNestedContinuationAnchorsGoalFromRoot is the load-bearing depth-stability
+// test (#418). It drives a real two-generation continuation chain and asserts the
+// NESTED continuation's prompt is anchored to the user's ROOT goal — not to the
+// parent continuation's built prompt (which parentPayload.Instructions would hold
+// for a nested generation). A naive implementation that sourced the goal from
+// parentPayload.Instructions would re-anchor the nested prompt to the parent
+// continuation's built text (which opens "All delegated jobs have finished") and
+// fail the assertions below.
+func TestNestedContinuationAnchorsGoalFromRoot(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	const rootGoal = "ROOT_GOAL_SENTINEL: build a tic-tac-toe AI and report its win rate"
+
+	// Generation 0: the root coordinator carries the user's goal in Instructions and
+	// delegates one child.
+	insertCompletedJob(t, store, db.Job{ID: "root", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:         "jerryfane/gitmoot",
+		Branch:       "task-1",
+		TaskID:       "task-1",
+		Sender:       "coord",
+		Instructions: rootGoal,
+		Result: &AgentResult{Decision: "approved", Summary: "g0", Delegations: []Delegation{
+			{ID: "c0", Agent: "w", Action: "review", Prompt: "do g0 work"},
+		}},
+	})
+	if err := engine.AdvanceJob(ctx, "root"); err != nil {
+		t.Fatalf("AdvanceJob(root) error: %v", err)
+	}
+	completeDelegationChild(t, store, "root/delegation/c0", JobSucceeded, AgentResult{Decision: "approved", Summary: "c0 done"})
+	if err := engine.AdvanceJob(ctx, "root/delegation/c0"); err != nil {
+		t.Fatalf("AdvanceJob(c0) error: %v", err)
+	}
+
+	// Generation 1: the first continuation. Its built Instructions restate the root
+	// goal (sanity) and, crucially, it inherits RootJobID == "root". Now make THIS
+	// continuation itself delegate again so a nested (gen-2) continuation is born.
+	gen1ID := delegationContinuationID("root")
+	gen1 := mustJob(t, store, gen1ID)
+	gen1Payload, err := unmarshalPayload(gen1.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(gen1) error: %v", err)
+	}
+	if gen1Payload.RootJobID != "root" {
+		t.Fatalf("gen1 continuation RootJobID = %q, want root", gen1Payload.RootJobID)
+	}
+	if !strings.Contains(gen1Payload.Instructions, rootGoal) {
+		t.Fatalf("gen1 continuation prompt should restate the root goal:\n%s", gen1Payload.Instructions)
+	}
+	// The parent (gen1) continuation prompt opens with this distinctive sentence; if
+	// a nested continuation were anchored to parentPayload.Instructions it would leak
+	// this into the nested goal section.
+	const parentPromptSentinel = "All delegated jobs have finished"
+	if !strings.Contains(gen1Payload.Instructions, parentPromptSentinel) {
+		t.Fatalf("precondition: gen1 prompt should contain %q:\n%s", parentPromptSentinel, gen1Payload.Instructions)
+	}
+
+	gen1Payload.Result = &AgentResult{Decision: "approved", Summary: "g1", Delegations: []Delegation{
+		{ID: "c1", Agent: "w", Action: "review", Prompt: "do g1 work"},
+	}}
+	encoded, err := marshalPayload(gen1Payload)
+	if err != nil {
+		t.Fatalf("marshalPayload(gen1) error: %v", err)
+	}
+	if err := store.UpdateJobPayload(ctx, gen1ID, encoded); err != nil {
+		t.Fatalf("UpdateJobPayload(gen1) error: %v", err)
+	}
+	if err := store.UpdateJobState(ctx, gen1ID, string(JobSucceeded)); err != nil {
+		t.Fatalf("UpdateJobState(gen1) error: %v", err)
+	}
+	if err := engine.AdvanceJob(ctx, gen1ID); err != nil {
+		t.Fatalf("AdvanceJob(gen1) error: %v", err)
+	}
+	gen1ChildID := gen1ID + "/delegation/c1"
+	completeDelegationChild(t, store, gen1ChildID, JobSucceeded, AgentResult{Decision: "approved", Summary: "c1 done"})
+	if err := engine.AdvanceJob(ctx, gen1ChildID); err != nil {
+		t.Fatalf("AdvanceJob(gen1 child) error: %v", err)
+	}
+
+	// Generation 2: the NESTED continuation. Its goal must resolve from the ROOT, so
+	// the goal section equals the root goal verbatim — NOT the parent continuation's
+	// built prompt.
+	gen2 := mustJob(t, store, delegationContinuationID(gen1ID))
+	gen2Payload, err := unmarshalPayload(gen2.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(gen2) error: %v", err)
+	}
+	header := "Original goal:\n" + rootGoal + "\n\n"
+	if !strings.HasPrefix(gen2Payload.Instructions, header) {
+		t.Fatalf("nested continuation must open with the ROOT goal header.\nwant prefix:\n%q\ngot:\n%s", header, gen2Payload.Instructions)
+	}
+	// Decisive depth-stability check: isolate the goal section (between the header
+	// and the body) and assert it is the root goal alone — never the parent prompt.
+	goalSection := strings.TrimPrefix(gen2Payload.Instructions, "Original goal:\n")
+	goalSection = strings.SplitN(goalSection, "\n\n", 2)[0]
+	if strings.TrimSpace(goalSection) != rootGoal {
+		t.Fatalf("nested goal section must equal the ROOT goal, got %q (a naive parentPayload.Instructions source would leak the parent prompt here)", goalSection)
+	}
+	if strings.Contains(goalSection, parentPromptSentinel) {
+		t.Fatalf("nested goal section leaked the parent continuation prompt %q:\n%s", parentPromptSentinel, goalSection)
+	}
+}


### PR DESCRIPTION
Closes #418. Researcher-designed (decided spec on the issue).

The coordinator's continuation/finale prompt said a generic "decide the next step." Now it **restates the original goal** and reframes to **goal-anchored synthesis**.

## What
- New `Engine.originalGoal(ctx, rootJobID, fallback)` resolves the user's original goal from the **root** coordinator's `payload.Instructions` (depth-stable — *not* `parentPayload`, which for a nested continuation is the parent continuation's built prompt), falling back to `parentPayload.Instructions` on a pruned/empty root; never errors the continuation.
- Threaded a plain `goal string` into all three builders (`buildContinuationPrompt` + a budget line, `buildCorrectiveContinuationPrompt`, `buildFinalizeContinuationPrompt`): each prepends an `Original goal:` header (omitted for empty goal) and reframes the close to "synthesize an answer to the goal, reconcile conflicts, flag gaps, return new delegations ONLY for a genuine remaining gap — otherwise EMPTY = finish." Optional budget-pressure line (fails open).
- **Termination semantics unchanged** (empty delegations = done; finalize stays terminal). Builders stay pure string functions.

## Verification
- Gate green: `build/vet/test ./...` + `-race ./internal/workflow/` (226s) + `-race ./internal/cli/` (538s).
- **Load-bearing** `TestNestedContinuationAnchorsGoalFromRoot` (drives a real 2-generation chain; the nested continuation's goal equals the ROOT goal verbatim — proven to fail against a naive `parentPayload` source); plus goal/reconcile-framing, empty-goal-omits-header, corrective/finalize anchored, budget-pressure, and the updated ~11 `TestContinuationPrompt*` (incl. the `InlineArtifactBodies` flag-off byte-parity test).
- 2-lens adversarial review: **clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)