### PR TITLE
ci: give the race-detector test step an explicit 20m timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,9 @@ jobs:
         # recovery / worktree-cleanup fix adds concurrency-sensitive resource_locks
         # reads (JobRuntimeLockLiveness, DeleteExpiredResourceLocks) that the daemon
         # worker pool exercises from multiple goroutines.
-        run: go test -race ./internal/workflow/ ./internal/cli/ ./internal/db/ ./internal/daemon/
+        #
+        # -timeout 20m: internal/cli is a large suite and the race detector runs
+        # it ~10x slower, so it sits right on Go's default 10m/package deadline —
+        # adding a handful of new tests intermittently tips it over (a timeout, not
+        # a real race). The explicit bound gives headroom without masking a hang.
+        run: go test -race -timeout 20m ./internal/workflow/ ./internal/cli/ ./internal/db/ ./internal/daemon/


### PR DESCRIPTION
The race step runs `internal/{workflow,cli,db,daemon}` in one `go test -race` invocation under Go's **default 10m/package** deadline. `internal/cli` is a large suite and the race detector runs it ~10× slower, so it sits right on that 10-minute line.

Two independent open PRs (#571 #560, #569 #566) failed the race step with `FAIL internal/cli 600.0s` — a **timeout**, not a data race (goroutine dumps show tests parked at `.Parallel()`, no `DATA RACE` warning). #570/#572 passed the same step, confirming it's variance around the 10m edge, not a per-PR bug.

Fix: bound the race step at `-timeout 20m` for headroom without masking a genuine hang. Unblocks the daemon-reliability PR batch.

Relates #555 #560 #566.