### PR TITLE
Cross-family review-agent soft signal: quality + scope-fidelity (#469)

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -233,10 +233,15 @@ scores subjective quality **and** scope-fidelity as ONE rubric:
 Each dimension is in `[0,1]`. The rubric maps to `dimension_scores`, is fused by
 the **mean-of-dimensions** path, and is written as a **second** `FeedbackEvent` in
 the SAME `auto-trace:<version>` run under a distinct item id (`review#<repo>#<pr>`)
-and reviewer (`gitmoot-review:<rt>`), so it **never overwrites** the verifiable
-floor. The review eval item carries `judge_derived = true` (and `self_family = true`
-on the same-family fallback) while the run keeps `feedback_source = automatic_trace`
-— additive, **no new contract field, `contract_version` stays `1`**.
+and the fixed `gitmoot-review` reviewer sentinel, so it **never overwrites** the
+verifiable floor — and so a re-review by a *different* reviewer family overwrites
+the row in place rather than accumulating a stale duplicate. The mapped mean
+**drives the a/b choice** (a below-`0.5` mean registers as a non-baseline `b` vote,
+not a baseline win) and an empty rubric writes **no row**. The review eval item
+carries `judge_derived = true`, the `reviewer_runtime` family, the projected
+`rubric_score`, and (on the same-family fallback) `self_family = true`, while the
+run keeps `feedback_source = automatic_trace` — additive, **no new contract field,
+`contract_version` stays `1`**.
 
 The signal is **soft, judge-tagged, and weighted low** — weight tiers:
 **human gold > verifiable floor > cross-family judge > same-family judge.** It
@@ -246,10 +251,10 @@ The rubric text is **never** injected into the implementer's prompt (anti-gaming
 
 When no different-family reviewer is available/authed, gitmoot falls back to a
 **same-family** reviewer — never silently: it logs and records a
-`cross_family_review_samefamily_fallback` job event, tags the row
-`gitmoot-review-self:<rt>` with `self_family = true`, and weights it below a
-cross-family review. Only when no review-capable runtime is authed at all is the
-review skipped (no review row).
+`cross_family_review_samefamily_fallback` job event, tags the review item
+`self_family = true` (with `reviewer_runtime` carrying the family), and weights it
+below a cross-family review. Only when no review-capable runtime is authed at all
+is the review skipped (no review row).
 
 The judge is uncalibrated in this slice — judge-tagged and weighted low, with a
 measure-the-judge calibration hook for #344/#345 as a follow-on. Promotion stays

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -213,6 +213,51 @@ human default `imported_human_review`), and the run lives in its own
 automatic feedback independently of sparse human gold. A human run never carries
 the `feedback_source` metadata key, so its export is byte-identical.
 
