### PR TITLE
feat(agenttemplate): GitHub-backed template read/backup core (#476 MVP)

### DIFF
--- a/internal/agenttemplate/agenttemplate.go
+++ b/internal/agenttemplate/agenttemplate.go
@@ -371,6 +371,28 @@ func IsLocal(template db.AgentTemplate) bool {
 	return template.SourceRepo == LocalSourceRepo && template.SourceRef == LocalSourceRef
 }
 
+// IsRemote reports whether a stored template was pulled from a real GitHub
+// owner/repo (and is therefore re-fetchable via the GHFetcher). It is the strict
+// gate that distinguishes pulled templates from local custom rows (SourceRepo
+// "local") and keeps the generalized update path off by default for those.
+func IsRemote(template db.AgentTemplate) bool {
+	return IsRemoteRepo(template.SourceRepo)
+}
+
+// IsRemoteRepo reports whether repo looks like a real GitHub "owner/repo"
+// reference (not the "local" sentinel and not an empty/malformed value).
+func IsRemoteRepo(repo string) bool {
+	repo = strings.TrimSpace(repo)
+	if repo == "" || repo == LocalSourceRepo {
+		return false
+	}
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 {
+		return false
+	}
+	return strings.TrimSpace(parts[0]) != "" && strings.TrimSpace(parts[1]) != ""
+}
+
 func HashContent(content string) string {
 	sum := sha256.Sum256([]byte(content))
 	return "sha256:" + hex.EncodeToString(sum[:])
@@ -418,6 +440,125 @@ func Update(ctx context.Context, store *db.Store, fetcher Fetcher, id string) (d
 		return db.AgentTemplate{}, err
 	}
 	return store.GetAgentTemplate(ctx, template.ID)
+}
+
+// AddRemote installs a custom template fetched from a real GitHub owner/repo,
+// mirroring AddLocal but routing through the existing GHFetcher so the stored row
+// carries SourceRepo/SourceRef/SourcePath/ResolvedCommit and gains update/revert
+// for free. It keeps AddLocal's guards: built-in ids and retired ids are
+// rejected, and the fetched file's frontmatter id must match the requested id.
+//
+// Caution: templates are stored and exported verbatim (prompt body + metadata).
+// Avoid pulling from, or publishing to, repos whose visibility you do not
+// control if the prompt could contain sensitive instructions.
+func AddRemote(ctx context.Context, store *db.Store, fetcher Fetcher, id string, repo string, ref string, path string) (db.AgentTemplate, error) {
+	if store == nil {
+		return db.AgentTemplate{}, errors.New("agent template store is required")
+	}
+	if fetcher == nil {
+		return db.AgentTemplate{}, errors.New("agent template fetcher is required")
+	}
+	id = strings.TrimSpace(id)
+	if err := ValidateID(id); err != nil {
+		return db.AgentTemplate{}, err
+	}
+	if _, ok := Lookup(id); ok {
+		return db.AgentTemplate{}, fmt.Errorf("agent template %s is built in and cannot be replaced with a remote template", id)
+	}
+	if IsRetired(id) {
+		return db.AgentTemplate{}, fmt.Errorf("agent template %s is retired; use %s", id, PlannerTemplateID)
+	}
+	repo = strings.TrimSpace(repo)
+	if !IsRemoteRepo(repo) {
+		return db.AgentTemplate{}, fmt.Errorf("template source repo %q must be a GitHub owner/repo", repo)
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		ref = "main"
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		path = "templates/" + id + ".md"
+	}
+	template, err := fetchRemoteTemplate(ctx, fetcher, id, repo, ref, path)
+	if err != nil {
+		return db.AgentTemplate{}, err
+	}
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		return db.AgentTemplate{}, err
+	}
+	return store.GetAgentTemplate(ctx, template.ID)
+}
+
+// UpdateRemote re-fetches a stored remote template from its recorded
+// SourceRepo/SourceRef/SourcePath. It is the remote sibling of UpdateLocal and is
+// strictly gated on IsRemote so local and built-in rows never reach it.
+func UpdateRemote(ctx context.Context, store *db.Store, fetcher Fetcher, cached db.AgentTemplate) (db.AgentTemplate, error) {
+	if store == nil {
+		return db.AgentTemplate{}, errors.New("agent template store is required")
+	}
+	if fetcher == nil {
+		return db.AgentTemplate{}, errors.New("agent template fetcher is required")
+	}
+	if !IsRemote(cached) {
+		return db.AgentTemplate{}, fmt.Errorf("agent template %s is not a remote custom template", cached.ID)
+	}
+	template, err := fetchRemoteTemplate(ctx, fetcher, cached.ID, cached.SourceRepo, cached.SourceRef, cached.SourcePath)
+	if err != nil {
+		return db.AgentTemplate{}, err
+	}
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		return db.AgentTemplate{}, err
+	}
+	return store.GetAgentTemplate(ctx, template.ID)
+}
+
+// fetchRemoteTemplate resolves repo@ref, fetches path, and builds an
+// AgentTemplate row from the file's frontmatter, requiring the frontmatter id to
+// match the requested id (the same contract AddLocal enforces for local files).
+func fetchRemoteTemplate(ctx context.Context, fetcher Fetcher, id string, repo string, ref string, path string) (db.AgentTemplate, error) {
+	resolvedCommit, err := fetcher.ResolveRef(ctx, repo, ref)
+	if err != nil {
+		return db.AgentTemplate{}, err
+	}
+	file, err := fetcher.FetchFile(ctx, repo, resolvedCommit, path)
+	if err != nil {
+		return db.AgentTemplate{}, err
+	}
+	parsed, err := ParseTemplateContent(file.Content)
+	if err != nil {
+		return db.AgentTemplate{}, err
+	}
+	if parsed.Metadata.ID != id {
+		return db.AgentTemplate{}, fmt.Errorf("template id %q does not match frontmatter id %q", id, parsed.Metadata.ID)
+	}
+	metadataJSON, err := MarshalMetadata(parsed.Metadata)
+	if err != nil {
+		return db.AgentTemplate{}, err
+	}
+	return db.AgentTemplate{
+		ID:             id,
+		Name:           parsed.Metadata.Name,
+		Description:    parsed.Metadata.Description,
+		SourceRepo:     repo,
+		SourceRef:      ref,
+		SourcePath:     path,
+		ResolvedCommit: resolvedCommit,
+		Content:        file.Content,
+		MetadataJSON:   metadataJSON,
+	}, nil
+}
+
+// Export reconstructs the canonical .md text (YAML frontmatter + body) for a
+// stored template row from its MetadataJSON and Content. It is network-free: it
+// reads only what is already in the local DB, so it is the always-available
+// primitive for backing templates up to disk or a git checkout.
+func Export(template db.AgentTemplate) (string, error) {
+	metadata, err := UnmarshalMetadata(template.MetadataJSON)
+	if err != nil {
+		return "", fmt.Errorf("export agent template %s: %w", template.ID, err)
+	}
+	return FormatTemplateContent(metadata, InstructionsForContent(template.Content)), nil
 }
 
 func ContentForDefinition(definition Definition, content string) (string, error) {

--- a/internal/agenttemplate/agenttemplate_test.go
+++ b/internal/agenttemplate/agenttemplate_test.go
@@ -420,6 +420,136 @@ func TestUpdateLocalRefreshesFromStoredPath(t *testing.T) {
 	}
 }
 
