### PR TITLE
feat(skillopt): read-side {score, feedback} projection (#462)

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -96,6 +96,45 @@ includes `ranked_event_id`, which matches the corresponding
 feedback event so a future optimizer can combine useful traits across multiple
 winning options rather than only copying the top option.
 
+## Normalized {score, feedback} projection
+
+The training package already carries a scalar quality signal and rich textual
+feedback, but they are spread across several optional fields. Gitmoot exposes a
+pure, read-side helper, `skillopt.ProjectSignal`, that fuses those existing
+fields into one uniform `NormalizedSignal{score, has_score, feedback}` view so a
+consumer reads one signal instead of N optional fields.
+
+This projection is **read-side only**: it is a return type, not a wire field. It
+adds no field to any package, does not change the JSON the optimizer subprocess
+reads, and leaves `contract_version` at `1`. The training and candidate packages
+are byte-identical with or without it.
+
+**Scalar (`score` in `[0,1]`, with `has_score`).** Precedence is
+`soft > mean(dimension_scores) > hard`:
+
+- If `hard` is present and equal to `0` (the gate failed), `score = 0` and
+  `has_score = true` — a hard-fail is an authoritative, informative `0`, not
+  "missing".
+- Otherwise the quality component is `soft` if present, else the arithmetic mean
+  of `dimension_scores` when that map is non-empty, else `hard` when `hard > 0`.
+  A positive `hard` is a gate, not a weight, so it does not scale the component.
+- If a quality component exists, `score` is that value clamped to `[0,1]` and
+  `has_score = true`.
+- If no usable field exists (`hard`, `soft`, and `dimension_scores` all absent),
+  `has_score = false`. The projection reports genuine absence rather than
+  fabricating a neutral `0.5`, so consumers can omit rather than invent a value.
+
+**Textual (`feedback`).** Non-empty parts are concatenated in a fixed section
+order — `optimizer_hint`, then `required_improvements`, then `useful_traits`,
+then `rejected_traits`, then `reasoning` — each under a stable header. Trait
+fields are best-effort decoded into their known shapes (`map[string][]string`
+keyed by option label, or `[]string`); map keys are rendered in sorted order for
+deterministic, byte-stable output, and any section that fails to decode is
+skipped rather than dumped raw. The assembled string is bounded to an 8 KiB byte
+cap; when it would exceed the cap it is truncated on a UTF-8 boundary with a
+trailing `… (truncated)` marker. When no textual signal is present, `feedback`
+is empty.
+
 ## Ranked Exploration Workflow
 
 Use ranked exploration when the template is still ambiguous and humans need to

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
 	"github.com/jerryfane/gitmoot/internal/artifact"
@@ -472,6 +473,209 @@ type CandidateImportOptions struct {
 	SourcePath  string
 	ArtifactDir string
 	BlobStore   artifact.Store
+}
+
+// feedbackByteCap bounds the assembled NormalizedSignal.Feedback string so a
+// read-side projection of very verbose trait/reasoning fields stays human- and
+// optimizer-readable. The cap is documented in the SkillOpt exchange contract
+// docs (8 KiB). When the assembled text exceeds the cap it is truncated and a
+// trailing marker is appended.
+const feedbackByteCap = 8 * 1024
+
+// feedbackTruncationMarker is appended when Feedback is truncated at the byte
+// cap so consumers can tell the tail was clipped.
+const feedbackTruncationMarker = "… (truncated)"
+
+// NormalizedSignal is a pure, read-side projection of the scalar quality signal
+// and the textual feedback that the SkillOpt contract already carries across
+// several optional fields. It is a view/return type only: it is NOT embedded in
+// any wire package (TrainingPackage/CandidatePackage), adds no field to any
+// existing contract struct, and does not change ContractVersion or the bytes the
+// optimizer subprocess reads.
+//
+// Score is in the range [0,1] when HasScore is true. When HasScore is false the
+// scalar signal was genuinely absent and Score is meaningless (do not treat it
+// as a neutral midpoint). Feedback is a single bounded string assembled in a
+// fixed section order; it is empty when no textual signal was present.
+type NormalizedSignal struct {
+	Score    float64 `json:"score"`
+	HasScore bool    `json:"has_score"`
+	Feedback string  `json:"feedback,omitempty"`
+}
+
+// ProjectSignal projects the already-present scalar and textual fields into one
+// uniform {Score, Feedback} view so consumers read a single signal instead of N
+// optional fields. All inputs are pointers and nil-tolerant, so callers pass
+// whatever subset they hold. It is pure and total: it never panics and has no
+// side effects.
+//
+// Scalar precedence (see normalizedScore): a present Hard == 0 is an
+// authoritative gate-fail 0 (HasScore=true); otherwise the quality component is
+// Soft, else the mean of DimensionScores, else Hard > 0; genuinely-absent data
+// yields HasScore=false. Textual assembly (see normalizedFeedback) concatenates
+// the non-empty parts in a fixed, deterministic order, bounded by a byte cap.
+func ProjectSignal(score *EvaluatorScore, ranked *RankedFeedbackEvent, failure *EvaluatorFailurePacket) NormalizedSignal {
+	value, ok := normalizedScore(score)
+	return NormalizedSignal{
+		Score:    value,
+		HasScore: ok,
+		Feedback: normalizedFeedback(ranked, failure),
+	}
+}
+
+// normalizedScore fuses EvaluatorScore.Hard/Soft/DimensionScores into a single
+// score in [0,1] and reports whether any usable scalar field existed.
+//
+// Rules:
+//  1. Hard present and == 0 (gate failed) → (0, true): a hard-fail dominates and
+//     is a real, informative 0, not "missing".
+//  2. Otherwise the quality component is Soft if present, else the arithmetic
+//     mean of DimensionScores if the map is non-empty, else Hard if Hard > 0,
+//     else unknown. Hard > 0 is a gate, not a weight, so it does not scale the
+//     quality component.
+//  3. A usable quality component → (clamp(quality), true).
+//  4. No usable field (Hard nil, Soft nil, DimensionScores empty) → (0, false):
+//     absent, not a fabricated neutral 0.5.
+//
+// Every returned score is clamped to [0,1].
+func normalizedScore(score *EvaluatorScore) (float64, bool) {
+	if score == nil {
+		return 0, false
+	}
+	// A hard-fail gate (Hard == 0) is an authoritative, informative 0.
+	if score.Hard != nil && *score.Hard == 0 {
+		return 0, true
+	}
+	// Quality component precedence: Soft > mean(DimensionScores) > Hard.
+	if score.Soft != nil {
+		return clampUnit(*score.Soft), true
+	}
+	if len(score.DimensionScores) > 0 {
+		var sum float64
+		for _, value := range score.DimensionScores {
+			sum += value
+		}
+		return clampUnit(sum / float64(len(score.DimensionScores))), true
+	}
+	if score.Hard != nil && *score.Hard > 0 {
+		return clampUnit(*score.Hard), true
+	}
+	return 0, false
+}
+
+func clampUnit(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}
+
+// normalizedFeedback deterministically concatenates the non-empty textual parts
+// into one bounded string, in a fixed section order:
+//
+//	OptimizerHint, RequiredImprovements, UsefulTraits, RejectedTraits, Reasoning
+//
+// Each section gets a stable header. json.RawMessage trait fields are best-effort
+// decoded into the known shapes (map[string][]string keyed by option label, or
+// []string); map keys are sorted for determinism, and an undecodable section is
+// skipped rather than dumped raw (the function never panics and never emits raw
+// braces). The whole string is truncated to feedbackByteCap with a trailing
+// marker. Empty inputs yield "".
+func normalizedFeedback(ranked *RankedFeedbackEvent, failure *EvaluatorFailurePacket) string {
+	var sections []string
+	if failure != nil {
+		if hint := strings.TrimSpace(failure.OptimizerHint); hint != "" {
+			sections = append(sections, "Optimizer hint:\n"+hint)
+		}
+	}
+	if ranked != nil {
+		if section := feedbackListSection("Required improvements:", ranked.RequiredImprovements); section != "" {
+			sections = append(sections, section)
+		}
+		if section := feedbackTraitsSection("Useful traits:", ranked.UsefulTraits); section != "" {
+			sections = append(sections, section)
+		}
+		if section := feedbackTraitsSection("Rejected traits:", ranked.RejectedTraits); section != "" {
+			sections = append(sections, section)
+		}
+		if reasoning := strings.TrimSpace(ranked.Reasoning); reasoning != "" {
+			sections = append(sections, "Reasoning:\n"+reasoning)
+		}
+	}
+	return truncateFeedback(strings.Join(sections, "\n\n"))
+}
+
+// feedbackListSection renders a RequiredImprovements-shaped json.RawMessage
+// ([]string) as a bulleted section, or "" when empty/undecodable.
+func feedbackListSection(header string, raw json.RawMessage) string {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return ""
+	}
+	var items []string
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return ""
+	}
+	lines := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			lines = append(lines, "- "+item)
+		}
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return header + "\n" + strings.Join(lines, "\n")
+}
+
+// feedbackTraitsSection renders a trait-shaped json.RawMessage
+// (map[string][]string keyed by option label) as deterministic "label: trait"
+// lines with sorted keys, or "" when empty/undecodable.
+func feedbackTraitsSection(header string, raw json.RawMessage) string {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return ""
+	}
+	var traits map[string][]string
+	if err := json.Unmarshal(raw, &traits); err != nil {
+		return ""
+	}
+	labels := make([]string, 0, len(traits))
+	for label := range traits {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	lines := make([]string, 0, len(labels))
+	for _, label := range labels {
+		for _, trait := range traits[label] {
+			trait = strings.TrimSpace(trait)
+			if trait != "" {
+				lines = append(lines, label+": "+trait)
+			}
+		}
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return header + "\n" + strings.Join(lines, "\n")
+}
+
+// truncateFeedback bounds text to feedbackByteCap, appending a marker when it
+// clips. It cuts on a UTF-8 rune boundary so the output stays valid UTF-8.
+func truncateFeedback(text string) string {
+	if len(text) <= feedbackByteCap {
+		return text
+	}
+	limit := feedbackByteCap - len(feedbackTruncationMarker)
+	if limit < 0 {
+		limit = 0
+	}
+	for limit > 0 && !utf8.RuneStart(text[limit]) {
+		limit--
+	}
+	return text[:limit] + feedbackTruncationMarker
 }
 
 func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (TrainingPackage, error) {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
 	"github.com/jerryfane/gitmoot/internal/artifact"
@@ -1384,5 +1385,296 @@ func TestEvaluatorScoreJudgePromptFieldsOmitEmpty(t *testing.T) {
 		if strings.Contains(string(encoded), field) {
 			t.Errorf("empty EvaluatorScore must omit %q, got %s", field, encoded)
 		}
+	}
+}
+
+func projectFloatPtr(v float64) *float64 { return &v }
+
+func TestProjectSignalScalar(t *testing.T) {
+	tests := []struct {
+		name    string
+		score   *EvaluatorScore
+		want    float64
+		wantHas bool
+	}{
+		{name: "nil score is absent", score: nil, wantHas: false},
+		{name: "empty score is absent", score: &EvaluatorScore{}, wantHas: false},
+		{
+			name:    "hard-fail zero is an authoritative 0",
+			score:   &EvaluatorScore{Hard: projectFloatPtr(0), Soft: projectFloatPtr(0.12)},
+			want:    0,
+			wantHas: true,
+		},
+		{
+			name:    "soft wins over dimensions and hard",
+			score:   &EvaluatorScore{Hard: projectFloatPtr(1), Soft: projectFloatPtr(0.42), DimensionScores: map[string]float64{"a": 0.1}},
+			want:    0.42,
+			wantHas: true,
+		},
+		{
+			name:    "mean of dimensions when soft absent",
+			score:   &EvaluatorScore{DimensionScores: map[string]float64{"a": 0.4, "b": 0.8}},
+			want:    0.6,
+			wantHas: true,
+		},
+		{
+			name:    "hard above zero used when only signal",
+			score:   &EvaluatorScore{Hard: projectFloatPtr(1.0)},
+			want:    1.0,
+			wantHas: true,
+		},
+		{
+			name:    "soft clamped to upper bound",
+			score:   &EvaluatorScore{Soft: projectFloatPtr(1.4)},
+			want:    1.0,
+			wantHas: true,
+		},
+		{
+			name:    "soft clamped to lower bound",
+			score:   &EvaluatorScore{Soft: projectFloatPtr(-0.2)},
+			want:    0.0,
+			wantHas: true,
+		},
+		{
+			name:    "dimension mean clamped",
+			score:   &EvaluatorScore{DimensionScores: map[string]float64{"a": 1.5, "b": 1.5}},
+			want:    1.0,
+			wantHas: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signal := ProjectSignal(tt.score, nil, nil)
+			if signal.HasScore != tt.wantHas {
+				t.Fatalf("HasScore = %v, want %v", signal.HasScore, tt.wantHas)
+			}
+			if diff := signal.Score - tt.want; tt.wantHas && (diff > 1e-9 || diff < -1e-9) {
+				t.Fatalf("Score = %v, want %v", signal.Score, tt.want)
+			}
+			if signal.Score < 0 || signal.Score > 1 {
+				t.Fatalf("Score %v out of [0,1]", signal.Score)
+			}
+		})
+	}
+}
+
+func TestProjectSignalAbsentScoreIsNotFabricatedMidpoint(t *testing.T) {
+	signal := ProjectSignal(&EvaluatorScore{}, nil, nil)
+	if signal.HasScore {
+		t.Fatalf("HasScore = true, want false for absent score")
+	}
+	if signal.Score == 0.5 {
+		t.Fatalf("absent score must not fabricate a neutral 0.5")
+	}
+}
+
+func TestProjectSignalTextualOrderAndContent(t *testing.T) {
+	useful, err := json.Marshal(map[string][]string{"c": {"clearest explanation"}, "a": {"crisp hero"}})
+	if err != nil {
+		t.Fatalf("marshal useful traits: %v", err)
+	}
+	rejected, err := json.Marshal(map[string][]string{"b": {"too generic"}})
+	if err != nil {
+		t.Fatalf("marshal rejected traits: %v", err)
+	}
+	required, err := json.Marshal([]string{"stronger visual identity", "responsive hero"})
+	if err != nil {
+		t.Fatalf("marshal required improvements: %v", err)
+	}
+	ranked := &RankedFeedbackEvent{
+		UsefulTraits:         useful,
+		RejectedTraits:       rejected,
+		RequiredImprovements: required,
+		Reasoning:            "C is the clearest direction.",
+	}
+	failure := &EvaluatorFailurePacket{OptimizerHint: "Return serialized bundle JSON."}
+
+	feedback := ProjectSignal(nil, ranked, failure).Feedback
+
+	for _, section := range []string{"Optimizer hint:", "Required improvements:", "Useful traits:", "Rejected traits:", "Reasoning:"} {
+		if !strings.Contains(feedback, section) {
+			t.Fatalf("feedback missing section %q:\n%s", section, feedback)
+		}
+	}
+	order := []string{"Optimizer hint:", "Required improvements:", "Useful traits:", "Rejected traits:", "Reasoning:"}
+	last := -1
+	for _, section := range order {
+		idx := strings.Index(feedback, section)
+		if idx <= last {
+			t.Fatalf("section %q out of order in:\n%s", section, feedback)
+		}
+		last = idx
+	}
+	// Sorted map keys: useful traits label "a" must render before "c".
+	usefulIdx := strings.Index(feedback, "Useful traits:")
+	aIdx := strings.Index(feedback[usefulIdx:], "a: crisp hero")
+	cIdx := strings.Index(feedback[usefulIdx:], "c: clearest explanation")
+	if aIdx == -1 || cIdx == -1 || aIdx > cIdx {
+		t.Fatalf("useful trait keys not sorted:\n%s", feedback)
+	}
+	// Required improvements bulleted.
+	if !strings.Contains(feedback, "- stronger visual identity") || !strings.Contains(feedback, "- responsive hero") {
+		t.Fatalf("required improvements not bulleted:\n%s", feedback)
+	}
+}
+
+func TestProjectSignalTextualDeterministic(t *testing.T) {
+	useful, err := json.Marshal(map[string][]string{"z": {"z trait"}, "m": {"m trait"}, "a": {"a trait"}})
+	if err != nil {
+		t.Fatalf("marshal useful traits: %v", err)
+	}
+	ranked := &RankedFeedbackEvent{UsefulTraits: useful}
+	first := ProjectSignal(nil, ranked, nil).Feedback
+	for i := 0; i < 20; i++ {
+		if got := ProjectSignal(nil, ranked, nil).Feedback; got != first {
+			t.Fatalf("feedback not deterministic across runs:\n%q\n!=\n%q", got, first)
+		}
+	}
+	// Explicit sorted order a < m < z.
+	aIdx := strings.Index(first, "a: a trait")
+	mIdx := strings.Index(first, "m: m trait")
+	zIdx := strings.Index(first, "z: z trait")
+	if !(aIdx >= 0 && aIdx < mIdx && mIdx < zIdx) {
+		t.Fatalf("trait keys not in sorted order:\n%s", first)
+	}
+}
+
+func TestProjectSignalTextualSkipsUndecodable(t *testing.T) {
+	ranked := &RankedFeedbackEvent{
+		// A JSON string is valid JSON but neither map[string][]string nor
+		// []string, so the section must be skipped, not dumped raw.
+		UsefulTraits:         json.RawMessage(`"not an object"`),
+		RequiredImprovements: json.RawMessage(`{"oops":"not a list"}`),
+		RejectedTraits:       json.RawMessage(`not even json`),
+		Reasoning:            "Only reasoning survives.",
+	}
+	feedback := ProjectSignal(nil, ranked, nil).Feedback
+	if strings.Contains(feedback, "Useful traits:") || strings.Contains(feedback, "Required improvements:") || strings.Contains(feedback, "Rejected traits:") {
+		t.Fatalf("undecodable sections were not skipped:\n%s", feedback)
+	}
+	if strings.ContainsAny(feedback, "{}") {
+		t.Fatalf("feedback leaked raw braces:\n%s", feedback)
+	}
+	if !strings.Contains(feedback, "Reasoning:\nOnly reasoning survives.") {
+		t.Fatalf("decodable section dropped:\n%s", feedback)
+	}
+}
+
+func TestProjectSignalTextualTruncatesAtCap(t *testing.T) {
+	improvements := make([]string, 0, 4000)
+	for i := 0; i < 4000; i++ {
+		improvements = append(improvements, "improve the responsive hero layout substantially")
+	}
+	required, err := json.Marshal(improvements)
+	if err != nil {
+		t.Fatalf("marshal required improvements: %v", err)
+	}
+	feedback := ProjectSignal(nil, &RankedFeedbackEvent{RequiredImprovements: required}, nil).Feedback
+	if len(feedback) > feedbackByteCap {
+		t.Fatalf("feedback length %d exceeds cap %d", len(feedback), feedbackByteCap)
+	}
+	if !strings.HasSuffix(feedback, feedbackTruncationMarker) {
+		t.Fatalf("truncated feedback missing marker, suffix = %q", feedback[len(feedback)-len(feedbackTruncationMarker):])
+	}
+	if !utf8.ValidString(feedback) {
+		t.Fatalf("truncated feedback is not valid UTF-8")
+	}
+}
+
+func TestProjectSignalAllEmpty(t *testing.T) {
+	signal := ProjectSignal(nil, &RankedFeedbackEvent{}, &EvaluatorFailurePacket{})
+	if signal.Feedback != "" {
+		t.Fatalf("Feedback = %q, want empty", signal.Feedback)
+	}
+	if signal.HasScore {
+		t.Fatalf("HasScore = true, want false for all-empty inputs")
+	}
+	encoded, err := json.Marshal(signal)
+	if err != nil {
+		t.Fatalf("marshal NormalizedSignal: %v", err)
+	}
+	if strings.Contains(string(encoded), "feedback") {
+		t.Fatalf("empty Feedback must be omitted from JSON, got %s", encoded)
+	}
+}
+
+// TestProjectSignalDoesNotChangeWirePackages pins the exact JSON bytes of an
+// unchanged TrainingPackage and CandidatePackage. ProjectSignal is a return type
+// only; it adds no field to any wire struct, so these golden bytes must remain
+// byte-identical and must never carry the NormalizedSignal keys (score/
+// has_score). This guards the additive / byte-identical optimizer-input contract.
+func TestProjectSignalDoesNotChangeWirePackages(t *testing.T) {
+	hard := 0.0
+	soft := 0.12
+	training := TrainingPackage{
+		Kind:            TrainingPackageKind,
+		ContractVersion: ContractVersion,
+		Template:        TemplateSnapshot{ID: "planner"},
+		EvalRun:         EvalRun{ID: "run-1", TemplateID: "planner", State: "review"},
+		RankedFeedbackEvents: []RankedFeedbackEvent{{
+			ID:                   "ranked-1",
+			RunID:                "run-1",
+			ItemID:               "item-1",
+			Ranking:              []string{"a", "b"},
+			Winner:               "a",
+			UsefulTraits:         json.RawMessage(`{"a":["clear"]}`),
+			RejectedTraits:       json.RawMessage(`{"b":["generic"]}`),
+			RequiredImprovements: json.RawMessage(`["stronger hero"]`),
+			Reasoning:            "A is clearer.",
+			Reviewer:             "jerry",
+			Source:               "github",
+			CreatedAt:            "2026-06-02T10:00:00Z",
+		}},
+	}
+	candidate := CandidatePackage{
+		Kind:            CandidatePackageKind,
+		ContractVersion: ContractVersion,
+		TemplateID:      "planner",
+		Candidate:       CandidateTemplate{Content: "Plan carefully."},
+		Summary: CandidateSummary{
+			EvaluatorScore: &EvaluatorScore{
+				Hard:            &hard,
+				Soft:            &soft,
+				DimensionScores: map[string]float64{"artifact_contract": 0},
+				Failure:         &EvaluatorFailurePacket{OptimizerHint: "Return bundle JSON."},
+			},
+		},
+	}
+
+	const wantTraining = `{"kind":"gitmoot-skillopt-training-package","contract_version":1,"template":{"id":"planner","version_id":"","version_number":0,"version_state":"","content_hash":"","source_repo":"","source_ref":"","source_path":"","resolved_commit":"","metadata":{"id":"","name":"","description":"","kind":"","version":0,"capabilities":null,"runtime_compatibility":null,"tags":null,"inputs":null,"outputs":null},"content":""},"eval_run":{"id":"run-1","template_id":"planner","template_version_id":"","target_repo":"","state":"review"},"items":null,"artifacts":null,"feedback_events":null,"ranked_feedback_events":[{"id":"ranked-1","run_id":"run-1","item_id":"item-1","ranking":["a","b"],"winner":"a","useful_traits":{"a":["clear"]},"rejected_traits":{"b":["generic"]},"required_improvements":["stronger hero"],"reasoning":"A is clearer.","reviewer":"jerry","source":"github","created_at":"2026-06-02T10:00:00Z"}]}`
+	const wantCandidate = `{"kind":"gitmoot-skillopt-candidate-package","contract_version":1,"template_id":"planner","candidate":{"content":"Plan carefully.","metadata":{"id":"","name":"","description":"","kind":"","version":0,"capabilities":null,"runtime_compatibility":null,"tags":null,"inputs":null,"outputs":null}},"summary":{"evaluator_score":{"hard":0,"soft":0.12,"dimension_scores":{"artifact_contract":0},"failure":{"optimizer_hint":"Return bundle JSON."}}}}`
+
+	trainingBytes, err := json.Marshal(training)
+	if err != nil {
+		t.Fatalf("marshal training package: %v", err)
+	}
+	if string(trainingBytes) != wantTraining {
+		t.Fatalf("training package bytes changed:\n got %s\nwant %s", trainingBytes, wantTraining)
+	}
+	candidateBytes, err := json.Marshal(candidate)
+	if err != nil {
+		t.Fatalf("marshal candidate package: %v", err)
+	}
+	if string(candidateBytes) != wantCandidate {
+		t.Fatalf("candidate package bytes changed:\n got %s\nwant %s", candidateBytes, wantCandidate)
+	}
+	for _, key := range []string{`"has_score"`} {
+		if strings.Contains(string(trainingBytes), key) || strings.Contains(string(candidateBytes), key) {
+			t.Fatalf("NormalizedSignal key %s leaked into a wire package", key)
+		}
+	}
+
+	// The projection still reads exactly these fields (sanity: it is callable and
+	// derives from the same bytes) without mutating them.
+	signal := ProjectSignal(candidate.Summary.EvaluatorScore, &training.RankedFeedbackEvents[0], candidate.Summary.EvaluatorScore.Failure)
+	if !signal.HasScore || signal.Score != 0 {
+		t.Fatalf("ProjectSignal over hard-fail score = %+v", signal)
+	}
+	reMarshaled, err := json.Marshal(candidate)
+	if err != nil {
+		t.Fatalf("re-marshal candidate package: %v", err)
+	}
+	if string(reMarshaled) != wantCandidate {
+		t.Fatalf("ProjectSignal mutated the candidate package")
 	}
 }

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -111,6 +111,45 @@ includes `ranked_event_id`, which matches the corresponding
 feedback event so a future optimizer can combine useful traits across multiple
 winning options rather than only copying the top option.
 
