### PR TITLE
feat(skillopt): wire automatic revert detection to corrective OutcomeReverted harvest (#467)

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -191,12 +191,22 @@ mirrors the off-by-default `[events]` stream.
 - **Reverted** → corrective negative. A later revert of a previously-merged PR
   **re-upserts the same** `UNIQUE(run_id, item_id, reviewer, source, source_url)`
   row, flipping the earlier positive `choice = a` to `choice = b` **in place**
-  (the row count is unchanged). **Not yet wired:** the projection and the
-  in-place corrective upsert are implemented and unit-tested, but no engine or
-  daemon path detects a revert and fires the `reverted` outcome today, so in a
-  running daemon a merged-then-reverted PR keeps its prior positive until revert
-  detection is wired (a follow-on). The corrective-overwrite mechanics above are
-  reachable only by invoking the harvester directly with a `reverted` outcome.
+  (the row count is unchanged). **Wired (#467):** the daemon PR-watcher detects a
+  GitHub Revert-button PR — whose body is `Reverts owner/repo#NN` / `Reverts #NN`,
+  same-repo only — being **merged**, parses the **original** PR number, and (via
+  `Engine.HandlePullRequestReverted` → `implementJobForTask` → the harvester)
+  fires the `reverted` outcome against the original PR's auto-trace row, attributed
+  to the original implement job's template version. It is gated off-by-default on
+  `auto_trace_enabled` **and** the optional opt-out `revert_detection_enabled`
+  (unset = on whenever the harvester is on; set `false` to keep the harvester
+  running but turn the corrective revert overwrites off). It is best-effort and
+  fail-safe: a malformed/cross-repo body, an unresolvable original implement job,
+  or a harvest error never blocks or fails the poll. Re-polling the persistent
+  revert PR is idempotent (the in-place upsert re-writes the same `choice = b`
+  row). **Not detected** (best-effort v1): a revert opened without the
+  `Reverts #NN` body line, or a `git revert` pushed straight to the default branch
+  with no PR. With `auto_trace_enabled` off (the default) **no PR body is parsed**
+  and behavior is byte-identical.
 
 **Scope.** Only implement-family jobs that carry a template attribution are
 harvested; coordinator continuation jobs (which produce no diff of their own) and

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -271,13 +271,14 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		defaultJobWorker(store, stdout, *home).applyOrchestratePolicy(&engine)
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
 		return runSingleRepoSupervisor(ctx, *home, daemon.Daemon{
-			Repo:          repo,
-			PollInterval:  *poll,
-			Store:         store,
-			GitHub:        gh,
-			Workflow:      &engine,
-			WatchIssues:   *watchIssues,
-			EscalationTTL: resolveEscalationTTL(*home),
+			Repo:                   repo,
+			PollInterval:           *poll,
+			Store:                  store,
+			GitHub:                 gh,
+			Workflow:               &engine,
+			WatchIssues:            *watchIssues,
+			EscalationTTL:          resolveEscalationTTL(*home),
+			RevertDetectionEnabled: resolveRevertDetectionEnabled(*home),
 		}, store, *workers, usePool, session, stdout)
 	})
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -1292,16 +1293,17 @@ func (s registeredRepoSchedule) ensure() registeredRepoSchedule {
 }
 
 type registeredRepoPoller struct {
-	Store           *db.Store
-	Workers         int
-	DryRun          bool
-	Stdout          io.Writer
-	RecoveryOnly    bool
-	WatchIssues     bool
-	EscalationTTL   time.Duration
-	CheckoutLocks   *repoCheckoutLocks
-	GitHubClient    func(checkout string) github.Client
-	WorkflowFactory func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
+	Store                  *db.Store
+	Workers                int
+	DryRun                 bool
+	Stdout                 io.Writer
+	RecoveryOnly           bool
+	WatchIssues            bool
+	EscalationTTL          time.Duration
+	RevertDetectionEnabled bool
+	CheckoutLocks          *repoCheckoutLocks
+	GitHubClient           func(checkout string) github.Client
+	WorkflowFactory        func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
 }
 
 // defaultRegisteredRepoPoller wires the registered-repo supervisor's per-tick
