### PR TITLE
Clean up delegation worktrees + gitmoot-delegation-* branches

### DIFF
--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -99,6 +99,18 @@ func (c Client) RemoveWorktreeForce(ctx context.Context, path string) error {
 	return err
 }
 
+// DeleteBranch force-deletes a local branch (git branch -D). It is used to tear
+// down a terminal implement delegation's gitmoot-delegation-* branch so it does
+// not linger in the shared checkout and contaminate a later coordinator's
+// planning. Force (-D) because the branch may be unmerged in the shared checkout.
+func (c Client) DeleteBranch(ctx context.Context, branch string) error {
+	if err := validateBranch(branch); err != nil {
+		return err
+	}
+	_, err := c.run(ctx, "branch", "-D", branch)
+	return err
+}
+
 // MergeBranches sequentially merges each branch into the worktree at dir (its
 // current HEAD). It is used to integrate the per-delegation branches of parallel
 // implement legs into one tree before a dependent verify/review step runs

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -834,6 +834,13 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 	// pending retries). No-op for jobs that did not allocate a read-only worktree.
 	defer e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload)
 
+	// An implement delegation child runs in a per-delegation worktree on its own
+	// gitmoot-delegation-* branch; tear both down once the child is terminal so they
+	// do not accumulate in the shared checkout and mislead a later coordinator (#478).
+	// No-op for non-implement / non-delegation jobs and (idempotently) for already
+	// cleaned ones. Skips succeeded legs still feeding a pending integration (#332).
+	defer e.cleanupImplementDelegationWorktree(ctx, jobID, job.Type, payload)
+
 	// Commit a succeeded implement leg's work to its own branch BEFORE advancing
 	// the parent's delegation DAG. The parent advance below may enqueue a dependent
 	// that integrates this leg (#332); if the commit ran later (in the switch), the

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -841,6 +841,14 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 	// cleaned ones. Skips succeeded legs still feeding a pending integration (#332).
 	defer e.cleanupImplementDelegationWorktree(ctx, jobID, job.Type, payload)
 
+	// When an integration step (#332) that consumed implement legs via its Deps
+	// reaches a terminal state, tear down those consumed legs' worktrees+branches:
+	// each leg's own terminal advance preserved its branch while this consumer was
+	// still pending/running, and nothing else ever reclaims an integration-fed leg
+	// (the merge gate cleans only the task worktree), so they would otherwise
+	// accumulate forever (#478). No-op for a job with no parent/deps.
+	defer e.cleanupConsumedImplementLegWorktrees(ctx, payload)
+
 	// Commit a succeeded implement leg's work to its own branch BEFORE advancing
 	// the parent's delegation DAG. The parent advance below may enqueue a dependent
 	// that integrates this leg (#332); if the commit ran later (in the switch), the