+## Normalized {score, feedback} projection
+
+The training package already carries a scalar quality signal and rich textual
+feedback, but they are spread across several optional fields. Gitmoot exposes a
+pure, read-side helper, `skillopt.ProjectSignal`, that fuses those existing
+fields into one uniform `NormalizedSignal{score, has_score, feedback}` view so a
+consumer reads one signal instead of N optional fields.
+
+This projection is **read-side only**: it is a return type, not a wire field. It
+adds no field to any package, does not change the JSON the optimizer subprocess
+reads, and leaves `contract_version` at `1`. The training and candidate packages
+are byte-identical with or without it.
+
+**Scalar (`score` in `[0,1]`, with `has_score`).** Precedence is
+`soft > mean(dimension_scores) > hard`:
+
+- If `hard` is present and equal to `0` (the gate failed), `score = 0` and
+  `has_score = true` — a hard-fail is an authoritative, informative `0`, not
+  "missing".
+- Otherwise the quality component is `soft` if present, else the arithmetic mean
+  of `dimension_scores` when that map is non-empty, else `hard` when `hard > 0`.
+  A positive `hard` is a gate, not a weight, so it does not scale the component.
+- If a quality component exists, `score` is that value clamped to `[0,1]` and
+  `has_score = true`.
+- If no usable field exists (`hard`, `soft`, and `dimension_scores` all absent),
+  `has_score = false`. The projection reports genuine absence rather than
+  fabricating a neutral `0.5`, so consumers can omit rather than invent a value.
+
+**Textual (`feedback`).** Non-empty parts are concatenated in a fixed section
+order — `optimizer_hint`, then `required_improvements`, then `useful_traits`,
+then `rejected_traits`, then `reasoning` — each under a stable header. Trait
+fields are best-effort decoded into their known shapes (`map[string][]string`
+keyed by option label, or `[]string`); map keys are rendered in sorted order for
+deterministic, byte-stable output, and any section that fails to decode is
+skipped rather than dumped raw. The assembled string is bounded to an 8 KiB byte
+cap; when it would exceed the cap it is truncated on a UTF-8 boundary with a
+trailing `… (truncated)` marker. When no textual signal is present, `feedback`
+is empty.
+
 ## Ranked Exploration Workflow
 
 Use ranked exploration when the template is still ambiguous and humans need to


