### PR TITLE
feat(skillopt): live-traffic A/B interception for ask agents (#482)

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -296,7 +296,8 @@ auto_promote_require_external_ci = false  # require >= 1 real-external-CI feedba
 auto_promote_require_measured_judge = false  # PARSED but DEFERRED (#344): true => fail safe to no-promote
 auto_promote_canary = false               # PARSED but DEFERRED (canary follow-on): true => fail safe to no-promote
 auto_promote_min_confidence = 0.95        # #473 Mode B: UNSET = ignore; SET = require bandit P(>) >= floor (+ enough samples)
-bandit_min_samples = 30                   # #473 Mode B low-traffic floor for the DEFERRED auto loop (manual `skillopt ab` always allowed)
+bandit_min_samples = 30                   # #473/#482 Mode B low-traffic floor (manual `skillopt ab` always allowed)
+live_ab_sample_rate = 0.0                 # #482 Mode B live A/B: 0.0 (default) = never intercept; fraction of foreground asks to A/B
 ```
 
 The guardrails read the candidate's **harvester auto-trace run**
@@ -386,11 +387,48 @@ confidence carried into `candidate.awaiting_promotion`'s detail and into the
 auto-promote guardrails.
 
 **Tiering.** Below `bandit_min_samples` (default 30) the bandit still records
-preferences and updates the posterior but the **deferred** auto A/B loop never
-runs and the confidence is never trusted to auto-promote (the promotion-side floor
+preferences and updates the posterior but live-traffic interception never fires
+and the confidence is never trusted to auto-promote (the promotion-side floor
 reuses `auto_promote_min_samples`). The **manual** `skillopt ab` CLI is always
-allowed. Live-traffic interception, the cross-family LLM-judge auto-pairwise,
-canary, and the auto A/B scheduling loop are **deferred** to follow-ons.
+allowed regardless of the floor.
+
+### Live-traffic A/B interception (off by default, #482)
+
+The same champion-vs-challenger pick can fire **automatically** on a **sampled
+fraction** of real foreground `gitmoot agent ask` traffic, so a template
+self-improves the more you use it — no operator has to remember to run
+`skillopt ab`. It is purely an **additional caller** of the #473 surface above: it
+adds **no new bandit math and no new contract field** (`ContractVersion` stays
+`1`), only a sampling decision, the `bandit_min_samples` traffic floor, and a
+serialized double-`Deliver` at the ask seam.
+
+- **Off by default.** `live_ab_sample_rate` is `0.0` (and unset with no
+  `[skillopt]` section), which makes the foreground ask path **byte-identical** —
+  no extra `Deliver`, no A/B row, no bandit update; the hot path is untouched when
+  off.
+- When `live_ab_sample_rate > 0`, a foreground ask on a **managed** agent whose
+  **champion bandit arm** has accrued `>= bandit_min_samples` pulls is intercepted
+  with probability `live_ab_sample_rate`. Low-traffic / bespoke agents (e.g. the
+  `researcher`) below the floor are **never** auto-A/B'd.
+- An intercepted ask runs the **champion** (the canonical answer you receive, via
+  the normal job path) and then a single pending **challenger** strictly
+  **serialized under the one runtime-session lock already held** by the foreground
+  ask — never a second lock, so it can never self-deadlock on `session is busy`. It
+  presents both answers and routes the human pick through the **exact same**
+  `recordSkillOptABPick` path as the manual A/B (same `source = skillopt-ab`
+  `RankedFeedbackEvent`, same Beta-Bernoulli bandit update).
+- It is **fail-safe**: a challenger `Deliver` error, no single pending challenger,
+  or no pick captured degrades to the normal single champion answer and logs a
+  `live_ab_skipped` job event — the primary ask is never blocked or degraded. Each
+  intercepted ask runs the runtime **twice** (the sampled cost, bounded by the rate
+  + floor).
+- **Promotion stays MANUAL.** Live A/B only writes feedback + updates the
+  posterior; it never auto-promotes or rolls back a version. The bandit confidence
+  still flows into `auto_promote_min_confidence` as a **suggestion**, gated by an
+  explicit human `promote`.
+
+The cross-family LLM-judge auto-pairwise, canary, and the unattended auto A/B
+scheduling loop remain **deferred** to follow-ons.
 
 ## Ranked Exploration Workflow
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -145,6 +145,7 @@ func runAgentAsk(args []string, stdout, stderr io.Writer) int {
 			SelectedAction:       "ask",
 			SelectedActionReason: "explicit agent ask",
 			ExecutionPath:        "agent_ask",
+			JSONOutput:           options.jsonOutput,
 		})
 		return err
 	}); err != nil {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -221,8 +221,22 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		defer cancel()
 	}
 	if request.Action == "ask" {
-		if _, err := (workflow.Mailbox{Store: store}).Run(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {
-			return localAgentJobOutput{}, err
+		// Live-traffic A/B interception (#482). Off by default: when
+		// [skillopt].live_ab_sample_rate is 0 (every existing home + DefaultConfig),
+		// the agent is unmanaged, the bandit floor is not met, or the sampling die
+		// misses, maybeRunLiveAB returns handled=false and the EXACT single
+		// Mailbox.Run below runs unchanged (byte-identical, no extra Deliver). It
+		// reuses the runtime-session lock already held from acquireRuntimeSessionLock
+		// above — no second lock acquisition — so the two serialized Deliver calls
+		// can never self-deadlock on "session is busy".
+		handled, abErr := maybeRunLiveAB(runCtx, store, request, agent, job, adapter, managed.OK)
+		if abErr != nil {
+			return localAgentJobOutput{}, abErr
+		}
+		if !handled {
+			if _, err := (workflow.Mailbox{Store: store}).Run(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {
+				return localAgentJobOutput{}, err
+			}
 		}
 		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_completed", Message: "workflow advancement completed"}); err != nil {
 			return localAgentJobOutput{}, err

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -45,6 +45,12 @@ type localAgentDispatchRequest struct {
 	SelectedAction         string
 	SelectedActionReason   string
 	ExecutionPath          string
+	// JSONOutput is true when the caller will emit machine-readable JSON (e.g.
+	// `agent ask --json`). The live-A/B interceptor (#482) MUST stay byte-clean for
+	// these consumers: it never presents the A/B block (which would prepend
+	// "[live A/B] ..." to the JSON object and break parsing) and never runs the
+	// second challenger Deliver, falling through to the plain single ask.
+	JSONOutput bool
 }
 
 type localAgentJobOutput struct {

--- a/internal/cli/agent_dispatch_live_ab.go
+++ b/internal/cli/agent_dispatch_live_ab.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/config"
@@ -19,6 +20,21 @@ import (
 // (rate>0, managed, action==ask, above floor) already passed, so an off-path ask
 // never even draws — keeping the hot path byte-identical.
 var liveABSampler = func() float64 { return rand.Float64() }
+
+// liveABInteractive reports whether the current ask is a genuine interactive TTY
+// session (both stdin AND stdout are character devices). It is a var seam so
+// tests can force interactive/non-interactive. The interceptor is gated on it so
+// a piped / scripted / redirected ask is NEVER intercepted: the A/B block can
+// only be presented (and the pick read) on a real terminal, never blocking an
+// unattended ask on fmt.Scanln nor polluting a redirected stdout. Combined with
+// the request.JSONOutput gate this keeps both `--json` and any non-tty ask
+// byte-identical to a plain single Mailbox.Run.
+var liveABInteractive = func() bool {
+	in, errIn := os.Stdin.Stat()
+	out, errOut := os.Stdout.Stat()
+	return errIn == nil && errOut == nil &&
+		in.Mode()&os.ModeCharDevice != 0 && out.Mode()&os.ModeCharDevice != 0
+}
 
 // liveABPolicyLoader is a var seam over LoadSkillOptABPolicy so tests can supply
 // a policy without writing a config file. It returns the off-by-default policy
@@ -67,6 +83,16 @@ func maybeRunLiveAB(ctx context.Context, store *db.Store, request localAgentDisp
 	}
 	if !managed {
 		// Shell / unmanaged / bespoke traffic stays byte-identical.
+		return false, nil
+	}
+	// Interactive-only gate (#482): the A/B presentation prints to stdout and reads
+	// a pick from stdin, so it can only fire on a genuine TTY. A `--json` ask or any
+	// piped / redirected / scripted (e.g. fully-unattended) ask is a pure no-op here
+	// — it never presents the "[live A/B] ..." block (which would corrupt the JSON
+	// stream) and never runs the second challenger Deliver, falling through to the
+	// single Mailbox.Run with byte-identical output. This is a cheap gate placed
+	// before any I/O so a non-interactive ask never even loads the policy.
+	if request.JSONOutput || !liveABInteractive() {
 		return false, nil
 	}
 	policy := liveABPolicyLoader(request.Home)
@@ -135,11 +161,20 @@ func runLiveABChallenger(ctx context.Context, store *db.Store, request localAgen
 		return fmt.Errorf("live_ab resolve paths: %w", err)
 	}
 
+	// CRITICAL (#482, goal Risk #4): the challenger Deliver MUST run on a
+	// forked/throwaway session, NEVER the agent's live RuntimeRef. Reusing
+	// agent.RuntimeRef would resume the user's real session a SECOND time (codex
+	// always `exec resume`s in Deliver; claude/kimi resume a pinned ref), injecting
+	// the challenger's "Template instructions:\n..." turn into the user's ongoing
+	// conversation and poisoning the resume_hint — so the NEXT genuine ask resumes a
+	// contaminated thread. An EMPTY RuntimeRef is the forked-session signal:
+	// realSkillOptABDeliver mints a fresh throwaway session via adapter.Start, so the
+	// agent's live session is never touched.
 	abAgent := runtime.Agent{
 		Name:           agent.Name,
 		Role:           firstNonEmpty(agent.Role, "ask"),
 		Runtime:        agent.Runtime,
-		RuntimeRef:     agent.RuntimeRef,
+		RuntimeRef:     "", // forked/throwaway session — never the agent's live ref
 		RepoScope:      agent.RepoScope,
 		TemplateID:     agent.TemplateID,
 		Capabilities:   agent.Capabilities,

--- a/internal/cli/agent_dispatch_live_ab.go
+++ b/internal/cli/agent_dispatch_live_ab.go
@@ -1,0 +1,267 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// liveABSampler returns the sampling draw used by maybeRunLiveAB to decide
+// whether a single foreground ask is intercepted. It is a var seam (defaults to
+// math/rand.Float64, in [0,1)) so tests can force a hit (return 0) or a miss
+// (return 1) deterministically. It is consulted ONLY after every cheap gate
+// (rate>0, managed, action==ask, above floor) already passed, so an off-path ask
+// never even draws — keeping the hot path byte-identical.
+var liveABSampler = func() float64 { return rand.Float64() }
+
+// liveABPolicyLoader is a var seam over LoadSkillOptABPolicy so tests can supply
+// a policy without writing a config file. It returns the off-by-default policy
+// (rate 0) on any error, which keeps the interceptor fail-safe: a malformed or
+// unreadable config can never turn interception ON, only leave it OFF.
+var liveABPolicyLoader = func(home string) config.SkillOptABPolicy {
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return config.DefaultSkillOptABPolicy()
+	}
+	policy, err := config.LoadSkillOptABPolicy(paths)
+	if err != nil {
+		return config.DefaultSkillOptABPolicy()
+	}
+	return policy
+}
+
+// liveABEventKind is the job event recorded whenever a sampled interception
+// degrades to the champion-only answer (no challenger, no pick, or a challenger
+// Deliver error) — the fail-safe marker the test asserts.
+const liveABEventKind = "live_ab_skipped"
+
+// maybeRunLiveAB optionally forks the single foreground `agent ask` Mailbox.Run
+// into a champion-vs-challenger A/B (#482) and routes the human pick through
+// #473's recordSkillOptABPick + bandit update. It returns handled=false (a pure
+// no-op, NO side effects, NO Deliver) whenever the feature is off or ungated, so
+// the caller falls through to the existing single Mailbox.Run unchanged —
+// byte-identical behavior when live_ab_sample_rate is 0 (the default).
+//
+// When it DOES intercept it returns handled=true and is responsible for
+// delivering the champion answer to the user (via the same Mailbox.Run path, so
+// the job/result the user sees is identical to a normal ask) plus a SECOND,
+// strictly-serialized challenger Deliver under the SAME runtime-session lock the
+// caller already holds — never acquiring a second lock. It is FAIL-SAFE: once the
+// champion has answered, any subsequent error (challenger Deliver failure, no
+// pick available, record failure) is swallowed, logged as a live_ab_skipped job
+// event, and reported as handled=true with a nil error so the user always gets
+// the champion answer and the primary ask is never degraded.
+func maybeRunLiveAB(ctx context.Context, store *db.Store, request localAgentDispatchRequest, agent db.Agent, job db.Job, adapter workflow.DeliveryAdapter, managed bool) (bool, error) {
+	// --- Cheap gates first (no I/O beyond the policy load); any miss is a no-op. ---
+	if strings.TrimSpace(request.Action) != "ask" {
+		return false, nil
+	}
+	if request.Background {
+		return false, nil
+	}
+	if !managed {
+		// Shell / unmanaged / bespoke traffic stays byte-identical.
+		return false, nil
+	}
+	policy := liveABPolicyLoader(request.Home)
+	if policy.LiveABSampleRate <= 0 {
+		return false, nil
+	}
+	templateID, _ := db.SplitAgentTemplateReference(strings.TrimSpace(agent.TemplateID))
+	if templateID == "" {
+		return false, nil
+	}
+
+	// --- Resolve champion + challenger versions; no challenger ⇒ nothing to A/B. ---
+	champion, challenger, ok, err := resolveLiveABVariants(ctx, store, templateID)
+	if err != nil {
+		// A resolution error must never break the ask: treat as not-intercepted.
+		return false, nil
+	}
+	if !ok {
+		return false, nil
+	}
+
+	// --- Traffic floor: the champion arm's bandit pull count must clear the floor.
+	// Reuses #473's bandit pull count as the honest traffic signal so low-traffic /
+	// bespoke agents (e.g. researcher) never auto-A/B, exactly as the issue demands.
+	arm, _, err := store.GetBanditArm(ctx, templateID, champion.version.ID)
+	if err != nil {
+		return false, nil
+	}
+	if arm.Pulls < policy.BanditMinSamples {
+		return false, nil
+	}
+
+	// --- Sampling die: only a ~rate fraction is intercepted. ---
+	if liveABSampler() >= policy.LiveABSampleRate {
+		return false, nil
+	}
+
+	// === Past this point we ARE intercepting (handled=true regardless of outcome). ===
+	// 1) Champion: the canonical answer the user receives, via the normal
+	//    Mailbox.Run path so the job/result are identical to a plain ask.
+	championResult, runErr := (workflow.Mailbox{Store: store}).Run(ctx, job.ID, runtimeAgent(agent), adapter)
+	if runErr != nil {
+		// The primary ask itself failed — surface it exactly as the non-intercepted
+		// path would (the caller propagates the same error).
+		return true, runErr
+	}
+	championAnswer := strings.TrimSpace(championResult.Summary)
+
+	// 2) Challenger: a SECOND Deliver, strictly AFTER the champion returned, under
+	//    the one already-held runtime-session lock. From here everything is
+	//    fail-safe: the champion already answered, so any error degrades to a
+	//    champion-only ask + a live_ab_skipped event.
+	if err := runLiveABChallenger(ctx, store, request, agent, job, templateID, champion, challenger, championAnswer); err != nil {
+		_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: liveABEventKind, Message: err.Error()})
+	}
+	return true, nil
+}
+
+// runLiveABChallenger delivers the challenger variant, presents both answers,
+// captures the human pick, and records it through the #473 path. Every failure
+// returns an error the fail-safe caller logs as live_ab_skipped; the champion
+// answer is already delivered, so no error here ever degrades the user's ask.
+func runLiveABChallenger(ctx context.Context, store *db.Store, request localAgentDispatchRequest, agent db.Agent, job db.Job, templateID string, champion, challenger skillOptABVariant, championAnswer string) error {
+	paths, err := pathsFromFlag(request.Home)
+	if err != nil {
+		return fmt.Errorf("live_ab resolve paths: %w", err)
+	}
+
+	abAgent := runtime.Agent{
+		Name:           agent.Name,
+		Role:           firstNonEmpty(agent.Role, "ask"),
+		Runtime:        agent.Runtime,
+		RuntimeRef:     agent.RuntimeRef,
+		RepoScope:      agent.RepoScope,
+		TemplateID:     agent.TemplateID,
+		Capabilities:   agent.Capabilities,
+		AutonomyPolicy: firstNonEmpty(agent.AutonomyPolicy, runtime.AutonomyPolicyReadOnly),
+		Model:          agent.Model,
+	}
+	prompt := strings.TrimSpace(request.Instructions)
+
+	// The challenger Deliver runs strictly after the champion's Mailbox.Run
+	// returned (serialized under the single held lock) via the shared #473 seam.
+	challengerDelivery, err := deliverSkillOptABVariant(ctx, abAgent, prompt, challenger)
+	if err != nil {
+		return fmt.Errorf("live_ab challenger deliver: %w", err)
+	}
+	championDelivery := skillOptABDelivery{label: skillOptABChampionLabel, answer: championAnswer}
+
+	// Present both answers and capture the pick. A missing pick (non-interactive
+	// session) is a clean fail-safe skip — the champion answer already stands.
+	winnerLabel, loserLabel, ok := presentLiveABAndCapturePick(prompt, championDelivery.answer, challengerDelivery.answer)
+	if !ok {
+		return fmt.Errorf("live_ab no pick captured")
+	}
+
+	// Route through the EXACT #473 record path: same RankedFeedbackEvent shape,
+	// source tag, run-id prefix, and per-pick SourceURL as a manual `skillopt ab`.
+	runID := skillOptABRunIDPrefix + challenger.version.ID
+	pickSourceURL := skillOptABPickSourceURL(challenger.version.ID)
+	if err := recordSkillOptABPick(ctx, store, paths, runID, pickSourceURL, templateID, champion, challenger, championDelivery, challengerDelivery, winnerLabel, loserLabel, prompt); err != nil {
+		return fmt.Errorf("live_ab record pick: %w", err)
+	}
+
+	// Update both bandit arms (winner +win, loser +loss) — the SAME posterior
+	// update as manual A/B. MANUAL PROMOTION is preserved: this writes feedback +
+	// the posterior only; it never promotes or rolls back a version.
+	championWin := winnerLabel == skillOptABChampionLabel
+	if _, err := store.IncrementBanditArm(ctx, templateID, champion.version.ID, championWin); err != nil {
+		return fmt.Errorf("live_ab update champion arm: %w", err)
+	}
+	if _, err := store.IncrementBanditArm(ctx, templateID, challenger.version.ID, !championWin); err != nil {
+		return fmt.Errorf("live_ab update challenger arm: %w", err)
+	}
+	return nil
+}
+
+// resolveLiveABVariants resolves the champion (current promoted version) and the
+// challenger (the sole pending candidate). ok=false (with nil error) means there
+// is nothing to A/B — no current version, or zero/multiple pending candidates —
+// and the caller falls through to a normal single ask.
+func resolveLiveABVariants(ctx context.Context, store *db.Store, templateID string) (skillOptABVariant, skillOptABVariant, bool, error) {
+	template, err := store.GetAgentTemplate(ctx, templateID)
+	if err != nil {
+		return skillOptABVariant{}, skillOptABVariant{}, false, err
+	}
+	championID := strings.TrimSpace(template.VersionID)
+	if championID == "" {
+		return skillOptABVariant{}, skillOptABVariant{}, false, nil
+	}
+	championVersion, err := store.GetAgentTemplateVersionByID(ctx, championID)
+	if err != nil {
+		return skillOptABVariant{}, skillOptABVariant{}, false, err
+	}
+	pending, err := store.ListPendingAgentTemplateVersions(ctx, templateID)
+	if err != nil {
+		return skillOptABVariant{}, skillOptABVariant{}, false, err
+	}
+	// Auto-interception only fires with a single unambiguous challenger; zero or
+	// multiple pending candidates is a clean no-op (the operator can disambiguate
+	// via the manual `skillopt ab --challenger`).
+	if len(pending) != 1 {
+		return skillOptABVariant{}, skillOptABVariant{}, false, nil
+	}
+	return skillOptABVariant{version: championVersion, label: skillOptABChampionLabel},
+		skillOptABVariant{version: pending[0], label: skillOptABChallengerLabel},
+		true, nil
+}
+
+// liveABPresenter is the presentation+pick seam (overridden in tests). It is
+// shown both answers and returns the human pick as a role label
+// (champion|challenger) plus ok=false when no pick could be captured (e.g. a
+// non-interactive session), which the fail-safe caller treats as a clean skip.
+var liveABPresenter = defaultLiveABPresenter
+
+func presentLiveABAndCapturePick(prompt, championAnswer, challengerAnswer string) (winnerLabel, loserLabel string, ok bool) {
+	return liveABPresenter(prompt, championAnswer, challengerAnswer)
+}
+
+// defaultLiveABPresenter prints both answers (shuffled as Option A/B) to stdout
+// and reads one pick line via the shared readSkillOptABLine seam. A missing pick
+// is the common non-interactive case and returns ok=false (fail-safe skip). When
+// a valid pick arrives it is mapped back through the shuffle to the correct role.
+func defaultLiveABPresenter(prompt, championAnswer, challengerAnswer string) (string, string, bool) {
+	// Shuffle so the human cannot infer which answer is the challenger; map the
+	// pick back to the role via the recorded swap.
+	swap := liveABShuffle()
+	optionAAnswer, optionAIsChampion := championAnswer, true
+	optionBAnswer := challengerAnswer
+	if swap {
+		optionAAnswer, optionBAnswer = challengerAnswer, championAnswer
+		optionAIsChampion = false
+	}
+
+	fmt.Printf("\n[live A/B] Two answers for: %s\n", prompt)
+	fmt.Printf("Option A:\n%s\n\n", optionAAnswer)
+	fmt.Printf("Option B:\n%s\n\n", optionBAnswer)
+	fmt.Print("Which is better? [a/b] (enter to skip): ")
+
+	line, gotLine := readSkillOptABLine()
+	if !gotLine {
+		return "", "", false
+	}
+	pick := strings.ToLower(strings.TrimSpace(line))
+	if pick != "a" && pick != "b" {
+		return "", "", false
+	}
+	pickedChampion := (pick == "a") == optionAIsChampion
+	if pickedChampion {
+		return skillOptABChampionLabel, skillOptABChallengerLabel, true
+	}
+	return skillOptABChallengerLabel, skillOptABChampionLabel, true
+}
+
+// liveABShuffle is a seam over the one coin flip that decides the A/B label
+// shuffle; tests pin it. The default uses the same package math/rand source as
+// liveABSampler so an unseeded run is non-deterministic (no fixed-seed bias).
+var liveABShuffle = func() bool { return rand.Intn(2) == 1 }

--- a/internal/cli/agent_dispatch_live_ab_test.go
+++ b/internal/cli/agent_dispatch_live_ab_test.go
@@ -1,0 +1,502 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// liveABChampionAdapter is the champion-side DeliveryAdapter (the one
+// Mailbox.Run drives). It records its Deliver calls and returns a valid
+// gitmoot_result whose summary is the champion answer.
+type liveABChampionAdapter struct {
+	mu      sync.Mutex
+	calls   int
+	summary string
+	// onDeliver, when set, records the champion call into a shared order slice so a
+	// test can prove the champion runs strictly before the challenger.
+	onDeliver func()
+}
+
+func (a *liveABChampionAdapter) Deliver(_ context.Context, _ runtime.Agent, _ runtime.Job) (runtime.Result, error) {
+	a.mu.Lock()
+	a.calls++
+	cb := a.onDeliver
+	a.mu.Unlock()
+	if cb != nil {
+		cb()
+	}
+	out := `{"gitmoot_result":{"decision":"approved","summary":"` + a.summary + `","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+	return runtime.Result{Summary: out, Raw: out}, nil
+}
+
+func (a *liveABChampionAdapter) deliverCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.calls
+}
+
+// liveABFixture installs a "planner" template (its current version is the
+// champion), a single pending challenger version, registers a managed agent bound
+// to the template, seeds the champion bandit arm to a chosen pull count, and
+// enqueues a foreground ask job. It returns the home, store, the request, the
+// db.Agent, the enqueued job, and the challenger version id.
+func liveABFixture(t *testing.T, championPulls int) (string, *db.Store, localAgentDispatchRequest, db.Agent, db.Job, string) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	ctx := context.Background()
+
+	if err := store.UpsertAgentTemplate(ctx, cliSkillOptTemplate("planner", "Champion guidance.")); err != nil {
+		t.Fatalf("UpsertAgentTemplate: %v", err)
+	}
+	champ, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate: %v", err)
+	}
+	challengerTmpl := cliSkillOptTemplate("planner", "Challenger guidance, stronger and more actionable.")
+	challengerVersion, err := store.AddPendingAgentTemplateVersion(ctx, challengerTmpl)
+	if err != nil {
+		t.Fatalf("AddPendingAgentTemplateVersion: %v", err)
+	}
+
+	agent := db.Agent{
+		Name:           "planner-bot",
+		Role:           "ask",
+		Runtime:        runtime.ShellRuntime,
+		RuntimeRef:     "last",
+		TemplateID:     "planner",
+		AutonomyPolicy: runtime.AutonomyPolicyReadOnly,
+	}
+	if err := store.UpsertAgent(ctx, agent); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	// Seed the champion arm above/below the floor by recording championPulls
+	// pairwise outcomes against it.
+	for i := 0; i < championPulls; i++ {
+		if _, err := store.IncrementBanditArm(ctx, "planner", champ.VersionID, i%2 == 0); err != nil {
+			t.Fatalf("IncrementBanditArm: %v", err)
+		}
+	}
+
+	request := localAgentDispatchRequest{
+		Agent:        "planner-bot",
+		Action:       "ask",
+		Instructions: "Plan the migration.",
+		Home:         home,
+	}
+	job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+		ID:           "ask-planner-bot",
+		Agent:        "planner-bot",
+		Action:       "ask",
+		Repo:         "jerryfane/gitmoot",
+		Instructions: "Plan the migration.",
+		Sender:       "local",
+	})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	return home, store, request, agent, job, challengerVersion.ID
+}
+
+// withLiveABPolicy overrides the policy loader seam for the test's duration.
+func withLiveABPolicy(t *testing.T, rate float64, floor int) {
+	t.Helper()
+	prev := liveABPolicyLoader
+	liveABPolicyLoader = func(string) config.SkillOptABPolicy {
+		return config.SkillOptABPolicy{LiveABSampleRate: rate, BanditMinSamples: floor}
+	}
+	t.Cleanup(func() { liveABPolicyLoader = prev })
+}
+
+// withLiveABSampler pins the sampling draw (0 = always hit, 1 = always miss).
+func withLiveABSampler(t *testing.T, value float64) {
+	t.Helper()
+	prev := liveABSampler
+	liveABSampler = func() float64 { return value }
+	t.Cleanup(func() { liveABSampler = prev })
+}
+
+// withLiveABChallengerDeliver pins the challenger Deliver seam (shared with the
+// CLI A/B) and records its calls. It records, in order, every champion+challenger
+// invocation so the test can prove serialization.
+func withLiveABChallengerDeliver(t *testing.T, calls *[]string, challengerAnswer string, challengerErr error) {
+	t.Helper()
+	prev := skillOptABDeliver
+	skillOptABDeliver = func(_ context.Context, _ runtime.Agent, prompt string) (string, error) {
+		*calls = append(*calls, "challenger")
+		if challengerErr != nil {
+			return "", challengerErr
+		}
+		return challengerAnswer, nil
+	}
+	t.Cleanup(func() { skillOptABDeliver = prev })
+}
+
+// withLiveABPresenter pins the presenter to deterministically pick a role.
+func withLiveABPresenter(t *testing.T, winner, loser string, ok bool) {
+	t.Helper()
+	prev := liveABPresenter
+	liveABPresenter = func(_, _, _ string) (string, string, bool) {
+		return winner, loser, ok
+	}
+	t.Cleanup(func() { liveABPresenter = prev })
+}
+
+// TestMaybeRunLiveABOffByDefaultIsNoop is the byte-identical proof: with rate 0
+// (the default, no [skillopt] section) maybeRunLiveAB returns handled=false and
+// performs NO Deliver, writes NO RankedFeedbackEvent, and updates NO bandit arm,
+// so the caller's single Mailbox.Run runs unchanged.
+func TestMaybeRunLiveABOffByDefaultIsNoop(t *testing.T) {
+	_, store, request, agent, job, challengerID := liveABFixture(t, 100)
+	withLiveABPolicy(t, 0.0, 1) // rate 0 = off, even above the floor
+	withLiveABSampler(t, 0.0)   // would hit if rate>0
+	var challengerCalls []string
+	withLiveABChallengerDeliver(t, &challengerCalls, "Challenger answer.", nil)
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+
+	handled, err := maybeRunLiveAB(context.Background(), store, request, agent, job, champ, true)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB: %v", err)
+	}
+	if handled {
+		t.Fatal("rate 0 must return handled=false (no-op)")
+	}
+	if champ.deliverCount() != 0 {
+		t.Fatalf("champion Deliver calls = %d, want 0 (interceptor must not run anything when off)", champ.deliverCount())
+	}
+	if len(challengerCalls) != 0 {
+		t.Fatalf("challenger Deliver calls = %d, want 0", len(challengerCalls))
+	}
+	assertNoLiveABRecord(t, store, challengerID)
+}
+
+// TestMaybeRunLiveABUnmanagedIsNoop: an unmanaged agent (managed=false) is never
+// intercepted regardless of rate.
+func TestMaybeRunLiveABUnmanagedIsNoop(t *testing.T) {
+	_, store, request, agent, job, challengerID := liveABFixture(t, 100)
+	withLiveABPolicy(t, 1.0, 1)
+	withLiveABSampler(t, 0.0)
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+
+	handled, err := maybeRunLiveAB(context.Background(), store, request, agent, job, champ, false /* unmanaged */)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB: %v", err)
+	}
+	if handled {
+		t.Fatal("unmanaged agent must return handled=false")
+	}
+	if champ.deliverCount() != 0 {
+		t.Fatalf("champion Deliver calls = %d, want 0", champ.deliverCount())
+	}
+	assertNoLiveABRecord(t, store, challengerID)
+}
+
+// TestMaybeRunLiveABBelowFloorIsNoop: a managed agent below bandit_min_samples is
+// NEVER auto-A/B'd even at rate 1.0 — the low-traffic guarantee.
+func TestMaybeRunLiveABBelowFloorIsNoop(t *testing.T) {
+	_, store, request, agent, job, challengerID := liveABFixture(t, 5) // 5 pulls
+	withLiveABPolicy(t, 1.0, 30)                                       // floor 30
+	withLiveABSampler(t, 0.0)
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+
+	handled, err := maybeRunLiveAB(context.Background(), store, request, agent, job, champ, true)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB: %v", err)
+	}
+	if handled {
+		t.Fatal("below the floor must return handled=false")
+	}
+	if champ.deliverCount() != 0 {
+		t.Fatalf("champion Deliver calls = %d, want 0", champ.deliverCount())
+	}
+	assertNoLiveABRecord(t, store, challengerID)
+}
+
+// TestMaybeRunLiveABSamplingMissIsNoop: above the floor and managed, a sampling
+// MISS (draw >= rate) returns handled=false and runs nothing.
+func TestMaybeRunLiveABSamplingMissIsNoop(t *testing.T) {
+	_, store, request, agent, job, challengerID := liveABFixture(t, 100)
+	withLiveABPolicy(t, 0.25, 1)
+	withLiveABSampler(t, 1.0) // miss
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+
+	handled, err := maybeRunLiveAB(context.Background(), store, request, agent, job, champ, true)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB: %v", err)
+	}
+	if handled {
+		t.Fatal("a sampling miss must return handled=false")
+	}
+	if champ.deliverCount() != 0 {
+		t.Fatalf("champion Deliver calls = %d, want 0", champ.deliverCount())
+	}
+	assertNoLiveABRecord(t, store, challengerID)
+}
+
+// TestMaybeRunLiveABInterceptsAndRecords: sampled + above the floor + managed runs
+// the champion via Mailbox.Run AND a serialized challenger Deliver, then records
+// exactly one RankedFeedbackEvent (source=skillopt-ab) and updates BOTH bandit
+// arms — the same path as a manual `skillopt ab` pick.
+func TestMaybeRunLiveABInterceptsAndRecords(t *testing.T) {
+	_, store, request, agent, job, challengerID := liveABFixture(t, 50)
+	withLiveABPolicy(t, 1.0, 30)
+	withLiveABSampler(t, 0.0) // hit
+	var calls []string
+	withLiveABChallengerDeliver(t, &calls, "Challenger answer.", nil)
+	withLiveABPresenter(t, skillOptABChallengerLabel, skillOptABChampionLabel, true)
+	ctx := context.Background()
+
+	champBefore, _, err := store.GetBanditArm(ctx, "planner", championVersionID(t, store))
+	if err != nil {
+		t.Fatalf("GetBanditArm champion before: %v", err)
+	}
+
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+	handled, err := maybeRunLiveAB(ctx, store, request, agent, job, champ, true)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB: %v", err)
+	}
+	if !handled {
+		t.Fatal("sampled+above-floor must return handled=true")
+	}
+	// Champion ran exactly once via Mailbox.Run.
+	if champ.deliverCount() != 1 {
+		t.Fatalf("champion Deliver calls = %d, want exactly 1", champ.deliverCount())
+	}
+	// Challenger ran exactly once.
+	if len(calls) != 1 || calls[0] != "challenger" {
+		t.Fatalf("challenger calls = %v, want exactly one challenger Deliver", calls)
+	}
+
+	// Exactly one RankedFeedbackEvent, source=skillopt-ab, challenger won.
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("ranked feedback events = %d, want exactly 1", len(events))
+	}
+	if events[0].Source != skillOptABSource {
+		t.Fatalf("event source = %q, want %q", events[0].Source, skillOptABSource)
+	}
+	if events[0].Winner != skillOptABChallengerLabel {
+		t.Fatalf("winner = %q, want challenger", events[0].Winner)
+	}
+
+	// Both arms updated: champion lost (+1 pull, +1 beta), challenger won.
+	champAfter, _, err := store.GetBanditArm(ctx, "planner", championVersionID(t, store))
+	if err != nil {
+		t.Fatalf("GetBanditArm champion after: %v", err)
+	}
+	if champAfter.Pulls != champBefore.Pulls+1 {
+		t.Fatalf("champion pulls = %d, want %d (one loss recorded)", champAfter.Pulls, champBefore.Pulls+1)
+	}
+	challengerArm, ok, err := store.GetBanditArm(ctx, "planner", challengerID)
+	if err != nil || !ok {
+		t.Fatalf("GetBanditArm challenger: ok=%v err=%v", ok, err)
+	}
+	if challengerArm.Pulls != 1 {
+		t.Fatalf("challenger pulls = %d, want 1 (one win recorded)", challengerArm.Pulls)
+	}
+}
+
+// TestMaybeRunLiveABSerializesChampionBeforeChallenger proves the two Deliver
+// calls run strictly in series (champion first, challenger second) — they share
+// the single runtime-session lock the caller already holds, so the interceptor
+// never acquires a second lock and the order is deterministic. The interceptor
+// itself must never reference acquireRuntimeSessionLock.
+func TestMaybeRunLiveABSerializesChampionBeforeChallenger(t *testing.T) {
+	_, store, request, agent, job, _ := liveABFixture(t, 50)
+	withLiveABPolicy(t, 1.0, 30)
+	withLiveABSampler(t, 0.0)
+	var order []string
+	// Challenger seam appends "challenger".
+	withLiveABChallengerDeliver(t, &order, "Challenger answer.", nil)
+	withLiveABPresenter(t, skillOptABChampionLabel, skillOptABChallengerLabel, true)
+
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+	champ.onDeliver = func() { order = append(order, "champion") }
+
+	handled, err := maybeRunLiveAB(context.Background(), store, request, agent, job, champ, true)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected handled=true")
+	}
+	if len(order) != 2 || order[0] != "champion" || order[1] != "challenger" {
+		t.Fatalf("Deliver order = %v, want [champion challenger] (serialized, champion first)", order)
+	}
+}
+
+// TestMaybeRunLiveABNoSecondLockAcquisition is the lock-reuse guard: the
+// interceptor source must not call acquireRuntimeSessionLock — it runs strictly
+// under the lock dispatchLocalAgentJob already holds, so a second acquisition
+// would self-deadlock with `session is busy`.
+func TestMaybeRunLiveABNoSecondLockAcquisition(t *testing.T) {
+	src, err := os.ReadFile("agent_dispatch_live_ab.go")
+	if err != nil {
+		t.Fatalf("read interceptor source: %v", err)
+	}
+	if strings.Contains(string(src), "acquireRuntimeSessionLock") {
+		t.Fatal("the live-AB interceptor must not acquire a second runtime-session lock")
+	}
+}
+
+// TestMaybeRunLiveABChallengerErrorFailSafe: when the challenger Deliver errors,
+// the champion answer still ran (handled=true, nil error), NO RankedFeedbackEvent
+// is written, NO bandit arm is updated, and a live_ab_skipped job event is logged.
+func TestMaybeRunLiveABChallengerErrorFailSafe(t *testing.T) {
+	_, store, request, agent, job, challengerID := liveABFixture(t, 50)
+	withLiveABPolicy(t, 1.0, 30)
+	withLiveABSampler(t, 0.0)
+	var calls []string
+	withLiveABChallengerDeliver(t, &calls, "", errors.New("challenger runtime exploded"))
+	withLiveABPresenter(t, skillOptABChallengerLabel, skillOptABChampionLabel, true)
+	ctx := context.Background()
+
+	champBefore, _, err := store.GetBanditArm(ctx, "planner", championVersionID(t, store))
+	if err != nil {
+		t.Fatalf("GetBanditArm before: %v", err)
+	}
+
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+	handled, err := maybeRunLiveAB(ctx, store, request, agent, job, champ, true)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB must be fail-safe (nil error), got %v", err)
+	}
+	if !handled {
+		t.Fatal("an intercepted ask with a challenger error is still handled=true (champion answered)")
+	}
+	// The champion answer was delivered to the user.
+	if champ.deliverCount() != 1 {
+		t.Fatalf("champion Deliver calls = %d, want 1 (the user always gets the champion answer)", champ.deliverCount())
+	}
+	// No A/B record, no bandit update.
+	assertNoLiveABRecord(t, store, challengerID)
+	champAfter, _, err := store.GetBanditArm(ctx, "planner", championVersionID(t, store))
+	if err != nil {
+		t.Fatalf("GetBanditArm after: %v", err)
+	}
+	if champAfter.Pulls != champBefore.Pulls {
+		t.Fatalf("champion pulls = %d, want unchanged %d (no update on fail-safe)", champAfter.Pulls, champBefore.Pulls)
+	}
+	// A live_ab_skipped job event was recorded.
+	assertLiveABSkippedEvent(t, store, job.ID)
+}
+
+// TestMaybeRunLiveABNoPickFailSafe: when the presenter captures no pick (non-
+// interactive), the champion answer still stands, no record is written, and a
+// live_ab_skipped event is logged.
+func TestMaybeRunLiveABNoPickFailSafe(t *testing.T) {
+	_, store, request, agent, job, challengerID := liveABFixture(t, 50)
+	withLiveABPolicy(t, 1.0, 30)
+	withLiveABSampler(t, 0.0)
+	var calls []string
+	withLiveABChallengerDeliver(t, &calls, "Challenger answer.", nil)
+	withLiveABPresenter(t, "", "", false) // no pick captured
+	ctx := context.Background()
+
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+	handled, err := maybeRunLiveAB(ctx, store, request, agent, job, champ, true)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB: %v", err)
+	}
+	if !handled {
+		t.Fatal("handled must be true (champion ran)")
+	}
+	if champ.deliverCount() != 1 {
+		t.Fatalf("champion Deliver calls = %d, want 1", champ.deliverCount())
+	}
+	assertNoLiveABRecord(t, store, challengerID)
+	assertLiveABSkippedEvent(t, store, job.ID)
+}
+
+// championVersionID reads the planner template's current promoted version id.
+func championVersionID(t *testing.T, store *db.Store) string {
+	t.Helper()
+	tmpl, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate: %v", err)
+	}
+	return tmpl.VersionID
+}
+
+func assertNoLiveABRecord(t *testing.T, store *db.Store, challengerID string) {
+	t.Helper()
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("ranked feedback events = %d, want 0 (no A/B record)", len(events))
+	}
+}
+
+func assertLiveABSkippedEvent(t *testing.T, store *db.Store, jobID string) {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	for _, ev := range events {
+		if ev.Kind == liveABEventKind {
+			return
+		}
+	}
+	t.Fatalf("expected a %q job event, got %d events", liveABEventKind, len(events))
+}
+
+// TestDefaultLiveABPresenterMapsPickThroughShuffle proves the default presenter
+// maps a pick back to the correct role under both shuffle orientations, so a
+// captured preference is never silently inverted.
+func TestDefaultLiveABPresenterMapsPickThroughShuffle(t *testing.T) {
+	prevShuffle := liveABShuffle
+	prevLine := readSkillOptABLine
+	t.Cleanup(func() {
+		liveABShuffle = prevShuffle
+		readSkillOptABLine = prevLine
+	})
+
+	// No swap: Option A = champion. Pick "a" -> champion wins.
+	liveABShuffle = func() bool { return false }
+	readSkillOptABLine = func() (string, bool) { return "a", true }
+	winner, loser, ok := defaultLiveABPresenter("q", "champ", "chal")
+	if !ok || winner != skillOptABChampionLabel || loser != skillOptABChallengerLabel {
+		t.Fatalf("no-swap pick a: winner=%q loser=%q ok=%v, want champion wins", winner, loser, ok)
+	}
+
+	// Swap: Option A = challenger. Pick "a" -> challenger wins.
+	liveABShuffle = func() bool { return true }
+	readSkillOptABLine = func() (string, bool) { return "a", true }
+	winner, loser, ok = defaultLiveABPresenter("q", "champ", "chal")
+	if !ok || winner != skillOptABChallengerLabel || loser != skillOptABChampionLabel {
+		t.Fatalf("swap pick a: winner=%q loser=%q ok=%v, want challenger wins", winner, loser, ok)
+	}
+
+	// No pick line -> ok=false (fail-safe skip).
+	readSkillOptABLine = func() (string, bool) { return "", false }
+	if _, _, ok := defaultLiveABPresenter("q", "champ", "chal"); ok {
+		t.Fatal("missing pick line must return ok=false")
+	}
+}

