### PR TITLE
fix(workflow): setTaskState branch-unique crash on advancement + feat(cli): doctor --json

### DIFF
--- a/internal/cli/doctor_json_test.go
+++ b/internal/cli/doctor_json_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestDoctorJSONOutput pins the fix for "gitmoot doctor --json advertised but
+// rejected": doctor now accepts --json and emits the checks as a JSON array (each
+// with name/status/ok/required/detail) instead of erroring with
+// "flag provided but not defined: -json".
+func TestDoctorJSONOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	// --repo at a temp dir keeps the run local; individual checks may warn/fail (no
+	// git remote, etc.) but the JSON shape is what this test asserts.
+	Run([]string{"doctor", "--json", "--repo", t.TempDir()}, &stdout, &stderr)
+
+	if bytes.Contains(stderr.Bytes(), []byte("flag provided but not defined")) {
+		t.Fatalf("doctor still rejects --json: %s", stderr.String())
+	}
+	var checks []map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &checks); err != nil {
+		t.Fatalf("doctor --json did not produce a JSON array: %v\nstdout=%q", err, stdout.String())
+	}
+	if len(checks) == 0 {
+		t.Fatalf("doctor --json produced an empty array")
+	}
+	for _, c := range checks {
+		for _, k := range []string{"name", "status", "ok", "required", "detail"} {
+			if _, ok := c[k]; !ok {
+				t.Errorf("doctor --json check missing key %q: %v", k, c)
+			}
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -118,6 +119,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	repoDir := fs.String("repo", ".", "repository directory to check")
+	jsonOutput := fs.Bool("json", false, "print the checks as a JSON array instead of the text table")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -134,6 +136,37 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	// Paths zero, which skips the daemon check and keeps the shell-local one.
 	paths, _ := config.DefaultPaths()
 	checks := doctor.Checker{Dir: *repoDir, LiveProbe: true, Paths: paths}.Run(context.Background())
+	if *jsonOutput {
+		type checkJSON struct {
+			Name     string `json:"name"`
+			Status   string `json:"status"`
+			OK       bool   `json:"ok"`
+			Required bool   `json:"required"`
+			Detail   string `json:"detail"`
+		}
+		out := make([]checkJSON, 0, len(checks))
+		for _, check := range checks {
+			status := "ok"
+			if !check.OK {
+				if check.Required {
+					status = "fail"
+				} else {
+					status = "warn"
+				}
+			}
+			out = append(out, checkJSON{Name: check.Name, Status: status, OK: check.OK, Required: check.Required, Detail: check.Detail})
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			fmt.Fprintf(stderr, "doctor: %v\n", err)
+			return 1
+		}
+		if err := doctor.FailedRequired(checks); err != nil {
+			return 1
+		}
+		return 0
+	}
 	for _, check := range checks {
 		status := "ok"
 		if !check.OK {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -5947,6 +5947,23 @@ func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) 
 			task.Branch = existing.Branch
 		}
 	}
+	// One task per (repo, branch) is enforced by the tasks(repo_full_name, branch)
+	// partial-unique index. If this ref carries a non-empty branch already owned by a
+	// DIFFERENT task -- e.g. workflow advancement re-running a phase on the same branch
+	// under a fresh task id -- upserting `task` would fail with
+	// "UNIQUE constraint failed: tasks.repo_full_name, tasks.branch" and wedge the
+	// advancement. Advance the branch's canonical task in place instead of inserting a
+	// duplicate (mirrors StartTaskBranch's reuse check).
+	if task.Branch != "" {
+		byBranch, berr := e.Store.GetTaskByRepoBranch(ctx, task.RepoFullName, task.Branch)
+		if berr != nil && !errors.Is(berr, sql.ErrNoRows) {
+			return berr
+		}
+		if berr == nil && byBranch.ID != task.ID {
+			byBranch.State = string(state)
+			return e.Store.UpsertTask(ctx, byBranch)
+		}
+	}
 	return e.Store.UpsertTask(ctx, task)
 }
 

