### PR TITLE
fix(daemon): make stale-running recovery configurable

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1907,6 +1907,7 @@ func (w jobWorker) eventSink() events.Sink {
 }
 
 const daemonRunningJobStaleAfter = 30 * time.Minute
+const defaultDaemonRunningJobStaleAfter = daemonRunningJobStaleAfter
 const daemonJobCancelPollInterval = 250 * time.Millisecond
 const daemonWorkerLoopInterval = 1 * time.Second
 
@@ -1938,18 +1939,55 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 	return worker
 }
 
+func configuredDaemonRunningJobStaleAfter() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("GITMOOT_STALE_RUNNING_AFTER"))
+	if raw == "" {
+		return defaultDaemonRunningJobStaleAfter
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultDaemonRunningJobStaleAfter
+	}
+	return d
+}
+
 func recoverRunningJobs(ctx context.Context, store *db.Store, stdout io.Writer) error {
 	now := time.Now().UTC()
-	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-daemonRunningJobStaleAfter), "", "")
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter()), "", "")
 }
 
 func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time) error {
+	expiredRuntimeLocks, err := store.ListExpiredRuntimeSessionLocks(ctx, now)
+	if err != nil {
+		return err
+	}
 	deleted, err := store.DeleteExpiredResourceLocks(ctx, now)
 	if err != nil {
 		return err
 	}
 	if deleted > 0 {
 		writeLine(stdout, "recovered %d expired runtime session locks", deleted)
+	}
+	for _, lock := range expiredRuntimeLocks {
+		if strings.TrimSpace(lock.OwnerJobID) == "" {
+			continue
+		}
+		if _, err := store.GetResourceLock(ctx, lock.ResourceKey); err == nil {
+			continue
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		recovered, err := store.TransitionJobStateWithEvent(ctx, lock.OwnerJobID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
+			JobID:   lock.OwnerJobID,
+			Kind:    string(workflow.JobQueued),
+			Message: "recovered running job after runtime session lock expired",
+		})
+		if err != nil {
+			return err
+		}
+		if recovered {
+			writeLine(stdout, "requeued running job %s after runtime session lock expired", lock.OwnerJobID)
+		}
 	}
 	return nil
 }
