### PR TITLE
fix(runtime): retry Claude delivery once on transient 401 socket-closed error (#487)

### DIFF
--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
@@ -375,10 +376,18 @@ func codexSandboxArgs(agent Agent) []string {
 	}
 }
 
+// defaultClaudeRetryBackoff is the pause between Claude delivery attempts when a
+// transient socket-closed failure is retried. ClaudeAdapter.RetryBackoff
+// overrides it; tests inject a near-zero value to stay fast.
+const defaultClaudeRetryBackoff = 500 * time.Millisecond
+
 type ClaudeAdapter struct {
 	Runner        subprocess.Runner
 	Dir           string
 	NewRuntimeRef func() (string, error)
+	// RetryBackoff is the pause before retrying a transient socket-closed
+	// delivery failure. When zero it defaults to defaultClaudeRetryBackoff.
+	RetryBackoff time.Duration
 }
 
 func (a ClaudeAdapter) Name() string { return ClaudeRuntime }
@@ -412,10 +421,23 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 		return Result{}, err
 	}
 	model := effectiveModel(agent, job)
-	args := claudeArgs(agent, job.Prompt, true, model)
-	result, err := a.runner().Run(ctx, a.Dir, "claude", args...)
-	if err != nil && isClaudeJSONUnsupported(result) {
-		result, err = a.runner().Run(ctx, a.Dir, "claude", claudeArgs(agent, job.Prompt, false, model)...)
+	// The Claude CLI intermittently fails a delivery with a transient
+	// "401 socket connection was closed unexpectedly" under sustained
+	// concurrency; a byte-identical retry typically clears it. Retry once on
+	// that signature only, never on a permanent failure (e.g. an invalid token).
+	// The retry is safe because the 401 fails before the model turn runs, so the
+	// failed attempt mutates no partial session state.
+	const maxAttempts = 2
+	var result subprocess.Result
+	var err error
+	for attempt := 1; ; attempt++ {
+		result, err = a.runClaude(ctx, agent, job, model)
+		if attempt >= maxAttempts || !isTransientClaudeDeliveryError(result, err) {
+			break
+		}
+		if waitErr := a.waitRetryBackoff(ctx); waitErr != nil {
+			break
+		}
 	}
 	// Self-heal a dead pinned session (#443): when a pinned --resume delivery
 	// fails before any model turn because the conversation no longer exists, mint
@@ -448,6 +470,66 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 	parsed.InputTokens = inTok
 	parsed.OutputTokens = outTok
 	return parsed, nil
+}
+
+// runClaude performs a single Claude delivery attempt, including the JSON
+// output-format fallback re-run for older CLIs that reject --output-format.
+func (a ClaudeAdapter) runClaude(ctx context.Context, agent Agent, job Job, model string) (subprocess.Result, error) {
+	result, err := a.runner().Run(ctx, a.Dir, "claude", claudeArgs(agent, job.Prompt, true, model)...)
+	if err != nil && isClaudeJSONUnsupported(result) {
+		result, err = a.runner().Run(ctx, a.Dir, "claude", claudeArgs(agent, job.Prompt, false, model)...)
+	}
+	return result, err
+}
+
+// waitRetryBackoff pauses before the next delivery attempt, returning early if
+// the context is cancelled so a killed job stops promptly. It uses a stopped
+// timer (not time.After) so the timer is released when ctx wins the race.
+func (a ClaudeAdapter) waitRetryBackoff(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	backoff := a.RetryBackoff
+	if backoff == 0 {
+		backoff = defaultClaudeRetryBackoff
+	}
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// isTransientClaudeDeliveryError reports whether a failed Claude delivery is the
+// known intermittent "401 socket connection was closed unexpectedly" transient,
+// which a byte-identical retry typically clears. It returns false when the run
+// succeeded (err == nil) and for permanent failures (e.g. an invalid token,
+// which carries no socket-closed signature). The signature shows up in the JSON
+// result on stdout in practice, so it matches both stdout and stderr; the
+// err != nil gate keeps a successful run from ever being treated as transient.
+//
+// The match also requires a "401" status so the retry is confined to the
+// provably-safe pre-turn handshake case the safety note in Deliver relies on: a
+// 401 fails before the model turn runs, so the failed attempt mutates no partial
+// session state and a byte-identical --resume retry cannot duplicate side
+// effects. A bare "socket connection was closed unexpectedly" (the underlying
+// Node/undici fetch error) can also be thrown on a MID-STREAM drop after the
+// turn has already executed tool calls or file edits, where a retry would be a
+// duplicate-execution hazard; such mid-stream drops carry no status code, so the
+// "401" requirement correctly excludes them.
+func isTransientClaudeDeliveryError(result subprocess.Result, err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	if !strings.Contains(text, "401") {
+		return false
+	}
+	return strings.Contains(text, "socket connection was closed unexpectedly") ||
+		strings.Contains(text, "socket connection closed unexpectedly")
 }
 
 // claudeFreshSessionArgs builds the args for a brand-new dedicated session,

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
@@ -694,6 +695,130 @@ func TestClaudeDeliverClassifiesAuthFailure(t *testing.T) {
 	}
 }
 