+func TestIsRemoteGatesOnRealOwnerRepo(t *testing.T) {
+	remote := []string{"jerry/templates", "owner/repo"}
+	for _, repo := range remote {
+		if !IsRemoteRepo(repo) {
+			t.Fatalf("IsRemoteRepo(%q) = false, want true", repo)
+		}
+	}
+	// The "local" sentinel and malformed values must NOT be treated as remote,
+	// so local custom rows keep using UpdateLocal.
+	for _, repo := range []string{"", LocalSourceRepo, "noslash", "owner/", "/repo", "owner/repo/extra"} {
+		if IsRemoteRepo(repo) {
+			t.Fatalf("IsRemoteRepo(%q) = true, want false", repo)
+		}
+	}
+	if IsRemote(db.AgentTemplate{SourceRepo: LocalSourceRepo, SourceRef: LocalSourceRef}) {
+		t.Fatal("local row reported as remote")
+	}
+	if !IsRemote(db.AgentTemplate{SourceRepo: "jerry/templates", SourceRef: "main"}) {
+		t.Fatal("owner/repo row not reported as remote")
+	}
+}
+
+func TestAddRemoteInstallsAndUpdatesFetchedTemplate(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	content := testTemplateContent("frontend-reviewer", "# Frontend Reviewer\n\nReview UI changes.\n")
+	added, err := AddRemote(ctx, store, fakeFetcher{commit: "sha-add", content: content}, "frontend-reviewer", "jerry/templates", "main", "templates/frontend-reviewer.md")
+	if err != nil {
+		t.Fatalf("AddRemote returned error: %v", err)
+	}
+	if added.SourceRepo != "jerry/templates" || added.SourceRef != "main" || added.SourcePath != "templates/frontend-reviewer.md" {
+		t.Fatalf("added remote source = %+v", added)
+	}
+	if added.ResolvedCommit != "sha-add" || added.Content != content || !strings.Contains(added.MetadataJSON, `"id":"frontend-reviewer"`) {
+		t.Fatalf("added remote content = %+v", added)
+	}
+	if IsLocal(added) || !IsRemote(added) {
+		t.Fatalf("added remote row should be remote, not local: %+v", added)
+	}
+
+	// A pulled row re-fetches from its stored source via UpdateRemote.
+	newContent := testTemplateContent("frontend-reviewer", "# Frontend Reviewer\n\nReview UI changes carefully.\n")
+	updated, err := UpdateRemote(ctx, store, fakeFetcher{commit: "sha-upd", content: newContent}, added)
+	if err != nil {
+		t.Fatalf("UpdateRemote returned error: %v", err)
+	}
+	if updated.ResolvedCommit != "sha-upd" || updated.Content != newContent {
+		t.Fatalf("updated remote row = %+v", updated)
+	}
+	if updated.SourceRepo != "jerry/templates" || updated.SourcePath != "templates/frontend-reviewer.md" {
+		t.Fatalf("updated remote source drifted = %+v", updated)
+	}
+}
+
+func TestAddRemoteRejectsInvalidInputs(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	valid := testTemplateContent("frontend-reviewer", "# Frontend Reviewer\n\nReview UI.\n")
+	mismatch := testTemplateContent("other-id", "# Other\n\nReview UI.\n")
+
+	cases := []struct {
+		name    string
+		id      string
+		repo    string
+		content string
+	}{
+		{name: "builtin id", id: ThermoNuclearCodeQualityReviewID, repo: "jerry/templates", content: valid},
+		{name: "retired id", id: "planner-" + "here", repo: "jerry/templates", content: valid},
+		{name: "bad id", id: "Bad", repo: "jerry/templates", content: valid},
+		{name: "not owner/repo", id: "frontend-reviewer", repo: "local", content: valid},
+		{name: "frontmatter mismatch", id: "frontend-reviewer", repo: "jerry/templates", content: mismatch},
+	}
+	for _, tc := range cases {
+		if _, err := AddRemote(ctx, store, fakeFetcher{commit: "sha", content: tc.content}, tc.id, tc.repo, "main", "templates/x.md"); err == nil {
+			t.Fatalf("%s: AddRemote returned nil", tc.name)
+		}
+	}
+}
+
+func TestUpdateRemoteRejectsLocalRow(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	local := db.AgentTemplate{ID: "frontend-reviewer", SourceRepo: LocalSourceRepo, SourceRef: LocalSourceRef}
+	if _, err := UpdateRemote(ctx, store, fakeFetcher{commit: "sha", content: ""}, local); err == nil {
+		t.Fatal("UpdateRemote on a local row returned nil")
+	}
+}
+
+func TestExportReconstructsStoredTemplate(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	content := testTemplateContent("frontend-reviewer", "# Frontend Reviewer\n\nReview UI changes.\n")
+	added, err := AddRemote(ctx, store, fakeFetcher{commit: "sha-add", content: content}, "frontend-reviewer", "jerry/templates", "main", "templates/frontend-reviewer.md")
+	if err != nil {
+		t.Fatalf("AddRemote returned error: %v", err)
+	}
+	exported, err := Export(added)
+	if err != nil {
+		t.Fatalf("Export returned error: %v", err)
+	}
+	// The export must round-trip back through the parser to the same id/body.
+	parsed, err := ParseTemplateContent(exported)
+	if err != nil {
+		t.Fatalf("exported content did not parse: %v\n%s", err, exported)
+	}
+	if parsed.Metadata.ID != "frontend-reviewer" || !strings.Contains(parsed.Body, "Review UI changes.") {
+		t.Fatalf("exported template = %+v body=%q", parsed.Metadata, parsed.Body)
+	}
+	if exported != content {
+		t.Fatalf("export did not round-trip:\n got: %q\nwant: %q", exported, content)
+	}
+}
+
 func testTemplateContent(id string, body string) string {
 	return FormatTemplateContent(testMetadata(id), body)
 }