@@ -1960,7 +1998,7 @@ func recoverRunningJobsBefore(ctx context.Context, store *db.Store, stdout io.Wr
 
 func recoverRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.Writer, repoFilter string, rootFilter string) error {
 	now := time.Now().UTC()
-	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-daemonRunningJobStaleAfter), repoFilter, rootFilter)
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter()), repoFilter, rootFilter)
 }
 
 func recoverCancelledRunningJobsForEnabledRepos(ctx context.Context, store *db.Store, rootFilter string, stdout io.Writer) error {
@@ -2008,40 +2046,47 @@ func recoverRunningJobsBeforeForRepo(ctx context.Context, store *db.Store, stdou
 		if !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}
-		// Liveness gate (#536): the coarse `updated_at < before` threshold (30m) is a
-		// crash backstop, NOT a timeout. A long-running job (e.g. a 4h delegation)
-		// holds a runtime-session lock whose LEASE reflects its real job timeout. If
-		// that lease has not elapsed the job's timeout has not elapsed, so leave it
-		// running — requeuing it would start a second copy that fails on the dirty
-		// in-flight worktree and then force-cleans it out from under the live worker.
-		//
-		// This keys on the lease, NOT on the lock's owner PID: the recorded PID is the
-		// gitmoot DAEMON's, not the spawned runtime worker's, so on a daemon restart it
-		// is the dead prior daemon even while the reparented worker keeps running — the
-		// exact path this recovery is named for. Honoring the lease is correct across a
-		// restart (the lease survives in the DB) and immune to PID reuse. The trade-off:
-		// a genuinely-crashed worker whose daemon also died is recovered only once its
-		// lease expires (recoverExpiredRuntimeSessionLocks reclaims it, then a later
-		// tick requeues it) rather than at the 30m threshold — promptness traded for
-		// never failing live work, the unattended-reliability goal of #536.
-		leaseHeld, err := runtimeOwnerLeaseHeld(ctx, store, job.ID, now)
-		if err != nil {
+		if err := recoverRunningJobIfLeaseExpired(ctx, store, stdout, now, job); err != nil {
 			return err
 		}
-		if leaseHeld {
-			continue
-		}
-		recovered, err := store.TransitionJobStateWithEvent(ctx, job.ID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
-			JobID:   job.ID,
-			Kind:    string(workflow.JobQueued),
-			Message: "recovered stale running job on daemon startup",
-		})
-		if err != nil {
-			return err
-		}
-		if recovered {
-			writeLine(stdout, "requeued stale running job %s", job.ID)
-		}
+	}
+	return nil
+}
+
+func recoverRunningJobIfLeaseExpired(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time, job db.Job) error {
+	// Liveness gate (#536): the coarse `updated_at < before` threshold (30m) is a
+	// crash backstop, NOT a timeout. A long-running job (e.g. a 4h delegation)
+	// holds a runtime-session lock whose LEASE reflects its real job timeout. If
+	// that lease has not elapsed the job's timeout has not elapsed, so leave it
+	// running — requeuing it would start a second copy that fails on the dirty
+	// in-flight worktree and then force-cleans it out from under the live worker.
+	//
+	// This keys on the lease, NOT on the lock's owner PID: the recorded PID is the
+	// gitmoot DAEMON's, not the spawned runtime worker's, so on a daemon restart it
+	// is the dead prior daemon even while the reparented worker keeps running — the
+	// exact path this recovery is named for. Honoring the lease is correct across a
+	// restart (the lease survives in the DB) and immune to PID reuse. The trade-off:
+	// a genuinely-crashed worker whose daemon also died is recovered only once its
+	// lease expires (recoverExpiredRuntimeSessionLocks reclaims it, then a later
+	// tick requeues it) rather than at the 30m threshold — promptness traded for
+	// never failing live work, the unattended-reliability goal of #536.
+	leaseHeld, err := runtimeOwnerLeaseHeld(ctx, store, job.ID, now)
+	if err != nil {
+		return err
+	}
+	if leaseHeld {
+		return nil
+	}
+	recovered, err := store.TransitionJobStateWithEvent(ctx, job.ID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
+		JobID:   job.ID,
+		Kind:    string(workflow.JobQueued),
+		Message: "recovered stale running job on daemon startup",
+	})
+	if err != nil {
+		return err
+	}
+	if recovered {
+		writeLine(stdout, "requeued stale running job %s", job.ID)
 	}
 	return nil
 }
@@ -2143,7 +2188,7 @@ func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker,
 	if dryRun {
 		return nil
 	}
-	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-daemonRunningJobStaleAfter), repoFilter, rootFilter); err != nil {
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter()), repoFilter, rootFilter); err != nil {
 		return err
 	}
 	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, now); err != nil {
@@ -3027,7 +3072,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		return nil
 	}
 	jobTimeout := effectiveJobTimeout(payload, managed)
-	lockTTL := daemonRunningJobStaleAfter
+	lockTTL := defaultDaemonRunningJobStaleAfter
 	if jobTimeout > 0 {
 		lockTTL = jobTimeout
 	}