--- a/internal/workflow/set_task_state_branch_test.go
+++ b/internal/workflow/set_task_state_branch_test.go
@@ -1,0 +1,61 @@
+package workflow
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// TestSetTaskStateBranchConflict pins the fix for the reported
+// "UNIQUE constraint failed: tasks.repo_full_name, tasks.branch" during workflow
+// advancement. When advancement calls setTaskState with a ref whose branch is already
+// owned by a DIFFERENT task (a fresh task id re-running a phase on the same branch after
+// a transient failure), it must advance the branch's canonical task in place rather than
+// crash on the tasks(repo_full_name, branch) partial-unique index.
+func TestSetTaskStateBranchConflict(t *testing.T) {
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	e := Engine{Store: store}
+
+	const repo = "owner/repo"
+	const branch = "council/slug-v1"
+
+	// Seed the branch's canonical task.
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-a", RepoFullName: repo, GoalID: "g1", Title: "impl", State: string(TaskImplementing), Branch: branch}); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+
+	// Advancement with a DIFFERENT (fresh) id on the same branch must NOT crash.
+	if err := e.setTaskState(ctx, taskRef{ID: "task-fresh", Repo: repo, GoalID: "g1", Title: "review", Branch: branch}, TaskReviewing); err != nil {
+		t.Fatalf("setTaskState onto a branch owned by another task must not error, got: %v", err)
+	}
+
+	// The branch's canonical task advanced in place; no duplicate was created.
+	got, err := store.GetTaskByRepoBranch(ctx, repo, branch)
+	if err != nil {
+		t.Fatalf("GetTaskByRepoBranch: %v", err)
+	}
+	if got.ID != "task-a" {
+		t.Errorf("branch task id = %q, want task-a (canonical id preserved)", got.ID)
+	}
+	if got.State != string(TaskReviewing) {
+		t.Errorf("branch task state = %q, want %q (advanced in place)", got.State, string(TaskReviewing))
+	}
+	if _, err := store.GetTask(ctx, "task-fresh"); err == nil {
+		t.Errorf("GetTask(task-fresh) unexpectedly succeeded; no duplicate should be created on the taken branch")
+	}
+
+	// Sanity: the normal same-id path still advances the task directly.
+	if err := e.setTaskState(ctx, taskRef{ID: "task-a", Repo: repo, GoalID: "g1", Title: "impl", Branch: branch}, TaskBlocked); err != nil {
+		t.Fatalf("setTaskState same-id: %v", err)
+	}
+	if got, _ := store.GetTask(ctx, "task-a"); got.State != string(TaskBlocked) {
+		t.Errorf("same-id advance state = %q, want %q", got.State, string(TaskBlocked))
+	}
+}


### PR DESCRIPTION
Two independent fixes surfaced by a downstream user running the coordinator.

## 1. `feat(cli): gitmoot doctor --json`
`gitmoot doctor` rejected `--json` (`flag provided but not defined: -json`) even though structured output is useful for tooling and `gitmoot job watch --json` already exists. Adds a `--json` flag emitting the checks as a JSON array (`name`/`status`/`ok`/`required`/`detail`); the text table and the `FailedRequired` exit code are unchanged when the flag is absent.

## 2. `fix(workflow): setTaskState UNIQUE(repo_full_name, branch) crash on advancement`
Observed as: *artifact jobs succeed, but workflow advancement retries in a loop with `UNIQUE constraint failed: tasks.repo_full_name, tasks.branch`.*

Root cause: `setTaskState` looked up the task by **id** only (`GetTask`), so when advancement re-ran a phase on an **existing branch under a fresh task id**, the upsert hit the `tasks(repo_full_name, branch)` partial-unique index directly and errored. `StartTaskBranch` already guards this with a `GetTaskByRepoBranch` reuse check; `setTaskState` now does the same — advancing the branch's canonical task in place (preserving its id) instead of inserting a duplicate. The one-task-per-branch invariant (and `TestTasksRequireUniqueNonEmptyBranches`) is preserved.

## Tests / verification
- `internal/cli/doctor_json_test.go`, `internal/workflow/set_task_state_branch_test.go` (both pass).
- `go build ./...`, `go vet ./...`, `go test ./internal/cli/... ./internal/db/... ./internal/workflow/...` pass locally.
- `go test -race ./internal/workflow/` could not be run on my box (ThreadSanitizer "unsupported VMA range 47/48" on arm64) — CI will exercise `-race`.

Note: `gitmoot job show --json` was also reported but is **already on `main`** (`runJobShow` has the flag); the reporter's binary was simply behind. Not included here.