### PR TITLE
fix(workflow): clear stale read-only worktrees on retry

### DIFF
--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -37,6 +37,10 @@ func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error
 		return db.Job{}, err
 	}
 	payload.Result = nil
+	if manualRetryShouldClearReadOnlyWorktree(job, payload) {
+		payload.WorktreePath = ""
+		payload.HeadSHA = ""
+	}
 	encoded, err := marshalPayload(payload)
 	if err != nil {
 		return db.Job{}, err
@@ -57,6 +61,21 @@ func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error
 		return db.Job{}, fmt.Errorf("job %s is %s; retry requires failed, blocked, or cancelled", latest.ID, latest.State)
 	}
 	return store.GetJob(ctx, job.ID)
+}
+
+func manualRetryShouldClearReadOnlyWorktree(job db.Job, payload JobPayload) bool {
+	if strings.TrimSpace(payload.WorktreePath) == "" {
+		return false
+	}
+	if strings.TrimSpace(payload.TaskID) != "" {
+		return false
+	}
+	switch strings.TrimSpace(job.Type) {
+	case "ask", "review":
+		return true
+	default:
+		return false
+	}
 }
 
 func latestCancellationWasFromRunning(ctx context.Context, store *db.Store, jobID string) (bool, error) {

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -47,6 +47,62 @@ func TestRetryJobRequeuesTerminalJobAndPreservesPayload(t *testing.T) {
 	}
 }
 
+func TestRetryJobClearsReadOnlyNoTaskWorktreePath(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	payload := `{"repo":"owner/repo","branch":"main","delegation_id":"plan-glm","worktree_path":"/tmp/gitmoot/worktrees/owner--repo/delegations/root/plan-glm/pool-isolation","head_sha":"abc123","result":{"decision":"failed","summary":"stale"}}`
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "root/delegation/plan-glm", Agent: "council-glm", Type: "ask", State: string(JobFailed), Payload: payload}, db.JobEvent{
+		Kind:    string(JobFailed),
+		Message: "failed",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	job, err := RetryJob(ctx, store, "root/delegation/plan-glm")
+	if err != nil {
+		t.Fatalf("RetryJob returned error: %v", err)
+	}
+
+	storedPayload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if storedPayload.WorktreePath != "" {
+		t.Fatalf("manual read-only retry kept stale WorktreePath = %q", storedPayload.WorktreePath)
+	}
+	if storedPayload.HeadSHA != "" {
+		t.Fatalf("manual read-only retry kept stale HeadSHA = %q", storedPayload.HeadSHA)
+	}
+}
+
+func TestRetryJobPreservesTaskWorktreePath(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	payload := `{"repo":"owner/repo","branch":"feature","task_id":"task-1","delegation_id":"implement","worktree_path":"/tmp/gitmoot/worktrees/owner--repo/task-1","head_sha":"abc123","result":{"decision":"failed","summary":"stale"}}`
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "root/delegation/implement", Agent: "builder", Type: "implement", State: string(JobFailed), Payload: payload}, db.JobEvent{
+		Kind:    string(JobFailed),
+		Message: "failed",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	job, err := RetryJob(ctx, store, "root/delegation/implement")
+	if err != nil {
+		t.Fatalf("RetryJob returned error: %v", err)
+	}
+
+	storedPayload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if storedPayload.WorktreePath != "/tmp/gitmoot/worktrees/owner--repo/task-1" {
+		t.Fatalf("task retry WorktreePath = %q, want preserved task worktree", storedPayload.WorktreePath)
+	}
+	if storedPayload.HeadSHA != "abc123" {
+		t.Fatalf("task retry HeadSHA = %q, want preserved", storedPayload.HeadSHA)
+	}
+}
+
 func TestRetryJobRejectsNonTerminalJob(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)


### PR DESCRIPTION
## Summary

- clear stale read-only delegation worktree/head metadata when manually retrying terminal ask/review jobs
- preserve task-owned implement worktrees so real implementation recovery is not lost
- add regression coverage for both paths

## Why

Manual retry of a failed read-only delegation can currently keep a deleted delegation worktree path. A subsequent manual run then fails while resolving the repo checkout with `chdir ... no such file or directory`. Clearing the stale path lets the retry resolve or recreate a fresh checkout.

## Tests

- `/home/smith/.local/go/bin/go test ./internal/workflow -run 'TestRetryJob' -count=1`\n