### PR TITLE
feat(skillopt): cross-family LLM-judge auto-pairwise for Mode B A/B (#483)

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -348,7 +348,7 @@ variants and feed the human's pick to the optimizer as a contract
 `RankedFeedbackEvent`.
 
 ```sh
-gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--home path]
+gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]
 ```
 
 - **Champion** = the agent template's **current promoted** version; **challenger**
@@ -389,8 +389,45 @@ auto-promote guardrails.
 preferences and updates the posterior but the **deferred** auto A/B loop never
 runs and the confidence is never trusted to auto-promote (the promotion-side floor
 reuses `auto_promote_min_samples`). The **manual** `skillopt ab` CLI is always
-allowed. Live-traffic interception, the cross-family LLM-judge auto-pairwise,
-canary, and the auto A/B scheduling loop are **deferred** to follow-ons.
+allowed. Live-traffic interception, canary, and the auto A/B scheduling loop are
+**deferred** to follow-ons.
+
+### Cross-family LLM-judge auto-pairwise (off by default, #483)
+
+Every A/B pick needs a human in the loop, so the comparison signal is cheap to
+want but expensive to get. With `--judge` (or `[skillopt].mode_b_judge_enabled =
+true`, both **off by default**), in addition to the human pick a **cross-family
+LLM judge** — a runtime family **different** from the agent under test — also
+picks the better of the two answers automatically:
+
+```sh
+gitmoot skillopt ab <agent> "<prompt>" --judge      # human pick AND a judge row
+gitmoot skillopt ab <agent> "<prompt>" --judge-only # only the judge row (skip the human prompt)
+```
+
+- **Off by default:** with neither the flag nor the config knob set, no
+  cross-family judge is selected, no judge delivery happens, and no judge row is
+  written — **byte-identical** to the #473 human-only path.
+- **Cross-family only.** The judge family is chosen by the **same**
+  `PickCrossFamilyReviewer` selector Mode A uses; a `SelfFamily` result (no
+  different family available) is **skipped with a clear message**, never a silent
+  same-family self-judgment of one's own template family.
+- The judge is shown the **same shuffled Option A / Option B** the human sees (it
+  never learns champion vs challenger) and returns a small `{"pick":"a"|"b"}`,
+  parsed leniently; **unparseable / empty / tie output drops the judge result**
+  (no row, no error) — fail-safe. Its pick maps back through the **same** shuffle
+  mapping, so the recorded judge winner is the correct champion/challenger role.
+- The judge writes its **own** `RankedFeedbackEvent` with `reviewer =
+  skillopt-ab-judge` and `source = skillopt-ab-judge`, so it **coexists** with the
+  human `source = skillopt-ab` row on the same run/item (the conflict key differs
+  by reviewer+source) and is **weighted below human** by the source tag.
+- The judge is **evidence-only**: it **never** increments the promotion
+  Beta-Bernoulli bandit and **never** changes `P(challenger > champion)`. Promotion
+  stays manual + human-driven. **No contract struct changes — `ContractVersion`
+  stays `1`** (the only new differentiator is the source/reviewer tag value).
+- **Trust is gated on measure-the-judge (#344):** the judge row is judge-tagged
+  and weighted low here and is **not** calibrated against human gold in this slice
+  — judge-tagged now, calibrated later.
 
 ## Ranked Exploration Workflow
 

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -101,7 +101,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
-	fmt.Fprintln(w, "  gitmoot skillopt ab <agent> \"<prompt>\" [--challenger <versionId>] [--pick a|b] [--seed N] [--home path]")
+	fmt.Fprintln(w, "  gitmoot skillopt ab <agent> \"<prompt>\" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]")
 	fmt.Fprintln(w, "  gitmoot skillopt judge-report [--template id]")
 	fmt.Fprintln(w, "  gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <h>] [--yes] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt train init --name <name> --template <id> --review-repo owner/repo --artifact-kind kind --preview kind (--request text|--request-file path)")

--- a/internal/cli/skillopt_ab.go
+++ b/internal/cli/skillopt_ab.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"strings"
 	"sync/atomic"
@@ -17,6 +18,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
 // skillOptABSource is the contract source tag on every Mode B (#473) row: the
@@ -30,6 +32,26 @@ const (
 	skillOptABItemID          = "ab"
 	skillOptABChampionLabel   = "champion"
 	skillOptABChallengerLabel = "challenger"
+)
+
+// skillOptABJudgeSource / skillOptABJudgeReviewer tag the off-by-default
+// cross-family LLM-judge auto-pairwise row (#483). They are DISTINCT from the
+// human row's source/reviewer (skillopt-ab / human) so the judge's
+// RankedFeedbackEvent COEXISTS with the human row under the UNIQUE
+// (run_id,item_id,reviewer,source,source_url) conflict key instead of
+// overwriting it — separable evidence, weighted BELOW the human pick by the
+// source tag in the downstream export/optimizer.
+//
+// MEASURE-THE-JUDGE (#344/#345): the A/B judge is judge-derived, cross-family,
+// and weighted-low here; it is NOT calibrated against human gold in this slice.
+// It is judge-tagged + weighted-below-human + evidence-only (it NEVER touches
+// the promotion Beta-Bernoulli bandit) until a judge↔human agreement capture
+// per task-kind lands (#344/#345) and the optimizer can trust it more. Mirrors
+// internal/skillopt/cross_family_review.go's reviewReviewerID MEASURE-THE-JUDGE
+// note.
+const (
+	skillOptABJudgeSource   = "skillopt-ab-judge"
+	skillOptABJudgeReviewer = "skillopt-ab-judge"
 )
 
 // skillOptABVariant is one resolved A/B arm: the version being served plus its
@@ -56,6 +78,29 @@ type skillOptABDeliverFunc func(ctx context.Context, agent runtime.Agent, prompt
 // adapter path; overridden in tests). It is a var, not a const, exactly so the
 // CLI A/B test can supply a fake adapter.
 var skillOptABDeliver skillOptABDeliverFunc = realSkillOptABDeliver
+
+// skillOptABJudgeDeliver is the SEPARATE delivery seam for the off-by-default
+// cross-family LLM-judge call (#483). It defaults to the SAME real adapter path
+// as skillOptABDeliver (realSkillOptABDeliver builds the adapter from the passed
+// runtime.Agent's Runtime, so a judge Agent carrying a DIFFERENT family runs the
+// judge on that family), and is its own var purely so tests inject a
+// deterministic judge independent of the variant seam. The judge call is run
+// SERIALIZED after the two variant deliveries (a third sequential Deliver) so
+// per-runtime session locks never overlap — the same serialize-the-Deliver-calls
+// discipline realSkillOptABDeliver documents (a foreground ask strands a 30-min
+// runtime-session lock if it overlaps another on the same family).
+var skillOptABJudgeDeliver skillOptABDeliverFunc = realSkillOptABDeliver
+
+// skillOptABJudgeAuthedRuntimes is the injectable probe for which runtime
+// families are authed/available, used to let PickCrossFamilyReviewer materialize
+// an ephemeral cross-family judge leg only on a family that can actually run. It
+// defaults to the real daemonAuthedRuntimes probe (which runs live Health checks)
+// and is overridden in tests so unit tests stay deterministic and offline. It is
+// a var of the reviewAuthedRuntimes type so it shares the cross-family review
+// injection seam.
+var skillOptABJudgeAuthedRuntimes = func(repoScope string) reviewAuthedRuntimes {
+	return daemonAuthedRuntimes(repoScope)
+}
 
 // realSkillOptABDeliver resolves the agent's runtime adapter and delivers a
 // single one-shot prompt, returning the answer text. Each call is independent
@@ -86,6 +131,14 @@ type skillOptABOptions struct {
 	pick       string
 	seed       int64
 	seedSet    bool
+	// judge turns the off-by-default cross-family LLM-judge auto-pairwise path ON
+	// for this invocation (#483); the [skillopt].mode_b_judge_enabled config knob is
+	// the equivalent persistent admission gate. When neither is set the command is
+	// byte-identical to #473 (no judge selected, delivered, or recorded).
+	judge bool
+	// judgeOnly skips soliciting the human pick and records ONLY the judge row
+	// (mirrors the --pick non-interactive escape). It implies --judge.
+	judgeOnly bool
 }
 
 func runSkillOptAB(args []string, stdout, stderr io.Writer) int {
@@ -124,6 +177,8 @@ func parseSkillOptABOptions(args []string, stderr io.Writer) (skillOptABOptions,
 	challenger := fs.String("challenger", "", "challenger version id (defaults to the sole pending candidate)")
 	pick := fs.String("pick", "", "non-interactive pick: a or b (the shuffled option labels)")
 	seed := fs.Int64("seed", 0, "deterministic seed for the label shuffle and the P(>) Monte Carlo")
+	judge := fs.Bool("judge", false, "also have a cross-family LLM judge pick A/B and record a separate skillopt-ab-judge row (#483; off by default)")
+	judgeOnly := fs.Bool("judge-only", false, "record ONLY the cross-family judge row, skipping the human pick prompt (implies --judge)")
 	// Separate the leading positionals (agent, prompt) from flags. flag.Parse stops
 	// at the first non-flag, so collect positionals manually to allow them anywhere.
 	positionals := []string{}
@@ -160,6 +215,9 @@ func parseSkillOptABOptions(args []string, stderr io.Writer) (skillOptABOptions,
 		fmt.Fprintln(stderr, "skillopt ab --pick must be a or b")
 		return skillOptABOptions{}, false
 	}
+	// --judge-only implies --judge: recording only the judge row still requires the
+	// judge path to be admitted.
+	judgeOn := *judge || *judgeOnly
 	return skillOptABOptions{
 		home:       strings.TrimSpace(*home),
 		agent:      strings.TrimSpace(positionals[0]),
@@ -168,12 +226,14 @@ func parseSkillOptABOptions(args []string, stderr io.Writer) (skillOptABOptions,
 		pick:       pickValue,
 		seed:       *seed,
 		seedSet:    seedSet,
+		judge:      judgeOn,
+		judgeOnly:  *judgeOnly,
 	}, true
 }
 
 func printSkillOptABUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot skillopt ab <agent> \"<prompt>\" [--challenger <versionId>] [--pick a|b] [--seed N] [--home path]")
+	fmt.Fprintln(w, "  gitmoot skillopt ab <agent> \"<prompt>\" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Champion-challenger A/B (#473 Mode B): serves the prompt through the agent's")
 	fmt.Fprintln(w, "current promoted template version (champion) AND a pending candidate version")
@@ -181,6 +241,13 @@ func printSkillOptABUsage(w io.Writer) {
 	fmt.Fprintln(w, "pairwise RankedFeedbackEvent (source=skillopt-ab), updates the Beta-Bernoulli")
 	fmt.Fprintln(w, "bandit, and prints P(challenger>champion). Manual only; no pending candidate is a")
 	fmt.Fprintln(w, "clean no-op.")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "--judge (or [skillopt].mode_b_judge_enabled, off by default) ALSO has a")
+	fmt.Fprintln(w, "CROSS-FAMILY LLM judge pick A/B from the same shuffled options and records a")
+	fmt.Fprintln(w, "SEPARATE skillopt-ab-judge RankedFeedbackEvent that coexists with (and weights")
+	fmt.Fprintln(w, "below) the human row. The judge NEVER touches the promotion bandit and is")
+	fmt.Fprintln(w, "skipped when no different runtime family is available. --judge-only records only")
+	fmt.Fprintln(w, "the judge row (skips the human pick prompt).")
 }
 
 func runSkillOptABWithStore(ctx context.Context, store *db.Store, paths config.Paths, options skillOptABOptions, stdout, stderr io.Writer) int {
@@ -248,6 +315,30 @@ func runSkillOptABWithStore(ctx context.Context, store *db.Store, paths config.P
 	fmt.Fprintf(stdout, "Option A:\n%s\n\n", optionA.answer)
 	fmt.Fprintf(stdout, "Option B:\n%s\n\n", optionB.answer)
 
+	// runID keeps the version-id prefix so every pick stays trivially filterable as
+	// Mode B for THIS challenger. The judge row (when enabled) reuses this SAME run
+	// and item so it coexists with the human row instead of forming a parallel run.
+	runID := skillOptABRunIDPrefix + challenger.version.ID
+
+	// OFF-BY-DEFAULT cross-family LLM-judge auto-pairwise (#483). When neither the
+	// --judge flag nor [skillopt].mode_b_judge_enabled is set, judgeEnabled is false
+	// and this whole branch is skipped — no cross-family reviewer is selected, no
+	// third Deliver happens, no judge row is written: byte-identical to #473. The
+	// judge delivery is the THIRD SERIALIZED Deliver (after both variants, before any
+	// interactive human pick) so per-runtime session locks never overlap; the judge
+	// sees the SAME shuffled Option A/B as the human (it never learns champion vs
+	// challenger), and its pick maps back through the SAME optionA/optionB mapping.
+	if skillOptABJudgeEnabled(paths, options) {
+		runSkillOptABJudge(ctx, store, paths, runtimeAgent, agent, runID, templateID, champion, challenger, optionA, optionB, options, stdout, stderr)
+	}
+
+	// --judge-only records ONLY the judge row above and skips the human pick + bandit
+	// update entirely (mirrors the --pick non-interactive escape). The human path is
+	// untouched in every other case.
+	if options.judgeOnly {
+		return 0
+	}
+
 	pick, ok := resolveSkillOptABPick(options.pick, stdout, stderr)
 	if !ok {
 		return 2
@@ -264,14 +355,12 @@ func runSkillOptABWithStore(ctx context.Context, store *db.Store, paths config.P
 		loserLabel = skillOptABChallengerLabel
 	}
 
-	// runID keeps the version-id prefix so every pick stays trivially filterable as
-	// Mode B for THIS challenger. pickSourceURL is a per-pick token that makes each
-	// recorded preference a DISTINCT contract row: the ranked_feedback_events
-	// conflict key is (run_id, item_id, reviewer, source, source_url), and the first
-	// four are identical across repeated A/Bs of the same challenger, so without a
-	// unique source_url an ON CONFLICT DO UPDATE would overwrite every prior pick and
-	// only the last preference would survive as evidence.
-	runID := skillOptABRunIDPrefix + challenger.version.ID
+	// pickSourceURL is a per-pick token that makes each recorded preference a
+	// DISTINCT contract row: the ranked_feedback_events conflict key is
+	// (run_id, item_id, reviewer, source, source_url), and the first four are
+	// identical across repeated A/Bs of the same challenger, so without a unique
+	// source_url an ON CONFLICT DO UPDATE would overwrite every prior pick and only
+	// the last preference would survive as evidence.
 	pickSourceURL := skillOptABPickSourceURL(challenger.version.ID)
 	if err := recordSkillOptABPick(ctx, store, paths, runID, pickSourceURL, templateID, champion, challenger, championDelivery, challengerDelivery, winnerLabel, loserLabel, options.prompt); err != nil {
 		fmt.Fprintf(stderr, "skillopt ab: record pick: %v\n", err)
@@ -453,6 +542,21 @@ func defaultReadSkillOptABLine() (string, bool) {
 // (ranking=[winner,loser], source=skillopt-ab) that passes
 // store.validateRankedFeedbackEventOptions.
 func recordSkillOptABPick(ctx context.Context, store *db.Store, paths config.Paths, runID, pickSourceURL, templateID string, champion, challenger skillOptABVariant, championDelivery, challengerDelivery skillOptABDelivery, winnerLabel, loserLabel, prompt string) error {
+	if err := ensureSkillOptABRunRows(ctx, store, paths, runID, templateID, champion, challenger, championDelivery, challengerDelivery, prompt); err != nil {
+		return err
+	}
+	return upsertSkillOptABRankedEvent(ctx, store, runID, winnerLabel, loserLabel, "human", skillOptABSource, pickSourceURL)
+}
+
+// ensureSkillOptABRunRows idempotently upserts the shared pairwise scaffolding for
+// one A/B run: the 2-option eval_run (OptionsCount=2, metadata
+// feedback_source=preference_ab), the eval_review_item, and the two
+// eval_review_options (champion/challenger) backed by the answer artifacts via the
+// blob path. Both the human-record path AND the judge-record path call it, so the
+// judge row is self-sufficient when --judge-only skips the human record, and the
+// rows are byte-identical when both run (every write here is an idempotent upsert
+// keyed by (run_id,item_id,label)).
+func ensureSkillOptABRunRows(ctx context.Context, store *db.Store, paths config.Paths, runID, templateID string, champion, challenger skillOptABVariant, championDelivery, challengerDelivery skillOptABDelivery, prompt string) error {
 	blobStore := artifact.NewStore(paths.ArtifactBlobs)
 
 	metadataJSON, err := json.Marshal(map[string]any{
@@ -506,7 +610,18 @@ func recordSkillOptABPick(ctx context.Context, store *db.Store, paths config.Pat
 			return err
 		}
 	}
+	return nil
+}
 
+// upsertSkillOptABRankedEvent writes ONE pairwise RankedFeedbackEvent
+// (ranking=[winner,loser], tie groups [[winner],[loser]]) for the given
+// reviewer/source/source_url over the existing run's two options. The
+// (run_id,item_id,reviewer,source,source_url) conflict key is what keeps the human
+// row (reviewer=human,source=skillopt-ab) and the judge row
+// (reviewer=skillopt-ab-judge,source=skillopt-ab-judge) as SEPARATE coexisting
+// rows on the same run/item, and what makes repeated picks each persist via a
+// distinct per-pick source_url.
+func upsertSkillOptABRankedEvent(ctx context.Context, store *db.Store, runID, winnerLabel, loserLabel, reviewer, source, sourceURL string) error {
 	ranking, err := json.Marshal([]string{winnerLabel, loserLabel})
 	if err != nil {
 		return err
@@ -521,13 +636,9 @@ func recordSkillOptABPick(ctx context.Context, store *db.Store, paths config.Pat
 		RankingJSON:   string(ranking),
 		TieGroupsJSON: string(tieGroups),
 		Winner:        winnerLabel,
-		Reviewer:      "human",
-		Source:        skillOptABSource,
-		// A distinct per-pick SourceURL makes the (run_id,item_id,reviewer,source,
-		// source_url) conflict key unique per pick, so repeated A/Bs of the same
-		// challenger each persist as their own immutable preference row instead of
-		// overwriting the prior one.
-		SourceURL: pickSourceURL,
+		Reviewer:      reviewer,
+		Source:        source,
+		SourceURL:     sourceURL,
 	})
 }
 
@@ -553,4 +664,193 @@ func answerOrPlaceholder(answer string) string {
 		return "(no answer)"
 	}
 	return answer
+}
+
+// skillOptABJudgeEnabled is the SINGLE admission gate for the off-by-default
+// cross-family LLM-judge auto-pairwise path (#483): the per-invocation --judge /
+// --judge-only flag OR the persistent [skillopt].mode_b_judge_enabled config knob.
+// When neither is set it returns false and the judge branch is skipped entirely —
+// byte-identical to #473. A config read error fails safe to OFF (the flag still
+// admits it) so a malformed config never turns the judge on by accident.
+func skillOptABJudgeEnabled(paths config.Paths, options skillOptABOptions) bool {
+	if options.judge {
+		return true
+	}
+	policy, err := config.LoadSkillOptPolicy(paths)
+	if err != nil {
+		return false
+	}
+	return policy.ModeBJudgeEnabled
+}
+
+// runSkillOptABJudge runs the off-by-default cross-family LLM-judge auto-pairwise
+// leg (#483) best-effort: it selects a CROSS-FAMILY judge (reusing #470's
+// PickCrossFamilyReviewer + the SelfFamily refinement), SKIPS on no-cross-family /
+// not-authed (never a silent same-family self-judgment), delivers the SAME shuffled
+// Option A/B text the human sees through the SERIALIZED third Deliver seam, parses
+// the judge's {"pick":"a"|"b"}, maps that pick back through the SAME optionA/optionB
+// mapping to the correct champion/challenger role, and records ONE separate
+// skillopt-ab-judge RankedFeedbackEvent that coexists with the human row. It NEVER
+// touches the promotion bandit and NEVER fails the command: every error path logs a
+// best-effort note and returns, leaving the human path intact (fail-safe).
+func runSkillOptABJudge(ctx context.Context, store *db.Store, paths config.Paths, runtimeAgent runtime.Agent, agent db.Agent, runID, templateID string, champion, challenger skillOptABVariant, optionA, optionB skillOptABDelivery, options skillOptABOptions, stdout, stderr io.Writer) {
+	// authedRuntimes probes which families can actually run, so an ephemeral judge
+	// leg is only materialized on an authed DIFFERENT family. The probe is injectable
+	// so unit tests stay deterministic/offline.
+	authed := map[string]bool{}
+	if probe := skillOptABJudgeAuthedRuntimes(agent.RepoScope); probe != nil {
+		authed = probe(ctx)
+	}
+	reviewer, ok, err := workflow.PickCrossFamilyReviewer(ctx, store, agent.Runtime, agent.RepoScope, authed)
+	if err != nil {
+		log.Printf("skillopt ab judge: select cross-family judge: %v", err)
+		return
+	}
+	// CROSS-FAMILY ONLY: SelfFamily (no different family available) or !ok (no
+	// review-capable runtime authed at all) means SKIP — never a same-family
+	// self-preference judgment of one's own template family. This is stricter than
+	// #470's same-family-with-warning, which is correct for an A/B judge of one's own
+	// family.
+	if !ok || reviewer.SelfFamily {
+		fmt.Fprintln(stdout, "skillopt ab: no cross-family judge available; skipping judge (cross-family only)")
+		return
+	}
+
+	judgeAgent := skillOptABJudgeAgent(reviewer)
+	prompt := buildSkillOptABJudgePrompt(options.prompt, optionA.answer, optionB.answer)
+	raw, err := skillOptABJudgeDeliver(ctx, judgeAgent, prompt)
+	if err != nil {
+		log.Printf("skillopt ab judge: deliver judge prompt: %v", err)
+		return
+	}
+	pick, parsed := parseSkillOptABJudgePick(raw)
+	if !parsed {
+		// Fail-safe: unparseable/empty/tie judge output drops the judge result — no
+		// row, no error escalation — exactly like ParseReviewRubric's HasScore=false
+		// "don't fabricate" stance. The human path is unaffected.
+		fmt.Fprintln(stdout, "skillopt ab: judge returned no usable pick; skipping judge row")
+		return
+	}
+
+	// Map the judge's a/b pick back to the role label via the SAME shuffle mapping
+	// the human pick uses (the judge saw the SAME debiased Option A/B), so an
+	// off-by-one here cannot silently invert the judged preference.
+	pickedDelivery := optionA
+	if pick == "b" {
+		pickedDelivery = optionB
+	}
+	winnerLabel := pickedDelivery.label
+	loserLabel := skillOptABChampionLabel
+	if winnerLabel == skillOptABChampionLabel {
+		loserLabel = skillOptABChallengerLabel
+	}
+
+	// Ensure the shared run/item/options exist (idempotent) so the judge row is
+	// self-sufficient even under --judge-only where the human record path never runs.
+	if err := ensureSkillOptABRunRows(ctx, store, paths, runID, templateID, champion, challenger, optionAToDelivery(optionA, optionB, champion), optionAToDelivery(optionA, optionB, challenger), options.prompt); err != nil {
+		log.Printf("skillopt ab judge: ensure run rows: %v", err)
+		return
+	}
+	judgeSourceURL := skillOptABJudgeSourceURL(challenger.version.ID)
+	if err := upsertSkillOptABRankedEvent(ctx, store, runID, winnerLabel, loserLabel, skillOptABJudgeReviewer, skillOptABJudgeSource, judgeSourceURL); err != nil {
+		log.Printf("skillopt ab judge: record judge pick: %v", err)
+		return
+	}
+
+	// Evidence-only, judge-tagged, weighted-below-human, NOT calibrated against human
+	// gold in this slice (MEASURE-THE-JUDGE, #344/#345). The judge NEVER increments
+	// the promotion Beta-Bernoulli bandit — promotion stays manual + human-driven.
+	fmt.Fprintf(stdout, "Judge (%s, cross-family): %s (Option %s) — recorded as %s (evidence-only, does not move the promotion bandit)\n",
+		reviewer.Runtime, winnerLabel, strings.ToUpper(pick), skillOptABJudgeSource)
+}
+
+// optionAToDelivery recovers the champion/challenger delivery from the shuffled
+// optionA/optionB pair by matching the role label, so the shared run-row scaffold
+// always registers the champion option with the champion answer and the challenger
+// option with the challenger answer regardless of the shuffle.
+func optionAToDelivery(optionA, optionB skillOptABDelivery, variant skillOptABVariant) skillOptABDelivery {
+	if optionA.label == variant.label {
+		return optionA
+	}
+	return optionB
+}
+
+// skillOptABJudgeAgent synthesizes the read-only runtime.Agent the judge runs as.
+// Its Runtime is the SELECTED CROSS-FAMILY reviewer family (a DIFFERENT family than
+// the agent under test), so realSkillOptABDeliver builds the adapter on that family
+// and the judgment is never a self-preference judgment of one's own template family.
+// A registered reviewer agent supplies its runtime ref/model; an ephemeral judge is
+// a synthetic read-only ask worker on the chosen family.
+func skillOptABJudgeAgent(reviewer workflow.CrossFamilyReviewer) runtime.Agent {
+	return runtime.Agent{
+		Name:           "gitmoot-ab-judge-" + reviewer.Runtime,
+		Role:           "ask",
+		Runtime:        reviewer.Runtime,
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: runtime.AutonomyPolicyReadOnly,
+	}
+}
+
+// buildSkillOptABJudgePrompt assembles the cross-family judge prompt from the SAME
+// shuffled Option A/Option B text the human sees (it NEVER learns which is champion
+// vs challenger — anti-position/identity bias), asking for a small
+// gitmoot_result-style JSON pick. The judge must return ONLY {"pick":"a"} or
+// {"pick":"b"}; anything else is dropped fail-safe by parseSkillOptABJudgePick.
+func buildSkillOptABJudgePrompt(userPrompt, optionA, optionB string) string {
+	var b strings.Builder
+	b.WriteString("You are an impartial cross-family judge comparing two answers to the SAME prompt. ")
+	b.WriteString("You do NOT know which answer is the established version and which is the candidate — judge ONLY on quality. ")
+	b.WriteString("This is a SOFT, advisory signal; it never promotes or blocks anything.\n\n")
+	b.WriteString("## Prompt\n")
+	b.WriteString(strings.TrimSpace(userPrompt) + "\n\n")
+	b.WriteString("## Option A\n")
+	b.WriteString(strings.TrimSpace(optionA) + "\n\n")
+	b.WriteString("## Option B\n")
+	b.WriteString(strings.TrimSpace(optionB) + "\n\n")
+	b.WriteString("Decide which option is the better answer. Return ONLY a JSON object of the form ")
+	b.WriteString(`{"pick":"a"} or {"pick":"b"} (no ties, no prose). Do NOT modify any files (read-only).`)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// parseSkillOptABJudgePick extracts the judge's a/b pick from its raw output using
+// the existing brace-balanced jsonCandidates scan (reused from the cross-family
+// review parser), tolerating a result wrapped in surrounding prose. It accepts a
+// top-level {"pick":...} or a gitmoot_result-nested pick. ok=false on
+// empty/unparseable/ambiguous output (the fail-safe drop): a non-a/non-b value, no
+// JSON candidate, or no pick field at all all yield ("", false), so a garbled judge
+// never fabricates a preference.
+func parseSkillOptABJudgePick(raw string) (string, bool) {
+	for _, candidate := range jsonCandidates(raw) {
+		var envelope struct {
+			Pick          string `json:"pick"`
+			GitmootResult struct {
+				Pick     string `json:"pick"`
+				Metadata struct {
+					Pick string `json:"pick"`
+				} `json:"metadata"`
+			} `json:"gitmoot_result"`
+		}
+		if err := json.Unmarshal([]byte(candidate), &envelope); err != nil {
+			continue
+		}
+		pick := firstNonEmpty(
+			strings.ToLower(strings.TrimSpace(envelope.Pick)),
+			strings.ToLower(strings.TrimSpace(envelope.GitmootResult.Pick)),
+			strings.ToLower(strings.TrimSpace(envelope.GitmootResult.Metadata.Pick)),
+		)
+		if pick == "a" || pick == "b" {
+			return pick, true
+		}
+	}
+	return "", false
+}
+
+// skillOptABJudgeSourceURL mints a unique-per-judgment SourceURL for the judge's
+// RankedFeedbackEvent, mirroring skillOptABPickSourceURL but with a distinct judge
+// prefix so the judge row's (run_id,item_id,reviewer,source,source_url) conflict key
+// never collides with a human pick's and repeated judge runs each persist.
+func skillOptABJudgeSourceURL(versionID string) string {
+	seq := atomic.AddUint64(&skillOptABPickSeq, 1)
+	return fmt.Sprintf("%s%s:judge#%d-%d", skillOptABRunIDPrefix, versionID, time.Now().UnixNano(), seq)
 }

--- a/internal/cli/skillopt_ab_judge_test.go
+++ b/internal/cli/skillopt_ab_judge_test.go
@@ -1,0 +1,385 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// withFakeSkillOptABJudge swaps the off-by-default cross-family judge seam for a
+// fake returning a fixed raw output, AND stubs the authed-runtimes probe so
+// PickCrossFamilyReviewer yields a DIFFERENT family (claude) than the codex agent
+// under test (a cross-family judge, SelfFamily=false). It records whether the
+// judge seam was actually invoked and restores both seams on cleanup.
+func withFakeSkillOptABJudge(t *testing.T, judgeRaw string, authed map[string]bool) *bool {
+	t.Helper()
+	called := false
+	prevDeliver := skillOptABJudgeDeliver
+	skillOptABJudgeDeliver = func(_ context.Context, agent runtime.Agent, _ string) (string, error) {
+		called = true
+		// The judge MUST run on a different family than the codex agent under test.
+		if agent.Runtime == runtime.CodexRuntime {
+			t.Errorf("judge ran on the SAME family (codex) as the agent under test; cross-family only")
+		}
+		return judgeRaw, nil
+	}
+	prevAuthed := skillOptABJudgeAuthedRuntimes
+	skillOptABJudgeAuthedRuntimes = func(string) reviewAuthedRuntimes {
+		return func(context.Context) map[string]bool { return authed }
+	}
+	t.Cleanup(func() {
+		skillOptABJudgeDeliver = prevDeliver
+		skillOptABJudgeAuthedRuntimes = prevAuthed
+	})
+	return &called
+}
+
+// TestRunSkillOptABJudgeRecordsSeparateRow proves the core #483 contract: with
+// --judge ON and a cross-family family (claude) authed, the judge picks A/B from
+// the SAME shuffled options and a SINGLE skillopt-ab-judge RankedFeedbackEvent is
+// written that COEXISTS with the human source=skillopt-ab row on the same run/item
+// (ListRankedFeedbackEvents len==2, distinct reviewer+source). The judge winner
+// maps back through the SAME shuffle as the human, and the judge adds NO bandit pull
+// (only the human pick moves the arm).
+func TestRunSkillOptABJudgeRecordsSeparateRow(t *testing.T) {
+	home, store, championID, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	// Judge picks Option A. seed 1 -> swap -> Option A is the challenger, so the
+	// judge winner must map to the challenger role (same mapping the human pick uses).
+	judgeCalled := withFakeSkillOptABJudge(t, `{"pick":"a"}`, map[string]bool{runtime.ClaudeRuntime: true})
+	ctx := context.Background()
+
+	var stdout, stderr bytes.Buffer
+	// --pick b (the human picks Option B = champion under seed-1 swap) so the human
+	// and judge winners DIFFER, proving the two rows are independently sourced.
+	code := runSkillOptAB([]string{"planner-bot", "Plan the migration.", "--home", home, "--pick", "b", "--seed", "1", "--judge"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+	if !*judgeCalled {
+		t.Fatal("judge seam was not called with --judge on and a cross-family runtime authed")
+	}
+
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("ranked feedback events = %d, want exactly 2 (human + judge coexisting)", len(events))
+	}
+
+	var humanWinner, judgeWinner string
+	humanSeen, judgeSeen := false, false
+	for _, ev := range events {
+		switch {
+		case ev.Reviewer == "human" && ev.Source == skillOptABSource:
+			humanWinner, humanSeen = ev.Winner, true
+		case ev.Reviewer == skillOptABJudgeReviewer && ev.Source == skillOptABJudgeSource:
+			judgeWinner, judgeSeen = ev.Winner, true
+		}
+	}
+	if !humanSeen {
+		t.Fatalf("missing human row (reviewer=human source=%s) among %d events", skillOptABSource, len(events))
+	}
+	if !judgeSeen {
+		t.Fatalf("missing judge row (reviewer=%s source=%s) among %d events", skillOptABJudgeReviewer, skillOptABJudgeSource, len(events))
+	}
+	// Seed 1 swaps: Option A=challenger, Option B=champion.
+	// Human picked b -> champion; judge picked a -> challenger.
+	if humanWinner != skillOptABChampionLabel {
+		t.Fatalf("human winner = %q, want %q (pick b under seed-1 swap is champion)", humanWinner, skillOptABChampionLabel)
+	}
+	if judgeWinner != skillOptABChallengerLabel {
+		t.Fatalf("judge winner = %q, want %q (pick a under seed-1 swap is challenger)", judgeWinner, skillOptABChallengerLabel)
+	}
+
+	// The judge added NO bandit pull: only the human pick moved the arms (1 pull each).
+	champArm, found, err := store.GetBanditArm(ctx, "planner", championID)
+	if err != nil || !found {
+		t.Fatalf("champion arm: found=%v err=%v", found, err)
+	}
+	if champArm.Pulls != 1 {
+		t.Fatalf("champion arm pulls = %d, want 1 (the judge must NOT increment the bandit)", champArm.Pulls)
+	}
+	chalArm, found, err := store.GetBanditArm(ctx, "planner", challengerID)
+	if err != nil || !found {
+		t.Fatalf("challenger arm: found=%v err=%v", found, err)
+	}
+	if chalArm.Pulls != 1 {
+		t.Fatalf("challenger arm pulls = %d, want 1 (the judge must NOT increment the bandit)", chalArm.Pulls)
+	}
+	// Human picked champion under seed-1 swap: champion won (Beta(2,1)), challenger lost (Beta(1,2)).
+	if champArm.Alpha != 2 || champArm.Beta != 1 {
+		t.Fatalf("champion arm = Beta(%.0f,%.0f), want Beta(2,1) (human picked champion, judge did not move it)", champArm.Alpha, champArm.Beta)
+	}
+	if chalArm.Alpha != 1 || chalArm.Beta != 2 {
+		t.Fatalf("challenger arm = Beta(%.0f,%.0f), want Beta(1,2)", chalArm.Alpha, chalArm.Beta)
+	}
+}
+
+// TestRunSkillOptABJudgeLabelShuffleMapsPickCorrectly proves the off-by-one guard
+// for the JUDGE: under both shuffles, a judge picking the option that is actually
+// the challenger records challenger-as-judge-winner, and picking the champion
+// option records champion-as-judge-winner — the judge maps back through the SAME
+// optionA/optionB mapping as the human, asserting the recorded ROLE, not the letter.
+func TestRunSkillOptABJudgeLabelShuffleMapsPickCorrectly(t *testing.T) {
+	cases := []struct {
+		name       string
+		seed       string
+		judgePick  string
+		wantWinner string
+	}{
+		// seed 0: no swap. A=champion, B=challenger.
+		{"no-swap judge picks A is champion", "0", "a", skillOptABChampionLabel},
+		{"no-swap judge picks B is challenger", "0", "b", skillOptABChallengerLabel},
+		// seed 1: swap. A=challenger, B=champion.
+		{"swap judge picks A is challenger", "1", "a", skillOptABChallengerLabel},
+		{"swap judge picks B is champion", "1", "b", skillOptABChampionLabel},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home, store, _, challengerID := skillOptABFixture(t)
+			withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+			withFakeSkillOptABJudge(t, `{"pick":"`+tc.judgePick+`"}`, map[string]bool{runtime.ClaudeRuntime: true})
+			ctx := context.Background()
+
+			var stdout, stderr bytes.Buffer
+			// --judge-only: record ONLY the judge row so we read exactly one event.
+			code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--seed", tc.seed, "--judge-only"}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+			}
+			runID := skillOptABRunIDPrefix + challengerID
+			events, err := store.ListRankedFeedbackEvents(ctx, runID)
+			if err != nil || len(events) != 1 {
+				t.Fatalf("events = %d err=%v (want exactly 1 judge row under --judge-only)", len(events), err)
+			}
+			if events[0].Reviewer != skillOptABJudgeReviewer || events[0].Source != skillOptABJudgeSource {
+				t.Fatalf("row reviewer/source = %q/%q, want %q/%q", events[0].Reviewer, events[0].Source, skillOptABJudgeReviewer, skillOptABJudgeSource)
+			}
+			if events[0].Winner != tc.wantWinner {
+				t.Fatalf("judge winner = %q, want %q", events[0].Winner, tc.wantWinner)
+			}
+		})
+	}
+}
+
+// TestRunSkillOptABJudgeSelfFamilySkips proves CROSS-FAMILY ONLY: when the only
+// authed runtime is the SAME family as the agent under test (codex), the selector
+// returns SelfFamily=true and the judge is SKIPPED — no judge row is written, a
+// clear "skipping judge" message is printed, and the human path still records its
+// single row normally.
+func TestRunSkillOptABJudgeSelfFamilySkips(t *testing.T) {
+	home, store, _, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	// Only codex authed = same family as the planner-bot agent -> SelfFamily skip.
+	judgeCalled := withFakeSkillOptABJudge(t, `{"pick":"a"}`, map[string]bool{runtime.CodexRuntime: true})
+	ctx := context.Background()
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--pick", "a", "--seed", "1", "--judge"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+	if *judgeCalled {
+		t.Fatal("judge seam was called despite no cross-family runtime (same-family must SKIP, never self-judge)")
+	}
+	if !strings.Contains(stdout.String(), "skipping judge") {
+		t.Fatalf("stdout missing 'skipping judge' message:\n%s", stdout.String())
+	}
+
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("ranked feedback events = %d, want exactly 1 (human only; judge skipped)", len(events))
+	}
+	if events[0].Reviewer != "human" || events[0].Source != skillOptABSource {
+		t.Fatalf("the surviving row must be the human row, got reviewer=%q source=%q", events[0].Reviewer, events[0].Source)
+	}
+}
+
+// TestRunSkillOptABJudgeUnparseableOutputDrops proves the fail-safe: a garbled /
+// empty / tie judge output drops the judge result (no judge row, no error) and the
+// human path still records normally.
+func TestRunSkillOptABJudgeUnparseableOutputDrops(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"empty", ""},
+		{"prose only", "I think they are both good, hard to say."},
+		{"no pick field", `{"verdict":"a"}`},
+		{"invalid pick value", `{"pick":"tie"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home, store, _, challengerID := skillOptABFixture(t)
+			withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+			withFakeSkillOptABJudge(t, tc.raw, map[string]bool{runtime.ClaudeRuntime: true})
+			ctx := context.Background()
+
+			var stdout, stderr bytes.Buffer
+			code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--pick", "a", "--seed", "1", "--judge"}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+			}
+			runID := skillOptABRunIDPrefix + challengerID
+			events, err := store.ListRankedFeedbackEvents(ctx, runID)
+			if err != nil {
+				t.Fatalf("ListRankedFeedbackEvents: %v", err)
+			}
+			if len(events) != 1 {
+				t.Fatalf("ranked feedback events = %d, want exactly 1 (human only; garbled judge dropped)", len(events))
+			}
+			if events[0].Reviewer != "human" {
+				t.Fatalf("the surviving row must be the human row, got reviewer=%q", events[0].Reviewer)
+			}
+		})
+	}
+}
+
+// TestRunSkillOptABJudgeOffByDefaultIsByteIdentical proves OFF-BY-DEFAULT: with
+// neither --judge nor the config knob set, the judge seam is NEVER called, no judge
+// row is written, and the stored result (the single human row + the bandit state)
+// is identical to the #473 human-only path. A judge seam that errors if invoked is
+// installed to assert it is never touched on the off path.
+func TestRunSkillOptABJudgeOffByDefaultIsByteIdentical(t *testing.T) {
+	home, store, championID, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+
+	// The judge seam (and the authed probe) must NEVER be touched on the off path.
+	prevDeliver := skillOptABJudgeDeliver
+	skillOptABJudgeDeliver = func(context.Context, runtime.Agent, string) (string, error) {
+		t.Fatal("judge seam was called on the OFF-BY-DEFAULT path")
+		return "", nil
+	}
+	prevProbe := skillOptABJudgeAuthedRuntimes
+	skillOptABJudgeAuthedRuntimes = func(string) reviewAuthedRuntimes {
+		t.Fatal("authed-runtimes probe was called on the OFF-BY-DEFAULT path")
+		return nil
+	}
+	t.Cleanup(func() {
+		skillOptABJudgeDeliver = prevDeliver
+		skillOptABJudgeAuthedRuntimes = prevProbe
+	})
+	ctx := context.Background()
+
+	var stdout, stderr bytes.Buffer
+	// NO --judge, NO mode_b_judge_enabled config: byte-identical to #473.
+	code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--pick", "a", "--seed", "1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("ranked feedback events = %d, want exactly 1 (human only; no judge row on the off path)", len(events))
+	}
+	if events[0].Reviewer != "human" || events[0].Source != skillOptABSource {
+		t.Fatalf("off path must record only the human row, got reviewer=%q source=%q", events[0].Reviewer, events[0].Source)
+	}
+	// Bandit state matches the #473 human-only path (seed-1 swap, pick a -> challenger wins).
+	chalArm, found, err := store.GetBanditArm(ctx, "planner", challengerID)
+	if err != nil || !found {
+		t.Fatalf("challenger arm: found=%v err=%v", found, err)
+	}
+	if chalArm.Alpha != 2 || chalArm.Beta != 1 || chalArm.Pulls != 1 {
+		t.Fatalf("challenger arm = Beta(%.0f,%.0f) pulls=%d, want Beta(2,1) pulls=1", chalArm.Alpha, chalArm.Beta, chalArm.Pulls)
+	}
+	champArm, _, _ := store.GetBanditArm(ctx, "planner", championID)
+	if champArm.Pulls != 1 {
+		t.Fatalf("champion arm pulls = %d, want 1", champArm.Pulls)
+	}
+}
+
+// TestRunSkillOptABJudgeConfigKnobEnables proves the config admission gate: with
+// [skillopt].mode_b_judge_enabled=true in the home config and NO --judge flag, the
+// judge path runs and records its separate row (the persistent knob is equivalent
+// to the per-invocation flag).
+func TestRunSkillOptABJudgeConfigKnobEnables(t *testing.T) {
+	home, store, _, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	judgeCalled := withFakeSkillOptABJudge(t, `{"pick":"a"}`, map[string]bool{runtime.ClaudeRuntime: true})
+
+	// Append the config knob to the home's config file.
+	paths := config.PathsForHome(home)
+	cfg, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, append(cfg, []byte("\n[skillopt]\nmode_b_judge_enabled = true\n")...), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Confirm the policy parses on (guards the config wiring directly).
+	policy, err := config.LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy: %v", err)
+	}
+	if !policy.ModeBJudgeEnabled {
+		t.Fatalf("ModeBJudgeEnabled = false after setting the knob; config wiring is broken")
+	}
+
+	ctx := context.Background()
+	var stdout, stderr bytes.Buffer
+	// NO --judge flag: the config knob alone must admit the judge.
+	code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--pick", "b", "--seed", "1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+	if !*judgeCalled {
+		t.Fatal("judge seam was not called with the config knob on (no --judge flag)")
+	}
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("ranked feedback events = %d, want 2 (human + judge via config knob)", len(events))
+	}
+}
+
+// TestParseSkillOptABJudgePick unit-tests the lenient brace-balanced pick parser:
+// it accepts a top-level pick, a gitmoot_result-nested pick, and a pick wrapped in
+// surrounding prose; it rejects empty/garbled/ambiguous output (fail-safe drop).
+func TestParseSkillOptABJudgePick(t *testing.T) {
+	cases := []struct {
+		name   string
+		raw    string
+		want   string
+		wantOK bool
+	}{
+		{"top level a", `{"pick":"a"}`, "a", true},
+		{"top level b uppercase", `{"pick":"B"}`, "b", true},
+		{"nested gitmoot_result", `{"gitmoot_result":{"pick":"a"}}`, "a", true},
+		{"nested metadata", `{"gitmoot_result":{"metadata":{"pick":"b"}}}`, "b", true},
+		{"wrapped in prose", "Here is my verdict:\n```json\n{\"pick\":\"a\"}\n```\nThanks!", "a", true},
+		{"empty", "", "", false},
+		{"prose only", "Option A seems better but it's close.", "", false},
+		{"no pick field", `{"winner":"a"}`, "", false},
+		{"invalid value", `{"pick":"both"}`, "", false},
+		{"tie", `{"pick":"tie"}`, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseSkillOptABJudgePick(tc.raw)
+			if ok != tc.wantOK || got != tc.want {
+				t.Fatalf("parseSkillOptABJudgePick(%q) = (%q,%v), want (%q,%v)", tc.raw, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -100,6 +100,14 @@ escalation_ttl = ""
 #     auto A/B loop. Below it the bandit still records preferences and updates its
 #     posterior but never auto-runs/auto-promotes off thin evidence. The manual
 #     'skillopt ab' CLI is always allowed regardless. (default 30)
+#   mode_b_judge_enabled (#483 Mode B): OFF by default. When true (or with the
+#     per-invocation 'skillopt ab --judge' flag), in addition to the human pick a
+#     CROSS-FAMILY LLM judge (a DIFFERENT runtime family than the agent under test)
+#     also picks the better of the two shuffled A/B answers and records a SEPARATE
+#     skillopt-ab-judge feedback row that COEXISTS with (and weights BELOW) the human
+#     row. The judge is cross-family ONLY (skipped — never same-family — when no other
+#     family is available), NEVER touches the promotion bandit, and is never the sole
+#     gate; its trust is DEFERRED to MEASURE-THE-JUDGE (#344). Off ⇒ byte-identical.
 # [skillopt]
 # auto_trace_enabled = false
 # cross_family_review_enabled = false
@@ -111,6 +119,7 @@ escalation_ttl = ""
 # auto_promote_canary = false
 # auto_promote_min_confidence = 0.95
 # bandit_min_samples = 30
+# mode_b_judge_enabled = false
 
 # [admission] is an OPT-IN, off-by-default host-global concurrency budget the
 # daemon applies BEFORE starting each agent session, on top of --workers/pool

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -439,6 +439,20 @@ type SkillOptPolicy struct {
 	// is ALWAYS allowed regardless of this floor; it only governs the deferred
 	// automatic path. The promotion side reuses AutoPromoteMinSamples.
 	BanditMinSamples *int
+
+	// ModeBJudgeEnabled opts the manual `skillopt ab` command into the off-by-default
+	// cross-family LLM-judge auto-pairwise path (#483): when true (OR the per-invocation
+	// --judge flag is passed), in addition to the human pick a CROSS-FAMILY LLM judge
+	// (a different runtime family than the agent under test) also picks the better of
+	// the two shuffled A/B answers and records its own SEPARATE RankedFeedbackEvent
+	// tagged reviewer=skillopt-ab-judge / source=skillopt-ab-judge. The judge row
+	// COEXISTS with (never overwrites) the human row and is weighted BELOW human by
+	// the source tag. Empty/false (the default) means OFF: no cross-family judge is
+	// selected, no judge delivery happens, no judge row is written — byte-identical to
+	// the #473 human-only Mode B path. The judge NEVER touches the promotion bandit
+	// and is NEVER the sole gate; its trust is explicitly deferred to MEASURE-THE-JUDGE
+	// (#344) — judge-tagged + weighted-low now, calibrated later.
+	ModeBJudgeEnabled bool
 }
 
 // DefaultBanditMinSamples is the documented default low-traffic floor for the
@@ -458,6 +472,7 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 		AutoPromoteCanary:               false,
 		AutoPromoteMinConfidence:        nil,
 		BanditMinSamples:                nil,
+		ModeBJudgeEnabled:               false,
 	}
 }
 
@@ -560,6 +575,10 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 		}
 		policy.BanditMinSamples = &parsed
 		return nil
+	case "mode_b_judge_enabled":
+		parsed, err := strconv.ParseBool(value)
+		policy.ModeBJudgeEnabled = parsed
+		return err
 	default:
 		return nil
 	}

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -214,6 +214,65 @@ auto_promote_min_samples = lots
 	}
 }
 
+// TestLoadSkillOptPolicyModeBJudgeDefaultsOff proves the #483 cross-family
+// LLM-judge auto-pairwise knob defaults OFF (byte-identical to #473 when unset).
+func TestLoadSkillOptPolicyModeBJudgeDefaultsOff(t *testing.T) {
+	policy := DefaultSkillOptPolicy()
+	if policy.ModeBJudgeEnabled {
+		t.Fatalf("mode_b_judge_enabled must default false, got %+v", policy)
+	}
+}
+
+// TestLoadSkillOptPolicyParsesModeBJudge proves mode_b_judge_enabled round-trips:
+// true parses on, false parses off, an absent key leaves the default (off), and a
+// non-bool value surfaces a parse error (fail-safe).
+func TestLoadSkillOptPolicyParsesModeBJudge(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"true", "[skillopt]\nmode_b_judge_enabled = true\n", true},
+		{"false", "[skillopt]\nmode_b_judge_enabled = false\n", false},
+		{"absent leaves default off", "[skillopt]\nauto_trace_enabled = true\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if err := Initialize(paths); err != nil {
+				t.Fatalf("Initialize returned error: %v", err)
+			}
+			if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+"\n"+tc.body), 0o600); err != nil {
+				t.Fatalf("write config returned error: %v", err)
+			}
+			policy, err := LoadSkillOptPolicy(paths)
+			if err != nil {
+				t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+			}
+			if policy.ModeBJudgeEnabled != tc.want {
+				t.Fatalf("ModeBJudgeEnabled = %v, want %v", policy.ModeBJudgeEnabled, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoadSkillOptPolicyRejectsBadModeBJudge proves a non-bool mode_b_judge_enabled
+// surfaces a parse error rather than silently turning the judge on/off.
+func TestLoadSkillOptPolicyRejectsBadModeBJudge(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+mode_b_judge_enabled = sometimes
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadSkillOptPolicy(paths); err == nil {
+		t.Fatal("expected an error for a non-bool mode_b_judge_enabled")
+	}
+}
+
 // TestLoadSkillOptPolicyIgnoresOtherSections proves a config that only sets
 // [events]/[orchestrate] leaves the trace-harvester at its disabled default.
 func TestLoadSkillOptPolicyIgnoresOtherSections(t *testing.T) {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -565,7 +565,7 @@ gitmoot skillopt candidate list [--template id]
 gitmoot skillopt candidate show <version-id>
 gitmoot skillopt candidate promote <version-id>
 gitmoot skillopt candidate reject <version-id> [--reason text]
-gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--home path]
+gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -461,8 +461,18 @@ not provide for ask agents. For a genuine ask candidate (no harvester score or
 feedback rows) the bandit pulls stand in for the Mode A sample/score floors, so the
 confidence gate alone can auto-promote it. `bandit_min_samples` (default 30) gates
 only the **deferred** auto loop; the manual A/B is always allowed. Live
-interception, the cross-family LLM-judge auto-pairwise, canary, and the auto A/B
-loop are deferred.
+interception, canary, and the auto A/B loop are deferred.
+
+Pass **`--judge`** (or set `[skillopt].mode_b_judge_enabled = true`, both **off by
+default**, #483) to ALSO have a **cross-family LLM judge** (a different runtime
+family than the agent under test) pick A/B from the **same shuffled** options and
+record a **separate** `RankedFeedbackEvent` (`reviewer`/`source =
+skillopt-ab-judge`) that **coexists with** and **weights below** the human row.
+The judge is **cross-family only** (skipped — never same-family — when no other
+family is available), **never** touches the promotion bandit, drops fail-safe on
+unparseable output, and its trust is **deferred to measure-the-judge (#344)**.
+`--judge-only` records only the judge row (skips the human prompt). Off ⇒
+byte-identical.
 
 ## Execution Model
 

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -363,7 +363,7 @@ variants and feed the human's pick to the optimizer as a contract
 `RankedFeedbackEvent`.
 
 ```sh
-gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--home path]
+gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]
 ```
 
 - **Champion** = the agent template's **current promoted** version; **challenger**
@@ -404,8 +404,45 @@ auto-promote guardrails.
 preferences and updates the posterior but the **deferred** auto A/B loop never
 runs and the confidence is never trusted to auto-promote (the promotion-side floor
 reuses `auto_promote_min_samples`). The **manual** `skillopt ab` CLI is always
-allowed. Live-traffic interception, the cross-family LLM-judge auto-pairwise,
-canary, and the auto A/B scheduling loop are **deferred** to follow-ons.
+allowed. Live-traffic interception, canary, and the auto A/B scheduling loop are
+**deferred** to follow-ons.
+
+### Cross-family LLM-judge auto-pairwise (off by default, #483)
+
+Every A/B pick needs a human in the loop, so the comparison signal is cheap to
+want but expensive to get. With `--judge` (or `[skillopt].mode_b_judge_enabled =
+true`, both **off by default**), in addition to the human pick a **cross-family
+LLM judge** — a runtime family **different** from the agent under test — also
+picks the better of the two answers automatically:
+
+```sh
+gitmoot skillopt ab <agent> "<prompt>" --judge      # human pick AND a judge row
+gitmoot skillopt ab <agent> "<prompt>" --judge-only # only the judge row (skip the human prompt)
+```
+
+- **Off by default:** with neither the flag nor the config knob set, no
+  cross-family judge is selected, no judge delivery happens, and no judge row is
+  written — **byte-identical** to the #473 human-only path.
+- **Cross-family only.** The judge family is chosen by the **same**
+  `PickCrossFamilyReviewer` selector Mode A uses; a `SelfFamily` result (no
+  different family available) is **skipped with a clear message**, never a silent
+  same-family self-judgment of one's own template family.
+- The judge is shown the **same shuffled Option A / Option B** the human sees (it
+  never learns champion vs challenger) and returns a small `{"pick":"a"|"b"}`,
+  parsed leniently; **unparseable / empty / tie output drops the judge result**
+  (no row, no error) — fail-safe. Its pick maps back through the **same** shuffle
+  mapping, so the recorded judge winner is the correct champion/challenger role.
+- The judge writes its **own** `RankedFeedbackEvent` with `reviewer =
+  skillopt-ab-judge` and `source = skillopt-ab-judge`, so it **coexists** with the
+  human `source = skillopt-ab` row on the same run/item (the conflict key differs
+  by reviewer+source) and is **weighted below human** by the source tag.
+- The judge is **evidence-only**: it **never** increments the promotion
+  Beta-Bernoulli bandit and **never** changes `P(challenger > champion)`. Promotion
+  stays manual + human-driven. **No contract struct changes — `ContractVersion`
+  stays `1`** (the only new differentiator is the source/reviewer tag value).
+- **Trust is gated on measure-the-judge (#344):** the judge row is judge-tagged
+  and weighted low here and is **not** calibrated against human gold in this slice
+  — judge-tagged now, calibrated later.
 
 ## Ranked Exploration Workflow
 


### PR DESCRIPTION
## Summary

Adds an **off-by-default** path to `gitmoot skillopt ab` (#473 Mode B) where, in addition to the human pick, a **cross-family LLM judge** (a runtime family *different* from the agent under test) also picks the better of the two shuffled A/B answers and records its **own separate** `RankedFeedbackEvent`. Augments the human pick with a cheap-but-biased automatic signal, kept clearly separable and weighted below human.

## Whole-feature invariants

- **OFF BY DEFAULT** — gated by the new `--judge`/`--judge-only` flags **OR** the new `[skillopt].mode_b_judge_enabled` config knob (default `false`). With neither set, the command is **byte-identical** to #473: no cross-family judge selected, no judge delivery, no judge row, no new work on the off path.
- **ADDITIVE** — `ContractVersion` stays `1`; no new exported contract field. The only new persisted differentiator is the `source`/`reviewer` tag value on an existing `RankedFeedbackEvent` shape.
- **MANUAL PROMOTION preserved** — the judge **never** increments the promotion Beta-Bernoulli bandit and never moves `P(challenger>champion)`.
- **BEST-EFFORT / FAIL-SAFE** — the judge runs as a third *serialized* `Deliver`; unparseable/empty/tie output drops the judge result (no row, no error); the human path is never blocked or failed.

## Issue-specific

- **Cross-family only** — reuses #470's `PickCrossFamilyReviewer` (incl. the SelfFamily refinement); a `SelfFamily`/not-authed result is **skipped with a clear message**, never a silent same-family self-judgment.
- **Separable + weighted-below-human** — the judge row carries `reviewer`/`source = skillopt-ab-judge`, so it **coexists** with the human `skillopt-ab` row on the same run/item under the `(run_id,item_id,reviewer,source,source_url)` conflict key.
- **Never the sole gate; trust deferred to #344** — judge-tagged + weighted-low now, calibrated later (code comment + docs mirror the existing MEASURE-THE-JUDGE note).
- **Label-shuffle integrity preserved** — the judge sees the same shuffled Option A/B as the human and maps its pick back through the same mapping to the correct champion/challenger role.

## Tests

`internal/cli/skillopt_ab_judge_test.go`: separate-row coexistence (human + judge, distinct sources, judge adds no bandit pull), shuffle mapping under both seeds, SelfFamily skip, fail-safe drop on garbled output, off-by-default byte-identical, config-knob admission, and a lenient pick-parser unit table. Plus `internal/config` round-trip tests for `mode_b_judge_enabled` (default off, parse true/false, reject non-bool).

Docs updated in **both trees** (in-repo `docs/` + `website/docs/`) and the packaged skill references (`CLI.md`, `WORKFLOWS.md`).

Gate: `go build`, `go vet`, `go test ./...`, and `go test -race` on `internal/{workflow,cli,skillopt,daemon}` all green.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)