### PR TITLE
fix(cli): reliable read-only agent ask (no implement-guard block, clear timeout) (#496)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -126,9 +126,8 @@ func runAgentAsk(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	if !options.force && looksLikeWorkflowOrchestration(options.message) {
-		fmt.Fprintln(stderr, "This looks like implementation workflow orchestration.")
-		fmt.Fprintln(stderr, "Use `gitmoot agent run` or `gitmoot agent implement` so Gitmoot can manage worktrees, branches, commits, and PRs safely.")
-		return 2
+		fmt.Fprintln(stderr, "note: this reads like implementation workflow orchestration, but `agent ask` is read-only and will only answer/analyze.")
+		fmt.Fprintln(stderr, "If you want Gitmoot to manage worktrees, branches, commits, and PRs, use `gitmoot agent run` or `gitmoot agent implement`.")
 	}
 	var output localAgentJobOutput
 	if err := withStore(options.home, func(store *db.Store) error {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -254,7 +254,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		}
 		if !handled {
 			if _, err := (workflow.Mailbox{Store: store}).Run(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {
-				return localAgentJobOutput{}, err
+				return localAgentJobOutput{}, foregroundAskTimeoutError(runCtx, jobTimeout, err)
 			}
 		}
 		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_completed", Message: "workflow advancement completed"}); err != nil {
@@ -278,6 +278,18 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		return localAgentJobOutput{}, err
 	}
 	return buildLocalAgentJobOutput(latest, request)
+}
+
+// foregroundAskTimeoutError turns a JobTimeout-driven context cancel into an
+// actionable message instead of the confusing "job ... is cancelled, not running".
+func foregroundAskTimeoutError(runCtx context.Context, jobTimeout time.Duration, err error) error {
+	if err == nil {
+		return nil
+	}
+	if jobTimeout > 0 && errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("ask timed out after %s; re-run with --background", jobTimeout)
+	}
+	return err
 }
 
 // recoverAdvanceErrorOutput salvages the persisted result when a post-success

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -250,7 +250,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		// can never self-deadlock on "session is busy".
 		handled, abErr := maybeRunLiveAB(runCtx, store, request, agent, job, adapter, managed.OK)
 		if abErr != nil {
-			return localAgentJobOutput{}, abErr
+			return localAgentJobOutput{}, foregroundAskTimeoutError(runCtx, jobTimeout, abErr)
 		}
 		if !handled {
 			if _, err := (workflow.Mailbox{Store: store}).Run(runCtx, job.ID, runtimeAgent(agent), adapter); err != nil {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -661,13 +661,17 @@ func TestRunAgentAskWarnsButDoesNotBlockOrchestration(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{"agent", "ask", "planner", "create branch, commit, push, and open PR", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr)
 	// The guard must not hard-block (rc 2). It falls through to dispatch and
-	// then fails downstream because the agent does not exist (rc 1), which
-	// confirms it reached dispatch rather than being blocked by the guard.
-	if code == 2 {
-		t.Fatalf("exit code = %d, ask was blocked by the workflow-orchestration guard", code)
+	// then fails downstream because the agent does not exist (rc 1). Asserting
+	// rc 1 *and* the "agent ask:" dispatch-error prefix positively confirms it
+	// reached dispatch rather than returning a non-2 code before the guard.
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (guard bypassed, downstream dispatch failure)", code)
 	}
 	if !strings.Contains(stderr.String(), "read-only") {
 		t.Fatalf("stderr = %q, want the read-only warning", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "agent ask:") {
+		t.Fatalf("stderr = %q, want the dispatch-error prefix confirming dispatch was reached", stderr.String())
 	}
 }
 

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -655,14 +656,40 @@ func TestSelectAgentRunAction(t *testing.T) {
 	}
 }
 
-func TestRunAgentAskBlocksWorkflowOrchestration(t *testing.T) {
+func TestRunAgentAskWarnsButDoesNotBlockOrchestration(t *testing.T) {
+	home := t.TempDir()
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"agent", "ask", "planner", "create branch, commit, push, and open PR"}, &stdout, &stderr)
-	if code != 2 {
-		t.Fatalf("exit code = %d, want 2", code)
+	code := Run([]string{"agent", "ask", "planner", "create branch, commit, push, and open PR", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr)
+	// The guard must not hard-block (rc 2). It falls through to dispatch and
+	// then fails downstream because the agent does not exist (rc 1), which
+	// confirms it reached dispatch rather than being blocked by the guard.
+	if code == 2 {
+		t.Fatalf("exit code = %d, ask was blocked by the workflow-orchestration guard", code)
 	}
-	if !strings.Contains(stderr.String(), "This looks like implementation workflow orchestration") {
-		t.Fatalf("stderr = %q", stderr.String())
+	if !strings.Contains(stderr.String(), "read-only") {
+		t.Fatalf("stderr = %q, want the read-only warning", stderr.String())
+	}
+}
+
+func TestForegroundAskTimeoutError(t *testing.T) {
+	wrapped := fmt.Errorf(`job "x" is cancelled, not running`)
+
+	// (1) deadline-exceeded context + jobTimeout > 0 -> actionable message.
+	expired, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	<-expired.Done()
+	if got := foregroundAskTimeoutError(expired, time.Minute, wrapped); got == nil || !strings.Contains(got.Error(), "re-run with --background") {
+		t.Fatalf("got = %v, want an error mentioning re-run with --background", got)
+	}
+
+	// (2) live context -> original error unchanged.
+	if got := foregroundAskTimeoutError(context.Background(), time.Minute, wrapped); got != wrapped {
+		t.Fatalf("got = %v, want the original error unchanged", got)
+	}
+
+	// (3) nil err -> nil.
+	if got := foregroundAskTimeoutError(expired, time.Minute, nil); got != nil {
+		t.Fatalf("got = %v, want nil", got)
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -341,8 +341,9 @@ This uses the same agent registry, repo access grants, cached template snapshot,
 runtime adapter, and local job history as PR-comment jobs. `agent run` is the
 default coordinator-safe entrypoint because it routes to `ask`, `review`, or
 `implement` and keeps branch, worktree, commit, push, PR, and workflow lifecycle
-inside Gitmoot. `agent ask` is for analysis, planning, and questions only; it
-blocks obvious branch/commit/push/PR orchestration unless `--force` is supplied.
+inside Gitmoot. `agent ask` is for analysis, planning, and questions only; it is
+read-only, so when the message reads like branch/commit/push/PR orchestration it
+prints a non-fatal note and still runs (pass `--force` to suppress the note).
 The runtime
 plugin helps Codex or Claude Code discover Gitmoot guidance, but it does not
 replace the Gitmoot CLI. Synchronous jobs and queued jobs both use the same

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -351,8 +351,9 @@ This uses the same agent registry, repo access grants, cached template snapshot,
 runtime adapter, and local job history as PR-comment jobs. `agent run` is the
 default coordinator-safe entrypoint because it routes to `ask`, `review`, or
 `implement` and keeps branch, worktree, commit, push, PR, and workflow lifecycle
-inside Gitmoot. `agent ask` is for analysis, planning, and questions only; it
-blocks obvious branch/commit/push/PR orchestration unless `--force` is supplied.
+inside Gitmoot. `agent ask` is for analysis, planning, and questions only; it is
+read-only, so when the message reads like branch/commit/push/PR orchestration it
+prints a non-fatal note and still runs (pass `--force` to suppress the note).
 The runtime
 plugin helps Codex or Claude Code discover Gitmoot guidance, but it does not
 replace the Gitmoot CLI. Synchronous jobs and queued jobs both use the same


### PR DESCRIPTION
## What

Two papercuts that made a legitimate, read-only `gitmoot agent ask` fail confusingly:

1. **Implement-guard blocked read-only asks.** `runAgentAsk` returned an error whenever the *question* contained words like worktree/branch/commit/PR. Since `ask` is read-only, the guard is now a non-fatal **warning** that still runs the ask (the hard block stays for `run`/`implement`).
2. **Managed-agent foreground asks were cancelled mid-run.** A managed agent's `JobTimeout` wrapped the synchronous run in `context.WithTimeout`, so a long ask died with the confusing "job is cancelled, not running". A new `foregroundAskTimeoutError` now turns a deadline into an actionable `ask timed out after <d>; re-run with --background`. Background behavior is unchanged; non-managed agents (no timeout) are unaffected.

## Tests

Extended `internal/cli/agent_test.go`: a keyword-y ask still runs (not blocked), and the timeout path yields the clear message. Docs updated (`CLI.md`, `website/docs/reference/cli.md`). Full gate green locally (go1.26.4).

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
