### PR TITLE
fix(workflow): preserve council delegation reliability

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -491,7 +491,14 @@ type sqlExecer interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
-const sqliteBusyTimeoutMillis = 5000
+// 15s (raised from 5s): several repo-scoped daemons can share one ~/.gitmoot DB
+// file, and WAL permits only one writer process at a time. A burst (e.g. a
+// plan-by-N fan-out all writing results plus a coordinator continuation across
+// processes) could exceed a 5s wait and surface "database is locked" (SQLITE_BUSY),
+// which in turn made dependent reads return stale data. A longer wait lets the
+// burst drain instead of erroring. (For many concurrent projects, also give each
+// daemon its own home via GITMOOT_HOME_DIR so they do not share a DB at all.)
+const sqliteBusyTimeoutMillis = 15000
 
 func Open(path string) (*Store, error) {
 	db, err := sql.Open("sqlite", path)

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -1243,7 +1243,7 @@ func TestKimiStartFallsBackToGeneratedRefWhenSessionIDMissing(t *testing.T) {
 	}
 }
 
-func TestKimiDeliverCommandResumesSession(t *testing.T) {
+func TestKimiDeliverCommandStartsFreshSession(t *testing.T) {
 	stdout := `{"role":"assistant","content":"done"}` + "\n" +
 		`{"role":"meta","type":"session.resume_hint","session_id":"session_550e8400-e29b-41d4-a716-446655440001","command":"kimi -r session_550e8400-e29b-41d4-a716-446655440001","content":"To resume this session: kimi -r session_550e8400-e29b-41d4-a716-446655440001"}` + "\n"
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
@@ -1260,7 +1260,7 @@ func TestKimiDeliverCommandResumesSession(t *testing.T) {
 	if result.Raw != "done" {
 		t.Fatalf("raw = %q", result.Raw)
 	}
-	runner.want(t, 0, "kimi", "-S", "session_550e8400-e29b-41d4-a716-446655440001", "-p", "review", "--output-format", "stream-json")
+	runner.want(t, 0, "kimi", "-p", "review", "--output-format", "stream-json")
 }
 
 func TestKimiDeliverCommandUsesJobModel(t *testing.T) {
@@ -1272,7 +1272,7 @@ func TestKimiDeliverCommandUsesJobModel(t *testing.T) {
 	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review", Model: "opus"}); err != nil {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
-	runner.want(t, 0, "kimi", "--model", "opus", "-S", "session_550e8400-e29b-41d4-a716-446655440001", "-p", "review", "--output-format", "stream-json")
+	runner.want(t, 0, "kimi", "--model", "opus", "-p", "review", "--output-format", "stream-json")
 }
 
 func TestKimiDeliverCommandFallsBackToAgentModel(t *testing.T) {
@@ -1284,7 +1284,7 @@ func TestKimiDeliverCommandFallsBackToAgentModel(t *testing.T) {
 	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
-	runner.want(t, 0, "kimi", "--model", "sonnet", "-S", "session_550e8400-e29b-41d4-a716-446655440001", "-p", "review", "--output-format", "stream-json")
+	runner.want(t, 0, "kimi", "--model", "sonnet", "-p", "review", "--output-format", "stream-json")
 }
 
 func TestKimiStartCommandUsesAgentModel(t *testing.T) {
@@ -1304,7 +1304,7 @@ func TestKimiStartCommandUsesAgentModel(t *testing.T) {
 	runner.want(t, 0, "kimi", "--model", "opus", "-p", "initialize", "--output-format", "stream-json")
 }
 
-func TestKimiHealthUsesRegisteredSession(t *testing.T) {
+func TestKimiHealthRunsFreshSession(t *testing.T) {
 	stdout := `{"role":"assistant","content":"OK"}` + "\n" +
 		`{"role":"meta","type":"session.resume_hint","session_id":"session_550e8400-e29b-41d4-a716-446655440002","command":"kimi -r session_550e8400-e29b-41d4-a716-446655440002","content":"To resume this session: kimi -r session_550e8400-e29b-41d4-a716-446655440002"}` + "\n"
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
@@ -1314,7 +1314,7 @@ func TestKimiHealthUsesRegisteredSession(t *testing.T) {
 	if err := adapter.Health(context.Background(), agent); err != nil {
 		t.Fatalf("Health returned error: %v", err)
 	}
-	runner.want(t, 0, "kimi", "-S", "session_550e8400-e29b-41d4-a716-446655440002", "-p", KimiLiveCheckPrompt, "--output-format", "stream-json")
+	runner.want(t, 0, "kimi", "-p", KimiLiveCheckPrompt, "--output-format", "stream-json")
 }
 
 func TestKimiHealthClassifiesAuthFailure(t *testing.T) {
@@ -1345,5 +1345,5 @@ func TestKimiHealthRejectsBrokenSession(t *testing.T) {
 	if err := adapter.Health(context.Background(), agent); err == nil {
 		t.Fatal("Health accepted broken Kimi session")
 	}
-	runner.want(t, 0, "kimi", "-S", "session_550e8400-e29b-41d4-a716-446655440002", "-p", KimiLiveCheckPrompt, "--output-format", "stream-json")
+	runner.want(t, 0, "kimi", "-p", KimiLiveCheckPrompt, "--output-format", "stream-json")
 }

--- a/internal/runtime/kimi.go
+++ b/internal/runtime/kimi.go
@@ -74,7 +74,14 @@ func (a KimiAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result,
 	if model != "" {
 		args = append(args, "--model", model)
 	}
-	args = append(args, "-S", agent.RuntimeRef, "-p", job.Prompt, "--output-format", "stream-json")
+	// Kimi Code sessions are DIRECTORY-SCOPED, and Gitmoot runs each job in its own
+	// worktree, so resuming a session created elsewhere fails ("Session ... was created
+	// under a different directory"). Gitmoot jobs are independent (the full context is in
+	// job.Prompt), so start a FRESH session per job (no -S). This works in any worktree
+	// and keeps Kimi a native runtime seat. agent.RuntimeRef stays validated but is not
+	// used to resume across directories.
+	_ = agent.RuntimeRef
+	args = append(args, "-p", job.Prompt, "--output-format", "stream-json")
 	result, err := a.runner().Run(ctx, a.Dir, "kimi", args...)
 	if err != nil {
 		return Result{Raw: result.Stdout + result.Stderr}, kimiCommandError(result, err)

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -1435,6 +1436,33 @@ const MaxDelegationDepth = 8
 // refuses further children and records a delegation_budget_exceeded event.
 const MaxDelegationTotalJobs = 64
 
+// envIntOr returns the POSITIVE integer value of env var name, else def.
+func envIntOr(name string, def int) int {
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// effectiveMaxDelegationDepth / effectiveMaxDelegationTotalJobs let a deployment
+// whose coordinator legitimately runs LONG continuation chains (e.g. a council
+// coordinator that drives 6 rounds plus up to 4 fix cycles — each round and each
+// fix-cycle continuation increments DelegationDepth, so the default 8 is exhausted
+// after ~1 fix cycle) raise the bounds via env, WITHOUT weakening the safe default
+// for every other gitmoot user. The other backstops (width, wall-clock, token/cost
+// budgets) still bound runaway recursion. Env (positive ints):
+//
+//	GITMOOT_MAX_DELEGATION_DEPTH       (default MaxDelegationDepth = 8)
+//	GITMOOT_MAX_DELEGATION_TOTAL_JOBS  (default MaxDelegationTotalJobs = 64)
+func effectiveMaxDelegationDepth() int {
+	return envIntOr("GITMOOT_MAX_DELEGATION_DEPTH", MaxDelegationDepth)
+}
+func effectiveMaxDelegationTotalJobs() int {
+	return envIntOr("GITMOOT_MAX_DELEGATION_TOTAL_JOBS", MaxDelegationTotalJobs)
+}
+
 // MaxDelegationWidth bounds how many delegations a single coordinator result may
 // fan out in one generation. The total-jobs budget is checked before a batch is
 // dispatched, so it cannot stop one enormous fan-out on its own; this caps the
@@ -1669,26 +1697,28 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 		return e.enqueueFinalizeContinuation(ctx, job, payload, "delegation tree killed by operator")
 	}
 
-	if payload.DelegationDepth >= MaxDelegationDepth {
+	maxDepth := effectiveMaxDelegationDepth()
+	if payload.DelegationDepth >= maxDepth {
 		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
 			JobID:   job.ID,
 			Kind:    "delegation_depth_exceeded",
-			Message: fmt.Sprintf("delegation depth %d reached the limit of %d; not dispatching %d delegation(s)", payload.DelegationDepth, MaxDelegationDepth, len(payload.Result.Delegations)),
+			Message: fmt.Sprintf("delegation depth %d reached the limit of %d; not dispatching %d delegation(s)", payload.DelegationDepth, maxDepth, len(payload.Result.Delegations)),
 		})
-		return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("delegation depth limit of %d reached", MaxDelegationDepth))
+		return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("delegation depth limit of %d reached", maxDepth))
 	}
 
 	total, err := e.countRootDelegationJobs(ctx, rootID)
 	if err != nil {
 		return err
 	}
-	if total >= MaxDelegationTotalJobs {
+	maxJobs := effectiveMaxDelegationTotalJobs()
+	if total >= maxJobs {
 		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
 			JobID:   job.ID,
 			Kind:    "delegation_budget_exceeded",
-			Message: fmt.Sprintf("delegation tree for root %s reached the job budget of %d (%d jobs); not dispatching %d delegation(s)", rootID, MaxDelegationTotalJobs, total, len(payload.Result.Delegations)),
+			Message: fmt.Sprintf("delegation tree for root %s reached the job budget of %d (%d jobs); not dispatching %d delegation(s)", rootID, maxJobs, total, len(payload.Result.Delegations)),
 		})
-		return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("per-root job budget of %d reached", MaxDelegationTotalJobs))
+		return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("per-root job budget of %d reached", maxJobs))
 	}
 
 	if exceeded, elapsed := e.rootWallClockExceeded(ctx, rootID); exceeded {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -2168,6 +2168,28 @@ func (e Engine) integrationDepBranches(ctx context.Context, job db.Job, payload 
 	return branches, nil
 }
 
+// declaresImplementDep reports whether delegation d depends on at least one
+// non-read-only (implement) sibling. Used to distinguish a read-only delegation
+// that LEGITIMATELY runs on the base checkout (no implement deps) from one that
+// EXPECTS an integration worktree (it deps on an implement leg) — so that when no
+// leg branch resolves we can fail closed rather than silently review the base.
+func (e Engine) declaresImplementDep(payload JobPayload, d Delegation) bool {
+	deps := compactStrings(d.Deps)
+	if len(deps) == 0 || payload.Result == nil {
+		return false
+	}
+	byID := make(map[string]Delegation, len(payload.Result.Delegations))
+	for _, sib := range payload.Result.Delegations {
+		byID[strings.TrimSpace(sib.ID)] = sib
+	}
+	for _, dep := range deps {
+		if sib, ok := byID[dep]; ok && !readOnlyDelegationAction(sib.Action) {
+			return true
+		}
+	}
+	return false
+}
+
 // commitDelegationLeg commits an implement delegation leg's worktree changes to
 // its own branch when the leg has its own per-delegation worktree but no task/PR
 // finalizer (a PR-less local orchestrate, where the finalizer never runs and the
@@ -2286,6 +2308,22 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 				Message: fmt.Sprintf("delegation %q runs in an integration worktree merging %d implement leg(s)", request.DelegationID, len(legBranches)),
 			})
 		}
+	} else if e.declaresImplementDep(payload, d) {
+		// Fail closed (#19): this read-only delegation depends on an implement leg,
+		// but integrationDepBranches resolved ZERO leg branches above — the leg's
+		// branch was not readable (e.g. transient store contention under several
+		// daemons sharing one DB, or the leg branch not yet committed/visible).
+		// Falling through to the BASE checkout here would make the reviewer judge
+		// code WITHOUT the implemented change, producing false verdicts (the observed
+		// "council reviewed the base, not the integration worktree" bug). Refuse to
+		// review base; block so the build surfaces/retries rather than silently
+		// shipping reviews of stale code.
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_integration_unresolved",
+			Message: fmt.Sprintf("delegation %q depends on an implement leg but no leg branch was resolvable; refusing to review the base checkout", request.DelegationID),
+		})
+		return e.block(ctx, ref, fmt.Sprintf("delegation %q depends on an implement leg but its integration worktree could not be built (no leg branch resolved); refusing to review the base checkout", request.DelegationID))
 	} else if readOnlyFanoutNeedsWorktree(payload, d) {
 		// Read-only fan-out: >=2 read-only siblings share the parent repo and would
 		// otherwise serialize on the repo:<repo> checkout key (only one runs per

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -2152,32 +2152,46 @@ func (e Engine) enqueueDelegation(ctx context.Context, job db.Job, payload JobPa
 	return e.allocateAndEnqueueDelegation(ctx, job, payload, d, request, ref)
 }
 
-// integrationDepBranches returns the per-delegation branches of delegation d's
-// succeeded implement-leg dependencies, so a dependent read-only step (e.g. a
-// decompose-and-verify verify gate) can run against a worktree with those legs
-// merged in rather than the base checkout (issue #332). It returns nil when d has
-// no such deps, in which case the normal read-only paths apply. Read-only deps
-// contribute no branch (they produce no implementation), and a leg that ran in
-// the shared checkout (branch == parent base) is skipped (its work is already on
-// the base).
-func (e Engine) integrationDepBranches(ctx context.Context, job db.Job, payload JobPayload, d Delegation) ([]string, error) {
+type integrationDepResolution struct {
+	branches       []string
+	alreadyOnBase  []string
+	unresolvedDeps []string
+}
+
+// resolveIntegrationDeps classifies delegation d's implement-leg dependencies.
+// Succeeded implement legs on their own branches must be merged into an
+// integration worktree; succeeded implement legs already on the parent base are
+// safe to read from the base checkout; missing/not-succeeded/invalid legs are
+// unresolved and must fail closed so reviewers do not inspect stale code.
+func (e Engine) resolveIntegrationDeps(ctx context.Context, job db.Job, payload JobPayload, d Delegation) (integrationDepResolution, error) {
 	deps := compactStrings(d.Deps)
 	if len(deps) == 0 || payload.Result == nil {
-		return nil, nil
+		return integrationDepResolution{}, nil
 	}
 	byID := make(map[string]Delegation, len(payload.Result.Delegations))
 	for _, sib := range payload.Result.Delegations {
 		byID[strings.TrimSpace(sib.ID)] = sib
 	}
+	hasImplementDep := false
+	for _, dep := range deps {
+		if sib, ok := byID[dep]; ok && !readOnlyDelegationAction(sib.Action) {
+			hasImplementDep = true
+			break
+		}
+	}
+	if !hasImplementDep {
+		return integrationDepResolution{}, nil
+	}
+
 	// Resolve each dep to its winning child job the same way advanceDelegations
 	// does (latest attempt per delegation id), so a leg that succeeded on a retry
 	// contributes its retry branch rather than the failed original.
 	children, err := e.childDelegationJobs(ctx, job.ID)
 	if err != nil {
-		return nil, err
+		return integrationDepResolution{}, err
 	}
 	base := strings.TrimSpace(payload.Branch)
-	var branches []string
+	var result integrationDepResolution
 	for _, dep := range deps {
 		sib, ok := byID[dep]
 		if !ok || readOnlyDelegationAction(sib.Action) {
@@ -2185,39 +2199,41 @@ func (e Engine) integrationDepBranches(ctx context.Context, job db.Job, payload 
 		}
 		legJob, ok := children[dep]
 		if !ok || legJob.State != string(JobSucceeded) {
+			result.unresolvedDeps = append(result.unresolvedDeps, dep)
 			continue
 		}
 		legPayload, err := unmarshalPayload(legJob.Payload)
 		if err != nil {
-			return nil, err
+			result.unresolvedDeps = append(result.unresolvedDeps, dep)
+			continue
 		}
-		if legBranch := strings.TrimSpace(legPayload.Branch); legBranch != "" && legBranch != base {
-			branches = append(branches, legBranch)
+		legBranch := strings.TrimSpace(legPayload.Branch)
+		switch {
+		case legBranch == "":
+			result.unresolvedDeps = append(result.unresolvedDeps, dep)
+		case legBranch == base:
+			result.alreadyOnBase = append(result.alreadyOnBase, dep)
+		default:
+			result.branches = append(result.branches, legBranch)
 		}
 	}
-	return branches, nil
+	return result, nil
 }
 
-// declaresImplementDep reports whether delegation d depends on at least one
-// non-read-only (implement) sibling. Used to distinguish a read-only delegation
-// that LEGITIMATELY runs on the base checkout (no implement deps) from one that
-// EXPECTS an integration worktree (it deps on an implement leg) — so that when no
-// leg branch resolves we can fail closed rather than silently review the base.
-func (e Engine) declaresImplementDep(payload JobPayload, d Delegation) bool {
-	deps := compactStrings(d.Deps)
-	if len(deps) == 0 || payload.Result == nil {
-		return false
+// integrationDepBranches returns the per-delegation branches of delegation d's
+// succeeded implement-leg dependencies, so a dependent read-only step (e.g. a
+// decompose-and-verify verify gate) can run against a worktree with those legs
+// merged in rather than the base checkout (issue #332). It returns nil when d has
+// no branch-backed implement deps, in which case the normal read-only paths apply.
+// Read-only deps contribute no branch (they produce no implementation), and a leg
+// that ran in the shared checkout (branch == parent base) is skipped because its
+// work is already on the base.
+func (e Engine) integrationDepBranches(ctx context.Context, job db.Job, payload JobPayload, d Delegation) ([]string, error) {
+	result, err := e.resolveIntegrationDeps(ctx, job, payload, d)
+	if err != nil {
+		return nil, err
 	}
-	byID := make(map[string]Delegation, len(payload.Result.Delegations))
-	for _, sib := range payload.Result.Delegations {
-		byID[strings.TrimSpace(sib.ID)] = sib
-	}
-	for _, dep := range deps {
-		if sib, ok := byID[dep]; ok && !readOnlyDelegationAction(sib.Action) {
-			return true
-		}
-	}
-	return false
+	return result.branches, nil
 }
 
 // commitDelegationLeg commits an implement delegation leg's worktree changes to
@@ -2298,9 +2314,22 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 			// worktree HEAD instead of a stale parent SHA.
 			request.HeadSHA = ""
 		}
-	} else if legBranches, err := e.integrationDepBranches(ctx, job, payload, d); err != nil {
+	} else if integration, err := e.resolveIntegrationDeps(ctx, job, payload, d); err != nil {
 		return err
-	} else if len(legBranches) > 0 {
+	} else if len(integration.unresolvedDeps) > 0 {
+		// Fail closed (#19): this read-only delegation depends on implement legs that
+		// are not safely readable from either the parent base checkout or branch-backed
+		// integration. Falling through to BASE here would make the reviewer judge code
+		// WITHOUT the implemented change. A zero-branch resolution is allowed only when
+		// every implement dep is already on the parent base branch.
+		unresolved := strings.Join(integration.unresolvedDeps, ", ")
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "delegation_integration_unresolved",
+			Message: fmt.Sprintf("delegation %q depends on unresolved implement leg(s) %s; refusing to review the base checkout", request.DelegationID, unresolved),
+		})
+		return e.block(ctx, ref, fmt.Sprintf("delegation %q depends on unresolved implement leg(s) %s; refusing to review the base checkout", request.DelegationID, unresolved))
+	} else if len(integration.branches) > 0 {
 		// This read-only delegation (e.g. a decompose-and-verify verify gate) depends
 		// on succeeded implement legs that each live on their own branch. Merge them
 		// into one detached worktree so the dependent sees the combined work instead
@@ -2320,7 +2349,7 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 				BaseBranch:   payload.Branch,
 				Checkout:     e.DelegationCheckout,
 				RetryAttempt: request.RetryCount,
-			}, legBranches, manager)
+			}, integration.branches, manager)
 			if err != nil {
 				var blocked BlockedError
 				if errors.As(err, &blocked) {
@@ -2335,25 +2364,9 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 			_ = e.Store.AddJobEvent(ctx, db.JobEvent{
 				JobID:   job.ID,
 				Kind:    "delegation_integrated",
-				Message: fmt.Sprintf("delegation %q runs in an integration worktree merging %d implement leg(s)", request.DelegationID, len(legBranches)),
+				Message: fmt.Sprintf("delegation %q runs in an integration worktree merging %d implement leg(s)", request.DelegationID, len(integration.branches)),
 			})
 		}
-	} else if e.declaresImplementDep(payload, d) {
-		// Fail closed (#19): this read-only delegation depends on an implement leg,
-		// but integrationDepBranches resolved ZERO leg branches above — the leg's
-		// branch was not readable (e.g. transient store contention under several
-		// daemons sharing one DB, or the leg branch not yet committed/visible).
-		// Falling through to the BASE checkout here would make the reviewer judge
-		// code WITHOUT the implemented change, producing false verdicts (the observed
-		// "council reviewed the base, not the integration worktree" bug). Refuse to
-		// review base; block so the build surfaces/retries rather than silently
-		// shipping reviews of stale code.
-		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
-			JobID:   job.ID,
-			Kind:    "delegation_integration_unresolved",
-			Message: fmt.Sprintf("delegation %q depends on an implement leg but no leg branch was resolvable; refusing to review the base checkout", request.DelegationID),
-		})
-		return e.block(ctx, ref, fmt.Sprintf("delegation %q depends on an implement leg but its integration worktree could not be built (no leg branch resolved); refusing to review the base checkout", request.DelegationID))
 	} else if readOnlyFanoutNeedsWorktree(payload, d) {
 		// Read-only fan-out: >=2 read-only siblings share the parent repo and would
 		// otherwise serialize on the repo:<repo> checkout key (only one runs per

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4837,3 +4837,31 @@ func TestEngineDelegationPreflightBoundedFinalize(t *testing.T) {
 		t.Fatalf("the finalize path must still record the structured preflight failure")
 	}
 }
