### PR TITLE
feat(daemon): host-global memory-aware admission budget, off by default (#365)

### DIFF
--- a/internal/cli/admission_budget.go
+++ b/internal/cli/admission_budget.go
@@ -31,7 +31,27 @@ type admissionBudget struct {
 	maxMemoryGB   float64 // 0 = memory gate off
 	reservedCount int
 	reservedMemGB float64
-	reservations  map[string]float64 // jobID -> reserved GB (idempotency)
+	reservations  map[string]reservation // jobID -> what it holds (idempotency)
+}
+
+// reservation is what a single admitted job holds in the budget. session records
+// whether the job consumed a max_concurrent_sessions slot — only session jobs
+// (queuedJobRuntimeResourceKey != "") do; a non-session job (shell runtime, or an
+// agent with no resumable runtime session) is "treated as 0 RAM / not
+// session-counted" per the frozen goal, so Release decrements symmetrically only
+// what Reserve actually charged.
+type reservation struct {
+	session bool
+	memGB   float64
+}
+
+// admissionEstimate is the per-job admission cost, computed lazily by the
+// dispatch call site ONLY for an active (non-nil) budget. session is true iff the
+// job holds a resumable runtime session (so it counts against
+// max_concurrent_sessions); memGB is its RAM estimate (0 for a non-session job).
+type admissionEstimate struct {
+	session bool
+	memGB   float64
 }
 
 // newAdmissionBudget returns an *admissionBudget for the policy, or nil when both
@@ -44,18 +64,26 @@ func newAdmissionBudget(policy config.AdmissionPolicy) *admissionBudget {
 	return &admissionBudget{
 		maxSessions:  policy.MaxConcurrentSessions,
 		maxMemoryGB:  policy.MaxMemoryGB,
-		reservations: map[string]float64{},
+		reservations: map[string]reservation{},
 	}
 }
 
-// Reserve atomically admits the job, reserving one session slot and estGB of RAM,
-// and reports whether it was admitted. A nil budget (feature off) always admits
-// without accounting. A job ID already reserved (in flight) is admitted again as
-// a no-op so a re-dispatch is safe. Otherwise the job is admitted only if BOTH
-// the session-count cap and the memory cap (each, when set) would still hold; a
-// job that does not fit is NOT reserved and false is returned (the caller leaves
-// it queued).
-func (b *admissionBudget) Reserve(jobID string, estGB float64) bool {
+// Reserve atomically admits the job, reserving (if it is a session job) one
+// session slot plus its RAM estimate, and reports whether it was admitted. A nil
+// budget (feature off) always admits without accounting AND WITHOUT EVALUATING
+// est — keeping the default (no [admission] config) dispatch path byte-identical:
+// the estimate is a thunk so its config read + DB lookups are skipped entirely on
+// the off path (and for an already-in-flight job).
+//
+// est is computed at most once, only after the nil/idempotency checks, and only
+// when at least one gate is active. A non-session estimate (session=false) does
+// NOT consume a max_concurrent_sessions slot — it is "not session-counted" per
+// the frozen goal — and contributes 0 RAM. A job ID already reserved (in flight)
+// is admitted again as a no-op so a re-dispatch is safe. Otherwise the job is
+// admitted only if BOTH the session-count cap and the memory cap (each, when set)
+// would still hold; a job that does not fit is NOT reserved and false is returned
+// (the caller leaves it queued).
+func (b *admissionBudget) Reserve(jobID string, est func() admissionEstimate) bool {
 	if b == nil {
 		return true
 	}
@@ -64,15 +92,19 @@ func (b *admissionBudget) Reserve(jobID string, estGB float64) bool {
 	if _, ok := b.reservations[jobID]; ok {
 		return true
 	}
-	if b.maxSessions > 0 && b.reservedCount+1 > b.maxSessions {
+	e := est()
+	// A non-session job neither consumes a session slot nor checks the session cap.
+	if e.session && b.maxSessions > 0 && b.reservedCount+1 > b.maxSessions {
 		return false
 	}
-	if b.maxMemoryGB > 0 && b.reservedMemGB+estGB > b.maxMemoryGB {
+	if b.maxMemoryGB > 0 && b.reservedMemGB+e.memGB > b.maxMemoryGB {
 		return false
 	}
-	b.reservedCount++
-	b.reservedMemGB += estGB
-	b.reservations[jobID] = estGB
+	if e.session {
+		b.reservedCount++
+	}
+	b.reservedMemGB += e.memGB
+	b.reservations[jobID] = reservation{session: e.session, memGB: e.memGB}
 	return true
 }
 
@@ -87,12 +119,14 @@ func (b *admissionBudget) Release(jobID string) {
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	estGB, ok := b.reservations[jobID]
+	r, ok := b.reservations[jobID]
 	if !ok {
 		return
 	}
-	b.reservedCount--
-	b.reservedMemGB -= estGB
+	if r.session {
+		b.reservedCount--
+	}
+	b.reservedMemGB -= r.memGB
 	delete(b.reservations, jobID)
 }
 

--- a/internal/cli/admission_budget.go
+++ b/internal/cli/admission_budget.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"sync"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+)
+
+// admissionBudget is the process-global, memory-aware concurrency gate the daemon
+// consults at the single dispatch decision in each scheduler (issue #365). It is
+// a stricter SECOND gate layered on --workers/pool and the per-repo checkout /
+// runtime-session locks: a job is admitted only if it fits BOTH the session-count
+// cap AND the summed-RAM cap; otherwise it is left queued (deferred), to be
+// retried on a later dispatch pass/tick.
+//
+// A nil *admissionBudget means the feature is OFF — callers MUST treat a nil
+// receiver as "always admit, never accounts", so default (no [admission] config)
+// scheduling is byte-identical. Both Reserve and Release are no-ops on a nil
+// receiver.
+//
+// Concurrency: reserve must check-and-add under ONE lock so the count cap and the
+// memory cap are enforced atomically together (two independent atomics cannot).
+// A single Mutex around a tiny critical section is race-clean and negligible at
+// daemon tick cadence. Reservations are keyed by job ID so Release is idempotent
+// (a double release — e.g. pool reap plus a panic-recovery path — never
+// double-credits the budget) and a re-reserve of the same in-flight job ID is a
+// no-op success.
+type admissionBudget struct {
+	mu            sync.Mutex
+	maxSessions   int     // 0 = session-count gate off
+	maxMemoryGB   float64 // 0 = memory gate off
+	reservedCount int
+	reservedMemGB float64
+	reservations  map[string]float64 // jobID -> reserved GB (idempotency)
+}
+
+// newAdmissionBudget returns an *admissionBudget for the policy, or nil when both
+// caps are 0/unset (the feature is off ⇒ byte-identical default behavior). The
+// returned budget enforces only the caps that are set (>0); a 0 cap is ignored.
+func newAdmissionBudget(policy config.AdmissionPolicy) *admissionBudget {
+	if !policy.Enabled() {
+		return nil
+	}
+	return &admissionBudget{
+		maxSessions:  policy.MaxConcurrentSessions,
+		maxMemoryGB:  policy.MaxMemoryGB,
+		reservations: map[string]float64{},
+	}
+}
+
+// Reserve atomically admits the job, reserving one session slot and estGB of RAM,
+// and reports whether it was admitted. A nil budget (feature off) always admits
+// without accounting. A job ID already reserved (in flight) is admitted again as
+// a no-op so a re-dispatch is safe. Otherwise the job is admitted only if BOTH
+// the session-count cap and the memory cap (each, when set) would still hold; a
+// job that does not fit is NOT reserved and false is returned (the caller leaves
+// it queued).
+func (b *admissionBudget) Reserve(jobID string, estGB float64) bool {
+	if b == nil {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.reservations[jobID]; ok {
+		return true
+	}
+	if b.maxSessions > 0 && b.reservedCount+1 > b.maxSessions {
+		return false
+	}
+	if b.maxMemoryGB > 0 && b.reservedMemGB+estGB > b.maxMemoryGB {
+		return false
+	}
+	b.reservedCount++
+	b.reservedMemGB += estGB
+	b.reservations[jobID] = estGB
+	return true
+}
+
+// Release frees the session slot and RAM a prior Reserve held for jobID. It is
+// idempotent: releasing a job ID that is not currently reserved (already
+// released, or never admitted) is a no-op, so a double release from the pool reap
+// plus a panic/shutdown path can never shrink the budget below its true in-flight
+// usage. A nil budget is a no-op.
+func (b *admissionBudget) Release(jobID string) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	estGB, ok := b.reservations[jobID]
+	if !ok {
+		return
+	}
+	b.reservedCount--
+	b.reservedMemGB -= estGB
+	delete(b.reservations, jobID)
+}
+
+// snapshot returns the currently reserved session count and RAM (GB) plus the
+// configured caps, for daemon status observability. A nil budget reports all
+// zeros (feature off).
+func (b *admissionBudget) snapshot() (reservedCount int, reservedMemGB float64, maxSessions int, maxMemoryGB float64) {
+	if b == nil {
+		return 0, 0, 0, 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.reservedCount, b.reservedMemGB, b.maxSessions, b.maxMemoryGB
+}

--- a/internal/cli/admission_budget_test.go
+++ b/internal/cli/admission_budget_test.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+)
+
+func TestNewAdmissionBudgetNilWhenOff(t *testing.T) {
+	// Both caps 0 (the default) ⇒ nil budget ⇒ feature off / byte-identical.
+	if b := newAdmissionBudget(config.DefaultAdmissionPolicy()); b != nil {
+		t.Fatalf("default (all-off) policy must yield a nil budget, got %+v", b)
+	}
+	// A nil budget always admits and never accounts.
+	var b *admissionBudget
+	if !b.Reserve("job-1", 10) {
+		t.Fatalf("nil budget Reserve must always admit")
+	}
+	b.Release("job-1") // must not panic
+	if rc, rm, ms, mm := b.snapshot(); rc != 0 || rm != 0 || ms != 0 || mm != 0 {
+		t.Fatalf("nil budget snapshot = (%d, %v, %d, %v), want all zero", rc, rm, ms, mm)
+	}
+}
+
+func TestAdmissionBudgetSessionCap(t *testing.T) {
+	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 2})
+	if b == nil {
+		t.Fatal("policy with a session cap must yield a non-nil budget")
+	}
+	if !b.Reserve("a", 0) || !b.Reserve("b", 0) {
+		t.Fatalf("first %d reservations must be admitted", 2)
+	}
+	if b.Reserve("c", 0) {
+		t.Fatalf("reservation beyond the session cap must be deferred")
+	}
+}
+
+func TestAdmissionBudgetMemoryCap(t *testing.T) {
+	// Memory gate only (no session cap): admit until the summed estimate would
+	// exceed the cap, then defer.
+	b := newAdmissionBudget(config.AdmissionPolicy{MaxMemoryGB: 1.0})
+	if !b.Reserve("a", 0.6) {
+		t.Fatalf("0.6 of 1.0GB must be admitted")
+	}
+	if !b.Reserve("b", 0.4) {
+		t.Fatalf("0.6+0.4=1.0 exactly at cap must be admitted")
+	}
+	if b.Reserve("c", 0.01) {
+		t.Fatalf("any further GB above the cap must be deferred")
+	}
+}
+
+func TestAdmissionBudgetBothGates(t *testing.T) {
+	// Count would allow it (1 of 5) but memory would overflow ⇒ defer; a job must
+	// fit BOTH gates.
+	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 5, MaxMemoryGB: 1.0})
+	if b.Reserve("big", 2.0) {
+		t.Fatalf("a job within the count cap but over the memory cap must be deferred")
+	}
+	// Inverse: memory fits but the count cap is full ⇒ defer.
+	c := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 1, MaxMemoryGB: 100})
+	if !c.Reserve("a", 0.1) {
+		t.Fatalf("first job must be admitted")
+	}
+	if c.Reserve("b", 0.1) {
+		t.Fatalf("a job within the memory cap but over the count cap must be deferred")
+	}
+}
+
+func TestAdmissionBudgetReleaseFrees(t *testing.T) {
+	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 1, MaxMemoryGB: 1.0})
+	if !b.Reserve("a", 0.9) {
+		t.Fatalf("first job must be admitted")
+	}
+	if b.Reserve("b", 0.9) {
+		t.Fatalf("second job must be deferred while the first holds the budget")
+	}
+	b.Release("a")
+	if !b.Reserve("b", 0.9) {
+		t.Fatalf("releasing the first job must re-admit the second")
+	}
+}
+
+func TestAdmissionBudgetIdempotentRelease(t *testing.T) {
+	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 2, MaxMemoryGB: 1.0})
+	if !b.Reserve("a", 0.9) {
+		t.Fatalf("first job must be admitted")
+	}
+	// Double-release (e.g. pool reap + a panic/shutdown path) plus a release of a
+	// never-reserved id must not credit the budget twice — exactly one slot frees.
+	b.Release("a")
+	b.Release("a")
+	b.Release("never-reserved")
+	if rc, rm, _, _ := b.snapshot(); rc != 0 || rm != 0 {
+		t.Fatalf("after release(s) reserved = (%d, %v), want (0, 0)", rc, rm)
+	}
+	// The budget must not be permanently shrunk: both the count (2) and memory
+	// (1.0GB) headroom are fully available again.
+	if !b.Reserve("a", 0.9) || !b.Reserve("b", 0.05) {
+		t.Fatalf("budget must not be permanently shrunk by a double-release")
+	}
+}
+
+func TestAdmissionBudgetReReserveIsNoOp(t *testing.T) {
+	// Re-reserving an already-in-flight job ID is an idempotent admit (no
+	// double-counting), so a re-dispatch of the same job is safe.
+	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 1})
+	if !b.Reserve("a", 0) {
+		t.Fatalf("first reserve must admit")
+	}
+	if !b.Reserve("a", 0) {
+		t.Fatalf("re-reserving the same in-flight job ID must be a no-op admit")
+	}
+	if rc, _, _, _ := b.snapshot(); rc != 1 {
+		t.Fatalf("re-reserve must not double-count: reservedCount = %d, want 1", rc)
+	}
+}
+
+func TestAdmissionBudgetConcurrent(t *testing.T) {
+	const cap = 4
+	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: cap, MaxMemoryGB: float64(cap)})
+
+	var mu sync.Mutex
+	live := 0
+	maxLive := 0
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			id := fmt.Sprintf("job-%d", n)
+			for attempt := 0; attempt < 50; attempt++ {
+				if !b.Reserve(id, 1.0) {
+					continue // deferred — retry, never over-admit
+				}
+				mu.Lock()
+				live++
+				if live > maxLive {
+					maxLive = live
+				}
+				mu.Unlock()
+
+				mu.Lock()
+				live--
+				mu.Unlock()
+				b.Release(id)
+				return
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if maxLive > cap {
+		t.Fatalf("observed %d concurrent admissions, exceeds cap %d (over-admission)", maxLive, cap)
+	}
+	if rc, rm, _, _ := b.snapshot(); rc != 0 || rm != 0 {
+		t.Fatalf("after all releases reserved = (%d, %v), want (0, 0) — leaked reservation", rc, rm)
+	}
+}

