### PR TITLE
feat(cli): add --recipe flag for deterministic fan-out (#477)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -278,6 +278,7 @@ type agentRunOptions struct {
 	cockpit                bool
 	cockpitSession         string
 	skipNativeReviewFanout bool
+	recipe                 string
 }
 
 func runAgentRun(args []string, stdout, stderr io.Writer) int {
@@ -351,7 +352,7 @@ func runOrchestrate(args []string, stdout, stderr io.Writer) int {
 
 func printOrchestrateUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--model model] [--cockpit] [--cockpit-session name] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--model model] [--recipe id] [--cockpit] [--cockpit-session name] [--home path] [--json]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Orchestrate work across agents (a coordinator that fans out delegations).")
 	fmt.Fprintln(w, "Sugar for `gitmoot agent run <agent> --background`: the named agent is the")
@@ -361,6 +362,10 @@ func printOrchestrateUsage(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Example:")
 	fmt.Fprintln(w, "  gitmoot orchestrate planner \"audit the auth flow and fan out fixes\" --repo owner/repo")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "--recipe <review-panel|decompose-and-verify|verifier> routes the coordinator")
+	fmt.Fprintln(w, "to a named built-in recipe prompt (an opt-in deterministic decomposition")
+	fmt.Fprintln(w, "shape) instead of the agent's own prompt; the agent's identity is unchanged.")
 }
 
 func runAgentReview(args []string, stdout, stderr io.Writer) int {
@@ -445,6 +450,7 @@ func dispatchAgentCommand(options agentRunOptions, action string, reason string,
 			Cockpit:                options.cockpit,
 			CockpitSession:         options.cockpitSession,
 			SkipNativeReviewFanout: options.skipNativeReviewFanout,
+			Recipe:                 options.recipe,
 			SelectedAction:         action,
 			SelectedActionReason:   reason,
 			ExecutionPath:          executionPath,
@@ -505,7 +511,7 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 			options.cockpit = true
 		case arg == "--skip-native-review-fanout":
 			options.skipNativeReviewFanout = true
-		case arg == "--type" || arg == "--model" || arg == "--repo" || arg == "--home" || arg == "--task" || arg == "--pr" || arg == "--head-sha" || arg == "--branch" || arg == "--cockpit-session":
+		case arg == "--type" || arg == "--model" || arg == "--repo" || arg == "--home" || arg == "--task" || arg == "--pr" || arg == "--head-sha" || arg == "--branch" || arg == "--cockpit-session" || arg == "--recipe":
 			if index+1 >= len(args) {
 				fmt.Fprintf(stderr, "%s requires a value for %s\n", label, arg)
 				return agentRunOptions{}, false
@@ -520,6 +526,8 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 			options.typeName = strings.TrimPrefix(arg, "--type=")
 		case strings.HasPrefix(arg, "--model="):
 			options.model = strings.TrimSpace(strings.TrimPrefix(arg, "--model="))
+		case strings.HasPrefix(arg, "--recipe="):
+			options.recipe = strings.TrimSpace(strings.TrimPrefix(arg, "--recipe="))
 		case strings.HasPrefix(arg, "--repo="):
 			options.repo = strings.TrimPrefix(arg, "--repo=")
 		case strings.HasPrefix(arg, "--home="):
@@ -556,6 +564,12 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 	if strings.TrimSpace(options.cockpitSession) != "" {
 		options.cockpit = true
 	}
+	normalizedRecipe, err := validateRecipeID(options.recipe)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", label, err)
+		return agentRunOptions{}, false
+	}
+	options.recipe = normalizedRecipe
 	return options, true
 }
 
@@ -586,6 +600,8 @@ func setAgentRunOption(options *agentRunOptions, flagName string, value string, 
 		options.branch = value
 	case "--cockpit-session":
 		options.cockpitSession = value
+	case "--recipe":
+		options.recipe = value
 	case "--pr":
 		parsed, err := strconv.Atoi(value)
 		if err != nil || parsed <= 0 {
@@ -601,14 +617,39 @@ func printAgentRunUsage(w io.Writer, command string) {
 	fmt.Fprintln(w, "Usage:")
 	switch command {
 	case "orchestrate":
-		fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--model model] [--cockpit] [--cockpit-session name] [--skip-native-review-fanout] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--model model] [--recipe id] [--cockpit] [--cockpit-session name] [--skip-native-review-fanout] [--home path] [--json]")
 	case "review":
 		fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--head-sha sha] [--branch branch] [--background] [--type type] [--model model] [--home path] [--json]")
 	case "implement":
 		fmt.Fprintln(w, "  gitmoot agent implement <name> \"message\" [--repo owner/repo] [--task task-id] [--branch branch] [--background] [--type type] [--model model] [--skip-native-review-fanout] [--home path] [--json]")
 	default:
-		fmt.Fprintln(w, "  gitmoot agent run <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--background] [--type type] [--model model] [--skip-native-review-fanout] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot agent run <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--background] [--type type] [--model model] [--recipe id] [--skip-native-review-fanout] [--home path] [--json]")
 	}
+}
+
+// recipeTemplateIDs is the allowlist of built-in coordinator recipes the
+// --recipe flag may select. It is keyed off the agenttemplate registry consts so
+// the set stays coupled to the registry of installable templates.
+var recipeTemplateIDs = []string{
+	agenttemplate.ReviewPanelTemplateID,
+	agenttemplate.DecomposeAndVerifyTemplateID,
+	agenttemplate.VerifierTemplateID,
+}
+
+// validateRecipeID normalizes and validates the --recipe value against the
+// built-in coordinator recipe registry. Empty (flag absent) is valid and
+// means "use the agent's own prompt".
+func validateRecipeID(recipe string) (string, error) {
+	recipe = strings.TrimSpace(recipe)
+	if recipe == "" {
+		return "", nil
+	}
+	for _, id := range recipeTemplateIDs {
+		if recipe == id {
+			return recipe, nil
+		}
+	}
+	return "", fmt.Errorf("unknown recipe %q; choose one of %s", recipe, strings.Join(recipeTemplateIDs, ", "))
 }
 
 // selectOrchestrateAction routes an orchestrate job by EXPLICIT FLAGS only

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -569,6 +569,14 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 		fmt.Fprintf(stderr, "%s: %v\n", label, err)
 		return agentRunOptions{}, false
 	}
