### PR TITLE
feat(events): off-by-default outbound event stream + EventSink seam (#446)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,130 @@
+# Outbound Event Stream (`[events]`)
+
+Gitmoot can push a small, versioned, redacted JSON event to one HTTP endpoint
+whenever a job reaches a terminal state or pauses awaiting a human. This is an
+**off-by-default, best-effort** outbound seam (#446): with no `[events]` config
+nothing is constructed and behavior is byte-identical to a build without it.
+
+It complements — it does not replace — the existing observability surfaces
+(`gitmoot job watch`, the local dashboard, PR comments). The typed lifecycle
+events recorded in SQLite (`job_events`) are unchanged; this is an additional
+fan-out, not a migration.
+
+## What it emits
+
+The pilot emits a tight allowlist of event types over the webhook transport:
+
+| `event_type`           | When                                                              |
+| ---------------------- | ---------------------------------------------------------------- |
+| `job.finished`         | a job reaches the `succeeded` terminal state                     |
+| `job.failed`           | a job reaches the `failed` terminal state                        |
+| `job.blocked`          | a job reaches the `blocked` terminal state                       |
+| `job.needs_attention`  | a tree pauses awaiting a human (the `escalate_human` pause today) |
+
+Each terminal transition emits **exactly once**. The engine owns the
+succeeded/failed/blocked emit on its `Mailbox` terminal path; the daemon owns the
+pre-flight (`queued -> failed|blocked`) and permission-blocked cases that never
+pass through that path. `job.needs_attention` is emitted once per fresh
+escalation round (a re-advance does not re-emit).
+
+The following `event_type` values are **reserved** for the graduate step. They
+are enumerated in the contract so a consumer can `switch` over them
+forward-compatibly without a schema bump when they start arriving, but the pilot
+does **not** emit them: `job.started`, `delegation.escalation`,
+`delegation.finalized`, `orchestration.finished`.
+
+## The event contract (`schema_version = 1`)
+
+Every event is a single JSON object:
+
+```json
+{
+  "schema_version": 1,
+  "event_type": "job.finished",
+  "job_id": "implement-task-7",
+  "root_id": "coordinator-job-id",
+  "repo": "owner/repo",
+  "status": "succeeded",
+  "ts": "2026-06-16T12:00:00Z",
+  "detail": "Opened PR #42"
+}
+```
+
+| Field            | Type   | Notes                                                                       |
+| ---------------- | ------ | --------------------------------------------------------------------------- |
+| `schema_version` | int    | Contract version. Currently `1`. A breaking field change bumps it.          |
+| `event_type`     | string | The enum above.                                                             |
+| `job_id`         | string | Opaque job id this event is about.                                          |
+| `root_id`        | string | The coordination tree's root id, so a consumer can aggregate a run client-side. |
+| `repo`           | string | `owner/repo` only — never an absolute checkout path.                        |
+| `status`         | string | Terminal/lifecycle state (`succeeded`/`failed`/`blocked`/`awaiting_human`). |
+| `ts`             | string | RFC3339 emit time.                                                          |
+| `detail`         | string | Short redacted human-facing string (failure summary, the escalation question). |
+
+There is **no** synthetic `orchestration.finished` in the pilot — every event
+carries `root_id`, so a consumer groups a run client-side. Server-side
+tree-convergence aggregation is a documented graduate item.
+
+## Redaction
+
+Every outbound string field is redacted at event construction through the same
+redactor Gitmoot uses for off-box PR/issue comments and bug reports
+(`workflow.RedactCommentText`): GitHub tokens, OpenAI keys, AWS secrets, and
+`api_key`/`token`/`secret`/`password` assignments are replaced with
+`[REDACTED]`. `repo` is reduced to `owner/repo` only. No absolute paths, raw
+runtime output, or secrets leave the box.
+
+## Best-effort delivery
+
+Delivery is **fire-and-forget**. A slow, hung, erroring, or full consumer never
+blocks or fails a job — this mirrors the `escalate_human` notifier contract:
+
+- Each event is handed to a small buffered channel drained by **one** background
+  goroutine, so concurrent emits from many workers serialize cleanly.
+- Each POST is bounded by `[events].timeout` (default `2s`). A hung consumer
+  times out and the event is dropped.
+- On a full buffer, a transport error, or a non-2xx response the event is
+  **dropped** and a single best-effort `event_sink_drop` job event is recorded
+  locally (so a drop is observable without coupling delivery to the job).
+
+There is **no** outbox / retry in the pilot: at-least-once delivery and an
+outbox table are the explicit graduate step.
+
+## Configuration
+
+Add an `[events]` section to the Gitmoot config file:
+
+```toml
+[events]
+# The single endpoint each event is POSTed to as application/json.
+# Empty (the default) means the event stream is OFF: no sink, no goroutine,
+# no emits, byte-identical behavior.
+webhook_url = "https://example.com/gitmoot-events"
+
+# Per-POST timeout (Go duration). Default 2s. Bounds a hung consumer.
+timeout = "2s"
+
+# RESERVED for the graduate Unix-socket transport. Parsed and validated but
+# UNUSED by the pilot (webhook-only).
+# socket_path = "/run/gitmoot/events.sock"
+```
+
+| Key           | Default | Meaning                                                          |
+| ------------- | ------- | ---------------------------------------------------------------- |
+| `webhook_url` | `""`    | HTTP(S) endpoint. Empty = OFF.                                   |
+| `timeout`     | `2s`    | Per-POST timeout (Go duration). Must be positive.               |
+| `socket_path` | `""`    | Reserved for the graduate Unix-socket transport (unused today). |
+
+`webhook_url` must be an `http://` or `https://` URL. An invalid `timeout`
+duration or a non-http(s) URL is rejected at config load.
+
+## Graduate (go/no-go)
+
+The pilot validates the contract and the best-effort guarantee with the least
+scaffolding. The following are out of scope and gated behind an explicit go/no-go
+on the tracking issue:
+
+- The Unix-socket transport (`socket_path`), behind the same `Sink` seam.
+- More event types (`job.started`, `delegation.*`, `orchestration.finished`).
+- An outbox table for at-least-once / durable delivery.
+- A server-side synthetic `orchestration.finished` (reliable tree convergence).

--- a/docs/events.md
+++ b/docs/events.md
@@ -71,8 +71,12 @@ Every outbound string field is redacted at event construction through the same
 redactor Gitmoot uses for off-box PR/issue comments and bug reports
 (`workflow.RedactCommentText`): GitHub tokens, OpenAI keys, AWS secrets, and
 `api_key`/`token`/`secret`/`password` assignments are replaced with
-`[REDACTED]`. `repo` is reduced to `owner/repo` only. No absolute paths, raw
-runtime output, or secrets leave the box.
+`[REDACTED]`. The `detail` field is then additionally scrubbed of absolute
+filesystem paths — host home layout, checkout and worktree paths embedded in
+pre-flight failure detail (e.g. `git worktree add /root/.gitmoot/...`) collapse
+to `<path>` — so host layout and usernames never leak. `repo` is reduced to
+`owner/repo` only. No absolute paths, raw runtime output, or secrets leave the
+box.
 
 ## Best-effort delivery
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/presence"
@@ -1360,6 +1361,24 @@ type jobWorker struct {
 	// it is a shared pointer across all per-repo dispatch passes so the cap is
 	// process-global (host-global for the normal single-daemon deployment).
 	Admission *admissionBudget
+	// EventSinkOverride lets a test inject a recording events.Sink (#446) without
+	// a config file / webhook. When nil (production), eventSink() resolves the
+	// shared process-global webhook sink from [events] config instead.
+	EventSinkOverride events.Sink
+}
+
+// eventSink resolves the best-effort outbound event Sink (#446) for the
+// worker's home, or nil when [events] is OFF (the default). It is the seam
+// finishQueuedJob / handleRunJobError use to emit the DAEMON-owned terminal
+// cases (pre-flight queued->failed/blocked and permission-blocked
+// running->blocked) that never pass through the engine's Mailbox chokepoint. The
+// underlying webhook sink is a process-global singleton, so this is a cheap
+// cache hit on the hot path. A test override short-circuits config resolution.
+func (w jobWorker) eventSink() events.Sink {
+	if w.EventSinkOverride != nil {
+		return w.EventSinkOverride
+	}
+	return daemonEventSink(w.Store, w.workflowHome())
 }
 
 const daemonRunningJobStaleAfter = 30 * time.Minute
@@ -3606,6 +3625,14 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// pauses awaiting a decision. Best-effort and nil-safe in the engine; the
 		// handle is filled in from policy by applyOrchestratePolicy.
 		EscalationNotifier: &daemonEscalationNotifier{Store: store, GitHub: gh},
+		// Off-by-default outbound event stream (#446): the engine emits
+		// job.finished/job.failed/job.blocked on its terminal Mailbox path and
+		// job.needs_attention on an escalate_human pause through this best-effort,
+		// nil-safe sink. daemonEventSink returns nil unless [events].webhook_url is
+		// set, so with no config NO sink is constructed and behavior is
+		// byte-identical. The sink is a process-global shared singleton (one drain
+		// goroutine), so re-building the engine per tick never leaks goroutines.
+		EventSink: daemonEventSink(store, home),
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},
@@ -4319,6 +4346,16 @@ func (w jobWorker) finishQueuedJob(ctx context.Context, jobID string, state work
 	}
 	if transitioned {
 		writeLine(w.Stdout, "job %s %s: %v", jobID, state, cause)
+		// Best-effort outbound emit (#446) for a DAEMON-owned pre-flight terminal
+		// transition (queued->failed|blocked) — this never reaches the engine's
+		// Mailbox.finishWithPayload chokepoint, so the daemon owns its emit. Gated
+		// on transitioned==true so it fires exactly once per genuine transition;
+		// nil-safe when [events] is OFF. The subsequent finalizePreflightDelegationChild
+		// only attaches a synthetic result via savePayload (no further transition),
+		// so it does not double-emit.
+		if eventType, ok := daemonTerminalEventType(state); ok {
+			emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, eventType, string(state), cause.Error())
+		}
 	}
 	// A delegation child that fails in ANY pre-flight step (checkout/branch-lock
 	// validation, adapter factory, managed config, runtime-session lock/busy,
@@ -4403,6 +4440,12 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause er
 				if err := blockTaskForPermissionBlockedJob(ctx, w.Store, latest); err != nil {
 					return err
 				}
+				// Best-effort outbound emit (#446): this running->blocked permission
+				// transition is daemon-owned (it does not pass through the engine's
+				// Mailbox.finishWithPayload chokepoint), so emit job.blocked exactly
+				// once here. The following finalizePreflightDelegationChild only attaches
+				// a synthetic result (savePayload, no transition), so it never re-emits.
+				emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, events.EventJobBlocked, string(workflow.JobBlocked), agentPermissionBlockedMessage)
 				// A WRITABLE implement DELEGATION child whose runtime fails MID-RUN
 				// with a permission error (read-only FS / sandbox denies write) is
 				// transitioned JobRunning->JobBlocked here and returns early — it never

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2228,6 +2228,15 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		if err := blockTaskForPermissionBlockedJob(ctx, w.Store, job); err != nil {
 			return err
 		}
+		// Best-effort outbound emit (#446): this PRE-FLIGHT queued->blocked
+		// permission transition is daemon-owned (it never reaches the engine's
+		// Mailbox chokepoint), exactly like the MID-RUN permission block in
+		// handleRunJobError which already emits job.blocked. Emit here too so both
+		// halves of the permission-blocked terminal case are covered; gated on the
+		// genuine transition above, nil-safe when [events] is OFF. The following
+		// finalizePreflightDelegationChild only attaches a synthetic result
+		// (savePayload, no transition), so it never re-emits.
+		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, job.ID, events.EventJobBlocked, string(workflow.JobBlocked), agentPermissionBlockedMessage)
 		_ = w.postJobResultComment(ctx, job.ID, agent, "", errors.New(agentPermissionBlockedMessage))
 		writeLine(w.Stdout, "job %s blocked: %s", job.ID, agentPermissionBlockedMessage)
 		// A read-only implement DELEGATION child short-circuits to blocked here,