--- a/internal/workflow/implement_worktree_cleanup_test.go
+++ b/internal/workflow/implement_worktree_cleanup_test.go
@@ -1,0 +1,120 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestIsImplementDelegationWorktree(t *testing.T) {
+	base := JobPayload{DelegationID: "d1", WorktreePath: "/wt/d1", Branch: "gitmoot-delegation-x-d1"}
+	if !isImplementDelegationWorktree("implement", base) {
+		t.Fatal("implement delegation worktree child not detected")
+	}
+	if isImplementDelegationWorktree("ask", base) {
+		t.Fatal("ask child must not be treated as an implement worktree")
+	}
+	if isImplementDelegationWorktree("review", base) {
+		t.Fatal("review child must not be treated as an implement worktree")
+	}
+	if isImplementDelegationWorktree("implement", JobPayload{WorktreePath: "/wt/d1", Branch: "b"}) {
+		t.Fatal("non-delegation job (no delegation id) must not match")
+	}
+	if isImplementDelegationWorktree("implement", JobPayload{DelegationID: "d1", Branch: "b"}) {
+		t.Fatal("implement child without a worktree path must not match")
+	}
+	if isImplementDelegationWorktree("implement", JobPayload{DelegationID: "d1", WorktreePath: "/wt/d1"}) {
+		t.Fatal("implement child without a branch must not match")
+	}
+}
+
+func TestCleanupImplementDelegationWorktreeRemovesWorktreeAndBranch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	branch := "gitmoot-delegation-x-d1"
+	manager := &fakeWorktreeManager{existingBranches: map[string]bool{branch: true}}
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	// The worktree path must exist on disk so the idempotency stat check proceeds.
+	wt := t.TempDir()
+	payload := JobPayload{
+		DelegationID: "d1",
+		WorktreePath: wt,
+		Branch:       branch,
+		Result:       &AgentResult{Decision: "implemented"},
+	}
+	engine.cleanupImplementDelegationWorktree(ctx, "job-1", "implement", payload)
+
+	if len(manager.removedForce) != 1 || manager.removedForce[0] != wt {
+		t.Fatalf("removedForce = %+v, want one force-remove of %q", manager.removedForce, wt)
+	}
+	if len(manager.deletedBranches) != 1 || manager.deletedBranches[0] != branch {
+		t.Fatalf("deletedBranches = %+v, want one delete of %q", manager.deletedBranches, branch)
+	}
+	if got := countJobEvents(t, store, "job-1", "delegation_worktree_removed"); got != 1 {
+		t.Fatalf("delegation_worktree_removed event count = %d, want 1", got)
+	}
+	if got := countJobEvents(t, store, "job-1", "delegation_worktree_cleanup_failed"); got != 0 {
+		t.Fatalf("cleanup must not emit cleanup_failed events, got %d", got)
+	}
+
+	// Idempotent: a second cleanup once both worktree and branch are gone is a
+	// silent no-op (no re-lock, no extra removal/delete, no spurious event).
+	if err := os.RemoveAll(wt); err != nil {
+		t.Fatalf("RemoveAll returned error: %v", err)
+	}
+	manager.existingBranches[branch] = false
+	engine.cleanupImplementDelegationWorktree(ctx, "job-1", "implement", payload)
+	if len(manager.removedForce) != 1 || len(manager.deletedBranches) != 1 {
+		t.Fatalf("idempotent cleanup must be a no-op: removedForce=%+v deletedBranches=%+v", manager.removedForce, manager.deletedBranches)
+	}
+
+	// No-op for a read-only child (cleaned by cleanupReadOnlyDelegationWorktree).
+	manager.removedForce = nil
+	manager.deletedBranches = nil
+	engine.cleanupImplementDelegationWorktree(ctx, "job-2", "ask", JobPayload{DelegationID: "d2", WorktreePath: t.TempDir(), Branch: "b2"})
+	if len(manager.removedForce) != 0 || len(manager.deletedBranches) != 0 {
+		t.Fatalf("read-only child must be a no-op: removedForce=%+v deletedBranches=%+v", manager.removedForce, manager.deletedBranches)
+	}
+}
+
+func TestCleanupImplementDelegationWorktreeSkipsIntegrationDep(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	branch := "gitmoot-delegation-x-d1"
+	manager := &fakeWorktreeManager{existingBranches: map[string]bool{branch: true}}
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	// Seed a parent whose result has a sibling (the integration step) that depends
+	// on the succeeded leg d1: its branch must NOT be torn down (#332).
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "owner/repo",
+		Result: &AgentResult{
+			Decision: "approved",
+			Delegations: []Delegation{
+				{ID: "d1", Action: "implement", Prompt: "produce"},
+				{ID: "integrate", Action: "review", Prompt: "verify", Deps: []string{"d1"}},
+			},
+		},
+	})
+
+	wt := t.TempDir()
+	payload := JobPayload{
+		ParentJobID:  "parent-job",
+		DelegationID: "d1",
+		WorktreePath: wt,
+		Branch:       branch,
+		Result:       &AgentResult{Decision: "implemented"},
+	}
+	engine.cleanupImplementDelegationWorktree(ctx, "parent-job/delegation/d1", "implement", payload)
+
+	if len(manager.removedForce) != 0 || len(manager.deletedBranches) != 0 {
+		t.Fatalf("succeeded leg feeding a pending integration must be kept: removedForce=%+v deletedBranches=%+v", manager.removedForce, manager.deletedBranches)
+	}
+}

--- a/internal/workflow/implement_worktree_cleanup_test.go
+++ b/internal/workflow/implement_worktree_cleanup_test.go
@@ -2,11 +2,65 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 )
+
+// roOnlyWorktreeManager satisfies ReadOnlyWorktreeManager (force-remove) but
+// implements neither BranchDeleter nor BranchExistenceChecker — a degraded
+// manager used to exercise the interface-degradation paths in
+// cleanupImplementDelegationWorktree.
+type roOnlyWorktreeManager struct{ removed []string }
+
+func (m *roOnlyWorktreeManager) AddWorktree(context.Context, string, string, string) error {
+	return nil
+}
+func (m *roOnlyWorktreeManager) AddDetachedWorktree(context.Context, string, string) error { return nil }
+func (m *roOnlyWorktreeManager) RemoveWorktreeForce(_ context.Context, path string) error {
+	m.removed = append(m.removed, path)
+	return nil
+}
+
+// deleterNoCheckerWorktreeManager satisfies ReadOnlyWorktreeManager + BranchDeleter
+// but NOT BranchExistenceChecker.
+type deleterNoCheckerWorktreeManager struct {
+	removed []string
+	deleted []string
+}
+
+func (m *deleterNoCheckerWorktreeManager) AddWorktree(context.Context, string, string, string) error {
+	return nil
+}
+func (m *deleterNoCheckerWorktreeManager) AddDetachedWorktree(context.Context, string, string) error {
+	return nil
+}
+func (m *deleterNoCheckerWorktreeManager) RemoveWorktreeForce(_ context.Context, path string) error {
+	m.removed = append(m.removed, path)
+	return nil
+}
+func (m *deleterNoCheckerWorktreeManager) DeleteBranch(_ context.Context, branch string) error {
+	m.deleted = append(m.deleted, branch)
+	return nil
+}
+
+func jobEventMessages(t *testing.T, store *db.Store, jobID, kind string) []string {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s) returned error: %v", jobID, err)
+	}
+	var msgs []string
+	for _, e := range events {
+		if e.Kind == kind {
+			msgs = append(msgs, e.Message)
+		}
+	}
+	return msgs
+}
 
 func TestIsImplementDelegationWorktree(t *testing.T) {
 	base := JobPayload{DelegationID: "d1", WorktreePath: "/wt/d1", Branch: "gitmoot-delegation-x-d1"}
@@ -82,6 +136,181 @@ func TestCleanupImplementDelegationWorktreeRemovesWorktreeAndBranch(t *testing.T
 	}
 }
 
