### PR TITLE
fix(events): event stream never fired due to home double-resolution (#446)

### DIFF
--- a/internal/cli/event_sink.go
+++ b/internal/cli/event_sink.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -75,14 +77,26 @@ func buildDaemonEventSink(store *db.Store, home string) events.Sink {
 // disabled default when the home or config cannot be resolved/parsed so the
 // event stream stays OFF rather than erroring the daemon.
 func loadEventsPolicy(home string) (config.EventsPolicy, error) {
-	if strings.TrimSpace(home) == "" {
+	home = strings.TrimSpace(home)
+	if home == "" {
 		return config.DefaultEventsPolicy(), nil
 	}
-	paths, err := initializedPaths(home)
-	if err != nil {
-		return config.DefaultEventsPolicy(), nil
+	// The daemon resolves `home` to two different shapes depending on the call
+	// path: jobWorker.workflowHome() yields the already-resolved <home>/.gitmoot
+	// ROOT, while the registered-repo supervisor passes the RAW --home value — and
+	// both flow into daemonWorkflowEngine -> daemonEventSink. Resolve robustly to
+	// the config.toml for EITHER shape, WITHOUT re-running pathsFromFlag/
+	// initializedPaths (which appended ".gitmoot" a SECOND time, read a phantom
+	// .gitmoot/.gitmoot/config.toml that has no [events] section, and even created
+	// that phantom home — leaving the event stream silently always-off even when
+	// [events].webhook_url was set; #446 regression caught by a live E2E).
+	cfg := filepath.Join(home, config.ConfigName)
+	if _, err := os.Stat(cfg); err != nil {
+		// `home` was the raw --home (no config.toml directly under it); append the
+		// .gitmoot dir as PathsForHome would. Side-effect-free (no Initialize).
+		cfg = config.PathsForHome(home).ConfigFile
 	}
-	return config.LoadEventsPolicy(paths)
+	return config.LoadEventsPolicy(config.Paths{ConfigFile: cfg})
 }
 
 // daemonTerminalEventType maps a daemon-owned terminal JobState to the outbound

--- a/internal/cli/event_sink_resolve_test.go
+++ b/internal/cli/event_sink_resolve_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+)
+
+// Regression for #446: the daemon resolves the [events] policy from the ALREADY-
+// resolved home ROOT (config.Paths.Home) that the engine factory passes in
+// (daemonWorkflowEngine / jobWorker.workflowHome both yield paths.Home). A prior
+// bug re-appended ".gitmoot" via pathsFromFlag/initializedPaths, reading (and
+// initializing) a phantom .gitmoot/.gitmoot/config.toml that has no [events]
+// section, so the webhook sink was never built even when [events].webhook_url was
+// set — the event stream was silently always-off. These tests exercise the REAL
+// home resolution (no EventSinkOverride), which the prior unit tests bypassed.
+func TestBuildDaemonEventSinkFromResolvedHomeRoot(t *testing.T) {
+	home := t.TempDir()
+	root := config.PathsForHome(home).Home // <home>/.gitmoot
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(root, config.ConfigName)
+	if err := os.WriteFile(cfg, []byte("[events]\nwebhook_url = \"http://127.0.0.1:9/\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sink := buildDaemonEventSink(nil, root)
+	if sink == nil {
+		t.Fatalf("expected a non-nil sink for a configured [events].webhook_url at %s", cfg)
+	}
+	// The buggy double-resolution would have created (and read) this phantom dir.
+	if _, err := os.Stat(filepath.Join(root, config.DirName)); err == nil {
+		t.Fatalf("phantom doubled home %s must not be created", filepath.Join(root, config.DirName))
+	}
+}
+
+func TestBuildDaemonEventSinkDisabledWithoutEventsSection(t *testing.T) {
+	home := t.TempDir()
+	root := config.PathsForHome(home).Home
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, config.ConfigName), []byte("[orchestrate]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if sink := buildDaemonEventSink(nil, root); sink != nil {
+		t.Fatal("expected nil sink when [events] is absent (off by default)")
+	}
+}
+
+// The registered-repo supervisor path passes the RAW --home (not the resolved
+// .gitmoot root) into daemonWorkflowEngine -> daemonEventSink, so the resolver
+// must also build the sink correctly from a raw --home, without creating a
+// phantom doubled home.
+func TestBuildDaemonEventSinkFromRawHome(t *testing.T) {
+	home := t.TempDir() // a raw --home value
+	root := config.PathsForHome(home).Home
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, config.ConfigName), []byte("[events]\nwebhook_url = \"http://127.0.0.1:9/\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sink := buildDaemonEventSink(nil, home)
+	if sink == nil {
+		t.Fatal("expected a non-nil sink when passed the raw --home")
+	}
+	if _, err := os.Stat(filepath.Join(root, config.DirName)); err == nil {
+		t.Fatalf("phantom doubled home %s must not be created", filepath.Join(root, config.DirName))
+	}
+}


### PR DESCRIPTION
## What

The off-by-default outbound event stream shipped in #446 **never fired in production**, even when `[events].webhook_url` was configured. This fixes the home resolution and adds regression tests that exercise the real (non-mocked) path.

## Root cause

The daemon constructs the workflow engine from two different `home` shapes:
- `jobWorker.workflowHome()` → the already-resolved `<home>/.gitmoot` **root**
- the registered-repo supervisor (`defaultRegisteredRepoPoller`) → the **raw** `--home`

Both flow into `daemonWorkflowEngine` → `daemonEventSink` → `loadEventsPolicy`, which re-resolved its argument via `initializedPaths` → `pathsFromFlag`, appending `.gitmoot` a **second** time. It then read (and `Initialize`-created) a phantom `<home>/.gitmoot/.gitmoot/config.toml` with no `[events]` section → `policy.Enabled()` false → **nil sink** → no events.

The existing unit tests passed because they inject `EventSinkOverride` and bypass home resolution entirely — so the integration gap was invisible.

## Fix

`loadEventsPolicy` now resolves the `config.toml` robustly for **either** home shape, side-effect-free (no `Initialize`, no phantom dir). New regression tests in `event_sink_resolve_test.go` cover: resolved-root home, raw `--home`, and the disabled (no `[events]`) default — exercising the real resolution path.

## Validation (live E2E)

Built from `main`, ran a daemon in a throwaway home with `[events].webhook_url` set and a deterministic shell-runtime agent. **Before:** zero POSTs. **After:**
```
{"schema_version":1,"event_type":"job.finished","status":"succeeded",...}
{"schema_version":1,"event_type":"job.needs_attention","status":"awaiting_human","detail":"- q1: Proceed to deploy? (choices: yes, no)"}
```
(The same E2E also validated #439 verify→replan and #445 ask-gate pause + emit.)

## Follow-up (separate issue to file)

This change makes the **event-sink** path robust, but the underlying inconsistency — `daemonWorkflowEngine` receiving `home` in two different shapes, which also affects `engine.ArtifactRoot` and leaves a phantom `.gitmoot/.gitmoot` created on the escalation path — should be normalized in its own change. Filing separately.

Closes #446 (the event stream now functions end-to-end).