### PR TITLE
feat(workflow): enrich delegation context-manifest with structured upstream dep refs (#438)

### DIFF
--- a/internal/workflow/artifacts.go
+++ b/internal/workflow/artifacts.go
@@ -79,7 +79,7 @@ func writeDelegationArtifacts(root string, parentJobID string, result *AgentResu
 		return "", fmt.Errorf("create delegation artifact directory: %w", err)
 	}
 	briefPath := filepath.Join(dir, "brief.md")
-	if err := os.WriteFile(briefPath, []byte(result.ArtifactBody), 0o644); err != nil {
+	if err := writeFileAtomic(briefPath, []byte(result.ArtifactBody), 0o644); err != nil {
 		return "", fmt.Errorf("write delegation brief %s: %w", briefPath, err)
 	}
 	manifest := delegationManifest{
@@ -100,7 +100,7 @@ func writeDelegationArtifacts(root string, parentJobID string, result *AgentResu
 		return "", fmt.Errorf("encode delegation manifest: %w", err)
 	}
 	manifestPath := filepath.Join(dir, "context-manifest.json")
-	if err := os.WriteFile(manifestPath, encoded, 0o644); err != nil {
+	if err := writeFileAtomic(manifestPath, encoded, 0o644); err != nil {
 		return "", fmt.Errorf("write delegation manifest %s: %w", manifestPath, err)
 	}
 	return dir, nil
@@ -123,8 +123,11 @@ func writeDelegationArtifacts(root string, parentJobID string, result *AgentResu
 // dispatch), so repeated passes over a stable succeeded set produce byte-identical
 // output (idempotent — no churn). It is a no-op (returns the resolved dir, no
 // write) when the root is empty or no delegation requested artifacts, mirroring
-// writeDelegationArtifacts. It reuses the same MkdirAll(0o755)+WriteFile(0o644)
-// pattern so a child reading the directory always sees a complete manifest.
+// writeDelegationArtifacts. The manifest write is atomic (writeFileAtomic:
+// temp-file + os.Rename), because advanceDelegations invokes this on EVERY child
+// completion and concurrent sibling completions of one parent can call it in
+// parallel; the rename guarantees a child reading the directory always sees a
+// complete (old-or-new) manifest, never a torn write.
 func augmentDelegationManifest(root string, parentJobID string, parentResult *AgentResult, children, dedupWinners map[string]db.Job, e Engine) (string, error) {
 	if strings.TrimSpace(root) == "" {
 		return "", nil
@@ -152,10 +155,53 @@ func augmentDelegationManifest(root string, parentJobID string, parentResult *Ag
 		return "", fmt.Errorf("encode delegation manifest: %w", err)
 	}
 	manifestPath := filepath.Join(dir, "context-manifest.json")
-	if err := os.WriteFile(manifestPath, encoded, 0o644); err != nil {
+	if err := writeFileAtomic(manifestPath, encoded, 0o644); err != nil {
 		return "", fmt.Errorf("write delegation manifest %s: %w", manifestPath, err)
 	}
 	return dir, nil
+}
+
+// writeFileAtomic writes data to path atomically: it writes to a uniquely-named
+// temp file in the same directory, closes it, then os.Renames it onto
+// path. Rename is atomic on a single filesystem, so a concurrent reader always
+// observes either the complete old or the complete new file, never a torn/short
+// one. This matters for context-manifest.json, which advanceDelegations re-writes
+// on every child completion (augmentDelegationManifest): two read-only sibling
+// delegations of one parent can finish near-simultaneously and the #328/#329
+// read-only fan-out runs them in parallel (distinct worktree checkout keys, not
+// serialized on repo:<repo>), so the augment write must not interleave a bare
+// O_TRUNC os.WriteFile. The encoded manifest is deterministic, so a lost-update
+// race over a stable succeeded set converges harmlessly. It mirrors the
+// established in-repo pattern (internal/artifact/store.go, internal/config/edit.go).
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 // buildEnrichedManifestEntry returns the reduced manifest entry for a delegation,

--- a/internal/workflow/artifacts.go
+++ b/internal/workflow/artifacts.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
 )
 
 // delegationManifest is the on-disk context-manifest.json written for a parent
@@ -17,14 +19,40 @@ type delegationManifest struct {
 }
 
 // delegationManifestEntry is the reduced view of a single delegation surfaced in
-// context-manifest.json. It intentionally exposes only the coordination fields
-// children need to reason about the wider batch.
+// context-manifest.json. It exposes the coordination fields children need to
+// reason about the wider batch, plus — when InjectUpstreamDepContext is on and
+// the delegation has a SUCCEEDED child (#438) — a set of additive, omitempty
+// result-reference fields so a downstream reader that prefers structured JSON
+// over the prose "Upstream dependency results" block (#419) can reference an
+// upstream output precisely. Bulk bodies are NEVER inlined here: OutputPath is
+// the only handle to full content (the on-disk brief.md). With the flag off, or
+// for a pending/failed/not-yet-run delegation, every result-reference field is
+// the zero value and omitempty leaves the entry byte-identical to the reduced
+// shape that shipped before #438.
 type delegationManifestEntry struct {
 	ID       string   `json:"id"`
 	Agent    string   `json:"agent"`
 	Action   string   `json:"action"`
 	Worktree string   `json:"worktree,omitempty"`
 	Deps     []string `json:"deps,omitempty"`
+
+	// Decision is the succeeded child's gitmoot_result decision (e.g. "approved").
+	Decision string `json:"decision,omitempty"`
+	// SummaryPreview is the child's summary capped to maxUpstreamDepSummaryPreviewBytes
+	// (rune-safe, with an ellipsis when truncated), mirroring the prose header preview.
+	SummaryPreview string `json:"summary_preview,omitempty"`
+	// ChangesMade is the COUNT of the child's changes_made entries (not the slice),
+	// kept as an int to stay token-cheap and match #419's "[changes_made: N]".
+	ChangesMade int `json:"changes_made,omitempty"`
+	// PullRequest is the rendered github PR URL for the child, when it opened one.
+	PullRequest string `json:"pull_request,omitempty"`
+	// OutputPath is the on-disk path to the parent's full brief.md — the only
+	// handle to bulk content; the manifest never inlines a body by value.
+	OutputPath string `json:"output_path,omitempty"`
+	// DerivedFrom is the delegation's own declared Deps (its declared upstream
+	// lineage). This is a deliberate simplification: it is the dep's declared
+	// upstreams, NOT a transitive/resolved ancestry graph.
+	DerivedFrom []string `json:"derived_from,omitempty"`
 }
 
 // writeDelegationArtifacts persists the coordinator brief and a context manifest
@@ -76,6 +104,116 @@ func writeDelegationArtifacts(root string, parentJobID string, result *AgentResu
 		return "", fmt.Errorf("write delegation manifest %s: %w", manifestPath, err)
 	}
 	return dir, nil
+}
+
+// augmentDelegationManifest re-writes context-manifest.json with the enriched
+// view (#438): each delegation entry whose child has SUCCEEDED gains the additive
+// result-reference fields (decision/summary_preview/changes_made/pull_request/
+// output_path/derived_from) so a downstream reader can reference an upstream
+// output by structured JSON instead of re-parsing the prose block (#419). It is
+// the structured sibling of buildUpstreamDepBlock and rides the identical gate:
+// callers MUST only invoke it when Engine.InjectUpstreamDepContext is set, so the
+// flag-off path never re-writes the manifest and stays byte-identical to today.
+//
+// Write timing is WRITE-ONCE-THEN-AUGMENT: writeDelegationArtifacts writes the
+// reduced manifest at dispatch (before any dep has run), and this overwrites it
+// each advanceDelegations pass once deps have actually reached JobSucceeded. The
+// enriched view is recomputed from the current children/dedupWinners every pass
+// and produces stable, sorted JSON (delegations in parentResult order, same as
+// dispatch), so repeated passes over a stable succeeded set produce byte-identical
+// output (idempotent — no churn). It is a no-op (returns the resolved dir, no
+// write) when the root is empty or no delegation requested artifacts, mirroring
+// writeDelegationArtifacts. It reuses the same MkdirAll(0o755)+WriteFile(0o644)
+// pattern so a child reading the directory always sees a complete manifest.
+func augmentDelegationManifest(root string, parentJobID string, parentResult *AgentResult, children, dedupWinners map[string]db.Job, e Engine) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		return "", nil
+	}
+	if parentResult == nil || !delegationsRequestArtifacts(parentResult.Delegations) {
+		return "", nil
+	}
+	segment, err := safeDelegationPathSegment(parentJobID, "parent job id")
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(root, "delegations", segment)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create delegation artifact directory: %w", err)
+	}
+	manifest := delegationManifest{
+		ParentJobID: parentJobID,
+		Delegations: make([]delegationManifestEntry, 0, len(parentResult.Delegations)),
+	}
+	for _, d := range parentResult.Delegations {
+		manifest.Delegations = append(manifest.Delegations, buildEnrichedManifestEntry(d, children, dedupWinners, e))
+	}
+	encoded, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode delegation manifest: %w", err)
+	}
+	manifestPath := filepath.Join(dir, "context-manifest.json")
+	if err := os.WriteFile(manifestPath, encoded, 0o644); err != nil {
+		return "", fmt.Errorf("write delegation manifest %s: %w", manifestPath, err)
+	}
+	return dir, nil
+}
+
+// buildEnrichedManifestEntry returns the reduced manifest entry for a delegation,
+// plus the result-reference fields when the delegation has a SUCCEEDED child
+// (#438). It mirrors buildUpstreamDepBlock's resolution exactly: the child is
+// looked up in children, falling back to dedupWinners so a fingerprint-deduped
+// delegation is followed to its winning sibling; only a JobSucceeded child with a
+// resolvable payload is enriched. A pending/failed/missing-child delegation
+// returns the bare reduced entry (every new field zero, so omitempty omits it),
+// keeping the flag-off / not-yet-run shape byte-identical.
+func buildEnrichedManifestEntry(d Delegation, children, dedupWinners map[string]db.Job, e Engine) delegationManifestEntry {
+	entry := delegationManifestEntry{
+		ID:       d.ID,
+		Agent:    d.Agent,
+		Action:   d.Action,
+		Worktree: d.Worktree,
+		Deps:     d.Deps,
+	}
+	child, ok := children[d.ID]
+	if !ok {
+		// A deduped delegation has no child of its own; follow it to the winner.
+		child, ok = dedupWinners[d.ID]
+	}
+	if !ok || child.State != string(JobSucceeded) {
+		return entry
+	}
+	payload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		return entry
+	}
+	// Defensive on a nil Result, mirroring buildUpstreamDepBlock: a succeeded child
+	// with no Result still carries the by-reference handles (PR/output_path/lineage)
+	// but no decision/summary/changes from the missing result.
+	if payload.Result != nil {
+		entry.Decision = strings.TrimSpace(payload.Result.Decision)
+		if summary := strings.TrimSpace(payload.Result.Summary); summary != "" {
+			entry.SummaryPreview = manifestSummaryPreview(summary)
+		}
+		entry.ChangesMade = len(payload.Result.ChangesMade)
+	}
+	entry.PullRequest = childPullRequestLink(payload)
+	entry.OutputPath = e.inlineBriefPath(child.ID)
+	entry.DerivedFrom = compactStrings(d.Deps)
+	return entry
+}
+
+// manifestSummaryPreview caps a child's summary to the same short, rune-safe
+// preview the prose header uses (maxUpstreamDepSummaryPreviewBytes), appending an
+// ellipsis when truncated. Unlike the prose path it does NOT backtick-fence the
+// preview: json.MarshalIndent already escapes any embedded backticks/sentinels
+// safely, and a fence would corrupt the JSON string. The full body travels by
+// reference via OutputPath, so this preview is deliberately short.
+func manifestSummaryPreview(summary string) string {
+	preview, omitted := truncateUTF8Bytes(summary, maxUpstreamDepSummaryPreviewBytes)
+	if omitted > 0 {
+		preview = strings.TrimRight(preview, " \t\n") + "…"
+	}
+	return preview
 }
 
 // delegationArtifactDir returns the directory writeDelegationArtifacts would

