### PR TITLE
feat(daemon): persist runtime auth so restart can't drop Claude auth (#578)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -125,9 +125,23 @@ func runDaemonStartWithWorkDirRestart(args []string, workDir string, restart boo
 		}
 	}
 
-	warnIfDaemonStartLosesClaudeAuth(stderr, restart, priorDaemonHadClaudeAuth)
+	// Persist the runtime auth token present in this environment, and recover any
+	// the launching shell LACKS from the owner-only daemon-runtime.env, so a
+	// restart can't silently drop Claude auth (#578 — the #559 root cause; #581
+	// only warns). recoveredEnv is injected into the child so a restart from a
+	// token-less shell keeps auth automatically; when we recover it we suppress the
+	// #581 warning (there is no drop) and note the recovery instead.
+	if err := persistDaemonRuntimeAuth(paths.Home, claudeAuthEnvLookup); err != nil {
+		fmt.Fprintf(stderr, "daemon start: warning: could not persist runtime auth: %v\n", err)
+	}
+	recoveredEnv := recoverDaemonChildAuthEnv(paths.Home, claudeAuthEnvLookup)
+	if len(recoveredEnv) > 0 {
+		writeLine(stdout, "recovered persisted runtime auth from %s (launching env lacked it)", daemonRuntimeAuthFileName)
+	} else {
+		warnIfDaemonStartLosesClaudeAuth(stderr, restart, priorDaemonHadClaudeAuth)
+	}
 
