### PR TITLE
feat(workflow): render findings[] objects as readable markdown in posted comments (#429)

### DIFF
--- a/internal/workflow/job_comment.go
+++ b/internal/workflow/job_comment.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -97,14 +98,233 @@ func writeFindings(builder *strings.Builder, findings []json.RawMessage) {
 	}
 	builder.WriteString("\n**Findings**\n")
 	for _, finding := range findings {
-		text := formatFinding(finding)
-		if text == "" {
-			continue
+		writeFinding(builder, finding)
+	}
+}
+
+// writeFinding renders a single finding. String findings render as a plain
+// bullet; object findings render as a bold heading plus an indented key/value
+// sub-list; anything unrenderable falls back to a pretty-printed fenced JSON
+// block. All emitted text is passed through limitCommentText for redaction and
+// truncation.
+func writeFinding(builder *strings.Builder, raw json.RawMessage) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return
+	}
+
+	// String finding -> plain bullet (unchanged behavior).
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		if strings.TrimSpace(text) == "" {
+			return
 		}
 		builder.WriteString("- ")
 		builder.WriteString(limitCommentText(text))
 		builder.WriteByte('\n')
+		return
 	}
+
+	// Object finding -> heading + indented key/value sub-list.
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err == nil && len(obj) > 0 {
+		writeFindingObject(builder, obj)
+		return
+	}
+
+	// Anything else (arrays, scalars, malformed) -> pretty-printed JSON block.
+	writeFindingJSONFallback(builder, raw)
+}
+
+// findingHeadingKeys are the conventional keys, in priority order, used to
+// derive a finding's bold heading. None is mandatory.
+var findingHeadingKeys = []string{"title", "approach", "name", "summary", "finding"}
+
+// findingSourceKeys are rendered as markdown links when present.
+var findingSourceKeys = map[string]bool{"source_url": true, "url": true, "source": true}
+
+func writeFindingObject(builder *strings.Builder, obj map[string]json.RawMessage) {
+	headingKey := ""
+	for _, key := range findingHeadingKeys {
+		if _, ok := obj[key]; ok {
+			if h := scalarFindingValue(obj[key]); strings.TrimSpace(h) != "" {
+				headingKey = key
+				break
+			}
+		}
+	}
+
+	heading := ""
+	if headingKey != "" {
+		heading = scalarFindingValue(obj[headingKey])
+	}
+
+	// A recommendation/severity-style qualifier shown alongside the heading.
+	qualifier := ""
+	for _, key := range []string{"recommendation", "severity", "status"} {
+		if _, ok := obj[key]; ok && key != headingKey {
+			if q := scalarFindingValue(obj[key]); strings.TrimSpace(q) != "" {
+				qualifier = q
+				break
+			}
+		}
+	}
+
+	builder.WriteString("- ")
+	if strings.TrimSpace(heading) != "" {
+		builder.WriteString("**")
+		builder.WriteString(limitCommentText(heading))
+		builder.WriteString("**")
+		if strings.TrimSpace(qualifier) != "" {
+			builder.WriteString(" (")
+			builder.WriteString(limitCommentText(qualifier))
+			builder.WriteString(")")
+		}
+	} else if strings.TrimSpace(qualifier) != "" {
+		builder.WriteString("**")
+		builder.WriteString(limitCommentText(qualifier))
+		builder.WriteString("**")
+	} else {
+		builder.WriteString("Finding")
+	}
+	builder.WriteByte('\n')
+
+	for _, key := range sortedFindingKeys(obj) {
+		if key == headingKey {
+			continue
+		}
+		writeFindingField(builder, "  ", key, obj[key], 0)
+	}
+}
+
+// writeFindingField renders a single key/value pair as an indented bullet.
+func writeFindingField(builder *strings.Builder, indent, key string, raw json.RawMessage, depth int) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return
+	}
+
+	// Nested array -> nested bullet sub-list.
+	if len(raw) > 0 && raw[0] == '[' {
+		var arr []json.RawMessage
+		if err := json.Unmarshal(raw, &arr); err == nil {
+			if len(arr) == 0 {
+				return
+			}
+			builder.WriteString(indent)
+			builder.WriteString("- ")
+			builder.WriteString(limitCommentText(key))
+			builder.WriteString(":\n")
+			if depth >= maxFindingDepth {
+				builder.WriteString(indent)
+				builder.WriteString("  - ")
+				builder.WriteString(limitCommentText(compactJSON(raw)))
+				builder.WriteByte('\n')
+				return
+			}
+			for _, item := range arr {
+				val := scalarFindingValue(item)
+				builder.WriteString(indent)
+				builder.WriteString("  - ")
+				builder.WriteString(limitCommentText(val))
+				builder.WriteByte('\n')
+			}
+			return
+		}
+	}
+
+	// Nested object -> key: value lines (depth-bounded).
+	if len(raw) > 0 && raw[0] == '{' {
+		var nested map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &nested); err == nil {
+			builder.WriteString(indent)
+			builder.WriteString("- ")
+			builder.WriteString(limitCommentText(key))
+			builder.WriteString(":\n")
+			if depth >= maxFindingDepth || len(nested) == 0 {
+				builder.WriteString(indent)
+				builder.WriteString("  - ")
+				builder.WriteString(limitCommentText(compactJSON(raw)))
+				builder.WriteByte('\n')
+				return
+			}
+			for _, nk := range sortedFindingKeys(nested) {
+				writeFindingField(builder, indent+"  ", nk, nested[nk], depth+1)
+			}
+			return
+		}
+	}
+
+	value := scalarFindingValue(raw)
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+
+	builder.WriteString(indent)
+	builder.WriteString("- ")
+	if findingSourceKeys[strings.ToLower(strings.TrimSpace(key))] {
+		// Sanitize the URL on its own, then render it as a markdown link. URLs
+		// are not field-prefixed secrets, so per-fragment redaction is safe.
+		link := limitCommentText(strings.TrimSpace(value))
+		builder.WriteString(limitCommentText(key))
+		builder.WriteString(": [")
+		builder.WriteString(link)
+		builder.WriteString("](")
+		builder.WriteString(link)
+		builder.WriteString(")")
+		builder.WriteByte('\n')
+		return
+	}
+
+	// Render "key: value" as one fragment so redactors keyed on the field name
+	// (e.g. token=, password:) see the prefix and value together.
+	builder.WriteString(limitCommentText(key + ": " + value))
+	builder.WriteByte('\n')
+}
+
+func writeFindingJSONFallback(builder *strings.Builder, raw json.RawMessage) {
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, raw, "", "  "); err != nil {
+		pretty.Reset()
+		pretty.WriteString(compactJSON(raw))
+	}
+	builder.WriteString("- \n  ```json\n")
+	builder.WriteString(limitCommentText(pretty.String()))
+	builder.WriteString("\n  ```\n")
+}
+
+const maxFindingDepth = 2
+
+// scalarFindingValue converts a JSON value to a single-line string: JSON
+// strings unwrap to their text, numbers/bools render literally, and
+// objects/arrays compact to JSON.
+func scalarFindingValue(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return compactJSON(raw)
+}
+
+func compactJSON(raw json.RawMessage) string {
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err == nil {
+		return compact.String()
+	}
+	return string(raw)
+}
+
+func sortedFindingKeys(obj map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func writeList(builder *strings.Builder, title string, values []string) {
@@ -120,22 +340,6 @@ func writeList(builder *strings.Builder, title string, values []string) {
 		builder.WriteString(limitCommentText(item))
 		builder.WriteByte('\n')
 	}
-}
-
-func formatFinding(raw json.RawMessage) string {
-	raw = bytes.TrimSpace(raw)
-	if len(raw) == 0 {
-		return ""
-	}
-	var text string
-	if err := json.Unmarshal(raw, &text); err == nil {
-		return text
-	}
-	var compact bytes.Buffer
-	if err := json.Compact(&compact, raw); err == nil {
-		return compact.String()
-	}
-	return string(raw)
 }
 
 // LimitCommentText applies the same redaction, truncation, and command

--- a/internal/workflow/job_comment.go
+++ b/internal/workflow/job_comment.go
@@ -161,10 +161,12 @@ func writeFindingObject(builder *strings.Builder, obj map[string]json.RawMessage
 
 	// A recommendation/severity-style qualifier shown alongside the heading.
 	qualifier := ""
+	qualifierKey := ""
 	for _, key := range []string{"recommendation", "severity", "status"} {
 		if _, ok := obj[key]; ok && key != headingKey {
 			if q := scalarFindingValue(obj[key]); strings.TrimSpace(q) != "" {
 				qualifier = q
+				qualifierKey = key
 				break
 			}
 		}
@@ -190,7 +192,7 @@ func writeFindingObject(builder *strings.Builder, obj map[string]json.RawMessage
 	builder.WriteByte('\n')
 
 	for _, key := range sortedFindingKeys(obj) {
-		if key == headingKey {
+		if key == headingKey || key == qualifierKey {
 			continue
 		}
 		writeFindingField(builder, "  ", key, obj[key], 0)

--- a/internal/workflow/job_comment_test.go
+++ b/internal/workflow/job_comment_test.go
@@ -16,7 +16,7 @@ func TestRenderJobResultCommentIncludesAttributionAndResult(t *testing.T) {
 		Result: &AgentResult{
 			Decision:    "changes_requested",
 			Summary:     "fix the edge case",
-			Findings:    []json.RawMessage{json.RawMessage(`{"severity":"high","body":"bad branch"}`)},
+			Findings:    []json.RawMessage{json.RawMessage(`{"severity":"high","summary":"bad branch"}`)},
 			ChangesMade: []string{"reviewed workflow"},
 			TestsRun:    []string{"go test ./..."},
 			Needs:       []string{"rerun review"},
@@ -32,7 +32,7 @@ func TestRenderJobResultCommentIncludesAttributionAndResult(t *testing.T) {
 		"**Decision:** `changes_requested`",
 		"**Summary:** fix the edge case",
 		"**Findings**",
-		`{"severity":"high","body":"bad branch"}`,
+		"- **bad branch** (high)",
 		"**Changes Made**",
 		"**Tests Run**",
 		"**Needs**",
@@ -42,6 +42,51 @@ func TestRenderJobResultCommentIncludesAttributionAndResult(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Fatalf("comment body missing %q:\n%s", want, body)
 		}
+	}
+}
+
+func TestRenderJobResultCommentRendersFindings(t *testing.T) {
+	body := RenderJobResultComment(JobResultComment{
+		AgentName: "researcher",
+		Runtime:   "claude",
+		JobID:     "job-findings",
+		JobState:  string(JobSucceeded),
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "researched options",
+			Findings: []json.RawMessage{
+				json.RawMessage(`"a plain string finding"`),
+				json.RawMessage(`{"approach":"A — Playwright Scraping","recommendation":"PRIMARY","cost":"$0","source_url":"https://example.com/a","steps":["scrape","parse"]}`),
+				json.RawMessage(`[1,2,3]`),
+			},
+		},
+	})
+
+	for _, want := range []string{
+		"**Findings**",
+		// String finding renders as a plain bullet.
+		"- a plain string finding",
+		// Object finding: bold heading + qualifier.
+		"- **A — Playwright Scraping** (PRIMARY)",
+		// Indented key/value sub-list.
+		"  - cost: $0",
+		// source_url rendered as a markdown link.
+		"  - source_url: [https://example.com/a](https://example.com/a)",
+		// Nested array rendered as a nested bullet sub-list.
+		"  - steps:",
+		"    - scrape",
+		"    - parse",
+		// Non-object/non-string JSON falls back to a fenced json block.
+		"```json",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("comment body missing %q:\n%s", want, body)
+		}
+	}
+
+	// The object finding must not appear as an inline raw JSON blob.
+	if strings.Contains(body, `{"approach":`) {
+		t.Fatalf("object finding rendered as inline raw JSON:\n%s", body)
 	}
 }
 
@@ -73,10 +118,10 @@ func TestRenderJobResultCommentRedactsSecretsAndOmitsRawOutput(t *testing.T) {
 	if !strings.Contains(body, "token=[REDACTED]") || !strings.Contains(body, "password=[REDACTED]") {
 		t.Fatalf("comment did not redact expected fields:\n%s", body)
 	}
-	if !strings.Contains(body, `"token":"[REDACTED]"`) || !strings.Contains(body, `"password":"[REDACTED]"`) {
-		t.Fatalf("comment did not redact JSON secret fields:\n%s", body)
+	if !strings.Contains(body, "token: [REDACTED]") || !strings.Contains(body, "password: [REDACTED]") {
+		t.Fatalf("comment did not redact rendered secret fields:\n%s", body)
 	}
-	if !strings.Contains(body, `"aws_secret_access_key":"[REDACTED]"`) {
+	if !strings.Contains(body, "aws_secret_access_key: [REDACTED]") {
 		t.Fatalf("comment did not redact AWS secret key field:\n%s", body)
 	}
 	if !strings.Contains(body, "AWS_SECRET_ACCESS_KEY=[REDACTED]") {

--- a/internal/workflow/job_comment_test.go
+++ b/internal/workflow/job_comment_test.go
@@ -88,6 +88,12 @@ func TestRenderJobResultCommentRendersFindings(t *testing.T) {
 	if strings.Contains(body, `{"approach":`) {
 		t.Fatalf("object finding rendered as inline raw JSON:\n%s", body)
 	}
+
+	// The qualifier promoted into the heading must not be repeated as a
+	// redundant key/value line in the sub-list.
+	if strings.Contains(body, "- recommendation: PRIMARY") {
+		t.Fatalf("qualifier duplicated in sub-list:\n%s", body)
+	}
 }
 
 func TestRenderJobResultCommentRedactsSecretsAndOmitsRawOutput(t *testing.T) {

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -17,6 +17,27 @@ truthful, and tied to work that actually happened.
 }
 ```
 
+## Findings
+
+`findings` is a free-form array — each entry may be a plain string or a JSON
+object; there is no rigid schema. When you emit **object** findings, the posted
+PR/issue comment renders them as readable markdown (a bold heading plus an
+indented `key: value` sub-list) instead of an inline JSON blob, so a few
+conventional keys make the result easier for humans to audit:
+
+- **Heading**: the renderer uses the first present of `title`, `approach`,
+  `name`, `summary`, or `finding` as the bold heading.
+- **Qualifier**: the first present of `recommendation`, `severity`, or `status`
+  is shown in parentheses next to the heading (e.g. `(PRIMARY)`, `(high)`).
+- **Links**: a `source_url`, `url`, or `source` value is rendered as a clickable
+  markdown link.
+- **Nested values**: arrays become a nested bullet sub-list; nested objects
+  render as `key: value` lines (depth-bounded).
+
+None of these keys is mandatory. String findings still render exactly as the
+plain text you provide, and any finding the renderer cannot map (for example a
+top-level array) falls back to a pretty-printed fenced ```json``` block.
+
 ## Delegations
 
 Orchestra is gitmoot's name for structured multi-agent delegation: a conductor

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -42,6 +42,27 @@ credentials, unclear scope, unavailable tools, failing external services, or
 required human decisions. Always redact secrets from summaries, findings, raw
 command output, and examples.
 
+## Findings
+
+`findings` is a free-form array — each entry may be a plain string or a JSON
+object; there is no rigid schema. When you emit **object** findings, the posted
+PR/issue comment renders them as readable markdown (a bold heading plus an
+indented `key: value` sub-list) instead of an inline JSON blob, so a few
+conventional keys make the result easier for humans to audit:
+
+- **Heading**: the renderer uses the first present of `title`, `approach`,
+  `name`, `summary`, or `finding` as the bold heading.
+- **Qualifier**: the first present of `recommendation`, `severity`, or `status`
+  is shown in parentheses next to the heading (e.g. `(PRIMARY)`, `(high)`).
+- **Links**: a `source_url`, `url`, or `source` value is rendered as a clickable
+  markdown link.
+- **Nested values**: arrays become a nested bullet sub-list; nested objects
+  render as `key: value` lines (depth-bounded).
+
+None of these keys is mandatory. String findings still render exactly as the
+plain text you provide, and any finding the renderer cannot map (for example a
+top-level array) falls back to a pretty-printed fenced ```json``` block.
+
 ## Delegations (Orchestration)
 
 The `delegations` array is how an agent asks named Gitmoot agents to do


### PR DESCRIPTION
Closes #429.

## What

The comment renderer (`internal/workflow/job_comment.go`) dumped object `findings[]` entries as a single inline blob of compacted raw JSON. This teaches it to render them as readable markdown.

- **String findings** render as a plain bullet (unchanged).
- **Object findings** render as a bold heading — first present of `title` / `approach` / `name` / `summary` / `finding` — with a `recommendation` / `severity` / `status` qualifier in parentheses, followed by an indented `key: value` sub-list. The qualifier promoted into the heading is not repeated in the sub-list.
- `source_url` / `url` / `source` values render as clickable markdown links.
- Nested arrays render as a nested bullet sub-list; nested objects render as `key: value` lines (depth-bounded, `maxFindingDepth = 2`).
- Unrenderable values (top-level arrays, scalars, malformed) fall back to a pretty-printed fenced ```json``` block instead of a one-line blob.

Findings stay free-form `[]json.RawMessage` — no key is mandatory, and the existing `limitCommentText` redaction/truncation is preserved (`key: value` pairs are sanitized as a single fragment so field-prefixed secret redactors still match).

## Docs

Documented the conventional finding keys in both doc trees: `skills/gitmoot/references/RESULT_CONTRACT.md` and the website mirror `website/docs/reference/result-contract.md`.

## Acceptance criteria

- [x] Object findings render as a bold heading + indented `key: value` sub-list (no inline raw JSON).
- [x] `source_url` / `url` becomes a clickable markdown link.
- [x] String findings render exactly as today.
- [x] Unknown/odd JSON falls back to a pretty-printed fenced ```json``` block.
- [x] `limitCommentText` redaction + truncation still applied to all rendered text.
- [x] Tests cover: string finding, object finding (heading + fields), `source_url` linking, nested array, and JSON fallback.
- [x] `go build ./... && go vet ./... && go test ./...` pass.

## Test

`go build ./...`, `go vet ./...`, and `go test ./...` pass. The `-race` gate aborts on this Raspberry Pi kernel with the documented "unsupported VMA range / Found 47 - Supported 48" ThreadSanitizer limitation; CI runs it on a supported runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)