+
+// TestEffectiveDelegationBoundsEnvOverride covers #22: the depth/total-jobs bounds
+// are env-overridable (so a council coordinator's long continuation chains aren't
+// strangled by the default-8 depth), defaulting to the safe consts when unset.
+func TestEffectiveDelegationBoundsEnvOverride(t *testing.T) {
+	if got := effectiveMaxDelegationDepth(); got != MaxDelegationDepth {
+		t.Fatalf("default depth = %d, want %d", got, MaxDelegationDepth)
+	}
+	if got := effectiveMaxDelegationTotalJobs(); got != MaxDelegationTotalJobs {
+		t.Fatalf("default total-jobs = %d, want %d", got, MaxDelegationTotalJobs)
+	}
+	t.Setenv("GITMOOT_MAX_DELEGATION_DEPTH", "32")
+	t.Setenv("GITMOOT_MAX_DELEGATION_TOTAL_JOBS", "128")
+	if got := effectiveMaxDelegationDepth(); got != 32 {
+		t.Fatalf("override depth = %d, want 32", got)
+	}
+	if got := effectiveMaxDelegationTotalJobs(); got != 128 {
+		t.Fatalf("override total-jobs = %d, want 128", got)
+	}
+	t.Setenv("GITMOOT_MAX_DELEGATION_DEPTH", "0")
+	if got := effectiveMaxDelegationDepth(); got != MaxDelegationDepth {
+		t.Fatalf("zero override -> %d, want default %d", got, MaxDelegationDepth)
+	}
+	t.Setenv("GITMOOT_MAX_DELEGATION_DEPTH", "notanint")
+	if got := effectiveMaxDelegationDepth(); got != MaxDelegationDepth {
+		t.Fatalf("invalid override -> %d, want default %d", got, MaxDelegationDepth)
+	}
+}

