### PR TITLE
feat(daemon): add agent heartbeat schedules (#533 MVP)

### DIFF
--- a/docs/heartbeats.md
+++ b/docs/heartbeats.md
@@ -1,0 +1,72 @@
+# Agent heartbeat schedules
+
+Heartbeats let the gitmoot daemon schedule **recurring agent work** itself —
+cron-like background jobs — without relying on an external cron. They reuse the
+normal job queue and background-agent path (no separate runner): a due heartbeat
+enqueues an ordinary job that the existing worker tick runs.
+
+Heartbeats are **off by default**. With no heartbeat sections in your config, the
+daemon's scan returns immediately and nothing changes.
+
+## Configuration
+
+Add one `[agents.<agent>.heartbeats.<name>]` section per schedule, scoped to a
+named agent:
+
+```toml
+[agents.repo-maintainer.heartbeats.daily-status]
+enabled = true
+repo = "jerryfane/gitmoot"
+interval = "24h"
+jitter = "15m"
+action = "ask"
+prompt = "Review open issues, PRs, and recent jobs. Return a concise status report with blockers and suggested next actions."
+max_concurrent = 1
+```
+
+| Field            | Required | Default | Notes                                                        |
+| ---------------- | -------- | ------- | ------------------------------------------------------------ |
+| `enabled`        | no       | `false` | A disabled heartbeat never runs.                             |
+| `repo`           | yes      | —       | `owner/name` the job runs against.                           |
+| `interval`       | yes      | —       | Go duration (e.g. `24h`, `1h30m`). Validated at load.        |
+| `jitter`         | no       | `0s`    | Random `[0, jitter]` added to each `next_due` to de-thunder. |
+| `action`         | no       | `ask`   | **MVP: only `ask` (read-only) is supported.**                |
+| `prompt`         | yes      | —       | Instructions passed to the agent.                            |
+| `max_concurrent` | no       | `1`     | Overlap cap; a new run is skipped while this many are active.|
+
+Invalid intervals/jitter or an unsupported action produce a clear validation
+error at config load.
+
+## Behavior
+
+- The daemon checks heartbeat schedules during its existing poll loop (both the
+  registered-repo and single-repo daemons).
+- When a heartbeat is due, gitmoot enqueues one normal background job. Heartbeat
+  jobs are visible in the usual job/status surfaces (sender `heartbeat`,
+  fingerprint `heartbeat:<agent>/<name>`).
+- gitmoot records heartbeat state locally: last run time, next due time, last job
+  id, and last status.
+- **No duplicate jobs:** a new run is skipped while a prior heartbeat job is still
+  active (the `max_concurrent` cap), and the persisted `next_due` means a daemon
+  restart does not re-fire an active heartbeat.
+- **Capacity-aware:** a heartbeat is skipped for this tick when the agent is
+  already at its `max_background`; it retries once capacity frees up.
+- **Missed ticks coalesce:** after a long outage the schedule replays only once
+  (`next_due` is re-anchored to now), not a backlog of every missed interval.
+
+## Safety notes
+
+- The default action is the conservative, read-only `ask`. Heartbeats do **not**
+  auto-implement code. (review/implement heartbeats are a deferred follow-up.)
+- Heartbeats respect existing agent/runtime capacity limits (`max_background`),
+  runtime locks, and repo policy — they enqueue through the same path as any other
+  job.
+- Keep `interval` sane: every due tick consumes a background slot and runtime
+  budget.
+
+## Not yet supported (deferred)
+
+- `action = "review" | "implement"` heartbeats.
+- Agent-**type** scoping (only named agents today).
+- A write-side CLI to create/edit heartbeats (edit the config file directly).
+- Per-job runtime override (see #531).

--- a/docs/heartbeats.md
+++ b/docs/heartbeats.md
@@ -27,7 +27,7 @@ max_concurrent = 1
 | Field            | Required | Default | Notes                                                        |
 | ---------------- | -------- | ------- | ------------------------------------------------------------ |
 | `enabled`        | no       | `false` | A disabled heartbeat never runs.                             |
-| `repo`           | yes      | —       | `owner/name` the job runs against.                           |
+| `repo`           | yes      | —       | `owner/name` the job runs against. Must be a registered, enabled daemon repo with a checkout (see note below). |
 | `interval`       | yes      | —       | Go duration (e.g. `24h`, `1h30m`). Validated at load.        |
 | `jitter`         | no       | `0s`    | Random `[0, jitter]` added to each `next_due` to de-thunder. |
 | `action`         | no       | `ask`   | **MVP: only `ask` (read-only) is supported.**                |
@@ -53,6 +53,11 @@ error at config load.
   already at its `max_background`; it retries once capacity frees up.
 - **Missed ticks coalesce:** after a long outage the schedule replays only once
   (`next_due` is re-anchored to now), not a backlog of every missed interval.
+- **Repo must be managed:** `repo` has to be a repo the daemon actually manages —
+  registered (added to the daemon), enabled, and with a local checkout. A
+  heartbeat pointing at an unmanaged/disabled repo is skipped each tick with
+  `last_status = repo_unmanaged` (it does not enqueue a job no worker would claim),
+  and starts running on its own once the repo becomes managed.
 
 ## Safety notes
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -1193,6 +1194,10 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			})
 			startCockpitReconcileLoop(ctx, store, paths.Home, stdout)
 		}
+		// Heartbeat schedules (#533) reuse the normal job queue. Off-by-default: with
+		// no heartbeat sections the scan returns before any store touch. Skip it under
+		// --dry-run (no worker loop runs there, so an enqueued job would just sit).
+		heartbeatEnqueue := newHeartbeatEnqueuer(store, home)
 		for {
 			if err := receiveSupervisorWorkerError(workerErr); err != nil {
 				return err
@@ -1200,6 +1205,11 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			wait, err := pollRegisteredReposWithPoller(ctx, poller, schedule, time.Now().UTC(), poll)
 			if err != nil {
 				return err
+			}
+			if !dryRun {
+				if err := runHeartbeatScanOnce(ctx, paths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
+					writeLine(stdout, "heartbeat scan error: %s", err)
+				}
 			}
 			if watchSkillOptReviews {
 				if _, err := pollSkillOptReviewWatches(ctx, paths, store, blobStore, reviewGitHub, stdout, dryRun, home); err != nil {
@@ -1247,6 +1257,15 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 		return runDaemonWorkerTick(ctx, store, worker, workers, false, d.Repo.FullName(), rootFilter, stdout, now)
 	})
 	startCockpitReconcileLoop(ctx, store, home, stdout)
+	// Heartbeat schedules (#533) must also fire in the single-repo daemon, or a
+	// single-repo daemon would silently never run them. Off-by-default: with no
+	// heartbeat sections the scan returns before any store touch. A failure to
+	// resolve paths only disables heartbeats (logged once); it never aborts the loop.
+	heartbeatPaths, heartbeatPathsErr := pathsFromFlag(home)
+	if heartbeatPathsErr != nil {
+		writeLine(stdout, "heartbeat scan disabled: %s", heartbeatPathsErr)
+	}
+	heartbeatEnqueue := newHeartbeatEnqueuer(store, home)
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -1259,6 +1278,11 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 			checkoutLock.Unlock()
 		} else {
 			_ = d.PollRecoveryCommandsOnce(ctx)
+		}
+		if heartbeatPathsErr == nil {
+			if err := runHeartbeatScanOnce(ctx, heartbeatPaths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
+				writeLine(stdout, "heartbeat scan error: %s", err)
+			}
 		}
 		timer := time.NewTimer(interval)
 		select {
@@ -1273,6 +1297,145 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 		case <-timer.C:
 		}
 	}