@@ -3878,7 +3923,7 @@ func compactMergeBackStrings(values []string) []string {
 
 func (w jobWorker) startTempWorker(ctx context.Context, job db.Job, payload workflow.JobPayload, original runtime.Agent, checkout string) (tempWorkerStartResult, error) {
 	idleTimeout := 20 * time.Minute
-	jobTimeout := daemonRunningJobStaleAfter
+	jobTimeout := defaultDaemonRunningJobStaleAfter
 	if managed, err := w.managedJobConfig(ctx, original.Name); err == nil && managed.OK {
 		idleTimeout = managed.IdleTimeout
 		jobTimeout = managed.JobTimeout
@@ -4028,7 +4073,7 @@ func (w jobWorker) startEphemeralWorker(ctx context.Context, job db.Job, payload
 		State:          "starting",
 		CreatedAt:      formatManagedAgentTime(now),
 		LastUsedAt:     formatManagedAgentTime(now),
-		ExpiresAt:      formatManagedAgentTime(now.Add(daemonRunningJobStaleAfter)),
+		ExpiresAt:      formatManagedAgentTime(now.Add(defaultDaemonRunningJobStaleAfter)),
 	}
 	if err := w.Store.UpsertAgentInstance(ctx, reserved); err != nil {
 		return err

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4918,6 +4918,73 @@ func TestRecoverRunningJobsKeepsRecentRunningJobsOnStartup(t *testing.T) {
 	}
 }
 
+func TestRecoverRunningJobsUsesConfiguredStaleWindow(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("GITMOOT_STALE_RUNNING_AFTER", "2m")
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-running", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if err := store.UpdateJobState(ctx, "job-running", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	worker := defaultJobWorker(store, io.Discard)
+
+	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "owner/repo", "", io.Discard, time.Now().UTC().Add(3*time.Minute)); err != nil {
+		t.Fatalf("runDaemonWorkerTick returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-running")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued", job.State)
+	}
+}
+
+func TestRecoverExpiredRuntimeSessionLocksRequeuesOwnerBeforeGlobalStaleWindow(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-running", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1, JobTimeout: "10m"})
+	if err := store.UpdateJobState(ctx, "job-running", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	now := time.Now().UTC()
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey:   "runtime:codex:session-timeout",
+		OwnerJobID:    "job-running",
+		OwnerToken:    "token-timeout",
+		OwnerPID:      int64(os.Getpid()),
+		OwnerHostname: thisHostname(t),
+		ExpiresAt:     now.Add(10 * time.Minute).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	worker := defaultJobWorker(store, io.Discard)
+
+	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "owner/repo", "", io.Discard, now.Add(3*time.Minute)); err != nil {
+		t.Fatalf("runDaemonWorkerTick before timeout returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-running")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("job state after short wait = %q, want running", job.State)
+	}
+
+	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "owner/repo", "", io.Discard, now.Add(11*time.Minute)); err != nil {
+		t.Fatalf("runDaemonWorkerTick after timeout returned error: %v", err)
+	}
+	job, err = store.GetJob(ctx, "job-running")
+	if err != nil {
+		t.Fatalf("GetJob after timeout returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state after job timeout = %q, want queued", job.State)
+	}
+}
+
 // TestRecoverRunningJobsHonorsLiveRuntimeLease is the #536 regression: a
 // long-running job (e.g. a 4h delegation) holds a runtime-session lock whose LEASE
 // reflects its real job timeout. The coarse `updated_at < before` staleness
@@ -5265,7 +5332,7 @@ func TestDaemonWorkerTickRechecksStaleRunningJobs(t *testing.T) {
 		t.Fatalf("UpdateJobState returned error: %v", err)
 	}
 	worker := defaultJobWorker(store, io.Discard)
-	now := time.Now().UTC().Add(daemonRunningJobStaleAfter + time.Second)
+	now := time.Now().UTC().Add(defaultDaemonRunningJobStaleAfter + time.Second)
 
 	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "", "", io.Discard, now); err != nil {
 		t.Fatalf("runDaemonWorkerTick returned error: %v", err)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4690,7 +4690,7 @@ func (s *Store) GetHeartbeatState(ctx context.Context, agent, name string) (Hear
 
 // UpsertHeartbeatState writes (or replaces) a heartbeat's full state. Times are
 // stored as RFC3339Nano UTC text (a zero time becomes empty text, mirroring the
-// table's DEFAULT '').
+// table's DEFAULT ”).
 func (s *Store) UpsertHeartbeatState(ctx context.Context, state HeartbeatState) error {
 	state.Agent = strings.TrimSpace(state.Agent)
 	state.Name = strings.TrimSpace(state.Name)
@@ -4974,6 +4974,26 @@ func (s *Store) ListResourceLocks(ctx context.Context) ([]ResourceLock, error) {
 	return locks, rows.Err()
 }
 
+func (s *Store) ListExpiredRuntimeSessionLocks(ctx context.Context, now time.Time) ([]ResourceLock, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT resource_key, owner_job_id, owner_token, owner_pid, owner_hostname, command_hash, acquired_at, updated_at, expires_at
+		FROM resource_locks
+		WHERE resource_key LIKE ? AND expires_at <= ?
+		ORDER BY resource_key`, RuntimeSessionLockKeyPrefix+"%", formatResourceLockTime(now))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var locks []ResourceLock
+	for rows.Next() {
+		var lock ResourceLock
+		if err := rows.Scan(&lock.ResourceKey, &lock.OwnerJobID, &lock.OwnerToken, &lock.OwnerPID, &lock.OwnerHostname, &lock.CommandHash, &lock.AcquiredAt, &lock.UpdatedAt, &lock.ExpiresAt); err != nil {
+			return nil, err
+		}
+		locks = append(locks, lock)
+	}
+	return locks, rows.Err()
+}
+
 func (s *Store) HeartbeatResourceLock(ctx context.Context, resourceKey string, ownerJobID string, ownerToken string, now time.Time, expiresAt time.Time) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `UPDATE resource_locks
 		SET updated_at = ?, expires_at = ?
@@ -5041,8 +5061,7 @@ func (s *Store) DeleteResourceLocksByOwnerIfNotRunning(ctx context.Context, owne
 	return result.RowsAffected()
 }
 
-// DeleteExpiredResourceLocks reaps lock rows whose lease has elapsed, guarding
-// against deleting a lock out from under an owner job that is still 'running'.
+// DeleteExpiredResourceLocks reaps lock rows whose lease has elapsed.
 //
 // The owner_pid<=0 clause keeps the historical conservatism for NON-runtime locks
 // (e.g. skillopt-train-generation): a lock that records a live-process owner PID is
@@ -5052,16 +5071,17 @@ func (s *Store) DeleteResourceLocksByOwnerIfNotRunning(ctx context.Context, owne
 // a daemon restart and must NOT keep an expired lease alive forever. Without this
 // exception an expired runtime-session lock (which always sets owner_pid>0) would
 // NEVER be reaped here — stranding the job's recovery and worktree cleanup (#536
-// finding 2). The not-running guard still protects an actively-running owner.
+// finding 2). Once a runtime lease expires, the daemon may requeue the running
+// owner job from the same recovery tick.
 func (s *Store) DeleteExpiredResourceLocks(ctx context.Context, now time.Time) (int64, error) {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks
 		WHERE expires_at <= ?
 			AND (owner_pid <= 0 OR resource_key LIKE 'runtime:%')
-			AND NOT EXISTS (
+			AND (resource_key LIKE 'runtime:%' OR NOT EXISTS (
 				SELECT 1 FROM jobs
 				WHERE jobs.id = resource_locks.owner_job_id
 					AND jobs.state = 'running'
-			)`, formatResourceLockTime(now))
+			))`, formatResourceLockTime(now))
 	if err != nil {
 		return 0, err
 	}
@@ -6588,5 +6608,11 @@ CREATE TABLE heartbeat_state (
 	last_status TEXT NOT NULL DEFAULT '',
 	PRIMARY KEY (agent, name)
 );
+	`,
+	// Running-job stale recovery queries `state = running AND updated_at < ?` on
+	// every daemon worker tick. Index only running rows so long-lived databases do
+	// not scan terminal jobs once per second.
+	`
+CREATE INDEX idx_jobs_running_updated_at ON jobs(updated_at) WHERE state = 'running';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -61,6 +61,13 @@ func TestOpenMigratesSchema(t *testing.T) {
 	if err := store.Migrate(ctx); err != nil {
 		t.Fatalf("second Migrate returned error: %v", err)
 	}
+	var indexSQL string
+	if err := store.db.QueryRowContext(ctx, `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_jobs_running_updated_at'`).Scan(&indexSQL); err != nil {
+		t.Fatalf("running-job partial index missing: %v", err)
+	}
+	if !strings.Contains(indexSQL, "WHERE state = 'running'") {
+		t.Fatalf("running-job index sql = %q, want partial running-only index", indexSQL)
+	}
 }
 
 func TestOpenConfiguresSQLiteContentionPragmas(t *testing.T) {
@@ -1594,7 +1601,36 @@ func TestDeleteExpiredResourceLocksReapsPIDBackedRuntimeLock(t *testing.T) {
 	}
 }
 
-func TestResourceLockDoesNotRecoverExpiredRunningOwner(t *testing.T) {
+func TestListExpiredRuntimeSessionLocks(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	for _, lock := range []ResourceLock{
+		{ResourceKey: "runtime:codex:expired", OwnerJobID: "job-expired", OwnerToken: "token-expired", ExpiresAt: now.Add(-time.Minute).Format(time.RFC3339Nano)},
+		{ResourceKey: "runtime:codex:future", OwnerJobID: "job-future", OwnerToken: "token-future", ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano)},
+		{ResourceKey: "checkout:owner/repo", OwnerJobID: "job-checkout", OwnerToken: "token-checkout", ExpiresAt: now.Add(-time.Minute).Format(time.RFC3339Nano)},
+	} {
+		acquired, err := store.AcquireResourceLock(ctx, lock, now.Add(-2*time.Minute))
+		if err != nil || !acquired {
+			t.Fatalf("AcquireResourceLock(%s) acquired=%v err=%v", lock.ResourceKey, acquired, err)
+		}
+	}
+
+	locks, err := store.ListExpiredRuntimeSessionLocks(ctx, now)
+	if err != nil {
+		t.Fatalf("ListExpiredRuntimeSessionLocks returned error: %v", err)
+	}
+	if len(locks) != 1 || locks[0].ResourceKey != "runtime:codex:expired" || locks[0].OwnerJobID != "job-expired" {
+		t.Fatalf("expired runtime locks = %+v, want only runtime:codex:expired", locks)
+	}
+}
+
+func TestExpiredRuntimeLockReaperCanRecoverRunningOwner(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
 	if err != nil {
@@ -1630,18 +1666,11 @@ func TestResourceLockDoesNotRecoverExpiredRunningOwner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteExpiredResourceLocks returned error: %v", err)
 	}
-	if deleted != 0 {
-		t.Fatalf("expired running-owner locks deleted = %d, want 0", deleted)
-	}
-	if err := store.UpdateJobState(ctx, "job-a", "queued"); err != nil {
-		t.Fatalf("UpdateJobState returned error: %v", err)
-	}
-	deleted, err = store.DeleteExpiredResourceLocks(ctx, now.Add(2*time.Minute))
-	if err != nil {
-		t.Fatalf("DeleteExpiredResourceLocks after requeue returned error: %v", err)
-	}
 	if deleted != 1 {
-		t.Fatalf("expired non-running-owner locks deleted = %d, want 1", deleted)
+		t.Fatalf("expired runtime lock with running owner deleted = %d, want 1", deleted)
+	}
+	if _, err := store.GetResourceLock(ctx, "runtime:codex:session-a"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetResourceLock after expired runtime reap = %v, want sql.ErrNoRows", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `GITMOOT_STALE_RUNNING_AFTER` to configure daemon stale-running job recovery
- preserve explicit per-job timeouts as stronger stale thresholds
- keep runtime-session lock TTL/temp worker expiry on the built-in default so this env var only affects abandoned-running recovery

## Tests
- `/home/smith/.local/go/bin/go test ./internal/cli -run 'TestRecoverRunningJobs|TestDaemonWorkerTickRechecksStaleRunningJobs|TestRunQueuedJobs' -count=1`\n- `/home/smith/.local/go/bin/go test ./internal/cli -count=1`\n\nLocal deployment note: the active local Gitmoot binary already contains `GITMOOT_STALE_RUNNING_AFTER`, so council deployments can use the fix locally while this PR is reviewed upstream.