+### Cross-family review soft signal (off by default)
+
+Setting **both** `[skillopt].auto_trace_enabled = true` **and**
+`[skillopt].cross_family_review_enabled = true` (both default `false`) adds a
+read-only **cross-family review leg** on every merge. A reviewer of a *different
+runtime family* than the implementer (codex→claude, claude→codex, kimi→claude —
+preferring a registered review-capable agent of another family scoped to the
+repo, else an ephemeral different-family read-only leg in the `verifier.md` style)
+scores subjective quality **and** scope-fidelity as ONE rubric:
+
+- **coverage / containment / fidelity** — intended scope (the implement job's
+  instructions + task title + goal title) vs. the delivered work (the PR diff,
+  read-only at the head SHA, plus the agent's self-reported `changes_made` as a
+  secondary cross-check). Coverage = did all of the ask; containment = no creep
+  beyond it; fidelity = the ask, not something adjacent.
+- **architecture / readability / abstraction** — subjective code quality.
+
+Each dimension is in `[0,1]`. The rubric maps to `dimension_scores`, is fused by
+the **mean-of-dimensions** path, and is written as a **second** `FeedbackEvent` in
+the SAME `auto-trace:<version>` run under a distinct item id (`review#<repo>#<pr>`)
+and reviewer (`gitmoot-review:<rt>`), so it **never overwrites** the verifiable
+floor. The review eval item carries `judge_derived = true` (and `self_family = true`
+on the same-family fallback) while the run keeps `feedback_source = automatic_trace`
+— additive, **no new contract field, `contract_version` stays `1`**.
+
+The signal is **soft, judge-tagged, and weighted low** — weight tiers:
+**human gold > verifiable floor > cross-family judge > same-family judge.** It
+runs **off the blocking merge path** and is best-effort: a review-leg failure
+records a `cross_family_review_failed` job event and never blocks or fails a job.
+The rubric text is **never** injected into the implementer's prompt (anti-gaming).
+
+When no different-family reviewer is available/authed, gitmoot falls back to a
+**same-family** reviewer — never silently: it logs and records a
+`cross_family_review_samefamily_fallback` job event, tags the row
+`gitmoot-review-self:<rt>` with `self_family = true`, and weights it below a
+cross-family review. Only when no review-capable runtime is authed at all is the
+review skipped (no review row).
+
+The judge is uncalibrated in this slice — judge-tagged and weighted low, with a
+measure-the-judge calibration hook for #344/#345 as a follow-on. Promotion stays
+manual (the harvester writes only `eval_runs` / `eval_review_items` /
+`feedback_events`); the review signal feeds the optimizer like any other and is
+subject to the configurable `[skillopt].auto_promote` policy (#463) when that
+lands — weighted-low + judge-tagged, **not** barred from promotion.
+
 ## Ranked Exploration Workflow
 
 Use ranked exploration when the template is still ambiguous and humans need to

--- a/internal/cli/cross_family_review.go
+++ b/internal/cli/cross_family_review.go
@@ -1,0 +1,317 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// reviewDiffMaxBytes bounds the PR diff text injected into the reviewer prompt so
+// a huge PR cannot blow the reviewer's context. Beyond it the diff is truncated
+// (the reviewer still has TaskTitle/Instructions/Goal + ChangesMade) — a graceful
+// degrade, not a failure.
+const reviewDiffMaxBytes = 60_000
+
+// reviewDiffFileReader is the minimal read the cross-family review dispatcher needs
+// for the read-only scope-fidelity diff (github.Client satisfies it). It is its own
+// narrow interface so the dispatcher is unit-testable with a stub and so the read
+// is provably read-only (list files at HEAD, never a write).
+type reviewDiffFileReader interface {
+	ListPullRequestFiles(ctx context.Context, repo github.Repository, number int64) ([]github.PullRequestFile, error)
+}
+
+// reviewAdapterBuilder builds the runtime adapter for the chosen reviewer agent.
+// It matches buildRuntimeAdapter's shape (agent, checkout, runner) and is
+// injectable so tests can substitute a shell-runtime stub reviewer.
+type reviewAdapterBuilder func(agent runtime.Agent, checkout string, runner subprocess.Runner) (workflow.DeliveryAdapter, error)
+
+// reviewAuthedRuntimes reports which runtime families are authed/available so the
+// cross-family selector only materializes an ephemeral leg on a runtime that can
+// actually run. It is injectable for tests; the daemon supplies the real probe.
+type reviewAuthedRuntimes func(ctx context.Context) map[string]bool
+
+// crossFamilyReviewDispatcher is the concrete workflow.ReviewLegDispatcher (#469):
+// it picks a cross-family reviewer (else a same-family fallback WITH WARNING,
+// REFINEMENT #1), assembles the read-only review prompt (intended scope vs the PR
+// diff + ChangesMade), runs the review leg through the runtime adapter, parses the
+// rubric, and returns an Outcome{Kind:OutcomeReviewed} for the engine to harvest.
+// Every leg is read-only and best-effort: the engine calls it OFF the blocking
+// merge path and swallows its error.
+type crossFamilyReviewDispatcher struct {
+	store        *db.Store
+	diff         reviewDiffFileReader
+	buildAdapter reviewAdapterBuilder
+	authed       reviewAuthedRuntimes
+	checkout     string
+}
+
+var _ workflow.ReviewLegDispatcher = (*crossFamilyReviewDispatcher)(nil)
+
+// Review runs the cross-family review leg for a just-merged implement job and
+// returns its OutcomeReviewed rubric (#469). ok=false means NO review-capable
+// runtime was authed at all (skip, no review row). It NEVER mutates the merge: it
+// reads the diff read-only, runs a read-only reviewer, and returns a value the
+// engine harvests into the auto-trace run.
+func (d *crossFamilyReviewDispatcher) Review(ctx context.Context, implementJob db.Job, implementPayload workflow.JobPayload, mergedHead string) (workflow.Outcome, bool, error) {
+	implementerRuntime := d.resolveImplementerRuntime(ctx, implementJob, implementPayload)
+
+	authed := map[string]bool{}
+	if d.authed != nil {
+		authed = d.authed(ctx)
+	}
+	reviewer, ok, err := workflow.PickCrossFamilyReviewer(ctx, d.store, implementerRuntime, implementPayload.Repo, authed)
+	if err != nil {
+		return workflow.Outcome{}, false, err
+	}
+	if !ok {
+		return workflow.Outcome{}, false, nil
+	}
+	if reviewer.SelfFamily {
+		// REFINEMENT #1: never silently same-family. Emit a best-effort warning event
+		// + log so an operator sees that self-preference bias applies to this row.
+		d.warnSameFamily(ctx, implementJob, reviewer)
+	}
+
+	goalTitle := d.resolveGoalTitle(ctx, implementPayload.GoalID)
+	diff := d.fetchDiff(ctx, implementPayload.Repo, implementPayload.PullRequest)
+	prompt := workflow.ReviewLegPrompt(implementPayload, goalTitle, diff)
+
+	rubric, findings, err := d.runReviewLeg(ctx, reviewer, implementPayload, prompt)
+	if err != nil {
+		return workflow.Outcome{}, false, err
+	}
+
+	return workflow.Outcome{
+		Kind:        workflow.OutcomeReviewed,
+		Repo:        implementPayload.Repo,
+		PullRequest: implementPayload.PullRequest,
+		HeadSHA:     mergedHead,
+		Reviewer:    reviewer.Runtime,
+		SelfFamily:  reviewer.SelfFamily,
+		Rubric:      rubric,
+		Findings:    findings,
+	}, true, nil
+}
+
+// resolveImplementerRuntime recovers the implement job's runtime family from its
+// payload (an ephemeral spec's runtime) or its registered agent. An unrecoverable
+// family yields "" so pickCrossFamilyReviewer SKIPs rather than risk a silent
+// same-family review (#469 risk: SKIP-not-guess).
+func (d *crossFamilyReviewDispatcher) resolveImplementerRuntime(ctx context.Context, job db.Job, payload workflow.JobPayload) string {
+	if payload.Ephemeral != nil && strings.TrimSpace(payload.Ephemeral.Runtime) != "" {
+		return strings.TrimSpace(payload.Ephemeral.Runtime)
+	}
+	agentName := strings.TrimSpace(job.Agent)
+	if agentName == "" || d.store == nil {
+		return ""
+	}
+	agent, err := d.store.GetAgent(ctx, agentName)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(agent.Runtime)
+}
+
+// resolveGoalTitle resolves the owning goal's title for the scope-fidelity intended
+// scope (best-effort: empty on any miss).
+func (d *crossFamilyReviewDispatcher) resolveGoalTitle(ctx context.Context, goalID string) string {
+	goalID = strings.TrimSpace(goalID)
+	if goalID == "" || d.store == nil {
+		return ""
+	}
+	goals, err := d.store.ListGoals(ctx)
+	if err != nil {
+		return ""
+	}
+	for _, goal := range goals {
+		if strings.TrimSpace(goal.ID) == goalID {
+			return strings.TrimSpace(goal.Title)
+		}
+	}
+	return ""
+}
+
+// fetchDiff reads the PR diff read-only (file patches) for the delivered-work side
+// of the scope-fidelity comparison. It degrades to "" (the reviewer then leans on
+// ChangesMade) when the read fails or there is no PR, per the #469 risk note.
+func (d *crossFamilyReviewDispatcher) fetchDiff(ctx context.Context, repo string, pullRequest int) string {
+	if d.diff == nil || pullRequest <= 0 {
+		return ""
+	}
+	parsed, ok := parseReviewRepo(repo)
+	if !ok {
+		return ""
+	}
+	files, err := d.diff.ListPullRequestFiles(ctx, parsed, int64(pullRequest))
+	if err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, file := range files {
+		b.WriteString("--- " + strings.TrimSpace(file.Filename) + " ---\n")
+		if patch := strings.TrimSpace(file.Patch); patch != "" {
+			b.WriteString(patch + "\n")
+		}
+		if b.Len() > reviewDiffMaxBytes {
+			b.WriteString("\n[diff truncated]\n")
+			break
+		}
+	}
+	return b.String()
+}
+
+// runReviewLeg builds the read-only reviewer agent + job and delivers the prompt
+// through the runtime adapter, then parses the rubric from the worker's output
+// (#469). The reviewer agent is read-only (ephemeral) or the registered reviewer.
+func (d *crossFamilyReviewDispatcher) runReviewLeg(ctx context.Context, reviewer workflow.CrossFamilyReviewer, payload workflow.JobPayload, prompt string) (map[string]float64, string, error) {
+	if d.buildAdapter == nil {
+		return nil, "", fmt.Errorf("no reviewer adapter builder")
+	}
+	agent, err := d.reviewerAgent(ctx, reviewer)
+	if err != nil {
+		return nil, "", err
+	}
+	adapter, err := d.buildAdapter(agent, d.checkout, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	result, err := adapter.Deliver(ctx, agent, runtime.Job{
+		AgentName:   agent.Name,
+		Action:      "review",
+		Prompt:      prompt,
+		Repository:  strings.TrimSpace(payload.Repo),
+		PullRequest: payload.PullRequest,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	// The reviewer returns the rubric under gitmoot_result.metadata.rubric, which is
+	// NOT a field ExtractAgentResult accepts (it is strict), so the rubric AND the
+	// summary are parsed directly from the raw output. ParseReviewRubric then keeps
+	// only the known dimensions (clamped) and the findings text.
+	rubric, summary := parseReviewOutput(result.Raw)
+	out := workflow.ParseReviewRubric(workflow.AgentResult{Summary: summary}, rubric)
+	return out.Rubric, out.Findings, nil
+}
+
+// reviewerAgent builds the runtime.Agent for the chosen reviewer: a registered
+// agent is loaded from the store; an ephemeral reviewer is synthesized read-only.
+func (d *crossFamilyReviewDispatcher) reviewerAgent(ctx context.Context, reviewer workflow.CrossFamilyReviewer) (runtime.Agent, error) {
+	if reviewer.RegisteredAgent != "" && d.store != nil {
+		agent, err := d.store.GetAgent(ctx, reviewer.RegisteredAgent)
+		if err != nil {
+			return runtime.Agent{}, err
+		}
+		role := strings.TrimSpace(agent.Role)
+		if role == "" {
+			role = "reviewer"
+		}
+		return runtime.Agent{
+			Name:           agent.Name,
+			Role:           role,
+			Runtime:        agent.Runtime,
+			RuntimeRef:     agent.RuntimeRef,
+			RepoScope:      agent.RepoScope,
+			Capabilities:   agent.Capabilities,
+			AutonomyPolicy: runtime.AutonomyPolicyReadOnly,
+			Model:          agent.Model,
+		}, nil
+	}
+	// Ephemeral read-only reviewer.
+	return runtime.Agent{
+		Name:           "gitmoot-review-" + reviewer.Runtime,
+		Role:           "reviewer",
+		Runtime:        reviewer.Runtime,
+		Capabilities:   []string{"ask", "review"},
+		AutonomyPolicy: runtime.AutonomyPolicyReadOnly,
+	}, nil
+}
+
+// warnSameFamily emits the REFINEMENT #1 best-effort warning (job event + log) on
+// the same-family fallback path so the bias is never silent.
+func (d *crossFamilyReviewDispatcher) warnSameFamily(ctx context.Context, job db.Job, reviewer workflow.CrossFamilyReviewer) {
+	msg := fmt.Sprintf("no different-family reviewer available; fell back to a SAME-family %s reviewer — self-preference bias applies, this signal weights below a cross-family review", reviewer.Runtime)
+	if d.store != nil {
+		_ = d.store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "cross_family_review_samefamily_fallback",
+			Message: msg,
+		})
+	}
+	log.Printf("cross_family_review: %s (job %s)", msg, job.ID)
+}
+
+// parseReviewOutput extracts the rubric (under gitmoot_result.metadata.rubric, also
+// tolerating a top-level rubric) AND the reviewer's summary/findings from the raw
+// worker output. It is lenient: an absent/malformed rubric yields nil so
+// ParseReviewRubric produces an empty (HasScore=false) signal rather than a
+// fabricated score. The rubric lives under metadata.rubric — a field the strict
+// ExtractAgentResult rejects — so it is parsed here directly.
+func parseReviewOutput(raw string) (map[string]float64, string) {
+	for _, candidate := range jsonCandidates(raw) {
+		var envelope struct {
+			GitmootResult struct {
+				Summary  string `json:"summary"`
+				Metadata struct {
+					Rubric map[string]float64 `json:"rubric"`
+				} `json:"metadata"`
+				Rubric map[string]float64 `json:"rubric"`
+			} `json:"gitmoot_result"`
+		}
+		if err := json.Unmarshal([]byte(candidate), &envelope); err != nil {
+			continue
+		}
+		rubric := envelope.GitmootResult.Metadata.Rubric
+		if len(rubric) == 0 {
+			rubric = envelope.GitmootResult.Rubric
+		}
+		summary := strings.TrimSpace(envelope.GitmootResult.Summary)
+		if len(rubric) > 0 || summary != "" {
+			return rubric, summary
+		}
+	}
+	return nil, ""
+}
+
+// jsonCandidates returns brace-balanced JSON object candidates from raw output so
+// the rubric can be recovered from a result wrapped in surrounding text.
+func jsonCandidates(raw string) []string {
+	var out []string
+	depth := 0
+	start := -1
+	for i, r := range raw {
+		switch r {
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+				if depth == 0 && start >= 0 {
+					out = append(out, raw[start:i+1])
+					start = -1
+				}
+			}
+		}
+	}
+	return out
+}
+
+// parseReviewRepo splits an "owner/name" repo for the diff read.
+func parseReviewRepo(value string) (github.Repository, bool) {
+	owner, name, ok := strings.Cut(strings.TrimSpace(value), "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return github.Repository{}, false
+	}
+	return github.Repository{Owner: owner, Name: name}, true
+}

--- a/internal/cli/cross_family_review_integration_test.go
+++ b/internal/cli/cross_family_review_integration_test.go
@@ -1,0 +1,310 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestCrossFamilyReviewFullChain is the FULL-CHAIN integration test for #469. It
+// drives a real workflow.Engine through AdvanceJob to a MERGE, where the engine
+// dispatches a CROSS-FAMILY review leg to a SHELL-runtime stub reviewer (a family
+// different from the codex implementer), the stub echoes a canned gitmoot_result
+// rubric, the engine derives Outcome{Kind:OutcomeReviewed}, and the REAL
+// skillopt.OutcomeHarvester writes a SECOND, judge-tagged, down-weighted
+// FeedbackEvent into the SAME auto-trace:<versionID> run alongside the verifiable
+// floor — with NO live LLM and NO live GitHub. Everything between AdvanceJob and
+// the persisted rows is production code.
+//
+// It also pins the invariants: the review never blocks the job (the merge still
+// happens), no candidate/promotion row is written, and the floor row coexists with
+// the review row.
+
+// reviewShellScript is the stub reviewer body run via `sh -c <script> gitmoot
+// <prompt>`. It ignores its input and echoes a canned gitmoot_result whose
+// metadata.rubric carries the [0,1] dimension scores, exactly the contract the
+// dispatcher's parser reads.
+const reviewShellScript = `printf '%s' '{"gitmoot_result":{"decision":"changes_requested","summary":"scope drift on PR","metadata":{"rubric":{"coverage":0.4,"containment":0.6,"fidelity":0.5,"architecture":0.7,"readability":0.8,"abstraction":0.6}}}}'`
+
+// seedCodexImplementJob seeds a completed implement job on the codex runtime,
+// attributed to the template version, so the dispatcher recovers the implementer
+// family as codex and the review row lands on this version.
+func seedCodexImplementJob(t *testing.T, store *db.Store, version db.AgentTemplateVersion) {
+	t.Helper()
+	// Register the implementer agent so resolveImplementerRuntime reads codex.
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:         "lead",
+		Runtime:      runtime.CodexRuntime,
+		RepoScope:    "jerryfane/gitmoot",
+		Capabilities: []string{"implement"},
+		RuntimeRef:   "last",
+	}); err != nil {
+		t.Fatalf("UpsertAgent(lead) returned error: %v", err)
+	}
+	insertChainJob(t, store, db.Job{ID: "implement-job", Agent: "lead", Type: "implement"}, workflow.JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-7", PullRequest: 7, HeadSHA: "head123",
+		TaskID: "task-7", TaskTitle: "Workflow Engine", LeadAgent: "lead",
+		TemplateID: version.TemplateID, TemplateResolvedCommit: version.ResolvedCommit,
+		Instructions: "Implement the cross-family review",
+		Result:       &workflow.AgentResult{Decision: "implemented", Summary: "did the work", ChangesMade: []string{"x.go"}},
+	})
+}
+
+// registerShellReviewer registers a REVIEW-capable agent on the SHELL runtime (a
+// family different from the codex implementer) whose RuntimeRef is the canned
+// rubric-echoing script — a deterministic cross-family stub reviewer.
+func registerShellReviewer(t *testing.T, store *db.Store) {
+	t.Helper()
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:         "shell-reviewer",
+		Runtime:      runtime.ShellRuntime,
+		RepoScope:    "jerryfane/gitmoot",
+		Capabilities: []string{"ask", "review"},
+		RuntimeRef:   reviewShellScript,
+	}); err != nil {
+		t.Fatalf("UpsertAgent(shell-reviewer) returned error: %v", err)
+	}
+}
+
+// reviewDispatcherForTest builds the REAL crossFamilyReviewDispatcher wired to the
+// real store + a real ShellAdapter builder, with a stub diff reader and an authed
+// probe that reports the shell reviewer available.
+func reviewDispatcherForTest(store *db.Store, diff reviewDiffFileReader) *crossFamilyReviewDispatcher {
+	return &crossFamilyReviewDispatcher{
+		store:        store,
+		diff:         diff,
+		buildAdapter: buildRuntimeAdapter,
+		authed: func(context.Context) map[string]bool {
+			return map[string]bool{runtime.ShellRuntime: true}
+		},
+	}
+}
+
+func TestCrossFamilyReviewFullChain(t *testing.T) {
+	ctx := context.Background()
+	store := openTraceChainStore(t)
+	version := installChainTemplate(t, store, "planner")
+	gate := &stubMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine := chainEngine(store, gate)
+
+	// The real harvester (built through the daemon construction path) AND the real
+	// cross-family review dispatcher with a shell stub reviewer.
+	engine.OutcomeHarvester = enabledHarvesterFor(t, store, harvestGitHubStub{status: realCIChainStatus()})
+	engine.ReviewLegDispatcher = reviewDispatcherForTest(store, harvestGitHubStub{})
+
+	seedCodexImplementJob(t, store, version)
+	registerShellReviewer(t, store)
+	seedChainApprovingReview(t, store, "head123")
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	events := autoTraceFeedback(t, store, version.ID)
+	// The verifiable floor (gitmoot-auto) AND the soft review (gitmoot-review:shell).
+	if len(events) != 2 {
+		t.Fatalf("expected the floor + review row (2), got %d: %+v", len(events), events)
+	}
+	var floor, review *db.FeedbackEvent
+	for i := range events {
+		switch {
+		case events[i].Reviewer == "gitmoot-auto":
+			floor = &events[i]
+		case strings.HasPrefix(events[i].Reviewer, "gitmoot-review:"):
+			review = &events[i]
+		}
+	}
+	if floor == nil {
+		t.Fatalf("verifiable floor row missing; got %+v", events)
+	}
+	if review == nil {
+		t.Fatalf("cross-family review row missing; got %+v", events)
+	}
+	// Cross-family ENFORCED: reviewer family (shell) != implementer family (codex);
+	// the reviewer id is the cross-family tag, NOT the self-family one.
+	if review.Reviewer != "gitmoot-review:shell" {
+		t.Fatalf("review reviewer = %q, want gitmoot-review:shell (cross-family)", review.Reviewer)
+	}
+	if strings.HasPrefix(review.Reviewer, "gitmoot-review-self:") {
+		t.Fatal("a cross-family review must NOT be tagged self-family")
+	}
+	// Distinct item ids: the review row never overwrote the floor.
+	if floor.ItemID == review.ItemID {
+		t.Fatalf("floor and review share item id %q (review overwrote the floor)", floor.ItemID)
+	}
+	// The findings from the shell stub flowed through to the persisted reasoning.
+	if !strings.Contains(review.Reasoning, "scope drift") {
+		t.Fatalf("review reasoning = %q, want the stub's findings", review.Reasoning)
+	}
+
+	// Judge-tagged: the review item carries judge_derived=true.
+	items, err := store.ListEvalReviewItems(ctx, "auto-trace:"+version.ID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	var reviewMeta map[string]any
+	for _, item := range items {
+		if item.ItemID == review.ItemID {
+			if err := json.Unmarshal([]byte(item.MetadataJSON), &reviewMeta); err != nil {
+				t.Fatalf("review item metadata unmarshal: %v", err)
+			}
+		}
+	}
+	if reviewMeta == nil || reviewMeta["judge_derived"] != true {
+		t.Fatalf("review item must be judge_derived=true, got %v", reviewMeta)
+	}
+
+	// The merge still happened (the review never blocked the job).
+	if len(gate.requests) != 1 {
+		t.Fatalf("merge gate requests = %d, want 1 (the merge runs regardless of the review)", len(gate.requests))
+	}
+
+	// Manual promotion preserved: the harvester writes ONLY eval/feedback rows, so
+	// no NEW template version (candidate/promotion) was created — only the single
+	// installed version still exists.
+	versions, err := store.ListAgentTemplateVersions(ctx, version.TemplateID)
+	if err != nil {
+		t.Fatalf("ListAgentTemplateVersions returned error: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("the review must create NO new template version (manual promotion), got %d", len(versions))
+	}
+}
+
+// TestCrossFamilyReviewOffByDefault: with cross_family_review_enabled UNSET,
+// daemonReviewLegDispatcher returns nil through the SAME gate, so the engine
+// dispatches no review leg and writes ONLY the verifiable floor row (the review is
+// byte-identically absent).
+func TestCrossFamilyReviewOffByDefault(t *testing.T) {
+	ctx := context.Background()
+	store := openTraceChainStore(t)
+	version := installChainTemplate(t, store, "planner")
+	gate := &stubMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine := chainEngine(store, gate)
+	engine.OutcomeHarvester = enabledHarvesterFor(t, store, harvestGitHubStub{status: realCIChainStatus()})
+
+	// auto_trace on but cross_family_review OFF: the dispatcher must be nil.
+	root := writeHarvestConfig(t, "[skillopt]\nauto_trace_enabled = true\n")
+	if d := daemonReviewLegDispatcher(store, harvestGitHubStub{}, "", root); d != nil {
+		t.Fatalf("off-by-default: review dispatcher must be nil, got %T", d)
+	}
+	// Leave engine.ReviewLegDispatcher nil (what the daemon would wire here).
+
+	seedCodexImplementJob(t, store, version)
+	registerShellReviewer(t, store)
+	seedChainApprovingReview(t, store, "head123")
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	events := autoTraceFeedback(t, store, version.ID)
+	if len(events) != 1 {
+		t.Fatalf("off-by-default must write only the floor row, got %d: %+v", len(events), events)
+	}
+	if events[0].Reviewer != "gitmoot-auto" {
+		t.Fatalf("off-by-default row reviewer = %q, want only the verifiable floor", events[0].Reviewer)
+	}
+}
+
+// stubReviewAdapter is a DeliveryAdapter that echoes a canned rubric regardless of
+// the agent's runtime, so the same-family-fallback path can be exercised without a
+// live codex/claude runtime.
+type stubReviewAdapter struct{}
+
+func (stubReviewAdapter) Deliver(_ context.Context, _ runtime.Agent, _ runtime.Job) (runtime.Result, error) {
+	return runtime.Result{Raw: `{"gitmoot_result":{"summary":"same-family review","metadata":{"rubric":{"coverage":0.5}}}}`}, nil
+}
+
+// TestCrossFamilyReviewSameFamilyFallbackWarns (REFINEMENT #1): when NO different
+// family is available, the dispatcher falls back to a SAME-family reviewer, emits
+// the cross_family_review_samefamily_fallback warning event, and tags the row
+// gitmoot-review-self:<rt> + self_family=true so it weights below cross-family.
+func TestCrossFamilyReviewSameFamilyFallbackWarns(t *testing.T) {
+	ctx := context.Background()
+	store := openTraceChainStore(t)
+	version := installChainTemplate(t, store, "planner")
+	gate := &stubMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine := chainEngine(store, gate)
+	engine.OutcomeHarvester = enabledHarvesterFor(t, store, harvestGitHubStub{status: realCIChainStatus()})
+
+	// A SAME-family (codex) registered reviewer; NO different family authed.
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name: "codex-reviewer", Role: "reviewer", Runtime: runtime.CodexRuntime,
+		RepoScope: "jerryfane/gitmoot", Capabilities: []string{"ask", "review"}, RuntimeRef: "last",
+	}); err != nil {
+		t.Fatalf("UpsertAgent(codex-reviewer) returned error: %v", err)
+	}
+	engine.ReviewLegDispatcher = &crossFamilyReviewDispatcher{
+		store: store,
+		diff:  harvestGitHubStub{},
+		buildAdapter: func(runtime.Agent, string, subprocess.Runner) (workflow.DeliveryAdapter, error) {
+			return stubReviewAdapter{}, nil
+		},
+		authed: func(context.Context) map[string]bool { return map[string]bool{} },
+	}
+
+	seedCodexImplementJob(t, store, version)
+	seedChainApprovingReview(t, store, "head123")
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	// The same-family warning event fired on the implement job.
+	events, err := store.ListJobEvents(ctx, "implement-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	warned := false
+	for _, ev := range events {
+		if ev.Kind == "cross_family_review_samefamily_fallback" {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("expected a cross_family_review_samefamily_fallback warning event, got %+v", events)
+	}
+
+	// The review row is tagged self-family (gitmoot-review-self:codex).
+	rows := autoTraceFeedback(t, store, version.ID)
+	foundSelf := false
+	for _, r := range rows {
+		if r.Reviewer == "gitmoot-review-self:codex" {
+			foundSelf = true
+		}
+	}
+	if !foundSelf {
+		t.Fatalf("expected a gitmoot-review-self:codex row, got %+v", rows)
+	}
+}
+
+// TestDaemonReviewLegDispatcherGate proves the admission gate: the dispatcher is
+// non-nil ONLY when BOTH knobs are set, and nil otherwise.
+func TestDaemonReviewLegDispatcherGate(t *testing.T) {
+	store := openHarvestStore(t)
+	gh := harvestGitHubStub{}
+
+	bothOff := writeHarvestConfig(t, "[skillopt]\n")
+	if d := daemonReviewLegDispatcher(store, gh, "", bothOff); d != nil {
+		t.Fatalf("both knobs off: want nil, got %T", d)
+	}
+	reviewOnly := writeHarvestConfig(t, "[skillopt]\ncross_family_review_enabled = true\n")
+	if d := daemonReviewLegDispatcher(store, gh, "", reviewOnly); d != nil {
+		t.Fatal("cross_family_review without auto_trace must be nil (requires BOTH)")
+	}
+	bothOn := writeHarvestConfig(t, "[skillopt]\nauto_trace_enabled = true\ncross_family_review_enabled = true\n")
+	d := daemonReviewLegDispatcher(store, gh, "", bothOn)
+	if d == nil {
+		t.Fatal("both knobs on: want a non-nil review dispatcher")
+	}
+	if _, ok := d.(*crossFamilyReviewDispatcher); !ok {
+		t.Fatalf("expected the real *crossFamilyReviewDispatcher, got %T", d)
+	}
+}

--- a/internal/cli/cross_family_review_integration_test.go
+++ b/internal/cli/cross_family_review_integration_test.go
@@ -107,16 +107,16 @@ func TestCrossFamilyReviewFullChain(t *testing.T) {
 	}
 
 	events := autoTraceFeedback(t, store, version.ID)
-	// The verifiable floor (gitmoot-auto) AND the soft review (gitmoot-review:shell).
+	// The verifiable floor (gitmoot-auto) AND the soft review (gitmoot-review).
 	if len(events) != 2 {
 		t.Fatalf("expected the floor + review row (2), got %d: %+v", len(events), events)
 	}
 	var floor, review *db.FeedbackEvent
 	for i := range events {
-		switch {
-		case events[i].Reviewer == "gitmoot-auto":
+		switch events[i].Reviewer {
+		case "gitmoot-auto":
 			floor = &events[i]
-		case strings.HasPrefix(events[i].Reviewer, "gitmoot-review:"):
+		case "gitmoot-review":
 			review = &events[i]
 		}
 	}
@@ -126,13 +126,10 @@ func TestCrossFamilyReviewFullChain(t *testing.T) {
 	if review == nil {
 		t.Fatalf("cross-family review row missing; got %+v", events)
 	}
-	// Cross-family ENFORCED: reviewer family (shell) != implementer family (codex);
-	// the reviewer id is the cross-family tag, NOT the self-family one.
-	if review.Reviewer != "gitmoot-review:shell" {
-		t.Fatalf("review reviewer = %q, want gitmoot-review:shell (cross-family)", review.Reviewer)
-	}
-	if strings.HasPrefix(review.Reviewer, "gitmoot-review-self:") {
-		t.Fatal("a cross-family review must NOT be tagged self-family")
+	// The review row uses the FIXED gitmoot-review sentinel (family-independent so a
+	// re-review by a different family overwrites in place).
+	if review.Reviewer != "gitmoot-review" {
+		t.Fatalf("review reviewer = %q, want the fixed gitmoot-review sentinel", review.Reviewer)
 	}
 	// Distinct item ids: the review row never overwrote the floor.
 	if floor.ItemID == review.ItemID {
@@ -143,7 +140,9 @@ func TestCrossFamilyReviewFullChain(t *testing.T) {
 		t.Fatalf("review reasoning = %q, want the stub's findings", review.Reasoning)
 	}
 
-	// Judge-tagged: the review item carries judge_derived=true.
+	// Judge-tagged: the review item carries judge_derived=true and the reviewer
+	// family (shell) lives in the item metadata; cross-family ENFORCED means it is
+	// NOT tagged self_family (reviewer family shell != implementer family codex).
 	items, err := store.ListEvalReviewItems(ctx, "auto-trace:"+version.ID)
 	if err != nil {
 		t.Fatalf("ListEvalReviewItems returned error: %v", err)
@@ -158,6 +157,12 @@ func TestCrossFamilyReviewFullChain(t *testing.T) {
 	}
 	if reviewMeta == nil || reviewMeta["judge_derived"] != true {
 		t.Fatalf("review item must be judge_derived=true, got %v", reviewMeta)
+	}
+	if reviewMeta["reviewer_runtime"] != "shell" {
+		t.Fatalf("review item must carry reviewer_runtime=shell, got %v", reviewMeta["reviewer_runtime"])
+	}
+	if _, present := reviewMeta["self_family"]; present {
+		t.Fatal("a cross-family review must NOT carry the self_family tag")
 	}
 
 	// The merge still happened (the review never blocked the job).
@@ -224,8 +229,9 @@ func (stubReviewAdapter) Deliver(_ context.Context, _ runtime.Agent, _ runtime.J
 
 // TestCrossFamilyReviewSameFamilyFallbackWarns (REFINEMENT #1): when NO different
 // family is available, the dispatcher falls back to a SAME-family reviewer, emits
-// the cross_family_review_samefamily_fallback warning event, and tags the row
-// gitmoot-review-self:<rt> + self_family=true so it weights below cross-family.
+// the cross_family_review_samefamily_fallback warning event, and tags the review
+// item self_family=true (reviewer_runtime=codex) so it weights below cross-family —
+// the feedback row keeps the fixed gitmoot-review reviewer sentinel.
 func TestCrossFamilyReviewSameFamilyFallbackWarns(t *testing.T) {
 	ctx := context.Background()
 	store := openTraceChainStore(t)
@@ -272,16 +278,32 @@ func TestCrossFamilyReviewSameFamilyFallbackWarns(t *testing.T) {
 		t.Fatalf("expected a cross_family_review_samefamily_fallback warning event, got %+v", events)
 	}
 
-	// The review row is tagged self-family (gitmoot-review-self:codex).
+	// The review row uses the fixed gitmoot-review sentinel; the same-family tag
+	// (self_family=true, reviewer_runtime=codex) lives in the review item metadata.
 	rows := autoTraceFeedback(t, store, version.ID)
-	foundSelf := false
-	for _, r := range rows {
-		if r.Reviewer == "gitmoot-review-self:codex" {
-			foundSelf = true
+	var review *db.FeedbackEvent
+	for i := range rows {
+		if rows[i].Reviewer == "gitmoot-review" {
+			review = &rows[i]
 		}
 	}
-	if !foundSelf {
-		t.Fatalf("expected a gitmoot-review-self:codex row, got %+v", rows)
+	if review == nil {
+		t.Fatalf("expected a gitmoot-review row, got %+v", rows)
+	}
+	items, err := store.ListEvalReviewItems(ctx, "auto-trace:"+version.ID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	var meta map[string]any
+	for _, item := range items {
+		if item.ItemID == review.ItemID {
+			if err := json.Unmarshal([]byte(item.MetadataJSON), &meta); err != nil {
+				t.Fatalf("review item metadata unmarshal: %v", err)
+			}
+		}
+	}
+	if meta["self_family"] != true || meta["reviewer_runtime"] != "codex" {
+		t.Fatalf("same-family fallback item must carry self_family=true + reviewer_runtime=codex, got %v", meta)
 	}
 }
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3977,6 +3977,15 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// TrainingPackage — is byte-identical. The harvester writes ONLY
 		// eval/feedback rows; promotion stays 100% manual.
 		OutcomeHarvester: daemonOutcomeHarvester(store, gh, home),
+		// Off-by-default cross-family review-agent soft signal (#469): on a MERGE the
+		// engine additionally runs a read-only CROSS-FAMILY review leg (off the
+		// blocking merge path, best-effort) whose subjective-quality + scope-fidelity
+		// rubric is projected into a SECOND, judge-tagged, down-weighted FeedbackEvent
+		// in the SAME auto-trace run. daemonReviewLegDispatcher returns nil unless BOTH
+		// [skillopt].cross_family_review_enabled AND auto_trace_enabled are set, so with
+		// no config NO review leg runs and NO review row is written — byte-identical.
+		// A review-leg failure never blocks or fails a job; promotion stays manual.
+		ReviewLegDispatcher: daemonReviewLegDispatcher(store, gh, checkout, home),
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},

--- a/internal/cli/trace_harvest_daemon.go
+++ b/internal/cli/trace_harvest_daemon.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -39,4 +42,51 @@ func loadSkillOptPolicy(home string) (config.SkillOptPolicy, error) {
 		return config.DefaultSkillOptPolicy(), nil
 	}
 	return config.LoadSkillOptPolicy(config.Paths{ConfigFile: cfg})
+}
+
+// daemonReviewLegDispatcher returns the best-effort cross-family review-leg
+// dispatcher for this home (#469), or nil when the review knob is OFF — the
+// default, or any config-load failure (fail-safe to disabled). ReviewEnabled()
+// requires BOTH cross_family_review_enabled AND auto_trace_enabled, so the soft
+// review row is only ever written inside an enabled auto-trace run. When nil, the
+// engine constructs no review leg and writes no review row, so daemon behavior is
+// byte-identical. It mirrors daemonOutcomeHarvester's off-by-default gate.
+func daemonReviewLegDispatcher(store *db.Store, gh github.Client, checkout string, home string) workflow.ReviewLegDispatcher {
+	if store == nil {
+		return nil
+	}
+	policy, err := loadSkillOptPolicy(home)
+	if err != nil || !policy.ReviewEnabled() {
+		return nil
+	}
+	return &crossFamilyReviewDispatcher{
+		store:        store,
+		diff:         gh,
+		buildAdapter: buildRuntimeAdapter,
+		authed:       daemonAuthedRuntimes(checkout),
+		checkout:     checkout,
+	}
+}
+
+// daemonAuthedRuntimes probes which of the cross-family runtimes (codex/claude/
+// kimi) are authed/available, best-effort, via each adapter's Health check with a
+// synthetic read-only agent. A runtime that errors (not installed / not authed) is
+// reported unavailable so the cross-family selector never materializes an
+// ephemeral leg on a runtime that cannot run. It is the seam tests substitute.
+func daemonAuthedRuntimes(checkout string) reviewAuthedRuntimes {
+	return func(ctx context.Context) map[string]bool {
+		authed := map[string]bool{}
+		factory := newRuntimeFactory()
+		for _, rt := range workflow.EphemeralRuntimes {
+			adapter, err := factory.Adapter(rt)
+			if err != nil {
+				continue
+			}
+			probe := runtime.Agent{Name: "gitmoot-review-probe", Runtime: rt, AutonomyPolicy: runtime.AutonomyPolicyReadOnly}
+			if err := adapter.Health(ctx, probe); err == nil {
+				authed[rt] = true
+			}
+		}
+		return authed
+	}
 }

--- a/internal/cli/trace_harvest_integration_test.go
+++ b/internal/cli/trace_harvest_integration_test.go
@@ -211,6 +211,10 @@ func chainEngine(store *db.Store, gate workflow.MergeGate) workflow.Engine {
 			}
 			return strings.Join(parts, "-")
 		},
+		// Run the detached cross-family review leg SYNCHRONOUSLY in the integration
+		// tests so its dispatch + harvest are deterministic; the daemon defaults to a
+		// goroutine (the review is genuinely off the AdvanceJob path in production).
+		ReviewSpawner: func(fn func()) { fn() },
 	}
 }
 

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -377,11 +377,24 @@ type SkillOptPolicy struct {
 	// FeedbackEvent in a dedicated auto-trace eval_run. Empty/false (the default)
 	// means OFF: no harvester is constructed and the daemon writes nothing extra.
 	AutoTraceEnabled bool
+
+	// CrossFamilyReviewEnabled opts the daemon into the Mode A cross-family
+	// review-agent SOFT signal (#469): when true (AND AutoTraceEnabled is also true),
+	// a merged implement job additionally runs a read-only CROSS-FAMILY review leg
+	// whose subjective-quality + scope-fidelity rubric is projected into a SECOND,
+	// judge-tagged, down-weighted FeedbackEvent in the SAME auto-trace run. Empty/
+	// false (the default) means OFF: NO review leg runs and NO review row is written
+	// — byte-identical to the verifiable-floor-only behavior. It additionally
+	// requires AutoTraceEnabled (a review row only makes sense inside the auto-trace
+	// run); ReviewEnabled() encodes that dependency. A live cross-family LLM review
+	// per merge is a real cost surface, so it must be opt-in.
+	CrossFamilyReviewEnabled bool
 }
 
 func DefaultSkillOptPolicy() SkillOptPolicy {
 	return SkillOptPolicy{
-		AutoTraceEnabled: false,
+		AutoTraceEnabled:         false,
+		CrossFamilyReviewEnabled: false,
 	}
 }
 
@@ -389,6 +402,14 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 // no [skillopt] config (the default) it is OFF and no harvester is constructed.
 func (p SkillOptPolicy) Enabled() bool {
 	return p.AutoTraceEnabled
+}
+
+// ReviewEnabled reports whether the cross-family review-agent soft signal (#469)
+// is configured on. It requires BOTH cross_family_review_enabled AND
+// auto_trace_enabled (the review row only makes sense inside the auto-trace run),
+// so enabling the review knob alone — without the auto-trace harvester — is OFF.
+func (p SkillOptPolicy) ReviewEnabled() bool {
+	return p.AutoTraceEnabled && p.CrossFamilyReviewEnabled
 }
 
 func LoadSkillOptPolicy(paths Paths) (SkillOptPolicy, error) {
@@ -427,6 +448,10 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 	case "auto_trace_enabled":
 		parsed, err := strconv.ParseBool(value)
 		policy.AutoTraceEnabled = parsed
+		return err
+	case "cross_family_review_enabled":
+		parsed, err := strconv.ParseBool(value)
+		policy.CrossFamilyReviewEnabled = parsed
 		return err
 	default:
 		return nil

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -56,6 +56,62 @@ auto_trace_enabled = maybe
 	}
 }
 
+// TestLoadSkillOptPolicyReviewDefaultsDisabled: the cross-family review knob is OFF
+// by default and ReviewEnabled() is false.
+func TestLoadSkillOptPolicyReviewDefaultsDisabled(t *testing.T) {
+	policy := DefaultSkillOptPolicy()
+	if policy.CrossFamilyReviewEnabled || policy.ReviewEnabled() {
+		t.Fatalf("cross-family review must default OFF, got %+v", policy)
+	}
+}
+
+// TestLoadSkillOptPolicyReviewRequiresAutoTrace: cross_family_review_enabled alone
+// (without auto_trace_enabled) is OFF — ReviewEnabled() requires BOTH.
+func TestLoadSkillOptPolicyReviewRequiresAutoTrace(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+cross_family_review_enabled = true
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.CrossFamilyReviewEnabled {
+		t.Fatal("cross_family_review_enabled = true should parse")
+	}
+	if policy.ReviewEnabled() {
+		t.Fatal("ReviewEnabled() must be false without auto_trace_enabled (requires BOTH)")
+	}
+}
+
+// TestLoadSkillOptPolicyReviewEnabledWithBoth: both knobs on => ReviewEnabled().
+func TestLoadSkillOptPolicyReviewEnabledWithBoth(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_trace_enabled = true
+cross_family_review_enabled = true
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.ReviewEnabled() {
+		t.Fatalf("ReviewEnabled() must be true with both knobs on, got %+v", policy)
+	}
+}
+
 // TestLoadSkillOptPolicyIgnoresOtherSections proves a config that only sets
 // [events]/[orchestrate] leaves the trace-harvester at its disabled default.
 func TestLoadSkillOptPolicyIgnoresOtherSections(t *testing.T) {

--- a/internal/skillopt/cross_family_review.go
+++ b/internal/skillopt/cross_family_review.go
@@ -1,0 +1,181 @@
+package skillopt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// reviewReviewerPrefix / reviewSelfReviewerPrefix are the distinct, judge-derived
+// reviewer ids the cross-family review-agent soft signal carries (#469 +
+// REFINEMENT #1). They are non-human sentinels (like autoTraceReviewer) so the
+// soft review row is never mistaken for a human ranking, and they are DISTINCT
+// from autoTraceReviewer so the review row coexists with the verifiable-floor row
+// under the run's UNIQUE (run_id,item_id,reviewer,source,source_url) key instead
+// of overwriting it.
+//
+// Weight tiers the export/optimizer can recognize from the reviewer id + the
+// item's judge tags: human gold > verifiable floor (gitmoot-auto) > cross-family
+// judge (gitmoot-review:<rt>) > same-family judge (gitmoot-review-self:<rt>).
+//
+// MEASURE-THE-JUDGE (#344/#345): the judge is judge-derived + weighted low here
+// and is NOT calibrated against human gold in this slice — TODO wire a judge↔human
+// agreement capture per task-kind (#344/#345) so the optimizer can trust it more.
+// It is weighted-low + judge-tagged; subject to the configurable auto_promote
+// policy (#463) when that lands — NOT barred from promotion.
+const (
+	reviewReviewerPrefix     = "gitmoot-review:"
+	reviewSelfReviewerPrefix = "gitmoot-review-self:"
+)
+
+// reviewItemIDPrefix namespaces the cross-family review eval item so it is a
+// DISTINCT item id from the verifiable-floor item (which is repo#pr): the review
+// item is review#<repo>#<pr>. A distinct item id means the soft review row never
+// overwrites the verifiable-floor row even though both live in the same
+// auto-trace:<versionID> run.
+const reviewItemIDPrefix = "review#"
+
+// reviewItemMetadataJudgeKey / reviewItemMetadataSelfFamilyKey are the per-item
+// metadata flags that mark a review row judge-derived (and same-family when the
+// fallback fired). The run-level feedback_source stays automatic_trace (no
+// contract bump); these item tags are the seam the export/optimizer reads to
+// down-weight judge rows below the verifiable floor and to weight same-family
+// judge rows below cross-family ones, and the seam #344/#345 calibration reads.
+const (
+	reviewItemMetadataJudgeKey      = "judge_derived"
+	reviewItemMetadataSelfFamilyKey = "self_family"
+	reviewItemMetadataReviewerKey   = "reviewer_runtime"
+)
+
+// reviewReviewer builds the judge-derived reviewer id for a review outcome: a
+// cross-family review is gitmoot-review:<rt>, a same-family fallback (REFINEMENT
+// #1) is gitmoot-review-self:<rt> so it weights below a cross-family review and
+// never collides with it on the UNIQUE key.
+func reviewReviewer(outcome workflow.Outcome) string {
+	rt := strings.TrimSpace(outcome.Reviewer)
+	if rt == "" {
+		rt = "unknown"
+	}
+	if outcome.SelfFamily {
+		return reviewSelfReviewerPrefix + rt
+	}
+	return reviewReviewerPrefix + rt
+}
+
+// crossFamilyReviewItemID is the DISTINCT eval item id for the soft review row (review#repo#pr)
+// so it never overwrites the verifiable-floor row (repo#pr) in the same run, while
+// a re-review of the SAME PR re-upserts the SAME review row in place (stable row
+// count, corrective overwrite).
+func crossFamilyReviewItemID(outcome workflow.Outcome) string {
+	return reviewItemIDPrefix + autoTraceItemID(outcome)
+}
+
+// projectReview maps a cross-family review rubric to a NormalizedSignal via
+// ProjectSignal over a synthetic EvaluatorScore whose DimensionScores ARE the
+// rubric (#469). ProjectSignal takes the arithmetic MEAN of DimensionScores when
+// Soft is absent (the #462 rubric-as-score path), so no new aggregation is
+// invented. An EMPTY rubric yields HasScore=false (no fabricated neutral 0.5).
+//
+// The review is always recorded as choice "a" (a soft, advisory positive-leaning
+// signal attached to the current promoted template); it is weighted-low and
+// judge-tagged via the reviewer id + item metadata, NOT via the choice, so it can
+// never outrank the verifiable floor.
+func projectReview(outcome workflow.Outcome) NormalizedSignal {
+	dims := map[string]float64{}
+	for k, v := range outcome.Rubric {
+		dims[k] = v
+	}
+	findings := strings.TrimSpace(outcome.Findings)
+	if findings == "" {
+		findings = fmt.Sprintf("Cross-family review of PR #%d.", outcome.PullRequest)
+	}
+	return ProjectSignal(&EvaluatorScore{DimensionScores: dims}, &RankedFeedbackEvent{Reasoning: findings}, nil)
+}
+
+// writeReviewFeedback upserts the SOFT cross-family review row into the EXISTING
+// auto-trace:<versionID> run (#469): the same run as the verifiable floor (so the
+// optimizer sees both), under a DISTINCT item id (review#repo#pr) and a
+// judge-derived reviewer (gitmoot-review[-self]:<rt>), so it coexists with the
+// floor row on the UNIQUE (run_id,item_id,reviewer,source,source_url) key instead
+// of overwriting it. The run keeps feedback_source=automatic_trace (no contract
+// bump, ContractVersion=1 unchanged); the review item carries judge_derived (and
+// self_family on the fallback) so the export/optimizer down-weights it.
+//
+// It writes ONLY eval_runs/eval_review_items/feedback_events — no candidate, no
+// promotion path — so promotion stays manual (subject to the configurable
+// auto_promote policy, #463, when that lands).
+func (h *OutcomeHarvester) writeReviewFeedback(ctx context.Context, version db.AgentTemplateVersion, outcome workflow.Outcome, signal NormalizedSignal) error {
+	runID := autoTraceRunIDPrefix + strings.TrimSpace(version.ID)
+	itemID := crossFamilyReviewItemID(outcome)
+	reviewer := reviewReviewer(outcome)
+	sourceURL := pullRequestURL(outcome.Repo, outcome.PullRequest)
+
+	// Reuse the EXISTING auto-trace run (same metadata: feedback_source=automatic_trace,
+	// validate mode); an upsert keyed by the run id is idempotent so the verifiable
+	// floor's run metadata is preserved verbatim.
+	if err := h.Store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                runID,
+		TemplateID:        strings.TrimSpace(version.TemplateID),
+		TemplateVersionID: strings.TrimSpace(version.ID),
+		TargetRepo:        strings.TrimSpace(outcome.Repo),
+		State:             "ready",
+		Mode:              db.EvalRunModeValidate,
+		MetadataJSON:      autoTraceRunMetadata(),
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace eval_run (review): %w", err)
+	}
+
+	if err := h.Store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:        runID,
+		ItemID:       itemID,
+		Title:        reviewItemTitle(outcome),
+		MetadataJSON: reviewItemMetadata(outcome),
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace eval_review_item (review): %w", err)
+	}
+
+	if err := h.Store.UpsertFeedbackEvent(ctx, db.FeedbackEvent{
+		RunID:     runID,
+		ItemID:    itemID,
+		Choice:    "a",
+		Reasoning: signal.Feedback,
+		Reviewer:  reviewer,
+		Source:    autoTraceSource,
+		SourceURL: sourceURL,
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace feedback_event (review): %w", err)
+	}
+	return nil
+}
+
+// reviewItemTitle is the human-readable title of the soft review item.
+func reviewItemTitle(outcome workflow.Outcome) string {
+	repo := strings.TrimSpace(outcome.Repo)
+	if outcome.PullRequest > 0 {
+		return fmt.Sprintf("Cross-family review: %s PR #%d", repo, outcome.PullRequest)
+	}
+	return "Cross-family review: " + repo
+}
+
+// reviewItemMetadata carries the judge-derived (+ self-family) tags on the review
+// eval item so the export/optimizer can down-weight it relative to the verifiable
+// floor and to human gold, WITHOUT a new contract field. self_family is present
+// (true) ONLY on the same-family fallback row so a same-family judge weights below
+// a cross-family judge.
+func reviewItemMetadata(outcome workflow.Outcome) string {
+	meta := map[string]any{
+		"repo":                        strings.TrimSpace(outcome.Repo),
+		"pull_request":                outcome.PullRequest,
+		reviewItemMetadataJudgeKey:    true,
+		reviewItemMetadataReviewerKey: strings.TrimSpace(outcome.Reviewer),
+	}
+	if outcome.SelfFamily {
+		meta[reviewItemMetadataSelfFamilyKey] = true
+	}
+	raw, _ := json.Marshal(meta)
+	return string(raw)
+}

--- a/internal/skillopt/cross_family_review.go
+++ b/internal/skillopt/cross_family_review.go
@@ -10,27 +10,32 @@ import (
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
-// reviewReviewerPrefix / reviewSelfReviewerPrefix are the distinct, judge-derived
-// reviewer ids the cross-family review-agent soft signal carries (#469 +
-// REFINEMENT #1). They are non-human sentinels (like autoTraceReviewer) so the
-// soft review row is never mistaken for a human ranking, and they are DISTINCT
-// from autoTraceReviewer so the review row coexists with the verifiable-floor row
-// under the run's UNIQUE (run_id,item_id,reviewer,source,source_url) key instead
-// of overwriting it.
+// reviewReviewerID is the FIXED, judge-derived reviewer id every cross-family
+// review row carries (#469 + REFINEMENT #1). It is a single non-human sentinel
+// (like autoTraceReviewer) so the soft review row is never mistaken for a human
+// ranking, and it is DISTINCT from autoTraceReviewer so the review row coexists
+// with the verifiable-floor row under the run's UNIQUE
+// (run_id,item_id,reviewer,source,source_url) key instead of overwriting it.
 //
-// Weight tiers the export/optimizer can recognize from the reviewer id + the
-// item's judge tags: human gold > verifiable floor (gitmoot-auto) > cross-family
-// judge (gitmoot-review:<rt>) > same-family judge (gitmoot-review-self:<rt>).
+// CRITICAL: the reviewer id is INTENTIONALLY independent of the selected reviewer
+// family/runtime so a re-review of the SAME PR by a DIFFERENT family (e.g. a first
+// cross-family claude review, a later same-family codex fallback after claude is
+// deauthed) OVERWRITES the prior review row in place instead of accumulating a
+// second, stale, contradictory row (row count stays stable, corrective overwrite).
+// The actual reviewer family + the same-family flag are carried in the item
+// METADATA (reviewer_runtime / self_family), which is where the export/optimizer
+// reads them — so the weight tiers below survive without varying the conflict key.
+//
+// Weight tiers the export/optimizer recognizes from the reviewer sentinel + the
+// item's judge/self-family tags: human gold > verifiable floor (gitmoot-auto) >
+// cross-family judge (self_family absent) > same-family judge (self_family=true).
 //
 // MEASURE-THE-JUDGE (#344/#345): the judge is judge-derived + weighted low here
 // and is NOT calibrated against human gold in this slice — TODO wire a judge↔human
 // agreement capture per task-kind (#344/#345) so the optimizer can trust it more.
 // It is weighted-low + judge-tagged; subject to the configurable auto_promote
 // policy (#463) when that lands — NOT barred from promotion.
-const (
-	reviewReviewerPrefix     = "gitmoot-review:"
-	reviewSelfReviewerPrefix = "gitmoot-review-self:"
-)
+const reviewReviewerID = "gitmoot-review"
 
 // reviewItemIDPrefix namespaces the cross-family review eval item so it is a
 // DISTINCT item id from the verifiable-floor item (which is repo#pr): the review
@@ -49,21 +54,20 @@ const (
 	reviewItemMetadataJudgeKey      = "judge_derived"
 	reviewItemMetadataSelfFamilyKey = "self_family"
 	reviewItemMetadataReviewerKey   = "reviewer_runtime"
+	// reviewItemMetadataScoreKey carries the projected rubric MEAN ([0,1]) on the
+	// review item so the magnitude the judge measured is recoverable by the
+	// export/optimizer (the score also drives the a/b choice). It is item metadata
+	// (no contract bump), the same no-new-field down-weight lever the run uses.
+	reviewItemMetadataScoreKey = "rubric_score"
 )
 
-// reviewReviewer builds the judge-derived reviewer id for a review outcome: a
-// cross-family review is gitmoot-review:<rt>, a same-family fallback (REFINEMENT
-// #1) is gitmoot-review-self:<rt> so it weights below a cross-family review and
-// never collides with it on the UNIQUE key.
-func reviewReviewer(outcome workflow.Outcome) string {
-	rt := strings.TrimSpace(outcome.Reviewer)
-	if rt == "" {
-		rt = "unknown"
-	}
-	if outcome.SelfFamily {
-		return reviewSelfReviewerPrefix + rt
-	}
-	return reviewReviewerPrefix + rt
+// reviewReviewer returns the FIXED judge-derived reviewer id for the review row's
+// UNIQUE key. It is deliberately constant across reviewer families so a re-review
+// of the same PR by a DIFFERENT family overwrites the prior row rather than
+// accumulating a stale duplicate; the actual family and the same-family flag are
+// carried in the item metadata (reviewer_runtime / self_family) instead.
+func reviewReviewer(workflow.Outcome) string {
+	return reviewReviewerID
 }
 
 // crossFamilyReviewItemID is the DISTINCT eval item id for the soft review row (review#repo#pr)
@@ -74,16 +78,39 @@ func crossFamilyReviewItemID(outcome workflow.Outcome) string {
 	return reviewItemIDPrefix + autoTraceItemID(outcome)
 }
 
+// reviewChoiceThreshold is the projected-mean cutoff that maps a review's quality
+// LEVEL onto the a/b choice the auto-trace pipeline actually reads
+// (recommendValidate counts "a" => baselineWins, "b" => candidateWins). It mirrors
+// the verifiable floor's positive=>"a" / negative=>"b" convention: a review whose
+// mean rubric score is below this cutoff is a NEGATIVE quality signal and must
+// register as "b" (a non-baseline vote), not as a baseline win. A review at or
+// above it is positive-leaning and registers as "a".
+const reviewChoiceThreshold = 0.5
+
+// reviewChoice derives the a/b choice from the projected quality so a poor review
+// actually registers as a non-baseline vote instead of silently inverting into a
+// baseline win (#469 review-fix). When the rubric was empty (HasScore=false) the
+// signal carries no quality level; the caller skips the write entirely rather than
+// fabricate a vote, so reviewChoice is only consulted for a scored signal.
+func reviewChoice(signal NormalizedSignal) string {
+	if signal.HasScore && signal.Score < reviewChoiceThreshold {
+		return "b"
+	}
+	return "a"
+}
+
 // projectReview maps a cross-family review rubric to a NormalizedSignal via
 // ProjectSignal over a synthetic EvaluatorScore whose DimensionScores ARE the
 // rubric (#469). ProjectSignal takes the arithmetic MEAN of DimensionScores when
 // Soft is absent (the #462 rubric-as-score path), so no new aggregation is
 // invented. An EMPTY rubric yields HasScore=false (no fabricated neutral 0.5).
 //
-// The review is always recorded as choice "a" (a soft, advisory positive-leaning
-// signal attached to the current promoted template); it is weighted-low and
-// judge-tagged via the reviewer id + item metadata, NOT via the choice, so it can
-// never outrank the verifiable floor.
+// The projected mean is load-bearing: writeReviewFeedback skips the write when the
+// rubric is empty (HasScore=false, non-informative) and maps the score LEVEL onto
+// the a/b choice via reviewChoice, so a low-quality review registers as a "b"
+// (non-baseline) vote rather than a fabricated baseline win. The row stays
+// weighted-low + judge-tagged via the reviewer id + item metadata so it can never
+// outrank the verifiable floor regardless of the choice.
 func projectReview(outcome workflow.Outcome) NormalizedSignal {
 	dims := map[string]float64{}
 	for k, v := range outcome.Rubric {
@@ -98,17 +125,27 @@ func projectReview(outcome workflow.Outcome) NormalizedSignal {
 
 // writeReviewFeedback upserts the SOFT cross-family review row into the EXISTING
 // auto-trace:<versionID> run (#469): the same run as the verifiable floor (so the
-// optimizer sees both), under a DISTINCT item id (review#repo#pr) and a
-// judge-derived reviewer (gitmoot-review[-self]:<rt>), so it coexists with the
-// floor row on the UNIQUE (run_id,item_id,reviewer,source,source_url) key instead
-// of overwriting it. The run keeps feedback_source=automatic_trace (no contract
-// bump, ContractVersion=1 unchanged); the review item carries judge_derived (and
-// self_family on the fallback) so the export/optimizer down-weights it.
+// optimizer sees both), under a DISTINCT item id (review#repo#pr) and the FIXED
+// judge-derived reviewer sentinel (gitmoot-review), so it coexists with the floor
+// row on the UNIQUE (run_id,item_id,reviewer,source,source_url) key instead of
+// overwriting it — and so a re-review by a different family overwrites the review
+// row in place rather than accumulating a stale duplicate. The run keeps
+// feedback_source=automatic_trace (no contract bump, ContractVersion=1 unchanged);
+// the review item carries judge_derived, the reviewer_runtime family, the projected
+// rubric_score, and self_family (on the fallback) so the export/optimizer
+// down-weights it. The a/b choice tracks the projected mean (poor review => "b").
 //
 // It writes ONLY eval_runs/eval_review_items/feedback_events — no candidate, no
 // promotion path — so promotion stays manual (subject to the configurable
 // auto_promote policy, #463, when that lands).
 func (h *OutcomeHarvester) writeReviewFeedback(ctx context.Context, version db.AgentTemplateVersion, outcome workflow.Outcome, signal NormalizedSignal) error {
+	// An empty rubric (HasScore=false) carries NO quality level: it is
+	// non-informative, so writing a row would either fabricate a neutral vote or
+	// (worse) default to a baseline win. Skip it entirely — matching the
+	// HasScore=false intent — so only a scored review ever lands a feedback row.
+	if !signal.HasScore {
+		return nil
+	}
 	runID := autoTraceRunIDPrefix + strings.TrimSpace(version.ID)
 	itemID := crossFamilyReviewItemID(outcome)
 	reviewer := reviewReviewer(outcome)
@@ -133,7 +170,7 @@ func (h *OutcomeHarvester) writeReviewFeedback(ctx context.Context, version db.A
 		RunID:        runID,
 		ItemID:       itemID,
 		Title:        reviewItemTitle(outcome),
-		MetadataJSON: reviewItemMetadata(outcome),
+		MetadataJSON: reviewItemMetadata(outcome, signal),
 	}); err != nil {
 		return fmt.Errorf("upsert auto-trace eval_review_item (review): %w", err)
 	}
@@ -141,7 +178,7 @@ func (h *OutcomeHarvester) writeReviewFeedback(ctx context.Context, version db.A
 	if err := h.Store.UpsertFeedbackEvent(ctx, db.FeedbackEvent{
 		RunID:     runID,
 		ItemID:    itemID,
-		Choice:    "a",
+		Choice:    reviewChoice(signal),
 		Reasoning: signal.Feedback,
 		Reviewer:  reviewer,
 		Source:    autoTraceSource,
@@ -165,13 +202,18 @@ func reviewItemTitle(outcome workflow.Outcome) string {
 // eval item so the export/optimizer can down-weight it relative to the verifiable
 // floor and to human gold, WITHOUT a new contract field. self_family is present
 // (true) ONLY on the same-family fallback row so a same-family judge weights below
-// a cross-family judge.
-func reviewItemMetadata(outcome workflow.Outcome) string {
+// a cross-family judge. It also persists the projected rubric MEAN (rubric_score)
+// so the quality MAGNITUDE the judge measured reaches the row — not just the a/b
+// choice derived from it — keeping projectReview's score path load-bearing.
+func reviewItemMetadata(outcome workflow.Outcome, signal NormalizedSignal) string {
 	meta := map[string]any{
 		"repo":                        strings.TrimSpace(outcome.Repo),
 		"pull_request":                outcome.PullRequest,
 		reviewItemMetadataJudgeKey:    true,
 		reviewItemMetadataReviewerKey: strings.TrimSpace(outcome.Reviewer),
+	}
+	if signal.HasScore {
+		meta[reviewItemMetadataScoreKey] = signal.Score
 	}
 	if outcome.SelfFamily {
 		meta[reviewItemMetadataSelfFamilyKey] = true

--- a/internal/skillopt/cross_family_review_test.go
+++ b/internal/skillopt/cross_family_review_test.go
@@ -91,7 +91,7 @@ func TestReviewRowCoexistsWithFloor(t *testing.T) {
 		switch events[i].Reviewer {
 		case autoTraceReviewer:
 			floor = &events[i]
-		case reviewReviewerPrefix + "claude":
+		case reviewReviewerID:
 			review = &events[i]
 		}
 	}
@@ -99,7 +99,7 @@ func TestReviewRowCoexistsWithFloor(t *testing.T) {
 		t.Fatal("the verifiable-floor row (gitmoot-auto) must still exist")
 	}
 	if review == nil {
-		t.Fatalf("the review row (gitmoot-review:claude) must exist; got %+v", events)
+		t.Fatalf("the review row (gitmoot-review) must exist; got %+v", events)
 	}
 	if floor.ItemID == review.ItemID {
 		t.Fatalf("floor and review must use DISTINCT item ids; both = %q", floor.ItemID)
@@ -123,8 +123,8 @@ func TestReviewRowJudgeTaggedAndDownWeighted(t *testing.T) {
 	}
 
 	events := feedbackForVersion(t, store, version.ID)
-	if len(events) != 1 || events[0].Reviewer != reviewReviewerPrefix+"claude" {
-		t.Fatalf("expected one gitmoot-review:claude row, got %+v", events)
+	if len(events) != 1 || events[0].Reviewer != reviewReviewerID {
+		t.Fatalf("expected one gitmoot-review row, got %+v", events)
 	}
 	if events[0].Source != autoTraceSource {
 		t.Fatalf("review row source = %q, want auto-trace (rides the automatic_trace run)", events[0].Source)
@@ -167,10 +167,11 @@ func TestReviewRowJudgeTaggedAndDownWeighted(t *testing.T) {
 	}
 }
 
-// TestSelfFamilyReviewWeightsLower: a same-family fallback row uses the DISTINCT
-// gitmoot-review-self:<rt> reviewer and carries self_family=true so it weights
-// below a cross-family review (REFINEMENT #1). The cross-family and same-family
-// rows coexist (distinct reviewers) without overwriting each other.
+// TestSelfFamilyReviewWeightsLower: a same-family fallback row carries
+// self_family=true (and its reviewer_runtime) in the item metadata so it weights
+// below a cross-family review (REFINEMENT #1), while the feedback row keeps the
+// FIXED gitmoot-review reviewer sentinel (the family lives in metadata, not the
+// conflict key, so a family change re-reviews in place — see TestReviewRowReUpserts*).
 func TestSelfFamilyReviewWeightsLower(t *testing.T) {
 	ctx := context.Background()
 	store := newTraceStore(t)
@@ -186,8 +187,8 @@ func TestSelfFamilyReviewWeightsLower(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected one self-family review row, got %+v", events)
 	}
-	if events[0].Reviewer != reviewSelfReviewerPrefix+"codex" {
-		t.Fatalf("self-family reviewer = %q, want gitmoot-review-self:codex", events[0].Reviewer)
+	if events[0].Reviewer != reviewReviewerID {
+		t.Fatalf("review reviewer = %q, want the fixed gitmoot-review sentinel", events[0].Reviewer)
 	}
 
 	item, ok := reviewItemFor(t, store, version.ID, reviewItemIDPrefix+"owner/repo#7")
@@ -201,8 +202,52 @@ func TestSelfFamilyReviewWeightsLower(t *testing.T) {
 	if meta[reviewItemMetadataSelfFamilyKey] != true {
 		t.Fatalf("self-family review must carry self_family=true, got %v", meta[reviewItemMetadataSelfFamilyKey])
 	}
+	if meta[reviewItemMetadataReviewerKey] != "codex" {
+		t.Fatalf("self-family review must carry reviewer_runtime=codex, got %v", meta[reviewItemMetadataReviewerKey])
+	}
 	if meta[reviewItemMetadataJudgeKey] != true {
 		t.Fatal("self-family review must still be judge_derived=true")
+	}
+}
+
+// TestReviewRowReUpsertsAcrossFamilyChange (#469 fix): a re-review of the SAME PR
+// by a DIFFERENT reviewer family (cross-family claude, then same-family codex
+// fallback) re-upserts the SAME single review row in place instead of accumulating
+// a stale duplicate — the reviewer id is family-independent, the family lives in
+// the item metadata, which the later harvest overwrites.
+func TestReviewRowReUpsertsAcrossFamilyChange(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	// First: a cross-family claude review.
+	if err := h.Harvest(ctx, implementJob(), payload, reviewOutcome(map[string]float64{"coverage": 0.7}, "claude", false)); err != nil {
+		t.Fatalf("Harvest cross-family review returned error: %v", err)
+	}
+	// Later: a same-family codex fallback (different family) for the SAME PR.
+	if err := h.Harvest(ctx, implementJob(), payload, reviewOutcome(map[string]float64{"coverage": 0.3}, "codex", true)); err != nil {
+		t.Fatalf("Harvest self-family review returned error: %v", err)
+	}
+
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 {
+		t.Fatalf("a family change must overwrite, not accumulate; want 1 review row, got %d: %+v", len(events), events)
+	}
+	// The surviving row reflects the LATEST (codex, self-family, low-mean) harvest.
+	if events[0].Choice != "b" {
+		t.Fatalf("the latest low-mean review must overwrite to Choice=b, got %q", events[0].Choice)
+	}
+	item, ok := reviewItemFor(t, store, version.ID, reviewItemIDPrefix+"owner/repo#7")
+	if !ok {
+		t.Fatal("review item missing after family change")
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(item.MetadataJSON), &meta); err != nil {
+		t.Fatalf("metadata unmarshal: %v", err)
+	}
+	if meta[reviewItemMetadataReviewerKey] != "codex" || meta[reviewItemMetadataSelfFamilyKey] != true {
+		t.Fatalf("the overwritten item must reflect the latest codex self-family review, got %v", meta)
 	}
 }
 
@@ -222,6 +267,84 @@ func TestReviewRowReUpsertsInPlace(t *testing.T) {
 	events := feedbackForVersion(t, store, version.ID)
 	if len(events) != 1 {
 		t.Fatalf("re-review must re-upsert in place (1 row), got %d: %+v", len(events), events)
+	}
+}
+
+// TestReviewChoiceTracksQualityLevel: the review's a/b choice is DERIVED from the
+// projected rubric mean, not hardcoded — a low-mean (poor) review registers as a
+// "b" (non-baseline) vote and a high-mean (good) review as "a" — so a negative
+// quality review is no longer silently inverted into a baseline win (#469 fix).
+func TestReviewChoiceTracksQualityLevel(t *testing.T) {
+	ctx := context.Background()
+
+	// Low mean (0.2/0.3 => 0.25) must register as a non-baseline "b" vote.
+	storeLow := newTraceStore(t)
+	versionLow, payloadLow := installTraceTemplate(t, storeLow, "planner")
+	hLow := NewOutcomeHarvester(storeLow, nil)
+	if err := hLow.Harvest(ctx, implementJob(), payloadLow, reviewOutcome(map[string]float64{"coverage": 0.2, "fidelity": 0.3}, "claude", false)); err != nil {
+		t.Fatalf("Harvest low review returned error: %v", err)
+	}
+	low := feedbackForVersion(t, storeLow, versionLow.ID)
+	if len(low) != 1 || low[0].Choice != "b" {
+		t.Fatalf("a low-mean review must write Choice=b, got %+v", low)
+	}
+
+	// High mean (0.9/0.8 => 0.85) stays a positive-leaning "a".
+	storeHigh := newTraceStore(t)
+	versionHigh, payloadHigh := installTraceTemplate(t, storeHigh, "planner")
+	hHigh := NewOutcomeHarvester(storeHigh, nil)
+	if err := hHigh.Harvest(ctx, implementJob(), payloadHigh, reviewOutcome(map[string]float64{"coverage": 0.9, "fidelity": 0.8}, "claude", false)); err != nil {
+		t.Fatalf("Harvest high review returned error: %v", err)
+	}
+	high := feedbackForVersion(t, storeHigh, versionHigh.ID)
+	if len(high) != 1 || high[0].Choice != "a" {
+		t.Fatalf("a high-mean review must write Choice=a, got %+v", high)
+	}
+}
+
+// TestReviewEmptyRubricWritesNoRow: an EMPTY rubric (HasScore=false) is
+// non-informative, so the harvester writes NO review row at all rather than
+// fabricating a baseline vote (#469 fix — the projected magnitude is load-bearing).
+func TestReviewEmptyRubricWritesNoRow(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	if err := h.Harvest(ctx, implementJob(), payload, reviewOutcome(map[string]float64{}, "claude", false)); err != nil {
+		t.Fatalf("Harvest empty-rubric review returned error: %v", err)
+	}
+	if events := feedbackForVersion(t, store, version.ID); len(events) != 0 {
+		t.Fatalf("an empty (HasScore=false) rubric must write no review row, got %+v", events)
+	}
+}
+
+// TestReviewItemCarriesProjectedScore: the projected rubric MEAN is persisted on
+// the review item (rubric_score) so the quality MAGNITUDE the judge measured
+// reaches the row — projectReview's score path is wired, not dead.
+func TestReviewItemCarriesProjectedScore(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	if err := h.Harvest(ctx, implementJob(), payload, reviewOutcome(map[string]float64{"coverage": 0.2, "fidelity": 0.4}, "claude", false)); err != nil {
+		t.Fatalf("Harvest review returned error: %v", err)
+	}
+	item, ok := reviewItemFor(t, store, version.ID, reviewItemIDPrefix+"owner/repo#7")
+	if !ok {
+		t.Fatal("review eval_review_item missing")
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(item.MetadataJSON), &meta); err != nil {
+		t.Fatalf("review item metadata did not unmarshal: %v", err)
+	}
+	score, ok := meta[reviewItemMetadataScoreKey].(float64)
+	if !ok {
+		t.Fatalf("review item must carry the projected rubric_score, got %v", meta[reviewItemMetadataScoreKey])
+	}
+	if want := (0.2 + 0.4) / 2.0; score-want > 1e-9 || score-want < -1e-9 {
+		t.Fatalf("rubric_score = %v, want the mean %v", score, want)
 	}
 }
 

--- a/internal/skillopt/cross_family_review_test.go
+++ b/internal/skillopt/cross_family_review_test.go
@@ -1,0 +1,243 @@
+package skillopt
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// reviewOutcome builds a cross-family OutcomeReviewed for the test PR with the
+// given rubric + reviewer + self-family flag.
+func reviewOutcome(rubric map[string]float64, reviewer string, selfFamily bool) workflow.Outcome {
+	return workflow.Outcome{
+		Kind:        workflow.OutcomeReviewed,
+		Repo:        "owner/repo",
+		PullRequest: 7,
+		HeadSHA:     "deadbeef",
+		Reviewer:    reviewer,
+		SelfFamily:  selfFamily,
+		Rubric:      rubric,
+		Findings:    "scope drift on PR #7",
+	}
+}
+
+func reviewItemFor(t *testing.T, store *db.Store, versionID, itemID string) (db.EvalReviewItem, bool) {
+	t.Helper()
+	items, err := store.ListEvalReviewItems(context.Background(), autoTraceRunIDPrefix+versionID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	for _, item := range items {
+		if item.ItemID == itemID {
+			return item, true
+		}
+	}
+	return db.EvalReviewItem{}, false
+}
+
+// TestProjectReviewMeanOfDimensionScores: the rubric projects to the arithmetic
+// MEAN of its DimensionScores (the #462 mean path), HasScore=true.
+func TestProjectReviewMeanOfDimensionScores(t *testing.T) {
+	signal := projectReview(reviewOutcome(map[string]float64{
+		"coverage": 0.6, "fidelity": 0.8, "architecture": 1.0,
+	}, "claude", false))
+	if !signal.HasScore {
+		t.Fatal("a non-empty rubric must yield HasScore=true")
+	}
+	want := (0.6 + 0.8 + 1.0) / 3.0
+	if diff := signal.Score - want; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("review score = %v, want the mean %v", signal.Score, want)
+	}
+}
+
+// TestProjectReviewEmptyRubricNoScore: an EMPTY rubric yields HasScore=false (no
+// fabricated neutral 0.5).
+func TestProjectReviewEmptyRubricNoScore(t *testing.T) {
+	signal := projectReview(reviewOutcome(map[string]float64{}, "claude", false))
+	if signal.HasScore {
+		t.Fatalf("empty rubric must yield HasScore=false, got score=%v", signal.Score)
+	}
+}
+
+// TestReviewRowCoexistsWithFloor: harvesting a merge floor THEN a cross-family
+// review writes TWO distinct rows in the SAME auto-trace run under distinct item
+// ids + reviewers — the review row NEVER overwrites the verifiable floor.
+func TestReviewRowCoexistsWithFloor(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, &stubStatusReader{status: realCIStatus()})
+
+	// Verifiable floor (merge with real CI).
+	if err := h.Harvest(ctx, implementJob(), payload, workflow.Outcome{
+		Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef",
+	}); err != nil {
+		t.Fatalf("Harvest merge returned error: %v", err)
+	}
+	// Soft cross-family review.
+	if err := h.Harvest(ctx, implementJob(), payload, reviewOutcome(map[string]float64{"coverage": 0.5}, "claude", false)); err != nil {
+		t.Fatalf("Harvest review returned error: %v", err)
+	}
+
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 2 {
+		t.Fatalf("expected the floor + review row (2), got %d: %+v", len(events), events)
+	}
+	var floor, review *db.FeedbackEvent
+	for i := range events {
+		switch events[i].Reviewer {
+		case autoTraceReviewer:
+			floor = &events[i]
+		case reviewReviewerPrefix + "claude":
+			review = &events[i]
+		}
+	}
+	if floor == nil {
+		t.Fatal("the verifiable-floor row (gitmoot-auto) must still exist")
+	}
+	if review == nil {
+		t.Fatalf("the review row (gitmoot-review:claude) must exist; got %+v", events)
+	}
+	if floor.ItemID == review.ItemID {
+		t.Fatalf("floor and review must use DISTINCT item ids; both = %q", floor.ItemID)
+	}
+	if review.ItemID != reviewItemIDPrefix+"owner/repo#7" {
+		t.Fatalf("review item id = %q, want review#owner/repo#7", review.ItemID)
+	}
+}
+
+// TestReviewRowJudgeTaggedAndDownWeighted: the review row carries the judge-derived
+// reviewer + item tag and the run keeps feedback_source=automatic_trace, and no
+// contract field/version changed.
+func TestReviewRowJudgeTaggedAndDownWeighted(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	if err := h.Harvest(ctx, implementJob(), payload, reviewOutcome(map[string]float64{"coverage": 0.7}, "claude", false)); err != nil {
+		t.Fatalf("Harvest review returned error: %v", err)
+	}
+
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 || events[0].Reviewer != reviewReviewerPrefix+"claude" {
+		t.Fatalf("expected one gitmoot-review:claude row, got %+v", events)
+	}
+	if events[0].Source != autoTraceSource {
+		t.Fatalf("review row source = %q, want auto-trace (rides the automatic_trace run)", events[0].Source)
+	}
+
+	// The review item carries judge_derived=true and is NOT self-family.
+	item, ok := reviewItemFor(t, store, version.ID, reviewItemIDPrefix+"owner/repo#7")
+	if !ok {
+		t.Fatal("review eval_review_item missing")
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(item.MetadataJSON), &meta); err != nil {
+		t.Fatalf("review item metadata did not unmarshal: %v", err)
+	}
+	if meta[reviewItemMetadataJudgeKey] != true {
+		t.Fatalf("review item must be judge_derived=true, got %v", meta[reviewItemMetadataJudgeKey])
+	}
+	if _, present := meta[reviewItemMetadataSelfFamilyKey]; present {
+		t.Fatal("a cross-family review must NOT carry the self_family tag")
+	}
+
+	// The run still stamps feedback_source=automatic_trace (no contract bump).
+	run, err := store.GetEvalRun(ctx, autoTraceRunIDPrefix+version.ID)
+	if err != nil {
+		t.Fatalf("GetEvalRun returned error: %v", err)
+	}
+	pkg, err := ExportTrainingPackage(ctx, store, run.ID)
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	if pkg.ContractVersion != ContractVersion || ContractVersion != 1 {
+		t.Fatalf("ContractVersion = %d (const %d), want 1 — additive, no bump", pkg.ContractVersion, ContractVersion)
+	}
+	var fc map[string]any
+	if err := json.Unmarshal(pkg.FeedbackContext, &fc); err != nil {
+		t.Fatalf("feedback context did not unmarshal: %v", err)
+	}
+	if fc["feedback_source"] != FeedbackSourceAutomaticTrace {
+		t.Fatalf("feedback_source = %v, want %q", fc["feedback_source"], FeedbackSourceAutomaticTrace)
+	}
+}
+
+// TestSelfFamilyReviewWeightsLower: a same-family fallback row uses the DISTINCT
+// gitmoot-review-self:<rt> reviewer and carries self_family=true so it weights
+// below a cross-family review (REFINEMENT #1). The cross-family and same-family
+// rows coexist (distinct reviewers) without overwriting each other.
+func TestSelfFamilyReviewWeightsLower(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	// A same-family (self) review.
+	if err := h.Harvest(ctx, implementJob(), payload, reviewOutcome(map[string]float64{"coverage": 0.4}, "codex", true)); err != nil {
+		t.Fatalf("Harvest self-family review returned error: %v", err)
+	}
+
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 {
+		t.Fatalf("expected one self-family review row, got %+v", events)
+	}
+	if events[0].Reviewer != reviewSelfReviewerPrefix+"codex" {
+		t.Fatalf("self-family reviewer = %q, want gitmoot-review-self:codex", events[0].Reviewer)
+	}
+
+	item, ok := reviewItemFor(t, store, version.ID, reviewItemIDPrefix+"owner/repo#7")
+	if !ok {
+		t.Fatal("self-family review item missing")
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(item.MetadataJSON), &meta); err != nil {
+		t.Fatalf("metadata unmarshal: %v", err)
+	}
+	if meta[reviewItemMetadataSelfFamilyKey] != true {
+		t.Fatalf("self-family review must carry self_family=true, got %v", meta[reviewItemMetadataSelfFamilyKey])
+	}
+	if meta[reviewItemMetadataJudgeKey] != true {
+		t.Fatal("self-family review must still be judge_derived=true")
+	}
+}
+
+// TestReviewRowReUpsertsInPlace: re-reviewing the SAME PR re-upserts the SAME
+// review row (stable row count) — a corrective overwrite, not a duplicate.
+func TestReviewRowReUpsertsInPlace(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	for i := 0; i < 3; i++ {
+		if err := h.Harvest(ctx, implementJob(), payload, reviewOutcome(map[string]float64{"coverage": 0.5}, "claude", false)); err != nil {
+			t.Fatalf("Harvest review iteration %d returned error: %v", i, err)
+		}
+	}
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 {
+		t.Fatalf("re-review must re-upsert in place (1 row), got %d: %+v", len(events), events)
+	}
+}
+
+// TestHarvestReviewOutOfScopeJobSkips: an OutcomeReviewed against a non-implement
+// (out-of-scope) job writes no review row (the harvester's inScope gate applies).
+func TestHarvestReviewOutOfScopeJobSkips(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	reviewJob := db.Job{ID: "job-review-1", Type: "review"}
+	if err := h.Harvest(ctx, reviewJob, payload, reviewOutcome(map[string]float64{"coverage": 0.5}, "claude", false)); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	if events := feedbackForVersion(t, store, version.ID); len(events) != 0 {
+		t.Fatalf("out-of-scope review must write nothing, got %+v", events)
+	}
+}

--- a/internal/skillopt/trace_harvest.go
+++ b/internal/skillopt/trace_harvest.go
@@ -126,6 +126,12 @@ func (h *OutcomeHarvester) Harvest(ctx context.Context, job db.Job, payload work
 		// Unresolvable template version: skip rather than guess (#465 risk note).
 		return nil
 	}
+	if outcome.Kind == workflow.OutcomeReviewed {
+		// SOFT cross-family review signal (#469): a SECOND, judge-tagged,
+		// down-weighted FeedbackEvent in the SAME auto-trace run under a distinct item
+		// id + reviewer, so it never overwrites the verifiable floor.
+		return h.writeReviewFeedback(ctx, version, outcome, projectReview(outcome))
+	}
 	signal, choice := h.project(ctx, payload, outcome)
 	return h.writeFeedback(ctx, version, payload, outcome, signal, choice)
 }

--- a/internal/workflow/cross_family_review.go
+++ b/internal/workflow/cross_family_review.go
@@ -1,0 +1,299 @@
+package workflow
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// ReviewLegDispatcher is the injected, best-effort, nil-by-default seam (#469)
+// the engine calls after a merge to run a CROSS-FAMILY review leg. It owns
+// reviewer selection (registered different-family agent, else an ephemeral
+// different-family leg, else — REFINEMENT #1 — a SAME-family fallback with a
+// warning), the read-only review-leg dispatch (reusing the runtime adapter +
+// EphemeralSpec, like the #421 verifier.md verify-leg), and the rubric parse. It
+// returns the OutcomeReviewed the engine then harvests into the auto-trace run.
+//
+// It NEVER blocks the merge path: the engine calls it best-effort off the
+// blocking path and swallows its error. ok=false means NO review-capable runtime
+// is authed at all (skip, no review row); ok=true returns the soft outcome
+// (cross-family OR same-family-with-warning, distinguished by Outcome.SelfFamily).
+type ReviewLegDispatcher interface {
+	Review(ctx context.Context, implementJob db.Job, implementPayload JobPayload, mergedHead string) (Outcome, bool, error)
+}
+
+// crossFamilyRotation is the fixed, deterministic family rotation used when no
+// registered different-family reviewer exists and the dispatcher materializes an
+// ephemeral different-family review leg (#469): codex→claude, claude→codex,
+// kimi→claude. Every target is provably a DIFFERENT family than the key, so the
+// ephemeral fallback is always cross-family.
+var crossFamilyRotation = map[string]string{
+	runtime.CodexRuntime:  runtime.ClaudeRuntime,
+	runtime.ClaudeRuntime: runtime.CodexRuntime,
+	runtime.KimiRuntime:   runtime.ClaudeRuntime,
+}
+
+// reviewCapability is the capability a registered agent must declare to be picked
+// as a cross-family reviewer.
+const reviewCapability = "review"
+
+// CrossFamilyReviewer is the resolved reviewer the dispatcher will run: either a
+// pre-registered agent (RegisteredAgent set) or an ephemeral worker spec
+// (Ephemeral set). Runtime is the resolved reviewer runtime family (always one of
+// codex/claude/kimi). SelfFamily is true ONLY when no different family was
+// available and selection fell back to a SAME-family reviewer (REFINEMENT #1) —
+// the engine/harvester tag that row distinctly so it weights below a cross-family
+// review.
+type CrossFamilyReviewer struct {
+	Runtime         string
+	RegisteredAgent string
+	Ephemeral       *EphemeralSpec
+	SelfFamily      bool
+}
+
+// AgentLister is the minimal read the cross-family selector needs over the store
+// (*db.Store satisfies it). It is its own narrow interface so PickCrossFamilyReviewer
+// is unit-testable with a stub and so the cli dispatcher can pass the real store.
+type AgentLister interface {
+	ListAgents(ctx context.Context) ([]db.Agent, error)
+}
+
+// PickCrossFamilyReviewer is the exported entry point the cli dispatcher calls;
+// see pickCrossFamilyReviewer for the full selection contract.
+func PickCrossFamilyReviewer(ctx context.Context, store AgentLister, implementerRuntime string, repo string, authedRuntimes map[string]bool) (CrossFamilyReviewer, bool, error) {
+	return pickCrossFamilyReviewer(ctx, store, implementerRuntime, repo, authedRuntimes)
+}
+
+// pickCrossFamilyReviewer selects the reviewer for an implement job whose runtime
+// family is implementerRuntime, scoped to repo (#469 + REFINEMENT #1).
+//
+// Preference order:
+//  1. A registered, review-capable agent of a DIFFERENT runtime family whose repo
+//     scope covers repo — picked deterministically by name (cross-family).
+//  2. An EPHEMERAL different-family review leg via the fixed crossFamilyRotation
+//     (codex→claude, claude→codex, kimi→claude), read-only, verifier.md-style —
+//     but ONLY when that target family is among the runtimes that are actually
+//     authed/available (authedRuntimes), so the leg can really run (cross-family).
+//  3. REFINEMENT #1: when NO different family is available at all, FALL BACK to a
+//     SAME-family reviewer WITH A WARNING — prefer a registered same-family
+//     review-capable agent, else an ephemeral same-family leg — and mark it
+//     SelfFamily so it weights BELOW a cross-family review. The caller emits the
+//     warning event/log; selection never silently returns same-family.
+//
+// ok=false is returned ONLY when NO review-capable runtime is authed at all (no
+// registered reviewer and no authed runtime to run an ephemeral leg) — the caller
+// then skips the review entirely (no review row). implementerRuntime that is not
+// a known family (e.g. an unrecoverable/migrated agent) yields ok=false too, so a
+// possibly-same-family review is never emitted by accident.
+func pickCrossFamilyReviewer(ctx context.Context, store AgentLister, implementerRuntime string, repo string, authedRuntimes map[string]bool) (CrossFamilyReviewer, bool, error) {
+	implementerRuntime = strings.TrimSpace(implementerRuntime)
+	if _, known := crossFamilyRotation[implementerRuntime]; !known {
+		// Unknown/unrecoverable implementer family: skip rather than guess and risk a
+		// silent same-family review (#469 risk note: SKIP-not-guess).
+		return CrossFamilyReviewer{}, false, nil
+	}
+
+	agents, err := listReviewAgents(ctx, store, repo)
+	if err != nil {
+		return CrossFamilyReviewer{}, false, err
+	}
+
+	// 1. A registered DIFFERENT-family review-capable agent (deterministic by name).
+	for _, agent := range agents {
+		if !strings.EqualFold(agent.Runtime, implementerRuntime) {
+			return CrossFamilyReviewer{
+				Runtime:         strings.TrimSpace(agent.Runtime),
+				RegisteredAgent: agent.Name,
+			}, true, nil
+		}
+	}
+
+	// 2. An ephemeral DIFFERENT-family leg, but only if that family is authed.
+	if target := crossFamilyRotation[implementerRuntime]; authedRuntimes[target] {
+		return CrossFamilyReviewer{
+			Runtime:   target,
+			Ephemeral: ephemeralReviewerSpec(target),
+		}, true, nil
+	}
+
+	// 3. REFINEMENT #1: same-family fallback WITH WARNING (caller emits it).
+	//    Prefer a registered same-family review-capable agent, else an ephemeral
+	//    same-family leg — but only if the implementer's own family is authed.
+	for _, agent := range agents {
+		if strings.EqualFold(agent.Runtime, implementerRuntime) {
+			return CrossFamilyReviewer{
+				Runtime:         strings.TrimSpace(agent.Runtime),
+				RegisteredAgent: agent.Name,
+				SelfFamily:      true,
+			}, true, nil
+		}
+	}
+	if authedRuntimes[implementerRuntime] {
+		return CrossFamilyReviewer{
+			Runtime:    implementerRuntime,
+			Ephemeral:  ephemeralReviewerSpec(implementerRuntime),
+			SelfFamily: true,
+		}, true, nil
+	}
+
+	// No review-capable runtime authed at all.
+	return CrossFamilyReviewer{}, false, nil
+}
+
+// listReviewAgents returns the registered review-capable agents whose repo scope
+// covers repo, sorted deterministically by name (ListAgents already orders by
+// name; this re-sorts defensively so the first-match selection is stable
+// regardless of the store's ordering).
+func listReviewAgents(ctx context.Context, store AgentLister, repo string) ([]db.Agent, error) {
+	if store == nil {
+		return nil, nil
+	}
+	all, err := store.ListAgents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	repo = strings.TrimSpace(repo)
+	var out []db.Agent
+	for _, agent := range all {
+		if !contains(agent.Capabilities, reviewCapability) {
+			continue
+		}
+		if !agentRepoScopeCovers(agent.RepoScope, repo) {
+			continue
+		}
+		out = append(out, agent)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// agentRepoScopeCovers reports whether a registered agent's repo scope covers repo.
+// An empty scope is treated as "all repos" (the registry convention used by
+// AgentCanAccessRepo for a global agent); otherwise the scope must equal the repo.
+func agentRepoScopeCovers(scope string, repo string) bool {
+	scope = strings.TrimSpace(scope)
+	repo = strings.TrimSpace(repo)
+	if scope == "" {
+		return true
+	}
+	return strings.EqualFold(scope, repo)
+}
+
+// ephemeralReviewerSpec builds the read-only ephemeral review-leg spec for the
+// given runtime, mirroring the verifier.md cross-model verify-leg (#421): a
+// reviewer role with ask+review capabilities and a read-only autonomy policy so
+// the leg can read the diff but never write.
+func ephemeralReviewerSpec(rt string) *EphemeralSpec {
+	return &EphemeralSpec{
+		Runtime:        rt,
+		Role:           "reviewer",
+		Capabilities:   []string{"ask", reviewCapability},
+		AutonomyPolicy: runtime.AutonomyPolicyReadOnly,
+	}
+}
+
+// ReviewLegPrompt assembles the read-only cross-family reviewer prompt from the
+// IMPLEMENT job's intended scope (Instructions + TaskTitle + resolved Goal.Title)
+// vs the delivered work (the PR diff + AgentResult.ChangesMade as a secondary
+// cross-check), per scope_fidelity_inputs (#469). The rubric instructions ask the
+// reviewer to score coverage/containment/fidelity (scope) + architecture/
+// readability/abstraction (subjective quality), each in [0,1], and return them in
+// its gitmoot_result. The exact rubric text is built ONLY here at review time and
+// is NEVER injected into the implementer's prompt (anti-gaming guardrail).
+//
+// goalTitle is the resolved Goal.Title (empty when the job carries no goal); diff
+// is the read-only PR diff text (empty when the diff read failed — the reviewer
+// then leans on ChangesMade only, a graceful degrade).
+func ReviewLegPrompt(payload JobPayload, goalTitle string, diff string) string {
+	var b strings.Builder
+	b.WriteString("You are a cross-family code reviewer scoring a MERGED pull request on subjective quality AND scope-fidelity. ")
+	b.WriteString("This is a SOFT, advisory signal — your score never blocks or reverts the merge.\n\n")
+
+	b.WriteString("## Intended scope (what was asked)\n")
+	if t := strings.TrimSpace(payload.TaskTitle); t != "" {
+		b.WriteString("Task: " + t + "\n")
+	}
+	if g := strings.TrimSpace(goalTitle); g != "" {
+		b.WriteString("Goal: " + g + "\n")
+	}
+	if instr := strings.TrimSpace(payload.Instructions); instr != "" {
+		b.WriteString("Instructions:\n" + instr + "\n")
+	}
+
+	b.WriteString("\n## Delivered work (what was done)\n")
+	if d := strings.TrimSpace(diff); d != "" {
+		b.WriteString("PR diff:\n" + d + "\n")
+	} else {
+		b.WriteString("(PR diff unavailable; rely on the self-reported changes below.)\n")
+	}
+	if payload.Result != nil && len(payload.Result.ChangesMade) > 0 {
+		b.WriteString("Self-reported changes (secondary cross-check):\n")
+		for _, change := range payload.Result.ChangesMade {
+			if c := strings.TrimSpace(change); c != "" {
+				b.WriteString("- " + c + "\n")
+			}
+		}
+	}
+
+	b.WriteString("\n## Rubric\n")
+	b.WriteString("Score EACH dimension in [0,1] (1 = excellent, 0 = poor):\n")
+	b.WriteString("- coverage: did the change do ALL of the ask?\n")
+	b.WriteString("- containment: no creep beyond the ask (no unrelated/over-broad changes)?\n")
+	b.WriteString("- fidelity: did it do THE ask, not something adjacent or different?\n")
+	b.WriteString("- architecture: does the design fit the codebase (no over-engineering)?\n")
+	b.WriteString("- readability: is the code clear and maintainable?\n")
+	b.WriteString("- abstraction: are abstractions appropriate (not duplicative, not premature)?\n\n")
+
+	b.WriteString("Return ONLY a gitmoot_result whose `metadata.rubric` is an object mapping each dimension above to its [0,1] score, ")
+	b.WriteString("with `summary`/`findings` carrying your reasoning. Do NOT modify any files (read-only).\n")
+	return b.String()
+}
+
+// ReviewRubricResult is the parsed reviewer rubric: the [0,1] dimension scores and
+// the free-text findings the dispatcher maps onto an Outcome{Kind:OutcomeReviewed}.
+type ReviewRubricResult struct {
+	Rubric   map[string]float64
+	Findings string
+}
+
+// reviewRubricDimensions is the fixed set of rubric dimensions the reviewer is
+// asked to score; the parser keeps only these keys (clamped to [0,1]) so a
+// reviewer that hallucinates extra keys cannot skew the mean.
+var reviewRubricDimensions = []string{
+	"coverage", "containment", "fidelity", "architecture", "readability", "abstraction",
+}
+
+// ParseReviewRubric extracts the rubric dimension scores + findings from a
+// reviewer's AgentResult (#469). The reviewer is asked to return the rubric under
+// metadata.rubric; this also tolerates a top-level rubric in the raw output. Only
+// the known dimensions are kept (each clamped to [0,1]); unknown keys are dropped.
+// An empty/absent rubric yields an empty map so the harvester writes HasScore=false
+// (no fabricated neutral 0.5) rather than a bogus score.
+func ParseReviewRubric(result AgentResult, rawRubric map[string]float64) ReviewRubricResult {
+	rubric := map[string]float64{}
+	for _, dim := range reviewRubricDimensions {
+		if v, ok := rawRubric[dim]; ok {
+			rubric[dim] = clampUnit01(v)
+		}
+	}
+	findings := strings.TrimSpace(result.Summary)
+	if findings == "" {
+		findings = "cross-family review"
+	}
+	return ReviewRubricResult{Rubric: rubric, Findings: findings}
+}
+
+// clampUnit01 clamps a rubric score to [0,1] so a reviewer that returns an
+// out-of-range value cannot push the projected mean outside the contract range.
+func clampUnit01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/internal/workflow/cross_family_review.go
+++ b/internal/workflow/cross_family_review.go
@@ -57,8 +57,16 @@ type CrossFamilyReviewer struct {
 // AgentLister is the minimal read the cross-family selector needs over the store
 // (*db.Store satisfies it). It is its own narrow interface so PickCrossFamilyReviewer
 // is unit-testable with a stub and so the cli dispatcher can pass the real store.
+//
+// AgentCanAccessRepo is the AUTHORITATIVE repo-access check (the agent_repos /
+// agent_instances join the rest of the engine uses at preflightDelegation /
+// availableAgentsForRepo), NOT the single agents.repo_scope string — so a reviewer
+// granted multi-repo access via agent_repos is correctly included and an
+// empty-scope agent is not silently treated as global. Its signature matches
+// *db.Store.AgentCanAccessRepo so the real store satisfies this interface directly.
 type AgentLister interface {
 	ListAgents(ctx context.Context) ([]db.Agent, error)
+	AgentCanAccessRepo(ctx context.Context, agentName string, repoFullName string) (bool, error)
 }
 
 // PickCrossFamilyReviewer is the exported entry point the cli dispatcher calls;
@@ -143,10 +151,18 @@ func pickCrossFamilyReviewer(ctx context.Context, store AgentLister, implementer
 	return CrossFamilyReviewer{}, false, nil
 }
 
-// listReviewAgents returns the registered review-capable agents whose repo scope
-// covers repo, sorted deterministically by name (ListAgents already orders by
-// name; this re-sorts defensively so the first-match selection is stable
-// regardless of the store's ordering).
+// listReviewAgents returns the registered review-capable agents that can access
+// repo, sorted deterministically by name (ListAgents already orders by name; this
+// re-sorts defensively so the first-match selection is stable regardless of the
+// store's ordering).
+//
+// Repo access is resolved through the AUTHORITATIVE AgentCanAccessRepo seam (the
+// agent_repos / agent_instances join the rest of the engine uses), NOT the single
+// agents.repo_scope string — so a reviewer granted access to repo via an
+// agent_repos row is correctly included even when its repo_scope column names a
+// different repo, and an empty-scope agent the convention would deny is not
+// silently treated as global. A per-agent access error fails soft (the agent is
+// dropped from the candidate set) rather than failing the whole selection.
 func listReviewAgents(ctx context.Context, store AgentLister, repo string) ([]db.Agent, error) {
 	if store == nil {
 		return nil, nil
@@ -161,25 +177,14 @@ func listReviewAgents(ctx context.Context, store AgentLister, repo string) ([]db
 		if !contains(agent.Capabilities, reviewCapability) {
 			continue
 		}
-		if !agentRepoScopeCovers(agent.RepoScope, repo) {
+		allowed, err := store.AgentCanAccessRepo(ctx, agent.Name, repo)
+		if err != nil || !allowed {
 			continue
 		}
 		out = append(out, agent)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
-}
-
-// agentRepoScopeCovers reports whether a registered agent's repo scope covers repo.
-// An empty scope is treated as "all repos" (the registry convention used by
-// AgentCanAccessRepo for a global agent); otherwise the scope must equal the repo.
-func agentRepoScopeCovers(scope string, repo string) bool {
-	scope = strings.TrimSpace(scope)
-	repo = strings.TrimSpace(repo)
-	if scope == "" {
-		return true
-	}
-	return strings.EqualFold(scope, repo)
 }
 
 // ephemeralReviewerSpec builds the read-only ephemeral review-leg spec for the

--- a/internal/workflow/cross_family_review_test.go
+++ b/internal/workflow/cross_family_review_test.go
@@ -4,34 +4,61 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
 // stubAgentLister is an in-memory AgentLister for the cross-family selector tests.
+// access maps an agent name to the set of repos it can access — modeling the
+// AUTHORITATIVE agent_repos / AgentCanAccessRepo convention (an explicit grant,
+// NOT the single repo_scope string). When access carries no entry for an agent the
+// agent has NO access (matching the real store: no rows => denied).
 type stubAgentLister struct {
 	agents []db.Agent
+	access map[string][]string
 }
 
 func (s stubAgentLister) ListAgents(context.Context) ([]db.Agent, error) {
 	return s.agents, nil
 }
 
+func (s stubAgentLister) AgentCanAccessRepo(_ context.Context, agentName string, repo string) (bool, error) {
+	for _, r := range s.access[agentName] {
+		if strings.EqualFold(strings.TrimSpace(r), strings.TrimSpace(repo)) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func reviewAgent(name, rt, repoScope string) db.Agent {
 	return db.Agent{Name: name, Runtime: rt, RepoScope: repoScope, Capabilities: []string{"review"}}
+}
+
+// reviewListerGrant builds a stubAgentLister granting EVERY listed agent access to
+// the given repo (the common cross-family case where the candidate reviewers are
+// authorized on the PR's repo via the authoritative grant).
+func reviewListerGrant(repo string, agents ...db.Agent) stubAgentLister {
+	access := map[string][]string{}
+	for _, a := range agents {
+		access[a.Name] = []string{repo}
+	}
+	return stubAgentLister{agents: agents, access: access}
 }
 
 // TestPickCrossFamilyReviewerPrefersDifferentFamilyRegistered: a registered
 // review-capable agent of a DIFFERENT runtime family wins, deterministically by
 // name, and is never tagged self-family.
 func TestPickCrossFamilyReviewerPrefersDifferentFamilyRegistered(t *testing.T) {
-	store := stubAgentLister{agents: []db.Agent{
+	store := reviewListerGrant("owner/repo",
 		// Same-family agent sorts first by name but must be skipped in favor of cross.
 		reviewAgent("aaa-codex-reviewer", runtime.CodexRuntime, "owner/repo"),
 		reviewAgent("zzz-claude-reviewer", runtime.ClaudeRuntime, "owner/repo"),
-	}}
+	)
 	reviewer, ok, err := PickCrossFamilyReviewer(context.Background(), store, runtime.CodexRuntime, "owner/repo", nil)
 	if err != nil {
 		t.Fatalf("PickCrossFamilyReviewer error: %v", err)
@@ -77,9 +104,9 @@ func TestPickCrossFamilyReviewerEphemeralFallback(t *testing.T) {
 // reviewer tagged SelfFamily (the caller emits the warning). It is never silent.
 func TestPickCrossFamilyReviewerSameFamilyFallbackWithWarning(t *testing.T) {
 	// (a) registered same-family agent path.
-	store := stubAgentLister{agents: []db.Agent{
+	store := reviewListerGrant("owner/repo",
 		reviewAgent("codex-reviewer", runtime.CodexRuntime, "owner/repo"),
-	}}
+	)
 	reviewer, ok, err := PickCrossFamilyReviewer(context.Background(), store, runtime.CodexRuntime, "owner/repo", nil)
 	if err != nil {
 		t.Fatalf("error: %v", err)
@@ -124,7 +151,7 @@ func TestPickCrossFamilyReviewerSkipsWhenNoRuntimeAuthed(t *testing.T) {
 // TestPickCrossFamilyReviewerUnknownImplementerSkips: an unrecoverable implementer
 // family yields SKIP rather than risk a silent same-family review.
 func TestPickCrossFamilyReviewerUnknownImplementerSkips(t *testing.T) {
-	store := stubAgentLister{agents: []db.Agent{reviewAgent("claude-reviewer", runtime.ClaudeRuntime, "owner/repo")}}
+	store := reviewListerGrant("owner/repo", reviewAgent("claude-reviewer", runtime.ClaudeRuntime, "owner/repo"))
 	_, ok, err := PickCrossFamilyReviewer(context.Background(), store, "mystery-runtime", "owner/repo", map[string]bool{runtime.ClaudeRuntime: true})
 	if err != nil {
 		t.Fatalf("error: %v", err)
@@ -134,19 +161,28 @@ func TestPickCrossFamilyReviewerUnknownImplementerSkips(t *testing.T) {
 	}
 }
 
-// TestPickCrossFamilyReviewerRepoScope: a registered reviewer whose scope does not
-// cover the repo is excluded; a global (empty-scope) reviewer is included.
-func TestPickCrossFamilyReviewerRepoScope(t *testing.T) {
-	store := stubAgentLister{agents: []db.Agent{
-		reviewAgent("scoped-elsewhere", runtime.ClaudeRuntime, "other/repo"),
-		reviewAgent("global", runtime.ClaudeRuntime, ""),
-	}}
+// TestPickCrossFamilyReviewerRepoAccess: repo access is resolved through the
+// AUTHORITATIVE AgentCanAccessRepo grant, NOT the single repo_scope string. A
+// reviewer GRANTED access to the PR's repo is included even when its repo_scope
+// column names a DIFFERENT repo (the multi-repo case), and a reviewer with NO
+// grant is excluded even when its repo_scope string matches.
+func TestPickCrossFamilyReviewerRepoAccess(t *testing.T) {
+	store := stubAgentLister{
+		agents: []db.Agent{
+			// repo_scope says "other/repo" but the agent is GRANTED owner/repo via the
+			// authoritative agent_repos seam — it must be included.
+			reviewAgent("multi-repo-claude", runtime.ClaudeRuntime, "other/repo"),
+			// repo_scope matches owner/repo but there is NO grant — it must be excluded.
+			reviewAgent("ungranted-claude", runtime.ClaudeRuntime, "owner/repo"),
+		},
+		access: map[string][]string{"multi-repo-claude": {"owner/repo"}},
+	}
 	reviewer, ok, err := PickCrossFamilyReviewer(context.Background(), store, runtime.CodexRuntime, "owner/repo", nil)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
-	if !ok || reviewer.RegisteredAgent != "global" {
-		t.Fatalf("picked %+v, want the global (empty-scope) reviewer", reviewer)
+	if !ok || reviewer.RegisteredAgent != "multi-repo-claude" {
+		t.Fatalf("picked %+v, want the granted multi-repo reviewer (authoritative access, not repo_scope)", reviewer)
 	}
 }
 
@@ -371,6 +407,84 @@ func TestEngineReviewDispatchSkipWritesNothing(t *testing.T) {
 	for _, o := range harvester.snapshot() {
 		if o.Kind == OutcomeReviewed {
 			t.Fatal("a SKIP must not harvest a reviewed outcome")
+		}
+	}
+}
+
+// blockingReviewDispatcher blocks inside Review until released, modeling a wedged
+// live reviewer adapter.Deliver. started fires once Review is entered.
+type blockingReviewDispatcher struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingReviewDispatcher) Review(_ context.Context, _ db.Job, _ JobPayload, _ string) (Outcome, bool, error) {
+	b.once.Do(func() { close(b.started) })
+	<-b.release
+	return Outcome{Kind: OutcomeReviewed, Repo: "jerryfane/gitmoot", PullRequest: 7, Reviewer: "claude"}, true, nil
+}
+
+// TestEngineReviewLegDoesNotBlockAdvanceJob is the review-fix regression: even when
+// the reviewer adapter blocks indefinitely, AdvanceJob returns PROMPTLY (the merge
+// completes) because the review leg is DETACHED into its own goroutine — it never
+// stalls AdvanceJob, the worker tick, or the daemon's checkoutLock. The detached
+// review still runs once unblocked.
+func TestEngineReviewLegDoesNotBlockAdvanceJob(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	// Build an engine with the PRODUCTION default async spawn (no synchronous
+	// spawnReview override), so the detached goroutine is exercised for real.
+	engine := Engine{
+		Store: store,
+		JobID: func(request JobRequest) string { return strings.Join([]string{request.Action, request.Agent, request.TaskID}, "-") },
+	}
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	dispatcher := &blockingReviewDispatcher{started: make(chan struct{}), release: make(chan struct{})}
+	engine.ReviewLegDispatcher = dispatcher
+	seedMergeReviewJobs(t, store)
+
+	done := make(chan error, 1)
+	go func() { done <- engine.AdvanceJob(ctx, "review-job") }()
+
+	// AdvanceJob must return promptly despite the wedged reviewer.
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("AdvanceJob returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("AdvanceJob did not return while the reviewer was blocked — the review leg is NOT detached")
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+
+	// The detached review goroutine did enter Review (proving it was dispatched).
+	select {
+	case <-dispatcher.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the detached review leg never started")
+	}
+
+	// Release the reviewer and confirm the detached leg eventually harvests.
+	close(dispatcher.release)
+	deadline := time.After(5 * time.Second)
+	for {
+		reviewed := false
+		for _, o := range harvester.snapshot() {
+			if o.Kind == OutcomeReviewed {
+				reviewed = true
+			}
+		}
+		if reviewed {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("the detached review never harvested its OutcomeReviewed after release")
+		case <-time.After(10 * time.Millisecond):
 		}
 	}
 }

--- a/internal/workflow/cross_family_review_test.go
+++ b/internal/workflow/cross_family_review_test.go
@@ -1,0 +1,376 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// stubAgentLister is an in-memory AgentLister for the cross-family selector tests.
+type stubAgentLister struct {
+	agents []db.Agent
+}
+
+func (s stubAgentLister) ListAgents(context.Context) ([]db.Agent, error) {
+	return s.agents, nil
+}
+
+func reviewAgent(name, rt, repoScope string) db.Agent {
+	return db.Agent{Name: name, Runtime: rt, RepoScope: repoScope, Capabilities: []string{"review"}}
+}
+
+// TestPickCrossFamilyReviewerPrefersDifferentFamilyRegistered: a registered
+// review-capable agent of a DIFFERENT runtime family wins, deterministically by
+// name, and is never tagged self-family.
+func TestPickCrossFamilyReviewerPrefersDifferentFamilyRegistered(t *testing.T) {
+	store := stubAgentLister{agents: []db.Agent{
+		// Same-family agent sorts first by name but must be skipped in favor of cross.
+		reviewAgent("aaa-codex-reviewer", runtime.CodexRuntime, "owner/repo"),
+		reviewAgent("zzz-claude-reviewer", runtime.ClaudeRuntime, "owner/repo"),
+	}}
+	reviewer, ok, err := PickCrossFamilyReviewer(context.Background(), store, runtime.CodexRuntime, "owner/repo", nil)
+	if err != nil {
+		t.Fatalf("PickCrossFamilyReviewer error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected a reviewer, got none")
+	}
+	if reviewer.SelfFamily {
+		t.Fatal("a different-family reviewer must not be tagged self-family")
+	}
+	if reviewer.Runtime != runtime.ClaudeRuntime || reviewer.RegisteredAgent != "zzz-claude-reviewer" {
+		t.Fatalf("picked %+v, want the claude registered reviewer", reviewer)
+	}
+}
+
+// TestPickCrossFamilyReviewerEphemeralFallback: with no registered different-family
+// agent but the rotation target authed, an ephemeral DIFFERENT-family read-only
+// leg is materialized (codex -> claude).
+func TestPickCrossFamilyReviewerEphemeralFallback(t *testing.T) {
+	store := stubAgentLister{}
+	authed := map[string]bool{runtime.ClaudeRuntime: true}
+	reviewer, ok, err := PickCrossFamilyReviewer(context.Background(), store, runtime.CodexRuntime, "owner/repo", authed)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !ok || reviewer.SelfFamily {
+		t.Fatalf("expected a cross-family ephemeral reviewer, got ok=%v self=%v", ok, reviewer.SelfFamily)
+	}
+	if reviewer.Runtime != runtime.ClaudeRuntime || reviewer.Ephemeral == nil {
+		t.Fatalf("picked %+v, want an ephemeral claude reviewer", reviewer)
+	}
+	if reviewer.Ephemeral.AutonomyPolicy != runtime.AutonomyPolicyReadOnly {
+		t.Fatalf("ephemeral reviewer must be read-only, got %q", reviewer.Ephemeral.AutonomyPolicy)
+	}
+	if !contains(reviewer.Ephemeral.Capabilities, "review") {
+		t.Fatalf("ephemeral reviewer must declare review capability, got %v", reviewer.Ephemeral.Capabilities)
+	}
+}
+
+// TestPickCrossFamilyReviewerSameFamilyFallbackWithWarning (REFINEMENT #1): when
+// NO different family is available (no different-family agent, rotation target NOT
+// authed) but the implementer's own family IS authed, fall back to a SAME-family
+// reviewer tagged SelfFamily (the caller emits the warning). It is never silent.
+func TestPickCrossFamilyReviewerSameFamilyFallbackWithWarning(t *testing.T) {
+	// (a) registered same-family agent path.
+	store := stubAgentLister{agents: []db.Agent{
+		reviewAgent("codex-reviewer", runtime.CodexRuntime, "owner/repo"),
+	}}
+	reviewer, ok, err := PickCrossFamilyReviewer(context.Background(), store, runtime.CodexRuntime, "owner/repo", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected a same-family fallback reviewer, got none")
+	}
+	if !reviewer.SelfFamily {
+		t.Fatal("same-family fallback MUST be tagged self-family so it weights below cross-family")
+	}
+	if reviewer.Runtime != runtime.CodexRuntime || reviewer.RegisteredAgent != "codex-reviewer" {
+		t.Fatalf("picked %+v, want the same-family registered reviewer", reviewer)
+	}
+
+	// (b) ephemeral same-family path: no registered agent, only the implementer's
+	// own family authed (rotation target NOT authed).
+	reviewer2, ok2, err2 := PickCrossFamilyReviewer(context.Background(), stubAgentLister{}, runtime.CodexRuntime, "owner/repo", map[string]bool{runtime.CodexRuntime: true})
+	if err2 != nil {
+		t.Fatalf("error: %v", err2)
+	}
+	if !ok2 || !reviewer2.SelfFamily {
+		t.Fatalf("expected an ephemeral same-family fallback, got ok=%v self=%v", ok2, reviewer2.SelfFamily)
+	}
+	if reviewer2.Runtime != runtime.CodexRuntime || reviewer2.Ephemeral == nil {
+		t.Fatalf("picked %+v, want an ephemeral same-family codex reviewer", reviewer2)
+	}
+}
+
+// TestPickCrossFamilyReviewerSkipsWhenNoRuntimeAuthed: ok=false ONLY when no
+// review-capable runtime is authed at all (no registered reviewer + nothing
+// authed) — the caller then writes no review row.
+func TestPickCrossFamilyReviewerSkipsWhenNoRuntimeAuthed(t *testing.T) {
+	_, ok, err := PickCrossFamilyReviewer(context.Background(), stubAgentLister{}, runtime.CodexRuntime, "owner/repo", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected SKIP (ok=false) when no review-capable runtime is authed")
+	}
+}
+
+// TestPickCrossFamilyReviewerUnknownImplementerSkips: an unrecoverable implementer
+// family yields SKIP rather than risk a silent same-family review.
+func TestPickCrossFamilyReviewerUnknownImplementerSkips(t *testing.T) {
+	store := stubAgentLister{agents: []db.Agent{reviewAgent("claude-reviewer", runtime.ClaudeRuntime, "owner/repo")}}
+	_, ok, err := PickCrossFamilyReviewer(context.Background(), store, "mystery-runtime", "owner/repo", map[string]bool{runtime.ClaudeRuntime: true})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if ok {
+		t.Fatal("an unknown implementer family must SKIP, never guess a reviewer")
+	}
+}
+
+// TestPickCrossFamilyReviewerRepoScope: a registered reviewer whose scope does not
+// cover the repo is excluded; a global (empty-scope) reviewer is included.
+func TestPickCrossFamilyReviewerRepoScope(t *testing.T) {
+	store := stubAgentLister{agents: []db.Agent{
+		reviewAgent("scoped-elsewhere", runtime.ClaudeRuntime, "other/repo"),
+		reviewAgent("global", runtime.ClaudeRuntime, ""),
+	}}
+	reviewer, ok, err := PickCrossFamilyReviewer(context.Background(), store, runtime.CodexRuntime, "owner/repo", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !ok || reviewer.RegisteredAgent != "global" {
+		t.Fatalf("picked %+v, want the global (empty-scope) reviewer", reviewer)
+	}
+}
+
+// TestReviewLegPromptAssembly: the prompt is built from Instructions + TaskTitle +
+// resolved Goal.Title vs the diff + ChangesMade, asks for the rubric dimensions,
+// and never leaks back into the implementer payload (it is a fresh string).
+func TestReviewLegPromptAssembly(t *testing.T) {
+	payload := JobPayload{
+		TaskTitle:    "Add cross-family review",
+		Instructions: "Implement the soft review signal",
+		Result:       &AgentResult{ChangesMade: []string{"added cross_family_review.go"}},
+	}
+	prompt := ReviewLegPrompt(payload, "Mode A review agent", "diff --git a/x b/x")
+	for _, want := range []string{
+		"Add cross-family review", "Implement the soft review signal", "Mode A review agent",
+		"diff --git a/x b/x", "added cross_family_review.go",
+		"coverage", "containment", "fidelity", "architecture", "readability", "abstraction",
+		"metadata.rubric",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	// Anti-gaming: assembling the prompt must not mutate the implementer payload.
+	if payload.Instructions != "Implement the soft review signal" {
+		t.Fatal("ReviewLegPrompt must not mutate the implementer payload")
+	}
+}
+
+// TestReviewLegPromptDegradesWithoutDiff: when the diff read failed (empty diff)
+// the prompt still assembles, telling the reviewer to lean on ChangesMade.
+func TestReviewLegPromptDegradesWithoutDiff(t *testing.T) {
+	payload := JobPayload{TaskTitle: "T", Result: &AgentResult{ChangesMade: []string{"c1"}}}
+	prompt := ReviewLegPrompt(payload, "", "")
+	if !strings.Contains(prompt, "PR diff unavailable") {
+		t.Fatalf("expected the degrade marker, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "c1") {
+		t.Fatal("degrade path must still surface ChangesMade")
+	}
+}
+
+// TestParseReviewRubricKeepsKnownDimensionsClamped: only the known dimensions are
+// kept, each clamped to [0,1]; unknown keys are dropped.
+func TestParseReviewRubricKeepsKnownDimensionsClamped(t *testing.T) {
+	raw := map[string]float64{
+		"coverage": 0.8, "fidelity": 1.5, "containment": -0.2, "hallucinated": 0.9,
+	}
+	out := ParseReviewRubric(AgentResult{Summary: "scope drift"}, raw)
+	if out.Findings != "scope drift" {
+		t.Fatalf("findings = %q, want the summary", out.Findings)
+	}
+	if got := out.Rubric["coverage"]; got != 0.8 {
+		t.Fatalf("coverage = %v, want 0.8", got)
+	}
+	if got := out.Rubric["fidelity"]; got != 1.0 {
+		t.Fatalf("fidelity = %v, want clamped 1.0", got)
+	}
+	if got := out.Rubric["containment"]; got != 0.0 {
+		t.Fatalf("containment = %v, want clamped 0.0", got)
+	}
+	if _, present := out.Rubric["hallucinated"]; present {
+		t.Fatal("unknown rubric keys must be dropped")
+	}
+}
+
+// TestParseReviewRubricEmpty: an empty rubric yields an empty map (no fabricated
+// scores) and a default findings string.
+func TestParseReviewRubricEmpty(t *testing.T) {
+	out := ParseReviewRubric(AgentResult{}, nil)
+	if len(out.Rubric) != 0 {
+		t.Fatalf("empty rubric must yield no dimensions, got %v", out.Rubric)
+	}
+	if strings.TrimSpace(out.Findings) == "" {
+		t.Fatal("findings should default to a non-empty marker")
+	}
+}
+
+// recordingReviewDispatcher is a stub ReviewLegDispatcher that records the call
+// and returns a canned OutcomeReviewed (or err/skip), so the engine trigger can be
+// tested without a live runtime.
+type recordingReviewDispatcher struct {
+	called  int
+	jobIDs  []string
+	heads   []string
+	outcome Outcome
+	ok      bool
+	err     error
+}
+
+func (r *recordingReviewDispatcher) Review(_ context.Context, job db.Job, _ JobPayload, mergedHead string) (Outcome, bool, error) {
+	r.called++
+	r.jobIDs = append(r.jobIDs, job.ID)
+	r.heads = append(r.heads, mergedHead)
+	return r.outcome, r.ok, r.err
+}
+
+func seedMergeReviewJobs(t *testing.T, store *db.Store) {
+	t.Helper()
+	seedImplementJobForHarvest(t, store)
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-7", PullRequest: 7, HeadSHA: "head123",
+		TaskID: "task-7", TaskTitle: "Workflow Engine", LeadAgent: "lead",
+		Result: &AgentResult{Decision: "approved", Summary: "looks good"},
+	})
+}
+
+// TestEngineDispatchesReviewLegOnMerge proves the cross-family review leg fires on
+// a merge, attributed to the implement job, and its OutcomeReviewed is harvested.
+func TestEngineDispatchesReviewLegOnMerge(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	dispatcher := &recordingReviewDispatcher{
+		ok: true,
+		outcome: Outcome{
+			Kind: OutcomeReviewed, Repo: "jerryfane/gitmoot", PullRequest: 7,
+			Reviewer: "claude", Rubric: map[string]float64{"coverage": 0.8},
+		},
+	}
+	engine.ReviewLegDispatcher = dispatcher
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if dispatcher.called != 1 {
+		t.Fatalf("review dispatcher called %d times, want 1", dispatcher.called)
+	}
+	if dispatcher.jobIDs[0] != "implement-job" {
+		t.Fatalf("review leg attributed to %q, want implement-job", dispatcher.jobIDs[0])
+	}
+	if dispatcher.heads[0] != "head123" {
+		t.Fatalf("review leg head sha = %q, want the PR head head123", dispatcher.heads[0])
+	}
+	// Both the merge floor AND the reviewed outcome are harvested.
+	kinds := map[OutcomeKind]bool{}
+	for _, o := range harvester.snapshot() {
+		kinds[o.Kind] = true
+	}
+	if !kinds[OutcomeMerged] || !kinds[OutcomeReviewed] {
+		t.Fatalf("harvested kinds = %v, want both merged and reviewed", kinds)
+	}
+}
+
+// TestEngineNilReviewDispatcherIsByteIdentical proves off-by-default: with no
+// ReviewLegDispatcher the merge advances exactly as before and no review leg runs.
+func TestEngineNilReviewDispatcherIsByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine.OutcomeHarvester = &recordingHarvester{}
+	// No ReviewLegDispatcher.
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob with nil review dispatcher returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+	for _, o := range engine.OutcomeHarvester.(*recordingHarvester).snapshot() {
+		if o.Kind == OutcomeReviewed {
+			t.Fatal("nil review dispatcher must not produce a reviewed outcome")
+		}
+	}
+}
+
+// TestEngineReviewDispatchErrorNeverFailsMerge proves a review-leg failure is
+// best-effort: the merge still completes and a cross_family_review_failed event is
+// recorded on the implement job (the review never blocks/fails the job).
+func TestEngineReviewDispatchErrorNeverFailsMerge(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine.OutcomeHarvester = &recordingHarvester{}
+	engine.ReviewLegDispatcher = &recordingReviewDispatcher{err: errors.New("review boom")}
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob must not fail on a review error, got: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+
+	events, err := store.ListJobEvents(ctx, "implement-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	found := false
+	for _, ev := range events {
+		if ev.Kind == "cross_family_review_failed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a cross_family_review_failed job event, got %+v", events)
+	}
+}
+
+// TestEngineReviewDispatchSkipWritesNothing proves a SKIP (ok=false, no
+// review-capable runtime authed) writes no review row and never errors.
+func TestEngineReviewDispatchSkipWritesNothing(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	engine.ReviewLegDispatcher = &recordingReviewDispatcher{ok: false}
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	for _, o := range harvester.snapshot() {
+		if o.Kind == OutcomeReviewed {
+			t.Fatal("a SKIP must not harvest a reviewed outcome")
+		}
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -58,6 +58,18 @@ type Engine struct {
 	// promotes. The concrete impl lives in internal/skillopt and is wired only in
 	// cli (daemonWorkflowEngine), keeping the engine free of skillopt coupling.
 	OutcomeHarvester OutcomeHarvester
+	// ReviewLegDispatcher is the injected, best-effort, nil-by-default seam (#469)
+	// the engine calls AFTER a merge harvest to run a CROSS-FAMILY review leg whose
+	// rubric is projected into the SAME auto-trace run as a SOFT, down-weighted,
+	// judge-tagged secondary signal. It mirrors OutcomeHarvester: optional and
+	// nil-safe (when nil — the default, no [skillopt].cross_family_review_enabled —
+	// NO review leg runs and NO review row is written, so behavior is
+	// byte-identical), and best-effort (a dispatch error is swallowed and recorded
+	// as a cross_family_review_failed job event, never returned up, so it can never
+	// block or fail a job). It runs OFF the blocking merge path. The concrete impl
+	// is wired only in cli (gated by cross_family_review_enabled AND
+	// auto_trace_enabled), keeping the engine free of runtime/skillopt coupling.
+	ReviewLegDispatcher ReviewLegDispatcher
 	// Home is the resolved GITMOOT_HOME root used to place per-delegation
 	// worktrees. DelegationWorktrees is the checkout-bound git client that
 	// performs the worktree-add. Both are optional: when either is unset, the
@@ -400,6 +412,16 @@ const (
 	// harvested merge, re-firing harvestOutcomeForMergeGate for the reverted PR) is
 	// a follow-on; see CORRECTIVE-ON-REVERT in docs/skillopt-exchange-contract.md.
 	OutcomeReverted OutcomeKind = "reverted"
+	// OutcomeReviewed is the SOFT, down-weighted, judge-tagged secondary signal a
+	// cross-family review leg produces (#469). Unlike the verifiable kinds above it
+	// is NOT derived from a gate transition: it is the rubric a different-runtime
+	// reviewer scored on subjective quality + scope-fidelity, projected into a
+	// SECOND FeedbackEvent in the SAME auto-trace run under a distinct item id and a
+	// gitmoot-review[-self]:<rt> reviewer so it never overwrites the verifiable
+	// floor. It is best-effort and off-by-default: only constructed when
+	// [skillopt].cross_family_review_enabled (which also requires auto_trace_enabled)
+	// is on, and a review-leg failure NEVER blocks or fails a job.
+	OutcomeReviewed OutcomeKind = "reviewed"
 )
 
 // Outcome carries the verifiable signal the engine derives at an outcome seam and
@@ -428,6 +450,31 @@ type Outcome struct {
 	// FixRounds is the review-round number at a changes_requested decision (round 1
 	// is the first), used to grade the negative: more rounds => worse score.
 	FixRounds int
+
+	// The fields below are populated ONLY for Kind == OutcomeReviewed (the
+	// cross-family review-agent soft signal, #469); they are zero for every
+	// verifiable kind so an OutcomeMerged/Blocked/ChangesRequested/Reverted is
+	// byte-identical to before.
+
+	// Reviewer is the reviewer runtime family that produced the rubric (codex /
+	// claude / kimi). The harvester tags the review FeedbackEvent's reviewer as
+	// gitmoot-review:<Reviewer> (or gitmoot-review-self:<Reviewer> when SelfFamily)
+	// so the soft row never collides with the verifiable-floor reviewer.
+	Reviewer string
+	// SelfFamily is true when no DIFFERENT-family reviewer was available and the
+	// review fell back to a SAME-family reviewer (REFINEMENT #1). A self-family row
+	// is tagged distinctly and weights BELOW a cross-family review because
+	// self-preference bias applies. It is always false for a true cross-family
+	// review.
+	SelfFamily bool
+	// Rubric is the reviewer's subjective-quality + scope-fidelity rubric, each
+	// dimension in [0,1] (coverage/containment/fidelity + architecture/readability/
+	// abstraction). The harvester maps it to EvaluatorScore.DimensionScores and lets
+	// ProjectSignal take the mean (#462 path), so no new aggregation is invented.
+	Rubric map[string]float64
+	// Findings is the reviewer's free-text reasoning, surfaced verbatim in the soft
+	// FeedbackEvent's reasoning.
+	Findings string
 }
 
 // OutcomeHarvester is the injected, best-effort, nil-by-default seam (#465, Mode
@@ -4300,9 +4347,48 @@ func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPa
 			PullRequest: payload.PullRequest,
 			HeadSHA:     mergedHead,
 		})
+		// Soft cross-family review signal (#469), OFF the blocking merge path and
+		// strictly best-effort: a nil dispatcher (the default, no
+		// cross_family_review_enabled) is a no-op, and any review-leg failure is
+		// swallowed so it can never block or fail the (already-completed) merge.
+		e.reviewCrossFamilyForMergeGate(ctx, payload, mergedHead)
 		return decision, nil
 	}
 	return decision, e.setTaskState(ctx, ref, TaskReadyToMerge)
+}
+
+// reviewCrossFamilyForMergeGate runs the cross-family review leg for a just-merged
+// PR and harvests its OutcomeReviewed rubric into the SAME auto-trace run as a
+// SOFT, down-weighted, judge-tagged secondary signal (#469). It is nil-safe (no
+// dispatcher => no-op, byte-identical) and best-effort: the review leg runs OFF
+// the blocking merge path and a dispatch error is swallowed + recorded as a
+// cross_family_review_failed job event, NEVER returned up, so a review failure can
+// never block or fail a job. The outcome is attributed to the IMPLEMENT job that
+// produced the diff (the same implementJobForTask attribution the merge-gate
+// harvest uses), so the soft review row lands on the implementer's template
+// version next to the verifiable floor.
+func (e Engine) reviewCrossFamilyForMergeGate(ctx context.Context, reviewPayload JobPayload, mergedHead string) {
+	if e.ReviewLegDispatcher == nil || e.OutcomeHarvester == nil {
+		return
+	}
+	job, payload, ok := e.implementJobForTask(ctx, reviewPayload)
+	if !ok {
+		return
+	}
+	outcome, ok, err := e.ReviewLegDispatcher.Review(ctx, job, payload, mergedHead)
+	if err != nil {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "cross_family_review_failed",
+			Message: err.Error(),
+		})
+		return
+	}
+	if !ok {
+		// No review-capable runtime authed at all: skip silently (no review row).
+		return
+	}
+	e.harvestOutcome(ctx, job, payload, outcome)
 }
 
 // harvestOutcomeForMergeGate resolves the implement job that owns this PR/task and

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -171,6 +171,21 @@ type Engine struct {
 	// existing set is byte-identical. It is sourced from the host
 	// [orchestrate].max_verify_replan_attempts config at daemon startup.
 	MaxVerifyReplanAttempts int
+	// ReviewLegTimeout bounds the DETACHED cross-family review leg (#469): the
+	// review runs a live LLM adapter.Deliver that can take minutes, so it must
+	// never run unbounded. The detached goroutine's context is wrapped in this
+	// timeout so a wedged reviewer process is reaped rather than leaking forever.
+	// <= 0 means defaultReviewLegTimeout. It only matters when a ReviewLegDispatcher
+	// is wired (off by default).
+	ReviewLegTimeout time.Duration
+	// ReviewSpawner runs the detached cross-family review leg OFF the AdvanceJob /
+	// daemon-poll path so a live, possibly-wedged reviewer adapter.Deliver can never
+	// block AdvanceJob, the worker tick, or the daemon's checkoutLock. The default
+	// (nil) spawns a goroutine; tests inject a synchronous runner so the review is
+	// deterministic. It mirrors the EventSink fire-and-forget seam: the engine hands
+	// off a self-contained closure that owns its own bounded, cancellation-detached
+	// context.
+	ReviewSpawner func(func())
 }
 
 // defaultMaxDelegationNonProgressStreak is the streak threshold used when the
@@ -183,6 +198,12 @@ const defaultMaxDelegationNonProgressStreak = 2
 // bounded corrective replan continuations on a failed verify verdict before
 // routing to the #305 graceful finalize continuation (#439).
 const defaultMaxVerifyReplanAttempts = 2
+
+// defaultReviewLegTimeout bounds the detached cross-family review leg (#469) when
+// the engine's ReviewLegTimeout is unset (<= 0). It is a generous ceiling — a live
+// cross-family LLM review can legitimately take a few minutes — whose only job is
+// to reap a wedged reviewer so the detached goroutine cannot leak forever.
+const defaultReviewLegTimeout = 10 * time.Minute
 
 // nonProgressStreakThreshold returns the configured result-aware non-progress
 // streak threshold, falling back to defaultMaxDelegationNonProgressStreak when
@@ -457,9 +478,11 @@ type Outcome struct {
 	// byte-identical to before.
 
 	// Reviewer is the reviewer runtime family that produced the rubric (codex /
-	// claude / kimi). The harvester tags the review FeedbackEvent's reviewer as
-	// gitmoot-review:<Reviewer> (or gitmoot-review-self:<Reviewer> when SelfFamily)
-	// so the soft row never collides with the verifiable-floor reviewer.
+	// claude / kimi). The harvester writes the review FeedbackEvent under a FIXED
+	// gitmoot-review reviewer sentinel (distinct from the verifiable-floor reviewer)
+	// and carries this family — plus the SelfFamily flag — in the review item
+	// metadata, so a re-review by a different family overwrites the row in place
+	// rather than accumulating a stale duplicate.
 	Reviewer string
 	// SelfFamily is true when no DIFFERENT-family reviewer was available and the
 	// review fell back to a SAME-family reviewer (REFINEMENT #1). A self-family row
@@ -4347,10 +4370,13 @@ func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPa
 			PullRequest: payload.PullRequest,
 			HeadSHA:     mergedHead,
 		})
-		// Soft cross-family review signal (#469), OFF the blocking merge path and
-		// strictly best-effort: a nil dispatcher (the default, no
-		// cross_family_review_enabled) is a no-op, and any review-leg failure is
-		// swallowed so it can never block or fail the (already-completed) merge.
+		// Soft cross-family review signal (#469), DETACHED from the blocking
+		// AdvanceJob / daemon-poll path and strictly best-effort: a nil dispatcher
+		// (the default, no cross_family_review_enabled) is a no-op, the live reviewer
+		// adapter.Deliver runs in its own bounded, cancellation-detached goroutine so
+		// it can never stall AdvanceJob / the worker tick / the daemon's checkoutLock,
+		// and any review-leg failure is swallowed so it can never block or fail the
+		// (already-completed) merge.
 		e.reviewCrossFamilyForMergeGate(ctx, payload, mergedHead)
 		return decision, nil
 	}
@@ -4360,21 +4386,43 @@ func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPa
 // reviewCrossFamilyForMergeGate runs the cross-family review leg for a just-merged
 // PR and harvests its OutcomeReviewed rubric into the SAME auto-trace run as a
 // SOFT, down-weighted, judge-tagged secondary signal (#469). It is nil-safe (no
-// dispatcher => no-op, byte-identical) and best-effort: the review leg runs OFF
-// the blocking merge path and a dispatch error is swallowed + recorded as a
-// cross_family_review_failed job event, NEVER returned up, so a review failure can
-// never block or fail a job. The outcome is attributed to the IMPLEMENT job that
-// produced the diff (the same implementJobForTask attribution the merge-gate
-// harvest uses), so the soft review row lands on the implementer's template
-// version next to the verifiable floor.
+// dispatcher => no-op, byte-identical) and best-effort.
+//
+// CRITICAL (review-fix): the review runs a LIVE reviewer adapter.Deliver that can
+// take minutes, so it is DETACHED from the caller's path — it runs in its own
+// goroutine (via spawnReview) under a fresh, cancellation-decoupled context bounded
+// by ReviewLegTimeout. This guarantees a wedged reviewer process can NEVER stall
+// AdvanceJob, the daemon worker tick, or the daemon's checkoutLock (which the
+// AdvanceJob path holds), and is reaped by the timeout rather than leaking forever.
+// A dispatch error is swallowed + recorded as a cross_family_review_failed job
+// event, NEVER returned up, so a review failure can never block or fail a job. The
+// outcome is attributed to the IMPLEMENT job that produced the diff (the same
+// implementJobForTask attribution the merge-gate harvest uses), so the soft review
+// row lands on the implementer's template version next to the verifiable floor.
 func (e Engine) reviewCrossFamilyForMergeGate(ctx context.Context, reviewPayload JobPayload, mergedHead string) {
 	if e.ReviewLegDispatcher == nil || e.OutcomeHarvester == nil {
 		return
 	}
+	// Resolve the owning implement job up front (a cheap store read, no LLM) so the
+	// detached closure is self-contained. If none resolves, there is nothing to
+	// review/attribute.
 	job, payload, ok := e.implementJobForTask(ctx, reviewPayload)
 	if !ok {
 		return
 	}
+	e.spawnReviewLeg(func() {
+		// Fresh context decoupled from the caller's ctx (which is cancelled the moment
+		// AdvanceJob returns) yet bounded so a wedged reviewer is reaped, not leaked.
+		reviewCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), e.reviewLegTimeout())
+		defer cancel()
+		e.runReviewLeg(reviewCtx, job, payload, mergedHead)
+	})
+}
+
+// runReviewLeg performs the actual cross-family review dispatch + harvest. It is
+// called from the DETACHED goroutine (never on the AdvanceJob path) so its live
+// adapter.Deliver cannot block job advancement.
+func (e Engine) runReviewLeg(ctx context.Context, job db.Job, payload JobPayload, mergedHead string) {
 	outcome, ok, err := e.ReviewLegDispatcher.Review(ctx, job, payload, mergedHead)
 	if err != nil {
 		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
@@ -4389,6 +4437,27 @@ func (e Engine) reviewCrossFamilyForMergeGate(ctx context.Context, reviewPayload
 		return
 	}
 	e.harvestOutcome(ctx, job, payload, outcome)
+}
+
+// reviewLegTimeout returns the configured detached-review-leg ceiling, defaulting
+// to defaultReviewLegTimeout when unset so a zero-valued Engine keeps a bounded
+// reviewer.
+func (e Engine) reviewLegTimeout() time.Duration {
+	if e.ReviewLegTimeout > 0 {
+		return e.ReviewLegTimeout
+	}
+	return defaultReviewLegTimeout
+}
+
+// spawnReviewLeg runs fn off the caller's path. The default spawns a goroutine
+// (fire-and-forget, like the EventSink seam); tests inject a synchronous runner via
+// the ReviewSpawner hook so the detached review is deterministic.
+func (e Engine) spawnReviewLeg(fn func()) {
+	if e.ReviewSpawner != nil {
+		e.ReviewSpawner(fn)
+		return
+	}
+	go fn()
 }
 
 // harvestOutcomeForMergeGate resolves the implement job that owns this PR/task and

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1965,6 +1965,9 @@ func testEngine(store *db.Store) Engine {
 			}
 			return strings.Join(parts, "-")
 		},
+		// Run the detached cross-family review leg SYNCHRONOUSLY in tests so its
+		// dispatch + harvest are deterministic; production defaults to a goroutine.
+		ReviewSpawner: func(fn func()) { fn() },
 	}
 }
 

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -500,13 +500,17 @@ read-only leg in the `verifier.md` style). The reviewer scores subjective qualit
 the PR diff + `changes_made`) plus `architecture` / `readability` / `abstraction`
 — each in `[0,1]`. The rubric is mapped to `dimension_scores`, fused by the
 mean-of-dimensions path, and written as a **second** `FeedbackEvent` in the SAME
-`auto-trace:<version>` run under a distinct item id (`review#<repo>#<pr>`) and a
-distinct reviewer (`gitmoot-review:<rt>`), so it never overwrites the verifiable
-floor row.
+`auto-trace:<version>` run under a distinct item id (`review#<repo>#<pr>`) and the
+fixed `gitmoot-review` reviewer sentinel, so it never overwrites the verifiable
+floor row — and so a re-review by a *different* reviewer family overwrites the row
+in place rather than accumulating a stale duplicate. The mapped mean **drives the
+a/b choice** (a below-`0.5` mean registers as a non-baseline `b` vote, not a
+baseline win) and an empty rubric writes **no row**.
 
 This signal is **soft, judge-tagged, and weighted low**. The review row rides the
 run's `feedback_source = automatic_trace` (no new contract field,
-`contract_version` stays `1`) and its eval item carries `judge_derived = true`, so
+`contract_version` stays `1`) and its eval item carries `judge_derived = true`,
+the `reviewer_runtime` family, and the projected `rubric_score`, so
 the export/optimizer ranks it below the verifiable floor and below human gold —
 **weight tiers: human gold > verifiable floor > cross-family judge > same-family
 judge.** It is **best-effort and off the blocking merge path**: a review-leg
@@ -517,9 +521,10 @@ event). The rubric text is **never** injected into the implementer's prompt
 **Same-family fallback (with warning).** When *no* different-family reviewer is
 available/authed, gitmoot falls back to a **same-family** reviewer — but never
 silently: it logs and records a `cross_family_review_samefamily_fallback` job
-event (self-preference bias applies), tags the row `gitmoot-review-self:<rt>` with
-`self_family = true`, and weights it *below* a cross-family review. Only when **no**
-review-capable runtime is authed at all is the review skipped (no review row).
+event (self-preference bias applies), tags the review item `self_family = true`
+(with `reviewer_runtime` carrying the family), and weights it *below* a
+cross-family review. Only when **no** review-capable runtime is authed at all is
+the review skipped (no review row).
 
 The judge is uncalibrated in this slice — it is judge-tagged and weighted low (a
 measure-the-judge calibration hook for #344/#345 is a follow-on). The review

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -485,3 +485,46 @@ promotes** — a human still promotes a candidate. With the knob unset, no
 harvester runs and behavior is byte-identical. See
 `docs/skillopt-exchange-contract.md` for the outcome→score mapping, the no-CI
 guard, and the corrective-on-revert overwrite.
+
+### Cross-family review soft signal (off by default)
+
+When **both** `[skillopt].auto_trace_enabled = true` **and**
+`[skillopt].cross_family_review_enabled = true` (both default `false`), a merged
+implement job additionally runs a read-only **cross-family review leg**: a
+reviewer of a *different runtime family* than the implementer
+(codex→claude, claude→codex, kimi→claude — a registered review-capable agent of
+another family if one is scoped to the repo, else an ephemeral different-family
+read-only leg in the `verifier.md` style). The reviewer scores subjective quality
+**and** scope-fidelity as ONE rubric — `coverage` / `containment` / `fidelity`
+(intended scope = the implement job's instructions + task title + goal title vs.
+the PR diff + `changes_made`) plus `architecture` / `readability` / `abstraction`
+— each in `[0,1]`. The rubric is mapped to `dimension_scores`, fused by the
+mean-of-dimensions path, and written as a **second** `FeedbackEvent` in the SAME
+`auto-trace:<version>` run under a distinct item id (`review#<repo>#<pr>`) and a
+distinct reviewer (`gitmoot-review:<rt>`), so it never overwrites the verifiable
+floor row.
+
+This signal is **soft, judge-tagged, and weighted low**. The review row rides the
+run's `feedback_source = automatic_trace` (no new contract field,
+`contract_version` stays `1`) and its eval item carries `judge_derived = true`, so
+the export/optimizer ranks it below the verifiable floor and below human gold —
+**weight tiers: human gold > verifiable floor > cross-family judge > same-family
+judge.** It is **best-effort and off the blocking merge path**: a review-leg
+failure never blocks or fails a job (it records a `cross_family_review_failed` job
+event). The rubric text is **never** injected into the implementer's prompt
+(anti-gaming).
+
+**Same-family fallback (with warning).** When *no* different-family reviewer is
+available/authed, gitmoot falls back to a **same-family** reviewer — but never
+silently: it logs and records a `cross_family_review_samefamily_fallback` job
+event (self-preference bias applies), tags the row `gitmoot-review-self:<rt>` with
+`self_family = true`, and weights it *below* a cross-family review. Only when **no**
+review-capable runtime is authed at all is the review skipped (no review row).
+
+The judge is uncalibrated in this slice — it is judge-tagged and weighted low (a
+measure-the-judge calibration hook for #344/#345 is a follow-on). The review
+signal feeds the optimizer like any other and, when the configurable
+`[skillopt].auto_promote` policy (#463) lands, is subject to it (weighted-low +
+judge-tagged — *not* barred from promotion); this slice simply preserves the
+current **manual** promotion by writing only `eval_runs` / `eval_review_items` /
+`feedback_events`.

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -379,6 +379,55 @@ Before launching it, verify `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help`; missing or broken installs should be
 handled as configuration blockers.
 
+## Automatic Trace-Harvested Feedback (Mode A, off by default)
+
+For hands-off template learning, the daemon can derive feedback from the
+**verifiable outcomes** an implement job reaches instead of waiting for a human
+ranking. Enable it per host in `[skillopt]`:
+
+```toml
+[skillopt]
+auto_trace_enabled = true            # off by default
+cross_family_review_enabled = false  # off by default; also needs auto_trace_enabled
+```
+
+With `auto_trace_enabled = true`, a merge (passing CI vs. empty-gate), a
+merge-gate block, or a review `changes_requested` is projected into a synthetic
+`FeedbackEvent` (`reviewer = gitmoot-auto`, `feedback_source = automatic_trace`)
+in a per-template-version `auto-trace:<version>` eval run. It is additive
+(`contract_version` stays `1`), best-effort (a failure records an
+`auto_trace_harvest_failed` job event, never blocks a job), and **never
+promotes** — a human still promotes a candidate. With the knob unset, no
+harvester runs and behavior is byte-identical.
+
+### Cross-family review agent (soft quality + scope-fidelity signal)
+
+Turning on **both** `auto_trace_enabled` and `cross_family_review_enabled` adds a
+read-only **cross-family review leg** on every merge: a reviewer of a *different
+runtime family* than the implementer (codex→claude, claude→codex, kimi→claude —
+preferring a registered review-capable agent of another family scoped to the
+repo, else an ephemeral different-family read-only leg in the `verifier.md`
+style) scores subjective quality + scope-fidelity as one rubric (coverage /
+containment / fidelity + architecture / readability / abstraction, each in
+`[0,1]`). The rubric becomes a **second**, judge-tagged, down-weighted
+`FeedbackEvent` in the SAME `auto-trace:<version>` run under a distinct item id
+(`review#<repo>#<pr>`) and reviewer (`gitmoot-review:<rt>`), so it never
+overwrites the verifiable floor. Weight tiers: **human gold > verifiable floor >
+cross-family judge > same-family judge.**
+
+The review leg runs **off the blocking merge path** and is best-effort — a
+failure records a `cross_family_review_failed` job event and never blocks the
+merge. When no different-family reviewer is available it falls back to a
+**same-family** reviewer *with a warning* (a `cross_family_review_samefamily_fallback`
+job event, a `gitmoot-review-self:<rt>` row tagged `self_family = true` so it
+weights below a cross-family review); only when no review-capable runtime is
+authed at all is the review skipped. The rubric text is never shown to the
+implementer (anti-gaming). Promotion stays manual (the harvester writes only
+eval/feedback rows); the signal is weighted-low + judge-tagged and is subject to
+the configurable `[skillopt].auto_promote` policy (#463) when that lands — it is
+not barred from promotion. See
+`skills/gitmoot/references/RESULT_CONTRACT.md` for the full contract.
+
 ## Execution Model
 
 Use `here` when the current chat should answer directly from the Gitmoot skill.

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -411,17 +411,20 @@ style) scores subjective quality + scope-fidelity as one rubric (coverage /
 containment / fidelity + architecture / readability / abstraction, each in
 `[0,1]`). The rubric becomes a **second**, judge-tagged, down-weighted
 `FeedbackEvent` in the SAME `auto-trace:<version>` run under a distinct item id
-(`review#<repo>#<pr>`) and reviewer (`gitmoot-review:<rt>`), so it never
-overwrites the verifiable floor. Weight tiers: **human gold > verifiable floor >
-cross-family judge > same-family judge.**
+(`review#<repo>#<pr>`) and the fixed `gitmoot-review` reviewer sentinel, so it
+never overwrites the verifiable floor — and so a re-review by a different reviewer
+family overwrites in place rather than accumulating a stale duplicate. The mapped
+mean **drives the a/b choice** (a below-`0.5` mean is a non-baseline `b` vote, not
+a baseline win) and an empty rubric writes no row. Weight tiers: **human gold >
+verifiable floor > cross-family judge > same-family judge.**
 
 The review leg runs **off the blocking merge path** and is best-effort — a
 failure records a `cross_family_review_failed` job event and never blocks the
 merge. When no different-family reviewer is available it falls back to a
 **same-family** reviewer *with a warning* (a `cross_family_review_samefamily_fallback`
-job event, a `gitmoot-review-self:<rt>` row tagged `self_family = true` so it
-weights below a cross-family review); only when no review-capable runtime is
-authed at all is the review skipped. The rubric text is never shown to the
+job event, a review item tagged `self_family = true` with `reviewer_runtime`
+carrying the family so it weights below a cross-family review); only when no
+review-capable runtime is authed at all is the review skipped. The rubric text is never shown to the
 implementer (anti-gaming). Promotion stays manual (the harvester writes only
 eval/feedback rows); the signal is weighted-low + judge-tagged and is subject to
 the configurable `[skillopt].auto_promote` policy (#463) when that lands — it is

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -248,11 +248,15 @@ scores subjective quality **and** scope-fidelity as ONE rubric:
 Each dimension is in `[0,1]`. The rubric is mapped to `dimension_scores` and fused
 by the **mean-of-dimensions** path of the normalized `{score, feedback}`
 projection, then written as a **second** `FeedbackEvent` in the SAME
-`auto-trace:<version>` run under a distinct item id (`review#<repo>#<pr>`) and a
-distinct reviewer (`gitmoot-review:<rt>`), so it **never overwrites** the
-verifiable-floor row. The review eval item carries `judge_derived = true` (and
-`self_family = true` on the same-family fallback) while the run keeps
-`feedback_source = automatic_trace` — additive, **no new contract field,
+`auto-trace:<version>` run under a distinct item id (`review#<repo>#<pr>`) and the
+fixed `gitmoot-review` reviewer sentinel, so it **never overwrites** the
+verifiable-floor row — and so a re-review by a *different* reviewer family
+overwrites the row in place rather than accumulating a stale duplicate. The mapped
+mean **drives the a/b choice** (a below-`0.5` mean registers as a non-baseline `b`
+vote, not a baseline win) and an empty rubric writes **no row**. The review eval
+item carries `judge_derived = true`, the `reviewer_runtime` family, the projected
+`rubric_score`, and (on the same-family fallback) `self_family = true`, while the
+run keeps `feedback_source = automatic_trace` — additive, **no new contract field,
 `contract_version` stays `1`**.
 
 The signal is **soft, judge-tagged, and weighted low** — weight tiers:
@@ -264,9 +268,9 @@ The rubric text is **never** injected into the implementer's prompt (anti-gaming
 When no different-family reviewer is available/authed, gitmoot falls back to a
 **same-family** reviewer — never silently: it logs and records a
 `cross_family_review_samefamily_fallback` job event (self-preference bias
-applies), tags the row `gitmoot-review-self:<rt>` with `self_family = true`, and
-weights it below a cross-family review. Only when no review-capable runtime is
-authed at all is the review skipped (no review row).
+applies), tags the review item `self_family = true` (with `reviewer_runtime`
+carrying the family), and weights it below a cross-family review. Only when no
+review-capable runtime is authed at all is the review skipped (no review row).
 
 The judge is uncalibrated in this slice — judge-tagged and weighted low, with a
 measure-the-judge calibration hook for #344/#345 as a follow-on. Promotion stays

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -228,6 +228,53 @@ human default `imported_human_review`), and the run lives in its own
 automatic feedback independently of sparse human gold. A human run never carries
 the `feedback_source` metadata key, so its export is byte-identical.
 
+### Cross-family review soft signal (off by default)
+
+Setting **both** `[skillopt].auto_trace_enabled = true` **and**
+`[skillopt].cross_family_review_enabled = true` (both default `false`) adds a
+read-only **cross-family review leg** on every merge. A reviewer of a *different
+runtime family* than the implementer (codex→claude, claude→codex, kimi→claude —
+preferring a registered review-capable agent of another family scoped to the
+repo, else an ephemeral different-family read-only leg in the `verifier.md` style)
+scores subjective quality **and** scope-fidelity as ONE rubric:
+
+- **coverage / containment / fidelity** — intended scope (the implement job's
+  instructions + task title + goal title) vs. the delivered work (the PR diff,
+  read-only at the head SHA, plus the agent's self-reported `changes_made` as a
+  secondary cross-check). Coverage = did all of the ask; containment = no creep
+  beyond it; fidelity = the ask, not something adjacent.
+- **architecture / readability / abstraction** — subjective code quality.
+
+Each dimension is in `[0,1]`. The rubric is mapped to `dimension_scores` and fused
+by the **mean-of-dimensions** path of the normalized `{score, feedback}`
+projection, then written as a **second** `FeedbackEvent` in the SAME
+`auto-trace:<version>` run under a distinct item id (`review#<repo>#<pr>`) and a
+distinct reviewer (`gitmoot-review:<rt>`), so it **never overwrites** the
+verifiable-floor row. The review eval item carries `judge_derived = true` (and
+`self_family = true` on the same-family fallback) while the run keeps
+`feedback_source = automatic_trace` — additive, **no new contract field,
+`contract_version` stays `1`**.
+
+The signal is **soft, judge-tagged, and weighted low** — weight tiers:
+**human gold > verifiable floor > cross-family judge > same-family judge.** It
+runs **off the blocking merge path** and is best-effort: a review-leg failure
+records a `cross_family_review_failed` job event and never blocks or fails a job.
+The rubric text is **never** injected into the implementer's prompt (anti-gaming).
+
+When no different-family reviewer is available/authed, gitmoot falls back to a
+**same-family** reviewer — never silently: it logs and records a
+`cross_family_review_samefamily_fallback` job event (self-preference bias
+applies), tags the row `gitmoot-review-self:<rt>` with `self_family = true`, and
+weights it below a cross-family review. Only when no review-capable runtime is
+authed at all is the review skipped (no review row).
+
+The judge is uncalibrated in this slice — judge-tagged and weighted low, with a
+measure-the-judge calibration hook for #344/#345 as a follow-on. Promotion stays
+manual (the harvester writes only `eval_runs` / `eval_review_items` /
+`feedback_events`); the review signal feeds the optimizer like any other and is
+subject to the configurable `[skillopt].auto_promote` policy (#463) when that
+lands — weighted-low + judge-tagged, **not** barred from promotion.
+
 ## Ranked Exploration Workflow
 
 Use ranked exploration when the template is still ambiguous and humans need to


### PR DESCRIPTION
## What

First slice of #469 (RFC #463): a Mode A **cross-family review leg** that scores subjective quality + scope-fidelity as ONE rubric and projects it into a **soft, down-weighted, judge-tagged** second `FeedbackEvent` in the existing #465 auto-trace eval run — next to (never overwriting) the verifiable floor.

Builds on merged #462 (`ProjectSignal`/mean-of-dimensions), #465 (`OutcomeHarvester` / `auto-trace:<version>` run), `EphemeralSpec`, and the #421 `verifier.md` cross-model verify-leg pattern — all reused, none reimplemented.

## Invariants

- **Off by default.** New `[skillopt].cross_family_review_enabled` (default `false`) AND it also requires `auto_trace_enabled` (`ReviewEnabled()` needs both). With it unset: no review leg, no review row, byte-identical behavior.
- **Cross-family, or same-family with a warning (REFINEMENT #1).** `pickCrossFamilyReviewer` prefers a different-family registered reviewer, else an ephemeral different-family read-only leg (codex→claude, claude→codex, kimi→claude). When **no** different family is available it falls back to a **same-family** reviewer — never silently: a `cross_family_review_samefamily_fallback` job event + log, a `gitmoot-review-self:<rt>` row tagged `self_family=true` so it weights *below* a cross-family review. Only when no review-capable runtime is authed at all is the review skipped. Weight tiers: **human gold > verifiable floor > cross-family judge > same-family judge.**
- **Runs as a read-only leg OFF the blocking merge/harvest path**, via a nil-by-default `ReviewLegDispatcher` seam; a review-leg failure never blocks or fails a job (records `cross_family_review_failed`).
- **Additive.** Rubric → `EvaluatorScore.DimensionScores` → `ProjectSignal` mean path → a second `FeedbackEvent` in `auto-trace:<versionID>` under a distinct item id (`review#<repo>#<pr>`) + `gitmoot-review[-self]:<rt>` reviewer. No new contract field; `ContractVersion` stays `1`.
- **Scope-fidelity inputs:** intended = `Instructions` + `TaskTitle` + `Goal.Title`; delivered = the PR diff (read-only at HeadSHA, degrades to `ChangesMade`-only on read failure) + `ChangesMade`. The rubric text is never injected into the implementer prompt (anti-gaming).
- **Manual promotion preserved** (writes only eval/feedback rows) — framed as *weighted-low + judge-tagged; subject to the configurable `auto_promote` policy (#463)*, not barred from promotion. Measure-the-judge calibration deferred to #344/#345 (TODO hook).

## Tests

Cross-family selection (incl. same-family-fallback-with-warning, SKIP-when-none, never-self-by-accident); rubric→mean→second-row-not-overwriting-floor; judge-tag + down-weight + same-family-even-lower; off-by-default; and a full-chain `internal/cli` integration test with a **shell-runtime cross-family stub reviewer → engine dispatch → real `OutcomeReviewed` harvest → real judge-tagged auto-trace row**. Docs updated in both trees + the website mirror.

Gate green: `go build/vet/test ./...` + `go test -race ./internal/workflow/ ./internal/cli/ ./internal/skillopt/`.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)