+}
+
+// heartbeatEnqueuer enqueues one heartbeat job. In production it wraps
+// workflow.Mailbox.Enqueue; tests inject a fake to assert the request shape (and
+// to fail loudly if an off-by-default scan ever enqueues).
+type heartbeatEnqueuer func(ctx context.Context, request workflow.JobRequest) (db.Job, error)
+
+// newHeartbeatEnqueuer builds the production enqueuer: a Mailbox bound to the
+// store and the daemon's canary-routing policy, matching dispatchLocalAgentJob's
+// construction so a heartbeat job is indistinguishable from a normal background
+// job once enqueued.
+func newHeartbeatEnqueuer(store *db.Store, home string) heartbeatEnqueuer {
+	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home)}
+	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
+		return mailbox.Enqueue(ctx, request)
+	}
+}
+
+func heartbeatFingerprint(agent, name string) string {
+	return fmt.Sprintf("heartbeat:%s/%s", agent, name)
+}
+
+func heartbeatJobID(agent, name string, now time.Time) string {
+	return fmt.Sprintf("heartbeat-%s-%s-%x", agent, name, now.UTC().UnixNano())
+}
+
+// heartbeatJitter returns a uniformly random delay in [0, jitter] so concurrent
+// heartbeats with the same interval do not thunder. jitter<=0 returns 0, which
+// keeps a no-jitter (the default) schedule deterministic.
+func heartbeatJitter(jitter time.Duration) time.Duration {
+	if jitter <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(jitter) + 1))
+}
+
+// runHeartbeatScanOnce checks every configured heartbeat schedule once and
+// enqueues a normal background job for each enabled+due entry (#533), reusing the
+// standard job queue: the existing worker tick then runs the job (no new
+// execution code).
+//
+// OFF BY DEFAULT: a config with no [agents.<agent>.heartbeats.<name>] sections
+// makes LoadHeartbeats return an empty slice, so this returns nil BEFORE touching
+// the store or the enqueuer. It is wired into BOTH supervisor loops; the caller
+// logs a scan error and never aborts the loop. A per-heartbeat error is collected
+// (first wins) but does not stop the remaining heartbeats.
+func runHeartbeatScanOnce(ctx context.Context, paths config.Paths, store *db.Store, enqueue heartbeatEnqueuer, now time.Time) error {
+	heartbeats, err := config.LoadHeartbeats(paths)
+	if err != nil {
+		return err
+	}
+	if len(heartbeats) == 0 {
+		return nil
+	}
+	agentTypes, err := config.LoadAgentTypes(paths)
+	if err != nil {
+		return err
+	}
+	now = now.UTC()
+	var firstErr error
+	for _, heartbeat := range heartbeats {
+		if err := runOneHeartbeat(ctx, store, enqueue, agentTypes, heartbeat, now); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqueuer, agentTypes map[string]config.AgentType, heartbeat config.Heartbeat, now time.Time) error {
+	if !heartbeat.Enabled {
+		return nil
+	}
+	interval, err := time.ParseDuration(heartbeat.Interval)
+	if err != nil {
+		return fmt.Errorf("heartbeat %s/%s interval: %w", heartbeat.Agent, heartbeat.Name, err)
+	}
+	jitter, err := time.ParseDuration(heartbeat.Jitter)
+	if err != nil {
+		return fmt.Errorf("heartbeat %s/%s jitter: %w", heartbeat.Agent, heartbeat.Name, err)
+	}
+	state, _, err := store.GetHeartbeatState(ctx, heartbeat.Agent, heartbeat.Name)
+	if err != nil {
+		return err
+	}
+	// Not yet due: a zero next_due (the first-ever scan) is in the past, so a fresh
+	// heartbeat runs immediately; a future next_due is skipped without advancing.
+	if !state.NextDueAt.IsZero() && now.Before(state.NextDueAt) {
+		return nil
+	}
+	// Overlap protection: a still-active heartbeat job (>= max_concurrent) means the
+	// previous run has not finished. Skip WITHOUT advancing so it is retried next
+	// tick (this is also the restart-safe dedup: a restart sees the active job).
+	fingerprint := heartbeatFingerprint(heartbeat.Agent, heartbeat.Name)
+	active, err := store.CountActiveJobsByFingerprint(ctx, fingerprint)
+	if err != nil {
+		return err
+	}
+	if active >= heartbeat.MaxConcurrent {
+		return nil
+	}
+	// Respect agent capacity: when the agent is already at its max_background, skip
+	// this tick WITHOUT advancing so the heartbeat is retried once capacity frees up
+	// rather than being silently dropped for a full interval.
+	if agentType, ok := agentTypes[heartbeat.Agent]; ok && agentType.MaxBackground > 0 {
+		busy, err := store.AgentActiveJobCount(ctx, heartbeat.Agent)
+		if err != nil {
+			return err
+		}
+		if busy >= agentType.MaxBackground {
+			return nil
+		}
+	}
+	job, enqueueErr := enqueue(ctx, workflow.JobRequest{
+		ID:           heartbeatJobID(heartbeat.Agent, heartbeat.Name, now),
+		Agent:        heartbeat.Agent,
+		Action:       heartbeat.Action,
+		Repo:         heartbeat.Repo,
+		Sender:       "heartbeat",
+		Instructions: heartbeat.Prompt,
+		Fingerprint:  fingerprint,
+	})
+	// Advance exactly one interval whether or not the enqueue succeeded. Anchoring
+	// next_due to `now` (not the old due time) coalesces missed ticks into a single
+	// run (no backlog replay), and advancing on failure (recording last_status)
+	// stops a broken heartbeat from hot-looping every tick.
+	state.Agent = heartbeat.Agent
+	state.Name = heartbeat.Name
+	state.LastRunAt = now
+	state.NextDueAt = now.Add(interval + heartbeatJitter(jitter))
+	if enqueueErr != nil {
+		state.LastStatus = "enqueue_failed"
+	} else {
+		state.LastJobID = job.ID
+		state.LastStatus = "enqueued"
+	}
+	if err := store.UpsertHeartbeatState(ctx, state); err != nil {
+		return err
+	}
+	return enqueueErr
 }
 
 func startSupervisorWorkerLoop(ctx context.Context, interval time.Duration, run func(time.Time) error) <-chan error {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1319,6 +1319,25 @@ func heartbeatFingerprint(agent, name string) string {
 	return fmt.Sprintf("heartbeat:%s/%s", agent, name)
 }
 
+// heartbeatRepoManaged reports whether repo is one the daemon worker tick can
+// actually run a job for: registered (a repos row exists), enabled, and with a
+// non-empty checkout_path. A heartbeat for any other repo must be skipped (with
+// next_due advanced) rather than enqueued into a job no worker will ever claim.
+func heartbeatRepoManaged(ctx context.Context, store *db.Store, repo string) (bool, error) {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return false, nil
+	}
+	record, err := store.GetRepo(ctx, repo)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return record.Enabled && strings.TrimSpace(record.CheckoutPath) != "", nil
+}
+
 func heartbeatJobID(agent, name string, now time.Time) string {
 	return fmt.Sprintf("heartbeat-%s-%s-%x", agent, name, now.UTC().UnixNano())
 }
@@ -1385,6 +1404,25 @@ func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqu
 	// heartbeat runs immediately; a future next_due is skipped without advancing.
 	if !state.NextDueAt.IsZero() && now.Before(state.NextDueAt) {
 		return nil
+	}
+	// Repo guard: the worker tick only claims jobs for a registered+enabled repo
+	// with a checkout. A heartbeat targeting an unmanaged/disabled/uncheckout repo
+	// would enqueue a job no worker ever claims, which would then permanently wedge
+	// the heartbeat (the zombie 'queued' job trips the overlap guard every tick).
+	// So skip the enqueue but ADVANCE next_due (record last_status) so no zombie is
+	// created and the heartbeat self-recovers once the repo becomes managed.
+	// dispatchLocalAgentJob does an equivalent resolve/upsert; this path bypasses it.
+	managed, err := heartbeatRepoManaged(ctx, store, heartbeat.Repo)
+	if err != nil {
+		return err
+	}
+	if !managed {
+		state.Agent = heartbeat.Agent
+		state.Name = heartbeat.Name
+		state.LastRunAt = now
+		state.NextDueAt = now.Add(interval + heartbeatJitter(jitter))
+		state.LastStatus = "repo_unmanaged"
+		return store.UpsertHeartbeatState(ctx, state)
 	}
 	// Overlap protection: a still-active heartbeat job (>= max_concurrent) means the
 	// previous run has not finished. Skip WITHOUT advancing so it is retried next

--- a/internal/cli/daemon_heartbeat_test.go
+++ b/internal/cli/daemon_heartbeat_test.go
@@ -27,6 +27,14 @@ func heartbeatScanFixture(t *testing.T, body string) (config.Paths, *db.Store) {
 		t.Fatalf("Open: %v", err)
 	}
 	t.Cleanup(func() { store.Close() })
+	// Register the heartbeat target repo as a managed (enabled + checked-out) repo
+	// so the heartbeat repo guard treats it as runnable. Tests that exercise the
+	// unmanaged-repo path register their own repo state instead.
+	if err := store.UpsertRepo(context.Background(), db.Repo{
+		Owner: "jerryfane", Name: "gitmoot", CheckoutPath: t.TempDir(),
+	}); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
 	return paths, store
 }
 
