### PR TITLE
Promotion canary + auto-rollback for auto-promote (#484)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -21,7 +21,9 @@ The pilot emits a tight allowlist of event types over the webhook transport:
 | `job.blocked`                   | a job reaches the `blocked` terminal state                                         |
 | `job.needs_attention`           | a tree pauses awaiting a human (the `escalate_human` pause today)                  |
 | `candidate.awaiting_promotion`  | a SkillOpt template candidate becomes `pending` after import (always, off the auto-promote policy) |
-| `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current`          |
+| `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current` (also the canary GRADUATE event) |
+| `candidate.canary_started`      | the off-by-default `[skillopt].auto_promote_canary` policy promoted a candidate to the `canary` state behind the live champion |
+| `candidate.rolled_back`         | the canary regression window auto-rolled-back a canary on a material regression (champion stays current, canary rejected) |
 
 Each terminal transition emits **exactly once**. The engine owns the
 succeeded/failed/blocked emit on its `Mailbox` terminal path; the daemon owns the
@@ -39,6 +41,22 @@ holds, the candidate is promoted via the existing promote path and
 `candidate.auto_promoted` fires so the change can be reviewed or rolled back. The
 adjacent dashboard **Attention** page also lists every pending candidate
 (read-only), so candidates are visible locally even with `[events]` off.
+
+When `[skillopt].auto_promote_canary` is on **and** `auto_promote_canary_sample`
+is a fraction in `(0,1]`, a guardrails-pass candidate is promoted to a **canary**
+instead of straight to `current`: it routes that sampled fraction of new job
+resolutions while the prior champion stays the live current version, and
+`candidate.canary_started` fires (carrying the canary version id, template id, and
+the sample fraction). The daemon then watches a bounded regression window over the
+canary's harvested verifiable outcomes (reusing the #465 Mode A signal, no new
+evaluator) and compares it to the prior champion: on parity-or-better it
+**graduates** the canary to `current` and emits `candidate.auto_promoted`; on a
+**material regression** it auto-rolls-back — the champion stays current, the canary
+is rejected, and `candidate.rolled_back` fires. It is **fail-safe**: too few canary
+outcomes, no champion baseline, or feedback it could not read all **hold** (keep
+sampling), never rolling back on unread evidence and never graduating without
+confirming non-regression. With the knob off (the default) promotion is the
+unchanged direct path and no canary event is ever emitted.
 
 The following `event_type` values are **reserved** for the graduate step. They
 are enumerated in the contract so a consumer can `switch` over them

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -350,7 +350,8 @@ auto_promote_min_samples = 0              # UNSET = hard "do not promote" (NOT 0
 auto_promote_min_score = 0.0              # UNSET, or a candidate with no score = do not promote
 auto_promote_require_external_ci = false  # require >= 1 real-external-CI feedback event in the eval_run
 auto_promote_require_measured_judge = false  # PARSED but DEFERRED (#344): true => fail safe to no-promote
-auto_promote_canary = false               # PARSED but DEFERRED (canary follow-on): true => fail safe to no-promote
+auto_promote_canary = false               # #484: true + a valid sample => promote to a CANARY (sampled) instead of direct; false = direct promote
+auto_promote_canary_sample = 0.1          # #484: canary sampled-traffic fraction in (0,1]; UNSET disables the canary (notify-only fail-safe when canary on)
 auto_promote_min_confidence = 0.95        # #473 Mode B: UNSET = ignore; SET = require bandit P(>) >= floor (+ enough samples)
 bandit_min_samples = 30                   # #473/#482 Mode B low-traffic floor (manual `skillopt ab` always allowed)
 live_ab_sample_rate = 0.0                 # #482 Mode B live A/B: 0.0 (default) = never intercept; fraction of foreground asks to A/B
@@ -380,11 +381,25 @@ auto-trace evidence fails safe to notify-only).
   free-text findings can never spoof it. It therefore applies only to **Mode A
   (auto-trace) runs**; a candidate with no harvested external-CI evidence fails
   safe to notify-only.