--- a/internal/workflow/artifacts_test.go
+++ b/internal/workflow/artifacts_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
+
+	"github.com/jerryfane/gitmoot/internal/db"
 )
 
 func TestWriteDelegationArtifactsWritesBriefAndManifest(t *testing.T) {
@@ -96,9 +99,21 @@ func TestWriteDelegationArtifactsManifestOnlyHasReducedFields(t *testing.T) {
 			t.Fatalf("manifest entry missing %q: %v", want, entry)
 		}
 	}
+	// The dispatch-time manifest has only the reduced coordination fields because
+	// no child has succeeded yet, so the #438 result-reference fields are
+	// omitempty-absent. The invariant under test is that the manifest never leaks
+	// the PROMPT or any lifecycle control (prompt/timeout/retry/failure_policy);
+	// the additive result-reference keys are allowed when populated and (here)
+	// absent when no dep has succeeded.
 	for got := range entry {
 		switch got {
 		case "id", "agent", "action", "worktree", "deps":
+			// reduced coordination fields (always present in shape)
+		case "decision", "summary_preview", "changes_made", "pull_request", "output_path", "derived_from":
+			// #438 additive result-reference fields — must NOT appear here (nothing
+			// has succeeded at dispatch), but if a future change populates them this
+			// is a legitimate enriched key, not a leak.
+			t.Fatalf("dispatch-time manifest unexpectedly carries enriched field %q (nothing succeeded yet): %v", got, entry)
 		default:
 			t.Fatalf("manifest entry leaked field %q: %v", got, entry)
 		}
@@ -175,4 +190,234 @@ func TestWriteDelegationArtifactsSanitizesUnsafeParentID(t *testing.T) {
 	if manifest.ParentJobID != "parent-job/delegation/del-1" {
 		t.Fatalf("manifest parent_job_id = %q, want original id", manifest.ParentJobID)
 	}
+}
+
+// --- #438: structured upstream dep references in context-manifest.json ---
+
+// TestBuildEnrichedManifestEntrySucceededDepPopulatesFields pins that a
+// delegation with a SUCCEEDED child yields the additive result-reference fields
+// (decision/summary_preview/changes_made/pull_request/output_path/derived_from),
+// mirroring the #419 prose channel but JSON-encoded.
+func TestBuildEnrichedManifestEntrySucceededDepPopulatesFields(t *testing.T) {
+	e := Engine{InjectUpstreamDepContext: true, ArtifactRoot: "/home/.gitmoot"}
+	children := map[string]db.Job{
+		"research": childJobWith(t, "parent/delegation/research", "researcher", "review", JobPayload{
+			Repo:        "jerryfane/gitmoot",
+			PullRequest: 42,
+			Result: &AgentResult{
+				Decision:     "approved",
+				Summary:      "found three relevant prior arts",
+				ChangesMade:  []string{"noted A", "noted B"},
+				ArtifactBody: "RESEARCH BRIEF BODY",
+			},
+		}),
+	}
+	d := Delegation{ID: "research", Agent: "researcher", Action: "review", Deps: []string{"seed"}}
+	entry := buildEnrichedManifestEntry(d, children, nil, e)
+
+	if entry.ID != "research" || entry.Agent != "researcher" || entry.Action != "review" {
+		t.Fatalf("reduced fields wrong: %+v", entry)
+	}
+	if entry.Decision != "approved" {
+		t.Fatalf("decision = %q, want approved", entry.Decision)
+	}
+	if entry.SummaryPreview != "found three relevant prior arts" {
+		t.Fatalf("summary_preview = %q", entry.SummaryPreview)
+	}
+	if entry.ChangesMade != 2 {
+		t.Fatalf("changes_made = %d, want 2", entry.ChangesMade)
+	}
+	if entry.PullRequest != "https://github.com/jerryfane/gitmoot/pull/42" {
+		t.Fatalf("pull_request = %q", entry.PullRequest)
+	}
+	if want := e.inlineBriefPath("parent/delegation/research"); entry.OutputPath != want {
+		t.Fatalf("output_path = %q, want %q", entry.OutputPath, want)
+	}
+	if len(entry.DerivedFrom) != 1 || entry.DerivedFrom[0] != "seed" {
+		t.Fatalf("derived_from = %v, want [seed]", entry.DerivedFrom)
+	}
+}
+
+// TestBuildEnrichedManifestEntryPendingOrFailedStaysReduced pins succeeded-only
+// enrichment: a delegation with a pending, failed, or missing child keeps the
+// bare reduced shape (all new fields zero/omitted), so omitempty leaves it
+// byte-identical to the pre-#438 manifest.
+func TestBuildEnrichedManifestEntryPendingOrFailedStaysReduced(t *testing.T) {
+	e := Engine{InjectUpstreamDepContext: true, ArtifactRoot: "/home/.gitmoot"}
+	cases := map[string]map[string]db.Job{
+		"missing child": {},
+		"failed child": {
+			"x": {ID: "parent/delegation/x", Agent: "a", Type: "review", State: string(JobFailed),
+				Payload: mustMarshalPayload(t, JobPayload{Result: &AgentResult{Decision: "failed"}})},
+		},
+		"queued child": {
+			"x": {ID: "parent/delegation/x", Agent: "a", Type: "review", State: string(JobQueued)},
+		},
+	}
+	for name, children := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := Delegation{ID: "x", Agent: "a", Action: "review", Worktree: "w", Deps: []string{"upstream"}}
+			entry := buildEnrichedManifestEntry(d, children, nil, e)
+			if entry.ID != "x" || entry.Agent != "a" || entry.Action != "review" || entry.Worktree != "w" {
+				t.Fatalf("reduced fields wrong: %+v", entry)
+			}
+			if len(entry.Deps) != 1 || entry.Deps[0] != "upstream" {
+				t.Fatalf("deps = %v, want [upstream]", entry.Deps)
+			}
+			if entry.Decision != "" || entry.SummaryPreview != "" || entry.ChangesMade != 0 ||
+				entry.PullRequest != "" || entry.OutputPath != "" || entry.DerivedFrom != nil {
+				t.Fatalf("non-succeeded entry must stay reduced, got: %+v", entry)
+			}
+		})
+	}
+}
+
+// TestBuildEnrichedManifestEntryFollowsDedupWinner pins that a delegation deduped
+// to a winning sibling (passed via dedupWinners, no child of its own) is enriched
+// from the winner's payload, matching buildUpstreamDepBlock's dedup-follow rule.
+func TestBuildEnrichedManifestEntryFollowsDedupWinner(t *testing.T) {
+	e := Engine{InjectUpstreamDepContext: true, ArtifactRoot: "/home/.gitmoot"}
+	winner := childJobWith(t, "parent/delegation/winner", "w", "review", JobPayload{
+		Result: &AgentResult{Decision: "approved", Summary: "winner summary"},
+	})
+	dedupWinners := map[string]db.Job{"dup": winner}
+	d := Delegation{ID: "dup", Agent: "w", Action: "review"}
+	entry := buildEnrichedManifestEntry(d, map[string]db.Job{}, dedupWinners, e)
+	if entry.Decision != "approved" || entry.SummaryPreview != "winner summary" {
+		t.Fatalf("deduped entry should be enriched from the winner, got: %+v", entry)
+	}
+	if want := e.inlineBriefPath("parent/delegation/winner"); entry.OutputPath != want {
+		t.Fatalf("output_path = %q, want winner path %q", entry.OutputPath, want)
+	}
+}
+
+// TestManifestSummaryPreviewTruncatedRuneSafe pins that an oversized multi-byte
+// summary is capped at maxUpstreamDepSummaryPreviewBytes, rune-safe, with an
+// ellipsis, and the full summary is not present.
+func TestManifestSummaryPreviewTruncatedRuneSafe(t *testing.T) {
+	e := Engine{InjectUpstreamDepContext: true, ArtifactRoot: "/home/.gitmoot"}
+	summary := strings.Repeat("世", 200) // 600 bytes, overruns the 280-byte cap
+	children := map[string]db.Job{
+		"d1": childJobWith(t, "parent/delegation/d1", "d", "review", JobPayload{
+			Result: &AgentResult{Decision: "approved", Summary: summary},
+		}),
+	}
+	d := Delegation{ID: "d1", Agent: "d", Action: "review"}
+	entry := buildEnrichedManifestEntry(d, children, nil, e)
+	if !utf8.ValidString(entry.SummaryPreview) {
+		t.Fatalf("summary_preview split a UTF-8 rune: %q", entry.SummaryPreview)
+	}
+	if len(entry.SummaryPreview) > maxUpstreamDepSummaryPreviewBytes+len("…") {
+		t.Fatalf("summary_preview = %d bytes, want <= cap+ellipsis", len(entry.SummaryPreview))
+	}
+	if !strings.HasSuffix(entry.SummaryPreview, "…") {
+		t.Fatalf("expected ellipsis on a truncated preview: %q", entry.SummaryPreview)
+	}
+	if entry.SummaryPreview == summary || strings.Contains(entry.SummaryPreview, strings.Repeat("世", 200)) {
+		t.Fatalf("full oversized summary leaked into the preview")
+	}
+}
+
+// TestAugmentDelegationManifestRoundTrip writes the base manifest, then augments
+// with a children map containing one succeeded dep, re-reads context-manifest.json
+// and asserts the enriched fields appear ONLY on the succeeded entry while the
+// pending sibling stays reduced.
+func TestAugmentDelegationManifestRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	e := Engine{InjectUpstreamDepContext: true, ArtifactRoot: root}
+	result := &AgentResult{
+		ArtifactBody: "shared brief",
+		Delegations: []Delegation{
+			{ID: "research", Agent: "researcher", Action: "review", Artifacts: []string{"brief.md"}},
+			{ID: "write", Agent: "writer", Action: "review", Deps: []string{"research"}},
+		},
+	}
+	// Base manifest at dispatch (reduced shape, nothing succeeded yet).
+	if _, err := writeDelegationArtifacts(root, "parent-job", result); err != nil {
+		t.Fatalf("writeDelegationArtifacts returned error: %v", err)
+	}
+
+	children := map[string]db.Job{
+		"research": childJobWith(t, "parent-job/delegation/research", "researcher", "review", JobPayload{
+			Repo:        "jerryfane/gitmoot",
+			PullRequest: 7,
+			Result: &AgentResult{
+				Decision:    "approved",
+				Summary:     "RESEARCH_SUMMARY",
+				ChangesMade: []string{"a", "b", "c"},
+			},
+		}),
+		// write is still queued (no entry / not succeeded).
+	}
+	dir, err := augmentDelegationManifest(root, "parent-job", result, children, nil, e)
+	if err != nil {
+		t.Fatalf("augmentDelegationManifest returned error: %v", err)
+	}
+	if dir != filepath.Join(root, "delegations", "parent-job") {
+		t.Fatalf("augment dir = %q", dir)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "context-manifest.json"))
+	if err != nil {
+		t.Fatalf("read context-manifest.json: %v", err)
+	}
+	var manifest delegationManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("manifest not valid JSON: %v", err)
+	}
+	if len(manifest.Delegations) != 2 {
+		t.Fatalf("manifest delegations = %d, want 2", len(manifest.Delegations))
+	}
+	research, write := manifest.Delegations[0], manifest.Delegations[1]
+	if research.ID != "research" || write.ID != "write" {
+		t.Fatalf("manifest order changed: %+v", manifest.Delegations)
+	}
+	// Succeeded entry is enriched.
+	if research.Decision != "approved" || research.SummaryPreview != "RESEARCH_SUMMARY" || research.ChangesMade != 3 {
+		t.Fatalf("research entry not enriched: %+v", research)
+	}
+	if research.PullRequest != "https://github.com/jerryfane/gitmoot/pull/7" {
+		t.Fatalf("research pull_request = %q", research.PullRequest)
+	}
+	if want := e.inlineBriefPath("parent-job/delegation/research"); research.OutputPath != want {
+		t.Fatalf("research output_path = %q, want %q", research.OutputPath, want)
+	}
+	// Pending sibling stays reduced.
+	if write.Decision != "" || write.SummaryPreview != "" || write.ChangesMade != 0 ||
+		write.PullRequest != "" || write.OutputPath != "" {
+		t.Fatalf("pending write entry must stay reduced: %+v", write)
+	}
+}
+
+// TestAugmentDelegationManifestNoOpWhenRootEmptyOrNoArtifacts pins that the
+// augmenting writer is a no-op (no dir, no write) when there is no artifact root
+// or no delegation requested artifacts, mirroring writeDelegationArtifacts.
+func TestAugmentDelegationManifestNoOpWhenRootEmptyOrNoArtifacts(t *testing.T) {
+	e := Engine{InjectUpstreamDepContext: true}
+	result := &AgentResult{
+		ArtifactBody: "b",
+		Delegations:  []Delegation{{ID: "a", Agent: "x", Action: "review"}}, // no Artifacts
+	}
+	if dir, err := augmentDelegationManifest("", "parent", result, nil, nil, e); err != nil || dir != "" {
+		t.Fatalf("empty root: dir=%q err=%v, want empty/no error", dir, err)
+	}
+	root := t.TempDir()
+	if dir, err := augmentDelegationManifest(root, "parent", result, nil, nil, e); err != nil || dir != "" {
+		t.Fatalf("no-artifacts: dir=%q err=%v, want empty/no error", dir, err)
+	}
+	if entries, err := os.ReadDir(root); err != nil {
+		t.Fatalf("read root: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("no-artifacts augment wrote %d entries, want none", len(entries))
+	}
+}
+
+// mustMarshalPayload is a test helper for building a db.Job.Payload inline.
+func mustMarshalPayload(t *testing.T, payload JobPayload) string {
+	t.Helper()
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	return encoded
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1828,6 +1828,34 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 		return err
 	}
 
+	// #438: structured sibling of the #419 prose block. Now that a child has
+	// finished, augment context-manifest.json with the result-reference fields for
+	// every SUCCEEDED delegation so a downstream reader can reference an upstream
+	// output by structured JSON rather than re-parsing the prose block. The
+	// just-finished child is already in the children map read above, so the enriched
+	// view reflects the current succeeded set (later re-reads in this pass only add
+	// newly-enqueued, not-yet-succeeded dependents). It is gated on
+	// InjectUpstreamDepContext so the flag-off path never re-writes the manifest and
+	// stays byte-identical to today, and the write is idempotent (deterministic,
+	// sorted JSON) so repeated passes over a stable succeeded set produce no churn.
+	// Best-effort like the dispatch artifact write: a manifest write failure must
+	// not block draining ready dependents.
+	if e.InjectUpstreamDepContext {
+		if augmentedDir, augErr := augmentDelegationManifest(e.ArtifactRoot, parentJob.ID, parentResult, children, dedupWinners, e); augErr != nil {
+			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   parentJob.ID,
+				Kind:    "delegation_manifest_augment_failed",
+				Message: fmt.Sprintf("augment delegation manifest: %v", augErr),
+			})
+		} else if augmentedDir != "" {
+			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   parentJob.ID,
+				Kind:    "delegation_manifest_augmented",
+				Message: fmt.Sprintf("delegation manifest augmented at %s", augmentedDir),
+			})
+		}
+	}
+
 	// Retry pass: a delegation that failed but has retry budget left is
 	// re-enqueued as a fresh child before any failure_policy is applied, so its
 	// failure is absorbed by the retry rather than blocking/escalating. A

