### PR TITLE
feat(skillopt): Mode A automatic trace-harvested feedback (#465)

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -135,6 +135,79 @@ cap; when it would exceed the cap it is truncated on a UTF-8 boundary with a
 trailing `… (truncated)` marker. When no textual signal is present, `feedback`
 is empty.
 
+## Automatic trace-harvested feedback (Mode A, off by default)
+
+Gitmoot can derive training feedback from the **verifiable outcomes** an
+implement job already reaches — a PR that merged with passing external CI vs. one
+that was blocked at the merge gate, a review that requested changes, or a later
+revert — and write it as synthetic feedback into the **existing** feedback tables
+without any human ranking. This is **Mode A** of the trace-harvester (issue
+#465). It is **off by default** and **strictly additive**: `contract_version`
+stays `1`, no new field is added to any package struct, and **promotion stays
+100% manual** — the harvester writes only `eval_runs`, `eval_review_items`, and
+`feedback_events`; a human still promotes a candidate with
+`gitmoot skillopt candidate promote`.
+
+**Enabling.** Add a `[skillopt]` section to the gitmoot config:
+
+```toml
+[skillopt]
+auto_trace_enabled = true   # default false
+```
+
+With the key unset or `false`, no harvester is constructed and behavior — and
+every human-run training package — is **byte-identical**. The admission knob
+mirrors the off-by-default `[events]` stream.
+
+**What gets written.** On a verifiable implement-job outcome the harvester:
+
+- Resolves the job's template version from its `template_id` +
+  `template_resolved_commit` attribution.
+- Upserts one dedicated **auto-trace `eval_run` per template version**, with id
+  `auto-trace:<template_version_id>`, `mode = validate`, and
+  `metadata_json` carrying `feedback_source = automatic_trace`.
+- Upserts a per-PR `eval_review_item` (item id `<repo>#<pr>`).
+- Upserts one `FeedbackEvent` (not a ranked event — a single implement diff has
+  no paired second artifact) tagged `source = auto-trace`,
+  `reviewer = gitmoot-auto`, with the verifiable-outcome `score`/`feedback`
+  assembled by `skillopt.ProjectSignal` (above). A **positive** outcome is
+  `choice = a` (the current promoted template as the implicit baseline champion);
+  a **negative** is `choice = b`. The textual `reasoning` is the projected
+  `NormalizedSignal.feedback`.
+
+**Outcome → score.**
+
+- **Merged with real CI** (a passing non-`gitmoot/` external status/check at the
+  merged head) → strong positive (`soft = 1.0`, `choice = a`).
+- **Merged through an empty gate** (the synthetic `gitmoot/ci` context, or no
+  external CI at head) → **near-neutral** (`soft ≈ 0.5`, `choice = a`), never a
+  strong positive. Rewarding an empty gate would optimize toward "merges that
+  pass no real CI"; the no-CI guard reads the combined status at the merged head
+  SHA and demotes it.
+- **Blocked at the merge gate** → authoritative gate-fail (`hard = 0`,
+  `choice = b`).
+- **Review changes_requested** → graded negative (`choice = b`) whose score
+  decreases with the fix-round count.
+- **Reverted** → corrective negative. A later revert of a previously-merged PR
+  **re-upserts the same** `UNIQUE(run_id, item_id, reviewer, source, source_url)`
+  row, flipping the earlier positive `choice = a` to `choice = b` **in place**
+  (the row count is unchanged).
+
+**Scope.** Only implement-family jobs that carry a template attribution are
+harvested; coordinator continuation jobs (which produce no diff of their own) and
+non-implement jobs are skipped. Only genuine outcome transitions are harvested —
+operational job events (`runtime_lock_wait`, `repair_retry`,
+`comment_post_failed`, `advance_retry`, …) never produce feedback. Harvesting is
+**best-effort**: a harvest error never blocks or fails a job; it is swallowed and
+recorded as an `auto_trace_harvest_failed` job event.
+
+**Export side.** When `ExportTrainingPackage` runs over an auto-trace run, the
+run-level `feedback_context.feedback_source` is `automatic_trace` (rather than the
+human default `imported_human_review`), and the run lives in its own
+`auto-trace:<version>` namespace, so a consumer can filter or down-weight
+automatic feedback independently of sparse human gold. A human run never carries
+the `feedback_source` metadata key, so its export is byte-identical.
+
 ## Ranked Exploration Workflow
 
 Use ranked exploration when the template is still ambiguous and humans need to

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -191,7 +191,12 @@ mirrors the off-by-default `[events]` stream.
 - **Reverted** → corrective negative. A later revert of a previously-merged PR
   **re-upserts the same** `UNIQUE(run_id, item_id, reviewer, source, source_url)`
   row, flipping the earlier positive `choice = a` to `choice = b` **in place**
-  (the row count is unchanged).
+  (the row count is unchanged). **Not yet wired:** the projection and the
+  in-place corrective upsert are implemented and unit-tested, but no engine or
+  daemon path detects a revert and fires the `reverted` outcome today, so in a
+  running daemon a merged-then-reverted PR keeps its prior positive until revert
+  detection is wired (a follow-on). The corrective-overwrite mechanics above are
+  reachable only by invoking the harvester directly with a `reverted` outcome.
 
 **Scope.** Only implement-family jobs that carry a template attribution are
 harvested; coordinator continuation jobs (which produce no diff of their own) and

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3968,6 +3968,15 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// byte-identical. The sink is a process-global shared singleton (one drain
 		// goroutine), so re-building the engine per tick never leaks goroutines.
 		EventSink: daemonEventSink(store, home),
+		// Off-by-default Mode-A trace-harvester (#465): on a verifiable implement-job
+		// outcome (merge merged/blocked, review changes_requested, revert) the engine
+		// harvests a synthetic {score, feedback} FeedbackEvent for the job's template
+		// version through this best-effort, nil-safe seam. daemonOutcomeHarvester
+		// returns nil unless [skillopt].auto_trace_enabled is set, so with no config
+		// NO harvester is constructed and behavior — and every human-run
+		// TrainingPackage — is byte-identical. The harvester writes ONLY
+		// eval/feedback rows; promotion stays 100% manual.
+		OutcomeHarvester: daemonOutcomeHarvester(store, gh, home),
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},

--- a/internal/cli/trace_harvest_daemon.go
+++ b/internal/cli/trace_harvest_daemon.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// daemonOutcomeHarvester returns the best-effort Mode-A trace-harvester for this
+// home, or nil when [skillopt].auto_trace_enabled is OFF (the default, or any
+// config load failure — fail-safe to disabled so a malformed config never starts
+// harvesting). When nil, the engine constructs no Outcome and calls no Harvest,
+// so daemon behavior and every human-run TrainingPackage stay byte-identical
+// (#465). It mirrors daemonEventSink's off-by-default admission gate.
+//
+// Unlike the webhook sink, the harvester owns no goroutine and holds only a store
+// + a read-only GitHub status reader, so it is constructed per engine without
+// caching — the gate read is the only cost, and that only matters once enabled.
+func daemonOutcomeHarvester(store *db.Store, gh github.Client, home string) workflow.OutcomeHarvester {
+	if store == nil {
+		return nil
+	}
+	policy, err := loadSkillOptPolicy(home)
+	if err != nil || !policy.Enabled() {
+		return nil
+	}
+	return skillopt.NewOutcomeHarvester(store, gh)
+}
+
+// loadSkillOptPolicy resolves the [skillopt] policy for a home, fail-safe to the
+// disabled default when the home or config cannot be resolved/parsed so the
+// trace-harvester stays OFF rather than erroring the daemon (mirrors
+// loadEventsPolicy / the #446 fail-safe-to-disabled pattern).
+func loadSkillOptPolicy(home string) (config.SkillOptPolicy, error) {
+	cfg := resolveConfigFile(home)
+	if cfg == "" {
+		return config.DefaultSkillOptPolicy(), nil
+	}
+	return config.LoadSkillOptPolicy(config.Paths{ConfigFile: cfg})
+}

--- a/internal/cli/trace_harvest_daemon_test.go
+++ b/internal/cli/trace_harvest_daemon_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+// openHarvestStore opens a throwaway SQLite store for the harvester-wiring tests.
+func openHarvestStore(t *testing.T) *db.Store {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+// writeHarvestConfig writes a config.toml under <home>/.gitmoot and returns the
+// resolved home ROOT (what daemonWorkflowEngine passes to daemonOutcomeHarvester).
+func writeHarvestConfig(t *testing.T, body string) string {
+	t.Helper()
+	home := t.TempDir()
+	root := config.PathsForHome(home).Home // <home>/.gitmoot
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, config.ConfigName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// TestDaemonOutcomeHarvesterDisabledByDefault proves the off-by-default guarantee
+// (#465): with no [skillopt] section (or no config at all), no harvester is
+// constructed so daemon behavior and every human-run TrainingPackage are
+// byte-identical. Mirrors event_sink_resolve_test.go's disabled assertions.
+func TestDaemonOutcomeHarvesterDisabledByDefault(t *testing.T) {
+	store := openHarvestStore(t)
+
+	// No config file at all (empty home).
+	if h := daemonOutcomeHarvester(store, github.NoopClient{}, t.TempDir()); h != nil {
+		t.Fatal("expected nil harvester with no config (off by default)")
+	}
+
+	// A config with no [skillopt] section.
+	root := writeHarvestConfig(t, "[orchestrate]\n")
+	if h := daemonOutcomeHarvester(store, github.NoopClient{}, root); h != nil {
+		t.Fatal("expected nil harvester when [skillopt] is absent")
+	}
+
+	// An explicit auto_trace_enabled = false.
+	rootFalse := writeHarvestConfig(t, "[skillopt]\nauto_trace_enabled = false\n")
+	if h := daemonOutcomeHarvester(store, github.NoopClient{}, rootFalse); h != nil {
+		t.Fatal("expected nil harvester when auto_trace_enabled = false")
+	}
+}
+
+// TestDaemonOutcomeHarvesterEnabled proves a non-nil harvester is wired only when
+// [skillopt].auto_trace_enabled = true.
+func TestDaemonOutcomeHarvesterEnabled(t *testing.T) {
+	store := openHarvestStore(t)
+	root := writeHarvestConfig(t, "[skillopt]\nauto_trace_enabled = true\n")
+	h := daemonOutcomeHarvester(store, github.NoopClient{}, root)
+	if h == nil {
+		t.Fatal("expected a non-nil harvester when auto_trace_enabled = true")
+	}
+}
+
+// TestDaemonOutcomeHarvesterNilStore proves a nil store never yields a harvester
+// (defensive: the harvester has nothing to write to).
+func TestDaemonOutcomeHarvesterNilStore(t *testing.T) {
+	root := writeHarvestConfig(t, "[skillopt]\nauto_trace_enabled = true\n")
+	if h := daemonOutcomeHarvester(nil, github.NoopClient{}, root); h != nil {
+		t.Fatal("expected nil harvester with a nil store")
+	}
+}
+
+// TestDaemonOutcomeHarvesterFailSafeOnBadConfig proves a malformed [skillopt]
+// value fails safe to disabled (nil harvester) rather than erroring the daemon —
+// mirroring the #446 fail-safe-to-disabled pattern.
+func TestDaemonOutcomeHarvesterFailSafeOnBadConfig(t *testing.T) {
+	store := openHarvestStore(t)
+	root := writeHarvestConfig(t, "[skillopt]\nauto_trace_enabled = not-a-bool\n")
+	if h := daemonOutcomeHarvester(store, github.NoopClient{}, root); h != nil {
+		t.Fatal("expected nil harvester when the [skillopt] config is malformed (fail-safe to disabled)")
+	}
+}
+
+// TestDaemonWorkflowEngineNilHarvesterByDefault proves the full engine wiring
+// leaves OutcomeHarvester nil with no [skillopt] config, so the engine constructs
+// no Outcome and harvests nothing (byte-identical default).
+func TestDaemonWorkflowEngineNilHarvesterByDefault(t *testing.T) {
+	store := openHarvestStore(t)
+	engine := daemonWorkflowEngine(store, github.NoopClient{}, "/tmp/gitmoot-checkout", "")
+	if engine.OutcomeHarvester != nil {
+		t.Fatal("daemonWorkflowEngine must wire a nil OutcomeHarvester with no [skillopt] config")
+	}
+}

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -361,3 +361,74 @@ func validateEventsPolicy(policy EventsPolicy) error {
 	}
 	return nil
 }
+
+// SkillOptPolicy is the host-level template-learning policy read from the
+// [skillopt] section of the gitmoot config (#465, Mode A). It gates the
+// off-by-default automatic trace-harvester: when AutoTraceEnabled is false (the
+// default) NO OutcomeHarvester is constructed and behavior is byte-identical
+// (no synthetic feedback rows are ever written). It mirrors EventsPolicy's
+// off-by-default admission knob; the daemon uses it to decide whether to wire a
+// best-effort harvester into the workflow engine. Promotion stays 100% manual
+// regardless of this knob — the harvester only writes eval/feedback rows.
+type SkillOptPolicy struct {
+	// AutoTraceEnabled opts the daemon into Mode A automatic trace-harvested
+	// feedback (#465): when true, an implement job's verifiable terminal outcome
+	// (merge merged/blocked, review decision, revert) is projected into a synthetic
+	// FeedbackEvent in a dedicated auto-trace eval_run. Empty/false (the default)
+	// means OFF: no harvester is constructed and the daemon writes nothing extra.
+	AutoTraceEnabled bool
+}
+
+func DefaultSkillOptPolicy() SkillOptPolicy {
+	return SkillOptPolicy{
+		AutoTraceEnabled: false,
+	}
+}
+
+// Enabled reports whether the automatic trace-harvester is configured on. With
+// no [skillopt] config (the default) it is OFF and no harvester is constructed.
+func (p SkillOptPolicy) Enabled() bool {
+	return p.AutoTraceEnabled
+}
+
+func LoadSkillOptPolicy(paths Paths) (SkillOptPolicy, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return SkillOptPolicy{}, err
+	}
+	policy := DefaultSkillOptPolicy()
+	current := false
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			current = strings.TrimSpace(section) == "skillopt"
+			continue
+		}
+		if !current {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if err := applySkillOptPolicyField(&policy, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
+			return SkillOptPolicy{}, fmt.Errorf("parse [skillopt].%s: %w", strings.TrimSpace(key), err)
+		}
+	}
+	return policy, nil
+}
+
+func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) error {
+	switch key {
+	case "auto_trace_enabled":
+		parsed, err := strconv.ParseBool(value)
+		policy.AutoTraceEnabled = parsed
+		return err
+	default:
+		return nil
+	}
+}

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadSkillOptPolicyDefaultsDisabled(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	// With no [skillopt] section the trace-harvester is OFF.
+	if policy.Enabled() || policy.AutoTraceEnabled {
+		t.Fatalf("default SkillOptPolicy must be disabled, got %+v", policy)
+	}
+}
+
+func TestLoadSkillOptPolicyParsesAutoTraceEnabled(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_trace_enabled = true
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.Enabled() || !policy.AutoTraceEnabled {
+		t.Fatalf("SkillOptPolicy with auto_trace_enabled = true should be enabled, got %+v", policy)
+	}
+}
+
+func TestLoadSkillOptPolicyRejectsBadBool(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_trace_enabled = maybe
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadSkillOptPolicy(paths); err == nil {
+		t.Fatal("expected an error for a non-bool auto_trace_enabled")
+	}
+}
+
+// TestLoadSkillOptPolicyIgnoresOtherSections proves a config that only sets
+// [events]/[orchestrate] leaves the trace-harvester at its disabled default.
+func TestLoadSkillOptPolicyIgnoresOtherSections(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[events]
+webhook_url = "https://example.test/hook"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if policy.Enabled() {
+		t.Fatalf("SkillOptPolicy must stay disabled when only [events] is set, got %+v", policy)
+	}
+}

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -792,6 +792,11 @@ func evaluatorConfigFromRunMetadata(metadata json.RawMessage) (json.RawMessage, 
 			delete(decoded, "mode")
 		}
 	}
