### PR TITLE
feat(daemon): warn loudly when a restart would drop Claude auth + clarify --repo (#559)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -127,7 +127,7 @@ func runDaemonStartWithWorkDirRestart(args []string, workDir string, restart boo
 
 	warnIfDaemonStartLosesClaudeAuth(stderr, restart, priorDaemonHadClaudeAuth)
 
-	started, err := startDaemonChild(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.WatchIssues, cfg.Scheduler, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir)
+	started, err := startDaemonChildFn(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.WatchIssues, cfg.Scheduler, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir)
 	if err != nil {
 		fmt.Fprintf(stderr, "daemon start: %v\n", err)
 		return 1
@@ -445,6 +445,11 @@ func runDaemonRestart(args []string, stdout, stderr io.Writer) int {
 // that same environment BEFORE launch. It is a package var so tests can seed the
 // auth-readiness seam deterministically instead of depending on real host creds.
 var claudeAuthEnvLookup = os.LookupEnv
+
+// startDaemonChildFn is the daemon child-spawn indirection. It defaults to the
+// real startDaemonChild; tests swap it so the start/restart command body can be
+// driven end-to-end without launching an actual daemon process.
+var startDaemonChildFn = startDaemonChild
 
 // warnIfDaemonStartLosesClaudeAuth prints a prominent, non-fatal stderr warning
 // when the daemon about to (re)start will inherit an environment WITHOUT Claude

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -67,6 +67,9 @@ func printDaemonUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot daemon restart")
 	fmt.Fprintln(w, "  gitmoot daemon status")
 	fmt.Fprintln(w, "  gitmoot daemon logs")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "  --repo sets the daemon's LAUNCH CONTEXT (working dir / preflight checkout) only; it does NOT")
+	fmt.Fprintln(w, "  scope supervision — the daemon supervises ALL subscribed repos regardless.")
 }
 
 func runDaemonStart(args []string, stdout, stderr io.Writer) int {
@@ -74,6 +77,14 @@ func runDaemonStart(args []string, stdout, stderr io.Writer) int {
 }
 
 func runDaemonStartWithWorkDir(args []string, workDir string, stdout, stderr io.Writer) int {
+	return runDaemonStartWithWorkDirRestart(args, workDir, false, stdout, stderr)
+}
+
+// runDaemonStartWithWorkDirRestart is the shared (re)start body. restart selects
+// the auth-drop warning flavor (#559): a plain start warns that the new daemon
+// will come up without Claude auth; a restart warns that a previously-authed
+// daemon's auth will be LOST.
+func runDaemonStartWithWorkDirRestart(args []string, workDir string, restart bool, stdout, stderr io.Writer) int {
 	cfg, code := parseDaemonStartConfig("daemon start", args, stderr)
 	if code == daemonHelp {
 		return 0
@@ -111,6 +122,8 @@ func runDaemonStartWithWorkDir(args []string, workDir string, stdout, stderr io.
 			return 1
 		}
 	}
+
+	warnIfDaemonStartLosesClaudeAuth(stderr, restart)
 
 	started, err := startDaemonChild(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.WatchIssues, cfg.Scheduler, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir)
 	if err != nil {
@@ -163,7 +176,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("daemon run", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
-	repoFlag := fs.String("repo", "", "GitHub repository as owner/repo")
+	repoFlag := fs.String("repo", "", "GitHub repository as owner/repo (sets the daemon launch context: working dir / preflight checkout; does NOT scope supervision — the daemon supervises ALL subscribed repos)")
 	var session string
 	fs.StringVar(&session, "session", "", "scope the daemon worker to a delegation root job id")
 	fs.StringVar(&session, "root", "", "alias for --session")
@@ -413,7 +426,37 @@ func runDaemonRestart(args []string, stdout, stderr io.Writer) int {
 	if stopCode != 0 {
 		return stopCode
 	}
-	return runDaemonStartWithWorkDir(targetArgs, targetWorkDir, stdout, stderr)
+	return runDaemonStartWithWorkDirRestart(targetArgs, targetWorkDir, true, stdout, stderr)
+}
+
+// claudeAuthEnvLookup predicts the environment the (re)started daemon child will
+// inherit. startDaemonChild launches the child with cmd.Env unset, so it inherits
+// THIS process's environment; the anti-footgun warning (#559) therefore inspects
+// that same environment BEFORE launch. It is a package var so tests can seed the
+// auth-readiness seam deterministically instead of depending on real host creds.
+var claudeAuthEnvLookup = os.LookupEnv
+
+// warnIfDaemonStartLosesClaudeAuth prints a prominent, non-fatal stderr warning
+// when the daemon about to (re)start will inherit an environment WITHOUT Claude
+// auth (#559). Because startDaemonChild does not set cmd.Env, the child inherits
+// this process's environment; a shell missing CLAUDE_CODE_OAUTH_TOKEN silently
+// disables Claude-runtime auth for ALL subscribed repos, discoverable only later
+// via `daemon status`. It only covers the Claude runtime (the one
+// InspectClaudeAuthEnv describes) and never refuses the start.
+func warnIfDaemonStartLosesClaudeAuth(w io.Writer, restart bool) {
+	if runtime.InspectClaudeAuthEnv(claudeAuthEnvLookup).Ready() {
+		return
+	}
+	if restart {
+		fmt.Fprintln(w, "⚠️  WARNING: this restart will DROP Claude auth — the new daemon is being launched WITHOUT")
+		fmt.Fprintln(w, "    CLAUDE_CODE_OAUTH_TOKEN in this environment, so it will LOSE the auth the previous daemon had.")
+	} else {
+		fmt.Fprintln(w, "⚠️  WARNING: the daemon is starting WITHOUT Claude auth (CLAUDE_CODE_OAUTH_TOKEN is unset in")
+		fmt.Fprintln(w, "    this environment).")
+	}
+	fmt.Fprintln(w, "    Every Claude-runtime job across ALL subscribed repos will fail auth.")
+	fmt.Fprintln(w, "    Set the token in this shell before (re)starting, or run the daemon via its systemd service")
+	fmt.Fprintln(w, "    (which loads the token from its EnvironmentFile). See `gitmoot daemon status`.")
 }
 
 func runDaemonStatus(args []string, stdout, stderr io.Writer) int {
@@ -697,7 +740,7 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 	fs := flag.NewFlagSet(command, flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
-	repoFlag := fs.String("repo", "", "GitHub repository as owner/repo")
+	repoFlag := fs.String("repo", "", "GitHub repository as owner/repo (sets the daemon launch context: working dir / preflight checkout; does NOT scope supervision — the daemon supervises ALL subscribed repos)")
 	var session string
 	fs.StringVar(&session, "session", "", "scope the daemon worker to a delegation root job id")
 	fs.StringVar(&session, "root", "", "alias for --session")
@@ -2750,7 +2793,14 @@ func warnSerializedParallelJobs(ctx context.Context, worker jobWorker, limit int
 		workers = count
 	}
 	writeLine(worker.Stdout, "warning: %d parallelizable jobs queued for %s will run serially under the current scheduler config; relaunch with: gitmoot daemon restart --parallel %d", count, target, workers)
+	writeLine(worker.Stdout, "         %s", daemonRestartEnvCaveat)
 }
+
+// daemonRestartEnvCaveat is the anti-footgun caveat (#559) appended to the
+// serialized-jobs relaunch hint: a `daemon restart` re-inherits the launching
+// shell's environment, so runtime tokens must be present in that shell or the
+// daemon loses auth, and it resets in-flight scheduler state.
+const daemonRestartEnvCaveat = "note: a restart RE-INHERITS the launching shell's environment (ensure runtime tokens like CLAUDE_CODE_OAUTH_TOKEN are set in that shell, or the daemon loses auth) and resets in-flight scheduler state."
 
 // listPendingQueuedJobs returns the queued jobs eligible to run for this
 // repo/session filter, dropping children of a killed root.

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -77,14 +77,16 @@ func runDaemonStart(args []string, stdout, stderr io.Writer) int {
 }
 
 func runDaemonStartWithWorkDir(args []string, workDir string, stdout, stderr io.Writer) int {
-	return runDaemonStartWithWorkDirRestart(args, workDir, false, stdout, stderr)
+	return runDaemonStartWithWorkDirRestart(args, workDir, false, false, stdout, stderr)
 }
 
 // runDaemonStartWithWorkDirRestart is the shared (re)start body. restart selects
 // the auth-drop warning flavor (#559): a plain start warns that the new daemon
 // will come up without Claude auth; a restart warns that a previously-authed
-// daemon's auth will be LOST.
-func runDaemonStartWithWorkDirRestart(args []string, workDir string, restart bool, stdout, stderr io.Writer) int {
+// daemon's auth will be LOST — but only when priorDaemonHadClaudeAuth confirms
+// the prior daemon actually had Claude auth (the caller inspects it before the
+// stop). When the prior state is unknown, the neutral plain-start wording is used.
+func runDaemonStartWithWorkDirRestart(args []string, workDir string, restart bool, priorDaemonHadClaudeAuth bool, stdout, stderr io.Writer) int {
 	cfg, code := parseDaemonStartConfig("daemon start", args, stderr)
 	if code == daemonHelp {
 		return 0
@@ -123,7 +125,7 @@ func runDaemonStartWithWorkDirRestart(args []string, workDir string, restart boo
 		}
 	}
 
-	warnIfDaemonStartLosesClaudeAuth(stderr, restart)
+	warnIfDaemonStartLosesClaudeAuth(stderr, restart, priorDaemonHadClaudeAuth)
 
 	started, err := startDaemonChild(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.WatchIssues, cfg.Scheduler, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir)
 	if err != nil {
@@ -418,6 +420,14 @@ func runDaemonRestart(args []string, stdout, stderr io.Writer) int {
 			return 1
 		}
 	}
+	// Inspect the still-running daemon's ACTUAL Claude auth BEFORE stopping it, so
+	// the restart warning only claims a DROP when there is genuinely auth to lose
+	// (#559). This is the same mechanism `daemon status` uses; it degrades to
+	// Detected=false on a non-Linux/unreadable-/proc host, which correctly falls
+	// back to the neutral plain-start wording. Must run before runDaemonStop below,
+	// which tears the prior daemon down and makes its env unreadable.
+	priorAuth := presence.InspectDaemonClaudeAuth(paths)
+	priorDaemonHadClaudeAuth := priorAuth.Detected && priorAuth.Auth.Ready()
 	stopArgs := []string{}
 	if restartCfg.Home != "" {
 		stopArgs = append(stopArgs, "--home", restartCfg.Home)
@@ -426,7 +436,7 @@ func runDaemonRestart(args []string, stdout, stderr io.Writer) int {
 	if stopCode != 0 {
 		return stopCode
 	}
-	return runDaemonStartWithWorkDirRestart(targetArgs, targetWorkDir, true, stdout, stderr)
+	return runDaemonStartWithWorkDirRestart(targetArgs, targetWorkDir, true, priorDaemonHadClaudeAuth, stdout, stderr)
 }
 
 // claudeAuthEnvLookup predicts the environment the (re)started daemon child will
@@ -443,11 +453,19 @@ var claudeAuthEnvLookup = os.LookupEnv
 // disables Claude-runtime auth for ALL subscribed repos, discoverable only later
 // via `daemon status`. It only covers the Claude runtime (the one
 // InspectClaudeAuthEnv describes) and never refuses the start.
-func warnIfDaemonStartLosesClaudeAuth(w io.Writer, restart bool) {
+//
+// The definite "this restart will DROP the auth the previous daemon had" wording
+// is only used when priorDaemonHadClaudeAuth is true — i.e. the caller confirmed,
+// by inspecting the still-running daemon's own environment BEFORE stopping it,
+// that there is genuinely auth to lose. On a Codex/Kimi-only box, or when the
+// prior daemon's env was unreadable (non-Linux/unreadable /proc), the prior state
+// is UNKNOWN and we fall back to the neutral plain-start wording rather than
+// asserting a loss that never happened.
+func warnIfDaemonStartLosesClaudeAuth(w io.Writer, restart bool, priorDaemonHadClaudeAuth bool) {
 	if runtime.InspectClaudeAuthEnv(claudeAuthEnvLookup).Ready() {
 		return
 	}
-	if restart {
+	if restart && priorDaemonHadClaudeAuth {
 		fmt.Fprintln(w, "⚠️  WARNING: this restart will DROP Claude auth — the new daemon is being launched WITHOUT")
 		fmt.Fprintln(w, "    CLAUDE_CODE_OAUTH_TOKEN in this environment, so it will LOSE the auth the previous daemon had.")
 	} else {

--- a/internal/cli/daemon_authwarn_e2e_test.go
+++ b/internal/cli/daemon_authwarn_e2e_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// withStubbedDaemonChild swaps the child-spawn seam so the real start/restart
+// command body can be driven end-to-end without launching an actual daemon
+// process. Mirrors the claudeAuthEnvLookup seam.
+func withStubbedDaemonChild(t *testing.T) {
+	t.Helper()
+	prev := startDaemonChildFn
+	startDaemonChildFn = func(home, poll string, workers int, watchSkillOptReviews, watchIssues bool, scheduler, repo, session string, state daemonState, workDir string) (daemonMeta, error) {
+		return daemonMeta{PID: 424242, LogFile: filepath.Join(home, "daemon.log")}, nil
+	}
+	t.Cleanup(func() { startDaemonChildFn = prev })
+}
+
+// TestDaemonStartPathEmitsAuthWarning_E2E drives the REAL start/restart command
+// body (runDaemonStartWithWorkDirRestart: arg parse -> paths -> pid check ->
+// warn -> spawn) with the child spawn stubbed, proving the #559 auth-drop
+// warning is actually WIRED into the (re)start path and reaches stderr with the
+// correct wording per scenario — not just the isolated warn function.
+//
+// Mutation check (manual): deleting the warnIfDaemonStartLosesClaudeAuth call in
+// runDaemonStartWithWorkDirRestart makes every wantWarn subtest fail (no WARNING
+// on stderr), confirming this exercises the real wiring rather than the function
+// in isolation.
+func TestDaemonStartPathEmitsAuthWarning_E2E(t *testing.T) {
+	withStubbedDaemonChild(t)
+
+	cases := []struct {
+		name         string
+		env          map[string]string
+		restart      bool
+		priorHadAuth bool
+		wantWarn     bool
+		wantDrop     bool
+	}{
+		{name: "plain_start_no_auth_neutral", env: map[string]string{}, restart: false, priorHadAuth: false, wantWarn: true, wantDrop: false},
+		{name: "restart_prior_had_auth_drop", env: map[string]string{}, restart: true, priorHadAuth: true, wantWarn: true, wantDrop: true},
+		{name: "restart_no_prior_auth_neutral", env: map[string]string{}, restart: true, priorHadAuth: false, wantWarn: true, wantDrop: false},
+		{name: "auth_ready_silent", env: map[string]string{runtime.ClaudeOAuthTokenEnv: "x"}, restart: true, priorHadAuth: true, wantWarn: false, wantDrop: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withClaudeAuthLookup(t, tc.env)
+			home := t.TempDir()
+			var stdout, stderr bytes.Buffer
+
+			code := runDaemonStartWithWorkDirRestart([]string{"--home", home}, "", tc.restart, tc.priorHadAuth, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("start returned code %d; stderr=%q", code, stderr.String())
+			}
+			// The start path ran through to the (stubbed) spawn.
+			if !strings.Contains(stdout.String(), "daemon started") {
+				t.Fatalf("expected the start path to complete; stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+
+			out := stderr.String()
+			if got := strings.Contains(out, "WARNING"); got != tc.wantWarn {
+				t.Fatalf("WARNING present = %v, want %v; stderr=%q", got, tc.wantWarn, out)
+			}
+			if !tc.wantWarn {
+				return
+			}
+			if got := strings.Contains(out, "DROP"); got != tc.wantDrop {
+				t.Fatalf("DROP wording = %v, want %v; stderr=%q", got, tc.wantDrop, out)
+			}
+			// Every warning, drop or neutral, must name the token and note the
+			// blast radius so the operator can act.
+			if !strings.Contains(out, "CLAUDE_CODE_OAUTH_TOKEN") || !strings.Contains(out, "ALL subscribed repos") {
+				t.Fatalf("warning should name the token and note it affects all repos; stderr=%q", out)
+			}
+		})
+	}
+}

--- a/internal/cli/daemon_authwarn_test.go
+++ b/internal/cli/daemon_authwarn_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// withClaudeAuthLookup swaps the injectable auth-readiness seam for the duration
+// of a test so the #559 warning can be exercised without real host credentials.
+func withClaudeAuthLookup(t *testing.T, env map[string]string) {
+	t.Helper()
+	prev := claudeAuthEnvLookup
+	claudeAuthEnvLookup = func(key string) (string, bool) {
+		v, ok := env[key]
+		return v, ok
+	}
+	t.Cleanup(func() { claudeAuthEnvLookup = prev })
+}
+
+func TestWarnIfDaemonStartLosesClaudeAuth_WarnsWhenNotReady(t *testing.T) {
+	withClaudeAuthLookup(t, map[string]string{}) // no Claude auth in the inherited env
+
+	for _, restart := range []bool{false, true} {
+		var buf bytes.Buffer
+		warnIfDaemonStartLosesClaudeAuth(&buf, restart)
+		out := buf.String()
+		if !strings.Contains(out, "WARNING") {
+			t.Fatalf("restart=%v: expected a WARNING, got %q", restart, out)
+		}
+		if !strings.Contains(out, "CLAUDE_CODE_OAUTH_TOKEN") {
+			t.Fatalf("restart=%v: warning should name the token, got %q", restart, out)
+		}
+		if !strings.Contains(out, "ALL subscribed repos") {
+			t.Fatalf("restart=%v: warning should note it affects all repos, got %q", restart, out)
+		}
+	}
+}
+
+func TestWarnIfDaemonStartLosesClaudeAuth_RestartWordingReflectsDrop(t *testing.T) {
+	withClaudeAuthLookup(t, map[string]string{})
+
+	var start, restart bytes.Buffer
+	warnIfDaemonStartLosesClaudeAuth(&start, false)
+	warnIfDaemonStartLosesClaudeAuth(&restart, true)
+
+	if strings.Contains(start.String(), "DROP") {
+		t.Fatalf("plain-start wording should not claim a DROP, got %q", start.String())
+	}
+	if !strings.Contains(restart.String(), "DROP") || !strings.Contains(restart.String(), "LOSE") {
+		t.Fatalf("restart wording should reflect the auth being dropped/lost, got %q", restart.String())
+	}
+}
+
+func TestWarnIfDaemonStartLosesClaudeAuth_SilentWhenReady(t *testing.T) {
+	// Any single Claude credential makes auth ready; the warning must stay silent.
+	for _, key := range []string{
+		runtime.ClaudeOAuthTokenEnv,
+		runtime.AnthropicAPIKeyEnv,
+		runtime.AnthropicAuthTokenEnv,
+	} {
+		withClaudeAuthLookup(t, map[string]string{key: "x"})
+		for _, restart := range []bool{false, true} {
+			var buf bytes.Buffer
+			warnIfDaemonStartLosesClaudeAuth(&buf, restart)
+			if buf.Len() != 0 {
+				t.Fatalf("key=%s restart=%v: expected silence when auth ready, got %q", key, restart, buf.String())
+			}
+		}
+	}
+}
+
+func TestDaemonRestartEnvCaveat_MentionsEnvReinheritance(t *testing.T) {
+	if !strings.Contains(daemonRestartEnvCaveat, "CLAUDE_CODE_OAUTH_TOKEN") {
+		t.Fatalf("footgun caveat should name the token: %q", daemonRestartEnvCaveat)
+	}
+	if !strings.Contains(daemonRestartEnvCaveat, "RE-INHERITS") {
+		t.Fatalf("footgun caveat should note env re-inheritance: %q", daemonRestartEnvCaveat)
+	}
+	if !strings.Contains(daemonRestartEnvCaveat, "scheduler state") {
+		t.Fatalf("footgun caveat should note scheduler-state reset: %q", daemonRestartEnvCaveat)
+	}
+}
+
+func TestDaemonUsage_ClarifiesRepoScope(t *testing.T) {
+	var buf bytes.Buffer
+	printDaemonUsage(&buf)
+	out := buf.String()
+	if !strings.Contains(out, "LAUNCH CONTEXT") {
+		t.Fatalf("usage should clarify --repo sets the launch context, got:\n%s", out)
+	}
+	if !strings.Contains(out, "does NOT") || !strings.Contains(out, "ALL subscribed repos") {
+		t.Fatalf("usage should clarify --repo does not scope supervision, got:\n%s", out)
+	}
+}

--- a/internal/cli/daemon_authwarn_test.go
+++ b/internal/cli/daemon_authwarn_test.go
@@ -25,7 +25,7 @@ func TestWarnIfDaemonStartLosesClaudeAuth_WarnsWhenNotReady(t *testing.T) {
 
 	for _, restart := range []bool{false, true} {
 		var buf bytes.Buffer
-		warnIfDaemonStartLosesClaudeAuth(&buf, restart)
+		warnIfDaemonStartLosesClaudeAuth(&buf, restart, restart)
 		out := buf.String()
 		if !strings.Contains(out, "WARNING") {
 			t.Fatalf("restart=%v: expected a WARNING, got %q", restart, out)
@@ -43,14 +43,37 @@ func TestWarnIfDaemonStartLosesClaudeAuth_RestartWordingReflectsDrop(t *testing.
 	withClaudeAuthLookup(t, map[string]string{})
 
 	var start, restart bytes.Buffer
-	warnIfDaemonStartLosesClaudeAuth(&start, false)
-	warnIfDaemonStartLosesClaudeAuth(&restart, true)
+	warnIfDaemonStartLosesClaudeAuth(&start, false, false)
+	warnIfDaemonStartLosesClaudeAuth(&restart, true, true) // prior daemon confirmed authed
 
 	if strings.Contains(start.String(), "DROP") {
 		t.Fatalf("plain-start wording should not claim a DROP, got %q", start.String())
 	}
 	if !strings.Contains(restart.String(), "DROP") || !strings.Contains(restart.String(), "LOSE") {
 		t.Fatalf("restart wording should reflect the auth being dropped/lost, got %q", restart.String())
+	}
+}
+
+// TestWarnIfDaemonStartLosesClaudeAuth_RestartWithoutPriorAuthUsesNeutralWording
+// guards the #559 review fix: a restart must NOT assert a DROP/LOSE when the prior
+// daemon's Claude auth is unknown or was absent (e.g. a Codex/Kimi-only box, or an
+// unreadable prior env). It still warns that the new daemon comes up without auth,
+// but with the neutral plain-start wording.
+func TestWarnIfDaemonStartLosesClaudeAuth_RestartWithoutPriorAuthUsesNeutralWording(t *testing.T) {
+	withClaudeAuthLookup(t, map[string]string{}) // no Claude auth in the inherited env
+
+	var buf bytes.Buffer
+	warnIfDaemonStartLosesClaudeAuth(&buf, true, false) // restart, but prior auth unknown/absent
+	out := buf.String()
+	if !strings.Contains(out, "WARNING") {
+		t.Fatalf("expected a WARNING even without prior auth, got %q", out)
+	}
+	if strings.Contains(out, "DROP") || strings.Contains(out, "LOSE") ||
+		strings.Contains(out, "the previous daemon had") {
+		t.Fatalf("restart without confirmed prior auth must not claim a DROP/LOSE, got %q", out)
+	}
+	if !strings.Contains(out, "starting WITHOUT Claude auth") {
+		t.Fatalf("expected neutral plain-start wording, got %q", out)
 	}
 }
 
@@ -64,7 +87,7 @@ func TestWarnIfDaemonStartLosesClaudeAuth_SilentWhenReady(t *testing.T) {
 		withClaudeAuthLookup(t, map[string]string{key: "x"})
 		for _, restart := range []bool{false, true} {
 			var buf bytes.Buffer
-			warnIfDaemonStartLosesClaudeAuth(&buf, restart)
+			warnIfDaemonStartLosesClaudeAuth(&buf, restart, restart)
 			if buf.Len() != 0 {
 				t.Fatalf("key=%s restart=%v: expected silence when auth ready, got %q", key, restart, buf.String())
 			}


### PR DESCRIPTION
## The footgun

`gitmoot daemon restart` (and `start`) relaunches the daemon via `exec.Command` **without setting `cmd.Env`**, so the new daemon inherits the *invoking shell's* environment. If that shell lacks `CLAUDE_CODE_OAUTH_TOKEN`, the restarted daemon silently loses Claude auth for **all** subscribed repos — discoverable only later via `daemon status` (claude auth flips ok → warn).

This caused a multi-hour debugging session: tuning one repo's parallelism via the recommended `daemon restart --parallel N` disabled Claude auth daemon-wide.

## The three changes (anti-footgun SAFETY slice)

1. **Loud auth-drop warning at (re)start time.** Before launching the child, we inspect the environment the child will inherit (the current process env, since `cmd.Env` is unset) via `runtime.InspectClaudeAuthEnv`. If Claude auth is not ready, a prominent, multi-line, **non-fatal** warning is printed to stderr. Restart uses drop/lost wording (a previously-running daemon presumably had auth); plain start says it is coming up without auth. Only the Claude runtime is covered (the one this inspection describes); the start is never refused.
2. **Fixed the footgun relaunch hint.** The serialized-jobs hint still recommends `daemon restart --parallel N`, but now appends a caveat that a restart re-inherits the launching shell's environment (so runtime tokens like `CLAUDE_CODE_OAUTH_TOKEN` must be present in that shell, or the daemon loses auth) and resets in-flight scheduler state.
3. **Clarified `--repo`.** The daemon usage/help and the `--repo` flag description now note that `--repo` sets the daemon's **launch context** (working dir / preflight checkout) only; it does **not** scope supervision — the daemon supervises all subscribed repos regardless.

## Tests

`internal/cli/daemon_authwarn_test.go` seeds the auth-readiness seam deterministically (an injectable `claudeAuthEnvLookup` var, no real host creds): the warning fires when auth is not ready and is silent when any single Claude credential is present; restart wording reflects a drop; the footgun caveat and the `--repo` usage clarification are asserted.

Scope is contained to `internal/cli/daemon.go` (+ test). The scheduler, worker pool, and supervisor loop are untouched.

## Scope

This references **#559** as the anti-footgun SAFETY slice and **does not close it**. Per-repo concurrency, warm reload, and daemon auth persistence are tracked as separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)