--- a/internal/cli/event_sink.go
+++ b/internal/cli/event_sink.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// eventSinkCache holds the single, process-global webhook Sink the daemon shares
+// across every per-tick / per-repo engine construction (#446). The webhook sink
+// owns a long-lived drain goroutine, so it MUST be constructed once — building a
+// fresh one per engine would leak a goroutine per poll. It is keyed by resolved
+// home so a multi-home test process never crosses streams; in the normal single-
+// daemon deployment there is exactly one entry. A cached nil entry records "this
+// home has [events] OFF" so the disabled path stays a cheap map hit with no
+// re-parse and, crucially, no sink/goroutine — the off-by-default guarantee.
+var eventSinkCache = struct {
+	sync.Mutex
+	built map[string]events.Sink
+}{built: map[string]events.Sink{}}
+
+// daemonEventSink returns the shared best-effort webhook Sink for this home, or
+// nil when the event stream is OFF (no [events].webhook_url, or any config load
+// failure — fail-safe to disabled so a malformed config never breaks the daemon
+// or silently starts emitting). It is safe for concurrent callers and constructs
+// the underlying webhook sink (and its drain goroutine) at most once per home.
+//
+// When enabled, the sink's OnDrop records a single best-effort event_sink_drop
+// job event so a dropped emit (full buffer / dead consumer) is locally
+// observable without coupling the events package to the db layer or ever
+// blocking the caller.
+func daemonEventSink(store *db.Store, home string) events.Sink {
+	home = strings.TrimSpace(home)
+	eventSinkCache.Lock()
+	defer eventSinkCache.Unlock()
+	if sink, ok := eventSinkCache.built[home]; ok {
+		return sink
+	}
+	sink := buildDaemonEventSink(store, home)
+	eventSinkCache.built[home] = sink
+	return sink
+}
+
+func buildDaemonEventSink(store *db.Store, home string) events.Sink {
+	policy, err := loadEventsPolicy(home)
+	if err != nil || !policy.Enabled() {
+		return nil
+	}
+	webhook := events.NewWebhookSink(policy.WebhookURL, policy.ResolvedTimeout())
+	if webhook == nil {
+		return nil
+	}
+	if store != nil {
+		webhook.OnDrop = func(event events.Event, reason string) {
+			// Best-effort local observability for a dropped outbound event; never
+			// blocks or fails (the drain goroutine is the only caller). A write
+			// error is swallowed.
+			_ = store.AddJobEvent(context.Background(), db.JobEvent{
+				JobID:   event.JobID,
+				Kind:    "event_sink_drop",
+				Message: string(event.Type) + ": " + reason,
+			})
+		}
+	}
+	return webhook
+}
+
+// loadEventsPolicy resolves the [events] policy for a home, fail-safe to the
+// disabled default when the home or config cannot be resolved/parsed so the
+// event stream stays OFF rather than erroring the daemon.
+func loadEventsPolicy(home string) (config.EventsPolicy, error) {
+	if strings.TrimSpace(home) == "" {
+		return config.DefaultEventsPolicy(), nil
+	}
+	paths, err := initializedPaths(home)
+	if err != nil {
+		return config.DefaultEventsPolicy(), nil
+	}
+	return config.LoadEventsPolicy(paths)
+}
+
+// daemonTerminalEventType maps a daemon-owned terminal JobState to the outbound
+// event_type (#446). Only failed/blocked map (the succeeded path is engine-owned
+// via the Mailbox chokepoint); any other state returns ok=false.
+func daemonTerminalEventType(state workflow.JobState) (events.EventType, bool) {
+	switch state {
+	case workflow.JobFailed:
+		return events.EventJobFailed, true
+	case workflow.JobBlocked:
+		return events.EventJobBlocked, true
+	default:
+		return "", false
+	}
+}
+
+// emitDaemonTerminalEvent emits a best-effort terminal event for a job the
+// DAEMON (not the engine) just transitioned to a terminal state — the pre-flight
+// queued->terminal cases and the permission-blocked running->blocked case that
+// never pass through the engine's Mailbox.finishWithPayload chokepoint (#446). It
+// is nil-safe (no sink => no-op), redacts via workflow.RedactCommentText, and
+// resolves root_id from the payload (falling back to the job id). It must only be
+// called on a GENUINE transition so the engine and daemon never double-emit for
+// the same terminal state.
+func emitDaemonTerminalEvent(ctx context.Context, sink events.Sink, store *db.Store, jobID string, eventType events.EventType, status, detail string) {
+	if sink == nil {
+		return
+	}
+	repo := ""
+	rootID := jobID
+	if store != nil {
+		if job, err := store.GetJob(ctx, jobID); err == nil {
+			if payload, perr := daemonJobPayload(job); perr == nil {
+				repo = payload.Repo
+				if strings.TrimSpace(payload.RootJobID) != "" {
+					rootID = payload.RootJobID
+				}
+			}
+		}
+	}
+	events.EmitEvent(ctx, sink, events.NewEvent(
+		eventType,
+		jobID,
+		rootID,
+		repo,
+		status,
+		detail,
+		time.Time{},
+		workflow.RedactCommentText,
+	))
+}