--- a/internal/workflow/upstream_dep_test.go
+++ b/internal/workflow/upstream_dep_test.go
@@ -2,6 +2,9 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -529,5 +532,203 @@ func TestAdvanceDelegationsUpstreamIdempotentReEnqueue(t *testing.T) {
 	}
 	if c := strings.Count(second.Instructions, "Upstream dependency results:"); c != 1 {
 		t.Fatalf("upstream block injected %d times, want exactly 1\n%s", c, second.Instructions)
+	}
+}
+
+// --- #438: structured upstream dep references in context-manifest.json (engine) ---
+
+// seedManifestParent inserts a coordinator parent whose research->write pipeline
+// requests artifacts (so the context manifest is written), mirroring the #419
+// engine fixtures but with Artifacts + an ArtifactBody so the manifest exists.
+func seedManifestParent(t *testing.T, store *db.Store) {
+	t.Helper()
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "researcher", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "writer", []string{"review"}, "jerryfane/gitmoot")
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-438",
+		TaskID:    "task-438",
+		TaskTitle: "Parent",
+		Sender:    "coord",
+		Result: &AgentResult{
+			Decision:     "approved",
+			Summary:      "done",
+			ArtifactBody: "# Shared brief\n",
+			Delegations: []Delegation{
+				{ID: "research", Agent: "researcher", Action: "review", Prompt: "research the topic", Artifacts: []string{"brief.md"}},
+				{ID: "write", Agent: "writer", Action: "review", Prompt: "WRITE_REPORT_PROMPT", Deps: []string{"research"}},
+			},
+		},
+	})
+}
+
+func readManifest(t *testing.T, root string) delegationManifest {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, "delegations", "parent-job", "context-manifest.json"))
+	if err != nil {
+		t.Fatalf("read context-manifest.json: %v", err)
+	}
+	var manifest delegationManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("manifest not valid JSON: %v", err)
+	}
+	return manifest
+}
+
+// TestAdvanceDelegationsEnrichesManifestWhenEnabled is the #438 engine pin: with
+// InjectUpstreamDepContext set, after research succeeds and advanceDelegations
+// runs, context-manifest.json's research entry carries the structured
+// result-reference fields while the still-pending write entry stays reduced.
+func TestAdvanceDelegationsEnrichesManifestWhenEnabled(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	engine.InjectUpstreamDepContext = true
+	engine.ArtifactRoot = t.TempDir()
+	seedManifestParent(t, store)
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/research", JobSucceeded, AgentResult{
+		Decision: "approved", Summary: "RESEARCH_FINDINGS_SUMMARY", ChangesMade: []string{"x", "y"}, ArtifactBody: "RESEARCH_BODY",
+	})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/research"); err != nil {
+		t.Fatalf("AdvanceJob(research) returned error: %v", err)
+	}
+
+	manifest := readManifest(t, engine.ArtifactRoot)
+	if len(manifest.Delegations) != 2 {
+		t.Fatalf("manifest delegations = %d, want 2", len(manifest.Delegations))
+	}
+	research, write := manifest.Delegations[0], manifest.Delegations[1]
+	if research.ID != "research" {
+		t.Fatalf("entry[0] = %q, want research", research.ID)
+	}
+	if research.Decision != "approved" {
+		t.Fatalf("research decision = %q, want approved", research.Decision)
+	}
+	if research.SummaryPreview != "RESEARCH_FINDINGS_SUMMARY" {
+		t.Fatalf("research summary_preview = %q", research.SummaryPreview)
+	}
+	if research.ChangesMade != 2 {
+		t.Fatalf("research changes_made = %d, want 2", research.ChangesMade)
+	}
+	if want := engine.inlineBriefPath("parent-job/delegation/research"); research.OutputPath != want {
+		t.Fatalf("research output_path = %q, want %q", research.OutputPath, want)
+	}
+	// output_path must reference the brief.md that actually exists on disk.
+	if _, err := os.Stat(research.OutputPath); err != nil {
+		t.Fatalf("research output_path does not exist on disk: %v", err)
+	}
+	if len(research.DerivedFrom) != 0 {
+		t.Fatalf("research derived_from = %v, want empty (no declared deps)", research.DerivedFrom)
+	}
+	// The still-pending write entry stays reduced.
+	if write.ID != "write" {
+		t.Fatalf("entry[1] = %q, want write", write.ID)
+	}
+	if write.Decision != "" || write.SummaryPreview != "" || write.OutputPath != "" {
+		t.Fatalf("pending write entry must stay reduced: %+v", write)
+	}
+	if len(write.DerivedFrom) != 0 { // not enriched -> derived_from omitted even though it has deps
+		t.Fatalf("pending write entry derived_from = %v, want omitted", write.DerivedFrom)
+	}
+}
+
+// TestAdvanceDelegationsManifestFlagOffByteIdentical is the load-bearing parity
+// pin: with InjectUpstreamDepContext off, the bytes of context-manifest.json after
+// the full research->write advance are byte-identical to the flag-off dispatch-time
+// manifest (no enrichment, no rewrite-induced churn). Sanity: flag-on bytes differ.
+func TestAdvanceDelegationsManifestFlagOffByteIdentical(t *testing.T) {
+	run := func(t *testing.T, inject bool) []byte {
+		t.Helper()
+		ctx := context.Background()
+		store := openEngineStore(t)
+		engine := testEngine(store)
+		engine.InjectUpstreamDepContext = inject
+		engine.ArtifactRoot = t.TempDir()
+		seedManifestParent(t, store)
+
+		if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+			t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+		}
+		completeDelegationChild(t, store, "parent-job/delegation/research", JobSucceeded, AgentResult{
+			Decision: "approved", Summary: "RESEARCH_FINDINGS_SUMMARY", ArtifactBody: "RESEARCH_BODY",
+		})
+		if err := engine.AdvanceJob(ctx, "parent-job/delegation/research"); err != nil {
+			t.Fatalf("AdvanceJob(research) returned error: %v", err)
+		}
+		raw, err := os.ReadFile(filepath.Join(engine.ArtifactRoot, "delegations", "parent-job", "context-manifest.json"))
+		if err != nil {
+			t.Fatalf("read context-manifest.json: %v", err)
+		}
+		return raw
+	}
+
+	// The dispatch-time reduced manifest, written by writeDelegationArtifacts, is
+	// the byte target the flag-off advance must NOT have changed.
+	dispatchRoot := t.TempDir()
+	dispatchResult := &AgentResult{
+		ArtifactBody: "# Shared brief\n",
+		Delegations: []Delegation{
+			{ID: "research", Agent: "researcher", Action: "review", Artifacts: []string{"brief.md"}},
+			{ID: "write", Agent: "writer", Action: "review", Deps: []string{"research"}},
+		},
+	}
+	if _, err := writeDelegationArtifacts(dispatchRoot, "parent-job", dispatchResult); err != nil {
+		t.Fatalf("writeDelegationArtifacts returned error: %v", err)
+	}
+	dispatchBytes, err := os.ReadFile(filepath.Join(dispatchRoot, "delegations", "parent-job", "context-manifest.json"))
+	if err != nil {
+		t.Fatalf("read dispatch manifest: %v", err)
+	}
+
+	off := run(t, false)
+	if string(off) != string(dispatchBytes) {
+		t.Fatalf("flag-off manifest changed after advance:\n--- dispatch ---\n%s\n--- after advance ---\n%s", dispatchBytes, off)
+	}
+	on := run(t, true)
+	if string(on) == string(off) {
+		t.Fatalf("flag-on manifest unexpectedly identical to flag-off; enrichment not wired")
+	}
+}
+
+// TestAdvanceDelegationsManifestIdempotentReAugment pins that re-running AdvanceJob
+// after the dependent is enqueued does not change context-manifest.json bytes
+// (stable sorted JSON, no double-write drift).
+func TestAdvanceDelegationsManifestIdempotentReAugment(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	engine.InjectUpstreamDepContext = true
+	engine.ArtifactRoot = t.TempDir()
+	seedManifestParent(t, store)
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob(parent) returned error: %v", err)
+	}
+	completeDelegationChild(t, store, "parent-job/delegation/research", JobSucceeded, AgentResult{
+		Decision: "approved", Summary: "RESEARCH_FINDINGS_SUMMARY", ArtifactBody: "RESEARCH_BODY",
+	})
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/research"); err != nil {
+		t.Fatalf("first AdvanceJob(research) returned error: %v", err)
+	}
+	manifestPath := filepath.Join(engine.ArtifactRoot, "delegations", "parent-job", "context-manifest.json")
+	first, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest #1: %v", err)
+	}
+
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/research"); err != nil {
+		t.Fatalf("second AdvanceJob(research) returned error: %v", err)
+	}
+	second, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest #2: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("re-augment changed manifest bytes:\n--- first ---\n%s\n--- second ---\n%s", first, second)
 	}
 }