--- a/internal/cli/agent_dispatch_live_ab_test.go
+++ b/internal/cli/agent_dispatch_live_ab_test.go
@@ -134,6 +134,16 @@ func withLiveABSampler(t *testing.T, value float64) {
 	t.Cleanup(func() { liveABSampler = prev })
 }
 
+// withLiveABInteractive pins the interactive-TTY gate. The test binary's stdio is
+// not a TTY, so the interactive interception path (#482) must be forced on for the
+// "intercepts" cases and can be forced off to assert the non-interactive no-op.
+func withLiveABInteractive(t *testing.T, interactive bool) {
+	t.Helper()
+	prev := liveABInteractive
+	liveABInteractive = func() bool { return interactive }
+	t.Cleanup(func() { liveABInteractive = prev })
+}
+
 // withLiveABChallengerDeliver pins the challenger Deliver seam (shared with the
 // CLI A/B) and records its calls. It records, in order, every champion+challenger
 // invocation so the test can prove serialization.
@@ -215,6 +225,7 @@ func TestMaybeRunLiveABBelowFloorIsNoop(t *testing.T) {
 	_, store, request, agent, job, challengerID := liveABFixture(t, 5) // 5 pulls
 	withLiveABPolicy(t, 1.0, 30)                                       // floor 30
 	withLiveABSampler(t, 0.0)
+	withLiveABInteractive(t, true) // isolate: prove the FLOOR gate, not the tty gate
 	champ := &liveABChampionAdapter{summary: "Champion answer."}
 
 	handled, err := maybeRunLiveAB(context.Background(), store, request, agent, job, champ, true)
@@ -235,7 +246,8 @@ func TestMaybeRunLiveABBelowFloorIsNoop(t *testing.T) {
 func TestMaybeRunLiveABSamplingMissIsNoop(t *testing.T) {
 	_, store, request, agent, job, challengerID := liveABFixture(t, 100)
 	withLiveABPolicy(t, 0.25, 1)
-	withLiveABSampler(t, 1.0) // miss
+	withLiveABSampler(t, 1.0)      // miss
+	withLiveABInteractive(t, true) // isolate: prove the SAMPLING gate, not the tty gate
 	champ := &liveABChampionAdapter{summary: "Champion answer."}
 
 	handled, err := maybeRunLiveAB(context.Background(), store, request, agent, job, champ, true)
@@ -259,6 +271,7 @@ func TestMaybeRunLiveABInterceptsAndRecords(t *testing.T) {
 	_, store, request, agent, job, challengerID := liveABFixture(t, 50)
 	withLiveABPolicy(t, 1.0, 30)
 	withLiveABSampler(t, 0.0) // hit
+	withLiveABInteractive(t, true)
 	var calls []string
 	withLiveABChallengerDeliver(t, &calls, "Challenger answer.", nil)
 	withLiveABPresenter(t, skillOptABChallengerLabel, skillOptABChampionLabel, true)
@@ -328,6 +341,7 @@ func TestMaybeRunLiveABSerializesChampionBeforeChallenger(t *testing.T) {
 	_, store, request, agent, job, _ := liveABFixture(t, 50)
 	withLiveABPolicy(t, 1.0, 30)
 	withLiveABSampler(t, 0.0)
+	withLiveABInteractive(t, true)
 	var order []string
 	// Challenger seam appends "challenger".
 	withLiveABChallengerDeliver(t, &order, "Challenger answer.", nil)
@@ -369,6 +383,7 @@ func TestMaybeRunLiveABChallengerErrorFailSafe(t *testing.T) {
 	_, store, request, agent, job, challengerID := liveABFixture(t, 50)
 	withLiveABPolicy(t, 1.0, 30)
 	withLiveABSampler(t, 0.0)
+	withLiveABInteractive(t, true)
 	var calls []string
 	withLiveABChallengerDeliver(t, &calls, "", errors.New("challenger runtime exploded"))
 	withLiveABPresenter(t, skillOptABChallengerLabel, skillOptABChampionLabel, true)
@@ -411,6 +426,7 @@ func TestMaybeRunLiveABNoPickFailSafe(t *testing.T) {
 	_, store, request, agent, job, challengerID := liveABFixture(t, 50)
 	withLiveABPolicy(t, 1.0, 30)
 	withLiveABSampler(t, 0.0)
+	withLiveABInteractive(t, true)
 	var calls []string
 	withLiveABChallengerDeliver(t, &calls, "Challenger answer.", nil)
 	withLiveABPresenter(t, "", "", false) // no pick captured
@@ -499,4 +515,186 @@ func TestDefaultLiveABPresenterMapsPickThroughShuffle(t *testing.T) {
 	if _, _, ok := defaultLiveABPresenter("q", "champ", "chal"); ok {
 		t.Fatal("missing pick line must return ok=false")
 	}
+}
+
+// TestMaybeRunLiveABChallengerUsesForkedSession is the session-isolation guard
+// (#482, goal Risk #4): the challenger Deliver must run on a FORKED/throwaway
+// session, never the agent's live RuntimeRef. The fixture pins the agent to the
+// live ref "last"; this asserts the runtime.Agent handed to the challenger deliver
+// seam carries an EMPTY ref, so realSkillOptABDeliver mints a fresh session via
+// adapter.Start instead of resuming (and poisoning) the user's real conversation.
+func TestMaybeRunLiveABChallengerUsesForkedSession(t *testing.T) {
+	_, store, request, agent, job, _ := liveABFixture(t, 50)
+	if agent.RuntimeRef != "last" {
+		t.Fatalf("fixture precondition: agent.RuntimeRef = %q, want the live ref %q", agent.RuntimeRef, "last")
+	}
+	withLiveABPolicy(t, 1.0, 30)
+	withLiveABSampler(t, 0.0)
+	withLiveABInteractive(t, true)
+
+	// Capture the runtime.Agent the challenger deliver seam actually receives.
+	prevDeliver := skillOptABDeliver
+	var challengerRef string
+	var sawChallenger bool
+	skillOptABDeliver = func(_ context.Context, a runtime.Agent, _ string) (string, error) {
+		sawChallenger = true
+		challengerRef = a.RuntimeRef
+		return "Challenger answer.", nil
+	}
+	t.Cleanup(func() { skillOptABDeliver = prevDeliver })
+	withLiveABPresenter(t, skillOptABChampionLabel, skillOptABChallengerLabel, true)
+
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+	handled, err := maybeRunLiveAB(context.Background(), store, request, agent, job, champ, true)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected handled=true (sampled + above floor + interactive)")
+	}
+	if !sawChallenger {
+		t.Fatal("challenger deliver was never invoked")
+	}
+	if challengerRef != "" {
+		t.Fatalf("challenger RuntimeRef = %q, want \"\" (forked/throwaway session, NEVER the agent's live ref %q)", challengerRef, agent.RuntimeRef)
+	}
+}
+
+// TestMaybeRunLiveABJSONOutputIsNoop is the byte-clean-JSON guard (#482): an
+// intercepted `agent ask --json` (JSONOutput=true) is a pure no-op — handled=false
+// with NO champion-via-intercept Deliver, NO challenger Deliver, and NO A/B record
+// — so runAgentAsk's writeJSON emits ONLY the JSON object, never prefixed by the
+// "[live A/B] ..." presentation block that would break a scripted consumer.
+func TestMaybeRunLiveABJSONOutputIsNoop(t *testing.T) {
+	_, store, request, agent, job, challengerID := liveABFixture(t, 100)
+	request.JSONOutput = true // `agent ask --json`
+	withLiveABPolicy(t, 1.0, 1)
+	withLiveABSampler(t, 0.0)       // would hit
+	withLiveABInteractive(t, true)  // even on a TTY, --json must stay byte-clean
+	var challengerCalls []string
+	withLiveABChallengerDeliver(t, &challengerCalls, "Challenger answer.", nil)
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+
+	handled, err := maybeRunLiveAB(context.Background(), store, request, agent, job, champ, true)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB: %v", err)
+	}
+	if handled {
+		t.Fatal("--json ask must return handled=false (no interception, byte-clean JSON)")
+	}
+	if champ.deliverCount() != 0 {
+		t.Fatalf("champion Deliver calls = %d, want 0 (caller runs the single Mailbox.Run)", champ.deliverCount())
+	}
+	if len(challengerCalls) != 0 {
+		t.Fatalf("challenger Deliver calls = %d, want 0 on --json", len(challengerCalls))
+	}
+	assertNoLiveABRecord(t, store, challengerID)
+}
+
+// TestMaybeRunLiveABNonInteractiveIsNoop is the no-blocking-pick guard (#482): a
+// non-interactive (piped / scripted / redirected) ask is a pure no-op — it never
+// runs the second Deliver and never reaches the blocking fmt.Scanln pick, so a
+// fully-unattended ask returns the champion answer immediately and is never hung
+// waiting for an A/B pick it cannot supply.
+func TestMaybeRunLiveABNonInteractiveIsNoop(t *testing.T) {
+	_, store, request, agent, job, challengerID := liveABFixture(t, 100)
+	withLiveABPolicy(t, 1.0, 1)
+	withLiveABSampler(t, 0.0)        // would hit
+	withLiveABInteractive(t, false)  // piped / non-tty session
+	var challengerCalls []string
+	withLiveABChallengerDeliver(t, &challengerCalls, "Challenger answer.", nil)
+	champ := &liveABChampionAdapter{summary: "Champion answer."}
+
+	handled, err := maybeRunLiveAB(context.Background(), store, request, agent, job, champ, true)
+	if err != nil {
+		t.Fatalf("maybeRunLiveAB: %v", err)
+	}
+	if handled {
+		t.Fatal("a non-interactive ask must return handled=false (no blocking pick)")
+	}
+	if champ.deliverCount() != 0 {
+		t.Fatalf("champion Deliver calls = %d, want 0", champ.deliverCount())
+	}
+	if len(challengerCalls) != 0 {
+		t.Fatalf("challenger Deliver calls = %d, want 0 when non-interactive", len(challengerCalls))
+	}
+	assertNoLiveABRecord(t, store, challengerID)
+}
+
+// TestRealSkillOptABDeliverForkedSessionUsesStart proves the forked-session
+// contract at the deliver layer: an EMPTY agent.RuntimeRef routes through
+// adapter.Start (a fresh throwaway conversation), NOT adapter.Deliver (which would
+// resume the agent's live session). This is the mechanism that protects the user's
+// live session for the live-AB challenger.
+func TestRealSkillOptABDeliverForkedSessionUsesStart(t *testing.T) {
+	prevFactory := newRuntimeFactory
+	prevAdapterFor := runtimeStartAdapterFor
+	t.Cleanup(func() {
+		newRuntimeFactory = prevFactory
+		runtimeStartAdapterFor = prevAdapterFor
+	})
+	fake := &forkSessionFakeAdapter{startAnswer: "fresh-session answer"}
+	runtimeStartAdapterFor = func(runtime.Factory, string, string) (runtime.Adapter, error) {
+		return fake, nil
+	}
+
+	answer, err := realSkillOptABDeliver(context.Background(), runtime.Agent{
+		Name:       "planner-bot",
+		Runtime:    runtime.CodexRuntime,
+		RuntimeRef: "", // forked/throwaway session signal
+	}, "challenger prompt")
+	if err != nil {
+		t.Fatalf("realSkillOptABDeliver: %v", err)
+	}
+	if fake.startCalls != 1 {
+		t.Fatalf("adapter.Start calls = %d, want exactly 1 (forked session)", fake.startCalls)
+	}
+	if fake.deliverCalls != 0 {
+		t.Fatalf("adapter.Deliver calls = %d, want 0 (an empty ref must NEVER resume the live session)", fake.deliverCalls)
+	}
+	if answer != "fresh-session answer" {
+		t.Fatalf("answer = %q, want the Start raw output", answer)
+	}
+
+	// Control: a NON-empty ref keeps the legacy resume (Deliver) path.
+	fake.startCalls, fake.deliverCalls = 0, 0
+	fake.deliverAnswer = "resumed answer"
+	answer, err = realSkillOptABDeliver(context.Background(), runtime.Agent{
+		Name:       "planner-bot",
+		Runtime:    runtime.CodexRuntime,
+		RuntimeRef: "last",
+	}, "champion prompt")
+	if err != nil {
+		t.Fatalf("realSkillOptABDeliver (resume): %v", err)
+	}
+	if fake.deliverCalls != 1 || fake.startCalls != 0 {
+		t.Fatalf("non-empty ref: Start=%d Deliver=%d, want Start=0 Deliver=1 (resume preserved)", fake.startCalls, fake.deliverCalls)
+	}
+	if answer != "resumed answer" {
+		t.Fatalf("answer = %q, want the Deliver summary", answer)
+	}
+}
+
+// forkSessionFakeAdapter records whether Start (fresh session) or Deliver (resume)
+// was used, so the forked-session contract can be asserted without a live runtime.
+type forkSessionFakeAdapter struct {
+	startCalls    int
+	deliverCalls  int
+	startAnswer   string
+	deliverAnswer string
+}
+
+func (a *forkSessionFakeAdapter) Name() string { return runtime.CodexRuntime }
+func (a *forkSessionFakeAdapter) Start(_ context.Context, _ runtime.StartRequest) (runtime.StartResult, error) {
+	a.startCalls++
+	return runtime.StartResult{RuntimeRef: "fresh-throwaway", Raw: a.startAnswer}, nil
+}
+func (a *forkSessionFakeAdapter) Validate(_ context.Context, _ runtime.Agent) error { return nil }
+func (a *forkSessionFakeAdapter) Deliver(_ context.Context, _ runtime.Agent, _ runtime.Job) (runtime.Result, error) {
+	a.deliverCalls++
+	return runtime.Result{Summary: a.deliverAnswer, Raw: a.deliverAnswer}, nil
+}
+func (a *forkSessionFakeAdapter) Health(_ context.Context, _ runtime.Agent) error { return nil }
+func (a *forkSessionFakeAdapter) Capabilities(_ context.Context) ([]string, error) {
+	return []string{"ask"}, nil
 }

--- a/internal/cli/skillopt_ab.go
+++ b/internal/cli/skillopt_ab.go
@@ -62,10 +62,29 @@ var skillOptABDeliver skillOptABDeliverFunc = realSkillOptABDeliver
 // and synchronous; runSkillOptAB invokes it twice in series so the second call
 // only starts after the first returns — never concurrently — which keeps any
 // per-runtime session usage cleanly serialized.
+//
+// Session isolation (#482): an EMPTY agent.RuntimeRef is the "forked/throwaway
+// session" signal. The live-AB challenger sets it so its Deliver never resumes
+// the agent's live session (codex always `exec resume`s in Deliver; claude/kimi
+// resume a pinned ref), which would otherwise inject the challenger turn into the
+// user's real conversation and poison the next genuine ask. On an empty ref we
+// mint a fresh throwaway session via adapter.Start instead — a brand-new
+// conversation the challenger answers on, leaving the agent's live session (and
+// its resume_hint) untouched. A non-empty ref (the manual `skillopt ab` path)
+// keeps its existing resume behavior unchanged.
 func realSkillOptABDeliver(ctx context.Context, agent runtime.Agent, prompt string) (string, error) {
 	adapter, err := runtimeStartAdapterFor(newRuntimeFactory(), agent.Runtime, agent.RepoScope)
 	if err != nil {
 		return "", err
+	}
+	if strings.TrimSpace(agent.RuntimeRef) == "" {
+		// Forked/throwaway session: Start opens a fresh conversation and answers the
+		// prompt in one shot, never touching the agent's live session.
+		started, startErr := adapter.Start(ctx, runtime.StartRequest{Agent: agent, Prompt: prompt})
+		if startErr != nil {
+			return "", startErr
+		}
+		return strings.TrimSpace(started.Raw), nil
 	}
 	result, err := adapter.Deliver(ctx, agent, runtime.Job{AgentName: agent.Name, Action: "ask", Prompt: prompt, Model: agent.Model})
 	if err != nil {

--- a/internal/config/agent_types.go
+++ b/internal/config/agent_types.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -201,6 +202,22 @@ func parseConfigString(value string) (string, error) {
 	parsed, err := strconv.Unquote(strings.TrimSpace(value))
 	if err != nil {
 		return "", err
+	}
+	return parsed, nil
+}
+
+// parseConfigFloat parses a bare TOML float scalar (e.g. 0.25) into a float64.
+// It rejects NaN and the infinities so a malformed [skillopt] knob can never
+// produce a sampling rate that bypasses the [0,1] bound check downstream. Unlike
+// parseConfigString it does NOT unquote: a sampling rate is a number, not a
+// quoted string. Callers (the [skillopt] loader) apply the range validation.
+func parseConfigFloat(value string) (float64, error) {
+	parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil {
+		return 0, err
+	}
+	if math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return 0, fmt.Errorf("not a finite number: %q", strings.TrimSpace(value))
 	}
 	return parsed, nil
 }

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -68,20 +68,25 @@ func SetConfigScalar(paths Paths, keyPath []string, value ConfigScalar) error {
 // ConfigScalar is a typed scalar value to write, so the caller need not build
 // TOML literals (and get quoting wrong).
 type ConfigScalar struct {
-	str  *string
-	num  *int
-	list []string
+	str   *string
+	num   *int
+	float *float64
+	list  []string
 }
 
-// StringScalar / IntScalar / StringListScalar construct a ConfigScalar.
+// StringScalar / IntScalar / FloatScalar / StringListScalar construct a
+// ConfigScalar.
 func StringScalar(v string) ConfigScalar       { return ConfigScalar{str: &v} }
 func IntScalar(v int) ConfigScalar             { return ConfigScalar{num: &v} }
+func FloatScalar(v float64) ConfigScalar       { return ConfigScalar{float: &v} }
 func StringListScalar(v []string) ConfigScalar { return ConfigScalar{list: v} }
 
 func (c ConfigScalar) toml() string {
 	switch {
 	case c.num != nil:
 		return strconv.Itoa(*c.num)
+	case c.float != nil:
+		return strconv.FormatFloat(*c.float, 'g', -1, 64)
 	case c.list != nil:
 		quoted := make([]string, len(c.list))
 		for i, item := range c.list {
@@ -104,6 +109,9 @@ func validateConfigFile(paths Paths) error {
 		return err
 	}
 	if _, err := LoadDefaultFeedbackRepo(paths); err != nil {
+		return err
+	}
+	if _, err := LoadSkillOptABPolicy(paths); err != nil {
 		return err
 	}
 	return nil

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -96,10 +96,20 @@ escalation_ttl = ""
 #     entirely (byte-identical to #471). When SET, auto-promote additionally
 #     requires a non-nil confidence >= this floor; a nil/low confidence FAILS SAFE
 #     to notify-only.
-#   bandit_min_samples (#473 Mode B): per-agent low-traffic floor for the DEFERRED
-#     auto A/B loop. Below it the bandit still records preferences and updates its
-#     posterior but never auto-runs/auto-promotes off thin evidence. The manual
-#     'skillopt ab' CLI is always allowed regardless. (default 30)
+#   bandit_min_samples (#473 Mode B): per-agent low-traffic floor. Below it the
+#     bandit still records preferences and updates its posterior but live-traffic
+#     A/B never auto-runs and the confidence is never trusted to auto-promote off
+#     thin evidence. The manual 'skillopt ab' CLI is always allowed regardless.
+#     (default 30)
+#   live_ab_sample_rate (#482 Mode B live A/B): probability in [0,1] that a single
+#     foreground 'agent ask' (on a MANAGED agent whose champion arm is already at
+#     or above bandit_min_samples) is intercepted into a champion-vs-challenger
+#     A/B — running both variants serially, presenting both answers, and recording
+#     the human pick through the SAME bandit + RankedFeedbackEvent path as the
+#     manual 'skillopt ab'. UNSET / 0.0 (the default) NEVER intercepts — the ask
+#     path is byte-identical. It only writes feedback + updates the posterior;
+#     promotion stays MANUAL. Each intercepted ask runs the runtime twice (cost),
+#     which is why it is sampled and floored.
 # [skillopt]
 # auto_trace_enabled = false
 # cross_family_review_enabled = false
@@ -111,6 +121,7 @@ escalation_ttl = ""
 # auto_promote_canary = false
 # auto_promote_min_confidence = 0.95
 # bandit_min_samples = 30
+# live_ab_sample_rate = 0.0
 
 # [admission] is an OPT-IN, off-by-default host-global concurrency budget the
 # daemon applies BEFORE starting each agent session, on top of --workers/pool

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -439,6 +439,14 @@ type SkillOptPolicy struct {
 	// is ALWAYS allowed regardless of this floor; it only governs the deferred
 	// automatic path. The promotion side reuses AutoPromoteMinSamples.
 	BanditMinSamples *int
+
+	// LiveABSampleRate is the live-traffic A/B (#482) sampling probability in
+	// [0,1]: the fraction of foreground `agent ask` calls (on a managed agent
+	// above BanditMinSamples) that are intercepted into a champion-vs-challenger
+	// A/B. nil (unset, the default) and 0.0 both mean NEVER intercept — the
+	// foreground ask path is byte-identical when this is absent. It is the ONLY
+	// new knob #482 adds; it reuses the existing bandit_min_samples as its floor.
+	LiveABSampleRate *float64
 }
 
 // DefaultBanditMinSamples is the documented default low-traffic floor for the
@@ -458,6 +466,7 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 		AutoPromoteCanary:               false,
 		AutoPromoteMinConfidence:        nil,
 		BanditMinSamples:                nil,
+		LiveABSampleRate:                nil,
 	}
 }
 
@@ -559,6 +568,13 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 			return err
 		}
 		policy.BanditMinSamples = &parsed
+		return nil
+	case "live_ab_sample_rate":
+		parsed, err := parseConfigFloat(value)
+		if err != nil {
+			return err
+		}
+		policy.LiveABSampleRate = &parsed
 		return nil
 	default:
 		return nil

--- a/internal/config/skillopt_ab.go
+++ b/internal/config/skillopt_ab.go
@@ -1,0 +1,75 @@
+package config
+
+import "fmt"
+
+// DefaultLiveABBanditMinSamples is the conservative traffic floor live-traffic
+// A/B (#482) falls back to when the [skillopt] section sets live_ab_sample_rate
+// but leaves bandit_min_samples unset: an agent's champion bandit arm must have
+// accrued at least this many pulls before interception fires. It keeps low-
+// traffic / bespoke agents (e.g. the researcher) from being auto-A/B'd until
+// they have a meaningful sample size. It reuses the same documented default as
+// the existing DefaultBanditMinSamples so the two never diverge.
+const DefaultLiveABBanditMinSamples = DefaultBanditMinSamples
+
+// SkillOptABPolicy is the resolved, off-by-default knob set for live-traffic A/B
+// interception (#482), projected from the shared [skillopt] SkillOptPolicy so
+// there is ONE parser for the section and no duplicate bandit_min_samples key.
+// Every existing home (and the DefaultConfig in init.go, which emits NO
+// [skillopt] section) resolves LiveABSampleRate=0.0 → the interceptor is a no-op
+// → the foreground `agent ask` path stays byte-identical.
+type SkillOptABPolicy struct {
+	// LiveABSampleRate is the probability in [0,1] that a single foreground ask
+	// (on a managed agent above the traffic floor) is intercepted into a champion-
+	// vs-challenger A/B. 0.0 (the default, and what an absent/unset knob resolves
+	// to) means NEVER intercept.
+	LiveABSampleRate float64
+	// BanditMinSamples is the traffic floor: the champion arm's bandit pull count
+	// must be >= this before any interception. It reuses [skillopt].bandit_min_
+	// samples (the same #473 tiering signal) so only high-traffic agents auto-A/B.
+	BanditMinSamples int
+}
+
+// DefaultSkillOptABPolicy returns the off-by-default resolved policy: rate 0.0
+// (never intercept) and the conservative min-samples floor. A config file
+// without a [skillopt] section resolves to exactly this.
+func DefaultSkillOptABPolicy() SkillOptABPolicy {
+	return SkillOptABPolicy{
+		LiveABSampleRate: 0.0,
+		BanditMinSamples: DefaultLiveABBanditMinSamples,
+	}
+}
+
+// LoadSkillOptABPolicy resolves the live-traffic A/B knobs from the shared
+// [skillopt] section by REUSING LoadSkillOptPolicy (no second scan of the file,
+// no duplicate parser). When live_ab_sample_rate is absent/unset it resolves
+// LiveABSampleRate=0.0 → the interceptor never fires. bandit_min_samples, when
+// unset, falls back to the conservative default floor. The [0,1] / >=1 bounds
+// are enforced here so `gitmoot config set` (via validateConfigFile) rejects an
+// out-of-range knob.
+func LoadSkillOptABPolicy(paths Paths) (SkillOptABPolicy, error) {
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		return SkillOptABPolicy{}, err
+	}
+	resolved := DefaultSkillOptABPolicy()
+	if policy.LiveABSampleRate != nil {
+		resolved.LiveABSampleRate = *policy.LiveABSampleRate
+	}
+	if policy.BanditMinSamples != nil {
+		resolved.BanditMinSamples = *policy.BanditMinSamples
+	}
+	if err := validateSkillOptABPolicy(resolved); err != nil {
+		return SkillOptABPolicy{}, err
+	}
+	return resolved, nil
+}
+
+func validateSkillOptABPolicy(policy SkillOptABPolicy) error {
+	if policy.LiveABSampleRate < 0 || policy.LiveABSampleRate > 1 {
+		return fmt.Errorf("skillopt.live_ab_sample_rate must be in [0, 1], got %v", policy.LiveABSampleRate)
+	}
+	if policy.BanditMinSamples < 1 {
+		return fmt.Errorf("skillopt.bandit_min_samples must be >= 1, got %d", policy.BanditMinSamples)
+	}
+	return nil
+}

--- a/internal/config/skillopt_ab_test.go
+++ b/internal/config/skillopt_ab_test.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLoadSkillOptABPolicyDefaultsOff: with no [skillopt] section (every existing
+// home + DefaultConfig), the resolved live-A/B policy is OFF — rate 0.0 — so the
+// interceptor is a no-op and the foreground ask path stays byte-identical.
+func TestLoadSkillOptABPolicyDefaultsOff(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	policy, err := LoadSkillOptABPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptABPolicy: %v", err)
+	}
+	if policy.LiveABSampleRate != 0.0 {
+		t.Fatalf("default LiveABSampleRate = %v, want 0.0 (off)", policy.LiveABSampleRate)
+	}
+	if policy.BanditMinSamples != DefaultLiveABBanditMinSamples {
+		t.Fatalf("default BanditMinSamples = %d, want %d", policy.BanditMinSamples, DefaultLiveABBanditMinSamples)
+	}
+}
+
+// TestLoadSkillOptABPolicyDefaultConfigHasNoLiveSkillOptSection guards the byte-
+// identical invariant at its source: DefaultConfig must NOT emit an UNCOMMENTED
+// [skillopt] section (the only one in the stub is a # comment), so a freshly-
+// initialized home resolves rate 0.0.
+func TestLoadSkillOptABPolicyDefaultConfigHasNoLiveSkillOptSection(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	for _, line := range strings.Split(DefaultConfig(paths), "\n") {
+		if strings.TrimSpace(stripConfigComment(line)) == "[skillopt]" {
+			t.Fatal("DefaultConfig must not emit a live [skillopt] section (would change the off-by-default path)")
+		}
+	}
+}
+
+// TestLoadSkillOptABPolicyParsesExplicit: an explicit live_ab_sample_rate +
+// bandit_min_samples are parsed from the shared [skillopt] section.
+func TestLoadSkillOptABPolicyParsesExplicit(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+live_ab_sample_rate = 0.25
+bandit_min_samples = 40
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	policy, err := LoadSkillOptABPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptABPolicy: %v", err)
+	}
+	if policy.LiveABSampleRate != 0.25 {
+		t.Fatalf("LiveABSampleRate = %v, want 0.25", policy.LiveABSampleRate)
+	}
+	if policy.BanditMinSamples != 40 {
+		t.Fatalf("BanditMinSamples = %d, want 40", policy.BanditMinSamples)
+	}
+}
+
+// TestLoadSkillOptABPolicyRateWithoutFloorUsesDefaultFloor: setting only the rate
+// inherits the conservative default floor (so a rate without an explicit floor is
+// never accidentally floor-less).
+func TestLoadSkillOptABPolicyRateWithoutFloorUsesDefaultFloor(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+live_ab_sample_rate = 0.5
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	policy, err := LoadSkillOptABPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptABPolicy: %v", err)
+	}
+	if policy.BanditMinSamples != DefaultLiveABBanditMinSamples {
+		t.Fatalf("BanditMinSamples = %d, want default %d", policy.BanditMinSamples, DefaultLiveABBanditMinSamples)
+	}
+}
+
+func TestLoadSkillOptABPolicyRejectsOutOfRange(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"negative", "live_ab_sample_rate = -0.1"},
+		{"above one", "live_ab_sample_rate = 1.5"},
+		{"nan", "live_ab_sample_rate = nan"},
+		{"inf", "live_ab_sample_rate = inf"},
+		{"zero floor", "live_ab_sample_rate = 0.5\nbandit_min_samples = 0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if err := Initialize(paths); err != nil {
+				t.Fatalf("Initialize: %v", err)
+			}
+			if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+"\n[skillopt]\n"+tc.body+"\n"), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			if _, err := LoadSkillOptABPolicy(paths); err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestSkillOptABRoundTripsThroughSetConfigScalar: writing a valid rate via
+// SetConfigScalar (which re-runs validateConfigFile, where LoadSkillOptABPolicy is
+// now registered) succeeds and parses back; an out-of-range write is rejected and
+// reverted, leaving the prior value intact.
+func TestSkillOptABRoundTripsThroughSetConfigScalar(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	// SetConfigScalar only edits EXISTING keys, so seed the section first.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+live_ab_sample_rate = 0.0
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := SetConfigScalar(paths, []string{"skillopt", "live_ab_sample_rate"}, FloatScalar(0.3)); err != nil {
+		t.Fatalf("SetConfigScalar valid: %v", err)
+	}
+	policy, err := LoadSkillOptABPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptABPolicy: %v", err)
+	}
+	if policy.LiveABSampleRate != 0.3 {
+		t.Fatalf("after set, LiveABSampleRate = %v, want 0.3", policy.LiveABSampleRate)
+	}
+
+	// An out-of-range write must be rejected by validateConfigFile and reverted.
+	if err := SetConfigScalar(paths, []string{"skillopt", "live_ab_sample_rate"}, FloatScalar(2.0)); err == nil {
+		t.Fatal("expected SetConfigScalar to reject out-of-range rate 2.0")
+	}
+	reverted, err := LoadSkillOptABPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptABPolicy after revert: %v", err)
+	}
+	if reverted.LiveABSampleRate != 0.3 {
+		t.Fatalf("after rejected write, LiveABSampleRate = %v, want preserved 0.3", reverted.LiveABSampleRate)
+	}
+}

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -460,9 +460,40 @@ else fail safe to notify-only) — supplying the promotion confidence Mode A cou
 not provide for ask agents. For a genuine ask candidate (no harvester score or
 feedback rows) the bandit pulls stand in for the Mode A sample/score floors, so the
 confidence gate alone can auto-promote it. `bandit_min_samples` (default 30) gates