--- a/internal/cli/event_sink_daemon_test.go
+++ b/internal/cli/event_sink_daemon_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// recordingSink captures Emit calls for the daemon best-effort event tests.
+type recordingSink struct {
+	mu     sync.Mutex
+	events []events.Event
+}
+
+func (r *recordingSink) Emit(_ context.Context, event events.Event) {
+	r.mu.Lock()
+	r.events = append(r.events, event)
+	r.mu.Unlock()
+}
+
+func (r *recordingSink) byType(typ events.EventType) []events.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []events.Event
+	for _, e := range r.events {
+		if e.Type == typ {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func (r *recordingSink) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.events)
+}
+
+// TestFinishQueuedJobEmitsJobFailed proves the DAEMON-owned pre-flight terminal
+// path (a queued->failed transition that never reaches the engine's Mailbox
+// chokepoint) fans a job.failed out through the sink, carrying repo/root_id from
+// the payload.
+func TestFinishQueuedJobEmitsJobFailed(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	if err := store.CreateJob(ctx, db.Job{ID: "queued-job", Agent: "coord", Type: "ask", State: string(workflow.JobQueued)}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	payload := workflow.JobPayload{Repo: "owner/repo", RootJobID: "root-1"}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.UpdateJobPayload(ctx, "queued-job", string(encoded)); err != nil {
+		t.Fatalf("UpdateJobPayload returned error: %v", err)
+	}
+
+	sink := &recordingSink{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.EventSinkOverride = sink
+
+	if err := worker.finishQueuedJob(ctx, "queued-job", workflow.JobFailed, errors.New("preflight check failed")); err != nil {
+		t.Fatalf("finishQueuedJob returned error: %v", err)
+	}
+
+	failed := sink.byType(events.EventJobFailed)
+	if len(failed) != 1 {
+		t.Fatalf("job.failed emissions = %d, want 1", len(failed))
+	}
+	ev := failed[0]
+	if ev.JobID != "queued-job" || ev.RootID != "root-1" || ev.Repo != "owner/repo" || ev.Status != "failed" {
+		t.Fatalf("job.failed event = %+v", ev)
+	}
+	if ev.SchemaVersion != 1 {
+		t.Fatalf("schema_version = %d, want 1", ev.SchemaVersion)
+	}
+	if ev.Detail != "preflight check failed" {
+		t.Fatalf("detail = %q, want the failure cause", ev.Detail)
+	}
+}
+
+// TestFinishQueuedJobEmitsJobBlocked proves a queued->blocked pre-flight
+// transition emits job.blocked.
+func TestFinishQueuedJobEmitsJobBlocked(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	if err := store.CreateJob(ctx, db.Job{ID: "queued-job", Agent: "coord", Type: "ask", State: string(workflow.JobQueued)}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	sink := &recordingSink{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.EventSinkOverride = sink
+
+	if err := worker.finishQueuedJob(ctx, "queued-job", workflow.JobBlocked, errors.New("missing capability")); err != nil {
+		t.Fatalf("finishQueuedJob returned error: %v", err)
+	}
+	if got := sink.byType(events.EventJobBlocked); len(got) != 1 {
+		t.Fatalf("job.blocked emissions = %d, want 1", len(got))
+	}
+}
+
+// TestFinishQueuedJobNilSinkIsByteIdentical proves the off-by-default path: with
+// no sink the transition still succeeds and nothing is emitted (no panic).
+func TestFinishQueuedJobNilSinkIsByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	if err := store.CreateJob(ctx, db.Job{ID: "queued-job", Agent: "coord", Type: "ask", State: string(workflow.JobQueued)}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	worker := defaultJobWorker(store, io.Discard) // no EventSinkOverride; home unset -> nil sink
+
+	if err := worker.finishQueuedJob(ctx, "queued-job", workflow.JobFailed, errors.New("boom")); err != nil {
+		t.Fatalf("finishQueuedJob returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "queued-job")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+}
+
+// TestFinishQueuedJobNoTransitionDoesNotEmit proves the gate on the GENUINE
+// transition: re-finishing an already-terminal job must NOT re-emit (the
+// transitioned==false branch), so a retry never double-emits.
+func TestFinishQueuedJobNoTransitionDoesNotEmit(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	// Already terminal (not queued): the transition is a no-op.
+	if err := store.CreateJob(ctx, db.Job{ID: "done-job", Agent: "coord", Type: "ask", State: string(workflow.JobFailed)}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	sink := &recordingSink{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.EventSinkOverride = sink
+
+	if err := worker.finishQueuedJob(ctx, "done-job", workflow.JobFailed, errors.New("boom")); err != nil {
+		t.Fatalf("finishQueuedJob returned error: %v", err)
+	}
+	if sink.count() != 0 {
+		t.Fatalf("emissions = %d, want 0 for a non-transition", sink.count())
+	}
+}

--- a/internal/cli/preflight_delegation_finalize_test.go
+++ b/internal/cli/preflight_delegation_finalize_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
 	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/workflow"
@@ -616,6 +617,50 @@ func TestPreflightReadOnlyImplementNonDelegationUnaffected(t *testing.T) {
 	}
 	if n := countWorkerJobEvents(t, store, "impl-job", "delegation_timeout_finalized"); n != 0 {
 		t.Fatalf("delegation_timeout_finalized events = %d, want 0 for a non-delegation job", n)
+	}
+}
+
+// TestPreflightReadOnlyImplementEmitsJobBlocked is the regression for the #446
+// review finding: the PRE-FLIGHT readOnlyImplementationBlocked path transitions a
+// job queued->blocked via markJobPermissionBlocked (a daemon-owned terminal
+// transition that never reaches the engine's Mailbox chokepoint), so it must emit
+// job.blocked itself — mirroring the MID-RUN permission block in
+// handleRunJobError. Before the fix this half of the permission-blocked terminal
+// case was silently dropped.
+func TestPreflightReadOnlyImplementEmitsJobBlocked(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "jerryfane/gitmoot", t.TempDir())
+	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.CodexRuntime, "unused", []string{"implement"}, "jerryfane/gitmoot", runtime.AutonomyPolicyReadOnly)
+	job := db.Job{ID: "impl-job", Agent: "lead", Type: "implement", State: string(workflow.JobQueued), Payload: mustJobPayload(t, workflow.JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "feature", TaskID: "task-impl", TaskTitle: "Solo implement", Sender: "lead", RootJobID: "root-impl",
+	})}
+	if err := store.CreateJobWithEvent(ctx, job, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	sink := &recordingSink{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.EventSinkOverride = sink
+
+	if err := worker.run(ctx, mustWorkerJob(t, store, "impl-job")); err != nil {
+		t.Fatalf("worker.run(read-only implement) returned error: %v", err)
+	}
+	got := mustWorkerJob(t, store, "impl-job")
+	if got.State != string(workflow.JobBlocked) {
+		t.Fatalf("job state = %q, want blocked", got.State)
+	}
+
+	blocked := sink.byType(events.EventJobBlocked)
+	if len(blocked) != 1 {
+		t.Fatalf("job.blocked emissions = %d, want exactly 1; all=%+v", len(blocked), sink.events)
+	}
+	ev := blocked[0]
+	if ev.JobID != "impl-job" || ev.RootID != "root-impl" || ev.Repo != "jerryfane/gitmoot" || ev.Status != string(workflow.JobBlocked) {
+		t.Fatalf("job.blocked event = %+v", ev)
+	}
+	if ev.Detail != agentPermissionBlockedMessage {
+		t.Fatalf("detail = %q, want the permission-blocked message", ev.Detail)
 	}
 }
 

--- a/internal/config/events_test.go
+++ b/internal/config/events_test.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLoadEventsPolicyDefaultsDisabled(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+
+	policy, err := LoadEventsPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadEventsPolicy returned error: %v", err)
+	}
+	// With no [events] section the stream is OFF: no sink should be constructed.
+	if policy.Enabled() {
+		t.Fatalf("default EventsPolicy must be disabled, got %+v", policy)
+	}
+	if policy.WebhookURL != "" || policy.Timeout != "" || policy.SocketPath != "" {
+		t.Fatalf("default EventsPolicy must be all-empty, got %+v", policy)
+	}
+	// ResolvedTimeout falls back to the documented default.
+	if got := policy.ResolvedTimeout(); got != 2*time.Second {
+		t.Fatalf("ResolvedTimeout default = %v, want 2s", got)
+	}
+}
+
+func TestLoadEventsPolicyParsesWebhookAndTimeout(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[events]
+webhook_url = "https://example.test/hook"
+timeout = "5s"
+socket_path = "/tmp/events.sock"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	policy, err := LoadEventsPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadEventsPolicy returned error: %v", err)
+	}
+	if !policy.Enabled() {
+		t.Fatalf("EventsPolicy with webhook_url should be enabled, got %+v", policy)
+	}
+	if policy.WebhookURL != "https://example.test/hook" {
+		t.Fatalf("WebhookURL = %q", policy.WebhookURL)
+	}
+	if policy.Timeout != "5s" {
+		t.Fatalf("Timeout = %q, want 5s", policy.Timeout)
+	}
+	if got := policy.ResolvedTimeout(); got != 5*time.Second {
+		t.Fatalf("ResolvedTimeout = %v, want 5s", got)
+	}
+	if policy.SocketPath != "/tmp/events.sock" {
+		t.Fatalf("SocketPath (reserved) = %q, want /tmp/events.sock", policy.SocketPath)
+	}
+}
+
+func TestLoadEventsPolicyRejectsInvalidTimeout(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[events]
+webhook_url = "https://example.test/hook"
+timeout = "not-a-duration"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadEventsPolicy(paths); err == nil {
+		t.Fatal("LoadEventsPolicy must reject an invalid timeout duration")
+	}
+}
+
+func TestLoadEventsPolicyRejectsNonHTTPURL(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[events]
+webhook_url = "ftp://example.test/hook"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadEventsPolicy(paths); err == nil {
+		t.Fatal("LoadEventsPolicy must reject a non-http(s) webhook_url")
+	}
+}
+
+// TestLoadEventsPolicyDoesNotBleedIntoOrchestrate pins the hand-rolled scanner's
+// section flag: an [events] section must not be parsed as [orchestrate] keys and
+// vice-versa. Interleave the two sections and assert each loader reads only its
+// own keys.
+func TestLoadEventsPolicyDoesNotBleedIntoOrchestrate(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+cockpit_mode = "on"
+max_verify_replan_attempts = 4
+
+[events]
+webhook_url = "http://127.0.0.1:9999/"
+timeout = "3s"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	events, err := LoadEventsPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadEventsPolicy returned error: %v", err)
+	}
+	if events.WebhookURL != "http://127.0.0.1:9999/" || events.Timeout != "3s" {
+		t.Fatalf("events policy = %+v, want webhook+timeout from [events] only", events)
+	}
+
+	orch, err := LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if orch.CockpitMode != CockpitModeOn || orch.MaxVerifyReplanAttempts != 4 {
+		t.Fatalf("orchestrate policy = %+v, want cockpit_mode=on + verify cap=4 from [orchestrate] only", orch)
+	}
+}

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -235,3 +235,129 @@ func validateOrchestratePolicy(policy OrchestratePolicy) error {
 	}
 	return nil
 }
+
+// EventsPolicy is the host-level outbound-event-stream policy read from the
+// [events] section of the gitmoot config (#446). It is a distinct concern from
+// [orchestrate] (cockpit/delegation budgets): when WebhookURL is empty (the
+// default) NO sink is constructed and behavior is byte-identical (off by
+// default). The daemon uses it to build the best-effort webhook Sink wired into
+// the workflow engine's terminal-transition path.
+type EventsPolicy struct {
+	// WebhookURL is the single https/http endpoint each terminal/needs_attention
+	// event is POSTed to as application/json. Empty (the default) means the event
+	// stream is OFF: no sink, no goroutine, no emits.
+	WebhookURL string
+	// Timeout bounds a single outbound POST so a hung consumer never stalls the
+	// drain goroutine, as a Go duration string. Empty (the default) uses
+	// DefaultEventsTimeout (2s); the daemon parses it.
+	Timeout string
+	// SocketPath is RESERVED for the graduate Unix-socket transport (#446
+	// open question). It is parsed and validated but UNUSED by the pilot
+	// (webhook-only); listing it keeps the config surface forward-compatible.
+	SocketPath string
+}
+
+// DefaultEventsTimeout is the fallback per-POST timeout when [events].timeout is
+// unset. It matches events.DefaultWebhookTimeout (kept as a string here so the
+// config package does not import internal/events).
+const DefaultEventsTimeout = "2s"
+
+func DefaultEventsPolicy() EventsPolicy {
+	return EventsPolicy{
+		WebhookURL: "",
+		Timeout:    "",
+		SocketPath: "",
+	}
+}
+
+// Enabled reports whether the event stream is configured on. With no [events]
+// config (the default) it is OFF and no sink should be constructed.
+func (p EventsPolicy) Enabled() bool {
+	return strings.TrimSpace(p.WebhookURL) != ""
+}
+
+// ResolvedTimeout returns the parsed per-POST timeout, falling back to
+// DefaultEventsTimeout when unset. validateEventsPolicy guarantees a non-empty
+// value parses, so this never errors for a validated policy.
+func (p EventsPolicy) ResolvedTimeout() time.Duration {
+	raw := strings.TrimSpace(p.Timeout)
+	if raw == "" {
+		raw = DefaultEventsTimeout
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		d, _ = time.ParseDuration(DefaultEventsTimeout)
+	}
+	return d
+}
+
+func LoadEventsPolicy(paths Paths) (EventsPolicy, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return EventsPolicy{}, err
+	}
+	policy := DefaultEventsPolicy()
+	current := false
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			current = strings.TrimSpace(section) == "events"
+			continue
+		}
+		if !current {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if err := applyEventsPolicyField(&policy, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
+			return EventsPolicy{}, fmt.Errorf("parse [events].%s: %w", strings.TrimSpace(key), err)
+		}
+	}
+	if err := validateEventsPolicy(policy); err != nil {
+		return EventsPolicy{}, err
+	}
+	return policy, nil
+}
+
+func applyEventsPolicyField(policy *EventsPolicy, key string, value string) error {
+	switch key {
+	case "webhook_url":
+		parsed, err := parseConfigString(value)
+		policy.WebhookURL = strings.TrimSpace(parsed)
+		return err
+	case "timeout":
+		parsed, err := parseConfigString(value)
+		policy.Timeout = strings.TrimSpace(parsed)
+		return err
+	case "socket_path":
+		parsed, err := parseConfigString(value)
+		policy.SocketPath = strings.TrimSpace(parsed)
+		return err
+	default:
+		return nil
+	}
+}
+
+func validateEventsPolicy(policy EventsPolicy) error {
+	if url := strings.TrimSpace(policy.WebhookURL); url != "" {
+		if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+			return fmt.Errorf("events.webhook_url %q must be an http:// or https:// URL", url)
+		}
+	}
+	if raw := strings.TrimSpace(policy.Timeout); raw != "" {
+		parsed, err := time.ParseDuration(raw)
+		if err != nil {
+			return fmt.Errorf("events.timeout %q is invalid: %w", raw, err)
+		}
+		if parsed <= 0 {
+			return fmt.Errorf("events.timeout must be positive")
+		}
+	}
+	return nil
+}

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -1,0 +1,160 @@
+// Package events defines the off-by-default, best-effort outbound event seam
+// (#446): a typed, versioned JobEvent contract plus a Sink interface the
+// workflow engine and daemon call from the terminal-transition path to fan a
+// redacted event out to one configured transport (the pilot ships a webhook).
+//
+// Design invariants:
+//   - OFF by default: a nil Sink is a no-op everywhere, so with no [events]
+//     config the engine/daemon behave byte-identically (no goroutine, no emit).
+//   - BEST-EFFORT: a slow/hung/erroring/full consumer must NEVER block or fail a
+//     job. Emit is fire-and-forget with a bounded transport timeout and
+//     drop-on-full, mirroring the EscalationNotifier contract.
+//   - NO IMPORT CYCLE: this package must NOT import internal/workflow. The
+//     redaction function is injected into NewEvent by the caller (the engine and
+//     daemon pass workflow.RedactCommentText) so redaction happens at event
+//     construction without an events->workflow dependency.
+//
+// #445 (the ask-gate) emits its job.needs_attention through this same seam.
+package events
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// SchemaVersion is the contract version stamped on every emitted Event. Consumers
+// pin to it; a breaking field change bumps it. Reserved (parsed-but-unused for
+// the pilot) event types let consumers be forward-compatible without churn.
+const SchemaVersion = 1
+
+// EventType is the lifecycle/terminal enum carried on an Event. The pilot emits
+// the terminal set plus needs_attention; the remaining values are reserved so
+// the contract is stable as the graduate step adds them.
+type EventType string
+
+const (
+	// EventJobFinished is emitted once when a job reaches a SUCCEEDED terminal
+	// state (the engine's success/advance path).
+	EventJobFinished EventType = "job.finished"
+	// EventJobFailed is emitted once when a job reaches a FAILED terminal state.
+	EventJobFailed EventType = "job.failed"
+	// EventJobBlocked is emitted once when a job reaches a BLOCKED terminal state.
+	EventJobBlocked EventType = "job.blocked"
+	// EventJobNeedsAttention is emitted once when a job/tree pauses awaiting a
+	// human (the escalate_human pause today; the #445 ask-gate next). detail
+	// carries the redacted question.
+	EventJobNeedsAttention EventType = "job.needs_attention"
+
+	// Reserved for the graduate step (parsed/enumerated but NOT emitted by the
+	// pilot). Listed so downstream consumers can switch over them forward-
+	// compatibly without a schema bump when they start arriving.
+	EventJobStarted            EventType = "job.started"
+	EventDelegationEscalation  EventType = "delegation.escalation"
+	EventDelegationFinalized   EventType = "delegation.finalized"
+	EventOrchestrationFinished EventType = "orchestration.finished"
+)
+
+// Event is the stable, versioned, redacted JSON object emitted outbound. Every
+// string field is redacted at construction (see NewEvent); ids are opaque, ts is
+// RFC3339, status is the terminal/lifecycle enum string. It is intentionally
+// small — a tight allowlist, not the AddJobEvent firehose — so the contract is
+// easy to consume and stable.
+type Event struct {
+	// SchemaVersion is the contract version (currently SchemaVersion=1).
+	SchemaVersion int `json:"schema_version"`
+	// Type is the event_type enum (job.finished / job.failed / job.blocked /
+	// job.needs_attention).
+	Type EventType `json:"event_type"`
+	// JobID is the opaque job id this event is about.
+	JobID string `json:"job_id"`
+	// RootID is the coordination tree's root id (payload.RootJobID, else the
+	// job's own id) so a consumer can aggregate a run client-side. No synthetic
+	// orchestration.finished is emitted in the pilot.
+	RootID string `json:"root_id,omitempty"`
+	// Repo is owner/repo only (never an absolute checkout path).
+	Repo string `json:"repo,omitempty"`
+	// Status is the terminal/lifecycle state string (succeeded/failed/blocked/
+	// awaiting_human).
+	Status string `json:"status,omitempty"`
+	// Timestamp is the RFC3339 emit time.
+	Timestamp string `json:"ts"`
+	// Detail is a short redacted human-facing string (failure summary, the
+	// escalation question, …). Never raw runtime output or secrets.
+	Detail string `json:"detail,omitempty"`
+}
+
+// Sink is the injected, best-effort outbound seam the engine and daemon call
+// from the terminal-transition path. Implementations MUST be non-blocking and
+// MUST NOT return an error path that can fail a job: Emit is fire-and-forget.
+// A nil Sink is a no-op (callers guard with EmitEvent / a nil check), so the
+// default (no [events] config) path is byte-identical.
+type Sink interface {
+	// Emit dispatches an event best-effort. It must not block beyond a bounded
+	// transport timeout and must never panic or fail the caller. ctx is honored
+	// for cancellation only as a courtesy; a cancelled ctx never fails a job.
+	Emit(ctx context.Context, event Event)
+}
+
+// RedactFunc redacts a single outbound string (secrets, tokens, …). The engine
+// and daemon pass workflow.RedactCommentText so this package does not import
+// internal/workflow (avoiding an import cycle).
+type RedactFunc func(string) string
+
+// NewEvent builds a redacted, versioned Event. Every free-text string field is
+// run through redact (when non-nil); repo is reduced to owner/repo only so an
+// absolute checkout path can never leak; ts defaults to time.Now() when zero.
+// The constructor — not the transport — owns redaction, so a Sink just
+// serializes and ships.
+func NewEvent(eventType EventType, jobID, rootID, repo, status, detail string, ts time.Time, redact RedactFunc) Event {
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	return Event{
+		SchemaVersion: SchemaVersion,
+		Type:          eventType,
+		JobID:         strings.TrimSpace(jobID),
+		RootID:        strings.TrimSpace(rootID),
+		Repo:          ownerRepoOnly(repo),
+		Status:        strings.TrimSpace(status),
+		Timestamp:     ts.UTC().Format(time.RFC3339),
+		Detail:        redactString(strings.TrimSpace(detail), redact),
+	}
+}
+
+// EmitEvent is a nil-safe convenience: a nil sink is a no-op (the off-by-default
+// guarantee), otherwise it forwards to sink.Emit. Callers in the engine/daemon
+// use it so every emit site is uniformly nil-guarded.
+func EmitEvent(ctx context.Context, sink Sink, event Event) {
+	if sink == nil {
+		return
+	}
+	sink.Emit(ctx, event)
+}
+
+func redactString(value string, redact RedactFunc) string {
+	if redact == nil {
+		return value
+	}
+	return redact(value)
+}
+
+// ownerRepoOnly trims a repo reference to its trailing owner/repo, dropping any
+// host or absolute-path prefix so an absolute checkout path never leaks. It
+// tolerates "owner/repo", "github.com/owner/repo", and a bare path; an empty or
+// path-only value collapses to "".
+func ownerRepoOnly(repo string) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return ""
+	}
+	// An absolute filesystem path is not a repo reference; never emit it.
+	if strings.HasPrefix(repo, "/") {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(repo, "/"), "/")
+	if len(parts) < 2 {
+		return repo
+	}
+	return parts[len(parts)-2] + "/" + parts[len(parts)-1]
+}

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -19,6 +19,7 @@ package events
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -106,6 +107,15 @@ type RedactFunc func(string) string
 // absolute checkout path can never leak; ts defaults to time.Now() when zero.
 // The constructor — not the transport — owns redaction, so a Sink just
 // serializes and ships.