-- `auto_promote_require_measured_judge` and `auto_promote_canary` are **parsed but
-  deferred**: there is no judge↔human calibration source yet (gated on #344) and
-  the sampled-traffic canary + auto-rollback do not exist, so setting either to
-  `true` **forces notify-only** today. They are documented so a user can write the
-  knob forward-compatibly.
+- `auto_promote_require_measured_judge` is **parsed but deferred**: there is no
+  judge↔human calibration source yet (gated on #344), so setting it `true` **forces
+  notify-only** today. It is documented so a user can write the knob
+  forward-compatibly.
+- `auto_promote_canary` + `auto_promote_canary_sample` (#484) turn a guardrails-pass
+  promotion into a **canary** instead of a direct promote. When `auto_promote_canary`
+  is on **and** `auto_promote_canary_sample` is a fraction in `(0,1]`, the candidate
+  is promoted to the `canary` state behind the live champion (which stays `current`,
+  so non-sampled resolutions are byte-identical) and that fraction of new job
+  resolutions route to the canary version. A bounded daemon **regression window**
+  then reuses the candidate's auto-trace outcomes (no new evaluator) to compare the
+  canary against the prior champion: parity-or-better **graduates** it to `current`
+  (`candidate.auto_promoted`); a material regression **auto-rolls-back** (champion
+  stays current, canary rejected, `candidate.rolled_back`). It is **fail-safe** —
+  too few canary outcomes, no champion baseline, or unread feedback all **hold**
+  (keep sampling), never rolling back on unread evidence and never graduating without
+  confirming non-regression. `auto_promote_canary` on with the sample **unset/invalid
+  forces notify-only** (a misconfigured canary never promotes). Off (the default) is
+  byte-identical to the direct promote.
 - `auto_promote_min_confidence` (#473 Mode B) is **additive and optional**. **Unset
   ignores it entirely** — the auto-promote decision is byte-identical to the
   guardrails above. When **set**, auto-promote additionally requires a non-nil

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -148,7 +148,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		}
 		recipeTemplate = &tmpl
 	}
-	job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home)}).Enqueue(ctx, workflow.JobRequest{
 		ID:                     localAgentJobID(request.Action, agent.Name),
 		Agent:                  agent.Name,
 		Action:                 request.Action,
@@ -332,7 +332,7 @@ func buildLocalAgentJobOutput(latest db.Job, request localAgentDispatchRequest) 
 }
 
 func enqueuePermissionBlockedLocalAgentJob(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string, defaultBranch string, agentName string) (localAgentJobOutput, error) {
-	job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home)}).Enqueue(ctx, workflow.JobRequest{
 		ID:           localAgentJobID(request.Action, agentName),
 		Agent:        agentName,
 		Action:       request.Action,

--- a/internal/cli/canary_daemon.go
+++ b/internal/cli/canary_daemon.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// daemonOutcomeHarvesterWithCanary returns the daemon's Mode-A trace-harvester,
+// wrapped with the off-by-default #484 canary regression evaluator when canary
+// promotion is configured. When the base harvester is nil
+// ([skillopt].auto_trace_enabled OFF — the default), it returns nil unchanged so
+// the engine harvests nothing and behavior is byte-identical. When auto_trace is
+// on but canary is off, it returns the bare base harvester, so the only path that
+// adds the post-harvest regression check is the fully-configured canary one. The
+// wrapper is gated on CanaryEnabled() (auto_promote_canary AND a valid sample), so
+// a malformed config or an unset sample never starts the evaluator. Because the
+// evaluator only acts when an active `canary` row exists — which is only ever
+// written when auto_promote fires in canary mode — it is a no-op until a canary is
+// live, even when constructed.
+func daemonOutcomeHarvesterWithCanary(store *db.Store, gh github.Client, home string) workflow.OutcomeHarvester {
+	base := daemonOutcomeHarvester(store, gh, home)
+	if base == nil {
+		return nil
+	}
+	policy, err := loadSkillOptPolicy(home)
+	if err != nil || !policy.CanaryEnabled() {
+		return base
+	}
+	return &canaryRegressionHarvester{
+		inner:      base,
+		store:      store,
+		sink:       daemonEventSink(store, home),
+		minSamples: policy.AutoPromoteMinSamples,
+	}
+}
+
+// canaryRegressionHarvester decorates the Mode-A OutcomeHarvester (#465) with the
+// #484 bounded regression window: after the inner harvester writes a verifiable
+// outcome (which is what attributes a canary-routed job's outcome to the canary
+// version's auto-trace run), it loads the active canary + the prior champion
+// auto-trace runs and runs the pure skillopt.EvaluateCanaryRegression comparator,
+// acting on the verdict via the EXISTING store transactions. It is best-effort:
+// the regression evaluation NEVER changes the inner harvester's error (which the
+// engine records as auto_trace_harvest_failed) and every store/read error in the
+// evaluation is swallowed (fail-safe: leave the champion live, keep the canary).
+type canaryRegressionHarvester struct {
+	inner      workflow.OutcomeHarvester
+	store      *db.Store
+	sink       events.Sink
+	minSamples *int
+}
+
+var _ workflow.OutcomeHarvester = (*canaryRegressionHarvester)(nil)
+
+func (h *canaryRegressionHarvester) Harvest(ctx context.Context, job db.Job, payload workflow.JobPayload, outcome workflow.Outcome) error {
+	err := h.inner.Harvest(ctx, job, payload, outcome)
+	// Run the regression window AFTER the inner harvest so the just-written outcome
+	// is counted. Best-effort and independent of the inner result.
+	h.evaluate(ctx, payload)
+	return err
+}
+
+// evaluate runs the bounded regression window for the job's template, if a canary
+// is active, and graduates / rolls back / holds per the pure comparator. It is
+// fail-safe throughout: any read or store error returns early (leaving the
+// champion live and the canary sampling), and it NEVER leaves the template without
+// a current version — on rollback the prior champion is already the live current
+// version (the canary never displaced it), so the rollback retires the canary via
+// the EXISTING RejectAgentTemplateVersion; the EXISTING RevertAgentTemplateVersion
+// is reused only defensively, to restore the champion if it had somehow been
+// superseded. Graduate reuses PromoteAgentTemplateVersion.
+func (h *canaryRegressionHarvester) evaluate(ctx context.Context, payload workflow.JobPayload) {
+	if h == nil || h.store == nil {
+		return
+	}
+	templateID := payload.TemplateID
+	if templateID == "" {
+		return
+	}
+	canary, found, err := h.store.GetActiveCanaryVersion(ctx, templateID)
+	if err != nil || !found {
+		return
+	}
+	template, err := h.store.GetAgentTemplate(ctx, templateID)
+	if err != nil {
+		return
+	}
+	championID := template.VersionID
+	if championID == "" || championID == canary.ID {
+		// No distinct champion to compare against; hold (fail-safe).
+		return
+	}
+	canaryEvents, canaryErr := h.store.ListFeedbackEvents(ctx, skillopt.AutoTraceRunID(canary.ID))
+	championEvents, championErr := h.store.ListFeedbackEvents(ctx, skillopt.AutoTraceRunID(championID))
+	minSamples := 0
+	if h.minSamples != nil {
+		minSamples = *h.minSamples
+	}
+	verdict := skillopt.EvaluateCanaryRegression(canaryEvents, championEvents, minSamples, canaryErr != nil, championErr != nil)
+	switch verdict.Decision {
+	case skillopt.CanaryRollback:
+		// Guarantee the prior champion is the live current version BEFORE retiring the
+		// canary, so a valid current version exists at every step. In the normal canary
+		// flow the champion never lost current (the canary sat behind it), so this is a
+		// no-op; the defensive RevertAgentTemplateVersion only fires if the champion had
+		// somehow been superseded (reusing the EXISTING rollback primitive).
+		if champion, err := h.store.GetAgentTemplateVersionByID(ctx, championID); err == nil && champion.State == "superseded" {
+			if _, err := h.store.RevertAgentTemplateVersion(ctx, templateID, championID); err != nil {
+				return
+			}
+		}
+		rejected, err := h.store.RejectAgentTemplateVersion(ctx, canary.ID, verdict.Reason)
+		if err != nil {
+			return
+		}
+		emitCandidateEvent(ctx, h.sink, events.EventCandidateRolledBack, rejected, "rolled_back", verdict.Reason)
+	case skillopt.CanaryGraduate:
+		promoted, err := h.store.PromoteAgentTemplateVersion(ctx, canary.ID)
+		if err != nil {
+			return
+		}
+		emitCandidateEvent(ctx, h.sink, events.EventCandidateAutoPromoted, promoted, "auto_promoted", verdict.Reason)
+	default:
+		// CanaryContinue: keep sampling; no state change.
+	}
+}

--- a/internal/cli/canary_daemon.go
+++ b/internal/cli/canary_daemon.go
@@ -101,7 +101,11 @@ func (h *canaryRegressionHarvester) evaluate(ctx context.Context, payload workfl
 	if h.minSamples != nil {
 		minSamples = *h.minSamples
 	}
-	verdict := skillopt.EvaluateCanaryRegression(canaryEvents, championEvents, minSamples, canaryErr != nil, championErr != nil)
+	// Bound BOTH event lists to the canary window (canary_started_at) so the
+	// champion baseline is its CONCURRENT outcomes, not its entire-lifetime mean
+	// (#484) — otherwise an old champion's stale lifetime average could wrongly
+	// graduate a regressing canary or roll back a healthy one.
+	verdict := skillopt.EvaluateCanaryRegression(canaryEvents, championEvents, canary.CanaryStartedAt, minSamples, canaryErr != nil, championErr != nil)
 	switch verdict.Decision {
 	case skillopt.CanaryRollback:
 		// Guarantee the prior champion is the live current version BEFORE retiring the
@@ -114,8 +118,16 @@ func (h *canaryRegressionHarvester) evaluate(ctx context.Context, payload workfl
 				return
 			}
 		}
-		rejected, err := h.store.RejectAgentTemplateVersion(ctx, canary.ID, verdict.Reason)
+		rejected, changed, err := h.store.RejectAgentTemplateVersion(ctx, canary.ID, verdict.Reason)
 		if err != nil {
+			return
+		}
+		// Emit candidate.rolled_back ONLY on a real transition (#484): the daemon
+		// runs jobs in a parallel worker pool, so two same-template harvests can race
+		// to roll back the same canary. SQLite serializes the two reject transactions;
+		// the second hits the idempotent already-rejected branch (changed=false), so
+		// gating on changed keeps the "emitted exactly once" contract.
+		if !changed {
 			return
 		}
 		emitCandidateEvent(ctx, h.sink, events.EventCandidateRolledBack, rejected, "rolled_back", verdict.Reason)

--- a/internal/cli/candidate_canary_test.go
+++ b/internal/cli/candidate_canary_test.go
@@ -1,0 +1,256 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// seedAutoTraceFeedback writes n harvested feedback events of the given a/b choice
+// into a version's auto-trace eval_run (#465), so the #484 regression comparator
+// has read evidence for that version. A choice "a" carries the real-CI marker so
+// it scores the strong-positive band.
+func seedAutoTraceFeedback(t *testing.T, store *db.Store, templateID, versionID, choice string, n int) {
+	t.Helper()
+	ctx := context.Background()
+	runID := skillopt.AutoTraceRunID(versionID)
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{ID: runID, TemplateID: templateID, TemplateVersionID: versionID, TargetRepo: "o/r", State: "ready"}); err != nil {
+		t.Fatalf("UpsertEvalRun: %v", err)
+	}
+	reasoning := "changes requested"
+	if choice == "a" {
+		reasoning = "PR merged with passing external CI."
+	}
+	for i := 0; i < n; i++ {
+		itemID := fmt.Sprintf("o/r#%d", i+1)
+		if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{RunID: runID, ItemID: itemID, Title: itemID}); err != nil {
+			t.Fatalf("UpsertEvalReviewItem: %v", err)
+		}
+		if err := store.UpsertFeedbackEvent(ctx, db.FeedbackEvent{
+			RunID:     runID,
+			ItemID:    itemID,
+			Choice:    choice,
+			Reasoning: reasoning,
+			Reviewer:  skillopt.AutoTraceReviewer,
+			Source:    skillopt.AutoTraceSource,
+		}); err != nil {
+			t.Fatalf("UpsertFeedbackEvent: %v", err)
+		}
+	}
+}
+
+// canaryHarvesterFixture installs a planner template (v1 champion current) + a
+// canary v2, returning the store, the champion id, and the canary id.
+func canaryHarvesterFixture(t *testing.T, sample float64) (store *db.Store, championID, canaryID string) {
+	t.Helper()
+	ctx := context.Background()
+	store, version, _, _ := candidateNotifyFixture(t)
+	champion, err := store.GetAgentTemplate(ctx, version.TemplateID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplate: %v", err)
+	}
+	canary, err := store.CanaryPromoteAgentTemplateVersion(ctx, version.ID, sample)
+	if err != nil {
+		t.Fatalf("CanaryPromoteAgentTemplateVersion: %v", err)
+	}
+	return store, champion.VersionID, canary.ID
+}
+
+// TestCanaryHarvesterGraduates proves the daemon evaluator graduates a canary at
+// parity-or-better than the champion: the canary becomes current, the prior
+// champion is superseded, and candidate.auto_promoted is emitted.
+func TestCanaryHarvesterGraduates(t *testing.T) {
+	ctx := context.Background()
+	store, championID, canaryID := canaryHarvesterFixture(t, 1.0)
+	seedAutoTraceFeedback(t, store, "planner", canaryID, "a", 3)    // canary all strong-positive
+	seedAutoTraceFeedback(t, store, "planner", championID, "a", 3)  // champion strong-positive too
+	sink := &recordingSink{}
+	h := &canaryRegressionHarvester{store: store, sink: sink, minSamples: floatPtrCLIInt(3)}
+
+	h.evaluate(ctx, workflow.JobPayload{TemplateID: "planner"})
+
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 1 {
+		t.Fatalf("auto_promoted emits = %d, want 1 (graduate)", got)
+	}
+	graduated, err := store.GetAgentTemplateVersionByID(ctx, canaryID)
+	if err != nil {
+		t.Fatalf("get canary: %v", err)
+	}
+	if graduated.State != "current" {
+		t.Fatalf("graduated state = %q, want current", graduated.State)
+	}
+}
+
+// TestCanaryHarvesterRollsBack proves the daemon evaluator rolls back a canary
+// that materially regresses vs the champion: the champion STAYS the live current
+// version, the canary is rejected, and candidate.rolled_back is emitted.
+func TestCanaryHarvesterRollsBack(t *testing.T) {
+	ctx := context.Background()
+	store, championID, canaryID := canaryHarvesterFixture(t, 1.0)
+	seedAutoTraceFeedback(t, store, "planner", canaryID, "b", 4)   // canary all negative
+	seedAutoTraceFeedback(t, store, "planner", championID, "a", 4) // champion all strong-positive
+	sink := &recordingSink{}
+	h := &canaryRegressionHarvester{store: store, sink: sink, minSamples: floatPtrCLIInt(3)}
+
+	h.evaluate(ctx, workflow.JobPayload{TemplateID: "planner"})
+
+	if got := len(sink.byType(events.EventCandidateRolledBack)); got != 1 {
+		t.Fatalf("rolled_back emits = %d, want 1", got)
+	}
+	rejected, err := store.GetAgentTemplateVersionByID(ctx, canaryID)
+	if err != nil {
+		t.Fatalf("get canary: %v", err)
+	}
+	if rejected.State != "rejected" {
+		t.Fatalf("rolled-back canary state = %q, want rejected", rejected.State)
+	}
+	// The champion is still the live current version — never left without one.
+	tmpl, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("get template: %v", err)
+	}
+	if tmpl.VersionID != championID {
+		t.Fatalf("current version = %q, want champion %q", tmpl.VersionID, championID)
+	}
+}
+
+// TestCanaryHarvesterHoldsOnThinSamples proves the daemon evaluator HOLDS (no
+// graduate, no rollback, no event, canary stays canary) when the canary has fewer
+// than minSamples outcomes — the insufficient-data fail-safe.
+func TestCanaryHarvesterHoldsOnThinSamples(t *testing.T) {
+	ctx := context.Background()
+	store, championID, canaryID := canaryHarvesterFixture(t, 1.0)
+	seedAutoTraceFeedback(t, store, "planner", canaryID, "b", 1)   // only 1 canary sample
+	seedAutoTraceFeedback(t, store, "planner", championID, "a", 5) // ample champion
+	sink := &recordingSink{}
+	h := &canaryRegressionHarvester{store: store, sink: sink, minSamples: floatPtrCLIInt(3)}
+
+	h.evaluate(ctx, workflow.JobPayload{TemplateID: "planner"})
+
+	if sink.count() != 0 {
+		t.Fatalf("thin samples must emit nothing, got %d", sink.count())
+	}
+	held, err := store.GetAgentTemplateVersionByID(ctx, canaryID)
+	if err != nil {
+		t.Fatalf("get canary: %v", err)
+	}
+	if held.State != "canary" {
+		t.Fatalf("held canary state = %q, want canary (still sampling)", held.State)
+	}
+}
+
+// TestRunCandidateNotifyCanaryRoutesToCanary proves a canary-mode guardrails-pass
+// promotes the candidate to the `canary` state (NOT current), emits
+// candidate.canary_started (not auto_promoted), and leaves the prior champion as
+// the live current version.
+func TestRunCandidateNotifyCanaryRoutesToCanary(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	championBefore, err := store.GetAgentTemplate(ctx, version.TemplateID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+
+	policy := autoPromotePolicy(1, 0.9)
+	policy.AutoPromoteCanary = true
+	policy.AutoPromoteCanarySample = floatPtrCLI(0.1)
+
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+
+	// candidate.canary_started fires exactly once; NO auto_promoted.
+	started := sink.byType(events.EventCandidateCanaryStarted)
+	if len(started) != 1 {
+		t.Fatalf("canary_started emits = %d, want 1", len(started))
+	}
+	if started[0].JobID != version.ID || started[0].RootID != version.TemplateID {
+		t.Fatalf("canary_started ids = %q/%q, want %q/%q", started[0].JobID, started[0].RootID, version.ID, version.TemplateID)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 0 {
+		t.Fatalf("auto_promoted emits = %d, want 0 (canary, not direct promote)", got)
+	}
+	// The candidate is now a canary; the champion is unchanged and still current.
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "canary" {
+		t.Fatalf("version state = %q, want canary", after.State)
+	}
+	if after.CanarySample != 0.1 {
+		t.Fatalf("canary sample = %v, want 0.1", after.CanarySample)
+	}
+	championAfter, err := store.GetAgentTemplate(ctx, version.TemplateID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplate after returned error: %v", err)
+	}
+	if championAfter.VersionID != championBefore.VersionID {
+		t.Fatalf("current version changed under canary: %q -> %q", championBefore.VersionID, championAfter.VersionID)
+	}
+}
+
+// TestRunCandidateNotifyCanaryOffByDefaultDirectPromote proves that with
+// auto_promote ON but canary OFF the path is byte-identical to #471: a direct
+// promote to current with candidate.auto_promoted (NO canary_started).
+func TestRunCandidateNotifyCanaryOffByDefaultDirectPromote(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+	if got := len(sink.byType(events.EventCandidateCanaryStarted)); got != 0 {
+		t.Fatalf("canary_started emits = %d, want 0 (canary off)", got)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 1 {
+		t.Fatalf("auto_promoted emits = %d, want 1 (direct promote)", got)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "current" {
+		t.Fatalf("version state = %q, want current (direct promote)", after.State)
+	}
+}
+
+// TestRunCandidateNotifyCanaryWithoutSampleStaysPending proves auto_promote_canary
+// set WITHOUT a sample fails safe to notify-only: no canary, no promote, the
+// candidate stays pending.
+func TestRunCandidateNotifyCanaryWithoutSampleStaysPending(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	policy := autoPromotePolicy(1, 0.9)
+	policy.AutoPromoteCanary = true // no AutoPromoteCanarySample => misconfigured
+
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+	if got := len(sink.byType(events.EventCandidateCanaryStarted)); got != 0 {
+		t.Fatalf("canary_started emits = %d, want 0 (misconfigured canary)", got)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 0 {
+		t.Fatalf("auto_promoted emits = %d, want 0 (fail-safe notify-only)", got)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "pending" {
+		t.Fatalf("version state = %q, want pending (notify-only fail-safe)", after.State)
+	}
+}

--- a/internal/cli/candidate_notify.go
+++ b/internal/cli/candidate_notify.go
@@ -154,6 +154,21 @@ func runCandidateNotify(ctx context.Context, store *db.Store, sink events.Sink, 
 	if store == nil {
 		return nil
 	}
+	// (4a) Canary path (#484): instead of promoting straight to current, promote the
+	// candidate to the `canary` state behind the live champion (the champion stays
+	// current, so non-sampled resolutions are byte-identical) and emit
+	// candidate.canary_started. The daemon regression window later graduates it
+	// (candidate.auto_promoted) or auto-rolls-back (candidate.rolled_back). The
+	// sample is validated by EvaluateAutoPromote (decision.Canary is only set when
+	// CanaryEnabled()), so the pointer deref is safe.
+	if decision.Canary && policy.AutoPromoteCanarySample != nil {
+		canary, err := store.CanaryPromoteAgentTemplateVersion(ctx, version.ID, *policy.AutoPromoteCanarySample)
+		if err != nil {
+			return fmt.Errorf("canary-promote candidate %s: %w", version.ID, err)
+		}
+		emitCandidateEvent(ctx, sink, events.EventCandidateCanaryStarted, canary, "canary_started", decision.Reason)
+		return nil
+	}
 	promoted, err := store.PromoteAgentTemplateVersion(ctx, version.ID)
 	if err != nil {
 		return fmt.Errorf("auto-promote candidate %s: %w", version.ID, err)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3986,8 +3986,18 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// returns nil unless [skillopt].auto_trace_enabled is set, so with no config
 		// NO harvester is constructed and behavior — and every human-run
 		// TrainingPackage — is byte-identical. The harvester writes ONLY
-		// eval/feedback rows; promotion stays 100% manual.
-		OutcomeHarvester: daemonOutcomeHarvester(store, gh, home),
+		// eval/feedback rows; promotion stays 100% manual (the #484 canary wrapper
+		// below is the only path that may graduate/roll back, and only when canary
+		// mode is configured AND a live canary exists).
+		//
+		// Off-by-default #484 canary regression window: when [skillopt].auto_promote_canary
+		// is configured with a valid sample, the base harvester is wrapped so that AFTER
+		// a verifiable outcome it loads the active canary + prior champion auto-trace runs
+		// and graduates (-> current) or auto-rolls-back (reusing RevertAgentTemplateVersion
+		// to keep the champion live + rejecting the canary) on a material regression.
+		// daemonOutcomeHarvesterWithCanary returns the bare base harvester when canary is
+		// off and nil when auto_trace is off, so both default paths stay byte-identical.
+		OutcomeHarvester: daemonOutcomeHarvesterWithCanary(store, gh, home),
 		// Off-by-default cross-family review-agent soft signal (#469): on a MERGE the
 		// engine additionally runs a read-only CROSS-FAMILY review leg (off the
 		// blocking merge path, best-effort) whose subjective-quality + scope-fidelity

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3375,7 +3375,7 @@ func (w jobWorker) queueTempWorkerMergeBack(ctx context.Context, completedJobID 
 			"Do not edit files, create commits, open pull requests, or dispatch more agents unless the summary explicitly requires follow-up.",
 		},
 	}
-	if _, err := (workflow.Mailbox{Store: w.Store}).Enqueue(ctx, request); err != nil {
+	if _, err := (workflow.Mailbox{Store: w.Store, CanaryEnabled: canaryRoutingEnabled(w.workflowHome())}).Enqueue(ctx, request); err != nil {
 		return err
 	}
 	return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: completedJob.ID, Kind: "temp_worker_merge_back_queued", Message: fmt.Sprintf("queued summary merge-back job %s for %s", mergeBackID, original.Name)})
@@ -4021,6 +4021,12 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},
+		// Gate the #484 canary ROUTING seam on the SAME policy.CanaryEnabled() the
+		// OutcomeHarvester's regression comparator above is gated on, so both seams
+		// are consistent: with canary off NO traffic is sampled (Mailbox.routeCanary
+		// returns before its query, byte-identical) AND no comparator runs, so a
+		// stranded canary row can never keep serving traffic with no auto-rollback.
+		CanaryEnabled: canaryRoutingEnabled(home),
 	}
 	if strings.TrimSpace(home) != "" {
 		// Root delegation artifacts under GITMOOT_HOME (alongside worktrees)

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -12109,7 +12109,7 @@ func runSkillOptCandidateReject(args []string, stdout, stderr io.Writer) int {
 	var rejected db.AgentTemplateVersion
 	if err := withStore(parsed.home, func(store *db.Store) error {
 		var err error
-		rejected, err = store.RejectAgentTemplateVersion(context.Background(), parsed.versionID, parsed.reason)
+		rejected, _, err = store.RejectAgentTemplateVersion(context.Background(), parsed.versionID, parsed.reason)
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "skillopt candidate reject: %v\n", err)

--- a/internal/cli/trace_harvest_daemon.go
+++ b/internal/cli/trace_harvest_daemon.go
@@ -60,6 +60,24 @@ func resolveRevertDetectionEnabled(home string) bool {
 	return policy.RevertDetectionEnabled()
 }
 
+// canaryRoutingEnabled resolves the #484 canary ROUTING gate for a home: true only
+// when [skillopt].auto_promote_canary AND a valid auto_promote_canary_sample are
+// configured (config.SkillOptPolicy.CanaryEnabled()). It is the SAME gate the
+// daemon's regression comparator (daemonOutcomeHarvesterWithCanary) uses, so the
+// routing and comparator seams turn on and off together — disabling the knob (or
+// unsetting the sample) and restarting stops BOTH sampled routing and
+// graduate/rollback, so a stranded canary row can never keep serving traffic. It is
+// FAIL-SAFE to false on any config-load error, mirroring the other gates. With
+// canary off (the default) every Mailbox is constructed with CanaryEnabled=false,
+// so routeCanary returns before its query and resolution is byte-identical.
+func canaryRoutingEnabled(home string) bool {
+	policy, err := loadSkillOptPolicy(home)
+	if err != nil {
+		return false
+	}
+	return policy.CanaryEnabled()
+}
+
 // daemonReviewLegDispatcher returns the best-effort cross-family review-leg
 // dispatcher for this home (#469), or nil when the review knob is OFF — the
 // default, or any config-load failure (fail-safe to disabled). ReviewEnabled()

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -425,7 +425,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fmt.Errorf("resolve task worktree head: %w", err)
 		}
-		startedJob, err = enqueueTaskRunImplementJob(context.Background(), store, started, strings.TrimSpace(*owner), headSHA)
+		startedJob, err = enqueueTaskRunImplementJob(context.Background(), store, started, strings.TrimSpace(*owner), headSHA, paths.Home)
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "run task: %v\n", err)
@@ -446,7 +446,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Task, owner string, headSHA string) (db.Job, error) {
+func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Task, owner string, headSHA string, home string) (db.Job, error) {
 	baseJobID := taskRunImplementJobID(task.ID, owner)
 	jobID := baseJobID
 	request := taskRunImplementJobRequest(jobID, task, owner, headSHA)
@@ -464,7 +464,7 @@ func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Ta
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return db.Job{}, err
 	}
-	return (workflow.Mailbox{Store: store}).Enqueue(ctx, request)
+	return (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home)}).Enqueue(ctx, request)
 }
 
 func findActiveTaskRunJob(ctx context.Context, store *db.Store, request workflow.JobRequest) (db.Job, bool, error) {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -92,8 +92,19 @@ escalation_ttl = ""
 #   auto_promote_require_measured_judge: PARSED but DEFERRED (gated on #344) — there
 #     is no judge<->human calibration source yet, so when true it FAILS SAFE to
 #     notify-only.
-#   auto_promote_canary: PARSED but DEFERRED (canary follow-on) — sampled traffic +
-#     auto-rollback do not exist yet, so when true it FAILS SAFE to notify-only.
+#   auto_promote_canary (#484): OFF by default. When true AND auto_promote_canary_sample
+#     is a valid fraction, a guardrails-pass candidate is promoted to a CANARY version
+#     (routed a sampled fraction of resolutions while the prior champion stays the live
+#     current version) instead of directly to current; a bounded regression window then
+#     graduates it (-> current, candidate.auto_promoted) or auto-rolls-back on a real
+#     regression vs the prior champion (champion stays current, canary rejected,
+#     candidate.rolled_back). Off ⇒ byte-identical to #471's direct promote. When true
+#     but auto_promote_canary_sample is unset/invalid it FAILS SAFE to notify-only.
+#   auto_promote_canary_sample (#484): the canary's sampled-traffic fraction in (0,1] —
+#     the per-resolution probability a job routes to the active canary version instead of
+#     the champion. UNSET (the default) disables the canary path (notify-only fail-safe
+#     when auto_promote_canary is on). 1.0 routes ALL traffic to the canary (useful for
+#     a deterministic test); a small value (e.g. 0.1) routes about a tenth of traffic.
 #   auto_promote_min_confidence (#473 Mode B): minimum bandit confidence
 #     P(challenger>champion) — supplied by the manual 'skillopt ab' champion-
 #     challenger A/B — required to auto-promote. UNSET ignores the guardrail
@@ -151,6 +162,7 @@ escalation_ttl = ""
 # auto_promote_require_external_ci = false
 # auto_promote_require_measured_judge = false
 # auto_promote_canary = false
+# auto_promote_canary_sample = 0.1
 # auto_promote_min_confidence = 0.95
 # bandit_min_samples = 30
 # live_ab_sample_rate = 0.0

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -432,10 +432,24 @@ type SkillOptPolicy struct {
 	// there is no judge<->human calibration source yet, so when true it FAILS SAFE
 	// to notify-don't-promote. Documented so a user can set it forward-compatibly.
 	AutoPromoteRequireMeasuredJudge bool
-	// AutoPromoteCanary is PARSED but DEFERRED (#471 canary follow-on): the sampled
-	// traffic + regression-window infrastructure does not exist yet, so when true it
-	// FAILS SAFE to notify-don't-promote. Documented as deferred.
+	// AutoPromoteCanary opts the auto-promote pass into CANARY promotion (#484):
+	// when true (AND a valid AutoPromoteCanarySample is set), a guardrails-pass
+	// candidate is promoted to the new `canary` version state — routed a sampled
+	// fraction of runtime resolutions while the prior champion stays the live
+	// current version — instead of being promoted directly to current. A bounded
+	// regression window then graduates or auto-rolls-back the canary. false (the
+	// default) is byte-identical to #471's direct promote. When true but
+	// AutoPromoteCanarySample is unset/invalid, the auto-promote pass FAILS SAFE to
+	// notify-only (never promotes), preserving the fail-safe envelope.
 	AutoPromoteCanary bool
+	// AutoPromoteCanarySample is the canary's sampled-traffic fraction in (0,1]
+	// (#484): the per-resolution probability a job routes to the active canary
+	// version instead of the champion. nil (unset, the default) means the canary
+	// path is OFF — with AutoPromoteCanary also requiring a valid sample, an unset
+	// sample makes the canary a no-op (notify-only fail-safe). It is the canary's
+	// defining parameter, kept as a separate required-when-on knob so the existing
+	// AutoPromoteCanary boolean's meaning stays intact and additive.
+	AutoPromoteCanarySample *float64
 
 	// AutoPromoteMinConfidence is the minimum Mode B bandit confidence
 	// P(challenger>champion) required to auto-promote (#473). nil (unset, the
@@ -526,6 +540,7 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 		AutoPromoteRequireExternalCI:    false,
 		AutoPromoteRequireMeasuredJudge: false,
 		AutoPromoteCanary:               false,
+		AutoPromoteCanarySample:         nil,
 		AutoPromoteMinConfidence:        nil,
 		BanditMinSamples:                nil,
 		ModeBJudgeEnabled:               false,
@@ -568,6 +583,23 @@ func (p SkillOptPolicy) RevertDetectionEnabled() bool {
 // guarantees byte-identical behavior with no config.
 func (p SkillOptPolicy) DeterministicCheckersEnabled() bool {
 	return p.AutoTraceEnabled && p.DeterministicCheckers
+}
+
+// CanaryEnabled reports whether the canary-promotion path (#484) is fully
+// configured: AutoPromoteCanary is set AND a valid sample fraction in (0,1] is
+// present. When false — the default, or AutoPromoteCanary on with the sample
+// unset/invalid — the canary path is OFF and the auto-promote pass behaves
+// exactly as #471 (direct promote when guardrails pass) or fails safe to
+// notify-only (canary requested but misconfigured). The validation in
+// applySkillOptPolicyField already rejects an out-of-range sample at load, so a
+// non-nil pointer here is always in (0,1]; the explicit range check keeps this
+// total even for a hand-built policy in a test.
+func (p SkillOptPolicy) CanaryEnabled() bool {
+	if !p.AutoPromoteCanary || p.AutoPromoteCanarySample == nil {
+		return false
+	}
+	sample := *p.AutoPromoteCanarySample
+	return sample > 0 && sample <= 1
 }
 
 // ResolvedDeterministicCheckers returns the per-checker selector resolved against
@@ -659,6 +691,20 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 		parsed, err := strconv.ParseBool(value)
 		policy.AutoPromoteCanary = parsed
 		return err
+	case "auto_promote_canary_sample":
+		parsed, err := parseConfigFloat(value)
+		if err != nil {
+			return err
+		}
+		// The sample is a probability fraction: it must be in (0,1]. A 0 or
+		// negative rate would route nothing (a silently-broken canary) and a >1
+		// rate is nonsensical, so both are hard errors rather than a clamp — a
+		// misconfigured canary fails the config load loudly instead of degrading.
+		if parsed <= 0 || parsed > 1 {
+			return fmt.Errorf("auto_promote_canary_sample %v must be in (0,1]", parsed)
+		}
+		policy.AutoPromoteCanarySample = &parsed
+		return nil
 	case "auto_promote_min_confidence":
 		parsed, err := strconv.ParseFloat(value, 64)
 		if err != nil {

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -195,6 +195,67 @@ auto_promote_canary = true
 	}
 }
 
+// TestLoadSkillOptPolicyCanarySampleDefaultsOff proves the #484 canary sample knob
+// defaults nil (unset) so CanaryEnabled() is OFF by default — byte-identical to
+// #471, and a bare auto_promote_canary (sample unset) is a no-op canary.
+func TestLoadSkillOptPolicyCanarySampleDefaultsOff(t *testing.T) {
+	policy := DefaultSkillOptPolicy()
+	if policy.AutoPromoteCanarySample != nil {
+		t.Fatalf("auto_promote_canary_sample must default nil (unset), got %v", policy.AutoPromoteCanarySample)
+	}
+	if policy.CanaryEnabled() {
+		t.Fatalf("CanaryEnabled() must be false by default, got %+v", policy)
+	}
+	// auto_promote_canary alone (no sample) is NOT enabled (fail-safe).
+	if (SkillOptPolicy{AutoPromoteCanary: true}).CanaryEnabled() {
+		t.Fatal("CanaryEnabled() must be false when the sample is unset")
+	}
+}
+
+// TestLoadSkillOptPolicyParsesCanarySample proves auto_promote_canary_sample parses
+// into the *float64 and that, with auto_promote_canary, CanaryEnabled() is true.
+func TestLoadSkillOptPolicyParsesCanarySample(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_promote_canary = true
+auto_promote_canary_sample = 0.25
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if policy.AutoPromoteCanarySample == nil || *policy.AutoPromoteCanarySample != 0.25 {
+		t.Fatalf("auto_promote_canary_sample = %v, want 0.25", policy.AutoPromoteCanarySample)
+	}
+	if !policy.CanaryEnabled() {
+		t.Fatalf("CanaryEnabled() must be true with canary + valid sample, got %+v", policy)
+	}
+}
+
+// TestLoadSkillOptPolicyRejectsBadCanarySample proves an out-of-range sample
+// (<=0 or >1) and a garbled value both surface a parse error (fail loud, never a
+// silently-broken canary).
+func TestLoadSkillOptPolicyRejectsBadCanarySample(t *testing.T) {
+	for _, bad := range []string{"0", "-0.1", "1.5", "lots"} {
+		paths := PathsForHome(t.TempDir())
+		if err := Initialize(paths); err != nil {
+			t.Fatalf("Initialize returned error: %v", err)
+		}
+		if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+"\n[skillopt]\nauto_promote_canary_sample = "+bad+"\n"), 0o600); err != nil {
+			t.Fatalf("write config returned error: %v", err)
+		}
+		if _, err := LoadSkillOptPolicy(paths); err == nil {
+			t.Fatalf("expected an error for auto_promote_canary_sample = %q", bad)
+		}
+	}
+}
+
 // TestLoadSkillOptPolicyRejectsBadAutoPromoteThreshold proves a garbled numeric
 // threshold surfaces a parse error (fail-safe: the policy is not silently kept).
 func TestLoadSkillOptPolicyRejectsBadAutoPromoteThreshold(t *testing.T) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1303,7 +1303,11 @@ func (d Daemon) enqueueJob(ctx context.Context, request workflow.JobRequest) (db
 	if !errors.Is(err, sql.ErrNoRows) {
 		return db.Job{}, false, err
 	}
-	job, err := (workflow.Mailbox{Store: d.Store}).Enqueue(ctx, request)
+	// Gate the #484 canary routing seam on the SAME policy the daemon's engine
+	// (and its regression comparator) is gated on, so a stranded canary is never
+	// sampled once the knob is off. The engine carries the resolved flag.
+	canaryEnabled := d.Workflow != nil && d.Workflow.CanaryEnabled
+	job, err := (workflow.Mailbox{Store: d.Store, CanaryEnabled: canaryEnabled}).Enqueue(ctx, request)
 	return job, true, err
 }
 

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -119,6 +119,15 @@ CREATE TABLE jobs (
 	delegated_by TEXT NOT NULL DEFAULT '',
 	root_killed INTEGER NOT NULL DEFAULT 0
 );
+-- A minimal agent_template_versions table (as it existed at the input_tokens
+-- migration point) so the later #484 canary ALTER ADD COLUMN has its table; the
+-- real table was created by an earlier (here pre-seeded-as-applied) migration.
+CREATE TABLE agent_template_versions (
+	id TEXT PRIMARY KEY,
+	template_id TEXT NOT NULL,
+	version INTEGER NOT NULL,
+	state TEXT NOT NULL
+);
 CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
 INSERT INTO jobs(id, agent, type, state, payload) VALUES ('old', 'w', 'ask', 'succeeded', '{}');
 `); err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -81,6 +81,15 @@ type AgentTemplateVersion struct {
 	CreatedAt      string
 	UpdatedAt      string
 	PromotedAt     string
+	// CanarySample is the active canary's sampled-traffic fraction in (0,1] (#484),
+	// recorded only on a `canary`-state version; 0 (the column DEFAULT) for every
+	// other state so existing rows read identically. The routing seam draws a
+	// per-resolution random < CanarySample to route to the canary.
+	CanarySample float64
+	// CanaryStartedAt is the RFC3339 window-start of the active canary (#484), set
+	// when a version transitions to `canary`; "" (the DEFAULT) otherwise. It bounds
+	// the daemon's regression-window comparator.
+	CanaryStartedAt string
 }
 
 type AgentTemplateCandidateReview struct {
@@ -1176,7 +1185,7 @@ func (s *Store) GetAgentTemplateReference(ctx context.Context, ref string) (Agen
 }
 
 func (s *Store) GetLatestAgentTemplateVersion(ctx context.Context, templateID string) (AgentTemplate, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT v.id, v.template_id, v.version, v.state, v.name, v.description, v.source_repo, v.source_ref, v.source_path, v.resolved_commit, v.content_hash, v.content, v.metadata_json, v.created_at, v.updated_at, v.promoted_at
+	row := s.db.QueryRowContext(ctx, `SELECT v.id, v.template_id, v.version, v.state, v.name, v.description, v.source_repo, v.source_ref, v.source_path, v.resolved_commit, v.content_hash, v.content, v.metadata_json, v.created_at, v.updated_at, v.promoted_at, v.canary_sample, v.canary_started_at
 		FROM agent_templates t
 		JOIN agent_template_versions v ON v.id = t.latest_version_id
 		WHERE t.id = ?`, strings.TrimSpace(templateID))
@@ -1193,20 +1202,20 @@ func (s *Store) GetAgentTemplateVersion(ctx context.Context, templateID string, 
 	if strings.HasPrefix(versionRef, "v") && len(versionRef) > 1 {
 		versionRef = versionRef[1:]
 	}
-	row := s.db.QueryRowContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
+	row := s.db.QueryRowContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at, canary_sample, canary_started_at
 		FROM agent_template_versions
 		WHERE template_id = ? AND (id = ? OR CAST(version AS TEXT) = ?)`, templateID, templateID+"@v"+versionRef, versionRef)
 	return scanAgentTemplateVersion(row)
 }
 
 func (s *Store) GetAgentTemplateVersionByID(ctx context.Context, versionID string) (AgentTemplateVersion, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
+	row := s.db.QueryRowContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at, canary_sample, canary_started_at
 		FROM agent_template_versions WHERE id = ?`, strings.TrimSpace(versionID))
 	return scanAgentTemplateVersion(row)
 }
 
 func (s *Store) ListAgentTemplateVersions(ctx context.Context, templateID string) ([]AgentTemplateVersion, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
+	rows, err := s.db.QueryContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at, canary_sample, canary_started_at
 		FROM agent_template_versions WHERE template_id = ? ORDER BY version`, templateID)
 	if err != nil {
 		return nil, err
@@ -1225,7 +1234,7 @@ func (s *Store) ListAgentTemplateVersions(ctx context.Context, templateID string
 
 func (s *Store) ListPendingAgentTemplateVersions(ctx context.Context, templateID string) ([]AgentTemplateVersion, error) {
 	templateID = strings.TrimSpace(templateID)
-	query := `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
+	query := `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at, canary_sample, canary_started_at
 		FROM agent_template_versions WHERE state = 'pending'`
 	args := []any{}
 	if templateID != "" {
@@ -1379,8 +1388,11 @@ func (s *Store) PromoteAgentTemplateVersion(ctx context.Context, versionID strin
 	if err != nil {
 		return AgentTemplateVersion{}, err
 	}
-	if target.State != "pending" {
-		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not pending", target.ID, target.State)
+	// A `pending` candidate promotes directly (#471); a `canary` candidate (#484)
+	// GRADUATES through the SAME state-machine writes (supersede champion, become
+	// current, clear the canary fraction/window). Any other state is a hard error.
+	if target.State != "pending" && target.State != "canary" {
+		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not pending or canary", target.ID, target.State)
 	}
 	current, hasCurrent, err := getCurrentAgentTemplateVersion(ctx, tx, target.TemplateID)
 	if err != nil {
@@ -1391,7 +1403,10 @@ func (s *Store) PromoteAgentTemplateVersion(ctx context.Context, versionID strin
 			return AgentTemplateVersion{}, err
 		}
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'current', promoted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, target.ID); err != nil {
+	// Clear canary_sample/canary_started_at on the target so a graduated canary
+	// carries no stale window state; pending targets already have the 0/'' defaults,
+	// so this is a no-op for the #471 path.
+	if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'current', promoted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, canary_sample = 0, canary_started_at = '' WHERE id = ?`, target.ID); err != nil {
 		return AgentTemplateVersion{}, err
 	}
 	latestID, err := latestSelectableVersionID(ctx, tx, target.TemplateID)
@@ -1469,10 +1484,24 @@ func (s *Store) RejectAgentTemplateVersion(ctx context.Context, versionID string
 	if err != nil {
 		return AgentTemplateVersion{}, err
 	}
-	if target.State != "pending" {
-		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not pending", target.ID, target.State)
+	// Idempotent: an already-rejected target is a no-op success so the #484 canary
+	// auto-rollback (which rejects the regressing canary) can be re-run safely after
+	// a crash without erroring.
+	if target.State == "rejected" {
+		if err := tx.Commit(); err != nil {
+			return AgentTemplateVersion{}, err
+		}
+		return target, nil
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'rejected', updated_at = CURRENT_TIMESTAMP WHERE id = ?`, target.ID); err != nil {
+	// A `pending` candidate rejects directly (#471); a `canary` candidate (#484) is
+	// retired by the auto-rollback. A canary never holds current_version_id (the
+	// champion stays current throughout the canary), so rejecting it leaves the
+	// champion live — no current pointer changes. The canary fraction/window are
+	// cleared so no stale routing state remains.
+	if target.State != "pending" && target.State != "canary" {
+		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not pending or canary", target.ID, target.State)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'rejected', updated_at = CURRENT_TIMESTAMP, canary_sample = 0, canary_started_at = '' WHERE id = ?`, target.ID); err != nil {
 		return AgentTemplateVersion{}, err
 	}
 	latestID, err := latestSelectableVersionID(ctx, tx, target.TemplateID)
@@ -1547,6 +1576,99 @@ func (s *Store) RevertAgentTemplateVersion(ctx context.Context, templateID strin
 		return AgentTemplateVersion{}, err
 	}
 	return s.GetAgentTemplateVersionByID(ctx, target.ID)
+}
+
+// CanaryPromoteAgentTemplateVersion transitions a PENDING candidate to the new
+// `canary` state (#484) WITHOUT touching the template's current_version_id: the
+// prior champion stays the live current version, so every non-sampled resolution
+// is byte-identical and the routing seam (templateSnapshot) opts only a sampled
+// fraction onto the canary. It records the active canary's sample fraction and
+// window-start for the daemon regression comparator, and recomputes
+// latest_version_id (which excludes the `canary` state) so the canary never leaks
+// into latest_version_id. It enforces at most ONE active canary per template and
+// requires an existing current champion (a canary only makes sense behind a live
+// champion). It mirrors PromoteAgentTemplateVersion's state-machine writes but
+// leaves the champion current — the defining safety property of the canary.
+func (s *Store) CanaryPromoteAgentTemplateVersion(ctx context.Context, versionID string, sample float64) (AgentTemplateVersion, error) {
+	if sample <= 0 || sample > 1 {
+		return AgentTemplateVersion{}, fmt.Errorf("canary sample %v must be in (0,1]", sample)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	defer tx.Rollback()
+	target, err := getAgentTemplateVersionByIDTx(ctx, tx, versionID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if target.State != "pending" {
+		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not pending; only a pending candidate can become a canary", target.ID, target.State)
+	}
+	// A canary sits BEHIND a live champion; refuse if there is no current version so
+	// non-sampled traffic always has a champion to resolve to.
+	_, hasCurrent, err := getCurrentAgentTemplateVersion(ctx, tx, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if !hasCurrent {
+		return AgentTemplateVersion{}, fmt.Errorf("template %s has no current champion; refusing to start a canary without one", target.TemplateID)
+	}
+	// At most one active canary per template: a second concurrent canary would make
+	// routing ambiguous and the regression window unattributable.
+	var existing int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_template_versions WHERE template_id = ? AND state = 'canary'`, target.TemplateID).Scan(&existing); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if existing > 0 {
+		return AgentTemplateVersion{}, fmt.Errorf("template %s already has an active canary; resolve it before starting another", target.TemplateID)
+	}
+	startedAt := time.Now().UTC().Format(time.RFC3339)
+	if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'canary', canary_sample = ?, canary_started_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, sample, startedAt, target.ID); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	// Recompute latest_version_id: latestSelectableVersionID only considers
+	// current/pending, so the now-canary version is excluded and latest falls back
+	// to the champion (or a higher pending) — the canary never becomes latest.
+	latestID, err := latestSelectableVersionID(ctx, tx, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET latest_version_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, latestID, target.TemplateID)
+	if err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := requireAffected(result, "agent template", target.TemplateID); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AgentTemplateVersion{}, err
+	}
+	return s.GetAgentTemplateVersionByID(ctx, target.ID)
+}
+
+// GetActiveCanaryVersion returns the template's single active `canary`-state
+// version (#484), or ok=false when none is canarying. It is the indexed lookup
+// (idx_atv_canary) the routing seam and the daemon regression comparator use to
+// discover the active canary. An unresolvable/empty template yields ok=false, not
+// an error.
+func (s *Store) GetActiveCanaryVersion(ctx context.Context, templateID string) (AgentTemplateVersion, bool, error) {
+	templateID = strings.TrimSpace(templateID)
+	if templateID == "" {
+		return AgentTemplateVersion{}, false, nil
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at, canary_sample, canary_started_at
+		FROM agent_template_versions
+		WHERE template_id = ? AND state = 'canary'
+		ORDER BY version DESC LIMIT 1`, templateID)
+	version, err := scanAgentTemplateVersion(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AgentTemplateVersion{}, false, nil
+	}
+	if err != nil {
+		return AgentTemplateVersion{}, false, err
+	}
+	return version, true, nil
 }
 
 func (s *Store) DecideSkillOptTrainCandidate(ctx context.Context, session SkillOptTrainSession, iteration SkillOptTrainIteration, candidateID string, decision string) (AgentTemplateVersion, error) {
@@ -5008,7 +5130,7 @@ func scanAgentTemplateWithVersion(scanner agentTemplateScanner) (AgentTemplate, 
 
 func scanAgentTemplateVersion(scanner agentTemplateScanner) (AgentTemplateVersion, error) {
 	var version AgentTemplateVersion
-	if err := scanner.Scan(&version.ID, &version.TemplateID, &version.VersionNumber, &version.State, &version.Name, &version.Description, &version.SourceRepo, &version.SourceRef, &version.SourcePath, &version.ResolvedCommit, &version.ContentHash, &version.Content, &version.MetadataJSON, &version.CreatedAt, &version.UpdatedAt, &version.PromotedAt); err != nil {
+	if err := scanner.Scan(&version.ID, &version.TemplateID, &version.VersionNumber, &version.State, &version.Name, &version.Description, &version.SourceRepo, &version.SourceRef, &version.SourcePath, &version.ResolvedCommit, &version.ContentHash, &version.Content, &version.MetadataJSON, &version.CreatedAt, &version.UpdatedAt, &version.PromotedAt, &version.CanarySample, &version.CanaryStartedAt); err != nil {
 		return AgentTemplateVersion{}, err
 	}
 	if version.ContentHash == "" {
@@ -5557,7 +5679,7 @@ func SplitAgentTemplateReference(ref string) (string, string) {
 }
 
 func getCurrentAgentTemplateVersion(ctx context.Context, tx *sql.Tx, templateID string) (AgentTemplateVersion, bool, error) {
-	row := tx.QueryRowContext(ctx, `SELECT v.id, v.template_id, v.version, v.state, v.name, v.description, v.source_repo, v.source_ref, v.source_path, v.resolved_commit, v.content_hash, v.content, v.metadata_json, v.created_at, v.updated_at, v.promoted_at
+	row := tx.QueryRowContext(ctx, `SELECT v.id, v.template_id, v.version, v.state, v.name, v.description, v.source_repo, v.source_ref, v.source_path, v.resolved_commit, v.content_hash, v.content, v.metadata_json, v.created_at, v.updated_at, v.promoted_at, v.canary_sample, v.canary_started_at
 		FROM agent_templates t
 		JOIN agent_template_versions v ON v.id = t.current_version_id
 		WHERE t.id = ?`, templateID)
@@ -5572,7 +5694,7 @@ func getCurrentAgentTemplateVersion(ctx context.Context, tx *sql.Tx, templateID 
 }
 
 func getAgentTemplateVersionByIDTx(ctx context.Context, tx *sql.Tx, versionID string) (AgentTemplateVersion, error) {
-	row := tx.QueryRowContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at
+	row := tx.QueryRowContext(ctx, `SELECT id, template_id, version, state, name, description, source_repo, source_ref, source_path, resolved_commit, content_hash, content, metadata_json, created_at, updated_at, promoted_at, canary_sample, canary_started_at
 		FROM agent_template_versions WHERE id = ?`, strings.TrimSpace(versionID))
 	return scanAgentTemplateVersion(row)
 }
@@ -6206,5 +6328,20 @@ CREATE TABLE skillopt_bandit_arms (
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	PRIMARY KEY (template_id, template_version_id)
 );
+	`,
+	// #484 canary promotion: a new `canary` version state plus two columns that
+	// record the active canary's sampled-traffic fraction and window-start so the
+	// routing seam and the daemon regression comparator can find/parametrize it.
+	// The state column is already free-text TEXT, so no structural change is needed;
+	// these columns carry DEFAULTs (0 / '') so every existing row reads identically
+	// and this migration is a pure additive append (it does not renumber or alter
+	// any prior migration). The partial index makes the "active canary for this
+	// template" lookup a single indexed probe (at most one canary row per template
+	// at a time) and indexes no non-canary rows.
+	`
+ALTER TABLE agent_template_versions ADD COLUMN canary_sample REAL NOT NULL DEFAULT 0;
+ALTER TABLE agent_template_versions ADD COLUMN canary_started_at TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX idx_atv_canary ON agent_template_versions(template_id) WHERE state = 'canary';
 	`,
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1474,24 +1474,31 @@ func (s *Store) UpdateAgentTemplateMetadata(ctx context.Context, templateID stri
 	return s.GetAgentTemplate(ctx, templateID)
 }
 
-func (s *Store) RejectAgentTemplateVersion(ctx context.Context, versionID string, reason string) (AgentTemplateVersion, error) {
+// RejectAgentTemplateVersion retires a pending (#471) or canary (#484) candidate.
+// The returned changed bool reports whether THIS call performed the rejection
+// transition: it is false in the idempotent already-rejected branch and true when
+// the row actually moved to `rejected`. Callers that emit a one-shot side effect on
+// rejection (the #484 candidate.rolled_back event) MUST gate it on changed so a
+// concurrent / post-crash re-run does not double-fire.
+func (s *Store) RejectAgentTemplateVersion(ctx context.Context, versionID string, reason string) (AgentTemplateVersion, bool, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return AgentTemplateVersion{}, err
+		return AgentTemplateVersion{}, false, err
 	}
 	defer tx.Rollback()
 	target, err := getAgentTemplateVersionByIDTx(ctx, tx, versionID)
 	if err != nil {
-		return AgentTemplateVersion{}, err
+		return AgentTemplateVersion{}, false, err
 	}
-	// Idempotent: an already-rejected target is a no-op success so the #484 canary
-	// auto-rollback (which rejects the regressing canary) can be re-run safely after
-	// a crash without erroring.
+	// Idempotent: an already-rejected target is a no-op success (changed=false) so
+	// the #484 canary auto-rollback (which rejects the regressing canary) can be
+	// re-run safely after a crash — or raced by a concurrent harvest — without
+	// erroring AND without re-firing the rolled_back event.
 	if target.State == "rejected" {
 		if err := tx.Commit(); err != nil {
-			return AgentTemplateVersion{}, err
+			return AgentTemplateVersion{}, false, err
 		}
-		return target, nil
+		return target, false, nil
 	}
 	// A `pending` candidate rejects directly (#471); a `canary` candidate (#484) is
 	// retired by the auto-rollback. A canary never holds current_version_id (the
@@ -1499,29 +1506,33 @@ func (s *Store) RejectAgentTemplateVersion(ctx context.Context, versionID string
 	// champion live — no current pointer changes. The canary fraction/window are
 	// cleared so no stale routing state remains.
 	if target.State != "pending" && target.State != "canary" {
-		return AgentTemplateVersion{}, fmt.Errorf("agent template version %s is %s, not pending or canary", target.ID, target.State)
+		return AgentTemplateVersion{}, false, fmt.Errorf("agent template version %s is %s, not pending or canary", target.ID, target.State)
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE agent_template_versions SET state = 'rejected', updated_at = CURRENT_TIMESTAMP, canary_sample = 0, canary_started_at = '' WHERE id = ?`, target.ID); err != nil {
-		return AgentTemplateVersion{}, err
+		return AgentTemplateVersion{}, false, err
 	}
 	latestID, err := latestSelectableVersionID(ctx, tx, target.TemplateID)
 	if err != nil {
-		return AgentTemplateVersion{}, err
+		return AgentTemplateVersion{}, false, err
 	}
 	result, err := tx.ExecContext(ctx, `UPDATE agent_templates SET latest_version_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, latestID, target.TemplateID)
 	if err != nil {
-		return AgentTemplateVersion{}, err
+		return AgentTemplateVersion{}, false, err
 	}
 	if err := requireAffected(result, "agent template", target.TemplateID); err != nil {
-		return AgentTemplateVersion{}, err
+		return AgentTemplateVersion{}, false, err
 	}
 	if err := upsertAgentTemplateCandidateReviewDecisionTx(ctx, tx, target, "rejected", reason); err != nil {
-		return AgentTemplateVersion{}, err
+		return AgentTemplateVersion{}, false, err
 	}
 	if err := tx.Commit(); err != nil {
-		return AgentTemplateVersion{}, err
+		return AgentTemplateVersion{}, false, err
 	}
-	return s.GetAgentTemplateVersionByID(ctx, target.ID)
+	version, err := s.GetAgentTemplateVersionByID(ctx, target.ID)
+	if err != nil {
+		return AgentTemplateVersion{}, false, err
+	}
+	return version, true, nil
 }
 
 // RevertAgentTemplateVersion makes a previously superseded version current

--- a/internal/db/store_canary_test.go
+++ b/internal/db/store_canary_test.go
@@ -1,0 +1,262 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// seedCanaryTemplate installs a template (v1 = current champion) and adds a fresh
+// pending v2 candidate, returning the champion v1 and the pending v2.
+func seedCanaryTemplate(t *testing.T, store *Store) (champion, pending AgentTemplateVersion) {
+	t.Helper()
+	ctx := context.Background()
+	base := AgentTemplate{ID: "planner", Name: "Planner", SourceRepo: "o/r", SourceRef: "main", SourcePath: "p.md", ResolvedCommit: "commit-v1", Content: "v1 content"}
+	if err := store.UpsertAgentTemplate(ctx, base); err != nil {
+		t.Fatalf("upsert template: %v", err)
+	}
+	v1, err := store.GetLatestAgentTemplateVersion(ctx, "planner")
+	if err != nil {
+		t.Fatalf("latest v1: %v", err)
+	}
+	v2Template := base
+	v2Template.Content = "v2 content"
+	v2Template.ResolvedCommit = "commit-v2"
+	v2, err := store.AddPendingAgentTemplateVersion(ctx, v2Template)
+	if err != nil {
+		t.Fatalf("add v2: %v", err)
+	}
+	championV1, err := store.GetAgentTemplateVersionByID(ctx, v1.VersionID)
+	if err != nil {
+		t.Fatalf("get v1: %v", err)
+	}
+	return championV1, v2
+}
+
+// TestCanaryPromoteLeavesChampionCurrent proves CanaryPromoteAgentTemplateVersion
+// (#484) transitions the pending candidate to `canary` WITHOUT changing the
+// template's current_version_id: the champion stays current, the canary records
+// its sample/window, and the canary never becomes latest_version_id.
+func TestCanaryPromoteLeavesChampionCurrent(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	champion, pending := seedCanaryTemplate(t, store)
+
+	canary, err := store.CanaryPromoteAgentTemplateVersion(ctx, pending.ID, 0.2)
+	if err != nil {
+		t.Fatalf("canary promote: %v", err)
+	}
+	if canary.State != "canary" {
+		t.Fatalf("canary state = %q, want canary", canary.State)
+	}
+	if canary.CanarySample != 0.2 {
+		t.Fatalf("canary sample = %v, want 0.2", canary.CanarySample)
+	}
+	if canary.CanaryStartedAt == "" {
+		t.Fatal("canary_started_at must be set")
+	}
+	// The champion is STILL current; the live template content is unchanged.
+	tmpl, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("get template: %v", err)
+	}
+	if tmpl.VersionID != champion.ID {
+		t.Fatalf("current version = %q, want champion %q", tmpl.VersionID, champion.ID)
+	}
+	if tmpl.Content != "v1 content" {
+		t.Fatalf("live content = %q, want v1 content (champion stays current)", tmpl.Content)
+	}
+	// The canary must NOT be latest_version_id (it would otherwise leak into latest).
+	latest, err := store.GetLatestAgentTemplateVersion(ctx, "planner")
+	if err != nil {
+		t.Fatalf("get latest: %v", err)
+	}
+	if latest.VersionID == canary.ID {
+		t.Fatalf("canary must not be latest_version_id, got %q", latest.VersionID)
+	}
+	// GetActiveCanaryVersion finds it.
+	got, found, err := store.GetActiveCanaryVersion(ctx, "planner")
+	if err != nil || !found {
+		t.Fatalf("GetActiveCanaryVersion found=%v err=%v", found, err)
+	}
+	if got.ID != canary.ID {
+		t.Fatalf("active canary = %q, want %q", got.ID, canary.ID)
+	}
+}
+
+// TestCanaryPromoteRejectsSecondCanary proves at most one active canary per template.
+func TestCanaryPromoteRejectsSecondCanary(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	_, pending := seedCanaryTemplate(t, store)
+	if _, err := store.CanaryPromoteAgentTemplateVersion(ctx, pending.ID, 0.2); err != nil {
+		t.Fatalf("first canary: %v", err)
+	}
+	// A second pending candidate cannot also become a canary while one is active.
+	base := AgentTemplate{ID: "planner", Name: "Planner", SourceRepo: "o/r", SourceRef: "main", SourcePath: "p.md", ResolvedCommit: "commit-v3", Content: "v3 content"}
+	v3, err := store.AddPendingAgentTemplateVersion(ctx, base)
+	if err != nil {
+		t.Fatalf("add v3: %v", err)
+	}
+	if _, err := store.CanaryPromoteAgentTemplateVersion(ctx, v3.ID, 0.2); err == nil {
+		t.Fatal("a second active canary must be refused")
+	}
+}
+
+// TestCanaryGraduate proves PromoteAgentTemplateVersion (#484-extended) graduates a
+// canary to current and supersedes the prior champion, and that the EXISTING
+// RevertAgentTemplateVersion can then restore the superseded champion (the
+// graduated-regret rollback round-trip).
+func TestCanaryGraduate(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	champion, pending := seedCanaryTemplate(t, store)
+	canary, err := store.CanaryPromoteAgentTemplateVersion(ctx, pending.ID, 1.0)
+	if err != nil {
+		t.Fatalf("canary promote: %v", err)
+	}
+
+	graduated, err := store.PromoteAgentTemplateVersion(ctx, canary.ID)
+	if err != nil {
+		t.Fatalf("graduate canary: %v", err)
+	}
+	if graduated.State != "current" {
+		t.Fatalf("graduated state = %q, want current", graduated.State)
+	}
+	if graduated.CanarySample != 0 || graduated.CanaryStartedAt != "" {
+		t.Fatalf("graduated canary must clear canary window, got sample=%v started=%q", graduated.CanarySample, graduated.CanaryStartedAt)
+	}
+	tmpl, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("get template: %v", err)
+	}
+	if tmpl.VersionID != canary.ID || tmpl.Content != "v2 content" {
+		t.Fatalf("after graduate current = %q content = %q, want canary v2", tmpl.VersionID, tmpl.Content)
+	}
+	// The prior champion is now superseded; no active canary remains.
+	championAfter, err := store.GetAgentTemplateVersionByID(ctx, champion.ID)
+	if err != nil {
+		t.Fatalf("get champion: %v", err)
+	}
+	if championAfter.State != "superseded" {
+		t.Fatalf("champion state after graduate = %q, want superseded", championAfter.State)
+	}
+	if _, found, _ := store.GetActiveCanaryVersion(ctx, "planner"); found {
+		t.Fatal("no canary should remain active after graduate")
+	}
+	// Graduated-regret rollback: the EXISTING RevertAgentTemplateVersion restores the
+	// superseded champion as current.
+	reverted, err := store.RevertAgentTemplateVersion(ctx, "planner", champion.ID)
+	if err != nil {
+		t.Fatalf("revert to champion: %v", err)
+	}
+	if reverted.State != "current" {
+		t.Fatalf("reverted champion state = %q, want current", reverted.State)
+	}
+}
+
+// TestCanaryRollbackKeepsChampion proves the daemon's rollback shape at the store
+// level: rejecting the canary leaves the champion as the live current version (the
+// canary never displaced it), and the reject is idempotent.
+func TestCanaryRollbackKeepsChampion(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	champion, pending := seedCanaryTemplate(t, store)
+	canary, err := store.CanaryPromoteAgentTemplateVersion(ctx, pending.ID, 0.5)
+	if err != nil {
+		t.Fatalf("canary promote: %v", err)
+	}
+
+	rejected, err := store.RejectAgentTemplateVersion(ctx, canary.ID, "auto-rollback: regression")
+	if err != nil {
+		t.Fatalf("reject canary: %v", err)
+	}
+	if rejected.State != "rejected" {
+		t.Fatalf("rejected canary state = %q, want rejected", rejected.State)
+	}
+	if rejected.CanarySample != 0 || rejected.CanaryStartedAt != "" {
+		t.Fatalf("rejected canary must clear window, got sample=%v started=%q", rejected.CanarySample, rejected.CanaryStartedAt)
+	}
+	// The champion is still current with its content; never left without a current.
+	tmpl, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("get template: %v", err)
+	}
+	if tmpl.VersionID != champion.ID || tmpl.Content != "v1 content" {
+		t.Fatalf("after rollback current = %q content = %q, want champion v1", tmpl.VersionID, tmpl.Content)
+	}
+	// Idempotent: rejecting an already-rejected canary is a no-op success.
+	if _, err := store.RejectAgentTemplateVersion(ctx, canary.ID, "again"); err != nil {
+		t.Fatalf("re-reject (idempotent) returned error: %v", err)
+	}
+	if _, found, _ := store.GetActiveCanaryVersion(ctx, "planner"); found {
+		t.Fatal("no canary should remain active after rollback")
+	}
+}
+
+// TestCanaryPromoteRequiresPending proves only a pending candidate can become a
+// canary (a superseded/current/rejected target is refused) and the sample must be
+// in (0,1].
+func TestCanaryPromoteValidation(t *testing.T) {
+	store := openCockpitStore(t)
+	ctx := context.Background()
+	champion, pending := seedCanaryTemplate(t, store)
+	if _, err := store.CanaryPromoteAgentTemplateVersion(ctx, pending.ID, 0); err == nil {
+		t.Fatal("sample 0 must be refused")
+	}
+	if _, err := store.CanaryPromoteAgentTemplateVersion(ctx, pending.ID, 1.5); err == nil {
+		t.Fatal("sample > 1 must be refused")
+	}
+	// The current champion is not pending and cannot become a canary.
+	if _, err := store.CanaryPromoteAgentTemplateVersion(ctx, champion.ID, 0.2); err == nil {
+		t.Fatal("a non-pending target must be refused")
+	}
+}
+
+// TestCanaryMigrationOnPreExistingDB proves the #484 columns are added with safe
+// DEFAULTs on a pre-existing DB: a row inserted before the canary migration reads
+// canary_sample=0 / canary_started_at="" after the upgrade, and the migration is
+// idempotent (re-Open does not re-apply).
+func TestCanaryMigrationOnPreExistingDB(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	// Apply every migration EXCEPT the last (the #484 canary migration), then seed a
+	// version row through the schema-before-canary.
+	store := &Store{db: raw}
+	for version, migration := range migrations[:len(migrations)-1] {
+		if err := store.applyMigration(ctx, version+1, migration); err != nil {
+			t.Fatalf("applyMigration(%d): %v", version+1, err)
+		}
+	}
+	if _, err := raw.ExecContext(ctx, `INSERT INTO agent_template_versions(id, template_id, version, state, name, source_repo, source_ref, source_path, resolved_commit, content)
+		VALUES ('planner@v1', 'planner', 1, 'current', 'Planner', 'o/r', 'main', 'p.md', 'abc', 'v1')`); err != nil {
+		t.Fatalf("seed legacy version: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw: %v", err)
+	}
+
+	upgraded, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open (migrate): %v", err)
+	}
+	defer upgraded.Close()
+	v, err := upgraded.GetAgentTemplateVersionByID(ctx, "planner@v1")
+	if err != nil {
+		t.Fatalf("get migrated version: %v", err)
+	}
+	if v.CanarySample != 0 || v.CanaryStartedAt != "" {
+		t.Fatalf("migrated row canary defaults = (%v, %q), want (0, \"\")", v.CanarySample, v.CanaryStartedAt)
+	}
+	// Idempotent: re-opening applies nothing new.
+	again, err := Open(path)
+	if err != nil {
+		t.Fatalf("re-Open (idempotent migrate): %v", err)
+	}
+	again.Close()
+}

--- a/internal/db/store_canary_test.go
+++ b/internal/db/store_canary_test.go
@@ -168,9 +168,12 @@ func TestCanaryRollbackKeepsChampion(t *testing.T) {
 		t.Fatalf("canary promote: %v", err)
 	}
 
-	rejected, err := store.RejectAgentTemplateVersion(ctx, canary.ID, "auto-rollback: regression")
+	rejected, changed, err := store.RejectAgentTemplateVersion(ctx, canary.ID, "auto-rollback: regression")
 	if err != nil {
 		t.Fatalf("reject canary: %v", err)
+	}
+	if !changed {
+		t.Fatalf("first canary reject must report changed=true")
 	}
 	if rejected.State != "rejected" {
 		t.Fatalf("rejected canary state = %q, want rejected", rejected.State)
@@ -186,9 +189,13 @@ func TestCanaryRollbackKeepsChampion(t *testing.T) {
 	if tmpl.VersionID != champion.ID || tmpl.Content != "v1 content" {
 		t.Fatalf("after rollback current = %q content = %q, want champion v1", tmpl.VersionID, tmpl.Content)
 	}
-	// Idempotent: rejecting an already-rejected canary is a no-op success.
-	if _, err := store.RejectAgentTemplateVersion(ctx, canary.ID, "again"); err != nil {
+	// Idempotent: rejecting an already-rejected canary is a no-op success that
+	// reports changed=false so a concurrent/post-crash re-run never re-fires the
+	// rolled_back event (#484).
+	if _, changed, err := store.RejectAgentTemplateVersion(ctx, canary.ID, "again"); err != nil {
 		t.Fatalf("re-reject (idempotent) returned error: %v", err)
+	} else if changed {
+		t.Fatalf("re-reject of an already-rejected canary must report changed=false")
 	}
 	if _, found, _ := store.GetActiveCanaryVersion(ctx, "planner"); found {
 		t.Fatal("no canary should remain active after rollback")

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1990,9 +1990,12 @@ func TestRepositoryMethods(t *testing.T) {
 	if review.State != "promoted" || review.DecidedAt == "" {
 		t.Fatalf("review after promote = %+v", review)
 	}
-	rejected, err := store.RejectAgentTemplateVersion(ctx, newerPending.ID, "too verbose")
+	rejected, changed, err := store.RejectAgentTemplateVersion(ctx, newerPending.ID, "too verbose")
 	if err != nil {
 		t.Fatalf("RejectAgentTemplateVersion returned error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("first reject must report changed=true")
 	}
 	if rejected.State != "rejected" {
 		t.Fatalf("rejected = %+v", rejected)

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -61,6 +61,21 @@ const (
 	// redacted reason naming the guardrails that passed, so a human can review or
 	// roll back even in full-auto.
 	EventCandidateAutoPromoted EventType = "candidate.auto_promoted"
+	// EventCandidateCanaryStarted is emitted once when the off-by-default
+	// [skillopt].auto_promote_canary path promotes a pending candidate to the
+	// `canary` state (#484) behind the live champion, AFTER the
+	// CanaryPromoteAgentTemplateVersion write. JobID is the canary version id,
+	// RootID the template id, Status "canary_started", Detail a redacted reason
+	// naming the guardrails that passed and the sample fraction — so a human sees a
+	// canary went live and can watch the regression window.
+	EventCandidateCanaryStarted EventType = "candidate.canary_started"
+	// EventCandidateRolledBack is emitted once when the #484 daemon regression
+	// window AUTO-ROLLS-BACK a canary on a material regression vs the prior
+	// champion: the champion stays the live current version and the canary is
+	// rejected. JobID is the rolled-back canary version id, RootID the template id,
+	// Status "rolled_back", Detail a redacted reason naming the score comparison, so
+	// a human sees the auto-rollback happened.
+	EventCandidateRolledBack EventType = "candidate.rolled_back"
 
 	// Reserved for the graduate step (parsed/enumerated but NOT emitted by the
 	// pilot). Listed so downstream consumers can switch over them forward-

--- a/internal/skillopt/auto_promote.go
+++ b/internal/skillopt/auto_promote.go
@@ -22,6 +22,14 @@ type AutoPromoteDecision struct {
 	// first blocking reason on a fail). It is redacted/path-scrubbed at the event
 	// seam before it leaves the box.
 	Reason string
+	// Canary (#484) is true ONLY on a Promote=true decision when canary mode is
+	// fully configured (auto_promote_canary AND a valid auto_promote_canary_sample):
+	// the candidate should be promoted to the `canary` state behind the live
+	// champion rather than directly to current. It is additive and internal (NOT a
+	// wire/contract field): when false (the default, including canary unset or
+	// misconfigured) the notify seam takes the existing #471 direct-promote path, so
+	// behavior is byte-identical. It is only ever consulted when Promote is true.
+	Canary bool
 }
 
 // notifyOnly is the canonical fail-safe decision: never promote, carry the reason.
@@ -102,8 +110,16 @@ func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackag
 	if policy.AutoPromoteRequireMeasuredJudge {
 		return notifyOnly("auto_promote_require_measured_judge is set but judge calibration is unavailable (deferred, #344); notify only")
 	}
-	if policy.AutoPromoteCanary {
-		return notifyOnly("auto_promote_canary is set but canary promotion is deferred; notify only")
+	// Canary mode (#484): when auto_promote_canary is set, promotion must go through
+	// a sampled canary + regression window rather than a direct promote. That path
+	// REQUIRES a valid auto_promote_canary_sample in (0,1]; without it the canary
+	// cannot route any traffic, so we FAIL SAFE to notify-only (never promote)
+	// rather than silently falling back to a direct full promote the operator did
+	// not ask for. When it IS valid, evaluation proceeds through the SAME guardrails
+	// below and the final pass sets Decision.Canary so the notify seam routes to the
+	// canary state instead of current.
+	if policy.AutoPromoteCanary && !policy.CanaryEnabled() {
+		return notifyOnly("auto_promote_canary is set but auto_promote_canary_sample is unset/invalid; notify only (canary needs a fraction in (0,1])")
 	}
 
 	// min_samples must always be set (the unset-is-hard-no discipline holds for both
@@ -198,6 +214,17 @@ func EvaluateAutoPromote(policy config.SkillOptPolicy, candidate CandidatePackag
 		passed = append(passed, fmt.Sprintf("confidence %.0f%% >= %.4g over %d samples", *confidence*100, floor, confidenceSamples))
 	}
 
+	// On a pass, route to the canary state (#484) when canary mode is fully
+	// configured; otherwise take the existing #471 direct-promote path. The reason
+	// names the destination so the candidate.* event explains whether the candidate
+	// went to canary or straight to current.
+	if policy.CanaryEnabled() {
+		return AutoPromoteDecision{
+			Promote: true,
+			Canary:  true,
+			Reason:  fmt.Sprintf("canary-promoted (sample %.3g): %s", *policy.AutoPromoteCanarySample, strings.Join(passed, ", ")),
+		}
+	}
 	return AutoPromoteDecision{
 		Promote: true,
 		Reason:  "auto-promoted: " + strings.Join(passed, ", "),

--- a/internal/skillopt/auto_promote_test.go
+++ b/internal/skillopt/auto_promote_test.go
@@ -38,6 +38,7 @@ func TestEvaluateAutoPromote(t *testing.T) {
 		confidence          *float64
 		confidenceSamples   int
 		wantPromote         bool
+		wantCanary          bool
 		reasonHas           string
 	}{
 		{
@@ -151,12 +152,48 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			reasonHas:   "require_measured_judge",
 		},
 		{
-			name:        "canary fails safe deferred",
+			// #484: canary requested but auto_promote_canary_sample UNSET => notify-only
+			// fail-safe (never a bare direct promote, never a canary).
+			name:        "canary without sample fails safe to notify-only",
 			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.5), AutoPromoteCanary: true},
 			candidate:   candidateWithScore(0.96),
 			feedback:    []db.FeedbackEvent{realCIFeedback()},
 			wantPromote: false,
-			reasonHas:   "canary",
+			wantCanary:  false,
+			reasonHas:   "auto_promote_canary_sample is unset",
+		},
+		{
+			// #484: canary + a valid sample + all guardrails pass => Promote=true AND
+			// Canary=true (route to the canary state, NOT a direct full promote).
+			name:        "canary with valid sample and guardrails pass routes to canary",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.5), AutoPromoteCanary: true, AutoPromoteCanarySample: floatPtr(0.1)},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: true,
+			wantCanary:  true,
+			reasonHas:   "canary-promoted",
+		},
+		{
+			// #484: canary + a valid sample but a guardrail FAILS => notify-only (no
+			// canary): the canary path never bypasses the guardrails.
+			name:        "canary with valid sample but failing guardrail stays pending",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.9), AutoPromoteCanary: true, AutoPromoteCanarySample: floatPtr(0.1)},
+			candidate:   candidateWithScore(0.4),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: false,
+			wantCanary:  false,
+			reasonHas:   "below auto_promote_min_score",
+		},
+		{
+			// #484 off-by-default: a guardrails-pass with canary OFF stays the #471
+			// direct promote (Promote=true, Canary=false) — byte-identical.
+			name:        "canary off stays direct promote",
+			policy:      config.SkillOptPolicy{AutoPromote: true, AutoPromoteMinSamples: intPtr(1), AutoPromoteMinScore: floatPtr(0.5)},
+			candidate:   candidateWithScore(0.96),
+			feedback:    []db.FeedbackEvent{realCIFeedback()},
+			wantPromote: true,
+			wantCanary:  false,
+			reasonHas:   "auto-promoted",
 		},
 		{
 			// MODE B (#473): a GENUINE ask-agent candidate has NO harvester feedback rows
@@ -229,6 +266,9 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			decision := EvaluateAutoPromote(tc.policy, tc.candidate, tc.feedback, tc.feedbackUnavailable, tc.confidence, tc.confidenceSamples)
 			if decision.Promote != tc.wantPromote {
 				t.Fatalf("Promote = %v, want %v (reason: %q)", decision.Promote, tc.wantPromote, decision.Reason)
+			}
+			if decision.Canary != tc.wantCanary {
+				t.Fatalf("Canary = %v, want %v (reason: %q)", decision.Canary, tc.wantCanary, decision.Reason)
 			}
 			if tc.reasonHas != "" && !strings.Contains(decision.Reason, tc.reasonHas) {
 				t.Fatalf("reason %q does not contain %q", decision.Reason, tc.reasonHas)

--- a/internal/skillopt/canary.go
+++ b/internal/skillopt/canary.go
@@ -1,0 +1,146 @@
+package skillopt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// CanaryDecision is the verdict of the bounded regression-window comparator
+// (#484). It is the canary analogue of #471's promote/notify-only decision, but
+// THREE-valued because a canary has a third, fail-safe outcome: keep sampling.
+type CanaryDecision string
+
+const (
+	// CanaryRollback retires the canary and keeps the prior champion live: the
+	// canary accrued enough verifiable outcomes AND its quality is materially below
+	// the champion's. This is the ONLY decision that reverses a canary; it is
+	// reached only on read evidence (never on uncertainty).
+	CanaryRollback CanaryDecision = "rollback"
+	// CanaryGraduate promotes the canary to full champion: it has enough outcomes
+	// AND is at parity-or-better than the prior champion.
+	CanaryGraduate CanaryDecision = "graduate"
+	// CanaryContinue keeps the canary sampling and the champion live: the
+	// fail-safe DEFAULT for every uncertainty — too few canary samples, no champion
+	// baseline to compare against, or feedback we could not read. Uncertainty never
+	// rolls back (never throws away the canary on unread evidence) and never
+	// graduates (never promotes the canary without confirming non-regression).
+	CanaryContinue CanaryDecision = "continue"
+)
+
+// CanaryVerdict is the pure result of EvaluateCanaryRegression: the decision plus
+// a short, human-facing reason that travels into the candidate.* event Detail.
+type CanaryVerdict struct {
+	Decision CanaryDecision
+	Reason   string
+}
+
+// Per-version coarse quality scores derived from the #465 harvest vocabulary.
+// They reuse the SAME band semantics the harvester writes (a strong real-CI
+// positive vs. a near-neutral empty-gate merge vs. a negative) so the comparator
+// never invents a new scoring scale.
+const (
+	// canaryScoreStrongPositive is a merge that passed GENUINE external CI (the
+	// FeedbackEventIsRealExternalCIPositive / scoreMergedRealCI band).
+	canaryScoreStrongPositive = 1.0
+	// canaryScoreNearPositive is a positive choice ("a") WITHOUT a real-CI marker —
+	// a near-neutral empty-gate merge or other soft positive.
+	canaryScoreNearPositive = 0.6
+	// canaryScoreNegative is a negative choice ("b").
+	canaryScoreNegative = 0.0
+)
+
+// canaryRegressionDelta is the MATERIAL-regression threshold: the canary's mean
+// quality score must be at least this far BELOW the prior champion's to trigger a
+// rollback. It is deliberately conservative (a buffer band, not a hair-trigger) so
+// ordinary sampling noise around parity GRADUATES rather than flapping into a
+// rollback. It is derived from the harvest score bands (the 0.4 gap between a
+// near-neutral 0.6 positive and a 1.0 strong positive) rather than a fresh magic
+// number, so it moves with the bands if they ever change.
+const canaryRegressionDelta = 0.2
+
+// EvaluateCanaryRegression is the pure, deterministic, total bounded-window
+// comparator (#484). Given the canary version's and the prior champion's harvested
+// auto-trace feedback events, the minimum sample floor (reusing
+// AutoPromoteMinSamples — no new knob), and per-side "could not read the feedback"
+// flags, it returns rollback / graduate / continue with a reason. It performs NO
+// I/O and NEVER mutates state: the daemon resolves the two runs, calls this, and
+// acts on the verdict via the EXISTING store rollback/graduate transactions.
+//
+// FAIL-SAFE DISCIPLINE (inverted vs. #471's promote: here uncertainty leaves the
+// champion live AND keeps the canary sampling — it never rolls back and never
+// graduates):
+//   - canaryUnavailable (a read error on the canary's run) -> continue: we never
+//     throw away a canary on evidence we could not read.
+//   - fewer than minSamples countable canary outcomes -> continue: the window is
+//     not yet decisive; keep sampling.
+//   - championUnavailable, or zero countable champion outcomes -> continue: with no
+//     baseline we can neither confirm a regression (so never rollback) nor confirm
+//     non-regression (so never graduate) — hold.
+//   - minSamples <= 0 -> continue: an unset/zero floor would let a single noisy
+//     sample decide; refuse to act without a real floor (mirrors the #471 unset
+//     min_samples hard stop).
+//
+// DECISION (only when both sides have read, decisive evidence):
+//   - canary score materially below champion (by >= canaryRegressionDelta) -> rollback.
+//   - otherwise (parity or improvement, within the buffer) -> graduate.
+func EvaluateCanaryRegression(canaryEvents, championEvents []db.FeedbackEvent, minSamples int, canaryUnavailable, championUnavailable bool) CanaryVerdict {
+	if minSamples <= 0 {
+		return CanaryVerdict{Decision: CanaryContinue, Reason: "no canary sample floor configured; holding (keep sampling)"}
+	}
+	if canaryUnavailable {
+		return CanaryVerdict{Decision: CanaryContinue, Reason: "canary feedback unavailable (read error); holding — never roll back on unread evidence"}
+	}
+	canaryScore, canarySamples := canaryVersionScore(canaryEvents)
+	if canarySamples < minSamples {
+		return CanaryVerdict{Decision: CanaryContinue, Reason: fmt.Sprintf("only %d canary outcome(s), below min_samples=%d; holding (keep sampling)", canarySamples, minSamples)}
+	}
+	if championUnavailable {
+		return CanaryVerdict{Decision: CanaryContinue, Reason: "champion feedback unavailable (read error); holding — no baseline to compare against"}
+	}
+	championScore, championSamples := canaryVersionScore(championEvents)
+	if championSamples == 0 {
+		return CanaryVerdict{Decision: CanaryContinue, Reason: "no champion baseline outcomes; holding — cannot confirm regression or non-regression"}
+	}
+	if canaryScore < championScore-canaryRegressionDelta {
+		return CanaryVerdict{
+			Decision: CanaryRollback,
+			Reason:   fmt.Sprintf("canary score %.3g materially below champion %.3g (delta>=%.3g) over %d/%d samples; rolling back", canaryScore, championScore, canaryRegressionDelta, canarySamples, championSamples),
+		}
+	}
+	return CanaryVerdict{
+		Decision: CanaryGraduate,
+		Reason:   fmt.Sprintf("canary score %.3g at parity-or-better than champion %.3g over %d/%d samples; graduating", canaryScore, championScore, canarySamples, championSamples),
+	}
+}
+
+// canaryVersionScore derives a coarse mean quality score in [0,1] and a countable
+// sample count from a version's harvested auto-trace feedback (#465 vocabulary). A
+// real-CI positive scores canaryScoreStrongPositive, any other positive choice
+// ("a") canaryScoreNearPositive, and a negative choice ("b") canaryScoreNegative;
+// events with neither an "a" nor "b" choice are ignored (not countable). The score
+// is the mean over countable events; with no countable events it is (0, 0).
+func canaryVersionScore(events []db.FeedbackEvent) (score float64, samples int) {
+	var sum float64
+	for _, event := range events {
+		switch strings.TrimSpace(strings.ToLower(event.Choice)) {
+		case "a":
+			if FeedbackEventIsRealExternalCIPositive(event) {
+				sum += canaryScoreStrongPositive
+			} else {
+				sum += canaryScoreNearPositive
+			}
+			samples++
+		case "b":
+			sum += canaryScoreNegative
+			samples++
+		default:
+			// Non-a/b rows (e.g. unscored placeholders) carry no verdict; skip.
+		}
+	}
+	if samples == 0 {
+		return 0, 0
+	}
+	return sum / float64(samples), samples
+}

--- a/internal/skillopt/canary.go
+++ b/internal/skillopt/canary.go
@@ -3,6 +3,7 @@ package skillopt
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 )
@@ -62,11 +63,22 @@ const canaryRegressionDelta = 0.2
 
 // EvaluateCanaryRegression is the pure, deterministic, total bounded-window
 // comparator (#484). Given the canary version's and the prior champion's harvested
-// auto-trace feedback events, the minimum sample floor (reusing
+// auto-trace feedback events, the canary window-start (canary_started_at — the
+// timestamp the canary was promoted), the minimum sample floor (reusing
 // AutoPromoteMinSamples — no new knob), and per-side "could not read the feedback"
 // flags, it returns rollback / graduate / continue with a reason. It performs NO
 // I/O and NEVER mutates state: the daemon resolves the two runs, calls this, and
 // acts on the verdict via the EXISTING store rollback/graduate transactions.
+//
+// BOUNDED WINDOW: BOTH event lists are first filtered to the canary window
+// (CreatedAt >= windowStart) so the canary's fresh outcomes are compared against
+// the champion's outcomes OVER THE SAME PERIOD, not the champion's entire-lifetime
+// mean. This makes it a true simultaneous A/B: a long-lived champion whose old
+// outcomes dragged its lifetime mean down (or up) can no longer produce a stale
+// baseline that wrongly graduates a regressing canary (or rolls back a healthy
+// one). When windowStart is empty/unparseable the filter is skipped (fail-open to
+// the prior lifetime baseline), and an event whose own CreatedAt cannot be parsed
+// is kept (never silently dropped).
 //
 // FAIL-SAFE DISCIPLINE (inverted vs. #471's promote: here uncertainty leaves the
 // champion live AND keeps the canary sampling — it never rolls back and never
@@ -85,13 +97,17 @@ const canaryRegressionDelta = 0.2
 // DECISION (only when both sides have read, decisive evidence):
 //   - canary score materially below champion (by >= canaryRegressionDelta) -> rollback.
 //   - otherwise (parity or improvement, within the buffer) -> graduate.
-func EvaluateCanaryRegression(canaryEvents, championEvents []db.FeedbackEvent, minSamples int, canaryUnavailable, championUnavailable bool) CanaryVerdict {
+func EvaluateCanaryRegression(canaryEvents, championEvents []db.FeedbackEvent, windowStart string, minSamples int, canaryUnavailable, championUnavailable bool) CanaryVerdict {
 	if minSamples <= 0 {
 		return CanaryVerdict{Decision: CanaryContinue, Reason: "no canary sample floor configured; holding (keep sampling)"}
 	}
 	if canaryUnavailable {
 		return CanaryVerdict{Decision: CanaryContinue, Reason: "canary feedback unavailable (read error); holding — never roll back on unread evidence"}
 	}
+	// Bound BOTH sides to the canary window so the baseline is the champion's
+	// CONCURRENT outcomes, not its lifetime mean (#484).
+	canaryEvents = withinCanaryWindow(canaryEvents, windowStart)
+	championEvents = withinCanaryWindow(championEvents, windowStart)
 	canaryScore, canarySamples := canaryVersionScore(canaryEvents)
 	if canarySamples < minSamples {
 		return CanaryVerdict{Decision: CanaryContinue, Reason: fmt.Sprintf("only %d canary outcome(s), below min_samples=%d; holding (keep sampling)", canarySamples, minSamples)}
@@ -143,4 +159,60 @@ func canaryVersionScore(events []db.FeedbackEvent) (score float64, samples int) 
 		return 0, 0
 	}
 	return sum / float64(samples), samples
+}
+
+// withinCanaryWindow returns the subset of events whose CreatedAt is at or after
+// the canary window-start, bounding the comparator to a matched A/B window (#484).
+// It is fail-open: an empty/unparseable windowStart returns all events unchanged
+// (the prior lifetime-baseline behavior), and an event whose own CreatedAt cannot
+// be parsed is KEPT rather than silently dropped — windowing must never throw away
+// evidence it cannot timestamp. The returned slice is freshly allocated, so the
+// caller's slices are never mutated.
+func withinCanaryWindow(events []db.FeedbackEvent, windowStart string) []db.FeedbackEvent {
+	start, ok := parseCanaryWindowTime(windowStart)
+	if !ok {
+		return events
+	}
+	filtered := make([]db.FeedbackEvent, 0, len(events))
+	for _, event := range events {
+		created, parsed := parseCanaryWindowTime(event.CreatedAt)
+		if parsed && created.Before(start) {
+			continue
+		}
+		filtered = append(filtered, event)
+	}
+	return filtered
+}
+
+// canaryWindowTimeLayouts are the timestamp formats the canary window comparator
+// tolerates so the RFC3339 canary_started_at and a feedback_events.created_at in
+// either RFC3339 (the harvester default) or SQLite's CURRENT_TIMESTAMP
+// 'YYYY-MM-DD HH:MM:SS' form all parse to a comparable instant.
+var canaryWindowTimeLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02 15:04:05.999999999",
+	"2006-01-02 15:04:05",
+	"2006-01-02T15:04:05",
+}
+
+// parseCanaryWindowTime parses a stored timestamp into a UTC instant, trying the
+// formats canary_started_at and feedback_events.created_at are written in. The
+// SQLite-datetime forms carry no zone and are read as UTC (matching how
+// CURRENT_TIMESTAMP and the RFC3339-UTC default are stored). It returns ok=false
+// for an empty or unrecognized value so the caller can fail open.
+func parseCanaryWindowTime(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range canaryWindowTimeLayouts {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.UTC(), true
+		}
+		if parsed, err := time.ParseInLocation(layout, value, time.UTC); err == nil {
+			return parsed.UTC(), true
+		}
+	}
+	return time.Time{}, false
 }

--- a/internal/skillopt/canary_test.go
+++ b/internal/skillopt/canary_test.go
@@ -1,0 +1,156 @@
+package skillopt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// negFeedback is a harvested negative outcome (choice "b"): a changes-requested
+// or reverted result, the lowest band.
+func negFeedback() db.FeedbackEvent {
+	return db.FeedbackEvent{Choice: "b", Reviewer: autoTraceReviewer, Source: autoTraceSource, Reasoning: "changes requested"}
+}
+
+func repeat(event db.FeedbackEvent, n int) []db.FeedbackEvent {
+	out := make([]db.FeedbackEvent, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, event)
+	}
+	return out
+}
+
+func TestEvaluateCanaryRegression(t *testing.T) {
+	cases := []struct {
+		name                string
+		canary              []db.FeedbackEvent
+		champion            []db.FeedbackEvent
+		minSamples          int
+		canaryUnavailable   bool
+		championUnavailable bool
+		want                CanaryDecision
+		reasonHas           string
+	}{
+		{
+			// (a) canary MATERIALLY worse than champion with >= minSamples => rollback.
+			name:       "material regression rolls back",
+			canary:     repeat(negFeedback(), 4),
+			champion:   repeat(realCIFeedback(), 4),
+			minSamples: 3,
+			want:       CanaryRollback,
+			reasonHas:  "rolling back",
+		},
+		{
+			// (b) fewer than minSamples canary outcomes => continue (keep sampling),
+			// even though the few it has are terrible.
+			name:       "thin canary samples hold",
+			canary:     repeat(negFeedback(), 2),
+			champion:   repeat(realCIFeedback(), 10),
+			minSamples: 3,
+			want:       CanaryContinue,
+			reasonHas:  "below min_samples",
+		},
+		{
+			// (c) canary feedback unavailable (read error) => continue: NEVER roll back
+			// on evidence we could not read.
+			name:              "canary unavailable holds (never roll back on unread evidence)",
+			canary:            nil,
+			champion:          repeat(realCIFeedback(), 10),
+			minSamples:        3,
+			canaryUnavailable: true,
+			want:              CanaryContinue,
+			reasonHas:         "unavailable",
+		},
+		{
+			// (d) canary at parity-or-better than champion => graduate.
+			name:       "parity or better graduates",
+			canary:     repeat(realCIFeedback(), 5),
+			champion:   repeat(realCIFeedback(), 5),
+			minSamples: 3,
+			want:       CanaryGraduate,
+			reasonHas:  "graduating",
+		},
+		{
+			// Canary strictly better than champion => graduate.
+			name:       "improvement graduates",
+			canary:     repeat(realCIFeedback(), 5),
+			champion:   repeat(noCIFeedback(), 5),
+			minSamples: 3,
+			want:       CanaryGraduate,
+			reasonHas:  "graduating",
+		},
+		{
+			// No champion baseline (empty) => continue: cannot confirm regression OR
+			// non-regression, so HOLD (fail-safe, never graduate without a baseline).
+			name:       "no champion baseline holds",
+			canary:     repeat(realCIFeedback(), 5),
+			champion:   nil,
+			minSamples: 3,
+			want:       CanaryContinue,
+			reasonHas:  "no champion baseline",
+		},
+		{
+			// Champion feedback unavailable (read error) => continue (no baseline).
+			name:                "champion unavailable holds",
+			canary:              repeat(realCIFeedback(), 5),
+			champion:            nil,
+			minSamples:          3,
+			championUnavailable: true,
+			want:                CanaryContinue,
+			reasonHas:           "champion feedback unavailable",
+		},
+		{
+			// minSamples <= 0 (unset floor) => continue: never act without a real floor.
+			name:       "no sample floor holds",
+			canary:     repeat(negFeedback(), 10),
+			champion:   repeat(realCIFeedback(), 10),
+			minSamples: 0,
+			want:       CanaryContinue,
+			reasonHas:  "no canary sample floor",
+		},
+		{
+			// A mild dip WITHIN the tolerance band (champion all real-CI=1.0, canary all
+			// near-positive=0.6 => delta 0.4 >= 0.2) is material => rollback. Confirms the
+			// band semantics: near-positive is materially below strong-positive.
+			name:       "near-positive canary vs strong-positive champion is material",
+			canary:     repeat(noCIFeedback(), 5),
+			champion:   repeat(realCIFeedback(), 5),
+			minSamples: 3,
+			want:       CanaryRollback,
+			reasonHas:  "rolling back",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			verdict := EvaluateCanaryRegression(tc.canary, tc.champion, tc.minSamples, tc.canaryUnavailable, tc.championUnavailable)
+			if verdict.Decision != tc.want {
+				t.Fatalf("Decision = %q, want %q (reason: %q)", verdict.Decision, tc.want, verdict.Reason)
+			}
+			if tc.reasonHas != "" && !strings.Contains(verdict.Reason, tc.reasonHas) {
+				t.Fatalf("reason %q does not contain %q", verdict.Reason, tc.reasonHas)
+			}
+		})
+	}
+}
+
+// TestCanaryVersionScoreBands proves the coarse per-version score reuses the #465
+// harvest vocabulary: a real-CI positive is the strong band, a near-neutral
+// choice-"a" the mid band, a choice-"b" the low band, and non-a/b rows are not
+// countable.
+func TestCanaryVersionScoreBands(t *testing.T) {
+	if score, n := canaryVersionScore([]db.FeedbackEvent{realCIFeedback()}); score != canaryScoreStrongPositive || n != 1 {
+		t.Fatalf("real-CI score = (%v, %d), want (%v, 1)", score, n, canaryScoreStrongPositive)
+	}
+	if score, n := canaryVersionScore([]db.FeedbackEvent{noCIFeedback()}); score != canaryScoreNearPositive || n != 1 {
+		t.Fatalf("near-positive score = (%v, %d), want (%v, 1)", score, n, canaryScoreNearPositive)
+	}
+	if score, n := canaryVersionScore([]db.FeedbackEvent{negFeedback()}); score != canaryScoreNegative || n != 1 {
+		t.Fatalf("negative score = (%v, %d), want (%v, 1)", score, n, canaryScoreNegative)
+	}
+	// A non-a/b row carries no verdict and is not counted.
+	if score, n := canaryVersionScore([]db.FeedbackEvent{{Choice: ""}}); score != 0 || n != 0 {
+		t.Fatalf("uncountable score = (%v, %d), want (0, 0)", score, n)
+	}
+}

--- a/internal/skillopt/canary_test.go
+++ b/internal/skillopt/canary_test.go
@@ -124,7 +124,7 @@ func TestEvaluateCanaryRegression(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			verdict := EvaluateCanaryRegression(tc.canary, tc.champion, tc.minSamples, tc.canaryUnavailable, tc.championUnavailable)
+			verdict := EvaluateCanaryRegression(tc.canary, tc.champion, "", tc.minSamples, tc.canaryUnavailable, tc.championUnavailable)
 			if verdict.Decision != tc.want {
 				t.Fatalf("Decision = %q, want %q (reason: %q)", verdict.Decision, tc.want, verdict.Reason)
 			}
@@ -133,6 +133,73 @@ func TestEvaluateCanaryRegression(t *testing.T) {
 			}
 		})
 	}
+}
+
+// at sets a feedback event's CreatedAt to an RFC3339 instant so the bounded-window
+// comparator can include/exclude it.
+func at(event db.FeedbackEvent, ts string) db.FeedbackEvent {
+	event.CreatedAt = ts
+	return event
+}
+
+// TestEvaluateCanaryRegressionWindow proves the comparator bounds BOTH sides to the
+// canary window (CreatedAt >= windowStart): a champion whose stale PRE-window
+// outcomes drag its lifetime mean DOWN no longer produces a low baseline that
+// wrongly graduates a regressing canary. With windowing, only the champion's
+// concurrent (in-window) strong outcomes count, so the regressing canary rolls back.
+func TestEvaluateCanaryRegressionWindow(t *testing.T) {
+	const windowStart = "2026-06-27T12:00:00Z"
+	// Champion: a long history of PRE-window negatives (which drag its lifetime mean
+	// far below parity) PLUS healthy in-window real-CI positives. Lifetime mean =
+	// (25*0.0 + 5*1.0)/30 ≈ 0.167; windowed baseline = 5*1.0/5 = 1.0.
+	champion := append(
+		repeatAt(negFeedback(), 25, "2026-06-01T00:00:00Z"),
+		repeatAt(realCIFeedback(), 5, "2026-06-27T13:00:00Z")...,
+	)
+	// Canary: all in-window negatives (score 0.0) — a genuine regression vs the
+	// windowed champion.
+	canary := repeatAt(negFeedback(), 5, "2026-06-27T13:30:00Z")
+
+	// With windowing the champion baseline is the in-window 1.0, so the canary's 0.0
+	// is materially below (0.0 < 1.0-0.2) => rollback.
+	if v := EvaluateCanaryRegression(canary, champion, windowStart, 3, false, false); v.Decision != CanaryRollback {
+		t.Fatalf("windowed: Decision = %q, want %q (reason: %q)", v.Decision, CanaryRollback, v.Reason)
+	}
+	// WITHOUT a window (empty), the champion's lifetime mean (~0.167) is dragged low
+	// by the pre-window negatives, so the canary's 0.0 is NOT materially below it
+	// (0.0 >= 0.167-0.2) => the regression is MASKED and it GRADUATES. This is the
+	// apples-to-oranges bug the window fixes; asserting it here pins the contrast.
+	if v := EvaluateCanaryRegression(canary, champion, "", 3, false, false); v.Decision != CanaryGraduate {
+		t.Fatalf("lifetime (no window): Decision = %q, want %q (reason: %q)", v.Decision, CanaryGraduate, v.Reason)
+	}
+}
+
+// TestParseCanaryWindowTime proves the window parser accepts both the RFC3339
+// canary_started_at / harvester-default created_at AND SQLite's CURRENT_TIMESTAMP
+// 'YYYY-MM-DD HH:MM:SS' form, all as the same UTC instant.
+func TestParseCanaryWindowTime(t *testing.T) {
+	rfc, ok := parseCanaryWindowTime("2026-06-27T12:00:00Z")
+	if !ok {
+		t.Fatal("RFC3339 must parse")
+	}
+	sqlite, ok := parseCanaryWindowTime("2026-06-27 12:00:00")
+	if !ok {
+		t.Fatal("SQLite datetime must parse")
+	}
+	if !rfc.Equal(sqlite) {
+		t.Fatalf("RFC3339 %v and SQLite %v must be the same instant", rfc, sqlite)
+	}
+	if _, ok := parseCanaryWindowTime("  "); ok {
+		t.Fatal("empty value must not parse (fail-open sentinel)")
+	}
+}
+
+func repeatAt(event db.FeedbackEvent, n int, ts string) []db.FeedbackEvent {
+	out := make([]db.FeedbackEvent, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, at(event, ts))
+	}
+	return out
 }
 
 // TestCanaryVersionScoreBands proves the coarse per-version score reuses the #465

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -93,6 +93,16 @@ type Engine struct {
 	Home                string
 	DelegationWorktrees WorktreeManager
 	DelegationCheckout  string
+	// CanaryEnabled gates the #484 canary ROUTING seam (Mailbox.routeCanary) on the
+	// SAME [skillopt] policy.CanaryEnabled() the daemon's regression comparator
+	// (daemonOutcomeHarvesterWithCanary) is gated on, so both seams turn on/off
+	// together. It is resolved ONCE at daemon-engine construction
+	// (daemonWorkflowEngine) and propagated into every Mailbox the engine builds via
+	// mailbox(). Default false (the engine's zero value and every test/ask-path
+	// Engine) means routing is off and resolution is byte-identical — a canary row
+	// left behind by a since-disabled run is never sampled, so it can never serve
+	// traffic without the comparator that would graduate or roll it back.
+	CanaryEnabled bool
 	// ArtifactRoot is the filesystem root under which delegation artifacts
 	// (delegations/<parent-job-id>/brief.md and context-manifest.json) are
 	// written when a coordinator returns delegations that request artifacts.
@@ -274,7 +284,7 @@ func (e Engine) now() time.Time {
 // path is byte-identical. The hook maps the terminal JobState to the event_type,
 // resolves root_id from the payload, and ships a redacted event fire-and-forget.
 func (e Engine) mailbox() Mailbox {
-	mb := Mailbox{Store: e.Store}
+	mb := Mailbox{Store: e.Store, CanaryEnabled: e.CanaryEnabled}
 	if e.EventSink == nil {
 		return mb
 	}
@@ -4206,7 +4216,7 @@ func (e Engine) enqueue(ctx context.Context, request JobRequest) error {
 	if request.ID == "" {
 		request.ID = e.jobID(request)
 	}
-	_, err := (Mailbox{Store: e.Store}).Enqueue(ctx, request)
+	_, err := e.mailbox().Enqueue(ctx, request)
 	if err == nil {
 		return nil
 	}

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
@@ -27,6 +28,15 @@ type Mailbox struct {
 	// constructed or emitted and behavior is byte-identical. The hook is
 	// fire-and-forget — it must never block or fail the finish.
 	emitTerminal func(ctx context.Context, jobID string, state JobState, payload JobPayload)
+	// CanaryRand, when set, is the per-resolution random draw in [0,1) the canary
+	// routing seam uses (#484) so tests can force a deterministic route (0.0 always
+	// hits the canary, a value >= sample always resolves the champion). When nil
+	// (the default, every production construction site) it falls back to the
+	// concurrency-safe global rand.Float64, so concurrent Enqueues each draw
+	// independently and safely. It is ONLY consulted when an active canary row
+	// exists for the resolved template, so when the feature is off the rng is never
+	// drawn and resolution is byte-identical.
+	CanaryRand func() float64
 }
 
 type JobRequest struct {
@@ -246,7 +256,63 @@ func (m Mailbox) templateSnapshot(ctx context.Context, agentName string) (db.Age
 		}
 		return db.AgentTemplate{}, err
 	}
+	// Canary routing (#484): a sampled fraction of resolutions that WOULD resolve the
+	// champion (the default/current reference, NOT a pinned version) route to the
+	// active canary version instead. The champion `template` resolved above is the
+	// always-valid fallback: any miss, error, or no-canary case returns it unchanged,
+	// so a mid-canary/half-promoted/missing canary or concurrent resolve can NEVER
+	// return no-template or a broken version. Off-by-default: with no canary row the
+	// lookup is one indexed miss, no rng is drawn, and the result is byte-identical.
+	if canary, ok := m.routeCanary(ctx, agent.TemplateID, template); ok {
+		return canary, nil
+	}
 	return template, nil
+}
+
+// routeCanary decides, for one resolution, whether to swap the resolved champion
+// snapshot for the template's active canary version (#484). It returns ok=false
+// (resolve the champion) in EVERY uncertain case — a pinned version reference, no
+// active canary, an out-of-range sample, a draw at/above the sample, or any store
+// error — so the champion (already resolved by the caller) is the guaranteed valid
+// fallback and resolution is never broken. The random draw is taken ONLY when an
+// active canary actually exists, keeping the no-canary path byte-identical.
+func (m Mailbox) routeCanary(ctx context.Context, agentTemplateRef string, champion db.AgentTemplate) (db.AgentTemplate, bool) {
+	templateID, versionRef := db.SplitAgentTemplateReference(agentTemplateRef)
+	// Only the default/current resolution participates in the canary; an explicit
+	// version pin (latest / @vN) is honored verbatim.
+	if versionRef != "" && versionRef != "current" {
+		return db.AgentTemplate{}, false
+	}
+	canary, found, err := m.Store.GetActiveCanaryVersion(ctx, templateID)
+	if err != nil || !found {
+		return db.AgentTemplate{}, false
+	}
+	sample := canary.CanarySample
+	if sample <= 0 || sample > 1 {
+		return db.AgentTemplate{}, false
+	}
+	if m.canaryDraw() >= sample {
+		return db.AgentTemplate{}, false
+	}
+	// Resolve the canary version's snapshot through the EXISTING reference path
+	// (canary.ID is "templateID@vN"), so its distinct ResolvedCommit/Content flow
+	// into the payload unchanged and the #465 harvester attributes the outcome to
+	// the canary version. A resolve error falls back to the champion (never break).
+	snap, err := m.Store.GetAgentTemplateReference(ctx, canary.ID)
+	if err != nil || strings.TrimSpace(snap.VersionID) == "" {
+		return db.AgentTemplate{}, false
+	}
+	return snap, true
+}
+
+// canaryDraw returns a per-resolution random draw in [0,1) for canary routing,
+// using the injected CanaryRand when set (deterministic tests) and the
+// concurrency-safe global rand.Float64 otherwise.
+func (m Mailbox) canaryDraw() float64 {
+	if m.CanaryRand != nil {
+		return m.CanaryRand()
+	}
+	return rand.Float64()
 }
 
 func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, adapter DeliveryAdapter) (AgentResult, error) {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -37,6 +37,19 @@ type Mailbox struct {
 	// exists for the resolved template, so when the feature is off the rng is never
 	// drawn and resolution is byte-identical.
 	CanaryRand func() float64
+	// CanaryEnabled gates the #484 canary ROUTING seam on the SAME policy the
+	// daemon's regression comparator uses (config.SkillOptPolicy.CanaryEnabled()),
+	// so the two seams turn on and off together. When false (the default, every
+	// construction site that does not opt in) routeCanary returns immediately —
+	// BEFORE the GetActiveCanaryVersion query — so no traffic is sampled, no rng is
+	// drawn, and the hot Enqueue path is byte-identical to before the feature
+	// existed. This is what stops a canary row from outliving the manager: turning
+	// auto_promote_canary off (or unsetting the sample) and restarting the daemon
+	// disables BOTH the comparator (no graduate/rollback) AND routing (no sampled
+	// traffic), so a stranded canary can never keep serving traffic with no
+	// auto-rollback. It is wired true only where the daemon-resolved policy reports
+	// CanaryEnabled().
+	CanaryEnabled bool
 }
 
 type JobRequest struct {
@@ -277,6 +290,15 @@ func (m Mailbox) templateSnapshot(ctx context.Context, agentName string) (db.Age
 // fallback and resolution is never broken. The random draw is taken ONLY when an
 // active canary actually exists, keeping the no-canary path byte-identical.
 func (m Mailbox) routeCanary(ctx context.Context, agentTemplateRef string, champion db.AgentTemplate) (db.AgentTemplate, bool) {
+	// Config gate (#484): routing is gated on the SAME policy the daemon's
+	// regression comparator uses, so the two seams are consistent. When the knob is
+	// off this returns before the GetActiveCanaryVersion query, so no rng is drawn,
+	// no traffic is sampled, and the path is byte-identical — and a canary row left
+	// behind by a since-disabled run can never keep serving traffic with no
+	// auto-rollback.
+	if !m.CanaryEnabled {
+		return db.AgentTemplate{}, false
+	}
 	templateID, versionRef := db.SplitAgentTemplateReference(agentTemplateRef)
 	// Only the default/current resolution participates in the canary; an explicit
 	// version pin (latest / @vN) is honored verbatim.

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1014,5 +1015,149 @@ func TestParseJobPayloadExported(t *testing.T) {
 	// Empty/malformed input errors (caller treats as no detail).
 	if _, err := ParseJobPayload(""); err == nil {
 		t.Fatal("empty payload should error")
+	}
+}
+
+// seedCanaryAgent installs a "planner" template (v1 current champion) + a pending
+// v2 candidate with a DISTINCT resolved_commit, promotes v2 to a canary at the
+// given sample, and binds an agent "planner-agent" to the template (unpinned). It
+// returns the store ready for an Enqueue with an injected CanaryRand.
+func seedCanaryAgent(t *testing.T, store *db.Store, sample float64) {
+	t.Helper()
+	ctx := context.Background()
+	base := db.AgentTemplate{ID: "planner", Name: "Planner", SourceRepo: "o/r", SourceRef: "main", SourcePath: "p.md", ResolvedCommit: "commit-v1", Content: "v1 content"}
+	if err := store.UpsertAgentTemplate(ctx, base); err != nil {
+		t.Fatalf("upsert template: %v", err)
+	}
+	v2 := base
+	v2.ResolvedCommit = "commit-v2"
+	v2.Content = "v2 content"
+	pending, err := store.AddPendingAgentTemplateVersion(ctx, v2)
+	if err != nil {
+		t.Fatalf("add v2: %v", err)
+	}
+	if _, err := store.CanaryPromoteAgentTemplateVersion(ctx, pending.ID, sample); err != nil {
+		t.Fatalf("canary promote: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "planner-agent", Role: "planner", Runtime: "codex", RuntimeRef: "last", RepoScope: "o/r", TemplateID: "planner", Capabilities: []string{"ask"}}); err != nil {
+		t.Fatalf("upsert agent: %v", err)
+	}
+}
+
+func enqueueAndResolve(t *testing.T, mailbox Mailbox, jobID string) JobPayload {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: jobID, Agent: "planner-agent", Action: "ask", Repo: "o/r"}); err != nil {
+		t.Fatalf("Enqueue %s: %v", jobID, err)
+	}
+	stored, err := mailbox.Store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob %s: %v", jobID, err)
+	}
+	payload, err := unmarshalPayload(stored.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload %s: %v", jobID, err)
+	}
+	return payload
+}
+
+// TestMailboxCanaryRoutingHitsCanary proves a draw BELOW the sample routes the
+// resolution to the canary version's snapshot (its distinct resolved_commit +
+// content), so the #465 harvester later attributes the outcome to the canary.
+func TestMailboxCanaryRoutingHitsCanary(t *testing.T) {
+	store := openTestStore(t)
+	seedCanaryAgent(t, store, 1.0)
+	mailbox := Mailbox{Store: store, CanaryRand: func() float64 { return 0.0 }}
+	payload := enqueueAndResolve(t, mailbox, "job-canary")
+	if payload.TemplateResolvedCommit != "commit-v2" || payload.TemplateContent != "v2 content" {
+		t.Fatalf("draw below sample must route to canary, got commit=%q content=%q", payload.TemplateResolvedCommit, payload.TemplateContent)
+	}
+	if payload.TemplateID != "planner" {
+		t.Fatalf("template id = %q, want planner", payload.TemplateID)
+	}
+}
+
+// TestMailboxCanaryRoutingMissesCanary proves a draw AT/ABOVE the sample resolves
+// the champion (byte-identical to the no-canary champion snapshot).
+func TestMailboxCanaryRoutingMissesCanary(t *testing.T) {
+	store := openTestStore(t)
+	seedCanaryAgent(t, store, 0.5)
+	mailbox := Mailbox{Store: store, CanaryRand: func() float64 { return 0.9 }}
+	payload := enqueueAndResolve(t, mailbox, "job-champ")
+	if payload.TemplateResolvedCommit != "commit-v1" || payload.TemplateContent != "v1 content" {
+		t.Fatalf("draw at/above sample must route to champion, got commit=%q content=%q", payload.TemplateResolvedCommit, payload.TemplateContent)
+	}
+}
+
+// TestMailboxCanaryOffByDefaultByteIdentical proves that with NO canary row the
+// resolution is byte-identical to today even when a CanaryRand that would always
+// hit (0.0) is injected: no canary exists, so no routing path is taken.
+func TestMailboxCanaryOffByDefaultByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	base := db.AgentTemplate{ID: "planner", Name: "Planner", SourceRepo: "o/r", SourceRef: "main", SourcePath: "p.md", ResolvedCommit: "commit-v1", Content: "v1 content"}
+	if err := store.UpsertAgentTemplate(ctx, base); err != nil {
+		t.Fatalf("upsert template: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "planner-agent", Role: "planner", Runtime: "codex", RuntimeRef: "last", RepoScope: "o/r", TemplateID: "planner", Capabilities: []string{"ask"}}); err != nil {
+		t.Fatalf("upsert agent: %v", err)
+	}
+	// Default mailbox (nil CanaryRand) and a forced-hit mailbox must resolve the SAME
+	// champion snapshot when no canary row exists.
+	def := enqueueAndResolve(t, Mailbox{Store: store}, "job-default")
+	forced := enqueueAndResolve(t, Mailbox{Store: store, CanaryRand: func() float64 { return 0.0 }}, "job-forced")
+	if def.TemplateResolvedCommit != "commit-v1" || def.TemplateContent != "v1 content" {
+		t.Fatalf("default resolution changed: %+v", def)
+	}
+	if forced.TemplateResolvedCommit != def.TemplateResolvedCommit || forced.TemplateContent != def.TemplateContent {
+		t.Fatalf("forced-hit resolution differs with no canary row: %+v vs %+v", forced, def)
+	}
+}
+
+// TestMailboxCanaryRoutingConcurrent proves the routing seam is concurrency-safe
+// and ALWAYS resolves a valid version under concurrent Enqueues against an active
+// canary (a mid-canary concurrent resolve never returns no-template/broken).
+func TestMailboxCanaryRoutingConcurrent(t *testing.T) {
+	store := openTestStore(t)
+	seedCanaryAgent(t, store, 0.5)
+	mailbox := Mailbox{Store: store} // real global rng — concurrency-safe
+	const n = 40
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			ctx := context.Background()
+			id := fmt.Sprintf("job-conc-%d", i)
+			if _, err := mailbox.Enqueue(ctx, JobRequest{ID: id, Agent: "planner-agent", Action: "ask", Repo: "o/r"}); err != nil {
+				errs <- err
+				return
+			}
+			stored, err := store.GetJob(ctx, id)
+			if err != nil {
+				errs <- err
+				return
+			}
+			payload, err := unmarshalPayload(stored.Payload)
+			if err != nil {
+				errs <- err
+				return
+			}
+			// EVERY resolution must be a valid version — either the champion or the
+			// canary, never empty/broken.
+			commit := payload.TemplateResolvedCommit
+			if commit != "commit-v1" && commit != "commit-v2" {
+				errs <- fmt.Errorf("job %s resolved invalid commit %q", id, commit)
+				return
+			}
+			if payload.TemplateContent == "" {
+				errs <- fmt.Errorf("job %s resolved empty template content", id)
+				return
+			}
+			errs <- nil
+		}(i)
+	}
+	for i := 0; i < n; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent enqueue: %v", err)
+		}
 	}
 }

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -1067,7 +1067,7 @@ func enqueueAndResolve(t *testing.T, mailbox Mailbox, jobID string) JobPayload {
 func TestMailboxCanaryRoutingHitsCanary(t *testing.T) {
 	store := openTestStore(t)
 	seedCanaryAgent(t, store, 1.0)
-	mailbox := Mailbox{Store: store, CanaryRand: func() float64 { return 0.0 }}
+	mailbox := Mailbox{Store: store, CanaryEnabled: true, CanaryRand: func() float64 { return 0.0 }}
 	payload := enqueueAndResolve(t, mailbox, "job-canary")
 	if payload.TemplateResolvedCommit != "commit-v2" || payload.TemplateContent != "v2 content" {
 		t.Fatalf("draw below sample must route to canary, got commit=%q content=%q", payload.TemplateResolvedCommit, payload.TemplateContent)
@@ -1082,10 +1082,28 @@ func TestMailboxCanaryRoutingHitsCanary(t *testing.T) {
 func TestMailboxCanaryRoutingMissesCanary(t *testing.T) {
 	store := openTestStore(t)
 	seedCanaryAgent(t, store, 0.5)
-	mailbox := Mailbox{Store: store, CanaryRand: func() float64 { return 0.9 }}
+	mailbox := Mailbox{Store: store, CanaryEnabled: true, CanaryRand: func() float64 { return 0.9 }}
 	payload := enqueueAndResolve(t, mailbox, "job-champ")
 	if payload.TemplateResolvedCommit != "commit-v1" || payload.TemplateContent != "v1 content" {
 		t.Fatalf("draw at/above sample must route to champion, got commit=%q content=%q", payload.TemplateResolvedCommit, payload.TemplateContent)
+	}
+}
+
+// TestMailboxCanaryDisabledIgnoresLiveCanary proves the #484 routing seam is gated
+// on the SAME policy the daemon's comparator uses: with an ACTIVE canary row but
+// CanaryEnabled=false (the knob off), even a forced-hit draw (0.0) resolves the
+// champion, never the canary. This is what stops a canary that outlived the
+// manager from continuing to serve sampled traffic with no auto-rollback once the
+// knob is turned off.
+func TestMailboxCanaryDisabledIgnoresLiveCanary(t *testing.T) {
+	store := openTestStore(t)
+	seedCanaryAgent(t, store, 1.0)
+	// CanaryEnabled defaults false; a forced-hit rng would route if the gate were
+	// open, so resolving the champion proves the gate short-circuits before the draw.
+	mailbox := Mailbox{Store: store, CanaryRand: func() float64 { return 0.0 }}
+	payload := enqueueAndResolve(t, mailbox, "job-gated")
+	if payload.TemplateResolvedCommit != "commit-v1" || payload.TemplateContent != "v1 content" {
+		t.Fatalf("canary disabled must resolve champion, got commit=%q content=%q", payload.TemplateResolvedCommit, payload.TemplateContent)
 	}
 }
 
@@ -1120,7 +1138,7 @@ func TestMailboxCanaryOffByDefaultByteIdentical(t *testing.T) {
 func TestMailboxCanaryRoutingConcurrent(t *testing.T) {
 	store := openTestStore(t)
 	seedCanaryAgent(t, store, 0.5)
-	mailbox := Mailbox{Store: store} // real global rng — concurrency-safe
+	mailbox := Mailbox{Store: store, CanaryEnabled: true} // real global rng — concurrency-safe
 	const n = 40
 	errs := make(chan error, n)
 	for i := 0; i < n; i++ {

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -21,7 +21,9 @@ The pilot emits a tight allowlist of event types over the webhook transport:
 | `job.blocked`                   | a job reaches the `blocked` terminal state                                         |
 | `job.needs_attention`           | a tree pauses awaiting a human (the `escalate_human` pause today)                  |
 | `candidate.awaiting_promotion`  | a SkillOpt template candidate becomes `pending` after import (always, off the auto-promote policy) |
-| `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current`          |
+| `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current` (also the canary GRADUATE event) |
+| `candidate.canary_started`      | the off-by-default `[skillopt].auto_promote_canary` policy promoted a candidate to the `canary` state behind the live champion |
+| `candidate.rolled_back`         | the canary regression window auto-rolled-back a canary on a material regression (champion stays current, canary rejected) |
 
 Each terminal transition emits **exactly once**. The engine owns the
 succeeded/failed/blocked emit on its `Mailbox` terminal path; the daemon owns the
@@ -39,6 +41,22 @@ holds, the candidate is promoted via the existing promote path and
 `candidate.auto_promoted` fires so the change can be reviewed or rolled back. The
 adjacent dashboard **Attention** page also lists every pending candidate
 (read-only), so candidates are visible locally even with `[events]` off.
+
+When `[skillopt].auto_promote_canary` is on **and** `auto_promote_canary_sample`
+is a fraction in `(0,1]`, a guardrails-pass candidate is promoted to a **canary**
+instead of straight to `current`: it routes that sampled fraction of new job
+resolutions while the prior champion stays the live current version, and
+`candidate.canary_started` fires (carrying the canary version id, template id, and
+the sample fraction). The daemon then watches a bounded regression window over the
+canary's harvested verifiable outcomes (reusing the Mode A trace signal, no new
+evaluator) and compares it to the prior champion: on parity-or-better it
+**graduates** the canary to `current` and emits `candidate.auto_promoted`; on a
+**material regression** it auto-rolls-back — the champion stays current, the canary
+is rejected, and `candidate.rolled_back` fires. It is **fail-safe**: too few canary
+outcomes, no champion baseline, or feedback it could not read all **hold** (keep
+sampling), never rolling back on unread evidence and never graduating without
+confirming non-regression. With the knob off (the default) promotion is the
+unchanged direct path and no canary event is ever emitted.
 
 The following `event_type` values are **reserved** for the graduate step. They
 are enumerated in the contract so a consumer can `switch` over them

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -365,7 +365,8 @@ auto_promote_min_samples = 0              # UNSET = hard "do not promote" (NOT 0
 auto_promote_min_score = 0.0              # UNSET, or a candidate with no score = do not promote
 auto_promote_require_external_ci = false  # require >= 1 real-external-CI feedback event in the eval_run
 auto_promote_require_measured_judge = false  # PARSED but DEFERRED (#344): true => fail safe to no-promote
-auto_promote_canary = false               # PARSED but DEFERRED (canary follow-on): true => fail safe to no-promote
+auto_promote_canary = false               # #484: true + a valid sample => promote to a CANARY (sampled) instead of direct; false = direct promote
+auto_promote_canary_sample = 0.1          # #484: canary sampled-traffic fraction in (0,1]; UNSET disables the canary (notify-only fail-safe when canary on)
 auto_promote_min_confidence = 0.95        # #473 Mode B: UNSET = ignore; SET = require bandit P(>) >= floor (+ enough samples)
 bandit_min_samples = 30                   # #473/#482 Mode B low-traffic floor (manual `skillopt ab` always allowed)
 live_ab_sample_rate = 0.0                 # #482 Mode B live A/B: 0.0 (default) = never intercept; fraction of foreground asks to A/B
@@ -395,11 +396,25 @@ auto-trace evidence fails safe to notify-only).
   free-text findings can never spoof it. It therefore applies only to **Mode A
   (auto-trace) runs**; a candidate with no harvested external-CI evidence fails
   safe to notify-only.
-- `auto_promote_require_measured_judge` and `auto_promote_canary` are **parsed but
-  deferred**: there is no judge↔human calibration source yet (gated on #344) and
-  the sampled-traffic canary + auto-rollback do not exist, so setting either to
-  `true` **forces notify-only** today. They are documented so a user can write the
-  knob forward-compatibly.
+- `auto_promote_require_measured_judge` is **parsed but deferred**: there is no
+  judge↔human calibration source yet (gated on #344), so setting it `true` **forces
+  notify-only** today. It is documented so a user can write the knob
+  forward-compatibly.
+- `auto_promote_canary` + `auto_promote_canary_sample` (#484) turn a guardrails-pass
+  promotion into a **canary** instead of a direct promote. When `auto_promote_canary`
+  is on **and** `auto_promote_canary_sample` is a fraction in `(0,1]`, the candidate
+  is promoted to the `canary` state behind the live champion (which stays `current`,
+  so non-sampled resolutions are byte-identical) and that fraction of new job
+  resolutions route to the canary version. A bounded daemon **regression window**
+  then reuses the candidate's auto-trace outcomes (no new evaluator) to compare the
+  canary against the prior champion: parity-or-better **graduates** it to `current`
+  (`candidate.auto_promoted`); a material regression **auto-rolls-back** (champion
+  stays current, canary rejected, `candidate.rolled_back`). It is **fail-safe** —
+  too few canary outcomes, no champion baseline, or unread feedback all **hold**
+  (keep sampling), never rolling back on unread evidence and never graduating without
+  confirming non-regression. `auto_promote_canary` on with the sample **unset/invalid
+  forces notify-only** (a misconfigured canary never promotes). Off (the default) is
+  byte-identical to the direct promote.
 - `auto_promote_min_confidence` (#473 Mode B) is **additive and optional**. **Unset
   ignores it entirely** — the auto-promote decision is byte-identical to the
   guardrails above. When **set**, auto-promote additionally requires a non-nil


### PR DESCRIPTION
Makes the previously-deferred `[skillopt].auto_promote_canary` knob real (follow-on to #471). When auto-promote fires **and** canary mode is configured with a valid `auto_promote_canary_sample` in `(0,1]`, a guardrails-pass candidate is promoted to a new **`canary`** version state **behind the live champion** (the champion stays `current`) and a sampled fraction of job resolutions route to the canary. A bounded daemon **regression window** reuses the #465 Mode A harvested outcomes (no new evaluator) to compare canary-vs-prior-champion and **graduates** it (`-> current`, `candidate.auto_promoted`) or **auto-rolls-back** on a material regression (champion stays current, canary rejected, `candidate.rolled_back`).

## Invariants
- **OFF BY DEFAULT / additive.** ContractVersion stays 1; no wire/contract struct changes. With the knob off (the default) promotion is the unchanged #471 direct promote, no canary state row is ever written, and **template resolution is byte-identical** (one indexed miss, no rng draw) — proven by an off-by-default golden test. With it on but `auto_promote` off, nothing auto-promotes (no canary is ever created).
- **Template-resolution safety.** Sampled routing lives in the single resolution seam (`Mailbox.templateSnapshot`); the resolved champion is the always-valid fallback for any miss/error/no-canary/concurrent case, so a mid-canary / missing / half-promoted canary can never return no-template or a broken version. The draw is injectable (`CanaryRand`) and concurrency-safe (global `rand`); covered by a concurrent routing test.
- **Routing always resolves a valid version.** A canary version carries a distinct `resolved_commit`, so the #465 harvester attributes canary-routed outcomes to `auto-trace:<canaryVersionID>` with zero harvester change.
- **Auto-rollback integrity.** Rollback never leaves the template without a current version or a dangling canary, and is idempotent. The prior champion stays the live `current` throughout the canary, so rollback retires the canary via the EXISTING `RejectAgentTemplateVersion` (idempotent on already-rejected) and reuses the EXISTING `RevertAgentTemplateVersion` defensively to guarantee the champion is current. Graduate reuses the EXISTING `PromoteAgentTemplateVersion` (extended to accept a canary target).
- **Fail-safe.** Canary on with the sample unset/invalid => notify-only. The comparator **holds** (never rolls back, never graduates) on too few canary samples, no champion baseline, or unread feedback — uncertainty never rolls back on unread evidence and never graduates without confirming non-regression.

## Changes
- **config**: `AutoPromoteCanarySample *float64` (validated `(0,1]`) + `CanaryEnabled()`; config stub in both the init template and docs.
- **db**: new `canary` state + `canary_sample`/`canary_started_at` columns via an appended, idempotent migration (DEFAULTs keep old rows identical, partial index for the active-canary lookup); `CanaryPromoteAgentTemplateVersion`, `GetActiveCanaryVersion`; `Promote`/`Reject` extended for the canary target.
- **workflow**: concurrency-safe sampled routing in `templateSnapshot`.
- **skillopt**: additive `AutoPromoteDecision.Canary`; new pure `EvaluateCanaryRegression` comparator (reuses the #465 harvest vocabulary).
- **cli**: `runCandidateNotify` canary branch + `candidate.canary_started`; daemon `canaryRegressionHarvester` decorator (off-by-default gate).
- **events**: `candidate.canary_started` / `candidate.rolled_back`.
- **docs**: events + skillopt-exchange-contract in both the in-repo and website trees.

## Tests
Comparator table (rollback / hold-thin / hold-unread / graduate); store canary transitions (champion stays current, graduate, rollback-keeps-champion, validation, migration on a pre-existing DB); sampled routing (hit at sample=1.0, miss above sample, off-by-default byte-identical, concurrent always-valid); `runCandidateNotify` canary path + off-by-default direct promote; daemon graduate/rollback/hold.

## Gate
`go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race ./internal/workflow/ ./internal/skillopt/ ./internal/db/` all green. The full `go test -race ./internal/cli/` is a known-slow suite that exceeds the sandbox time limit (CI only races `internal/workflow`); the new cli canary tests pass under `-race`.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)