### PR TITLE
fix(runtime): strengthen claude transient-401 retry — 4 attempts + exponential backoff (#509)

### DIFF
--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -376,10 +376,23 @@ func codexSandboxArgs(agent Agent) []string {
 	}
 }
 
-// defaultClaudeRetryBackoff is the pause between Claude delivery attempts when a
-// transient socket-closed failure is retried. ClaudeAdapter.RetryBackoff
+// defaultClaudeRetryBackoff is the base pause between Claude delivery attempts
+// when a transient socket-closed failure is retried. ClaudeAdapter.RetryBackoff
 // overrides it; tests inject a near-zero value to stay fast.
 const defaultClaudeRetryBackoff = 500 * time.Millisecond
+
+// claudeDeliveryMaxAttempts bounds how many times a single Claude delivery is
+// attempted when it keeps hitting the transient socket-closed 401 (#509). A
+// fixed single retry (the old maxAttempts=2) empirically does not clear it, yet
+// a fresh delivery minutes later does, so we retry more and spread the attempts
+// across different transient windows via exponential backoff. Each failing
+// attempt burns ~30-77s, so 4 attempts is ~few min worst case — comfortably
+// inside the managed ask job-timeout (~10m). Only transient errors are retried.
+const claudeDeliveryMaxAttempts = 4
+
+// maxClaudeRetryBackoff caps the exponential per-attempt pause so the backoff
+// never balloons past a sane ceiling on the later attempts.
+const maxClaudeRetryBackoff = 30 * time.Second
 
 type ClaudeAdapter struct {
 	Runner        subprocess.Runner
@@ -423,19 +436,19 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 	model := effectiveModel(agent, job)
 	// The Claude CLI intermittently fails a delivery with a transient
 	// "401 socket connection was closed unexpectedly" under sustained
-	// concurrency; a byte-identical retry typically clears it. Retry once on
-	// that signature only, never on a permanent failure (e.g. an invalid token).
+	// concurrency; a byte-identical retry typically clears it. Retry on that
+	// signature only, never on a permanent failure (e.g. an invalid token).
 	// The retry is safe because the 401 fails before the model turn runs, so the
-	// failed attempt mutates no partial session state.
-	const maxAttempts = 2
+	// failed attempt mutates no partial session state. Use exponential backoff
+	// (see waitRetryBackoff) so retries land in different transient windows.
 	var result subprocess.Result
 	var err error
 	for attempt := 1; ; attempt++ {
 		result, err = a.runClaude(ctx, agent, job, model)
-		if attempt >= maxAttempts || !isTransientClaudeDeliveryError(result, err) {
+		if attempt >= claudeDeliveryMaxAttempts || !isTransientClaudeDeliveryError(result, err) {
 			break
 		}
-		if waitErr := a.waitRetryBackoff(ctx); waitErr != nil {
+		if waitErr := a.waitRetryBackoff(ctx, attempt); waitErr != nil {
 			break
 		}
 	}
@@ -482,18 +495,14 @@ func (a ClaudeAdapter) runClaude(ctx context.Context, agent Agent, job Job, mode
 	return result, err
 }
 
-// waitRetryBackoff pauses before the next delivery attempt, returning early if
-// the context is cancelled so a killed job stops promptly. It uses a stopped
-// timer (not time.After) so the timer is released when ctx wins the race.
-func (a ClaudeAdapter) waitRetryBackoff(ctx context.Context) error {
+// waitRetryBackoff pauses before the next delivery attempt (1-indexed), returning
+// early if the context is cancelled so a killed job stops promptly. It uses a
+// stopped timer (not time.After) so the timer is released when ctx wins the race.
+func (a ClaudeAdapter) waitRetryBackoff(ctx context.Context, attempt int) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	backoff := a.RetryBackoff
-	if backoff == 0 {
-		backoff = defaultClaudeRetryBackoff
-	}
-	timer := time.NewTimer(backoff)
+	timer := time.NewTimer(a.retryBackoff(attempt))
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
@@ -501,6 +510,30 @@ func (a ClaudeAdapter) waitRetryBackoff(ctx context.Context) error {
 	case <-timer.C:
 		return nil
 	}
+}
+
+// retryBackoff computes the exponential pause before the next delivery attempt:
+// base * 2^(attempt-1), capped at maxClaudeRetryBackoff. base is RetryBackoff
+// when set (tests inject a tiny value to stay fast) else defaultClaudeRetryBackoff.
+func (a ClaudeAdapter) retryBackoff(attempt int) time.Duration {
+	base := a.RetryBackoff
+	if base <= 0 {
+		base = defaultClaudeRetryBackoff
+	}
+	if attempt < 1 {
+		attempt = 1
+	}
+	backoff := base
+	for i := 1; i < attempt; i++ {
+		backoff *= 2
+		if backoff >= maxClaudeRetryBackoff {
+			return maxClaudeRetryBackoff
+		}
+	}
+	if backoff > maxClaudeRetryBackoff {
+		return maxClaudeRetryBackoff
+	}
+	return backoff
 }
 
 // isTransientClaudeDeliveryError reports whether a failed Claude delivery is the

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -756,23 +756,109 @@ func TestClaudeDeliverSucceedsWithoutRetry(t *testing.T) {
 }
 
 func TestClaudeDeliverRetriesExhausted(t *testing.T) {
-	// Both attempts hit the transient: the bound (maxAttempts=2) must stop after
-	// exactly one retry and surface the final error rather than loop forever.
-	runner := &fakeRunner{
-		results: []subprocess.Result{
-			{Stderr: "401 The socket connection was closed unexpectedly"},
-			{Stderr: "401 The socket connection was closed unexpectedly"},
-		},
-		errs: []error{errors.New("exit 1"), errors.New("exit 1")},
+	// Every attempt hits the transient: the bound (claudeDeliveryMaxAttempts) must
+	// stop after exactly that many tries and surface the final error, never loop.
+	results := make([]subprocess.Result, claudeDeliveryMaxAttempts)
+	errs := make([]error, claudeDeliveryMaxAttempts)
+	for i := range results {
+		results[i] = subprocess.Result{Stderr: "401 The socket connection was closed unexpectedly"}
+		errs[i] = errors.New("exit 1")
 	}
+	runner := &fakeRunner{results: results, errs: errs}
 	adapter := ClaudeAdapter{Runner: runner, RetryBackoff: time.Nanosecond}
 	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
 
 	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err == nil {
 		t.Fatal("Deliver accepted a transient that persisted across all attempts")
 	}
-	if len(runner.calls) != 2 {
-		t.Fatalf("runner called %d times, want exactly 2 (maxAttempts bound): %v", len(runner.calls), runner.calls)
+	if len(runner.calls) != claudeDeliveryMaxAttempts {
+		t.Fatalf("runner called %d times, want exactly %d (claudeDeliveryMaxAttempts bound): %v", len(runner.calls), claudeDeliveryMaxAttempts, runner.calls)
+	}
+}
+
+func TestClaudeDeliverSucceedsOnFinalAttempt(t *testing.T) {
+	// Transient on the first claudeDeliveryMaxAttempts-1 attempts, then a JSON
+	// success on the last: Deliver must recover and call exactly the bound times.
+	results := make([]subprocess.Result, claudeDeliveryMaxAttempts)
+	errs := make([]error, claudeDeliveryMaxAttempts)
+	for i := 0; i < claudeDeliveryMaxAttempts-1; i++ {
+		results[i] = subprocess.Result{Stderr: "401 The socket connection was closed unexpectedly"}
+		errs[i] = errors.New("exit 1")
+	}
+	results[claudeDeliveryMaxAttempts-1] = subprocess.Result{Stdout: `{"result":"recovered"}`}
+	runner := &fakeRunner{results: results, errs: errs}
+	adapter := ClaudeAdapter{Runner: runner, RetryBackoff: time.Nanosecond}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "recovered" {
+		t.Fatalf("summary = %q, want %q", result.Summary, "recovered")
+	}
+	if len(runner.calls) != claudeDeliveryMaxAttempts {
+		t.Fatalf("runner called %d times, want exactly %d: %v", len(runner.calls), claudeDeliveryMaxAttempts, runner.calls)
+	}
+}
+
+func TestClaudeDeliverStopsRetryOnContextCancelledDuringBackoff(t *testing.T) {
+	// A persistent transient with a large backoff would hang if cancellation were
+	// ignored mid-backoff; cancelling after the first call must stop promptly.
+	results := make([]subprocess.Result, claudeDeliveryMaxAttempts)
+	errs := make([]error, claudeDeliveryMaxAttempts)
+	for i := range results {
+		results[i] = subprocess.Result{Stderr: "401 The socket connection was closed unexpectedly"}
+		errs[i] = errors.New("exit 1")
+	}
+	runner := &fakeRunner{results: results, errs: errs}
+	adapter := ClaudeAdapter{Runner: runner, RetryBackoff: time.Hour}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "jerryfane/gitmoot"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Cancel shortly after delivery starts so the first backoff is interrupted.
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := adapter.Deliver(ctx, agent, Job{Prompt: "review"}); err == nil {
+			t.Error("Deliver accepted transient error under cancelled context")
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Deliver hung instead of honouring context cancellation during backoff")
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner called %d times, want exactly 1 (cancel during backoff must stop): %v", len(runner.calls), runner.calls)
+	}
+}
+
+func TestClaudeRetryBackoffExponentialCapped(t *testing.T) {
+	a := ClaudeAdapter{RetryBackoff: time.Second}
+	for _, tt := range []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{attempt: 1, want: time.Second},
+		{attempt: 2, want: 2 * time.Second},
+		{attempt: 3, want: 4 * time.Second},
+		{attempt: 4, want: 8 * time.Second},
+		{attempt: 10, want: maxClaudeRetryBackoff}, // capped
+	} {
+		if got := a.retryBackoff(tt.attempt); got != tt.want {
+			t.Fatalf("retryBackoff(%d) = %v, want %v", tt.attempt, got, tt.want)
+		}
+	}
+	// Defaults to defaultClaudeRetryBackoff when RetryBackoff is unset.
+	if got := (ClaudeAdapter{}).retryBackoff(1); got != defaultClaudeRetryBackoff {
+		t.Fatalf("default retryBackoff(1) = %v, want %v", got, defaultClaudeRetryBackoff)
 	}
 }
 


### PR DESCRIPTION
## What
Addresses #509 (primary fix). Claude `@agent ask` delivery intermittently fails with a transient `401 "socket connection closed unexpectedly"` (~1/3 of attempts). The existing #487 retry (2 attempts, fixed 500ms) doesn't clear it because it's deterministic *within* one `Deliver`; a separate, later delivery succeeds.

## How
In `ClaudeAdapter.Deliver` (`internal/runtime/adapter.go`):
- `maxAttempts 2 → claudeDeliveryMaxAttempts = 4` (3 retries).
- Fixed backoff → **exponential** `base*2^(attempt-1)` capped at `maxClaudeRetryBackoff = 30s` (pure `retryBackoff(attempt)` helper), so retries land in *different* transient windows instead of hammering the same ~1s window.
- Unchanged: only retries `isTransientClaudeDeliveryError` (never permanent/auth), ctx-cancellable backoff, the #443 self-heal block, the runClaude JSON fallback, and Codex/Kimi/Shell adapters.
- Worst case ≈ 5 min (4 attempts × ~30–77s + ~3.5s backoff), within the ~10m managed-ask timeout.

## Tests
`internal/runtime/adapter_test.go`: persistent-transient → exactly `claudeDeliveryMaxAttempts` calls + error; eventual success on the final attempt; no-retry-on-permanent (1 call); cancel-during-backoff (no hang); exponential+cap unit. Pre-existing #487 retry tests updated for the new count. `build`/`vet`/`test ./internal/runtime/...` green; touched files gofmt-clean.

## Honest caveat
The root cause is **upstream in the claude CLI**, so this is a best-effort reliability mitigation, not a guaranteed cure — the live success rate should be measured after deploy (post N asks, compare to ~1/3 today). If it's still flaky, the serialize-claude defense-in-depth from #509 is the next lever.

Refs #509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
