### PR TITLE
feat(workflow): deps[] as dataflow — inject upstream dependency results into dependent legs (#419)

### DIFF
--- a/docs/cockpit-orchestrate.md
+++ b/docs/cockpit-orchestrate.md
@@ -75,6 +75,7 @@ cockpit_max_panes = 4      # cap on simultaneous panes per run
 cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
 inline_artifact_bodies = false   # inline each child's artifact_body into the coordinator continuation
 inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
+inject_upstream_dep_context = false  # inject succeeded upstream dependency results into a dependent leg's prompt; default off
 max_delegation_token_budget = 0  # per-root delegation token budget (input+output); 0 = unlimited (off)
 max_delegation_cost_usd = 0      # per-root delegation dollar-cost budget (USD); 0 = unlimited (off)
 ```
@@ -95,6 +96,8 @@ max_delegation_cost_usd = 0      # per-root delegation dollar-cost budget (USD);
   many bytes of each child's body are inlined; longer bodies are rune-safe
   truncated with a marker pointing at the full on-disk brief. A per-continuation
   aggregate cap also bounds the total inlined across all children.
+- `inject_upstream_dep_context` (default `false`) injects succeeded upstream
+  dependency results into a dependent leg's prompt; default off.
 - `max_delegation_token_budget` (default `0` = unlimited/off) bounds a delegation
   tree by **cost** in addition to depth/width/total-jobs/wall-clock. When set to a
   positive value, the whole tree under one root is capped at that many cumulative

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3379,11 +3379,12 @@ func (w jobWorker) defaultWorkflow(checkout string) workflow.Engine {
 }
 
 // applyOrchestratePolicy sets the engine's opt-in [orchestrate] fields — the
-// artifact-body inlining knobs, the per-root delegation token (#338 Part B) and
-// dollar-cost (#380) budgets, and the result-aware non-progress streak threshold
-// (#339) — from the host policy. It is fail-safe: any load error leaves the
-// engine with its defaults (inlining off, both budgets 0 = unlimited, streak
-// threshold 0 = engine default) rather than failing engine construction.
+// artifact-body inlining knobs, the upstream-dep-context injection toggle (#419),
+// the per-root delegation token (#338 Part B) and dollar-cost (#380) budgets, and
+// the result-aware non-progress streak threshold (#339) — from the host policy. It
+// is fail-safe: any load error leaves the engine with its defaults (inlining off,
+// upstream-dep injection off, both budgets 0 = unlimited, streak threshold 0 =
+// engine default) rather than failing engine construction.
 func (w jobWorker) applyOrchestratePolicy(engine *workflow.Engine) {
 	policy, err := w.orchestratePolicy()
 	if err != nil {
@@ -3391,6 +3392,7 @@ func (w jobWorker) applyOrchestratePolicy(engine *workflow.Engine) {
 	}
 	engine.InlineArtifactBodies = policy.InlineArtifactBodies
 	engine.MaxInlineArtifactBytes = policy.InlineArtifactMaxBytes
+	engine.InjectUpstreamDepContext = policy.InjectUpstreamDepContext
 	engine.MaxDelegationTokenBudget = policy.MaxDelegationTokenBudget
 	engine.MaxDelegationCostUSD = policy.MaxDelegationCostUSD
 	engine.MaxDelegationNonProgressStreak = policy.MaxDelegationNonProgressStreak

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -39,6 +39,14 @@ type OrchestratePolicy struct {
 	// InlineArtifactMaxBytes is the per-body byte cap applied when
 	// InlineArtifactBodies is set; 0 means the engine's built-in default.
 	InlineArtifactMaxBytes int
+	// InjectUpstreamDepContext opts a ready dependent delegation leg into running
+	// with its succeeded direct deps' results injected into its prompt as a
+	// byte-budgeted "Upstream dependency results" block (deps[] as real dataflow,
+	// see issue #419). It is off by default — flag-off the enqueued prompt is
+	// byte-identical — and reuses the same artifact-body byte budget as
+	// InlineArtifactBodies (no new knob). The daemon wires this into
+	// Engine.InjectUpstreamDepContext at startup.
+	InjectUpstreamDepContext bool
 	// MaxDelegationTokenBudget is the cumulative per-root token budget (input +
 	// output, summed across a delegation tree) that bounds a tree by cost in
 	// addition to depth/width/total-jobs/wall-clock (#338 Part B). 0 (the default)
@@ -80,6 +88,7 @@ func DefaultOrchestratePolicy() OrchestratePolicy {
 		CockpitPaneKey:                 CockpitPaneKeyJob,
 		InlineArtifactBodies:           false,
 		InlineArtifactMaxBytes:         0,
+		InjectUpstreamDepContext:       false,
 		MaxDelegationTokenBudget:       0,
 		MaxDelegationCostUSD:           0,
 		EscalationHandle:               "",
@@ -147,6 +156,10 @@ func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value st
 	case "inline_artifact_max_bytes":
 		parsed, err := strconv.Atoi(value)
 		policy.InlineArtifactMaxBytes = parsed
+		return err
+	case "inject_upstream_dep_context":
+		parsed, err := strconv.ParseBool(value)
+		policy.InjectUpstreamDepContext = parsed
 		return err
 	case "max_delegation_token_budget":
 		parsed, err := strconv.Atoi(value)

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -35,6 +35,9 @@ func TestLoadOrchestratePolicyDefaults(t *testing.T) {
 	if policy.InlineArtifactMaxBytes != 0 {
 		t.Fatalf("InlineArtifactMaxBytes = %d, want 0 by default", policy.InlineArtifactMaxBytes)
 	}
+	if policy.InjectUpstreamDepContext {
+		t.Fatalf("InjectUpstreamDepContext = true, want false by default")
+	}
 	if policy.MaxDelegationTokenBudget != 0 {
 		t.Fatalf("MaxDelegationTokenBudget = %d, want 0 (unlimited) by default", policy.MaxDelegationTokenBudget)
 	}
@@ -258,6 +261,45 @@ cockpit_mode = "auto"
 	}
 }
 
+// TestLoadOrchestratePolicyInjectUpstreamDepContext pins #419: the
+// inject_upstream_dep_context toggle parses from [orchestrate], and an absent key
+// keeps the off default, mirroring the inline-artifact keys above.
+func TestLoadOrchestratePolicyInjectUpstreamDepContext(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+inject_upstream_dep_context = true
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	policy, err := LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if !policy.InjectUpstreamDepContext {
+		t.Fatalf("InjectUpstreamDepContext = false, want true")
+	}
+
+	// Absent key keeps the off default even when the section is otherwise present.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+cockpit_mode = "auto"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err = LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.InjectUpstreamDepContext {
+		t.Fatalf("absent inject_upstream_dep_context should default off, got %+v", policy)
+	}
+}
+
 func TestLoadOrchestratePolicyOverrides(t *testing.T) {
 	paths := PathsForHome(t.TempDir())
 	if err := Initialize(paths); err != nil {
@@ -344,6 +386,14 @@ max_delegation_cost_usd = cheap
 max_delegation_cost_usd = -0.5
 `,
 			wantErr: "max_delegation_cost_usd must be 0 (unlimited) or positive",
+		},
+		{
+			name: "inject_upstream_dep_context_non_bool",
+			body: `
+[orchestrate]
+inject_upstream_dep_context = maybe
+`,
+			wantErr: "parse [orchestrate].inject_upstream_dep_context",
 		},
 		{
 			name: "max_delegation_non_progress_streak_non_int",

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1704,8 +1704,12 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 // retry uses a distinct .../retry/<n> id so the enqueue idempotency path does not
 // mistake it for the already-failed original, carries RetryCount+1 in its
 // payload, and inherits the same DelegationID so it represents the same node in
-// the delegation graph. It returns whether a retry was enqueued.
-func (e Engine) requeueDelegation(ctx context.Context, parentJob db.Job, parentPayload JobPayload, d Delegation, failedChild db.Job, artifactDir string, ref taskRef) (bool, error) {
+// the delegation graph. upstreamContext is the #419 "Upstream dependency results"
+// block (or "" when InjectUpstreamDepContext is off); the caller computes it from
+// the current children/dedupWinners so a retried dependent re-receives the same
+// upstream block its first attempt got rather than running blind. It returns
+// whether a retry was enqueued.
+func (e Engine) requeueDelegation(ctx context.Context, parentJob db.Job, parentPayload JobPayload, d Delegation, failedChild db.Job, artifactDir string, upstreamContext string, ref taskRef) (bool, error) {
 	if d.Retry <= 0 {
 		return false, nil
 	}
@@ -1719,6 +1723,13 @@ func (e Engine) requeueDelegation(ctx context.Context, parentJob db.Job, parentP
 	request.ID = parentJob.ID + "/delegation/" + d.ID + "/retry/" + strconv.Itoa(next)
 	request.RetryCount = next
 	request.DelegationArtifactDir = artifactDir
+	// Re-inject the #419 "Upstream dependency results" block so a retried dependent
+	// runs WITH its upstream deps' results, exactly as its first attempt did.
+	// upstreamContext is "" unless Engine.InjectUpstreamDepContext is set, so the
+	// flag-off retry prompt is byte-identical to before this field existed.
+	if upstreamContext != "" {
+		request.Instructions = request.Instructions + upstreamContext
+	}
 
 	if err := e.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, d, request, ref); err != nil {
 		return false, err
@@ -1778,7 +1789,18 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 		if !ok || !isTerminalJobState(child.State) || child.State == string(JobSucceeded) {
 			continue
 		}
-		didRetry, err := e.requeueDelegation(ctx, parentJob, parentPayload, d, child, artifactDir, ref)
+		// #419: a retried dependent must not run blind to its upstream deps. The
+		// first attempt got the "Upstream dependency results" block injected at its
+		// enqueue point in advanceDelegations, but a retry re-enqueues from
+		// requeueDelegation, so re-inject the same block here (resolved against the
+		// current children/dedupWinners, which still hold the succeeded deps).
+		// Gated on InjectUpstreamDepContext so the flag-off retry prompt is
+		// byte-identical to before this change.
+		upstreamContext := ""
+		if e.InjectUpstreamDepContext {
+			upstreamContext = e.buildUpstreamDepBlock(d, children, dedupWinners)
+		}
+		didRetry, err := e.requeueDelegation(ctx, parentJob, parentPayload, d, child, artifactDir, upstreamContext, ref)
 		if err != nil {
 			return err
 		}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -65,6 +65,17 @@ type Engine struct {
 	// defaultMaxInlineArtifactBytes. The total inlined across all children in one
 	// continuation is additionally bounded by maxInlineArtifactTotalBytes.
 	MaxInlineArtifactBytes int
+	// InjectUpstreamDepContext, when true, makes deps[] real dataflow (#419):
+	// when advanceDelegations enqueues a ready dependent leg, each of that leg's
+	// succeeded DIRECT deps' results (decision, summary preview, PR link,
+	// changes_made count, short HeadSHA, then the fenced artifact_body) are
+	// appended to the dependent's Instructions as a byte-budgeted "Upstream
+	// dependency results" block, so the dependent runs WITH its upstream results
+	// rather than blind to them. It mirrors InlineArtifactBodies: opt-in (default
+	// false) and reusing the SAME MaxInlineArtifactBytes per-body cap and
+	// maxInlineArtifactTotalBytes aggregate budget (no new knob). With the flag
+	// off the enqueued prompt is byte-identical to before this field existed.
+	InjectUpstreamDepContext bool
 	// MaxDelegationTokenBudget is the cumulative per-root token budget (input +
 	// output, summed across a coordination tree) that bounds a delegation tree by
 	// cost in addition to depth/width/total-jobs/wall-clock (#338 Part B). When a
@@ -1256,7 +1267,10 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		if len(compactStrings(d.Deps)) > 0 {
 			continue
 		}
-		if err := e.enqueueDelegation(ctx, job, payload, d, artifactDir, ref); err != nil {
+		// Ready (dep-free) delegations dispatch here with no upstream context: a
+		// dep-free leg has no upstream deps to inject, and a deps-bearing leg is
+		// deferred to advanceDelegations (which injects #419 upstream results).
+		if err := e.enqueueDelegation(ctx, job, payload, d, artifactDir, "", ref); err != nil {
 			return err
 		}
 	}
@@ -1435,9 +1449,16 @@ func (e Engine) enqueueFinalizeContinuation(ctx context.Context, job db.Job, pay
 // deterministic-ID insert is swallowed by e.enqueue when the existing job
 // matches the request, so it is safe to call from both dispatchDelegations and
 // advanceDelegations.
-func (e Engine) enqueueDelegation(ctx context.Context, job db.Job, payload JobPayload, d Delegation, artifactDir string, ref taskRef) error {
+func (e Engine) enqueueDelegation(ctx context.Context, job db.Job, payload JobPayload, d Delegation, artifactDir string, upstreamContext string, ref taskRef) error {
 	request := e.delegationRequest(job, payload, d)
 	request.DelegationArtifactDir = artifactDir
+	// Append the #419 "Upstream dependency results" block (built by the caller
+	// from this dependent's succeeded direct deps) to the child's instructions.
+	// upstreamContext is "" unless Engine.InjectUpstreamDepContext is set, so the
+	// flag-off enqueued prompt is byte-identical to before this field existed.
+	if upstreamContext != "" {
+		request.Instructions = request.Instructions + upstreamContext
+	}
 
 	// Fingerprint dedup: skip enqueueing a child whose fingerprint already
 	// appears among a sibling under the same parent. Scoped to this parent via
@@ -1842,7 +1863,16 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 			if !depsSatisfied(d.Deps, children, dedupWinners) {
 				continue
 			}
-			if err := e.enqueueDelegation(ctx, parentJob, parentPayload, d, artifactDir, ref); err != nil {
+			// #419: make deps[] real dataflow. This dependent is enqueued exactly
+			// here, after every dep succeeded and while children/dedupWinners hold
+			// the dep payloads, so inject the succeeded direct deps' results into
+			// its prompt. Gated behind InjectUpstreamDepContext so the flag-off
+			// enqueued instructions are byte-identical to before this change.
+			upstreamContext := ""
+			if e.InjectUpstreamDepContext {
+				upstreamContext = e.buildUpstreamDepBlock(d, children, dedupWinners)
+			}
+			if err := e.enqueueDelegation(ctx, parentJob, parentPayload, d, artifactDir, upstreamContext, ref); err != nil {
 				return err
 			}
 			// Re-read children AND events so a second satisfied dependent in the
@@ -2493,6 +2523,139 @@ func (e Engine) appendInlineArtifactBody(builder *strings.Builder, payload JobPa
 	builder.WriteString(inner.String())
 	builder.WriteString(fence)
 	builder.WriteString("\n")
+}
+
+// maxUpstreamDepSummaryPreviewBytes caps the inline summary preview emitted on a
+// dependency's header line in the "Upstream dependency results" block (#419). The
+// full body travels by reference as the fenced artifact_body below the line, so
+// the header preview is intentionally short; it is rune-safe truncated and fenced
+// so an embedded gitmoot_result sentinel in a summary cannot escape inline.
+const maxUpstreamDepSummaryPreviewBytes = 280
+
+// buildUpstreamDepBlock renders the "Upstream dependency results" block injected
+// into a ready dependent leg's prompt when InjectUpstreamDepContext is set (#419):
+// deps[] as real dataflow. For each of d's succeeded DIRECT deps (sorted by id for
+// stable output), it emits a header line —
+//
+//	- dep <id> (agent <a>, action <act>): <decision> — <summary preview> (<PR>) [changes_made: N] [head <sha7>]
+//
+// then the dep's artifact_body as a fenced, byte-budgeted block reusing
+// appendInlineArtifactBody (the SAME per-body cap and shared aggregate budget the
+// continuation prompt uses). Deps travel by reference: decision + truncated
+// summary preview + PR link + changes count + short HeadSHA + the on-disk body
+// path in any truncation marker — never the bulk body by value beyond the budget.
+//
+// Decided defaults (#419): direct-deps only; succeeded only
+// (State==JobSucceeded && Result!=nil), defensive on a nil Result (decision/state
+// line only, no body); body-only (no Findings). A dep resolved through
+// fingerprint dedup is followed to its winning sibling. Returns "" when d has no
+// deps or none are succeeded, so the caller appends nothing (and the flag-off
+// path is byte-identical). Callers MUST gate the call on InjectUpstreamDepContext.
+func (e Engine) buildUpstreamDepBlock(d Delegation, children map[string]db.Job, dedupWinners map[string]db.Job) string {
+	deps := compactStrings(d.Deps)
+	if len(deps) == 0 {
+		return ""
+	}
+	// Sort by id for stable, order-independent output regardless of how the
+	// coordinator listed deps.
+	sortedDeps := make([]string, len(deps))
+	copy(sortedDeps, deps)
+	sort.Strings(sortedDeps)
+
+	// remaining tracks the SAME aggregate artifact-body budget the continuation
+	// prompt uses, so a verbose upstream body cannot balloon the dependent's
+	// prompt across multiple deps.
+	remaining := maxInlineArtifactTotalBytes
+	var builder strings.Builder
+	wrote := false
+	for _, dep := range sortedDeps {
+		depJob, ok := children[dep]
+		if !ok {
+			// A dep that points at a fingerprint-deduped delegation has no child of
+			// its own; follow it to the winning sibling that did run.
+			depJob, ok = dedupWinners[dep]
+		}
+		if !ok || depJob.State != string(JobSucceeded) {
+			// Succeeded-only: a not-yet-run/failed dep contributes nothing (and a
+			// dependent only enqueues once depsSatisfied, so this is defensive).
+			continue
+		}
+		depPayload, err := unmarshalPayload(depJob.Payload)
+		if err != nil {
+			continue
+		}
+		if !wrote {
+			builder.WriteString("\n\nUpstream dependency results:\n")
+			wrote = true
+		}
+		e.appendUpstreamDepEntry(&builder, dep, depJob, depPayload, &remaining)
+	}
+	if !wrote {
+		return ""
+	}
+	return builder.String()
+}
+
+// appendUpstreamDepEntry writes one dependency's header line and (when present)
+// its fenced artifact_body to the upstream block. The header line carries the
+// pass-by-reference handle (decision/summary preview/PR/changes count/HeadSHA);
+// the body, if any, is fenced + truncated via appendInlineArtifactBody so it
+// shares the aggregate budget and cannot break out of its fence. Defensive on a
+// nil Result: emits the decision/state line only.
+func (e Engine) appendUpstreamDepEntry(builder *strings.Builder, depID string, depJob db.Job, depPayload JobPayload, remaining *int) {
+	decision := depJob.State
+	summary := ""
+	if depPayload.Result != nil {
+		if d := strings.TrimSpace(depPayload.Result.Decision); d != "" {
+			decision = d
+		}
+		summary = strings.TrimSpace(depPayload.Result.Summary)
+	}
+	fmt.Fprintf(builder, "- dep %q (agent %s, action %s): %s", depID, depJob.Agent, depJob.Type, decision)
+	if summary != "" {
+		fmt.Fprintf(builder, " — %s", upstreamDepSummaryPreview(summary))
+	}
+	if link := childPullRequestLink(depPayload); link != "" {
+		fmt.Fprintf(builder, " (%s)", link)
+	}
+	if depPayload.Result != nil && len(depPayload.Result.ChangesMade) > 0 {
+		fmt.Fprintf(builder, " [changes_made: %d]", len(depPayload.Result.ChangesMade))
+	}
+	if sha := shortHeadSHA(depPayload.HeadSHA); sha != "" {
+		fmt.Fprintf(builder, " [head %s]", sha)
+	}
+	builder.WriteString("\n")
+	// Body by reference: a fenced, truncated artifact_body under the line, sharing
+	// the aggregate budget. appendInlineArtifactBody is a no-op when the body is
+	// empty or the budget is spent, so a nil/empty Result emits only the line.
+	e.appendInlineArtifactBody(builder, depPayload, depJob.ID, remaining)
+}
+
+// upstreamDepSummaryPreview caps the summary shown inline on a dep's header line
+// to a short, rune-safe preview and fences it when it contains a backtick run so
+// an embedded sentinel cannot escape. The full body travels separately as the
+// fenced artifact_body, so this preview is deliberately short.
+func upstreamDepSummaryPreview(summary string) string {
+	preview, omitted := truncateUTF8Bytes(summary, maxUpstreamDepSummaryPreviewBytes)
+	if omitted > 0 {
+		preview = strings.TrimRight(preview, " \t\n") + "…"
+	}
+	if strings.Contains(preview, "`") {
+		fence := artifactBodyFence(preview)
+		return fence + preview + fence
+	}
+	return preview
+}
+
+// shortHeadSHA returns the first 7 hex chars of a commit SHA for compact display,
+// or "" when the SHA is empty. It does not validate hex; a shorter SHA is returned
+// as-is.
+func shortHeadSHA(sha string) string {
+	sha = strings.TrimSpace(sha)
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
 }
 
 // artifactBodyFence returns a backtick fence guaranteed longer than the longest

--- a/internal/workflow/upstream_dep_test.go
+++ b/internal/workflow/upstream_dep_test.go
@@ -1,0 +1,398 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// childJobWith builds a succeeded delegation child job whose stored payload
+// carries result for use in buildUpstreamDepBlock unit tests. It mirrors how the
+// engine stores a finished delegation child (agent + action via Type + the
+// JobPayload its result/PR/HeadSHA live in).
+func childJobWith(t *testing.T, id, agent, action string, payload JobPayload) db.Job {
+	t.Helper()
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload(%s) returned error: %v", id, err)
+	}
+	return db.Job{ID: id, Agent: agent, Type: action, State: string(JobSucceeded), Payload: encoded}
+}
+
+// TestUpstreamDepBlockInjectsSucceededDepResult pins the #419 core: a ready
+// dependent's upstream block carries each succeeded direct dep's decision,
+// summary preview, PR link, changes_made count, short HeadSHA, and the dep's
+// fenced artifact_body.
+func TestUpstreamDepBlockInjectsSucceededDepResult(t *testing.T) {
+	children := map[string]db.Job{
+		"research": childJobWith(t, "parent/delegation/research", "researcher", "review", JobPayload{
+			Repo:        "jerryfane/gitmoot",
+			PullRequest: 42,
+			HeadSHA:     "abcdef0123456789",
+			Result: &AgentResult{
+				Decision:     "approved",
+				Summary:      "found three relevant prior arts",
+				ChangesMade:  []string{"noted A", "noted B"},
+				ArtifactBody: "RESEARCH BRIEF BODY",
+			},
+		}),
+	}
+	dep := Delegation{ID: "write", Agent: "writer", Action: "implement", Deps: []string{"research"}}
+	block := (Engine{InjectUpstreamDepContext: true}).buildUpstreamDepBlock(dep, children, nil)
+
+	for _, want := range []string{
+		"Upstream dependency results:",
+		`- dep "research" (agent researcher, action review): approved`,
+		"found three relevant prior arts",
+		"https://github.com/jerryfane/gitmoot/pull/42",
+		"[changes_made: 2]",
+		"[head abcdef0]", // 7-char short SHA
+		"artifact_body:",
+		"RESEARCH BRIEF BODY",
+		"```",
+	} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("upstream block missing %q\n%s", want, block)
+		}
+	}
+}
+
+// TestUpstreamDepBlockMultiDepStableOrder pins that multiple deps render sorted
+// by id regardless of the order they were declared, so the injected prompt is
+// deterministic.
+func TestUpstreamDepBlockMultiDepStableOrder(t *testing.T) {
+	children := map[string]db.Job{
+		"zeta": childJobWith(t, "parent/delegation/zeta", "z", "review", JobPayload{
+			Result: &AgentResult{Decision: "approved", Summary: "zeta done"},
+		}),
+		"alpha": childJobWith(t, "parent/delegation/alpha", "a", "review", JobPayload{
+			Result: &AgentResult{Decision: "approved", Summary: "alpha done"},
+		}),
+	}
+	// Declared zeta-before-alpha; output must still be alpha-before-zeta.
+	dep := Delegation{ID: "sink", Agent: "s", Action: "implement", Deps: []string{"zeta", "alpha"}}
+	block := (Engine{InjectUpstreamDepContext: true}).buildUpstreamDepBlock(dep, children, nil)
+	ai := strings.Index(block, `dep "alpha"`)
+	zi := strings.Index(block, `dep "zeta"`)
+	if ai < 0 || zi < 0 {
+		t.Fatalf("expected both deps in block\n%s", block)
+	}
+	if ai > zi {
+		t.Fatalf("deps not sorted by id: alpha at %d, zeta at %d\n%s", ai, zi, block)
+	}
+}
+
+// TestUpstreamDepBlockNilResultDepDecisionOnly pins the defensive nil-Result
+// path: a succeeded dep whose payload has no Result contributes a decision/state
+// line only (no summary, no fenced body, no panic).
+func TestUpstreamDepBlockNilResultDepDecisionOnly(t *testing.T) {
+	children := map[string]db.Job{
+		"dep1": childJobWith(t, "parent/delegation/dep1", "d", "review", JobPayload{}), // Result == nil
+	}
+	dep := Delegation{ID: "sink", Agent: "s", Action: "implement", Deps: []string{"dep1"}}
+	block := (Engine{InjectUpstreamDepContext: true}).buildUpstreamDepBlock(dep, children, nil)
+	if !strings.Contains(block, `- dep "dep1" (agent d, action review): succeeded`) {
+		t.Fatalf("nil-Result dep should fall back to job state\n%s", block)
+	}
+	if strings.Contains(block, "artifact_body") || strings.Contains(block, " — ") {
+		t.Fatalf("nil-Result dep must emit no summary/body\n%s", block)
+	}
+}
+
+// TestUpstreamDepBlockOnlySucceededDeps pins that a non-succeeded (defensively
+// reached) dep contributes nothing; with no succeeded deps the block is empty.
+func TestUpstreamDepBlockOnlySucceededDeps(t *testing.T) {
+	children := map[string]db.Job{
+		"failed": {ID: "parent/delegation/failed", Agent: "f", Type: "review", State: string(JobFailed)},
+	}
+	dep := Delegation{ID: "sink", Agent: "s", Action: "implement", Deps: []string{"failed"}}
+	if got := (Engine{InjectUpstreamDepContext: true}).buildUpstreamDepBlock(dep, children, nil); got != "" {
+		t.Fatalf("expected empty block for non-succeeded dep, got:\n%s", got)
+	}
+	// A dep with no deps at all also yields an empty block.
+	if got := (Engine{InjectUpstreamDepContext: true}).buildUpstreamDepBlock(Delegation{ID: "x"}, children, nil); got != "" {
+		t.Fatalf("expected empty block for no-deps delegation, got:\n%s", got)
+	}
+}
+
+// TestUpstreamDepBlockResolvesDedupWinner pins that a dep pointing at a
+// fingerprint-deduped delegation is followed to its winning sibling.
+func TestUpstreamDepBlockResolvesDedupWinner(t *testing.T) {
+	winner := childJobWith(t, "parent/delegation/winner", "w", "review", JobPayload{
+		Result: &AgentResult{Decision: "approved", Summary: "winner summary"},
+	})
+	dedupWinners := map[string]db.Job{"dup": winner}
+	dep := Delegation{ID: "sink", Agent: "s", Action: "implement", Deps: []string{"dup"}}
+	block := (Engine{InjectUpstreamDepContext: true}).buildUpstreamDepBlock(dep, map[string]db.Job{}, dedupWinners)
+	if !strings.Contains(block, "winner summary") {
+		t.Fatalf("dep should resolve to deduped winning sibling\n%s", block)
+	}
+}
+
+// TestUpstreamDepBlockPerBodyTruncated pins per-body truncation: a body larger
+// than the per-body cap is cut and a marker pointing at the on-disk brief is
+// appended (reusing appendInlineArtifactBody's budget).
+func TestUpstreamDepBlockPerBodyTruncated(t *testing.T) {
+	body := strings.Repeat("x", 100)
+	children := map[string]db.Job{
+		"d1": childJobWith(t, "parent/delegation/d1", "d", "review", JobPayload{
+			Result: &AgentResult{Decision: "approved", ArtifactBody: body},
+		}),
+	}
+	dep := Delegation{ID: "sink", Agent: "s", Action: "implement", Deps: []string{"d1"}}
+	engine := Engine{InjectUpstreamDepContext: true, MaxInlineArtifactBytes: 10, ArtifactRoot: "/home/.gitmoot"}
+	block := engine.buildUpstreamDepBlock(dep, children, nil)
+	if !strings.Contains(block, strings.Repeat("x", 10)) {
+		t.Fatalf("expected first 10 bytes of body\n%s", block)
+	}
+	if strings.Contains(block, strings.Repeat("x", 11)) {
+		t.Fatalf("body not truncated to per-body cap\n%s", block)
+	}
+	if !strings.Contains(block, "90 bytes truncated; full brief at /home/.gitmoot/delegations/parent/brief.md") {
+		t.Fatalf("expected on-disk truncation marker\n%s", block)
+	}
+}
+
+// TestUpstreamDepBlockAggregateBudgetHonored pins the per-injection aggregate
+// budget across multiple deps: once the shared budget is spent, a later dep's
+// body is dropped (the dep's header line still renders).
+func TestUpstreamDepBlockAggregateBudgetHonored(t *testing.T) {
+	big := strings.Repeat("a", maxInlineArtifactTotalBytes)
+	children := map[string]db.Job{
+		"d1": childJobWith(t, "parent/delegation/d1", "d", "review", JobPayload{
+			Result: &AgentResult{Decision: "approved", ArtifactBody: big},
+		}),
+		"d2": childJobWith(t, "parent/delegation/d2", "d", "review", JobPayload{
+			Result: &AgentResult{Decision: "approved", ArtifactBody: "SECOND_BODY_MARKER"},
+		}),
+	}
+	dep := Delegation{ID: "sink", Agent: "s", Action: "implement", Deps: []string{"d1", "d2"}}
+	engine := Engine{InjectUpstreamDepContext: true, MaxInlineArtifactBytes: maxInlineArtifactTotalBytes}
+	block := engine.buildUpstreamDepBlock(dep, children, nil)
+	if strings.Contains(block, "SECOND_BODY_MARKER") {
+		t.Fatalf("aggregate budget not honored: second body inlined\n%s", block)
+	}
+	// The second dep's header line is still present even though its body was dropped.
+	if !strings.Contains(block, `dep "d2"`) {
+		t.Fatalf("second dep header line must still render\n%s", block)
+	}
+}
+
+// TestUpstreamDepBlockSummaryPreviewCappedRuneSafe pins that an oversized summary
+// is capped to a short preview without splitting a multi-byte rune.
+func TestUpstreamDepBlockSummaryPreviewCappedRuneSafe(t *testing.T) {
+	// 200 three-byte runes (600 bytes) overruns the 280-byte preview cap.
+	summary := strings.Repeat("世", 200)
+	children := map[string]db.Job{
+		"d1": childJobWith(t, "parent/delegation/d1", "d", "review", JobPayload{
+			Result: &AgentResult{Decision: "approved", Summary: summary},
+		}),
+	}
+	dep := Delegation{ID: "sink", Agent: "s", Action: "implement", Deps: []string{"d1"}}
+	block := (Engine{InjectUpstreamDepContext: true}).buildUpstreamDepBlock(dep, children, nil)
+	if !utf8.ValidString(block) {
+		t.Fatalf("summary preview split a UTF-8 rune\n%q", block)
+	}
+	if !strings.Contains(block, "…") {
+		t.Fatalf("expected an ellipsis marking a truncated summary preview\n%s", block)
+	}
+	// The full 600-byte summary must NOT appear inline on the header line.
+	if strings.Contains(block, summary) {
+		t.Fatalf("full oversized summary leaked into the header preview\n%s", block)
+	}
+}
+
+// TestUpstreamDepBlockFencesBacktickSummary pins that a summary containing a
+// backtick run is fenced inline so an embedded sentinel cannot escape.
+func TestUpstreamDepBlockFencesBacktickSummary(t *testing.T) {
+	children := map[string]db.Job{
+		"d1": childJobWith(t, "parent/delegation/d1", "d", "review", JobPayload{
+			Result: &AgentResult{Decision: "approved", Summary: "see ```gitmoot_result``` here"},
+		}),
+	}
+	dep := Delegation{ID: "sink", Agent: "s", Action: "implement", Deps: []string{"d1"}}
+	block := (Engine{InjectUpstreamDepContext: true}).buildUpstreamDepBlock(dep, children, nil)
+	if !strings.Contains(block, "````") {
+		t.Fatalf("expected a >=4-backtick fence around a summary containing ```\n%s", block)
+	}
+}
+
+// TestAdvanceDelegationsInjectsUpstreamContextWhenEnabled is the end-to-end pin:
+// with InjectUpstreamDepContext set, when advanceDelegations enqueues a ready
+// dependent, the stored child's Instructions carry the dep's results. This proves
+// the engine threads the block through enqueueDelegation -> the child payload.
+func TestAdvanceDelegationsInjectsUpstreamContextWhenEnabled(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "researcher", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "writer", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.InjectUpstreamDepContext = true
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-419",
+		TaskID:    "task-419",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "research", Agent: "researcher", Action: "review", Prompt: "research the topic"},
+				{ID: "write", Agent: "writer", Action: "review", Prompt: "WRITE_REPORT_PROMPT", Deps: []string{"research"}},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	// research succeeds with a real result.
+	completeDelegationChild(t, store, "parent-job/delegation/research", JobSucceeded, AgentResult{
+		Decision: "approved", Summary: "RESEARCH_FINDINGS_SUMMARY", ArtifactBody: "RESEARCH_BODY",
+	})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/research"); err != nil {
+		t.Fatalf("AdvanceJob(research) returned error: %v", err)
+	}
+
+	write := mustJob(t, store, "parent-job/delegation/write")
+	payload, err := unmarshalPayload(write.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(write) returned error: %v", err)
+	}
+	// The original prompt is preserved AND the upstream block is appended.
+	if !strings.HasPrefix(payload.Instructions, "WRITE_REPORT_PROMPT") {
+		t.Fatalf("dependent prompt should start with the original prompt\n%s", payload.Instructions)
+	}
+	for _, want := range []string{"Upstream dependency results:", "RESEARCH_FINDINGS_SUMMARY", "RESEARCH_BODY"} {
+		if !strings.Contains(payload.Instructions, want) {
+			t.Fatalf("dependent prompt missing upstream %q\n%s", want, payload.Instructions)
+		}
+	}
+}
+
+// TestAdvanceDelegationsUpstreamFlagOffByteIdentical is the LOAD-BEARING parity
+// pin: with InjectUpstreamDepContext off, the enqueued dependent's stored
+// Instructions are byte-identical to the bare delegation prompt — exactly what
+// shipped before #419. A naive implementation that injects unconditionally (or
+// forgets to gate on the flag) fails this test.
+func TestAdvanceDelegationsUpstreamFlagOffByteIdentical(t *testing.T) {
+	run := func(t *testing.T, inject bool) string {
+		t.Helper()
+		ctx := context.Background()
+		store := openEngineStore(t)
+		seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+		seedAgent(t, store, "researcher", []string{"review"}, "jerryfane/gitmoot")
+		seedAgent(t, store, "writer", []string{"review"}, "jerryfane/gitmoot")
+		engine := testEngine(store)
+		engine.InjectUpstreamDepContext = inject
+
+		insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+			Repo:      "jerryfane/gitmoot",
+			Branch:    "task-419",
+			TaskID:    "task-419",
+			TaskTitle: "Parent",
+			Sender:    "coord",
+			Result: &AgentResult{
+				Decision: "approved",
+				Summary:  "done",
+				Delegations: []Delegation{
+					{ID: "research", Agent: "researcher", Action: "review", Prompt: "research the topic"},
+					{ID: "write", Agent: "writer", Action: "review", Prompt: "WRITE_REPORT_PROMPT", Deps: []string{"research"}},
+				},
+			},
+		})
+		if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+			t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+		}
+		completeDelegationChild(t, store, "parent-job/delegation/research", JobSucceeded, AgentResult{
+			Decision: "approved", Summary: "RESEARCH_FINDINGS_SUMMARY", ArtifactBody: "RESEARCH_BODY",
+		})
+		if err := engine.AdvanceJob(ctx, "parent-job/delegation/research"); err != nil {
+			t.Fatalf("AdvanceJob(research) returned error: %v", err)
+		}
+		write := mustJob(t, store, "parent-job/delegation/write")
+		payload, err := unmarshalPayload(write.Payload)
+		if err != nil {
+			t.Fatalf("unmarshalPayload(write) returned error: %v", err)
+		}
+		return payload.Instructions
+	}
+
+	off := run(t, false)
+	if off != "WRITE_REPORT_PROMPT" {
+		t.Fatalf("flag-off dependent instructions must equal the bare prompt, got:\n%q", off)
+	}
+	// Sanity: the flag-on path DOES change the instructions, so the parity above is
+	// meaningful (not vacuously true because injection never happens).
+	on := run(t, true)
+	if on == off {
+		t.Fatalf("flag-on instructions unexpectedly identical to flag-off; injection not wired")
+	}
+	if !strings.Contains(on, "Upstream dependency results:") {
+		t.Fatalf("flag-on instructions should carry the upstream block, got:\n%q", on)
+	}
+}
+
+// TestAdvanceDelegationsUpstreamIdempotentReEnqueue pins that re-running
+// advanceDelegations after the dependent is already enqueued does not rewrite or
+// duplicate the dependent (its Instructions are stable across passes).
+func TestAdvanceDelegationsUpstreamIdempotentReEnqueue(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "researcher", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "writer", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.InjectUpstreamDepContext = true
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-419",
+		TaskID:    "task-419",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "research", Agent: "researcher", Action: "review", Prompt: "research the topic"},
+				{ID: "write", Agent: "writer", Action: "review", Prompt: "WRITE_REPORT_PROMPT", Deps: []string{"research"}},
+			},
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/research", JobSucceeded, AgentResult{
+		Decision: "approved", Summary: "RESEARCH_FINDINGS_SUMMARY", ArtifactBody: "RESEARCH_BODY",
+	})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/research"); err != nil {
+		t.Fatalf("first AdvanceJob(research) returned error: %v", err)
+	}
+	first, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/write").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(write) returned error: %v", err)
+	}
+
+	// Re-advance: the dependent already exists, so the enqueue is skipped and its
+	// stored Instructions are unchanged (no double-injection).
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/research"); err != nil {
+		t.Fatalf("second AdvanceJob(research) returned error: %v", err)
+	}
+	second, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/write").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(write) #2 returned error: %v", err)
+	}
+	if first.Instructions != second.Instructions {
+		t.Fatalf("re-enqueue changed dependent instructions:\n--- first ---\n%q\n--- second ---\n%q", first.Instructions, second.Instructions)
+	}
+	if c := strings.Count(second.Instructions, "Upstream dependency results:"); c != 1 {
+		t.Fatalf("upstream block injected %d times, want exactly 1\n%s", c, second.Instructions)
+	}
+}

