### PR TITLE
docs(release): v0.5.2 release notes

### DIFF
--- a/docs/release-notes/v0.5.2.md
+++ b/docs/release-notes/v0.5.2.md
@@ -1,0 +1,93 @@
+# Gitmoot v0.5.2
+
+A large orchestration + runtime-robustness release: a smarter multi-agent
+"Orchestra" (goal-anchored synthesis, dependency dataflow, independent
+verification, human-in-the-loop pauses), more resilient agent/runtime
+management, and automated cross-platform releases. All changes are additive /
+opt-in or bug fixes — default behavior is unchanged.
+
+## What's new since v0.5.1
+
+### Orchestra — multi-agent delegation
+
+- **feat(workflow): goal-anchored finale continuations** (#418) — when delegated
+  jobs finish, the coordinator's continuation now restates the original goal
+  (resolved depth-stably from the root job) and synthesizes an answer to *that
+  goal* — reconciling child conflicts and flagging gaps — instead of a generic
+  "decide the next step." Termination semantics are unchanged.
+- **feat(workflow): deps[] as dataflow** (#419) — a dependent leg can now receive
+  its succeeded upstream dependencies' results (decision, summary, PR, changes,
+  artifact body) injected into its prompt, so legs build on each other instead of
+  only knowing a dep *finished*. Opt-in via
+  `[orchestrate].inject_upstream_dep_context` (default off; flag-off output is
+  byte-identical).
+- **docs(orchestra): verifier delegation pattern + built-in template** (#421) — a
+  new built-in `verifier` coordinator recipe for **independent** (different-model,
+  read-only) checking of delegated work against the goal, generalizing the
+  decompose-and-verify verify leg. Cross-evaluation beats self-grading; documented
+  in both doc trees.
+- **feat(workflow): result-aware non-progress loop detection** (#339) —
+  delegation trees that perturb the work set each round but produce no new
+  verifiable side effects now trip the loop ladder after a configurable streak
+  (`[orchestrate].max_delegation_non_progress_streak`, default 2), not just the
+  blunt depth cap.
+- **feat(workflow): escalate_human failure_policy** (#340) — a delegation can
+  pause the whole tree durably for a human (`awaiting_human`), @-tag them on the
+  PR/issue + surface it in the dashboard Attention list, and resume via
+  `/gitmoot resume <jobID> retry|continue|abort`. Zero tokens while waiting; a TTL
+  auto-finalizes a never-answered escalation; paused time is excluded from the
+  per-root wall-clock budget.
+- **fix(daemon): pre-flight failures advance the parent DAG** (#409, #413) — a
+  delegation child that fails *before its agent runs* (checkout / branch-lock /
+  permission / etc.) now still advances the parent so its `failure_policy` fires
+  (including `escalate_human`), instead of stranding the tree silently. The
+  checkout guard was also relaxed so a worktree-less delegation child isn't
+  false-failed.
+- **perf(db): index the delegation tree by root_id** (#420) — root-scoped engine
+  lookups now use an indexed `root_id` column instead of full-table scans that
+  re-parsed every job, removing an O(n) cost on every child completion under large
+  trees. Behavior is identical.
+- **refactor(prompts): single-source the gitmoot_result contract** (#422) — the
+  agent JSON contract is generated from the Go structs at build time with a
+  drift-guard test, so the prompt can't silently diverge from the code; the
+  delegation field docs are now complete (15/15 fields).
+
+### Agents & runtimes
+
+- **feat(cli): `gitmoot agent restart`** (#414) — rebind a registered agent to a
+  fresh runtime session **in place** (preserving role / repo / template /
+  capabilities), instead of remove-and-recreate; refuses while a live session or
+  queued/running jobs are in flight.
+- **fix(doctor): accurate Claude auth health** (#414, #427) — `agent doctor`,
+  `gitmoot doctor`, and `plugin doctor` now run a live Claude probe instead of
+  false-failing when only an env token is missing (foreground works via cached
+  credentials), with daemon-aware guidance that background jobs still need a token
+  in the daemon env. The status is `warn` (not a hard fail) when the box is
+  actually authenticated.
+- **feat(cli): record owner PID+host on runtime-session locks** (#425) — so
+  `gitmoot agent restart` (and recovery tooling) can distinguish a live foreground
+  session from a stranded lock.
+- **feat(skillopt): `recover --generation`** (#303) — reclaim a stranded SkillOpt
+  option-generation lock (left by a killed `train continue`) and salvage the
+  already-persisted options; `--advance-state` completes the iteration.
+
+### CLI, setup & comments
+
+- **feat(cli): tagging-ready `gitmoot setup`** (#428) — `setup` now defaults to
+  `--watch-issues`, so `@<agent> ask …` mentions on issues route to jobs out of
+  the box.
+- **feat(workflow): readable findings in posted comments** (#429) — `findings[]`
+  objects render as readable markdown in PR/issue comments instead of raw JSON.
+
+### Release & install
+
+- **ci(release): automated cross-platform releases + linux/arm64** (#412) —
+  release binaries (linux/darwin × amd64/arm64, static, CGO-off) are now built,
+  checksummed (`sha256sums.txt`), and attached by a GitHub Actions workflow on
+  release publish; the one-line installer supports `linux/arm64` (e.g. Raspberry
+  Pi).
+
+## Install / upgrade
+
+- Existing install: `gitmoot update`
+- Fresh install: `curl -fsSL https://gitmoot.io/install.sh | sh`

--- a/website/docs/release-notes/v0.5.2.md
+++ b/website/docs/release-notes/v0.5.2.md
@@ -1,0 +1,93 @@
+# Gitmoot v0.5.2
+
+A large orchestration + runtime-robustness release: a smarter multi-agent
+"Orchestra" (goal-anchored synthesis, dependency dataflow, independent
+verification, human-in-the-loop pauses), more resilient agent/runtime
+management, and automated cross-platform releases. All changes are additive /
+opt-in or bug fixes — default behavior is unchanged.
+
+## What's new since v0.5.1
+
+### Orchestra — multi-agent delegation
+
+- **feat(workflow): goal-anchored finale continuations** (#418) — when delegated
+  jobs finish, the coordinator's continuation now restates the original goal
+  (resolved depth-stably from the root job) and synthesizes an answer to *that
+  goal* — reconciling child conflicts and flagging gaps — instead of a generic
+  "decide the next step." Termination semantics are unchanged.
+- **feat(workflow): deps[] as dataflow** (#419) — a dependent leg can now receive
+  its succeeded upstream dependencies' results (decision, summary, PR, changes,
+  artifact body) injected into its prompt, so legs build on each other instead of
+  only knowing a dep *finished*. Opt-in via
+  `[orchestrate].inject_upstream_dep_context` (default off; flag-off output is
+  byte-identical).
+- **docs(orchestra): verifier delegation pattern + built-in template** (#421) — a
+  new built-in `verifier` coordinator recipe for **independent** (different-model,
+  read-only) checking of delegated work against the goal, generalizing the
+  decompose-and-verify verify leg. Cross-evaluation beats self-grading; documented
+  in both doc trees.
+- **feat(workflow): result-aware non-progress loop detection** (#339) —
+  delegation trees that perturb the work set each round but produce no new
+  verifiable side effects now trip the loop ladder after a configurable streak
+  (`[orchestrate].max_delegation_non_progress_streak`, default 2), not just the
+  blunt depth cap.
+- **feat(workflow): escalate_human failure_policy** (#340) — a delegation can
+  pause the whole tree durably for a human (`awaiting_human`), @-tag them on the
+  PR/issue + surface it in the dashboard Attention list, and resume via
+  `/gitmoot resume <jobID> retry|continue|abort`. Zero tokens while waiting; a TTL
+  auto-finalizes a never-answered escalation; paused time is excluded from the
+  per-root wall-clock budget.
+- **fix(daemon): pre-flight failures advance the parent DAG** (#409, #413) — a
+  delegation child that fails *before its agent runs* (checkout / branch-lock /
+  permission / etc.) now still advances the parent so its `failure_policy` fires
+  (including `escalate_human`), instead of stranding the tree silently. The
+  checkout guard was also relaxed so a worktree-less delegation child isn't
+  false-failed.
+- **perf(db): index the delegation tree by root_id** (#420) — root-scoped engine
+  lookups now use an indexed `root_id` column instead of full-table scans that
+  re-parsed every job, removing an O(n) cost on every child completion under large
+  trees. Behavior is identical.
+- **refactor(prompts): single-source the gitmoot_result contract** (#422) — the
+  agent JSON contract is generated from the Go structs at build time with a
+  drift-guard test, so the prompt can't silently diverge from the code; the
+  delegation field docs are now complete (15/15 fields).
+
+### Agents & runtimes
+
+- **feat(cli): `gitmoot agent restart`** (#414) — rebind a registered agent to a
+  fresh runtime session **in place** (preserving role / repo / template /
+  capabilities), instead of remove-and-recreate; refuses while a live session or
+  queued/running jobs are in flight.
+- **fix(doctor): accurate Claude auth health** (#414, #427) — `agent doctor`,
+  `gitmoot doctor`, and `plugin doctor` now run a live Claude probe instead of
+  false-failing when only an env token is missing (foreground works via cached
+  credentials), with daemon-aware guidance that background jobs still need a token
+  in the daemon env. The status is `warn` (not a hard fail) when the box is
+  actually authenticated.
+- **feat(cli): record owner PID+host on runtime-session locks** (#425) — so
+  `gitmoot agent restart` (and recovery tooling) can distinguish a live foreground
+  session from a stranded lock.
+- **feat(skillopt): `recover --generation`** (#303) — reclaim a stranded SkillOpt
+  option-generation lock (left by a killed `train continue`) and salvage the
+  already-persisted options; `--advance-state` completes the iteration.
+
+### CLI, setup & comments
+
+- **feat(cli): tagging-ready `gitmoot setup`** (#428) — `setup` now defaults to
+  `--watch-issues`, so `@<agent> ask …` mentions on issues route to jobs out of
+  the box.
+- **feat(workflow): readable findings in posted comments** (#429) — `findings[]`
+  objects render as readable markdown in PR/issue comments instead of raw JSON.
+
+### Release & install
+
+- **ci(release): automated cross-platform releases + linux/arm64** (#412) —
+  release binaries (linux/darwin × amd64/arm64, static, CGO-off) are now built,
+  checksummed (`sha256sums.txt`), and attached by a GitHub Actions workflow on
+  release publish; the one-line installer supports `linux/arm64` (e.g. Raspberry
+  Pi).
+
+## Install / upgrade
+
+- Existing install: `gitmoot update`
+- Fresh install: `curl -fsSL https://gitmoot.io/install.sh | sh`

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -62,6 +62,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Release Notes',
       items: [
+        'release-notes/v0.5.2',
         'release-notes/v0.5.1',
         'release-notes/v0.5.0',
         'release-notes/v0.4.2',

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1208,6 +1208,39 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    filters to run. Leaving both empty keeps the default of matching all enabled
    repos and all jobs.
 
+   ### Set up a GitHub "tagging" agent
+
+   To get an agent that answers `@<agent> ask …` comments on a repo's issues and
+   PRs, use `gitmoot setup` — it registers the repo, subscribes the agent, grants
+   it repo access, and (with `--start-daemon`) launches a tagging-ready daemon:
+
+   ```sh
+   gitmoot setup --repo owner/project --path . \
+     --agent helper --runtime claude --session last --start-daemon
+   ```
+
+   `gitmoot setup` enables issue-watching by default (`--watch-issues`, on unless
+   you pass `--watch-issues=false`), so `gitmoot setup --start-daemon` yields a
+   daemon that actually answers issue tags rather than silently leaving
+   issue-watching off. After setup it prints a readiness summary: repo registered,
+   agent access granted, daemon issue-watching state, a daemon runtime-auth note,
+   and the exact comment to post.
+
+   Two things to know when tagging on issues:
+
+   - **Run the daemon from a shell that holds the runtime token.** The daemon
+     inherits the environment of the shell that (re)started it, so start it where
+     the runtime (e.g. Claude) is authenticated. (Daemon-aware auth validation is
+     tracked in #427.)
+   - **On issues only the `ask` action is acted on.** Post the tag as the first
+     token of a line:
+
+     ```text
+     @helper ask <your question>
+     ```
+
+   `review` and `implement` actions apply to PRs; on issues they are ignored.
+
    Gitmoot records agent autonomy policy as `read-only`, `workspace-write`,
    `danger-full-access`, or `auto`. For Codex these map to Codex sandbox
    policies; for Claude Code they map to Claude permission modes. Implementation
@@ -7088,6 +7121,27 @@ truthful, and tied to work that actually happened.
   }
 }
 ```
+
+## Findings
+
+`findings` is a free-form array — each entry may be a plain string or a JSON
+object; there is no rigid schema. When you emit **object** findings, the posted
+PR/issue comment renders them as readable markdown (a bold heading plus an
+indented `key: value` sub-list) instead of an inline JSON blob, so a few
+conventional keys make the result easier for humans to audit:
+
+- **Heading**: the renderer uses the first present of `title`, `approach`,
+  `name`, `summary`, or `finding` as the bold heading.
+- **Qualifier**: the first present of `recommendation`, `severity`, or `status`
+  is shown in parentheses next to the heading (e.g. `(PRIMARY)`, `(high)`).
+- **Links**: a `source_url`, `url`, or `source` value is rendered as a clickable
+  markdown link.
+- **Nested values**: arrays become a nested bullet sub-list; nested objects
+  render as `key: value` lines (depth-bounded).
+
+None of these keys is mandatory. String findings still render exactly as the
+plain text you provide, and any finding the renderer cannot map (for example a
+top-level array) falls back to a pretty-printed fenced ```json``` block.
 
 ## Delegations
 


### PR DESCRIPTION
v0.5.2 release notes (both doc trees) + sidebar entry + regenerated `llms-full.txt`. Cut ahead of tagging the v0.5.2 GA release so the tag includes its notes.

Covers the 18 commits since v0.5.1: the Orchestra cluster (#418 goal-anchored finale, #419 deps→dataflow, #420 root_id index, #421 verifier pattern, #422 single-source contract, #339 loop detection, #340 escalate_human, #409/#413 pre-flight DAG fix), runtime/agent robustness (#414 agent restart + live-probe doctor, #425 lock ownership, #427 daemon-aware auth, #303 skillopt recover), CLI/comments (#428 setup --watch-issues, #429 findings markdown), and release automation (#412 arm64 + automated builds).

Docs-only. `npm run build` passes (onBrokenLinks: throw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)