--- a/internal/cli/admission_budget_test.go
+++ b/internal/cli/admission_budget_test.go
@@ -8,15 +8,32 @@ import (
 	"github.com/jerryfane/gitmoot/internal/config"
 )
 
+// sessionEst is a test thunk for an admitted session job holding gb of RAM (it
+// counts against max_concurrent_sessions).
+func sessionEst(gb float64) func() admissionEstimate {
+	return func() admissionEstimate { return admissionEstimate{session: true, memGB: gb} }
+}
+
+// nonSessionEst is a test thunk for a job with no resumable runtime session: it
+// contributes 0 RAM and must NOT consume a max_concurrent_sessions slot.
+func nonSessionEst() func() admissionEstimate {
+	return func() admissionEstimate { return admissionEstimate{session: false, memGB: 0} }
+}
+
 func TestNewAdmissionBudgetNilWhenOff(t *testing.T) {
 	// Both caps 0 (the default) ⇒ nil budget ⇒ feature off / byte-identical.
 	if b := newAdmissionBudget(config.DefaultAdmissionPolicy()); b != nil {
 		t.Fatalf("default (all-off) policy must yield a nil budget, got %+v", b)
 	}
-	// A nil budget always admits and never accounts.
+	// A nil budget always admits and never accounts — and must NOT evaluate the
+	// estimate thunk (the off path does zero config-read / DB-lookup work).
 	var b *admissionBudget
-	if !b.Reserve("job-1", 10) {
+	evaluated := false
+	if !b.Reserve("job-1", func() admissionEstimate { evaluated = true; return admissionEstimate{session: true, memGB: 10} }) {
 		t.Fatalf("nil budget Reserve must always admit")
+	}
+	if evaluated {
+		t.Fatalf("nil budget must not evaluate the estimate thunk (off path must be byte-identical)")
 	}
 	b.Release("job-1") // must not panic
 	if rc, rm, ms, mm := b.snapshot(); rc != 0 || rm != 0 || ms != 0 || mm != 0 {
@@ -29,10 +46,10 @@ func TestAdmissionBudgetSessionCap(t *testing.T) {
 	if b == nil {
 		t.Fatal("policy with a session cap must yield a non-nil budget")
 	}
-	if !b.Reserve("a", 0) || !b.Reserve("b", 0) {
+	if !b.Reserve("a", sessionEst(0)) || !b.Reserve("b", sessionEst(0)) {
 		t.Fatalf("first %d reservations must be admitted", 2)
 	}
-	if b.Reserve("c", 0) {
+	if b.Reserve("c", sessionEst(0)) {
 		t.Fatalf("reservation beyond the session cap must be deferred")
 	}
 }
@@ -41,13 +58,13 @@ func TestAdmissionBudgetMemoryCap(t *testing.T) {
 	// Memory gate only (no session cap): admit until the summed estimate would
 	// exceed the cap, then defer.
 	b := newAdmissionBudget(config.AdmissionPolicy{MaxMemoryGB: 1.0})
-	if !b.Reserve("a", 0.6) {
+	if !b.Reserve("a", sessionEst(0.6)) {
 		t.Fatalf("0.6 of 1.0GB must be admitted")
 	}
-	if !b.Reserve("b", 0.4) {
+	if !b.Reserve("b", sessionEst(0.4)) {
 		t.Fatalf("0.6+0.4=1.0 exactly at cap must be admitted")
 	}
-	if b.Reserve("c", 0.01) {
+	if b.Reserve("c", sessionEst(0.01)) {
 		t.Fatalf("any further GB above the cap must be deferred")
 	}
 }
@@ -56,36 +73,36 @@ func TestAdmissionBudgetBothGates(t *testing.T) {
 	// Count would allow it (1 of 5) but memory would overflow ⇒ defer; a job must
 	// fit BOTH gates.
 	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 5, MaxMemoryGB: 1.0})
-	if b.Reserve("big", 2.0) {
+	if b.Reserve("big", sessionEst(2.0)) {
 		t.Fatalf("a job within the count cap but over the memory cap must be deferred")
 	}
 	// Inverse: memory fits but the count cap is full ⇒ defer.
 	c := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 1, MaxMemoryGB: 100})
-	if !c.Reserve("a", 0.1) {
+	if !c.Reserve("a", sessionEst(0.1)) {
 		t.Fatalf("first job must be admitted")
 	}
-	if c.Reserve("b", 0.1) {
+	if c.Reserve("b", sessionEst(0.1)) {
 		t.Fatalf("a job within the memory cap but over the count cap must be deferred")
 	}
 }
 
 func TestAdmissionBudgetReleaseFrees(t *testing.T) {
 	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 1, MaxMemoryGB: 1.0})
-	if !b.Reserve("a", 0.9) {
+	if !b.Reserve("a", sessionEst(0.9)) {
 		t.Fatalf("first job must be admitted")
 	}
-	if b.Reserve("b", 0.9) {
+	if b.Reserve("b", sessionEst(0.9)) {
 		t.Fatalf("second job must be deferred while the first holds the budget")
 	}
 	b.Release("a")
-	if !b.Reserve("b", 0.9) {
+	if !b.Reserve("b", sessionEst(0.9)) {
 		t.Fatalf("releasing the first job must re-admit the second")
 	}
 }
 
 func TestAdmissionBudgetIdempotentRelease(t *testing.T) {
 	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 2, MaxMemoryGB: 1.0})
-	if !b.Reserve("a", 0.9) {
+	if !b.Reserve("a", sessionEst(0.9)) {
 		t.Fatalf("first job must be admitted")
 	}
 	// Double-release (e.g. pool reap + a panic/shutdown path) plus a release of a
@@ -98,7 +115,7 @@ func TestAdmissionBudgetIdempotentRelease(t *testing.T) {
 	}
 	// The budget must not be permanently shrunk: both the count (2) and memory
 	// (1.0GB) headroom are fully available again.
-	if !b.Reserve("a", 0.9) || !b.Reserve("b", 0.05) {
+	if !b.Reserve("a", sessionEst(0.9)) || !b.Reserve("b", sessionEst(0.05)) {
 		t.Fatalf("budget must not be permanently shrunk by a double-release")
 	}
 }
@@ -107,10 +124,15 @@ func TestAdmissionBudgetReReserveIsNoOp(t *testing.T) {
 	// Re-reserving an already-in-flight job ID is an idempotent admit (no
 	// double-counting), so a re-dispatch of the same job is safe.
 	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 1})
-	if !b.Reserve("a", 0) {
+	if !b.Reserve("a", sessionEst(0)) {
 		t.Fatalf("first reserve must admit")
 	}
-	if !b.Reserve("a", 0) {
+	// A re-reserve of an in-flight job ID must short-circuit BEFORE evaluating the
+	// estimate thunk (no redundant config-read / DB-lookup on re-dispatch).
+	if !b.Reserve("a", func() admissionEstimate {
+		t.Fatalf("re-reserve of an in-flight job must not evaluate the estimate thunk")
+		return admissionEstimate{}
+	}) {
 		t.Fatalf("re-reserving the same in-flight job ID must be a no-op admit")
 	}
 	if rc, _, _, _ := b.snapshot(); rc != 1 {
@@ -133,7 +155,7 @@ func TestAdmissionBudgetConcurrent(t *testing.T) {
 			defer wg.Done()
 			id := fmt.Sprintf("job-%d", n)
 			for attempt := 0; attempt < 50; attempt++ {
-				if !b.Reserve(id, 1.0) {
+				if !b.Reserve(id, sessionEst(1.0)) {
 					continue // deferred — retry, never over-admit
 				}
 				mu.Lock()
@@ -158,5 +180,74 @@ func TestAdmissionBudgetConcurrent(t *testing.T) {
 	}
 	if rc, rm, _, _ := b.snapshot(); rc != 0 || rm != 0 {
 		t.Fatalf("after all releases reserved = (%d, %v), want (0, 0) — leaked reservation", rc, rm)
+	}
+}
+
+func TestAdmissionBudgetNonSessionNotSessionCounted(t *testing.T) {
+	// Frozen goal: a job whose runtime has no resumable session key is "treated as
+	// 0 RAM / not session-counted". So with max_concurrent_sessions=1 a non-session
+	// job admitted first must NOT consume the only slot — a subsequent real session
+	// job still fits.
+	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 1})
+	if !b.Reserve("nonsession", nonSessionEst()) {
+		t.Fatalf("a non-session job must always be admitted")
+	}
+	if rc, _, _, _ := b.snapshot(); rc != 0 {
+		t.Fatalf("a non-session job must not consume a session slot: reservedCount = %d, want 0", rc)
+	}
+	if !b.Reserve("codex", sessionEst(0)) {
+		t.Fatalf("a session job must still be admitted alongside a non-session job under cap=1")
+	}
+	// And the session cap is still honored for actual session jobs.
+	if b.Reserve("codex2", sessionEst(0)) {
+		t.Fatalf("a second session job beyond the cap must be deferred")
+	}
+	// Many non-session jobs never exhaust the session cap.
+	for i := 0; i < 5; i++ {
+		if !b.Reserve(fmt.Sprintf("ns-%d", i), nonSessionEst()) {
+			t.Fatalf("non-session job %d must be admitted regardless of the session cap", i)
+		}
+	}
+	if rc, _, _, _ := b.snapshot(); rc != 1 {
+		t.Fatalf("only the one real session job counts: reservedCount = %d, want 1", rc)
+	}
+}
+
+func TestAdmissionBudgetNonSessionReleaseSymmetric(t *testing.T) {
+	// Releasing a non-session reservation must not underflow the session count
+	// (Reserve never incremented it, so Release must not decrement it).
+	b := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 2})
+	if !b.Reserve("ns", nonSessionEst()) || !b.Reserve("s", sessionEst(0)) {
+		t.Fatalf("both jobs must be admitted")
+	}
+	b.Release("ns")
+	if rc, _, _, _ := b.snapshot(); rc != 1 {
+		t.Fatalf("releasing a non-session job must not change the session count: reservedCount = %d, want 1", rc)
+	}
+	b.Release("s")
+	if rc, _, _, _ := b.snapshot(); rc != 0 {
+		t.Fatalf("after releasing the session job reservedCount = %d, want 0", rc)
+	}
+	// Cap headroom is intact: two fresh session jobs fit.
+	if !b.Reserve("a", sessionEst(0)) || !b.Reserve("b", sessionEst(0)) {
+		t.Fatalf("session-count headroom must be fully restored")
+	}
+}
+
+func TestAdmissionBudgetNonSessionStillMemoryAccounted(t *testing.T) {
+	// Defensive: the session flag and the RAM estimate are independent. A reservation
+	// reported as non-session but carrying RAM (not produced by the real estimator,
+	// but the budget must not assume session-ness gates memory) is still memory
+	// accounted and released symmetrically.
+	b := newAdmissionBudget(config.AdmissionPolicy{MaxMemoryGB: 1.0})
+	if !b.Reserve("x", func() admissionEstimate { return admissionEstimate{session: false, memGB: 0.6} }) {
+		t.Fatalf("memory-only gate must admit a 0.6GB reservation")
+	}
+	if _, rm, _, _ := b.snapshot(); rm != 0.6 {
+		t.Fatalf("reservedMemGB = %v, want 0.6", rm)
+	}
+	b.Release("x")
+	if _, rm, _, _ := b.snapshot(); rm != 0 {
+		t.Fatalf("after release reservedMemGB = %v, want 0", rm)
 	}
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1630,7 +1630,8 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 		// when a freed slot can admit them (avoids spinning on an unfittable job).
 		admitted := make([]db.Job, 0, len(queued))
 		for _, job := range queued {
-			if worker.Admission.Reserve(job.ID, worker.admissionEstimateGB(ctx, job)) {
+			job := job
+			if worker.Admission.Reserve(job.ID, func() admissionEstimate { return worker.admissionEstimate(ctx, job) }) {
 				admitted = append(admitted, job)
 				continue
 			}
@@ -1783,7 +1784,7 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 					// A job that does not fit the budget is skipped (left queued) and the
 					// pool re-queries on the next pass once a reap frees a slot — never
 					// failed/dropped. A nil budget always admits ⇒ byte-identical default.
-					if !worker.Admission.Reserve(job.ID, worker.admissionEstimateGB(ctx, job)) {
+					if !worker.Admission.Reserve(job.ID, func() admissionEstimate { return worker.admissionEstimate(ctx, job) }) {
 						continue
 					}
 					checkoutKey := queuedJobCheckoutKey(ctx, worker.Store, job)
@@ -1820,7 +1821,7 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 					}
 					// Host-global admission gate (#365): reserve before creating the
 					// isolation worktree so a deferred job leaves no orphan worktree behind.
-					if !worker.Admission.Reserve(job.ID, worker.admissionEstimateGB(ctx, job)) {
+					if !worker.Admission.Reserve(job.ID, func() admissionEstimate { return worker.admissionEstimate(ctx, job) }) {
 						continue
 					}
 					iso, ok := worker.allocatePoolIsolationWorktree(ctx, job, payload)
@@ -2441,45 +2442,51 @@ func (w jobWorker) loadAdmissionBudget() *admissionBudget {
 	return newAdmissionBudget(policy)
 }
 
-// perJobMemoryEstimateGB maps a queued job's runtime to its configured RAM
-// estimate (GB) for the memory admission gate (#365). A job whose runtime has no
-// resumable session key — exactly the runtimes already exempt from the runtime
-// session lock (queuedJobRuntimeResourceKey returns "") — contributes 0 and is
-// not memory-accounted. Otherwise it returns the per-runtime prior, falling back
-// to default_memory_gb for a session runtime not explicitly mapped.
-func perJobMemoryEstimateGB(ctx context.Context, store *db.Store, job db.Job, policy config.AdmissionPolicy) float64 {
+// perJobAdmissionEstimate maps a queued job's runtime to its admission cost
+// (#365): whether it holds a resumable runtime session (so it counts against
+// max_concurrent_sessions) and its configured RAM estimate (GB). A job whose
+// runtime has no resumable session key — exactly the runtimes already exempt from
+// the runtime session lock (queuedJobRuntimeResourceKey returns "") — is "not
+// session-counted" and contributes 0 RAM, per the frozen goal. Otherwise the job
+// is session-counted and its RAM is the per-runtime prior, falling back to
+// default_memory_gb for a session runtime not explicitly mapped.
+func perJobAdmissionEstimate(ctx context.Context, store *db.Store, job db.Job, policy config.AdmissionPolicy) admissionEstimate {
 	if queuedJobRuntimeResourceKey(ctx, store, job) == "" {
-		return 0
+		return admissionEstimate{session: false, memGB: 0}
 	}
 	if store == nil {
-		return policy.DefaultMemoryGB
+		return admissionEstimate{session: true, memGB: policy.DefaultMemoryGB}
 	}
 	agent, err := store.GetAgent(ctx, job.Agent)
 	if err != nil {
-		return policy.DefaultMemoryGB
+		return admissionEstimate{session: true, memGB: policy.DefaultMemoryGB}
 	}
 	switch strings.TrimSpace(runtimeAgent(agent).Runtime) {
 	case runtime.CodexRuntime:
-		return policy.CodexMemoryGB
+		return admissionEstimate{session: true, memGB: policy.CodexMemoryGB}
 	case runtime.ClaudeRuntime:
-		return policy.ClaudeMemoryGB
+		return admissionEstimate{session: true, memGB: policy.ClaudeMemoryGB}
 	case runtime.KimiRuntime:
-		return policy.KimiMemoryGB
+		return admissionEstimate{session: true, memGB: policy.KimiMemoryGB}
 	default:
-		return policy.DefaultMemoryGB
+		return admissionEstimate{session: true, memGB: policy.DefaultMemoryGB}
 	}
 }
 
-// admissionEstimateGB resolves the per-job memory estimate for THIS worker's
-// configured admission policy. It is a thin convenience used at the dispatch
-// reserve points; a load error degrades to the default estimate so a transient
-// config read never silently disables the memory gate.
-func (w jobWorker) admissionEstimateGB(ctx context.Context, job db.Job) float64 {
+// admissionEstimate resolves the per-job admission cost (session-ness + RAM) for
+// THIS worker's configured admission policy. It is the thunk handed to
+// admissionBudget.Reserve at the dispatch reserve points: Reserve invokes it ONLY
+// when the budget is active (non-nil) and the job is not already in flight, so on
+// the default (no [admission] config) off path it is never called and the
+// dispatch loop does ZERO extra config-file I/O or DB lookups — keeping that path
+// byte-identical. A load error degrades to the default policy so a transient
+// config read never silently disables a gate.
+func (w jobWorker) admissionEstimate(ctx context.Context, job db.Job) admissionEstimate {
 	policy, err := w.admissionPolicy()
 	if err != nil {
 		policy = config.DefaultAdmissionPolicy()
 	}
-	return perJobMemoryEstimateGB(ctx, w.Store, job, policy)
+	return perJobAdmissionEstimate(ctx, w.Store, job, policy)
 }
 
 // orchestratePolicy loads the host-level [orchestrate] cockpit policy, mirroring

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -377,7 +377,30 @@ func runDaemonStatus(args []string, stdout, stderr io.Writer) int {
 	if pid > 0 {
 		writeLine(stdout, "%s", daemonClaudeAuthLine(paths))
 	}
+	writeLine(stdout, "%s", daemonAdmissionLine(paths))
 	return 0
+}
+
+// daemonAdmissionLine reports the configured host-global admission budget caps
+// (#365) for `gitmoot daemon status`. It is intentionally a single additive line
+// (no edits to existing lines) so it composes with #444's status edits. When the
+// budget is off (both caps 0/unset, the default) it says so; the in-flight
+// reservation gauge lives in the daemon process, not the status CLI, so only the
+// configured caps are surfaced here.
+func daemonAdmissionLine(paths config.Paths) string {
+	policy, err := config.LoadAdmissionPolicy(paths)
+	if err != nil || !policy.Enabled() {
+		return "admission budget: off"
+	}
+	sessions := "off"
+	if policy.MaxConcurrentSessions > 0 {
+		sessions = fmt.Sprintf("%d", policy.MaxConcurrentSessions)
+	}
+	memory := "off"
+	if policy.MaxMemoryGB > 0 {
+		memory = fmt.Sprintf("%gGB", policy.MaxMemoryGB)
+	}
+	return fmt.Sprintf("admission budget: max_concurrent_sessions=%s max_memory_gb=%s", sessions, memory)
 }
 
 // daemonClaudeAuthLine reports the running daemon's Claude background-auth state
@@ -913,6 +936,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 		worker := defaultJobWorker(store, stdout, home)
 		worker.CommenterFactory = worker.defaultCommenter
 		worker.UsePool = usePool
+		worker.Admission = worker.loadAdmissionBudget()
 		checkoutLocks := &repoCheckoutLocks{}
 		poller.CheckoutLocks = checkoutLocks
 		var workerErr <-chan error
@@ -974,6 +998,7 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 	worker := defaultJobWorker(store, stdout, home)
 	worker.CommenterFactory = worker.defaultCommenter
 	worker.UsePool = usePool
+	worker.Admission = worker.loadAdmissionBudget()
 	var checkoutLock sync.Mutex
 	workerErr := startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
 		checkoutLock.Lock()
@@ -1328,6 +1353,13 @@ type jobWorker struct {
 	// UsePool selects the opt-in continuous worker-pool scheduler (#394,
 	// --scheduler=pool) over the default per-tick wg.Wait() barrier.
 	UsePool bool
+	// Admission is the opt-in, host-global memory-aware concurrency budget (#365)
+	// the scheduler consults before dispatching each session job. nil means the
+	// feature is OFF (no [admission] config) ⇒ scheduling is byte-identical to a
+	// build without admission accounting. The supervisors attach it at startup;
+	// it is a shared pointer across all per-repo dispatch passes so the cap is
+	// process-global (host-global for the normal single-daemon deployment).
+	Admission *admissionBudget
 }
 
 const daemonRunningJobStaleAfter = 30 * time.Minute
@@ -1588,13 +1620,34 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 		}
 		pending = remaining
 
-		errs := make(chan error, len(queued))
-		var wg sync.WaitGroup
+		// Host-global admission gate (#365): reserve a session slot + RAM estimate
+		// for each selected job BEFORE dispatching it. A job that does not fit the
+		// budget is left queued — defer it back to `pending` so it is retried on the
+		// next loop iteration once this batch's reservations are released in the
+		// goroutine defers (worker.Admission is nil ⇒ Reserve always admits, so the
+		// default path is byte-identical). If nothing was admitted this pass we
+		// return: the deferred jobs stay queued in the DB for the next daemon tick,
+		// when a freed slot can admit them (avoids spinning on an unfittable job).
+		admitted := make([]db.Job, 0, len(queued))
 		for _, job := range queued {
+			if worker.Admission.Reserve(job.ID, worker.admissionEstimateGB(ctx, job)) {
+				admitted = append(admitted, job)
+				continue
+			}
+			pending = append([]db.Job{job}, pending...)
+		}
+		if len(admitted) == 0 {
+			return nil
+		}
+
+		errs := make(chan error, len(admitted))
+		var wg sync.WaitGroup
+		for _, job := range admitted {
 			job := job
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
+				defer worker.Admission.Release(job.ID)
 				errs <- worker.run(ctx, job)
 			}()
 		}
@@ -1661,6 +1714,7 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 	}
 
 	type finished struct {
+		jobID        string
 		checkoutKey  string
 		runtimeKey   string
 		worktreePath string
@@ -1678,6 +1732,11 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 		if f.runtimeKey != "" {
 			delete(inflightRuntimes, f.runtimeKey)
 		}
+		// Release the host-global admission reservation (#365) keyed by job ID,
+		// alongside the checkout/runtime release. Release is idempotent and a nil
+		// budget is a no-op, so this is safe on every reap path incl. panic
+		// recovery and shutdown (mirrors the worktree cleanup discipline).
+		worker.Admission.Release(f.jobID)
 		running--
 		// Dispose an auto-created isolation worktree (#394 part 2). Best-effort and
 		// on a non-cancellable context so it still runs during daemon shutdown; both
@@ -1719,6 +1778,14 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 				queued, remaining := selectRunnableQueuedJobsSeeded(ctx, worker.Store, pending, slots, policy, inflightCheckouts, inflightRuntimes)
 				for _, job := range queued {
 					job := job
+					// Host-global admission gate (#365): reserve a session slot + RAM
+					// estimate before claiming any checkout/runtime key or a worker slot.
+					// A job that does not fit the budget is skipped (left queued) and the
+					// pool re-queries on the next pass once a reap frees a slot — never
+					// failed/dropped. A nil budget always admits ⇒ byte-identical default.
+					if !worker.Admission.Reserve(job.ID, worker.admissionEstimateGB(ctx, job)) {
+						continue
+					}
 					checkoutKey := queuedJobCheckoutKey(ctx, worker.Store, job)
 					runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
 					inflightCheckouts[checkoutKey] = true
@@ -1728,7 +1795,7 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 					running++
 					dispatched++
 					go func() {
-						done <- finished{checkoutKey: checkoutKey, runtimeKey: runtimeKey, err: runPoolJobRecovered(ctx, worker, job)}
+						done <- finished{jobID: job.ID, checkoutKey: checkoutKey, runtimeKey: runtimeKey, err: runPoolJobRecovered(ctx, worker, job)}
 					}()
 				}
 				// #394 part 2: a read-only job left blocked ONLY by a contended same-repo
@@ -1751,8 +1818,14 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 					if runtimeKey != "" && (inflightRuntimes[runtimeKey] || runtimeResourceLocked(ctx, worker.Store, runtimeKey)) {
 						continue // also runtime-contended; leave it to the runtime/temp-worker path
 					}
+					// Host-global admission gate (#365): reserve before creating the
+					// isolation worktree so a deferred job leaves no orphan worktree behind.
+					if !worker.Admission.Reserve(job.ID, worker.admissionEstimateGB(ctx, job)) {
+						continue
+					}
 					iso, ok := worker.allocatePoolIsolationWorktree(ctx, job, payload)
 					if !ok {
+						worker.Admission.Release(job.ID)
 						continue
 					}
 					inflightCheckouts[iso.checkoutKey] = true
@@ -1762,7 +1835,7 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 					running++
 					dispatched++
 					go func() {
-						done <- finished{checkoutKey: iso.checkoutKey, runtimeKey: iso.runtimeKey, worktreePath: iso.worktreePath, repoCheckout: iso.repoCheckout, err: runPoolJobRecovered(ctx, worker, iso.job)}
+						done <- finished{jobID: iso.job.ID, checkoutKey: iso.checkoutKey, runtimeKey: iso.runtimeKey, worktreePath: iso.worktreePath, repoCheckout: iso.repoCheckout, err: runPoolJobRecovered(ctx, worker, iso.job)}
 					}()
 				}
 			}
@@ -2339,6 +2412,74 @@ func (w jobWorker) parallelSessionPolicy() (config.ParallelSessionPolicy, error)
 		return config.ParallelSessionPolicy{}, err
 	}
 	return config.LoadParallelSessionPolicy(paths)
+}
+
+// admissionPolicy loads the host-level [admission] budget config, mirroring
+// parallelSessionPolicy: an implicit/empty config home uses the defaults
+// (both caps 0 ⇒ off), and an explicit home loads from the config file.
+func (w jobWorker) admissionPolicy() (config.AdmissionPolicy, error) {
+	if !w.ConfigHomeExplicit && strings.TrimSpace(w.ConfigHome) == "" {
+		return config.DefaultAdmissionPolicy(), nil
+	}
+	paths, err := initializedPaths(w.ConfigHome)
+	if err != nil {
+		return config.AdmissionPolicy{}, err
+	}
+	return config.LoadAdmissionPolicy(paths)
+}
+
+// loadAdmissionBudget builds the opt-in *admissionBudget from the [admission]
+// config, returning nil when the feature is off (both caps 0/unset) or the
+// config cannot be loaded — nil keeps scheduling byte-identical to today. The
+// supervisors call this once at startup and share the returned pointer across all
+// per-repo dispatch passes so the cap is process-global.
+func (w jobWorker) loadAdmissionBudget() *admissionBudget {
+	policy, err := w.admissionPolicy()
+	if err != nil {
+		return nil
+	}
+	return newAdmissionBudget(policy)
+}
+
+// perJobMemoryEstimateGB maps a queued job's runtime to its configured RAM
+// estimate (GB) for the memory admission gate (#365). A job whose runtime has no
+// resumable session key — exactly the runtimes already exempt from the runtime
+// session lock (queuedJobRuntimeResourceKey returns "") — contributes 0 and is
+// not memory-accounted. Otherwise it returns the per-runtime prior, falling back
+// to default_memory_gb for a session runtime not explicitly mapped.
+func perJobMemoryEstimateGB(ctx context.Context, store *db.Store, job db.Job, policy config.AdmissionPolicy) float64 {
+	if queuedJobRuntimeResourceKey(ctx, store, job) == "" {
+		return 0
+	}
+	if store == nil {
+		return policy.DefaultMemoryGB
+	}
+	agent, err := store.GetAgent(ctx, job.Agent)
+	if err != nil {
+		return policy.DefaultMemoryGB
+	}
+	switch strings.TrimSpace(runtimeAgent(agent).Runtime) {
+	case runtime.CodexRuntime:
+		return policy.CodexMemoryGB
+	case runtime.ClaudeRuntime:
+		return policy.ClaudeMemoryGB
+	case runtime.KimiRuntime:
+		return policy.KimiMemoryGB
+	default:
+		return policy.DefaultMemoryGB
+	}
+}
+
+// admissionEstimateGB resolves the per-job memory estimate for THIS worker's
+// configured admission policy. It is a thin convenience used at the dispatch
+// reserve points; a load error degrades to the default estimate so a transient
+// config read never silently disables the memory gate.
+func (w jobWorker) admissionEstimateGB(ctx context.Context, job db.Job) float64 {
+	policy, err := w.admissionPolicy()
+	if err != nil {
+		policy = config.DefaultAdmissionPolicy()
+	}
+	return perJobMemoryEstimateGB(ctx, w.Store, job, policy)
 }
 
 // orchestratePolicy loads the host-level [orchestrate] cockpit policy, mirroring

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4301,37 +4301,43 @@ claude_memory_gb = 0.85
 	}
 }
 
-// TestPerJobMemoryEstimateGB maps each session runtime to its configured RAM
-// estimate and a non-session runtime (shell) to 0.
-func TestPerJobMemoryEstimateGB(t *testing.T) {
+// TestPerJobAdmissionEstimate maps each session runtime to its configured RAM
+// estimate (and marks it session-counted), and a non-session runtime (shell, or a
+// session runtime with no ref) to 0 RAM AND not session-counted.
+func TestPerJobAdmissionEstimate(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
 	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
 	seedDaemonWorkerAgent(t, store, "codex-agent", runtime.CodexRuntime, "ref-1", []string{"ask"}, "owner/repo")
 	seedDaemonWorkerAgent(t, store, "claude-agent", runtime.ClaudeRuntime, "ref-2", []string{"ask"}, "owner/repo")
 	seedDaemonWorkerAgent(t, store, "kimi-agent", runtime.KimiRuntime, "ref-3", []string{"ask"}, "owner/repo")
-	// A shell agent has no resumable runtime session key ⇒ contributes 0 (matches
-	// its exemption from the runtime session lock).
+	// A shell agent has no resumable runtime session key ⇒ contributes 0 and is not
+	// session-counted (matches its exemption from the runtime session lock).
 	seedDaemonWorkerAgent(t, store, "shell-agent", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
-	// A codex agent with an empty runtime ref also has no session key ⇒ 0.
+	// A codex agent with an empty runtime ref also has no session key ⇒ 0 / not counted.
 	seedDaemonWorkerAgent(t, store, "codex-no-ref", runtime.CodexRuntime, "", []string{"ask"}, "owner/repo")
 
 	policy := config.AdmissionPolicy{CodexMemoryGB: 0.2, ClaudeMemoryGB: 0.85, KimiMemoryGB: 0.5, DefaultMemoryGB: 0.7}
 	cases := []struct {
-		agent string
-		want  float64
+		agent       string
+		wantMemGB   float64
+		wantSession bool
 	}{
-		{"codex-agent", 0.2},
-		{"claude-agent", 0.85},
-		{"kimi-agent", 0.5},
-		{"shell-agent", 0},
-		{"codex-no-ref", 0},
+		{"codex-agent", 0.2, true},
+		{"claude-agent", 0.85, true},
+		{"kimi-agent", 0.5, true},
+		{"shell-agent", 0, false},
+		{"codex-no-ref", 0, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.agent, func(t *testing.T) {
 			job := db.Job{ID: "job-" + tc.agent, Agent: tc.agent}
-			if got := perJobMemoryEstimateGB(ctx, store, job, policy); got != tc.want {
-				t.Fatalf("perJobMemoryEstimateGB(%s) = %v, want %v", tc.agent, got, tc.want)
+			got := perJobAdmissionEstimate(ctx, store, job, policy)
+			if got.memGB != tc.wantMemGB {
+				t.Fatalf("perJobAdmissionEstimate(%s).memGB = %v, want %v", tc.agent, got.memGB, tc.wantMemGB)
+			}
+			if got.session != tc.wantSession {
+				t.Fatalf("perJobAdmissionEstimate(%s).session = %v, want %v", tc.agent, got.session, tc.wantSession)
 			}
 		})
 	}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4179,6 +4179,164 @@ func TestRunQueuedJobsPoolRecoversWorkerPanicAndCleansWorktree(t *testing.T) {
 	}
 }
 
+// runAdmissionConcurrencyScenario enqueues two jobs that would otherwise run in
+// parallel (distinct repos ⇒ distinct checkout keys; distinct codex sessions ⇒
+// distinct runtime keys, so neither the checkout nor the runtime lock serializes
+// them) and runs them under the barrier or pool scheduler with the given
+// admission budget attached. It returns the observed peak concurrent deliveries.
+func runAdmissionConcurrencyScenario(t *testing.T, usePool bool, budget *admissionBudget) int {
+	t.Helper()
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit-a", runtime.CodexRuntime, "session-a", []string{"ask"}, "owner/repo-a")
+	seedDaemonWorkerAgent(t, store, "audit-b", runtime.CodexRuntime, "session-b", []string{"ask"}, "owner/repo-b")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit-a", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit-b", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2})
+
+	tracker := &poolConcurrencyTracker{}
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
+	adapter.onDeliver = tracker.span
+	worker := poolSchedulerWorker(t, store, adapter, usePool)
+	worker.Admission = budget
+
+	if err := runQueuedJobsForRepo(ctx, worker, 2, "", ""); err != nil {
+		t.Fatalf("runQueuedJobsForRepo(usePool=%v): %v", usePool, err)
+	}
+	for _, id := range []string{"job-a", "job-b"} {
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob %s: %v", id, err)
+		}
+		if job.State != string(workflow.JobSucceeded) {
+			t.Fatalf("%s state = %q, want succeeded (a deferred job must still run, never drop)", id, job.State)
+		}
+	}
+	return tracker.peak()
+}
+
+// TestRunQueuedJobsBarrierAdmissionDefers proves the host-global session cap (#365)
+// serializes two otherwise-parallel jobs under the barrier scheduler, and that a
+// nil Admission (the default) preserves byte-identical parallel behavior.
+func TestRunQueuedJobsBarrierAdmissionDefers(t *testing.T) {
+	if peak := runAdmissionConcurrencyScenario(t, false, nil); peak != 2 {
+		t.Fatalf("nil-Admission barrier peak = %d, want 2 (default parallelism must be unchanged)", peak)
+	}
+	budget := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 1})
+	if peak := runAdmissionConcurrencyScenario(t, false, budget); peak != 1 {
+		t.Fatalf("max_concurrent_sessions=1 barrier peak = %d, want 1 (cap must override --workers)", peak)
+	}
+}
+
+// TestRunQueuedJobsPoolAdmissionDefers proves the same host-global cap serializes
+// two otherwise-parallel jobs under the pool scheduler, and the nil default keeps
+// the pool's parallel dispatch byte-identical.
+func TestRunQueuedJobsPoolAdmissionDefers(t *testing.T) {
+	if peak := runAdmissionConcurrencyScenario(t, true, nil); peak != 2 {
+		t.Fatalf("nil-Admission pool peak = %d, want 2 (default parallelism must be unchanged)", peak)
+	}
+	budget := newAdmissionBudget(config.AdmissionPolicy{MaxConcurrentSessions: 1})
+	if peak := runAdmissionConcurrencyScenario(t, true, budget); peak != 1 {
+		t.Fatalf("max_concurrent_sessions=1 pool peak = %d, want 1 (cap must override pool width)", peak)
+	}
+}
+
+// TestRunQueuedJobsAdmissionMemoryCapDefers proves the memory gate serializes two
+// jobs whose summed per-runtime RAM estimate exceeds the cap. Two codex sessions
+// (0.2GB prior each) fit a 0.5GB cap together but two claude sessions (0.85GB
+// each) do not, so the claude pair serializes.
+func TestRunQueuedJobsAdmissionMemoryCapDefers(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+`
+[admission]
+max_memory_gb = 1.0
+codex_memory_gb = 0.2
+claude_memory_gb = 0.85
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+	seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "claude-a", runtime.ClaudeRuntime, "session-a", []string{"ask"}, "owner/repo-a")
+	seedDaemonWorkerAgent(t, store, "claude-b", runtime.ClaudeRuntime, "session-b", []string{"ask"}, "owner/repo-b")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "claude-a", Action: "ask", Repo: "owner/repo-a", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "claude-b", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2})
+
+	tracker := &poolConcurrencyTracker{}
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
+	adapter.onDeliver = tracker.span
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.Admission = worker.loadAdmissionBudget()
+	if worker.Admission == nil {
+		t.Fatal("a [admission] config with max_memory_gb set must yield a non-nil budget")
+	}
+
+	if err := runQueuedJobsForRepo(ctx, worker, 2, "", ""); err != nil {
+		t.Fatalf("runQueuedJobsForRepo: %v", err)
+	}
+	if peak := tracker.peak(); peak != 1 {
+		t.Fatalf("two 0.85GB claude jobs under a 1.0GB cap peak = %d, want 1 (summed estimate must defer)", peak)
+	}
+	for _, id := range []string{"job-a", "job-b"} {
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob %s: %v", id, err)
+		}
+		if job.State != string(workflow.JobSucceeded) {
+			t.Fatalf("%s state = %q, want succeeded", id, job.State)
+		}
+	}
+}
+
+// TestPerJobMemoryEstimateGB maps each session runtime to its configured RAM
+// estimate and a non-session runtime (shell) to 0.
+func TestPerJobMemoryEstimateGB(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "codex-agent", runtime.CodexRuntime, "ref-1", []string{"ask"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "claude-agent", runtime.ClaudeRuntime, "ref-2", []string{"ask"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "kimi-agent", runtime.KimiRuntime, "ref-3", []string{"ask"}, "owner/repo")
+	// A shell agent has no resumable runtime session key ⇒ contributes 0 (matches
+	// its exemption from the runtime session lock).
+	seedDaemonWorkerAgent(t, store, "shell-agent", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	// A codex agent with an empty runtime ref also has no session key ⇒ 0.
+	seedDaemonWorkerAgent(t, store, "codex-no-ref", runtime.CodexRuntime, "", []string{"ask"}, "owner/repo")
+
+	policy := config.AdmissionPolicy{CodexMemoryGB: 0.2, ClaudeMemoryGB: 0.85, KimiMemoryGB: 0.5, DefaultMemoryGB: 0.7}
+	cases := []struct {
+		agent string
+		want  float64
+	}{
+		{"codex-agent", 0.2},
+		{"claude-agent", 0.85},
+		{"kimi-agent", 0.5},
+		{"shell-agent", 0},
+		{"codex-no-ref", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.agent, func(t *testing.T) {
+			job := db.Job{ID: "job-" + tc.agent, Agent: tc.agent}
+			if got := perJobMemoryEstimateGB(ctx, store, job, policy); got != tc.want {
+				t.Fatalf("perJobMemoryEstimateGB(%s) = %v, want %v", tc.agent, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRunQueuedJobsForRepoSkipsOtherSessions(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)

--- a/internal/config/admission.go
+++ b/internal/config/admission.go
@@ -1,0 +1,145 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// AdmissionPolicy is the host-level, opt-in concurrency admission budget read
+// from the [admission] section of the gitmoot config (issue #365). It is a
+// process-global, memory-aware second gate the daemon applies BEFORE dispatching
+// each session job, on top of --workers/pool and the per-repo checkout /
+// runtime-session locks. With both caps 0 (the default) it is OFF and daemon
+// scheduling is byte-identical to today.
+//
+// Scope: the budget is enforced per daemon process. The registered-repo
+// supervisor runs ONE worker across all enabled repos, so a process-global
+// counter is host-global for the normal single-daemon deployment. Multiple
+// `daemon start --repo` processes each get their own in-memory budget — a
+// documented limitation; a DB-backed cross-process gauge is a follow-up.
+type AdmissionPolicy struct {
+	// MaxConcurrentSessions caps the total number of in-flight session jobs
+	// admitted across all repos in the daemon process. 0 (the default) means
+	// off — the session-count gate is not applied.
+	MaxConcurrentSessions int
+	// MaxMemoryGB caps the sum of the per-runtime RAM estimates of all in-flight
+	// session jobs. 0 (the default) means off — the memory gate is not applied.
+	MaxMemoryGB float64
+	// CodexMemoryGB / ClaudeMemoryGB / KimiMemoryGB are the per-runtime steady-state
+	// RAM priors (in GB) used by the memory gate, keyed by runtime name. The defaults
+	// reflect gitmoot's measured per-session spread (codex ~0.1-0.2, claude ~0.3-0.85,
+	// kimi in-between). They are operator-tunable.
+	CodexMemoryGB  float64
+	ClaudeMemoryGB float64
+	KimiMemoryGB   float64
+	// DefaultMemoryGB is the fallback RAM estimate (in GB) for a session runtime not
+	// otherwise mapped. A job whose runtime has no resumable session (the runtime
+	// session lock is also skipped for it) contributes 0 and is not session-counted.
+	DefaultMemoryGB float64
+}
+
+// DefaultAdmissionPolicy returns the off-by-default policy: both caps 0
+// (disabled) with the documented per-runtime RAM priors as defaults.
+func DefaultAdmissionPolicy() AdmissionPolicy {
+	return AdmissionPolicy{
+		MaxConcurrentSessions: 0,
+		MaxMemoryGB:           0,
+		CodexMemoryGB:         0.2,
+		ClaudeMemoryGB:        0.85,
+		KimiMemoryGB:          0.5,
+		DefaultMemoryGB:       0.5,
+	}
+}
+
+// Enabled reports whether either admission gate is active. When false the daemon
+// skips admission accounting entirely (byte-identical default behavior).
+func (p AdmissionPolicy) Enabled() bool {
+	return p.MaxConcurrentSessions > 0 || p.MaxMemoryGB > 0
+}
+
+func LoadAdmissionPolicy(paths Paths) (AdmissionPolicy, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return AdmissionPolicy{}, err
+	}
+	policy := DefaultAdmissionPolicy()
+	current := false
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			current = strings.TrimSpace(section) == "admission"
+			continue
+		}
+		if !current {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if err := applyAdmissionPolicyField(&policy, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
+			return AdmissionPolicy{}, fmt.Errorf("parse [admission].%s: %w", strings.TrimSpace(key), err)
+		}
+	}
+	if err := validateAdmissionPolicy(policy); err != nil {
+		return AdmissionPolicy{}, err
+	}
+	return policy, nil
+}
+
+func applyAdmissionPolicyField(policy *AdmissionPolicy, key string, value string) error {
+	switch key {
+	case "max_concurrent_sessions":
+		parsed, err := strconv.Atoi(value)
+		policy.MaxConcurrentSessions = parsed
+		return err
+	case "max_memory_gb":
+		parsed, err := strconv.ParseFloat(value, 64)
+		policy.MaxMemoryGB = parsed
+		return err
+	case "codex_memory_gb":
+		parsed, err := strconv.ParseFloat(value, 64)
+		policy.CodexMemoryGB = parsed
+		return err
+	case "claude_memory_gb":
+		parsed, err := strconv.ParseFloat(value, 64)
+		policy.ClaudeMemoryGB = parsed
+		return err
+	case "kimi_memory_gb":
+		parsed, err := strconv.ParseFloat(value, 64)
+		policy.KimiMemoryGB = parsed
+		return err
+	case "default_memory_gb":
+		parsed, err := strconv.ParseFloat(value, 64)
+		policy.DefaultMemoryGB = parsed
+		return err
+	default:
+		return nil
+	}
+}
+
+func validateAdmissionPolicy(policy AdmissionPolicy) error {
+	if policy.MaxConcurrentSessions < 0 {
+		return fmt.Errorf("admission.max_concurrent_sessions must be 0 (off) or positive")
+	}
+	if policy.MaxMemoryGB < 0 {
+		return fmt.Errorf("admission.max_memory_gb must be 0 (off) or positive")
+	}
+	for name, value := range map[string]float64{
+		"codex_memory_gb":   policy.CodexMemoryGB,
+		"claude_memory_gb":  policy.ClaudeMemoryGB,
+		"kimi_memory_gb":    policy.KimiMemoryGB,
+		"default_memory_gb": policy.DefaultMemoryGB,
+	} {
+		if value < 0 {
+			return fmt.Errorf("admission.%s must be 0 or positive", name)
+		}
+	}
+	return nil
+}

--- a/internal/config/admission_test.go
+++ b/internal/config/admission_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDefaultAdmissionPolicyAllOff(t *testing.T) {
+	policy := DefaultAdmissionPolicy()
+	if policy.MaxConcurrentSessions != 0 {
+		t.Fatalf("MaxConcurrentSessions = %d, want 0 (off)", policy.MaxConcurrentSessions)
+	}
+	if policy.MaxMemoryGB != 0 {
+		t.Fatalf("MaxMemoryGB = %v, want 0 (off)", policy.MaxMemoryGB)
+	}
+	if policy.Enabled() {
+		t.Fatalf("default policy must be disabled (both caps 0)")
+	}
+	// Priors are present so the memory gate has a per-runtime estimate when an
+	// operator turns it on without setting each runtime explicitly.
+	if policy.CodexMemoryGB != 0.2 || policy.ClaudeMemoryGB != 0.85 || policy.KimiMemoryGB != 0.5 || policy.DefaultMemoryGB != 0.5 {
+		t.Fatalf("unexpected default priors: %+v", policy)
+	}
+}
+
+func TestLoadAdmissionPolicyAbsentKeepsDefaults(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+
+	policy, err := LoadAdmissionPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadAdmissionPolicy returned error: %v", err)
+	}
+	if policy != DefaultAdmissionPolicy() {
+		t.Fatalf("absent [admission] section = %+v, want defaults %+v", policy, DefaultAdmissionPolicy())
+	}
+	if policy.Enabled() {
+		t.Fatalf("absent [admission] section must leave the budget disabled")
+	}
+}
+
+func TestLoadAdmissionPolicyParsesCaps(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[admission]
+max_concurrent_sessions = 3
+max_memory_gb = 4.5
+codex_memory_gb = 0.1
+claude_memory_gb = 1.2
+kimi_memory_gb = 0.4
+default_memory_gb = 0.7
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	policy, err := LoadAdmissionPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadAdmissionPolicy returned error: %v", err)
+	}
+	if policy.MaxConcurrentSessions != 3 {
+		t.Fatalf("MaxConcurrentSessions = %d, want 3", policy.MaxConcurrentSessions)
+	}
+	if policy.MaxMemoryGB != 4.5 {
+		t.Fatalf("MaxMemoryGB = %v, want 4.5", policy.MaxMemoryGB)
+	}
+	if policy.CodexMemoryGB != 0.1 || policy.ClaudeMemoryGB != 1.2 || policy.KimiMemoryGB != 0.4 || policy.DefaultMemoryGB != 0.7 {
+		t.Fatalf("per-runtime estimates = %+v", policy)
+	}
+	if !policy.Enabled() {
+		t.Fatalf("policy with caps set must report Enabled()")
+	}
+}
+
+func TestValidateAdmissionPolicyRejectsNegative(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "max_concurrent_sessions",
+			body: `
+[admission]
+max_concurrent_sessions = -1
+`,
+			wantErr: "max_concurrent_sessions must be 0",
+		},
+		{
+			name: "max_memory_gb",
+			body: `
+[admission]
+max_memory_gb = -2.5
+`,
+			wantErr: "max_memory_gb must be 0",
+		},
+		{
+			name: "codex_memory_gb",
+			body: `
+[admission]
+codex_memory_gb = -0.1
+`,
+			wantErr: "admission.codex_memory_gb must be 0 or positive",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if err := Initialize(paths); err != nil {
+				t.Fatalf("Initialize returned error: %v", err)
+			}
+			if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+tt.body), 0o600); err != nil {
+				t.Fatalf("write config returned error: %v", err)
+			}
+
+			_, err := LoadAdmissionPolicy(paths)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("LoadAdmissionPolicy error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -59,5 +59,24 @@ cockpit_pane_key = "job"
 # (Go duration; default 24h). Both optional.
 escalation_handle = ""
 escalation_ttl = ""
+
+# [admission] is an OPT-IN, off-by-default host-global concurrency budget the
+# daemon applies BEFORE starting each agent session, on top of --workers/pool
+# and the per-repo checkout / runtime-session locks (issue #365). With both caps
+# 0 (the default, below) it is DISABLED and scheduling is byte-identical to a
+# config with no [admission] section. Set max_concurrent_sessions to cap total
+# in-flight sessions across all repos in the daemon process; set max_memory_gb to
+# cap the summed per-runtime RAM estimate of in-flight sessions (a job is admitted
+# only if it fits BOTH). A job that does not fit is left queued and retried next
+# tick — never failed. The per-runtime *_memory_gb values are operator-tunable
+# RAM priors; a non-session runtime contributes 0. Note: the budget is enforced
+# per daemon process (host-global for the normal single-daemon deployment).
+# [admission]
+# max_concurrent_sessions = 0
+# max_memory_gb = 0
+# codex_memory_gb = 0.2
+# claude_memory_gb = 0.85
+# kimi_memory_gb = 0.5
+# default_memory_gb = 0.5
 `, paths.Database, paths.Logs, paths.Workspaces, paths.Evals, paths.ArtifactBlobs)
 }


### PR DESCRIPTION
## Summary

Adds an **opt-in, off-by-default** `[admission]` concurrency budget the daemon honors **before dispatching each session job**, on top of `--workers`/pool and the per-repo checkout / runtime-session locks. It is a STRICTER second gate applied at the single dispatch decision in BOTH schedulers (barrier `runQueuedJobsForRepo` and pool `runQueuedJobsForRepoPool`):

- **Coarse host-global session cap** — `max_concurrent_sessions` caps total in-flight session jobs across all repos in the daemon process.
- **Memory-aware budget** — `max_memory_gb` sums a config-driven per-runtime RAM estimate (codex/claude/kimi/default priors, operator-tunable) across in-flight sessions and **defers (keeps queued)** a job that would overcommit instead of dispatching it.

A job is admitted only if it fits **both** caps. A deferred job is **never failed or dropped** — it stays queued and is retried on a later dispatch pass/tick. The tracker is a small Mutex-guarded `*admissionBudget` (check-and-add under one lock so both caps are enforced atomically together; reserve-by-job-ID so Release is idempotent on the pool reap + panic/shutdown paths).

**Off by default => byte-identical.** With no `[admission]` config (both caps 0/unset) `worker.Admission` is `nil` and `Reserve`/`Release` are no-ops, so scheduling is byte-identical to today.

`gitmoot daemon status` reports the configured caps on a single additive line.

## Scope / limitation

The budget is **process-global** — host-global for the normal single-daemon deployment (one worker runs all enabled repos). Multiple `daemon start --repo` processes each get their own in-memory budget; a DB-backed cross-process gauge is a documented follow-up. Local-work-burst throttling is explicitly deferred (steady-state session RAM only).

## Merge-collision note (#444)

Per the goal, #365's logic lives in **new files** (`internal/config/admission.go`, `internal/cli/admission_budget.go`); the shared functions are touched only at additive insertion points (one reserve before dispatch, one release in reap/defer, a single separate status line). No launch flag added — config-only, so `parseDaemonStartConfig`/`daemonChildArgs` are untouched.

## Files

New: `internal/config/admission.go` (+`_test`), `internal/cli/admission_budget.go` (+`_test`, run under `-race`).
Modified: `internal/cli/daemon.go` (jobWorker field, both schedulers, both supervisors, status line, loader + per-job estimate helpers), `internal/config/init.go` (commented all-off `[admission]` template), `internal/cli/daemon_test.go` (scheduler + estimate tests).

## Test evidence

Full gate green:

```
go build ./...                       # ok
go vet ./...                         # ok
go test ./...                        # ok (all packages)
go test -race ./internal/workflow/   # ok 198s
go test -race ./internal/cli/        # ok 495s
go test -race ./internal/config/     # ok 1s
```

New tests:
- config: `TestDefaultAdmissionPolicyAllOff`, `TestLoadAdmissionPolicyAbsentKeepsDefaults`, `TestLoadAdmissionPolicyParsesCaps`, `TestValidateAdmissionPolicyRejectsNegative`
- budget (-race): session cap, memory cap, both-gates, release-frees, idempotent double-release, re-reserve no-op, nil-off, concurrent reserve/release (no over-admission)
- scheduler: `TestRunQueuedJobsBarrierAdmissionDefers` / `TestRunQueuedJobsPoolAdmissionDefers` (cap=1 serializes two otherwise-parallel jobs in BOTH schedulers; **nil Admission preserves peak=2** as a regression guard), `TestRunQueuedJobsAdmissionMemoryCapDefers`, `TestPerJobMemoryEstimateGB`

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)