### PR TITLE
Promotion policy + candidate.* notifications (#471)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -14,18 +14,31 @@ fan-out, not a migration.
 
 The pilot emits a tight allowlist of event types over the webhook transport:
 
-| `event_type`           | When                                                              |
-| ---------------------- | ---------------------------------------------------------------- |
-| `job.finished`         | a job reaches the `succeeded` terminal state                     |
-| `job.failed`           | a job reaches the `failed` terminal state                        |
-| `job.blocked`          | a job reaches the `blocked` terminal state                       |
-| `job.needs_attention`  | a tree pauses awaiting a human (the `escalate_human` pause today) |
+| `event_type`                    | When                                                                              |
+| ------------------------------- | --------------------------------------------------------------------------------- |
+| `job.finished`                  | a job reaches the `succeeded` terminal state                                       |
+| `job.failed`                    | a job reaches the `failed` terminal state                                          |
+| `job.blocked`                   | a job reaches the `blocked` terminal state                                         |
+| `job.needs_attention`           | a tree pauses awaiting a human (the `escalate_human` pause today)                  |
+| `candidate.awaiting_promotion`  | a SkillOpt template candidate becomes `pending` after import (always, off the auto-promote policy) |
+| `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current`          |
 
 Each terminal transition emits **exactly once**. The engine owns the
 succeeded/failed/blocked emit on its `Mailbox` terminal path; the daemon owns the
 pre-flight (`queued -> failed|blocked`) and permission-blocked cases that never
 pass through that path. `job.needs_attention` is emitted once per fresh
 escalation round (a re-advance does not re-emit).
+
+The two `candidate.*` events come from the `skillopt import` / `train continue`
+CLI path, NOT the daemon (#471). When a candidate becomes `pending`,
+`candidate.awaiting_promotion` is emitted **once** carrying the version id
+(`job_id`), the template id (`root_id`), and a redacted score/samples/CI reason —
+independent of the auto-promote policy, so a human is notified even in the manual
+default. If `[skillopt].auto_promote` is on **and** every configured guardrail
+holds, the candidate is promoted via the existing promote path and
+`candidate.auto_promoted` fires so the change can be reviewed or rolled back. The
+adjacent dashboard **Attention** page also lists every pending candidate
+(read-only), so candidates are visible locally even with `[events]` off.
 
 The following `event_type` values are **reserved** for the graduate step. They
 are enumerated in the contract so a consumer can `switch` over them

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -297,16 +297,30 @@ auto_promote_require_measured_judge = false  # PARSED but DEFERRED (#344): true 
 auto_promote_canary = false               # PARSED but DEFERRED (canary follow-on): true => fail safe to no-promote
 ```
 
+The guardrails read the candidate's **harvester auto-trace run**
+(`auto-trace:<template_version_id>`) — the run the OutcomeHarvester writes the
+verifiable `{score, feedback}` signal into — **not** the human/markdown review
+run. A feedback read error (or an unresolvable run) is treated as *feedback
+unavailable* → notify-only (we never promote on evidence we could not read), and
+**zero feedback samples is always a hard do-not-promote** regardless of the
+configured `auto_promote_min_samples` (so a sparse `skillopt import` with no
+auto-trace evidence fails safe to notify-only).
+
 - `auto_promote_min_samples` — the count of `feedback_events` in the candidate's
-  eval_run must meet this floor. **Unset is a hard do-not-promote, never `0`**, so
-  flipping `auto_promote` on without a sample floor never promotes (a sparse
-  `skillopt import` with no resolvable eval_run also fails safe to notify-only).
+  auto-trace run must meet this floor. **Unset is a hard do-not-promote, never
+  `0`**, so flipping `auto_promote` on without a sample floor never promotes. Even
+  an explicit `auto_promote_min_samples = 0` cannot promote a zero-evidence
+  candidate — there is an absolute floor of at least one real sample.
 - `auto_promote_min_score` — the candidate's `summary.score` must be `>=` this.
   **Unset, or a candidate with no score, is a hard do-not-promote.**
-- `auto_promote_require_external_ci` — at least one eval_run feedback event must
+- `auto_promote_require_external_ci` — at least one auto-trace feedback event must
   record a merge that passed **genuine external CI** (not the no-CI near-neutral
-  band). It reuses the harvester's own real-CI vocabulary, so it never rewards an
-  empty gate.
+  band). The predicate keys off the harvester's own provenance (the `auto-trace`
+  source + `gitmoot-auto` reviewer) AND its real-CI marker phrase, so it reads
+  only the harvester's verifiable rows and a sibling cross-family review row's
+  free-text findings can never spoof it. It therefore applies only to **Mode A
+  (auto-trace) runs**; a candidate with no harvested external-CI evidence fails
+  safe to notify-only.
 - `auto_promote_require_measured_judge` and `auto_promote_canary` are **parsed but
   deferred**: there is no judge↔human calibration source yet (gated on #344) and
   the sampled-traffic canary + auto-rollback do not exist, so setting either to

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -263,6 +263,56 @@ manual (the harvester writes only `eval_runs` / `eval_review_items` /
 subject to the configurable `[skillopt].auto_promote` policy (#463) when that
 lands — weighted-low + judge-tagged, **not** barred from promotion.
 
+### Promotion policy + notifications (off by default)
+
+When a candidate becomes **pending** (after `skillopt import` or `train
+continue`), gitmoot can (a) **notify** over the [event stream](events.md) and
+(b) optionally **auto-promote** it — both **off by default** and **additive**
+(#471). Importing **never** promotes: the import write only ever creates the
+pending version; the notify + auto-promote is a separate, config-gated step that
+runs *after* import returns and, on a guardrails pass, calls the same
+`gitmoot skillopt candidate promote` machinery.
+
+**Notifications (always-on when `[events]` is configured).** Every newly-pending
+candidate emits a single **`candidate.awaiting_promotion`** event carrying the
+version id (`job_id`), template id (`root_id`), and a redacted score/samples/CI
+reason — independent of the auto-promote policy, so a human is notified even in
+the manual default. The dashboard **Attention** page also lists every pending
+candidate (read-only), so candidates are visible locally even with `[events]`
+off. A successful auto-promotion additionally emits **`candidate.auto_promoted`**
+so the change can be reviewed or rolled back (`gitmoot skillopt candidate` /
+template revert) even in full-auto.
+
+**Auto-promote (gated on guardrails, fail-safe).** With `auto_promote = true`, a
+candidate is auto-promoted **only when every configured guardrail holds**; **any**
+uncertainty fails safe to *notify, don't promote*:
+
+```toml
+[skillopt]
+auto_promote = false                      # default false = manual, byte-identical
+auto_promote_min_samples = 0              # UNSET = hard "do not promote" (NOT 0)
+auto_promote_min_score = 0.0              # UNSET, or a candidate with no score = do not promote
+auto_promote_require_external_ci = false  # require >= 1 real-external-CI feedback event in the eval_run
+auto_promote_require_measured_judge = false  # PARSED but DEFERRED (#344): true => fail safe to no-promote
+auto_promote_canary = false               # PARSED but DEFERRED (canary follow-on): true => fail safe to no-promote
+```
+
+- `auto_promote_min_samples` — the count of `feedback_events` in the candidate's
+  eval_run must meet this floor. **Unset is a hard do-not-promote, never `0`**, so
+  flipping `auto_promote` on without a sample floor never promotes (a sparse
+  `skillopt import` with no resolvable eval_run also fails safe to notify-only).
+- `auto_promote_min_score` — the candidate's `summary.score` must be `>=` this.
+  **Unset, or a candidate with no score, is a hard do-not-promote.**
+- `auto_promote_require_external_ci` — at least one eval_run feedback event must
+  record a merge that passed **genuine external CI** (not the no-CI near-neutral
+  band). It reuses the harvester's own real-CI vocabulary, so it never rewards an
+  empty gate.
+- `auto_promote_require_measured_judge` and `auto_promote_canary` are **parsed but
+  deferred**: there is no judge↔human calibration source yet (gated on #344) and
+  the sampled-traffic canary + auto-rollback do not exist, so setting either to
+  `true` **forces notify-only** today. They are documented so a user can write the
+  knob forward-compatibly.
+
 ## Ranked Exploration Workflow
 
 Use ranked exploration when the template is still ambiguous and humans need to

--- a/internal/cli/candidate_autopromote_test.go
+++ b/internal/cli/candidate_autopromote_test.go
@@ -23,10 +23,16 @@ func autoPromotePolicy(minSamples int, minScore float64) config.SkillOptPolicy {
 	return policy
 }
 
-// realCIFeedbackEvent mirrors a harvested real-CI positive (choice "a" + the
-// shared marker phrase) the external-CI guardrail accepts.
+// realCIFeedbackEvent mirrors a harvested real-CI positive: choice "a" + the
+// shared marker phrase AND the harvester provenance (reviewer/source) the hardened
+// external-CI guardrail now requires so a human-typed review row can never spoof it.
 func realCIFeedbackEvent() db.FeedbackEvent {
-	return db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged with passing external CI."}
+	return db.FeedbackEvent{
+		Choice:    "a",
+		Reviewer:  skillopt.AutoTraceReviewer,
+		Source:    skillopt.AutoTraceSource,
+		Reasoning: "PR #7 merged with passing external CI.",
+	}
 }
 
 // TestRunCandidateNotifyAutoPromoteOffStaysPending proves auto_promote=false (the
@@ -38,7 +44,7 @@ func TestRunCandidateNotifyAutoPromoteOffStaysPending(t *testing.T) {
 	autoPromoteCandidateScore(&candidate, 0.99)
 	sink := &recordingSink{}
 
-	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -66,7 +72,7 @@ func TestRunCandidateNotifyAutoPromoteGuardrailsPass(t *testing.T) {
 	autoPromoteCandidateScore(&candidate, 0.96)
 	sink := &recordingSink{}
 
-	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -100,7 +106,7 @@ func TestRunCandidateNotifyAutoPromoteGuardrailFailStaysPending(t *testing.T) {
 
 	// A near-neutral (no external CI) feedback event fails require_external_ci.
 	nearNeutral := db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged through an empty gate (no external CI); near-neutral, not a strong positive."}
-	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{nearNeutral}); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{nearNeutral}, false); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 

--- a/internal/cli/candidate_autopromote_test.go
+++ b/internal/cli/candidate_autopromote_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+func autoPromoteCandidateScore(candidate *skillopt.CandidatePackage, score float64) {
+	candidate.Summary.Score = &score
+}
+
+func autoPromotePolicy(minSamples int, minScore float64) config.SkillOptPolicy {
+	policy := config.DefaultSkillOptPolicy()
+	policy.AutoPromote = true
+	policy.AutoPromoteMinSamples = &minSamples
+	policy.AutoPromoteMinScore = &minScore
+	policy.AutoPromoteRequireExternalCI = true
+	return policy
+}
+
+// realCIFeedbackEvent mirrors a harvested real-CI positive (choice "a" + the
+// shared marker phrase) the external-CI guardrail accepts.
+func realCIFeedbackEvent() db.FeedbackEvent {
+	return db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged with passing external CI."}
+}
+
+// TestRunCandidateNotifyAutoPromoteOffStaysPending proves auto_promote=false (the
+// default) leaves the candidate pending: only candidate.awaiting_promotion is
+// emitted, no candidate.auto_promoted, and PromoteAgentTemplateVersion is not run.
+func TestRunCandidateNotifyAutoPromoteOffStaysPending(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.99)
+	sink := &recordingSink{}
+
+	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+
+	if got := len(sink.byType(events.EventCandidateAwaitingPromotion)); got != 1 {
+		t.Fatalf("awaiting_promotion emits = %d, want 1", got)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 0 {
+		t.Fatalf("auto_promoted emits = %d, want 0", got)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "pending" {
+		t.Fatalf("version state = %q, want pending", after.State)
+	}
+}
+
+// TestRunCandidateNotifyAutoPromoteGuardrailsPass proves auto_promote=true with all
+// guardrails satisfied promotes the version to current AND emits both
+// candidate.awaiting_promotion and candidate.auto_promoted.
+func TestRunCandidateNotifyAutoPromoteGuardrailsPass(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+
+	if got := len(sink.byType(events.EventCandidateAwaitingPromotion)); got != 1 {
+		t.Fatalf("awaiting_promotion emits = %d, want 1", got)
+	}
+	promoted := sink.byType(events.EventCandidateAutoPromoted)
+	if len(promoted) != 1 {
+		t.Fatalf("auto_promoted emits = %d, want 1", len(promoted))
+	}
+	if promoted[0].JobID != version.ID || promoted[0].RootID != version.TemplateID {
+		t.Fatalf("auto_promoted ids = %q/%q, want %q/%q", promoted[0].JobID, promoted[0].RootID, version.ID, version.TemplateID)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "current" {
+		t.Fatalf("version state = %q, want current (auto-promoted)", after.State)
+	}
+}
+
+// TestRunCandidateNotifyAutoPromoteGuardrailFailStaysPending proves auto_promote=true
+// with a FAILING guardrail (here: no real external-CI feedback) does NOT promote —
+// only candidate.awaiting_promotion fires and the version stays pending.
+func TestRunCandidateNotifyAutoPromoteGuardrailFailStaysPending(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	// A near-neutral (no external CI) feedback event fails require_external_ci.
+	nearNeutral := db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged through an empty gate (no external CI); near-neutral, not a strong positive."}
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{nearNeutral}); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+
+	if got := len(sink.byType(events.EventCandidateAwaitingPromotion)); got != 1 {
+		t.Fatalf("awaiting_promotion emits = %d, want 1", got)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 0 {
+		t.Fatalf("auto_promoted emits = %d, want 0 (guardrail failed)", got)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "pending" {
+		t.Fatalf("version state = %q, want pending (no promotion)", after.State)
+	}
+}

--- a/internal/cli/candidate_notify.go
+++ b/internal/cli/candidate_notify.go
@@ -24,19 +24,31 @@ import (
 //
 //  1. Builds the best-effort event sink the SAME way the daemon does
 //     (buildDaemonEventSink, nil when [events] is OFF), so emission is nil-safe and
-//     byte-identical when the event stream is unset.
-//  2. Loads the candidate's eval_run feedback events (when an evalRunID is
-//     resolvable; unresolvable -> empty -> the sample-count guardrail fails safe).
+//     byte-identical when the event stream is unset. Unlike the daemon's CACHED
+//     long-lived sink, this CLI command is short-lived, so the webhook sink it
+//     builds is FLUSHED before return (defer) — otherwise the queued candidate.*
+//     POST is destroyed when the process exits before the drain goroutine delivers.
+//  2. Loads the candidate's HARVESTER auto-trace eval_run feedback events
+//     (skillopt.AutoTraceRunID(version.ID)) — the run the harvester writes the
+//     verifiable {score, feedback} signal (incl. the real external-CI marker) into,
+//     NOT the human/markdown review run. A read error marks feedback UNAVAILABLE
+//     (fail safe: never promote on evidence we could not read); an unset run id
+//     yields no samples (the zero-evidence floor fails safe too).
 //  3. Emits candidate.awaiting_promotion EXACTLY ONCE (independent of the promote
 //     policy), carrying the version id (JobID), template id (RootID), and a
 //     score/samples/CI reason in Detail.
 //  4. Evaluates the pure skillopt.EvaluateAutoPromote guardrails; on a pass it calls
 //     the EXISTING store.PromoteAgentTemplateVersion and emits candidate.auto_promoted.
 //
-// It is best-effort and NEVER fails the import: a sink build error, a feedback
-// read error, or an emit are all swallowed (the candidate is already durably
-// pending). A promote error IS surfaced (it is a real, requested mutation that
-// failed), but only AFTER the awaiting_promotion notify already fired.
+// It is best-effort and NEVER fails the import: a sink build error or an emit are
+// swallowed (the candidate is already durably pending); a feedback read error fails
+// SAFE to notify-only rather than promoting on unread evidence. A promote error IS
+// surfaced (it is a real, requested mutation that failed), but only AFTER the
+// awaiting_promotion notify already fired.
+//
+// evalRunID is the candidate's human/markdown review run id (or "" for a plain
+// import). The auto-promote guardrails read the HARVESTER run derived from
+// version.ID, not evalRunID, so evalRunID is retained only for parity/logging.
 func notifyAndMaybeAutoPromoteCandidate(ctx context.Context, store *db.Store, home string, candidate skillopt.CandidatePackage, version db.AgentTemplateVersion, evalRunID string) error {
 	policy, perr := loadSkillOptPolicy(home)
 	if perr != nil {
@@ -45,31 +57,46 @@ func notifyAndMaybeAutoPromoteCandidate(ctx context.Context, store *db.Store, ho
 		policy = config.DefaultSkillOptPolicy()
 	}
 
-	// Resolve the candidate's eval_run feedback events. A read error or an empty/
-	// unresolvable run id degrades to no samples, which the min_samples guardrail
-	// treats as a hard do-not-promote (notify only) — a sparse import never promotes.
+	// Resolve the candidate's HARVESTER auto-trace eval_run feedback events: the
+	// real external-CI marker and the verifiable samples live in
+	// auto-trace:<versionID> (written by the OutcomeHarvester), NOT in the
+	// human/markdown review run that evalRunID points at. A ListFeedbackEvents error
+	// degrades to feedbackUnavailable=true so EvaluateAutoPromote fails SAFE (never
+	// promote on evidence we failed to read) instead of silently passing a
+	// min_samples=0 floor with samples=0. An empty/unresolvable run id is NOT an
+	// error: it yields no samples, which the absolute zero-evidence floor rejects.
 	var feedbackEvents []db.FeedbackEvent
-	if runID := strings.TrimSpace(evalRunID); runID != "" && store != nil {
-		if list, err := store.ListFeedbackEvents(ctx, runID); err == nil {
+	feedbackUnavailable := false
+	if runID := skillopt.AutoTraceRunID(version.ID); runID != "" && store != nil {
+		list, err := store.ListFeedbackEvents(ctx, runID)
+		if err != nil {
+			feedbackUnavailable = true
+		} else {
 			feedbackEvents = list
 		}
 	}
 
 	// Build the sink the SAME way the daemon does (nil when [events] is OFF), so the
-	// emit path is nil-safe and byte-identical when the event stream is unset.
+	// emit path is nil-safe and byte-identical when the event stream is unset. This
+	// is a PER-INVOCATION sink (buildDaemonEventSink, not the daemon's cached
+	// daemonEventSink), so we own its drain goroutine and MUST flush it before this
+	// short-lived CLI command exits, or the candidate.* POST never lands.
 	sink := buildDaemonEventSink(store, home)
-	return runCandidateNotify(ctx, store, sink, policy, candidate, version, feedbackEvents)
+	defer events.FlushSink(ctx, sink)
+	return runCandidateNotify(ctx, store, sink, policy, candidate, version, feedbackEvents, feedbackUnavailable)
 }
 
 // runCandidateNotify is the testable core of the post-import notify+auto-promote
 // step: given a resolved sink, the [skillopt] policy, the candidate, the pending
-// version, and the eval_run feedback events, it (3) emits candidate.awaiting_promotion
-// EXACTLY ONCE and (4) on a guardrails pass calls the existing
-// PromoteAgentTemplateVersion then emits candidate.auto_promoted. Splitting it from
-// the home/sink/feedback resolution lets a recording sink assert the exactly-once
-// emit and the no-double-emit invariant deterministically.
-func runCandidateNotify(ctx context.Context, store *db.Store, sink events.Sink, policy config.SkillOptPolicy, candidate skillopt.CandidatePackage, version db.AgentTemplateVersion, feedbackEvents []db.FeedbackEvent) error {
-	decision := skillopt.EvaluateAutoPromote(policy, candidate, feedbackEvents)
+// version, the eval_run feedback events, and a feedbackUnavailable flag (true when
+// the caller could not READ the eval_run — a read error vs. a legitimately empty
+// run), it (3) emits candidate.awaiting_promotion EXACTLY ONCE and (4) on a
+// guardrails pass calls the existing PromoteAgentTemplateVersion then emits
+// candidate.auto_promoted. Splitting it from the home/sink/feedback resolution lets
+// a recording sink assert the exactly-once emit and the no-double-emit invariant
+// deterministically.
+func runCandidateNotify(ctx context.Context, store *db.Store, sink events.Sink, policy config.SkillOptPolicy, candidate skillopt.CandidatePackage, version db.AgentTemplateVersion, feedbackEvents []db.FeedbackEvent, feedbackUnavailable bool) error {
+	decision := skillopt.EvaluateAutoPromote(policy, candidate, feedbackEvents, feedbackUnavailable)
 
 	// (3) Always-on notify (when [events] is configured), independent of the
 	// promotion policy: emit candidate.awaiting_promotion exactly once.

--- a/internal/cli/candidate_notify.go
+++ b/internal/cli/candidate_notify.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// notifyAndMaybeAutoPromoteCandidate is the SINGLE shared post-import step (#471)
+// that BOTH CLI callers (runSkillOptImport for manual `skillopt import` and
+// importSkillOptTrainCandidate for `train continue`) invoke AFTER
+// ImportCandidatePackageWithOptions returns the just-committed PENDING version.
+//
+// It preserves the "importing never promotes" invariant: the import write itself
+// stays side-effect-pure (no emit, no promote); the notify + auto-promote is this
+// separate, config-gated step layered on top. It:
+//
+//  1. Builds the best-effort event sink the SAME way the daemon does
+//     (buildDaemonEventSink, nil when [events] is OFF), so emission is nil-safe and
+//     byte-identical when the event stream is unset.
+//  2. Loads the candidate's eval_run feedback events (when an evalRunID is
+//     resolvable; unresolvable -> empty -> the sample-count guardrail fails safe).
+//  3. Emits candidate.awaiting_promotion EXACTLY ONCE (independent of the promote
+//     policy), carrying the version id (JobID), template id (RootID), and a
+//     score/samples/CI reason in Detail.
+//  4. Evaluates the pure skillopt.EvaluateAutoPromote guardrails; on a pass it calls
+//     the EXISTING store.PromoteAgentTemplateVersion and emits candidate.auto_promoted.
+//
+// It is best-effort and NEVER fails the import: a sink build error, a feedback
+// read error, or an emit are all swallowed (the candidate is already durably
+// pending). A promote error IS surfaced (it is a real, requested mutation that
+// failed), but only AFTER the awaiting_promotion notify already fired.
+func notifyAndMaybeAutoPromoteCandidate(ctx context.Context, store *db.Store, home string, candidate skillopt.CandidatePackage, version db.AgentTemplateVersion, evalRunID string) error {
+	policy, perr := loadSkillOptPolicy(home)
+	if perr != nil {
+		// Fail-safe: a malformed [skillopt] config never auto-promotes; treat as the
+		// disabled default so we still notify (with the default policy off).
+		policy = config.DefaultSkillOptPolicy()
+	}
+
+	// Resolve the candidate's eval_run feedback events. A read error or an empty/
+	// unresolvable run id degrades to no samples, which the min_samples guardrail
+	// treats as a hard do-not-promote (notify only) — a sparse import never promotes.
+	var feedbackEvents []db.FeedbackEvent
+	if runID := strings.TrimSpace(evalRunID); runID != "" && store != nil {
+		if list, err := store.ListFeedbackEvents(ctx, runID); err == nil {
+			feedbackEvents = list
+		}
+	}
+
+	// Build the sink the SAME way the daemon does (nil when [events] is OFF), so the
+	// emit path is nil-safe and byte-identical when the event stream is unset.
+	sink := buildDaemonEventSink(store, home)
+	return runCandidateNotify(ctx, store, sink, policy, candidate, version, feedbackEvents)
+}
+
+// runCandidateNotify is the testable core of the post-import notify+auto-promote
+// step: given a resolved sink, the [skillopt] policy, the candidate, the pending
+// version, and the eval_run feedback events, it (3) emits candidate.awaiting_promotion
+// EXACTLY ONCE and (4) on a guardrails pass calls the existing
+// PromoteAgentTemplateVersion then emits candidate.auto_promoted. Splitting it from
+// the home/sink/feedback resolution lets a recording sink assert the exactly-once
+// emit and the no-double-emit invariant deterministically.
+func runCandidateNotify(ctx context.Context, store *db.Store, sink events.Sink, policy config.SkillOptPolicy, candidate skillopt.CandidatePackage, version db.AgentTemplateVersion, feedbackEvents []db.FeedbackEvent) error {
+	decision := skillopt.EvaluateAutoPromote(policy, candidate, feedbackEvents)
+
+	// (3) Always-on notify (when [events] is configured), independent of the
+	// promotion policy: emit candidate.awaiting_promotion exactly once.
+	awaitingDetail := candidateAwaitingDetail(version, candidate, len(feedbackEvents), decision)
+	emitCandidateEvent(ctx, sink, events.EventCandidateAwaitingPromotion, version, "awaiting_promotion", awaitingDetail)
+
+	// (4) Auto-promote only on a guardrails pass; on a fail the awaiting_promotion
+	// notify above is the only emit.
+	if !decision.Promote {
+		return nil
+	}
+	if store == nil {
+		return nil
+	}
+	promoted, err := store.PromoteAgentTemplateVersion(ctx, version.ID)
+	if err != nil {
+		return fmt.Errorf("auto-promote candidate %s: %w", version.ID, err)
+	}
+	emitCandidateEvent(ctx, sink, events.EventCandidateAutoPromoted, promoted, "auto_promoted", decision.Reason)
+	return nil
+}
+
+// emitCandidateEvent maps a candidate version onto the #446 Event contract and
+// emits it best-effort (nil-safe). JobID = version id, RootID = template id, Repo
+// is empty (templates are not repo-scoped), and the detail is redacted/path-
+// scrubbed by NewEvent via workflow.RedactCommentText so no absolute path or
+// secret leaves the box.
+func emitCandidateEvent(ctx context.Context, sink events.Sink, eventType events.EventType, version db.AgentTemplateVersion, status, detail string) {
+	events.EmitEvent(ctx, sink, events.NewEvent(
+		eventType,
+		version.ID,
+		version.TemplateID,
+		"",
+		status,
+		detail,
+		time.Time{},
+		workflow.RedactCommentText,
+	))
+}
+
+// candidateAwaitingDetail builds the human-facing reason for the
+// candidate.awaiting_promotion event: the candidate's score (when present), the
+// eval_run sample count, and — on an auto_promote-on run — the guardrail decision
+// reason so a reader sees WHY it will or will not auto-promote.
+func candidateAwaitingDetail(version db.AgentTemplateVersion, candidate skillopt.CandidatePackage, samples int, decision skillopt.AutoPromoteDecision) string {
+	score := "n/a"
+	if candidate.Summary.Score != nil {
+		score = fmt.Sprintf("%.4g", *candidate.Summary.Score)
+	}
+	detail := fmt.Sprintf("candidate %s for template %s awaiting promotion (score %s, %d samples)", version.ID, version.TemplateID, score, samples)
+	if reason := strings.TrimSpace(decision.Reason); reason != "" {
+		detail += "; " + reason
+	}
+	return detail
+}

--- a/internal/cli/candidate_notify_test.go
+++ b/internal/cli/candidate_notify_test.go
@@ -4,9 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -56,7 +60,7 @@ func TestRunCandidateNotifyEmitsAwaitingExactlyOnce(t *testing.T) {
 	store, version, candidate, _ := candidateNotifyFixture(t)
 	sink := &recordingSink{}
 
-	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, nil); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, nil, false); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -92,7 +96,7 @@ func TestRunCandidateNotifyNilSinkIsNoOp(t *testing.T) {
 	ctx := context.Background()
 	store, version, candidate, _ := candidateNotifyFixture(t)
 
-	if err := runCandidateNotify(ctx, store, nil, config.DefaultSkillOptPolicy(), candidate, version, nil); err != nil {
+	if err := runCandidateNotify(ctx, store, nil, config.DefaultSkillOptPolicy(), candidate, version, nil, false); err != nil {
 		t.Fatalf("runCandidateNotify with nil sink returned error: %v", err)
 	}
 	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
@@ -154,6 +158,57 @@ func TestRunSkillOptImportOffByDefaultByteIdentical(t *testing.T) {
 	}
 	if len(pending) != 1 || pending[0].State != "pending" {
 		t.Fatalf("expected exactly one pending candidate, got %+v", pending)
+	}
+}
+
+// TestNotifyAndMaybeAutoPromoteFlushesPerInvocationSink proves the HIGH #471 fix
+// end to end: the SHORT-LIVED CLI path (notifyAndMaybeAutoPromoteCandidate) builds
+// its OWN per-invocation webhook sink and FLUSHES it before returning, so the
+// candidate.awaiting_promotion POST lands even though the "process" (here, the
+// helper) returns immediately after. Without the deferred flush the queued event
+// would be destroyed when the drain goroutine never gets to run.
+func TestNotifyAndMaybeAutoPromoteFlushesPerInvocationSink(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, home := candidateNotifyFixture(t)
+
+	var delivered atomic.Int64
+	got := make(chan events.Event, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ev events.Event
+		_ = json.NewDecoder(r.Body).Decode(&ev)
+		delivered.Add(1)
+		got <- ev
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Configure [events] for this home so buildDaemonEventSink yields a real webhook
+	// sink pointed at the test server. The fixture returns the already-resolved
+	// <home>/.gitmoot ROOT, so the config.toml lives directly under it.
+	cfgPath := filepath.Join(home, config.ConfigName)
+	if err := os.WriteFile(cfgPath, []byte("[events]\nwebhook_url = \""+srv.URL+"\"\n"), 0o644); err != nil {
+		t.Fatalf("write events config: %v", err)
+	}
+
+	if err := notifyAndMaybeAutoPromoteCandidate(ctx, store, home, candidate, version, ""); err != nil {
+		t.Fatalf("notifyAndMaybeAutoPromoteCandidate returned error: %v", err)
+	}
+
+	// The flush must have delivered the awaiting_promotion event by the time the
+	// helper returned — no post-return sleep needed.
+	if n := delivered.Load(); n != 1 {
+		t.Fatalf("delivered = %d immediately after return, want 1 (the per-invocation sink must flush before exit)", n)
+	}
+	select {
+	case ev := <-got:
+		if ev.Type != events.EventCandidateAwaitingPromotion {
+			t.Fatalf("event type = %q, want candidate.awaiting_promotion", ev.Type)
+		}
+		if ev.JobID != version.ID || ev.RootID != version.TemplateID {
+			t.Fatalf("event ids = %q/%q, want %q/%q", ev.JobID, ev.RootID, version.ID, version.TemplateID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected the delivered awaiting_promotion event")
 	}
 }
 

--- a/internal/cli/candidate_notify_test.go
+++ b/internal/cli/candidate_notify_test.go
@@ -1,0 +1,169 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// candidateNotifyFixture installs a base "planner" template, imports a candidate,
+// and returns the store, the just-pending version, and the candidate package — the
+// shared setup for the #471 notify/auto-promote tests.
+func candidateNotifyFixture(t *testing.T) (*db.Store, db.AgentTemplateVersion, skillopt.CandidatePackage, string) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	candidate := cliSkillOptCandidatePackage(t, "planner", installed.VersionID, "Plan with stronger guidance.")
+	version, err := skillopt.ImportCandidatePackage(context.Background(), store, candidate, "candidate.json")
+	if err != nil {
+		t.Fatalf("ImportCandidatePackage returned error: %v", err)
+	}
+	if version.State != "pending" {
+		t.Fatalf("imported version state = %q, want pending", version.State)
+	}
+	return store, version, candidate, paths.Home
+}
+
+// TestRunCandidateNotifyEmitsAwaitingExactlyOnce proves the shared helper emits
+// EXACTLY ONE candidate.awaiting_promotion carrying the version id (JobID) and
+// template id (RootID), and — with auto_promote off (the default) — NO
+// candidate.auto_promoted and no promotion.
+func TestRunCandidateNotifyEmitsAwaitingExactlyOnce(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	sink := &recordingSink{}
+
+	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, nil); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+
+	awaiting := sink.byType(events.EventCandidateAwaitingPromotion)
+	if len(awaiting) != 1 {
+		t.Fatalf("awaiting_promotion emits = %d, want 1", len(awaiting))
+	}
+	if awaiting[0].JobID != version.ID || awaiting[0].RootID != version.TemplateID {
+		t.Fatalf("awaiting event ids = %q/%q, want %q/%q", awaiting[0].JobID, awaiting[0].RootID, version.ID, version.TemplateID)
+	}
+	if awaiting[0].Status != "awaiting_promotion" {
+		t.Fatalf("awaiting status = %q", awaiting[0].Status)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 0 {
+		t.Fatalf("auto_promoted emits = %d, want 0 (default policy off)", got)
+	}
+	if sink.count() != 1 {
+		t.Fatalf("total emits = %d, want 1 (no double-emit)", sink.count())
+	}
+	// The version stays pending (manual default).
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "pending" {
+		t.Fatalf("version state = %q, want pending (no promotion)", after.State)
+	}
+}
+
+// TestRunCandidateNotifyNilSinkIsNoOp proves the helper is byte-identical when the
+// event stream is OFF: a nil sink emits nothing and the pending row is unchanged.
+func TestRunCandidateNotifyNilSinkIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+
+	if err := runCandidateNotify(ctx, store, nil, config.DefaultSkillOptPolicy(), candidate, version, nil); err != nil {
+		t.Fatalf("runCandidateNotify with nil sink returned error: %v", err)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "pending" {
+		t.Fatalf("version state = %q, want pending", after.State)
+	}
+}
+
+// TestRunSkillOptImportOffByDefaultByteIdentical proves the full `skillopt import`
+// path with [events] AND [skillopt].auto_promote unset writes ONLY the pending
+// version (no promotion, no current change) — the manual, byte-identical default.
+func TestRunSkillOptImportOffByDefaultByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(ctx, cliSkillOptTemplate("planner", "Plan the work.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	before, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	candidate := cliSkillOptCandidatePackage(t, "planner", before.VersionID, "Plan with stronger guidance.")
+	store.Close()
+
+	candidatePath := filepath.Join(t.TempDir(), "candidate.json")
+	writeCandidateJSON(t, candidatePath, candidate)
+
+	var stdout, stderr bytes.Buffer
+	if code := runSkillOptImport([]string{"--home", home, "--file", candidatePath}, &stdout, &stderr); code != 0 {
+		t.Fatalf("runSkillOptImport exit = %d, stderr: %s", code, stderr.String())
+	}
+
+	store2, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("reopen store returned error: %v", err)
+	}
+	defer store2.Close()
+	after, err := store2.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate after import returned error: %v", err)
+	}
+	if after.VersionID != before.VersionID || after.Content != before.Content {
+		t.Fatalf("current template changed by import: before=%q after=%q", before.VersionID, after.VersionID)
+	}
+	pending, err := store2.ListPendingAgentTemplateVersions(ctx, "planner")
+	if err != nil {
+		t.Fatalf("ListPendingAgentTemplateVersions returned error: %v", err)
+	}
+	if len(pending) != 1 || pending[0].State != "pending" {
+		t.Fatalf("expected exactly one pending candidate, got %+v", pending)
+	}
+}
+
+func writeCandidateJSON(t *testing.T, path string, candidate skillopt.CandidatePackage) {
+	t.Helper()
+	encoded, err := json.Marshal(candidate)
+	if err != nil {
+		t.Fatalf("marshal candidate: %v", err)
+	}
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+}

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -56,6 +56,10 @@ type dashboardSnapshot struct {
 	// awaitingHuman carries the tasks paused at awaiting_human (#340) for the
 	// TUI's Attention page. Unexported so --json/--plain stay byte-stable.
 	awaitingHuman []dashboardAwaitingHuman
+	// pendingCandidates carries the SkillOpt template candidates awaiting a
+	// promote/reject decision (#471) for the TUI's Attention page. Unexported so
+	// --json/--plain stay byte-stable.
+	pendingCandidates []dashboardPendingCandidate
 	// daemonDetail carries the persisted daemon flags/workdir and a tail of
 	// recent log errors for the TUI's Health page. Unexported so --json and
 	// the plain renderer stay byte-stable.
@@ -92,6 +96,14 @@ type dashboardAwaitingHuman struct {
 	TaskID string
 	Repo   string
 	Title  string
+}
+
+// dashboardPendingCandidate is one SkillOpt template candidate awaiting a
+// promote/reject decision (#471), shown in the TUI's Attention page.
+type dashboardPendingCandidate struct {
+	VersionID  string
+	TemplateID string
+	Score      string
 }
 
 type dashboardResourceLock struct {
@@ -511,6 +523,20 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 		}
 		for _, lock := range locks {
 			snapshot.BranchLocks = append(snapshot.BranchLocks, dashboardBranchLock{Repo: lock.RepoFullName, Branch: lock.Branch, Owner: lock.Owner})
+		}
+		// Pending SkillOpt candidates awaiting a promote/reject decision (#471), for
+		// the TUI Attention page. Read-only: the existing ListPendingAgentTemplateVersions
+		// + the review row's score, no new query infrastructure.
+		pendingCandidates, err := store.ListPendingAgentTemplateVersions(ctx, "")
+		if err != nil {
+			return err
+		}
+		for _, version := range pendingCandidates {
+			entry := dashboardPendingCandidate{VersionID: version.ID, TemplateID: version.TemplateID}
+			if review, err := store.GetAgentTemplateCandidateReview(ctx, version.ID); err == nil && review.Score != nil {
+				entry.Score = fmt.Sprintf("%.4g", *review.Score)
+			}
+			snapshot.pendingCandidates = append(snapshot.pendingCandidates, entry)
 		}
 		trainSessions, err := store.ListSkillOptTrainSessions(ctx)
 		if err != nil {

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -587,6 +587,9 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 	for _, t := range s.awaitingHuman {
 		out.AwaitingHuman = append(out.AwaitingHuman, tui.AwaitingHumanTask{TaskID: t.TaskID, Repo: t.Repo, Title: t.Title})
 	}
+	for _, c := range s.pendingCandidates {
+		out.PendingCandidates = append(out.PendingCandidates, tui.PendingCandidate{VersionID: c.VersionID, TemplateID: c.TemplateID, Score: c.Score})
+	}
 	out.Activity = buildDashboardActivity(jobs)
 	return out
 }

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -10173,6 +10173,13 @@ func importSkillOptTrainCandidate(ctx context.Context, paths config.Paths, store
 	if err != nil {
 		return db.AgentTemplateVersion{}, fmt.Errorf("import optimizer candidate package: %w", err)
 	}
+	// Notify + (config-gated) auto-promote on the just-pending version (#471). The
+	// import write above stays side-effect-pure; this is the separate post-import
+	// step both CLI callers share. The train iteration carries the eval_run id whose
+	// feedback events feed the min_samples / external-CI guardrails.
+	if err := notifyAndMaybeAutoPromoteCandidate(ctx, store, paths.Home, candidate, version, iteration.EvalRunID); err != nil {
+		return db.AgentTemplateVersion{}, err
+	}
 	return version, nil
 }
 
@@ -11346,7 +11353,12 @@ func runSkillOptImport(args []string, stdout, stderr io.Writer) int {
 			return err
 		}
 		versionID = version.ID
-		return nil
+		// Notify + (config-gated) auto-promote on the just-pending version (#471). The
+		// import write above stays side-effect-pure; this is the separate post-import
+		// step. A plain `skillopt import` has no train iteration, so no eval_run id is
+		// resolvable — auto-promote fails safe to notify-only (a sparse import never
+		// auto-promotes), but candidate.awaiting_promotion still fires.
+		return notifyAndMaybeAutoPromoteCandidate(context.Background(), store, paths.Home, pkg, version, "")
 	}); err != nil {
 		fmt.Fprintf(stderr, "skillopt import: %v\n", err)
 		return 1

--- a/internal/cli/tui/attention.go
+++ b/internal/cli/tui/attention.go
@@ -287,6 +287,22 @@ func (m Model) attentionListRows() []listRow {
 		}
 	}
 
+	// Pending candidates (#471): SkillOpt template candidates awaiting a
+	// promote/reject decision. Display-only (the verb lives on `gitmoot skillopt
+	// candidate promote|reject`), so these are static rows next to Awaiting human,
+	// visible locally even when [events] is off.
+	if n := len(m.snap.PendingCandidates); n > 0 {
+		rows = append(rows, staticRow(0, "Pending candidates ("+strconv.Itoa(n)+")"))
+		for _, c := range m.snap.PendingCandidates {
+			line := "candidate " + c.VersionID + "  template " + c.TemplateID
+			if strings.TrimSpace(c.Score) != "" {
+				line += "  " + mutedStyle.Render("score "+c.Score)
+			}
+			rows = append(rows, staticRow(1, line))
+			rows = append(rows, staticRow(2, mutedStyle.Render("decide: gitmoot skillopt candidate promote|reject "+c.VersionID)))
+		}
+	}
+
 	// Locks are display-only context (no actions), shown as static lines.
 	if stale := staleLocks(m.snap.ResourceLocks); len(stale) > 0 {
 		rows = append(rows, staticRow(0, "Stale locks ("+strconv.Itoa(len(stale))+")"))

--- a/internal/cli/tui/attention_test.go
+++ b/internal/cli/tui/attention_test.go
@@ -337,6 +337,30 @@ func TestAttentionShowsAwaitingHuman(t *testing.T) {
 	}
 }
 
+// TestAttentionShowsPendingCandidates proves a pending SkillOpt candidate (#471)
+// renders on the Attention page next to AwaitingHumanTask, with its version id,
+// template id, score, and the decide hint; zero candidates renders unchanged.
+func TestAttentionShowsPendingCandidates(t *testing.T) {
+	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
+	snap := Snapshot{
+		Daemon:            Daemon{Running: true},
+		PendingCandidates: []PendingCandidate{{VersionID: "planner:v7", TemplateID: "planner", Score: "0.96"}},
+	}
+	m := attentionModel(t, deps, snap)
+	view := m.View()
+	for _, want := range []string{"Pending candidates (1)", "planner:v7", "template planner", "score 0.96", "skillopt candidate promote|reject"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected %q in attention view:\n%s", want, view)
+		}
+	}
+
+	// Zero pending candidates: no Pending candidates header.
+	empty := attentionModel(t, deps, Snapshot{Daemon: Daemon{Running: true}})
+	if strings.Contains(empty.View(), "Pending candidates") {
+		t.Fatalf("empty candidate list should not render the header:\n%s", empty.View())
+	}
+}
+
 func TestAttentionCursorClampedOnRefresh(t *testing.T) {
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	m := attentionModel(t, deps, promptSnap(choicePrompt(), textPrompt()))

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -17,22 +17,23 @@ import (
 // dashboardSnapshot. Prompts carries the full interactive-prompt records (not
 // just id/question) so the Attention page can answer them inline.
 type Snapshot struct {
-	Home           string
-	DatabaseExists bool
-	Daemon         Daemon
-	Repos          []Repo
-	Agents         []Agent
-	Sessions       []Session
-	Jobs           Jobs
-	Worktrees      []Worktree
-	BranchLocks    []BranchLock
-	Trains         []TrainSession
-	ResourceLocks  []ResourceLock
-	Prompts        []db.InteractivePrompt
-	JobRows        []JobRow
-	AwaitingHuman  []AwaitingHumanTask
-	Activity       []ActivityRoot
-	Config         ConfigView
+	Home              string
+	DatabaseExists    bool
+	Daemon            Daemon
+	Repos             []Repo
+	Agents            []Agent
+	Sessions          []Session
+	Jobs              Jobs
+	Worktrees         []Worktree
+	BranchLocks       []BranchLock
+	Trains            []TrainSession
+	ResourceLocks     []ResourceLock
+	Prompts           []db.InteractivePrompt
+	JobRows           []JobRow
+	AwaitingHuman     []AwaitingHumanTask
+	PendingCandidates []PendingCandidate
+	Activity          []ActivityRoot
+	Config            ConfigView
 }
 
 // AwaitingHumanTask is one delegation tree paused at awaiting_human (#340), shown
@@ -41,6 +42,16 @@ type AwaitingHumanTask struct {
 	TaskID string
 	Repo   string
 	Title  string
+}
+
+// PendingCandidate is one SkillOpt template candidate awaiting a promote/reject
+// decision (#471), shown on the Attention page next to AwaitingHumanTask so a
+// candidate is locally visible even when [events] is off. VersionID is the pending
+// agent_template_version id; Score is the review row's score (empty when absent).
+type PendingCandidate struct {
+	VersionID  string
+	TemplateID string
+	Score      string
 }
 
 // ActivityRoot is one live delegation tree on the Activity page: a root

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -71,13 +71,20 @@ escalation_ttl = ""
 # A pending candidate ALWAYS emits candidate.awaiting_promotion when [events] is
 # configured, independent of auto_promote; a successful auto-promote additionally
 # emits candidate.auto_promoted so a human can review or roll back.
+# The guardrails read the candidate's HARVESTER auto-trace run
+# (auto-trace:<version_id>), NOT the human/markdown review run. A feedback read
+# error or unresolvable run fails safe to notify-only, and ZERO samples is always a
+# hard do-not-promote regardless of the min below.
 #   auto_promote_min_samples: minimum feedback-event count in the candidate's
-#     eval_run. UNSET is a HARD "do not promote" (never 0) — flipping auto_promote
-#     on without this never promotes.
+#     auto-trace run. UNSET is a HARD "do not promote" (never 0) — flipping
+#     auto_promote on without this never promotes. Even an explicit 0 cannot promote
+#     a zero-evidence candidate (absolute floor of at least one sample).
 #   auto_promote_min_score: minimum candidate score. UNSET, or a candidate with no
 #     score, is a HARD "do not promote".
-#   auto_promote_require_external_ci: require at least one eval_run feedback event
-#     to record a merge that passed GENUINE external CI (not the no-CI band).
+#   auto_promote_require_external_ci: require at least one auto-trace feedback event
+#     to record a merge that passed GENUINE external CI (not the no-CI band). Keys
+#     off the harvester's provenance so only Mode A (auto-trace) evidence counts and
+#     a cross-family review row cannot spoof it.
 #   auto_promote_require_measured_judge: PARSED but DEFERRED (gated on #344) — there
 #     is no judge<->human calibration source yet, so when true it FAILS SAFE to
 #     notify-only.

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -60,6 +60,39 @@ cockpit_pane_key = "job"
 escalation_handle = ""
 escalation_ttl = ""
 
+# [skillopt] is the OFF-BY-DEFAULT template-learning policy (#465 Mode A, #471).
+# With no [skillopt] section behavior is byte-identical: no trace harvesting, no
+# event emission, and promotion stays fully MANUAL. auto_trace_enabled opts the
+# daemon into harvesting an implement job's verifiable terminal outcome into a
+# synthetic feedback event; cross_family_review_enabled (requires auto_trace) adds
+# a down-weighted cross-family review soft signal. auto_promote (#471) opts into
+# AUTO-PROMOTING a newly-pending candidate, but ONLY when every configured
+# guardrail below holds — any uncertainty fails safe to notify-only (no promote).
+# A pending candidate ALWAYS emits candidate.awaiting_promotion when [events] is
+# configured, independent of auto_promote; a successful auto-promote additionally
+# emits candidate.auto_promoted so a human can review or roll back.
+#   auto_promote_min_samples: minimum feedback-event count in the candidate's
+#     eval_run. UNSET is a HARD "do not promote" (never 0) — flipping auto_promote
+#     on without this never promotes.
+#   auto_promote_min_score: minimum candidate score. UNSET, or a candidate with no
+#     score, is a HARD "do not promote".
+#   auto_promote_require_external_ci: require at least one eval_run feedback event
+#     to record a merge that passed GENUINE external CI (not the no-CI band).
+#   auto_promote_require_measured_judge: PARSED but DEFERRED (gated on #344) — there
+#     is no judge<->human calibration source yet, so when true it FAILS SAFE to
+#     notify-only.
+#   auto_promote_canary: PARSED but DEFERRED (canary follow-on) — sampled traffic +
+#     auto-rollback do not exist yet, so when true it FAILS SAFE to notify-only.
+# [skillopt]
+# auto_trace_enabled = false
+# cross_family_review_enabled = false
+# auto_promote = false
+# auto_promote_min_samples = 0
+# auto_promote_min_score = 0.0
+# auto_promote_require_external_ci = false
+# auto_promote_require_measured_judge = false
+# auto_promote_canary = false
+
 # [admission] is an OPT-IN, off-by-default host-global concurrency budget the
 # daemon applies BEFORE starting each agent session, on top of --workers/pool
 # and the per-repo checkout / runtime-session locks (issue #365). With both caps

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -389,12 +389,50 @@ type SkillOptPolicy struct {
 	// run); ReviewEnabled() encodes that dependency. A live cross-family LLM review
 	// per merge is a real cost surface, so it must be opt-in.
 	CrossFamilyReviewEnabled bool
+
+	// AutoPromote opts into the off-by-default auto-promote policy (#471): when
+	// false (the default) a newly-pending candidate is ONLY notified
+	// (candidate.awaiting_promotion) and NEVER auto-promoted — promotion stays
+	// 100% manual, byte-identical to today. When true, a candidate is auto-promoted
+	// (the existing PromoteAgentTemplateVersion + a candidate.auto_promoted event)
+	// ONLY when every configured guardrail below holds; ANY uncertainty fails safe
+	// to notify-don't-promote.
+	AutoPromote bool
+
+	// AutoPromoteMinSamples is the minimum count of feedback_events in the
+	// candidate's eval_run required to auto-promote. nil (unset) is a HARD
+	// "do not promote" — flipping AutoPromote on without a threshold never promotes.
+	AutoPromoteMinSamples *int
+	// AutoPromoteMinScore is the minimum candidate Summary.Score required to
+	// auto-promote. nil (unset) is a HARD "do not promote"; a nil candidate score
+	// also fails safe.
+	AutoPromoteMinScore *float64
+	// AutoPromoteRequireExternalCI requires at least one feedback event in the
+	// candidate's eval_run to be a real-CI positive (a merge that passed genuine
+	// external CI, not the no-CI near-neutral band). When true and no such event is
+	// present, the candidate is not promoted.
+	AutoPromoteRequireExternalCI bool
+
+	// AutoPromoteRequireMeasuredJudge is PARSED but DEFERRED (#471 / gated on #344):
+	// there is no judge<->human calibration source yet, so when true it FAILS SAFE
+	// to notify-don't-promote. Documented so a user can set it forward-compatibly.
+	AutoPromoteRequireMeasuredJudge bool
+	// AutoPromoteCanary is PARSED but DEFERRED (#471 canary follow-on): the sampled
+	// traffic + regression-window infrastructure does not exist yet, so when true it
+	// FAILS SAFE to notify-don't-promote. Documented as deferred.
+	AutoPromoteCanary bool
 }
 
 func DefaultSkillOptPolicy() SkillOptPolicy {
 	return SkillOptPolicy{
-		AutoTraceEnabled:         false,
-		CrossFamilyReviewEnabled: false,
+		AutoTraceEnabled:                false,
+		CrossFamilyReviewEnabled:        false,
+		AutoPromote:                     false,
+		AutoPromoteMinSamples:           nil,
+		AutoPromoteMinScore:             nil,
+		AutoPromoteRequireExternalCI:    false,
+		AutoPromoteRequireMeasuredJudge: false,
+		AutoPromoteCanary:               false,
 	}
 }
 
@@ -452,6 +490,36 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 	case "cross_family_review_enabled":
 		parsed, err := strconv.ParseBool(value)
 		policy.CrossFamilyReviewEnabled = parsed
+		return err
+	case "auto_promote":
+		parsed, err := strconv.ParseBool(value)
+		policy.AutoPromote = parsed
+		return err
+	case "auto_promote_min_samples":
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		policy.AutoPromoteMinSamples = &parsed
+		return nil
+	case "auto_promote_min_score":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		policy.AutoPromoteMinScore = &parsed
+		return nil
+	case "auto_promote_require_external_ci":
+		parsed, err := strconv.ParseBool(value)
+		policy.AutoPromoteRequireExternalCI = parsed
+		return err
+	case "auto_promote_require_measured_judge":
+		parsed, err := strconv.ParseBool(value)
+		policy.AutoPromoteRequireMeasuredJudge = parsed
+		return err
+	case "auto_promote_canary":
+		parsed, err := strconv.ParseBool(value)
+		policy.AutoPromoteCanary = parsed
 		return err
 	default:
 		return nil

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -112,6 +112,77 @@ cross_family_review_enabled = true
 	}
 }
 
+// TestLoadSkillOptPolicyAutoPromoteDefaultsOff proves auto_promote and its
+// thresholds default OFF/unset (#471): the manual flow, byte-identical. An unset
+// threshold is nil (a hard do-not-promote), never 0.
+func TestLoadSkillOptPolicyAutoPromoteDefaultsOff(t *testing.T) {
+	policy := DefaultSkillOptPolicy()
+	if policy.AutoPromote {
+		t.Fatalf("auto_promote must default false, got %+v", policy)
+	}
+	if policy.AutoPromoteMinSamples != nil || policy.AutoPromoteMinScore != nil {
+		t.Fatalf("auto_promote thresholds must default nil (unset), got %+v", policy)
+	}
+	if policy.AutoPromoteRequireExternalCI || policy.AutoPromoteRequireMeasuredJudge || policy.AutoPromoteCanary {
+		t.Fatalf("auto_promote guardrail flags must default false, got %+v", policy)
+	}
+}
+
+// TestLoadSkillOptPolicyParsesAutoPromote proves every new auto_promote_* key
+// parses into the policy (including the deferred-but-parsed knobs).
+func TestLoadSkillOptPolicyParsesAutoPromote(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_promote = true
+auto_promote_min_samples = 5
+auto_promote_min_score = 0.9
+auto_promote_require_external_ci = true
+auto_promote_require_measured_judge = true
+auto_promote_canary = true
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.AutoPromote {
+		t.Fatal("auto_promote = true should parse")
+	}
+	if policy.AutoPromoteMinSamples == nil || *policy.AutoPromoteMinSamples != 5 {
+		t.Fatalf("auto_promote_min_samples = %v, want 5", policy.AutoPromoteMinSamples)
+	}
+	if policy.AutoPromoteMinScore == nil || *policy.AutoPromoteMinScore != 0.9 {
+		t.Fatalf("auto_promote_min_score = %v, want 0.9", policy.AutoPromoteMinScore)
+	}
+	if !policy.AutoPromoteRequireExternalCI || !policy.AutoPromoteRequireMeasuredJudge || !policy.AutoPromoteCanary {
+		t.Fatalf("deferred/external-ci guardrail flags should parse, got %+v", policy)
+	}
+}
+
+// TestLoadSkillOptPolicyRejectsBadAutoPromoteThreshold proves a garbled numeric
+// threshold surfaces a parse error (fail-safe: the policy is not silently kept).
+func TestLoadSkillOptPolicyRejectsBadAutoPromoteThreshold(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_promote = true
+auto_promote_min_samples = lots
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadSkillOptPolicy(paths); err == nil {
+		t.Fatal("expected an error for a non-integer auto_promote_min_samples")
+	}
+}
+
 // TestLoadSkillOptPolicyIgnoresOtherSections proves a config that only sets
 // [events]/[orchestrate] leaves the trace-harvester at its disabled default.
 func TestLoadSkillOptPolicyIgnoresOtherSections(t *testing.T) {

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -157,6 +157,31 @@ func EmitEvent(ctx context.Context, sink Sink, event Event) {
 	sink.Emit(ctx, event)
 }
 
+// Flusher is the OPTIONAL drain-and-wait extension a Sink may implement when its
+// Emit is asynchronous (the webhook sink hands events to a background goroutine).
+// Flush blocks — bounded — until the already-enqueued events are delivered, so a
+// SHORT-LIVED caller (a CLI command) does not exit and destroy them before the
+// goroutine runs. The long-lived engine/daemon never need it; only per-invocation
+// sinks do. A synchronous Sink need not implement it.
+type Flusher interface {
+	Flush(ctx context.Context)
+}
+
+// FlushSink drains a sink that implements Flusher and is a no-op for a nil sink or
+// a synchronous one (so callers can defer it unconditionally over a sink that may
+// be nil when [events] is OFF). It is the seam a short-lived CLI command uses to
+// guarantee a candidate.* webhook POST lands before the process exits. The daemon,
+// which shares one long-lived cached sink for the whole process, must NOT call it
+// per-invocation.
+func FlushSink(ctx context.Context, sink Sink) {
+	if sink == nil {
+		return
+	}
+	if f, ok := sink.(Flusher); ok {
+		f.Flush(ctx)
+	}
+}
+
 func redactString(value string, redact RedactFunc) string {
 	if redact == nil {
 		return value

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -47,6 +47,21 @@ const (
 	// carries the redacted question.
 	EventJobNeedsAttention EventType = "job.needs_attention"
 
+	// EventCandidateAwaitingPromotion is emitted once when a SkillOpt template
+	// candidate becomes PENDING (the post-import notify, #471): a new pending
+	// agent_template_version is awaiting a human (or auto-promote) decision. JobID
+	// is the pending version id, RootID the template id, Status "awaiting_promotion",
+	// Detail a redacted score/samples/CI reason. Always emitted (when [events] is
+	// configured) independent of the auto-promote policy.
+	EventCandidateAwaitingPromotion EventType = "candidate.awaiting_promotion"
+	// EventCandidateAutoPromoted is emitted once when the off-by-default
+	// [skillopt].auto_promote policy auto-promotes a pending candidate to current
+	// (#471), AFTER the existing PromoteAgentTemplateVersion write. JobID is the
+	// promoted version id, RootID the template id, Status "auto_promoted", Detail a
+	// redacted reason naming the guardrails that passed, so a human can review or
+	// roll back even in full-auto.
+	EventCandidateAutoPromoted EventType = "candidate.auto_promoted"
+
 	// Reserved for the graduate step (parsed/enumerated but NOT emitted by the
 	// pilot). Listed so downstream consumers can switch over them forward-
 	// compatibly without a schema bump when they start arriving.

--- a/internal/events/sink_test.go
+++ b/internal/events/sink_test.go
@@ -52,14 +52,16 @@ func TestNewEventContractShape(t *testing.T) {
 
 func TestEventTypeEnumValues(t *testing.T) {
 	cases := map[EventType]string{
-		EventJobFinished:           "job.finished",
-		EventJobFailed:             "job.failed",
-		EventJobBlocked:            "job.blocked",
-		EventJobNeedsAttention:     "job.needs_attention",
-		EventJobStarted:            "job.started",
-		EventDelegationEscalation:  "delegation.escalation",
-		EventDelegationFinalized:   "delegation.finalized",
-		EventOrchestrationFinished: "orchestration.finished",
+		EventJobFinished:                "job.finished",
+		EventJobFailed:                  "job.failed",
+		EventJobBlocked:                 "job.blocked",
+		EventJobNeedsAttention:          "job.needs_attention",
+		EventCandidateAwaitingPromotion: "candidate.awaiting_promotion",
+		EventCandidateAutoPromoted:      "candidate.auto_promoted",
+		EventJobStarted:                 "job.started",
+		EventDelegationEscalation:       "delegation.escalation",
+		EventDelegationFinalized:        "delegation.finalized",
+		EventOrchestrationFinished:      "orchestration.finished",
 	}
 	for typ, want := range cases {
 		if string(typ) != want {
@@ -147,6 +149,29 @@ func TestNewEventRepoIsOwnerRepoOnly(t *testing.T) {
 		if ev.Repo != want {
 			t.Fatalf("ownerRepoOnly(%q) -> %q, want %q", in, ev.Repo, want)
 		}
+	}
+}
+
+// TestNewEventCandidateDetailRedactedAndScrubbed proves a candidate.* event's
+// Detail is redacted (secret) and path-scrubbed (no absolute path) like every
+// other emit site, and SchemaVersion stays 1 for the additive enum values (#471).
+func TestNewEventCandidateDetailRedactedAndScrubbed(t *testing.T) {
+	redact := func(s string) string {
+		return strings.ReplaceAll(s, "ghp_secretsecretsecret", "[REDACTED]")
+	}
+	detail := "candidate agent-template:foo:v7 promoted from /root/.gitmoot/evals/run; token ghp_secretsecretsecret"
+	ev := NewEvent(EventCandidateAutoPromoted, "agent-template:foo:v7", "agent-template:foo", "", "auto_promoted", detail, time.Now(), redact)
+	if ev.SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d, want 1 (additive enum, no bump)", ev.SchemaVersion)
+	}
+	if strings.Contains(ev.Detail, "ghp_secretsecretsecret") {
+		t.Fatalf("candidate detail not redacted: %q", ev.Detail)
+	}
+	if strings.Contains(ev.Detail, "/root/.gitmoot/evals/run") {
+		t.Fatalf("candidate detail absolute path not scrubbed: %q", ev.Detail)
+	}
+	if ev.JobID != "agent-template:foo:v7" || ev.RootID != "agent-template:foo" {
+		t.Fatalf("candidate event ids = %q/%q, want version/template id", ev.JobID, ev.RootID)
 	}
 }
 

--- a/internal/events/webhook.go
+++ b/internal/events/webhook.go
@@ -6,8 +6,16 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 )
+
+// DefaultWebhookFlushTimeout bounds how long Flush waits for the drain goroutine
+// to deliver the already-queued events before a short-lived caller (a CLI command)
+// returns. It is generous relative to a single POST (DefaultWebhookTimeout) so a
+// small queue drains, but still bounded so a hung consumer can never wedge the
+// process on exit.
+const DefaultWebhookFlushTimeout = 5 * time.Second
 
 // DefaultWebhookTimeout bounds a single outbound POST so a hung consumer can
 // never stall the drain goroutine indefinitely. It is the fallback when
@@ -31,6 +39,16 @@ type webhookSink struct {
 	url    string
 	client *http.Client
 	queue  chan queued
+	// done is closed by the drain goroutine when it has finished delivering every
+	// queued event (i.e. after queue is closed and emptied). Flush waits on it.
+	done chan struct{}
+	// closeOnce guards the single queue close so Flush is idempotent and a
+	// post-Flush Emit can never panic by sending on a closed channel.
+	closeOnce sync.Once
+	// closed is set under mu when the queue has been closed; Emit reads it to drop
+	// (rather than send on a closed channel) after a Flush.
+	mu     sync.Mutex
+	closed bool
 	// OnDrop, when set, is called best-effort when an event is dropped (full
 	// buffer or transport failure). The daemon wires it to record a single
 	// event_sink_drop job event. It must itself be non-blocking/best-effort.
@@ -57,6 +75,7 @@ func NewWebhookSink(url string, timeout time.Duration) *webhookSink {
 		url:    url,
 		client: &http.Client{Timeout: timeout},
 		queue:  make(chan queued, defaultWebhookBuffer),
+		done:   make(chan struct{}),
 	}
 	go s.drain()
 	return s
@@ -70,6 +89,14 @@ func (s *webhookSink) Emit(ctx context.Context, event Event) {
 	if s == nil {
 		return
 	}
+	// After Flush has closed the queue a send would panic; drop instead. Holding mu
+	// across the send keeps the closeOnce in Flush from racing the send.
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		s.dropped(event, "sink flushed")
+		return
+	}
 	select {
 	case s.queue <- queued{event: event}:
 	case <-ctx.Done():
@@ -78,6 +105,39 @@ func (s *webhookSink) Emit(ctx context.Context, event Event) {
 		// Buffer full: drop rather than block the caller.
 		s.dropped(event, "buffer full")
 	}
+	s.mu.Unlock()
+}
+
+// Flush closes the queue and waits — bounded by ctx and DefaultWebhookFlushTimeout
+// — for the drain goroutine to deliver every already-enqueued event, then returns.
+// It is the synchronous counterpart to the fire-and-forget Emit, for SHORT-LIVED
+// callers (a CLI command) that would otherwise exit and destroy the queued POSTs
+// before the background goroutine runs. It is idempotent (safe to call twice / via
+// defer) and nil-safe. The daemon, which reuses one long-lived cached sink across
+// the whole process, must NEVER Flush per-call — only the per-invocation CLI sink
+// is flushed.
+func (s *webhookSink) Flush(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	// Close the queue exactly once so drain can range to completion; guard with mu
+	// so a concurrent Emit drops instead of sending on the closed channel.
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		s.closed = true
+		close(s.queue)
+		s.mu.Unlock()
+	})
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timer := time.NewTimer(DefaultWebhookFlushTimeout)
+	defer timer.Stop()
+	select {
+	case <-s.done:
+	case <-ctx.Done():
+	case <-timer.C:
+	}
 }
 
 // drain is the single goroutine that serializes delivery. Running one goroutine
@@ -85,6 +145,7 @@ func (s *webhookSink) Emit(ctx context.Context, event Event) {
 // channel the only synchronization point, so concurrent Emit from many workers
 // is race-clean.
 func (s *webhookSink) drain() {
+	defer close(s.done)
 	for q := range s.queue {
 		s.post(q.event)
 	}

--- a/internal/events/webhook_test.go
+++ b/internal/events/webhook_test.go
@@ -159,6 +159,72 @@ func TestWebhookSinkRefusedConnectionDropsWithoutError(t *testing.T) {
 	}
 }
 
+// TestWebhookSinkFlushDeliversQueuedEvent proves the HIGH #471 fix: a SHORT-LIVED
+// caller (a CLI command) that Emits and then Flushes sees the queued POST land
+// before Flush returns — without Flush the process would exit and destroy the
+// event. The handler is gated so the event provably is NOT delivered at Emit time
+// and only completes because Flush waits on the drain goroutine.
+func TestWebhookSinkFlushDeliversQueuedEvent(t *testing.T) {
+	var delivered atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		delivered.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := NewWebhookSink(srv.URL, time.Second)
+	sink.Emit(context.Background(), NewEvent(EventCandidateAwaitingPromotion, "ver-1", "tmpl-1", "", "awaiting_promotion", "candidate awaiting", time.Now(), nil))
+
+	sink.Flush(context.Background())
+	if got := delivered.Load(); got != 1 {
+		t.Fatalf("after Flush delivered = %d, want 1 (the queued event must POST before Flush returns)", got)
+	}
+}
+
+// TestWebhookSinkFlushIsIdempotentAndDropsLateEmit proves Flush can be called
+// twice (e.g. via defer) without panicking on a double-close, and that an Emit
+// arriving AFTER Flush drops (rather than panicking by sending on the closed
+// queue).
+func TestWebhookSinkFlushIsIdempotentAndDropsLateEmit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := NewWebhookSink(srv.URL, time.Second)
+	dropped := make(chan string, 1)
+	sink.OnDrop = func(_ Event, reason string) { dropped <- reason }
+
+	sink.Flush(context.Background())
+	sink.Flush(context.Background()) // second call must not panic (double-close guard)
+
+	// A post-Flush Emit must drop, not panic on a closed channel.
+	sink.Emit(context.Background(), NewEvent(EventCandidateAutoPromoted, "ver-2", "tmpl-2", "", "auto_promoted", "", time.Now(), nil))
+	select {
+	case reason := <-dropped:
+		if reason != "sink flushed" {
+			t.Fatalf("late-Emit drop reason = %q, want sink flushed", reason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("a post-Flush Emit should have dropped")
+	}
+}
+
+// TestFlushSinkNilAndNonFlusherAreNoOps proves the FlushSink helper is safe to
+// defer unconditionally: a nil sink and a synchronous (non-Flusher) sink are both
+// no-ops, so the CLI can `defer events.FlushSink(ctx, sink)` over a sink that may
+// be nil when [events] is OFF.
+func TestFlushSinkNilAndNonFlusherAreNoOps(t *testing.T) {
+	FlushSink(context.Background(), nil)           // must not panic
+	FlushSink(context.Background(), &syncTestSink{}) // non-Flusher: no-op, must not panic
+}
+
+// syncTestSink is a minimal synchronous Sink that does NOT implement Flusher, to
+// prove FlushSink degrades to a no-op for such sinks.
+type syncTestSink struct{}
+
+func (s *syncTestSink) Emit(context.Context, Event) {}
+
 func TestWebhookSinkConcurrentEmitIsRaceClean(t *testing.T) {
 	var count int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/skillopt/auto_promote.go
+++ b/internal/skillopt/auto_promote.go
@@ -38,10 +38,17 @@ func notifyOnly(reason string) AutoPromoteDecision {
 //
 // FAIL-SAFE DISCIPLINE (every uncertainty returns Promote=false):
 //   - policy.AutoPromote off (the default) -> notify only (manual, byte-identical).
+//   - feedbackUnavailable=true (the caller could not resolve/read the eval_run, e.g.
+//     a ListFeedbackEvents error or a missing run id) -> hard do-not-promote: we can
+//     never promote on evidence we failed to read, regardless of the configured
+//     min_samples floor.
 //   - require_measured_judge=true -> DEFERRED (#344): no judge<->human calibration
 //     source exists, so honoring it now would lie; fail safe.
 //   - canary=true -> DEFERRED (canary follow-on): the sampled-traffic + regression
 //     infrastructure does not exist; fail safe.
+//   - ZERO feedback samples -> a HARD do-not-promote (an absolute floor of at least
+//     one real sample), even when min_samples is explicitly 0: we never promote on
+//     zero verifiable evidence.
 //   - min_samples unset (nil) -> a HARD do-not-promote, NOT 0 (a user who flips
 //     auto_promote without a sample floor must never promote a sparse candidate).
 //   - min_score unset (nil) OR a nil candidate Summary.Score -> hard do-not-promote.
@@ -49,9 +56,16 @@ func notifyOnly(reason string) AutoPromoteDecision {
 //
 // On a pass the reason names the guardrails that held (score, samples, external CI)
 // so the candidate.auto_promoted event explains the decision.
-func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackage, feedbackEvents []db.FeedbackEvent) AutoPromoteDecision {
+func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackage, feedbackEvents []db.FeedbackEvent, feedbackUnavailable bool) AutoPromoteDecision {
 	if !policy.AutoPromote {
 		return notifyOnly("auto_promote is off; notify only (manual promotion)")
+	}
+
+	// A read error or an unresolvable eval_run is uncertainty, not "zero samples":
+	// promoting on evidence we could not read would defeat every downstream
+	// guardrail, so fail safe outright.
+	if feedbackUnavailable {
+		return notifyOnly("candidate eval_run feedback is unavailable (unresolved run or read error); notify only")
 	}
 
 	// Deferred knobs (#471): parsed for forward-compat, but they have no honest
@@ -70,6 +84,13 @@ func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackag
 		return notifyOnly("auto_promote_min_samples is not set; refusing to promote without a sample floor (notify only)")
 	}
 	samples := len(feedbackEvents)
+	// Absolute floor: a configured auto_promote_min_samples=0 is a LEGAL value, but
+	// `0 < 0` is false, so without this an explicit 0 would let a zero-evidence
+	// candidate promote. We never auto-promote on zero verifiable samples regardless
+	// of the configured minimum.
+	if samples == 0 {
+		return notifyOnly("no eval_run feedback samples; refusing to auto-promote on zero evidence (notify only)")
+	}
 	if samples < *policy.AutoPromoteMinSamples {
 		return notifyOnly(fmt.Sprintf("only %d feedback sample(s), below auto_promote_min_samples=%d; notify only", samples, *policy.AutoPromoteMinSamples))
 	}

--- a/internal/skillopt/auto_promote.go
+++ b/internal/skillopt/auto_promote.go
@@ -1,0 +1,116 @@
+package skillopt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// AutoPromoteDecision is the pure, total result of EvaluateAutoPromote (#471): a
+// promote/notify-only verdict plus a human-readable reason that travels into the
+// candidate.* event Detail. Promote is true ONLY when EVERY configured, checkable
+// guardrail held; any uncertainty (off, nil score, unset threshold, deferred
+// knob, …) returns Promote=false with a reason explaining why — the fail-safe
+// "notify, don't promote" path.
+type AutoPromoteDecision struct {
+	// Promote is true only when the policy is on AND every configured guardrail
+	// passed; false is the always-safe default.
+	Promote bool
+	// Reason is a short, human-facing explanation (named guardrails on a pass; the
+	// first blocking reason on a fail). It is redacted/path-scrubbed at the event
+	// seam before it leaves the box.
+	Reason string
+}
+
+// notifyOnly is the canonical fail-safe decision: never promote, carry the reason.
+func notifyOnly(reason string) AutoPromoteDecision {
+	return AutoPromoteDecision{Promote: false, Reason: reason}
+}
+
+// EvaluateAutoPromote is the pure, deterministic, total auto-promote guardrail
+// evaluator (#471). It takes the host [skillopt] policy, the just-imported
+// candidate package, and the feedback events of the candidate's eval_run, and
+// returns a promote/notify-only decision + reason. It performs NO I/O and NEVER
+// mutates state: the CLI helper resolves the eval_run, calls this, and only on a
+// Promote=true result invokes the EXISTING PromoteAgentTemplateVersion.
+//
+// FAIL-SAFE DISCIPLINE (every uncertainty returns Promote=false):
+//   - policy.AutoPromote off (the default) -> notify only (manual, byte-identical).
+//   - require_measured_judge=true -> DEFERRED (#344): no judge<->human calibration
+//     source exists, so honoring it now would lie; fail safe.
+//   - canary=true -> DEFERRED (canary follow-on): the sampled-traffic + regression
+//     infrastructure does not exist; fail safe.
+//   - min_samples unset (nil) -> a HARD do-not-promote, NOT 0 (a user who flips
+//     auto_promote without a sample floor must never promote a sparse candidate).
+//   - min_score unset (nil) OR a nil candidate Summary.Score -> hard do-not-promote.
+//   - require_external_ci=true with no real-CI positive in the run -> do not promote.
+//
+// On a pass the reason names the guardrails that held (score, samples, external CI)
+// so the candidate.auto_promoted event explains the decision.
+func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackage, feedbackEvents []db.FeedbackEvent) AutoPromoteDecision {
+	if !policy.AutoPromote {
+		return notifyOnly("auto_promote is off; notify only (manual promotion)")
+	}
+
+	// Deferred knobs (#471): parsed for forward-compat, but they have no honest
+	// implementation yet, so when set they force the safe path.
+	if policy.AutoPromoteRequireMeasuredJudge {
+		return notifyOnly("auto_promote_require_measured_judge is set but judge calibration is unavailable (deferred, #344); notify only")
+	}
+	if policy.AutoPromoteCanary {
+		return notifyOnly("auto_promote_canary is set but canary promotion is deferred; notify only")
+	}
+
+	passed := make([]string, 0, 3)
+
+	// Guardrail: min_samples. Unset is a hard do-not-promote, never 0.
+	if policy.AutoPromoteMinSamples == nil {
+		return notifyOnly("auto_promote_min_samples is not set; refusing to promote without a sample floor (notify only)")
+	}
+	samples := len(feedbackEvents)
+	if samples < *policy.AutoPromoteMinSamples {
+		return notifyOnly(fmt.Sprintf("only %d feedback sample(s), below auto_promote_min_samples=%d; notify only", samples, *policy.AutoPromoteMinSamples))
+	}
+	passed = append(passed, fmt.Sprintf("%d samples >= %d", samples, *policy.AutoPromoteMinSamples))
+
+	// Guardrail: min_score. Unset, or a nil candidate score, is a hard do-not-promote.
+	if policy.AutoPromoteMinScore == nil {
+		return notifyOnly("auto_promote_min_score is not set; refusing to promote without a score floor (notify only)")
+	}
+	if candidate.Summary.Score == nil {
+		return notifyOnly("candidate has no score; cannot evaluate auto_promote_min_score (notify only)")
+	}
+	score := *candidate.Summary.Score
+	if score < *policy.AutoPromoteMinScore {
+		return notifyOnly(fmt.Sprintf("score %.4g below auto_promote_min_score=%.4g; notify only", score, *policy.AutoPromoteMinScore))
+	}
+	passed = append(passed, fmt.Sprintf("score %.4g >= %.4g", score, *policy.AutoPromoteMinScore))
+
+	// Guardrail: require_external_ci. At least one feedback event in the eval_run
+	// must be a real-CI positive (mirrors the harvester's vocabulary, never the
+	// raw 0.5 band).
+	if policy.AutoPromoteRequireExternalCI {
+		if !hasRealExternalCIPositive(feedbackEvents) {
+			return notifyOnly("auto_promote_require_external_ci is set but no eval_run feedback recorded a real external-CI pass; notify only")
+		}
+		passed = append(passed, "external CI confirmed")
+	}
+
+	return AutoPromoteDecision{
+		Promote: true,
+		Reason:  "auto-promoted: " + strings.Join(passed, ", "),
+	}
+}
+
+// hasRealExternalCIPositive reports whether any feedback event in the run records
+// a merge that passed genuine external CI, via the shared harvester predicate.
+func hasRealExternalCIPositive(events []db.FeedbackEvent) bool {
+	for _, event := range events {
+		if FeedbackEventIsRealExternalCIPositive(event) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/skillopt/auto_promote_test.go
+++ b/internal/skillopt/auto_promote_test.go
@@ -12,15 +12,16 @@ func intPtr(v int) *int           { return &v }
 func floatPtr(v float64) *float64 { return &v }
 
 // realCIFeedback is a feedback event the harvester would write for a merge that
-// passed genuine external CI (choice "a", the real-CI marker phrase).
+// passed genuine external CI (choice "a", the real-CI marker phrase, AND the
+// harvester provenance the hardened predicate now requires).
 func realCIFeedback() db.FeedbackEvent {
-	return db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged with " + realExternalCIPhrase + "."}
+	return db.FeedbackEvent{Choice: "a", Reviewer: autoTraceReviewer, Source: autoTraceSource, Reasoning: "PR #7 merged with " + realExternalCIPhrase + "."}
 }
 
 // noCIFeedback is a feedback event for a near-neutral empty-gate merge (choice
 // "a" but NO external CI) — it must NOT count as a real-CI positive.
 func noCIFeedback() db.FeedbackEvent {
-	return db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged through an empty gate (no external CI); near-neutral, not a strong positive."}
+	return db.FeedbackEvent{Choice: "a", Reviewer: autoTraceReviewer, Source: autoTraceSource, Reasoning: "PR #7 merged through an empty gate (no external CI); near-neutral, not a strong positive."}
 }
 
 func candidateWithScore(score float64) CandidatePackage {
@@ -29,12 +30,13 @@ func candidateWithScore(score float64) CandidatePackage {
 
 func TestEvaluateAutoPromote(t *testing.T) {
 	cases := []struct {
-		name        string
-		policy      config.SkillOptPolicy
-		candidate   CandidatePackage
-		feedback    []db.FeedbackEvent
-		wantPromote bool
-		reasonHas   string
+		name                string
+		policy              config.SkillOptPolicy
+		candidate           CandidatePackage
+		feedback            []db.FeedbackEvent
+		feedbackUnavailable bool
+		wantPromote         bool
+		reasonHas           string
 	}{
 		{
 			name:        "off by default never promotes",
@@ -83,6 +85,28 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			feedback:    []db.FeedbackEvent{realCIFeedback()},
 			wantPromote: false,
 			reasonHas:   "auto_promote_min_samples is not set",
+		},
+		{
+			// An explicit min_samples=0 is legal, but the absolute zero-evidence floor
+			// must still reject a candidate with no feedback (0 < 0 == false would have
+			// let it through before the fix).
+			name:        "explicit min_samples zero still rejects zero evidence",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(0), AutoPromoteMinScore: floatPtr(0.5)},
+			candidate:   candidateWithScore(0.96),
+			feedback:    nil,
+			wantPromote: false,
+			reasonHas:   "zero evidence",
+		},
+		{
+			// A read error / unresolvable eval_run is uncertainty, not "zero samples":
+			// it fails safe even with an otherwise-satisfiable min_samples=0.
+			name:                "feedback unavailable fails safe even at min_samples zero",
+			policy:              config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(0), AutoPromoteMinScore: floatPtr(0.5)},
+			candidate:           candidateWithScore(0.96),
+			feedback:            nil,
+			feedbackUnavailable: true,
+			wantPromote:         false,
+			reasonHas:           "feedback is unavailable",
 		},
 		{
 			name:        "unset min_score is hard do-not-promote",
@@ -136,7 +160,7 @@ func TestEvaluateAutoPromote(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			decision := EvaluateAutoPromote(tc.policy, tc.candidate, tc.feedback)
+			decision := EvaluateAutoPromote(tc.policy, tc.candidate, tc.feedback, tc.feedbackUnavailable)
 			if decision.Promote != tc.wantPromote {
 				t.Fatalf("Promote = %v, want %v (reason: %q)", decision.Promote, tc.wantPromote, decision.Reason)
 			}
@@ -155,7 +179,20 @@ func TestFeedbackEventIsRealExternalCIPositive(t *testing.T) {
 		t.Fatalf("near-neutral empty-gate merge must NOT count as real CI")
 	}
 	// A negative (choice "b") carrying the phrase still must not count.
-	if FeedbackEventIsRealExternalCIPositive(db.FeedbackEvent{Choice: "b", Reasoning: realExternalCIPhrase}) {
+	if FeedbackEventIsRealExternalCIPositive(db.FeedbackEvent{Choice: "b", Reviewer: autoTraceReviewer, Source: autoTraceSource, Reasoning: realExternalCIPhrase}) {
 		t.Fatalf("a negative choice must never be a real-CI positive")
+	}
+	// Provenance guard: the marker phrase WITHOUT the harvester's reviewer/source
+	// (e.g. a raw human-typed review row) must NOT count — only the harvester writes
+	// the real-CI marker.
+	if FeedbackEventIsRealExternalCIPositive(db.FeedbackEvent{Choice: "a", Reasoning: realExternalCIPhrase}) {
+		t.Fatalf("the marker without harvester provenance must NOT count as real CI")
+	}
+	// Spoof guard: a cross-family review row shares the auto-trace source but carries
+	// the DISTINCT gitmoot-review reviewer and FREE-TEXT findings; even if its prose
+	// mentions the phrase it must NEVER satisfy the real-CI gate.
+	spoof := db.FeedbackEvent{Choice: "a", Reviewer: reviewReviewerID, Source: autoTraceSource, Reasoning: "merged after " + realExternalCIPhrase}
+	if FeedbackEventIsRealExternalCIPositive(spoof) {
+		t.Fatalf("a cross-family review row must never spoof the real-CI marker")
 	}
 }

--- a/internal/skillopt/auto_promote_test.go
+++ b/internal/skillopt/auto_promote_test.go
@@ -1,0 +1,161 @@
+package skillopt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func intPtr(v int) *int           { return &v }
+func floatPtr(v float64) *float64 { return &v }
+
+// realCIFeedback is a feedback event the harvester would write for a merge that
+// passed genuine external CI (choice "a", the real-CI marker phrase).
+func realCIFeedback() db.FeedbackEvent {
+	return db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged with " + realExternalCIPhrase + "."}
+}
+
+// noCIFeedback is a feedback event for a near-neutral empty-gate merge (choice
+// "a" but NO external CI) — it must NOT count as a real-CI positive.
+func noCIFeedback() db.FeedbackEvent {
+	return db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged through an empty gate (no external CI); near-neutral, not a strong positive."}
+}
+
+func candidateWithScore(score float64) CandidatePackage {
+	return CandidatePackage{Summary: CandidateSummary{Score: &score}}
+}
+
+func TestEvaluateAutoPromote(t *testing.T) {
+	cases := []struct {
+		name        string
+		policy      config.SkillOptPolicy
+		candidate   CandidatePackage
+		feedback    []db.FeedbackEvent
+		wantPromote bool
+		reasonHas   string
+	}{
+		{
+			name:        "off by default never promotes",
+			policy:      config.SkillOptPolicy{AutoPromote: false, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.5)},
+			candidate:   candidateWithScore(0.99),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: false,
+			reasonHas:   "auto_promote is off",
+		},
+		{
+			name:        "all guardrails pass promotes",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.9), AutoPromoteRequireExternalCI: true},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: true,
+			reasonHas:   "external CI",
+		},
+		{
+			name:        "all guardrails pass reason mentions score and samples",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.9), AutoPromoteRequireExternalCI: true},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{realCIFeedback(), realCIFeedback()},
+			wantPromote: true,
+			reasonHas:   "samples",
+		},
+		{
+			name:        "nil score fails safe",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.5)},
+			candidate:   CandidatePackage{Summary: CandidateSummary{Score: nil}},
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: false,
+			reasonHas:   "no score",
+		},
+		{
+			name:        "samples below min no promote",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(3), AutoPromoteMinScore: floatPtr(0.5)},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: false,
+			reasonHas:   "below auto_promote_min_samples",
+		},
+		{
+			name:        "unset min_samples is hard do-not-promote not zero",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: nil, AutoPromoteMinScore: floatPtr(0.5)},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: false,
+			reasonHas:   "auto_promote_min_samples is not set",
+		},
+		{
+			name:        "unset min_score is hard do-not-promote",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: nil},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: false,
+			reasonHas:   "auto_promote_min_score is not set",
+		},
+		{
+			name:        "score below min no promote",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.9)},
+			candidate:   candidateWithScore(0.5),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: false,
+			reasonHas:   "below auto_promote_min_score",
+		},
+		{
+			name:        "require external ci but only near-neutral no promote",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.5), AutoPromoteRequireExternalCI: true},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{noCIFeedback()},
+			wantPromote: false,
+			reasonHas:   "no eval_run feedback recorded a real external-CI pass",
+		},
+		{
+			name:        "external ci satisfied by one real positive among near-neutral",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.5), AutoPromoteRequireExternalCI: true},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{noCIFeedback(), realCIFeedback()},
+			wantPromote: true,
+			reasonHas:   "external CI confirmed",
+		},
+		{
+			name:        "require measured judge fails safe deferred",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.5), AutoPromoteRequireMeasuredJudge: true},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: false,
+			reasonHas:   "require_measured_judge",
+		},
+		{
+			name:        "canary fails safe deferred",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.5), AutoPromoteCanary: true},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: false,
+			reasonHas:   "canary",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := EvaluateAutoPromote(tc.policy, tc.candidate, tc.feedback)
+			if decision.Promote != tc.wantPromote {
+				t.Fatalf("Promote = %v, want %v (reason: %q)", decision.Promote, tc.wantPromote, decision.Reason)
+			}
+			if tc.reasonHas != "" && !strings.Contains(decision.Reason, tc.reasonHas) {
+				t.Fatalf("reason %q does not contain %q", decision.Reason, tc.reasonHas)
+			}
+		})
+	}
+}
+
+func TestFeedbackEventIsRealExternalCIPositive(t *testing.T) {
+	if !FeedbackEventIsRealExternalCIPositive(realCIFeedback()) {
+		t.Fatalf("real-CI positive should be detected")
+	}
+	if FeedbackEventIsRealExternalCIPositive(noCIFeedback()) {
+		t.Fatalf("near-neutral empty-gate merge must NOT count as real CI")
+	}
+	// A negative (choice "b") carrying the phrase still must not count.
+	if FeedbackEventIsRealExternalCIPositive(db.FeedbackEvent{Choice: "b", Reasoning: realExternalCIPhrase}) {
+		t.Fatalf("a negative choice must never be a real-CI positive")
+	}
+}