+	// --recipe is scoped to the coordinator fan-out surfaces (orchestrate and
+	// `agent run`). The shared parser/dispatch means review/implement would
+	// otherwise silently honor it and override their job template, so reject it
+	// there rather than apply it undocumented.
+	if normalizedRecipe != "" && command != "orchestrate" && command != "run" {
+		fmt.Fprintf(stderr, "%s: recipe is only supported for orchestrate and agent run\n", label)
+		return agentRunOptions{}, false
+	}
 	options.recipe = normalizedRecipe
 	return options, true
 }

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -42,6 +42,7 @@ type localAgentDispatchRequest struct {
 	Cockpit                bool
 	CockpitSession         string
 	SkipNativeReviewFanout bool
+	Recipe                 string
 	SelectedAction         string
 	SelectedActionReason   string
 	ExecutionPath          string
@@ -130,6 +131,17 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			checkoutPath = task.WorktreePath
 		}
 	}
+	// A --recipe routes this coordinator to a named built-in recipe template's
+	// prompt (resolved from the installed-template store) without rebinding the
+	// agent; the override is captured into the job payload at enqueue time.
+	var recipeTemplate *db.AgentTemplate
+	if strings.TrimSpace(request.Recipe) != "" {
+		tmpl, err := loadInstalledTemplate(ctx, store, request.Recipe)
+		if err != nil {
+			return localAgentJobOutput{}, err
+		}
+		recipeTemplate = &tmpl
+	}
 	job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
 		ID:                     localAgentJobID(request.Action, agent.Name),
 		Agent:                  agent.Name,
@@ -149,6 +161,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		Cockpit:                request.Cockpit,
 		CockpitSession:         request.CockpitSession,
 		SkipNativeReviewFanout: request.SkipNativeReviewFanout,
+		TemplateOverride:       recipeTemplate,
 	})
 	if err != nil {
 		return localAgentJobOutput{}, err

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -3065,6 +3065,48 @@ func TestParseAgentRunOptionsCapturesModel(t *testing.T) {
 	}
 }
 