@@ -208,6 +216,37 @@ func TestHeartbeatScanSkipsAtMaxBackground(t *testing.T) {
 	}
 	if _, found, _ := store.GetHeartbeatState(ctx, "repo-maintainer", "daily"); found {
 		t.Fatalf("capacity skip must not advance/write state")
+	}
+}
+
+// TestHeartbeatScanSkipsUnmanagedRepo proves a heartbeat targeting a repo the
+// daemon does not manage (not registered / disabled / no checkout) does NOT
+// enqueue a job (which no worker would ever claim, wedging the heartbeat), but
+// DOES advance next_due with last_status=repo_unmanaged so it self-recovers.
+func TestHeartbeatScanSkipsUnmanagedRepo(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, enabledHeartbeatBody)
+	ctx := context.Background()
+	// Disable the registered repo so it is no longer a runnable target.
+	if err := store.SetRepoEnabled(ctx, "jerryfane/gitmoot", false); err != nil {
+		t.Fatalf("SetRepoEnabled: %v", err)
+	}
+	enq, seen := recordingEnqueuer()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("unmanaged-repo heartbeat enqueued %d jobs (zombie risk)", len(*seen))
+	}
+	state, found, err := store.GetHeartbeatState(ctx, "repo-maintainer", "daily")
+	if err != nil || !found {
+		t.Fatalf("expected state row after unmanaged skip, found=%v err=%v", found, err)
+	}
+	if state.LastStatus != "repo_unmanaged" {
+		t.Fatalf("last_status = %q, want repo_unmanaged", state.LastStatus)
+	}
+	if !state.NextDueAt.Equal(now.Add(24 * time.Hour)) {
+		t.Fatalf("unmanaged skip must advance next_due (no wedge): %+v", state)
 	}
 }
 

