### PR TITLE
fix(dashboard/daemon): live in-flight view + systemd daemon status (#505)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -236,20 +236,11 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	// launched directly (e.g. under `systemd --user`), not only one spawned by
 	// `daemon start` (#505 gap 3), and reconcile any phantom "running" runtime
 	// sessions a previously-crashed daemon left behind (#505 gap 2). Both are
-	// best-effort: a failure here never blocks the daemon from running.
-	if paths, perr := initializedPaths(*home); perr == nil {
-		state := daemonProcessState(paths)
-		workDir, _ := os.Getwd()
-		if registered, regErr := registerDaemonRunState(state, os.Args, workDir); regErr == nil && registered {
-			defer deregisterDaemonRunState(state)
-		}
-		_ = withStore(*home, func(store *db.Store) error {
-			if n, err := store.ReconcileOrphanedRunningInstances(ctx, time.Now().UTC()); err == nil && n > 0 {
-				writeLine(stdout, "reconciled %d orphaned running runtime session(s)", n)
-			}
-			return nil
-		})
-	}
+	// best-effort: a failure here never blocks the daemon from running. The work
+	// lives in daemonRunStartupReconcile so the integration — daemon run actually
+	// self-registers AND reconciles at startup — is exercised by a test, not only
+	// the leaf helpers (a revert of this wiring would otherwise stay green).
+	defer daemonRunStartupReconcile(ctx, *home, os.Args, stdout)()
 
 	if *repoFlag == "" {
 		err := runRegisteredRepoSupervisor(ctx, *home, *poll, *workers, *dryRun, *watchSkillOptReviews, *watchIssues, usePool, session, stdout)
@@ -973,6 +964,37 @@ func writeDaemonState(state daemonState, meta daemonMeta) error {
 	return os.WriteFile(state.MetaFile, append(encoded, '\n'), 0o600)
 }
 
+// daemonRunStartupReconcile performs the two #505 startup steps for a directly
+// launched `daemon run`: it self-registers THIS process's pid/meta so `daemon
+// status` and the dashboard recognize it (gap 3), and it reconciles phantom
+// "running" runtime sessions a previously-crashed daemon left behind (gap 2).
+// Both are best-effort — a failure never blocks the daemon. It returns a cleanup
+// func (never nil) the caller defers: it deregisters this process's state on exit
+// only when this process actually self-registered (so a `daemon start`-spawned
+// child, whose parent already owns the pid, is a no-op). Keeping the logic here —
+// rather than inline in runDaemonRun — lets a test bind the regression to the
+// integration point (status flips to "running", an orphaned row resets to idle),
+// not just the leaf helpers it calls.
+func daemonRunStartupReconcile(ctx context.Context, home string, argv []string, stdout io.Writer) func() {
+	cleanup := func() {}
+	paths, err := initializedPaths(home)
+	if err != nil {
+		return cleanup
+	}
+	state := daemonProcessState(paths)
+	workDir, _ := os.Getwd()
+	if registered, regErr := registerDaemonRunState(state, argv, workDir); regErr == nil && registered {
+		cleanup = func() { deregisterDaemonRunState(state) }
+	}
+	_ = withStore(home, func(store *db.Store) error {
+		if n, err := store.ReconcileOrphanedRunningInstances(ctx, time.Now().UTC()); err == nil && n > 0 {
+			writeLine(stdout, "reconciled %d orphaned running runtime session(s)", n)
+		}
+		return nil
+	})
+	return cleanup
+}
+
 // registerDaemonRunState records THIS process as the running daemon so `daemon
 // status` and the dashboard recognize a `daemon run` launched directly — e.g. as
 // the ExecStart of a `systemd --user` unit — and not only one spawned by `daemon
@@ -1009,16 +1031,23 @@ func registerDaemonRunState(state daemonState, argv []string, workDir string) (o
 	return true, nil
 }
 
-// deregisterDaemonRunState removes the pid/meta written by registerDaemonRunState
-// when the daemon-run process exits, but ONLY when they still point at THIS
-// process — so a daemon that was restarted out from under us (a fresh pid already
-// recorded) never has its live state clobbered on our shutdown.
+// deregisterDaemonRunState clears the running marker written by
+// registerDaemonRunState when the daemon-run process exits, but ONLY when the
+// recorded state still points at THIS process — so a daemon that was restarted out
+// from under us (a fresh pid already recorded) never has its live state clobbered
+// on our shutdown.
+//
+// It removes ONLY the PIDFile, mirroring `daemon stop` (which also leaves the meta
+// in place): currentDaemonPID already treats an absent/dead pid as stopped, so a
+// status check correctly reports "stopped" with the meta retained, and keeping
+// daemon.json preserves `daemon restart`'s recovery of the prior daemon's
+// --repo/--watch-issues/--workers/workdir (readDaemonMeta) that worked on main.
+// Deleting the meta here would silently break that restart path (#505 review).
 func deregisterDaemonRunState(state daemonState) {
 	if meta, err := readDaemonMeta(state); err != nil || meta.PID != os.Getpid() {
 		return
 	}
 	_ = os.Remove(state.PIDFile)
-	_ = os.Remove(state.MetaFile)
 }
 
 func stopDaemonPID(pid int) error {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -232,6 +232,25 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Self-register so `daemon status` / the dashboard recognize a `daemon run`
+	// launched directly (e.g. under `systemd --user`), not only one spawned by
+	// `daemon start` (#505 gap 3), and reconcile any phantom "running" runtime
+	// sessions a previously-crashed daemon left behind (#505 gap 2). Both are
+	// best-effort: a failure here never blocks the daemon from running.
+	if paths, perr := initializedPaths(*home); perr == nil {
+		state := daemonProcessState(paths)
+		workDir, _ := os.Getwd()
+		if registered, regErr := registerDaemonRunState(state, os.Args, workDir); regErr == nil && registered {
+			defer deregisterDaemonRunState(state)
+		}
+		_ = withStore(*home, func(store *db.Store) error {
+			if n, err := store.ReconcileOrphanedRunningInstances(ctx, time.Now().UTC()); err == nil && n > 0 {
+				writeLine(stdout, "reconciled %d orphaned running runtime session(s)", n)
+			}
+			return nil
+		})
+	}
+
 	if *repoFlag == "" {
 		err := runRegisteredRepoSupervisor(ctx, *home, *poll, *workers, *dryRun, *watchSkillOptReviews, *watchIssues, usePool, session, stdout)
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -952,6 +971,54 @@ func writeDaemonState(state daemonState, meta daemonMeta) error {
 		return err
 	}
 	return os.WriteFile(state.MetaFile, append(encoded, '\n'), 0o600)
+}
+
+// registerDaemonRunState records THIS process as the running daemon so `daemon
+// status` and the dashboard recognize a `daemon run` launched directly — e.g. as
+// the ExecStart of a `systemd --user` unit — and not only one spawned by `daemon
+// start` (#505 gap 3). `daemon start` forks a detached child and writes the
+// pid/meta from the PARENT; a systemd-managed `daemon run` has no such parent, so
+// without this self-registration daemon.json is never written and status falsely
+// reports "stopped" while the daemon is alive and processing.
+//
+// args MUST be the process's own argv (os.Args) so the recorded meta.Executable
+// (argv[0]) and meta.Args (argv[1:]) match /proc/<pid>/cmdline and pass
+// processLooksLikeDaemon. It refuses to clobber a DIFFERENT live daemon's state
+// (returns ok=false), so the existing "daemon start then child self-registers"
+// flow stays idempotent (the child owns the pid it finds) and an unrelated daemon
+// is never overwritten.
+func registerDaemonRunState(state daemonState, argv []string, workDir string) (ok bool, err error) {
+	if existing, _, perr := currentDaemonPID(state); perr == nil && existing > 0 && existing != os.Getpid() {
+		return false, nil
+	}
+	executable := ""
+	if len(argv) > 0 {
+		executable = argv[0]
+	}
+	meta := daemonMeta{
+		PID:        os.Getpid(),
+		StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		Args:       argv[1:],
+		LogFile:    state.LogFile,
+		Executable: executable,
+		WorkingDir: workDir,
+	}
+	if err := writeDaemonState(state, meta); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// deregisterDaemonRunState removes the pid/meta written by registerDaemonRunState
+// when the daemon-run process exits, but ONLY when they still point at THIS
+// process — so a daemon that was restarted out from under us (a fresh pid already
+// recorded) never has its live state clobbered on our shutdown.
+func deregisterDaemonRunState(state daemonState) {
+	if meta, err := readDaemonMeta(state); err != nil || meta.PID != os.Getpid() {
+		return
+	}
+	_ = os.Remove(state.PIDFile)
+	_ = os.Remove(state.MetaFile)
 }
 
 func stopDaemonPID(pid int) error {

--- a/internal/cli/daemon_inflight_test.go
+++ b/internal/cli/daemon_inflight_test.go
@@ -2,11 +2,14 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
 )
 
 // TestDaemonRunSelfRegistrationSurfacesRunningDaemon is the #505 gap-3 regression:
@@ -66,6 +69,103 @@ func TestDaemonRunSelfRegistrationSurfacesRunningDaemon(t *testing.T) {
 	}
 }
 
+// TestDaemonRunStartupReconcile binds the #505 regression to the INTEGRATION
+// point, not just the leaf helpers: the single startup seam runDaemonRun defers
+// (daemonRunStartupReconcile) must, in one call, (a) self-register this process so
+// `daemon status` flips from "stopped" to "running pid" (gap 3) AND (b) reconcile
+// a pre-seeded orphaned running runtime session to idle (gap 2). Without the
+// wiring both user-visible behaviors silently regress; exercising the seam (rather
+// than registerDaemonRunState / ReconcileOrphanedRunningInstances in isolation)
+// makes a dropped call detectable. The returned cleanup deregisters our marker.
+func TestDaemonRunStartupReconcile(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+
+	// Pre-seed an orphaned running runtime session: a crashed daemon left it at
+	// state=running with an elapsed lease and no active job.
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	past := time.Now().UTC().Add(-time.Hour).Format("2006-01-02T15:04:05.000000000Z")
+	nowStr := time.Now().UTC().Format("2006-01-02T15:04:05.000000000Z")
+	if err := store.UpsertAgentInstance(context.Background(), db.AgentInstance{
+		Name:           "researcher-bg-orphan",
+		Type:           "researcher",
+		Runtime:        "claude",
+		RuntimeRef:     "ref-orphan",
+		RepoFullName:   "owner/repo",
+		Role:           "researcher",
+		AutonomyPolicy: "read-only",
+		State:          "running",
+		CreatedAt:      nowStr,
+		LastUsedAt:     nowStr,
+		ExpiresAt:      past,
+	}); err != nil {
+		t.Fatalf("UpsertAgentInstance returned error: %v", err)
+	}
+	store.Close()
+
+	// Before startup: no daemon.json → status reports stopped (the systemd bug).
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"daemon", "status", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("daemon status exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stopped") {
+		t.Fatalf("pre-startup status = %q, want stopped", stdout.String())
+	}
+
+	// The integration seam: register + reconcile in one call (test process stands
+	// in for the daemon-run process; its argv passes processLooksLikeDaemon).
+	var startupOut bytes.Buffer
+	cleanup := daemonRunStartupReconcile(context.Background(), home, os.Args, &startupOut)
+	if !strings.Contains(startupOut.String(), "reconciled 1 orphaned running runtime session(s)") {
+		t.Fatalf("startup reconcile message missing: %q", startupOut.String())
+	}
+
+	// (a) self-registered: status now reports the live daemon.
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"daemon", "status", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("daemon status (registered) exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "running pid") {
+		t.Fatalf("post-startup status = %q, want running pid", stdout.String())
+	}
+
+	// (b) the orphaned running session was reset to idle.
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	instance, err := store.GetAgentInstance(context.Background(), "researcher-bg-orphan")
+	if err != nil {
+		t.Fatalf("GetAgentInstance returned error: %v", err)
+	}
+	store.Close()
+	if instance.State != "idle" {
+		t.Fatalf("orphaned instance state = %q, want idle", instance.State)
+	}
+
+	// cleanup deregisters our marker → status back to stopped, but the meta is kept
+	// so `daemon restart` can still recover the prior daemon's args/workdir.
+	cleanup()
+	if _, err := os.Stat(daemonProcessState(paths).MetaFile); err != nil {
+		t.Fatalf("deregister must preserve daemon.json for restart recovery: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"daemon", "status", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("daemon status (deregistered) exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stopped") {
+		t.Fatalf("post-cleanup status = %q, want stopped", stdout.String())
+	}
+}
+
 // TestDeregisterDaemonRunStateOnlyRemovesOwnState confirms shutdown cleanup never
 // clobbers state a restarted daemon recorded under a different pid.
 func TestDeregisterDaemonRunStateOnlyRemovesOwnState(t *testing.T) {
@@ -88,5 +188,44 @@ func TestDeregisterDaemonRunStateOnlyRemovesOwnState(t *testing.T) {
 	}
 	if _, err := os.Stat(state.PIDFile); err != nil {
 		t.Fatalf("deregister removed foreign daemon pid: %v", err)
+	}
+}
+
+// TestDeregisterDaemonRunStatePreservesMetaForRestart is the #505-review
+// regression: a clean shutdown must remove ONLY daemon.pid and keep daemon.json,
+// mirroring `daemon stop`. currentDaemonPID already reports "stopped" once the pid
+// is gone, and `daemon restart` reads daemon.json (readDaemonMeta) to recover the
+// prior daemon's --repo/--watch-issues/--workers/workdir — deleting the meta on
+// exit silently broke that restart-recovery path that worked on main.
+func TestDeregisterDaemonRunStatePreservesMetaForRestart(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	state := daemonProcessState(paths)
+
+	// This process self-registers, then exits cleanly.
+	ok, err := registerDaemonRunState(state, []string{"gitmoot", "daemon", "run", "--repo", "owner/repo", "--watch-issues"}, home)
+	if err != nil || !ok {
+		t.Fatalf("registerDaemonRunState ok=%v err=%v", ok, err)
+	}
+	deregisterDaemonRunState(state)
+
+	// pid removed → status sees a stopped daemon.
+	if _, err := os.Stat(state.PIDFile); !os.IsNotExist(err) {
+		t.Fatalf("deregister must remove daemon.pid, stat err=%v", err)
+	}
+	// meta retained → restart can still recover the recorded args/workdir.
+	meta, err := readDaemonMeta(state)
+	if err != nil {
+		t.Fatalf("deregister must preserve daemon.json: %v", err)
+	}
+	joined := strings.Join(meta.Args, " ")
+	if !strings.Contains(joined, "--repo owner/repo") || !strings.Contains(joined, "--watch-issues") {
+		t.Fatalf("preserved meta lost restart args: %q", joined)
+	}
+	if meta.WorkingDir != home {
+		t.Fatalf("preserved meta working dir = %q, want %q", meta.WorkingDir, home)
 	}
 }

--- a/internal/cli/daemon_inflight_test.go
+++ b/internal/cli/daemon_inflight_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+)
+
+// TestDaemonRunSelfRegistrationSurfacesRunningDaemon is the #505 gap-3 regression:
+// a `daemon run` launched directly (the form a `systemd --user` unit uses as its
+// ExecStart) must be recognized as running by `daemon status` / the dashboard.
+//
+// Before the fix only `daemon start` (the forking parent) wrote daemon.json, so a
+// systemd-managed `daemon run` left no pid/meta and currentDaemonPID — and thus
+// `daemon status` — falsely reported "stopped". registerDaemonRunState lets the
+// daemon-run process record ITSELF; this test drives that boundary using the test
+// process as the stand-in daemon (its argv matches /proc/<pid>/cmdline, so it
+// passes processLooksLikeDaemon exactly as a real `gitmoot daemon run` would).
+func TestDaemonRunSelfRegistrationSurfacesRunningDaemon(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	state := daemonProcessState(paths)
+
+	// systemd scenario: a `daemon run` has NOT self-registered yet — no daemon.json
+	// exists, so the daemon is invisible (the reported bug).
+	if pid, _, err := currentDaemonPID(state); err != nil || pid != 0 {
+		t.Fatalf("pre-registration currentDaemonPID = (%d, err=%v), want (0, nil)", pid, err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"daemon", "status", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("daemon status exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stopped") {
+		t.Fatalf("pre-registration status = %q, want stopped", stdout.String())
+	}
+
+	// The fix: the daemon-run process self-registers with its own argv.
+	wd, _ := os.Getwd()
+	ok, err := registerDaemonRunState(state, os.Args, wd)
+	if err != nil || !ok {
+		t.Fatalf("registerDaemonRunState ok=%v err=%v, want true nil", ok, err)
+	}
+
+	if pid, stale, err := currentDaemonPID(state); err != nil || pid != os.Getpid() || stale {
+		t.Fatalf("post-registration currentDaemonPID = (%d, stale=%v, err=%v), want (%d, false, nil)", pid, stale, err, os.Getpid())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"daemon", "status", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("daemon status (registered) exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "running pid") {
+		t.Fatalf("post-registration status = %q, want running pid", stdout.String())
+	}
+
+	// Shutdown cleanup removes our own state but is restricted to our pid.
+	deregisterDaemonRunState(state)
+	if pid, _, err := currentDaemonPID(state); err != nil || pid != 0 {
+		t.Fatalf("post-deregister currentDaemonPID = (%d, err=%v), want (0, nil)", pid, err)
+	}
+}
+
+// TestDeregisterDaemonRunStateOnlyRemovesOwnState confirms shutdown cleanup never
+// clobbers state a restarted daemon recorded under a different pid.
+func TestDeregisterDaemonRunStateOnlyRemovesOwnState(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	state := daemonProcessState(paths)
+
+	// A restarted daemon recorded a foreign pid in the meta.
+	foreign := daemonMeta{PID: os.Getpid() + 1, Args: []string{"daemon", "run"}, LogFile: state.LogFile}
+	if err := writeDaemonState(state, foreign); err != nil {
+		t.Fatalf("writeDaemonState returned error: %v", err)
+	}
+	// Our shutdown must leave the foreign daemon's state intact.
+	deregisterDaemonRunState(state)
+	if _, err := os.Stat(state.MetaFile); err != nil {
+		t.Fatalf("deregister removed foreign daemon meta: %v", err)
+	}
+	if _, err := os.Stat(state.PIDFile); err != nil {
+		t.Fatalf("deregister removed foreign daemon pid: %v", err)
+	}
+}

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -139,6 +139,10 @@ type dashboardSession struct {
 	Runtime string `json:"runtime"`
 	Repo    string `json:"repo,omitempty"`
 	State   string `json:"state,omitempty"`
+	// Stale marks a phantom "running" session — an agent_instance still at
+	// state=running whose lease (expires_at) has elapsed (#505 gap 2). omitempty
+	// keeps the --json shape byte-identical for healthy sessions (no new key).
+	Stale bool `json:"stale,omitempty"`
 
 	// Detail fields shown only in the interactive session detail view. They are
 	// unexported so the --json/--plain output stays byte-stable (mirrors how
@@ -454,6 +458,7 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 				Runtime:     instance.Runtime,
 				Repo:        instance.RepoFullName,
 				State:       instance.State,
+				Stale:       dashboardSessionStale(instance.State, instance.ExpiresAt, now),
 				sessionType: instance.Type,
 				role:        instance.Role,
 				templateID:  instance.TemplateID,
@@ -674,7 +679,7 @@ func printDashboardSnapshot(stdout io.Writer, st style.Style, snapshot dashboard
 		}
 	} else {
 		for _, session := range snapshot.RuntimeSessions {
-			writeLine(stdout, "  %s [%s] %s %s", session.Name, session.Runtime, emptyText(session.Repo), session.State)
+			writeLine(stdout, "  %s [%s] %s %s", session.Name, session.Runtime, emptyText(session.Repo), dashboardSessionStateText(session))
 		}
 	}
 
@@ -742,6 +747,11 @@ func printDashboardAttention(stdout io.Writer, st style.Style, snapshot dashboar
 			lines = append(lines, st.Red("stale lock")+" "+lock.Key)
 		}
 	}
+	for _, session := range snapshot.RuntimeSessions {
+		if session.Stale {
+			lines = append(lines, st.Red("stale session")+" "+session.Name)
+		}
+	}
 	if len(lines) == 0 {
 		return
 	}
@@ -800,17 +810,31 @@ func dashboardDeadTrainPhase(phase string) bool {
 	}
 }
 
+// dashboardSessionStateText renders a session's state, appending "(stale)" for a
+// phantom running session (#505 gap 2) so a dead runtime session is never
+// silently shown as live.
+func dashboardSessionStateText(session dashboardSession) string {
+	if session.Stale {
+		return session.State + " (stale)"
+	}
+	return session.State
+}
+
 // groupedRuntimeSessions collapses generated "<type>-bg-<hex>" sessions sharing
 // a type/runtime/state into a single counted line, leaving other sessions
-// individual.
+// individual. Stale (phantom running) sessions group separately so they are not
+// hidden inside a healthy "running" count (#505 gap 2).
 func groupedRuntimeSessions(sessions []dashboardSession) []string {
-	type groupKey struct{ prefix, runtime, state string }
+	type groupKey struct {
+		prefix, runtime, state string
+		stale                  bool
+	}
 	order := []groupKey{}
 	counts := map[groupKey]int{}
 	singles := []dashboardSession{}
 	for _, session := range sessions {
 		if prefix, ok := style.GroupSuffix(session.Name); ok {
-			key := groupKey{prefix: prefix, runtime: session.Runtime, state: session.State}
+			key := groupKey{prefix: prefix, runtime: session.Runtime, state: session.State, stale: session.Stale}
 			if counts[key] == 0 {
 				order = append(order, key)
 			}
@@ -821,12 +845,26 @@ func groupedRuntimeSessions(sessions []dashboardSession) []string {
 	}
 	lines := make([]string, 0, len(order)+len(singles))
 	for _, key := range order {
-		lines = append(lines, fmt.Sprintf("%s [%s] ×%d %s", key.prefix, key.runtime, counts[key], key.state))
+		state := key.state
+		if key.stale {
+			state += " (stale)"
+		}
+		lines = append(lines, fmt.Sprintf("%s [%s] ×%d %s", key.prefix, key.runtime, counts[key], state))
 	}
 	for _, session := range singles {
-		lines = append(lines, fmt.Sprintf("%s [%s] %s %s", session.Name, session.Runtime, emptyText(session.Repo), session.State))
+		lines = append(lines, fmt.Sprintf("%s [%s] %s %s", session.Name, session.Runtime, emptyText(session.Repo), dashboardSessionStateText(session)))
 	}
 	return lines
+}
+
+// dashboardSessionStale reports a phantom "running" runtime session: an
+// agent_instance still at state=running whose lease (expires_at) has elapsed
+// (#505 gap 2). A daemon that dies mid-job never runs its deferred
+// TouchAgentInstance, so the row keeps advertising a session that no longer
+// exists. It reuses the same expiry test as resource_locks; a normal idle row
+// past its lease (the idle GC reclaims it) is deliberately NOT flagged.
+func dashboardSessionStale(state, expiresAt string, now time.Time) bool {
+	return state == "running" && dashboardLockStale(expiresAt, now)
 }
 
 func dashboardLockStale(expiresAt string, now time.Time) bool {

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/cli/tui"
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/skillopt"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -458,7 +459,7 @@ func buildDashboardSnapshot(home string, paths config.Paths) (dashboardSnapshot,
 				Runtime:     instance.Runtime,
 				Repo:        instance.RepoFullName,
 				State:       instance.State,
-				Stale:       dashboardSessionStale(instance.State, instance.ExpiresAt, now),
+				Stale:       runningSessionStale(ctx, store, instance, now),
 				sessionType: instance.Type,
 				role:        instance.Role,
 				templateID:  instance.TemplateID,
@@ -857,12 +858,49 @@ func groupedRuntimeSessions(sessions []dashboardSession) []string {
 	return lines
 }
 
-// dashboardSessionStale reports a phantom "running" runtime session: an
-// agent_instance still at state=running whose lease (expires_at) has elapsed
-// (#505 gap 2). A daemon that dies mid-job never runs its deferred
-// TouchAgentInstance, so the row keeps advertising a session that no longer
-// exists. It reuses the same expiry test as resource_locks; a normal idle row
-// past its lease (the idle GC reclaims it) is deliberately NOT flagged.
+// runningSessionStale reports a phantom "running" runtime session (#505 gap 2)
+// using TWO independent signals, so a daemon that crashed EARLY in a long job —
+// and thus still holds a FUTURE lease — is not mistaken for live:
+//
+//   - lease elapsed (dashboardSessionStale): the deferred TouchAgentInstance never
+//     ran and the lease aged out — the "long after completion" case; and
+//   - the resumable runtime-session lock (runtime:<rt>:<ref>) is no longer held by
+//     a live owner: the daemon that marked the session running has died, so even
+//     WITHIN the lease window the session is dead. This closes the crash-soon-
+//     after-start gap the lease-only check missed (a 1-minute-in crash of a
+//     30-minute job left a ~29-minute future lease and showed as healthy).
+//
+// For a non-resumable runtime / empty ref (no session lock exists) there is no
+// liveness signal, so it falls back to the lease check alone. It never flags a
+// genuinely live session: a running job marks the instance running AFTER acquiring
+// the lock and clears it to idle BEFORE releasing the lock (LIFO defers), so a
+// running row always coincides with a live-owner lock; and any lock-lookup error
+// fails safe to "not stale" rather than mislabeling a live session.
+func runningSessionStale(ctx context.Context, store *db.Store, instance db.AgentInstance, now time.Time) bool {
+	if dashboardSessionStale(instance.State, instance.ExpiresAt, now) {
+		return true
+	}
+	if instance.State != "running" || store == nil {
+		return false
+	}
+	agent := runtime.Agent{Runtime: instance.Runtime, RuntimeRef: instance.RuntimeRef}
+	if _, ok := runtimeSessionResourceKey(agent); !ok {
+		return false // non-resumable / no ref: the lease is the only available signal
+	}
+	held, _, err := runtimeSessionHeldByLiveOwner(ctx, store, agent)
+	if err != nil {
+		return false // never mislabel a live session on a transient lookup error
+	}
+	return !held
+}
+
+// dashboardSessionStale reports a phantom "running" runtime session whose lease
+// (expires_at) has already elapsed (#505 gap 2) — the lease-based half of the
+// signal (see runningSessionStale for the within-lease liveness half). A daemon
+// that dies mid-job never runs its deferred TouchAgentInstance, so the row keeps
+// advertising a session that no longer exists. It reuses the same expiry test as
+// resource_locks; a normal idle row past its lease (the idle GC reclaims it) is
+// deliberately NOT flagged.
 func dashboardSessionStale(state, expiresAt string, now time.Time) bool {
 	return state == "running" && dashboardLockStale(expiresAt, now)
 }

--- a/internal/cli/dashboard_test.go
+++ b/internal/cli/dashboard_test.go
@@ -429,6 +429,87 @@ func TestBuildDashboardActiveJobsEmpty(t *testing.T) {
 	}
 }
 
+func TestDashboardSessionStale(t *testing.T) {
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	past := "2026-06-27T11:00:00.000000000Z"
+	future := "2026-06-27T13:00:00.000000000Z"
+	cases := []struct {
+		name    string
+		state   string
+		expires string
+		want    bool
+	}{
+		{name: "running and lease elapsed is a phantom", state: "running", expires: past, want: true},
+		{name: "running within lease is live", state: "running", expires: future, want: false},
+		{name: "idle past lease is normal GC, not phantom", state: "idle", expires: past, want: false},
+		{name: "running with unparseable lease is not flagged", state: "running", expires: "nope", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dashboardSessionStale(tc.state, tc.expires, now); got != tc.want {
+				t.Fatalf("dashboardSessionStale(%q,%q) = %v, want %v", tc.state, tc.expires, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDashboardFlagsPhantomRunningSession is the #505 gap-2 regression at the
+// snapshot/render boundary: an agent_instance left at state=running with an
+// elapsed lease must surface as "(stale)" (and on the needs-attention list), not
+// as a plainly-live "running" session.
+func TestDashboardFlagsPhantomRunningSession(t *testing.T) {
+	home := dashboardTestHome(t)
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	// expires_at is far in the past, so the running lease has elapsed → phantom.
+	past := time.Now().UTC().Add(-time.Hour).Format("2006-01-02T15:04:05.000000000Z")
+	nowStr := time.Now().UTC().Format("2006-01-02T15:04:05.000000000Z")
+	if err := store.UpsertAgentInstance(context.Background(), db.AgentInstance{
+		Name:           "researcher-bg-dead",
+		Type:           "researcher",
+		Runtime:        "claude",
+		RuntimeRef:     "ref-dead",
+		RepoFullName:   "owner/repo",
+		Role:           "researcher",
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: "read-only",
+		State:          "running",
+		CreatedAt:      nowStr,
+		LastUsedAt:     nowStr,
+		ExpiresAt:      past,
+	}); err != nil {
+		t.Fatalf("UpsertAgentInstance returned error: %v", err)
+	}
+	store.Close()
+
+	// Snapshot carries the Stale flag.
+	paths, err := initializedPaths(home)
+	if err != nil {
+		t.Fatalf("initializedPaths returned error: %v", err)
+	}
+	snap, err := buildDashboardSnapshot(home, paths)
+	if err != nil {
+		t.Fatalf("buildDashboardSnapshot returned error: %v", err)
+	}
+	if len(snap.RuntimeSessions) != 1 || !snap.RuntimeSessions[0].Stale {
+		t.Fatalf("expected one stale runtime session, got %+v", snap.RuntimeSessions)
+	}
+
+	// Plain render shows "(stale)" and flags it for attention.
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"dashboard", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("dashboard exit code = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"(stale)", "stale session", "researcher-bg-dead"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dashboard output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestDashboardRendersActiveJobsSection(t *testing.T) {
 	home := dashboardTestHome(t)
 	store, err := db.Open(config.PathsForHome(home).Database)

--- a/internal/cli/dashboard_test.go
+++ b/internal/cli/dashboard_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/cli/style"
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
 func dashboardTestHome(t *testing.T) string {
@@ -507,6 +508,120 @@ func TestDashboardFlagsPhantomRunningSession(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("dashboard output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// seedAgentInstanceWithLock seeds a state=running agent_instance with a future
+// (within-)lease and a held runtime:<rt>:<ref> session lock owned by ownerPID.
+func seedAgentInstanceWithLock(t *testing.T, home, name, ref string, ownerPID int64) {
+	t.Helper()
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	now := time.Now().UTC()
+	future := now.Add(29 * time.Minute).Format("2006-01-02T15:04:05.000000000Z")
+	nowStr := now.Format("2006-01-02T15:04:05.000000000Z")
+	if err := store.UpsertAgentInstance(context.Background(), db.AgentInstance{
+		Name:           name,
+		Type:           "researcher",
+		Runtime:        "claude",
+		RuntimeRef:     ref,
+		RepoFullName:   "owner/repo",
+		Role:           "researcher",
+		AutonomyPolicy: "read-only",
+		State:          "running",
+		CreatedAt:      nowStr,
+		LastUsedAt:     nowStr,
+		ExpiresAt:      future,
+	}); err != nil {
+		t.Fatalf("UpsertAgentInstance returned error: %v", err)
+	}
+	key, ok := runtimeSessionResourceKey(runtime.Agent{Runtime: "claude", RuntimeRef: ref})
+	if !ok {
+		t.Fatalf("expected a runtime session key for ref %q", ref)
+	}
+	acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey:   key,
+		OwnerJobID:    "job-" + ref,
+		OwnerToken:    "tok-" + ref,
+		OwnerPID:      ownerPID,
+		OwnerHostname: "", // empty host = treated as this host by the liveness check
+		ExpiresAt:     now.Add(29 * time.Minute).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock acquired=%v err=%v", acquired, err)
+	}
+}
+
+// TestRunningSessionStaleWithinLeaseDeadLock is the #505-review regression for the
+// within-lease phantom gap: a daemon that crashes SOON after starting a long job
+// leaves the instance state=running with a FUTURE lease, so the lease-only check
+// treats the dead session as live. The liveness-aware check flags it stale when
+// the held runtime-session lock has no live owner, and leaves a genuinely live
+// (this-process-owned) session alone.
+func TestRunningSessionStaleWithinLeaseDeadLock(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedAgentInstanceWithLock(t, home, "researcher-bg-crashed", "ref-crashed", deadPID(t))
+	seedAgentInstanceWithLock(t, home, "researcher-bg-live", "ref-live", int64(os.Getpid()))
+
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	dead, err := store.GetAgentInstance(ctx, "researcher-bg-crashed")
+	if err != nil {
+		t.Fatalf("GetAgentInstance dead: %v", err)
+	}
+	live, err := store.GetAgentInstance(ctx, "researcher-bg-live")
+	if err != nil {
+		t.Fatalf("GetAgentInstance live: %v", err)
+	}
+
+	// Lease-only signal misses it (future lease) — this is the gap.
+	if dashboardSessionStale(dead.State, dead.ExpiresAt, now) {
+		t.Fatalf("within-lease running session should not be lease-stale")
+	}
+	// Liveness-aware signal flags the dead-owner session...
+	if !runningSessionStale(ctx, store, dead, now) {
+		t.Fatalf("within-lease running session with a dead-owner lock must be stale")
+	}
+	// ...but never a live-owner session.
+	if runningSessionStale(ctx, store, live, now) {
+		t.Fatalf("within-lease running session held by a live owner must not be stale")
+	}
+}
+
+// TestDashboardFlagsWithinLeasePhantomViaDeadLock binds the within-lease liveness
+// fix to the snapshot/render boundary: a running session with a future lease but a
+// dead-owner session lock must render as "(stale)", not as a plainly-live session.
+func TestDashboardFlagsWithinLeasePhantomViaDeadLock(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedAgentInstanceWithLock(t, home, "researcher-bg-crashed", "ref-crashed", deadPID(t))
+
+	paths, err := initializedPaths(home)
+	if err != nil {
+		t.Fatalf("initializedPaths returned error: %v", err)
+	}
+	snap, err := buildDashboardSnapshot(home, paths)
+	if err != nil {
+		t.Fatalf("buildDashboardSnapshot returned error: %v", err)
+	}
+	if len(snap.RuntimeSessions) != 1 || !snap.RuntimeSessions[0].Stale {
+		t.Fatalf("within-lease dead-lock session should be stale: %+v", snap.RuntimeSessions)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"dashboard", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("dashboard exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "(stale)") {
+		t.Fatalf("within-lease phantom not rendered stale:\n%s", stdout.String())
 	}
 }
 

--- a/internal/cli/dashboard_tui.go
+++ b/internal/cli/dashboard_tui.go
@@ -550,6 +550,7 @@ func toTUISnapshot(s dashboardSnapshot) tui.Snapshot {
 			Runtime:  sess.Runtime,
 			Repo:     sess.Repo,
 			State:    sess.State,
+			Stale:    sess.Stale,
 			Type:     sess.sessionType,
 			Role:     sess.role,
 			Template: sess.templateID,

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -199,6 +199,8 @@ type Session struct {
 	Template string
 	LastUsed string
 	Expires  string
+	// Stale marks a phantom running session whose lease has elapsed (#505 gap 2).
+	Stale bool
 }
 
 // Jobs mirrors cli.dashboardJobs.

--- a/internal/cli/tui/sessions.go
+++ b/internal/cli/tui/sessions.go
@@ -22,14 +22,17 @@ type sessionRow struct {
 // type/runtime/state into one counted line (mirroring cli.groupedRuntimeSessions)
 // while keeping each row's representative session for the detail view.
 func (m Model) sessionRows() []sessionRow {
-	type groupKey struct{ prefix, runtime, state string }
+	type groupKey struct {
+		prefix, runtime, state string
+		stale                  bool
+	}
 	order := []groupKey{}
 	counts := map[groupKey]int{}
 	rep := map[groupKey]Session{}
 	singles := []Session{}
 	for _, s := range m.snap.Sessions {
 		if prefix, ok := style.GroupSuffix(s.Name); ok {
-			key := groupKey{prefix: prefix, runtime: s.Runtime, state: s.State}
+			key := groupKey{prefix: prefix, runtime: s.Runtime, state: s.State, stale: s.Stale}
 			if counts[key] == 0 {
 				order = append(order, key)
 				rep[key] = s
@@ -42,19 +45,28 @@ func (m Model) sessionRows() []sessionRow {
 	rows := make([]sessionRow, 0, len(order)+len(singles))
 	for _, key := range order {
 		rows = append(rows, sessionRow{
-			label:   fmt.Sprintf("%s [%s] ×%d %s", key.prefix, key.runtime, counts[key], key.state),
+			label:   fmt.Sprintf("%s [%s] ×%d %s", key.prefix, key.runtime, counts[key], sessionStateText(key.state, key.stale)),
 			session: rep[key],
 			count:   counts[key],
 		})
 	}
 	for _, s := range singles {
 		rows = append(rows, sessionRow{
-			label:   fmt.Sprintf("%s (%s) [%s] %s %s", s.Name, dash(s.Type), s.Runtime, dash(s.Repo), s.State),
+			label:   fmt.Sprintf("%s (%s) [%s] %s %s", s.Name, dash(s.Type), s.Runtime, dash(s.Repo), sessionStateText(s.State, s.Stale)),
 			session: s,
 			count:   1,
 		})
 	}
 	return rows
+}
+
+// sessionStateText appends "(stale)" to a phantom running session's state so the
+// Sessions page never shows a dead runtime session as plainly live (#505 gap 2).
+func sessionStateText(state string, stale bool) string {
+	if stale {
+		return state + " (stale)"
+	}
+	return state
 }
 
 // updateSessionOverlay handles keys in the session detail and stop-confirm

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2003,6 +2003,33 @@ func (s *Store) DeleteExpiredAgentInstances(ctx context.Context, now time.Time) 
 	return result.RowsAffected()
 }
 
+// ReconcileOrphanedRunningInstances resets to 'idle' any agent_instance left at
+// state='running' whose lease (expires_at) has already elapsed and that has NO
+// active (queued/running) job (#505 gap 2). Such a row is a phantom: a daemon
+// that died mid-job never ran its deferred TouchAgentInstance, so the instance is
+// stuck advertising a runtime session that no longer exists and the existing
+// idle-only GC never reclaims it. It never disturbs a genuinely live session: an
+// in-flight job within its timeout keeps a FUTURE expires_at (set to
+// now+jobTimeout by MarkAgentInstanceRunning), and the active-job guard protects
+// queued/running work — so this is safe to call from any number of concurrent
+// daemons. Resetting (rather than deleting) keeps the row reusable and lets the
+// normal idle GC reclaim it. Returns the number of rows reconciled.
+func (s *Store) ReconcileOrphanedRunningInstances(ctx context.Context, now time.Time) (int64, error) {
+	result, err := s.db.ExecContext(ctx, `UPDATE agent_instances
+		SET state = 'idle'
+		WHERE state = 'running'
+			AND expires_at <= ?
+			AND NOT EXISTS (
+				SELECT 1 FROM jobs
+				WHERE jobs.agent = agent_instances.name
+					AND jobs.state IN ('queued', 'running')
+			)`, formatResourceLockTime(now))
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 func scanAgentInstance(row interface{ Scan(dest ...any) error }) (AgentInstance, error) {
 	var instance AgentInstance
 	var capabilities string

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1775,6 +1775,103 @@ func TestAgentInstanceMethods(t *testing.T) {
 	}
 }
 
+// TestReconcileOrphanedRunningInstances is the #505 gap-2 regression: a daemon
+// that dies mid-job never runs its deferred TouchAgentInstance, leaving the row
+// stuck at state='running' with an elapsed lease — a phantom session the existing
+// idle-only GC (DeleteExpiredAgentInstances) never reclaims. ReconcileOrphaned-
+// RunningInstances resets only those phantoms to idle while leaving genuinely live
+// sessions (future lease, or an active queued/running job) untouched.
+func TestReconcileOrphanedRunningInstances(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+
+	base := func(name, state string, expires time.Time) AgentInstance {
+		return AgentInstance{
+			Name:           name,
+			Type:           "planner",
+			Runtime:        "codex",
+			RuntimeRef:     "ref-" + name,
+			RepoFullName:   "owner/repo",
+			Role:           "planner",
+			Capabilities:   []string{"ask"},
+			AutonomyPolicy: "read-only",
+			State:          state,
+			CreatedAt:      formatResourceLockTime(now.Add(-time.Hour)),
+			LastUsedAt:     formatResourceLockTime(now.Add(-time.Hour)),
+			ExpiresAt:      formatResourceLockTime(expires),
+		}
+	}
+
+	cases := []struct {
+		name        string
+		instance    AgentInstance
+		job         *Job
+		wantReset   bool
+		wantDeleted int64
+	}{
+		{
+			name:        "phantom running with elapsed lease and no job is reconciled",
+			instance:    base("phantom", "running", now.Add(-time.Minute)),
+			wantReset:   true,
+			wantDeleted: 1,
+		},
+		{
+			name:        "live running within lease is left alone",
+			instance:    base("live-lease", "running", now.Add(time.Minute)),
+			wantReset:   false,
+			wantDeleted: 0,
+		},
+		{
+			name:        "running with an active job is left alone even past lease",
+			instance:    base("busy", "running", now.Add(-time.Minute)),
+			job:         &Job{ID: "j-busy", Agent: "busy", Type: "ask", State: "running", Payload: "{}"},
+			wantReset:   false,
+			wantDeleted: 0,
+		},
+		{
+			name:        "idle past lease is not this reconciler's job",
+			instance:    base("idle-old", "idle", now.Add(-time.Minute)),
+			wantReset:   false,
+			wantDeleted: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+			if err != nil {
+				t.Fatalf("Open returned error: %v", err)
+			}
+			defer store.Close()
+			if err := store.UpsertAgentInstance(ctx, tc.instance); err != nil {
+				t.Fatalf("UpsertAgentInstance returned error: %v", err)
+			}
+			if tc.job != nil {
+				if err := store.CreateJob(ctx, *tc.job); err != nil {
+					t.Fatalf("CreateJob returned error: %v", err)
+				}
+			}
+			deleted, err := store.ReconcileOrphanedRunningInstances(ctx, now)
+			if err != nil {
+				t.Fatalf("ReconcileOrphanedRunningInstances returned error: %v", err)
+			}
+			if deleted != tc.wantDeleted {
+				t.Fatalf("reconciled rows = %d, want %d", deleted, tc.wantDeleted)
+			}
+			got, err := store.GetAgentInstance(ctx, tc.instance.Name)
+			if err != nil {
+				t.Fatalf("GetAgentInstance returned error: %v", err)
+			}
+			if tc.wantReset && got.State != "idle" {
+				t.Fatalf("instance state = %q, want idle (reconciled)", got.State)
+			}
+			if !tc.wantReset && got.State != tc.instance.State {
+				t.Fatalf("instance state = %q, want unchanged %q", got.State, tc.instance.State)
+			}
+		})
+	}
+}
+
 func TestRepositoryMethods(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))


### PR DESCRIPTION
## Root cause

`gitmoot dashboard`/`daemon status` had no reliable live view of in-flight work. Two distinct, code-grounded mechanisms (gap 1 — active_jobs — already shipped in #506/#513; this PR closes gaps 2 and 3):

- **Gap 2 (phantom running sessions):** `agent_instances.state` is set to `running` on job start with a lease of `now+jobTimeout` (`MarkAgentInstanceRunning`), and reset to `idle` by a *deferred* `TouchAgentInstance`. A daemon that dies mid-job never runs that defer, so the row stays `running` with an elapsed lease. The existing GC (`DeleteExpiredAgentInstances`) only reclaims `state='idle'` rows, so the phantom `running` session persists forever and the dashboard advertises a runtime session that no longer exists.
- **Gap 3 (false "stopped" under systemd):** only `daemon start` (the forking parent) writes `daemon.json`/`daemon.pid` — for its detached child. A `daemon run` launched directly (the form a `systemd --user` unit uses as ExecStart) has no such parent, so nothing writes the pid/meta. `currentDaemonPID` then finds no state and `daemon status`/the dashboard report `stopped` while the daemon is alive and processing.

## The fix (and why it's at the right depth)

- **Gap 2:** add `Store.ReconcileOrphanedRunningInstances` — resets to `idle` any `running` row whose lease has elapsed **and** that has no active (`queued`/`running`) job. This generalizes the liveness predicate from "state" to "expired lease + no active job": a genuinely live job keeps a *future* lease and/or an active job, so it is never disturbed (safe under any number of concurrent daemons). It's called once at `daemon run` startup. The dashboard additionally **flags** such rows as `(stale)` — reusing the same `expires_at` test (`dashboardLockStale`) that already powers `resource_locks`, so this is one shared staleness mechanism, not a special case. The dashboard stays read-only (it never mutates store state); the reconcile lives in the daemon.
- **Gap 3:** `daemon run` now self-registers its own pid/meta on startup (recording `os.Args` so the meta matches `/proc/<pid>/cmdline` and passes `processLooksLikeDaemon`) and deregisters on exit — but only when the recorded state still points at this pid, so a restarted daemon's fresh state is never clobbered. It declines to overwrite a different live daemon, keeping the existing `daemon start`→child flow idempotent. This makes the daemon detectable on **any** launch path (systemd, manual `daemon run`, or `daemon start`'s child), rather than band-aiding the systemd case.

Both daemon-startup steps are best-effort and never block the daemon from running. `--json`/`--plain` output stays byte-identical for healthy sessions (`stale` uses `omitempty`).

## Regression tests (table-driven, real temp Store/home; all fail without the fix, pass with it)

- `internal/db`: `TestReconcileOrphanedRunningInstances` — phantom (expired, no job) → reset to `idle`; live-lease / active-job / idle-expired rows left untouched.
- `internal/cli`: `TestDashboardFlagsPhantomRunningSession` + `TestDashboardSessionStale` — an expired `running` instance surfaces as `(stale)` in the snapshot, the plain render, and the needs-attention list.
- `internal/cli`: `TestDaemonRunSelfRegistrationSurfacesRunningDaemon` — pre-registration `daemon status` is `stopped` (documents the bug), post `registerDaemonRunState` it is `running pid`, and `deregisterDaemonRunState` clears it; `TestDeregisterDaemonRunStateOnlyRemovesOwnState` guards the foreign-pid case.

Gate: `go build`, `go vet`, `go test ./...`, and `go test -race` for `daemon`/`workflow`/`runtime`/`cli` all green.

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)