-only the **deferred** auto loop; the manual A/B is always allowed. Live
-interception, the cross-family LLM-judge auto-pairwise, canary, and the auto A/B
-loop are deferred.
+both the manual-floor read and live interception; the manual A/B is always allowed.
+
+### Live-traffic A/B (off by default, #482)
+
+The same champion-vs-challenger comparison can fire **automatically** on a
+**sampled fraction** of real foreground `gitmoot agent ask` traffic, so templates
+self-improve as you use them — no operator has to remember to run `skillopt ab`:
+
+```toml
+[skillopt]
+live_ab_sample_rate = 0.1   # 10% of qualifying asks are intercepted; 0.0 (default) = never
+bandit_min_samples  = 30    # only agents whose champion arm has >= 30 bandit pulls
+```
+
+`live_ab_sample_rate` is **0.0 by default** (and unset with no `[skillopt]`
+section), which makes the foreground ask path **byte-identical**: no extra
+`Deliver`, no A/B record, no bandit update — the hot path is untouched when off.
+When set `> 0`, a foreground ask on a **managed** agent whose champion bandit arm
+is **at or above `bandit_min_samples`** is intercepted with probability
+`live_ab_sample_rate`: it runs the champion (the canonical answer you receive) and
+then a single pending challenger **serialized under the one runtime-session lock
+already held** (no second lock, no `session is busy`), presents both answers, and
+routes the human pick through the **exact same** `recordSkillOptABPick` path as the
+manual A/B (same `source = skillopt-ab` `RankedFeedbackEvent`, same bandit update).
+
+Low-traffic / bespoke agents (e.g. `researcher`) below `bandit_min_samples` are
+**never** auto-A/B'd. It is **fail-safe**: a challenger error, no pending
+challenger, or no pick captured degrades to the normal single champion answer and
+logs a `live_ab_skipped` job event — the primary ask is never blocked or
+degraded. Each intercepted ask runs the runtime **twice** (the sampled cost), and
+`contract_version` stays `1`. **Promotion stays MANUAL**: live A/B only writes
+feedback + updates the posterior; it never auto-promotes or rolls back a version.
+The cross-family LLM-judge auto-pairwise, canary, and the unattended auto A/B loop
+remain deferred.
 
 ## Execution Model
 

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -311,7 +311,8 @@ auto_promote_require_external_ci = false  # require >= 1 real-external-CI feedba
 auto_promote_require_measured_judge = false  # PARSED but DEFERRED (#344): true => fail safe to no-promote
 auto_promote_canary = false               # PARSED but DEFERRED (canary follow-on): true => fail safe to no-promote
 auto_promote_min_confidence = 0.95        # #473 Mode B: UNSET = ignore; SET = require bandit P(>) >= floor (+ enough samples)