+//
+// detail is additionally scrubbed of absolute filesystem paths AFTER the
+// injected secret redaction (scrubAbsolutePaths): the injected redact func
+// (workflow.RedactCommentText) only strips secrets/tokens, but pre-flight
+// causes routinely embed absolute checkout/worktree paths (CheckoutValidator
+// errors, `git worktree add /root/.gitmoot/...`). Collapsing them to <path>
+// here — the single chokepoint both the engine and daemon pass through —
+// upholds the "no absolute paths/secrets/raw runtime output leave the box"
+// acceptance criterion for every emit site at once (#446).
 func NewEvent(eventType EventType, jobID, rootID, repo, status, detail string, ts time.Time, redact RedactFunc) Event {
 	if ts.IsZero() {
 		ts = time.Now()
@@ -118,7 +128,7 @@ func NewEvent(eventType EventType, jobID, rootID, repo, status, detail string, t
 		Repo:          ownerRepoOnly(repo),
 		Status:        strings.TrimSpace(status),
 		Timestamp:     ts.UTC().Format(time.RFC3339),
-		Detail:        redactString(strings.TrimSpace(detail), redact),
+		Detail:        scrubAbsolutePaths(redactString(strings.TrimSpace(detail), redact)),
 	}
 }
 
@@ -137,6 +147,26 @@ func redactString(value string, redact RedactFunc) string {
 		return value
 	}
 	return redact(value)
+}
+
+// absolutePathPattern matches an absolute Unix filesystem path: a `/` that is
+// not preceded by another path/URL character (so the `//` of `https://host` is
+// left intact — the leading `https:` is a non-`/` char before the first slash,
+// and the second slash is excluded by requiring a name segment after the
+// matched slash) followed by one or more `name/` segments and a trailing name.
+// It collapses host home layout (`/root/.gitmoot/...`), usernames, and worktree
+// paths embedded in failure detail to a single `<path>` placeholder. It runs
+// AFTER secret redaction so a `[REDACTED]` token already substituted for a
+// secret is never re-scanned as a path. Path-like fragments WITHOUT a separator
+// after the leading slash (a bare `/`) are left untouched.
+var absolutePathPattern = regexp.MustCompile(`(^|[^A-Za-z0-9_./:-])(/[^\s/<>]+(?:/[^\s/<>]+)+/?)`)
+
+// scrubAbsolutePaths collapses absolute filesystem paths in a redacted detail
+// string to `<path>`, so host-layout/checkout/worktree paths never leave the
+// box. It preserves the single non-path leading character the pattern captures
+// (whitespace/punctuation before the path) so surrounding text stays readable.
+func scrubAbsolutePaths(value string) string {
+	return absolutePathPattern.ReplaceAllString(value, "${1}<path>")
 }
 
 // ownerRepoOnly trims a repo reference to its trailing owner/repo, dropping any

--- a/internal/events/sink_test.go
+++ b/internal/events/sink_test.go
@@ -1,0 +1,133 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewEventContractShape(t *testing.T) {
+	ts := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	ev := NewEvent(EventJobFinished, "job-1", "root-1", "jerryfane/gitmoot", "succeeded", "all good", ts, nil)
+
+	if ev.SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d, want 1", ev.SchemaVersion)
+	}
+	if SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion const = %d, want 1", SchemaVersion)
+	}
+	if ev.Type != EventJobFinished {
+		t.Fatalf("Type = %q, want %q", ev.Type, EventJobFinished)
+	}
+	if ev.JobID != "job-1" || ev.RootID != "root-1" || ev.Repo != "jerryfane/gitmoot" || ev.Status != "succeeded" || ev.Detail != "all good" {
+		t.Fatalf("event fields = %+v", ev)
+	}
+	if ev.Timestamp != "2026-06-16T12:00:00Z" {
+		t.Fatalf("Timestamp = %q, want RFC3339 2026-06-16T12:00:00Z", ev.Timestamp)
+	}
+
+	// The JSON wire shape is the documented contract; pin the key names.
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	for _, key := range []string{"schema_version", "event_type", "job_id", "root_id", "repo", "status", "ts", "detail"} {
+		if _, ok := decoded[key]; !ok {
+			t.Fatalf("event JSON missing key %q; got %s", key, raw)
+		}
+	}
+	if decoded["schema_version"].(float64) != 1 {
+		t.Fatalf("schema_version = %v, want 1", decoded["schema_version"])
+	}
+	if decoded["event_type"].(string) != "job.finished" {
+		t.Fatalf("event_type = %v, want job.finished", decoded["event_type"])
+	}
+}
+
+func TestEventTypeEnumValues(t *testing.T) {
+	cases := map[EventType]string{
+		EventJobFinished:           "job.finished",
+		EventJobFailed:             "job.failed",
+		EventJobBlocked:            "job.blocked",
+		EventJobNeedsAttention:     "job.needs_attention",
+		EventJobStarted:            "job.started",
+		EventDelegationEscalation:  "delegation.escalation",
+		EventDelegationFinalized:   "delegation.finalized",
+		EventOrchestrationFinished: "orchestration.finished",
+	}
+	for typ, want := range cases {
+		if string(typ) != want {
+			t.Fatalf("event type %q != %q", typ, want)
+		}
+	}
+}
+
+func TestNewEventRedactsEveryStringField(t *testing.T) {
+	// A redactor that uppercases proves the func is applied to detail (the only
+	// free-text field); the real RedactCommentText is exercised by the workflow
+	// tests. Secrets must not survive into detail.
+	redact := func(s string) string {
+		return strings.ReplaceAll(s, "ghp_secretsecretsecret", "[REDACTED]")
+	}
+	ev := NewEvent(EventJobFailed, "job-1", "root-1", "jerryfane/gitmoot", "failed", "token ghp_secretsecretsecret leaked", time.Now(), redact)
+	if strings.Contains(ev.Detail, "ghp_secretsecretsecret") {
+		t.Fatalf("detail not redacted: %q", ev.Detail)
+	}
+	if !strings.Contains(ev.Detail, "[REDACTED]") {
+		t.Fatalf("redaction marker missing: %q", ev.Detail)
+	}
+}
+
+func TestNewEventRepoIsOwnerRepoOnly(t *testing.T) {
+	cases := map[string]string{
+		"jerryfane/gitmoot":            "jerryfane/gitmoot",
+		"github.com/jerryfane/gitmoot": "jerryfane/gitmoot",
+		"/abs/path/to/checkout":        "", // absolute path must never leak
+		"":                             "",
+		"singletoken":                  "singletoken",
+	}
+	for in, want := range cases {
+		ev := NewEvent(EventJobFinished, "j", "r", in, "succeeded", "", time.Now(), nil)
+		if ev.Repo != want {
+			t.Fatalf("ownerRepoOnly(%q) -> %q, want %q", in, ev.Repo, want)
+		}
+	}
+}
+
+func TestNewEventDefaultsTimestamp(t *testing.T) {
+	ev := NewEvent(EventJobFinished, "j", "r", "o/r", "succeeded", "", time.Time{}, nil)
+	if ev.Timestamp == "" {
+		t.Fatal("zero ts should default to now, got empty Timestamp")
+	}
+	if _, err := time.Parse(time.RFC3339, ev.Timestamp); err != nil {
+		t.Fatalf("Timestamp %q is not RFC3339: %v", ev.Timestamp, err)
+	}
+}
+
+// recordingSink captures Emit calls for the engine/daemon best-effort tests.
+type recordingSink struct {
+	events []Event
+}
+
+func (r *recordingSink) Emit(_ context.Context, event Event) {
+	r.events = append(r.events, event)
+}
+
+func TestEmitEventNilSinkIsNoOp(t *testing.T) {
+	// A nil Sink must be a no-op (the off-by-default guarantee): no panic, nothing
+	// dispatched.
+	EmitEvent(context.Background(), nil, NewEvent(EventJobFinished, "j", "r", "o/r", "succeeded", "", time.Now(), nil))
+
+	// A real sink does dispatch, proving the nil-guard is the only short circuit.
+	rec := &recordingSink{}
+	EmitEvent(context.Background(), rec, NewEvent(EventJobFinished, "j", "r", "o/r", "succeeded", "", time.Now(), nil))
+	if len(rec.events) != 1 {
+		t.Fatalf("recording sink got %d events, want 1", len(rec.events))
+	}
+}