--- a/internal/cli/agent_template.go
+++ b/internal/cli/agent_template.go
@@ -28,6 +28,8 @@ func runAgentTemplate(args []string, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "add":
 		return runAgentTemplateAdd(args[1:], stdout, stderr)
+	case "export":
+		return runAgentTemplateExport(args[1:], stdout, stderr)
 	case "draft":
 		return runAgentTemplateDraft(args[1:], stdout, stderr)
 	case "list":
@@ -52,6 +54,8 @@ func runAgentTemplate(args []string, stdout, stderr io.Writer) int {
 func printAgentTemplateUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot agent template add <template-id> --file ./agents/<template-id>.md [--name <name>] [--description <text>]")
+	fmt.Fprintln(w, "  gitmoot agent template add <template-id> --from-repo <owner/repo> [--ref <ref>] [--path <file>]")
+	fmt.Fprintln(w, "  gitmoot agent template export [<template-id>...] [--all] [--to <dir>] [--dry-run]")
 	fmt.Fprintln(w, "  gitmoot agent template draft <template-id> [--output .gitmoot/templates/<template-id>.md] [--force]")
 	fmt.Fprintln(w, "  gitmoot agent template validate <file>")
 	fmt.Fprintln(w, "  gitmoot agent template list")
@@ -100,6 +104,9 @@ func runAgentTemplateAdd(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	file := fs.String("file", "", "local template file to install")
+	fromRepo := fs.String("from-repo", "", "GitHub owner/repo to fetch the template from")
+	ref := fs.String("ref", "", "git ref to fetch from --from-repo (default main)")
+	path := fs.String("path", "", "template file path within --from-repo (default templates/<id>.md)")
 	name := fs.String("name", "", "agent template display name")
 	description := fs.String("description", "", "agent template description")
 	id, flagArgs := leadingID(args)
@@ -120,8 +127,25 @@ func runAgentTemplateAdd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "agent template add requires exactly one template id")
 		return 2
 	}
-	if strings.TrimSpace(*file) == "" {
-		fmt.Fprintln(stderr, "agent template add requires --file")
+	hasFile := strings.TrimSpace(*file) != ""
+	hasRepo := strings.TrimSpace(*fromRepo) != ""
+	if hasFile && hasRepo {
+		fmt.Fprintln(stderr, "agent template add accepts either --file or --from-repo, not both")
+		return 2
+	}
+	if hasRepo {
+		fmt.Fprintln(stderr, "note: pulled templates are stored verbatim; only pull from repos you trust, and keep private prompts in a private repo")
+		return withStoreExit(*home, stderr, "add agent template", func(store *db.Store) error {
+			added, err := agenttemplate.AddRemote(context.Background(), store, newAgentTemplateFetcher(), id, *fromRepo, *ref, *path)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, "added %s at %s\n", added.ID, added.ResolvedCommit)
+			return nil
+		})
+	}
+	if !hasFile {
+		fmt.Fprintln(stderr, "agent template add requires --file or --from-repo")
 		return 2
 	}
 	return withStoreExit(*home, stderr, "add agent template", func(store *db.Store) error {
@@ -132,6 +156,126 @@ func runAgentTemplateAdd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "added %s at %s\n", added.ID, added.ResolvedCommit)
 		return nil
 	})
