### PR TITLE
fix(cli): validate the Claude token in doctor instead of trusting presence (#486)

### DIFF
--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -63,7 +63,7 @@ func (c Checker) GlobalChecks(ctx context.Context) []Check {
 	// state first when it can be detected (issue #427). The shell-local check
 	// follows, clearly labeled, so a warn in a terminal can't be mistaken for "the
 	// daemon is broken".
-	if daemon, ok := c.claudeAuthDaemon(); ok {
+	if daemon, ok := c.claudeAuthDaemon(ctx); ok {
 		checks = append(checks, daemon)
 	}
 	checks = append(checks, c.claudeAuthEnv(ctx), c.ghAuth(ctx, runner))
@@ -153,11 +153,33 @@ const claudeShellAuthLabel = "current shell (not the daemon)"
 // fail-open (Linux /proc only): when the daemon isn't running or its environment
 // can't be read it returns ok=false and the caller falls back to the shell-local
 // check. Secrets are never printed (masked set/unset only).
-func (c Checker) claudeAuthDaemon() (Check, bool) {
+func (c Checker) claudeAuthDaemon(ctx context.Context) (Check, bool) {
 	if strings.TrimSpace(c.Paths.Home) == "" {
 		return Check{}, false
 	}
-	return claudeAuthDaemonCheck(presence.InspectDaemonClaudeAuth(c.Paths))
+	snap := presence.InspectDaemonClaudeAuth(c.Paths)
+	base, ok := claudeAuthDaemonCheck(snap)
+	if !ok {
+		return Check{}, false
+	}
+	// Dashboard path (LiveProbe false) or a daemon with no credential: keep the
+	// presence-only report. The dashboard must never spawn claude, and an
+	// unauthenticated daemon is already a warn — only the one-shot `gitmoot doctor`
+	// validates the live token. The prior code reported OK:true for a set-but-
+	// invalid daemon token (#486); below it actually probes that exact token.
+	if !c.LiveProbe || !snap.Auth.Ready() {
+		return base, true
+	}
+	credEnv, hasCred := presence.DaemonClaudeCredEnv(c.Paths)
+	if !hasCred {
+		// Booleans were readable but the values are not (non-Linux, hardened /proc):
+		// fall back to presence rather than probe the doctor's own credential, which
+		// may differ from the daemon's and would give a misleading verdict.
+		return base, true
+	}
+	masked := "running daemon (pid " + strconv.Itoa(snap.PID) + "): " + snap.Auth.MaskedDetail()
+	probeErr := runtime.ClaudeLiveCheckEnv(ctx, c.runner(), "", credEnv)
+	return claudeProbeCheck("claude auth (daemon)", masked, "live token check passed", true, probeErr), true
 }
 
 // claudeAuthDaemonCheck builds the daemon-aware claude auth Check from an already
@@ -184,35 +206,63 @@ func claudeAuthDaemonCheck(daemon presence.DaemonAuthSnapshot) (Check, bool) {
 func (c Checker) claudeAuthEnv(ctx context.Context) Check {
 	auth := runtime.InspectClaudeAuthEnv(os.LookupEnv)
 	masked := claudeShellAuthLabel + ": " + auth.MaskedDetail()
-	if auth.Ready() {
-		detail := masked
+	withWarn := func(detail string) string {
 		if warning := auth.Warning(); warning != "" {
-			detail += "; " + warning
+			return detail + "; " + warning
 		}
-		return Check{Name: "claude auth", OK: true, Required: false, Detail: detail}
+		return detail
 	}
-	// Env not Ready does not mean auth is broken: foreground Claude may
-	// authenticate fine via cached ~/.claude credentials. The dashboard path
-	// (LiveProbe false) keeps the env-only warn — it must never spawn claude per
-	// refresh. The one-shot `gitmoot doctor` (LiveProbe true) probes the real
-	// dependency (claude -p) so a cached-creds box reports OK instead of a
-	// false-negative warn.
+	// Dashboard path (LiveProbe false): never spawn claude — GlobalChecks reruns
+	// on every dashboard refresh. Report the env-presence signal only. A set token
+	// reads OK; an unset one warns (foreground Claude may still authenticate via
+	// cached ~/.claude credentials, hence non-required).
 	if !c.LiveProbe {
-		detail := masked
-		if warning := auth.Warning(); warning != "" {
-			detail += "; " + warning
-		}
-		return Check{Name: "claude auth", OK: false, Required: false, Detail: detail}
+		return Check{Name: "claude auth", OK: auth.Ready(), Required: false, Detail: withWarn(masked)}
 	}
-	if err := runtime.ClaudeLiveCheck(ctx, c.runner(), ""); err != nil {
-		if runtime.ClaudeProbeUnavailable(err) {
+	// One-shot `gitmoot doctor` (LiveProbe true): a token that is merely SET is not
+	// proof it authenticates (#486) — the prior code short-circuited a present token
+	// to OK:true and never probed, so an invalid CLAUDE_CODE_OAUTH_TOKEN reported
+	// ok. Probe the real dependency (a fresh `claude -p`, the same non-interactive
+	// path daemon jobs take) and distinguish valid / invalid / unknown. The probe
+	// also covers the cached-creds case (no env token) it always did.
+	probeErr := runtime.ClaudeLiveCheck(ctx, c.runner(), "")
+	return claudeProbeCheck("claude auth", masked, runtime.ClaudeBackgroundTokenMessage, auth.Ready(), probeErr)
+}
+
+// claudeProbeCheck maps a live-probe outcome to a claude auth Check, distinguishing
+// valid / invalid / unknown (#486). It is shared by the shell-local and the
+// daemon-aware checks so both VALIDATE the credential instead of trusting that it
+// is merely set:
+//   - valid   → OK:true,  detail + okCaveat (the caveat is empty when the probe
+//     validated the exact credential that matters, e.g. the daemon's own token).
+//   - invalid → OK:false, the credential was rejected — the false-green this fixes.
+//   - unknown → fail-open so doctor never goes red on a transient/network blip or a
+//     missing binary: a binary that could not run is a probe-unavailable warn; a
+//     transient error leaves a SET credential reported (OK) but clearly unvalidated,
+//     while an UNSET credential stays a warn.
+func claudeProbeCheck(name, masked, okCaveat string, ready bool, probeErr error) Check {
+	switch runtime.ClaudeClassifyProbe(probeErr) {
+	case runtime.ClaudeTokenValid:
+		detail := masked
+		if okCaveat != "" {
+			detail += "; " + okCaveat
+		}
+		return Check{Name: name, OK: true, Required: false, Detail: detail}
+	case runtime.ClaudeTokenInvalid:
+		return Check{Name: name, OK: false, Required: false, Detail: masked + "; " + runtime.ClaudeSessionAuthFailedMessage}
+	default: // unknown
+		if runtime.ClaudeProbeUnavailable(probeErr) {
 			// Missing/unrunnable binary is not an auth regression; the claude CLI
 			// presence check already covers it. Keep it a non-required warn.
-			return Check{Name: "claude auth", OK: false, Required: false, Detail: masked + "; " + runtime.ClaudeBackgroundTokenMessage + " (probe unavailable)"}
+			return Check{Name: name, OK: false, Required: false, Detail: masked + "; " + runtime.ClaudeBackgroundTokenMessage + " (probe unavailable)"}
 		}
-		return Check{Name: "claude auth", OK: false, Required: false, Detail: masked + "; " + runtime.ClaudeSessionAuthFailedMessage}
+		if ready {
+			// A transient/network error must not flip a SET credential to a failure
+			// (that would make doctor flaky); report it as set-but-unvalidated.
+			return Check{Name: name, OK: true, Required: false, Detail: masked + "; could not validate the token (transient error); reporting it set-but-unvalidated"}
+		}
+		return Check{Name: name, OK: false, Required: false, Detail: masked + "; " + runtime.ClaudeBackgroundTokenMessage}
 	}
-	return Check{Name: "claude auth", OK: true, Required: false, Detail: masked + "; " + runtime.ClaudeBackgroundTokenMessage}
 }
 
 func FailedRequired(checks []Check) error {

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -177,6 +177,15 @@ func (c Checker) claudeAuthDaemon(ctx context.Context) (Check, bool) {
 		// may differ from the daemon's and would give a misleading verdict.
 		return base, true
 	}
+	// Isolate the probe to the injected daemon token: point claude at a throwaway
+	// empty CLAUDE_CONFIG_DIR so cached ~/.claude credentials in the doctor's HOME
+	// cannot mask a bad daemon token — the decisive token-only test for #486. If the
+	// throwaway dir can't be created, fall through with the (already neutralized)
+	// credEnv rather than skipping the probe.
+	if probeDir, err := os.MkdirTemp("", "gitmoot-claude-probe-"); err == nil {
+		defer os.RemoveAll(probeDir)
+		credEnv = append(credEnv, runtime.ClaudeConfigDirEnv+"="+probeDir)
+	}
 	masked := "running daemon (pid " + strconv.Itoa(snap.PID) + "): " + snap.Auth.MaskedDetail()
 	probeErr := runtime.ClaudeLiveCheckEnv(ctx, c.runner(), "", credEnv)
 	return claudeProbeCheck("claude auth (daemon)", masked, "live token check passed", true, probeErr), true

--- a/internal/doctor/checker_test.go
+++ b/internal/doctor/checker_test.go
@@ -192,23 +192,75 @@ func TestClaudeAuthEnvDashboardNeverProbes(t *testing.T) {
 	}
 }
 
-func TestClaudeAuthEnvReadySkipsProbe(t *testing.T) {
-	withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
-	runs := 0
-	runner := countingRunner{
-		fakeRunner: fakeRunner{
-			runs: map[string]subprocess.Result{claudeProbeKey: {Stderr: "should not run"}},
-			errs: map[string]error{claudeProbeKey: fmt.Errorf("should not run")},
+// TestClaudeAuthEnvLiveProbeValidatesSetToken486 is the #486 regression: with an
+// env token PRESENT and LiveProbe on, `gitmoot doctor` must actually validate the
+// token instead of short-circuiting a set credential to OK:true. The prior code
+// trusted presence and never probed, so an invalid CLAUDE_CODE_OAUTH_TOKEN
+// reported "ok" while it 401'd fresh sessions. Each case asserts the probe RAN
+// (runs==1) and that valid/invalid/transient map to OK / not-OK / set-but-
+// unvalidated, with transient never reported as invalid (no flaky red).
+//
+// Reverting claudeAuthEnv to the set-token instant path makes the invalid case
+// assert OK:false against the old OK:true — a failing-then-passing guard.
+func TestClaudeAuthEnvLiveProbeValidatesSetToken486(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		result      subprocess.Result
+		err         error
+		wantOK      bool
+		wantDetail  string
+		wantNoMatch string
+	}{
+		{
+			name:       "valid token authenticates",
+			result:     subprocess.Result{Stdout: `{"result":"OK"}`},
+			wantOK:     true,
+			wantDetail: runtime.ClaudeBackgroundTokenMessage,
 		},
-		runs: &runs,
-	}
-	// Even with LiveProbe true, an env token present takes the instant path.
-	check := Checker{Runner: runner, LiveProbe: true}.claudeAuthEnv(context.Background())
-	if !check.OK {
-		t.Fatalf("claude auth check = %+v, want OK:true when env token present", check)
-	}
-	if runs != 0 {
-		t.Fatalf("env-Ready path ran the runner %d times, want 0", runs)
+		{
+			name:        "invalid token is rejected not ok",
+			result:      subprocess.Result{Stderr: "401 Invalid authentication credentials"},
+			err:         fmt.Errorf("exit 1"),
+			wantOK:      false,
+			wantDetail:  runtime.ClaudeSessionAuthFailedMessage,
+			wantNoMatch: "could not validate",
+		},
+		{
+			name:        "transient error is unknown not invalid",
+			result:      subprocess.Result{Stderr: "could not connect: network is unreachable"},
+			err:         fmt.Errorf("exit 1"),
+			wantOK:      true,
+			wantDetail:  "could not validate the token",
+			wantNoMatch: runtime.ClaudeSessionAuthFailedMessage,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			withClaudeAuthEnv(t, map[string]string{runtime.ClaudeOAuthTokenEnv: "secret-token"})
+			runs := 0
+			runner := countingRunner{
+				fakeRunner: fakeRunner{
+					runs: map[string]subprocess.Result{claudeProbeKey: tt.result},
+					errs: map[string]error{claudeProbeKey: tt.err},
+				},
+				runs: &runs,
+			}
+			check := Checker{Runner: runner, LiveProbe: true}.claudeAuthEnv(context.Background())
+			if runs != 1 {
+				t.Fatalf("probe ran %d times, want exactly 1 (a set token must be validated, not trusted)", runs)
+			}
+			if check.OK != tt.wantOK {
+				t.Fatalf("claude auth check = %+v, want OK=%t", check, tt.wantOK)
+			}
+			if !strings.Contains(check.Detail, tt.wantDetail) {
+				t.Fatalf("claude auth detail = %q, want substring %q", check.Detail, tt.wantDetail)
+			}
+			if tt.wantNoMatch != "" && strings.Contains(check.Detail, tt.wantNoMatch) {
+				t.Fatalf("claude auth detail = %q, must not contain %q", check.Detail, tt.wantNoMatch)
+			}
+			if strings.Contains(check.Detail, "secret-token") {
+				t.Fatalf("claude auth detail = %q must never print the token", check.Detail)
+			}
+		})
 	}
 }
 
@@ -379,7 +431,7 @@ func TestClaudeAuthEnvLabeledAsShellScoped(t *testing.T) {
 // Paths the daemon-aware check is skipped (ok=false) and callers fall back to the
 // shell-local check, so GlobalChecks never invents a daemon check it can't back.
 func TestClaudeAuthDaemonSkippedWithoutPaths(t *testing.T) {
-	if _, ok := (Checker{}).claudeAuthDaemon(); ok {
+	if _, ok := (Checker{}).claudeAuthDaemon(context.Background()); ok {
 		t.Fatalf("claudeAuthDaemon returned a check without Paths set; want skip")
 	}
 }

--- a/internal/doctor/checker_test.go
+++ b/internal/doctor/checker_test.go
@@ -210,12 +210,14 @@ func TestClaudeAuthEnvLiveProbeValidatesSetToken486(t *testing.T) {
 		wantOK      bool
 		wantDetail  string
 		wantNoMatch string
+		wantRuns    int
 	}{
 		{
 			name:       "valid token authenticates",
 			result:     subprocess.Result{Stdout: `{"result":"OK"}`},
 			wantOK:     true,
 			wantDetail: runtime.ClaudeBackgroundTokenMessage,
+			wantRuns:   1,
 		},
 		{
 			name:        "invalid token is rejected not ok",
@@ -224,6 +226,20 @@ func TestClaudeAuthEnvLiveProbeValidatesSetToken486(t *testing.T) {
 			wantOK:      false,
 			wantDetail:  runtime.ClaudeSessionAuthFailedMessage,
 			wantNoMatch: "could not validate",
+			wantRuns:    1,
+		},
+		{
+			// The EXACT documented #486 symptom of an invalid CLAUDE_CODE_OAUTH_TOKEN:
+			// it carries "authenticate" + "401" but NOT "authentication", so the prior
+			// probe classified it Unknown and doctor reported OK:true. The probe retries
+			// the 401-socket-closed once (wantRuns 2) and, persisting, reports OK:false.
+			name:        "documented invalid-token socket-closed 401 is rejected",
+			result:      subprocess.Result{Stderr: "Failed to authenticate. API Error: 401 The socket connection was closed unexpectedly"},
+			err:         fmt.Errorf("exit 1"),
+			wantOK:      false,
+			wantDetail:  runtime.ClaudeSessionAuthFailedMessage,
+			wantNoMatch: "could not validate",
+			wantRuns:    2,
 		},
 		{
 			name:        "transient error is unknown not invalid",
@@ -232,6 +248,7 @@ func TestClaudeAuthEnvLiveProbeValidatesSetToken486(t *testing.T) {
 			wantOK:      true,
 			wantDetail:  "could not validate the token",
 			wantNoMatch: runtime.ClaudeSessionAuthFailedMessage,
+			wantRuns:    1,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -245,8 +262,8 @@ func TestClaudeAuthEnvLiveProbeValidatesSetToken486(t *testing.T) {
 				runs: &runs,
 			}
 			check := Checker{Runner: runner, LiveProbe: true}.claudeAuthEnv(context.Background())
-			if runs != 1 {
-				t.Fatalf("probe ran %d times, want exactly 1 (a set token must be validated, not trusted)", runs)
+			if runs != tt.wantRuns {
+				t.Fatalf("probe ran %d times, want exactly %d (a set token must be validated, not trusted)", runs, tt.wantRuns)
 			}
 			if check.OK != tt.wantOK {
 				t.Fatalf("claude auth check = %+v, want OK=%t", check, tt.wantOK)

--- a/internal/presence/snapshot.go
+++ b/internal/presence/snapshot.go
@@ -157,14 +157,21 @@ func InspectDaemonClaudeAuth(paths config.Paths) DaemonAuthSnapshot {
 	return snapshot
 }
 
-// DaemonClaudeCredEnv returns the running daemon's set Claude credential
-// variables as KEY=VALUE entries, for injecting into a live validation probe so
-// the doctor validates the token the daemon will actually use rather than the
-// doctor process's own credential. Unlike DaemonAuthSnapshot (which exposes only
-// set/unset booleans), this returns the secret VALUES — callers must use them
-// solely as subprocess env and never print or persist them. It is best-effort
-// and fail-open: a missing daemon, unreadable /proc, or non-Linux host yields
-// (nil, false). Only non-empty values are returned.
+// DaemonClaudeCredEnv returns the env entries needed to validate the token the
+// running daemon will ACTUALLY use, for injecting into a live probe so the doctor
+// checks the daemon's credential rather than the doctor process's own. It returns
+// the daemon's set Claude credential VALUES as KEY=VALUE entries AND, critically,
+// NAME= (empty) for each Claude credential var the daemon does NOT set — so when
+// the entries are appended onto the doctor process's environment (RunEnv), they
+// NEUTRALIZE any competing credential the doctor shell carries but the daemon
+// lacks (claude treats empty as unset). Without this, a doctor-shell
+// ANTHROPIC_API_KEY (which outranks OAuth) could validate the WRONG credential and
+// mask a bad daemon token (#486). Unlike DaemonAuthSnapshot (set/unset booleans
+// only) this returns secret VALUES — callers must use them solely as subprocess
+// env and never print or persist them. It is best-effort and fail-open: a missing
+// daemon, unreadable /proc, or non-Linux host yields (nil, false); a detected
+// daemon with no Claude credential at all also yields (nil, false) so the caller
+// falls back to the presence-only report.
 func DaemonClaudeCredEnv(paths config.Paths) ([]string, bool) {
 	daemon := InspectDaemon(paths)
 	if daemon.State != DaemonRunning || daemon.PID <= 0 {
@@ -174,7 +181,19 @@ func DaemonClaudeCredEnv(paths config.Paths) ([]string, bool) {
 	if !ok {
 		return nil, false
 	}
-	var env []string
+	return claudeCredEnvFromLookup(lookup)
+}
+
+// claudeCredEnvFromLookup builds the isolated Claude credential env from a
+// lookup func (split out from DaemonClaudeCredEnv so the neutralization contract
+// is testable without a live daemon / readable /proc). Returns (nil, false) when
+// the lookup carries no non-empty Claude credential.
+func claudeCredEnvFromLookup(lookup func(string) (string, bool)) ([]string, bool) {
+	if lookup == nil {
+		return nil, false
+	}
+	hasCred := false
+	env := make([]string, 0, 3)
 	for _, name := range []string{
 		runtime.ClaudeOAuthTokenEnv,
 		runtime.AnthropicAPIKeyEnv,
@@ -182,9 +201,14 @@ func DaemonClaudeCredEnv(paths config.Paths) ([]string, bool) {
 	} {
 		if value, present := lookup(name); present && strings.TrimSpace(value) != "" {
 			env = append(env, name+"="+value)
+			hasCred = true
+			continue
 		}
+		// The daemon does not set this credential: neutralize the doctor's own value
+		// so it cannot leak into the probe and validate the wrong credential.
+		env = append(env, name+"=")
 	}
-	if len(env) == 0 {
+	if !hasCred {
 		return nil, false
 	}
 	return env, true

--- a/internal/presence/snapshot.go
+++ b/internal/presence/snapshot.go
@@ -157,6 +157,39 @@ func InspectDaemonClaudeAuth(paths config.Paths) DaemonAuthSnapshot {
 	return snapshot
 }
 
+// DaemonClaudeCredEnv returns the running daemon's set Claude credential
+// variables as KEY=VALUE entries, for injecting into a live validation probe so
+// the doctor validates the token the daemon will actually use rather than the
+// doctor process's own credential. Unlike DaemonAuthSnapshot (which exposes only
+// set/unset booleans), this returns the secret VALUES — callers must use them
+// solely as subprocess env and never print or persist them. It is best-effort
+// and fail-open: a missing daemon, unreadable /proc, or non-Linux host yields
+// (nil, false). Only non-empty values are returned.
+func DaemonClaudeCredEnv(paths config.Paths) ([]string, bool) {
+	daemon := InspectDaemon(paths)
+	if daemon.State != DaemonRunning || daemon.PID <= 0 {
+		return nil, false
+	}
+	lookup, ok := readProcessEnviron(daemon.PID)
+	if !ok {
+		return nil, false
+	}
+	var env []string
+	for _, name := range []string{
+		runtime.ClaudeOAuthTokenEnv,
+		runtime.AnthropicAPIKeyEnv,
+		runtime.AnthropicAuthTokenEnv,
+	} {
+		if value, present := lookup(name); present && strings.TrimSpace(value) != "" {
+			env = append(env, name+"="+value)
+		}
+	}
+	if len(env) == 0 {
+		return nil, false
+	}
+	return env, true
+}
+
 func InspectDaemon(paths config.Paths) DaemonSnapshot {
 	paths = normalizePaths(paths)
 	snapshot := DaemonSnapshot{

--- a/internal/presence/snapshot_test.go
+++ b/internal/presence/snapshot_test.go
@@ -13,7 +13,58 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	gmruntime "github.com/jerryfane/gitmoot/internal/runtime"
 )
+
+// TestClaudeCredEnvFromLookupNeutralizesAbsentVars is the #486 credential-isolation
+// regression: the daemon-token probe env must carry the daemon's set credential
+// AND an empty NAME= for every Claude credential the daemon does NOT set, so when
+// the entries are appended onto the doctor process's own environment a competing
+// doctor-shell credential (e.g. a valid ANTHROPIC_API_KEY the daemon lacks, which
+// outranks OAuth) is neutralized rather than leaking in and validating the wrong
+// credential. Without the empty-neutralization this asserts fails: a missing var
+// would be omitted, letting the doctor's value survive.
+func TestClaudeCredEnvFromLookupNeutralizesAbsentVars(t *testing.T) {
+	lookup := func(name string) (string, bool) {
+		if name == gmruntime.ClaudeOAuthTokenEnv {
+			return "daemon-secret", true
+		}
+		return "", false
+	}
+	env, ok := claudeCredEnvFromLookup(lookup)
+	if !ok {
+		t.Fatal("claudeCredEnvFromLookup ok=false for a daemon with an OAuth token")
+	}
+	got := make(map[string]string, len(env))
+	for _, e := range env {
+		k, v, _ := strings.Cut(e, "=")
+		got[k] = v
+	}
+	if got[gmruntime.ClaudeOAuthTokenEnv] != "daemon-secret" {
+		t.Fatalf("OAuth token = %q, want the daemon's value", got[gmruntime.ClaudeOAuthTokenEnv])
+	}
+	for _, name := range []string{gmruntime.AnthropicAPIKeyEnv, gmruntime.AnthropicAuthTokenEnv} {
+		v, present := got[name]
+		if !present {
+			t.Fatalf("%s missing from probe env; an absent daemon var must be neutralized with NAME=, not omitted (it would let the doctor's value leak in)", name)
+		}
+		if v != "" {
+			t.Fatalf("%s = %q, want empty (neutralized)", name, v)
+		}
+	}
+}
+
+// TestClaudeCredEnvFromLookupNoCredentialSkips guards the fail-open contract: a
+// daemon with no Claude credential at all yields (nil, false) so the caller falls
+// back to the presence-only report instead of probing an all-empty env.
+func TestClaudeCredEnvFromLookupNoCredentialSkips(t *testing.T) {
+	if env, ok := claudeCredEnvFromLookup(func(string) (string, bool) { return "", false }); ok || env != nil {
+		t.Fatalf("claudeCredEnvFromLookup = (%v, %t), want (nil, false) for a credential-less daemon", env, ok)
+	}
+	if env, ok := claudeCredEnvFromLookup(nil); ok || env != nil {
+		t.Fatalf("claudeCredEnvFromLookup(nil) = (%v, %t), want (nil, false)", env, ok)
+	}
+}
 
 func TestBuildSnapshotCountsRepoLocalState(t *testing.T) {
 	paths := testPaths(t)

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -766,8 +766,29 @@ func ClassifyClaudeCommandError(result subprocess.Result, err error) error {
 	if !isClaudeAuthFailure(result) {
 		return base
 	}
-	return fmt.Errorf("Claude Code authentication failed. %s: %w", ClaudeSessionAuthFailedMessage, base)
+	msg := fmt.Errorf("Claude Code authentication failed. %s: %w", ClaudeSessionAuthFailedMessage, base)
+	// Tag the classified auth failure with ErrClaudeAuthFailed so callers can
+	// distinguish a genuine credential rejection (401/invalid) from a transient
+	// or network error via errors.Is, without re-matching stderr strings. The
+	// wrapper's Error() is the message verbatim, so existing text assertions and
+	// the wrapped exec error remain reachable.
+	return &claudeAuthFailedError{wrapped: msg}
 }
+
+// ErrClaudeAuthFailed marks an error chain produced by ClassifyClaudeCommandError
+// for a genuine Claude credential rejection. Use errors.Is(err, ErrClaudeAuthFailed)
+// to tell "the token was rejected" (Invalid) apart from "the probe could not
+// reach a verdict" (transient/network/binary-missing → Unknown).
+var ErrClaudeAuthFailed = errors.New("Claude authentication failed")
+
+// claudeAuthFailedError tags wrapped with ErrClaudeAuthFailed while preserving
+// wrapped's message and chain. Go's errors.Is walks the slice returned by
+// Unwrap() []error, so both wrapped (and through it the exec error) and the
+// sentinel stay reachable.
+type claudeAuthFailedError struct{ wrapped error }
+
+func (e *claudeAuthFailedError) Error() string   { return e.wrapped.Error() }
+func (e *claudeAuthFailedError) Unwrap() []error { return []error{e.wrapped, ErrClaudeAuthFailed} }
 
 // claudeSessionMissingMarker is the exact stderr signature emitted by `claude
 // --resume <uuid>` when the pinned conversation no longer exists (captured from

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -554,6 +554,19 @@ func (a ClaudeAdapter) retryBackoff(attempt int) time.Duration {
 // duplicate-execution hazard; such mid-stream drops carry no status code, so the
 // "401" requirement correctly excludes them.
 func isTransientClaudeDeliveryError(result subprocess.Result, err error) bool {
+	return isClaude401SocketClosed(result, err)
+}
+
+// isClaude401SocketClosed reports whether a failed run carries the
+// "401 socket connection was closed unexpectedly" signature. In the Deliver path
+// this is the concurrency transient a byte-identical retry clears
+// (isTransientClaudeDeliveryError); in the isolated doctor probe path (no
+// concurrency) a signature that SURVIVES a retry is instead the documented #486
+// invalid-token symptom — `Failed to authenticate. API Error: 401 The socket
+// connection was closed unexpectedly` — which carries "401" and "socket connection
+// was closed unexpectedly" but NOT "authentication", so isClaudeAuthFailure alone
+// would miss it. The err != nil gate keeps a successful run from ever matching.
+func isClaude401SocketClosed(result subprocess.Result, err error) bool {
 	if err == nil {
 		return false
 	}
@@ -758,6 +771,24 @@ func parseCodexErrorMessage(output string) string {
 }
 
 func claudeCommandError(result subprocess.Result, err error) error {
+	return ClassifyClaudeCommandError(result, err)
+}
+
+// classifyClaudeProbeError classifies the error from an ISOLATED doctor live
+// probe (a single `claude -p`, no concurrency). It is ClassifyClaudeCommandError
+// plus one extra Invalid signature: a 401 "socket connection was closed
+// unexpectedly" that survived the probe's retry is the documented #486
+// invalid-token symptom rather than a concurrency transient, so it must be tagged
+// ErrClaudeAuthFailed (→ ClaudeClassifyProbe Invalid) instead of falling through
+// to Unknown, which kept `gitmoot doctor` green for the exact bug it exists to
+// catch. The Deliver path keeps treating the same signature as transient (it
+// never calls this), so retry behavior there is unchanged.
+func classifyClaudeProbeError(result subprocess.Result, err error) error {
+	if !isClaudeAuthFailure(result) && isClaude401SocketClosed(result, err) {
+		base := commandError(result, err)
+		msg := fmt.Errorf("Claude Code authentication failed. %s: %w", ClaudeSessionAuthFailedMessage, base)
+		return &claudeAuthFailedError{wrapped: msg}
+	}
 	return ClassifyClaudeCommandError(result, err)
 }
 

--- a/internal/runtime/claude_auth.go
+++ b/internal/runtime/claude_auth.go
@@ -77,12 +77,29 @@ func (e ClaudeAuthEnv) Warning() string {
 }
 
 func ClaudeLiveCheck(ctx context.Context, runner subprocess.Runner, dir string) error {
+	return ClaudeLiveCheckEnv(ctx, runner, dir, nil)
+}
+
+// ClaudeLiveCheckEnv is ClaudeLiveCheck with extraEnv (KEY=VALUE entries)
+// appended to the probe's environment. The doctor uses it to validate a SPECIFIC
+// credential — e.g. the running daemon's CLAUDE_CODE_OAUTH_TOKEN read from /proc —
+// rather than whatever the doctor process happens to carry. extraEnv is honored
+// only when runner implements subprocess.EnvRunner; otherwise (fakes, plain
+// runners) it falls back to the same command+args so the override is invisible to
+// arg-keyed test doubles. A nil extraEnv is exactly the prior behavior.
+func ClaudeLiveCheckEnv(ctx context.Context, runner subprocess.Runner, dir string, extraEnv []string) error {
 	if runner == nil {
 		runner = subprocess.ExecRunner{}
 	}
-	result, err := runner.Run(ctx, dir, "claude", "-p", "--output-format", "json", "--", ClaudeLiveCheckPrompt)
+	run := func(args ...string) (subprocess.Result, error) {
+		if env, ok := runner.(subprocess.EnvRunner); ok && len(extraEnv) > 0 {
+			return env.RunEnv(ctx, dir, extraEnv, "claude", args...)
+		}
+		return runner.Run(ctx, dir, "claude", args...)
+	}
+	result, err := run("-p", "--output-format", "json", "--", ClaudeLiveCheckPrompt)
 	if err != nil && isClaudeJSONUnsupported(result) {
-		result, err = runner.Run(ctx, dir, "claude", "-p", "--", ClaudeLiveCheckPrompt)
+		result, err = run("-p", "--", ClaudeLiveCheckPrompt)
 		if err != nil {
 			return ClassifyClaudeCommandError(result, err)
 		}
@@ -92,6 +109,46 @@ func ClaudeLiveCheck(ctx context.Context, runner subprocess.Runner, dir string) 
 		return ClassifyClaudeCommandError(result, err)
 	}
 	return validateClaudeLiveJSON(result.Stdout)
+}
+
+// ClaudeTokenStatus is the tri-state verdict of validating a Claude credential
+// with a live probe: it either authenticated (Valid), was rejected (Invalid), or
+// could not be determined (Unknown — a transient/network error, or the probe
+// could not run at all). A merely-SET token is not Valid until a probe says so.
+type ClaudeTokenStatus int
+
+const (
+	ClaudeTokenUnknown ClaudeTokenStatus = iota
+	ClaudeTokenValid
+	ClaudeTokenInvalid
+)
+
+func (s ClaudeTokenStatus) String() string {
+	switch s {
+	case ClaudeTokenValid:
+		return "valid"
+	case ClaudeTokenInvalid:
+		return "invalid"
+	default:
+		return "unknown"
+	}
+}
+
+// ClaudeClassifyProbe maps a ClaudeLiveCheck/ClaudeLiveCheckEnv error to a
+// tri-state status. A nil error is Valid; a classified credential rejection
+// (errors.Is ErrClaudeAuthFailed) is Invalid; everything else — a missing/
+// unrunnable binary or a transient/network/timeout error — is Unknown and MUST
+// NOT be reported as Invalid, so a network blip can never flip doctor red or
+// claim the token is bad.
+func ClaudeClassifyProbe(err error) ClaudeTokenStatus {
+	switch {
+	case err == nil:
+		return ClaudeTokenValid
+	case errors.Is(err, ErrClaudeAuthFailed):
+		return ClaudeTokenInvalid
+	default:
+		return ClaudeTokenUnknown
+	}
 }
 
 // ClaudeProbeUnavailable reports whether a ClaudeLiveCheck error means the probe

--- a/internal/runtime/claude_auth.go
+++ b/internal/runtime/claude_auth.go
@@ -7,14 +7,27 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
+
+// ClaudeLiveProbeTimeout bounds a single live `claude -p` probe so a hung or slow
+// claude (or a network stall) can never block the caller — notably `gitmoot
+// doctor`, which after #486 always probes — indefinitely. It is a var so tests can
+// shrink it; production callers pass context.Background(), and WithTimeout honors a
+// shorter caller deadline if one is already set.
+var ClaudeLiveProbeTimeout = 30 * time.Second
 
 const (
 	ClaudeOAuthTokenEnv   = "CLAUDE_CODE_OAUTH_TOKEN"
 	AnthropicAPIKeyEnv    = "ANTHROPIC_API_KEY"
 	AnthropicAuthTokenEnv = "ANTHROPIC_AUTH_TOKEN"
+	// ClaudeConfigDirEnv points the Claude CLI at a config directory. The doctor's
+	// daemon-token probe sets it to a throwaway empty dir so cached ~/.claude
+	// credentials cannot mask a bad injected token — the decisive token-only test
+	// for #486.
+	ClaudeConfigDirEnv = "CLAUDE_CONFIG_DIR"
 	// ClaudeBackgroundTokenMessage is the warn-path caveat: foreground Claude
 	// authenticates fine via cached credentials, but daemon background jobs run
 	// non-interactively and need an explicit token in the daemon env.
@@ -91,22 +104,38 @@ func ClaudeLiveCheckEnv(ctx context.Context, runner subprocess.Runner, dir strin
 	if runner == nil {
 		runner = subprocess.ExecRunner{}
 	}
+	// Bound the live probe so a hung/slow claude or a network stall degrades to a
+	// transient/Unknown verdict instead of hanging the caller forever. Before #486
+	// a set token short-circuited with zero subprocess; now doctor always probes,
+	// so an unbounded probe would let a stalled claude block `gitmoot doctor`
+	// indefinitely. WithTimeout respects an already-shorter caller deadline.
+	ctx, cancel := context.WithTimeout(ctx, ClaudeLiveProbeTimeout)
+	defer cancel()
 	run := func(args ...string) (subprocess.Result, error) {
 		if env, ok := runner.(subprocess.EnvRunner); ok && len(extraEnv) > 0 {
 			return env.RunEnv(ctx, dir, extraEnv, "claude", args...)
 		}
 		return runner.Run(ctx, dir, "claude", args...)
 	}
-	result, err := run("-p", "--output-format", "json", "--", ClaudeLiveCheckPrompt)
+	jsonArgs := []string{"-p", "--output-format", "json", "--", ClaudeLiveCheckPrompt}
+	result, err := run(jsonArgs...)
 	if err != nil && isClaudeJSONUnsupported(result) {
 		result, err = run("-p", "--", ClaudeLiveCheckPrompt)
 		if err != nil {
-			return ClassifyClaudeCommandError(result, err)
+			return classifyClaudeProbeError(result, err)
 		}
 		return validateClaudeLiveText(result.Stdout)
 	}
+	// A "401 socket connection was closed unexpectedly" is the concurrency
+	// transient the daemon path retries; this probe is a single isolated run, so
+	// retry once and only persist the verdict if the signature survives — at which
+	// point classifyClaudeProbeError treats it as the documented #486 invalid-token
+	// symptom (Invalid) rather than leaving it Unknown (which kept doctor green).
+	if isClaude401SocketClosed(result, err) {
+		result, err = run(jsonArgs...)
+	}
 	if err != nil {
-		return ClassifyClaudeCommandError(result, err)
+		return classifyClaudeProbeError(result, err)
 	}
 	return validateClaudeLiveJSON(result.Stdout)
 }

--- a/internal/runtime/claude_auth_test.go
+++ b/internal/runtime/claude_auth_test.go
@@ -137,6 +137,74 @@ func TestClaudeProbeUnavailableClassifiesMissingBinary(t *testing.T) {
 	}
 }
 
+// envFakeRunner is a fakeRunner that also implements subprocess.EnvRunner,
+// recording the extra environment passed to RunEnv so a test can prove the
+// daemon's actual credential is what gets injected into the validation probe.
+type envFakeRunner struct {
+	fakeRunner
+	gotEnv []string
+}
+
+func (f *envFakeRunner) RunEnv(ctx context.Context, dir string, env []string, command string, args ...string) (subprocess.Result, error) {
+	f.gotEnv = append([]string(nil), env...)
+	return f.fakeRunner.Run(ctx, dir, command, args...)
+}
+
+// TestClaudeClassifyProbe486 is the tri-state core of the #486 fix: a live-probe
+// outcome must map to valid / invalid / unknown so doctor can stop reporting a
+// set-but-unvalidated token as ok, while never flipping a transient/network blip
+// (or a missing binary) to a hard "invalid".
+func TestClaudeClassifyProbe486(t *testing.T) {
+	authErr := ClassifyClaudeCommandError(
+		subprocess.Result{Stderr: "401 Invalid authentication credentials"},
+		errors.New("exit 1"),
+	)
+	for _, tt := range []struct {
+		name string
+		err  error
+		want ClaudeTokenStatus
+	}{
+		{name: "nil is valid", err: nil, want: ClaudeTokenValid},
+		{name: "classified auth failure is invalid", err: authErr, want: ClaudeTokenInvalid},
+		{name: "transient/network is unknown not invalid", err: errors.New("network is unreachable"), want: ClaudeTokenUnknown},
+		{name: "missing binary is unknown", err: &exec.Error{Name: "claude", Err: exec.ErrNotFound}, want: ClaudeTokenUnknown},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClaudeClassifyProbe(tt.err); got != tt.want {
+				t.Fatalf("ClaudeClassifyProbe(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+	if !errors.Is(authErr, ErrClaudeAuthFailed) {
+		t.Fatal("a classified auth failure must satisfy errors.Is(err, ErrClaudeAuthFailed)")
+	}
+	if errors.Is(errors.New("boom"), ErrClaudeAuthFailed) {
+		t.Fatal("a plain error must not satisfy errors.Is(err, ErrClaudeAuthFailed)")
+	}
+}
+
+// TestClaudeLiveCheckEnvInjectsCredential proves the daemon-token validation seam:
+// ClaudeLiveCheckEnv passes the supplied credential env to an EnvRunner probe (so
+// doctor validates the daemon's own token, not the doctor process's), and a 401
+// from that probe classifies Invalid.
+func TestClaudeLiveCheckEnvInjectsCredential(t *testing.T) {
+	runner := &envFakeRunner{
+		fakeRunner: fakeRunner{
+			results: []subprocess.Result{{Stderr: "401 Invalid authentication credentials"}},
+			errs:    []error{errors.New("exit 1")},
+		},
+	}
+	cred := []string{ClaudeOAuthTokenEnv + "=daemon-secret"}
+	err := ClaudeLiveCheckEnv(context.Background(), runner, "", cred)
+	if ClaudeClassifyProbe(err) != ClaudeTokenInvalid {
+		t.Fatalf("ClaudeLiveCheckEnv error = %v, want classified invalid", err)
+	}
+	if len(runner.gotEnv) != 1 || runner.gotEnv[0] != cred[0] {
+		t.Fatalf("probe env = %v, want the injected daemon credential %v", runner.gotEnv, cred)
+	}
+	runner.want(t, 0, "claude", "-p", "--output-format", "json", "--", ClaudeLiveCheckPrompt)
+}
+
 func TestClaudeLiveCheckFallsBackToText(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{

--- a/internal/runtime/claude_auth_test.go
+++ b/internal/runtime/claude_auth_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
@@ -203,6 +204,84 @@ func TestClaudeLiveCheckEnvInjectsCredential(t *testing.T) {
 		t.Fatalf("probe env = %v, want the injected daemon credential %v", runner.gotEnv, cred)
 	}
 	runner.want(t, 0, "claude", "-p", "--output-format", "json", "--", ClaudeLiveCheckPrompt)
+}
+
+// TestClaudeLiveCheckClassifiesSocketClosed401AsInvalid486 is the #486 regression
+// for the DOCUMENTED invalid-token symptom: an invalid CLAUDE_CODE_OAUTH_TOKEN
+// manifests as `Failed to authenticate. API Error: 401 The socket connection was
+// closed unexpectedly`. That string carries "authenticate" and "401" but NOT
+// "authentication", so isClaudeAuthFailure misses it and the prior probe returned
+// Unknown — which left `gitmoot doctor` reporting OK:true for the exact scenario
+// the fix exists to catch. The isolated probe retries the 401-socket-closed
+// signature once and, when it PERSISTS, must classify Invalid.
+func TestClaudeLiveCheckClassifiesSocketClosed401AsInvalid486(t *testing.T) {
+	const symptom = "Failed to authenticate. API Error: 401 The socket connection was closed unexpectedly"
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: symptom}, {Stderr: symptom}},
+		errs:    []error{errors.New("exit 1"), errors.New("exit 1")},
+	}
+	err := ClaudeLiveCheck(context.Background(), runner, "/repo")
+	if ClaudeClassifyProbe(err) != ClaudeTokenInvalid {
+		t.Fatalf("socket-closed 401 classified %v, want invalid\nerr=%v", ClaudeClassifyProbe(err), err)
+	}
+	if !errors.Is(err, ErrClaudeAuthFailed) {
+		t.Fatalf("persistent socket-closed 401 must satisfy errors.Is(err, ErrClaudeAuthFailed):\n%v", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("probe made %d calls, want 2 (one retry of the 401-socket-closed)", len(runner.calls))
+	}
+}
+
+// TestClaudeLiveCheckSocketClosed401RetryClears486 guards the other side: a one-off
+// 401-socket-closed that CLEARS on the byte-identical retry is the concurrency
+// transient the daemon path tolerates, so the isolated probe must report Valid, not
+// flip a healthy token to Invalid.
+func TestClaudeLiveCheckSocketClosed401RetryClears486(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stderr: "API Error: 401 The socket connection was closed unexpectedly"},
+			{Stdout: `{"result":"OK"}`},
+		},
+		errs: []error{errors.New("exit 1"), nil},
+	}
+	if err := ClaudeLiveCheck(context.Background(), runner, "/repo"); err != nil {
+		t.Fatalf("a cleared socket-closed retry must be valid, got %v", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("probe made %d calls, want 2 (the cleared retry)", len(runner.calls))
+	}
+}
+
+// blockingRunner blocks until the context is cancelled, simulating a hung/slow
+// `claude -p`, so a test can prove the probe bounds an unbounded caller.
+type blockingRunner struct{}
+
+func (blockingRunner) Run(ctx context.Context, _ string, _ string, _ ...string) (subprocess.Result, error) {
+	<-ctx.Done()
+	return subprocess.Result{}, ctx.Err()
+}
+
+func (blockingRunner) LookPath(file string) (string, error) { return "/usr/bin/" + file, nil }
+
+// TestClaudeLiveCheckBoundsUnboundedContext486 proves the probe bounds an unbounded
+// (context.Background) caller — the regression #486 introduced by always probing in
+// doctor — so a stalled claude can't block forever. With a hung runner the probe
+// returns within its own timeout, and the timeout maps to Unknown (never Invalid),
+// so a SET token degrades to set-but-unvalidated rather than flipping doctor red.
+func TestClaudeLiveCheckBoundsUnboundedContext486(t *testing.T) {
+	old := ClaudeLiveProbeTimeout
+	ClaudeLiveProbeTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { ClaudeLiveProbeTimeout = old })
+	done := make(chan error, 1)
+	go func() { done <- ClaudeLiveCheck(context.Background(), blockingRunner{}, "/repo") }()
+	select {
+	case err := <-done:
+		if ClaudeClassifyProbe(err) != ClaudeTokenUnknown {
+			t.Fatalf("timed-out probe classified %v, want unknown\nerr=%v", ClaudeClassifyProbe(err), err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ClaudeLiveCheck did not honor its bounded timeout (hung)")
+	}
 }
 
 func TestClaudeLiveCheckFallsBackToText(t *testing.T) {

--- a/internal/subprocess/runner.go
+++ b/internal/subprocess/runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"os/exec"
 	"sync"
 )
@@ -18,6 +19,17 @@ type Result struct {
 type Runner interface {
 	Run(ctx context.Context, dir string, command string, args ...string) (Result, error)
 	LookPath(file string) (string, error)
+}
+
+// EnvRunner is an optional Runner capability: it runs a command with extra
+// environment variables (KEY=VALUE entries) appended to the inherited
+// environment. It is opt-in so callers that only need the env override (e.g. the
+// doctor probing a specific Claude credential) can type-assert for it and fall
+// back to a plain Run when the runner does not implement it — fakes that key on
+// command+args therefore need no change.
+type EnvRunner interface {
+	Runner
+	RunEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error)
 }
 
 // StreamRunner additionally tees the child's stdout and stderr to a writer as
@@ -41,6 +53,10 @@ func (ExecRunner) RunStream(ctx context.Context, dir string, out io.Writer, comm
 
 func (ExecRunner) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
+}
+
+func (ExecRunner) RunEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error) {
+	return RunEnv(ctx, dir, env, command, args...)
 }
 
 // TeeRunner adapts a stream-capable runner into a plain Runner that always tees
@@ -166,8 +182,20 @@ func runStreamingCmd(cmd *exec.Cmd, out io.Writer, command string, args []string
 }
 
 func Run(ctx context.Context, dir string, command string, args ...string) (Result, error) {
+	return RunEnv(ctx, dir, nil, command, args...)
+}
+
+// RunEnv runs like Run but appends extraEnv (KEY=VALUE entries) to the inherited
+// process environment, letting later entries override earlier ones per the os/exec
+// last-wins rule. A nil extraEnv leaves the environment untouched (cmd.Env nil →
+// inherit os.Environ), so RunEnv(ctx, dir, nil, …) is byte-identical to the prior
+// Run.
+func RunEnv(ctx context.Context, dir string, extraEnv []string, command string, args ...string) (Result, error) {
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Dir = dir
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout


### PR DESCRIPTION
## Root cause
`gitmoot doctor`'s Claude auth checks equated a credential being **SET** with it being **valid**. `claudeAuthDaemon` returned `OK:true` whenever the daemon's env carried a token, and `claudeAuthEnv` short-circuited a present env token straight to `OK:true` and never ran its live probe. So an **invalid** `CLAUDE_CODE_OAUTH_TOKEN` reported `claude auth (daemon) ok` while it silently 401'd fresh non-interactive sessions. `--resume` masks the failure because resuming an already-authenticated session needs no fresh auth handshake.

## The fix (at the right depth)
The buggy mechanism is shared by both checks: "presence == ok". So both now **validate** the credential with a live `claude -p` probe — the same fresh, non-interactive path that daemon jobs actually take — and classify the result **tri-state**:

- **valid** -> `OK:true`
- **invalid** (a genuine 401/credential rejection) -> `OK:false` — the false-green this closes
- **unknown** (transient/network error, or `claude` binary missing) -> fail-open: never flips a SET credential to a hard failure, so doctor doesn't go red on a network blip (`unknown` vs `invalid`).

New shared infra rather than a special-case:
- `runtime.ErrClaudeAuthFailed` sentinel tagged onto the classified auth error (via an `Unwrap() []error` wrapper that preserves the existing message/chain), so callers tell "rejected" from "couldn't reach a verdict" with `errors.Is` instead of re-matching stderr.
- `runtime.ClaudeClassifyProbe(err) ClaudeTokenStatus` for the tri-state.
- The **daemon** check validates the daemon's *own* token (not the doctor process's) by reading it from `/proc` (`presence.DaemonClaudeCredEnv`, secret values used only as subprocess env, never printed) and injecting it into the probe via a new optional `subprocess.EnvRunner` (`ClaudeLiveCheckEnv`).

Healthy paths preserved: the dashboard path (`LiveProbe` false) still never spawns claude; the cached-creds / unset-token probe behavior is unchanged.

## Regression test
`TestClaudeAuthEnvLiveProbeValidatesSetToken486` (table-driven, doctor pkg): with an env token present + `LiveProbe`, asserts the probe **runs** and valid/invalid/transient map to OK / not-OK / set-but-unvalidated. It **fails** against the old set-token short-circuit (`probe ran 0 times, want 1`) and **passes** with the fix (verified by temporarily restoring the short-circuit). Plus `TestClaudeClassifyProbe486` (tri-state + sentinel) and `TestClaudeLiveCheckEnvInjectsCredential` (daemon-token injection seam) in the runtime pkg.

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)