### PR TITLE
fix(cli): dashboard --web returns 404 for unknown job/run (#503)

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -109,13 +110,20 @@ func (d *webDataSource) State(ctx context.Context, runID string) (dashboard.Stat
 			jobByID[j.ID] = j
 		}
 
-		target := strings.TrimSpace(runID)
+		requested := strings.TrimSpace(runID)
+		target := requested
 		if target == "" {
 			target = mostRecentRunRoot(jobs, jobByID)
 		} else {
 			target = jobRootID(jobByID, target)
 		}
-		if target == "" {
+		if _, ok := jobByID[target]; target == "" || !ok {
+			// An explicitly requested run that does not resolve to a real job is
+			// a 404; an empty request against an empty store is just an empty
+			// snapshot.
+			if requested != "" {
+				return dashboard.ErrRunNotFound
+			}
 			return nil
 		}
 
@@ -156,6 +164,9 @@ func (d *webDataSource) Job(ctx context.Context, jobID string) (dashboard.Node, 
 	err := withStore(d.home, func(store *db.Store) error {
 		job, err := store.GetJob(ctx, jobID)
 		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return dashboard.ErrJobNotFound
+			}
 			return err
 		}
 		payload, _ := workflow.ParseJobPayload(job.Payload)

--- a/internal/cli/dashboard_web_test.go
+++ b/internal/cli/dashboard_web_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	dashboard "github.com/jerryfane/gitmoot-dashboard"
@@ -55,6 +56,25 @@ func seedWebDashboardTree(t *testing.T, home string) {
 	// Continuation job carries no delegation id.
 	contPayload := workflow.JobPayload{Repo: "jerryfane/noted", TaskTitle: "synthesize"}
 	mustCreateJob(t, store, db.Job{ID: "coord-cont", Agent: "project-lead", Type: "orchestrate", State: "queued", Payload: mustJSON(t, contPayload), ParentJobID: "coord"}, "", "")
+}
+
+// TestWebDataSourceNotFound asserts the DataSource maps an unknown job/run to the
+// dashboard sentinels (so the API returns 404, not 500), while a real run resolves.
+func TestWebDataSourceNotFound(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedWebDashboardTree(t, home)
+	ds := &webDataSource{home: home}
+	ctx := context.Background()
+
+	if _, err := ds.Job(ctx, "no-such-job"); !errors.Is(err, dashboard.ErrJobNotFound) {
+		t.Fatalf("Job(unknown) err = %v, want ErrJobNotFound", err)
+	}
+	if _, err := ds.State(ctx, "no-such-run"); !errors.Is(err, dashboard.ErrRunNotFound) {
+		t.Fatalf("State(unknown) err = %v, want ErrRunNotFound", err)
+	}
+	if _, err := ds.State(ctx, "coord"); err != nil {
+		t.Fatalf("State(coord) err = %v, want nil", err)
+	}
 }
 
 func mustCreateJob(t *testing.T, store *db.Store, job db.Job, eventKind, eventMsg string) {


### PR DESCRIPTION
Follow-up to #574, found by an end-to-end test of `gitmoot dashboard --web` against the live store.

- `/api/job/<unknown>` and `/api/state?run=<unknown>` returned **500** instead of **404** because `GetJob`s `sql.ErrNoRows` (and an unresolved run root) were passed through raw, so the dashboard `statusForError` could not recognize them.
- Map store not-found to `dashboard.ErrJobNotFound` / `dashboard.ErrRunNotFound`; add a `TestWebDataSourceNotFound` regression test.

Verified live: `/api/job/bogus` and `/api/state?run=bogus` now 404; real job/run still 200; `/api/runs`, `/api/state`, `/events` (SSE) all serve real data.

Part of #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)