### PR TITLE
fix(daemon): make stale-running recovery configurable + close #536 teardown window

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -198,10 +198,15 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	lockTTL := daemonRunningJobStaleAfter
 	jobTimeout := request.JobTimeout
 	if managed.OK {
-		lockTTL = managed.JobTimeout
 		jobTimeout = managed.JobTimeout
-	} else if jobTimeout > 0 {
-		lockTTL = jobTimeout
+	}
+	// Mirror run()/runWithTempWorker(): size the runtime-session lease to
+	// jobTimeout + a teardown grace so a foreground `agent ask` that hits its
+	// timeout releases the lock before the lease expires. Otherwise the lease
+	// (== the run-context deadline) would expire mid-teardown and the stale
+	// reaper could requeue the still-live job — the #536 double-run window.
+	if jobTimeout > 0 {
+		lockTTL = jobTimeout + runtimeLeaseTeardownGrace
 	}
 	releaseLock, acquired, lockKey, ownerToken, err := acquireRuntimeSessionLock(ctx, store, job.ID, runtimeAgent(agent), time.Now().UTC(), lockTTL)
 	if err != nil {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2093,6 +2093,31 @@ func (w jobWorker) eventSink() events.Sink {
 
 const daemonRunningJobStaleAfter = 30 * time.Minute
 const defaultDaemonRunningJobStaleAfter = daemonRunningJobStaleAfter
+
+// daemonRunningJobStaleFloor is the smallest GITMOOT_STALE_RUNNING_AFTER we
+// honor. The stale-running window is a CRASH BACKSTOP, not a job timeout: it is
+// how long a job may sit in 'running' with no lease progress before the daemon
+// assumes the worker died and requeues it. A tiny value (e.g. 1s) turns that
+// backstop into an aggressive killer — especially for NON-resumable runtimes
+// (shell/no runtime-session lock) where runtimeOwnerLeaseHeld is always false,
+// so there is no lease to protect a live worker and the coarse threshold is the
+// ONLY gate. Sub-floor values are rejected in favor of the default (#560).
+const daemonRunningJobStaleFloor = 1 * time.Minute
+
+// runtimeLeaseTeardownGrace is added to a job's timeout when sizing its
+// runtime-session lock lease so the lease strictly OUTLIVES the run-context
+// deadline plus worst-case terminal teardown (runtime subprocess kill + worktree
+// force-clean). run() arms the run context at exactly jobTimeout but holds the
+// lease through that teardown, which happens AFTER the deadline fires. Without
+// this margin the lease would expire in the window [t0+jobTimeout,
+// t0+jobTimeout+teardown] while the worker is STILL ALIVE finishing — and
+// recoverExpiredRuntimeSessionLocks + DeleteExpiredResourceLocks (runtime:%
+// bypasses the not-running guard) would reap that live worker's lock and requeue
+// its still-'running' owner, starting a SECOND worker on the dirty in-flight
+// worktree: the exact #536 clobber. With the grace a NORMALLY-terminating worker
+// always releases its lease before it expires; only a genuinely stuck/crashed
+// worker past jobTimeout+grace is reaped and requeued.
+const runtimeLeaseTeardownGrace = 2 * time.Minute
 const daemonJobCancelPollInterval = 250 * time.Millisecond
 const daemonWorkerLoopInterval = 1 * time.Second
 
@@ -2137,7 +2162,20 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 	return worker
 }
 
-func configuredDaemonRunningJobStaleAfter() time.Duration {
+// staleFloorWarnOnce keeps the sub-floor warning from flooding the log: the
+// recovery path that reads this runs once per worker-loop tick (~1s), so we warn
+// at most once per daemon process.
+var staleFloorWarnOnce sync.Once
+
+// configuredDaemonRunningJobStaleAfter resolves the crash-backstop window from
+// GITMOOT_STALE_RUNNING_AFTER, falling back to the default when unset, malformed,
+// non-positive, OR below daemonRunningJobStaleFloor. This is a CRASH BACKSTOP,
+// not a timeout: it bounds how long a job may sit 'running' with no lease
+// progress before the daemon assumes the worker crashed and requeues it. A
+// sub-floor value (e.g. 1s) would let the backstop requeue live workers — most
+// dangerously for non-resumable runtimes that hold no lease — so it is rejected
+// with a one-time warning rather than honored (#560).
+func configuredDaemonRunningJobStaleAfter(stdout io.Writer) time.Duration {
 	raw := strings.TrimSpace(os.Getenv("GITMOOT_STALE_RUNNING_AFTER"))
 	if raw == "" {
 		return defaultDaemonRunningJobStaleAfter
@@ -2146,12 +2184,18 @@ func configuredDaemonRunningJobStaleAfter() time.Duration {
 	if err != nil || d <= 0 {
 		return defaultDaemonRunningJobStaleAfter
 	}
+	if d < daemonRunningJobStaleFloor {
+		staleFloorWarnOnce.Do(func() {
+			writeLine(stdout, "GITMOOT_STALE_RUNNING_AFTER=%s is below the %s crash-backstop floor; using default %s", raw, daemonRunningJobStaleFloor, defaultDaemonRunningJobStaleAfter)
+		})
+		return defaultDaemonRunningJobStaleAfter
+	}
 	return d
 }
 
 func recoverRunningJobs(ctx context.Context, store *db.Store, stdout io.Writer) error {
 	now := time.Now().UTC()
-	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter()), "", "")
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter(stdout)), "", "")
 }
 
 func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time) error {
@@ -2205,7 +2249,7 @@ func recoverRunningJobsBefore(ctx context.Context, store *db.Store, stdout io.Wr
 
 func recoverRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.Writer, repoFilter string, rootFilter string) error {
 	now := time.Now().UTC()
-	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter()), repoFilter, rootFilter)
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter(stdout)), repoFilter, rootFilter)
 }
 
 func recoverCancelledRunningJobsForEnabledRepos(ctx context.Context, store *db.Store, rootFilter string, stdout io.Writer) error {
@@ -2395,7 +2439,7 @@ func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker,
 	if dryRun {
 		return nil
 	}
-	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter()), repoFilter, rootFilter); err != nil {
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter(stdout)), repoFilter, rootFilter); err != nil {
 		return err
 	}
 	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, now); err != nil {
@@ -3305,9 +3349,16 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		return nil
 	}
 	jobTimeout := effectiveJobTimeout(payload, managed)
