### PR TITLE
job kill: release stranded locks + terminalize queued children

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2415,6 +2415,13 @@ func queuedJobMatchesSession(job db.Job, rootFilter string) bool {
 // Delegation child legs set DelegationID (delegationRequest), so a non-empty
 // DelegationID is what marks a job as skippable work. A payload-parse miss or
 // store error fails open (returns false) so a hiccup never silently strands a job.
+//
+// NOTE: the same child-leg classification invariant (RootJobID != "" &&
+// RootJobID != job.ID && DelegationID != "") is re-implemented inline in
+// workflow.KillDelegationTree (internal/workflow/job_kill.go, #480) to eagerly
+// cancel queued child legs at kill time. The cli->workflow import direction
+// prevents sharing one helper, so if the classification rules here change, update
+// the workflow site too — the two MUST stay in lockstep.
 func queuedChildOfKilledRoot(ctx context.Context, store *db.Store, job db.Job) bool {
 	if store == nil {
 		return false

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4689,6 +4689,31 @@ func (s *Store) DeleteResourceLocksByOwner(ctx context.Context, ownerJobID strin
 	return result.RowsAffected()
 }
 
+// DeleteResourceLocksByOwnerIfNotRunning releases an owner's resource locks
+// only while that owner job is not currently running, evaluated atomically in
+// the DELETE itself. This mirrors DeleteExpiredResourceLocks's
+// `NOT EXISTS (... jobs.state='running')` guard and closes the TOCTOU race in
+// the delegation-kill cleanup path (#479): a child that raced queued->running
+// after a stale snapshot was read keeps its live runtime-session / checkout
+// lock instead of having it deleted out from under its in-flight process.
+func (s *Store) DeleteResourceLocksByOwnerIfNotRunning(ctx context.Context, ownerJobID string) (int64, error) {
+	ownerJobID = strings.TrimSpace(ownerJobID)
+	if ownerJobID == "" {
+		return 0, nil
+	}
+	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks
+		WHERE owner_job_id = ?
+			AND NOT EXISTS (
+				SELECT 1 FROM jobs
+				WHERE jobs.id = resource_locks.owner_job_id
+					AND jobs.state = 'running'
+			)`, ownerJobID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 func (s *Store) DeleteExpiredResourceLocks(ctx context.Context, now time.Time) (int64, error) {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks
 		WHERE expires_at <= ?

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1423,6 +1423,56 @@ func TestDeleteResourceLocksByOwner(t *testing.T) {
 	}
 }
 
+func TestDeleteResourceLocksByOwnerIfNotRunning(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	// Two owners: job-running is RUNNING, job-queued is QUEUED.
+	if err := store.CreateJob(ctx, Job{ID: "job-running", Agent: "w", Type: "ask", State: "running", Payload: "{}"}); err != nil {
+		t.Fatalf("CreateJob(job-running) returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, Job{ID: "job-queued", Agent: "w", Type: "ask", State: "queued", Payload: "{}"}); err != nil {
+		t.Fatalf("CreateJob(job-queued) returned error: %v", err)
+	}
+
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	for _, lock := range []ResourceLock{
+		{ResourceKey: "runtime:codex:session-r", OwnerJobID: "job-running", OwnerToken: "tok-r", ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano)},
+		{ResourceKey: "runtime:codex:session-q", OwnerJobID: "job-queued", OwnerToken: "tok-q", ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano)},
+	} {
+		if acquired, err := store.AcquireResourceLock(ctx, lock, now); err != nil || !acquired {
+			t.Fatalf("AcquireResourceLock(%s) acquired=%v err=%v", lock.ResourceKey, acquired, err)
+		}
+	}
+
+	// Empty owner id is a no-op.
+	if released, err := store.DeleteResourceLocksByOwnerIfNotRunning(ctx, "  "); err != nil || released != 0 {
+		t.Fatalf("DeleteResourceLocksByOwnerIfNotRunning(empty) released=%d err=%v, want 0/nil", released, err)
+	}
+
+	// A RUNNING owner's lock is NOT released: this is the #479 TOCTOU guard. A
+	// child that raced queued->running after a stale snapshot was read keeps its
+	// live runtime-session / checkout lock.
+	if released, err := store.DeleteResourceLocksByOwnerIfNotRunning(ctx, "job-running"); err != nil || released != 0 {
+		t.Fatalf("DeleteResourceLocksByOwnerIfNotRunning(job-running) released=%d err=%v, want 0/nil", released, err)
+	}
+	if _, err := store.GetResourceLock(ctx, "runtime:codex:session-r"); err != nil {
+		t.Fatalf("running owner's lock must survive: GetResourceLock returned error: %v", err)
+	}
+
+	// A non-running owner's lock IS released.
+	if released, err := store.DeleteResourceLocksByOwnerIfNotRunning(ctx, "job-queued"); err != nil || released != 1 {
+		t.Fatalf("DeleteResourceLocksByOwnerIfNotRunning(job-queued) released=%d err=%v, want 1/nil", released, err)
+	}
+	if _, err := store.GetResourceLock(ctx, "runtime:codex:session-q"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetResourceLock(session-q) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
 func TestResourceLockRecoversExpiredLock(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))

--- a/internal/workflow/job_kill.go
+++ b/internal/workflow/job_kill.go
@@ -63,6 +63,46 @@ func KillDelegationTree(ctx context.Context, store *db.Store, jobID string) (db.
 	}); err != nil {
 		return db.Job{}, err
 	}
+	// Best-effort tree cleanup (#479 + #480). The kill's contract — the root flag
+	// plus the delegation_killed event — is already committed above, so neither
+	// step here may turn a successful kill into an error. This mirrors CancelJob's
+	// documented philosophy that incidental lock cleanup must never fail the
+	// operation. If the tree walk itself fails, skip cleanup and return the
+	// already-killed root.
+	if tree, terr := store.ListJobsByRoot(ctx, root.ID); terr == nil {
+		for _, j := range tree {
+			// (#480) Eagerly terminalize QUEUED, not-yet-started delegation child
+			// legs. Guard exactly like daemon.go queuedChildOfKilledRoot: skip the
+			// root (rootID == j.ID) and skip continuations (DelegationID == ""),
+			// which must still run to drive the #305 graceful finalize. Only real
+			// child legs are cancelled. The from=queued transition is idempotent: a
+			// re-kill or a leg that raced to running simply does not match.
+			if j.State == string(JobQueued) {
+				if p, perr := unmarshalPayload(j.Payload); perr == nil {
+					rootID := strings.TrimSpace(p.RootJobID)
+					if rootID != "" && rootID != j.ID && strings.TrimSpace(p.DelegationID) != "" {
+						_, _ = store.TransitionJobStateWithEvent(ctx, j.ID, string(JobQueued), string(JobCancelled), db.JobEvent{
+							JobID:   j.ID,
+							Kind:    string(JobCancelled),
+							Message: fmt.Sprintf("delegation tree rooted at %s killed; queued child leg cancelled before start", root.ID),
+						})
+					}
+				}
+			}
+			// (#479) Release any resource/branch locks this tree job owns, using the
+			// same owner-scoped call CancelJob uses. Running children are NOT
+			// transitioned, so they keep executing to completion — only their DB
+			// lock row is dropped. DeleteResourceLocksByOwner returns 0 on a re-kill,
+			// so the lock_released event is not duplicated.
+			if released, derr := store.DeleteResourceLocksByOwner(ctx, j.ID); derr == nil && released > 0 {
+				_ = store.AddJobEvent(ctx, db.JobEvent{
+					JobID:   j.ID,
+					Kind:    "lock_released",
+					Message: fmt.Sprintf("released %d resource lock(s) on delegation kill of tree %s", released, root.ID),
+				})
+			}
+		}
+	}
 	root.RootKilled = true
 	return root, nil
 }

--- a/internal/workflow/job_kill.go
+++ b/internal/workflow/job_kill.go
@@ -89,28 +89,33 @@ func KillDelegationTree(ctx context.Context, store *db.Store, jobID string) (db.
 					}
 				}
 			}
-			// (#479) Release any resource/branch locks this tree job owns, using the
-			// same owner-scoped call CancelJob uses, but ONLY for jobs that are not
-			// still running. Resource locks are job-ID-owned (the runtime-session lock
-			// in internal/cli/runtime_lock.go and the checkout-mutation lock in
-			// checkout_lock.go), so dropping a RUNNING child's lock while its process
-			// is mid-flight would let a competing same-key job (a continuation, or a
-			// foreground `agent ask`/`agent run`) acquire it and run concurrently
-			// against the same runtime session / working tree — risking session or
-			// git-index corruption. The kill is graceful: running children keep
-			// executing and release their own locks via their token-scoped deferred
-			// ReleaseResourceLock when they finish. A just-cancelled queued child still
-			// reads State == queued on this local row (it was transitioned to cancelled
-			// just above), so it is now terminal and its lock is correctly released; the
-			// root and any already-terminal descendants release too — only in-flight
-			// (running) legs are kept.
-			// DeleteResourceLocksByOwner returns 0 on a re-kill, so the lock_released
-			// event is not duplicated. This mirrors CancelJob, which only frees locks
-			// for the job it is STOPPING.
-			if j.State == string(JobRunning) {
-				continue
-			}
-			if released, derr := store.DeleteResourceLocksByOwner(ctx, j.ID); derr == nil && released > 0 {
+			// (#479) Release any resource/branch locks this tree job owns, but ONLY
+			// for jobs that are not still running. Resource locks are job-ID-owned (the
+			// runtime-session lock in internal/cli/runtime_lock.go and the
+			// checkout-mutation lock in checkout_lock.go), so dropping a RUNNING child's
+			// lock while its process is mid-flight would let a competing same-key job (a
+			// continuation, or a foreground `agent ask`/`agent run`) acquire it and run
+			// concurrently against the same runtime session / working tree — risking
+			// session or git-index corruption. The kill is graceful: running children
+			// keep executing and release their own locks via their token-scoped deferred
+			// ReleaseResourceLock when they finish.
+			//
+			// The running-or-not test MUST be evaluated atomically against the CURRENT
+			// job state, not the j.State captured in the ListJobsByRoot snapshot above:
+			// a child selected by an in-flight daemon tick (e.g. the barrier scheduler
+			// built it into `pending` before root_killed committed) can transition
+			// queued->running AFTER its snapshot row was read. Trusting the stale
+			// snapshot state would delete that now-running child's live lock. So we use
+			// DeleteResourceLocksByOwnerIfNotRunning, whose `NOT EXISTS (... state=
+			// 'running')` clause mirrors DeleteExpiredResourceLocks and skips the delete
+			// in the same statement that reads the live state. A just-cancelled queued
+			// child (transitioned to cancelled just above) is terminal, so its lock is
+			// correctly released; the root and any already-terminal descendants release
+			// too — only in-flight (running) legs are kept.
+			// The call returns 0 on a re-kill, so the lock_released event is not
+			// duplicated. This mirrors CancelJob, which only frees locks for the job it
+			// is STOPPING.
+			if released, derr := store.DeleteResourceLocksByOwnerIfNotRunning(ctx, j.ID); derr == nil && released > 0 {
 				_ = store.AddJobEvent(ctx, db.JobEvent{
 					JobID:   j.ID,
 					Kind:    "lock_released",

--- a/internal/workflow/job_kill.go
+++ b/internal/workflow/job_kill.go
@@ -90,10 +90,26 @@ func KillDelegationTree(ctx context.Context, store *db.Store, jobID string) (db.
 				}
 			}
 			// (#479) Release any resource/branch locks this tree job owns, using the
-			// same owner-scoped call CancelJob uses. Running children are NOT
-			// transitioned, so they keep executing to completion — only their DB
-			// lock row is dropped. DeleteResourceLocksByOwner returns 0 on a re-kill,
-			// so the lock_released event is not duplicated.
+			// same owner-scoped call CancelJob uses, but ONLY for jobs that are not
+			// still running. Resource locks are job-ID-owned (the runtime-session lock
+			// in internal/cli/runtime_lock.go and the checkout-mutation lock in
+			// checkout_lock.go), so dropping a RUNNING child's lock while its process
+			// is mid-flight would let a competing same-key job (a continuation, or a
+			// foreground `agent ask`/`agent run`) acquire it and run concurrently
+			// against the same runtime session / working tree — risking session or
+			// git-index corruption. The kill is graceful: running children keep
+			// executing and release their own locks via their token-scoped deferred
+			// ReleaseResourceLock when they finish. A just-cancelled queued child still
+			// reads State == queued on this local row (it was transitioned to cancelled
+			// just above), so it is now terminal and its lock is correctly released; the
+			// root and any already-terminal descendants release too — only in-flight
+			// (running) legs are kept.
+			// DeleteResourceLocksByOwner returns 0 on a re-kill, so the lock_released
+			// event is not duplicated. This mirrors CancelJob, which only frees locks
+			// for the job it is STOPPING.
+			if j.State == string(JobRunning) {
+				continue
+			}
 			if released, derr := store.DeleteResourceLocksByOwner(ctx, j.ID); derr == nil && released > 0 {
 				_ = store.AddJobEvent(ctx, db.JobEvent{
 					JobID:   j.ID,

--- a/internal/workflow/job_kill_test.go
+++ b/internal/workflow/job_kill_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 )
@@ -146,5 +147,119 @@ func TestKillDelegationTreeResolvesChildToRoot(t *testing.T) {
 	}
 	if got := countJobEvents(t, store, "root", "delegation_killed"); got != 1 {
 		t.Fatalf("delegation_killed events on root = %d, want 1", got)
+	}
+}
+
+// TestKillDelegationTreeReleasesLocksAndTerminalizesQueuedChildren pins the
+// companion cleanup defects #479 + #480: a kill releases the resource/branch
+// locks owned by every tree job and eagerly cancels the tree's QUEUED child
+// legs, while leaving running children and queued continuations untouched.
+func TestKillDelegationTreeReleasesLocksAndTerminalizesQueuedChildren(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"ask"}, "jerryfane/gitmoot")
+
+	// Root coordinator (self-roots; succeeded).
+	insertCompletedJob(t, store, db.Job{ID: "root", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", TaskID: "task-9", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "tree"},
+	})
+
+	mustCreateJob := func(id, state string, payload JobPayload) {
+		t.Helper()
+		encoded, err := marshalPayload(payload)
+		if err != nil {
+			t.Fatalf("marshalPayload(%s) returned error: %v", id, err)
+		}
+		if err := store.CreateJob(ctx, db.Job{ID: id, Agent: "w", Type: "ask", State: state, Payload: encoded}); err != nil {
+			t.Fatalf("CreateJob(%s) returned error: %v", id, err)
+		}
+	}
+
+	// QUEUED child leg — must be cancelled.
+	mustCreateJob("root/delegation/c1", string(JobQueued), JobPayload{
+		Repo: "jerryfane/gitmoot", Sender: "w", RootJobID: "root", DelegationID: "d1",
+	})
+	// RUNNING child leg — must stay running (graceful).
+	mustCreateJob("root/delegation/c2", string(JobRunning), JobPayload{
+		Repo: "jerryfane/gitmoot", Sender: "w", RootJobID: "root", DelegationID: "d2",
+	})
+	// QUEUED continuation (DelegationID == "") — must stay queued to drive the
+	// #305 graceful finalize.
+	mustCreateJob("root/continuation", string(JobQueued), JobPayload{
+		Repo: "jerryfane/gitmoot", Sender: "w", RootJobID: "root", DelegationID: "",
+	})
+
+	// Acquire locks owned by the root and two child legs.
+	now := time.Now()
+	expires := now.Add(time.Hour).Format(time.RFC3339Nano)
+	for _, lk := range []struct{ key, owner string }{
+		{"repo:a", "root"},
+		{"repo:b", "root/delegation/c1"},
+		{"branch:c", "root/delegation/c2"},
+	} {
+		acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+			ResourceKey: lk.key, OwnerJobID: lk.owner, OwnerToken: "t", ExpiresAt: expires,
+		}, now)
+		if err != nil {
+			t.Fatalf("AcquireResourceLock(%s) returned error: %v", lk.key, err)
+		}
+		if !acquired {
+			t.Fatalf("AcquireResourceLock(%s) = false, want true", lk.key)
+		}
+	}
+
+	if _, err := KillDelegationTree(ctx, store, "root"); err != nil {
+		t.Fatalf("KillDelegationTree returned error: %v", err)
+	}
+
+	// (#480) Queued child leg terminalized with a cancelled event.
+	if got := mustJob(t, store, "root/delegation/c1").State; got != string(JobCancelled) {
+		t.Fatalf("queued child leg state = %q, want %q", got, JobCancelled)
+	}
+	if got := countJobEvents(t, store, "root/delegation/c1", "cancelled"); got != 1 {
+		t.Fatalf("queued child cancelled events = %d, want 1", got)
+	}
+	// Running leg unchanged.
+	if got := mustJob(t, store, "root/delegation/c2").State; got != string(JobRunning) {
+		t.Fatalf("running child leg state = %q, want %q (must run to completion)", got, JobRunning)
+	}
+	// Continuation unchanged.
+	if got := mustJob(t, store, "root/continuation").State; got != string(JobQueued) {
+		t.Fatalf("continuation state = %q, want %q (must still run finalize)", got, JobQueued)
+	}
+
+	// (#479) No locks remain owned by any tree job.
+	locks, err := store.ListResourceLocks(ctx)
+	if err != nil {
+		t.Fatalf("ListResourceLocks returned error: %v", err)
+	}
+	treeOwners := map[string]bool{"root": true, "root/delegation/c1": true, "root/delegation/c2": true}
+	for _, l := range locks {
+		if treeOwners[l.OwnerJobID] {
+			t.Fatalf("lock %q still owned by tree job %q after kill", l.ResourceKey, l.OwnerJobID)
+		}
+	}
+
+	// Existing behavior preserved.
+	if got := countJobEvents(t, store, "root", "delegation_killed"); got != 1 {
+		t.Fatalf("delegation_killed events = %d, want 1", got)
+	}
+
+	// Idempotency: a second kill must not error or duplicate events.
+	if _, err := KillDelegationTree(ctx, store, "root"); err != nil {
+		t.Fatalf("second KillDelegationTree returned error: %v", err)
+	}
+	if got := countJobEvents(t, store, "root", "delegation_killed"); got != 2 {
+		// SetRootJobKilled + delegation_killed are emitted unconditionally on each
+		// call; what must stay stable is the child cancellation, asserted below.
+		t.Logf("delegation_killed events after re-kill = %d", got)
+	}
+	if got := mustJob(t, store, "root/delegation/c1").State; got != string(JobCancelled) {
+		t.Fatalf("queued child leg state after re-kill = %q, want %q", got, JobCancelled)
+	}
+	if got := countJobEvents(t, store, "root/delegation/c1", "cancelled"); got != 1 {
+		t.Fatalf("queued child cancelled events after re-kill = %d, want 1 (no dup)", got)
 	}
 }

--- a/internal/workflow/job_kill_test.go
+++ b/internal/workflow/job_kill_test.go
@@ -152,8 +152,10 @@ func TestKillDelegationTreeResolvesChildToRoot(t *testing.T) {
 
 // TestKillDelegationTreeReleasesLocksAndTerminalizesQueuedChildren pins the
 // companion cleanup defects #479 + #480: a kill releases the resource/branch
-// locks owned by every tree job and eagerly cancels the tree's QUEUED child
-// legs, while leaving running children and queued continuations untouched.
+// locks owned by every NON-RUNNING tree job (root + just-cancelled queued legs)
+// and eagerly cancels the tree's QUEUED child legs, while leaving running
+// children — and crucially the locks they still hold — untouched, plus queued
+// continuations.
 func TestKillDelegationTreeReleasesLocksAndTerminalizesQueuedChildren(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -230,16 +232,25 @@ func TestKillDelegationTreeReleasesLocksAndTerminalizesQueuedChildren(t *testing
 		t.Fatalf("continuation state = %q, want %q (must still run finalize)", got, JobQueued)
 	}
 
-	// (#479) No locks remain owned by any tree job.
+	// (#479) Locks of NON-RUNNING tree jobs are released (root + the just-cancelled
+	// queued leg c1), but the RUNNING leg c2 keeps its lock (branch:c) so a competing
+	// same-key job cannot start against its still-live runtime session / working tree.
 	locks, err := store.ListResourceLocks(ctx)
 	if err != nil {
 		t.Fatalf("ListResourceLocks returned error: %v", err)
 	}
-	treeOwners := map[string]bool{"root": true, "root/delegation/c1": true, "root/delegation/c2": true}
+	releasedOwners := map[string]bool{"root": true, "root/delegation/c1": true}
+	c2LockOwned := false
 	for _, l := range locks {
-		if treeOwners[l.OwnerJobID] {
-			t.Fatalf("lock %q still owned by tree job %q after kill", l.ResourceKey, l.OwnerJobID)
+		if releasedOwners[l.OwnerJobID] {
+			t.Fatalf("lock %q still owned by non-running tree job %q after kill", l.ResourceKey, l.OwnerJobID)
 		}
+		if l.OwnerJobID == "root/delegation/c2" && l.ResourceKey == "branch:c" {
+			c2LockOwned = true
+		}
+	}
+	if !c2LockOwned {
+		t.Fatal("the RUNNING child leg c2 must KEEP its lock (branch:c) after a graceful kill")
 	}
 
 	// Existing behavior preserved.


### PR DESCRIPTION
## Summary

Killing a delegation job used to strand two kinds of state (issues #479, #480):
- **Stranded locks (#479):** job-ID-owned `resource_locks` (the runtime-session lock and the checkout-mutation lock) were left behind, so the next same-key job ("session is busy", checkout serialization) blocked until the TTL expired.
- **Orphaned queued children (#480):** not-yet-started delegation child legs stayed `queued` after the root was killed, only getting reaped lazily by the daemon's `queuedChildOfKilledRoot` check.

This makes `KillDelegationTree` clean up the whole tree eagerly and gracefully:

- **#480 — terminalize queued child legs.** Walk the tree (`ListJobsByRoot`) and transition each `queued` real child leg `queued -> cancelled` with a `delegation_killed`-context event. The classification guard matches `daemon.go`'s `queuedChildOfKilledRoot` exactly (`RootJobID != "" && RootJobID != job.ID && DelegationID != ""`) so the root and continuation legs are preserved — continuations must still run to drive the #305 graceful finalize. A cross-reference note was added at both sites since the `cli -> workflow` import direction prevents sharing one helper; they MUST stay in lockstep.
- **#479 — release stranded locks.** New `Store.DeleteResourceLocksByOwnerIfNotRunning` deletes an owner's resource locks only when that owner is not `running`, evaluated atomically inside the DELETE via a `NOT EXISTS (... jobs.state='running')` clause (mirrors `DeleteExpiredResourceLocks`). This closes a TOCTOU race: a child that raced `queued -> running` after the `ListJobsByRoot` snapshot was read keeps its live lock instead of having it deleted out from under its in-flight process. The kill stays graceful — running children keep executing and release their own token-scoped locks on completion.

Best-effort by design: the kill's contract (root flag + `delegation_killed` event) is committed first, so neither cleanup step can turn a successful kill into an error (mirrors `CancelJob`). Both steps are idempotent on re-kill (`from=queued` transition no-ops; `DeleteResourceLocksByOwnerIfNotRunning` returns 0, so no duplicate `lock_released` event).

## Files
- `internal/workflow/job_kill.go` — eager tree cleanup in `KillDelegationTree`
- `internal/db/store.go` — `DeleteResourceLocksByOwnerIfNotRunning` (TOCTOU-safe)
- `internal/cli/daemon.go` — lockstep cross-reference note on `queuedChildOfKilledRoot`
- `internal/workflow/job_kill_test.go`, `internal/db/store_test.go` — coverage for cancel/lock-release, running-child preservation, idempotent re-kill

## Gate / review
- Implement/fix gate: green.
- Review loop: converged CLEAN.

Closes #479
Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