+// TestCleanupImplementDelegationWorktreePreservesWhileConsumerLive pins the #332
+// guard's failure direction: cleanup is DESTRUCTIVE, so a succeeded leg whose
+// branch a sibling integration step may still merge must be PRESERVED on any
+// uncertainty — a parent fetch error, and a consumer that has not yet reached a
+// terminal state.
+func TestCleanupImplementDelegationWorktreePreservesWhileConsumerLive(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	branch := "gitmoot-delegation-x-produce"
+	manager := &fakeWorktreeManager{existingBranches: map[string]bool{branch: true}}
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	legPayload := JobPayload{
+		ParentJobID:  "parent-job",
+		DelegationID: "produce",
+		WorktreePath: t.TempDir(),
+		Branch:       branch,
+		Result:       &AgentResult{Decision: "implemented"},
+	}
+
+	// (a) Parent not readable yet (no parent job in the store) -> "cannot determine"
+	// must preserve, not delete.
+	engine.cleanupImplementDelegationWorktree(ctx, "parent-job/delegation/produce", "implement", legPayload)
+	if len(manager.removedForce) != 0 || len(manager.deletedBranches) != 0 {
+		t.Fatalf("unreadable parent must preserve the leg (fail safe): removedForce=%+v deletedBranches=%+v", manager.removedForce, manager.deletedBranches)
+	}
+
+	// Seed the parent and a consumer integration step that is still QUEUED.
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "owner/repo",
+		Result: &AgentResult{
+			Decision: "approved",
+			Delegations: []Delegation{
+				{ID: "produce", Action: "implement", Prompt: "produce"},
+				{ID: "integrate", Action: "review", Prompt: "verify", Deps: []string{"produce"}},
+			},
+		},
+	})
+	consumerEncoded, err := marshalPayload(JobPayload{ParentJobID: "parent-job", DelegationID: "integrate", Deps: []string{"produce"}})
+	if err != nil {
+		t.Fatalf("marshalPayload(integrate) returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: "parent-job/delegation/integrate", Agent: "verifier", Type: "review",
+		State: string(JobQueued), ParentJobID: "parent-job", DelegationID: "integrate",
+		Payload: consumerEncoded,
+	}, db.JobEvent{Kind: string(JobQueued), Message: "queued"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(integrate) returned error: %v", err)
+	}
+
+	// (b) Consumer still live (queued) -> preserve.
+	engine.cleanupImplementDelegationWorktree(ctx, "parent-job/delegation/produce", "implement", legPayload)
+	if len(manager.removedForce) != 0 || len(manager.deletedBranches) != 0 {
+		t.Fatalf("live integration consumer must preserve the leg: removedForce=%+v deletedBranches=%+v", manager.removedForce, manager.deletedBranches)
+	}
+}
+
+// TestCleanupConsumedImplementLegWorktreesAfterIntegrationTerminal covers the
+// #478 integration shape: once the integration step that consumed a leg reaches a
+// terminal state, the leg's branch+worktree are reclaimed (they are preserved
+// while the consumer is live, then nothing else would ever delete them).
+func TestCleanupConsumedImplementLegWorktreesAfterIntegrationTerminal(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	legBranch := "gitmoot-delegation-x-produce"
+	manager := &fakeWorktreeManager{existingBranches: map[string]bool{legBranch: true}}
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "owner/repo",
+		Result: &AgentResult{
+			Decision: "approved",
+			Delegations: []Delegation{
+				{ID: "produce", Action: "implement", Prompt: "produce"},
+				{ID: "integrate", Action: "review", Prompt: "verify", Deps: []string{"produce"}},
+			},
+		},
+	})
+
+	legWt := t.TempDir()
+	insertCompletedJob(t, store, db.Job{
+		ID: "parent-job/delegation/produce", Agent: "producer", Type: "implement",
+		ParentJobID: "parent-job", DelegationID: "produce",
+	}, JobPayload{
+		ParentJobID: "parent-job", DelegationID: "produce", WorktreePath: legWt, Branch: legBranch,
+		Result: &AgentResult{Decision: "implemented"},
+	})
+	// The integration step consumed the leg and is now terminal (succeeded).
+	insertCompletedJob(t, store, db.Job{
+		ID: "parent-job/delegation/integrate", Agent: "verifier", Type: "review",
+		ParentJobID: "parent-job", DelegationID: "integrate",
+	}, JobPayload{
+		ParentJobID: "parent-job", DelegationID: "integrate", Deps: []string{"produce"},
+		Result: &AgentResult{Decision: "approved"},
+	})
+
+	consumerPayload := JobPayload{ParentJobID: "parent-job", DelegationID: "integrate", Deps: []string{"produce"}}
+	engine.cleanupConsumedImplementLegWorktrees(ctx, consumerPayload)
+
+	if len(manager.removedForce) != 1 || manager.removedForce[0] != legWt {
+		t.Fatalf("consumed leg worktree must be removed once the integration is terminal: removedForce=%+v", manager.removedForce)
+	}
+	if len(manager.deletedBranches) != 1 || manager.deletedBranches[0] != legBranch {
+		t.Fatalf("consumed leg branch must be deleted once the integration is terminal: deletedBranches=%+v", manager.deletedBranches)
+	}
+}
+
+// TestAdvanceJobTerminalImplementLegFiresCleanup drives a delegated implement
+// child to a terminal result through engine.AdvanceJob() and asserts the defer
+// wiring actually tears the worktree+branch down — covering the placement of the
+// defer (a future early-return added above it, or a dropped/misplaced defer,
+// would be caught). It checks both a succeeded (implemented) leg and a terminal
+// failed leg.
+func TestAdvanceJobTerminalImplementLegFiresCleanup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("implemented", func(t *testing.T) {
+		store := openEngineStore(t)
+		engine := testEngine(store)
+		engine.Home = t.TempDir()
+		engine.DelegationCheckout = t.TempDir()
+		branch := "gitmoot-delegation-x-d1"
+		manager := &fakeWorktreeManager{existingBranches: map[string]bool{branch: true}}
+		engine.DelegationWorktrees = manager
+
+		wt := t.TempDir()
+		insertCompletedJob(t, store, db.Job{ID: "leg-impl", Agent: "producer", Type: "implement", DelegationID: "d1"}, JobPayload{
+			DelegationID: "d1", WorktreePath: wt, Branch: branch,
+			Result: &AgentResult{Decision: "implemented", Summary: "done"},
+		})
+		if err := engine.AdvanceJob(ctx, "leg-impl"); err != nil {
+			t.Fatalf("AdvanceJob(leg-impl) returned error: %v", err)
+		}
+		if len(manager.removedForce) != 1 || manager.removedForce[0] != wt {
+			t.Fatalf("terminal implement leg AdvanceJob must force-remove the worktree: removedForce=%+v", manager.removedForce)
+		}
+		if len(manager.deletedBranches) != 1 || manager.deletedBranches[0] != branch {
+			t.Fatalf("terminal implement leg AdvanceJob must delete the branch: deletedBranches=%+v", manager.deletedBranches)
+		}
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		store := openEngineStore(t)
+		engine := testEngine(store)
+		engine.Home = t.TempDir()
+		engine.DelegationCheckout = t.TempDir()
+		branch := "gitmoot-delegation-x-d2"
+		manager := &fakeWorktreeManager{existingBranches: map[string]bool{branch: true}}
+		engine.DelegationWorktrees = manager
+
+		wt := t.TempDir()
+		insertCompletedJob(t, store, db.Job{ID: "leg-fail", Agent: "producer", Type: "implement", DelegationID: "d2"}, JobPayload{
+			DelegationID: "d2", WorktreePath: wt, Branch: branch,
+			Result: &AgentResult{Decision: "failed", Summary: "boom"},
+		})
+		// A failed leg blocks its (empty) task ref, so AdvanceJob returns a
+		// BlockedError; the cleanup defer must still fire on that return path.
+		err := engine.AdvanceJob(ctx, "leg-fail")
+		var blocked BlockedError
+		if err != nil && !errors.As(err, &blocked) {
+			t.Fatalf("AdvanceJob(leg-fail) returned unexpected error: %v", err)
+		}
+		if len(manager.removedForce) != 1 || manager.removedForce[0] != wt {
+			t.Fatalf("terminal failed leg AdvanceJob must force-remove the worktree: removedForce=%+v", manager.removedForce)
+		}
+		if len(manager.deletedBranches) != 1 || manager.deletedBranches[0] != branch {
+			t.Fatalf("terminal failed leg AdvanceJob must delete the branch: deletedBranches=%+v", manager.deletedBranches)
+		}
+	})
+}
+
 func TestCleanupImplementDelegationWorktreeSkipsIntegrationDep(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -116,5 +345,78 @@ func TestCleanupImplementDelegationWorktreeSkipsIntegrationDep(t *testing.T) {
 
 	if len(manager.removedForce) != 0 || len(manager.deletedBranches) != 0 {
 		t.Fatalf("succeeded leg feeding a pending integration must be kept: removedForce=%+v deletedBranches=%+v", manager.removedForce, manager.deletedBranches)
+	}
+}
+
+// TestCleanupImplementDelegationWorktreeNoBranchDeleter pins that when the manager
+// cannot delete branches (no BranchDeleter), the worktree is removed, the branch
+// is intentionally kept, and the emitted event does NOT falsely claim the branch
+// was removed. Re-advances are silent no-ops (no repeated removed event).
+func TestCleanupImplementDelegationWorktreeNoBranchDeleter(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	manager := &roOnlyWorktreeManager{}
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	wt := t.TempDir()
+	payload := JobPayload{DelegationID: "d1", WorktreePath: wt, Branch: "gitmoot-delegation-x-d1", Result: &AgentResult{Decision: "implemented"}}
+	engine.cleanupImplementDelegationWorktree(ctx, "job-1", "implement", payload)
+
+	if len(manager.removed) != 1 || manager.removed[0] != wt {
+		t.Fatalf("worktree must still be removed without a deleter: removed=%+v", manager.removed)
+	}
+	msgs := jobEventMessages(t, store, "job-1", "delegation_worktree_removed")
+	if len(msgs) != 1 {
+		t.Fatalf("delegation_worktree_removed event count = %d, want 1", len(msgs))
+	}
+	if strings.Contains(msgs[0], "branch") {
+		t.Fatalf("event must not claim a branch was removed when no deleter exists: %q", msgs[0])
+	}
+
+	// Re-advance with the worktree already gone is a silent no-op (no deleter, so
+	// nothing is pending) — no second removed event.
+	if err := os.RemoveAll(wt); err != nil {
+		t.Fatalf("RemoveAll returned error: %v", err)
+	}
+	engine.cleanupImplementDelegationWorktree(ctx, "job-1", "implement", payload)
+	if msgs := jobEventMessages(t, store, "job-1", "delegation_worktree_removed"); len(msgs) != 1 {
+		t.Fatalf("re-advance without a deleter must be a no-op: removed events = %d", len(msgs))
+	}
+}
+
+// TestCleanupImplementDelegationWorktreeNoChecker pins that without a
+// BranchExistenceChecker, an already-removed worktree is a sufficient idempotent
+// short-circuit: a re-advance must NOT re-run DeleteBranch on the already-deleted
+// branch (which would emit a spurious cleanup_failed event).
+func TestCleanupImplementDelegationWorktreeNoChecker(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	manager := &deleterNoCheckerWorktreeManager{}
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	branch := "gitmoot-delegation-x-d1"
+	wt := t.TempDir()
+	payload := JobPayload{DelegationID: "d1", WorktreePath: wt, Branch: branch, Result: &AgentResult{Decision: "implemented"}}
+	engine.cleanupImplementDelegationWorktree(ctx, "job-1", "implement", payload)
+	if len(manager.removed) != 1 || len(manager.deleted) != 1 {
+		t.Fatalf("first cleanup must remove worktree and delete branch: removed=%+v deleted=%+v", manager.removed, manager.deleted)
+	}
+
+	// Re-advance with the worktree gone must short-circuit (no second DeleteBranch,
+	// no spurious cleanup_failed event) even though no checker can confirm the
+	// branch is gone.
+	if err := os.RemoveAll(wt); err != nil {
+		t.Fatalf("RemoveAll returned error: %v", err)
+	}
+	engine.cleanupImplementDelegationWorktree(ctx, "job-1", "implement", payload)
+	if len(manager.deleted) != 1 {
+		t.Fatalf("re-advance without a checker must not re-delete the branch: deleted=%+v", manager.deleted)
+	}
+	if got := countJobEvents(t, store, "job-1", "delegation_worktree_cleanup_failed"); got != 0 {
+		t.Fatalf("re-advance without a checker must not emit cleanup_failed, got %d", got)
 	}
 }

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -501,17 +501,24 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	opCtx := context.WithoutCancel(ctx)
 	path := strings.TrimSpace(payload.WorktreePath)
 	branch := strings.TrimSpace(payload.Branch)
-	// Idempotency: if the worktree dir is already gone AND the branch is already
-	// gone (prior advance cleaned it), do nothing (no lock, no spurious event).
+	// Idempotency: short-circuit (no lock, no spurious event) once there is nothing
+	// left to do. The pending work is (a) removing the worktree if it still exists
+	// and (b) deleting the branch if a BranchDeleter is wired and the branch is not
+	// already gone. A branch delete can only be pending when BOTH a deleter and a
+	// checker are available: without a checker we cannot prove the branch survived,
+	// so a `git branch -D` on every re-advance would error on a missing branch and
+	// emit a spurious cleanup_failed event. In that case (and when no deleter
+	// exists at all) treat an already-removed worktree as sufficient.
 	_, statErr := os.Stat(path)
 	worktreeGone := os.IsNotExist(statErr)
-	branchGone := false
+	branchKnownGone := false
 	if checker != nil {
 		if exists, err := checker.BranchExists(opCtx, branch); err == nil {
-			branchGone = !exists
+			branchKnownGone = !exists
 		}
 	}
-	if worktreeGone && branchGone {
+	branchCleanupPending := deleter != nil && checker != nil && !branchKnownGone
+	if worktreeGone && !branchCleanupPending {
 		return
 	}
 	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(opCtx, e.Store, e.DelegationCheckout, "worktree-cleanup:"+jobID, time.Now().UTC())
@@ -530,18 +537,40 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 			return
 		}
 	}
