### PR TITLE
fix: disable native merge gate for council-owned PRs

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4578,11 +4578,26 @@ type daemonMergeGate struct {
 }
 
 func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeRequest) (workflow.MergeDecision, error) {
+	if nativeMergeGateDisabled() {
+		return workflow.MergeDecision{
+			Ready:  false,
+			Reason: "native Gitmoot merge gate disabled by GITMOOT_DISABLE_NATIVE_MERGE_GATE; use external gate",
+		}, nil
+	}
 	checkout, err := mergeGateCheckout(ctx, g.Store, request.Repo, g.FallbackCheckout)
 	if err != nil {
 		return workflow.MergeDecision{}, err
 	}
 	return newDaemonPolicyMergeGate(g.Store, g.githubClient(checkout), checkout).Evaluate(ctx, request)
+}
+
+func nativeMergeGateDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("GITMOOT_DISABLE_NATIVE_MERGE_GATE"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func (g daemonMergeGate) githubClient(checkout string) github.Client {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -3404,6 +3404,26 @@ func TestNewDaemonPolicyMergeGateIncludesWorktreeCleaner(t *testing.T) {
 	}
 }
 
+func TestDaemonMergeGateCanBeDisabledByEnvironment(t *testing.T) {
+	t.Setenv("GITMOOT_DISABLE_NATIVE_MERGE_GATE", "1")
+	gate := daemonMergeGate{}
+
+	decision, err := gate.Evaluate(context.Background(), workflow.MergeRequest{
+		Repo:        "owner/repo",
+		PullRequest: 1,
+	})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Ready {
+		t.Fatalf("decision.Ready = true, want disabled gate to block")
+	}
+	if !strings.Contains(decision.Reason, "GITMOOT_DISABLE_NATIVE_MERGE_GATE") {
+		t.Fatalf("decision reason = %q", decision.Reason)
+	}
+}
+
 func TestDaemonMergeGatePreservesInjectedGitHubClient(t *testing.T) {
 	fake := github.NoopClient{}
 	gate := daemonMergeGate{GitHub: fake}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -393,6 +393,11 @@ func (d Daemon) pullRequestReadyToMerge(ctx context.Context, pull github.PullReq
 		}
 		return false, err
 	}
+	if lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef); err == nil && lock.SkipNativeReviewFanout {
+		return false, nil
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, err
+	}
 	return task.State == string(workflow.TaskReadyToMerge), nil
 }
 
