### PR TITLE
feat(cli): surface why queued/blocked jobs are stuck + proactive auth validation (#552)

### DIFF
--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -47,8 +47,8 @@ func runJob(args []string, stdout, stderr io.Writer) int {
 
 func printJobUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot job list [--repo owner/repo] [--state state]")
-	fmt.Fprintln(w, "  gitmoot job show <id>")
+	fmt.Fprintln(w, "  gitmoot job list [--repo owner/repo] [--state state] [--json]")
+	fmt.Fprintln(w, "  gitmoot job show <id> [--json]")
 	fmt.Fprintln(w, "  gitmoot job events <id>")
 	fmt.Fprintln(w, "  gitmoot job watch <id> [--poll 1s] [--json]")
 	fmt.Fprintln(w, "  gitmoot job run <id>")
@@ -63,6 +63,7 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	repo := fs.String("repo", "", "repo scope as owner/repo")
 	state := fs.String("state", "", "job state filter")
+	jsonOutput := fs.Bool("json", false, "print jobs (with why-stuck detail) as JSON")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -80,6 +81,12 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 	// not reveal it; this surfaces the reason as a trailing column so a zero-child
 	// fan-out is not invisible. Best-effort: a lookup error leaves the column off.
 	var preflightFailed map[string]string
+	// reasonEvents / locks feed the why-stuck surface (#552): the latest
+	// reason-bearing event per job and the live resource locks, both fetched in a
+	// single query so the derived reason costs no per-job lookup. Best-effort: a
+	// lookup error leaves the reason off rather than failing the listing.
+	var reasonEvents map[string]db.JobEvent
+	var locks []db.ResourceLock
 	if err := withStore(*home, func(store *db.Store) error {
 		var err error
 		jobs, err = store.ListJobs(context.Background())
@@ -87,37 +94,156 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 			return err
 		}
 		preflightFailed, _ = store.JobIDsWithEventKind(context.Background(), "delegation_preflight_failed")
+		reasonEvents, _ = store.LatestJobEventsOfKinds(context.Background(), stuckReasonEventKinds)
+		locks, _ = store.ListResourceLocks(context.Background())
 		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "job list: %v\n", err)
 		return 1
 	}
-	for _, job := range filterJobs(jobs, *repo, *state) {
+	filtered := filterJobs(jobs, *repo, *state)
+	if *jsonOutput {
+		entries := make([]jobListEntry, 0, len(filtered))
+		for _, job := range filtered {
+			payload, _ := daemonJobPayload(job)
+			ev, ok := reasonEvents[job.ID]
+			reason := deriveStuckReason(job, ev, ok, locks)
+			entries = append(entries, jobListEntry{
+				ID:              job.ID,
+				State:           job.State,
+				Type:            job.Type,
+				Agent:           job.Agent,
+				Repo:            payload.Repo,
+				PullRequest:     payload.PullRequest,
+				PreflightFailed: strings.TrimSpace(preflightFailed[job.ID]),
+				WhyStuck:        reason.Reason,
+				NextRetryAt:     reason.NextRetryAt,
+			})
+		}
+		if err := writeJSON(stdout, entries); err != nil {
+			fmt.Fprintf(stderr, "job list: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	for _, job := range filtered {
 		payload, _ := daemonJobPayload(job)
 		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t#%d", job.ID, job.State, job.Type, job.Agent, payload.Repo, payload.PullRequest)
 		if reason, ok := preflightFailed[job.ID]; ok && strings.TrimSpace(reason) != "" {
 			fmt.Fprintf(stdout, "\tPREFLIGHT_FAILED: %s", reason)
+		}
+		ev, ok := reasonEvents[job.ID]
+		if reason := deriveStuckReason(job, ev, ok, locks); !reason.empty() {
+			fmt.Fprintf(stdout, "\tWHY: %s", reason.Reason)
+			if reason.NextRetryAt != "" {
+				fmt.Fprintf(stdout, " (next retry %s)", reason.NextRetryAt)
+			}
 		}
 		fmt.Fprintln(stdout)
 	}
 	return 0
 }
 
+// jobListEntry is the JSON shape for `job list --json`: the existing table
+// columns plus the additive why-stuck fields (#552). The stuck fields are omitted
+// when empty so a healthy job's JSON is not bloated.
+type jobListEntry struct {
+	ID              string `json:"id"`
+	State           string `json:"state"`
+	Type            string `json:"type"`
+	Agent           string `json:"agent"`
+	Repo            string `json:"repo"`
+	PullRequest     int    `json:"pull_request"`
+	PreflightFailed string `json:"preflight_failed,omitempty"`
+	WhyStuck        string `json:"why_stuck,omitempty"`
+	NextRetryAt     string `json:"next_retry_at,omitempty"`
+}
+
 func runJobShow(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("job show", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "print the job (with why-stuck detail) as JSON")
 	jobID, ok := parseSingleJobID(fs, args, stderr, "job show")
 	if !ok {
 		return parseSingleJobIDExitCode(args)
 	}
-	job, payload, err := loadJobWithPayload(*home, jobID)
-	if err != nil {
+	var job db.Job
+	var payload workflow.JobPayload
+	var reason stuckReason
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		job, err = store.GetJob(context.Background(), jobID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("job %q not found", jobID)
+			}
+			return err
+		}
+		payload, err = daemonJobPayload(job)
+		if err != nil {
+			return err
+		}
+		reason = loadStuckReason(store, job)
+		return nil
+	}); err != nil {
 		fmt.Fprintf(stderr, "job show: %v\n", err)
 		return 1
 	}
-	printJob(stdout, job, payload)
+	if *jsonOutput {
+		out := jobShowOutput{Job: job, Payload: payload, WhyStuck: reason.Reason, NextRetryAt: reason.NextRetryAt}
+		if err := writeJSON(stdout, out); err != nil {
+			fmt.Fprintf(stderr, "job show: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printJob(stdout, job, payload, reason)
 	return 0
+}
+
+// jobShowOutput is the JSON shape for `job show --json`: the job, its decoded
+// payload, and the additive why-stuck detail (#552). The stuck fields are omitted
+// when empty so a healthy job's JSON is unchanged in spirit.
+type jobShowOutput struct {
+	Job         db.Job              `json:"job"`
+	Payload     workflow.JobPayload `json:"payload"`
+	WhyStuck    string              `json:"why_stuck,omitempty"`
+	NextRetryAt string              `json:"next_retry_at,omitempty"`
+}
+
+// loadStuckReason derives a queued/blocked job's why-stuck reason from its full
+// event history (scanning for the LATEST reason-bearing event, which is more
+// authoritative than the overall-latest event) and the live resource locks. It is
+// best-effort: a lookup error yields the zero reason rather than failing `job
+// show`. Non-queued/blocked jobs short-circuit without any query.
+func loadStuckReason(store *db.Store, job db.Job) stuckReason {
+	state := strings.TrimSpace(job.State)
+	if state != string(workflow.JobQueued) && state != string(workflow.JobBlocked) {
+		return stuckReason{}
+	}
+	events, err := store.ListJobEvents(context.Background(), job.ID)
+	if err != nil {
+		return stuckReason{}
+	}
+	ev, ok := latestReasonEvent(events)
+	locks, _ := store.ListResourceLocks(context.Background())
+	return deriveStuckReason(job, ev, ok, locks)
+}
+
+// latestReasonEvent returns the last event whose kind is a stuck-reason kind.
+func latestReasonEvent(events []db.JobEvent) (db.JobEvent, bool) {
+	var found db.JobEvent
+	var ok bool
+	for _, event := range events {
+		for _, kind := range stuckReasonEventKinds {
+			if event.Kind == kind {
+				found, ok = event, true
+				break
+			}
+		}
+	}
+	return found, ok
 }
 
 func runJobEvents(args []string, stdout, stderr io.Writer) int {
@@ -365,27 +491,15 @@ func filterJobs(jobs []db.Job, repoFilter string, stateFilter string) []db.Job {
 	return filtered
 }
 
-func loadJobWithPayload(home string, jobID string) (db.Job, workflow.JobPayload, error) {
-	var job db.Job
-	var payload workflow.JobPayload
-	err := withStore(home, func(store *db.Store) error {
-		var err error
-		job, err = store.GetJob(context.Background(), jobID)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("job %q not found", jobID)
-			}
-			return err
-		}
-		payload, err = daemonJobPayload(job)
-		return err
-	})
-	return job, payload, err
-}
-
-func printJob(stdout io.Writer, job db.Job, payload workflow.JobPayload) {
+func printJob(stdout io.Writer, job db.Job, payload workflow.JobPayload, reason stuckReason) {
 	fmt.Fprintf(stdout, "id: %s\n", job.ID)
 	fmt.Fprintf(stdout, "state: %s\n", job.State)
+	if !reason.empty() {
+		fmt.Fprintf(stdout, "why_stuck: %s\n", reason.Reason)
+		if reason.NextRetryAt != "" {
+			fmt.Fprintf(stdout, "next_retry_at: %s\n", reason.NextRetryAt)
+		}
+	}
 	fmt.Fprintf(stdout, "type: %s\n", job.Type)
 	fmt.Fprintf(stdout, "agent: %s\n", job.Agent)
 	fmt.Fprintf(stdout, "repo: %s\n", payload.Repo)

--- a/internal/cli/job_stuck.go
+++ b/internal/cli/job_stuck.go
@@ -2,11 +2,17 @@ package cli
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
+
+// authWordRe matches "auth" only as a whole word, so an authoritative auth
+// signal ("auth token invalid") is caught while an unrelated substring such as
+// "author" in "invalid author email" is not.
+var authWordRe = regexp.MustCompile(`\bauth\b`)
 
 // stuckReasonEventKinds are the job_event kinds that carry an authoritative
 // reason a queued or blocked job is not progressing (issue #552). Surfacing why a
@@ -112,14 +118,17 @@ func deriveStuckReason(job db.Job, reasonEvent db.JobEvent, hasReasonEvent bool,
 // the caller keeps its generic label.
 func classifyAuthQuota(msg string) string {
 	l := strings.ToLower(msg)
+	// A bare 401/429 digit run is ambiguous (a PR number, a token count), so only
+	// treat it as an HTTP status when the message actually frames it as one.
+	httpCtx := strings.Contains(l, "status") || strings.Contains(l, "http")
 	switch {
 	case strings.Contains(l, "usage limit"), strings.Contains(l, "rate limit"),
-		strings.Contains(l, "quota"), strings.Contains(l, "429"),
-		strings.Contains(l, "resets"):
+		strings.Contains(l, "quota"), strings.Contains(l, "limit resets"),
+		httpCtx && strings.Contains(l, "429"):
 		return "throttled"
 	case strings.Contains(l, "authentication"), strings.Contains(l, "unauthorized"),
-		strings.Contains(l, "401"),
-		strings.Contains(l, "auth") && strings.Contains(l, "invalid"):
+		httpCtx && strings.Contains(l, "401"),
+		authWordRe.MatchString(l) && strings.Contains(l, "invalid"):
 		return "auth failing"
 	}
 	return ""

--- a/internal/cli/job_stuck.go
+++ b/internal/cli/job_stuck.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// stuckReasonEventKinds are the job_event kinds that carry an authoritative
+// reason a queued or blocked job is not progressing (issue #552). Surfacing why a
+// stuck job waits keys on the LATEST event of one of these kinds; benign
+// lifecycle events (queued, route_selected, delegation_continuation_enqueued) are
+// deliberately excluded so a healthy queued job stays silent and its `job list`
+// row keeps its existing shape.
+var stuckReasonEventKinds = []string{
+	"runtime_lock_wait",
+	"advance_blocked",
+	"advance_awaiting_human",
+	"permission_blocked",
+	"deterministic_checkers_failed",
+	"advance_retry",
+	"retry_queued",
+	"repair_retry",
+	"session_refresh_retry",
+	"delegation_retry",
+	"delegation_escalation_retry",
+	"delegation_loop_detected",
+	"delegation_width_exceeded",
+	"delegation_depth_exceeded",
+	"delegation_walltime_exceeded",
+	"delegation_cost_exceeded",
+	"delegation_cost_usd_exceeded",
+	"delegation_preflight_failed",
+}
+
+// stuckReason is a concise, human-readable explanation of why a queued/blocked
+// job is not progressing, derived from existing signals. The zero value means
+// "not stuck / no derivable reason" — callers must render nothing so healthy
+// output is byte-stable.
+type stuckReason struct {
+	Reason      string // e.g. "waiting on runtime session lock ...", "blocked: awaiting human", "auth failing: ..."
+	NextRetryAt string // an RFC3339 lease expiry when one applies (a runtime-session lock), else ""
+}
+
+func (r stuckReason) empty() bool { return strings.TrimSpace(r.Reason) == "" }
+
+// deriveStuckReason returns why a queued/blocked job is not progressing, from the
+// most authoritative existing signal: the latest reason-bearing job_event and,
+// for a runtime-session lock wait, the owning lock's lease. It is a pure function
+// over already-queried state so it is trivially testable. Healthy (non-queued/
+// blocked) jobs and jobs with no derivable signal return the zero value.
+func deriveStuckReason(job db.Job, reasonEvent db.JobEvent, hasReasonEvent bool, locks []db.ResourceLock) stuckReason {
+	state := strings.TrimSpace(job.State)
+	queued := state == string(workflow.JobQueued)
+	blocked := state == string(workflow.JobBlocked)
+	if !queued && !blocked {
+		return stuckReason{}
+	}
+	if !hasReasonEvent {
+		// A blocked job with no reason-bearing event is still stuck by definition;
+		// surface the bare state so it is never silently unexplained. A plain queued
+		// job with only lifecycle events is not yet "stuck" — leave it silent.
+		if blocked {
+			return stuckReason{Reason: "blocked"}
+		}
+		return stuckReason{}
+	}
+	msg := firstLineTrimmed(reasonEvent.Message)
+	switch reasonEvent.Kind {
+	case "runtime_lock_wait":
+		reason := "waiting on runtime session lock"
+		next := ""
+		if key := extractRuntimeLockKey(reasonEvent.Message); key != "" {
+			reason += " " + key
+			if lock, ok := findResourceLock(locks, key); ok {
+				if owner := strings.TrimSpace(lock.OwnerJobID); owner != "" && owner != job.ID {
+					reason += fmt.Sprintf(" (held by job %s)", owner)
+				}
+				next = strings.TrimSpace(lock.ExpiresAt)
+			}
+		}
+		return stuckReason{Reason: reason, NextRetryAt: next}
+	case "advance_awaiting_human":
+		return stuckReason{Reason: withDetail("blocked: awaiting human", msg)}
+	case "permission_blocked":
+		return stuckReason{Reason: withDetail("permission blocked", msg)}
+	case "advance_retry", "retry_queued", "repair_retry", "session_refresh_retry",
+		"delegation_retry", "delegation_escalation_retry":
+		return stuckReason{Reason: withDetail("retrying", msg)}
+	case "delegation_preflight_failed":
+		return stuckReason{Reason: withDetail("delegation preflight failed", msg)}
+	default:
+		// advance_blocked, delegation_*_exceeded, delegation_loop_detected,
+		// deterministic_checkers_failed, ... — classify auth/quota so the operator
+		// sees an actionable label instead of a raw error line.
+		label := "blocked"
+		if queued {
+			label = "waiting"
+		}
+		if cls := classifyAuthQuota(msg); cls != "" {
+			label = cls
+		}
+		return stuckReason{Reason: withDetail(label, msg)}
+	}
+}
+
+// classifyAuthQuota labels a stuck-reason message as an auth or throttling
+// problem when its text matches the well-known runtime/gh signatures (issue #552
+// points 3 and 4). It returns "" when the message is not auth/quota related, so
+// the caller keeps its generic label.
+func classifyAuthQuota(msg string) string {
+	l := strings.ToLower(msg)
+	switch {
+	case strings.Contains(l, "usage limit"), strings.Contains(l, "rate limit"),
+		strings.Contains(l, "quota"), strings.Contains(l, "429"),
+		strings.Contains(l, "resets"):
+		return "throttled"
+	case strings.Contains(l, "authentication"), strings.Contains(l, "unauthorized"),
+		strings.Contains(l, "401"),
+		strings.Contains(l, "auth") && strings.Contains(l, "invalid"):
+		return "auth failing"
+	}
+	return ""
+}
+
+// extractRuntimeLockKey pulls the runtime:<rt>:<ref> resource key out of a
+// runtime_lock_wait event message ("runtime session runtime:codex:foo is busy;
+// ..."). It returns "" when the message does not carry a recognizable key.
+func extractRuntimeLockKey(message string) string {
+	const marker = "runtime session "
+	idx := strings.Index(message, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := message[idx+len(marker):]
+	if end := strings.Index(rest, " "); end >= 0 {
+		rest = rest[:end]
+	}
+	rest = strings.TrimSpace(rest)
+	if !strings.HasPrefix(rest, "runtime:") {
+		return ""
+	}
+	return rest
+}
+
+// firstLineTrimmed returns the first non-empty line of value, trimmed. Unlike the
+// display-oriented firstLine helper it returns "" (not "-") for an empty value so
+// withDetail can drop an absent detail cleanly.
+func firstLineTrimmed(value string) string {
+	for _, line := range strings.Split(value, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+func findResourceLock(locks []db.ResourceLock, key string) (db.ResourceLock, bool) {
+	for _, lock := range locks {
+		if lock.ResourceKey == key {
+			return lock, true
+		}
+	}
+	return db.ResourceLock{}, false
+}
+
+// withDetail appends a concise detail to a label, guarding against an empty or
+// duplicate detail so the surface stays tidy.
+func withDetail(label, detail string) string {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return label
+	}
+	return label + ": " + detail
+}

--- a/internal/cli/job_stuck_test.go
+++ b/internal/cli/job_stuck_test.go
@@ -1,0 +1,268 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/doctor"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestDeriveStuckReason exercises the pure why-stuck derivation (#552): the
+// authoritative reason for each stuck signal, and silence for healthy jobs.
+func TestDeriveStuckReason(t *testing.T) {
+	queued := db.Job{ID: "j", State: string(workflow.JobQueued)}
+	blocked := db.Job{ID: "j", State: string(workflow.JobBlocked)}
+	locks := []db.ResourceLock{{
+		ResourceKey: "runtime:codex:agent-x",
+		OwnerJobID:  "other-job",
+		ExpiresAt:   "2026-07-01T03:00:00Z",
+	}}
+
+	for _, tt := range []struct {
+		name        string
+		job         db.Job
+		event       db.JobEvent
+		hasEvent    bool
+		wantReason  string // substring; "" means expect empty
+		wantNoMatch string
+		wantNext    string
+	}{
+		{
+			name:       "queued waiting on runtime session lock surfaces owner and lease",
+			job:        queued,
+			event:      db.JobEvent{Kind: "runtime_lock_wait", Message: "runtime session runtime:codex:agent-x is busy"},
+			hasEvent:   true,
+			wantReason: "waiting on runtime session lock runtime:codex:agent-x (held by job other-job)",
+			wantNext:   "2026-07-01T03:00:00Z",
+		},
+		{
+			name:       "blocked awaiting human",
+			job:        blocked,
+			event:      db.JobEvent{Kind: "advance_awaiting_human", Message: "need a decision"},
+			hasEvent:   true,
+			wantReason: "blocked: awaiting human",
+		},
+		{
+			name:       "auth failure is labeled auth failing",
+			job:        blocked,
+			event:      db.JobEvent{Kind: "advance_blocked", Message: "GitHub CLI authentication for account jerryfane is invalid"},
+			hasEvent:   true,
+			wantReason: "auth failing:",
+		},
+		{
+			name:       "usage limit is labeled throttled",
+			job:        queued,
+			event:      db.JobEvent{Kind: "advance_blocked", Message: "You've hit your usage limit; resets Jul 1, 3am"},
+			hasEvent:   true,
+			wantReason: "throttled:",
+		},
+		{
+			name:       "retry event surfaces retrying",
+			job:        queued,
+			event:      db.JobEvent{Kind: "advance_retry", Message: "attempt 2 of 3"},
+			hasEvent:   true,
+			wantReason: "retrying: attempt 2 of 3",
+		},
+		{
+			name:       "blocked with no reason event still explained",
+			job:        blocked,
+			hasEvent:   false,
+			wantReason: "blocked",
+		},
+		{
+			name:       "healthy queued job stays silent",
+			job:        queued,
+			hasEvent:   false,
+			wantReason: "",
+		},
+		{
+			name:       "running job is never stuck",
+			job:        db.Job{ID: "j", State: string(workflow.JobRunning)},
+			event:      db.JobEvent{Kind: "runtime_lock_wait", Message: "runtime session runtime:codex:agent-x is busy"},
+			hasEvent:   true,
+			wantReason: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveStuckReason(tt.job, tt.event, tt.hasEvent, locks)
+			if tt.wantReason == "" {
+				if !got.empty() {
+					t.Fatalf("deriveStuckReason = %+v, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got.Reason, tt.wantReason) {
+				t.Fatalf("reason = %q, want substring %q", got.Reason, tt.wantReason)
+			}
+			if tt.wantNext != "" && got.NextRetryAt != tt.wantNext {
+				t.Fatalf("next retry = %q, want %q", got.NextRetryAt, tt.wantNext)
+			}
+		})
+	}
+}
+
+// TestRunJobListShowSurfaceWhyStuck is the end-to-end surface: a queued job
+// waiting on a runtime session lock reports WHY in `job list` and why_stuck in
+// `job show`, while a healthy queued job keeps its output unchanged (no WHY
+// column, exactly six columns).
+func TestRunJobListShowSurfaceWhyStuck(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	seedCLIJob(t, store, db.Job{
+		ID:      "stuck-job",
+		Agent:   "impl",
+		Type:    "ask",
+		State:   string(workflow.JobQueued),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", PullRequest: 4}),
+	}, "queued")
+	if err := store.AddJobEvent(context.Background(), db.JobEvent{
+		JobID:   "stuck-job",
+		Kind:    "runtime_lock_wait",
+		Message: "runtime session runtime:codex:agent-x is busy",
+	}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+	if _, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey: "runtime:codex:agent-x",
+		OwnerJobID:  "other-running-job",
+		OwnerToken:  "tok",
+		ExpiresAt:   time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil {
+		t.Fatalf("AcquireResourceLock returned error: %v", err)
+	}
+	// A healthy queued job with only lifecycle events must stay unchanged.
+	seedCLIJob(t, store, db.Job{
+		ID:      "healthy-job",
+		Agent:   "impl",
+		Type:    "ask",
+		State:   string(workflow.JobQueued),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", PullRequest: 5}),
+	}, "queued")
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"job", "list", "--home", home, "--repo", "owner/repo"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job list exit = %d, stderr=%s", code, stderr.String())
+	}
+	var stuckLine, healthyLine string
+	for _, line := range strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n") {
+		if strings.HasPrefix(line, "stuck-job\t") {
+			stuckLine = line
+		}
+		if strings.HasPrefix(line, "healthy-job\t") {
+			healthyLine = line
+		}
+	}
+	if stuckLine == "" || healthyLine == "" {
+		t.Fatalf("job list output = %q", stdout.String())
+	}
+	if !strings.Contains(stuckLine, "WHY: waiting on runtime session lock runtime:codex:agent-x") {
+		t.Fatalf("stuck line missing WHY column: %q", stuckLine)
+	}
+	if !strings.Contains(stuckLine, "held by job other-running-job") || !strings.Contains(stuckLine, "next retry") {
+		t.Fatalf("stuck line missing lock owner / next retry: %q", stuckLine)
+	}
+	if strings.Contains(healthyLine, "WHY:") {
+		t.Fatalf("healthy job must not carry a WHY column: %q", healthyLine)
+	}
+	if got := strings.Count(healthyLine, "\t"); got != 5 {
+		t.Fatalf("healthy job line changed shape (%d tabs, want 5): %q", got, healthyLine)
+	}
+
+	// job show surfaces the reason as a detail line.
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"job", "show", "stuck-job", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job show exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "why_stuck: waiting on runtime session lock") {
+		t.Fatalf("job show missing why_stuck line:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "next_retry_at:") {
+		t.Fatalf("job show missing next_retry_at line:\n%s", stdout.String())
+	}
+
+	// A healthy job's show output carries no why_stuck line.
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"job", "show", "healthy-job", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job show exit = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "why_stuck:") {
+		t.Fatalf("healthy job show must not carry why_stuck:\n%s", stdout.String())
+	}
+
+	// --json carries the fields for the stuck job and omits them for the healthy one.
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"job", "show", "stuck-job", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job show --json exit = %d, stderr=%s", code, stderr.String())
+	}
+	var decoded jobShowOutput
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("job show --json did not decode: %v\n%s", err, stdout.String())
+	}
+	if !strings.Contains(decoded.WhyStuck, "waiting on runtime session lock") || decoded.NextRetryAt == "" {
+		t.Fatalf("job show --json missing stuck fields: %+v", decoded)
+	}
+}
+
+// authFakeRunner is a minimal subprocess.Runner for the doctor auth checks: every
+// binary looks present and Run returns the result/err configured per command line.
+type authFakeRunner struct {
+	runs map[string]subprocess.Result
+	errs map[string]error
+}
+
+func (f authFakeRunner) LookPath(string) (string, error) { return "/bin/x", nil }
+
+func (f authFakeRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	key := command + " " + strings.Join(args, " ")
+	return f.runs[key], f.errs[key]
+}
+
+// TestDoctorGHAuthValidVsInvalid is the proactive auth-validation report (#552
+// slice B): `gh auth status` success reports OK; failure reports not-OK with an
+// actionable remediation message. Exercised through doctor.GlobalChecks so the
+// same code the `gitmoot doctor` command runs is validated.
+func TestDoctorGHAuthValidVsInvalid(t *testing.T) {
+	find := func(checks []doctor.Check) doctor.Check {
+		for _, c := range checks {
+			if c.Name == "gh auth" {
+				return c
+			}
+		}
+		t.Fatalf("no gh auth check in %+v", checks)
+		return doctor.Check{}
+	}
+
+	valid := doctor.Checker{Runner: authFakeRunner{
+		runs: map[string]subprocess.Result{"gh auth status": {Stdout: "Logged in to github.com account jerryfane\n"}},
+	}}.GlobalChecks(context.Background())
+	if got := find(valid); !got.OK || !got.Required {
+		t.Fatalf("valid gh auth = %+v, want required OK", got)
+	}
+
+	invalid := doctor.Checker{Runner: authFakeRunner{
+		runs: map[string]subprocess.Result{"gh auth status": {Stderr: "You are not logged into any GitHub hosts\n"}},
+		errs: map[string]error{"gh auth status": context.DeadlineExceeded},
+	}}.GlobalChecks(context.Background())
+	got := find(invalid)
+	if got.OK {
+		t.Fatalf("invalid gh auth = %+v, want not OK", got)
+	}
+	if !strings.Contains(got.Detail, doctor.GHAuthRemediation) {
+		t.Fatalf("invalid gh auth detail = %q, want actionable remediation %q", got.Detail, doctor.GHAuthRemediation)
+	}
+	if !strings.Contains(got.Detail, "not logged into") {
+		t.Fatalf("invalid gh auth detail = %q, want the underlying gh error", got.Detail)
+	}
+}

--- a/internal/cli/job_stuck_test.go
+++ b/internal/cli/job_stuck_test.go
@@ -64,6 +64,37 @@ func TestDeriveStuckReason(t *testing.T) {
 			wantReason: "throttled:",
 		},
 		{
+			name:        "failed-check test name containing 'resets' is not mislabeled throttled",
+			job:         blocked,
+			event:       db.JobEvent{Kind: "deterministic_checkers_failed", Message: "--- FAIL: TestConfigResets (0.01s)"},
+			hasEvent:    true,
+			wantReason:  "blocked:",
+			wantNoMatch: "throttled",
+		},
+		{
+			name:        "git 'invalid author email' is not mislabeled auth failing",
+			job:         blocked,
+			event:       db.JobEvent{Kind: "advance_blocked", Message: "commit failed: invalid author email"},
+			hasEvent:    true,
+			wantReason:  "blocked:",
+			wantNoMatch: "auth failing",
+		},
+		{
+			name:        "bare 401 digit run without http context is not mislabeled auth failing",
+			job:         queued,
+			event:       db.JobEvent{Kind: "advance_blocked", Message: "delegation to PR 401 exceeded budget"},
+			hasEvent:    true,
+			wantReason:  "waiting:",
+			wantNoMatch: "auth failing",
+		},
+		{
+			name:       "http 401 status is labeled auth failing",
+			job:        blocked,
+			event:      db.JobEvent{Kind: "advance_blocked", Message: "gh api returned http 401"},
+			hasEvent:   true,
+			wantReason: "auth failing:",
+		},
+		{
 			name:       "retry event surfaces retrying",
 			job:        queued,
 			event:      db.JobEvent{Kind: "advance_retry", Message: "attempt 2 of 3"},
@@ -100,6 +131,9 @@ func TestDeriveStuckReason(t *testing.T) {
 			}
 			if !strings.Contains(got.Reason, tt.wantReason) {
 				t.Fatalf("reason = %q, want substring %q", got.Reason, tt.wantReason)
+			}
+			if tt.wantNoMatch != "" && strings.Contains(got.Reason, tt.wantNoMatch) {
+				t.Fatalf("reason = %q, must not contain %q", got.Reason, tt.wantNoMatch)
 			}
 			if tt.wantNext != "" && got.NextRetryAt != tt.wantNext {
 				t.Fatalf("next retry = %q, want %q", got.NextRetryAt, tt.wantNext)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2763,6 +2763,46 @@ func (s *Store) JobIDsWithEventKind(ctx context.Context, kind string) (map[strin
 	return out, rows.Err()
 }
 
+// LatestJobEventsOfKinds returns, per job, the LATEST job_event whose kind is one
+// of the given kinds, keyed by job id, in a single indexed query. It mirrors
+// LatestJobEvents but restricts the candidate set to the caller's "reason" kinds
+// so a stuck-job surface (issue #552) can find the most recent event that
+// actually explains why a queued/blocked job is waiting — ignoring benign
+// lifecycle events (queued, route_selected, delegation_continuation_enqueued)
+// that would otherwise be the overall latest event and mask the real reason. An
+// empty kinds slice returns an empty map without querying.
+func (s *Store) LatestJobEventsOfKinds(ctx context.Context, kinds []string) (map[string]JobEvent, error) {
+	if len(kinds) == 0 {
+		return map[string]JobEvent{}, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(kinds)), ",")
+	args := make([]any, 0, len(kinds)*2)
+	for _, kind := range kinds {
+		args = append(args, kind)
+	}
+	// The IN list appears twice (outer filter + inner MAX(id) subquery), so the
+	// bound args are the kinds repeated.
+	args = append(args, args...)
+	query := `SELECT job_id, kind, message FROM job_events
+		WHERE kind IN (` + placeholders + `) AND id IN (
+			SELECT MAX(id) FROM job_events WHERE kind IN (` + placeholders + `) GROUP BY job_id)`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := map[string]JobEvent{}
+	for rows.Next() {
+		var event JobEvent
+		if err := rows.Scan(&event.JobID, &event.Kind, &event.Message); err != nil {
+			return nil, err
+		}
+		out[event.JobID] = event
+	}
+	return out, rows.Err()
+}
+
 // JobIDsWithPendingDelegationWorktreeReclaim returns the IDs of jobs whose most
 // recent terminal delegation-worktree cleanup outcome was a PRESERVE
 // (delegation_worktree_cleanup_skipped) NOT yet followed by a removal

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -103,10 +103,26 @@ func (c Checker) command(ctx context.Context, runner subprocess.Runner, name str
 	return Check{Name: name, OK: true, Required: required, Detail: firstLine(result.Stdout, result.Stderr)}
 }
 
+// GHAuthRemediation is the actionable hint appended when `gh auth status` fails.
+// A job that pushes branches or opens PRs needs valid gh credentials in the
+// environment that RUNS it — which for background jobs is the daemon's, not the
+// invoking shell's (issue #552 point 4: an integrate leg failed on invalid gh
+// auth even though interactive `gh auth status` was valid, because the daemon did
+// not inherit the shell's credentials).
+const GHAuthRemediation = "run `gh auth login` and ensure the daemon inherits valid gh credentials before dispatching jobs that push or open PRs"
+
 func (c Checker) ghAuth(ctx context.Context, runner subprocess.Runner) Check {
 	result, err := runner.Run(ctx, "", "gh", "auth", "status")
 	if err != nil {
-		return Check{Name: "gh auth", Required: true, Detail: strings.TrimSpace(result.Stderr)}
+		detail := strings.TrimSpace(result.Stderr)
+		if detail == "" {
+			detail = strings.TrimSpace(err.Error())
+		}
+		if detail != "" {
+			detail += "; "
+		}
+		detail += GHAuthRemediation
+		return Check{Name: "gh auth", Required: true, Detail: detail}
 	}
 	return Check{Name: "gh auth", OK: true, Required: true, Detail: firstLine(result.Stdout, result.Stderr)}
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -540,8 +540,8 @@ Use GitHub PR comments as the public audit trail:
 ## Jobs And Locks
 
 ```sh
-gitmoot job list --repo owner/repo
-gitmoot job show <job-id>
+gitmoot job list --repo owner/repo   # add --json for machine-readable rows
+gitmoot job show <job-id>            # add --json for the full job + why-stuck detail
 gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
@@ -557,6 +557,17 @@ gracefully. In-flight jobs finish normally; the coordinator's next continuation
 is routed through the graceful finalize path (synthesize what completed → stop)
 and the daemon stops starting queued children of that root. See
 `references/SAFETY.md` for how it relates to the other termination bounds.
+
+For a `queued` or `blocked` job, `gitmoot job list` appends a `WHY:` column and
+`gitmoot job show` prints a `why_stuck:` (and, when a lease applies, a
+`next_retry_at:`) line explaining what the job is waiting on — e.g. `waiting on
+runtime session lock runtime:codex:<ref> (held by job <id>)`, `blocked: awaiting
+human`, `auth failing: …`, `throttled: …`, or `retrying: …`. The reason is
+derived from the most authoritative existing signal (the latest reason-bearing
+`job events` entry plus the owning resource lock's lease); a healthy job's output
+is unchanged. `gitmoot doctor` proactively validates `gh auth` (with an
+actionable remediation hint) and the Claude runtime token so a bad credential is
+caught before a job stalls on it.
 
 `gitmoot job cancel <job-id>` also releases any resource locks the cancelled job
 still owned — including a stranded `runtime:<rt>:<session>` lock left behind when


### PR DESCRIPTION
## What & why

Diagnosing why an `orchestrate` coordinator wasn't producing delegations required four CLI commands and grepping a 30 MB `daemon.log` (#552). The state model was already truthful — every fact was queryable — but the observability at the `queued`/`blocked` boundary was weak: a waiting job never told you *what* it was waiting on or *until when*, so a throttled or auth-starved run looked broken. This PR is purely surfacing; it derives from existing signals and does not change dispatch semantics.

### Slice A — surface why-stuck
- `deriveStuckReason` (pure, unit-tested) maps the most authoritative existing signal — the latest reason-bearing `job_event` plus the owning runtime-session lock's lease — to a concise reason: `waiting on runtime session lock <key> (held by job <id>)`, `blocked: awaiting human`, `auth failing: …`, `throttled: …`, `retrying: …`. Auth/quota phrases are classified into actionable labels.
- `gitmoot job list` appends a `WHY:` column and `gitmoot job show` prints `why_stuck:` / `next_retry_at:` lines — **for queued/blocked jobs only**.
- Both commands gain `--json` carrying the additive fields (omitted when empty).
- New indexed store query `LatestJobEventsOfKinds` fetches the latest reason event per job in one pass so `job list` costs no per-job lookup.

### Slice B — proactive auth validation
- `gitmoot doctor`'s `gh auth` check now appends an actionable remediation hint on failure (run `gh auth login`; the daemon must inherit valid gh credentials), so a bad credential is caught before a job stalls on it. The existing Claude runtime-token validation is retained.

## How behavior is preserved
- The reason surface only fires for `queued`/`blocked` jobs with a derivable signal; a healthy job's `job list` row keeps its exact six columns and `job show` gains no lines (guarded by a test asserting the plain row still has five tabs / no `why_stuck`).
- No dispatch semantics change — the guard is read-only/advisory. `doctor`'s gh-auth check keeps its required/OK contract on success.

## Tests
- Pure-derivation table: each stuck signal maps to the right reason + lease; healthy/running jobs stay silent.
- End-to-end `job list` / `job show` / `--json` surface driven by a real runtime-lock wait (event + resource lock), asserting the healthy job is unchanged.
- `gh auth` valid-vs-invalid reporting via `doctor.GlobalChecks` (actionable remediation on failure).

Gate green: `go build ./...`, `go vet ./...`, `go test ./internal/cli/ -count=1`, `go test -race ./internal/cli/` (708s, no data race).

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)