### PR TITLE
feat(dashboard): surface in-flight jobs as an active_jobs view (#505 gap 1)

### DIFF
--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -39,6 +39,7 @@ type dashboardSnapshot struct {
 	Repos           []dashboardRepo         `json:"repos"`
 	Agents          []dashboardAgent        `json:"agents"`
 	RuntimeSessions []dashboardSession      `json:"runtime_sessions"`
+	ActiveJobs      []dashboardActiveJob    `json:"active_jobs"`
 	Jobs            dashboardJobs           `json:"jobs"`
 	Worktrees       []dashboardWorktree     `json:"worktrees"`
 	BranchLocks     []dashboardBranchLock   `json:"branch_locks"`
@@ -152,6 +153,20 @@ type dashboardSession struct {
 type dashboardJobs struct {
 	Total   int            `json:"total"`
 	ByState map[string]int `json:"by_state"`
+}
+
+// dashboardActiveJob is one in-flight job (queued or running) surfaced in the
+// dashboard's live "active work" view (#505). Without it a running `@agent ask`
+// is invisible — the jobs table otherwise holds mostly terminal rows. It is
+// built from the already-loaded jobs slice (no extra DB round-trip); the held
+// runtime-session lock (resource_locks key prefix "runtime:") is the reliable
+// "session busy" signal and is already surfaced in the resource_locks section.
+type dashboardActiveJob struct {
+	ID    string `json:"id"`
+	Agent string `json:"agent"`
+	Repo  string `json:"repo,omitempty"`
+	Type  string `json:"type"`
+	State string `json:"state"`
 }
 
 type dashboardWorktree struct {
@@ -389,6 +404,7 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 		Repos:           []dashboardRepo{},
 		Agents:          []dashboardAgent{},
 		RuntimeSessions: []dashboardSession{},
+		ActiveJobs:      []dashboardActiveJob{},
 		Worktrees:       []dashboardWorktree{},
 		BranchLocks:     []dashboardBranchLock{},
 		TrainSessions:   []dashboardTrainSession{},
@@ -450,6 +466,9 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 			return err
 		}
 		snapshot.Jobs.Total = len(jobs)
+		// Live "active work" view (#505): reuse the already-loaded jobs slice (no
+		// extra DB round-trip) so a running @agent ask is visible while it runs.
+		snapshot.ActiveJobs = buildDashboardActiveJobs(jobs)
 		// One batched read of every job's latest event; blocked/failed rows
 		// surface WHY in the attention list.
 		latestEvents, err := store.LatestJobEvents(ctx)
@@ -593,6 +612,30 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 	return snapshot, nil
 }
 
+// buildDashboardActiveJobs projects the already-loaded jobs slice into the live
+// active-work view (#505), keeping only in-flight jobs (queued/running) and
+// excluding terminal rows. The repo is parsed from the job payload (the same
+// shape used elsewhere in the snapshot). It is pure (no store access) so it is
+// unit-tested directly. The result is always non-nil so the --json output is
+// `[]` rather than null when nothing is in flight.
+func buildDashboardActiveJobs(jobs []db.Job) []dashboardActiveJob {
+	active := []dashboardActiveJob{}
+	for _, job := range jobs {
+		if job.State != "queued" && job.State != "running" {
+			continue
+		}
+		entry := dashboardActiveJob{ID: job.ID, Agent: job.Agent, Type: job.Type, State: job.State}
+		var p struct {
+			Repo string `json:"repo"`
+		}
+		if err := json.Unmarshal([]byte(job.Payload), &p); err == nil {
+			entry.Repo = strings.TrimSpace(p.Repo)
+		}
+		active = append(active, entry)
+	}
+	return active
+}
+
 func printDashboardSnapshot(stdout io.Writer, st style.Style, snapshot dashboardSnapshot, home string, all bool) {
 	printDashboardAttention(stdout, st, snapshot, home)
 
@@ -634,6 +677,13 @@ func printDashboardSnapshot(stdout io.Writer, st style.Style, snapshot dashboard
 			writeLine(stdout, "  %s [%s] %s %s", session.Name, session.Runtime, emptyText(session.Repo), session.State)
 		}
 	}
+
+	dashboardSectionHeader(stdout, st, "active_jobs", len(snapshot.ActiveJobs))
+	activeJobs, hidden := dashboardTruncate(st, all, snapshot.ActiveJobs)
+	for _, job := range activeJobs {
+		writeLine(stdout, "  %s %s [%s] %s %s", job.ID, job.Agent, job.Type, emptyText(job.Repo), dashboardJobStateColor(st, job.State))
+	}
+	dashboardMore(stdout, st, hidden)
 
 	dashboardSectionHeader(stdout, st, "jobs", snapshot.Jobs.Total)
 	for _, state := range sortedKeys(snapshot.Jobs.ByState) {

--- a/internal/cli/dashboard_test.go
+++ b/internal/cli/dashboard_test.go
@@ -377,6 +377,81 @@ func TestTailDaemonLogErrors(t *testing.T) {
 	}
 }
 
+func TestBuildDashboardActiveJobsKeepsInFlightOnly(t *testing.T) {
+	jobs := []db.Job{
+		{ID: "j-run", Agent: "planner", Type: "ask", State: "running", Payload: `{"repo":"o/r"}`},
+		{ID: "j-queued", Agent: "impl", Type: "implement", State: "queued", Payload: `{"repo":"o/x"}`},
+		{ID: "j-succeeded", Agent: "planner", Type: "ask", State: "succeeded", Payload: `{"repo":"o/r"}`},
+		{ID: "j-failed", Agent: "impl", Type: "implement", State: "failed", Payload: `{"repo":"o/r"}`},
+		{ID: "j-blocked", Agent: "impl", Type: "review", State: "blocked", Payload: `{"repo":"o/r"}`},
+		{ID: "j-cancelled", Agent: "impl", Type: "review", State: "cancelled", Payload: `{"repo":"o/r"}`},
+		{ID: "j-badpayload", Agent: "x", Type: "ask", State: "running", Payload: "not json"},
+	}
+	active := buildDashboardActiveJobs(jobs)
+	if active == nil {
+		t.Fatal("active jobs must be non-nil for stable JSON")
+	}
+	gotIDs := map[string]dashboardActiveJob{}
+	for _, j := range active {
+		gotIDs[j.ID] = j
+	}
+	if len(active) != 3 {
+		t.Fatalf("expected 3 in-flight jobs, got %d: %+v", len(active), active)
+	}
+	for _, terminal := range []string{"j-succeeded", "j-failed", "j-blocked", "j-cancelled"} {
+		if _, ok := gotIDs[terminal]; ok {
+			t.Fatalf("terminal job %s must be excluded from active jobs", terminal)
+		}
+	}
+	run, ok := gotIDs["j-run"]
+	if !ok {
+		t.Fatal("running job j-run missing from active jobs")
+	}
+	if run.Agent != "planner" || run.Type != "ask" || run.State != "running" || run.Repo != "o/r" {
+		t.Fatalf("running job fields wrong: %+v", run)
+	}
+	if q := gotIDs["j-queued"]; q.State != "queued" || q.Repo != "o/x" {
+		t.Fatalf("queued job fields wrong: %+v", q)
+	}
+	// An unparseable payload still surfaces the job, just with an empty repo.
+	if bad, ok := gotIDs["j-badpayload"]; !ok || bad.Repo != "" {
+		t.Fatalf("job with bad payload should surface with empty repo: %+v", bad)
+	}
+}
+
+func TestBuildDashboardActiveJobsEmpty(t *testing.T) {
+	active := buildDashboardActiveJobs(nil)
+	if active == nil {
+		t.Fatal("active jobs must be non-nil even with no jobs")
+	}
+	if len(active) != 0 {
+		t.Fatalf("expected no active jobs, got %d", len(active))
+	}
+}
+
+func TestDashboardRendersActiveJobsSection(t *testing.T) {
+	home := dashboardTestHome(t)
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.CreateJob(context.Background(), db.Job{ID: "live-1", Agent: "planner", Type: "ask", State: "running", Payload: `{"repo":"o/r"}`}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	store.Close()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"dashboard", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("dashboard exit code = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"active_jobs: 1", "live-1", "planner"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dashboard output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestBuildDashboardDaemonDetailNoMeta(t *testing.T) {
 	dir := t.TempDir()
 	state := daemonState{

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -569,6 +569,9 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 	for _, l := range s.ResourceLocks {
 		out.ResourceLocks = append(out.ResourceLocks, tui.ResourceLock{Key: l.Key, Owner: l.Owner, Stale: l.Stale})
 	}
+	// Note: s.ActiveJobs (in-flight jobs) is rendered only in the plain/--json
+	// dashboard; surfacing it in the interactive TUI is deferred (the Activity
+	// page already covers live delegation trees).
 	out.Config = s.configView
 	jobs := make([]db.Job, 0, len(s.jobRows))
 	for _, row := range s.jobRows {


### PR DESCRIPTION
## What
Partially addresses #505 (**Gap 1**): the dashboard had no live in-flight view — `jobs` was terminal-state counts only, so a running `@agent ask` was invisible. This adds an **`active_jobs`** section to `gitmoot dashboard` (plain text) and `--json`.

## How
- `buildDashboardActiveJobs(jobs []db.Job)` (`internal/cli/dashboard.go`) projects the **already-loaded** jobs slice (no extra DB round-trip) to those in `queued`/`running`, surfacing `id · agent · repo · type · state`.
- New `dashboardActiveJob` struct + `active_jobs` JSON field (initialized non-nil → emits `[]`, never `null`); rendered section between `runtime_sessions` and the jobs counts, reusing the existing section/format helpers.
- The persistent "session busy" signal (the `runtime:<rt>:<ref>` resource lock, held for the whole job) is already shown in `resource_locks`; this complements it with the live job list.

## Scope / deferred (tracked on #505)
- **TUI**: not changed — an earlier review caught dead wiring; `active_jobs` renders only in plain/`--json` (noted in code). The interactive Activity page already shows live delegation trees.
- **Gap 2** (stale `running` agent_instances need a reaper) and **Gap 3** (daemon shows "stopped" under `systemd --user` because `daemon run` doesn't update `daemon.json`) — separate follow-up PRs.

## Tests
`internal/cli/dashboard_test.go`: includes queued+running / excludes all four terminal states / non-nil on nil input / bad payload → empty repo / end-to-end render of the section. `go build`/`vet`/`test ./internal/cli/...` green; touched files gofmt-clean.

Refs #505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