+	// Size the runtime-session lease to jobTimeout PLUS a teardown grace so the
+	// lease strictly OUTLIVES the run-context deadline (armed at exactly jobTimeout
+	// below) and the terminal worktree teardown that runs while this lock is still
+	// held. A normally-terminating worker therefore releases its lease before it
+	// expires; without the grace the lease would expire in the live-worker teardown
+	// window and the expired-lock reaper would requeue the still-'running' owner
+	// onto its dirty worktree — the #536 clobber. See runtimeLeaseTeardownGrace.
 	lockTTL := defaultDaemonRunningJobStaleAfter
 	if jobTimeout > 0 {
-		lockTTL = jobTimeout
+		lockTTL = jobTimeout + runtimeLeaseTeardownGrace
 	}
 	releaseLock, acquired, lockKey, ownerToken, err := acquireRuntimeSessionLock(ctx, w.Store, job.ID, agent, time.Now().UTC(), lockTTL)
 	if err != nil {
@@ -3994,7 +4045,14 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		return nil
 	}
 	writeLine(w.Stdout, "running job %s for temporary worker %s in %s", job.ID, started.Agent.Name, payload.Repo)
-	releaseLock, acquired, lockKey, ownerToken, err := acquireRuntimeSessionLock(ctx, w.Store, delegatedJob.ID, started.Agent, time.Now().UTC(), started.JobTimeout)
+	// Same lease-outlives-context invariant as run(): the temp-worker run context is
+	// armed at started.JobTimeout below, so the lease must be jobTimeout+grace to
+	// cover teardown and avoid the #536 live-worker reap+requeue window.
+	tempLockTTL := defaultDaemonRunningJobStaleAfter
+	if started.JobTimeout > 0 {
+		tempLockTTL = started.JobTimeout + runtimeLeaseTeardownGrace
+	}
+	releaseLock, acquired, lockKey, ownerToken, err := acquireRuntimeSessionLock(ctx, w.Store, delegatedJob.ID, started.Agent, time.Now().UTC(), tempLockTTL)
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, delegatedJob.ID, workflow.JobFailed, err); finishErr != nil {
 			return finishErr
@@ -4437,8 +4495,12 @@ func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (mana
 // effectiveJobTimeout returns the timeout to enforce for a job: the
 // per-delegation payload.JobTimeout when it parses to a positive duration,
 // otherwise the agent-type managed.JobTimeout, otherwise the daemon stale window
-// for unmanaged jobs. The same value drives both the runtime-session lock TTL and
-// the run context deadline so a job cannot outlive the lease that guards it.
+// for unmanaged jobs (so an unmanaged job still has a watchdog, #555). This value
+// drives the run context deadline directly; the runtime-session lock TTL is this
+// value PLUS runtimeLeaseTeardownGrace (#536/#560) so the lease strictly outlives
+// the deadline and the terminal teardown — the lock cannot expire while the
+// worker is still finishing, which would otherwise let the reaper requeue a live
+// job onto its dirty worktree.
 func effectiveJobTimeout(payload workflow.JobPayload, managed managedJobRuntimeConfig) time.Duration {
 	if d, err := time.ParseDuration(strings.TrimSpace(payload.JobTimeout)); err == nil && d > 0 {
 		return d

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2203,21 +2203,18 @@ func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, std
 	if err != nil {
 		return err
 	}
-	deleted, err := store.DeleteExpiredResourceLocks(ctx, now)
-	if err != nil {
-		return err
-	}
-	if deleted > 0 {
-		writeLine(stdout, "recovered %d expired runtime session locks", deleted)
-	}
+	// Requeue owners BEFORE reaping the lock rows. An expired runtime lease means
+	// the job's real timeout + teardown grace has elapsed, so a still-'running'
+	// owner is genuinely stale (a normally-terminating worker releases its lock
+	// before the grace-padded lease expires — see runtimeLeaseTeardownGrace).
+	// Ordering requeue-then-delete keeps the two durable: if a mid-loop DB error
+	// aborts the sweep, the un-processed locks are still expired and get retried
+	// next tick, instead of being deleted up front and losing the requeue signal
+	// (which would strand those owners as 'running' until the coarse 30m window).
+	// TransitionJobStateWithEvent is a no-op unless the owner is still 'running'.
 	for _, lock := range expiredRuntimeLocks {
 		if strings.TrimSpace(lock.OwnerJobID) == "" {
 			continue
-		}
-		if _, err := store.GetResourceLock(ctx, lock.ResourceKey); err == nil {
-			continue
-		} else if !errors.Is(err, sql.ErrNoRows) {
-			return err
 		}
 		recovered, err := store.TransitionJobStateWithEvent(ctx, lock.OwnerJobID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
 			JobID:   lock.OwnerJobID,
@@ -2230,6 +2227,13 @@ func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, std
 		if recovered {
 			writeLine(stdout, "requeued running job %s after runtime session lock expired", lock.OwnerJobID)
 		}
+	}
+	deleted, err := store.DeleteExpiredResourceLocks(ctx, now)
+	if err != nil {
+		return err
+	}
+	if deleted > 0 {
+		writeLine(stdout, "recovered %d expired runtime session locks", deleted)
 	}
 	return nil
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2092,6 +2092,7 @@ func (w jobWorker) eventSink() events.Sink {
 }
 
 const daemonRunningJobStaleAfter = 30 * time.Minute
+const defaultDaemonRunningJobStaleAfter = daemonRunningJobStaleAfter
 const daemonJobCancelPollInterval = 250 * time.Millisecond
 const daemonWorkerLoopInterval = 1 * time.Second
 
@@ -2136,18 +2137,55 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 	return worker
 }
 
+func configuredDaemonRunningJobStaleAfter() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("GITMOOT_STALE_RUNNING_AFTER"))
+	if raw == "" {
+		return defaultDaemonRunningJobStaleAfter
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultDaemonRunningJobStaleAfter
+	}
+	return d
+}
+
 func recoverRunningJobs(ctx context.Context, store *db.Store, stdout io.Writer) error {
 	now := time.Now().UTC()
-	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-daemonRunningJobStaleAfter), "", "")
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter()), "", "")
 }
 
 func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time) error {
+	expiredRuntimeLocks, err := store.ListExpiredRuntimeSessionLocks(ctx, now)
+	if err != nil {
+		return err
+	}
 	deleted, err := store.DeleteExpiredResourceLocks(ctx, now)
 	if err != nil {
 		return err
 	}
 	if deleted > 0 {
 		writeLine(stdout, "recovered %d expired runtime session locks", deleted)
+	}
+	for _, lock := range expiredRuntimeLocks {
+		if strings.TrimSpace(lock.OwnerJobID) == "" {
+			continue
+		}
+		if _, err := store.GetResourceLock(ctx, lock.ResourceKey); err == nil {
+			continue
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		recovered, err := store.TransitionJobStateWithEvent(ctx, lock.OwnerJobID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
+			JobID:   lock.OwnerJobID,
+			Kind:    string(workflow.JobQueued),
+			Message: "recovered running job after runtime session lock expired",
+		})
+		if err != nil {
+			return err
+		}
+		if recovered {
+			writeLine(stdout, "requeued running job %s after runtime session lock expired", lock.OwnerJobID)
+		}
 	}
 	return nil
 }
