### PR TITLE
feat(runtime,doctor): daemon-aware Claude background-auth check + persistence guidance (#427)

### DIFF
--- a/docs/claude-runtime-validation.md
+++ b/docs/claude-runtime-validation.md
@@ -17,8 +17,52 @@ transcripts in the repository.
   export CLAUDE_CODE_OAUTH_TOKEN=<token>
   ```
 
-  Then restart the Gitmoot daemon so it inherits the token. Do not commit or
-  paste the token into issue comments, PR bodies, logs, or tracked files.
+  Then restart the Gitmoot daemon **from that same shell** so it inherits the
+  token. Do not commit or paste the token into issue comments, PR bodies, logs,
+  or tracked files.
+
+### Where to persist the token (this trips people up)
+
+`export` only affects the **current shell**. `gitmoot doctor` shows `claude
+auth` based on whatever shell you ran it in — and now also reports the **running
+daemon's** auth state on Linux (best-effort, read from the daemon process's
+environment). The daemon is what actually runs Claude jobs, so the daemon line
+is the signal that matters; a `current shell (not the daemon)` warn in some
+terminal does not mean the daemon is broken.
+
+To make the token survive new terminals and daemon restarts:
+
+- Persist it in **`~/.bashrc`**, not `~/.profile`. Interactive non-login
+  terminals (desktop tabs, most SSH sessions) read `~/.bashrc`; `~/.profile` is
+  read **only by login shells**. On Debian / Raspberry Pi OS the default
+  `~/.profile` itself sources `~/.bashrc`, so `~/.bashrc` covers both login and
+  non-login shells:
+
+  ```sh
+  echo 'export CLAUDE_CODE_OAUTH_TOKEN=<token>' >> ~/.bashrc
+  ```
+
+  Open a new terminal (or `source ~/.bashrc`), then restart the daemon from it.
+
+- Most robust: run the daemon under **`systemd --user`** with an
+  `EnvironmentFile`, so the daemon's auth no longer depends on which shell
+  launched it:
+
+  ```ini
+  # ~/.config/systemd/user/gitmoot-daemon.service
+  [Service]
+  EnvironmentFile=%h/.config/gitmoot/daemon.env   # contains CLAUDE_CODE_OAUTH_TOKEN=<token>
+  ExecStart=%h/.local/bin/gitmoot daemon run --repo owner/repo
+  ```
+
+  Keep the env file readable only by you (`chmod 600`); never commit it.
+
+Check the daemon's view of auth with:
+
+```sh
+gitmoot daemon status   # prints the running daemon's claude auth line on Linux
+gitmoot doctor          # shows claude auth (daemon) and the shell-local check
+```
 - `gitmoot plugin doctor claude` stays cheap and environment-only.
 - `gitmoot plugin doctor claude --live` is the explicit token-consuming smoke
   check. It should report `runtime-live ok` or a classified auth setup error.

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/db"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/presence"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 	"github.com/jerryfane/gitmoot/internal/workflow"
@@ -373,7 +374,26 @@ func runDaemonStatus(args []string, stdout, stderr io.Writer) int {
 		writeLine(stdout, "daemon stopped")
 	}
 	writeLine(stdout, "log: %s", state.LogFile)
+	if pid > 0 {
+		writeLine(stdout, "%s", daemonClaudeAuthLine(paths))
+	}
 	return 0
+}
+
+// daemonClaudeAuthLine reports the running daemon's Claude background-auth state
+// for `gitmoot daemon status` (#427). It is best-effort and OS-gated: when the
+// daemon's environment can't be read (non-Linux, hardened /proc) it says so
+// rather than implying the daemon is unauthenticated. Secrets are never printed
+// — only the masked set/unset booleans.
+func daemonClaudeAuthLine(paths config.Paths) string {
+	daemon := presence.InspectDaemonClaudeAuth(paths)
+	if !daemon.Detected {
+		return "claude auth: unknown (daemon environment not readable on this host)"
+	}
+	if daemon.Auth.Ready() {
+		return "claude auth: ok (" + daemon.Auth.MaskedDetail() + ")"
+	}
+	return "claude auth: warn (" + daemon.Auth.MaskedDetail() + "); " + runtime.ClaudeBackgroundTokenMessage
 }
 
 func runDaemonLogs(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -448,7 +448,13 @@ func dashboardTUIDeps(home string, interval time.Duration) tui.Deps {
 		},
 		HealthChecks: func() ([]tui.HealthCheck, error) {
 			ctx := context.Background()
-			checker := doctor.Checker{}
+			// Resolve paths best-effort so the Health page can report the running
+			// daemon's Claude auth state, not just the shell that launched the
+			// dashboard (#427). A failure leaves Paths zero and skips the daemon
+			// check. LiveProbe stays false: a dashboard refresh must never spawn
+			// claude.
+			paths, _ := initializedPaths(home)
+			checker := doctor.Checker{Paths: paths}
 			out := []tui.HealthCheck{}
 			for _, c := range checker.GlobalChecks(ctx) {
 				out = append(out, toTUIHealthCheck(c, ""))

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -129,7 +129,11 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	// so a cached-creds box is reported accurately rather than false-warned. The
 	// dashboard (dashboard_tui.go) leaves LiveProbe false so its refresh loop
 	// never spawns claude.
-	checks := doctor.Checker{Dir: *repoDir, LiveProbe: true}.Run(context.Background())
+	// Resolve paths best-effort so the daemon-aware claude auth check (#427) can
+	// locate the running daemon. A failure here (no initialized home) just leaves
+	// Paths zero, which skips the daemon check and keeps the shell-local one.
+	paths, _ := config.DefaultPaths()
+	checks := doctor.Checker{Dir: *repoDir, LiveProbe: true, Paths: paths}.Run(context.Background())
 	for _, check := range checks {
 		status := "ok"
 		if !check.OK {

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -157,7 +157,15 @@ func (c Checker) claudeAuthDaemon() (Check, bool) {
 	if strings.TrimSpace(c.Paths.Home) == "" {
 		return Check{}, false
 	}
-	daemon := presence.InspectDaemonClaudeAuth(c.Paths)
+	return claudeAuthDaemonCheck(presence.InspectDaemonClaudeAuth(c.Paths))
+}
+
+// claudeAuthDaemonCheck builds the daemon-aware claude auth Check from an already
+// inspected snapshot. It is split from claudeAuthDaemon so the Detected=true
+// branches (Check name/detail, pid prefix, masked set/unset, warn vs ok) are
+// testable without a live daemon or readable /proc (issue #427). Secrets never
+// reach the detail — only daemon.Auth.MaskedDetail()'s set/unset booleans.
+func claudeAuthDaemonCheck(daemon presence.DaemonAuthSnapshot) (Check, bool) {
 	if !daemon.Detected {
 		return Check{}, false
 	}

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
+	"github.com/jerryfane/gitmoot/internal/config"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/presence"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
@@ -28,6 +31,12 @@ type Checker struct {
 	// The one-shot `gitmoot doctor` (root.go) sets this true; the dashboard leaves
 	// it false so a refresh never spawns claude.
 	LiveProbe bool
+	// Paths locates the running daemon for the daemon-aware claude auth check
+	// (issue #427). When unset, the daemon check is skipped and only the
+	// shell-local check is reported. The signal that actually matters for Claude
+	// background jobs is the daemon's own environment, not the shell that ran
+	// `gitmoot doctor`.
+	Paths config.Paths
 }
 
 // Run returns the global (cwd-independent) checks followed by the per-repo
@@ -43,15 +52,22 @@ func (c Checker) Run(ctx context.Context) []Check {
 // anywhere, so the dashboard renders them once.
 func (c Checker) GlobalChecks(ctx context.Context) []Check {
 	runner := c.runner()
-	return []Check{
+	checks := []Check{
 		c.command(ctx, runner, "git", true, "--version"),
 		c.command(ctx, runner, "gh", true, "--version"),
 		c.command(ctx, runner, "codex", true, "--version"),
 		c.command(ctx, runner, "claude", false, "--help"),
 		c.command(ctx, runner, "kimi", false, "--version"),
-		c.claudeAuthEnv(ctx),
-		c.ghAuth(ctx, runner),
 	}
+	// The daemon is what actually runs Claude background jobs, so report its auth
+	// state first when it can be detected (issue #427). The shell-local check
+	// follows, clearly labeled, so a warn in a terminal can't be mistaken for "the
+	// daemon is broken".
+	if daemon, ok := c.claudeAuthDaemon(); ok {
+		checks = append(checks, daemon)
+	}
+	checks = append(checks, c.claudeAuthEnv(ctx), c.ghAuth(ctx, runner))
+	return checks
 }
 
 // RepoChecks returns the per-repo diagnostics (origin remote resolves, base
@@ -125,9 +141,41 @@ func (c Checker) baseBranch(ctx context.Context, runner subprocess.Runner, dir s
 	return Check{Name: "base branch", OK: true, Required: true, Detail: branch}
 }
 
+// claudeShellAuthLabel prefixes the shell-local claude auth detail so a warn in
+// one terminal can't be mistaken for "the daemon is broken": the env-based check
+// only ever reflects the shell that ran the command, not the daemon that runs
+// background jobs (issue #427).
+const claudeShellAuthLabel = "current shell (not the daemon)"
+
+// claudeAuthDaemon reports the running daemon's Claude auth state, best-effort.
+// The daemon is what actually runs Claude background jobs, so its environment —
+// not the invoking shell — is the signal that matters. It is OS-gated and
+// fail-open (Linux /proc only): when the daemon isn't running or its environment
+// can't be read it returns ok=false and the caller falls back to the shell-local
+// check. Secrets are never printed (masked set/unset only).
+func (c Checker) claudeAuthDaemon() (Check, bool) {
+	if strings.TrimSpace(c.Paths.Home) == "" {
+		return Check{}, false
+	}
+	daemon := presence.InspectDaemonClaudeAuth(c.Paths)
+	if !daemon.Detected {
+		return Check{}, false
+	}
+	masked := daemon.Auth.MaskedDetail()
+	detail := "running daemon (pid " + strconv.Itoa(daemon.PID) + "): " + masked
+	if daemon.Auth.Ready() {
+		if warning := daemon.Auth.Warning(); warning != "" {
+			detail += "; " + warning
+		}
+		return Check{Name: "claude auth (daemon)", OK: true, Required: false, Detail: detail}, true
+	}
+	detail += "; " + runtime.ClaudeBackgroundTokenMessage
+	return Check{Name: "claude auth (daemon)", OK: false, Required: false, Detail: detail}, true
+}
+
 func (c Checker) claudeAuthEnv(ctx context.Context) Check {
 	auth := runtime.InspectClaudeAuthEnv(os.LookupEnv)
-	masked := auth.MaskedDetail()
+	masked := claudeShellAuthLabel + ": " + auth.MaskedDetail()
 	if auth.Ready() {
 		detail := masked
 		if warning := auth.Warning(); warning != "" {

--- a/internal/doctor/checker_test.go
+++ b/internal/doctor/checker_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jerryfane/gitmoot/internal/presence"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
@@ -380,5 +381,69 @@ func TestClaudeAuthEnvLabeledAsShellScoped(t *testing.T) {
 func TestClaudeAuthDaemonSkippedWithoutPaths(t *testing.T) {
 	if _, ok := (Checker{}).claudeAuthDaemon(); ok {
 		t.Fatalf("claudeAuthDaemon returned a check without Paths set; want skip")
+	}
+}
+
+// TestClaudeAuthDaemonCheckReadyBuildsLabeledCheck exercises the Detected=true
+// ok branch (#427) without a live daemon: a detected daemon whose env carries an
+// OAuth token yields an OK `claude auth (daemon)` check whose detail is prefixed
+// with the daemon pid and reports the masked set/unset booleans — never a secret.
+func TestClaudeAuthDaemonCheckReadyBuildsLabeledCheck(t *testing.T) {
+	check, ok := claudeAuthDaemonCheck(presence.DaemonAuthSnapshot{
+		Running:  true,
+		PID:      4321,
+		Detected: true,
+		Auth:     runtime.ClaudeAuthEnv{ClaudeOAuthToken: true},
+	})
+	if !ok {
+		t.Fatalf("claudeAuthDaemonCheck ok=false for a detected daemon, want true")
+	}
+	if check.Name != "claude auth (daemon)" {
+		t.Fatalf("check.Name = %q, want \"claude auth (daemon)\"", check.Name)
+	}
+	if !check.OK || check.Required {
+		t.Fatalf("check = %+v, want optional OK check for a token-bearing daemon", check)
+	}
+	if !strings.Contains(check.Detail, "running daemon (pid 4321):") {
+		t.Fatalf("check.Detail = %q, want pid-prefixed daemon detail", check.Detail)
+	}
+	if !strings.Contains(check.Detail, runtime.ClaudeOAuthTokenEnv+"=set") {
+		t.Fatalf("check.Detail = %q, want masked CLAUDE_CODE_OAUTH_TOKEN=set", check.Detail)
+	}
+	if strings.Contains(check.Detail, "set; ANTHROPIC") && !strings.Contains(check.Detail, "=unset") {
+		t.Fatalf("check.Detail = %q, want unset reported for absent vars", check.Detail)
+	}
+}
+
+// TestClaudeAuthDaemonCheckUnauthenticatedWarns exercises the Detected=true warn
+// branch: a detected daemon with no token yields an OK:false check carrying the
+// background-token persistence guidance, still pid-prefixed and secret-free.
+func TestClaudeAuthDaemonCheckUnauthenticatedWarns(t *testing.T) {
+	check, ok := claudeAuthDaemonCheck(presence.DaemonAuthSnapshot{
+		Running:  true,
+		PID:      7,
+		Detected: true,
+		Auth:     runtime.ClaudeAuthEnv{},
+	})
+	if !ok {
+		t.Fatalf("claudeAuthDaemonCheck ok=false for a detected daemon, want true")
+	}
+	if check.OK || check.Required {
+		t.Fatalf("check = %+v, want optional warn for an unauthenticated daemon", check)
+	}
+	if !strings.Contains(check.Detail, "running daemon (pid 7):") {
+		t.Fatalf("check.Detail = %q, want pid-prefixed daemon detail", check.Detail)
+	}
+	if !strings.Contains(check.Detail, runtime.ClaudeBackgroundTokenMessage) {
+		t.Fatalf("check.Detail = %q, want background-token persistence guidance", check.Detail)
+	}
+}
+
+// TestClaudeAuthDaemonCheckSkipsWhenUndetected guards the fail-open contract at
+// the construction seam: an undetected snapshot (non-Linux, unreadable /proc, or
+// no daemon) yields ok=false so callers fall back to the shell-local check.
+func TestClaudeAuthDaemonCheckSkipsWhenUndetected(t *testing.T) {
+	if _, ok := claudeAuthDaemonCheck(presence.DaemonAuthSnapshot{Running: true, PID: 9, Detected: false}); ok {
+		t.Fatalf("claudeAuthDaemonCheck ok=true for an undetected daemon, want skip")
 	}
 }

--- a/internal/doctor/checker_test.go
+++ b/internal/doctor/checker_test.go
@@ -356,3 +356,29 @@ func (r pathSensitiveRunner) Run(ctx context.Context, dir string, command string
 	}
 	return r.fakeRunner.Run(ctx, dir, command, args...)
 }
+
+// TestClaudeAuthEnvLabeledAsShellScoped guards the #427 fix: the shell-local
+// claude auth check must label itself as reflecting the current shell, not the
+// daemon, so a warn in one terminal can't be mistaken for "the daemon is broken".
+func TestClaudeAuthEnvLabeledAsShellScoped(t *testing.T) {
+	withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
+	check := Checker{}.claudeAuthEnv(context.Background())
+	if !check.OK {
+		t.Fatalf("claude auth check = %+v, want OK with env token", check)
+	}
+	if !strings.Contains(check.Detail, claudeShellAuthLabel) {
+		t.Fatalf("claude auth detail = %q, want shell-scoped label %q", check.Detail, claudeShellAuthLabel)
+	}
+	if strings.Contains(check.Detail, "secret-token") {
+		t.Fatalf("claude auth detail = %q must never print the token", check.Detail)
+	}
+}
+
+// TestClaudeAuthDaemonSkippedWithoutPaths guards the fail-open contract: with no
+// Paths the daemon-aware check is skipped (ok=false) and callers fall back to the
+// shell-local check, so GlobalChecks never invents a daemon check it can't back.
+func TestClaudeAuthDaemonSkippedWithoutPaths(t *testing.T) {
+	if _, ok := (Checker{}).claudeAuthDaemon(); ok {
+		t.Fatalf("claudeAuthDaemon returned a check without Paths set; want skip")
+	}
+}

--- a/internal/presence/daemon_env_linux.go
+++ b/internal/presence/daemon_env_linux.go
@@ -23,6 +23,15 @@ func readProcessEnviron(pid int) (func(string) (string, bool), bool) {
 	if err != nil {
 		return nil, false
 	}
+	return parseEnviron(contents), true
+}
+
+// parseEnviron turns the raw NUL-delimited contents of /proc/<pid>/environ into
+// an env lookup. Each entry is a NUL-terminated key=value pair; the value may
+// itself contain '=', so the split is on the first '=' only. Entries without an
+// '=' (or empty trailing entries) are skipped. It is split from readProcessEnviron
+// so the parser can be unit-tested on synthetic bytes (issue #427).
+func parseEnviron(contents []byte) func(string) (string, bool) {
 	env := map[string]string{}
 	for _, entry := range strings.Split(string(contents), "\x00") {
 		if entry == "" {
@@ -37,5 +46,5 @@ func readProcessEnviron(pid int) (func(string) (string, bool), bool) {
 	return func(key string) (string, bool) {
 		value, ok := env[key]
 		return value, ok
-	}, true
+	}
 }

--- a/internal/presence/daemon_env_linux.go
+++ b/internal/presence/daemon_env_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package presence
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// readProcessEnviron reads /proc/<pid>/environ and returns an env lookup over the
+// running process's environment. It is best-effort and fail-open: a missing or
+// unreadable /proc entry (different user, hardened kernel, process gone) reports
+// detected=false rather than an error, mirroring the OS-gated /proc reads in
+// process_unix.go. It is only built on Linux; other platforms get the no-op
+// variant in daemon_env_other.go.
+func readProcessEnviron(pid int) (func(string) (string, bool), bool) {
+	if pid <= 0 {
+		return nil, false
+	}
+	contents, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "environ"))
+	if err != nil {
+		return nil, false
+	}
+	env := map[string]string{}
+	for _, entry := range strings.Split(string(contents), "\x00") {
+		if entry == "" {
+			continue
+		}
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		env[name] = value
+	}
+	return func(key string) (string, bool) {
+		value, ok := env[key]
+		return value, ok
+	}, true
+}

--- a/internal/presence/daemon_env_linux_test.go
+++ b/internal/presence/daemon_env_linux_test.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package presence
+
+import (
+	"os"
+	"testing"
+)
+
+// TestParseEnvironSplitsNULAndFirstEquals exercises the only genuinely new
+// algorithm in #427: the NUL-split of /proc/<pid>/environ plus the key=value Cut.
+// It feeds synthetic NUL-delimited bytes so a mis-parse (wrong delimiter, wrong
+// '=' split, dropped/extra entries) can no longer pass silently. It asserts:
+// values containing '=' keep everything after the first '=', a key with an empty
+// value resolves to "" (present), entries without '=' are skipped, empty/trailing
+// entries are ignored, and an absent key reports not-present.
+func TestParseEnvironSplitsNULAndFirstEquals(t *testing.T) {
+	raw := []byte("CLAUDE_CODE_OAUTH_TOKEN=tok=with=equals\x00EMPTY=\x00NO_EQUALS\x00\x00PATH=/usr/bin\x00")
+	lookup := parseEnviron(raw)
+
+	if got, ok := lookup("CLAUDE_CODE_OAUTH_TOKEN"); !ok || got != "tok=with=equals" {
+		t.Fatalf("lookup(CLAUDE_CODE_OAUTH_TOKEN) = (%q, %t), want (\"tok=with=equals\", true)", got, ok)
+	}
+	if got, ok := lookup("EMPTY"); !ok || got != "" {
+		t.Fatalf("lookup(EMPTY) = (%q, %t), want (\"\", true)", got, ok)
+	}
+	if got, ok := lookup("PATH"); !ok || got != "/usr/bin" {
+		t.Fatalf("lookup(PATH) = (%q, %t), want (\"/usr/bin\", true)", got, ok)
+	}
+	if _, ok := lookup("NO_EQUALS"); ok {
+		t.Fatalf("lookup(NO_EQUALS) ok=true, want false for an entry without '='")
+	}
+	if _, ok := lookup("ABSENT"); ok {
+		t.Fatalf("lookup(ABSENT) ok=true, want false for an unset key")
+	}
+}
+
+// TestReadProcessEnvironReadsOwnProc exercises the live read path end to end:
+// /proc/self/environ is always readable by the running process, so the read
+// succeeds and a variable present in this process's exec-time environment
+// resolves. PATH is set for every test binary launched by `go test` and is not
+// mutated by this test, so it is a stable known-present key.
+func TestReadProcessEnvironReadsOwnProc(t *testing.T) {
+	path, present := os.LookupEnv("PATH")
+	if !present {
+		t.Skip("PATH not set in this process; nothing stable to assert against")
+	}
+
+	lookup, ok := readProcessEnviron(os.Getpid())
+	if !ok {
+		t.Fatalf("readProcessEnviron(self) detected=false, want true reading own /proc/self/environ")
+	}
+	if got, ok := lookup("PATH"); !ok || got != path {
+		t.Fatalf("lookup(PATH) = (%q, %t), want (%q, true) from /proc/self/environ", got, ok, path)
+	}
+	if _, ok := lookup("GITMOOT_DEFINITELY_UNSET_ENVIRON_VAR"); ok {
+		t.Fatalf("lookup(missing) ok=true, want false for an unset var")
+	}
+}
+
+// TestReadProcessEnvironFailsOpenOnBadPID guards the fail-open contract: a
+// non-positive or unreadable pid degrades to detected=false (nil lookup) rather
+// than panicking or erroring, mirroring the OS-gated /proc reads in
+// process_unix.go.
+func TestReadProcessEnvironFailsOpenOnBadPID(t *testing.T) {
+	if lookup, ok := readProcessEnviron(0); ok || lookup != nil {
+		t.Fatalf("readProcessEnviron(0) = (lookup!=nil:%t, ok:%t), want (nil, false)", lookup != nil, ok)
+	}
+	// A pid that almost certainly does not exist: /proc/<pid>/environ is unreadable
+	// so the read fails open to detected=false.
+	if lookup, ok := readProcessEnviron(999999); ok || lookup != nil {
+		t.Fatalf("readProcessEnviron(999999) = (lookup!=nil:%t, ok:%t), want (nil, false)", lookup != nil, ok)
+	}
+}

--- a/internal/presence/daemon_env_other.go
+++ b/internal/presence/daemon_env_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package presence
+
+// readProcessEnviron has no portable implementation outside Linux. Daemon-env
+// auth detection is best-effort and OS-gated (issue #427 non-goal: no /proc read
+// on Windows/macOS), mirroring the OS gating in internal/presence. Non-Linux
+// builds always report detected=false so callers fall back to the shell-local
+// check.
+func readProcessEnviron(_ int) (func(string) (string, bool), bool) {
+	return nil, false
+}

--- a/internal/presence/snapshot.go
+++ b/internal/presence/snapshot.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -113,6 +114,47 @@ func BuildSnapshot(ctx context.Context, paths config.Paths, repoFullName string)
 		})
 	}
 	return snapshot, nil
+}
+
+// DaemonAuthSnapshot reports the running daemon's Claude auth env, best-effort.
+// The signal that actually matters for background Claude jobs is the daemon's own
+// environment (not the shell that ran `gitmoot doctor`), so this reads the live
+// daemon process's environment. It is fail-open and OS-gated: outside Linux, or
+// when /proc is unreadable, Detected is false and callers fall back to the
+// shell-local check (issue #427).
+type DaemonAuthSnapshot struct {
+	// Running reports whether a daemon process was located at all.
+	Running bool
+	// PID is the daemon process id when Running.
+	PID int
+	// Detected reports whether the daemon's environment could be read. When false,
+	// Auth is zero and callers must not treat it as "daemon has no token".
+	Detected bool
+	// Auth is the daemon's Claude auth env (only meaningful when Detected).
+	Auth runtime.ClaudeAuthEnv
+}
+
+// InspectDaemonClaudeAuth locates the running daemon and reports its Claude auth
+// environment, best-effort. It never returns an error: a missing daemon,
+// unreadable /proc, or non-Linux host all degrade to Detected=false so the
+// caller can fall back to the shell-local check. Secrets are never returned —
+// only the presence/absence booleans on ClaudeAuthEnv.
+func InspectDaemonClaudeAuth(paths config.Paths) DaemonAuthSnapshot {
+	daemon := InspectDaemon(paths)
+	snapshot := DaemonAuthSnapshot{
+		PID:     daemon.PID,
+		Running: daemon.State == DaemonRunning,
+	}
+	if !snapshot.Running || daemon.PID <= 0 {
+		return snapshot
+	}
+	lookup, ok := readProcessEnviron(daemon.PID)
+	if !ok {
+		return snapshot
+	}
+	snapshot.Detected = true
+	snapshot.Auth = runtime.InspectClaudeAuthEnv(lookup)
+	return snapshot
 }
 
 func InspectDaemon(paths config.Paths) DaemonSnapshot {

--- a/internal/presence/snapshot_test.go
+++ b/internal/presence/snapshot_test.go
@@ -121,6 +121,26 @@ func TestInspectDaemonTreatsLiveNonDaemonPIDAsStale(t *testing.T) {
 	}
 }
 
+// TestInspectDaemonClaudeAuthFailsOpenWithoutDaemon guards the #427 fail-open
+// contract: with no running daemon, the auth snapshot reports neither running nor
+// detected so doctor/dashboard/daemon-status fall back to the shell-local check
+// instead of implying the daemon is unauthenticated.
+func TestInspectDaemonClaudeAuthFailsOpenWithoutDaemon(t *testing.T) {
+	paths := testPaths(t)
+
+	snapshot := InspectDaemonClaudeAuth(paths)
+
+	if snapshot.Running {
+		t.Fatalf("daemon auth Running = true, want false without a daemon")
+	}
+	if snapshot.Detected {
+		t.Fatalf("daemon auth Detected = true, want false without a readable daemon env")
+	}
+	if snapshot.Auth.Ready() {
+		t.Fatalf("daemon auth Ready = true, want false when env is undetected")
+	}
+}
+
 func TestFormatSnapshotQuotesLockMetadata(t *testing.T) {
 	text := FormatSnapshot(Snapshot{
 		Daemon:     DaemonSnapshot{State: DaemonRunning, PID: 42},

--- a/internal/runtime/claude_auth.go
+++ b/internal/runtime/claude_auth.go
@@ -18,7 +18,7 @@ const (
 	// ClaudeBackgroundTokenMessage is the warn-path caveat: foreground Claude
 	// authenticates fine via cached credentials, but daemon background jobs run
 	// non-interactively and need an explicit token in the daemon env.
-	ClaudeBackgroundTokenMessage = "Foreground Claude works via cached credentials, but daemon background jobs run non-interactively and need a token in the daemon env. Run: claude setup-token; export CLAUDE_CODE_OAUTH_TOKEN=<token>; then restart the Gitmoot daemon so it inherits the token."
+	ClaudeBackgroundTokenMessage = "Foreground Claude works via cached credentials, but daemon background jobs run non-interactively and need a token in the daemon env. Run: claude setup-token; export CLAUDE_CODE_OAUTH_TOKEN=<token>; then restart the Gitmoot daemon from that same shell so it inherits the token. export is per-shell, so persist the token in ~/.bashrc (interactive non-login terminals read it; on Debian/Raspberry Pi OS ~/.profile is login-only and itself sources ~/.bashrc). For a daemon that does not depend on which shell launched it, run it under `systemd --user` with an EnvironmentFile."
 	// ClaudeSessionAuthFailedMessage is the failure-path message: a genuine
 	// authentication/session failure (the cached session is expired or the
 	// --resume target is dead) that needs re-authentication and a fresh bind.

--- a/website/docs/plugins/codex-claude.md
+++ b/website/docs/plugins/codex-claude.md
@@ -243,6 +243,39 @@ Gitmoot daemon or runtime session that must inherit the new environment. Never
 paste tokens into PR comments, issue bodies, tracked files, generated plugin
 packages, or logs.
 
+### Claude background-auth: per-shell export vs. the daemon
+
+Claude background jobs run **non-interactively** inside the daemon, so the
+daemon's environment must carry the token:
+
+```sh
+claude setup-token
+export CLAUDE_CODE_OAUTH_TOKEN=<token>
+```
+
+`export` only affects the **current shell**, so restart the daemon **from that
+same shell** so it inherits the token. `gitmoot doctor` reports `claude auth`
+for the shell that ran it, labeled `current shell (not the daemon)`, and on
+Linux it also reports `claude auth (daemon)` read from the running daemon's
+environment. The daemon line is the one that matters; `gitmoot daemon status`
+prints it too. A shell-local warn in one terminal does not mean the daemon is
+broken.
+
+To make the token survive new terminals and daemon restarts:
+
+- Persist it in **`~/.bashrc`**, not `~/.profile`. Interactive non-login
+  terminals (desktop tabs, most SSH sessions) read `~/.bashrc`; `~/.profile` is
+  read only by login shells. On Debian / Raspberry Pi OS the default
+  `~/.profile` itself sources `~/.bashrc`, so `~/.bashrc` covers both:
+
+  ```sh
+  echo 'export CLAUDE_CODE_OAUTH_TOKEN=<token>' >> ~/.bashrc
+  ```
+
+- Most robust: run the daemon under **`systemd --user`** with an
+  `EnvironmentFile`, so daemon auth no longer depends on which shell launched
+  it. Keep that env file readable only by you (`chmod 600`) and never commit it.
+
 For fast current-chat planning, ask Claude Code to use the Gitmoot planner here
 instead of starting a background `gitmoot agent ask` job.
 


### PR DESCRIPTION
Closes #427

## Why

Setting up Claude credentials for **background (daemon) jobs** was confusing in two ways: the `claude auth` check in `gitmoot doctor` / dashboard Health reported the **invoking shell's** environment (`os.LookupEnv`) rather than the daemon's — the thing that actually runs jobs — so the same setup showed `ok` in the tab you `export`ed in and `warn` everywhere else. And the guidance never said *where to persist* the token (`~/.profile` is login-only; interactive terminals read `~/.bashrc`).

## Research that backed it

The issue documented the exact failure path and the in-repo precedent: `internal/presence/process_unix.go` already reads `/proc/<pid>/cmdline` to identify the daemon, so reading `/proc/<pid>/environ` (best-effort, OS-gated, fail-open) for a daemon-aware auth check fits the existing pattern. The shell-local check lives at `internal/doctor/checker.go`, the dashboard reuses it via `GlobalChecks`, and the warn-path message lives in `internal/runtime/claude_auth.go`.

## Changes

- **Daemon-aware auth (the signal that matters).** New `internal/presence/daemon_env_linux.go` reads `/proc/<pid>/environ` on Linux (NUL-delimited, first-`=` split), with a `!linux` no-op fallback in `daemon_env_other.go`. New `presence.InspectDaemonClaudeAuth` locates the running daemon and reports its `ClaudeAuthEnv`, fail-open (`Detected=false` when /proc is unreadable or off-Linux). Secrets never leave presence — only set/unset booleans.
- **Surfaced in three places:** `gitmoot doctor` adds a `claude auth (daemon)` check (pid-labeled, shown first); the dashboard Health page resolves paths so it reports the daemon too (LiveProbe stays false — a refresh never spawns claude); `gitmoot daemon status` prints a `claude auth:` line for the running daemon.
- **Shell-local check labeled** `current shell (not the daemon)` so a terminal warn can't be mistaken for a broken daemon.
- **Expanded guidance** in `ClaudeBackgroundTokenMessage` (the warn-path constant returned by `ClaudeAuthEnv.Warning()`): per-shell `export`, restart the daemon from a token-bearing shell, persist in `~/.bashrc` (with the Debian/Raspberry Pi OS `.profile`-sources-`.bashrc` note), and the `systemd --user` `EnvironmentFile` option.
- **Docs (both trees):** `docs/claude-runtime-validation.md` and `website/docs/plugins/codex-claude.md`.

Secrets stay masked (`MaskedDetail`), no token is stored in DB/config, and `/proc` reads are Linux-only and fail-open (non-goals respected). Independently mergeable from #428.

## Tests / checks run

- `go build ./...`, `go vet ./...`, `go test ./...` — all pass.
- New tests: `internal/presence/daemon_env_linux_test.go` (parseEnviron, readProcessEnviron own-proc + bad-pid fail-open), `internal/presence/snapshot_test.go` (fail-open without daemon), `internal/doctor/checker_test.go` (shell label, daemon check ready/warn/skip), plus the existing runtime auth-message tests.
- `go test -race ./internal/workflow/` is the CI race gate; it cannot run on this Raspberry Pi kernel (`ThreadSanitizer: unsupported VMA range`) — the non-race run passes and CI runs it on supported runners.
- E2E against the live daemon on this host: `gitmoot daemon status` prints `claude auth: ok` read from the daemon's env; `gitmoot doctor` shows `claude auth (daemon) ok (pid …)` AND a shell-local line labeled `current shell (not the daemon)` that warns when the shell token is unset — demonstrating the daemon-vs-shell disambiguation with masked set/unset values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
