### PR TITLE
perf(daemon): collapse per-issue comment pagination into one since=-bounded repo-wide call (#566)

### DIFF
--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -5491,6 +5491,17 @@ func (f *cliPollFakeGitHub) ListIssueComments(_ context.Context, _ github.Reposi
 	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
 }
 
+func (f *cliPollFakeGitHub) ListRepoIssueComments(_ context.Context, _ github.Repository, _ time.Time) ([]github.IssueComment, error) {
+	var out []github.IssueComment
+	for number, list := range f.comments {
+		for _, c := range list {
+			c.IssueNumber = number
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
 func (f *cliPollFakeGitHub) PostIssueComment(_ context.Context, _ github.Repository, issueNumber int64, body string) (github.IssueComment, error) {
 	if f.postErr != nil {
 		return github.IssueComment{}, f.postErr

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -11342,6 +11342,17 @@ func (f *skillOptFakeGitHub) ListIssueComments(_ context.Context, repo github.Re
 	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
 }
 
+func (f *skillOptFakeGitHub) ListRepoIssueComments(_ context.Context, _ github.Repository, _ time.Time) ([]github.IssueComment, error) {
+	var out []github.IssueComment
+	for number, list := range f.comments {
+		for _, c := range list {
+			c.IssueNumber = number
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
 func (f *skillOptFakeGitHub) baseURL() string {
 	if strings.TrimSpace(f.host) == "" {
 		return "https://github.com"

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -19,6 +19,13 @@ import (
 
 const defaultPollInterval = 30 * time.Second
 
+// issueCommentPollOverlap is subtracted from the persisted last-seen cursor when
+// computing the `since` bound for the repo-wide issue-comment fetch (#566). It
+// re-fetches a few seconds of boundary comments each tick to absorb local/GitHub
+// clock skew and same-second comments straddling the cursor; the seen_comments
+// dedup makes the replay a no-op.
+const issueCommentPollOverlap = 5 * time.Second
+
 type Daemon struct {
 	Repo         github.Repository
 	PollInterval time.Duration
@@ -26,6 +33,9 @@ type Daemon struct {
 	GitHub       github.Client
 	Workflow     *workflow.Engine
 	Sleep        func(context.Context, time.Duration) error
+	// Now is an injectable clock (test seam). It defaults to time.Now and is used
+	// to seed/advance the #566 issue-comment `since` cursor deterministically.
+	Now func() time.Time
 	// WatchIssues opts in to the issue-comment workflow (#389): when true,
 	// PollOnce also polls open non-PR issues and routes `@<agent> ask …`
 	// comments to jobs. Default false keeps the PR-only behavior unchanged.
@@ -161,12 +171,30 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 	return firstErr
 }
 
-// PollIssuesOnce is the opt-in issue-comment workflow (#389). It lists open
-// non-PR issues (PRs are filtered out by github.ListIssues so the PR-watcher is
-// not duplicated) and, for each, routes `@<agent> ask …` comments to jobs via
-// the shared comment->job->reply core. It reuses the seen_comments dedup, the
+// PollIssuesOnce is the opt-in issue-comment workflow (#389, bounded by #566). It
+// lists open non-PR issues (PRs are filtered out by github.ListIssues so the
+// PR-watcher is not duplicated) and routes `@<agent> ask …` comments to jobs via
+// the shared comment->job->reply core, reusing the seen_comments dedup, the
 // authorize-commenter gate, and PostIssueComment exactly like the PR path; an
 // `ask` needs no branch/HeadSHA, so those are left empty.
+//
+// #566 collapses the former O(open-issues) per-issue ListIssueComments fan-out
+// (one full paginated gh call per open issue every tick) into ONE repo-wide
+// ListRepoIssueComments(repo, since) call per tick: it fetches only comments
+// updated since the persisted cursor, groups them back by issue number, and feeds
+// each open non-PR issue's comments through the UNCHANGED handleIssueComment path.
+// The repo-wide endpoint also returns PR conversation comments; those are owned by
+// PollOnce's per-PR loop and are skipped here (their number is not in the open
+// non-PR issue set). NEW-issue enumeration still uses ListIssues, so nothing that
+// depends on issue listing changes — only the comment pagination is collapsed.
+//
+// FIRST-POLL SEMANTICS (intentional #566 difference): with no persisted cursor the
+// `since` window is seeded from `now` (minus the skew overlap), so a fresh watcher
+// does NOT backfill the entire repo's comment history. The prior code paginated
+// every open issue's full comment thread on the first tick (acting only on unseen
+// comments); the new code instead ignores comments older than daemon start. In
+// steady state both behave identically because every processed comment is recorded
+// in seen_comments and the cursor advances monotonically.
 func (d Daemon) PollIssuesOnce(ctx context.Context) error {
 	if err := d.validate(); err != nil {
 		return err
@@ -175,25 +203,82 @@ func (d Daemon) PollIssuesOnce(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	var firstErr error
+	// Index open non-PR issues by number so repo-wide comments can be routed back
+	// to their issue (handleIssueComment needs the issue's title). PR comments and
+	// comments on issues not in this set are skipped.
+	openIssues := make(map[int64]github.Issue, len(issues))
 	for _, issue := range issues {
 		if issue.IsPullRequest {
 			continue
 		}
-		comments, err := d.GitHub.ListIssueComments(ctx, d.Repo, issue.Number)
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
+		openIssues[issue.Number] = issue
+	}
+
+	// Resolve the `since` bound. base is the prior cursor, or `now` on the first
+	// ever poll (bounded initial fetch — no history backfill). since re-fetches a
+	// small overlap window for clock skew; seen_comments dedups the replay.
+	base, hasCursor, err := d.Store.GetIssueCommentPollCursor(ctx, d.Repo.FullName())
+	if err != nil {
+		return err
+	}
+	if !hasCursor {
+		base = d.now()
+	}
+	since := base.Add(-issueCommentPollOverlap)
+
+	comments, err := d.GitHub.ListRepoIssueComments(ctx, d.Repo, since)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+	newCursor := base // monotonic: never regress below the prior cursor / seed
+	for _, comment := range comments {
+		if t, ok := parseCommentUpdatedAt(comment.UpdatedAt); ok && t.After(newCursor) {
+			newCursor = t
+		}
+		issue, ok := openIssues[comment.IssueNumber]
+		if !ok {
+			// PR comment (owned by the PR loop) or a comment on a closed/unknown
+			// issue: not routed here.
 			continue
 		}
-		for _, comment := range comments {
-			if err := d.handleIssueComment(ctx, issue, comment); err != nil && firstErr == nil {
-				firstErr = err
-			}
+		if err := d.handleIssueComment(ctx, issue, comment); err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
+
+	// Persist the advanced cursor so the next tick's `since` moves forward. Done
+	// even on an error above so a single bad comment never re-scans the backlog.
+	if err := d.Store.UpsertIssueCommentPollCursor(ctx, d.Repo.FullName(), newCursor); err != nil && firstErr == nil {
+		firstErr = err
+	}
 	return firstErr
+}
+
+// parseCommentUpdatedAt parses a GitHub comment updated_at (RFC3339) timestamp.
+// It returns ok=false for an empty/unparseable value so the cursor simply does
+// not advance on that comment rather than regressing.
+func parseCommentUpdatedAt(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// now returns the daemon's clock, defaulting to time.Now when unset.
+func (d Daemon) now() time.Time {
+	if d.Now != nil {
+		return d.Now()
+	}
+	return time.Now()
 }
 
 func (d Daemon) PollRecoveryCommandsOnce(ctx context.Context) error {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2305,6 +2305,126 @@ func TestPollIssuesOnceRoutesAskAndDedupes(t *testing.T) {
 	}
 }
 
+// TestPollIssuesOnceCollapsesToSingleRepoWideCommentCall is the #566 regression
+// guard: PollIssuesOnce must make ONE repo-wide ListRepoIssueComments call per
+// tick (not N per-issue ListIssueComments calls), group the flat result back by
+// issue number, route each open non-PR issue's comments through the unchanged
+// handleIssueComment path, advance a persisted since cursor, and dedup an
+// already-seen/edited comment on the next tick.
+func TestPollIssuesOnceCollapsesToSingleRepoWideCommentCall(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "researcher",
+		Role:           "researcher",
+		Runtime:        "claude",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	client := &fakeGitHub{
+		issues: []github.Issue{
+			{Number: 42, Title: "Question A", State: "open"},
+			{Number: 7, Title: "Question B", State: "open"},
+			// A PR in the issue listing: its comments must be skipped here (owned by
+			// the PR loop), even though the repo-wide endpoint returns them.
+			{Number: 43, Title: "A PR", State: "open", IsPullRequest: true},
+		},
+		repoComments: []github.IssueComment{
+			{ID: 900, IssueNumber: 42, Body: "/gitmoot researcher ask question one", Author: "alice", UpdatedAt: "2026-06-27T12:00:30Z"},
+			{ID: 901, IssueNumber: 7, Body: "/gitmoot researcher ask question two", Author: "alice", UpdatedAt: "2026-06-27T12:00:45Z"},
+			// PR comment (issue 43) and a comment on an unknown/closed issue (99):
+			// both must be skipped by the grouping.
+			{ID: 902, IssueNumber: 43, Body: "/gitmoot researcher ask on a PR", Author: "alice", UpdatedAt: "2026-06-27T12:00:20Z"},
+			{ID: 903, IssueNumber: 99, Body: "/gitmoot researcher ask on unknown", Author: "alice", UpdatedAt: "2026-06-27T12:00:20Z"},
+		},
+	}
+	d := Daemon{Repo: repo, Store: store, GitHub: client, WatchIssues: true, Now: func() time.Time { return now }}
+
+	if err := d.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+
+	// ONE repo-wide comment call, ZERO per-issue comment calls (no open PRs, so the
+	// PR loop makes none either).
+	if client.listRepoCommentsCalls != 1 {
+		t.Fatalf("ListRepoIssueComments calls = %d, want 1 per tick", client.listRepoCommentsCalls)
+	}
+	if client.listIssueCommentsCalls != 0 {
+		t.Fatalf("per-issue ListIssueComments calls = %d, want 0 (collapsed into the repo-wide call)", client.listIssueCommentsCalls)
+	}
+	// since seeded from now minus the skew overlap on the first poll.
+	if len(client.repoCommentsSince) != 1 || !client.repoCommentsSince[0].Equal(now.Add(-issueCommentPollOverlap)) {
+		t.Fatalf("first since = %v, want %v", client.repoCommentsSince, now.Add(-issueCommentPollOverlap))
+	}
+
+	// Grouping/routing: jobs for issue 42 and issue 7; none for the PR or unknown.
+	if _, err := store.GetJob(ctx, issueJobID(repo, 42, 900, 0, "researcher", "ask")); err != nil {
+		t.Fatalf("issue 42 comment was not routed: %v", err)
+	}
+	if _, err := store.GetJob(ctx, issueJobID(repo, 7, 901, 0, "researcher", "ask")); err != nil {
+		t.Fatalf("issue 7 comment was not routed: %v", err)
+	}
+	if _, err := store.GetJob(ctx, issueJobID(repo, 43, 902, 0, "researcher", "ask")); err == nil {
+		t.Fatal("PR comment was routed by the issue watcher; must be skipped")
+	}
+	if _, err := store.GetJob(ctx, issueJobID(repo, 99, 903, 0, "researcher", "ask")); err == nil {
+		t.Fatal("comment on an unknown issue was routed; must be skipped")
+	}
+	if len(client.posted) != 2 {
+		t.Fatalf("acks = %d, want 2 (issues 42 and 7)", len(client.posted))
+	}
+
+	// Cursor advanced to the newest comment updated_at seen (12:00:45).
+	cursor, ok, err := store.GetIssueCommentPollCursor(ctx, repo.FullName())
+	if err != nil || !ok {
+		t.Fatalf("GetIssueCommentPollCursor ok=%v err=%v", ok, err)
+	}
+	wantCursor := time.Date(2026, 6, 27, 12, 0, 45, 0, time.UTC)
+	if !cursor.Equal(wantCursor) {
+		t.Fatalf("cursor = %v, want %v", cursor, wantCursor)
+	}
+
+	// Second poll: an EDITED replay of comment 900 (newer updated_at, so it passes
+	// the since filter) plus a genuinely new comment 904. The edit is already seen
+	// and must be deduped; only 904 routes.
+	client.repoComments = []github.IssueComment{
+		{ID: 900, IssueNumber: 42, Body: "/gitmoot researcher ask question one edited", Author: "alice", UpdatedAt: "2026-06-27T12:01:00Z"},
+		{ID: 904, IssueNumber: 7, Body: "/gitmoot researcher ask question three", Author: "alice", UpdatedAt: "2026-06-27T12:01:10Z"},
+	}
+	if err := d.PollOnce(ctx); err != nil {
+		t.Fatalf("second PollOnce returned error: %v", err)
+	}
+	if client.listRepoCommentsCalls != 2 {
+		t.Fatalf("ListRepoIssueComments calls = %d after 2 ticks, want 2", client.listRepoCommentsCalls)
+	}
+	// Second since = advanced cursor (12:00:45) minus overlap.
+	if !client.repoCommentsSince[1].Equal(wantCursor.Add(-issueCommentPollOverlap)) {
+		t.Fatalf("second since = %v, want %v", client.repoCommentsSince[1], wantCursor.Add(-issueCommentPollOverlap))
+	}
+	// Edited already-seen comment 900 produced no second ack; only 904 did.
+	if len(client.posted) != 3 {
+		t.Fatalf("acks after 2nd poll = %d, want 3 (edited 900 deduped, only 904 new)", len(client.posted))
+	}
+	if _, err := store.GetJob(ctx, issueJobID(repo, 7, 904, 0, "researcher", "ask")); err != nil {
+		t.Fatalf("new comment 904 was not routed: %v", err)
+	}
+	cursor2, _, err := store.GetIssueCommentPollCursor(ctx, repo.FullName())
+	if err != nil {
+		t.Fatalf("GetIssueCommentPollCursor: %v", err)
+	}
+	if !cursor2.Equal(time.Date(2026, 6, 27, 12, 1, 10, 0, time.UTC)) {
+		t.Fatalf("cursor after 2nd poll = %v, want 12:01:10", cursor2)
+	}
+}
+
 func TestPollIssuesOnceIgnoresNonAskAndUnknownAgent(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
@@ -2413,18 +2533,22 @@ func testStore(t *testing.T) *db.Store {
 }
 
 type fakeGitHub struct {
-	pulls                 []github.PullRequest
-	pullsByState          map[string][]github.PullRequest
-	pullsByNumber         map[int64]github.PullRequest
-	issues                []github.Issue
-	comments              map[int64][]github.IssueComment
-	posted                []postedComment
-	permissions           map[string]string
-	postErrs              []error
-	listPullRequestsCalls int
-	listPullRequestsErrs  []error
-	listIssuesCalls       int
-	recentClosedCalls     int
+	pulls                  []github.PullRequest
+	pullsByState           map[string][]github.PullRequest
+	pullsByNumber          map[int64]github.PullRequest
+	issues                 []github.Issue
+	comments               map[int64][]github.IssueComment
+	repoComments           []github.IssueComment
+	repoCommentsSince      []time.Time
+	listRepoCommentsCalls  int
+	listIssueCommentsCalls int
+	posted                 []postedComment
+	permissions            map[string]string
+	postErrs               []error
+	listPullRequestsCalls  int
+	listPullRequestsErrs   []error
+	listIssuesCalls        int
+	recentClosedCalls      int
 }
 
 type postedComment struct {
@@ -2513,7 +2637,44 @@ func (f *fakeGitHub) CloseIssue(context.Context, github.Repository, int64) (gith
 }
 
 func (f *fakeGitHub) ListIssueComments(_ context.Context, _ github.Repository, issueNumber int64) ([]github.IssueComment, error) {
+	f.listIssueCommentsCalls++
 	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
+}
+
+// ListRepoIssueComments models the repo-wide comment endpoint (#566). It counts
+// calls (so a test can prove ONE call per repo per tick, not N per-issue) and
+// records the `since` cursor it was handed. Fixtures can be supplied two ways:
+//   - repoComments: an explicit flat list (each carries its own IssueNumber and
+//     UpdatedAt); comments with a parseable UpdatedAt strictly before `since` are
+//     filtered out, mirroring the real endpoint's since= behavior.
+//   - comments map (issue-number keyed): flattened with IssueNumber set to the
+//     key. Map fixtures carry no timestamps, so they are always returned (the
+//     since filter only applies to comments that declare an UpdatedAt).
+func (f *fakeGitHub) ListRepoIssueComments(_ context.Context, _ github.Repository, since time.Time) ([]github.IssueComment, error) {
+	f.listRepoCommentsCalls++
+	f.repoCommentsSince = append(f.repoCommentsSince, since)
+	var out []github.IssueComment
+	appendIfAfter := func(c github.IssueComment) {
+		if !since.IsZero() && strings.TrimSpace(c.UpdatedAt) != "" {
+			if t, err := time.Parse(time.RFC3339, c.UpdatedAt); err == nil && t.Before(since) {
+				return
+			}
+		}
+		out = append(out, c)
+	}
+	if f.repoComments != nil {
+		for _, c := range f.repoComments {
+			appendIfAfter(c)
+		}
+		return out, nil
+	}
+	for number, list := range f.comments {
+		for _, c := range list {
+			c.IssueNumber = number
+			appendIfAfter(c)
+		}
+	}
+	return out, nil
 }
 
 func (f *fakeGitHub) PostIssueComment(_ context.Context, _ github.Repository, issueNumber int64, body string) (github.IssueComment, error) {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4750,6 +4750,56 @@ func (s *Store) UpsertHeartbeatState(ctx context.Context, state HeartbeatState) 
 	return err
 }
 
+// GetIssueCommentPollCursor returns the newest issue/PR comment updated_at the
+// --watch-issues poller has persisted for a repo (#566). A missing row is NOT an
+// error: it returns ok=false with a zero time, which the daemon treats as a
+// first-ever poll and seeds a bounded window from `now` (no history backfill).
+func (s *Store) GetIssueCommentPollCursor(ctx context.Context, repoFullName string) (time.Time, bool, error) {
+	repoFullName = strings.TrimSpace(repoFullName)
+	if repoFullName == "" {
+		return time.Time{}, false, errors.New("repo full name is required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT last_seen_comment_at FROM issue_comment_poll_state WHERE repo_full_name = ?`, repoFullName)
+	var raw string
+	if err := row.Scan(&raw); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return time.Time{}, false, nil
+		}
+		return time.Time{}, false, err
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		// A malformed persisted cursor is treated as "no cursor" rather than a hard
+		// error so a poison row can't wedge the poller; the next write repairs it.
+		return time.Time{}, false, nil
+	}
+	return parsed, true, nil
+}
+
+// UpsertIssueCommentPollCursor persists the newest observed comment updated_at for
+// a repo (#566). The time is stored as RFC3339Nano UTC text.
+func (s *Store) UpsertIssueCommentPollCursor(ctx context.Context, repoFullName string, lastSeen time.Time) error {
+	repoFullName = strings.TrimSpace(repoFullName)
+	if repoFullName == "" {
+		return errors.New("repo full name is required")
+	}
+	raw := ""
+	if !lastSeen.IsZero() {
+		raw = lastSeen.UTC().Format(time.RFC3339Nano)
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO issue_comment_poll_state(repo_full_name, last_seen_comment_at, updated_at)
+		VALUES (?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(repo_full_name) DO UPDATE SET
+			last_seen_comment_at = excluded.last_seen_comment_at,
+			updated_at = CURRENT_TIMESTAMP`,
+		repoFullName, raw)
+	return err
+}
+
 // CountActiveJobsByFingerprint counts queued/running jobs whose stored payload
 // carries the given fingerprint — the heartbeat overlap guard (#533), a cousin of
 // countActiveJobsTx that filters on the payload fingerprint instead of the agent
@@ -6654,5 +6704,19 @@ CREATE TABLE heartbeat_state (
 	// not scan terminal jobs once per second.
 	`
 CREATE INDEX idx_jobs_running_updated_at ON jobs(updated_at) WHERE state = 'running';
+	`,
+	// #566 --watch-issues bounded polling: one row per repo tracking the newest
+	// issue/PR comment updated_at the issue-comment watcher has observed. The
+	// daemon passes it (minus a small overlap) as the `since` bound to the repo-wide
+	// comment endpoint, collapsing the former O(open-issues) per-issue comment
+	// fan-out into a single since-bounded call per repo per tick. Pure additive
+	// append (CREATE TABLE only); the table stays empty until --watch-issues runs,
+	// so every existing DB reads identically.
+	`
+CREATE TABLE issue_comment_poll_state (
+	repo_full_name TEXT PRIMARY KEY,
+	last_seen_comment_at TEXT NOT NULL DEFAULT '',
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 	`,
 }

--- a/internal/feedback/github_test.go
+++ b/internal/feedback/github_test.go
@@ -887,3 +887,14 @@ func (f *fakeFeedbackGitHub) PostIssueComment(_ context.Context, repo github.Rep
 func (f *fakeFeedbackGitHub) ListIssueComments(_ context.Context, _ github.Repository, issueNumber int64) ([]github.IssueComment, error) {
 	return append([]github.IssueComment(nil), f.comments[issueNumber]...), nil
 }
+
+func (f *fakeFeedbackGitHub) ListRepoIssueComments(_ context.Context, _ github.Repository, _ time.Time) ([]github.IssueComment, error) {
+	var out []github.IssueComment
+	for number, list := range f.comments {
+		for _, c := range list {
+			c.IssueNumber = number
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -38,6 +38,10 @@ type Client interface {
 	CreateIssue(ctx context.Context, input CreateIssueInput) (Issue, error)
 	CloseIssue(ctx context.Context, repo Repository, issueNumber int64) (Issue, error)
 	ListIssueComments(ctx context.Context, repo Repository, issueNumber int64) ([]IssueComment, error)
+	// ListRepoIssueComments returns one bounded page of the repo's issue/PR
+	// conversation comments updated at/after `since` (#566), collapsing the
+	// per-issue comment fan-out into a single repo-wide call.
+	ListRepoIssueComments(ctx context.Context, repo Repository, since time.Time) ([]IssueComment, error)
 	PostIssueComment(ctx context.Context, repo Repository, issueNumber int64, body string) (IssueComment, error)
 	GetUserPermission(ctx context.Context, repo Repository, username string) (UserPermission, error)
 	MergePullRequest(ctx context.Context, input MergePullRequestInput) (MergeResult, error)
@@ -138,6 +142,15 @@ type IssueComment struct {
 	Author    string
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
+	// IssueNumber is the issue/PR number this comment belongs to. The per-issue
+	// endpoint omits it (the caller already knows the number), but the REPO-WIDE
+	// endpoint (GET /repos/{owner}/{repo}/issues/comments, #566) returns comments
+	// for every issue AND PR at once, carrying only an `issue_url`. It is parsed
+	// from that `issue_url` so ListRepoIssueComments callers can group the flat
+	// result back by issue/PR number. It is 0 when the source payload carried no
+	// parseable issue_url (the per-issue endpoint), so existing callers that ignore
+	// it are byte-identical.
+	IssueNumber int64
 }
 
 type UserPermission struct {
@@ -150,6 +163,7 @@ func (c *IssueComment) UnmarshalJSON(data []byte) error {
 		ID        int64  `json:"id"`
 		Body      string `json:"body"`
 		URL       string `json:"html_url"`
+		IssueURL  string `json:"issue_url"`
 		CreatedAt string `json:"created_at"`
 		UpdatedAt string `json:"updated_at"`
 		User      struct {
@@ -166,7 +180,30 @@ func (c *IssueComment) UnmarshalJSON(data []byte) error {
 	c.Author = decoded.User.Login
 	c.CreatedAt = decoded.CreatedAt
 	c.UpdatedAt = decoded.UpdatedAt
+	c.IssueNumber = issueNumberFromURL(decoded.IssueURL)
 	return nil
+}
+
+// issueNumberFromURL extracts the trailing issue/PR number from a GitHub
+// `issue_url` (e.g. https://api.github.com/repos/owner/repo/issues/123 -> 123).
+// It returns 0 for an empty or unparseable URL, which the repo-wide comment
+// grouping treats as "unknown issue" and skips. Every comment (issue OR PR) on
+// the /issues/comments endpoint carries this shape; PR review/diff comments live
+// on a different endpoint and are not returned here.
+func issueNumberFromURL(issueURL string) int64 {
+	issueURL = strings.TrimRight(strings.TrimSpace(issueURL), "/")
+	if issueURL == "" {
+		return 0
+	}
+	idx := strings.LastIndex(issueURL, "/")
+	if idx < 0 || idx == len(issueURL)-1 {
+		return 0
+	}
+	number, err := strconv.ParseInt(issueURL[idx+1:], 10, 64)
+	if err != nil || number <= 0 {
+		return 0
+	}
+	return number
 }
 
 type Issue struct {
@@ -652,6 +689,40 @@ func isPullRequestAlreadyExists(err error) bool {
 
 func (c *GhClient) ListIssueComments(ctx context.Context, repo Repository, issueNumber int64) ([]IssueComment, error) {
 	comments, err := apiPaginatedJSON[IssueComment](ctx, c, endpoint(repo, "issues", issueNumber, "comments"))
+	return dedupeComments(comments), err
+}
+
+// ListRepoIssueComments returns a SINGLE bounded page of the repo's issue/PR
+// conversation comments updated at or after `since` (#566), ordered oldest-first
+// (sort=updated&direction=asc) so the poller always makes forward progress and can
+// advance its `since` cursor to the newest comment it saw.
+//
+// It hits GET /repos/{owner}/{repo}/issues/comments — the REPO-WIDE endpoint that
+// returns comments for EVERY issue AND pull request in one paginated call
+// (excluding only PR review/diff comments, which the @mention command flow does
+// not use). This collapses the daemon's former O(issues) per-issue comment
+// fan-out into ONE gh call per repo per tick. Each returned comment carries its
+// IssueNumber (parsed from `issue_url`) so callers can group the flat result back
+// by issue/PR.
+//
+// BOUNDED COST: like ListRecentClosedPullRequests (#467) it fetches ONE page
+// (apiPageJSON, no --paginate) with per_page=100. With direction=asc a backlog
+// larger than one page is drained across successive ticks as the caller advances
+// `since`, so steady-state polling is a single fixed request rather than
+// re-paginating the repo's entire comment history. A zero `since` omits the
+// filter (the caller seeds a bounded window on first poll, so this is only a
+// safety fallback).
+func (c *GhClient) ListRepoIssueComments(ctx context.Context, repo Repository, since time.Time) ([]IssueComment, error) {
+	args := []string{
+		"-X", "GET", endpoint(repo, "issues", "comments"),
+		"-f", "sort=updated",
+		"-f", "direction=asc",
+		"-f", "per_page=100",
+	}
+	if !since.IsZero() {
+		args = append(args, "-f", "since="+since.UTC().Format(time.RFC3339))
+	}
+	comments, err := apiPageJSON[IssueComment](ctx, c, args...)
 	return dedupeComments(comments), err
 }
 
@@ -1306,6 +1377,10 @@ func (NoopClient) CloseIssue(context.Context, Repository, int64) (Issue, error) 
 }
 
 func (NoopClient) ListIssueComments(context.Context, Repository, int64) ([]IssueComment, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (NoopClient) ListRepoIssueComments(context.Context, Repository, time.Time) ([]IssueComment, error) {
 	return nil, errors.ErrUnsupported
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -196,6 +196,53 @@ func TestListIssueCommentsDedupesByID(t *testing.T) {
 	runner.wantArgs(t, 0, "api", "--paginate", "repos/jerryfane/gitmoot/issues/2/comments")
 }
 
+func TestListRepoIssueCommentsPassesSinceAndGroupsByIssue(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{
+			// Single-page (apiPageJSON) repo-wide payload: comments for a plain issue
+			// (#41) AND a PR (#42, every PR is an issue), each carrying issue_url.
+			Stdout: `[
+				{"id": 11, "body": "@a ask on issue", "issue_url": "https://api.github.com/repos/jerryfane/gitmoot/issues/41", "updated_at": "2026-06-27T10:00:00Z", "user": {"login": "alice"}},
+				{"id": 12, "body": "@a ask on PR", "issue_url": "https://api.github.com/repos/jerryfane/gitmoot/issues/42", "updated_at": "2026-06-27T11:00:00Z", "user": {"login": "bob"}},
+				{"id": 11, "body": "duplicate", "issue_url": "https://api.github.com/repos/jerryfane/gitmoot/issues/41", "updated_at": "2026-06-27T10:00:00Z", "user": {"login": "alice"}}
+			]`,
+		}},
+	}
+	client := GhClient{Runner: runner}
+
+	since := time.Date(2026, 6, 27, 9, 30, 0, 0, time.UTC)
+	comments, err := client.ListRepoIssueComments(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, since)
+	if err != nil {
+		t.Fatalf("ListRepoIssueComments returned error: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("comments length = %d, want 2 (deduped by id): %+v", len(comments), comments)
+	}
+	// PR conversation comments are INCLUDED (the @mention command channel).
+	if comments[0].IssueNumber != 41 || comments[1].IssueNumber != 42 {
+		t.Fatalf("IssueNumber not parsed from issue_url: %+v", comments)
+	}
+	if comments[1].Author != "bob" {
+		t.Fatalf("author decode: %+v", comments[1])
+	}
+	// One bounded page (no --paginate), since passthrough as RFC3339, oldest-first.
+	runner.wantArgs(t, 0, "api", "-X", "GET", "repos/jerryfane/gitmoot/issues/comments",
+		"-f", "sort=updated", "-f", "direction=asc", "-f", "per_page=100",
+		"-f", "since=2026-06-27T09:30:00Z")
+}
+
+func TestListRepoIssueCommentsZeroSinceOmitsFilter(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `[]`}}}
+	client := GhClient{Runner: runner}
+
+	if _, err := client.ListRepoIssueComments(context.Background(), Repository{Owner: "jerryfane", Name: "gitmoot"}, time.Time{}); err != nil {
+		t.Fatalf("ListRepoIssueComments returned error: %v", err)
+	}
+	// A zero since omits the since= arg entirely (no whole-history backfill trigger).
+	runner.wantArgs(t, 0, "api", "-X", "GET", "repos/jerryfane/gitmoot/issues/comments",
+		"-f", "sort=updated", "-f", "direction=asc", "-f", "per_page=100")
+}
+
 func TestPostIssueCommentUsesIssueCommentsEndpoint(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{


### PR DESCRIPTION
## What

Cuts the `--watch-issues` daemon's steady CPU/`gh` cost by collapsing the per-issue comment fan-out into a single, `since`-bounded, repo-wide call per repo per tick.

### Root cause
`PollIssuesOnce` listed open issues and then, per repo per ~30s tick, shelled out a **full paginated `ListIssueComments` for EACH open issue** — `O(repos × issues × comment-pages)` of `gh` subprocess/network/JSON work every cycle, re-fetching everything with no change detection.

## How

- **`github.ListRepoIssueComments(ctx, repo, since)`** — built on the existing bounded `apiPageJSON` helper (still `gh`, no new http/auth code). Calls `GET /repos/{owner}/{repo}/issues/comments?since={RFC3339}&sort=updated&direction=asc&per_page=100`. This repo-wide endpoint returns every issue's comments in one paginated call and, because every PR is an issue, **includes PR conversation comments** (the `@mention` command channel), excluding only PR review/diff comments (which the command flow does not use). Each comment carries its `IssueNumber`, parsed from `issue_url`, so callers can regroup. `direction=asc` + a persisted cursor drains any backlog larger than one page across successive ticks, so steady state is a single fixed request.
- **`PollIssuesOnce` rewrite** — one `ListRepoIssueComments(repo, lastSeen)` call per tick, group comments by issue number, and feed each open non-PR issue's comments through the **unchanged** `handleIssueComment` (authorize + seen-comments dedup + `ask` routing).
- **Per-repo cursor** persisted in a new additive `issue_comment_poll_state` table (`GetIssueCommentPollCursor` / `UpsertIssueCommentPollCursor`): the max comment `updated_at` seen, passed next tick as `since` minus a 5s clock-skew overlap.

## Behavior preserved

- **New-issue enumeration** still uses `ListIssues` (this endpoint returns comments only) — only the per-issue comment pagination is collapsed.
- **PR `@mention` commands are byte-identical**: PR comments in the repo-wide result are skipped here and remain owned by `PollOnce`'s existing per-PR loop (untouched — smallest blast radius).
- **Seen-comments dedup unchanged**, so an edited-comment replay (new `updated_at`, same id) is still deduped.
- **Intentional first-poll difference** (documented in code): with no cursor the `since` window is seeded from `now`, so a fresh watcher does not backfill the entire repo comment history. The old code paginated every open issue's full thread on the first tick (acting only on unseen comments); in steady state both are identical because the cursor advances monotonically and every processed comment is recorded in `seen_comments`.

## Tests

- `ListRepoIssueComments`: single bounded page (no `--paginate`), `since` passthrough as RFC3339, oldest-first, dedup, PR-comment inclusion, and `issue_url`→`IssueNumber` grouping; zero-`since` omits the filter.
- `PollIssuesOnce`: **one** repo-wide call per tick and **zero** per-issue calls, correct grouping→routing (PR/unknown-issue comments skipped), cursor advance to the newest `updated_at`, and dedup of an edited/already-seen comment — via an injected clock seam.

## Follow-up (out of scope)

An **ETag / `If-None-Match` → `304`** conditional-request optimization would further cut steady cost, but it needs an in-process `http.Client` + a per-repo etag cache (not `gh --paginate`), so it is deferred as a documented follow-up.

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)