### PR TITLE
fix(daemon): keep wedged jobs from stalling workers, but escalate persistent faults

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1629,6 +1629,24 @@ func startSupervisorWorkerLoopRecovering(ctx context.Context, interval time.Dura
 	return startSupervisorWorkerLoopInternal(ctx, interval, stdout, run, true)
 }
 
+// maxConsecutiveWorkerTickFailures bounds how many CONSECUTIVE recovering
+// worker-tick failures the supervisor tolerates before it stops retrying and
+// surfaces the error on its channel so the caller (the daemon) exits and
+// systemd restarts/alerts. gaijinjoe's #555 made a single transient tick error
+// survivable (the daemon no longer wedges), but retry-forever turned a
+// PERMANENT infra fault — job-level failures already return nil, so what bubbles
+// up here is disk-full / corrupt-or-locked SQLite / a failed migration — into a
+// silent false-green daemon: status still "running", zero progress, ~86k log
+// lines/day. The streak resets to 0 on any successful tick, so only a genuinely
+// stuck daemon escalates. At the capped backoff below this spans a few minutes
+// before escalating (1+2+4+8+16 then 30s each ≈ 4m for a 1s base interval).
+const maxConsecutiveWorkerTickFailures = 12
+
+// maxWorkerTickBackoff caps the exponential retry sleep applied to a persistent
+// recovering-loop fault, so a permanent error backs off to the poll cadence
+// instead of spinning at the 1s base interval and flooding the journal.
+const maxWorkerTickBackoff = 30 * time.Second
+
 func startSupervisorWorkerLoopInternal(ctx context.Context, interval time.Duration, stdout io.Writer, run func(time.Time) error, recoverErrors bool) <-chan error {
 	errCh := make(chan error, 1)
 	if interval <= 0 {
@@ -1636,27 +1654,68 @@ func startSupervisorWorkerLoopInternal(ctx context.Context, interval time.Durati
 	}
 	go func() {
 		defer close(errCh)
+		consecutiveFailures := 0
 		for {
 			if err := ctx.Err(); err != nil {
 				return
 			}
 			if err := run(time.Now().UTC()); err != nil {
-				if recoverErrors {
-					writeLine(stdout, "daemon worker tick error: %v; retrying", err)
-					if sleepErr := sleepSupervisorWorkerLoop(ctx, interval); sleepErr != nil {
-						return
-					}
-					continue
+				// A cancellation observed mid-tick is a clean shutdown, never a
+				// fault: return WITHOUT logging or counting it toward the
+				// escalation streak, so graceful shutdown stays quiet and never
+				// pushes context.Canceled onto errCh.
+				if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+					return
 				}
-				errCh <- err
-				return
+				if !recoverErrors {
+					errCh <- err
+					return
+				}
+				consecutiveFailures++
+				// A PERSISTENT fault (a bounded streak of consecutive tick
+				// errors) is infra-level, not a transient blip: escalate it so
+				// the daemon exits instead of spinning silently forever.
+				if consecutiveFailures >= maxConsecutiveWorkerTickFailures {
+					writeLine(stdout, "daemon worker tick error: %v; %d consecutive failures, escalating", err, consecutiveFailures)
+					errCh <- err
+					return
+				}
+				writeLine(stdout, "daemon worker tick error: %v; retrying (%d/%d)", err, consecutiveFailures, maxConsecutiveWorkerTickFailures)
+				if sleepErr := sleepSupervisorWorkerLoop(ctx, workerTickBackoff(interval, consecutiveFailures)); sleepErr != nil {
+					return
+				}
+				continue
 			}
+			// A successful tick clears the streak: only CONSECUTIVE failures
+			// escalate, so one bad pass between good ones never trips the ceiling.
+			consecutiveFailures = 0
 			if err := sleepSupervisorWorkerLoop(ctx, interval); err != nil {
 				return
 			}
 		}
 	}()
 	return errCh
+}
+
+// workerTickBackoff returns the retry sleep for the Nth consecutive recovering
+// worker-tick failure: the base interval doubled per failure, capped at
+// maxWorkerTickBackoff. consecutiveFailures==1 returns the base interval (his
+// original single-transient-error cadence is preserved).
+func workerTickBackoff(base time.Duration, consecutiveFailures int) time.Duration {
+	if base <= 0 {
+		base = daemonWorkerLoopInterval
+	}
+	backoff := base
+	for i := 1; i < consecutiveFailures; i++ {
+		if backoff >= maxWorkerTickBackoff {
+			return maxWorkerTickBackoff
+		}
+		backoff *= 2
+	}
+	if backoff > maxWorkerTickBackoff {
+		return maxWorkerTickBackoff
+	}
+	return backoff
 }
 
 func sleepSupervisorWorkerLoop(ctx context.Context, interval time.Duration) error {
@@ -1923,10 +1982,16 @@ func (p registeredRepoPoller) pollRepo(ctx context.Context, repoRecord db.Repo, 
 		EscalationTTL:          p.EscalationTTL,
 		RevertDetectionEnabled: p.RevertDetectionEnabled,
 	}
+	// Bound the poll the same way the single-repo supervisor does (#555 / #536):
+	// this call runs while HOLDING the per-repo checkout lock (deferred Unlock
+	// above), so a wedged PollOnce would hold that lock forever and freeze this
+	// repo's worker ticks — the exact stall #555 targets. The timeout only
+	// bounds the poll; the lock's per-repo checkout semantics are unchanged
+	// because Unlock still runs via defer once the (now-bounded) poll returns.
 	if recoveryOnly {
-		err = d.PollRecoveryCommandsOnce(ctx)
+		err = runDaemonPollWithTimeout(ctx, daemonRunningJobStaleAfter, d.PollRecoveryCommandsOnce)
 	} else {
-		err = d.PollOnce(ctx)
+		err = runDaemonPollWithTimeout(ctx, daemonRunningJobStaleAfter, d.PollOnce)
 	}
 	lastError := ""
 	if err != nil {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1383,10 +1383,10 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 			return err
 		}
 		if checkoutLock.TryLock() {
-			_ = runDaemonPollWithTimeout(ctx, daemonRunningJobStaleAfter, d.PollOnce)
+			_ = runDaemonPollWithTimeout(ctx, daemonPollTimeout, d.PollOnce)
 			checkoutLock.Unlock()
 		} else {
-			_ = runDaemonPollWithTimeout(ctx, daemonRunningJobStaleAfter, d.PollRecoveryCommandsOnce)
+			_ = runDaemonPollWithTimeout(ctx, daemonPollTimeout, d.PollRecoveryCommandsOnce)
 		}
 		if heartbeatPathsErr == nil {
 			if err := runHeartbeatScanOnce(ctx, heartbeatPaths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
@@ -1989,9 +1989,9 @@ func (p registeredRepoPoller) pollRepo(ctx context.Context, repoRecord db.Repo, 
 	// bounds the poll; the lock's per-repo checkout semantics are unchanged
 	// because Unlock still runs via defer once the (now-bounded) poll returns.
 	if recoveryOnly {
-		err = runDaemonPollWithTimeout(ctx, daemonRunningJobStaleAfter, d.PollRecoveryCommandsOnce)
+		err = runDaemonPollWithTimeout(ctx, daemonPollTimeout, d.PollRecoveryCommandsOnce)
 	} else {
-		err = runDaemonPollWithTimeout(ctx, daemonRunningJobStaleAfter, d.PollOnce)
+		err = runDaemonPollWithTimeout(ctx, daemonPollTimeout, d.PollOnce)
 	}
 	lastError := ""
 	if err != nil {
@@ -2094,6 +2094,19 @@ func (w jobWorker) eventSink() events.Sink {
 const daemonRunningJobStaleAfter = 30 * time.Minute
 const daemonJobCancelPollInterval = 250 * time.Millisecond
 const daemonWorkerLoopInterval = 1 * time.Second
+
+// daemonPollTimeout bounds a single repo's PollOnce / PollRecoveryCommandsOnce.
+// The poll runs while HOLDING that repo's checkout lock, and both supervisors
+// take each repo's lock SEQUENTIALLY, so a wedged (ctx-respecting-but-slow)
+// poll on one repo freezes that repo's — and, in the multi-repo sweep, every
+// later repo's — worker ticks until it returns (#555 / #536). It is therefore a
+// hard STALL bound, not the expected poll duration: reusing
+// daemonRunningJobStaleAfter (30 min) here left the sweep frozen for up to half
+// an hour, largely defeating #555's anti-stall goal, so it is deliberately much
+// tighter. A healthy poll finishes well inside this; exceeding it means the poll
+// is wedged and cancelling it (the deferred checkout Unlock still runs, so no
+// lock leak) is the correct recovery.
+const daemonPollTimeout = 2 * time.Minute
 
 // cockpitReconcileInterval is the low-frequency cadence of the cockpit reconcile
 // GC sweep (Task 7): it drops cockpit_pane rows whose herdr pane is gone and whose
@@ -2364,23 +2377,49 @@ func runEnabledRepoWorkerTicksWithLocks(ctx context.Context, store *db.Store, wo
 	if err != nil {
 		return err
 	}
+	// Scope tick faults per repo (#555 follow-up): the recovering supervisor
+	// treats a returned error as one fleet-wide failure unit and, after a bounded
+	// streak, exits the WHOLE daemon. Returning on the first repo's error would
+	// let a single repo-local fault (e.g. a broken/permission-denied checkout
+	// dir) both starve every later repo in ListRepos order AND escalate/kill the
+	// healthy repos' daemon with it. So log a single repo's tick error and keep
+	// sweeping; only a fault hitting EVERY enabled repo — a shared/store-level
+	// fault such as locked/corrupt SQLite or disk-full, the genuine global fault
+	// #555's escalation targets — is returned so the supervisor can escalate.
+	enabled := 0
+	failed := 0
+	var lastErr error
 	for _, repo := range repos {
 		if !repo.Enabled {
 			continue
 		}
+		enabled++
 		lock := locks.For(repo.FullName())
 		if lock != nil {
 			lock.Lock()
 		}
-		if err := runDaemonWorkerTick(ctx, store, worker, workers, false, repo.FullName(), rootFilter, stdout, now); err != nil {
-			if lock != nil {
-				lock.Unlock()
-			}
-			return err
-		}
+		tickErr := runDaemonWorkerTick(ctx, store, worker, workers, false, repo.FullName(), rootFilter, stdout, now)
 		if lock != nil {
 			lock.Unlock()
 		}
+		if tickErr != nil {
+			// A cancellation observed mid-sweep is a clean shutdown, not a repo
+			// fault: propagate it immediately so the supervisor treats it as such
+			// (and it never counts toward or masks the escalation streak).
+			if errors.Is(tickErr, context.Canceled) || ctx.Err() != nil {
+				return tickErr
+			}
+			failed++
+			lastErr = tickErr
+			writeLine(stdout, "%s: worker tick error: %v", repo.FullName(), tickErr)
+		}
+	}
+	// Every enabled repo failing is the global-fault signal: return it so the
+	// recovering supervisor's streak can trip and escalate. A single-repo daemon
+	// (enabled==1) still escalates on its own persistent fault, matching the
+	// single-repo supervisor.
+	if enabled > 0 && failed == enabled {
+		return lastErr
 	}
 	return nil
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1298,7 +1298,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			if err := recoverCancelledRunningJobsForEnabledRepos(ctx, store, rootFilter, stdout); err != nil {
 				return err
 			}
-			workerErr = startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
+			workerErr = startSupervisorWorkerLoopRecovering(ctx, daemonWorkerLoopInterval, stdout, func(now time.Time) error {
 				return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, rootFilter, stdout, now, checkoutLocks)
 			})
 			startCockpitReconcileLoop(ctx, store, paths.Home, stdout)
@@ -1360,7 +1360,7 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 	worker.UsePool = usePool
 	worker.Admission = worker.loadAdmissionBudget()
 	var checkoutLock sync.Mutex
-	workerErr := startSupervisorWorkerLoop(ctx, daemonWorkerLoopInterval, func(now time.Time) error {
+	workerErr := startSupervisorWorkerLoopRecovering(ctx, daemonWorkerLoopInterval, stdout, func(now time.Time) error {
 		checkoutLock.Lock()
 		defer checkoutLock.Unlock()
 		return runDaemonWorkerTick(ctx, store, worker, workers, false, d.Repo.FullName(), rootFilter, stdout, now)
@@ -1383,10 +1383,10 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 			return err
 		}
 		if checkoutLock.TryLock() {
-			_ = d.PollOnce(ctx)
+			_ = runDaemonPollWithTimeout(ctx, daemonRunningJobStaleAfter, d.PollOnce)
 			checkoutLock.Unlock()
 		} else {
-			_ = d.PollRecoveryCommandsOnce(ctx)
+			_ = runDaemonPollWithTimeout(ctx, daemonRunningJobStaleAfter, d.PollRecoveryCommandsOnce)
 		}
 		if heartbeatPathsErr == nil {
 			if err := runHeartbeatScanOnce(ctx, heartbeatPaths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
@@ -1622,6 +1622,14 @@ func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqu
 }
 
 func startSupervisorWorkerLoop(ctx context.Context, interval time.Duration, run func(time.Time) error) <-chan error {
+	return startSupervisorWorkerLoopInternal(ctx, interval, nil, run, false)
+}
+
+func startSupervisorWorkerLoopRecovering(ctx context.Context, interval time.Duration, stdout io.Writer, run func(time.Time) error) <-chan error {
+	return startSupervisorWorkerLoopInternal(ctx, interval, stdout, run, true)
+}
+
+func startSupervisorWorkerLoopInternal(ctx context.Context, interval time.Duration, stdout io.Writer, run func(time.Time) error, recoverErrors bool) <-chan error {
 	errCh := make(chan error, 1)
 	if interval <= 0 {
 		interval = daemonWorkerLoopInterval
@@ -1633,19 +1641,33 @@ func startSupervisorWorkerLoop(ctx context.Context, interval time.Duration, run 
 				return
 			}
 			if err := run(time.Now().UTC()); err != nil {
+				if recoverErrors {
+					writeLine(stdout, "daemon worker tick error: %v; retrying", err)
+					if sleepErr := sleepSupervisorWorkerLoop(ctx, interval); sleepErr != nil {
+						return
+					}
+					continue
+				}
 				errCh <- err
 				return
 			}
-			timer := time.NewTimer(interval)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
+			if err := sleepSupervisorWorkerLoop(ctx, interval); err != nil {
 				return
-			case <-timer.C:
 			}
 		}
 	}()
 	return errCh
+}
+
+func sleepSupervisorWorkerLoop(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func receiveSupervisorWorkerError(errCh <-chan error) error {
@@ -2050,6 +2072,15 @@ func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, std
 		writeLine(stdout, "recovered %d expired runtime session locks", deleted)
 	}
 	return nil
+}
+
+func runDaemonPollWithTimeout(ctx context.Context, timeout time.Duration, poll func(context.Context) error) error {
+	if timeout <= 0 {
+		return poll(ctx)
+	}
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return poll(pollCtx)
 }
 
 func recoverRunningJobsBefore(ctx context.Context, store *db.Store, stdout io.Writer, before time.Time) error {
@@ -4256,14 +4287,17 @@ func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (mana
 
 // effectiveJobTimeout returns the timeout to enforce for a job: the
 // per-delegation payload.JobTimeout when it parses to a positive duration,
-// otherwise the agent-type managed.JobTimeout (which is zero when the agent is
-// not managed). The same value drives both the runtime-session lock TTL and the
-// run context deadline so the lock cannot expire before the job does.
+// otherwise the agent-type managed.JobTimeout, otherwise the daemon stale window
+// for unmanaged jobs. The same value drives both the runtime-session lock TTL and
+// the run context deadline so a job cannot outlive the lease that guards it.
 func effectiveJobTimeout(payload workflow.JobPayload, managed managedJobRuntimeConfig) time.Duration {
 	if d, err := time.ParseDuration(strings.TrimSpace(payload.JobTimeout)); err == nil && d > 0 {
 		return d
 	}
-	return managed.JobTimeout
+	if managed.JobTimeout > 0 {
+		return managed.JobTimeout
+	}
+	return daemonRunningJobStaleAfter
 }
 
 func originalAgentForTempWorkerType(typ string) string {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -5730,14 +5730,82 @@ func TestEffectiveJobTimeout(t *testing.T) {
 		t.Fatalf("effectiveJobTimeout(zero payload) = %v, want 10m", got)
 	}
 
-	// With no managed config, an empty payload timeout yields zero (no deadline).
-	if got := effectiveJobTimeout(workflow.JobPayload{}, managedJobRuntimeConfig{}); got != 0 {
-		t.Fatalf("effectiveJobTimeout(unmanaged, empty) = %v, want 0", got)
+	// With no managed config, an empty payload timeout falls back to the daemon
+	// stale window so an unmanaged job still has a watchdog.
+	if got := effectiveJobTimeout(workflow.JobPayload{}, managedJobRuntimeConfig{}); got != daemonRunningJobStaleAfter {
+		t.Fatalf("effectiveJobTimeout(unmanaged, empty) = %v, want %v", got, daemonRunningJobStaleAfter)
 	}
 
 	// With no managed config, a valid payload timeout still applies.
 	if got := effectiveJobTimeout(workflow.JobPayload{JobTimeout: "45s"}, managedJobRuntimeConfig{}); got != 45*time.Second {
 		t.Fatalf("effectiveJobTimeout(unmanaged, payload) = %v, want 45s", got)
+	}
+}
+
+func TestStartSupervisorWorkerLoopReportsErrorByDefault(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := startSupervisorWorkerLoop(ctx, time.Millisecond, func(time.Time) error {
+		return errors.New("boom")
+	})
+
+	select {
+	case err, ok := <-errCh:
+		if !ok {
+			t.Fatal("worker loop closed without reporting the run error")
+		}
+		if err == nil || err.Error() != "boom" {
+			t.Fatalf("worker loop error = %v, want boom", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker loop did not report the run error")
+	}
+}
+
+func TestStartSupervisorWorkerLoopRecoveringRetriesAfterRunError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls int
+	var mu sync.Mutex
+	errCh := startSupervisorWorkerLoopRecovering(ctx, time.Millisecond, io.Discard, func(time.Time) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls == 1 {
+			return errors.New("transient")
+		}
+		cancel()
+		return nil
+	})
+
+	select {
+	case err, ok := <-errCh:
+		if ok && err != nil {
+			t.Fatalf("recovering worker loop reported error = %v, want silent retry", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("recovering worker loop did not retry after the run error")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls < 2 {
+		t.Fatalf("recovering worker loop calls = %d, want at least 2", calls)
+	}
+}
+
+func TestRunDaemonPollWithTimeoutCancelsPoll(t *testing.T) {
+	start := time.Now()
+	err := runDaemonPollWithTimeout(context.Background(), time.Millisecond, func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runDaemonPollWithTimeout error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("runDaemonPollWithTimeout took %v, want bounded", elapsed)
 	}
 }
 

--- a/internal/cli/daemon_worker_loop_escalate_e2e_test.go
+++ b/internal/cli/daemon_worker_loop_escalate_e2e_test.go
@@ -1,0 +1,315 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// This file is the end-to-end proof for the daemon worker-loop hardening built
+// on top of gaijinjoe's PR #555 ("fix(daemon): keep wedged jobs from stalling
+// workers"). It drives the REAL supervisor worker loop the daemon wires at
+// runSingleRepoSupervisor / runRegisteredRepoSupervisor
+// (startSupervisorWorkerLoopRecovering) — no mocks, no hand-rolled fake loop.
+//
+// #555 made a SINGLE transient worker-tick error survivable so the daemon no
+// longer wedges (property A below — his win, preserved). But retry-forever left
+// a "silent-forever" gap (#536-class safety): job-level failures already return
+// nil, so what bubbles up here is INFRA (disk-full / corrupt-or-locked SQLite /
+// failed migration). A PERMANENT such fault would spin silently at ~1s forever
+// — a false-green daemon (status still "running"), zero progress, ~86k log
+// lines/day — instead of surfacing so the process exits and systemd restarts.
+// The fix tracks CONSECUTIVE tick failures, resets on any success, applies
+// capped backoff, and after maxConsecutiveWorkerTickFailures escalates on errCh
+// and returns. Cancellation mid-tick is a clean shutdown, never a fault.
+//
+// MUTATION PROOF for the escalation property (B): remove the escalation ceiling
+// so the recovering loop retries forever, e.g. in
+// startSupervisorWorkerLoopInternal delete the block:
+//
+//	if consecutiveFailures >= maxConsecutiveWorkerTickFailures {
+//	    writeLine(stdout, "...escalating", err, consecutiveFailures)
+//	    errCh <- err
+//	    return
+//	}
+//
+// Then TestRecoveringWorkerLoopEscalatesPersistentFault_555_E2E goes RED: errCh
+// never receives, the loop never surfaces the persistent fault, and the test
+// times out. Restore the block -> green.
+
+// TestWedgedWorkerLoopRecoveringProcessesLaterQueuedWork_555_E2E is property (A):
+// a SINGLE transient tick error is survived and a later queued job is still
+// processed. This is gaijinjoe's #555 win; before it the daemon wedged on the
+// first tick error and never drained subsequently-queued work.
+func TestWedgedWorkerLoopRecoveringProcessesLaterQueuedWork_555_E2E(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("db.Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Real "later work": a job queued in the real store. It must survive a
+	// transient worker-tick error and still get processed by a subsequent tick.
+	const laterJobID = "job-later-queued-555"
+	if err := store.CreateJob(ctx, db.Job{
+		ID:      laterJobID,
+		Agent:   "worker-e2e",
+		Type:    "delegation",
+		State:   "queued",
+		Payload: `{"prompt":"later queued work that must not be stranded"}`,
+	}); err != nil {
+		t.Fatalf("CreateJob(queued later work) returned error: %v", err)
+	}
+
+	loopCtx, cancelLoop := context.WithCancel(ctx)
+	defer cancelLoop()
+
+	var ticks int32
+
+	errCh := startSupervisorWorkerLoopRecovering(loopCtx, 2*time.Millisecond, io.Discard, func(now time.Time) error {
+		n := atomic.AddInt32(&ticks, 1)
+		if n == 1 {
+			return errors.New("transient worker tick failure (e2e #555)")
+		}
+		claimed, err := store.TransitionJobState(ctx, laterJobID, "queued", "running")
+		if err != nil {
+			return err
+		}
+		if claimed {
+			if err := store.UpdateJobState(ctx, laterJobID, "done"); err != nil {
+				return err
+			}
+		}
+		job, err := store.GetJob(ctx, laterJobID)
+		if err != nil {
+			return err
+		}
+		if job.State == "done" {
+			cancelLoop()
+		}
+		return nil
+	})
+
+	select {
+	case err, ok := <-errCh:
+		if ok && err != nil {
+			t.Fatalf("recovering worker loop reported fatal error %v; a single transient tick error must be retried, not surfaced", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("recovering worker loop never terminated (deadlock / no retry)")
+	}
+
+	if got := atomic.LoadInt32(&ticks); got < 2 {
+		t.Fatalf("worker loop ran %d tick(s); the transient tick #1 error wedged the loop so no SUBSEQUENT tick ran (pre-#555 bug)", got)
+	}
+
+	job, err := store.GetJob(ctx, laterJobID)
+	if err != nil {
+		t.Fatalf("GetJob(later work) returned error: %v", err)
+	}
+	if job.State != "done" {
+		t.Fatalf("later queued job state = %q, want %q; the worker loop wedged on the transient error", job.State, "done")
+	}
+}
+
+// TestRecoveringWorkerLoopEscalatesPersistentFault_555_E2E is property (B): a
+// PERMANENT tick fault (every tick errors) is retried a bounded number of times
+// and then ESCALATED — the error is surfaced on errCh and the loop returns — so
+// systemd can restart the daemon instead of it spinning silently forever. This
+// closes the "silent-forever" gap left by #555's retry-forever behavior.
+//
+// This is the mutation target: delete the escalation ceiling and this goes RED
+// (errCh never receives, this times out).
+func TestRecoveringWorkerLoopEscalatesPersistentFault_555_E2E(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var ticks int32
+	permanent := errors.New("persistent infra fault (corrupt sqlite) (e2e #555)")
+
+	// Small base interval so the capped exponential backoff stays sub-second
+	// across the whole streak; the production const is unchanged.
+	errCh := startSupervisorWorkerLoopRecovering(ctx, 100*time.Microsecond, io.Discard, func(now time.Time) error {
+		atomic.AddInt32(&ticks, 1)
+		return permanent
+	})
+
+	select {
+	case err, ok := <-errCh:
+		if !ok {
+			t.Fatal("recovering worker loop closed WITHOUT surfacing the persistent fault; a permanent tick error must escalate so systemd can restart")
+		}
+		if !errors.Is(err, permanent) {
+			t.Fatalf("recovering worker loop surfaced %v, want the persistent fault %v", err, permanent)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("recovering worker loop NEVER surfaced the persistent fault (silent-forever gap); it must escalate after maxConsecutiveWorkerTickFailures")
+	}
+
+	// It escalated at (not before, not long after) the ceiling: exactly
+	// maxConsecutiveWorkerTickFailures ticks ran before the loop returned.
+	if got := int(atomic.LoadInt32(&ticks)); got != maxConsecutiveWorkerTickFailures {
+		t.Fatalf("worker loop ran %d ticks before escalating, want %d (maxConsecutiveWorkerTickFailures)", got, maxConsecutiveWorkerTickFailures)
+	}
+}
+
+// TestRecoveringWorkerLoopResetsStreakOnSuccess_555_E2E is property (C): a
+// SUCCESS between failures resets the consecutive-failure streak, so (max-1)
+// failures, then a success, then (max-1) more failures does NOT prematurely
+// escalate — even though the TOTAL failure count far exceeds the ceiling. Only
+// CONSECUTIVE failures escalate.
+func TestRecoveringWorkerLoopResetsStreakOnSuccess_555_E2E(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Two bursts of (max-1) failures separated by a single success. The success
+	// resets the streak, so neither burst reaches the ceiling. Total failures
+	// (2*(max-1)) is well above max, proving it is CONSECUTIVE failures — not a
+	// lifetime count — that escalate.
+	burst := maxConsecutiveWorkerTickFailures - 1
+	transient := errors.New("transient tick error (e2e #555 reset)")
+
+	var mu sync.Mutex
+	var n int
+	errCh := startSupervisorWorkerLoopRecovering(ctx, 100*time.Microsecond, io.Discard, func(now time.Time) error {
+		mu.Lock()
+		defer mu.Unlock()
+		n++
+		switch {
+		case n <= burst:
+			return transient // first burst: streak climbs to max-1
+		case n == burst+1:
+			return nil // success: streak resets to 0
+		case n <= 2*burst+1:
+			return transient // second burst: streak climbs to max-1 again
+		default:
+			cancel() // clean stop; we never hit the ceiling
+			return nil
+		}
+	})
+
+	select {
+	case err, ok := <-errCh:
+		if ok && err != nil {
+			t.Fatalf("recovering worker loop escalated %v after a reset; %d total failures never reached %d CONSECUTIVE, so it must NOT escalate", err, 2*burst, maxConsecutiveWorkerTickFailures)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("recovering worker loop never terminated after the reset scenario")
+	}
+}
+
+// TestRecoveringWorkerLoopCleanShutdownOnCancel_555_E2E is property (D): a ctx
+// cancellation observed mid-tick is a clean shutdown — the loop returns WITHOUT
+// surfacing an error on errCh and WITHOUT emitting a spurious "tick error;
+// retrying" log line, and the cancellation does NOT count toward the escalation
+// streak.
+func TestRecoveringWorkerLoopCleanShutdownOnCancel_555_E2E(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var logs bytes.Buffer
+	var logMu sync.Mutex
+	safeLog := &lockedWriter{w: &logs, mu: &logMu}
+
+	errCh := startSupervisorWorkerLoopRecovering(ctx, time.Millisecond, safeLog, func(now time.Time) error {
+		// Simulate a tick that is interrupted by graceful shutdown: cancel the
+		// context and return the context error the way a real tick would when
+		// its own ctx is cancelled mid-work.
+		cancel()
+		return context.Canceled
+	})
+
+	select {
+	case err, ok := <-errCh:
+		if ok && err != nil {
+			t.Fatalf("clean shutdown surfaced %v on errCh; a mid-tick cancellation must be silent, never a fault", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("recovering worker loop did not shut down cleanly on cancellation")
+	}
+
+	logMu.Lock()
+	got := logs.String()
+	logMu.Unlock()
+	if strings.Contains(got, "retrying") || strings.Contains(got, "escalating") || strings.Contains(got, "context canceled") {
+		t.Fatalf("clean shutdown emitted a spurious log line %q; a mid-tick cancellation must not log or count as a failure", got)
+	}
+}
+
+// TestRunDaemonPollWithTimeoutBoundsWedgedPoll_555_E2E is the poll half of #555:
+// polling runs under the checkout lock, so a poll that hangs forever holds that
+// lock forever and freezes the daemon. runDaemonPollWithTimeout bounds it. This
+// path is now ALSO wired into the multi-repo supervisor's pollRepo (the real
+// deployment), not just single-repo.
+func TestRunDaemonPollWithTimeoutBoundsWedgedPoll_555_E2E(t *testing.T) {
+	start := time.Now()
+
+	poll := func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	err := runDaemonPollWithTimeout(context.Background(), 20*time.Millisecond, poll)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runDaemonPollWithTimeout error = %v, want context.DeadlineExceeded (a hung poll must be bounded)", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("runDaemonPollWithTimeout took %v; a wedged poll was NOT bounded", elapsed)
+	}
+}
+
+// TestWorkerTickBackoffCapsAtMax verifies the retry sleep grows from the base
+// interval and never exceeds maxWorkerTickBackoff (so a persistent fault backs
+// off to the poll cadence instead of spinning at the base interval).
+func TestWorkerTickBackoffCapsAtMax(t *testing.T) {
+	base := time.Second
+	if got := workerTickBackoff(base, 1); got != base {
+		t.Fatalf("workerTickBackoff(1) = %v, want base %v (his single-transient cadence preserved)", got, base)
+	}
+	if got := workerTickBackoff(base, 2); got != 2*base {
+		t.Fatalf("workerTickBackoff(2) = %v, want %v", got, 2*base)
+	}
+	prev := time.Duration(0)
+	for f := 1; f <= maxConsecutiveWorkerTickFailures; f++ {
+		got := workerTickBackoff(base, f)
+		if got > maxWorkerTickBackoff {
+			t.Fatalf("workerTickBackoff(%d) = %v exceeds cap %v", f, got, maxWorkerTickBackoff)
+		}
+		if got < prev {
+			t.Fatalf("workerTickBackoff(%d) = %v decreased below previous %v (backoff must be monotonic up to the cap)", f, got, prev)
+		}
+		prev = got
+	}
+	if got := workerTickBackoff(base, 1000); got != maxWorkerTickBackoff {
+		t.Fatalf("workerTickBackoff(1000) = %v, want cap %v", got, maxWorkerTickBackoff)
+	}
+}
+
+// lockedWriter serializes writes to an underlying buffer so the loop goroutine
+// and the test goroutine can share it without a data race.
+type lockedWriter struct {
+	w  io.Writer
+	mu *sync.Mutex
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
+}


### PR DESCRIPTION
## What

Builds directly on **gaijinjoe's #555** ("fix(daemon): keep wedged jobs from stalling workers") — his single commit is cherry-picked here unchanged (authorship preserved) — and closes two gaps his retry-forever behavior left. **Supersedes #555.**

## Why

#555 fixed a real wedge: a single transient worker-tick error no longer takes down the daemon supervisor, so later-queued work is still drained. But `startSupervisorWorkerLoopInternal(recoverErrors=true)` then logged + retried **every** tick error every ~1s **forever** with no escalation. Job-level failures already return `nil`, so what actually bubbles up here is **infra** (disk full, corrupt/locked SQLite, a failed migration). A *permanent* such fault would spin silently:

- false-green daemon (`gitmoot daemon status` still "running"),
- zero progress,
- ~86k log lines/day,

instead of the pre-#555 behavior of surfacing the error so the process exits and systemd restarts/alerts. That is the #536-class safety regression this PR fixes.

## Changes (on top of #555)

1. **Escalate persistent faults (the silent-forever gap).** Track *consecutive* worker-tick failures; **reset the streak to 0 on any successful tick**; after `maxConsecutiveWorkerTickFailures` (12) surface the error on `errCh` and **return** so a genuinely-stuck daemon still escalates (systemd restart). A **single transient error is still survived** — his core win is preserved.
2. **Capped exponential backoff.** A persistent fault backs off from the base interval up to `maxWorkerTickBackoff` (30s ≈ the poll cadence) instead of spinning at 1s and flooding the journal. `consecutiveFailures==1` still sleeps the base interval, so his single-transient cadence is unchanged. At the base 1s interval this spans a few minutes before escalating.
3. **Bound the multi-repo poll (the real deployment).** `runDaemonPollWithTimeout` was only wired into `runSingleRepoSupervisor`. The multi-repo supervisor drives its poll via `pollRegisteredReposWithPoller` → `pollRepo`, which calls `PollOnce` / `PollRecoveryCommandsOnce` **while holding the per-repo checkout lock** — so a wedged poll there still blocks that repo's worker ticks (the exact stall #555 targets). Those calls are now wrapped in `runDaemonPollWithTimeout` **without** changing the per-repo checkout-lock semantics (`Unlock` still runs via `defer` once the now-bounded poll returns).
4. **Clean shutdown.** A `ctx` cancel observed mid-tick returns **without** logging or counting toward the escalation streak, so graceful shutdown stays quiet and never pushes `context.Canceled` onto `errCh`.

## Tests

`internal/cli/daemon_worker_loop_escalate_e2e_test.go` drives the **real** recovering loop (real `db.Store`, no mocks):

- **(A) transient survived** — one bad tick, later-queued job still drained to `done` (gaijinjoe's #555 win).
- **(B) escalation** — a permanent fault escalates on `errCh` after exactly `maxConsecutiveWorkerTickFailures` ticks and returns.
- **(C) reset** — a success between two `(max-1)` failure bursts (total failures ≫ ceiling) does **not** escalate; only *consecutive* failures do.
- **(D) clean shutdown** — mid-tick cancellation returns silently, no `errCh` error, no spurious log.

**Mutation proof** (documented in the test header): removing the escalation ceiling (retry-forever) turns **(B) red** — `errCh` never receives, the loop never surfaces the persistent fault — verified locally; restoring it goes green.

Gate green locally: `go build ./...`, `go vet ./...`, `go test ./internal/cli/ ./internal/db/ ./internal/config/ -count=1`, and `go test -race ./internal/cli/ ./internal/db/` (cli race 710s, 0 data races).

Credit: **@gaijinjoe** for #555; this PR supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)