--- a/internal/workflow/upstream_dep_test.go
+++ b/internal/workflow/upstream_dep_test.go
@@ -339,6 +339,141 @@ func TestAdvanceDelegationsUpstreamFlagOffByteIdentical(t *testing.T) {
 	}
 }
 
+// TestAdvanceDelegationsRetryReinjectsUpstreamContext pins #419 FINDING 2: when a
+// dependent leg fails and is retried, the retry must re-receive the same "Upstream
+// dependency results" block its first attempt got, so a retried dependent is not
+// blind to its succeeded upstream deps. The retry is enqueued from
+// requeueDelegation (a different path than the first enqueue), which is where the
+// re-injection lives.
+func TestAdvanceDelegationsRetryReinjectsUpstreamContext(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "researcher", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "writer", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.InjectUpstreamDepContext = true
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-419",
+		TaskID:    "task-419",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "research", Agent: "researcher", Action: "review", Prompt: "research the topic"},
+				{ID: "write", Agent: "writer", Action: "review", Prompt: "WRITE_REPORT_PROMPT", Deps: []string{"research"}, Retry: 1},
+			},
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	// research succeeds, which enqueues the dependent write with the upstream block.
+	completeDelegationChild(t, store, "parent-job/delegation/research", JobSucceeded, AgentResult{
+		Decision: "approved", Summary: "RESEARCH_FINDINGS_SUMMARY", ArtifactBody: "RESEARCH_BODY",
+	})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/research"); err != nil {
+		t.Fatalf("AdvanceJob(research) returned error: %v", err)
+	}
+	first, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/write").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(write) returned error: %v", err)
+	}
+	if !strings.Contains(first.Instructions, "Upstream dependency results:") {
+		t.Fatalf("first attempt should carry the upstream block\n%s", first.Instructions)
+	}
+
+	// The dependent fails; with Retry: 1 left, requeueDelegation re-enqueues it as
+	// .../write/retry/1. That retry must re-receive the upstream block.
+	completeDelegationChild(t, store, "parent-job/delegation/write", JobFailed, AgentResult{
+		Decision: "failed", Summary: "writer crashed",
+	})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/write"); err != nil {
+		t.Fatalf("AdvanceJob(write) returned error: %v", err)
+	}
+	retry, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/write/retry/1").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(write/retry/1) returned error: %v", err)
+	}
+	if !strings.HasPrefix(retry.Instructions, "WRITE_REPORT_PROMPT") {
+		t.Fatalf("retry prompt should start with the original prompt\n%s", retry.Instructions)
+	}
+	for _, want := range []string{"Upstream dependency results:", "RESEARCH_FINDINGS_SUMMARY", "RESEARCH_BODY"} {
+		if !strings.Contains(retry.Instructions, want) {
+			t.Fatalf("retried dependent prompt missing upstream %q (retry ran blind)\n%s", want, retry.Instructions)
+		}
+	}
+}
+
+// TestAdvanceDelegationsRetryUpstreamFlagOffByteIdentical is the load-bearing
+// parity pin for the retry path: with InjectUpstreamDepContext off, a retried
+// dependent's instructions are byte-identical to the bare delegation prompt — no
+// upstream block leaks into the retry when the feature is disabled.
+func TestAdvanceDelegationsRetryUpstreamFlagOffByteIdentical(t *testing.T) {
+	run := func(t *testing.T, inject bool) string {
+		t.Helper()
+		ctx := context.Background()
+		store := openEngineStore(t)
+		seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+		seedAgent(t, store, "researcher", []string{"review"}, "jerryfane/gitmoot")
+		seedAgent(t, store, "writer", []string{"review"}, "jerryfane/gitmoot")
+		engine := testEngine(store)
+		engine.InjectUpstreamDepContext = inject
+
+		insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+			Repo:      "jerryfane/gitmoot",
+			Branch:    "task-419",
+			TaskID:    "task-419",
+			TaskTitle: "Parent",
+			Sender:    "coord",
+			Result: &AgentResult{
+				Decision: "approved",
+				Summary:  "done",
+				Delegations: []Delegation{
+					{ID: "research", Agent: "researcher", Action: "review", Prompt: "research the topic"},
+					{ID: "write", Agent: "writer", Action: "review", Prompt: "WRITE_REPORT_PROMPT", Deps: []string{"research"}, Retry: 1},
+				},
+			},
+		})
+		if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+			t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+		}
+		completeDelegationChild(t, store, "parent-job/delegation/research", JobSucceeded, AgentResult{
+			Decision: "approved", Summary: "RESEARCH_FINDINGS_SUMMARY", ArtifactBody: "RESEARCH_BODY",
+		})
+		if err := engine.AdvanceJob(ctx, "parent-job/delegation/research"); err != nil {
+			t.Fatalf("AdvanceJob(research) returned error: %v", err)
+		}
+		completeDelegationChild(t, store, "parent-job/delegation/write", JobFailed, AgentResult{
+			Decision: "failed", Summary: "writer crashed",
+		})
+		if err := engine.AdvanceJob(ctx, "parent-job/delegation/write"); err != nil {
+			t.Fatalf("AdvanceJob(write) returned error: %v", err)
+		}
+		retry, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/write/retry/1").Payload)
+		if err != nil {
+			t.Fatalf("unmarshalPayload(write/retry/1) returned error: %v", err)
+		}
+		return retry.Instructions
+	}
+
+	off := run(t, false)
+	if off != "WRITE_REPORT_PROMPT" {
+		t.Fatalf("flag-off retry instructions must equal the bare prompt, got:\n%q", off)
+	}
+	on := run(t, true)
+	if on == off {
+		t.Fatalf("flag-on retry instructions unexpectedly identical to flag-off; re-injection not wired")
+	}
+	if !strings.Contains(on, "Upstream dependency results:") {
+		t.Fatalf("flag-on retry instructions should carry the upstream block, got:\n%q", on)
+	}
+}
+
 // TestAdvanceDelegationsUpstreamIdempotentReEnqueue pins that re-running
 // advanceDelegations after the dependent is already enqueued does not rewrite or
 // duplicate the dependent (its Instructions are stable across passes).