-	if deleter != nil && !branchGone {
+	branchDeleted := false
+	if deleter != nil && !branchKnownGone {
 		if err := deleter.DeleteBranch(opCtx, branch); err != nil {
 			_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("implement branch %s delete failed: %v", branch, err)})
 			return
 		}
+		branchDeleted = true
 	}
-	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: fmt.Sprintf("implement worktree %s and branch %s removed", path, branch)})
+	// Only claim the branch was removed when a delete actually occurred this pass
+	// (or the checker confirmed it already gone). With no BranchDeleter the branch
+	// is intentionally kept, so the event must not say it was removed.
+	message := fmt.Sprintf("implement worktree %s removed", path)
+	if branchDeleted || branchKnownGone {
+		message = fmt.Sprintf("implement worktree %s and branch %s removed", path, branch)
+	}
+	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: message})
 }
 
-// implementLegBranchMayBeMerged reports whether some sibling delegation lists
-// this leg's delegation id in its Deps, meaning a dependent integration step
-// (#332) may still merge the leg's branch. It reads the parent's result.
+// implementLegBranchMayBeMerged reports whether a succeeded implement leg's
+// branch must be PRESERVED because a dependent integration step (#332) may still
+// merge it. A sibling delegation that lists this leg in its Deps consumes the
+// leg's branch (integrationDepBranches requires the leg JobSucceeded), but only
+// until that consumer reaches a terminal state: once every consumer is terminal
+// the merge has already run (or failed terminally) and the branch can be torn
+// down (#478). cleanupConsumedImplementLegWorktrees re-fires this leg's cleanup
+// from the consumer's terminal advance so an integration-fed leg is reclaimed
+// rather than accumulating forever.
+//
+// Cleanup is DESTRUCTIVE (git branch -D + force worktree removal), so on any
+// uncertainty it fails safe by returning true (preserve): a missing/unreadable
+// parent result, a not-yet-dispatched consumer, or an inability to read consumer
+// job states all mean "cannot prove the branch is unneeded". It returns false
+// (safe to clean) only when the parent result was read AND either no sibling
+// lists this leg in its Deps or every such consumer is terminal.
 func (e Engine) implementLegBranchMayBeMerged(ctx context.Context, payload JobPayload) bool {
 	parentID := strings.TrimSpace(payload.ParentJobID)
 	if parentID == "" {
@@ -549,16 +578,65 @@ func (e Engine) implementLegBranchMayBeMerged(ctx context.Context, payload JobPa
 	}
 	_, parentPayload, err := e.jobPayload(ctx, parentID)
 	if err != nil || parentPayload.Result == nil {
-		return false // best-effort; don't block cleanup on a fetch error
+		return true // cannot determine -> preserve (destructive op fails safe)
 	}
+	legID := strings.TrimSpace(payload.DelegationID)
+	var consumerIDs []string
 	for _, sib := range parentPayload.Result.Delegations {
 		for _, dep := range sib.Deps {
-			if strings.TrimSpace(dep) == strings.TrimSpace(payload.DelegationID) {
-				return true
+			if strings.TrimSpace(dep) == legID {
+				consumerIDs = append(consumerIDs, strings.TrimSpace(sib.ID))
+				break
 			}
 		}
 	}
-	return false
+	if len(consumerIDs) == 0 {
+		return false // no integration consumer -> always safe to clean
+	}
+	children, err := e.childDelegationJobs(ctx, parentID)
+	if err != nil {
+		return true // cannot read consumer job states -> preserve
+	}
+	for _, consumerID := range consumerIDs {
+		consumer, ok := children[consumerID]
+		if !ok || !isTerminalJobState(consumer.State) {
+			return true // consumer not yet dispatched or still running -> preserve
+		}
+	}
+	return false // every consumer is terminal: the merge is done -> clean the leg
+}
+
+// cleanupConsumedImplementLegWorktrees tears down the per-delegation worktrees
+// and branches of the implement legs that THIS now-terminal integration step
+// consumed via its Deps (#332/#478). A leg's own terminal advance preserves its
+// branch while a consumer is still pending/running (implementLegBranchMayBeMerged),
+// and the merge gate only cleans the task worktree, so without this nothing would
+// ever reclaim an integration-fed leg and its gitmoot-delegation-* branch and
+// worktree would accumulate forever after the tree finished. It re-runs each
+// leg's cleanup, whose #332 guard now observes this consumer terminal and (absent
+// another live consumer) proceeds. Best-effort and idempotent: a no-op for a job
+// with no parent/deps and for already-cleaned legs.
+func (e Engine) cleanupConsumedImplementLegWorktrees(ctx context.Context, payload JobPayload) {
+	parentID := strings.TrimSpace(payload.ParentJobID)
+	deps := compactStrings(payload.Deps)
+	if parentID == "" || len(deps) == 0 {
+		return
+	}
+	children, err := e.childDelegationJobs(ctx, parentID)
+	if err != nil {
+		return
+	}
+	for _, dep := range deps {
+		legJob, ok := children[strings.TrimSpace(dep)]
+		if !ok {
+			continue
+		}
+		legPayload, err := unmarshalPayload(legJob.Payload)
+		if err != nil {
+			continue
+		}
+		e.cleanupImplementDelegationWorktree(ctx, legJob.ID, legJob.Type, legPayload)
+	}
 }
 
 func addTaskWorktree(ctx context.Context, manager WorktreeManager, branch string, path string, base string) error {

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -39,6 +39,12 @@ type ReadOnlyWorktreeManager interface {
 	RemoveWorktreeForce(ctx context.Context, path string) error
 }
 
+// BranchDeleter deletes a local branch. The checkout-bound gitutil.Client
+// satisfies it; used to tear down a terminal implement delegation's branch.
+type BranchDeleter interface {
+	DeleteBranch(ctx context.Context, branch string) error
+}
+
 // IntegrationWorktreeManager builds a detached worktree off the parent base and
 // merges the per-delegation branches of succeeded implement legs into it, so a
 // dependent verify/review step sees the legs' combined work instead of the base
@@ -450,6 +456,109 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 		return
 	}
 	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: fmt.Sprintf("read-only worktree %s removed", path)})