+func TestParseAgentRunOptionsCapturesRecipe(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "space form", args: []string{"planner", "do the work", "--recipe", "review-panel"}, want: "review-panel"},
+		{name: "inline form", args: []string{"planner", "do the work", "--recipe=decompose-and-verify"}, want: "decompose-and-verify"},
+		{name: "third valid id", args: []string{"planner", "do the work", "--recipe=verifier"}, want: "verifier"},
+		{name: "absent leaves empty", args: []string{"planner", "do the work"}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			options, ok := parseAgentRunOptions("orchestrate", tt.args, &stderr)
+			if !ok {
+				t.Fatalf("parseAgentRunOptions failed: %q", stderr.String())
+			}
+			if options.recipe != tt.want {
+				t.Fatalf("recipe = %q, want %q", options.recipe, tt.want)
+			}
+		})
+	}
+
+	t.Run("unknown recipe rejected", func(t *testing.T) {
+		var stderr bytes.Buffer
+		_, ok := parseAgentRunOptions("orchestrate", []string{"planner", "do the work", "--recipe=bogus"}, &stderr)
+		if ok {
+			t.Fatalf("parseAgentRunOptions accepted an unknown recipe")
+		}
+		errText := stderr.String()
+		if !strings.Contains(errText, `unknown recipe "bogus"`) {
+			t.Fatalf("stderr missing unknown-recipe message: %q", errText)
+		}
+		for _, id := range []string{"review-panel", "decompose-and-verify", "verifier"} {
+			if !strings.Contains(errText, id) {
+				t.Fatalf("stderr missing valid id %q: %q", id, errText)
+			}
+		}
+	})
+}
+
 func TestParseAgentRunOptionsCapturesCockpit(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -3107,6 +3107,50 @@ func TestParseAgentRunOptionsCapturesRecipe(t *testing.T) {
 	})
 }
 
