### PR TITLE
docs: bump pinned gitmoot-skillopt wheel to v0.4.1

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -428,7 +428,7 @@ recommended install path is:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.0/gitmoot_skillopt-0.4.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.1/gitmoot_skillopt-0.4.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -653,7 +653,7 @@ training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
 to validate the contract without model calls.
 Before real model-backed optimization, check `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help`, or install it with
-`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.0/gitmoot_skillopt-0.4.0-py3-none-any.whl`.
+`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.1/gitmoot_skillopt-0.4.1-py3-none-any.whl`.
 Verify required model/backend environment variables for the installed optimizer
 version. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -129,7 +129,7 @@ training:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.0/gitmoot_skillopt-0.4.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.1/gitmoot_skillopt-0.4.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -290,7 +290,7 @@ Fix:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.0/gitmoot_skillopt-0.4.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.1/gitmoot_skillopt-0.4.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -668,7 +668,7 @@ training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
 to validate the contract without model calls.
 Before real model-backed optimization, check `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help`, or install it with
-`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.0/gitmoot_skillopt-0.4.0-py3-none-any.whl`.
+`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.1/gitmoot_skillopt-0.4.1-py3-none-any.whl`.
 Verify required model/backend environment variables for the installed optimizer
 version. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -421,7 +421,7 @@ recommended install path is:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.0/gitmoot_skillopt-0.4.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.1/gitmoot_skillopt-0.4.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2810,7 +2810,7 @@ recommended install path is:
 ```sh
 python3 -m pip install --user pipx
 python3 -m pipx ensurepath
-pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.0/gitmoot_skillopt-0.4.0-py3-none-any.whl
+pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.1/gitmoot_skillopt-0.4.1-py3-none-any.whl
 gitmoot-skillopt --version
 gitmoot-skillopt optimize --help
 ```
@@ -6600,7 +6600,7 @@ training.json --artifact-root ~/.gitmoot/evals/blobs --out-root
 to validate the contract without model calls.
 Before real model-backed optimization, check `gitmoot-skillopt --version` and
 `gitmoot-skillopt optimize --help`, or install it with
-`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.0/gitmoot_skillopt-0.4.0-py3-none-any.whl`.
+`pipx install https://github.com/jerryfane/gitmoot-skillopt/releases/download/v0.4.1/gitmoot_skillopt-0.4.1-py3-none-any.whl`.
 Verify required model/backend environment variables for the installed optimizer
 version. `skillopt import` validates a candidate package and stores the
 candidate template as a pending version; it never promotes the candidate


### PR DESCRIPTION
Bumps the pinned gitmoot-skillopt wheel URL v0.4.0 → v0.4.1 (kimi runtime fix) across both doc trees + regenerated llms-full.txt.