+}
+
+// isImplementDelegationWorktree reports whether a job ran in a per-delegation
+// implement worktree (carries a branch) that must be torn down on terminal.
+func isImplementDelegationWorktree(jobType string, payload JobPayload) bool {
+	return strings.TrimSpace(payload.DelegationID) != "" &&
+		strings.TrimSpace(payload.WorktreePath) != "" &&
+		strings.TrimSpace(payload.Branch) != "" &&
+		!readOnlyDelegationAction(jobType) // i.e. jobType == "implement"
+}
+
+// cleanupImplementDelegationWorktree disposes the per-delegation worktree AND
+// deletes the gitmoot-delegation-* branch allocated for an implement delegation
+// child once the child job is terminal, so they do not accumulate in the shared
+// checkout and mislead a later coordinator (#478). It is best-effort and
+// idempotent: an already-gone worktree+branch short-circuit to a no-op. Removal
+// and branch deletion mutate the shared .git, so it holds the checkout mutation
+// lock like allocation does. The worktree is removed FIRST so the branch is no
+// longer checked out, then `git branch -D` can succeed.
+func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID string, jobType string, payload JobPayload) {
+	if !isImplementDelegationWorktree(jobType, payload) {
+		return
+	}
+	// #332 guard: a succeeded implement leg's branch is merged into a dependent
+	// integration worktree (integrationDepBranches requires JobSucceeded). Do
+	// NOT delete a succeeded leg whose branch a sibling lists in Deps, or a
+	// pending integration would fail to merge it. Failed/blocked legs are never
+	// merged, so they are always safe to clean.
+	if payload.Result != nil && payload.Result.Decision == "implemented" &&
+		e.implementLegBranchMayBeMerged(ctx, payload) {
+		return
+	}
+	manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager) // RemoveWorktreeForce
+	if !ok || manager == nil {
+		return
+	}
+	deleter, _ := e.DelegationWorktrees.(BranchDeleter)
+	checker, _ := e.DelegationWorktrees.(BranchExistenceChecker)
+	// Detach from the caller's cancellation: this runs on the child's terminal
+	// AdvanceJob, which may carry a job context already cancelled by a run timeout.
+	// The worktree must still be disposed, so keep context values but drop the
+	// deadline/cancel.
+	opCtx := context.WithoutCancel(ctx)
+	path := strings.TrimSpace(payload.WorktreePath)
+	branch := strings.TrimSpace(payload.Branch)
+	// Idempotency: if the worktree dir is already gone AND the branch is already
+	// gone (prior advance cleaned it), do nothing (no lock, no spurious event).
+	_, statErr := os.Stat(path)
+	worktreeGone := os.IsNotExist(statErr)
+	branchGone := false
+	if checker != nil {
+		if exists, err := checker.BranchExists(opCtx, branch); err == nil {
+			branchGone = !exists
+		}
+	}
+	if worktreeGone && branchGone {
+		return
+	}
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(opCtx, e.Store, e.DelegationCheckout, "worktree-cleanup:"+jobID, time.Now().UTC())
+	if err != nil {
+		_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("implement worktree %s cleanup could not lock checkout: %v", path, err)})
+		return
+	}
+	defer func() {
+		if releaseCheckoutLock != nil {
+			_ = releaseCheckoutLock(context.Background())
+		}
+	}()
+	if !worktreeGone {
+		if err := manager.RemoveWorktreeForce(opCtx, path); err != nil {
+			_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("implement worktree %s force-remove failed: %v", path, err)})
+			return
+		}
+	}
+	if deleter != nil && !branchGone {
+		if err := deleter.DeleteBranch(opCtx, branch); err != nil {
+			_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("implement branch %s delete failed: %v", branch, err)})
+			return
+		}
+	}
+	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: fmt.Sprintf("implement worktree %s and branch %s removed", path, branch)})
+}
+
+// implementLegBranchMayBeMerged reports whether some sibling delegation lists
+// this leg's delegation id in its Deps, meaning a dependent integration step
+// (#332) may still merge the leg's branch. It reads the parent's result.
+func (e Engine) implementLegBranchMayBeMerged(ctx context.Context, payload JobPayload) bool {
+	parentID := strings.TrimSpace(payload.ParentJobID)
+	if parentID == "" {
+		return false
+	}
+	_, parentPayload, err := e.jobPayload(ctx, parentID)
+	if err != nil || parentPayload.Result == nil {
+		return false // best-effort; don't block cleanup on a fetch error
+	}
+	for _, sib := range parentPayload.Result.Delegations {
+		for _, dep := range sib.Deps {
+			if strings.TrimSpace(dep) == strings.TrimSpace(payload.DelegationID) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func addTaskWorktree(ctx context.Context, manager WorktreeManager, branch string, path string, base string) error {

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -658,6 +658,8 @@ type fakeWorktreeManager struct {
 	detachedCalls    []worktreeCall // AddDetachedWorktree: path in .path, ref in .base
 	removedForce     []string       // RemoveWorktreeForce paths
 	removeErr        error
+	deletedBranches  []string // DeleteBranch branches
+	deleteErr        error
 	mergeCalls       []mergeCall // MergeBranches calls
 	mergeErr         error
 	committedDirs    []string // CommitWorktree dirs
@@ -717,6 +719,11 @@ func (f *fakeWorktreeManager) CommitWorktree(_ context.Context, dir string, _ st
 func (f *fakeWorktreeManager) RemoveWorktreeForce(_ context.Context, path string) error {
 	f.removedForce = append(f.removedForce, path)
 	return f.removeErr
+}
+
+func (f *fakeWorktreeManager) DeleteBranch(_ context.Context, branch string) error {
+	f.deletedBranches = append(f.deletedBranches, branch)
+	return f.deleteErr
 }
 
 func TestTaskWorktreePathSegmentSanitizesSlashedIDs(t *testing.T) {


### PR DESCRIPTION
## Summary

Implement-delegation children run in per-delegation git worktrees on their own
`gitmoot-delegation-*` branches, but the existing terminal cleanup only handled
read-only (ask/review) fan-out worktrees. Implement worktrees and branches were
**never torn down**, so they accumulated in the shared checkout and misled a
later, independent coordinator (`ask`) into planning a "recover / open PR from
integration" instead of doing the work fresh. Runs were not isolated from each
other.

## Change

Extend the read-only cleanup pattern to implement delegations:

- `internal/git/client.go`: add `Client.DeleteBranch` (`git branch -D`),
  analogous to `RemoveWorktreeForce`, reusing `validateBranch`. Force-delete
  because the branch may be unmerged in the shared checkout.
- `internal/workflow/worktree.go`: add a `BranchDeleter` interface, an
  `isImplementDelegationWorktree` predicate, and
  `cleanupImplementDelegationWorktree`, which removes the worktree first then
  deletes the branch. It is idempotent (`os.Stat` + `BranchExists`
  short-circuit), best-effort, holds the checkout mutation lock, and detaches
  from a cancelled ctx so a run-timeout still disposes the worktree. A #332
  guard skips deleting a succeeded leg whose branch a sibling still depends on
  (a pending integration step would otherwise fail to merge it); failed/blocked
  legs are always cleaned.
- `internal/workflow/engine.go`: defer the cleanup in `AdvanceJob` so it fires
  on every terminal return path, right after the read-only cleanup defer.

## Tests

Added `internal/workflow/implement_worktree_cleanup_test.go` (plus a
`worktree_test.go` case) covering the predicate, worktree+branch removal with
the emitted event and idempotency, and the #332 integration-dep skip.

## Gate

Implement/fix gate: green. Review loop: reached CLEAN.

Closes #478

The review loop reached CLEAN.
