### PR TITLE
feat(skillopt): champion-challenger Thompson bandit + CLI A/B + promotion confidence (#473)

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -295,6 +295,8 @@ auto_promote_min_score = 0.0              # UNSET, or a candidate with no score 
 auto_promote_require_external_ci = false  # require >= 1 real-external-CI feedback event in the eval_run
 auto_promote_require_measured_judge = false  # PARSED but DEFERRED (#344): true => fail safe to no-promote
 auto_promote_canary = false               # PARSED but DEFERRED (canary follow-on): true => fail safe to no-promote
+auto_promote_min_confidence = 0.95        # #473 Mode B: UNSET = ignore; SET = require bandit P(>) >= floor (+ enough samples)
+bandit_min_samples = 30                   # #473 Mode B low-traffic floor for the DEFERRED auto loop (manual `skillopt ab` always allowed)
 ```
 
 The guardrails read the candidate's **harvester auto-trace run**
@@ -326,6 +328,65 @@ auto-trace evidence fails safe to notify-only).
   the sampled-traffic canary + auto-rollback do not exist, so setting either to
   `true` **forces notify-only** today. They are documented so a user can write the
   knob forward-compatibly.
+- `auto_promote_min_confidence` (#473 Mode B) is **additive and optional**. **Unset
+  ignores it entirely** — the auto-promote decision is byte-identical to the
+  guardrails above. When **set**, auto-promote additionally requires a non-nil
+  bandit confidence `P(challenger > champion) >=` this floor, backed by at least
+  `auto_promote_min_samples` bandit pulls (a Beta posterior on a couple of pulls
+  can read 0.9 by luck — the sample floor refuses thin evidence). A nil, low, or
+  thin confidence **fails safe to notify-only**. The confidence is supplied by the
+  manual `skillopt ab` A/B (below); promotion is still the existing
+  `PromoteAgentTemplateVersion` path, never a bypass.
+
+## Champion-challenger A/B preferences (Mode B, off by default)
+
+For **ask / research** agents there is no verifiable terminal outcome (no PR / CI
+/ merge), so Mode A's single-artifact harvester and the score/CI guardrails above
+cannot supply a promotion confidence. **Mode B** (issue #473, scoped from RFC
+#463) closes the loop via **pairwise preference**: A/B a query across two template
+variants and feed the human's pick to the optimizer as a contract
+`RankedFeedbackEvent`.
+
+```sh
+gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--home path]
+```
+
+- **Champion** = the agent template's **current promoted** version; **challenger**
+  = a **pending** candidate version (the sole pending one, or `--challenger`). With
+  **no pending challenger** the command is a clean no-op (`nothing to A/B …`) — no
+  rows are written.
+- It delivers **both** variants through the runtime adapter (serialized, so the two
+  one-shot asks never overlap and runtime-session locks release cleanly), presents
+  the two answers **label-shuffled** as Option A / Option B, and records the human
+  pick. The shuffle mapping is recorded so the stored event maps the pick back to
+  the **correct** champion/challenger label.
+- Each pick writes exactly **one 2-option `eval_run`** (`OptionsCount = 2`,
+  `metadata.feedback_source = preference_ab`, run id `skillopt-ab:<versionId>`),
+  **two `eval_review_options`** (`champion` / `challenger`) whose answer text is
+  stored as `eval_artifacts` via the existing blob path, and **one
+  `RankedFeedbackEvent`** (`ranking = [winner, loser]`, `reviewer = human`,
+  `source = skillopt-ab`) that passes `validateRankedFeedbackEventOptions`. The
+  distinct `source` tag and run-id prefix keep Mode B rows trivially separable from
+  Mode A (`auto-trace`) and human gold. **No contract struct changes —
+  `ContractVersion` stays `1`.**
+
+**The bandit.** Each `(template_id, version_id)` variant is one **Beta-Bernoulli
+arm** (uniform `Beta(1,1)` prior; a win bumps `alpha`, a loss bumps `beta`),
+persisted in the dedicated `skillopt_bandit_arms` table as the sufficient
+statistic. A pick increments the winner (`+win`) and loser (`+loss`), then the
+confidence `P(challenger > champion)` is recomputed by Monte Carlo (deterministic
+given an injected seed) and printed as `NN% likely better over K samples`. That
+scalar is exactly what `auto_promote_min_confidence` consumes: at the candidate
+notify seam the candidate's challenger arm + the champion arm produce the
+confidence carried into `candidate.awaiting_promotion`'s detail and into the
+auto-promote guardrails.
+
+**Tiering.** Below `bandit_min_samples` (default 30) the bandit still records
+preferences and updates the posterior but the **deferred** auto A/B loop never
+runs and the confidence is never trusted to auto-promote (the promotion-side floor
+reuses `auto_promote_min_samples`). The **manual** `skillopt ab` CLI is always
+allowed. Live-traffic interception, the cross-family LLM-judge auto-pairwise,
+canary, and the auto A/B scheduling loop are **deferred** to follow-ons.
 
 ## Ranked Exploration Workflow
 

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -360,15 +360,19 @@ gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [
   the two answers **label-shuffled** as Option A / Option B, and records the human
   pick. The shuffle mapping is recorded so the stored event maps the pick back to
   the **correct** champion/challenger label.
-- Each pick writes exactly **one 2-option `eval_run`** (`OptionsCount = 2`,
+- Each pick writes a 2-option `eval_run` (`OptionsCount = 2`,
   `metadata.feedback_source = preference_ab`, run id `skillopt-ab:<versionId>`),
   **two `eval_review_options`** (`champion` / `challenger`) whose answer text is
   stored as `eval_artifacts` via the existing blob path, and **one
-  `RankedFeedbackEvent`** (`ranking = [winner, loser]`, `reviewer = human`,
-  `source = skillopt-ab`) that passes `validateRankedFeedbackEventOptions`. The
-  distinct `source` tag and run-id prefix keep Mode B rows trivially separable from
-  Mode A (`auto-trace`) and human gold. **No contract struct changes —
-  `ContractVersion` stays `1`.**
+  `RankedFeedbackEvent` per pick** (`ranking = [winner, loser]`, `reviewer =
+  human`, `source = skillopt-ab`) that passes `validateRankedFeedbackEventOptions`.
+  Repeated A/Bs of the **same** challenger each persist as a **distinct** preference
+  row: the `ranked_feedback_events` conflict key is
+  `(run_id, item_id, reviewer, source, source_url)`, and every pick carries a unique
+  per-pick `source_url`, so picks accumulate as evidence instead of overwriting one
+  row. The distinct `source` tag and run-id prefix keep Mode B rows trivially
+  separable from Mode A (`auto-trace`) and human gold. **No contract struct changes
+  — `ContractVersion` stays `1`.**
 
 **The bandit.** Each `(template_id, version_id)` variant is one **Beta-Bernoulli
 arm** (uniform `Beta(1,1)` prior; a win bumps `alpha`, a loss bumps `beta`),

--- a/internal/cli/candidate_autopromote_test.go
+++ b/internal/cli/candidate_autopromote_test.go
@@ -168,6 +168,54 @@ func TestRunCandidateNotifyBanditConfidencePromotes(t *testing.T) {
 	}
 }
 
+// TestRunCandidateNotifyModeBNoScoreNoFeedbackPromotes is the #473 acceptance
+// case that the PR's other promote test did NOT cover: a GENUINE Mode B ask-agent
+// candidate has NO harvester score and NO eval_run feedback events (the harvester
+// only writes Mode A runs), so its ONLY evidence is the pairwise bandit confidence.
+// This proves that path actually reaches EvaluateAutoPromote and auto-promotes —
+// before the Mode B confidence fix, the empty-feedback zero-evidence floor (and the
+// nil-score hard stop) made it structurally unreachable, so it could never fire for
+// the ask agents the feature targets.
+func TestRunCandidateNotifyModeBNoScoreNoFeedbackPromotes(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	// Genuine Mode B: no harvester score at all.
+	candidate.Summary.Score = nil
+	sink := &recordingSink{}
+
+	// require_external_ci OFF (a pure ask agent has no CI); the bandit confidence is
+	// the whole evidence. min_samples=30 is the bandit-pull floor.
+	policy := config.DefaultSkillOptPolicy()
+	policy.AutoPromote = true
+	policy.AutoPromoteMinSamples = floatPtrCLIInt(30)
+	policy.AutoPromoteMinScore = floatPtrCLI(0.5)
+	policy.AutoPromoteMinConfidence = floatPtrCLI(0.95)
+
+	confidence := 0.97
+	summary := skillopt.ConfidenceSummary(confidence, 80)
+	// EMPTY feedback events — the defining property of a Mode B candidate.
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, nil, false, &confidence, 80, summary); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+
+	if got := len(sink.byType(events.EventCandidateAwaitingPromotion)); got != 1 {
+		t.Fatalf("awaiting_promotion emits = %d, want 1", got)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 1 {
+		t.Fatalf("auto_promoted emits = %d, want 1 (Mode B confidence path must reach the gate)", got)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "current" {
+		t.Fatalf("version state = %q, want current (Mode B auto-promoted on confidence alone)", after.State)
+	}
+}
+
+// floatPtrCLIInt is a local int-pointer helper for the Mode B sample-floor cases.
+func floatPtrCLIInt(v int) *int { return &v }
+
 // TestRunCandidateNotifyBanditConfidenceBelowFloorStaysPending proves a set
 // confidence floor that is NOT met fails safe to notify-only — the candidate
 // stays pending even though the other guardrails pass.

--- a/internal/cli/candidate_autopromote_test.go
+++ b/internal/cli/candidate_autopromote_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/config"
@@ -44,7 +45,7 @@ func TestRunCandidateNotifyAutoPromoteOffStaysPending(t *testing.T) {
 	autoPromoteCandidateScore(&candidate, 0.99)
 	sink := &recordingSink{}
 
-	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -72,7 +73,7 @@ func TestRunCandidateNotifyAutoPromoteGuardrailsPass(t *testing.T) {
 	autoPromoteCandidateScore(&candidate, 0.96)
 	sink := &recordingSink{}
 
-	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -106,7 +107,7 @@ func TestRunCandidateNotifyAutoPromoteGuardrailFailStaysPending(t *testing.T) {
 
 	// A near-neutral (no external CI) feedback event fails require_external_ci.
 	nearNeutral := db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged through an empty gate (no external CI); near-neutral, not a strong positive."}
-	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{nearNeutral}, false); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{nearNeutral}, false, nil, 0, ""); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -122,5 +123,102 @@ func TestRunCandidateNotifyAutoPromoteGuardrailFailStaysPending(t *testing.T) {
 	}
 	if after.State != "pending" {
 		t.Fatalf("version state = %q, want pending (no promotion)", after.State)
+	}
+}
+
+// floatPtrCLI is a local pointer helper for the Mode B confidence cases.
+func floatPtrCLI(v float64) *float64 { return &v }
+
+// TestRunCandidateNotifyBanditConfidencePromotes proves the #473 Mode B
+// confidence reaches EvaluateAutoPromote AND the awaiting_promotion Detail: with
+// a confidence above auto_promote_min_confidence and enough samples, the
+// candidate auto-promotes and the awaiting detail carries the "NN% likely better
+// over K samples" string.
+func TestRunCandidateNotifyBanditConfidencePromotes(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	policy := autoPromotePolicy(1, 0.9)
+	policy.AutoPromoteMinConfidence = floatPtrCLI(0.95)
+
+	confidence := 0.97
+	summary := skillopt.ConfidenceSummary(confidence, 80)
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, &confidence, 80, summary); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+
+	awaiting := sink.byType(events.EventCandidateAwaitingPromotion)
+	if len(awaiting) != 1 {
+		t.Fatalf("awaiting_promotion emits = %d, want 1", len(awaiting))
+	}
+	if !strings.Contains(awaiting[0].Detail, "97% likely better over 80 samples") {
+		t.Fatalf("awaiting detail missing confidence string: %q", awaiting[0].Detail)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 1 {
+		t.Fatalf("auto_promoted emits = %d, want 1", got)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "current" {
+		t.Fatalf("version state = %q, want current (auto-promoted on confidence)", after.State)
+	}
+}
+
+// TestRunCandidateNotifyBanditConfidenceBelowFloorStaysPending proves a set
+// confidence floor that is NOT met fails safe to notify-only — the candidate
+// stays pending even though the other guardrails pass.
+func TestRunCandidateNotifyBanditConfidenceBelowFloorStaysPending(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	policy := autoPromotePolicy(1, 0.9)
+	policy.AutoPromoteMinConfidence = floatPtrCLI(0.95)
+
+	confidence := 0.60
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, &confidence, 80, skillopt.ConfidenceSummary(confidence, 80)); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 0 {
+		t.Fatalf("auto_promoted emits = %d, want 0 (confidence below floor)", got)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "pending" {
+		t.Fatalf("version state = %q, want pending", after.State)
+	}
+}
+
+// TestRunCandidateNotifyNoBanditConfidenceUnchanged proves byte-identical #471
+// behavior when Mode B was never exercised: nil confidence + empty summary +
+// nil floor means the awaiting detail carries no confidence string and the
+// auto-promote decision is the same as before #473.
+func TestRunCandidateNotifyNoBanditConfidenceUnchanged(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	// No min_confidence floor; nil confidence; empty summary.
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+	awaiting := sink.byType(events.EventCandidateAwaitingPromotion)
+	if len(awaiting) != 1 {
+		t.Fatalf("awaiting_promotion emits = %d, want 1", len(awaiting))
+	}
+	if strings.Contains(awaiting[0].Detail, "likely better over") {
+		t.Fatalf("awaiting detail should carry NO confidence string when Mode B is unused: %q", awaiting[0].Detail)
+	}
+	// The other guardrails still pass, so it auto-promotes exactly as #471 did.
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 1 {
+		t.Fatalf("auto_promoted emits = %d, want 1 (471 behavior unchanged)", got)
 	}
 }

--- a/internal/cli/candidate_notify.go
+++ b/internal/cli/candidate_notify.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -12,6 +13,13 @@ import (
 	"github.com/jerryfane/gitmoot/internal/skillopt"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
+
+// banditConfidenceSeed pins the Monte Carlo rng used at the notify seam so the
+// confidence carried into a candidate.awaiting_promotion event is deterministic
+// for a given pair of posteriors (the same discipline the CLI A/B uses). The
+// estimate is stable to ~0.003 at DefaultProbDraws, well under any sensible
+// auto_promote_min_confidence floor.
+const banditConfidenceSeed int64 = 473
 
 // notifyAndMaybeAutoPromoteCandidate is the SINGLE shared post-import step (#471)
 // that BOTH CLI callers (runSkillOptImport for manual `skillopt import` and
@@ -83,7 +91,40 @@ func notifyAndMaybeAutoPromoteCandidate(ctx context.Context, store *db.Store, ho
 	// short-lived CLI command exits, or the candidate.* POST never lands.
 	sink := buildDaemonEventSink(store, home)
 	defer events.FlushSink(ctx, sink)
-	return runCandidateNotify(ctx, store, sink, policy, candidate, version, feedbackEvents, feedbackUnavailable)
+	confidence, confidenceSamples, confidenceSummary := resolveBanditConfidence(ctx, store, version)
+	return runCandidateNotify(ctx, store, sink, policy, candidate, version, feedbackEvents, feedbackUnavailable, confidence, confidenceSamples, confidenceSummary)
+}
+
+// resolveBanditConfidence looks up the #473 Mode B bandit confidence backing a
+// just-pending candidate: the challenger arm is the candidate version itself; the
+// champion arm is the template's current promoted version. When the challenger
+// has at least one recorded pull it computes P(challenger>champion) from the two
+// Beta posteriors and returns (confidence, challengerPulls, "NN% likely better
+// over K samples"). When there is no bandit evidence (no challenger arm, or no
+// store) it returns (nil, 0, "") so EvaluateAutoPromote ignores the confidence
+// guardrail and the awaiting detail is unchanged — byte-identical to #471 when
+// Mode B was never exercised. Missing rows degrade to the Beta(1,1) prior; any
+// read error degrades to "no confidence" (fail safe, never block the notify).
+func resolveBanditConfidence(ctx context.Context, store *db.Store, version db.AgentTemplateVersion) (*float64, int, string) {
+	if store == nil {
+		return nil, 0, ""
+	}
+	challengerArm, found, err := store.GetBanditArm(ctx, version.TemplateID, version.ID)
+	if err != nil || !found || challengerArm.Pulls == 0 {
+		// No A/B evidence for this candidate: Mode B contributes nothing, so the
+		// optional confidence guardrail stays a no-op.
+		return nil, 0, ""
+	}
+	champion := skillopt.BetaParams{Alpha: 1, Beta: 1}
+	if tmpl, terr := store.GetAgentTemplate(ctx, version.TemplateID); terr == nil && strings.TrimSpace(tmpl.VersionID) != "" {
+		if champArm, champFound, cerr := store.GetBanditArm(ctx, version.TemplateID, tmpl.VersionID); cerr == nil && champFound {
+			champion = skillopt.BetaParams{Alpha: champArm.Alpha, Beta: champArm.Beta}
+		}
+	}
+	challenger := skillopt.BetaParams{Alpha: challengerArm.Alpha, Beta: challengerArm.Beta}
+	prob := skillopt.ProbChallengerBeats(champion, challenger, rand.New(rand.NewSource(banditConfidenceSeed)), skillopt.DefaultProbDraws)
+	summary := skillopt.ConfidenceSummary(prob, challengerArm.Pulls)
+	return &prob, challengerArm.Pulls, summary
 }
 
 // runCandidateNotify is the testable core of the post-import notify+auto-promote
@@ -95,12 +136,14 @@ func notifyAndMaybeAutoPromoteCandidate(ctx context.Context, store *db.Store, ho
 // candidate.auto_promoted. Splitting it from the home/sink/feedback resolution lets
 // a recording sink assert the exactly-once emit and the no-double-emit invariant
 // deterministically.
-func runCandidateNotify(ctx context.Context, store *db.Store, sink events.Sink, policy config.SkillOptPolicy, candidate skillopt.CandidatePackage, version db.AgentTemplateVersion, feedbackEvents []db.FeedbackEvent, feedbackUnavailable bool) error {
-	decision := skillopt.EvaluateAutoPromote(policy, candidate, feedbackEvents, feedbackUnavailable)
+func runCandidateNotify(ctx context.Context, store *db.Store, sink events.Sink, policy config.SkillOptPolicy, candidate skillopt.CandidatePackage, version db.AgentTemplateVersion, feedbackEvents []db.FeedbackEvent, feedbackUnavailable bool, confidence *float64, confidenceSamples int, confidenceSummary string) error {
+	decision := skillopt.EvaluateAutoPromote(policy, candidate, feedbackEvents, feedbackUnavailable, confidence, confidenceSamples)
 
 	// (3) Always-on notify (when [events] is configured), independent of the
-	// promotion policy: emit candidate.awaiting_promotion exactly once.
-	awaitingDetail := candidateAwaitingDetail(version, candidate, len(feedbackEvents), decision)
+	// promotion policy: emit candidate.awaiting_promotion exactly once. When the
+	// candidate has a Mode B bandit arm (#473) its confidence string rides along in
+	// the detail so a reader sees "NN% likely better over K samples".
+	awaitingDetail := candidateAwaitingDetail(version, candidate, len(feedbackEvents), decision, confidenceSummary)
 	emitCandidateEvent(ctx, sink, events.EventCandidateAwaitingPromotion, version, "awaiting_promotion", awaitingDetail)
 
 	// (4) Auto-promote only on a guardrails pass; on a fail the awaiting_promotion
@@ -141,12 +184,15 @@ func emitCandidateEvent(ctx context.Context, sink events.Sink, eventType events.
 // candidate.awaiting_promotion event: the candidate's score (when present), the
 // eval_run sample count, and — on an auto_promote-on run — the guardrail decision
 // reason so a reader sees WHY it will or will not auto-promote.
-func candidateAwaitingDetail(version db.AgentTemplateVersion, candidate skillopt.CandidatePackage, samples int, decision skillopt.AutoPromoteDecision) string {
+func candidateAwaitingDetail(version db.AgentTemplateVersion, candidate skillopt.CandidatePackage, samples int, decision skillopt.AutoPromoteDecision, confidenceSummary string) string {
 	score := "n/a"
 	if candidate.Summary.Score != nil {
 		score = fmt.Sprintf("%.4g", *candidate.Summary.Score)
 	}
 	detail := fmt.Sprintf("candidate %s for template %s awaiting promotion (score %s, %d samples)", version.ID, version.TemplateID, score, samples)
+	if summary := strings.TrimSpace(confidenceSummary); summary != "" {
+		detail += "; " + summary
+	}
 	if reason := strings.TrimSpace(decision.Reason); reason != "" {
 		detail += "; " + reason
 	}

--- a/internal/cli/candidate_notify_test.go
+++ b/internal/cli/candidate_notify_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -60,7 +61,7 @@ func TestRunCandidateNotifyEmitsAwaitingExactlyOnce(t *testing.T) {
 	store, version, candidate, _ := candidateNotifyFixture(t)
 	sink := &recordingSink{}
 
-	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, nil, false); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, nil, false, nil, 0, ""); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -96,7 +97,7 @@ func TestRunCandidateNotifyNilSinkIsNoOp(t *testing.T) {
 	ctx := context.Background()
 	store, version, candidate, _ := candidateNotifyFixture(t)
 
-	if err := runCandidateNotify(ctx, store, nil, config.DefaultSkillOptPolicy(), candidate, version, nil, false); err != nil {
+	if err := runCandidateNotify(ctx, store, nil, config.DefaultSkillOptPolicy(), candidate, version, nil, false, nil, 0, ""); err != nil {
 		t.Fatalf("runCandidateNotify with nil sink returned error: %v", err)
 	}
 	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
@@ -209,6 +210,53 @@ func TestNotifyAndMaybeAutoPromoteFlushesPerInvocationSink(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("expected the delivered awaiting_promotion event")
+	}
+}
+
+// TestResolveBanditConfidenceNoArmIsNil proves the notify seam contributes
+// nothing when the candidate has no bandit arm: (nil, 0, "") so the optional
+// confidence guardrail stays a no-op and the awaiting detail is unchanged.
+func TestResolveBanditConfidenceNoArmIsNil(t *testing.T) {
+	ctx := context.Background()
+	store, version, _, _ := candidateNotifyFixture(t)
+	conf, samples, summary := resolveBanditConfidence(ctx, store, version)
+	if conf != nil || samples != 0 || summary != "" {
+		t.Fatalf("no-arm confidence = (%v, %d, %q), want (nil, 0, \"\")", conf, samples, summary)
+	}
+}
+
+// TestResolveBanditConfidenceComputesFromArms proves the seam computes a
+// confidence when the candidate (challenger) arm has pulls: a challenger far
+// ahead of the champion yields a high P(>) and a summary naming the challenger
+// pull count. The champion arm is keyed by the template's CURRENT version id,
+// which resolveBanditConfidence resolves via GetAgentTemplate.
+func TestResolveBanditConfidenceComputesFromArms(t *testing.T) {
+	ctx := context.Background()
+	store, version, _, _ := candidateNotifyFixture(t)
+
+	champ, err := store.GetAgentTemplate(ctx, version.TemplateID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplate: %v", err)
+	}
+	if err := store.UpsertBanditArm(ctx, db.BanditArm{TemplateID: version.TemplateID, TemplateVersionID: champ.VersionID, Alpha: 2, Beta: 40, Pulls: 40}); err != nil {
+		t.Fatalf("seed champion arm: %v", err)
+	}
+	if err := store.UpsertBanditArm(ctx, db.BanditArm{TemplateID: version.TemplateID, TemplateVersionID: version.ID, Alpha: 40, Beta: 2, Pulls: 40}); err != nil {
+		t.Fatalf("seed challenger arm: %v", err)
+	}
+
+	conf, samples, summary := resolveBanditConfidence(ctx, store, version)
+	if conf == nil {
+		t.Fatal("expected a non-nil confidence when the challenger arm has pulls")
+	}
+	if *conf < 0.95 {
+		t.Fatalf("P(>) = %.4f, want > 0.95 for a dominant challenger", *conf)
+	}
+	if samples != 40 {
+		t.Fatalf("samples = %d, want 40 (challenger pulls)", samples)
+	}
+	if !strings.Contains(summary, "over 40 samples") {
+		t.Fatalf("summary = %q, want it to name 40 samples", summary)
 	}
 }
 

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -76,6 +76,8 @@ func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptJudge(args[1:], stdout, stderr)
 	case "train":
 		return runSkillOptTrain(args[1:], stdout, stderr)
+	case "ab":
+		return runSkillOptAB(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown skillopt command %q\n\n", args[0])
 		printSkillOptUsage(stderr)
@@ -99,6 +101,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
+	fmt.Fprintln(w, "  gitmoot skillopt ab <agent> \"<prompt>\" [--challenger <versionId>] [--pick a|b] [--seed N] [--home path]")
 	fmt.Fprintln(w, "  gitmoot skillopt judge-report [--template id]")
 	fmt.Fprintln(w, "  gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <h>] [--yes] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt train init --name <name> --template <id> --review-repo owner/repo --artifact-kind kind --preview kind (--request text|--request-file path)")

--- a/internal/cli/skillopt_ab.go
+++ b/internal/cli/skillopt_ab.go
@@ -1,0 +1,506 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// skillOptABSource is the contract source tag on every Mode B (#473) row: the
+// eval_run metadata feedback_source, the two eval_review_options, and the
+// RankedFeedbackEvent. It keeps the pairwise A/B preferences trivially separable
+// from Mode A's auto-trace rows (source=auto-trace) and from human gold.
+const (
+	skillOptABSource          = "skillopt-ab"
+	skillOptABFeedbackSource  = "preference_ab"
+	skillOptABRunIDPrefix     = "skillopt-ab:"
+	skillOptABItemID          = "ab"
+	skillOptABChampionLabel   = "champion"
+	skillOptABChallengerLabel = "challenger"
+)
+
+// skillOptABVariant is one resolved A/B arm: the version being served plus its
+// human-readable role label (champion|challenger).
+type skillOptABVariant struct {
+	version db.AgentTemplateVersion
+	label   string
+}
+
+// skillOptABDelivery is the result of running one variant through the runtime.
+type skillOptABDelivery struct {
+	label  string
+	answer string
+}
+
+// skillOptABDeliverFunc is the seam tests override to inject deterministic
+// answers without a live runtime (a foreground ask would also strand a
+// runtime-session lock, so the two real calls MUST be serialized — see
+// deliverSkillOptABVariant). The default builds a runtime adapter and calls
+// Deliver once per variant.
+type skillOptABDeliverFunc func(ctx context.Context, agent runtime.Agent, prompt string) (string, error)
+
+// skillOptABDeliver is the package-level delivery seam (defaults to the real
+// adapter path; overridden in tests). It is a var, not a const, exactly so the
+// CLI A/B test can supply a fake adapter.
+var skillOptABDeliver skillOptABDeliverFunc = realSkillOptABDeliver
+
+// realSkillOptABDeliver resolves the agent's runtime adapter and delivers a
+// single one-shot prompt, returning the answer text. Each call is independent
+// and synchronous; runSkillOptAB invokes it twice in series so the second call
+// only starts after the first returns — never concurrently — which keeps any
+// per-runtime session usage cleanly serialized.
+func realSkillOptABDeliver(ctx context.Context, agent runtime.Agent, prompt string) (string, error) {
+	adapter, err := runtimeStartAdapterFor(newRuntimeFactory(), agent.Runtime, agent.RepoScope)
+	if err != nil {
+		return "", err
+	}
+	result, err := adapter.Deliver(ctx, agent, runtime.Job{AgentName: agent.Name, Action: "ask", Prompt: prompt, Model: agent.Model})
+	if err != nil {
+		return "", err
+	}
+	answer := strings.TrimSpace(result.Summary)
+	if answer == "" {
+		answer = strings.TrimSpace(result.Raw)
+	}
+	return answer, nil
+}
+
+type skillOptABOptions struct {
+	home       string
+	agent      string
+	prompt     string
+	challenger string
+	pick       string
+	seed       int64
+	seedSet    bool
+}
+
+func runSkillOptAB(args []string, stdout, stderr io.Writer) int {
+	options, ok := parseSkillOptABOptions(args, stderr)
+	if !ok {
+		if containsHelpFlag(args) {
+			return 0
+		}
+		return 2
+	}
+
+	exit := 0
+	err := withStoreAndPaths(options.home, func(paths config.Paths, store *db.Store) error {
+		code := runSkillOptABWithStore(context.Background(), store, paths, options, stdout, stderr)
+		exit = code
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: %v\n", err)
+		return 1
+	}
+	return exit
+}
+
+func parseSkillOptABOptions(args []string, stderr io.Writer) (skillOptABOptions, bool) {
+	if len(args) == 0 || containsHelpFlag(args) {
+		printSkillOptABUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "skillopt ab requires an agent and a prompt")
+		}
+		return skillOptABOptions{}, false
+	}
+	fs := flag.NewFlagSet("skillopt ab", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	challenger := fs.String("challenger", "", "challenger version id (defaults to the sole pending candidate)")
+	pick := fs.String("pick", "", "non-interactive pick: a or b (the shuffled option labels)")
+	seed := fs.Int64("seed", 0, "deterministic seed for the label shuffle and the P(>) Monte Carlo")
+	// Separate the leading positionals (agent, prompt) from flags. flag.Parse stops
+	// at the first non-flag, so collect positionals manually to allow them anywhere.
+	positionals := []string{}
+	rest := []string{}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if strings.HasPrefix(arg, "-") {
+			rest = append(rest, arg)
+			// flags that take a value consume the next token unless --flag=value.
+			if !strings.Contains(arg, "=") && (arg == "--home" || arg == "--challenger" || arg == "--pick" || arg == "--seed") && i+1 < len(args) {
+				i++
+				rest = append(rest, args[i])
+			}
+			continue
+		}
+		positionals = append(positionals, arg)
+	}
+	if err := fs.Parse(rest); err != nil {
+		return skillOptABOptions{}, false
+	}
+	if len(positionals) != 2 {
+		fmt.Fprintln(stderr, "skillopt ab requires exactly one agent and one prompt")
+		printSkillOptABUsage(stderr)
+		return skillOptABOptions{}, false
+	}
+	seedSet := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "seed" {
+			seedSet = true
+		}
+	})
+	pickValue := strings.ToLower(strings.TrimSpace(*pick))
+	if pickValue != "" && pickValue != "a" && pickValue != "b" {
+		fmt.Fprintln(stderr, "skillopt ab --pick must be a or b")
+		return skillOptABOptions{}, false
+	}
+	return skillOptABOptions{
+		home:       strings.TrimSpace(*home),
+		agent:      strings.TrimSpace(positionals[0]),
+		prompt:     strings.TrimSpace(positionals[1]),
+		challenger: strings.TrimSpace(*challenger),
+		pick:       pickValue,
+		seed:       *seed,
+		seedSet:    seedSet,
+	}, true
+}
+
+func printSkillOptABUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot skillopt ab <agent> \"<prompt>\" [--challenger <versionId>] [--pick a|b] [--seed N] [--home path]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Champion-challenger A/B (#473 Mode B): serves the prompt through the agent's")
+	fmt.Fprintln(w, "current promoted template version (champion) AND a pending candidate version")
+	fmt.Fprintln(w, "(challenger), shuffles the two answers as Option A/B, records the human pick as a")
+	fmt.Fprintln(w, "pairwise RankedFeedbackEvent (source=skillopt-ab), updates the Beta-Bernoulli")
+	fmt.Fprintln(w, "bandit, and prints P(challenger>champion). Manual only; no pending candidate is a")
+	fmt.Fprintln(w, "clean no-op.")
+}
+
+func runSkillOptABWithStore(ctx context.Context, store *db.Store, paths config.Paths, options skillOptABOptions, stdout, stderr io.Writer) int {
+	agent, err := store.GetAgent(ctx, options.agent)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: resolve agent %q: %v\n", options.agent, err)
+		return 1
+	}
+	templateID, _ := db.SplitAgentTemplateReference(strings.TrimSpace(agent.TemplateID))
+	if templateID == "" {
+		fmt.Fprintf(stderr, "skillopt ab: agent %q has no template; nothing to A/B\n", options.agent)
+		return 1
+	}
+
+	champion, challenger, ok, code := resolveSkillOptABVariants(ctx, store, templateID, options, stdout, stderr)
+	if !ok {
+		return code
+	}
+
+	runtimeAgent := runtime.Agent{
+		Name:           agent.Name,
+		Role:           firstNonEmpty(agent.Role, "ask"),
+		Runtime:        agent.Runtime,
+		RuntimeRef:     agent.RuntimeRef,
+		RepoScope:      agent.RepoScope,
+		TemplateID:     agent.TemplateID,
+		Capabilities:   agent.Capabilities,
+		AutonomyPolicy: firstNonEmpty(agent.AutonomyPolicy, runtime.AutonomyPolicyReadOnly),
+		Model:          agent.Model,
+	}
+
+	// Deliver BOTH variants, SERIALIZED (the second call only after the first
+	// returns) so any per-runtime session usage never overlaps and locks release
+	// cleanly between calls.
+	championDelivery, err := deliverSkillOptABVariant(ctx, runtimeAgent, options.prompt, champion)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: deliver champion: %v\n", err)
+		return 1
+	}
+	challengerDelivery, err := deliverSkillOptABVariant(ctx, runtimeAgent, options.prompt, challenger)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: deliver challenger: %v\n", err)
+		return 1
+	}
+
+	// Label-shuffle: map Option A/B to champion/challenger via a recorded mapping so
+	// the human cannot infer which is the challenger, yet the stored event maps the
+	// pick back to the CORRECT role (an off-by-one here would silently invert every
+	// preference). optionA/optionB are the deliveries behind the presented labels.
+	rng := rand.New(rand.NewSource(options.seed))
+	swap := rng.Intn(2) == 1
+	optionA, optionB := championDelivery, challengerDelivery
+	if swap {
+		optionA, optionB = challengerDelivery, championDelivery
+	}
+
+	fmt.Fprintf(stdout, "Prompt: %s\n\n", options.prompt)
+	fmt.Fprintf(stdout, "Option A:\n%s\n\n", optionA.answer)
+	fmt.Fprintf(stdout, "Option B:\n%s\n\n", optionB.answer)
+
+	pick, ok := resolveSkillOptABPick(options.pick, stdout, stderr)
+	if !ok {
+		return 2
+	}
+
+	// Map the presented pick (a|b) back to the role label via the shuffle mapping.
+	pickedDelivery := optionA
+	if pick == "b" {
+		pickedDelivery = optionB
+	}
+	winnerLabel := pickedDelivery.label
+	loserLabel := skillOptABChampionLabel
+	if winnerLabel == skillOptABChampionLabel {
+		loserLabel = skillOptABChallengerLabel
+	}
+
+	runID := skillOptABRunIDPrefix + challenger.version.ID
+	if err := recordSkillOptABPick(ctx, store, paths, runID, templateID, champion, challenger, championDelivery, challengerDelivery, winnerLabel, loserLabel, options.prompt); err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: record pick: %v\n", err)
+		return 1
+	}
+
+	// Update both bandit arms in the same logical step: winner +win, loser +loss.
+	championWin := winnerLabel == skillOptABChampionLabel
+	if _, err := store.IncrementBanditArm(ctx, templateID, champion.version.ID, championWin); err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: update champion arm: %v\n", err)
+		return 1
+	}
+	challengerArm, err := store.IncrementBanditArm(ctx, templateID, challenger.version.ID, !championWin)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: update challenger arm: %v\n", err)
+		return 1
+	}
+	championArm, _, err := store.GetBanditArm(ctx, templateID, champion.version.ID)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: read champion arm: %v\n", err)
+		return 1
+	}
+
+	prob := skillopt.ProbChallengerBeats(
+		skillopt.BetaParams{Alpha: championArm.Alpha, Beta: championArm.Beta},
+		skillopt.BetaParams{Alpha: challengerArm.Alpha, Beta: challengerArm.Beta},
+		rand.New(rand.NewSource(skillOptABProbSeed(options))),
+		skillopt.DefaultProbDraws,
+	)
+
+	fmt.Fprintf(stdout, "Recorded pick: %s (Option %s)\n", winnerLabel, strings.ToUpper(pick))
+	fmt.Fprintf(stdout, "Champion %s: Beta(%.0f, %.0f)\n", champion.version.ID, championArm.Alpha, championArm.Beta)
+	fmt.Fprintf(stdout, "Challenger %s: Beta(%.0f, %.0f)\n", challenger.version.ID, challengerArm.Alpha, challengerArm.Beta)
+	fmt.Fprintf(stdout, "P(challenger>champion): %s\n", skillopt.ConfidenceSummary(prob, challengerArm.Pulls))
+	return 0
+}
+
+// skillOptABProbSeed derives the P(>) Monte Carlo seed: the explicit --seed when
+// set, else a deterministic-enough fallback so repeated runs without a seed do
+// not all reuse 0 (which would bias toward the same rng stream). The shuffle uses
+// the raw seed; the prob estimate offsets it so the two streams are independent.
+func skillOptABProbSeed(options skillOptABOptions) int64 {
+	if options.seedSet {
+		return options.seed ^ 0x6a09e667f3bcc908
+	}
+	return time.Now().UnixNano()
+}
+
+// resolveSkillOptABVariants resolves the champion (current promoted version) and
+// challenger (the --challenger version, or the sole pending candidate). It
+// returns ok=false with a clean exit code: 0 (no pending challenger — the honest
+// no-op) or 1 (a real error). The champion must be a promoted current version.
+func resolveSkillOptABVariants(ctx context.Context, store *db.Store, templateID string, options skillOptABOptions, stdout, stderr io.Writer) (skillOptABVariant, skillOptABVariant, bool, int) {
+	template, err := store.GetAgentTemplate(ctx, templateID)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: resolve template %q: %v\n", templateID, err)
+		return skillOptABVariant{}, skillOptABVariant{}, false, 1
+	}
+	championID := strings.TrimSpace(template.VersionID)
+	if championID == "" {
+		fmt.Fprintf(stderr, "skillopt ab: template %q has no current promoted version\n", templateID)
+		return skillOptABVariant{}, skillOptABVariant{}, false, 1
+	}
+	championVersion, err := store.GetAgentTemplateVersionByID(ctx, championID)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: resolve champion version: %v\n", err)
+		return skillOptABVariant{}, skillOptABVariant{}, false, 1
+	}
+
+	pending, err := store.ListPendingAgentTemplateVersions(ctx, templateID)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt ab: list pending candidates: %v\n", err)
+		return skillOptABVariant{}, skillOptABVariant{}, false, 1
+	}
+	var challengerVersion db.AgentTemplateVersion
+	switch {
+	case options.challenger != "":
+		found := false
+		for _, v := range pending {
+			if v.ID == options.challenger {
+				challengerVersion = v
+				found = true
+				break
+			}
+		}
+		if !found {
+			fmt.Fprintf(stderr, "skillopt ab: challenger %q is not a pending candidate of template %q\n", options.challenger, templateID)
+			return skillOptABVariant{}, skillOptABVariant{}, false, 1
+		}
+	case len(pending) == 0:
+		fmt.Fprintln(stdout, "nothing to A/B: no pending challenger; promote a candidate or run skillopt train to produce one")
+		return skillOptABVariant{}, skillOptABVariant{}, false, 0
+	case len(pending) == 1:
+		challengerVersion = pending[0]
+	default:
+		fmt.Fprintf(stderr, "skillopt ab: %d pending candidates; pass --challenger <versionId> to choose one\n", len(pending))
+		return skillOptABVariant{}, skillOptABVariant{}, false, 1
+	}
+
+	return skillOptABVariant{version: championVersion, label: skillOptABChampionLabel},
+		skillOptABVariant{version: challengerVersion, label: skillOptABChallengerLabel},
+		true, 0
+}
+
+// deliverSkillOptABVariant builds the per-variant prompt (the variant's own
+// template instructions prepended to the user prompt) and delivers it through
+// the seam.
+func deliverSkillOptABVariant(ctx context.Context, agent runtime.Agent, userPrompt string, variant skillOptABVariant) (skillOptABDelivery, error) {
+	prompt := skillOptABVariantPrompt(variant.version, userPrompt)
+	answer, err := skillOptABDeliver(ctx, agent, prompt)
+	if err != nil {
+		return skillOptABDelivery{}, err
+	}
+	return skillOptABDelivery{label: variant.label, answer: strings.TrimSpace(answer)}, nil
+}
+
+func skillOptABVariantPrompt(version db.AgentTemplateVersion, userPrompt string) string {
+	var b strings.Builder
+	instructions := strings.TrimRight(agenttemplate.InstructionsForContent(version.Content), "\n")
+	if instructions != "" {
+		b.WriteString("Template instructions:\n")
+		b.WriteString(instructions)
+		b.WriteString("\n\n")
+	}
+	b.WriteString(userPrompt)
+	return b.String()
+}
+
+// resolveSkillOptABPick returns the human pick (a|b). With --pick it is
+// non-interactive; otherwise it reads one line from stdin.
+func resolveSkillOptABPick(flagPick string, stdout io.Writer, stderr io.Writer) (string, bool) {
+	if flagPick == "a" || flagPick == "b" {
+		return flagPick, true
+	}
+	fmt.Fprint(stdout, "Which is better? [a/b]: ")
+	line, ok := readSkillOptABLine()
+	if !ok {
+		fmt.Fprintln(stderr, "skillopt ab: no pick provided")
+		return "", false
+	}
+	pick := strings.ToLower(strings.TrimSpace(line))
+	if pick != "a" && pick != "b" {
+		fmt.Fprintln(stderr, "skillopt ab: pick must be a or b")
+		return "", false
+	}
+	return pick, true
+}
+
+// readSkillOptABLine is a thin seam over reading one interactive line, overridden
+// in tests; the default reads from os.Stdin.
+var readSkillOptABLine = defaultReadSkillOptABLine
+
+func defaultReadSkillOptABLine() (string, bool) {
+	var line string
+	if _, err := fmt.Scanln(&line); err != nil {
+		return "", false
+	}
+	return line, true
+}
+
+// recordSkillOptABPick persists the pairwise contract rows for one A/B pick: a
+// 2-option eval_run (OptionsCount=2, metadata feedback_source=preference_ab), two
+// eval_review_options (champion/challenger) backed by the answer artifacts (via
+// the existing blob path), one eval_review_item, and ONE RankedFeedbackEvent
+// (ranking=[winner,loser], source=skillopt-ab) that passes
+// store.validateRankedFeedbackEventOptions.
+func recordSkillOptABPick(ctx context.Context, store *db.Store, paths config.Paths, runID, templateID string, champion, challenger skillOptABVariant, championDelivery, challengerDelivery skillOptABDelivery, winnerLabel, loserLabel, prompt string) error {
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+
+	metadataJSON, err := json.Marshal(map[string]any{
+		"feedback_source": skillOptABFeedbackSource,
+		"source":          skillOptABSource,
+		"champion":        champion.version.ID,
+		"challenger":      challenger.version.ID,
+	})
+	if err != nil {
+		return err
+	}
+	run := db.EvalRun{
+		ID:                runID,
+		TemplateID:        templateID,
+		TemplateVersionID: challenger.version.ID,
+		State:             "complete",
+		Mode:              db.EvalRunModeValidate,
+		OptionsCount:      2,
+		MetadataJSON:      string(metadataJSON),
+	}
+	if err := store.UpsertEvalRun(ctx, run); err != nil {
+		return err
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{RunID: runID, ItemID: skillOptABItemID, Title: prompt}); err != nil {
+		return err
+	}
+
+	// Store each answer as an eval_artifact via the blob path, then register the
+	// option pointing at it.
+	for _, opt := range []struct {
+		label    string
+		delivery skillOptABDelivery
+	}{
+		{label: skillOptABChampionLabel, delivery: championDelivery},
+		{label: skillOptABChallengerLabel, delivery: challengerDelivery},
+	} {
+		evalArtifact, err := prepareReviewItemContentArtifact(blobStore, runID, skillOptABItemID, opt.label, []byte(answerOrPlaceholder(opt.delivery.answer)), "text/plain", "text")
+		if err != nil {
+			return err
+		}
+		if err := store.UpsertEvalArtifact(ctx, evalArtifact); err != nil {
+			return err
+		}
+		if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{
+			RunID:      runID,
+			ItemID:     skillOptABItemID,
+			Label:      opt.label,
+			ArtifactID: evalArtifact.ID,
+			Role:       opt.label,
+		}); err != nil {
+			return err
+		}
+	}
+
+	ranking, err := json.Marshal([]string{winnerLabel, loserLabel})
+	if err != nil {
+		return err
+	}
+	tieGroups, err := json.Marshal([][]string{{winnerLabel}, {loserLabel}})
+	if err != nil {
+		return err
+	}
+	return store.UpsertRankedFeedbackEvent(ctx, db.RankedFeedbackEvent{
+		RunID:         runID,
+		ItemID:        skillOptABItemID,
+		RankingJSON:   string(ranking),
+		TieGroupsJSON: string(tieGroups),
+		Winner:        winnerLabel,
+		Reviewer:      "human",
+		Source:        skillOptABSource,
+	})
+}
+
+// answerOrPlaceholder guarantees a non-empty artifact body (the blob path rejects
+// empty content), substituting a marker when a variant returned no text.
+func answerOrPlaceholder(answer string) string {
+	if strings.TrimSpace(answer) == "" {
+		return "(no answer)"
+	}
+	return answer
+}

--- a/internal/cli/skillopt_ab.go
+++ b/internal/cli/skillopt_ab.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
@@ -229,7 +230,14 @@ func runSkillOptABWithStore(ctx context.Context, store *db.Store, paths config.P
 	// the human cannot infer which is the challenger, yet the stored event maps the
 	// pick back to the CORRECT role (an off-by-one here would silently invert every
 	// preference). optionA/optionB are the deliveries behind the presented labels.
-	rng := rand.New(rand.NewSource(options.seed))
+	//
+	// Seed selection mirrors skillOptABProbSeed: when --seed is set the shuffle is
+	// deterministic (so the seeded tests pin the A=champion/A=challenger mapping);
+	// when it is NOT set we MUST seed nondeterministically. rand.NewSource(0).Intn(2)
+	// is a constant 0, so a fixed default-0 seed would make swap=false on EVERY
+	// unseeded run — Option B would always be the challenger, reintroducing exactly
+	// the position/identity bias the shuffle exists to remove.
+	rng := rand.New(rand.NewSource(skillOptABShuffleSeed(options)))
 	swap := rng.Intn(2) == 1
 	optionA, optionB := championDelivery, challengerDelivery
 	if swap {
@@ -256,8 +264,16 @@ func runSkillOptABWithStore(ctx context.Context, store *db.Store, paths config.P
 		loserLabel = skillOptABChallengerLabel
 	}
 
+	// runID keeps the version-id prefix so every pick stays trivially filterable as
+	// Mode B for THIS challenger. pickSourceURL is a per-pick token that makes each
+	// recorded preference a DISTINCT contract row: the ranked_feedback_events
+	// conflict key is (run_id, item_id, reviewer, source, source_url), and the first
+	// four are identical across repeated A/Bs of the same challenger, so without a
+	// unique source_url an ON CONFLICT DO UPDATE would overwrite every prior pick and
+	// only the last preference would survive as evidence.
 	runID := skillOptABRunIDPrefix + challenger.version.ID
-	if err := recordSkillOptABPick(ctx, store, paths, runID, templateID, champion, challenger, championDelivery, challengerDelivery, winnerLabel, loserLabel, options.prompt); err != nil {
+	pickSourceURL := skillOptABPickSourceURL(challenger.version.ID)
+	if err := recordSkillOptABPick(ctx, store, paths, runID, pickSourceURL, templateID, champion, challenger, championDelivery, challengerDelivery, winnerLabel, loserLabel, options.prompt); err != nil {
 		fmt.Fprintf(stderr, "skillopt ab: record pick: %v\n", err)
 		return 1
 	}
@@ -291,6 +307,20 @@ func runSkillOptABWithStore(ctx context.Context, store *db.Store, paths config.P
 	fmt.Fprintf(stdout, "Challenger %s: Beta(%.0f, %.0f)\n", challenger.version.ID, challengerArm.Alpha, challengerArm.Beta)
 	fmt.Fprintf(stdout, "P(challenger>champion): %s\n", skillopt.ConfidenceSummary(prob, challengerArm.Pulls))
 	return 0
+}
+
+// skillOptABShuffleSeed derives the label-shuffle seed: the explicit --seed when
+// set (so the seeded shuffle tests pin the A/B->role mapping deterministically),
+// else a nondeterministic time-based fallback so repeated unseeded interactive
+// runs do NOT all reuse seed 0. rand.NewSource(0).Intn(2) is a constant 0, so a
+// pinned-0 default would make swap=false on every default run — Option B would
+// always be the challenger, defeating the anti-bias guarantee. This mirrors
+// skillOptABProbSeed's !seedSet fallback so the two seams stay consistent.
+func skillOptABShuffleSeed(options skillOptABOptions) int64 {
+	if options.seedSet {
+		return options.seed
+	}
+	return time.Now().UnixNano()
 }
 
 // skillOptABProbSeed derives the P(>) Monte Carlo seed: the explicit --seed when
@@ -422,7 +452,7 @@ func defaultReadSkillOptABLine() (string, bool) {
 // the existing blob path), one eval_review_item, and ONE RankedFeedbackEvent
 // (ranking=[winner,loser], source=skillopt-ab) that passes
 // store.validateRankedFeedbackEventOptions.
-func recordSkillOptABPick(ctx context.Context, store *db.Store, paths config.Paths, runID, templateID string, champion, challenger skillOptABVariant, championDelivery, challengerDelivery skillOptABDelivery, winnerLabel, loserLabel, prompt string) error {
+func recordSkillOptABPick(ctx context.Context, store *db.Store, paths config.Paths, runID, pickSourceURL, templateID string, champion, challenger skillOptABVariant, championDelivery, challengerDelivery skillOptABDelivery, winnerLabel, loserLabel, prompt string) error {
 	blobStore := artifact.NewStore(paths.ArtifactBlobs)
 
 	metadataJSON, err := json.Marshal(map[string]any{
@@ -493,8 +523,28 @@ func recordSkillOptABPick(ctx context.Context, store *db.Store, paths config.Pat
 		Winner:        winnerLabel,
 		Reviewer:      "human",
 		Source:        skillOptABSource,
+		// A distinct per-pick SourceURL makes the (run_id,item_id,reviewer,source,
+		// source_url) conflict key unique per pick, so repeated A/Bs of the same
+		// challenger each persist as their own immutable preference row instead of
+		// overwriting the prior one.
+		SourceURL: pickSourceURL,
 	})
 }
+
+// skillOptABPickSourceURL mints a unique-per-pick SourceURL for the Mode B
+// RankedFeedbackEvent. The run id, item id, reviewer, and source are constant
+// across repeated A/Bs of one challenger, so this token is what differentiates
+// each pick's conflict key; it embeds the version id for separability and a
+// strictly increasing nanosecond+counter suffix so a tight loop of picks never
+// collides on a single row.
+func skillOptABPickSourceURL(versionID string) string {
+	seq := atomic.AddUint64(&skillOptABPickSeq, 1)
+	return fmt.Sprintf("%s%s#%d-%d", skillOptABRunIDPrefix, versionID, time.Now().UnixNano(), seq)
+}
+
+// skillOptABPickSeq is a process-local monotonic counter that guarantees two
+// picks recorded within the same nanosecond still get distinct SourceURLs.
+var skillOptABPickSeq uint64
 
 // answerOrPlaceholder guarantees a non-empty artifact body (the blob path rejects
 // empty content), substituting a marker when a variant returned no text.

--- a/internal/cli/skillopt_ab_test.go
+++ b/internal/cli/skillopt_ab_test.go
@@ -186,6 +186,105 @@ func TestRunSkillOptABLabelShuffleMapsPickCorrectly(t *testing.T) {
 	}
 }
 
+// TestRunSkillOptABUnseededShuffleIsNotPinned proves the debiasing fix: on the
+// DEFAULT interactive path (no --seed), the label shuffle must NOT be pinned to
+// swap=false. Before the fix, options.seed defaulted to 0 and
+// rand.NewSource(0).Intn(2) is a constant 0, so Option A was ALWAYS the champion
+// and Option B ALWAYS the challenger on every run — a human doing repeated A/Bs
+// would learn "Option B is always the new variant", reintroducing exactly the
+// position/identity bias the shuffle exists to remove. With a nondeterministic
+// (time-based) fallback seed, both shuffle orderings occur, so picking the SAME
+// presented letter (a) records the champion on some runs and the challenger on
+// others. We assert BOTH winner roles appear across many unseeded runs.
+func TestRunSkillOptABUnseededShuffleIsNotPinned(t *testing.T) {
+	home, store, _, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	ctx := context.Background()
+
+	sawChampion, sawChallenger := false, false
+	const runs = 40
+	for i := 0; i < runs; i++ {
+		var stdout, stderr bytes.Buffer
+		// NO --seed: the shuffle seed must be nondeterministic. Always pick a.
+		code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--pick", "a"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+		}
+	}
+
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	for _, ev := range events {
+		switch ev.Winner {
+		case skillOptABChampionLabel:
+			sawChampion = true
+		case skillOptABChallengerLabel:
+			sawChallenger = true
+		}
+	}
+	if !sawChampion || !sawChallenger {
+		t.Fatalf("unseeded shuffle is pinned: over %d runs with pick a, sawChampion=%v sawChallenger=%v (want both); the default-0 seed would pin swap=false", runs, sawChampion, sawChallenger)
+	}
+}
+
+// TestRunSkillOptABRepeatedPicksEachPersist proves the contract-row fix: repeated
+// A/Bs of the SAME challenger each write a DISTINCT RankedFeedbackEvent instead of
+// overwriting a single row. The ranked_feedback_events conflict key is
+// (run_id, item_id, reviewer, source, source_url); run_id (skillopt-ab:<versionId>),
+// item_id (ab), reviewer (human), and source (skillopt-ab) are all constant across
+// picks, so without a unique per-pick source_url the ON CONFLICT DO UPDATE would
+// overwrite every prior preference and only the last pick would survive as evidence
+// — silently losing all earlier human preferences the optimizer/audit consumes.
+func TestRunSkillOptABRepeatedPicksEachPersist(t *testing.T) {
+	home, store, _, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	ctx := context.Background()
+
+	const picks = 5
+	for i := 0; i < picks; i++ {
+		var stdout, stderr bytes.Buffer
+		// Fixed seed so each pick records the challenger as winner (seed 1 swaps:
+		// A=challenger, pick a -> challenger wins). The point is row COUNT, not role.
+		code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--pick", "a", "--seed", "1"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("pick %d: runSkillOptAB exit = %d, stderr: %s", i, code, stderr.String())
+		}
+	}
+
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	if len(events) != picks {
+		t.Fatalf("ranked feedback events = %d after %d picks, want %d (each pick must persist a distinct contract row)", len(events), picks, picks)
+	}
+	// Every row must carry a distinct source_url (the per-pick uniqueness key).
+	seen := make(map[string]struct{}, len(events))
+	for _, ev := range events {
+		if strings.TrimSpace(ev.SourceURL) == "" {
+			t.Fatalf("pick row has empty source_url; the conflict key would collapse repeated picks")
+		}
+		if _, dup := seen[ev.SourceURL]; dup {
+			t.Fatalf("duplicate source_url %q across picks; rows would overwrite", ev.SourceURL)
+		}
+		seen[ev.SourceURL] = struct{}{}
+	}
+
+	// The bandit arm still accrues one pull per pick (it is keyed per (template,
+	// version), not per pick, and is unchanged by the source_url fix).
+	chalArm, found, err := store.GetBanditArm(ctx, "planner", challengerID)
+	if err != nil || !found {
+		t.Fatalf("challenger arm: found=%v err=%v", found, err)
+	}
+	if chalArm.Pulls != picks {
+		t.Fatalf("challenger arm pulls = %d, want %d", chalArm.Pulls, picks)
+	}
+}
+
 // TestRunSkillOptABNoChallengerIsCleanNoOp proves the honest no-op: with NO
 // pending challenger, the command exits 0, writes no eval run and no bandit arm,
 // and prints the "nothing to A/B" message.

--- a/internal/cli/skillopt_ab_test.go
+++ b/internal/cli/skillopt_ab_test.go
@@ -1,0 +1,248 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// skillOptABFixture installs a "planner" template (its current version is the
+// champion), adds one pending challenger version with distinct content, and
+// registers a codex agent bound to the template. It returns the home, the
+// store, and the champion/challenger version ids.
+func skillOptABFixture(t *testing.T) (string, *db.Store, string, string) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	ctx := context.Background()
+
+	if err := store.UpsertAgentTemplate(ctx, cliSkillOptTemplate("planner", "Champion guidance.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate: %v", err)
+	}
+	champ, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate: %v", err)
+	}
+	// Add a pending challenger with different content so the two answers differ.
+	challengerTmpl := cliSkillOptTemplate("planner", "Challenger guidance, stronger and more actionable.")
+	challengerVersion, err := store.AddPendingAgentTemplateVersion(ctx, challengerTmpl)
+	if err != nil {
+		t.Fatalf("AddPendingAgentTemplateVersion: %v", err)
+	}
+
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "planner-bot",
+		Role:           "ask",
+		Runtime:        runtime.CodexRuntime,
+		RuntimeRef:     "last",
+		RepoScope:      "",
+		TemplateID:     "planner",
+		AutonomyPolicy: runtime.AutonomyPolicyReadOnly,
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	return home, store, champ.VersionID, challengerVersion.ID
+}
+
+// withFakeSkillOptABDeliver swaps the delivery seam for a fake that returns a
+// fixed answer per variant, keyed by which template instructions the prompt
+// carries (champion vs challenger), so the test never touches a live runtime and
+// stays deterministic. It restores the seam on cleanup.
+func withFakeSkillOptABDeliver(t *testing.T, championAnswer, challengerAnswer string) {
+	t.Helper()
+	prev := skillOptABDeliver
+	skillOptABDeliver = func(_ context.Context, _ runtime.Agent, prompt string) (string, error) {
+		if strings.Contains(prompt, "Challenger guidance") {
+			return challengerAnswer, nil
+		}
+		return championAnswer, nil
+	}
+	t.Cleanup(func() { skillOptABDeliver = prev })
+}
+
+// TestRunSkillOptABRecordsValidPairwiseEvent is the core contract test: a pick
+// writes exactly one RankedFeedbackEvent that store.UpsertRankedFeedbackEvent
+// ACCEPTED (the 2-option/ranking==OptionsCount/all-labels-covered gate), tagged
+// source=skillopt-ab with a skillopt-ab: run id, two eval_review_options
+// (champion/challenger), and BOTH bandit arms incremented. Here Option B is the
+// challenger (seed 1 swaps) and the human picks B, so the challenger wins.
+func TestRunSkillOptABRecordsValidPairwiseEvent(t *testing.T) {
+	home, store, championID, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	ctx := context.Background()
+
+	var stdout, stderr bytes.Buffer
+	// seed 1 -> rng.Intn(2)==1 -> swap, so Option A=challenger, Option B=champion.
+	// We will assert the actual mapping by reading the recorded winner.
+	code := runSkillOptAB([]string{"planner-bot", "Plan the migration.", "--home", home, "--pick", "a", "--seed", "1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("ranked feedback events = %d, want exactly 1", len(events))
+	}
+	ev := events[0]
+	if ev.Source != skillOptABSource {
+		t.Fatalf("event source = %q, want %q", ev.Source, skillOptABSource)
+	}
+	if ev.Reviewer != "human" {
+		t.Fatalf("event reviewer = %q, want human", ev.Reviewer)
+	}
+	// With seed 1 (swap) and pick a, Option A is the challenger, so challenger wins.
+	if ev.Winner != skillOptABChallengerLabel {
+		t.Fatalf("winner = %q, want %q (seed-1 swap maps pick a -> challenger)", ev.Winner, skillOptABChallengerLabel)
+	}
+
+	// Two registered options.
+	options, err := store.ListEvalReviewOptions(ctx, runID, skillOptABItemID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewOptions: %v", err)
+	}
+	if len(options) != 2 {
+		t.Fatalf("eval review options = %d, want 2", len(options))
+	}
+
+	// Both bandit arms incremented: challenger won (Beta(2,1)), champion lost (Beta(1,2)).
+	champArm, found, err := store.GetBanditArm(ctx, "planner", championID)
+	if err != nil || !found {
+		t.Fatalf("champion arm: found=%v err=%v", found, err)
+	}
+	if champArm.Alpha != 1 || champArm.Beta != 2 || champArm.Pulls != 1 {
+		t.Fatalf("champion arm = Beta(%.0f,%.0f) pulls=%d, want Beta(1,2) pulls=1", champArm.Alpha, champArm.Beta, champArm.Pulls)
+	}
+	chalArm, found, err := store.GetBanditArm(ctx, "planner", challengerID)
+	if err != nil || !found {
+		t.Fatalf("challenger arm: found=%v err=%v", found, err)
+	}
+	if chalArm.Alpha != 2 || chalArm.Beta != 1 || chalArm.Pulls != 1 {
+		t.Fatalf("challenger arm = Beta(%.0f,%.0f) pulls=%d, want Beta(2,1) pulls=1", chalArm.Alpha, chalArm.Beta, chalArm.Pulls)
+	}
+
+	if !strings.Contains(stdout.String(), "P(challenger>champion):") {
+		t.Fatalf("stdout missing P(>) line:\n%s", stdout.String())
+	}
+}
+
+// TestRunSkillOptABLabelShuffleMapsPickCorrectly proves the off-by-one-sensitive
+// invariant: under BOTH shuffles, picking the option that is actually the
+// challenger records challenger-as-winner, and picking the champion option
+// records champion-as-winner. We drive the two shuffle outcomes via the seed
+// (seed 0 -> no swap: A=champion, B=challenger; seed 1 -> swap: A=challenger,
+// B=champion) and assert the recorded winner matches the true role behind the
+// pick, never the presented letter.
+func TestRunSkillOptABLabelShuffleMapsPickCorrectly(t *testing.T) {
+	cases := []struct {
+		name       string
+		seed       string
+		pick       string
+		wantWinner string
+	}{
+		// seed 0: no swap. A=champion, B=challenger.
+		{"no-swap pick A is champion", "0", "a", skillOptABChampionLabel},
+		{"no-swap pick B is challenger", "0", "b", skillOptABChallengerLabel},
+		// seed 1: swap. A=challenger, B=champion.
+		{"swap pick A is challenger", "1", "a", skillOptABChallengerLabel},
+		{"swap pick B is champion", "1", "b", skillOptABChampionLabel},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home, store, _, challengerID := skillOptABFixture(t)
+			withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+			ctx := context.Background()
+
+			var stdout, stderr bytes.Buffer
+			code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--pick", tc.pick, "--seed", tc.seed}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+			}
+			runID := skillOptABRunIDPrefix + challengerID
+			events, err := store.ListRankedFeedbackEvents(ctx, runID)
+			if err != nil || len(events) != 1 {
+				t.Fatalf("events = %d err=%v", len(events), err)
+			}
+			if events[0].Winner != tc.wantWinner {
+				t.Fatalf("winner = %q, want %q", events[0].Winner, tc.wantWinner)
+			}
+		})
+	}
+}
+
+// TestRunSkillOptABNoChallengerIsCleanNoOp proves the honest no-op: with NO
+// pending challenger, the command exits 0, writes no eval run and no bandit arm,
+// and prints the "nothing to A/B" message.
+func TestRunSkillOptABNoChallengerIsCleanNoOp(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	if err := store.UpsertAgentTemplate(ctx, cliSkillOptTemplate("planner", "Only champion.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate: %v", err)
+	}
+	champ, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "planner-bot", Role: "ask", Runtime: runtime.CodexRuntime, RuntimeRef: "last", TemplateID: "planner", AutonomyPolicy: runtime.AutonomyPolicyReadOnly}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	store.Close()
+
+	// The seam must NEVER be called when there is nothing to A/B.
+	called := false
+	prev := skillOptABDeliver
+	skillOptABDeliver = func(_ context.Context, _ runtime.Agent, _ string) (string, error) {
+		called = true
+		return "x", nil
+	}
+	t.Cleanup(func() { skillOptABDeliver = prev })
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--pick", "a"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+	if called {
+		t.Fatal("delivery seam was called despite no challenger")
+	}
+	if !strings.Contains(stdout.String(), "nothing to A/B") {
+		t.Fatalf("stdout missing no-op message:\n%s", stdout.String())
+	}
+
+	store2, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer store2.Close()
+	if _, found, err := store2.GetBanditArm(ctx, "planner", champ.VersionID); err != nil || found {
+		t.Fatalf("expected no bandit arm written, found=%v err=%v", found, err)
+	}
+	runID := skillOptABRunIDPrefix + "anything"
+	if events, err := store2.ListRankedFeedbackEvents(ctx, runID); err != nil || len(events) != 0 {
+		t.Fatalf("expected no ranked events, got %d err=%v", len(events), err)
+	}
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -90,6 +90,16 @@ escalation_ttl = ""
 #     notify-only.
 #   auto_promote_canary: PARSED but DEFERRED (canary follow-on) — sampled traffic +
 #     auto-rollback do not exist yet, so when true it FAILS SAFE to notify-only.
+#   auto_promote_min_confidence (#473 Mode B): minimum bandit confidence
+#     P(challenger>champion) — supplied by the manual 'skillopt ab' champion-
+#     challenger A/B — required to auto-promote. UNSET ignores the guardrail
+#     entirely (byte-identical to #471). When SET, auto-promote additionally
+#     requires a non-nil confidence >= this floor; a nil/low confidence FAILS SAFE
+#     to notify-only.
+#   bandit_min_samples (#473 Mode B): per-agent low-traffic floor for the DEFERRED
+#     auto A/B loop. Below it the bandit still records preferences and updates its
+#     posterior but never auto-runs/auto-promotes off thin evidence. The manual
+#     'skillopt ab' CLI is always allowed regardless. (default 30)
 # [skillopt]
 # auto_trace_enabled = false
 # cross_family_review_enabled = false
@@ -99,6 +109,8 @@ escalation_ttl = ""
 # auto_promote_require_external_ci = false
 # auto_promote_require_measured_judge = false
 # auto_promote_canary = false
+# auto_promote_min_confidence = 0.95
+# bandit_min_samples = 30
 
 # [admission] is an OPT-IN, off-by-default host-global concurrency budget the
 # daemon applies BEFORE starting each agent session, on top of --workers/pool

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -421,7 +421,30 @@ type SkillOptPolicy struct {
 	// traffic + regression-window infrastructure does not exist yet, so when true it
 	// FAILS SAFE to notify-don't-promote. Documented as deferred.
 	AutoPromoteCanary bool
+
+	// AutoPromoteMinConfidence is the minimum Mode B bandit confidence
+	// P(challenger>champion) required to auto-promote (#473). nil (unset, the
+	// default) IGNORES the guardrail entirely — #471's behavior is byte-identical
+	// when this is absent. When SET, auto-promote additionally requires a non-nil
+	// confidence >= this floor; a nil or below-floor confidence FAILS SAFE to
+	// notify-only (the same nil-is-hard-no discipline as the other guardrails). It
+	// is the scalar the pairwise A/B bandit supplies at the runCandidateNotify seam.
+	AutoPromoteMinConfidence *float64
+
+	// BanditMinSamples is the per-agent low-traffic floor (#473 tiering): below
+	// this many bandit pulls the Mode B bandit still records preferences and
+	// updates the posterior, but the (deferred) auto A/B loop never runs and the
+	// confidence is never trusted to auto-promote. nil (unset, the default) means
+	// the deferred auto loop has no floor configured. The manual `skillopt ab` CLI
+	// is ALWAYS allowed regardless of this floor; it only governs the deferred
+	// automatic path. The promotion side reuses AutoPromoteMinSamples.
+	BanditMinSamples *int
 }
+
+// DefaultBanditMinSamples is the documented default low-traffic floor for the
+// deferred Mode B auto loop (#473). It is NOT applied when bandit_min_samples is
+// unset (nil stays nil, off); it is the value the config stub comments suggest.
+const DefaultBanditMinSamples = 30
 
 func DefaultSkillOptPolicy() SkillOptPolicy {
 	return SkillOptPolicy{
@@ -433,6 +456,8 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 		AutoPromoteRequireExternalCI:    false,
 		AutoPromoteRequireMeasuredJudge: false,
 		AutoPromoteCanary:               false,
+		AutoPromoteMinConfidence:        nil,
+		BanditMinSamples:                nil,
 	}
 }
 
@@ -521,6 +546,20 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 		parsed, err := strconv.ParseBool(value)
 		policy.AutoPromoteCanary = parsed
 		return err
+	case "auto_promote_min_confidence":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		policy.AutoPromoteMinConfidence = &parsed
+		return nil
+	case "bandit_min_samples":
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		policy.BanditMinSamples = &parsed
+		return nil
 	default:
 		return nil
 	}

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -126,6 +126,37 @@ func TestLoadSkillOptPolicyAutoPromoteDefaultsOff(t *testing.T) {
 	if policy.AutoPromoteRequireExternalCI || policy.AutoPromoteRequireMeasuredJudge || policy.AutoPromoteCanary {
 		t.Fatalf("auto_promote guardrail flags must default false, got %+v", policy)
 	}
+	// #473 Mode B additive keys default nil (off): byte-identical when unset.
+	if policy.AutoPromoteMinConfidence != nil || policy.BanditMinSamples != nil {
+		t.Fatalf("auto_promote_min_confidence and bandit_min_samples must default nil (unset), got %+v", policy)
+	}
+}
+
+// TestLoadSkillOptPolicyParsesModeBKeys proves the #473 auto_promote_min_confidence
+// and bandit_min_samples keys parse into their pointers, and an absent section
+// leaves them nil (the off-by-default contract).
+func TestLoadSkillOptPolicyParsesModeBKeys(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_promote_min_confidence = 0.95
+bandit_min_samples = 30
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if policy.AutoPromoteMinConfidence == nil || *policy.AutoPromoteMinConfidence != 0.95 {
+		t.Fatalf("auto_promote_min_confidence = %v, want 0.95", policy.AutoPromoteMinConfidence)
+	}
+	if policy.BanditMinSamples == nil || *policy.BanditMinSamples != 30 {
+		t.Fatalf("bandit_min_samples = %v, want 30", policy.BanditMinSamples)
+	}
 }
 
 // TestLoadSkillOptPolicyParsesAutoPromote proves every new auto_promote_* key

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -123,11 +124,23 @@ INSERT INTO jobs(id, agent, type, state, payload) VALUES ('old', 'w', 'ask', 'su
 `); err != nil {
 		t.Fatalf("seed old schema returned error: %v", err)
 	}