@@ -2167,7 +2205,7 @@ func recoverRunningJobsBefore(ctx context.Context, store *db.Store, stdout io.Wr
 
 func recoverRunningJobsForRepo(ctx context.Context, store *db.Store, stdout io.Writer, repoFilter string, rootFilter string) error {
 	now := time.Now().UTC()
-	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-daemonRunningJobStaleAfter), repoFilter, rootFilter)
+	return recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter()), repoFilter, rootFilter)
 }
 
 func recoverCancelledRunningJobsForEnabledRepos(ctx context.Context, store *db.Store, rootFilter string, stdout io.Writer) error {
@@ -2215,40 +2253,47 @@ func recoverRunningJobsBeforeForRepo(ctx context.Context, store *db.Store, stdou
 		if !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}
-		// Liveness gate (#536): the coarse `updated_at < before` threshold (30m) is a
-		// crash backstop, NOT a timeout. A long-running job (e.g. a 4h delegation)
-		// holds a runtime-session lock whose LEASE reflects its real job timeout. If
-		// that lease has not elapsed the job's timeout has not elapsed, so leave it
-		// running — requeuing it would start a second copy that fails on the dirty
-		// in-flight worktree and then force-cleans it out from under the live worker.
-		//
-		// This keys on the lease, NOT on the lock's owner PID: the recorded PID is the
-		// gitmoot DAEMON's, not the spawned runtime worker's, so on a daemon restart it
-		// is the dead prior daemon even while the reparented worker keeps running — the
-		// exact path this recovery is named for. Honoring the lease is correct across a
-		// restart (the lease survives in the DB) and immune to PID reuse. The trade-off:
-		// a genuinely-crashed worker whose daemon also died is recovered only once its
-		// lease expires (recoverExpiredRuntimeSessionLocks reclaims it, then a later
-		// tick requeues it) rather than at the 30m threshold — promptness traded for
-		// never failing live work, the unattended-reliability goal of #536.
-		leaseHeld, err := runtimeOwnerLeaseHeld(ctx, store, job.ID, now)
-		if err != nil {
+		if err := recoverRunningJobIfLeaseExpired(ctx, store, stdout, now, job); err != nil {
 			return err
 		}
-		if leaseHeld {
-			continue
-		}
-		recovered, err := store.TransitionJobStateWithEvent(ctx, job.ID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
-			JobID:   job.ID,
-			Kind:    string(workflow.JobQueued),
-			Message: "recovered stale running job on daemon startup",
-		})
-		if err != nil {
-			return err
-		}
-		if recovered {
-			writeLine(stdout, "requeued stale running job %s", job.ID)
-		}
+	}
+	return nil
+}
+
+func recoverRunningJobIfLeaseExpired(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time, job db.Job) error {
+	// Liveness gate (#536): the coarse `updated_at < before` threshold (30m) is a
+	// crash backstop, NOT a timeout. A long-running job (e.g. a 4h delegation)
+	// holds a runtime-session lock whose LEASE reflects its real job timeout. If
+	// that lease has not elapsed the job's timeout has not elapsed, so leave it
+	// running — requeuing it would start a second copy that fails on the dirty
+	// in-flight worktree and then force-cleans it out from under the live worker.
+	//
+	// This keys on the lease, NOT on the lock's owner PID: the recorded PID is the
+	// gitmoot DAEMON's, not the spawned runtime worker's, so on a daemon restart it
+	// is the dead prior daemon even while the reparented worker keeps running — the
+	// exact path this recovery is named for. Honoring the lease is correct across a
+	// restart (the lease survives in the DB) and immune to PID reuse. The trade-off:
+	// a genuinely-crashed worker whose daemon also died is recovered only once its
+	// lease expires (recoverExpiredRuntimeSessionLocks reclaims it, then a later
+	// tick requeues it) rather than at the 30m threshold — promptness traded for
+	// never failing live work, the unattended-reliability goal of #536.
+	leaseHeld, err := runtimeOwnerLeaseHeld(ctx, store, job.ID, now)
+	if err != nil {
+		return err
+	}
+	if leaseHeld {
+		return nil
+	}
+	recovered, err := store.TransitionJobStateWithEvent(ctx, job.ID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
+		JobID:   job.ID,
+		Kind:    string(workflow.JobQueued),
+		Message: "recovered stale running job on daemon startup",
+	})
+	if err != nil {
+		return err
+	}
+	if recovered {
+		writeLine(stdout, "requeued stale running job %s", job.ID)
 	}
 	return nil
 }