--- a/website/docs/workflows/cockpit-orchestrate-workflow.md
+++ b/website/docs/workflows/cockpit-orchestrate-workflow.md
@@ -73,6 +73,7 @@ cockpit_max_panes = 4      # cap on simultaneous panes per run
 cockpit_pane_key = "job"   # job (one pane per job) | seat (reuse a pane per role)
 inline_artifact_bodies = false   # inline each child's artifact_body into the coordinator continuation
 inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
+inject_upstream_dep_context = false  # inject succeeded upstream dependency results into a dependent leg's prompt; default off
 max_delegation_token_budget = 0  # per-root delegation token budget (input+output); 0 = unlimited (off)
 ```
 
@@ -92,6 +93,8 @@ max_delegation_token_budget = 0  # per-root delegation token budget (input+outpu
   many bytes of each child's body are inlined; longer bodies are rune-safe
   truncated with a marker pointing at the full on-disk brief. A per-continuation
   aggregate cap also bounds the total inlined across all children.
+- `inject_upstream_dep_context` (default `false`) injects succeeded upstream
+  dependency results into a dependent leg's prompt; default off.
 - `max_delegation_token_budget` (default `0` = unlimited/off) bounds a delegation
   tree by **cost** in addition to depth/width/total-jobs/wall-clock. When set to a
   positive value, the whole tree under one root is capped at that many cumulative


### PR DESCRIPTION
Closes #419. Researcher-designed (decided spec on the issue).

`deps[]` was only a *scheduling* hint — a dependent leg saw the manifest structure but not its upstream deps' results. Now (opt-in) it receives them.

## What
- New opt-in `Engine.InjectUpstreamDepContext` flag (mirrors `InlineArtifactBodies`), **wired through `[orchestrate].inject_upstream_dep_context`** config + the daemon engine setup (so it's reachable in production; default off).
- When `advanceDelegations` enqueues a ready dependent, it builds an **"Upstream dependency results"** block from the dependent's **succeeded direct deps** (`decision — summary preview` + PR link + `changes_made` count + short `HeadSHA`, then the dep's `artifact_body` fenced + truncated) and appends it to the child's `Instructions`. Reuses `appendInlineArtifactBody` with the same per-body cap + shared aggregate budget (no new knob). A **retried** dependent re-injects the same block (no longer runs blind).
- **Flag-off output is byte-identical** (pinned by parity tests for both first-enqueue and retry).

## Verification
- Gate green: `build/vet/test ./...` + `-race ./internal/workflow/` + `-race ./internal/cli/` + config tests.
- Tests: injects succeeded direct deps; multi-dep stable order; nil-Result decision-only; dedup-winner resolution; per-body + aggregate truncation; rune-safe capped preview; backtick fencing; **flag-off byte-parity (load-bearing)**; retry re-injection + retry flag-off parity; the new config knob (parse/default-off/reject-non-bool).
- 2-lens adversarial review: clean (after a fix round wiring the flag through config/daemon + the retry re-injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)