+func TestClaudeDeliverRetriesTransientSocketError(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stderr: "API Error: 401 The socket connection was closed unexpectedly"},
+			{Stdout: `{"result":"recovered"}`},
+		},
+		errs: []error{errors.New("exit 1"), nil},
+	}
+	adapter := ClaudeAdapter{Runner: runner, RetryBackoff: time.Nanosecond}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "recovered" {
+		t.Fatalf("summary = %q, want %q", result.Summary, "recovered")
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("runner called %d times, want exactly 2 (one retry): %v", len(runner.calls), runner.calls)
+	}
+	runner.want(t, 0, "claude", "--resume", "550e8400-e29b-41d4-a716-446655440002", "-p", "--output-format", "json", "--", "review")
+	runner.want(t, 1, "claude", "--resume", "550e8400-e29b-41d4-a716-446655440002", "-p", "--output-format", "json", "--", "review")
+}
+
+func TestClaudeDeliverDoesNotRetryPermanentError(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "401 Invalid authentication credentials"}},
+		errs:    []error{errors.New("exit 1")},
+	}
+	adapter := ClaudeAdapter{Runner: runner, RetryBackoff: time.Nanosecond}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err == nil {
+		t.Fatal("Deliver accepted permanent error")
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner called %d times, want exactly 1 (no retry on permanent error): %v", len(runner.calls), runner.calls)
+	}
+}
+
+func TestClaudeDeliverSucceedsWithoutRetry(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"done"}`}}}
+	adapter := ClaudeAdapter{Runner: runner, RetryBackoff: time.Nanosecond}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "done" {
+		t.Fatalf("summary = %q", result.Summary)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner called %d times, want exactly 1: %v", len(runner.calls), runner.calls)
+	}
+}
+
+func TestClaudeDeliverRetriesExhausted(t *testing.T) {
+	// Both attempts hit the transient: the bound (maxAttempts=2) must stop after
+	// exactly one retry and surface the final error rather than loop forever.
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stderr: "401 The socket connection was closed unexpectedly"},
+			{Stderr: "401 The socket connection was closed unexpectedly"},
+		},
+		errs: []error{errors.New("exit 1"), errors.New("exit 1")},
+	}
+	adapter := ClaudeAdapter{Runner: runner, RetryBackoff: time.Nanosecond}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err == nil {
+		t.Fatal("Deliver accepted a transient that persisted across all attempts")
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("runner called %d times, want exactly 2 (maxAttempts bound): %v", len(runner.calls), runner.calls)
+	}
+}
+
+func TestClaudeDeliverStopsRetryOnContextCancellation(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "401 The socket connection was closed unexpectedly"}},
+		errs:    []error{errors.New("exit 1")},
+	}
+	// A large backoff would hang for an hour if cancellation were ignored.
+	adapter := ClaudeAdapter{Runner: runner, RetryBackoff: time.Hour}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := adapter.Deliver(ctx, agent, Job{Prompt: "review"}); err == nil {
+		t.Fatal("Deliver accepted transient error under cancelled context")
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner called %d times, want exactly 1 (cancelled ctx must skip backoff/retry): %v", len(runner.calls), runner.calls)
+	}
+}
+
+func TestIsTransientClaudeDeliveryError(t *testing.T) {
+	runErr := errors.New("exit 1")
+	for _, tt := range []struct {
+		name   string
+		result subprocess.Result
+		err    error
+		want   bool
+	}{
+		{name: "socket_was_closed_on_stderr", result: subprocess.Result{Stderr: "401 The socket connection was closed unexpectedly"}, err: runErr, want: true},
+		{name: "socket_closed_alt_wording_on_stdout", result: subprocess.Result{Stdout: "API Error: 401 socket connection closed unexpectedly"}, err: runErr, want: true},
+		{name: "mixed_case", result: subprocess.Result{Stderr: "401 Socket Connection Was Closed Unexpectedly"}, err: runErr, want: true},
+		{name: "socket_closed_without_401_mid_stream", result: subprocess.Result{Stderr: "socket connection was closed unexpectedly"}, err: runErr, want: false},
+		{name: "permanent_auth_error", result: subprocess.Result{Stderr: "401 Invalid authentication credentials"}, err: runErr, want: false},
+		{name: "nil_error_even_with_signature", result: subprocess.Result{Stderr: "401 socket connection was closed unexpectedly"}, err: nil, want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientClaudeDeliveryError(tt.result, tt.err); got != tt.want {
+				t.Fatalf("isTransientClaudeDeliveryError = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClaudeHealthUsesRegisteredSession(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"OK"}`}}}
 	adapter := ClaudeAdapter{Runner: runner}