@@ -2350,7 +2395,7 @@ func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker,
 	if dryRun {
 		return nil
 	}
-	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-daemonRunningJobStaleAfter), repoFilter, rootFilter); err != nil {
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter()), repoFilter, rootFilter); err != nil {
 		return err
 	}
 	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, now); err != nil {
@@ -3260,7 +3305,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		return nil
 	}
 	jobTimeout := effectiveJobTimeout(payload, managed)
-	lockTTL := daemonRunningJobStaleAfter
+	lockTTL := defaultDaemonRunningJobStaleAfter
 	if jobTimeout > 0 {
 		lockTTL = jobTimeout
 	}
@@ -4111,7 +4156,7 @@ func compactMergeBackStrings(values []string) []string {
 
 func (w jobWorker) startTempWorker(ctx context.Context, job db.Job, payload workflow.JobPayload, original runtime.Agent, checkout string) (tempWorkerStartResult, error) {
 	idleTimeout := 20 * time.Minute
-	jobTimeout := daemonRunningJobStaleAfter
+	jobTimeout := defaultDaemonRunningJobStaleAfter
 	if managed, err := w.managedJobConfig(ctx, original.Name); err == nil && managed.OK {
 		idleTimeout = managed.IdleTimeout
 		jobTimeout = managed.JobTimeout
@@ -4261,7 +4306,7 @@ func (w jobWorker) startEphemeralWorker(ctx context.Context, job db.Job, payload
 		State:          "starting",
 		CreatedAt:      formatManagedAgentTime(now),
 		LastUsedAt:     formatManagedAgentTime(now),
-		ExpiresAt:      formatManagedAgentTime(now.Add(daemonRunningJobStaleAfter)),
+		ExpiresAt:      formatManagedAgentTime(now.Add(defaultDaemonRunningJobStaleAfter)),
 	}
 	if err := w.Store.UpsertAgentInstance(ctx, reserved); err != nil {
 		return err

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4918,6 +4918,73 @@ func TestRecoverRunningJobsKeepsRecentRunningJobsOnStartup(t *testing.T) {
 	}
 }
 
+func TestRecoverRunningJobsUsesConfiguredStaleWindow(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("GITMOOT_STALE_RUNNING_AFTER", "2m")
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-running", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if err := store.UpdateJobState(ctx, "job-running", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	worker := defaultJobWorker(store, io.Discard)
+
+	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "owner/repo", "", io.Discard, time.Now().UTC().Add(3*time.Minute)); err != nil {
+		t.Fatalf("runDaemonWorkerTick returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-running")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued", job.State)
+	}
+}
+
+func TestRecoverExpiredRuntimeSessionLocksRequeuesOwnerBeforeGlobalStaleWindow(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-running", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1, JobTimeout: "10m"})
+	if err := store.UpdateJobState(ctx, "job-running", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	now := time.Now().UTC()
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey:   "runtime:codex:session-timeout",
+		OwnerJobID:    "job-running",
+		OwnerToken:    "token-timeout",
+		OwnerPID:      int64(os.Getpid()),
+		OwnerHostname: thisHostname(t),
+		ExpiresAt:     now.Add(10 * time.Minute).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	worker := defaultJobWorker(store, io.Discard)
+
+	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "owner/repo", "", io.Discard, now.Add(3*time.Minute)); err != nil {
+		t.Fatalf("runDaemonWorkerTick before timeout returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-running")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("job state after short wait = %q, want running", job.State)
+	}
+
+	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "owner/repo", "", io.Discard, now.Add(11*time.Minute)); err != nil {
+		t.Fatalf("runDaemonWorkerTick after timeout returned error: %v", err)
+	}
+	job, err = store.GetJob(ctx, "job-running")
+	if err != nil {
+		t.Fatalf("GetJob after timeout returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state after job timeout = %q, want queued", job.State)
+	}
+}
+
 // TestRecoverRunningJobsHonorsLiveRuntimeLease is the #536 regression: a
 // long-running job (e.g. a 4h delegation) holds a runtime-session lock whose LEASE
 // reflects its real job timeout. The coarse `updated_at < before` staleness
@@ -5265,7 +5332,7 @@ func TestDaemonWorkerTickRechecksStaleRunningJobs(t *testing.T) {
 		t.Fatalf("UpdateJobState returned error: %v", err)
 	}
 	worker := defaultJobWorker(store, io.Discard)
-	now := time.Now().UTC().Add(daemonRunningJobStaleAfter + time.Second)
+	now := time.Now().UTC().Add(defaultDaemonRunningJobStaleAfter + time.Second)
 
 	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "", "", io.Discard, now); err != nil {
 		t.Fatalf("runDaemonWorkerTick returned error: %v", err)

--- a/internal/cli/e2e_560_lease_grace_536_safe_test.go
+++ b/internal/cli/e2e_560_lease_grace_536_safe_test.go
@@ -1,0 +1,277 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestE2E560LeaseGraceGuardsTeardownWindow is the load-bearing SAFETY E2E for the
+// #536-safe layer on top of gaijinjoe's #560 (make stale-running recovery
+// configurable + reap expired runtime-session locks). It drives the REAL
+// production chain end to end:
+//
+//   - REAL jobWorker.run() with a codex (resumable) agent, so run() itself sizes
+//     and acquires the runtime-session lease from lockTTL = jobTimeout +
+//     runtimeLeaseTeardownGrace while arming the run context at exactly jobTimeout.
+//   - a fake adapter that BLOCKS inside Deliver, standing in for a live worker that
+//     has passed its run-context deadline and is now in terminal teardown (runtime
+//     kill + worktree force-clean) while STILL holding its lease.
+//   - the REAL recovery chain (runDaemonWorkerTick ->
+//     recoverExpiredRuntimeSessionLocks -> DeleteExpiredResourceLocks) against the
+//     REAL db.Store, fired at a simulated time INSIDE the teardown grace window:
+//     after t0+jobTimeout (context deadline) but before the lease expires.
+//
+// THE #536 GUARD (load-bearing): that recovery tick must NOT reap the live
+// worker's lease and must NOT requeue its still-'running' owner. Reaping+requeuing
+// here would start a SECOND worker on the dirty in-flight worktree — the exact
+// #536 clobber. This flips RED under the grace=0 mutation (see the package const
+// runtimeLeaseTeardownGrace): with no grace the lease expires at t0+jobTimeout,
+// strictly before teardown completes, so the reaper deletes it and requeues the
+// owner inside the window.
+//
+// Credit: builds on gaijinjoe's #560.
+func TestE2E560LeaseGraceGuardsTeardownWindow(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	// codex is a resumable runtime, so run() acquires a runtime:codex:<ref> session
+	// lease we can inspect mid-flight — the lease whose expiry drives #560 recovery.
+	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-a", []string{"ask"}, "owner/repo")
+
+	const jobTimeout = 10 * time.Minute
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 1, JobTimeout: jobTimeout.String(),
+	})
+	jobSnapshot, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+
+	// onDeliver blocks the run inside Deliver (lease held, job 'running') until the
+	// test releases it — this is the live-worker-in-teardown window.
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"ask ran","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+		onDeliver: func() {
+			close(entered)
+			<-release
+		},
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+
+	t0 := time.Now().UTC()
+	runErr := make(chan error, 1)
+	go func() { runErr <- worker.run(ctx, jobSnapshot) }()
+
+	select {
+	case <-entered:
+	case <-time.After(30 * time.Second):
+		t.Fatal("adapter Deliver was never entered; run() did not acquire the runtime lease")
+	}
+	// Guarantee the blocked run is unblocked and joined exactly once even if a later
+	// assertion t.Fatalf's (which runs the defer), so the goroutine cannot leak and
+	// we never double-close/double-drain.
+	released := false
+	joined := false
+	defer func() {
+		if !released {
+			released = true
+			close(release)
+		}
+		if !joined {
+			joined = true
+			<-runErr
+		}
+	}()
+
+	const lockKey = "runtime:codex:session-a"
+	lock, err := store.GetResourceLock(ctx, lockKey)
+	if err != nil {
+		t.Fatalf("runtime lease not held while run() is mid-Deliver: %v", err)
+	}
+	leaseExp, perr := time.Parse(time.RFC3339Nano, lock.ExpiresAt)
+	if perr != nil {
+		t.Fatalf("parse lease expiry %q: %v", lock.ExpiresAt, perr)
+	}
+
+	// LOAD-BEARING #536 GUARD (asserted FIRST so the mutation demonstrates the actual
+	// requeue): a recovery tick DURING teardown — 30s past the run-context deadline
+	// (t0+jobTimeout), i.e. a live worker still force-cleaning its worktree. With the
+	// real grace this is well inside the lease (t0+jobTimeout+2m) so the worker is
+	// left strictly alone. Under the grace=0 mutation the lease already expired at
+	// t0+jobTimeout, so this same tick reaps the live lease and requeues the
+	// still-'running' owner — the two assertions below FLIP RED, demonstrating the
+	// reopened #536 clobber window (a SECOND worker on the dirty in-flight worktree).
+	teardownNow := t0.Add(jobTimeout + 30*time.Second)
+	recovery := defaultJobWorker(store, io.Discard)
+	if err := runDaemonWorkerTick(ctx, store, recovery, 0, false, "owner/repo", "", io.Discard, teardownNow); err != nil {
+		t.Fatalf("recovery tick during teardown grace returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob after teardown tick returned error: %v", err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("job state during teardown grace = %q, want running; the live worker was requeued — the #536 clobber window reopened", job.State)
+	}
+	if _, err := store.GetResourceLock(ctx, lockKey); err != nil {
+		t.Fatalf("live worker's runtime lease was reaped during the teardown grace window: %v", err)
+	}
+
+	// SECONDARY INVARIANT (also mutation-proven): the lease must strictly OUTLIVE the
+	// run-context deadline (t0+jobTimeout) by a real teardown margin. The threshold
+	// is a FIXED 30s (NOT jobTimeout+runtimeLeaseTeardownGrace — that would move with
+	// the mutation and never catch it): the lease must exceed jobTimeout by clearly
+	// more than the teardown probe above. gotTTL uses t0 as the base (run() acquires
+	// a few ms after t0, so gotTTL slightly UNDERstates the real TTL). Under the
+	// grace=0 mutation gotTTL collapses to ~jobTimeout (< jobTimeout+30s).
+	gotTTL := leaseExp.Sub(t0)
+	if gotTTL < jobTimeout+30*time.Second {
+		t.Fatalf("runtime lease TTL = %s, want clearly > jobTimeout (%s); the lease does not outlive the teardown window (#536)", gotTTL, jobTimeout)
+	}
+
+	// Let the worker finish its (real) run cleanly and assert no error.
+	released = true
+	close(release)
+	joined = true
+	if err := <-runErr; err != nil {
+		t.Fatalf("run() returned error: %v", err)
+	}
+	final, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob after run returned error: %v", err)
+	}
+	if final.State != string(workflow.JobSucceeded) {
+		t.Fatalf("final job state = %q, want succeeded", final.State)
+	}
+}
+
+// TestE2E560ExpiredLeaseRequeuesStuckWorker proves crash recovery still works
+// after the grace is added: a genuinely stuck/crashed worker whose runtime lease
+// (sized jobTimeout+grace, as run() sizes it) has FULLY elapsed is promptly
+// requeued (running -> queued) and its expired lease reaped — well before the
+// coarse 30m stale window. This is the #560 recovery path; without it a crashed
+// worker's owner would strand in 'running' until the coarse backstop.
+func TestE2E560ExpiredLeaseRequeuesStuckWorker(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-stuck", Agent: "audit", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 1, JobTimeout: "10m",
+	})
+	if err := store.UpdateJobState(ctx, "job-stuck", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	now := time.Now().UTC()
+	// The lease was sized exactly as run() sizes it (jobTimeout+grace) but the worker
+	// crashed and the whole lease has since elapsed — it expired a minute ago.
+	leaseTTL := 10*time.Minute + runtimeLeaseTeardownGrace
+	acquiredAt := now.Add(-(leaseTTL + time.Minute))
+	const lockKey = "runtime:codex:session-stuck"
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey:   lockKey,
+		OwnerJobID:    "job-stuck",
+		OwnerToken:    "token-stuck",
+		OwnerPID:      deadPID(t),
+		OwnerHostname: thisHostname(t),
+		ExpiresAt:     acquiredAt.Add(leaseTTL).Format(time.RFC3339Nano),
+	}, acquiredAt)
+	if err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+
+	// A recovery tick "now" — far short of the 30m coarse window (the job went
+	// running ~now) — must still recover the crashed worker via the expired-lease
+	// reaper.
+	recovery := defaultJobWorker(store, io.Discard)
+	if err := runDaemonWorkerTick(ctx, store, recovery, 0, false, "owner/repo", "", io.Discard, now); err != nil {
+		t.Fatalf("recovery tick returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-stuck")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued; a crashed worker with a fully-expired lease must be requeued", job.State)
+	}
+	if _, err := store.GetResourceLock(ctx, lockKey); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetResourceLock after expired-lease reap = %v, want sql.ErrNoRows", err)
+	}
+}
+
+// TestE2E560SubFloorStaleWindowRejected pins the env floor (#560 finding 3):
+// GITMOOT_STALE_RUNNING_AFTER is a CRASH BACKSTOP, not a timeout, so a sub-floor
+// value must be rejected in favor of the default window rather than turned into an
+// aggressive killer. The danger is sharpest for NON-resumable runtimes (shell)
+// that hold no lease — there the coarse window is the ONLY gate, so a 1s window
+// would requeue a healthy worker on its next tick.
+func TestE2E560SubFloorStaleWindowRejected(t *testing.T) {
+	t.Setenv("GITMOOT_STALE_RUNNING_AFTER", "1s") // below the 1m floor
+
+	seed := func(t *testing.T) (*db.Store, jobWorker, time.Time) {
+		store := daemonWorkerStore(t)
+		seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+		// shell runtime => no runtime-session lease => the coarse window is the sole gate.
+		seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+			ID: "job-x", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+		})
+		if err := store.UpdateJobState(context.Background(), "job-x", string(workflow.JobRunning)); err != nil {
+			t.Fatalf("UpdateJobState returned error: %v", err)
+		}
+		return store, defaultJobWorker(store, io.Discard), time.Now().UTC()
+	}
+
+	// A 5m-old running job: OLDER than the sub-floor 1s (which would requeue it) but
+	// well YOUNGER than the enforced 30m default (which leaves it running). Staying
+	// 'running' proves the 1s was rejected.
+	t.Run("sub_floor_rejected_uses_default_window", func(t *testing.T) {
+		ctx := context.Background()
+		store, worker, now := seed(t)
+		if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "owner/repo", "", io.Discard, now.Add(5*time.Minute)); err != nil {
+			t.Fatalf("recovery tick returned error: %v", err)
+		}
+		job, err := store.GetJob(ctx, "job-x")
+		if err != nil {
+			t.Fatalf("GetJob returned error: %v", err)
+		}
+		if job.State != string(workflow.JobRunning) {
+			t.Fatalf("job state at +5m = %q, want running; the sub-floor 1s window was honored (should fall back to the 30m default)", job.State)
+		}
+	})
+
+	// Positive control: past the enforced 30m default the SAME job IS recovered, so
+	// the floor falls back to a real finite window, not an infinite one.
+	t.Run("default_window_still_recovers_when_truly_stale", func(t *testing.T) {
+		ctx := context.Background()
+		store, worker, now := seed(t)
+		if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "owner/repo", "", io.Discard, now.Add(31*time.Minute)); err != nil {
+			t.Fatalf("recovery tick returned error: %v", err)
+		}
+		job, err := store.GetJob(ctx, "job-x")
+		if err != nil {
+			t.Fatalf("GetJob returned error: %v", err)
+		}
+		if job.State != string(workflow.JobQueued) {
+			t.Fatalf("job state at +31m = %q, want queued; the enforced default 30m window must still recover a truly-stale job", job.State)
+		}
+	})
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4690,7 +4690,7 @@ func (s *Store) GetHeartbeatState(ctx context.Context, agent, name string) (Hear
 
 // UpsertHeartbeatState writes (or replaces) a heartbeat's full state. Times are
 // stored as RFC3339Nano UTC text (a zero time becomes empty text, mirroring the
-// table's DEFAULT '').
+// table's DEFAULT ”).
 func (s *Store) UpsertHeartbeatState(ctx context.Context, state HeartbeatState) error {
 	state.Agent = strings.TrimSpace(state.Agent)
 	state.Name = strings.TrimSpace(state.Name)
@@ -4974,6 +4974,26 @@ func (s *Store) ListResourceLocks(ctx context.Context) ([]ResourceLock, error) {
 	return locks, rows.Err()
 }
 
+func (s *Store) ListExpiredRuntimeSessionLocks(ctx context.Context, now time.Time) ([]ResourceLock, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT resource_key, owner_job_id, owner_token, owner_pid, owner_hostname, command_hash, acquired_at, updated_at, expires_at
+		FROM resource_locks
+		WHERE resource_key LIKE ? AND expires_at <= ?
+		ORDER BY resource_key`, RuntimeSessionLockKeyPrefix+"%", formatResourceLockTime(now))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var locks []ResourceLock
+	for rows.Next() {
+		var lock ResourceLock
+		if err := rows.Scan(&lock.ResourceKey, &lock.OwnerJobID, &lock.OwnerToken, &lock.OwnerPID, &lock.OwnerHostname, &lock.CommandHash, &lock.AcquiredAt, &lock.UpdatedAt, &lock.ExpiresAt); err != nil {
+			return nil, err
+		}
+		locks = append(locks, lock)
+	}
+	return locks, rows.Err()
+}
+
 func (s *Store) HeartbeatResourceLock(ctx context.Context, resourceKey string, ownerJobID string, ownerToken string, now time.Time, expiresAt time.Time) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `UPDATE resource_locks
 		SET updated_at = ?, expires_at = ?
@@ -5041,8 +5061,7 @@ func (s *Store) DeleteResourceLocksByOwnerIfNotRunning(ctx context.Context, owne
 	return result.RowsAffected()
 }
 
-// DeleteExpiredResourceLocks reaps lock rows whose lease has elapsed, guarding
-// against deleting a lock out from under an owner job that is still 'running'.
+// DeleteExpiredResourceLocks reaps lock rows whose lease has elapsed.
 //
 // The owner_pid<=0 clause keeps the historical conservatism for NON-runtime locks
 // (e.g. skillopt-train-generation): a lock that records a live-process owner PID is
@@ -5052,16 +5071,17 @@ func (s *Store) DeleteResourceLocksByOwnerIfNotRunning(ctx context.Context, owne
 // a daemon restart and must NOT keep an expired lease alive forever. Without this
 // exception an expired runtime-session lock (which always sets owner_pid>0) would
 // NEVER be reaped here — stranding the job's recovery and worktree cleanup (#536
-// finding 2). The not-running guard still protects an actively-running owner.
+// finding 2). Once a runtime lease expires, the daemon may requeue the running
+// owner job from the same recovery tick.
 func (s *Store) DeleteExpiredResourceLocks(ctx context.Context, now time.Time) (int64, error) {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks
 		WHERE expires_at <= ?
 			AND (owner_pid <= 0 OR resource_key LIKE 'runtime:%')
-			AND NOT EXISTS (
+			AND (resource_key LIKE 'runtime:%' OR NOT EXISTS (
 				SELECT 1 FROM jobs
 				WHERE jobs.id = resource_locks.owner_job_id
 					AND jobs.state = 'running'
-			)`, formatResourceLockTime(now))
+			))`, formatResourceLockTime(now))
 	if err != nil {
 		return 0, err
 	}
@@ -6588,5 +6608,11 @@ CREATE TABLE heartbeat_state (
 	last_status TEXT NOT NULL DEFAULT '',
 	PRIMARY KEY (agent, name)
 );
+	`,
+	// Running-job stale recovery queries `state = running AND updated_at < ?` on
+	// every daemon worker tick. Index only running rows so long-lived databases do
+	// not scan terminal jobs once per second.
+	`
+CREATE INDEX idx_jobs_running_updated_at ON jobs(updated_at) WHERE state = 'running';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -61,6 +61,13 @@ func TestOpenMigratesSchema(t *testing.T) {
 	if err := store.Migrate(ctx); err != nil {
 		t.Fatalf("second Migrate returned error: %v", err)
 	}
+	var indexSQL string
+	if err := store.db.QueryRowContext(ctx, `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_jobs_running_updated_at'`).Scan(&indexSQL); err != nil {
+		t.Fatalf("running-job partial index missing: %v", err)
+	}
+	if !strings.Contains(indexSQL, "WHERE state = 'running'") {
+		t.Fatalf("running-job index sql = %q, want partial running-only index", indexSQL)
+	}
 }
 
 func TestOpenConfiguresSQLiteContentionPragmas(t *testing.T) {
@@ -1594,7 +1601,36 @@ func TestDeleteExpiredResourceLocksReapsPIDBackedRuntimeLock(t *testing.T) {
 	}
 }
 
-func TestResourceLockDoesNotRecoverExpiredRunningOwner(t *testing.T) {
+func TestListExpiredRuntimeSessionLocks(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	for _, lock := range []ResourceLock{
+		{ResourceKey: "runtime:codex:expired", OwnerJobID: "job-expired", OwnerToken: "token-expired", ExpiresAt: now.Add(-time.Minute).Format(time.RFC3339Nano)},
+		{ResourceKey: "runtime:codex:future", OwnerJobID: "job-future", OwnerToken: "token-future", ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano)},
+		{ResourceKey: "checkout:owner/repo", OwnerJobID: "job-checkout", OwnerToken: "token-checkout", ExpiresAt: now.Add(-time.Minute).Format(time.RFC3339Nano)},
+	} {
+		acquired, err := store.AcquireResourceLock(ctx, lock, now.Add(-2*time.Minute))
+		if err != nil || !acquired {
+			t.Fatalf("AcquireResourceLock(%s) acquired=%v err=%v", lock.ResourceKey, acquired, err)
+		}
+	}
+
+	locks, err := store.ListExpiredRuntimeSessionLocks(ctx, now)
+	if err != nil {
+		t.Fatalf("ListExpiredRuntimeSessionLocks returned error: %v", err)
+	}
+	if len(locks) != 1 || locks[0].ResourceKey != "runtime:codex:expired" || locks[0].OwnerJobID != "job-expired" {
+		t.Fatalf("expired runtime locks = %+v, want only runtime:codex:expired", locks)
+	}
+}
+
+func TestExpiredRuntimeLockReaperCanRecoverRunningOwner(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
 	if err != nil {
@@ -1630,18 +1666,11 @@ func TestResourceLockDoesNotRecoverExpiredRunningOwner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteExpiredResourceLocks returned error: %v", err)
 	}
-	if deleted != 0 {
-		t.Fatalf("expired running-owner locks deleted = %d, want 0", deleted)
-	}
-	if err := store.UpdateJobState(ctx, "job-a", "queued"); err != nil {
-		t.Fatalf("UpdateJobState returned error: %v", err)
-	}
-	deleted, err = store.DeleteExpiredResourceLocks(ctx, now.Add(2*time.Minute))
-	if err != nil {
-		t.Fatalf("DeleteExpiredResourceLocks after requeue returned error: %v", err)
-	}
 	if deleted != 1 {
-		t.Fatalf("expired non-running-owner locks deleted = %d, want 1", deleted)
+		t.Fatalf("expired runtime lock with running owner deleted = %d, want 1", deleted)
+	}
+	if _, err := store.GetResourceLock(ctx, "runtime:codex:session-a"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetResourceLock after expired runtime reap = %v, want sql.ErrNoRows", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Builds directly on **gaijinjoe's #560** (make stale-running recovery
configurable + reap expired runtime-session locks) — his commit is preserved
verbatim (cherry-picked, unchanged authorship) as the first commit — and adds a
thin layer that makes his prompt lease-expiry recovery **#536-safe**. **This PR
supersedes #560.**

Credit: bounded `ListRunningJobsUpdatedBefore` recovery, the
`idx_jobs_running_updated_at` partial index, `GITMOOT_STALE_RUNNING_AFTER`,
`recoverExpiredRuntimeSessionLocks` requeue, and the `DeleteExpiredResourceLocks`
runtime-lock reaping are all gaijinjoe's work.

## The #536 teardown window (HIGH regression this closes)

`jobWorker.run()` acquired the runtime-session lock with `lockTTL == jobTimeout`,
but armed the run context at `jobTimeout` **after** it, and holds the lease
through terminal worktree teardown (runtime subprocess kill + `git worktree
remove --force`), releasing it only after `run` returns. So the lease expired
**strictly before** the context fired, opening a window
`[t0+jobTimeout, t0+jobTimeout+teardown]` where the lease is expired while the
worker is **still alive** finishing/cleaning.

In that window #560's new `recoverExpiredRuntimeSessionLocks` +
`DeleteExpiredResourceLocks` (where `runtime:%` now bypasses the not-running
guard) would reap the **live** worker's lock and requeue the still-`running`
owner → a **second** worker on the dirty in-flight worktree: the exact #536
clobber `recoverRunningJobIfLeaseExpired`'s own comment warns about.

## Fix

1. **`runtimeLeaseTeardownGrace = 2m`** — the runtime-session lease is now sized
   `jobTimeout + grace` so it strictly **outlives** the run-context deadline plus
   worst-case teardown. A normally-terminating worker releases its lease *before*
   it expires; only a genuinely stuck/crashed worker past `jobTimeout+grace` is
   reaped and requeued. Applied in **both** lease-acquiring paths: `run()` and
   `runWithTempWorker()`. (Audited: these are the only two `runtime:`-prefixed
   session-lock acquisitions; `agent-type:` / `checkout:` / `skillopt-*` locks
   keep the not-running guard and are exempt from the reap bypass.)

2. **Env floor** — `GITMOOT_STALE_RUNNING_AFTER` is a crash **backstop**, not a
   timeout. `configuredDaemonRunningJobStaleAfter()` now clamps sub-floor values
   (`< 1m`) to the default with a one-time warning, so a tiny value (e.g. `1s`)
   can't turn the backstop into an aggressive killer — most dangerous for
   **non-resumable** runtimes that hold no lease (the coarse threshold is their
   only gate).

## Tests

New full-chain E2Es in `internal/cli/e2e_560_lease_grace_536_safe_test.go`,
driving the **real** `db.Store` + the real recovery functions:

- **`TestE2E560LeaseGraceGuardsTeardownWindow`** (load-bearing safety): drives
  the **real `run()`** with a fake adapter blocked mid-`Deliver` holding its
  lease, then fires the **real recovery tick** at a simulated time inside the
  teardown grace (past the context deadline, before lease expiry). Asserts the
  live worker is **not** reaped and **not** requeued. **Mutation-proven**: set the
  grace to `0` and the safety assertion flips to a requeue (`queued, want
  running`) → RED. The lease-outlives-context TTL invariant is also
  mutation-proven (fixed 30s margin, so it doesn't move with the mutated const).
- **`TestE2E560ExpiredLeaseRequeuesStuckWorker`**: a crashed worker whose
  `jobTimeout+grace` lease has fully elapsed **is** promptly requeued + reaped
  (crash recovery still works).
- **`TestE2E560SubFloorStaleWindowRejected`**: a sub-floor `1s` is rejected and
  the default window is used (a truly-stale job is still recovered at the default).

gaijinjoe's db-level and daemon tests from #560 are preserved.

## Gate

`go build ./...`, `go vet ./...`, `go test ./internal/cli/ ./internal/db/
./internal/config/ -count=1`, and `go test -race ./internal/cli/ ./internal/db/`
all pass locally (cli `-race` clean, 0 data races).

🤖 Generated with [Claude Code](https://claude.com/claude-code)