### PR TITLE
Deterministic checkers as objective auto-trace dimensions (#485)

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -273,6 +273,52 @@ manual (the harvester writes only `eval_runs` / `eval_review_items` /
 subject to the configurable `[skillopt].auto_promote` policy (#463) when that
 lands — weighted-low + judge-tagged, **not** barred from promotion.
 
+### Deterministic checker objective signal (off by default)
+
+Setting **both** `[skillopt].auto_trace_enabled = true` **and**
+`[skillopt].deterministic_checkers_enabled = true` (both default `false`) adds an
+**OBJECTIVE, non-LLM** checker leg on every merge — the tool-measured complement to
+the subjective cross-family review. Where the review asks an LLM to *estimate*
+quality, the checker runs plain external **tools** that *measure* it exactly:
+
+- **`diff_size`** — pure-Go, **always available** (no tool, no checkout): parses the
+  PR file patches, counts changed `+/-` hunk lines + changed files, and normalizes
+  against a soft cap so a tight diff scores ~`1.0` and a larger-than-budget one
+  scores lower. It is the one dimension that is never a no-op on a tool-less host.
+- **`duplication`** — code-clone count via `dupl` (else `jscpd`).
+- **`lint`** — issue count via `golangci-lint`.
+- **`complexity`** — over-threshold function count via `gocyclo`.
+
+Each tool dimension is normalized to `[0,1]` (fewer issues → higher). The optional
+`[skillopt].deterministic_checkers` comma list selects which run (default:
+`diff_size` only); widen it to opt heavy tools in. The dimensions map to
+`dimension_scores`, are fused by the **mean-of-dimensions** path, and are written as
+a **third** `FeedbackEvent` in the SAME `auto-trace:<version>` run under a distinct
+item id (`checker#<repo>#<pr>`) and the fixed `gitmoot-checker` reviewer sentinel —
+so it **coexists with** (never overwrites) both the verifiable floor (`gitmoot-auto`,
+`repo#pr`) and the cross-family review (`gitmoot-review`, `review#<repo>#<pr>`) under
+the run's UNIQUE `(run_id,item_id,reviewer,source,source_url)` key. A re-evaluation
+re-upserts the SAME checker row in place (stable row count). The checker eval item
+carries `objective = true`, the projected `checker_score`, and the per-dimension
+`dimension_scores`, while the run keeps `feedback_source = automatic_trace` —
+additive, **no new contract field, `contract_version` stays `1`**.
+
+These dimensions are **objective and un-gameable**, so the export/optimizer weights
+them distinctly from the subjective judge row via the `gitmoot-checker` sentinel +
+the `objective` item tag. The leg runs **off the blocking merge path** (detached,
+timeout-bounded) and is **fail-safe throughout**: a missing tool binary
+(`LookPath` miss), no PR-head checkout, a tool error, or a timeout **SKIPS that one
+dimension** (no row for it) and never errors the harvest, blocks the merge, or
+stalls `AdvanceJob`. An all-skipped run yields an empty rubric ⇒ **no checker row**.
+A dispatch failure records a `deterministic_checkers_failed` job event and is
+swallowed. Promotion stays manual (the leg writes only `eval_runs` /
+`eval_review_items` / `feedback_events`).
+
+> Note: the merge-gate path holds the daemon's own checkout, not a working tree at
+> the PR head, so the tool-backed dimensions are effectively produced only when such
+> a checkout happens to be available; `diff_size` always runs. Plumbing a PR-head
+> worktree through to the tool runners is a documented follow-on.
+
 ### Promotion policy + notifications (off by default)
 
 When a candidate becomes **pending** (after `skillopt import` or `train

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3997,6 +3997,17 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// no config NO review leg runs and NO review row is written — byte-identical.
 		// A review-leg failure never blocks or fails a job; promotion stays manual.
 		ReviewLegDispatcher: daemonReviewLegDispatcher(store, gh, checkout, home),
+		// Off-by-default OBJECTIVE deterministic-checker signal (#485): on a MERGE the
+		// engine additionally runs a best-effort, DETACHED leg of plain external tools
+		// (duplication/lint/complexity) + a pure-Go diff-size metric whose tool-derived
+		// [0,1] dimensions are projected into a THIRD, objective-tagged FeedbackEvent in
+		// the SAME auto-trace run, distinct from the verifiable floor and the subjective
+		// review. daemonDeterministicCheckerDispatcher returns nil unless BOTH
+		// [skillopt].deterministic_checkers_enabled AND auto_trace_enabled are set, so
+		// with no config NO checker leg runs and NO checker row is written —
+		// byte-identical. A missing tool/checkout/timeout SKIPS that dimension and never
+		// blocks or fails the merge; promotion stays manual.
+		DeterministicCheckerDispatcher: daemonDeterministicCheckerDispatcher(store, gh, checkout, home),
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},

--- a/internal/cli/deterministic_checkers.go
+++ b/internal/cli/deterministic_checkers.go
@@ -197,31 +197,47 @@ func diffSizeNormalize(changedLines int) float64 {
 // duplicationScore runs the code-duplication tool (dupl, else jscpd) against the
 // checkout and normalizes its reported duplicate count to [0,1] (#485). It
 // DEGRADE-SKIPS (ok=false) when no checkout is available, neither tool binary is on
-// PATH, or the tool errors/times out — so a tool-less host omits the dimension
-// rather than failing.
+// PATH, or the tool truly failed (errored with no usable output) — so a tool-less
+// host omits the dimension rather than failing.
+//
+// CRITICAL (#485 review): jscpd (and some dupl wrappers) exit NON-ZERO precisely
+// when duplication EXCEEDS a threshold — i.e. exactly when there ARE clones to
+// report, which is the signal the metric exists to capture. subprocess.Run returns a
+// non-nil error for any non-zero exit, so blanket-skipping on err!=nil would drop
+// the dimension on the WORST diffs and keep it (scoring 1.0) only on clean ones,
+// biasing the objective upward. Instead we treat parseable stdout as a real signal
+// regardless of exit code, and only SKIP when the run produced no usable output AND
+// errored (binary crash / context timeout).
 func (d *deterministicCheckerDispatcher) duplicationScore(ctx context.Context) (float64, bool) {
 	if strings.TrimSpace(d.checkout) == "" || d.runner == nil {
 		return 0, false
 	}
 	// Prefer dupl; fall back to jscpd. The leg only needs a clones COUNT, which both
-	// can report; absence/err => SKIP.
-	if tool, ok := d.firstAvailable("dupl", "jscpd"); ok {
-		var args []string
-		switch tool {
-		case "dupl":
-			args = []string{"-plumbing", "."}
-		case "jscpd":
-			args = []string{"--silent", "."}
-		}
-		res, err := d.runner.Run(ctx, d.checkout, tool, args...)
+	// can report; absence => SKIP.
+	tool, ok := d.firstAvailable("dupl", "jscpd")
+	if !ok {
+		return 0, false
+	}
+	var args []string
+	switch tool {
+	case "dupl":
+		args = []string{"-plumbing", "."}
+	case "jscpd":
+		args = []string{"--silent", "."}
+	}
+	res, err := d.runner.Run(ctx, d.checkout, tool, args...)
+	out := strings.TrimSpace(res.Stdout)
+	if out == "" {
+		// No usable output: a real failure (err) SKIPS; a genuinely clean exit with no
+		// clones scores 1.0.
 		if err != nil {
-			// A non-zero exit OR a real run error degrades to SKIP: we never trust a
-			// partial/garbled output to fabricate a score.
 			return 0, false
 		}
-		return duplicationNormalize(countNonEmptyLines(res.Stdout)), true
+		return 1.0, true
 	}
-	return 0, false
+	// Parseable clone listing (one clone/finding per line) is a real signal even when
+	// the tool exits non-zero to flag "duplication found".
+	return duplicationNormalize(countNonEmptyLines(out)), true
 }
 
 // duplicationNormalize maps a reported duplicate-clone count to [0,1]: zero clones
@@ -240,11 +256,20 @@ func duplicationNormalize(clones int) float64 {
 
 // lintScore runs golangci-lint against the checkout and normalizes the issue count
 // to [0,1] (#485). It DEGRADE-SKIPS (ok=false) when no checkout is available, the
-// binary is absent, or the run errors — never failing the leg on a tool-less host.
+// binary is absent, or the tool truly failed (errored with no usable output) — never
+// failing the leg on a tool-less host.
 //
-// golangci-lint exits non-zero WHEN it finds issues, which is NOT a tool error: we
-// still parse the issue count from its output, so a non-zero exit with parseable
-// output is a real signal, while an unparseable result degrades to SKIP.
+// CRITICAL (#485 review): golangci-lint exits non-zero for TWO distinct reasons:
+//  1. it FOUND lint issues (exit 1, with the issues on stdout), and
+//  2. a genuine tool FAILURE (a compile/typecheck error in the tree, an invalid
+//     .golangci.yml, an OOM/panic, an incompatible flag, or a context timeout —
+//     exit >=2 with the diagnostic on stderr and STDOUT empty).
+//
+// We must NOT swallow case 2 and fabricate a perfect 1.0 "clean lint" signal from a
+// linter that never actually linted (that violates DEGRADE-GRACEFULLY and corrupts
+// the objective auto-trace dimension). So we honor the error: parseable stdout is a
+// real issue-count signal regardless of exit code, an empty stdout with NO error is a
+// genuinely clean lint (1.0), and an empty/unparseable stdout WITH an error SKIPS.
 func (d *deterministicCheckerDispatcher) lintScore(ctx context.Context) (float64, bool) {
 	if strings.TrimSpace(d.checkout) == "" || d.runner == nil {
 		return 0, false
@@ -253,13 +278,19 @@ func (d *deterministicCheckerDispatcher) lintScore(ctx context.Context) (float64
 		return 0, false
 	}
 	// `run` prints one issue per line; we count non-empty output lines as a coarse
-	// issue count. The exit code is ignored (non-zero just means issues were found).
-	res, _ := d.runner.Run(ctx, d.checkout, "golangci-lint", "run")
+	// issue count.
+	res, err := d.runner.Run(ctx, d.checkout, "golangci-lint", "run")
 	out := strings.TrimSpace(res.Stdout)
 	if out == "" {
-		// No issues reported: a clean lint scores 1.0.
+		// No usable output: a real failure (err) SKIPS rather than fabricating a 1.0;
+		// a clean run (no err, no issues) scores 1.0.
+		if err != nil {
+			return 0, false
+		}
 		return 1.0, true
 	}
+	// Non-empty parseable output: a real issue count even if the exit was non-zero
+	// (non-zero merely flags "issues found").
 	return lintNormalize(countNonEmptyLines(out)), true
 }
 
@@ -280,7 +311,16 @@ func lintNormalize(issues int) float64 {
 // complexityScore runs the cyclomatic-complexity tool (gocyclo) against the checkout
 // and normalizes the over-threshold function count to [0,1] (#485). It
 // DEGRADE-SKIPS (ok=false) when no checkout is available, the binary is absent, or
-// the run errors.
+// the tool truly failed (errored with no usable output).
+//
+// CRITICAL (#485 review): `gocyclo -over 15` exits NON-ZERO precisely WHEN
+// over-threshold functions exist — i.e. exactly the case the complexity dimension
+// exists to penalize. subprocess.Run returns a non-nil error for that non-zero exit,
+// so blanket-skipping on err!=nil would emit the dimension ONLY on a clean tree
+// (scoring 1.0) and drop it whenever there is real complexity to flag — silently
+// inverting the metric. Instead the function list on stdout is the signal of truth:
+// parse it regardless of exit code, and only SKIP when the run produced no usable
+// output AND errored (binary crash / context timeout).
 func (d *deterministicCheckerDispatcher) complexityScore(ctx context.Context) (float64, bool) {
 	if strings.TrimSpace(d.checkout) == "" || d.runner == nil {
 		return 0, false
@@ -289,12 +329,21 @@ func (d *deterministicCheckerDispatcher) complexityScore(ctx context.Context) (f
 		return 0, false
 	}
 	// `gocyclo -over 15 .` lists every function whose complexity exceeds 15, one per
-	// line; an empty list means no over-threshold function. A run error => SKIP.
+	// line, and exits non-zero when that list is non-empty; an empty list means no
+	// over-threshold function.
 	res, err := d.runner.Run(ctx, d.checkout, "gocyclo", "-over", "15", ".")
-	if err != nil {
-		return 0, false
+	out := strings.TrimSpace(res.Stdout)
+	if out == "" {
+		// No usable output: a real failure (err) SKIPS; a clean tree (no err, no
+		// over-threshold functions) scores 1.0.
+		if err != nil {
+			return 0, false
+		}
+		return 1.0, true
 	}
-	return complexityNormalize(countNonEmptyLines(res.Stdout)), true
+	// The over-threshold function listing is a real signal even though gocyclo exits
+	// non-zero to flag that such functions exist.
+	return complexityNormalize(countNonEmptyLines(out)), true
 }
 
 // complexityNormalize maps the over-threshold function count to [0,1]: none is best

--- a/internal/cli/deterministic_checkers.go
+++ b/internal/cli/deterministic_checkers.go
@@ -1,0 +1,362 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// Checker names recognized by the deterministic-checker dispatcher (#485). They
+// match the [skillopt].deterministic_checkers selector values. diff_size is pure-Go
+// and ALWAYS available; the rest are tool-backed and DEGRADE-SKIP when their binary
+// or a PR-head checkout is absent.
+const (
+	checkerDiffSize    = "diff_size"
+	checkerDuplication = "duplication"
+	checkerLint        = "lint"
+	checkerComplexity  = "complexity"
+)
+
+// checkerDiffSizeSoftCapLines is the changed-line soft cap the diff-size metric
+// normalizes against (#485): a diff at or below it scores ~1.0 (tight, easy to
+// review); a larger diff scores lower toward 0 as it grows. It is a coarse,
+// host-relative quality prior (a smaller, more contained change is preferable), so
+// the optimizer weights this objective-but-soft dimension accordingly.
+const checkerDiffSizeSoftCapLines = 400
+
+// diffFileLister is the minimal read the diff-size metric needs (github.Client
+// satisfies it): list the PR's changed files + their unified-diff patches at HEAD.
+// It is its own narrow interface so the dispatcher is unit-testable with a stub and
+// so the read is provably read-only (the same seam the #469 review diff uses).
+type diffFileLister interface {
+	ListPullRequestFiles(ctx context.Context, repo github.Repository, number int64) ([]github.PullRequestFile, error)
+}
+
+// deterministicCheckerDispatcher is the concrete workflow.DeterministicCheckerDispatcher
+// (#485): it computes a pure-Go diff-size dimension from the PR file patches and
+// runs degrade-graceful external-tool dimensions (duplication via dupl/jscpd, lint
+// via golangci-lint, cyclomatic complexity via gocyclo) against a working tree when
+// one is available, normalizes each to [0,1], and returns an
+// Outcome{Kind:OutcomeReviewed, Objective:true} for the engine to harvest into the
+// SAME auto-trace run as a THIRD coexisting OBJECTIVE signal. Every dimension is
+// best-effort: a missing tool binary (LookPath miss), no checkout, or a tool
+// error/timeout SKIPS that ONE dimension (it is omitted from the Rubric) and the
+// leg proceeds with whatever survives — NEVER an error, NEVER a blocked merge. An
+// all-skipped run yields an empty Rubric => ok=false => no checker row.
+type deterministicCheckerDispatcher struct {
+	store    *db.Store
+	diff     diffFileLister
+	runner   subprocess.Runner
+	checkout string
+	// checkers is the resolved per-checker selector (already defaulted to the safe
+	// set by the daemon constructor). Only the listed checkers run.
+	checkers []string
+}
+
+var _ workflow.DeterministicCheckerDispatcher = (*deterministicCheckerDispatcher)(nil)
+
+// Check runs the selected deterministic checkers for a just-merged implement job
+// and returns their objective tool dimensions (#485). ok=false means NO dimension
+// was producible at all (every checker skipped), so the engine writes no checker
+// row. It NEVER mutates the merge: it reads the diff read-only and runs read-only
+// tools, returning a value the engine harvests into the auto-trace run.
+func (d *deterministicCheckerDispatcher) Check(ctx context.Context, implementJob db.Job, implementPayload workflow.JobPayload, mergedHead string) (workflow.Outcome, bool, error) {
+	rubric := map[string]float64{}
+	ran := make([]string, 0, len(d.checkers))
+
+	for _, name := range d.checkers {
+		score, ok := d.runChecker(ctx, strings.TrimSpace(name), implementPayload)
+		if !ok {
+			// DEGRADE-SKIP: the tool is absent, no checkout, or it errored/timed out.
+			// Omit the dimension and proceed; never fail the leg.
+			continue
+		}
+		rubric[name] = clampUnitChecker(score)
+		ran = append(ran, name)
+	}
+
+	if len(rubric) == 0 {
+		// Every checker skipped: nothing producible. ok=false => no checker row (the
+		// harvester would skip an empty rubric anyway, but skipping here avoids the
+		// store round-trip entirely).
+		return workflow.Outcome{}, false, nil
+	}
+
+	sort.Strings(ran)
+	findings := fmt.Sprintf("Deterministic checkers on PR #%d: %s.", implementPayload.PullRequest, strings.Join(ran, ", "))
+
+	return workflow.Outcome{
+		Kind:        workflow.OutcomeReviewed,
+		Objective:   true,
+		Repo:        implementPayload.Repo,
+		PullRequest: implementPayload.PullRequest,
+		HeadSHA:     mergedHead,
+		Rubric:      rubric,
+		Findings:    findings,
+	}, true, nil
+}
+
+// runChecker dispatches one named checker and returns its [0,1] score. ok=false
+// means SKIP (omit the dimension): an unknown name, a missing tool, no checkout, or
+// a tool error/timeout — all degrade to skip, never an error.
+func (d *deterministicCheckerDispatcher) runChecker(ctx context.Context, name string, payload workflow.JobPayload) (float64, bool) {
+	switch name {
+	case checkerDiffSize:
+		// Pure-Go, always available: no tool, no checkout needed.
+		return d.diffSizeScore(ctx, payload)
+	case checkerDuplication:
+		return d.duplicationScore(ctx)
+	case checkerLint:
+		return d.lintScore(ctx)
+	case checkerComplexity:
+		return d.complexityScore(ctx)
+	default:
+		// Unknown checker name (typo / unsupported): ignore, best-effort.
+		return 0, false
+	}
+}
+
+// diffSizeScore computes the pure-Go diff-size dimension from the GitHub PR file
+// patches (#485): it counts changed (+/-) hunk lines across every file's unified
+// diff and the number of changed files, then normalizes the total changed lines
+// against checkerDiffSizeSoftCapLines so a tight diff scores ~1.0 and a
+// larger-than-cap diff scores lower toward 0. It has NO external tool and NO
+// checkout dependency, so it ALWAYS produces a dimension when the PR file read
+// succeeds — the one always-available objective signal. A failed read or no PR
+// degrades to SKIP (ok=false) so a malformed read is never scored.
+func (d *deterministicCheckerDispatcher) diffSizeScore(ctx context.Context, payload workflow.JobPayload) (float64, bool) {
+	if d.diff == nil || payload.PullRequest <= 0 {
+		return 0, false
+	}
+	repo, ok := parseCheckerRepo(payload.Repo)
+	if !ok {
+		return 0, false
+	}
+	files, err := d.diff.ListPullRequestFiles(ctx, repo, int64(payload.PullRequest))
+	if err != nil {
+		return 0, false
+	}
+	changedLines := 0
+	for _, file := range files {
+		changedLines += countPatchChangedLines(file.Patch)
+	}
+	return diffSizeNormalize(changedLines), true
+}
+
+// countPatchChangedLines counts the added/removed lines in a unified-diff patch:
+// lines beginning with a single '+' or '-' that are NOT the '+++'/'---' file
+// headers and NOT an '@@' hunk header. It parses the patch TEXT because
+// github.PullRequestFile carries no additions/deletions integers (only the Patch
+// string) — so the metric is derived purely from the diff body.
+func countPatchChangedLines(patch string) int {
+	if strings.TrimSpace(patch) == "" {
+		return 0
+	}
+	count := 0
+	for _, line := range strings.Split(patch, "\n") {
+		if line == "" {
+			continue
+		}
+		// Skip the file headers (+++ / ---) and hunk headers (@@ ... @@).
+		if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") || strings.HasPrefix(line, "@@") {
+			continue
+		}
+		switch line[0] {
+		case '+', '-':
+			count++
+		}
+	}
+	return count
+}
+
+// diffSizeNormalize maps a changed-line count to a [0,1] score: at or below the soft
+// cap scores 1.0 (tight, contained diff), and beyond it decays linearly toward 0 as
+// the diff grows to twice the cap, flooring at 0. The mapping is intentionally
+// coarse + bucketed (a host-relative soft prior, not a hard gate) so the objective
+// row stays reproducible enough to be useful while the optimizer weights it as a
+// soft signal.
+func diffSizeNormalize(changedLines int) float64 {
+	if changedLines <= checkerDiffSizeSoftCapLines {
+		return 1.0
+	}
+	over := changedLines - checkerDiffSizeSoftCapLines
+	// Decay across one more cap's worth of lines down to 0.
+	score := 1.0 - float64(over)/float64(checkerDiffSizeSoftCapLines)
+	if score < 0 {
+		return 0
+	}
+	return score
+}
+
+// duplicationScore runs the code-duplication tool (dupl, else jscpd) against the
+// checkout and normalizes its reported duplicate count to [0,1] (#485). It
+// DEGRADE-SKIPS (ok=false) when no checkout is available, neither tool binary is on
+// PATH, or the tool errors/times out — so a tool-less host omits the dimension
+// rather than failing.
+func (d *deterministicCheckerDispatcher) duplicationScore(ctx context.Context) (float64, bool) {
+	if strings.TrimSpace(d.checkout) == "" || d.runner == nil {
+		return 0, false
+	}
+	// Prefer dupl; fall back to jscpd. The leg only needs a clones COUNT, which both
+	// can report; absence/err => SKIP.
+	if tool, ok := d.firstAvailable("dupl", "jscpd"); ok {
+		var args []string
+		switch tool {
+		case "dupl":
+			args = []string{"-plumbing", "."}
+		case "jscpd":
+			args = []string{"--silent", "."}
+		}
+		res, err := d.runner.Run(ctx, d.checkout, tool, args...)
+		if err != nil {
+			// A non-zero exit OR a real run error degrades to SKIP: we never trust a
+			// partial/garbled output to fabricate a score.
+			return 0, false
+		}
+		return duplicationNormalize(countNonEmptyLines(res.Stdout)), true
+	}
+	return 0, false
+}
+
+// duplicationNormalize maps a reported duplicate-clone count to [0,1]: zero clones
+// is best (1.0), and the score decays as clones accumulate (bucketed, host-relative).
+func duplicationNormalize(clones int) float64 {
+	if clones <= 0 {
+		return 1.0
+	}
+	// Each clone costs a fixed fraction; floor at 0 for heavily-duplicated diffs.
+	score := 1.0 - float64(clones)*0.1
+	if score < 0 {
+		return 0
+	}
+	return score
+}
+
+// lintScore runs golangci-lint against the checkout and normalizes the issue count
+// to [0,1] (#485). It DEGRADE-SKIPS (ok=false) when no checkout is available, the
+// binary is absent, or the run errors — never failing the leg on a tool-less host.
+//
+// golangci-lint exits non-zero WHEN it finds issues, which is NOT a tool error: we
+// still parse the issue count from its output, so a non-zero exit with parseable
+// output is a real signal, while an unparseable result degrades to SKIP.
+func (d *deterministicCheckerDispatcher) lintScore(ctx context.Context) (float64, bool) {
+	if strings.TrimSpace(d.checkout) == "" || d.runner == nil {
+		return 0, false
+	}
+	if _, err := d.runner.LookPath("golangci-lint"); err != nil {
+		return 0, false
+	}
+	// `run` prints one issue per line; we count non-empty output lines as a coarse
+	// issue count. The exit code is ignored (non-zero just means issues were found).
+	res, _ := d.runner.Run(ctx, d.checkout, "golangci-lint", "run")
+	out := strings.TrimSpace(res.Stdout)
+	if out == "" {
+		// No issues reported: a clean lint scores 1.0.
+		return 1.0, true
+	}
+	return lintNormalize(countNonEmptyLines(out)), true
+}
+
+// lintNormalize maps a lint-issue count to [0,1]: zero issues is best (1.0), more
+// issues decay the score (bucketed, host/version-relative — different linter
+// versions may differ, which is why this is weighted as a soft objective prior).
+func lintNormalize(issues int) float64 {
+	if issues <= 0 {
+		return 1.0
+	}
+	score := 1.0 - float64(issues)*0.05
+	if score < 0 {
+		return 0
+	}
+	return score
+}
+
+// complexityScore runs the cyclomatic-complexity tool (gocyclo) against the checkout
+// and normalizes the over-threshold function count to [0,1] (#485). It
+// DEGRADE-SKIPS (ok=false) when no checkout is available, the binary is absent, or
+// the run errors.
+func (d *deterministicCheckerDispatcher) complexityScore(ctx context.Context) (float64, bool) {
+	if strings.TrimSpace(d.checkout) == "" || d.runner == nil {
+		return 0, false
+	}
+	if _, err := d.runner.LookPath("gocyclo"); err != nil {
+		return 0, false
+	}
+	// `gocyclo -over 15 .` lists every function whose complexity exceeds 15, one per
+	// line; an empty list means no over-threshold function. A run error => SKIP.
+	res, err := d.runner.Run(ctx, d.checkout, "gocyclo", "-over", "15", ".")
+	if err != nil {
+		return 0, false
+	}
+	return complexityNormalize(countNonEmptyLines(res.Stdout)), true
+}
+
+// complexityNormalize maps the over-threshold function count to [0,1]: none is best
+// (1.0), more over-complex functions decay the score (bucketed, host-relative).
+func complexityNormalize(overThreshold int) float64 {
+	if overThreshold <= 0 {
+		return 1.0
+	}
+	score := 1.0 - float64(overThreshold)*0.1
+	if score < 0 {
+		return 0
+	}
+	return score
+}
+
+// firstAvailable returns the first of the given tool names found on PATH via the
+// runner's LookPath, so the dispatcher can prefer one tool and fall back to another.
+// ok=false when none is available (DEGRADE-SKIP).
+func (d *deterministicCheckerDispatcher) firstAvailable(names ...string) (string, bool) {
+	if d.runner == nil {
+		return "", false
+	}
+	for _, name := range names {
+		if _, err := d.runner.LookPath(name); err == nil {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// countNonEmptyLines counts the non-blank lines in tool output, a coarse proxy for
+// the issue/clone/function count tools emit one-per-line.
+func countNonEmptyLines(out string) int {
+	count := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// clampUnitChecker clamps a normalized checker score to [0,1] so a metric that
+// returns an out-of-range value cannot push the projected mean outside the contract
+// range.
+func clampUnitChecker(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+// parseCheckerRepo splits an "owner/name" repo into a github.Repository for the
+// diff-size file read. It reports ok=false for a malformed repo (so the metric
+// degrades to SKIP rather than panicking), mirroring parseReviewRepo.
+func parseCheckerRepo(value string) (github.Repository, bool) {
+	owner, name, ok := strings.Cut(strings.TrimSpace(value), "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return github.Repository{}, false
+	}
+	return github.Repository{Owner: owner, Name: name}, true
+}

--- a/internal/cli/deterministic_checkers_integration_test.go
+++ b/internal/cli/deterministic_checkers_integration_test.go
@@ -1,0 +1,248 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestDeterministicCheckerFullChain is the FULL-CHAIN integration test for #485. It
+// drives a real workflow.Engine through AdvanceJob to a MERGE, where the engine
+// dispatches the OBJECTIVE deterministic-checker leg (a real
+// deterministicCheckerDispatcher whose diff reader returns canned PR patches so
+// diff_size is deterministic and whose tool runners all LookPath-miss so only
+// diff_size is produced), the engine derives Outcome{Kind:OutcomeReviewed,
+// Objective:true}, and the REAL skillopt.OutcomeHarvester writes a THIRD coexisting
+// objective FeedbackEvent (gitmoot-checker) into the SAME auto-trace:<versionID> run
+// alongside the verifiable floor (gitmoot-auto) — with NO live LLM and NO live
+// GitHub. Everything between AdvanceJob and the persisted rows is production code.
+//
+// It pins the invariants: the checker leg never blocks the job (the merge still
+// happens), no candidate/promotion row is written (manual promotion preserved), the
+// floor row coexists with the checker row under a distinct item id, and the objective
+// dimension lands in the checker item metadata.
+func TestDeterministicCheckerFullChain(t *testing.T) {
+	ctx := context.Background()
+	store := openTraceChainStore(t)
+	version := installChainTemplate(t, store, "planner")
+	gate := &stubMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine := chainEngine(store, gate)
+
+	// The real harvester (built through the daemon construction path) AND a real
+	// deterministic-checker dispatcher: diff_size from canned patches, tool runners
+	// all LookPath-miss (so only diff_size is produced).
+	engine.OutcomeHarvester = enabledHarvesterFor(t, store, harvestGitHubStub{status: realCIChainStatus()})
+	engine.DeterministicCheckerDispatcher = &deterministicCheckerDispatcher{
+		store:    store,
+		diff:     checkerDiffStub{files: smallDiffFiles()},
+		runner:   &fakeCheckerRunner{present: map[string]bool{}}, // nothing installed
+		checkout: t.TempDir(),
+		checkers: []string{checkerDiffSize, checkerDuplication, checkerLint, checkerComplexity},
+	}
+
+	seedCodexImplementJob(t, store, version)
+	seedChainApprovingReview(t, store, "head123")
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	events := autoTraceFeedback(t, store, version.ID)
+	// The verifiable floor (gitmoot-auto) AND the objective checker (gitmoot-checker).
+	if len(events) != 2 {
+		t.Fatalf("expected the floor + checker row (2), got %d: %+v", len(events), events)
+	}
+	var floor, checker *db.FeedbackEvent
+	for i := range events {
+		switch events[i].Reviewer {
+		case "gitmoot-auto":
+			floor = &events[i]
+		case "gitmoot-checker":
+			checker = &events[i]
+		}
+	}
+	if floor == nil {
+		t.Fatalf("verifiable floor row missing; got %+v", events)
+	}
+	if checker == nil {
+		t.Fatalf("objective checker row missing; got %+v", events)
+	}
+	// Distinct item ids: the checker row never overwrote the floor.
+	if floor.ItemID == checker.ItemID {
+		t.Fatalf("floor and checker share item id %q (checker overwrote the floor)", floor.ItemID)
+	}
+	if checker.ItemID != "checker#jerryfane/gitmoot#7" {
+		t.Fatalf("checker item id = %q, want checker#jerryfane/gitmoot#7", checker.ItemID)
+	}
+
+	// The checker item carries objective=true and the deterministic diff_size
+	// dimension in its per-dimension metadata; the tool dims (LookPath-missed) are
+	// absent.
+	items, err := store.ListEvalReviewItems(ctx, "auto-trace:"+version.ID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	var meta map[string]any
+	for _, item := range items {
+		if item.ItemID == checker.ItemID {
+			if err := json.Unmarshal([]byte(item.MetadataJSON), &meta); err != nil {
+				t.Fatalf("checker item metadata unmarshal: %v", err)
+			}
+		}
+	}
+	if meta == nil || meta["objective"] != true {
+		t.Fatalf("checker item must be objective=true, got %v", meta)
+	}
+	dims, _ := meta["dimension_scores"].(map[string]any)
+	if dims == nil || dims["diff_size"] != 1.0 {
+		t.Fatalf("checker item must carry the deterministic diff_size=1.0 dimension, got %v", meta["dimension_scores"])
+	}
+	if _, present := dims["lint"]; present {
+		t.Fatalf("a LookPath-missed tool dim must be absent, got %v", dims)
+	}
+
+	// The merge still happened (the checker never blocked the job).
+	if len(gate.requests) != 1 {
+		t.Fatalf("merge gate requests = %d, want 1 (the merge runs regardless of the checker)", len(gate.requests))
+	}
+
+	// Manual promotion preserved: only the single installed version still exists.
+	versions, err := store.ListAgentTemplateVersions(ctx, version.TemplateID)
+	if err != nil {
+		t.Fatalf("ListAgentTemplateVersions returned error: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("the checker must create NO new template version (manual promotion), got %d", len(versions))
+	}
+}
+
+// TestDeterministicCheckerOffByDefault: with deterministic_checkers_enabled UNSET,
+// daemonDeterministicCheckerDispatcher returns nil through the SAME gate, so the
+// engine dispatches no checker leg and writes ONLY the verifiable floor row (the
+// checker is byte-identically absent — the BYTE-IDENTICAL guard).
+func TestDeterministicCheckerOffByDefault(t *testing.T) {
+	ctx := context.Background()
+	store := openTraceChainStore(t)
+	version := installChainTemplate(t, store, "planner")
+	gate := &stubMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine := chainEngine(store, gate)
+	engine.OutcomeHarvester = enabledHarvesterFor(t, store, harvestGitHubStub{status: realCIChainStatus()})
+
+	// auto_trace on but deterministic_checkers OFF: the dispatcher must be nil.
+	root := writeHarvestConfig(t, "[skillopt]\nauto_trace_enabled = true\n")
+	if d := daemonDeterministicCheckerDispatcher(store, harvestGitHubStub{}, "", root); d != nil {
+		t.Fatalf("off-by-default: checker dispatcher must be nil, got %T", d)
+	}
+	// Leave engine.DeterministicCheckerDispatcher nil (what the daemon would wire).
+
+	seedCodexImplementJob(t, store, version)
+	seedChainApprovingReview(t, store, "head123")
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	events := autoTraceFeedback(t, store, version.ID)
+	if len(events) != 1 {
+		t.Fatalf("off-by-default must write only the floor row, got %d: %+v", len(events), events)
+	}
+	if events[0].Reviewer != "gitmoot-auto" {
+		t.Fatalf("off-by-default row reviewer = %q, want only the verifiable floor", events[0].Reviewer)
+	}
+}
+
+// TestDaemonDeterministicCheckerDispatcherGate proves the admission gate: the
+// dispatcher is non-nil ONLY when BOTH knobs are set, and nil otherwise (including a
+// malformed config — fail-safe to disabled). Mirrors
+// TestDaemonReviewLegDispatcherGate.
+func TestDaemonDeterministicCheckerDispatcherGate(t *testing.T) {
+	store := openHarvestStore(t)
+	gh := harvestGitHubStub{}
+
+	bothOff := writeHarvestConfig(t, "[skillopt]\n")
+	if d := daemonDeterministicCheckerDispatcher(store, gh, "", bothOff); d != nil {
+		t.Fatalf("both knobs off: want nil, got %T", d)
+	}
+	checkerOnly := writeHarvestConfig(t, "[skillopt]\ndeterministic_checkers_enabled = true\n")
+	if d := daemonDeterministicCheckerDispatcher(store, gh, "", checkerOnly); d != nil {
+		t.Fatal("deterministic_checkers without auto_trace must be nil (requires BOTH)")
+	}
+	malformed := writeHarvestConfig(t, "[skillopt]\nauto_trace_enabled = true\ndeterministic_checkers_enabled = perhaps\n")
+	if d := daemonDeterministicCheckerDispatcher(store, gh, "", malformed); d != nil {
+		t.Fatal("a malformed config must fail-safe to a nil (disabled) dispatcher")
+	}
+	bothOn := writeHarvestConfig(t, "[skillopt]\nauto_trace_enabled = true\ndeterministic_checkers_enabled = true\n")
+	d := daemonDeterministicCheckerDispatcher(store, gh, "", bothOn)
+	if d == nil {
+		t.Fatal("both knobs on: want a non-nil checker dispatcher")
+	}
+	concrete, ok := d.(*deterministicCheckerDispatcher)
+	if !ok {
+		t.Fatalf("expected the real *deterministicCheckerDispatcher, got %T", d)
+	}
+	// The default selector (diff_size only) is wired when no list is configured.
+	if len(concrete.checkers) != 1 || concrete.checkers[0] != "diff_size" {
+		t.Fatalf("default checker selector = %v, want [diff_size]", concrete.checkers)
+	}
+}
+
+// TestDeterministicCheckerCoexistsWithReview proves all THREE rows coexist when both
+// the #469 review leg AND the #485 checker leg are wired: gitmoot-auto (floor),
+// gitmoot-review (subjective), gitmoot-checker (objective), each under a distinct
+// item id, with the merge unaffected.
+func TestDeterministicCheckerCoexistsWithReview(t *testing.T) {
+	ctx := context.Background()
+	store := openTraceChainStore(t)
+	version := installChainTemplate(t, store, "planner")
+	gate := &stubMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine := chainEngine(store, gate)
+	engine.OutcomeHarvester = enabledHarvesterFor(t, store, harvestGitHubStub{status: realCIChainStatus()})
+	engine.ReviewLegDispatcher = reviewDispatcherForTest(store, harvestGitHubStub{})
+	engine.DeterministicCheckerDispatcher = &deterministicCheckerDispatcher{
+		store:    store,
+		diff:     checkerDiffStub{files: smallDiffFiles()},
+		runner:   &fakeCheckerRunner{present: map[string]bool{}},
+		checkout: t.TempDir(),
+		checkers: []string{checkerDiffSize},
+	}
+
+	seedCodexImplementJob(t, store, version)
+	registerShellReviewer(t, store)
+	seedChainApprovingReview(t, store, "head123")
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	events := autoTraceFeedback(t, store, version.ID)
+	reviewers := map[string]bool{}
+	itemIDs := map[string]int{}
+	for _, ev := range events {
+		reviewers[ev.Reviewer] = true
+		itemIDs[ev.ItemID]++
+	}
+	for _, want := range []string{"gitmoot-auto", "gitmoot-review", "gitmoot-checker"} {
+		if !reviewers[want] {
+			t.Fatalf("expected the %s row to coexist, got reviewers %v", want, reviewers)
+		}
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected exactly 3 coexisting rows, got %d: %+v", len(events), events)
+	}
+	for id, n := range itemIDs {
+		if n != 1 {
+			t.Fatalf("item id %q has %d rows, want distinct item ids (1 each)", id, n)
+		}
+	}
+	if len(gate.requests) != 1 {
+		t.Fatalf("merge gate requests = %d, want 1", len(gate.requests))
+	}
+}
+
+// compile-time assurance the integration stub matches the diff reader seam.
+var _ diffFileLister = checkerDiffStub{}
+var _ github.Client = harvestGitHubStub{}

--- a/internal/cli/deterministic_checkers_test.go
+++ b/internal/cli/deterministic_checkers_test.go
@@ -46,10 +46,11 @@ func (r *fakeCheckerRunner) LookPath(file string) (string, error) {
 
 func (r *fakeCheckerRunner) Run(_ context.Context, _ string, command string, _ ...string) (subprocess.Result, error) {
 	r.calls = append(r.calls, command)
-	if err := r.runErr[command]; err != nil {
-		return subprocess.Result{}, err
-	}
-	return subprocess.Result{Command: command, Stdout: r.stdout[command]}, nil
+	// Faithful to subprocess.Run: a non-zero exit returns BOTH the buffered stdout
+	// (e.g. golangci-lint's issue list / gocyclo's function list / jscpd's clone
+	// listing) AND a non-nil error. Tools that "report findings via a non-zero exit"
+	// still populate stdout, so the fake must too.
+	return subprocess.Result{Command: command, Stdout: r.stdout[command]}, r.runErr[command]
 }
 
 var _ subprocess.Runner = (*fakeCheckerRunner)(nil)
@@ -226,6 +227,128 @@ func TestToolCheckerErrorDegradesToSkip(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("a sole-checker error must yield ok=false (no producible dimension, no row)")
+	}
+}
+
+// runToolChecker runs a single tool checker through Check and returns its rubric
+// score and whether the dimension was produced (present in the rubric).
+func runToolChecker(t *testing.T, runner *fakeCheckerRunner, checker string) (float64, bool) {
+	t.Helper()
+	d := &deterministicCheckerDispatcher{
+		diff:     checkerDiffStub{err: errors.New("no diff in this fixture")}, // isolate the tool dim
+		runner:   runner,
+		checkout: t.TempDir(),
+		checkers: []string{checker},
+	}
+	outcome, _, err := d.Check(context.Background(), db.Job{ID: "implement-job"}, canonicalImplementPayload(), "head123")
+	if err != nil {
+		t.Fatalf("a tool checker must NEVER error the leg, got: %v", err)
+	}
+	score, present := outcome.Rubric[checker]
+	return score, present
+}
+
+// TestLintErrorWithEmptyStdoutSkips guards the #485 HIGH finding: a genuinely BROKEN
+// golangci-lint (compile/typecheck failure, invalid .golangci.yml, OOM, version
+// mismatch, or a context timeout) writes its diagnostic to STDERR, leaves STDOUT
+// empty, and exits non-zero. lintScore must DEGRADE-SKIP (omit the dimension) rather
+// than fabricate a perfect 1.0 "clean lint" from a linter that never linted.
+func TestLintErrorWithEmptyStdoutSkips(t *testing.T) {
+	runner := &fakeCheckerRunner{
+		present: map[string]bool{"golangci-lint": true},
+		stdout:  map[string]string{"golangci-lint": ""}, // diagnostic went to stderr
+		runErr:  map[string]error{"golangci-lint": errors.New("exit status 2: typecheck failed")},
+	}
+	if score, present := runToolChecker(t, runner, checkerLint); present {
+		t.Fatalf("a broken golangci-lint (err + empty stdout) must SKIP, not score %v", score)
+	}
+}
+
+// TestLintIssuesOnNonZeroExitStillScores: golangci-lint exits non-zero WHEN it finds
+// issues, with the issues on stdout. That is a real signal, not a failure — the
+// dimension must be produced from the issue count even though Run returned an error.
+func TestLintIssuesOnNonZeroExitStillScores(t *testing.T) {
+	runner := &fakeCheckerRunner{
+		present: map[string]bool{"golangci-lint": true},
+		stdout:  map[string]string{"golangci-lint": "a.go:1:1: issue one\na.go:2:1: issue two\n"},
+		runErr:  map[string]error{"golangci-lint": errors.New("exit status 1")}, // "issues found"
+	}
+	score, present := runToolChecker(t, runner, checkerLint)
+	if !present {
+		t.Fatal("lint with issues on stdout (non-zero exit) must still produce a dimension")
+	}
+	// 2 issues => 1.0 - 2*0.05 = 0.9.
+	if score < 0.89 || score > 0.91 {
+		t.Fatalf("lint with 2 issues must score ~0.9, got %v", score)
+	}
+}
+
+// TestComplexityOverThresholdOnNonZeroExitStillScores guards the #485 complexity
+// finding: `gocyclo -over 15` exits NON-ZERO precisely when over-threshold functions
+// exist (the case the metric exists to penalize). The function list on stdout is the
+// signal of truth — the dimension must be produced from it, NOT skipped on the
+// non-zero exit (which would silently reward complex code by omission).
+func TestComplexityOverThresholdOnNonZeroExitStillScores(t *testing.T) {
+	runner := &fakeCheckerRunner{
+		present: map[string]bool{"gocyclo": true},
+		stdout:  map[string]string{"gocyclo": "20 pkg fnA file.go:1:1\n18 pkg fnB file.go:9:1\n"},
+		runErr:  map[string]error{"gocyclo": errors.New("exit status 1")}, // over-threshold funcs present
+	}
+	score, present := runToolChecker(t, runner, checkerComplexity)
+	if !present {
+		t.Fatal("complexity with over-threshold funcs on stdout (non-zero exit) must still produce a dimension")
+	}
+	// 2 over-threshold funcs => 1.0 - 2*0.1 = 0.8.
+	if score < 0.79 || score > 0.81 {
+		t.Fatalf("complexity with 2 over-threshold funcs must score ~0.8, got %v", score)
+	}
+}
+
+// TestDuplicationFoundOnNonZeroExitStillScores guards the #485 duplication finding:
+// jscpd exits NON-ZERO when duplication exceeds its threshold — i.e. exactly when
+// there ARE clones to report. The clone listing on stdout is a real signal; the
+// dimension must be produced from it, NOT skipped on the non-zero exit (which would
+// drop duplication exactly on the worst diffs and bias the objective upward).
+func TestDuplicationFoundOnNonZeroExitStillScores(t *testing.T) {
+	runner := &fakeCheckerRunner{
+		present: map[string]bool{"jscpd": true},
+		stdout:  map[string]string{"jscpd": "clone a\nclone b\nclone c\n"},
+		runErr:  map[string]error{"jscpd": errors.New("exit status 1")}, // threshold breached
+	}
+	score, present := runToolChecker(t, runner, checkerDuplication)
+	if !present {
+		t.Fatal("duplication clones on stdout (non-zero exit) must still produce a dimension")
+	}
+	// 3 clones => 1.0 - 3*0.1 = 0.7.
+	if score < 0.69 || score > 0.71 {
+		t.Fatalf("duplication with 3 clones must score ~0.7, got %v", score)
+	}
+}
+
+// TestDuplicationErrorWithEmptyStdoutSkips: a duplication tool that truly fails
+// (binary crash / context timeout) leaves stdout empty and errors — that SKIPS,
+// never fabricating a 1.0.
+func TestDuplicationErrorWithEmptyStdoutSkips(t *testing.T) {
+	runner := &fakeCheckerRunner{
+		present: map[string]bool{"jscpd": true},
+		stdout:  map[string]string{"jscpd": ""},
+		runErr:  map[string]error{"jscpd": errors.New("jscpd crashed")},
+	}
+	if score, present := runToolChecker(t, runner, checkerDuplication); present {
+		t.Fatalf("a crashed duplication tool (err + empty stdout) must SKIP, not score %v", score)
+	}
+}
+
+// TestDuplicationCleanScores: a duplication tool that exits 0 with no clones (empty
+// stdout, no err) is a genuinely clean diff and scores 1.0.
+func TestDuplicationCleanScores(t *testing.T) {
+	runner := &fakeCheckerRunner{
+		present: map[string]bool{"dupl": true},
+		stdout:  map[string]string{"dupl": ""},
+	}
+	score, present := runToolChecker(t, runner, checkerDuplication)
+	if !present || score != 1.0 {
+		t.Fatalf("a clean duplication run must score 1.0, got score=%v present=%v", score, present)
 	}
 }
 

--- a/internal/cli/deterministic_checkers_test.go
+++ b/internal/cli/deterministic_checkers_test.go
@@ -1,0 +1,282 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// checkerDiffStub is a diffFileLister that returns canned PullRequestFile patches so
+// the pure-Go diff-size metric is deterministic.
+type checkerDiffStub struct {
+	files []github.PullRequestFile
+	err   error
+}
+
+func (s checkerDiffStub) ListPullRequestFiles(context.Context, github.Repository, int64) ([]github.PullRequestFile, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.files, nil
+}
+
+// fakeCheckerRunner is a subprocess.Runner whose LookPath only finds the listed
+// binaries and whose Run returns canned stdout per command — so a tool runner can be
+// exercised deterministically AND a LookPath miss can be modeled (the degrade-skip
+// path). A binary not in present makes LookPath fail (the tool is "not installed").
+type fakeCheckerRunner struct {
+	present map[string]bool   // binaries on PATH
+	stdout  map[string]string // command -> canned stdout
+	runErr  map[string]error  // command -> error to return from Run
+	calls   []string          // commands actually Run
+}
+
+func (r *fakeCheckerRunner) LookPath(file string) (string, error) {
+	if r.present[file] {
+		return "/usr/bin/" + file, nil
+	}
+	return "", fmt.Errorf("exec: %q: executable file not found in $PATH", file)
+}
+
+func (r *fakeCheckerRunner) Run(_ context.Context, _ string, command string, _ ...string) (subprocess.Result, error) {
+	r.calls = append(r.calls, command)
+	if err := r.runErr[command]; err != nil {
+		return subprocess.Result{}, err
+	}
+	return subprocess.Result{Command: command, Stdout: r.stdout[command]}, nil
+}
+
+var _ subprocess.Runner = (*fakeCheckerRunner)(nil)
+
+// canonicalImplementPayload is the implement job payload the dispatcher checks
+// against (a real merged PR on a real repo).
+func canonicalImplementPayload() workflow.JobPayload {
+	return workflow.JobPayload{Repo: "jerryfane/gitmoot", PullRequest: 7}
+}
+
+// smallDiffFiles is a tight (well-under-cap) diff: a few changed lines.
+func smallDiffFiles() []github.PullRequestFile {
+	return []github.PullRequestFile{
+		{Filename: "a.go", Patch: "@@ -1,2 +1,3 @@\n unchanged\n+added one\n+added two\n-removed one\n"},
+	}
+}
+
+// TestDiffSizeAlwaysProducesADimension: diff_size is pure-Go and needs no tool/
+// checkout, so it ALWAYS produces a dimension from the canned PR patches — a tight
+// diff scores high (1.0).
+func TestDiffSizeAlwaysProducesADimension(t *testing.T) {
+	d := &deterministicCheckerDispatcher{
+		diff:     checkerDiffStub{files: smallDiffFiles()},
+		checkers: []string{checkerDiffSize},
+		// No runner, no checkout: tool checkers would skip, but diff_size still runs.
+	}
+	outcome, ok, err := d.Check(context.Background(), db.Job{ID: "implement-job"}, canonicalImplementPayload(), "head123")
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("diff_size must always produce a dimension (ok=true)")
+	}
+	if !outcome.Objective {
+		t.Fatal("the deterministic-checker outcome must be tagged Objective=true")
+	}
+	if outcome.Kind != workflow.OutcomeReviewed {
+		t.Fatalf("outcome kind = %q, want reviewed", outcome.Kind)
+	}
+	score, present := outcome.Rubric[checkerDiffSize]
+	if !present {
+		t.Fatalf("diff_size dimension missing from rubric %v", outcome.Rubric)
+	}
+	if score != 1.0 {
+		t.Fatalf("a tight diff must score 1.0, got %v", score)
+	}
+	// HeadSHA / repo / PR carried through for the harvester's per-PR keying.
+	if outcome.HeadSHA != "head123" || outcome.Repo != "jerryfane/gitmoot" || outcome.PullRequest != 7 {
+		t.Fatalf("outcome context not carried through: %+v", outcome)
+	}
+}
+
+// TestDiffSizeLargeDiffScoresLower: a diff far over the soft cap scores below 1.0
+// (a larger-than-budget change is a weaker objective signal).
+func TestDiffSizeLargeDiffScoresLower(t *testing.T) {
+	// Build a patch with many more changed lines than the soft cap.
+	patch := "@@ -1,1 +1,600 @@\n"
+	for i := 0; i < 600; i++ {
+		patch += "+line\n"
+	}
+	d := &deterministicCheckerDispatcher{
+		diff:     checkerDiffStub{files: []github.PullRequestFile{{Filename: "big.go", Patch: patch}}},
+		checkers: []string{checkerDiffSize},
+	}
+	outcome, ok, err := d.Check(context.Background(), db.Job{ID: "implement-job"}, canonicalImplementPayload(), "head123")
+	if err != nil || !ok {
+		t.Fatalf("Check ok=%v err=%v", ok, err)
+	}
+	if score := outcome.Rubric[checkerDiffSize]; score >= 1.0 {
+		t.Fatalf("a large (>cap) diff must score below 1.0, got %v", score)
+	}
+}
+
+// TestToolCheckerDegradesSkipsOnLookPathMiss: when a tool binary is absent (LookPath
+// miss) the dimension is OMITTED (no row for it) and the leg never errors — the
+// degrade-skip contract. diff_size still survives.
+func TestToolCheckerDegradesSkipsOnLookPathMiss(t *testing.T) {
+	runner := &fakeCheckerRunner{present: map[string]bool{}} // nothing installed
+	d := &deterministicCheckerDispatcher{
+		diff:     checkerDiffStub{files: smallDiffFiles()},
+		runner:   runner,
+		checkout: t.TempDir(), // a checkout exists, but no tools do
+		checkers: []string{checkerDiffSize, checkerDuplication, checkerLint, checkerComplexity},
+	}
+	outcome, ok, err := d.Check(context.Background(), db.Job{ID: "implement-job"}, canonicalImplementPayload(), "head123")
+	if err != nil {
+		t.Fatalf("a LookPath miss must NEVER error, got: %v", err)
+	}
+	if !ok {
+		t.Fatal("diff_size must still survive a tool-less host")
+	}
+	if len(outcome.Rubric) != 1 {
+		t.Fatalf("only diff_size should survive, got %v", outcome.Rubric)
+	}
+	if _, present := outcome.Rubric[checkerDiffSize]; !present {
+		t.Fatalf("diff_size must survive, got %v", outcome.Rubric)
+	}
+	for _, skipped := range []string{checkerDuplication, checkerLint, checkerComplexity} {
+		if _, present := outcome.Rubric[skipped]; present {
+			t.Fatalf("%s must be SKIPPED on a LookPath miss, got %v", skipped, outcome.Rubric)
+		}
+	}
+}
+
+// TestToolCheckerSkipsWithoutCheckout: with no checkout the tool dims skip (they need
+// a working tree) but diff_size (pure-Go, no checkout) still runs.
+func TestToolCheckerSkipsWithoutCheckout(t *testing.T) {
+	runner := &fakeCheckerRunner{present: map[string]bool{"dupl": true, "golangci-lint": true, "gocyclo": true}}
+	d := &deterministicCheckerDispatcher{
+		diff:     checkerDiffStub{files: smallDiffFiles()},
+		runner:   runner,
+		checkout: "", // NO checkout
+		checkers: []string{checkerDiffSize, checkerDuplication, checkerLint, checkerComplexity},
+	}
+	outcome, ok, err := d.Check(context.Background(), db.Job{ID: "implement-job"}, canonicalImplementPayload(), "head123")
+	if err != nil || !ok {
+		t.Fatalf("Check ok=%v err=%v", ok, err)
+	}
+	if len(outcome.Rubric) != 1 || outcome.Rubric[checkerDiffSize] == 0 {
+		t.Fatalf("without a checkout only diff_size should run, got %v", outcome.Rubric)
+	}
+}
+
+// TestToolCheckerProducesDimensionWhenAvailable: with the tool binaries present AND a
+// checkout, the tool dimensions ARE produced from the canned tool output (the
+// best-effort happy path that DOES run a subprocess).
+func TestToolCheckerProducesDimensionWhenAvailable(t *testing.T) {
+	runner := &fakeCheckerRunner{
+		present: map[string]bool{"dupl": true, "golangci-lint": true, "gocyclo": true},
+		stdout: map[string]string{
+			"dupl":          "",           // no clones reported => 1.0
+			"golangci-lint": "",           // no issues => 1.0
+			"gocyclo":       "fn1\nfn2\n", // 2 over-threshold functions
+		},
+	}
+	d := &deterministicCheckerDispatcher{
+		diff:     checkerDiffStub{files: smallDiffFiles()},
+		runner:   runner,
+		checkout: t.TempDir(),
+		checkers: []string{checkerDuplication, checkerLint, checkerComplexity},
+	}
+	outcome, ok, err := d.Check(context.Background(), db.Job{ID: "implement-job"}, canonicalImplementPayload(), "head123")
+	if err != nil || !ok {
+		t.Fatalf("Check ok=%v err=%v", ok, err)
+	}
+	if outcome.Rubric[checkerDuplication] != 1.0 {
+		t.Fatalf("no-clones duplication must score 1.0, got %v", outcome.Rubric[checkerDuplication])
+	}
+	if outcome.Rubric[checkerLint] != 1.0 {
+		t.Fatalf("no-issues lint must score 1.0, got %v", outcome.Rubric[checkerLint])
+	}
+	// gocyclo reported 2 over-threshold functions => 1.0 - 2*0.1 = 0.8.
+	if got := outcome.Rubric[checkerComplexity]; got < 0.79 || got > 0.81 {
+		t.Fatalf("complexity with 2 over-threshold funcs must score ~0.8, got %v", got)
+	}
+}
+
+// TestToolCheckerErrorDegradesToSkip: a tool that ERRORS (e.g. a crash) skips that
+// dimension rather than failing the leg.
+func TestToolCheckerErrorDegradesToSkip(t *testing.T) {
+	runner := &fakeCheckerRunner{
+		present: map[string]bool{"gocyclo": true},
+		runErr:  map[string]error{"gocyclo": errors.New("gocyclo crashed")},
+	}
+	d := &deterministicCheckerDispatcher{
+		diff:     checkerDiffStub{files: smallDiffFiles()},
+		runner:   runner,
+		checkout: t.TempDir(),
+		checkers: []string{checkerComplexity},
+	}
+	_, ok, err := d.Check(context.Background(), db.Job{ID: "implement-job"}, canonicalImplementPayload(), "head123")
+	if err != nil {
+		t.Fatalf("a tool error must NEVER error the leg, got: %v", err)
+	}
+	if ok {
+		t.Fatal("a sole-checker error must yield ok=false (no producible dimension, no row)")
+	}
+}
+
+// TestCheckerEmptyWhenEverythingSkips: when diff-size cannot read (PR file read
+// fails) AND no tools/checkout exist, NOTHING is producible => ok=false (no checker
+// row). The all-skipped fail-safe.
+func TestCheckerEmptyWhenEverythingSkips(t *testing.T) {
+	d := &deterministicCheckerDispatcher{
+		diff:     checkerDiffStub{err: errors.New("github down")},
+		checkers: []string{checkerDiffSize, checkerLint},
+		// no runner, no checkout
+	}
+	_, ok, err := d.Check(context.Background(), db.Job{ID: "implement-job"}, canonicalImplementPayload(), "head123")
+	if err != nil {
+		t.Fatalf("an all-skipped run must NEVER error, got: %v", err)
+	}
+	if ok {
+		t.Fatal("an all-skipped run must yield ok=false (no checker row)")
+	}
+}
+
+// TestCheckerSelectorHonored: only the SELECTED checkers run — a diff_size-only
+// selector never invokes a tool runner even when binaries are present.
+func TestCheckerSelectorHonored(t *testing.T) {
+	runner := &fakeCheckerRunner{present: map[string]bool{"dupl": true, "golangci-lint": true, "gocyclo": true}}
+	d := &deterministicCheckerDispatcher{
+		diff:     checkerDiffStub{files: smallDiffFiles()},
+		runner:   runner,
+		checkout: t.TempDir(),
+		checkers: []string{checkerDiffSize}, // ONLY diff_size selected
+	}
+	outcome, ok, err := d.Check(context.Background(), db.Job{ID: "implement-job"}, canonicalImplementPayload(), "head123")
+	if err != nil || !ok {
+		t.Fatalf("Check ok=%v err=%v", ok, err)
+	}
+	if len(outcome.Rubric) != 1 {
+		t.Fatalf("only diff_size selected, got %v", outcome.Rubric)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("a diff_size-only selector must invoke NO tool runner, ran %v", runner.calls)
+	}
+}
+
+// TestCountPatchChangedLines: the pure-Go patch parser counts +/- body lines and
+// ignores the +++/---/@@ headers.
+func TestCountPatchChangedLines(t *testing.T) {
+	patch := "--- a/x.go\n+++ b/x.go\n@@ -1,3 +1,4 @@\n context\n+added\n-removed\n+another\n"
+	if got := countPatchChangedLines(patch); got != 3 {
+		t.Fatalf("countPatchChangedLines = %d, want 3 (+added, -removed, +another)", got)
+	}
+	if got := countPatchChangedLines(""); got != 0 {
+		t.Fatalf("empty patch must count 0, got %d", got)
+	}
+}

--- a/internal/cli/trace_harvest_daemon.go
+++ b/internal/cli/trace_harvest_daemon.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -80,6 +81,33 @@ func daemonReviewLegDispatcher(store *db.Store, gh github.Client, checkout strin
 		buildAdapter: buildRuntimeAdapter,
 		authed:       daemonAuthedRuntimes(checkout),
 		checkout:     checkout,
+	}
+}
+
+// daemonDeterministicCheckerDispatcher returns the best-effort OBJECTIVE
+// deterministic-checker dispatcher for this home (#485), or nil when the checker
+// knob is OFF — the default, or any config-load failure (fail-safe to disabled).
+// DeterministicCheckersEnabled() requires BOTH deterministic_checkers_enabled AND
+// auto_trace_enabled, so the objective row is only ever written inside an enabled
+// auto-trace run. When nil, the engine constructs no checker leg and writes no
+// checker row, so daemon behavior is byte-identical. It mirrors
+// daemonReviewLegDispatcher's off-by-default gate. The resolved per-checker selector
+// (defaulted to the safe diff_size-only set) is passed in so an operator can run
+// only the always-available metric on a tool-less host.
+func daemonDeterministicCheckerDispatcher(store *db.Store, gh github.Client, checkout string, home string) workflow.DeterministicCheckerDispatcher {
+	if store == nil {
+		return nil
+	}
+	policy, err := loadSkillOptPolicy(home)
+	if err != nil || !policy.DeterministicCheckersEnabled() {
+		return nil
+	}
+	return &deterministicCheckerDispatcher{
+		store:    store,
+		diff:     gh,
+		runner:   subprocess.ExecRunner{},
+		checkout: checkout,
+		checkers: policy.ResolvedDeterministicCheckers(),
 	}
 }
 

--- a/internal/cli/trace_harvest_integration_test.go
+++ b/internal/cli/trace_harvest_integration_test.go
@@ -215,6 +215,9 @@ func chainEngine(store *db.Store, gate workflow.MergeGate) workflow.Engine {
 		// tests so its dispatch + harvest are deterministic; the daemon defaults to a
 		// goroutine (the review is genuinely off the AdvanceJob path in production).
 		ReviewSpawner: func(fn func()) { fn() },
+		// Likewise run the detached deterministic-checker leg (#485) synchronously so
+		// its dispatch + harvest are deterministic in the integration tests.
+		CheckerSpawner: func(fn func()) { fn() },
 	}
 }
 

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -122,10 +122,29 @@ escalation_ttl = ""
 #     row. The judge is cross-family ONLY (skipped — never same-family — when no other
 #     family is available), NEVER touches the promotion bandit, and is never the sole
 #     gate; its trust is DEFERRED to MEASURE-THE-JUDGE (#344). Off ⇒ byte-identical.
+#   deterministic_checkers_enabled (#485): OFF by default; requires auto_trace. When
+#     true, a MERGED implement job additionally runs a best-effort, DETACHED leg of
+#     plain external TOOLS (code duplication, lint, cyclomatic complexity) plus a
+#     pure-Go diff-size metric, normalizes each to a [0,1] dimension, and records a
+#     THIRD coexisting OBJECTIVE feedback row (reviewer gitmoot-checker, item
+#     checker#repo#pr) in the SAME auto-trace run as the verifiable floor and the
+#     cross-family review. These dimensions are TOOL-MEASURED (no LLM) and
+#     un-gameable. DEGRADE-GRACEFULLY: a missing tool binary, no PR-head checkout, a
+#     tool error, or a timeout SKIPS that ONE dimension (no row for it) and NEVER
+#     fails the harvest or blocks the merge; an all-skipped run writes no row.
+#     diff_size is pure-Go and always available; tool dims appear only when their
+#     binary AND a checkout are present. Off ⇒ byte-identical. Promotion stays MANUAL.
+#   deterministic_checkers (#485): optional comma list selecting which checkers run
+#     when enabled (diff_size,duplication,lint,complexity). UNSET/empty ⇒ the safe
+#     default (diff_size only) so a tool-less host runs the always-available metric
+#     and never a heavy tool. Narrow it to run only the cheap dims, or widen it to
+#     opt heavy tools (jscpd/golangci-lint) in. An unknown name is ignored.
 # [skillopt]
 # auto_trace_enabled = false
 # cross_family_review_enabled = false
 # revert_detection_enabled = true
+# deterministic_checkers_enabled = false
+# deterministic_checkers = diff_size
 # auto_promote = false
 # auto_promote_min_samples = 0
 # auto_promote_min_score = 0.0

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -475,7 +475,40 @@ type SkillOptPolicy struct {
 	// foreground ask path is byte-identical when this is absent. It is the ONLY
 	// new knob #482 adds; it reuses the existing bandit_min_samples as its floor.
 	LiveABSampleRate *float64
+
+	// DeterministicCheckersEnabled opts the daemon into the Mode A OBJECTIVE,
+	// non-LLM deterministic-checker signal (#485): when true (AND AutoTraceEnabled
+	// is also true), a merged implement job additionally runs a best-effort,
+	// DETACHED leg of plain external TOOLS (code duplication, lint, cyclomatic
+	// complexity) plus a pure-Go diff-size metric, normalizes each to a [0,1]
+	// dimension, and projects them as a THIRD coexisting FeedbackEvent (reviewer
+	// gitmoot-checker) into the SAME auto-trace run as the verifiable floor and the
+	// subjective cross-family review. These dimensions are OBJECTIVE and
+	// un-gameable, so they are tagged distinctly from the LLM rubric. Empty/false
+	// (the default) means OFF: NO checker leg runs and NO checker row is written —
+	// byte-identical to the verifiable-floor-only behavior. It additionally requires
+	// AutoTraceEnabled (a checker row only makes sense inside the auto-trace run);
+	// DeterministicCheckersEnabled() encodes that dependency, mirroring
+	// ReviewEnabled(). The field is named …Enabled because Go forbids a field and
+	// method sharing a name; the DeterministicCheckersEnabled() method below is the
+	// resolved accessor callers use.
+	DeterministicCheckers bool
+
+	// DeterministicCheckerList is the optional per-checker selector (#485): a comma
+	// list of checker names (diff_size, duplication, lint, complexity) the leg runs
+	// when the feature is enabled. nil/empty (the default) means the safe default
+	// set (DefaultDeterministicCheckers) — which an operator can narrow to only the
+	// always-available, tool-less diff_size on a host without dupl/golangci-lint/
+	// gocyclo. An unknown name is ignored (best-effort), never an error.
+	DeterministicCheckerList []string
 }
+
+// DefaultDeterministicCheckers is the safe default checker set used when the
+// per-checker selector is unset (#485). It is diff_size only — the one pure-Go,
+// always-available, tool-less dimension — so enabling the feature on a tool-less
+// host is useful and never a no-op, and a heavy tool (jscpd/golangci-lint) is only
+// ever run when an operator explicitly opts it into the list.
+var DefaultDeterministicCheckers = []string{"diff_size"}
 
 // DefaultBanditMinSamples is the documented default low-traffic floor for the
 // deferred Mode B auto loop (#473). It is NOT applied when bandit_min_samples is
@@ -497,6 +530,8 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 		BanditMinSamples:                nil,
 		ModeBJudgeEnabled:               false,
 		LiveABSampleRate:                nil,
+		DeterministicCheckers:           false,
+		DeterministicCheckerList:        nil,
 	}
 }
 
@@ -523,6 +558,27 @@ func (p SkillOptPolicy) ReviewEnabled() bool {
 // (byte-identical default), mirroring ReviewEnabled()'s dependency on AutoTraceEnabled.
 func (p SkillOptPolicy) RevertDetectionEnabled() bool {
 	return p.AutoTraceEnabled && (p.RevertDetection == nil || *p.RevertDetection)
+}
+
+// DeterministicCheckersEnabled reports whether the OBJECTIVE deterministic-checker
+// signal (#485) is configured on. It requires BOTH deterministic_checkers_enabled
+// AND auto_trace_enabled (the checker row only makes sense inside the auto-trace
+// run), so enabling the checker knob alone — without the auto-trace harvester — is
+// OFF, mirroring ReviewEnabled()'s AND-dependency. Default false + the AND-gate
+// guarantees byte-identical behavior with no config.
+func (p SkillOptPolicy) DeterministicCheckersEnabled() bool {
+	return p.AutoTraceEnabled && p.DeterministicCheckers
+}
+
+// ResolvedDeterministicCheckers returns the per-checker selector resolved against
+// the safe default (#485): the configured DeterministicCheckerList when non-empty,
+// else DefaultDeterministicCheckers (diff_size only). It is only meaningful when
+// DeterministicCheckersEnabled() is true; callers gate on that first.
+func (p SkillOptPolicy) ResolvedDeterministicCheckers() []string {
+	if len(p.DeterministicCheckerList) > 0 {
+		return p.DeterministicCheckerList
+	}
+	return DefaultDeterministicCheckers
 }
 
 func LoadSkillOptPolicy(paths Paths) (SkillOptPolicy, error) {
@@ -628,7 +684,30 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 		}
 		policy.LiveABSampleRate = &parsed
 		return nil
+	case "deterministic_checkers_enabled":
+		parsed, err := strconv.ParseBool(value)
+		policy.DeterministicCheckers = parsed
+		return err
+	case "deterministic_checkers":
+		policy.DeterministicCheckerList = parseDeterministicCheckerList(value)
+		return nil
 	default:
 		return nil
 	}
+}
+
+// parseDeterministicCheckerList parses the [skillopt].deterministic_checkers
+// per-checker selector — a plain comma list like "diff_size,duplication" — into a
+// trimmed, non-empty slice (#485). An empty value (or one with only blanks) yields
+// nil so ResolvedDeterministicCheckers falls back to the safe default set. It never
+// errors: an unknown name is simply ignored downstream (best-effort), so a typo
+// degrades to fewer dimensions rather than failing the daemon's config load.
+func parseDeterministicCheckerList(value string) []string {
+	var out []string
+	for _, part := range strings.Split(value, ",") {
+		if name := strings.TrimSpace(part); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
 }

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -273,6 +273,122 @@ mode_b_judge_enabled = sometimes
 	}
 }
 
+// TestLoadSkillOptPolicyDeterministicCheckersDefaultsDisabled: the #485 objective
+// checker knob is OFF by default and DeterministicCheckersEnabled() is false.
+func TestLoadSkillOptPolicyDeterministicCheckersDefaultsDisabled(t *testing.T) {
+	policy := DefaultSkillOptPolicy()
+	if policy.DeterministicCheckers || policy.DeterministicCheckersEnabled() {
+		t.Fatalf("deterministic checkers must default OFF, got %+v", policy)
+	}
+	if policy.DeterministicCheckerList != nil {
+		t.Fatalf("deterministic_checkers list must default nil, got %+v", policy.DeterministicCheckerList)
+	}
+	// The resolved selector falls back to the safe default set (diff_size only).
+	resolved := policy.ResolvedDeterministicCheckers()
+	if len(resolved) != 1 || resolved[0] != "diff_size" {
+		t.Fatalf("default resolved checkers = %v, want [diff_size]", resolved)
+	}
+}
+
+// TestLoadSkillOptPolicyDeterministicCheckersRequiresAutoTrace:
+// deterministic_checkers_enabled alone (without auto_trace_enabled) is OFF —
+// DeterministicCheckersEnabled() requires BOTH, mirroring ReviewEnabled().
+func TestLoadSkillOptPolicyDeterministicCheckersRequiresAutoTrace(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+deterministic_checkers_enabled = true
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.DeterministicCheckers {
+		t.Fatal("deterministic_checkers_enabled = true should parse")
+	}
+	if policy.DeterministicCheckersEnabled() {
+		t.Fatal("DeterministicCheckersEnabled() must be false without auto_trace_enabled (requires BOTH)")
+	}
+}
+
+// TestLoadSkillOptPolicyDeterministicCheckersEnabledWithBoth: both knobs on =>
+// DeterministicCheckersEnabled().
+func TestLoadSkillOptPolicyDeterministicCheckersEnabledWithBoth(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_trace_enabled = true
+deterministic_checkers_enabled = true
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.DeterministicCheckersEnabled() {
+		t.Fatalf("DeterministicCheckersEnabled() must be true with both knobs on, got %+v", policy)
+	}
+}
+
+// TestLoadSkillOptPolicyParsesDeterministicCheckerList: the comma list selector
+// parses into a trimmed slice and ResolvedDeterministicCheckers returns it verbatim.
+func TestLoadSkillOptPolicyParsesDeterministicCheckerList(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_trace_enabled = true
+deterministic_checkers_enabled = true
+deterministic_checkers = diff_size, duplication ,lint
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	want := []string{"diff_size", "duplication", "lint"}
+	got := policy.ResolvedDeterministicCheckers()
+	if len(got) != len(want) {
+		t.Fatalf("resolved checkers = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("resolved checkers[%d] = %q, want %q (got %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestLoadSkillOptPolicyRejectsBadDeterministicCheckersBool: a non-bool
+// deterministic_checkers_enabled surfaces a parse error (fail-safe, consistent with
+// applySkillOptPolicyField).
+func TestLoadSkillOptPolicyRejectsBadDeterministicCheckersBool(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+deterministic_checkers_enabled = perhaps
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadSkillOptPolicy(paths); err == nil {
+		t.Fatal("expected an error for a non-bool deterministic_checkers_enabled")
+	}
+}
+
 // TestLoadSkillOptPolicyIgnoresOtherSections proves a config that only sets
 // [events]/[orchestrate] leaves the trace-harvester at its disabled default.
 func TestLoadSkillOptPolicyIgnoresOtherSections(t *testing.T) {

--- a/internal/skillopt/deterministic_checkers.go
+++ b/internal/skillopt/deterministic_checkers.go
@@ -1,0 +1,198 @@
+package skillopt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// checkerReviewerID is the FIXED, tool-derived reviewer id every OBJECTIVE
+// deterministic-checker row carries (#485). It is a single non-human sentinel (like
+// autoTraceReviewer and reviewReviewerID) so the objective row is never mistaken
+// for a human ranking, and it is DISTINCT from BOTH autoTraceReviewer (gitmoot-auto,
+// the verifiable floor) AND reviewReviewerID (gitmoot-review, the subjective LLM
+// rubric) so the objective row coexists with both under the run's UNIQUE
+// (run_id,item_id,reviewer,source,source_url) key instead of overwriting either.
+//
+// The objective row is a THIRD coexisting signal: it is OBJECTIVE and un-gameable
+// (plain tool measurements, no LLM), so the export/optimizer can weight it
+// distinctly from the subjective judge row via this reviewer sentinel + the
+// objective item tag. A re-evaluation of the SAME PR re-upserts the SAME checker
+// row in place (the reviewer id is constant), so the row count stays stable.
+const checkerReviewerID = "gitmoot-checker"
+
+// checkerItemIDPrefix namespaces the objective checker eval item so it is a DISTINCT
+// item id from BOTH the verifiable-floor item (repo#pr) AND the subjective review
+// item (review#repo#pr): the checker item is checker#<repo>#<pr>. A distinct item id
+// means the objective row never overwrites either sibling even though all three live
+// in the same auto-trace:<versionID> run.
+const checkerItemIDPrefix = "checker#"
+
+const (
+	// checkerItemMetadataObjectiveKey marks a checker row OBJECTIVE (tool-measured,
+	// non-LLM) on its eval item so the export/optimizer can recognize and weight it
+	// distinctly from the subjective judge_derived review row, WITHOUT a new contract
+	// field. The run-level feedback_source stays automatic_trace (no contract bump).
+	checkerItemMetadataObjectiveKey = "objective"
+	// checkerItemMetadataScoreKey carries the projected dimension MEAN ([0,1]) on the
+	// checker item so the magnitude the tools measured is recoverable by the
+	// export/optimizer (the same no-new-field lever the review row uses).
+	checkerItemMetadataScoreKey = "checker_score"
+	// checkerItemMetadataDimensionsKey persists the per-dimension tool scores (the
+	// surviving Rubric map) so each tool's individual magnitude is recoverable, not
+	// just the aggregate mean — keeping the objective row fully auditable.
+	checkerItemMetadataDimensionsKey = "dimension_scores"
+)
+
+// checkerChoiceThreshold is the projected-mean cutoff mapping an objective quality
+// LEVEL onto the a/b choice the auto-trace pipeline reads (recommendValidate counts
+// "a" => baselineWins, "b" => candidateWins), mirroring the review row's convention:
+// an objective signal whose mean dimension score is below this cutoff is a NEGATIVE
+// quality signal and registers as "b"; at or above it is positive-leaning ("a").
+const checkerChoiceThreshold = 0.5
+
+// checkerChoice derives the a/b choice from the projected objective quality so a
+// poor objective signal registers as a non-baseline vote instead of silently
+// inverting into a baseline win, mirroring reviewChoice. It is only consulted for a
+// scored signal (the caller skips the write on HasScore=false).
+func checkerChoice(signal NormalizedSignal) string {
+	if signal.HasScore && signal.Score < checkerChoiceThreshold {
+		return "b"
+	}
+	return "a"
+}
+
+// projectChecker maps the deterministic-checker tool dimensions to a
+// NormalizedSignal via ProjectSignal over a synthetic EvaluatorScore whose
+// DimensionScores ARE the tool-derived Rubric (#485), exactly like projectReview.
+// ProjectSignal takes the arithmetic MEAN of DimensionScores when Soft is absent
+// (the #462 rubric-as-score path), so no new aggregation is invented. An EMPTY
+// rubric (every checker skipped) yields HasScore=false (no fabricated neutral 0.5),
+// so writeCheckerFeedback skips the write entirely.
+func projectChecker(outcome workflow.Outcome) NormalizedSignal {
+	dims := map[string]float64{}
+	for k, v := range outcome.Rubric {
+		dims[k] = v
+	}
+	findings := strings.TrimSpace(outcome.Findings)
+	if findings == "" {
+		findings = fmt.Sprintf("Deterministic checkers on PR #%d.", outcome.PullRequest)
+	}
+	return ProjectSignal(&EvaluatorScore{DimensionScores: dims}, &RankedFeedbackEvent{Reasoning: findings}, nil)
+}
+
+// writeCheckerFeedback upserts the OBJECTIVE deterministic-checker row into the
+// EXISTING auto-trace:<versionID> run (#485): the same run as the verifiable floor
+// and the subjective review (so the optimizer sees all three), under a DISTINCT item
+// id (checker#repo#pr) and the FIXED tool-derived reviewer sentinel
+// (gitmoot-checker), so it coexists with both siblings on the UNIQUE
+// (run_id,item_id,reviewer,source,source_url) key instead of overwriting either —
+// and so a re-evaluation of the same PR overwrites the checker row in place rather
+// than accumulating a stale duplicate. The run keeps feedback_source=automatic_trace
+// (no contract bump, ContractVersion=1 unchanged); the checker item carries the
+// objective tag, the projected mean (checker_score), and the per-dimension tool
+// scores so the export/optimizer can weight it distinctly. The a/b choice tracks the
+// projected mean (poor objective signal => "b").
+//
+// It writes ONLY eval_runs/eval_review_items/feedback_events — no candidate, no
+// promotion path — so promotion stays manual.
+func (h *OutcomeHarvester) writeCheckerFeedback(ctx context.Context, version db.AgentTemplateVersion, outcome workflow.Outcome, signal NormalizedSignal) error {
+	// An empty rubric (HasScore=false) carries NO quality level: every checker
+	// skipped (no tool, no checkout, error, timeout) means there is nothing to
+	// record. Skip it entirely — matching the HasScore=false intent — so only a
+	// scored objective signal ever lands a feedback row.
+	if !signal.HasScore {
+		return nil
+	}
+	runID := AutoTraceRunID(version.ID)
+	itemID := checkerItemID(outcome)
+	sourceURL := pullRequestURL(outcome.Repo, outcome.PullRequest)
+
+	// Reuse the EXISTING auto-trace run (same metadata: feedback_source=automatic_trace,
+	// validate mode); an upsert keyed by the run id is idempotent so the verifiable
+	// floor's and the review's run metadata are preserved verbatim.
+	if err := h.Store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                runID,
+		TemplateID:        strings.TrimSpace(version.TemplateID),
+		TemplateVersionID: strings.TrimSpace(version.ID),
+		TargetRepo:        strings.TrimSpace(outcome.Repo),
+		State:             "ready",
+		Mode:              db.EvalRunModeValidate,
+		MetadataJSON:      autoTraceRunMetadata(),
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace eval_run (checker): %w", err)
+	}
+
+	if err := h.Store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:        runID,
+		ItemID:       itemID,
+		Title:        checkerItemTitle(outcome),
+		MetadataJSON: checkerItemMetadata(outcome, signal),
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace eval_review_item (checker): %w", err)
+	}
+
+	if err := h.Store.UpsertFeedbackEvent(ctx, db.FeedbackEvent{
+		RunID:     runID,
+		ItemID:    itemID,
+		Choice:    checkerChoice(signal),
+		Reasoning: signal.Feedback,
+		Reviewer:  checkerReviewerID,
+		Source:    autoTraceSource,
+		SourceURL: sourceURL,
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace feedback_event (checker): %w", err)
+	}
+	return nil
+}
+
+// checkerItemID is the DISTINCT eval item id for the objective checker row
+// (checker#repo#pr) so it never overwrites the verifiable-floor row (repo#pr) or the
+// subjective review row (review#repo#pr) in the same run, while a re-evaluation of
+// the SAME PR re-upserts the SAME checker row in place (stable row count).
+func checkerItemID(outcome workflow.Outcome) string {
+	return checkerItemIDPrefix + autoTraceItemID(outcome)
+}
+
+// checkerItemTitle is the human-readable title of the objective checker item.
+func checkerItemTitle(outcome workflow.Outcome) string {
+	repo := strings.TrimSpace(outcome.Repo)
+	if outcome.PullRequest > 0 {
+		return fmt.Sprintf("Deterministic checkers: %s PR #%d", repo, outcome.PullRequest)
+	}
+	return "Deterministic checkers: " + repo
+}
+
+// checkerItemMetadata carries the objective tag + the per-dimension tool scores on
+// the checker eval item so the export/optimizer can recognize it as objective
+// (un-gameable, non-LLM) and recover each tool's magnitude, WITHOUT a new contract
+// field. It persists the projected MEAN (checker_score) so the aggregate magnitude
+// reaches the row, and the surviving Rubric map (dimension_scores) so each
+// individual tool dimension is auditable — the same no-new-field lever the review
+// row uses. The dimension names are also listed (checkers) for quick filtering.
+func checkerItemMetadata(outcome workflow.Outcome, signal NormalizedSignal) string {
+	dims := map[string]float64{}
+	names := make([]string, 0, len(outcome.Rubric))
+	for k, v := range outcome.Rubric {
+		dims[k] = v
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	meta := map[string]any{
+		"repo":                           strings.TrimSpace(outcome.Repo),
+		"pull_request":                   outcome.PullRequest,
+		checkerItemMetadataObjectiveKey:  true,
+		checkerItemMetadataDimensionsKey: dims,
+		"checkers":                       names,
+	}
+	if signal.HasScore {
+		meta[checkerItemMetadataScoreKey] = signal.Score
+	}
+	raw, _ := json.Marshal(meta)
+	return string(raw)
+}

--- a/internal/skillopt/deterministic_checkers_test.go
+++ b/internal/skillopt/deterministic_checkers_test.go
@@ -1,0 +1,265 @@
+package skillopt
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// checkerOutcome builds an OBJECTIVE deterministic-checker outcome
+// (Kind=OutcomeReviewed, Objective=true) for the test PR with the given tool
+// dimensions.
+func checkerOutcome(rubric map[string]float64) workflow.Outcome {
+	return workflow.Outcome{
+		Kind:        workflow.OutcomeReviewed,
+		Objective:   true,
+		Repo:        "owner/repo",
+		PullRequest: 7,
+		HeadSHA:     "deadbeef",
+		Rubric:      rubric,
+		Findings:    "deterministic checkers on PR #7: diff_size",
+	}
+}
+
+func checkerItemFor(t *testing.T, store *db.Store, versionID, itemID string) (db.EvalReviewItem, bool) {
+	t.Helper()
+	items, err := store.ListEvalReviewItems(context.Background(), autoTraceRunIDPrefix+versionID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	for _, item := range items {
+		if item.ItemID == itemID {
+			return item, true
+		}
+	}
+	return db.EvalReviewItem{}, false
+}
+
+// TestProjectCheckerMeanOfDimensionScores: the tool dimensions project to the
+// arithmetic MEAN of their DimensionScores (the #462 mean path), HasScore=true.
+func TestProjectCheckerMeanOfDimensionScores(t *testing.T) {
+	signal := projectChecker(checkerOutcome(map[string]float64{
+		"diff_size": 1.0, "lint": 0.8, "complexity": 0.6,
+	}))
+	if !signal.HasScore {
+		t.Fatal("non-empty tool dimensions must yield HasScore=true")
+	}
+	want := (1.0 + 0.8 + 0.6) / 3.0
+	if diff := signal.Score - want; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("checker score = %v, want the mean %v", signal.Score, want)
+	}
+}
+
+// TestProjectCheckerEmptyRubricNoScore: an EMPTY rubric (every checker skipped)
+// yields HasScore=false (no fabricated neutral 0.5).
+func TestProjectCheckerEmptyRubricNoScore(t *testing.T) {
+	signal := projectChecker(checkerOutcome(map[string]float64{}))
+	if signal.HasScore {
+		t.Fatalf("empty rubric must yield HasScore=false, got score=%v", signal.Score)
+	}
+}
+
+// TestCheckerRowCoexistsWithFloorAndReview: harvesting the verifiable floor, the
+// subjective review, AND the objective checker writes THREE distinct rows in the
+// SAME auto-trace run under distinct item ids + reviewers — the checker row NEVER
+// overwrites the floor or the review.
+func TestCheckerRowCoexistsWithFloorAndReview(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, &stubStatusReader{status: realCIStatus()})
+
+	// Verifiable floor (merge with real CI).
+	if err := h.Harvest(ctx, implementJob(), payload, workflow.Outcome{
+		Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef",
+	}); err != nil {
+		t.Fatalf("Harvest merge returned error: %v", err)
+	}
+	// Subjective cross-family review.
+	if err := h.Harvest(ctx, implementJob(), payload, reviewOutcome(map[string]float64{"coverage": 0.5}, "claude", false)); err != nil {
+		t.Fatalf("Harvest review returned error: %v", err)
+	}
+	// Objective deterministic checker.
+	if err := h.Harvest(ctx, implementJob(), payload, checkerOutcome(map[string]float64{"diff_size": 0.9})); err != nil {
+		t.Fatalf("Harvest checker returned error: %v", err)
+	}
+
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 3 {
+		t.Fatalf("expected the floor + review + checker rows (3), got %d: %+v", len(events), events)
+	}
+	var floor, review, checker *db.FeedbackEvent
+	for i := range events {
+		switch events[i].Reviewer {
+		case autoTraceReviewer:
+			floor = &events[i]
+		case reviewReviewerID:
+			review = &events[i]
+		case checkerReviewerID:
+			checker = &events[i]
+		}
+	}
+	if floor == nil || review == nil || checker == nil {
+		t.Fatalf("all three rows (floor/review/checker) must coexist; got %+v", events)
+	}
+	if checker.ItemID != checkerItemIDPrefix+"owner/repo#7" {
+		t.Fatalf("checker item id = %q, want checker#owner/repo#7", checker.ItemID)
+	}
+	if checker.ItemID == floor.ItemID || checker.ItemID == review.ItemID {
+		t.Fatalf("checker must use a DISTINCT item id; checker=%q floor=%q review=%q", checker.ItemID, floor.ItemID, review.ItemID)
+	}
+	if checker.Reviewer != checkerReviewerID {
+		t.Fatalf("checker reviewer = %q, want %q", checker.Reviewer, checkerReviewerID)
+	}
+}
+
+// TestCheckerRowObjectiveTaggedAndPersistsDimensions: the checker row carries the
+// objective tag, the projected mean (checker_score), and the per-dimension tool
+// scores on its eval item; the run keeps feedback_source=automatic_trace and no
+// contract field/version changed.
+func TestCheckerRowObjectiveTaggedAndPersistsDimensions(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	if err := h.Harvest(ctx, implementJob(), payload, checkerOutcome(map[string]float64{"diff_size": 0.8, "lint": 0.6})); err != nil {
+		t.Fatalf("Harvest checker returned error: %v", err)
+	}
+
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 || events[0].Reviewer != checkerReviewerID {
+		t.Fatalf("expected one gitmoot-checker row, got %+v", events)
+	}
+	if events[0].Source != autoTraceSource {
+		t.Fatalf("checker row source = %q, want auto-trace (rides the automatic_trace run)", events[0].Source)
+	}
+
+	item, ok := checkerItemFor(t, store, version.ID, checkerItemIDPrefix+"owner/repo#7")
+	if !ok {
+		t.Fatal("checker eval_review_item missing")
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(item.MetadataJSON), &meta); err != nil {
+		t.Fatalf("checker item metadata did not unmarshal: %v", err)
+	}
+	if meta[checkerItemMetadataObjectiveKey] != true {
+		t.Fatalf("checker item must be objective=true, got %v", meta[checkerItemMetadataObjectiveKey])
+	}
+	if _, present := meta[reviewItemMetadataJudgeKey]; present {
+		t.Fatal("the OBJECTIVE checker row must NOT carry the subjective judge_derived tag")
+	}
+	// The projected mean is persisted.
+	score, ok := meta[checkerItemMetadataScoreKey].(float64)
+	if !ok {
+		t.Fatalf("checker item must carry the projected checker_score, got %v", meta[checkerItemMetadataScoreKey])
+	}
+	if want := (0.8 + 0.6) / 2.0; score-want > 1e-9 || score-want < -1e-9 {
+		t.Fatalf("checker_score = %v, want the mean %v", score, want)
+	}
+	// The per-dimension tool scores are persisted.
+	dims, ok := meta[checkerItemMetadataDimensionsKey].(map[string]any)
+	if !ok {
+		t.Fatalf("checker item must persist per-dimension scores, got %v", meta[checkerItemMetadataDimensionsKey])
+	}
+	if dims["diff_size"] != 0.8 || dims["lint"] != 0.6 {
+		t.Fatalf("dimension_scores = %v, want diff_size=0.8 lint=0.6", dims)
+	}
+
+	// The run still stamps feedback_source=automatic_trace (no contract bump).
+	run, err := store.GetEvalRun(ctx, autoTraceRunIDPrefix+version.ID)
+	if err != nil {
+		t.Fatalf("GetEvalRun returned error: %v", err)
+	}
+	pkg, err := ExportTrainingPackage(ctx, store, run.ID)
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage returned error: %v", err)
+	}
+	if pkg.ContractVersion != ContractVersion || ContractVersion != 1 {
+		t.Fatalf("ContractVersion = %d (const %d), want 1 — additive, no bump", pkg.ContractVersion, ContractVersion)
+	}
+}
+
+// TestCheckerChoiceTracksQualityLevel: the checker's a/b choice is DERIVED from the
+// projected mean — a low-mean (poor) objective signal registers "b", a high-mean
+// (good) one registers "a".
+func TestCheckerChoiceTracksQualityLevel(t *testing.T) {
+	ctx := context.Background()
+
+	storeLow := newTraceStore(t)
+	versionLow, payloadLow := installTraceTemplate(t, storeLow, "planner")
+	hLow := NewOutcomeHarvester(storeLow, nil)
+	if err := hLow.Harvest(ctx, implementJob(), payloadLow, checkerOutcome(map[string]float64{"diff_size": 0.2, "lint": 0.3})); err != nil {
+		t.Fatalf("Harvest low checker returned error: %v", err)
+	}
+	low := feedbackForVersion(t, storeLow, versionLow.ID)
+	if len(low) != 1 || low[0].Choice != "b" {
+		t.Fatalf("a low-mean checker must write Choice=b, got %+v", low)
+	}
+
+	storeHigh := newTraceStore(t)
+	versionHigh, payloadHigh := installTraceTemplate(t, storeHigh, "planner")
+	hHigh := NewOutcomeHarvester(storeHigh, nil)
+	if err := hHigh.Harvest(ctx, implementJob(), payloadHigh, checkerOutcome(map[string]float64{"diff_size": 1.0, "lint": 0.9})); err != nil {
+		t.Fatalf("Harvest high checker returned error: %v", err)
+	}
+	high := feedbackForVersion(t, storeHigh, versionHigh.ID)
+	if len(high) != 1 || high[0].Choice != "a" {
+		t.Fatalf("a high-mean checker must write Choice=a, got %+v", high)
+	}
+}
+
+// TestCheckerEmptyRubricWritesNoRow: an EMPTY rubric (HasScore=false, every checker
+// skipped) is non-informative, so the harvester writes NO checker row at all.
+func TestCheckerEmptyRubricWritesNoRow(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	if err := h.Harvest(ctx, implementJob(), payload, checkerOutcome(map[string]float64{})); err != nil {
+		t.Fatalf("Harvest empty-rubric checker returned error: %v", err)
+	}
+	if events := feedbackForVersion(t, store, version.ID); len(events) != 0 {
+		t.Fatalf("an empty (HasScore=false) checker rubric must write no row, got %+v", events)
+	}
+}
+
+// TestCheckerRowReUpsertsInPlace: re-evaluating the SAME PR re-upserts the SAME
+// checker row (stable row count) — a corrective overwrite, not a duplicate.
+func TestCheckerRowReUpsertsInPlace(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	for i := 0; i < 3; i++ {
+		if err := h.Harvest(ctx, implementJob(), payload, checkerOutcome(map[string]float64{"diff_size": 0.7})); err != nil {
+			t.Fatalf("Harvest checker iteration %d returned error: %v", i, err)
+		}
+	}
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 {
+		t.Fatalf("re-evaluation must re-upsert in place (1 row), got %d: %+v", len(events), events)
+	}
+}
+
+// TestHarvestCheckerOutOfScopeJobSkips: an objective checker outcome against a
+// non-implement (out-of-scope) job writes no checker row (the inScope gate applies).
+func TestHarvestCheckerOutOfScopeJobSkips(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	reviewJob := db.Job{ID: "job-review-1", Type: "review"}
+	if err := h.Harvest(ctx, reviewJob, payload, checkerOutcome(map[string]float64{"diff_size": 0.5})); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	if events := feedbackForVersion(t, store, version.ID); len(events) != 0 {
+		t.Fatalf("out-of-scope checker must write nothing, got %+v", events)
+	}
+}

--- a/internal/skillopt/trace_harvest.go
+++ b/internal/skillopt/trace_harvest.go
@@ -189,6 +189,13 @@ func (h *OutcomeHarvester) Harvest(ctx context.Context, job db.Job, payload work
 		return nil
 	}
 	if outcome.Kind == workflow.OutcomeReviewed {
+		if outcome.Objective {
+			// OBJECTIVE deterministic-checker signal (#485): a THIRD, tool-measured,
+			// non-LLM FeedbackEvent in the SAME auto-trace run under a DISTINCT item id
+			// (checker#repo#pr) + reviewer (gitmoot-checker), so it coexists with BOTH the
+			// verifiable floor AND the subjective review row instead of overwriting either.
+			return h.writeCheckerFeedback(ctx, version, outcome, projectChecker(outcome))
+		}
 		// SOFT cross-family review signal (#469): a SECOND, judge-tagged,
 		// down-weighted FeedbackEvent in the SAME auto-trace run under a distinct item
 		// id + reviewer, so it never overwrites the verifiable floor.

--- a/internal/workflow/cross_family_review.go
+++ b/internal/workflow/cross_family_review.go
@@ -25,6 +25,29 @@ type ReviewLegDispatcher interface {
 	Review(ctx context.Context, implementJob db.Job, implementPayload JobPayload, mergedHead string) (Outcome, bool, error)
 }
 
+// DeterministicCheckerDispatcher is the injected, best-effort, nil-by-default seam
+// (#485) the engine calls after a merge to run an OBJECTIVE, non-LLM
+// deterministic-checker leg ALONGSIDE the subjective cross-family review leg. It
+// runs plain external TOOLS (code duplication, lint, cyclomatic complexity) plus a
+// pure-Go diff-size metric, normalizes each to a [0,1] dimension, and returns an
+// Outcome{Kind: OutcomeReviewed, Objective: true, Rubric: <tool dims>} the engine
+// harvests into the SAME auto-trace run as a THIRD coexisting signal — distinct
+// from the LLM rubric via the Objective tag.
+//
+// It mirrors ReviewLegDispatcher EXACTLY: nil-safe (when nil — the default, no
+// deterministic_checkers_enabled — NO checker leg runs and NO checker row is
+// written, so behavior is byte-identical), DETACHED off the blocking AdvanceJob
+// path (a wedged tool can never stall job advancement), and best-effort (a dispatch
+// error is swallowed and recorded as a deterministic_checkers_failed job event,
+// never returned up). ok=false means NO dimension was producible at all (every
+// checker skipped) so the engine writes no checker row; ok=true returns the
+// objective outcome with whatever dimensions survived. The concrete impl is wired
+// only in cli (gated by deterministic_checkers_enabled AND auto_trace_enabled),
+// keeping the engine free of subprocess/skillopt coupling.
+type DeterministicCheckerDispatcher interface {
+	Check(ctx context.Context, implementJob db.Job, implementPayload JobPayload, mergedHead string) (Outcome, bool, error)
+}
+
 // crossFamilyRotation is the fixed, deterministic family rotation used when no
 // registered different-family reviewer exists and the dispatcher materializes an
 // ephemeral different-family review leg (#469): codex→claude, claude→codex,

--- a/internal/workflow/deterministic_checkers_test.go
+++ b/internal/workflow/deterministic_checkers_test.go
@@ -1,0 +1,242 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// recordingCheckerDispatcher is a stub DeterministicCheckerDispatcher that records
+// the call and returns a canned objective OutcomeReviewed (or err/skip), so the
+// engine trigger can be tested without external tools.
+type recordingCheckerDispatcher struct {
+	called  int
+	jobIDs  []string
+	heads   []string
+	outcome Outcome
+	ok      bool
+	err     error
+}
+
+func (r *recordingCheckerDispatcher) Check(_ context.Context, job db.Job, _ JobPayload, mergedHead string) (Outcome, bool, error) {
+	r.called++
+	r.jobIDs = append(r.jobIDs, job.ID)
+	r.heads = append(r.heads, mergedHead)
+	return r.outcome, r.ok, r.err
+}
+
+// TestEngineDispatchesCheckerLegOnMerge proves the objective deterministic-checker
+// leg fires on a merge, attributed to the implement job, and its objective
+// OutcomeReviewed is harvested (#485).
+func TestEngineDispatchesCheckerLegOnMerge(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	dispatcher := &recordingCheckerDispatcher{
+		ok: true,
+		outcome: Outcome{
+			Kind: OutcomeReviewed, Objective: true, Repo: "jerryfane/gitmoot", PullRequest: 7,
+			Rubric: map[string]float64{"diff_size": 0.9},
+		},
+	}
+	engine.DeterministicCheckerDispatcher = dispatcher
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if dispatcher.called != 1 {
+		t.Fatalf("checker dispatcher called %d times, want 1", dispatcher.called)
+	}
+	if dispatcher.jobIDs[0] != "implement-job" {
+		t.Fatalf("checker leg attributed to %q, want implement-job", dispatcher.jobIDs[0])
+	}
+	if dispatcher.heads[0] != "head123" {
+		t.Fatalf("checker leg head sha = %q, want the PR head head123", dispatcher.heads[0])
+	}
+	// Both the merge floor AND the objective checker outcome are harvested; the
+	// checker outcome carries Objective=true.
+	var sawObjectiveReviewed bool
+	kinds := map[OutcomeKind]bool{}
+	for _, o := range harvester.snapshot() {
+		kinds[o.Kind] = true
+		if o.Kind == OutcomeReviewed && o.Objective {
+			sawObjectiveReviewed = true
+		}
+	}
+	if !kinds[OutcomeMerged] {
+		t.Fatalf("harvested kinds = %v, want the merged floor", kinds)
+	}
+	if !sawObjectiveReviewed {
+		t.Fatalf("expected an Objective=true OutcomeReviewed harvest, got %v", harvester.snapshot())
+	}
+}
+
+// TestEngineNilCheckerDispatcherIsByteIdentical proves off-by-default: with no
+// DeterministicCheckerDispatcher the merge advances exactly as before and no checker
+// leg runs (no Objective outcome harvested).
+func TestEngineNilCheckerDispatcherIsByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine.OutcomeHarvester = &recordingHarvester{}
+	// No DeterministicCheckerDispatcher.
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob with nil checker dispatcher returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+	for _, o := range engine.OutcomeHarvester.(*recordingHarvester).snapshot() {
+		if o.Kind == OutcomeReviewed && o.Objective {
+			t.Fatal("nil checker dispatcher must not produce an objective reviewed outcome")
+		}
+	}
+}
+
+// TestEngineCheckerDispatchErrorNeverFailsMerge proves a checker-leg failure is
+// best-effort: the merge still completes and a deterministic_checkers_failed event
+// is recorded on the implement job (the checker never blocks/fails the job).
+func TestEngineCheckerDispatchErrorNeverFailsMerge(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine.OutcomeHarvester = &recordingHarvester{}
+	engine.DeterministicCheckerDispatcher = &recordingCheckerDispatcher{err: errors.New("checker boom")}
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob must not fail on a checker error, got: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+
+	events, err := store.ListJobEvents(ctx, "implement-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	found := false
+	for _, ev := range events {
+		if ev.Kind == "deterministic_checkers_failed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a deterministic_checkers_failed job event, got %+v", events)
+	}
+}
+
+// TestEngineCheckerDispatchSkipWritesNothing proves a SKIP (ok=false, every checker
+// skipped) writes no checker row and never errors.
+func TestEngineCheckerDispatchSkipWritesNothing(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	engine.DeterministicCheckerDispatcher = &recordingCheckerDispatcher{ok: false}
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	for _, o := range harvester.snapshot() {
+		if o.Kind == OutcomeReviewed && o.Objective {
+			t.Fatal("a SKIP must not harvest an objective reviewed outcome")
+		}
+	}
+}
+
+// blockingCheckerDispatcher blocks inside Check until released, modeling a wedged
+// external tool. started fires once Check is entered.
+type blockingCheckerDispatcher struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingCheckerDispatcher) Check(_ context.Context, _ db.Job, _ JobPayload, _ string) (Outcome, bool, error) {
+	b.once.Do(func() { close(b.started) })
+	<-b.release
+	return Outcome{Kind: OutcomeReviewed, Objective: true, Repo: "jerryfane/gitmoot", PullRequest: 7, Rubric: map[string]float64{"diff_size": 1.0}}, true, nil
+}
+
+// TestEngineCheckerLegDoesNotBlockAdvanceJob is the detach regression: even when the
+// checker tool blocks indefinitely, AdvanceJob returns PROMPTLY (the merge completes)
+// because the checker leg is DETACHED into its own goroutine — it never stalls
+// AdvanceJob, the worker tick, or the daemon's checkoutLock. The detached checker
+// still runs once unblocked, and the goroutine is exercised for real (race-tested).
+func TestEngineCheckerLegDoesNotBlockAdvanceJob(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	// Build an engine with the PRODUCTION default async spawn (no synchronous
+	// CheckerSpawner override), so the detached goroutine is exercised for real.
+	engine := Engine{
+		Store: store,
+		JobID: func(request JobRequest) string {
+			return strings.Join([]string{request.Action, request.Agent, request.TaskID}, "-")
+		},
+	}
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	dispatcher := &blockingCheckerDispatcher{started: make(chan struct{}), release: make(chan struct{})}
+	engine.DeterministicCheckerDispatcher = dispatcher
+	seedMergeReviewJobs(t, store)
+
+	done := make(chan error, 1)
+	go func() { done <- engine.AdvanceJob(ctx, "review-job") }()
+
+	// AdvanceJob must return promptly despite the wedged checker.
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("AdvanceJob returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("AdvanceJob did not return while the checker was blocked — the checker leg is NOT detached")
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+
+	// The detached checker goroutine did enter Check (proving it was dispatched).
+	select {
+	case <-dispatcher.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the detached checker leg never started")
+	}
+
+	// Release the checker and confirm the detached leg eventually harvests.
+	close(dispatcher.release)
+	deadline := time.After(5 * time.Second)
+	for {
+		harvested := false
+		for _, o := range harvester.snapshot() {
+			if o.Kind == OutcomeReviewed && o.Objective {
+				harvested = true
+			}
+		}
+		if harvested {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("the detached checker never harvested its objective OutcomeReviewed after release")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -70,6 +70,21 @@ type Engine struct {
 	// is wired only in cli (gated by cross_family_review_enabled AND
 	// auto_trace_enabled), keeping the engine free of runtime/skillopt coupling.
 	ReviewLegDispatcher ReviewLegDispatcher
+	// DeterministicCheckerDispatcher is the injected, best-effort, nil-by-default
+	// seam (#485) the engine calls AFTER a merge harvest to run an OBJECTIVE,
+	// non-LLM deterministic-checker leg (code duplication / lint / cyclomatic
+	// complexity tools + a pure-Go diff-size metric) whose tool-derived dimensions
+	// are projected into the SAME auto-trace run as a THIRD coexisting signal,
+	// distinct from the verifiable floor and the subjective cross-family review. It
+	// mirrors ReviewLegDispatcher EXACTLY: optional and nil-safe (when nil — the
+	// default, no [skillopt].deterministic_checkers_enabled — NO checker leg runs
+	// and NO checker row is written, byte-identical), DETACHED off the blocking
+	// merge path (a wedged tool can never stall AdvanceJob), and best-effort (a
+	// dispatch error is swallowed and recorded as a deterministic_checkers_failed
+	// job event, never returned up). The concrete impl is wired only in cli (gated
+	// by deterministic_checkers_enabled AND auto_trace_enabled), keeping the engine
+	// free of subprocess/skillopt coupling.
+	DeterministicCheckerDispatcher DeterministicCheckerDispatcher
 	// Home is the resolved GITMOOT_HOME root used to place per-delegation
 	// worktrees. DelegationWorktrees is the checkout-bound git client that
 	// performs the worktree-add. Both are optional: when either is unset, the
@@ -186,6 +201,19 @@ type Engine struct {
 	// off a self-contained closure that owns its own bounded, cancellation-detached
 	// context.
 	ReviewSpawner func(func())
+	// CheckerLegTimeout bounds the DETACHED deterministic-checker leg (#485): the
+	// leg shells out to external tools (dupl/jscpd/golangci-lint/gocyclo) that can
+	// be slow, so it must never run unbounded. The detached goroutine's context is
+	// wrapped in this timeout so a wedged tool is reaped rather than leaking
+	// forever. <= 0 means defaultCheckerLegTimeout. It only matters when a
+	// DeterministicCheckerDispatcher is wired (off by default).
+	CheckerLegTimeout time.Duration
+	// CheckerSpawner runs the detached deterministic-checker leg OFF the AdvanceJob
+	// / daemon-poll path so a slow, possibly-wedged external tool can never block
+	// AdvanceJob, the worker tick, or the daemon's checkoutLock. The default (nil)
+	// spawns a goroutine; tests inject a synchronous runner so the checker leg is
+	// deterministic. It mirrors ReviewSpawner.
+	CheckerSpawner func(func())
 }
 
 // defaultMaxDelegationNonProgressStreak is the streak threshold used when the
@@ -204,6 +232,13 @@ const defaultMaxVerifyReplanAttempts = 2
 // cross-family LLM review can legitimately take a few minutes — whose only job is
 // to reap a wedged reviewer so the detached goroutine cannot leak forever.
 const defaultReviewLegTimeout = 10 * time.Minute
+
+// defaultCheckerLegTimeout bounds the detached deterministic-checker leg (#485)
+// when the engine's CheckerLegTimeout is unset (<= 0). It is a generous ceiling —
+// running dupl/jscpd/golangci-lint/gocyclo over a working tree can legitimately
+// take a few minutes — whose only job is to reap a wedged tool so the detached
+// goroutine cannot leak forever.
+const defaultCheckerLegTimeout = 10 * time.Minute
 
 // nonProgressStreakThreshold returns the configured result-aware non-progress
 // streak threshold, falling back to defaultMaxDelegationNonProgressStreak when
@@ -519,6 +554,19 @@ type Outcome struct {
 	// Findings is the reviewer's free-text reasoning, surfaced verbatim in the soft
 	// FeedbackEvent's reasoning.
 	Findings string
+
+	// Objective distinguishes an OBJECTIVE, tool-measured deterministic-checker
+	// outcome (#485) from the SUBJECTIVE cross-family review outcome (#469) WITHOUT a
+	// new OutcomeKind. Both share Kind == OutcomeReviewed and the Rubric/Findings
+	// fields (so they reuse the SAME OutcomeReviewed -> Harvest -> ProjectSignal
+	// path), but the harvester branches on this flag to write the checker row under a
+	// DISTINCT reviewer sentinel (gitmoot-checker) + item-id prefix (checker#) so the
+	// objective row coexists with the verifiable floor AND the subjective review row
+	// instead of overwriting either. It is zero (false) for every existing
+	// merge/block/changes-requested/revert/review path, so those outcomes are
+	// byte-identical to before this field existed (ADDITIVE: Outcome is an internal
+	// non-wire struct, so this touches no exported contract field or ContractVersion).
+	Objective bool
 }
 
 // OutcomeHarvester is the injected, best-effort, nil-by-default seam (#465, Mode
@@ -4414,6 +4462,15 @@ func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPa
 		// and any review-leg failure is swallowed so it can never block or fail the
 		// (already-completed) merge.
 		e.reviewCrossFamilyForMergeGate(ctx, payload, mergedHead)
+		// Objective deterministic-checker signal (#485), DETACHED off the blocking
+		// AdvanceJob / daemon-poll path and strictly best-effort, mirroring the review
+		// leg above: a nil dispatcher (the default, no deterministic_checkers_enabled)
+		// is a no-op, the external tools (dupl/jscpd/golangci-lint/gocyclo) run in
+		// their own bounded, cancellation-detached goroutine so a slow tool can never
+		// stall AdvanceJob / the worker tick / the daemon's checkoutLock, and any
+		// checker-leg failure is swallowed so it can never block or fail the
+		// (already-completed) merge.
+		e.checkDeterministicForMergeGate(ctx, payload, mergedHead)
 		return decision, nil
 	}
 	return decision, e.setTaskState(ctx, ref, TaskReadyToMerge)
@@ -4491,6 +4548,85 @@ func (e Engine) reviewLegTimeout() time.Duration {
 func (e Engine) spawnReviewLeg(fn func()) {
 	if e.ReviewSpawner != nil {
 		e.ReviewSpawner(fn)
+		return
+	}
+	go fn()
+}
+
+// checkDeterministicForMergeGate runs the OBJECTIVE deterministic-checker leg for a
+// just-merged PR and harvests its tool-derived OutcomeReviewed{Objective:true}
+// dimensions into the SAME auto-trace run as a THIRD coexisting, non-LLM signal
+// (#485). It is nil-safe (no dispatcher => no-op, byte-identical) and best-effort,
+// and mirrors reviewCrossFamilyForMergeGate EXACTLY.
+//
+// CRITICAL: the checker leg shells out to external tools that can be slow, so it is
+// DETACHED from the caller's path — it runs in its own goroutine (via
+// spawnCheckerLeg) under a fresh, cancellation-decoupled context bounded by
+// CheckerLegTimeout. This guarantees a wedged tool can NEVER stall AdvanceJob, the
+// daemon worker tick, or the daemon's checkoutLock, and is reaped by the timeout
+// rather than leaking. A dispatch error is swallowed + recorded as a
+// deterministic_checkers_failed job event, NEVER returned up, so a tool failure can
+// never block or fail a job. The outcome is attributed to the IMPLEMENT job that
+// produced the diff (the same implementJobForTask attribution the merge-gate harvest
+// and the review leg use), so the objective row lands on the implementer's template
+// version next to the verifiable floor and the subjective review.
+func (e Engine) checkDeterministicForMergeGate(ctx context.Context, reviewPayload JobPayload, mergedHead string) {
+	if e.DeterministicCheckerDispatcher == nil || e.OutcomeHarvester == nil {
+		return
+	}
+	// Resolve the owning implement job up front (a cheap store read, no tools) so the
+	// detached closure is self-contained. If none resolves, there is nothing to
+	// check/attribute.
+	job, payload, ok := e.implementJobForTask(ctx, reviewPayload)
+	if !ok {
+		return
+	}
+	e.spawnCheckerLeg(func() {
+		// Fresh context decoupled from the caller's ctx (which is cancelled the moment
+		// AdvanceJob returns) yet bounded so a wedged tool is reaped, not leaked.
+		checkCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), e.checkerLegTimeout())
+		defer cancel()
+		e.runCheckerLeg(checkCtx, job, payload, mergedHead)
+	})
+}
+
+// runCheckerLeg performs the actual deterministic-checker dispatch + harvest. It is
+// called from the DETACHED goroutine (never on the AdvanceJob path) so its external
+// tool runs cannot block job advancement (#485).
+func (e Engine) runCheckerLeg(ctx context.Context, job db.Job, payload JobPayload, mergedHead string) {
+	outcome, ok, err := e.DeterministicCheckerDispatcher.Check(ctx, job, payload, mergedHead)
+	if err != nil {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "deterministic_checkers_failed",
+			Message: err.Error(),
+		})
+		return
+	}
+	if !ok {
+		// No producible dimension at all (every checker skipped): skip silently (no
+		// checker row), exactly like an empty-rubric review.
+		return
+	}
+	e.harvestOutcome(ctx, job, payload, outcome)
+}
+
+// checkerLegTimeout returns the configured detached-checker-leg ceiling, defaulting
+// to defaultCheckerLegTimeout when unset so a zero-valued Engine keeps a bounded
+// checker.
+func (e Engine) checkerLegTimeout() time.Duration {
+	if e.CheckerLegTimeout > 0 {
+		return e.CheckerLegTimeout
+	}
+	return defaultCheckerLegTimeout
+}
+
+// spawnCheckerLeg runs fn off the caller's path. The default spawns a goroutine
+// (fire-and-forget, like spawnReviewLeg); tests inject a synchronous runner via the
+// CheckerSpawner hook so the detached checker leg is deterministic.
+func (e Engine) spawnCheckerLeg(fn func()) {
+	if e.CheckerSpawner != nil {
+		e.CheckerSpawner(fn)
 		return
 	}
 	go fn()

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1968,6 +1968,9 @@ func testEngine(store *db.Store) Engine {
 		// Run the detached cross-family review leg SYNCHRONOUSLY in tests so its
 		// dispatch + harvest are deterministic; production defaults to a goroutine.
 		ReviewSpawner: func(fn func()) { fn() },
+		// Likewise run the detached deterministic-checker leg (#485) synchronously so
+		// its dispatch + harvest are deterministic in tests.
+		CheckerSpawner: func(fn func()) { fn() },
 	}
 }
 

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -537,6 +537,36 @@ judge-tagged — *not* barred from promotion); this slice simply preserves the
 current **manual** promotion by writing only `eval_runs` / `eval_review_items` /
 `feedback_events`.
 
+### Deterministic checkers (objective, non-LLM signal, off by default)
+
+When **both** `[skillopt].auto_trace_enabled = true` **and**
+`[skillopt].deterministic_checkers_enabled = true` (both default `false`), a merged
+implement job additionally runs an **objective, tool-measured** checker leg (#485)
+— the complement to the subjective cross-family review. It runs plain external
+**tools** (no LLM): `dupl`/`jscpd` for duplication, `golangci-lint` for lint,
+`gocyclo` for cyclomatic complexity, plus a **pure-Go `diff_size`** metric parsed
+from the PR patches (always available, no tool/checkout needed). Each is normalized
+to `[0,1]` (fewer issues → higher), mapped to `dimension_scores`, fused by the
+mean-of-dimensions path, and written as a **third** `FeedbackEvent` in the SAME
+`auto-trace:<version>` run under the fixed `gitmoot-checker` reviewer sentinel + a
+distinct item id (`checker#<repo>#<pr>`), so it **coexists with** both the
+verifiable floor (`gitmoot-auto`) and the cross-family review (`gitmoot-review`)
+instead of overwriting either. The optional `[skillopt].deterministic_checkers`
+comma list selects which run (default `diff_size` only).
+
+These dimensions are **objective and un-gameable** (tool-measured, not estimated),
+tagged `objective = true` on the eval item (alongside the projected `checker_score`
+and per-dimension `dimension_scores`), so the optimizer weights them distinctly
+from the subjective judge row. The leg is **fail-safe throughout**: a missing tool
+binary, no PR-head checkout, a tool error, or a timeout **SKIPS that one dimension**
+(no row for it) and never errors the harvest, blocks the merge, or stalls the job;
+an all-skipped run writes **no row**. It runs **off the blocking merge path**
+(detached, timeout-bounded); a dispatch failure records a
+`deterministic_checkers_failed` job event. It is additive (`contract_version` stays
+`1`) and **never promotes** (writes only `eval_runs` / `eval_review_items` /
+`feedback_events`). With the knob unset, no checker leg runs and behavior is
+byte-identical.
+
 ### Candidate promotion policy + notifications (off by default)
 
 When a candidate becomes **pending** (after `skillopt import` or `train

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -387,9 +387,11 @@ ranking. Enable it per host in `[skillopt]`:
 
 ```toml
 [skillopt]
-auto_trace_enabled = true            # off by default
-cross_family_review_enabled = false  # off by default; also needs auto_trace_enabled
-revert_detection_enabled = true      # unset = on when auto_trace_enabled; set false to opt out (#467)
+auto_trace_enabled = true              # off by default
+cross_family_review_enabled = false    # off by default; also needs auto_trace_enabled
+revert_detection_enabled = true        # unset = on when auto_trace_enabled; set false to opt out (#467)
+deterministic_checkers_enabled = false # off by default; also needs auto_trace_enabled (#485)
+deterministic_checkers = diff_size     # optional comma list; default = diff_size only
 ```
 
 With `auto_trace_enabled = true`, a merge (passing CI vs. empty-gate), a
@@ -435,6 +437,25 @@ eval/feedback rows); the signal is weighted-low + judge-tagged and is subject to
 the configurable `[skillopt].auto_promote` policy (#463) when that lands — it is
 not barred from promotion. See
 `skills/gitmoot/references/RESULT_CONTRACT.md` for the full contract.
+
+### Deterministic checkers (objective, non-LLM signal)
+
+Turning on **both** `auto_trace_enabled` and `deterministic_checkers_enabled`
+(#485) adds an **objective, tool-measured** checker leg on every merge — the
+complement to the subjective cross-family review. It runs plain external tools
+(`dupl`/`jscpd` for duplication, `golangci-lint` for lint, `gocyclo` for
+cyclomatic complexity) plus a **pure-Go `diff_size`** metric (parsed from the PR
+patches; always available, no tool/checkout needed), normalizes each to `[0,1]`,
+and writes a **third** `FeedbackEvent` in the SAME `auto-trace:<version>` run under
+the fixed `gitmoot-checker` reviewer sentinel + a distinct item id
+(`checker#<repo>#<pr>`), so it coexists with both the verifiable floor and the
+cross-family review. The `deterministic_checkers` comma list selects which run
+(default `diff_size` only). It is **fail-safe**: a missing tool, no checkout, a
+tool error, or a timeout SKIPS that one dimension (never the harvest, never the
+merge); an all-skipped run writes no row. The dimensions are objective and
+un-gameable, tagged `objective = true`, additive (`contract_version` stays `1`),
+and never promote. With the knob unset, no checker leg runs and behavior is
+byte-identical.
 
 ## Champion-Challenger A/B (Mode B, off by default)
 

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -289,6 +289,52 @@ manual (the harvester writes only `eval_runs` / `eval_review_items` /
 subject to the configurable `[skillopt].auto_promote` policy (#463) when that
 lands — weighted-low + judge-tagged, **not** barred from promotion.
 
+### Deterministic checker objective signal (off by default)
+
+Setting **both** `[skillopt].auto_trace_enabled = true` **and**
+`[skillopt].deterministic_checkers_enabled = true` (both default `false`) adds an
+**OBJECTIVE, non-LLM** checker leg on every merge — the tool-measured complement to
+the subjective cross-family review. Where the review asks an LLM to *estimate*
+quality, the checker runs plain external **tools** that *measure* it exactly:
+
+- **`diff_size`** — pure-Go, **always available** (no tool, no checkout): parses the
+  PR file patches, counts changed `+/-` hunk lines + changed files, and normalizes
+  against a soft cap so a tight diff scores ~`1.0` and a larger-than-budget one
+  scores lower. It is the one dimension that is never a no-op on a tool-less host.
+- **`duplication`** — code-clone count via `dupl` (else `jscpd`).
+- **`lint`** — issue count via `golangci-lint`.
+- **`complexity`** — over-threshold function count via `gocyclo`.
+
+Each tool dimension is normalized to `[0,1]` (fewer issues → higher). The optional
+`[skillopt].deterministic_checkers` comma list selects which run (default:
+`diff_size` only); widen it to opt heavy tools in. The dimensions map to
+`dimension_scores`, are fused by the **mean-of-dimensions** path, and are written as
+a **third** `FeedbackEvent` in the SAME `auto-trace:<version>` run under a distinct
+item id (`checker#<repo>#<pr>`) and the fixed `gitmoot-checker` reviewer sentinel —
+so it **coexists with** (never overwrites) both the verifiable floor (`gitmoot-auto`,
+`repo#pr`) and the cross-family review (`gitmoot-review`, `review#<repo>#<pr>`) under
+the run's UNIQUE `(run_id,item_id,reviewer,source,source_url)` key. A re-evaluation
+re-upserts the SAME checker row in place (stable row count). The checker eval item
+carries `objective = true`, the projected `checker_score`, and the per-dimension
+`dimension_scores`, while the run keeps `feedback_source = automatic_trace` —
+additive, **no new contract field, `contract_version` stays `1`**.
+
+These dimensions are **objective and un-gameable**, so the export/optimizer weights
+them distinctly from the subjective judge row via the `gitmoot-checker` sentinel +
+the `objective` item tag. The leg runs **off the blocking merge path** (detached,
+timeout-bounded) and is **fail-safe throughout**: a missing tool binary
+(`LookPath` miss), no PR-head checkout, a tool error, or a timeout **SKIPS that one
+dimension** (no row for it) and never errors the harvest, blocks the merge, or
+stalls `AdvanceJob`. An all-skipped run yields an empty rubric ⇒ **no checker row**.
+A dispatch failure records a `deterministic_checkers_failed` job event and is
+swallowed. Promotion stays manual (the leg writes only `eval_runs` /
+`eval_review_items` / `feedback_events`).
+
+> Note: the merge-gate path holds the daemon's own checkout, not a working tree at
+> the PR head, so the tool-backed dimensions are effectively produced only when such
+> a checkout happens to be available; `diff_size` always runs. Plumbing a PR-head
+> worktree through to the tool runners is a documented follow-on.
+
 ### Promotion policy + notifications (off by default)
 
 When a candidate becomes **pending** (after `skillopt import` or `train


### PR DESCRIPTION
## Summary

Adds the **objective, non-LLM** half of the review-agent signal (#485): the
tool-measured complement to #469's subjective cross-family LLM rubric. On a merged
implement PR, gitmoot runs deterministic **tools** (code duplication via
`dupl`/`jscpd`, lint via `golangci-lint`, cyclomatic complexity via `gocyclo`)
plus a **pure-Go diff-size** metric, normalizes each to a `[0,1]` dimension, and
feeds them as a **third coexisting** `FeedbackEvent` into the EXISTING #465/#469
auto-trace run by reusing the `OutcomeReviewed -> ProjectSignal(DimensionScores)`
path — no new aggregation, no LLM in this path.

## Invariants honored

- **OFF BY DEFAULT** — new `[skillopt].deterministic_checkers_enabled` (requires
  `auto_trace_enabled`, via a `DeterministicCheckersEnabled()` AND-gate mirroring
  `ReviewEnabled()`) + optional `deterministic_checkers` comma selector. nil/false
  => no harvester/leg constructed => byte-identical (asserted by an off-by-default
  full-chain test + the daemon admission-gate test).
- **TOOLS-NOT-LLM** — objective, un-gameable tool measurements. `diff_size` is
  pure-Go (parsed from the PR patches, always available); tool dims run via
  `internal/subprocess` + `exec.LookPath`.
- **FEED THE SAME RUN** — distinct `gitmoot-checker` reviewer sentinel +
  `checker#repo#pr` item id so the objective row coexists with the verifiable floor
  (`gitmoot-auto`) AND the subjective review (`gitmoot-review`) under the run's
  UNIQUE key, routed by a new internal `Outcome.Objective` bool (zero for every
  existing path; no exported contract field).
- **DEGRADE GRACEFULLY** — a missing tool (`LookPath` miss), no checkout, a tool
  error, or a timeout SKIPS that one dimension (no row for it) and NEVER fails the
  harvest or blocks the merge; an all-skipped run writes no row. The leg is
  detached + timeout-bounded, mirroring the #469 review leg (race-clean — the
  detached goroutine passes `go test -race ./internal/workflow/`).
- **ADDITIVE** — `ContractVersion` stays `1`; manual promotion preserved (writes
  only `eval_runs`/`eval_review_items`/`feedback_events`).

## Tests

Each checker→dimension mapping (faked tool output), tool-missing degrades-to-skip,
off-by-default no-rows, the byte-identical guard, and a full `AdvanceJob`→merge
integration test proving the third `gitmoot-checker` row lands in the same
auto-trace run alongside the floor (and coexists with the review row).

Full gate green: `go build/vet/test ./...`, `go test -race` on
`./internal/workflow/`, `./internal/cli/`, `./internal/skillopt/`.

Docs updated in **both** trees (in-repo `docs/skillopt-exchange-contract.md` +
skill references, website reference).

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)