@@ -1321,12 +1323,13 @@ type registeredRepoPoller struct {
 // leaves ArtifactRoot/Home/EventSink unset.
 func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdout io.Writer, rawHome, resolvedRoot string) registeredRepoPoller {
 	return registeredRepoPoller{
-		Store:         store,
-		Workers:       workers,
-		DryRun:        dryRun,
-		Stdout:        stdout,
-		EscalationTTL: resolveEscalationTTL(rawHome),
-		GitHubClient:  func(checkout string) github.Client { return github.NewClient(checkout) },
+		Store:                  store,
+		Workers:                workers,
+		DryRun:                 dryRun,
+		Stdout:                 stdout,
+		EscalationTTL:          resolveEscalationTTL(rawHome),
+		RevertDetectionEnabled: resolveRevertDetectionEnabled(rawHome),
+		GitHubClient:           func(checkout string) github.Client { return github.NewClient(checkout) },
 		WorkflowFactory: func(store *db.Store, gh github.Client, checkout string) *workflow.Engine {
 			engine := daemonWorkflowEngine(store, gh, checkout, resolvedRoot)
 			// Apply only the escalate_human notifier handle from policy (#340),
@@ -1448,12 +1451,13 @@ func (p registeredRepoPoller) pollRepo(ctx context.Context, repoRecord db.Repo, 
 		}
 	}
 	d := daemon.Daemon{
-		Repo:          repo,
-		Store:         store,
-		GitHub:        gh,
-		Workflow:      engine,
-		WatchIssues:   p.WatchIssues,
-		EscalationTTL: p.EscalationTTL,
+		Repo:                   repo,
+		Store:                  store,
+		GitHub:                 gh,
+		Workflow:               engine,
+		WatchIssues:            p.WatchIssues,
+		EscalationTTL:          p.EscalationTTL,
+		RevertDetectionEnabled: p.RevertDetectionEnabled,
 	}
 	if recoveryOnly {
 		err = d.PollRecoveryCommandsOnce(ctx)

--- a/internal/cli/trace_harvest_daemon.go
+++ b/internal/cli/trace_harvest_daemon.go
@@ -44,6 +44,21 @@ func loadSkillOptPolicy(home string) (config.SkillOptPolicy, error) {
 	return config.LoadSkillOptPolicy(config.Paths{ConfigFile: cfg})
 }
 
+// resolveRevertDetectionEnabled resolves the daemon's corrective revert-detection
+// gate for a home (#467): true only when [skillopt].auto_trace_enabled AND the
+// optional opt-out revert_detection_enabled (nil=on) both hold. It is FAIL-SAFE to
+// false on any config-load error, so a malformed config never turns the (delayed,
+// corrective) revert overwrites on — matching daemonOutcomeHarvester's
+// fail-safe-to-disabled gate. With auto_trace off (the default) this is always
+// false, so the daemon parses no PR bodies — byte-identical default.
+func resolveRevertDetectionEnabled(home string) bool {
+	policy, err := loadSkillOptPolicy(home)
+	if err != nil {
+		return false
+	}
+	return policy.RevertDetectionEnabled()
+}
+
 // daemonReviewLegDispatcher returns the best-effort cross-family review-leg
 // dispatcher for this home (#469), or nil when the review knob is OFF — the
 // default, or any config-load failure (fail-safe to disabled). ReviewEnabled()

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -65,7 +65,11 @@ escalation_ttl = ""
 # event emission, and promotion stays fully MANUAL. auto_trace_enabled opts the
 # daemon into harvesting an implement job's verifiable terminal outcome into a
 # synthetic feedback event; cross_family_review_enabled (requires auto_trace) adds
-# a down-weighted cross-family review soft signal. auto_promote (#471) opts into
+# a down-weighted cross-family review soft signal. revert_detection_enabled (#467,
+# requires auto_trace; UNSET = on) lets the daemon detect a merged GitHub
+# Revert-button PR (body "Reverts owner/repo#NN") and CORRECT the original PR's
+# auto-trace positive to a negative in place; set it false to keep the harvester on
+# but turn the (delayed, corrective) revert overwrites OFF. auto_promote (#471) opts into
 # AUTO-PROMOTING a newly-pending candidate, but ONLY when every configured
 # guardrail below holds — any uncertainty fails safe to notify-only (no promote).
 # A pending candidate ALWAYS emits candidate.awaiting_promotion when [events] is
@@ -103,6 +107,7 @@ escalation_ttl = ""
 # [skillopt]
 # auto_trace_enabled = false
 # cross_family_review_enabled = false
+# revert_detection_enabled = true
 # auto_promote = false
 # auto_promote_min_samples = 0
 # auto_promote_min_score = 0.0

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -390,6 +390,21 @@ type SkillOptPolicy struct {
 	// per merge is a real cost surface, so it must be opt-in.
 	CrossFamilyReviewEnabled bool
 
+	// RevertDetectionEnabled is the optional opt-OUT sub-knob for the corrective
+	// OutcomeReverted harvest (#467): the daemon detects a GitHub Revert-button PR
+	// (`Reverts owner/repo#NN`) being merged, maps it to the ORIGINAL PR's auto-trace
+	// row, and overwrites the prior positive with a negative in place. It is a
+	// *bool: nil (unset, the default) means ON whenever the harvester is on — so it
+	// rides AutoTraceEnabled with no extra config. An explicit false turns the
+	// (delayed, corrective) revert overwrites OFF while keeping the harvester running
+	// for merge/block/changes-requested. RevertDetectionEnabled() encodes the
+	// dependency (AutoTraceEnabled AND (nil || *ptr)), mirroring ReviewEnabled().
+	// With AutoTraceEnabled false this is irrelevant — no detection ever runs and no
+	// PR body is parsed (byte-identical default). The field is named RevertDetection
+	// (not …Enabled) because Go forbids a field and method sharing a name; the
+	// RevertDetectionEnabled() method below is the resolved accessor callers use.
+	RevertDetection *bool
+
 	// AutoPromote opts into the off-by-default auto-promote policy (#471): when
 	// false (the default) a newly-pending candidate is ONLY notified
 	// (candidate.awaiting_promotion) and NEVER auto-promoted — promotion stays
@@ -450,6 +465,7 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 	return SkillOptPolicy{
 		AutoTraceEnabled:                false,
 		CrossFamilyReviewEnabled:        false,
+		RevertDetection:                 nil,
 		AutoPromote:                     false,
 		AutoPromoteMinSamples:           nil,
 		AutoPromoteMinScore:             nil,
@@ -473,6 +489,17 @@ func (p SkillOptPolicy) Enabled() bool {
 // so enabling the review knob alone — without the auto-trace harvester — is OFF.
 func (p SkillOptPolicy) ReviewEnabled() bool {
 	return p.AutoTraceEnabled && p.CrossFamilyReviewEnabled
+}
+
+// RevertDetectionEnabled reports whether the corrective OutcomeReverted harvest
+// (#467) is configured on. It requires AutoTraceEnabled (a revert overwrite only
+// makes sense inside the auto-trace run) AND the optional opt-OUT sub-knob
+// revert_detection_enabled: nil (unset, the default) is ON-when-the-harvester-is-on,
+// an explicit false turns ONLY the revert overwrites off. With AutoTraceEnabled
+// false this is always false — no detection runs and no PR body is parsed
+// (byte-identical default), mirroring ReviewEnabled()'s dependency on AutoTraceEnabled.
+func (p SkillOptPolicy) RevertDetectionEnabled() bool {
+	return p.AutoTraceEnabled && (p.RevertDetection == nil || *p.RevertDetection)
 }
 
 func LoadSkillOptPolicy(paths Paths) (SkillOptPolicy, error) {
@@ -516,6 +543,13 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 		parsed, err := strconv.ParseBool(value)
 		policy.CrossFamilyReviewEnabled = parsed
 		return err
+	case "revert_detection_enabled":
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		policy.RevertDetection = &parsed
+		return nil
 	case "auto_promote":
 		parsed, err := strconv.ParseBool(value)
 		policy.AutoPromote = parsed

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -235,3 +235,118 @@ webhook_url = "https://example.test/hook"
 		t.Fatalf("SkillOptPolicy must stay disabled when only [events] is set, got %+v", policy)
 	}
 }
+
+// TestRevertDetectionDefaultsOnWithAutoTrace: the #467 sub-knob is UNSET by default
+// (nil) and rides AutoTraceEnabled — RevertDetectionEnabled() is true whenever the
+// harvester is on with no extra config, but false when auto_trace is off.
+func TestRevertDetectionDefaultsOnWithAutoTrace(t *testing.T) {
+	policy := DefaultSkillOptPolicy()
+	if policy.RevertDetection != nil {
+		t.Fatalf("revert_detection must default UNSET (nil), got %+v", policy.RevertDetection)
+	}
+	// auto_trace off (the default) => detection off, byte-identical.
+	if policy.RevertDetectionEnabled() {
+		t.Fatal("RevertDetectionEnabled() must be false with auto_trace off")
+	}
+	// auto_trace on, knob unset => detection ON (nil = on-when-harvester-on).
+	policy.AutoTraceEnabled = true
+	if !policy.RevertDetectionEnabled() {
+		t.Fatal("RevertDetectionEnabled() must be true with auto_trace on and the knob unset")
+	}
+}
+
+// TestRevertDetectionRequiresAutoTrace: revert_detection_enabled = true alone
+// (without auto_trace) is OFF — RevertDetectionEnabled() requires the harvester.
+func TestRevertDetectionRequiresAutoTrace(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+revert_detection_enabled = true
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if policy.RevertDetection == nil || !*policy.RevertDetection {
+		t.Fatalf("revert_detection_enabled = true should parse to *true, got %+v", policy.RevertDetection)
+	}
+	if policy.RevertDetectionEnabled() {
+		t.Fatal("RevertDetectionEnabled() must be false without auto_trace_enabled (requires the harvester)")
+	}
+}
+
+// TestRevertDetectionOptOutWithAutoTrace: auto_trace on but
+// revert_detection_enabled = false keeps the harvester on while turning the
+// corrective revert overwrites OFF.
+func TestRevertDetectionOptOutWithAutoTrace(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_trace_enabled = true
+revert_detection_enabled = false
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.Enabled() {
+		t.Fatal("auto_trace_enabled = true should keep the harvester on")
+	}
+	if policy.RevertDetection == nil || *policy.RevertDetection {
+		t.Fatalf("revert_detection_enabled = false should parse to *false, got %+v", policy.RevertDetection)
+	}
+	if policy.RevertDetectionEnabled() {
+		t.Fatal("RevertDetectionEnabled() must be false when explicitly opted out")
+	}
+}
+
+// TestRevertDetectionEnabledWithAutoTraceExplicitTrue: both auto_trace and
+// revert_detection_enabled = true => RevertDetectionEnabled().
+func TestRevertDetectionEnabledWithAutoTraceExplicitTrue(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_trace_enabled = true
+revert_detection_enabled = true
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.RevertDetectionEnabled() {
+		t.Fatalf("RevertDetectionEnabled() must be true with both knobs on, got %+v", policy)
+	}
+}
+
+// TestRevertDetectionRejectsBadBool: a non-bool revert_detection_enabled is a load
+// error (the daemon fail-safes to disabled around it).
+func TestRevertDetectionRejectsBadBool(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+revert_detection_enabled = maybe
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadSkillOptPolicy(paths); err == nil {
+		t.Fatal("expected an error for a non-bool revert_detection_enabled")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -33,6 +34,15 @@ type Daemon struct {
 	// PollOnce auto-finalizes it gracefully (#340). 0 disables the scan, keeping
 	// behavior unchanged for trees that never use escalate_human.
 	EscalationTTL time.Duration
+	// RevertDetectionEnabled opts PollOnce into corrective revert detection (#467):
+	// when true, a polled PR whose body is `Reverts owner/repo#NN` and which is
+	// merged maps back to the ORIGINAL PR's auto-trace row and fires
+	// Workflow.HandlePullRequestReverted (best-effort) to overwrite the prior
+	// positive with a negative in place. Resolved once at construction from
+	// [skillopt].RevertDetectionEnabled() (AutoTraceEnabled AND the opt-out knob).
+	// Default false is a CHEAP SHORT-CIRCUIT: PollOnce parses NO PR body and fires
+	// nothing, so the off path is byte-identical (no new GitHub reads, no new work).
+	RevertDetectionEnabled bool
 }
 
 func (d Daemon) Run(ctx context.Context) error {
@@ -116,6 +126,16 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 			}
 		}
 		if err := d.reconcileReviewingPullRequest(ctx, pull); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	// Corrective revert detection (#467): OFF-BY-DEFAULT cheap short-circuit. When
+	// disabled, the scan never runs — no extra GitHub read, no PR body parsed, no
+	// fire — so the off path is byte-identical. When enabled it lists closed PRs
+	// (a merged GitHub Revert-button PR is closed, not in the "open" set above) and
+	// fires the corrective harvest best-effort; an error never aborts the poll.
+	if d.RevertDetectionEnabled {
+		if err := d.harvestRevertsOnce(ctx); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -545,6 +565,116 @@ func (d Daemon) lookupPullRequestTask(ctx context.Context, repoFullName string, 
 		return db.Task{}, sql.ErrNoRows
 	}
 	return task, nil
+}
+
+// revertBodyPattern matches the GitHub Revert-button PR body anchor (#467):
+// `Reverts owner/repo#NN` or `Reverts #NN`. The owner/repo segment is captured so
+// harvestRevertIfAny can reject a CROSS-REPO reference (the harvester's item_id is
+// repo-scoped and the daemon polls one repo). Case-insensitive on "Reverts" so a
+// hand-edited "reverts #N" still matches.
+var revertBodyPattern = regexp.MustCompile(`(?i)\breverts\s+(?:([\w.-]+/[\w.-]+))?#(\d+)\b`)
+
+// revertedOriginalPR parses a polled PR's body for the GitHub Revert-button anchor
+// and returns the ORIGINAL (reverted) PR number when the body references a
+// SAME-REPO PR (#467). It returns ok=false for a body with no `Reverts #NN`
+// anchor, a malformed/unparseable number, or a CROSS-REPO reference (an
+// owner/repo prefix that is not d.Repo) — so a foreign Reverts never maps onto
+// this repo's item_id. It is a pure string parse with no side effects, kept
+// isolated for unit testing.
+func (d Daemon) revertedOriginalPR(pull github.PullRequest) (int, bool) {
+	body := strings.TrimSpace(pull.Body)
+	if body == "" {
+		return 0, false
+	}
+	match := revertBodyPattern.FindStringSubmatch(body)
+	if match == nil {
+		return 0, false
+	}
+	if repoRef := strings.TrimSpace(match[1]); repoRef != "" {
+		// An explicit owner/repo prefix must match the polled repo exactly; a
+		// cross-repo Reverts reference does not map onto this repo's item_id.
+		if !strings.EqualFold(repoRef, d.Repo.FullName()) {
+			return 0, false
+		}
+	}
+	number, err := strconv.Atoi(match[2])
+	if err != nil || number <= 0 {
+		return 0, false
+	}
+	return number, true
+}
+
+// harvestRevertsOnce scans CLOSED PRs for merged GitHub Revert-button PRs and
+// fires the corrective OutcomeReverted harvest for each (#467). It is called from
+// PollOnce ONLY when RevertDetectionEnabled, so the off path issues no extra
+// GitHub read and parses no bodies (byte-identical). A merged revert PR is closed
+// (the "open" loop above never sees it), so the merged-revert anchor lives here in
+// the closed set. Best-effort: a list error returns up for firstErr collection but
+// per-PR harvest errors are collected and never abort the scan.
+func (d Daemon) harvestRevertsOnce(ctx context.Context) error {
+	if d.Workflow == nil {
+		return nil
+	}
+	closed, err := d.GitHub.ListPullRequests(ctx, d.Repo, "closed")
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for _, pull := range closed {
+		if err := d.harvestRevertIfAny(ctx, pull); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// harvestRevertIfAny fires the corrective OutcomeReverted harvest for the ORIGINAL
+// PR a (now-merged) revert PR undid (#467). It is called per closed PR from
+// harvestRevertsOnce ONLY when RevertDetectionEnabled, so the off path parses no
+// bodies. It
+// is best-effort and FAIL-SAFE: it fires ONLY when the revert PR itself is MERGED
+// (so a not-yet-landed revert never corrects), the engine carries a harvester
+// (nil-safe HandlePullRequestReverted), and the body parses to a same-repo
+// original PR number. Errors from the engine are returned for collection into the
+// poll's firstErr but never abort the loop (PollOnce calls it best-effort), and
+// HandlePullRequestReverted itself swallows the actual harvest error.
+func (d Daemon) harvestRevertIfAny(ctx context.Context, pull github.PullRequest) error {
+	if d.Workflow == nil {
+		return nil
+	}
+	// Fire on a LANDED revert only: a merged revert PR (or a closed-as-merged one).
+	if !revertPullMerged(pull) {
+		return nil
+	}
+	original, ok := d.revertedOriginalPR(pull)
+	if !ok {
+		return nil
+	}
+	// Best-effort attribution hints: resolve the original PR's branch/task so
+	// implementJobForTask's sameTask has the strongest possible match. A lookup
+	// failure degrades to the Repo+PR-only match (still correct via sameTask).
+	event := workflow.RevertEvent{
+		Repo:                d.Repo.FullName(),
+		OriginalPullRequest: original,
+	}
+	if stored, err := d.Store.GetPullRequest(ctx, d.Repo.FullName(), int64(original)); err == nil {
+		event.OriginalBranch = stored.HeadBranch
+		if task, terr := d.lookupPullRequestTask(ctx, d.Repo.FullName(), stored.HeadBranch); terr == nil {
+			event.OriginalTaskID = task.ID
+		}
+	}
+	return d.Workflow.HandlePullRequestReverted(ctx, event)
+}
+
+// revertPullMerged reports whether a polled revert PR has LANDED, so the corrective
+// overwrite only fires on a merged revert (#467). github.ListPullRequests(state)
+// surfaces Merged on closed PRs; a "merged" state string or the Merged flag both
+// count.
+func revertPullMerged(pull github.PullRequest) bool {
+	if pull.Merged {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(pull.State), "merged")
 }
 
 func (d Daemon) workflowReviewers(ctx context.Context) ([]string, error) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -604,18 +604,25 @@ func (d Daemon) revertedOriginalPR(pull github.PullRequest) (int, bool) {
 	return number, true
 }
 
-// harvestRevertsOnce scans CLOSED PRs for merged GitHub Revert-button PRs and
-// fires the corrective OutcomeReverted harvest for each (#467). It is called from
-// PollOnce ONLY when RevertDetectionEnabled, so the off path issues no extra
-// GitHub read and parses no bodies (byte-identical). A merged revert PR is closed
-// (the "open" loop above never sees it), so the merged-revert anchor lives here in
-// the closed set. Best-effort: a list error returns up for firstErr collection but
-// per-PR harvest errors are collected and never abort the scan.
+// harvestRevertsOnce scans recently-closed PRs for merged GitHub Revert-button
+// PRs and fires the corrective OutcomeReverted harvest for each (#467). It is
+// called from PollOnce ONLY when RevertDetectionEnabled, so the off path issues no
+// extra GitHub read and parses no bodies (byte-identical). A merged revert PR is
+// closed (the "open" loop above never sees it), so the merged-revert anchor lives
+// here in the closed set.
+//
+// BOUNDED COST: it uses ListRecentClosedPullRequests (one page of the
+// most-recently-updated closed PRs, no --paginate) rather than walking the repo's
+// entire closed-PR history every tick. A freshly-merged revert is recently
+// updated, so it lands at the top of that window; steady-state polling is a single
+// fixed GitHub request, not O(all-closed-PRs). Best-effort: a list error returns
+// up for firstErr collection but per-PR harvest errors are collected and never
+// abort the scan.
 func (d Daemon) harvestRevertsOnce(ctx context.Context) error {
 	if d.Workflow == nil {
 		return nil
 	}
-	closed, err := d.GitHub.ListPullRequests(ctx, d.Repo, "closed")
+	closed, err := d.GitHub.ListRecentClosedPullRequests(ctx, d.Repo)
 	if err != nil {
 		return err
 	}
@@ -667,10 +674,19 @@ func (d Daemon) harvestRevertIfAny(ctx context.Context, pull github.PullRequest)
 }
 
 // revertPullMerged reports whether a polled revert PR has LANDED, so the corrective
-// overwrite only fires on a merged revert (#467). github.ListPullRequests(state)
-// surfaces Merged on closed PRs; a "merged" state string or the Merged flag both
-// count.
+// overwrite only fires on a merged revert (#467).
+//
+// CRITICAL: these PRs come from the GitHub LIST endpoint
+// (ListPullRequests state="closed"), which reports merged PRs as state="closed"
+// and OMITS the top-level `merged` boolean — `merged` is computed only on the
+// single-PR GET endpoint. The list's ONLY merged signal is `merged_at`, so the
+// non-empty MergedAt check is the load-bearing one against real GitHub data; the
+// Merged flag and "merged" state string are kept only as belt-and-suspenders for
+// the single-PR shape and never fire on a list item.
 func revertPullMerged(pull github.PullRequest) bool {
+	if strings.TrimSpace(pull.MergedAt) != "" {
+		return true
+	}
 	if pull.Merged {
 		return true
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2308,6 +2308,7 @@ func testStore(t *testing.T) *db.Store {
 type fakeGitHub struct {
 	pulls                 []github.PullRequest
 	pullsByState          map[string][]github.PullRequest
+	pullsByNumber         map[int64]github.PullRequest
 	issues                []github.Issue
 	comments              map[int64][]github.IssueComment
 	posted                []postedComment
@@ -2423,7 +2424,12 @@ func (f *fakeGitHub) UpdatePullRequestBranch(context.Context, github.UpdatePullR
 	return github.UpdatePullRequestBranchResult{}, errors.New("not implemented")
 }
 
-func (f *fakeGitHub) GetPullRequest(context.Context, github.Repository, int64) (github.PullRequest, error) {
+func (f *fakeGitHub) GetPullRequest(_ context.Context, _ github.Repository, number int64) (github.PullRequest, error) {
+	if f.pullsByNumber != nil {
+		if pull, ok := f.pullsByNumber[number]; ok {
+			return pull, nil
+		}
+	}
 	return github.PullRequest{}, errors.New("not implemented")
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2317,6 +2317,7 @@ type fakeGitHub struct {
 	listPullRequestsCalls int
 	listPullRequestsErrs  []error
 	listIssuesCalls       int
+	recentClosedCalls     int
 }
 
 type postedComment struct {
@@ -2363,6 +2364,18 @@ func (f *fakeGitHub) ListPullRequests(_ context.Context, _ github.Repository, st
 	}
 	if f.pullsByState != nil {
 		return append([]github.PullRequest(nil), f.pullsByState[state]...), nil
+	}
+	return append([]github.PullRequest(nil), f.pulls...), nil
+}
+
+// ListRecentClosedPullRequests models the bounded closed-PR scan (#467): the fake
+// simply returns the "closed"-state fixtures (the test fixtures are already small,
+// so a single page covers them). It counts calls so the off-path byte-identical
+// test can prove no closed read happens when revert detection is disabled.
+func (f *fakeGitHub) ListRecentClosedPullRequests(_ context.Context, _ github.Repository) ([]github.PullRequest, error) {
+	f.recentClosedCalls++
+	if f.pullsByState != nil {
+		return append([]github.PullRequest(nil), f.pullsByState["closed"]...), nil
 	}
 	return append([]github.PullRequest(nil), f.pulls...), nil
 }

--- a/internal/daemon/revert_detection_test.go
+++ b/internal/daemon/revert_detection_test.go
@@ -1,0 +1,286 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestRevertedOriginalPRParsesBody covers the pure body-parser (#467): a GitHub
+// Revert-button body maps to the ORIGINAL same-repo PR number; no-match,
+// cross-repo, and malformed bodies all reject.
+func TestRevertedOriginalPRParsesBody(t *testing.T) {
+	d := Daemon{Repo: github.Repository{Owner: "jerryfane", Name: "gitmoot"}}
+	cases := []struct {
+		name string
+		body string
+		want int
+		ok   bool
+	}{
+		{"plain reverts hash", "Reverts #7", 7, true},
+		{"owner repo reference", "Reverts jerryfane/gitmoot#42", 42, true},
+		{"lowercase reverts", "reverts #11", 11, true},
+		{"embedded in prose", "This PR\n\nReverts jerryfane/gitmoot#9\n\ncc @someone", 9, true},
+		{"no anchor", "Just a normal PR description.", 0, false},
+		{"empty body", "", 0, false},
+		{"cross repo owner", "Reverts otherowner/gitmoot#7", 0, false},
+		{"cross repo name", "Reverts jerryfane/other#7", 0, false},
+		{"malformed no number", "Reverts #", 0, false},
+		{"zero pr", "Reverts #0", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := d.revertedOriginalPR(github.PullRequest{Body: tc.body})
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("revertedOriginalPR(%q) = (%d, %v), want (%d, %v)", tc.body, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// seedHarvestedPositive installs a template, a completed implement job attributed
+// to its version, the original PR row, and writes the ORIGINAL merge's choice=a
+// auto-trace feedback row (by running the harvester's merge path), returning the
+// version id so a test can inspect the corrective overwrite.
+func seedHarvestedPositive(t *testing.T, store *db.Store, repo github.Repository, originalPR int64, branch string) string {
+	t.Helper()
+	ctx := context.Background()
+	template := db.AgentTemplate{
+		ID:             "planner",
+		Name:           "Planner",
+		SourceRepo:     "cursor/plugins",
+		SourceRef:      "main",
+		SourcePath:     "planner.md",
+		ResolvedCommit: "commit-1",
+		Content:        "Do the work.",
+	}
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, template.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+
+	payload := workflow.JobPayload{
+		Repo:                   repo.FullName(),
+		Branch:                 branch,
+		PullRequest:            int(originalPR),
+		TaskID:                 branch,
+		TemplateID:             template.ID,
+		TemplateResolvedCommit: template.ResolvedCommit,
+		Result:                 &workflow.AgentResult{Decision: "implemented", Summary: "did the work"},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{
+		ID:      "implement-original",
+		Agent:   "lead",
+		Type:    "implement",
+		State:   string(workflow.JobSucceeded),
+		Payload: string(encoded),
+	}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           branch,
+		RepoFullName: repo.FullName(),
+		Title:        "Task 7",
+		State:        "merged",
+		Branch:       branch,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       originalPR,
+		URL:          "https://github.com/" + repo.FullName() + "/pull/7",
+		HeadBranch:   branch,
+		BaseBranch:   "main",
+		HeadSHA:      "orig-head",
+		State:        "merged",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest original returned error: %v", err)
+	}
+
+	// Write the ORIGINAL merge's choice=a positive via the real harvester so the
+	// corrective overwrite later targets the exact same UNIQUE row.
+	harvester := skillopt.NewOutcomeHarvester(store, nil)
+	if err := harvester.Harvest(ctx, db.Job{ID: "implement-original", Type: "implement"}, payload, workflow.Outcome{
+		Kind: workflow.OutcomeMerged, Repo: repo.FullName(), PullRequest: int(originalPR), HeadSHA: "orig-head",
+	}); err != nil {
+		t.Fatalf("seed Harvest (merge) returned error: %v", err)
+	}
+	return installed.VersionID
+}
+
+func revertFeedback(t *testing.T, store *db.Store, versionID string) []db.FeedbackEvent {
+	t.Helper()
+	events, err := store.ListFeedbackEvents(context.Background(), skillopt.AutoTraceRunID(versionID))
+	if err != nil {
+		t.Fatalf("ListFeedbackEvents returned error: %v", err)
+	}
+	return events
+}
+
+func revertDaemonEngine(store *db.Store) *workflow.Engine {
+	return &workflow.Engine{
+		Store:            store,
+		OutcomeHarvester: skillopt.NewOutcomeHarvester(store, nil),
+		JobID: func(request workflow.JobRequest) string {
+			return strings.Join([]string{request.Action, request.Agent, request.TaskID}, "-")
+		},
+	}
+}
+
+// TestPollOnceCorrectsOnMergedRevert proves the wired daemon trigger (#467): with
+// RevertDetectionEnabled, a merged revert PR (body `Reverts #7`) in the closed set
+// flips the original PR's auto-trace row a -> b in place (count unchanged), and a
+// second poll is idempotent.
+func TestPollOnceCorrectsOnMergedRevert(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	versionID := seedHarvestedPositive(t, store, repo, 7, "task-7")
+
+	before := revertFeedback(t, store, versionID)
+	if len(before) != 1 || before[0].Choice != "a" {
+		t.Fatalf("expected one choice=a row before revert, got %+v", before)
+	}
+
+	client := &fakeGitHub{
+		pullsByState: map[string][]github.PullRequest{
+			"open": {},
+			"closed": {{
+				Number:  20,
+				Title:   `Revert "Task 7"`,
+				State:   "merged",
+				Merged:  true,
+				URL:     "https://github.com/jerryfane/gitmoot/pull/20",
+				Body:    "Reverts #7",
+				HeadRef: "revert-task-7",
+				BaseRef: "main",
+			}},
+		},
+		comments: map[int64][]github.IssueComment{},
+	}
+	d := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: revertDaemonEngine(store), RevertDetectionEnabled: true}
+
+	if err := d.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	after := revertFeedback(t, store, versionID)
+	if len(after) != 1 {
+		t.Fatalf("revert must overwrite in place, got %d rows: %+v", len(after), after)
+	}
+	if after[0].Choice != "b" {
+		t.Fatalf("revert must flip choice a -> b, got %q", after[0].Choice)
+	}
+	if after[0].ItemID != before[0].ItemID {
+		t.Fatalf("revert wrote a different item id %q vs %q", after[0].ItemID, before[0].ItemID)
+	}
+
+	// A second poll re-fires the same in-place upsert: still one row, still b.
+	if err := d.PollOnce(ctx); err != nil {
+		t.Fatalf("second PollOnce returned error: %v", err)
+	}
+	idempotent := revertFeedback(t, store, versionID)
+	if len(idempotent) != 1 || idempotent[0].Choice != "b" {
+		t.Fatalf("re-poll must be idempotent (one choice=b row), got %+v", idempotent)
+	}
+}
+
+// TestPollOnceSkipsUnmergedRevert proves an OPEN (not-yet-landed) revert PR does
+// not correct: detection fires on a merged revert only.
+func TestPollOnceSkipsUnmergedRevert(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	versionID := seedHarvestedPositive(t, store, repo, 7, "task-7")
+
+	client := &fakeGitHub{
+		pullsByState: map[string][]github.PullRequest{
+			"open": {},
+			"closed": {{
+				Number:  21,
+				Title:   `Revert "Task 7"`,
+				State:   "closed", // closed but NOT merged
+				Merged:  false,
+				URL:     "https://github.com/jerryfane/gitmoot/pull/21",
+				Body:    "Reverts #7",
+				HeadRef: "revert-task-7",
+				BaseRef: "main",
+			}},
+		},
+		comments: map[int64][]github.IssueComment{},
+	}
+	d := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: revertDaemonEngine(store), RevertDetectionEnabled: true}
+
+	if err := d.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	events := revertFeedback(t, store, versionID)
+	if len(events) != 1 || events[0].Choice != "a" {
+		t.Fatalf("an unmerged revert must not correct the positive, got %+v", events)
+	}
+}
+
+// TestPollOnceDisabledIsByteIdentical is the off-by-default regression (#467):
+// with RevertDetectionEnabled=false the daemon issues NO closed-PR list, parses NO
+// body, and writes NOTHING — the original positive is untouched and the closed-PR
+// list is never requested.
+func TestPollOnceDisabledIsByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	versionID := seedHarvestedPositive(t, store, repo, 7, "task-7")
+
+	client := &countingClosedListGitHub{fakeGitHub: &fakeGitHub{
+		pullsByState: map[string][]github.PullRequest{
+			"open": {},
+			"closed": {{
+				Number: 20, State: "merged", Merged: true, Body: "Reverts #7",
+				HeadRef: "revert-task-7", BaseRef: "main",
+			}},
+		},
+		comments: map[int64][]github.IssueComment{},
+	}}
+	// RevertDetectionEnabled defaults false.
+	d := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: revertDaemonEngine(store)}
+
+	if err := d.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	events := revertFeedback(t, store, versionID)
+	if len(events) != 1 || events[0].Choice != "a" {
+		t.Fatalf("disabled revert detection must be byte-identical (positive untouched), got %+v", events)
+	}
+	if client.closedListCalls != 0 {
+		t.Fatalf("disabled revert detection must request NO closed-PR list, got %d calls", client.closedListCalls)
+	}
+}
+
+// countingClosedListGitHub counts "closed"-state ListPullRequests calls so the
+// off-path byte-identical test can prove no extra GitHub read happens when revert
+// detection is disabled.
+type countingClosedListGitHub struct {
+	*fakeGitHub
+	closedListCalls int
+}
+
+func (c *countingClosedListGitHub) ListPullRequests(ctx context.Context, repo github.Repository, state string) ([]github.PullRequest, error) {
+	if state == "closed" {
+		c.closedListCalls++
+	}
+	return c.fakeGitHub.ListPullRequests(ctx, repo, state)
+}

--- a/internal/daemon/revert_detection_test.go
+++ b/internal/daemon/revert_detection_test.go
@@ -44,6 +44,33 @@ func TestRevertedOriginalPRParsesBody(t *testing.T) {
 	}
 }
 
+// TestRevertPullMergedGatesOnMergedAt locks in the merged-ness gate (#467): the
+// GitHub LIST endpoint reports a merged PR as state="closed" with merged_at set
+// and NO `merged` boolean, so MergedAt is the load-bearing signal. Trusting only
+// the list `Merged` flag (always false on a list) would make the whole feature a
+// silent no-op against real GitHub.
+func TestRevertPullMergedGatesOnMergedAt(t *testing.T) {
+	cases := []struct {
+		name string
+		pull github.PullRequest
+		want bool
+	}{
+		{"real list merged shape (closed + merged_at, no Merged)", github.PullRequest{State: "closed", MergedAt: "2026-06-27T12:00:00Z"}, true},
+		{"closed not merged (no merged_at)", github.PullRequest{State: "closed"}, false},
+		{"open", github.PullRequest{State: "open"}, false},
+		{"single-PR detail shape (Merged flag)", github.PullRequest{State: "closed", Merged: true}, true},
+		{"merged state string", github.PullRequest{State: "merged"}, true},
+		{"blank merged_at is not merged", github.PullRequest{State: "closed", MergedAt: "   "}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := revertPullMerged(tc.pull); got != tc.want {
+				t.Fatalf("revertPullMerged(%+v) = %v, want %v", tc.pull, got, tc.want)
+			}
+		})
+	}
+}
+
 // seedHarvestedPositive installs a template, a completed implement job attributed
 // to its version, the original PR row, and writes the ORIGINAL merge's choice=a
 // auto-trace feedback row (by running the harvester's merge path), returning the
@@ -147,6 +174,12 @@ func revertDaemonEngine(store *db.Store) *workflow.Engine {
 // RevertDetectionEnabled, a merged revert PR (body `Reverts #7`) in the closed set
 // flips the original PR's auto-trace row a -> b in place (count unchanged), and a
 // second poll is idempotent.
+//
+// CRITICAL: the closed fixture mirrors the REAL GitHub LIST shape — State:"closed"
+// with merged_at set and NO Merged boolean (the list endpoint omits `merged` and
+// reports merged PRs as state="closed"). This exercises the production path that
+// gates merged-ness on MergedAt; trusting the list's Merged would be a silent
+// no-op against real GitHub (the original review finding).
 func TestPollOnceCorrectsOnMergedRevert(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
@@ -162,14 +195,16 @@ func TestPollOnceCorrectsOnMergedRevert(t *testing.T) {
 		pullsByState: map[string][]github.PullRequest{
 			"open": {},
 			"closed": {{
-				Number:  20,
-				Title:   `Revert "Task 7"`,
-				State:   "merged",
-				Merged:  true,
-				URL:     "https://github.com/jerryfane/gitmoot/pull/20",
-				Body:    "Reverts #7",
-				HeadRef: "revert-task-7",
-				BaseRef: "main",
+				Number: 20,
+				Title:  `Revert "Task 7"`,
+				// Real LIST shape: merged PRs come back as state="closed" with a
+				// merged_at timestamp and NO `merged` boolean.
+				State:    "closed",
+				MergedAt: "2026-06-27T12:00:00Z",
+				URL:      "https://github.com/jerryfane/gitmoot/pull/20",
+				Body:     "Reverts #7",
+				HeadRef:  "revert-task-7",
+				BaseRef:  "main",
 			}},
 		},
 		comments: map[int64][]github.IssueComment{},
@@ -249,7 +284,7 @@ func TestPollOnceDisabledIsByteIdentical(t *testing.T) {
 		pullsByState: map[string][]github.PullRequest{
 			"open": {},
 			"closed": {{
-				Number: 20, State: "merged", Merged: true, Body: "Reverts #7",
+				Number: 20, State: "closed", MergedAt: "2026-06-27T12:00:00Z", Body: "Reverts #7",
 				HeadRef: "revert-task-7", BaseRef: "main",
 			}},
 		},
@@ -270,9 +305,12 @@ func TestPollOnceDisabledIsByteIdentical(t *testing.T) {
 	}
 }
 
-// countingClosedListGitHub counts "closed"-state ListPullRequests calls so the
-// off-path byte-identical test can prove no extra GitHub read happens when revert
-// detection is disabled.
+// countingClosedListGitHub counts bounded closed-PR list calls so the off-path
+// byte-identical test can prove no extra GitHub read happens when revert detection
+// is disabled. The revert scan reads closed PRs via the bounded
+// ListRecentClosedPullRequests (#467), so that is the call counted; a plain
+// "closed" ListPullRequests (used by retryClosedReadyToMerge) is counted too as a
+// belt-and-suspenders guard.
 type countingClosedListGitHub struct {
 	*fakeGitHub
 	closedListCalls int
@@ -283,4 +321,9 @@ func (c *countingClosedListGitHub) ListPullRequests(ctx context.Context, repo gi
 		c.closedListCalls++
 	}
 	return c.fakeGitHub.ListPullRequests(ctx, repo, state)
+}
+
+func (c *countingClosedListGitHub) ListRecentClosedPullRequests(ctx context.Context, repo github.Repository) ([]github.PullRequest, error) {
+	c.closedListCalls++
+	return c.fakeGitHub.ListRecentClosedPullRequests(ctx, repo)
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -60,11 +60,16 @@ func (r Repository) FullName() string {
 }
 
 type PullRequest struct {
-	Number    int64  `json:"number"`
-	Title     string `json:"title"`
-	State     string `json:"state"`
-	URL       string `json:"html_url"`
-	Merged    bool   `json:"merged"`
+	Number int64  `json:"number"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+	URL    string `json:"html_url"`
+	Merged bool   `json:"merged"`
+	// Body is the PR description. It is additive (#467): the daemon's revert
+	// detection reads it for a GitHub Revert-button body (`Reverts owner/repo#NN`)
+	// to map a revert back to the original PR. It defaults to "" so every existing
+	// caller that ignores it is byte-identical.
+	Body      string `json:"body"`
 	HeadRef   string
 	BaseRef   string
 	BaseSHA   string
@@ -80,6 +85,7 @@ func (p *PullRequest) UnmarshalJSON(data []byte) error {
 		State     string `json:"state"`
 		URL       string `json:"html_url"`
 		Merged    bool   `json:"merged"`
+		Body      string `json:"body"`
 		Mergeable *bool  `json:"mergeable"`
 		MergeSHA  string `json:"merge_commit_sha"`
 		Head      struct {
@@ -100,6 +106,7 @@ func (p *PullRequest) UnmarshalJSON(data []byte) error {
 	p.State = decoded.State
 	p.URL = decoded.URL
 	p.Merged = decoded.Merged
+	p.Body = decoded.Body
 	p.Mergeable = decoded.Mergeable
 	p.HeadRef = decoded.Head.Ref
 	p.HeadSHA = decoded.Head.SHA

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -26,6 +26,10 @@ type Client interface {
 	DeleteRepository(ctx context.Context, repo Repository) error
 	ListUserRepositories(ctx context.Context, limit int) ([]RepoSummary, error)
 	ListPullRequests(ctx context.Context, repo Repository, state string) ([]PullRequest, error)
+	// ListRecentClosedPullRequests returns a bounded page of the most-recently-
+	// updated closed PRs (#467) so the per-tick revert scan never re-paginates the
+	// repo's entire closed-PR history.
+	ListRecentClosedPullRequests(ctx context.Context, repo Repository) ([]PullRequest, error)
 	ListIssues(ctx context.Context, repo Repository, state string) ([]Issue, error)
 	GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error)
 	GetOpenPullRequestByHead(ctx context.Context, repo Repository, head string, base string) (PullRequest, bool, error)
@@ -65,6 +69,15 @@ type PullRequest struct {
 	State  string `json:"state"`
 	URL    string `json:"html_url"`
 	Merged bool   `json:"merged"`
+	// MergedAt is the PR's merge timestamp (RFC3339), or "" if not merged. It is
+	// additive (#467): the GitHub LIST endpoint (GET /pulls?state=closed) reports
+	// merged PRs as state="closed" and OMITS the top-level `merged` boolean —
+	// `merged` is computed only on the single-PR GET endpoint. `merged_at` is the
+	// ONLY merged signal the list carries, so revert detection treats a non-empty
+	// MergedAt as merged (revertPullMerged) rather than trusting list `merged`,
+	// which is always false on the list. It defaults to "" so callers that ignore
+	// it are byte-identical.
+	MergedAt string `json:"merged_at"`
 	// Body is the PR description. It is additive (#467): the daemon's revert
 	// detection reads it for a GitHub Revert-button body (`Reverts owner/repo#NN`)
 	// to map a revert back to the original PR. It defaults to "" so every existing
@@ -85,6 +98,7 @@ func (p *PullRequest) UnmarshalJSON(data []byte) error {
 		State     string `json:"state"`
 		URL       string `json:"html_url"`
 		Merged    bool   `json:"merged"`
+		MergedAt  string `json:"merged_at"`
 		Body      string `json:"body"`
 		Mergeable *bool  `json:"mergeable"`
 		MergeSHA  string `json:"merge_commit_sha"`
@@ -106,6 +120,7 @@ func (p *PullRequest) UnmarshalJSON(data []byte) error {
 	p.State = decoded.State
 	p.URL = decoded.URL
 	p.Merged = decoded.Merged
+	p.MergedAt = decoded.MergedAt
 	p.Body = decoded.Body
 	p.Mergeable = decoded.Mergeable
 	p.HeadRef = decoded.Head.Ref
@@ -470,6 +485,30 @@ func (c *GhClient) ListPullRequests(ctx context.Context, repo Repository, state 
 		state = "open"
 	}
 	return apiPaginatedJSON[PullRequest](ctx, c, "-X", "GET", endpoint(repo, "pulls"), "-f", "state="+state)
+}
+
+// recentClosedPullRequestsPerPage caps the bounded closed-PR scan (#467) at one
+// page of the most-recently-updated closed PRs. GitHub's pulls list allows up to
+// 100 per page; 100 keeps the per-tick GitHub cost a single, fixed request even on
+// a repo with thousands of closed PRs. A merged GitHub Revert-button PR is freshly
+// updated when it lands, so sort=updated&direction=desc puts it at the top of this
+// window — far more than enough to catch a revert between poll ticks.
+const recentClosedPullRequestsPerPage = 100
+
+// ListRecentClosedPullRequests returns ONE page of the most-recently-updated
+// CLOSED PRs (sort=updated&direction=desc, no --paginate), bounding the per-tick
+// cost of the revert scan (#467) to a single fixed GitHub request instead of
+// walking the repo's entire closed-PR history every poll. It is the bounded
+// counterpart to ListPullRequests(state="closed"); revert detection only needs
+// recently-landed reverts, so a single recent page is sufficient.
+func (c *GhClient) ListRecentClosedPullRequests(ctx context.Context, repo Repository) ([]PullRequest, error) {
+	return apiPageJSON[PullRequest](ctx, c,
+		"-X", "GET", endpoint(repo, "pulls"),
+		"-f", "state=closed",
+		"-f", "sort=updated",
+		"-f", "direction=desc",
+		"-f", "per_page="+strconv.Itoa(recentClosedPullRequestsPerPage),
+	)
 }
 
 // ListIssues lists repository issues via GET /repos/{owner}/{repo}/issues. That
@@ -1013,6 +1052,22 @@ func apiPaginatedJSON[T any](ctx context.Context, c *GhClient, args ...string) (
 	return values, nil
 }
 
+// apiPageJSON fetches a SINGLE page (no --paginate), so the caller controls the
+// page size and never walks the entire result set. It is the bounded counterpart
+// to apiPaginatedJSON, used by ListRecentClosedPullRequests (#467) so the per-tick
+// revert scan does not re-paginate a repo's entire closed-PR history.
+func apiPageJSON[T any](ctx context.Context, c *GhClient, args ...string) ([]T, error) {
+	result, err := c.run(ctx, false, append([]string{"api"}, args...)...)
+	if err != nil {
+		return nil, err
+	}
+	var values []T
+	if err := json.Unmarshal([]byte(result.Stdout), &values); err != nil {
+		return nil, fmt.Errorf("decode gh api response: %w", err)
+	}
+	return values, nil
+}
+
 func decodePaginatedJSON[T any](output string) ([]T, error) {
 	decoder := json.NewDecoder(strings.NewReader(output))
 	var values []T
@@ -1211,6 +1266,10 @@ func (NoopClient) Preflight(context.Context, Repository) error {
 }
 
 func (NoopClient) ListPullRequests(context.Context, Repository, string) ([]PullRequest, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (NoopClient) ListRecentClosedPullRequests(context.Context, Repository) ([]PullRequest, error) {
 	return nil, errors.ErrUnsupported
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -483,6 +483,51 @@ func TestGetPullRequestDecodesBaseSHA(t *testing.T) {
 	runner.wantArgs(t, 0, "api", "repos/jerryfane/gitmoot/pulls/2")
 }
 
+// TestGetPullRequestDecodesBody proves PullRequest.UnmarshalJSON decodes the wire
+// `body` field into the additive PullRequest.Body (#467) so the daemon's revert
+// detection can read a GitHub Revert-button body (`Reverts owner/repo#NN`).
+func TestGetPullRequestDecodesBody(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"number": 9, "title": "Revert \"Add feature\"", "state": "closed", "merged": true, "html_url": "https://github.com/jerryfane/gitmoot/pull/9", "body": "Reverts jerryfane/gitmoot#7", "head": {"ref": "revert-7", "sha": "rev123"}, "base": {"ref": "main", "sha": "base123"}}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	pr, err := client.GetPullRequest(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, 9)
+
+	if err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+	if pr.Body != "Reverts jerryfane/gitmoot#7" {
+		t.Fatalf("pull request body = %q, want the Reverts anchor", pr.Body)
+	}
+	if !pr.Merged {
+		t.Fatalf("pull request merged = %v, want true", pr.Merged)
+	}
+}
+
+// TestGetPullRequestBodyDefaultsEmpty proves Body defaults to "" when the wire
+// payload omits `body` — the additive field is byte-identical for every existing
+// caller that ignores it.
+func TestGetPullRequestBodyDefaultsEmpty(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `{"number": 2, "title": "Task", "state": "open", "html_url": "https://github.com/jerryfane/gitmoot/pull/2", "head": {"ref": "task", "sha": "head123"}, "base": {"ref": "main", "sha": "base123"}}`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	pr, err := client.GetPullRequest(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, 2)
+
+	if err != nil {
+		t.Fatalf("GetPullRequest returned error: %v", err)
+	}
+	if pr.Body != "" {
+		t.Fatalf("pull request body = %q, want empty default", pr.Body)
+	}
+}
+
 func TestCompareCommitsUsesEscapedCompareEndpoint(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -528,6 +528,47 @@ func TestGetPullRequestBodyDefaultsEmpty(t *testing.T) {
 	}
 }
 
+// TestListRecentClosedPullRequestsDecodesMergedAt proves the bounded closed-PR
+// scan (#467) decodes the LIST endpoint's real merged shape: a merged PR comes
+// back as state="closed" with merged_at set and NO `merged` boolean. revert
+// detection gates on merged_at, so this field must survive decoding.
+func TestListRecentClosedPullRequestsDecodesMergedAt(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			Stdout: `[{"number": 20, "title": "Revert \"Task 7\"", "state": "closed", "merged_at": "2026-06-27T12:00:00Z", "html_url": "https://github.com/jerryfane/gitmoot/pull/20", "body": "Reverts #7", "head": {"ref": "revert-task-7"}, "base": {"ref": "main"}}]`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	pulls, err := client.ListRecentClosedPullRequests(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"})
+	if err != nil {
+		t.Fatalf("ListRecentClosedPullRequests returned error: %v", err)
+	}
+	if len(pulls) != 1 {
+		t.Fatalf("pulls = %d, want 1", len(pulls))
+	}
+	if pulls[0].MergedAt != "2026-06-27T12:00:00Z" {
+		t.Fatalf("merged_at = %q, want the merge timestamp", pulls[0].MergedAt)
+	}
+	if pulls[0].Merged {
+		t.Fatalf("list endpoint must not set Merged; got %v", pulls[0].Merged)
+	}
+
+	// The scan must be BOUNDED: a single page (no --paginate) sorted by recency.
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1", len(runner.calls))
+	}
+	args := strings.Join(runner.calls[0], " ")
+	if strings.Contains(args, "--paginate") {
+		t.Fatalf("recent closed scan must NOT paginate the whole history; args = %q", args)
+	}
+	for _, want := range []string{"state=closed", "sort=updated", "direction=desc", "per_page="} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("recent closed scan args missing %q; args = %q", want, args)
+		}
+	}
+}
+
 func TestCompareCommitsUsesEscapedCompareEndpoint(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -304,6 +304,27 @@ type PullRequestEvent struct {
 	SkipReviewFanout bool
 }
 
+// RevertEvent locates the ORIGINAL PR that a (now-merged) revert PR undid (#467).
+// The daemon PR-watcher fills it after parsing a GitHub Revert-button body
+// (`Reverts owner/repo#NN`) back to the original PR number; HandlePullRequestReverted
+// resolves the original implement job from these fields and fires the corrective
+// OutcomeReverted harvest. It carries ONLY what the Reverted projection needs
+// (Repo + the original PR number); OriginalBranch/OriginalTaskID are optional
+// attribution hints that improve implementJobForTask's sameTask match.
+type RevertEvent struct {
+	// Repo is the "owner/name" the original PR lives in (same-repo as the revert).
+	Repo string
+	// OriginalPullRequest is the number of the PR that was reverted — the anchor for
+	// the harvester's per-PR item_id / source_url UNIQUE corrective-overwrite key.
+	OriginalPullRequest int
+	// OriginalBranch is the original PR's head branch, if known, used as an
+	// attribution hint for implementJobForTask. Optional.
+	OriginalBranch string
+	// OriginalTaskID is the original PR's task id, if known, used as a strong
+	// attribution hint for implementJobForTask (sameTask prefers TaskID). Optional.
+	OriginalTaskID string
+}
+
 type MergeRequest struct {
 	Repo           string
 	Branch         string
@@ -422,16 +443,16 @@ const (
 	// reverted — a delayed, corrective negative that overwrites the prior positive
 	// in place on the same UNIQUE feedback key.
 	//
-	// NOT YET WIRED (#465): the harvester's projection + corrective in-place upsert
-	// for this kind are implemented and unit-tested (the same per-PR item_id
-	// re-upserts and flips choice a->b), but NO engine/daemon code path constructs
-	// an Outcome{Kind: OutcomeReverted} today — there is no revert detection in
-	// AdvanceJob, runMergeGate, or the daemon PR-watcher. The corrective-on-revert
-	// flow is therefore reachable only via a direct Harvest call (tests); a
-	// production revert does not yet overwrite the prior positive. Wiring real
-	// revert detection (the daemon observing a revert PR/commit of a previously
-	// harvested merge, re-firing harvestOutcomeForMergeGate for the reverted PR) is
-	// a follow-on; see CORRECTIVE-ON-REVERT in docs/skillopt-exchange-contract.md.
+	// WIRED (#467): the daemon PR-watcher detects a GitHub Revert-button PR (whose
+	// body is `Reverts owner/repo#NN` / `Reverts #NN`) being merged, parses the
+	// ORIGINAL PR number, and — gated off-by-default on
+	// [skillopt].auto_trace_enabled AND revert_detection_enabled — calls
+	// HandlePullRequestReverted, which resolves the original implement job via
+	// implementJobForTask and fires harvestOutcome with this kind. The harvester's
+	// in-place corrective upsert re-writes the SAME per-PR item_id row, flipping the
+	// prior positive choice a->b (row count unchanged). It is best-effort: a
+	// malformed/cross-repo/unresolvable revert never blocks the poll. See
+	// CORRECTIVE-ON-REVERT in docs/skillopt-exchange-contract.md.
 	OutcomeReverted OutcomeKind = "reverted"
 	// OutcomeReviewed is the SOFT, down-weighted, judge-tagged secondary signal a
 	// cross-family review leg produces (#469). Unlike the verifiable kinds above it
@@ -4476,6 +4497,54 @@ func (e Engine) harvestOutcomeForMergeGate(ctx context.Context, reviewPayload Jo
 		return
 	}
 	e.harvestOutcome(ctx, job, payload, outcome)
+}
+
+// HandlePullRequestReverted fires the corrective OutcomeReverted harvest for an
+// ORIGINAL PR that a (now-merged) revert PR undid (#467). It mirrors
+// harvestOutcomeForMergeGate exactly: it resolves the original implement job via
+// implementJobForTask (so the revert is attributed to the right template version,
+// matched by Repo+PR or TaskID) and calls harvestOutcome with Outcome{Kind:
+// OutcomeReverted, Repo, PullRequest}; the Reverted projection needs only
+// Repo+PullRequest (no HeadSHA / no CI read), so the daemon need not fetch the
+// original head.
+//
+// It is best-effort and FAIL-SAFE end to end: a nil harvester (the default —
+// auto_trace off) short-circuits to no-op, an invalid event or an unresolvable
+// original implement job returns nil (skip, no rows written), and a Harvest error
+// is swallowed inside harvestOutcome and recorded as an auto_trace_harvest_failed
+// job event — so a revert-detection call can NEVER block or fail the daemon poll.
+// Re-firing is naturally idempotent: the harvester's per-PR item_id re-upserts the
+// SAME UNIQUE feedback row in place (corrective overwrite, row count unchanged),
+// so repeated polls of the same persistent revert PR are harmless.
+func (e Engine) HandlePullRequestReverted(ctx context.Context, event RevertEvent) error {
+	if e.OutcomeHarvester == nil {
+		// No harvester (auto_trace off) => byte-identical no-op, no lookup.
+		return nil
+	}
+	repo := strings.TrimSpace(event.Repo)
+	if repo == "" || event.OriginalPullRequest <= 0 {
+		// Nothing to anchor the corrective overwrite to; skip rather than guess.
+		return nil
+	}
+	reviewPayload := JobPayload{
+		Repo:        repo,
+		PullRequest: event.OriginalPullRequest,
+		Branch:      strings.TrimSpace(event.OriginalBranch),
+		TaskID:      strings.TrimSpace(event.OriginalTaskID),
+	}
+	job, payload, ok := e.implementJobForTask(ctx, reviewPayload)
+	if !ok {
+		// No implement job owns the original PR (e.g. it was opened outside the
+		// implement flow, or auto-trace was enabled only after the original merge):
+		// skip rather than create a spurious fresh negative row.
+		return nil
+	}
+	e.harvestOutcome(ctx, job, payload, Outcome{
+		Kind:        OutcomeReverted,
+		Repo:        repo,
+		PullRequest: event.OriginalPullRequest,
+	})
+	return nil
 }
 
 // implementJobForTask finds the implement job that produced the diff/PR for the

--- a/internal/workflow/handle_reverted_test.go
+++ b/internal/workflow/handle_reverted_test.go
@@ -1,0 +1,145 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// TestHandlePullRequestRevertedFiresCorrectiveHarvest proves the wired revert
+// trigger (#467): HandlePullRequestReverted resolves the ORIGINAL implement job
+// via implementJobForTask (sameTask) and fires the harvester with
+// Outcome{Kind: OutcomeReverted, Repo, PullRequest:<orig>}, attributed to the
+// implement job that produced the original diff.
+func TestHandlePullRequestRevertedFiresCorrectiveHarvest(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	seedImplementJobForHarvest(t, store)
+
+	if err := engine.HandlePullRequestReverted(ctx, RevertEvent{
+		Repo:                "jerryfane/gitmoot",
+		OriginalPullRequest: 7,
+		OriginalBranch:      "task-7",
+		OriginalTaskID:      "task-7",
+	}); err != nil {
+		t.Fatalf("HandlePullRequestReverted returned error: %v", err)
+	}
+
+	got := harvester.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("Harvest calls = %d, want 1; %+v", len(got), got)
+	}
+	if got[0].Kind != OutcomeReverted {
+		t.Fatalf("outcome kind = %q, want reverted", got[0].Kind)
+	}
+	if got[0].PullRequest != 7 || got[0].Repo != "jerryfane/gitmoot" {
+		t.Fatalf("outcome attribution = %+v, want repo=jerryfane/gitmoot pr=7", got[0])
+	}
+	if harvester.jobIDs[0] != "implement-job" {
+		t.Fatalf("reverted outcome attributed to %q, want implement-job", harvester.jobIDs[0])
+	}
+}
+
+// TestHandlePullRequestRevertedResolvesByRepoPROnly proves the corrective harvest
+// still resolves the original implement job when only Repo+PR are known (no
+// branch/task hints), matching sameTask's Repo+PullRequest path — so the daemon
+// need not fetch the original head/task to map the revert.
+func TestHandlePullRequestRevertedResolvesByRepoPROnly(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	// Seed an implement job WITHOUT a TaskID so sameTask must match on Repo+PR.
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-no-task",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:                   "jerryfane/gitmoot",
+		PullRequest:            42,
+		TemplateID:             "planner",
+		TemplateResolvedCommit: "commit-1",
+		Result:                 &AgentResult{Decision: "implemented", Summary: "did the work"},
+	})
+
+	if err := engine.HandlePullRequestReverted(ctx, RevertEvent{
+		Repo:                "jerryfane/gitmoot",
+		OriginalPullRequest: 42,
+	}); err != nil {
+		t.Fatalf("HandlePullRequestReverted returned error: %v", err)
+	}
+
+	got := harvester.snapshot()
+	if len(got) != 1 || got[0].Kind != OutcomeReverted || got[0].PullRequest != 42 {
+		t.Fatalf("Repo+PR-only resolution = %+v, want one reverted outcome for pr 42", got)
+	}
+}
+
+// TestHandlePullRequestRevertedNilHarvesterNoOp proves the nil-harvester (default,
+// auto_trace off) path is a byte-identical no-op: no lookup, no fire, no error.
+func TestHandlePullRequestRevertedNilHarvesterNoOp(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	// No OutcomeHarvester.
+	seedImplementJobForHarvest(t, store)
+
+	if err := engine.HandlePullRequestReverted(ctx, RevertEvent{
+		Repo:                "jerryfane/gitmoot",
+		OriginalPullRequest: 7,
+	}); err != nil {
+		t.Fatalf("HandlePullRequestReverted with nil harvester returned error: %v", err)
+	}
+}
+
+// TestHandlePullRequestRevertedUnresolvableSkips proves the corrective harvest is
+// SKIPPED (no fire, no error) when no implement job owns the original PR — so a
+// revert of a PR opened outside the implement flow never forges a spurious fresh
+// negative.
+func TestHandlePullRequestRevertedUnresolvableSkips(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	// No implement job seeded for PR 99.
+
+	if err := engine.HandlePullRequestReverted(ctx, RevertEvent{
+		Repo:                "jerryfane/gitmoot",
+		OriginalPullRequest: 99,
+	}); err != nil {
+		t.Fatalf("HandlePullRequestReverted returned error: %v", err)
+	}
+	if got := harvester.snapshot(); len(got) != 0 {
+		t.Fatalf("Harvest calls = %d, want 0 (unresolvable original PR); %+v", len(got), got)
+	}
+}
+
+// TestHandlePullRequestRevertedInvalidEventSkips proves a malformed event (empty
+// repo or non-positive PR) is fail-safe: no fire, no error, no lookup.
+func TestHandlePullRequestRevertedInvalidEventSkips(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	seedImplementJobForHarvest(t, store)
+
+	for _, event := range []RevertEvent{
+		{Repo: "", OriginalPullRequest: 7},
+		{Repo: "jerryfane/gitmoot", OriginalPullRequest: 0},
+		{Repo: "jerryfane/gitmoot", OriginalPullRequest: -1},
+	} {
+		if err := engine.HandlePullRequestReverted(ctx, event); err != nil {
+			t.Fatalf("HandlePullRequestReverted(%+v) returned error: %v", event, err)
+		}
+	}
+	if got := harvester.snapshot(); len(got) != 0 {
+		t.Fatalf("Harvest calls = %d, want 0 (invalid events); %+v", len(got), got)
+	}
+}

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -474,15 +474,18 @@ table is intentionally **not** implemented yet; the budget is in raw tokens.
 When `[skillopt].auto_trace_enabled = true` (default `false`), gitmoot derives
 template-learning feedback from the **verifiable outcomes** an implement job
 reaches — merged with passing CI vs. blocked at the merge gate, review
-`changes_requested` (a later revert is supported by the harvester but not yet
-fired by any engine/daemon path — see the contract doc) — and writes a synthetic
-`FeedbackEvent` (`source = auto-trace`, `reviewer = gitmoot-auto`, A/B `choice`,
-`feedback_source = automatic_trace`) into a dedicated per-template-version
-`auto-trace:<version>` eval run. This is **additive** (`contract_version` stays
-`1`, no new result field), **best-effort** (a harvest error never blocks or fails
-a job; it records an `auto_trace_harvest_failed` job event), and **never
-promotes** — a human still promotes a candidate. With the knob unset, no
-harvester runs and behavior is byte-identical. See
+`changes_requested`, and a later **revert** (wired #467: the daemon detects a
+merged GitHub Revert-button PR whose body is `Reverts owner/repo#NN`, maps it back
+to the original PR's auto-trace row, and overwrites the prior positive with a
+negative in place — gated additionally on the optional opt-out
+`revert_detection_enabled`, unset = on whenever the harvester is on) — and writes
+a synthetic `FeedbackEvent` (`source = auto-trace`, `reviewer = gitmoot-auto`, A/B
+`choice`, `feedback_source = automatic_trace`) into a dedicated
+per-template-version `auto-trace:<version>` eval run. This is **additive**
+(`contract_version` stays `1`, no new result field), **best-effort** (a harvest
+error never blocks or fails a job; it records an `auto_trace_harvest_failed` job
+event), and **never promotes** — a human still promotes a candidate. With the knob
+unset, no harvester runs and behavior is byte-identical. See
 `docs/skillopt-exchange-contract.md` for the outcome→score mapping, the no-CI
 guard, and the corrective-on-revert overwrite.
 

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -389,10 +389,15 @@ ranking. Enable it per host in `[skillopt]`:
 [skillopt]
 auto_trace_enabled = true            # off by default
 cross_family_review_enabled = false  # off by default; also needs auto_trace_enabled
+revert_detection_enabled = true      # unset = on when auto_trace_enabled; set false to opt out (#467)
 ```
 
 With `auto_trace_enabled = true`, a merge (passing CI vs. empty-gate), a
-merge-gate block, or a review `changes_requested` is projected into a synthetic
+merge-gate block, a review `changes_requested`, or a later **revert** (the daemon
+detects a merged GitHub Revert-button PR — body `Reverts owner/repo#NN` — and
+overwrites the original PR's positive with a negative in place; gated additionally
+on `revert_detection_enabled`, unset = on, set `false` to keep the harvester on
+but turn revert overwrites off) is projected into a synthetic
 `FeedbackEvent` (`reviewer = gitmoot-auto`, `feedback_source = automatic_trace`)
 in a per-template-version `auto-trace:<version>` eval run. It is additive
 (`contract_version` stays `1`), best-effort (a failure records an

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -206,12 +206,22 @@ mirrors the off-by-default `[events]` stream.
 - **Reverted** → corrective negative. A later revert of a previously-merged PR
   **re-upserts the same** `UNIQUE(run_id, item_id, reviewer, source, source_url)`
   row, flipping the earlier positive `choice = a` to `choice = b` **in place**
-  (the row count is unchanged). **Not yet wired:** the projection and the
-  in-place corrective upsert are implemented and unit-tested, but no engine or
-  daemon path detects a revert and fires the `reverted` outcome today, so in a
-  running daemon a merged-then-reverted PR keeps its prior positive until revert
-  detection is wired (a follow-on). The corrective-overwrite mechanics above are
-  reachable only by invoking the harvester directly with a `reverted` outcome.
+  (the row count is unchanged). **Wired (#467):** the daemon PR-watcher detects a
+  GitHub Revert-button PR — whose body is `Reverts owner/repo#NN` / `Reverts #NN`,
+  same-repo only — being **merged**, parses the **original** PR number, and (via
+  `Engine.HandlePullRequestReverted` → `implementJobForTask` → the harvester)
+  fires the `reverted` outcome against the original PR's auto-trace row, attributed
+  to the original implement job's template version. It is gated off-by-default on
+  `auto_trace_enabled` **and** the optional opt-out `revert_detection_enabled`
+  (unset = on whenever the harvester is on; set `false` to keep the harvester
+  running but turn the corrective revert overwrites off). It is best-effort and
+  fail-safe: a malformed/cross-repo body, an unresolvable original implement job,
+  or a harvest error never blocks or fails the poll. Re-polling the persistent
+  revert PR is idempotent (the in-place upsert re-writes the same `choice = b`
+  row). **Not detected** (best-effort v1): a revert opened without the
+  `Reverts #NN` body line, or a `git revert` pushed straight to the default branch
+  with no PR. With `auto_trace_enabled` off (the default) **no PR body is parsed**
+  and behavior is byte-identical.
 
 **Scope.** Only implement-family jobs that carry a template attribution are
 harvested; coordinator continuation jobs (which produce no diff of their own) and


### PR DESCRIPTION
## What

Wires the production trigger for the corrective `OutcomeReverted` harvest. #465 implemented and unit-tested the projection + in-place corrective upsert, but nothing in production ever constructed an `Outcome{Kind: OutcomeReverted}`, so a real revert of a previously-harvested merge never corrected the stale positive (only a direct `Harvest(...)` call in tests reached the flow).

Now the daemon PR-watcher detects a **merged** GitHub Revert-button PR (body `Reverts owner/repo#NN` / `Reverts #NN`, **same-repo only**), parses the **original** PR number, and fires the corrective harvest via a new exported `Engine.HandlePullRequestReverted`. That resolves the original implement job through the existing `implementJobForTask` and calls the existing `harvestOutcome`, so the revert flips the original PR's auto-trace row `a → b` **in place** (UNIQUE-key upsert, row count unchanged), attributed to the right template version.

## Invariants

- **OFF BY DEFAULT / byte-identical off path** — gated on the existing `[skillopt].auto_trace_enabled` **and** a new optional opt-out `*bool` sub-knob `revert_detection_enabled` (nil = on whenever the harvester is on; set `false` to keep the harvester on but turn revert overwrites off). When disabled the daemon issues **no extra closed-PR list** and parses **no PR body**.
- **Additive** — `ContractVersion` stays `1`; **no new exported contract field**. Changes: a new engine method, a new config knob, an additive `github.PullRequest.Body` field (decoded in `UnmarshalJSON`), and a daemon field.
- **Manual promotion preserved** — the revert path overwrites only the existing feedback row; it never promotes/demotes.
- **Best-effort / fail-safe** — a malformed/cross-repo body, an unresolvable original implement job, or a harvest error never blocks or fails the poll. Re-polling the persistent revert PR is idempotent (in-place upsert).

## Tests

- `internal/github`: `PullRequest.Body` decode + empty default.
- `internal/config`: `revert_detection_enabled` parse + `RevertDetectionEnabled()` gate (requires auto_trace; opt-out; explicit true; bad-bool).
- `internal/workflow`: `HandlePullRequestReverted` fires the corrective harvest, Repo+PR-only resolution, nil-harvester no-op, unresolvable/invalid-event skip.
- `internal/daemon`: body-parser table (positive / no-match / cross-repo / malformed); a `PollOnce` flip `a → b` with idempotent re-poll; an unmerged-revert skip; and an **off-by-default byte-identical** case proving NO closed-PR list and NO row write.

Full gate green locally: `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race` on `internal/{workflow,cli,skillopt,daemon}`.

Docs updated in **both** trees (`docs/` + `website/docs/`) plus `RESULT_CONTRACT.md`, `WORKFLOWS.md`, and the `[skillopt]` config stub.

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)