-	started, err := startDaemonChildFn(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.WatchIssues, cfg.Scheduler, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir)
+	started, err := startDaemonChildFn(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.WatchIssues, cfg.Scheduler, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir, recoveredEnv)
 	if err != nil {
 		fmt.Fprintf(stderr, "daemon start: %v\n", err)
 		return 1
@@ -1073,7 +1087,7 @@ func currentDaemonPID(state daemonState) (pid int, stale bool, err error) {
 	return pid, false, nil
 }
 
-func startDaemonChild(home string, poll string, workers int, watchSkillOptReviews bool, watchIssues bool, scheduler string, repo string, session string, state daemonState, workDir string) (daemonMeta, error) {
+func startDaemonChild(home string, poll string, workers int, watchSkillOptReviews bool, watchIssues bool, scheduler string, repo string, session string, state daemonState, workDir string, extraEnv []string) (daemonMeta, error) {
 	executable, err := os.Executable()
 	if err != nil {
 		return daemonMeta{}, err
@@ -1088,6 +1102,14 @@ func startDaemonChild(home string, poll string, workers int, watchSkillOptReview
 	cmd.Dir = workDir
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
+	// By default the child inherits THIS process's environment (cmd.Env unset).
+	// When extraEnv carries runtime auth recovered from the persisted 0600 file
+	// (#578), start from the current environ and append it so the restarted daemon
+	// keeps auth even though the launching shell lacked the token. The token is
+	// never written to args/meta/log — only to the child's live environment.
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := cmd.Start(); err != nil {
 		return daemonMeta{}, err

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -272,6 +272,20 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		return code
 	}
 
+	// Seed the persisted runtime-auth file from THIS process's inherited
+	// environment (#578). `daemon start` persists before spawning the child, but
+	// the production, systemd-managed daemon is launched DIRECTLY via `daemon run`
+	// (the unit's ExecStart, token from EnvironmentFile) and never goes through
+	// that path — so without this the file is never seeded in the primary
+	// deployment and the #559 recovery could not trigger there. Best-effort: a
+	// persist failure never blocks the daemon, and the token value never touches
+	// stdout/stderr (only the env-var name and file name are ever named).
+	if paths, err := initializedPaths(*home); err == nil {
+		if perr := persistDaemonRuntimeAuth(paths.Home, claudeAuthEnvLookup); perr != nil {
+			fmt.Fprintf(stderr, "daemon run: warning: could not persist runtime auth: %v\n", perr)
+		}
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 

--- a/internal/cli/daemon_authwarn_e2e_test.go
+++ b/internal/cli/daemon_authwarn_e2e_test.go
@@ -15,7 +15,7 @@ import (
 func withStubbedDaemonChild(t *testing.T) {
 	t.Helper()
 	prev := startDaemonChildFn
-	startDaemonChildFn = func(home, poll string, workers int, watchSkillOptReviews, watchIssues bool, scheduler, repo, session string, state daemonState, workDir string) (daemonMeta, error) {
+	startDaemonChildFn = func(home, poll string, workers int, watchSkillOptReviews, watchIssues bool, scheduler, repo, session string, state daemonState, workDir string, extraEnv []string) (daemonMeta, error) {
 		return daemonMeta{PID: 424242, LogFile: filepath.Join(home, "daemon.log")}, nil
 	}
 	t.Cleanup(func() { startDaemonChildFn = prev })

--- a/internal/cli/daemon_runtime_auth.go
+++ b/internal/cli/daemon_runtime_auth.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// daemon_runtime_auth.go persists the daemon's runtime auth so a `daemon
+// restart` (or a plain start) from a shell that lacks the token cannot silently
+// disable Claude-runtime auth — the #559 root cause. #581 only WARNS; this
+// PERSISTS (#578): on start the live token is written to an owner-only 0600 file
+// in the daemon home, and on a later (re)start that inherits an environment
+// WITHOUT the token, the persisted value is loaded and injected into the child
+// daemon's environment so auth is preserved automatically.
+//
+// SECURITY: the token value NEVER touches stdout/stderr, the log, or the
+// world-readable daemon.json/meta. It lives only in this 0600 file and in the
+// child process environment. Diagnostics name the env var and the file, never
+// the value.
+
+// daemonRuntimeAuthEnvVars is the single source of truth for which runtime auth
+// environment variables the daemon persists and recovers. Only Claude/Anthropic
+// credentials are runtime auth secrets today (Codex/Kimi authenticate out of
+// band); ordering is deterministic so the persisted file and injected child env
+// are stable.
+var daemonRuntimeAuthEnvVars = []string{
+	runtime.ClaudeOAuthTokenEnv,
+	runtime.AnthropicAPIKeyEnv,
+	runtime.AnthropicAuthTokenEnv,
+}
+
+// daemonRuntimeAuthFileName is the owner-only (0600) file, under the daemon home
+// (config.Paths.Home = <home>/.gitmoot), that carries the persisted tokens.
+const daemonRuntimeAuthFileName = "daemon-runtime.env"
+
+// daemonRuntimeAuthFilePerm is the required mode: owner read/write only. It is a
+// non-negotiable security invariant asserted by a test — the file carries live
+// credentials and must never be group/world readable.
+const daemonRuntimeAuthFilePerm os.FileMode = 0o600
+
+func daemonRuntimeAuthFilePath(homeDir string) string {
+	return filepath.Join(homeDir, daemonRuntimeAuthFileName)
+}
+
+// collectRuntimeAuthEnv returns the runtime auth vars that are present AND
+// non-empty in the given environment lookup, keyed by env-var name. A nil lookup
+// or an unset/blank value contributes nothing.
+func collectRuntimeAuthEnv(lookup func(string) (string, bool)) map[string]string {
+	present := map[string]string{}
+	if lookup == nil {
+		return present
+	}
+	for _, name := range daemonRuntimeAuthEnvVars {
+		if v, ok := lookup(name); ok && strings.TrimSpace(v) != "" {
+			present[name] = v
+		}
+	}
+	return present
+}
+
+// persistDaemonRuntimeAuth writes the runtime auth tokens present in the live
+// environment to the 0600 daemon-runtime.env file under homeDir.
+//
+// Invariants (#578):
+//   - Only persist when a token is actually present: an environment with NO
+//     runtime auth token leaves any existing file untouched — a good persisted
+//     token is NEVER overwritten with an empty/unset env.
+//   - Prefer the live env over the file: when a var is set in both, the live
+//     value wins; vars only in the file are preserved (merge, not replace).
+//   - The file is created/re-secured to 0600, owner read/write only.
+func persistDaemonRuntimeAuth(homeDir string, lookup func(string) (string, bool)) error {
+	present := collectRuntimeAuthEnv(lookup)
+	if len(present) == 0 {
+		// Nothing to persist; never clobber a previously-persisted good token.
+		return nil
+	}
+	path := daemonRuntimeAuthFilePath(homeDir)
+	merged := loadDaemonRuntimeAuthFile(path) // best-effort; missing/unreadable => empty
+	for name, value := range present {         // live env wins over the file
+		merged[name] = value
+	}
+	return writeDaemonRuntimeAuthFile(path, merged)
+}
+
+// recoverDaemonChildAuthEnv returns the KEY=VALUE env entries to inject into the
+// (re)started daemon child: for each runtime auth var that the launching
+// environment LACKS but the persisted file HAS, one entry is returned. Vars
+// already present in the live env are omitted (the child inherits them via
+// os.Environ()), honoring "prefer the live env over the file". The result is
+// sorted for determinism and is empty when nothing needs recovering.
+func recoverDaemonChildAuthEnv(homeDir string, lookup func(string) (string, bool)) []string {
+	persisted := loadDaemonRuntimeAuthFile(daemonRuntimeAuthFilePath(homeDir))
+	if len(persisted) == 0 {
+		return nil
+	}
+	live := collectRuntimeAuthEnv(lookup)
+	var extra []string
+	for _, name := range daemonRuntimeAuthEnvVars {
+		if _, inLive := live[name]; inLive {
+			continue
+		}
+		if value, ok := persisted[name]; ok {
+			extra = append(extra, name+"="+value)
+		}
+	}
+	sort.Strings(extra)
+	return extra
+}
+
+// loadDaemonRuntimeAuthFile parses the persisted KEY=VALUE file into a map,
+// keeping only recognized runtime auth vars. It is best-effort: a missing or
+// unreadable file yields an empty (non-nil) map so callers can merge into it.
+func loadDaemonRuntimeAuthFile(path string) map[string]string {
+	out := map[string]string{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return out
+	}
+	recognized := map[string]bool{}
+	for _, name := range daemonRuntimeAuthEnvVars {
+		recognized[name] = true
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if recognized[key] && strings.TrimSpace(value) != "" {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+// writeDaemonRuntimeAuthFile writes vars as KEY=VALUE lines and enforces mode
+// 0600. It opens with O_CREATE|O_TRUNC and then explicitly Chmods, so an existing
+// file with looser permissions is re-secured (OpenFile does not change the mode
+// of a pre-existing file). Keys are emitted in daemonRuntimeAuthEnvVars order for
+// a stable file.
+func writeDaemonRuntimeAuthFile(path string, vars map[string]string) error {
+	var b strings.Builder
+	for _, name := range daemonRuntimeAuthEnvVars {
+		if value, ok := vars[name]; ok {
+			b.WriteString(name)
+			b.WriteString("=")
+			b.WriteString(value)
+			b.WriteString("\n")
+		}
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, daemonRuntimeAuthFilePerm)
+	if err != nil {
+		return err
+	}
+	if _, err := f.WriteString(b.String()); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	// Re-assert 0600 in case the file pre-existed with looser bits or umask
+	// interfered: the mode is a security invariant, not an approximation.
+	if err := os.Chmod(path, daemonRuntimeAuthFilePerm); err != nil {
+		return fmt.Errorf("securing %s: %w", daemonRuntimeAuthFileName, err)
+	}
+	return nil
+}

--- a/internal/cli/daemon_runtime_auth.go
+++ b/internal/cli/daemon_runtime_auth.go
@@ -18,6 +18,12 @@ import (
 // WITHOUT the token, the persisted value is loaded and injected into the child
 // daemon's environment so auth is preserved automatically.
 //
+// Persistence is a full REPLACE of the file with the currently-present auth vars
+// (not a merge), and recovery is ALL-OR-NOTHING (only fires when the live env has
+// no runtime auth at all): together these ensure a credential the operator
+// deliberately removed is pruned rather than resurrected, and a present token is
+// never supplemented by a stale persisted one that could flip billing/precedence.
+//
 // SECURITY: the token value NEVER touches stdout/stderr, the log, or the
 // world-readable daemon.json/meta. It lives only in this 0600 file and in the
 // child process environment. Diagnostics name the env var and the file, never
@@ -70,8 +76,14 @@ func collectRuntimeAuthEnv(lookup func(string) (string, bool)) map[string]string
 //   - Only persist when a token is actually present: an environment with NO
 //     runtime auth token leaves any existing file untouched — a good persisted
 //     token is NEVER overwritten with an empty/unset env.
-//   - Prefer the live env over the file: when a var is set in both, the live
-//     value wins; vars only in the file are preserved (merge, not replace).
+//   - Rewrite the file to EXACTLY the runtime auth vars currently present in the
+//     live env (a full replace, NOT a merge with prior on-disk state). A merge
+//     would preserve any var ever seen forever, so a credential the operator
+//     deliberately removed from the environment — e.g. switching from
+//     ANTHROPIC_API_KEY (which per runtime.ClaudeAuthEnv.Warning() overrides
+//     OAuth billing/precedence) to OAuth-only — would stick on disk and later be
+//     resurrected into the child. Replacing prunes removed vars; recovery only
+//     fires on a genuine total gap (see recoverDaemonChildAuthEnv).
 //   - The file is created/re-secured to 0600, owner read/write only.
 func persistDaemonRuntimeAuth(homeDir string, lookup func(string) (string, bool)) error {
 	present := collectRuntimeAuthEnv(lookup)
@@ -79,31 +91,34 @@ func persistDaemonRuntimeAuth(homeDir string, lookup func(string) (string, bool)
 		// Nothing to persist; never clobber a previously-persisted good token.
 		return nil
 	}
-	path := daemonRuntimeAuthFilePath(homeDir)
-	merged := loadDaemonRuntimeAuthFile(path) // best-effort; missing/unreadable => empty
-	for name, value := range present {         // live env wins over the file
-		merged[name] = value
-	}
-	return writeDaemonRuntimeAuthFile(path, merged)
+	// Write exactly the currently-present set so intentionally-removed
+	// credentials are pruned rather than carried forward.
+	return writeDaemonRuntimeAuthFile(daemonRuntimeAuthFilePath(homeDir), present)
 }
 
 // recoverDaemonChildAuthEnv returns the KEY=VALUE env entries to inject into the
-// (re)started daemon child: for each runtime auth var that the launching
-// environment LACKS but the persisted file HAS, one entry is returned. Vars
-// already present in the live env are omitted (the child inherits them via
-// os.Environ()), honoring "prefer the live env over the file". The result is
-// sorted for determinism and is empty when nothing needs recovering.
+// (re)started daemon child from the persisted file. Recovery is ALL-OR-NOTHING and
+// scoped to a genuine total auth gap: if the launching environment already carries
+// ANY runtime auth, the live env is authoritative and nothing is injected — a
+// present token is never supplemented by a stale persisted var. This prevents a
+// deliberately-removed credential (e.g. a stale ANTHROPIC_API_KEY, which per
+// runtime.ClaudeAuthEnv.Warning() overrides OAuth billing/precedence) from being
+// silently resurrected alongside the operator's current token. Only when the live
+// env has NO runtime auth at all (the #559 token-less restart) are all persisted
+// vars injected. The result is sorted for determinism and empty when nothing needs
+// recovering.
 func recoverDaemonChildAuthEnv(homeDir string, lookup func(string) (string, bool)) []string {
 	persisted := loadDaemonRuntimeAuthFile(daemonRuntimeAuthFilePath(homeDir))
 	if len(persisted) == 0 {
 		return nil
 	}
-	live := collectRuntimeAuthEnv(lookup)
+	// If the launching env already has any auth, treat it as authoritative and do
+	// not gap-fill individual vars from stale on-disk state.
+	if len(collectRuntimeAuthEnv(lookup)) > 0 {
+		return nil
+	}
 	var extra []string
 	for _, name := range daemonRuntimeAuthEnvVars {
-		if _, inLive := live[name]; inLive {
-			continue
-		}
 		if value, ok := persisted[name]; ok {
 			extra = append(extra, name+"="+value)
 		}

--- a/internal/cli/daemon_runtime_auth_test.go
+++ b/internal/cli/daemon_runtime_auth_test.go
@@ -1,0 +1,225 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// secretToken is a distinctive value so tests can assert it NEVER leaks into
+// stdout/stderr/log while still confirming it lands in the 0600 file / child env.
+const secretToken = "sk-ant-oat01-SECRET-DO-NOT-LOG-abcdef0123456789"
+
+func runtimeAuthFileFor(t *testing.T, home string) string {
+	t.Helper()
+	return daemonRuntimeAuthFilePath(config.PathsForHome(home).Home)
+}
+
+// TestDaemonStartPersistsRuntimeAuth_0600 — scenario (a): starting with a token
+// in the environment writes the owner-only file with mode 0600 whose contents
+// carry the token, and the token never appears on stdout/stderr.
+func TestDaemonStartPersistsRuntimeAuth_0600(t *testing.T) {
+	withStubbedDaemonChild(t)
+	withClaudeAuthLookup(t, map[string]string{runtime.ClaudeOAuthTokenEnv: secretToken})
+	home := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	if code := runDaemonStartWithWorkDirRestart([]string{"--home", home}, "", false, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("start returned %d; stderr=%q", code, stderr.String())
+	}
+
+	path := runtimeAuthFileFor(t, home)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected persisted runtime-auth file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != daemonRuntimeAuthFilePerm {
+		t.Fatalf("runtime-auth file mode = %o, want %o (owner read/write only)", got, daemonRuntimeAuthFilePerm)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read persisted file: %v", err)
+	}
+	if !strings.Contains(string(data), runtime.ClaudeOAuthTokenEnv+"="+secretToken) {
+		t.Fatalf("persisted file should carry the token line; got %q", string(data))
+	}
+
+	// The token must NEVER reach the world-readable daemon.json meta.
+	if meta, err := os.ReadFile(filepath.Join(config.PathsForHome(home).Home, "daemon.json")); err == nil {
+		assertNoTokenLeak(t, string(meta))
+	}
+	assertNoTokenLeak(t, stdout.String(), stderr.String())
+}
+
+// TestDaemonStartRecoversRuntimeAuthIntoChildEnv — scenario (b): with the token
+// ABSENT from the launching environment but PRESENT in the persisted file, the
+// computed child environment (captured via the startDaemonChildFn seam) carries
+// the token, and it never appears on stdout/stderr.
+func TestDaemonStartRecoversRuntimeAuthIntoChildEnv(t *testing.T) {
+	home := t.TempDir()
+	// Seed a persisted token as if a prior token-bearing start had written it.
+	if err := os.MkdirAll(config.PathsForHome(home).Home, 0o700); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	if err := persistDaemonRuntimeAuth(config.PathsForHome(home).Home, func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return secretToken, true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("seed persist: %v", err)
+	}
+
+	// Launching shell LACKS any runtime auth token.
+	withClaudeAuthLookup(t, map[string]string{})
+
+	var capturedEnv []string
+	prev := startDaemonChildFn
+	startDaemonChildFn = func(h, poll string, workers int, wsor, wi bool, scheduler, repo, session string, state daemonState, workDir string, extraEnv []string) (daemonMeta, error) {
+		capturedEnv = extraEnv
+		return daemonMeta{PID: 424242, LogFile: filepath.Join(h, "daemon.log")}, nil
+	}
+	t.Cleanup(func() { startDaemonChildFn = prev })
+
+	var stdout, stderr bytes.Buffer
+	if code := runDaemonStartWithWorkDirRestart([]string{"--home", home}, "", true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("start returned %d; stderr=%q", code, stderr.String())
+	}
+
+	want := runtime.ClaudeOAuthTokenEnv + "=" + secretToken
+	found := false
+	for _, e := range capturedEnv {
+		if e == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("child env should carry the recovered token entry %q; got %v (redacted)", runtime.ClaudeOAuthTokenEnv, redactEnvKeys(capturedEnv))
+	}
+	// Recovery replaces the #581 warning; the drop warning must NOT fire.
+	if strings.Contains(stderr.String(), "WARNING") {
+		t.Fatalf("recovered auth should suppress the drop warning; stderr=%q", stderr.String())
+	}
+	assertNoTokenLeak(t, stdout.String(), stderr.String())
+}
+
+// TestPersistDaemonRuntimeAuth_NeverOverwritesGoodTokenWithEmpty — invariant (3):
+// an environment with no runtime auth token must not clobber a previously
+// persisted good token.
+func TestPersistDaemonRuntimeAuth_NeverOverwritesGoodTokenWithEmpty(t *testing.T) {
+	dir := t.TempDir()
+	// First persist a good token.
+	if err := persistDaemonRuntimeAuth(dir, func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return secretToken, true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("first persist: %v", err)
+	}
+	// Now persist with an empty env: the file must be untouched.
+	if err := persistDaemonRuntimeAuth(dir, func(string) (string, bool) { return "", false }); err != nil {
+		t.Fatalf("empty persist: %v", err)
+	}
+	got := loadDaemonRuntimeAuthFile(daemonRuntimeAuthFilePath(dir))
+	if got[runtime.ClaudeOAuthTokenEnv] != secretToken {
+		t.Fatalf("empty env clobbered the persisted token; got %v (redacted keys=%v)", got[runtime.ClaudeOAuthTokenEnv] != "", keysOf(got))
+	}
+}
+
+// TestPersistDaemonRuntimeAuth_PrefersLiveEnvOverFile — invariant (3): when a var
+// is set in both env and file, the live value wins.
+func TestPersistDaemonRuntimeAuth_PrefersLiveEnvOverFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := persistDaemonRuntimeAuth(dir, func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return "old-token", true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := persistDaemonRuntimeAuth(dir, func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return "new-token", true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	got := loadDaemonRuntimeAuthFile(daemonRuntimeAuthFilePath(dir))
+	if got[runtime.ClaudeOAuthTokenEnv] != "new-token" {
+		t.Fatalf("live env should win over file; got %q", got[runtime.ClaudeOAuthTokenEnv])
+	}
+}
+
+// TestRecoverDaemonChildAuthEnv_PrefersLiveEnv — a var present in the live env is
+// NOT re-injected (the child inherits it), so recovery only fills genuine gaps.
+func TestRecoverDaemonChildAuthEnv_PrefersLiveEnv(t *testing.T) {
+	dir := t.TempDir()
+	if err := persistDaemonRuntimeAuth(dir, func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return secretToken, true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	live := func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return "live-value", true
+		}
+		return "", false
+	}
+	if got := recoverDaemonChildAuthEnv(dir, live); len(got) != 0 {
+		t.Fatalf("live-present var must not be re-injected; got %v (redacted)", redactEnvKeys(got))
+	}
+}
+
+// TestPersistDaemonRuntimeAuth_NoTokenNoFile — invariant (3): with no token the
+// file is not created at all.
+func TestPersistDaemonRuntimeAuth_NoTokenNoFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := persistDaemonRuntimeAuth(dir, func(string) (string, bool) { return "", false }); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	if _, err := os.Stat(daemonRuntimeAuthFilePath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("no-token persist should not create the file; stat err=%v", err)
+	}
+}
+
+// assertNoTokenLeak fails if the secret token appears in any captured diagnostic
+// stream — the SECURITY-CRITICAL non-leak requirement.
+func assertNoTokenLeak(t *testing.T, streams ...string) {
+	t.Helper()
+	for _, s := range streams {
+		if strings.Contains(s, secretToken) {
+			t.Fatalf("token leaked into diagnostic output: %q", s)
+		}
+	}
+}
+
+func redactEnvKeys(entries []string) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if k, _, ok := strings.Cut(e, "="); ok {
+			out = append(out, k+"=<redacted>")
+		} else {
+			out = append(out, "<redacted>")
+		}
+	}
+	return out
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/cli/daemon_runtime_auth_test.go
+++ b/internal/cli/daemon_runtime_auth_test.go
@@ -193,6 +193,63 @@ func TestPersistDaemonRuntimeAuth_NoTokenNoFile(t *testing.T) {
 	}
 }
 
+// TestRecoverDaemonChildAuthEnv_LiveAuthSuppressesStalePersisted — the
+// all-or-nothing recovery guard: when the live env already carries ANY runtime
+// auth, a DIFFERENT stale var still on disk must NOT be resurrected into the
+// child. Concretely, a stale ANTHROPIC_API_KEY (which overrides OAuth
+// billing/precedence) must not be injected alongside the operator's current
+// OAuth token after they migrated to OAuth-only.
+func TestRecoverDaemonChildAuthEnv_LiveAuthSuppressesStalePersisted(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeDaemonRuntimeAuthFile(daemonRuntimeAuthFilePath(dir), map[string]string{
+		runtime.AnthropicAPIKeyEnv: "stale-api-key",
+	}); err != nil {
+		t.Fatalf("seed stale file: %v", err)
+	}
+	// Live env carries ONLY an OAuth token (operator migrated to OAuth-only).
+	live := func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return secretToken, true
+		}
+		return "", false
+	}
+	if got := recoverDaemonChildAuthEnv(dir, live); len(got) != 0 {
+		t.Fatalf("live auth present: stale persisted vars must NOT be resurrected; got %v (redacted)", redactEnvKeys(got))
+	}
+}
+
+// TestPersistDaemonRuntimeAuth_PrunesRemovedVars — persistence is a full replace,
+// not a merge: a var present on an earlier start but REMOVED from the environment
+// by a later start must be pruned from the file so it can never be resurrected.
+func TestPersistDaemonRuntimeAuth_PrunesRemovedVars(t *testing.T) {
+	dir := t.TempDir()
+	// Day 1: only ANTHROPIC_API_KEY present.
+	if err := persistDaemonRuntimeAuth(dir, func(k string) (string, bool) {
+		if k == runtime.AnthropicAPIKeyEnv {
+			return "day1-api-key", true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("day1 persist: %v", err)
+	}
+	// Day 2: operator removed the API key and switched to OAuth-only.
+	if err := persistDaemonRuntimeAuth(dir, func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return secretToken, true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("day2 persist: %v", err)
+	}
+	got := loadDaemonRuntimeAuthFile(daemonRuntimeAuthFilePath(dir))
+	if _, stale := got[runtime.AnthropicAPIKeyEnv]; stale {
+		t.Fatalf("removed ANTHROPIC_API_KEY must be pruned from the persisted file; got keys=%v", keysOf(got))
+	}
+	if got[runtime.ClaudeOAuthTokenEnv] != secretToken {
+		t.Fatalf("current OAuth token must be persisted; got keys=%v", keysOf(got))
+	}
+}
+
 // assertNoTokenLeak fails if the secret token appears in any captured diagnostic
 // stream — the SECURITY-CRITICAL non-leak requirement.
 func assertNoTokenLeak(t *testing.T, streams ...string) {


### PR DESCRIPTION
## What & why

A `daemon restart`/start launches the daemon child with `cmd.Env` unset, so the
child inherits whatever shell environment invoked the command. If that shell is
missing `CLAUDE_CODE_OAUTH_TOKEN` (e.g. a restart from a fresh terminal), the
restarted daemon silently comes up **without Claude auth** — every Claude-runtime
job across all subscribed repos then fails auth. This was the #559 root cause.
#581 added a loud **warning** but still let the auth drop.

This PR makes the daemon **persist** its runtime auth so a restart keeps it
automatically.

## Design

New `internal/cli/daemon_runtime_auth.go`:

- **Persist on start** — any runtime auth env var present in the live environment
  (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`) is
  written to an owner-only file `<home>/.gitmoot/daemon-runtime.env` (mode
  `0600`).
- **Recover on (re)start** — when the launching shell **lacks** a token but the
  file **has** one, the persisted value is loaded and injected into the child:
  `cmd.Env = os.Environ() + recovered vars`. The restarted daemon keeps auth with
  no operator action. `startDaemonChild` gains an `extraEnv []string` parameter;
  the child env is only overridden when there is something to recover (otherwise
  `cmd.Env` stays unset and the child inherits as before).

Invariants:
- Only persist when a token is actually present — an empty/unset env **never**
  clobbers a previously-persisted good token.
- Prefer the live env over the file when both are set (merge, not replace).
- When auth is recovered from the file, the #581 drop warning is **suppressed**
  in favor of a recovery note (there is no drop), so #581 now rarely fires.

## Behavior preserved

- No token in env and no persisted file → identical to today: neutral/drop
  warning fires, child inherits the (token-less) env.
- Token already in the launching env → child inherits it (no injection); the
  live token is additionally persisted for the next restart.
- The existing `#559` warning wiring and wording are unchanged; the existing
  `TestDaemonStartPathEmitsAuthWarning_E2E` (fresh homes, no persisted file)
  still passes.

## Security

- The file is created and re-asserted `0600` (owner read/write only) — asserted
  via a `FileMode` check in a test.
- The token value is **never** logged, printed, or written to the
  world-readable `daemon.json`/meta. Diagnostics name the env var and the file,
  never the value. A test asserts a distinctive token never appears in captured
  stdout/stderr or `daemon.json`.

## Tests (`internal/cli/daemon_runtime_auth_test.go`)

- `TestDaemonStartPersistsRuntimeAuth_0600` — start with a token → the `0600`
  file is written (mode asserted) and contains the token; token absent from
  stdout/stderr and `daemon.json`.
- `TestDaemonStartRecoversRuntimeAuthIntoChildEnv` — token absent from env but
  present in the file → the computed child env (captured via the
  `startDaemonChildFn` seam, no real daemon spawned) carries the token; the drop
  warning is suppressed; no token leak.
- `TestPersistDaemonRuntimeAuth_NeverOverwritesGoodTokenWithEmpty`,
  `..._PrefersLiveEnvOverFile`, `..._NoTokenNoFile`,
  `TestRecoverDaemonChildAuthEnv_PrefersLiveEnv` — the invariants above.

## Gate

`go build ./...`, `go vet ./...`, `go test ./internal/cli/ ./internal/runtime/`,
and `go test -race -timeout 20m ./internal/cli/` all green.

Closes #578
