### PR TITLE
fix(daemon): guard daemon run against a second live daemon (#550)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -229,6 +229,19 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
+	// Singleton guard (#550). `daemon run` is the inner worker that `daemon start`
+	// execs, but it is ALSO a public command and the ExecStart of `systemd --user`
+	// units, so a stray `daemon run` could previously coexist silently with the
+	// managed daemon: two daemons polling the same repos and racing on the same
+	// WAL'd SQLite store, with the newcomer clobbering daemon.json so the prior one
+	// ran untracked for days. `daemon start` already refuses when a live daemon is
+	// registered; extend the SAME check to `daemon run` so the second one refuses
+	// up front instead of entering its loop. The check must run BEFORE the deferred
+	// self-registration so a refused run never touches the existing daemon's state.
+	if code := guardDaemonRunSingleton(*home, stderr); code != 0 {
+		return code
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -871,6 +884,40 @@ func withDaemonBoolFlagArg(args []string, name string, enabled bool) []string {
 		return append(cleaned, flagName)
 	}
 	return cleaned
+}
+
+// guardDaemonRunSingleton refuses to start a second daemon against the same home
+// (#550). It reuses currentDaemonPID — the exact liveness check `daemon start`
+// uses and the #505 definition of "running": an owner-pid that is alive AND whose
+// /proc cmdline still matches the recorded daemon meta (processLooksLikeDaemon).
+// Reusing that check is what makes this correct at the right depth:
+//   - a STALE pidfile from a dead (or non-daemon) pid is treated as not-running,
+//     so it is silently cleared and never blocks a fresh start; and
+//   - a genuinely live registered daemon is detected and the new run refuses.
+//
+// A recorded pid equal to our own is never a conflict: when `daemon start` forks
+// the detached child it writes the pidfile with the CHILD's pid, so the child's
+// own `daemon run` guard sees itself and proceeds (the healthy start path).
+//
+// Returns 0 to proceed, or a non-zero exit code (with a clear message on stderr)
+// to refuse.
+func guardDaemonRunSingleton(home string, stderr io.Writer) int {
+	paths, err := initializedPaths(home)
+	if err != nil {
+		fmt.Fprintf(stderr, "daemon run: %v\n", err)
+		return 1
+	}
+	state := daemonProcessState(paths)
+	pid, _, err := currentDaemonPID(state)
+	if err != nil {
+		fmt.Fprintf(stderr, "daemon run: %v\n", err)
+		return 1
+	}
+	if pid > 0 && pid != os.Getpid() {
+		fmt.Fprintf(stderr, "daemon already running with pid %d\n", pid)
+		return 1
+	}
+	return 0
 }
 
 func currentDaemonPID(state daemonState) (pid int, stale bool, err error) {

--- a/internal/cli/daemon_singleton_test.go
+++ b/internal/cli/daemon_singleton_test.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+)
+
+// spawnFakeDaemon starts a real, long-lived child process and records it in the
+// daemon meta/pid files so it passes the SAME liveness check the singleton guard
+// uses (currentDaemonPID -> processLooksLikeDaemon: a live pid whose /proc
+// cmdline matches the recorded executable+args). We exec `sleep` with an explicit
+// argv[0] of "sleep" so /proc/<pid>/cmdline == {"sleep", "<dur>"} matches the
+// meta we write. The child is killed on test cleanup.
+func spawnFakeDaemon(t *testing.T, state daemonState) (pid int) {
+	t.Helper()
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("sleep not available: %v", err)
+	}
+	cmd := &exec.Cmd{Path: sleepPath, Args: []string{"sleep", "120"}}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	pid = cmd.Process.Pid
+	meta := daemonMeta{
+		PID:        pid,
+		StartedAt:  time.Now().UTC().Format(time.RFC3339),
+		Args:       []string{"120"},
+		LogFile:    state.LogFile,
+		Executable: "sleep",
+	}
+	if err := writeDaemonState(state, meta); err != nil {
+		t.Fatalf("writeDaemonState: %v", err)
+	}
+	// Sanity: the recorded process must register as a live daemon.
+	if got, stale, err := currentDaemonPID(state); err != nil || got != pid || stale {
+		t.Fatalf("fake daemon not seen as live: pid=%d stale=%v err=%v want pid=%d", got, stale, err, pid)
+	}
+	return pid
+}
+
+// TestGuardDaemonRunSingleton is the #550 regression: `daemon run` must refuse to
+// start a SECOND daemon on a home that already has a LIVE registered daemon, while
+// a stale pidfile from a dead daemon (and a clean home) must NOT block a fresh
+// start. Before the fix `daemon run` had no singleton guard at all — it would
+// enter its loop regardless, racing the existing daemon on the shared SQLite store
+// and clobbering daemon.json so the prior daemon ran untracked.
+func TestGuardDaemonRunSingleton(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, state daemonState)
+		wantCode int
+		wantErr  string
+	}{
+		{
+			name:     "clean home allows start",
+			setup:    func(t *testing.T, state daemonState) {},
+			wantCode: 0,
+		},
+		{
+			name: "stale pidfile from dead daemon allows start",
+			setup: func(t *testing.T, state daemonState) {
+				// A pid that is guaranteed not running: spawn `true`, reap it.
+				cmd := exec.Command("true")
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("run true: %v", err)
+				}
+				deadPID := cmd.Process.Pid
+				if err := os.WriteFile(state.PIDFile, []byte(strconv.Itoa(deadPID)+"\n"), 0o600); err != nil {
+					t.Fatalf("write stale pidfile: %v", err)
+				}
+			},
+			wantCode: 0,
+		},
+		{
+			name: "live registered daemon refuses start",
+			setup: func(t *testing.T, state daemonState) {
+				spawnFakeDaemon(t, state)
+			},
+			wantCode: 1,
+			wantErr:  "daemon already running with pid",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			home := t.TempDir()
+			paths := config.PathsForHome(home)
+			if err := config.Initialize(paths); err != nil {
+				t.Fatalf("Initialize: %v", err)
+			}
+			state := daemonProcessState(paths)
+			tt.setup(t, state)
+
+			var stderr bytes.Buffer
+			code := guardDaemonRunSingleton(home, &stderr)
+			if code != tt.wantCode {
+				t.Fatalf("guardDaemonRunSingleton code = %d, want %d (stderr=%q)", code, tt.wantCode, stderr.String())
+			}
+			if tt.wantErr != "" && !strings.Contains(stderr.String(), tt.wantErr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tt.wantErr)
+			}
+
+			// The stale-pidfile case must also have been cleared, so a fresh start
+			// is unobstructed (currentDaemonPID reports not-running).
+			if tt.name == "stale pidfile from dead daemon allows start" {
+				if pid, _, err := currentDaemonPID(state); err != nil || pid != 0 {
+					t.Fatalf("stale pidfile not cleared: pid=%d err=%v", pid, err)
+				}
+			}
+		})
+	}
+}
+
+// TestDaemonRunCommandRefusesSecondDaemon binds the regression to the real command
+// surface: with a live daemon already registered, `gitmoot daemon run` must return
+// promptly with a non-zero exit and a clear message instead of entering its
+// supervisor loop. Without the guard this call would block forever (the loop), so
+// the test would time out — exactly the #550 behavior we are preventing.
+func TestDaemonRunCommandRefusesSecondDaemon(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	state := daemonProcessState(paths)
+	livePID := spawnFakeDaemon(t, state)
+
+	type result struct {
+		code   int
+		stderr string
+	}
+	done := make(chan result, 1)
+	go func() {
+		var stdout, stderr bytes.Buffer
+		code := Run([]string{"daemon", "run", "--home", home}, &stdout, &stderr)
+		done <- result{code: code, stderr: stderr.String()}
+	}()
+
+	select {
+	case res := <-done:
+		if res.code == 0 {
+			t.Fatalf("daemon run exit = 0, want non-zero refusal (stderr=%q)", res.stderr)
+		}
+		if !strings.Contains(res.stderr, "daemon already running with pid "+strconv.Itoa(livePID)) {
+			t.Fatalf("stderr = %q, want 'daemon already running with pid %d'", res.stderr, livePID)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatalf("daemon run did not refuse and is blocking (missing singleton guard)")
+	}
+}


### PR DESCRIPTION
## Root cause

`daemon run` is the inner foreground worker that `daemon start` execs, but it is also a public command and the ExecStart of `systemd --user` units. The singleton liveness guard lived **only** on the `daemon start` path (`currentDaemonPID` at `internal/cli/daemon.go`), so:

- Running `gitmoot daemon run …` directly bypassed the guard entirely.
- Two `run` invocations could coexist with no error — two daemons polling the same repos and racing on the same WAL'd SQLite store (cross-process `fcntl` lock contention, doubled `gh` load).
- A new daemon's startup self-registration (`registerDaemonRunState`) detected the existing live daemon but only returned `ok=false` and **kept running anyway**, clobbering `daemon.json`/`daemon.pid` so the prior daemon ran untracked (observed: an orphan alive ~2.9 days, invisible to gitmoot).

## Fix (and why it's at the right depth)

Extend the **same** check `daemon start` already uses to `daemon run`, via a small `guardDaemonRunSingleton(home, stderr)` that reuses `currentDaemonPID` — the #505 definition of "running": a live owner pid whose `/proc` cmdline still matches the recorded daemon meta (`processLooksLikeDaemon`). This is a generalization of the existing mechanism, not a special-case band-aid:

- A **stale** pidfile from a dead (or non-daemon) pid is treated as not-running, cleared, and never blocks a fresh start.
- A genuinely **live** registered daemon is detected and the second `daemon run` refuses up front (`daemon already running with pid N`, non-zero exit) before it enters its loop or touches the existing daemon's state.
- The check runs **before** the deferred self-registration and treats our own pid as non-conflicting, so the `daemon start` → detached self-registering child path is fully preserved.

## Regression test

`internal/cli/daemon_singleton_test.go` (real temp Store/home, race-safe):

- `TestGuardDaemonRunSingleton` — table-driven: clean home allows start; stale dead-pid pidfile allows start (and is cleared); a real live stand-in process recorded in the meta (passes the liveness check exactly as a real daemon would) makes the guard refuse.
- `TestDaemonRunCommandRefusesSecondDaemon` — drives the real `gitmoot daemon run` command surface: with a live daemon registered it must return promptly with a non-zero refusal instead of entering its supervisor loop. **Without the guard wiring this test blocks and times out** (verified by reverting the wiring).

Full gate green: `go build`, `go vet`, `go test ./...`, and `-race` on `internal/daemon`, `internal/workflow`, `internal/db`. The touched `internal/cli` daemon tests pass under `-race -count=3` (full `internal/cli -race` is ~11min and runs in CI).

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)
