### PR TITLE
docs(llms): bump curated llms.txt 'Latest release' to v0.5.2

### DIFF
--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -27,7 +27,7 @@ full expanded context.
 - [Codex And Claude Plugins](https://gitmoot.io/docs/plugins/codex-claude): Plugin discovery and runtime skill setup.
 - [SkillOpt Exchange Contract](https://gitmoot.io/docs/reference/skillopt-exchange-contract): Training and candidate package boundary for the external optimizer.
 - [Troubleshooting](https://gitmoot.io/docs/operations/troubleshooting): Diagnose GitHub auth, bug reports, runtimes, agent templates, remotes, permissions, and locks.
-- [Release Notes](https://gitmoot.io/docs/release-notes/v0.4.2): Latest release — five opt-in orchestration primitives: daemon `--repo`/`--session` scoping, delegation `phase`, inline `artifact_body`, `quorum` synthesis rule, and `--skip-native-review-fanout` (v0.4.1 fixed the Herdr cockpit panes).
+- [Release Notes](https://gitmoot.io/docs/release-notes/v0.5.2): Latest release (v0.5.2) — Orchestra upgrades: goal-anchored finale, `deps[]` dataflow, independent `verifier` pattern, result-aware loop detection, `escalate_human` human-in-the-loop pause, pre-flight DAG fix, `root_id` index, single-sourced result contract; plus `agent restart`, accurate Claude auth health, and automated linux/arm64 releases.
 - [Raw SKILL.md](https://gitmoot.io/SKILL.md): Agent skill entrypoint.
 - [Full LLM Context](https://gitmoot.io/llms-full.txt): Expanded Markdown context for agents.
 - [GitHub Repository](https://github.com/jerryfane/gitmoot): Source code and releases.


### PR DESCRIPTION
The hand-curated `website/static/llms.txt` still advertised **v0.4.2** as the latest release (it was missed for v0.5.0 and v0.5.1 as well). Updated the entry to **v0.5.2** with the current headline features. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)