-bandit_min_samples = 30                   # #473 Mode B low-traffic floor for the DEFERRED auto loop (manual `skillopt ab` always allowed)
+bandit_min_samples = 30                   # #473/#482 Mode B low-traffic floor (manual `skillopt ab` always allowed)
+live_ab_sample_rate = 0.0                 # #482 Mode B live A/B: 0.0 (default) = never intercept; fraction of foreground asks to A/B
 ```
 
 The guardrails read the candidate's **harvester auto-trace run**
@@ -401,11 +402,48 @@ confidence carried into `candidate.awaiting_promotion`'s detail and into the
 auto-promote guardrails.
 
 **Tiering.** Below `bandit_min_samples` (default 30) the bandit still records
-preferences and updates the posterior but the **deferred** auto A/B loop never
-runs and the confidence is never trusted to auto-promote (the promotion-side floor
+preferences and updates the posterior but live-traffic interception never fires
+and the confidence is never trusted to auto-promote (the promotion-side floor
 reuses `auto_promote_min_samples`). The **manual** `skillopt ab` CLI is always
-allowed. Live-traffic interception, the cross-family LLM-judge auto-pairwise,
-canary, and the auto A/B scheduling loop are **deferred** to follow-ons.
+allowed regardless of the floor.
+
+### Live-traffic A/B interception (off by default, #482)
+
+The same champion-vs-challenger pick can fire **automatically** on a **sampled
+fraction** of real foreground `gitmoot agent ask` traffic, so a template
+self-improves the more you use it — no operator has to remember to run
+`skillopt ab`. It is purely an **additional caller** of the #473 surface above: it
+adds **no new bandit math and no new contract field** (`ContractVersion` stays
+`1`), only a sampling decision, the `bandit_min_samples` traffic floor, and a
+serialized double-`Deliver` at the ask seam.
+
+- **Off by default.** `live_ab_sample_rate` is `0.0` (and unset with no
+  `[skillopt]` section), which makes the foreground ask path **byte-identical** —
+  no extra `Deliver`, no A/B row, no bandit update; the hot path is untouched when
+  off.
+- When `live_ab_sample_rate > 0`, a foreground ask on a **managed** agent whose
+  **champion bandit arm** has accrued `>= bandit_min_samples` pulls is intercepted
+  with probability `live_ab_sample_rate`. Low-traffic / bespoke agents (e.g. the
+  `researcher`) below the floor are **never** auto-A/B'd.
+- An intercepted ask runs the **champion** (the canonical answer you receive, via
+  the normal job path) and then a single pending **challenger** strictly
+  **serialized under the one runtime-session lock already held** by the foreground
+  ask — never a second lock, so it can never self-deadlock on `session is busy`. It
+  presents both answers and routes the human pick through the **exact same**
+  `recordSkillOptABPick` path as the manual A/B (same `source = skillopt-ab`
+  `RankedFeedbackEvent`, same Beta-Bernoulli bandit update).
+- It is **fail-safe**: a challenger `Deliver` error, no single pending challenger,
+  or no pick captured degrades to the normal single champion answer and logs a
+  `live_ab_skipped` job event — the primary ask is never blocked or degraded. Each
+  intercepted ask runs the runtime **twice** (the sampled cost, bounded by the rate
+  + floor).
+- **Promotion stays MANUAL.** Live A/B only writes feedback + updates the
+  posterior; it never auto-promotes or rolls back a version. The bandit confidence
+  still flows into `auto_promote_min_confidence` as a **suggestion**, gated by an
+  explicit human `promote`.
+
+The cross-family LLM-judge auto-pairwise, canary, and the unattended auto A/B
+scheduling loop remain **deferred** to follow-ons.
 
 ## Ranked Exploration Workflow
 


### PR DESCRIPTION
## Summary

Adds an **off-by-default** interceptor that runs the #473 champion-vs-challenger A/B **automatically** on a **sampled fraction** of real foreground `gitmoot agent ask` traffic, so ask-agent templates self-improve the more you use them — no operator has to remember to run `skillopt ab` (RFC #463 / issue #482).

It is purely an **additional caller** of the #473 Mode B surface: **no new bandit math, no new contract field — `ContractVersion` stays `1`**. It adds only (a) a sampling decision, (b) the `bandit_min_samples` traffic floor, and (c) a serialized double-`Deliver` at the ask seam.

## Behavior

On a sampled foreground ask (managed agent whose champion bandit arm is at/above `bandit_min_samples`), the interceptor runs the **champion** via the normal `Mailbox.Run` (the canonical answer the user receives) and then a single pending **challenger** strictly serialized under the **one runtime-session lock already held** by the foreground ask, presents both answers, and routes the human pick through the **exact same** `recordSkillOptABPick` + Beta-Bernoulli bandit update as a manual `skillopt ab` (same `source = skillopt-ab` `RankedFeedbackEvent`, same posterior update).

## Invariants (all enforced by tests)

- **OFF BY DEFAULT.** `live_ab_sample_rate` defaults to `0.0` (no `[skillopt]` section in `DefaultConfig`), making the foreground ask path **byte-identical** — no extra `Deliver`, no A/B row, no bandit update; the hot path is untouched when off.
- **ADDITIVE.** `ContractVersion` stays `1`; no new exported `gitmoot_result` field. New `[skillopt].live_ab_sample_rate` knob resolves via `LoadSkillOptABPolicy`, which **reuses** the existing `LoadSkillOptPolicy` parser and `bandit_min_samples` key (no duplicate section scan), registered in `validateConfigFile`.
- **Lock reuse.** The interceptor never acquires a second runtime-session lock (guards against the `session is busy` self-deadlock); the two `Deliver` calls run strictly in series — asserted by tests.
- **Tiering.** Low-traffic / bespoke agents (e.g. `researcher`) below `bandit_min_samples` are **never** auto-A/B'd, regardless of rate.
- **FAIL-SAFE.** A challenger `Deliver` error, no single pending challenger, or no pick captured degrades to the normal single champion answer and logs a `live_ab_skipped` job event — the primary ask is never blocked or degraded.
- **MANUAL PROMOTION preserved.** Live A/B only writes feedback + updates the posterior; it never auto-promotes or rolls back a version. The confidence still flows into `auto_promote_min_confidence` as a suggestion, gated by an explicit human `promote`.

## Tests

- `internal/config/skillopt_ab_test.go`: absent section ⇒ rate 0; explicit parse; rate-without-floor inherits the default floor; rejects `-0.1` / `1.5` / `NaN` / `Inf` / `0` floor; round-trips through `SetConfigScalar` + `validateConfigFile` (and reverts on out-of-range).
- `internal/cli/agent_dispatch_live_ab_test.go`: rate 0 / unmanaged / below-floor / sampling-miss ⇒ `handled=false`, **zero** Deliver; sampled+above-floor ⇒ one `Mailbox.Run` + one serialized challenger Deliver + one `recordSkillOptABPick` + both arms updated; champion-before-challenger ordering; no-second-lock guard; challenger-error and no-pick fail-safe (champion returned, no record, `live_ab_skipped` event); presenter pick-mapping under both shuffle orientations.

## Gate

`go build ./...`, `go vet ./...`, `go test ./...` all green; `-race` on `internal/workflow`, `internal/cli`, `internal/skillopt`, `internal/daemon` all green.

## Docs

Updated in **both** trees (`skills/gitmoot/references/WORKFLOWS.md`, `website/docs/reference/skillopt-exchange-contract.md`, `docs/skillopt-exchange-contract.md`) plus the `[skillopt]` config stub in `internal/config/init.go`.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)