--- a/internal/events/sink_test.go
+++ b/internal/events/sink_test.go
@@ -84,6 +84,56 @@ func TestNewEventRedactsEveryStringField(t *testing.T) {
 	}
 }
 
+func TestNewEventScrubsAbsolutePathsFromDetail(t *testing.T) {
+	// The injected redact func (workflow.RedactCommentText) only strips secrets;
+	// absolute checkout/worktree paths in a pre-flight failure detail must not
+	// leave the box (#446 frozen criterion). NewEvent collapses them to <path>
+	// even when redact is nil, so the scrub is unconditional.
+	cases := map[string]struct {
+		mustNotContain []string
+		mustContain    []string
+	}{
+		"checkout /root/.gitmoot/repos/owner__repo/main is dirty": {
+			mustNotContain: []string{"/root/.gitmoot", "/root"},
+			mustContain:    []string{"<path>", "is dirty"},
+		},
+		"worktree add /root/.gitmoot/worktrees/some-job failed": {
+			mustNotContain: []string{"/root/.gitmoot/worktrees", "/root"},
+			mustContain:    []string{"<path>", "failed"},
+		},
+	}
+	for detail, want := range cases {
+		ev := NewEvent(EventJobFailed, "j", "r", "o/r", "failed", detail, time.Now(), nil)
+		for _, frag := range want.mustNotContain {
+			if strings.Contains(ev.Detail, frag) {
+				t.Fatalf("detail %q still contains absolute path fragment %q: %q", detail, frag, ev.Detail)
+			}
+		}
+		for _, frag := range want.mustContain {
+			if !strings.Contains(ev.Detail, frag) {
+				t.Fatalf("detail %q missing expected fragment %q: %q", detail, frag, ev.Detail)
+			}
+		}
+	}
+
+	// A URL is not an absolute filesystem path and must survive intact.
+	ev := NewEvent(EventJobFinished, "j", "r", "o/r", "succeeded", "see https://github.com/owner/repo for details", time.Now(), nil)
+	if !strings.Contains(ev.Detail, "https://github.com/owner/repo") {
+		t.Fatalf("URL was mangled by the path scrubber: %q", ev.Detail)
+	}
+
+	// Scrubbing runs AFTER redaction: a secret and a path in the same detail are
+	// both removed.
+	redact := func(s string) string { return strings.ReplaceAll(s, "ghp_secretsecretsecret00", "[REDACTED]") }
+	ev = NewEvent(EventJobFailed, "j", "r", "o/r", "failed", "token ghp_secretsecretsecret00 at /root/.gitmoot/x/y", time.Now(), redact)
+	if strings.Contains(ev.Detail, "ghp_secretsecretsecret00") || strings.Contains(ev.Detail, "/root/.gitmoot") {
+		t.Fatalf("secret or path leaked: %q", ev.Detail)
+	}
+	if !strings.Contains(ev.Detail, "[REDACTED]") || !strings.Contains(ev.Detail, "<path>") {
+		t.Fatalf("expected both redaction marker and path placeholder: %q", ev.Detail)
+	}
+}
+
 func TestNewEventRepoIsOwnerRepoOnly(t *testing.T) {
 	cases := map[string]string{
 		"jerryfane/gitmoot":            "jerryfane/gitmoot",

--- a/internal/events/webhook.go
+++ b/internal/events/webhook.go
@@ -1,0 +1,125 @@
+package events
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+// DefaultWebhookTimeout bounds a single outbound POST so a hung consumer can
+// never stall the drain goroutine indefinitely. It is the fallback when
+// [events].timeout is unset.
+const DefaultWebhookTimeout = 2 * time.Second
+
+// defaultWebhookBuffer bounds the in-flight event queue. On a full buffer Emit
+// drops (never blocks the caller); the drop is surfaced via the OnDrop hook so
+// the daemon can record a single best-effort event_sink_drop job event without
+// this package importing the db layer.
+const defaultWebhookBuffer = 256
+
+// webhookSink is the pilot Sink: it POSTs each event as application/json to one
+// configured URL. Emit is fire-and-forget — it hands the event to a small
+// buffered channel drained by ONE background goroutine, so a slow/hung/erroring
+// consumer (bounded by the http.Client timeout) never blocks or fails a job. On
+// a full buffer or any transport error the event is dropped (best-effort) and
+// OnDrop, if set, is invoked. There is no outbox/retry: at-least-once delivery
+// is the documented graduate step.
+type webhookSink struct {
+	url    string
+	client *http.Client
+	queue  chan queued
+	// OnDrop, when set, is called best-effort when an event is dropped (full
+	// buffer or transport failure). The daemon wires it to record a single
+	// event_sink_drop job event. It must itself be non-blocking/best-effort.
+	OnDrop func(event Event, reason string)
+}
+
+type queued struct {
+	event Event
+}
+
+// NewWebhookSink constructs a webhook Sink that POSTs events to url with a
+// bounded per-request timeout (DefaultWebhookTimeout when timeout <= 0) and
+// starts its single drain goroutine. It returns nil when url is empty so the
+// caller (the daemon) treats an unconfigured webhook as "no sink" — preserving
+// the off-by-default, byte-identical guarantee (a nil Sink is a no-op).
+func NewWebhookSink(url string, timeout time.Duration) *webhookSink {
+	if url == "" {
+		return nil
+	}
+	if timeout <= 0 {
+		timeout = DefaultWebhookTimeout
+	}
+	s := &webhookSink{
+		url:    url,
+		client: &http.Client{Timeout: timeout},
+		queue:  make(chan queued, defaultWebhookBuffer),
+	}
+	go s.drain()
+	return s
+}
+
+// Emit enqueues event for delivery and returns immediately. If the buffer is
+// full it drops the event (best-effort) rather than blocking the caller — the
+// core best-effort guarantee that a dead/slow consumer never stalls a job. ctx
+// is honored only as a courtesy: a cancelled ctx drops rather than blocks.
+func (s *webhookSink) Emit(ctx context.Context, event Event) {
+	if s == nil {
+		return
+	}
+	select {
+	case s.queue <- queued{event: event}:
+	case <-ctx.Done():
+		s.dropped(event, "context cancelled")
+	default:
+		// Buffer full: drop rather than block the caller.
+		s.dropped(event, "buffer full")
+	}
+}
+
+// drain is the single goroutine that serializes delivery. Running one goroutine
+// (rather than a goroutine per Emit) bounds outbound concurrency and keeps the
+// channel the only synchronization point, so concurrent Emit from many workers
+// is race-clean.
+func (s *webhookSink) drain() {
+	for q := range s.queue {
+		s.post(q.event)
+	}
+}
+
+func (s *webhookSink) post(event Event) {
+	body, err := json.Marshal(event)
+	if err != nil {
+		s.dropped(event, "marshal failed")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), s.client.Timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, bytes.NewReader(body))
+	if err != nil {
+		s.dropped(event, "request build failed")
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.dropped(event, "transport error")
+		return
+	}
+	defer resp.Body.Close()
+	// Drain and discard the body so the connection can be reused; the consumer's
+	// response content is irrelevant to a fire-and-forget transport.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= 400 {
+		s.dropped(event, "non-2xx response")
+	}
+}
+
+func (s *webhookSink) dropped(event Event, reason string) {
+	if s.OnDrop != nil {
+		s.OnDrop(event, reason)
+	}
+}

