### PR TITLE
fix(workflow): add orchestrate delegation timeout defaults

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4170,6 +4170,14 @@ func (w jobWorker) applyOrchestratePolicy(engine *workflow.Engine) {
 	engine.MaxDelegationCostUSD = policy.MaxDelegationCostUSD
 	engine.MaxDelegationNonProgressStreak = policy.MaxDelegationNonProgressStreak
 	engine.MaxVerifyReplanAttempts = policy.MaxVerifyReplanAttempts
+	engine.DelegationTimeoutDefaults = workflow.DelegationTimeoutDefaults{
+		Default:   policy.DefaultDelegationTimeout,
+		Plan:      policy.DefaultPlanTimeout,
+		Implement: policy.DefaultImplementTimeout,
+		Review:    policy.DefaultReviewTimeout,
+		Gate:      policy.DefaultGateTimeout,
+		Repair:    policy.DefaultRepairTimeout,
+	}
 	if notifier, ok := engine.EscalationNotifier.(*daemonEscalationNotifier); ok && notifier != nil {
 		notifier.Handle = policy.EscalationHandle
 	}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -59,6 +59,15 @@ cockpit_pane_key = "job"
 # (Go duration; default 24h). Both optional.
 escalation_handle = ""
 escalation_ttl = ""
+# Optional default timeouts for child delegation jobs. Empty means unbounded,
+# preserving historical behavior. Per-delegation timeout always wins; otherwise
+# phase-specific defaults apply, then default_delegation_timeout, then unbounded.
+default_delegation_timeout = ""
+default_plan_timeout = ""
+default_implement_timeout = ""
+default_review_timeout = ""
+default_gate_timeout = ""
+default_repair_timeout = ""
 
 # [skillopt] is the OFF-BY-DEFAULT template-learning policy (#465 Mode A, #471).
 # With no [skillopt] section behavior is byte-identical: no trace harvesting, no

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -81,6 +81,16 @@ type OrchestratePolicy struct {
 	// default behavior is unchanged. The daemon wires this into
 	// Engine.MaxVerifyReplanAttempts at startup.
 	MaxVerifyReplanAttempts int
+	// Default*Timeout are optional child delegation job timeout defaults. Empty
+	// strings mean unbounded. Explicit per-delegation timeout values win, then the
+	// phase-specific default, then DefaultDelegationTimeout, then unbounded. These
+	// are ordinary orchestrator defaults; they are not tied to an agent name.
+	DefaultDelegationTimeout string
+	DefaultPlanTimeout       string
+	DefaultImplementTimeout  string
+	DefaultReviewTimeout     string
+	DefaultGateTimeout       string
+	DefaultRepairTimeout     string
 }
 
 // DefaultEscalationTTL is the fallback time a paused-for-human tree may sit
@@ -102,6 +112,12 @@ func DefaultOrchestratePolicy() OrchestratePolicy {
 		EscalationTTL:                  "",
 		MaxDelegationNonProgressStreak: 0,
 		MaxVerifyReplanAttempts:        0,
+		DefaultDelegationTimeout:       "",
+		DefaultPlanTimeout:             "",
+		DefaultImplementTimeout:        "",
+		DefaultReviewTimeout:           "",
+		DefaultGateTimeout:             "",
+		DefaultRepairTimeout:           "",
 	}
 }
 
@@ -193,6 +209,30 @@ func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value st
 		parsed, err := strconv.Atoi(value)
 		policy.MaxVerifyReplanAttempts = parsed
 		return err
+	case "default_delegation_timeout":
+		parsed, err := parseConfigString(value)
+		policy.DefaultDelegationTimeout = strings.TrimSpace(parsed)
+		return err
+	case "default_plan_timeout":
+		parsed, err := parseConfigString(value)
+		policy.DefaultPlanTimeout = strings.TrimSpace(parsed)
+		return err
+	case "default_implement_timeout":
+		parsed, err := parseConfigString(value)
+		policy.DefaultImplementTimeout = strings.TrimSpace(parsed)
+		return err
+	case "default_review_timeout":
+		parsed, err := parseConfigString(value)
+		policy.DefaultReviewTimeout = strings.TrimSpace(parsed)
+		return err
+	case "default_gate_timeout":
+		parsed, err := parseConfigString(value)
+		policy.DefaultGateTimeout = strings.TrimSpace(parsed)
+		return err
+	case "default_repair_timeout":
+		parsed, err := parseConfigString(value)
+		policy.DefaultRepairTimeout = strings.TrimSpace(parsed)
+		return err
 	default:
 		return nil
 	}
