### PR TITLE
fix(kimi): add opt-in legacy CLI runtime

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -889,7 +889,7 @@ func runAgentTypeSet(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("agent type set", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
-	runtimeName := fs.String("runtime", "", "agent runtime: codex, claude, or kimi")
+	runtimeName := fs.String("runtime", "", "agent runtime: codex, claude, kimi, or kimi-cli")
 	templateID := fs.String("template", "", "agent template")
 	model := fs.String("model", "", "default runtime model for this agent type")
 	role := fs.String("role", "", "agent role")
@@ -941,7 +941,7 @@ func runAgentTypeSet(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	if entry.Runtime == runtime.ShellRuntime {
-		fmt.Fprintln(stderr, "invalid runtime: managed agent types support codex, claude, or kimi")
+		fmt.Fprintln(stderr, "invalid runtime: managed agent types support codex, claude, kimi, or kimi-cli")
 		return 2
 	}
 	if strings.TrimSpace(*templateID) != "" {
@@ -1093,7 +1093,7 @@ func runAgentStart(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("agent start", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
-	runtimeName := fs.String("runtime", "", "agent runtime: codex, claude, or kimi")
+	runtimeName := fs.String("runtime", "", "agent runtime: codex, claude, kimi, or kimi-cli")
 	repoFlag := fs.String("repo", "", "allowed repo as owner/repo")
 	path := fs.String("path", ".", "local checkout path")
 	role := fs.String("role", "", "agent role")
@@ -1246,7 +1246,7 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("agent subscribe", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
-	runtimeName := fs.String("runtime", "", "agent runtime: codex, claude, kimi, or shell")
+	runtimeName := fs.String("runtime", "", "agent runtime: codex, claude, kimi, kimi-cli, or shell")
 	session := fs.String("session", "", "runtime session reference, last, or shell command")
 	role := fs.String("role", "", "agent role")
 	templateID := fs.String("template", "", "agent template")
@@ -1481,6 +1481,8 @@ func runtimeStartAdapter(factory runtime.Factory, runtimeName string, checkout s
 		return runtime.ClaudeAdapter{Runner: factory.Runner, Dir: checkout}, nil
 	case runtime.KimiRuntime:
 		return runtime.KimiAdapter{Runner: factory.Runner, Dir: checkout}, nil
+	case runtime.KimiCLIRuntime:
+		return runtime.KimiCLIAdapter{Runner: factory.Runner, Dir: checkout}, nil
 	case runtime.ShellRuntime:
 		return runtime.ShellAdapter{Runner: factory.Runner, Dir: checkout}, nil
 	default:

--- a/internal/cli/agent_restart_test.go
+++ b/internal/cli/agent_restart_test.go
@@ -17,7 +17,7 @@ import (
 // agentRestartFakeAdapter is a runtime.Adapter test double for `agent restart`:
 // it records whether Start was called and returns a deterministic, configurable
 // new runtime_ref (or an error). Runtime-agnostic — the adapter the restart path
-// builds is replaced wholesale via runtimeStartAdapterFor so codex/claude/kimi
+// builds is replaced wholesale via runtimeStartAdapterFor so codex/claude/kimi/kimi-cli
 // all funnel through this one fake without depending on each adapter's
 // runtime-specific ref generation.
 type agentRestartFakeAdapter struct {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -1562,7 +1562,7 @@ func TestRunAgentTypeSetRejectsNonStartableRuntime(t *testing.T) {
 	if code != 2 {
 		t.Fatalf("agent type set shell exit code = %d, want 2", code)
 	}
-	if !strings.Contains(stderr.String(), "managed agent types support codex, claude, or kimi") {
+	if !strings.Contains(stderr.String(), "managed agent types support codex, claude, kimi, or kimi-cli") {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
 }
@@ -3287,11 +3287,11 @@ func TestCockpitAutoEnabled(t *testing.T) {
 		env      string
 		want     bool
 	}{
-		{false, "", false},     // outside Herdr, no flag -> off
-		{false, "1", true},     // inside a Herdr session -> auto on
-		{false, "  ", false},   // whitespace HERDR_ENV -> off
-		{true, "", true},       // explicit --cockpit -> on even outside Herdr
-		{true, "1", true},      // explicit + in Herdr -> on
+		{false, "", false},   // outside Herdr, no flag -> off
+		{false, "1", true},   // inside a Herdr session -> auto on
+		{false, "  ", false}, // whitespace HERDR_ENV -> off
+		{true, "", true},     // explicit --cockpit -> on even outside Herdr
+		{true, "1", true},    // explicit + in Herdr -> on
 	}
 	for _, c := range cases {
 		if got := cockpitAutoEnabled(c.explicit, c.env); got != c.want {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3064,7 +3064,7 @@ func perJobAdmissionEstimate(ctx context.Context, store *db.Store, job db.Job, p
 		return admissionEstimate{session: true, memGB: policy.CodexMemoryGB}
 	case runtime.ClaudeRuntime:
 		return admissionEstimate{session: true, memGB: policy.ClaudeMemoryGB}
-	case runtime.KimiRuntime:
+	case runtime.KimiRuntime, runtime.KimiCLIRuntime:
 		return admissionEstimate{session: true, memGB: policy.KimiMemoryGB}
 	default:
 		return admissionEstimate{session: true, memGB: policy.DefaultMemoryGB}
@@ -3413,7 +3413,7 @@ func tempWorkerEligible(ctx context.Context, store *db.Store, job db.Job, payloa
 		return tempWorkerEligibility{Reason: "parallel_sessions.same_session is queue"}
 	}
 	switch agent.Runtime {
-	case runtime.CodexRuntime, runtime.ClaudeRuntime, runtime.KimiRuntime:
+	case runtime.CodexRuntime, runtime.ClaudeRuntime, runtime.KimiRuntime, runtime.KimiCLIRuntime:
 	default:
 		return tempWorkerEligibility{Reason: fmt.Sprintf("runtime %s does not support temp workers", agent.Runtime)}
 	}
@@ -4133,6 +4133,8 @@ func buildRuntimeAdapter(agent runtime.Agent, checkout string, runner subprocess
 		return runtime.ClaudeAdapter{Dir: checkout, Runner: runner}, nil
 	case runtime.KimiRuntime:
 		return runtime.KimiAdapter{Dir: checkout, Runner: runner}, nil
+	case runtime.KimiCLIRuntime:
+		return runtime.KimiCLIAdapter{Dir: checkout, Runner: runner}, nil
 	case runtime.ShellRuntime:
 		return runtime.ShellAdapter{Dir: checkout, Runner: runner}, nil
 	default:

--- a/internal/cli/runtime_lock.go
+++ b/internal/cli/runtime_lock.go
@@ -63,7 +63,7 @@ func runtimeSessionResourceKey(agent runtime.Agent) (string, bool) {
 	runtimeName := strings.TrimSpace(agent.Runtime)
 	runtimeRef := strings.TrimSpace(agent.RuntimeRef)
 	switch runtimeName {
-	case runtime.CodexRuntime, runtime.ClaudeRuntime, runtime.KimiRuntime:
+	case runtime.CodexRuntime, runtime.ClaudeRuntime, runtime.KimiRuntime, runtime.KimiCLIRuntime:
 	default:
 		return "", false
 	}

--- a/internal/cli/tui/agents.go
+++ b/internal/cli/tui/agents.go
@@ -98,7 +98,7 @@ func (m *Model) openAgentDelete(agent Agent) {
 }
 
 // agentRuntimeOptions are the runtimes an agent can be switched between.
-var agentRuntimeOptions = []string{"codex", "claude", "kimi"}
+var agentRuntimeOptions = []string{"codex", "claude", "kimi", "kimi-cli"}
 
 // openAgentRuntimePick enters the switch-runtime overlay, preselecting the
 // agent's current runtime.
@@ -593,12 +593,13 @@ func NewAgentCreateForm(store PromptStore, templates []Choice) TrainInitModel {
 				{Value: "codex", Label: "codex"},
 				{Value: "claude", Label: "claude"},
 				{Value: "kimi", Label: "kimi"},
+				{Value: "kimi-cli", Label: "kimi-cli"},
 			},
 			Default: "codex",
 			Prompt: db.InteractivePrompt{
 				ID:            "agent-create-runtime",
 				Question:      "Runtime for the new agent?",
-				Choices:       []string{"codex", "claude", "kimi"},
+				Choices:       []string{"codex", "claude", "kimi", "kimi-cli"},
 				Default:       "codex",
 				Required:      true,
 				AnswerFormat:  "choice",

--- a/internal/cli/tui/data.go
+++ b/internal/cli/tui/data.go
@@ -367,7 +367,7 @@ type Deps struct {
 	// queued/running jobs, plus any unexpected error.
 	DeleteAgents   func(names []string) (deleted int, skipped []string, err error)
 	RevertTemplate func(templateID, versionID string) error
-	// SetAgentRuntime switches a registered agent's runtime (codex/claude/kimi),
+	// SetAgentRuntime switches a registered agent's runtime (codex/claude/kimi/kimi-cli),
 	// preserving its role/capabilities/repos and clearing the warm session.
 	SetAgentRuntime func(name, runtime string) error
 

--- a/internal/cli/tui/sessions.go
+++ b/internal/cli/tui/sessions.go
@@ -164,7 +164,7 @@ func (m *Model) openSessionDetail() {
 func (m Model) sessionsContent() string {
 	var b strings.Builder
 	// Kept as short lines so the key phrases survive viewport wrapping.
-	b.WriteString(mutedStyle.Render("Live runtime processes (codex/claude/kimi) that execute jobs for your agents.") + "\n")
+	b.WriteString(mutedStyle.Render("Live runtime processes (codex/claude/kimi/kimi-cli) that execute jobs for your agents.") + "\n")
 	b.WriteString(mutedStyle.Render("Each row shows its owning agent type.") + "\n")
 	b.WriteString(mutedStyle.Render("Stopping one frees the warm process; it does NOT cancel a running job.") + "\n")
 	b.WriteString(mutedStyle.Render("Idle sessions expire on their own.") + "\n")

--- a/internal/cli/tui/view.go
+++ b/internal/cli/tui/view.go
@@ -166,7 +166,7 @@ func (m Model) helpContent() string {
 		b.WriteString("enter open the agent (template, recent jobs, versions)\n")
 		b.WriteString("n    register a new agent (name, runtime, template)\n")
 		b.WriteString("o    optimize: start a training session for the agent's template\n")
-		b.WriteString("     (asks repos, request, codex/claude/kimi backend, optional model)\n")
+		b.WriteString("     (asks repos, request, codex/claude/kimi/kimi-cli backend, optional model)\n")
 		b.WriteString("D    delete the selected agent (refused while jobs reference it)\n")
 		b.WriteString("v    in the detail: revert the template to a previous version\n")
 	case pageJobs:

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -17,11 +17,12 @@ import (
 )
 
 const (
-	CodexRuntime  = "codex"
-	ClaudeRuntime = "claude"
-	KimiRuntime   = "kimi"
-	ShellRuntime  = "shell"
-	LastRef       = "last"
+	CodexRuntime   = "codex"
+	ClaudeRuntime  = "claude"
+	KimiRuntime    = "kimi"
+	KimiCLIRuntime = "kimi-cli"
+	ShellRuntime   = "shell"
+	LastRef        = "last"
 
 	healthPrompt = "Gitmoot health check. Reply OK only."
 
@@ -105,6 +106,8 @@ func (f Factory) Adapter(name string) (Adapter, error) {
 		return ClaudeAdapter{Runner: f.Runner}, nil
 	case KimiRuntime:
 		return KimiAdapter{Runner: f.Runner}, nil
+	case KimiCLIRuntime:
+		return KimiCLIAdapter{Runner: f.Runner}, nil
 	case ShellRuntime:
 		return ShellAdapter{Runner: f.Runner}, nil
 	default:
@@ -119,7 +122,7 @@ func ValidateAgent(agent Agent) error {
 	if agent.Runtime == ClaudeRuntime && agent.RuntimeRef != LastRef && !isUUID(agent.RuntimeRef) {
 		return fmt.Errorf("claude runtime reference %q must be a UUID or last", agent.RuntimeRef)
 	}
-	if agent.Runtime == KimiRuntime && agent.RuntimeRef != "" && !isKimiSessionID(agent.RuntimeRef) {
+	if isKimiRuntime(agent.Runtime) && agent.RuntimeRef != "" && !isKimiSessionID(agent.RuntimeRef) {
 		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id or empty", agent.RuntimeRef)
 	}
 	return nil

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -1247,17 +1247,21 @@ func TestCodexCommandError(t *testing.T) {
 	})
 }
 
-func TestValidateAgentAcceptsKimi(t *testing.T) {
-	agent := Agent{Name: "audit", Role: "reviewer", Runtime: KimiRuntime, RuntimeRef: "session_550e8400-e29b-41d4-a716-446655440000", RepoScope: "jerryfane/gitmoot"}
-	if err := ValidateAgent(agent); err != nil {
-		t.Fatalf("ValidateAgent rejected valid Kimi agent: %v", err)
+func TestValidateAgentAcceptsKimiRuntimes(t *testing.T) {
+	for _, runtimeName := range []string{KimiRuntime, KimiCLIRuntime} {
+		agent := Agent{Name: "audit", Role: "reviewer", Runtime: runtimeName, RuntimeRef: "session_550e8400-e29b-41d4-a716-446655440000", RepoScope: "jerryfane/gitmoot"}
+		if err := ValidateAgent(agent); err != nil {
+			t.Fatalf("ValidateAgent rejected valid %s agent: %v", runtimeName, err)
+		}
 	}
 }
 
 func TestValidateAgentRejectsInvalidKimiRef(t *testing.T) {
-	agent := Agent{Name: "audit", Role: "reviewer", Runtime: KimiRuntime, RuntimeRef: "not-a-session", RepoScope: "jerryfane/gitmoot"}
-	if err := ValidateAgent(agent); err == nil {
-		t.Fatal("ValidateAgent accepted invalid Kimi runtime ref")
+	for _, runtimeName := range []string{KimiRuntime, KimiCLIRuntime} {
+		agent := Agent{Name: "audit", Role: "reviewer", Runtime: runtimeName, RuntimeRef: "not-a-session", RepoScope: "jerryfane/gitmoot"}
+		if err := ValidateAgent(agent); err == nil {
+			t.Fatalf("ValidateAgent accepted invalid %s runtime ref", runtimeName)
+		}
 	}
 }
 
@@ -1265,6 +1269,9 @@ func TestKimiAdapterValidateRejectsRuntimeMismatch(t *testing.T) {
 	agent := Agent{Name: "audit", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "session_550e8400-e29b-41d4-a716-446655440000", RepoScope: "jerryfane/gitmoot"}
 	if err := (KimiAdapter{}).Validate(context.Background(), agent); err == nil {
 		t.Fatal("KimiAdapter accepted a Claude agent")
+	}
+	if err := (KimiCLIAdapter{}).Validate(context.Background(), agent); err == nil {
+		t.Fatal("KimiCLIAdapter accepted a Claude agent")
 	}
 }
 
@@ -1358,6 +1365,39 @@ func TestKimiDeliverCommandStartsFreshSession(t *testing.T) {
 	runner.want(t, 0, "kimi", "-p", "review", "--output-format", "stream-json")
 }
 
+func TestKimiDeliverAcceptsArrayContentParts(t *testing.T) {
+	stdout := "{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"prefix\\n```json\\n{\\\"gitmoot_result\\\":{\\\"decision\\\":\\\"approved\\\",\\\"summary\\\":\\\"ok\\\",\\\"findings\\\":[],\\\"changes_made\\\":[],\\\"tests_run\\\":[],\\\"needs\\\":[],\\\"delegations\\\":[]}}\\n```\\n\"}]}\n"
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
+	adapter := KimiAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: KimiRuntime, RuntimeRef: "session_550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot", AutonomyPolicy: AutonomyPolicyReadOnly}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if !strings.Contains(result.Raw, `"gitmoot_result"`) {
+		t.Fatalf("raw output missing gitmoot_result: %q", result.Raw)
+	}
+	runner.want(t, 0, "kimi", "-p", "review", "--output-format", "stream-json")
+}
+
+func TestKimiDeliverDoesNotProbePrintFallback(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "unknown option '--print'"}},
+		errs:    []error{errors.New("exit 1")},
+	}
+	adapter := KimiAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: KimiRuntime, RuntimeRef: "session_550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot", AutonomyPolicy: AutonomyPolicyReadOnly}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err == nil {
+		t.Fatal("Deliver accepted command failure")
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1 (no probe/fallback)", len(runner.calls))
+	}
+	runner.want(t, 0, "kimi", "-p", "review", "--output-format", "stream-json")
+}
+
 func TestKimiDeliverCommandUsesJobModel(t *testing.T) {
 	stdout := `{"role":"assistant","content":"done"}` + "\n"
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
@@ -1441,4 +1481,37 @@ func TestKimiHealthRejectsBrokenSession(t *testing.T) {
 		t.Fatal("Health accepted broken Kimi session")
 	}
 	runner.want(t, 0, "kimi", "-p", KimiLiveCheckPrompt, "--output-format", "stream-json")
+}
+
+func TestKimiCLIStartCommandUsesPrintRuntime(t *testing.T) {
+	stdout := `{"role":"assistant","content":"ready"}` + "\n" +
+		`{"role":"meta","type":"session.resume_hint","session_id":"session_550e8400-e29b-41d4-a716-446655440003"}` + "\n"
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
+	adapter := KimiCLIAdapter{Runner: runner, Dir: "/repo"}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: KimiCLIRuntime, RepoScope: "jerryfane/gitmoot", AutonomyPolicy: AutonomyPolicyReadOnly}
+
+	result, err := adapter.Start(context.Background(), StartRequest{Agent: agent, Prompt: "initialize"})
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	if result.RuntimeRef != "session_550e8400-e29b-41d4-a716-446655440003" {
+		t.Fatalf("runtime ref = %q", result.RuntimeRef)
+	}
+	runner.want(t, 0, "kimi", "--print", "-p", "initialize", "--output-format", "stream-json")
+}
+
+func TestKimiCLIDeliverCommandUsesPrintRuntime(t *testing.T) {
+	stdout := `{"role":"assistant","content":"done"}` + "\n"
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
+	adapter := KimiCLIAdapter{Runner: runner}
+	agent := Agent{Name: "reviewer", Role: "reviewer", Runtime: KimiCLIRuntime, RuntimeRef: "session_550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot", AutonomyPolicy: AutonomyPolicyReadOnly, Model: "agent-default"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review", Model: "opus"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "done" {
+		t.Fatalf("summary = %q", result.Summary)
+	}
+	runner.want(t, 0, "kimi", "--model", "opus", "--print", "-p", "review", "--output-format", "stream-json")
 }

--- a/internal/runtime/kimi.go
+++ b/internal/runtime/kimi.go
@@ -16,9 +16,10 @@ const (
 )
 
 // KimiAdapter delivers Gitmoot jobs to the local Kimi Code CLI.
-// Kimi supports non-interactive prompt mode (`-p`), structured stream-json output,
-// and session resume (`-S <session_id>`). The adapter extracts the assistant
-// response and the session id from the JSONL stream.
+// Kimi Code supports non-interactive prompt mode (`-p`), structured stream-json
+// output, and session resume (`-S <session_id>`). The adapter extracts the
+// assistant response and the session id from the JSONL stream. Keep this runtime
+// print-less: kimi-code does not support `--print`.
 type KimiAdapter struct {
 	Runner        subprocess.Runner
 	Dir           string
@@ -119,25 +120,124 @@ func (a KimiAdapter) newRuntimeRef() (string, error) {
 	return newUUID()
 }
 
+// KimiCLIAdapter delivers jobs to the opt-in legacy Kimi CLI runtime. This
+// runtime is intentionally separate from `kimi`: it uses the older `--print`
+// command shape without probing or changing the default Kimi Code path.
+type KimiCLIAdapter struct {
+	Runner        subprocess.Runner
+	Dir           string
+	NewRuntimeRef func() (string, error)
+}
+
+func (a KimiCLIAdapter) Name() string { return KimiCLIRuntime }
+
+func (a KimiCLIAdapter) Start(ctx context.Context, request StartRequest) (StartResult, error) {
+	if err := validateStartRequest(request.Agent, a.Name(), request.Prompt); err != nil {
+		return StartResult{}, err
+	}
+	runtimeRef, err := a.newRuntimeRef()
+	if err != nil {
+		return StartResult{}, err
+	}
+	args := kimiCLIPromptArgs(request.Agent, request.Agent.Model, request.Prompt)
+	result, err := a.runner().Run(ctx, a.Dir, "kimi", args...)
+	if err != nil {
+		return StartResult{Raw: result.Stdout + result.Stderr}, kimiCommandError(result, err)
+	}
+	content, sessionID, _, parseErr := parseKimiStreamJSON(result.Stdout)
+	if parseErr != nil {
+		return StartResult{Raw: result.Stdout}, fmt.Errorf("parse kimi stream-json output: %w", parseErr)
+	}
+	if sessionID == "" {
+		sessionID = runtimeRef
+	}
+	return StartResult{RuntimeRef: sessionID, Raw: content}, nil
+}
+
+func (a KimiCLIAdapter) Validate(_ context.Context, agent Agent) error {
+	if err := validateRuntime(agent, a.Name()); err != nil {
+		return err
+	}
+	if agent.RuntimeRef != "" && !isKimiSessionID(agent.RuntimeRef) {
+		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id or empty", agent.RuntimeRef)
+	}
+	return nil
+}
+
+func (a KimiCLIAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, error) {
+	if err := a.Validate(ctx, agent); err != nil {
+		return Result{}, err
+	}
+	_ = agent.RuntimeRef
+	result, err := a.runner().Run(ctx, a.Dir, "kimi", kimiCLIPromptArgs(agent, effectiveModel(agent, job), job.Prompt)...)
+	if err != nil {
+		return Result{Raw: result.Stdout + result.Stderr}, kimiCommandError(result, err)
+	}
+	content, _, usage, parseErr := parseKimiStreamJSON(result.Stdout)
+	if parseErr != nil {
+		return Result{Raw: result.Stdout}, fmt.Errorf("parse kimi stream-json output: %w", parseErr)
+	}
+	return Result{Raw: content, Summary: strings.TrimSpace(content), InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens}, nil
+}
+
+func (a KimiCLIAdapter) Health(ctx context.Context, agent Agent) error {
+	if err := a.Validate(ctx, agent); err != nil {
+		return err
+	}
+	_, err := a.Deliver(ctx, agent, Job{Prompt: KimiLiveCheckPrompt})
+	return err
+}
+
+func (a KimiCLIAdapter) Capabilities(context.Context) ([]string, error) {
+	return []string{"review", "implement", "ask"}, nil
+}
+
+func (a KimiCLIAdapter) runner() subprocess.Runner {
+	if a.Runner != nil {
+		return a.Runner
+	}
+	return subprocess.GroupRunner{}
+}
+
+func (a KimiCLIAdapter) newRuntimeRef() (string, error) {
+	if a.NewRuntimeRef != nil {
+		return a.NewRuntimeRef()
+	}
+	return newUUID()
+}
+
+func kimiCLIPromptArgs(agent Agent, model string, prompt string) []string {
+	args := kimiPermissionArgs(agent)
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	return append(args, "--print", "-p", prompt, "--output-format", "stream-json")
+}
+
 func kimiPermissionArgs(agent Agent) []string {
-	// Kimi's `-p` prompt mode already runs non-interactively and auto-approves
-	// tool calls. The --yolo and --auto flags cannot be combined with -p, so we
-	// pass no extra permission flags. Read-only enforcement is handled by the
-	// agent's capabilities and Gitmoot's dispatch/lock logic.
+	// Kimi's prompt mode already runs non-interactively. The --yolo and --auto
+	// flags cannot be combined with -p, so we pass no extra permission flags.
+	// Read-only enforcement is handled by the agent's capabilities and Gitmoot's
+	// dispatch/lock logic.
 	_ = agent
 	return nil
 }
 
 type kimiStreamEvent struct {
-	Role      string `json:"role"`
-	Type      string `json:"type"`
-	Content   string `json:"content"`
-	SessionID string `json:"session_id"`
+	Role      string          `json:"role"`
+	Type      string          `json:"type"`
+	Content   json.RawMessage `json:"content"`
+	SessionID string          `json:"session_id"`
 	// Usage carries best-effort token counts when Kimi's stream emits a usage or
 	// result event (#338 Part B). The field set mirrors the common LLM-CLI shape
 	// (input_tokens/output_tokens). It is nil/zero on events that carry no usage,
 	// so a runtime that never reports usage simply contributes 0 to the budget.
 	Usage *kimiUsage `json:"usage"`
+}
+
+type kimiContentPart struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
 }
 
 // kimiUsage holds the best-effort token counts extracted from a Kimi stream-json
@@ -173,7 +273,9 @@ func parseKimiStreamJSON(output string) (string, string, kimiUsage, error) {
 		}
 		switch event.Role {
 		case "assistant":
-			contentParts = append(contentParts, event.Content)
+			if content := kimiEventContentText(event.Content); content != "" {
+				contentParts = append(contentParts, content)
+			}
 		case "meta":
 			if event.Type == "session.resume_hint" && event.SessionID != "" {
 				sessionID = event.SessionID
@@ -186,8 +288,38 @@ func parseKimiStreamJSON(output string) (string, string, kimiUsage, error) {
 	return strings.Join(contentParts, ""), sessionID, usage, nil
 }
 
+func kimiEventContentText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	var parts []kimiContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, part := range parts {
+		if part.Type == "text" {
+			b.WriteString(part.Text)
+		}
+	}
+	return b.String()
+}
+
 func isKimiSessionID(ref string) bool {
 	return strings.HasPrefix(ref, "session_")
+}
+
+func isKimiRuntime(runtimeName string) bool {
+	switch runtimeName {
+	case KimiRuntime, KimiCLIRuntime:
+		return true
+	default:
+		return false
+	}
 }
 
 func kimiCommandError(result subprocess.Result, err error) error {


### PR DESCRIPTION
## Summary
- keep the default `kimi` runtime on the existing kimi-code command shape: `kimi -p ... --output-format stream-json`
- add a separate opt-in `kimi-cli` runtime for the legacy `--print` CLI variant
- keep structured stream-json parsing/token usage/session handling on the default `kimi` path
- preserve the useful content-part parsing improvement for stream-json assistant content arrays

## Shape after review feedback
This no longer probes `--print` from the default `kimi` runtime and no longer falls back to plain text for common kimi-code installs.

Runtime split:
- `kimi`: current/common kimi-code runtime, no `--print`, keeps `--output-format stream-json`
- `kimi-cli`: opt-in legacy runtime, uses `--print -p ... --output-format stream-json`

## Tests
- `go test ./internal/runtime -run 'TestValidateAgent.*Kimi|TestKimi|TestKimiCLI' -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./internal/cli -run 'TestRunAgent(Start|Subscribe|Type)|TestRuntime|TestRunQueuedJobs|TestAgentRestart|Test.*Kimi|Test.*Admission|Test.*TempWorker' -count=1`
- `go test ./internal/runtime ./internal/cli -count=1`