### PR DESCRIPTION
## Summary

Adds a pure, **additive**, read-side projection helper to `internal/skillopt/contract.go` that fuses the scalar quality signal and textual feedback already carried across several optional contract fields into one uniform view, so the optimizer and the planned #463 auto-feedback intake read **one** signal instead of N optional fields.

New exported surface (return/view types only — no new wire fields):

- `NormalizedSignal{Score float64, HasScore bool, Feedback string}`
- `ProjectSignal(*EvaluatorScore, *RankedFeedbackEvent, *EvaluatorFailurePacket) NormalizedSignal`
- private pure helpers `normalizedScore` / `normalizedFeedback`

### Scalar fusion
Precedence `Soft > mean(DimensionScores) > Hard`, clamped to `[0,1]`:
- `Hard == 0` (gate failed) is an authoritative, informative `0` (`HasScore=true`), not "missing".
- Genuinely absent data → `HasScore=false` (no fabricated neutral `0.5`).
- A positive `Hard` is a gate, not a weight.

### Textual assembly
Fixed section order `OptimizerHint, RequiredImprovements, UsefulTraits, RejectedTraits, Reasoning`, each under a stable header. `json.RawMessage` traits are best-effort decoded (`map[string][]string` / `[]string`) with **sorted keys** for determinism; undecodable sections are skipped (never panics, never dumps raw braces). Output is bounded to an **8 KiB** byte cap with a `… (truncated)` marker on a UTF-8 boundary.

