### PR TITLE
fix(workflow): bound malformed-output repair into a re-ask loop (#495)

### DIFF
--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -14,6 +14,16 @@ import (
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
+// maxRepairAttempts bounds how many times a malformed (missing gitmoot_result
+// envelope) output is re-asked with the repair prompt before the job is failed
+// terminally. The initial delivery plus up to this many repair re-asks salvages a
+// recoverable missing envelope — where the agent already produced useful work but
+// omitted the JSON contract — instead of driving the job straight to JobFailed,
+// which would make automation treat delivered work as a failure and re-run it
+// (causing duplicate side effects). It is intentionally small and bounded so the
+// loop can never spin (#495).
+const maxRepairAttempts = 2
+
 type Mailbox struct {
 	Store *db.Store
 	// emitTerminal, when set, is called best-effort AFTER a genuine running->
@@ -294,32 +304,57 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 
 	result, parseErr := ExtractAgentResult(firstRaw)
 	if parseErr != nil {
+		// The agent may have delivered useful work but omitted the required
+		// gitmoot_result envelope. Re-ask with the repair prompt up to
+		// maxRepairAttempts times to salvage a recoverable missing envelope before
+		// failing terminally (#495). Persist the malformed output and emit the
+		// malformed_output event once, preserving the existing event semantics, then
+		// loop the (previously single) repair re-ask.
 		if err := m.savePayload(ctx, job.ID, payload); err != nil {
 			return AgentResult{}, err
 		}
 		if err := m.addEvent(ctx, job.ID, "malformed_output", parseErr.Error()); err != nil {
 			return AgentResult{}, err
 		}
-		if err := m.ensureRunning(ctx, job.ID); err != nil {
-			return AgentResult{}, err
-		}
-		if err := m.addEvent(ctx, job.ID, "repair_retry", "retrying once with repair prompt"); err != nil {
-			return AgentResult{}, err
-		}
 
-		repairPrompt := prompts.RenderRepairPrompt(firstRaw, parseErr)
-		secondRaw, secondRefreshedRef, secondErr := m.deliver(ctx, adapter, agent, job, payload, repairPrompt)
-		if secondErr != nil {
-			_ = m.fail(ctx, job.ID, fmt.Sprintf("repair delivery failed: %v", secondErr))
-			return AgentResult{}, secondErr
-		}
-		m.persistRefreshedRuntimeRef(ctx, job.ID, agent, secondRefreshedRef)
-		payload.RawOutputs = append(payload.RawOutputs, secondRaw)
-		result, parseErr = ExtractAgentResult(secondRaw)
-		if parseErr != nil {
+		lastRaw := firstRaw
+		for attempt := 1; attempt <= maxRepairAttempts; attempt++ {
+			// Re-check cancellation before each repair delivery so a job cancelled
+			// during the repair window is not re-asked (preserves the cancellation
+			// guards).
+			if err := m.ensureRunning(ctx, job.ID); err != nil {
+				return AgentResult{}, err
+			}
+			if err := m.addEvent(ctx, job.ID, "repair_retry", fmt.Sprintf("retrying with repair prompt (attempt %d of %d)", attempt, maxRepairAttempts)); err != nil {
+				return AgentResult{}, err
+			}
+
+			repairPrompt := prompts.RenderRepairPrompt(lastRaw, parseErr)
+			repairRaw, repairRefreshedRef, repairErr := m.deliver(ctx, adapter, agent, job, payload, repairPrompt)
+			if repairErr != nil {
+				_ = m.fail(ctx, job.ID, fmt.Sprintf("repair delivery failed: %v", repairErr))
+				return AgentResult{}, repairErr
+			}
+			m.persistRefreshedRuntimeRef(ctx, job.ID, agent, repairRefreshedRef)
+			// Adopt a freshly minted session ref so the next repair re-ask resumes the
+			// new session rather than re-resuming a dead UUID (mirrors the first
+			// delivery's self-heal adoption above).
+			if repairRefreshedRef != "" {
+				agent.RuntimeRef = repairRefreshedRef
+			}
+			payload.RawOutputs = append(payload.RawOutputs, repairRaw)
+			lastRaw = repairRaw
+
+			result, parseErr = ExtractAgentResult(repairRaw)
+			if parseErr == nil {
+				break
+			}
 			if err := m.savePayload(ctx, job.ID, payload); err != nil {
 				return AgentResult{}, err
 			}
+		}
+
+		if parseErr != nil {
 			_ = m.fail(ctx, job.ID, fmt.Sprintf("repair output malformed: %v", parseErr))
 			return AgentResult{}, parseErr
 		}

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -760,6 +760,82 @@ func TestMailboxRunRetriesMalformedOutputOnce(t *testing.T) {
 	}
 }
 
+func TestMailboxRunSalvagesMissingEnvelopeAfterSecondRepair(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		"findings posted, no json",
+		"still no json",
+		`{"gitmoot_result":{"decision":"approved","summary":"salvaged after second repair","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	result, err := mailbox.Run(ctx, "job-1", agent, adapter)
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Summary != "salvaged after second repair" {
+		t.Fatalf("summary = %q", result.Summary)
+	}
+	if len(adapter.prompts) != 3 {
+		t.Fatalf("deliveries = %d, want 3", len(adapter.prompts))
+	}
+	if !strings.Contains(adapter.prompts[1], "Previous raw output") {
+		t.Fatalf("first repair prompt = %s", adapter.prompts[1])
+	}
+	if !strings.Contains(adapter.prompts[2], "Previous raw output") {
+		t.Fatalf("second repair prompt = %s", adapter.prompts[2])
+	}
+	stored, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(JobSucceeded) {
+		t.Fatalf("state = %q, want succeeded", stored.State)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !hasEvent(events, "malformed_output") || !hasEvent(events, "repair_retry") {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestMailboxRunFailsAfterExhaustingRepairs(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		"no json here",
+		"still no json",
+		"and again no json",
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err == nil {
+		t.Fatal("Run succeeded despite exhausting all repair attempts")
+	}
+	if len(adapter.prompts) != 3 {
+		t.Fatalf("deliveries = %d, want 3 (initial + maxRepairAttempts)", len(adapter.prompts))
+	}
+	stored, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(JobFailed) {
+		t.Fatalf("state = %q, want failed", stored.State)
+	}
+}
+
 func TestMailboxRunMarksBlockedDecision(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)


### PR DESCRIPTION
## What

When an agent delivered useful work but its final message lacked the `gitmoot_result` JSON envelope, the malformed-output path failed the job after a single repair attempt, so automation treated delivered work as a failure and re-ran it (which caused duplicate side effects, e.g. duplicate issue comments).

This bounds the repair into a small re-ask loop (`maxRepairAttempts = 2`) instead of a single shot: the initial delivery plus up to two repair re-asks salvage a recoverable missing envelope before failing terminally. Each repair re-ask re-checks cancellation, adopts a refreshed session ref (so it resumes the new session rather than a dead UUID), and persists the payload. `malformed_output` is still emitted once, preserving existing event semantics.

Scoped to `internal/workflow/mailbox.go` — **no DB schema/state change**.

## Tests

Added `internal/workflow/mailbox_test.go` coverage for the bounded re-ask/salvage path. Full gate green locally (`go build ./... && go vet ./... && go test ./...`, go1.26.4).

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
