### PR TITLE
feat(skillopt): cross-family judge jury (#349)

### DIFF
--- a/internal/cli/skillopt_ab.go
+++ b/internal/cli/skillopt_ab.go
@@ -54,6 +54,27 @@ const (
 	skillOptABJudgeReviewer = "skillopt-ab-judge"
 )
 
+// skillOptABJurorSource / skillOptABJurorReviewerPrefix tag the PER-JUROR detail
+// rows of a cross-family judge JURY (#349). The AGGREGATED jury verdict reuses the
+// canonical skillopt-ab-judge reviewer/source above (so a jury strictly upgrades
+// the single-judge evidence under the SAME tag — a downstream consumer that reads
+// the judge row gets the better, aggregated verdict for free). Each individual
+// juror's pick is recorded SEPARATELY under this DISTINCT source (reviewer
+// skillopt-ab-juror:<family>) so the per-juror transparency rows coexist with the
+// aggregate without being double-counted as extra judge votes. Like the single
+// judge, NONE of these ever touch the promotion bandit (evidence-only).
+const (
+	skillOptABJurorSource         = "skillopt-ab-juror"
+	skillOptABJurorReviewerPrefix = "skillopt-ab-juror:"
+	// skillOptABJuryItemID is a DEDICATED eval_review_item id that carries ONLY the
+	// jury aggregation metadata (disagreement flag, tallies, per-juror picks). It is
+	// distinct from the shared "ab" item so the human/single-judge path's idempotent
+	// ensureSkillOptABRunRows (which re-upserts the "ab" item without jury metadata)
+	// can never clobber it. The per-juror ranked rows still reference the shared "ab"
+	// item (with the real options); this item is metadata-only.
+	skillOptABJuryItemID = skillOptABItemID + "-jury"
+)
+
 // skillOptABVariant is one resolved A/B arm: the version being served plus its
 // human-readable role label (champion|challenger).
 type skillOptABVariant struct {
@@ -158,6 +179,11 @@ type skillOptABOptions struct {
 	// judgeOnly skips soliciting the human pick and records ONLY the judge row
 	// (mirrors the --pick non-interactive escape). It implies --judge.
 	judgeOnly bool
+	// jurySize turns the cross-family judge into a JURY of this many DISTINCT-family
+	// judges (#349); >= 2 implies --judge. 0 (the default) defers to the
+	// [skillopt].mode_b_jury_size config knob; an explicit flag overrides it. < 2
+	// (after resolution) is the single-judge path (byte-identical).
+	jurySize int
 }
 
 func runSkillOptAB(args []string, stdout, stderr io.Writer) int {
@@ -198,6 +224,7 @@ func parseSkillOptABOptions(args []string, stderr io.Writer) (skillOptABOptions,
 	seed := fs.Int64("seed", 0, "deterministic seed for the label shuffle and the P(>) Monte Carlo")
 	judge := fs.Bool("judge", false, "also have a cross-family LLM judge pick A/B and record a separate skillopt-ab-judge row (#483; off by default)")
 	judgeOnly := fs.Bool("judge-only", false, "record ONLY the cross-family judge row, skipping the human pick prompt (implies --judge)")
+	jurySize := fs.Int("jury-size", 0, "run a cross-family judge JURY of N distinct-family judges instead of one (#349; >=2 implies --judge; 0 defers to [skillopt].mode_b_jury_size)")
 	// Separate the leading positionals (agent, prompt) from flags. flag.Parse stops
 	// at the first non-flag, so collect positionals manually to allow them anywhere.
 	positionals := []string{}
@@ -207,7 +234,7 @@ func parseSkillOptABOptions(args []string, stderr io.Writer) (skillOptABOptions,
 		if strings.HasPrefix(arg, "-") {
 			rest = append(rest, arg)
 			// flags that take a value consume the next token unless --flag=value.
-			if !strings.Contains(arg, "=") && (arg == "--home" || arg == "--challenger" || arg == "--pick" || arg == "--seed") && i+1 < len(args) {
+			if !strings.Contains(arg, "=") && (arg == "--home" || arg == "--challenger" || arg == "--pick" || arg == "--seed" || arg == "--jury-size") && i+1 < len(args) {
 				i++
 				rest = append(rest, args[i])
 			}
@@ -234,9 +261,10 @@ func parseSkillOptABOptions(args []string, stderr io.Writer) (skillOptABOptions,
 		fmt.Fprintln(stderr, "skillopt ab --pick must be a or b")
 		return skillOptABOptions{}, false
 	}
-	// --judge-only implies --judge: recording only the judge row still requires the
-	// judge path to be admitted.
-	judgeOn := *judge || *judgeOnly
+	// --judge-only implies --judge; --jury-size >= 2 implies --judge (the jury runs
+	// inside the judge seam): recording any judge/jury row requires the judge path
+	// to be admitted.
+	judgeOn := *judge || *judgeOnly || *jurySize >= 2
 	return skillOptABOptions{
 		home:       strings.TrimSpace(*home),
 		agent:      strings.TrimSpace(positionals[0]),
@@ -247,6 +275,7 @@ func parseSkillOptABOptions(args []string, stderr io.Writer) (skillOptABOptions,
 		seedSet:    seedSet,
 		judge:      judgeOn,
 		judgeOnly:  *judgeOnly,
+		jurySize:   *jurySize,
 	}, true
 }
 
@@ -699,7 +728,39 @@ func skillOptABJudgeEnabled(paths config.Paths, options skillOptABOptions) bool 
 	if err != nil {
 		return false
 	}
-	return policy.ModeBJudgeEnabled
+	// A configured jury (mode_b_jury_size >= 2) admits the judge seam too: the jury
+	// runs INSIDE it, so enabling the jury alone is enough to turn it on (#349).
+	return policy.ModeBJudgeEnabled || policy.ModeBJurySize >= 2
+}
+
+// skillOptABJuryConfig resolves the effective jury parameters (#349): the
+// per-invocation --jury-size flag wins when set (>0), else the persistent
+// [skillopt].mode_b_jury_* config knobs. A size < 2 means the single-judge path
+// (the jury is off / byte-identical). A config read error fails safe to size 0
+// (single judge) so a malformed config never silently fans out judges.
+func skillOptABJuryConfig(paths config.Paths, options skillOptABOptions) skillopt.JuryConfig {
+	cfg := skillopt.JuryConfig{}
+	policy, err := config.LoadSkillOptPolicy(paths)
+	if err == nil {
+		cfg.VetoDimensions = policy.ModeBJuryVetoDimensions
+		cfg.VetoFloor = policy.ModeBJuryVetoFloor
+		cfg.DisagreementTau = policy.ModeBJuryDisagreementTau
+	}
+	return cfg
+}
+
+// skillOptABJurySize resolves the effective jury size: the --jury-size flag when
+// set (>0), else [skillopt].mode_b_jury_size, else 0 (single judge). A config read
+// error fails safe to the single-judge path.
+func skillOptABJurySize(paths config.Paths, options skillOptABOptions) int {
+	if options.jurySize > 0 {
+		return options.jurySize
+	}
+	policy, err := config.LoadSkillOptPolicy(paths)
+	if err != nil {
+		return 0
+	}
+	return policy.ModeBJurySize
 }
 
 // runSkillOptABJudge runs the off-by-default cross-family LLM-judge auto-pairwise
@@ -720,6 +781,26 @@ func runSkillOptABJudge(ctx context.Context, store *db.Store, paths config.Paths
 	if probe := skillOptABJudgeAuthedRuntimes(agent.RepoScope); probe != nil {
 		authed = probe(ctx)
 	}
+
+	// JURY (#349): when a jury of >= 2 distinct families is configured AND >= 2
+	// distinct families are actually available, run the cross-family judge JURY and
+	// return. With the jury OFF (size < 2) or fewer than 2 distinct families
+	// available, fall through to the EXISTING single cross-family judge path below —
+	// byte-identical to #483. The authed probe is computed once above and shared.
+	if size := skillOptABJurySize(paths, options); size >= 2 {
+		jury, err := workflow.PickCrossFamilyJury(ctx, store, agent.Runtime, agent.RepoScope, authed, size)
+		if err != nil {
+			log.Printf("skillopt ab jury: select cross-family jury: %v", err)
+			return
+		}
+		if len(jury) >= 2 {
+			runSkillOptABJudgeJury(ctx, store, paths, runID, templateID, champion, challenger, optionA, optionB, options, jury, stdout)
+			return
+		}
+		// < 2 distinct families: graceful degradation to the single-judge path.
+		fmt.Fprintf(stdout, "skillopt ab: only %d distinct cross-family judge(s) available; falling back to a single judge\n", len(jury))
+	}
+
 	reviewer, ok, err := workflow.PickCrossFamilyReviewer(ctx, store, agent.Runtime, agent.RepoScope, authed)
 	if err != nil {
 		log.Printf("skillopt ab judge: select cross-family judge: %v", err)
@@ -781,6 +862,161 @@ func runSkillOptABJudge(ctx context.Context, store *db.Store, paths config.Paths
 	// the promotion Beta-Bernoulli bandit — promotion stays manual + human-driven.
 	fmt.Fprintf(stdout, "Judge (%s, cross-family): %s (Option %s) — recorded as %s (evidence-only, does not move the promotion bandit)\n",
 		reviewer.Runtime, winnerLabel, strings.ToUpper(pick), skillOptABJudgeSource)
+}
+
+// skillOptABJuror is one surviving jury member's parsed verdict: its resolved
+// family, the role it picked (champion|challenger), and whether that pick means
+// the challenger won (the boolean the pure aggregator votes on).
+type skillOptABJuror struct {
+	family         string
+	winnerLabel    string
+	challengerWins bool
+}
+
+// runSkillOptABJudgeJury runs the off-by-default cross-family judge JURY (#349)
+// best-effort: it delivers the SAME blind shuffled Option A/B to EACH distinct-family
+// juror (SERIALIZED — one Deliver at a time so per-runtime session locks never
+// overlap), DROPS any juror that errors or returns an unparseable pick (fail-safe —
+// the jury proceeds with the rest), aggregates the survivors' picks via the PURE
+// skillopt.EvaluateJury (majority vote + disagreement flag), and records the
+// aggregated verdict (under the canonical skillopt-ab-judge tag) PLUS one per-juror
+// detail row (under the distinct skillopt-ab-juror source). It NEVER touches the
+// promotion bandit and NEVER fails the command (every error path logs/prints and
+// returns, leaving the human path intact). Candidate origin is blinded to every
+// juror exactly as the single judge blinds it. When NO juror survives it writes no
+// row (same as the single judge's unparseable drop).
+func runSkillOptABJudgeJury(ctx context.Context, store *db.Store, paths config.Paths, runID, templateID string, champion, challenger skillOptABVariant, optionA, optionB skillOptABDelivery, options skillOptABOptions, jury []workflow.CrossFamilyReviewer, stdout io.Writer) {
+	prompt := buildSkillOptABJudgePrompt(options.prompt, optionA.answer, optionB.answer)
+
+	var jurors []skillOptABJuror
+	for _, reviewer := range jury {
+		judgeAgent := skillOptABJudgeAgent(reviewer)
+		raw, err := skillOptABJudgeDeliver(ctx, judgeAgent, prompt)
+		if err != nil {
+			// Fail-safe: a juror that errors is DROPPED; the jury proceeds with the rest.
+			log.Printf("skillopt ab jury: juror %s deliver: %v", reviewer.Runtime, err)
+			continue
+		}
+		pick, parsed := parseSkillOptABJudgePick(raw)
+		if !parsed {
+			log.Printf("skillopt ab jury: juror %s returned no usable pick; dropping", reviewer.Runtime)
+			continue
+		}
+		// Map the juror's a/b pick back to the role via the SAME shuffle mapping the
+		// human/single-judge use (the juror saw the SAME blind Option A/B).
+		pickedDelivery := optionA
+		if pick == "b" {
+			pickedDelivery = optionB
+		}
+		jurors = append(jurors, skillOptABJuror{
+			family:         reviewer.Runtime,
+			winnerLabel:    pickedDelivery.label,
+			challengerWins: pickedDelivery.label == skillOptABChallengerLabel,
+		})
+	}
+
+	if len(jurors) == 0 {
+		fmt.Fprintln(stdout, "skillopt ab: no jury member returned a usable pick; skipping jury rows")
+		return
+	}
+
+	// Pure aggregation: majority vote on "challenger wins" + disagreement flag. The
+	// pairwise A/B path carries no rubric dimensions, so the median/veto outputs are
+	// inert here; the same aggregator serves a future promotion-boundary rubric jury.
+	verdicts := make([]skillopt.JuryJudgeVerdict, 0, len(jurors))
+	for _, j := range jurors {
+		verdicts = append(verdicts, skillopt.JuryJudgeVerdict{Decision: j.challengerWins})
+	}
+	decision := skillopt.EvaluateJury(skillOptABJuryConfig(paths, options), verdicts)
+
+	// Ensure the shared run/item/options exist (idempotent), then stamp the jury
+	// aggregation onto the eval_review_item metadata (existing MetadataJSON — no new
+	// contract field) so the disagreement flag + tallies ride existing eval metadata.
+	if err := ensureSkillOptABRunRows(ctx, store, paths, runID, skillOptABItemID, templateID, champion, challenger, optionAToDelivery(optionA, optionB, champion), optionAToDelivery(optionA, optionB, challenger), options.prompt, skillOptABSource, skillOptABFeedbackSource); err != nil {
+		log.Printf("skillopt ab jury: ensure run rows: %v", err)
+		return
+	}
+	if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:        runID,
+		ItemID:       skillOptABJuryItemID,
+		Title:        "jury aggregation: " + options.prompt,
+		MetadataJSON: skillOptABJuryMetadata(decision, jurors),
+	}); err != nil {
+		log.Printf("skillopt ab jury: stamp jury metadata: %v", err)
+		return
+	}
+
+	// Per-juror transparency rows (distinct skillopt-ab-juror source so they coexist
+	// with the aggregate without being double-counted as judge votes).
+	for _, j := range jurors {
+		loserLabel := skillOptABChampionLabel
+		if j.winnerLabel == skillOptABChampionLabel {
+			loserLabel = skillOptABChallengerLabel
+		}
+		reviewer := skillOptABJurorReviewerPrefix + j.family
+		sourceURL := skillOptABJurorSourceURL(challenger.version.ID, j.family)
+		if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, j.winnerLabel, loserLabel, reviewer, skillOptABJurorSource, sourceURL); err != nil {
+			log.Printf("skillopt ab jury: record juror %s row: %v", j.family, err)
+			return
+		}
+	}
+
+	// Aggregated verdict under the CANONICAL judge tag (a jury upgrades the single
+	// judge's evidence in place). Majority "challenger wins" => challenger is the
+	// winner; a tie/veto resolves to champion (fail-safe baseline).
+	aggWinner := skillOptABChampionLabel
+	aggLoser := skillOptABChallengerLabel
+	if decision.Decision {
+		aggWinner, aggLoser = skillOptABChallengerLabel, skillOptABChampionLabel
+	}
+	if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, aggWinner, aggLoser, skillOptABJudgeReviewer, skillOptABJudgeSource, skillOptABJudgeSourceURL(challenger.version.ID)); err != nil {
+		log.Printf("skillopt ab jury: record aggregate verdict: %v", err)
+		return
+	}
+
+	fmt.Fprintf(stdout, "Jury (%d cross-family judges): %s wins %d:%d — recorded as %s (evidence-only, does not move the promotion bandit)\n",
+		len(jurors), aggWinner, decision.Approve, decision.Reject, skillOptABJudgeSource)
+	if decision.Disagreement {
+		// Route to a human (and feed #345): a split jury is the load-this-to-a-human
+		// signal the issue mandates.
+		fmt.Fprintf(stdout, "Jury DISAGREEMENT (%s): routing to human review (recorded for judge<->human calibration, #345)\n", decision.DisagreementReason)
+	}
+}
+
+// skillOptABJuryMetadata serializes the jury aggregation onto the eval_review_item
+// metadata (#349) — existing MetadataJSON, NO new contract field — so the
+// disagreement flag, the vote tally, and the per-juror picks ride the existing eval
+// metadata the export/optimizer (and #345 capture) already read.
+func skillOptABJuryMetadata(decision skillopt.JuryDecision, jurors []skillOptABJuror) string {
+	picks := make([]map[string]any, 0, len(jurors))
+	for _, j := range jurors {
+		picks = append(picks, map[string]any{"family": j.family, "winner": j.winnerLabel})
+	}
+	meta := map[string]any{
+		"jury":              true,
+		"jury_size":         len(jurors),
+		"jury_approve":      decision.Approve,
+		"jury_reject":       decision.Reject,
+		"jury_disagreement": decision.Disagreement,
+		"jury_jurors":       picks,
+	}
+	if decision.Disagreement {
+		meta["jury_disagreement_reason"] = decision.DisagreementReason
+	}
+	if decision.Vetoed {
+		meta["jury_vetoed"] = true
+		meta["jury_veto_reason"] = decision.VetoReason
+	}
+	raw, _ := json.Marshal(meta)
+	return string(raw)
+}
+
+// skillOptABJurorSourceURL mints a unique-per-juror SourceURL embedding the juror
+// family so each juror's detail row has a distinct (run,item,reviewer,source,url)
+// conflict key and repeated jury runs each persist without colliding.
+func skillOptABJurorSourceURL(versionID, family string) string {
+	seq := atomic.AddUint64(&skillOptABPickSeq, 1)
+	return fmt.Sprintf("%s%s:juror:%s#%d-%d", skillOptABRunIDPrefix, versionID, family, time.Now().UnixNano(), seq)
 }
 
 // optionAToDelivery recovers the champion/challenger delivery from the shuffled

--- a/internal/cli/skillopt_ab_jury_test.go
+++ b/internal/cli/skillopt_ab_jury_test.go
@@ -1,0 +1,352 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// jurorErrorSentinel is the per-family raw value that makes the fake judge seam
+// return an ERROR for that juror (to exercise the per-juror fail-safe drop).
+const jurorErrorSentinel = "__error__"
+
+// withFakeSkillOptABJury swaps the judge seam for a fake that returns a per-family
+// pick (keyed by the juror's runtime family) and stubs the authed-runtimes probe.
+// A family mapped to jurorErrorSentinel returns an error (a dropped juror). It
+// records the families the seam was actually invoked on. The codex agent under test
+// must never be judged (cross-family only).
+func withFakeSkillOptABJury(t *testing.T, picks map[string]string, authed map[string]bool) *[]string {
+	t.Helper()
+	calls := []string{}
+	prevDeliver := skillOptABJudgeDeliver
+	skillOptABJudgeDeliver = func(_ context.Context, agent runtime.Agent, _ string) (string, error) {
+		calls = append(calls, agent.Runtime)
+		if agent.Runtime == runtime.CodexRuntime {
+			t.Errorf("a juror ran on the SAME family (codex) as the agent under test; cross-family only")
+		}
+		raw, ok := picks[agent.Runtime]
+		if !ok || raw == jurorErrorSentinel {
+			return "", fmt.Errorf("simulated juror error on family %s", agent.Runtime)
+		}
+		return raw, nil
+	}
+	prevAuthed := skillOptABJudgeAuthedRuntimes
+	skillOptABJudgeAuthedRuntimes = func(string) reviewAuthedRuntimes {
+		return func(context.Context) map[string]bool { return authed }
+	}
+	t.Cleanup(func() {
+		skillOptABJudgeDeliver = prevDeliver
+		skillOptABJudgeAuthedRuntimes = prevAuthed
+	})
+	return &calls
+}
+
+// TestRunSkillOptABJuryRecordsAggregateAndJurorRows proves the #349 contract: with
+// jury-size 2 and two distinct cross-families authed, BOTH jurors judge the SAME
+// blind A/B, the aggregated verdict is recorded under the canonical skillopt-ab-judge
+// tag, EACH juror's pick is recorded under the distinct skillopt-ab-juror source,
+// and the human row coexists. The jury adds NO bandit pull.
+func TestRunSkillOptABJuryRecordsAggregateAndJurorRows(t *testing.T) {
+	home, store, championID, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	// Both jurors pick Option A. seed 1 -> swap -> Option A is the challenger, so the
+	// aggregate (2:0) winner is the challenger.
+	calls := withFakeSkillOptABJury(t, map[string]string{
+		runtime.ClaudeRuntime: `{"pick":"a"}`,
+		runtime.KimiRuntime:   `{"pick":"a"}`,
+	}, map[string]bool{runtime.ClaudeRuntime: true, runtime.KimiRuntime: true})
+	ctx := context.Background()
+
+	var stdout, stderr bytes.Buffer
+	// Human picks Option B (champion under seed-1 swap) so human != jury.
+	code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--pick", "b", "--seed", "1", "--jury-size", "2"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("judge seam invoked %d times, want 2 (one per distinct-family juror): %v", len(*calls), *calls)
+	}
+
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	// human + aggregate judge + 2 juror rows = 4.
+	var human, aggregate int
+	jurors := map[string]string{}
+	for _, ev := range events {
+		switch {
+		case ev.Reviewer == "human" && ev.Source == skillOptABSource:
+			human++
+		case ev.Reviewer == skillOptABJudgeReviewer && ev.Source == skillOptABJudgeSource:
+			aggregate++
+			if ev.Winner != skillOptABChallengerLabel {
+				t.Fatalf("aggregate winner = %q, want %q (2:0 jury for the challenger)", ev.Winner, skillOptABChallengerLabel)
+			}
+		case ev.Source == skillOptABJurorSource:
+			jurors[ev.Reviewer] = ev.Winner
+		default:
+			t.Fatalf("unexpected row reviewer=%q source=%q", ev.Reviewer, ev.Source)
+		}
+	}
+	if human != 1 {
+		t.Fatalf("human rows = %d, want 1", human)
+	}
+	if aggregate != 1 {
+		t.Fatalf("aggregate judge rows = %d, want exactly 1 (canonical skillopt-ab-judge tag)", aggregate)
+	}
+	if len(jurors) != 2 {
+		t.Fatalf("juror rows = %d, want 2 distinct-family jurors: %v", len(jurors), jurors)
+	}
+	for _, fam := range []string{runtime.ClaudeRuntime, runtime.KimiRuntime} {
+		reviewer := skillOptABJurorReviewerPrefix + fam
+		if jurors[reviewer] != skillOptABChallengerLabel {
+			t.Fatalf("juror %s winner = %q, want %q", reviewer, jurors[reviewer], skillOptABChallengerLabel)
+		}
+	}
+
+	// Jury metadata rides the eval_review_item (no contract bump).
+	meta := juryMetadataFor(t, store, runID)
+	if meta["jury"] != true {
+		t.Fatalf("eval_review_item metadata missing jury flag: %v", meta)
+	}
+	if meta["jury_disagreement"] != false {
+		t.Fatalf("expected no disagreement on a 2:0 jury, metadata: %v", meta)
+	}
+
+	// MANUAL PROMOTION preserved: only the human pick moved the bandit (1 pull each).
+	champArm, _, _ := store.GetBanditArm(ctx, "planner", championID)
+	chalArm, _, _ := store.GetBanditArm(ctx, "planner", challengerID)
+	if champArm.Pulls != 1 || chalArm.Pulls != 1 {
+		t.Fatalf("bandit pulls champ=%d chal=%d, want 1/1 (the jury must NOT move the bandit)", champArm.Pulls, chalArm.Pulls)
+	}
+}
+
+// TestRunSkillOptABJuryDisagreementFlag proves a split jury (1:1) records the
+// disagreement flag in the item metadata, prints the route-to-human notice, and
+// the aggregate resolves to the fail-safe champion (baseline).
+func TestRunSkillOptABJuryDisagreementFlag(t *testing.T) {
+	home, store, _, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	// claude picks A (challenger), kimi picks B (champion) -> 1:1 split.
+	withFakeSkillOptABJury(t, map[string]string{
+		runtime.ClaudeRuntime: `{"pick":"a"}`,
+		runtime.KimiRuntime:   `{"pick":"b"}`,
+	}, map[string]bool{runtime.ClaudeRuntime: true, runtime.KimiRuntime: true})
+	ctx := context.Background()
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--seed", "1", "--jury-size", "2", "--judge-only"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "DISAGREEMENT") {
+		t.Fatalf("stdout missing the disagreement route-to-human notice:\n%s", stdout.String())
+	}
+
+	runID := skillOptABRunIDPrefix + challengerID
+	meta := juryMetadataFor(t, store, runID)
+	if meta["jury_disagreement"] != true {
+		t.Fatalf("expected jury_disagreement=true on a 1:1 split, metadata: %v", meta)
+	}
+
+	// The aggregate resolves to the fail-safe champion on a tie.
+	events, _ := store.ListRankedFeedbackEvents(ctx, runID)
+	for _, ev := range events {
+		if ev.Reviewer == skillOptABJudgeReviewer && ev.Source == skillOptABJudgeSource {
+			if ev.Winner != skillOptABChampionLabel {
+				t.Fatalf("aggregate winner = %q, want %q (1:1 tie is fail-safe to the champion)", ev.Winner, skillOptABChampionLabel)
+			}
+		}
+	}
+}
+
+// TestRunSkillOptABJuryJurorFailureFailSafe proves the per-juror fail-safe: a juror
+// that errors is DROPPED and the jury proceeds with the survivor — no error, the
+// surviving juror's row + the aggregate are still recorded.
+func TestRunSkillOptABJuryJurorFailureFailSafe(t *testing.T) {
+	home, store, _, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	// kimi errors (dropped); claude survives and picks A (challenger).
+	withFakeSkillOptABJury(t, map[string]string{
+		runtime.ClaudeRuntime: `{"pick":"a"}`,
+		runtime.KimiRuntime:   jurorErrorSentinel,
+	}, map[string]bool{runtime.ClaudeRuntime: true, runtime.KimiRuntime: true})
+	ctx := context.Background()
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--seed", "1", "--jury-size", "2", "--judge-only"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	var aggregate, jurorRows int
+	for _, ev := range events {
+		switch {
+		case ev.Reviewer == skillOptABJudgeReviewer && ev.Source == skillOptABJudgeSource:
+			aggregate++
+		case ev.Source == skillOptABJurorSource:
+			jurorRows++
+		}
+	}
+	if aggregate != 1 {
+		t.Fatalf("aggregate rows = %d, want 1 (survivor still aggregated)", aggregate)
+	}
+	if jurorRows != 1 {
+		t.Fatalf("juror rows = %d, want 1 (the failed kimi juror is dropped)", jurorRows)
+	}
+}
+
+// TestRunSkillOptABJuryGracefulDegradationToSingleJudge proves that when fewer than
+// 2 distinct cross-families are available, the jury FALLS BACK to the single-judge
+// path: ONE skillopt-ab-judge row, NO skillopt-ab-juror rows.
+func TestRunSkillOptABJuryGracefulDegradationToSingleJudge(t *testing.T) {
+	home, store, _, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	// Only claude authed -> PickCrossFamilyJury returns 1 -> fall back to single judge.
+	withFakeSkillOptABJury(t, map[string]string{
+		runtime.ClaudeRuntime: `{"pick":"a"}`,
+	}, map[string]bool{runtime.ClaudeRuntime: true})
+	ctx := context.Background()
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--seed", "1", "--jury-size", "3", "--judge-only"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "falling back to a single judge") {
+		t.Fatalf("stdout missing the single-judge fallback notice:\n%s", stdout.String())
+	}
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("rows = %d, want exactly 1 (single judge fallback, no juror rows)", len(events))
+	}
+	if events[0].Reviewer != skillOptABJudgeReviewer || events[0].Source != skillOptABJudgeSource {
+		t.Fatalf("the single row must be the canonical judge row, got reviewer=%q source=%q", events[0].Reviewer, events[0].Source)
+	}
+}
+
+// TestRunSkillOptABJuryOffByDefaultNoJuryRuns proves OFF-BY-DEFAULT: with --judge on
+// but NO jury size configured (size defaults to 1), the SINGLE-judge path runs and
+// NO skillopt-ab-juror row is ever written. This test FAILS if a jury runs by
+// default (any juror row, or more than one judge invocation).
+func TestRunSkillOptABJuryOffByDefaultNoJuryRuns(t *testing.T) {
+	home, store, _, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	calls := withFakeSkillOptABJury(t, map[string]string{
+		runtime.ClaudeRuntime: `{"pick":"a"}`,
+		runtime.KimiRuntime:   `{"pick":"a"}`,
+	}, map[string]bool{runtime.ClaudeRuntime: true, runtime.KimiRuntime: true})
+	ctx := context.Background()
+
+	var stdout, stderr bytes.Buffer
+	// --judge (single), NO --jury-size, NO config: the single-judge path only.
+	code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--seed", "1", "--judge-only"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("judge seam invoked %d times, want exactly 1 (single judge; a jury would fan out): %v", len(*calls), *calls)
+	}
+	runID := skillOptABRunIDPrefix + challengerID
+	events, err := store.ListRankedFeedbackEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("rows = %d, want exactly 1 single judge row (no jury by default)", len(events))
+	}
+	for _, ev := range events {
+		if ev.Source == skillOptABJurorSource {
+			t.Fatalf("a juror row was written on the off-by-default path: %+v", ev)
+		}
+	}
+}
+
+// TestRunSkillOptABJuryConfigKnobEnables proves the persistent config knob
+// (mode_b_jury_size) admits the jury with NO --jury-size flag (and even with no
+// --judge flag — a configured jury implies the judge seam).
+func TestRunSkillOptABJuryConfigKnobEnables(t *testing.T) {
+	home, store, _, challengerID := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	calls := withFakeSkillOptABJury(t, map[string]string{
+		runtime.ClaudeRuntime: `{"pick":"a"}`,
+		runtime.KimiRuntime:   `{"pick":"a"}`,
+	}, map[string]bool{runtime.ClaudeRuntime: true, runtime.KimiRuntime: true})
+
+	paths := config.PathsForHome(home)
+	cfg, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, append(cfg, []byte("\n[skillopt]\nmode_b_jury_size = 2\n")...), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	policy, err := config.LoadSkillOptPolicy(paths)
+	if err != nil || policy.ModeBJurySize != 2 {
+		t.Fatalf("ModeBJurySize = %d err=%v, want 2 (config wiring broken)", policy.ModeBJurySize, err)
+	}
+
+	ctx := context.Background()
+	var stdout, stderr bytes.Buffer
+	// NO --judge, NO --jury-size: the config knob alone admits the jury.
+	code := runSkillOptAB([]string{"planner-bot", "Plan it.", "--home", home, "--pick", "a", "--seed", "1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runSkillOptAB exit = %d, stderr: %s", code, stderr.String())
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("judge seam invoked %d times, want 2 (jury via config knob): %v", len(*calls), *calls)
+	}
+	runID := skillOptABRunIDPrefix + challengerID
+	var jurorRows int
+	events, _ := store.ListRankedFeedbackEvents(ctx, runID)
+	for _, ev := range events {
+		if ev.Source == skillOptABJurorSource {
+			jurorRows++
+		}
+	}
+	if jurorRows != 2 {
+		t.Fatalf("juror rows = %d, want 2 (jury enabled by config knob)", jurorRows)
+	}
+}
+
+// juryMetadataFor reads the run's single eval_review_item MetadataJSON (where the
+// jury aggregation rides) as a generic map.
+func juryMetadataFor(t *testing.T, store *db.Store, runID string) map[string]any {
+	t.Helper()
+	items, err := store.ListEvalReviewItems(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems: %v", err)
+	}
+	meta := map[string]any{}
+	for _, item := range items {
+		if item.ItemID != skillOptABJuryItemID {
+			continue
+		}
+		if raw := strings.TrimSpace(item.MetadataJSON); raw != "" {
+			if err := json.Unmarshal([]byte(raw), &meta); err != nil {
+				t.Fatalf("unmarshal item metadata %q: %v", raw, err)
+			}
+		}
+		return meta
+	}
+	t.Fatalf("no dedicated jury item (%s) among %d items", skillOptABJuryItemID, len(items))
+	return meta
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -133,6 +133,24 @@ escalation_ttl = ""
 #     row. The judge is cross-family ONLY (skipped — never same-family — when no other
 #     family is available), NEVER touches the promotion bandit, and is never the sole
 #     gate; its trust is DEFERRED to MEASURE-THE-JUDGE (#344). Off ⇒ byte-identical.
+#   mode_b_jury_size (#349 Mode B): turns the single cross-family judge above into a
+#     cross-family judge JURY — up to this many judges from DISTINCT model families
+#     judge the same blind A/B, and their picks are aggregated by MAJORITY vote with
+#     a DISAGREEMENT flag (non-unanimous vote, or per-dimension std > tau) that routes
+#     to a human and feeds #345. 0/1 (the default) ⇒ jury OFF, byte-identical to the
+#     single judge. Families are DEDUPED (diversity over headcount): a host with only
+#     2 families caps the jury at 2; with < 2 distinct families it falls back to the
+#     single judge (never fails the eval). Like the single judge, the jury is EVIDENCE
+#     only — it NEVER promotes and NEVER touches the bandit.
+#   mode_b_jury_veto_dimensions (#349): optional comma list of safety / hard-correctness
+#     rubric dimensions subject to the jury's MINORITY-VETO — one judge below
+#     mode_b_jury_veto_floor on any of these BLOCKS (fail-closed). UNSET/empty ⇒ no
+#     veto. Inert on the pairwise A/B path (no rubric); applies to a rubric jury.
+#   mode_b_jury_veto_floor (#349): the [0,1] floor for the veto dimensions. 0.0 (the
+#     default) makes the veto inert (a clamped score is never < 0).
+#   mode_b_jury_disagreement_tau (#349): per-dimension population-std threshold above
+#     which the jury flags disagreement. 0.0 (the default) disables the std check,
+#     leaving only the vote-split check (a non-unanimous vote always flags).
 #   deterministic_checkers_enabled (#485): OFF by default; requires auto_trace. When
 #     true, a MERGED implement job additionally runs a best-effort, DETACHED leg of
 #     plain external TOOLS (code duplication, lint, cyclomatic complexity) plus a
@@ -167,6 +185,10 @@ escalation_ttl = ""
 # bandit_min_samples = 30
 # live_ab_sample_rate = 0.0
 # mode_b_judge_enabled = false
+# mode_b_jury_size = 1
+# mode_b_jury_veto_dimensions =
+# mode_b_jury_veto_floor = 0.0
+# mode_b_jury_disagreement_tau = 0.0
 
 # [admission] is an OPT-IN, off-by-default host-global concurrency budget the
 # daemon applies BEFORE starting each agent session, on top of --workers/pool

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -482,6 +482,35 @@ type SkillOptPolicy struct {
 	// and is NEVER the sole gate; its trust is explicitly deferred to MEASURE-THE-JUDGE
 	// (#344) — judge-tagged + weighted-low now, calibrated later.
 	ModeBJudgeEnabled bool
+
+	// ModeBJurySize opts the off-by-default cross-family judge (#483) into a
+	// cross-family judge JURY (#349): instead of ONE judge, up to this many judges
+	// from DISTINCT model families judge the same blind A/B and their verdicts are
+	// aggregated (majority vote + disagreement flag). 0 or 1 (the default) means the
+	// jury is OFF and behavior is BYTE-IDENTICAL to the single cross-family judge.
+	// The jury only activates at >= 2 AND when >= 2 distinct families are actually
+	// available; with fewer distinct families it gracefully degrades to as many as
+	// exist, and below 2 it falls back to the single judge (never fails the eval).
+	// Diversity over headcount: families are deduped, so a host with only 2 families
+	// caps the jury at 2 no matter how high this is set. The jury is EVIDENCE only —
+	// like the single judge it NEVER promotes and NEVER touches the bandit.
+	ModeBJurySize int
+	// ModeBJuryVetoDimensions is the optional set of safety / hard-correctness
+	// rubric dimensions subject to the jury's MINORITY-VETO (#349): a single judge
+	// scoring below ModeBJuryVetoFloor on any of these BLOCKS (fail-closed), even
+	// when the majority would promote. nil/empty (the default) disables the veto.
+	// It is inert on the pairwise A/B path (which carries no rubric dimensions) and
+	// applies to a future promotion-boundary rubric jury.
+	ModeBJuryVetoDimensions []string
+	// ModeBJuryVetoFloor is the [0,1] floor for the veto dimensions (#349). 0.0
+	// (the default) makes the veto inert (a clamped score is never < 0), so a veto
+	// only ever fires when an operator sets BOTH a floor AND the dimensions.
+	ModeBJuryVetoFloor float64
+	// ModeBJuryDisagreementTau is the per-dimension population-std threshold above
+	// which the jury flags DISAGREEMENT (routes to a human, feeds #345). 0.0 (the
+	// default) disables the std-based check, leaving only the vote-split check (a
+	// non-unanimous boolean vote always flags disagreement regardless of tau).
+	ModeBJuryDisagreementTau float64
 	// LiveABSampleRate is the live-traffic A/B (#482) sampling probability in
 	// [0,1]: the fraction of foreground `agent ask` calls (on a managed agent
 	// above BanditMinSamples) that are intercepted into a champion-vs-challenger
@@ -544,6 +573,10 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 		AutoPromoteMinConfidence:        nil,
 		BanditMinSamples:                nil,
 		ModeBJudgeEnabled:               false,
+		ModeBJurySize:                   0,
+		ModeBJuryVetoDimensions:         nil,
+		ModeBJuryVetoFloor:              0,
+		ModeBJuryDisagreementTau:        0,
 		LiveABSampleRate:                nil,
 		DeterministicCheckers:           false,
 		DeterministicCheckerList:        nil,
@@ -723,6 +756,30 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 		parsed, err := strconv.ParseBool(value)
 		policy.ModeBJudgeEnabled = parsed
 		return err
+	case "mode_b_jury_size":
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		policy.ModeBJurySize = parsed
+		return nil
+	case "mode_b_jury_veto_dimensions":
+		policy.ModeBJuryVetoDimensions = parseConfigStringList(value)
+		return nil
+	case "mode_b_jury_veto_floor":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		policy.ModeBJuryVetoFloor = parsed
+		return nil
+	case "mode_b_jury_disagreement_tau":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		policy.ModeBJuryDisagreementTau = parsed
+		return nil
 	case "live_ab_sample_rate":
 		parsed, err := parseConfigFloat(value)
 		if err != nil {
@@ -749,6 +806,14 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 // errors: an unknown name is simply ignored downstream (best-effort), so a typo
 // degrades to fewer dimensions rather than failing the daemon's config load.
 func parseDeterministicCheckerList(value string) []string {
+	return parseConfigStringList(value)
+}
+
+// parseConfigStringList parses a plain comma list (e.g. "a, b ,c") into a
+// trimmed, non-empty slice; an empty value (or only blanks) yields nil. It is the
+// shared parser for comma-list config knobs (deterministic_checkers,
+// mode_b_jury_veto_dimensions) and never errors.
+func parseConfigStringList(value string) []string {
 	var out []string
 	for _, part := range strings.Split(value, ",") {
 		if name := strings.TrimSpace(part); name != "" {

--- a/internal/skillopt/jury.go
+++ b/internal/skillopt/jury.go
@@ -1,0 +1,210 @@
+package skillopt
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+// JuryJudgeVerdict is ONE judge's contribution to the pure jury aggregation
+// (#349): its per-dimension [0,1] scores (empty on a pairwise A/B pick that has
+// no rubric) and its boolean Decision (promote / pairwise "challenger wins").
+// The aggregator is agnostic to the boolean's semantics — it only counts votes —
+// so the same EvaluateJury serves both a promotion-boundary rubric jury and a
+// pairwise A/B jury.
+type JuryJudgeVerdict struct {
+	// DimensionScores is this judge's per-dimension [0,1] rubric. It MAY be empty
+	// (a pairwise A/B pick carries no rubric); the median/veto outputs are then
+	// simply empty/inert and only the majority/disagreement outputs are meaningful.
+	DimensionScores map[string]float64
+	// Decision is this judge's boolean verdict: true = promote / "challenger wins",
+	// false = reject / "champion wins". The aggregator never interprets it beyond
+	// the majority count.
+	Decision bool
+}
+
+// JuryConfig parameterizes the pure aggregation (#349). All fields are optional;
+// the zero value is a total, safe configuration (no veto can fire, std-based
+// disagreement is disabled).
+type JuryConfig struct {
+	// VetoDimensions is the configured set of safety / hard-correctness dimensions
+	// subject to the minority-veto: a SINGLE judge scoring below VetoFloor on any
+	// of these BLOCKS (fail-closed), even when the majority would promote. Empty
+	// (the default) disables the veto entirely.
+	VetoDimensions []string
+	// VetoFloor is the [0,1] floor for the veto dimensions. The default 0 makes the
+	// veto inert (a clamped [0,1] score is never < 0), so a veto only ever fires
+	// when an operator sets BOTH a floor AND the dimensions.
+	VetoFloor float64
+	// DisagreementTau is the per-dimension population-std threshold above which the
+	// jury is flagged as disagreeing (routes to a human, feeds #345). <= 0 (the
+	// default) DISABLES the std-based check, leaving only the vote-split check.
+	DisagreementTau float64
+}
+
+// JuryDecision is the pure, deterministic, total result of EvaluateJury (#349):
+// the per-dimension medians, the majority boolean, the fail-closed veto flag, and
+// the disagreement flag (+ human-readable reasons). It performs NO I/O and never
+// mutates state — like EvaluateAutoPromote / EvaluateCanaryRegression — so the
+// caller records it as EVIDENCE only and NEVER promotes or touches the bandit on it.
+type JuryDecision struct {
+	// MedianScores is the per-dimension MEDIAN across the judges that scored that
+	// dimension (robust to one outlier judge; even N averages the two middle
+	// values). Empty when no judge supplied any dimension (the pairwise A/B path).
+	MedianScores map[string]float64
+	// Decision is the MAJORITY vote of the judges' booleans. A tie (including the
+	// even-N 1:1 / 2:2 case) resolves to false — the fail-safe "do not promote /
+	// keep the baseline" verdict — and is additionally flagged as disagreement. A
+	// fired veto forces Decision=false regardless of the majority.
+	Decision bool
+	// Vetoed is true when the minority-veto fired: at least one judge scored below
+	// VetoFloor on a configured safety dimension (fail-closed). It is independent of
+	// Disagreement (a unanimous below-floor reject is a veto but not a disagreement).
+	Vetoed bool
+	// VetoReason names the dimension/score that tripped the veto (empty when none).
+	VetoReason string
+	// Disagreement is true when the judges materially disagree: a non-unanimous
+	// boolean vote (the 2:1 split generalized to "both sides voted") OR any
+	// dimension whose population std exceeds DisagreementTau. It routes to a human
+	// and is recorded to feed the judge<->human capture (#345).
+	Disagreement bool
+	// DisagreementReason explains the flag (vote split and/or the offending
+	// dimension std); empty when there is no disagreement.
+	DisagreementReason string
+	// JudgeCount is the number of judges aggregated; Approve/Reject are the boolean
+	// tallies (Approve+Reject == JudgeCount).
+	JudgeCount int
+	Approve    int
+	Reject     int
+}
+
+// EvaluateJury is the pure, deterministic, total jury aggregator (#349): given N
+// judges' per-dimension scores + boolean verdicts and a JuryConfig, it computes
+// the per-dimension MEDIAN (robust to one outlier), the MAJORITY boolean vote
+// (tie => false, fail-safe), the fail-closed MINORITY-VETO over the configured
+// safety dimensions, and the DISAGREEMENT flag (vote split or std > tau). It is
+// the unambiguous, load-bearing core; the CLI wiring records its result as
+// EVIDENCE only (never promotes, never touches the bandit).
+//
+// It is total: zero judges yields the zero decision (JudgeCount 0, Decision
+// false, no veto, no disagreement) and never panics; a judge may omit any
+// dimension (the median is taken over the judges that scored it).
+func EvaluateJury(cfg JuryConfig, verdicts []JuryJudgeVerdict) JuryDecision {
+	decision := JuryDecision{MedianScores: map[string]float64{}, JudgeCount: len(verdicts)}
+	if len(verdicts) == 0 {
+		return decision
+	}
+
+	// Collect each dimension's scores across the judges that provided it, in a
+	// deterministic key order so the reasons (and median map iteration in tests)
+	// are stable.
+	dimValues := map[string][]float64{}
+	var dims []string
+	for _, v := range verdicts {
+		for k, val := range v.DimensionScores {
+			if _, seen := dimValues[k]; !seen {
+				dims = append(dims, k)
+			}
+			dimValues[k] = append(dimValues[k], val)
+		}
+	}
+	sort.Strings(dims)
+	for _, k := range dims {
+		decision.MedianScores[k] = medianFloat(dimValues[k])
+	}
+
+	// MAJORITY vote. A tie (approve == reject, including even-N 1:1/2:2) is the
+	// fail-safe reject: Decision=false, and it is flagged as disagreement below.
+	for _, v := range verdicts {
+		if v.Decision {
+			decision.Approve++
+		} else {
+			decision.Reject++
+		}
+	}
+	decision.Decision = decision.Approve > decision.Reject
+
+	// DISAGREEMENT: a non-unanimous boolean vote (the 2:1 split, generalized to
+	// "both sides cast a vote") OR any dimension whose population std exceeds tau.
+	voteSplit := decision.Approve > 0 && decision.Reject > 0
+	stdReason := ""
+	if cfg.DisagreementTau > 0 {
+		for _, k := range dims {
+			if s := populationStd(dimValues[k]); s > cfg.DisagreementTau {
+				stdReason = fmt.Sprintf("dimension %q std %.4g > tau %.4g", k, s, cfg.DisagreementTau)
+				break
+			}
+		}
+	}
+	if voteSplit || stdReason != "" {
+		decision.Disagreement = true
+		switch {
+		case voteSplit && stdReason != "":
+			decision.DisagreementReason = fmt.Sprintf("vote split %d:%d; %s", decision.Approve, decision.Reject, stdReason)
+		case voteSplit:
+			decision.DisagreementReason = fmt.Sprintf("vote split %d:%d", decision.Approve, decision.Reject)
+		default:
+			decision.DisagreementReason = stdReason
+		}
+	}
+
+	// MINORITY-VETO (fail-closed): one judge below the floor on a configured safety
+	// dimension BLOCKS, forcing Decision=false regardless of the majority. It is
+	// independent of the disagreement flag (a unanimous below-floor reject vetoes
+	// without being a disagreement).
+	for _, dim := range cfg.VetoDimensions {
+		vals, ok := dimValues[dim]
+		if !ok {
+			continue
+		}
+		for _, v := range vals {
+			if v < cfg.VetoFloor {
+				decision.Vetoed = true
+				decision.VetoReason = fmt.Sprintf("safety dimension %q scored %.4g below veto floor %.4g (minority veto, fail-closed)", dim, v, cfg.VetoFloor)
+				break
+			}
+		}
+		if decision.Vetoed {
+			break
+		}
+	}
+	if decision.Vetoed {
+		decision.Decision = false
+	}
+
+	return decision
+}
+
+// medianFloat returns the median of vals (the caller guarantees len>0). Odd N is
+// the middle element; even N averages the two middle elements so a single outlier
+// judge cannot drag the central estimate. It copies before sorting so the caller's
+// slice is untouched.
+func medianFloat(vals []float64) float64 {
+	n := len(vals)
+	sorted := append([]float64(nil), vals...)
+	sort.Float64s(sorted)
+	if n%2 == 1 {
+		return sorted[n/2]
+	}
+	return (sorted[n/2-1] + sorted[n/2]) / 2
+}
+
+// populationStd returns the population standard deviation of vals (0 for an
+// empty slice or a single value), used for the std-based disagreement check.
+func populationStd(vals []float64) float64 {
+	n := len(vals)
+	if n == 0 {
+		return 0
+	}
+	var sum float64
+	for _, v := range vals {
+		sum += v
+	}
+	mean := sum / float64(n)
+	var sq float64
+	for _, v := range vals {
+		d := v - mean
+		sq += d * d
+	}
+	return math.Sqrt(sq / float64(n))
+}

--- a/internal/skillopt/jury.go
+++ b/internal/skillopt/jury.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 )
 
 // JuryJudgeVerdict is ONE judge's contribution to the pure jury aggregation
@@ -152,8 +153,18 @@ func EvaluateJury(cfg JuryConfig, verdicts []JuryJudgeVerdict) JuryDecision {
 	// dimension BLOCKS, forcing Decision=false regardless of the majority. It is
 	// independent of the disagreement flag (a unanimous below-floor reject vetoes
 	// without being a disagreement).
+	// Build a case/space-insensitive lookup so a veto dimension configured as
+	// "Safety" still matches a judge dimension key "safety": the minority-veto is a
+	// fail-CLOSED safety control and must never silently fail OPEN on a mere
+	// name-casing/whitespace mismatch between the config and the rubric keys. Merge
+	// over the already-sorted dims for a deterministic VetoReason.
+	normValues := map[string][]float64{}
+	for _, k := range dims {
+		nk := normalizeDimKey(k)
+		normValues[nk] = append(normValues[nk], dimValues[k]...)
+	}
 	for _, dim := range cfg.VetoDimensions {
-		vals, ok := dimValues[dim]
+		vals, ok := normValues[normalizeDimKey(dim)]
 		if !ok {
 			continue
 		}
@@ -173,6 +184,14 @@ func EvaluateJury(cfg JuryConfig, verdicts []JuryJudgeVerdict) JuryDecision {
 	}
 
 	return decision
+}
+
+// normalizeDimKey canonicalizes a dimension name for veto matching so the
+// configured veto set and the judges' dimension keys compare case- and
+// whitespace-insensitively (a fail-closed safety control must not depend on the
+// operator matching the rubric's exact casing).
+func normalizeDimKey(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
 }
 
 // medianFloat returns the median of vals (the caller guarantees len>0). Odd N is

--- a/internal/skillopt/jury_test.go
+++ b/internal/skillopt/jury_test.go
@@ -1,0 +1,217 @@
+package skillopt
+
+import (
+	"math"
+	"testing"
+)
+
+// pick is a tiny helper building a verdict with only a boolean decision (the
+// pairwise A/B shape: no rubric dimensions).
+func pick(decision bool) JuryJudgeVerdict {
+	return JuryJudgeVerdict{Decision: decision}
+}
+
+// scored builds a verdict with both a boolean decision and per-dimension scores.
+func scored(decision bool, dims map[string]float64) JuryJudgeVerdict {
+	return JuryJudgeVerdict{Decision: decision, DimensionScores: dims}
+}
+
+// TestEvaluateJuryMedian covers the per-dimension median for ODD and EVEN N
+// (even averages the two middle values) and robustness to one outlier judge.
+func TestEvaluateJuryMedian(t *testing.T) {
+	cases := []struct {
+		name     string
+		verdicts []JuryJudgeVerdict
+		dim      string
+		want     float64
+	}{
+		{
+			// Odd N=3: the middle value, unmoved by the 0.1 outlier.
+			name: "odd N median ignores outlier",
+			verdicts: []JuryJudgeVerdict{
+				scored(true, map[string]float64{"quality": 0.8}),
+				scored(true, map[string]float64{"quality": 0.7}),
+				scored(true, map[string]float64{"quality": 0.1}),
+			},
+			dim:  "quality",
+			want: 0.7,
+		},
+		{
+			// Even N=4: average of the two middle values (0.6 and 0.8 => 0.7).
+			name: "even N median averages middle two",
+			verdicts: []JuryJudgeVerdict{
+				scored(true, map[string]float64{"quality": 0.9}),
+				scored(true, map[string]float64{"quality": 0.8}),
+				scored(true, map[string]float64{"quality": 0.6}),
+				scored(true, map[string]float64{"quality": 0.5}),
+			},
+			dim:  "quality",
+			want: 0.7,
+		},
+		{
+			// A dimension only some judges scored: median over the judges that have it.
+			name: "median over judges that scored the dim",
+			verdicts: []JuryJudgeVerdict{
+				scored(true, map[string]float64{"safety": 0.4}),
+				scored(true, map[string]float64{"safety": 0.6}),
+				pick(true), // no dims
+			},
+			dim:  "safety",
+			want: 0.5,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EvaluateJury(JuryConfig{}, tc.verdicts)
+			if math.Abs(got.MedianScores[tc.dim]-tc.want) > 1e-9 {
+				t.Fatalf("median[%q] = %v, want %v", tc.dim, got.MedianScores[tc.dim], tc.want)
+			}
+		})
+	}
+}
+
+// TestEvaluateJuryMajority covers the boolean majority vote INCLUDING tie
+// handling (an even-N tie resolves to the fail-safe false AND flags disagreement).
+func TestEvaluateJuryMajority(t *testing.T) {
+	cases := []struct {
+		name             string
+		verdicts         []JuryJudgeVerdict
+		wantDecision     bool
+		wantApprove      int
+		wantReject       int
+		wantDisagreement bool
+	}{
+		{"unanimous promote", []JuryJudgeVerdict{pick(true), pick(true), pick(true)}, true, 3, 0, false},
+		{"unanimous reject", []JuryJudgeVerdict{pick(false), pick(false)}, false, 0, 2, false},
+		{"2:1 promote with disagreement", []JuryJudgeVerdict{pick(true), pick(true), pick(false)}, true, 2, 1, true},
+		{"1:2 reject with disagreement", []JuryJudgeVerdict{pick(true), pick(false), pick(false)}, false, 1, 2, true},
+		// Even-N tie: fail-safe false, and the split is flagged.
+		{"2:2 tie is fail-safe reject + disagreement", []JuryJudgeVerdict{pick(true), pick(true), pick(false), pick(false)}, false, 2, 2, true},
+		{"1:1 tie is fail-safe reject + disagreement", []JuryJudgeVerdict{pick(true), pick(false)}, false, 1, 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EvaluateJury(JuryConfig{}, tc.verdicts)
+			if got.Decision != tc.wantDecision {
+				t.Fatalf("Decision = %v, want %v", got.Decision, tc.wantDecision)
+			}
+			if got.Approve != tc.wantApprove || got.Reject != tc.wantReject {
+				t.Fatalf("tally = %d:%d, want %d:%d", got.Approve, got.Reject, tc.wantApprove, tc.wantReject)
+			}
+			if got.Disagreement != tc.wantDisagreement {
+				t.Fatalf("Disagreement = %v, want %v (reason %q)", got.Disagreement, tc.wantDisagreement, got.DisagreementReason)
+			}
+		})
+	}
+}
+
+// TestEvaluateJuryMinorityVeto covers the fail-closed minority veto: ONE judge
+// below the floor on a configured safety dimension BLOCKS even when the majority
+// would promote; an unconfigured/absent dimension never vetoes.
+func TestEvaluateJuryMinorityVeto(t *testing.T) {
+	cfg := JuryConfig{VetoDimensions: []string{"safety"}, VetoFloor: 0.5}
+
+	t.Run("one judge below floor blocks despite majority promote", func(t *testing.T) {
+		got := EvaluateJury(cfg, []JuryJudgeVerdict{
+			scored(true, map[string]float64{"safety": 0.9}),
+			scored(true, map[string]float64{"safety": 0.8}),
+			scored(true, map[string]float64{"safety": 0.2}), // one veto
+		})
+		if !got.Vetoed {
+			t.Fatal("expected Vetoed=true (one judge below the safety floor)")
+		}
+		if got.Decision {
+			t.Fatal("expected Decision=false: a veto must force the fail-closed reject despite the 3:0 promote")
+		}
+	})
+
+	t.Run("all above floor does not veto", func(t *testing.T) {
+		got := EvaluateJury(cfg, []JuryJudgeVerdict{
+			scored(true, map[string]float64{"safety": 0.9}),
+			scored(true, map[string]float64{"safety": 0.6}),
+		})
+		if got.Vetoed {
+			t.Fatal("expected Vetoed=false: every judge cleared the floor")
+		}
+		if !got.Decision {
+			t.Fatal("expected Decision=true: unanimous promote, no veto")
+		}
+	})
+
+	t.Run("veto dimension absent never vetoes", func(t *testing.T) {
+		got := EvaluateJury(cfg, []JuryJudgeVerdict{
+			scored(true, map[string]float64{"quality": 0.1}), // low, but not a veto dim
+			scored(true, map[string]float64{"quality": 0.2}),
+		})
+		if got.Vetoed {
+			t.Fatal("expected Vetoed=false: the safety dimension was never scored")
+		}
+	})
+
+	t.Run("default floor zero is inert", func(t *testing.T) {
+		got := EvaluateJury(JuryConfig{VetoDimensions: []string{"safety"}}, []JuryJudgeVerdict{
+			scored(true, map[string]float64{"safety": 0.0}),
+		})
+		if got.Vetoed {
+			t.Fatal("expected Vetoed=false: a [0,1] score is never < 0, so floor 0 cannot fire")
+		}
+	})
+}
+
+// TestEvaluateJuryDisagreement covers BOTH disagreement triggers: a per-dimension
+// std above tau, and a 2:1 vote split. A tau of 0 disables the std check.
+func TestEvaluateJuryDisagreement(t *testing.T) {
+	t.Run("std above tau flags disagreement on a unanimous vote", func(t *testing.T) {
+		// Unanimous promote (no vote split) but the scores are far apart.
+		cfg := JuryConfig{DisagreementTau: 0.2}
+		got := EvaluateJury(cfg, []JuryJudgeVerdict{
+			scored(true, map[string]float64{"quality": 0.9}),
+			scored(true, map[string]float64{"quality": 0.1}),
+		})
+		if !got.Disagreement {
+			t.Fatalf("expected Disagreement=true (std 0.4 > tau 0.2) even on a unanimous vote")
+		}
+	})
+
+	t.Run("tight scores below tau do not flag", func(t *testing.T) {
+		cfg := JuryConfig{DisagreementTau: 0.2}
+		got := EvaluateJury(cfg, []JuryJudgeVerdict{
+			scored(true, map[string]float64{"quality": 0.55}),
+			scored(true, map[string]float64{"quality": 0.50}),
+		})
+		if got.Disagreement {
+			t.Fatalf("expected Disagreement=false (std 0.025 < tau 0.2, unanimous vote), got reason %q", got.DisagreementReason)
+		}
+	})
+
+	t.Run("tau zero disables std check", func(t *testing.T) {
+		// Wide spread but tau unset: only a vote split could flag, and the vote is
+		// unanimous, so no disagreement.
+		got := EvaluateJury(JuryConfig{}, []JuryJudgeVerdict{
+			scored(true, map[string]float64{"quality": 0.9}),
+			scored(true, map[string]float64{"quality": 0.1}),
+		})
+		if got.Disagreement {
+			t.Fatal("expected Disagreement=false: tau=0 disables the std check and the vote is unanimous")
+		}
+	})
+
+	t.Run("2:1 vote split flags regardless of tau", func(t *testing.T) {
+		got := EvaluateJury(JuryConfig{}, []JuryJudgeVerdict{pick(true), pick(true), pick(false)})
+		if !got.Disagreement {
+			t.Fatal("expected Disagreement=true for a 2:1 vote split")
+		}
+	})
+}
+
+// TestEvaluateJuryEmptyIsTotal proves the aggregator is total: zero judges yields
+// the zero decision and never panics.
+func TestEvaluateJuryEmptyIsTotal(t *testing.T) {
+	got := EvaluateJury(JuryConfig{VetoDimensions: []string{"safety"}, VetoFloor: 0.9, DisagreementTau: 0.1}, nil)
+	if got.JudgeCount != 0 || got.Decision || got.Vetoed || got.Disagreement {
+		t.Fatalf("empty jury must be the zero decision, got %+v", got)
+	}
+	if len(got.MedianScores) != 0 {
+		t.Fatalf("empty jury must have no medians, got %v", got.MedianScores)
+	}
+}

--- a/internal/skillopt/jury_test.go
+++ b/internal/skillopt/jury_test.go
@@ -156,6 +156,22 @@ func TestEvaluateJuryMinorityVeto(t *testing.T) {
 			t.Fatal("expected Vetoed=false: a [0,1] score is never < 0, so floor 0 cannot fire")
 		}
 	})
+
+	// Fails WITHOUT case/space normalization: a fail-closed safety control must not
+	// silently fail OPEN just because the configured veto name's casing/whitespace
+	// differs from the rubric's dimension key.
+	t.Run("veto matches case- and space-insensitively", func(t *testing.T) {
+		got := EvaluateJury(JuryConfig{VetoDimensions: []string{" Safety "}, VetoFloor: 0.5}, []JuryJudgeVerdict{
+			scored(true, map[string]float64{"safety": 0.9}),
+			scored(true, map[string]float64{"safety": 0.2}), // one veto on the lowercase rubric key
+		})
+		if !got.Vetoed {
+			t.Fatal("expected Vetoed=true: \" Safety \" must match the rubric key \"safety\" (fail-closed)")
+		}
+		if got.Decision {
+			t.Fatal("expected Decision=false: the normalized-name veto must force the fail-closed reject")
+		}
+	})
 }
 
 // TestEvaluateJuryDisagreement covers BOTH disagreement triggers: a per-dimension

--- a/internal/workflow/cross_family_jury_test.go
+++ b/internal/workflow/cross_family_jury_test.go
@@ -1,0 +1,154 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// TestPickCrossFamilyJuryDistinctFamilies: with all three families available, a
+// codex implementer's jury is the two OTHER families (claude + codex's rotation),
+// each DISTINCT and never the implementer's own family.
+func TestPickCrossFamilyJuryDistinctFamilies(t *testing.T) {
+	store := stubAgentLister{}
+	authed := map[string]bool{runtime.ClaudeRuntime: true, runtime.KimiRuntime: true, runtime.CodexRuntime: true}
+	jury, err := PickCrossFamilyJury(context.Background(), store, runtime.CodexRuntime, "owner/repo", authed, 3)
+	if err != nil {
+		t.Fatalf("PickCrossFamilyJury error: %v", err)
+	}
+	// codex implementer -> at most 2 cross-family judges (claude, kimi).
+	if len(jury) != 2 {
+		t.Fatalf("jury size = %d, want 2 (claude + kimi; never codex)", len(jury))
+	}
+	seen := map[string]bool{}
+	for _, j := range jury {
+		if j.Runtime == runtime.CodexRuntime {
+			t.Fatalf("jury included the implementer's own family (codex): %+v", j)
+		}
+		if seen[j.Runtime] {
+			t.Fatalf("jury contains a duplicate family %q (must be deduped)", j.Runtime)
+		}
+		seen[j.Runtime] = true
+		if j.SelfFamily {
+			t.Fatalf("a cross-family juror must not be self-family: %+v", j)
+		}
+	}
+	if !seen[runtime.ClaudeRuntime] || !seen[runtime.KimiRuntime] {
+		t.Fatalf("jury families = %v, want claude+kimi", seen)
+	}
+}
+
+// TestPickCrossFamilyJuryDedupesNeverPads: even with size 5 and many registered
+// same-family agents, the jury never exceeds the count of DISTINCT cross-families
+// (diversity over headcount — no padding with near-identical families).
+func TestPickCrossFamilyJuryDedupesNeverPads(t *testing.T) {
+	store := reviewListerGrant("owner/repo",
+		reviewAgent("claude-1", runtime.ClaudeRuntime, "owner/repo"),
+		reviewAgent("claude-2", runtime.ClaudeRuntime, "owner/repo"),
+		reviewAgent("kimi-1", runtime.KimiRuntime, "owner/repo"),
+	)
+	jury, err := PickCrossFamilyJury(context.Background(), store, runtime.CodexRuntime, "owner/repo", nil, 5)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(jury) != 2 {
+		t.Fatalf("jury size = %d, want 2 distinct families (claude once, kimi once) despite size 5", len(jury))
+	}
+	families := map[string]int{}
+	for _, j := range jury {
+		families[j.Runtime]++
+	}
+	if families[runtime.ClaudeRuntime] != 1 || families[runtime.KimiRuntime] != 1 {
+		t.Fatalf("expected exactly one juror per distinct family, got %v", families)
+	}
+}
+
+// TestPickCrossFamilyJuryGracefulDegradation: when only ONE other family is
+// available, the picker returns that one (size 1) — the CALLER then falls back to
+// the single-judge path (a jury of one is just the single judge). With NO other
+// family available it returns empty.
+func TestPickCrossFamilyJuryGracefulDegradation(t *testing.T) {
+	t.Run("one family available returns one", func(t *testing.T) {
+		store := stubAgentLister{}
+		authed := map[string]bool{runtime.ClaudeRuntime: true} // only claude
+		jury, err := PickCrossFamilyJury(context.Background(), store, runtime.CodexRuntime, "owner/repo", authed, 3)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if len(jury) != 1 || jury[0].Runtime != runtime.ClaudeRuntime {
+			t.Fatalf("jury = %+v, want exactly one claude juror (caller falls back to single judge)", jury)
+		}
+	})
+
+	t.Run("no cross-family available returns empty", func(t *testing.T) {
+		store := stubAgentLister{}
+		// Only the implementer's own family authed -> no cross-family juror.
+		authed := map[string]bool{runtime.CodexRuntime: true}
+		jury, err := PickCrossFamilyJury(context.Background(), store, runtime.CodexRuntime, "owner/repo", authed, 3)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if len(jury) != 0 {
+			t.Fatalf("jury = %+v, want empty (no cross-family family available)", jury)
+		}
+	})
+}
+
+// TestPickCrossFamilyJurySizeBelowTwoIsOff: size < 2 is the OFF signal — the
+// picker returns nil so the caller takes the byte-identical single-judge path,
+// even when many distinct families are available.
+func TestPickCrossFamilyJurySizeBelowTwoIsOff(t *testing.T) {
+	store := stubAgentLister{}
+	authed := map[string]bool{runtime.ClaudeRuntime: true, runtime.KimiRuntime: true}
+	for _, size := range []int{0, 1} {
+		jury, err := PickCrossFamilyJury(context.Background(), store, runtime.CodexRuntime, "owner/repo", authed, size)
+		if err != nil {
+			t.Fatalf("size %d: error: %v", size, err)
+		}
+		if jury != nil {
+			t.Fatalf("size %d: jury = %+v, want nil (jury off, single-judge path)", size, jury)
+		}
+	}
+}
+
+// TestPickCrossFamilyJuryUnknownImplementerSkips: an unknown implementer family
+// yields nil (skip — never a possibly-same-family jury).
+func TestPickCrossFamilyJuryUnknownImplementerSkips(t *testing.T) {
+	store := stubAgentLister{}
+	authed := map[string]bool{runtime.ClaudeRuntime: true, runtime.KimiRuntime: true}
+	jury, err := PickCrossFamilyJury(context.Background(), store, "mystery-runtime", "owner/repo", authed, 3)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if jury != nil {
+		t.Fatalf("jury = %+v, want nil for an unknown implementer family", jury)
+	}
+}
+
+// TestPickCrossFamilyJuryPrefersRegisteredOverEphemeral: a registered
+// different-family agent is preferred for its family; the remaining family with no
+// registered agent but authed falls back to an ephemeral read-only leg.
+func TestPickCrossFamilyJuryPrefersRegisteredOverEphemeral(t *testing.T) {
+	store := reviewListerGrant("owner/repo",
+		reviewAgent("claude-rev", runtime.ClaudeRuntime, "owner/repo"),
+	)
+	authed := map[string]bool{runtime.KimiRuntime: true} // kimi only via ephemeral
+	jury, err := PickCrossFamilyJury(context.Background(), store, runtime.CodexRuntime, "owner/repo", authed, 3)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(jury) != 2 {
+		t.Fatalf("jury size = %d, want 2 (claude registered + kimi ephemeral)", len(jury))
+	}
+	byFamily := map[string]CrossFamilyReviewer{}
+	for _, j := range jury {
+		byFamily[j.Runtime] = j
+	}
+	if byFamily[runtime.ClaudeRuntime].RegisteredAgent != "claude-rev" {
+		t.Fatalf("claude juror = %+v, want the registered claude-rev", byFamily[runtime.ClaudeRuntime])
+	}
+	if byFamily[runtime.KimiRuntime].Ephemeral == nil {
+		t.Fatalf("kimi juror = %+v, want an ephemeral leg", byFamily[runtime.KimiRuntime])
+	}
+}

--- a/internal/workflow/cross_family_review.go
+++ b/internal/workflow/cross_family_review.go
@@ -174,6 +174,95 @@ func pickCrossFamilyReviewer(ctx context.Context, store AgentLister, implementer
 	return CrossFamilyReviewer{}, false, nil
 }
 
+// crossFamilyJuryUniverse is the fixed, deterministic family universe the
+// N-diverse-family jury picker iterates (#349): the three known runtime families
+// in a stable order. PickCrossFamilyJury draws DISTINCT families from this list
+// (skipping the implementer's own family), so the resulting jury is cross-family
+// AND family-deduped by construction — diversity over headcount, never two
+// near-identical judges of the same family.
+var crossFamilyJuryUniverse = []string{
+	runtime.ClaudeRuntime,
+	runtime.CodexRuntime,
+	runtime.KimiRuntime,
+}
+
+// PickCrossFamilyJury selects up to `size` cross-family reviewers from DISTINCT
+// model families for the judge-jury (#349), generalizing PickCrossFamilyReviewer
+// from one reviewer to N diverse ones. It is the diversity-first picker the issue
+// mandates: every returned reviewer is a DIFFERENT family from the implementer
+// AND from every other returned reviewer (deduped by family), because correlated
+// same-family judges undermine a panel — so it NEVER pads with a near-identical
+// family to reach `size`.
+//
+// Selection per candidate family (iterating crossFamilyJuryUniverse minus the
+// implementer's family, deterministically):
+//  1. a registered, review-capable agent of that family whose repo scope covers
+//     repo (deterministic by name), else
+//  2. an EPHEMERAL read-only review leg on that family — but ONLY when that family
+//     is actually authed/available (so the leg can really run).
+//
+// A family with neither is skipped. The result is the available distinct families
+// (0..size). GRACEFUL DEGRADATION: when fewer than `size` distinct families are
+// available it returns as many as exist; the CALLER falls back to the single
+// PickCrossFamilyReviewer path when fewer than 2 are returned (a jury of one is
+// just the single judge). An unknown/unrecoverable implementer family yields nil
+// (skip — never a possibly-same-family jury), and size < 2 yields nil (the jury
+// is off; the caller takes the single-judge path) so the off-by-default behavior
+// is byte-identical to today's single cross-family judge.
+func PickCrossFamilyJury(ctx context.Context, store AgentLister, implementerRuntime string, repo string, authedRuntimes map[string]bool, size int) ([]CrossFamilyReviewer, error) {
+	implementerRuntime = strings.TrimSpace(implementerRuntime)
+	if _, known := crossFamilyRotation[implementerRuntime]; !known {
+		// Unknown implementer family: skip rather than risk a same-family jury.
+		return nil, nil
+	}
+	if size < 2 {
+		// A jury needs at least two distinct families; below that the caller uses the
+		// existing single cross-family judge path (byte-identical off-by-default).
+		return nil, nil
+	}
+
+	agents, err := listReviewAgents(ctx, store, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	var jury []CrossFamilyReviewer
+	for _, family := range crossFamilyJuryUniverse {
+		if strings.EqualFold(family, implementerRuntime) {
+			// Cross-family ONLY: never include the agent's own family (preference-leakage
+			// guard), which also keeps the panel's families distinct.
+			continue
+		}
+
+		// 1. A registered DIFFERENT-family review-capable agent of this family.
+		var picked *CrossFamilyReviewer
+		for _, agent := range agents {
+			if strings.EqualFold(agent.Runtime, family) {
+				picked = &CrossFamilyReviewer{
+					Runtime:         family,
+					RegisteredAgent: agent.Name,
+				}
+				break
+			}
+		}
+		// 2. Else an ephemeral DIFFERENT-family leg, but only if that family is authed.
+		if picked == nil && authedRuntimes[family] {
+			picked = &CrossFamilyReviewer{
+				Runtime:   family,
+				Ephemeral: ephemeralReviewerSpec(family),
+			}
+		}
+		if picked == nil {
+			continue
+		}
+		jury = append(jury, *picked)
+		if len(jury) >= size {
+			break
+		}
+	}
+	return jury, nil
+}
+
 // listReviewAgents returns the registered review-capable agents that can access
 // repo, sorted deterministically by name (ListAgents already orders by name; this
 // re-sorts defensively so the first-match selection is stable regardless of the


### PR DESCRIPTION
Generalizes the off-by-default single cross-family LLM judge (#483) into an N-diverse-family judge **jury** for promotion-boundary / pairwise comparisons, per the evaluator-hardening epic (#344).

## What it does
- **Pure aggregator** `internal/skillopt/jury.go` (`EvaluateJury`, in the style of the existing pure `EvaluateAutoPromote`/`EvaluateCanaryRegression` — pure, deterministic, total, no I/O): per-dimension **median** (robust to one outlier; correct for even N), **majority** vote (tie => fail-safe `false`), fail-closed **minority-veto** over configured safety dimensions, and a **disagreement** flag (per-dimension std > tau, or a non-unanimous "2:1" vote). Fully unit-tested.
- **N-diverse-family picker** `workflow.PickCrossFamilyJury`: returns up to N reviewers from **distinct** model families, **deduped by family** (diversity > headcount, never padded with near-identical families). Fewer than N distinct families => runs as many as exist; size < 2 (or an unknown implementer family) => `nil` so the caller uses the single-judge path.
- **Wired into the existing `runSkillOptABJudge` seam**: when `jury_size >= 2` **and** >= 2 distinct families are available, each juror judges the **same blind** shuffled A/B (serialized Deliver), any erroring/unparseable juror is **dropped** (fail-safe) and the jury proceeds, the **aggregated verdict** is recorded under the canonical `skillopt-ab-judge` tag, each juror's pick under the distinct `skillopt-ab-juror` source, and the **disagreement flag** rides the `eval_review_item` metadata and routes to a human (feeds #345). Falls back to the single judge when < 2 families.

## Invariants
- **Off-by-default / byte-identical**: with `jury_size <= 1` (the default) behavior is **exactly** today's single cross-family judge — no extra judges picked, no behavior change. Covered by a test that fails if a jury runs by default.
- **Additive, no contract bump**: `contract_version=1` unchanged; jury/disagreement metadata rides existing eval metadata.
- **Manual promotion preserved**: the jury is **evidence-only** — never promotes, never touches the bandit posterior (verified by a bandit-pull test).
- **Diversity + fail-safe**: families deduped; graceful degradation below N (and below 2); a single failing juror is dropped and the jury proceeds; the eval is never aborted.
- **Blinding**: candidate origin never leaks to any juror.

## Config knobs (all off by default)
`mode_b_jury_size` (0/1 = off), `mode_b_jury_veto_dimensions`, `mode_b_jury_veto_floor`, `mode_b_jury_disagreement_tau` (+ a `--jury-size` flag). Added to `SkillOptPolicy` and the commented `init.go` stub.

## Tests
Pure aggregator (median odd/even, majority incl. tie, minority-veto, disagreement via std>tau and 2:1), picker (distinct-family dedupe, graceful degradation < N and < 2, size<2 off, unknown-implementer skip, registered-over-ephemeral), and CLI wiring (aggregate + per-juror rows, disagreement flag, per-juror failure fail-safe, single-judge fallback, off-by-default no-jury, config-knob enable, manual-promotion preserved).

Gate green: `go build ./... && go vet ./... && go test ./...` + `-race` on `internal/cli`, `internal/skillopt`, `internal/workflow`.

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)