### PR TITLE
fix(daemon): kill phantom .gitmoot/.gitmoot from home-convention mismatch (#459)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1071,7 +1071,9 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			NextPoll:    map[string]time.Time{},
 			ErrorStreak: map[string]int{},
 		}
-		poller := defaultRegisteredRepoPoller(store, workers, dryRun, stdout, paths.Home)
+		// rawHome (the function's own param) feeds the read-only policy loaders;
+		// paths.Home (the resolved <home>/.gitmoot root) feeds the engine wiring (#459).
+		poller := defaultRegisteredRepoPoller(store, workers, dryRun, stdout, home, paths.Home)
 		poller.WatchIssues = watchIssues
 		blobStore := artifact.NewStore(paths.ArtifactBlobs)
 		reviewGitHub := newSkillOptGitHubClient()
@@ -1271,7 +1273,7 @@ func (l *repoCheckoutLocks) For(repo string) *sync.Mutex {
 }
 
 func pollRegisteredRepos(ctx context.Context, store *db.Store, workers int, dryRun bool, stdout io.Writer, nextPoll map[string]time.Time, now time.Time, fallbackPoll time.Duration) (time.Duration, error) {
-	return pollRegisteredReposWithPoller(ctx, defaultRegisteredRepoPoller(store, workers, dryRun, stdout, ""), registeredRepoSchedule{NextPoll: nextPoll}, now, fallbackPoll)
+	return pollRegisteredReposWithPoller(ctx, defaultRegisteredRepoPoller(store, workers, dryRun, stdout, "", ""), registeredRepoSchedule{NextPoll: nextPoll}, now, fallbackPoll)
 }
 
 type registeredRepoSchedule struct {
@@ -1302,22 +1304,39 @@ type registeredRepoPoller struct {
 	WorkflowFactory func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
 }
 
-func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdout io.Writer, home string) registeredRepoPoller {
+// defaultRegisteredRepoPoller wires the registered-repo supervisor's per-tick
+// poller. It takes TWO home values with DISTINCT, documented shapes (#459):
+//
+//   - rawHome: the RAW --home (NOT <home>/.gitmoot). It feeds the READ-ONLY policy
+//     loaders — resolveEscalationTTL and jobWorker.ConfigHome (orchestratePolicy) —
+//     each of which resolves it to the config.toml exactly once. Passing a resolved
+//     root here would re-append ".gitmoot" inside those loaders and create the
+//     phantom <home>/.gitmoot/.gitmoot.
+//   - resolvedRoot: the already-resolved <home>/.gitmoot root (config.Paths.Home).
+//     It feeds the engine wiring — daemonWorkflowEngine's ArtifactRoot/Home and
+//     daemonEventSink — which expect the resolved root and do NOT re-resolve.
+//
+// The legacy/test caller (pollRegisteredRepos) passes "" for both, which is a
+// no-op: resolveEscalationTTL("") returns the default and daemonWorkflowEngine("")
+// leaves ArtifactRoot/Home/EventSink unset.
+func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdout io.Writer, rawHome, resolvedRoot string) registeredRepoPoller {
 	return registeredRepoPoller{
 		Store:         store,
 		Workers:       workers,
 		DryRun:        dryRun,
 		Stdout:        stdout,
-		EscalationTTL: resolveEscalationTTL(home),
+		EscalationTTL: resolveEscalationTTL(rawHome),
 		GitHubClient:  func(checkout string) github.Client { return github.NewClient(checkout) },
 		WorkflowFactory: func(store *db.Store, gh github.Client, checkout string) *workflow.Engine {
-			engine := daemonWorkflowEngine(store, gh, checkout, home)
+			engine := daemonWorkflowEngine(store, gh, checkout, resolvedRoot)
 			// Apply only the escalate_human notifier handle from policy (#340),
 			// keeping the budget/inlining knobs out of this path so its existing
 			// behavior is unchanged. The notifier itself is already wired by
 			// daemonWorkflowEngine; this just sets the configured @-handle.
+			// orchestratePolicy reads via jobWorker.ConfigHome, which is ALWAYS the
+			// RAW --home (#459) so it never re-resolves into a phantom doubled home.
 			if notifier, ok := engine.EscalationNotifier.(*daemonEscalationNotifier); ok && notifier != nil {
-				if policy, err := defaultJobWorker(store, stdout, home).orchestratePolicy(); err == nil {
+				if policy, err := defaultJobWorker(store, stdout, rawHome).orchestratePolicy(); err == nil {
 					notifier.Handle = policy.EscalationHandle
 				}
 			}
@@ -1329,13 +1348,20 @@ func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdo
 // resolveEscalationTTL reads the [orchestrate].escalation_ttl policy (#340),
 // falling back to DefaultEscalationTTL when unset and to 0 (scan disabled) only
 // on a hard parse failure, so the auto-finalize backstop is on by default.
+//
+// It is READ-ONLY and shape-tolerant (#459): it resolves the config.toml for
+// EITHER a raw --home or an already-resolved <home>/.gitmoot root via
+// resolveConfigFile, then LoadOrchestratePolicy (which only ReadFile-s, never
+// MkdirAll-s). It MUST NOT call initializedPaths/config.Initialize: the real home
+// is already initialized upstream by withStore/withStoreAndPaths, and Initializing
+// here on a resolved root would re-append ".gitmoot" and create the phantom
+// <home>/.gitmoot/.gitmoot. Being side-effect-free makes it phantom-free even if a
+// caller hands it the resolved root by mistake — defense in depth.
 func resolveEscalationTTL(home string) time.Duration {
 	policy := config.DefaultOrchestratePolicy()
-	if strings.TrimSpace(home) != "" {
-		if paths, err := initializedPaths(home); err == nil {
-			if loaded, err := config.LoadOrchestratePolicy(paths); err == nil {
-				policy = loaded
-			}
+	if cfg := resolveConfigFile(home); cfg != "" {
+		if loaded, err := config.LoadOrchestratePolicy(config.Paths{ConfigFile: cfg}); err == nil {
+			policy = loaded
 		}
 	}
 	raw := strings.TrimSpace(policy.EscalationTTL)
@@ -1483,8 +1509,18 @@ func shorterWait(current time.Duration, candidate time.Duration, set *bool) time
 }
 
 type jobWorker struct {
-	Store               *db.Store
-	Stdout              io.Writer
+	Store  *db.Store
+	Stdout io.Writer
+	// ConfigHome is ALWAYS the RAW --home (never the resolved <home>/.gitmoot
+	// root) — INVARIANT (#459). The read-only policy loaders below
+	// (orchestratePolicy/parallelSessionPolicy/admissionPolicy via configPaths())
+	// resolve it through pathsFromFlag -> PathsForHome, which appends ".gitmoot"
+	// exactly once. Passing the already-resolved root here would append it a SECOND
+	// time and read a phantom <home>/.gitmoot/.gitmoot/config.toml. workflowHome()
+	// likewise resolves ConfigHome once to the engine's resolved root. The loaders
+	// are side-effect-free (no config.Initialize), so even a mistaken resolved-root
+	// ConfigHome can never MkdirAll the phantom — but every construction site must
+	// still pass the raw --home so the config is actually found.
 	ConfigHome          string
 	ConfigHomeExplicit  bool
 	AdapterFactory      func(runtime.Agent, string) (workflow.DeliveryAdapter, error)
@@ -2698,11 +2734,24 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	return nil
 }
 
+// configPaths resolves this worker's config.Paths for READ-ONLY policy loading
+// WITHOUT calling config.Initialize (#459). ConfigHome is the raw --home invariant
+// (see the struct field doc), so pathsFromFlag resolves it exactly once to the
+// real <home>/.gitmoot, which withStore/withStoreAndPaths already initialized
+// upstream. Using pathsFromFlag instead of initializedPaths here is the durable
+// guard: even if a caller mistakenly passes the already-resolved root, this never
+// MkdirAll-s the phantom <home>/.gitmoot/.gitmoot — it just reads (and degrades to
+// an error the best-effort callers absorb). Initialize is the only dir-creator and
+// the policy loaders only need to READ.
+func (w jobWorker) configPaths() (config.Paths, error) {
+	return pathsFromFlag(w.ConfigHome)
+}
+
 func (w jobWorker) parallelSessionPolicy() (config.ParallelSessionPolicy, error) {
 	if !w.ConfigHomeExplicit && strings.TrimSpace(w.ConfigHome) == "" {
 		return config.DefaultParallelSessionPolicy(), nil
 	}
-	paths, err := initializedPaths(w.ConfigHome)
+	paths, err := w.configPaths()
 	if err != nil {
 		return config.ParallelSessionPolicy{}, err
 	}
@@ -2716,7 +2765,7 @@ func (w jobWorker) admissionPolicy() (config.AdmissionPolicy, error) {
 	if !w.ConfigHomeExplicit && strings.TrimSpace(w.ConfigHome) == "" {
 		return config.DefaultAdmissionPolicy(), nil
 	}
-	paths, err := initializedPaths(w.ConfigHome)
+	paths, err := w.configPaths()
 	if err != nil {
 		return config.AdmissionPolicy{}, err
 	}
@@ -2791,7 +2840,7 @@ func (w jobWorker) orchestratePolicy() (config.OrchestratePolicy, error) {
 	if !w.ConfigHomeExplicit && strings.TrimSpace(w.ConfigHome) == "" {
 		return config.DefaultOrchestratePolicy(), nil
 	}
-	paths, err := initializedPaths(w.ConfigHome)
+	paths, err := w.configPaths()
 	if err != nil {
 		return config.OrchestratePolicy{}, err
 	}
@@ -3894,6 +3943,14 @@ var (
 	_ workflow.WorktreeCommitter          = gitutil.Client{}
 )
 
+// daemonWorkflowEngine builds the per-tick/per-repo workflow.Engine. Its `home`
+// param is — by convention (#459) — the already-RESOLVED <home>/.gitmoot root
+// (config.Paths.Home), NOT the raw --home. All three callers comply:
+// jobWorker.workflowHome() (resolves ConfigHome once), the registered-repo
+// supervisor (paths.Home), and local dispatch (paths.Home). The resolved root is
+// used verbatim for engine.ArtifactRoot, engine.Home, and daemonEventSink — none
+// of which re-resolve — so handing it the raw --home would misplace delegation
+// artifacts and the event-sink config probe.
 func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, home string) workflow.Engine {
 	engine := workflow.Engine{
 		Store:                   store,

--- a/internal/cli/daemon_home_shape_test.go
+++ b/internal/cli/daemon_home_shape_test.go
@@ -1,0 +1,245 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+// These regression tests pin the #459 daemon home-convention: the daemon resolves
+// `home` to two shapes (the RAW --home and the resolved <home>/.gitmoot root) and
+// must NEVER create the phantom <home>/.gitmoot/.gitmoot, while keeping default
+// behavior byte-identical (TTL values + ArtifactRoot values unchanged). #458
+// already fixed the ArtifactRoot-misplacement half by routing the resolved root to
+// daemonWorkflowEngine on every caller; these tests lock that in AND prove the
+// remaining phantom-dir half is gone.
+
+// phantomDir is <home>/.gitmoot/.gitmoot — the doubled home that initializedPaths
+// (-> config.Initialize) would create if a resolved root were re-resolved.
+func phantomDir(home string) string {
+	return filepath.Join(config.PathsForHome(home).Home, config.DirName)
+}
+
+// initHomeWithEscalationTTL writes a real, initialized home with an
+// [orchestrate].escalation_ttl set, returning the raw home root.
+func initHomeWithEscalationTTL(t *testing.T, ttl string) string {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	// Overwrite the default config.toml with one that sets escalation_ttl so we can
+	// assert the value is read identically from both home shapes.
+	body := "[orchestrate]\nescalation_ttl = \"" + ttl + "\"\n"
+	if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return home
+}
+
+func assertNoPhantom(t *testing.T, home string) {
+	t.Helper()
+	if _, err := os.Stat(phantomDir(home)); !os.IsNotExist(err) {
+		t.Fatalf("phantom doubled home %s must not exist (stat err=%v)", phantomDir(home), err)
+	}
+}
+
+// PHANTOM producer #1 + ESCALATION TTL (both shapes): resolveEscalationTTL must
+// return the configured TTL for BOTH the raw --home and the already-resolved
+// <home>/.gitmoot root, and create NO phantom dir in either case. Before the fix
+// the resolved-input case ran initializedPaths(resolved) -> config.Initialize and
+// created <home>/.gitmoot/.gitmoot.
+func TestResolveEscalationTTLShapeTolerantNoPhantom(t *testing.T) {
+	home := initHomeWithEscalationTTL(t, "30m")
+	resolved := config.PathsForHome(home).Home
+
+	rawTTL := resolveEscalationTTL(home)
+	if rawTTL != 30*time.Minute {
+		t.Fatalf("resolveEscalationTTL(raw) = %s, want 30m", rawTTL)
+	}
+	assertNoPhantom(t, home)
+
+	resolvedTTL := resolveEscalationTTL(resolved)
+	if resolvedTTL != 30*time.Minute {
+		t.Fatalf("resolveEscalationTTL(resolved) = %s, want 30m", resolvedTTL)
+	}
+	// The pre-fix bug: resolving the already-resolved root created the phantom.
+	assertNoPhantom(t, home)
+
+	if rawTTL != resolvedTTL {
+		t.Fatalf("TTL differs across home shapes: raw=%s resolved=%s", rawTTL, resolvedTTL)
+	}
+}
+
+// ESCALATION TTL table: {raw, resolved, empty} x {config present/absent} returns
+// the SAME TTL and writes nothing to the filesystem.
+func TestResolveEscalationTTLTable(t *testing.T) {
+	// Config present with an explicit TTL.
+	present := initHomeWithEscalationTTL(t, "15m")
+	presentResolved := config.PathsForHome(present).Home
+
+	// Config absent: an initialized home whose default config leaves escalation_ttl
+	// empty, so resolveEscalationTTL falls back to DefaultEscalationTTL (24h).
+	absent := t.TempDir()
+	if err := config.Initialize(config.PathsForHome(absent)); err != nil {
+		t.Fatalf("Initialize absent: %v", err)
+	}
+	absentResolved := config.PathsForHome(absent).Home
+
+	defaultTTL, err := time.ParseDuration(config.DefaultEscalationTTL)
+	if err != nil {
+		t.Fatalf("parse DefaultEscalationTTL: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		home string
+		want time.Duration
+	}{
+		{"present-raw", present, 15 * time.Minute},
+		{"present-resolved", presentResolved, 15 * time.Minute},
+		{"absent-raw", absent, defaultTTL},
+		{"absent-resolved", absentResolved, defaultTTL},
+		{"empty", "", defaultTTL},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveEscalationTTL(tc.home)
+			if got != tc.want {
+				t.Fatalf("resolveEscalationTTL(%q) = %s, want %s", tc.home, got, tc.want)
+			}
+		})
+	}
+	// Zero filesystem side effects: neither home grew a phantom doubled root.
+	assertNoPhantom(t, present)
+	assertNoPhantom(t, absent)
+}
+
+// PHANTOM producer #2 (durable hardening): the read-only policy loaders must
+// NEVER create a phantom doubled home, even when handed the RESOLVED root
+// (mimicking the pre-fix buggy supervisor call site). Pre-fix they ran
+// initializedPaths -> config.Initialize and created <home>/.gitmoot/.gitmoot. The
+// resolved-root input is a CALLER MISTAKE: degrading to an error is fine; creating
+// a phantom is not. The raw home (the production ConfigHome invariant) must read
+// cleanly with no phantom.
+func TestPolicyLoadersNoPhantomDefenseInDepth(t *testing.T) {
+	home := initHomeWithEscalationTTL(t, "1h")
+	resolved := config.PathsForHome(home).Home
+
+	resolvedWorker := defaultJobWorker(nil, io.Discard, resolved)
+	// Each loader, given the resolved root, must create NO phantom regardless of
+	// whether the (now non-existent doubled) config reads.
+	_, _ = resolvedWorker.orchestratePolicy()
+	assertNoPhantom(t, home)
+	_, _ = resolvedWorker.parallelSessionPolicy()
+	assertNoPhantom(t, home)
+	_, _ = resolvedWorker.admissionPolicy()
+	assertNoPhantom(t, home)
+
+	// The raw home (the production invariant) reads cleanly AND creates no phantom.
+	rawWorker := defaultJobWorker(nil, io.Discard, home)
+	if _, err := rawWorker.orchestratePolicy(); err != nil {
+		t.Fatalf("orchestratePolicy(raw): %v", err)
+	}
+	if _, err := rawWorker.parallelSessionPolicy(); err != nil {
+		t.Fatalf("parallelSessionPolicy(raw): %v", err)
+	}
+	if _, err := rawWorker.admissionPolicy(); err != nil {
+		t.Fatalf("admissionPolicy(raw): %v", err)
+	}
+	assertNoPhantom(t, home)
+}
+
+// ARTIFACTROOT (jobWorker path): the engine the per-tick worker builds roots
+// artifacts at the resolved <home>/.gitmoot root (NOT the raw --home, NOT a
+// doubled root), and engine.Home matches when a checkout is present.
+func TestJobWorkerWorkflowArtifactRootResolved(t *testing.T) {
+	home := initHomeWithEscalationTTL(t, "5m")
+	resolvedRoot := config.PathsForHome(home).Home
+	checkout := t.TempDir()
+
+	w := defaultJobWorker(nil, io.Discard, home)
+	engine := w.defaultWorkflow(checkout)
+
+	if engine.ArtifactRoot != resolvedRoot {
+		t.Fatalf("jobWorker engine.ArtifactRoot = %q, want resolved root %q", engine.ArtifactRoot, resolvedRoot)
+	}
+	if engine.Home != resolvedRoot {
+		t.Fatalf("jobWorker engine.Home = %q, want resolved root %q", engine.Home, resolvedRoot)
+	}
+	assertNoPhantom(t, home)
+}
+
+// ARTIFACTROOT (supervisor path) + PHANTOM (integration): the registered-repo
+// supervisor's poller WorkflowFactory must root artifacts at the resolved
+// <home>/.gitmoot root, and driving it once (exercising both resolveEscalationTTL
+// at construction and the orchestratePolicy notifier-handle read inside the
+// factory) must leave NO phantom doubled home. This wires the poller exactly as
+// runRegisteredRepoSupervisor does: rawHome for policy/TTL, paths.Home for the
+// engine.
+func TestSupervisorPollerWorkflowArtifactRootResolvedNoPhantom(t *testing.T) {
+	home := initHomeWithEscalationTTL(t, "45m")
+	paths := config.PathsForHome(home)
+	resolvedRoot := paths.Home
+
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	poller := defaultRegisteredRepoPoller(store, 1, false, io.Discard, home, resolvedRoot)
+
+	// resolveEscalationTTL ran at construction; it must have read the real config
+	// (45m) and created no phantom.
+	if poller.EscalationTTL != 45*time.Minute {
+		t.Fatalf("poller.EscalationTTL = %s, want 45m", poller.EscalationTTL)
+	}
+	assertNoPhantom(t, home)
+
+	checkout := t.TempDir()
+	engine := poller.WorkflowFactory(store, github.NewClient(checkout), checkout)
+	if engine == nil {
+		t.Fatal("WorkflowFactory returned nil engine")
+	}
+	if engine.ArtifactRoot != resolvedRoot {
+		t.Fatalf("supervisor engine.ArtifactRoot = %q, want resolved root %q (not raw --home, not doubled)", engine.ArtifactRoot, resolvedRoot)
+	}
+	if engine.Home != resolvedRoot {
+		t.Fatalf("supervisor engine.Home = %q, want resolved root %q", engine.Home, resolvedRoot)
+	}
+	// The factory's orchestratePolicy notifier-handle read used the raw home, so no
+	// phantom can appear even though the engine got the resolved root.
+	assertNoPhantom(t, home)
+}
+
+// The legacy/test poller construction (pollRegisteredRepos passes "","") stays a
+// no-op: nil engine wiring, default TTL, and no filesystem writes.
+func TestEmptyHomePollerIsNoOp(t *testing.T) {
+	poller := defaultRegisteredRepoPoller(nil, 1, false, io.Discard, "", "")
+	defaultTTL, err := time.ParseDuration(config.DefaultEscalationTTL)
+	if err != nil {
+		t.Fatalf("parse DefaultEscalationTTL: %v", err)
+	}
+	if poller.EscalationTTL != defaultTTL {
+		t.Fatalf("empty-home poller.EscalationTTL = %s, want %s", poller.EscalationTTL, defaultTTL)
+	}
+	engine := poller.WorkflowFactory(nil, github.NewClient(""), "")
+	if engine == nil {
+		t.Fatal("WorkflowFactory returned nil engine")
+	}
+	// Empty home => daemonWorkflowEngine leaves ArtifactRoot/Home unset.
+	if engine.ArtifactRoot != "" {
+		t.Fatalf("empty-home engine.ArtifactRoot = %q, want empty", engine.ArtifactRoot)
+	}
+	if engine.Home != "" {
+		t.Fatalf("empty-home engine.Home = %q, want empty", engine.Home)
+	}
+}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -524,7 +524,7 @@ func TestPollRegisteredReposRoutesEachRepoWithOwnGitHubClient(t *testing.T) {
 			},
 		},
 	}
-	poller := defaultRegisteredRepoPoller(store, 2, false, io.Discard, "")
+	poller := defaultRegisteredRepoPoller(store, 2, false, io.Discard, "", "")
 	poller.GitHubClient = func(checkout string) github.Client { return clients[checkout] }
 	poller.WorkflowFactory = func(*db.Store, github.Client, string) *workflow.Engine { return nil }
 
@@ -594,7 +594,7 @@ func TestPollRegisteredReposBacksOffFailedRepoWithoutStoppingOthers(t *testing.T
 	}
 	failing := &cliPollFakeGitHub{listErr: errors.New("rate limited")}
 	healthy := &cliPollFakeGitHub{}
-	poller := defaultRegisteredRepoPoller(store, 1, false, io.Discard, "")
+	poller := defaultRegisteredRepoPoller(store, 1, false, io.Discard, "", "")
 	poller.GitHubClient = func(checkout string) github.Client {
 		if checkout == "/tmp/failing" {
 			return failing

--- a/internal/cli/event_sink.go
+++ b/internal/cli/event_sink.go
@@ -77,26 +77,43 @@ func buildDaemonEventSink(store *db.Store, home string) events.Sink {
 // disabled default when the home or config cannot be resolved/parsed so the
 // event stream stays OFF rather than erroring the daemon.
 func loadEventsPolicy(home string) (config.EventsPolicy, error) {
-	home = strings.TrimSpace(home)
-	if home == "" {
+	cfg := resolveConfigFile(home)
+	if cfg == "" {
 		return config.DefaultEventsPolicy(), nil
 	}
-	// The daemon resolves `home` to two different shapes depending on the call
-	// path: jobWorker.workflowHome() yields the already-resolved <home>/.gitmoot
-	// ROOT, while the registered-repo supervisor passes the RAW --home value — and
-	// both flow into daemonWorkflowEngine -> daemonEventSink. Resolve robustly to
-	// the config.toml for EITHER shape, WITHOUT re-running pathsFromFlag/
-	// initializedPaths (which appended ".gitmoot" a SECOND time, read a phantom
-	// .gitmoot/.gitmoot/config.toml that has no [events] section, and even created
-	// that phantom home — leaving the event stream silently always-off even when
-	// [events].webhook_url was set; #446 regression caught by a live E2E).
+	return config.LoadEventsPolicy(config.Paths{ConfigFile: cfg})
+}
+
+// resolveConfigFile resolves the gitmoot config.toml for a `home` that may be
+// EITHER an already-resolved <home>/.gitmoot ROOT or a RAW --home, returning ""
+// for an empty home. It is the single, side-effect-free home->config.toml
+// resolver shared by the daemon's read-only policy loaders (loadEventsPolicy,
+// resolveEscalationTTL).
+//
+// On main the daemon's engine wiring (daemonWorkflowEngine -> daemonEventSink)
+// receives the already-resolved <home>/.gitmoot root on ALL callers
+// (jobWorker.workflowHome(), the registered-repo supervisor's paths.Home, and
+// local dispatch's paths.Home), so the common case is the resolved-root branch.
+// The probe also tolerates a RAW --home (no config.toml directly under it) by
+// appending the .gitmoot dir as PathsForHome would — kept as defense in depth so
+// a caller mistake can never re-introduce the #446 silent-off bug.
+//
+// It MUST stay side-effect-free: it never runs pathsFromFlag/initializedPaths
+// (which re-appended ".gitmoot" a SECOND time, read a phantom
+// .gitmoot/.gitmoot/config.toml with no [events]/[orchestrate] section, and even
+// created that phantom home; #446/#459).
+func resolveConfigFile(home string) string {
+	home = strings.TrimSpace(home)
+	if home == "" {
+		return ""
+	}
 	cfg := filepath.Join(home, config.ConfigName)
 	if _, err := os.Stat(cfg); err != nil {
 		// `home` was the raw --home (no config.toml directly under it); append the
 		// .gitmoot dir as PathsForHome would. Side-effect-free (no Initialize).
 		cfg = config.PathsForHome(home).ConfigFile
 	}
-	return config.LoadEventsPolicy(config.Paths{ConfigFile: cfg})
+	return cfg
 }
 
 // daemonTerminalEventType maps a daemon-owned terminal JobState to the outbound

--- a/internal/cli/event_sink_resolve_test.go
+++ b/internal/cli/event_sink_resolve_test.go
@@ -50,10 +50,12 @@ func TestBuildDaemonEventSinkDisabledWithoutEventsSection(t *testing.T) {
 	}
 }
 
-// The registered-repo supervisor path passes the RAW --home (not the resolved
-// .gitmoot root) into daemonWorkflowEngine -> daemonEventSink, so the resolver
-// must also build the sink correctly from a raw --home, without creating a
-// phantom doubled home.
+// On main the registered-repo supervisor passes paths.Home (the already-resolved
+// <home>/.gitmoot root), not the raw --home, into daemonWorkflowEngine ->
+// daemonEventSink (#459). The resolver must nonetheless also build the sink
+// correctly from a RAW --home — kept as defense in depth so a caller mistake can
+// never re-introduce the #446 silent-off bug — without creating a phantom doubled
+// home. This test exercises that raw-home tolerance directly.
 func TestBuildDaemonEventSinkFromRawHome(t *testing.T) {
 	home := t.TempDir() // a raw --home value
 	root := config.PathsForHome(home).Home


### PR DESCRIPTION
## Problem

On `main` (with #458 merged), the registered-repo supervisor passed the **resolved** `<home>/.gitmoot` root (`paths.Home`) into helpers that expect the **raw** `--home`:

- `resolveEscalationTTL(home)` (daemon.go) → `initializedPaths(resolved)` → `pathsFromFlag` → `PathsForHome(resolved)` appends `.gitmoot` a **second** time, then `config.Initialize` MkdirAll-s and writes a default config.toml.
- `defaultJobWorker(store, stdout, resolved).orchestratePolicy()` in the WorkflowFactory → same `initializedPaths(resolved)` path.

Both created the phantom `<home>/.gitmoot/.gitmoot/` (config.toml + logs/ + workspaces/ + evals/blobs/) during escalation/orchestrate-policy reads.

## Scope note (post-#458)

**#458 already fixed the ArtifactRoot-misplacement half** by routing the resolved root to `daemonWorkflowEngine` on all three callers, so `engine.ArtifactRoot`/`Home`/`EventSink` were already correct on both the jobWorker and supervisor paths. This PR is the **remaining phantom-dir half + hardening + corrected comments**.

## Fix

- `defaultRegisteredRepoPoller` now takes `(rawHome, resolvedRoot)`: `rawHome` feeds the read-only policy loaders (`resolveEscalationTTL`, the WorkflowFactory's `orchestratePolicy`); `resolvedRoot` (= `paths.Home`) feeds the engine wiring (`daemonWorkflowEngine` → ArtifactRoot/Home/EventSink). `runRegisteredRepoSupervisor` already holds both and now threads them explicitly.
- `resolveEscalationTTL` is now **side-effect-free** and shape-tolerant: it resolves the config.toml via a shared `resolveConfigFile` (raw-or-resolved) and reads `[orchestrate]` via `LoadOrchestratePolicy` (read-only `ReadFile`), **never** `initializedPaths`/`config.Initialize`. Phantom-free even under a caller mistake.
- The read-only policy loaders (`orchestratePolicy`/`parallelSessionPolicy`/`admissionPolicy`) now resolve via `pathsFromFlag` (`configPaths()`) **without** `config.Initialize` — they only need to READ, so they can never MkdirAll a doubled home (durable guard, defense in depth).
- Documented the `daemonWorkflowEngine` `home`=RESOLVED convention and the `jobWorker.ConfigHome`=RAW invariant.
- Kept #458's `loadEventsPolicy` `os.Stat` tolerance (refactored into the shared `resolveConfigFile`); **corrected the now-stale comments** in `event_sink.go` and `event_sink_resolve_test.go` that wrongly said "the supervisor passes the RAW --home" (it passes `paths.Home`, the resolved root).

## Default behavior is byte-identical

Escalation TTL values, ArtifactRoot/Home values, and event-sink nil/non-nil decisions are unchanged. The only observable change is **no phantom dir**. (The real home is always Initialized upstream by `withStore`/`withStoreAndPaths`, so dropping the gratuitous Initialize on read changes nothing for the default path.)

## Test evidence

New `internal/cli/daemon_home_shape_test.go`:
- **PHANTOM producer #1**: `resolveEscalationTTL` returns the configured TTL for both raw and resolved home with `os.Stat(<home>/.gitmoot/.gitmoot) == ErrNotExist` in both (failing-before/passing-after on the resolved case).
- **PHANTOM producer #2 (hardening)**: the read-only loaders create no phantom even when handed the resolved root; raw home reads cleanly.
- **PHANTOM integration**: driving the supervisor `WorkflowFactory` once (exercising `resolveEscalationTTL` + the orchestratePolicy notifier-handle read) leaves no phantom.
- **ArtifactRoot (jobWorker + supervisor)**: `engine.ArtifactRoot == engine.Home == config.PathsForHome(home).Home` on both paths.
- **ESCALATION TTL table**: identical TTL across {raw, resolved, empty} × {present, absent} with zero FS side effects.
- Empty-home poller stays a no-op.

Full gate green in the worktree:
- `go build ./...`, `go vet ./...`, `go test ./...`
- `go test -race ./internal/workflow/` (222s ok)
- `go test -race ./internal/cli/` (492s ok)

Closes #459