### PR TITLE
fix(daemon): keep wedged jobs from stalling workers

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1236,7 +1236,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			if err := recoverCancelledRunningJobsForEnabledRepos(ctx, store, rootFilter, stdout); err != nil {
 				return err
 			}
-			workerErr = startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
+			workerErr = startSupervisorWorkerLoopRecovering(ctx, daemonWorkerLoopInterval, stdout, func(now time.Time) error {
 				return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, rootFilter, stdout, now, checkoutLocks)
 			})
 			startCockpitReconcileLoop(ctx, store, paths.Home, stdout)
@@ -1298,7 +1298,7 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 	worker.UsePool = usePool
 	worker.Admission = worker.loadAdmissionBudget()
 	var checkoutLock sync.Mutex
-	workerErr := startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
+	workerErr := startSupervisorWorkerLoopRecovering(ctx, daemonWorkerLoopInterval, stdout, func(now time.Time) error {
 		checkoutLock.Lock()
 		defer checkoutLock.Unlock()
 		return runDaemonWorkerTick(ctx, store, worker, workers, false, d.Repo.FullName(), rootFilter, stdout, now)
@@ -1321,10 +1321,10 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 			return err
 		}
 		if checkoutLock.TryLock() {
-			_ = d.PollOnce(ctx)
+			_ = runDaemonPollWithTimeout(ctx, daemonRunningJobStaleAfter, d.PollOnce)
 			checkoutLock.Unlock()
 		} else {
-			_ = d.PollRecoveryCommandsOnce(ctx)
+			_ = runDaemonPollWithTimeout(ctx, daemonRunningJobStaleAfter, d.PollRecoveryCommandsOnce)
 		}
 		if heartbeatPathsErr == nil {
 			if err := runHeartbeatScanOnce(ctx, heartbeatPaths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
@@ -1524,6 +1524,14 @@ func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqu
 }
 
 func startSupervisorWorkerLoop(ctx context.Context, interval time.Duration, run func(time.Time) error) <-chan error {
+	return startSupervisorWorkerLoopInternal(ctx, interval, nil, run, false)
+}
+
+func startSupervisorWorkerLoopRecovering(ctx context.Context, interval time.Duration, stdout io.Writer, run func(time.Time) error) <-chan error {
+	return startSupervisorWorkerLoopInternal(ctx, interval, stdout, run, true)
+}
+
+func startSupervisorWorkerLoopInternal(ctx context.Context, interval time.Duration, stdout io.Writer, run func(time.Time) error, recoverErrors bool) <-chan error {
 	errCh := make(chan error, 1)
 	if interval <= 0 {
 		interval = daemonWorkerLoopInterval
@@ -1535,19 +1543,33 @@ func startSupervisorWorkerLoop(ctx context.Context, interval time.Duration, run 
 				return
 			}
 			if err := run(time.Now().UTC()); err != nil {
+				if recoverErrors {
+					writeLine(stdout, "daemon worker tick error: %v; retrying", err)
+					if sleepErr := sleepSupervisorWorkerLoop(ctx, interval); sleepErr != nil {
+						return
+					}
+					continue
+				}
 				errCh <- err
 				return
 			}
-			timer := time.NewTimer(interval)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
+			if err := sleepSupervisorWorkerLoop(ctx, interval); err != nil {
 				return
-			case <-timer.C:
 			}
 		}
 	}()
 	return errCh
+}
+
+func sleepSupervisorWorkerLoop(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func receiveSupervisorWorkerError(errCh <-chan error) error {
@@ -1952,6 +1974,15 @@ func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, std
 		writeLine(stdout, "recovered %d expired runtime session locks", deleted)
 	}
 	return nil
+}
+
+func runDaemonPollWithTimeout(ctx context.Context, timeout time.Duration, poll func(context.Context) error) error {
+	if timeout <= 0 {
+		return poll(ctx)
+	}
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return poll(pollCtx)
 }
 
 func recoverRunningJobsBefore(ctx context.Context, store *db.Store, stdout io.Writer, before time.Time) error {
@@ -4158,14 +4189,17 @@ func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (mana
 
 // effectiveJobTimeout returns the timeout to enforce for a job: the
 // per-delegation payload.JobTimeout when it parses to a positive duration,
-// otherwise the agent-type managed.JobTimeout (which is zero when the agent is
-// not managed). The same value drives both the runtime-session lock TTL and the
-// run context deadline so the lock cannot expire before the job does.
+// otherwise the agent-type managed.JobTimeout, otherwise the daemon stale window
+// for unmanaged jobs. The same value drives both the runtime-session lock TTL and
+// the run context deadline so a job cannot outlive the lease that guards it.
 func effectiveJobTimeout(payload workflow.JobPayload, managed managedJobRuntimeConfig) time.Duration {
 	if d, err := time.ParseDuration(strings.TrimSpace(payload.JobTimeout)); err == nil && d > 0 {
 		return d
 	}
-	return managed.JobTimeout
+	if managed.JobTimeout > 0 {
+		return managed.JobTimeout
+	}
+	return daemonRunningJobStaleAfter
 }
 
 func originalAgentForTempWorkerType(typ string) string {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -5730,14 +5730,82 @@ func TestEffectiveJobTimeout(t *testing.T) {
 		t.Fatalf("effectiveJobTimeout(zero payload) = %v, want 10m", got)
 	}
 
-	// With no managed config, an empty payload timeout yields zero (no deadline).
-	if got := effectiveJobTimeout(workflow.JobPayload{}, managedJobRuntimeConfig{}); got != 0 {
-		t.Fatalf("effectiveJobTimeout(unmanaged, empty) = %v, want 0", got)
+	// With no managed config, an empty payload timeout falls back to the daemon
+	// stale window so an unmanaged job still has a watchdog.
+	if got := effectiveJobTimeout(workflow.JobPayload{}, managedJobRuntimeConfig{}); got != daemonRunningJobStaleAfter {
+		t.Fatalf("effectiveJobTimeout(unmanaged, empty) = %v, want %v", got, daemonRunningJobStaleAfter)
 	}
 
 	// With no managed config, a valid payload timeout still applies.
 	if got := effectiveJobTimeout(workflow.JobPayload{JobTimeout: "45s"}, managedJobRuntimeConfig{}); got != 45*time.Second {
 		t.Fatalf("effectiveJobTimeout(unmanaged, payload) = %v, want 45s", got)
+	}
+}
+
+func TestStartSupervisorWorkerLoopReportsErrorByDefault(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := startSupervisorWorkerLoop(ctx, time.Millisecond, func(time.Time) error {
+		return errors.New("boom")
+	})
+
+	select {
+	case err, ok := <-errCh:
+		if !ok {
+			t.Fatal("worker loop closed without reporting the run error")
+		}
+		if err == nil || err.Error() != "boom" {
+			t.Fatalf("worker loop error = %v, want boom", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker loop did not report the run error")
+	}
+}
+
+func TestStartSupervisorWorkerLoopRecoveringRetriesAfterRunError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls int
+	var mu sync.Mutex
+	errCh := startSupervisorWorkerLoopRecovering(ctx, time.Millisecond, io.Discard, func(time.Time) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls == 1 {
+			return errors.New("transient")
+		}
+		cancel()
+		return nil
+	})
+
+	select {
+	case err, ok := <-errCh:
+		if ok && err != nil {
+			t.Fatalf("recovering worker loop reported error = %v, want silent retry", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("recovering worker loop did not retry after the run error")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls < 2 {
+		t.Fatalf("recovering worker loop calls = %d, want at least 2", calls)
+	}
+}
+
+func TestRunDaemonPollWithTimeoutCancelsPoll(t *testing.T) {
+	start := time.Now()
+	err := runDaemonPollWithTimeout(context.Background(), time.Millisecond, func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runDaemonPollWithTimeout error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("runDaemonPollWithTimeout took %v, want bounded", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

Reworks the earlier queued-job PR to address the root cause Jerry identified instead of changing poll ordering.

Changes:
- daemon worker loops now retry after a worker tick error instead of returning the error and taking down the daemon supervisor
- unmanaged daemon jobs now get a watchdog timeout by falling back to the daemon stale-running window when there is no payload or managed-agent timeout
- single-repo PR/comment polling under the shared checkout lock is run with a bounded context so a hung poll cannot hold the lock forever

This intentionally removes the prior `council-lead`/name-based behavior and does not key off any private orchestrator naming convention.

## Tests

- `/home/smith/.local/go/bin/go test ./internal/cli -run 'TestEffectiveJobTimeout|TestStartSupervisorWorkerLoop|TestRunDaemonPollWithTimeout' -count=1`
- `/home/smith/.local/go/bin/go test ./internal/cli -count=1`