@@ -1051,7 +1176,6 @@ func TestKimiDeliverCommandResumesSession(t *testing.T) {
 	}
 	runner.want(t, 0, "kimi", "-S", "session_550e8400-e29b-41d4-a716-446655440001", "-p", "review", "--output-format", "stream-json")
 }
-
 
 func TestKimiDeliverCommandUsesJobModel(t *testing.T) {
 	stdout := `{"role":"assistant","content":"done"}` + "\n"


### PR DESCRIPTION
## What

Fixes #487 — the Claude Code CLI intermittently fails a delivery with a transient `401 "socket connection was closed unexpectedly"` under sustained concurrency. `ClaudeAdapter.Deliver` now **retries that specific transient once**, while never retrying permanent failures.

## Why (root cause)

After exhaustive instrumentation (a `claude` PATH-shim proved a failing watcher run and a succeeding direct ask used **byte-identical** invocations; 36 concurrent raw `claude` calls reproduced 0 failures), the failure is a **rare, non-deterministic Claude-CLI transient** — not a gitmoot logic bug. It only piled up during debugging because of sustained concurrent claude activity. A single retry virtually eliminates it. Full trail on #487.

## How

- `isTransientClaudeDeliveryError(result, err)` returns true only when `err != nil` **and** stdout+stderr contains **both** `"401"` **and** the socket-closed signature (case-insensitive, both wordings).
  - Requiring `401` confines the retry to the **provably-safe pre-turn handshake** case. A non-401 mid-stream socket drop is *not* retried, so a byte-identical `--resume` re-run can't duplicate already-applied tool/file side effects (important for unattended workspace-write/implement jobs).
  - Permanent auth errors (`"401 Invalid authentication credentials"`) lack the socket phrase → not retried.
- Bounded to 2 attempts (1 retry); the final error is surfaced unchanged via `claudeCommandError`.
- Backoff is ctx-cancellable (`time.NewTimer` + `defer Stop()`) and injectable via a new `ClaudeAdapter.RetryBackoff` field (defaults to `defaultClaudeRetryBackoff = 500ms`).
- Preserves the existing JSON-output fallback and the #443 session self-heal path; **Codex/Kimi/Shell adapters untouched**.

## Tests

`internal/runtime/adapter_test.go` — retry-then-success (exactly 2 calls), no-retry-on-permanent (1 call), retry-exhausted (2 calls + error), ctx-cancellation (1 call, no hang), and the matcher table (incl. a non-401 socket string → `false`). `go build/vet/test` green, `gofmt` clean.

## Scope / follow-ups (out of scope here)

- Faithful job-state recording (a hard delivery failure should be recorded `failed`, not `succeeded`) — the secondary item noted on #487.
- Optional: retry jitter to de-correlate simultaneous retries.

Reviewed adversarially (a correctness reviewer caught and we fixed a `--resume` duplicate-execution hazard by requiring `401`).

Closes #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
