### PR TITLE
feat(agenttemplate): finalize GitHub-backed templates publish/pull (#476)

### DIFF
--- a/internal/agenttemplate/agenttemplate.go
+++ b/internal/agenttemplate/agenttemplate.go
@@ -3,6 +3,7 @@ package agenttemplate
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -12,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -61,6 +63,30 @@ type File struct {
 type Fetcher interface {
 	ResolveRef(ctx context.Context, repo string, ref string) (string, error)
 	FetchFile(ctx context.Context, repo string, ref string, path string) (File, error)
+}
+
+// DirEntry is one entry in a remote directory listing (a subset of the GitHub
+// contents API entry shape), used by bulk pull to discover the template .md
+// files under a remote subdir.
+type DirEntry struct {
+	Name string
+	Path string
+	Type string
+}
+
+// DirLister lists a directory on a remote repo. It is the bulk-pull counterpart
+// to Fetcher's single-file FetchFile; GHFetcher implements both.
+type DirLister interface {
+	ListDir(ctx context.Context, repo string, ref string, path string) ([]DirEntry, error)
+}
+
+// RemoteSource is the combined read surface bulk pull needs: resolve a ref,
+// fetch a file, and list a directory. GHFetcher satisfies it. It is a separate
+// interface from Fetcher so existing single-file callers and their test fakes
+// are unaffected (additive).
+type RemoteSource interface {
+	Fetcher
+	DirLister
 }
 
 var builtins = []Definition{
@@ -561,6 +587,145 @@ func Export(template db.AgentTemplate) (string, error) {
 	return FormatTemplateContent(metadata, InstructionsForContent(template.Content)), nil
 }
 
+// PullOutcome is the per-template result of a bulk pull.
+type PullOutcome string
+
+const (
+	// PullInstalled means the template was not present locally and was installed.
+	PullInstalled PullOutcome = "installed"
+	// PullUpdated means a divergent local row was re-fetched as a new version
+	// (UpsertAgentTemplate auto-versions — conflict-as-new-version).
+	PullUpdated PullOutcome = "updated"
+	// PullUnchanged means the remote content matched the local row byte-for-byte;
+	// nothing was written (identical-content no-op).
+	PullUnchanged PullOutcome = "unchanged"
+	// PullSkipped means the id was deliberately not pulled (built-in or retired).
+	PullSkipped PullOutcome = "skipped"
+	// PullFailed means this one template failed; the batch continues (partial).
+	PullFailed PullOutcome = "failed"
+)
+
+// PullResult reports the outcome of pulling one template id.
+type PullResult struct {
+	ID      string
+	Outcome PullOutcome
+	Commit  string
+	Detail  string
+}
+
+// ListRemoteTemplateIDs lists path on repo@ref and returns the ids of the .md
+// files it contains (basename without the .md suffix), sorted and de-duplicated
+// of non-template entries. It is the discovery half of bulk pull.
+func ListRemoteTemplateIDs(ctx context.Context, lister DirLister, repo string, ref string, path string) ([]string, error) {
+	if lister == nil {
+		return nil, errors.New("agent template directory lister is required")
+	}
+	entries, err := lister.ListDir(ctx, repo, ref, path)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !strings.EqualFold(strings.TrimSpace(entry.Type), "file") {
+			continue
+		}
+		name := strings.TrimSpace(entry.Name)
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		id := strings.TrimSuffix(name, ".md")
+		if ValidateID(id) != nil {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// Pull bulk-installs templates from a remote subdir, routing each through the
+// same fetch core AddRemote/UpdateRemote use and the auto-versioning
+// UpsertAgentTemplate. When ids is empty it discovers every .md file under path
+// via ListRemoteTemplateIDs. Conflicts become a new version; identical content
+// is a no-op; built-in and retired ids are skipped; a per-file error fails only
+// that entry (the batch continues, so a partial result is reported clearly). It
+// only touches the network when invoked. dryRun fetches and compares but writes
+// nothing.
+func Pull(ctx context.Context, store *db.Store, source RemoteSource, repo string, ref string, path string, ids []string, dryRun bool) ([]PullResult, error) {
+	if store == nil {
+		return nil, errors.New("agent template store is required")
+	}
+	if source == nil {
+		return nil, errors.New("agent template source is required")
+	}
+	repo = strings.TrimSpace(repo)
+	if !IsRemoteRepo(repo) {
+		return nil, fmt.Errorf("template source repo %q must be a GitHub owner/repo", repo)
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		ref = "main"
+	}
+	path = strings.Trim(strings.TrimSpace(path), "/")
+	if path == "" {
+		path = "templates"
+	}
+	selected := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if trimmed := strings.TrimSpace(id); trimmed != "" {
+			selected = append(selected, trimmed)
+		}
+	}
+	if len(selected) == 0 {
+		discovered, err := ListRemoteTemplateIDs(ctx, source, repo, ref, path)
+		if err != nil {
+			return nil, err
+		}
+		selected = discovered
+	}
+	results := make([]PullResult, 0, len(selected))
+	for _, id := range selected {
+		results = append(results, pullOne(ctx, store, source, repo, ref, path, id, dryRun))
+	}
+	return results, nil
+}
+
+func pullOne(ctx context.Context, store *db.Store, source RemoteSource, repo string, ref string, path string, id string, dryRun bool) PullResult {
+	if _, ok := Lookup(id); ok {
+		return PullResult{ID: id, Outcome: PullSkipped, Detail: "built-in template; already lives upstream"}
+	}
+	if IsRetired(id) {
+		return PullResult{ID: id, Outcome: PullSkipped, Detail: "retired template"}
+	}
+	if err := ValidateID(id); err != nil {
+		return PullResult{ID: id, Outcome: PullFailed, Detail: err.Error()}
+	}
+	filePath := path + "/" + id + ".md"
+	fetched, err := fetchRemoteTemplate(ctx, source, id, repo, ref, filePath)
+	if err != nil {
+		return PullResult{ID: id, Outcome: PullFailed, Detail: err.Error()}
+	}
+	existing, err := store.GetAgentTemplate(ctx, id)
+	hasExisting := err == nil
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return PullResult{ID: id, Outcome: PullFailed, Detail: err.Error()}
+	}
+	if hasExisting && existing.Content == fetched.Content {
+		return PullResult{ID: id, Outcome: PullUnchanged, Commit: fetched.ResolvedCommit}
+	}
+	outcome := PullInstalled
+	if hasExisting {
+		outcome = PullUpdated
+	}
+	if dryRun {
+		return PullResult{ID: id, Outcome: outcome, Commit: fetched.ResolvedCommit, Detail: "dry-run"}
+	}
+	if err := store.UpsertAgentTemplate(ctx, fetched); err != nil {
+		return PullResult{ID: id, Outcome: PullFailed, Detail: err.Error()}
+	}
+	return PullResult{ID: id, Outcome: outcome, Commit: fetched.ResolvedCommit}
+}
+
 func ContentForDefinition(definition Definition, content string) (string, error) {
 	content, _, err := ContentAndMetadataForDefinition(definition, content)
 	return content, err
@@ -683,6 +848,36 @@ func (f GHFetcher) FetchFile(ctx context.Context, repo string, ref string, path 
 		return File{}, fmt.Errorf("decode github contents: %w", err)
 	}
 	return File{Content: string(decoded)}, nil
+}
+
+// ListDir lists path on repo@ref via `gh api repos/<repo>/contents/<path>`,
+// returning the directory's entries. It is the bulk-pull discovery call that
+// finds the template .md files under a remote subdir; per-file content is then
+// fetched via FetchFile.
+func (f GHFetcher) ListDir(ctx context.Context, repo string, ref string, path string) ([]DirEntry, error) {
+	repo = strings.TrimSpace(repo)
+	ref = strings.TrimSpace(ref)
+	path = strings.Trim(strings.TrimSpace(path), "/")
+	if repo == "" || ref == "" || path == "" {
+		return nil, errors.New("repo, ref, and path are required")
+	}
+	result, err := f.run(ctx, "api", "-X", "GET", "repos/"+repo+"/contents/"+path, "-f", "ref="+ref)
+	if err != nil {
+		return nil, err
+	}
+	var entries []struct {
+		Name string `json:"name"`
+		Path string `json:"path"`
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &entries); err != nil {
+		return nil, fmt.Errorf("decode github directory listing: %w", err)
+	}
+	out := make([]DirEntry, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, DirEntry{Name: entry.Name, Path: entry.Path, Type: entry.Type})
+	}
+	return out, nil
 }
 
 func (f GHFetcher) run(ctx context.Context, args ...string) (subprocess.Result, error) {

--- a/internal/agenttemplate/pull_test.go
+++ b/internal/agenttemplate/pull_test.go
@@ -1,0 +1,185 @@
+package agenttemplate
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+type fakeRemoteSource struct {
+	commit  string
+	entries []DirEntry
+	files   map[string]string
+}
+
+func (f fakeRemoteSource) ResolveRef(context.Context, string, string) (string, error) {
+	return f.commit, nil
+}
+
+func (f fakeRemoteSource) FetchFile(_ context.Context, _ string, _ string, path string) (File, error) {
+	content, ok := f.files[path]
+	if !ok {
+		return File{}, fmt.Errorf("no file at %s", path)
+	}
+	return File{Content: content}, nil
+}
+
+func (f fakeRemoteSource) ListDir(context.Context, string, string, string) ([]DirEntry, error) {
+	return f.entries, nil
+}
+
+func outcomeByID(results []PullResult) map[string]PullResult {
+	out := make(map[string]PullResult, len(results))
+	for _, result := range results {
+		out[result.ID] = result
+	}
+	return out
+}
+
+func TestPullListsInstallsSkipsAndNoOps(t *testing.T) {
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	frontend := testTemplateContent("frontend-reviewer", "Review UI changes.\n")
+	api := testTemplateContent("api-reviewer", "Review API changes.\n")
+	source := fakeRemoteSource{
+		commit: "sha-1",
+		entries: []DirEntry{
+			{Name: "frontend-reviewer.md", Path: "templates/frontend-reviewer.md", Type: "file"},
+			{Name: "api-reviewer.md", Path: "templates/api-reviewer.md", Type: "file"},
+			// A built-in id present in the repo must be discovered then SKIPPED.
+			{Name: PlannerTemplateID + ".md", Path: "templates/" + PlannerTemplateID + ".md", Type: "file"},
+			// Non-template entries are filtered out by discovery.
+			{Name: "README.md", Path: "templates/README.md", Type: "file"},
+			{Name: "nested", Path: "templates/nested", Type: "dir"},
+		},
+		files: map[string]string{
+			"templates/frontend-reviewer.md":         frontend,
+			"templates/api-reviewer.md":              api,
+			"templates/" + PlannerTemplateID + ".md": testTemplateContent(PlannerTemplateID, "Plan.\n"),
+		},
+	}
+
+	// First pull with --all (empty ids) installs the two custom templates and
+	// skips the built-in.
+	results, err := Pull(ctx, store, source, "jerry/templates", "main", "templates", nil, false)
+	if err != nil {
+		t.Fatalf("Pull returned error: %v", err)
+	}
+	got := outcomeByID(results)
+	if got["frontend-reviewer"].Outcome != PullInstalled || got["api-reviewer"].Outcome != PullInstalled {
+		t.Fatalf("expected both custom templates installed, got %+v", results)
+	}
+	if got[PlannerTemplateID].Outcome != PullSkipped {
+		t.Fatalf("expected built-in %s skipped, got %+v", PlannerTemplateID, results)
+	}
+	if _, ok := got["README"]; ok {
+		t.Fatalf("README must not be discovered as a template: %+v", results)
+	}
+
+	// Second identical pull is a no-op for both.
+	results, err = Pull(ctx, store, source, "jerry/templates", "main", "templates", nil, false)
+	if err != nil {
+		t.Fatalf("second Pull returned error: %v", err)
+	}
+	got = outcomeByID(results)
+	if got["frontend-reviewer"].Outcome != PullUnchanged || got["api-reviewer"].Outcome != PullUnchanged {
+		t.Fatalf("expected unchanged no-op on identical pull, got %+v", results)
+	}
+
+	// Change one template upstream: it re-fetches as a new version (conflict-as-
+	// new-version), the other stays unchanged.
+	source.commit = "sha-2"
+	source.files["templates/frontend-reviewer.md"] = testTemplateContent("frontend-reviewer", "Review UI changes deeply.\n")
+	results, err = Pull(ctx, store, source, "jerry/templates", "main", "templates", []string{"frontend-reviewer", "api-reviewer"}, false)
+	if err != nil {
+		t.Fatalf("third Pull returned error: %v", err)
+	}
+	got = outcomeByID(results)
+	if got["frontend-reviewer"].Outcome != PullUpdated {
+		t.Fatalf("expected frontend-reviewer updated, got %+v", results)
+	}
+	if got["api-reviewer"].Outcome != PullUnchanged {
+		t.Fatalf("expected api-reviewer unchanged, got %+v", results)
+	}
+	stored, err := store.GetAgentTemplate(ctx, "frontend-reviewer")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	if stored.VersionNumber != 2 {
+		t.Fatalf("expected frontend-reviewer at v2 after conflict, got v%d", stored.VersionNumber)
+	}
+}
+
+func TestPullDryRunWritesNothing(t *testing.T) {
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	source := fakeRemoteSource{
+		commit: "sha-1",
+		files: map[string]string{
+			"templates/frontend-reviewer.md": testTemplateContent("frontend-reviewer", "Review UI changes.\n"),
+		},
+	}
+	results, err := Pull(ctx, store, source, "jerry/templates", "main", "templates", []string{"frontend-reviewer"}, true)
+	if err != nil {
+		t.Fatalf("Pull dry-run returned error: %v", err)
+	}
+	if len(results) != 1 || results[0].Outcome != PullInstalled {
+		t.Fatalf("dry-run should report would-install, got %+v", results)
+	}
+	if _, err := store.GetAgentTemplate(ctx, "frontend-reviewer"); err == nil {
+		t.Fatalf("dry-run must not write the template to the store")
+	}
+}
+
+func TestPullReportsPerFileFailureAndContinues(t *testing.T) {
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	source := fakeRemoteSource{
+		commit: "sha-1",
+		files: map[string]string{
+			"templates/frontend-reviewer.md": testTemplateContent("frontend-reviewer", "Review UI changes.\n"),
+			// api-reviewer.md is deliberately absent -> fetch fails.
+		},
+	}
+	results, err := Pull(ctx, store, source, "jerry/templates", "main", "templates", []string{"api-reviewer", "frontend-reviewer"}, false)
+	if err != nil {
+		t.Fatalf("Pull returned error: %v", err)
+	}
+	got := outcomeByID(results)
+	if got["api-reviewer"].Outcome != PullFailed || got["api-reviewer"].Detail == "" {
+		t.Fatalf("expected api-reviewer failed with detail, got %+v", results)
+	}
+	// The batch continued and still installed the healthy one.
+	if got["frontend-reviewer"].Outcome != PullInstalled {
+		t.Fatalf("expected frontend-reviewer installed despite sibling failure, got %+v", results)
+	}
+}
+
+func TestPullRejectsMalformedRepo(t *testing.T) {
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if _, err := Pull(context.Background(), store, fakeRemoteSource{}, "not-owner-repo", "main", "templates", []string{"x"}, false); err == nil {
+		t.Fatalf("Pull accepted a malformed repo")
+	}
+}

--- a/internal/cli/agent_template.go
+++ b/internal/cli/agent_template.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 )
 
@@ -30,6 +31,12 @@ func runAgentTemplate(args []string, stdout, stderr io.Writer) int {
 		return runAgentTemplateAdd(args[1:], stdout, stderr)
 	case "export":
 		return runAgentTemplateExport(args[1:], stdout, stderr)
+	case "publish":
+		return runAgentTemplatePublish(args[1:], stdout, stderr)
+	case "pull":
+		return runAgentTemplatePull(args[1:], stdout, stderr)
+	case "remote":
+		return runAgentTemplateRemote(args[1:], stdout, stderr)
 	case "draft":
 		return runAgentTemplateDraft(args[1:], stdout, stderr)
 	case "list":
@@ -56,6 +63,10 @@ func printAgentTemplateUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent template add <template-id> --file ./agents/<template-id>.md [--name <name>] [--description <text>]")
 	fmt.Fprintln(w, "  gitmoot agent template add <template-id> --from-repo <owner/repo> [--ref <ref>] [--path <file>]")
 	fmt.Fprintln(w, "  gitmoot agent template export [<template-id>...] [--all] [--to <dir>] [--dry-run]")
+	fmt.Fprintln(w, "  gitmoot agent template publish [<template-id>...] [--all] [--repo <owner/repo>] [--path <subdir>] [--ref <branch>] [--message <msg>] [--create] [--dry-run]")
+	fmt.Fprintln(w, "  gitmoot agent template pull [<template-id>...] [--all] [--repo <owner/repo>] [--ref <ref>] [--path <subdir>] [--dry-run]")
+	fmt.Fprintln(w, "  gitmoot agent template remote set <owner/repo> [--ref <ref>] [--path <subdir>]")
+	fmt.Fprintln(w, "  gitmoot agent template remote show")
 	fmt.Fprintln(w, "  gitmoot agent template draft <template-id> [--output .gitmoot/templates/<template-id>.md] [--force]")
 	fmt.Fprintln(w, "  gitmoot agent template validate <file>")
 	fmt.Fprintln(w, "  gitmoot agent template list")
@@ -132,6 +143,22 @@ func runAgentTemplateAdd(args []string, stdout, stderr io.Writer) int {
 	if hasFile && hasRepo {
 		fmt.Fprintln(stderr, "agent template add accepts either --file or --from-repo, not both")
 		return 2
+	}
+	// With neither source given, fall back to the configured [template_remote]
+	// default (#476). This is additive/off-by-default: it only fires when a remote
+	// is configured; with no remote, hasRepo stays false and the existing
+	// "requires --file or --from-repo" error path below is byte-identical.
+	if !hasFile && !hasRepo {
+		if remote, ok := configuredTemplateRemote(*home); ok {
+			*fromRepo = remote.Repo
+			if strings.TrimSpace(*ref) == "" {
+				*ref = remote.Ref
+			}
+			if strings.TrimSpace(*path) == "" && strings.TrimSpace(remote.Path) != "" {
+				*path = strings.Trim(remote.Path, "/") + "/" + id + ".md"
+			}
+			hasRepo = true
+		}
 	}
 	if hasRepo {
 		fmt.Fprintln(stderr, "note: pulled templates are stored verbatim; only pull from repos you trust, and keep private prompts in a private repo")
@@ -543,27 +570,45 @@ func runAgentTemplateDiff(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprint(stdout, agenttemplate.DiffExact(cached.Content, file.Content))
 			return nil
 		}
-		definition, ok := agenttemplate.Lookup(id)
-		if !ok {
-			return fmt.Errorf("agent template %s is not a local custom template and has no built-in source", id)
+		if definition, ok := agenttemplate.Lookup(id); ok {
+			fetcher := newAgentTemplateFetcher()
+			resolvedCommit, err := fetcher.ResolveRef(context.Background(), definition.SourceRepo, definition.SourceRef)
+			if err != nil {
+				return err
+			}
+			upstream, err := fetcher.FetchFile(context.Background(), definition.SourceRepo, resolvedCommit, definition.SourcePath)
+			if err != nil {
+				return err
+			}
+			upstreamContent, err := agenttemplate.ContentForDefinition(definition, upstream.Content)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, "cached:   %s\n", cached.ResolvedCommit)
+			fmt.Fprintf(stdout, "upstream: %s\n", resolvedCommit)
+			fmt.Fprint(stdout, agenttemplate.Diff(cached.Content, upstreamContent))
+			return nil
 		}
-		fetcher := newAgentTemplateFetcher()
-		resolvedCommit, err := fetcher.ResolveRef(context.Background(), definition.SourceRepo, definition.SourceRef)
-		if err != nil {
-			return err
+		// A pulled (remote-sourced) row carries a real owner/repo and is
+		// re-fetchable: mirror the built-in branch against its stored
+		// SourceRepo/SourceRef/SourcePath so `diff` works for pulled templates
+		// (#476). Gated on IsRemote so local rows never reach here.
+		if agenttemplate.IsRemote(cached) {
+			fetcher := newAgentTemplateFetcher()
+			resolvedCommit, err := fetcher.ResolveRef(context.Background(), cached.SourceRepo, cached.SourceRef)
+			if err != nil {
+				return err
+			}
+			upstream, err := fetcher.FetchFile(context.Background(), cached.SourceRepo, resolvedCommit, cached.SourcePath)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(stdout, "cached:   %s\n", cached.ResolvedCommit)
+			fmt.Fprintf(stdout, "upstream: %s\n", resolvedCommit)
+			fmt.Fprint(stdout, agenttemplate.Diff(cached.Content, upstream.Content))
+			return nil
 		}
-		upstream, err := fetcher.FetchFile(context.Background(), definition.SourceRepo, resolvedCommit, definition.SourcePath)
-		if err != nil {
-			return err
-		}
-		upstreamContent, err := agenttemplate.ContentForDefinition(definition, upstream.Content)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(stdout, "cached:   %s\n", cached.ResolvedCommit)
-		fmt.Fprintf(stdout, "upstream: %s\n", resolvedCommit)
-		fmt.Fprint(stdout, agenttemplate.Diff(cached.Content, upstreamContent))
-		return nil
+		return fmt.Errorf("agent template %s is not a local custom template and has no built-in source", id)
 	})
 }
 
@@ -733,6 +778,14 @@ func shortCommit(commit string) string {
 
 func withStoreExit(home string, stderr io.Writer, label string, fn func(*db.Store) error) int {
 	if err := withStore(home, fn); err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", label, err)
+		return 1
+	}
+	return 0
+}
+
+func withStoreAndPathsExit(home string, stderr io.Writer, label string, fn func(config.Paths, *db.Store) error) int {
+	if err := withStoreAndPaths(home, fn); err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", label, err)
 		return 1
 	}

--- a/internal/cli/agent_template_remote.go
+++ b/internal/cli/agent_template_remote.go
@@ -1,0 +1,372 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/daemon"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+// templateRemoteClient is the GitHub write surface `publish` needs.
+// *github.GhClient satisfies it; tests inject a GhClient with a stubbed Runner
+// (or a fake) via newTemplateRemoteClient.
+type templateRemoteClient interface {
+	UpsertFile(ctx context.Context, input github.UpsertFileInput) (github.RepositoryFile, error)
+	RepositoryExists(ctx context.Context, repo github.Repository) (bool, error)
+	CreateRepository(ctx context.Context, repo github.Repository, private bool) error
+}
+
+// newTemplateRemoteClient builds the GitHub client `publish` uses. It is a var so
+// tests can replace it with a stubbed-Runner GhClient.
+var newTemplateRemoteClient = func() templateRemoteClient {
+	return github.NewClient("")
+}
+
+// newAgentTemplateRemoteSource builds the RemoteSource bulk `pull` uses (resolve
+// ref + fetch file + list dir). It is a var so tests can replace it with a fake.
+var newAgentTemplateRemoteSource = func() agenttemplate.RemoteSource {
+	return agenttemplate.GHFetcher{}
+}
+
+// configuredTemplateRemote returns the configured default template remote and
+// whether one is set. It is best-effort: any path/parse error (e.g. an
+// uninitialized home) reports "not configured" so callers fall back to their
+// existing flag-required behavior (off by default).
+func configuredTemplateRemote(home string) (config.TemplateRemotePolicy, bool) {
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return config.TemplateRemotePolicy{}, false
+	}
+	remote, err := config.LoadTemplateRemote(paths)
+	if err != nil || !remote.Configured() {
+		return config.TemplateRemotePolicy{}, false
+	}
+	return remote, true
+}
+
+// resolveTemplateRemote resolves the effective owner/repo, ref, and subdir for a
+// publish/pull invocation: an explicit flag wins, else the configured
+// [template_remote] default. The repo must resolve to a valid owner/repo or it
+// is an error. ref may be empty (the publish branch then defaults to the repo
+// default branch; pull defaults it to main). path falls back to the built-in
+// templates subdir.
+func resolveTemplateRemote(paths config.Paths, repoFlag, refFlag, pathFlag string) (repo, ref, path string, err error) {
+	remote, err := config.LoadTemplateRemote(paths)
+	if err != nil {
+		return "", "", "", err
+	}
+	repo = strings.TrimSpace(repoFlag)
+	if repo == "" {
+		repo = strings.TrimSpace(remote.Repo)
+	}
+	if repo == "" {
+		return "", "", "", errors.New("no template repo: pass --repo <owner/repo> or set a default with `gitmoot agent template remote set <owner/repo>`")
+	}
+	if _, perr := daemon.ParseRepository(repo); perr != nil {
+		return "", "", "", perr
+	}
+	ref = strings.TrimSpace(refFlag)
+	if ref == "" {
+		ref = strings.TrimSpace(remote.Ref)
+	}
+	path = strings.Trim(strings.TrimSpace(pathFlag), "/")
+	if path == "" {
+		path = strings.Trim(strings.TrimSpace(remote.Path), "/")
+	}
+	if path == "" {
+		path = config.DefaultTemplateRemotePath
+	}
+	return repo, ref, path, nil
+}
+
+// runAgentTemplatePublish pushes each selected custom template's rebuilt .md to
+// <repo>/<path>/<id>.md via the existing github.Client.UpsertFile (one GET-sha-
+// then-PUT call per file). It reports per-file success/failure so a partial batch
+// is clear, and only touches the network when invoked (--dry-run is network-free).
+func runAgentTemplatePublish(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent template publish", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	all := fs.Bool("all", false, "publish all custom templates (skips built-ins)")
+	repo := fs.String("repo", "", "GitHub owner/repo to publish to (default: configured remote)")
+	path := fs.String("path", "", "subdir within the repo to publish into (default: configured remote or templates)")
+	ref := fs.String("ref", "", "branch to commit to (default: configured remote or the repo default branch)")
+	message := fs.String("message", "", "commit message for each pushed file")
+	create := fs.Bool("create", false, "create the repo (private) if it does not exist")
+	dryRun := fs.Bool("dry-run", false, "list what would be published without touching the network")
+	ids, flagArgs := leadingIDs(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	ids = append(ids, fs.Args()...)
+	ids = compactValues(ids)
+	if len(ids) == 0 && !*all {
+		fmt.Fprintln(stderr, "agent template publish requires one or more template ids or --all")
+		return 2
+	}
+	if len(ids) > 0 && *all {
+		fmt.Fprintln(stderr, "agent template publish accepts either template ids or --all, not both")
+		return 2
+	}
+	return withStoreAndPathsExit(*home, stderr, "publish agent template", func(paths config.Paths, store *db.Store) error {
+		repoName, branch, subdir, err := resolveTemplateRemote(paths, *repo, *ref, *path)
+		if err != nil {
+			return err
+		}
+		targets, err := exportTargets(context.Background(), store, ids, *all, stderr)
+		if err != nil {
+			return err
+		}
+		if len(targets) == 0 {
+			fmt.Fprintln(stderr, "no custom templates to publish")
+			return nil
+		}
+		repository, err := daemon.ParseRepository(repoName)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(stderr, "note: publishing %d template(s) to %s; prompts are pushed verbatim — only publish private prompts to a private repo\n", len(targets), repoName)
+		if *dryRun {
+			for _, target := range targets {
+				writeLine(stdout, "would publish %s -> %s/%s/%s.md", target.ID, repoName, subdir, target.ID)
+			}
+			return nil
+		}
+		client := newTemplateRemoteClient()
+		if *create {
+			exists, err := client.RepositoryExists(context.Background(), repository)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				if err := client.CreateRepository(context.Background(), repository, true); err != nil {
+					return err
+				}
+				writeLine(stdout, "created %s (private)", repoName)
+			}
+		}
+		message := strings.TrimSpace(*message)
+		failures := 0
+		for _, target := range targets {
+			content, err := agenttemplate.Export(target)
+			if err != nil {
+				fmt.Fprintf(stderr, "publish %s: export failed: %v\n", target.ID, err)
+				failures++
+				continue
+			}
+			commitMessage := message
+			if commitMessage == "" {
+				commitMessage = "Publish agent template " + target.ID
+			}
+			file, err := client.UpsertFile(context.Background(), github.UpsertFileInput{
+				Repo:    repository,
+				Path:    subdir + "/" + target.ID + ".md",
+				Content: []byte(content),
+				Message: commitMessage,
+				Branch:  branch,
+			})
+			if err != nil {
+				fmt.Fprintf(stderr, "publish %s: %v\n", target.ID, err)
+				failures++
+				continue
+			}
+			writeLine(stdout, "published %s -> %s (%s)", target.ID, file.Path, shortCommit(file.SHA))
+		}
+		if failures > 0 {
+			return fmt.Errorf("%d of %d template(s) failed to publish", failures, len(targets))
+		}
+		return nil
+	})
+}
+
+// runAgentTemplatePull bulk-installs templates from a remote subdir via the
+// existing AddRemote/update fetch core and auto-versioning UpsertAgentTemplate.
+// Conflicts become a new version; identical content is a no-op; built-in and
+// retired ids are skipped; a per-file failure does not abort the batch.
+func runAgentTemplatePull(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent template pull", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	all := fs.Bool("all", false, "pull every template found under the remote subdir")
+	repo := fs.String("repo", "", "GitHub owner/repo to pull from (default: configured remote)")
+	ref := fs.String("ref", "", "git ref to pull from (default: configured remote or main)")
+	path := fs.String("path", "", "subdir within the repo to pull from (default: configured remote or templates)")
+	dryRun := fs.Bool("dry-run", false, "list what would be pulled without writing")
+	ids, flagArgs := leadingIDs(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	ids = append(ids, fs.Args()...)
+	ids = compactValues(ids)
+	if len(ids) == 0 && !*all {
+		fmt.Fprintln(stderr, "agent template pull requires one or more template ids or --all")
+		return 2
+	}
+	if len(ids) > 0 && *all {
+		fmt.Fprintln(stderr, "agent template pull accepts either template ids or --all, not both")
+		return 2
+	}
+	return withStoreAndPathsExit(*home, stderr, "pull agent template", func(paths config.Paths, store *db.Store) error {
+		repoName, gitRef, subdir, err := resolveTemplateRemote(paths, *repo, *ref, *path)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(stderr, "note: pulled templates are stored verbatim; only pull from repos you trust")
+		results, err := agenttemplate.Pull(context.Background(), store, newAgentTemplateRemoteSource(), repoName, gitRef, subdir, ids, *dryRun)
+		if err != nil {
+			return err
+		}
+		if len(results) == 0 {
+			fmt.Fprintln(stderr, "no templates to pull")
+			return nil
+		}
+		failures := 0
+		for _, result := range results {
+			switch result.Outcome {
+			case agenttemplate.PullFailed:
+				fmt.Fprintf(stderr, "pull %s: %s\n", result.ID, result.Detail)
+				failures++
+			case agenttemplate.PullSkipped:
+				writeLine(stdout, "skipped %s (%s)", result.ID, result.Detail)
+			case agenttemplate.PullUnchanged:
+				writeLine(stdout, "unchanged %s at %s", result.ID, result.Commit)
+			default:
+				verb := string(result.Outcome)
+				if *dryRun {
+					verb = "would " + verb
+				}
+				writeLine(stdout, "%s %s at %s", verb, result.ID, result.Commit)
+			}
+		}
+		if failures > 0 {
+			return fmt.Errorf("%d of %d template(s) failed to pull", failures, len(results))
+		}
+		return nil
+	})
+}
+
+func runAgentTemplateRemote(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printAgentTemplateRemoteUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "set":
+		return runAgentTemplateRemoteSet(args[1:], stdout, stderr)
+	case "show":
+		return runAgentTemplateRemoteShow(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown agent template remote command %q\n\n", args[0])
+		printAgentTemplateRemoteUsage(stderr)
+		return 2
+	}
+}
+
+func printAgentTemplateRemoteUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot agent template remote set <owner/repo> [--ref <ref>] [--path <subdir>]")
+	fmt.Fprintln(w, "  gitmoot agent template remote show")
+}
+
+func runAgentTemplateRemoteSet(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent template remote set", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	ref := fs.String("ref", "", "default git ref for publish/pull/add")
+	path := fs.String("path", "", "default subdir holding the template .md files")
+	repoArg, flagArgs := leadingID(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if repoArg == "" {
+		if fs.NArg() == 1 {
+			repoArg = fs.Arg(0)
+		} else {
+			fmt.Fprintln(stderr, "agent template remote set requires <owner/repo>")
+			return 2
+		}
+	} else if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent template remote set requires exactly one <owner/repo>")
+		return 2
+	}
+	repository, err := daemon.ParseRepository(repoArg)
+	if err != nil {
+		fmt.Fprintf(stderr, "set template remote: %v\n", err)
+		return 2
+	}
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "set template remote: %v\n", err)
+		return 1
+	}
+	if err := config.Initialize(paths); err != nil {
+		fmt.Fprintf(stderr, "set template remote: %v\n", err)
+		return 1
+	}
+	if err := config.EnsureTemplateRemoteSection(paths); err != nil {
+		fmt.Fprintf(stderr, "set template remote: %v\n", err)
+		return 1
+	}
+	edits := []struct {
+		key   string
+		value string
+		set   bool
+	}{
+		{"repo", repository.FullName(), true},
+		{"ref", strings.TrimSpace(*ref), strings.TrimSpace(*ref) != ""},
+		{"path", strings.Trim(strings.TrimSpace(*path), "/"), strings.TrimSpace(*path) != ""},
+	}
+	for _, edit := range edits {
+		if !edit.set {
+			continue
+		}
+		if err := config.SetConfigScalar(paths, []string{"template_remote", edit.key}, config.StringScalar(edit.value)); err != nil {
+			fmt.Fprintf(stderr, "set template remote: %v\n", err)
+			return 1
+		}
+	}
+	writeLine(stdout, "set default template remote to %s", repository.FullName())
+	return 0
+}
+
+func runAgentTemplateRemoteShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent template remote show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "agent template remote show does not accept positional arguments")
+		return 2
+	}
+	remote, ok := configuredTemplateRemote(*home)
+	if !ok {
+		fmt.Fprintln(stdout, "no default template remote configured")
+		return 0
+	}
+	writeLine(stdout, "repo: %s", remote.Repo)
+	writeLine(stdout, "ref: %s", remote.ResolvedRef())
+	writeLine(stdout, "path: %s", remote.ResolvedPath())
+	return 0
+}