### PR DESCRIPTION
## What

Completes "deps[] as dataflow" started in #419. #419 shipped the **prose** channel: when a deferred dependent leg enqueues, `advanceDelegations` injects its succeeded direct deps' results into the child's **prompt** (the "Upstream dependency results:" block), gated behind `Engine.InjectUpstreamDepContext`. The parallel **structured, pass-by-reference** channel in `context-manifest.json` was explicitly deferred — this PR adds it.

When `InjectUpstreamDepContext` is on, `advanceDelegations` now re-writes `context-manifest.json` each pass with additive, `omitempty` result-reference fields on the entries of **succeeded** delegations:

- `decision` — the child's gitmoot_result decision
- `summary_preview` — rune-safe, capped at the existing 280-byte `maxUpstreamDepSummaryPreviewBytes` with an ellipsis
- `changes_made` — int **count** (token-cheap, matches #419's `[changes_made: N]`)
- `pull_request` — rendered GitHub PR URL (via `childPullRequestLink`)
- `output_path` — the on-disk `brief.md` path (via `inlineBriefPath`) — the **only** handle to bulk content; bodies are never inlined into the manifest
- `derived_from` — the delegation's declared `Deps` lineage (a deliberate simplification: declared upstreams, not a transitive ancestry graph)

A fingerprint-deduped delegation is followed to its winning sibling via `dedupWinners`, mirroring the prose path's resolution.

## Design

- **Same flag, no new knob.** Reuses `Engine.InjectUpstreamDepContext`; the structured manifest is the additive sibling of the prose block and rides the identical gate.
- **Write-once-then-augment.** The base reduced manifest is still written at dispatch by `writeDelegationArtifacts` (unchanged). A new `augmentDelegationManifest` overwrites it from `advanceDelegations` once deps reach `JobSucceeded`. It is idempotent — deterministic, sorted JSON over the `parentResult.Delegations` order → no byte churn on repeated passes.
- **Succeeded-only + strictly additive/omitempty.** With the flag **off** the manifest is byte-identical to today (reduced `id/agent/action/worktree/deps`, no rewrite). Pending/failed/not-yet-run delegations keep the reduced shape.

## Files

- `internal/workflow/artifacts.go` — 6 omitempty fields on `delegationManifestEntry`; new `augmentDelegationManifest` + `buildEnrichedManifestEntry` + `manifestSummaryPreview`; `internal/db` import.
- `internal/workflow/engine.go` — `advanceDelegations` calls `augmentDelegationManifest` right after `delegationArtifactDir` resolves, gated on the flag, best-effort with a `delegation_manifest_augmented`/`_failed` event like the dispatch artifact write.
- `internal/workflow/artifacts_test.go` + `internal/workflow/upstream_dep_test.go` — unit + engine E2E tests (below). Updated the reduced-fields assertion to allow the new keys while still pinning no PROMPT/lifecycle leak.

## Test evidence

Full CI gate green locally:

- `go build ./...` — OK
- `go vet ./...` — OK
- `go test ./...` — all packages ok (incl. `internal/workflow`, `internal/cli`)
- `go test -race ./internal/workflow/` — ok (196s)
- `go test -race ./internal/cli/` — ok (486s)

New tests:
- UNIT `buildEnrichedManifestEntry`: succeeded dep → all fields populated; pending/failed/missing → bare reduced entry; dedup-follow to winner.
- UNIT `manifestSummaryPreview`: oversized multi-byte summary capped 280B, rune-safe (`utf8.ValidString`), ellipsis, full summary absent.
- UNIT `augmentDelegationManifest`: round-trip (enriched only on the succeeded entry; `output_path` == `inlineBriefPath`), no-op when root empty / no artifacts.
- ENGINE flag-on: after research succeeds, the research entry carries `decision`/`summary_preview`/`changes_made`/`output_path` (which points at a `brief.md` that exists on disk); the pending write entry stays reduced.
- ENGINE flag-off **byte-parity** (load-bearing): manifest bytes after the full advance == the dispatch-time reduced manifest; flag-on bytes differ.
- ENGINE **idempotent** re-augment: re-running `AdvanceJob` does not change manifest bytes.

Closes #438