--- a/internal/workflow/integration_worktree_test.go
+++ b/internal/workflow/integration_worktree_test.go
@@ -213,3 +213,46 @@ func TestAllocateAndEnqueueDelegationRoutesVerifyToIntegrationWorktree(t *testin
 		t.Fatalf("merge calls = %+v, want one merge of the two leg branches", manager.mergeCalls)
 	}
 }
+
+// TestAllocateAndEnqueueDelegationBlocksWhenImplementLegUnresolved covers the #19
+// fix: a read-only delegation that DEPENDS on an implement leg must NOT silently
+// fall through to the base checkout when no leg branch resolves (e.g. the leg's
+// branch was not readable under store contention). Reviewing base would judge code
+// without the implemented change. It must fail closed (block) instead.
+func TestAllocateAndEnqueueDelegationBlocksWhenImplementLegUnresolved(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	home := t.TempDir()
+	manager := &fakeWorktreeManager{}
+	engine := testEngine(store)
+	engine.Home = home
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	// The implement leg "legA" is declared as a sibling and depended on, but NO
+	// succeeded leg job exists for it -> integrationDepBranches yields 0 branches
+	// while the delegation still declares an implement dep.
+	parentJob := db.Job{ID: "p", Agent: "coord", Type: "ask"}
+	parentPayload := JobPayload{
+		Repo:   "owner/repo",
+		Branch: "task-x",
+		Result: &AgentResult{Delegations: []Delegation{
+			{ID: "legA", Action: "implement"},
+			{ID: "verify", Action: "review", Deps: []string{"legA"}},
+		}},
+	}
+	verify := Delegation{ID: "verify", Agent: "checker", Action: "review", Prompt: "verify", Deps: []string{"legA"}}
+	request := engine.delegationRequest(parentJob, parentPayload, verify)
+
+	err := engine.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, verify, request, taskRefFromPayload(parentPayload))
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("err = %v, want BlockedError (must fail closed, not review the base checkout)", err)
+	}
+	if len(manager.mergeCalls) != 0 {
+		t.Fatalf("mergeCalls = %d, want 0 (no leg branch to merge)", len(manager.mergeCalls))
+	}
+	if got := countJobEvents(t, store, "p", "delegation_integration_unresolved"); got != 1 {
+		t.Fatalf("delegation_integration_unresolved events = %d, want 1", got)
+	}
+}