-	// Mark every migration before the token-column ALTER as already applied. The
-	// token-column ALTER is the second-to-last migration (the #420 root_id ALTER
-	// is last), so leave the final two versions unapplied: both run on Open, and
-	// the seeded table is missing both sets of columns so both ALTERs succeed.
-	tokenMigrationVersion := len(migrations) - 1
+	// Mark every migration before the token-column ALTER as already applied, then
+	// leave that ALTER (and everything after it) unapplied so they all run on Open.
+	// The seeded jobs table is missing the token columns AND root_id, so the
+	// token-column ALTER and the #420 root_id ALTER both succeed; any later
+	// migrations (e.g. #473's skillopt_bandit_arms) are independent and also run.
+	// We locate the token migration by CONTENT rather than position so appending
+	// new migrations never breaks this pin.
+	tokenMigrationVersion := -1
+	for i, m := range migrations {
+		if strings.Contains(m, "input_tokens") {
+			tokenMigrationVersion = i + 1 // migration versions are 1-indexed
+			break
+		}
+	}
+	if tokenMigrationVersion < 1 {
+		t.Fatalf("could not locate the input_tokens migration")
+	}
 	for v := 1; v < tokenMigrationVersion; v++ {
 		if _, err := raw.ExecContext(ctx, `INSERT INTO schema_migrations(version, applied_at) VALUES (?, 'seed')`, v); err != nil {
 			t.Fatalf("seed schema_migrations v%d returned error: %v", v, err)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -99,6 +99,23 @@ type AgentTemplateCandidateReview struct {
 	DecidedAt           string
 }
 
+// BanditArm is one persisted Beta-Bernoulli arm of the #473 Mode B
+// champion-challenger bandit, keyed by (TemplateID, TemplateVersionID). Alpha
+// and Beta are the Beta(1+wins, 1+losses) posterior under the uniform Beta(1,1)
+// prior (so a missing row is exactly NewArm()); Pulls is the total win+loss
+// count that drives the "over K samples" string and the low-traffic tiering
+// floor. The arm key is the version id (which already encodes the agent and
+// template), so champion and challenger are two distinct rows and promoting or
+// rejecting a version naturally retires its arm.
+type BanditArm struct {
+	TemplateID        string
+	TemplateVersionID string
+	Alpha             float64
+	Beta              float64
+	Pulls             int
+	UpdatedAt         string
+}
+
 // SkillOptJudgeOutcome records a single human promote/reject decision on a
 // SkillOpt candidate alongside the LLM judge's signal for the same candidate,
 // so judge calibration (agreement, Cohen's kappa, per-dimension drift) can be
@@ -4369,6 +4386,108 @@ func scanRankedFeedbackEvent(row interface{ Scan(dest ...any) error }) (RankedFe
 	return event, nil
 }
 
+// GetBanditArm reads the #473 Mode B bandit arm for a (templateID,
+// versionID) variant. A missing row is NOT an error: it returns ok=false with a
+// zero arm, and the caller treats that as the uniform Beta(1,1) prior
+// (skillopt.NewArm). This keeps the table off-by-default — no row exists until
+// the manual A/B records its first pick.
+func (s *Store) GetBanditArm(ctx context.Context, templateID, versionID string) (BanditArm, bool, error) {
+	templateID = strings.TrimSpace(templateID)
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return BanditArm{}, false, errors.New("bandit arm version id is required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT template_id, template_version_id, alpha, beta, pulls, updated_at
+		FROM skillopt_bandit_arms WHERE template_id = ? AND template_version_id = ?`, templateID, versionID)
+	var arm BanditArm
+	if err := row.Scan(&arm.TemplateID, &arm.TemplateVersionID, &arm.Alpha, &arm.Beta, &arm.Pulls, &arm.UpdatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return BanditArm{}, false, nil
+		}
+		return BanditArm{}, false, err
+	}
+	return arm, true, nil
+}
+
+// UpsertBanditArm writes (or replaces) a bandit arm's full posterior. The alpha/
+// beta/pulls are the caller's authoritative counters; this never increments, it
+// stores exactly what it is given.
+func (s *Store) UpsertBanditArm(ctx context.Context, arm BanditArm) error {
+	arm.TemplateVersionID = strings.TrimSpace(arm.TemplateVersionID)
+	if arm.TemplateVersionID == "" {
+		return errors.New("bandit arm version id is required")
+	}
+	arm.TemplateID = strings.TrimSpace(arm.TemplateID)
+	if arm.Alpha <= 0 {
+		arm.Alpha = 1
+	}
+	if arm.Beta <= 0 {
+		arm.Beta = 1
+	}
+	if arm.Pulls < 0 {
+		arm.Pulls = 0
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO skillopt_bandit_arms(template_id, template_version_id, alpha, beta, pulls, updated_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(template_id, template_version_id) DO UPDATE SET
+			alpha = excluded.alpha,
+			beta = excluded.beta,
+			pulls = excluded.pulls,
+			updated_at = CURRENT_TIMESTAMP`,
+		arm.TemplateID, arm.TemplateVersionID, arm.Alpha, arm.Beta, arm.Pulls)
+	return err
+}
+
+// IncrementBanditArm atomically applies ONE pairwise outcome to a (templateID,
+// versionID) arm in a single transaction: a win bumps alpha, a loss bumps beta,
+// and either way pulls increments. A first-ever pull seeds the row from the
+// Beta(1,1) prior. It returns the post-update arm so the caller can recompute
+// P(challenger>champion) immediately. The two arms of one A/B are incremented
+// with two calls (winner=+win, loser=+loss).
+func (s *Store) IncrementBanditArm(ctx context.Context, templateID, versionID string, win bool) (BanditArm, error) {
+	templateID = strings.TrimSpace(templateID)
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return BanditArm{}, errors.New("bandit arm version id is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return BanditArm{}, err
+	}
+	defer tx.Rollback()
+
+	arm := BanditArm{TemplateID: templateID, TemplateVersionID: versionID, Alpha: 1, Beta: 1, Pulls: 0}
+	row := tx.QueryRowContext(ctx, `SELECT template_id, alpha, beta, pulls FROM skillopt_bandit_arms
+		WHERE template_id = ? AND template_version_id = ?`, templateID, versionID)
+	if err := row.Scan(&arm.TemplateID, &arm.Alpha, &arm.Beta, &arm.Pulls); err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return BanditArm{}, err
+		}
+		// No row yet: keep the Beta(1,1) prior seeded above.
+		arm.TemplateID = templateID
+	}
+	if win {
+		arm.Alpha++
+	} else {
+		arm.Beta++
+	}
+	arm.Pulls++
+	if _, err := tx.ExecContext(ctx, `INSERT INTO skillopt_bandit_arms(template_id, template_version_id, alpha, beta, pulls, updated_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(template_id, template_version_id) DO UPDATE SET
+			alpha = excluded.alpha,
+			beta = excluded.beta,
+			pulls = excluded.pulls,
+			updated_at = CURRENT_TIMESTAMP`,
+		arm.TemplateID, arm.TemplateVersionID, arm.Alpha, arm.Beta, arm.Pulls); err != nil {
+		return BanditArm{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BanditArm{}, err
+	}
+	return arm, nil
+}
+
 func (s *Store) ListPairwisePreferences(ctx context.Context, runID string) ([]PairwisePreference, error) {
 	events, err := s.ListRankedFeedbackEvents(ctx, runID)
 	if err != nil {
@@ -6044,5 +6163,23 @@ ALTER TABLE jobs ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE jobs ADD COLUMN root_id TEXT NOT NULL DEFAULT '';
 
 CREATE INDEX idx_jobs_root_id ON jobs(root_id);
+	`,
+	// #473 Mode B: per-(template, version) Beta-Bernoulli bandit arm. alpha/beta
+	// are the Beta(1+wins, 1+losses) posterior under the uniform Beta(1,1) prior,
+	// so the row is the sufficient statistic and the posterior is reconstructable.
+	// pulls is wins+losses (the "over K samples" / tiering count). The table is
+	// dedicated so these MUTABLE counters never overload the immutable contract
+	// rows (ranked_feedback_events). Off-by-default: no rows exist unless the
+	// manual `skillopt ab` A/B runs.
+	`
+CREATE TABLE skillopt_bandit_arms (
+	template_id TEXT NOT NULL,
+	template_version_id TEXT NOT NULL,
+	alpha REAL NOT NULL DEFAULT 1,
+	beta REAL NOT NULL DEFAULT 1,
+	pulls INTEGER NOT NULL DEFAULT 0,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (template_id, template_version_id)
+);
 	`,
 }

--- a/internal/db/store_bandit_test.go
+++ b/internal/db/store_bandit_test.go
@@ -1,0 +1,92 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func openBanditStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+// TestBanditArmMissingIsPrior proves an unrecorded arm reads back as "not found"
+// (the caller treats that as the Beta(1,1) prior), keeping the table off-by-
+// default: no rows exist until an A/B records a pick.
+func TestBanditArmMissingIsPrior(t *testing.T) {
+	store := openBanditStore(t)
+	ctx := context.Background()
+	arm, found, err := store.GetBanditArm(ctx, "planner", "planner@v1")
+	if err != nil {
+		t.Fatalf("GetBanditArm: %v", err)
+	}
+	if found {
+		t.Fatalf("expected no row for a fresh arm, got %+v", arm)
+	}
+}
+
+// TestIncrementBanditArm proves the atomic win/loss counters: a first win seeds
+// Beta(2,1) pulls=1 from the prior, a subsequent loss yields Beta(2,2) pulls=2,
+// and the returned arm matches the persisted row.
+func TestIncrementBanditArm(t *testing.T) {
+	store := openBanditStore(t)
+	ctx := context.Background()
+
+	won, err := store.IncrementBanditArm(ctx, "planner", "planner@v2", true)
+	if err != nil {
+		t.Fatalf("IncrementBanditArm win: %v", err)
+	}
+	if won.Alpha != 2 || won.Beta != 1 || won.Pulls != 1 {
+		t.Fatalf("after win = Beta(%.0f,%.0f) pulls=%d, want Beta(2,1) pulls=1", won.Alpha, won.Beta, won.Pulls)
+	}
+
+	lost, err := store.IncrementBanditArm(ctx, "planner", "planner@v2", false)
+	if err != nil {
+		t.Fatalf("IncrementBanditArm loss: %v", err)
+	}
+	if lost.Alpha != 2 || lost.Beta != 2 || lost.Pulls != 2 {
+		t.Fatalf("after loss = Beta(%.0f,%.0f) pulls=%d, want Beta(2,2) pulls=2", lost.Alpha, lost.Beta, lost.Pulls)
+	}
+
+	got, found, err := store.GetBanditArm(ctx, "planner", "planner@v2")
+	if err != nil || !found {
+		t.Fatalf("GetBanditArm after increments: found=%v err=%v", found, err)
+	}
+	if got.Alpha != 2 || got.Beta != 2 || got.Pulls != 2 {
+		t.Fatalf("persisted arm = Beta(%.0f,%.0f) pulls=%d, want Beta(2,2) pulls=2", got.Alpha, got.Beta, got.Pulls)
+	}
+}
+
+// TestUpsertBanditArmReplaces proves UpsertBanditArm stores the full posterior
+// verbatim (it does not increment) and clamps degenerate inputs to the prior.
+func TestUpsertBanditArmReplaces(t *testing.T) {
+	store := openBanditStore(t)
+	ctx := context.Background()
+	if err := store.UpsertBanditArm(ctx, BanditArm{TemplateID: "planner", TemplateVersionID: "planner@v3", Alpha: 7, Beta: 3, Pulls: 8}); err != nil {
+		t.Fatalf("UpsertBanditArm: %v", err)
+	}
+	got, found, err := store.GetBanditArm(ctx, "planner", "planner@v3")
+	if err != nil || !found {
+		t.Fatalf("GetBanditArm: found=%v err=%v", found, err)
+	}
+	if got.Alpha != 7 || got.Beta != 3 || got.Pulls != 8 {
+		t.Fatalf("arm = Beta(%.0f,%.0f) pulls=%d, want Beta(7,3) pulls=8", got.Alpha, got.Beta, got.Pulls)
+	}
+	// Degenerate alpha/beta clamp to the prior, not below.
+	if err := store.UpsertBanditArm(ctx, BanditArm{TemplateVersionID: "planner@v4", Alpha: 0, Beta: -1, Pulls: -5}); err != nil {
+		t.Fatalf("UpsertBanditArm degenerate: %v", err)
+	}
+	clamped, _, err := store.GetBanditArm(ctx, "", "planner@v4")
+	if err != nil {
+		t.Fatalf("GetBanditArm clamped: %v", err)
+	}
+	if clamped.Alpha != 1 || clamped.Beta != 1 || clamped.Pulls != 0 {
+		t.Fatalf("clamped arm = Beta(%.0f,%.0f) pulls=%d, want Beta(1,1) pulls=0", clamped.Alpha, clamped.Beta, clamped.Pulls)
+	}
+}

--- a/internal/skillopt/auto_promote.go
+++ b/internal/skillopt/auto_promote.go
@@ -53,10 +53,23 @@ func notifyOnly(reason string) AutoPromoteDecision {
 //     auto_promote without a sample floor must never promote a sparse candidate).
 //   - min_score unset (nil) OR a nil candidate Summary.Score -> hard do-not-promote.
 //   - require_external_ci=true with no real-CI positive in the run -> do not promote.
+//   - min_confidence (#473 Mode B) is ADDITIVE and OPTIONAL: when
+//     policy.AutoPromoteMinConfidence is nil (the default) the bandit confidence is
+//     ignored entirely and behavior is byte-identical to #471 — `confidence` may be
+//     nil. When the floor IS set, promote additionally requires a non-nil
+//     confidence >= the floor AND at least AutoPromoteMinSamples bandit samples
+//     behind it (small-sample over-confidence guard); a nil/low confidence or thin
+//     evidence FAILS SAFE to notify-only.
 //
-// On a pass the reason names the guardrails that held (score, samples, external CI)
-// so the candidate.auto_promoted event explains the decision.
-func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackage, feedbackEvents []db.FeedbackEvent, feedbackUnavailable bool) AutoPromoteDecision {
+// `confidence` is the Mode B P(challenger>champion) the runCandidateNotify seam
+// supplies from the bandit (nil when there is no arm); `confidenceSamples` is the
+// challenger arm's pull count behind it (0 when absent). Both are ignored unless
+// AutoPromoteMinConfidence is set, so EXISTING callers/tests are unchanged in
+// behavior.
+//
+// On a pass the reason names the guardrails that held (score, samples, external CI,
+// confidence) so the candidate.auto_promoted event explains the decision.
+func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackage, feedbackEvents []db.FeedbackEvent, feedbackUnavailable bool, confidence *float64, confidenceSamples int) AutoPromoteDecision {
 	if !policy.AutoPromote {
 		return notifyOnly("auto_promote is off; notify only (manual promotion)")
 	}
@@ -117,6 +130,27 @@ func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackag
 			return notifyOnly("auto_promote_require_external_ci is set but no eval_run feedback recorded a real external-CI pass; notify only")
 		}
 		passed = append(passed, "external CI confirmed")
+	}
+
+	// Guardrail: min_confidence (#473 Mode B). ADDITIVE and OPTIONAL — when unset
+	// (the default) the bandit confidence is ignored and this whole block is a
+	// no-op, so #471 behavior is byte-identical. When set, promote requires a
+	// non-nil confidence at or above the floor, backed by at least
+	// AutoPromoteMinSamples bandit pulls (a Beta posterior on a couple of pulls can
+	// read 0.9 by luck — the tiering floor refuses thin evidence). nil/low/thin all
+	// fail safe to notify-only.
+	if policy.AutoPromoteMinConfidence != nil {
+		floor := *policy.AutoPromoteMinConfidence
+		if confidence == nil {
+			return notifyOnly(fmt.Sprintf("auto_promote_min_confidence=%.4g is set but no bandit confidence is available; notify only", floor))
+		}
+		if confidenceSamples < *policy.AutoPromoteMinSamples {
+			return notifyOnly(fmt.Sprintf("bandit confidence %.0f%% has only %d sample(s), below auto_promote_min_samples=%d; notify only", *confidence*100, confidenceSamples, *policy.AutoPromoteMinSamples))
+		}
+		if *confidence < floor {
+			return notifyOnly(fmt.Sprintf("bandit confidence %.0f%% below auto_promote_min_confidence=%.4g; notify only", *confidence*100, floor))
+		}
+		passed = append(passed, fmt.Sprintf("confidence %.0f%% >= %.4g over %d samples", *confidence*100, floor, confidenceSamples))
 	}
 
 	return AutoPromoteDecision{

--- a/internal/skillopt/auto_promote.go
+++ b/internal/skillopt/auto_promote.go
@@ -51,8 +51,14 @@ func notifyOnly(reason string) AutoPromoteDecision {
 //     zero verifiable evidence.
 //   - min_samples unset (nil) -> a HARD do-not-promote, NOT 0 (a user who flips
 //     auto_promote without a sample floor must never promote a sparse candidate).
-//   - min_score unset (nil) OR a nil candidate Summary.Score -> hard do-not-promote.
-//   - require_external_ci=true with no real-CI positive in the run -> do not promote.
+//   - min_score unset (nil) OR a nil candidate Summary.Score -> hard do-not-promote
+//     ON THE MODE A (verifiable-outcome) PATH. A genuine Mode B (ask/research)
+//     candidate has NO harvester score; its evidence is the pairwise bandit, so the
+//     score/feedback-sample floors are satisfied by the confidence + bandit-pull
+//     floor instead (see modeBConfidenceBacked below) and a nil score is allowed.
+//   - require_external_ci=true with no real-CI positive in the run -> do not promote
+//     (still hard, including on the Mode B path: a pure ask agent has no CI, so an
+//     operator simply leaves require_external_ci off; if they DO set it we fail safe).
 //   - min_confidence (#473 Mode B) is ADDITIVE and OPTIONAL: when
 //     policy.AutoPromoteMinConfidence is nil (the default) the bandit confidence is
 //     ignored entirely and behavior is byte-identical to #471 — `confidence` may be
@@ -60,6 +66,16 @@ func notifyOnly(reason string) AutoPromoteDecision {
 //     confidence >= the floor AND at least AutoPromoteMinSamples bandit samples
 //     behind it (small-sample over-confidence guard); a nil/low confidence or thin
 //     evidence FAILS SAFE to notify-only.
+//
+// MODE B PATH (the ask/research loop this slice closes): when AutoPromoteMinConfidence
+// is set AND a confidence backed by >= AutoPromoteMinSamples bandit pulls is present,
+// the bandit pulls ARE the sample evidence and the pairwise preference IS the quality
+// signal — so the bandit-pull floor stands in for len(feedbackEvents) (a Mode B
+// candidate has zero harvester feedback rows) and the nil-score hard stop is skipped.
+// This is what makes a real ask-agent candidate (empty feedbackEvents, nil score)
+// reachable by the confidence gate; without it the zero-evidence / nil-score hard
+// stops above would make Mode B auto-promotion structurally unreachable. A score, if
+// present, must still clear min_score; require_external_ci, if set, must still hold.
 //
 // `confidence` is the Mode B P(challenger>champion) the runCandidateNotify seam
 // supplies from the bandit (nil when there is no arm); `confidenceSamples` is the
@@ -90,41 +106,69 @@ func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackag
 		return notifyOnly("auto_promote_canary is set but canary promotion is deferred; notify only")
 	}
 
-	passed := make([]string, 0, 3)
-
-	// Guardrail: min_samples. Unset is a hard do-not-promote, never 0.
+	// min_samples must always be set (the unset-is-hard-no discipline holds for both
+	// paths: a user who flips auto_promote without a sample floor must never promote).
 	if policy.AutoPromoteMinSamples == nil {
 		return notifyOnly("auto_promote_min_samples is not set; refusing to promote without a sample floor (notify only)")
 	}
-	samples := len(feedbackEvents)
-	// Absolute floor: a configured auto_promote_min_samples=0 is a LEGAL value, but
-	// `0 < 0` is false, so without this an explicit 0 would let a zero-evidence
-	// candidate promote. We never auto-promote on zero verifiable samples regardless
-	// of the configured minimum.
-	if samples == 0 {
-		return notifyOnly("no eval_run feedback samples; refusing to auto-promote on zero evidence (notify only)")
-	}
-	if samples < *policy.AutoPromoteMinSamples {
-		return notifyOnly(fmt.Sprintf("only %d feedback sample(s), below auto_promote_min_samples=%d; notify only", samples, *policy.AutoPromoteMinSamples))
-	}
-	passed = append(passed, fmt.Sprintf("%d samples >= %d", samples, *policy.AutoPromoteMinSamples))
 
-	// Guardrail: min_score. Unset, or a nil candidate score, is a hard do-not-promote.
+	// modeBConfidenceBacked is true when this candidate's promotion rests on pairwise
+	// bandit evidence rather than a harvested score/feedback run: a min_confidence
+	// floor is configured AND a confidence is present. On this path the bandit pulls
+	// are the samples and the preference is the quality signal, so the Mode A
+	// feedback-sample and score floors below are deferred to the confidence block —
+	// which is the single place the bandit-pull floor and confidence floor are
+	// enforced (with precise, Mode-B-worded reasons). The pull-count adequacy is NOT
+	// part of this predicate on purpose: a too-thin confidence must still reach the
+	// confidence block and be rejected there with the "below auto_promote_min_samples"
+	// reason, not silently fall back to the Mode A "zero evidence" stop.
+	modeBConfidenceBacked := policy.AutoPromoteMinConfidence != nil && confidence != nil
+
+	passed := make([]string, 0, 4)
+
+	// Guardrail: min_samples (Mode A feedback rows). On the Mode B confidence path the
+	// bandit pulls ARE the sample evidence (a real ask candidate has zero harvester
+	// feedback rows), so the sample floor is checked against the bandit pulls in the
+	// confidence block below instead of here.
+	if !modeBConfidenceBacked {
+		samples := len(feedbackEvents)
+		// Absolute floor: a configured auto_promote_min_samples=0 is a LEGAL value, but
+		// `0 < 0` is false, so without this an explicit 0 would let a zero-evidence
+		// candidate promote. We never auto-promote on zero verifiable samples regardless
+		// of the configured minimum.
+		if samples == 0 {
+			return notifyOnly("no eval_run feedback samples; refusing to auto-promote on zero evidence (notify only)")
+		}
+		if samples < *policy.AutoPromoteMinSamples {
+			return notifyOnly(fmt.Sprintf("only %d feedback sample(s), below auto_promote_min_samples=%d; notify only", samples, *policy.AutoPromoteMinSamples))
+		}
+		passed = append(passed, fmt.Sprintf("%d samples >= %d", samples, *policy.AutoPromoteMinSamples))
+	}
+
+	// Guardrail: min_score. Unset is always a hard do-not-promote. A nil candidate
+	// score is a hard stop ONLY on the Mode A path — a genuine Mode B candidate has no
+	// harvester score, so the bandit confidence stands in for it; a score that IS
+	// present must still clear the floor on either path.
 	if policy.AutoPromoteMinScore == nil {
 		return notifyOnly("auto_promote_min_score is not set; refusing to promote without a score floor (notify only)")
 	}
 	if candidate.Summary.Score == nil {
-		return notifyOnly("candidate has no score; cannot evaluate auto_promote_min_score (notify only)")
+		if !modeBConfidenceBacked {
+			return notifyOnly("candidate has no score; cannot evaluate auto_promote_min_score (notify only)")
+		}
+		// Mode B: no score is expected; the confidence gate below carries the burden.
+	} else {
+		score := *candidate.Summary.Score
+		if score < *policy.AutoPromoteMinScore {
+			return notifyOnly(fmt.Sprintf("score %.4g below auto_promote_min_score=%.4g; notify only", score, *policy.AutoPromoteMinScore))
+		}
+		passed = append(passed, fmt.Sprintf("score %.4g >= %.4g", score, *policy.AutoPromoteMinScore))
 	}
-	score := *candidate.Summary.Score
-	if score < *policy.AutoPromoteMinScore {
-		return notifyOnly(fmt.Sprintf("score %.4g below auto_promote_min_score=%.4g; notify only", score, *policy.AutoPromoteMinScore))
-	}
-	passed = append(passed, fmt.Sprintf("score %.4g >= %.4g", score, *policy.AutoPromoteMinScore))
 
 	// Guardrail: require_external_ci. At least one feedback event in the eval_run
 	// must be a real-CI positive (mirrors the harvester's vocabulary, never the
-	// raw 0.5 band).
+	// raw 0.5 band). Applies on both paths: a Mode B ask agent has no CI, so an
+	// operator leaves this off; if they set it anyway we fail safe.
 	if policy.AutoPromoteRequireExternalCI {
 		if !hasRealExternalCIPositive(feedbackEvents) {
 			return notifyOnly("auto_promote_require_external_ci is set but no eval_run feedback recorded a real external-CI pass; notify only")
@@ -138,7 +182,8 @@ func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackag
 	// non-nil confidence at or above the floor, backed by at least
 	// AutoPromoteMinSamples bandit pulls (a Beta posterior on a couple of pulls can
 	// read 0.9 by luck — the tiering floor refuses thin evidence). nil/low/thin all
-	// fail safe to notify-only.
+	// fail safe to notify-only. On the Mode B path this floor IS the sample floor
+	// (the bandit pulls stand in for the absent harvester feedback rows).
 	if policy.AutoPromoteMinConfidence != nil {
 		floor := *policy.AutoPromoteMinConfidence
 		if confidence == nil {

--- a/internal/skillopt/auto_promote_confidence_test.go
+++ b/internal/skillopt/auto_promote_confidence_test.go
@@ -1,0 +1,110 @@
+package skillopt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// TestEvaluateAutoPromoteConfidenceGuardrail covers the additive #473 Mode B
+// min_confidence guardrail: nil floor leaves #471 behavior untouched (confidence
+// ignored, even when present), a set floor with a nil/low/thin confidence fails
+// safe to notify-only, and a set floor met (with enough samples) passes and names
+// the confidence in the reason.
+func TestEvaluateAutoPromoteConfidenceGuardrail(t *testing.T) {
+	basePolicy := func() config.SkillOptPolicy {
+		return config.SkillOptPolicy{
+			AutoPromote:                  true,
+			AutoPromoteMinSamples:        intPtr(1),
+			AutoPromoteMinScore:          floatPtr(0.9),
+			AutoPromoteRequireExternalCI: true,
+		}
+	}
+	// Enough feedback events to clear the largest AutoPromoteMinSamples floor used
+	// below (30): the FEEDBACK-side sample guardrail and the bandit confidenceSamples
+	// guardrail both read AutoPromoteMinSamples, so the feedback slice must be at
+	// least as large as the floor for the confidence cases to be the deciding gate.
+	feedback := make([]db.FeedbackEvent, 0, 40)
+	for i := 0; i < 40; i++ {
+		feedback = append(feedback, realCIFeedback())
+	}
+
+	cases := []struct {
+		name              string
+		minConfidence     *float64
+		minSamples        *int
+		confidence        *float64
+		confidenceSamples int
+		wantPromote       bool
+		reasonHas         string
+	}{
+		{
+			name:          "nil floor ignores confidence (471 unchanged)",
+			minConfidence: nil,
+			confidence:    floatPtr(0.1), // a low confidence is IGNORED when the floor is unset
+			wantPromote:   true,
+			reasonHas:     "external CI",
+		},
+		{
+			name:          "nil floor with nil confidence still promotes",
+			minConfidence: nil,
+			confidence:    nil,
+			wantPromote:   true,
+			reasonHas:     "score",
+		},
+		{
+			name:              "floor set, confidence nil -> notify only",
+			minConfidence:     floatPtr(0.95),
+			confidence:        nil,
+			confidenceSamples: 0,
+			wantPromote:       false,
+			reasonHas:         "no bandit confidence",
+		},
+		{
+			name:              "floor set, confidence below floor -> notify only",
+			minConfidence:     floatPtr(0.95),
+			minSamples:        intPtr(10),
+			confidence:        floatPtr(0.80),
+			confidenceSamples: 50,
+			wantPromote:       false,
+			reasonHas:         "below auto_promote_min_confidence",
+		},
+		{
+			name:              "floor met but too few samples -> notify only",
+			minConfidence:     floatPtr(0.95),
+			minSamples:        intPtr(30),
+			confidence:        floatPtr(0.99),
+			confidenceSamples: 5,
+			wantPromote:       false,
+			reasonHas:         "below auto_promote_min_samples",
+		},
+		{
+			name:              "floor met with enough samples -> promote",
+			minConfidence:     floatPtr(0.95),
+			minSamples:        intPtr(30),
+			confidence:        floatPtr(0.97),
+			confidenceSamples: 80,
+			wantPromote:       true,
+			reasonHas:         "confidence 97%",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := basePolicy()
+			policy.AutoPromoteMinConfidence = tc.minConfidence
+			if tc.minSamples != nil {
+				policy.AutoPromoteMinSamples = tc.minSamples
+			}
+			decision := EvaluateAutoPromote(policy, candidateWithScore(0.96), feedback, false, tc.confidence, tc.confidenceSamples)
+			if decision.Promote != tc.wantPromote {
+				t.Fatalf("Promote = %v, want %v (reason: %q)", decision.Promote, tc.wantPromote, decision.Reason)
+			}
+			if tc.reasonHas != "" && !strings.Contains(decision.Reason, tc.reasonHas) {
+				t.Fatalf("reason %q does not contain %q", decision.Reason, tc.reasonHas)
+			}
+		})
+	}
+}

--- a/internal/skillopt/auto_promote_test.go
+++ b/internal/skillopt/auto_promote_test.go
@@ -35,6 +35,8 @@ func TestEvaluateAutoPromote(t *testing.T) {
 		candidate           CandidatePackage
 		feedback            []db.FeedbackEvent
 		feedbackUnavailable bool
+		confidence          *float64
+		confidenceSamples   int
 		wantPromote         bool
 		reasonHas           string
 	}{
@@ -156,11 +158,75 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			wantPromote: false,
 			reasonHas:   "canary",
 		},
+		{
+			// MODE B (#473): a GENUINE ask-agent candidate has NO harvester feedback rows
+			// and NO score. Without the Mode B confidence path the empty-feedback
+			// zero-evidence floor (or the nil-score hard stop) would make this candidate
+			// structurally unreachable by the confidence gate. With a set min_confidence,
+			// a present confidence, and enough bandit pulls, the bandit evidence stands in
+			// for the sample/score floors and it promotes.
+			name:              "mode B confidence-backed promotes with no feedback and no score",
+			policy:            config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(30), AutoPromoteMinScore: floatPtr(0.5), AutoPromoteMinConfidence: floatPtr(0.95)},
+			candidate:         CandidatePackage{Summary: CandidateSummary{Score: nil}},
+			feedback:          nil,
+			confidence:        floatPtr(0.97),
+			confidenceSamples: 80,
+			wantPromote:       true,
+			reasonHas:         "confidence 97%",
+		},
+		{
+			// Mode B thin evidence: a high confidence but FEWER bandit pulls than the
+			// sample floor must NOT promote — small-sample over-confidence is exactly the
+			// tiering failure the floor exists to block. It also must not fall back to the
+			// Mode A zero-evidence path (that would still refuse, but for the wrong reason).
+			name:              "mode B confidence below sample floor stays pending",
+			policy:            config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(30), AutoPromoteMinScore: floatPtr(0.5), AutoPromoteMinConfidence: floatPtr(0.95)},
+			candidate:         CandidatePackage{Summary: CandidateSummary{Score: nil}},
+			feedback:          nil,
+			confidence:        floatPtr(0.99),
+			confidenceSamples: 5,
+			wantPromote:       false,
+			reasonHas:         "below auto_promote_min_samples",
+		},
+		{
+			// Mode B with a confidence below the floor fails safe even though the pull
+			// count clears the sample floor.
+			name:              "mode B confidence below floor stays pending",
+			policy:            config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(30), AutoPromoteMinScore: floatPtr(0.5), AutoPromoteMinConfidence: floatPtr(0.95)},
+			candidate:         CandidatePackage{Summary: CandidateSummary{Score: nil}},
+			feedback:          nil,
+			confidence:        floatPtr(0.60),
+			confidenceSamples: 80,
+			wantPromote:       false,
+			reasonHas:         "below auto_promote_min_confidence",
+		},
+		{
+			// A nil score with NO bandit confidence (min_confidence unset) is still the
+			// Mode A hard stop — the score floor is not waived without bandit evidence.
+			name:        "nil score without confidence is still a hard stop",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.5)},
+			candidate:   CandidatePackage{Summary: CandidateSummary{Score: nil}},
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: false,
+			reasonHas:   "no score",
+		},
+		{
+			// Mode B path still honors a PRESENT score that is below the floor: the bandit
+			// stands in only for an ABSENT score, never to override a real failing one.
+			name:              "mode B with present failing score stays pending",
+			policy:            config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(30), AutoPromoteMinScore: floatPtr(0.9), AutoPromoteMinConfidence: floatPtr(0.95)},
+			candidate:         candidateWithScore(0.4),
+			feedback:          nil,
+			confidence:        floatPtr(0.99),
+			confidenceSamples: 80,
+			wantPromote:       false,
+			reasonHas:         "below auto_promote_min_score",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			decision := EvaluateAutoPromote(tc.policy, tc.candidate, tc.feedback, tc.feedbackUnavailable, nil, 0)
+			decision := EvaluateAutoPromote(tc.policy, tc.candidate, tc.feedback, tc.feedbackUnavailable, tc.confidence, tc.confidenceSamples)
 			if decision.Promote != tc.wantPromote {
 				t.Fatalf("Promote = %v, want %v (reason: %q)", decision.Promote, tc.wantPromote, decision.Reason)
 			}

--- a/internal/skillopt/auto_promote_test.go
+++ b/internal/skillopt/auto_promote_test.go
@@ -160,7 +160,7 @@ func TestEvaluateAutoPromote(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			decision := EvaluateAutoPromote(tc.policy, tc.candidate, tc.feedback, tc.feedbackUnavailable)
+			decision := EvaluateAutoPromote(tc.policy, tc.candidate, tc.feedback, tc.feedbackUnavailable, nil, 0)
 			if decision.Promote != tc.wantPromote {
 				t.Fatalf("Promote = %v, want %v (reason: %q)", decision.Promote, tc.wantPromote, decision.Reason)
 			}

--- a/internal/skillopt/bandit.go
+++ b/internal/skillopt/bandit.go
@@ -1,0 +1,206 @@
+package skillopt
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+)
+
+// DefaultProbDraws is the Monte Carlo draw count used when a caller passes 0 to
+// ProbChallengerBeats. 20000 draws gives a P(>) estimate stable to ~0.003 while
+// staying cheap enough to recompute on every pick.
+const DefaultProbDraws = 20000
+
+// Mode B champion-challenger Thompson-sampling bandit (#473, scoped from RFC
+// #463). This file is the PURE, I/O-free engine: a Beta-Bernoulli posterior per
+// arm, where an arm is one (template_id, version_id) variant. The champion arm
+// is the current promoted version, the challenger arm a pending candidate
+// version. Persistence (the skillopt_bandit_arms table) and the CLI A/B wiring
+// live elsewhere; this file only does the math, and every randomized routine
+// takes an INJECTED *rand.Rand so tests pin a seed and assert exact values.
+//
+// A "win" for an arm means that variant's answer was the human's preferred pick
+// in a pairwise A/B; the other arm takes a "loss". The promotion confidence #471
+// consumes is P(challenger > champion), the probability a fresh sample from the
+// challenger's posterior beats one from the champion's.
+
+// BetaParams is a Beta(Alpha, Beta) posterior. Alpha = 1 + wins and Beta =
+// 1 + losses under the uniform Beta(1,1) prior, so the pair is the Bernoulli
+// sufficient statistic and a stored arm row is exactly reconstructable.
+type BetaParams struct {
+	Alpha float64
+	Beta  float64
+}
+
+// BanditArm is a persisted arm's mutable counters: the Beta posterior plus the
+// total number of pulls (wins + losses) it has accrued. Pulls drives the
+// human-facing "over K samples" string and the low-traffic tiering floor.
+type BanditArm struct {
+	Alpha float64
+	Beta  float64
+	Pulls int
+}
+
+// NewArm returns a fresh arm with the uniform Beta(1,1) prior and zero pulls.
+func NewArm() BanditArm {
+	return BanditArm{Alpha: 1, Beta: 1, Pulls: 0}
+}
+
+// Update applies one pairwise outcome to the arm: a win bumps Alpha, a loss
+// bumps Beta, and either way the pull count increments. It is pure (returns a
+// new arm) so callers control persistence.
+func (a BanditArm) Update(win bool) BanditArm {
+	next := a
+	if win {
+		next.Alpha++
+	} else {
+		next.Beta++
+	}
+	next.Pulls++
+	return next
+}
+
+// SampleTheta draws one Thompson sample theta ~ Beta(Alpha, Beta) from the arm's
+// posterior using the injected rng. The draw is X/(X+Y) with X~Gamma(Alpha,1)
+// and Y~Gamma(Beta,1) — the standard Beta-from-two-Gammas construction — so the
+// argmax-over-arms selection used by the (deferred) live loop is regret
+// minimizing. Deterministic given a seeded rng.
+func (p BetaParams) SampleTheta(rng *rand.Rand) float64 {
+	x := sampleGamma(rng, p.Alpha)
+	y := sampleGamma(rng, p.Beta)
+	if x+y <= 0 {
+		// Degenerate only when both shapes are ~0; fall back to the prior mean.
+		return 0.5
+	}
+	return x / (x + y)
+}
+
+// ProbChallengerBeats estimates P(theta_challenger > theta_champion) by Monte
+// Carlo: it draws `draws` independent pairs from the two posteriors using the
+// SAME injected rng and returns the fraction where the challenger sample is
+// strictly larger. This is the promotion confidence #471's auto_promote_min_
+// confidence guardrail compares against. Deterministic given a seeded rng; the
+// MANDATORY closed-form cross-check test (probChallengerBeatsClosedForm) proves
+// the sampler is unbiased. Equal samples (a measure-zero tie for continuous
+// Beta, but possible at the float boundary) count as NOT beating, the
+// conservative direction for a promotion gate.
+func ProbChallengerBeats(champion, challenger BetaParams, rng *rand.Rand, draws int) float64 {
+	if draws <= 0 {
+		draws = DefaultProbDraws
+	}
+	wins := 0
+	for i := 0; i < draws; i++ {
+		champTheta := champion.SampleTheta(rng)
+		chalTheta := challenger.SampleTheta(rng)
+		if chalTheta > champTheta {
+			wins++
+		}
+	}
+	return float64(wins) / float64(draws)
+}
+
+// ConfidenceSummary renders the human-facing promotion-confidence string the
+// candidate.awaiting_promotion event Detail carries, e.g. "96% likely better
+// over 80 samples". samples is the challenger arm's pull count.
+func ConfidenceSummary(prob float64, samples int) string {
+	return fmt.Sprintf("%.0f%% likely better over %d samples", prob*100, samples)
+}
+
+// sampleGamma draws X ~ Gamma(shape, 1) using the injected rng. For shape >= 1
+// it uses Marsaglia-Tsang's squeeze method (rejection on a normal proposal),
+// the same algorithm math/rand's own gamma helpers use; for 0 < shape < 1 it
+// boosts via the Gamma(shape+1) * U^(1/shape) identity. shape <= 0 returns 0.
+// All randomness flows through rng so the whole engine is reproducible.
+func sampleGamma(rng *rand.Rand, shape float64) float64 {
+	if shape <= 0 {
+		return 0
+	}
+	if shape < 1 {
+		// Boosting: if G ~ Gamma(shape+1, 1) and U ~ Uniform(0,1) then
+		// G * U^(1/shape) ~ Gamma(shape, 1).
+		u := rng.Float64()
+		// Guard against U==0 producing -Inf through the log path.
+		for u <= 0 {
+			u = rng.Float64()
+		}
+		return sampleGamma(rng, shape+1) * math.Pow(u, 1/shape)
+	}
+	// Marsaglia & Tsang (2000).
+	d := shape - 1.0/3.0
+	c := 1.0 / math.Sqrt(9*d)
+	for {
+		x := rng.NormFloat64()
+		v := 1 + c*x
+		if v <= 0 {
+			continue
+		}
+		v = v * v * v
+		u := rng.Float64()
+		x2 := x * x
+		// Squeeze: cheap acceptance test first, full log test as the fallback.
+		if u < 1-0.0331*x2*x2 {
+			return d * v
+		}
+		if math.Log(u) < 0.5*x2+d*(1-v+math.Log(v)) {
+			return d * v
+		}
+	}
+}
+
+// probChallengerBeatsClosedForm is the exact P(X > Y) for X ~ Beta(challenger)
+// and Y ~ Beta(champion) when ALL four parameters are positive integers, used
+// ONLY as the cross-check oracle for the Monte Carlo sampler in tests (it is not
+// on any production path). It evaluates the standard Beta-exceedance identity
+//
+//	P(X > Y) = sum_{i=0}^{a_x-1} B(a_y+i, b_y+b_x) / ((b_x+i) * B(1+i, b_x) * B(a_y, b_y))
+//
+// where X ~ Beta(a_x,b_x), Y ~ Beta(a_y,b_y), and B is the Beta function. It is
+// summed in log space for numerical stability. Returns (value, true) when every
+// parameter is a positive integer, else (0, false).
+func probChallengerBeatsClosedForm(champion, challenger BetaParams) (float64, bool) {
+	ax, axOK := positiveInteger(challenger.Alpha)
+	bx, bxOK := positiveInteger(challenger.Beta)
+	ay, ayOK := positiveInteger(champion.Alpha)
+	by, byOK := positiveInteger(champion.Beta)
+	if !axOK || !bxOK || !ayOK || !byOK {
+		return 0, false
+	}
+	total := 0.0
+	for i := 0; i < ax; i++ {
+		// term = B(ay+i, by+bx) / ((bx+i) * B(1+i, bx) * B(ay, by)), evaluated as
+		// the exponential of a difference of log-Beta values.
+		logTerm := logBeta(float64(ay+i), float64(by+bx)) -
+			math.Log(float64(bx+i)) -
+			logBeta(float64(1+i), float64(bx)) -
+			logBeta(float64(ay), float64(by))
+		total += math.Exp(logTerm)
+	}
+	if total < 0 {
+		total = 0
+	}
+	if total > 1 {
+		total = 1
+	}
+	return total, true
+}
+
+// logBeta returns log B(a, b) = lgamma(a) + lgamma(b) - lgamma(a+b).
+func logBeta(a, b float64) float64 {
+	la, _ := math.Lgamma(a)
+	lb, _ := math.Lgamma(b)
+	lab, _ := math.Lgamma(a + b)
+	return la + lb - lab
+}
+
+// positiveInteger reports whether v is a positive integer and returns it as an
+// int when so.
+func positiveInteger(v float64) (int, bool) {
+	if v < 1 {
+		return 0, false
+	}
+	rounded := math.Round(v)
+	if math.Abs(v-rounded) > 1e-9 {
+		return 0, false
+	}
+	return int(rounded), true
+}

--- a/internal/skillopt/bandit_test.go
+++ b/internal/skillopt/bandit_test.go
@@ -1,0 +1,134 @@
+package skillopt
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// TestNewArmAndUpdate proves the prior and the win/loss accounting: Beta(1,1)
+// with zero pulls, a win bumps Alpha and pulls, a loss bumps Beta and pulls.
+func TestNewArmAndUpdate(t *testing.T) {
+	arm := NewArm()
+	if arm.Alpha != 1 || arm.Beta != 1 || arm.Pulls != 0 {
+		t.Fatalf("NewArm = Beta(%.0f,%.0f) pulls=%d, want Beta(1,1) pulls=0", arm.Alpha, arm.Beta, arm.Pulls)
+	}
+	won := arm.Update(true)
+	if won.Alpha != 2 || won.Beta != 1 || won.Pulls != 1 {
+		t.Fatalf("after win = Beta(%.0f,%.0f) pulls=%d, want Beta(2,1) pulls=1", won.Alpha, won.Beta, won.Pulls)
+	}
+	lost := won.Update(false)
+	if lost.Alpha != 2 || lost.Beta != 2 || lost.Pulls != 2 {
+		t.Fatalf("after loss = Beta(%.0f,%.0f) pulls=%d, want Beta(2,2) pulls=2", lost.Alpha, lost.Beta, lost.Pulls)
+	}
+}
+
+// TestProbChallengerBeatsPriorIsHalf proves two identical Beta(1,1) posteriors
+// give P(challenger>champion) ~ 0.5 (the uniform prior is symmetric), and that
+// it is exactly reproducible for a fixed seed.
+func TestProbChallengerBeatsPriorIsHalf(t *testing.T) {
+	prior := BetaParams{Alpha: 1, Beta: 1}
+	got := ProbChallengerBeats(prior, prior, rand.New(rand.NewSource(42)), 20000)
+	if math.Abs(got-0.5) > 0.02 {
+		t.Fatalf("P(>) for equal priors = %.4f, want ~0.5", got)
+	}
+	// Determinism: same seed, same draws, identical value.
+	again := ProbChallengerBeats(prior, prior, rand.New(rand.NewSource(42)), 20000)
+	if got != again {
+		t.Fatalf("P(>) not deterministic for a fixed seed: %.6f vs %.6f", got, again)
+	}
+}
+
+// TestSampleThetaDeterministic pins the seed and asserts SampleTheta reproduces
+// exactly — the acceptance-criterion reproducibility guarantee.
+func TestSampleThetaDeterministic(t *testing.T) {
+	p := BetaParams{Alpha: 3, Beta: 2}
+	first := p.SampleTheta(rand.New(rand.NewSource(7)))
+	second := p.SampleTheta(rand.New(rand.NewSource(7)))
+	if first != second {
+		t.Fatalf("SampleTheta not deterministic: %.10f vs %.10f", first, second)
+	}
+	if first < 0 || first > 1 {
+		t.Fatalf("SampleTheta out of [0,1]: %.10f", first)
+	}
+}
+
+// TestProbChallengerBeatsMonotone proves the confidence rises monotonically as
+// the challenger's win margin grows over the champion — the gate must move the
+// right direction.
+func TestProbChallengerBeatsMonotone(t *testing.T) {
+	champion := BetaParams{Alpha: 5, Beta: 5} // 4 wins, 4 losses
+	margins := []BetaParams{
+		{Alpha: 5, Beta: 5},  // even
+		{Alpha: 8, Beta: 3},  // ahead
+		{Alpha: 15, Beta: 2}, // well ahead
+	}
+	prev := -1.0
+	for _, chal := range margins {
+		got := ProbChallengerBeats(champion, chal, rand.New(rand.NewSource(99)), 40000)
+		if got < prev {
+			t.Fatalf("P(>) not monotone: Beta(%.0f,%.0f) -> %.4f after %.4f", chal.Alpha, chal.Beta, got, prev)
+		}
+		prev = got
+	}
+	if prev <= 0.9 {
+		t.Fatalf("strong challenger P(>) = %.4f, want > 0.9", prev)
+	}
+}
+
+// TestProbChallengerBeatsClosedFormCrossCheck is the MANDATORY sampler-validation
+// test: for several small integer alpha/beta pairs the Monte Carlo estimate must
+// match the exact closed-form Beta-exceedance value within tolerance. This proves
+// the Gamma/Beta sampler is unbiased — without it a confidently-wrong confidence
+// could ship.
+func TestProbChallengerBeatsClosedFormCrossCheck(t *testing.T) {
+	cases := []struct {
+		name       string
+		champion   BetaParams
+		challenger BetaParams
+	}{
+		{"both prior", BetaParams{1, 1}, BetaParams{1, 1}},
+		{"challenger one win", BetaParams{1, 1}, BetaParams{2, 1}},
+		{"champion one win", BetaParams{2, 1}, BetaParams{1, 1}},
+		{"challenger ahead", BetaParams{3, 4}, BetaParams{6, 2}},
+		{"champion ahead", BetaParams{7, 2}, BetaParams{3, 5}},
+		{"larger counts", BetaParams{10, 8}, BetaParams{14, 5}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exact, ok := probChallengerBeatsClosedForm(tc.champion, tc.challenger)
+			if !ok {
+				t.Fatalf("closed form unavailable for integer params %v / %v", tc.champion, tc.challenger)
+			}
+			mc := ProbChallengerBeats(tc.champion, tc.challenger, rand.New(rand.NewSource(2024)), 200000)
+			if math.Abs(mc-exact) > 0.01 {
+				t.Fatalf("MC %.4f vs closed-form %.4f differ by more than tolerance (sampler may be biased)", mc, exact)
+			}
+		})
+	}
+}
+
+// TestClosedFormSanity checks the closed-form oracle itself against hand values:
+// symmetric priors give exactly 0.5, and a strict win ordering is > 0.5.
+func TestClosedFormSanity(t *testing.T) {
+	half, ok := probChallengerBeatsClosedForm(BetaParams{1, 1}, BetaParams{1, 1})
+	if !ok || math.Abs(half-0.5) > 1e-9 {
+		t.Fatalf("closed form P(Beta(1,1)>Beta(1,1)) = %.6f, want 0.5", half)
+	}
+	// P(Beta(2,1) > Beta(1,1)): challenger has one win. Exact value is 2/3.
+	ahead, ok := probChallengerBeatsClosedForm(BetaParams{1, 1}, BetaParams{2, 1})
+	if !ok || math.Abs(ahead-2.0/3.0) > 1e-9 {
+		t.Fatalf("closed form P(Beta(2,1)>Beta(1,1)) = %.6f, want 0.6667", ahead)
+	}
+	rejected, ok := probChallengerBeatsClosedForm(BetaParams{1.5, 1}, BetaParams{1, 1})
+	if ok {
+		t.Fatalf("closed form should reject non-integer params, got %.4f", rejected)
+	}
+}
+
+// TestConfidenceSummary proves the human-facing string format.
+func TestConfidenceSummary(t *testing.T) {
+	if got := ConfidenceSummary(0.962, 80); got != "96% likely better over 80 samples" {
+		t.Fatalf("ConfidenceSummary = %q", got)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -565,6 +565,7 @@ gitmoot skillopt candidate list [--template id]
 gitmoot skillopt candidate show <version-id>
 gitmoot skillopt candidate promote <version-id>
 gitmoot skillopt candidate reject <version-id> [--reason text]
+gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--home path]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -580,24 +580,33 @@ preference**, and is **additive** (`contract_version` stays `1`) and **manual**:
   presents them **label-shuffled** as Option A / Option B, and records the human
   pick mapped back to the correct role. **No pending challenger ⇒ a clean no-op**
   (`nothing to A/B …`), zero rows written.
-- A pick writes one **2-option `eval_run`** (`OptionsCount = 2`,
+- A pick writes a **2-option `eval_run`** (`OptionsCount = 2`,
   `metadata.feedback_source = preference_ab`, run id `skillopt-ab:<versionId>`),
   **two `eval_review_options`** (`champion` / `challenger`, answers stored as
-  `eval_artifacts` via the blob path), and **one `RankedFeedbackEvent`**
+  `eval_artifacts` via the blob path), and **one `RankedFeedbackEvent` per pick**
   (`ranking = [winner, loser]`, `reviewer = human`, `source = skillopt-ab`) that
-  passes `validateRankedFeedbackEventOptions`. The `source = skillopt-ab` tag keeps
+  passes `validateRankedFeedbackEventOptions`. Repeated A/Bs of the same challenger
+  each persist as a **distinct** row (a unique per-pick `source_url` keeps the
+  `(run_id, item_id, reviewer, source, source_url)` conflict key distinct), so picks
+  accumulate instead of overwriting one row. The `source = skillopt-ab` tag keeps
   Mode B rows separable from Mode A (`auto-trace`) and human gold.
 - Each `(template_id, version_id)` variant is a **Beta-Bernoulli arm** (`Beta(1,1)`
   prior) persisted in `skillopt_bandit_arms`; a pick increments winner/loser, then
   the confidence **`P(challenger > champion)`** is recomputed by deterministic (seeded)
   Monte Carlo and surfaced as `NN% likely better over K samples`.
-- That confidence is the scalar **`[skillopt].auto_promote_min_confidence`** (nil
-  default = ignored, byte-identical to #471) consumes: at the candidate notify seam
-  it rides into `candidate.awaiting_promotion`'s detail and, when the floor is set,
-  auto-promote additionally requires `confidence >= floor` backed by at least
-  `auto_promote_min_samples` bandit pulls — a nil/low/thin confidence fails safe to
-  notify-only. **`bandit_min_samples`** (default 30) is the low-traffic floor for the
-  DEFERRED auto loop; the manual `skillopt ab` CLI is always allowed.
+- That confidence is the scalar the **`[skillopt].auto_promote_min_confidence`** (nil
+  default = ignored, byte-identical to #471) guardrail consumes: at the candidate
+  notify seam it rides into `candidate.awaiting_promotion`'s detail and, when the
+  floor is set, auto-promote additionally requires `confidence >= floor` backed by at
+  least `auto_promote_min_samples` bandit pulls — a nil/low/thin confidence fails safe
+  to notify-only. For a **genuine Mode B candidate** (an ask/research agent with no
+  harvester score and no eval_run feedback rows), the bandit pulls stand in for the
+  Mode A feedback-sample floor and the absent score, so the confidence gate alone can
+  promote it — the loop actually closes for ask agents, not just when Mode A evidence
+  is also present. A present score still has to clear `auto_promote_min_score`, and a
+  set `require_external_ci` still applies (a pure ask agent simply leaves it off).
+  **`bandit_min_samples`** (default 30) is the low-traffic floor for the DEFERRED auto
+  loop; the manual `skillopt ab` CLI is always allowed.
 
 See `docs/skillopt-exchange-contract.md` and `docs/events.md` for the full knob
 reference and event shapes.

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -565,5 +565,39 @@ returns and, on a guardrails pass, calls the existing promote machinery.
   `0`**. On a pass it promotes via the existing path and emits
   **`candidate.auto_promoted`** so a human can review or roll back even in full-auto.
 
+### Champion-challenger A/B preferences (Mode B, off by default)
+
+For **ask / research** agents there is no verifiable terminal outcome, so Mode A's
+harvester and the score/CI guardrails above cannot supply a promotion confidence.
+**Mode B** (#473, scoped from RFC #463) closes the loop via **pairwise
+preference**, and is **additive** (`contract_version` stays `1`) and **manual**:
+
+- `gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b]
+  [--seed N] [--home path]` resolves the **champion** (the template's current
+  promoted version) and a **challenger** (a pending candidate version, or
+  `--challenger`), delivers **both** through the runtime adapter **serialized** (so
+  the two one-shot asks never overlap and runtime-session locks release cleanly),
+  presents them **label-shuffled** as Option A / Option B, and records the human
+  pick mapped back to the correct role. **No pending challenger ⇒ a clean no-op**
+  (`nothing to A/B …`), zero rows written.
+- A pick writes one **2-option `eval_run`** (`OptionsCount = 2`,
+  `metadata.feedback_source = preference_ab`, run id `skillopt-ab:<versionId>`),
+  **two `eval_review_options`** (`champion` / `challenger`, answers stored as
+  `eval_artifacts` via the blob path), and **one `RankedFeedbackEvent`**
+  (`ranking = [winner, loser]`, `reviewer = human`, `source = skillopt-ab`) that
+  passes `validateRankedFeedbackEventOptions`. The `source = skillopt-ab` tag keeps
+  Mode B rows separable from Mode A (`auto-trace`) and human gold.
+- Each `(template_id, version_id)` variant is a **Beta-Bernoulli arm** (`Beta(1,1)`
+  prior) persisted in `skillopt_bandit_arms`; a pick increments winner/loser, then
+  the confidence **`P(challenger > champion)`** is recomputed by deterministic (seeded)
+  Monte Carlo and surfaced as `NN% likely better over K samples`.
+- That confidence is the scalar **`[skillopt].auto_promote_min_confidence`** (nil
+  default = ignored, byte-identical to #471) consumes: at the candidate notify seam
+  it rides into `candidate.awaiting_promotion`'s detail and, when the floor is set,
+  auto-promote additionally requires `confidence >= floor` backed by at least
+  `auto_promote_min_samples` bandit pulls — a nil/low/thin confidence fails safe to
+  notify-only. **`bandit_min_samples`** (default 30) is the low-traffic floor for the
+  DEFERRED auto loop; the manual `skillopt ab` CLI is always allowed.
+
 See `docs/skillopt-exchange-contract.md` and `docs/events.md` for the full knob
 reference and event shapes.

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -446,18 +446,23 @@ a **challenger** (the sole pending candidate, or `--challenger <versionId>`),
 delivers **both** through the runtime adapter **serialized**, shows the two
 answers **label-shuffled** as Option A / Option B, and records the human pick
 (`--pick a|b`, or interactively). With **no pending challenger** it is a clean
-no-op. The pick writes one 2-option `eval_run` + two `eval_review_options`
-(`champion`/`challenger`) + one `RankedFeedbackEvent` (`source = skillopt-ab`,
-`contract_version` stays `1`), updates the per-variant **Beta-Bernoulli bandit**
+no-op. The pick writes a 2-option `eval_run` + two `eval_review_options`
+(`champion`/`challenger`) + one `RankedFeedbackEvent` **per pick** (`source =
+skillopt-ab`, `contract_version` stays `1`; a unique per-pick `source_url` makes
+repeated A/Bs of the same challenger each persist as a distinct row instead of
+overwriting one), updates the per-variant **Beta-Bernoulli bandit**
 (`skillopt_bandit_arms`), and prints `P(challenger > champion)` as
 `NN% likely better over K samples`.
 
 That confidence feeds the **`[skillopt].auto_promote_min_confidence`** guardrail
 (nil default = ignored; set = require `confidence >= floor` over enough samples,
 else fail safe to notify-only) — supplying the promotion confidence Mode A could
-not provide for ask agents. `bandit_min_samples` (default 30) gates only the
-**deferred** auto loop; the manual A/B is always allowed. Live interception, the
-cross-family LLM-judge auto-pairwise, canary, and the auto A/B loop are deferred.
+not provide for ask agents. For a genuine ask candidate (no harvester score or
+feedback rows) the bandit pulls stand in for the Mode A sample/score floors, so the
+confidence gate alone can auto-promote it. `bandit_min_samples` (default 30) gates
+only the **deferred** auto loop; the manual A/B is always allowed. Live
+interception, the cross-family LLM-judge auto-pairwise, canary, and the auto A/B
+loop are deferred.
 
 ## Execution Model
 

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -431,6 +431,34 @@ the configurable `[skillopt].auto_promote` policy (#463) when that lands — it 
 not barred from promotion. See
 `skills/gitmoot/references/RESULT_CONTRACT.md` for the full contract.
 
+## Champion-Challenger A/B (Mode B, off by default)
+
+For **ask / research** agents — which have no verifiable PR/CI/merge outcome —
+use the manual champion-challenger A/B to capture a **pairwise preference**
+(#473):
+
+```sh
+gitmoot skillopt ab planner-bot "Plan the data migration." --seed 42
+```
+
+It resolves the **champion** (the agent template's current promoted version) and
+a **challenger** (the sole pending candidate, or `--challenger <versionId>`),
+delivers **both** through the runtime adapter **serialized**, shows the two
+answers **label-shuffled** as Option A / Option B, and records the human pick
+(`--pick a|b`, or interactively). With **no pending challenger** it is a clean
+no-op. The pick writes one 2-option `eval_run` + two `eval_review_options`
+(`champion`/`challenger`) + one `RankedFeedbackEvent` (`source = skillopt-ab`,
+`contract_version` stays `1`), updates the per-variant **Beta-Bernoulli bandit**
+(`skillopt_bandit_arms`), and prints `P(challenger > champion)` as
+`NN% likely better over K samples`.
+
+That confidence feeds the **`[skillopt].auto_promote_min_confidence`** guardrail
+(nil default = ignored; set = require `confidence >= floor` over enough samples,
+else fail safe to notify-only) — supplying the promotion confidence Mode A could
+not provide for ask agents. `bandit_min_samples` (default 30) gates only the
+**deferred** auto loop; the manual A/B is always allowed. Live interception, the
+cross-family LLM-judge auto-pairwise, canary, and the auto A/B loop are deferred.
+
 ## Execution Model
 
 Use `here` when the current chat should answer directly from the Gitmoot skill.

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -310,6 +310,8 @@ auto_promote_min_score = 0.0              # UNSET, or a candidate with no score 
 auto_promote_require_external_ci = false  # require >= 1 real-external-CI feedback event in the eval_run
 auto_promote_require_measured_judge = false  # PARSED but DEFERRED (#344): true => fail safe to no-promote
 auto_promote_canary = false               # PARSED but DEFERRED (canary follow-on): true => fail safe to no-promote
+auto_promote_min_confidence = 0.95        # #473 Mode B: UNSET = ignore; SET = require bandit P(>) >= floor (+ enough samples)
+bandit_min_samples = 30                   # #473 Mode B low-traffic floor for the DEFERRED auto loop (manual `skillopt ab` always allowed)
 ```
 
 The guardrails read the candidate's **harvester auto-trace run**
@@ -341,6 +343,65 @@ auto-trace evidence fails safe to notify-only).
   the sampled-traffic canary + auto-rollback do not exist, so setting either to
   `true` **forces notify-only** today. They are documented so a user can write the
   knob forward-compatibly.
+- `auto_promote_min_confidence` (#473 Mode B) is **additive and optional**. **Unset
+  ignores it entirely** — the auto-promote decision is byte-identical to the
+  guardrails above. When **set**, auto-promote additionally requires a non-nil
+  bandit confidence `P(challenger > champion) >=` this floor, backed by at least
+  `auto_promote_min_samples` bandit pulls (a Beta posterior on a couple of pulls
+  can read 0.9 by luck — the sample floor refuses thin evidence). A nil, low, or
+  thin confidence **fails safe to notify-only**. The confidence is supplied by the
+  manual `skillopt ab` A/B (below); promotion is still the existing
+  `PromoteAgentTemplateVersion` path, never a bypass.
+
+## Champion-challenger A/B preferences (Mode B, off by default)
+
+For **ask / research** agents there is no verifiable terminal outcome (no PR / CI
+/ merge), so Mode A's single-artifact harvester and the score/CI guardrails above
+cannot supply a promotion confidence. **Mode B** (issue #473, scoped from RFC
+#463) closes the loop via **pairwise preference**: A/B a query across two template
+variants and feed the human's pick to the optimizer as a contract
+`RankedFeedbackEvent`.
+
+```sh
+gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--home path]
+```
+
+- **Champion** = the agent template's **current promoted** version; **challenger**
+  = a **pending** candidate version (the sole pending one, or `--challenger`). With
+  **no pending challenger** the command is a clean no-op (`nothing to A/B …`) — no
+  rows are written.
+- It delivers **both** variants through the runtime adapter (serialized, so the two
+  one-shot asks never overlap and runtime-session locks release cleanly), presents
+  the two answers **label-shuffled** as Option A / Option B, and records the human
+  pick. The shuffle mapping is recorded so the stored event maps the pick back to
+  the **correct** champion/challenger label.
+- Each pick writes exactly **one 2-option `eval_run`** (`OptionsCount = 2`,
+  `metadata.feedback_source = preference_ab`, run id `skillopt-ab:<versionId>`),
+  **two `eval_review_options`** (`champion` / `challenger`) whose answer text is
+  stored as `eval_artifacts` via the existing blob path, and **one
+  `RankedFeedbackEvent`** (`ranking = [winner, loser]`, `reviewer = human`,
+  `source = skillopt-ab`) that passes `validateRankedFeedbackEventOptions`. The
+  distinct `source` tag and run-id prefix keep Mode B rows trivially separable from
+  Mode A (`auto-trace`) and human gold. **No contract struct changes —
+  `ContractVersion` stays `1`.**
+
+**The bandit.** Each `(template_id, version_id)` variant is one **Beta-Bernoulli
+arm** (uniform `Beta(1,1)` prior; a win bumps `alpha`, a loss bumps `beta`),
+persisted in the dedicated `skillopt_bandit_arms` table as the sufficient
+statistic. A pick increments the winner (`+win`) and loser (`+loss`), then the
+confidence `P(challenger > champion)` is recomputed by Monte Carlo (deterministic
+given an injected seed) and printed as `NN% likely better over K samples`. That
+scalar is exactly what `auto_promote_min_confidence` consumes: at the candidate
+notify seam the candidate's challenger arm + the champion arm produce the
+confidence carried into `candidate.awaiting_promotion`'s detail and into the
+auto-promote guardrails.
+
+**Tiering.** Below `bandit_min_samples` (default 30) the bandit still records
+preferences and updates the posterior but the **deferred** auto A/B loop never
+runs and the confidence is never trusted to auto-promote (the promotion-side floor
+reuses `auto_promote_min_samples`). The **manual** `skillopt ab` CLI is always
+allowed. Live-traffic interception, the cross-family LLM-judge auto-pairwise,
+canary, and the auto A/B scheduling loop are **deferred** to follow-ons.
 
 ## Ranked Exploration Workflow
 

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -375,15 +375,19 @@ gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [
   the two answers **label-shuffled** as Option A / Option B, and records the human
   pick. The shuffle mapping is recorded so the stored event maps the pick back to
   the **correct** champion/challenger label.
-- Each pick writes exactly **one 2-option `eval_run`** (`OptionsCount = 2`,
+- Each pick writes a 2-option `eval_run` (`OptionsCount = 2`,
   `metadata.feedback_source = preference_ab`, run id `skillopt-ab:<versionId>`),
   **two `eval_review_options`** (`champion` / `challenger`) whose answer text is
   stored as `eval_artifacts` via the existing blob path, and **one
-  `RankedFeedbackEvent`** (`ranking = [winner, loser]`, `reviewer = human`,
-  `source = skillopt-ab`) that passes `validateRankedFeedbackEventOptions`. The
-  distinct `source` tag and run-id prefix keep Mode B rows trivially separable from
-  Mode A (`auto-trace`) and human gold. **No contract struct changes —
-  `ContractVersion` stays `1`.**
+  `RankedFeedbackEvent` per pick** (`ranking = [winner, loser]`, `reviewer =
+  human`, `source = skillopt-ab`) that passes `validateRankedFeedbackEventOptions`.
+  Repeated A/Bs of the **same** challenger each persist as a **distinct** preference
+  row: the `ranked_feedback_events` conflict key is
+  `(run_id, item_id, reviewer, source, source_url)`, and every pick carries a unique
+  per-pick `source_url`, so picks accumulate as evidence instead of overwriting one
+  row. The distinct `source` tag and run-id prefix keep Mode B rows trivially
+  separable from Mode A (`auto-trace`) and human gold. **No contract struct changes
+  — `ContractVersion` stays `1`.**
 
 **The bandit.** Each `(template_id, version_id)` variant is one **Beta-Bernoulli
 arm** (uniform `Beta(1,1)` prior; a win bumps `alpha`, a loss bumps `beta`),


### PR DESCRIPTION
## Mode B first slice (#473, scoped from RFC #463)

The **input half for ask/research agents**, whose outputs have no verifiable PR/CI/merge outcome. A **manual champion-challenger A/B** captures a pairwise preference, feeds it to the optimizer as a contract `RankedFeedbackEvent`, maintains a **Beta-Bernoulli (Thompson) posterior per template version**, and surfaces **`P(challenger>champion)`** as the promotion confidence #471's `auto_promote` gate wanted but Mode A could not supply for ask agents.

### Off by default / additive
- New `auto_promote_min_confidence` (`*float64`) + `bandit_min_samples` (`*int`) on `SkillOptPolicy` are **nil-default ⇒ byte-identical when unset**.
- One **idempotent appended migration** creates `skillopt_bandit_arms`; **`ContractVersion` stays `1`** (no contract-struct change). Pairwise data rides existing `RankedFeedbackEvent` + `eval_review_options`.
- **Manual promotion preserved**: a crossed confidence only **notifies** unless `auto_promote=true` (default false); the confidence floor is an additional **fail-safe** guardrail, never a bypass of `PromoteAgentTemplateVersion`.

### What ships
- **`internal/skillopt/bandit.go`** — pure, I/O-free engine: `BetaParams`/`BanditArm`, `NewArm`, `Update`, `SampleTheta(*rand.Rand)` (Beta via two Gamma draws), `ProbChallengerBeats` (Monte Carlo). **Deterministic given an injected seeded `*rand.Rand`**, validated by a **mandatory closed-form Beta-exceedance cross-check** test.
- **db** — `skillopt_bandit_arms` + `GetBanditArm`/`UpsertBanditArm`/`IncrementBanditArm`.
- **`internal/cli/skillopt_ab.go`** — `gitmoot skillopt ab <agent> "<prompt>" [--challenger v] [--pick a|b] [--seed N] [--home p]`. Resolves champion (current promoted) + challenger (a pending version), delivers **both serialized** via the runtime factory seam, **label-shuffles** and maps the pick back to the correct role, writes a 2-option `eval_run` + two options + answer artifacts + one `RankedFeedbackEvent` (`source=skillopt-ab`, run id `skillopt-ab:<versionId>`), increments both arms, prints `P(>)`. **No pending challenger ⇒ clean no-op.**
- **`EvaluateAutoPromote`** gains an **additive optional** confidence guardrail; `runCandidateNotify` computes the bandit confidence at the notify seam and carries `NN% likely better over K samples` into `candidate.awaiting_promotion`.
- **Tiering** — below `bandit_min_samples` the bandit records preferences but the deferred auto loop never trips `auto_promote`; the manual A/B is always allowed.

### Tests
Bandit determinism + the closed-form vs MC cross-check; label-shuffle `pick→winner` correctness under **both** shuffles; a recorded pick writes a `RankedFeedbackEvent` **accepted by** `validateRankedFeedbackEventOptions` with both arms updated and the confidence computed; the new `min_confidence` guardrail cases; config parse; off-by-default no-rows.

Gate green locally: `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race ./internal/skillopt/ ./internal/cli/ ./internal/db/`.

### Deferred
Live-traffic interception in `runAgentAsk`/`Deliver`, the #470 cross-family LLM-judge auto-pairwise, canary, and the auto A/B scheduling loop.

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)