@@ -232,6 +272,33 @@ func validateOrchestratePolicy(policy OrchestratePolicy) error {
 	}
 	if policy.MaxVerifyReplanAttempts < 0 {
 		return fmt.Errorf("orchestrate.max_verify_replan_attempts must be 0 (engine default) or positive")
+	}
+	for key, value := range map[string]string{
+		"default_delegation_timeout": policy.DefaultDelegationTimeout,
+		"default_plan_timeout":       policy.DefaultPlanTimeout,
+		"default_implement_timeout":  policy.DefaultImplementTimeout,
+		"default_review_timeout":     policy.DefaultReviewTimeout,
+		"default_gate_timeout":       policy.DefaultGateTimeout,
+		"default_repair_timeout":     policy.DefaultRepairTimeout,
+	} {
+		if err := validateOptionalDuration("orchestrate."+key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateOptionalDuration(name string, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return fmt.Errorf("%s %q is invalid: %w", name, value, err)
+	}
+	if parsed <= 0 {
+		return fmt.Errorf("%s must be positive when set", name)
 	}
 	return nil
 }

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -50,6 +50,49 @@ func TestLoadOrchestratePolicyDefaults(t *testing.T) {
 	if policy.MaxVerifyReplanAttempts != 0 {
 		t.Fatalf("MaxVerifyReplanAttempts = %d, want 0 (engine default) by default", policy.MaxVerifyReplanAttempts)
 	}
+	if policy.DefaultDelegationTimeout != "" || policy.DefaultPlanTimeout != "" || policy.DefaultImplementTimeout != "" || policy.DefaultReviewTimeout != "" || policy.DefaultGateTimeout != "" || policy.DefaultRepairTimeout != "" {
+		t.Fatalf("delegation timeout defaults = %+v, want all empty by default", policy)
+	}
+}
+
+func TestLoadOrchestratePolicyDelegationTimeoutDefaults(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+default_delegation_timeout = "45m"
+default_plan_timeout = "15m"
+default_implement_timeout = "75m"
+default_review_timeout = "25m"
+default_gate_timeout = "10m"
+default_repair_timeout = "5m"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+
+	policy, err := LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.DefaultDelegationTimeout != "45m" || policy.DefaultPlanTimeout != "15m" || policy.DefaultImplementTimeout != "75m" || policy.DefaultReviewTimeout != "25m" || policy.DefaultGateTimeout != "10m" || policy.DefaultRepairTimeout != "5m" {
+		t.Fatalf("delegation timeout defaults = %+v", policy)
+	}
+
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+default_review_timeout = ""
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err = LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.DefaultReviewTimeout != "" {
+		t.Fatalf("empty default_review_timeout = %q, want empty/unbounded", policy.DefaultReviewTimeout)
+	}
 }
 
 // TestLoadOrchestratePolicyMaxDelegationNonProgressStreak pins #339: the
@@ -468,6 +511,22 @@ max_verify_replan_attempts = lots
 max_verify_replan_attempts = -1
 `,
 			wantErr: "max_verify_replan_attempts must be 0 (engine default) or positive",
+		},
+		{
+			name: "default_delegation_timeout_invalid",
+			body: `
+[orchestrate]
+default_delegation_timeout = "banana"
+`,
+			wantErr: "orchestrate.default_delegation_timeout",
+		},
+		{
+			name: "default_review_timeout_zero",
+			body: `
+[orchestrate]
+default_review_timeout = "0s"
+`,
+			wantErr: "orchestrate.default_review_timeout must be positive",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -126,6 +126,11 @@ type Engine struct {
 	// left behind by a since-disabled run is never sampled, so it can never serve
 	// traffic without the comparator that would graduate or roll it back.
 	CanaryEnabled bool
+	// DelegationTimeoutDefaults carries optional [orchestrate] default child-job
+	// timeouts. Empty fields mean unbounded. Explicit per-delegation timeout values
+	// still win, so an engine with the zero value is byte-identical to historical
+	// behavior.
+	DelegationTimeoutDefaults DelegationTimeoutDefaults
 	// ArtifactRoot is the filesystem root under which delegation artifacts
 	// (delegations/<parent-job-id>/brief.md and context-manifest.json) are
 	// written when a coordinator returns delegations that request artifacts.
@@ -247,6 +252,54 @@ type Engine struct {
 	// spawns a goroutine; tests inject a synchronous runner so the checker leg is
 	// deterministic. It mirrors ReviewSpawner.
 	CheckerSpawner func(func())
+}
+
+// DelegationTimeoutDefaults are optional fallback timeouts for child delegation
+// jobs. They are intentionally generic orchestration policy, not tied to any
+// particular external coordinator or agent naming convention.
+type DelegationTimeoutDefaults struct {
+	Default   string
+	Plan      string
+	Implement string
+	Review    string
+	Gate      string
+	Repair    string
+}
+
+func (d DelegationTimeoutDefaults) timeoutFor(del Delegation) string {
+	switch strings.ToLower(strings.TrimSpace(del.Phase)) {
+	case "plan":
+		if d.Plan != "" {
+			return d.Plan
+		}
+	case "implement":
+		if d.Implement != "" {
+			return d.Implement
+		}
+	case "review", "review-prep", "review-dispatch":
+		if d.Review != "" {
+			return d.Review
+		}
+	case "gate":
+		if d.Gate != "" {
+			return d.Gate
+		}
+	case "repair", "continue":
+		if d.Repair != "" {
+			return d.Repair
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(del.Action)) {
+	case "implement":
+		if d.Implement != "" {
+			return d.Implement
+		}
+	case "review":
+		if d.Review != "" {
+			return d.Review
+		}
+	}
+	return d.Default
 }
 
 // defaultMaxDelegationNonProgressStreak is the streak threshold used when the
@@ -1495,6 +1548,13 @@ func parseJobTimestamp(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("unrecognized job timestamp %q", s)
 }
 
+func effectiveDelegationTimeout(d Delegation, defaults DelegationTimeoutDefaults) string {
+	if timeout := strings.TrimSpace(d.Timeout); timeout != "" {
+		return timeout
+	}
+	return defaults.timeoutFor(d)
+}
+
 // delegationRequest builds the canonical child JobRequest for a delegation,
 // inheriting the parent's repo/branch/PR context and stamping the DAG fields
 // (ParentJobID/DelegationID/DelegationDepth/DelegatedBy/RootJobID/Deps). It is
@@ -1513,6 +1573,7 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 		agent = ephemeralAgentName(d.ID, job.ID)
 		ephemeral = d.Ephemeral
 	}
+	rootID := e.rootJobID(job, payload)
 	return JobRequest{
 		ID:              job.ID + "/delegation/" + d.ID,
 		Agent:           agent,
@@ -1535,9 +1596,9 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 		DelegationID:    d.ID,
 		DelegationDepth: payload.DelegationDepth + 1,
 		DelegatedBy:     job.Agent,
-		RootJobID:       e.rootJobID(job, payload),
+		RootJobID:       rootID,
 		Deps:            compactStrings(d.Deps),
-		JobTimeout:      strings.TrimSpace(d.Timeout),
+		JobTimeout:      effectiveDelegationTimeout(d, e.DelegationTimeoutDefaults),
 		Fingerprint:     strings.TrimSpace(d.Fingerprint),
 		FailurePolicy:   strings.TrimSpace(d.FailurePolicy),
 		SynthesisRule:   strings.TrimSpace(d.SynthesisRule),

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2745,6 +2745,94 @@ func TestEngineDelegationTimeoutPlumbedToChildPayload(t *testing.T) {
 	}
 }
 
+func TestEngineDelegationDefaultTimeoutsAppliedFromPolicy(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "conductor", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "planner", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "reviewer", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.DelegationTimeoutDefaults = DelegationTimeoutDefaults{
+		Default: "45m",
+		Plan:    "15m",
+		Review:  "20m",
+	}
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "conductor", Type: "ask"}, JobPayload{
+		Repo:   "jerryfane/gitmoot",
+		Branch: "task-005",
+		Sender: "conductor",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "plan", Agent: "planner", Action: "ask", Phase: "plan", Prompt: "plan"},
+				{ID: "review", Agent: "reviewer", Action: "review", Phase: "review", Prompt: "review"},
+				{ID: "fallback", Agent: "planner", Action: "ask", Prompt: "fallback"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	planPayload, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/plan").Payload)
+	if err != nil {
+		t.Fatalf("unmarshal plan payload returned error: %v", err)
+	}
+	if planPayload.JobTimeout != "15m" {
+		t.Fatalf("plan JobTimeout = %q, want 15m", planPayload.JobTimeout)
+	}
+	reviewPayload, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/review").Payload)
+	if err != nil {
+		t.Fatalf("unmarshal review payload returned error: %v", err)
+	}
+	if reviewPayload.JobTimeout != "20m" {
+		t.Fatalf("review JobTimeout = %q, want 20m", reviewPayload.JobTimeout)
+	}
+	fallbackPayload, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/fallback").Payload)
+	if err != nil {
+		t.Fatalf("unmarshal fallback payload returned error: %v", err)
+	}
+	if fallbackPayload.JobTimeout != "45m" {
+		t.Fatalf("fallback JobTimeout = %q, want 45m", fallbackPayload.JobTimeout)
+	}
+}
+
+func TestEngineDelegationWithoutTimeoutDefaultStaysUnbounded(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "helper", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "parent-job", Agent: "audit", Type: "ask"}, JobPayload{
+		Repo:   "jerryfane/gitmoot",
+		Branch: "task-005",
+		Sender: "audit",
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "done",
+			Delegations: []Delegation{
+				{ID: "del-1", Agent: "helper", Action: "review", Prompt: "review this"},
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "parent-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	payload, err := unmarshalPayload(mustJob(t, store, "parent-job/delegation/del-1").Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.JobTimeout != "" {
+		t.Fatalf("non-council child JobTimeout = %q, want empty", payload.JobTimeout)
+	}
+}
+
 func TestEngineDelegationModelPlumbedToChildPayload(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)


### PR DESCRIPTION
## Summary
- replace the earlier council-name based timeout detection with ordinary `[orchestrate]` delegation timeout defaults
- keep all defaults empty/unset, so existing behavior remains unbounded unless an operator opts in
- apply precedence as: explicit per-delegation `timeout` -> phase-specific config default -> `default_delegation_timeout` -> unbounded

## Config keys
```toml
[orchestrate]
default_delegation_timeout = ""
default_plan_timeout = ""
default_implement_timeout = ""
default_review_timeout = ""
default_gate_timeout = ""
default_repair_timeout = ""
```

## Notes
- removes all `council-lead` / agent-name / job-id substring matching from the engine
- no `GITMOOT_COUNCIL_*` environment fallback remains in core workflow code
- this is a generic orchestration feature rather than a council-specific behavior
- explicit delegation timeouts still win exactly as before

## Tests
- `go test ./internal/config ./internal/workflow -count=1`
- `go test ./internal/cli -run 'Test.*Orchestrate|Test.*DelegationTimeout|TestRunQueuedJobs|TestEffectiveJobTimeout|TestRunOrchestrate' -count=1`
- `go test ./internal/config ./internal/workflow ./internal/cli -run 'TestLoadOrchestratePolicy|TestEngineDelegation|TestEngineDelegationDefault|TestEngineDelegationWithout|TestEngineDelegationTimeout|TestRunQueuedJobs|TestEffectiveJobTimeout|TestRunOrchestrate|Test.*Orchestrate|Test.*DelegationTimeout' -count=1`