--- a/internal/workflow/integration_worktree_test.go
+++ b/internal/workflow/integration_worktree_test.go
@@ -214,6 +214,52 @@ func TestAllocateAndEnqueueDelegationRoutesVerifyToIntegrationWorktree(t *testin
 	}
 }
 
+func TestAllocateAndEnqueueDelegationAllowsImplementDepAlreadyOnBase(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	home := t.TempDir()
+	manager := &fakeWorktreeManager{}
+	engine := testEngine(store)
+	engine.Home = home
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legA", Agent: "builder", Type: "implement", ParentJobID: "p", DelegationID: "legA"},
+		JobPayload{Repo: "owner/repo", Branch: "task-x", DelegationID: "legA"})
+
+	parentJob := db.Job{ID: "p", Agent: "coord", Type: "ask"}
+	parentPayload := JobPayload{
+		Repo:   "owner/repo",
+		Branch: "task-x",
+		Result: &AgentResult{Delegations: []Delegation{
+			{ID: "legA", Action: "implement"},
+			{ID: "verify", Action: "review", Deps: []string{"legA"}},
+		}},
+	}
+	verify := Delegation{ID: "verify", Agent: "checker", Action: "review", Prompt: "verify the base work", Deps: []string{"legA"}}
+	request := engine.delegationRequest(parentJob, parentPayload, verify)
+
+	if err := engine.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, verify, request, taskRefFromPayload(parentPayload)); err != nil {
+		t.Fatalf("allocateAndEnqueueDelegation returned error: %v", err)
+	}
+	child, err := unmarshalPayload(mustJob(t, store, "p/delegation/verify").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if child.Branch != "task-x" {
+		t.Fatalf("verify branch = %q, want parent branch task-x", child.Branch)
+	}
+	if child.WorktreePath != "" {
+		t.Fatalf("verify worktree path = %q, want shared checkout", child.WorktreePath)
+	}
+	if len(manager.mergeCalls) != 0 {
+		t.Fatalf("merge calls = %+v, want none for already-on-base implement dep", manager.mergeCalls)
+	}
+	if got := countJobEvents(t, store, "p", "delegation_integration_unresolved"); got != 0 {
+		t.Fatalf("delegation_integration_unresolved events = %d, want 0", got)
+	}
+}
+
 // TestAllocateAndEnqueueDelegationBlocksWhenImplementLegUnresolved covers the #19
 // fix: a read-only delegation that DEPENDS on an implement leg must NOT silently
 // fall through to the base checkout when no leg branch resolves (e.g. the leg's
