### PR TITLE
feat(cli): make gitmoot setup tagging-ready with default --watch-issues (#428)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -324,6 +324,39 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    filters to run. Leaving both empty keeps the default of matching all enabled
    repos and all jobs.
 
+   ### Set up a GitHub "tagging" agent
+
+   To get an agent that answers `@<agent> ask …` comments on a repo's issues and
+   PRs, use `gitmoot setup` — it registers the repo, subscribes the agent, grants
+   it repo access, and (with `--start-daemon`) launches a tagging-ready daemon:
+
+   ```sh
+   gitmoot setup --repo owner/project --path . \
+     --agent helper --runtime claude --session last --start-daemon
+   ```
+
+   `gitmoot setup` enables issue-watching by default (`--watch-issues`, on unless
+   you pass `--watch-issues=false`), so `gitmoot setup --start-daemon` yields a
+   daemon that actually answers issue tags rather than silently leaving
+   issue-watching off. After setup it prints a readiness summary: repo registered,
+   agent access granted, daemon issue-watching state, a daemon runtime-auth note,
+   and the exact comment to post.
+
+   Two things to know when tagging on issues:
+
+   - **Run the daemon from a shell that holds the runtime token.** The daemon
+     inherits the environment of the shell that (re)started it, so start it where
+     the runtime (e.g. Claude) is authenticated. (Daemon-aware auth validation is
+     tracked in #427.)
+   - **On issues only the `ask` action is acted on.** Post the tag as the first
+     token of a line:
+
+     ```text
+     @helper ask <your question>
+     ```
+
+   `review` and `implement` actions apply to PRs; on issues they are ignored.
+
    Gitmoot records agent autonomy policy as `read-only`, `workspace-write`,
    `danger-full-access`, or `auto`. For Codex these map to Codex sandbox
    policies; for Claude Code they map to Claude permission modes. Implementation

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/daemon"
@@ -25,6 +26,7 @@ func runSetup(args []string, stdout, stderr io.Writer) int {
 	session := fs.String("session", "", "runtime session reference, last, or shell command")
 	role := fs.String("role", "agent", "agent role")
 	startDaemon := fs.Bool("start-daemon", false, "start the background daemon after setup")
+	watchIssues := fs.Bool("watch-issues", true, "watch open issues and route @<agent> ask comments to jobs (#389); on by default so the daemon is tagging-ready")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -88,10 +90,71 @@ func runSetup(args []string, stdout, stderr io.Writer) int {
 	writeLine(stdout, "configured %s with agent %s", repo.FullName(), agent.Name)
 	if *startDaemon {
 		writeLine(stdout, "step: start background daemon")
-		return runDaemonStartWithWorkDir([]string{"--home", *home, "--repo", repo.FullName()}, record.CheckoutPath, stdout, stderr)
+		daemonArgs := []string{"--home", *home, "--repo", repo.FullName()}
+		if *watchIssues {
+			daemonArgs = append(daemonArgs, "--watch-issues")
+		}
+		code := runDaemonStartWithWorkDir(daemonArgs, record.CheckoutPath, stdout, stderr)
+		if code != 0 {
+			return code
+		}
+		writeSetupReadiness(stdout, agent, repo.FullName(), *watchIssues, true)
+		return 0
 	}
-	writeLine(stdout, "next: gitmoot daemon start --repo %s", repo.FullName())
+	writeSetupReadiness(stdout, agent, repo.FullName(), *watchIssues, false)
 	return 0
+}
+
+// writeSetupReadiness prints a post-setup readiness summary so a freshly
+// configured tagging agent is usable without tribal knowledge: which
+// prerequisites are wired, whether the daemon watches issues, a daemon
+// runtime-auth note, and the exact comment to post (#428).
+func writeSetupReadiness(stdout io.Writer, agent runtime.Agent, repoFullName string, watchIssues bool, daemonStarted bool) {
+	writeLine(stdout, "")
+	writeLine(stdout, "readiness:")
+	writeLine(stdout, "  [ok] repo registered: %s", repoFullName)
+	writeLine(stdout, "  [ok] agent access: %s -> %s", agent.Name, repoFullName)
+	if daemonStarted {
+		if watchIssues {
+			writeLine(stdout, "  [ok] daemon: started with --watch-issues (answers issue tags)")
+		} else {
+			writeLine(stdout, "  [warn] daemon: started WITHOUT --watch-issues; it will NOT answer issue tags")
+			writeLine(stdout, "         re-run with --watch-issues, or: gitmoot daemon restart --repo %s --watch-issues", repoFullName)
+		}
+		writeSetupDaemonAuthNote(stdout, agent)
+	} else {
+		if watchIssues {
+			writeLine(stdout, "  [next] daemon not started; run from a shell that holds the runtime token:")
+		} else {
+			writeLine(stdout, "  [next] daemon not started; issue-watching is OFF for this run.")
+		}
+		writeLine(stdout, "next: gitmoot daemon start --repo %s --watch-issues", repoFullName)
+	}
+	if watchIssues {
+		writeLine(stdout, "")
+		writeLine(stdout, "to tag the agent, post this as the FIRST token of a line in a %s issue/PR comment:", repoFullName)
+		writeLine(stdout, "  @%s ask <your question>", agent.Name)
+		writeLine(stdout, "note: on issues only the `ask` action is acted on (review/implement apply to PRs).")
+	}
+}
+
+// writeSetupDaemonAuthNote surfaces a fail-open daemon runtime-auth note. The
+// authoritative daemon-aware auth check is tracked in #427 (a sibling PR); to
+// keep this flow independently mergeable we only inspect the current shell's
+// env for the claude runtime and never fail setup on it — the daemon inherits
+// the env of the shell that (re)started it, which is the common footgun.
+func writeSetupDaemonAuthNote(stdout io.Writer, agent runtime.Agent) {
+	if !strings.EqualFold(strings.TrimSpace(agent.Runtime), "claude") {
+		return
+	}
+	env := runtime.InspectClaudeAuthEnv(os.LookupEnv)
+	if env.Ready() {
+		writeLine(stdout, "  [ok] daemon runtime auth: claude credentials present in this shell (%s)", env.MaskedDetail())
+		return
+	}
+	writeLine(stdout, "  [warn] daemon runtime auth: no claude credentials in this shell; the daemon inherits this env.")
+	writeLine(stdout, "         %s", env.Warning())
+	writeLine(stdout, "         (daemon-aware auth validation is tracked in #427)")
 }
 
 func existingCompatibleAgent(ctx context.Context, store *db.Store, agent runtime.Agent) (bool, error) {

--- a/internal/cli/setup_config_events_test.go
+++ b/internal/cli/setup_config_events_test.go
@@ -75,6 +75,54 @@ func TestRunSetupRegistersRepoAndAgent(t *testing.T) {
 	}
 }
 
+func TestRunSetupPrintsTaggingReadinessByDefault(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"setup", "--home", home, "--repo", "owner/repo", "--path", repoDir, "--agent", "lead", "--runtime", "codex", "--session", "last"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("setup exit code = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"readiness:",
+		"repo registered: owner/repo",
+		"agent access: lead -> owner/repo",
+		"gitmoot daemon start --repo owner/repo --watch-issues",
+		"@lead ask <your question>",
+		"only the `ask` action is acted on",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("tagging readiness output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunSetupWatchIssuesFalseSuppressesTagHelp(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"setup", "--home", home, "--repo", "owner/repo", "--path", repoDir, "--agent", "lead", "--runtime", "codex", "--session", "last", "--watch-issues=false"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("setup exit code = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "issue-watching is OFF for this run") {
+		t.Fatalf("expected off-note when --watch-issues=false:\n%s", out)
+	}
+	if strings.Contains(out, "@lead ask") {
+		t.Fatalf("did not expect tag help when issue-watching is off:\n%s", out)
+	}
+}
+
 func TestRunSetupPreservesExistingAgentRepoAccess(t *testing.T) {
 	home := t.TempDir()
 	firstRepoDir := t.TempDir()

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -45,6 +45,40 @@ The `--runtime` flag accepts `codex`, `claude`, or `kimi`. To use the Kimi Code
 runtime, run `kimi login` first, then restart the Gitmoot daemon so it inherits
 the session.
 
+## Set up a GitHub "tagging" agent
+
+To get an agent that answers `@<agent> ask …` comments on a repo's issues and
+PRs in one step, use `gitmoot setup`. It registers the repo, subscribes the
+agent, grants it repo access, and (with `--start-daemon`) launches a
+tagging-ready daemon:
+
+```sh
+gitmoot setup --repo owner/repo --path . \
+  --agent helper --runtime claude --session last --start-daemon
+```
+
+`gitmoot setup` enables issue-watching by default (`--watch-issues`, on unless
+you pass `--watch-issues=false`), so `gitmoot setup --start-daemon` produces a
+daemon that actually answers issue tags instead of silently leaving
+issue-watching off. After setup it prints a readiness summary: repo registered,
+agent access granted, daemon issue-watching state, a daemon runtime-auth note,
+and the exact comment to post.
+
+Two things to know when tagging on issues:
+
+- **Run the daemon from a shell that holds the runtime token.** The daemon
+  inherits the environment of the shell that (re)started it, so start it where
+  the runtime (for example Claude) is authenticated. Daemon-aware auth
+  validation is tracked in #427.
+- **On issues only the `ask` action is acted on.** Post the tag as the first
+  token of a line:
+
+  ```text
+  @helper ask <your question>
+  ```
+
+  `review` and `implement` actions apply to PRs; on issues they are ignored.
+
 For fast planning in the current Codex or Claude chat, ask the runtime:
 
 ```text


### PR DESCRIPTION
Closes #428

## Summary

Turns the 6-step "wire up a GitHub tagging agent" flow into a single guided command. `gitmoot setup` already registered the repo, subscribed the agent, and granted repo access — but it launched the daemon with only `--home`/`--repo`, silently leaving issue-watching **off**, so the most obvious onboarding path could not answer `@<agent> ask …` tags on issues.

## Approach

- Add a `--watch-issues` flag to `gitmoot setup` (default **on**). With `--start-daemon` the daemon now launches with `--watch-issues`, so `gitmoot setup --start-daemon` yields a tagging-ready daemon. Passing `--watch-issues=false` opts out and the readiness summary clearly states issue-watching is off and how to enable it (no silent gap).
- Print a post-setup **readiness summary**: repo registered, agent access, daemon issue-watching state, and the exact `@<agent> ask …` comment to post (first token of a line) plus the issues-only-`ask` note (review/implement apply to PRs).
- Add a fail-open **daemon runtime-auth note** for the claude runtime by inspecting the current shell env (the daemon inherits it). The authoritative daemon-aware auth check is tracked in #427 (PR #433, still unmerged); this stays independently mergeable and never fails setup on auth.

## Changes

- `internal/cli/setup.go` — `--watch-issues` flag, daemon launch wiring, `writeSetupReadiness` + `writeSetupDaemonAuthNote`.
- `internal/cli/setup_config_events_test.go` — tests for the default tagging-ready readiness output and the `--watch-issues=false` suppression path.
- `docs/local-workflow.md` and `website/docs/getting-started/quick-start.md` — "Set up a GitHub tagging agent" section in both doc trees (per the two-tree rule; no new sidebar page needed).

## Acceptance criteria

- [x] Single guided path wires repo registration, agent + template, repo access, daemon `--watch-issues`, and surfaces a daemon runtime-auth note.
- [x] `gitmoot setup --start-daemon` enables issue-watching by default; `--watch-issues=false` clearly states it didn't and how to enable it.
- [x] Flow surfaces the exact `@<agent> ask …` comment and the issues-only-`ask` limitation.
- [x] Readiness note distinguishes daemon vs shell auth (ties to #427).
- [x] Docs applied to both in-repo and website trees.
- [x] `go build`/`go vet`/`go test ./...` pass.

## Tests / checks run

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — pass (includes new `TestRunSetupPrintsTaggingReadinessByDefault` and `TestRunSetupWatchIssuesFalseSuppressesTagHelp`)
- E2E: built `/tmp/gitmoot-428` and ran `gitmoot setup` against a temp repo with default `--watch-issues` (prints readiness + `@helper ask` help + issues-only-`ask` note) and `--watch-issues=false` (prints "issue-watching is OFF" + how to enable, suppresses tag help). `setup --help` shows the new flag defaulting to true.

(Issue #428 is the setup-flow track; this PR does not depend on #427/#433 being merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