+	// The run-level feedback_source override (set by the Mode-A auto-trace
+	// harvester, #465) is run metadata, not evaluator config — strip it so an
+	// auto-trace run does not surface a spurious evaluator_config. A human run
+	// never carries this key, so its export is unaffected.
+	delete(decoded, feedbackSourceMetadataKey)
 	if len(decoded) == 0 {
 		return nil, nil
 	}
@@ -811,12 +816,30 @@ func isTrainingMode(value string) bool {
 	}
 }
 
+// FeedbackSourceHumanReview is the run-level feedback_source the export stamps on
+// a human-ranked run (the historical default).
+const FeedbackSourceHumanReview = "imported_human_review"
+
+// FeedbackSourceAutomaticTrace is the run-level feedback_source the export stamps
+// on a Mode-A auto-trace run (#465). The harvester sets this in the auto-trace
+// eval_run's metadata_json under feedbackSourceMetadataKey so the optimizer/export
+// side can filter or down-weight automatic feedback independently of sparse human
+// gold, WITHOUT a new contract field or a ContractVersion bump. A human run never
+// carries this key, so its exported feedback_context stays byte-identical.
+const FeedbackSourceAutomaticTrace = "automatic_trace"
+
+// feedbackSourceMetadataKey is the eval_run metadata_json key the export reads to
+// override the run-level feedback_source. It is set only by the auto-trace
+// harvester; a human run omits it (so the default FeedbackSourceHumanReview is
+// used and the bytes are unchanged).
+const feedbackSourceMetadataKey = "feedback_source"
+
 func buildTrainingFeedbackContext(run db.EvalRun, feedback []FeedbackEvent, ranked []RankedFeedbackEvent) (json.RawMessage, error) {
 	if len(feedback) == 0 && len(ranked) == 0 {
 		return nil, nil
 	}
 	context := map[string]any{
-		"feedback_source":        "imported_human_review",
+		"feedback_source":        runFeedbackSource(run),
 		"feedback_target":        "baseline_review_outputs",
 		"review_run_id":          run.ID,
 		"reviewed_skill_version": run.TemplateVersionID,
@@ -832,6 +855,35 @@ func buildTrainingFeedbackContext(run db.EvalRun, feedback []FeedbackEvent, rank
 		return nil, err
 	}
 	return raw, nil
+}
+
+// runFeedbackSource resolves the run-level feedback_source the export stamps into
+// feedback_context. It defaults to FeedbackSourceHumanReview and is overridden
+// ONLY when the run's metadata_json carries a non-empty feedbackSourceMetadataKey
+// (set by the Mode-A auto-trace harvester). This keeps every human run's export
+// byte-identical (its metadata never carries the key) while letting an auto-trace
+// run surface feedback_source=automatic_trace.
+func runFeedbackSource(run db.EvalRun) string {
+	metadata := strings.TrimSpace(run.MetadataJSON)
+	if metadata == "" {
+		return FeedbackSourceHumanReview
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(metadata), &decoded); err != nil {
+		return FeedbackSourceHumanReview
+	}
+	raw, ok := decoded[feedbackSourceMetadataKey]
+	if !ok {
+		return FeedbackSourceHumanReview
+	}
+	var source string
+	if err := json.Unmarshal(raw, &source); err != nil {
+		return FeedbackSourceHumanReview
+	}
+	if source = strings.TrimSpace(source); source != "" {
+		return source
+	}
+	return FeedbackSourceHumanReview
 }
 
 func reviewIssueFromFeedback(feedback []FeedbackEvent, ranked []RankedFeedbackEvent) string {

--- a/internal/skillopt/contract_test.go
+++ b/internal/skillopt/contract_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1676,5 +1677,133 @@ func TestProjectSignalDoesNotChangeWirePackages(t *testing.T) {
 	}
 	if string(reMarshaled) != wantCandidate {
 		t.Fatalf("ProjectSignal mutated the candidate package")
+	}
+}
+
+// TestHumanRunFeedbackContextByteIdentical pins the exact feedback_context bytes
+// of a human-ranked run's exported TrainingPackage (#465 acceptance: the Mode-A
+// auto-trace feedback_source override must NEVER leak into a human run). A human
+// run's eval_run metadata never carries the feedback_source key, so runFeedbackSource
+// falls back to imported_human_review and the bytes are unchanged from before the
+// harvester existed. The companion auto-trace assertion lives in
+// TestExportAutoTraceRunFeedbackSource.
+func TestHumanRunFeedbackContextByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertAgentTemplate(ctx, testTemplate("planner", "Plan carefully.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	// A human run carries NO feedback_source in metadata_json.
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "human-run-1",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "ready",
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:  "human-run-1",
+		ItemID: "item-001",
+		Title:  "README",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	if err := store.UpsertFeedbackEvent(ctx, db.FeedbackEvent{
+		RunID:     "human-run-1",
+		ItemID:    "item-001",
+		Choice:    "b",
+		Reasoning: "More specific.",
+		Reviewer:  "jerry",
+		Source:    "markdown",
+		SourceURL: "https://github.com/owner/repo/pull/1",
+		CreatedAt: "2026-05-31T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertFeedbackEvent returned error: %v", err)
+	}
+	pkg, err := ExportTrainingPackage(ctx, store, "human-run-1")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	// Pinned bytes: the historical human feedback_context, unchanged.
+	want := fmt.Sprintf(
+		`{"feedback_source":"imported_human_review","feedback_target":"baseline_review_outputs","review_issue":"owner/repo#1","review_run_id":"human-run-1","reviewed_skill_version":%q,"target_repo":"owner/repo"}`,
+		installed.VersionID,
+	)
+	if string(pkg.FeedbackContext) != want {
+		t.Fatalf("human feedback_context bytes changed:\n got %s\nwant %s", pkg.FeedbackContext, want)
+	}
+	if strings.Contains(string(pkg.FeedbackContext), FeedbackSourceAutomaticTrace) {
+		t.Fatalf("auto-trace feedback_source leaked into a human run: %s", pkg.FeedbackContext)
+	}
+}
+
+// TestExportAutoTraceRunFeedbackSource asserts the companion: an eval_run whose
+// metadata_json carries feedback_source=automatic_trace exports with that
+// run-level feedback_source (and no spurious evaluator_config), without any
+// contract field or ContractVersion change (#465).
+func TestExportAutoTraceRunFeedbackSource(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertAgentTemplate(ctx, testTemplate("planner", "Plan carefully.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "auto-trace:" + installed.VersionID,
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "ready",
+		Mode:              db.EvalRunModeValidate,
+		MetadataJSON:      `{"feedback_source":"automatic_trace","mode":"validate"}`,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:  "auto-trace:" + installed.VersionID,
+		ItemID: "owner/repo#7",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	if err := store.UpsertFeedbackEvent(ctx, db.FeedbackEvent{
+		RunID:     "auto-trace:" + installed.VersionID,
+		ItemID:    "owner/repo#7",
+		Choice:    "a",
+		Reviewer:  "gitmoot-auto",
+		Source:    "auto-trace",
+		SourceURL: "https://github.com/owner/repo/pull/7",
+	}); err != nil {
+		t.Fatalf("UpsertFeedbackEvent returned error: %v", err)
+	}
+	pkg, err := ExportTrainingPackage(ctx, store, "auto-trace:"+installed.VersionID)
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	var fc map[string]any
+	if err := json.Unmarshal(pkg.FeedbackContext, &fc); err != nil {
+		t.Fatalf("feedback context did not unmarshal: %v", err)
+	}
+	if fc["feedback_source"] != FeedbackSourceAutomaticTrace {
+		t.Fatalf("auto-trace feedback_source = %v, want %q", fc["feedback_source"], FeedbackSourceAutomaticTrace)
+	}
+	if len(pkg.EvaluatorConfig) != 0 {
+		t.Fatalf("auto-trace run leaked evaluator_config = %s", string(pkg.EvaluatorConfig))
 	}
 }

--- a/internal/skillopt/trace_harvest.go
+++ b/internal/skillopt/trace_harvest.go
@@ -1,0 +1,426 @@
+package skillopt
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// gitmootNoCIContext is the synthetic commit-status context the merge gate writes
+// (internal/workflow/merge_gate.go) EXACTLY when a PR head carries zero external
+// checks and zero external statuses — i.e. it merged through an EMPTY gate. The
+// no-CI guard treats its presence (or the absence of any non-gitmoot/ external
+// status) as "no real CI" and demotes the merge to near-neutral so the harvester
+// never rewards "merges that pass no real CI" (#465, #463 guardrail).
+const gitmootNoCIContext = "gitmoot/ci"
+
+// autoTraceSource is the FeedbackEvent.source tag every synthetic auto-trace row
+// carries (#465). Combined with autoTraceReviewer it makes auto feedback
+// identifiable per-event even within a mixed package, and the UNIQUE
+// (run_id,item_id,reviewer,source,source_url) key it participates in is what lets
+// a later revert overwrite the prior positive in place.
+const autoTraceSource = "auto-trace"
+
+// autoTraceReviewer is the FeedbackEvent.reviewer attributed to every synthetic
+// auto-trace row (#465): a sentinel non-human reviewer so auto feedback is never
+// mistaken for a human ranking.
+const autoTraceReviewer = "gitmoot-auto"
+
+// autoTraceRunIDPrefix namespaces the dedicated per-template-version auto-trace
+// eval_run id ("auto-trace:"+versionID) so human-gold runs stay entirely
+// untouched and the export/optimizer can filter or down-weight the auto namespace
+// independently (#465).
+const autoTraceRunIDPrefix = "auto-trace:"
+
+// Score bands for the verifiable-outcome → {score, feedback} projection (#465).
+// These feed a synthetic EvaluatorScore that ProjectSignal fuses into one
+// NormalizedSignal, keeping signal assembly in the single canonical place.
+const (
+	// scoreMergedRealCI is the strong-positive Soft score for a merge that passed a
+	// genuine external CI (a non-gitmoot/ status or check that succeeded).
+	scoreMergedRealCI = 1.0
+	// scoreMergedNoCI is the near-neutral Soft score for a merge through an empty
+	// gate (the synthetic gitmoot/ci context, or no external CI at head): not a
+	// strong positive, but not a negative either — absence of verifiable evidence.
+	scoreMergedNoCI = 0.5
+	// scoreChangesRequestedBase is the first-fix-round Soft score for a
+	// changes_requested negative; each additional fix round subtracts
+	// scoreChangesRequestedStep toward 0.
+	scoreChangesRequestedBase = 0.6
+	scoreChangesRequestedStep = 0.2
+)
+
+// CombinedStatusReader is the minimal GitHub read the no-CI guard needs (#465):
+// the combined commit status at a merged head SHA. github.Client satisfies it.
+// It is its own narrow interface so the harvester can be unit-tested with a stub
+// and so the skillopt package depends only on the read it actually uses.
+type CombinedStatusReader interface {
+	GetCombinedStatus(ctx context.Context, repo github.Repository, ref string) (github.CombinedStatus, error)
+}
+
+// OutcomeHarvester implements workflow.OutcomeHarvester (#465, Mode A): on a
+// verifiable implement-job outcome transition it projects the outcome into a
+// synthetic {score, feedback} FeedbackEvent and writes it (plus its dedicated
+// per-template-version eval_run and a per-PR eval_review_item) into the EXISTING
+// feedback tables, tagged source=auto-trace / reviewer=gitmoot-auto. It writes
+// ONLY eval_runs/eval_review_items/feedback_events — never a candidate or
+// promotion path, so promotion stays 100% manual. It is constructed only when
+// [skillopt].auto_trace_enabled is on; the engine calls it best-effort and
+// nil-safe, so a Harvest error never blocks a job.
+type OutcomeHarvester struct {
+	// Store is the SQLite store the synthetic rows are written to.
+	Store *db.Store
+	// Status is the no-CI guard's combined-status reader. It is optional: when nil
+	// (or a read fails), a merge is treated conservatively as no-real-CI
+	// (near-neutral) rather than rewarded as a strong positive, so a missing/erroring
+	// read degrades to the safe band and never blocks the (already-completed) merge.
+	Status CombinedStatusReader
+}
+
+// NewOutcomeHarvester constructs the Mode-A harvester (#465). The returned value
+// satisfies workflow.OutcomeHarvester.
+func NewOutcomeHarvester(store *db.Store, status CombinedStatusReader) *OutcomeHarvester {
+	return &OutcomeHarvester{Store: store, Status: status}
+}
+
+var _ workflow.OutcomeHarvester = (*OutcomeHarvester)(nil)
+
+// Harvest projects a verifiable implement-job outcome into a synthetic
+// FeedbackEvent for the job's template version (#465). It is in-scope only for
+// implement-family jobs that carry a template attribution and are NOT coordinator
+// continuation jobs; an out-of-scope job returns nil (no rows written). All writes
+// are best-effort from the engine's perspective: a returned error is swallowed by
+// the engine and recorded as an auto_trace_harvest_failed job event.
+func (h *OutcomeHarvester) Harvest(ctx context.Context, job db.Job, payload workflow.JobPayload, outcome workflow.Outcome) error {
+	if h == nil || h.Store == nil {
+		return nil
+	}
+	if !inScope(job, payload) {
+		return nil
+	}
+	version, ok, err := h.resolveTemplateVersion(ctx, payload)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		// Unresolvable template version: skip rather than guess (#465 risk note).
+		return nil
+	}
+	signal, choice := h.project(ctx, payload, outcome)
+	return h.writeFeedback(ctx, version, payload, outcome, signal, choice)
+}
+
+// inScope reports whether a job is an implement-family job the harvester should
+// score (#465): it must be an implement job that carries a template attribution
+// and must NOT be a coordinator continuation (a job with a parent/delegation but
+// no own diff/PR). A coordinator continuation produces no diff of its own, so
+// scoring it would mis-attribute the children's outcome to the coordinator's
+// template — it is skipped.
+func inScope(job db.Job, payload workflow.JobPayload) bool {
+	if job.Type != "implement" {
+		return false
+	}
+	if strings.TrimSpace(payload.TemplateID) == "" {
+		return false
+	}
+	if isCoordinatorContinuation(payload) {
+		return false
+	}
+	return true
+}
+
+// isCoordinatorContinuation reports whether the payload is a coordinator
+// continuation job (the Orchestra pattern's synthesis leg): it carries a
+// delegation/parent linkage or is flagged as a finalize continuation but produced
+// no PR of its own. Such a job has no diff to attribute an outcome to, so it is
+// out of scope for the harvester.
+func isCoordinatorContinuation(payload workflow.JobPayload) bool {
+	if payload.DelegationFinalize {
+		return true
+	}
+	// A delegation/continuation leg with no own PR has no diff to score.
+	if strings.TrimSpace(payload.ParentJobID) != "" && payload.PullRequest <= 0 {
+		return true
+	}
+	if strings.TrimSpace(payload.DelegationID) != "" && payload.PullRequest <= 0 {
+		return true
+	}
+	return false
+}
+
+// resolveTemplateVersion resolves the job's template version id from its payload
+// attribution (#465). It prefers TemplateResolvedCommit (the exact version the
+// job ran) matched against the template's versions, falling back to the
+// template's current version when the commit cannot be matched. Returns ok=false
+// (skip, do not guess) when neither the template nor a version can be resolved.
+func (h *OutcomeHarvester) resolveTemplateVersion(ctx context.Context, payload workflow.JobPayload) (db.AgentTemplateVersion, bool, error) {
+	templateID := strings.TrimSpace(payload.TemplateID)
+	if templateID == "" {
+		return db.AgentTemplateVersion{}, false, nil
+	}
+	resolvedCommit := strings.TrimSpace(payload.TemplateResolvedCommit)
+	if resolvedCommit != "" {
+		versions, err := h.Store.ListAgentTemplateVersions(ctx, templateID)
+		if err == nil {
+			for _, version := range versions {
+				if strings.TrimSpace(version.ResolvedCommit) == resolvedCommit {
+					return version, true, nil
+				}
+			}
+		}
+	}
+	// Fall back to the template's current promoted version.
+	template, err := h.Store.GetAgentTemplate(ctx, templateID)
+	if err != nil {
+		// Best-effort: an unresolvable template is skipped, not an error that would
+		// spam auto_trace_harvest_failed for every legacy/missing-template job.
+		return db.AgentTemplateVersion{}, false, nil
+	}
+	versionID := strings.TrimSpace(template.VersionID)
+	if versionID == "" {
+		return db.AgentTemplateVersion{}, false, nil
+	}
+	version, err := h.Store.GetAgentTemplateVersionByID(ctx, versionID)
+	if err != nil {
+		return db.AgentTemplateVersion{}, false, nil
+	}
+	return version, true, nil
+}
+
+// project maps a verifiable outcome to a NormalizedSignal (via ProjectSignal over
+// a synthetic EvaluatorScore) and the a/b feedback choice (#465). A positive
+// outcome is choice "a" (the current promoted template as the implicit baseline
+// champion); a negative is choice "b". The no-CI guard runs here for a merge.
+func (h *OutcomeHarvester) project(ctx context.Context, payload workflow.JobPayload, outcome workflow.Outcome) (NormalizedSignal, string) {
+	switch outcome.Kind {
+	case workflow.OutcomeMerged:
+		if h.mergeHasRealCI(ctx, outcome) {
+			return positiveSignal(scoreMergedRealCI,
+				fmt.Sprintf("PR #%d merged with passing external CI.", outcome.PullRequest)), "a"
+		}
+		return positiveSignal(scoreMergedNoCI,
+			fmt.Sprintf("PR #%d merged through an empty gate (no external CI); near-neutral, not a strong positive.", outcome.PullRequest)), "a"
+	case workflow.OutcomeBlocked:
+		reason := strings.TrimSpace(outcome.Reason)
+		if reason == "" {
+			reason = "merge gate rejected the action"
+		}
+		return negativeSignal(0,
+			fmt.Sprintf("PR #%d was blocked at the merge gate: %s", outcome.PullRequest, reason)), "b"
+	case workflow.OutcomeChangesRequested:
+		score := changesRequestedScore(outcome.FixRounds)
+		reason := strings.TrimSpace(outcome.Reason)
+		detail := fmt.Sprintf("Review requested changes on PR #%d (fix round %d).", outcome.PullRequest, fixRoundFloor(outcome.FixRounds))
+		if reason != "" {
+			detail += " " + reason
+		}
+		return gradedSignal(score, detail), "b"
+	case workflow.OutcomeReverted:
+		return negativeSignal(0,
+			fmt.Sprintf("PR #%d was later reverted; the prior positive is corrected to a negative.", outcome.PullRequest)), "b"
+	default:
+		// An unknown outcome kind is treated as a weak neutral negative rather than a
+		// strong signal; it should never occur because the engine only emits the four
+		// known kinds.
+		return gradedSignal(scoreMergedNoCI,
+			fmt.Sprintf("Unclassified outcome on PR #%d.", outcome.PullRequest)), "b"
+	}
+}
+
+// mergeHasRealCI reports whether the merged head carries a GENUINE external CI
+// success — a non-gitmoot/ commit status that succeeded — so the no-CI guard can
+// distinguish a real CI pass (strong+) from an empty-gate merge (near-neutral).
+// It reads the combined status at the merged head SHA best-effort: a nil reader,
+// a read error, or the synthetic gitmoot/ci context (with no external status) all
+// degrade to false (no real CI), so a missing read is never rewarded as a strong
+// positive (#465).
+func (h *OutcomeHarvester) mergeHasRealCI(ctx context.Context, outcome workflow.Outcome) bool {
+	if h.Status == nil {
+		return false
+	}
+	head := strings.TrimSpace(outcome.HeadSHA)
+	if head == "" {
+		return false
+	}
+	repo, ok := parseRepo(outcome.Repo)
+	if !ok {
+		return false
+	}
+	status, err := h.Status.GetCombinedStatus(ctx, repo, head)
+	if err != nil {
+		return false
+	}
+	for _, item := range status.Statuses {
+		context := strings.TrimSpace(item.Context)
+		if context == "" || strings.HasPrefix(context, "gitmoot/") {
+			// gitmoot/* (including the synthetic gitmoot/ci and the merge-gate context)
+			// are not external CI; skip them.
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(item.State), "success") {
+			return true
+		}
+	}
+	return false
+}
+
+// changesRequestedScore grades a changes_requested negative by fix-round count
+// (#465): round 1 ≈ 0.6, each additional round subtracts a step toward 0.
+func changesRequestedScore(fixRounds int) float64 {
+	round := fixRoundFloor(fixRounds)
+	score := scoreChangesRequestedBase - float64(round-1)*scoreChangesRequestedStep
+	if score < 0 {
+		score = 0
+	}
+	return score
+}
+
+// fixRoundFloor clamps a fix-round count to at least 1 so a first/legacy
+// changes_requested always grades as round 1.
+func fixRoundFloor(fixRounds int) int {
+	if fixRounds < 1 {
+		return 1
+	}
+	return fixRounds
+}
+
+// positiveSignal builds a NormalizedSignal for a positive outcome via
+// ProjectSignal over a synthetic Soft EvaluatorScore, so signal assembly stays in
+// the single canonical place (#465). The textual feedback rides RankedFeedbackEvent.Reasoning.
+func positiveSignal(score float64, feedback string) NormalizedSignal {
+	soft := score
+	return ProjectSignal(&EvaluatorScore{Soft: &soft}, &RankedFeedbackEvent{Reasoning: feedback}, nil)
+}
+
+// gradedSignal builds a NormalizedSignal for a graded (Soft) outcome.
+func gradedSignal(score float64, feedback string) NormalizedSignal {
+	soft := score
+	return ProjectSignal(&EvaluatorScore{Soft: &soft}, &RankedFeedbackEvent{Reasoning: feedback}, nil)
+}
+
+// negativeSignal builds a NormalizedSignal for an authoritative gate-fail
+// negative via a synthetic Hard==0 EvaluatorScore (ProjectSignal reads Hard==0 as
+// an informative 0, HasScore=true) and an optimizer-hint failure packet so the
+// feedback explains the failure (#465).
+func negativeSignal(hard float64, feedback string) NormalizedSignal {
+	h := hard
+	return ProjectSignal(&EvaluatorScore{Hard: &h}, nil, &EvaluatorFailurePacket{OptimizerHint: feedback})
+}
+
+// writeFeedback upserts the dedicated per-template-version auto-trace eval_run,
+// the per-PR eval_review_item, and the synthetic FeedbackEvent for one outcome
+// (#465). The FeedbackEvent's UNIQUE (run_id,item_id,reviewer,source,source_url)
+// key is deterministic per PR, so a later revert re-upserts the SAME row in place
+// (corrective overwrite, row count unchanged).
+func (h *OutcomeHarvester) writeFeedback(ctx context.Context, version db.AgentTemplateVersion, payload workflow.JobPayload, outcome workflow.Outcome, signal NormalizedSignal, choice string) error {
+	runID := autoTraceRunIDPrefix + strings.TrimSpace(version.ID)
+	itemID := autoTraceItemID(outcome)
+	sourceURL := pullRequestURL(outcome.Repo, outcome.PullRequest)
+
+	if err := h.Store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                runID,
+		TemplateID:        strings.TrimSpace(version.TemplateID),
+		TemplateVersionID: strings.TrimSpace(version.ID),
+		TargetRepo:        strings.TrimSpace(outcome.Repo),
+		State:             "ready",
+		Mode:              db.EvalRunModeValidate,
+		MetadataJSON:      autoTraceRunMetadata(),
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace eval_run: %w", err)
+	}
+
+	if err := h.Store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:        runID,
+		ItemID:       itemID,
+		Title:        autoTraceItemTitle(outcome),
+		MetadataJSON: autoTraceItemMetadata(outcome),
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace eval_review_item: %w", err)
+	}
+
+	if err := h.Store.UpsertFeedbackEvent(ctx, db.FeedbackEvent{
+		RunID:     runID,
+		ItemID:    itemID,
+		Choice:    choice,
+		Reasoning: signal.Feedback,
+		Reviewer:  autoTraceReviewer,
+		Source:    autoTraceSource,
+		SourceURL: sourceURL,
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace feedback_event: %w", err)
+	}
+	return nil
+}
+
+// autoTraceRunMetadata is the eval_run metadata_json for the auto-trace run. It
+// carries feedback_source=automatic_trace so ExportTrainingPackage stamps the
+// run-level feedback_source as automatic_trace (and the run is filterable),
+// WITHOUT a new contract field, and the validate mode so evaluatorConfig stays
+// empty.
+func autoTraceRunMetadata() string {
+	raw, _ := json.Marshal(map[string]any{
+		feedbackSourceMetadataKey: FeedbackSourceAutomaticTrace,
+		"mode":                    db.EvalRunModeValidate,
+	})
+	return string(raw)
+}
+
+// autoTraceItemID is the per-PR/per-job eval item id (#465 risk note): distinct
+// PRs must not collide under one UNIQUE(run_id,item_id), but the SAME PR being
+// re-evaluated (e.g. a merge then a revert) MUST map to the same item so the
+// revert overwrites the prior row. It is keyed by repo#pr.
+func autoTraceItemID(outcome workflow.Outcome) string {
+	repo := strings.TrimSpace(outcome.Repo)
+	if outcome.PullRequest > 0 {
+		return fmt.Sprintf("%s#%d", repo, outcome.PullRequest)
+	}
+	// No PR (defensive): hash the repo so the item is still deterministic.
+	sum := sha256.Sum256([]byte(repo))
+	return "pr-" + hex.EncodeToString(sum[:8])
+}
+
+func autoTraceItemTitle(outcome workflow.Outcome) string {
+	repo := strings.TrimSpace(outcome.Repo)
+	if outcome.PullRequest > 0 {
+		return fmt.Sprintf("%s PR #%d", repo, outcome.PullRequest)
+	}
+	return repo
+}
+
+func autoTraceItemMetadata(outcome workflow.Outcome) string {
+	raw, _ := json.Marshal(map[string]any{
+		"repo":         strings.TrimSpace(outcome.Repo),
+		"pull_request": outcome.PullRequest,
+	})
+	return string(raw)
+}
+
+// pullRequestURL builds the canonical PR html URL used as the FeedbackEvent
+// source_url (part of the UNIQUE corrective-overwrite key). Empty repo/PR yields
+// "" so a malformed outcome still produces a valid (empty source_url) key.
+func pullRequestURL(repo string, pullRequest int) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" || pullRequest <= 0 {
+		return ""
+	}
+	return "https://github.com/" + repo + "/pull/" + strconv.Itoa(pullRequest)
+}
+
+// parseRepo splits an "owner/name" repo into a github.Repository for the no-CI
+// guard's status read. It reports ok=false for a malformed repo (so the guard
+// degrades to no-real-CI rather than panicking).
+func parseRepo(value string) (github.Repository, bool) {
+	owner, name, ok := strings.Cut(strings.TrimSpace(value), "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return github.Repository{}, false
+	}
+	return github.Repository{Owner: owner, Name: name}, true
+}