@@ -251,6 +297,48 @@ func TestAllocateAndEnqueueDelegationBlocksWhenImplementLegUnresolved(t *testing
 	}
 	if len(manager.mergeCalls) != 0 {
 		t.Fatalf("mergeCalls = %d, want 0 (no leg branch to merge)", len(manager.mergeCalls))
+	}
+	if got := countJobEvents(t, store, "p", "delegation_integration_unresolved"); got != 1 {
+		t.Fatalf("delegation_integration_unresolved events = %d, want 1", got)
+	}
+}
+
+func TestAllocateAndEnqueueDelegationBlocksWhenAnyImplementLegUnresolved(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	home := t.TempDir()
+	manager := &fakeWorktreeManager{}
+	engine := testEngine(store)
+	engine.Home = home
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	insertCompletedJob(t, store, db.Job{ID: "p/delegation/legA", Agent: "builder", Type: "implement", ParentJobID: "p", DelegationID: "legA"},
+		JobPayload{Repo: "owner/repo", Branch: "branchA", DelegationID: "legA"})
+
+	parentJob := db.Job{ID: "p", Agent: "coord", Type: "ask"}
+	parentPayload := JobPayload{
+		Repo:   "owner/repo",
+		Branch: "task-x",
+		Result: &AgentResult{Delegations: []Delegation{
+			{ID: "legA", Action: "implement"},
+			{ID: "legB", Action: "implement"},
+			{ID: "verify", Action: "review", Deps: []string{"legA", "legB"}},
+		}},
+	}
+	verify := Delegation{ID: "verify", Agent: "checker", Action: "review", Prompt: "verify the combined work", Deps: []string{"legA", "legB"}}
+	request := engine.delegationRequest(parentJob, parentPayload, verify)
+
+	err := engine.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, verify, request, taskRefFromPayload(parentPayload))
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("err = %v, want BlockedError (must not partially integrate while a dep is unresolved)", err)
+	}
+	if len(manager.mergeCalls) != 0 {
+		t.Fatalf("mergeCalls = %d, want 0 when any implement dep is unresolved", len(manager.mergeCalls))
+	}
+	if jobExists(t, store, "p/delegation/verify") {
+		t.Fatal("verify job was enqueued despite unresolved implement dep")
 	}
 	if got := countJobEvents(t, store, "p", "delegation_integration_unresolved"); got != 1 {
 		t.Fatalf("delegation_integration_unresolved events = %d, want 1", got)


### PR DESCRIPTION
## Summary

This PR upstreams the council reliability fixes currently carried in gaijinjoe/gitmoot so downstream council users can run upstream Gitmoot without reintroducing known failures.

## Fixes

- Fail closed when a review integration worktree cannot be built, instead of letting reviewers inspect stale/base code.
- Make delegation depth and total-job bounds environment-overridable via `GITMOOT_MAX_DELEGATION_DEPTH` and `GITMOOT_MAX_DELEGATION_TOTAL_JOBS`, preserving existing defaults when unset/invalid.
- Start Kimi jobs with a fresh session per job instead of resuming a directory-bound session that fails in per-delegation worktrees.

## Verification

- `go build ./...`
- `go test ./internal/db ./internal/workflow ./internal/runtime`
- `go test ./internal/workflow ./internal/runtime`

## Notes

These changes are based on upstream `main` at `a06b6ad` and are already validated locally with the council stack.
