### PR TITLE
feat(dashboard): render active_jobs in the interactive TUI Activity page (#505)

### DIFF
--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -569,9 +569,15 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 	for _, l := range s.ResourceLocks {
 		out.ResourceLocks = append(out.ResourceLocks, tui.ResourceLock{Key: l.Key, Owner: l.Owner, Stale: l.Stale})
 	}
-	// Note: s.ActiveJobs (in-flight jobs) is rendered only in the plain/--json
-	// dashboard; surfacing it in the interactive TUI is deferred (the Activity
-	// page already covers live delegation trees).
+	for _, j := range s.ActiveJobs {
+		out.ActiveJobs = append(out.ActiveJobs, tui.ActiveJob{
+			ID:    j.ID,
+			Agent: j.Agent,
+			Repo:  j.Repo,
+			Type:  j.Type,
+			State: j.State,
+		})
+	}
 	out.Config = s.configView
 	jobs := make([]db.Job, 0, len(s.jobRows))
 	for _, row := range s.jobRows {

--- a/internal/cli/tui/activity.go
+++ b/internal/cli/tui/activity.go
@@ -111,6 +111,47 @@ func (m Model) activityRows() []activityRow {
 	return rows
 }
 
+// activeJobsSection renders standalone in-flight jobs (queued/running) that are
+// not part of a delegation tree — e.g. a live `@agent ask`. It mirrors the
+// locks-section style: a bold "active jobs" header then one compact line per job
+// (agent · state · id, with repo/type when present), coloured by job state.
+// Returns the empty string when there are no active jobs so the orchestras keep
+// the full window; the empty hint is shown by activityContent's empty state.
+func (m Model) activeJobsSection() string {
+	if len(m.snap.ActiveJobs) == 0 {
+		return ""
+	}
+	// Jobs that belong to a delegation tree are already rendered as orchestras
+	// below, so exclude them here to avoid showing the same in-flight job twice.
+	inTree := map[string]bool{}
+	for _, r := range m.snap.Activity {
+		inTree[r.JobID] = true
+		if r.ContinuationID != "" {
+			inTree[r.ContinuationID] = true
+		}
+		for _, c := range r.Children {
+			inTree[c.ID] = true
+		}
+	}
+	var b strings.Builder
+	for _, j := range m.snap.ActiveJobs {
+		if inTree[j.ID] {
+			continue
+		}
+		if b.Len() == 0 {
+			b.WriteString(headerStyle.Render("active jobs"))
+			b.WriteByte('\n')
+		}
+		line := dash(j.Agent) + "  " + jobStateColor(j.State) + "  " + mutedStyle.Render(truncate(j.ID, 12))
+		if detail := strings.TrimSpace(j.Type + " " + j.Repo); detail != "" {
+			line += "  " + mutedStyle.Render(detail)
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
 // activityContent renders the Activity page: delegation trees with
 // queued/running work, newest first. Each root shows the coordinator line, a
 // progress summary, and the delegation children (which agent is doing what, and
@@ -120,12 +161,42 @@ func (m Model) activityRows() []activityRow {
 // visible — even for a single wide fan-out — with "↑/↓ N more rows" markers for
 // what is scrolled off.
 func (m Model) activityContent() string {
+	var b strings.Builder
+
+	// A standalone in-flight job (a live `@agent ask`) is not a delegation tree,
+	// so it gets its own section above the orchestras.
+	section := m.activeJobsSection()
+	if section != "" {
+		b.WriteString(section)
+		b.WriteByte('\n')
+	}
+
 	if len(m.snap.Activity) == 0 {
-		return m.loadingOr("No active jobs — nothing is running right now.", !m.loadedAt.IsZero())
+		if section == "" {
+			// Nothing standalone is running either: make the empty state explicit.
+			b.WriteString(headerStyle.Render("active jobs"))
+			b.WriteByte('\n')
+			b.WriteString(m.loadingOr("No in-flight jobs.", !m.loadedAt.IsZero()))
+			b.WriteString("\n\n")
+			b.WriteString(m.loadingOr("No active jobs — nothing is running right now.", !m.loadedAt.IsZero()))
+		} else {
+			// Standalone jobs are running, but no delegation trees: refer to the
+			// orchestras here rather than contradicting the section above.
+			b.WriteString(mutedStyle.Render("No delegation trees running."))
+		}
+		return b.String()
 	}
 
 	rows := m.activityRows()
+	// The active-jobs section eats into the tree window so the combined page
+	// still fits the viewport.
 	capacity := activityWindowCap(m.height)
+	if section != "" {
+		capacity -= strings.Count(section, "\n") + 1
+		if capacity < 3 {
+			capacity = 3
+		}
+	}
 
 	// Clamp the effective cursor into the selectable range so the row search
 	// below always matches — even if a future code path mutates m.snap.Activity
@@ -168,7 +239,6 @@ func (m Model) activityContent() string {
 		end = len(rows)
 	}
 
-	var b strings.Builder
 	b.WriteString(mutedStyle.Render("Orchestras — live delegation trees with queued/running work (refreshes every 5s).") + "\n\n")
 	if start > 0 {
 		b.WriteString(mutedStyle.Render("  ↑ "+strconv.Itoa(start)+" more rows above") + "\n")

--- a/internal/cli/tui/activity_test.go
+++ b/internal/cli/tui/activity_test.go
@@ -63,6 +63,38 @@ func TestActivityPageEmpty(t *testing.T) {
 	}
 }
 
+// TestActivityPageRendersActiveJob guards that a standalone in-flight job (a live
+// `@agent ask`, not a delegation tree) surfaces in the Activity page's "active
+// jobs" section with its agent, state, and (truncated) id.
+func TestActivityPageRendersActiveJob(t *testing.T) {
+	snap := Snapshot{
+		Daemon: Daemon{Running: true},
+		ActiveJobs: []ActiveJob{{
+			ID: "job-abcdef123456", Agent: "researcher", Repo: "o/r", Type: "ask", State: "running",
+		}},
+	}
+	m := activityPageModel(t, snap)
+	view := m.View()
+	for _, want := range []string{"active jobs", "researcher", "running", "job-abcdef1"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("active-jobs view missing %q:\n%s", want, view)
+		}
+	}
+	// With a live job present, the page must not also claim nothing is running.
+	if strings.Contains(view, "No active jobs") {
+		t.Fatalf("active-jobs view contradicts itself with the empty hint:\n%s", view)
+	}
+}
+
+// TestActivityPageActiveJobsEmpty guards that a nil ActiveJobs renders the empty
+// hint and does not panic.
+func TestActivityPageActiveJobsEmpty(t *testing.T) {
+	m := activityPageModel(t, Snapshot{Daemon: Daemon{Running: true}, ActiveJobs: nil})
+	if !strings.Contains(m.View(), "No in-flight jobs.") {
+		t.Fatalf("empty active-jobs section should show its hint:\n%s", m.View())
+	}
+}
+
 // TestActivityPageShowsCorrectiveContinuation guards that a live continuation is
 // rendered even when the root has no fresh delegation children (Total == 0) — the
 // engine's corrective-continuation path, where the continuation is the only live

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -32,8 +32,21 @@ type Snapshot struct {
 	JobRows           []JobRow
 	AwaitingHuman     []AwaitingHumanTask
 	PendingCandidates []PendingCandidate
+	ActiveJobs        []ActiveJob
 	Activity          []ActivityRoot
 	Config            ConfigView
+}
+
+// ActiveJob mirrors cli.dashboardActiveJob: one in-flight (queued/running) job
+// surfaced on the Activity page so a standalone `@agent ask` is visible while it
+// runs — distinct from the delegation trees in Activity, since a lone ask is not
+// a tree.
+type ActiveJob struct {
+	ID    string
+	Agent string
+	Repo  string
+	Type  string
+	State string
 }
 
 // AwaitingHumanTask is one delegation tree paused at awaiting_human (#340), shown


### PR DESCRIPTION
## What
Completes **Gap 1** of #505 for the **interactive TUI**. #506 added the `active_jobs` view to the plain/`--json` dashboard; this renders it in the full-screen `gitmoot dashboard` Activity page, so a running `@agent ask` is visible while it runs (not just in `--json`).

## How
- `tui.Snapshot` gains `ActiveJobs []ActiveJob` (`internal/cli/tui/data.go`); `toTUISnapshot` populates it from `dashboardSnapshot.ActiveJobs`.
- New `activeJobsSection()` renders an "active jobs" section (agent · state · id · type/repo, state-coloured) on the Activity page, **deduped** against delegation-tree orchestras (skips any job whose ID is a tree root / continuation / child) so tree jobs aren't shown twice. Returns "" when nothing standalone is running (orchestras keep the full window).
- Empty/edge handling: with live jobs but no trees it shows `No delegation trees running.`; the `No active jobs` line only appears when truly nothing is running.

## Tests
`activity_test.go`: renders an active job (+ negative assertion the contradictory line is absent), and the empty/nil case (no panic). `build`/`vet`/`test ./internal/cli/...` green; the 4 touched files gofmt-clean.

## Scope
Plain/`--json` `dashboard.go` behavior unchanged. #505 Gaps **2** (stale `running` agent_instances) and **3** (daemon shows "stopped" under systemd) remain as follow-ups.

Refs #505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