--- a/internal/skillopt/trace_harvest.go
+++ b/internal/skillopt/trace_harvest.go
@@ -59,11 +59,23 @@ const (
 )
 
 // CombinedStatusReader is the minimal GitHub read the no-CI guard needs (#465):
-// the combined commit status at a merged head SHA. github.Client satisfies it.
-// It is its own narrow interface so the harvester can be unit-tested with a stub
-// and so the skillopt package depends only on the read it actually uses.
+// the combined commit status at a head SHA AND the PR's check-runs. github.Client
+// satisfies it. It is its own narrow interface so the harvester can be unit-tested
+// with a stub and so the skillopt package depends only on the reads it actually
+// uses.
+//
+// Both reads are required because the merge gate's ensureStatuses
+// (internal/workflow/merge_gate.go) counts BOTH external commit-statuses (legacy
+// Travis/Jenkins, via GetCombinedStatus.Statuses) AND external check-runs (modern
+// GitHub Actions, via ListPullRequestChecks) as real CI, and only writes the
+// synthetic gitmoot/ci commit-status when BOTH external counts are zero. A no-CI
+// guard that read only commit-statuses would misclassify the dominant
+// Actions-only configuration (zero legacy statuses, CI reported as check-runs) as
+// no-real-CI and under-reward a genuine CI pass — so the guard mirrors the gate
+// and consults check-runs too.
 type CombinedStatusReader interface {
 	GetCombinedStatus(ctx context.Context, repo github.Repository, ref string) (github.CombinedStatus, error)
+	ListPullRequestChecks(ctx context.Context, repo github.Repository, number int64) ([]github.PullRequestCheck, error)
 }
 
 // OutcomeHarvester implements workflow.OutcomeHarvester (#465, Mode A): on a