--- a/internal/events/webhook_test.go
+++ b/internal/events/webhook_test.go
@@ -1,0 +1,189 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWebhookSinkDeliversExactJSON(t *testing.T) {
+	received := make(chan Event, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var ev Event
+		if err := json.Unmarshal(body, &ev); err != nil {
+			t.Errorf("Unmarshal body: %v", err)
+		}
+		received <- ev
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := NewWebhookSink(srv.URL, time.Second)
+	if sink == nil {
+		t.Fatal("NewWebhookSink returned nil for a valid URL")
+	}
+	want := NewEvent(EventJobNeedsAttention, "job-1", "root-1", "jerryfane/gitmoot", "awaiting_human", "please decide", time.Now(), nil)
+	sink.Emit(context.Background(), want)
+
+	select {
+	case got := <-received:
+		if got.Type != EventJobNeedsAttention || got.JobID != "job-1" || got.RootID != "root-1" || got.Repo != "jerryfane/gitmoot" || got.Status != "awaiting_human" || got.Detail != "please decide" {
+			t.Fatalf("received event = %+v, want %+v", got, want)
+		}
+		if got.SchemaVersion != 1 {
+			t.Fatalf("schema_version = %d, want 1", got.SchemaVersion)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("webhook consumer never received the event")
+	}
+}
+
+func TestWebhookSinkNilForEmptyURL(t *testing.T) {
+	if sink := NewWebhookSink("", time.Second); sink != nil {
+		t.Fatal("NewWebhookSink(\"\") must return nil so the daemon treats it as no sink")
+	}
+}
+
+func TestWebhookSinkSlowConsumerNeverBlocksEmit(t *testing.T) {
+	// A handler that blocks well past the sink timeout proves Emit returns
+	// immediately (fire-and-forget) — the core best-effort guarantee that a hung
+	// consumer never stalls a job.
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // block until the test releases it
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	sink := NewWebhookSink(srv.URL, 50*time.Millisecond)
+	dropped := make(chan string, 4)
+	sink.OnDrop = func(_ Event, reason string) { dropped <- reason }
+
+	start := time.Now()
+	for i := 0; i < 4; i++ {
+		sink.Emit(context.Background(), NewEvent(EventJobFinished, "job", "root", "o/r", "succeeded", "", time.Now(), nil))
+	}
+	elapsed := time.Since(start)
+	// Four fire-and-forget Emits must return effectively instantly, far below the
+	// 50ms per-request timeout (let alone the handler's indefinite block).
+	if elapsed > 40*time.Millisecond {
+		t.Fatalf("Emit blocked for %s; must be fire-and-forget", elapsed)
+	}
+}
+
+func TestWebhookSinkHungHandlerDoesNotBlockBeyondTimeout(t *testing.T) {
+	// The drain goroutine bounds each POST by the http.Client timeout; a hung
+	// handler results in a transport-timeout drop, never an indefinite stall.
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	sink := NewWebhookSink(srv.URL, 50*time.Millisecond)
+	dropped := make(chan string, 1)
+	sink.OnDrop = func(_ Event, reason string) { dropped <- reason }
+	sink.Emit(context.Background(), NewEvent(EventJobFinished, "job", "root", "o/r", "succeeded", "", time.Now(), nil))
+
+	select {
+	case reason := <-dropped:
+		if reason != "transport error" {
+			t.Fatalf("drop reason = %q, want transport error (timeout)", reason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("hung handler should have produced a timeout drop")
+	}
+}
+
+func TestWebhookSinkBadStatusDropsWithoutError(t *testing.T) {
+	var dropReason atomic.Value
+	dropped := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	sink := NewWebhookSink(srv.URL, time.Second)
+	sink.OnDrop = func(_ Event, reason string) {
+		dropReason.Store(reason)
+		dropped <- struct{}{}
+	}
+	// Emit must not panic or return an error path; the job is unaffected.
+	sink.Emit(context.Background(), NewEvent(EventJobFailed, "job", "root", "o/r", "failed", "boom", time.Now(), nil))
+
+	select {
+	case <-dropped:
+		if r, _ := dropReason.Load().(string); r != "non-2xx response" {
+			t.Fatalf("drop reason = %q, want non-2xx response", r)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("500 response should have produced a drop")
+	}
+}
+
+func TestWebhookSinkRefusedConnectionDropsWithoutError(t *testing.T) {
+	// A closed server (refused connection) is a transport error: dropped, never
+	// fatal.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close() // now nothing is listening
+
+	sink := NewWebhookSink(url, 200*time.Millisecond)
+	dropped := make(chan string, 1)
+	sink.OnDrop = func(_ Event, reason string) { dropped <- reason }
+	sink.Emit(context.Background(), NewEvent(EventJobBlocked, "job", "root", "o/r", "blocked", "", time.Now(), nil))
+
+	select {
+	case reason := <-dropped:
+		if reason != "transport error" {
+			t.Fatalf("drop reason = %q, want transport error", reason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("refused connection should have produced a transport drop")
+	}
+}
+
+func TestWebhookSinkConcurrentEmitIsRaceClean(t *testing.T) {
+	var count int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&count, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := NewWebhookSink(srv.URL, time.Second)
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 8; j++ {
+				sink.Emit(context.Background(), NewEvent(EventJobFinished, "job", "root", "o/r", "succeeded", "", time.Now(), nil))
+			}
+		}()
+	}
+	wg.Wait()
+	// Give the single drain goroutine time to flush whatever fit in the buffer.
+	// We don't assert an exact count (drop-on-full is allowed); the point is the
+	// -race detector finds no data race across concurrent Emit + drain.
+	time.Sleep(200 * time.Millisecond)
+	if atomic.LoadInt64(&count) == 0 {
+		t.Fatal("expected at least some events delivered under concurrency")
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
@@ -33,6 +34,18 @@ type Engine struct {
 	// dashboard "Attention" section and the recorded event remain), only the
 	// GitHub notification is skipped. A notifier error never fails the pause.
 	EscalationNotifier EscalationNotifier
+	// EventSink is the injected, best-effort outbound event seam (#446), mirroring
+	// EscalationNotifier: when configured, the engine emits a redacted, versioned
+	// events.Event on each terminal transition it owns (job.finished on a
+	// succeeded terminal, job.needs_attention on an escalate_human pause) so an
+	// off-box consumer (a webhook) can observe the run. It is optional and
+	// nil-safe: when nil (the default, no [events] config) NO event is constructed
+	// or emitted and behavior is byte-identical. Emit is fire-and-forget and best-
+	// effort — a slow/hung/erroring sink never blocks or fails a job (see
+	// internal/events). The daemon emits the failure/blocked/awaiting-human
+	// terminal cases it owns through the SAME sink so the whole terminal set is
+	// covered. #445 (the ask-gate) rides this seam to emit its job.needs_attention.
+	EventSink events.Sink
 	// Home is the resolved GITMOOT_HOME root used to place per-delegation
 	// worktrees. DelegationWorktrees is the checkout-bound git client that
 	// performs the worktree-add. Both are optional: when either is unset, the
@@ -173,6 +186,59 @@ func (e Engine) now() time.Time {
 		return e.Now()
 	}
 	return time.Now()
+}
+
+// mailbox builds the engine's Mailbox with the best-effort terminal-event hook
+// wired to e.EventSink (#446). When EventSink is nil (the default) the hook is
+// nil too, so finishWithPayload neither constructs nor emits an event and the
+// path is byte-identical. The hook maps the terminal JobState to the event_type,
+// resolves root_id from the payload, and ships a redacted event fire-and-forget.
+func (e Engine) mailbox() Mailbox {
+	mb := Mailbox{Store: e.Store}
+	if e.EventSink == nil {
+		return mb
+	}
+	mb.emitTerminal = func(ctx context.Context, jobID string, state JobState, payload JobPayload) {
+		eventType, ok := terminalEventType(state)
+		if !ok {
+			return
+		}
+		rootID := strings.TrimSpace(payload.RootJobID)
+		if rootID == "" {
+			rootID = jobID
+		}
+		detail := ""
+		if payload.Result != nil {
+			detail = payload.Result.Summary
+		}
+		events.EmitEvent(ctx, e.EventSink, events.NewEvent(
+			eventType,
+			jobID,
+			rootID,
+			payload.Repo,
+			string(state),
+			detail,
+			e.now(),
+			RedactCommentText,
+		))
+	}
+	return mb
+}
+
+// terminalEventType maps a terminal JobState to the outbound event_type (#446).
+// Only the terminal set {succeeded,failed,blocked} maps; any other state returns
+// ok=false so no event is emitted for it.
+func terminalEventType(state JobState) (events.EventType, bool) {
+	switch state {
+	case JobSucceeded:
+		return events.EventJobFinished, true
+	case JobFailed:
+		return events.EventJobFailed, true
+	case JobBlocked:
+		return events.EventJobBlocked, true
+	default:
+		return "", false
+	}
 }
 
 type PullRequestEvent struct {
@@ -415,7 +481,7 @@ func (e Engine) RunJob(ctx context.Context, jobID string, agent runtime.Agent, a
 	if err := e.ensureJobExecutorAllowed(ctx, job, payload, taskRefFromPayload(payload)); err != nil {
 		return AgentResult{}, err
 	}
-	result, err := (Mailbox{Store: e.Store}).Run(ctx, jobID, agent, adapter)
+	result, err := e.mailbox().Run(ctx, jobID, agent, adapter)
 	if err != nil {
 		return result, err
 	}
@@ -484,7 +550,7 @@ func (e Engine) FinalizeTimedOutDelegationChild(ctx context.Context, jobID strin
 		Decision: "failed",
 		Summary:  reason,
 	}
-	mailbox := Mailbox{Store: e.Store}
+	mailbox := e.mailbox()
 	if job.State == string(JobRunning) {
 		if err := mailbox.finishWithPayload(ctx, jobID, JobFailed, reason, payload); err != nil {
 			return false, err
@@ -3919,6 +3985,28 @@ func (e Engine) pauseAwaitingHuman(ctx context.Context, parentJob db.Job, parent
 			TaskTitle:        ref.Title,
 		})
 	}
+
+	// Emit a best-effort job.needs_attention on the FRESH escalation round (#446).
+	// It is gated on the same one-shot path as the escalationRequested event above
+	// (we only reach here when the round was CLOSED), so a re-advance does NOT
+	// re-emit. nil-safe: no EventSink => no event. detail carries the redacted
+	// question. This is the seam #445's ask-gate rides to emit its own
+	// job.needs_attention. The coordinator job id is the subject so a consumer can
+	// resume the right tree; root_id groups the run.
+	rootID := strings.TrimSpace(parentPayload.RootJobID)
+	if rootID == "" {
+		rootID = parentJob.ID
+	}
+	events.EmitEvent(ctx, e.EventSink, events.NewEvent(
+		events.EventJobNeedsAttention,
+		parentJob.ID,
+		rootID,
+		firstNonEmptyString(ref.Repo, parentPayload.Repo),
+		string(TaskAwaitingHuman),
+		strings.TrimSpace(d.Prompt),
+		e.now(),
+		RedactCommentText,
+	))
 
 	return awaitErr
 }

--- a/internal/workflow/event_sink_test.go
+++ b/internal/workflow/event_sink_test.go
@@ -1,0 +1,274 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// recordingSink captures EventSink emissions for the engine best-effort tests.
+// hang, when set, makes Emit block (a slow consumer) so a test can prove the
+// engine's finish path does not deadlock holding a lock across the emit. The
+// Sink contract has no error return, so a sink can never fail a job by design.
+type recordingSink struct {
+	mu     sync.Mutex
+	events []events.Event
+	hang   chan struct{} // when non-nil, Emit blocks on it (slow consumer)
+}
+
+func (r *recordingSink) Emit(_ context.Context, event events.Event) {
+	if r.hang != nil {
+		<-r.hang
+	}
+	r.mu.Lock()
+	r.events = append(r.events, event)
+	r.mu.Unlock()
+}
+
+func (r *recordingSink) snapshot() []events.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]events.Event, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+func (r *recordingSink) byType(typ events.EventType) []events.Event {
+	var out []events.Event
+	for _, e := range r.snapshot() {
+		if e.Type == typ {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestEngineEmitsJobFinishedOnSucceededTerminal proves the engine fans a
+// job.finished out through the EventSink on the succeeded terminal transition
+// (the Mailbox.finishWithPayload chokepoint), carrying root_id/repo/status.
+func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	sink := &recordingSink{}
+	engine := testEngine(store)
+	engine.EventSink = sink
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"looks good","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:        "review-job",
+		Agent:     "audit",
+		Action:    "review",
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-9",
+		TaskID:    "task-9",
+		TaskTitle: "Review",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	if _, err := engine.RunJob(ctx, "review-job", agent, adapter); err != nil {
+		t.Fatalf("RunJob returned error: %v", err)
+	}
+
+	finished := sink.byType(events.EventJobFinished)
+	if len(finished) != 1 {
+		t.Fatalf("job.finished emissions = %d, want 1; all=%+v", len(finished), sink.snapshot())
+	}
+	ev := finished[0]
+	if ev.JobID != "review-job" || ev.RootID != "review-job" || ev.Repo != "jerryfane/gitmoot" || ev.Status != "succeeded" {
+		t.Fatalf("job.finished event = %+v", ev)
+	}
+	if ev.SchemaVersion != 1 {
+		t.Fatalf("schema_version = %d, want 1", ev.SchemaVersion)
+	}
+	if ev.Detail != "looks good" {
+		t.Fatalf("detail = %q, want the result summary", ev.Detail)
+	}
+}
+
+// TestEngineEmitsJobFailedOnFailedDecision proves a failed decision (running->
+// failed via finishWithPayload) emits job.failed, not job.finished.
+func TestEngineEmitsJobFailedOnFailedDecision(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	sink := &recordingSink{}
+	engine := testEngine(store)
+	engine.EventSink = sink
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"failed","summary":"could not finish","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:        "review-job",
+		Agent:     "audit",
+		Action:    "review",
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-9",
+		TaskID:    "task-9",
+		TaskTitle: "Review",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	// A failed decision terminates the job failed; the running->failed transition
+	// (and its emit) happens inside Mailbox.finishWithPayload regardless of whether
+	// the subsequent advance returns an error, so the emit is what we assert.
+	_, _ = engine.RunJob(ctx, "review-job", agent, adapter)
+	job := mustJob(t, store, "review-job")
+	if job.State != string(JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+
+	if got := sink.byType(events.EventJobFinished); len(got) != 0 {
+		t.Fatalf("job.finished emissions = %d, want 0 for a failed decision", len(got))
+	}
+	failed := sink.byType(events.EventJobFailed)
+	if len(failed) != 1 {
+		t.Fatalf("job.failed emissions = %d, want 1; all=%+v", len(failed), sink.snapshot())
+	}
+	if failed[0].Status != "failed" || failed[0].Detail != "could not finish" {
+		t.Fatalf("job.failed event = %+v", failed[0])
+	}
+}
+
+// TestEngineEmitsNeedsAttentionOnEscalateHumanPause proves the escalate_human
+// pause fans a job.needs_attention out carrying the redacted question in detail,
+// rooted at the coordinator.
+func TestEngineEmitsNeedsAttentionOnEscalateHumanPause(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	sink := &recordingSink{}
+	engine := testEngine(store)
+	engine.EventSink = sink
+
+	seedEscalateHumanCoordinator(t, store, engine)
+
+	err := engine.AdvanceJob(ctx, "parent-job/delegation/api")
+	var awaiting AwaitingHumanError
+	if !errors.As(err, &awaiting) {
+		t.Fatalf("AdvanceJob(api) error = %v, want AwaitingHumanError", err)
+	}
+
+	attention := sink.byType(events.EventJobNeedsAttention)
+	if len(attention) != 1 {
+		t.Fatalf("job.needs_attention emissions = %d, want 1; all=%+v", len(attention), sink.snapshot())
+	}
+	ev := attention[0]
+	if ev.JobID != "parent-job" || ev.RootID != "parent-job" || ev.Status != string(TaskAwaitingHuman) {
+		t.Fatalf("needs_attention event = %+v", ev)
+	}
+	if ev.Detail != "build api" {
+		t.Fatalf("detail = %q, want the escalation question", ev.Detail)
+	}
+}
+
+// TestEngineNeedsAttentionEmitIsOneShot proves a re-advance of the failing leg
+// (idempotent re-pause) does NOT re-emit job.needs_attention, mirroring the
+// one-shot escalationRequested event.
+func TestEngineNeedsAttentionEmitIsOneShot(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	sink := &recordingSink{}
+	engine := testEngine(store)
+	engine.EventSink = sink
+
+	seedEscalateHumanCoordinator(t, store, engine)
+
+	for i := 0; i < 2; i++ {
+		_ = engine.AdvanceJob(ctx, "parent-job/delegation/api")
+	}
+	if got := sink.byType(events.EventJobNeedsAttention); len(got) != 1 {
+		t.Fatalf("job.needs_attention emissions after re-advance = %d, want 1 (one-shot)", len(got))
+	}
+}
+
+// TestEngineNilSinkIsByteIdentical proves the off-by-default path: with no
+// EventSink, a terminal transition succeeds exactly as before and no event is
+// constructed (no panic, the job still reaches its terminal state).
+func TestEngineNilSinkIsByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store) // no EventSink
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:     "review-job",
+		Agent:  "audit",
+		Action: "review",
+		Repo:   "jerryfane/gitmoot",
+		Branch: "task-9",
+		TaskID: "task-9",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if _, err := engine.RunJob(ctx, "review-job", agent, adapter); err != nil {
+		t.Fatalf("RunJob with nil EventSink returned error: %v", err)
+	}
+	job := mustJob(t, store, "review-job")
+	if job.State != string(JobSucceeded) {
+		t.Fatalf("job state = %q, want succeeded", job.State)
+	}
+}
+
+// TestEngineSlowSinkNeverBlocksFinish proves a slow sink (Emit blocks) never
+// stalls the engine beyond the test's own release: we run RunJob in a goroutine
+// and assert the terminal transition is durable even while Emit is hung, then
+// release. (The real webhook sink is non-blocking; this guards a misbehaving
+// in-process sink from wedging the engine's finish path indefinitely is the
+// SINK's contract — here we verify the engine does not deadlock holding a lock
+// across the emit.)
+func TestEngineSlowSinkDoesNotDeadlockEngine(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	hang := make(chan struct{})
+	sink := &recordingSink{hang: hang}
+	engine := testEngine(store)
+	engine.EventSink = sink
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:     "review-job",
+		Agent:  "audit",
+		Action: "review",
+		Repo:   "jerryfane/gitmoot",
+		Branch: "task-9",
+		TaskID: "task-9",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := engine.RunJob(ctx, "review-job", agent, adapter)
+		done <- err
+	}()
+
+	// Release the hung Emit promptly; the engine must complete cleanly afterwards.
+	close(hang)
+	if err := <-done; err != nil {
+		t.Fatalf("RunJob with slow sink returned error: %v", err)
+	}
+	if got := sink.byType(events.EventJobFinished); len(got) != 1 {
+		t.Fatalf("job.finished emissions = %d, want 1", len(got))
+	}
+}

--- a/internal/workflow/event_sink_test.go
+++ b/internal/workflow/event_sink_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -136,6 +137,105 @@ func TestEngineEmitsJobFailedOnFailedDecision(t *testing.T) {
 	}
 	if failed[0].Status != "failed" || failed[0].Detail != "could not finish" {
 		t.Fatalf("job.failed event = %+v", failed[0])
+	}
+}
+
+// TestEngineEmitsJobFailedOnDeliveryFailure proves the most common failure mode
+// — a runtime delivery error that never produces a parseable result — emits
+// exactly one job.failed. This exercises the m.fail -> m.finish path (NOT
+// finishWithPayload), the gap the #446 review found: finish now carries the
+// emit symmetrically, so a delivery failure is no longer silently dropped.
+func TestEngineEmitsJobFailedOnDeliveryFailure(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	sink := &recordingSink{}
+	engine := testEngine(store)
+	engine.EventSink = sink
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	// A delivery error: Deliver returns an error, so Mailbox.Run takes the m.fail
+	// branch and never reaches finishWithPayload.
+	adapter := &fakeDelivery{err: errors.New("codex transport failure")}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:        "review-job",
+		Agent:     "audit",
+		Action:    "review",
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-9",
+		TaskID:    "task-9",
+		TaskTitle: "Review",
+		RootJobID: "root-9",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	// RunJob returns the delivery error; the running->failed transition (and its
+	// emit) happens inside Mailbox.fail -> finish regardless.
+	if _, err := engine.RunJob(ctx, "review-job", agent, adapter); err == nil {
+		t.Fatalf("RunJob with a delivery error returned nil, want the delivery error")
+	}
+	job := mustJob(t, store, "review-job")
+	if job.State != string(JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+
+	if got := sink.byType(events.EventJobFinished); len(got) != 0 {
+		t.Fatalf("job.finished emissions = %d, want 0 for a delivery failure", len(got))
+	}
+	failed := sink.byType(events.EventJobFailed)
+	if len(failed) != 1 {
+		t.Fatalf("job.failed emissions = %d, want exactly 1; all=%+v", len(failed), sink.snapshot())
+	}
+	ev := failed[0]
+	if ev.JobID != "review-job" || ev.RootID != "root-9" || ev.Repo != "jerryfane/gitmoot" || ev.Status != "failed" {
+		t.Fatalf("job.failed event = %+v", ev)
+	}
+	// The transition message ("delivery failed: ...") is surfaced as the detail
+	// since the failed delivery left no result to summarize.
+	if !strings.Contains(ev.Detail, "delivery failed") {
+		t.Fatalf("detail = %q, want it to carry the delivery-failure message", ev.Detail)
+	}
+}
+
+// TestEngineEmitsJobFailedOnMalformedOutputAfterRepair proves the second
+// finish-path failure mode — a parse failure that survives the repair retry —
+// also emits exactly one job.failed (parse error, not delivery error).
+func TestEngineEmitsJobFailedOnMalformedOutputAfterRepair(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	sink := &recordingSink{}
+	engine := testEngine(store)
+	engine.EventSink = sink
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	// Two un-parseable outputs: the first triggers the repair retry, the second
+	// (also malformed) drives m.fail -> finish with a parse error.
+	adapter := &fakeDelivery{outputs: []string{"not json", "still not json"}}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:        "review-job",
+		Agent:     "audit",
+		Action:    "review",
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-9",
+		TaskID:    "task-9",
+		TaskTitle: "Review",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	if _, err := engine.RunJob(ctx, "review-job", agent, adapter); err == nil {
+		t.Fatalf("RunJob with malformed output returned nil, want a parse error")
+	}
+	job := mustJob(t, store, "review-job")
+	if job.State != string(JobFailed) {
+		t.Fatalf("job state = %q, want failed", job.State)
+	}
+	failed := sink.byType(events.EventJobFailed)
+	if len(failed) != 1 {
+		t.Fatalf("job.failed emissions = %d, want exactly 1; all=%+v", len(failed), sink.snapshot())
+	}
+	if got := sink.byType(events.EventJobFinished); len(got) != 0 {
+		t.Fatalf("job.finished emissions = %d, want 0 for a malformed-output failure", len(got))
 	}
 }
 

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -16,6 +16,14 @@ import (
 
 type Mailbox struct {
 	Store *db.Store
+	// emitTerminal, when set, is called best-effort AFTER a genuine running->
+	// terminal transition in finishWithPayload (#446). It is the single
+	// chokepoint the engine uses to emit job.finished/job.failed/job.blocked, so
+	// the success/advance path and the timeout-finalize path both fan out exactly
+	// once. It is nil-safe: when unset (the default, no EventSink configured) no
+	// event is constructed or emitted and behavior is byte-identical. The hook is
+	// fire-and-forget — it must never block or fail the finish.
+	emitTerminal func(ctx context.Context, jobID string, state JobState, payload JobPayload)
 }
 
 type JobRequest struct {
@@ -367,6 +375,12 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 			return getErr
 		}
 		return fmt.Errorf("job %q is %s, not running", jobID, latest.State)
+	}
+	// Best-effort outbound emit on the genuine running->terminal transition only
+	// (#446). Gated on transitioned==true so a re-run never double-emits; nil-safe
+	// so the default (no EventSink) path is byte-identical.
+	if m.emitTerminal != nil {
+		m.emitTerminal(ctx, jobID, state, payload)
 	}
 	return nil
 }

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -17,11 +17,14 @@ import (
 type Mailbox struct {
 	Store *db.Store
 	// emitTerminal, when set, is called best-effort AFTER a genuine running->
-	// terminal transition in finishWithPayload (#446). It is the single
-	// chokepoint the engine uses to emit job.finished/job.failed/job.blocked, so
-	// the success/advance path and the timeout-finalize path both fan out exactly
-	// once. It is nil-safe: when unset (the default, no EventSink configured) no
-	// event is constructed or emitted and behavior is byte-identical. The hook is
+	// terminal transition in BOTH finishWithPayload (success/advance + timeout-
+	// finalize) and finish (the m.fail delivery/parse-failure path) (#446). Wiring
+	// both is what makes the whole terminal set fan out exactly once: the
+	// success/advance path emits job.finished, and the most common failure mode —
+	// a runtime delivery error, timeout, or malformed-output-after-repair — emits
+	// job.failed/job.blocked through finish rather than being silently dropped. It
+	// is nil-safe: when unset (the default, no EventSink configured) no event is
+	// constructed or emitted and behavior is byte-identical. The hook is
 	// fire-and-forget — it must never block or fail the finish.
 	emitTerminal func(ctx context.Context, jobID string, state JobState, payload JobPayload)
 }
@@ -349,7 +352,43 @@ func (m Mailbox) finish(ctx context.Context, jobID string, state JobState, messa
 		}
 		return fmt.Errorf("job %q is %s, not running", jobID, latest.State)
 	}
+	// Best-effort outbound emit on the genuine running->terminal transition, wired
+	// symmetrically with finishWithPayload (#446). m.fail (delivery failure,
+	// malformed-output-after-repair) reaches a terminal state through THIS path,
+	// not finishWithPayload, so without this the most common runtime failure mode
+	// silently never emits job.failed/job.blocked. finish has no payload arg, so
+	// load the stored one for full root_id/repo; when it carries no Result (the
+	// usual delivery-failure case) synthesize a transient one from the transition
+	// message so detail is a meaningful, redacted failure summary. Gated on
+	// transitioned==true (fires exactly once) and nil-safe (no EventSink => no-op,
+	// byte-identical). The load failure degrades gracefully to an id-rooted emit
+	// rather than dropping the event or failing the finish.
+	if m.emitTerminal != nil {
+		payload := m.loadTerminalEmitPayload(ctx, jobID, message)
+		m.emitTerminal(ctx, jobID, state, payload)
+	}
 	return nil
+}
+
+// loadTerminalEmitPayload loads the stored payload for a finish-path terminal
+// emit, ensuring a non-nil Result so the emit detail carries a failure summary.
+// A delivery/parse failure transitions via finish without a stored Result; the
+// transition message (e.g. "delivery failed: ...") is the only failure context,
+// so synthesize a transient Result from it (in-memory only — never persisted).
+// On any load error it returns a minimal payload so the emit still fires.
+func (m Mailbox) loadTerminalEmitPayload(ctx context.Context, jobID, message string) JobPayload {
+	job, err := m.Store.GetJob(ctx, jobID)
+	if err != nil {
+		return JobPayload{Result: &AgentResult{Summary: strings.TrimSpace(message)}}
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		return JobPayload{Result: &AgentResult{Summary: strings.TrimSpace(message)}}
+	}
+	if payload.Result == nil {
+		payload.Result = &AgentResult{Summary: strings.TrimSpace(message)}
+	}
+	return payload
 }
 
 func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobState, message string, payload JobPayload) error {

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -1,0 +1,130 @@
+# Outbound Event Stream (`[events]`)
+
+Gitmoot can push a small, versioned, redacted JSON event to one HTTP endpoint
+whenever a job reaches a terminal state or pauses awaiting a human. This is an
+**off-by-default, best-effort** outbound seam (#446): with no `[events]` config
+nothing is constructed and behavior is byte-identical to a build without it.
+
+It complements — it does not replace — the existing observability surfaces
+(`gitmoot job watch`, the local dashboard, PR comments). The typed lifecycle
+events recorded in SQLite (`job_events`) are unchanged; this is an additional
+fan-out, not a migration.
+
+## What it emits
+
+The pilot emits a tight allowlist of event types over the webhook transport:
+
+| `event_type`           | When                                                              |
+| ---------------------- | ---------------------------------------------------------------- |
+| `job.finished`         | a job reaches the `succeeded` terminal state                     |
+| `job.failed`           | a job reaches the `failed` terminal state                        |
+| `job.blocked`          | a job reaches the `blocked` terminal state                       |
+| `job.needs_attention`  | a tree pauses awaiting a human (the `escalate_human` pause today) |
+
+Each terminal transition emits **exactly once**. The engine owns the
+succeeded/failed/blocked emit on its `Mailbox` terminal path; the daemon owns the
+pre-flight (`queued -> failed|blocked`) and permission-blocked cases that never
+pass through that path. `job.needs_attention` is emitted once per fresh
+escalation round (a re-advance does not re-emit).
+
+The following `event_type` values are **reserved** for the graduate step. They
+are enumerated in the contract so a consumer can `switch` over them
+forward-compatibly without a schema bump when they start arriving, but the pilot
+does **not** emit them: `job.started`, `delegation.escalation`,
+`delegation.finalized`, `orchestration.finished`.
+
+## The event contract (`schema_version = 1`)
+
+Every event is a single JSON object:
+
+```json
+{
+  "schema_version": 1,
+  "event_type": "job.finished",
+  "job_id": "implement-task-7",
+  "root_id": "coordinator-job-id",
+  "repo": "owner/repo",
+  "status": "succeeded",
+  "ts": "2026-06-16T12:00:00Z",
+  "detail": "Opened PR #42"
+}
+```
+
+| Field            | Type   | Notes                                                                       |
+| ---------------- | ------ | --------------------------------------------------------------------------- |
+| `schema_version` | int    | Contract version. Currently `1`. A breaking field change bumps it.          |
+| `event_type`     | string | The enum above.                                                             |
+| `job_id`         | string | Opaque job id this event is about.                                          |
+| `root_id`        | string | The coordination tree's root id, so a consumer can aggregate a run client-side. |
+| `repo`           | string | `owner/repo` only — never an absolute checkout path.                        |
+| `status`         | string | Terminal/lifecycle state (`succeeded`/`failed`/`blocked`/`awaiting_human`). |
+| `ts`             | string | RFC3339 emit time.                                                          |
+| `detail`         | string | Short redacted human-facing string (failure summary, the escalation question). |
+
+There is **no** synthetic `orchestration.finished` in the pilot — every event
+carries `root_id`, so a consumer groups a run client-side. Server-side
+tree-convergence aggregation is a documented graduate item.
+
+## Redaction
+
+Every outbound string field is redacted at event construction through the same
+redactor Gitmoot uses for off-box PR/issue comments and bug reports
+(`workflow.RedactCommentText`): GitHub tokens, OpenAI keys, AWS secrets, and
+`api_key`/`token`/`secret`/`password` assignments are replaced with
+`[REDACTED]`. `repo` is reduced to `owner/repo` only. No absolute paths, raw
+runtime output, or secrets leave the box.
+
+## Best-effort delivery
+
+Delivery is **fire-and-forget**. A slow, hung, erroring, or full consumer never
+blocks or fails a job — this mirrors the `escalate_human` notifier contract:
+
+- Each event is handed to a small buffered channel drained by **one** background
+  goroutine, so concurrent emits from many workers serialize cleanly.
+- Each POST is bounded by `[events].timeout` (default `2s`). A hung consumer
+  times out and the event is dropped.
+- On a full buffer, a transport error, or a non-2xx response the event is
+  **dropped** and a single best-effort `event_sink_drop` job event is recorded
+  locally (so a drop is observable without coupling delivery to the job).
+
+There is **no** outbox / retry in the pilot: at-least-once delivery and an
+outbox table are the explicit graduate step.
+
+## Configuration
+
+Add an `[events]` section to the Gitmoot config file:
+
+```toml
+[events]
+# The single endpoint each event is POSTed to as application/json.
+# Empty (the default) means the event stream is OFF: no sink, no goroutine,
+# no emits, byte-identical behavior.
+webhook_url = "https://example.com/gitmoot-events"
+
+# Per-POST timeout (Go duration). Default 2s. Bounds a hung consumer.
+timeout = "2s"
+
+# RESERVED for the graduate Unix-socket transport. Parsed and validated but
+# UNUSED by the pilot (webhook-only).
+# socket_path = "/run/gitmoot/events.sock"
+```
+
+| Key           | Default | Meaning                                                          |
+| ------------- | ------- | ---------------------------------------------------------------- |
+| `webhook_url` | `""`    | HTTP(S) endpoint. Empty = OFF.                                   |
+| `timeout`     | `2s`    | Per-POST timeout (Go duration). Must be positive.               |
+| `socket_path` | `""`    | Reserved for the graduate Unix-socket transport (unused today). |
+
+`webhook_url` must be an `http://` or `https://` URL. An invalid `timeout`
+duration or a non-http(s) URL is rejected at config load.
+
+## Graduate (go/no-go)
+
+The pilot validates the contract and the best-effort guarantee with the least
+scaffolding. The following are out of scope and gated behind an explicit go/no-go
+on the tracking issue:
+
+- The Unix-socket transport (`socket_path`), behind the same `Sink` seam.
+- More event types (`job.started`, `delegation.*`, `orchestration.finished`).
+- An outbox table for at-least-once / durable delivery.
+- A server-side synthetic `orchestration.finished` (reliable tree convergence).

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -71,8 +71,12 @@ Every outbound string field is redacted at event construction through the same
 redactor Gitmoot uses for off-box PR/issue comments and bug reports
 (`workflow.RedactCommentText`): GitHub tokens, OpenAI keys, AWS secrets, and
 `api_key`/`token`/`secret`/`password` assignments are replaced with
-`[REDACTED]`. `repo` is reduced to `owner/repo` only. No absolute paths, raw
-runtime output, or secrets leave the box.
+`[REDACTED]`. The `detail` field is then additionally scrubbed of absolute
+filesystem paths — host home layout, checkout and worktree paths embedded in
+pre-flight failure detail (e.g. `git worktree add /root/.gitmoot/...`) collapse
+to `<path>` — so host layout and usernames never leak. `repo` is reduced to
+`owner/repo` only. No absolute paths, raw runtime output, or secrets leave the
+box.
 
 ## Best-effort delivery
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -46,6 +46,7 @@ const sidebars: SidebarsConfig = {
         'reference/cli',
         'reference/runtime-adapters',
         'reference/result-contract',
+        'reference/event-stream',
         'reference/skillopt-exchange-contract',
       ],
     },


### PR DESCRIPTION
## Summary

Adds the keystone outbound-event seam (#446): a typed, versioned, best-effort `EventSink` that the workflow engine and daemon call from the terminal-transition path to fan a redacted JSON event out to one configured transport (the pilot ships a webhook). This is the seam #445 (the ask-gate) will emit its `job.needs_attention` through.

- **New `internal/events` package**: `Sink` interface + redacted `Event` contract (`schema_version=1`, `event_type` enum, `job_id`, `root_id`, `repo`, `status`, `ts`, `detail`) + `NewEvent` constructor (redaction injected, no workflow import) + a `webhookSink` (buffered channel + single drain goroutine, bounded `http.Client` timeout, POST `application/json`, fire-and-forget, drop-on-full/-error).
- **Engine** (`internal/workflow`): nil-safe `EventSink` field mirroring `EscalationNotifier`; emits `job.finished`/`job.failed`/`job.blocked` on the single `Mailbox.finishWithPayload` genuine-transition chokepoint (covers normal decisions + timeout-finalize) and `job.needs_attention` on the `escalate_human` pause (one-shot).
- **Daemon** (`internal/cli`): constructs a process-global shared webhook sink from `[events]` policy and wires `engine.EventSink`; emits the pre-flight `queued -> failed|blocked` (`finishQueuedJob`) and permission-blocked `running -> blocked` cases the engine path does not own. Dropped emits record a best-effort `event_sink_drop` job event.
- **Config** (`internal/config`): new `[events]` section (`webhook_url`, `timeout` default 2s, reserved `socket_path`) via the existing `applyXField`/`validateX`/`DefaultX`/`LoadX` parser pattern.
- **Docs** in BOTH trees (`docs/events.md` + `website/docs/reference/event-stream.md` + sidebar).

## Invariants enforced

- **OFF by default**: no `[events]` config => nil sink, no goroutine, no emits, byte-identical behavior.
- **Best-effort**: a slow / hung / erroring / full consumer never blocks or fails a job (bounded timeout, drop-on-full). Mirrors the `EscalationNotifier` contract.
- **No import cycle**: `internal/events` never imports `internal/workflow`; the redact func (`workflow.RedactCommentText`) is injected.
- **Exactly once** per terminal transition: engine owns the `Mailbox` chokepoint emits, daemon owns the pre-flight/permission-blocked emits, each gated on a genuine transition — no double-emit across `Mailbox.finish*` / `finishQueuedJob` / `handleRunJobError`.
- **Redacted**: every outbound string through `RedactCommentText`; `repo` is `owner/repo` only; no absolute paths/secrets/raw output leave the box.
- **Versioned**: `schema_version=1`; reserved enum values (`job.started`, `delegation.*`, `orchestration.finished`) listed for graduate.

## Test evidence

Full gate green in the worktree:

```
go build ./...            # OK
go vet ./...              # OK
go test ./...             # OK (all packages)
go test -race ./internal/workflow/ ./internal/cli/ ./internal/events/ ./internal/config/   # OK
```

New tests:
- `internal/events`: contract JSON shape/enum/`schema_version`, `NewEvent` redaction + owner/repo-only, nil-sink no-op; httptest webhook delivers exact JSON, slow/hung handler never blocks `Emit` past timeout, 500 / refused-connection dropped without error, `-race` concurrent emit.
- `internal/config`: `[events]` defaults (disabled), webhook+timeout parse, invalid-timeout / non-http URL rejected, `[events]` does not bleed into `[orchestrate]`.
- `internal/workflow`: recording sink captures `job.finished` (succeeded) / `job.failed` (failed decision) / `job.needs_attention` (escalate_human, one-shot); nil-sink byte-identical; slow sink does not deadlock the engine.
- `internal/cli`: `finishQueuedJob` emits `job.failed`/`job.blocked` on a genuine transition, nil-sink byte-identical, no-transition does not emit.

## Go/no-go for graduate

Deferred (behind the same `Sink` seam): the Unix-socket transport (`socket_path`), more event types, an outbox for at-least-once delivery, and a server-side synthetic `orchestration.finished`. The pilot keeps `root_id` on every event so consumers aggregate a run client-side today.

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)