### PR TITLE
fix(daemon): bound the delegation-worktree reclaim scan (#549)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1856,24 +1856,35 @@ func (w jobWorker) delegationWorktreeCleanupPending(ctx context.Context, jobID s
 // owner's lock releases or its lease expires (recoverExpiredRuntimeSessionLocks
 // runs earlier in the tick), the preserved worktree+branch are reclaimed rather
 // than leaked forever.
+//
+// It is BOUNDED, not a full-table scan (#549): rather than list every job and
+// re-read each terminal job's full event history (ListJobEvents) on every 1s
+// supervisor tick — O(jobs × events), which burned a core once a few hundred
+// terminal jobs had accumulated — it asks the store for ONLY the (small) set of
+// jobs whose latest cleanup outcome is still an unreconciled preserve marker, and
+// reads just those. Correctness is unchanged: a worktree that genuinely needs
+// reclaiming still carries that marker and is still reclaimed; once reclaimed it
+// emits delegation_worktree_removed and drops out of the candidate set.
 func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string) error {
-	jobs, err := worker.Store.ListJobs(ctx)
+	jobIDs, err := worker.Store.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
 	if err != nil {
 		return err
 	}
-	for _, job := range jobs {
-		if !jobStateCanRetryAdvancement(job.State) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
+	for _, jobID := range jobIDs {
+		job, err := worker.Store.GetJob(ctx, jobID)
+		if errors.Is(err, sql.ErrNoRows) {
+			// A cleanup-marker event with no surviving job row (e.g. a pruned job):
+			// nothing to reclaim, and erroring here would abort the whole tick.
 			continue
 		}
-		pending, err := worker.delegationWorktreeCleanupPending(ctx, job.ID)
 		if err != nil {
 			return err
 		}
-		if !pending {
+		if !jobStateCanRetryAdvancement(job.State) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}
 		engine := worker.WorkflowFactory(worker.delegationParentCheckout(ctx, job))
-		if err := engine.ReclaimTerminalDelegationWorktree(ctx, job.ID); err != nil {
+		if err := engine.ReclaimTerminalDelegationWorktree(ctx, jobID); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -5105,6 +5106,93 @@ func TestReclaimSkippedDelegationWorktrees(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestReclaimSkippedDelegationWorktreesBoundedToMarkedJobs is the #549 wiring
+// guard: the reclaim pass must source its candidates from the store's bounded
+// pending-marker query, so a large backlog of terminal jobs WITHOUT a preserve
+// marker (the ~95% steady-state majority) is never event-scanned and never
+// touched — only the one genuinely-pending child is reclaimed. The fix replaced
+// ListJobs + per-job ListJobEvents (O(jobs × events) every 1s tick) with
+// JobIDsWithPendingDelegationWorktreeReclaim + a per-candidate GetJob.
+func TestReclaimSkippedDelegationWorktreesBoundedToMarkedJobs(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+
+	// A large backlog of terminal jobs with rich, immutable event history but NO
+	// cleanup marker. These must stay out of the candidate set entirely.
+	for i := 0; i < 50; i++ {
+		id := "terminal-no-marker-" + strconv.Itoa(i)
+		if err := store.CreateJobWithEvent(ctx, db.Job{
+			ID: id, Agent: "producer", Type: "implement", State: string(workflow.JobSucceeded),
+		}, db.JobEvent{Kind: string(workflow.JobSucceeded), Message: "seed"}); err != nil {
+			t.Fatalf("CreateJobWithEvent(%s) returned error: %v", id, err)
+		}
+		for _, kind := range []string{"queued", "running", "advance_succeeded"} {
+			if err := store.AddJobEvent(ctx, db.JobEvent{JobID: id, Kind: kind, Message: "noise"}); err != nil {
+				t.Fatalf("AddJobEvent returned error: %v", err)
+			}
+		}
+	}
+	// A job whose preserve was already reconciled (skip then removed): not pending.
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: "reconciled", Agent: "producer", Type: "implement", State: string(workflow.JobFailed),
+	}, db.JobEvent{Kind: string(workflow.JobFailed), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(reconciled) returned error: %v", err)
+	}
+	for _, kind := range []string{"delegation_worktree_cleanup_skipped", "delegation_worktree_removed"} {
+		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "reconciled", Kind: kind, Message: "m"}); err != nil {
+			t.Fatalf("AddJobEvent returned error: %v", err)
+		}
+	}
+
+	// The one genuinely-pending delegation child.
+	branch := "gitmoot-delegation-x-d1"
+	wt := t.TempDir()
+	pendingID := "parent/delegation/d1"
+	payload := workflow.JobPayload{
+		Repo: "owner/repo", DelegationID: "d1", WorktreePath: wt, Branch: branch,
+		Result: &workflow.AgentResult{Decision: "failed"},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal payload returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: pendingID, Agent: "producer", Type: "implement", State: string(workflow.JobFailed),
+		ParentJobID: "parent", DelegationID: "d1", Payload: string(encoded),
+	}, db.JobEvent{Kind: string(workflow.JobFailed), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(pending) returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: pendingID, Kind: "delegation_worktree_cleanup_skipped", Message: "preserved"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+
+	manager := &fakeReclaimWorktreeManager{branches: map[string]bool{branch: true}}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{
+			Store:               store,
+			DelegationCheckout:  t.TempDir(),
+			DelegationWorktrees: manager,
+			OwnerPIDLive:        func(int64) bool { return false },
+		}
+	}
+
+	if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", ""); err != nil {
+		t.Fatalf("reclaimSkippedDelegationWorktrees returned error: %v", err)
+	}
+
+	if len(manager.removed) != 1 || manager.removed[0] != wt {
+		t.Fatalf("only the marked pending worktree must be reclaimed: removed=%+v", manager.removed)
+	}
+	pending, err := worker.delegationWorktreeCleanupPending(ctx, pendingID)
+	if err != nil {
+		t.Fatalf("delegationWorktreeCleanupPending returned error: %v", err)
+	}
+	if pending {
+		t.Fatalf("cleanup pending must clear after reclaim")
 	}
 }
 

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -128,6 +128,15 @@ CREATE TABLE agent_template_versions (
 	version INTEGER NOT NULL,
 	state TEXT NOT NULL
 );
+-- job_events as it existed at an earlier (here pre-seeded-as-applied) migration,
+-- so the #549 job_events index migration that runs in this pass has its table.
+CREATE TABLE job_events (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	job_id TEXT NOT NULL,
+	kind TEXT NOT NULL,
+	message TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
 INSERT INTO jobs(id, agent, type, state, payload) VALUES ('old', 'w', 'ask', 'succeeded', '{}');
 `); err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2763,6 +2763,49 @@ func (s *Store) JobIDsWithEventKind(ctx context.Context, kind string) (map[strin
 	return out, rows.Err()
 }
 
+// JobIDsWithPendingDelegationWorktreeReclaim returns the IDs of jobs whose most
+// recent terminal delegation-worktree cleanup outcome was a PRESERVE
+// (delegation_worktree_cleanup_skipped) NOT yet followed by a removal
+// (delegation_worktree_removed) — i.e. their per-delegation worktree and
+// gitmoot-delegation-* branch are still on disk awaiting reclaim (#536/#549).
+//
+// This is a single indexed query so the daemon's reclaim pass can iterate only
+// the (small) set of jobs that genuinely carry an unreconciled preserve marker,
+// instead of listing EVERY terminal job and re-reading each one's FULL event
+// history (ListJobEvents) on every 1s supervisor tick — which was O(jobs ×
+// events) and burned a core once a few hundred terminal jobs had accumulated.
+//
+// The order of the two cleanup-outcome kinds matters (a worktree can be
+// preserved, then later removed), so the LAST one wins: a job is "pending" iff
+// the highest-id event among the two kinds is a skip. The MAX(id) subquery picks
+// that latest outcome per job and the outer filter keeps only the jobs where it
+// is a skip — exactly mirroring the per-job lastCleanupOutcomeIsSkip walk, but
+// set-at-once.
+func (s *Store) JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT job_id FROM job_events
+		WHERE kind = 'delegation_worktree_cleanup_skipped'
+		  AND id IN (
+			SELECT MAX(id) FROM job_events
+			WHERE kind IN ('delegation_worktree_cleanup_skipped', 'delegation_worktree_removed')
+			GROUP BY job_id
+		)
+		ORDER BY job_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobIDs []string
+	for rows.Next() {
+		var jobID string
+		if err := rows.Scan(&jobID); err != nil {
+			return nil, err
+		}
+		jobIDs = append(jobIDs, jobID)
+	}
+	return jobIDs, rows.Err()
+}
+
 func (s *Store) UpsertEvalArtifact(ctx context.Context, artifact EvalArtifact) error {
 	artifact, err := normalizeEvalArtifact(artifact)
 	if err != nil {
@@ -6400,5 +6443,16 @@ ALTER TABLE agent_template_versions ADD COLUMN canary_sample REAL NOT NULL DEFAU
 ALTER TABLE agent_template_versions ADD COLUMN canary_started_at TEXT NOT NULL DEFAULT '';
 
 CREATE INDEX idx_atv_canary ON agent_template_versions(template_id) WHERE state = 'canary';
+	`,
+	// #549: index job_events so per-job and per-kind lookups stop full-scanning
+	// the table. job_events had NO index, so every ListJobEvents(jobID) (one per
+	// job in several daemon passes) and the cleanup-marker queries scanned the
+	// whole table. idx_job_events_job_id covers the WHERE job_id=? ORDER BY id
+	// read; idx_job_events_kind covers the kind-filtered marker queries
+	// (JobIDsWithEventKind / JobIDsWithPendingDelegationWorktreeReclaim). Both are
+	// pure additive indexes — no row reads differently, only faster.
+	`
+CREATE INDEX idx_job_events_job_id ON job_events(job_id);
+CREATE INDEX idx_job_events_kind ON job_events(kind);
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3848,3 +3848,138 @@ func TestGetOrCreateWorkspaceForRootConcurrent(t *testing.T) {
 		t.Fatalf("post-race bound id = %q, want %q", final, winner)
 	}
 }
+
+// TestJobIDsWithPendingDelegationWorktreeReclaim is the #549 regression guard:
+// the daemon's reclaim pass must find the (small) set of jobs whose latest
+// delegation-worktree cleanup outcome is still an unreconciled PRESERVE marker
+// via ONE bounded query, instead of listing every job and re-reading each
+// terminal job's full event history every tick (O(jobs × events)). It asserts
+// the marker bookkeeping (skip vs removed, last-one-wins) end-to-end against a
+// real temp Store, and that jobs with no marker — the ~95% terminal majority —
+// never enter the candidate set regardless of how much OTHER event history they
+// carry.
+func TestJobIDsWithPendingDelegationWorktreeReclaim(t *testing.T) {
+	const (
+		skipKind   = "delegation_worktree_cleanup_skipped"
+		removeKind = "delegation_worktree_removed"
+	)
+	cases := []struct {
+		name        string
+		events      []string // in insertion order
+		wantPending bool
+	}{
+		{name: "no events", events: nil, wantPending: false},
+		{name: "unrelated events only", events: []string{"queued", "running", "succeeded"}, wantPending: false},
+		{name: "preserve marker pending", events: []string{"failed", skipKind}, wantPending: true},
+		{name: "preserve then removed reconciled", events: []string{skipKind, removeKind}, wantPending: false},
+		{name: "removed only not pending", events: []string{removeKind}, wantPending: false},
+		{name: "preserve removed preserve last wins", events: []string{skipKind, removeKind, skipKind}, wantPending: true},
+		{name: "removed after preserve with trailing noise", events: []string{skipKind, removeKind, "succeeded"}, wantPending: false},
+		{name: "preserve with trailing noise still pending", events: []string{skipKind, "succeeded"}, wantPending: true},
+	}
+
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	want := map[string]bool{}
+	for i, tc := range cases {
+		jobID := "job-" + tc.name + "-" + string(rune('a'+i))
+		if err := store.CreateJob(ctx, Job{ID: jobID, Agent: "producer", Type: "implement", State: string("failed")}); err != nil {
+			t.Fatalf("CreateJob(%s) returned error: %v", jobID, err)
+		}
+		for _, kind := range tc.events {
+			if err := store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: kind, Message: "m"}); err != nil {
+				t.Fatalf("AddJobEvent(%s, %s) returned error: %v", jobID, kind, err)
+			}
+		}
+		if tc.wantPending {
+			want[jobID] = true
+		}
+	}
+
+	got, err := store.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithPendingDelegationWorktreeReclaim returned error: %v", err)
+	}
+	gotSet := map[string]bool{}
+	for _, id := range got {
+		if gotSet[id] {
+			t.Fatalf("duplicate job id %q in result %v", id, got)
+		}
+		gotSet[id] = true
+	}
+	if len(gotSet) != len(want) {
+		t.Fatalf("pending set = %v, want exactly %v", got, want)
+	}
+	for id := range want {
+		if !gotSet[id] {
+			t.Fatalf("expected job %q in pending set, got %v", id, got)
+		}
+	}
+}
+
+// TestJobIDsWithPendingDelegationWorktreeReclaimRaceSafe exercises the bounded
+// reclaim query concurrently with writers that emit and reconcile markers, the
+// way the daemon supervisor tick reads while RunJob/ReclaimTerminalDelegationWorktree
+// write. It must never error or deadlock under -race.
+func TestJobIDsWithPendingDelegationWorktreeReclaimRaceSafe(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	const n = 12
+	for i := 0; i < n; i++ {
+		jobID := "race-job-" + string(rune('a'+i))
+		if err := store.CreateJob(ctx, Job{ID: jobID, Agent: "producer", Type: "implement", State: "failed"}); err != nil {
+			t.Fatalf("CreateJob returned error: %v", err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			jobID := "race-job-" + string(rune('a'+i))
+			_ = store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_skipped", Message: "preserve"})
+			if i%2 == 0 {
+				_ = store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: "removed"})
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			if _, err := store.JobIDsWithPendingDelegationWorktreeReclaim(ctx); err != nil {
+				t.Errorf("concurrent JobIDsWithPendingDelegationWorktreeReclaim returned error: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	// Final steady state: odd-indexed jobs kept their preserve marker (pending),
+	// even-indexed jobs reconciled with a removal (not pending).
+	got, err := store.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithPendingDelegationWorktreeReclaim returned error: %v", err)
+	}
+	gotSet := map[string]bool{}
+	for _, id := range got {
+		gotSet[id] = true
+	}
+	for i := 0; i < n; i++ {
+		jobID := "race-job-" + string(rune('a'+i))
+		wantPending := i%2 == 1
+		if gotSet[jobID] != wantPending {
+			t.Fatalf("job %s pending=%v, want %v (set=%v)", jobID, gotSet[jobID], wantPending, got)
+		}
+	}
+}


### PR DESCRIPTION
## Root cause

The supervisor worker tick runs every 1s. Its `reclaimSkippedDelegationWorktrees` pass listed **every** job (`store.ListJobs`), filtered to terminal ones, and re-read each one's **full event history** (`ListJobEvents`) just to find an unreconciled `delegation_worktree_cleanup_skipped` marker — i.e. O(jobs × events) per tick. With a few hundred mostly-terminal, immutable jobs (~95% of the table per #549) this re-scanned finished work that will never change, every second, under the single SQLite write mutex — burning a full CPU core. `job_events` also had **no index**, so every per-job `ListJobEvents` was itself a full-table scan.

This is exactly the scan the #536 review flagged (`reclaimSkippedDelegationWorktrees` / `delegationWorktreeCleanupPending`).

## Fix (right depth)

Generalize the lookup instead of special-casing it: add one bounded store query, `JobIDsWithPendingDelegationWorktreeReclaim`, that returns **only** the jobs whose latest cleanup outcome is still a preserve marker. It applies the same last-one-wins rule as the per-job `lastCleanupOutcomeIsSkip` (the `MAX(id)` among the skip/removed kinds must be a skip) — evaluated set-at-once in SQL, mirroring the existing `JobIDsWithEventKind` / `LatestJobEvents` patterns.

`reclaimSkippedDelegationWorktrees` now iterates just that small candidate set and `GetJob`s each, instead of listing + event-scanning every job. Indexes on `job_events(job_id)` and `job_events(kind)` make this query (and every other `ListJobEvents` read) indexed rather than a full scan.

Correctness preserved: a worktree that genuinely needs reclaiming still carries the marker and is still reclaimed; once reclaimed it emits `delegation_worktree_removed` and drops out of the set. A marker event whose job row was pruned is skipped rather than aborting the tick. Existing `TestReclaimSkippedDelegationWorktrees` (the #536 leak guard) stays green.

## Regression tests (table-driven, real temp Store, race-safe)

- `TestJobIDsWithPendingDelegationWorktreeReclaim` — covers the marker bookkeeping (skip / removed / last-wins / no-marker jobs excluded). **Fails to compile (= fails) without the new bounded query; passes with it** (verified by stashing the fix).
- `TestJobIDsWithPendingDelegationWorktreeReclaimRaceSafe` — reads the query concurrently with marker writers under `-race`.
- `TestReclaimSkippedDelegationWorktreesBoundedToMarkedJobs` — seeds a large backlog of terminal no-marker jobs plus a reconciled one and asserts only the single genuinely-pending child is reclaimed.

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)