@@ -235,13 +247,19 @@ func (h *OutcomeHarvester) project(ctx context.Context, payload workflow.JobPayl
 	}
 }
 
-// mergeHasRealCI reports whether the merged head carries a GENUINE external CI
-// success — a non-gitmoot/ commit status that succeeded — so the no-CI guard can
-// distinguish a real CI pass (strong+) from an empty-gate merge (near-neutral).
-// It reads the combined status at the merged head SHA best-effort: a nil reader,
-// a read error, or the synthetic gitmoot/ci context (with no external status) all
-// degrade to false (no real CI), so a missing read is never rewarded as a strong
-// positive (#465).
+// mergeHasRealCI reports whether the PR head carries a GENUINE external CI success
+// so the no-CI guard can distinguish a real CI pass (strong+) from an empty-gate
+// merge (near-neutral). It mirrors the merge gate's own ensureStatuses detection:
+// a non-gitmoot/ commit status that succeeded (legacy Travis/Jenkins) OR a
+// non-gitmoot/ check-run that passed (modern GitHub Actions) counts as real CI.
+//
+// It reads at the PR HEAD SHA (Outcome.HeadSHA = payload.HeadSHA) — the SHA the
+// merge gate evaluated and posted statuses/checks at — NOT the merge commit;
+// GitHub does not copy statuses/checks onto the merge commit, so a read there
+// would always be empty. Both reads are best-effort: a nil reader, a read error,
+// no PR number, or only the synthetic gitmoot/ci context (with no external CI)
+// all degrade to false (no real CI), so a missing read is never rewarded as a
+// strong positive (#465).
 func (h *OutcomeHarvester) mergeHasRealCI(ctx context.Context, outcome workflow.Outcome) bool {
 	if h.Status == nil {
 		return false
@@ -254,22 +272,53 @@ func (h *OutcomeHarvester) mergeHasRealCI(ctx context.Context, outcome workflow.
 	if !ok {
 		return false
 	}
-	status, err := h.Status.GetCombinedStatus(ctx, repo, head)
+	if status, err := h.Status.GetCombinedStatus(ctx, repo, head); err == nil {
+		for _, item := range status.Statuses {
+			context := strings.TrimSpace(item.Context)
+			if context == "" || strings.HasPrefix(context, "gitmoot/") {
+				// gitmoot/* (including the synthetic gitmoot/ci and the merge-gate context)
+				// are not external CI; skip them.
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(item.State), "success") {
+				return true
+			}
+		}
+	}
+	// Also consult GitHub Actions check-runs (the dominant modern CI model), which
+	// report as check-runs NOT commit-statuses, mirroring ensureStatuses'
+	// externalCheckCount. A passing non-gitmoot/merge-gate check is real CI.
+	if outcome.PullRequest <= 0 {
+		return false
+	}
+	checks, err := h.Status.ListPullRequestChecks(ctx, repo, int64(outcome.PullRequest))
 	if err != nil {
 		return false
 	}
-	for _, item := range status.Statuses {
-		context := strings.TrimSpace(item.Context)
-		if context == "" || strings.HasPrefix(context, "gitmoot/") {
-			// gitmoot/* (including the synthetic gitmoot/ci and the merge-gate context)
-			// are not external CI; skip them.
+	for _, check := range checks {
+		name := strings.TrimSpace(check.Name)
+		if name == "" || strings.HasPrefix(name, "gitmoot/") {
+			// gitmoot/* checks (e.g. gitmoot/merge-gate) are not external CI; skip them.
 			continue
 		}
-		if strings.EqualFold(strings.TrimSpace(item.State), "success") {
+		if checkPassed(check) {
 			return true
 		}
 	}
 	return false
+}
+
+// checkPassed reports whether a GitHub Actions check-run passed, mirroring the
+// merge gate's checkPassed (internal/workflow/merge_gate.go): prefer the rolled-up
+// bucket ("pass"/"skipping"), else the conclusion-style state. Keeping the same
+// semantics keeps the no-CI guard's "real CI" definition identical to the gate's.
+func checkPassed(check github.PullRequestCheck) bool {
+	bucket := strings.ToLower(strings.TrimSpace(check.Bucket))
+	if bucket != "" {
+		return bucket == "pass" || bucket == "skipping"
+	}
+	state := strings.ToLower(strings.TrimSpace(check.State))
+	return state == "success" || state == "skipped" || state == "neutral"
 }
 
 // changesRequestedScore grades a changes_requested negative by fix-round count

--- a/internal/skillopt/trace_harvest_test.go
+++ b/internal/skillopt/trace_harvest_test.go
@@ -1,0 +1,393 @@
+package skillopt
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// stubStatusReader is a CombinedStatusReader stub for the no-CI guard tests. It
+// returns a canned CombinedStatus (or an error) regardless of repo/ref.
+type stubStatusReader struct {
+	status github.CombinedStatus
+	err    error
+	calls  int
+}
+
+func (s *stubStatusReader) GetCombinedStatus(_ context.Context, _ github.Repository, _ string) (github.CombinedStatus, error) {
+	s.calls++
+	if s.err != nil {
+		return github.CombinedStatus{}, s.err
+	}
+	return s.status, nil
+}
+
+// realCIStatus is a combined status with a passing external (non-gitmoot/) check.
+func realCIStatus() github.CombinedStatus {
+	return github.CombinedStatus{
+		State: "success",
+		Statuses: []github.CommitStatus{
+			{Context: "ci/build", State: "success"},
+		},
+	}
+}
+
+// noCIStatus is the empty-gate combined status carrying only the synthetic
+// gitmoot/ci context the merge gate writes when no external CI exists.
+func noCIStatus() github.CombinedStatus {
+	return github.CombinedStatus{
+		State: "success",
+		Statuses: []github.CommitStatus{
+			{Context: gitmootNoCIContext, State: "success"},
+		},
+	}
+}
+
+// installTraceTemplate installs a template and returns its current version, plus
+// an implement JobPayload attributed to that exact version (TemplateID +
+// TemplateResolvedCommit), so the harvester resolves the version from the payload.
+func installTraceTemplate(t *testing.T, store *db.Store, id string) (db.AgentTemplateVersion, workflow.JobPayload) {
+	t.Helper()
+	ctx := context.Background()
+	template := testTemplate(id, "Do the work.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	version, err := store.GetAgentTemplateVersionByID(ctx, installed.VersionID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	payload := workflow.JobPayload{
+		Repo:                   "owner/repo",
+		PullRequest:            7,
+		TaskID:                 "task-1",
+		TemplateID:             id,
+		TemplateResolvedCommit: template.ResolvedCommit,
+	}
+	return version, payload
+}
+
+func newTraceStore(t *testing.T) *db.Store {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func implementJob() db.Job {
+	return db.Job{ID: "job-implement-1", Type: "implement"}
+}
+
+func feedbackForVersion(t *testing.T, store *db.Store, versionID string) []db.FeedbackEvent {
+	t.Helper()
+	events, err := store.ListFeedbackEvents(context.Background(), autoTraceRunIDPrefix+versionID)
+	if err != nil {
+		t.Fatalf("ListFeedbackEvents returned error: %v", err)
+	}
+	return events
+}
+
+// TestHarvestMergedRealCIWritesStrongPositive asserts a merge with a genuine
+// external CI pass yields a strong-positive (score 1.0, choice "a") FeedbackEvent
+// in the per-version auto-trace run, tagged source=auto-trace/reviewer=gitmoot-auto.
+func TestHarvestMergedRealCIWritesStrongPositive(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	status := &stubStatusReader{status: realCIStatus()}
+	h := NewOutcomeHarvester(store, status)
+
+	if err := h.Harvest(ctx, implementJob(), payload, workflow.Outcome{
+		Kind:        workflow.OutcomeMerged,
+		Repo:        "owner/repo",
+		PullRequest: 7,
+		HeadSHA:     "deadbeef",
+	}); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+
+	if status.calls != 1 {
+		t.Fatalf("expected exactly one combined-status read, got %d", status.calls)
+	}
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 {
+		t.Fatalf("expected exactly one feedback event, got %d: %+v", len(events), events)
+	}
+	event := events[0]
+	if event.Choice != "a" {
+		t.Fatalf("merged+real-CI choice = %q, want a", event.Choice)
+	}
+	if event.Source != autoTraceSource || event.Reviewer != autoTraceReviewer {
+		t.Fatalf("source/reviewer = %q/%q, want %q/%q", event.Source, event.Reviewer, autoTraceSource, autoTraceReviewer)
+	}
+	if event.SourceURL != "https://github.com/owner/repo/pull/7" {
+		t.Fatalf("source_url = %q", event.SourceURL)
+	}
+
+	// Verify the score via the projection: merged + real CI => Soft 1.0.
+	signal, choice := h.project(ctx, payload, workflow.Outcome{Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef"})
+	if choice != "a" || !signal.HasScore || signal.Score != scoreMergedRealCI {
+		t.Fatalf("merged+real-CI projection = %+v choice=%q, want score=%v choice=a", signal, choice, scoreMergedRealCI)
+	}
+
+	// Run-level metadata + export must surface feedback_source=automatic_trace.
+	run, err := store.GetEvalRun(ctx, autoTraceRunIDPrefix+version.ID)
+	if err != nil {
+		t.Fatalf("GetEvalRun returned error: %v", err)
+	}
+	if run.Mode != db.EvalRunModeValidate {
+		t.Fatalf("auto-trace run mode = %q, want validate", run.Mode)
+	}
+	pkg, err := ExportTrainingPackage(ctx, store, run.ID)
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	var fc map[string]any
+	if err := json.Unmarshal(pkg.FeedbackContext, &fc); err != nil {
+		t.Fatalf("feedback context did not unmarshal: %v", err)
+	}
+	if fc["feedback_source"] != FeedbackSourceAutomaticTrace {
+		t.Fatalf("feedback_source = %v, want %q", fc["feedback_source"], FeedbackSourceAutomaticTrace)
+	}
+	if len(pkg.EvaluatorConfig) != 0 {
+		t.Fatalf("auto-trace run leaked evaluator_config = %s", string(pkg.EvaluatorConfig))
+	}
+}
+
+// TestHarvestMergedNoCINearNeutral asserts a merge through the empty gate (only
+// the synthetic gitmoot/ci context) is scored near-neutral (~0.5), NOT a strong
+// positive — the no-CI guard.
+func TestHarvestMergedNoCINearNeutral(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, &stubStatusReader{status: noCIStatus()})
+
+	outcome := workflow.Outcome{Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef"}
+	if err := h.Harvest(ctx, implementJob(), payload, outcome); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	signal, choice := h.project(ctx, payload, outcome)
+	if choice != "a" {
+		t.Fatalf("merged+no-CI choice = %q, want a (positive but weak)", choice)
+	}
+	if !signal.HasScore || signal.Score != scoreMergedNoCI {
+		t.Fatalf("merged+no-CI score = %v (has=%v), want %v", signal.Score, signal.HasScore, scoreMergedNoCI)
+	}
+	if signal.Score >= scoreMergedRealCI {
+		t.Fatalf("no-CI merge must not score a strong positive, got %v", signal.Score)
+	}
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 || events[0].Choice != "a" {
+		t.Fatalf("expected one choice=a feedback row, got %+v", events)
+	}
+}
+
+// TestHarvestMergedNoStatusReaderIsNearNeutral asserts a nil status reader (or a
+// status read failure) conservatively degrades a merge to near-neutral rather
+// than rewarding it as a strong positive.
+func TestHarvestMergedNoStatusReaderIsNearNeutral(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	_, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+	signal, _ := h.project(ctx, payload, workflow.Outcome{Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef"})
+	if signal.Score != scoreMergedNoCI {
+		t.Fatalf("nil status reader merge score = %v, want near-neutral %v", signal.Score, scoreMergedNoCI)
+	}
+}
+
+// TestHarvestBlockedWritesHardNegative asserts a merge-gate block yields an
+// authoritative gate-fail (Hard 0, choice "b") negative.
+func TestHarvestBlockedWritesHardNegative(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, &stubStatusReader{})
+
+	outcome := workflow.Outcome{Kind: workflow.OutcomeBlocked, Repo: "owner/repo", PullRequest: 7, Reason: "external CI check failed"}
+	if err := h.Harvest(ctx, implementJob(), payload, outcome); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	signal, choice := h.project(ctx, payload, outcome)
+	if choice != "b" || !signal.HasScore || signal.Score != 0 {
+		t.Fatalf("blocked projection = %+v choice=%q, want score=0 choice=b", signal, choice)
+	}
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 || events[0].Choice != "b" {
+		t.Fatalf("expected one choice=b feedback row, got %+v", events)
+	}
+}
+
+// TestHarvestChangesRequestedGradedByFixRounds asserts the changes_requested
+// score decreases monotonically as the fix-round count grows.
+func TestHarvestChangesRequestedGradedByFixRounds(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	_, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, &stubStatusReader{})
+
+	var prev float64 = 2 // larger than any score so the first comparison passes
+	for round := 1; round <= 4; round++ {
+		signal, choice := h.project(ctx, payload, workflow.Outcome{
+			Kind:        workflow.OutcomeChangesRequested,
+			Repo:        "owner/repo",
+			PullRequest: 7,
+			FixRounds:   round,
+		})
+		if choice != "b" {
+			t.Fatalf("changes_requested round %d choice = %q, want b", round, choice)
+		}
+		if !signal.HasScore {
+			t.Fatalf("changes_requested round %d has no score", round)
+		}
+		if signal.Score >= prev {
+			t.Fatalf("changes_requested score did not decrease at round %d: %v >= %v", round, signal.Score, prev)
+		}
+		prev = signal.Score
+	}
+	if changesRequestedScore(1) != scoreChangesRequestedBase {
+		t.Fatalf("round-1 score = %v, want %v", changesRequestedScore(1), scoreChangesRequestedBase)
+	}
+}
+
+// TestHarvestCorrectiveOnRevert asserts a later revert re-upserts the SAME
+// UNIQUE row (count stays 1) and flips the prior positive choice a -> b in place.
+func TestHarvestCorrectiveOnRevert(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, &stubStatusReader{status: realCIStatus()})
+
+	if err := h.Harvest(ctx, implementJob(), payload, workflow.Outcome{
+		Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef",
+	}); err != nil {
+		t.Fatalf("Harvest (merge) returned error: %v", err)
+	}
+	before := feedbackForVersion(t, store, version.ID)
+	if len(before) != 1 || before[0].Choice != "a" {
+		t.Fatalf("expected one choice=a row before revert, got %+v", before)
+	}
+
+	if err := h.Harvest(ctx, implementJob(), payload, workflow.Outcome{
+		Kind: workflow.OutcomeReverted, Repo: "owner/repo", PullRequest: 7,
+	}); err != nil {
+		t.Fatalf("Harvest (revert) returned error: %v", err)
+	}
+	after := feedbackForVersion(t, store, version.ID)
+	if len(after) != 1 {
+		t.Fatalf("revert must overwrite in place, got %d rows: %+v", len(after), after)
+	}
+	if after[0].Choice != "b" {
+		t.Fatalf("revert must flip choice a -> b, got %q", after[0].Choice)
+	}
+	if after[0].ItemID != before[0].ItemID {
+		t.Fatalf("revert wrote a different item id %q vs %q", after[0].ItemID, before[0].ItemID)
+	}
+}
+
+// TestHarvestSkipsCoordinatorContinuation asserts a coordinator continuation job
+// (parent set, no own PR) writes no eval_run/feedback row.
+func TestHarvestSkipsCoordinatorContinuation(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, base := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, &stubStatusReader{status: realCIStatus()})
+
+	// A continuation leg: carries a parent linkage but produced no PR of its own.
+	continuation := base
+	continuation.ParentJobID = "coord-1"
+	continuation.PullRequest = 0
+	if err := h.Harvest(ctx, db.Job{ID: "job-cont", Type: "implement"}, continuation, workflow.Outcome{
+		Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef",
+	}); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	if events := feedbackForVersion(t, store, version.ID); len(events) != 0 {
+		t.Fatalf("coordinator continuation must write no feedback, got %+v", events)
+	}
+
+	// A delegation-finalize continuation is also out of scope.
+	finalize := base
+	finalize.DelegationFinalize = true
+	if err := h.Harvest(ctx, db.Job{ID: "job-fin", Type: "implement"}, finalize, workflow.Outcome{
+		Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef",
+	}); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	if events := feedbackForVersion(t, store, version.ID); len(events) != 0 {
+		t.Fatalf("delegation-finalize continuation must write no feedback, got %+v", events)
+	}
+}
+
+// TestHarvestSkipsNonImplementAndUntemplated asserts a non-implement job and an
+// implement job with no template attribution are both skipped.
+func TestHarvestSkipsNonImplementAndUntemplated(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, &stubStatusReader{status: realCIStatus()})
+
+	// A review job is out of scope.
+	if err := h.Harvest(ctx, db.Job{ID: "job-review", Type: "review"}, payload, workflow.Outcome{
+		Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef",
+	}); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	if events := feedbackForVersion(t, store, version.ID); len(events) != 0 {
+		t.Fatalf("non-implement job must write no feedback, got %+v", events)
+	}
+
+	// An implement job with no TemplateID is out of scope.
+	untemplated := payload
+	untemplated.TemplateID = ""
+	untemplated.TemplateResolvedCommit = ""
+	if err := h.Harvest(ctx, db.Job{ID: "job-untemplated", Type: "implement"}, untemplated, workflow.Outcome{
+		Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef",
+	}); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	if events := feedbackForVersion(t, store, version.ID); len(events) != 0 {
+		t.Fatalf("untemplated implement job must write no feedback, got %+v", events)
+	}
+}
+
+// TestHarvestResolvesByCurrentVersionFallback asserts that when the payload's
+// TemplateResolvedCommit does not match any version, the harvester falls back to
+// the template's current version rather than guessing or erroring.
+func TestHarvestResolvesByCurrentVersionFallback(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	payload.TemplateResolvedCommit = "does-not-match-any-version"
+	h := NewOutcomeHarvester(store, &stubStatusReader{status: realCIStatus()})
+
+	if err := h.Harvest(ctx, implementJob(), payload, workflow.Outcome{
+		Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef",
+	}); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	if events := feedbackForVersion(t, store, version.ID); len(events) != 1 {
+		t.Fatalf("fallback to current version must write one feedback row, got %+v", events)
+	}
+}
+
+// TestHarvestNilStoreNoOp asserts a harvester with no store is a safe no-op.
+func TestHarvestNilStoreNoOp(t *testing.T) {
+	h := &OutcomeHarvester{}
+	if err := h.Harvest(context.Background(), db.Job{Type: "implement"}, workflow.JobPayload{TemplateID: "x"}, workflow.Outcome{Kind: workflow.OutcomeMerged}); err != nil {
+		t.Fatalf("nil-store Harvest returned error: %v", err)
+	}
+}

--- a/internal/skillopt/trace_harvest_test.go
+++ b/internal/skillopt/trace_harvest_test.go
@@ -12,11 +12,15 @@ import (
 )
 
 // stubStatusReader is a CombinedStatusReader stub for the no-CI guard tests. It
-// returns a canned CombinedStatus (or an error) regardless of repo/ref.
+// returns a canned CombinedStatus and canned PR check-runs (or errors) regardless
+// of repo/ref.
 type stubStatusReader struct {
-	status github.CombinedStatus
-	err    error
-	calls  int
+	status     github.CombinedStatus
+	err        error
+	calls      int
+	checks     []github.PullRequestCheck
+	checksErr  error
+	checkCalls int
 }
 
 func (s *stubStatusReader) GetCombinedStatus(_ context.Context, _ github.Repository, _ string) (github.CombinedStatus, error) {
@@ -25,6 +29,14 @@ func (s *stubStatusReader) GetCombinedStatus(_ context.Context, _ github.Reposit
 		return github.CombinedStatus{}, s.err
 	}
 	return s.status, nil
+}
+
+func (s *stubStatusReader) ListPullRequestChecks(_ context.Context, _ github.Repository, _ int64) ([]github.PullRequestCheck, error) {
+	s.checkCalls++
+	if s.checksErr != nil {
+		return nil, s.checksErr
+	}
+	return s.checks, nil
 }
 
 // realCIStatus is a combined status with a passing external (non-gitmoot/) check.
@@ -192,6 +204,66 @@ func TestHarvestMergedNoCINearNeutral(t *testing.T) {
 	events := feedbackForVersion(t, store, version.ID)
 	if len(events) != 1 || events[0].Choice != "a" {
 		t.Fatalf("expected one choice=a feedback row, got %+v", events)
+	}
+}
+
+// TestHarvestMergedActionsCheckIsStrongPositive asserts the dominant GitHub
+// Actions configuration — CI reported as a passing CHECK-RUN with ZERO external
+// commit-statuses (only the synthetic gitmoot/ci status) — is still scored a
+// strong positive (score 1.0, choice "a"). This is the regression the original
+// status-only guard missed: it read only CombinedStatus.Statuses and never
+// consulted ListPullRequestChecks, so an Actions-only merge looked like no-CI.
+func TestHarvestMergedActionsCheckIsStrongPositive(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	// Empty-gate commit status (only gitmoot/ci) but a PASSING external Actions check.
+	status := &stubStatusReader{
+		status: noCIStatus(),
+		checks: []github.PullRequestCheck{
+			{Name: "build", Bucket: "pass"},
+		},
+	}
+	h := NewOutcomeHarvester(store, status)
+
+	outcome := workflow.Outcome{Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef"}
+	if err := h.Harvest(ctx, implementJob(), payload, outcome); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	if status.checkCalls != 1 {
+		t.Fatalf("expected exactly one check-runs read, got %d", status.checkCalls)
+	}
+	signal, choice := h.project(ctx, payload, outcome)
+	if choice != "a" || !signal.HasScore || signal.Score != scoreMergedRealCI {
+		t.Fatalf("merged+Actions-check projection = %+v choice=%q, want score=%v choice=a", signal, choice, scoreMergedRealCI)
+	}
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 || events[0].Choice != "a" {
+		t.Fatalf("expected one choice=a feedback row, got %+v", events)
+	}
+}
+
+// TestHarvestMergedFailingActionsCheckIsNotRealCI asserts a FAILING (or only
+// gitmoot/) check-run is NOT treated as real CI, so a no-external-success merge
+// stays near-neutral. This guards against rewarding a merge whose only check did
+// not pass.
+func TestHarvestMergedFailingActionsCheckIsNotRealCI(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	_, payload := installTraceTemplate(t, store, "planner")
+	status := &stubStatusReader{
+		status: noCIStatus(),
+		checks: []github.PullRequestCheck{
+			{Name: "build", Bucket: "fail"},
+			{Name: "gitmoot/merge-gate", Bucket: "pass"}, // gitmoot/ checks do not count
+		},
+	}
+	h := NewOutcomeHarvester(store, status)
+
+	outcome := workflow.Outcome{Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef"}
+	signal, choice := h.project(ctx, payload, outcome)
+	if choice != "a" || signal.Score != scoreMergedNoCI {
+		t.Fatalf("failing-check merge score = %v choice=%q, want near-neutral %v choice=a", signal.Score, choice, scoreMergedNoCI)
 	}
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -46,6 +46,18 @@ type Engine struct {
 	// terminal cases it owns through the SAME sink so the whole terminal set is
 	// covered. #445 (the ask-gate) rides this seam to emit its job.needs_attention.
 	EventSink events.Sink
+	// OutcomeHarvester is the injected, best-effort, nil-by-default seam (#465,
+	// Mode A) the engine calls after a verifiable implement-job outcome transition
+	// (merge merged/blocked, review changes_requested, revert) to harvest a
+	// synthetic {score, feedback} FeedbackEvent for the job's template version. It
+	// mirrors EventSink/EscalationNotifier: optional and nil-safe (when nil — the
+	// default, no [skillopt].auto_trace_enabled — NO Outcome is constructed and
+	// Harvest is never called, so behavior is byte-identical), and best-effort (a
+	// Harvest error is swallowed and recorded as an auto_trace_harvest_failed job
+	// event, never returned up). It writes ONLY eval/feedback rows and never
+	// promotes. The concrete impl lives in internal/skillopt and is wired only in
+	// cli (daemonWorkflowEngine), keeping the engine free of skillopt coupling.
+	OutcomeHarvester OutcomeHarvester
 	// Home is the resolved GITMOOT_HOME root used to place per-delegation
 	// worktrees. DelegationWorktrees is the checkout-bound git client that
 	// performs the worktree-add. Both are optional: when either is unset, the
@@ -322,6 +334,94 @@ type EscalationRequest struct {
 // comment that @-tags the human with the resume instructions.
 type EscalationNotifier interface {
 	NotifyEscalation(ctx context.Context, request EscalationRequest) error
+}
+
+// OutcomeKind enumerates the verifiable terminal/outcome transitions the engine
+// reports to the OutcomeHarvester (#465, Mode A). Only GENUINE outcome
+// transitions are reported; operational job_events (runtime_lock_wait,
+// repair_retry, comment_post_failed, advance_retry, …) are structurally excluded
+// because the harvester is hooked at the outcome seams (runMergeGate result,
+// dispatchFix), not the job_events firehose.
+type OutcomeKind string
+
+const (
+	// OutcomeMerged is reported after a PR merges through the merge gate (a
+	// positive). The harvester applies the no-CI guard at MergeCommitSHA/HeadSHA
+	// before scoring it as a strong positive.
+	OutcomeMerged OutcomeKind = "merged"
+	// OutcomeBlocked is reported when the merge gate rejects the action
+	// (decision not ready) — an authoritative gate-fail negative.
+	OutcomeBlocked OutcomeKind = "blocked"
+	// OutcomeChangesRequested is reported on a review changes_requested decision
+	// that dispatches a fix round — a graded negative whose severity grows with the
+	// fix-round count.
+	OutcomeChangesRequested OutcomeKind = "changes_requested"
+	// OutcomeReverted is reported when a previously-merged PR's work is later
+	// reverted — a delayed, corrective negative that overwrites the prior positive
+	// in place on the same UNIQUE feedback key.
+	OutcomeReverted OutcomeKind = "reverted"
+)
+
+// Outcome carries the verifiable signal the engine derives at an outcome seam and
+// hands to the OutcomeHarvester (#465). The engine fills only the fields it
+// already knows from the transition (kind, merge/review context, the merged head
+// SHA, the PR URL); the harvester owns the no-CI guard read and the projection
+// into a {score, feedback} FeedbackEvent. It is a pure value with no behavior so
+// the engine stays free of any skillopt/db-write coupling.
+type Outcome struct {
+	// Kind is the verifiable transition that fired.
+	Kind OutcomeKind
+	// Repo is the "owner/name" the PR lives in.
+	Repo string
+	// PullRequest is the PR number, used (with Repo) to build the deterministic
+	// per-PR feedback item_id / source_url UNIQUE key.
+	PullRequest int
+	// HeadSHA is the merged head commit (for OutcomeMerged) the harvester reads the
+	// combined status at for the no-CI guard. It falls back to the payload HeadSHA.
+	HeadSHA string
+	// Reason is the merge-gate rejection reason for OutcomeBlocked (free text from
+	// merge_gates.Reason), surfaced verbatim in the negative feedback reasoning.
+	Reason string
+	// FixRounds is the review-round number at a changes_requested decision (round 1
+	// is the first), used to grade the negative: more rounds => worse score.
+	FixRounds int
+}
+
+// OutcomeHarvester is the injected, best-effort, nil-by-default seam (#465, Mode
+// A) the engine calls AFTER a verifiable implement-job outcome transition. The
+// concrete implementation lives in internal/skillopt and writes a synthetic
+// FeedbackEvent (and its eval_run/eval_review_item) into the EXISTING feedback
+// tables so a template accrues training signal from verifiable outcomes without
+// human ranking. It NEVER promotes — a human still promotes a candidate.
+//
+// It mirrors EventSink/EscalationNotifier: optional and nil-safe (when nil — the
+// default, no [skillopt].auto_trace_enabled — the engine neither constructs an
+// Outcome nor calls Harvest, so behavior is byte-identical), and best-effort (a
+// Harvest error never blocks or fails a job — the engine swallows it and records
+// an auto_trace_harvest_failed job event). The harvester itself decides whether a
+// job is in scope (implement-family with a resolvable template version, skipping
+// coordinator continuations) and returns nil for out-of-scope jobs.
+type OutcomeHarvester interface {
+	Harvest(ctx context.Context, job db.Job, payload JobPayload, outcome Outcome) error
+}
+
+// harvestOutcome calls the injected OutcomeHarvester best-effort: it is nil-safe
+// (no harvester => no-op), and a harvester error is swallowed and recorded as a
+// best-effort auto_trace_harvest_failed job event — it is NEVER returned up, so a
+// harvest failure can never block or fail a job (mirrors emitDaemonTerminalEvent /
+// EscalationNotifier). It must only be called on a GENUINE verifiable outcome
+// transition (#465).
+func (e Engine) harvestOutcome(ctx context.Context, job db.Job, payload JobPayload, outcome Outcome) {
+	if e.OutcomeHarvester == nil {
+		return
+	}
+	if err := e.OutcomeHarvester.Harvest(ctx, job, payload, outcome); err != nil {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "auto_trace_harvest_failed",
+			Message: string(outcome.Kind) + ": " + err.Error(),
+		})
+	}
 }
 
 type BlockedError struct {
@@ -828,7 +928,23 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			if err := e.setTaskState(ctx, ref, TaskChangesRequested); err != nil {
 				return err
 			}
-			return e.dispatchFix(ctx, reviewer, payload, *payload.Result, ref)
+			if err := e.dispatchFix(ctx, reviewer, payload, *payload.Result, ref); err != nil {
+				return err
+			}
+			// Verifiable graded negative (#465): a review asked for changes, so the
+			// implement job's diff did not pass review. Harvested AFTER dispatchFix so a
+			// harvest error can never affect the (already-completed) fix dispatch. The
+			// fix-round count (the review round number, round 1 = first) grades severity:
+			// more rounds => a worse score.
+			e.harvestOutcomeForMergeGate(ctx, payload, Outcome{
+				Kind:        OutcomeChangesRequested,
+				Repo:        payload.Repo,
+				PullRequest: payload.PullRequest,
+				HeadSHA:     payload.HeadSHA,
+				Reason:      strings.TrimSpace(payload.Result.Summary),
+				FixRounds:   reviewRoundCount(payload.ReviewRound),
+			})
+			return nil
 		case "approved":
 			ready, err := e.allRequiredReviewersApproved(ctx, reviewer, payload)
 			if err != nil {
@@ -3837,6 +3953,18 @@ func reviewRoundNumber(round string) (int, bool) {
 	return number, true
 }
 
+// reviewRoundCount maps a review-round label to a 1-based fix-round count for the
+// Mode-A harvester's graded changes_requested negative (#465): "review-1" => 1,
+// "review-3" => 3. An empty or unparseable round (a first/legacy review with no
+// numbered round) counts as 1, so a single changes_requested is always at least
+// the first fix round. The harvester turns a higher count into a worse score.
+func reviewRoundCount(round string) int {
+	if number, ok := reviewRoundNumber(strings.TrimSpace(round)); ok && number >= 1 {
+		return number
+	}
+	return 1
+}
+
 func (e Engine) requiredReviewers(payload JobPayload) []string {
 	reviewers := compactStrings(append([]string{}, payload.Reviewers...))
 	if len(reviewers) == 0 {
@@ -4084,12 +4212,109 @@ func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPa
 		if reason == "" {
 			reason = "merge gate rejected action"
 		}
-		return decision, e.block(ctx, ref, reason)
+		// e.block returns a BlockedError on SUCCESS (the task is durably blocked) and
+		// a plain error only on a store failure. Harvest the verifiable negative (#465)
+		// only when the block transition itself succeeded — i.e. the returned error is
+		// a BlockedError — then propagate that BlockedError unchanged. A real store
+		// error skips the harvest and returns up. Best-effort and nil-safe: a harvest
+		// error can never affect the (already-durable) block.
+		err := e.block(ctx, ref, reason)
+		var blocked BlockedError
+		if errors.As(err, &blocked) {
+			e.harvestOutcomeForMergeGate(ctx, payload, Outcome{
+				Kind:        OutcomeBlocked,
+				Repo:        payload.Repo,
+				PullRequest: payload.PullRequest,
+				HeadSHA:     payload.HeadSHA,
+				Reason:      reason,
+			})
+		}
+		return decision, err
 	}
 	if decision.Merged {
-		return decision, e.setTaskState(ctx, ref, TaskMerged)
+		if err := e.setTaskState(ctx, ref, TaskMerged); err != nil {
+			return decision, err
+		}
+		// Verifiable positive (#465): a merge through the gate. The merged head SHA
+		// is carried so the harvester's no-CI guard can read GetCombinedStatus and
+		// demote an empty-gate (gitmoot/ci synthetic) merge to near-neutral.
+		mergedHead := strings.TrimSpace(decision.MergeCommitSHA)
+		if mergedHead == "" {
+			mergedHead = payload.HeadSHA
+		}
+		e.harvestOutcomeForMergeGate(ctx, payload, Outcome{
+			Kind:        OutcomeMerged,
+			Repo:        payload.Repo,
+			PullRequest: payload.PullRequest,
+			HeadSHA:     mergedHead,
+		})
+		return decision, nil
 	}
 	return decision, e.setTaskState(ctx, ref, TaskReadyToMerge)
+}
+
+// harvestOutcomeForMergeGate resolves the implement job that owns this PR/task and
+// harvests the merge-gate outcome against it (#465). runMergeGate runs in the
+// context of the APPROVING REVIEW job (or a merge-gate re-run), so the outcome
+// must be attributed to the implement job that produced the diff/PR — the one
+// carrying the TemplateID/TemplateResolvedCommit. When no implement job can be
+// resolved (best-effort), the harvest is skipped. Nil-safe: a nil harvester
+// short-circuits before any lookup.
+func (e Engine) harvestOutcomeForMergeGate(ctx context.Context, reviewPayload JobPayload, outcome Outcome) {
+	if e.OutcomeHarvester == nil {
+		return
+	}
+	job, payload, ok := e.implementJobForTask(ctx, reviewPayload)
+	if !ok {
+		return
+	}
+	e.harvestOutcome(ctx, job, payload, outcome)
+}
+
+// implementJobForTask finds the implement job that produced the diff/PR for the
+// task the given payload belongs to, so a merge-gate outcome fired from a review
+// job is attributed to the right template version (#465). It prefers the most
+// recent implement job for the same task/PR. Returns ok=false when none exists
+// (e.g. a PR opened outside the implement flow) so the caller skips the harvest.
+func (e Engine) implementJobForTask(ctx context.Context, reviewPayload JobPayload) (db.Job, JobPayload, bool) {
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return db.Job{}, JobPayload{}, false
+	}
+	var best db.Job
+	var bestPayload JobPayload
+	found := false
+	for _, job := range jobs {
+		if job.Type != "implement" {
+			continue
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			continue
+		}
+		if !sameTask(reviewPayload, payload) {
+			continue
+		}
+		// Prefer the latest implement job so the freshest diff's template version is
+		// the one credited. ListJobs orders by id and populates UpdatedAt; compare by
+		// UpdatedAt then id as a stable, deterministic tiebreak.
+		if !found || implementJobNewer(job, best) {
+			best = job
+			bestPayload = payload
+			found = true
+		}
+	}
+	return best, bestPayload, found
+}
+
+// implementJobNewer reports whether candidate is a later implement job than
+// current, ordering by UpdatedAt then id so the harvester credits the freshest
+// diff's template version deterministically.
+func implementJobNewer(candidate db.Job, current db.Job) bool {
+	if candidate.UpdatedAt != current.UpdatedAt {
+		return candidate.UpdatedAt > current.UpdatedAt
+	}
+	return candidate.ID > current.ID
 }
 
 func (e Engine) mergeGateReviewRequired(ctx context.Context, payload JobPayload) (bool, error) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -286,7 +286,36 @@ type MergeDecision struct {
 	Merged         bool
 	MergeCommitSHA string
 	Reason         string
+	// BlockClass classifies a not-ready block (Ready=false) so the Mode-A
+	// trace-harvester (#465) only scores AUTHORITATIVE template-quality rejections as
+	// a negative and skips transient/infra blocks (branch staleness, dirty local
+	// worktree, missing-SHA/base, freshness-unknown). It is the zero value
+	// (MergeBlockNone) for a ready/merged decision and is purely advisory — it never
+	// changes the block/merge transition itself, so behavior is byte-identical when
+	// the harvester is off.
+	BlockClass MergeBlockClass
 }
+
+// MergeBlockClass classifies a merge-gate block (#465 INFRA-NOISE-FILTERED).
+type MergeBlockClass int
+
+const (
+	// MergeBlockNone is the zero value (a ready/merged decision, or a block whose
+	// class was not set). The harvester treats an unclassified block conservatively
+	// as transient (no negative) so a missed classification under-rewards rather than
+	// pollutes the corpus with a false negative.
+	MergeBlockNone MergeBlockClass = iota
+	// MergeBlockQuality is an authoritative template-quality rejection — external CI
+	// failed, the latest review captured a blocking result, or the PR was closed
+	// without merging. These are the only blocks the harvester scores as a negative.
+	MergeBlockQuality
+	// MergeBlockTransient is an operational/branch-staleness/infra condition (not
+	// mergeable; rebase, dirty local worktree, missing head/base SHA, branch update
+	// conflict, freshness unknown) that says nothing about template quality. The
+	// harvester skips it so branch-staleness and daemon-machine state are not
+	// mis-attributed to the template.
+	MergeBlockTransient
+)
 
 type MergeGate interface {
 	Evaluate(ctx context.Context, request MergeRequest) (MergeDecision, error)
@@ -346,8 +375,8 @@ type OutcomeKind string
 
 const (
 	// OutcomeMerged is reported after a PR merges through the merge gate (a
-	// positive). The harvester applies the no-CI guard at MergeCommitSHA/HeadSHA
-	// before scoring it as a strong positive.
+	// positive). The harvester applies the no-CI guard at the PR HEAD SHA (where the
+	// gate posted statuses/checks) before scoring it as a strong positive.
 	OutcomeMerged OutcomeKind = "merged"
 	// OutcomeBlocked is reported when the merge gate rejects the action
 	// (decision not ready) — an authoritative gate-fail negative.
@@ -359,6 +388,17 @@ const (
 	// OutcomeReverted is reported when a previously-merged PR's work is later
 	// reverted — a delayed, corrective negative that overwrites the prior positive
 	// in place on the same UNIQUE feedback key.
+	//
+	// NOT YET WIRED (#465): the harvester's projection + corrective in-place upsert
+	// for this kind are implemented and unit-tested (the same per-PR item_id
+	// re-upserts and flips choice a->b), but NO engine/daemon code path constructs
+	// an Outcome{Kind: OutcomeReverted} today — there is no revert detection in
+	// AdvanceJob, runMergeGate, or the daemon PR-watcher. The corrective-on-revert
+	// flow is therefore reachable only via a direct Harvest call (tests); a
+	// production revert does not yet overwrite the prior positive. Wiring real
+	// revert detection (the daemon observing a revert PR/commit of a previously
+	// harvested merge, re-firing harvestOutcomeForMergeGate for the reverted PR) is
+	// a follow-on; see CORRECTIVE-ON-REVERT in docs/skillopt-exchange-contract.md.
 	OutcomeReverted OutcomeKind = "reverted"
 )
 
@@ -376,8 +416,11 @@ type Outcome struct {
 	// PullRequest is the PR number, used (with Repo) to build the deterministic
 	// per-PR feedback item_id / source_url UNIQUE key.
 	PullRequest int
-	// HeadSHA is the merged head commit (for OutcomeMerged) the harvester reads the
-	// combined status at for the no-CI guard. It falls back to the payload HeadSHA.
+	// HeadSHA is the PR HEAD SHA (for OutcomeMerged) the harvester reads the combined
+	// status / check-runs at for the no-CI guard — the SHA the merge gate evaluated
+	// and posted statuses/checks at, NOT the merge commit (GitHub does not copy
+	// statuses/checks onto the merge commit). It falls back to the merge commit SHA
+	// only when the payload head SHA is empty.
 	HeadSHA string
 	// Reason is the merge-gate rejection reason for OutcomeBlocked (free text from
 	// merge_gates.Reason), surfaced verbatim in the negative feedback reasoning.
@@ -4215,12 +4258,18 @@ func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPa
 		// e.block returns a BlockedError on SUCCESS (the task is durably blocked) and
 		// a plain error only on a store failure. Harvest the verifiable negative (#465)
 		// only when the block transition itself succeeded — i.e. the returned error is
-		// a BlockedError — then propagate that BlockedError unchanged. A real store
-		// error skips the harvest and returns up. Best-effort and nil-safe: a harvest
-		// error can never affect the (already-durable) block.
+		// a BlockedError — AND the block is an AUTHORITATIVE template-quality rejection
+		// (external CI failed, blocking review captured, closed-without-merge). A
+		// transient/infra block (branch staleness, dirty local worktree, missing
+		// head/base SHA, freshness-unknown) says nothing about template quality, so it
+		// is NOT harvested — otherwise branch-staleness/infra noise would be
+		// mis-attributed to the template as a false Hard=0 negative (#465
+		// INFRA-NOISE-FILTERED). A real store error skips the harvest and returns up.
+		// Best-effort and nil-safe: a harvest error can never affect the (already-
+		// durable) block.
 		err := e.block(ctx, ref, reason)
 		var blocked BlockedError
-		if errors.As(err, &blocked) {
+		if errors.As(err, &blocked) && decision.BlockClass == MergeBlockQuality {
 			e.harvestOutcomeForMergeGate(ctx, payload, Outcome{
 				Kind:        OutcomeBlocked,
 				Repo:        payload.Repo,
@@ -4235,12 +4284,15 @@ func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPa
 		if err := e.setTaskState(ctx, ref, TaskMerged); err != nil {
 			return decision, err
 		}
-		// Verifiable positive (#465): a merge through the gate. The merged head SHA
-		// is carried so the harvester's no-CI guard can read GetCombinedStatus and
-		// demote an empty-gate (gitmoot/ci synthetic) merge to near-neutral.
-		mergedHead := strings.TrimSpace(decision.MergeCommitSHA)
+		// Verifiable positive (#465): a merge through the gate. Carry the PR HEAD SHA
+		// (not the merge commit) so the harvester's no-CI guard can read
+		// GetCombinedStatus/ListPullRequestChecks at the SHA the merge gate actually
+		// evaluated and posted statuses/checks at — GitHub does not copy them onto the
+		// new merge commit, so reading the merge commit would always look like no CI.
+		// Fall back to the merge commit only if the head SHA is somehow empty.
+		mergedHead := strings.TrimSpace(payload.HeadSHA)
 		if mergedHead == "" {
-			mergedHead = payload.HeadSHA
+			mergedHead = strings.TrimSpace(decision.MergeCommitSHA)
 		}
 		e.harvestOutcomeForMergeGate(ctx, payload, Outcome{
 			Kind:        OutcomeMerged,

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -72,7 +72,7 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	}
 	headSHA := strings.TrimSpace(pr.HeadSHA)
 	if headSHA == "" {
-		return g.block(ctx, request, "", "pull request head SHA is missing")
+		return g.block(ctx, request, "", "pull request head SHA is missing", MergeBlockTransient)
 	}
 	releaseCheckoutLock, err := g.acquireLocalCheckoutMutationLock(ctx, request)
 	if err != nil {
@@ -91,7 +91,7 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 		return g.finishMerged(ctx, request, pr, strings.TrimSpace(pr.MergeSHA))
 	}
 	if strings.TrimSpace(pr.State) == "closed" {
-		return g.block(ctx, request, headSHA, "pull request is closed without being merged")
+		return g.block(ctx, request, headSHA, "pull request is closed without being merged", MergeBlockQuality)
 	}
 	if g.Git != nil {
 		clean, err := g.Git.WorktreeClean(ctx)
@@ -99,12 +99,20 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 			return MergeDecision{}, err
 		}
 		if !clean {
-			return g.block(ctx, request, headSHA, "local worktree is not clean")
+			return g.block(ctx, request, headSHA, "local worktree is not clean", MergeBlockTransient)
 		}
 	}
 	if !request.ReviewOptional {
 		if err := g.ensureFinalReviewCaptured(ctx, request, headSHA); err != nil {
-			return g.block(ctx, request, headSHA, err.Error())
+			// A captured blocking review (mergeBlocked) is a template-quality rejection;
+			// every other review error (approval missing / not yet captured / head
+			// mismatch) is a transient/process condition the harvester must not score.
+			class := MergeBlockTransient
+			var blocked mergeBlocked
+			if errors.As(err, &blocked) {
+				class = MergeBlockQuality
+			}
+			return g.block(ctx, request, headSHA, err.Error(), class)
 		}
 	}
 	releaseMergeQueueLock, err := g.acquireMergeQueueLock(ctx, request, pr)
@@ -124,7 +132,7 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 		return decision, nil
 	}
 	if pr.Mergeable != nil && !*pr.Mergeable {
-		return g.block(ctx, request, headSHA, "pull request is not mergeable; rebase or update the branch")
+		return g.block(ctx, request, headSHA, "pull request is not mergeable; rebase or update the branch", MergeBlockTransient)
 	}
 	if err := g.ensureStatuses(ctx, repo, int64(request.PullRequest), headSHA); err != nil {
 		var pending mergePending
@@ -133,7 +141,8 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 		}
 		var blocked mergeBlocked
 		if errors.As(err, &blocked) {
-			return g.block(ctx, request, headSHA, blocked.reason)
+			// An external CI failure is an authoritative template-quality rejection.
+			return g.block(ctx, request, headSHA, blocked.reason, MergeBlockQuality)
 		}
 		return MergeDecision{}, err
 	}
@@ -344,7 +353,11 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		case "approved":
 			approved = true
 		case "changes_requested", "blocked", "failed":
-			return fmt.Errorf("latest review round has blocking result from %s", job.Agent)
+			// A captured blocking review is an authoritative template-quality rejection
+			// (mergeBlocked), distinct from the transient/process review errors below
+			// (missing approval, not-yet-captured), so the trace-harvester scores only
+			// this one as a negative (#465 INFRA-NOISE-FILTERED).
+			return mergeBlocked{reason: fmt.Sprintf("latest review round has blocking result from %s", job.Agent)}
 		}
 	}
 	if !approved {
@@ -359,7 +372,7 @@ func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repo
 		base = strings.TrimSpace(pr.BaseSHA)
 	}
 	if base == "" {
-		decision, err := g.block(ctx, request, headSHA, "pull request base ref is missing")
+		decision, err := g.block(ctx, request, headSHA, "pull request base ref is missing", MergeBlockTransient)
 		return decision, true, err
 	}
 	compare, err := g.GitHub.CompareCommits(ctx, repo, base, headSHA)
@@ -384,10 +397,10 @@ func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repo
 		case github.IsUpdatePullRequestBranchError(err, github.UpdatePullRequestBranchErrorConflict):
 			reason := fmt.Sprintf("branch update conflicts with %s; manual or agent fix required", base)
 			_ = g.postMergeConflictComment(ctx, repo, request, pr, reason)
-			decision, blockErr := g.block(ctx, request, headSHA, reason)
+			decision, blockErr := g.block(ctx, request, headSHA, reason, MergeBlockTransient)
 			return decision, true, blockErr
 		case github.IsUpdatePullRequestBranchError(err, github.UpdatePullRequestBranchErrorUnsupported):
-			decision, blockErr := g.block(ctx, request, headSHA, fmt.Sprintf("GitHub cannot update this pull request branch automatically: %s", err))
+			decision, blockErr := g.block(ctx, request, headSHA, fmt.Sprintf("GitHub cannot update this pull request branch automatically: %s", err), MergeBlockTransient)
 			return decision, true, blockErr
 		default:
 			decision, pendingErr := g.pending(ctx, request, headSHA, fmt.Sprintf("GitHub branch update failed transiently: %s; daemon will retry", err))
@@ -395,7 +408,7 @@ func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repo
 		}
 	}
 	if status != "" && status != "ahead" && status != "identical" {
-		decision, err := g.block(ctx, request, headSHA, fmt.Sprintf("pull request branch freshness is unknown: compare status %q", compare.Status))
+		decision, err := g.block(ctx, request, headSHA, fmt.Sprintf("pull request branch freshness is unknown: compare status %q", compare.Status), MergeBlockTransient)
 		return decision, true, err
 	}
 	return MergeDecision{}, false, nil
@@ -541,7 +554,12 @@ func reviewRoundAfter(left string, right string) bool {
 	return left > right
 }
 
-func (g PolicyMergeGate) block(ctx context.Context, request MergeRequest, sha string, reason string) (MergeDecision, error) {
+// block records a not-ready block at the given quality classification (#465). The
+// class is advisory metadata for the Mode-A trace-harvester only; it never changes
+// the block transition itself. Call sites pass MergeBlockQuality for authoritative
+// template-quality rejections (external CI failed, blocking review captured, closed
+// without merge) and MergeBlockTransient for branch-staleness/infra conditions.
+func (g PolicyMergeGate) block(ctx context.Context, request MergeRequest, sha string, reason string, class MergeBlockClass) (MergeDecision, error) {
 	if err := g.Store.UpsertMergeGate(ctx, db.MergeGate{RepoFullName: request.Repo, PullRequest: int64(request.PullRequest), State: "blocked", Reason: reason}); err != nil {
 		return MergeDecision{}, err
 	}
@@ -560,7 +578,7 @@ func (g PolicyMergeGate) block(ctx context.Context, request MergeRequest, sha st
 			return MergeDecision{}, err
 		}
 	}
-	return MergeDecision{Reason: reason}, nil
+	return MergeDecision{Reason: reason, BlockClass: class}, nil
 }
 
 func (g PolicyMergeGate) pending(ctx context.Context, request MergeRequest, sha string, reason string) (MergeDecision, error) {

--- a/internal/workflow/outcome_harvester_test.go
+++ b/internal/workflow/outcome_harvester_test.go
@@ -1,0 +1,284 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// recordingHarvester captures OutcomeHarvester.Harvest calls for the engine
+// best-effort tests. When err is set, Harvest returns it so a test can prove a
+// harvest failure never fails AdvanceJob and is recorded as a best-effort job
+// event.
+type recordingHarvester struct {
+	mu       sync.Mutex
+	outcomes []Outcome
+	jobIDs   []string
+	err      error
+}
+
+func (r *recordingHarvester) Harvest(_ context.Context, job db.Job, _ JobPayload, outcome Outcome) error {
+	r.mu.Lock()
+	r.outcomes = append(r.outcomes, outcome)
+	r.jobIDs = append(r.jobIDs, job.ID)
+	r.mu.Unlock()
+	return r.err
+}
+
+func (r *recordingHarvester) snapshot() []Outcome {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Outcome, len(r.outcomes))
+	copy(out, r.outcomes)
+	return out
+}
+
+// seedImplementJobForHarvest inserts a completed implement job carrying a template
+// attribution so the harvester's implementJobForTask resolves it as the diff owner
+// for the task's merge/review outcome.
+func seedImplementJobForHarvest(t *testing.T, store *db.Store) {
+	t.Helper()
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-job",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:                   "jerryfane/gitmoot",
+		Branch:                 "task-7",
+		PullRequest:            7,
+		TaskID:                 "task-7",
+		TaskTitle:              "Workflow Engine",
+		LeadAgent:              "lead",
+		TemplateID:             "planner",
+		TemplateResolvedCommit: "commit-1",
+		Result:                 &AgentResult{Decision: "implemented", Summary: "did the work"},
+	})
+}
+
+// TestEngineHarvestsMergedOutcomeOnce proves AdvanceJob calls Harvest exactly once
+// with OutcomeMerged when an approval drives runMergeGate to a merge, attributing
+// it to the implement job.
+func TestEngineHarvestsMergedOutcomeOnce(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	seedImplementJobForHarvest(t, store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "approved", Summary: "looks good"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+
+	got := harvester.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("Harvest calls = %d, want 1; %+v", len(got), got)
+	}
+	if got[0].Kind != OutcomeMerged {
+		t.Fatalf("outcome kind = %q, want merged", got[0].Kind)
+	}
+	if got[0].HeadSHA != "merge123" {
+		t.Fatalf("outcome head sha = %q, want the merge commit", got[0].HeadSHA)
+	}
+	if got[0].PullRequest != 7 || got[0].Repo != "jerryfane/gitmoot" {
+		t.Fatalf("outcome attribution = %+v", got[0])
+	}
+	if harvester.jobIDs[0] != "implement-job" {
+		t.Fatalf("merged outcome attributed to %q, want implement-job", harvester.jobIDs[0])
+	}
+}
+
+// TestEngineHarvestsBlockedOutcomeOnce proves a not-ready merge gate harvests
+// exactly one OutcomeBlocked carrying the rejection reason, AND that the job is
+// still blocked (the harvest does not change the block transition).
+func TestEngineHarvestsBlockedOutcomeOnce(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Reason: "external CI failed"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	seedImplementJobForHarvest(t, store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "approved", Summary: "looks good"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-job")
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || blocked.Reason != "external CI failed" {
+		t.Fatalf("AdvanceJob error = %v, want blocked", err)
+	}
+	got := harvester.snapshot()
+	if len(got) != 1 || got[0].Kind != OutcomeBlocked {
+		t.Fatalf("Harvest calls = %+v, want one blocked", got)
+	}
+	if got[0].Reason != "external CI failed" {
+		t.Fatalf("blocked outcome reason = %q", got[0].Reason)
+	}
+}
+
+// TestEngineHarvestsChangesRequestedOnce proves a review changes_requested
+// harvests exactly one OutcomeChangesRequested while still dispatching the fix.
+func TestEngineHarvestsChangesRequestedOnce(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	seedImplementJobForHarvest(t, store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		ReviewRound: "review-2",
+		Result:      &AgentResult{Decision: "changes_requested", Summary: "fix edge case"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskChangesRequested)
+	// The fix was dispatched (the JobID helper appends the review round).
+	mustJob(t, store, "implement-lead-task-7-review-2")
+
+	got := harvester.snapshot()
+	if len(got) != 1 || got[0].Kind != OutcomeChangesRequested {
+		t.Fatalf("Harvest calls = %+v, want one changes_requested", got)
+	}
+	if got[0].FixRounds != 2 {
+		t.Fatalf("changes_requested fix rounds = %d, want 2 (review-2)", got[0].FixRounds)
+	}
+}
+
+// TestEngineHarvestErrorDoesNotFailAdvance proves a Harvest that returns an error
+// is best-effort: AdvanceJob still succeeds, the merge still happens, and an
+// auto_trace_harvest_failed job event is recorded.
+func TestEngineHarvestErrorDoesNotFailAdvance(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine.OutcomeHarvester = &recordingHarvester{err: errors.New("harvest boom")}
+	seedImplementJobForHarvest(t, store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "approved", Summary: "looks good"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob must not fail on a harvest error, got: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+
+	// The failure is recorded as a best-effort job event on the implement job.
+	events, err := store.ListJobEvents(ctx, "implement-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	found := false
+	for _, ev := range events {
+		if ev.Kind == "auto_trace_harvest_failed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an auto_trace_harvest_failed job event, got %+v", events)
+	}
+}
+
+// TestEngineNilHarvesterIsByteIdentical proves the off-by-default path: with no
+// OutcomeHarvester the merge advances exactly as before and no harvest fires.
+func TestEngineNilHarvesterIsByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	// No OutcomeHarvester.
+	seedImplementJobForHarvest(t, store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "approved", Summary: "looks good"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob with nil harvester returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+}
+
+// TestReviewRoundCount pins the fix-round mapping the changes_requested grading
+// depends on.
+func TestReviewRoundCount(t *testing.T) {
+	cases := map[string]int{
+		"":          1,
+		"review-1":  1,
+		"review-3":  3,
+		"weird":     1,
+		"review-0":  1,
+		"review-10": 10,
+	}
+	for round, want := range cases {
+		if got := reviewRoundCount(round); got != want {
+			t.Fatalf("reviewRoundCount(%q) = %d, want %d", round, got, want)
+		}
+	}
+}

--- a/internal/workflow/outcome_harvester_test.go
+++ b/internal/workflow/outcome_harvester_test.go
@@ -78,6 +78,7 @@ func TestEngineHarvestsMergedOutcomeOnce(t *testing.T) {
 		Repo:        "jerryfane/gitmoot",
 		Branch:      "task-7",
 		PullRequest: 7,
+		HeadSHA:     "head123",
 		TaskID:      "task-7",
 		TaskTitle:   "Workflow Engine",
 		LeadAgent:   "lead",
@@ -96,8 +97,11 @@ func TestEngineHarvestsMergedOutcomeOnce(t *testing.T) {
 	if got[0].Kind != OutcomeMerged {
 		t.Fatalf("outcome kind = %q, want merged", got[0].Kind)
 	}
-	if got[0].HeadSHA != "merge123" {
-		t.Fatalf("outcome head sha = %q, want the merge commit", got[0].HeadSHA)
+	// The no-CI guard reads statuses/checks at the PR HEAD SHA (where the merge gate
+	// posted them), NOT the merge commit — GitHub does not copy them onto the merge
+	// commit, so reading there would always look like no CI.
+	if got[0].HeadSHA != "head123" {
+		t.Fatalf("outcome head sha = %q, want the PR head SHA head123", got[0].HeadSHA)
 	}
 	if got[0].PullRequest != 7 || got[0].Repo != "jerryfane/gitmoot" {
 		t.Fatalf("outcome attribution = %+v", got[0])
@@ -115,7 +119,7 @@ func TestEngineHarvestsBlockedOutcomeOnce(t *testing.T) {
 	store := openEngineStore(t)
 	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
 	engine := testEngine(store)
-	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Reason: "external CI failed"}}
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Reason: "external CI failed", BlockClass: MergeBlockQuality}}
 	harvester := &recordingHarvester{}
 	engine.OutcomeHarvester = harvester
 	seedImplementJobForHarvest(t, store)
@@ -144,6 +148,47 @@ func TestEngineHarvestsBlockedOutcomeOnce(t *testing.T) {
 	}
 	if got[0].Reason != "external CI failed" {
 		t.Fatalf("blocked outcome reason = %q", got[0].Reason)
+	}
+}
+
+// TestEngineSkipsTransientBlockHarvest proves a transient/infra merge-gate block
+// (BlockClass=MergeBlockTransient: branch staleness, dirty local worktree, …) is
+// NOT harvested — only authoritative template-quality blocks score a negative, so
+// branch-staleness/infra noise is never mis-attributed to the template (#465
+// INFRA-NOISE-FILTERED). The block transition itself still happens.
+func TestEngineSkipsTransientBlockHarvest(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{
+		Reason:     "pull request is not mergeable; rebase or update the branch",
+		BlockClass: MergeBlockTransient,
+	}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	seedImplementJobForHarvest(t, store)
+	insertCompletedJob(t, store, db.Job{
+		ID:    "review-job",
+		Agent: "audit",
+		Type:  "review",
+	}, JobPayload{
+		Repo:        "jerryfane/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "approved", Summary: "looks good"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-job")
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("AdvanceJob error = %v, want a blocked transition", err)
+	}
+	if got := harvester.snapshot(); len(got) != 0 {
+		t.Fatalf("transient block must not be harvested, got %+v", got)
 	}
 }
 

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -468,3 +468,19 @@ table is intentionally **not** implemented yet; the budget is in raw tokens.
   external services, or required human decisions.
 - Use `delegations` when another named Gitmoot agent should be invoked.
 - Redact secrets from summaries, findings, raw command output, and examples.
+
+## Automatic trace-harvested feedback (Mode A, off by default)
+
+When `[skillopt].auto_trace_enabled = true` (default `false`), gitmoot derives
+template-learning feedback from the **verifiable outcomes** an implement job
+reaches — merged with passing CI vs. blocked at the merge gate, review
+`changes_requested`, or a later revert — and writes a synthetic
+`FeedbackEvent` (`source = auto-trace`, `reviewer = gitmoot-auto`, A/B `choice`,
+`feedback_source = automatic_trace`) into a dedicated per-template-version
+`auto-trace:<version>` eval run. This is **additive** (`contract_version` stays
+`1`, no new result field), **best-effort** (a harvest error never blocks or fails
+a job; it records an `auto_trace_harvest_failed` job event), and **never
+promotes** — a human still promotes a candidate. With the knob unset, no
+harvester runs and behavior is byte-identical. See
+`docs/skillopt-exchange-contract.md` for the outcome→score mapping, the no-CI
+guard, and the corrective-on-revert overwrite.

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -474,7 +474,8 @@ table is intentionally **not** implemented yet; the budget is in raw tokens.
 When `[skillopt].auto_trace_enabled = true` (default `false`), gitmoot derives
 template-learning feedback from the **verifiable outcomes** an implement job
 reaches — merged with passing CI vs. blocked at the merge gate, review
-`changes_requested`, or a later revert — and writes a synthetic
+`changes_requested` (a later revert is supported by the harvester but not yet
+fired by any engine/daemon path — see the contract doc) — and writes a synthetic
 `FeedbackEvent` (`source = auto-trace`, `reviewer = gitmoot-auto`, A/B `choice`,
 `feedback_source = automatic_trace`) into a dedicated per-template-version
 `auto-trace:<version>` eval run. This is **additive** (`contract_version` stays

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -150,6 +150,79 @@ cap; when it would exceed the cap it is truncated on a UTF-8 boundary with a
 trailing `… (truncated)` marker. When no textual signal is present, `feedback`
 is empty.
 
+## Automatic trace-harvested feedback (Mode A, off by default)
+
+Gitmoot can derive training feedback from the **verifiable outcomes** an
+implement job already reaches — a PR that merged with passing external CI vs. one
+that was blocked at the merge gate, a review that requested changes, or a later
+revert — and write it as synthetic feedback into the **existing** feedback tables
+without any human ranking. This is **Mode A** of the trace-harvester (issue
+#465). It is **off by default** and **strictly additive**: `contract_version`
+stays `1`, no new field is added to any package struct, and **promotion stays
+100% manual** — the harvester writes only `eval_runs`, `eval_review_items`, and
+`feedback_events`; a human still promotes a candidate with
+`gitmoot skillopt candidate promote`.
+
+**Enabling.** Add a `[skillopt]` section to the gitmoot config:
+
+```toml
+[skillopt]
+auto_trace_enabled = true   # default false
+```
+
+With the key unset or `false`, no harvester is constructed and behavior — and
+every human-run training package — is **byte-identical**. The admission knob
+mirrors the off-by-default `[events]` stream.
+
+**What gets written.** On a verifiable implement-job outcome the harvester:
+
+- Resolves the job's template version from its `template_id` +
+  `template_resolved_commit` attribution.
+- Upserts one dedicated **auto-trace `eval_run` per template version**, with id
+  `auto-trace:<template_version_id>`, `mode = validate`, and
+  `metadata_json` carrying `feedback_source = automatic_trace`.
+- Upserts a per-PR `eval_review_item` (item id `<repo>#<pr>`).
+- Upserts one `FeedbackEvent` (not a ranked event — a single implement diff has
+  no paired second artifact) tagged `source = auto-trace`,
+  `reviewer = gitmoot-auto`, with the verifiable-outcome `score`/`feedback`
+  assembled by `skillopt.ProjectSignal` (above). A **positive** outcome is
+  `choice = a` (the current promoted template as the implicit baseline champion);
+  a **negative** is `choice = b`. The textual `reasoning` is the projected
+  `NormalizedSignal.feedback`.
+
+**Outcome → score.**
+
+- **Merged with real CI** (a passing non-`gitmoot/` external status/check at the
+  merged head) → strong positive (`soft = 1.0`, `choice = a`).
+- **Merged through an empty gate** (the synthetic `gitmoot/ci` context, or no
+  external CI at head) → **near-neutral** (`soft ≈ 0.5`, `choice = a`), never a
+  strong positive. Rewarding an empty gate would optimize toward "merges that
+  pass no real CI"; the no-CI guard reads the combined status at the merged head
+  SHA and demotes it.
+- **Blocked at the merge gate** → authoritative gate-fail (`hard = 0`,
+  `choice = b`).
+- **Review changes_requested** → graded negative (`choice = b`) whose score
+  decreases with the fix-round count.
+- **Reverted** → corrective negative. A later revert of a previously-merged PR
+  **re-upserts the same** `UNIQUE(run_id, item_id, reviewer, source, source_url)`
+  row, flipping the earlier positive `choice = a` to `choice = b` **in place**
+  (the row count is unchanged).
+
+**Scope.** Only implement-family jobs that carry a template attribution are
+harvested; coordinator continuation jobs (which produce no diff of their own) and
+non-implement jobs are skipped. Only genuine outcome transitions are harvested —
+operational job events (`runtime_lock_wait`, `repair_retry`,
+`comment_post_failed`, `advance_retry`, …) never produce feedback. Harvesting is
+**best-effort**: a harvest error never blocks or fails a job; it is swallowed and
+recorded as an `auto_trace_harvest_failed` job event.
+
+**Export side.** When `ExportTrainingPackage` runs over an auto-trace run, the
+run-level `feedback_context.feedback_source` is `automatic_trace` (rather than the
+human default `imported_human_review`), and the run lives in its own
+`auto-trace:<version>` namespace, so a consumer can filter or down-weight
+automatic feedback independently of sparse human gold. A human run never carries
+the `feedback_source` metadata key, so its export is byte-identical.
+
 ## Ranked Exploration Workflow
 
 Use ranked exploration when the template is still ambiguous and humans need to

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -206,7 +206,12 @@ mirrors the off-by-default `[events]` stream.
 - **Reverted** → corrective negative. A later revert of a previously-merged PR
   **re-upserts the same** `UNIQUE(run_id, item_id, reviewer, source, source_url)`
   row, flipping the earlier positive `choice = a` to `choice = b` **in place**
-  (the row count is unchanged).
+  (the row count is unchanged). **Not yet wired:** the projection and the
+  in-place corrective upsert are implemented and unit-tested, but no engine or
+  daemon path detects a revert and fires the `reverted` outcome today, so in a
+  running daemon a merged-then-reverted PR keeps its prior positive until revert
+  detection is wired (a follow-on). The corrective-overwrite mechanics above are
+  reachable only by invoking the harvester directly with a `reverted` outcome.
 
 **Scope.** Only implement-family jobs that carry a template attribution are
 harvested; coordinator continuation jobs (which produce no diff of their own) and


### PR DESCRIPTION
## Summary

Mode A of the trace-harvester (issue #465, scoped from RFC #463): gitmoot derives template-learning feedback from an implement job's **verifiable terminal outcomes** — a PR merged with passing external CI vs. blocked at the merge gate, a review `changes_requested`, or a later revert — and writes it as synthetic feedback into the **existing** eval/feedback tables, so a template accrues training signal **without human ranking**.

It is **off by default**, **strictly additive** (`ContractVersion` stays `1`, no new field on any existing contract struct), and **manual promotion is preserved** (the harvester writes ONLY `eval_runs` / `eval_review_items` / `feedback_events`, never a candidate/promote/optimizer path).

## How it works

- New `[skillopt].auto_trace_enabled = false` (default) admission knob (`config.SkillOptPolicy`), wired into the engine **exactly like the #446 EventSink**: with no config, the `OutcomeHarvester` is `nil`, so daemon behavior and every human-run `TrainingPackage` JSON are **byte-identical** (golden regression test).
- New nil-safe, **best-effort** `workflow.Engine.OutcomeHarvester` seam, called at the outcome seams (`runMergeGate` merged/blocked, review `changes_requested`). A harvest error **never blocks or fails a job** — it is swallowed and recorded as an `auto_trace_harvest_failed` job event (mirrors EventSink/EscalationNotifier; race-tested).
- `skillopt.OutcomeHarvester` assembles the `{score, feedback}` via **#462 `ProjectSignal`** and writes an A/B `FeedbackEvent` (`choice` a=positive / b=negative, `source=auto-trace`, `reviewer=gitmoot-auto`) in a dedicated **per-template-version** `auto-trace:<versionID>` run (`mode=validate`, `feedback_source=automatic_trace`). Item id is **per-PR** (`<repo>#<pr>`) so distinct PRs never silently collide.
- **No-CI guard:** reads `GetCombinedStatus` at the merged head SHA. The synthetic `gitmoot/ci` context (zero external CI) → **near-neutral ~0.5**, never a strong positive; a real external CI pass → **strong+ (Soft=1.0)**. Blocked → Hard=0; `changes_requested` graded by fix-round count.
- **Corrective-on-revert:** a later revert re-upserts the **same** `UNIQUE(run_id,item_id,reviewer,source,source_url)` row, flipping `choice` a→b **in place** (row count unchanged).
- **Implement-only:** coordinator continuation jobs (no own diff/PR) and non-implement jobs are skipped; only genuine outcome transitions are harvested (infra-noise like `runtime_lock_wait`/`repair_retry` is excluded structurally by hooking the outcome seams, not the job_events firehose).

## Invariants

- **Off by default** ✅ — nil harvester ⇒ byte-identical daemon + human-run TrainingPackage.
- **Additive** ✅ — ContractVersion stays 1; no new exported field on any contract struct.
- **Manual promotion preserved** ✅ — only eval/feedback rows written.
- **Best-effort** ✅ — a harvest error never fails a job.

## Tests

`internal/skillopt/trace_harvest_test.go` (outcome→score mapping, no-CI guard, corrective-on-revert, scope skips), `internal/cli/trace_harvest_daemon_test.go` (off-by-default wiring, mirrors event_sink_resolve_test), `internal/workflow/outcome_harvester_test.go` (Harvest once per transition + best-effort error path), `internal/config/skillopt_test.go`, and golden byte-identical human-run + auto-trace regressions in `contract_test.go`.

Full gate green: `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race ./internal/workflow/ ./internal/cli/ ./internal/skillopt/`.

## Docs

Documented (off-by-default, `automatic_trace` source, outcome→score, no-CI guard, corrective-on-revert) in **both** `docs/skillopt-exchange-contract.md` and `website/docs/reference/skillopt-exchange-contract.md`, plus a note in `skills/gitmoot/references/RESULT_CONTRACT.md`.

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)