--- a/internal/cli/agent_template_remote_test.go
+++ b/internal/cli/agent_template_remote_test.go
@@ -1,0 +1,307 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+// stubGitHubRunner answers the gh calls UpsertFile / RepositoryExists /
+// CreateRepository make, so publish can be exercised against a real
+// github.GhClient with no network (the seam the spec asks for).
+type stubGitHubRunner struct {
+	mu        sync.Mutex
+	calls     []string
+	failPaths map[string]bool // contents path -> force the PUT to fail
+	repoVisib bool            // repo view reports the repo exists
+}
+
+func (s *stubGitHubRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, command+" "+strings.Join(args, " "))
+	s.mu.Unlock()
+	joined := strings.Join(args, " ")
+	switch {
+	case len(args) >= 2 && args[0] == "repo" && args[1] == "view":
+		if s.repoVisib {
+			return subprocess.Result{Stdout: `{"nameWithOwner":"jerry/templates"}`}, nil
+		}
+		return subprocess.Result{Stderr: "Could not resolve to a Repository with the name"}, errors.New("not found")
+	case len(args) >= 2 && args[0] == "repo" && args[1] == "create":
+		return subprocess.Result{Stdout: ""}, nil
+	case strings.Contains(joined, "-X GET") && strings.Contains(joined, "/contents/"):
+		// No existing file -> 404 so UpsertFile creates it (sha stays empty).
+		return subprocess.Result{Stderr: "gh: Not Found (HTTP 404)"}, errors.New("not found")
+	case strings.Contains(joined, "-X PUT") && strings.Contains(joined, "/contents/"):
+		path := contentsPath(args)
+		if s.failPaths[path] {
+			return subprocess.Result{Stderr: "HTTP 422 validation failed"}, errors.New("upsert failed")
+		}
+		return subprocess.Result{Stdout: `{"content":{"path":"` + path + `","html_url":"https://github.com/jerry/templates/blob/main/` + path + `","sha":"deadbeefcafe1234"}}`}, nil
+	default:
+		return subprocess.Result{Stderr: "unexpected gh call"}, errors.New("unexpected gh call: " + joined)
+	}
+}
+
+func (s *stubGitHubRunner) LookPath(file string) (string, error) { return file, nil }
+
+func contentsPath(args []string) string {
+	for _, a := range args {
+		if strings.HasPrefix(a, "repos/") {
+			if idx := strings.Index(a, "/contents/"); idx >= 0 {
+				return a[idx+len("/contents/"):]
+			}
+		}
+	}
+	return ""
+}
+
+func replaceTemplateRemoteClient(client templateRemoteClient) func() {
+	previous := newTemplateRemoteClient
+	newTemplateRemoteClient = func() templateRemoteClient { return client }
+	return func() { newTemplateRemoteClient = previous }
+}
+
+func replaceAgentTemplateRemoteSource(source agenttemplate.RemoteSource) func() {
+	previous := newAgentTemplateRemoteSource
+	newAgentTemplateRemoteSource = func() agenttemplate.RemoteSource { return source }
+	return func() { newAgentTemplateRemoteSource = previous }
+}
+
+func addCustomTemplate(t *testing.T, home, id, body string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	promptPath := filepath.Join(t.TempDir(), id+".md")
+	if err := os.WriteFile(promptPath, []byte(testLocalTemplateContent(id, body)), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if code := Run([]string{"agent", "template", "add", "--home", home, "--file", promptPath, id}, &stdout, &stderr); code != 0 {
+		t.Fatalf("template add %s exit code = %d, stderr=%s", id, code, stderr.String())
+	}
+}
+
+func TestAgentTemplatePublishReportsPerFileResults(t *testing.T) {
+	stub := &stubGitHubRunner{failPaths: map[string]bool{"templates/api-reviewer.md": true}}
+	restore := replaceTemplateRemoteClient(&github.GhClient{Runner: stub, MaxRetries: 1})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	addCustomTemplate(t, home, "frontend-reviewer", "Review UI.\n")
+	addCustomTemplate(t, home, "api-reviewer", "Review API.\n")
+
+	code := Run([]string{"agent", "template", "publish", "--home", home, "--all", "--repo", "jerry/templates"}, &stdout, &stderr)
+	// One file failed, so the command reports failure overall (partial batch).
+	if code == 0 {
+		t.Fatalf("publish with one failing file should exit non-zero, stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "published frontend-reviewer -> templates/frontend-reviewer.md") {
+		t.Fatalf("expected the healthy file to publish:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "publish api-reviewer:") {
+		t.Fatalf("expected the failing file reported on stderr:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "1 of 2 template(s) failed to publish") {
+		t.Fatalf("expected a partial-batch summary:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "verbatim") {
+		t.Fatalf("expected a secrets/visibility caution before publishing:\n%s", stderr.String())
+	}
+}
+
+func TestAgentTemplatePublishAllSucceeds(t *testing.T) {
+	stub := &stubGitHubRunner{}
+	restore := replaceTemplateRemoteClient(&github.GhClient{Runner: stub, MaxRetries: 1})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	addCustomTemplate(t, home, "frontend-reviewer", "Review UI.\n")
+
+	code := Run([]string{"agent", "template", "publish", "frontend-reviewer", "--home", home, "--repo", "jerry/templates", "--create"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("publish exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "created jerry/templates (private)") {
+		t.Fatalf("expected --create to create the missing repo:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "published frontend-reviewer ->") {
+		t.Fatalf("expected publish success line:\n%s", stdout.String())
+	}
+}
+
+// panickingRemoteClient fails the test if any of its methods are called, proving
+// --dry-run never touches the network.
+type panickingRemoteClient struct{ t *testing.T }
+
+func (c panickingRemoteClient) UpsertFile(context.Context, github.UpsertFileInput) (github.RepositoryFile, error) {
+	c.t.Fatal("UpsertFile called during --dry-run")
+	return github.RepositoryFile{}, nil
+}
+func (c panickingRemoteClient) RepositoryExists(context.Context, github.Repository) (bool, error) {
+	c.t.Fatal("RepositoryExists called during --dry-run")
+	return false, nil
+}
+func (c panickingRemoteClient) CreateRepository(context.Context, github.Repository, bool) error {
+	c.t.Fatal("CreateRepository called during --dry-run")
+	return nil
+}
+
+func TestAgentTemplatePublishDryRunIsNetworkFree(t *testing.T) {
+	restore := replaceTemplateRemoteClient(panickingRemoteClient{t: t})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	addCustomTemplate(t, home, "frontend-reviewer", "Review UI.\n")
+
+	code := Run([]string{"agent", "template", "publish", "--home", home, "--all", "--repo", "jerry/templates", "--dry-run"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("publish --dry-run exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "would publish frontend-reviewer -> jerry/templates/templates/frontend-reviewer.md") {
+		t.Fatalf("dry-run stdout = %s", stdout.String())
+	}
+}
+
+func TestAgentTemplatePublishRequiresRepoWhenNoRemoteConfigured(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	addCustomTemplate(t, home, "frontend-reviewer", "Review UI.\n")
+	code := Run([]string{"agent", "template", "publish", "--home", home, "--all"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("publish without --repo or a configured remote should fail, stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no template repo") {
+		t.Fatalf("stderr missing remote guidance:\n%s", stderr.String())
+	}
+}
+
+func TestAgentTemplateRemoteSetShowAndPublishDefault(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+
+	// show before set reports nothing configured.
+	if code := Run([]string{"agent", "template", "remote", "show", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("remote show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no default template remote configured") {
+		t.Fatalf("remote show before set = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"agent", "template", "remote", "set", "jerry/templates", "--home", home, "--path", "agents"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("remote set exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "set default template remote to jerry/templates") {
+		t.Fatalf("remote set stdout = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"agent", "template", "remote", "show", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("remote show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"repo: jerry/templates", "ref: main", "path: agents"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("remote show after set missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	// publish with no --repo now defaults to the configured remote (path agents).
+	stub := &stubGitHubRunner{}
+	restore := replaceTemplateRemoteClient(&github.GhClient{Runner: stub, MaxRetries: 1})
+	defer restore()
+	addCustomTemplate(t, home, "frontend-reviewer", "Review UI.\n")
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"agent", "template", "publish", "--home", home, "--all"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("publish via configured remote exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "published frontend-reviewer -> agents/frontend-reviewer.md") {
+		t.Fatalf("publish did not use the configured remote subdir:\n%s", stdout.String())
+	}
+}
+
+// fakeRemoteSource serves a directory listing + per-path content for pull.
+type cliFakeRemoteSource struct {
+	commit  string
+	entries []agenttemplate.DirEntry
+	files   map[string]string
+}
+
+func (f cliFakeRemoteSource) ResolveRef(context.Context, string, string) (string, error) {
+	return f.commit, nil
+}
+func (f cliFakeRemoteSource) FetchFile(_ context.Context, _ string, _ string, path string) (agenttemplate.File, error) {
+	content, ok := f.files[path]
+	if !ok {
+		return agenttemplate.File{}, errors.New("no file at " + path)
+	}
+	return agenttemplate.File{Content: content}, nil
+}
+func (f cliFakeRemoteSource) ListDir(context.Context, string, string, string) ([]agenttemplate.DirEntry, error) {
+	return f.entries, nil
+}
+
+func TestAgentTemplatePullInstallsThenDiffsRemoteRow(t *testing.T) {
+	source := cliFakeRemoteSource{
+		commit: "remote-sha-1",
+		entries: []agenttemplate.DirEntry{
+			{Name: "frontend-reviewer.md", Path: "templates/frontend-reviewer.md", Type: "file"},
+		},
+		files: map[string]string{
+			"templates/frontend-reviewer.md": testLocalTemplateContent("frontend-reviewer", "Review UI changes.\n"),
+		},
+	}
+	restore := replaceAgentTemplateRemoteSource(source)
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+	code := Run([]string{"agent", "template", "pull", "--home", home, "--all", "--repo", "jerry/templates"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("pull exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "installed frontend-reviewer at remote-sha-1") {
+		t.Fatalf("pull stdout = %s", stdout.String())
+	}
+
+	// A second identical pull is a no-op.
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"agent", "template", "pull", "--home", home, "--all", "--repo", "jerry/templates"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("second pull exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "unchanged frontend-reviewer") {
+		t.Fatalf("identical pull should be a no-op:\n%s", stdout.String())
+	}
+
+	// diff now works for the pulled (remote-sourced) row: point the diff fetcher at
+	// changed upstream content and confirm the diff renders.
+	diffRestore := replaceAgentTemplateFetcher(fakeAgentTemplateFetcher{
+		commit:  "remote-sha-2",
+		content: testLocalTemplateContent("frontend-reviewer", "Review UI changes deeply.\n"),
+	})
+	defer diffRestore()
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"agent", "template", "diff", "--home", home, "frontend-reviewer"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("diff on remote row exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"cached:   remote-sha-1", "upstream: remote-sha-2", "-Review UI changes.", "+Review UI changes deeply."} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("diff on remote row missing %q:\n%s", want, stdout.String())
+		}
+	}
+}

--- a/internal/cli/agent_template_test.go
+++ b/internal/cli/agent_template_test.go
@@ -280,6 +280,84 @@ func TestAgentTemplateAddRejectsConflictingSources(t *testing.T) {
 	}
 }
 
+// TestAgentTemplateAddWithoutSourceAndNoRemoteIsByteIdenticalError proves the
+// off-by-default no-regression invariant for the [template_remote] fallback
+// (#476): with NO remote configured, `agent template add <id>` (neither --file
+// nor --from-repo) must still hard-error with the documented guidance and exit
+// 2, exactly as before the fallback existed. It also exercises
+// configuredTemplateRemote returning not-configured for a fresh home.
+func TestAgentTemplateAddWithoutSourceAndNoRemoteIsByteIdenticalError(t *testing.T) {
+	// Fail loudly if the fallback ever silently reaches the network when no
+	// remote is configured.
+	restore := replaceAgentTemplateFetcher(explodingFetcher{t: t})
+	defer restore()
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+
+	if _, ok := configuredTemplateRemote(home); ok {
+		t.Fatalf("configuredTemplateRemote on a fresh home should report not-configured")
+	}
+
+	code := Run([]string{"agent", "template", "add", "--home", home, "someid"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("add with no source and no remote exit code = %d (want 2), stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "requires --file or --from-repo") {
+		t.Fatalf("stderr missing flag-required guidance:\n%s", stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("add with no source should not print to stdout:\n%s", stdout.String())
+	}
+}
+
+// TestAgentTemplateAddFallsBackToConfiguredRemote proves the additive fallback
+// branch (#476): after `remote set jerry/templates --path agents`, a bare
+// `agent template add frontend-reviewer` (no --file/--from-repo) fetches
+// agents/frontend-reviewer.md from the configured remote and installs it,
+// confirming the fallback wires repo/ref/path correctly.
+func TestAgentTemplateAddFallsBackToConfiguredRemote(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	home := t.TempDir()
+
+	if code := Run([]string{"agent", "template", "remote", "set", "jerry/templates", "--home", home, "--path", "agents"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("remote set exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	recorder := &recordingAgentTemplateFetcher{
+		commit:  "remote-sha",
+		content: testLocalTemplateContent("frontend-reviewer", "Review frontend changes.\n"),
+	}
+	restore := replaceAgentTemplateFetcher(recorder)
+	defer restore()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"agent", "template", "add", "--home", home, "frontend-reviewer"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("add via configured remote exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "added frontend-reviewer at remote-sha") {
+		t.Fatalf("add via configured remote stdout = %s", stdout.String())
+	}
+	if recorder.fetchedRepo != "jerry/templates" {
+		t.Fatalf("fallback fetched repo = %q, want jerry/templates", recorder.fetchedRepo)
+	}
+	if recorder.fetchedPath != "agents/frontend-reviewer.md" {
+		t.Fatalf("fallback fetched path = %q, want agents/frontend-reviewer.md", recorder.fetchedPath)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"agent", "template", "show", "--home", home, "frontend-reviewer"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("template show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"source: jerry/templates@main:agents/frontend-reviewer.md", "installed: yes", "Review frontend changes."} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("show output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
 func TestAgentTemplateExportWritesCustomTemplatesAndSkipsBuiltins(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	home := t.TempDir()
@@ -994,6 +1072,29 @@ func (f explodingFetcher) FetchFile(context.Context, string, string, string) (ag
 type fakeAgentTemplateFetcher struct {
 	commit  string
 	content string
+}
+
+// recordingAgentTemplateFetcher serves content like fakeAgentTemplateFetcher but
+// records the repo/ref/path it was asked to fetch, so tests can assert the caller
+// wired the source correctly.
+type recordingAgentTemplateFetcher struct {
+	commit      string
+	content     string
+	fetchedRepo string
+	fetchedRef  string
+	fetchedPath string
+}
+
+func (f *recordingAgentTemplateFetcher) ResolveRef(_ context.Context, repo string, ref string) (string, error) {
+	f.fetchedRepo = repo
+	f.fetchedRef = ref
+	return f.commit, nil
+}
+
+func (f *recordingAgentTemplateFetcher) FetchFile(_ context.Context, repo string, _ string, path string) (agenttemplate.File, error) {
+	f.fetchedRepo = repo
+	f.fetchedPath = path
+	return agenttemplate.File{Content: f.content}, nil
 }
 
 func (f fakeAgentTemplateFetcher) ResolveRef(context.Context, string, string) (string, error) {

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -114,6 +114,9 @@ func validateConfigFile(paths Paths) error {
 	if _, err := LoadSkillOptABPolicy(paths); err != nil {
 		return err
 	}
+	if _, err := LoadTemplateRemote(paths); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -69,6 +69,20 @@ default_review_timeout = ""
 default_gate_timeout = ""
 default_repair_timeout = ""
 
+# [template_remote] is the OPTIONAL default GitHub repo the agent-template
+# publish / pull / add commands fall back to when --repo is omitted (#476).
+# Empty repo (the default) means no default remote: those commands then require
+# an explicit --repo, so behavior is byte-identical to having no section. repo is
+# owner/repo; ref defaults to "main" when empty; path is the subdir holding the
+# template .md files and defaults to "templates" when empty. Set it with
+# gitmoot agent template remote set <owner/repo> [--ref] [--path].
+# CAUTION: templates are stored and published verbatim (prompt body + metadata);
+# point this at a PRIVATE repo unless you intend the prompts to be public.
+[template_remote]
+repo = ""
+ref = ""
+path = ""
+
 # [skillopt] is the OFF-BY-DEFAULT template-learning policy (#465 Mode A, #471).
 # With no [skillopt] section behavior is byte-identical: no trace harvesting, no
 # event emission, and promotion stays fully MANUAL. auto_trace_enabled opts the

--- a/internal/config/template_remote.go
+++ b/internal/config/template_remote.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// TemplateRemotePolicy is the host-level default GitHub repo the agent-template
+// publish/pull/add commands fall back to when --repo is omitted, read from the
+// [template_remote] section of the gitmoot config (#476). It is OFF BY DEFAULT:
+// with no [template_remote] section (or an empty repo) Configured() is false and
+// those commands require an explicit --repo, so behavior is byte-identical to a
+// config without the section. It follows the LoadEventsPolicy line-parser
+// pattern in orchestrate.go.
+type TemplateRemotePolicy struct {
+	// Repo is the default GitHub owner/repo. Empty (the default) means no default
+	// remote is configured.
+	Repo string
+	// Ref is the default git ref. Empty falls back to DefaultTemplateRemoteRef.
+	Ref string
+	// Path is the default subdir holding the template .md files. Empty falls back
+	// to DefaultTemplateRemotePath.
+	Path string
+}
+
+const (
+	// DefaultTemplateRemoteRef is the ref used when [template_remote].ref is unset.
+	DefaultTemplateRemoteRef = "main"
+	// DefaultTemplateRemotePath is the subdir used when [template_remote].path is
+	// unset: the directory holding the template .md files.
+	DefaultTemplateRemotePath = "templates"
+)
+
+func DefaultTemplateRemotePolicy() TemplateRemotePolicy {
+	return TemplateRemotePolicy{Repo: "", Ref: "", Path: ""}
+}
+
+// Configured reports whether a default template remote is set. With no
+// [template_remote] section (the default) it is false.
+func (p TemplateRemotePolicy) Configured() bool {
+	return strings.TrimSpace(p.Repo) != ""
+}
+
+// ResolvedRef returns Ref, or DefaultTemplateRemoteRef when unset.
+func (p TemplateRemotePolicy) ResolvedRef() string {
+	if ref := strings.TrimSpace(p.Ref); ref != "" {
+		return ref
+	}
+	return DefaultTemplateRemoteRef
+}
+
+// ResolvedPath returns Path (the subdir holding the .md files), or
+// DefaultTemplateRemotePath when unset.
+func (p TemplateRemotePolicy) ResolvedPath() string {
+	if path := strings.TrimSpace(p.Path); path != "" {
+		return path
+	}
+	return DefaultTemplateRemotePath
+}
+
+func LoadTemplateRemote(paths Paths) (TemplateRemotePolicy, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return TemplateRemotePolicy{}, err
+	}
+	policy := DefaultTemplateRemotePolicy()
+	current := false
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			current = strings.TrimSpace(section) == "template_remote"
+			continue
+		}
+		if !current {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if err := applyTemplateRemoteField(&policy, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
+			return TemplateRemotePolicy{}, fmt.Errorf("parse [template_remote].%s: %w", strings.TrimSpace(key), err)
+		}
+	}
+	if err := validateTemplateRemote(policy); err != nil {
+		return TemplateRemotePolicy{}, err
+	}
+	return policy, nil
+}
+
+func applyTemplateRemoteField(policy *TemplateRemotePolicy, key string, value string) error {
+	switch key {
+	case "repo":
+		parsed, err := parseConfigString(value)
+		policy.Repo = strings.TrimSpace(parsed)
+		return err
+	case "ref":
+		parsed, err := parseConfigString(value)
+		policy.Ref = strings.TrimSpace(parsed)
+		return err
+	case "path":
+		parsed, err := parseConfigString(value)
+		policy.Path = strings.TrimSpace(parsed)
+		return err
+	default:
+		return nil
+	}
+}
+
+func validateTemplateRemote(policy TemplateRemotePolicy) error {
+	repo := strings.TrimSpace(policy.Repo)
+	if repo == "" {
+		return nil
+	}
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return fmt.Errorf("template_remote.repo %q must be a GitHub owner/repo", repo)
+	}
+	return nil
+}
+
+// EnsureTemplateRemoteSection appends an empty [template_remote] section to the
+// config when it is absent, so SetConfigScalar (which only edits keys that
+// already exist) can drive `agent template remote set` on a config created
+// before this feature. It is idempotent: when the section already exists it is a
+// no-op. Fresh configs (DefaultConfig) ship the section, so this only ever fires
+// for older configs.
+func EnsureTemplateRemoteSection(paths Paths) error {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return err
+	}
+	for _, raw := range strings.Split(string(content), "\n") {
+		if strings.TrimSpace(stripConfigComment(raw)) == "[template_remote]" {
+			return nil
+		}
+	}
+	body := string(content)
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	body += "\n[template_remote]\nrepo = \"\"\nref = \"\"\npath = \"\"\n"
+	return os.WriteFile(paths.ConfigFile, []byte(body), 0o600)
+}

--- a/internal/config/template_remote_test.go
+++ b/internal/config/template_remote_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoadTemplateRemoteDefaultsUnconfigured(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	// The DefaultConfig ships a [template_remote] section with an empty repo, which
+	// must read back as NOT configured (off by default).
+	remote, err := LoadTemplateRemote(paths)
+	if err != nil {
+		t.Fatalf("LoadTemplateRemote returned error: %v", err)
+	}
+	if remote.Configured() {
+		t.Fatalf("default template remote must be unconfigured, got %+v", remote)
+	}
+	if remote.Repo != "" || remote.Ref != "" || remote.Path != "" {
+		t.Fatalf("default template remote must be all-empty, got %+v", remote)
+	}
+	// Resolved* fall back to the documented defaults.
+	if remote.ResolvedRef() != DefaultTemplateRemoteRef {
+		t.Fatalf("ResolvedRef default = %q, want %q", remote.ResolvedRef(), DefaultTemplateRemoteRef)
+	}
+	if remote.ResolvedPath() != DefaultTemplateRemotePath {
+		t.Fatalf("ResolvedPath default = %q, want %q", remote.ResolvedPath(), DefaultTemplateRemotePath)
+	}
+}
+
+func TestLoadTemplateRemoteParsesSection(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[template_remote]
+repo = "jerry/my-templates"
+ref = "publish"
+path = "agents"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	remote, err := LoadTemplateRemote(paths)
+	if err != nil {
+		t.Fatalf("LoadTemplateRemote returned error: %v", err)
+	}
+	if !remote.Configured() {
+		t.Fatalf("template remote should be configured, got %+v", remote)
+	}
+	if remote.Repo != "jerry/my-templates" || remote.ResolvedRef() != "publish" || remote.ResolvedPath() != "agents" {
+		t.Fatalf("parsed template remote = %+v", remote)
+	}
+}
+
+func TestLoadTemplateRemoteRejectsMalformedRepo(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[template_remote]
+repo = "not-an-owner-repo"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadTemplateRemote(paths); err == nil {
+		t.Fatalf("LoadTemplateRemote accepted a malformed repo")
+	}
+}
+
+func TestEnsureTemplateRemoteSectionAppendsThenSetRoundTrips(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	// Simulate an older config that predates the section by stripping it from the
+	// default config (the other sections stay intact so SetConfigScalar's
+	// post-edit validation of every parser still passes).
+	full := DefaultConfig(paths)
+	stripped := full[:strings.Index(full, "[template_remote]")] + full[strings.Index(full, "[skillopt] is"):]
+	if strings.Contains(stripped, "[template_remote]") {
+		t.Fatalf("failed to strip [template_remote] from default config")
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(stripped), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if err := EnsureTemplateRemoteSection(paths); err != nil {
+		t.Fatalf("EnsureTemplateRemoteSection returned error: %v", err)
+	}
+	// Idempotent: a second call is a no-op (does not append a duplicate section).
+	if err := EnsureTemplateRemoteSection(paths); err != nil {
+		t.Fatalf("EnsureTemplateRemoteSection (second) returned error: %v", err)
+	}
+	body, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if got := strings.Count(string(body), "[template_remote]"); got != 1 {
+		t.Fatalf("expected exactly one [template_remote] section, got %d:\n%s", got, string(body))
+	}
+	// SetConfigScalar can now edit the appended keys, and the result round-trips.
+	if err := SetConfigScalar(paths, []string{"template_remote", "repo"}, StringScalar("jerry/templates")); err != nil {
+		t.Fatalf("SetConfigScalar repo returned error: %v", err)
+	}
+	if err := SetConfigScalar(paths, []string{"template_remote", "path"}, StringScalar("agents")); err != nil {
+		t.Fatalf("SetConfigScalar path returned error: %v", err)
+	}
+	remote, err := LoadTemplateRemote(paths)
+	if err != nil {
+		t.Fatalf("LoadTemplateRemote returned error: %v", err)
+	}
+	if remote.Repo != "jerry/templates" || remote.ResolvedPath() != "agents" {
+		t.Fatalf("round-tripped template remote = %+v", remote)
+	}
+}


### PR DESCRIPTION
Completes the deferred remainder of GitHub-backed agent templates (#476) on top of the merged MVP (#557: AddRemote + Export + gated update + `export`/`add --from-repo`).

## What this completes

1. **publish** — `gitmoot agent template publish [<id>...] [--all] [--repo <owner/repo>] [--path <subdir>] [--ref <branch>] [--message <msg>] [--create] [--dry-run]`. Pushes each selected custom template's rebuilt `.md` (via the existing `Export`/`FormatTemplateContent`) to `<repo>/<path>/<id>.md` using the EXISTING `github.Client.UpsertFile` (the GET-sha-then-PUT dance over `gh api`, no local clone). Per-file success/failure reporting with a clear partial-batch summary. Optional `--create` via `CreateRepository` (private) when the repo is missing.
2. **bulk pull** — `gitmoot agent template pull [<id>...] [--all] [--repo <owner/repo>] [--ref <ref>] [--path <subdir>] [--dry-run]`. Lists `<path>/*.md` (new `GHFetcher.ListDir` over `gh api` contents) and routes each through the EXISTING `AddRemote`/generalized-update fetch core + auto-versioning `UpsertAgentTemplate`: **conflict-as-new-version**, **identical-content no-op**, and a per-file failure that does not abort the batch.
3. **`[template_remote]` config** — new `internal/config/template_remote.go` (`LoadTemplateRemote`, `EnsureTemplateRemoteSection`) following the `LoadEventsPolicy` line-parser pattern; `gitmoot agent template remote set <owner/repo> [--ref] [--path]` + `remote show` via `SetConfigScalar`. publish/pull/add default to it when `--repo` is omitted.
4. **generalized diff** — `runAgentTemplateDiff` now mirrors the built-in branch against a pulled row's stored `SourceRepo/Ref/Path`, so `diff` works for pulled (remote-sourced) templates.

## Off-by-default / additive proof

- **No DB migration** — reuses `SourceRepo/SourceRef/SourcePath` + `UpsertAgentTemplate` auto-versioning.
- The `[template_remote]` section ships **empty** in `DefaultConfig` so `Configured()` is false: publish/pull require an explicit `--repo` until a remote is set, byte-identical to having no section (`TestLoadTemplateRemoteDefaultsUnconfigured`). `add` only falls back to the configured remote when one is set (additive).
- publish/pull **only touch the network when invoked**; `publish --dry-run` is network-free, proven by a client whose methods fail the test if called (`TestAgentTemplatePublishDryRunIsNetworkFree`).
- diff/update for **local** and **built-in** rows is unchanged (the remote branch is gated on `IsRemote`); the full existing `cli`/`agenttemplate` suites stay green.
- A secrets/visibility caution is printed before prompts leave the local DB (publish to a repo, pull from a repo).

## Tests

- config: `TestLoadTemplateRemoteDefaultsUnconfigured`, `TestLoadTemplateRemoteParsesSection`, `TestLoadTemplateRemoteRejectsMalformedRepo`, `TestEnsureTemplateRemoteSectionAppendsThenSetRoundTrips`.
- agenttemplate (fake source over a dir listing): `TestPullListsInstallsSkipsAndNoOps` (install -> identical no-op -> conflict new-version), `TestPullDryRunWritesNothing`, `TestPullReportsPerFileFailureAndContinues`, `TestPullRejectsMalformedRepo`.
- cli (stubbed `gh` Runner on a real `GhClient`): `TestAgentTemplatePublishReportsPerFileResults`, `TestAgentTemplatePublishAllSucceeds` (incl. `--create`), `TestAgentTemplatePublishDryRunIsNetworkFree`, `TestAgentTemplatePublishRequiresRepoWhenNoRemoteConfigured`, `TestAgentTemplateRemoteSetShowAndPublishDefault`, `TestAgentTemplatePullInstallsThenDiffsRemoteRow` (pull + diff-on-remote).

## Gate

`go build`, `go vet`, `go test ./...` all green; `-race` green on `config`, `agenttemplate`, and the touched `cli` tests (full `cli` `-race` runs in CI).

## Still deferred (out of scope)

`--open-pr`, an interactive picker, and SkillOpt-publish wiring.

Relates #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)