--- a/internal/skillopt/cross_family_review.go
+++ b/internal/skillopt/cross_family_review.go
@@ -146,7 +146,7 @@ func (h *OutcomeHarvester) writeReviewFeedback(ctx context.Context, version db.A
 	if !signal.HasScore {
 		return nil
 	}
-	runID := autoTraceRunIDPrefix + strings.TrimSpace(version.ID)
+	runID := AutoTraceRunID(version.ID)
 	itemID := crossFamilyReviewItemID(outcome)
 	reviewer := reviewReviewer(outcome)
 	sourceURL := pullRequestURL(outcome.Repo, outcome.PullRequest)

--- a/internal/skillopt/trace_harvest.go
+++ b/internal/skillopt/trace_harvest.go
@@ -22,23 +22,47 @@ import (
 // never rewards "merges that pass no real CI" (#465, #463 guardrail).
 const gitmootNoCIContext = "gitmoot/ci"
 
-// autoTraceSource is the FeedbackEvent.source tag every synthetic auto-trace row
-// carries (#465). Combined with autoTraceReviewer it makes auto feedback
+// AutoTraceSource is the FeedbackEvent.source tag every synthetic auto-trace row
+// carries (#465). Combined with AutoTraceReviewer it makes auto feedback
 // identifiable per-event even within a mixed package, and the UNIQUE
 // (run_id,item_id,reviewer,source,source_url) key it participates in is what lets
-// a later revert overwrite the prior positive in place.
-const autoTraceSource = "auto-trace"
+// a later revert overwrite the prior positive in place. Exported because the #471
+// auto-promote external-CI guardrail (FeedbackEventIsRealExternalCIPositive) keys
+// off this provenance, so any caller constructing/recognizing a real-CI event must
+// match it.
+const AutoTraceSource = "auto-trace"
 
-// autoTraceReviewer is the FeedbackEvent.reviewer attributed to every synthetic
+// autoTraceSource is the internal alias kept so the dense in-package call sites
+// stay terse; it is the same value as the exported AutoTraceSource.
+const autoTraceSource = AutoTraceSource
+
+// AutoTraceReviewer is the FeedbackEvent.reviewer attributed to every synthetic
 // auto-trace row (#465): a sentinel non-human reviewer so auto feedback is never
-// mistaken for a human ranking.
-const autoTraceReviewer = "gitmoot-auto"
+// mistaken for a human ranking. Exported alongside AutoTraceSource so the real-CI
+// provenance the #471 guardrail requires is a shared, forge-proof contract.
+const AutoTraceReviewer = "gitmoot-auto"
+
+// autoTraceReviewer is the internal alias for AutoTraceReviewer.
+const autoTraceReviewer = AutoTraceReviewer
 
 // autoTraceRunIDPrefix namespaces the dedicated per-template-version auto-trace
 // eval_run id ("auto-trace:"+versionID) so human-gold runs stay entirely
 // untouched and the export/optimizer can filter or down-weight the auto namespace
 // independently (#465).
 const autoTraceRunIDPrefix = "auto-trace:"
+
+// AutoTraceRunID is the dedicated harvester eval_run id for a template version
+// ("auto-trace:"+versionID). It is the single source of truth for the namespacing
+// so callers outside this package (the #471 auto-promote external-CI guardrail,
+// which must read the HARVESTER's run rather than the human/markdown review run)
+// build the same id the harvester writes. Returns "" for an empty version id.
+func AutoTraceRunID(versionID string) string {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return ""
+	}
+	return autoTraceRunIDPrefix + versionID
+}
 
 // Score bands for the verifiable-outcome → {score, feedback} projection (#465).
 // These feed a synthetic EvaluatorScore that ProjectSignal fuses into one
@@ -74,10 +98,23 @@ const realExternalCIPhrase = "passing external CI"
 // external-CI guardrail uses it to require at least one real-CI positive in the
 // candidate's eval_run; it mirrors the harvester's own vocabulary via the shared
 // realExternalCIPhrase rather than re-deriving the 0.5 band, so the two cannot
-// drift. A choice of "a" (the positive baseline-champion choice) whose Reasoning
-// carries the real-CI marker is the only thing that counts.
+// drift.
+//
+// PROVENANCE (#471 review): the real-CI marker is written ONLY by the harvester's
+// project path (this file), attributed to the autoTraceReviewer/autoTraceSource
+// sentinels. We therefore require BOTH the structured provenance (reviewer AND
+// source) AND the marker phrase, so a SIBLING auto-trace row that shares the
+// run — notably the cross-family review (cross_family_review.go), which writes
+// Choice=="a" with FREE-TEXT human-derived findings under the DISTINCT
+// gitmoot-review reviewer — can never spoof the gate by coincidentally mentioning
+// "passing external CI" in its prose. A choice of "a" (the positive
+// baseline-champion choice) from the harvester whose Reasoning carries the real-CI
+// marker is the only thing that counts.
 func FeedbackEventIsRealExternalCIPositive(event db.FeedbackEvent) bool {
 	if strings.TrimSpace(event.Choice) != "a" {
+		return false
+	}
+	if strings.TrimSpace(event.Reviewer) != autoTraceReviewer || strings.TrimSpace(event.Source) != autoTraceSource {
 		return false
 	}
 	return strings.Contains(strings.ToLower(event.Reasoning), strings.ToLower(realExternalCIPhrase))
@@ -401,7 +438,7 @@ func negativeSignal(hard float64, feedback string) NormalizedSignal {
 // key is deterministic per PR, so a later revert re-upserts the SAME row in place
 // (corrective overwrite, row count unchanged).
 func (h *OutcomeHarvester) writeFeedback(ctx context.Context, version db.AgentTemplateVersion, payload workflow.JobPayload, outcome workflow.Outcome, signal NormalizedSignal, choice string) error {
-	runID := autoTraceRunIDPrefix + strings.TrimSpace(version.ID)
+	runID := AutoTraceRunID(version.ID)
 	itemID := autoTraceItemID(outcome)
 	sourceURL := pullRequestURL(outcome.Repo, outcome.PullRequest)
 

--- a/internal/skillopt/trace_harvest.go
+++ b/internal/skillopt/trace_harvest.go
@@ -58,6 +58,31 @@ const (
 	scoreChangesRequestedStep = 0.2
 )
 
+// realExternalCIPhrase is the canonical marker phrase the harvester writes into a
+// real-CI positive feedback event's Reasoning (the scoreMergedRealCI band: a
+// merge that passed a genuine non-gitmoot/ external CI). It is the SINGLE source
+// of truth shared between the harvester (which writes it) and
+// FeedbackEventIsRealExternalCIPositive (which the #471 auto-promote external-CI
+// guardrail reads), so the guardrail never re-hardcodes the 0.5 near-neutral band
+// or its own copy of the phrase — if the band/phrasing changes, both move together.
+const realExternalCIPhrase = "passing external CI"
+
+// FeedbackEventIsRealExternalCIPositive reports whether a harvested auto-trace
+// feedback event records a merge that passed GENUINE external CI (the
+// scoreMergedRealCI band), as opposed to a near-neutral empty-gate merge
+// (scoreMergedNoCI / "no external CI") or any negative. The #471 auto-promote
+// external-CI guardrail uses it to require at least one real-CI positive in the
+// candidate's eval_run; it mirrors the harvester's own vocabulary via the shared
+// realExternalCIPhrase rather than re-deriving the 0.5 band, so the two cannot
+// drift. A choice of "a" (the positive baseline-champion choice) whose Reasoning
+// carries the real-CI marker is the only thing that counts.
+func FeedbackEventIsRealExternalCIPositive(event db.FeedbackEvent) bool {
+	if strings.TrimSpace(event.Choice) != "a" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(event.Reasoning), strings.ToLower(realExternalCIPhrase))
+}
+
 // CombinedStatusReader is the minimal GitHub read the no-CI guard needs (#465):
 // the combined commit status at a head SHA AND the PR's check-runs. github.Client
 // satisfies it. It is its own narrow interface so the harvester can be unit-tested
@@ -222,7 +247,7 @@ func (h *OutcomeHarvester) project(ctx context.Context, payload workflow.JobPayl
 	case workflow.OutcomeMerged:
 		if h.mergeHasRealCI(ctx, outcome) {
 			return positiveSignal(scoreMergedRealCI,
-				fmt.Sprintf("PR #%d merged with passing external CI.", outcome.PullRequest)), "a"
+				fmt.Sprintf("PR #%d merged with %s.", outcome.PullRequest, realExternalCIPhrase)), "a"
 		}
 		return positiveSignal(scoreMergedNoCI,
 			fmt.Sprintf("PR #%d merged through an empty gate (no external CI); near-neutral, not a strong positive.", outcome.PullRequest)), "a"

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -550,13 +550,17 @@ returns and, on a guardrails pass, calls the existing promote machinery.
   (read-only), so they are visible locally even with `[events]` off. Nil-safe:
   with `[events]` unset, nothing is emitted and behavior is byte-identical.
 - **`[skillopt].auto_promote`** (default `false` = manual, byte-identical) gates
-  auto-promotion on **checkable guardrails**: `auto_promote_min_samples`
-  (feedback-event count in the candidate's eval_run), `auto_promote_min_score`
+  auto-promotion on **checkable guardrails** read from the candidate's HARVESTER
+  auto-trace run (`auto-trace:<version>`), not the human/markdown review run:
+  `auto_promote_min_samples` (feedback-event count), `auto_promote_min_score`
   (`summary.score >=` threshold), and `auto_promote_require_external_ci` (≥1 real
-  external-CI feedback event). **ALL configured guardrails must hold**, and **any**
-  uncertainty — nil score, unset/garbled threshold, unresolvable eval_run, a store
-  read error, `auto_promote_require_measured_judge = true` (deferred, gated on
-  #344), or `auto_promote_canary = true` (deferred) — **fails safe to notify, do
+  external-CI feedback event, keyed off the harvester's `auto-trace`/`gitmoot-auto`
+  provenance so a cross-family review row cannot spoof it). **ALL configured
+  guardrails must hold**, and **any** uncertainty — nil score, unset/garbled
+  threshold, an unresolvable run or a store read error (treated as *feedback
+  unavailable*), **zero feedback samples** (an absolute floor even when
+  `min_samples = 0`), `auto_promote_require_measured_judge = true` (deferred, gated
+  on #344), or `auto_promote_canary = true` (deferred) — **fails safe to notify, do
   not promote**. An unset `min_samples`/`min_score` is a **hard do-not-promote, not
   `0`**. On a pass it promotes via the existing path and emits
   **`candidate.auto_promoted`** so a human can review or roll back even in full-auto.

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -533,3 +533,33 @@ signal feeds the optimizer like any other and, when the configurable
 judge-tagged — *not* barred from promotion); this slice simply preserves the
 current **manual** promotion by writing only `eval_runs` / `eval_review_items` /
 `feedback_events`.
+
+### Candidate promotion policy + notifications (off by default)
+
+When a candidate becomes **pending** (after `skillopt import` or `train
+continue`), gitmoot can **notify** over the event stream and optionally
+**auto-promote** it — both **off by default**, additive, and **importing never
+promotes** (#471). The import write only ever creates the pending version; the
+notify + auto-promote is a separate, config-gated step that runs *after* import
+returns and, on a guardrails pass, calls the existing promote machinery.
+
+- **`candidate.awaiting_promotion`** is emitted **once** for every newly-pending
+  candidate over the `[events]` stream (`job_id` = version id, `root_id` = template
+  id, a redacted score/samples/CI `detail`), **independent of the auto-promote
+  policy**. The dashboard **Attention** page also lists pending candidates
+  (read-only), so they are visible locally even with `[events]` off. Nil-safe:
+  with `[events]` unset, nothing is emitted and behavior is byte-identical.
+- **`[skillopt].auto_promote`** (default `false` = manual, byte-identical) gates
+  auto-promotion on **checkable guardrails**: `auto_promote_min_samples`
+  (feedback-event count in the candidate's eval_run), `auto_promote_min_score`
+  (`summary.score >=` threshold), and `auto_promote_require_external_ci` (≥1 real
+  external-CI feedback event). **ALL configured guardrails must hold**, and **any**
+  uncertainty — nil score, unset/garbled threshold, unresolvable eval_run, a store
+  read error, `auto_promote_require_measured_judge = true` (deferred, gated on
+  #344), or `auto_promote_canary = true` (deferred) — **fails safe to notify, do
+  not promote**. An unset `min_samples`/`min_score` is a **hard do-not-promote, not
+  `0`**. On a pass it promotes via the existing path and emits
+  **`candidate.auto_promoted`** so a human can review or roll back even in full-auto.
+
+See `docs/skillopt-exchange-contract.md` and `docs/events.md` for the full knob
+reference and event shapes.

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -14,18 +14,31 @@ fan-out, not a migration.
 
 The pilot emits a tight allowlist of event types over the webhook transport:
 
-| `event_type`           | When                                                              |
-| ---------------------- | ---------------------------------------------------------------- |
-| `job.finished`         | a job reaches the `succeeded` terminal state                     |
-| `job.failed`           | a job reaches the `failed` terminal state                        |
-| `job.blocked`          | a job reaches the `blocked` terminal state                       |
-| `job.needs_attention`  | a tree pauses awaiting a human (the `escalate_human` pause today) |
+| `event_type`                    | When                                                                              |
+| ------------------------------- | --------------------------------------------------------------------------------- |
+| `job.finished`                  | a job reaches the `succeeded` terminal state                                       |
+| `job.failed`                    | a job reaches the `failed` terminal state                                          |
+| `job.blocked`                   | a job reaches the `blocked` terminal state                                         |
+| `job.needs_attention`           | a tree pauses awaiting a human (the `escalate_human` pause today)                  |
+| `candidate.awaiting_promotion`  | a SkillOpt template candidate becomes `pending` after import (always, off the auto-promote policy) |
+| `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current`          |
 
 Each terminal transition emits **exactly once**. The engine owns the
 succeeded/failed/blocked emit on its `Mailbox` terminal path; the daemon owns the
 pre-flight (`queued -> failed|blocked`) and permission-blocked cases that never
 pass through that path. `job.needs_attention` is emitted once per fresh
 escalation round (a re-advance does not re-emit).
+
+The two `candidate.*` events come from the `skillopt import` / `train continue`
+CLI path, NOT the daemon. When a candidate becomes `pending`,
+`candidate.awaiting_promotion` is emitted **once** carrying the version id
+(`job_id`), the template id (`root_id`), and a redacted score/samples/CI reason —
+independent of the auto-promote policy, so a human is notified even in the manual
+default. If `[skillopt].auto_promote` is on **and** every configured guardrail
+holds, the candidate is promoted via the existing promote path and
+`candidate.auto_promoted` fires so the change can be reviewed or rolled back. The
+adjacent dashboard **Attention** page also lists every pending candidate
+(read-only), so candidates are visible locally even with `[events]` off.
 
 The following `event_type` values are **reserved** for the graduate step. They
 are enumerated in the contract so a consumer can `switch` over them

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -312,16 +312,30 @@ auto_promote_require_measured_judge = false  # PARSED but DEFERRED (#344): true 
 auto_promote_canary = false               # PARSED but DEFERRED (canary follow-on): true => fail safe to no-promote
 ```
 
+The guardrails read the candidate's **harvester auto-trace run**
+(`auto-trace:<template_version_id>`) — the run the OutcomeHarvester writes the
+verifiable `{score, feedback}` signal into — **not** the human/markdown review
+run. A feedback read error (or an unresolvable run) is treated as *feedback
+unavailable* → notify-only (we never promote on evidence we could not read), and
+**zero feedback samples is always a hard do-not-promote** regardless of the
+configured `auto_promote_min_samples` (so a sparse `skillopt import` with no
+auto-trace evidence fails safe to notify-only).
+
 - `auto_promote_min_samples` — the count of `feedback_events` in the candidate's
-  eval_run must meet this floor. **Unset is a hard do-not-promote, never `0`**, so
-  flipping `auto_promote` on without a sample floor never promotes (a sparse
-  `skillopt import` with no resolvable eval_run also fails safe to notify-only).
+  auto-trace run must meet this floor. **Unset is a hard do-not-promote, never
+  `0`**, so flipping `auto_promote` on without a sample floor never promotes. Even
+  an explicit `auto_promote_min_samples = 0` cannot promote a zero-evidence
+  candidate — there is an absolute floor of at least one real sample.
 - `auto_promote_min_score` — the candidate's `summary.score` must be `>=` this.
   **Unset, or a candidate with no score, is a hard do-not-promote.**
-- `auto_promote_require_external_ci` — at least one eval_run feedback event must
+- `auto_promote_require_external_ci` — at least one auto-trace feedback event must
   record a merge that passed **genuine external CI** (not the no-CI near-neutral
-  band). It reuses the harvester's own real-CI vocabulary, so it never rewards an
-  empty gate.
+  band). The predicate keys off the harvester's own provenance (the `auto-trace`
+  source + `gitmoot-auto` reviewer) AND its real-CI marker phrase, so it reads
+  only the harvester's verifiable rows and a sibling cross-family review row's
+  free-text findings can never spoof it. It therefore applies only to **Mode A
+  (auto-trace) runs**; a candidate with no harvested external-CI evidence fails
+  safe to notify-only.
 - `auto_promote_require_measured_judge` and `auto_promote_canary` are **parsed but
   deferred**: there is no judge↔human calibration source yet (gated on #344) and
   the sampled-traffic canary + auto-rollback do not exist, so setting either to

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -279,6 +279,55 @@ manual (the harvester writes only `eval_runs` / `eval_review_items` /
 subject to the configurable `[skillopt].auto_promote` policy (#463) when that
 lands — weighted-low + judge-tagged, **not** barred from promotion.
 
+### Promotion policy + notifications (off by default)
+
+When a candidate becomes **pending** (after `skillopt import` or `train
+continue`), gitmoot can (a) **notify** over the [event stream](./event-stream.md)
+and (b) optionally **auto-promote** it — both **off by default** and **additive**
+(#471). Importing **never** promotes: the import write only ever creates the
+pending version; the notify + auto-promote is a separate, config-gated step that
+runs *after* import returns and, on a guardrails pass, calls the same
+`gitmoot skillopt candidate promote` machinery.
+
+**Notifications (always-on when `[events]` is configured).** Every newly-pending
+candidate emits a single **`candidate.awaiting_promotion`** event carrying the
+version id (`job_id`), template id (`root_id`), and a redacted score/samples/CI
+reason — independent of the auto-promote policy, so a human is notified even in
+the manual default. The dashboard **Attention** page also lists every pending
+candidate (read-only), so candidates are visible locally even with `[events]`
+off. A successful auto-promotion additionally emits **`candidate.auto_promoted`**
+so the change can be reviewed or rolled back even in full-auto.
+
+**Auto-promote (gated on guardrails, fail-safe).** With `auto_promote = true`, a
+candidate is auto-promoted **only when every configured guardrail holds**; **any**
+uncertainty fails safe to *notify, don't promote*:
+
+```toml
+[skillopt]
+auto_promote = false                      # default false = manual, byte-identical
+auto_promote_min_samples = 0              # UNSET = hard "do not promote" (NOT 0)
+auto_promote_min_score = 0.0              # UNSET, or a candidate with no score = do not promote
+auto_promote_require_external_ci = false  # require >= 1 real-external-CI feedback event in the eval_run
+auto_promote_require_measured_judge = false  # PARSED but DEFERRED (#344): true => fail safe to no-promote
+auto_promote_canary = false               # PARSED but DEFERRED (canary follow-on): true => fail safe to no-promote
+```
+
+- `auto_promote_min_samples` — the count of `feedback_events` in the candidate's
+  eval_run must meet this floor. **Unset is a hard do-not-promote, never `0`**, so
+  flipping `auto_promote` on without a sample floor never promotes (a sparse
+  `skillopt import` with no resolvable eval_run also fails safe to notify-only).
+- `auto_promote_min_score` — the candidate's `summary.score` must be `>=` this.
+  **Unset, or a candidate with no score, is a hard do-not-promote.**
+- `auto_promote_require_external_ci` — at least one eval_run feedback event must
+  record a merge that passed **genuine external CI** (not the no-CI near-neutral
+  band). It reuses the harvester's own real-CI vocabulary, so it never rewards an
+  empty gate.
+- `auto_promote_require_measured_judge` and `auto_promote_canary` are **parsed but
+  deferred**: there is no judge↔human calibration source yet (gated on #344) and
+  the sampled-traffic canary + auto-rollback do not exist, so setting either to
+  `true` **forces notify-only** today. They are documented so a user can write the
+  knob forward-compatibly.
+
 ## Ranked Exploration Workflow
 
 Use ranked exploration when the template is still ambiguous and humans need to


### PR DESCRIPTION
Closes #471. Scoped from RFC #463 — the output side that closes the Mode A loop (#465/#470).

## What this adds (off by default, additive)

When a SkillOpt template candidate becomes **pending** (after `skillopt import` or `train continue`), gitmoot can now (a) **notify** over the #446 event stream and surface it on the dashboard **Attention** page, and (b) optionally **auto-promote** it when checkable guardrails pass. Both are **off by default** and **additive**.

- **Two new EventTypes** (`candidate.awaiting_promotion`, `candidate.auto_promoted`) — additive enum on the existing `internal/events` contract; `SchemaVersion` stays `1`.
- **A shared CLI helper** (`notifyAndMaybeAutoPromoteCandidate`) invoked by **both** callers (`runSkillOptImport` and `importSkillOptTrainCandidate`) **after** the pending version is returned. It builds the sink via `buildDaemonEventSink` (nil when `[events]` is off) and emits `candidate.awaiting_promotion` **exactly once** (asserted by a recording sink).
- **A pure `skillopt.EvaluateAutoPromote(policy, candidate, feedbackEvents)`** gating on `auto_promote_min_samples`, `auto_promote_min_score`, and `auto_promote_require_external_ci`. On a pass it calls the **existing** `PromoteAgentTemplateVersion` then emits `candidate.auto_promoted`.
- **Attention page** lists pending candidates (`ListPendingAgentTemplateVersions` + the review score) next to `AwaitingHumanTask`, read-only, visible even with `[events]` off.
- **Docs** in both trees (`RESULT_CONTRACT.md`, `docs/`, `website/docs/`) and config `init.go` comments.

## Invariants honored

- **MANUAL DEFAULT, BYTE-IDENTICAL** — `[skillopt].auto_promote` unset/false ⇒ no auto-promote; `[events]` unset ⇒ no emit (nil-safe). Both off ⇒ behavior byte-identical (proven by an off-by-default import test + a nil-sink test).
- **IMPORTING NEVER PROMOTES** — `ImportCandidatePackageWithOptions` stays side-effect-pure; the notify + auto-promote is a separate post-import step. Emit happens in exactly one place (no double-emit).
- **FAIL-SAFE on every uncertainty** — nil candidate score, unresolvable eval_run, store read error, `auto_promote_require_measured_judge=true` (deferred, gated on #344), `auto_promote_canary=true` (deferred), or unset `min_samples`/`min_score` ⇒ notify only, never promote. Unset threshold is a **hard do-not-promote, not `0`**.
- **external-CI detection** shares a single exported predicate keyed on the harvester's marker phrase (not a re-hardcoded `0.5` band).

## Deferred (parsed-but-fail-safe, documented)

`auto_promote_require_measured_judge` (no judge↔human calibration until #344) and `auto_promote_canary` (sampled-traffic + auto-rollback not built) are parsed for forward-compat but force notify-only today.

## Gate

`go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race ./internal/cli/ ./internal/skillopt/ ./internal/events/ ./internal/workflow/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