## Strictly additive / byte-identical
- `NormalizedSignal` is a **return type, not a wire field**. No new field on any existing contract struct.
- `ContractVersion` stays **1**.
- `ExportTrainingPackage` / `ImportCandidatePackage` / optimizer-subprocess JSON stay **byte-identical** — guarded by a new golden-bytes regression test (`TestProjectSignalDoesNotChangeWirePackages`) that pins the exact marshaled `TrainingPackage`/`CandidatePackage` bytes and asserts the `NormalizedSignal` keys never leak.
- **Expose-and-document only**: `ProjectSignal` is callable + documented but deliberately **not wired** into the export/optimizer path in this PR. Consumption (optimizer-side and #463 intake) is deferred.

## Docs
The projection is documented **identically** in both doc trees:
- `docs/skillopt-exchange-contract.md`
- `website/docs/reference/skillopt-exchange-contract.md`

(range, precedence, `has_score`/absent rule, section order + byte cap, "read-side only, does not change the wire package").

## Tests
New unit tests in `internal/skillopt/contract_test.go`: scalar precedence/absence/clamp; textual order/decode-skip/sort/truncation/determinism; the byte-identical-marshal regression.

## Gate
`go build ./... && go vet ./... && go test ./... && go test -race ./internal/skillopt/ && go test -race ./internal/cli/` all green.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)