@@ -407,6 +412,9 @@ func (d Daemon) handleReadyToMergeWorkflow(ctx context.Context, pull github.Pull
 	lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
+	}
+	if lock.SkipNativeReviewFanout {
+		return nil
 	}
 	leadAgent := strings.TrimSpace(lock.Owner)
 	if leadAgent == "" {
@@ -510,6 +518,11 @@ func (d Daemon) retryClosedReadyToMerge(ctx context.Context, openBranches map[st
 	for _, task := range tasks {
 		if task.Branch == "" {
 			continue
+		}
+		if lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), task.Branch); err == nil && lock.SkipNativeReviewFanout {
+			continue
+		} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
 		}
 		if _, open := openBranches[task.Branch]; open {
 			continue
@@ -1142,9 +1155,15 @@ func (d Daemon) handleMergeCommand(ctx context.Context, pull github.PullRequest,
 		return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot cannot merge PR #%d because task `%s` is `%s`, not `%s`.", pull.Number, task.ID, task.State, workflow.TaskReadyToMerge))
 	}
 	leadAgent := "github"
-	if lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef); err == nil && strings.TrimSpace(lock.Owner) != "" {
-		leadAgent = lock.Owner
-	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef)
+	if err == nil {
+		if lock.SkipNativeReviewFanout {
+			return d.ack(ctx, pull.Number, fmt.Sprintf("Gitmoot native merge is disabled for PR #%d because branch `%s` is managed by an external council gate.", pull.Number, pull.HeadRef))
+		}
+		if strings.TrimSpace(lock.Owner) != "" {
+			leadAgent = lock.Owner
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
 	reviewers, err := d.workflowReviewers(ctx)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -300,9 +300,9 @@ func TestHandlePullRequestWorkflowSkipsReviewFanoutWhenLockSet(t *testing.T) {
 			t.Fatalf("expected no review jobs with skip set, found %+v", job)
 		}
 	}
-	// The no-reviewers tail still ran (merge gate evaluated, baseline recorded).
-	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 {
-		t.Fatalf("merge gate requests = %+v", gate.requests)
+	// The baseline is recorded, but native merge authority is skipped entirely.
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate requests = %+v, want none for skip-native-review-fanout", gate.requests)
 	}
 	if _, err := store.GetPullRequest(ctx, repo.FullName(), 7); err != nil {
 		t.Fatalf("GetPullRequest returned error: %v", err)
@@ -852,6 +852,73 @@ func TestPollOnceRetriesReadyToMergePullRequestWithoutHeadChange(t *testing.T) {
 	}
 	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 || gate.requests[0].HeadSHA != "abc123" {
 		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestPollOnceDoesNotRetryReadyToMergeWhenNativeFanoutSkipped(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-7",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1",
+		Title:        "Task 7",
+		State:        string(workflow.TaskReadyToMerge),
+		Branch:       "task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "builder",
+		Role:           "builder",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "builder"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.SetBranchLockReviewFanout(ctx, repo.FullName(), "task-7", true); err != nil {
+		t.Fatalf("SetBranchLockReviewFanout returned error: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       7,
+		URL:          "https://github.com/jerryfane/gitmoot/pull/7",
+		HeadBranch:   "task-7",
+		BaseBranch:   "main",
+		HeadSHA:      "abc123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Task 7",
+			State:   "open",
+			URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+			HeadRef: "task-7",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate requests = %+v, want none for skip-native-review-fanout branch", gate.requests)
 	}
 }
 
@@ -1879,6 +1946,46 @@ func TestPollOnceMergeCommandRunsMergeGate(t *testing.T) {
 	}
 	if task.State != string(workflow.TaskMerged) {
 		t.Fatalf("task state = %q, want merged", task.State)
+	}
+}
+
+func TestPollOnceMergeCommandRefusesSkipNativeFanoutBranch(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-010",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1",
+		Title:        "Task 10",
+		State:        string(workflow.TaskReadyToMerge),
+		Branch:       "task-10",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-10", Owner: "builder"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.SetBranchLockReviewFanout(ctx, repo.FullName(), "task-10", true); err != nil {
+		t.Fatalf("SetBranchLockReviewFanout returned error: %v", err)
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	client := &fakeGitHub{}
+	err := (Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}).handleMergeCommand(
+		ctx,
+		github.PullRequest{Number: 10, Title: "Task 10", State: "open", HeadRef: "task-10", BaseRef: "main", HeadSHA: "abc123"},
+		github.IssueComment{ID: 910, Body: "/gitmoot merge", Author: "dana"},
+	)
+
+	if err != nil {
+		t.Fatalf("handleMergeCommand returned error: %v", err)
+	}
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate requests = %+v, want none", gate.requests)
+	}
+	if len(client.posted) != 1 || !strings.Contains(client.posted[0].body, "external council gate") {
+		t.Fatalf("posted acknowledgements = %+v", client.posted)
 	}
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -365,10 +365,11 @@ type PullRequestEvent struct {
 	LeadAgent         string
 	Sender            string
 	RequiredReviewers []string
-	// SkipReviewFanout, when true, suppresses the native review-fanout loop in
-	// HandlePullRequestOpened: zero review jobs are enqueued and the PR runs the
-	// same no-reviewers tail (record baseline + merge gate) the zero-reviewers
-	// case already runs, so the PR still advances. Defaults false => full fanout.
+	// SkipReviewFanout, when true, suppresses Gitmoot's native PR advancement in
+	// HandlePullRequestOpened: zero review jobs are enqueued, the PR baseline is
+	// recorded, and the native merge gate is not run. Council-style external
+	// orchestrators use this to make their own gate the only merge authority.
+	// Defaults false => full native fanout/advancement.
 	SkipReviewFanout bool
 }
 
@@ -705,10 +706,10 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 	if len(reviewers) == 0 {
 		reviewers = compactStrings(append([]string{}, e.RequiredReviewers...))
 	}
-	// When the caller asked to skip the native review fanout, run the exact same
-	// no-reviewers tail the zero-reviewers case runs (merge gate + baseline) so the
-	// PR still advances, but enqueue ZERO review jobs.
-	if len(reviewers) == 0 || event.SkipReviewFanout {
+	if event.SkipReviewFanout {
+		return e.recordPullRequestBaseline(ctx, event)
+	}
+	if len(reviewers) == 0 {
 		decision, err := e.runMergeGate(ctx, "", JobPayload{
 			Repo:        event.Repo,
 			Branch:      event.Branch,

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -597,8 +597,6 @@ func TestEngineHandlePullRequestOpenedSkipsReviewFanout(t *testing.T) {
 	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
 	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
 	engine := testEngine(store)
-	// A ready-but-not-merged gate so the no-reviewers tail runs to completion and
-	// records the baseline (the same tail the zero-reviewers path runs).
 	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
 	engine.MergeGate = gate
 
@@ -619,7 +617,7 @@ func TestEngineHandlePullRequestOpenedSkipsReviewFanout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
 	}
-	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+	assertTaskState(t, store, "task-7", TaskPullRequestOpen)
 	// Zero review jobs enqueued despite a required reviewer being present.
 	jobs, err := store.ListJobs(ctx)
 	if err != nil {
@@ -630,8 +628,9 @@ func TestEngineHandlePullRequestOpenedSkipsReviewFanout(t *testing.T) {
 			t.Fatalf("expected no review jobs, found %+v", job)
 		}
 	}
-	// The merge gate (no-reviewers tail) still ran.
-	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 || !gate.requests[0].ReviewOptional {
+	// The native merge gate does not run; an external council gate owns merge
+	// authority for skip-native-review-fanout branches.
+	if len(gate.requests) != 0 {
 		t.Fatalf("merge gate requests = %+v", gate.requests)
 	}
 	// Baseline still recorded so the PR advances.
@@ -673,11 +672,8 @@ func TestEngineAdvanceImplementPersistsSkipReviewFanoutOntoLock(t *testing.T) {
 
 	err := engine.AdvanceJob(ctx, "implement-job")
 
-	// The no-reviewers tail blocks on the pending gate; trigger 1 must have fired
-	// (no review jobs) and the flag must be persisted onto the lock (trigger 2).
-	var blocked BlockedError
-	if !errors.As(err, &blocked) || blocked.Reason != "ci is pending" {
-		t.Fatalf("error = %v, want merge gate BlockedError", err)
+	if err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
 	}
 	jobs, err := store.ListJobs(ctx)
 	if err != nil {
@@ -695,6 +691,10 @@ func TestEngineAdvanceImplementPersistsSkipReviewFanoutOntoLock(t *testing.T) {
 	if !lock.SkipNativeReviewFanout {
 		t.Fatalf("expected lock.SkipNativeReviewFanout = true, got %+v", lock)
 	}
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate requests = %+v, want none for skip-native-review-fanout", gate.requests)
+	}
+	assertTaskState(t, store, "task-7", TaskPullRequestOpen)
 }
 
 func TestEngineAdvanceImplementDispatchesReviewers(t *testing.T) {


### PR DESCRIPTION
## Summary

- add a guard to disable Gitmoot native merge-gate behavior for council-owned PRs
- require explicit opt-in/daemon configuration for native merge behavior where applicable
- add daemon/workflow coverage for the council merge-safety path

## Why

Council-controlled PRs need council-gate to be the single merge authority. Native Gitmoot merge-gate behavior can race or bypass council-gate, which caused protected council runs to merge outside the intended gate path.

## Tests

- `/home/smith/.local/go/bin/go test ./internal/daemon ./internal/cli ./internal/workflow -run 'Test.*Native|Test.*Merge|Test.*Council|TestEngine.*Delegation' -count=1`\n