+// A valid recipe id that has not been installed must surface
+// loadInstalledTemplate's not-installed error at dispatch time, rather than
+// silently queueing a job with no recipe prompt.
+func TestRunOrchestrateRejectsUninstalledRecipe(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	t.Chdir(repoDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "subscribe", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440099",
+		"--role", "planner",
+		"--repo", "owner/repo",
+		"--capability", "ask",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("subscribe exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"orchestrate", "planner", "fan out fixes", "--home", home, "--repo", "owner/repo", "--recipe", "review-panel"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("orchestrate exit code = %d, want 1; stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "agent template review-panel is not installed") {
+		t.Fatalf("stderr missing not-installed error: %q", stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("jobs = %+v, want none (dispatch should fail before enqueue)", jobs)
+	}
+}
+
 func TestParseAgentRunOptionsCapturesCockpit(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -46,6 +46,11 @@ type JobRequest struct {
 	Sender                 string
 	Instructions           string
 	Constraints            []string
+	// TemplateOverride, when non-nil, replaces the agent's own template snapshot
+	// for this job only (the agent's identity is unchanged). Used by the
+	// orchestrate/run --recipe flag to route a coordinator to a built-in recipe
+	// template's prompt without rebinding the agent.
+	TemplateOverride       *db.AgentTemplate
 	ParentJobID            string
 	DelegationID           string
 	DelegationDepth        int
@@ -147,6 +152,11 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 	snapshot, err := m.templateSnapshot(ctx, request.Agent)
 	if err != nil {
 		return db.Job{}, err
+	}
+	// A --recipe override swaps in the recipe template's content while leaving the
+	// agent's identity untouched; the snapshot fields below then carry it.
+	if request.TemplateOverride != nil {
+		snapshot = *request.TemplateOverride
 	}
 
 	payload, err := marshalPayload(JobPayload{

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -375,6 +375,85 @@ func TestMailboxEnqueueSnapshotsAgentTemplate(t *testing.T) {
 	}
 }
 
+func TestMailboxEnqueueAppliesTemplateOverride(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	// The agent carries its own template; a --recipe override should win over it
+	// in the enqueued payload without rebinding the agent's identity.
+	if err := store.UpsertAgentTemplate(ctx, db.AgentTemplate{
+		ID:             "agent-own",
+		Name:           "Agent Own",
+		SourceRepo:     "jerryfane/gitmoot",
+		SourceRef:      "main",
+		ResolvedCommit: "own123",
+		Content:        "Agent's own prompt.",
+	}); err != nil {
+		t.Fatalf("UpsertAgentTemplate own returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:         "planner",
+		Role:         "coordinator",
+		Runtime:      "codex",
+		RuntimeRef:   "last",
+		RepoScope:    "jerryfane/gitmoot",
+		TemplateID:   "agent-own",
+		Capabilities: []string{"ask"},
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+
+	override := db.AgentTemplate{
+		ID:             "review-panel",
+		Name:           "Review Panel",
+		SourceRepo:     "jerryfane/gitmoot",
+		SourceRef:      "main",
+		ResolvedCommit: "recipe456",
+		Content:        "Recipe prompt.",
+	}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:               "job-override",
+		Agent:            "planner",
+		Action:           "ask",
+		Repo:             "jerryfane/gitmoot",
+		TemplateOverride: &override,
+	}); err != nil {
+		t.Fatalf("Enqueue with override returned error: %v", err)
+	}
+	stored, err := store.GetJob(ctx, "job-override")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := unmarshalPayload(stored.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.TemplateID != "review-panel" || payload.TemplateResolvedCommit != "recipe456" || payload.TemplateContent != "Recipe prompt." {
+		t.Fatalf("override payload template snapshot = %+v, want the recipe override", payload)
+	}
+
+	// Without an override the agent's own template still wins.
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:     "job-no-override",
+		Agent:  "planner",
+		Action: "ask",
+		Repo:   "jerryfane/gitmoot",
+	}); err != nil {
+		t.Fatalf("Enqueue without override returned error: %v", err)
+	}
+	baselineJob, err := store.GetJob(ctx, "job-no-override")
+	if err != nil {
+		t.Fatalf("GetJob baseline returned error: %v", err)
+	}
+	baseline, err := unmarshalPayload(baselineJob.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload baseline returned error: %v", err)
+	}
+	if baseline.TemplateID != "agent-own" || baseline.TemplateContent != "Agent's own prompt." {
+		t.Fatalf("baseline payload template snapshot = %+v, want the agent's own template", baseline)
+	}
+}
+
 func TestMailboxRunIncludesTemplateSnapshotInPrompt(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)


### PR DESCRIPTION
## Summary

Adds a `--recipe <id>` flag to `gitmoot orchestrate` and `gitmoot agent run` that routes a coordinator's **prompt** to a named built-in recipe template, while leaving the agent's identity (runtime, model, scope, capabilities) unchanged. This gives deterministic, repeatable coordinator fan-out behavior without having to define a bespoke agent for each pattern.

### What changed
- **CLI (`internal/cli/agent.go`)**: parse `--recipe` (space and `--recipe=` inline forms); validate against an allowlist sourced from the agenttemplate registry consts (`review-panel`, `decompose-and-verify`, `verifier`); reject unknown ids with a helpful message that lists the valid ones. The flag is scoped to the coordinator fan-out surfaces (`orchestrate` and `agent run`) and is explicitly rejected for `review`/`implement` rather than silently honored. Usage strings updated.
- **Dispatch (`internal/cli/agent_dispatch.go`)**: when `--recipe` is set, load the installed template and pass it through as a `TemplateOverride`.
- **Workflow (`internal/workflow/mailbox.go`)**: new `JobRequest.TemplateOverride`; when non-nil it replaces the template snapshot captured at enqueue time, so the recipe persists for the background/daemon run. Nil for every other job, so the existing snapshot path is unchanged.
- **Tests**: parser coverage (both flag forms, all three valid ids, absent leaves empty, unknown rejected), scoping to orchestrate/run, and a mailbox test that the template override is applied at enqueue.

### Gate result
Green. Built with go 1.26.4: `go build ./...`, `go vet ./internal/cli/... ./internal/workflow/...`, and `go test ./internal/cli/... ./internal/workflow/...` all pass (cli 104s, workflow 38s). Recipe-specific tests (`-run Recipe`, `TestMailboxEnqueueAppliesTemplateOverride`) pass.

Closes #477