+}
+
+// runAgentTemplateExport reconstructs stored templates back into .md files on
+// disk. It is network-free (DB only). By default it scopes to custom templates
+// and skips built-ins, which already live upstream.
+func runAgentTemplateExport(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent template export", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	all := fs.Bool("all", false, "export all custom templates (skips built-ins)")
+	to := fs.String("to", ".", "directory to write exported .md files into")
+	dryRun := fs.Bool("dry-run", false, "list what would be exported without writing files")
+	ids, flagArgs := leadingIDs(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	ids = append(ids, fs.Args()...)
+	ids = compactValues(ids)
+	if len(ids) == 0 && !*all {
+		fmt.Fprintln(stderr, "agent template export requires one or more template ids or --all")
+		return 2
+	}
+	if len(ids) > 0 && *all {
+		fmt.Fprintln(stderr, "agent template export accepts either template ids or --all, not both")
+		return 2
+	}
+	dir := strings.TrimSpace(*to)
+	if dir == "" {
+		dir = "."
+	}
+	return withStoreExit(*home, stderr, "export agent template", func(store *db.Store) error {
+		targets, err := exportTargets(context.Background(), store, ids, *all, stderr)
+		if err != nil {
+			return err
+		}
+		if len(targets) == 0 {
+			fmt.Fprintln(stderr, "no custom templates to export")
+			return nil
+		}
+		if !*dryRun {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("create export directory: %w", err)
+			}
+		}
+		for _, target := range targets {
+			content, err := agenttemplate.Export(target)
+			if err != nil {
+				return err
+			}
+			path := filepath.Join(dir, target.ID+".md")
+			if *dryRun {
+				writeLine(stdout, "would export %s -> %s", target.ID, path)
+				continue
+			}
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				return fmt.Errorf("write exported template %s: %w", path, err)
+			}
+			writeLine(stdout, "exported %s -> %s", target.ID, path)
+		}
+		fmt.Fprintln(stderr, "note: exported .md files contain the full prompt; review for secrets before committing to a shared or public repo")
+		return nil
+	})
+}
+
+// exportTargets resolves the rows to export: explicit ids look up each custom
+// row (built-in ids are skipped with a note), while --all collects every custom
+// row and skips built-ins and retired ids.
+func exportTargets(ctx context.Context, store *db.Store, ids []string, all bool, stderr io.Writer) ([]db.AgentTemplate, error) {
+	if len(ids) > 0 {
+		targets := make([]db.AgentTemplate, 0, len(ids))
+		for _, id := range ids {
+			if _, ok := agenttemplate.Lookup(id); ok {
+				fmt.Fprintf(stderr, "skipping built-in template %s; built-ins already live upstream\n", id)
+				continue
+			}
+			if agenttemplate.IsRetired(id) {
+				return nil, retiredAgentTemplateError(id)
+			}
+			cached, err := store.GetAgentTemplate(ctx, id)
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, fmt.Errorf("unknown agent template %q", id)
+			}
+			if err != nil {
+				return nil, err
+			}
+			targets = append(targets, cached)
+		}
+		return targets, nil
+	}
+	cachedTemplates, err := store.ListAgentTemplates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	targets := make([]db.AgentTemplate, 0, len(cachedTemplates))
+	for _, cached := range cachedTemplates {
+		if _, ok := agenttemplate.Lookup(cached.ID); ok {
+			continue
+		}
+		if agenttemplate.IsRetired(cached.ID) {
+			continue
+		}
+		targets = append(targets, cached)
+	}
+	return targets, nil
+}
+
+func leadingIDs(args []string) ([]string, []string) {
+	ids := make([]string, 0, len(args))
+	index := 0
+	for index < len(args) {
+		if strings.HasPrefix(args[index], "-") {
+			break
+		}
+		ids = append(ids, args[index])
+		index++
+	}
+	return ids, args[index:]
 }
 
 func leadingID(args []string) (string, []string) {
@@ -437,10 +581,17 @@ func updateTemplateByID(ctx context.Context, store *db.Store, id string) (db.Age
 	if err != nil {
 		return db.AgentTemplate{}, err
 	}
-	if !agenttemplate.IsLocal(cached) {
-		return db.AgentTemplate{}, fmt.Errorf("agent template %s is not a local custom template and has no built-in source", id)
+	if agenttemplate.IsLocal(cached) {
+		return agenttemplate.UpdateLocal(ctx, store, cached)
 	}
-	return agenttemplate.UpdateLocal(ctx, store, cached)
+	// Pulled templates carry a real owner/repo SourceRepo and are re-fetchable
+	// via the GHFetcher. This branch is strictly gated on IsRemote so local rows
+	// (SourceRepo "local") keep using UpdateLocal and the path stays byte-for-byte
+	// unchanged for them.
+	if agenttemplate.IsRemote(cached) {
+		return agenttemplate.UpdateRemote(ctx, store, newAgentTemplateFetcher(), cached)
+	}
+	return db.AgentTemplate{}, fmt.Errorf("agent template %s is not a local custom template and has no built-in source", id)
 }
 
 func retiredAgentTemplateError(id string) error {

--- a/internal/cli/agent_template_test.go
+++ b/internal/cli/agent_template_test.go
@@ -205,6 +205,196 @@ func TestAgentTemplateAddRejectsInvalidLocalFiles(t *testing.T) {
 	}
 }
 
+func TestAgentTemplateAddFromRepoInstallsAndUpdatesRemoteTemplate(t *testing.T) {
+	content := testLocalTemplateContent("frontend-reviewer", "Review frontend changes.\n")
+	restore := replaceAgentTemplateFetcher(fakeAgentTemplateFetcher{commit: "remote-sha", content: content})
+	defer restore()
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+
+	code := Run([]string{"agent", "template", "add", "frontend-reviewer",
+		"--home", home,
+		"--from-repo", "jerry/templates",
+		"--path", "templates/frontend-reviewer.md",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template add --from-repo exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "added frontend-reviewer at remote-sha") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "template", "show", "--home", home, "frontend-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"source: jerry/templates@main:templates/frontend-reviewer.md", "installed: yes", "Review frontend changes."} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("show output missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	// The generalized update path re-fetches a pulled row from its stored source.
+	restore()
+	restore = replaceAgentTemplateFetcher(fakeAgentTemplateFetcher{
+		commit:  "remote-sha-2",
+		content: testLocalTemplateContent("frontend-reviewer", "Review frontend changes deeply.\n"),
+	})
+	defer restore()
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "template", "update", "--home", home, "frontend-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template update exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "updated frontend-reviewer at remote-sha-2") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"agent", "template", "show", "--home", home, "frontend-reviewer"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("template show after update exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"version: v2", "Review frontend changes deeply."} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("show after update missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestAgentTemplateAddRejectsConflictingSources(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	code := Run([]string{"agent", "template", "add", "frontend-reviewer",
+		"--home", home,
+		"--file", "ignored.md",
+		"--from-repo", "jerry/templates",
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("conflicting sources exit code = 0, stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "either --file or --from-repo") {
+		t.Fatalf("stderr missing conflict guidance:\n%s", stderr.String())
+	}
+}
+
+func TestAgentTemplateExportWritesCustomTemplatesAndSkipsBuiltins(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	promptPath := filepath.Join(t.TempDir(), "frontend.md")
+	if err := os.WriteFile(promptPath, []byte(testLocalTemplateContent("frontend-reviewer", "Review frontend changes.\n")), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if code := Run([]string{"agent", "template", "add", "--home", home, "--file", promptPath, "frontend-reviewer"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("template add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	// Install a built-in too, to prove --all skips it.
+	restore := replaceAgentTemplateFetcher(fakeAgentTemplateFetcher{commit: "abc123", content: "Review deeply."})
+	defer restore()
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"agent", "template", "update", "--home", home, "thermo-nuclear-code-quality-review"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("template update builtin exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	outDir := t.TempDir()
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"agent", "template", "export", "--home", home, "--all", "--to", outDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template export exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "exported frontend-reviewer ->") {
+		t.Fatalf("export stdout = %s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "thermo-nuclear-code-quality-review") {
+		t.Fatalf("export --all should skip built-ins:\n%s", stdout.String())
+	}
+	exported, err := os.ReadFile(filepath.Join(outDir, "frontend-reviewer.md"))
+	if err != nil {
+		t.Fatalf("ReadFile exported template returned error: %v", err)
+	}
+	parsed, err := agenttemplate.ParseTemplateContent(string(exported))
+	if err != nil {
+		t.Fatalf("exported file did not parse: %v\n%s", err, string(exported))
+	}
+	if parsed.Metadata.ID != "frontend-reviewer" || !strings.Contains(parsed.Body, "Review frontend changes.") {
+		t.Fatalf("exported file = %+v body=%q", parsed.Metadata, parsed.Body)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "thermo-nuclear-code-quality-review.md")); !os.IsNotExist(err) {
+		t.Fatalf("built-in should not be exported, stat err=%v", err)
+	}
+}
+
+func TestAgentTemplateExportDryRunWritesNothing(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	promptPath := filepath.Join(t.TempDir(), "frontend.md")
+	if err := os.WriteFile(promptPath, []byte(testLocalTemplateContent("frontend-reviewer", "Review frontend changes.\n")), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if code := Run([]string{"agent", "template", "add", "--home", home, "--file", promptPath, "frontend-reviewer"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("template add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	outDir := t.TempDir()
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"agent", "template", "export", "frontend-reviewer", "--home", home, "--to", outDir, "--dry-run"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("template export --dry-run exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "would export frontend-reviewer ->") {
+		t.Fatalf("dry-run stdout = %s", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "frontend-reviewer.md")); !os.IsNotExist(err) {
+		t.Fatalf("--dry-run should not write files, stat err=%v", err)
+	}
+}
+
+func TestAgentTemplateExportRequiresScope(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	code := Run([]string{"agent", "template", "export", "--home", home}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("export without scope exit code = 0, stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "requires one or more template ids or --all") {
+		t.Fatalf("stderr missing scope guidance:\n%s", stderr.String())
+	}
+}
+
+func TestAgentTemplateLocalUpdatePathUnchangedByGeneralization(t *testing.T) {
+	// Additive invariant: a local custom row (SourceRepo "local") must still flow
+	// through UpdateLocal — never the remote fetch path — so installing the
+	// remote machinery does not change behavior for existing local templates.
+	// Set a fetcher that fails loudly if it is ever called for a local row.
+	restore := replaceAgentTemplateFetcher(explodingFetcher{t: t})
+	defer restore()
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	promptPath := filepath.Join(t.TempDir(), "frontend.md")
+	if err := os.WriteFile(promptPath, []byte(testLocalTemplateContent("frontend-reviewer", "Old prompt.\n")), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if code := Run([]string{"agent", "template", "add", "--home", home, "--file", promptPath, "frontend-reviewer"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("template add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if err := os.WriteFile(promptPath, []byte(testLocalTemplateContent("frontend-reviewer", "New prompt.\n")), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"agent", "template", "update", "--home", home, "frontend-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("local template update exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "updated frontend-reviewer at sha256:") {
+		t.Fatalf("local update did not use UpdateLocal:\n%s", stdout.String())
+	}
+}
+
 func TestAgentTemplateDraftWritesDefaultTemplatePath(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	cwd := chdirTemp(t)
@@ -785,6 +975,20 @@ func replaceSkillOptTrainInitStdin(input string) func() {
 	return func() {
 		skillOptTrainInitStdin = previous
 	}
+}
+
+type explodingFetcher struct {
+	t *testing.T
+}
+
+func (f explodingFetcher) ResolveRef(context.Context, string, string) (string, error) {
+	f.t.Fatal("fetcher ResolveRef called for a local custom template")
+	return "", nil
+}
+
+func (f explodingFetcher) FetchFile(context.Context, string, string, string) (agenttemplate.File, error) {
+	f.t.Fatal("fetcher FetchFile called for a local custom template")
+	return agenttemplate.File{}, nil
 }
 
 type fakeAgentTemplateFetcher struct {


### PR DESCRIPTION
## What this MVP does

The read/backup core of GitHub-backed agent templates (#476). Today custom templates live only in the local DB and are inert (`SourceRepo=local`, never re-fetched). This routes them through the same GitHub source mechanism built-ins already use, and adds a network-free export primitive.

- **`agenttemplate.AddRemote`** — install a custom template fetched from a real `owner/repo` via the existing `GHFetcher` (ResolveRef + FetchFile + ParseTemplateContent). Keeps `AddLocal`'s guards: rejects built-in ids (`Lookup`) and retired ids (`IsRetired`), and requires the fetched frontmatter id to match the requested id.
- **`agenttemplate.Export`** — reconstructs the canonical `.md` (frontmatter + body) from a stored row via `UnmarshalMetadata(MetadataJSON)` + `FormatTemplateContent`. Network-free.
- **Generalized `updateTemplateByID`** — a stored row whose `SourceRepo` is a real `owner/repo` re-fetches via the new `UpdateRemote`. Strictly gated on `IsRemote` (NOT `"local"`), so pulled templates get `update`/`revert` for free.
- **CLI**:
  - `agent template add <id> --from-repo <owner/repo> [--ref <ref>] [--path <file>]`
  - `agent template export [<id>...] [--all] [--to <dir>] [--dry-run]` (DB→.md, custom-only by default, skips built-ins)

A secrets/visibility caution is printed when prompts leave the local DB (pull from a repo / export to disk).

## Off-by-default / additive proof

- **No DB migration** — `AgentTemplate` already has `SourceRepo/SourceRef/SourcePath/ResolvedCommit`; `UpsertAgentTemplate` auto-versions.
- The generalized update only affects rows with a real `owner/repo` `SourceRepo`. Local rows (`SourceRepo="local"`) still flow through `UpdateLocal`; built-ins still flow through `Lookup` — byte-identical. Covered by `TestAgentTemplateLocalUpdatePathUnchangedByGeneralization`, which installs an `explodingFetcher` that fails if the network path is ever touched for a local row.
- `IsRemote`/`IsRemoteRepo` reject `""`, `"local"`, and malformed values (`TestIsRemoteGatesOnRealOwnerRepo`).
- `export` is network-free; `--dry-run` writes nothing (`TestAgentTemplateExportDryRunWritesNothing`).
- Existing add/draft/list/validate/show/diff/revert unchanged.

## Gate

`go build`, `go vet`, `go test ./...` all green; `-race` green on `config`, `db`, `agenttemplate`, and the touched `cli` tests (full `cli` `-race` ~11min runs in CI).

## Deferred to follow-ups (NOT in this PR)

- `publish` (`UpsertFile` push path)
- bulk `pull`
- the `[template_remote]` config (named default remotes)
- generalizing the `diff` CLI handler for remote rows (kept unchanged per the additive invariant)

Relates #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)