--- a/internal/cli/daemon_heartbeat_test.go
+++ b/internal/cli/daemon_heartbeat_test.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// heartbeatScanFixture writes a config (DefaultConfig + body), initializes it, and
+// opens a store, returning both for a runHeartbeatScanOnce test.
+func heartbeatScanFixture(t *testing.T, body string) (config.Paths, *db.Store) {
+	t.Helper()
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return paths, store
+}
+
+// recordingEnqueuer captures every request and returns a synthetic job.
+func recordingEnqueuer() (heartbeatEnqueuer, *[]workflow.JobRequest) {
+	var seen []workflow.JobRequest
+	enq := func(_ context.Context, request workflow.JobRequest) (db.Job, error) {
+		seen = append(seen, request)
+		return db.Job{ID: request.ID, Agent: request.Agent, Type: request.Action, State: string(workflow.JobQueued)}, nil
+	}
+	return enq, &seen
+}
+
+const enabledHeartbeatBody = `
+[agents.repo-maintainer]
+runtime = "codex"
+role = "repo-maintainer"
+max_background = 1
+
+[agents.repo-maintainer.heartbeats.daily]
+enabled = true
+repo = "jerryfane/gitmoot"
+interval = "24h"
+prompt = "Review open issues and PRs."
+max_concurrent = 1
+`
+
+// TestHeartbeatScanOffByDefault is the off-by-default invariant: a config with no
+// heartbeat sections must enqueue nothing and write no heartbeat_state row.
+func TestHeartbeatScanOffByDefault(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, `
+[agents.repo-maintainer]
+runtime = "codex"
+role = "repo-maintainer"
+`)
+	ctx := context.Background()
+	enq := func(context.Context, workflow.JobRequest) (db.Job, error) {
+		t.Fatal("enqueuer must not be called when no heartbeats are configured")
+		return db.Job{}, nil
+	}
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, time.Now().UTC()); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if _, found, err := store.GetHeartbeatState(ctx, "repo-maintainer", "daily"); err != nil || found {
+		t.Fatalf("expected no heartbeat_state row, found=%v err=%v", found, err)
+	}
+}
+
+// TestHeartbeatScanEnqueuesDueJob proves a due heartbeat enqueues exactly one job
+// shaped like dispatchLocalAgentJob (sender=heartbeat, action=ask, fingerprint),
+// and advances next_due so a same-now rescan does NOT duplicate (restart dedup).
+func TestHeartbeatScanEnqueuesDueJob(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, enabledHeartbeatBody)
+	ctx := context.Background()
+	enq, seen := recordingEnqueuer()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("expected 1 enqueued job, got %d", len(*seen))
+	}
+	req := (*seen)[0]
+	if req.Agent != "repo-maintainer" || req.Action != "ask" || req.Sender != "heartbeat" ||
+		req.Repo != "jerryfane/gitmoot" || req.Instructions != "Review open issues and PRs." ||
+		req.Fingerprint != "heartbeat:repo-maintainer/daily" {
+		t.Fatalf("unexpected request shape: %+v", req)
+	}
+	state, found, err := store.GetHeartbeatState(ctx, "repo-maintainer", "daily")
+	if err != nil || !found {
+		t.Fatalf("expected state row after enqueue, found=%v err=%v", found, err)
+	}
+	wantDue := now.Add(24 * time.Hour)
+	if !state.NextDueAt.Equal(wantDue) || state.LastStatus != "enqueued" || state.LastJobID != req.ID {
+		t.Fatalf("state not advanced: %+v (want due %s)", state, wantDue)
+	}
+
+	// Restart dedup: a second scan at the SAME now is not yet due → no new job.
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce rescan: %v", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("rescan duplicated the job: %d enqueues", len(*seen))
+	}
+}
+
+// TestHeartbeatScanSkipsDisabled proves a disabled heartbeat never runs and never
+// writes state.
+func TestHeartbeatScanSkipsDisabled(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, `
+[agents.repo-maintainer]
+runtime = "codex"
+role = "repo-maintainer"
+
+[agents.repo-maintainer.heartbeats.daily]
+enabled = false
+repo = "jerryfane/gitmoot"
+interval = "24h"
+prompt = "p"
+`)
+	ctx := context.Background()
+	enq, seen := recordingEnqueuer()
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, time.Now().UTC()); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("disabled heartbeat enqueued %d jobs", len(*seen))
+	}
+	if _, found, _ := store.GetHeartbeatState(ctx, "repo-maintainer", "daily"); found {
+		t.Fatalf("disabled heartbeat wrote state")
+	}
+}
+
+// TestHeartbeatScanSkipsNotDue proves a future next_due is honored (no enqueue).
+func TestHeartbeatScanSkipsNotDue(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, enabledHeartbeatBody)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	if err := store.UpsertHeartbeatState(ctx, db.HeartbeatState{
+		Agent: "repo-maintainer", Name: "daily", NextDueAt: now.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	enq, seen := recordingEnqueuer()
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("not-due heartbeat enqueued %d jobs", len(*seen))
+	}
+}
+
+// TestHeartbeatScanSkipsOnActiveJob proves overlap protection: an active job
+// carrying the heartbeat fingerprint (>= max_concurrent) blocks a new enqueue and
+// does NOT advance next_due (so it retries next tick).
+func TestHeartbeatScanSkipsOnActiveJob(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, enabledHeartbeatBody)
+	ctx := context.Background()
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "active-1", Agent: "repo-maintainer", Type: "ask", State: "running",
+		Payload: `{"fingerprint":"heartbeat:repo-maintainer/daily"}`,
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	enq, seen := recordingEnqueuer()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("overlap not respected: enqueued %d jobs", len(*seen))
+	}
+	if _, found, _ := store.GetHeartbeatState(ctx, "repo-maintainer", "daily"); found {
+		t.Fatalf("overlap skip must not advance/write state")
+	}
+}
+
+// TestHeartbeatScanSkipsAtMaxBackground proves agent capacity is respected: when
+// the agent is already at max_background, the heartbeat skips this tick without
+// advancing. The blocking jobs carry a DIFFERENT fingerprint so the overlap guard
+// passes and the max_background guard is the one under test.
+func TestHeartbeatScanSkipsAtMaxBackground(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, enabledHeartbeatBody) // max_background = 1
+	ctx := context.Background()
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "busy-1", Agent: "repo-maintainer", Type: "ask", State: "running",
+		Payload: `{"fingerprint":"some-other-work"}`,
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	enq, seen := recordingEnqueuer()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("max_background not respected: enqueued %d jobs", len(*seen))
+	}
+	if _, found, _ := store.GetHeartbeatState(ctx, "repo-maintainer", "daily"); found {
+		t.Fatalf("capacity skip must not advance/write state")
+	}
+}
+
+// TestHeartbeatScanCoalescesMissedTicks proves a long outage replays only ONCE:
+// next_due is anchored to now (not the stale due time), so one scan after many
+// missed intervals enqueues a single job and schedules the next from now.
+func TestHeartbeatScanCoalescesMissedTicks(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, enabledHeartbeatBody)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	// Seed a next_due 10 days in the past (10 missed daily ticks).
+	if err := store.UpsertHeartbeatState(ctx, db.HeartbeatState{
+		Agent: "repo-maintainer", Name: "daily", NextDueAt: now.Add(-10 * 24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	enq, seen := recordingEnqueuer()
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("expected a single coalesced run, got %d", len(*seen))
+	}
+	state, _, err := store.GetHeartbeatState(ctx, "repo-maintainer", "daily")
+	if err != nil {
+		t.Fatalf("GetHeartbeatState: %v", err)
+	}
+	if !state.NextDueAt.Equal(now.Add(24 * time.Hour)) {
+		t.Fatalf("next_due not re-anchored to now: %+v", state)
+	}
+}

--- a/internal/config/agent_types.go
+++ b/internal/config/agent_types.go
@@ -261,7 +261,13 @@ func removeAgentTypeBlocks(content string) string {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
 			section := strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")
-			skip = strings.HasPrefix(section, "agents.")
+			// Only strip TOP-LEVEL agent-type blocks. Mirror the LoadAgentTypes
+			// guard (#533): a remainder containing a '.' is a SUBSECTION (e.g.
+			// agents.x.heartbeats.y) owned by another loader. Stripping those here
+			// would silently delete every heartbeat on an unrelated `agent type set`
+			// rewrite, since SaveAgentType re-appends only the agent-TYPE blocks.
+			rest := strings.TrimPrefix(section, "agents.")
+			skip = strings.HasPrefix(section, "agents.") && !strings.Contains(rest, ".")
 		}
 		if !skip {
 			kept = append(kept, line)

--- a/internal/config/agent_types.go
+++ b/internal/config/agent_types.go
@@ -39,6 +39,16 @@ func LoadAgentTypes(paths Paths) (map[string]AgentType, error) {
 			current = ""
 			if strings.HasPrefix(section, "agents.") {
 				current = strings.TrimSpace(strings.TrimPrefix(section, "agents."))
+				// GUARD (#533): a remainder containing a '.' is a SUBSECTION (e.g.
+				// agents.x.heartbeats.y), not an agent. Without this it would register a
+				// phantom agent named "x.heartbeats.y" and absorb the subsection's fields.
+				// Clearing current both skips the registration and skips the subsection's
+				// fields below; that subsection's own loader (e.g. LoadHeartbeats) owns it.
+				// No existing (non-subsection) agent name contains a '.', so this never
+				// changes behavior for any current config.
+				if strings.Contains(current, ".") {
+					current = ""
+				}
 				if current != "" {
 					entry := types[current]
 					entry.Name = current

--- a/internal/config/agent_types_test.go
+++ b/internal/config/agent_types_test.go
@@ -135,6 +135,69 @@ runtime = "codex"
 	}
 }
 
+// TestSaveAgentTypePreservesHeartbeatSection is the regression guard for #533:
+// an unrelated `agent type set` rewrite (SaveAgentType) must NOT delete a
+// pre-existing [agents.<agent>.heartbeats.<name>] subsection. Before the fix
+// removeAgentTypeBlocks stripped every "agents." section (including heartbeats),
+// silently dropping the heartbeat with no error.
+func TestSaveAgentTypePreservesHeartbeatSection(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[agents.repo-maintainer]
+runtime = "codex"
+role = "repo-maintainer"
+max_background = 1
+
+[agents.repo-maintainer.heartbeats.daily]
+enabled = true
+repo = "jerryfane/gitmoot"
+interval = "24h"
+prompt = "Review open issues and PRs."
+max_concurrent = 1
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	before, err := LoadHeartbeats(paths)
+	if err != nil {
+		t.Fatalf("LoadHeartbeats before save: %v", err)
+	}
+	if len(before) != 1 {
+		t.Fatalf("expected 1 heartbeat before save, got %d", len(before))
+	}
+
+	types, err := LoadAgentTypes(paths)
+	if err != nil {
+		t.Fatalf("LoadAgentTypes: %v", err)
+	}
+	maintainer := types["repo-maintainer"]
+	maintainer.MaxBackground = 2
+	if err := SaveAgentType(paths, maintainer); err != nil {
+		t.Fatalf("SaveAgentType: %v", err)
+	}
+
+	after, err := LoadHeartbeats(paths)
+	if err != nil {
+		t.Fatalf("LoadHeartbeats after save: %v", err)
+	}
+	if len(after) != 1 {
+		t.Fatalf("heartbeat dropped by SaveAgentType: got %d heartbeats", len(after))
+	}
+	if after[0].Agent != "repo-maintainer" || after[0].Name != "daily" || after[0].Prompt != "Review open issues and PRs." {
+		t.Fatalf("heartbeat mangled by SaveAgentType: %+v", after[0])
+	}
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(content), "[agents.repo-maintainer.heartbeats.daily]") {
+		t.Fatalf("heartbeat section missing from rewritten config:\n%s", string(content))
+	}
+}
+
 func TestLoadAgentTypesRejectsInvalidAutonomyPolicy(t *testing.T) {
 	paths := PathsForHome(t.TempDir())
 	if err := Initialize(paths); err != nil {

--- a/internal/config/heartbeats.go
+++ b/internal/config/heartbeats.go
@@ -1,0 +1,197 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Heartbeat is one named recurring agent schedule parsed from an
+// [agents.<agent>.heartbeats.<name>] config section (#533). The daemon's
+// heartbeat scan enqueues a normal background job for each enabled+due entry,
+// reusing the standard job queue/background-agent path (no separate runner). The
+// loader mirrors the AgentType idioms (Load/applyField/Defaults/validate).
+type Heartbeat struct {
+	Agent         string
+	Name          string
+	Enabled       bool
+	Repo          string
+	Interval      string
+	Jitter        string
+	Action        string
+	Prompt        string
+	MaxConcurrent int
+}
+
+// LoadHeartbeats collects every [agents.<agent>.heartbeats.<name>] section from
+// the config file into a stable, validated slice (config order preserved). It is
+// OFF BY DEFAULT: a config with no heartbeat subsections returns an empty slice
+// and never errors, and a caller that finds an empty slice does no further work.
+//
+// It reuses the same line-scanner shape as LoadAgentTypes. The agent-types
+// loader carries a guard (see LoadAgentTypes) so these subsection headers are NOT
+// mis-registered as phantom agents named "<agent>.heartbeats.<name>"; this loader
+// owns them instead.
+func LoadHeartbeats(paths Paths) ([]Heartbeat, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	type key struct{ agent, name string }
+	collected := map[key]*Heartbeat{}
+	order := make([]key, 0)
+	var current *Heartbeat
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = nil
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			agent, name, ok := parseHeartbeatSection(section)
+			if !ok {
+				continue
+			}
+			k := key{agent: agent, name: name}
+			if collected[k] == nil {
+				collected[k] = &Heartbeat{Agent: agent, Name: name}
+				order = append(order, k)
+			}
+			current = collected[k]
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		field, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if err := applyHeartbeatField(current, strings.TrimSpace(field), strings.TrimSpace(value)); err != nil {
+			return nil, fmt.Errorf("parse [agents.%s.heartbeats.%s].%s: %w", current.Agent, current.Name, strings.TrimSpace(field), err)
+		}
+	}
+	heartbeats := make([]Heartbeat, 0, len(order))
+	for _, k := range order {
+		entry := collected[k]
+		applyHeartbeatDefaults(entry)
+		if err := validateHeartbeat(*entry); err != nil {
+			return nil, err
+		}
+		heartbeats = append(heartbeats, *entry)
+	}
+	return heartbeats, nil
+}
+
+// parseHeartbeatSection extracts the agent and the heartbeat name from a section
+// of the form agents.<agent>.heartbeats.<name>. It returns ok=false for any other
+// section (including a deeper sub-subsection under <name>), so unrelated sections
+// are ignored.
+func parseHeartbeatSection(section string) (agent string, name string, ok bool) {
+	section = strings.TrimSpace(section)
+	if !strings.HasPrefix(section, "agents.") {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(section, "agents.")
+	const marker = ".heartbeats."
+	index := strings.Index(rest, marker)
+	if index < 0 {
+		return "", "", false
+	}
+	agent = strings.TrimSpace(rest[:index])
+	name = strings.TrimSpace(rest[index+len(marker):])
+	if agent == "" || name == "" {
+		return "", "", false
+	}
+	// The name must be a leaf: a further '.' would be a deeper subsection this MVP
+	// does not define, so reject it rather than silently truncating.
+	if strings.Contains(name, ".") {
+		return "", "", false
+	}
+	return agent, name, true
+}
+
+func applyHeartbeatField(entry *Heartbeat, key string, value string) error {
+	switch key {
+	case "enabled":
+		parsed, err := strconv.ParseBool(value)
+		entry.Enabled = parsed
+		return err
+	case "repo":
+		parsed, err := parseConfigString(value)
+		entry.Repo = parsed
+		return err
+	case "interval":
+		parsed, err := parseConfigString(value)
+		entry.Interval = parsed
+		return err
+	case "jitter":
+		parsed, err := parseConfigString(value)
+		entry.Jitter = parsed
+		return err
+	case "action":
+		parsed, err := parseConfigString(value)
+		entry.Action = parsed
+		return err
+	case "prompt":
+		parsed, err := parseConfigString(value)
+		entry.Prompt = parsed
+		return err
+	case "max_concurrent":
+		parsed, err := strconv.Atoi(value)
+		entry.MaxConcurrent = parsed
+		return err
+	default:
+		return nil
+	}
+}
+
+func applyHeartbeatDefaults(entry *Heartbeat) {
+	entry.Agent = strings.TrimSpace(entry.Agent)
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.Repo = strings.TrimSpace(entry.Repo)
+	entry.Interval = strings.TrimSpace(entry.Interval)
+	entry.Jitter = strings.TrimSpace(entry.Jitter)
+	if entry.Jitter == "" {
+		entry.Jitter = "0s"
+	}
+	entry.Action = strings.TrimSpace(entry.Action)
+	if entry.Action == "" {
+		entry.Action = "ask"
+	}
+	entry.Prompt = strings.TrimSpace(entry.Prompt)
+	if entry.MaxConcurrent <= 0 {
+		entry.MaxConcurrent = 1
+	}
+}
+
+// validateHeartbeat enforces the MVP contract with explicit errors (matching the
+// agent_types.go validation style). Durations are validated via
+// time.ParseDuration so an invalid interval/jitter is a clear config error rather
+// than a silent skip.
+func validateHeartbeat(entry Heartbeat) error {
+	if entry.Repo == "" {
+		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: repo is required", entry.Agent, entry.Name)
+	}
+	if entry.Interval == "" {
+		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: interval is required", entry.Agent, entry.Name)
+	}
+	if _, err := time.ParseDuration(entry.Interval); err != nil {
+		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: interval %q: %w", entry.Agent, entry.Name, entry.Interval, err)
+	}
+	if _, err := time.ParseDuration(entry.Jitter); err != nil {
+		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: jitter %q: %w", entry.Agent, entry.Name, entry.Jitter, err)
+	}
+	// MVP scope: only the conservative read-only "ask" action is supported.
+	// review/implement heartbeats are a deferred follow-up.
+	if entry.Action != "ask" {
+		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: unsupported action %q; only \"ask\" is supported", entry.Agent, entry.Name, entry.Action)
+	}
+	if entry.Prompt == "" {
+		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: prompt is required", entry.Agent, entry.Name)
+	}
+	return nil
+}

--- a/internal/config/heartbeats_test.go
+++ b/internal/config/heartbeats_test.go
@@ -1,0 +1,158 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func writeHeartbeatConfig(t *testing.T, body string) Paths {
+	t.Helper()
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return paths
+}
+
+func TestLoadHeartbeatsParsesAndDefaults(t *testing.T) {
+	paths := writeHeartbeatConfig(t, `
+[agents.repo-maintainer.heartbeats.daily-status]
+enabled = true
+repo = "jerryfane/gitmoot"
+interval = "24h"
+jitter = "15m"
+action = "ask"
+prompt = "Review open issues and PRs."
+max_concurrent = 1
+
+[agents.repo-maintainer.heartbeats.minimal]
+enabled = false
+repo = "jerryfane/gitmoot"
+interval = "1h"
+prompt = "Quick check."
+`)
+	heartbeats, err := LoadHeartbeats(paths)
+	if err != nil {
+		t.Fatalf("LoadHeartbeats returned error: %v", err)
+	}
+	if len(heartbeats) != 2 {
+		t.Fatalf("expected 2 heartbeats, got %d: %+v", len(heartbeats), heartbeats)
+	}
+	first := heartbeats[0]
+	if first.Agent != "repo-maintainer" || first.Name != "daily-status" || !first.Enabled ||
+		first.Repo != "jerryfane/gitmoot" || first.Interval != "24h" || first.Jitter != "15m" ||
+		first.Action != "ask" || first.Prompt != "Review open issues and PRs." || first.MaxConcurrent != 1 {
+		t.Fatalf("first heartbeat = %+v", first)
+	}
+	// Defaults: jitter -> 0s, action -> ask, max_concurrent -> 1.
+	second := heartbeats[1]
+	if second.Name != "minimal" || second.Enabled || second.Jitter != "0s" || second.Action != "ask" || second.MaxConcurrent != 1 {
+		t.Fatalf("second heartbeat defaults = %+v", second)
+	}
+}
+
+func TestLoadHeartbeatsOffByDefault(t *testing.T) {
+	// A config with NO heartbeat sections must return an empty slice and no error,
+	// so the daemon scan does no work (the off-by-default invariant).
+	paths := writeHeartbeatConfig(t, `
+[agents.planner]
+runtime = "codex"
+role = "planner"
+`)
+	heartbeats, err := LoadHeartbeats(paths)
+	if err != nil {
+		t.Fatalf("LoadHeartbeats returned error: %v", err)
+	}
+	if len(heartbeats) != 0 {
+		t.Fatalf("expected no heartbeats, got %+v", heartbeats)
+	}
+}
+
+func TestLoadHeartbeatsValidationErrors(t *testing.T) {
+	cases := map[string]string{
+		"bad interval": `
+[agents.x.heartbeats.h]
+enabled = true
+repo = "o/r"
+interval = "not-a-duration"
+prompt = "p"
+`,
+		"missing repo": `
+[agents.x.heartbeats.h]
+enabled = true
+interval = "1h"
+prompt = "p"
+`,
+		"missing prompt": `
+[agents.x.heartbeats.h]
+enabled = true
+repo = "o/r"
+interval = "1h"
+`,
+		"unsupported action": `
+[agents.x.heartbeats.h]
+enabled = true
+repo = "o/r"
+interval = "1h"
+action = "implement"
+prompt = "p"
+`,
+		"bad jitter": `
+[agents.x.heartbeats.h]
+enabled = true
+repo = "o/r"
+interval = "1h"
+jitter = "nope"
+prompt = "p"
+`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			paths := writeHeartbeatConfig(t, body)
+			if _, err := LoadHeartbeats(paths); err == nil {
+				t.Fatalf("expected validation error for %q", name)
+			}
+		})
+	}
+}
+
+// TestLoadAgentTypesGuardIgnoresHeartbeatSubsections is the critical parser guard
+// (#533): the agent-types line scanner must NOT register a phantom agent named
+// "x.heartbeats.h" when it encounters a heartbeat subsection header.
+func TestLoadAgentTypesGuardIgnoresHeartbeatSubsections(t *testing.T) {
+	paths := writeHeartbeatConfig(t, `
+[agents.x]
+runtime = "codex"
+role = "x"
+
+[agents.x.heartbeats.h]
+enabled = true
+repo = "o/r"
+interval = "1h"
+prompt = "p"
+`)
+	types, err := LoadAgentTypes(paths)
+	if err != nil {
+		t.Fatalf("LoadAgentTypes returned error: %v", err)
+	}
+	if _, ok := types["x"]; !ok {
+		t.Fatalf("expected real agent x to be registered, got %v", keysOf(types))
+	}
+	for name := range types {
+		if strings.Contains(name, ".heartbeats.") || strings.Contains(name, ".") {
+			t.Fatalf("phantom agent registered for subsection: %q (all: %v)", name, keysOf(types))
+		}
+	}
+}
+
+func keysOf(m map[string]AgentType) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	return names
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4605,6 +4605,123 @@ func (s *Store) UpsertBanditArm(ctx context.Context, arm BanditArm) error {
 	return err
 }
 
+// HeartbeatState is the persisted state of one named agent heartbeat schedule
+// (#533): when it last ran, when it is next due, and the id/status of its most
+// recent job. The next_due + last_status are what make a heartbeat restart-safe
+// (a restart re-reads next_due rather than firing immediately).
+type HeartbeatState struct {
+	Agent      string
+	Name       string
+	LastRunAt  time.Time
+	NextDueAt  time.Time
+	LastJobID  string
+	LastStatus string
+}
+
+// GetHeartbeatState returns the persisted state for one (agent, name) heartbeat.
+// A missing row is NOT an error: it returns ok=false with a zero state, which the
+// daemon treats as "due now" (a zero next_due is in the past). This keeps the
+// table off-by-default — no row exists until a heartbeat first fires.
+func (s *Store) GetHeartbeatState(ctx context.Context, agent, name string) (HeartbeatState, bool, error) {
+	agent = strings.TrimSpace(agent)
+	name = strings.TrimSpace(name)
+	if agent == "" || name == "" {
+		return HeartbeatState{}, false, errors.New("heartbeat agent and name are required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT agent, name, last_run_at, next_due_at, last_job_id, last_status
+		FROM heartbeat_state WHERE agent = ? AND name = ?`, agent, name)
+	var (
+		state            HeartbeatState
+		lastRun, nextDue string
+	)
+	if err := row.Scan(&state.Agent, &state.Name, &lastRun, &nextDue, &state.LastJobID, &state.LastStatus); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return HeartbeatState{}, false, nil
+		}
+		return HeartbeatState{}, false, err
+	}
+	state.LastRunAt = parseHeartbeatTime(lastRun)
+	state.NextDueAt = parseHeartbeatTime(nextDue)
+	return state, true, nil
+}
+
+// UpsertHeartbeatState writes (or replaces) a heartbeat's full state. Times are
+// stored as RFC3339Nano UTC text (a zero time becomes empty text, mirroring the
+// table's DEFAULT '').
+func (s *Store) UpsertHeartbeatState(ctx context.Context, state HeartbeatState) error {
+	state.Agent = strings.TrimSpace(state.Agent)
+	state.Name = strings.TrimSpace(state.Name)
+	if state.Agent == "" || state.Name == "" {
+		return errors.New("heartbeat agent and name are required")
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO heartbeat_state(agent, name, last_run_at, next_due_at, last_job_id, last_status)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(agent, name) DO UPDATE SET
+			last_run_at = excluded.last_run_at,
+			next_due_at = excluded.next_due_at,
+			last_job_id = excluded.last_job_id,
+			last_status = excluded.last_status`,
+		state.Agent, state.Name,
+		formatHeartbeatTime(state.LastRunAt), formatHeartbeatTime(state.NextDueAt),
+		strings.TrimSpace(state.LastJobID), strings.TrimSpace(state.LastStatus))
+	return err
+}
+
+// CountActiveJobsByFingerprint counts queued/running jobs whose stored payload
+// carries the given fingerprint — the heartbeat overlap guard (#533), a cousin of
+// countActiveJobsTx that filters on the payload fingerprint instead of the agent
+// column. The fingerprint lives in the JSON payload, and modernc's json_extract
+// raises a SQL error on a malformed payload (see backfillJobRootID), so this
+// counts Go-side: it scans the small set of active rows and tolerates a malformed
+// payload (skipped) rather than aborting. An empty fingerprint matches nothing.
+func (s *Store) CountActiveJobsByFingerprint(ctx context.Context, fingerprint string) (int, error) {
+	fingerprint = strings.TrimSpace(fingerprint)
+	if fingerprint == "" {
+		return 0, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT payload FROM jobs WHERE state IN ('queued', 'running')`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	count := 0
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			return 0, err
+		}
+		var probe struct {
+			Fingerprint string `json:"fingerprint"`
+		}
+		if err := json.Unmarshal([]byte(payload), &probe); err != nil {
+			continue
+		}
+		if strings.TrimSpace(probe.Fingerprint) == fingerprint {
+			count++
+		}
+	}
+	return count, rows.Err()
+}
+
+func formatHeartbeatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func parseHeartbeatTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
+}
+
 // IncrementBanditArm atomically applies ONE pairwise outcome to a (templateID,
 // versionID) arm in a single transaction: a win bumps alpha, a loss bumps beta,
 // and either way pulls increments. A first-ever pull seeds the row from the
@@ -6400,5 +6517,22 @@ ALTER TABLE agent_template_versions ADD COLUMN canary_sample REAL NOT NULL DEFAU
 ALTER TABLE agent_template_versions ADD COLUMN canary_started_at TEXT NOT NULL DEFAULT '';
 
 CREATE INDEX idx_atv_canary ON agent_template_versions(template_id) WHERE state = 'canary';
+	`,
+	// #533 agent heartbeat schedules: one row per (agent, named heartbeat) tracking
+	// the schedule's persisted state so a daemon restart never duplicates an active
+	// run (the next_due_at + the active-job check are the restart-safe dedup). This
+	// is a pure additive append — CREATE TABLE only, no ALTER/renumber of any prior
+	// migration — and the table stays empty unless a heartbeat is configured AND
+	// fires, so every existing DB reads identically.
+	`
+CREATE TABLE heartbeat_state (
+	agent TEXT NOT NULL,
+	name TEXT NOT NULL,
+	last_run_at TEXT NOT NULL DEFAULT '',
+	next_due_at TEXT NOT NULL DEFAULT '',
+	last_job_id TEXT NOT NULL DEFAULT '',
+	last_status TEXT NOT NULL DEFAULT '',
+	PRIMARY KEY (agent, name)
+);
 	`,
 }

--- a/internal/db/store_heartbeat_test.go
+++ b/internal/db/store_heartbeat_test.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func openHeartbeatStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+// TestHeartbeatStateMissingIsNotError proves a fresh schedule reads back as "not
+// found" (the daemon treats that as "due now"), keeping the table off-by-default:
+// no row exists until a heartbeat first fires.
+func TestHeartbeatStateMissingIsNotError(t *testing.T) {
+	store := openHeartbeatStore(t)
+	ctx := context.Background()
+	state, found, err := store.GetHeartbeatState(ctx, "repo-maintainer", "daily")
+	if err != nil {
+		t.Fatalf("GetHeartbeatState: %v", err)
+	}
+	if found {
+		t.Fatalf("expected no row for a fresh heartbeat, got %+v", state)
+	}
+}
+
+func TestUpsertAndGetHeartbeatState(t *testing.T) {
+	store := openHeartbeatStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	due := now.Add(24 * time.Hour)
+	if err := store.UpsertHeartbeatState(ctx, HeartbeatState{
+		Agent: "repo-maintainer", Name: "daily",
+		LastRunAt: now, NextDueAt: due, LastJobID: "job-1", LastStatus: "enqueued",
+	}); err != nil {
+		t.Fatalf("UpsertHeartbeatState: %v", err)
+	}
+	state, found, err := store.GetHeartbeatState(ctx, "repo-maintainer", "daily")
+	if err != nil {
+		t.Fatalf("GetHeartbeatState: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected row after upsert")
+	}
+	if !state.LastRunAt.Equal(now) || !state.NextDueAt.Equal(due) || state.LastJobID != "job-1" || state.LastStatus != "enqueued" {
+		t.Fatalf("roundtrip mismatch: %+v", state)
+	}
+	// Upsert again (same key) replaces in place — one row per (agent, name).
+	later := due.Add(24 * time.Hour)
+	if err := store.UpsertHeartbeatState(ctx, HeartbeatState{
+		Agent: "repo-maintainer", Name: "daily",
+		LastRunAt: due, NextDueAt: later, LastJobID: "job-2", LastStatus: "enqueue_failed",
+	}); err != nil {
+		t.Fatalf("UpsertHeartbeatState replace: %v", err)
+	}
+	state, _, err = store.GetHeartbeatState(ctx, "repo-maintainer", "daily")
+	if err != nil {
+		t.Fatalf("GetHeartbeatState after replace: %v", err)
+	}
+	if state.LastJobID != "job-2" || state.LastStatus != "enqueue_failed" || !state.NextDueAt.Equal(later) {
+		t.Fatalf("replace mismatch: %+v", state)
+	}
+}
+
+func TestCountActiveJobsByFingerprint(t *testing.T) {
+	store := openHeartbeatStore(t)
+	ctx := context.Background()
+	const fp = "heartbeat:repo-maintainer/daily"
+
+	if count, err := store.CountActiveJobsByFingerprint(ctx, fp); err != nil || count != 0 {
+		t.Fatalf("empty store: count=%d err=%v", count, err)
+	}
+
+	mustJob := func(id, state, payload string) {
+		if err := store.CreateJob(ctx, Job{ID: id, Agent: "repo-maintainer", Type: "ask", State: state, Payload: payload}); err != nil {
+			t.Fatalf("CreateJob %s: %v", id, err)
+		}
+	}
+	mustJob("j1", "queued", `{"fingerprint":"heartbeat:repo-maintainer/daily"}`)
+	mustJob("j2", "running", `{"fingerprint":"heartbeat:repo-maintainer/daily"}`)
+	mustJob("j3", "succeeded", `{"fingerprint":"heartbeat:repo-maintainer/daily"}`) // terminal: not counted
+	mustJob("j4", "queued", `{"fingerprint":"heartbeat:other/x"}`)                   // different fp
+	mustJob("j5", "queued", `not-json`)                                             // malformed: tolerated, skipped
+
+	count, err := store.CountActiveJobsByFingerprint(ctx, fp)
+	if err != nil {
+		t.Fatalf("CountActiveJobsByFingerprint: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 active jobs for %q, got %d", fp, count)
+	}
+
+	// An empty fingerprint matches nothing (never counts every active job).
+	if count, err := store.CountActiveJobsByFingerprint(ctx, ""); err != nil || count != 0 {
+		t.Fatalf("empty fingerprint: count=%d err=%v", count, err)
+	}
+}


### PR DESCRIPTION
## What this MVP does

Adds opt-in, cron-like **agent heartbeat schedules** (#533). A new
`[agents.<agent>.heartbeats.<name>]` config section schedules recurring agent
work; when a heartbeat is due the daemon enqueues a **normal background job**
through the existing queue, and the existing worker tick runs it — no new runner,
no new execution code.

```toml
[agents.repo-maintainer.heartbeats.daily-status]
enabled = true
repo = "jerryfane/gitmoot"
interval = "24h"
jitter = "15m"
action = "ask"
prompt = "Review open issues, PRs, and recent jobs. Return a concise status report."
max_concurrent = 1
```

### Components
- **config** (`internal/config/heartbeats.go`): `LoadHeartbeats` reader mirroring
  the `agent_types.go` idioms (Load/applyField/Defaults/validate), durations via
  `time.ParseDuration`, explicit validation errors. Plus the critical **parser
  guard** in `LoadAgentTypes`: a `[agents.x.heartbeats.y]` subsection is no longer
  mis-registered as a phantom agent named `x.heartbeats.y`.
- **db** (`internal/db/store.go`): one additive migration creating
  `heartbeat_state(agent, name, last_run_at, next_due_at, last_job_id,
  last_status)`, plus `GetHeartbeatState` / `UpsertHeartbeatState` and
  `CountActiveJobsByFingerprint` (a fingerprint-filtered cousin of
  `countActiveJobsTx`, Go-side to tolerate malformed payloads).
- **daemon** (`internal/cli/daemon.go`): `runHeartbeatScanOnce` wired into **both**
  the registered-repo and single-repo supervisor loops (a single-repo daemon would
  otherwise silently never fire). Per enabled+due heartbeat it enqueues one job via
  `workflow.Mailbox.Enqueue` shaped like `dispatchLocalAgentJob`
  (`action="ask"`, `sender="heartbeat"`, `fingerprint="heartbeat:<agent>/<name>"`).

### Semantics
disabled / not-due / overlap (`CountActiveJobsByFingerprint >= max_concurrent`) /
agent at `max_background` → skip (skips don't advance `next_due`); else enqueue +
`UpsertHeartbeatState(last_run_at=now, next_due=now+interval+rand(jitter))`. Missed
ticks **coalesce to a single run** (next_due re-anchored to now). A failed enqueue
records `last_status` but still advances one interval (no hot-loop). Scan errors
are logged and never abort the supervisor loop.

## Off-by-default / additive proof
- With **no** heartbeat sections, `LoadHeartbeats` returns empty and
  `runHeartbeatScanOnce` returns **before any store touch or enqueue** — proven by
  `TestHeartbeatScanOffByDefault` and `TestLoadHeartbeatsOffByDefault`. The
  registered-loop scan is additionally gated on `!dryRun`.
- The `LoadAgentTypes` guard only clears a remainder containing `.`; no existing
  (non-subsection) agent name contains `.`, so existing configs are unchanged —
  proven by `TestLoadAgentTypesGuardIgnoresHeartbeatSubsections`.
- The migration is **CREATE TABLE only** (no ALTER/renumber); the table stays
  empty until a heartbeat fires.

## Restart-safe dedup
The persisted `next_due` plus the active-job (`max_concurrent`) check mean a daemon
restart never re-fires an active or not-yet-due heartbeat
(`TestHeartbeatScanEnqueuesDueJob` rescan assertion, `TestHeartbeatScanSkipsOnActiveJob`).

## Deferred (NOT built — kept to MVP)
- `action = "review" | "implement"` heartbeats (only read-only `ask`).
- Agent-**type** scoping (only named agents).
- A write-side CLI to create/edit heartbeats (edit config directly).
- Per-job runtime override (#531).

Relates #533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
